### PR TITLE
[Bugfix] Fix bincount Triton kernel grid overflow with repetition_penalty

### DIFF
--- a/vllm_ascend/ops/triton/bincount.py
+++ b/vllm_ascend/ops/triton/bincount.py
@@ -45,20 +45,17 @@ def token_bin_counts_and_mask_kernel(
 ):
     """Count token occurrences per batch row.
 
-    1D grid: each program iterates over its share of linearized
-    (batch_idx, seq_block_id) blocks to stay within the Triton-Ascend
-    grid-size limit (65535).
+    1D grid with grid-stride loop: each program processes blocks at
+    stride=num_programs to stay within the Triton-Ascend coreDim
+    limit (65535) while distributing work evenly across cores.
     """
     pid = tl.program_id(axis=0)
     num_progs = tl.num_programs(axis=0)
 
     vocab_start_idx = tp_rank * vocab_size
     n_seq_blocks = tl.cdiv(seq_len, SEQ_BLOCK)
-    blocks_per_prog = (total_blocks + num_progs - 1) // num_progs
-    start_block = pid * blocks_per_prog
-    end_block = tl.minimum(start_block + blocks_per_prog, total_blocks)
 
-    for linear_block in tl.range(start_block, end_block):
+    for linear_block in tl.range(pid, total_blocks, num_progs):
         batch_idx = linear_block // n_seq_blocks
         seq_block_id = linear_block - batch_idx * n_seq_blocks
         seq_start = seq_block_id * SEQ_BLOCK
@@ -75,12 +72,10 @@ def token_bin_counts_and_mask_kernel(
         )
 
         local_token = token - vocab_start_idx
-        token_in_range = (pos_mask & (token >= vocab_start_idx)
-                          & (local_token < vocab_size))
+        token_in_range = pos_mask & (token >= vocab_start_idx) & (local_token < vocab_size)
 
         safe_local_token = tl.where(token_in_range, local_token, 0)
-        count_ptr = (batch_counts_start
-                     + safe_local_token * counts_vocab_stride)
+        count_ptr = batch_counts_start + safe_local_token * counts_vocab_stride
         tl.atomic_add(count_ptr, 1, mask=token_in_range)
 
 

--- a/vllm_ascend/ops/triton/bincount.py
+++ b/vllm_ascend/ops/triton/bincount.py
@@ -106,8 +106,7 @@ def get_token_bin_counts_and_mask_triton(
         assert n_rows == num_seqs, f"tokens rows must match num_seqs: tokens.shape[0]={n_rows}, num_seqs={num_seqs}"
     n_rows = num_seqs if num_seqs is not None else n_rows
 
-    # seq_len == 0 is valid for empty decode history; return directly.
-    if n_cols == 0:
+    if n_rows == 0 or n_cols == 0:
         bin_counts = torch.zeros((n_rows, vocab_size), dtype=torch.int32, device=tokens.device)
         return bin_counts, bin_counts > 0
 

--- a/vllm_ascend/ops/triton/bincount.py
+++ b/vllm_ascend/ops/triton/bincount.py
@@ -28,7 +28,7 @@ from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 
 
-@triton.jit
+@triton.jit(do_not_specialize=["batch_size", "seq_len"])
 def token_bin_counts_and_mask_kernel(
     tokens_ptr,
     tokens_batch_stride,
@@ -40,52 +40,48 @@ def token_bin_counts_and_mask_kernel(
     tp_rank,
     counts_batch_stride,
     counts_vocab_stride,
+    total_blocks,
     SEQ_BLOCK: tl.constexpr,
 ):
     """Count token occurrences per batch row.
 
-    2D tiling:
-      - axis=0: core/program group dimension
-      - axis=1: block id dimension
-
-    We linearize (batch_idx, seq_block_id) into a single global block id and
-    distribute blocks across all programs to improve utilization when
-    batch_size is small but seq_len is large (typical prefill).
-
-    Tokens with value >= vocab_size (e.g. padding) are skipped.
+    1D grid: each program iterates over its share of linearized
+    (batch_idx, seq_block_id) blocks to stay within the Triton-Ascend
+    grid-size limit (65535).
     """
-    pid0 = tl.program_id(axis=0)
-    pid1 = tl.program_id(axis=1)
-    progs = tl.num_programs(axis=0)
+    pid = tl.program_id(axis=0)
+    num_progs = tl.num_programs(axis=0)
 
     vocab_start_idx = tp_rank * vocab_size
     n_seq_blocks = tl.cdiv(seq_len, SEQ_BLOCK)
-    linear_block = pid1 * progs + pid0
-    total_blocks = batch_size * n_seq_blocks
-    if linear_block >= total_blocks:
-        return
+    blocks_per_prog = (total_blocks + num_progs - 1) // num_progs
+    start_block = pid * blocks_per_prog
+    end_block = tl.minimum(start_block + blocks_per_prog, total_blocks)
 
-    batch_idx = linear_block // n_seq_blocks
-    seq_block_id = linear_block - batch_idx * n_seq_blocks
-    seq_start = seq_block_id * SEQ_BLOCK
+    for linear_block in tl.range(start_block, end_block):
+        batch_idx = linear_block // n_seq_blocks
+        seq_block_id = linear_block - batch_idx * n_seq_blocks
+        seq_start = seq_block_id * SEQ_BLOCK
 
-    batch_tokens_start = tokens_ptr + batch_idx * tokens_batch_stride
-    batch_counts_start = bin_counts_ptr + batch_idx * counts_batch_stride
+        batch_tokens_start = tokens_ptr + batch_idx * tokens_batch_stride
+        batch_counts_start = bin_counts_ptr + batch_idx * counts_batch_stride
 
-    pos_offsets = seq_start + tl.arange(0, SEQ_BLOCK)
-    pos_mask = pos_offsets < seq_len
-    token = tl.load(
-        batch_tokens_start + pos_offsets * tokens_seq_stride,
-        mask=pos_mask,
-        other=vocab_size + vocab_start_idx,
-    )
+        pos_offsets = seq_start + tl.arange(0, SEQ_BLOCK)
+        pos_mask = pos_offsets < seq_len
+        token = tl.load(
+            batch_tokens_start + pos_offsets * tokens_seq_stride,
+            mask=pos_mask,
+            other=vocab_size + vocab_start_idx,
+        )
 
-    local_token = token - vocab_start_idx
-    token_in_range = pos_mask & (token >= vocab_start_idx) & (local_token < vocab_size)
+        local_token = token - vocab_start_idx
+        token_in_range = (pos_mask & (token >= vocab_start_idx)
+                          & (local_token < vocab_size))
 
-    safe_local_token = tl.where(token_in_range, local_token, 0)
-    count_ptr = batch_counts_start + safe_local_token * counts_vocab_stride
-    tl.atomic_add(count_ptr, 1, mask=token_in_range)
+        safe_local_token = tl.where(token_in_range, local_token, 0)
+        count_ptr = (batch_counts_start
+                     + safe_local_token * counts_vocab_stride)
+        tl.atomic_add(count_ptr, 1, mask=token_in_range)
 
 
 def get_token_bin_counts_and_mask_triton(
@@ -121,21 +117,20 @@ def get_token_bin_counts_and_mask_triton(
     if not tokens.is_contiguous():
         tokens = tokens.contiguous()
 
-    # 2D grid: (progs, blocks_per_prog_group)
-    # Keep axis-0 bounded by vector core count, and distribute (batch, seq_block)
-    # blocks across all programs to increase utilization when n_rows is small.
+    # 1D grid: distribute all (batch, seq_block) work items across
+    # vector cores via a loop inside the kernel.  This avoids the
+    # Triton-Ascend grid-size limit of 65535.
     SEQ_BLOCK = 256
     n_seq_blocks = triton.cdiv(n_cols, SEQ_BLOCK)
     total_blocks = n_rows * n_seq_blocks
-    progs = min(core_num, total_blocks)
-    grid = (progs, triton.cdiv(total_blocks, progs))
+    grid_size = min(core_num, total_blocks)
 
     if get_ascend_config().enable_reduce_sample:
         tp_group = get_tp_group()
         tp_rank = tp_group.rank_in_group
     else:
         tp_rank = 0
-    token_bin_counts_and_mask_kernel[grid](
+    token_bin_counts_and_mask_kernel[(grid_size,)](
         tokens,
         tokens.stride(0),
         tokens.stride(1),
@@ -146,6 +141,8 @@ def get_token_bin_counts_and_mask_triton(
         tp_rank,
         bin_counts.stride(0),
         bin_counts.stride(1),
+        total_blocks,
         SEQ_BLOCK=SEQ_BLOCK,
+        multibuffer=False,
     )
     return bin_counts, bin_counts > 0


### PR DESCRIPTION
## Summary

Fix `RuntimeError: grid should be less than 65536` crash in the V1 model runner when using `repetition_penalty`, `frequency_penalty`, or `presence_penalty` with long prompts or large batch sizes.

**Root cause**: The `token_bin_counts_and_mask_kernel` in `vllm_ascend/ops/triton/bincount.py` used a 2D grid `(progs, ceil(total_blocks / progs))`. Ascend NPU's `rtKernelLaunch` requires `coreDim` (the product of all grid dimensions) to be ≤ 65535. When `num_seqs * ceil(seq_len / 256)` exceeds this limit, the NPU runtime rejects the kernel launch.

## Production-like Reproduction

Simulates the production configuration: 128K context + 384 concurrent requests + a few long prompts + `repetition_penalty`.

Uses Qwen2.5-0.5B with `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` to bypass the context length validation:

```python
import os
os.environ["VLLM_ALLOW_LONG_MAX_MODEL_LEN"] = "1"

from vllm import LLM, SamplingParams

llm = LLM(model="Qwen/Qwen2.5-0.5B-Instruct",
          max_model_len=131072,
          enforce_eager=True,
          trust_remote_code=True,
          max_num_seqs=384)

# 380 short prompts + 4 long prompts with 50K tokens each.
# The prompt_token_ids tensor is padded to [384, 50001],
# because all prompts are padded to the longest one in the batch.
# total_blocks = 384 * ceil(50001 / 256) = 384 * 196 = 75264
# grid product = 48 * 1568 = 75264 > 65535 -> crash
short_prompt = "Hello, tell me a joke"
long_prompt = "word " * 50000
prompts = [short_prompt] * 380 + [long_prompt] * 4

outputs = llm.generate(prompts,
    SamplingParams(max_tokens=8, temperature=0.5, repetition_penalty=1.2))
```

Error:

```text
RuntimeError: operator name is token_bin_counts_and_mask_kernel.
KernelLaunch failed because value 74688 for parameter coreDim is invalid.
Expected value: less than or equal to 65535.
```

Trigger condition:

```text
grid_product = core_num x ceil((num_seqs x ceil(max_prompt_len / 256)) / core_num) > 65535
```

Where `max_prompt_len` is the token count of the longest prompt in the batch, because all prompts are padded to this length.

With a production config using long context like 128K or 256K, a single prompt exceeding ~43K tokens in a batch of 384 is enough to trigger the crash.

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
