### PR TITLE
[CI] Fix ci error `Invalid device ID`

### DIFF
--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -228,6 +228,7 @@ jobs:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
           PYTORCH_NPU_ALLOC_CONF: max_split_size_mb:256
         run: |
+          . /usr/local/Ascend/ascend-toolkit/set_env.sh
           .github/workflows/scripts/run_selected_tests.sh \
             "${{ matrix.group.npu_type }}" \
             "${{ matrix.group.num_npus }}" \


### PR DESCRIPTION
### What this PR does / why we need it?
Fix the error (https://github.com/vllm-project/vllm-ascend/actions/runs/27002883697/job/79688007585?pr=9825#step:15:1321):
```
<vllm.v1.executor.ray_utils.RayWorkerWrapper object at 0xfffab58643e0>)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/python3.12.13/lib/python3.12/site-packages/vllm/v1/executor/ray_utils.py", line 90, in execute_method
      raise e
    File "/usr/local/python3.12.13/lib/python3.12/site-packages/vllm/v1/executor/ray_utils.py", line 80, in execute_method
      return run_method(self, method, args, kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/python3.12.13/lib/python3.12/site-packages/vllm/v1/serial_utils.py", line 510, in run_method
      return func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/python3.12.13/lib/python3.12/site-packages/vllm/v1/worker/worker_base.py", line 317, in init_device
      self.worker.init_device()  # type: ignore
      ^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/__w/vllm-ascend/vllm-ascend/vllm_ascend/worker/worker.py", line 321, in init_device
      self.device = self._init_device()
                    ^^^^^^^^^^^^^^^^^^^
    File "/__w/vllm-ascend/vllm-ascend/vllm_ascend/worker/worker.py", line 262, in _init_device
      torch.npu.set_device(device)
    File "/usr/local/python3.12.13/lib/python3.12/site-packages/torch_npu/npu/utils.py", line 91, in set_device
      torch_npu._C._npu_setDevice(device_id)
  RuntimeError: ExchangeDevice:../torch_npu/csrc/core/npu/sys_ctrl/npu_sys_ctrl.cpp:286 NPU function error: c10_npu::SetDevice(device), error code is 107001
  Error:  2026-06-05-08:18:18 (PID:23942, Device:0, RankID:-1) ERR00100 PTA call acl api failed
  Error: : Invalid device ID.
          Check whether the device ID is valid.
  [PID: 23942] 2026-06-05-08:18:18.244.598 Invalid_Argument(EE1001): The argument is invalid.Reason: Failed to set visible device. The invalid device is 1 and the input visible device is 1.
```

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
