### PR TITLE
[Test] Drop max_split_size_mb:256 set

### DIFF
--- a/tests/e2e/pull_request/two_card/test_deepseek_multistream_moe.py
+++ b/tests/e2e/pull_request/two_card/test_deepseek_multistream_moe.py
@@ -16,12 +16,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-import os
-
 from tests.e2e.conftest import VllmRunner
-
-os.environ["PYTORCH_NPU_ALLOC_CONF"] = "max_split_size_mb:256"
-os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 
 def test_deepseek_multistream_moe_tp2():

--- a/tests/e2e/pull_request/two_card/test_flashcomm_distributed.py
+++ b/tests/e2e/pull_request/two_card/test_flashcomm_distributed.py
@@ -30,9 +30,6 @@ from vllm.config import KVTransferConfig
 
 from tests.e2e.conftest import VllmRunner
 
-os.environ["PYTORCH_NPU_ALLOC_CONF"] = "max_split_size_mb:256"
-os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
-
 QWEN_DENSE_MODELS = [
     "vllm-ascend/Qwen3-0.6B-W8A8",
 ]

--- a/tests/e2e/pull_request/two_card/test_gpt_oss_distributed.py
+++ b/tests/e2e/pull_request/two_card/test_gpt_oss_distributed.py
@@ -21,14 +21,9 @@
 Run `pytest tests/e2e/pull_request/two_card/test_gpt_oss_distributed.py`.
 """
 
-import os
-
 import pytest
 
 from tests.e2e.conftest import VllmRunner
-
-os.environ["PYTORCH_NPU_ALLOC_CONF"] = "max_split_size_mb:256"
-os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 GPT_OSS_MODELS = [
     "unsloth/gpt-oss-20b-BF16",


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request removes the environment variables `PYTORCH_NPU_ALLOC_CONF` and `VLLM_WORKER_MULTIPROC_METHOD` from several distributed test files, including `test_deepseek_multistream_moe.py`, `test_flashcomm_distributed.py`, and `test_gpt_oss_distributed.py`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
The changes should be tested by running the affected distributed tests on Ascend NPUs to ensure they do not hang or fail.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
