### PR TITLE
[CI] remove wait-feedback label when a new reply is received

### DIFF
--- a/.github/workflows/schedule_stale_manage.yaml
+++ b/.github/workflows/schedule_stale_manage.yaml
@@ -1,10 +1,23 @@
 name: "Close stale resolved/wait-feedback issues"
 on:
   schedule:
-    - cron: '0 2 * * *' 
+    - cron: '0 2 * * *'
+  issue_comment:
+    types: [created]
 
 jobs:
+  remove-wait-feedback-on-comment:
+    if: ${{ github.event_name == 'issue_comment' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      # When an issue tagged with "wait-feedback" receives a new response, the "wait-feedback" tag will be removed.
+      - run: gh issue edit "${{ github.event.issue.number }}" --remove-label "wait-feedback"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   stale:
+    if: ${{ github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
     permissions:
       actions: write


### PR DESCRIPTION
### What this PR does / why we need it?
Remove wait-feedback label when a new reply is received

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
