### PR TITLE
[CI] fix ci error when rebase on latest main

### DIFF
--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -109,6 +109,8 @@ jobs:
 
       - name: Rebase on latest main
         run: |
+          git config user.name "vllm-ascend-ci"
+          git config user.email "vllm-ascend-ci@users.noreply.github.com"
           git fetch origin main
           git rebase origin/main
 


### PR DESCRIPTION
### What this PR does / why we need it?
fix committer identity unknown when rebase on latest main.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
<img width="1892" height="400" alt="image" src="https://github.com/user-attachments/assets/f30f757b-b931-420e-900f-ccbdc9fcbcca" />

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
