### PR TITLE
[CI] Fix csrc cache build error

### DIFF
--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -121,19 +121,50 @@ jobs:
             -type f -not -path '*/.*' | sort | xargs sha256sum | sha256sum | awk '{print $1}')
           echo "CSRC_HASH=$CSRC_HASH" >> $GITHUB_OUTPUT
 
-      - name: Cache vllm-ascend csrc
+      - name: Get architecture
+        id: get_arch
+        run: |
+          ARCH=$(uname -m)
+          case "$ARCH" in
+            x86_64) echo "arch=X64" >> $GITHUB_OUTPUT ;;
+            aarch64) echo "arch=ARM64" >> $GITHUB_OUTPUT ;;
+            *) echo "arch=$ARCH" >> $GITHUB_OUTPUT ;;
+          esac
+
+      - uses: dorny/paths-filter@v4
+        id: csrc-filter
+        with:
+          filters: |
+            csrc:
+              - 'csrc/**'
+              - 'setup.py'
+              - 'CMakeLists.txt'
+              - 'cmake/**'
+
+      - name: Restore vllm-ascend csrc cache
         id: cache-csrc
         if: ${{ steps.check_npu.outputs.has_npu == 'true' }}
-        uses: runs-on/cache@v5
+        uses: runs-on/cache/restore@v5
         with:
           path: |
             vllm_ascend/_cann_ops_custom
             vllm_ascend/*.so
             vllm_ascend/lib
             vllm_ascend/include
-          key: vllm-ascend-build-v1-${{ runner.os }}-swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.group.image_tag }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
+          key: vllm-ascend-build-v1-${{ steps.get_arch.outputs.arch }}-${{ matrix.group.image_tag }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
           restore-keys: |
-            vllm-ascend-build-v1-${{ runner.os }}-swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.group.image_tag }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
+            vllm-ascend-build-v1-${{ steps.get_arch.outputs.arch }}-${{ matrix.group.image_tag }}-
+
+      - name: Save vllm-ascend csrc cache
+        if: ${{ steps.check_npu.outputs.has_npu == 'true' && steps.csrc-filter.outputs.csrc == 'true' && steps.cache-csrc.outputs.cache-hit != 'true' }}
+        uses: runs-on/cache/save@v5
+        with:
+          path: |
+            vllm_ascend/_cann_ops_custom
+            vllm_ascend/*.so
+            vllm_ascend/lib
+            vllm_ascend/include
+          key: vllm-ascend-build-v1-${{ steps.get_arch.outputs.arch }}-${{ matrix.group.image_tag }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install Mooncake wheel
         if: ${{ steps.check_npu.outputs.has_npu == 'true' }}
@@ -157,13 +188,16 @@ jobs:
       - name: Install vllm-project/vllm-ascend with device
         if: ${{ steps.check_npu.outputs.has_npu == 'true' }}
         run: |
+          echo "CSRC cache restored from cache: ${{ steps.cache-csrc.outputs.cache-hit }}"
           export MAX_JOBS=$(( ${{ matrix.group.num_npus }} * 23 ))
           pip install uc-manager
           uv pip install -r requirements-dev.txt
           uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
           if find vllm_ascend -maxdepth 1 -name '*.so' -type f 2>/dev/null | grep -q .; then
+            echo "CSRC cache hit: .so files found, skip kernel compilation"
             COMPILE_CUSTOM_KERNELS=0 uv pip install -e .
           else
+            echo "CSRC cache miss: no .so files found, compile kernels"
             uv pip install -e .
           fi
 

--- a/.github/workflows/push_build_csrc_cache.yaml
+++ b/.github/workflows/push_build_csrc_cache.yaml
@@ -136,7 +136,7 @@ jobs:
       - name: Install system dependencies (openeuler)
         if: matrix.os == 'openeuler'
         run: |
-          yum install -y gcc gcc-c++ cmake numactl-devel clang
+          yum install -y gcc gcc-c++ cmake numactl-devel clang patch
           pip install uv
 
       - name: Get image tag
@@ -155,7 +155,7 @@ jobs:
 
       - name: Cache vllm-ascend csrc
         id: cache-csrc
-        uses: actions/cache@v5
+        uses: runs-on/cache@v5
         with:
           path: |
             vllm_ascend/_cann_ops_custom
@@ -174,11 +174,6 @@ jobs:
           source /usr/local/Ascend/nnal/atb/set_env.sh
           arch=$(uname -i)
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/${arch}-linux/devlib
-
-          # os-specific: openeuler needs C++ include path for compilation
-          if [ "${{ matrix.os }}" = "openeuler" ]; then
-            export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/include/c++/12:/usr/include/c++/12/${arch}-openEuler-linux
-          fi
 
           pip install uc-manager
           # NOTE: indexes (ascend repo for triton-ascend + pytorch cpu whl) come from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.uv.extra-build-dependencies]
-pandas = ["setuptools"]
+pandas = ["setuptools<72"]
 
 [tool.pymarkdown]
 plugins.md004.style = "sublist" # ul-style

--- a/tests/e2e/pull_request/one_card/test_qwen3_0_6b.py
+++ b/tests/e2e/pull_request/one_card/test_qwen3_0_6b.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
-#
 
 from tests.e2e.conftest import wait_until_npu_memory_free
 from tests.e2e.pull_request.utils import PROMPTS_SHORT, compare_logprobs


### PR DESCRIPTION
### What this PR does / why we need it?
This PR pins the `setuptools` dependency to `<72` under `tool.uv.extra-build-dependencies` for `pandas` to resolve a build incompatibility. This PR also makes the csrc cache works for PR

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
