### PR TITLE
[CI] Fix csrc CI build error

### DIFF
--- a/.github/workflows/push_build_csrc_cache.yaml
+++ b/.github/workflows/push_build_csrc_cache.yaml
@@ -26,6 +26,7 @@ on:
       - 'CMakeLists.txt'
       - 'cmake/**'
       - .github/workflows/push_build_csrc_cache.yaml
+      - 'pyproject.toml'
   workflow_dispatch:
 
 defaults:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.uv.extra-build-dependencies]
+pandas = ["setuptools"]
+
 [tool.pymarkdown]
 plugins.md004.style = "sublist" # ul-style
 plugins.md007.indent = 4 # ul-indent


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds `pandas = ["setuptools"]` to `[tool.uv.extra-build-dependencies]` in `pyproject.toml` to resolve build errors during the compilation of C++ extensions (`csrc`) in the CI environment when using `uv`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified via CI build pipeline.
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
