### PR TITLE
[BugFix][UT] Fix platform eager mode log assertion

### DIFF
--- a/.github/workflows/scripts/run_selected_tests.sh
+++ b/.github/workflows/scripts/run_selected_tests.sh
@@ -80,9 +80,35 @@ run_pytest_target() {
   fi
 }
 
+run_pytest_batch() {
+  local target="$1"
+  shift
+  local batch_targets=("$@")
+  test_index=$((test_index + 1))
+  local log_file="${pytest_log_dir}/${test_index}-cpu-ut.log"
+
+  echo "::group::${target}"
+  echo -e "\033[1;34m=== Running target: ${target} ===\033[0m"
+  set +e
+  pytest -sv --color=yes "${batch_targets[@]}" 2>&1 | tee "${log_file}"
+  local status=${PIPESTATUS[0]}
+  set -e
+  echo "::endgroup::"
+  if [ "${status}" -eq 0 ]; then
+    test_results+=("${target}|PASSED|${log_file}")
+  else
+    test_results+=("${target}|FAILED|${log_file}")
+    failed_logs+=("${target}|${log_file}")
+    print_summary
+    exit "${status}"
+  fi
+}
+
 print_test_info
 
-if [ "${mode}" = "with-device" ]; then
+if [ "${npu_type}" = "cpu" ]; then
+  run_pytest_batch "cpu-ut (${#targets[@]} targets)" "${targets[@]}"
+elif [ "${mode}" = "with-device" ]; then
   aclgraph_capture_replay="tests/e2e/pull_request/two_card/aclgraph/test_aclgraph_capture_replay.py"
   run_aclgraph_capture_replay=0
   for target in "${targets[@]}"; do

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -32,7 +32,7 @@ class TestNPUPlatform(TestBase):
         mock_vllm_config.speculative_config = None
         mock_vllm_config.additional_config = {}
         mock_vllm_config.compilation_config.pass_config.enable_sp = False
-        mock_vllm_config.compilation_config.cudagraph_mode = None
+        mock_vllm_config.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
         return mock_vllm_config
 
     @staticmethod

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -24,6 +24,7 @@ class TestNPUPlatform(TestBase):
         mock_vllm_config.compilation_config = MagicMock()
         mock_vllm_config.model_config = MagicMock()
         mock_vllm_config.model_config.is_hybrid = False
+        mock_vllm_config.model_config.is_encoder_decoder = False
         mock_vllm_config.parallel_config = MagicMock()
         mock_vllm_config.cache_config = MagicMock()
         mock_vllm_config.scheduler_config = MagicMock()
@@ -372,7 +373,7 @@ class TestNPUPlatform(TestBase):
             with patch.object(platform.NPUPlatform, "_fix_incompatible_config"):
                 self.platform.check_and_update_config(vllm_config)
 
-        self.assertTrue("Compilation disabled, using eager mode by default" in cm.output[0])
+        self.assertTrue(any("Compilation disabled, using eager mode by default" in output for output in cm.output))
 
         self.assertEqual(
             vllm_config.compilation_config.mode,


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes a CPU UT failure in `tests/ut/test_platform.py::TestNPUPlatform::test_check_and_update_config_enforce_eager_mode`.

When CPU UTs are run in one pytest process, `vllm_ascend.platform` module reload can emit extra INFO logs before the eager-mode log being asserted. The test previously checked only `cm.output[0]`, making it sensitive to log order.

This PR:
- Sets `mock_vllm_config.model_config.is_encoder_decoder = False` to avoid MagicMock incorrectly entering the encoder-decoder fallback branch.
- Updates the eager-mode log assertion to check all captured logs instead of only the first entry.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
