### PR TITLE
[Feature]add update config and reload weights to NPU Worker

### DIFF
--- a/examples/offline_reload_weight.py
+++ b/examples/offline_reload_weight.py
@@ -1,0 +1,50 @@
+from vllm import LLM, RequestOutput, SamplingParams
+
+# Sample prompts.
+prompts = [
+    "Hello, my name is",
+    "The president of the United States is",
+    "The capital of France is",
+    "The future of AI is",
+]
+# Create a sampling params object.
+sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
+
+
+def print_prompts_and_outputs(outputs: list[RequestOutput]) -> None:
+    print("-" * 60)
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        print(f"Prompt:    {prompt!r}")
+        print(f"Output:    {generated_text!r}")
+        print("-" * 60)
+
+
+def main():
+    # Create an LLM without loading real weights
+    llm = LLM(
+        model="Qwen/Qwen3-0.6B",
+        load_format="dummy",
+        enforce_eager=True,
+        tensor_parallel_size=4,
+    )
+    outputs = llm.generate(prompts, sampling_params)
+    print("\nOutputs do not make sense:")
+    print_prompts_and_outputs(outputs)
+
+    # Update load format from `dummy` to `auto`
+    llm.collective_rpc(
+        "update_config", args=({"load_config": {"load_format": "auto"}},)
+    )
+    # Now reload real weights inplace
+    llm.collective_rpc("reload_weights")
+
+    # Check outputs make sense
+    outputs = llm.generate(prompts, sampling_params)
+    print("\nOutputs make sense after loading real weights:")
+    print_prompts_and_outputs(outputs)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/offline_reload_weight.py
+++ b/examples/offline_reload_weight.py
@@ -40,7 +40,7 @@ def main():
 
     # Update load format from `dummy` to `auto`
     llm.collective_rpc(
-        "update_config", args=({"load_config": {"load_format": "auto"}},)
+        "update_config", args=({"load_config": {"load_format": "auto"}})
     )
     # Now reload real weights inplace
     llm.collective_rpc("reload_weights")

--- a/examples/offline_reload_weight.py
+++ b/examples/offline_reload_weight.py
@@ -1,3 +1,8 @@
+import os
+
+os.environ["VLLM_USE_MODELSCOPE"] = "True"
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
 from vllm import LLM, RequestOutput, SamplingParams
 
 # Sample prompts.

--- a/examples/offline_reload_weight.py
+++ b/examples/offline_reload_weight.py
@@ -39,9 +39,7 @@ def main():
     print_prompts_and_outputs(outputs)
 
     # Update load format from `dummy` to `auto`
-    llm.collective_rpc(
-        "update_config", args=({"load_config": {"load_format": "auto"}})
-    )
+    llm.collective_rpc("update_config", args=({"load_config": {"load_format": "auto"}}))
     # Now reload real weights inplace
     llm.collective_rpc("reload_weights")
 

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -1334,6 +1334,33 @@ class TestNPUWorker(TestBase):
             # When both flags are False, return EMPTY_MODEL_RUNNER_OUTPUT directly.
             self.assertEqual(result, mock_empty_output)
 
+    def test_update_config(self):
+        """Test update_config delegates to model_runner.update_config"""
+        from vllm_ascend.worker.worker import NPUWorker
+
+        with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
+            worker = NPUWorker()
+            worker.model_runner = MagicMock()
+
+            overrides = {"load_config": {"load_format": "dummy"}}
+            worker.update_config(overrides)
+
+            worker.model_runner.update_config.assert_called_once_with(overrides)
+
+    def test_reload_weights(self):
+        """Test reload_weights delegates to model_runner.reload_weights"""
+        from vllm_ascend.worker.worker import NPUWorker
+
+        with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
+            worker = NPUWorker()
+            worker.model_runner = MagicMock()
+
+            worker.reload_weights(weights_path="/tmp/weights", is_checkpoint_format=True)
+
+            worker.model_runner.reload_weights.assert_called_once_with(
+                weights_path="/tmp/weights", is_checkpoint_format=True
+            )
+
 
 class TestNPUWorkerWeightUpdate(TestBase):
     def _make_worker(self, engine=None):

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -21,6 +21,7 @@ import copy
 import gc
 import logging
 from types import NoneType
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -1024,6 +1025,12 @@ class NPUWorker(WorkerBase):
 
     def take_draft_token_ids(self) -> DraftTokenIds | None:
         return self.model_runner.take_draft_token_ids()
+
+    def update_config(self, overrides: dict[str, Any]) -> None:
+        self.model_runner.update_config(overrides)
+
+    def reload_weights(self, *args, **kwargs) -> None:
+        self.model_runner.reload_weights(*args, **kwargs)
 
     def check_health(self) -> None:
         import subprocess


### PR DESCRIPTION
### What this PR does / why we need it?
Add missing worker interfaces update_config and reload_weights to NPUWorker, delegating to model_runner which inherits implementations from upstream GPUModelRunner. This addresses part of issue https://github.com/vllm-project/vllm-ascend/issues/4112.

### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
Run examples/offline_reload_weight.py

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
