### PR TITLE
[CI][v0.20.2]: support v0.20.2rc1 dispatch and 310p manylinux_2_34 baseimage

### DIFF
--- a/.github/workflows/dockerfiles/Dockerfile.buildwheel.310p
+++ b/.github/workflows/dockerfiles/Dockerfile.buildwheel.310p
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 ARG PY_VERSION=3.11
-FROM quay.io/ascend/manylinux:9.1.0-beta.1-310p-manylinux_2_28-py${PY_VERSION}
+FROM quay.io/ascend/manylinux:9.1.0-beta.1-310p-manylinux_2_34-py${PY_VERSION}
 
 ARG SOC_VERSION="ascend310p1"
 

--- a/.github/workflows/schedule_release_code_and_wheel.yml
+++ b/.github/workflows/schedule_release_code_and_wheel.yml
@@ -33,6 +33,7 @@ on:
         type: choice
         options:
           - main
+          - v0.20.2rc1
           - v0.19.1rc1
           - v0.18.0
           - v0.18.0rc1
@@ -277,6 +278,17 @@ jobs:
         with:
           tool-cache: true
           docker-images: false
+
+      - name: Patch 310p Dockerfile base image to manylinux_2_34
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          FILE=.github/workflows/dockerfiles/Dockerfile.buildwheel.310p
+          if ! grep -q 'quay.io/ascend/manylinux:9\.1\.0-beta\.1-310p-manylinux_2_28' "$FILE"; then
+            echo "ERROR: Expected base image pattern not found in $FILE"
+            exit 1
+          fi
+          sed -i 's|9\.1\.0-beta\.1-310p-manylinux_2_28|9.1.0-beta.1-310p-manylinux_2_34|' "$FILE"
+          grep '^FROM' "$FILE"
 
       - name: Build wheel
         run: |


### PR DESCRIPTION



<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?

Fix [the error](https://github.com/vllm-project/vllm-ascend/actions/runs/26894814044/job/79477689281) verification baseimage not updated after https://github.com/vllm-project/vllm-ascend/pull/9710/changes#diff-e648e6ecc4ed55f550fc621019e61d85e00c2ab5c3f647733512ee48ba901f29L18 



- Add v0.20.2rc1 to workflow_dispatch tag choice list so wheel and variant can be re-published via UI on the release branch
- Insert a workflow_dispatch-only sed step in the 310p build job to bump Dockerfile.buildwheel.310p base image from 9.1.0-beta.1-310p-manylinux_2_28 to manylinux_2_34, addressing the 310p base image requirement for the v0.20.2rc1 release


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
