### PR TITLE
[BugFix][Refactor] Reduce Mooncake KV cache register regions for sparse C8

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -57,13 +57,13 @@ from vllm.v1.request import RequestStatus
 from vllm_ascend import envs as ascend_envs
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
-from vllm_ascend.distributed.kv_transfer.utils.utils import get_transfer_timeout_value
-from vllm_ascend.utils import enable_custom_op
 from vllm_ascend.distributed.kv_transfer.utils.utils import (
     RegisterRegions,
     collect_storage_merged_register_regions,
-    warn_if_register_regions_exceed_limit,
+    get_transfer_timeout_value,
+    validate_register_region_count,
 )
+from vllm_ascend.utils import enable_custom_op
 
 # isort: off
 if TYPE_CHECKING:
@@ -1768,7 +1768,7 @@ class MooncakeConnectorWorker:
             # storage to avoid exceeding the HCCL per-process region limit.
             register_regions = collect_storage_merged_register_regions(kv_caches)
 
-        warn_if_register_regions_exceed_limit(register_regions)
+        validate_register_region_count(register_regions)
         global_te.register_buffer(register_regions.ptrs, register_regions.lengths)
 
         logger.debug(

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -59,6 +59,11 @@ from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
 from vllm_ascend.distributed.kv_transfer.utils.utils import get_transfer_timeout_value
 from vllm_ascend.utils import enable_custom_op
+from vllm_ascend.distributed.kv_transfer.utils.utils import (
+    RegisterRegions,
+    collect_storage_merged_register_regions,
+    warn_if_register_regions_exceed_limit,
+)
 
 # isort: off
 if TYPE_CHECKING:
@@ -1756,10 +1761,16 @@ class MooncakeConnectorWorker:
 
         if has_mamba_group:
             ptrs, lengths = self._get_registered_kv_tensor_buffers(kv_caches)
+            register_regions = RegisterRegions(ptrs=ptrs, lengths=lengths)
         else:
-            ptrs, lengths = self._get_registered_layer_buffers(kv_caches)
+            # For normal attention / sparse-c8 KV cache, keep metadata at the
+            # logical tensor level but merge registration ranges by underlying
+            # storage to avoid exceeding the HCCL per-process region limit.
+            register_regions = collect_storage_merged_register_regions(kv_caches)
 
-        global_te.register_buffer(ptrs, lengths)
+        warn_if_register_regions_exceed_limit(register_regions)
+        global_te.register_buffer(register_regions.ptrs, register_regions.lengths)
+
         logger.debug(
             "Mooncake register kv caches metadata: kv_group2layeridx=%s, kv_caches_base_addr=%s, "
             "block_len_per_addr=%s, block_size_scale=%s, ptrs=%s, lengths=%s",
@@ -1767,8 +1778,8 @@ class MooncakeConnectorWorker:
             self.kv_caches_base_addr,
             self.block_len_per_addr,
             self.block_size_scale,
-            ptrs,
-            lengths,
+            register_regions.ptrs,
+            register_regions.lengths,
         )
         # After KV Caches registered, start the sending or receiving thread.
         metadata = MooncakeAgentMetadata(

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -58,7 +58,9 @@ from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector import GET_META_MSG
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
 from vllm_ascend.distributed.kv_transfer.utils.utils import (
+    RegisterRegions,
     align_memory,
+    collect_storage_merged_register_regions,
     context_parallel_parameters_check,
     get_cp_group,
     get_local_remote_block_port_mappings,
@@ -66,11 +68,7 @@ from vllm_ascend.distributed.kv_transfer.utils.utils import (
     get_transfer_timeout_value,
     kv_alltoall_and_rearrange,
     parallel_info,
-)
-from vllm_ascend.distributed.kv_transfer.utils.utils import (
-    RegisterRegions,
-    collect_storage_merged_register_regions,
-    warn_if_register_regions_exceed_limit,
+    validate_register_region_count,
 )
 from vllm_ascend.utils import npu_stream_switch, trans_nd_to_nz
 
@@ -1248,7 +1246,7 @@ class MooncakeLayerwiseConnectorWorker:
             # ranges while keeping layer metadata at logical tensor addresses.
             register_regions = collect_storage_merged_register_regions(kv_caches)
 
-        warn_if_register_regions_exceed_limit(register_regions)
+        validate_register_region_count(register_regions)
         global_te.register_buffer(register_regions.ptrs, register_regions.lengths)
 
         if use_kv_buffer:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -67,6 +67,11 @@ from vllm_ascend.distributed.kv_transfer.utils.utils import (
     kv_alltoall_and_rearrange,
     parallel_info,
 )
+from vllm_ascend.distributed.kv_transfer.utils.utils import (
+    RegisterRegions,
+    collect_storage_merged_register_regions,
+    warn_if_register_regions_exceed_limit,
+)
 from vllm_ascend.utils import npu_stream_switch, trans_nd_to_nz
 
 # isort: off
@@ -1236,7 +1241,16 @@ class MooncakeLayerwiseConnectorWorker:
                 ptrs.append(min(set(tensor_addrs)))
                 lengths.append(kv_cache_tensor.size)
 
-        global_te.register_buffer(ptrs, lengths)
+        if self.use_attn_mamba_hybrid:
+            register_regions = RegisterRegions(ptrs=ptrs, lengths=lengths)
+        else:
+            # For normal attention / sparse-c8 KV cache, register merged memory
+            # ranges while keeping layer metadata at logical tensor addresses.
+            register_regions = collect_storage_merged_register_regions(kv_caches)
+
+        warn_if_register_regions_exceed_limit(register_regions)
+        global_te.register_buffer(register_regions.ptrs, register_regions.lengths)
+
         if use_kv_buffer:
             self.create_kv_buffer(kv_buffer)
 

--- a/vllm_ascend/distributed/kv_transfer/utils/utils.py
+++ b/vllm_ascend/distributed/kv_transfer/utils/utils.py
@@ -1,7 +1,6 @@
 import math
 import os
-from collections import OrderedDict
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
@@ -14,6 +13,7 @@ from vllm_ascend.distributed.parallel_state import get_p_tp_group
 
 MAX_HCCL_REGISTER_REGIONS = 256
 REGISTER_MERGE_GAP_BYTES = 4096
+
 
 def kv_alltoall_and_rearrange(pd_tp_ratio: int, key: torch.Tensor, value: torch.TensorType):
     if pd_tp_ratio <= 1:
@@ -316,6 +316,12 @@ class RegisterRange:
 class RegisterRegions:
     ptrs: list[int]
     lengths: list[int]
+    logical_tensor_count: int | None = None
+    logical_total_bytes: int | None = None
+
+    @property
+    def registered_bytes(self) -> int:
+        return sum(self.lengths)
 
 
 def iter_kv_cache_tensors(obj: Any) -> Iterator[torch.Tensor]:
@@ -336,10 +342,6 @@ def iter_kv_cache_tensors(obj: Any) -> Iterator[torch.Tensor]:
         for item in obj.values():
             yield from iter_kv_cache_tensors(item)
         return
-
-
-def tensor_nbytes(tensor: torch.Tensor) -> int:
-    return tensor.numel() * tensor.element_size()
 
 
 def tensor_storage_key(tensor: torch.Tensor) -> int:
@@ -367,6 +369,8 @@ def collect_storage_merged_register_regions(
     register_buffer should use the merged memory ranges returned here.
     """
     ranges_by_storage: OrderedDict[int, list[RegisterRange]] = OrderedDict()
+    logical_tensor_count = 0
+    logical_total_bytes = 0
 
     for tensor in iter_kv_cache_tensors(kv_caches):
         if tensor is None or tensor.numel() == 0:
@@ -382,13 +386,15 @@ def collect_storage_merged_register_regions(
                 hex(tensor.data_ptr()),
             )
 
+        nbytes = tensor.nbytes
         start = tensor.data_ptr()
-        end = start + tensor_nbytes(tensor)
+        end = start + nbytes
         storage_key = tensor_storage_key(tensor)
 
-        ranges_by_storage.setdefault(storage_key, []).append(
-            RegisterRange(start, end)
-        )
+        logical_tensor_count += 1
+        logical_total_bytes += nbytes
+
+        ranges_by_storage.setdefault(storage_key, []).append(RegisterRange(start, end))
 
     register_ptrs: list[int] = []
     register_lengths: list[int] = []
@@ -411,17 +417,29 @@ def collect_storage_merged_register_regions(
         register_ptrs.append(merged_start)
         register_lengths.append(merged_end - merged_start)
 
-    return RegisterRegions(ptrs=register_ptrs, lengths=register_lengths)
+    return RegisterRegions(
+        ptrs=register_ptrs,
+        lengths=register_lengths,
+        logical_tensor_count=logical_tensor_count,
+        logical_total_bytes=logical_total_bytes,
+    )
 
 
-def warn_if_register_regions_exceed_limit(regions: RegisterRegions) -> None:
-    if len(regions.ptrs) <= MAX_HCCL_REGISTER_REGIONS:
+def validate_register_region_count(regions: RegisterRegions) -> None:
+    region_count = len(regions.ptrs)
+    if region_count <= MAX_HCCL_REGISTER_REGIONS:
         return
 
-    logger.warning(
-        "Mooncake register_buffer merged region count %d exceeds "
-        "HCCL per-process limit %d. This may still fail. "
-        "Consider merging k/v/dsa/scale allocation further.",
-        len(regions.ptrs),
-        MAX_HCCL_REGISTER_REGIONS,
+    detail = f"registered_bytes={regions.registered_bytes}"
+    if regions.logical_tensor_count is not None:
+        detail += f", logical_tensors={regions.logical_tensor_count}, logical_bytes={regions.logical_total_bytes}"
+
+    raise RuntimeError(
+        "Mooncake register_buffer region count "
+        f"{region_count} exceeds HCCL per-process limit "
+        f"{MAX_HCCL_REGISTER_REGIONS}. "
+        "KV cache registration would fail. "
+        f"{detail}. "
+        "Please reduce KV cache allocation fragmentation or merge "
+        "k/v/dsa/scale allocations further."
     )

--- a/vllm_ascend/distributed/kv_transfer/utils/utils.py
+++ b/vllm_ascend/distributed/kv_transfer/utils/utils.py
@@ -1,6 +1,8 @@
 import math
 import os
+from collections import OrderedDict
 from collections import defaultdict
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
 
@@ -10,6 +12,8 @@ from vllm.logger import logger
 
 from vllm_ascend.distributed.parallel_state import get_p_tp_group
 
+MAX_HCCL_REGISTER_REGIONS = 256
+REGISTER_MERGE_GAP_BYTES = 4096
 
 def kv_alltoall_and_rearrange(pd_tp_ratio: int, key: torch.Tensor, value: torch.TensorType):
     if pd_tp_ratio <= 1:
@@ -300,3 +304,124 @@ def get_transfer_mappings(
         block_dict["trans_count"] = d_trans_count_mapping[(host, port)]
     logger.debug("MooncakeLayerwiseConnector Request %s transfer tasks: %s", req_id, transfer_mappings)
     return transfer_mappings
+
+
+@dataclass
+class RegisterRange:
+    start: int
+    end: int
+
+
+@dataclass
+class RegisterRegions:
+    ptrs: list[int]
+    lengths: list[int]
+
+
+def iter_kv_cache_tensors(obj: Any) -> Iterator[torch.Tensor]:
+    """Flatten kv_caches into tensors without materializing new tensors."""
+    if obj is None:
+        return
+
+    if isinstance(obj, torch.Tensor):
+        yield obj
+        return
+
+    if isinstance(obj, (tuple, list)):
+        for item in obj:
+            yield from iter_kv_cache_tensors(item)
+        return
+
+    if isinstance(obj, dict):
+        for item in obj.values():
+            yield from iter_kv_cache_tensors(item)
+        return
+
+
+def tensor_nbytes(tensor: torch.Tensor) -> int:
+    return tensor.numel() * tensor.element_size()
+
+
+def tensor_storage_key(tensor: torch.Tensor) -> int:
+    """Return a stable grouping key for tensors sharing the same storage.
+
+    Do NOT use this key as the register address directly. For aligned KV cache
+    views, tensor.untyped_storage().data_ptr() may point to the original raw
+    allocation, whose address can be unaligned. We only use it to group views.
+    """
+    try:
+        return tensor.untyped_storage().data_ptr()
+    except Exception:
+        try:
+            return tensor.storage().data_ptr()
+        except Exception:
+            return tensor.data_ptr()
+
+
+def collect_storage_merged_register_regions(
+    kv_caches: dict[str, Any],
+) -> RegisterRegions:
+    """Collect HCCL/Mooncake register regions with storage-aware merging.
+
+    Metadata should still use each logical tensor's own data_ptr().
+    register_buffer should use the merged memory ranges returned here.
+    """
+    ranges_by_storage: OrderedDict[int, list[RegisterRange]] = OrderedDict()
+
+    for tensor in iter_kv_cache_tensors(kv_caches):
+        if tensor is None or tensor.numel() == 0:
+            continue
+
+        if not tensor.is_contiguous():
+            logger.warning(
+                "Mooncake register_buffer got a non-contiguous KV cache "
+                "tensor: shape=%s, dtype=%s, data_ptr=%s. "
+                "Registration will use logical numel * element_size.",
+                tuple(tensor.shape),
+                tensor.dtype,
+                hex(tensor.data_ptr()),
+            )
+
+        start = tensor.data_ptr()
+        end = start + tensor_nbytes(tensor)
+        storage_key = tensor_storage_key(tensor)
+
+        ranges_by_storage.setdefault(storage_key, []).append(
+            RegisterRange(start, end)
+        )
+
+    register_ptrs: list[int] = []
+    register_lengths: list[int] = []
+
+    for ranges in ranges_by_storage.values():
+        ranges.sort(key=lambda r: r.start)
+
+        merged_start = ranges[0].start
+        merged_end = ranges[0].end
+
+        for region in ranges[1:]:
+            if region.start <= merged_end + REGISTER_MERGE_GAP_BYTES:
+                merged_end = max(merged_end, region.end)
+            else:
+                register_ptrs.append(merged_start)
+                register_lengths.append(merged_end - merged_start)
+                merged_start = region.start
+                merged_end = region.end
+
+        register_ptrs.append(merged_start)
+        register_lengths.append(merged_end - merged_start)
+
+    return RegisterRegions(ptrs=register_ptrs, lengths=register_lengths)
+
+
+def warn_if_register_regions_exceed_limit(regions: RegisterRegions) -> None:
+    if len(regions.ptrs) <= MAX_HCCL_REGISTER_REGIONS:
+        return
+
+    logger.warning(
+        "Mooncake register_buffer merged region count %d exceeds "
+        "HCCL per-process limit %d. This may still fail. "
+        "Consider merging k/v/dsa/scale allocation further.",
+        len(regions.ptrs),
+        MAX_HCCL_REGISTER_REGIONS,
+    )

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3844,17 +3844,18 @@ class NPUModelRunner(GPUModelRunner):
                     # Allocate raw int8 tensors. Even bf16/fp16 KV cache entries
                     # are allocated as int8 raw bytes first and then viewed as
                     # the target dtype in _reshape_kv_cache_tensors.
+                    dsa_k_tensor = None
+                    dsa_k_scale_tensor = None
+                    v_tensor = None
                     k_tensor = self._allocate_int8_cache_tensor(
                         k_tensor_size,
                         alignment,
                     )
-                    v_tensor = self._allocate_int8_cache_tensor(
-                        v_tensor_size,
-                        alignment,
-                    )
-
-                    dsa_k_tensor = None
-                    dsa_k_scale_tensor = None
+                    if v_tensor_size is not None:
+                        v_tensor = self._allocate_int8_cache_tensor(
+                            v_tensor_size,
+                            alignment,
+                        )
 
                     if self.use_sparse:
                         assert dsa_k_tensor_size is not None

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3641,6 +3641,88 @@ class NPUModelRunner(GPUModelRunner):
         head_size_v = kv_cache_spec.head_size_v if hasattr(kv_cache_spec, "head_size_v") else kv_cache_spec.head_size
         return kv_cache_spec.head_size, head_size_v
 
+    @staticmethod
+    def _align_up(value: int, alignment: int) -> int:
+        return (value + alignment - 1) // alignment * alignment
+
+    def _allocate_int8_cache_tensor(
+        self,
+        numel: int,
+        alignment: int,
+    ) -> torch.Tensor:
+        """Allocate an int8 raw cache tensor.
+
+        When KV transfer is enabled, the returned tensor's data_ptr is aligned
+        to `alignment`. This keeps the original Mooncake/ADXL alignment behavior.
+        """
+        if numel <= 0:
+            raise ValueError(f"Invalid cache tensor size: {numel}")
+
+        if self.vllm_config.kv_transfer_config is None:
+            return torch.zeros(numel, dtype=torch.int8, device=self.device)
+
+        raw_tensor = torch.zeros(
+            numel + alignment,
+            dtype=torch.int8,
+            device=self.device,
+        )
+        return self._align_memory(raw_tensor, alignment)[:numel]
+
+    def _allocate_sparse_c8_indexer_tensors(
+        self,
+        dsa_k_tensor_size: int,
+        dsa_k_scale_tensor_size: int,
+        alignment: int,
+        scale_dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Allocate dsa_k and dsa_k_scale from one aligned int8 raw allocation.
+
+        Both returned tensors are logical views into the same underlying storage:
+
+            sparse_c8_raw
+              ├── dsa_k_tensor        int8 raw bytes
+              └── dsa_k_scale_tensor  scale dtype raw bytes stored as int8 view
+
+        `dsa_k_scale_tensor` is still returned as int8 raw storage. Later reshape
+        code should continue to use:
+
+            raw_dsa_k_scale_tensor.view(scale_dtype).view(scale_shape)
+
+        This reduces HCCL/Mooncake registration count because register_buffer
+        can merge these two views into one registered memory range.
+        """
+        if dsa_k_tensor_size <= 0:
+            raise ValueError(
+                f"Invalid dsa_k_tensor_size: {dsa_k_tensor_size}"
+            )
+        if dsa_k_scale_tensor_size <= 0:
+            raise ValueError(
+                f"Invalid dsa_k_scale_tensor_size: {dsa_k_scale_tensor_size}"
+            )
+
+        scale_dtype_size = torch.empty((), dtype=scale_dtype).element_size()
+
+        # Ensure the scale view starts at an address aligned for scale_dtype.
+        scale_offset = self._align_up(dsa_k_tensor_size, scale_dtype_size)
+        total_raw_size = scale_offset + dsa_k_scale_tensor_size
+
+        sparse_c8_raw_tensor = self._allocate_int8_cache_tensor(
+            total_raw_size,
+            alignment,
+        )
+
+        dsa_k_tensor = sparse_c8_raw_tensor[:dsa_k_tensor_size]
+        dsa_k_scale_tensor = sparse_c8_raw_tensor[
+            scale_offset : scale_offset + dsa_k_scale_tensor_size
+        ]
+
+        assert dsa_k_tensor.is_contiguous()
+        assert dsa_k_scale_tensor.is_contiguous()
+        assert dsa_k_scale_tensor.data_ptr() % scale_dtype_size == 0
+        assert dsa_k_scale_tensor.numel() % scale_dtype_size == 0
+
+        return dsa_k_tensor, dsa_k_scale_tensor
+
     def _allocate_kv_cache_tensors(self, kv_cache_config: KVCacheConfig) -> dict[str, torch.Tensor]:
         """
         Initializes the KV cache buffer with the correct size. The buffer needs
@@ -3759,39 +3841,41 @@ class NPUModelRunner(GPUModelRunner):
                     if self.use_sparse and current_sparse_c8:
                         dsa_k_scale_tensor_size = int(kv_cache_tensor.size // dsa_k_scale_tensor_split_factor)
 
-                    # for other attentions, e.g., self_attn, sliding window attn
-                    if self.vllm_config.kv_transfer_config is None:
-                        k_tensor = torch.zeros(k_tensor_size, dtype=torch.int8, device=self.device)
-                        v_tensor = None
-                        if v_tensor_size is not None:
-                            v_tensor = torch.zeros(v_tensor_size, dtype=torch.int8, device=self.device)
-                        #### for deepseek sparse attention
-                        if dsa_k_tensor_size is not None:
-                            dsa_k_tensor = torch.zeros(dsa_k_tensor_size, dtype=torch.int8, device=self.device)
-                        if dsa_k_scale_tensor_size is not None:
-                            dsa_k_scale_tensor = torch.zeros(
-                                dsa_k_scale_tensor_size, dtype=torch.int8, device=self.device
+                    # Allocate raw int8 tensors. Even bf16/fp16 KV cache entries
+                    # are allocated as int8 raw bytes first and then viewed as
+                    # the target dtype in _reshape_kv_cache_tensors.
+                    k_tensor = self._allocate_int8_cache_tensor(
+                        k_tensor_size,
+                        alignment,
+                    )
+                    v_tensor = self._allocate_int8_cache_tensor(
+                        v_tensor_size,
+                        alignment,
+                    )
+
+                    dsa_k_tensor = None
+                    dsa_k_scale_tensor = None
+
+                    if self.use_sparse:
+                        assert dsa_k_tensor_size is not None
+
+                        if current_sparse_c8:
+                            assert dsa_k_scale_tensor_size is not None
+
+                            (
+                                dsa_k_tensor,
+                                dsa_k_scale_tensor,
+                            ) = self._allocate_sparse_c8_indexer_tensors(
+                                dsa_k_tensor_size=dsa_k_tensor_size,
+                                dsa_k_scale_tensor_size=dsa_k_scale_tensor_size,
+                                alignment=alignment,
+                                scale_dtype=current_kv_cache_spec.scale_dtype,
                             )
-                    else:
-                        k_tensor = torch.zeros(k_tensor_size + alignment, dtype=torch.int8, device=self.device)
-                        v_tensor = None
-                        if v_tensor_size is not None:
-                            v_tensor = torch.zeros(v_tensor_size + alignment, dtype=torch.int8, device=self.device)
-                            v_tensor = self._align_memory(v_tensor, alignment)[:v_tensor_size]
-                        k_tensor = self._align_memory(k_tensor, alignment)[:k_tensor_size]
-                        #### for deepseek sparse attention
-                        if dsa_k_tensor_size is not None:
-                            dsa_k_tensor = torch.zeros(
-                                dsa_k_tensor_size + alignment, dtype=torch.int8, device=self.device
+                        else:
+                            dsa_k_tensor = self._allocate_int8_cache_tensor(
+                                dsa_k_tensor_size,
+                                alignment,
                             )
-                            dsa_k_tensor = self._align_memory(dsa_k_tensor, alignment)[:dsa_k_tensor_size]
-                        if dsa_k_scale_tensor_size is not None:
-                            dsa_k_scale_tensor = torch.zeros(
-                                dsa_k_scale_tensor_size + alignment, dtype=torch.int8, device=self.device
-                            )
-                            dsa_k_scale_tensor = self._align_memory(
-                                dsa_k_scale_tensor, alignment
-                            )[:dsa_k_scale_tensor_size]
 
                     for layer_name_inner in kv_cache_tensor.shared_by:
                         # shared the attn kvcache for all shared layers


### PR DESCRIPTION
### What this PR does / why we need it?

This PR refactors Mooncake KV cache buffer registration to reduce duplicated logic between the normal Mooncake connector and the layerwise connector.

It also reduces HCCL/Mooncake register region count for sparse-c8 KV caches by:
- allocating dsa_k and dsa_k_scale from one aligned raw allocation;
- keeping logical KV cache metadata unchanged;
- registering storage-merged memory ranges instead of registering every logical tensor separately.

For Mamba / attention-Mamba hybrid paths, the existing special registration ranges are preserved to avoid losing MTP padding handling.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
