### PR TITLE
[Feature] Support configuring RFork settings via environment variables

### DIFF
--- a/docs/source/user_guide/feature_guide/rfork.md
+++ b/docs/source/user_guide/feature_guide/rfork.md
@@ -31,7 +31,9 @@ The RFork loading flow in the current implementation is:
 
 ## Usage
 
-To enable RFork, pass `--load-format rfork` and provide RFork settings through `--model-loader-extra-config` as a JSON string.
+To enable RFork, pass `--load-format rfork` and provide RFork settings through `--model-loader-extra-config` as a JSON string, or through the corresponding environment variables.
+
+When both are set, `--model-loader-extra-config` takes precedence. Environment variables are used only when the matching JSON field is absent or has an unsupported type.
 
 ### RFork Prerequisites
 
@@ -40,13 +42,13 @@ To enable RFork, pass `--load-format rfork` and provide RFork settings through `
 
 ### Configuration Fields
 
-| Field Name | Type | Description | Allowed Values / Notes |
-|------------|------|-------------|------------------------|
-| **model_url** | String | Logical model identifier used to build the RFork seed key. | Required for RFork transfer. Instances that should share seeds must use the same value. |
-| **model_deploy_strategy_name** | String | Deployment strategy identifier used together with `model_url` to build the seed key. | Required for RFork transfer. Instances that should share seeds must use the same value. |
-| **rfork_scheduler_url** | String | Base URL of the planner service used for seed allocation, release, and heartbeat. | Required for planner-based matching. Example: `http://127.0.0.1:1223`. |
-| **rfork_seed_timeout_sec** | Number | Timeout for waiting until the local seed HTTP service becomes healthy after startup. | Optional. Default: `30`. Must be greater than `0`. |
-| **rfork_seed_key_separator** | String | Separator used when building the RFork seed key string. | Optional. Default: `$`. Keep the same value across compatible instances. |
+| Field Name | Environment Variable | Type | Description | Allowed Values / Notes |
+|------------|----------------------|------|-------------|------------------------|
+| **model_url** | `MODEL_URL` | String | Logical model identifier used to build the RFork seed key. | Required for RFork transfer. Instances that should share seeds must use the same value. |
+| **model_deploy_strategy_name** | `MODEL_DEPLOY_STRATEGY_NAME` | String | Deployment strategy identifier used together with `model_url` to build the seed key. | Required for RFork transfer. Instances that should share seeds must use the same value. |
+| **rfork_scheduler_url** | `RFORK_SCHEDULER_URL` | String | Base URL of the planner service used for seed allocation, release, and heartbeat. | Required for planner-based matching. Example: `http://127.0.0.1:1223`. |
+| **rfork_seed_timeout_sec** | `RFORK_SEED_TIMEOUT_SEC` | Number | Timeout for waiting until the local seed HTTP service becomes healthy after startup. | Optional. Default: `5.0`. Must be greater than `0`. Invalid values fall back to the default. |
+| **rfork_seed_key_separator** | `RFORK_SEED_KEY_SEPARATOR` | String | Separator used when building the RFork seed key string. | Optional. Default: `$`. Keep the same value across compatible instances. |
 
 ### How RFork Matches Seeds
 
@@ -91,17 +93,33 @@ For the first instance, the planner usually has no compatible seed yet, so RFork
 
 For later instances, if the planner can allocate a compatible seed, RFork will try to transfer weights from the existing seed instance before falling back to the default loader.
 
+Using environment variables:
+
+```shell
+export MODEL_URL="<model_url>"
+export MODEL_DEPLOY_STRATEGY_NAME="<deploy_strategy>"
+export RFORK_SCHEDULER_URL="http://<planner_ip>:<planner_port>"
+
+vllm serve <model_path> \
+  --tensor-parallel-size 1 \
+  --served-model-name <served_model_name> \
+  --port <port> \
+  --load-format rfork
+```
+
+Using `--model-loader-extra-config`:
+
 ```shell
 export RFORK_CONFIG='{
-  "model_url": "`<model_url>`",
-  "model_deploy_strategy_name": "`<deploy_strategy>`",
-  "rfork_scheduler_url": "http://`<planner_ip>`:`<planner_port>`"
+  "model_url": "<model_url>",
+  "model_deploy_strategy_name": "<deploy_strategy>",
+  "rfork_scheduler_url": "http://<planner_ip>:<planner_port>"
 }'
 
 vllm serve <model_path> \
   --tensor-parallel-size 1 \
-  --served-model-name `<served_model_name>` \
-  --port `<port>` \
+  --served-model-name <served_model_name> \
+  --port <port> \
   --load-format rfork \
   --model-loader-extra-config "${RFORK_CONFIG}"
 ```

--- a/vllm_ascend/model_loader/rfork/rfork_loader.py
+++ b/vllm_ascend/model_loader/rfork/rfork_loader.py
@@ -15,6 +15,7 @@
 #
 
 import gc
+import os
 import time
 
 import torch
@@ -40,17 +41,23 @@ class RForkModelLoader(BaseModelLoader):
     def __init__(self, load_config: LoadConfig):
         super().__init__(load_config)
         config = load_config.model_loader_extra_config
-        if not isinstance(config, dict):
+        if config is None:
+            config = {}
+        elif not isinstance(config, dict):
             err_msg = "RFork requires --model-loader-extra-config to be a JSON object."
             logger.error(err_msg)
             raise RuntimeError(err_msg)
 
         def _get_extra_config(key: str, default: str = "") -> str:
             value = config.get(key)
+            if value is None or not isinstance(value, str):
+                value = os.environ.get(key.upper())
             return value if isinstance(value, str) and value else default
 
         def _get_extra_config_float(key: str, default: float) -> float:
             value = config.get(key)
+            if value is None:
+                value = os.environ.get(key.upper())
             parsed_value = default
             if isinstance(value, (int, float)):
                 parsed_value = float(value)

--- a/vllm_ascend/model_loader/rfork/seed_protocol.py
+++ b/vllm_ascend/model_loader/rfork/seed_protocol.py
@@ -39,7 +39,8 @@ def get_local_seed_key(
             f"RFork seed key is not set: model_url={model_url!r}, "
             f"model_deploy_strategy_name={model_deploy_strategy_name!r}. "
             "Ensure model_loader_extra_config contains "
-            "`model_url` and `model_deploy_strategy_name`."
+            "`model_url` and `model_deploy_strategy_name`, or set "
+            "MODEL_URL and MODEL_DEPLOY_STRATEGY_NAME."
         )
         logger.error(err_msg)
         raise RuntimeError(err_msg)
@@ -92,7 +93,9 @@ class RForkSeedProtocol:
 
     def _ensure_scheduler_url_set(self) -> None:
         if not self.scheduler_url:
-            raise RuntimeError("rfork_scheduler_url is not set. Cannot interact with the scheduler.")
+            raise RuntimeError(
+                "rfork_scheduler_url is not set. Set it through model_loader_extra_config or RFORK_SCHEDULER_URL."
+            )
 
     def get_seed(self):
         try:


### PR DESCRIPTION
### What this PR does / why we need it?
This PR introduces support for configuring RFork settings via environment variables as fallbacks when they are absent from `--model-loader-extra-config`. It also updates the documentation and error messages to reflect these changes.

Feedback: In `rfork_loader.py`, `isinstance(value, (int, float, str))` will evaluate to `True` for boolean values because `bool` is a subclass of `int` in Python. This can cause boolean values to be incorrectly parsed as `1.0` or `0.0` instead of falling back to the environment variables. An explicit check for `isinstance(value, bool)` should be added.

### Does this PR introduce _any_ user-facing change?
Yes, users can now configure RFork settings using environment variables.

### How was this patch tested?
No tests were added in this PR.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
