### PR TITLE
[CI] add git clone try support to pr e2e test

### DIFF
--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -73,6 +73,14 @@ jobs:
           echo "✓ PR title prefix is valid"
 
       - name: Checkout vllm-project/vllm-ascend repo
+        id: checkout_ascend_1
+        uses: actions/checkout@v6
+        continue-on-error: true
+        with:
+          fetch-depth: 0
+
+      - name: Checkout vllm-project/vllm-ascend repo (Retry when failure)
+        if: steps.checkout_ascend_1.outcome == 'failure'
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -88,8 +96,20 @@ jobs:
       - run: echo "::add-matcher::$RUNNER_TEMP/mypy.json"
 
       - name: Checkout vllm-project/vllm repo
+        id: checkout_vllm_1
+        uses: actions/checkout@v6
+        continue-on-error: true
+        with:
+          fetch-depth: 0
+          repository: vllm-project/vllm
+          path: ./vllm-empty
+          ref: 9090368b650896bf5fc990c921df7eb4c20355a5
+
+      - name: Checkout vllm-project/vllm repo (Retry when failure)
+        if: steps.checkout_vllm_1.outcome == 'failure'
         uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           repository: vllm-project/vllm
           path: ./vllm-empty
           ref: 9090368b650896bf5fc990c921df7eb4c20355a5


### PR DESCRIPTION
### What this PR does / why we need it?
Add git clone try support to pr e2e test.

Fix the bug network unstable lead code clone failed.
<img width="1869" height="553" alt="7b8ae023-4fe8-41a0-abe4-2e2d5c82b5e7" src="https://github.com/user-attachments/assets/bca0d576-f5e0-4776-8143-ad77ac100ff8" />

https://github.com/vllm-project/vllm-ascend/actions/runs/26873282806/job/79254495068?pr=9933

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
NA


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
