### PR TITLE
[Doc][CI] Refine doctest workflow with PR-driven and doc-driven matrix

### DIFF
--- a/.github/workflows/labeled_doctest.yaml
+++ b/.github/workflows/labeled_doctest.yaml
@@ -19,12 +19,31 @@ name: Doc Test
 
 on:
   workflow_dispatch:
+    inputs:
+      doc_versions:
+        description: 'JSON array of Read the Docs versions to test, e.g. ["v0.18.0","latest"]'
+        required: true
+        type: string
   workflow_call:
+    inputs:
+      doc_versions:
+        description: 'JSON array of Read the Docs versions to test'
+        required: false
+        type: string
+        default: '["v0.18.0","latest"]'
   pull_request:
     branches:
       - 'main'
+      - '*-dev'
+      - 'releases/v*'
     paths:
+      # If we are changing the doctest we should do a PR test
       - '.github/workflows/labeled_doctest.yaml'
+      - 'tests/e2e/doctests/**'
+      - 'tests/e2e/common.sh'
+      - 'tests/e2e/run_doctests.sh'
+permissions:
+  contents: read
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -38,35 +57,142 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup-matrix:
+    name: Setup test matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        env:
+          INPUT_DOC_VERSIONS: ${{ inputs.doc_versions || '["v0.18.0","latest"]' }}
+        run: |
+          set -euo pipefail
+
+          echo "${INPUT_DOC_VERSIONS}" | jq -e 'type == "array" and all(.[]; type == "string")' >/dev/null
+
+          matrix_file="$(mktemp)"
+          workdir="$(mktemp -d)"
+          trap 'rm -rf "${matrix_file}" "${workdir}"' EXIT
+          echo '{"include":[]}' > "${matrix_file}"
+
+          while IFS= read -r doc_version; do
+            version_url="https://readthedocs.org/api/v3/projects/vllm-ascend/versions/${doc_version}/"
+            metadata_file="${workdir}/${doc_version}.json"
+            repo_dir="${workdir}/repo-${doc_version//[^A-Za-z0-9._-]/-}"
+
+            echo "Resolving Read the Docs version: ${doc_version}"
+            curl --fail --show-error --location \
+              --retry 3 \
+              --retry-delay 5 \
+              "${version_url}" \
+              -o "${metadata_file}"
+
+            doc_ref="$(jq -r '.identifier // empty' "${metadata_file}")"
+            doc_verbose_name="$(jq -r '.verbose_name // empty' "${metadata_file}")"
+            documentation_url="$(jq -r '.urls.documentation // empty' "${metadata_file}")"
+
+            if [ -z "${doc_ref}" ]; then
+              echo "Read the Docs version ${doc_version} does not have an identifier." >&2
+              exit 1
+            fi
+
+            git clone --depth 1 --branch "${doc_ref}" \
+              https://github.com/vllm-project/vllm-ascend.git "${repo_dir}"
+
+            vllm_ascend_version="$(python3 "${repo_dir}/docs/source/conf.py" \
+              | jq -r '.vllm_ascend_version // empty')"
+            if [ -z "${vllm_ascend_version}" ]; then
+              echo "Failed to resolve vllm_ascend_version from ${doc_ref}." >&2
+              exit 1
+            fi
+
+            for os_variant in ubuntu openeuler; do
+              if [ "${os_variant}" = "ubuntu" ]; then
+                image="quay.io/ascend/vllm-ascend:${vllm_ascend_version}"
+              else
+                image="quay.io/ascend/vllm-ascend:${vllm_ascend_version}-${os_variant}"
+              fi
+
+              next_matrix_file="$(mktemp)"
+              jq \
+                --arg doc_version "${doc_version}" \
+                --arg doc_ref "${doc_ref}" \
+                --arg doc_verbose_name "${doc_verbose_name}" \
+                --arg documentation_url "${documentation_url}" \
+                --arg vllm_ascend_version "${vllm_ascend_version}" \
+                --arg os_variant "${os_variant}" \
+                --arg image "${image}" \
+                '.include += [{
+                  doc_version: $doc_version,
+                  doc_ref: $doc_ref,
+                  doc_verbose_name: $doc_verbose_name,
+                  documentation_url: $documentation_url,
+                  vllm_ascend_version: $vllm_ascend_version,
+                  os_variant: $os_variant,
+                  image: $image
+                }]' "${matrix_file}" > "${next_matrix_file}"
+              mv "${next_matrix_file}" "${matrix_file}"
+            done
+          done < <(echo "${INPUT_DOC_VERSIONS}" | jq -r '.[]')
+
+          echo "Resolved doctest matrix:"
+          jq . "${matrix_file}"
+
+          {
+            echo "matrix<<EOF"
+            jq -c . "${matrix_file}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
   test:
+    needs: setup-matrix
     strategy:
       # Each version should be tested
       fail-fast: false
-      matrix:
-        vllm_version: [v0.18.0, v0.20.2rc1]
-    name: vLLM Ascend test
+      matrix: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
+    name: vLLM Ascend test (${{ matrix.doc_version }}, ${{ matrix.os_variant }})
     runs-on: linux-aarch64-a2b3-1
     container:
-      image: quay.io/ascend/vllm-ascend:${{ matrix.vllm_version }}
+      image: ${{ matrix.image }}
     steps:
+      - name: Checkout doctest source
+        uses: actions/checkout@v4
+        with:
+          repository: vllm-project/vllm-ascend
+          ref: ${{ matrix.doc_ref }}
+          path: doctest-src
+
       - name: Check NPU/CANN and git info
         run: |
+          echo "====> Print Read the Docs info"
+          echo "Doc version: ${{ matrix.doc_version }}"
+          echo "Doc ref: ${{ matrix.doc_ref }}"
+          echo "Doc verbose name: ${{ matrix.doc_verbose_name }}"
+          echo "Documentation URL: ${{ matrix.documentation_url }}"
+          echo "vllm-ascend version: ${{ matrix.vllm_ascend_version }}"
+          echo "Container image: ${{ matrix.image }}"
+
           echo "====> Print NPU/CANN info"
           npu-smi info
           cat /usr/local/Ascend/ascend-toolkit/latest/"$(uname -i)"-linux/ascend_toolkit_install.info
 
-          echo "====> Print vllm-ascend git info"
-          cd /vllm-workspace/vllm-ascend
-          git --no-pager log -1 || true
-          echo "====> Print vllm git info"
-          cd /vllm-workspace/vllm
-          git --no-pager log -1 || true
+          echo "====> Print doctest source git info"
+          git -C "${GITHUB_WORKSPACE}/doctest-src" --no-pager log -1
+          echo "====> Print doctest source version info"
+          python3 "${GITHUB_WORKSPACE}/doctest-src/docs/source/conf.py" | jq .
 
-      - name: Run vllm-ascend/tests/e2e/run_doctests.sh
+          echo "====> Print container vllm-ascend git info"
+          git -C /vllm-workspace/vllm-ascend --no-pager log -1 || true
+          echo "====> Print container vllm git info"
+          git -C /vllm-workspace/vllm --no-pager log -1 || true
+
+      - name: Run doctest source tests/e2e/run_doctests.sh
         run: |
-          # Simulate container to enter directory
+          # Avoid putting the checkout root on Python's import path. The test
+          # should use doctest scripts from the checkout and packages installed
+          # in the container image.
           cd /workspace
 
-          # Run real test
           echo "Test:"
-          /vllm-workspace/vllm-ascend/tests/e2e/run_doctests.sh
+          bash "${GITHUB_WORKSPACE}/doctest-src/tests/e2e/run_doctests.sh"

--- a/.github/workflows/labeled_doctest.yaml
+++ b/.github/workflows/labeled_doctest.yaml
@@ -23,14 +23,8 @@ on:
   pull_request:
     branches:
       - 'main'
-      - '*-dev'
-      - 'releases/v*'
     paths:
-      # If we are changing the doctest we should do a PR test
       - '.github/workflows/labeled_doctest.yaml'
-      - 'tests/e2e/doctests/**'
-      - 'tests/e2e/common.sh'
-      - 'tests/e2e/run_doctests.sh'
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -49,11 +43,11 @@ jobs:
       # Each version should be tested
       fail-fast: false
       matrix:
-        vllm_version: [nightly-releases-v0.18.0, nightly-releases-v0.18.0-openeuler, nightly-main, nightly-main-openeuler]
+        vllm_version: [v0.18.0, v0.20.2rc1]
     name: vLLM Ascend test
     runs-on: linux-aarch64-a2b3-1
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:${{ matrix.vllm_version }}
+      image: quay.io/ascend/vllm-ascend:${{ matrix.vllm_version }}
     steps:
       - name: Check NPU/CANN and git info
         run: |
@@ -68,22 +62,8 @@ jobs:
           cd /vllm-workspace/vllm
           git --no-pager log -1 || true
 
-      - name: Checkout vllm-project/vllm-ascend repo
-        uses: actions/checkout@v6
-
       - name: Run vllm-ascend/tests/e2e/run_doctests.sh
         run: |
-          # PWD: /__w/vllm-ascend/vllm-ascend
-          # Make sure e2e tests are latest
-          echo "Replacing /vllm-workspace/vllm-ascend/tests/e2e ..."
-          rm -rf /vllm-workspace/vllm-ascend/tests/e2e
-          mkdir -p /vllm-workspace/vllm-ascend/tests
-          # Overwrite e2e and examples
-          cp -r tests/e2e /vllm-workspace/vllm-ascend/tests/
-          cp -r examples /vllm-workspace/vllm-ascend/
-          # We are now maintain version policy in the main, so we need to copy docs to make sure the doctest can be run successfully.
-          cp -r docs /vllm-workspace/vllm-ascend/
-
           # Simulate container to enter directory
           cd /workspace
 

--- a/.github/workflows/labeled_doctest.yaml
+++ b/.github/workflows/labeled_doctest.yaml
@@ -39,6 +39,9 @@ on:
     paths:
       # If we are changing the doctest we should do a PR test
       - '.github/workflows/labeled_doctest.yaml'
+      - 'docs/source/conf.py'
+      - 'docs/source/installation.md'
+      - 'docs/source/quick_start.md'
       - 'tests/e2e/doctests/**'
       - 'tests/e2e/common.sh'
       - 'tests/e2e/run_doctests.sh'
@@ -63,42 +66,31 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - name: Checkout current source
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          path: matrix-src
+
       - id: set-matrix
         env:
           INPUT_DOC_VERSIONS: ${{ inputs.doc_versions || '["v0.18.0","latest"]' }}
         run: |
           set -euo pipefail
 
-          echo "${INPUT_DOC_VERSIONS}" | jq -e 'type == "array" and all(.[]; type == "string")' >/dev/null
-
           matrix_file="$(mktemp)"
           workdir="$(mktemp -d)"
           trap 'rm -rf "${matrix_file}" "${workdir}"' EXIT
           echo '{"include":[]}' > "${matrix_file}"
 
-          while IFS= read -r doc_version; do
-            version_url="https://readthedocs.org/api/v3/projects/vllm-ascend/versions/${doc_version}/"
-            metadata_file="${workdir}/${doc_version}.json"
-            repo_dir="${workdir}/repo-${doc_version//[^A-Za-z0-9._-]/-}"
-
-            echo "Resolving Read the Docs version: ${doc_version}"
-            curl --fail --show-error --location \
-              --retry 3 \
-              --retry-delay 5 \
-              "${version_url}" \
-              -o "${metadata_file}"
-
-            doc_ref="$(jq -r '.identifier // empty' "${metadata_file}")"
-            doc_verbose_name="$(jq -r '.verbose_name // empty' "${metadata_file}")"
-            documentation_url="$(jq -r '.urls.documentation // empty' "${metadata_file}")"
-
-            if [ -z "${doc_ref}" ]; then
-              echo "Read the Docs version ${doc_version} does not have an identifier." >&2
-              exit 1
-            fi
-
-            git clone --depth 1 --branch "${doc_ref}" \
-              https://github.com/vllm-project/vllm-ascend.git "${repo_dir}"
+          add_matrix_entries() {
+            local repo_dir="$1"
+            local doc_repository="$2"
+            local doc_version="$3"
+            local doc_ref="$4"
+            local doc_verbose_name="$5"
+            local documentation_url="$6"
+            local vllm_ascend_version
 
             vllm_ascend_version="$(python3 "${repo_dir}/docs/source/conf.py" \
               | jq -r '.vllm_ascend_version // empty')"
@@ -116,6 +108,7 @@ jobs:
 
               next_matrix_file="$(mktemp)"
               jq \
+                --arg doc_repository "${doc_repository}" \
                 --arg doc_version "${doc_version}" \
                 --arg doc_ref "${doc_ref}" \
                 --arg doc_verbose_name "${doc_verbose_name}" \
@@ -124,6 +117,7 @@ jobs:
                 --arg os_variant "${os_variant}" \
                 --arg image "${image}" \
                 '.include += [{
+                  doc_repository: $doc_repository,
                   doc_version: $doc_version,
                   doc_ref: $doc_ref,
                   doc_verbose_name: $doc_verbose_name,
@@ -134,7 +128,52 @@ jobs:
                 }]' "${matrix_file}" > "${next_matrix_file}"
               mv "${next_matrix_file}" "${matrix_file}"
             done
-          done < <(echo "${INPUT_DOC_VERSIONS}" | jq -r '.[]')
+          }
+
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            add_matrix_entries \
+              "${GITHUB_WORKSPACE}/matrix-src" \
+              "${GITHUB_REPOSITORY}" \
+              "pull_request" \
+              "${GITHUB_REF}" \
+              "${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}" \
+              ""
+          else
+            echo "${INPUT_DOC_VERSIONS}" | jq -e 'type == "array" and all(.[]; type == "string")' >/dev/null
+
+            while IFS= read -r doc_version; do
+              version_url="https://readthedocs.org/api/v3/projects/vllm-ascend/versions/${doc_version}/"
+              metadata_file="${workdir}/${doc_version}.json"
+              repo_dir="${workdir}/repo-${doc_version//[^A-Za-z0-9._-]/-}"
+
+              echo "Resolving Read the Docs version: ${doc_version}"
+              curl --fail --show-error --location \
+                --retry 3 \
+                --retry-delay 5 \
+                "${version_url}" \
+                -o "${metadata_file}"
+
+              doc_ref="$(jq -r '.identifier // empty' "${metadata_file}")"
+              doc_verbose_name="$(jq -r '.verbose_name // empty' "${metadata_file}")"
+              documentation_url="$(jq -r '.urls.documentation // empty' "${metadata_file}")"
+
+              if [ -z "${doc_ref}" ]; then
+                echo "Read the Docs version ${doc_version} does not have an identifier." >&2
+                exit 1
+              fi
+
+              git clone --depth 1 --branch "${doc_ref}" \
+                https://github.com/vllm-project/vllm-ascend.git "${repo_dir}"
+
+              add_matrix_entries \
+                "${repo_dir}" \
+                "vllm-project/vllm-ascend" \
+                "${doc_version}" \
+                "${doc_ref}" \
+                "${doc_verbose_name}" \
+                "${documentation_url}"
+            done < <(echo "${INPUT_DOC_VERSIONS}" | jq -r '.[]')
+          fi
 
           echo "Resolved doctest matrix:"
           jq . "${matrix_file}"
@@ -159,13 +198,14 @@ jobs:
       - name: Checkout doctest source
         uses: actions/checkout@v4
         with:
-          repository: vllm-project/vllm-ascend
+          repository: ${{ matrix.doc_repository }}
           ref: ${{ matrix.doc_ref }}
           path: doctest-src
 
       - name: Check NPU/CANN and git info
         run: |
-          echo "====> Print Read the Docs info"
+          echo "====> Print doctest source info"
+          echo "Doc repository: ${{ matrix.doc_repository }}"
           echo "Doc version: ${{ matrix.doc_version }}"
           echo "Doc ref: ${{ matrix.doc_ref }}"
           echo "Doc verbose name: ${{ matrix.doc_verbose_name }}"

--- a/.github/workflows/labeled_doctest.yaml
+++ b/.github/workflows/labeled_doctest.yaml
@@ -24,6 +24,7 @@ on:
         description: 'JSON array of Read the Docs versions to test, e.g. ["v0.18.0","latest"]'
         required: true
         type: string
+        default: '["v0.18.0","latest"]'
   workflow_call:
     inputs:
       doc_versions:
@@ -40,8 +41,6 @@ on:
       # If we are changing the doctest we should do a PR test
       - '.github/workflows/labeled_doctest.yaml'
       - 'docs/source/conf.py'
-      - 'docs/source/installation.md'
-      - 'docs/source/quick_start.md'
       - 'tests/e2e/doctests/**'
       - 'tests/e2e/common.sh'
       - 'tests/e2e/run_doctests.sh'
@@ -64,15 +63,82 @@ jobs:
     name: Setup test matrix
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      matrix: ${{ steps.set_matrix_pr.outputs.matrix || steps.set_matrix_doc.outputs.matrix }}
     steps:
+      # PR runs should validate the PR content itself. The matrix is generated
+      # from this checkout instead of resolving a Read the Docs version.
       - name: Checkout current source
         if: github.event_name == 'pull_request'
         uses: actions/checkout@v4
         with:
           path: matrix-src
 
-      - id: set-matrix
+      - name: Set matrix (PR-driven)
+        if: github.event_name == 'pull_request'
+        id: set_matrix_pr
+        run: |
+          set -euo pipefail
+
+          matrix_file="$(mktemp)"
+          trap 'rm -f "${matrix_file}"' EXIT
+          echo '{"include":[]}' > "${matrix_file}"
+
+          doc_repository="${GITHUB_REPOSITORY}"
+          doc_version="pull_request"
+          doc_ref="${GITHUB_REF}"
+          doc_verbose_name="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          documentation_url=""
+          repo_dir="${GITHUB_WORKSPACE}/matrix-src"
+
+          vllm_ascend_version="$(python3 "${repo_dir}/docs/source/conf.py" \
+            | jq -r '.vllm_ascend_version // empty')"
+          if [ -z "${vllm_ascend_version}" ]; then
+            echo "Failed to resolve vllm_ascend_version from ${doc_ref}." >&2
+            exit 1
+          fi
+
+          for os_variant in ubuntu openeuler; do
+            if [ "${os_variant}" = "ubuntu" ]; then
+              image="quay.io/ascend/vllm-ascend:${vllm_ascend_version}"
+            else
+              image="quay.io/ascend/vllm-ascend:${vllm_ascend_version}-${os_variant}"
+            fi
+
+            next_matrix_file="$(mktemp)"
+            jq \
+              --arg doc_repository "${doc_repository}" \
+              --arg doc_version "${doc_version}" \
+              --arg doc_ref "${doc_ref}" \
+              --arg doc_verbose_name "${doc_verbose_name}" \
+              --arg documentation_url "${documentation_url}" \
+              --arg vllm_ascend_version "${vllm_ascend_version}" \
+              --arg os_variant "${os_variant}" \
+              --arg image "${image}" \
+              '.include += [{
+                doc_repository: $doc_repository,
+                doc_version: $doc_version,
+                doc_ref: $doc_ref,
+                doc_verbose_name: $doc_verbose_name,
+                documentation_url: $documentation_url,
+                vllm_ascend_version: $vllm_ascend_version,
+                os_variant: $os_variant,
+                image: $image
+              }]' "${matrix_file}" > "${next_matrix_file}"
+            mv "${next_matrix_file}" "${matrix_file}"
+          done
+
+          echo "Resolved PR-driven doctest matrix:"
+          jq . "${matrix_file}"
+
+          {
+            echo "matrix<<EOF"
+            jq -c . "${matrix_file}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Set matrix (doc-driven)
+        if: github.event_name != 'pull_request'
+        id: set_matrix_doc
         env:
           INPUT_DOC_VERSIONS: ${{ inputs.doc_versions || '["v0.18.0","latest"]' }}
         run: |
@@ -83,15 +149,35 @@ jobs:
           trap 'rm -rf "${matrix_file}" "${workdir}"' EXIT
           echo '{"include":[]}' > "${matrix_file}"
 
-          add_matrix_entries() {
-            local repo_dir="$1"
-            local doc_repository="$2"
-            local doc_version="$3"
-            local doc_ref="$4"
-            local doc_verbose_name="$5"
-            local documentation_url="$6"
-            local vllm_ascend_version
+          # Manual and scheduled runs are version-driven. Resolve each RTD
+          # version to the Git ref that owns the published documentation.
+          echo "${INPUT_DOC_VERSIONS}" | jq -e 'type == "array" and all(.[]; type == "string")' >/dev/null
 
+          while IFS= read -r doc_version; do
+            version_url="https://readthedocs.org/api/v3/projects/vllm-ascend/versions/${doc_version}/"
+            metadata_file="${workdir}/${doc_version}.json"
+            repo_dir="${workdir}/repo-${doc_version//[^A-Za-z0-9._-]/-}"
+
+            echo "Resolving Read the Docs version: ${doc_version}"
+            curl --fail --show-error --location \
+              --retry 3 \
+              --retry-delay 5 \
+              "${version_url}" \
+              -o "${metadata_file}"
+
+            doc_ref="$(jq -r '.identifier // empty' "${metadata_file}")"
+            doc_verbose_name="$(jq -r '.verbose_name // empty' "${metadata_file}")"
+            documentation_url="$(jq -r '.urls.documentation // empty' "${metadata_file}")"
+
+            if [ -z "${doc_ref}" ]; then
+              echo "Read the Docs version ${doc_version} does not have an identifier." >&2
+              exit 1
+            fi
+
+            git clone --depth 1 --branch "${doc_ref}" \
+              https://github.com/vllm-project/vllm-ascend.git "${repo_dir}"
+
+            doc_repository="vllm-project/vllm-ascend"
             vllm_ascend_version="$(python3 "${repo_dir}/docs/source/conf.py" \
               | jq -r '.vllm_ascend_version // empty')"
             if [ -z "${vllm_ascend_version}" ]; then
@@ -128,54 +214,9 @@ jobs:
                 }]' "${matrix_file}" > "${next_matrix_file}"
               mv "${next_matrix_file}" "${matrix_file}"
             done
-          }
+          done < <(echo "${INPUT_DOC_VERSIONS}" | jq -r '.[]')
 
-          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-            add_matrix_entries \
-              "${GITHUB_WORKSPACE}/matrix-src" \
-              "${GITHUB_REPOSITORY}" \
-              "pull_request" \
-              "${GITHUB_REF}" \
-              "${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}" \
-              ""
-          else
-            echo "${INPUT_DOC_VERSIONS}" | jq -e 'type == "array" and all(.[]; type == "string")' >/dev/null
-
-            while IFS= read -r doc_version; do
-              version_url="https://readthedocs.org/api/v3/projects/vllm-ascend/versions/${doc_version}/"
-              metadata_file="${workdir}/${doc_version}.json"
-              repo_dir="${workdir}/repo-${doc_version//[^A-Za-z0-9._-]/-}"
-
-              echo "Resolving Read the Docs version: ${doc_version}"
-              curl --fail --show-error --location \
-                --retry 3 \
-                --retry-delay 5 \
-                "${version_url}" \
-                -o "${metadata_file}"
-
-              doc_ref="$(jq -r '.identifier // empty' "${metadata_file}")"
-              doc_verbose_name="$(jq -r '.verbose_name // empty' "${metadata_file}")"
-              documentation_url="$(jq -r '.urls.documentation // empty' "${metadata_file}")"
-
-              if [ -z "${doc_ref}" ]; then
-                echo "Read the Docs version ${doc_version} does not have an identifier." >&2
-                exit 1
-              fi
-
-              git clone --depth 1 --branch "${doc_ref}" \
-                https://github.com/vllm-project/vllm-ascend.git "${repo_dir}"
-
-              add_matrix_entries \
-                "${repo_dir}" \
-                "vllm-project/vllm-ascend" \
-                "${doc_version}" \
-                "${doc_ref}" \
-                "${doc_verbose_name}" \
-                "${documentation_url}"
-            done < <(echo "${INPUT_DOC_VERSIONS}" | jq -r '.[]')
-          fi
-
-          echo "Resolved doctest matrix:"
+          echo "Resolved doc-driven doctest matrix:"
           jq . "${matrix_file}"
 
           {
@@ -195,6 +236,8 @@ jobs:
     container:
       image: ${{ matrix.image }}
     steps:
+      # setup-matrix decides whether this is a PR ref or an RTD identifier, so
+      # the test job can use the same checkout step for both trigger types.
       - name: Checkout doctest source
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -323,11 +323,6 @@ jobs:
         }}
       upload: false
 
-  doc-test:
-    name: doc-test
-    if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
-    uses: ./.github/workflows/labeled_doctest.yaml
-
   clear-pre-logs:
     needs: [parse-trigger, multi-node-tests]
     runs-on: linux-aarch64-a2b3-0

--- a/.github/workflows/schedule_weekly_test_a2.yaml
+++ b/.github/workflows/schedule_weekly_test_a2.yaml
@@ -34,3 +34,5 @@ jobs:
   doc-test:
     name: doc-test
     uses: ./.github/workflows/labeled_doctest.yaml
+    with:
+      doc_versions: '["v0.18.0","latest"]'

--- a/.github/workflows/schedule_weekly_test_a2.yaml
+++ b/.github/workflows/schedule_weekly_test_a2.yaml
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+name: Weekly-A2
+
+on:
+  schedule:
+      # Run doctest at 00:00 Beijing time (UTC+8) every Sunday
+      - cron: "0 16 * * 6"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ascend-weekly-${{ github.ref }}-a2
+  cancel-in-progress: true
+
+jobs:
+  doc-test:
+    name: doc-test
+    uses: ./.github/workflows/labeled_doctest.yaml

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,7 +77,7 @@ myst_substitutions = {
     # This value should be updated when cut down release.
     "pip_vllm_ascend_version": "0.20.2rc1",
     "pip_vllm_version": "0.20.2",
-    # CANN image tag
+    # CANN image tag paired with the vllm_ascend_version above
     "cann_image_tag": "9.0.0-910b-ubuntu22.04-py3.11",
     # vLLM commit hash for main branch
     "main_vllm_commit": "9090368b650896bf5fc990c921df7eb4c20355a5",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -78,7 +78,7 @@ myst_substitutions = {
     "pip_vllm_ascend_version": "0.20.2rc1",
     "pip_vllm_version": "0.20.2",
     # CANN image tag
-    "cann_image_tag": "9.0.0-910b-ubuntu22.04-py3.12",
+    "cann_image_tag": "9.0.0-910b-ubuntu22.04-py3.11",
     # vLLM commit hash for main branch
     "main_vllm_commit": "9090368b650896bf5fc990c921df7eb4c20355a5",
     # vLLM tag for main branch

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -157,6 +157,7 @@ pip install vllm==|pip_vllm_version|
 # Install vllm-project/vllm-ascend.
 pip install \
 --extra-index-url https://mirrors.huaweicloud.com/repository/pypi/simple  \
+--extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi  \
 vllm-ascend==|pip_vllm_ascend_version|
 
 ```
@@ -183,6 +184,7 @@ pip install vllm==|pip_vllm_version|
 # Install vllm-project/vllm-ascend from wheelnext index.
 uv pip install --system \
 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant   \
+--extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi   \
 vllm-ascend==|pip_vllm_ascend_version|
 
 ```

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -156,7 +156,7 @@ pip install vllm==|pip_vllm_version|
 
 # Install vllm-project/vllm-ascend.
 pip install \
---extra-index-url https://mirrors.huaweicloud.com/repository/pypi/simple https://mirrors.huaweicloud.com/ascend/repos/pypi  \
+--extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant https://mirrors.huaweicloud.com/ascend/repos/pypi  \
 vllm-ascend==|pip_vllm_ascend_version|
 
 ```

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -156,8 +156,7 @@ pip install vllm==|pip_vllm_version|
 
 # Install vllm-project/vllm-ascend.
 pip install \
---extra-index-url https://mirrors.huaweicloud.com/repository/pypi/simple  \
---extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi  \
+--extra-index-url https://mirrors.huaweicloud.com/repository/pypi/simple https://mirrors.huaweicloud.com/ascend/repos/pypi  \
 vllm-ascend==|pip_vllm_ascend_version|
 
 ```
@@ -183,8 +182,7 @@ pip install vllm==|pip_vllm_version|
 
 # Install vllm-project/vllm-ascend from wheelnext index.
 uv pip install --system \
---extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant   \
---extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi   \
+--extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant https://mirrors.huaweicloud.com/ascend/repos/pypi   \
 vllm-ascend==|pip_vllm_ascend_version|
 
 ```

--- a/tests/e2e/doctests/002-pip-binary-installation-test.sh
+++ b/tests/e2e/doctests/002-pip-binary-installation-test.sh
@@ -59,10 +59,13 @@ function install_binary_test() {
     _info "====> Install vllm==${PIP_VLLM_VERSION} and vllm-ascend ${PIP_VLLM_ASCEND_VERSION}"
 
     # Setup extra-index-url for public PyPI mirror, Ascend packages, and PyTorch CPU wheels.
-    local pip_extra_index_urls="https://mirrors.huaweicloud.com/repository/pypi/simple"
-    pip_extra_index_urls+=" https://mirrors.huaweicloud.com/ascend/repos/pypi"
-    pip_extra_index_urls+=" https://download.pytorch.org/whl/cpu/"
-    pip config set global.extra-index-url "${pip_extra_index_urls}"
+    local pip_extra_index_urls=(
+        "https://mirrors.huaweicloud.com/repository/pypi/simple"
+        "https://mirrors.huaweicloud.com/ascend/repos/pypi"
+        "https://download.pytorch.org/whl/cpu/"
+    )
+    local IFS=" "
+    pip config set global.extra-index-url "${pip_extra_index_urls[*]}"
 
     # The vLLM version already in pypi, we install from pypi.
     pip install --default-timeout=300 --retries 3 vllm=="${PIP_VLLM_VERSION}"

--- a/tests/e2e/doctests/002-pip-binary-installation-test.sh
+++ b/tests/e2e/doctests/002-pip-binary-installation-test.sh
@@ -60,7 +60,7 @@ function install_binary_test() {
 
     # Setup extra-index-url for public PyPI mirror, Ascend packages, and PyTorch CPU wheels.
     local pip_extra_index_urls=(
-        "https://mirrors.huaweicloud.com/repository/pypi/simple"
+        "https://mirrors.huaweicloud.com/repository/pypi/variant"
         "https://mirrors.huaweicloud.com/ascend/repos/pypi"
         "https://download.pytorch.org/whl/cpu/"
     )

--- a/tests/e2e/doctests/002-pip-binary-installation-test.sh
+++ b/tests/e2e/doctests/002-pip-binary-installation-test.sh
@@ -58,8 +58,11 @@ function install_binary_test() {
     PIP_VLLM_ASCEND_VERSION=$(get_version pip_vllm_ascend_version)
     _info "====> Install vllm==${PIP_VLLM_VERSION} and vllm-ascend ${PIP_VLLM_ASCEND_VERSION}"
 
-    # Setup extra-index-url for x86 & torch_npu dev version
-    pip config set global.extra-index-url "https://download.pytorch.org/whl/cpu/"
+    # Setup extra-index-url for public PyPI mirror, Ascend packages, and PyTorch CPU wheels.
+    local pip_extra_index_urls="https://mirrors.huaweicloud.com/repository/pypi/simple"
+    pip_extra_index_urls+=" https://mirrors.huaweicloud.com/ascend/repos/pypi"
+    pip_extra_index_urls+=" https://download.pytorch.org/whl/cpu/"
+    pip config set global.extra-index-url "${pip_extra_index_urls}"
 
     # The vLLM version already in pypi, we install from pypi.
     pip install --default-timeout=300 --retries 3 vllm=="${PIP_VLLM_VERSION}"


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the doctest workflow to make the tested document source explicit for different trigger types.

After this change, the workflow has two matrix generation modes:

- **PR-driven**: pull request runs test the current PR checkout.
- **doc-driven**: manual / scheduled / workflow_call runs test specified RTD documentation versions.

Each resolved document source produces two test jobs:

- `quay.io/ascend/vllm-ascend:<vllm_ascend_version>`
- `quay.io/ascend/vllm-ascend:<vllm_ascend_version>-openeuler`

The `vllm_ascend_version` is always read from the selected document repository’s `docs/source/conf.py`.

#### Current doctest flow

```mermaid
flowchart TD
    A[Workflow trigger] --> B{Trigger type}

    B -->|pull_request| C[Checkout current PR source]
    C --> D[Read docs/source/conf.py]
    D --> E[Generate PR-driven matrix]

    B -->|workflow_dispatch / workflow_call / weekly| F[Read doc_versions input]
    F --> G[Query RTD version API]
    G --> H[Resolve RTD identifier, e.g. releases/v0.18.0 or main]
    H --> I[Clone resolved doc repository/ref]
    I --> J[Read docs/source/conf.py]
    J --> K[Generate doc-driven matrix]

    E --> L[Ubuntu image job]
    E --> M[openEuler image job]
    K --> L
    K --> M

    L --> N[Checkout matrix.doc_repository + matrix.doc_ref to doctest-src]
    M --> N
    N --> O[Run doctest-src/tests/e2e/run_doctests.sh]
```

#### Matrix fields

Each matrix entry contains:

```text
doc_repository
doc_version
doc_ref
doc_verbose_name
documentation_url
vllm_ascend_version
os_variant
image
```

These fields are printed in the test job to make doc/ref/image mismatches easier to debug.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

https://github.com/vllm-project/vllm-ascend/actions/runs/27128592720/job/80063641811?pr=10070


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
