### PR TITLE
[CI] Fix triton-ascend install failure in csrc cache build

### DIFF
--- a/.github/workflows/push_build_csrc_cache.yaml
+++ b/.github/workflows/push_build_csrc_cache.yaml
@@ -25,6 +25,7 @@ on:
       - 'setup.py'
       - 'CMakeLists.txt'
       - 'cmake/**'
+      - .github/workflows/push_build_csrc_cache.yaml
   workflow_dispatch:
 
 defaults:
@@ -37,7 +38,7 @@ concurrency:
 
 env:
   UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-  UV_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi"
+  UV_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi https://download.pytorch.org/whl/cpu"
   UV_INDEX_STRATEGY: unsafe-best-match
   UV_INSECURE_HOST: cache-service.nginx-pypi-cache.svc.cluster.local
   UV_HTTP_TIMEOUT: 120
@@ -179,6 +180,9 @@ jobs:
           fi
 
           pip install uc-manager
-          uv pip install -r requirements-dev.txt --extra-index-url https://download.pytorch.org/whl/cpu
+          # NOTE: indexes (ascend repo for triton-ascend + pytorch cpu whl) come from
+          # UV_EXTRA_INDEX_URL. Do not pass --extra-index-url on the CLI here: it overrides
+          # (does not append to) the env var and would drop the ascend repo.
+          uv pip install -r requirements-dev.txt
           uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
-          uv pip install -e . --extra-index-url https://download.pytorch.org/whl/cpu
+          uv pip install -e .

--- a/.github/workflows/push_build_csrc_cache.yaml
+++ b/.github/workflows/push_build_csrc_cache.yaml
@@ -38,7 +38,7 @@ concurrency:
 
 env:
   UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-  UV_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi https://download.pytorch.org/whl/cpu"
+  UV_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
   UV_INDEX_STRATEGY: unsafe-best-match
   UV_INSECURE_HOST: cache-service.nginx-pypi-cache.svc.cluster.local
   UV_HTTP_TIMEOUT: 120


### PR DESCRIPTION
### What this PR does / why we need it?
The `Cache csrc Build Artifacts` workflow was failing at the `Install vllm-ascend`
step with:
``` bash
× No solution found when resolving dependencies:
╰─▶ Because there is no version of triton-ascend==3.2.1 and you require
triton-ascend==3.2.1, we can conclude that your requirements are unsatisfiable.
```

Failing run: https://github.com/vllm-project/vllm-ascend/actions/runs/26924100423

**Root cause:** `triton-ascend==3.2.1` is hosted on the Ascend repo
(`https://repo.huaweicloud.com/ascend/repos/pypi`), which was provided via
`UV_EXTRA_INDEX_URL`. However, the install step passed
`--extra-index-url https://download.pytorch.org/whl/cpu` on the command line, and
uv's CLI `--extra-index-url` **overrides** (rather than appends to) the
`UV_EXTRA_INDEX_URL` env var. This dropped the Ascend repo during resolution, so
`triton-ascend==3.2.1` could no longer be found. (Since #9304 removed the
`--extra-index-url https://triton-ascend.osinfra.cn/pypi/simple` line from
`requirements.txt`, the env var became the only source for that index.)

**Fix:** Make `UV_EXTRA_INDEX_URL` the single source of truth for extra indexes —
add the pytorch cpu whl index to it and drop the CLI `--extra-index-url` flags from
the `uv pip install` commands. This mirrors the working setup in
`_selected_tests.yaml`. A comment is added to prevent the flags from being
reintroduced. Also added this workflow file to the `push` path filter so changes to
it are exercised.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
