### PR TITLE
[feature]Fused MTP Graph Merge Test

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -161,6 +161,12 @@ class AscendConfig:
             "VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE",
             ascend_envs.VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE,
         )
+        self.enable_fused_mtp_full_graph = self._get_config_value(
+            additional_config,
+            "enable_fused_mtp_full_graph",
+            "VLLM_ASCEND_ENABLE_FUSED_MTP_FULL_GRAPH",
+            ascend_envs.VLLM_ASCEND_ENABLE_FUSED_MTP_FULL_GRAPH,
+        )
         self.msmonitor_use_daemon = self._get_config_value(
             additional_config,
             "msmonitor_use_daemon",

--- a/vllm_ascend/attention/abstract.py
+++ b/vllm_ascend/attention/abstract.py
@@ -49,3 +49,16 @@ class DSAAttentionImpl(AttentionImpl[T], Generic[T]):
         output_block_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
         raise NotImplementedError
+
+    @staticmethod
+    def update_graph_params(
+        update_stream,
+        forward_context,
+        num_tokens,
+        vllm_config=None,
+        speculative_config=None,
+        num_dcp_pcp_tokens=None,
+        draft_attn_metadatas=None,
+    ):
+        # DSA graph metadata is carried by tensors prepared before replay.
+        pass

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -18,7 +18,6 @@ from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
-from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.ops.cv_linear import CVLinearWrapper
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
@@ -208,8 +207,7 @@ class AscendDSABackend(AttentionBackend):
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int]:
-        kernel_block_sizes = DeviceOperator.get_dsa_kernel_block_sizes()
-        return kernel_block_sizes
+        return [8, 32, 128]
 
 
 @dataclass
@@ -425,9 +423,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.cu_seqlens_ori_kv = torch.tensor([], device=self.device)
         self.cu_seqlens_cmp_kv = torch.tensor([], device=self.device)
         self.seqused_q = torch.tensor([], device=self.device)
-        self._zero_i32 = torch.tensor([0], device=self.device, dtype=torch.int32)
-        # Note(qcs): we use two dimension slot_mapping for kvcache with shape
-        # [block_nums, block_size, head_num, head_dim]
+        # Note(qcs): we use two dimension slot_mapping for kvcache with
+        # shape [block_nums, block_size, head_num, head_dim]
         self.slot_mapping = torch.zeros(
             (vllm_config.scheduler_config.max_num_batched_tokens, 2), dtype=torch.int32, device=self.device
         )
@@ -557,7 +554,9 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
         # NOTE: Currently, MTP-fullgraph is incompatibility pcp
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
-        self.slot_mapping = DeviceOperator.format_dsa_slot_mapping(slot_mapping, self.block_size)
+        self.slot_mapping[:num_input_tokens] = torch.stack(
+            [slot_mapping // self.block_size, slot_mapping % self.block_size], axis=-1
+        )
 
         self.graph_pad_size = common_attn_metadata.graph_pad_size
         block_table_size = self.get_block_table_size(common_attn_metadata, BUILD_METADATA_STEP_PREFILL)
@@ -725,12 +724,9 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         cu_c128_cmp_seqlen_list = None
 
         layer_name = f"c{self.compressor_ratio}"
-        metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-        metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
         if self.compressor_ratio <= 1:
             if self.prefill_ratio_to_sas_metadata.get(layer_name) is None:
-                self.prefill_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
+                self.prefill_ratio_to_sas_metadata[layer_name] = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
                     num_heads_q=n_local_heads,
                     num_heads_kv=1,
                     head_dim=self.model_config.get_head_size(),
@@ -750,12 +746,12 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     layout_kv="PA_ND",
                     has_ori_kv=True,
                     has_cmp_kv=False,
+                    device=str(self.seqused_q.device),
                 )
             sas_metadata = self.prefill_ratio_to_sas_metadata[layer_name]
         elif self.compressor_ratio == 4:
             if self.prefill_ratio_to_sas_metadata.get(layer_name) is None:
-                self.prefill_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
+                self.prefill_ratio_to_sas_metadata[layer_name] = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
                     num_heads_q=n_local_heads,
                     num_heads_kv=1,
                     head_dim=self.model_config.get_head_size(),
@@ -778,12 +774,12 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     layout_kv="PA_ND",
                     has_ori_kv=True,
                     has_cmp_kv=True,
+                    device=str(self.seqused_q.device),
                 )
             sas_metadata = self.prefill_ratio_to_sas_metadata[layer_name]
         else:
             if self.prefill_ratio_to_sas_metadata.get(layer_name) is None:
-                self.prefill_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
+                self.prefill_ratio_to_sas_metadata[layer_name] = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
                     num_heads_q=n_local_heads,
                     num_heads_kv=1,
                     head_dim=self.model_config.get_head_size(),
@@ -804,6 +800,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     layout_kv="PA_ND",
                     has_ori_kv=True,
                     has_cmp_kv=True,
+                    device=str(self.seqused_q.device),
                 )
             sas_metadata = self.prefill_ratio_to_sas_metadata[layer_name]
         if self.prefill_ratio_to_sas_metadata.get("qli") is None:
@@ -957,9 +954,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 "compressed_tokens_start_" + str(self.compressor_ratio)
             ]
 
-        slot_mapping = DeviceOperator.pad_dsa_decode_slot_mapping(
-            self.slot_mapping[:compressed_tokens_start], self.num_decode_tokens, self.compressor_ratio, self.num_decodes
-        )
+        slot_mapping = self.slot_mapping[:compressed_tokens_start]
 
         assert self.start_pos_decode is not None
         self.start_pos_decode.fill_(0)
@@ -974,28 +969,15 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         index_topk = self.model_config.hf_config.index_topk
 
         assert self.decode_sas_metadata is not None
-
-        cu_seqlens_ori_kv = DeviceOperator.get_dsa_decode_cu_seqlens_ori_kv(
-            self.decode_ratio_to_sas_metadata,
-            "cu_seqlens_ori_kv",
-            self.seq_lens,
-            self.num_decodes,
-            self._zero_i32,
-            self.cu_seqlens_ori_kv,
-        )
-        metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-        metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
-        cu_seqlens_cmp_kv = DeviceOperator.get_dsa_decode_cu_seqlens_cmp_kv(self.cu_seqlens_cmp_kv)
         if self.compressor_ratio <= 1:
             if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
-                self.decode_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
+                self.decode_ratio_to_sas_metadata[layer_name] = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
                     num_heads_q=n_local_heads,
                     num_heads_kv=1,
                     head_dim=self.model_config.get_head_size(),
                     cu_seqlens_q=query_start_loc,  # cached
-                    cu_seqlens_ori_kv=cu_seqlens_ori_kv,
-                    cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
+                    cu_seqlens_ori_kv=self.cu_seqlens_ori_kv,
+                    cu_seqlens_cmp_kv=self.cu_seqlens_cmp_kv,
                     seqused_q=self.seqused_q,
                     seqused_kv=self.seq_lens[: self.num_decodes],  # cached
                     max_seqlen_q=max_seqlen_q,
@@ -1010,18 +992,18 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     layout_kv="PA_ND",
                     has_ori_kv=True,
                     has_cmp_kv=False,
+                    device=str(self.seqused_q.device),
                 )
             self.decode_sas_metadata[:1024] = self.decode_ratio_to_sas_metadata[layer_name]
         elif self.compressor_ratio == 4:
             if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
-                self.decode_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
+                self.decode_ratio_to_sas_metadata[layer_name] = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
                     num_heads_q=n_local_heads,
                     num_heads_kv=1,
                     head_dim=self.model_config.get_head_size(),
                     cu_seqlens_q=query_start_loc,  # cached
-                    cu_seqlens_ori_kv=cu_seqlens_ori_kv,
-                    cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
+                    cu_seqlens_ori_kv=self.cu_seqlens_ori_kv,
+                    cu_seqlens_cmp_kv=self.cu_seqlens_cmp_kv,
                     seqused_q=self.seqused_q,
                     seqused_kv=self.seq_lens[: self.num_decodes],  # cached
                     max_seqlen_q=max_seqlen_q,
@@ -1038,18 +1020,18 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     layout_kv="PA_ND",
                     has_ori_kv=True,
                     has_cmp_kv=True,
+                    device=str(self.seqused_q.device),
                 )
             self.decode_sas_metadata[:1024] = self.decode_ratio_to_sas_metadata[layer_name]
         else:
             if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
-                self.decode_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
+                self.decode_ratio_to_sas_metadata[layer_name] = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
                     num_heads_q=n_local_heads,
                     num_heads_kv=1,
                     head_dim=self.model_config.get_head_size(),
                     cu_seqlens_q=query_start_loc,
-                    cu_seqlens_ori_kv=cu_seqlens_ori_kv,
-                    cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
+                    cu_seqlens_ori_kv=self.cu_seqlens_ori_kv,
+                    cu_seqlens_cmp_kv=self.cu_seqlens_cmp_kv,
                     seqused_q=self.seqused_q,
                     seqused_kv=self.seq_lens[: self.num_decodes],
                     max_seqlen_q=max_seqlen_q,
@@ -1064,6 +1046,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     layout_kv="PA_ND",
                     has_ori_kv=True,
                     has_cmp_kv=True,
+                    device=str(self.seqused_q.device),
                 )
             self.decode_sas_metadata[:1024] = self.decode_ratio_to_sas_metadata[layer_name]
         assert self.decode_qli_metadata is not None
@@ -1134,8 +1117,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=False)
 
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
-        self.spec_slot_mapping[draft_step - 1] = DeviceOperator.format_dsa_slot_mapping(  # type: ignore[index]
-            slot_mapping, self.block_size
+        self.spec_slot_mapping[draft_step - 1][:num_input_tokens] = torch.stack(  # type: ignore[index]
+            [slot_mapping // self.block_size, slot_mapping % self.block_size], axis=-1
         )
 
         prefill_metadata = None
@@ -1203,10 +1186,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         prefill_slot_mapping = self.spec_slot_mapping[draft_step - 1][tokens_start:num_prefill_tokens]  # type: ignore[index]
         block_table = common_attn_metadata.block_table_tensor[: common_attn_metadata.num_reqs]
 
-        metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-        metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
-        sas_metadata = metadata_op(
-            **metadata_kwargs,
+        sas_metadata = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
             num_heads_q=n_local_heads,
             num_heads_kv=1,
             head_dim=self.model_config.get_head_size(),
@@ -1226,6 +1206,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             layout_kv="PA_ND",
             has_ori_kv=True,
             has_cmp_kv=False,
+            device=str(self.seqused_q.device),
         )
 
         return AscendDSAPrefillMetadata(
@@ -1284,11 +1265,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         slot_mapping = self.spec_slot_mapping[draft_step - 1][:num_decode_tokens_typed]  # type: ignore[index]
         block_table = common_attn_metadata.block_table_tensor
 
-        metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-        metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
-
-        decode_sas_metadata = metadata_op(
-            **metadata_kwargs,
+        decode_sas_metadata = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
             num_heads_q=n_local_heads,
             num_heads_kv=1,
             head_dim=self.model_config.get_head_size(),
@@ -1309,6 +1286,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             layout_kv="PA_ND",
             has_ori_kv=True,
             has_cmp_kv=False,
+            device=str(self.seqused_q.device),
         )
 
         decode_metadata = AscendDSADecodeMetadata(
@@ -1408,7 +1386,6 @@ class AscendDSAImpl(DSAAttentionImpl):
         self.wq_b = kwargs["wq_b"]
         self.wkv = kwargs["wkv"]
         self.q_norm = kwargs["q_norm"]
-        self.q_norm_without_weight = kwargs["q_norm_without_weight"]
         self.kv_norm = kwargs["kv_norm"]
 
         # CV wrapper: split wq_a/wkv/wq_b into quantize(Vector) + matmul(Cube)
@@ -1510,11 +1487,26 @@ class AscendDSAImpl(DSAAttentionImpl):
                 _ = self.kv_norm(kv_dummy)
 
                 # indexer module aux stream ops
-                # Part1 aux: kv_quant + scatter (device-dispatched via DeviceOperator)
+                # Part1 aux: kv_quant (npu_dynamic_quant)
+                soc_version = get_ascend_device_type()
+                dst_type = torch.float8_e4m3fn if soc_version in {AscendDeviceType.A5} else torch.int8
+                kv_dummy, kv_scale_dummy = torch_npu.npu_dynamic_quant(hidden_states_dummy, dst_type=dst_type)
+                kv_scale_dummy = kv_scale_dummy.unsqueeze(-1)
+                if soc_version not in {AscendDeviceType.A5}:
+                    kv_scale_dummy = kv_scale_dummy.to(torch.float16).unsqueeze(-1)
+                # Part1 aux: scatter_k_cache (npu_scatter_nd_update_v2)
                 # In profiling stage, create dummy tensors to ensure ACL graph captures scatter operator.
                 if self.compress_ratio == 4 and self.indexer is not None:
                     slot_mapping_dummy = torch.zeros(1, dtype=torch.int64, device=hidden_states.device)
-                    DeviceOperator.warmup_indexer_quant_scatter(hidden_states_dummy, slot_mapping_dummy)
+                    # Create dummy tensors for scatter warmup
+                    dummy_shape = (1, 1, 1, kv_dummy.shape[-1])  # [num_blocks, block_size, num_heads, head_dim]
+                    indexer_k_cache = torch.zeros(dummy_shape, dtype=kv_dummy.dtype, device=hidden_states.device)
+                    indexer_scale_cache = torch.zeros(dummy_shape, dtype=torch.float16, device=hidden_states.device)
+                    # Part3 aux: scatter_k_cache/scatter_scale_cache (npu_scatter_nd_update_v2)
+                    torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_k_cache, slot_mapping_dummy, kv_dummy)
+                    torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                        indexer_scale_cache, slot_mapping_dummy, kv_scale_dummy
+                    )
 
                     # Warm up weights_proj on the aux stream.
                     _ = self.weights_proj(hidden_states_dummy)
@@ -1641,42 +1633,24 @@ class AscendDSAImpl(DSAAttentionImpl):
         )
 
         # o
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
-            o = o_proj_input.view(num_tokens, self.n_local_groups, -1)
-            o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
-            o = torch_npu.npu_transpose_quant_batchmatmul(
-                o,
+        o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, -1)
+        if olora_tp_enable():
+            o_proj_input = self.wo_a(o_proj_input)
+        else:
+            # wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
+            # o = torch.einsum("tgd,grd->tgr", o, wo_a)
+            o_proj_input = torch_npu.npu_transpose_batchmatmul(
+                o_proj_input,
                 self.wo_a.weight,
-                dtype=torch.bfloat16,
                 bias=None,
-                group_sizes=(0, 0, 32),
-                x1_scale=swiglu_out_scale.view(torch.float8_e8m0fnu),
-                x2_scale=self.wo_a.weight_scale.view(torch.float8_e8m0fnu),
+                scale=None,
                 perm_x1=(1, 0, 2),
                 perm_x2=(0, 1, 2),
                 perm_y=(1, 0, 2),
+                batch_split_factor=1,
             )
-            o = o.reshape(num_tokens, -1)
-            output[...] = self.wo_b(o)
-        else:
-            o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, -1)
-            if olora_tp_enable():
-                o_proj_input = self.wo_a(o_proj_input)
-            else:
-                # wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
-                # o = torch.einsum("tgd,grd->tgr", o, wo_a)
-                o_proj_input = torch_npu.npu_transpose_batchmatmul(
-                    o_proj_input,
-                    self.wo_a.weight,
-                    bias=None,
-                    scale=None,
-                    perm_x1=(1, 0, 2),
-                    perm_x2=(0, 1, 2),
-                    perm_y=(1, 0, 2),
-                    batch_split_factor=1,
-                )
             o_proj_input = o_proj_input.reshape(num_tokens, -1)
-            output[...] = self.wo_b(o_proj_input)
+        output[...] = self.wo_b(o_proj_input)
 
         return output_padded
 
@@ -1749,7 +1723,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 rotary_mode="interleave",
                 partial_slice=[self.nope_head_dim, self.head_dim],
             )
-            DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, slot_mapping)
+            torch.ops._C_ascend.npu_scatter_nd_update_v2(swa_kv_cache, slot_mapping, kv)
 
         if is_prefill:
             q = self.cv_wq_b.matmul(q_b_quant, q_b_scale).unflatten(-1, (self.n_local_heads, self.head_dim))
@@ -1768,7 +1742,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         # Serial tail: wait for auxiliary stream then execute q_rms[V] + rope[V]
         main_stream.wait_stream(aux_stream)
 
-        q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
+        q = triton_q_rms(q, self.eps)
         torch.ops._C_ascend.inplace_partial_rotary_mul(
             q.unsqueeze(1),
             cos,
@@ -1823,7 +1797,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             torch.npu.current_stream().wait_event(e_phase3)
             q_b_quant, q_b_scale = self.cv_wq_b.quantize(qr)
             q = self.cv_wq_b.matmul(q_b_quant, q_b_scale).unflatten(-1, (self.n_local_heads, self.head_dim))
-            q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
+            q = triton_q_rms(q, self.eps)
 
         kv = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(kv, True)
         kv = kv[:num_actual_tokens]
@@ -1853,7 +1827,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             rotary_mode="interleave",
             partial_slice=[self.nope_head_dim, self.head_dim],
         )
-        DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, slot_mapping)
+        torch.ops._C_ascend.npu_scatter_nd_update_v2(swa_kv_cache, slot_mapping, kv)
 
         return q, qr, full_hidden_states
 
@@ -1866,21 +1840,27 @@ class AscendDSAImpl(DSAAttentionImpl):
         need_prefill_gather: bool = False,
     ):
         compress_common_attn_metadata = None
-        (compress_kv_cache, swa_kv_cache, state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
-            DeviceOperator.unpack_dsa_forward_kv_cache(kv_cache, self.compress_ratio)
-        )
-
         if self.compress_ratio == 4:
+            (compress_kv_cache, swa_kv_cache, state_cache, _, indexer_k_cache, indexer_scale_cache) = kv_cache
             # sorted keys: [attn, compressor.state_cache, indexer.compressor.state_cache, indexer.k_cache, swa_cache]
             (compressor_attn_metadata, compressor_kv_state_metadata, _, indexer_kv_scale_metadata, swa_metadata) = (
                 attn_metadata
             )
             compress_common_attn_metadata = compressor_attn_metadata
         elif self.compress_ratio == 128:
+            (compress_kv_cache, swa_kv_cache, state_cache, _, _, _) = kv_cache
             # sorted keys: [attn, compressor.state_cache, swa_cache]
             (compressor_attn_metadata, compressor_kv_state_metadata, swa_metadata) = attn_metadata
             compress_common_attn_metadata = compressor_attn_metadata
         else:
+            (
+                _,
+                swa_kv_cache,
+                _,
+                _,
+                _,
+                _,
+            ) = kv_cache
             # sorted keys: [swa_cache]
             (swa_metadata,) = attn_metadata
             compress_common_attn_metadata = swa_metadata
@@ -1905,7 +1885,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 cos,
                 sin,
                 swa_kv_cache,
-                swa_prefill_metadata.slot_mapping,
+                swa_metadata.prefill.slot_mapping,
             )
             qr_pertoken_scale = None  # noqa: F841
         else:
@@ -1913,7 +1893,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             # q
             qr = self.q_norm(self.wq_a(hidden_states))
             q = self.wq_b(qr).unflatten(-1, (self.n_local_heads, self.head_dim))
-            q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
+            q = triton_q_rms(q, self.eps)
 
             torch.ops._C_ascend.inplace_partial_rotary_mul(
                 q.unsqueeze(1),
@@ -1937,34 +1917,10 @@ class AscendDSAImpl(DSAAttentionImpl):
             )
 
             # swa exec kv
-            DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, swa_prefill_metadata.slot_mapping)
+            torch.ops._C_ascend.npu_scatter_nd_update_v2(swa_kv_cache, swa_prefill_metadata.slot_mapping, kv)
 
         compress_cos = common_prefill_metadata.compress_cos[layer_name]
         compress_sin = common_prefill_metadata.compress_sin[layer_name]
-
-        attn_op = DeviceOperator.get_dsa_sparse_attn_op()
-        extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
-        DeviceOperator.add_dsa_sparse_attn_extra_kwargs(extra_attn_kwargs, cu_seqlens_ori_kv=actual_seq_lengths_query)
-
-        if self.compress_ratio <= 1:
-            return attn_op(
-                q,
-                ori_kv=swa_kv_cache,
-                ori_block_table=swa_prefill_metadata.block_table,
-                cu_seqlens_q=actual_seq_lengths_query,
-                seqused_kv=actual_seq_lengths_key,
-                sinks=self.attn_sink,
-                metadata=common_prefill_metadata.sas_metadata,
-                softmax_scale=self.softmax_scale,
-                cmp_ratio=max(self.compress_ratio, 1),
-                ori_mask_mode=4,
-                ori_win_left=self.window_size - 1,
-                ori_win_right=0,
-                layout_q="TND",
-                layout_kv="PA_ND",
-                **extra_attn_kwargs,
-            )[0]
-
         if self.compress_ratio > 1:
             compressor_prefill_metadata = _require_prefill_metadata(compressor_attn_metadata)
             compressor_state_prefill_metadata = _require_prefill_metadata(compressor_kv_state_metadata)
@@ -2045,10 +2001,14 @@ class AscendDSAImpl(DSAAttentionImpl):
                     torch.npu.current_stream().wait_event(e_compressed_kv_done)
                     weights_proj_output = self.weights_proj(hidden_states)
                 # Main stream: q_quant (between compressed_kv and kv_scatter)
-                q_quant, q_scale = DeviceOperator.indexer_quantize_query(indexer_q)
+                soc_version = get_ascend_device_type()
+                dst_type = torch.float8_e4m3fn if soc_version in {AscendDeviceType.A5} else torch.int8
+                q_quant, q_scale = torch_npu.npu_dynamic_quant(indexer_q, dst_type=dst_type)
+                if soc_version not in {AscendDeviceType.A5}:
+                    q_scale = q_scale.to(torch.float16)
 
-            DeviceOperator.dsa_kv_compress_scatter(
-                compress_kv_cache, compressed_kv, compressor_prefill_metadata.slot_mapping
+            torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                compress_kv_cache, compressor_prefill_metadata.slot_mapping, compressed_kv
             )
 
             if self.multistream_dsv4_dsa_overlap and self.compress_ratio == 4 and not self.skip_topk:
@@ -2064,9 +2024,9 @@ class AscendDSAImpl(DSAAttentionImpl):
                 compress_topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer(
                     query=q_quant,
                     key=indexer_k_cache,
-                    weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
-                    query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
-                    key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
+                    weights=weights.to(torch.float16),
+                    query_dequant_scale=q_scale,
+                    key_dequant_scale=indexer_scale_cache.squeeze(-2),
                     actual_seq_lengths_query=qlens,
                     actual_seq_lengths_key=kvlens,
                     block_table=block_table,
@@ -2086,55 +2046,69 @@ class AscendDSAImpl(DSAAttentionImpl):
             if self.compress_ratio == 4 and self.use_index_cache:
                 self._update_indexcache_topk_indices(compress_topk_idxs, offset=prefill_offset)
 
-            if self.compress_ratio == 4:
-                DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
-                    extra_attn_kwargs, cu_seqlens_cmp_kv=common_prefill_metadata.cu_c4_cmp_seqlen_list
-                )
-                attn_output = attn_op(
-                    q,
-                    ori_kv=swa_kv_cache,
-                    cmp_kv=compress_kv_cache,
-                    cmp_sparse_indices=compress_topk_idxs,
-                    ori_block_table=swa_prefill_metadata.block_table,
-                    cmp_block_table=compressor_prefill_metadata.block_table,
-                    cu_seqlens_q=actual_seq_lengths_query,
-                    seqused_kv=actual_seq_lengths_key,
-                    sinks=self.attn_sink,
-                    metadata=common_prefill_metadata.sas_metadata,
-                    softmax_scale=self.softmax_scale,
-                    cmp_ratio=self.compress_ratio,
-                    ori_mask_mode=4,
-                    cmp_mask_mode=3,
-                    ori_win_left=self.window_size - 1,
-                    ori_win_right=0,
-                    layout_q="TND",
-                    layout_kv="PA_ND",
-                    **extra_attn_kwargs,
-                )[0]
-            else:
-                DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
-                    extra_attn_kwargs, cu_seqlens_cmp_kv=common_prefill_metadata.cu_c128_cmp_seqlen_list
-                )
-                attn_output = attn_op(
-                    q,
-                    ori_kv=swa_kv_cache,
-                    cmp_kv=compress_kv_cache,
-                    ori_block_table=swa_prefill_metadata.block_table,
-                    cmp_block_table=compressor_prefill_metadata.block_table,
-                    cu_seqlens_q=actual_seq_lengths_query,
-                    seqused_kv=actual_seq_lengths_key,
-                    sinks=self.attn_sink,
-                    metadata=common_prefill_metadata.sas_metadata,
-                    softmax_scale=self.softmax_scale,
-                    cmp_ratio=self.compress_ratio,
-                    ori_mask_mode=4,
-                    cmp_mask_mode=3,
-                    ori_win_left=self.window_size - 1,
-                    ori_win_right=0,
-                    layout_q="TND",
-                    layout_kv="PA_ND",
-                    **extra_attn_kwargs,
-                )[0]
+        if self.compress_ratio <= 1:
+            attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
+                q,
+                ori_kv=swa_kv_cache,
+                ori_block_table=swa_prefill_metadata.block_table,
+                cu_seqlens_q=actual_seq_lengths_query,
+                cu_seqlens_ori_kv=actual_seq_lengths_query,
+                seqused_kv=actual_seq_lengths_key,
+                sinks=self.attn_sink,
+                metadata=common_prefill_metadata.sas_metadata,
+                softmax_scale=self.softmax_scale,
+                cmp_ratio=self.compress_ratio,
+                ori_mask_mode=4,
+                ori_win_left=self.window_size - 1,
+                ori_win_right=0,
+                layout_q="TND",
+                layout_kv="PA_ND",
+            )[0]
+        elif self.compress_ratio == 4:
+            attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
+                q,
+                ori_kv=swa_kv_cache,
+                cmp_kv=compress_kv_cache,
+                cmp_sparse_indices=compress_topk_idxs,
+                ori_block_table=swa_prefill_metadata.block_table,
+                cmp_block_table=compressor_prefill_metadata.block_table,
+                cu_seqlens_q=actual_seq_lengths_query,
+                cu_seqlens_ori_kv=actual_seq_lengths_query,
+                cu_seqlens_cmp_kv=common_prefill_metadata.cu_c4_cmp_seqlen_list,
+                seqused_kv=actual_seq_lengths_key,
+                sinks=self.attn_sink,
+                metadata=common_prefill_metadata.sas_metadata,
+                softmax_scale=self.softmax_scale,
+                cmp_ratio=self.compress_ratio,
+                ori_mask_mode=4,
+                cmp_mask_mode=3,
+                ori_win_left=self.window_size - 1,
+                ori_win_right=0,
+                layout_q="TND",
+                layout_kv="PA_ND",
+            )[0]
+        else:
+            attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
+                q,
+                ori_kv=swa_kv_cache,
+                cmp_kv=compress_kv_cache,
+                ori_block_table=swa_prefill_metadata.block_table,
+                cmp_block_table=compressor_prefill_metadata.block_table,
+                cu_seqlens_q=actual_seq_lengths_query,
+                cu_seqlens_ori_kv=actual_seq_lengths_query,
+                cu_seqlens_cmp_kv=common_prefill_metadata.cu_c128_cmp_seqlen_list,
+                seqused_kv=actual_seq_lengths_key,
+                sinks=self.attn_sink,
+                metadata=compressor_prefill_metadata.sas_metadata,
+                softmax_scale=self.softmax_scale,
+                cmp_ratio=self.compress_ratio,
+                ori_mask_mode=4,
+                cmp_mask_mode=3,
+                ori_win_left=self.window_size - 1,
+                ori_win_right=0,
+                layout_q="TND",
+                layout_kv="PA_ND",
+            )[0]
         return attn_output
 
     def _forward_decode(
@@ -2147,21 +2121,20 @@ class AscendDSAImpl(DSAAttentionImpl):
         assert attn_metadata[0].decode is not None
         compress_common_attn_metadata = None
 
-        (compress_kv_cache, swa_kv_cache, state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
-            DeviceOperator.unpack_dsa_forward_kv_cache(kv_cache, self.compress_ratio)
-        )
-
         if self.compress_ratio == 4:
+            (compress_kv_cache, swa_kv_cache, state_cache, _, indexer_k_cache, indexer_scale_cache) = kv_cache
             # sorted keys: [attn, compressor.state_cache, indexer.compressor.state_cache, indexer.k_cache, swa_cache]
             (compressor_attn_metadata, compressor_kv_state_metadata, _, indexer_kv_scale_metadata, swa_metadata) = (
                 attn_metadata
             )
             compress_common_attn_metadata = compressor_attn_metadata
         elif self.compress_ratio == 128:
+            (compress_kv_cache, swa_kv_cache, state_cache, _, _, _) = kv_cache
             # sorted keys: [attn, compressor.state_cache, swa_cache]
             (compressor_attn_metadata, compressor_kv_state_metadata, swa_metadata) = attn_metadata
             compress_common_attn_metadata = compressor_attn_metadata
         else:
+            (_, swa_kv_cache, _, _, _, _) = kv_cache
             # sorted keys: [swa_cache]
             (swa_metadata,) = attn_metadata
             compress_common_attn_metadata = swa_metadata
@@ -2203,7 +2176,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 q = self.wq_b(q).unflatten(-1, (self.n_local_heads, self.head_dim))
                 qr_pertoken_scale = None
 
-            q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
+            q = triton_q_rms(q, self.eps)
 
             torch.ops._C_ascend.inplace_partial_rotary_mul(
                 q.unsqueeze(1),
@@ -2232,7 +2205,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 )
 
                 # swa exec kv
-                DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, swa_decode_metadata.slot_mapping)
+                torch.ops._C_ascend.npu_scatter_nd_update_v2(swa_kv_cache, swa_decode_metadata.slot_mapping, kv)
 
                 wait_attention_cal_event = (
                     torch.npu.current_stream().record_event() if self.multistream_dsa_preprocess else None
@@ -2318,10 +2291,14 @@ class AscendDSAImpl(DSAAttentionImpl):
                     torch.npu.current_stream().wait_event(e_compressed_kv_done)
                     weights_proj_output = self.weights_proj(hidden_states)
                 # Main stream: q_quant (between compressed_kv and kv_scatter)
-                q_quant, q_scale = DeviceOperator.indexer_quantize_query(indexer_q)
+                soc_version = get_ascend_device_type()
+                dst_type = torch.float8_e4m3fn if soc_version in {AscendDeviceType.A5} else torch.int8
+                q_quant, q_scale = torch_npu.npu_dynamic_quant(indexer_q, dst_type=dst_type)
+                if soc_version not in {AscendDeviceType.A5}:
+                    q_scale = q_scale.to(torch.float16)
 
-            DeviceOperator.dsa_kv_compress_scatter(
-                compress_kv_cache, compressed_kv, compressor_decode_metadata.slot_mapping
+            torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                compress_kv_cache, compressor_decode_metadata.slot_mapping, compressed_kv
             )
 
             if self.multistream_dsv4_dsa_overlap and self.compress_ratio == 4 and not self.skip_topk:
@@ -2337,9 +2314,9 @@ class AscendDSAImpl(DSAAttentionImpl):
                 compress_topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer(
                     query=q_quant,
                     key=indexer_k_cache,
-                    weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
-                    query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
-                    key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
+                    weights=weights.to(torch.float16),
+                    query_dequant_scale=q_scale,
+                    key_dequant_scale=indexer_scale_cache.squeeze(-2),
                     actual_seq_lengths_query=qlens,
                     actual_seq_lengths_key=kvlens,
                     block_table=block_table,
@@ -2359,11 +2336,8 @@ class AscendDSAImpl(DSAAttentionImpl):
             if self.compress_ratio == 4 and self.use_index_cache:
                 self._update_indexcache_topk_indices(compress_topk_idxs, offset=0)
 
-        attn_op = DeviceOperator.get_dsa_sparse_attn_op()
-        extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
-
         if self.compress_ratio <= 1:
-            attn_output = attn_op(
+            attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
                 q,
                 ori_kv=swa_kv_cache,
                 ori_block_table=swa_decode_metadata.block_table,
@@ -2372,16 +2346,15 @@ class AscendDSAImpl(DSAAttentionImpl):
                 sinks=self.attn_sink,
                 metadata=swa_decode_metadata.sas_metadata,
                 softmax_scale=self.softmax_scale,
-                cmp_ratio=max(self.compress_ratio, 1),
+                cmp_ratio=self.compress_ratio,
                 ori_mask_mode=4,
                 ori_win_left=self.window_size - 1,
                 ori_win_right=0,
                 layout_q="TND",
                 layout_kv="PA_ND",
-                **extra_attn_kwargs,
             )[0]
         elif self.compress_ratio == 4:
-            attn_output = attn_op(
+            attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
                 q,
                 ori_kv=swa_kv_cache,
                 cmp_kv=compress_kv_cache,
@@ -2400,10 +2373,9 @@ class AscendDSAImpl(DSAAttentionImpl):
                 ori_win_right=0,
                 layout_q="TND",
                 layout_kv="PA_ND",
-                **extra_attn_kwargs,
             )[0]
         else:
-            attn_output = attn_op(
+            attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
                 q,
                 ori_kv=swa_kv_cache,
                 cmp_kv=compress_kv_cache,
@@ -2421,7 +2393,6 @@ class AscendDSAImpl(DSAAttentionImpl):
                 ori_win_right=0,
                 layout_q="TND",
                 layout_kv="PA_ND",
-                **extra_attn_kwargs,
             )[0]
         return attn_output
 
@@ -2439,9 +2410,14 @@ class AscendDSAImpl(DSAAttentionImpl):
         with_prefill: bool = False,
         qr_pertoken_scale: torch.Tensor = None,
     ):
-        (indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
-            DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
-        )
+        (
+            _,
+            _,
+            _,
+            indexer_state_cache,
+            indexer_k_cache,
+            indexer_scale_cache,
+        ) = kv_cache
         (
             _,
             _,
@@ -2454,7 +2430,6 @@ class AscendDSAImpl(DSAAttentionImpl):
             (not isinstance(self.inderxer_wq_b.quant_method, AscendUnquantizedLinearMethod))
             and isinstance(self.inderxer_wq_b.quant_method.quant_method, AscendW8A8DynamicLinearMethod)
             and qr_pertoken_scale is not None
-            and get_ascend_device_type() not in {AscendDeviceType.A5}
         ):
             q = torch_npu.npu_quant_matmul(
                 qr,
@@ -2521,7 +2496,6 @@ class AscendDSAImpl(DSAAttentionImpl):
             kv,
             indexer_k_cache,
             indexer_scale_cache,
-            indexer_full_cache,
             indexer_kv_state_metadata,
             indexer_kv_scale_metadata,
             with_prefill,
@@ -2534,7 +2508,6 @@ class AscendDSAImpl(DSAAttentionImpl):
         weights: torch.Tensor,
         indexer_k_cache: torch.Tensor,
         indexer_scale_cache: torch.Tensor,
-        indexer_full_cache: torch.Tensor | None,
         indexer_kv_state_metadata,
         indexer_kv_scale_metadata,
         with_prefill: bool,
@@ -2544,7 +2517,6 @@ class AscendDSAImpl(DSAAttentionImpl):
             kv,
             indexer_k_cache,
             indexer_scale_cache,
-            indexer_full_cache,
             indexer_kv_scale_metadata,
             with_prefill,
         )
@@ -2564,18 +2536,45 @@ class AscendDSAImpl(DSAAttentionImpl):
         kv: torch.Tensor | None,
         indexer_k_cache: torch.Tensor,
         indexer_scale_cache: torch.Tensor,
-        indexer_full_cache: torch.Tensor | None,
         indexer_kv_scale_metadata,
         with_prefill: bool,
     ):
-        slot_mapping = (
-            indexer_kv_scale_metadata.prefill.slot_mapping
-            if with_prefill
-            else indexer_kv_scale_metadata.decode.slot_mapping
-        )
-        return DeviceOperator.indexer_quant_scatter(
-            q, kv, indexer_k_cache, indexer_scale_cache, indexer_full_cache, slot_mapping
-        )
+        soc_version = get_ascend_device_type()
+        dst_type = torch.float8_e4m3fn if soc_version in {AscendDeviceType.A5} else torch.int8
+
+        q, q_scale = torch_npu.npu_dynamic_quant(q, dst_type=dst_type)
+        if kv is not None:
+            kv, kv_scale = torch_npu.npu_dynamic_quant(kv, dst_type=dst_type)
+            kv_scale = kv_scale.unsqueeze(-1)
+        else:
+            kv_scale = None
+
+        if soc_version not in {AscendDeviceType.A5}:
+            q_scale = q_scale.to(torch.float16)
+            if kv is not None:
+                kv_scale = kv_scale.to(torch.float16)
+                kv_scale = kv_scale.unsqueeze(-1)
+
+        if with_prefill:
+            assert indexer_kv_scale_metadata.prefill is not None
+            if kv is not None:
+                torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                    indexer_k_cache, indexer_kv_scale_metadata.prefill.slot_mapping, kv
+                )
+                torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                    indexer_scale_cache, indexer_kv_scale_metadata.prefill.slot_mapping, kv_scale
+                )
+        else:
+            assert indexer_kv_scale_metadata.decode is not None
+            if kv is not None:
+                torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                    indexer_k_cache, indexer_kv_scale_metadata.decode.slot_mapping, kv
+                )
+                torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                    indexer_scale_cache, indexer_kv_scale_metadata.decode.slot_mapping, kv_scale
+                )
+
+        return q, q_scale, kv, kv_scale
 
     def _indexer_qli(
         self,
@@ -2603,9 +2602,9 @@ class AscendDSAImpl(DSAAttentionImpl):
         topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer(
             query=q,
             key=indexer_k_cache,
-            weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
-            query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
-            key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
+            weights=weights.to(torch.float16),
+            query_dequant_scale=q_scale,
+            key_dequant_scale=indexer_scale_cache.squeeze(-2),
             actual_seq_lengths_query=qlens,
             actual_seq_lengths_key=kvlens,
             block_table=block_table,
@@ -2638,7 +2637,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         with_prefill: bool = False,
         qr_pertoken_scale: torch.Tensor = None,
     ):
-        q, kv, ik, isc, ifc, indexer_kv_state_meta, isc_meta, wp = self._indexer_qkv_prepare(
+        q, kv, ik, isc, indexer_kv_state_meta, isc_meta, wp = self._indexer_qkv_prepare(
             x,
             qr,
             kv_cache,
@@ -2654,7 +2653,7 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         weights = self.weights_proj(x) * (self.indexer_softmax_scale * self.indexer_heads**-0.5)
 
-        return self._indexer_qli_finish(q, kv, weights, ik, isc, ifc, indexer_kv_state_meta, isc_meta, wp)
+        return self._indexer_qli_finish(q, kv, weights, ik, isc, indexer_kv_state_meta, isc_meta, wp)
 
     def cv_indexer_select_qli(
         self,
@@ -2681,14 +2680,15 @@ class AscendDSAImpl(DSAAttentionImpl):
         - Part3: Main q_hadamard[C] ∥ Aux scatter_scale_cache[AIV]
         - Part4: Caller runs weights_proj + q_quant + indexer
         """
-        (indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
-            DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
-        )
+        (_, _, _, indexer_state_cache, indexer_k_cache, indexer_scale_cache) = kv_cache
         # sorted keys: [attn, compressor.state_cache, indexer.compressor.state_cache, indexer.k_cache, swa_cache]
         (_, _, indexer_kv_state_metadata, indexer_kv_scale_metadata, _) = attn_metadata
 
         main_stream = torch.npu.current_stream()
         aux_stream = dsv4_dsa_overlap_stream()
+
+        soc_version = get_ascend_device_type()
+        dst_type = torch.float8_e4m3fn if soc_version in {AscendDeviceType.A5} else torch.int8
 
         # ===== Part0: Pre-compute on main =====
         if (
@@ -2746,16 +2746,18 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         # Aux: kv_quant + scatter_k_cache (parallel with main matmul + rope)
         if kv is not None:
-            slot_mapping_indexer = (
-                indexer_scale_prefill_metadata.slot_mapping
-                if with_prefill
-                else indexer_scale_decode_metadata.slot_mapping
-            )
             with npu_stream_switch(aux_stream, enabled=True):
                 torch.npu.current_stream().wait_event(e_kv_ready)
-                kv, kv_scale = DeviceOperator.indexer_quant_scatter_part1(
-                    kv, indexer_k_cache, indexer_full_cache, slot_mapping_indexer
-                )
+                kv, kv_scale = torch_npu.npu_dynamic_quant(kv, dst_type=dst_type)
+                kv_scale = kv_scale.unsqueeze(-1)
+                if with_prefill:
+                    torch.ops._C_ascend.npu_scatter_nd_update_v2(  # kv_scatter
+                        indexer_k_cache, indexer_scale_prefill_metadata.slot_mapping, kv
+                    )
+                else:
+                    torch.ops._C_ascend.npu_scatter_nd_update_v2(  # kv_scatter
+                        indexer_k_cache, indexer_scale_decode_metadata.slot_mapping, kv
+                    )
 
         # Main: matmul q from qr (directly submit, V/C different engines dispatch naturally)
         if (
@@ -2795,20 +2797,19 @@ class AscendDSAImpl(DSAAttentionImpl):
         e_rope_done = main_stream.record_event()
 
         # ===== Part3: q_hadamard[C] ∥ scatter_scale_cache[AIV] =====
-        # Note: On A5, indexer_compress_epilog_v2 in Part1 handles both k_cache
-        # and scale_cache in one fused operation, so Part3 is skipped
-        # (kv_scale is None on A5 from indexer_quant_scatter_part1).
-        if kv is not None and kv_scale is not None:
-            slot_mapping_indexer_part3 = (
-                indexer_scale_prefill_metadata.slot_mapping
-                if with_prefill
-                else indexer_scale_decode_metadata.slot_mapping
-            )
+        if kv is not None:
             with npu_stream_switch(aux_stream, enabled=True):
                 torch.npu.current_stream().wait_event(e_rope_done)
-                DeviceOperator.dsa_indexer_scatter_scale_part3(
-                    kv_scale, indexer_scale_cache, slot_mapping_indexer_part3
-                )
+                if soc_version not in {AscendDeviceType.A5}:
+                    kv_scale = kv_scale.to(torch.float16).unsqueeze(-1)
+                if with_prefill:
+                    torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                        indexer_scale_cache, indexer_scale_prefill_metadata.slot_mapping, kv_scale
+                    )
+                else:
+                    torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                        indexer_scale_cache, indexer_scale_decode_metadata.slot_mapping, kv_scale
+                    )
 
         # Main: q_hadamard[Part1 - linear] (directly submit, C/AIV different engines dispatch naturally)
         # Part1: F.linear - parallel with aux_stream kv_scatter

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -107,6 +107,10 @@ class ACLGraphWrapper:
         # in case we need to access the original runnable.
         return self.runnable
 
+    def is_captured(self, batch_descriptor: BatchDescriptor) -> bool:
+        entry = self.concrete_aclgraph_entries.get(batch_descriptor)
+        return entry is not None and entry.aclgraph is not None
+
     def __call__(self, *args, **kwargs):
         forward_context = get_forward_context()
         batch_descriptor = forward_context.batch_descriptor

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -25,6 +25,7 @@ from vllm_ascend.device.mxfp_compat import (
 )
 from vllm_ascend.ops.triton.fla.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd_kernel
 from vllm_ascend.ops.triton.fla.solve_tril import solve_tril_16x16_kernel
+from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
@@ -370,6 +371,10 @@ class BaseDeviceAdaptor:
     def npu_gemma_rms_norm(x, weight, variance_epsilon):
         x, _ = torch.ops._C_ascend.npu_gemma_rms_norm(x, weight, variance_epsilon)
         return x
+
+    @staticmethod
+    def fused_gdn_gating(A_log: torch.Tensor, a: torch.Tensor, b: torch.Tensor, dt_bias: torch.Tensor):
+        return torch.ops._C_ascend.npu_fused_gdn_gating(A_log, a, b, dt_bias.to(torch.float32))
 
 
 class A5DeviceAdaptor(BaseDeviceAdaptor):
@@ -776,6 +781,10 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
     def npu_gemma_rms_norm(x, weight, variance_epsilon):
         x, _ = torch_npu.npu_rms_norm(x, 1.0 + weight, variance_epsilon)
         return x
+
+    @staticmethod
+    def fused_gdn_gating(A_log: torch.Tensor, a: torch.Tensor, b: torch.Tensor, dt_bias: torch.Tensor):
+        return fused_gdn_gating_patch(A_log, a, b, dt_bias)
 
 
 def get_device_adaptor() -> type["BaseDeviceAdaptor"]:

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -16,7 +16,6 @@
 # This file is a part of the vllm-ascend project.
 #
 import torch
-import torch.nn.functional as F
 import torch_npu
 
 from vllm_ascend.device.mxfp_compat import (
@@ -124,7 +123,7 @@ class BaseDeviceAdaptor:
         use_mxfp_quant: bool = False,
         act_quant_type: torch.dtype | int = torch.float8_e4m3fn,
         weight_quant_type: torch.dtype | int = torch.float8_e4m3fn,
-        swiglu_limit: float = 0.0,
+        swiglu_limit: int = 0,
         mxfp_quant_dtype: QuantType | None = None,
     ):
         if use_mxfp_quant:
@@ -314,192 +313,6 @@ class BaseDeviceAdaptor:
 
         return context_layer
 
-    # ===== Sparse Attention Metadata & Op Selectors =====
-
-    @staticmethod
-    def get_dsa_sparse_attn_metadata_op():
-        """Returns the metadata-building operator for sparse attention."""
-        return torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata
-
-    @staticmethod
-    def get_dsa_sparse_attn_metadata_kwargs(device):
-        """Returns kwargs for sparse attention metadata builder."""
-        return {"device": str(device)}
-
-    @staticmethod
-    def get_dsa_sparse_attn_op():
-        """Returns the sparse attention operator."""
-        return torch.ops._C_ascend.npu_sparse_attn_sharedkv
-
-    @staticmethod
-    def get_dsa_sparse_attn_base_kwargs():
-        """Returns base kwargs for sparse attention (extended by caller)."""
-        return {}
-
-    # ===== SWA / Compressor KV Scatter =====
-
-    @staticmethod
-    def dsa_kv_compress_scatter(cache, x, slot_mapping):
-        """Scatter KV into cache. Non-A5: simple scatter of pre-quantized tensor."""
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(cache, slot_mapping, x)
-
-    # ===== Indexer Quant + Scatter =====
-
-    @staticmethod
-    def indexer_quantize_query(q):
-        """Quantize indexer query for lightning_indexer.
-        Non-A5: int8 quant with float16 scale."""
-        q_quant, q_scale = torch_npu.npu_dynamic_quant(q, dst_type=torch.int8)
-        q_scale = q_scale.to(torch.float16)
-        return q_quant, q_scale
-
-    @staticmethod
-    def indexer_quant_scatter(q, kv, indexer_k_cache, indexer_scale_cache, indexer_full_cache, slot_mapping):
-        """Quantize q and scatter kv into indexer cache.
-        Non-A5: int8 quant + 2x scatter_nd_update_v2 for k_cache and scale_cache."""
-        q, q_scale = torch_npu.npu_dynamic_quant(q, dst_type=torch.int8)
-        q_scale = q_scale.to(torch.float16)
-
-        kv_out = kv
-        kv_scale_out = None
-        if kv is not None:
-            kv_out, kv_scale_out = torch_npu.npu_dynamic_quant(kv, dst_type=torch.int8)
-            kv_scale_out = kv_scale_out.unsqueeze(-1).to(torch.float16)
-            if kv_scale_out.ndim < 4:
-                kv_scale_out = kv_scale_out.unsqueeze(-1)
-            torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_k_cache, slot_mapping, kv_out)
-            torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_scale_cache, slot_mapping, kv_scale_out)
-
-        return q, q_scale, kv_out, kv_scale_out
-
-    @staticmethod
-    def indexer_quant_scatter_part1(kv, indexer_k_cache, indexer_full_cache, slot_mapping):
-        """Part1 of multi-stream indexer scatter.
-        Non-A5: quantize kv + scatter k_cache.
-        Returns (kv_quant, kv_scale) for use in Part3, or (None, None) if kv is None."""
-        if kv is None:
-            return None, None
-        kv_out, kv_scale = torch_npu.npu_dynamic_quant(kv, dst_type=torch.int8)
-        kv_scale = kv_scale.unsqueeze(-1)
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_k_cache, slot_mapping, kv_out)
-        return kv_out, kv_scale
-
-    @staticmethod
-    def dsa_indexer_scatter_scale_part3(kv_scale, indexer_scale_cache, slot_mapping):
-        """Part3 of multi-stream indexer scatter.
-        Non-A5: scatter scale_cache (float16 conversion + scatter)."""
-        kv_scale = kv_scale.to(torch.float16)
-        if kv_scale.ndim < 4:
-            kv_scale = kv_scale.unsqueeze(-1)
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_scale_cache, slot_mapping, kv_scale)
-
-    @staticmethod
-    def warmup_indexer_quant_scatter(hidden_states, slot_mapping):
-        """Warmup profiling for indexer quant+scatter.
-        Non-A5: int8 quant + 2x scatter with dummy cache tensors."""
-        kv_dummy, kv_scale_dummy = torch_npu.npu_dynamic_quant(hidden_states, dst_type=torch.int8)
-        kv_scale_dummy = kv_scale_dummy.unsqueeze(-1).to(torch.float16)
-        if kv_scale_dummy.ndim < 4:
-            kv_scale_dummy = kv_scale_dummy.unsqueeze(-1)
-        dummy_shape = (1, 1, 1, kv_dummy.shape[-1])
-        indexer_k_cache = torch.zeros(dummy_shape, dtype=kv_dummy.dtype, device=hidden_states.device)
-        indexer_scale_cache = torch.zeros(dummy_shape, dtype=torch.float16, device=hidden_states.device)
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_k_cache, slot_mapping, kv_dummy)
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_scale_cache, slot_mapping, kv_scale_dummy)
-
-    # ===== Lightning Indexer Dtype Prep =====
-
-    @staticmethod
-    def prepare_dsa_indexer_weights(weights):
-        """Non-A5: cast indexer weights to float16."""
-        return weights.to(torch.float16)
-
-    @staticmethod
-    def prepare_dsa_indexer_query_scale(q_scale):
-        """Non-A5: q_scale already float16, pass through."""
-        return q_scale
-
-    @staticmethod
-    def prepare_dsa_indexer_key_scale(indexer_scale_cache):
-        """Non-A5: cast key dequant scale to float16."""
-        return indexer_scale_cache.squeeze(-2).to(torch.float16)
-
-    # ===== Q RMS Norm =====
-
-    @staticmethod
-    def apply_dsa_q_rms(q, eps, q_norm_without_weight=None):
-        """Apply Q RMS norm. Non-A5: triton_q_rms.
-        A5: uses q_norm_without_weight callable when provided."""
-        from vllm.triton_utils import HAS_TRITON
-
-        if HAS_TRITON:
-            from vllm_ascend.ops.triton.rms_norm import triton_q_rms
-
-            return triton_q_rms(q, eps)
-        return q
-
-    # ===== KV Cache Helpers =====
-
-    @staticmethod
-    def unpack_dsa_indexer_kv_cache(kv_cache):
-        """Unpack indexer kv_cache tuple.
-        Non-A5: returns (state_cache, k_cache, scale_cache, None).
-        A5: returns (state_cache, k_cache, scale_cache, full_cache)."""
-        _, _, _, indexer_state_cache, indexer_k_cache, indexer_scale_cache = kv_cache
-        return indexer_state_cache, indexer_k_cache, indexer_scale_cache, None
-
-    @staticmethod
-    def unpack_dsa_forward_kv_cache(kv_cache, compress_ratio):
-        """Unpack kv_cache for forward pass.
-        Returns 6-tuple: (compress_kv_cache, swa_kv_cache, state_cache,
-        indexer_k_cache, indexer_scale_cache, indexer_full_cache).
-        Non-A5: indexer_full_cache is always None.
-        All devices: unused slots are None.
-        """
-        idx_full = 6  # 7th element (indexer_full_cache), A5 only
-        full_cache = kv_cache[idx_full] if len(kv_cache) > idx_full else None
-        if compress_ratio == 4:
-            # [0]=compress, [1]=swa, [2]=state, [3]=unused, [4]=ik, [5]=isc
-            return (kv_cache[0], kv_cache[1], kv_cache[2], kv_cache[4], kv_cache[5], full_cache)
-        elif compress_ratio == 128:
-            return (kv_cache[0], kv_cache[1], kv_cache[2], None, None, full_cache)
-        else:
-            return (None, kv_cache[1], None, None, None, full_cache)
-
-    @staticmethod
-    def pad_dsa_decode_slot_mapping(slot_mapping, num_decode_tokens, compress_ratio, num_decodes):
-        """Pad slot_mapping for decode metadata. Non-A5: pass through."""
-        return slot_mapping
-
-    @staticmethod
-    def format_dsa_slot_mapping(slot_mapping, block_size):
-        """Format slot_mapping for metadata storage.
-        Non-A5: 2D [block_idx, offset]; A5: 1D pass-through."""
-        return torch.stack([slot_mapping // block_size, slot_mapping % block_size], axis=-1)
-
-    @staticmethod
-    def get_dsa_decode_cu_seqlens_cmp_kv(cmp_kv_tensor):
-        """Non-A5: return the cached cu_seqlens_cmp_kv tensor.
-        A5 override always returns None."""
-        return cmp_kv_tensor
-
-    @staticmethod
-    def add_dsa_sparse_attn_extra_kwargs(extra_kwargs, **kwargs_to_add):
-        """Non-A5: add extra kwargs for sparse attention. A5: no-op."""
-        extra_kwargs.update(kwargs_to_add)
-
-    @staticmethod
-    def get_dsa_decode_cu_seqlens_ori_kv(
-        decode_ratio_to_sas_metadata, cache_key, seq_lens, num_decodes, zero_i32, fallback_cu_seqlens
-    ):
-        """Non-A5: return fallback directly (self.cu_seqlens_ori_kv)."""
-        return fallback_cu_seqlens
-
-    @staticmethod
-    def get_dsa_kernel_block_sizes():
-        """Non-A5: return supported kernel block sizes."""
-        return [8, 32, 128]
-
     @staticmethod
     def chunk_scaled_dot_kkt_fwd(NT, k, beta, g_cumsum, A, cu_seqlens, chunk_indices, T, B, H, Hg, K, BT, BK):
         chunk_scaled_dot_kkt_fwd_kernel[(NT, 1)](
@@ -669,7 +482,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         use_mxfp_quant: bool = False,
         act_quant_type: torch.dtype | int = torch.float8_e4m3fn,
         weight_quant_type: torch.dtype | int = torch.float8_e4m3fn,
-        swiglu_limit: float = 0.0,
+        swiglu_limit: int = 0,
         mxfp_quant_dtype: QuantType | None = None,
     ):
         if not use_mxfp_quant:
@@ -701,14 +514,9 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
                 weight_dtype=torch_npu.float4_e2m1fn_x2,
                 output_dtype=torch.bfloat16,
             )[0]
-            # DSV4 need swiglu_limit input
-            out, out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
-                hidden_states,
-                topk_weight=None,
-                group_index=None,
-                dst_type=torch.float8_e4m3fn,
-                quant_mode=2,
-                clamp_value=swiglu_limit,
+            hidden_states = torch_npu.npu_swiglu(hidden_states)
+            out, out_scale = torch_npu.npu_dynamic_mx_quant(
+                hidden_states, dst_type=torch.float8_e4m3fn, round_mode="rint"
             )
         else:
             out, out_scale = torch_npu.npu_grouped_matmul_swiglu_quant_v2(
@@ -808,7 +616,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             input_dtype=input_dtype,
             act_quant_type=act_quant_type,
             weight_quant_type=weight_quant_type,
-            scale_type=scale_type if mxfp_quant_dtype != QuantType.W4A8MXFP else None,
+            scale_type=scale_type,
             per_token_scale_type=per_token_scale_type,
             use_bf16=use_bf16,
             use_mxfp_quant=True,
@@ -821,10 +629,6 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             raise ValueError(f"w2_scale must have a single tensor in MXFP path, but got {len(weight_scale)}.")
         gmm2_weight = weight if isinstance(weight, list) else [weight]
         gmm2_scale = weight_scale if isinstance(weight_scale, list) else [weight_scale]
-
-        if mxfp_quant_dtype == QuantType.W4A8MXFP:
-            gmm2_scale = None  # type: ignore[assignment]
-            gmm2_kwargs.update({"antiquant_scale": [weight_scale]})
 
         if mxfp_quant_dtype == QuantType.W4A8MXFP:
             gmm2_scale = None  # type: ignore[assignment]
@@ -899,209 +703,6 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             decode_q_nope, decode_q_pe, decode_k_nope, decode_k_pe, dequant_scale_q_nope=dequant_scale_q_nope
         )
         return decode_preprocess_res, None
-
-    # ===== Sparse Attention Metadata & Op Selectors =====
-
-    @staticmethod
-    def get_dsa_sparse_attn_metadata_op():
-        return torch.ops._C_ascend.npu_kv_quant_sparse_attn_sharedkv_metadata
-
-    @staticmethod
-    def get_dsa_sparse_attn_metadata_kwargs(device):
-        return {"kv_quant_mode": 1}
-
-    @staticmethod
-    def get_dsa_sparse_attn_op():
-        return torch.ops._C_ascend.npu_kv_quant_sparse_attn_sharedkv
-
-    @staticmethod
-    def get_dsa_sparse_attn_base_kwargs():
-        return {"kv_quant_mode": 1, "tile_size": 64, "rope_head_dim": 64}
-
-    # ===== SWA / Compressor KV Scatter =====
-
-    @staticmethod
-    def dsa_kv_compress_scatter(cache, x, slot_mapping):
-        """Scatter KV into cache with fused quantization+compression.
-        A5: kv_compress_epilog handles quant/compress/scatter internally.
-        Input x is unquantized bf16; cache shape is [..., head_dim]."""
-        torch.ops._C_ascend.kv_compress_epilog(
-            kv_compress_cache=cache.view(-1, 1, cache.shape[-1]),
-            x=x.view(-1, x.shape[-1]),
-            slot_mapping=slot_mapping,
-            quant_group_size=64,
-            quant_mode=2,
-            round_scale_flag=True,
-            layout=1,
-        )
-
-    # ===== Indexer Quant + Scatter =====
-
-    @staticmethod
-    def indexer_quantize_query(q):
-        """Quantize indexer query. A5: fp8 quant, no extra scale conversion."""
-        q_quant, q_scale = torch_npu.npu_dynamic_quant(q, dst_type=torch.float8_e4m3fn)
-        return q_quant, q_scale
-
-    @staticmethod
-    def indexer_quant_scatter(q, kv, indexer_k_cache, indexer_scale_cache, indexer_full_cache, slot_mapping):
-        """Quantize q (fp8) and scatter kv via fused indexer_compress_epilog_v2.
-        On A5, the fused op handles kv quantization, k_cache scatter, and
-        scale_cache scatter internally. q is quantized separately for use
-        by lightning_indexer."""
-        q, q_scale = torch_npu.npu_dynamic_quant(q, dst_type=torch.float8_e4m3fn)
-
-        kv_out = kv
-        kv_scale_out = None
-        if kv is not None:
-            torch.ops._C_ascend.indexer_compress_epilog_v2(
-                indexer_compress_cache=indexer_full_cache.view(torch.uint8),
-                x=kv,
-                slot_mapping=slot_mapping,
-                layout=2,
-            )
-
-        return q, q_scale, kv_out, kv_scale_out
-
-    @staticmethod
-    def indexer_quant_scatter_part1(kv, indexer_k_cache, indexer_full_cache, slot_mapping):
-        """Part1 of multi-stream indexer scatter.
-        A5: fused indexer_compress_epilog_v2 handles both k_cache and scale_cache.
-        Returns (kv, None) to signal Part3 is a no-op."""
-        if kv is None:
-            return None, None
-        torch.ops._C_ascend.indexer_compress_epilog_v2(
-            indexer_compress_cache=indexer_full_cache.view(torch.uint8),
-            x=kv,
-            slot_mapping=slot_mapping,
-            layout=2,
-        )
-        return kv, None
-
-    @staticmethod
-    def dsa_indexer_scatter_scale_part3(kv_scale, indexer_scale_cache, slot_mapping):
-        """Part3 of multi-stream indexer scatter.
-        A5: no-op — fused op in Part1 already handled scale_cache."""
-        pass
-
-    @staticmethod
-    def warmup_indexer_quant_scatter(hidden_states, slot_mapping):
-        """Warmup profiling for indexer quant+scatter.
-        A5: fused indexer_compress_epilog_v2 with dummy cache tensor."""
-        dummy_cache_shape = (1, 1, 1, hidden_states.shape[-1])
-        indexer_full_cache_dummy = torch.zeros(dummy_cache_shape, dtype=torch.uint8, device=hidden_states.device)
-        torch.ops._C_ascend.indexer_compress_epilog_v2(
-            indexer_compress_cache=indexer_full_cache_dummy,
-            x=hidden_states,
-            slot_mapping=slot_mapping,
-            layout=2,
-        )
-
-    # ===== Lightning Indexer Dtype Prep =====
-
-    @staticmethod
-    def prepare_dsa_indexer_weights(weights):
-        """A5: cast indexer weights to float32 (fp8 scale format needs float)."""
-        return weights.float()
-
-    @staticmethod
-    def prepare_dsa_indexer_query_scale(q_scale):
-        """A5: cast query dequant scale to float32."""
-        return q_scale.float()
-
-    @staticmethod
-    def prepare_dsa_indexer_key_scale(indexer_scale_cache):
-        """A5: cast key dequant scale to float32."""
-        return indexer_scale_cache.squeeze(-2).float()
-
-    # ===== Q RMS Norm =====
-
-    @staticmethod
-    def apply_dsa_q_rms(q, eps, q_norm_without_weight=None):
-        """Apply Q RMS norm. A5: uses q_norm_without_weight callable."""
-        if q_norm_without_weight is not None:
-            return q_norm_without_weight(q)
-        from vllm.triton_utils import HAS_TRITON
-
-        if HAS_TRITON:
-            from vllm_ascend.ops.triton.rms_norm import triton_q_rms
-
-            return triton_q_rms(q, eps)
-        return q
-
-    # ===== KV Cache Helpers =====
-
-    @staticmethod
-    def unpack_dsa_indexer_kv_cache(kv_cache):
-        """Unpack indexer kv_cache tuple.
-        A5: returns (state_cache, k_cache, scale_cache, full_cache)."""
-        _, _, _, indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache = kv_cache
-        return indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache
-
-    @staticmethod
-    def unpack_dsa_forward_kv_cache(kv_cache, compress_ratio):
-        """Unpack kv_cache for forward pass. A5: 7-element tuple with
-        indexer_full_cache at position 6; non-A5: 6 elements (None substituted)."""
-        idx_full = 6
-        full_cache = kv_cache[idx_full]
-        if compress_ratio == 4:
-            return (kv_cache[0], kv_cache[1], kv_cache[2], kv_cache[4], kv_cache[5], full_cache)
-        elif compress_ratio == 128:
-            return (kv_cache[0], kv_cache[1], kv_cache[2], None, None, full_cache)
-        else:
-            return (None, kv_cache[1], None, None, None, full_cache)
-
-    @staticmethod
-    def pad_dsa_decode_slot_mapping(slot_mapping, num_decode_tokens, compress_ratio, num_decodes):
-        """A5: pad slot_mapping to target shape for ACL graph compatibility."""
-        tmp = compress_ratio if compress_ratio != 0 else 1
-        target_shape = min(num_decode_tokens, num_decode_tokens // tmp + num_decodes)
-        pad_size = target_shape - slot_mapping.shape[0]
-        if pad_size > 0:
-            if slot_mapping.ndim == 1:
-                slot_mapping = F.pad(slot_mapping, (0, pad_size), value=-1)
-            else:
-                slot_mapping = F.pad(slot_mapping, (0, 0, 0, pad_size), value=-1)
-        else:
-            slot_mapping = slot_mapping[:target_shape]
-        return slot_mapping
-
-    @staticmethod
-    def format_dsa_slot_mapping(slot_mapping, block_size):
-        """A5: 1D pass-through."""
-        return slot_mapping
-
-    @staticmethod
-    def get_dsa_decode_cu_seqlens_cmp_kv(cmp_kv_tensor):
-        """A5: cu_seqlens_cmp_kv is always None."""
-        return None
-
-    @staticmethod
-    def add_dsa_sparse_attn_extra_kwargs(extra_kwargs, **kwargs_to_add):
-        """A5: no-op — A5 ops do not need extra kwargs from this path."""
-        pass
-
-    @staticmethod
-    def get_dsa_decode_cu_seqlens_ori_kv(
-        decode_ratio_to_sas_metadata, cache_key, seq_lens, num_decodes, zero_i32, fallback_cu_seqlens
-    ):
-        """A5: compute from cumsum of seq_lens, with caching."""
-        if decode_ratio_to_sas_metadata is not None and cache_key in decode_ratio_to_sas_metadata:
-            return decode_ratio_to_sas_metadata[cache_key]
-        cu_seqlens = torch.cat(
-            [
-                zero_i32,
-                torch.cumsum(seq_lens[:num_decodes], dim=0).to(torch.int32),
-            ]
-        )
-        if decode_ratio_to_sas_metadata is not None:
-            decode_ratio_to_sas_metadata[cache_key] = cu_seqlens
-        return cu_seqlens
-
-    @staticmethod
-    def get_dsa_kernel_block_sizes():
-        """A5: return supported kernel block sizes."""
-        return [8, 16, 128]
 
     def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):
         seq_lens_cpu = list(seq_lens_cpu.cumsum(0))

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -20,7 +20,6 @@ from vllm.forward_context import ForwardContext
 from vllm.logger import logger
 from vllm.utils.network_utils import make_zmq_socket
 from vllm.v1.attention.backend import AttentionMetadata  # type: ignore
-from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -28,7 +27,6 @@ from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
 from vllm.v1.serial_utils import MsgpackDecoder
 
-from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import AscendStoreKVConnectorWorkerMetadata
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler import (
     KVPoolScheduler,
     get_zmq_rpc_path_lookup,
@@ -155,9 +153,6 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         Args:
             connector_output (KVConnectorOutput): the worker-side connectors output.
         """
-        if self.connector_scheduler is not None:
-            self.connector_scheduler.update_connector_output(connector_output)
-
         # Get the KV events
         kv_cache_events = connector_output.kv_cache_events
         if not kv_cache_events or not isinstance(kv_cache_events, AscendStoreKVEvents):
@@ -259,14 +254,6 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         ascend_store_kv_events = AscendStoreKVEvents(num_workers=1)
         ascend_store_kv_events.add_events(events)
         return ascend_store_kv_events
-
-    def bind_gpu_block_pool(self, gpu_block_pool: "BlockPool") -> None:
-        assert self.connector_scheduler is not None
-        self.connector_scheduler.bind_gpu_block_pool(gpu_block_pool)
-
-    def build_connector_worker_meta(self) -> AscendStoreKVConnectorWorkerMetadata | None:
-        assert self.connector_worker is not None
-        return self.connector_worker.build_connector_worker_meta()
 
 
 class LookupKeyServer:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, cast
 
 import torch
-from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata, KVConnectorWorkerMetadata
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
 from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashList, BlockHashListWithBlockSize
@@ -197,14 +197,17 @@ def infer_group_cache_families(
 class ChunkedTokenDatabase:
     def __init__(
         self,
-        metadata: list[KeyMetadata],
-        block_size: list[int],
+        metadata: KeyMetadata,
+        block_size: int | list[int],
         partitions: list[int] | None,
         use_hybrid: bool = False,
         hash_block_size: int | None = None,
     ):
         self.metadata = metadata
-        self.block_size = block_size
+        self.block_size = block_size if isinstance(block_size, list) else [block_size]
+        self.kv_caches_base_addr: list[int] = []
+        self.block_len: list[int] = []
+        self.block_stride: list[int] = []
         self.group_kv_caches_base_addr: dict[int, list[int]] = {}
         self.group_block_len: dict[int, list[int]] = {}
         self.group_block_stride: dict[int, list[int]] = {}
@@ -231,20 +234,28 @@ class ChunkedTokenDatabase:
         assert self.metadata is not None
         if cache_family is None:
             cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
-        group_metadata = self.metadata[kv_cache_group_id]
         return PoolKey(
             KeyMetadata(
-                model_name=group_metadata.model_name,
-                head_or_tp_rank=group_metadata.head_or_tp_rank,
-                pcp_rank=group_metadata.pcp_rank,
-                dcp_rank=group_metadata.dcp_rank,
-                pp_rank=group_metadata.pp_rank,
+                model_name=self.metadata.model_name,
+                head_or_tp_rank=self.metadata.head_or_tp_rank,
+                pcp_rank=self.metadata.pcp_rank,
+                dcp_rank=self.metadata.dcp_rank,
+                pp_rank=self.metadata.pp_rank,
                 kv_cache_group_id=kv_cache_group_id,
                 cache_role=cache_role,
                 cache_family=cache_family,
             ),
             chunk_hash,
         )
+
+    def set_kv_caches_base_addr(self, kv_caches_base_addr: list[int]):
+        self.kv_caches_base_addr = kv_caches_base_addr
+
+    def set_block_len(self, block_len: list[int]):
+        self.block_len = block_len
+
+    def set_block_stride(self, block_stride: list[int]):
+        self.block_stride = block_stride
 
     def get_block_size(self, kv_cache_group_id: int) -> int:
         if kv_cache_group_id >= len(self.block_size):
@@ -273,15 +284,13 @@ class ChunkedTokenDatabase:
         if group_num_layers is not None:
             self.group_num_layers[cache_role] = group_num_layers.copy()
 
-    def _get_group_buffers(
-        self, kv_cache_group_id: int, cache_role: str = "kv"
-    ) -> tuple[list[int], list[int], list[int] | None]:
+    def _get_group_buffers(self, kv_cache_group_id: int, cache_role: str) -> tuple[list[int], list[int], list[int]]:
         if cache_role == "state":
             return [], [], []
         return (
-            self.group_kv_caches_base_addr[kv_cache_group_id],
-            self.group_block_len[kv_cache_group_id],
-            self.group_block_stride.get(kv_cache_group_id),
+            self.group_kv_caches_base_addr.get(kv_cache_group_id, self.kv_caches_base_addr),
+            self.group_block_len.get(kv_cache_group_id, self.block_len),
+            self.group_block_stride.get(kv_cache_group_id, self.block_stride),
         )
 
     def prepare_value(
@@ -314,12 +323,11 @@ class ChunkedTokenDatabase:
         block_id = block_ids[start // group_block_size]
         addr_list: list[int] = []
         size_list: list[int] = []
-        group_addrs, group_block_len, group_block_stride = self._get_group_buffers(0)
-        length = len(group_block_len)
+        length = len(self.block_len)
         for i in range(length):
-            block_stride = group_block_stride[i] if group_block_stride else group_block_len[i]
-            addr = group_addrs[layer_id * length] + block_id * block_stride
-            size = int(group_block_len[i] / group_block_size * (end - start))
+            block_stride = self.block_stride[i] if self.block_stride else self.block_len[i]
+            addr = self.kv_caches_base_addr[layer_id * length] + block_id * block_stride
+            size = int(self.block_len[i] / group_block_size * (end - start))
             addr_list.append(addr)
             size_list.append(size)
         return addr_list, size_list, block_id
@@ -573,8 +581,6 @@ class ReqMeta:
     token_ids: list[int] | None = None
     original_block_size: list[int] | int | None = None
 
-    event_id: int | None = None
-
     def __init__(
         self,
         req_id: str,
@@ -592,7 +598,6 @@ class ReqMeta:
         token_ids: list[int] | None = None,
         original_block_size: list[int] | int | None = None,
         block_ids: list[int] | list[list[int]] | None = None,
-        event_id: int | None = None,
     ) -> None:
         self.req_id = req_id
         self.token_len_chunk = token_len_chunk
@@ -610,7 +615,6 @@ class ReqMeta:
         self.disable_tp_key_sharding = disable_tp_key_sharding
         self.token_ids = token_ids
         self.original_block_size = original_block_size
-        self.event_id = event_id
 
     @property
     def block_ids(self) -> list[int]:
@@ -623,7 +627,7 @@ class ReqMeta:
     @staticmethod
     def from_request_tracker(
         tracker: RequestTracker,
-        cache_transfer_granularity: int,
+        block_size: int,
         load_spec: LoadSpec | None = None,
         skip_save: bool | None = False,
         block_hashes: list[BlockHash] | None = None,
@@ -640,16 +644,8 @@ class ReqMeta:
         # For save operation: do not save if the following condition is met
         # 1. has already been saved before (num_saved_tokens > 0)
         # 2. number of unsaved tokens is not reached the chunk boundary
-        chunk_boundary = (
-            cdiv(tracker.num_saved_tokens + 1, cache_transfer_granularity) * cache_transfer_granularity
-            if discard_partial_chunks
-            else 0
-        )
-        num_tokens_to_save = (
-            (input_token_len // cache_transfer_granularity * cache_transfer_granularity)
-            if discard_partial_chunks
-            else input_token_len
-        )
+        chunk_boundary = cdiv(tracker.num_saved_tokens + 1, block_size) * block_size if discard_partial_chunks else 0
+        num_tokens_to_save = (input_token_len // block_size * block_size) if discard_partial_chunks else input_token_len
 
         skip_save = skip_save or num_tokens_to_save < chunk_boundary
         if skip_save and load_spec is None:
@@ -705,12 +701,8 @@ class LayerMultiBlockReqMeta:
     ends: list[int]
     block_ids_by_group: list[list[int]]
     layer_id: int
-    block_hashes: list[Any] = field(default_factory=list)
     is_last_chunk: bool | None = True
     current_event: torch.npu.Event | None = None
-    token_ids: list[int] | None = None
-    original_block_size: list[int] | int | None = None
-    kv_cache_group_id: int = 0
 
     def __init__(
         self,
@@ -723,10 +715,6 @@ class LayerMultiBlockReqMeta:
         is_last_chunk: bool | None = True,
         current_event: torch.npu.Event | None = None,
         block_ids: list[int] | list[list[int]] | None = None,
-        token_ids: list[int] | None = None,
-        original_block_size: list[int] | int | None = None,
-        block_hashes: list[Any] | None = None,
-        kv_cache_group_id: int = 0,
     ) -> None:
         self.req_id = req_id
         self.keys = keys
@@ -738,10 +726,6 @@ class LayerMultiBlockReqMeta:
         self.layer_id = layer_id
         self.is_last_chunk = is_last_chunk
         self.current_event = current_event
-        self.token_ids = token_ids
-        self.original_block_size = original_block_size
-        self.block_hashes = [] if block_hashes is None else block_hashes
-        self.kv_cache_group_id = kv_cache_group_id
 
     @property
     def block_ids(self) -> list[int]:
@@ -750,26 +734,3 @@ class LayerMultiBlockReqMeta:
     @block_ids.setter
     def block_ids(self, block_ids: list[int] | list[list[int]]) -> None:
         self.block_ids_by_group = normalize_block_ids_by_group(block_ids)
-
-
-@dataclass
-class AscendStoreKVConnectorWorkerMetadata(KVConnectorWorkerMetadata):
-    completed_events: dict[int, int] = field(default_factory=dict)
-    """key: event_id, value: completed worker count"""
-
-    def mark_completed_events(self, event_id: int | None) -> None:
-        if event_id is not None:
-            self.completed_events[event_id] = 1
-
-    def aggregate(self, other: KVConnectorWorkerMetadata) -> KVConnectorWorkerMetadata:
-        assert isinstance(other, AscendStoreKVConnectorWorkerMetadata), (
-            "aggregate worker metadata must be type of AscendStoreKVConnectorWorkerMetadata"
-        )
-
-        merged: dict[int, int] = dict(self.completed_events)
-        for event_id in other.completed_events:
-            if event_id not in merged:
-                merged[event_id] = other.completed_events[event_id]
-            else:
-                merged[event_id] = merged[event_id] + other.completed_events[event_id]
-        return AscendStoreKVConnectorWorkerMetadata(merged)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -217,7 +217,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
         put_step: int,
         kv_role: str,
         ready_event: threading.Event,
-        group_uses_align_state: list[bool],
         enable_kv_event: bool = False,
     ):
         super().__init__(
@@ -226,10 +225,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         self.put_step = put_step
         self.kv_role = kv_role
         self.stored_requests = defaultdict[str, int](int)
-        self.group_uses_align_state = group_uses_align_state
         self.enable_kv_event = enable_kv_event
-        self.completed_events_lock = threading.Lock()
-        self.completed_events: dict[int, int] = {}
 
     def add_stored_request(self, req_id: str):
         with self.done_task_lock:
@@ -245,149 +241,128 @@ class KVCacheStoreSendingThread(KVTransferThread):
             if req_id in self.stored_requests:
                 del self.stored_requests[req_id]
 
-    def mark_completed_events(self, event_id: int | None) -> None:
-        if event_id is not None:
-            with self.completed_events_lock:
-                self.completed_events[event_id] = 1
-
-    def get_completed_events(self):
-        if not self.completed_events:
-            return None
-        with self.completed_events_lock:
-            completed_events = self.completed_events.copy()
-            self.completed_events.clear()
-        return completed_events
-
     def _handle_request(self, req_meta: ReqMeta):
         token_len = req_meta.token_len_chunk
         req_id = req_meta.req_id
         current_event = req_meta.current_event
-        try:
-            if req_id not in self.stored_requests:
-                self.request_queue.task_done()
-                return
+        if req_id not in self.stored_requests:
+            self.request_queue.task_done()
+            return
 
-            for group_id in req_meta.kv_cache_group_ids or [0]:
-                starts = []
-                ends = []
-                keys = []
-                block_hashes = []
-                block_ids = req_meta.block_ids_by_group[group_id]
-                group_block_size = self._get_block_size(group_id)
-                group_block_hashes = get_block_hashes(
-                    req_meta.block_hashes,
-                    group_block_size,
-                    getattr(self.token_database, "hash_block_size", group_block_size),
-                )
+        for group_id in req_meta.kv_cache_group_ids or [0]:
+            starts = []
+            ends = []
+            keys = []
+            block_hashes = []
+            block_ids = req_meta.block_ids_by_group[group_id]
+            group_block_size = self._get_block_size(group_id)
+            group_block_hashes = get_block_hashes(
+                req_meta.block_hashes,
+                group_block_size,
+                getattr(self.token_database, "hash_block_size", group_block_size),
+            )
 
-                for start, end, key, _ in self._process_tokens_with_block_ids(
-                    token_len,
-                    req_meta.block_hashes,
+            for start, end, key, _ in self._process_tokens_with_block_ids(
+                token_len,
+                req_meta.block_hashes,
+                block_ids,
+                kv_cache_group_id=group_id,
+                skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
+            ):
+                starts.append(start)
+                ends.append(end)
+                keys.append(key.to_string())
+                block_hashes.append(group_block_hashes[start // group_block_size])
+
+            if not self.dcp_size > 1 and not req_meta.disable_tp_key_sharding:
+                starts = starts[self.tp_rank % self.put_step :: self.put_step]
+                ends = ends[self.tp_rank % self.put_step :: self.put_step]
+                keys = keys[self.tp_rank % self.put_step :: self.put_step]
+                block_hashes = block_hashes[self.tp_rank % self.put_step :: self.put_step]
+
+            if not keys:
+                continue
+
+            exists_states = self.lookup(keys)
+            missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
+
+            if not missing_indices:
+                continue
+
+            starts = [starts[index] for index in missing_indices]
+            ends = [ends[index] for index in missing_indices]
+            keys = [keys[index] for index in missing_indices]
+            block_hashes = [block_hashes[index] for index in missing_indices]
+
+            logger.info(
+                "Storing KV cache for %d out of %d blocks (missing_count=%d) for request %s in group %d",
+                len(keys),
+                token_len // group_block_size,
+                len(missing_indices),
+                req_id,
+                group_id,
+            )
+            logger.debug(
+                "KV pool put request=%s group=%d token_len=%d keys=%d sample_keys=%s",
+                req_id,
+                group_id,
+                token_len,
+                len(keys),
+                keys[:3],
+            )
+
+            addrs = []
+            sizes = []
+            stored_events: list[BlockStored] = []
+            prev_key = None
+            new_block_hashes = [maybe_convert_block_hash(bh) for bh in block_hashes]
+            for index, start in enumerate(starts):
+                addr, size, _ = self._prepare_value(
+                    start,
+                    ends[index],
                     block_ids,
                     kv_cache_group_id=group_id,
-                    skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
-                ):
-                    starts.append(start)
-                    ends.append(end)
-                    keys.append(key.to_string())
-                    block_hashes.append(group_block_hashes[start // group_block_size])
-
-                if (
-                    not self.dcp_size > 1
-                    and not req_meta.disable_tp_key_sharding
-                    and not self.group_uses_align_state[group_id]
-                ):
-                    starts = starts[self.tp_rank % self.put_step :: self.put_step]
-                    ends = ends[self.tp_rank % self.put_step :: self.put_step]
-                    keys = keys[self.tp_rank % self.put_step :: self.put_step]
-                    block_hashes = block_hashes[self.tp_rank % self.put_step :: self.put_step]
-
-                if not keys:
-                    continue
-
-                exists_states = self.lookup(keys)
-                missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
-
-                if not missing_indices:
-                    continue
-
-                starts = [starts[index] for index in missing_indices]
-                ends = [ends[index] for index in missing_indices]
-                keys = [keys[index] for index in missing_indices]
-                block_hashes = [block_hashes[index] for index in missing_indices]
-
-                logger.info(
-                    "Storing KV cache for %d out of %d blocks (missing_count=%d) for request %s in group %d",
-                    len(keys),
-                    token_len // group_block_size,
-                    len(missing_indices),
-                    req_id,
-                    group_id,
                 )
-                logger.debug(
-                    "KV pool put request=%s group=%d token_len=%d keys=%d sample_keys=%s",
-                    req_id,
-                    group_id,
-                    token_len,
-                    len(keys),
-                    keys[:3],
+                addrs.append(addr)
+                sizes.append(size)
+
+                # Create KV event
+                if self.enable_kv_event:
+                    token_ids = req_meta.token_ids[start : ends[index]] if req_meta.token_ids is not None else None
+                    block_size = (
+                        req_meta.original_block_size[group_id]
+                        if isinstance(req_meta.original_block_size, list)
+                        else req_meta.original_block_size
+                    )
+                    stored_event = BlockStored(
+                        block_hashes=[new_block_hashes[index]],
+                        parent_block_hash=prev_key,
+                        token_ids=token_ids,
+                        block_size=block_size,
+                        lora_id=None,
+                        medium="cpu",
+                        lora_name=None,
+                    )
+                    stored_events.append(stored_event)
+                    prev_key = new_block_hashes[index]
+                    logger.debug("Added kv cache event '%s' to kv cache events queue", stored_event)
+
+            if self.kv_role == "kv_consumer":
+                keys, addrs, sizes = self._decode_adaptor_prefill_pp(
+                    keys,
+                    addrs,
+                    sizes,
+                    kv_cache_group_id=group_id,
                 )
 
-                addrs = []
-                sizes = []
-                stored_events: list[BlockStored] = []
-                prev_key = None
-                new_block_hashes = [maybe_convert_block_hash(bh) for bh in block_hashes]
-                for index, start in enumerate(starts):
-                    addr, size, _ = self._prepare_value(
-                        start,
-                        ends[index],
-                        block_ids,
-                        kv_cache_group_id=group_id,
-                    )
-                    addrs.append(addr)
-                    sizes.append(size)
+            if current_event is not None:
+                current_event.synchronize()
+            self.m_store.put(keys, addrs, sizes)
 
-                    # Create KV event
-                    if self.enable_kv_event:
-                        token_ids = req_meta.token_ids[start : ends[index]] if req_meta.token_ids is not None else None
-                        block_size = (
-                            req_meta.original_block_size[group_id]
-                            if isinstance(req_meta.original_block_size, list)
-                            else req_meta.original_block_size
-                        )
-                        if block_size is not None:
-                            stored_event = BlockStored(
-                                block_hashes=[new_block_hashes[index]],
-                                parent_block_hash=prev_key,
-                                token_ids=token_ids,
-                                block_size=block_size,
-                                lora_id=None,
-                                medium="cpu",
-                                lora_name=None,
-                            )
-                            stored_events.append(stored_event)
-                            prev_key = new_block_hashes[index]
-                            logger.debug("Added kv cache event '%s' to kv cache events queue", stored_event)
+            # TODO Query specific replica info to update the event
+            if self.enable_kv_event and stored_events is not None:
+                self.update_kv_event(stored_events)
 
-                if self.kv_role == "kv_consumer":
-                    keys, addrs, sizes = self._decode_adaptor_prefill_pp(
-                        keys,
-                        addrs,
-                        sizes,
-                        kv_cache_group_id=group_id,
-                    )
-
-                if current_event is not None:
-                    current_event.synchronize()
-                self.m_store.put(keys, addrs, sizes)
-
-                # TODO Query specific replica info to update the event
-                if self.enable_kv_event and stored_events is not None:
-                    self.update_kv_event(stored_events)
-        finally:
-            # always free blocks
-            self.mark_completed_events(req_meta.event_id)
         self.dec_stored_request(req_id)
         self.request_queue.task_done()
 
@@ -507,67 +482,6 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         self.final_layer_id = num_layers - 1
         self.put_step = put_step
         self.enable_kv_event = enable_kv_event
-        self.layerwise_event_starts: dict[str, set[int]] = defaultdict(set)
-        self.stored_requests: dict[str, int] = defaultdict(int)
-        self.done_task_lock = threading.Lock()
-        self.layerwise_event_lock = threading.Lock()
-
-    def add_stored_request(self, req_id: str):
-        with self.done_task_lock:
-            self.stored_requests[req_id] += 1
-
-    def dec_stored_request(self, req_id: str):
-        with self.done_task_lock:
-            if req_id in self.stored_requests:
-                self.stored_requests[req_id] -= 1
-
-    def delete_finished_stored_request(self, req_id: str):
-        with self.done_task_lock:
-            if req_id in self.stored_requests:
-                del self.stored_requests[req_id]
-        with self.layerwise_event_lock:
-            self.layerwise_event_starts.pop(req_id, None)
-
-    def _record_layerwise_event_starts(self, req_meta: LayerMultiBlockReqMeta, starts: list[int]) -> None:
-        if self.enable_kv_event:
-            with self.layerwise_event_lock:
-                self.layerwise_event_starts[req_meta.req_id].update(starts)
-
-    def _build_stored_events(self, req_meta: LayerMultiBlockReqMeta) -> list[BlockStored]:
-        if not self.enable_kv_event or req_meta.layer_id != self.final_layer_id:
-            return []
-        block_size = (
-            req_meta.original_block_size[req_meta.kv_cache_group_id]
-            if isinstance(req_meta.original_block_size, list)
-            else req_meta.original_block_size
-        )
-        if block_size is None:
-            return []
-        stored_events: list[BlockStored] = []
-        group_block_size = self._get_block_size(req_meta.kv_cache_group_id)
-        new_block_hashes = [maybe_convert_block_hash(bh) for bh in req_meta.block_hashes]
-        with self.layerwise_event_lock:
-            starts_set = self.layerwise_event_starts.pop(req_meta.req_id, set())
-        for start in sorted(starts_set):
-            block_idx = start // group_block_size
-            if block_idx >= len(new_block_hashes):
-                continue
-            block_hash = new_block_hashes[block_idx]
-            parent_block_hash = new_block_hashes[block_idx - 1] if block_idx > 0 else None
-            end = min(start + group_block_size, len(req_meta.token_ids or []))
-            token_ids = req_meta.token_ids[start:end] if req_meta.token_ids is not None else None
-            stored_event = BlockStored(
-                block_hashes=[block_hash],
-                parent_block_hash=parent_block_hash,
-                token_ids=token_ids,
-                block_size=block_size,
-                lora_id=None,
-                medium="cpu",
-                lora_name=None,
-            )
-            stored_events.append(stored_event)
-            logger.debug("Added layerwise kv cache event '%s' to kv cache events queue", stored_event)
-        return stored_events
 
     def add_request(  # type: ignore[override]
         self, req_meta: ReqMeta
@@ -584,24 +498,14 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         current_event = req_meta.current_event
         total_block = len(keys)
         is_last_chunk = req_meta.is_last_chunk
-        with self.done_task_lock:
-            if req_meta.req_id not in self.stored_requests:
-                self.request_queue.task_done()
-                return
         if not self.dcp_size > 1:
             starts = starts[self.tp_rank % self.put_step :: self.put_step]
             ends = ends[self.tp_rank % self.put_step :: self.put_step]
             keys = keys[self.tp_rank % self.put_step :: self.put_step]
 
         if not keys:
-            if layer_id == self.final_layer_id:
-                stored_events = self._build_stored_events(req_meta)
-                if stored_events:
-                    self.update_kv_event(stored_events)
-            if is_last_chunk and layer_id == self.final_layer_id:
-                self.dec_stored_request(req_meta.req_id)
+            if is_last_chunk:
                 self.set_finished_request(req_meta.req_id)
-            self.request_queue.task_done()
             return
 
         key_list = []
@@ -612,14 +516,8 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
 
         if not missing_indices:
-            if layer_id == self.final_layer_id:
-                stored_events = self._build_stored_events(req_meta)
-                if stored_events:
-                    self.update_kv_event(stored_events)
             if is_last_chunk and layer_id == self.final_layer_id:
-                self.dec_stored_request(req_meta.req_id)
                 self.set_finished_request(req_meta.req_id)
-            self.request_queue.task_done()
             return
 
         starts = [starts[index] for index in missing_indices]
@@ -638,36 +536,18 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         if current_event is not None:
             current_event.synchronize()
         self.m_store.put(key_list, addr_list, size_list)
-        self._record_layerwise_event_starts(req_meta, starts)
-        stored_events = self._build_stored_events(req_meta)
-        if stored_events:
-            self.update_kv_event(stored_events)
 
         if layer_id == self.final_layer_id and is_last_chunk:
-            with self.layerwise_event_lock:
-                self.layerwise_event_starts.pop(req_meta.req_id, None)
-            self.dec_stored_request(req_meta.req_id)
             self.set_finished_request(req_meta.req_id)
         self.request_queue.task_done()
 
-        if layer_id == self.final_layer_id:
-            logger.info(
-                "Storing KV cache layerwise for %d out of %d blocks (missing_count=%d) for request %s, layer %d",
-                len(key_list),
-                total_block,
-                len(missing_indices),
-                req_meta.req_id,
-                layer_id,
-            )
-        else:
-            logger.debug(
-                "Storing KV cache layerwise for %d out of %d blocks (missing_count=%d) for request %s, layer %d",
-                len(key_list),
-                total_block,
-                len(missing_indices),
-                req_meta.req_id,
-                layer_id,
-            )
+        logger.info(
+            "Storing KV cache for %d out of %d blocks (missing_count=%d) for request %s",
+            len(key_list),
+            total_block,
+            len(missing_indices),
+            req_meta.req_id,
+        )
 
 
 class KVCacheStoreLayerRecvingThread(KVTransferThread):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -8,7 +8,6 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadat
 from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
 from vllm.utils.network_utils import make_zmq_socket
-from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.kv_cache_utils import BlockHash
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -19,13 +18,11 @@ from vllm.v1.kv_cache_interface import (
     SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
 )
-from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
 from vllm.v1.serial_utils import MsgpackEncoder
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     AscendConnectorMetadata,
-    AscendStoreKVConnectorWorkerMetadata,
     LoadSpec,
     ReqMeta,
     RequestTracker,
@@ -85,7 +82,6 @@ class KVPoolScheduler:
         self.pcp_size = getattr(vllm_config.parallel_config, "prefill_context_parallel_size", 1)
         self.dcp_size = getattr(vllm_config.parallel_config, "decode_context_parallel_size", 1)
 
-        self.mamba_group_ids = self._infer_mamba_groups()
         self.original_block_size = self._infer_group_block_sizes(vllm_config, kv_cache_config)
         cp_scale = self.pcp_size * self.dcp_size
         self.grouped_block_size = [block_size * cp_scale for block_size in self.original_block_size]
@@ -109,13 +105,6 @@ class KVPoolScheduler:
         )
         self._unfinished_requests: dict[str, tuple[Request, list[list[int]]]] = {}
         self._unfinished_request_ids: set[str] = set()
-        self._block_pool: BlockPool | None = None
-        self.sending_event_id = 0
-        # {event_id, flattened block_ids}
-        self.sending_blocks: dict[int, list[int]] = {}
-        # {event_id, completed_woke_count}
-        self.sending_events: dict[int, int] = {}
-        self._expected_worker_count = vllm_config.parallel_config.world_size
 
     def _infer_group_families(self) -> list[str]:
         kv_cache_groups = self.kv_cache_config.kv_cache_groups if self.kv_cache_config is not None else None
@@ -170,18 +159,6 @@ class KVPoolScheduler:
         return len(kv_cache_config.kv_cache_groups) > 1 and any(
             not isinstance(group.kv_cache_spec, FullAttentionSpec) for group in kv_cache_config.kv_cache_groups
         )
-
-    def _infer_mamba_groups(self):
-        if self.kv_cache_config is None or not self.use_hybrid:
-            return []
-        mamba_group_ids: list[int] = []
-        for group_id, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups):
-            kv_cache_spec = kv_cache_group.kv_cache_spec
-            if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
-                kv_cache_spec = next(iter(kv_cache_spec.kv_cache_specs.values()))
-            if isinstance(kv_cache_spec, MambaSpec):
-                mamba_group_ids.append(group_id)
-        return mamba_group_ids
 
     def _infer_swa_blocks(self) -> list[int]:
         if self.kv_cache_config is None:
@@ -414,7 +391,6 @@ class KVPoolScheduler:
                 kv_cache_group_families=self.kv_cache_group_families,
             )
             if req_meta is not None:
-                self.touch_sending_mamba_blocks(req_meta)
                 meta.add_request(req_meta)
 
         cached_reqs = scheduler_output.scheduled_cached_reqs
@@ -493,7 +469,6 @@ class KVPoolScheduler:
                         kv_cache_group_families=self.kv_cache_group_families,
                     )
                 if req_meta is not None:
-                    self.touch_sending_mamba_blocks(req_meta)
                     meta.add_request(req_meta)
 
         request_ids = [req.req_id for req in scheduler_output.scheduled_new_reqs]
@@ -525,62 +500,8 @@ class KVPoolScheduler:
                     kv_cache_group_families=self.kv_cache_group_families,
                 )
                 if req_meta is not None:
-                    self.touch_sending_mamba_blocks(req_meta)
                     meta.add_request(req_meta)
         return meta
-
-    def get_sending_event_id(self):
-        """
-        get a unique event id for a kv store request
-        """
-        using_id = self.sending_event_id
-        # todo: reset sending_event_id, in case infinitely increasing
-        self.sending_event_id += 1
-        return using_id
-
-    def touch_sending_mamba_blocks(self, req_meta: ReqMeta):
-        """
-        keep the reference of all non-null mamba blocks that will send to external kv store
-        """
-        if not self.use_hybrid or len(self.mamba_group_ids) == 0 or not req_meta.can_save:
-            return
-        using_event_id = self.get_sending_event_id()
-        req_meta.event_id = using_event_id
-        current_step_sending: list[int] = []
-        for group_id in self.mamba_group_ids:
-            group_block_ids = req_meta.block_ids_by_group[group_id]
-            current_step_sending.extend([block_id for block_id in group_block_ids if block_id > 0])
-        logger.debug("event: %s touch blocks: %s", using_event_id, current_step_sending)
-        assert self._block_pool is not None
-        self._block_pool.touch([self._block_pool.blocks[block_id] for block_id in current_step_sending])
-        self.sending_events[using_event_id] = 0
-        self.sending_blocks[using_event_id] = current_step_sending
-
-    def update_connector_output(self, connector_output: KVConnectorOutput):
-        """
-        hand the connector_output, free non-null mamba blocks and so on.
-        """
-        meta = connector_output.kv_connector_worker_meta
-        if not isinstance(meta, AscendStoreKVConnectorWorkerMetadata):
-            return
-        to_free_block_ids: list[int] = []
-        for event_id, count in meta.completed_events.items():
-            logger.debug("event %s update with %s", event_id, count)
-            total = self.sending_events.get(event_id, -1)
-            if total == -1:
-                logger.warning("worker reports an invalid event: %s, count %s", event_id, count)
-                continue
-            total = total + count
-            if total >= self._expected_worker_count:
-                to_free_block_ids.extend(self.sending_blocks.pop(event_id, []))
-                self.sending_events.pop(event_id, None)
-            else:
-                self.sending_events[event_id] = total
-
-        if to_free_block_ids:
-            logger.debug("free blocks: %s", to_free_block_ids)
-            assert self._block_pool is not None
-            self._block_pool.free_blocks([self._block_pool.blocks[block_id] for block_id in to_free_block_ids])
 
     def request_finished(
         self,
@@ -623,9 +544,6 @@ class KVPoolScheduler:
                 request.request_id,
             )
         return delay_free_blocks, None
-
-    def bind_gpu_block_pool(self, gpu_block_pool: "BlockPool") -> None:
-        self._block_pool = gpu_block_pool
 
 
 class LookupKeyClient:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -26,12 +26,10 @@ from vllm.v1.kv_cache_interface import (
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     AscendConnectorMetadata,
-    AscendStoreKVConnectorWorkerMetadata,
     ChunkedTokenDatabase,
     KeyMetadata,
     LayerMultiBlockReqMeta,
     ReqMeta,
-    get_block_hashes,
     get_cache_family_granularity,
     infer_group_cache_families,
 )
@@ -104,7 +102,6 @@ class KVPoolWorker:
         )
         self.backend = vllm_config.kv_transfer_config.kv_connector_extra_config.get("backend", "mooncake")
         self.use_hybrid = self._uses_hybrid_kv_cache(vllm_config, kv_cache_config)
-        self.use_mamba = self._uses_mamba_kv_cache(self.use_hybrid, kv_cache_config)
         self.original_block_size = self._infer_group_block_sizes(vllm_config, kv_cache_config)
         cp_scale = self.pcp_size * self.dcp_size
         self.grouped_block_size = [block_size * cp_scale for block_size in self.original_block_size]
@@ -125,14 +122,6 @@ class KVPoolWorker:
         if self.use_layerwise and self.num_kv_cache_groups > 1:
             raise NotImplementedError("AscendStore layerwise mode does not yet support hybrid KV cache groups.")
 
-        logger.info(
-            "use_hybrid: %s, use_mamba: %s, num_kv_cache_groups: %s, hash_block_size: %s, lcm_block_size: %s",
-            self.use_hybrid,
-            self.use_mamba,
-            self.num_kv_cache_groups,
-            self.hash_block_size,
-            self.lcm_block_size,
-        )
         self.current_layer = 0
         self.num_layers = model_config.get_num_layers(parallel_config)
 
@@ -147,6 +136,14 @@ class KVPoolWorker:
         else:
             self.head_or_tp_rank = self.tp_rank
             self.put_step = 1
+
+        self.metadata = KeyMetadata(
+            model_config.model.rstrip("/").split("/")[-1],
+            self.head_or_tp_rank,
+            self.pcp_rank,
+            self.dcp_rank,
+            self.pp_rank,
+        )
 
         partitions = None
         if self.kv_role == "kv_consumer" and self.consumer_is_to_put:
@@ -173,23 +170,12 @@ class KVPoolWorker:
                     for i in range(2, remaining_layers + 2):
                         partitions[-i] += 1
 
-        self.metadata: list[KeyMetadata] = []
-        for group_id in range(self.num_kv_cache_groups):
-            # the mamba kv_heads is not same with the full attention, can't share the cache data
-            group_tp_rank = self.tp_rank if self.group_uses_align_state[group_id] else self.head_or_tp_rank
-            self.metadata.append(
-                KeyMetadata(
-                    model_config.model.rstrip("/").split("/")[-1],
-                    group_tp_rank,
-                    self.pcp_rank,
-                    self.dcp_rank,
-                    self.pp_rank,
-                    group_id,
-                )
-            )
-
         self.token_database = ChunkedTokenDatabase(
-            self.metadata, self.grouped_block_size, partitions, self.use_hybrid, self.hash_block_size
+            self.metadata,
+            self.grouped_block_size,
+            partitions,
+            use_hybrid=self.use_hybrid,
+            hash_block_size=self.hash_block_size,
         )
 
         backend = backend_map.get(self.backend.lower())
@@ -290,12 +276,6 @@ class KVPoolWorker:
         )
 
     @staticmethod
-    def _uses_mamba_kv_cache(use_hybrid: bool, kv_cache_config: KVCacheConfig | None):
-        if not use_hybrid or kv_cache_config is None:
-            return False
-        return any([isinstance(g.kv_cache_spec, MambaSpec) for g in kv_cache_config.kv_cache_groups])
-
-    @staticmethod
     def _as_cache_tuple(cache_or_caches) -> tuple[torch.Tensor, ...]:
         if isinstance(cache_or_caches, torch.Tensor):
             return (cache_or_caches,)
@@ -319,23 +299,6 @@ class KVPoolWorker:
         except AttributeError:
             return cache.storage().data_ptr()
 
-    def _infer_cache_group_metadata(self, group_id: int, layer_names: list[str]):
-        group_addrs: list[int] = []
-        group_block_lens: list[int] = []
-        group_block_strides: list[int] = []
-        for layer_name in layer_names:
-            cache_or_caches = self.kv_caches[layer_name]
-            for cache in self._as_cache_tuple(cache_or_caches):
-                base_addr = cache.data_ptr()
-                block_len, block_stride, _, _ = self._get_cache_block_metadata(cache)
-                group_addrs.append(base_addr)
-                group_block_lens.append(block_len)
-                group_block_strides.append(block_stride)
-        self.group_kv_caches_base_addr[group_id] = group_addrs
-        self.group_block_len[group_id] = group_block_lens
-        self.group_block_stride[group_id] = group_block_strides
-        self.group_num_layers[group_id] = len(layer_names)
-
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         _, first_kv_cache_tuple = next(iter(kv_caches.items()))
         first_kv_cache_tuple = self._as_cache_tuple(first_kv_cache_tuple)
@@ -345,15 +308,13 @@ class KVPoolWorker:
             self.kv_cache_config.num_blocks if self.kv_cache_config is not None else first_kv_cache.shape[0]
         )
         logger.info("num_blocks: %s", self.num_blocks)
-        self.group_kv_caches_base_addr: dict[int, list[int]] = {}
-        self.group_block_len: dict[int, list[int]] = {}
-        self.group_block_stride: dict[int, list[int]] = {}
-        self.kv_caches = kv_caches
-        self.group_kv_cache_families: dict[int, str] = {
-            group_id: self._get_group_family(self.kv_cache_group_families, group_id)
-            for group_id in range(self.num_kv_cache_groups)
-        }
-        self.group_num_layers: dict[int, int] = {}
+        self.block_len = []
+        self.block_stride = []
+        for cache in first_kv_cache_tuple:
+            block_len, block_stride, _, _ = self._get_cache_block_metadata(cache)
+            logger.info("block_shape: %s", cache.shape[1:])
+            self.block_len.append(block_len)
+            self.block_stride.append(block_stride)
 
         logger.info(
             "Registering KV_Caches. use_mla: %s, use_sparse: %s, shape %s",
@@ -362,6 +323,16 @@ class KVPoolWorker:
             first_kv_cache.shape,
         )
 
+        self.kv_caches = kv_caches
+        self.kv_caches_base_addr = []
+        self.group_kv_caches_base_addr: dict[int, list[int]] = {}
+        self.group_block_len: dict[int, list[int]] = {}
+        self.group_block_stride: dict[int, list[int]] = {}
+        self.group_kv_cache_families: dict[int, str] = {
+            group_id: self._get_group_family(self.kv_cache_group_families, group_id)
+            for group_id in range(self.num_kv_cache_groups)
+        }
+        self.group_num_layers: dict[int, int] = {}
         registered_regions: dict[int, tuple[int, int]] = {}
         for cache_or_caches in kv_caches.values():
             for cache in self._as_cache_tuple(cache_or_caches):
@@ -369,6 +340,7 @@ class KVPoolWorker:
                 _, _, region_len, _ = self._get_cache_block_metadata(cache)
                 if not isinstance(region_len, int):
                     region_len = 0
+                self.kv_caches_base_addr.append(base_addr)
                 storage_key = self._get_storage_key(cache)
                 start = base_addr
                 end = base_addr + region_len
@@ -383,11 +355,30 @@ class KVPoolWorker:
 
         if self.kv_cache_config is not None and self.use_hybrid:
             for group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups):
-                self._infer_cache_group_metadata(group_id, group_spec.layer_names)
-        else:
-            self._infer_cache_group_metadata(0, list(kv_caches.keys()))
+                group_addrs: list[int] = []
+                group_block_lens: list[int] = []
+                group_block_strides: list[int] = []
+                seen_group_ptrs: set[int] = set()
+                for layer_name in group_spec.layer_names:
+                    cache_or_caches = kv_caches[layer_name]
+                    for cache in self._as_cache_tuple(cache_or_caches):
+                        base_addr = cache.data_ptr()
+                        if base_addr in seen_group_ptrs:
+                            continue
+                        block_len, block_stride, _, _ = self._get_cache_block_metadata(cache)
+                        group_addrs.append(base_addr)
+                        group_block_lens.append(block_len)
+                        group_block_strides.append(block_stride)
+                        seen_group_ptrs.add(base_addr)
+                self.group_kv_caches_base_addr[group_id] = group_addrs
+                self.group_block_len[group_id] = group_block_lens
+                self.group_block_stride[group_id] = group_block_strides
+                self.group_num_layers[group_id] = len(group_spec.layer_names)
 
         self.m_store.register_buffer(ptrs, lengths)
+        self.token_database.set_kv_caches_base_addr(self.kv_caches_base_addr)
+        self.token_database.set_block_len(self.block_len)
+        self.token_database.set_block_stride(self.block_stride)
         self.token_database.set_group_buffers(
             self.group_kv_caches_base_addr,
             self.group_block_len,
@@ -404,7 +395,7 @@ class KVPoolWorker:
                 self.kv_send_thread = KVCacheStoreLayerSendingThread(
                     self.m_store,
                     self.token_database,
-                    self.grouped_block_size,
+                    self.block_size,
                     self.tp_rank,
                     self.dcp_size,
                     self.put_step,
@@ -417,7 +408,7 @@ class KVPoolWorker:
             self.kv_recv_thread = KVCacheStoreLayerRecvingThread(
                 self.m_store,
                 self.token_database,
-                self.grouped_block_size,
+                self.block_size,
                 self.tp_rank,
                 self.dcp_size,
                 ready_event,
@@ -433,13 +424,12 @@ class KVPoolWorker:
                 self.kv_send_thread = KVCacheStoreSendingThread(
                     self.m_store,
                     self.token_database,
-                    self.grouped_block_size,
+                    self.block_size,
                     self.tp_rank,
                     self.dcp_size,
                     self.put_step,
                     self.kv_role,
                     ready_event_sending,
-                    self.group_uses_align_state,
                     self.enable_kv_events,
                 )
                 self.kv_send_thread.start()
@@ -448,7 +438,7 @@ class KVPoolWorker:
                 self.kv_recv_thread = KVCacheStoreRecvingThread(
                     self.m_store,
                     self.token_database,
-                    self.grouped_block_size,
+                    self.block_size,
                     self.tp_rank,
                     self.dcp_size,
                     ready_event,
@@ -603,10 +593,6 @@ class KVPoolWorker:
                 if can_save is None or not can_save:
                     continue
 
-                request.current_event = current_event
-                self.kv_send_thread.add_stored_request(  # type: ignore[union-attr]
-                    request.req_id
-                )
                 layerwise_storer = self.store_layer(request, current_event)
                 self.layerwise_storers.append(layerwise_storer)
         for layerwise_storer in self.layerwise_storers:
@@ -750,9 +736,6 @@ class KVPoolWorker:
         starts = []
         ends = []
         keys = []
-        group_id = 0
-        group_block_size = self.grouped_block_size[group_id]
-        group_block_hashes = get_block_hashes(request.block_hashes, group_block_size, self.hash_block_size)
         for start, end, key in self.token_database.process_tokens(request.token_len_chunk, request.block_hashes):
             keys_multi_layer = key.split_layers(self.num_layers)
             starts.append(start)
@@ -771,10 +754,6 @@ class KVPoolWorker:
                     layer_id,
                     request.is_last_chunk,
                     current_event,
-                    token_ids=request.token_ids,
-                    original_block_size=request.original_block_size,
-                    block_hashes=group_block_hashes,
-                    kv_cache_group_id=group_id,
                 )
                 self.kv_send_thread.add_request(  # type: ignore[union-attr, call-arg]
                     req_meta
@@ -953,11 +932,6 @@ class KVPoolWorker:
             return 1
         return self.num_kv_head
 
-    def get_group_tp_size(self, kv_cache_group_id: int):
-        if self.group_uses_align_state[kv_cache_group_id]:
-            return self.tp_size
-        return min(self.tp_size, self._get_group_num_kv_heads(kv_cache_group_id))
-
     def lookup_scheduler(
         self,
         token_len: int,
@@ -975,6 +949,7 @@ class KVPoolWorker:
             kv_cache_group_ids = kv_cache_group_ids or [0]
             kv_cache_group_ids = self._get_lookup_gate_group_ids(kv_cache_group_ids)
             for group_id in kv_cache_group_ids:
+                end = 0
                 keys = []
                 starts = []
                 ends = []
@@ -993,10 +968,11 @@ class KVPoolWorker:
                     ends.append(end)
 
                 if not keys:
-                    return 0
+                    hits.append(0)
+                    continue
 
                 multi_tp_keys = keys[:]
-                group_tp_size = self.get_group_tp_size(group_id)
+                group_tp_size = min(self.tp_size, self._get_group_num_kv_heads(group_id))
                 for i in range(1, group_tp_size):
                     for item in keys:
                         new_str = item.replace(  # type: ignore[attr-defined]
@@ -1021,40 +997,39 @@ class KVPoolWorker:
                     res[i * num_block : (i + 1) * num_block]  # type: ignore[index]
                     for i in range(group_tp_size * self.pp_size)
                 ]
+                first_missing = self.find_min_first_non_one_index(multi_tp_values)
                 logger.debug(
                     "KV pool lookup request token_len=%d group=%d keys=%d multi_tp_keys=%d "
-                    "exists_count=%d/%d exists_sample=%s sample_keys=%s",
+                    "exists_count=%d/%d first_missing=%d exists_sample=%s sample_keys=%s",
                     token_len,
                     group_id,
                     len(keys),
                     len(multi_tp_keys),
                     sum(1 for value in res if value == 1),  # type: ignore[union-attr]
                     len(res),
+                    first_missing,
                     list(res[: min(12, len(res))]),  # type: ignore[index]
                     multi_tp_keys[:3],
                 )
                 if group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]:
-                    # mamba group with align mode will skip some null block, we must loop it in reverse order
-                    for i in range(num_block - 1, -1, -1):
-                        if (
-                            all(values[i] == 1 for values in multi_tp_values)
-                            and ends[i] % self.cache_transfer_granularity == 0
-                        ):
-                            hits.append(ends[i])
+                    exists_by_block = [all(values[idx] == 1 for values in multi_tp_values) for idx in range(num_block)]
+                    hit_end = 0
+                    for index in range(num_block - 1, -1, -1):
+                        if exists_by_block[index] and ends[index] % self.cache_transfer_granularity == 0:
+                            hit_end = ends[index]
                             break
-                    else:
-                        return 0
+                    hits.append(hit_end)
                 else:
-                    index = self.find_max_hit_index(multi_tp_values, num_block)
+                    index = first_missing
                     if index == -1:
-                        return 0
+                        hits.append(end)
                     else:
-                        for hit_index in range(index, -1, -1):
-                            if ends[hit_index] % self.cache_transfer_granularity == 0:
-                                hits.append(ends[hit_index])
+                        hit_end = 0
+                        for hit_index in range(index, 0, -1):
+                            if starts[hit_index] % self.cache_transfer_granularity == 0:
+                                hit_end = starts[hit_index]
                                 break
-                        else:
-                            return 0
+                        hits.append(hit_end)
                 logger.debug(
                     "KV pool scheduler lookup group=%d keys=%d hit=%d token_len=%d",
                     group_id,
@@ -1086,13 +1061,11 @@ class KVPoolWorker:
 
         return result
 
-    def find_max_hit_index(self, arr, num_blocks: int):
-        for i in range(num_blocks):
-            if any(row[i] != 1 for row in arr):
-                return i - 1
-        else:
-            # if arr is not empty, all hits, else no hits
-            return len(arr[0]) - 1 if arr else -1
+    def find_min_first_non_one_index(self, arr):
+        try:
+            return min(idx for row in arr for idx, val in enumerate(row) if val != 1)
+        except ValueError:
+            return -1
 
     def get_kv_events(self) -> list[BlockStored]:
         if self.enable_kv_events and self.kv_send_thread is not None:
@@ -1100,9 +1073,3 @@ class KVPoolWorker:
             events = self.kv_send_thread.get_kv_events()
             return events
         return []
-
-    def build_connector_worker_meta(self) -> AscendStoreKVConnectorWorkerMetadata | None:
-        if self.use_mamba and isinstance(self.kv_send_thread, KVCacheStoreSendingThread):
-            if ce := self.kv_send_thread.get_completed_events():
-                return AscendStoreKVConnectorWorkerMetadata(ce)
-        return None

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -107,6 +107,9 @@ env_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK": lambda: bool(
         int(os.getenv("VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK", "1"))
     ),
+    "VLLM_ASCEND_ENABLE_FUSED_MTP_FULL_GRAPH": lambda: bool(
+        int(os.getenv("VLLM_ASCEND_ENABLE_FUSED_MTP_FULL_GRAPH", "0"))
+    ),
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),

--- a/vllm_ascend/model_loader/netloader/executor/elastic_load.py
+++ b/vllm_ascend/model_loader/netloader/executor/elastic_load.py
@@ -31,7 +31,6 @@ class P2PLoad:
         world_name: str,
         source_ip: str,
         source_port: int,
-        group_name: str = "netloader",
     ):
         """
         Initializes the P2PLoad instance.
@@ -40,12 +39,10 @@ class P2PLoad:
         - world_name: The name of the distributed group.
         - source_ip: The IP address of the source node.
         - source_port: The port number for the source node.
-        - group_name: Name of the HCCL process group.
         """
         self.world_name = world_name
         self.source_ip = source_ip
         self.source_port = source_port
-        self.group_name = group_name
 
     def load(self, model):
         """
@@ -69,7 +66,7 @@ class P2PLoad:
                 port=self.source_port,
                 rank=0,
                 world_size=2,
-                group_name=self.group_name,
+                group_name="netloader",
             )
             logger.info(
                 "Finish init_process_group, name: %s, addr: %s:%s", self.world_name, self.source_ip, self.source_port
@@ -103,7 +100,7 @@ class P2PSend:
     Class for sending model parameters in a distributed manner using HCCL backend.
     """
 
-    def __init__(self, listen_ip: str, listen_port: int, comm_name: str, group_name: str = "netloader"):
+    def __init__(self, listen_ip: str, listen_port: int, comm_name: str):
         """
         Initializes the P2PSend instance.
 
@@ -111,12 +108,10 @@ class P2PSend:
         - listen_ip: The IP address to listen on.
         - listen_port: The port number to listen on.
         - comm_name: The name of the communication group.
-        - group_name: Name of the HCCL process group.
         """
         self.listen_ip = listen_ip
         self.listen_port = listen_port
         self.comm_name = comm_name
-        self.group_name = group_name
 
     def send(self, model, int8_params: dict):
         """
@@ -136,7 +131,7 @@ class P2PSend:
                 port=self.listen_port,
                 rank=1,
                 world_size=2,
-                group_name=self.group_name,
+                group_name="netloader",
             )
             logger.info(
                 "Finish init_process_group, name: %s, addr: %s:%s", self.comm_name, self.listen_ip, self.listen_port

--- a/vllm_ascend/model_loader/netloader/interaction/elastic.py
+++ b/vllm_ascend/model_loader/netloader/interaction/elastic.py
@@ -32,9 +32,7 @@ class ElasticClient:
     Class for handling the client-side logic of Netloader of models.
     """
 
-    def __init__(
-        self, sources: list[str], device_id: int, model_path: str, tp: int, pp: int, group_name: str = "netloader"
-    ):
+    def __init__(self, sources: list[str], device_id: int, model_path: str, tp: int, pp: int):
         """
         Initializes the ElasticClient instance.
 
@@ -44,14 +42,12 @@ class ElasticClient:
         - model_path: The path to the model.
         - tp: Tensor parallel size.
         - pp: Pipeline parallel size.
-        - group_name: Name of the HCCL process group.
         """
         self.sources = sources
         self.device_id = device_id
         self.model_path = model_path
         self.tp = tp
         self.pp = pp
-        self.group_name = group_name
 
         self.s: socket.socket | None = None
         self.ack: tuple[str, int] | None = None
@@ -173,14 +169,7 @@ class ElasticClient:
         free_port = find_free_port()
         data = {
             "label": "JOIN",
-            "content": {
-                "device_id": device_id,
-                "model_path": model_path,
-                "tp": tp,
-                "pp": pp,
-                "port": free_port,
-                "group_name": self.group_name,
-            },
+            "content": {"device_id": device_id, "model_path": model_path, "tp": tp, "pp": pp, "port": free_port},
         }
 
         try:
@@ -230,7 +219,6 @@ class ElasticServer:
         pp: int,
         int8_cache: str,
         int8_cache_name: list[str] | None,
-        group_name: str = "netloader",
     ):
         """
         Initializes the ElasticServer instance.
@@ -245,7 +233,6 @@ class ElasticServer:
         - pp: Pipeline parallel size.
         - int8_cache: The type of caching for int8 parameters (HBM, DRAM, or no).
         - int8_cache_name: List of parameter names to be cached.
-        - group_name: Name of the HCCL process group.
         """
         self.addr = addr
         self.port = port
@@ -259,7 +246,6 @@ class ElasticServer:
         self.model_path = model_path
         self.tp = tp
         self.pp = pp
-        self.group_name = group_name
 
         self.original_int8 = {}
         int8_pattern = "|".join(map(re.escape, int8_cache_name)) if int8_cache_name is not None else "(?:)"
@@ -410,12 +396,7 @@ class ElasticServer:
 
         if ack["content"] and isinstance(ack["content"], dict) and "name" in ack["content"]:
             try:
-                p2psend = P2PSend(
-                    self.addr,
-                    data["content"]["port"],
-                    ack["content"]["name"],
-                    data["content"].get("group_name", "netloader"),
-                )
+                p2psend = P2PSend(self.addr, data["content"]["port"], ack["content"]["name"])
                 p2psend.send(self.model, self.original_int8)
             except Exception as e:
                 logger.error("P2PSend Failed to send model to %s, details: %s", self.addr, e)

--- a/vllm_ascend/model_loader/netloader/load.py
+++ b/vllm_ascend/model_loader/netloader/load.py
@@ -29,7 +29,6 @@ def elastic_load(
     sources: list,
     tp: int,
     pp: int,
-    group_name: str = "netloader",
 ):
     """
     Loads a model using elastic loading across multiple devices.
@@ -41,7 +40,6 @@ def elastic_load(
     - sources: A list of source configurations, each containing device_id and sources.
     - tp: Tensor parallel size, indicating the number of devices for tensor parallelism.
     - pp: Pipeline parallel size, indicating the number of devices for pipeline parallelism.
-    - group_name: Name of the HCCL process group.
 
     Returns:
     - The loaded model if successful, otherwise None.
@@ -57,7 +55,7 @@ def elastic_load(
 
     try:
         # Initialize the interaction layer with the ElasticClient
-        with ElasticClient(sources_this_device, device_id, model_path, tp, pp, group_name) as client_interaction_layer:
+        with ElasticClient(sources_this_device, device_id, model_path, tp, pp) as client_interaction_layer:
             if client_interaction_layer.s is None or client_interaction_layer.server_addr is None:
                 raise RuntimeError("Failed to initialize ElasticClient: socket or server_addr is None")
             ack = client_interaction_layer.ack
@@ -65,7 +63,7 @@ def elastic_load(
                 raise RuntimeError("ElasticClient.register did not return ack")
 
             t0 = time.perf_counter()
-            elastic_loader = P2PLoad(ack[0], client_interaction_layer.server_addr, ack[1], group_name)
+            elastic_loader = P2PLoad(ack[0], client_interaction_layer.server_addr, ack[1])
             model_loaded = elastic_loader.load(model=model)
             if model_loaded is None:
                 logger.error("Failed to load model")

--- a/vllm_ascend/model_loader/netloader/netloader.py
+++ b/vllm_ascend/model_loader/netloader/netloader.py
@@ -33,8 +33,6 @@ from .interaction.elastic import ElasticServer
 from .load import elastic_load
 from .utils import find_free_port, is_valid_path_prefix
 
-DRAFT_PORT_OFFSET = 10000
-
 
 @register_model_loader("netloader")
 class ModelNetLoaderElastic(BaseModelLoader):
@@ -125,19 +123,13 @@ class ModelNetLoaderElastic(BaseModelLoader):
             self.output_prefix,
         )
 
-    @staticmethod
-    def _is_draft_model(model_config: ModelConfig) -> bool:
-        """Check whether the model_config corresponds to a draft model for speculative decoding."""
-        return getattr(model_config, "runner_type", None) == "draft"
-
-    def load_model(self, vllm_config: VllmConfig, model_config: ModelConfig, prefix: str = "") -> nn.Module:
+    def load_model(self, vllm_config: VllmConfig, model_config: ModelConfig) -> nn.Module:
         """
         Loads the model using the specified configuration.
 
         Parameters:
         - vllm_config: Configuration for the VLLM.
         - model_config: Configuration for the model.
-        - prefix: Module prefix for pipeline parallelism (e.g., "model.layers.0.").
 
         Returns:
         - The loaded model.
@@ -153,12 +145,6 @@ class ModelNetLoaderElastic(BaseModelLoader):
             logger.info("model_path is set to %s", self.model_path)
 
         device_id = torch.distributed.get_rank()
-        is_draft = self._is_draft_model(model_config)
-
-        if is_draft:
-            logger.info("Loading draft model via netloader, model_path: %s", model_config.model)
-        else:
-            logger.info("Loading target model via netloader, model_path: %s", model_config.model)
 
         if (
             self.source is None
@@ -171,9 +157,7 @@ class ModelNetLoaderElastic(BaseModelLoader):
             ]
         ):
             logger.warning("Did not get valid source info, use DefaultModelLoader")
-            model, need_process_weights_after_loading = self.revert_to_default(
-                model_config, vllm_config, device_config, prefix
-            )
+            model, need_process_weights_after_loading = self.revert_to_default(model_config, vllm_config, device_config)
 
         else:
             target_device = torch.device(device_config.device)
@@ -183,35 +167,16 @@ class ModelNetLoaderElastic(BaseModelLoader):
 
             with set_default_torch_dtype(model_config.dtype):
                 with target_device:
-                    model = initialize_model(vllm_config=vllm_config, model_config=model_config, prefix=prefix)
+                    model = initialize_model(vllm_config=vllm_config, model_config=model_config)
 
                 start_elastic_load = time.perf_counter()
-
-                sources = self.source
-                if is_draft:
-                    sources = [
-                        {
-                            "device_id": s["device_id"],
-                            "sources": [
-                                f"{parts[0]}:{int(parts[1]) + DRAFT_PORT_OFFSET}"
-                                for addr in s.get("sources", [])
-                                if isinstance(addr, str)
-                                and len(parts := addr.rsplit(":", 1)) == 2
-                                and parts[1].isdigit()
-                            ],
-                        }
-                        for s in self.source
-                        if isinstance(s, dict) and "device_id" in s
-                    ]
-
                 model = elastic_load(
                     model=model,
                     device_id=device_id,
-                    model_path=model_config.model,
-                    sources=sources,
+                    model_path=self.model_path,
+                    sources=self.source,
                     tp=parallel_config.tensor_parallel_size,
                     pp=parallel_config.pipeline_parallel_size,
-                    group_name="netloader_draft" if is_draft else "netloader",
                 )
                 end_elastic_load = time.perf_counter()
                 logger.info("Elastic load time: %s, rank: %s", end_elastic_load - start_elastic_load, device_id)
@@ -233,7 +198,7 @@ class ModelNetLoaderElastic(BaseModelLoader):
                         torch.cuda.empty_cache()
 
                     model, need_process_weights_after_loading = self.revert_to_default(
-                        model_config, vllm_config, device_config, prefix
+                        model_config, vllm_config, device_config
                     )
 
         start_elastic_server = time.perf_counter()
@@ -249,27 +214,21 @@ class ModelNetLoaderElastic(BaseModelLoader):
                 logger.error("Driver IP is not set, skip to start Netloader server")
             else:
                 if self.listen_port is None:
-                    listen_port = find_free_port()
+                    self.listen_port = find_free_port()
                 else:
-                    listen_port = self.listen_port + device_id
-                if is_draft:
-                    listen_port += DRAFT_PORT_OFFSET
-                self.listen_port = listen_port
-
-                group_name = "netloader_draft" if is_draft else "netloader"
+                    self.listen_port += device_id
 
                 logger.info(
-                    "Start elastic Netloader server, rank: %s, listen port: %s:%s, group: %s",
+                    "Start elastic Netloader server, rank: %s, listen port: %s:%s",
                     device_id,
                     driver_ip,
-                    listen_port,
-                    group_name,
+                    self.listen_port,
                 )
 
-                if self.output_prefix is not None and not is_draft:
+                if self.output_prefix is not None:
                     try:
                         with open(self.output_prefix + str(device_id) + ".txt", "w") as file:
-                            file.write(f"{driver_ip}:{listen_port}")
+                            file.write(f"{driver_ip}:{self.listen_port}")
                         logger.info(
                             "Successfully wrote server address to file: %s", self.output_prefix + str(device_id)
                         )
@@ -285,23 +244,20 @@ class ModelNetLoaderElastic(BaseModelLoader):
                         logger.error("Unknown error: %s", e)
 
                 try:
+                    assert isinstance(self.listen_port, int), f"listen port should be int but get {self.listen_port}"
+
                     elastic_server = ElasticServer(
                         driver_ip,
-                        listen_port,
+                        self.listen_port,
                         model,
                         device_id,
-                        model_config.model,
+                        self.model_path,
                         parallel_config.tensor_parallel_size,
                         parallel_config.pipeline_parallel_size,
                         self.int8_cache,
                         self.int8_cache_name,
-                        group_name=group_name,
                     )
                     elastic_server.start()
-                    if is_draft:
-                        self._draft_elastic_server = elastic_server
-                    else:
-                        self._target_elastic_server = elastic_server
                 except Exception as e:
                     logger.error("Failed to start Netloader server for rank: %s, details: %s", device_id, e)
         else:
@@ -319,7 +275,7 @@ class ModelNetLoaderElastic(BaseModelLoader):
 
         return model.eval()
 
-    def revert_to_default(self, model_config, vllm_config, device_config, prefix: str = "") -> tuple[nn.Module, bool]:
+    def revert_to_default(self, model_config, vllm_config, device_config) -> tuple[nn.Module, bool]:
         """
         Reverts to the default model loading logic when elastic loading fails or is not applicable.
 
@@ -332,7 +288,6 @@ class ModelNetLoaderElastic(BaseModelLoader):
         - model_config: Configuration describing model architecture, quantization, etc.
         - vllm_config: Configuration for vLLM (device, parallelism, dtype, etc).
         - device_config: Configuration for the target device (device type, device id, etc).
-        - prefix: Module prefix for pipeline parallelism.
 
         Returns:
         - A tuple (model, need_process_weights_after_loading):
@@ -340,13 +295,12 @@ class ModelNetLoaderElastic(BaseModelLoader):
             * need_process_weights_after_loading: A boolean flag indicating whether
               weights post-processing (e.g. quantization adjustments) still needs to be applied.
         """
-        load_config = deepcopy(self.load_config)
-        load_config.model_loader_extra_config = {}
-        load_config.load_format = "auto"
-        default_model_loader = DefaultModelLoader(load_config)
+        self.load_config.model_loader_extra_config = {}
+        self.load_config.load_format = "auto"
+        default_model_loader = DefaultModelLoader(self.load_config)
 
         if model_config.quantization is None:
-            model = default_model_loader.load_model(vllm_config=vllm_config, model_config=model_config, prefix=prefix)
+            model = default_model_loader.load_model(vllm_config=vllm_config, model_config=model_config)
             need_process_weights_after_loading = False
         else:
             logger.warning("Quantization is set, netloader use DefaultModelLoader with process_weights_after_loading ")
@@ -354,7 +308,7 @@ class ModelNetLoaderElastic(BaseModelLoader):
             target_device = torch.device(device_config.device)
             with set_default_torch_dtype(model_config.dtype):
                 with target_device:
-                    model = initialize_model(vllm_config=vllm_config, model_config=model_config, prefix=prefix)
+                    model = initialize_model(vllm_config=vllm_config, model_config=model_config)
                 default_model_loader.load_weights(model, model_config)
             model = model.eval()
 

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -22,7 +22,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+"""Inference-only DeepseekV2/DeepseekV3 model."""
+
 import math
 import typing
 from collections.abc import Callable, Iterable
@@ -185,7 +186,6 @@ class DeepseekV2MLP(nn.Module):
         hidden_size: int,
         intermediate_size: int,
         hidden_act: str,
-        swiglu_limit: float | None = None,
         quant_config: QuantizationConfig | None = None,
         reduce_results: bool = True,
         is_sequence_parallel=False,
@@ -240,7 +240,6 @@ class DeepseekV4MoE(nn.Module):
         layer_idx = int(prefix.split(sep=".")[-2])
         self.layer_idx = layer_idx
         self.routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.5)
-        self.swiglu_limit = getattr(config, "swiglu_limit", None)
 
         self.ep_group = get_ep_group().device_group
         self.ep_rank = get_ep_group().rank_in_group
@@ -282,7 +281,6 @@ class DeepseekV4MoE(nn.Module):
                 hidden_size=config.hidden_size,
                 intermediate_size=intermediate_size,
                 hidden_act=config.hidden_act,
-                swiglu_limit=self.swiglu_limit,
                 quant_config=quant_config,
                 is_sequence_parallel=self.is_sequence_parallel,
                 reduce_results=False,
@@ -499,7 +497,7 @@ class Compressor(nn.Module):
             self.dim,
             self.coff * self.head_dim,
             bias=False,
-            quant_config=None if get_ascend_device_type() in {AscendDeviceType.A5} else quant_config,
+            quant_config=quant_config,
             prefix=f"{prefix}.wkv",
             return_bias=False,
         )
@@ -507,14 +505,11 @@ class Compressor(nn.Module):
             self.dim,
             self.coff * self.head_dim,
             bias=False,
-            quant_config=None if get_ascend_device_type() in {AscendDeviceType.A5} else quant_config,
+            quant_config=quant_config,
             prefix=f"{prefix}.wgate",
             return_bias=False,
         )
-
-        # A5 compressor kernel needs float for norm_weight input
-        norm_dtype = torch.float32 if get_ascend_device_type() == AscendDeviceType.A5 else None
-        self.norm = RMSNorm(self.head_dim, config.rms_norm_eps, dtype=norm_dtype)
+        self.norm = RMSNorm(self.head_dim, config.rms_norm_eps)
 
         state_dtype = torch.float32
         # TODO(zyj): change following codes if block_size is configurable & refactor the magic numbers
@@ -532,7 +527,7 @@ class Compressor(nn.Module):
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=16 if get_ascend_device_type() in {AscendDeviceType.A5} else 32,
+                block_size=32,
             )
         else:
             raise ValueError(
@@ -625,7 +620,6 @@ class DeepseekV4Attention(nn.Module):
             return_bias=False,
         )
         self.q_norm = RMSNorm(self.q_lora_rank, eps=config.rms_norm_eps)
-        self.q_norm_without_weight = RMSNorm(self.head_dim, eps=config.rms_norm_eps, has_weight=False)
         wq_b_cls = ReplicatedLinear if self.enable_dsa_cp else ColumnParallelLinear
         self.wq_b = wq_b_cls(
             self.q_lora_rank,
@@ -729,7 +723,6 @@ class DeepseekV4Attention(nn.Module):
         dsa_modules = DSAModules(
             wq_a=self.wq_a,
             q_norm=self.q_norm,
-            q_norm_without_weight=self.q_norm_without_weight,
             wq_b=self.wq_b,
             wkv=self.wkv,
             kv_norm=self.kv_norm,
@@ -1221,8 +1214,6 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
                 name = name.replace(".ffn_norm.", ".post_attention_layernorm.")
             if ".attn_norm." in name:
                 name = name.replace(".attn_norm.", ".input_layernorm.")
-            if name.endswith(".scale"):
-                name = name.replace(".scale", ".weight_scale")
 
             if "rotary_emb.inv_freq" in name:
                 continue

--- a/vllm_ascend/models/deepseek_v4_mtp.py
+++ b/vllm_ascend/models/deepseek_v4_mtp.py
@@ -12,7 +12,6 @@ from vllm.config import VllmConfig
 from vllm.distributed import get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size
 from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.layernorm import RMSNorm
-from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead, VocabParallelEmbedding
@@ -61,12 +60,8 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
         self.config = config
         quant_config = vllm_config.quant_config
 
-        self.e_proj = ReplicatedLinear(
-            config.hidden_size, config.hidden_size, bias=False, quant_config=quant_config, return_bias=False
-        )
-        self.h_proj = ReplicatedLinear(
-            config.hidden_size, config.hidden_size, bias=False, quant_config=quant_config, return_bias=False
-        )
+        self.e_proj = nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+        self.h_proj = nn.Linear(config.hidden_size, config.hidden_size, bias=False)
 
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -115,10 +110,15 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
         # masking inputs at position 0, as not needed by MTP
         inputs_embeds = torch.where(positions.unsqueeze(-1) == 0, 0, inputs_embeds)
         inputs_embeds = self.enorm(inputs_embeds)
-        previous_hidden_states = previous_hidden_states.view(-1, self.hc_mult, self.config.hidden_size)
-        previous_hidden_states = self.hnorm(previous_hidden_states)
 
-        hidden_states = self.e_proj(inputs_embeds).unsqueeze(-2) + self.h_proj(previous_hidden_states)
+        if previous_hidden_states.dim() == 2 and previous_hidden_states.shape[-1] == self.config.hidden_size:
+            previous_hidden_states = self.hnorm(previous_hidden_states)
+            hidden_states = self.e_proj(inputs_embeds) + self.h_proj(previous_hidden_states)
+            hidden_states = hidden_states.unsqueeze(1).repeat(1, self.hc_mult, 1)
+        else:
+            previous_hidden_states = previous_hidden_states.view(-1, self.hc_mult, self.config.hidden_size)
+            previous_hidden_states = self.hnorm(previous_hidden_states)
+            hidden_states = self.e_proj(inputs_embeds).unsqueeze(-2) + self.h_proj(previous_hidden_states)
 
         hidden_states, residual = self.mtp_block(positions=positions, hidden_states=hidden_states, residual=None)
 
@@ -202,7 +202,6 @@ class DeepSeekV4MTP(nn.Module, SupportsPP, DeepseekV2MixtureOfExperts):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         self.config = vllm_config.model_config.hf_config
-        self.quant_config = vllm_config.quant_config
         self.model = DeepSeekMultiTokenPredictor(vllm_config=vllm_config, prefix=maybe_prefix(prefix, "mtp"))
         # Set MoE hyperparameters
         self.set_moe_parameters()
@@ -279,14 +278,6 @@ class DeepSeekV4MTP(nn.Module, SupportsPP, DeepseekV2MixtureOfExperts):
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
                 continue
-
-            if self.quant_config is not None and self.quant_config.get_name() == "fp8":
-                if name == "embed.weight":
-                    name = "mtp.0.emb.tok_emb.weight"
-
-                if name == "head.weight":
-                    name = "mtp.0.head.weight"
-
             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
             if spec_layer is None:
                 continue
@@ -305,9 +296,6 @@ class DeepSeekV4MTP(nn.Module, SupportsPP, DeepseekV2MixtureOfExperts):
                 name = name.replace(".w2.", ".down_proj.")
             if ".w3." in name:
                 name = name.replace(".w3.", ".up_proj.")
-
-            if ".scale" in name:
-                name = name.replace(".scale", ".weight_scale")
 
             if ".head." in name:
                 name = name.replace(".head.", ".shared_head.head.")

--- a/vllm_ascend/models/layer/attention/layer.py
+++ b/vllm_ascend/models/layer/attention/layer.py
@@ -22,10 +22,6 @@ from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec
 
 from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.dsa_v1 import AscendDSABackend
-from vllm_ascend.utils import (
-    AscendDeviceType,
-    get_ascend_device_type,
-)
 
 
 class DSAAttention(nn.Module, AttentionLayerBase):
@@ -154,17 +150,10 @@ class DSAAttention(nn.Module, AttentionLayerBase):
         if self.compress_ratio <= 1:  # SWA part. Allocated separately as DeepseekV4SWACache.
             return None
         kv_cache_dtype = kv_cache_dtype_str_to_dtype(self.kv_cache_dtype, vllm_config.model_config)
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
-            kv_cache_dtype = torch.float8_e4m3fn
-            vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
-
-        cached_head_size = (
-            (self.head_size + 128) if get_ascend_device_type() in {AscendDeviceType.A5} else self.head_size
-        )
         return MLAAttentionSpec(
             block_size=128,
             num_kv_heads=1,
-            head_size=cached_head_size,
+            head_size=self.head_size,
             dtype=kv_cache_dtype,
             model_version="deepseek_v4",
             compress_ratio=self.compress_ratio,

--- a/vllm_ascend/ops/activation.py
+++ b/vllm_ascend/ops/activation.py
@@ -16,35 +16,25 @@
 #
 
 import torch
-import torch_npu
-from vllm.model_executor.layers.activation import QuickGELU, SiluAndMul, SiluAndMulWithClamp, SwigluOAIAndMul
+from vllm.model_executor.layers.activation import QuickGELU, SiluAndMul, SwigluOAIAndMul
 
 from vllm_ascend.utils import get_weight_prefetch_method
 
 
 class AscendQuickGELU(QuickGELU):
     def forward_oot(self, x: torch.tensor) -> torch.Tensor:
+        import torch_npu
+
         out = torch_npu.npu_fast_gelu(x)
         return out
 
 
 class AscendSiluAndMul(SiluAndMul):
     def forward_oot(self, x: torch.Tensor) -> torch.Tensor:
+        import torch_npu
+
         weight_prefetch_method = get_weight_prefetch_method()
         weight_prefetch_method.maybe_prefetch_mlp_weight_preprocess(weight_prefetch_method.MLP_DOWN, x)
-        out = torch_npu.npu_swiglu(x)
-        weight_prefetch_method.maybe_prefetch_mlp_weight_postprocess(out)
-        return out
-
-
-class AscendSiluAndMulWithClamp(SiluAndMulWithClamp):
-    def forward_oot(self, x: torch.Tensor) -> torch.Tensor:
-        weight_prefetch_method = get_weight_prefetch_method()
-        weight_prefetch_method.maybe_prefetch_mlp_weight_preprocess(weight_prefetch_method.MLP_DOWN, x)
-        d = x.shape[-1] // 2
-        gate = torch.clamp(x[..., :d], max=self.swiglu_limit)
-        up = torch.clamp(x[..., d:], min=-self.swiglu_limit, max=self.swiglu_limit)
-        x = torch.cat([gate, up], dim=-1)
         out = torch_npu.npu_swiglu(x)
         weight_prefetch_method.maybe_prefetch_mlp_weight_postprocess(out)
         return out

--- a/vllm_ascend/ops/dsa.py
+++ b/vllm_ascend/ops/dsa.py
@@ -44,7 +44,6 @@ class DSAModules:
 
     wq_a: torch.nn.Module
     q_norm: torch.nn.Module
-    q_norm_without_weight: torch.nn.Module
     wq_b: torch.nn.Module
     wkv: torch.nn.Module
     kv_norm: torch.nn.Module
@@ -98,7 +97,6 @@ class AscendDeepseekSparseAttention(MultiHeadLatentAttentionWrapper):
 
         self.wq_a = dsa_modules.wq_a
         self.q_norm = dsa_modules.q_norm
-        self.q_norm_without_weight = dsa_modules.q_norm_without_weight
         self.wq_b = dsa_modules.wq_b
         self.wkv = dsa_modules.wkv
         self.kv_norm = dsa_modules.kv_norm
@@ -113,7 +111,7 @@ class AscendDeepseekSparseAttention(MultiHeadLatentAttentionWrapper):
         self.prefix = prefix
 
         ascend_device_type = get_ascend_device_type()
-        k_dtype = torch.float8_e4m3fn if ascend_device_type == AscendDeviceType.A5 else torch.bfloat16
+        k_dtype = torch.fp8 if ascend_device_type == AscendDeviceType.A5 else torch.bfloat16
         self.swa_cache_layer = DeepseekV4SWACache(
             head_dim=self.head_dim,
             window_size=self.window_size,
@@ -144,7 +142,6 @@ class AscendDeepseekSparseAttention(MultiHeadLatentAttentionWrapper):
             wq_b=self.wq_b,
             wkv=self.wkv,
             q_norm=self.q_norm,
-            q_norm_without_weight=self.q_norm_without_weight,
             kv_norm=self.kv_norm,
             indexer=self.indexer,
             compressor=self.compressor,
@@ -240,7 +237,6 @@ def _build_kv_cache(self, forward_context):
     indexer_state_cache = None
     indexer_k_cache = None
     indexer_scale_cache = None
-    indexer_full_cache = None
 
     if self.compress_ratio > 1:
         state_cache = self.compressor.state_cache.kv_cache
@@ -250,48 +246,24 @@ def _build_kv_cache(self, forward_context):
             compress_kv_cache = compress_kv_cache[virtual_engine]
     if self.compress_ratio == 4:
         indexer_state_cache = self.indexer.compressor.state_cache.kv_cache
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
-            indexer_k_cache, indexer_scale_cache, indexer_full_cache = (
-                self.indexer.k_cache.kv_cache[0][0],
-                self.indexer.k_cache.kv_cache[0][1],
-                self.indexer.k_cache.kv_cache[0][2],
-            )
-        else:
-            indexer_k_cache, indexer_scale_cache = (
-                self.indexer.k_cache.kv_cache[0][0],
-                self.indexer.k_cache.kv_cache[0][1],
-            )
+        indexer_k_cache, indexer_scale_cache = (
+            self.indexer.k_cache.kv_cache[0][0],
+            self.indexer.k_cache.kv_cache[0][1],
+        )
 
-    if get_ascend_device_type() in {AscendDeviceType.A5}:
-        kv_cache = tuple(
-            [
-                unfold_kvcache(cache)
-                for cache in (
-                    compress_kv_cache,
-                    swa_kv_cache,
-                    state_cache,
-                    indexer_state_cache,
-                    indexer_k_cache,
-                    indexer_scale_cache,
-                    indexer_full_cache,
-                )
-            ]
-        )
-    else:
-        kv_cache = tuple(
-            [
-                unfold_kvcache(cache)
-                for cache in (
-                    compress_kv_cache,
-                    swa_kv_cache,
-                    state_cache,
-                    indexer_state_cache,
-                    indexer_k_cache,
-                    indexer_scale_cache,
-                )
-            ]
-        )
-    return kv_cache
+    return tuple(
+        [
+            unfold_kvcache(cache)
+            for cache in (
+                compress_kv_cache,
+                swa_kv_cache,
+                state_cache,
+                indexer_state_cache,
+                indexer_k_cache,
+                indexer_scale_cache,
+            )
+        ]
+    )
 
 
 def unfold_kvcache(kvcache):

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -69,7 +69,7 @@ class FusedMoEResult:
     before_dispatch_evt: torch.npu.Event | None = None
     before_gmm2_evt: torch.npu.Event | None = None
     before_combine_evt: torch.npu.Event | None = None
-    swiglu_limit: float = 0.0
+    swiglu_limit: int = 0
 
 
 @dataclass
@@ -79,7 +79,7 @@ class FusedMoEEvents:
     before_dispatch: torch.npu.Event | None = field(default=None)
     before_gmm2: torch.npu.Event | None = field(default=None)
     before_combine: torch.npu.Event | None = field(default=None)
-    swiglu_limit: float = 0.0
+    swiglu_limit: int = 0
 
 
 def mock_false():
@@ -181,7 +181,7 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         )
         if layer.vllm_config.model_config is not None and layer.vllm_config.model_config.enable_return_routed_experts:
             if vllm_version_is("0.20.2"):
-                # In 0.20.2, capturer is a process-wide singleton.
+                # 0.20.2: capturer is a process-wide singleton.
                 capturer = RoutedExpertsCapturer.get_instance()
             else:
                 capturer = getattr(layer, "_ascend_routed_experts_capturer", None)
@@ -775,51 +775,6 @@ class AscendFusedMoE(FusedMoE):
                     pertoken_scale=swiglu_out_scale,
                     bias=None,
                     output_dtype=original_dtype,
-                )
-            elif has_quantized_shared and self.quant_type == QuantType.W4A8MXFP:
-                original_dtype = hidden_states.dtype
-                # Execute dynamic quant concurrently with MoE gate.
-                torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
-                quantized_x, pertoken_scale = torch_npu.npu_dynamic_mx_quant(
-                    hidden_states, dst_type=torch.float8_e4m3fn
-                )
-                # Execute the gate projection and activation concurrently with the
-                # dispatch communication.
-                maybe_wait_event(fused_moe_evts.before_dispatch)
-                hidden_states = torch_npu.npu_quant_matmul(
-                    quantized_x,
-                    self._shared_experts.gate_up_proj.weight,
-                    self._shared_experts.gate_up_proj.weight_scale,
-                    scale_dtype=torch_npu.float8_e8m0fnu,
-                    pertoken_scale=pertoken_scale,
-                    pertoken_scale_dtype=torch_npu.float8_e8m0fnu,
-                    bias=None,
-                    output_dtype=original_dtype,
-                    group_sizes=[1, 1, 32],
-                )
-                # Execute activation concurrently with gmm2.
-                maybe_wait_event(fused_moe_evts.before_gmm2)
-                quantized_x, swiglu_out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
-                    hidden_states,
-                    topk_weight=None,
-                    group_index=None,
-                    dst_type=torch.float8_e4m3fn,
-                    quant_mode=2,
-                    clamp_value=fused_moe_evts.swiglu_limit,
-                )
-                # Execute the down projection concurrently with the combine
-                # communication.
-                maybe_wait_event(fused_moe_evts.before_combine)
-                shared_out = torch_npu.npu_quant_matmul(
-                    quantized_x,
-                    self._shared_experts.down_proj.weight,
-                    self._shared_experts.down_proj.weight_scale,
-                    scale_dtype=torch_npu.float8_e8m0fnu,
-                    pertoken_scale=swiglu_out_scale,
-                    pertoken_scale_dtype=torch_npu.float8_e8m0fnu,
-                    bias=None,
-                    output_dtype=original_dtype,
-                    group_sizes=[1, 1, 32],
                 )
             else:
                 # Ensure the shared experts wait for hidden_states to be ready.

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -81,7 +81,7 @@ class FusedExpertsResult:
     # For dynamic_eplb
     group_list_type: int = 1
     expert_tokens: torch.Tensor | None = None
-    swiglu_limit: float = 0.0
+    swiglu_limit: int = 0
 
 
 class MoECommMethod(ABC):

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -31,11 +31,8 @@ from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import (
     dispose_tensor,
     enable_custom_op,
-    get_ascend_device_type,
     get_weight_prefetch_method,
 )
-
-ASCEND_DEVICE_TYPE = get_ascend_device_type()
 
 
 def _custom_gmm_swiglu_enabled(fusion, dynamic_eplb):
@@ -106,7 +103,7 @@ def quant_apply_mlp(
     scale_type: torch.dtype | None = None,
     per_token_scale_type: torch.dtype | None = None,
     use_bf16: bool = True,
-    swiglu_limit: float = 0.0,
+    swiglu_limit: int = 0,
     use_w4a8_per_channel_gmm_swiglu: bool = False,
 ) -> torch.Tensor:
     input_hidden_dtype = hidden_states.dtype
@@ -450,11 +447,9 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
 
     if use_mxfp_quant:
         mxfp = mlp_compute_input.quant.mxfp
-        assert mxfp is not None, "mlp_compute_input.quant.mxfp is required when quant_type is MXFP8."
+        assert mxfp is not None, "mlp_compute_input.quant.mxfp is required for MXFP quant types."
         act_quant_type = mxfp.act_quant_type or act_quant_type
         weight_quant_type = mxfp.weight_quant_type or weight_quant_type
-        if mxfp_quant_dtype == QuantType.W4A8MXFP:
-            weight_quant_type = mxfp.weight_quant_type
         scale_type = mxfp.scale_dtype
         per_token_scale_type = mxfp.per_token_scale_dtype
         use_bf16 = mxfp.use_bf16

--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -145,7 +145,7 @@ def build_fused_experts_input(
     w2_scale_bias: list[torch.Tensor] | torch.Tensor | None = None,
     w1_offset: torch.Tensor | None = None,
     w2_offset: torch.Tensor | None = None,
-    swiglu_limit: float = 0.0,
+    swiglu_limit: int = 0,
 ) -> MoEFusedExpertsInput:
     return MoEFusedExpertsInput(
         hidden_states=hidden_states,

--- a/vllm_ascend/ops/fused_moe/moe_stage_contracts.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_contracts.py
@@ -68,7 +68,7 @@ class MoEFusedExpertsInput:
     activation: str = "silu"
     need_trans: bool = False
     dynamic_eplb: bool = False
-    swiglu_limit: float = 0.0
+    swiglu_limit: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -140,7 +140,7 @@ class MoEMlpComputeInput:
     activation: str = "silu"
     need_trans: bool = False
     dynamic_eplb: bool = False
-    swiglu_limit: float = 0.0
+    swiglu_limit: int = 0
 
 
 __all__ = [

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -46,6 +46,7 @@ from vllm_ascend.compilation.acl_graph import (
 from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
 from vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape import fused_qkvzba_split_reshape_cat
 from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
+from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
 from vllm_ascend.ops.triton.mamba.causal_conv1d import causal_conv1d_fn
 from vllm_ascend.utils import weak_ref_tensors
 
@@ -617,7 +618,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
         query_non_spec, key_non_spec, value_non_spec = self.rearrange_mixed_qkv(mixed_qkv_non_spec)
 
         # 2. Recurrent attention
-        g, beta = torch.ops._C_ascend.npu_fused_gdn_gating(self.A_log, a, b, self.dt_bias.to(torch.float32))
+        g, beta = fused_gdn_gating_patch(self.A_log, a, b, self.dt_bias)
         if spec_sequence_masks is not None:
             if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
                 g_spec = g

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -43,10 +43,10 @@ from vllm_ascend.compilation.acl_graph import (
     get_draft_graph_params,
     get_graph_params,
 )
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
 from vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape import fused_qkvzba_split_reshape_cat
 from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
-from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
 from vllm_ascend.ops.triton.mamba.causal_conv1d import causal_conv1d_fn
 from vllm_ascend.utils import weak_ref_tensors
 
@@ -618,7 +618,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
         query_non_spec, key_non_spec, value_non_spec = self.rearrange_mixed_qkv(mixed_qkv_non_spec)
 
         # 2. Recurrent attention
-        g, beta = fused_gdn_gating_patch(self.A_log, a, b, self.dt_bias)
+        g, beta = DeviceOperator.fused_gdn_gating(self.A_log, a, b, self.dt_bias)
         if spec_sequence_masks is not None:
             if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
                 g_spec = g

--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -41,12 +41,7 @@ from vllm.model_executor.utils import set_weight_attrs
 from vllm.utils.torch_utils import direct_register_custom_op
 
 from vllm_ascend.ops.linear_op import get_parallel_op, get_replicated_op
-from vllm_ascend.utils import (
-    AscendDeviceType,
-    enable_sp,
-    get_ascend_device_type,
-    maybe_trans_nz,
-)
+from vllm_ascend.utils import enable_sp, maybe_trans_nz
 
 
 def unquantized_gemm(
@@ -454,7 +449,7 @@ class AscendColumnParallelLinear(ColumnParallelLinear):
         return super().forward(input_)
 
     def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
-        if "wo_a" in self.prefix and get_ascend_device_type() != AscendDeviceType.A5:
+        if "wo_a" in self.prefix:
             if self.weight.ndim == 2:
                 super().weight_loader(param, loaded_weight)
                 self.weight.data = (

--- a/vllm_ascend/ops/rope_dsv4.py
+++ b/vllm_ascend/ops/rope_dsv4.py
@@ -7,6 +7,8 @@ import torch_npu
 from vllm.config import VllmConfig
 from vllm.platforms import current_platform
 
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
 
 class RopeGlobalState:
     def __init__(self):
@@ -117,6 +119,8 @@ class ComplexExpRotaryEmbedding(nn.Module):
             rope_groups = ["default"]
         self.layername = layername
         self.rotary_dim = rotary_dim
+        use_fp32_rope = get_ascend_device_type() in {AscendDeviceType.A2, AscendDeviceType.A3}
+        dtype = torch.float32 if use_fp32_rope else torch.get_default_dtype()
         beta_fast = extra_kwargs.get("beta_fast", 32)
         beta_slow = extra_kwargs.get("beta_slow", 1)
         config_key = (
@@ -142,6 +146,9 @@ class ComplexExpRotaryEmbedding(nn.Module):
             freqs = torch.einsum("i,j -> ij", t, inv_freq)
             cos = freqs.cos().repeat_interleave(2, dim=-1)
             sin = freqs.sin().repeat_interleave(2, dim=-1)
+            if not use_fp32_rope:
+                cos = cos.to(dtype)
+                sin = sin.to(dtype)
             cos = cos.to(current_platform.device_type)
             sin = sin.to(current_platform.device_type)
 
@@ -154,8 +161,8 @@ class ComplexExpRotaryEmbedding(nn.Module):
         max_batch_size = vllm_config.scheduler_config.max_num_batched_tokens
         for grp in rope_groups:
             if grp not in _ROPE_STATE.runtime_buffer[config_key]:
-                buf_cos = torch.ones(max_batch_size, 1, 1, rotary_dim, dtype=torch.float32, device=target_device)
-                buf_sin = torch.zeros(max_batch_size, 1, 1, rotary_dim, dtype=torch.float32, device=target_device)
+                buf_cos = torch.ones(max_batch_size, 1, 1, rotary_dim, dtype=dtype, device=target_device)
+                buf_sin = torch.zeros(max_batch_size, 1, 1, rotary_dim, dtype=dtype, device=target_device)
                 _ROPE_STATE.runtime_buffer[config_key][grp] = (buf_cos, buf_sin)
 
     @staticmethod

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -182,24 +182,6 @@
 #       Remove this patch once the supported vLLM version contains the upstream
 #       GLM tool-call final chunk fixes.
 #
-# ** 7b. File: platform/patch_glm47_tool_call_parser.py**
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#   1. `vllm.tool_parsers.glm47_moe_tool_parser.Glm47MoeModelToolParser`
-#    Why:
-#       vLLM's GLM47 streaming parser can drop complete inline zero-argument
-#       tool calls such as `<tool_call>get_current_time</tool_call>`, while
-#       non-streaming parses the same output correctly.
-#    How：
-#       Monkey-patch GLM47 tool-call region extraction so complete inline
-#       zero-argument regions are normalized for the existing streaming name
-#       extractor without emitting partial names for incomplete regions.
-#    Related PR (if no, explain why):
-#       https://github.com/vllm-project/vllm/issues/44326
-#       https://github.com/vllm-project/vllm/pull/44327
-#    Future Plan:
-#       Remove this patch once the supported vLLM version contains the upstream
-#       GLM47 inline zero-argument streaming parser fix.
-#
 # ** 10a. File: platform/patch_kv_cache_utils.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes`
@@ -361,18 +343,6 @@
 #    Future Plan:
 #       Remove this patch if upstream exposes a platform allocator capability hook
 #       for sleep mode validation.
-#
-# ** 14. File: platform/patch_scheduler.py**
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#   1. `vllm.v1.core.sched.scheduler.Scheduler._mamba_block_aligned_split`
-#    Why:
-#       Upstream vLLM has an assert logic, cause it fails when external KV connector hit
-#    How:
-#      remove the assert
-#    Related PR (if no, explain why):
-#       https://github.com/vllm-project/vllm/pull/43935
-#    Future Plan:
-#       Remove this patch if upstream streaming behavior is updated to support mamba external KV connector
 #
 # * Worker Patch:
 # ===============
@@ -746,16 +716,7 @@
 #    Future Plan:
 #       Remove this patch when:
 #       design a dispatch mechanism for batch_memcpy_kernel.
-#   3. `mamba_utils.preprocess_mamba = preprocess_mamba`
-#    Why:
-#       1. preprocess_mamba has a assert logic, cause kv transfer call fails
-#       2. preprocess_mamba copy the state of previous step to the last block before kv transfer load
-#    How:
-#       1. patch to remove assert
-#       2. path to only collect copy metadata in preprocess_mamba(and do actual copy after kv transfer load).
-#    Future Plan:
-#       Remove this patch when:
-#       vLLM itself supports kv transfer for mamba
+#
 # ** 21. File: worker/patch_weight_utils.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.models.deepseek_v2.DeepseekV2ForCausalLM.load_weights`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -31,7 +31,6 @@ else:
 import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
 import vllm_ascend.patch.platform.patch_minimax_usage_accounting  # noqa
 import vllm_ascend.patch.platform.patch_glm_tool_call_streaming  # noqa
-import vllm_ascend.patch.platform.patch_glm47_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_minimax_m2_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_thinking  # noqa
@@ -46,5 +45,3 @@ import vllm_ascend.patch.platform.patch_balance_schedule  # noqa
 if envs.VLLM_ASCEND_APPLY_DSV4_PATCH:
     import vllm_ascend.patch.platform.patch_kv_cache_coordinator  # noqa
     import vllm_ascend.patch.platform.patch_speculative_config  # noqa
-
-import vllm_ascend.patch.platform.patch_scheduler  # noqa

--- a/vllm_ascend/patch/platform/patch_kv_cache_interface.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_interface.py
@@ -145,7 +145,6 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
             num_kv_heads=specs[0].num_kv_heads,
             head_size=specs[0].head_size,
             scale_dim=specs[0].scale_dim,
-            scale_dtype=specs[0].scale_dtype,
             sparse_head_dim=specs[0].sparse_head_dim,
             dtype=specs[0].dtype,
             cache_dtype_str=cache_dtype_str_set.pop(),

--- a/vllm_ascend/patch/platform/patch_mamba_config.py
+++ b/vllm_ascend/patch/platform/patch_mamba_config.py
@@ -21,9 +21,6 @@ def verify_and_update_config(cls, vllm_config) -> None:
     Args:
         vllm_config: vLLM Config
     """
-    using_kv_transfer_with_hybrid = (
-        not vllm_config.scheduler_config.disable_hybrid_kv_cache_manager and vllm_config.kv_transfer_config
-    )
     # Enable FULL_AND_PIECEWISE by default
     MambaModelConfig.verify_and_update_config(vllm_config)
 
@@ -103,13 +100,6 @@ def verify_and_update_config(cls, vllm_config) -> None:
             "exactly equal.",
             mamba_padding_pct,
         )
-    if using_kv_transfer_with_hybrid:
-        if cache_config.mamba_cache_mode == "none":
-            cache_config.mamba_cache_mode = "align"
-        else:
-            assert cache_config.mamba_cache_mode == "align", (
-                "mamba_cache_mode only support 'align' when kv_transfer enabled now!"
-            )
     if cache_config.enable_prefix_caching and cache_config.mamba_cache_mode == "align":
         cache_config.mamba_block_size = cache_config.block_size
     else:

--- a/vllm_ascend/patch/worker/patch_deepseek_compressor.py
+++ b/vllm_ascend/patch/worker/patch_deepseek_compressor.py
@@ -10,7 +10,7 @@ from vllm.v1.kv_cache_interface import (
 
 from vllm_ascend.attention.dsa_v1 import AscendDSABackend
 from vllm_ascend.patch.platform.patch_kv_cache_interface import AscendMLAAttentionSpec
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type, vllm_version_is
+from vllm_ascend.utils import vllm_version_is
 
 if vllm_version_is("0.20.2"):
     from vllm.model_executor.layers import (
@@ -50,15 +50,10 @@ class AscendCompressorStateCache(CompressorStateCache):
         self.compress_ratio = compress_ratio
         coff = 1 + (compress_ratio == 4)
         self.sliding_window = coff * compress_ratio
-
         self.block_size = block_size
 
     def get_kv_cache_spec(self, vllm_config) -> KVCacheSpec:
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
-            page_size_padded = 16896 if self.state_dim == 2 * 256 and self.compress_ratio == 4 else 81920
-        else:
-            page_size_padded = 16640 if self.state_dim == 2 * 256 and self.compress_ratio == 4 else 131072
-
+        page_size_padded = 16640 if self.state_dim == 2 * 256 and self.compress_ratio == 4 else 131072
         return SlidingWindowMLASpec(  # only has one vector instead of K + V
             block_size=self.block_size,
             num_kv_heads=1,
@@ -87,10 +82,6 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
         super().__init__(head_dim, dtype, prefix, cache_config, compress_ratio)
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
-            self.dtype = torch.float8_e4m3fn
-            vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
-
         return AscendMLAAttentionSpec(  # Only has one vector instead of K + V
             block_size=128,
             num_kv_heads=1,
@@ -100,7 +91,7 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
             compress_ratio=self.compress_ratio,
             cache_dtype_str=self.cache_config.cache_dtype,
             scale_dim=1 if self.head_dim == 128 else 0,
-            scale_dtype=torch.float if get_ascend_device_type() in {AscendDeviceType.A5} else torch.float16,
+            scale_dtype=torch.float16,
         )
 
     def forward(self): ...
@@ -129,15 +120,11 @@ class AscendDeepseekV4SWACache(DeepseekV4SWACache):
         self.block_size = 128
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
-            self.dtype = torch.float8_e4m3fn
-            vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
         # TODO(cmq): alignment = 0 if A3 else 128
-        cached_head_size = (self.head_dim + 128) if get_ascend_device_type() in {AscendDeviceType.A5} else self.head_dim
         return SlidingWindowMLASpec(
             block_size=self.block_size,
             num_kv_heads=1,
-            head_size=cached_head_size,
+            head_size=self.head_dim,
             dtype=self.dtype,
             sliding_window=self.window_size,
             cache_dtype_str=self.cache_config.cache_dtype,

--- a/vllm_ascend/patch/worker/patch_kimi_k25.py
+++ b/vllm_ascend/patch/worker/patch_kimi_k25.py
@@ -39,9 +39,7 @@ class AscendLearnable2DInterpPosEmbDivided_fixed(nn.Module):
     def forward(self, x: torch.Tensor, grid_thws: torch.Tensor) -> torch.Tensor:
         pos_embs = []
         for t, h, w in grid_thws.tolist():
-            assert t <= self.num_frames, (
-                f"[vllm-ascend/patch_kimi_k25] Invalid frame count. t={t}, num_frames={self.num_frames}"
-            )
+            assert t <= self.num_frames, f"t:{t} > self.num_frames:{self.num_frames}"
             if (h, w) == self.weight.shape[:-1]:
                 pos_emb_2d = self.weight.flatten(end_dim=1)
             else:

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -3,15 +3,7 @@
 from typing import Any
 
 import torch
-from vllm.config import CacheConfig
-from vllm.model_executor.layers.mamba.mamba_utils import MambaStateCopyFunc
-from vllm.utils.math_utils import cdiv
-from vllm.v1.core.sched.output import SchedulerOutput
-from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker import mamba_utils
-from vllm.v1.worker.gpu_input_batch import CachedRequestState
-from vllm.v1.worker.lora_model_runner_mixin import GPUInputBatch
-from vllm.v1.worker.mamba_utils import MambaCopyBuffers
 
 from vllm_ascend.ops.triton.batch_memcpy import batch_memcpy_kernel
 from vllm_ascend.utils import is_310p
@@ -117,72 +109,3 @@ else:
     mamba_utils.batch_memcpy = _batch_memcpy_unavailable
     mamba_utils.collect_mamba_copy_meta = _collect_mamba_copy_meta_torch
     mamba_utils.do_mamba_copy_block = _do_mamba_copy_block_torch
-
-
-def preprocess_mamba(
-    scheduler_output: SchedulerOutput,
-    kv_cache_config: KVCacheConfig,
-    cache_config: CacheConfig,
-    mamba_state_idx: dict[str, int],
-    input_batch: GPUInputBatch,
-    requests: dict[str, CachedRequestState],
-    forward_context: dict[str, Any],
-    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
-    copy_bufs: MambaCopyBuffers,
-):
-    """
-    Copy the mamba state of previous step to the last
-    (1 + num_speculative_blocks) block.
-    """
-    mamba_group_ids = copy_bufs.mamba_group_ids
-    mamba_spec = copy_bufs.mamba_spec
-    num_speculative_blocks = mamba_spec.num_speculative_blocks
-    # TODO(Chen): we need to optimize this function a lot
-    # assert cache_config.enable_prefix_caching
-    block_size = mamba_spec.block_size
-    mamba_utils.cleanup_mamba_state_idx(scheduler_output, mamba_state_idx)
-
-    copy_bufs.offset = 0
-    for i, req_id in enumerate(input_batch.req_ids):
-        req_state = requests[req_id]
-        prev_state_idx = mamba_state_idx.get(req_id)
-        if prev_state_idx is None:
-            # new / resumed request, no previous state
-            # if num_computed_tokens is 0, prev_state_idx will be -1
-            prev_state_idx = (req_state.num_computed_tokens - 1) // block_size
-
-        num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
-        num_blocks: int = (
-            cdiv(req_state.num_computed_tokens + num_scheduled_tokens, block_size) + num_speculative_blocks
-        )
-
-        # We always save the current running state at the last
-        # (1 + num_speculative_blocks) block.
-        # A corner case worth mention here: assume we have block_size = 4 and
-        # num_speculative_tokens = 2. The request is [A, B, C] and contains 2 draft
-        # tokens [draft 1, draft 2]. Then we will have:
-        # Block 0: [A, B, C, draft 1]
-        # Block 1: [draft 2, TOFILL, TOFILL, TOFILL]
-        # Block 2: speculative block
-        # Block 3: speculative block
-        # And use block 1 to save the running state.
-        curr_state_idx = num_blocks - 1 - num_speculative_blocks
-        mamba_state_idx[req_id] = curr_state_idx
-        if prev_state_idx != -1 and prev_state_idx != curr_state_idx:
-            mamba_utils.collect_mamba_copy_meta(
-                copy_bufs,
-                kv_cache_config,
-                mamba_state_copy_funcs,
-                mamba_group_ids,
-                prev_state_idx,
-                curr_state_idx,
-                input_batch.num_accepted_tokens_cpu[i] - 1,
-                req_state,
-                forward_context,
-            )
-            input_batch.num_accepted_tokens_cpu[i] = 1
-    # do not copy here, since kv_transfer still not load
-    # do_mamba_copy_block(copy_bufs)
-
-
-mamba_utils.preprocess_mamba = preprocess_mamba

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -40,6 +40,7 @@ from vllm_ascend.utils import (
     ASCEND_QUANTIZATION_METHOD,
     COMPILATION_PASS_KEY,
     COMPRESSED_TENSORS_METHOD,
+    FP8_METHOD,
     AscendDeviceType,
     bootstrap_custom_op_env,
     check_kv_extra_config,
@@ -51,6 +52,14 @@ from vllm_ascend.utils import (
     update_cudagraph_capture_sizes,
     is_310p,
     enable_sp,
+)
+
+# Since vllm-project/vllm#43746, DeepSeek V4 model classes no longer
+# carry @support_torch_compile. This makes vLLM auto-enable the breakable
+# cudagraph PIECEWISE path, which is not supported on Ascend yet.
+envs_vllm.VLLM_USE_BREAKABLE_CUDAGRAPH = False
+logger.info(
+    "Breakable cudagraph is force disabled on Ascend because DeepSeek V4 PIECEWISE cudagraph is not supported yet."
 )
 
 if TYPE_CHECKING:
@@ -103,7 +112,12 @@ class NPUPlatform(Platform):
     device_control_env_var: str = "ASCEND_RT_VISIBLE_DEVICES"
     dispatch_key: str = "PrivateUse1"
 
-    supported_quantization: list[str] = [ASCEND_QUANTIZATION_METHOD, COMPRESSED_TENSORS_METHOD]
+    supported_quantization: list[str] = [
+        ASCEND_QUANTIZATION_METHOD,
+        COMPRESSED_TENSORS_METHOD,
+        FP8_METHOD,
+        "deepseek_v4_fp8",
+    ]
 
     def is_sleep_mode_available(self) -> bool:
         return True
@@ -150,7 +164,7 @@ class NPUPlatform(Platform):
                     quant_action.choices.append(ASCEND_QUANTIZATION_METHOD)
 
         if not is_310p():
-            from vllm_ascend.quantization import AscendCompressedTensorsConfig, AscendModelSlimConfig  # noqa: F401
+            from vllm_ascend.quantization import AscendCompressedTensorsConfig, AscendFp8Config, AscendModelSlimConfig  # noqa: F401
         else:
             from vllm_ascend._310p.quantization import AscendModelSlimConfig310  # noqa: F401
 
@@ -199,7 +213,9 @@ class NPUPlatform(Platform):
 
     @classmethod
     def apply_config_platform_defaults(cls, vllm_config: VllmConfig) -> None:
-        """Apply Ascend-specific defaults. Set sp_min_token_num=1 when enable_sp and not set."""
+        """Apply Ascend-specific defaults."""
+
+        # Set sp_min_token_num=1 when enable_sp and not set.
         pass_config = vllm_config.compilation_config.pass_config
         if pass_config.enable_sp and pass_config.sp_min_token_num is None:
             from vllm_ascend.compilation.passes.sequence_parallelism import get_sp_min_token_num
@@ -255,7 +271,23 @@ class NPUPlatform(Platform):
     def update_block_size_for_backend(cls, vllm_config: VllmConfig) -> None:
         # TODO: NPU still sets block_size in check_and_update_config.
         # Move that logic here so block_size is chosen by the backend.
-        pass
+        using_kv_transfer_with_hybrid = (
+            not vllm_config.scheduler_config.disable_hybrid_kv_cache_manager and vllm_config.kv_transfer_config
+        )
+        cache_config = vllm_config.cache_config
+        model_config = vllm_config.model_config
+        if (
+            not cache_config.enable_prefix_caching
+            and using_kv_transfer_with_hybrid
+            and cache_config.mamba_cache_mode == "align"
+        ):
+            if cache_config.mamba_block_size is None or cache_config.mamba_block_size == model_config.max_model_len:
+                cache_config.mamba_block_size = cache_config.block_size
+            else:
+                # mamba_block_size must be a multiple of block_size, so that it can hand the block hash
+                assert cache_config.mamba_block_size % cache_config.block_size == 0, (
+                    f"mamba_block_size must be a multiple of block_size: {cache_config.block_size}"
+                )
 
     @classmethod
     def set_device(cls, device: torch.device):
@@ -475,13 +507,18 @@ class NPUPlatform(Platform):
                 all2all_backend=vllm_config.parallel_config.all2all_backend,
                 data_parallel_size=vllm_config.parallel_config.data_parallel_size,
             )
-            # NOTE: Theoretically, we should also add vllm::mla_forward in the attention ops.
+            # NOTE: Theoretically, we should also add this in the attention ops.
             # Since the process is created in the spawn mode, the value of the class attribute
             # attention ops transmitted is still the one before modification, so it has not been modified.
             # This will cause in scenarios where both piecewise and splitting ops are configured simultaneously,
-            # If splitting ops does not contain the vllm::mla forward value, this configuration issue will
+            # If splitting ops does not contain the this value, this configuration issue will
             # not be detected in advance assert.
-            compilation_config.splitting_ops.extend(["vllm::mla_forward"])
+            compilation_config.splitting_ops.extend(
+                [
+                    "vllm::mla_forward",
+                    "vllm::dsa_forward",
+                ]
+            )
             update_aclgraph_sizes(vllm_config)
             ascend_config.ascend_compilation_config.enable_npugraph_ex = False
         elif compilation_config.cudagraph_mode.has_full_cudagraphs():

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -40,7 +40,6 @@ from vllm_ascend.utils import (
     ASCEND_QUANTIZATION_METHOD,
     COMPILATION_PASS_KEY,
     COMPRESSED_TENSORS_METHOD,
-    FP8_METHOD,
     AscendDeviceType,
     bootstrap_custom_op_env,
     check_kv_extra_config,
@@ -104,12 +103,7 @@ class NPUPlatform(Platform):
     device_control_env_var: str = "ASCEND_RT_VISIBLE_DEVICES"
     dispatch_key: str = "PrivateUse1"
 
-    supported_quantization: list[str] = [
-        ASCEND_QUANTIZATION_METHOD,
-        COMPRESSED_TENSORS_METHOD,
-        FP8_METHOD,
-        "deepseek_v4_fp8",
-    ]
+    supported_quantization: list[str] = [ASCEND_QUANTIZATION_METHOD, COMPRESSED_TENSORS_METHOD]
 
     def is_sleep_mode_available(self) -> bool:
         return True
@@ -156,7 +150,7 @@ class NPUPlatform(Platform):
                     quant_action.choices.append(ASCEND_QUANTIZATION_METHOD)
 
         if not is_310p():
-            from vllm_ascend.quantization import AscendCompressedTensorsConfig, AscendFp8Config, AscendModelSlimConfig  # noqa: F401
+            from vllm_ascend.quantization import AscendCompressedTensorsConfig, AscendModelSlimConfig  # noqa: F401
         else:
             from vllm_ascend._310p.quantization import AscendModelSlimConfig310  # noqa: F401
 
@@ -205,17 +199,7 @@ class NPUPlatform(Platform):
 
     @classmethod
     def apply_config_platform_defaults(cls, vllm_config: VllmConfig) -> None:
-        """Apply Ascend-specific defaults."""
-        # Since vllm-project/vllm#43746, DeepSeek V4 model classes no longer
-        # carry @support_torch_compile. This makes vLLM auto-enable the breakable
-        # cudagraph PIECEWISE path, which is not supported on Ascend yet.
-        envs_vllm.VLLM_USE_BREAKABLE_CUDAGRAPH = False
-        logger.info(
-            "Breakable cudagraph is force disabled on Ascend because "
-            "DeepSeek V4 PIECEWISE cudagraph is not supported yet."
-        )
-
-        # Set sp_min_token_num=1 when enable_sp and not set.
+        """Apply Ascend-specific defaults. Set sp_min_token_num=1 when enable_sp and not set."""
         pass_config = vllm_config.compilation_config.pass_config
         if pass_config.enable_sp and pass_config.sp_min_token_num is None:
             from vllm_ascend.compilation.passes.sequence_parallelism import get_sp_min_token_num
@@ -271,23 +255,7 @@ class NPUPlatform(Platform):
     def update_block_size_for_backend(cls, vllm_config: VllmConfig) -> None:
         # TODO: NPU still sets block_size in check_and_update_config.
         # Move that logic here so block_size is chosen by the backend.
-        using_kv_transfer_with_hybrid = (
-            not vllm_config.scheduler_config.disable_hybrid_kv_cache_manager and vllm_config.kv_transfer_config
-        )
-        cache_config = vllm_config.cache_config
-        model_config = vllm_config.model_config
-        if (
-            not cache_config.enable_prefix_caching
-            and using_kv_transfer_with_hybrid
-            and cache_config.mamba_cache_mode == "align"
-        ):
-            if cache_config.mamba_block_size is None or cache_config.mamba_block_size == model_config.max_model_len:
-                cache_config.mamba_block_size = cache_config.block_size
-            else:
-                # mamba_block_size must be a multiple of block_size, so that it can hand the block hash
-                assert cache_config.mamba_block_size % cache_config.block_size == 0, (
-                    f"mamba_block_size must be a multiple of block_size: {cache_config.block_size}"
-                )
+        pass
 
     @classmethod
     def set_device(cls, device: torch.device):
@@ -507,18 +475,13 @@ class NPUPlatform(Platform):
                 all2all_backend=vllm_config.parallel_config.all2all_backend,
                 data_parallel_size=vllm_config.parallel_config.data_parallel_size,
             )
-            # NOTE: Theoretically, we should also add this in the attention ops.
+            # NOTE: Theoretically, we should also add vllm::mla_forward in the attention ops.
             # Since the process is created in the spawn mode, the value of the class attribute
             # attention ops transmitted is still the one before modification, so it has not been modified.
             # This will cause in scenarios where both piecewise and splitting ops are configured simultaneously,
-            # If splitting ops does not contain the this value, this configuration issue will
+            # If splitting ops does not contain the vllm::mla forward value, this configuration issue will
             # not be detected in advance assert.
-            compilation_config.splitting_ops.extend(
-                [
-                    "vllm::mla_forward",
-                    "vllm::dsa_forward",
-                ]
-            )
+            compilation_config.splitting_ops.extend(["vllm::mla_forward"])
             update_aclgraph_sizes(vllm_config)
             ascend_config.ascend_compilation_config.enable_npugraph_ex = False
         elif compilation_config.cudagraph_mode.has_full_cudagraphs():

--- a/vllm_ascend/quantization/__init__.py
+++ b/vllm_ascend/quantization/__init__.py
@@ -25,10 +25,12 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .compressed_tensors_config import AscendCompressedTensorsConfig
-    from .fp8_config import AscendFp8Config
     from .modelslim_config import AscendModelSlimConfig
 
-__all__ = ["AscendModelSlimConfig", "AscendCompressedTensorsConfig", "AscendFp8Config"]
+__all__ = [
+    "AscendModelSlimConfig",
+    "AscendCompressedTensorsConfig",
+]
 
 
 def __getattr__(name: str) -> Any:
@@ -40,8 +42,4 @@ def __getattr__(name: str) -> Any:
         from .compressed_tensors_config import AscendCompressedTensorsConfig
 
         return AscendCompressedTensorsConfig
-    if name == "AscendFp8Config":
-        from .fp8_config import AscendFp8Config
-
-        return AscendFp8Config
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/vllm_ascend/quantization/method_adapters.py
+++ b/vllm_ascend/quantization/method_adapters.py
@@ -105,15 +105,11 @@ class AscendLinearMethod(LinearMethodBase):
         pergroup_dict = self.quant_method.get_pergroup_param(
             input_size_per_partition, output_size_per_partition, params_dtype, layer_type=layer_type
         )
-        scale_packed_dim = pergroup_dict.pop("_packed_dim", None)
-        scale_packed_factor = pergroup_dict.pop("_packed_factor", None)
         for pergroup_name, pergroup_param in pergroup_dict.items():
             param = torch.nn.Parameter(pergroup_param, requires_grad=False)
             set_weight_attrs(param, {"output_dim": 0})
             layer.register_parameter(pergroup_name, param)
             set_weight_attrs(param, extra_weight_attrs)
-            if scale_packed_dim is not None and scale_packed_factor is not None:
-                set_weight_attrs(param, {"packed_dim": scale_packed_dim, "packed_factor": scale_packed_factor})
             if (
                 "weight_scale_second" in pergroup_name
                 or "weight_offset_second" in pergroup_name

--- a/vllm_ascend/quantization/methods/__init__.py
+++ b/vllm_ascend/quantization/methods/__init__.py
@@ -33,7 +33,6 @@ from typing import Any
 from .base import AscendAttentionScheme, AscendLinearScheme, AscendMoEScheme, QuantType
 
 # Import all scheme classes for external access
-from .fp8 import AscendW4A8MXFPDSDynamicFusedMoEMethod, AscendW8A8MXFP8DSDynamicLinearMethod
 from .kv_c8 import AscendFAQuantAttentionMethod
 
 # Import registry functions
@@ -92,7 +91,4 @@ __all__ = [
     "AscendFAQuantAttentionMethod",
     "AscendW4A4MXFP4DynamicLinearMethod",
     "AscendW4A4MXFP4DynamicFusedMoEMethod",
-    "AscendW4A4MXFP4FlatQuantDynamicLinearMethod",
-    "AscendW8A8MXFP8DSDynamicLinearMethod",
-    "AscendW4A8MXFPDSDynamicFusedMoEMethod",
 ]

--- a/vllm_ascend/quantization/methods/kv_c8.py
+++ b/vllm_ascend/quantization/methods/kv_c8.py
@@ -1,7 +1,6 @@
 import torch
 from vllm.config import get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size
-from vllm.logger import logger
 
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
@@ -19,9 +18,7 @@ def _fa_quant_weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor):
         shard_size = loaded_weight.shape[0] // tp_size
         loaded_weight = loaded_weight.narrow(0, shard_size * tp_rank, shard_size)
         assert param.size() == loaded_weight.size(), (
-            "[vllm-ascend/FAKQuant] Attempted to load weight "
-            f"({loaded_weight.size()}) into parameter ({param.size()}) "
-            f"when TP size is {tp_size} and TP rank is {tp_rank}."
+            f"Attempted to load weight ({loaded_weight.size()}) into parameter ({param.size()}) when TP is ({tp_size})"
         )
 
         param.data.copy_(loaded_weight)
@@ -119,9 +116,6 @@ class AscendC8KVCacheAttentionMethod(AscendAttentionScheme):
     def create_weights(self, layer: torch.nn.Module) -> None:
         # Returns int8 if the P node is not a PD detachment node.
         if not self.is_kv_producer:
-            logger.info_once(
-                "[vllm-ascend/C8_KV] KV cache producer is disabled; setting kv_cache_torch_dtype to torch.int8."
-            )
             layer.kv_cache_torch_dtype = torch.int8
         # Upgrade impl to the C8-specific subclass so the C8 forward path is always used.
         if hasattr(layer, "impl"):
@@ -156,9 +150,7 @@ class AscendC8KVCacheAttentionMethod(AscendAttentionScheme):
         scale,
         output,
     ) -> torch.Tensor:
-        err_msg = (
-            "[vllm-ascend/C8_KV] AscendC8KVCacheAttentionMethod.apply should "
-            "not be called. C8 KV cache quantization is handled by the "
-            "attention backend."
+        raise RuntimeError(
+            "AscendC8KVCacheAttentionMethod.apply should not be called. "
+            "C8 KV cache quantization is handled by the attention backend."
         )
-        raise RuntimeError(err_msg)

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -553,9 +553,9 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
         topk_weights = topk_weights.to(x.dtype)
 
         if self.dynamic_eplb:
-            w1 = [i.view(torch.int32) for i in layer.w13_weight_list]
+            w1 = layer.w13_weight_list
             w1_scale = layer.w13_weight_scale_list
-            w2 = [i.view(torch.int32) for i in layer.w2_weight_list]
+            w2 = layer.w2_weight_list
             w2_scale = layer.w2_weight_scale_list
             w1_scale_bias = layer.w13_scale_bias_list
             w2_scale_bias = layer.w2_scale_bias_list
@@ -753,8 +753,8 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
         layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)
 
         if self.dynamic_eplb:
-            layer.w13_weight_list = [weight.clone() for weight in layer.w13_weight.data.unbind(dim=0)]
-            layer.w2_weight_list = [weight.clone() for weight in layer.w2_weight.data.unbind(dim=0)]
+            layer.w13_weight_list = [weight.clone().view(torch.int32) for weight in layer.w13_weight.data.unbind(dim=0)]
+            layer.w2_weight_list = [weight.clone().view(torch.int32) for weight in layer.w2_weight.data.unbind(dim=0)]
             layer.w13_weight_scale_list = [weight.clone() for weight in layer.w13_weight_scale.data.unbind(dim=0)]
             layer.w2_weight_scale_list = [weight.clone() for weight in layer.w2_weight_scale.data.unbind(dim=0)]
             layer.w13_scale_bias_list = (

--- a/vllm_ascend/quantization/methods/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8_mxfp4.py
@@ -184,7 +184,6 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
             custom_routing_function=custom_routing_function,
             scoring_func=scoring_func,
             e_score_correction_bias=e_score_correction_bias,
-            routed_scaling_factor=routed_scaling_factor,
             num_experts=num_logical_experts,
             tid2eid=tid2eid,
         )
@@ -222,7 +221,6 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
                 mxfp_use_bf16=(x.dtype == torch.bfloat16),
                 w1_scale=layer.w13_weight_scale,
                 w2_scale=layer.w2_weight_scale,
-                swiglu_limit=layer.swiglu_limit,
             )
         )
 

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -22,7 +22,6 @@ import torch
 import torch_npu
 from vllm.config import CompilationMode, get_current_vllm_config
 from vllm.distributed import get_ep_group
-from vllm.logger import logger
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
@@ -179,10 +178,6 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
             backend = device_group._get_backend(torch.device("npu"))
             self.moe_all_to_all_group_name = backend.get_hccl_comm_name(local_rank)
         except AttributeError:
-            logger.warning_once(
-                "[vllm-ascend/W8A8_DYNAMIC] MC2 group metadata unavailable, "
-                "falling back to empty moe_all_to_all_group_name."
-            )
             self.moe_all_to_all_group_name = ""
 
     def get_weight(
@@ -251,19 +246,12 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
         )
         if zero_expert_num == 0 or zero_expert_type is None:
             assert router_logits.shape[1] == num_logical_experts, (
-                "[vllm-ascend/W8A8_DYNAMIC] Number of global experts mismatch "
-                "(excluding redundancy). "
-                f"router_experts={router_logits.shape[1]}, "
-                f"expected_experts={num_logical_experts}, "
-                f"zero_expert_num={zero_expert_num}, "
-                f"zero_expert_type={zero_expert_type}"
+                "Number of global experts mismatch (excluding redundancy)"
             )
 
         if self.multistream_overlap_gate:
             fc3_context = get_flash_common3_context()
-            assert fc3_context is not None, (
-                "[vllm-ascend/W8A8_DYNAMIC] flash_common3 context is required when multistream_overlap_gate is enabled."
-            )
+            assert fc3_context is not None
             topk_weights = fc3_context.topk_weights
             topk_ids = fc3_context.topk_ids
         else:

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -23,7 +23,6 @@ import torch.nn.functional as F
 import torch_npu
 from vllm.config import CompilationMode, get_current_vllm_config
 from vllm.distributed import get_ep_group
-from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
 
 from vllm_ascend.ascend_config import get_ascend_config
@@ -160,13 +159,10 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
             return
 
         if not hasattr(layer, "_mxfp8_original_shapes"):
-            err_msg = (
-                "[vllm-ascend/W8A8_MXFP8] Cannot restore weights: original "
-                "shapes not recorded. "
+            raise RuntimeError(
+                "Cannot restore weights: original shapes not recorded. "
                 "This should not happen if process_weights_after_loading was called first."
             )
-            logger.error(err_msg)
-            raise RuntimeError(err_msg)
 
         orig_shapes = layer._mxfp8_original_shapes
         orig_scale_shape = orig_shapes["weight_scale"]
@@ -396,13 +392,10 @@ class AscendW8A8MXFP8DynamicFusedMoEMethod(AscendMoEScheme):
             return
 
         if not hasattr(layer, "_mxfp8_original_shapes"):
-            err_msg = (
-                "[vllm-ascend/W8A8_MXFP8] Cannot restore weights: original "
-                "shapes not recorded. "
+            raise RuntimeError(
+                "Cannot restore weights: original shapes not recorded. "
                 "This should not happen if process_weights_after_loading was called first."
             )
-            logger.error(err_msg)
-            raise RuntimeError(err_msg)
 
         orig_shapes = layer._mxfp8_original_shapes
 

--- a/vllm_ascend/quantization/utils.py
+++ b/vllm_ascend/quantization/utils.py
@@ -24,7 +24,6 @@ from vllm.logger import logger
 from vllm_ascend.utils import (
     ASCEND_QUANTIZATION_METHOD,
     COMPRESSED_TENSORS_METHOD,
-    FP8_METHOD,
     AscendDeviceType,
     get_ascend_device_type,
 )
@@ -127,10 +126,6 @@ def detect_quantization_method(model: str, revision: str | None = None) -> str |
                 quant_method = quant_cfg.get("quant_method", "")
                 if quant_method == COMPRESSED_TENSORS_METHOD:
                     return COMPRESSED_TENSORS_METHOD
-            if isinstance(quant_cfg, dict):
-                quant_method = quant_cfg.get("quant_method", "")
-                if quant_method == FP8_METHOD:
-                    return FP8_METHOD
         except (json.JSONDecodeError, OSError):
             pass
 

--- a/vllm_ascend/sample/sampler.py
+++ b/vllm_ascend/sample/sampler.py
@@ -1,7 +1,7 @@
 import torch
 import vllm.envs as envs
 from vllm.distributed.parallel_state import get_tp_group
-from vllm.triton_utils import HAS_TRITON
+from vllm.triton_utils import HAS_TRITON, triton
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.topk_topp_sampler import TopKTopPSampler
 from vllm.v1.sample.sampler import Sampler
@@ -9,6 +9,7 @@ from vllm.v1.sample.sampler import Sampler
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.sample.penalties import apply_all_penalties
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type, global_stream, npu_stream_switch
+from vllm_ascend.worker.v2.sample.gumbel import gumbel_sample
 
 DEFAULT_LOGPROBS_MODE = "raw_logprobs"
 
@@ -39,6 +40,104 @@ def random_sample(
                 q[i].exponential_(generator=generator)
     torch.npu.current_stream().wait_stream(global_stream())
     return probs.div_(q).argmax(dim=-1).view(-1)
+
+
+def _ensure_runtime_state_tensor(
+    tensor: torch.Tensor | None,
+    needed: int,
+    default_value,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    if tensor is not None and tensor.shape[0] >= needed:
+        return tensor
+    out = torch.full((needed,), default_value, dtype=dtype, device=device)
+    if tensor is not None and tensor.numel() > 0:
+        out[: tensor.shape[0]].copy_(tensor)
+    return out
+
+
+def sample_with_runtime_state(
+    logits: torch.Tensor,
+    idx_mapping: torch.Tensor,
+    positions: torch.Tensor,
+    temperature: torch.Tensor | None,
+    top_k: torch.Tensor | None,
+    top_p: torch.Tensor | None,
+    seeds: torch.Tensor | None,
+    all_greedy: bool = False,
+    all_random: bool = False,
+) -> torch.Tensor:
+    needed = max(int(idx_mapping.shape[0]), 1)
+    if all_greedy or temperature is None:
+        return logits.argmax(dim=-1)
+
+    temperature = _ensure_runtime_state_tensor(
+        temperature,
+        needed,
+        0.0,
+        torch.float32,
+        logits.device,
+    )
+    seeds = _ensure_runtime_state_tensor(
+        seeds,
+        needed,
+        0,
+        torch.int64,
+        logits.device,
+    )
+
+    idx_mapping_long = idx_mapping.to(torch.long)
+    row_temperature = temperature[idx_mapping_long]
+    greedy_sampled = None if all_random else logits.argmax(dim=-1)
+    if not all_random:
+        safe_temperature = torch.where(
+            row_temperature < _SAMPLING_EPS,
+            torch.ones_like(row_temperature),
+            row_temperature,
+        )
+    else:
+        safe_temperature = row_temperature
+    logits = logits.div_(safe_temperature.unsqueeze(dim=1))
+    if top_k is not None or top_p is not None:
+        top_k_base = _ensure_runtime_state_tensor(
+            top_k,
+            needed,
+            logits.shape[1],
+            torch.int32,
+            logits.device,
+        )
+        top_p_base = _ensure_runtime_state_tensor(
+            top_p,
+            needed,
+            1.0,
+            torch.float32,
+            logits.device,
+        )
+        logits = apply_top_k_top_p(
+            logits,
+            top_k_base[idx_mapping_long],
+            top_p_base[idx_mapping_long],
+        )
+    if logits.device.type != "npu" or not hasattr(triton, "cdiv"):
+        return logits.argmax(dim=-1) if greedy_sampled is None else greedy_sampled
+    random_sampled = gumbel_sample(
+        logits,
+        idx_mapping.to(torch.int32),
+        temperature,
+        seeds,
+        positions.to(torch.int32),
+        apply_temperature=False,
+    )
+    if all_random:
+        return random_sampled
+    assert greedy_sampled is not None
+    return torch.where(
+        temperature[idx_mapping_long] < _SAMPLING_EPS,
+        greedy_sampled,
+        random_sampled,
+        out=greedy_sampled,
+    )
 
 
 class AscendSampler(Sampler):

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -4,7 +4,7 @@ import torch
 from vllm.config import VllmConfig
 from vllm.v1.spec_decode.eagle import EagleProposer
 
-from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
+from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer, _FusedModelWithMTP
 
 
 class AscendEagleProposer(EagleProposer, AscendSpecDecodeBaseProposer):

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -4,7 +4,7 @@ import torch
 from vllm.config import VllmConfig
 from vllm.v1.spec_decode.eagle import EagleProposer
 
-from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer, _FusedModelWithMTP
+from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
 
 
 class AscendEagleProposer(EagleProposer, AscendSpecDecodeBaseProposer):

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -10,6 +10,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from vllm.config import CompilationMode, CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
+from vllm.sequence import IntermediateTensors
 from vllm.distributed.parallel_state import (
     get_pcp_group,
     get_pp_group,
@@ -18,7 +19,7 @@ from vllm.distributed.parallel_state import (
     init_model_parallel_group,
     patch_tensor_parallel_group,
 )
-from vllm.forward_context import BatchDescriptor, ForwardContext, get_forward_context
+from vllm.forward_context import BatchDescriptor, ForwardContext, get_forward_context, is_forward_context_available
 from vllm.logger import logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.model_loader import get_model
@@ -28,7 +29,7 @@ from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
 from vllm.model_executor.models.qwen3_dflash import DFlashQwen3ForCausalLM
 from vllm.triton_utils import HAS_TRITON, triton
-from vllm.utils.math_utils import cdiv
+from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -51,7 +52,8 @@ from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.compilation.acl_graph import ACLGraphWrapper, update_full_graph_params
 from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
-from vllm_ascend.utils import enable_sp, lmhead_tp_enable, shared_expert_dp_enabled
+from vllm_ascend.sample.sampler import sample_with_runtime_state
+from vllm_ascend.utils import enable_sp, enable_sp_by_pass, lmhead_tp_enable, shared_expert_dp_enabled
 
 # Currently we will fix block size to a small one since `num_reqs` can't be too large
 _PREPARE_INPUTS_BLOCK_SIZE = 4
@@ -88,6 +90,268 @@ def split_inputs_tp_to_sp(hidden_states, out):
     hidden_states_curr_rank = hidden_states[start:end]
     out[: hidden_states_curr_rank.shape[0]] = hidden_states_curr_rank
     return out[:padded_num_tokens_per_rank]
+
+
+class _FusedModelWithMTP:
+    """Wrap the target model forward together with all MTP draft steps."""
+
+    def __init__(self, raw_model: nn.Module, drafter: "AscendSpecDecodeBaseProposer"):
+        self.raw_model = raw_model
+        self.drafter = drafter
+        self.skip_aclgraph_replay_sync = False
+        self.capture_mtp_enabled = True
+
+        num_spec_tokens = drafter.num_speculative_tokens
+        max_num_reqs = drafter.runner.max_num_reqs
+        max_num_tokens = drafter.runner.max_num_tokens
+        device = drafter.device
+
+        self.logits_indices_buf = torch.zeros(
+            max_num_reqs * (1 + num_spec_tokens), dtype=torch.int64, device=device
+        )
+        self.sample_logits_indices_buf = torch.zeros(
+            max_num_reqs * (1 + num_spec_tokens), dtype=torch.int64, device=device
+        )
+        self.sample_idx_mapping_buf = torch.zeros(
+            max_num_reqs * (1 + num_spec_tokens), dtype=torch.int32, device=device
+        )
+        self.bonus_row_indices_buf = torch.zeros((max_num_reqs,), dtype=torch.int64, device=device)
+        self.target_row_indices_buf = torch.zeros(
+            (max_num_reqs * num_spec_tokens,), dtype=torch.int64, device=device
+        )
+        self.num_reqs_buf = torch.zeros(1, dtype=torch.int32, device=device)
+        self.num_actual_tokens_buf = torch.zeros(1, dtype=torch.int32, device=device)
+        self.num_sample_rows_buf = torch.zeros(1, dtype=torch.int32, device=device)
+        self.num_target_rows_buf = torch.zeros(1, dtype=torch.int32, device=device)
+        self.cu_num_draft_tokens_buf = torch.zeros((max_num_reqs,), dtype=torch.int32, device=device)
+        self.target_logits_indices_buf = torch.full(
+            (max_num_reqs, num_spec_tokens), -1, dtype=torch.int64, device=device
+        )
+        self.spec_decode_token_ids_buf = torch.zeros(
+            (max_num_reqs, num_spec_tokens), dtype=torch.int64, device=device
+        )
+        self.draft_token_ids_flat_buf = torch.zeros(
+            (max_num_reqs * num_spec_tokens,), dtype=torch.int64, device=device
+        )
+        self.backup_next_token_ids_buf = torch.zeros((max_num_reqs,), dtype=torch.int64, device=device)
+        self.discarded_req_mask_buf = torch.zeros((max_num_reqs,), dtype=torch.bool, device=device)
+        self.sampled_token_ids_buf = torch.full(
+            (max_num_reqs, num_spec_tokens + 1), -1, dtype=torch.int32, device=device
+        )
+        self.draft_token_ids_buf = torch.zeros(
+            (max_num_reqs, num_spec_tokens), dtype=torch.int64, device=device
+        )
+        self.next_token_ids_buf = torch.zeros((max_num_reqs,), dtype=torch.int64, device=device)
+        self.valid_sampled_tokens_count_buf = torch.zeros((max_num_reqs,), dtype=torch.int32, device=device)
+        self.mtp_last_hidden_states_buf = torch.zeros(
+            (max_num_tokens, drafter.hidden_size), dtype=drafter.dtype, device=device
+        )
+
+    def __getattr__(self, key: str):
+        return getattr(self.raw_model, key)
+
+    def _prepare_next_token_ids_from_sampled(self) -> torch.Tensor:
+        valid_mask = self.sampled_token_ids_buf != -1
+        valid_mask &= ~self.discarded_req_mask_buf[:, None]
+        max_num_reqs = self.sampled_token_ids_buf.shape[0]
+        req_indices = torch.arange(max_num_reqs, device=self.sampled_token_ids_buf.device, dtype=torch.int64)
+        active_req_mask = req_indices < self.num_reqs_buf[0].to(torch.int64)
+
+        valid_sampled_tokens_count = valid_mask.sum(dim=1, dtype=torch.int32)
+        self.valid_sampled_tokens_count_buf.copy_(valid_sampled_tokens_count)
+
+        last_valid_indices = torch.clamp(valid_sampled_tokens_count.to(torch.long) - 1, min=0)
+        selected_tokens = torch.gather(
+            self.sampled_token_ids_buf,
+            1,
+            last_valid_indices.unsqueeze(1),
+        ).squeeze(1)
+        next_token_ids = torch.where(
+            valid_sampled_tokens_count > 0,
+            selected_tokens.to(torch.int64),
+            self.backup_next_token_ids_buf,
+        )
+        dummy_tokens = torch.zeros_like(next_token_ids)
+        next_token_ids = torch.where(active_req_mask, next_token_ids, dummy_tokens)
+        self.next_token_ids_buf.copy_(next_token_ids)
+        return self.next_token_ids_buf
+
+    def _update_token_indices_to_sample(self, active_req_mask: torch.Tensor, draft_counts: torch.Tensor) -> None:
+        valid_counts = self.valid_sampled_tokens_count_buf.to(torch.int64)
+        sample_counts = torch.where(active_req_mask, draft_counts + 1, torch.zeros_like(draft_counts))
+        has_valid_tokens = active_req_mask & (valid_counts > 0)
+        sample_row_indices = self.bonus_row_indices_buf - (sample_counts - valid_counts)
+        sample_row_indices = sample_row_indices.clamp(min=0, max=self.sample_logits_indices_buf.shape[0] - 1)
+        current_token_positions = self.sample_logits_indices_buf[sample_row_indices]
+        num_reqs = self.bonus_row_indices_buf.shape[0]
+        self.logits_indices_buf[:num_reqs] = torch.where(
+            has_valid_tokens,
+            current_token_positions,
+            self.logits_indices_buf[:num_reqs],
+        )
+
+    def _run_rejection_verifier(self, sample_logits: torch.Tensor, runtime_positions: torch.Tensor) -> torch.Tensor:
+        sampling_metadata = self.drafter.runner.input_batch.sampling_metadata
+        device = sample_logits.device
+        max_num_reqs, max_num_sampled_tokens = self.sampled_token_ids_buf.shape
+        max_spec_len = max_num_sampled_tokens - 1
+
+        req_indices = torch.arange(max_num_reqs, device=device, dtype=torch.int64)
+        num_reqs = self.num_reqs_buf[0].to(torch.int64)
+        active_req_mask = req_indices < num_reqs
+
+        cu_num_draft_tokens = self.cu_num_draft_tokens_buf.to(torch.int64)
+        cu_start = torch.cat([torch.zeros(1, dtype=torch.int64, device=device), cu_num_draft_tokens[:-1]])
+        draft_counts = torch.where(
+            active_req_mask,
+            cu_num_draft_tokens - cu_start,
+            torch.zeros_like(cu_num_draft_tokens),
+        )
+        all_greedy = getattr(sampling_metadata, "all_greedy", sampling_metadata.temperature is None)
+        # MTP draft tokens are deterministic. Use target argmax for
+        # acceptance, while keeping sampled target tokens as rejection fallback.
+        verify_row_token_ids = sample_logits.argmax(dim=-1)
+        if all_greedy:
+            sampled_row_token_ids = verify_row_token_ids
+        else:
+            sample_positions = runtime_positions[self.sample_logits_indices_buf]
+            sampled_row_token_ids = sample_with_runtime_state(
+                sample_logits.to(torch.float32),
+                self.sample_idx_mapping_buf,
+                sample_positions,
+                sampling_metadata.temperature,
+                sampling_metadata.top_k,
+                sampling_metadata.top_p,
+                getattr(sampling_metadata, "seeds", None),
+                all_greedy,
+                getattr(sampling_metadata, "all_random", False),
+            )
+        target_token_ids = sampled_row_token_ids[self.target_row_indices_buf].to(torch.int32)
+        target_verify_token_ids = verify_row_token_ids[self.target_row_indices_buf].to(torch.int32)
+        bonus_token_ids = sampled_row_token_ids[self.bonus_row_indices_buf].to(torch.int32)
+        if max_spec_len == 1:
+            draft_token_ids = self.spec_decode_token_ids_buf[:, 0].to(torch.int32)
+            placeholder_token_ids = torch.full_like(target_token_ids, -1)
+            has_draft_mask = active_req_mask & (draft_counts > 0)
+            accepted_bonus_mask = has_draft_mask & (draft_token_ids == target_verify_token_ids)
+            accepted_or_sampled_target_ids = torch.where(
+                accepted_bonus_mask,
+                draft_token_ids,
+                target_token_ids,
+            )
+            first_token_ids = torch.where(
+                has_draft_mask,
+                accepted_or_sampled_target_ids,
+                bonus_token_ids,
+            )
+            self.sampled_token_ids_buf[:, 0].copy_(
+                torch.where(active_req_mask, first_token_ids, placeholder_token_ids)
+            )
+            self.sampled_token_ids_buf[:, 1].copy_(
+                torch.where(accepted_bonus_mask, bonus_token_ids, placeholder_token_ids)
+            )
+        else:
+            draft_token_ids = self.draft_token_ids_flat_buf.to(torch.int32)
+            placeholder_req = torch.full((max_num_reqs,), -1, dtype=torch.int32, device=device)
+            token_offsets = torch.arange(max_spec_len, device=device, dtype=torch.int64)
+            flat_indices = (cu_start.unsqueeze(1) + token_offsets.unsqueeze(0)).clamp(
+                max=max_num_reqs * max_spec_len - 1
+            )
+            target_token_matrix = target_token_ids[flat_indices]
+            target_verify_token_matrix = target_verify_token_ids[flat_indices]
+            draft_token_matrix = draft_token_ids[flat_indices]
+
+            prefix_accepted = active_req_mask
+            sampled_columns = []
+            for draft_idx in range(max_spec_len):
+                has_draft = draft_counts > draft_idx
+                emit_target = prefix_accepted & has_draft
+                target_column = target_token_matrix[:, draft_idx]
+                target_verify_column = target_verify_token_matrix[:, draft_idx]
+                draft_column = draft_token_matrix[:, draft_idx]
+                accepted_column = draft_column == target_verify_column
+                sampled_or_accepted_column = torch.where(
+                    accepted_column,
+                    draft_column,
+                    target_column,
+                )
+                sampled_columns.append(torch.where(emit_target, sampled_or_accepted_column, placeholder_req))
+                prefix_accepted = prefix_accepted & (~has_draft | accepted_column)
+
+            sampled_without_bonus = torch.cat(
+                [torch.stack(sampled_columns, dim=1), placeholder_req.unsqueeze(1)],
+                dim=1,
+            )
+            output_columns = torch.arange(max_spec_len + 1, device=device, dtype=torch.int64)
+            bonus_column = draft_counts.clamp(min=0, max=max_spec_len)
+            bonus_mask = prefix_accepted.unsqueeze(1) & (
+                output_columns.unsqueeze(0) == bonus_column.unsqueeze(1)
+            )
+            sampled_token_ids = torch.where(
+                bonus_mask,
+                bonus_token_ids.unsqueeze(1),
+                sampled_without_bonus,
+            )
+            self.sampled_token_ids_buf.copy_(sampled_token_ids)
+
+        next_token_ids = self._prepare_next_token_ids_from_sampled()
+        self._update_token_indices_to_sample(active_req_mask, draft_counts)
+        return next_token_ids
+
+    def __call__(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors=None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        hidden_states = self.raw_model(
+            input_ids=input_ids,
+            positions=positions,
+            intermediate_tensors=intermediate_tensors,
+            inputs_embeds=inputs_embeds,
+            **kwargs,
+        )
+        forward_context = get_forward_context()
+        is_capturing = getattr(forward_context, "capturing", False)
+        if (
+            is_capturing
+            and self.capture_mtp_enabled
+            and not isinstance(hidden_states, IntermediateTensors)
+        ):
+            raw_hidden = hidden_states[0] if isinstance(hidden_states, tuple) else hidden_states
+            if getattr(forward_context, "flash_comm_v1_enabled", False):
+                from vllm.distributed import tensor_model_parallel_all_gather
+
+                raw_hidden = tensor_model_parallel_all_gather(raw_hidden, 0)
+                pad_size = getattr(forward_context, "pad_size", 0)
+                if pad_size > 0:
+                    raw_hidden = raw_hidden[:-pad_size, :]
+            runtime_positions = positions[0] if positions.ndim > 1 else positions
+            num_tokens = input_ids.shape[0]
+            num_spec = self.drafter.num_speculative_tokens
+            batch_size = max(num_tokens // (num_spec + 1), 1)
+            sample_hs = raw_hidden[self.sample_logits_indices_buf]
+            sample_logits = self.raw_model.compute_logits(sample_hs)
+            next_token_ids = self._run_rejection_verifier(sample_logits, runtime_positions)
+            draft_hidden_states = raw_hidden
+            mtp_hidden_states = getattr(self.raw_model, "get_mtp_target_hidden_states", lambda: None)()
+            if mtp_hidden_states is not None:
+                draft_hidden_states = mtp_hidden_states
+            all_draft_ids = self.drafter.propose_all_in_graph(
+                hidden_states=draft_hidden_states,
+                input_ids=input_ids,
+                positions=positions,
+                logits_indices=self.logits_indices_buf,
+                next_token_ids=next_token_ids[:batch_size],
+                num_tokens=num_tokens,
+                num_reqs=self.num_reqs_buf,
+                num_actual_tokens=self.num_actual_tokens_buf,
+            )
+            num_reqs = all_draft_ids.shape[0]
+            self.draft_token_ids_buf[:num_reqs, : all_draft_ids.shape[1]].copy_(all_draft_ids)
+        return hidden_states
 
 
 class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
@@ -189,6 +453,147 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.enable_enpu = self.runner.enable_enpu
         self.use_eagle = self.runner.use_eagle
 
+    def _draft_graph_capture_enabled(self) -> bool:
+        return self.use_cuda_graph or getattr(self, "fused_with_main_graph", False)
+
+    def build_graph_capture_attn_metadata(
+        self,
+        num_tokens: int,
+        num_reqs: int,
+        aclgraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+    ) -> list[dict]:
+        multi_steps_attn_metadata: list[dict] = []
+        if not self._draft_graph_capture_enabled():
+            return multi_steps_attn_metadata
+        if aclgraph_runtime_mode != CUDAGraphMode.FULL:
+            return multi_steps_attn_metadata
+        if len(self.draft_attn_groups) == 0:
+            return multi_steps_attn_metadata
+
+        num_reqs = self._prepare_graph_capture_query_start_loc(num_tokens, num_reqs)
+        num_computed_tokens_cpu = self.runner.input_batch.num_computed_tokens_cpu_tensor[:num_reqs]
+        common_attn_metadata = AscendCommonAttentionMetadata(
+            query_start_loc=self.query_start_loc.gpu[: num_reqs + 1],
+            query_start_loc_cpu=self.query_start_loc.cpu[: num_reqs + 1],
+            seq_lens_cpu=self.runner.optimistic_seq_lens_cpu,
+            seq_lens_cpu_upper_bound=self.runner.optimistic_seq_lens_cpu,
+            seq_lens=self.runner.seq_lens[:num_reqs],
+            num_reqs=num_reqs,
+            num_actual_tokens=num_tokens,
+            num_input_tokens=num_tokens,
+            max_query_len=self.num_speculative_tokens + 1,
+            num_computed_tokens_cpu=num_computed_tokens_cpu,
+            actual_seq_lengths_q=self.runner.actual_seq_lengths_q,
+            block_table_tensor=self.runner.input_batch.block_table[0].get_device_tensor()[:num_reqs],
+            slot_mapping=self.runner.input_batch.block_table[0].slot_mapping.gpu,
+            positions=self.runner.positions,
+            positions_cpu=self.runner._dsa_positions_cpu_buf if self.use_compress else None,
+            attn_state=self.runner.attn_state,
+            decode_token_per_req=self.runner.decode_token_per_req,
+            max_seq_len=0,
+        )
+        if self.pcp_size * self.dcp_size > 1:
+            common_attn_metadata.prefill_context_parallel_metadata = self.runner.pcp_manager.long_seq_metadata
+            common_attn_metadata.block_table_tensor = self.runner.input_batch.block_table[0].get_device_tensor()[
+                : num_reqs * self.decode_threshold
+            ]
+
+        builder = self.draft_attn_groups[0].get_metadata_builder()
+        extra_attn_metadata_args: dict[str, Any] = {}
+        if self.use_compress:
+            extra_attn_metadata_args = dict(
+                prefill_ratio_to_sas_metadata=dict(),
+                decode_ratio_to_sas_metadata=dict(),
+                common_ratio_to_sas_metadata=dict(),
+                block_size=self.draft_attn_groups[0].kv_cache_spec.block_size,
+            )
+        for draft_step in range(self.num_speculative_tokens):
+            common_attn_metadata = self.shallow_copy_metadata(common_attn_metadata)
+            common_attn_metadata.slot_mapping = self.slot_mapping_group[draft_step]
+            attn_metadata_eagle = builder.build_for_graph_capture(
+                common_attn_metadata,
+                AscendAttentionState.SpecDecoding if self.method == "mtp" else AscendAttentionState.ChunkedPrefill,
+                **extra_attn_metadata_args,
+            )
+            per_layer_attn_metadata = dict()
+            for layer_name in self.attn_layer_names:
+                per_layer_attn_metadata[layer_name] = attn_metadata_eagle
+            multi_steps_attn_metadata.append(per_layer_attn_metadata)
+
+        return multi_steps_attn_metadata
+
+    def _uses_mtp_full_graph_padding(self, aclgraph_runtime_mode: CUDAGraphMode) -> bool:
+        return self.method == "mtp" and aclgraph_runtime_mode == CUDAGraphMode.FULL
+
+    def _get_mtp_eager_padded_num_input_tokens(
+        self,
+        num_input_tokens: int,
+        aclgraph_runtime_mode: CUDAGraphMode,
+    ) -> int:
+        if self.method != "mtp" or aclgraph_runtime_mode != CUDAGraphMode.NONE:
+            return num_input_tokens
+        tp_size = getattr(getattr(self.vllm_config, "parallel_config", None), "tensor_parallel_size", 1)
+        try:
+            tp_size = int(tp_size)
+        except (TypeError, ValueError):
+            return num_input_tokens
+        if tp_size <= 1 or num_input_tokens <= 0:
+            return num_input_tokens
+        if num_input_tokens < tp_size or enable_sp(self.vllm_config) or enable_sp_by_pass():
+            return round_up(num_input_tokens, tp_size)
+        return num_input_tokens
+
+    def _uses_mtp_eager_input_padding(
+        self,
+        num_tokens: int,
+        num_input_tokens: int,
+        aclgraph_runtime_mode: CUDAGraphMode,
+    ) -> bool:
+        return self.method == "mtp" and aclgraph_runtime_mode == CUDAGraphMode.NONE and num_input_tokens > num_tokens
+
+    def _graph_padding_slot_id(self, aclgraph_runtime_mode: CUDAGraphMode) -> int:
+        if self._uses_mtp_full_graph_padding(aclgraph_runtime_mode):
+            return 0
+        return PADDING_SLOT_ID
+
+    def _pad_mtp_full_graph_inputs(
+        self,
+        num_tokens: int,
+        num_input_tokens: int,
+        aclgraph_runtime_mode: CUDAGraphMode,
+        force: bool = False,
+    ) -> None:
+        if not force and not self._uses_mtp_full_graph_padding(aclgraph_runtime_mode):
+            return
+        if num_input_tokens <= num_tokens:
+            return
+        start = int(num_tokens)
+        end = int(num_input_tokens)
+        self.input_ids[start:end].zero_()
+        if self.uses_mrope:
+            self.mrope_positions[:, start:end].zero_()
+        elif self.uses_xdrope_dim > 0 and self.draft_uses_xdrope_dim > 0:
+            self.xdrope_positions[:, start:end].zero_()
+        else:
+            self.positions[start:end].zero_()
+        self.hidden_states[start:end].zero_()
+        for slot_mapping in getattr(self, "slot_mapping_group", ()):
+            slot_mapping[start:end].fill_(0)
+
+    def _prepare_graph_capture_query_start_loc(self, num_tokens: int, num_reqs: int) -> int:
+        actual_num_reqs = num_reqs
+        self.query_start_loc.cpu[: actual_num_reqs + 1].copy_(
+            self.runner.query_start_loc.cpu[: actual_num_reqs + 1]
+        )
+        uniform_decode_query_len = getattr(self.runner, "uniform_decode_query_len", self.decode_threshold)
+        if not isinstance(uniform_decode_query_len, int):
+            uniform_decode_query_len = self.decode_threshold
+        if num_tokens != actual_num_reqs * uniform_decode_query_len:
+            self.query_start_loc.cpu[actual_num_reqs + 1] = num_tokens
+            num_reqs = actual_num_reqs + 1
+        self.query_start_loc.copy_to_gpu()
+        return num_reqs
+
     def _get_model(self) -> nn.Module:
         """
         Default method to call get_model(). Can be overridden by subclasses which
@@ -196,18 +601,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         """
         from vllm.compilation.backends import set_model_tag
 
-        draft_vllm_config = self._create_draft_vllm_config()
-        draft_load_config = self.speculative_config.draft_load_config
-        logger.info(
-            "AscendSpecDecodeBaseProposer._get_model(): loading draft model with load_format=%s, model=%s",
-            getattr(draft_load_config, "load_format", None),
-            getattr(self.speculative_config.draft_model_config, "model", None),
-        )
         with set_model_tag("eagle_head"):
             model = get_model(
-                vllm_config=draft_vllm_config,
-                model_config=self.speculative_config.draft_model_config,
-                load_config=self.speculative_config.draft_load_config,
+                vllm_config=self.vllm_config,
+                model_config=self.vllm_config.speculative_config.draft_model_config,
             )
         return model
 
@@ -344,29 +741,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # some model definition do not define lm_head explicitly
         # and reuse embed_tokens for lm_head, e.g., CohereForCausalLM
         if self.method in ("eagle", "dflash"):
-            # For DFlash drafters trained with a reduced draft vocabulary, the
-            # draft model ships its own lm_head of shape [draft_vocab_size,
-            # hidden] whose rows map to a trained subset of the target vocab via
-            # the draft_id_to_target_id (d2t) buffer. Overwriting it with the
-            # target lm_head ([target_vocab_size, hidden]) makes the draft emit
-            # logits over the wrong vocabulary, so the verifier rejects almost
-            # every speculative token. Keep the draft's own lm_head in that case.
-            draft_has_own_lm_head = (
-                self.method == "dflash" and getattr(self.model, "draft_id_to_target_id", None) is not None
-            )
-            if draft_has_own_lm_head:
-                logger.info(
-                    "DFlash draft uses d2t vocab remapping; keeping the draft's "
-                    "own lm_head instead of sharing the target lm_head."
-                )
+            logger.info("Loading EAGLE or DFLASH LM head weights from the target model.")
+            if hasattr(model, "lm_head"):
+                self.model.lm_head = model.lm_head
+            elif hasattr(model, "get_language_model") and hasattr(model.get_language_model(), "lm_head"):
+                self.model.lm_head = model.get_language_model().lm_head
             else:
-                logger.info("Loading EAGLE or DFLASH LM head weights from the target model.")
-                if hasattr(model, "lm_head"):
-                    self.model.lm_head = model.lm_head
-                elif hasattr(model, "get_language_model") and hasattr(model.get_language_model(), "lm_head"):
-                    self.model.lm_head = model.get_language_model().lm_head
-                else:
-                    logger.warning("Target model has no accessible lm_head for sharing.")
+                logger.warning("Target model has no accessible lm_head for sharing.")
 
         if self.method == "mtp" and self.vllm_config.model_config.is_deepseek_mla:
             for _, layer_module in self.model.model.layers.items():
@@ -375,13 +756,17 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         if self.vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs() and self.use_cuda_graph:
             self.update_stream = torch.npu.Stream()
-            self._runnable = ACLGraphWrapper(
-                self._run_merged_draft,
-                self.vllm_config,
-                runtime_mode=CUDAGraphMode.FULL,
-                use_eagle=self.use_eagle,
-                enable_enpu=self.enable_enpu,
-            )
+            if self.method == "mtp" and getattr(self, "fused_with_main_graph", False):
+                logger.info("MTP fused full graph: using eager draft runnable for warmup")
+                self._runnable = self._run_merged_draft
+            else:
+                self._runnable = ACLGraphWrapper(
+                    self._run_merged_draft,
+                    self.vllm_config,
+                    runtime_mode=CUDAGraphMode.FULL,
+                    use_eagle=self.use_eagle,
+                    enable_enpu=self.enable_enpu,
+                )
 
     def _maybe_share_topk_indices(self, target_language_model: nn.Module) -> None:
         if hasattr(target_language_model.model, "topk_indices_buffer"):
@@ -398,6 +783,279 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         if isinstance(self.model, ACLGraphWrapper):
             return self.model.unwrap()
         return self.model
+
+    @staticmethod
+    def _get_mtp_hc_shape(raw_model: nn.Module) -> tuple[int | None, int | None]:
+        layers = getattr(getattr(raw_model, "model", None), "layers", None)
+        if layers is None:
+            return None, None
+        for layer in layers.values():
+            hc_mult = getattr(layer, "hc_mult", None)
+            config = getattr(layer, "config", None)
+            hidden_size = getattr(config, "hidden_size", None)
+            if hc_mult is not None and hidden_size is not None:
+                return int(hc_mult), int(hidden_size)
+        return None, None
+
+    def _prepare_mtp_previous_hidden_states_for_graph(
+        self,
+        raw_model: nn.Module,
+        hidden_states: torch.Tensor,
+        active_token_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, bool]:
+        if self.method != "mtp":
+            return hidden_states, False
+
+        hc_mult, hidden_size = self._get_mtp_hc_shape(raw_model)
+        if hc_mult is None or hidden_size is None:
+            if hidden_states.shape[-1] == self.hidden_states.shape[-1]:
+                return hidden_states, False
+            hidden_mask = active_token_mask
+            while hidden_mask.dim() < hidden_states.dim():
+                hidden_mask = hidden_mask.unsqueeze(-1)
+            return torch.where(hidden_mask, hidden_states, torch.zeros_like(hidden_states)), True
+
+        if hidden_states.dim() == 2 and hidden_states.shape[-1] == hidden_size:
+            masked_hidden_states = torch.where(
+                active_token_mask.unsqueeze(-1),
+                hidden_states,
+                torch.zeros_like(hidden_states),
+            )
+            return masked_hidden_states.unsqueeze(1).repeat(1, hc_mult, 1), True
+
+        if hidden_states.dim() == 2 and hidden_states.shape[-1] == hc_mult * hidden_size:
+            hidden_states = hidden_states.view(-1, hc_mult, hidden_size)
+
+        if (
+            hidden_states.dim() == 3
+            and hidden_states.shape[1] == hc_mult
+            and hidden_states.shape[2] == hidden_size
+        ):
+            return (
+                torch.where(
+                    active_token_mask.view(-1, 1, 1),
+                    hidden_states,
+                    torch.zeros_like(hidden_states),
+                ),
+                True,
+            )
+
+        if hidden_states.shape[-1] == self.hidden_states.shape[-1]:
+            return hidden_states, False
+        hidden_mask = active_token_mask
+        while hidden_mask.dim() < hidden_states.dim():
+            hidden_mask = hidden_mask.unsqueeze(-1)
+        return torch.where(hidden_mask, hidden_states, torch.zeros_like(hidden_states)), True
+
+    def propose_all_in_graph(
+        self,
+        hidden_states: torch.Tensor,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        logits_indices: torch.Tensor,
+        next_token_ids: torch.Tensor,
+        num_tokens: int,
+        num_reqs: torch.Tensor | None = None,
+        num_actual_tokens: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Run all MTP draft steps inside the target model ACL graph."""
+        batch_size = max(num_tokens // (self.num_speculative_tokens + 1), 1)
+        raw_model = self.get_model()
+        next_token_ids = next_token_ids.to(self.input_ids.dtype)
+        if num_actual_tokens is None:
+            actual_num_tokens = torch.tensor(num_tokens, dtype=torch.int32, device=self.device)
+        else:
+            actual_num_tokens = num_actual_tokens[0].to(torch.int32)
+
+        token_offsets = self.arange[:num_tokens].to(torch.int32)
+        active_token_mask = token_offsets < actual_num_tokens
+        if num_reqs is None:
+            decode_query_len = self.num_speculative_tokens + 1
+            active_batch_size = torch.div(
+                actual_num_tokens.to(torch.int64) + decode_query_len - 1,
+                decode_query_len,
+                rounding_mode="floor",
+            )
+        else:
+            active_batch_size = num_reqs[0].to(torch.int64)
+        active_batch_size = torch.clamp(active_batch_size, min=0, max=batch_size)
+        batch_offsets = self.arange[:batch_size].to(torch.int64)
+        active_batch_mask = batch_offsets < active_batch_size
+        raw_logits_indices = logits_indices[:batch_size].to(torch.int64)
+        safe_logits_indices = torch.where(active_batch_mask, raw_logits_indices, torch.zeros_like(raw_logits_indices))
+
+        current_input_ids = self.input_ids[:num_tokens]
+        shifted_input_ids = current_input_ids.clone()
+        shifted_input_ids[: num_tokens - 1].copy_(input_ids[1:num_tokens])
+        shift_mask = token_offsets < torch.clamp(actual_num_tokens - 1, min=0)
+        current_input_ids.copy_(torch.where(shift_mask, shifted_input_ids, torch.zeros_like(current_input_ids)))
+
+        next_token_ids = next_token_ids[:batch_size]
+        token_offsets_i64 = token_offsets.to(torch.int64)
+        bonus_write_mask = (
+            (raw_logits_indices.unsqueeze(1) == token_offsets_i64.unsqueeze(0))
+            & active_batch_mask.unsqueeze(1)
+        )
+        bonus_update_mask = bonus_write_mask.any(dim=0)
+        bonus_values = (bonus_write_mask.to(next_token_ids.dtype) * next_token_ids.unsqueeze(1)).sum(dim=0)
+        current_input_ids.copy_(
+            torch.where(bonus_update_mask, bonus_values.to(current_input_ids.dtype), current_input_ids)
+        )
+
+        current_positions = self._get_positions(num_tokens)
+        if positions.ndim > 1:
+            incoming_positions = positions[:, :num_tokens]
+            position_mask = active_token_mask.unsqueeze(0)
+        else:
+            incoming_positions = positions[:num_tokens]
+            position_mask = active_token_mask
+        self._set_positions(
+            num_tokens,
+            torch.where(position_mask, incoming_positions, torch.zeros_like(current_positions)),
+        )
+
+        incoming_hidden_states = hidden_states[:num_tokens]
+        model_hidden_states_buffer, uses_mtp_hidden_model_buffer = (
+            self._prepare_mtp_previous_hidden_states_for_graph(
+                raw_model,
+                incoming_hidden_states,
+                active_token_mask,
+            )
+        )
+        if not uses_mtp_hidden_model_buffer:
+            current_hidden_states = self.hidden_states[:num_tokens]
+            current_hidden_states.copy_(
+                torch.where(
+                    active_token_mask.unsqueeze(-1),
+                    incoming_hidden_states,
+                    torch.zeros_like(current_hidden_states),
+                )
+            )
+            model_hidden_states_buffer = current_hidden_states
+
+        forward_context = get_forward_context() if is_forward_context_available() else None
+        draft_attn_metadatas = getattr(forward_context, "draft_attn_metadatas", None)
+
+        @contextmanager
+        def draft_forward_context(attn_metadata=None):
+            if forward_context is None:
+                yield
+                return
+
+            saved_attn_metadata = getattr(forward_context, "attn_metadata", None)
+            saved_num_tokens = getattr(forward_context, "num_tokens", None)
+            saved_num_accept_tokens = getattr(forward_context, "num_accept_tokens", None)
+            saved_is_draft_model = getattr(forward_context, "is_draft_model", False)
+            saved_moe_layer_index = getattr(forward_context, "moe_layer_index", 0)
+
+            forward_context.num_tokens = num_tokens
+            forward_context.num_accept_tokens = batch_size
+            forward_context.is_draft_model = True
+            forward_context.moe_layer_index = 0
+            forward_context.attn_metadata = attn_metadata
+            try:
+                yield
+            finally:
+                forward_context.attn_metadata = saved_attn_metadata
+                if saved_num_tokens is not None:
+                    forward_context.num_tokens = saved_num_tokens
+                if saved_num_accept_tokens is not None:
+                    forward_context.num_accept_tokens = saved_num_accept_tokens
+                forward_context.is_draft_model = saved_is_draft_model
+                forward_context.moe_layer_index = saved_moe_layer_index
+
+        first_step_attn_metadata = draft_attn_metadatas[0] if draft_attn_metadatas else None
+        with draft_forward_context(first_step_attn_metadata):
+            model_input_ids = self.input_ids[:num_tokens]
+            model_positions = self._get_positions(num_tokens)
+            model_hidden_states = model_hidden_states_buffer
+            model_hidden_states, model_positions = self.maybe_pad_and_reduce(
+                model_hidden_states, model_positions
+            )
+
+            model_kwargs: dict[str, torch.Tensor] = {
+                "input_ids": model_input_ids,
+                "positions": model_positions,
+            }
+            if self.pass_hidden_states_to_model:
+                model_kwargs["hidden_states"] = model_hidden_states
+                if self.method == "mtp":
+                    model_kwargs["positions"] = model_positions
+
+            ret_hidden_states = raw_model(**model_kwargs)
+            if not self.model_returns_tuple():
+                last_hidden_states = ret_hidden_states
+                hidden_states_out = last_hidden_states
+            else:
+                last_hidden_states, hidden_states_out = ret_hidden_states
+
+            last_hidden_states, model_positions, hidden_states_out = self.maybe_all_gather_and_unpad(
+                last_hidden_states, model_positions, hidden_states_out
+            )
+            logits = raw_model.compute_logits(last_hidden_states[safe_logits_indices])
+            draft_token_ids = logits.argmax(dim=-1)
+
+        if self.num_speculative_tokens == 1:
+            return draft_token_ids.view(-1, 1)
+
+        draft_token_ids_tensor = torch.zeros(
+            (self.num_speculative_tokens, *draft_token_ids.shape),
+            dtype=draft_token_ids.dtype,
+            device=self.device,
+        )
+        draft_token_ids_tensor[0] = draft_token_ids
+
+        step_positions = self.positions[safe_logits_indices]
+        step_hidden_states = hidden_states_out[safe_logits_indices]
+        token_indices_to_sample = self.arange[:batch_size]
+
+        for draft_step in range(self.num_speculative_tokens - 1):
+            step_input_ids = draft_token_ids_tensor[draft_step].to(self.input_ids.dtype)
+            step_positions = step_positions + 1
+            exceeds_max_model_len = step_positions >= self.vllm_config.model_config.max_model_len
+            clamped_positions = torch.where(exceeds_max_model_len, 0, step_positions)
+
+            self.input_ids[:batch_size] = step_input_ids
+            self._set_positions(batch_size, clamped_positions)
+            self.hidden_states[:batch_size] = step_hidden_states
+
+            model_input_ids = self.input_ids[:num_tokens]
+            model_positions = self._get_positions(num_tokens)
+            model_hidden_states = self.hidden_states[:num_tokens]
+            step_attn_metadata = (
+                draft_attn_metadatas[draft_step + 1]
+                if draft_attn_metadatas and draft_step + 1 < len(draft_attn_metadatas)
+                else None
+            )
+
+            with draft_forward_context(step_attn_metadata):
+                model_hidden_states, model_positions = self.maybe_pad_and_reduce(
+                    model_hidden_states, model_positions
+                )
+                model_kwargs = {
+                    "input_ids": model_input_ids,
+                    "positions": model_positions,
+                }
+                if self.pass_hidden_states_to_model:
+                    model_kwargs["hidden_states"] = model_hidden_states
+
+                ret_hidden_states = raw_model(**model_kwargs)
+                if not self.model_returns_tuple():
+                    last_hidden_states = ret_hidden_states
+                    hidden_states_out = last_hidden_states
+                else:
+                    last_hidden_states, hidden_states_out = ret_hidden_states
+
+                last_hidden_states, model_positions, hidden_states_out = self.maybe_all_gather_and_unpad(
+                    last_hidden_states, model_positions, hidden_states_out
+                )
+                logits = raw_model.compute_logits(last_hidden_states[token_indices_to_sample])
+                draft_token_ids = logits.argmax(dim=-1)
+
+            draft_token_ids_tensor[draft_step + 1] = draft_token_ids
+            step_hidden_states = hidden_states_out[:batch_size]
+
+        return draft_token_ids_tensor.swapaxes(0, 1)
 
     def shallow_copy_metadata(self, attn_metadata):
         # Currently, new objects will be assigned to the lists in attn_metadata
@@ -431,7 +1089,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         ) = self.runner._sync_metadata_across_dp(num_tokens, is_draft_model=True)
 
         multi_steps_attn_metadata = []
-        if not self.use_cuda_graph:
+        if not self._draft_graph_capture_enabled():
             aclgraph_runtime_mode = CUDAGraphMode.NONE
 
         # init block table tensor clone is only available after profile run and is only used for graph mode
@@ -474,6 +1132,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 # This is used to hold a position.
                 slot_mapping=self.runner.input_batch.block_table[0].slot_mapping.gpu,
                 positions=self.runner.positions,
+                positions_cpu=self.runner._dsa_positions_cpu_buf if self.use_compress else None,
                 attn_state=self.runner.attn_state,
                 decode_token_per_req=self.runner.decode_token_per_req,
                 max_seq_len=0,
@@ -487,6 +1146,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
             assert len(self.draft_attn_groups) > 0
             builder = self.draft_attn_groups[0].get_metadata_builder()
+            extra_attn_metadata_args: dict[str, Any] = {}
+            if self.use_compress:
+                extra_attn_metadata_args = dict(
+                    prefill_ratio_to_sas_metadata=dict(),
+                    decode_ratio_to_sas_metadata=dict(),
+                    common_ratio_to_sas_metadata=dict(),
+                    block_size=self.draft_attn_groups[0].kv_cache_spec.block_size,
+                )
             # update the tensor's address for each step.
             for draft_step in range(self.num_speculative_tokens):
                 common_attn_metadata = self.shallow_copy_metadata(common_attn_metadata)
@@ -501,6 +1168,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 attn_metadata_eagle = builder.build_for_graph_capture(
                     common_attn_metadata,
                     AscendAttentionState.SpecDecoding if self.method == "mtp" else AscendAttentionState.ChunkedPrefill,
+                    **extra_attn_metadata_args,
                 )
                 per_layer_attn_metadata = dict()
                 for layer_name in self.attn_layer_names:

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -92,6 +92,24 @@ def split_inputs_tp_to_sp(hidden_states, out):
     return out[:padded_num_tokens_per_rank]
 
 
+def greedy_sample(logits: torch.Tensor) -> torch.Tensor:
+    tp_group = get_tp_group()
+    _, vocab_local = logits.shape
+    rank = tp_group.rank_in_group
+
+    local_max_logits, local_max_indices = logits.max(dim=-1)
+    local_global_idx = local_max_indices + rank * vocab_local
+
+    gathered_logits = tp_group.all_gather(local_max_logits.unsqueeze(-1), dim=-1)
+    gathered_global_idx = tp_group.all_gather(local_global_idx.unsqueeze(-1), dim=-1)
+    global_max_rank = gathered_logits.argmax(dim=-1)
+    target_argmax = gathered_global_idx.gather(
+        dim=-1,
+        index=global_max_rank.unsqueeze(-1),
+    ).squeeze(-1)
+    return target_argmax
+
+
 class _FusedModelWithMTP:
     """Wrap the target model forward together with all MTP draft steps."""
 
@@ -741,13 +759,22 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # some model definition do not define lm_head explicitly
         # and reuse embed_tokens for lm_head, e.g., CohereForCausalLM
         if self.method in ("eagle", "dflash"):
-            logger.info("Loading EAGLE or DFLASH LM head weights from the target model.")
-            if hasattr(model, "lm_head"):
-                self.model.lm_head = model.lm_head
-            elif hasattr(model, "get_language_model") and hasattr(model.get_language_model(), "lm_head"):
-                self.model.lm_head = model.get_language_model().lm_head
+            draft_has_own_lm_head = (
+                self.method == "dflash" and getattr(self.model, "draft_id_to_target_id", None) is not None
+            )
+            if draft_has_own_lm_head:
+                logger.info(
+                    "DFlash draft uses d2t vocab remapping; keeping the draft's own "
+                    "lm_head instead of sharing the target lm_head."
+                )
             else:
-                logger.warning("Target model has no accessible lm_head for sharing.")
+                logger.info("Loading EAGLE or DFLASH LM head weights from the target model.")
+                if hasattr(model, "lm_head"):
+                    self.model.lm_head = model.lm_head
+                elif hasattr(model, "get_language_model") and hasattr(model.get_language_model(), "lm_head"):
+                    self.model.lm_head = model.get_language_model().lm_head
+                else:
+                    logger.warning("Target model has no accessible lm_head for sharing.")
 
         if self.method == "mtp" and self.vllm_config.model_config.is_deepseek_mla:
             for _, layer_module in self.model.model.layers.items():

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -47,7 +47,6 @@ else:
 COMPILATION_PASS_KEY = "graph_fusion_manager"
 ASCEND_QUANTIZATION_METHOD = "ascend"
 COMPRESSED_TENSORS_METHOD = "compressed-tensors"
-FP8_METHOD = "fp8"
 SOC_VERSION_INFERENCE_SERIES = ["Ascend310P3"]
 REGISTERED_ASCEND_OPS = {}
 
@@ -121,10 +120,6 @@ def clear_enable_sp():
 
 def is_310p():
     return get_ascend_device_type() == AscendDeviceType._310P
-
-
-def is_950():
-    return get_ascend_device_type() == AscendDeviceType.A5
 
 
 def _mark_op_side_effectful(op: Any) -> None:
@@ -768,11 +763,7 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
         return
     from vllm.model_executor.custom_op import CustomOp
 
-    from vllm_ascend.ops.activation import (
-        AscendQuickGELU,
-        AscendSiluAndMul,
-        AscendSiluAndMulWithClamp,
-    )
+    from vllm_ascend.ops.activation import AscendQuickGELU, AscendSiluAndMul
     from vllm_ascend.ops.bailing_moe_linear_attn import AscendBailingMoELinearAttention
     from vllm_ascend.ops.conv import AscendConv3dLayer
     from vllm_ascend.ops.fused_moe.fused_moe import AscendFusedMoE
@@ -806,7 +797,6 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
     REGISTERED_ASCEND_OPS = {
         "QuickGELU": AscendQuickGELU,
         "SiluAndMul": AscendSiluAndMul,
-        "SiluAndMulClamp": AscendSiluAndMulWithClamp,
         "RotaryEmbedding": AscendRotaryEmbedding,
         "MRotaryEmbedding": AscendMRotaryEmbedding,
         "ColumnParallelLinear": AscendColumnParallelLinear,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3461,15 +3461,17 @@ class NPUModelRunner(GPUModelRunner):
         return async_output
 
     # overwrite _sample for lmhead_tp_enable and need_accepted_tokens
-    def _sample(self, logits, spec_decode_metadata, sample_positions):
+    def _sample(self, logits, spec_decode_metadata, sample_positions=None):
         # Sample the next token and get logprobs if needed.
         sampling_metadata = self.input_batch.sampling_metadata
         self.input_batch.update_async_output_token_ids()
         if spec_decode_metadata is None:
             if lmhead_tp_enable() and logits is not None:
                 logits = logits[: self.input_batch.num_reqs]
-                sample_positions = sample_positions[: self.input_batch.num_reqs]
-            self._attach_sampling_runtime_metadata(sampling_metadata, sample_positions, spec_decode_metadata)
+                if sample_positions is not None:
+                    sample_positions = sample_positions[: self.input_batch.num_reqs]
+            if sample_positions is not None:
+                self._attach_sampling_runtime_metadata(sampling_metadata, sample_positions, spec_decode_metadata)
             if self.input_batch.sampling_metadata.top_k is not None and get_ascend_config().enable_reduce_sample:
                 max_topk = self.input_batch.top_k_cpu[self.input_batch.top_k_cpu < logits.shape[1]].max()
                 self.sampler.prepare_sampling(max_topk)
@@ -3480,11 +3482,13 @@ class NPUModelRunner(GPUModelRunner):
 
         if lmhead_tp_enable() and logits is not None:
             logits = logits[: len(spec_decode_metadata.logits_indices)]
-            sample_positions = sample_positions[: len(spec_decode_metadata.logits_indices)]
+            if sample_positions is not None:
+                sample_positions = sample_positions[: len(spec_decode_metadata.logits_indices)]
         if self.use_async_scheduling and self._draft_token_req_ids is not None:
             draft_token_ids_cpu, _ = self._get_draft_token_ids_cpu()
             self.input_batch.update_async_spec_token_ids(draft_token_ids_cpu)
-        self._attach_sampling_runtime_metadata(sampling_metadata, sample_positions, spec_decode_metadata)
+        if sample_positions is not None:
+            self._attach_sampling_runtime_metadata(sampling_metadata, sample_positions, spec_decode_metadata)
         if self.input_batch.sampling_metadata.top_k is not None and get_ascend_config().enable_reduce_sample:
             max_topk = self.input_batch.top_k_cpu[self.input_batch.top_k_cpu < logits.shape[1]].max()
             self.rejection_sampler.prepare_sampling(max_topk)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -131,7 +131,8 @@ from vllm_ascend.sample.sampler import AscendSampler
 from vllm_ascend.spec_decode import get_spec_decode_method
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
-from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer, _FusedModelWithMTP
+from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
+from vllm_ascend.spec_decode.llm_base_proposer import _FusedModelWithMTP
 from vllm_ascend.spec_decode.extract_hidden_states_proposer import (
     AscendExtractHiddenStatesProposer,
 )

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -18,6 +18,7 @@
 #
 
 import math
+import os
 import sys
 import time
 from collections import defaultdict
@@ -79,11 +80,12 @@ from vllm.v1.outputs import (
 )
 from vllm.v1.worker.utils import select_common_block_size
 
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type, vllm_version_is
+from vllm_ascend.utils import vllm_version_is
 
 if not vllm_version_is("0.20.2"):
     from vllm.v1.outputs import RoutedExpertsLists
 from vllm.v1.sample.logits_processor import build_logitsprocs
+from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import RejectionSampler
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
@@ -129,7 +131,7 @@ from vllm_ascend.sample.sampler import AscendSampler
 from vllm_ascend.spec_decode import get_spec_decode_method
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
-from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
+from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer, _FusedModelWithMTP
 from vllm_ascend.spec_decode.extract_hidden_states_proposer import (
     AscendExtractHiddenStatesProposer,
 )
@@ -231,11 +233,12 @@ class ExecuteModelState(NamedTuple):
     sample_tokens(), after execute_model() returns None."""
 
     scheduler_output: "SchedulerOutput"
-    logits: torch.Tensor
+    logits: torch.Tensor | None
     spec_decode_metadata: SpecDecodeMetadata | None
     spec_decode_common_attn_metadata: AscendCommonAttentionMetadata | None
     hidden_states: torch.Tensor
     sample_hidden_states: torch.Tensor
+    sample_positions: torch.Tensor
     aux_hidden_states: list[torch.Tensor] | None
     attn_metadata: "PerLayerAttnMetadata"
     positions: torch.Tensor
@@ -408,6 +411,24 @@ class NPUModelRunner(GPUModelRunner):
         self.enable_enpu = _enpu is not None and _enpu.lower() == "true"
 
         self._set_up_drafter()
+        self._fused_mtp_wrapper: _FusedModelWithMTP | None = None
+        self._used_fused_mtp_graph_sampler_output = False
+        self._fused_mtp_graph_outputs_ready = False
+        self._fused_mtp_runtime_common_attn_metadata: AscendCommonAttentionMetadata | None = None
+        self._fused_mtp_debug_enabled = os.getenv(
+            "VLLM_ASCEND_FUSED_MTP_DEBUG", "0"
+        ).lower() in ("1", "true", "yes", "on")
+        try:
+            fused_mtp_debug_interval = int(
+                os.getenv("VLLM_ASCEND_FUSED_MTP_DEBUG_INTERVAL", "200")
+            )
+        except ValueError:
+            fused_mtp_debug_interval = 200
+        self._fused_mtp_debug_interval = max(
+            fused_mtp_debug_interval, 1
+        )
+        self._fused_mtp_debug_step = 0
+        self._fused_mtp_debug_last_prepare: dict[str, Any] = {}
 
         # Event for async GPU→CPU copy of corrected seq_lens in async
         # spec decode mode. Recorded in _prepare_inputs, synchronized
@@ -563,6 +584,1027 @@ class NPUModelRunner(GPUModelRunner):
     def _get_drafter(self):
         return get_spec_decode_method(self.speculative_config.method, self.vllm_config, self.device, self)
 
+    def _can_use_fused_mtp_draft_path(
+        self,
+        grammar_output,
+        spec_decode_metadata: SpecDecodeMetadata | None,
+    ) -> bool:
+        return self._get_fused_mtp_draft_path_block_reason(grammar_output, spec_decode_metadata) is None
+
+    def _get_fused_mtp_sampling_block_reason(self, sampling_metadata) -> str | None:
+        if sampling_metadata.all_greedy:
+            return None
+        # sample_with_runtime_state can synthesize default runtime seeds when
+        # requests do not provide explicit seeds. Do not force non-greedy
+        # requests back to the old rejection sampler only because seed is None.
+        return None
+
+    def _can_use_fused_mtp_graph_sampling_batch(
+        self,
+        batch_descriptor: BatchDescriptor | None,
+    ) -> bool:
+        if not self._fused_mtp_full_graph_enabled():
+            return False
+        if self._fused_mtp_wrapper is None:
+            return False
+        if not self._is_fused_mtp_uniform_decode_graph_batch(batch_descriptor):
+            return False
+        return self._get_fused_mtp_sampling_block_reason(
+            self.input_batch.sampling_metadata,
+        ) is None
+
+    @staticmethod
+    def _fused_mtp_full_graph_enabled() -> bool:
+        return bool(getattr(get_ascend_config(), "enable_fused_mtp_full_graph", False))
+
+    def _get_fused_mtp_draft_path_block_reason(
+        self,
+        grammar_output,
+        spec_decode_metadata: SpecDecodeMetadata | None,
+    ) -> str | None:
+        if self._fused_mtp_wrapper is None or self.drafter is None:
+            return "no_wrapper_or_drafter"
+        if self.speculative_config is None or self.speculative_config.method != "mtp":
+            return f"spec_method={getattr(self.speculative_config, 'method', None)}"
+        if spec_decode_metadata is None:
+            return "no_spec_decode_metadata"
+        if not self._fused_mtp_graph_outputs_ready:
+            return "graph_outputs_not_ready"
+        if grammar_output is not None:
+            return "grammar_output"
+
+        sampling_metadata = self.input_batch.sampling_metadata
+        if sampling_metadata.max_num_logprobs is not None:
+            return f"logprobs={sampling_metadata.max_num_logprobs}"
+        logitsprocs = getattr(sampling_metadata, "logitsprocs", None)
+        if logitsprocs is not None and getattr(logitsprocs, "argmax_invariant", ()):
+            return "argmax_invariant_logitsproc"
+        sampling_block_reason = self._get_fused_mtp_sampling_block_reason(sampling_metadata)
+        if sampling_block_reason is not None:
+            return sampling_block_reason
+        if not sampling_metadata.no_penalties:
+            return "penalties"
+        if sampling_metadata.allowed_token_ids_mask is not None:
+            return "allowed_token_ids"
+        if sampling_metadata.bad_words_token_ids:
+            return "bad_words"
+        if self._has_active_non_argmax_invariant_logitprocs(sampling_metadata):
+            return "non_argmax_invariant_logitsproc"
+        return None
+
+    def _build_fused_mtp_sampler_output(self) -> SamplerOutput:
+        wrapper = self._fused_mtp_wrapper
+        assert wrapper is not None
+        num_reqs = self.input_batch.num_reqs
+        self._maybe_log_fused_mtp_debug(num_reqs)
+        sampled_token_ids = wrapper.sampled_token_ids_buf[:num_reqs].clone()
+        if self.num_discarded_requests > 0:
+            discard_indices = self.discard_request_indices.gpu[: self.num_discarded_requests].to(torch.long)
+            sampled_token_ids.index_fill_(0, discard_indices, -1)
+        return SamplerOutput(sampled_token_ids=sampled_token_ids, logprobs_tensors=None)
+
+    def _record_fused_mtp_prepare_debug(
+        self,
+        spec_decode_metadata: SpecDecodeMetadata | None,
+        num_tokens_padded: int | None,
+        active_num_tokens: int,
+        all_greedy: bool,
+    ) -> None:
+        if not self._fused_mtp_debug_enabled:
+            return
+        num_reqs = self.input_batch.num_reqs
+        prev_positions = getattr(getattr(self, "prev_positions", None), "np", None)
+        common_reqs = 0
+        reordered = False
+        if prev_positions is not None and getattr(
+            self.input_batch, "prev_sampled_token_ids", None
+        ) is not None:
+            prev_positions_np = prev_positions[:num_reqs]
+            common_reqs = int(np.count_nonzero(prev_positions_np >= 0))
+            if common_reqs:
+                current_positions = np.arange(num_reqs, dtype=prev_positions_np.dtype)
+                reordered = bool(np.any((prev_positions_np >= 0) & (prev_positions_np != current_positions)))
+
+        if spec_decode_metadata is None:
+            num_draft_tokens = []
+            total_drafts = 0
+            draft_hist: dict[int, int] = {}
+        else:
+            num_draft_tokens = spec_decode_metadata.num_draft_tokens
+            total_drafts = int(sum(num_draft_tokens))
+            draft_hist = {
+                int(k): int(num_draft_tokens.count(k))
+                for k in sorted(set(num_draft_tokens))
+            }
+
+        self._fused_mtp_debug_last_prepare = {
+            "num_reqs": num_reqs,
+            "num_tokens_padded": num_tokens_padded,
+            "active_num_tokens": active_num_tokens,
+            "all_greedy": all_greedy,
+            "discarded": self.num_discarded_requests,
+            "common_reqs": common_reqs,
+            "new_or_reordered_reqs": num_reqs - common_reqs,
+            "reordered": reordered,
+            "total_drafts": total_drafts,
+            "draft_hist": draft_hist,
+        }
+
+    def _maybe_log_fused_mtp_debug(self, num_reqs: int) -> None:
+        if not self._fused_mtp_debug_enabled:
+            return
+        self._fused_mtp_debug_step += 1
+        if self._fused_mtp_debug_step % self._fused_mtp_debug_interval != 0:
+            return
+
+        wrapper = self._fused_mtp_wrapper
+        if wrapper is None:
+            return
+        counts = wrapper.valid_sampled_tokens_count_buf[:num_reqs].detach().to("cpu").tolist()
+        count_hist = {int(k): int(counts.count(k)) for k in sorted(set(counts))}
+        accepted_drafts = int(sum(max(int(count) - 1, 0) for count in counts))
+        prepare = self._fused_mtp_debug_last_prepare
+        total_drafts = int(prepare.get("total_drafts", 0))
+        accept_rate = accepted_drafts / total_drafts if total_drafts > 0 else 0.0
+        logger.info(
+            "Fused MTP debug: step=%d num_reqs=%d padded_tokens=%s "
+            "active_tokens=%s all_greedy=%s discarded=%s common_reqs=%s "
+            "new_or_reordered_reqs=%s reordered=%s draft_hist=%s "
+            "valid_count_hist=%s accepted_drafts=%d total_drafts=%d "
+            "accept_rate=%.4f",
+            self._fused_mtp_debug_step,
+            num_reqs,
+            prepare.get("num_tokens_padded"),
+            prepare.get("active_num_tokens"),
+            prepare.get("all_greedy"),
+            prepare.get("discarded"),
+            prepare.get("common_reqs"),
+            prepare.get("new_or_reordered_reqs"),
+            prepare.get("reordered"),
+            prepare.get("draft_hist"),
+            count_hist,
+            accepted_drafts,
+            total_drafts,
+            accept_rate,
+        )
+
+    def _should_defer_fused_mtp_logits(self, spec_decode_metadata: SpecDecodeMetadata | None) -> bool:
+        return self._get_fused_mtp_draft_path_block_reason(None, spec_decode_metadata) is None
+
+    def _compute_deferred_logits(
+        self,
+        logits: torch.Tensor | None,
+        sample_hidden_states: torch.Tensor | None,
+    ) -> torch.Tensor:
+        if logits is not None:
+            return logits
+        assert sample_hidden_states is not None
+        return self.model.compute_logits(sample_hidden_states)
+
+    def _is_fused_mtp_uniform_decode_graph_batch(self, batch_descriptor: BatchDescriptor | None) -> bool:
+        wrapper = self._fused_mtp_wrapper
+        if wrapper is None or batch_descriptor is None or self.num_spec_tokens <= 0:
+            return False
+        decode_query_len = self.num_spec_tokens + 1
+        num_tokens = batch_descriptor.num_tokens
+        if num_tokens % decode_query_len != 0:
+            return False
+        padded_num_reqs = num_tokens // decode_query_len
+        actual_num_reqs = int(getattr(self.input_batch, "num_reqs", 0))
+        if padded_num_reqs < actual_num_reqs:
+            return False
+        if batch_descriptor.num_reqs is not None and padded_num_reqs < int(batch_descriptor.num_reqs):
+            return False
+        max_graph_reqs = min(
+            wrapper.bonus_row_indices_buf.shape[0],
+            wrapper.next_token_ids_buf.shape[0],
+            wrapper.cu_num_draft_tokens_buf.shape[0],
+            wrapper.sampled_token_ids_buf.shape[0],
+        )
+        return padded_num_reqs <= max_graph_reqs
+
+    def _should_warmup_fused_mtp_drafter(
+        self,
+        batch_descriptor: BatchDescriptor | None,
+        cudagraph_runtime_mode: CUDAGraphMode,
+    ) -> bool:
+        return (
+            self._fused_mtp_wrapper is not None
+            and self._fused_mtp_full_graph_enabled()
+            and cudagraph_runtime_mode == CUDAGraphMode.NONE
+            and self._is_fused_mtp_uniform_decode_graph_batch(batch_descriptor)
+        )
+
+    def _get_fused_mtp_partial_decode_graph_tokens(
+        self,
+        num_tokens: int,
+        num_reqs: int,
+        max_num_scheduled_tokens: int,
+        is_all_decode: bool,
+        force_uniform_decode: bool | None,
+    ) -> int | None:
+        if force_uniform_decode is not None:
+            return None
+        if self._fused_mtp_wrapper is None:
+            return None
+        if not self._fused_mtp_full_graph_enabled():
+            return None
+        if self.speculative_config is None or self.speculative_config.method != "mtp":
+            return None
+        if not is_all_decode:
+            return None
+
+        decode_query_len = self.num_spec_tokens + 1
+        if decode_query_len <= 1:
+            return None
+        if max_num_scheduled_tokens != decode_query_len:
+            return None
+
+        graph_tokens = decode_query_len * num_reqs
+        if graph_tokens <= num_tokens:
+            return None
+        max_capture_size = getattr(self.compilation_config, "max_cudagraph_capture_size", None)
+        if max_capture_size is not None and graph_tokens > max_capture_size:
+            return None
+        return graph_tokens
+
+    def _pad_fused_mtp_graph_inputs(self, num_actual_tokens: int, num_tokens_padded: int) -> None:
+        if num_tokens_padded <= num_actual_tokens:
+            return
+        start = int(num_actual_tokens)
+        end = int(num_tokens_padded)
+        input_ids = getattr(self, "input_ids", None)
+        if input_ids is not None:
+            input_ids_gpu = getattr(input_ids, "gpu", None)
+            if torch.is_tensor(input_ids_gpu):
+                input_ids_gpu[start:end].fill_(0)
+            input_ids_cpu = getattr(input_ids, "cpu", None)
+            if torch.is_tensor(input_ids_cpu):
+                input_ids_cpu[start:end].fill_(0)
+
+        if self.uses_mrope:
+            positions = getattr(self, "mrope_positions", None)
+            if positions is not None:
+                positions_gpu = getattr(positions, "gpu", None)
+                if torch.is_tensor(positions_gpu):
+                    positions_gpu[:, start:end].zero_()
+                positions_cpu = getattr(positions, "cpu", None)
+                if torch.is_tensor(positions_cpu):
+                    positions_cpu[:, start:end].zero_()
+            return
+
+        if self.uses_xdrope_dim > 0:
+            positions = getattr(self, "xdrope_positions", None)
+            if positions is not None:
+                positions_gpu = getattr(positions, "gpu", None)
+                if torch.is_tensor(positions_gpu):
+                    positions_gpu[:, start:end].zero_()
+                positions_cpu = getattr(positions, "cpu", None)
+                if torch.is_tensor(positions_cpu):
+                    positions_cpu[:, start:end].zero_()
+            return
+
+        positions = getattr(self, "positions", None)
+        if positions is None:
+            return
+        pad_position = 127 if self.use_compress else 0
+        positions_gpu = getattr(positions, "gpu", None)
+        if torch.is_tensor(positions_gpu):
+            positions_gpu[start:end].fill_(pad_position)
+        positions_cpu = getattr(positions, "cpu", None)
+        if torch.is_tensor(positions_cpu):
+            positions_cpu[start:end].fill_(pad_position)
+        positions_np = getattr(positions, "np", None)
+        if positions_np is not None:
+            positions_np[start:end] = pad_position
+        elif torch.is_tensor(positions):
+            positions[start:end].fill_(pad_position)
+
+    def _materialize_fused_draft_token_ids(
+        self,
+        scheduler_output: SchedulerOutput,
+        draft_token_ids: torch.Tensor,
+    ) -> None:
+        self._draft_token_req_ids = self.input_batch.req_ids.copy()
+        draft_token_ids = self._token_ids_for_input_buffer(draft_token_ids)
+        if not self.use_cp and not self.use_async_scheduling:
+            self._draft_token_ids = draft_token_ids.to("cpu").tolist()
+            return
+        self._draft_token_ids = draft_token_ids
+        self._copy_draft_token_ids_to_cpu(scheduler_output)
+
+    def _token_ids_for_input_buffer(self, token_ids: torch.Tensor) -> torch.Tensor:
+        input_ids_gpu = getattr(getattr(self, "input_ids", None), "gpu", None)
+        if torch.is_tensor(input_ids_gpu) and token_ids.dtype != input_ids_gpu.dtype:
+            return token_ids.to(input_ids_gpu.dtype)
+        return token_ids
+
+    def _set_prev_sampled_token_ids(self, next_token_ids: torch.Tensor) -> None:
+        next_token_ids = self._token_ids_for_input_buffer(next_token_ids)
+        self.input_batch.prev_sampled_token_ids = next_token_ids.unsqueeze(1)
+
+    def _has_active_non_argmax_invariant_logitprocs(self, sampling_metadata: SamplingMetadata) -> bool:
+        logitsprocs = getattr(sampling_metadata, "logitsprocs", None)
+        non_argmax_invariant = getattr(logitsprocs, "non_argmax_invariant", ()) if logitsprocs is not None else ()
+        for logitsproc in non_argmax_invariant:
+            if isinstance(logitsproc, MinTokensLogitsProcessor):
+                if logitsproc.min_toks:
+                    return True
+                continue
+            return True
+        return False
+
+    def _prepare_fused_mtp_runtime_buffers(
+        self,
+        logits_indices: torch.Tensor,
+        spec_decode_metadata: SpecDecodeMetadata | None,
+        spec_decode_common_attn_metadata: AscendCommonAttentionMetadata | None,
+        num_tokens_padded: int | None = None,
+    ) -> None:
+        wrapper = self._fused_mtp_wrapper
+        assert wrapper is not None
+
+        num_reqs = self.input_batch.num_reqs
+        sampling_metadata = self.input_batch.sampling_metadata
+        all_greedy = getattr(sampling_metadata, "all_greedy", False)
+        active_num_tokens = int(logits_indices.shape[0])
+        if spec_decode_common_attn_metadata is not None:
+            active_num_tokens = min(
+                active_num_tokens,
+                int(getattr(spec_decode_common_attn_metadata, "num_actual_tokens", active_num_tokens)),
+            )
+        if num_tokens_padded is not None:
+            active_num_tokens = min(active_num_tokens, int(num_tokens_padded))
+
+        self._record_fused_mtp_prepare_debug(
+            spec_decode_metadata,
+            num_tokens_padded,
+            active_num_tokens,
+            all_greedy,
+        )
+
+        wrapper.num_reqs_buf[0] = num_reqs
+        wrapper.num_actual_tokens_buf[0] = active_num_tokens
+        wrapper.target_logits_indices_buf[:num_reqs].fill_(-1)
+        wrapper.spec_decode_token_ids_buf[:num_reqs].zero_()
+        wrapper.discarded_req_mask_buf[:num_reqs].zero_()
+        wrapper.cu_num_draft_tokens_buf[:num_reqs].zero_()
+        wrapper.bonus_row_indices_buf.zero_()
+        wrapper.num_sample_rows_buf.zero_()
+        wrapper.num_target_rows_buf.zero_()
+        wrapper.sample_logits_indices_buf.zero_()
+        if not all_greedy:
+            wrapper.sample_idx_mapping_buf.zero_()
+        wrapper.target_row_indices_buf.zero_()
+        wrapper.draft_token_ids_flat_buf.zero_()
+        wrapper.draft_token_ids_buf.zero_()
+        wrapper.next_token_ids_buf.zero_()
+        wrapper.valid_sampled_tokens_count_buf.zero_()
+        wrapper.sampled_token_ids_buf.fill_(-1)
+
+        if (
+            spec_decode_common_attn_metadata is not None
+            and self.drafter is not None
+            and hasattr(self.drafter, "slot_mapping_group")
+            and self.drafter.slot_mapping_group
+        ):
+            slot_mapping = getattr(spec_decode_common_attn_metadata, "slot_mapping", None)
+            if torch.is_tensor(slot_mapping):
+                mtp_slot_mapping = self.drafter.slot_mapping_group[0]
+                slot_mapping_len = min(active_num_tokens, slot_mapping.shape[0], mtp_slot_mapping.shape[0])
+                mtp_slot_mapping[:slot_mapping_len].copy_(
+                    slot_mapping[:slot_mapping_len].to(dtype=mtp_slot_mapping.dtype, device=mtp_slot_mapping.device)
+                )
+                mtp_slot_mapping[slot_mapping_len:].fill_(0)
+
+        dummy_sample_idx = wrapper.sample_idx_mapping_buf.shape[0] - 1
+
+        def fill_padded_logits_indices() -> None:
+            if num_tokens_padded is None or self.num_spec_tokens <= 0:
+                return
+            decode_query_len = self.num_spec_tokens + 1
+            if num_tokens_padded % decode_query_len != 0:
+                return
+            max_graph_reqs = min(
+                wrapper.bonus_row_indices_buf.shape[0],
+                wrapper.next_token_ids_buf.shape[0],
+                wrapper.cu_num_draft_tokens_buf.shape[0],
+                wrapper.sampled_token_ids_buf.shape[0],
+            )
+            padded_num_reqs = max(num_reqs, num_tokens_padded // decode_query_len)
+            if padded_num_reqs > max_graph_reqs or padded_num_reqs <= num_reqs:
+                return
+            wrapper.logits_indices_buf[num_reqs:padded_num_reqs].zero_()
+
+        def fill_padded_sample_rows(num_sample_rows: int) -> None:
+            if num_tokens_padded is None:
+                return
+            pad_end = min(
+                int(num_tokens_padded),
+                wrapper.sample_logits_indices_buf.shape[0],
+            )
+            num_sample_rows = min(int(num_sample_rows), pad_end)
+            if pad_end <= num_sample_rows:
+                return
+            wrapper.sample_logits_indices_buf[num_sample_rows:pad_end].zero_()
+            if not all_greedy:
+                wrapper.sample_idx_mapping_buf[num_sample_rows:pad_end].fill_(dummy_sample_idx)
+
+        if self.num_discarded_requests > 0:
+            seq_lens_cpu = getattr(spec_decode_common_attn_metadata, "seq_lens_cpu", None) \
+                if spec_decode_common_attn_metadata is not None else None
+            if seq_lens_cpu is None:
+                seq_lens_cpu = self.optimistic_seq_lens_cpu[:num_reqs]
+            backup_next_token_ids = np.array(
+                [
+                    self.requests[self.input_batch.req_ids[i]].get_token_id(seq_lens_cpu[i].item())
+                    for i in range(num_reqs)
+                ],
+                dtype=np.int64,
+            )
+            wrapper.backup_next_token_ids_buf[:num_reqs].copy_(torch.from_numpy(backup_next_token_ids).to(self.device))
+            discard_indices = self.discard_request_indices.gpu[: self.num_discarded_requests].to(torch.long)
+            wrapper.discarded_req_mask_buf[discard_indices] = True
+
+        if spec_decode_metadata is not None:
+            bonus_positions = logits_indices[spec_decode_metadata.bonus_logits_indices]
+            wrapper.logits_indices_buf[: bonus_positions.shape[0]].copy_(bonus_positions)
+            fill_padded_logits_indices()
+            wrapper.bonus_row_indices_buf[:num_reqs].copy_(
+                spec_decode_metadata.bonus_logits_indices.to(torch.int64)
+            )
+            sample_positions = logits_indices[spec_decode_metadata.logits_indices].to(torch.int64)
+            wrapper.sample_logits_indices_buf[: sample_positions.shape[0]].copy_(sample_positions)
+            wrapper.num_sample_rows_buf[0] = sample_positions.shape[0]
+            if not all_greedy:
+                sample_idx_mapping = self._build_sampling_idx_mapping(spec_decode_metadata, sample_positions.shape[0])
+                wrapper.sample_idx_mapping_buf[: sample_idx_mapping.shape[0]].copy_(sample_idx_mapping)
+            wrapper.cu_num_draft_tokens_buf[:num_reqs].copy_(
+                spec_decode_metadata.cu_num_draft_tokens.to(torch.int32)
+            )
+            if num_reqs < wrapper.cu_num_draft_tokens_buf.shape[0]:
+                wrapper.cu_num_draft_tokens_buf[num_reqs:].fill_(
+                    spec_decode_metadata.cu_num_draft_tokens[-1].to(torch.int32)
+                )
+            target_row_indices = spec_decode_metadata.target_logits_indices.to(torch.int64)
+            wrapper.target_row_indices_buf[: target_row_indices.shape[0]].copy_(target_row_indices)
+            wrapper.num_target_rows_buf[0] = target_row_indices.shape[0]
+            wrapper.draft_token_ids_flat_buf[: spec_decode_metadata.draft_token_ids.shape[0]].copy_(
+                spec_decode_metadata.draft_token_ids.to(torch.int64)
+            )
+            target_positions = logits_indices[spec_decode_metadata.target_logits_indices].to(torch.int64)
+            draft_token_ids = spec_decode_metadata.draft_token_ids.to(torch.int64)
+            fill_padded_sample_rows(sample_positions.shape[0])
+            draft_offset = 0
+            for req_idx, num_drafts in enumerate(spec_decode_metadata.num_draft_tokens):
+                if num_drafts <= 0:
+                    continue
+                next_offset = draft_offset + num_drafts
+                wrapper.target_logits_indices_buf[req_idx, :num_drafts] = target_positions[draft_offset:next_offset]
+                wrapper.spec_decode_token_ids_buf[req_idx, :num_drafts] = draft_token_ids[draft_offset:next_offset]
+                draft_offset = next_offset
+            return
+
+        wrapper.logits_indices_buf[: logits_indices.shape[0]].copy_(logits_indices[: logits_indices.shape[0]])
+        fill_padded_logits_indices()
+        wrapper.sample_logits_indices_buf[: logits_indices.shape[0]].copy_(logits_indices[: logits_indices.shape[0]])
+        wrapper.num_sample_rows_buf[0] = logits_indices.shape[0]
+        fill_padded_sample_rows(logits_indices.shape[0])
+        wrapper.bonus_row_indices_buf[:num_reqs].copy_(torch.arange(num_reqs, dtype=torch.int64, device=self.device))
+        if not all_greedy:
+            wrapper.sample_idx_mapping_buf[:num_reqs].copy_(
+                torch.arange(num_reqs, dtype=torch.int32, device=self.device)
+            )
+
+    def _prepare_fused_mtp_capture_buffers(self, num_tokens_padded: int) -> None:
+        wrapper = self._fused_mtp_wrapper
+        if wrapper is None or self.num_spec_tokens <= 0:
+            return
+        decode_query_len = self.num_spec_tokens + 1
+        if num_tokens_padded % decode_query_len != 0:
+            return
+        padded_num_reqs = num_tokens_padded // decode_query_len
+        max_graph_reqs = min(
+            wrapper.bonus_row_indices_buf.shape[0],
+            wrapper.next_token_ids_buf.shape[0],
+            wrapper.cu_num_draft_tokens_buf.shape[0],
+            wrapper.sampled_token_ids_buf.shape[0],
+        )
+        if padded_num_reqs <= 0 or padded_num_reqs > max_graph_reqs:
+            return
+
+        device = self.device
+        dummy_sample_idx = wrapper.sample_idx_mapping_buf.shape[0] - 1
+        wrapper.logits_indices_buf.zero_()
+        wrapper.sample_logits_indices_buf.zero_()
+        wrapper.sample_idx_mapping_buf.fill_(dummy_sample_idx)
+        wrapper.bonus_row_indices_buf.zero_()
+        wrapper.target_row_indices_buf.zero_()
+        wrapper.cu_num_draft_tokens_buf.zero_()
+        wrapper.target_logits_indices_buf.fill_(-1)
+        wrapper.spec_decode_token_ids_buf.zero_()
+        wrapper.draft_token_ids_flat_buf.zero_()
+        wrapper.backup_next_token_ids_buf.zero_()
+        wrapper.discarded_req_mask_buf.zero_()
+        wrapper.sampled_token_ids_buf.fill_(-1)
+        wrapper.draft_token_ids_buf.zero_()
+        wrapper.next_token_ids_buf.zero_()
+        wrapper.valid_sampled_tokens_count_buf.zero_()
+
+        req_indices = torch.arange(padded_num_reqs, dtype=torch.int64, device=device)
+        row_offsets = torch.arange(num_tokens_padded, dtype=torch.int64, device=device)
+        bonus_positions = req_indices * decode_query_len + (decode_query_len - 1)
+        target_positions = req_indices * decode_query_len
+        target_position_matrix = target_positions.unsqueeze(1) + torch.arange(
+            self.num_spec_tokens, dtype=torch.int64, device=device
+        ).unsqueeze(0)
+
+        wrapper.num_reqs_buf[0] = padded_num_reqs
+        wrapper.num_actual_tokens_buf[0] = num_tokens_padded
+        wrapper.num_sample_rows_buf[0] = num_tokens_padded
+        wrapper.num_target_rows_buf[0] = padded_num_reqs * self.num_spec_tokens
+        wrapper.logits_indices_buf[:padded_num_reqs].copy_(bonus_positions)
+        wrapper.sample_logits_indices_buf[:num_tokens_padded].copy_(row_offsets)
+        wrapper.bonus_row_indices_buf[:padded_num_reqs].copy_(bonus_positions)
+        wrapper.target_row_indices_buf[: padded_num_reqs * self.num_spec_tokens].copy_(
+            target_position_matrix.reshape(-1)
+        )
+        wrapper.sample_idx_mapping_buf[:num_tokens_padded].copy_(
+            torch.repeat_interleave(req_indices.to(torch.int32), decode_query_len)
+        )
+        wrapper.cu_num_draft_tokens_buf[:padded_num_reqs].copy_(
+            (req_indices.to(torch.int32) + 1) * self.num_spec_tokens
+        )
+        wrapper.target_logits_indices_buf[:padded_num_reqs, : self.num_spec_tokens].copy_(
+            target_position_matrix.to(torch.int64)
+        )
+
+    def _build_sampling_idx_mapping(
+        self,
+        spec_decode_metadata: SpecDecodeMetadata | None,
+        num_rows: int,
+    ) -> torch.Tensor:
+        if spec_decode_metadata is None:
+            return torch.arange(num_rows, dtype=torch.int32, device=self.device)
+        repeat_counts = np.asarray(
+            [num_drafts + 1 for num_drafts in spec_decode_metadata.num_draft_tokens],
+            dtype=np.int32,
+        )
+        req_indices = np.arange(repeat_counts.shape[0], dtype=np.int32)
+        idx_mapping = np.repeat(req_indices, repeat_counts)
+        if idx_mapping.shape[0] > num_rows:
+            idx_mapping = idx_mapping[:num_rows]
+        elif idx_mapping.shape[0] < num_rows:
+            idx_mapping = np.pad(idx_mapping, (0, num_rows - idx_mapping.shape[0]), mode="constant")
+        idx_mapping_tensor = torch.from_numpy(idx_mapping)
+        if self.device.type == "cpu":
+            return idx_mapping_tensor
+        return idx_mapping_tensor.pin_memory().to(self.device, non_blocking=True)
+
+    def _attach_sampling_runtime_metadata(
+        self,
+        sampling_metadata: SamplingMetadata,
+        sample_positions: torch.Tensor,
+        spec_decode_metadata: SpecDecodeMetadata | None,
+    ) -> None:
+        sampling_metadata._ascend_positions = sample_positions.to(torch.int32)
+        sampling_metadata._ascend_idx_mapping = self._build_sampling_idx_mapping(
+            spec_decode_metadata,
+            sample_positions.shape[0],
+        )
+
+    def _build_and_inject_mtp_attn_metadata(
+        self,
+        forward_context,
+        num_tokens: int,
+        num_reqs: int,
+        cudagraph_runtime_mode: CUDAGraphMode,
+    ) -> None:
+        drafter = self.drafter
+        if drafter is None:
+            return
+        saved_metadata = drafter.build_graph_capture_attn_metadata(
+            num_tokens=num_tokens,
+            num_reqs=num_reqs,
+            aclgraph_runtime_mode=cudagraph_runtime_mode,
+        )
+        if saved_metadata and len(saved_metadata) > 0:
+            if isinstance(forward_context.attn_metadata, dict):
+                for layer_name, meta in saved_metadata[0].items():
+                    forward_context.attn_metadata[layer_name] = meta
+            forward_context.draft_attn_metadatas = saved_metadata
+
+    def _needs_fused_mtp_capture_metadata(self, batch_descriptor) -> bool:
+        if not isinstance(self.model, ACLGraphWrapper):
+            return True
+        if batch_descriptor is None:
+            return True
+        return not self.model.is_captured(batch_descriptor)
+
+    def _get_fused_mtp_builder_num_reqs(self, num_tokens: int | None, actual_num_reqs: int) -> int:
+        return actual_num_reqs
+
+    @staticmethod
+    def _to_int_list(value) -> list[int] | None:
+        if value is None:
+            return None
+        if torch.is_tensor(value):
+            return value.detach().cpu().to(torch.int64).tolist()
+        return list(value)
+
+    def _ensure_mtp_actual_seq_lengths_q(
+        self,
+        draft_attn_metadatas: list[dict],
+        builder_num_reqs: int,
+    ) -> None:
+        fallback_query_start_loc = self.query_start_loc.cpu[: builder_num_reqs + 1]
+        for per_layer_metadata in draft_attn_metadatas:
+            for metadata in per_layer_metadata.values():
+                decode = getattr(metadata, "decode", None)
+                if decode is None or getattr(decode, "actual_seq_lengths_q", None) is not None:
+                    continue
+                query_start_loc = getattr(decode, "query_start_loc_cpu", None)
+                if query_start_loc is None:
+                    query_start_loc = getattr(decode, "query_start_loc", None)
+                if query_start_loc is None:
+                    query_start_loc = fallback_query_start_loc
+                actual_seq_lengths_q = self._to_int_list(query_start_loc[1:])
+                if actual_seq_lengths_q is not None:
+                    decode.actual_seq_lengths_q = actual_seq_lengths_q
+
+    def _pad_mtp_query_start_loc_for_graph(self, num_tokens_padded: int, actual_num_reqs: int) -> int:
+        num_tokens_padded = int(num_tokens_padded)
+        actual_num_reqs = int(actual_num_reqs)
+        if actual_num_reqs <= 0:
+            return actual_num_reqs
+
+        actual_end = int(self.query_start_loc.np[actual_num_reqs])
+        decode_query_len = int(getattr(self, "num_spec_tokens", 0)) + 1
+        if decode_query_len <= 1:
+            decode_query_len = int(getattr(self, "uniform_decode_query_len", decode_query_len))
+
+        graph_num_reqs = actual_num_reqs
+        if decode_query_len > 0 and num_tokens_padded % decode_query_len == 0:
+            candidate_num_reqs = num_tokens_padded // decode_query_len
+            if candidate_num_reqs >= actual_num_reqs:
+                graph_num_reqs = candidate_num_reqs
+        elif num_tokens_padded > actual_end:
+            graph_num_reqs = actual_num_reqs + 1
+
+        if graph_num_reqs > actual_num_reqs:
+            remaining_tokens = num_tokens_padded - actual_end
+            remaining_reqs = graph_num_reqs - actual_num_reqs
+            if remaining_tokens < remaining_reqs:
+                graph_num_reqs = actual_num_reqs + 1
+            for req_idx in range(actual_num_reqs + 1, graph_num_reqs + 1):
+                if req_idx == graph_num_reqs:
+                    next_loc = num_tokens_padded
+                else:
+                    next_loc = actual_end + (req_idx - actual_num_reqs) * decode_query_len
+                    next_loc = min(next_loc, num_tokens_padded)
+                self.query_start_loc.np[req_idx] = next_loc
+        elif num_tokens_padded > actual_end:
+            self.query_start_loc.np[actual_num_reqs] = num_tokens_padded
+
+        self.query_start_loc.copy_to_gpu()
+        return graph_num_reqs
+
+    @staticmethod
+    def _pad_fused_mtp_metadata_rows(
+        tensor: torch.Tensor,
+        active_rows: int,
+        desired_rows: int,
+    ) -> torch.Tensor:
+        desired_rows = int(desired_rows)
+        active_rows = min(max(int(active_rows), 0), tensor.shape[0], desired_rows)
+        if desired_rows <= 0:
+            return tensor[:0]
+        if active_rows == desired_rows:
+            return tensor[:desired_rows]
+        padded = torch.empty((desired_rows, *tensor.shape[1:]), dtype=tensor.dtype, device=tensor.device)
+        if active_rows > 0:
+            padded[:active_rows].copy_(tensor[:active_rows])
+            dummy_row = tensor[:1].expand((desired_rows - active_rows, *tensor.shape[1:]))
+            padded[active_rows:].copy_(dummy_row)
+        else:
+            padded.zero_()
+        return padded
+
+    def _build_fused_mtp_builder_metadata(self, num_tokens: int | None, actual_num_reqs: int) -> list[dict]:
+        assert self.drafter is not None
+        if num_tokens is None:
+            return []
+        runtime_metadata = self._build_fused_mtp_runtime_builder_metadata(num_tokens)
+        if runtime_metadata:
+            return runtime_metadata
+        builder_num_reqs = self._get_fused_mtp_builder_num_reqs(num_tokens, actual_num_reqs)
+        draft_attn_metadatas = self.drafter.build_graph_capture_attn_metadata(
+            num_tokens=int(num_tokens),
+            num_reqs=builder_num_reqs,
+            aclgraph_runtime_mode=CUDAGraphMode.FULL,
+        )
+        self._ensure_mtp_actual_seq_lengths_q(draft_attn_metadatas, builder_num_reqs)
+        return draft_attn_metadatas
+
+    def _build_fused_mtp_runtime_builder_metadata(self, num_tokens: int) -> list[dict]:
+        drafter = self.drafter
+        assert drafter is not None
+        if getattr(drafter, "num_speculative_tokens", 1) != 1:
+            return []
+        runtime_common = getattr(self, "_fused_mtp_runtime_common_attn_metadata", None)
+        if runtime_common is None:
+            return []
+        if not getattr(drafter, "draft_attn_groups", None) or not getattr(drafter, "attn_layer_names", None):
+            return []
+
+        common_attn_metadata = copy(runtime_common)
+        active_num_reqs = int(getattr(self.input_batch, "num_reqs", getattr(runtime_common, "num_reqs", 0)))
+        if active_num_reqs <= 0:
+            return []
+
+        query_start_loc_cpu = getattr(runtime_common, "query_start_loc_cpu", None)
+        if query_start_loc_cpu is not None:
+            copy_len = min(active_num_reqs + 1, query_start_loc_cpu.shape[0])
+            self.query_start_loc.cpu[:copy_len].copy_(query_start_loc_cpu[:copy_len])
+            if hasattr(self.query_start_loc, "np"):
+                self.query_start_loc.np[:copy_len] = self.query_start_loc.cpu[:copy_len].cpu().numpy()
+
+        num_reqs_padded = self._pad_mtp_query_start_loc_for_graph(int(num_tokens), active_num_reqs)
+        common_attn_metadata.num_reqs = num_reqs_padded
+        common_attn_metadata.query_start_loc = self.query_start_loc.gpu[: num_reqs_padded + 1]
+        common_attn_metadata.query_start_loc_cpu = self.query_start_loc.cpu[: num_reqs_padded + 1]
+        common_attn_metadata.actual_seq_lengths_q = self.query_start_loc.cpu[1 : num_reqs_padded + 1].tolist()
+
+        block_table_tensor = getattr(common_attn_metadata, "block_table_tensor", None)
+        if torch.is_tensor(block_table_tensor):
+            common_attn_metadata.block_table_tensor = self._pad_fused_mtp_metadata_rows(
+                block_table_tensor,
+                active_num_reqs,
+                num_reqs_padded,
+            )
+
+        common_attn_metadata.seq_lens = self._pad_fused_mtp_metadata_rows(
+            self.seq_lens,
+            active_num_reqs,
+            num_reqs_padded,
+        )
+        common_attn_metadata.seq_lens_cpu = self._pad_fused_mtp_metadata_rows(
+            self.optimistic_seq_lens_cpu,
+            active_num_reqs,
+            num_reqs_padded,
+        )
+        num_computed_tokens_cpu = getattr(runtime_common, "num_computed_tokens_cpu", None)
+        if torch.is_tensor(num_computed_tokens_cpu):
+            common_attn_metadata.num_computed_tokens_cpu = self._pad_fused_mtp_metadata_rows(
+                num_computed_tokens_cpu,
+                active_num_reqs,
+                num_reqs_padded,
+            )
+
+        slot_mapping = getattr(runtime_common, "slot_mapping", None)
+        if torch.is_tensor(slot_mapping):
+            mtp_slot_mapping = drafter.slot_mapping_group[0]
+            active_slot_mapping_len = int(
+                getattr(runtime_common, "num_actual_tokens", self.query_start_loc.np[active_num_reqs])
+            )
+            slot_mapping_len = min(
+                active_slot_mapping_len,
+                int(num_tokens),
+                slot_mapping.shape[0],
+                mtp_slot_mapping.shape[0],
+            )
+            mtp_slot_mapping[:slot_mapping_len].copy_(
+                slot_mapping[:slot_mapping_len].to(dtype=mtp_slot_mapping.dtype, device=mtp_slot_mapping.device)
+            )
+            mtp_slot_mapping[slot_mapping_len:].fill_(0)
+        common_attn_metadata.slot_mapping = drafter.slot_mapping_group[0]
+        common_attn_metadata.num_input_tokens = int(num_tokens)
+        common_attn_metadata.num_actual_tokens = int(num_tokens)
+
+        builder = drafter.draft_attn_groups[0].get_metadata_builder()
+        extra_attn_metadata_args = {}
+        if getattr(drafter, "use_compress", False):
+            extra_attn_metadata_args = dict(
+                prefill_ratio_to_sas_metadata=dict(),
+                decode_ratio_to_sas_metadata=dict(),
+                common_ratio_to_sas_metadata=dict(),
+                block_size=drafter.draft_attn_groups[0].kv_cache_spec.block_size,
+            )
+        attn_metadata = builder.build(0, common_attn_metadata, self.get_model(), **extra_attn_metadata_args)
+        attn_metadata = drafter._freeze_draft_step_attn_metadata(attn_metadata)
+        per_layer_attn_metadata = {}
+        for layer_name in drafter.attn_layer_names:
+            per_layer_attn_metadata[layer_name] = attn_metadata
+        return [per_layer_attn_metadata]
+
+    def _build_fused_mtp_stub_metadata(self) -> list[dict]:
+        assert self.drafter is not None
+        num_reqs = self.input_batch.num_reqs
+        query_start_loc_cpu = self.query_start_loc.cpu[: num_reqs + 1]
+        actual_seq_lengths_q = query_start_loc_cpu[1 : num_reqs + 1].tolist()
+        seq_lens_list = self.optimistic_seq_lens_cpu[:num_reqs].tolist()
+        block_table = self.input_batch.block_table[0].get_device_tensor()[:num_reqs]
+
+        class _DecodeStub:
+            pass
+
+        class _MetaStub:
+            pass
+
+        draft_attn_metadatas = []
+        num_draft_steps = max(getattr(self.drafter, "num_speculative_tokens", 1), 1)
+        for _ in range(num_draft_steps):
+            per_layer_metadata = {}
+            for layer_name in self.drafter.attn_layer_names:
+                decode_stub = _DecodeStub()
+                decode_stub.seq_lens_list = seq_lens_list
+                decode_stub.actual_seq_lengths_q = actual_seq_lengths_q
+                decode_stub.block_table = block_table
+                meta = _MetaStub()
+                meta.decode = decode_stub
+                per_layer_metadata[layer_name] = meta
+            draft_attn_metadatas.append(per_layer_metadata)
+        return draft_attn_metadatas
+
+    def _inject_mtp_metadata_stubs(self, forward_context, num_tokens: int | None = None):
+        assert self.drafter is not None
+        num_reqs = self.input_batch.num_reqs
+        draft_attn_metadatas = []
+        if num_tokens is not None:
+            try:
+                draft_attn_metadatas = self._build_fused_mtp_builder_metadata(num_tokens, num_reqs)
+            except Exception:
+                logger.exception(
+                    "Failed to build fused MTP builder metadata; falling back to lightweight stubs. "
+                    "num_tokens=%s num_reqs=%s",
+                    num_tokens,
+                    num_reqs,
+                )
+        if not draft_attn_metadatas:
+            draft_attn_metadatas = self._build_fused_mtp_stub_metadata()
+        attn_metadata = forward_context.attn_metadata
+        if isinstance(attn_metadata, dict) and draft_attn_metadatas:
+            for layer_name, meta in draft_attn_metadatas[0].items():
+                attn_metadata[layer_name] = meta
+        forward_context.draft_attn_metadatas = draft_attn_metadatas
+
+    def _update_mtp_graph_params_sparse(
+        self,
+        forward_context,
+        num_tokens: int,
+        draft_attn_metadatas: list[dict],
+        draft_layer_names: list[str],
+    ) -> None:
+        """Update MTP MLA graph params when the target model uses sparse DSA."""
+        import torch_npu
+
+        from vllm_ascend.compilation.acl_graph import get_graph_params
+
+        graph_params = get_graph_params()
+        if graph_params is None:
+            return
+        params_list = graph_params.attn_params.get(num_tokens)
+        if not params_list:
+            return
+        handles_list = graph_params.handles.get(num_tokens, [])
+        events_list = graph_params.events.get(num_tokens, [])
+
+        draft_updates = []
+        for per_layer_metadata in draft_attn_metadatas:
+            for key in draft_layer_names:
+                if key in per_layer_metadata:
+                    draft_updates.append(per_layer_metadata[key])
+
+        num_draft = len(draft_updates)
+        if num_draft == 0:
+            return
+        offset = len(params_list) - num_draft
+        if offset < 0:
+            return
+
+        self.update_stream.wait_stream(torch.npu.current_stream())
+        with torch.npu.stream(self.update_stream):
+            for metadata, param, handle, event in zip(
+                draft_updates,
+                params_list[offset:],
+                handles_list[offset:],
+                events_list[offset:],
+            ):
+                (
+                    q_nope,
+                    k_nope,
+                    q_pe,
+                    k_pe,
+                    num_heads,
+                    num_kv_heads,
+                    input_layout,
+                    attn_mask,
+                    sparse_mode,
+                    scale,
+                    block_table,
+                    block_size,
+                    seq_lens_list,
+                    actual_seq_lengths,
+                    attn_output,
+                    softmax_lse,
+                    dequant_scale_q_nope,
+                    fak_descale_float,
+                ) = param
+                seq_lens_list = getattr(metadata.decode, "seq_lens_list", None)
+                if seq_lens_list is None:
+                    seq_lens_list = self._to_int_list(metadata.decode.seq_lens)
+                actual_seq_lengths = getattr(metadata.decode, "actual_seq_lengths_q", None)
+                if actual_seq_lengths is None:
+                    query_start_loc = getattr(metadata.decode, "query_start_loc_cpu", None)
+                    if query_start_loc is None:
+                        query_start_loc = getattr(metadata.decode, "query_start_loc", None)
+                    actual_seq_lengths = self._to_int_list(
+                        query_start_loc[1:] if query_start_loc is not None else None
+                    )
+                if actual_seq_lengths is None:
+                    continue
+
+                block_table = metadata.decode.block_table
+                spec_config = self.speculative_config
+                if spec_config and spec_config.disable_padded_drafter_batch:
+                    block_table = block_table[: len(actual_seq_lengths)]
+                seq_lens_list = seq_lens_list + [0] * (len(actual_seq_lengths) - len(seq_lens_list))
+
+                torch.npu.graph_task_update_begin(self.update_stream, handle)
+                extra_args = {}
+                if dequant_scale_q_nope is not None:
+                    extra_args = {
+                        "query_quant_mode": 3,
+                        "key_quant_mode": 0,
+                        "value_quant_mode": 0,
+                        "dequant_scale_query": dequant_scale_q_nope,
+                        "dequant_scale_key": fak_descale_float,
+                        "dequant_scale_value": fak_descale_float,
+                    }
+                torch_npu.npu_fused_infer_attention_score_v2.out(
+                    q_nope,
+                    k_nope,
+                    k_nope,
+                    query_rope=q_pe,
+                    key_rope=k_pe,
+                    num_query_heads=num_heads,
+                    num_key_value_heads=num_kv_heads,
+                    input_layout=input_layout,
+                    atten_mask=attn_mask,
+                    sparse_mode=sparse_mode,
+                    softmax_scale=scale,
+                    block_table=block_table,
+                    block_size=block_size,
+                    actual_seq_qlen=actual_seq_lengths,
+                    actual_seq_kvlen=seq_lens_list,
+                    workspace=graph_params.workspaces.get(num_tokens),
+                    out=[attn_output, softmax_lse],
+                    **extra_args,
+                )
+                torch.npu.graph_task_update_end(self.update_stream)
+                event.record(self.update_stream)
+
+    def _update_fused_mtp_graph_params_for_replay(
+        self,
+        forward_context,
+        num_tokens: int,
+        draft_layer_names: list[str],
+    ) -> None:
+        if self.drafter is None or not draft_layer_names:
+            return
+        if forward_context is None or forward_context.attn_metadata is None:
+            return
+        self._inject_mtp_metadata_stubs(forward_context, num_tokens)
+        draft_attn_metadatas = getattr(forward_context, "draft_attn_metadatas", None)
+        if not draft_attn_metadatas:
+            return
+        if getattr(self, "use_sparse", False):
+            self._update_mtp_graph_params_sparse(
+                forward_context,
+                num_tokens,
+                draft_attn_metadatas,
+                draft_layer_names,
+            )
+        self._update_fused_mtp_draft_graph_params(forward_context, num_tokens, draft_attn_metadatas)
+
+    def _update_fused_mtp_draft_graph_params(
+        self,
+        forward_context,
+        num_tokens: int,
+        draft_attn_metadatas: list[dict],
+    ) -> None:
+        if self.drafter is None or not draft_attn_metadatas:
+            return
+        update_fn = getattr(self.drafter, "_update_full_graph_params", None)
+        if update_fn is None:
+            return
+        saved_is_draft_model = getattr(forward_context, "is_draft_model", False)
+        forward_context.is_draft_model = True
+        try:
+            update_fn(forward_context, num_tokens, draft_attn_metadatas)
+        finally:
+            forward_context.is_draft_model = saved_is_draft_model
+
     def _use_aclgraph(self) -> bool:
         return (
             self.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
@@ -612,9 +1654,12 @@ class NPUModelRunner(GPUModelRunner):
 
     def get_model(self) -> nn.Module:
         # get raw model out of the aclgraph wrapper.
-        if isinstance(self.model, ACLGraphWrapper):
-            return self.model.unwrap()
-        return self.model
+        model = self.model
+        if isinstance(model, ACLGraphWrapper):
+            model = model.unwrap()
+        if isinstance(model, _FusedModelWithMTP):
+            model = model.raw_model
+        return model
 
     def _update_states(self, scheduler_output: "SchedulerOutput") -> Callable | None:
         # Temporary rewind guard for KV-load-failure recompute.
@@ -1414,7 +2459,7 @@ class NPUModelRunner(GPUModelRunner):
         if self.use_async_spec_decode:
             # Stash for GPU-side correction in _prepare_inputs.
             self.valid_sampled_token_count_gpu = valid_sampled_tokens_count # type: ignore[no-redef]
-        self.input_batch.prev_sampled_token_ids = next_token_ids.unsqueeze(1)
+        self._set_prev_sampled_token_ids(next_token_ids)
 
     # TODO: Once the PCP features are complete, it will fully inherit the classes from the VLLM community.
     def propose_draft_token_ids(
@@ -1468,7 +2513,7 @@ class NPUModelRunner(GPUModelRunner):
 
             # only async scheduling, set prev_sampled_token_ids，
             if self.use_async_scheduling:
-                self.input_batch.prev_sampled_token_ids = next_token_ids.unsqueeze(1)
+                self._set_prev_sampled_token_ids(next_token_ids)
 
             # save num_valid_draft_tokens for scheduler trim
             self._num_valid_draft_tokens = num_valid_draft_tokens
@@ -1658,6 +2703,7 @@ class NPUModelRunner(GPUModelRunner):
             scheduler_output.has_structured_output_requests
             or self.input_batch.sampling_metadata.output_token_ids
         ):
+            self._draft_token_req_ids = None
             return
         self._draft_token_req_ids = self.input_batch.req_ids.copy()
 
@@ -1973,6 +3019,8 @@ class NPUModelRunner(GPUModelRunner):
                 else total_num_scheduled_tokens,
                 intermediate_tensors,
             )
+            if self._fused_mtp_wrapper is not None and cudagraph_mode == CUDAGraphMode.FULL:
+                self._pad_fused_mtp_graph_inputs(total_num_scheduled_tokens, num_tokens_padded)
 
             # update global cos, sin
             update_cos_sin(positions)
@@ -1987,7 +3035,13 @@ class NPUModelRunner(GPUModelRunner):
             cudagraph_mode = CUDAGraphMode.NONE
             # Mark KV scales as calculated after the first forward pass
             self.calculate_kv_scales = False  # type: ignore[has-type]
-        if self.ascend_config.enable_async_exponential:
+        if (
+            self.ascend_config.enable_async_exponential
+            and not (
+                cudagraph_mode == CUDAGraphMode.FULL
+                and self._can_use_fused_mtp_graph_sampling_batch(batch_desc)
+            )
+        ):
             self.sampler.do_async_exponential(
                 b_s=logits_indices.shape[0],
                 head_dim=self.model_config.get_vocab_size(),
@@ -2024,8 +3078,46 @@ class NPUModelRunner(GPUModelRunner):
                 ),
             ) as kv_connector_output,
         ):
-            if self.cache_config.mamba_cache_mode == "align":
-                mamba_utils.do_mamba_copy_block(preprocess_bufs)
+            self._fused_mtp_graph_outputs_ready = False
+            self._fused_mtp_runtime_common_attn_metadata = None
+            if self._fused_mtp_wrapper is not None:
+                fused_mtp_graph_batch = (
+                    cudagraph_mode == CUDAGraphMode.FULL
+                    and self._can_use_fused_mtp_graph_sampling_batch(batch_desc)
+                )
+                self._fused_mtp_wrapper.capture_mtp_enabled = fused_mtp_graph_batch
+                if fused_mtp_graph_batch:
+                    self._fused_mtp_runtime_common_attn_metadata = spec_decode_common_attn_metadata
+                self._prepare_fused_mtp_runtime_buffers(
+                    logits_indices,
+                    spec_decode_metadata,
+                    spec_decode_common_attn_metadata,
+                    num_tokens_padded,
+                )
+                if (
+                    cudagraph_mode == CUDAGraphMode.FULL
+                    and self.drafter is not None
+                    and hasattr(self.drafter, "draft_attn_groups")
+                    and len(self.drafter.draft_attn_groups) > 0
+                    and fused_mtp_graph_batch
+                ):
+                    if self._needs_fused_mtp_capture_metadata(batch_desc):
+                        self._build_and_inject_mtp_attn_metadata(
+                            get_forward_context(),
+                            num_tokens_padded,
+                            num_reqs_padded,
+                            cudagraph_mode,
+                        )
+                    else:
+                        draft_layer_names = getattr(self.drafter, "attn_layer_names", None)
+                        if draft_layer_names:
+                            self._update_fused_mtp_graph_params_for_replay(
+                                get_forward_context(),
+                                num_tokens_padded,
+                                draft_layer_names,
+                            )
+                    self._fused_mtp_graph_outputs_ready = True
+
             hidden_states = self._model_forward(
                 num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds, **model_kwargs
             )
@@ -2062,17 +3154,27 @@ class NPUModelRunner(GPUModelRunner):
                     return output
 
                 sample_hidden_states = hidden_states[logits_indices]
-                logits = self.model.compute_logits(sample_hidden_states)
+                runtime_positions = positions[0] if positions.ndim > 1 else positions
+                sample_positions = runtime_positions[logits_indices]
+                logits = (
+                    None
+                    if self._should_defer_fused_mtp_logits(spec_decode_metadata)
+                    else self.model.compute_logits(sample_hidden_states)
+                )
             else:
                 # Rare case.
                 assert not self.is_pooling_model
 
                 if not get_pp_group().is_last_rank:
                     sample_hidden_states = hidden_states[logits_indices]
+                    runtime_positions = positions[0] if positions.ndim > 1 else positions
+                    sample_positions = runtime_positions[logits_indices]
                     get_pp_group().send_tensor_dict(hidden_states.tensors, all_gather_group=get_tp_group())
                     logits = None
                 else:
                     sample_hidden_states = hidden_states[logits_indices]
+                    runtime_positions = positions[0] if positions.ndim > 1 else positions
+                    sample_positions = runtime_positions[logits_indices]
                     logits = self.model.compute_logits(sample_hidden_states)
 
                 model_output_broadcast_data: dict[str, Any] = {}
@@ -2092,6 +3194,7 @@ class NPUModelRunner(GPUModelRunner):
                 spec_decode_common_attn_metadata,
                 hidden_states,
                 sample_hidden_states,
+                sample_positions,
                 aux_hidden_states,
                 attn_metadata,
                 positions,
@@ -2140,6 +3243,7 @@ class NPUModelRunner(GPUModelRunner):
             spec_decode_common_attn_metadata,
             hidden_states,
             sample_hidden_states,
+            sample_positions,
             aux_hidden_states,
             attn_metadata,
             positions,
@@ -2152,6 +3256,7 @@ class NPUModelRunner(GPUModelRunner):
 
         # Apply structured output bitmasks if present.
         if grammar_output is not None:
+            logits = self._compute_deferred_logits(logits, sample_hidden_states)
             # here we are different from gpu_model_runner,
             # the apply_grammar_bitmask uses torch.compile to optimize this,ascend does not support it now
             logits_dtype = logits.dtype
@@ -2159,8 +3264,14 @@ class NPUModelRunner(GPUModelRunner):
             apply_grammar_bitmask(scheduler_output, grammar_output, self.input_batch, logits)
             logits = logits.to(self.device).to(logits_dtype)
 
+        use_fused_mtp_graph_path = self._can_use_fused_mtp_draft_path(grammar_output, spec_decode_metadata)
+        self._used_fused_mtp_graph_sampler_output = use_fused_mtp_graph_path
         with record_function_or_nullcontext("sample_token"):
-            sampler_output = self._sample(logits, spec_decode_metadata)
+            if use_fused_mtp_graph_path:
+                sampler_output = self._build_fused_mtp_sampler_output()
+            else:
+                logits = self._compute_deferred_logits(logits, sample_hidden_states)
+                sampler_output = self._sample(logits, spec_decode_metadata, sample_positions)
 
         if self.need_accepted_tokens:
             if self.sampling_done_event is None:
@@ -2169,9 +3280,27 @@ class NPUModelRunner(GPUModelRunner):
             assert self.sampling_done_event is not None
             self.sampling_done_event.record()
 
+        self._draft_token_ids = None
+        self._draft_token_req_ids = None
         self.valid_sampled_token_count_gpu: torch.Tensor | None = None # type: ignore[no-redef]
+        self.input_batch.prev_sampled_token_ids = None
 
         def propose_draft_token_ids(sampled_token_ids):
+            if (
+                use_fused_mtp_graph_path
+                and self._fused_mtp_wrapper is not None
+                and isinstance(sampled_token_ids, torch.Tensor)
+                and spec_decode_common_attn_metadata is not None
+            ):
+                wrapper = self._fused_mtp_wrapper
+                num_reqs = self.input_batch.num_reqs
+                next_token_ids = wrapper.next_token_ids_buf[:num_reqs]
+                valid_sampled_tokens_count = wrapper.valid_sampled_tokens_count_buf[:num_reqs]
+                self._copy_valid_sampled_token_count(next_token_ids, valid_sampled_tokens_count)
+                draft_ids = wrapper.draft_token_ids_buf[:num_reqs]
+                self._materialize_fused_draft_token_ids(scheduler_output, draft_ids)
+                return
+
             assert spec_decode_common_attn_metadata is not None
             self._draft_token_ids = self.propose_draft_token_ids(
                 sampled_token_ids,
@@ -2331,13 +3460,15 @@ class NPUModelRunner(GPUModelRunner):
         return async_output
 
     # overwrite _sample for lmhead_tp_enable and need_accepted_tokens
-    def _sample(self, logits, spec_decode_metadata):
+    def _sample(self, logits, spec_decode_metadata, sample_positions):
         # Sample the next token and get logprobs if needed.
         sampling_metadata = self.input_batch.sampling_metadata
         self.input_batch.update_async_output_token_ids()
         if spec_decode_metadata is None:
             if lmhead_tp_enable() and logits is not None:
                 logits = logits[: self.input_batch.num_reqs]
+                sample_positions = sample_positions[: self.input_batch.num_reqs]
+            self._attach_sampling_runtime_metadata(sampling_metadata, sample_positions, spec_decode_metadata)
             if self.input_batch.sampling_metadata.top_k is not None and get_ascend_config().enable_reduce_sample:
                 max_topk = self.input_batch.top_k_cpu[self.input_batch.top_k_cpu < logits.shape[1]].max()
                 self.sampler.prepare_sampling(max_topk)
@@ -2348,6 +3479,11 @@ class NPUModelRunner(GPUModelRunner):
 
         if lmhead_tp_enable() and logits is not None:
             logits = logits[: len(spec_decode_metadata.logits_indices)]
+            sample_positions = sample_positions[: len(spec_decode_metadata.logits_indices)]
+        if self.use_async_scheduling and self._draft_token_req_ids is not None:
+            draft_token_ids_cpu, _ = self._get_draft_token_ids_cpu()
+            self.input_batch.update_async_spec_token_ids(draft_token_ids_cpu)
+        self._attach_sampling_runtime_metadata(sampling_metadata, sample_positions, spec_decode_metadata)
         if self.input_batch.sampling_metadata.top_k is not None and get_ascend_config().enable_reduce_sample:
             max_topk = self.input_batch.top_k_cpu[self.input_batch.top_k_cpu < logits.shape[1]].max()
             self.rejection_sampler.prepare_sampling(max_topk)
@@ -2379,10 +3515,11 @@ class NPUModelRunner(GPUModelRunner):
     ]:
         # TODO: implement PR 28597 from vllm
         discard_sampled_tokens_req_indices = self.discard_request_indices.np[: self.num_discarded_requests]
-        for i in discard_sampled_tokens_req_indices:
-            gen = self.input_batch.generators.get(int(i))
-            if gen is not None:
-                gen.set_offset(gen.get_offset() - 4)
+        if not self._used_fused_mtp_graph_sampler_output:
+            for i in discard_sampled_tokens_req_indices:
+                gen = self.input_batch.generators.get(int(i))
+                if gen is not None:
+                    gen.set_offset(gen.get_offset() - 4)
 
         # Copy some objects so they don't get modified after returning.
         # This is important when using async scheduling.
@@ -2642,11 +3779,23 @@ class NPUModelRunner(GPUModelRunner):
     ) -> tuple[CUDAGraphMode, BatchDescriptor, bool, torch.Tensor | None, CUDAGraphStat | None]:
         num_tokens_padded = self._pad_for_sequence_parallelism(num_tokens)
         is_all_decode = np.all(self.input_batch.num_computed_tokens_cpu[:num_reqs] > 0)
+        partial_decode_graph_tokens = self._get_fused_mtp_partial_decode_graph_tokens(
+            num_tokens,
+            num_reqs,
+            max_num_scheduled_tokens,
+            bool(is_all_decode),
+            force_uniform_decode,
+        )
+        if partial_decode_graph_tokens is not None:
+            num_tokens_padded = partial_decode_graph_tokens
         uniform_decode = (
             (
-                (is_all_decode if self.speculative_config else True)
-                and (max_num_scheduled_tokens == self.uniform_decode_query_len)
-                and (num_tokens == max_num_scheduled_tokens * num_reqs)
+                partial_decode_graph_tokens is not None
+                or (
+                    (is_all_decode if self.speculative_config else True)
+                    and (max_num_scheduled_tokens == self.uniform_decode_query_len)
+                    and (num_tokens == max_num_scheduled_tokens * num_reqs)
+                )
             )
             if force_uniform_decode is None
             else force_uniform_decode
@@ -3304,6 +4453,8 @@ class NPUModelRunner(GPUModelRunner):
                 if hasattr(self.drafter, "model") and hasattr(self.drafter.model, "compute_logits"):
                     return self.drafter.model.compute_logits(hidden_states[dummy_indices])
 
+            fused_mtp_graph_batch = False
+            fused_mtp_draft_warmup_batch = False
             with set_ascend_forward_context(
                 attn_metadata,
                 self.vllm_config,
@@ -3317,6 +4468,40 @@ class NPUModelRunner(GPUModelRunner):
                 has_sinks = self._has_sinks,
                 input_ids=input_ids,
             ):
+                fused_mtp_graph_batch = (
+                    self._fused_mtp_wrapper is not None
+                    and self._fused_mtp_full_graph_enabled()
+                    and cudagraph_runtime_mode == CUDAGraphMode.FULL
+                    and self._is_fused_mtp_uniform_decode_graph_batch(batch_desc)
+                )
+                fused_mtp_draft_warmup_batch = self._should_warmup_fused_mtp_drafter(
+                    batch_desc,
+                    cudagraph_runtime_mode,
+                )
+                if self._fused_mtp_wrapper is not None:
+                    self._fused_mtp_wrapper.capture_mtp_enabled = fused_mtp_graph_batch
+                    if fused_mtp_graph_batch:
+                        self._prepare_fused_mtp_capture_buffers(num_tokens_padded)
+                        if (
+                            self.drafter is not None
+                            and hasattr(self.drafter, "draft_attn_groups")
+                            and len(self.drafter.draft_attn_groups) > 0
+                        ):
+                            if self._needs_fused_mtp_capture_metadata(batch_desc):
+                                self._build_and_inject_mtp_attn_metadata(
+                                    get_forward_context(),
+                                    num_tokens_padded,
+                                    num_reqs_padded,
+                                    cudagraph_runtime_mode,
+                                )
+                            else:
+                                draft_layer_names = getattr(self.drafter, "attn_layer_names", None)
+                                if draft_layer_names:
+                                    self._update_fused_mtp_graph_params_for_replay(
+                                        get_forward_context(),
+                                        num_tokens_padded,
+                                        draft_layer_names,
+                                    )
                 outputs = self._model_forward(
                     num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds
                 )
@@ -3327,17 +4512,23 @@ class NPUModelRunner(GPUModelRunner):
             dummy_compute_logits(hidden_states)
 
             if self.drafter:
-                self.drafter.dummy_run(
-                    num_tokens=num_tokens_padded,
-                    with_prefill=with_prefill,
-                    num_reqs=num_reqs_padded,
-                    num_tokens_across_dp=num_tokens_across_dp,
-                    aclgraph_runtime_mode=cudagraph_runtime_mode,
-                    batch_descriptor=batch_desc,
-                    dummy_compute_logits=dummy_drafter_compute_logits,
-                    in_graph_capturing=not force_attention,
-                    is_profile=is_profile,
-                )
+                if self._fused_mtp_wrapper is not None and not fused_mtp_draft_warmup_batch:
+                    dummy_drafter_compute_logits(hidden_states)
+                else:
+                    draft_aclgraph_runtime_mode = (
+                        CUDAGraphMode.FULL if fused_mtp_draft_warmup_batch else cudagraph_runtime_mode
+                    )
+                    self.drafter.dummy_run(
+                        num_tokens=num_tokens_padded,
+                        with_prefill=with_prefill,
+                        num_reqs=num_reqs_padded,
+                        num_tokens_across_dp=num_tokens_across_dp,
+                        aclgraph_runtime_mode=draft_aclgraph_runtime_mode,
+                        batch_descriptor=batch_desc,
+                        dummy_compute_logits=dummy_drafter_compute_logits,
+                        in_graph_capturing=(not force_attention) and not fused_mtp_draft_warmup_batch,
+                        is_profile=is_profile,
+                    )
             if is_profile and self.dynamic_eplb:
                 target = self.model.language_model if hasattr(self.model, "language_model") else self.model
                 target.clear_all_moe_loads()
@@ -3422,6 +4613,14 @@ class NPUModelRunner(GPUModelRunner):
                 logger.info("Loading drafter model...")
                 if self.vllm_config.quant_config is not None:
                     patch_load_weights(self.vllm_config)
+                if (
+                    self._fused_mtp_full_graph_enabled()
+                    and self.speculative_config is not None
+                    and self.speculative_config.method == "mtp"
+                    and isinstance(self.drafter, AscendEagleProposer)
+                    and get_pp_group().is_last_rank
+                ):
+                    self.drafter.fused_with_main_graph = True
                 with get_tp_context(self.drafter):
                     self.drafter.load_model(self.model)
                 if self.use_aux_hidden_state_outputs:
@@ -3444,8 +4643,23 @@ class NPUModelRunner(GPUModelRunner):
         # wrap the model with full graph wrapper if needed.
         if self.compilation_config.cudagraph_mode.has_full_cudagraphs():
             self.update_stream: torch.npu.Stream = torch.npu.Stream()
+            runnable = self.model
+            if (
+                self._fused_mtp_full_graph_enabled()
+                and self.speculative_config is not None
+                and self.speculative_config.method == "mtp"
+                and self.drafter is not None
+                and isinstance(self.drafter, AscendEagleProposer)
+                and get_pp_group().is_last_rank
+            ):
+                self._fused_mtp_wrapper = _FusedModelWithMTP(self.model, self.drafter)
+                runnable = self._fused_mtp_wrapper
+                self.drafter.update_stream = self.update_stream
+                logger.info("Fused MTP full graph is enabled.")
+            else:
+                self._fused_mtp_wrapper = None
             self.model = ACLGraphWrapper(
-                self.model,
+                runnable,
                 self.vllm_config,
                 runtime_mode=CUDAGraphMode.FULL,
                 use_eagle=self.use_eagle,
@@ -3777,14 +4991,10 @@ class NPUModelRunner(GPUModelRunner):
         kv_cache_shape_list: list[int],
         kv_cache_dtype_list: list[int],
         page_size_bytes: int,
-        overlap_full_kv_cache: bool = False,
     ):
         reshaped_kv_tensors = []
-        base_storage_offset_bytes = raw_tensor.storage_offset()
-        storage_offset_bytes = base_storage_offset_bytes
-        for idx, (shape, dtype) in enumerate(zip(kv_cache_shape_list, kv_cache_dtype_list)):
-            if overlap_full_kv_cache and idx == 2:
-                storage_offset_bytes = base_storage_offset_bytes
+        storage_offset_bytes = raw_tensor.storage_offset()
+        for shape, dtype in zip(kv_cache_shape_list, kv_cache_dtype_list):
             dtype_size = get_dtype_size(dtype)
             num_element_per_page = (
                 page_size_bytes // dtype_size
@@ -3846,7 +5056,6 @@ class NPUModelRunner(GPUModelRunner):
                         current_kv_cache_spec.head_size)
                     kv_cache_shape_list = [kv_cache_shape]
                     kv_cache_dtype_list = [current_kv_cache_spec.dtype]
-                    overlap_full_kv_cache = False
 
                     if hasattr(current_kv_cache_spec, "scale_dim") and current_kv_cache_spec.scale_dim != 0:
                         indexer_k_shape = kv_cache_shape
@@ -3855,34 +5064,13 @@ class NPUModelRunner(GPUModelRunner):
                                                 current_kv_cache_spec.num_kv_heads,
                                                 current_kv_cache_spec.scale_dim
                                                 )
-                        if get_ascend_device_type() in {AscendDeviceType.A5}:
-                            indexer_full_shape = self.attn_backend.get_kv_cache_shape(
-                                num_blocks, current_kv_cache_spec.block_size,
-                                current_kv_cache_spec.num_kv_heads,
-                                current_kv_cache_spec.head_size
-                                + current_kv_cache_spec.scale_dim
-                                * get_dtype_size(current_kv_cache_spec.scale_dtype))
-                            kv_cache_shape_list = [
-                                indexer_k_shape, indexer_scale_shape, indexer_full_shape
-                            ]
-                            kv_cache_dtype_list = [
-                                current_kv_cache_spec.dtype,
-                                current_kv_cache_spec.scale_dtype,
-                                current_kv_cache_spec.dtype,
-                            ]
-                            overlap_full_kv_cache = True
-                        else:
-                            kv_cache_shape_list = [indexer_k_shape, indexer_scale_shape]
-                            kv_cache_dtype_list = [
-                                current_kv_cache_spec.dtype, current_kv_cache_spec.scale_dtype
-                            ]
-                            overlap_full_kv_cache = False
+                        kv_cache_shape_list = [indexer_k_shape, indexer_scale_shape]
+                        kv_cache_dtype_list = [current_kv_cache_spec.dtype, current_kv_cache_spec.scale_dtype]
 
                     kv_cache = self._adjust_kv_layout(kv_tensor,
                                            kv_cache_shape_list,
                                            kv_cache_dtype_list,
                                            current_kv_cache_spec.page_size_bytes,
-                                           overlap_full_kv_cache=overlap_full_kv_cache,
                                            )
 
                     kv_caches[layer_name] = kv_cache


### PR DESCRIPTION
Base on the closest community commit fcb30beb and apply source-compatible file-level changes while preserving community-only modules that are not wired into the current source runtime path.

Sign-off: calyoung80
Sign-off: BobQiu1981

 ### What this PR does / why we need it?

  This PR ports the fused MTP full-graph support from the current DeepSeek V4 source snapshot onto the closest community baseline, fcb30beb, using a minimal file-level adaptation
  strategy.

  The main goal is to land the fused MTP runtime path needed by the source code while preserving community consistency wherever possible instead of replacing the whole tree with
  the source snapshot.

  Core changes:

  - vllm_ascend/worker/model_runner_v1.py
    Main fused MTP integration:
      - full-graph enable checks
      - fused wrapper creation
      - capture / replay parameter updates
      - runtime buffers
      - graph-internal sampling output handling
      - draft token writeback
      - dtype fixes
      - get_model() unwrap fix

  - vllm_ascend/spec_decode/llm_base_proposer.py
    Adds _FusedModelWithMTP wrapper:
      - target forward + in-graph verifier
      - in-graph sampling
      - MTP draft propose
      - previous hidden-state shape handling

  - vllm_ascend/spec_decode/eagle_proposer.py
    Exposes _FusedModelWithMTP for reuse from model_runner_v1.py.

  - vllm_ascend/sample/sampler.py
    Adds / wires sample_with_runtime_state() for fused-graph runtime-state sampling, reusing gumbel_sample.

  - vllm_ascend/compilation/acl_graph.py
    Adds ACLGraphWrapper.is_captured() so replay can check whether capture metadata already exists.

  Config and env support:

  - vllm_ascend/ascend_config.py
    Adds additional_config.enable_fused_mtp_full_graph.

  - vllm_ascend/envs.py
    Adds VLLM_ASCEND_ENABLE_FUSED_MTP_FULL_GRAPH.

  Model compatibility support:

  - vllm_ascend/models/deepseek_v4.py
    Stores / exposes MTP target hidden states through _mtp_hidden_buffer and get_mtp_target_hidden_states().

  - vllm_ascend/models/deepseek_v4_mtp.py
    Handles fused-path previous_hidden_states in both 2D and expanded forms, fixing the previous [-1, 4, 4096] reshape issue.

  Implementation approach:

  - Files that already exist in community history with content exactly matching the source snapshot were restored from community history.
  - Only files that do not have an exact upstream match were taken directly from source.
  - Generated / packaged artifacts from the source snapshot were intentionally excluded:
      - vllm_ascend/_build_info.py
      - vllm_ascend/_cann_ops_custom/vendors/

  This is needed because the source snapshot is not a clean export of a single upstream commit; it is a mixed snapshot with a small number of non-upstream file variants. A full
  overwrite would unnecessarily discard valid community code.

  ### Does this PR introduce any user-facing change?

  Yes.

  This PR introduces user-facing runtime behavior changes for Ascend-specific fused MTP / speculative decoding paths, especially for DeepSeek V4 related execution.

  User-visible impact may include:

  - different fused graph behavior for MTP execution
  - changed speculative decoding behavior in affected paths
  - new config / env control for fused MTP full-graph mode

  No new public API surface is intentionally introduced beyond the new config/env controls.

  ### How was this patch tested?

  - Identified fcb30beb as the closest community baseline to the source snapshot.
  - Compared file blobs against local community Git history and restored exact upstream-matching file versions where possible.
  - Applied only the required source-only files directly.
  - Ran syntax validation with python -m py_compile on the source-applied files.
  - Reviewed format_ci.log / format_ci_01.log and fixed the issues in the source-applied scope:
      - long-line cleanup in vllm_ascend/worker/model_runner_v1.py
      - removal of unused local variables in the same file

  - Confirmed that remaining shellcheck findings are from existing community shell scripts under csrc/ and are outside the scope of this patch.

  No new unit tests were added in this PR. The work is primarily a source-to-community adaptation for fused MTP full-graph support, and the immediate goal was to preserve required
  runtime behavior while minimizing unrelated divergence from community code.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
