### PR TITLE
All-Hit 快速路径（预期收益：额外节省 ~50ms/step）

### DIFF
--- a/docs/moe_offload_lrc_test_flow.md
+++ b/docs/moe_offload_lrc_test_flow.md
@@ -1,0 +1,151 @@
+# MoE Offload LRC Cache Test Flow
+
+This file is for the agent that validates the `moe_offload_v2.0` branch.
+The goal is to verify that expert offload now uses the LRC cache policy and
+that every decode-layer update can report which routed experts were already
+resident on device and which experts had to be loaded again.
+
+## What changed
+
+- Added `vllm_ascend/expert_offload/lrc_policy.py`.
+- `ExpertOffloadManager.update_weights()` now accepts `topk_weights`.
+- Decode path computes:
+  - `already_there = needed & on_device`
+  - `need_to_load = needed - already_there`
+- Runtime logs expose per-layer cache hits and misses.
+- Config options were added under `additional_config.expert_offload_config`:
+  - `cache_policy_enabled`
+  - `cache_recent_window`
+  - `cache_ema_beta`
+  - `cache_recent_weight`
+  - `cache_ema_weight`
+  - `cache_router_weight`
+  - `cache_age_weight`
+  - `cache_stats_log_interval`
+
+## Static checks
+
+Run from the repo root:
+
+```bash
+python -B -c "from pathlib import Path; files=['vllm_ascend/expert_offload/lrc_policy.py','vllm_ascend/expert_offload/expert_offload_manager.py','vllm_ascend/ascend_config.py','vllm_ascend/ops/fused_moe/fused_moe.py','vllm_ascend/quantization/methods/w8a8_dynamic.py','tests/ut/expert_offload/test_lrc_policy.py']; [compile(Path(p).read_text(), p, 'exec') for p in files]; print('syntax checks passed')"
+```
+
+Expected result:
+
+- The command prints `syntax checks passed`.
+- There is no `SyntaxError`.
+
+If the test machine has the vLLM Ascend test environment, also run:
+
+```bash
+pytest tests/ut/expert_offload/test_lrc_policy.py
+```
+
+Expected result:
+
+- All tests in `test_lrc_policy.py` pass.
+- If pytest fails before collecting tests because `torch_npu` is missing, that is an environment failure, not a policy failure.
+
+## Runtime config
+
+Expert offload and the LRC cache policy must both be enabled. For focused validation,
+make the cache log every decode call by setting `cache_stats_log_interval` to `1`.
+
+Example `--additional-config`:
+
+```bash
+--additional-config '{"enable_cpu_binding":true,"multistream_overlap_shared_expert":false,"expert_offload_config":{"expert_offload":true,"num_device_experts":6,"num_device_layers":2,"cache_policy_enabled":true,"cache_stats_log_interval":1}}'
+```
+
+Notes:
+
+- If the model really has 6 total experts per layer and `num_device_experts` is also `6`, then after warmup the expected steady-state behavior is that all routed experts are hits and `last_miss=[]`.
+- If total experts is greater than `num_device_experts`, misses are expected. Success is not zero misses; success is that already-resident experts appear in `last_hit` and are not loaded again.
+- Keep the rest of the user's online launch script unchanged unless the environment requires normal deployment changes.
+
+## Runtime test
+
+1. Start `vllm serve` with expert offload enabled and `cache_stats_log_interval=1`.
+2. Send several decode-heavy requests. Repeated prompts are useful because they should stabilize routing and improve hit rate.
+
+Example:
+
+```bash
+curl http://127.0.0.1:7000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"ds","messages":[{"role":"user","content":"写一段 800 字的技术说明，主题是 MoE 专家缓存命中率。"}],"max_tokens":512,"temperature":0}'
+```
+
+Run the same request 5 to 10 times.
+
+## Logs to check
+
+Search the server log for:
+
+```text
+[EXPERT-OFFLOAD-CACHE]
+```
+
+Expected log shape:
+
+```text
+[EXPERT-OFFLOAD-CACHE] layer=<layer> cache_step=<n> calls=<n> policy_step=<m> hit_rate=<r> hits=<h> misses=<m> last_hit=[...] last_miss=[...] resident=[...]
+```
+
+`cache_step` / `calls` is the number of cache updates for that layer.
+`policy_step` is the number of routed token rows observed by the LRC policy for that layer.
+
+Also useful:
+
+```text
+[UPDATE-W] l=<layer> cache_hit=[...] cache_miss=[...]
+```
+
+These two lists are the key validation signal:
+
+- `cache_hit` / `last_hit`: experts already prefetched or resident on device; they should not be copied again.
+- `cache_miss` / `last_miss`: routed experts not currently resident; these require CPU to NPU loading.
+
+## Success criteria
+
+The change is considered tested successfully when all of the following are true:
+
+1. The server starts with `expert_offload_config.expert_offload=true` and `expert_offload_config.cache_policy_enabled=true`.
+2. Decode requests complete successfully and return valid model output.
+3. Logs contain `[EXPERT-OFFLOAD-CACHE]` for active MoE layers.
+4. Each cache log has sane counters:
+   - `calls` increases over time for the same layer.
+   - `hits + misses == total routed expert requests accumulated for that layer`.
+   - `0.0 <= hit_rate <= 1.0`.
+   - `last_hit`, `last_miss`, and `resident` contain valid expert ids.
+5. For a 6-expert model/cache case:
+   - expert ids in `last_hit`, `last_miss`, and `resident` are within `0..5`;
+   - after warmup, repeated similar requests should show increasing hit rate;
+   - if all 6 experts fit on device, steady-state `last_miss` should usually become `[]`.
+6. No log shows repeated loading for an expert that is already listed in `cache_hit` for the same layer update.
+7. There are no crashes, shape errors, invalid config errors, or NPU copy errors from the modified offload path.
+
+## Failure criteria
+
+Treat any of the following as a failed validation:
+
+- No `[EXPERT-OFFLOAD-CACHE]` logs appear while expert offload is enabled and decode requests are running.
+- `cache_hit` is always empty after many repeated decode requests, even when the cache can hold the routed experts.
+- An expert appears in both hit and miss lists for the same layer update.
+- Expert ids are outside the valid range, for example outside `0..5` in a 6-expert setup.
+- `hit_rate` is negative, greater than 1, or does not match `hits / (hits + misses)`.
+- The process crashes inside `ExpertOffloadManager.update_weights()` or `_update_weights()`.
+- Accuracy/output becomes obviously broken compared with the same branch before this change under the same model and prompt.
+
+## Suggested final report
+
+Report these items back:
+
+- commit id tested;
+- exact launch command or changed `--additional-config`;
+- whether static checks passed;
+- whether pytest passed or was blocked by environment;
+- sample `[EXPERT-OFFLOAD-CACHE]` lines from at least two layers;
+- final observed hit rate range;
+- whether the 6-expert resident/hit/miss behavior matched expectations.

--- a/tests/ut/expert_offload/test_lrc_policy.py
+++ b/tests/ut/expert_offload/test_lrc_policy.py
@@ -1,0 +1,98 @@
+from vllm_ascend.expert_offload.lrc_policy import LRCExpertCachePolicy
+
+
+def test_choose_victim_keeps_recently_hot_expert():
+    policy = LRCExpertCachePolicy(
+        num_layers=1,
+        num_experts=8,
+        cache_size=4,
+        topk=2,
+        recent_window=4,
+        ema_beta=0.5,
+        age_weight=0.0,
+    )
+    layer_idx = 0
+
+    for _ in range(4):
+        policy.observe(layer_idx, [[1, 2]])
+
+    slot_owner = {0: 1, 1: 2, 2: 3, 3: 4}
+
+    assert policy.choose_victim(layer_idx, slot_owner, protected={5, 6}) == 3
+
+
+def test_choose_victim_never_evicts_current_topk():
+    policy = LRCExpertCachePolicy(
+        num_layers=1,
+        num_experts=8,
+        cache_size=4,
+        topk=2,
+        recent_window=4,
+        ema_beta=0.5,
+        age_weight=0.0,
+    )
+    layer_idx = 0
+
+    policy.observe(layer_idx, [[3, 4]])
+    slot_owner = {0: 1, 1: 2, 2: 3, 3: 4}
+
+    assert policy.choose_victim(layer_idx, slot_owner, protected={3, 4}) == 1
+
+
+def test_observe_maintains_recent_window_frequency():
+    policy = LRCExpertCachePolicy(
+        num_layers=1,
+        num_experts=8,
+        cache_size=4,
+        topk=2,
+        recent_window=2,
+        ema_beta=0.5,
+        age_weight=0.0,
+    )
+    layer_idx = 0
+
+    policy.observe(layer_idx, [[1, 2]])
+    policy.observe(layer_idx, [[2, 3]])
+    policy.observe(layer_idx, [[3, 4]])
+
+    state = policy.layer_states[layer_idx]
+    assert state.freq[1] == 0
+    assert state.freq[2] == 1
+    assert state.freq[3] == 2
+    assert state.freq[4] == 1
+
+
+def test_router_score_contributes_to_hotness():
+    policy = LRCExpertCachePolicy(
+        num_layers=1,
+        num_experts=8,
+        cache_size=4,
+        topk=2,
+        recent_window=4,
+        ema_beta=0.5,
+        recent_weight=0.0,
+        ema_weight=0.0,
+        router_weight=1.0,
+        age_weight=0.0,
+    )
+    layer_idx = 0
+
+    policy.observe(layer_idx, [[1, 2]], router_scores=[[0.1, 0.9]])
+    slot_owner = {0: 1, 1: 2, 2: 3, 3: 4}
+
+    assert policy.choose_victim(layer_idx, slot_owner, protected={5, 6}) == 3
+
+
+def test_layer_steps_are_tracked_independently():
+    policy = LRCExpertCachePolicy(
+        num_layers=2,
+        num_experts=8,
+        cache_size=4,
+        topk=2,
+    )
+
+    policy.observe(0, [[1, 2], [2, 3]])
+    policy.observe(1, [[4, 5]])
+
+    assert policy.layer_step(0) == 2
+    assert policy.layer_step(1) == 1

--- a/tools/analyze_expert_cache_log.py
+++ b/tools/analyze_expert_cache_log.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Summarize expert offload cache hit rates from vllm-ascend logs."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import csv
+import json
+import re
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, TextIO
+
+
+DETAIL_RE = re.compile(
+    r"\[UPDATE-W\]\s+l=(?P<layer>\d+)\s+call=(?P<call>\d+).*?\|needed\|=(?P<needed_count>\d+).*?needed=(?P<needed>\[[^\]]*\])"
+)
+HIT_RE = re.compile(
+    r"\[UPDATE-W\]\s+l=(?P<layer>\d+)\s+cache_hit=(?P<hit>\[[^\]]*\])\s+cache_miss=(?P<miss>\[[^\]]*\])"
+)
+
+
+@dataclass
+class Event:
+    layer: int
+    call: int | None
+    hits: int
+    misses: int
+    requests: int
+    hit_experts: list[int]
+    miss_experts: list[int]
+    needed_experts: list[int] = field(default_factory=list)
+
+    @property
+    def hit_rate(self) -> float:
+        return self.hits / self.requests if self.requests else 0.0
+
+
+@dataclass
+class Bucket:
+    calls: int = 0
+    hits: int = 0
+    misses: int = 0
+    requests: int = 0
+
+    @property
+    def hit_rate(self) -> float:
+        return self.hits / self.requests if self.requests else 0.0
+
+    def add(self, event: Event) -> None:
+        self.calls += 1
+        self.hits += event.hits
+        self.misses += event.misses
+        self.requests += event.requests
+
+
+@dataclass
+class Summary:
+    layers: dict[int, Bucket]
+    event_steps: dict[int, Bucket]
+    decode_steps: dict[int, Bucket]
+    events: list[Event]
+    global_hits: int
+    global_misses: int
+    global_requests: int
+    decode_step_layers: int | None = None
+
+    @property
+    def global_hit_rate(self) -> float:
+        return self.global_hits / self.global_requests if self.global_requests else 0.0
+
+
+def _parse_list(value: str) -> list[int]:
+    parsed = ast.literal_eval(value)
+    if not isinstance(parsed, list):
+        raise ValueError(f"expected list, got {value}")
+    return [int(item) for item in parsed]
+
+
+def parse_lines(lines: Iterable[str]) -> list[Event]:
+    pending: dict[int, tuple[int, list[int]]] = {}
+    events: list[Event] = []
+
+    for line in lines:
+        detail_match = DETAIL_RE.search(line)
+        if detail_match:
+            layer = int(detail_match.group("layer"))
+            call = int(detail_match.group("call"))
+            needed = _parse_list(detail_match.group("needed"))
+            pending[layer] = (call, needed)
+            continue
+
+        hit_match = HIT_RE.search(line)
+        if not hit_match:
+            continue
+
+        layer = int(hit_match.group("layer"))
+        hit_experts = _parse_list(hit_match.group("hit"))
+        miss_experts = _parse_list(hit_match.group("miss"))
+        call = None
+        needed_experts: list[int] = []
+        if layer in pending:
+            call, needed_experts = pending.pop(layer)
+
+        requests = len(needed_experts) if needed_experts else len(hit_experts) + len(miss_experts)
+        events.append(
+            Event(
+                layer=layer,
+                call=call,
+                hits=len(hit_experts),
+                misses=len(miss_experts),
+                requests=requests,
+                hit_experts=hit_experts,
+                miss_experts=miss_experts,
+                needed_experts=needed_experts,
+            )
+        )
+
+    return events
+
+
+def _infer_decode_step_layers(events: list[Event]) -> int | None:
+    layers = {event.layer for event in events}
+    if not layers:
+        return None
+    return max(layers) + 1
+
+
+def summarize(events: list[Event], decode_step_layers: int | None = None) -> Summary:
+    layers: dict[int, Bucket] = defaultdict(Bucket)
+    event_steps: dict[int, Bucket] = defaultdict(Bucket)
+    decode_steps: dict[int, Bucket] = defaultdict(Bucket)
+    global_bucket = Bucket()
+    if decode_step_layers is None:
+        decode_step_layers = _infer_decode_step_layers(events)
+
+    for event in events:
+        layers[event.layer].add(event)
+        global_bucket.add(event)
+        if event.call is not None:
+            event_steps[event.call].add(event)
+            if decode_step_layers:
+                decode_steps[event.call // decode_step_layers].add(event)
+
+    return Summary(
+        layers=dict(layers),
+        event_steps=dict(event_steps),
+        decode_steps=dict(decode_steps),
+        events=events,
+        global_hits=global_bucket.hits,
+        global_misses=global_bucket.misses,
+        global_requests=global_bucket.requests,
+        decode_step_layers=decode_step_layers,
+    )
+
+
+def _open_log(path: str) -> TextIO:
+    if path == "-":
+        return sys.stdin
+    return Path(path).open("r", encoding="utf-8", errors="replace")
+
+
+def _print_table(summary: Summary, top_steps: int) -> None:
+    print("GLOBAL")
+    print(
+        f"  requests={summary.global_requests} hits={summary.global_hits} "
+        f"misses={summary.global_misses} hit_rate={summary.global_hit_rate:.6f}"
+    )
+
+    print("\nPER_LAYER")
+    print("layer,calls,requests,hits,misses,hit_rate")
+    for layer, bucket in sorted(summary.layers.items()):
+        print(
+            f"{layer},{bucket.calls},{bucket.requests},{bucket.hits},"
+            f"{bucket.misses},{bucket.hit_rate:.6f}"
+        )
+
+    print("\nPER_EVENT_STEP")
+    print("step,events,requests,hits,misses,hit_rate")
+    for step, bucket in sorted(summary.event_steps.items())[:top_steps]:
+        print(
+            f"{step},{bucket.calls},{bucket.requests},{bucket.hits},"
+            f"{bucket.misses},{bucket.hit_rate:.6f}"
+        )
+    if len(summary.event_steps) > top_steps:
+        print(f"... truncated {len(summary.event_steps) - top_steps} event steps; use --top-steps to show more")
+
+    print(f"\nPER_DECODE_STEP decode_step_layers={summary.decode_step_layers}")
+    print("decode_step,layer_events,requests,hits,misses,hit_rate")
+    for step, bucket in sorted(summary.decode_steps.items())[:top_steps]:
+        print(
+            f"{step},{bucket.calls},{bucket.requests},{bucket.hits},"
+            f"{bucket.misses},{bucket.hit_rate:.6f}"
+        )
+    if len(summary.decode_steps) > top_steps:
+        print(f"... truncated {len(summary.decode_steps) - top_steps} decode steps; use --top-steps to show more")
+
+
+def _write_csv(path: str, rows: Iterable[dict[str, int | float]]) -> None:
+    rows = list(rows)
+    if not rows:
+        return
+    with Path(path).open("w", newline="", encoding="utf-8") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _json_summary(summary: Summary) -> dict[str, object]:
+    return {
+        "global": {
+            "requests": summary.global_requests,
+            "hits": summary.global_hits,
+            "misses": summary.global_misses,
+            "hit_rate": summary.global_hit_rate,
+        },
+        "decode_step_layers": summary.decode_step_layers,
+        "layers": {
+            str(layer): {
+                "calls": bucket.calls,
+                "requests": bucket.requests,
+                "hits": bucket.hits,
+                "misses": bucket.misses,
+                "hit_rate": bucket.hit_rate,
+            }
+            for layer, bucket in sorted(summary.layers.items())
+        },
+        "event_steps": {
+            str(step): {
+                "events": bucket.calls,
+                "requests": bucket.requests,
+                "hits": bucket.hits,
+                "misses": bucket.misses,
+                "hit_rate": bucket.hit_rate,
+            }
+            for step, bucket in sorted(summary.event_steps.items())
+        },
+        "decode_steps": {
+            str(step): {
+                "layer_events": bucket.calls,
+                "requests": bucket.requests,
+                "hits": bucket.hits,
+                "misses": bucket.misses,
+                "hit_rate": bucket.hit_rate,
+            }
+            for step, bucket in sorted(summary.decode_steps.items())
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", help="log path, or '-' for stdin")
+    parser.add_argument("--json", action="store_true", help="print JSON instead of tables")
+    parser.add_argument("--top-steps", type=int, default=30, help="number of per-step rows to print")
+    parser.add_argument(
+        "--decode-step-layers",
+        default="auto",
+        help="MoE layer count used to group event calls into decode steps; use 'auto' or an integer",
+    )
+    parser.add_argument("--layer-csv", help="write per-layer stats as CSV")
+    parser.add_argument("--event-step-csv", help="write per-event-step stats as CSV")
+    parser.add_argument("--step-csv", help="write per-decode-step stats as CSV")
+    args = parser.parse_args()
+
+    with _open_log(args.log) as log_file:
+        events = parse_lines(log_file)
+
+    if args.decode_step_layers == "auto":
+        decode_step_layers = None
+    else:
+        decode_step_layers = int(args.decode_step_layers)
+        if decode_step_layers < 1:
+            raise ValueError("--decode-step-layers must be >= 1")
+    summary = summarize(events, decode_step_layers=decode_step_layers)
+
+    if args.layer_csv:
+        _write_csv(
+            args.layer_csv,
+            (
+                {
+                    "layer": layer,
+                    "calls": bucket.calls,
+                    "requests": bucket.requests,
+                    "hits": bucket.hits,
+                    "misses": bucket.misses,
+                    "hit_rate": bucket.hit_rate,
+                }
+                for layer, bucket in sorted(summary.layers.items())
+            ),
+        )
+    if args.event_step_csv:
+        _write_csv(
+            args.event_step_csv,
+            (
+                {
+                    "step": step,
+                    "events": bucket.calls,
+                    "requests": bucket.requests,
+                    "hits": bucket.hits,
+                    "misses": bucket.misses,
+                    "hit_rate": bucket.hit_rate,
+                }
+                for step, bucket in sorted(summary.event_steps.items())
+            ),
+        )
+    if args.step_csv:
+        _write_csv(
+            args.step_csv,
+            (
+                {
+                    "decode_step": step,
+                    "layer_events": bucket.calls,
+                    "requests": bucket.requests,
+                    "hits": bucket.hits,
+                    "misses": bucket.misses,
+                    "hit_rate": bucket.hit_rate,
+                }
+                for step, bucket in sorted(summary.decode_steps.items())
+            ),
+        )
+
+    if args.json:
+        print(json.dumps(_json_summary(summary), indent=2, sort_keys=True))
+    else:
+        _print_table(summary, args.top_steps)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_analyze_expert_cache_log.py
+++ b/tools/test_analyze_expert_cache_log.py
@@ -1,0 +1,33 @@
+import unittest
+
+from analyze_expert_cache_log import parse_lines, summarize
+
+
+class AnalyzeExpertCacheLogTest(unittest.TestCase):
+
+    def test_summarizes_layer_step_and_global_hit_rates(self):
+        lines = [
+            "[UPDATE-W] l=0 call=10 topk_shape=(1, 6) |needed|=6 |on_dev|=12 |to_load|=4 reusable=10 needed=[1, 2, 3, 4, 5, 6]",
+            "[UPDATE-W] l=0 cache_hit=[1, 2] cache_miss=[3, 4, 5, 6]",
+            "[UPDATE-W] l=1 call=11 topk_shape=(1, 6) |needed|=6 |on_dev|=12 |to_load|=0 reusable=6 needed=[7, 8, 9, 10, 11, 12]",
+            "[UPDATE-W] l=1 cache_hit=[7, 8, 9, 10, 11, 12] cache_miss=[]",
+            "[UPDATE-W] l=0 call=12 topk_shape=(1, 6) |needed|=6 |on_dev|=12 |to_load|=3 reusable=9 needed=[1, 2, 3, 7, 8, 9]",
+            "[UPDATE-W] l=0 cache_hit=[1, 2, 3] cache_miss=[7, 8, 9]",
+        ]
+
+        summary = summarize(parse_lines(lines), decode_step_layers=2)
+
+        self.assertEqual(summary.global_hits, 11)
+        self.assertEqual(summary.global_requests, 18)
+        self.assertAlmostEqual(summary.global_hit_rate, 11 / 18)
+        self.assertAlmostEqual(summary.layers[0].hit_rate, 5 / 12)
+        self.assertAlmostEqual(summary.layers[1].hit_rate, 1.0)
+        self.assertEqual(summary.event_steps[10].hit_rate, 2 / 6)
+        self.assertEqual(summary.event_steps[11].hit_rate, 1.0)
+        self.assertEqual(summary.event_steps[12].hit_rate, 3 / 6)
+        self.assertAlmostEqual(summary.decode_steps[5].hit_rate, 8 / 12)
+        self.assertAlmostEqual(summary.decode_steps[6].hit_rate, 3 / 6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -48,6 +48,9 @@ class AscendConfig:
         eplb_config = additional_config.get("eplb_config", {})
         self.eplb_config = EplbConfig(eplb_config)
 
+        expert_offload_config = additional_config.get("expert_offload_config", {})
+        self.expert_offload_config = ExpertOffloadConfig(expert_offload_config)
+
         weight_prefetch_config = additional_config.get("weight_prefetch_config", {})
         self.weight_prefetch_config = WeightPrefetchConfig(weight_prefetch_config)
 
@@ -607,6 +610,55 @@ class EplbConfig:
         logger.info("The number of redundant experts is %s", self.config["num_redundant_experts"])
 
 
+class ExpertOffloadConfig:
+    """
+    Configuration Object for expert_offload_config from additional_config
+    """
+
+    _defaults = {
+        "expert_offload": False,
+        "num_device_experts": 32,
+        "num_device_layers": 2,
+        "expert_map_path": None,
+    }
+
+    def __init__(self, user_config: dict | None = None):
+        if user_config is None:
+            user_config = {}
+        self.config = self._defaults.copy()
+        if user_config and isinstance(user_config, dict):
+            for key, value in user_config.items():
+                if key in self.config:
+                    self.config[key] = value
+                else:
+                    raise ValueError(f"Config has no attribute '{key}'")
+
+        self._validate_config()
+
+    def __getattr__(self, key):
+        if key in self.config:
+            return self.config[key]
+        raise AttributeError(f"Config has no attribute '{key}'")
+
+    def _validate_config(self):
+        if self.expert_map_path is not None:
+            logger.info("The expert_map is %s", self.expert_map_path)
+            if not self.expert_map_path.endswith(".json"):
+                raise TypeError("The expert_map is not json.")
+            if not (os.path.exists(self.expert_map_path) and os.access(self.expert_map_path, os.R_OK)):
+                raise ValueError("The expert_map is not exist.")
+        if not isinstance(self.config["num_device_experts"], int):
+            raise TypeError("num_device_experts must be an integer")
+        if self.config["num_device_experts"] < 0:
+            raise ValueError(f"num_device_experts must >= 0; got {self.config['num_device_experts']} instead")
+        if not isinstance(self.config["num_device_layers"], int):
+            raise TypeError("num_device_layers must be an integer")
+        if self.config["num_device_layers"] < 1:
+            raise ValueError(f"num_device_layers must >= 1; got {self.config['num_device_layers']} instead")
+        if not isinstance(self.config["expert_offload"], bool):
+            raise TypeError("expert_offload must be a boolean")
+
+
 _ASCEND_CONFIG: AscendConfig | None = None
 
 
@@ -620,7 +672,7 @@ def _is_ascend_config_initialized(config: AscendConfig | None) -> bool:
     """
     if config is None:
         return False
-    return hasattr(config, "ascend_compilation_config") and hasattr(config, "eplb_config")
+    return hasattr(config, "ascend_compilation_config") and hasattr(config, "eplb_config") and hasattr(config, "expert_offload_config")
 
 
 def init_ascend_config(vllm_config):

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -620,6 +620,15 @@ class ExpertOffloadConfig:
         "num_device_experts": 32,
         "num_device_layers": 2,
         "expert_map_path": None,
+        "cache_policy_enabled": False,
+        "cache_recent_window": 32,
+        "cache_ema_beta": 0.9,
+        "cache_recent_weight": 1.0,
+        "cache_ema_weight": 0.5,
+        "cache_router_weight": 0.3,
+        "cache_age_weight": 0.01,
+        "cache_stats_log_interval": 1000,
+        "cache_debug_log_updates": False,
     }
 
     def __init__(self, user_config: dict | None = None):
@@ -657,6 +666,29 @@ class ExpertOffloadConfig:
             raise ValueError(f"num_device_layers must >= 1; got {self.config['num_device_layers']} instead")
         if not isinstance(self.config["expert_offload"], bool):
             raise TypeError("expert_offload must be a boolean")
+        if not isinstance(self.config["cache_policy_enabled"], bool):
+            raise TypeError("cache_policy_enabled must be a boolean")
+        if not isinstance(self.config["cache_recent_window"], int):
+            raise TypeError("cache_recent_window must be an integer")
+        if self.config["cache_recent_window"] < 1:
+            raise ValueError("cache_recent_window must >= 1")
+        for key in (
+            "cache_ema_beta",
+            "cache_recent_weight",
+            "cache_ema_weight",
+            "cache_router_weight",
+            "cache_age_weight",
+        ):
+            if not isinstance(self.config[key], (int, float)):
+                raise TypeError(f"{key} must be a number")
+        if not 0 <= self.config["cache_ema_beta"] < 1:
+            raise ValueError("cache_ema_beta must be in [0, 1)")
+        if not isinstance(self.config["cache_stats_log_interval"], int):
+            raise TypeError("cache_stats_log_interval must be an integer")
+        if self.config["cache_stats_log_interval"] < 0:
+            raise ValueError("cache_stats_log_interval must >= 0")
+        if not isinstance(self.config["cache_debug_log_updates"], bool):
+            raise TypeError("cache_debug_log_updates must be a boolean")
 
 
 _ASCEND_CONFIG: AscendConfig | None = None

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -312,6 +312,7 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig, is_draft_mo
             moe_comm_type = MoECommType.ALLTOALL
     else:
         raise ValueError(f"Unsupported soc_version: {soc_version}")
+    moe_comm_type = MoECommType.ALLGATHER
     return moe_comm_type
 
 

--- a/vllm_ascend/expert_offload/__init__.py
+++ b/vllm_ascend/expert_offload/__init__.py
@@ -1,0 +1,3 @@
+from .expert_offload_manager import ExpertOffloadManager
+
+__all__ = ["ExpertOffloadManager"]

--- a/vllm_ascend/expert_offload/__init__.py
+++ b/vllm_ascend/expert_offload/__init__.py
@@ -1,3 +1,8 @@
-from .expert_offload_manager import ExpertOffloadManager
+def __getattr__(name):
+    if name == "ExpertOffloadManager":
+        from .expert_offload_manager import ExpertOffloadManager
+
+        return ExpertOffloadManager
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 __all__ = ["ExpertOffloadManager"]

--- a/vllm_ascend/expert_offload/expert_offload_manager.py
+++ b/vllm_ascend/expert_offload/expert_offload_manager.py
@@ -1,0 +1,655 @@
+"""Expert Offload Manager — manages CPU-side expert weights and NPU paging."""
+
+import torch
+import torch_npu
+from vllm.config import VllmConfig
+from vllm.logger import logger
+
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+
+
+_SUBSCRIBED_COMPUTE_STREAMS = set()
+def get_subscribed_compute_streams() -> set:
+    return _SUBSCRIBED_COMPUTE_STREAMS
+
+
+class ExpertOffloadManager:
+    """Singleton manager for expert weight offloading.
+
+    Stores all expert weights on CPU and pages the needed experts to NPU
+    during forward based on routing topk_ids.
+    """
+
+    _instance: "ExpertOffloadManager | None" = None
+
+    @classmethod
+    def get_instance(cls) -> "ExpertOffloadManager":
+        assert cls._instance is not None, "ExpertOffloadManager not initialized"
+        return cls._instance
+
+    def __init__(self, vllm_config: VllmConfig):
+        from vllm_ascend.ascend_config import get_ascend_config
+
+        self.offload_config = get_ascend_config().expert_offload_config
+        self.num_device_experts = self.offload_config.num_device_experts
+        self.topk = vllm_config.model_config.hf_config.num_experts_per_tok
+        self.offload_threshold = self.num_device_experts // self.topk
+
+        # CPU weight buffers (post-transpose format, matching device after
+        # process_weights_after_loading):
+        #   w13 per expert: [hidden_size, w13_up_dim]
+        #   w2 per expert:  [intermediate_size_per_partition, hidden_size]
+        self.w13_weights_cpu: list[list[torch.Tensor]] = []
+        self.w2_weights_cpu: list[list[torch.Tensor]] = []
+
+        # Registered AscendFusedMoE layers, indexed by moe_instance_id order
+        self.moe_layers: list = []
+
+        # Temporary storage for weights loaded before create_weights()
+        self._pending_weights: dict = {}
+
+        # CPU buffers for quantized model scale/offset parameters.
+        # Keyed by attr_name (e.g. "w13_weight_scale", "w2_weight_offset").
+        # Each value is a list of layers, each layer is a list of expert tensors.
+        self.scale_cpu_buffers: dict[str, list[list[torch.Tensor]]] = {}
+        self.offset_cpu_buffers: dict[str, list[list[torch.Tensor]]] = {}
+
+        # Temporary storage for scale/offset weights loaded before
+        # maybe_create_scale_buffers runs.
+        self._pending_scales: dict[tuple, dict[str, torch.Tensor]] = {}
+
+        self.num_device_layers = self.offload_config.num_device_layers
+        self.num_total_experts = None  # set in create_weights
+
+        ExpertOffloadManager._instance = self
+
+        self.load_stream = torch_npu.npu.Stream()
+
+        # Prefill pool: ndl layers × all experts on NPU, shared round-robin
+        self._prefill_w13: list[torch.Tensor] = []
+        self._prefill_w2: list[torch.Tensor] = []
+        self._prefill_w13_scale: list[torch.Tensor] = []       # W8A8
+        self._prefill_w13_scale_fp32: list[torch.Tensor] = []   # W8A8
+        self._prefill_w13_offset: list[torch.Tensor] = []       # W8A8
+        self._prefill_w2_scale: list[torch.Tensor] = []         # W8A8
+        self._prefill_w2_offset: list[torch.Tensor] = []        # W8A8
+        self._prefill_log2phy: torch.Tensor = None              # identity [0..127]
+        self._prefill_initialized: bool = False
+        self._skip_prefill: bool = False  # set during profile runs
+
+    # ------------------------------------------------------------------ #
+    #  Lifecycle: called from NPUModelRunner during model loading         #
+    # ------------------------------------------------------------------ #
+
+    def create_weights(
+        self,
+        num_moe_layers: int,
+        num_total_experts: int,
+        w13_up_dim: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype: torch.dtype,
+    ):
+        """Allocate CPU buffers for all MoE layers."""
+        for _ in range(num_moe_layers):
+            w13_list = [
+                torch.empty(hidden_size, w13_up_dim, dtype=params_dtype, device="cpu")
+                for _ in range(num_total_experts)
+            ]
+            w2_list = [
+                torch.empty(intermediate_size_per_partition, hidden_size,
+                            dtype=params_dtype, device="cpu")
+                for _ in range(num_total_experts)
+            ]
+            self.w13_weights_cpu.append(w13_list)
+            self.w2_weights_cpu.append(w2_list)
+        self._drain_pending_weights()
+
+        self.num_total_experts = num_total_experts
+
+        # update weights related buffers
+        self.topk_ids_h = torch.zeros([self.offload_threshold, self.topk], dtype=torch.int32, device='cpu', pin_memory=True)
+        self.log2phy_h = torch.zeros(num_total_experts, dtype=torch.int32, device='cpu', pin_memory=True)
+        self.log2phy_np = self.log2phy_h.numpy()
+
+    def register_moe_layer(self, layer):
+        self.moe_layers.append(layer)
+
+    def load_w13(self, layer_moe_idx: int, expert_id: int,
+                 loaded_weight: torch.Tensor, shard_id: str):
+        """Store w1/w3 shard to CPU buffer (with transpose to post format)."""
+        if not self.w13_weights_cpu:
+            key = (layer_moe_idx, expert_id)
+            self._pending_weights.setdefault(key, {})[f"w13_{shard_id}"] = \
+                loaded_weight.cpu().clone()
+            return
+        cpu = self.w13_weights_cpu[layer_moe_idx][expert_id]
+        intermed = cpu.shape[1] // 2
+        w = loaded_weight.cpu()
+        if shard_id == "w1":
+            cpu[:, :intermed].copy_(w.t())
+        elif shard_id == "w3":
+            cpu[:, intermed: intermed + w.shape[0]].copy_(w.t())
+
+    def load_w2(self, layer_moe_idx: int, expert_id: int,
+                loaded_weight: torch.Tensor):
+        """Store w2 weight to CPU buffer (with transpose to post format)."""
+        if not self.w2_weights_cpu:
+            key = (layer_moe_idx, expert_id)
+            self._pending_weights.setdefault(key, {})["w2"] = \
+                loaded_weight.cpu().clone()
+            return
+        self.w2_weights_cpu[layer_moe_idx][expert_id].copy_(loaded_weight.cpu().t())
+
+    # ------------------------------------------------------------------ #
+    #  Scale / offset helpers (quantized models only)                     #
+    # ------------------------------------------------------------------ #
+
+    def _add_pending_scale(self, layer_moe_idx: int, expert_id: int,
+                           attr_name: str, shard_id: str,
+                           loaded_weight: torch.Tensor):
+        """Store a scale/offset weight that arrived before CPU buffers exist."""
+        key = (layer_moe_idx, expert_id)
+        sub_key = f"{attr_name}_{shard_id}"
+        self._pending_scales.setdefault(key, {})[sub_key] = \
+            loaded_weight.cpu().clone()
+
+    def maybe_create_scale_buffers(self, layer, layer_moe_idx: int):
+        """Inspect layer for scale/offset params and allocate CPU buffers.
+
+        Called from _register_offload_layers AFTER process_weights_after_loading
+        has transformed device tensor shapes, so we detect the final per-expert
+        shape from the device tensor.
+        """
+        attr_names = [
+            ("scale_cpu_buffers", "w13_weight_scale"),
+            ("scale_cpu_buffers", "w2_weight_scale"),
+            ("offset_cpu_buffers", "w13_weight_offset"),
+            ("offset_cpu_buffers", "w2_weight_offset"),
+        ]
+        created_any = False
+        global_num_experts = len(self.w13_weights_cpu[layer_moe_idx])
+
+        for buffer_dict_name, attr_name in attr_names:
+            if not hasattr(layer, attr_name):
+                continue
+            dev_tensor = getattr(layer, attr_name)
+            per_expert_shape = dev_tensor.shape[1:]
+            dtype = dev_tensor.dtype
+            buffer_dict: dict = getattr(self, buffer_dict_name)
+            if attr_name not in buffer_dict:
+                buffer_dict[attr_name] = []
+            buffers = buffer_dict[attr_name]
+            while len(buffers) <= layer_moe_idx:
+                buffers.append([])
+            for _ in range(global_num_experts):
+                buffers[layer_moe_idx].append(
+                    torch.empty(per_expert_shape, dtype=dtype, device="cpu"))
+            created_any = True
+
+        if created_any:
+            self._drain_pending_scales()
+
+    def _drain_pending_scales(self):
+        """Drain _pending_scales into CPU buffers, assembling w1/w3 shards.
+
+        Only removes entries that were successfully copied to CPU buffers.
+        Entries for layers whose buffers haven't been created yet are left
+        in _pending_scales for the next call.
+        """
+        if not self._pending_scales:
+            return
+        processed_keys: list[tuple] = []
+        for (layer_idx, eid), items in self._pending_scales.items():
+            if layer_idx >= len(self.w13_weights_cpu):
+                continue
+            if eid >= len(self.w13_weights_cpu[layer_idx]):
+                continue
+            # Group shards by attr_name
+            attr_shards: dict[str, dict[str, torch.Tensor]] = {}
+            for sub_key, w in items.items():
+                # sub_key format: "{attr_name}_{shard_id}"
+                # attr_name may contain underscores (e.g. "w13_weight_scale")
+                # shard_id is always "w1", "w2", or "w3" (no underscores)
+                parts = sub_key.rsplit("_", 1)
+                if len(parts) == 2 and parts[1] in ("w1", "w2", "w3"):
+                    attr_name, shard = parts[0], parts[1]
+                else:
+                    attr_name, shard = parts[0], parts[1] if len(parts) > 1 else ""
+                attr_shards.setdefault(attr_name, {})[shard] = w
+
+            copied_any = False
+            for attr_name, shards in attr_shards.items():
+                target_dict = None
+                if "scale" in attr_name:
+                    target_dict = self.scale_cpu_buffers
+                elif "offset" in attr_name:
+                    target_dict = self.offset_cpu_buffers
+                if target_dict is None or attr_name not in target_dict:
+                    continue
+                buffers = target_dict[attr_name]
+                if layer_idx >= len(buffers) or eid >= len(buffers[layer_idx]):
+                    continue
+                target = buffers[layer_idx][eid]
+
+                if attr_name.startswith("w13_"):
+                    # w13 scale/offset: assemble w1 + w3 shards along dim 0
+                    if "w1" in shards and "w3" in shards:
+                        assembled = torch.cat(
+                            [shards["w1"].cpu(), shards["w3"].cpu()], dim=0)
+                        # squeeze trailing dim-1 if present (W8A8_DYNAMIC)
+                        assembled = assembled.reshape(target.shape)
+                        target.copy_(assembled)
+                        copied_any = True
+                elif attr_name.startswith("w2_"):
+                    # w2 scale/offset: single shard
+                    if "w2" in shards:
+                        w_cpu = shards["w2"]
+                        if w_cpu.device.type != "cpu":
+                            w_cpu = w_cpu.cpu()
+                        w_cpu = w_cpu.reshape(target.shape)
+                        target.copy_(w_cpu)
+                        copied_any = True
+            if copied_any:
+                processed_keys.append((layer_idx, eid))
+        # Only remove successfully processed entries
+        for key in processed_keys:
+            del self._pending_scales[key]
+
+    def init_device_experts(self):
+        """Refresh derived fp32 scale after weight loading.
+
+        Device experts are already loaded by the weight loader and
+        process_weights_after_loading. Only refresh w13_weight_scale_fp32.
+        """
+        for i, layer in enumerate(self.moe_layers):
+            ndev = min(self.num_device_experts, layer.w13_weight.shape[0])
+            if hasattr(layer, 'w13_weight_scale_fp32'):
+                for j in range(ndev):
+                    layer.w13_weight_scale_fp32[j].copy_(
+                        layer.w13_weight_scale.data[j].to(torch.float32))
+
+    def create_prefill_pool(self):
+        """Allocate prefill pool tensors on NPU with full expert count.
+
+        Called from _register_offload_layers after decode buffers are set up.
+        Creates ndl device tensors each holding all experts (e.g. 128).
+        These are used when num_tokens > offload_threshold (large-batch
+        prefill), loaded via full-overwrite in _prefill_load_layer.
+        """
+        if self._prefill_initialized:
+            return
+        if not self.moe_layers:
+            return
+        ndl = self.num_device_layers
+        pool_layer = self.moe_layers[0]
+        dev = pool_layer.w13_weight.device
+        dt = pool_layer.w13_weight.dtype
+        ntotal = self.num_total_experts
+
+        for _ in range(ndl):
+            # w13: [ntotal, hidden_size, w13_up_dim] — match decode layer shape
+            w13_shape = (ntotal,) + tuple(pool_layer.w13_weight.shape[1:])
+            self._prefill_w13.append(
+                torch.empty(w13_shape, dtype=dt, device=dev))
+
+            # w2: [ntotal, hidden_size, intermediate_size_per_partition]
+            w2_shape = (ntotal,) + tuple(pool_layer.w2_weight.shape[1:])
+            self._prefill_w2.append(
+                torch.empty(w2_shape, dtype=dt, device=dev))
+
+            # W8A8 scale/offset (optional)
+            if hasattr(pool_layer, 'w13_weight_scale'):
+                s13_shape = (ntotal,) + tuple(pool_layer.w13_weight_scale.shape[1:])
+                self._prefill_w13_scale.append(
+                    torch.empty(s13_shape, dtype=pool_layer.w13_weight_scale.dtype, device=dev))
+            if hasattr(pool_layer, 'w13_weight_scale_fp32'):
+                fp32_13_shape = (ntotal,) + tuple(pool_layer.w13_weight_scale_fp32.shape[1:])
+                self._prefill_w13_scale_fp32.append(
+                    torch.empty(fp32_13_shape, dtype=torch.float32, device=dev))
+            if hasattr(pool_layer, 'w13_weight_offset'):
+                o13_shape = (ntotal,) + tuple(pool_layer.w13_weight_offset.shape[1:])
+                self._prefill_w13_offset.append(
+                    torch.empty(o13_shape, dtype=pool_layer.w13_weight_offset.dtype, device=dev))
+            if hasattr(pool_layer, 'w2_weight_scale'):
+                s2_shape = (ntotal,) + tuple(pool_layer.w2_weight_scale.shape[1:])
+                self._prefill_w2_scale.append(
+                    torch.empty(s2_shape, dtype=pool_layer.w2_weight_scale.dtype, device=dev))
+            if hasattr(pool_layer, 'w2_weight_offset'):
+                o2_shape = (ntotal,) + tuple(pool_layer.w2_weight_offset.shape[1:])
+                self._prefill_w2_offset.append(
+                    torch.empty(o2_shape, dtype=pool_layer.w2_weight_offset.dtype, device=dev))
+
+        # Cast prefill pool weight tensors to NZ format (W8A8 kernel requires it).
+        # Must happen BEFORE loading data — same order as decode path:
+        # create → NZ-cast → copy_(cpu → npu)
+        if dt == torch.int8:
+            from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ
+            for i in range(ndl):
+                self._prefill_w13[i] = torch_npu.npu_format_cast(
+                    self._prefill_w13[i], ACL_FORMAT_FRACTAL_NZ)
+                self._prefill_w2[i] = torch_npu.npu_format_cast(
+                    self._prefill_w2[i], ACL_FORMAT_FRACTAL_NZ)
+
+        # Prefill log2phy: identity — all experts mapped to their slots
+        self._prefill_log2phy = torch.arange(ntotal, dtype=torch.int32, device=dev)
+
+        # Pre-initialize all pool slots with layer 0 weights so that
+        # profile_run / _dummy_run (which may use prefill path) has
+        # valid data.  Subsequent _prefill_load_layer calls will
+        # overwrite with the correct per-layer weights.
+        self._init_prefill_pool_data(dev, ntotal, ndl)
+        self._prefill_initialized = True
+        logger.warning("[PREFILL_POOL] allocated %d layers × %d experts, "
+                       "w13[0].shape=%s w2[0].shape=%s",
+                       ndl, ntotal,
+                       tuple(self._prefill_w13[0].shape),
+                       tuple(self._prefill_w2[0].shape))
+
+    def _init_prefill_pool_data(self, dev, ntotal: int, ndl: int):
+        """Load layer 0 weights into all prefill pool slots.
+
+        Prefill pool tensors are already NZ-cast at this point (done in
+        create_prefill_pool). Use simple per-expert copy_() — same pattern
+        as the decode path's _update_weights.
+        """
+        has_scales = bool(self._prefill_w13_scale)
+        has_offsets = bool(self._prefill_w13_offset)
+
+        for slot in range(ndl):
+            for eid in range(min(ntotal, len(self.w13_weights_cpu[0]))):
+                self._prefill_w13[slot][eid].copy_(
+                    self.w13_weights_cpu[0][eid].to(dev))
+                self._prefill_w2[slot][eid].copy_(
+                    self.w2_weights_cpu[0][eid].to(dev))
+
+            # Initialize scale/offset buffers with layer 0 data (W8A8)
+            if has_scales:
+                for scale_name, prefill_list, cpu_buffers in [
+                    ("w13_weight_scale", self._prefill_w13_scale, self.scale_cpu_buffers),
+                    ("w2_weight_scale", self._prefill_w2_scale, self.scale_cpu_buffers),
+                ]:
+                    if (scale_name in cpu_buffers and
+                            0 < len(cpu_buffers[scale_name])):
+                        for eid in range(min(ntotal, len(cpu_buffers[scale_name][0]))):
+                            prefill_list[slot][eid].copy_(
+                                cpu_buffers[scale_name][0][eid].to(dev))
+            if has_offsets:
+                for offset_name, prefill_list, cpu_buffers in [
+                    ("w13_weight_offset", self._prefill_w13_offset, self.offset_cpu_buffers),
+                    ("w2_weight_offset", self._prefill_w2_offset, self.offset_cpu_buffers),
+                ]:
+                    if (offset_name in cpu_buffers and
+                            0 < len(cpu_buffers[offset_name])):
+                        for eid in range(min(ntotal, len(cpu_buffers[offset_name][0]))):
+                            prefill_list[slot][eid].copy_(
+                                cpu_buffers[offset_name][0][eid].to(dev))
+            # Initialize fp32 scale (convert from scale)
+            if has_scales and slot < len(self._prefill_w13_scale_fp32):
+                for eid in range(min(ntotal, self._prefill_w13_scale[slot].shape[0])):
+                    self._prefill_w13_scale_fp32[slot][eid].copy_(
+                        self._prefill_w13_scale[slot][eid].to(torch.float32))
+
+    def _prefill_load_layer(self, layer_idx: int, log2phy: torch.Tensor):
+        """Load ALL experts for model layer layer_idx into the prefill pool.
+
+        For W8A8: loads into normal-format scratch, then casts to NZ.
+        For unquantized: loads directly into pool tensors via copy_().
+        Full-overwrite into pool_slot = layer_idx % ndl.  No slot_owner
+        tracking needed — log2phy is set to identity for prefill.
+        """
+        ndl = self.num_device_layers
+        pool_slot = layer_idx % ndl
+        dev = self._prefill_w13[pool_slot].device
+        ntotal = self.num_total_experts
+        is_w8a8 = self._prefill_w13[pool_slot].dtype == torch.int8
+
+        import logging
+        _dbg = logging.getLogger(__name__)
+        _dbg.warning("[PREFILL_LOAD] layer=%d pool_slot=%d ntotal=%d is_w8a8=%s",
+                     layer_idx, pool_slot, ntotal, is_w8a8)
+
+        from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ
+
+        with torch_npu.npu.stream(self.load_stream):
+            for eid in range(ntotal):
+                self._prefill_w13[pool_slot][eid].copy_(
+                    self.w13_weights_cpu[layer_idx][eid].to(dev))
+                self._prefill_w2[pool_slot][eid].copy_(
+                    self.w2_weights_cpu[layer_idx][eid].to(dev))
+
+            # W8A8 scale/offset — load into prefill buffers
+            for scale_name, prefill_list, cpu_buffers in [
+                ("w13_weight_scale", self._prefill_w13_scale, self.scale_cpu_buffers),
+                ("w2_weight_scale", self._prefill_w2_scale, self.scale_cpu_buffers),
+            ]:
+                if pool_slot < len(prefill_list):
+                    if (scale_name in cpu_buffers and
+                            layer_idx < len(cpu_buffers[scale_name])):
+                        for eid in range(min(ntotal, len(cpu_buffers[scale_name][layer_idx]))):
+                            prefill_list[pool_slot][eid].copy_(
+                                cpu_buffers[scale_name][layer_idx][eid].to(dev))
+            for offset_name, prefill_list, cpu_buffers in [
+                ("w13_weight_offset", self._prefill_w13_offset, self.offset_cpu_buffers),
+                ("w2_weight_offset", self._prefill_w2_offset, self.offset_cpu_buffers),
+            ]:
+                if pool_slot < len(prefill_list):
+                    if (offset_name in cpu_buffers and
+                            layer_idx < len(cpu_buffers[offset_name])):
+                        for eid in range(min(ntotal, len(cpu_buffers[offset_name][layer_idx]))):
+                            prefill_list[pool_slot][eid].copy_(
+                                cpu_buffers[offset_name][layer_idx][eid].to(dev))
+
+            # Refresh fp32 scale for prefill pool
+            if (pool_slot < len(self._prefill_w13_scale_fp32) and
+                    pool_slot < len(self._prefill_w13_scale)):
+                # Copy scale data from freshly loaded scale to fp32
+                for eid in range(min(ntotal, self._prefill_w13_scale[pool_slot].shape[0])):
+                    self._prefill_w13_scale_fp32[pool_slot][eid].copy_(
+                        self._prefill_w13_scale[pool_slot][eid].to(torch.float32))
+
+            self.load_stream.synchronize()
+
+        # NOTE: Do NOT modify the layer's own log2phy here — decode path
+        # relies on it staying with 32-expert mapping.  Prefill path in
+        # apply() explicitly uses self._prefill_log2phy instead.
+
+    # ------------------------------------------------------------------ #
+    #  Forward path: page in experts based on topk_ids                    #
+    # ------------------------------------------------------------------ #
+
+    def update_weights(self, layer, topk_ids: torch.Tensor,
+                        log2phy: torch.Tensor) -> int:
+        """Incrementally page in needed experts, overwriting unused slots.
+
+        Routes to prefill pool (full-overwrite) when num_tokens exceeds
+        offload_threshold, otherwise uses per-expert paging (decode path).
+
+        Args:
+            layer: AscendFusedMoE instance.
+            topk_ids: [num_tokens, top_k] routed expert indices.
+            log2phy: [global_num_experts] CPU tensor, modified in-place.
+
+        Returns: number of CPU→NPU copies performed (decode path),
+                 0 for prefill path (full-overwrite via pool).
+        """
+        num_tokens = topk_ids.size(0)
+        if num_tokens > self.offload_threshold:
+            # Prefill: layerwise reuse + full-overwrite of all experts
+            if (self._prefill_initialized
+                    and not self._skip_prefill):
+                try:
+                    layer_idx = self.moe_layers.index(layer)
+                except ValueError:
+                    return 0
+                self._prefill_load_layer(layer_idx, log2phy)
+                return 0
+            else:
+                # Profile run or pool not ready — bail out gracefully
+                return 0
+
+        try:
+            layer_idx = self.moe_layers.index(layer)
+        except ValueError:
+            return 0
+
+        topk_ids_h = self.topk_ids_h[:num_tokens]
+        log2phy_h = self.log2phy_h
+        log2phy_np = self.log2phy_np
+        topk_ids_h.copy_(topk_ids, non_blocking=_EXTRA_CTX.capturing)
+        log2phy_h.copy_(log2phy, non_blocking=_EXTRA_CTX.capturing)
+
+        current_compute_stream = torch_npu.npu.current_stream()
+        subscribed_compute_streams = get_subscribed_compute_streams()
+        if current_compute_stream not in subscribed_compute_streams:
+            torch_npu.npu._subscribe_report(current_compute_stream)
+            subscribed_compute_streams.add(current_compute_stream)
+
+        args = (
+            topk_ids_h,
+            log2phy_np,
+            layer,
+            layer_idx,
+        )
+        if _EXTRA_CTX.capturing:
+            torch_npu.npu._launch_host_func(
+                current_compute_stream,
+                self._update_weights,
+                args,
+            )
+        else:
+            self._update_weights(args)
+
+        log2phy.copy_(log2phy_h, non_blocking=_EXTRA_CTX.capturing)
+    
+    def _update_weights(self, args):
+        (
+            topk_ids_h,
+            log2phy_np,
+            layer,
+            layer_idx,
+        ) = args
+        with torch_npu.npu.stream(self.load_stream):
+            unique_experts = topk_ids_h.unique().tolist()
+            needed = set(unique_experts)
+
+            # Build reverse map: slot → expert_id currently occupying it
+            slot_owner: dict[int, int] = {}
+            for eid, slot in enumerate(log2phy_np):
+                if slot >= 0:
+                    slot_owner[slot] = eid
+
+            on_device = set(slot_owner.values())
+            already_there = needed & on_device           # no-op
+            need_to_load = needed - already_there          # CPU→NPU copy
+            reusable_slots = [s for s, e in slot_owner.items()
+                            if e not in needed]          # slots to recycle
+
+            # Debug: print routing info for first 30 calls
+            if not hasattr(self, '_dbg_call'):
+                self._dbg_call = 0
+            if self._dbg_call < 10000:
+                import logging
+                _dbg = logging.getLogger(__name__)
+                _dbg.warning("[UPDATE-W] l=%d call=%d topk_shape=%s |needed|=%d |on_dev|=%d |to_load|=%d reusable=%d needed=%s",
+                            layer_idx, self._dbg_call, tuple(topk_ids_h.shape),
+                            len(needed), len(on_device),
+                            len(need_to_load), len(reusable_slots),
+                            sorted(needed)[:30])
+                if need_to_load and len(need_to_load) > len(reusable_slots):
+                    _dbg.warning("[UPDATE-W] l=%d SHORTFALL: need %d load but only %d slots, to_load=%s",
+                                layer_idx, len(need_to_load), len(reusable_slots),
+                                sorted(need_to_load)[:20])
+                self._dbg_call += 1
+
+            dev = layer.w13_weight.device
+            n_copies = 0
+            for eid in need_to_load:
+                if not reusable_slots:
+                    import logging
+                    logging.getLogger(__name__).warning(
+                        "[UPDATE-W] l=%d NO SLOTS: %d experts could not be loaded, missed=%s",
+                        layer_idx, len(need_to_load) - n_copies,
+                        sorted(list(need_to_load))[n_copies:][:20])
+                    break  # no free slots — should not happen in normal usage
+                slot = reusable_slots.pop()
+                # Copy weights from CPU to NPU
+                # TODO remove the to(dev) leads to wrong accuracy, weird, need to check why.
+                layer.w13_weight.data[slot].copy_(
+                    self.w13_weights_cpu[layer_idx][eid].to(dev))
+                layer.w2_weight.data[slot].copy_(
+                    self.w2_weights_cpu[layer_idx][eid].to(dev))
+                # Copy scales/offsets from CPU to NPU
+                for attr_name, buffers in self.scale_cpu_buffers.items():
+                    if layer_idx >= len(buffers) or eid >= len(buffers[layer_idx]):
+                        continue
+                    dev_tensor = getattr(layer, attr_name, None)
+                    if dev_tensor is None:
+                        continue
+                    dev_tensor.data[slot].copy_(buffers[layer_idx][eid].to(dev))
+                for attr_name, buffers in self.offset_cpu_buffers.items():
+                    if layer_idx >= len(buffers) or eid >= len(buffers[layer_idx]):
+                        continue
+                    dev_tensor = getattr(layer, attr_name, None)
+                    if dev_tensor is None:
+                        continue
+                    dev_tensor.data[slot].copy_(buffers[layer_idx][eid].to(dev))
+                # Refresh derived fp32 scale if present (W8A8_DYNAMIC)
+                if hasattr(layer, 'w13_weight_scale_fp32'):
+                    layer.w13_weight_scale_fp32[slot].copy_(
+                        layer.w13_weight_scale.data[slot].to(torch.float32))
+                # Update mapping
+                log2phy_np[slot_owner[slot]] = -1   # evict old occupant
+                log2phy_np[eid] = slot               # assign slot to new expert
+                slot_owner[slot] = eid
+                n_copies += 1
+
+            self.load_stream.synchronize()
+
+    # ------------------------------------------------------------------ #
+    #  Internal helpers                                                    #
+    # ------------------------------------------------------------------ #
+
+    def _drain_pending_weights(self):
+        if not self._pending_weights:
+            return
+        for (layer_idx, eid), weights in self._pending_weights.items():
+            if layer_idx >= len(self.w13_weights_cpu):
+                continue
+            if eid >= len(self.w13_weights_cpu[layer_idx]):
+                continue
+            cpu_w13 = self.w13_weights_cpu[layer_idx][eid]
+            intermed = cpu_w13.shape[1] // 2
+            for key, w in weights.items():
+                w_cpu = w if w.device.type == "cpu" else w.cpu()
+                if key.startswith("w13_"):
+                    shard = key.split("_")[1]
+                    if shard == "w1":
+                        cpu_w13[:, :intermed].copy_(w_cpu.t())
+                    elif shard == "w3":
+                        cpu_w13[:, intermed: intermed + w_cpu.shape[0]].copy_(w_cpu.t())
+                elif key == "w2":
+                    self.w2_weights_cpu[layer_idx][eid].copy_(w_cpu.t())
+        self._pending_weights.clear()
+
+
+_EXPERT_OFFLOAD_MANAGER: ExpertOffloadManager = None
+
+
+def maybe_init_expert_offload_manager(vllm_config: VllmConfig):
+    # if no need to init offload manager:
+    #     return
+    global _EXPERT_OFFLOAD_MANAGER
+    if _EXPERT_OFFLOAD_MANAGER is None:
+        _EXPERT_OFFLOAD_MANAGER = ExpertOffloadManager(vllm_config)
+
+
+def has_expert_offload_manager():
+    return _EXPERT_OFFLOAD_MANAGER is not None
+
+
+def get_expert_offload_manager():
+    assert _EXPERT_OFFLOAD_MANAGER is not None, (
+        "Expert Offload Manager is not initialized"
+    )
+    return _EXPERT_OFFLOAD_MANAGER

--- a/vllm_ascend/expert_offload/expert_offload_manager.py
+++ b/vllm_ascend/expert_offload/expert_offload_manager.py
@@ -6,6 +6,7 @@ from vllm.config import VllmConfig
 from vllm.logger import logger
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ
 
 
 _SUBSCRIBED_COMPUTE_STREAMS = set()
@@ -93,17 +94,18 @@ class ExpertOffloadManager:
         """Allocate CPU buffers for all MoE layers."""
         for _ in range(num_moe_layers):
             w13_list = [
-                torch.empty(hidden_size, w13_up_dim, dtype=params_dtype, device="cpu")
+                torch.empty(hidden_size, w13_up_dim, dtype=params_dtype, device="cpu", pin_memory=True)
                 for _ in range(num_total_experts)
             ]
             w2_list = [
                 torch.empty(intermediate_size_per_partition, hidden_size,
-                            dtype=params_dtype, device="cpu")
+                            dtype=params_dtype, device="cpu", pin_memory=True)
                 for _ in range(num_total_experts)
             ]
             self.w13_weights_cpu.append(w13_list)
             self.w2_weights_cpu.append(w2_list)
         self._drain_pending_weights()
+        self.process_weights_after_loading()
 
         self.num_total_experts = num_total_experts
 
@@ -111,6 +113,34 @@ class ExpertOffloadManager:
         self.topk_ids_h = torch.zeros([self.offload_threshold, self.topk], dtype=torch.int32, device='cpu', pin_memory=True)
         self.log2phy_h = torch.zeros(num_total_experts, dtype=torch.int32, device='cpu', pin_memory=True)
         self.log2phy_np = self.log2phy_h.numpy()
+
+    def process_weights_after_loading(self):
+        first_w13 = self.w13_weights_cpu[0][0]
+        first_w2 = self.w2_weights_cpu[0][0]
+        if first_w13.dtype != torch.int8:
+            return
+        # for w8a8, npu weight tensor is cast to NZ format,
+        # so we also store NZ format weight in weights_cpu,
+        # and copy_ tensor's underlying storage instead of tensor itself
+        # to avoid implicit format conversion during h2d.
+        num_moe_layers = len(self.w13_weights_cpu)
+        num_experts = len(self.w13_weights_cpu[0])
+        self.w13_element_num = first_w13.nelement()
+        self.w2_element_num = first_w2.nelement()
+        for layer_id in range(num_moe_layers):
+            w13 = torch.stack(self.w13_weights_cpu[layer_id]).to('npu')
+            w13_nz = torch_npu.npu_format_cast(w13, ACL_FORMAT_FRACTAL_NZ)
+            w13_nz_storage = w13_nz.untyped_storage()
+            w2 = torch.stack(self.w2_weights_cpu[layer_id]).to('npu')
+            w2_nz = torch_npu.npu_format_cast(w2, ACL_FORMAT_FRACTAL_NZ)
+            w2_nz_storage = w2_nz.untyped_storage()
+            for expert_id in range(num_experts):
+                self.w13_weights_cpu[layer_id][expert_id].untyped_storage().copy_(
+                    w13_nz_storage[expert_id * self.w13_element_num : (expert_id + 1) * self.w13_element_num]
+                )
+                self.w2_weights_cpu[layer_id][expert_id].untyped_storage().copy_(
+                    w2_nz_storage[expert_id * self.w2_element_num : (expert_id + 1) * self.w2_element_num]
+                )
 
     def register_moe_layer(self, layer):
         self.moe_layers.append(layer)
@@ -184,7 +214,7 @@ class ExpertOffloadManager:
                 buffers.append([])
             for _ in range(global_num_experts):
                 buffers[layer_moe_idx].append(
-                    torch.empty(per_expert_shape, dtype=dtype, device="cpu"))
+                    torch.empty(per_expert_shape, dtype=dtype, device="cpu", pin_memory=True))
             created_any = True
 
         if created_any:
@@ -358,10 +388,12 @@ class ExpertOffloadManager:
 
         for slot in range(ndl):
             for eid in range(min(ntotal, len(self.w13_weights_cpu[0]))):
-                self._prefill_w13[slot][eid].copy_(
-                    self.w13_weights_cpu[0][eid].to(dev))
-                self._prefill_w2[slot][eid].copy_(
-                    self.w2_weights_cpu[0][eid].to(dev))
+                self._prefill_w13[slot].untyped_storage()[eid * self.w13_element_num : (eid + 1) * self.w13_element_num].copy_(
+                    self.w13_weights_cpu[0][eid].untyped_storage()
+                )
+                self._prefill_w2[slot].untyped_storage()[eid * self.w2_element_num : (eid + 1) * self.w2_element_num].copy_(
+                    self.w2_weights_cpu[0][eid].untyped_storage()
+                )
 
             # Initialize scale/offset buffers with layer 0 data (W8A8)
             if has_scales:
@@ -373,7 +405,7 @@ class ExpertOffloadManager:
                             0 < len(cpu_buffers[scale_name])):
                         for eid in range(min(ntotal, len(cpu_buffers[scale_name][0]))):
                             prefill_list[slot][eid].copy_(
-                                cpu_buffers[scale_name][0][eid].to(dev))
+                                cpu_buffers[scale_name][0][eid])
             if has_offsets:
                 for offset_name, prefill_list, cpu_buffers in [
                     ("w13_weight_offset", self._prefill_w13_offset, self.offset_cpu_buffers),
@@ -383,7 +415,7 @@ class ExpertOffloadManager:
                             0 < len(cpu_buffers[offset_name])):
                         for eid in range(min(ntotal, len(cpu_buffers[offset_name][0]))):
                             prefill_list[slot][eid].copy_(
-                                cpu_buffers[offset_name][0][eid].to(dev))
+                                cpu_buffers[offset_name][0][eid])
             # Initialize fp32 scale (convert from scale)
             if has_scales and slot < len(self._prefill_w13_scale_fp32):
                 for eid in range(min(ntotal, self._prefill_w13_scale[slot].shape[0])):
@@ -413,10 +445,12 @@ class ExpertOffloadManager:
 
         with torch_npu.npu.stream(self.load_stream):
             for eid in range(ntotal):
-                self._prefill_w13[pool_slot][eid].copy_(
-                    self.w13_weights_cpu[layer_idx][eid].to(dev))
-                self._prefill_w2[pool_slot][eid].copy_(
-                    self.w2_weights_cpu[layer_idx][eid].to(dev))
+                self._prefill_w13[pool_slot].untyped_storage()[eid * self.w13_element_num : (eid + 1) * self.w13_element_num].copy_(
+                    self.w13_weights_cpu[layer_idx][eid].untyped_storage()
+                )
+                self._prefill_w2[pool_slot].untyped_storage()[eid * self.w2_element_num : (eid + 1) * self.w2_element_num].copy_(
+                    self.w2_weights_cpu[layer_idx][eid].untyped_storage()
+                )
 
             # W8A8 scale/offset — load into prefill buffers
             for scale_name, prefill_list, cpu_buffers in [
@@ -428,7 +462,7 @@ class ExpertOffloadManager:
                             layer_idx < len(cpu_buffers[scale_name])):
                         for eid in range(min(ntotal, len(cpu_buffers[scale_name][layer_idx]))):
                             prefill_list[pool_slot][eid].copy_(
-                                cpu_buffers[scale_name][layer_idx][eid].to(dev))
+                                cpu_buffers[scale_name][layer_idx][eid])
             for offset_name, prefill_list, cpu_buffers in [
                 ("w13_weight_offset", self._prefill_w13_offset, self.offset_cpu_buffers),
                 ("w2_weight_offset", self._prefill_w2_offset, self.offset_cpu_buffers),
@@ -438,7 +472,7 @@ class ExpertOffloadManager:
                             layer_idx < len(cpu_buffers[offset_name])):
                         for eid in range(min(ntotal, len(cpu_buffers[offset_name][layer_idx]))):
                             prefill_list[pool_slot][eid].copy_(
-                                cpu_buffers[offset_name][layer_idx][eid].to(dev))
+                                cpu_buffers[offset_name][layer_idx][eid])
 
             # Refresh fp32 scale for prefill pool
             if (pool_slot < len(self._prefill_w13_scale_fp32) and
@@ -574,11 +608,12 @@ class ExpertOffloadManager:
                     break  # no free slots — should not happen in normal usage
                 slot = reusable_slots.pop()
                 # Copy weights from CPU to NPU
-                # TODO remove the to(dev) leads to wrong accuracy, weird, need to check why.
-                layer.w13_weight.data[slot].copy_(
-                    self.w13_weights_cpu[layer_idx][eid].to(dev))
-                layer.w2_weight.data[slot].copy_(
-                    self.w2_weights_cpu[layer_idx][eid].to(dev))
+                layer.w13_weight.data.untyped_storage()[slot * self.w13_element_num : (slot + 1) * self.w13_element_num].copy_(
+                    self.w13_weights_cpu[layer_idx][eid].untyped_storage()
+                )
+                layer.w2_weight.data.untyped_storage()[slot * self.w2_element_num : (slot + 1) * self.w2_element_num].copy_(
+                    self.w2_weights_cpu[layer_idx][eid].untyped_storage()
+                )
                 # Copy scales/offsets from CPU to NPU
                 for attr_name, buffers in self.scale_cpu_buffers.items():
                     if layer_idx >= len(buffers) or eid >= len(buffers[layer_idx]):
@@ -586,14 +621,14 @@ class ExpertOffloadManager:
                     dev_tensor = getattr(layer, attr_name, None)
                     if dev_tensor is None:
                         continue
-                    dev_tensor.data[slot].copy_(buffers[layer_idx][eid].to(dev))
+                    dev_tensor.data[slot].copy_(buffers[layer_idx][eid])
                 for attr_name, buffers in self.offset_cpu_buffers.items():
                     if layer_idx >= len(buffers) or eid >= len(buffers[layer_idx]):
                         continue
                     dev_tensor = getattr(layer, attr_name, None)
                     if dev_tensor is None:
                         continue
-                    dev_tensor.data[slot].copy_(buffers[layer_idx][eid].to(dev))
+                    dev_tensor.data[slot].copy_(buffers[layer_idx][eid])
                 # Refresh derived fp32 scale if present (W8A8_DYNAMIC)
                 if hasattr(layer, 'w13_weight_scale_fp32'):
                     layer.w13_weight_scale_fp32[slot].copy_(

--- a/vllm_ascend/expert_offload/expert_offload_manager.py
+++ b/vllm_ascend/expert_offload/expert_offload_manager.py
@@ -6,6 +6,7 @@ from vllm.config import VllmConfig
 from vllm.logger import logger
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.expert_offload.lrc_policy import LRCExpertCachePolicy
 
 
 _SUBSCRIBED_COMPUTE_STREAMS = set()
@@ -60,6 +61,14 @@ class ExpertOffloadManager:
 
         self.num_device_layers = self.offload_config.num_device_layers
         self.num_total_experts = None  # set in create_weights
+        self.cache_policy: LRCExpertCachePolicy | None = None
+        self.cache_requests: list[int] = []
+        self.cache_hits: list[int] = []
+        self.cache_misses: list[int] = []
+        self.cache_calls: list[int] = []
+        self.last_hit_experts: list[list[int]] = []
+        self.last_miss_experts: list[list[int]] = []
+        self._debug_update_weights = self.offload_config.cache_debug_log_updates
 
         ExpertOffloadManager._instance = self
 
@@ -106,9 +115,39 @@ class ExpertOffloadManager:
         self._drain_pending_weights()
 
         self.num_total_experts = num_total_experts
+        if self.offload_config.cache_policy_enabled:
+            self.cache_requests = [0 for _ in range(num_moe_layers)]
+            self.cache_hits = [0 for _ in range(num_moe_layers)]
+            self.cache_misses = [0 for _ in range(num_moe_layers)]
+            self.cache_calls = [0 for _ in range(num_moe_layers)]
+            self.last_hit_experts = [[] for _ in range(num_moe_layers)]
+            self.last_miss_experts = [[] for _ in range(num_moe_layers)]
+            self.cache_policy = LRCExpertCachePolicy(
+                num_layers=num_moe_layers,
+                num_experts=num_total_experts,
+                cache_size=self.num_device_experts,
+                topk=self.topk,
+                recent_window=self.offload_config.cache_recent_window,
+                ema_beta=self.offload_config.cache_ema_beta,
+                recent_weight=self.offload_config.cache_recent_weight,
+                ema_weight=self.offload_config.cache_ema_weight,
+                router_weight=self.offload_config.cache_router_weight,
+                age_weight=self.offload_config.cache_age_weight,
+            )
 
         # update weights related buffers
-        self.topk_ids_h = torch.zeros([self.offload_threshold, self.topk], dtype=torch.int32, device='cpu', pin_memory=True)
+        self.topk_ids_h = torch.zeros(
+            [self.offload_threshold, self.topk],
+            dtype=torch.int32,
+            device="cpu",
+            pin_memory=True,
+        )
+        self.topk_weights_h = torch.zeros(
+            [self.offload_threshold, self.topk],
+            dtype=torch.float32,
+            device="cpu",
+            pin_memory=True,
+        )
         self.log2phy_h = torch.zeros(num_total_experts, dtype=torch.int32, device='cpu', pin_memory=True)
         self.log2phy_np = self.log2phy_h.numpy()
 
@@ -459,7 +498,8 @@ class ExpertOffloadManager:
     # ------------------------------------------------------------------ #
 
     def update_weights(self, layer, topk_ids: torch.Tensor,
-                        log2phy: torch.Tensor) -> int:
+                        log2phy: torch.Tensor,
+                        topk_weights: torch.Tensor | None = None) -> int:
         """Incrementally page in needed experts, overwriting unused slots.
 
         Routes to prefill pool (full-overwrite) when num_tokens exceeds
@@ -494,6 +534,11 @@ class ExpertOffloadManager:
             return 0
 
         topk_ids_h = self.topk_ids_h[:num_tokens]
+        topk_weights_h = None
+        if (self.cache_policy is not None and topk_weights is not None and not _EXTRA_CTX.capturing
+                and self.offload_config.cache_router_weight != 0):
+            topk_weights_h = self.topk_weights_h[:num_tokens]
+            topk_weights_h.copy_(topk_weights.to(dtype=torch.float32), non_blocking=False)
         log2phy_h = self.log2phy_h
         log2phy_np = self.log2phy_np
         topk_ids_h.copy_(topk_ids, non_blocking=_EXTRA_CTX.capturing)
@@ -510,6 +555,7 @@ class ExpertOffloadManager:
             log2phy_np,
             layer,
             layer_idx,
+            topk_weights_h,
         )
         if _EXTRA_CTX.capturing:
             torch_npu.npu._launch_host_func(
@@ -528,10 +574,18 @@ class ExpertOffloadManager:
             log2phy_np,
             layer,
             layer_idx,
+            topk_weights_h,
         ) = args
         with torch_npu.npu.stream(self.load_stream):
-            unique_experts = topk_ids_h.unique().tolist()
-            needed = set(unique_experts)
+            if self.cache_policy is not None:
+                router_scores = topk_weights_h.tolist() if topk_weights_h is not None else None
+                needed = self.cache_policy.observe(
+                    layer_idx,
+                    topk_ids_h.tolist(),
+                    router_scores=router_scores,
+                )
+            else:
+                needed = set(topk_ids_h.unique().tolist())
 
             # Build reverse map: slot → expert_id currently occupying it
             slot_owner: dict[int, int] = {}
@@ -542,37 +596,53 @@ class ExpertOffloadManager:
             on_device = set(slot_owner.values())
             already_there = needed & on_device           # no-op
             need_to_load = needed - already_there          # CPU→NPU copy
+            if self.cache_policy is not None:
+                self._record_cache_stats(layer_idx, already_there, need_to_load, needed, on_device)
             reusable_slots = [s for s, e in slot_owner.items()
                             if e not in needed]          # slots to recycle
 
-            # Debug: print routing info for first 30 calls
-            if not hasattr(self, '_dbg_call'):
-                self._dbg_call = 0
-            if self._dbg_call < 10000:
+            if self.cache_policy is not None and self._debug_update_weights:
                 import logging
                 _dbg = logging.getLogger(__name__)
-                _dbg.warning("[UPDATE-W] l=%d call=%d topk_shape=%s |needed|=%d |on_dev|=%d |to_load|=%d reusable=%d needed=%s",
-                            layer_idx, self._dbg_call, tuple(topk_ids_h.shape),
-                            len(needed), len(on_device),
-                            len(need_to_load), len(reusable_slots),
-                            sorted(needed)[:30])
+                _dbg.warning(
+                    "[UPDATE-W] l=%d call=%d topk_shape=%s |needed|=%d |on_dev|=%d "
+                    "|to_load|=%d reusable=%d needed=%s",
+                    layer_idx, self.cache_calls[layer_idx], tuple(topk_ids_h.shape),
+                    len(needed), len(on_device),
+                    len(need_to_load), len(reusable_slots),
+                    sorted(needed)[:30],
+                )
+                _dbg.warning("[UPDATE-W] l=%d cache_hit=%s cache_miss=%s",
+                             layer_idx, sorted(already_there), sorted(need_to_load))
                 if need_to_load and len(need_to_load) > len(reusable_slots):
                     _dbg.warning("[UPDATE-W] l=%d SHORTFALL: need %d load but only %d slots, to_load=%s",
                                 layer_idx, len(need_to_load), len(reusable_slots),
                                 sorted(need_to_load)[:20])
-                self._dbg_call += 1
 
             dev = layer.w13_weight.device
             n_copies = 0
             for eid in need_to_load:
-                if not reusable_slots:
+                if self.cache_policy is not None:
+                    victim = self.cache_policy.choose_victim(
+                        layer_idx,
+                        slot_owner,
+                        protected=needed,
+                    )
+                    slot = int(log2phy_np[victim]) if victim is not None else -1
+                elif reusable_slots:
+                    slot = reusable_slots.pop()
+                    victim = slot_owner[slot]
+                else:
+                    slot = -1
+                    victim = None
+
+                if slot < 0:
                     import logging
                     logging.getLogger(__name__).warning(
                         "[UPDATE-W] l=%d NO SLOTS: %d experts could not be loaded, missed=%s",
                         layer_idx, len(need_to_load) - n_copies,
                         sorted(list(need_to_load))[n_copies:][:20])
                     break  # no free slots — should not happen in normal usage
-                slot = reusable_slots.pop()
                 # Copy weights from CPU to NPU
                 # TODO remove the to(dev) leads to wrong accuracy, weird, need to check why.
                 layer.w13_weight.data[slot].copy_(
@@ -599,9 +669,13 @@ class ExpertOffloadManager:
                     layer.w13_weight_scale_fp32[slot].copy_(
                         layer.w13_weight_scale.data[slot].to(torch.float32))
                 # Update mapping
-                log2phy_np[slot_owner[slot]] = -1   # evict old occupant
+                if victim is None:
+                    victim = slot_owner[slot]
+                log2phy_np[victim] = -1             # evict old occupant
                 log2phy_np[eid] = slot               # assign slot to new expert
                 slot_owner[slot] = eid
+                if slot in reusable_slots:
+                    reusable_slots.remove(slot)
                 n_copies += 1
 
             self.load_stream.synchronize()
@@ -609,6 +683,45 @@ class ExpertOffloadManager:
     # ------------------------------------------------------------------ #
     #  Internal helpers                                                    #
     # ------------------------------------------------------------------ #
+
+    def _record_cache_stats(
+        self,
+        layer_idx: int,
+        hit_experts: set[int],
+        miss_experts: set[int],
+        needed: set[int],
+        on_device: set[int],
+    ):
+        self.cache_calls[layer_idx] += 1
+        self.cache_requests[layer_idx] += len(needed)
+        self.cache_hits[layer_idx] += len(hit_experts)
+        self.cache_misses[layer_idx] += len(miss_experts)
+        self.last_hit_experts[layer_idx] = sorted(hit_experts)
+        self.last_miss_experts[layer_idx] = sorted(miss_experts)
+
+        interval = self.offload_config.cache_stats_log_interval
+        if interval == 0 or self.cache_calls[layer_idx] % interval != 0:
+            return
+
+        requests = self.cache_requests[layer_idx]
+        hit_rate = self.cache_hits[layer_idx] / requests if requests else 0.0
+        policy_step = -1
+        if self.cache_policy is not None:
+            policy_step = self.cache_policy.layer_step(layer_idx)
+        logger.info(
+            "[EXPERT-OFFLOAD-CACHE] layer=%d cache_step=%d calls=%d policy_step=%d "
+            "hit_rate=%.4f hits=%d misses=%d last_hit=%s last_miss=%s resident=%s",
+            layer_idx,
+            self.cache_calls[layer_idx],
+            self.cache_calls[layer_idx],
+            policy_step,
+            hit_rate,
+            self.cache_hits[layer_idx],
+            self.cache_misses[layer_idx],
+            self.last_hit_experts[layer_idx],
+            self.last_miss_experts[layer_idx],
+            sorted(on_device),
+        )
 
     def _drain_pending_weights(self):
         if not self._pending_weights:

--- a/vllm_ascend/expert_offload/expert_offload_manager.py
+++ b/vllm_ascend/expert_offload/expert_offload_manager.py
@@ -78,6 +78,10 @@ class ExpertOffloadManager:
         ExpertOffloadManager._instance = self
 
         self.load_stream = torch_npu.npu.Stream()
+        # Reusable event: recorded on load_stream after H2D copies complete.
+        # Compute stream waits on this before cache-miss MLP to overlap
+        # cache-hit compute with weight transfer.
+        self._weights_loaded_event = torch_npu.npu.Event()
 
         # Prefill pool: ndl layers × all experts on NPU, shared round-robin
         self._prefill_w13: list[torch.Tensor] = []
@@ -560,7 +564,8 @@ class ExpertOffloadManager:
             topk_ids: [num_tokens, top_k] routed expert indices.
             log2phy: [global_num_experts] CPU tensor, modified in-place.
 
-        Returns: (log2phy_cache_hit_gpu, log2phy_cache_miss_gpu) or (None, None)
+        Returns: (log2phy_cache_hit_gpu, log2phy_cache_miss_gpu, weights_loaded_event)
+                  or (None, None, None)
         """
         num_tokens = topk_ids.size(0)
         if num_tokens > self.offload_threshold:
@@ -570,17 +575,17 @@ class ExpertOffloadManager:
                 try:
                     layer_idx = self.moe_layers.index(layer)
                 except ValueError:
-                    return (None, None)
+                    return (None, None, None)
                 self._prefill_load_layer(layer_idx, log2phy)
-                return (None, None)
+                return (None, None, None)
             else:
                 # Profile run or pool not ready — bail out gracefully
-                return (None, None)
+                return (None, None, None)
 
         try:
             layer_idx = self.moe_layers.index(layer)
         except ValueError:
-            return (None, None)
+            return (None, None, None)
 
         topk_ids_h = self.topk_ids_h[:num_tokens]
         topk_weights_h = None
@@ -619,7 +624,7 @@ class ExpertOffloadManager:
         self.log2phy_cache_hit.copy_to_gpu()
         self.log2phy_cache_miss.copy_to_gpu()
         # return (None, None)
-        return (self.log2phy_cache_hit.gpu, self.log2phy_cache_miss.gpu)
+        return (self.log2phy_cache_hit.gpu, self.log2phy_cache_miss.gpu, self._weights_loaded_event)
     def _update_weights(self, args):
         (
             topk_ids_h,
@@ -737,7 +742,9 @@ class ExpertOffloadManager:
             log2phy_need_to_load = np.where(need_to_load_mask, log2phy_np, -1)
             np.copyto(self.log2phy_cache_miss.np, log2phy_need_to_load)
 
-            self.load_stream.synchronize()
+            # Record event instead of synchronizing, so that cache-hit
+            # compute can overlap with the tail of H2D copies.
+            self._weights_loaded_event.record(self.load_stream)
 
     # ------------------------------------------------------------------ #
     #  Internal helpers                                                    #

--- a/vllm_ascend/expert_offload/expert_offload_manager.py
+++ b/vllm_ascend/expert_offload/expert_offload_manager.py
@@ -82,6 +82,10 @@ class ExpertOffloadManager:
         # Compute stream waits on this before cache-miss MLP to overlap
         # cache-hit compute with weight transfer.
         self._weights_loaded_event = torch_npu.npu.Event()
+        # Set to True by _update_weights when all needed experts are already
+        # on device — lets update_weights skip cache-hit/miss buffers and
+        # return (None, None, None) so fused_experts uses single-pass path.
+        self._all_hits = False
 
         # Prefill pool: ndl layers × all experts on NPU, shared round-robin
         self._prefill_w13: list[torch.Tensor] = []
@@ -621,6 +625,14 @@ class ExpertOffloadManager:
             self._update_weights(args)
 
         log2phy.copy_(log2phy_h, non_blocking=_EXTRA_CTX.capturing)
+
+        # All-hit fast path: every needed expert was already on device.
+        # Skip cache-hit/miss buffers entirely so fused_experts uses the
+        # normal single-pass log2phy path — avoids a full dispatch+MLP+combine
+        # round that would produce zero output anyway.
+        if self._all_hits:
+            return (None, None, None)
+
         self.log2phy_cache_hit.copy_to_gpu()
         self.log2phy_cache_miss.copy_to_gpu()
         # return (None, None)
@@ -654,6 +666,14 @@ class ExpertOffloadManager:
             on_device = set(slot_owner.values())
             already_there = needed & on_device           # no-op
             need_to_load = needed - already_there          # CPU→NPU copy
+
+            # All-hit fast path: nothing to load, skip H2D copies and
+            # cache-miss buffer setup.  The caller checks self._all_hits
+            # to skip copy_to_gpu and return (None, None, None).
+            self._all_hits = len(need_to_load) == 0
+            if self._all_hits:
+                return
+
             if self.cache_policy is not None:
                 self._record_cache_stats(layer_idx, already_there, need_to_load, needed, on_device)
             reusable_slots = [s for s, e in slot_owner.items()

--- a/vllm_ascend/expert_offload/expert_offload_manager.py
+++ b/vllm_ascend/expert_offload/expert_offload_manager.py
@@ -1,9 +1,13 @@
 """Expert Offload Manager — manages CPU-side expert weights and NPU paging."""
 
+import time
+
+import numpy as np
 import torch
 import torch_npu
 from vllm.config import VllmConfig
 from vllm.logger import logger
+from vllm.v1.utils import CpuGpuBuffer
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.expert_offload.lrc_policy import LRCExpertCachePolicy
@@ -152,6 +156,18 @@ class ExpertOffloadManager:
         )
         self.log2phy_h = torch.zeros(num_total_experts, dtype=torch.int32, device='cpu', pin_memory=True)
         self.log2phy_np = self.log2phy_h.numpy()
+        self.log2phy_cache_hit = CpuGpuBuffer(
+            num_total_experts,
+            dtype=torch.int32,
+            device='npu',
+            pin_memory=True,
+        )
+        self.log2phy_cache_miss = CpuGpuBuffer(
+            num_total_experts,
+            dtype=torch.int32,
+            device='npu',
+            pin_memory=True,
+        )
 
     def process_weights_after_loading(self):
         first_w13 = self.w13_weights_cpu[0][0]
@@ -533,19 +549,18 @@ class ExpertOffloadManager:
 
     def update_weights(self, layer, topk_ids: torch.Tensor,
                         log2phy: torch.Tensor,
-                        topk_weights: torch.Tensor | None = None) -> int:
+                        topk_weights: torch.Tensor | None = None):
         """Incrementally page in needed experts, overwriting unused slots.
 
-        Routes to prefill pool (full-overwrite) when num_tokens exceeds
-        offload_threshold, otherwise uses per-expert paging (decode path).
+        Only copies experts that are NOT already on device. Experts
+        already loaded are left in place.
 
         Args:
             layer: AscendFusedMoE instance.
             topk_ids: [num_tokens, top_k] routed expert indices.
             log2phy: [global_num_experts] CPU tensor, modified in-place.
 
-        Returns: number of CPU→NPU copies performed (decode path),
-                 0 for prefill path (full-overwrite via pool).
+        Returns: (log2phy_cache_hit_gpu, log2phy_cache_miss_gpu) or (None, None)
         """
         num_tokens = topk_ids.size(0)
         if num_tokens > self.offload_threshold:
@@ -555,17 +570,17 @@ class ExpertOffloadManager:
                 try:
                     layer_idx = self.moe_layers.index(layer)
                 except ValueError:
-                    return 0
+                    return (None, None)
                 self._prefill_load_layer(layer_idx, log2phy)
-                return 0
+                return (None, None)
             else:
                 # Profile run or pool not ready — bail out gracefully
-                return 0
+                return (None, None)
 
         try:
             layer_idx = self.moe_layers.index(layer)
         except ValueError:
-            return 0
+            return (None, None)
 
         topk_ids_h = self.topk_ids_h[:num_tokens]
         topk_weights_h = None
@@ -601,7 +616,10 @@ class ExpertOffloadManager:
             self._update_weights(args)
 
         log2phy.copy_(log2phy_h, non_blocking=_EXTRA_CTX.capturing)
-    
+        self.log2phy_cache_hit.copy_to_gpu()
+        self.log2phy_cache_miss.copy_to_gpu()
+        # return (None, None)
+        return (self.log2phy_cache_hit.gpu, self.log2phy_cache_miss.gpu)
     def _update_weights(self, args):
         (
             topk_ids_h,
@@ -611,6 +629,7 @@ class ExpertOffloadManager:
             topk_weights_h,
         ) = args
         with torch_npu.npu.stream(self.load_stream):
+            np.copyto(self.log2phy_cache_hit.np, log2phy_np)
             if self.cache_policy is not None:
                 router_scores = topk_weights_h.tolist() if topk_weights_h is not None else None
                 needed = self.cache_policy.observe(
@@ -713,6 +732,11 @@ class ExpertOffloadManager:
                     reusable_slots.remove(slot)
                 n_copies += 1
 
+            need_to_load_mask = np.zeros_like(log2phy_np)
+            need_to_load_mask[list(need_to_load)] = 1
+            log2phy_need_to_load = np.where(need_to_load_mask, log2phy_np, -1)
+            np.copyto(self.log2phy_cache_miss.np, log2phy_need_to_load)
+
             self.load_stream.synchronize()
 
     # ------------------------------------------------------------------ #
@@ -785,8 +809,7 @@ _EXPERT_OFFLOAD_MANAGER: ExpertOffloadManager = None
 
 
 def maybe_init_expert_offload_manager(vllm_config: VllmConfig):
-    # if no need to init offload manager:
-    #     return
+    print("sicheng's env")
     global _EXPERT_OFFLOAD_MANAGER
     if _EXPERT_OFFLOAD_MANAGER is None:
         _EXPERT_OFFLOAD_MANAGER = ExpertOffloadManager(vllm_config)

--- a/vllm_ascend/expert_offload/lrc_policy.py
+++ b/vllm_ascend/expert_offload/lrc_policy.py
@@ -1,0 +1,151 @@
+"""Local-routing-consistency policy for expert offload decode paging."""
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Iterable
+
+
+@dataclass
+class LRCLayerState:
+    recent_queue: deque[tuple[int, ...]] = field(default_factory=deque)
+    freq: list[int] = field(default_factory=list)
+    ema: list[float] = field(default_factory=list)
+    router_score: list[float] = field(default_factory=list)
+    last_used: list[int] = field(default_factory=list)
+    step: int = 0
+
+
+class LRCExpertCachePolicy:
+    """Online approximation of SCH using recent frequency and EMA hotness.
+
+    The policy is intentionally CPU-only. ExpertOffloadManager owns the actual
+    CPU-to-NPU copies; this class only decides which resident expert should be
+    evicted when a miss needs a device slot.
+    """
+
+    def __init__(
+        self,
+        num_layers: int,
+        num_experts: int,
+        cache_size: int,
+        topk: int,
+        recent_window: int = 32,
+        ema_beta: float = 0.9,
+        recent_weight: float = 1.0,
+        ema_weight: float = 0.5,
+        router_weight: float = 0.3,
+        age_weight: float = 0.01,
+    ) -> None:
+        if num_layers < 1:
+            raise ValueError("num_layers must be >= 1")
+        if num_experts < 1:
+            raise ValueError("num_experts must be >= 1")
+        if cache_size < 1:
+            raise ValueError("cache_size must be >= 1")
+        if topk < 1:
+            raise ValueError("topk must be >= 1")
+        if recent_window < 1:
+            raise ValueError("recent_window must be >= 1")
+        if not 0.0 <= ema_beta < 1.0:
+            raise ValueError("ema_beta must be in [0, 1)")
+
+        self.num_experts = num_experts
+        self.cache_size = cache_size
+        self.topk = topk
+        self.recent_window = recent_window
+        self.ema_beta = ema_beta
+        self.recent_weight = recent_weight
+        self.ema_weight = ema_weight
+        self.router_weight = router_weight
+        self.age_weight = age_weight
+        self.layer_states = [self._new_state() for _ in range(num_layers)]
+
+    def _new_state(self) -> LRCLayerState:
+        return LRCLayerState(
+            recent_queue=deque(),
+            freq=[0 for _ in range(self.num_experts)],
+            ema=[0.0 for _ in range(self.num_experts)],
+            router_score=[0.0 for _ in range(self.num_experts)],
+            last_used=[-1 for _ in range(self.num_experts)],
+        )
+
+    def observe(
+        self,
+        layer_idx: int,
+        topk_ids: Iterable[Iterable[int]],
+        router_scores: Iterable[Iterable[float]] | None = None,
+    ) -> set[int]:
+        """Update per-layer routing statistics and return unique routed ids."""
+        state = self.layer_states[layer_idx]
+        score_rows = router_scores if router_scores is not None else []
+        unique: set[int] = set()
+
+        for row_index, row in enumerate(topk_ids):
+            experts = tuple(self._valid_expert(eid) for eid in row)
+            unique.update(experts)
+            state.step += 1
+
+            hit_set = set(experts)
+            for eid in range(self.num_experts):
+                hit = 1.0 if eid in hit_set else 0.0
+                state.ema[eid] = self.ema_beta * state.ema[eid] + (1.0 - self.ema_beta) * hit
+
+            state.recent_queue.append(experts)
+            for eid in experts:
+                state.freq[eid] += 1
+                state.last_used[eid] = state.step
+
+            if router_scores is not None:
+                score_row = list(score_rows[row_index])
+                for eid, score in zip(experts, score_row, strict=False):
+                    state.router_score[eid] = float(score)
+
+            while len(state.recent_queue) > self.recent_window:
+                old_experts = state.recent_queue.popleft()
+                for old_eid in old_experts:
+                    state.freq[old_eid] -= 1
+
+        return unique
+
+    def choose_victim(
+        self,
+        layer_idx: int,
+        slot_owner: dict[int, int],
+        protected: set[int],
+        loading: set[int] | None = None,
+    ) -> int | None:
+        """Return resident expert id with the lowest predicted hotness."""
+        loading = loading or set()
+        candidates = [
+            eid for eid in slot_owner.values()
+            if eid not in protected and eid not in loading
+        ]
+        if not candidates:
+            candidates = [eid for eid in slot_owner.values() if eid not in protected]
+        if not candidates:
+            return None
+
+        return min(candidates, key=lambda eid: self._victim_key(layer_idx, eid))
+
+    def hotness(self, layer_idx: int, expert_id: int) -> float:
+        state = self.layer_states[layer_idx]
+        age = 0 if state.last_used[expert_id] < 0 else state.step - state.last_used[expert_id]
+        return (
+            self.recent_weight * state.freq[expert_id]
+            + self.ema_weight * state.ema[expert_id]
+            + self.router_weight * state.router_score[expert_id]
+            - self.age_weight * age
+        )
+
+    def layer_step(self, layer_idx: int) -> int:
+        return self.layer_states[layer_idx].step
+
+    def _victim_key(self, layer_idx: int, expert_id: int) -> tuple[float, int, int]:
+        state = self.layer_states[layer_idx]
+        return (self.hotness(layer_idx, expert_id), state.last_used[expert_id], expert_id)
+
+    def _valid_expert(self, expert_id: int) -> int:
+        expert_id = int(expert_id)
+        if expert_id < 0 or expert_id >= self.num_experts:
+            raise ValueError(f"expert id out of range: {expert_id}")
+        return expert_id

--- a/vllm_ascend/expert_offload/utils.py
+++ b/vllm_ascend/expert_offload/utils.py
@@ -1,0 +1,35 @@
+"""Utility functions for expert offload initialization."""
+
+import torch
+
+
+def init_expert_offload_config(offload_config, num_experts: int):
+    """Prepare pre-super().__init__() expert offload setup.
+
+    Builds an expert_map_offload that the upstream layer.py hook reads
+    to shrink the device weight and skip loading cold experts.
+
+    Args:
+        offload_config: ExpertOffloadConfig instance from AscendConfig.
+        num_experts: Total routed expert count from model config.
+
+    Returns:
+        (enable: bool, expert_map_offload: torch.Tensor | None)
+    """
+    enable = (offload_config.expert_offload
+              and offload_config.num_device_experts > 0
+              and offload_config.num_device_experts < num_experts)
+    if not enable:
+        return False, None
+
+    ndev = offload_config.num_device_experts
+    emap = torch.full((num_experts,), -1, dtype=torch.int32)
+    emap[:ndev] = torch.arange(ndev, dtype=torch.int32)
+    return True, emap
+
+
+def init_log2phy_for_offload(global_num_experts: int, num_device_experts: int):
+    """Initialize the forward-pass log2phy mapping table."""
+    log2phy = torch.arange(global_num_experts, dtype=torch.int32, device='npu')
+    log2phy[num_device_experts:].fill_(-1)
+    return log2phy

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -179,7 +179,24 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             tid2eid=self.tid2eid,
             input_ids=input_ids,
         )
-        if layer.vllm_config.model_config is not None and layer.vllm_config.model_config.enable_return_routed_experts:
+
+        # Expert offload: incrementally page in needed experts, update log2phy
+        use_prefill_pool = False
+        prefill_slot = -1
+        if getattr(layer, 'enable_expert_offload', False):
+            from vllm_ascend.expert_offload import ExpertOffloadManager
+            mgr = ExpertOffloadManager.get_instance()
+            num_tokens = topk_ids.size(0)
+            mgr.update_weights(layer, topk_ids, log2phy)
+            if num_tokens > mgr.offload_threshold and mgr._prefill_initialized and not mgr._skip_prefill:
+                use_prefill_pool = True
+                try:
+                    layer_idx = mgr.moe_layers.index(layer)
+                except ValueError:
+                    layer_idx = 0
+                prefill_slot = layer_idx % len(mgr._prefill_w13)
+
+        if zero_expert_num > 0 and zero_expert_type is not None:
             if vllm_version_is("0.20.2"):
                 # 0.20.2: capturer is a process-wide singleton.
                 capturer = RoutedExpertsCapturer.get_instance()
@@ -206,30 +223,53 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
 
         moe_comm_method = _EXTRA_CTX.moe_comm_method
-        # NOTE: In the MoECommType.FUSED_MC2 branch, we wrap weights (w1, w2) into lists
-        # and provide dummy scales (w1_scale, w2_scale). This is required because:
-        # The underlying Ascend fused operator (e.g., dispatch_ffn_combine) expects
-        # inputs in a list format.
-        # TODO: Passing an empty tensor as scale for float (BF16) cases is semantically
-        # incorrect. The ideal solution is to pass None. However, if the underlying
-        # dispatch_ffn_combine C++ operator does not support None for the scale argument
-        # (due to signature constraints), we are forced to use a placeholder empty tensor.
-        # This TODO tracks the requirement to update the C++ operator to accept Optional[Tensor]
-        # or None for scales in non-quantized scenarios.
-        if _EXTRA_CTX.moe_comm_type == MoECommType.FUSED_MC2:
-            w1 = [layer.w13_weight]
-            w1_scale = [torch.tensor([], dtype=torch.int64)]
-            w2 = [layer.w2_weight]
-            w2_scale = [torch.tensor([], dtype=torch.int64)]
-            w1_scale_bias = [torch.tensor([], dtype=torch.float32)]
-            w2_scale_bias = [torch.tensor([], dtype=torch.float32)]
+        if use_prefill_pool:
+            from vllm_ascend.expert_offload import ExpertOffloadManager
+            mgr = ExpertOffloadManager.get_instance()
+            # Override local expert count so kernel groupList matches prefill pool
+            _saved_nle = layer.moe_config.num_local_experts
+            _saved_lne = layer.local_num_experts
+            ntotal = mgr.num_total_experts
+            layer.moe_config.num_local_experts = ntotal
+            layer.local_num_experts = ntotal
+            # Also patch token dispatcher (cached with old num_experts_local)
+            _saved_td_nel = moe_comm_method.token_dispatcher.num_experts_local
+            moe_comm_method.token_dispatcher.num_experts_local = ntotal
+            # Use prefill-specific identity log2phy (don't pollute decode path)
+            log2phy = mgr._prefill_log2phy
+            if _EXTRA_CTX.moe_comm_type == MoECommType.FUSED_MC2:
+                w1 = [mgr._prefill_w13[prefill_slot]]
+                w1_scale = [torch.tensor([], dtype=torch.int64)]
+                w2 = [mgr._prefill_w2[prefill_slot]]
+                w2_scale = [torch.tensor([], dtype=torch.int64)]
+                w1_scale_bias = [torch.tensor([], dtype=torch.float32)]
+                w2_scale_bias = [torch.tensor([], dtype=torch.float32)]
+            else:
+                w1 = mgr._prefill_w13[prefill_slot]
+                w1_scale = None
+                w2 = mgr._prefill_w2[prefill_slot]
+                w2_scale = None
+                w1_scale_bias = None
+                w2_scale_bias = None
         else:
-            w1 = layer.w13_weight
-            w1_scale = None
-            w2 = layer.w2_weight
-            w2_scale = None
-            w1_scale_bias = None
-            w2_scale_bias = None
+            # NOTE: In the MoECommType.FUSED_MC2 branch, we wrap weights (w1, w2) into lists
+            # and provide dummy scales (w1_scale, w2_scale). This is required because:
+            # The underlying Ascend fused operator (e.g., dispatch_ffn_combine) expects
+            # inputs in a list format.
+            if _EXTRA_CTX.moe_comm_type == MoECommType.FUSED_MC2:
+                w1 = [layer.w13_weight]
+                w1_scale = [torch.tensor([], dtype=torch.int64)]
+                w2 = [layer.w2_weight]
+                w2_scale = [torch.tensor([], dtype=torch.int64)]
+                w1_scale_bias = [torch.tensor([], dtype=torch.float32)]
+                w2_scale_bias = [torch.tensor([], dtype=torch.float32)]
+            else:
+                w1 = layer.w13_weight
+                w1_scale = None
+                w2 = layer.w2_weight
+                w2_scale = None
+                w1_scale_bias = None
+                w2_scale_bias = None
 
         final_hidden_states = moe_comm_method.fused_experts(
             fused_experts_input=build_fused_experts_input(
@@ -258,6 +298,11 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         )
         if zero_expert_num > 0 and zero_expert_type is not None:
             final_hidden_states += zero_expert_result
+        # Restore decode-path expert count after prefill override
+        if use_prefill_pool:
+            layer.moe_config.num_local_experts = _saved_nle
+            layer.local_num_experts = _saved_lne
+            moe_comm_method.token_dispatcher.num_experts_local = _saved_td_nel
         return final_hidden_states
 
 
@@ -343,6 +388,17 @@ class AscendFusedMoE(FusedMoE):
         _ = kwargs.pop("hash") if "hash" in kwargs else None
         tid2eid = kwargs.pop("tid2eid") if "tid2eid" in kwargs else None
 
+        # Expert offload: preset _expert_map before super().__init__()
+        # so that create_weights allocates the right size (no peak memory).
+        from vllm_ascend.ascend_config import get_ascend_config
+        from vllm_ascend.expert_offload.utils import init_expert_offload_config
+        _offload_cfg = get_ascend_config().expert_offload_config
+        self.enable_expert_offload, _offload_emap = init_expert_offload_config(
+            _offload_cfg, kwargs.get("num_experts", 0))
+        if _offload_emap is not None:
+            self._expert_map_offload = _offload_emap
+            self._expert_map_offload_count = _offload_cfg.num_device_experts
+
         self._original_routed_scaling_factor = kwargs.get("routed_scaling_factor", 1.0)
         super().__init__(*args, **kwargs)
         self.use_overlapped = True
@@ -357,7 +413,8 @@ class AscendFusedMoE(FusedMoE):
         AscendFusedMoE.moe_counter += 1
         self.moe_instance_id = AscendFusedMoE.moe_counter
 
-        self._expert_map = None
+        if not self.enable_expert_offload:
+            self._expert_map = None
         self.log2phy = None
 
         self.tid2eid = tid2eid
@@ -413,7 +470,13 @@ class AscendFusedMoE(FusedMoE):
         )
         self.global_num_experts = num_experts + self.global_redundant_expert_num
         self.dynamic_eplb = eplb_config.dynamic_eplb and (self.log2phy is not None)
-        self.local_num_experts = self.global_num_experts // self.ep_size
+        if not self.enable_expert_offload:
+            self.local_num_experts = self.global_num_experts // self.ep_size
+
+        if self.enable_expert_offload:
+            from vllm_ascend.expert_offload.utils import init_log2phy_for_offload
+            self.log2phy = init_log2phy_for_offload(
+                self.global_num_experts, _offload_cfg.num_device_experts)
         if self._expert_map is not None:
             logger.info_once(
                 "[EP Rank %s/%s] Expert parallelism is enabled. Local/global"
@@ -438,6 +501,9 @@ class AscendFusedMoE(FusedMoE):
         self.moe_config.num_local_experts = self.local_num_experts
         self.moe_config.global_redundant_expert_num = self.global_redundant_expert_num
         self.swiglu_limit = getattr(self.vllm_config.model_config.hf_config, "swiglu_limit", 1000000)
+
+        if self.enable_expert_offload:
+            self._wrap_weight_loader_for_offload()
 
         moe_quant_params = {
             "num_experts": self.local_num_experts,
@@ -482,6 +548,52 @@ class AscendFusedMoE(FusedMoE):
                 return result
 
             self.quant_method.process_weights_after_loading = wrapped_process_weights  # type: ignore
+
+    def _wrap_weight_loader_for_offload(self):
+        """Wrap weight_loader to intercept w13/w2 weights and store them on CPU.
+
+        Also intercepts scale/offset parameters for quantized models (W8A8).
+        Uses weight_name substring matching to distinguish param types:
+        - "weight_scale" → scale params
+        - "weight_offset" → offset params
+        - otherwise → weight params
+        """
+        from vllm_ascend.expert_offload import ExpertOffloadManager
+        mgr = ExpertOffloadManager.get_instance()
+        layer_moe_idx = self.moe_instance_id
+        orig_wl = self.weight_loader
+        ndev = mgr.num_device_experts
+
+        def _offload_weight_loader(param, loaded_weight, weight_name, shard_id,
+                                   expert_id, **kwargs):
+            # --- Handle scale/offset params (quantized models) ---
+            if "weight_scale" in weight_name:
+                mgr._add_pending_scale(layer_moe_idx, expert_id,
+                                       "w13_weight_scale" if shard_id in ("w1", "w3")
+                                       else "w2_weight_scale",
+                                       shard_id, loaded_weight)
+                if expert_id >= ndev:
+                    return None
+            elif "weight_offset" in weight_name:
+                mgr._add_pending_scale(layer_moe_idx, expert_id,
+                                       "w13_weight_offset" if shard_id in ("w1", "w3")
+                                       else "w2_weight_offset",
+                                       shard_id, loaded_weight)
+                if expert_id >= ndev:
+                    return None
+            else:
+                # --- Handle weight params (existing logic) ---
+                if shard_id in ("w1", "w3"):
+                    mgr.load_w13(layer_moe_idx, expert_id, loaded_weight, shard_id)
+                elif shard_id == "w2":
+                    mgr.load_w2(layer_moe_idx, expert_id, loaded_weight)
+                # Only load to device if expert_id < num_device_experts
+                if shard_id in ("w1", "w2", "w3") and expert_id >= ndev:
+                    return None
+            return orig_wl(param, loaded_weight, weight_name, shard_id,
+                           expert_id, **kwargs)
+
+        self.weight_loader = _offload_weight_loader
 
     def _validate_shared_expert_consistency(self):
         """Validate that split shared expert computation matches integrated

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -187,7 +187,7 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             from vllm_ascend.expert_offload import ExpertOffloadManager
             mgr = ExpertOffloadManager.get_instance()
             num_tokens = topk_ids.size(0)
-            mgr.update_weights(layer, topk_ids, log2phy, topk_weights)
+            log2phy_cache_hit, log2phy_cache_miss = mgr.update_weights(layer, topk_ids, log2phy, topk_weights)
             if num_tokens > mgr.offload_threshold and mgr._prefill_initialized and not mgr._skip_prefill:
                 use_prefill_pool = True
                 try:
@@ -195,6 +195,9 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
                 except ValueError:
                     layer_idx = 0
                 prefill_slot = layer_idx % len(mgr._prefill_w13)
+
+        else:
+            log2phy_cache_hit, log2phy_cache_miss = None, None
 
         if zero_expert_num > 0 and zero_expert_type is not None:
             if vllm_version_is("0.20.2"):
@@ -294,6 +297,8 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
                 w1_scale_bias=w1_scale_bias,
                 w2_scale_bias=w2_scale_bias,
                 swiglu_limit=layer.swiglu_limit,
+                log2phy_cache_hit=log2phy_cache_hit,
+                log2phy_cache_miss=log2phy_cache_miss,
             )
         )
         if zero_expert_num > 0 and zero_expert_type is not None:

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -187,7 +187,7 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             from vllm_ascend.expert_offload import ExpertOffloadManager
             mgr = ExpertOffloadManager.get_instance()
             num_tokens = topk_ids.size(0)
-            log2phy_cache_hit, log2phy_cache_miss = mgr.update_weights(layer, topk_ids, log2phy, topk_weights)
+            log2phy_cache_hit, log2phy_cache_miss, weights_loaded_event = mgr.update_weights(layer, topk_ids, log2phy, topk_weights)
             if num_tokens > mgr.offload_threshold and mgr._prefill_initialized and not mgr._skip_prefill:
                 use_prefill_pool = True
                 try:
@@ -197,7 +197,7 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
                 prefill_slot = layer_idx % len(mgr._prefill_w13)
 
         else:
-            log2phy_cache_hit, log2phy_cache_miss = None, None
+            log2phy_cache_hit, log2phy_cache_miss, weights_loaded_event = None, None, None
 
         if zero_expert_num > 0 and zero_expert_type is not None:
             if vllm_version_is("0.20.2"):
@@ -299,6 +299,7 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
                 swiglu_limit=layer.swiglu_limit,
                 log2phy_cache_hit=log2phy_cache_hit,
                 log2phy_cache_miss=log2phy_cache_miss,
+                weights_loaded_event=weights_loaded_event,
             )
         )
         if zero_expert_num > 0 and zero_expert_type is not None:

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -187,7 +187,7 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             from vllm_ascend.expert_offload import ExpertOffloadManager
             mgr = ExpertOffloadManager.get_instance()
             num_tokens = topk_ids.size(0)
-            mgr.update_weights(layer, topk_ids, log2phy)
+            mgr.update_weights(layer, topk_ids, log2phy, topk_weights)
             if num_tokens > mgr.offload_threshold and mgr._prefill_initialized and not mgr._skip_prefill:
                 use_prefill_pool = True
                 try:

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -139,6 +139,7 @@ class MoECommMethod(ABC):
         routed_topk_ids = fused_experts_input.topk_ids
         if fused_experts_input.routing.log2phy is not None:
             routed_topk_ids = fused_experts_input.routing.log2phy[routed_topk_ids]
+            routed_topk_ids = routed_topk_ids.clamp(min=0)  # safety: unmapped -> 0
 
         token_dispatch_input = build_token_dispatch_input(
             fused_experts_input=fused_experts_input,

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -23,6 +23,7 @@ from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
 import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
+from vllm_ascend.expert_offload.expert_offload_manager import has_expert_offload_manager
 from vllm_ascend.ops.fused_moe.moe_mlp import unified_apply_mlp
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEFusedExpertsInput,
@@ -137,13 +138,26 @@ class MoECommMethod(ABC):
 
         before_dispatch_evt = torch.npu.current_stream().record_event()
         routed_topk_ids = fused_experts_input.topk_ids
-        if fused_experts_input.routing.log2phy is not None:
+        topk_weights_mask = None
+        if has_expert_offload_manager():
+            log2phy = fused_experts_input.routing.log2phy
+            log2phy_cache_hit = fused_experts_input.routing.log2phy_cache_hit
+            log2phy_cache_miss = fused_experts_input.routing.log2phy_cache_miss
+            assert log2phy is not None
+            if log2phy_cache_hit is not None:
+                routed_topk_ids = log2phy_cache_hit[routed_topk_ids]
+            else:
+                routed_topk_ids = log2phy[routed_topk_ids]
+            topk_weights_mask = routed_topk_ids > -1
+            routed_topk_ids = routed_topk_ids.clamp(min=0)  # safety: unmapped -> 0
+        elif fused_experts_input.routing.log2phy is not None:
             routed_topk_ids = fused_experts_input.routing.log2phy[routed_topk_ids]
             routed_topk_ids = routed_topk_ids.clamp(min=0)  # safety: unmapped -> 0
 
         token_dispatch_input = build_token_dispatch_input(
             fused_experts_input=fused_experts_input,
             topk_ids=routed_topk_ids,
+            topk_weights_mask=topk_weights_mask,
         )
         token_dispatch_output = self.token_dispatcher.token_dispatch(token_dispatch_input=token_dispatch_input)
 
@@ -160,6 +174,35 @@ class MoECommMethod(ABC):
             hidden_states=mlp_output,
             combine_metadata=token_dispatch_output.combine_metadata,
         )
+
+        if has_expert_offload_manager() and log2phy_cache_hit is not None:
+            assert log2phy_cache_miss is not None
+            # TODO async onload in update_weights, and wait for load finish here
+            routed_topk_ids = fused_experts_input.topk_ids
+            routed_topk_ids = log2phy_cache_miss[routed_topk_ids]
+            topk_weights_mask = routed_topk_ids > -1
+            routed_topk_ids = routed_topk_ids.clamp(min=0)  # safety: unmapped -> 0
+
+            token_dispatch_input = build_token_dispatch_input(
+                fused_experts_input=fused_experts_input,
+                topk_ids=routed_topk_ids,
+                topk_weights_mask=topk_weights_mask,
+            )
+            token_dispatch_output = self.token_dispatcher.token_dispatch(token_dispatch_input=token_dispatch_input)
+
+            mlp_compute_input = build_mlp_compute_input(
+                fused_experts_input=fused_experts_input,
+                token_dispatch_output=token_dispatch_output,
+                use_fusion_ops=self.use_fusion_ops,
+            )
+
+            mlp_output, _ = self._apply_mlp(mlp_compute_input)
+
+            routed_out_cache_miss = self.token_dispatcher.token_combine(
+                hidden_states=mlp_output,
+                combine_metadata=token_dispatch_output.combine_metadata,
+            )
+            routed_out = routed_out + routed_out_cache_miss
 
         return FusedExpertsResult(
             routed_out=routed_out,

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -177,7 +177,12 @@ class MoECommMethod(ABC):
 
         if has_expert_offload_manager() and log2phy_cache_hit is not None:
             assert log2phy_cache_miss is not None
-            # TODO async onload in update_weights, and wait for load finish here
+            # Wait for H2D weight copies on load_stream to complete before
+            # cache-miss MLP compute.  This enables overlap between cache-hit
+            # compute and the tail of the weight transfer.
+            weights_loaded_event = fused_experts_input.routing.weights_loaded_event
+            if weights_loaded_event is not None:
+                torch.npu.current_stream().wait_event(weights_loaded_event)
             routed_topk_ids = fused_experts_input.topk_ids
             routed_topk_ids = log2phy_cache_miss[routed_topk_ids]
             topk_weights_mask = routed_topk_ids > -1

--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -146,6 +146,7 @@ def build_fused_experts_input(
     w2_offset: torch.Tensor | None = None,
     log2phy_cache_hit: torch.Tensor | None = None,
     log2phy_cache_miss: torch.Tensor | None = None,
+    weights_loaded_event: torch.npu.Event | None = None,
     swiglu_limit: int = 0,
 ) -> MoEFusedExpertsInput:
     return MoEFusedExpertsInput(
@@ -173,6 +174,7 @@ def build_fused_experts_input(
             pertoken_scale=pertoken_scale,
             log2phy_cache_hit=log2phy_cache_hit,
             log2phy_cache_miss=log2phy_cache_miss,
+            weights_loaded_event=weights_loaded_event,
         ),
         activation=activation,
         need_trans=need_trans,

--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -144,6 +144,8 @@ def build_fused_experts_input(
     w2_scale_bias: list[torch.Tensor] | torch.Tensor | None = None,
     w1_offset: torch.Tensor | None = None,
     w2_offset: torch.Tensor | None = None,
+    log2phy_cache_hit: torch.Tensor | None = None,
+    log2phy_cache_miss: torch.Tensor | None = None,
     swiglu_limit: int = 0,
 ) -> MoEFusedExpertsInput:
     return MoEFusedExpertsInput(
@@ -169,6 +171,8 @@ def build_fused_experts_input(
             apply_router_weight_on_input=apply_router_weight_on_input,
             log2phy=log2phy,
             pertoken_scale=pertoken_scale,
+            log2phy_cache_hit=log2phy_cache_hit,
+            log2phy_cache_miss=log2phy_cache_miss,
         ),
         activation=activation,
         need_trans=need_trans,
@@ -193,6 +197,7 @@ def build_token_dispatch_input(
     *,
     fused_experts_input: MoEFusedExpertsInput,
     topk_ids: torch.Tensor | None = None,
+    topk_weights_mask: torch.Tensor | None = None,
 ) -> MoETokenDispatchInput:
     return MoETokenDispatchInput(
         hidden_states=fused_experts_input.hidden_states,
@@ -200,6 +205,7 @@ def build_token_dispatch_input(
         topk_ids=fused_experts_input.topk_ids if topk_ids is None else topk_ids,
         routing=fused_experts_input.routing,
         quant=fused_experts_input.quant,
+        topk_weights_mask=topk_weights_mask,
     )
 
 

--- a/vllm_ascend/ops/fused_moe/moe_stage_contracts.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_contracts.py
@@ -80,6 +80,7 @@ class MoETokenDispatchInput:
     topk_ids: torch.Tensor
     routing: MoERoutingParams
     quant: MoEQuantParams
+    topk_weights_mask: torch.Tensor | None
 
 
 # dispatch carry-over state consumed by combine

--- a/vllm_ascend/ops/fused_moe/moe_stage_params.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_params.py
@@ -23,7 +23,7 @@ import torch
 from vllm_ascend.quantization.quant_type import QuantType
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=False, slots=True)
 class MoERoutingParams:
     """Routing and dispatch side inputs for one MoE invocation.
 
@@ -41,6 +41,8 @@ class MoERoutingParams:
     log2phy: torch.Tensor | None = None
     # Precomputed activation scales from prepare stage for quantized dispatch.
     pertoken_scale: torch.Tensor | None = None
+    log2phy_cache_hit: torch.Tensor | None = None
+    log2phy_cache_miss: torch.Tensor | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/vllm_ascend/ops/fused_moe/moe_stage_params.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_params.py
@@ -43,6 +43,10 @@ class MoERoutingParams:
     pertoken_scale: torch.Tensor | None = None
     log2phy_cache_hit: torch.Tensor | None = None
     log2phy_cache_miss: torch.Tensor | None = None
+    # Event signaled when H2D weight copies on load_stream complete.
+    # Compute stream waits on this before cache-miss MLP to enable
+    # overlap between cache-hit compute and weight transfer.
+    weights_loaded_event: torch.npu.Event | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -348,6 +348,7 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
         dynamic_scale = token_dispatch_input.routing.pertoken_scale
         global_redundant_expert_num = token_dispatch_input.routing.global_redundant_expert_num
         restore_shape = hidden_states.shape
+        topk_weights_mask = token_dispatch_input.topk_weights_mask
         # Fuse the first dynamic quant of moe_mlp into initrouting when
         # dispatch_with_quant is on but got a None dynamic_scale.
         if with_quant and dynamic_scale is None:
@@ -362,7 +363,12 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
             _, topk = topk_weights.shape
             assert topk == 1, "Only support topk=1 when `apply_router_weight_on_input` is True"
             hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
-        if expert_map is not None:
+        if topk_weights_mask is not None:
+            first_expert_idx = 0
+            last_expert_idx = self.num_experts_local
+            global_num_experts = self.num_experts_local
+            topk_weights = topk_weights * topk_weights_mask
+        elif expert_map is not None:
             global_num_experts = len(expert_map) + global_redundant_expert_num
             mask = expert_map[topk_ids] != -1
             topk_weights = topk_weights * mask

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -249,11 +249,47 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
         assert topk_weights is not None
         topk_weights = topk_weights.to(self.in_dtype)
 
+        # Expert offload: incrementally page in needed experts, update log2phy
+        use_prefill_pool = False
+        prefill_slot = -1
+        if getattr(layer, 'enable_expert_offload', False):
+            from vllm_ascend.expert_offload import ExpertOffloadManager
+            mgr = ExpertOffloadManager.get_instance()
+            num_tokens = topk_ids.size(0)
+            mgr.update_weights(layer, topk_ids, log2phy)
+            if num_tokens > mgr.offload_threshold and mgr._prefill_initialized and not mgr._skip_prefill:
+                use_prefill_pool = True
+                try:
+                    layer_idx = mgr.moe_layers.index(layer)
+                except ValueError:
+                    layer_idx = 0
+                prefill_slot = layer_idx % len(mgr._prefill_w13)
+
         moe_comm_method = _EXTRA_CTX.moe_comm_method
         fused_scale_flag = (
             _EXTRA_CTX.moe_comm_type == MoECommType.FUSED_MC2 and envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2 == 1
         )
-        if self.dynamic_eplb:
+        if use_prefill_pool:
+            from vllm_ascend.expert_offload import ExpertOffloadManager
+            mgr = ExpertOffloadManager.get_instance()
+            w1 = [mgr._prefill_w13[prefill_slot]]
+            w1_scale = [mgr._prefill_w13_scale_fp32[prefill_slot]]
+            w2 = [mgr._prefill_w2[prefill_slot]]
+            w2_scale = [mgr._prefill_w2_scale[prefill_slot]]
+            w1_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
+            w2_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
+            # Override local expert count so kernel groupList matches prefill pool
+            _saved_nle = layer.moe_config.num_local_experts
+            _saved_lne = layer.local_num_experts
+            ntotal = mgr.num_total_experts
+            layer.moe_config.num_local_experts = ntotal
+            layer.local_num_experts = ntotal
+            # Also patch token dispatcher (cached with old num_experts_local)
+            _saved_td_nel = moe_comm_method.token_dispatcher.num_experts_local
+            moe_comm_method.token_dispatcher.num_experts_local = ntotal
+            # Use prefill-specific identity log2phy (don't pollute decode path)
+            log2phy = mgr._prefill_log2phy
+        elif self.dynamic_eplb:
             w1 = layer.w13_weight_list
             w1_scale = layer.fused_w1_scale_list if fused_scale_flag else layer.w13_weight_scale_fp32_list
             w2 = layer.w2_weight_list
@@ -292,6 +328,11 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
         )
         if zero_expert_num > 0 and zero_expert_type is not None:
             final_hidden_states += zero_expert_result
+        # Restore decode-path expert count after prefill override
+        if use_prefill_pool:
+            layer.moe_config.num_local_experts = _saved_nle
+            layer.local_num_experts = _saved_lne
+            moe_comm_method.token_dispatcher.num_experts_local = _saved_td_nel
         return final_hidden_states
 
     def process_weights_after_loading(self, layer):

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -256,7 +256,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
             from vllm_ascend.expert_offload import ExpertOffloadManager
             mgr = ExpertOffloadManager.get_instance()
             num_tokens = topk_ids.size(0)
-            mgr.update_weights(layer, topk_ids, log2phy)
+            mgr.update_weights(layer, topk_ids, log2phy, topk_weights)
             if num_tokens > mgr.offload_threshold and mgr._prefill_initialized and not mgr._skip_prefill:
                 use_prefill_pool = True
                 try:

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -256,7 +256,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
             from vllm_ascend.expert_offload import ExpertOffloadManager
             mgr = ExpertOffloadManager.get_instance()
             num_tokens = topk_ids.size(0)
-            log2phy_cache_hit, log2phy_cache_miss = mgr.update_weights(layer, topk_ids, log2phy, topk_weights)
+            log2phy_cache_hit, log2phy_cache_miss, weights_loaded_event = mgr.update_weights(layer, topk_ids, log2phy, topk_weights)
             if num_tokens > mgr.offload_threshold and mgr._prefill_initialized and not mgr._skip_prefill:
                 use_prefill_pool = True
                 try:
@@ -266,7 +266,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
                 prefill_slot = layer_idx % len(mgr._prefill_w13)
 
         else:
-            log2phy_cache_hit, log2phy_cache_miss = None, None
+            log2phy_cache_hit, log2phy_cache_miss, weights_loaded_event = None, None, None
 
         moe_comm_method = _EXTRA_CTX.moe_comm_method
         fused_scale_flag = (
@@ -329,6 +329,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
                 swiglu_limit=layer.swiglu_limit,
                 log2phy_cache_hit=log2phy_cache_hit,
                 log2phy_cache_miss=log2phy_cache_miss,
+                weights_loaded_event=weights_loaded_event,
             )
         )
         if zero_expert_num > 0 and zero_expert_type is not None:

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -256,7 +256,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
             from vllm_ascend.expert_offload import ExpertOffloadManager
             mgr = ExpertOffloadManager.get_instance()
             num_tokens = topk_ids.size(0)
-            mgr.update_weights(layer, topk_ids, log2phy, topk_weights)
+            log2phy_cache_hit, log2phy_cache_miss = mgr.update_weights(layer, topk_ids, log2phy, topk_weights)
             if num_tokens > mgr.offload_threshold and mgr._prefill_initialized and not mgr._skip_prefill:
                 use_prefill_pool = True
                 try:
@@ -264,6 +264,9 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
                 except ValueError:
                     layer_idx = 0
                 prefill_slot = layer_idx % len(mgr._prefill_w13)
+
+        else:
+            log2phy_cache_hit, log2phy_cache_miss = None, None
 
         moe_comm_method = _EXTRA_CTX.moe_comm_method
         fused_scale_flag = (
@@ -324,6 +327,8 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
                 w1_scale_bias=w1_scale_bias,
                 w2_scale_bias=w2_scale_bias,
                 swiglu_limit=layer.swiglu_limit,
+                log2phy_cache_hit=log2phy_cache_hit,
+                log2phy_cache_miss=log2phy_cache_miss,
             )
         )
         if zero_expert_num > 0 and zero_expert_type is not None:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -120,6 +120,11 @@ from vllm_ascend.eplb.core.eplb_device_transfer_loader import D2DExpertWeightLoa
 from vllm_ascend.eplb.core.eplb_worker import EplbProcess
 from vllm_ascend.eplb.eplb_updator import EplbUpdator
 from vllm_ascend.eplb.utils import model_register
+from vllm_ascend.expert_offload.expert_offload_manager import (
+    maybe_init_expert_offload_manager,
+    has_expert_offload_manager,
+    get_expert_offload_manager,
+)
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
 from vllm_ascend.patch.worker.patch_draft_quarot import patch_load_weights
 from vllm_ascend.quantization.utils import enable_fa_quant
@@ -291,6 +296,12 @@ class NPUModelRunner(GPUModelRunner):
 
         # Ascend-specific configurations
         self.ascend_config = get_ascend_config()
+
+        if self.ascend_config.expert_offload_config.expert_offload:
+            maybe_init_expert_offload_manager(self.vllm_config)
+            if has_expert_offload_manager():
+                self.offload_manager = get_expert_offload_manager()
+
         set_weight_prefetch_method(self.ascend_config.weight_prefetch_config)
         # Dump / PrecisionDebugger configuration now comes from AscendConfig
         dump_cfg = self.ascend_config.dump_config_path
@@ -3276,13 +3287,24 @@ class NPUModelRunner(GPUModelRunner):
         if self.max_num_tokens > mc2_tokens_capacity and select_moe_comm_method(
             mc2_tokens_capacity, self.vllm_config
         ) in {MoECommType.MC2, MoECommType.FUSED_MC2}:
+            # Disable prefill pool during profile run — the kernel is
+            # configured for decode expert counts and cannot handle
+            # full-expert-count prefill tensors.
+            if hasattr(self, 'offload_manager'):
+                self.offload_manager._skip_prefill = True
             self._dummy_run(mc2_tokens_capacity, with_prefill=True, is_profile=True)
+            if hasattr(self, 'offload_manager'):
+                self.offload_manager._skip_prefill = False
         origin_max_num_tokens = self.max_num_tokens
         # in the pcp scenario, the split sequence needs to be used for profile run
         # TODO: after the vllm pcp function is launched, this logic needs to be brought up to the community
         if self.pcp_size > 1:
             self.max_num_tokens = math.ceil(self.max_num_tokens / (self.pcp_size * 2)) * 2
+        if hasattr(self, 'offload_manager'):
+            self.offload_manager._skip_prefill = True
         super().profile_run()
+        if hasattr(self, 'offload_manager'):
+            self.offload_manager._skip_prefill = False
         self.max_num_tokens = origin_max_num_tokens
 
     def eplb_warmup(self):
@@ -3311,6 +3333,8 @@ class NPUModelRunner(GPUModelRunner):
                 from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
                 DefaultModelLoader._init_ep_weight_filter = mock_pass
             self.model: nn.Module = get_model(vllm_config=self.vllm_config)
+            if hasattr(self, 'offload_manager'):
+                self._register_offload_layers()
             if self.dynamic_eplb:
                 model_register(self.model)
             if self.drafter:
@@ -3364,6 +3388,41 @@ class NPUModelRunner(GPUModelRunner):
             self._debugger_started = False
 
         self.debugger.step(**kwargs)
+
+    def _register_offload_layers(self):
+        """Find all AscendFusedMoE layers and register with ExpertOffloadManager."""
+        from vllm_ascend.ops.fused_moe.fused_moe import AscendFusedMoE
+
+        moe_layers = [m for m in self.model.modules()
+                      if isinstance(m, AscendFusedMoE)]
+        if not moe_layers:
+            return
+        first = moe_layers[0]
+        w13_up_dim = (first.w13_weight.shape[2] if hasattr(first, 'w13_weight')
+                      else first.intermediate_size_per_partition * 2)
+        t_a = time.perf_counter()
+        self.offload_manager.create_weights(
+            num_moe_layers=len(moe_layers),
+            num_total_experts=first.global_num_experts,
+            w13_up_dim=w13_up_dim,
+            hidden_size=first.hidden_size,
+            intermediate_size_per_partition=first.intermediate_size_per_partition,
+            params_dtype=first.w13_weight.data.dtype,
+        )
+        t_b = time.perf_counter()
+        for i, layer in enumerate(moe_layers):
+            self.offload_manager.register_moe_layer(layer)
+            self.offload_manager.maybe_create_scale_buffers(layer, i)
+        t_c = time.perf_counter()
+        self.offload_manager.init_device_experts()
+        t_d = time.perf_counter()
+        # Create prefill pool for large-batch (num_tokens > threshold) path
+        t_e = time.perf_counter()
+        self.offload_manager.create_prefill_pool()
+        t_f = time.perf_counter()
+        logger.info("offload steps: create_weights=%.1fs  scale_buffers=%.1fs  "
+                     "init_device=%.1fs  prefill_pool=%.1fs",
+                     t_b - t_a, t_c - t_b, t_d - t_c, t_f - t_e)
 
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
         """


### PR DESCRIPTION
稳态 decode 中约 50-70% 的层全部 cache hit，但仍走完整的两轮 pass 机制（dispatch → MLP → combine × 2）。

做法：在 update_weights 入口检查 need_to_load 是否为空。如果全命中，直接返回 log2phy，跳过 cache hit/miss 分流逻辑，单轮执行。

if len(need_to_load) == 0:
    # 全命中快速路径：不触发异步加载，不走两轮 pass
    return (log2phy.gpu, None, None)
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
