### PR TITLE
[BugFix] Fix the out-of-bounds index in `token_indices_to_sample`

### DIFF
--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -209,6 +209,8 @@ class AscendDflashProposer(AscendEagleProposer):
                 per_layer_attn_metadata[layer_name] = attn_metadata_dflash
             multi_steps_attn_metadata.append(per_layer_attn_metadata)
 
+        self.token_indices_to_sample.fill_(0)
+
         with set_ascend_forward_context(
             multi_steps_attn_metadata[0] if multi_steps_attn_metadata else None,
             self.vllm_config,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -542,6 +542,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         else:
             inputs_embeds = None
 
+        self.token_indices_to_sample.fill_(0)
+
         with set_ascend_forward_context(
             multi_steps_attn_metadata[0] if multi_steps_attn_metadata else None,
             self.vllm_config,


### PR DESCRIPTION
### What this PR does / why we need it?
This PR aims to fix the out-of-bounds index in draft model proposer. Similar to #9867, `token_indices_to_sample` also introduces dirty value in `dummy_run`, so we have to clean it to 0.

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
by ci

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
