### PR TITLE
[CI] Only used to refresh new csrc cache

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def check_or_set_default_env(cmake_args, env_name, env_variable, default_path=""
         env_variable = default_path
     else:
         logging.info("Found existing %s: %s", env_name, env_variable)
-    # cann package seems will check this environments in cmake, need write this env variable back.
+    # cann package seems will check this environments in cmake, so need write this env variable back.
     if env_name == "ASCEND_HOME_PATH":
         os.environ["ASCEND_HOME_PATH"] = env_variable
     cmake_args += [f"-D{env_name}={env_variable}"]


### PR DESCRIPTION
### What this PR does / why we need it?
Only to change the operator cache file, to trigger new build and then refresh the cache

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
NA

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
