### PR TITLE
[CI] Improve re-run workflow

### DIFF
--- a/.github/workflows/pr_e2e_command.yml
+++ b/.github/workflows/pr_e2e_command.yml
@@ -74,9 +74,9 @@ jobs:
         with:
           token: ${{ secrets.PAT_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
-            e2e command triggered. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
+            [Bot]: e2e command triggered. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
           reactions: rocket
 
       - name: Post unauthorized comment
@@ -85,9 +85,9 @@ jobs:
         with:
           token: ${{ secrets.PAT_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
-            e2e command failed: you do not have permission. Only the PR author or users with triage+ permission can trigger /e2e.
+            [Bot]: e2e command failed: you do not have permission. Only the PR author or users with triage+ permission can trigger /e2e.
           reactions: confused
 
       - name: Fail if unauthorized
@@ -168,5 +168,5 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ needs.e2e-test.outputs.notify_comment_id }}
           body: |
-            e2e command ${{ (needs.trigger-selected-tests.result == 'success' || needs.trigger-selected-tests.result == 'skipped') && 'completed successfully' || 'failed' }}. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
+            [Bot]: e2e command ${{ (needs.trigger-selected-tests.result == 'success' || needs.trigger-selected-tests.result == 'skipped') && 'completed successfully' || 'failed' }}.
           reactions: ${{ (needs.trigger-selected-tests.result == 'success' || needs.trigger-selected-tests.result == 'skipped') && 'hooray' || 'confused' }}

--- a/.github/workflows/pr_rerun_command.yml
+++ b/.github/workflows/pr_rerun_command.yml
@@ -66,10 +66,10 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
           body: |
-            rerun command failed: you do not have permission. Only the PR author or users with triage+ permission can trigger /rerun.
+            [Bot]: rerun command failed: you do not have permission. Only the PR author or users with triage+ permission can trigger /rerun.
           reactions: confused
 
-      - name: Re-run failed workflows
+      - name: Re-run failed jobs
         id: rerun
         if: steps.auth.outputs.authorized == 'true'
         env:
@@ -90,12 +90,12 @@ jobs:
           while IFS= read -r RUN; do
             RUN_ID=$(echo "$RUN" | cut -d'|' -f1)
             RUN_NAME=$(echo "$RUN" | cut -d'|' -f2)
-            echo "Re-running $RUN_NAME (ID: $RUN_ID)..."
-            gh api "repos/$REPO/actions/runs/$RUN_ID/rerun" -X POST --silent
+            echo "Re-running failed jobs in $RUN_NAME (ID: $RUN_ID)..."
+            gh api "repos/$REPO/actions/runs/$RUN_ID/rerun-failed-jobs" -X POST --silent
             COUNT=$((COUNT + 1))
           done <<< "$FAILED_RUNS"
 
-          echo "Successfully re-ran $COUNT failed workflow run(s)."
+          echo "Successfully re-ran failed jobs in $COUNT workflow run(s)."
           echo "rerun_count=$COUNT" >> "$GITHUB_OUTPUT"
 
       - name: Comment result on PR
@@ -106,9 +106,9 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
-            rerun completed.
+            [Bot]: rerun completed.
 
-            - **Re-ran**: ${{ steps.rerun.outputs.rerun_count }} failed workflow(s)
+            - **Re-ran failed jobs in**: ${{ steps.rerun.outputs.rerun_count }} workflow run(s)
             - **Ref**: `${{ github.event.client_payload.pull_request.head.sha }}`
             - **Workflow run**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           reactions: hooray

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -558,6 +558,7 @@
     - tests/ut/test_meta_registration.py
     - tests/ut/test_profiling_config.py
     - tests/ut/test_utils.py
+    - tests/ut/test_platform.py
     - tests/e2e/pull_request/one_card/test_qwen3_0_6b.py
     - tests/e2e/pull_request/one_card/test_qwen3_5_0_8b.py
 

--- a/.github/workflows/slash_command_dispatch.yml
+++ b/.github/workflows/slash_command_dispatch.yml
@@ -41,14 +41,17 @@ jobs:
             [
               {
                 "command": "e2e",
+                "permission": "none",
                 "issue_type": "pull-request"
               },
               {
                 "command": "rerun",
+                "permission": "none",
                 "issue_type": "pull-request"
               },
               {
                 "command": "nightly",
+                "permission": "none",
                 "issue_type": "both"
               }
             ]


### PR DESCRIPTION
1. rerun failed job instead of whole workflow
2. bot comment using append way instead of create new comment
3. fix comment permission

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
