### PR TITLE
[BugFix] Solve the lmhead parallel feature assert lack and nightly bug

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/Qwen3-30B-QuaRot-eagle3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3-30B-QuaRot-eagle3.yaml
@@ -10,7 +10,6 @@ test_cases:
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
       - "--enforce-eager"
-      - "True"
       - "--no-enable-prefix-caching"
       - "--enable-expert-parallel"
       - "--tensor-parallel-size"

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3-32B-QuaRot-eagle3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3-32B-QuaRot-eagle3.yaml
@@ -10,7 +10,6 @@ test_cases:
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
       - "--enforce-eager"
-      - "True"
       - "--no-enable-prefix-caching"
       - "--tensor-parallel-size"
       - "2"

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -462,8 +462,10 @@ class FinegrainedTPConfig:
             self.olora_tensor_parallel_size,
         ]
         for module_tp_size in module_tp_sizes:
+            if not vllm_config.model_config.is_moe:
+                raise AssertionError("The lmhead parallel feature can be enabled only for MOE models.")
             if module_tp_size > 0 and vllm_config.parallel_config.data_parallel_size % module_tp_size != 0:
-                raise AssertionError("module tp sizes must divide data_parallel_size")
+                raise AssertionError("lmhead_tensor_parallel_size must divide by data_parallel_size.")
         if any(size > 0 for size in module_tp_sizes) and enabled_configs:
             logger.info("finegrained_tp_config enabled: %s", ", ".join(enabled_configs))
 

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -464,7 +464,7 @@ class FinegrainedTPConfig:
         for module_tp_size in module_tp_sizes:
             # If it is a dense model, then expert parallel is not needed,
             # and data parallel is also not needed. If the data parallel size is set
-            # to greater than 1 in the model launch configuration, its value will be changed to 1 later. 
+            # to greater than 1 in the model launch configuration, its value will be changed to 1 later.
             # This will cause an issue when lmhead parallel is enabled, as the lmhead
             # cannot be split into the data parallel communication group, leading to an error.
             if module_tp_size > 0 and not vllm_config.model_config.is_moe:

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -462,7 +462,12 @@ class FinegrainedTPConfig:
             self.olora_tensor_parallel_size,
         ]
         for module_tp_size in module_tp_sizes:
-            if not vllm_config.model_config.is_moe:
+            # If it is a dense model, then expert parallel is not needed,
+            # and data parallel is also not needed. If the data parallel size is set
+            # to greater than 1 in the model launch configuration, its value will be changed to 1 later. 
+            # This will cause an issue when lmhead parallel is enabled, as the lmhead
+            # cannot be split into the data parallel communication group, leading to an error.
+            if module_tp_size > 0 and not vllm_config.model_config.is_moe:
                 raise AssertionError("The lmhead parallel feature can be enabled only for MOE models.")
             if module_tp_size > 0 and vllm_config.parallel_config.data_parallel_size % module_tp_size != 0:
                 raise AssertionError("lmhead_tensor_parallel_size must divide by data_parallel_size.")


### PR DESCRIPTION
### What this PR does / why we need it?
The verification that the lmhead parallel feature is not supported by the dense model is added, and the incorrect writing of the nightly test case is modified.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ut and tests

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
