### PR TITLE
[CI] Fix panda version outdated in csrc cache build

### DIFF
--- a/.github/workflows/push_build_csrc_cache.yaml
+++ b/.github/workflows/push_build_csrc_cache.yaml
@@ -27,6 +27,7 @@ on:
       - 'cmake/**'
       - .github/workflows/push_build_csrc_cache.yaml
   workflow_dispatch:
+  pull_request:
 
 defaults:
   run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.uv.extra-build-dependencies]
+pandas = ["setuptools"]
+
 [tool.pymarkdown]
 plugins.md004.style = "sublist" # ul-style
 plugins.md007.indent = 4 # ul-indent

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pybind11
 pyyaml
 regex
 scipy
-pandas
+pandas>=2.1.1
 psutil
 setuptools>=64
 setuptools-scm>=8

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pybind11
 pyyaml
 regex
 scipy
-pandas>=2.1.1
+pandas
 psutil
 setuptools>=64
 setuptools-scm>=8


### PR DESCRIPTION
### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
