### PR TITLE
[Test] Fix e2e test error

### DIFF
--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -222,7 +222,6 @@ jobs:
         if: ${{ matrix.group.npu_type != 'cpu' }}
         env:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
-          PYTORCH_NPU_ALLOC_CONF: max_split_size_mb:256
         run: |
           . /usr/local/Ascend/ascend-toolkit/set_env.sh
           .github/workflows/scripts/run_selected_tests.sh \

--- a/tests/e2e/pull_request/four_card/test_profiling_chunk_performance.py
+++ b/tests/e2e/pull_request/four_card/test_profiling_chunk_performance.py
@@ -38,7 +38,6 @@ BASELINE_TTFT_S = 5.2
     {
         "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
         "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
-        "VLLM_ASCEND_ENABLE_FLASHCOMM1": "1",
     },
 )
 def test_profiling_chunk_ttft_performance() -> None:
@@ -58,6 +57,7 @@ def test_profiling_chunk_ttft_performance() -> None:
         additional_config={
             "profiling_chunk_config": {"enabled": True, "smooth_factor": 0.9},
             "enable_cpu_binding": False,
+            "enable_flashcomm1": True,
         },
         hf_overrides={
             "rope_parameters": {


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes an end-to-end (e2e) test error in `test_profiling_chunk_performance.py` by replacing the deprecated environment variable `VLLM_ASCEND_ENABLE_FLASHCOMM1` with the correct configuration option `enable_flashcomm1` in `additional_config`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested via the updated e2e test `test_profiling_chunk_ttft_performance`.


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
