### PR TITLE
[Feature] Add PP and MTP support

### DIFF
--- a/tests/ut/core/test_profiling_chunk.py
+++ b/tests/ut/core/test_profiling_chunk.py
@@ -418,3 +418,47 @@ class TestProfilingChunkScheduler(TestBase):
         scheduler.update_from_output(output, model_output)
 
         self.assertEqual(len(scheduler.running), 3)
+
+    def test_update_from_output_uses_model_output_spec_tokens(self):
+        scheduler = self.create_scheduler()
+        requests = create_requests(num_requests=2)
+        for req in requests:
+            scheduler.add_request(req)
+
+        output = scheduler.schedule()
+        model_output = ModelRunnerOutput(
+            req_ids=["0", "1"],
+            req_id_to_index={"0": 0, "1": 1},
+            sampled_token_ids=[[1000], [1001]],
+            spec_token_ids=[[11, 12], [21, 22]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        )
+
+        scheduler.update_from_output(output, model_output)
+
+        self.assertEqual(scheduler.requests["0"].spec_token_ids, [11, 12])
+        self.assertEqual(scheduler.requests["1"].spec_token_ids, [21, 22])
+
+    def test_update_from_output_clears_spec_tokens_for_prefill_output(self):
+        scheduler = self.create_scheduler()
+        requests = create_requests(num_requests=1)
+        for req in requests:
+            scheduler.add_request(req)
+        scheduler.requests["0"].spec_token_ids = [1, 2]
+
+        output = scheduler.schedule()
+        model_output = ModelRunnerOutput(
+            req_ids=["0"],
+            req_id_to_index={"0": 0},
+            sampled_token_ids=[[]],
+            spec_token_ids=[[11, 12]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        )
+
+        scheduler.update_from_output(output, model_output)
+
+        self.assertEqual(scheduler.requests["0"].spec_token_ids, [])

--- a/tests/ut/patch/platform/test_patch_pp_mtp.py
+++ b/tests/ut/patch/platform/test_patch_pp_mtp.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from vllm.config.model import ModelConfig
+from vllm.v1.engine.core import EngineCore
+from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, ModelRunnerOutput
+
+import vllm_ascend.patch.platform.patch_pp_mtp as pp_mtp_patch
+
+
+def test_model_runner_output_accepts_spec_token_ids():
+    output = ModelRunnerOutput(
+        req_ids=["req0"],
+        req_id_to_index={"req0": 0},
+        sampled_token_ids=[[10]],
+        spec_token_ids=[[11, 12]],
+    )
+
+    assert output.spec_token_ids == [[11, 12]]
+    assert hasattr(EMPTY_MODEL_RUNNER_OUTPUT, "spec_token_ids")
+
+
+def test_model_runner_output_patch_backfills_legacy_runtime(monkeypatch):
+    class LegacyModelRunnerOutput:
+        __dataclass_fields__ = {"req_ids": object()}
+
+        def __init__(self, req_ids=None):
+            self.req_ids = req_ids or []
+
+    fake_outputs_mod = SimpleNamespace(
+        ModelRunnerOutput=LegacyModelRunnerOutput,
+        EMPTY_MODEL_RUNNER_OUTPUT=LegacyModelRunnerOutput(),
+    )
+
+    import vllm.v1 as vllm_v1
+
+    monkeypatch.setattr(vllm_v1, "outputs", fake_outputs_mod)
+
+    pp_mtp_patch._patch_model_runner_output()
+
+    patched_output_cls = cast(Any, LegacyModelRunnerOutput)
+    output = patched_output_cls(
+        req_ids=["req0"],
+        spec_token_ids=[[100, 101]],
+    )
+    assert output.spec_token_ids == [[100, 101]]
+    assert fake_outputs_mod.EMPTY_MODEL_RUNNER_OUTPUT.spec_token_ids is None
+
+
+def test_engine_core_post_step_skips_pp_batch_queue_spec_decode_path():
+    fake_core = SimpleNamespace(
+        batch_queue=object(),
+        async_scheduling=False,
+        use_spec_decode=True,
+    )
+
+    assert EngineCore.post_step(fake_core, model_executed=True) is None
+
+
+def test_model_config_validates_local_mtp_drafter_as_single_pp_rank(monkeypatch):
+    fake_registry = SimpleNamespace(
+        is_pp_supported_model=lambda _architectures, _model_config: False,
+    )
+    monkeypatch.setattr(ModelConfig, "registry", property(lambda _self: fake_registry))
+
+    model_config = ModelConfig.__new__(ModelConfig)
+    model_config.hf_config = SimpleNamespace(model_type="qwen3_5_mtp")
+    model_config.runner = "draft"
+    model_config.model_arch_config = SimpleNamespace(
+        total_num_attention_heads=1,
+        architectures=["Qwen3_5MTP"],
+    )
+    model_config.multimodal_config = None
+
+    parallel_config = SimpleNamespace(
+        tensor_parallel_size=1,
+        enable_expert_parallel=False,
+        pipeline_parallel_size=2,
+        decode_context_parallel_size=1,
+    )
+
+    ModelConfig.verify_with_parallel_config(model_config, parallel_config)
+    assert parallel_config.pipeline_parallel_size == 2
+
+
+def test_model_config_keeps_target_model_pp_validation(monkeypatch):
+    fake_registry = SimpleNamespace(
+        is_pp_supported_model=lambda _architectures, _model_config: False,
+    )
+    monkeypatch.setattr(ModelConfig, "registry", property(lambda _self: fake_registry))
+
+    model_config = ModelConfig.__new__(ModelConfig)
+    model_config.hf_config = SimpleNamespace(model_type="qwen3_5_mtp")
+    model_config.runner = "generate"
+    model_config.model_arch_config = SimpleNamespace(
+        total_num_attention_heads=1,
+        architectures=["UnsupportedForPP"],
+    )
+
+    parallel_config = SimpleNamespace(
+        tensor_parallel_size=1,
+        enable_expert_parallel=False,
+        pipeline_parallel_size=2,
+        decode_context_parallel_size=1,
+    )
+
+    with pytest.raises(NotImplementedError):
+        ModelConfig.verify_with_parallel_config(model_config, parallel_config)

--- a/tests/ut/patch/worker/test_patch_qwen3_5_mtp.py
+++ b/tests/ut/patch/worker/test_patch_qwen3_5_mtp.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from vllm.sequence import IntermediateTensors
+
+from vllm_ascend.patch.worker import patch_qwen3_5
+
+
+@pytest.mark.skipif(
+    patch_qwen3_5.Qwen3_5MultiTokenPredictor is None,
+    reason="Qwen3.5 MTP model is not available in this vLLM version.",
+)
+def test_qwen3_5_mtp_forward_uses_local_inputs_on_last_pp_rank():
+    predictor = patch_qwen3_5.Qwen3_5MultiTokenPredictor.__new__(patch_qwen3_5.Qwen3_5MultiTokenPredictor)
+    predictor.num_mtp_layers = 2
+    predictor.embed_input_ids = MagicMock(return_value=torch.ones(2, 4))
+    predictor.pre_fc_norm_embedding = MagicMock(side_effect=lambda x: x + 1)
+    predictor.pre_fc_norm_hidden = MagicMock(side_effect=lambda x: x + 2)
+    predictor.fc = MagicMock(side_effect=lambda x: x[:, :4] + x[:, 4:])
+    layer0 = MagicMock(return_value=(torch.full((2, 4), 3.0), torch.full((2, 4), 4.0)))
+    layer1 = MagicMock(return_value=(torch.full((2, 4), 5.0), torch.full((2, 4), 6.0)))
+    predictor.layers = [layer0, layer1]
+    predictor.norm = MagicMock(return_value=(torch.full((2, 4), 7.0), None))
+
+    with patch(
+        "vllm_ascend.patch.worker.patch_qwen3_5.get_pp_group",
+        return_value=SimpleNamespace(is_last_rank=True),
+    ):
+        output = predictor.forward(
+            input_ids=torch.tensor([1, 2]),
+            positions=torch.tensor([0, 1]),
+            hidden_states=torch.zeros(2, 4),
+            intermediate_tensors=IntermediateTensors({"hidden_states": torch.full((2, 4), 99.0)}),
+            spec_step_idx=3,
+        )
+
+    predictor.embed_input_ids.assert_called_once()
+    layer1.assert_called_once()
+    predictor.norm.assert_called_once()
+    assert torch.equal(output, torch.full((2, 4), 7.0))
+
+
+@pytest.mark.skipif(
+    patch_qwen3_5.Qwen3_5MultiTokenPredictor is None,
+    reason="Qwen3.5 MTP model is not available in this vLLM version.",
+)
+def test_qwen3_5_mtp_forward_returns_intermediate_tensors_on_non_last_pp_rank():
+    predictor = patch_qwen3_5.Qwen3_5MultiTokenPredictor.__new__(patch_qwen3_5.Qwen3_5MultiTokenPredictor)
+    predictor.num_mtp_layers = 1
+    predictor.embed_input_ids = MagicMock(return_value=torch.ones(1, 4))
+    predictor.pre_fc_norm_embedding = MagicMock(side_effect=lambda x: x)
+    predictor.pre_fc_norm_hidden = MagicMock(side_effect=lambda x: x)
+    predictor.fc = MagicMock(side_effect=lambda x: x[:, :4])
+    predictor.layers = [MagicMock(return_value=(torch.full((1, 4), 3.0), torch.full((1, 4), 4.0)))]
+    predictor.norm = MagicMock()
+
+    with patch(
+        "vllm_ascend.patch.worker.patch_qwen3_5.get_pp_group",
+        return_value=SimpleNamespace(is_last_rank=False),
+    ):
+        output = predictor.forward(
+            input_ids=torch.tensor([1]),
+            positions=torch.tensor([0]),
+            hidden_states=torch.zeros(1, 4),
+        )
+
+    assert isinstance(output, IntermediateTensors)
+    assert torch.equal(output["hidden_states"], torch.full((1, 4), 3.0))
+    assert torch.equal(output["residual"], torch.full((1, 4), 4.0))
+    predictor.norm.assert_not_called()

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -193,5 +193,129 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
         self.assertTrue(runner._debugger_started)
 
 
+class TestNPUModelRunnerPPMTP(unittest.TestCase):
+    def _build_runner(self):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.need_accepted_tokens = True
+        runner.speculative_config = MagicMock()
+        runner.use_async_scheduling = False
+        runner.input_batch = MagicMock()
+        runner.input_batch.req_id_to_index = {"req0": 0, "req1": 1}
+        runner.input_batch.num_reqs = 2
+        runner.input_batch.num_accepted_tokens_cpu = torch.ones(4, dtype=torch.int32).numpy()
+        runner.num_accepted_tokens = MagicMock()
+        runner.num_accepted_tokens.np = torch.ones(4, dtype=torch.int32).numpy()
+        runner._prev_non_last_pp_mtp_scheduler_output = None
+        runner.requests = {}
+        return runner
+
+    @patch("vllm_ascend.worker.model_runner_v1.get_pp_group")
+    def test_compute_non_last_pp_mtp_accepted_counts_from_scheduler_delta(self, mock_get_pp_group):
+        mock_get_pp_group.return_value = MagicMock(is_last_rank=False)
+        runner = self._build_runner()
+        runner.requests = {
+            "req0": SimpleNamespace(num_computed_tokens=10),
+            "req1": SimpleNamespace(num_computed_tokens=20),
+        }
+        prev_output = SimpleNamespace(
+            scheduled_spec_decode_tokens={
+                "req0": [101, 102],
+                "req1": [201, 202],
+            }
+        )
+        scheduler_output = SimpleNamespace(
+            scheduled_cached_reqs=SimpleNamespace(
+                req_ids=["req0", "req1"],
+                num_computed_tokens=[12, 30],
+            )
+        )
+
+        accepted_counts = runner._compute_non_last_pp_mtp_accepted_counts(
+            scheduler_output,
+            prev_output,
+        )
+
+        self.assertEqual(accepted_counts, {"req0": 2, "req1": 1})
+
+    @patch("vllm_ascend.worker.model_runner_v1.get_pp_group")
+    def test_prepare_non_last_pp_mtp_state_update_syncs_counts(self, mock_get_pp_group):
+        mock_get_pp_group.return_value = MagicMock(is_last_rank=False)
+        runner = self._build_runner()
+        runner.requests = {
+            "req0": SimpleNamespace(num_computed_tokens=10),
+            "req1": SimpleNamespace(num_computed_tokens=20),
+        }
+        runner._prev_non_last_pp_mtp_scheduler_output = SimpleNamespace(
+            scheduled_spec_decode_tokens={
+                "req0": [101, 102],
+                "req1": [201],
+            }
+        )
+        runner.cache_config = SimpleNamespace(mamba_cache_mode="disabled")
+        scheduler_output = SimpleNamespace(
+            scheduled_cached_reqs=SimpleNamespace(
+                req_ids=["req0", "req1"],
+                num_computed_tokens=[13, 22],
+            )
+        )
+
+        runner._prepare_non_last_pp_mtp_state_update(scheduler_output)
+
+        self.assertEqual(runner.input_batch.num_accepted_tokens_cpu[:2].tolist(), [3, 2])
+        self.assertEqual(runner.num_accepted_tokens.np[:2].tolist(), [3, 2])
+        runner.num_accepted_tokens.copy_to_gpu.assert_called_once_with(2)
+
+    @patch("vllm_ascend.worker.model_runner_v1.get_pp_group")
+    def test_collect_pp_mtp_re_added_token_ignores_existing_cached_requests(self, mock_get_pp_group):
+        mock_get_pp_group.return_value = MagicMock(is_last_rank=False)
+        runner = self._build_runner()
+        runner.input_batch.req_id_to_index = {"kept": 0, "removed": 1}
+        scheduler_output = SimpleNamespace(
+            scheduled_cached_reqs=SimpleNamespace(
+                req_ids=["kept", "re-added"],
+                new_token_ids=[[1], [7, 8]],
+                resumed_req_ids=set(),
+                num_computed_tokens=[5, 9],
+            ),
+            finished_req_ids={"removed"},
+            num_scheduled_tokens={"kept": 1, "re-added": 2},
+        )
+
+        collect_token_fixes = runner._collect_pp_mtp_readded_token  # codespell:ignore readded
+        token_fixes = collect_token_fixes(scheduler_output)
+
+        self.assertEqual(token_fixes, {"re-added": ([7, 8], 9)})
+
+    @patch("vllm_ascend.worker.model_runner_v1.get_pp_group")
+    def test_pp_mtp_update_req_spec_token_ids_injects_re_added_tokens(self, mock_get_pp_group):
+        mock_get_pp_group.return_value = MagicMock(is_last_rank=False)
+        runner = self._build_runner()
+        runner.input_batch.req_id_to_index = {}
+        runner.input_batch.token_ids_cpu = torch.zeros((1, 16), dtype=torch.int32)
+        runner.input_batch.num_tokens_no_spec = torch.zeros(1, dtype=torch.int32)
+        original_update = MagicMock()
+        runner.input_batch.update_req_spec_token_ids = original_update
+        scheduler_output = SimpleNamespace(
+            total_num_scheduled_tokens=2,
+            scheduled_cached_reqs=SimpleNamespace(
+                req_ids=["re-added"],
+                new_token_ids=[[7, 8]],
+                resumed_req_ids=set(),
+                num_computed_tokens=[3],
+            ),
+            finished_req_ids=set(),
+            num_scheduled_tokens={"re-added": 2},
+        )
+        request = SimpleNamespace(req_id="re-added")
+
+        with runner._pp_mtp_update_req_spec_token_ids(scheduler_output):
+            runner.input_batch.req_id_to_index["re-added"] = 0
+            runner.input_batch.update_req_spec_token_ids(request, [11, 12])
+
+        self.assertEqual(runner.input_batch.token_ids_cpu[0, 3:5].tolist(), [7, 8])
+        self.assertEqual(int(runner.input_batch.num_tokens_no_spec[0]), 5)
+        original_update.assert_called_once_with(request, [11, 12])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/vllm_ascend/core/scheduler_profiling_chunk.py
+++ b/vllm_ascend/core/scheduler_profiling_chunk.py
@@ -516,7 +516,12 @@ class ProfilingChunkScheduler(Scheduler):
                     assert num_external_computed_tokens > 0
                     num_new_tokens = 0
                 else:
-                    num_new_tokens = request.num_tokens - num_computed_tokens
+                    if self.is_mtp_kv_consumer:
+                        num_new_tokens = (
+                            request.num_tokens_with_spec - num_computed_tokens
+                        )
+                    else:
+                        num_new_tokens = request.num_tokens - num_computed_tokens
                     threshold = self.scheduler_config.long_prefill_token_threshold
                     if 0 < threshold < num_new_tokens:
                         num_new_tokens = threshold
@@ -629,6 +634,24 @@ class ProfilingChunkScheduler(Scheduler):
                     step_skipped_waiting.prepend_request(request)
                     request.num_computed_tokens = num_computed_tokens
                     continue
+
+                # Speculative decode related. In MTP KV-consumer mode, waiting
+                # requests may already carry placeholder draft tokens that need
+                # to be scheduled together with the prefill tokens.
+                if (
+                    self.is_mtp_kv_consumer or not self.vllm_config.kv_transfer_config
+                ) and request.spec_token_ids:
+                    num_scheduled_spec_tokens = (
+                        num_new_tokens + num_computed_tokens - request.num_tokens
+                    )
+                    if num_scheduled_spec_tokens > 0:
+                        del request.spec_token_ids[num_scheduled_spec_tokens:]
+                        scheduled_spec_decode_tokens[request_id] = (
+                            request.spec_token_ids
+                        )
+                    else:
+                        # Prefill request: spec tokens not applicable yet.
+                        request.spec_token_ids = []
 
                 self.running.append(request)
                 if self.log_stats:

--- a/vllm_ascend/core/scheduler_profiling_chunk.py
+++ b/vllm_ascend/core/scheduler_profiling_chunk.py
@@ -34,8 +34,9 @@ from vllm.v1.core.sched.output import (
 )
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
 from vllm.v1.core.sched.scheduler import Scheduler
-from vllm.v1.engine import EngineCoreEventType
+from vllm.v1.engine import EngineCoreEventType, EngineCoreOutputs
 from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
 from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
@@ -76,6 +77,16 @@ class ProfilingChunkScheduler(Scheduler):
             mm_registry=mm_registry,
             include_finished_set=include_finished_set,
             log_stats=log_stats,
+        )
+
+        pp_size = self.vllm_config.parallel_config.pipeline_parallel_size
+        self.max_num_running_reqs = self.scheduler_config.max_num_seqs * pp_size
+        self.max_num_per_batch = self.scheduler_config.max_num_seqs
+        kv_transfer_config = getattr(self.vllm_config, "kv_transfer_config", None)
+        self.is_mtp_kv_consumer = (
+            getattr(self.vllm_config, "speculative_config", None) is not None
+            and kv_transfer_config is not None
+            and getattr(kv_transfer_config, "is_kv_consumer", False)
         )
 
         from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
@@ -227,6 +238,45 @@ class ProfilingChunkScheduler(Scheduler):
             return float(result[0])
         return None
 
+    def update_from_output(
+        self,
+        scheduler_output: SchedulerOutput,
+        model_runner_output: ModelRunnerOutput,
+    ) -> dict[int, EngineCoreOutputs]:
+        engine_core_outputs = super().update_from_output(
+            scheduler_output,
+            model_runner_output,
+        )
+        spec_token_ids = getattr(model_runner_output, "spec_token_ids", None)
+        if spec_token_ids:
+            # Backport PP+MTP output alignment: in PP batch_queue mode, a newer
+            # batch may be scheduled before this older output is consumed. Use
+            # this output's generated tokens to decide whether its draft tokens
+            # belong to a decode step, instead of reading live Request phase
+            # flags that may already reflect a later schedule step. Remove this
+            # block when upstream vLLM carries ModelRunnerOutput.spec_token_ids.
+            sampled_token_ids = getattr(model_runner_output, "sampled_token_ids", None)
+            for req_id in scheduler_output.num_scheduled_tokens:
+                request = self.requests.get(req_id)
+                if request is None or request.is_finished():
+                    continue
+
+                req_index = model_runner_output.req_id_to_index[req_id]
+                new_token_ids = sampled_token_ids[req_index] if sampled_token_ids else []
+                if not new_token_ids:
+                    if request.spec_token_ids:
+                        request.spec_token_ids = []
+                    continue
+
+                next_spec_token_ids = spec_token_ids[req_index]
+                if self.structured_output_manager.should_advance(request):
+                    metadata = request.structured_output_request
+                    assert metadata is not None and metadata.grammar is not None
+                    next_spec_token_ids = metadata.grammar.validate_tokens(
+                        next_spec_token_ids)
+                request.spec_token_ids = next_spec_token_ids
+        return engine_core_outputs
+
     # ------------------------------------------------------------------
     # schedule() override
     # ------------------------------------------------------------------
@@ -274,6 +324,9 @@ class ProfilingChunkScheduler(Scheduler):
         while req_index < len(self.running) and token_budget > 0 and time_budget > 0:
             # <<< PROFILING CHUNK <<<
             request = self.running[req_index]
+            current_batch_size = len(scheduled_new_reqs) + len(scheduled_resumed_reqs) + len(scheduled_running_reqs)
+            if current_batch_size == self.max_num_per_batch:
+                break
 
             if (
                 request.num_output_placeholders > 0
@@ -332,7 +385,7 @@ class ProfilingChunkScheduler(Scheduler):
             if self.need_mamba_block_aligned_split:
                 num_new_tokens = self._mamba_block_aligned_split(request, num_new_tokens)
 
-            if num_new_tokens == 0:
+            if num_new_tokens <= 0:
                 req_index += 1
                 continue
 
@@ -434,7 +487,8 @@ class ProfilingChunkScheduler(Scheduler):
             # >>> PROFILING CHUNK >>>
             while (self.waiting or self.skipped_waiting) and token_budget > 0 and time_budget > 0:
                 # <<< PROFILING CHUNK <<<
-                if len(self.running) == self.max_num_running_reqs:
+                current_batch_size = len(scheduled_new_reqs) + len(scheduled_resumed_reqs) + len(scheduled_running_reqs)
+                if len(self.running) == self.max_num_running_reqs or current_batch_size == self.max_num_per_batch:
                     break
 
                 request_queue = self._select_waiting_queue_for_scheduling()

--- a/vllm_ascend/core/scheduler_profiling_chunk.py
+++ b/vllm_ascend/core/scheduler_profiling_chunk.py
@@ -272,8 +272,7 @@ class ProfilingChunkScheduler(Scheduler):
                 if self.structured_output_manager.should_advance(request):
                     metadata = request.structured_output_request
                     assert metadata is not None and metadata.grammar is not None
-                    next_spec_token_ids = metadata.grammar.validate_tokens(
-                        next_spec_token_ids)
+                    next_spec_token_ids = metadata.grammar.validate_tokens(next_spec_token_ids)
                 request.spec_token_ids = next_spec_token_ids
         return engine_core_outputs
 
@@ -571,9 +570,7 @@ class ProfilingChunkScheduler(Scheduler):
                     num_new_tokens = 0
                 else:
                     if self.is_mtp_kv_consumer:
-                        num_new_tokens = (
-                            request.num_tokens_with_spec - num_computed_tokens
-                        )
+                        num_new_tokens = request.num_tokens_with_spec - num_computed_tokens
                     else:
                         num_new_tokens = request.num_tokens - num_computed_tokens
                     threshold = self.scheduler_config.long_prefill_token_threshold
@@ -692,17 +689,11 @@ class ProfilingChunkScheduler(Scheduler):
                 # Speculative decode related. In MTP KV-consumer mode, waiting
                 # requests may already carry placeholder draft tokens that need
                 # to be scheduled together with the prefill tokens.
-                if (
-                    self.is_mtp_kv_consumer or not self.vllm_config.kv_transfer_config
-                ) and request.spec_token_ids:
-                    num_scheduled_spec_tokens = (
-                        num_new_tokens + num_computed_tokens - request.num_tokens
-                    )
+                if (self.is_mtp_kv_consumer or not self.vllm_config.kv_transfer_config) and request.spec_token_ids:
+                    num_scheduled_spec_tokens = num_new_tokens + num_computed_tokens - request.num_tokens
                     if num_scheduled_spec_tokens > 0:
                         del request.spec_token_ids[num_scheduled_spec_tokens:]
-                        scheduled_spec_decode_tokens[request_id] = (
-                            request.spec_token_ids
-                        )
+                        scheduled_spec_decode_tokens[request_id] = request.spec_token_ids
                     else:
                         # Prefill request: spec tokens not applicable yet.
                         request.spec_token_ids = []

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -269,6 +269,28 @@
 #       profiling startup and per-step timing callbacks without monkey-patching
 #       `EngineCore` and the multiprocess entry point.
 #
+# ** 10b. File: platform/patch_pp_mtp.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.v1.outputs.ModelRunnerOutput`
+#   2. `vllm.v1.engine.core.EngineCore.post_step`
+#   3. `vllm.config.speculative.SpeculativeConfig._verify_args`
+#    Why:
+#       PP batch_queue schedules newer batches before consuming older model
+#       outputs. The old `post_step -> update_draft_token_ids` path updates
+#       global Request state using the newer schedule state, which can attach
+#       MTP draft tokens to the wrong prefill/decode phase.
+#    How：
+#       Carry drafter output as `ModelRunnerOutput.spec_token_ids`, skip the
+#       global post-step draft-token update in PP batch_queue mode, and validate
+#       local Eagle/MTP drafters as PP=1. Scheduler-level PP+MTP alignment is
+#       implemented by `core/scheduler_profiling_chunk.py`, which is the only
+#       scheduler supported for this feature in vllm-ascend.
+#    Related PR (if no, explain why):
+#       Backport of local vLLM PP+MTP branch changes.
+#    Future Plan:
+#       Remove this patch once the runtime vLLM version contains the upstream
+#       PP+MTP output/config/post-step fixes.
+#
 # ** 11. File: platform/patch_tool_choice_none_content.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.entrypoints.openai.engine.serving.OpenAIServing._parse_tool_calls_from_content`
@@ -724,6 +746,23 @@
 #       Rotary quant is a unique feature of vllm-ascend.
 #    Future Plan:
 #       Remove this patch when vllm supports rotary quant or pluggable `MultiTokenPredictorLayer`.
+# ** 19b. File: worker/model_runner_v1.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `NPUModelRunner._update_states`
+#    Why:
+#       Product vLLM may not contain PP+MTP worker state fixes. Non-last PP
+#       ranks can re-add requests whose `output_token_ids` do not include
+#       accepted draft tokens, causing `token_ids_cpu` and following spec
+#       token placement to drift.
+#    How：
+#       Wrap the parent `_update_states` in vllm-ascend and inject only the
+#       upstream PP+MTP fix before `update_req_spec_token_ids` places draft
+#       tokens for re-added non-last PP requests.
+#    Related PR (if no, explain why):
+#       Backport of local vLLM PP+MTP branch changes.
+#    Future Plan:
+#       Remove this wrapper once the minimum supported runtime vLLM contains
+#       the PP+MTP worker state fixes.
 # ** 20. File: worker/patch_mamba_utils.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.worker.mamba_utils.batch_memcpy_kernel = batch_memcpy_kernel`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -21,6 +21,7 @@ import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_interface  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa
 import vllm_ascend.patch.platform.patch_mla_prefill_backend  # noqa
+import vllm_ascend.patch.platform.patch_pp_mtp  # noqa
 from vllm_ascend import envs
 from vllm_ascend.utils import is_310p
 

--- a/vllm_ascend/patch/platform/patch_pp_mtp.py
+++ b/vllm_ascend/patch/platform/patch_pp_mtp.py
@@ -103,8 +103,7 @@ def _patch_model_config_validation() -> None:
         hf_config = getattr(self, "hf_config", None)
         model_type = getattr(hf_config, "model_type", None)
         is_eagle_drafter = model_type == "eagle" and any(
-            arch.startswith("Eagle") or arch.endswith("Eagle3")
-            for arch in getattr(self, "architectures", ())
+            arch.startswith("Eagle") or arch.endswith("Eagle3") for arch in getattr(self, "architectures", ())
         )
         is_mtp_drafter = model_type in mtp_model_types
         if (

--- a/vllm_ascend/patch/platform/patch_pp_mtp.py
+++ b/vllm_ascend/patch/platform/patch_pp_mtp.py
@@ -1,0 +1,142 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Backport vLLM PP + MTP runtime support.
+
+The local Eagle/MTP drafter returns the draft tokens that belong to the model
+output being processed. With PP batch_queue, EngineCore schedules a newer batch
+before consuming the older output, so updating ``request.spec_token_ids`` from
+``post_step`` observes live Request state from the newer schedule step.
+"""
+
+from __future__ import annotations
+
+import copy
+from functools import wraps
+
+from vllm.logger import logger
+
+_PATCHED = False
+_ORIGINAL_ENGINE_POST_STEP = None
+_ORIGINAL_MODEL_CONFIG_VERIFY = None
+
+
+def _patch_model_runner_output() -> None:
+    from vllm.v1 import outputs as outputs_mod
+
+    model_runner_output_cls = outputs_mod.ModelRunnerOutput
+    fields = getattr(model_runner_output_cls, "__dataclass_fields__", {})
+    if "spec_token_ids" not in fields:
+        model_runner_output_cls.spec_token_ids = None
+        original_init = model_runner_output_cls.__init__
+        if getattr(original_init, "_vllm_ascend_pp_mtp_patched", False):
+            return
+
+        @wraps(original_init)
+        def _patched_init(self, *args, spec_token_ids=None, **kwargs):
+            original_init(self, *args, **kwargs)
+            self.spec_token_ids = spec_token_ids
+
+        _patched_init._vllm_ascend_pp_mtp_patched = True  # type: ignore[attr-defined]
+        model_runner_output_cls.__init__ = _patched_init
+
+    empty_output = outputs_mod.EMPTY_MODEL_RUNNER_OUTPUT
+    if not hasattr(empty_output, "spec_token_ids"):
+        empty_output.spec_token_ids = None
+
+
+def _patch_engine_core() -> None:
+    global _ORIGINAL_ENGINE_POST_STEP
+
+    from vllm.v1.engine.core import EngineCore
+
+    if getattr(EngineCore.post_step, "_vllm_ascend_pp_mtp_patched", False):
+        return
+
+    _ORIGINAL_ENGINE_POST_STEP = EngineCore.post_step
+
+    @wraps(_ORIGINAL_ENGINE_POST_STEP)
+    def _patched_post_step(self, model_executed: bool) -> None:
+        if (
+            getattr(self, "batch_queue", None) is not None
+            and not getattr(self, "async_scheduling", False)
+            and getattr(self, "use_spec_decode", False)
+            and model_executed
+        ):
+            return
+        return _ORIGINAL_ENGINE_POST_STEP(self, model_executed)
+
+    _patched_post_step._vllm_ascend_pp_mtp_patched = True  # type: ignore[attr-defined]
+    EngineCore.post_step = _patched_post_step
+
+
+def _patch_model_config_validation() -> None:
+    global _ORIGINAL_MODEL_CONFIG_VERIFY
+
+    from typing import get_args
+
+    from vllm.config.model import ModelConfig
+    from vllm.config.speculative import MTPModelTypes
+
+    original_verify = ModelConfig.verify_with_parallel_config
+    if getattr(original_verify, "_vllm_ascend_pp_mtp_patched", False):
+        return
+
+    _ORIGINAL_MODEL_CONFIG_VERIFY = original_verify
+    mtp_model_types = set(get_args(MTPModelTypes))
+
+    @wraps(original_verify)
+    def _patched_verify_with_parallel_config(self, parallel_config):
+        hf_config = getattr(self, "hf_config", None)
+        model_type = getattr(hf_config, "model_type", None)
+        is_eagle_drafter = model_type == "eagle" and any(
+            arch.startswith("Eagle") or arch.endswith("Eagle3")
+            for arch in getattr(self, "architectures", ())
+        )
+        is_mtp_drafter = model_type in mtp_model_types
+        if (
+            getattr(self, "runner", None) == "draft"
+            and (is_eagle_drafter or is_mtp_drafter)
+            and getattr(parallel_config, "pipeline_parallel_size", 1) > 1
+        ):
+            # Local Eagle/MTP drafters are loaded on the last PP stage rather
+            # than partitioned across all PP stages. Keep normal target-model
+            # validation intact, but validate these draft models as PP=1.
+            logger.warning(
+                "Validating local Eagle/MTP drafter with pipeline_parallel_size=1 "
+                "because it is loaded locally on the last pipeline stage."
+            )
+            patched_config = copy.copy(parallel_config)
+            patched_config.pipeline_parallel_size = 1
+            return original_verify(self, patched_config)
+        return original_verify(self, parallel_config)
+
+    _patched_verify_with_parallel_config._vllm_ascend_pp_mtp_patched = True  # type: ignore[attr-defined]
+    ModelConfig.verify_with_parallel_config = _patched_verify_with_parallel_config
+
+
+def _apply_patch() -> None:
+    global _PATCHED
+    if _PATCHED:
+        return
+    _PATCHED = True
+
+    _patch_model_runner_output()
+    _patch_engine_core()
+    _patch_model_config_validation()
+
+
+_apply_patch()

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -21,6 +21,7 @@ import torch
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.distributed.parallel_state import get_pp_group
 from vllm.model_executor.models.qwen3_5 import Qwen3_5DecoderLayer
+
 try:
     from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MultiTokenPredictor
     from vllm.sequence import IntermediateTensors
@@ -184,10 +185,12 @@ if Qwen3_5MultiTokenPredictor is not None:
         )
 
         if not get_pp_group().is_last_rank:
-            return IntermediateTensors({
-                "hidden_states": hidden_states,
-                "residual": residual,
-            })
+            return IntermediateTensors(
+                {
+                    "hidden_states": hidden_states,
+                    "residual": residual,
+                }
+            )
 
         hidden_states, _ = self.norm(hidden_states, residual)
         return hidden_states

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -19,7 +19,14 @@
 
 import torch
 from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.distributed.parallel_state import get_pp_group
 from vllm.model_executor.models.qwen3_5 import Qwen3_5DecoderLayer
+try:
+    from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MultiTokenPredictor
+    from vllm.sequence import IntermediateTensors
+except ImportError:
+    Qwen3_5MultiTokenPredictor = None
+    IntermediateTensors = None
 from vllm.model_executor.models.qwen3_next import Qwen3NextAttention
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
@@ -144,6 +151,48 @@ class AscendQwen3_5DecoderLayer(Qwen3_5DecoderLayer):
                 hidden_states = hidden_states * (self.ffn_layer_scale.to(hidden_states.dtype) + 1)
 
         return hidden_states, residual
+
+
+if Qwen3_5MultiTokenPredictor is not None:
+
+    def qwen3_5_mtp_forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor:
+        # Backport upstream Qwen3.5 MTP behavior: the local drafter runs on the
+        # last PP stage and should always combine token embeddings with the
+        # target hidden states instead of consuming PP intermediate tensors.
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_input_ids(input_ids)
+        assert hidden_states.shape[-1] == inputs_embeds.shape[-1]
+        inputs_embeds = self.pre_fc_norm_embedding(inputs_embeds)
+        hidden_states = self.pre_fc_norm_hidden(hidden_states)
+        hidden_states = torch.cat([inputs_embeds, hidden_states], dim=-1)
+        hidden_states = self.fc(hidden_states)
+        residual = None
+
+        current_step_idx = spec_step_idx % self.num_mtp_layers
+        hidden_states, residual = self.layers[current_step_idx](
+            positions=positions,
+            hidden_states=hidden_states,
+            residual=residual,
+        )
+
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors({
+                "hidden_states": hidden_states,
+                "residual": residual,
+            })
+
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+    Qwen3_5MultiTokenPredictor.forward = qwen3_5_mtp_forward
 
 
 Qwen3_5DecoderLayer.forward = AscendQwen3_5DecoderLayer.forward

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -230,6 +230,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         return model
 
     def load_model(self, model: nn.Module) -> None:
+        assert get_pp_group().is_last_rank, (
+            f"{self.method} drafter must be loaded on the last pipeline stage."
+        )
+
         target_attn_layer_names = set(get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase).keys())
 
         with self.maybe_eager_context:

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -230,9 +230,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         return model
 
     def load_model(self, model: nn.Module) -> None:
-        assert get_pp_group().is_last_rank, (
-            f"{self.method} drafter must be loaded on the last pipeline stage."
-        )
+        assert get_pp_group().is_last_rank, f"{self.method} drafter must be loaded on the last pipeline stage."
 
         target_attn_layer_names = set(get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase).keys())
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -674,6 +674,105 @@ class NPUModelRunner(GPUModelRunner):
         self.query_start_loc.copy_to_gpu()
 
         return num_reqs_padded
+    
+    def _is_non_last_pp_mtp(self) -> bool:
+        return (
+            self.need_accepted_tokens
+            and self.speculative_config is not None
+            and not get_pp_group().is_last_rank
+            and not self.use_async_scheduling
+        )
+
+    def _sync_num_accepted_tokens_to_gpu(
+        self, accepted_counts: dict[str, int]
+    ) -> None:
+        if not accepted_counts:
+            return
+        for req_id, count in accepted_counts.items():
+            req_index = self.input_batch.req_id_to_index.get(req_id)
+            if req_index is not None:
+                self.input_batch.num_accepted_tokens_cpu[req_index] = count
+        num_reqs = self.input_batch.num_reqs
+        self.num_accepted_tokens.np[:num_reqs] = (
+            self.input_batch.num_accepted_tokens_cpu[:num_reqs]
+        )
+        self.num_accepted_tokens.copy_to_gpu(num_reqs)
+
+    def _compute_non_last_pp_mtp_accepted_counts(
+        self,
+        scheduler_output: SchedulerOutput,
+        prev_scheduler_output: SchedulerOutput | None,
+    ) -> dict[str, int]:
+        req_data = scheduler_output.scheduled_cached_reqs
+        prev_spec_tokens = (
+            prev_scheduler_output.scheduled_spec_decode_tokens
+            if prev_scheduler_output is not None
+            else {}
+        )
+        accepted_counts: dict[str, int] = {}
+
+        for i, req_id in enumerate(req_data.req_ids):
+            count = 1
+            req_state = self.requests.get(req_id)
+            if req_state is not None and req_id in prev_spec_tokens:
+                prev_num_computed = req_state.num_computed_tokens
+                num_computed = int(req_data.num_computed_tokens[i])
+                delta = num_computed - prev_num_computed
+                max_count = len(prev_spec_tokens[req_id]) + 1
+                logger.info(f">>>>>>>>>> max_count: {max_count}, delta: {delta}, num_computed: {num_computed}, prev_num_computed: {prev_num_computed}")
+                if 0 < delta <= max_count:
+                    count = delta
+            accepted_counts[req_id] = max(1, count)
+
+        return accepted_counts
+    
+    def _update_states(self, scheduler_output: "SchedulerOutput"):
+        # For non-last PP + MTP, compute accepted counts via delta of
+        # num_computed_tokens (last rank produces sampled ids; non-last must
+        # infer acceptance from scheduler output delta).
+        accepted_counts = (
+            self._compute_non_last_pp_mtp_accepted_counts(
+                scheduler_output,
+                self._prev_non_last_pp_mamba_scheduler_output,
+            )
+            if self._is_non_last_pp_mtp()
+            else {}
+        )
+
+        # Sync accepted counts to GPU and run mamba postprocess
+        # (needs correct `num_accepted_tokens_cpu` BEFORE super()._update_states).
+        self._sync_num_accepted_tokens_to_gpu(accepted_counts)
+        prev_scheduler_output = self._prev_non_last_pp_mamba_scheduler_output
+        if (
+            self._is_non_last_pp_mtp()
+            and accepted_counts
+            and prev_scheduler_output is not None
+            and self.cache_config.mamba_cache_mode == "align"
+        ):
+            mamba_utils.postprocess_mamba(
+                prev_scheduler_output,
+                self.kv_cache_config,
+                self.input_batch,
+                self.requests,
+                self.mamba_state_idx,
+                self.compilation_config.static_forward_context,
+                self.model.get_mamba_state_copy_func(),
+                self._get_mamba_copy_bufs(),
+            )
+
+        # Parent _update_states may reset num_accepted_tokens on
+        # non-last ranks (since no sampled_token_ids exist locally).
+        deferred_state_corrections_fn = super()._update_states(scheduler_output)
+
+        # Cache scheduler_output for next step's mamba postprocess
+        # (only when spec decode actually happened).
+        if (
+            self._is_non_last_pp_mtp()
+            and scheduler_output.scheduled_spec_decode_tokens
+        ):
+            self._prev_non_last_pp_mamba_scheduler_output = scheduler_output
+
+        return deferred_state_corrections_fn
 
     def _prepare_inputs(
         self,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -762,18 +762,6 @@ class NPUModelRunner(GPUModelRunner):
                 self._get_mamba_copy_bufs(),
             )
 
-    def _finish_non_last_pp_mtp_state_update(
-        self,
-        scheduler_output: SchedulerOutput,
-    ) -> None:
-        if (
-            self._is_non_last_pp_mtp()
-            and scheduler_output.scheduled_spec_decode_tokens
-        ):
-            self._prev_non_last_pp_mtp_scheduler_output = scheduler_output
-        else:
-            self._prev_non_last_pp_mtp_scheduler_output = None
-
     def _prepare_inputs(
         self,
         scheduler_output: "SchedulerOutput",
@@ -1946,10 +1934,15 @@ class NPUModelRunner(GPUModelRunner):
 
                 # Update persistent batch states.
                 self._prepare_non_last_pp_mtp_state_update(scheduler_output)
-                with self._pp_mtp_update_req_spec_token_ids(scheduler_output):
-                    deferred_state_corrections_fn = self._update_states(
-                        scheduler_output)
-                self._finish_non_last_pp_mtp_state_update(scheduler_output)
+                if scheduler_output.total_num_scheduled_tokens != 0:
+                    with self._pp_mtp_update_req_spec_token_ids(scheduler_output):
+                        deferred_state_corrections_fn = self._update_states(
+                            scheduler_output)
+                if (
+                    self._is_non_last_pp_mtp()
+                    and scheduler_output.scheduled_spec_decode_tokens
+                ):
+                    self._prev_non_last_pp_mtp_scheduler_output = scheduler_output
 
                 if has_ec_transfer() and get_ec_transfer().is_producer:
                     with self.maybe_get_ec_connector_output(
@@ -4595,9 +4588,27 @@ class NPUModelRunner(GPUModelRunner):
         attention_backends: list[set[type[AttentionBackend]]],
         kv_cache_groups: list[KVCacheGroupSpec],
     ) -> None:
-        with update_pass_config(self):
-            super()._check_and_update_cudagraph_mode(attention_backends, kv_cache_groups)
+        speculative_config = self.speculative_config
+        skip_parent_drafter_init = (
+            speculative_config is not None
+            and not get_pp_group().is_last_rank
+            and (
+                speculative_config.use_eagle()
+                or speculative_config.uses_extract_hidden_states()
+            )
+        )
+        try:
+            if skip_parent_drafter_init:
+                # vLLM releases before the PP guard still try to initialize the
+                # drafter on every PP rank. Ascend only creates it on last rank.
+                self.speculative_config = None
+            with update_pass_config(self):
+                super()._check_and_update_cudagraph_mode(attention_backends, kv_cache_groups)
+        finally:
+            if skip_parent_drafter_init:
+                self.speculative_config = speculative_config
 
+        self._maybe_initialize_drafter_cudagraph_keys()
 
         capture_descs = self.cudagraph_dispatcher.get_capture_descs()
         capture_sizes = sorted({
@@ -4612,6 +4623,37 @@ class NPUModelRunner(GPUModelRunner):
             set_graph_params(capture_sizes)
             if self.speculative_config:
                 set_draft_graph_params(capture_sizes)
+
+    def _maybe_initialize_drafter_cudagraph_keys(self) -> None:
+        # Keep a local fallback for vLLM variants that do not initialize the
+        # drafter here. When the parent already did it, keys_initialized avoids
+        # rebuilding the drafter dispatch keys.
+        if not self.speculative_config:
+            return
+        if not (
+            self.speculative_config.use_eagle()
+            or self.speculative_config.uses_extract_hidden_states()
+        ):
+            return
+        if not get_pp_group().is_last_rank:
+            return
+
+        assert isinstance(
+            self.drafter,
+            AscendEagleProposer
+            | AscendDflashProposer
+            | AscendExtractHiddenStatesProposer,
+        )
+        drafter_dispatcher = getattr(self.drafter, "cudagraph_dispatcher", None)
+        if getattr(drafter_dispatcher, "keys_initialized", False):
+            return
+
+        cudagraph_mode = getattr(
+            self.cudagraph_dispatcher,
+            "cudagraph_mode",
+            self.compilation_config.cudagraph_mode,
+        )
+        self.drafter.initialize_cudagraph_keys(cudagraph_mode)
 
     def capture_model(self) -> int:
         """Capture NPU graphs and return actual graph pool memory bytes consumed."""

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -511,6 +511,7 @@ class NPUModelRunner(GPUModelRunner):
         self.mamba_state_idx: dict[str, int] = {}
         self._mamba_bufs: Any | None = None
         self._mamba_copy_bufs: Any | None = None
+        self._prev_non_last_pp_mtp_scheduler_output: SchedulerOutput | None = None
         self.enable_hamming_sparse = (self.ascend_config.enable_hamming_sparse is True)
         self.enable_hamming_sparse = self.enable_hamming_sparse and not vllm_config.speculative_config
         if self.enable_hamming_sparse is True:
@@ -674,7 +675,7 @@ class NPUModelRunner(GPUModelRunner):
         self.query_start_loc.copy_to_gpu()
 
         return num_reqs_padded
-    
+
     def _is_non_last_pp_mtp(self) -> bool:
         return (
             self.need_accepted_tokens
@@ -719,34 +720,35 @@ class NPUModelRunner(GPUModelRunner):
                 num_computed = int(req_data.num_computed_tokens[i])
                 delta = num_computed - prev_num_computed
                 max_count = len(prev_spec_tokens[req_id]) + 1
-                logger.info(f">>>>>>>>>> max_count: {max_count}, delta: {delta}, num_computed: {num_computed}, prev_num_computed: {prev_num_computed}")
                 if 0 < delta <= max_count:
                     count = delta
             accepted_counts[req_id] = max(1, count)
 
         return accepted_counts
-    
-    def _update_states(self, scheduler_output: "SchedulerOutput"):
-        # For non-last PP + MTP, compute accepted counts via delta of
-        # num_computed_tokens (last rank produces sampled ids; non-last must
-        # infer acceptance from scheduler output delta).
+
+    def _prepare_non_last_pp_mtp_state_update(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> None:
+        if not self._is_non_last_pp_mtp():
+            return
+
         accepted_counts = (
             self._compute_non_last_pp_mtp_accepted_counts(
                 scheduler_output,
-                self._prev_non_last_pp_mamba_scheduler_output,
+                self._prev_non_last_pp_mtp_scheduler_output,
             )
-            if self._is_non_last_pp_mtp()
-            else {}
         )
+        if not accepted_counts:
+            return
 
-        # Sync accepted counts to GPU and run mamba postprocess
-        # (needs correct `num_accepted_tokens_cpu` BEFORE super()._update_states).
+        # Hybrid-attention models with Mamba cache need the accepted draft-token
+        # count before the upstream state update. Non-last PP ranks do not sample
+        # locally, so infer acceptance from the scheduler's computed-token delta.
         self._sync_num_accepted_tokens_to_gpu(accepted_counts)
-        prev_scheduler_output = self._prev_non_last_pp_mamba_scheduler_output
+        prev_scheduler_output = self._prev_non_last_pp_mtp_scheduler_output
         if (
-            self._is_non_last_pp_mtp()
-            and accepted_counts
-            and prev_scheduler_output is not None
+            prev_scheduler_output is not None
             and self.cache_config.mamba_cache_mode == "align"
         ):
             mamba_utils.postprocess_mamba(
@@ -760,19 +762,17 @@ class NPUModelRunner(GPUModelRunner):
                 self._get_mamba_copy_bufs(),
             )
 
-        # Parent _update_states may reset num_accepted_tokens on
-        # non-last ranks (since no sampled_token_ids exist locally).
-        deferred_state_corrections_fn = super()._update_states(scheduler_output)
-
-        # Cache scheduler_output for next step's mamba postprocess
-        # (only when spec decode actually happened).
+    def _finish_non_last_pp_mtp_state_update(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> None:
         if (
             self._is_non_last_pp_mtp()
             and scheduler_output.scheduled_spec_decode_tokens
         ):
-            self._prev_non_last_pp_mamba_scheduler_output = scheduler_output
-
-        return deferred_state_corrections_fn
+            self._prev_non_last_pp_mtp_scheduler_output = scheduler_output
+        else:
+            self._prev_non_last_pp_mtp_scheduler_output = None
 
     def _prepare_inputs(
         self,
@@ -1945,9 +1945,11 @@ class NPUModelRunner(GPUModelRunner):
                             req_state.prev_num_draft_len = 0
 
                 # Update persistent batch states.
+                self._prepare_non_last_pp_mtp_state_update(scheduler_output)
                 with self._pp_mtp_update_req_spec_token_ids(scheduler_output):
                     deferred_state_corrections_fn = self._update_states(
                         scheduler_output)
+                self._finish_non_last_pp_mtp_state_update(scheduler_output)
 
                 if has_ec_transfer() and get_ec_transfer().is_producer:
                     with self.maybe_get_ec_connector_output(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -168,6 +168,7 @@ from vllm_ascend.sample.rejection_sampler import AscendRejectionSampler
 
 if TYPE_CHECKING:
     import xgrammar as xgr  # type: ignore[import-untyped]
+    from vllm.config.speculative import SpeculativeConfig
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 else:
     xgr = LazyLoader("xgr", globals(), "xgrammar")
@@ -245,6 +246,10 @@ class ExecuteModelState(NamedTuple):
 
 
 class NPUModelRunner(GPUModelRunner):
+    speculative_config: "SpeculativeConfig | None"
+    _draft_token_ids: torch.Tensor | list[list[int]] | None
+    _draft_token_req_ids: list[str] | None
+
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         # TODO(qcs): These manual pad and unpad for GPUModelRunner are
         # used to expand some buffers, which need to be reverted after
@@ -562,7 +567,9 @@ class NPUModelRunner(GPUModelRunner):
         self.num_discarded_requests = 0
 
     def _get_drafter(self):
-        return get_spec_decode_method(self.speculative_config.method, self.vllm_config, self.device, self)
+        speculative_config = self.speculative_config
+        assert speculative_config is not None
+        return get_spec_decode_method(speculative_config.method, self.vllm_config, self.device, self)
 
     def _use_aclgraph(self) -> bool:
         return (
@@ -1397,7 +1404,12 @@ class NPUModelRunner(GPUModelRunner):
 
         # For the overlay of the PCP feature and the eagle3, attn_state needs to be recovered
         # TODO: Resolved the conflict between the sunset of attn_state and the PCP that requires this interface.
-        if attn_state == AscendAttentionState.SpecDecoding and self.speculative_config.method != "mtp":
+        speculative_config = self.speculative_config
+        if (
+            attn_state == AscendAttentionState.SpecDecoding
+            and speculative_config is not None
+            and speculative_config.method != "mtp"
+        ):
             self.attn_state = AscendAttentionState.ChunkedPrefill  # type: ignore
         else:
             self.attn_state = attn_state  # type: ignore
@@ -1518,6 +1530,8 @@ class NPUModelRunner(GPUModelRunner):
         sample_hidden_states: torch.Tensor = None,
         target_model_batch_desc: BatchDescriptor = None,
     ) -> list[list[int]] | None:
+        speculative_config = self.speculative_config
+        assert speculative_config is not None
         if not self.drafter:
             # Speculative decoding is not enabled.
             draft_token_ids = None
@@ -1572,7 +1586,7 @@ class NPUModelRunner(GPUModelRunner):
             draft_token_ids = self.drafter.propose(
                 valid_sampled_token_ids, sampling_metadata, spec_decode_metadata, sample_hidden_states
             )
-        elif self.speculative_config.uses_extract_hidden_states():
+        elif speculative_config.uses_extract_hidden_states():
             # Handle extract_hidden_states method
             assert isinstance(self.drafter, AscendExtractHiddenStatesProposer)
             assert isinstance(valid_sampled_token_ids, torch.Tensor), (
@@ -1601,7 +1615,7 @@ class NPUModelRunner(GPUModelRunner):
                 )
             )
             self._copy_valid_sampled_token_count(next_token_ids, valid_sampled_tokens_count)
-        elif self.speculative_config.use_eagle() or self.speculative_config.uses_draft_model():
+        elif speculative_config.use_eagle() or speculative_config.uses_draft_model():
             common_attn_metadata = spec_decode_common_attn_metadata
             sampled_token_ids = valid_sampled_token_ids
 
@@ -1732,7 +1746,7 @@ class NPUModelRunner(GPUModelRunner):
             if not self.vllm_config.speculative_config.disable_padded_drafter_batch:
                 self._copy_valid_sampled_token_count(next_token_ids, valid_sampled_tokens_count)
         else:
-            raise ValueError(f"Unknown speculative decoding method: {self.speculative_config.method}")
+            raise ValueError(f"Unknown speculative decoding method: {speculative_config.method}")
 
         return draft_token_ids
 
@@ -2433,17 +2447,18 @@ class NPUModelRunner(GPUModelRunner):
 
             # Get draft token ids if available
             output_spec_token_ids = None
-            if self._draft_token_ids is not None:
+            draft_token_ids = self._draft_token_ids
+            if draft_token_ids is not None:
                 # Use synchronous copy to avoid NPU async stream/event
                 # synchronization issues. _get_draft_token_ids_cpu relies on
                 # event.synchronize() which may not properly wait for the
                 # async copy on NPU, resulting in stale data.
-                if torch.is_tensor(self._draft_token_ids):
-                    num_reqs = self._draft_token_ids.shape[0]
-                    draft_ids_list = self._draft_token_ids[:num_reqs].cpu().tolist()
+                if isinstance(draft_token_ids, torch.Tensor):
+                    num_reqs = draft_token_ids.shape[0]
+                    draft_ids_list = draft_token_ids[:num_reqs].cpu().tolist()
                     draft_req_ids = self._draft_token_req_ids
                 else:
-                    draft_ids_list = self._draft_token_ids
+                    draft_ids_list = draft_token_ids
                     draft_req_ids = self.input_batch.req_ids
                 if draft_ids_list and draft_req_ids:
                     draft_by_req_id = dict(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2205,6 +2205,8 @@ class NPUModelRunner(GPUModelRunner):
         )
 
         with record_function_or_nullcontext("draft_token"):
+            self._draft_token_ids = None
+            self._draft_token_req_ids = None
             if self.speculative_config:
                 input_fits_in_drafter = spec_decode_common_attn_metadata is not None and (
                     spec_decode_common_attn_metadata.max_seq_len + self.num_spec_tokens
@@ -2254,6 +2256,28 @@ class NPUModelRunner(GPUModelRunner):
             if self.speculative_config is not None:
                 self.finalize_kv_connector()
 
+            # Get draft token ids if available
+            output_spec_token_ids = None
+            if self._draft_token_ids is not None:
+                # Use synchronous copy to avoid NPU async stream/event
+                # synchronization issues. _get_draft_token_ids_cpu relies on
+                # event.synchronize() which may not properly wait for the
+                # async copy on NPU, resulting in stale data.
+                if torch.is_tensor(self._draft_token_ids):
+                    num_reqs = self._draft_token_ids.shape[0]
+                    draft_ids_list = self._draft_token_ids[:num_reqs].cpu().tolist()
+                    draft_req_ids = self._draft_token_req_ids
+                else:
+                    draft_ids_list = self._draft_token_ids
+                    draft_req_ids = self.input_batch.req_ids
+                if draft_ids_list and draft_req_ids:
+                    draft_by_req_id = dict(
+                        zip(draft_req_ids, draft_ids_list))
+                    output_spec_token_ids = [
+                        draft_by_req_id.get(req_id, [])
+                        for req_id in req_ids_output_copy
+                    ]
+
         routed_experts_lists = None
         if self.model_config.enable_return_routed_experts:
             if vllm_version_is("0.20.2"):
@@ -2278,6 +2302,7 @@ class NPUModelRunner(GPUModelRunner):
             req_ids=req_ids_output_copy,
             req_id_to_index=req_id_to_index_output_copy,
             sampled_token_ids=valid_sampled_token_ids,
+            spec_token_ids=output_spec_token_ids,
             logprobs=logprobs_lists,
             prompt_logprobs_dict=prompt_logprobs_dict,
             kv_connector_output=kv_connector_output,
@@ -3497,7 +3522,7 @@ class NPUModelRunner(GPUModelRunner):
         # Initialize drafter attention group initialization
         if self.speculative_config and (
             self.speculative_config.use_eagle() or self.speculative_config.uses_draft_model()
-        ):
+        ) and get_pp_group().is_last_rank:
             assert isinstance(self.drafter, AscendEagleProposer | AscendDflashProposer | AscendDraftModelProposer)
             block_size = (self.kernel_block_sizes[0] if isinstance(
             self.kernel_block_sizes, list) else self.kernel_block_sizes)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1679,6 +1679,87 @@ class NPUModelRunner(GPUModelRunner):
                 self.draft_token_ids_cpu[:num_reqs] = 0
             self.draft_token_ids_event.record()
 
+    def _collect_pp_mtp_readded_token(
+        self,
+        scheduler_output: "SchedulerOutput",
+    ) -> dict[str, tuple[list[int], int]]:
+        if get_pp_group().is_last_rank:
+            return {}
+
+        req_data = scheduler_output.scheduled_cached_reqs
+        new_token_ids = getattr(req_data, "new_token_ids", None)
+        if not new_token_ids:
+            return {}
+
+        cached_req_ids = set(self.input_batch.req_id_to_index)
+        finished_req_ids = set(scheduler_output.finished_req_ids)
+        scheduled_req_ids = set(scheduler_output.num_scheduled_tokens)
+        resumed_req_ids = set(req_data.resumed_req_ids)
+        unscheduled_req_ids = cached_req_ids - (scheduled_req_ids - resumed_req_ids)
+        req_ids_after_parent_removals = (
+            cached_req_ids - finished_req_ids - unscheduled_req_ids
+        )
+
+        token_fixes: dict[str, tuple[list[int], int]] = {}
+        for i, req_id in enumerate(req_data.req_ids):
+            if req_id in req_ids_after_parent_removals or i >= len(new_token_ids):
+                continue
+            if new_tokens := new_token_ids[i]:
+                token_fixes[req_id] = (
+                    list(new_tokens),
+                    req_data.num_computed_tokens[i],
+                )
+        return token_fixes
+
+    @contextmanager
+    def _pp_mtp_update_req_spec_token_ids(
+        self,
+        scheduler_output: "SchedulerOutput",
+    ):
+        if scheduler_output.total_num_scheduled_tokens == 0:
+            yield
+            return
+
+        token_fixes = self._collect_pp_mtp_readded_token(scheduler_output)
+        if not token_fixes:
+            yield
+            return
+
+        input_batch = self.input_batch
+        had_instance_update_spec_tokens = (
+            "update_req_spec_token_ids" in input_batch.__dict__
+        )
+        original_update_spec_tokens = input_batch.update_req_spec_token_ids
+        fixed_req_ids: set[str] = set()
+
+        # Parent _update_states places spec tokens immediately through this API.
+        def update_req_spec_token_ids_pp_mtp(
+            request,
+            scheduled_spec_tokens,
+        ) -> None:
+            req_id = request.req_id
+            if req_id not in fixed_req_ids and (fix_data := token_fixes.get(req_id)):
+                req_index = input_batch.req_id_to_index.get(req_id)
+                if req_index is not None:
+                    new_tokens, num_computed_tokens = fix_data
+                    end_token_index = num_computed_tokens + len(new_tokens)
+                    input_batch.token_ids_cpu[
+                        req_index, num_computed_tokens:end_token_index
+                    ] = new_tokens
+                    input_batch.num_tokens_no_spec[req_index] = end_token_index
+                    fixed_req_ids.add(req_id)
+
+            return original_update_spec_tokens(request, scheduled_spec_tokens)
+
+        input_batch.update_req_spec_token_ids = update_req_spec_token_ids_pp_mtp
+        try:
+            yield
+        finally:
+            if had_instance_update_spec_tokens:
+                input_batch.update_req_spec_token_ids = original_update_spec_tokens
+            else:
+                del input_batch.update_req_spec_token_ids
+
     @torch.inference_mode()
     def execute_model(
         self,
@@ -1765,9 +1846,9 @@ class NPUModelRunner(GPUModelRunner):
                             req_state.prev_num_draft_len = 0
 
                 # Update persistent batch states.
-                deferred_state_corrections_fn = self._update_states(
-                    scheduler_output
-                )
+                with self._pp_mtp_update_req_spec_token_ids(scheduler_output):
+                    deferred_state_corrections_fn = self._update_states(
+                        scheduler_output)
 
                 if has_ec_transfer() and get_ec_transfer().is_producer:
                     with self.maybe_get_ec_connector_output(


### PR DESCRIPTION
### What this PR does / why we need it?
This PR backports vLLM Pipeline Parallelism (PP) + Multi-Token Prediction (MTP) runtime support to `vllm-ascend`. It introduces scheduler-level PP+MTP alignment in `scheduler_profiling_chunk.py`, patches `ModelRunnerOutput` and `EngineCore` to support `spec_token_ids` and skip global post-step updates in PP batch_queue mode, and implements worker-state updates and token broadcasting in `model_runner_v1.py`.

### Does this PR introduce _any_ user-facing change?
No, this is an internal backend enablement and backport of PP+MTP support.

### How was this patch tested?
New unit tests were added in `test_profiling_chunk.py`, `test_patch_pp_mtp.py`, `test_patch_qwen3_5_mtp.py`, and `test_model_runner_v1.py`. Note that some of the new tests currently call unimplemented methods and will fail until those methods are implemented or the tests are corrected.


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
