### PR TITLE
[Test] Fix pp e2e error

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -110,6 +110,9 @@ class NPUPlatform(Platform):
     simple_compile_backend: str = "eager"  # Disable torch.compile()
     ray_device_key: str = "NPU"
     device_control_env_var: str = "ASCEND_RT_VISIBLE_DEVICES"
+    ray_noset_device_env_vars: list[str] = [
+        "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES",
+    ]
     dispatch_key: str = "PrivateUse1"
 
     supported_quantization: list[str] = [


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request adds the `ray_noset_device_env_vars` attribute to the `NPUPlatform` class, specifying `"RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES"` to prevent Ray from automatically setting device environment variables for NPU.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No tests were added in this pull request.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
