### PR TITLE
[Feature] Introduce explicit MTP spec-sampling executor with lifecycle and rollback alignment

### DIFF
--- a/tests/ut/core/test_profiling_chunk.py
+++ b/tests/ut/core/test_profiling_chunk.py
@@ -418,3 +418,34 @@ class TestProfilingChunkScheduler(TestBase):
         scheduler.update_from_output(output, model_output)
 
         self.assertEqual(len(scheduler.running), 3)
+
+    def test_update_from_output_rolls_back_rejected_spec_tokens(self):
+        scheduler = self.create_scheduler()
+        scheduler.num_spec_tokens = 3
+        request = create_requests(num_requests=1, num_tokens=32, max_tokens=16)[0]
+        request.spec_token_ids = [101, 102, 103]
+        request.num_output_placeholders = 3
+        scheduler.add_request(request)
+
+        output = scheduler.schedule()
+        req_id = request.request_id
+        # Simulate one decode token plus three speculative tokens scheduled.
+        output.scheduled_spec_decode_tokens = {req_id: [101, 102, 103]}
+        request.num_computed_tokens = 20
+        request.num_output_placeholders = 3
+
+        model_output = ModelRunnerOutput(
+            req_ids=[req_id],
+            req_id_to_index={req_id: 0},
+            # bonus token included => accepted draft tokens = len(...) - 1 = 1
+            sampled_token_ids=[[200, 201]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        )
+
+        scheduler.update_from_output(output, model_output)
+
+        # 3 draft tokens scheduled, only 1 accepted => 2 rejected
+        self.assertEqual(request.num_computed_tokens, 18)
+        self.assertEqual(request.num_output_placeholders, 1)

--- a/tests/ut/kv_offload/a2/test_remote_decode_lifecycle.py
+++ b/tests/ut/kv_offload/a2/test_remote_decode_lifecycle.py
@@ -144,3 +144,31 @@ def test_prefix_cache_lifecycle():
     model_runner_output.kv_connector_output = KVConnectorOutput(finished_sending={request_remote.request_id})
     scheduler.update_from_output(scheduler_output, model_runner_output)
     assert_scheduler_empty(scheduler)
+
+
+def test_remote_decode_marks_request_for_delayed_send_after_finish():
+    """Remote decode finish should enter the delayed-send lifecycle after the
+    first output update."""
+
+    vllm_config = create_vllm_config(block_size=2, max_num_batched_tokens=32)
+    scheduler = create_scheduler(vllm_config)
+
+    # Prompt uses exactly 2 blocks. One generated token should expand the
+    # committed footprint to 3 blocks.
+    request = create_request(
+        request_id=7,
+        max_tokens=1,
+        num_tokens=4,
+        do_remote_decode=True,
+        block_size=2,
+    )
+
+    scheduler.add_request(request)
+    scheduler_output = scheduler.schedule()
+    model_runner_output = create_model_runner_output(reqs=[request])
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert scheduler.connector is not None
+    connector_scheduler = scheduler.connector.connector_scheduler
+    assert connector_scheduler is not None
+    assert request.request_id in connector_scheduler._reqs_need_send

--- a/tests/ut/kv_offload/a2/test_remote_decode_lifecycle.py
+++ b/tests/ut/kv_offload/a2/test_remote_decode_lifecycle.py
@@ -180,6 +180,7 @@ def test_remote_decode_committed_block_lifecycle_frees_after_finished_sending():
 
     vllm_config = create_vllm_config(block_size=2, max_num_batched_tokens=32)
     scheduler = create_scheduler(vllm_config)
+    start_free_blocks = scheduler.kv_cache_manager.block_pool.free_block_queue.num_free_blocks
 
     request = create_request(
         request_id=8,
@@ -208,6 +209,7 @@ def test_remote_decode_committed_block_lifecycle_frees_after_finished_sending():
     blocks = scheduler.kv_cache_manager.coordinator.single_type_managers[0].req_to_blocks[request_id]
     for block in blocks:
         assert block.ref_cnt == 1
+    assert scheduler.kv_cache_manager.block_pool.free_block_queue.num_free_blocks < start_free_blocks
 
     scheduler.update_from_output(scheduler_output, EMPTY_MODEL_RUNNER_OUTPUT)
 
@@ -218,3 +220,4 @@ def test_remote_decode_committed_block_lifecycle_frees_after_finished_sending():
     scheduler.update_from_output(scheduler_output, model_runner_output)
 
     assert_scheduler_empty(scheduler)
+    assert scheduler.kv_cache_manager.block_pool.free_block_queue.num_free_blocks == start_free_blocks

--- a/tests/ut/kv_offload/a2/test_remote_decode_lifecycle.py
+++ b/tests/ut/kv_offload/a2/test_remote_decode_lifecycle.py
@@ -258,3 +258,43 @@ def test_remote_decode_abort_during_delayed_send_still_frees_after_finished_send
 
     assert_scheduler_empty(scheduler)
     assert scheduler.kv_cache_manager.block_pool.free_block_queue.num_free_blocks == start_free_blocks
+
+
+def test_remote_decode_duplicate_finished_sending_is_idempotent():
+    vllm_config = create_vllm_config(block_size=2, max_num_batched_tokens=32)
+    scheduler = create_scheduler(vllm_config)
+    start_free_blocks = scheduler.kv_cache_manager.block_pool.free_block_queue.num_free_blocks
+
+    request = create_request(
+        request_id=14,
+        max_tokens=1,
+        num_tokens=4,
+        do_remote_decode=True,
+        block_size=2,
+    )
+    request_id = request.request_id
+
+    scheduler.add_request(request)
+
+    scheduler_output = scheduler.schedule()
+    model_runner_output = create_model_runner_output(reqs=[request])
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    scheduler_output = scheduler.schedule()
+    scheduler.update_from_output(scheduler_output, EMPTY_MODEL_RUNNER_OUTPUT)
+
+    # First finished_sending fully frees the request.
+    scheduler_output = scheduler.schedule()
+    model_runner_output = copy.deepcopy(EMPTY_MODEL_RUNNER_OUTPUT)
+    model_runner_output.kv_connector_output = KVConnectorOutput(finished_sending={request_id})
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+    assert_scheduler_empty(scheduler)
+    assert scheduler.kv_cache_manager.block_pool.free_block_queue.num_free_blocks == start_free_blocks
+
+    # Duplicate finished_sending should be a no-op and must not double-free.
+    scheduler_output = scheduler.schedule()
+    model_runner_output = copy.deepcopy(EMPTY_MODEL_RUNNER_OUTPUT)
+    model_runner_output.kv_connector_output = KVConnectorOutput(finished_sending={request_id})
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+    assert_scheduler_empty(scheduler)
+    assert scheduler.kv_cache_manager.block_pool.free_block_queue.num_free_blocks == start_free_blocks

--- a/tests/ut/kv_offload/a2/test_remote_decode_lifecycle.py
+++ b/tests/ut/kv_offload/a2/test_remote_decode_lifecycle.py
@@ -221,3 +221,40 @@ def test_remote_decode_committed_block_lifecycle_frees_after_finished_sending():
 
     assert_scheduler_empty(scheduler)
     assert scheduler.kv_cache_manager.block_pool.free_block_queue.num_free_blocks == start_free_blocks
+
+
+def test_remote_decode_abort_during_delayed_send_still_frees_after_finished_sending():
+    vllm_config = create_vllm_config(block_size=2, max_num_batched_tokens=32)
+    scheduler = create_scheduler(vllm_config)
+    start_free_blocks = scheduler.kv_cache_manager.block_pool.free_block_queue.num_free_blocks
+
+    request = create_request(
+        request_id=11,
+        max_tokens=1,
+        num_tokens=4,
+        do_remote_decode=True,
+        block_size=2,
+    )
+    scheduler.add_request(request)
+    request_id = request.request_id
+
+    scheduler_output = scheduler.schedule()
+    model_runner_output = create_model_runner_output(reqs=[request])
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert scheduler.connector is not None
+    connector_scheduler = scheduler.connector.connector_scheduler
+    assert connector_scheduler is not None
+    assert request_id in connector_scheduler._reqs_need_send
+
+    # Abort after the request has entered delayed-send lifecycle.
+    scheduler.finish_requests(request_id, RequestStatus.FINISHED_ABORTED)
+    assert request.is_finished()
+
+    scheduler_output = scheduler.schedule()
+    model_runner_output = copy.deepcopy(EMPTY_MODEL_RUNNER_OUTPUT)
+    model_runner_output.kv_connector_output = KVConnectorOutput(finished_sending={request_id})
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert_scheduler_empty(scheduler)
+    assert scheduler.kv_cache_manager.block_pool.free_block_queue.num_free_blocks == start_free_blocks

--- a/tests/ut/kv_offload/a2/test_remote_decode_lifecycle.py
+++ b/tests/ut/kv_offload/a2/test_remote_decode_lifecycle.py
@@ -172,3 +172,49 @@ def test_remote_decode_marks_request_for_delayed_send_after_finish():
     connector_scheduler = scheduler.connector.connector_scheduler
     assert connector_scheduler is not None
     assert request.request_id in connector_scheduler._reqs_need_send
+
+
+def test_remote_decode_committed_block_lifecycle_frees_after_finished_sending():
+    """Committed-block sizing should still preserve the delayed-free -> true
+    free lifecycle once finished_sending is reported."""
+
+    vllm_config = create_vllm_config(block_size=2, max_num_batched_tokens=32)
+    scheduler = create_scheduler(vllm_config)
+
+    request = create_request(
+        request_id=8,
+        max_tokens=1,
+        num_tokens=4,
+        do_remote_decode=True,
+        block_size=2,
+    )
+
+    scheduler.add_request(request)
+    request_id = request.request_id
+
+    # Step 1: finish decode, enter delayed-send state.
+    scheduler_output = scheduler.schedule()
+    model_runner_output = create_model_runner_output(reqs=[request])
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert scheduler.connector is not None
+    connector_scheduler = scheduler.connector.connector_scheduler
+    assert connector_scheduler is not None
+    assert request_id in connector_scheduler._reqs_need_send
+
+    # Step 2: scheduler emits finished req id, but blocks still retained.
+    scheduler_output = scheduler.schedule()
+    assert request_id in scheduler_output.finished_req_ids
+    blocks = scheduler.kv_cache_manager.coordinator.single_type_managers[0].req_to_blocks[request_id]
+    for block in blocks:
+        assert block.ref_cnt == 1
+
+    scheduler.update_from_output(scheduler_output, EMPTY_MODEL_RUNNER_OUTPUT)
+
+    # Step 3: finished_sending arrives, scheduler should fully free.
+    scheduler_output = scheduler.schedule()
+    model_runner_output = copy.deepcopy(EMPTY_MODEL_RUNNER_OUTPUT)
+    model_runner_output.kv_connector_output = KVConnectorOutput(finished_sending={request_id})
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert_scheduler_empty(scheduler)

--- a/tests/ut/kv_offload/a2/test_remote_prefill_lifecycle.py
+++ b/tests/ut/kv_offload/a2/test_remote_prefill_lifecycle.py
@@ -235,3 +235,37 @@ def test_remote_prefill_invalid_blocks_finish_request_with_error():
     assert request.status == RequestStatus.FINISHED_ERROR
     output = engine_core_outputs[request.client_index].outputs[0]
     assert output.finish_reason == request.get_finished_reason()
+
+
+def test_remote_prefill_finished_recving_and_invalid_blocks_do_not_leave_stale_state():
+    vllm_config = create_vllm_config()
+    scheduler = create_scheduler(vllm_config)
+
+    block_size = vllm_config.cache_config.block_size
+    request = create_request(
+        request_id=12,
+        num_tokens=block_size * 2,
+        do_remote_prefill=True,
+        block_size=block_size,
+    )
+    request_id = request.request_id
+
+    scheduler.add_request(request)
+    scheduler_output = scheduler.schedule()
+    blocks = scheduler.kv_cache_manager.coordinator.single_type_managers[0].req_to_blocks[request_id]
+    block_ids = {block.block_id for block in blocks}
+
+    model_runner_output = copy.deepcopy(EMPTY_MODEL_RUNNER_OUTPUT)
+    model_runner_output.kv_connector_output = KVConnectorOutput(
+        finished_recving={request_id},
+        invalid_block_ids=block_ids,
+    )
+    engine_core_outputs = scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert request.is_finished()
+    assert request.status == RequestStatus.FINISHED_ERROR
+    output = engine_core_outputs[request.client_index].outputs[0]
+    assert output.finish_reason == request.get_finished_reason()
+    assert request_id not in scheduler.finished_recving_kv_req_ids
+    assert request_id not in scheduler.requests
+    assert request_id not in scheduler.kv_cache_manager.coordinator.single_type_managers[0].req_to_blocks

--- a/tests/ut/kv_offload/a2/test_remote_prefill_lifecycle.py
+++ b/tests/ut/kv_offload/a2/test_remote_prefill_lifecycle.py
@@ -207,3 +207,31 @@ def test_full_block_prompt():
     scheduler.schedule()
 
     assert_scheduler_empty(scheduler)
+
+
+def test_remote_prefill_invalid_blocks_finish_request_with_error():
+    vllm_config = create_vllm_config()
+    scheduler = create_scheduler(vllm_config)
+
+    block_size = vllm_config.cache_config.block_size
+    request = create_request(
+        request_id=9,
+        num_tokens=block_size * 2,
+        do_remote_prefill=True,
+        block_size=block_size,
+    )
+    request_id = request.request_id
+
+    scheduler.add_request(request)
+    scheduler_output = scheduler.schedule()
+    blocks = scheduler.kv_cache_manager.coordinator.single_type_managers[0].req_to_blocks[request_id]
+    block_ids = {block.block_id for block in blocks}
+
+    model_runner_output = copy.deepcopy(EMPTY_MODEL_RUNNER_OUTPUT)
+    model_runner_output.kv_connector_output = KVConnectorOutput(invalid_block_ids=block_ids)
+    engine_core_outputs = scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert request.is_finished()
+    assert request.status == RequestStatus.FINISHED_ERROR
+    output = engine_core_outputs[request.client_index].outputs[0]
+    assert output.finish_reason == request.get_finished_reason()

--- a/tests/ut/kv_offload/a2/test_remote_prefill_lifecycle.py
+++ b/tests/ut/kv_offload/a2/test_remote_prefill_lifecycle.py
@@ -269,3 +269,41 @@ def test_remote_prefill_finished_recving_and_invalid_blocks_do_not_leave_stale_s
     assert request_id not in scheduler.finished_recving_kv_req_ids
     assert request_id not in scheduler.requests
     assert request_id not in scheduler.kv_cache_manager.coordinator.single_type_managers[0].req_to_blocks
+
+
+def test_remote_prefill_partial_invalid_blocks_recompute_after_finished_recving():
+    vllm_config = create_vllm_config(block_size=2, max_num_batched_tokens=32)
+    scheduler = create_scheduler(vllm_config)
+    scheduler.recompute_kv_load_failures = True
+
+    request = create_request(
+        request_id=13,
+        num_tokens=4,
+        do_remote_prefill=True,
+        block_size=2,
+    )
+    request_id = request.request_id
+
+    scheduler.add_request(request)
+    scheduler_output = scheduler.schedule()
+    blocks = scheduler.kv_cache_manager.coordinator.single_type_managers[0].req_to_blocks[request_id]
+    invalid_block_ids = {blocks[-1].block_id}
+
+    model_runner_output = copy.deepcopy(EMPTY_MODEL_RUNNER_OUTPUT)
+    model_runner_output.kv_connector_output = KVConnectorOutput(
+        finished_recving={request_id},
+        invalid_block_ids=invalid_block_ids,
+    )
+    engine_core_outputs = scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert not engine_core_outputs or not engine_core_outputs[0].outputs
+    assert not request.is_finished()
+    assert request_id in scheduler.finished_recving_kv_req_ids
+
+    scheduler_output = scheduler.schedule()
+
+    assert request_id not in scheduler.finished_recving_kv_req_ids
+    assert request_id not in scheduler.failed_recving_kv_req_ids
+    assert len(scheduler.running) == 1
+    assert scheduler.running[0].request_id == request_id
+    assert scheduler_output.num_scheduled_tokens[request_id] > 0

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -14,6 +14,7 @@ import msgspec
 import torch
 import zmq
 from vllm.utils.network_utils import make_zmq_path
+from vllm.v1.request import RequestStatus
 
 fake_engine = types.ModuleType("mooncake.engine")
 fake_engine.TransferEngine = MagicMock()  # type: ignore[attr-defined]
@@ -1068,6 +1069,28 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         delay_free, params = self.scheduler.request_finished(request, [1, 2, 3])
         self.assertFalse(delay_free)
         self.assertIsNone(params)
+
+    def test_request_finished_requires_length_capped_status(self):
+        request = MockRequest(
+            "req1",
+            kv_transfer_params={"do_remote_decode": True},
+            status=RequestStatus.RUNNING,
+        )
+        delay_free, params = self.scheduler.request_finished(request, ([1, 2, 3],))
+        self.assertFalse(delay_free)
+        self.assertIsNone(params)
+
+    def test_request_finished_clips_remote_blocks_to_prompt_span(self):
+        request = MockRequest(
+            "req1",
+            prompt_token_ids=[1, 2, 3, 4],
+            kv_transfer_params={"do_remote_decode": True},
+            status=RequestStatus.FINISHED_LENGTH_CAPPED,
+        )
+        delay_free, params = self.scheduler.request_finished(request, ([1, 2, 3],))
+        self.assertTrue(delay_free)
+        assert params is not None
+        self.assertEqual(params["remote_block_ids"], ([1],))
 
 
 class TestUtils(unittest.TestCase):

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -487,6 +487,25 @@ class TestCoreFunctionality(unittest.TestCase):
         cast(Any, self.thread.task_tracker).update_done_task_count.assert_called_once_with("req1")
         self.mock_queue.task_done.assert_called_once()
 
+    @patch.object(KVCacheRecvingThread, "_send_done_recv_signal")
+    @patch.object(KVCacheRecvingThread, "_send_done_signal_to_free_remote_port")
+    @patch.object(KVCacheRecvingThread, "_transfer_kv_cache_all_groups")
+    def test_handle_request_marks_failure_and_finishes_request(
+        self, mock_transfer, mock_send_free, mock_send_recv
+    ):
+        mock_transfer.side_effect = RuntimeError("transfer failed")
+        mock_send_free.return_value = None
+        mock_send_recv.return_value = None
+        self.thread.task_tracker = MagicMock()
+
+        self.thread._handle_request(self.test_req)
+
+        self.assertIn("req1", self.thread.invalid_block_ids)
+        cast(Any, self.thread.task_tracker).update_done_task_count.assert_called_once_with("req1")
+        mock_send_free.assert_called_once_with("req1", "localhost", {6666: 1})
+        mock_send_recv.assert_called_once_with("req1", "localhost", 6666, {6666: 1})
+        self.mock_queue.task_done.assert_called_once()
+
     @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
     def test_transfer_kv_cache(self, mock_get_meta):
         with patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ascend_config") as mock_config:

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -500,7 +500,8 @@ class TestCoreFunctionality(unittest.TestCase):
 
         self.thread._handle_request(self.test_req)
 
-        self.assertIn("req1", self.thread.invalid_block_ids)
+        self.assertSetEqual(self.thread.invalid_block_ids, {1, 2})
+        self.assertFalse(self.thread._is_failed_recv_request("req1"))
         cast(Any, self.thread.task_tracker).update_done_task_count.assert_called_once_with("req1")
         mock_send_free.assert_called_once_with("req1", "localhost", {6666: 1})
         mock_send_recv.assert_called_once_with("req1", "localhost", 6666, {6666: 1})

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -15,6 +15,7 @@ import torch
 import zmq
 from vllm.utils.network_utils import make_zmq_path
 from vllm.v1.request import RequestStatus
+from vllm.v1.kv_cache_interface import MambaSpec
 
 fake_engine = types.ModuleType("mooncake.engine")
 fake_engine.TransferEngine = MagicMock()  # type: ignore[attr-defined]
@@ -1118,6 +1119,47 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         self.assertEqual(params["num_prompt_blocks"], 2)
         self.assertEqual(params["num_committed_blocks"], 4)
         self.assertEqual(params["remote_block_ids"], ([1, 2, 3, 4],))
+
+    def test_request_finished_all_groups_uses_committed_blocks_for_attention_group(self):
+        class DummyMambaSpec:
+            pass
+
+        kv_cache_groups = [
+            MockKVCacheGroup(kv_cache_spec=MagicMock()),
+            MockKVCacheGroup(kv_cache_spec=DummyMambaSpec()),
+        ]
+        with (
+            patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.init_ascend_config"),
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ascend_config",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.MambaSpec",
+                DummyMambaSpec,
+            ),
+        ):
+            self.scheduler = MooncakeConnectorScheduler(self.config, "test_engine", MockKVCacheConfig(kv_cache_groups))
+
+        self.scheduler.block_size = 2
+        request = MockRequest(
+            "req1",
+            prompt_token_ids=[1, 2, 3, 4],
+            kv_transfer_params={"do_remote_decode": True},
+            status=RequestStatus.FINISHED_LENGTH_CAPPED,
+        )
+        request.output_token_ids = [101, 102, 103]
+
+        delay_free, params = self.scheduler.request_finished(
+            request,
+            ([1, 2, 3, 4, 5], [10, 11, 12]),
+        )
+
+        self.assertTrue(delay_free)
+        assert params is not None
+        self.assertEqual(params["num_prompt_blocks"], 2)
+        self.assertEqual(params["num_committed_blocks"], 4)
+        self.assertEqual(params["remote_block_ids"], ([1, 2, 3, 4], [10, 11, 12]))
 
 
 class TestUtils(unittest.TestCase):

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -1705,6 +1705,7 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
                 "remote_block_ids": ([10, 11], [10, 11]),
                 "local_block_ids": ([20, 21], [20, 21]),
                 "num_prompt_blocks": 6,
+                "num_committed_blocks": 8,
                 "num_external_blocks": 4,
             },
             {
@@ -1721,6 +1722,7 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
                 "remote_block_ids": ([30, 31, 32], [30, 31, 32]),
                 "local_block_ids": ([40, 41], [40, 41]),
                 "num_prompt_blocks": 5,
+                "num_committed_blocks": 7,
                 "num_external_blocks": 4,
             },
         ]
@@ -1745,6 +1747,7 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
                                 local_block_ids=case["local_block_ids"],
                                 num_external_tokens=case["num_external_blocks"] * worker.block_size,
                                 num_prompt_blocks=case["num_prompt_blocks"],
+                                num_committed_blocks=case["num_committed_blocks"],
                                 remote_engine_id=f"remote_{case['name']}_{tp_rank}_{pcp_rank}_{dcp_rank}",
                                 remote_host="localhost",
                                 remote_multi_nodes_meta_mapping={},

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -15,7 +15,6 @@ import torch
 import zmq
 from vllm.utils.network_utils import make_zmq_path
 from vllm.v1.request import RequestStatus
-from vllm.v1.kv_cache_interface import MambaSpec
 
 fake_engine = types.ModuleType("mooncake.engine")
 fake_engine.TransferEngine = MagicMock()  # type: ignore[attr-defined]
@@ -490,9 +489,7 @@ class TestCoreFunctionality(unittest.TestCase):
     @patch.object(KVCacheRecvingThread, "_send_done_recv_signal")
     @patch.object(KVCacheRecvingThread, "_send_done_signal_to_free_remote_port")
     @patch.object(KVCacheRecvingThread, "_transfer_kv_cache_all_groups")
-    def test_handle_request_marks_failure_and_finishes_request(
-        self, mock_transfer, mock_send_free, mock_send_recv
-    ):
+    def test_handle_request_marks_failure_and_finishes_request(self, mock_transfer, mock_send_free, mock_send_recv):
         mock_transfer.side_effect = RuntimeError("transfer failed")
         mock_send_free.return_value = None
         mock_send_recv.return_value = None
@@ -510,9 +507,7 @@ class TestCoreFunctionality(unittest.TestCase):
     @patch.object(KVCacheRecvingThread, "_send_done_recv_signal")
     @patch.object(KVCacheRecvingThread, "_send_done_signal_to_free_remote_port")
     @patch.object(KVCacheRecvingThread, "_transfer_kv_cache_all_groups")
-    def test_handle_request_carries_failure_across_partial_groups(
-        self, mock_transfer, mock_send_free, mock_send_recv
-    ):
+    def test_handle_request_carries_failure_across_partial_groups(self, mock_transfer, mock_send_free, mock_send_recv):
         partial_req = dict(self.test_req)
         partial_req["all_task_done"] = False
         final_req = dict(self.test_req)

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -507,6 +507,37 @@ class TestCoreFunctionality(unittest.TestCase):
         mock_send_recv.assert_called_once_with("req1", "localhost", 6666, {6666: 1})
         self.mock_queue.task_done.assert_called_once()
 
+    @patch.object(KVCacheRecvingThread, "_send_done_recv_signal")
+    @patch.object(KVCacheRecvingThread, "_send_done_signal_to_free_remote_port")
+    @patch.object(KVCacheRecvingThread, "_transfer_kv_cache_all_groups")
+    def test_handle_request_carries_failure_across_partial_groups(
+        self, mock_transfer, mock_send_free, mock_send_recv
+    ):
+        partial_req = dict(self.test_req)
+        partial_req["all_task_done"] = False
+        final_req = dict(self.test_req)
+        final_req["all_task_done"] = True
+
+        mock_transfer.side_effect = [RuntimeError("partial transfer failed")]
+        mock_send_free.return_value = None
+        mock_send_recv.return_value = None
+        self.thread.task_tracker = MagicMock()
+
+        # First partial group fails and records the request as failed, but
+        # does not clear the failure marker because more groups remain.
+        self.thread._handle_request(partial_req)
+        self.assertSetEqual(self.thread.invalid_block_ids, {1, 2})
+        self.assertTrue(self.thread._is_failed_recv_request("req1"))
+        cast(Any, self.thread.task_tracker).update_done_task_count.assert_not_called()
+
+        # Final group for the same request should skip transfer, preserve the
+        # invalid blocks, mark the task done, and clear the failed marker.
+        self.thread._handle_request(final_req)
+        self.assertSetEqual(self.thread.invalid_block_ids, {1, 2})
+        self.assertFalse(self.thread._is_failed_recv_request("req1"))
+        cast(Any, self.thread.task_tracker).update_done_task_count.assert_called_once_with("req1")
+        self.assertEqual(mock_transfer.call_count, 1)
+
     @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
     def test_transfer_kv_cache(self, mock_get_meta):
         with patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ascend_config") as mock_config:

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -208,6 +208,15 @@ class TestGetAndClearFinishedRequests(unittest.TestCase):
         mock_get_clear.assert_called_once()
         self.assertEqual(result, expected_requests)
 
+    def test_get_and_clear_finished_requests_returns_expired_delayed_request(self):
+        current_time = time.time()
+        self.thread.task_tracker.add_req_to_process("req_timeout")
+        self.thread.task_tracker.add_delayed_request("req_timeout", current_time - 100000)
+
+        result = self.thread.get_and_clear_finished_requests()
+
+        self.assertEqual(result, {"req_timeout"})
+
 
 class TestKVCacheSendingThread(unittest.TestCase):
     def test_run_handles_get_meta_and_done_recv_msgs(self):

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -1101,6 +1101,23 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         assert params is not None
         self.assertEqual(params["remote_block_ids"], ([1],))
 
+    def test_request_finished_exposes_committed_block_count(self):
+        self.scheduler.block_size = 2
+        request = MockRequest(
+            "req1",
+            prompt_token_ids=[1, 2, 3, 4],
+            kv_transfer_params={"do_remote_decode": True},
+            status=RequestStatus.FINISHED_LENGTH_CAPPED,
+        )
+        request.output_token_ids = [101, 102, 103]
+
+        delay_free, params = self.scheduler.request_finished(request, ([1, 2, 3, 4, 5],))
+
+        self.assertTrue(delay_free)
+        assert params is not None
+        self.assertEqual(params["num_prompt_blocks"], 2)
+        self.assertEqual(params["num_committed_blocks"], 4)
+
 
 class TestUtils(unittest.TestCase):
     def test_string_to_int64_hash(self):

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -1117,6 +1117,7 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         assert params is not None
         self.assertEqual(params["num_prompt_blocks"], 2)
         self.assertEqual(params["num_committed_blocks"], 4)
+        self.assertEqual(params["remote_block_ids"], ([1, 2, 3, 4],))
 
 
 class TestUtils(unittest.TestCase):

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -218,6 +218,39 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
         self.assertTrue(torch.equal(counts, expected_counts))
         runner.spec_sampling_executor.execute_from_runtime.assert_called_once()
 
+    @patch("vllm_ascend.worker.model_runner_v1.get_tp_group")
+    @patch("torch.distributed.broadcast")
+    def test_sync_mtp_output_counts_across_tp_noop_for_single_tp(self, mock_broadcast, mock_get_tp_group):
+        runner = self._build_runner()
+        runner.speculative_config = SimpleNamespace(method="mtp")
+        mock_get_tp_group.return_value = SimpleNamespace(world_size=1, device_group="tp")
+
+        counts = torch.tensor([2, 1], dtype=torch.int32)
+        result = runner._sync_mtp_output_counts_across_tp(counts)
+
+        self.assertTrue(torch.equal(result, counts))
+        mock_broadcast.assert_not_called()
+
+    @patch("vllm_ascend.worker.model_runner_v1.get_tp_group")
+    @patch("torch.distributed.broadcast")
+    def test_sync_mtp_output_counts_across_tp_broadcasts_from_rank0(
+        self, mock_broadcast, mock_get_tp_group
+    ):
+        runner = self._build_runner()
+        runner.speculative_config = SimpleNamespace(method="mtp")
+        mock_get_tp_group.return_value = SimpleNamespace(world_size=2, device_group="tp")
+
+        def _fill_from_rank0(tensor, src=0, group=None):
+            tensor.copy_(torch.tensor([4, 3], dtype=tensor.dtype))
+
+        mock_broadcast.side_effect = _fill_from_rank0
+        counts = torch.tensor([2, 1], dtype=torch.int32)
+
+        result = runner._sync_mtp_output_counts_across_tp(counts)
+
+        self.assertTrue(torch.equal(result, torch.tensor([4, 3], dtype=torch.int32)))
+        mock_broadcast.assert_called_once()
+
 
 class TestNPUModelRunnerDebugger(unittest.TestCase):
     def _build_runner(self, debugger=None):

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -1,4 +1,5 @@
 import unittest
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -151,6 +152,71 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
         actual_output_token_ids = actual_sampling_metadata.output_token_ids
         self.assertEqual(actual_output_token_ids[0], [1, 2, 3, 6])
         self.assertEqual(actual_output_token_ids[1], [4, 5, 7])
+
+    @patch("torch.npu.current_stream")
+    @patch("torch.npu.stream")
+    def test_copy_valid_sampled_token_count_syncs_host_accepted_counts(
+        self, mock_npu_stream, mock_current_stream
+    ):
+        mock_current_stream.return_value = MagicMock()
+        mock_npu_stream.side_effect = lambda _stream: nullcontext()
+
+        runner = self._build_runner()
+        runner.valid_sampled_token_count_event = MagicMock()
+        runner.valid_sampled_token_count_copy_stream = MagicMock()
+        runner.use_async_spec_decode = False
+        runner.valid_sampled_token_count_cpu = torch.zeros(4, dtype=torch.int32)
+        runner.input_batch = SimpleNamespace(
+            num_accepted_tokens_cpu_tensor=torch.zeros(4, dtype=torch.int32),
+            prev_sampled_token_ids=None,
+        )
+
+        next_token_ids = torch.tensor([11, 12], dtype=torch.int32)
+        valid_counts = torch.tensor([3, 1], dtype=torch.int32)
+
+        runner._copy_valid_sampled_token_count(next_token_ids, valid_counts)
+
+        self.assertTrue(
+            torch.equal(runner.input_batch.num_accepted_tokens_cpu_tensor[:2], valid_counts)
+        )
+        self.assertTrue(
+            torch.equal(runner.input_batch.prev_sampled_token_ids, next_token_ids.unsqueeze(1))
+        )
+
+    @patch("vllm_ascend.worker.model_runner_v1.lmhead_tp_enable")
+    @patch("vllm_ascend.worker.model_runner_v1.get_ascend_config")
+    def test_sample_mtp_returns_executor_counts_explicitly(
+        self, mock_get_ascend_config, mock_lmhead_tp_enable
+    ):
+        mock_lmhead_tp_enable.return_value = False
+        mock_ascend_config = MagicMock()
+        mock_ascend_config.enable_reduce_sample = False
+        mock_get_ascend_config.return_value = mock_ascend_config
+
+        runner = self._build_runner()
+        runner.input_batch = MagicMock()
+        runner.input_batch.sampling_metadata = MagicMock()
+        runner.input_batch.sampling_metadata.top_k = None
+        runner.input_batch.top_k_cpu = None
+        runner.input_batch.num_reqs = 2
+        runner.input_batch.update_async_output_token_ids = MagicMock()
+        runner.speculative_config = SimpleNamespace(method="mtp")
+        runner.num_spec_tokens = 3
+        expected_output = MagicMock()
+        expected_counts = torch.tensor([4, 2], dtype=torch.int32)
+        runner.spec_sampling_executor = MagicMock()
+        runner.spec_sampling_executor.execute_from_runtime.return_value = SimpleNamespace(
+            sampler_output=expected_output,
+            num_output_tokens_per_req=expected_counts,
+        )
+
+        logits = torch.randn(4, 32)
+        spec_decode_metadata = MagicMock()
+        sampler_output, counts = runner._sample(logits, spec_decode_metadata)
+
+        self.assertIs(sampler_output, expected_output)
+        self.assertTrue(torch.equal(counts, expected_counts))
+        runner.spec_sampling_executor.execute_from_runtime.assert_called_once()
 
 
 class TestNPUModelRunnerDebugger(unittest.TestCase):

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -258,6 +258,15 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
         self.assertFalse(runner._step_needs_accepted_tokens(False))
         self.assertTrue(runner._step_needs_accepted_tokens(True))
 
+    def test_step_needs_seq_lens_cpu_sync_requires_spec_step(self):
+        runner = self._build_runner()
+        runner._needs_seq_lens_cpu_sync = True
+        runner.use_async_spec_decode = True
+        runner.valid_sampled_token_count_gpu = torch.tensor([1], dtype=torch.int32)
+
+        self.assertFalse(runner._step_needs_seq_lens_cpu_sync(False, {"req": 0}))
+        self.assertTrue(runner._step_needs_seq_lens_cpu_sync(True, {"req": 0}))
+
     def test_gdn_builder_enables_need_accepted_tokens(self):
         class DummyGDN:
             pass

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -155,9 +155,7 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
 
     @patch("torch.npu.current_stream")
     @patch("torch.npu.stream")
-    def test_copy_valid_sampled_token_count_syncs_host_accepted_counts(
-        self, mock_npu_stream, mock_current_stream
-    ):
+    def test_copy_valid_sampled_token_count_syncs_host_accepted_counts(self, mock_npu_stream, mock_current_stream):
         mock_current_stream.return_value = MagicMock()
         mock_npu_stream.side_effect = lambda _stream: nullcontext()
 
@@ -176,18 +174,12 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
 
         runner._copy_valid_sampled_token_count(next_token_ids, valid_counts)
 
-        self.assertTrue(
-            torch.equal(runner.input_batch.num_accepted_tokens_cpu_tensor[:2], valid_counts)
-        )
-        self.assertTrue(
-            torch.equal(runner.input_batch.prev_sampled_token_ids, next_token_ids.unsqueeze(1))
-        )
+        self.assertTrue(torch.equal(runner.input_batch.num_accepted_tokens_cpu_tensor[:2], valid_counts))
+        self.assertTrue(torch.equal(runner.input_batch.prev_sampled_token_ids, next_token_ids.unsqueeze(1)))
 
     @patch("vllm_ascend.worker.model_runner_v1.lmhead_tp_enable")
     @patch("vllm_ascend.worker.model_runner_v1.get_ascend_config")
-    def test_sample_mtp_returns_executor_counts_explicitly(
-        self, mock_get_ascend_config, mock_lmhead_tp_enable
-    ):
+    def test_sample_mtp_returns_executor_counts_explicitly(self, mock_get_ascend_config, mock_lmhead_tp_enable):
         mock_lmhead_tp_enable.return_value = False
         mock_ascend_config = MagicMock()
         mock_ascend_config.enable_reduce_sample = False
@@ -233,9 +225,7 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
 
     @patch("vllm_ascend.worker.model_runner_v1.get_tp_group")
     @patch("torch.distributed.broadcast")
-    def test_sync_mtp_output_counts_across_tp_broadcasts_from_rank0(
-        self, mock_broadcast, mock_get_tp_group
-    ):
+    def test_sync_mtp_output_counts_across_tp_broadcasts_from_rank0(self, mock_broadcast, mock_get_tp_group):
         runner = self._build_runner()
         runner.speculative_config = SimpleNamespace(method="mtp")
         mock_get_tp_group.return_value = SimpleNamespace(world_size=2, device_group="tp")
@@ -282,8 +272,7 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
             ]
             runner.attn_groups = [fake_group]
             runner.need_accepted_tokens = any(
-                isinstance(attn_group[0].get_metadata_builder(0), DummyGDN)
-                for attn_group in runner.attn_groups
+                isinstance(attn_group[0].get_metadata_builder(0), DummyGDN) for attn_group in runner.attn_groups
             )
 
             self.assertTrue(runner.need_accepted_tokens)

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -251,6 +251,34 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
         self.assertTrue(torch.equal(result, torch.tensor([4, 3], dtype=torch.int32)))
         mock_broadcast.assert_called_once()
 
+    def test_step_needs_accepted_tokens_requires_spec_step(self):
+        runner = self._build_runner()
+        runner.need_accepted_tokens = True
+
+        self.assertFalse(runner._step_needs_accepted_tokens(False))
+        self.assertTrue(runner._step_needs_accepted_tokens(True))
+
+    def test_gdn_builder_enables_need_accepted_tokens(self):
+        class DummyGDN:
+            pass
+
+        runner = self._build_runner()
+        with patch("vllm_ascend.worker.model_runner_v1.GDNAttentionMetadataBuilder", DummyGDN):
+            gdn_builder = DummyGDN()
+            fake_group = [
+                SimpleNamespace(
+                    kv_cache_spec=object(),
+                    get_metadata_builder=MagicMock(return_value=gdn_builder),
+                )
+            ]
+            runner.attn_groups = [fake_group]
+            runner.need_accepted_tokens = any(
+                isinstance(attn_group[0].get_metadata_builder(0), DummyGDN)
+                for attn_group in runner.attn_groups
+            )
+
+            self.assertTrue(runner.need_accepted_tokens)
+
 
 class TestNPUModelRunnerDebugger(unittest.TestCase):
     def _build_runner(self, debugger=None):

--- a/tools/inspect_spec_sampling_case.py
+++ b/tools/inspect_spec_sampling_case.py
@@ -43,4 +43,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/tools/inspect_spec_sampling_case.py
+++ b/tools/inspect_spec_sampling_case.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+import torch
+
+from vllm_ascend.sample.spec_sampling_poc import load_spec_sampling_case
+
+
+def _describe(prefix: str, value: Any) -> list[str]:
+    lines: list[str] = []
+    if torch.is_tensor(value):
+        lines.append(f"{prefix}: tensor shape={list(value.shape)} dtype={value.dtype} device={value.device}")
+        return lines
+    if hasattr(value, "__dataclass_fields__"):
+        lines.append(f"{prefix}: {type(value).__name__}")
+        for name in value.__dataclass_fields__:
+            lines.extend(_describe(f"{prefix}.{name}", getattr(value, name)))
+        return lines
+    if isinstance(value, list):
+        lines.append(f"{prefix}: list len={len(value)}")
+        return lines
+    if isinstance(value, dict):
+        lines.append(f"{prefix}: dict len={len(value)}")
+        return lines
+    lines.append(f"{prefix}: {type(value).__name__} value={repr(value)[:200]}")
+    return lines
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Inspect one dumped spec-sampling case.")
+    parser.add_argument("case_path")
+    args = parser.parse_args()
+
+    case = load_spec_sampling_case(args.case_path)
+    for key in sorted(case.keys()):
+        for line in _describe(key, case[key]):
+            print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tools/run_kv_lifecycle_audit.py
+++ b/tools/run_kv_lifecycle_audit.py
@@ -107,11 +107,38 @@ def run_one_iteration(iteration: int, args: argparse.Namespace) -> dict[str, obj
 def main() -> int:
     args = parse_args()
     records = [run_one_iteration(i, args) for i in range(args.iterations)]
+    passed = True
+    failures: list[dict[str, object]] = []
+    for record in records:
+        final_state = record["states"][-1]
+        ok = (
+            record["start_free_blocks"] == record["end_free_blocks"]
+            and record["delayed_send_marked"] is True
+            and final_state["req_to_blocks"] == {}
+            and final_state["num_requests"] == 0
+        )
+        if not ok:
+            passed = False
+            failures.append(
+                {
+                    "iteration": record["iteration"],
+                    "start_free_blocks": record["start_free_blocks"],
+                    "end_free_blocks": record["end_free_blocks"],
+                    "delayed_send_marked": record["delayed_send_marked"],
+                    "final_state": final_state,
+                }
+            )
+
+    report = {
+        "passed": passed,
+        "iterations": records,
+        "failures": failures,
+    }
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(json.dumps({"iterations": records}, ensure_ascii=False, indent=2), encoding="utf-8")
+    out_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
     print(out_path)
-    return 0
+    return 0 if passed else 1
 
 
 if __name__ == "__main__":

--- a/tools/run_kv_lifecycle_audit.py
+++ b/tools/run_kv_lifecycle_audit.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from pathlib import Path
+
+from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, KVConnectorOutput
+
+from tests.ut.kv_offload.utils import (
+    assert_scheduler_empty,
+    create_model_runner_output,
+    create_request,
+    create_scheduler,
+    create_vllm_config,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a deterministic KV lifecycle audit using the unit-test scheduler helpers."
+    )
+    parser.add_argument("--iterations", type=int, default=20)
+    parser.add_argument("--block-size", type=int, default=16)
+    parser.add_argument("--num-tokens", type=int, default=40)
+    parser.add_argument("--max-num-batched-tokens", type=int, default=1024)
+    parser.add_argument("--out", default="/tmp/kv_lifecycle_audit.json")
+    return parser.parse_args()
+
+
+def snapshot(scheduler, label: str) -> dict[str, object]:
+    manager = scheduler.kv_cache_manager.coordinator.single_type_managers[0]
+    return {
+        "label": label,
+        "free_blocks": scheduler.kv_cache_manager.block_pool.free_block_queue.num_free_blocks,
+        "num_requests": len(scheduler.requests),
+        "running": len(scheduler.running),
+        "waiting": len(scheduler.waiting),
+        "finished_req_ids": sorted(scheduler.finished_req_ids),
+        "req_to_blocks": {
+            req_id: len(blocks)
+            for req_id, blocks in manager.req_to_blocks.items()
+        },
+    }
+
+
+def run_one_iteration(iteration: int, args: argparse.Namespace) -> dict[str, object]:
+    vllm_config = create_vllm_config(
+        max_num_batched_tokens=args.max_num_batched_tokens,
+        block_size=args.block_size,
+    )
+    scheduler = create_scheduler(vllm_config)
+    start_free_blocks = scheduler.kv_cache_manager.block_pool.free_block_queue.num_free_blocks
+
+    request = create_request(
+        request_id=iteration + 1,
+        max_tokens=1,
+        num_tokens=args.num_tokens,
+        do_remote_decode=True,
+        block_size=args.block_size,
+    )
+    request_id = request.request_id
+
+    states: list[dict[str, object]] = [snapshot(scheduler, "start")]
+
+    scheduler.add_request(request)
+    states.append(snapshot(scheduler, "after_add_request"))
+
+    scheduler_output = scheduler.schedule()
+    states.append(snapshot(scheduler, "after_schedule_step1"))
+
+    model_runner_output = create_model_runner_output(reqs=[request])
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+    states.append(snapshot(scheduler, "after_update_from_output_step1"))
+
+    connector_scheduler = scheduler.connector.connector_scheduler if scheduler.connector else None
+    delayed_send_marked = connector_scheduler is not None and request_id in connector_scheduler._reqs_need_send
+
+    scheduler_output = scheduler.schedule()
+    states.append(snapshot(scheduler, "after_schedule_step2"))
+
+    scheduler.update_from_output(scheduler_output, EMPTY_MODEL_RUNNER_OUTPUT)
+    states.append(snapshot(scheduler, "after_update_from_output_step2"))
+
+    scheduler_output = scheduler.schedule()
+    states.append(snapshot(scheduler, "after_schedule_step3"))
+
+    model_runner_output = copy.deepcopy(EMPTY_MODEL_RUNNER_OUTPUT)
+    model_runner_output.kv_connector_output = KVConnectorOutput(finished_sending={request_id})
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+    states.append(snapshot(scheduler, "after_finished_sending"))
+
+    assert_scheduler_empty(scheduler)
+    end_free_blocks = scheduler.kv_cache_manager.block_pool.free_block_queue.num_free_blocks
+
+    return {
+        "iteration": iteration,
+        "request_id": request_id,
+        "start_free_blocks": start_free_blocks,
+        "end_free_blocks": end_free_blocks,
+        "delayed_send_marked": delayed_send_marked,
+        "states": states,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    records = [run_one_iteration(i, args) for i in range(args.iterations)]
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps({"iterations": records}, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(out_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_kv_lifecycle_audit.py
+++ b/tools/run_kv_lifecycle_audit.py
@@ -38,10 +38,7 @@ def snapshot(scheduler, label: str) -> dict[str, object]:
         "running": len(scheduler.running),
         "waiting": len(scheduler.waiting),
         "finished_req_ids": sorted(scheduler.finished_req_ids),
-        "req_to_blocks": {
-            req_id: len(blocks)
-            for req_id, blocks in manager.req_to_blocks.items()
-        },
+        "req_to_blocks": {req_id: len(blocks) for req_id, blocks in manager.req_to_blocks.items()},
     }
 
 
@@ -142,12 +139,7 @@ def main() -> int:
     print(f"failures={len(failures)}")
     if records:
         first = records[0]
-        print(
-            "first_iter="
-            f"{first['start_free_blocks']} "
-            f"{first['end_free_blocks']} "
-            f"{first['delayed_send_marked']}"
-        )
+        print(f"first_iter={first['start_free_blocks']} {first['end_free_blocks']} {first['delayed_send_marked']}")
     print(out_path)
     return 0 if passed else 1
 

--- a/tools/run_kv_lifecycle_audit.py
+++ b/tools/run_kv_lifecycle_audit.py
@@ -137,6 +137,17 @@ def main() -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"passed={passed}")
+    print(f"iterations={len(records)}")
+    print(f"failures={len(failures)}")
+    if records:
+        first = records[0]
+        print(
+            "first_iter="
+            f"{first['start_free_blocks']} "
+            f"{first['end_free_blocks']} "
+            f"{first['delayed_send_marked']}"
+        )
     print(out_path)
     return 0 if passed else 1
 

--- a/tools/run_mtp_spec_sampling_dump.py
+++ b/tools/run_mtp_spec_sampling_dump.py
@@ -12,7 +12,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--model",
-        default="/mnt/hcs/models/DeepSeek-V4-Flash-w8a8-mtp",
+        default="/home/117_share/weight/DeepSeek-V4-Flash-w8a8-mtp",
         help="Local MTP model path inside the runtime environment.",
     )
     parser.add_argument(
@@ -30,6 +30,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--gpu-memory-utilization", type=float, default=0.7)
     parser.add_argument("--max-model-len", type=int, default=2048)
     parser.add_argument("--max-num-seqs", type=int, default=32)
+    parser.add_argument("--tensor-parallel-size", type=int, default=8)
+    parser.add_argument("--pipeline-parallel-size", type=int, default=1)
+    parser.add_argument("--data-parallel-size", type=int, default=1)
+    parser.add_argument("--distributed-executor-backend", default="mp")
+    parser.add_argument("--enable-expert-parallel", action="store_true", default=True)
+    parser.add_argument("--disable-expert-parallel", action="store_true")
+    parser.add_argument("--cudagraph-mode", default="FULL_DECODE_ONLY")
+    parser.add_argument(
+        "--cudagraph-capture-sizes",
+        default="20",
+        help="Comma-separated capture sizes, e.g. 20 or 12,20",
+    )
     return parser.parse_args()
 
 
@@ -46,14 +58,19 @@ def main() -> int:
     from vllm import LLM, SamplingParams
     from vllm.config import CompilationConfig
 
+    capture_sizes = [int(item) for item in args.cudagraph_capture_sizes.split(",") if item.strip()]
+    enable_expert_parallel = args.enable_expert_parallel and not args.disable_expert_parallel
+
     llm = LLM(
         model=args.model,
         trust_remote_code=True,
-        tensor_parallel_size=1,
+        tensor_parallel_size=args.tensor_parallel_size,
+        pipeline_parallel_size=args.pipeline_parallel_size,
+        data_parallel_size=args.data_parallel_size,
         max_num_seqs=args.max_num_seqs,
         gpu_memory_utilization=args.gpu_memory_utilization,
-        distributed_executor_backend="mp",
-        enable_expert_parallel=True,
+        distributed_executor_backend=args.distributed_executor_backend,
+        enable_expert_parallel=enable_expert_parallel,
         speculative_config={
             "method": "mtp",
             "num_speculative_tokens": args.num_speculative_tokens,
@@ -62,8 +79,8 @@ def main() -> int:
         max_model_len=args.max_model_len,
         disable_log_stats=True,
         compilation_config=CompilationConfig(
-            cudagraph_mode="FULL_DECODE_ONLY",
-            cudagraph_capture_sizes=[20],
+            cudagraph_mode=args.cudagraph_mode,
+            cudagraph_capture_sizes=capture_sizes,
         ),
     )
 
@@ -87,4 +104,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/tools/run_mtp_spec_sampling_dump.py
+++ b/tools/run_mtp_spec_sampling_dump.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run one minimal MTP generation and dump one spec-sampling PoC case."
+    )
+    parser.add_argument(
+        "--model",
+        default="/mnt/hcs/models/DeepSeek-V4-Flash-w8a8-mtp",
+        help="Local MTP model path inside the runtime environment.",
+    )
+    parser.add_argument(
+        "--dump-dir",
+        default="/tmp/spec_sampling_poc",
+        help="Directory used by VLLM_ASCEND_SPEC_SAMPLING_POC_DIR.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default="Hello, my name is",
+        help="Single prompt used to trigger one minimal MTP generation.",
+    )
+    parser.add_argument("--max-tokens", type=int, default=16)
+    parser.add_argument("--num-speculative-tokens", type=int, default=3)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.7)
+    parser.add_argument("--max-model-len", type=int, default=2048)
+    parser.add_argument("--max-num-seqs", type=int, default=32)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    os.environ["VLLM_ASCEND_SPEC_SAMPLING_POC_DIR"] = args.dump_dir
+    os.environ["VLLM_ASCEND_SPEC_SAMPLING_POC_MAX_CASES"] = "1"
+    os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+
+    dump_dir = Path(args.dump_dir)
+    dump_dir.mkdir(parents=True, exist_ok=True)
+
+    from vllm import LLM, SamplingParams
+    from vllm.config import CompilationConfig
+
+    llm = LLM(
+        model=args.model,
+        trust_remote_code=True,
+        tensor_parallel_size=1,
+        max_num_seqs=args.max_num_seqs,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        distributed_executor_backend="mp",
+        enable_expert_parallel=True,
+        speculative_config={
+            "method": "mtp",
+            "num_speculative_tokens": args.num_speculative_tokens,
+            "disable_padded_drafter_batch": False,
+        },
+        max_model_len=args.max_model_len,
+        disable_log_stats=True,
+        compilation_config=CompilationConfig(
+            cudagraph_mode="FULL_DECODE_ONLY",
+            cudagraph_capture_sizes=[20],
+        ),
+    )
+
+    outputs = llm.generate(
+        [args.prompt],
+        SamplingParams(
+            temperature=0,
+            max_tokens=args.max_tokens,
+            ignore_eos=False,
+        ),
+    )
+    print(outputs[0].outputs[0].text)
+
+    case_paths = sorted(dump_dir.glob("case_*/case.pt"))
+    if not case_paths:
+        raise RuntimeError(f"No PoC case dumped under {dump_dir}")
+
+    print(f"Dumped PoC case: {case_paths[0]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tools/run_mtp_spec_sampling_dump.py
+++ b/tools/run_mtp_spec_sampling_dump.py
@@ -42,6 +42,7 @@ def parse_args() -> argparse.Namespace:
         default="20",
         help="Comma-separated capture sizes, e.g. 20 or 12,20",
     )
+    parser.add_argument("--enforce-eager", action="store_true")
     return parser.parse_args()
 
 
@@ -54,6 +55,10 @@ def main() -> int:
 
     dump_dir = Path(args.dump_dir)
     dump_dir.mkdir(parents=True, exist_ok=True)
+    (dump_dir / "marker_runner_start.json").write_text(
+        '{"stage":"runner_start"}',
+        encoding="utf-8",
+    )
 
     from vllm import LLM, SamplingParams
     from vllm.config import CompilationConfig
@@ -71,6 +76,7 @@ def main() -> int:
         gpu_memory_utilization=args.gpu_memory_utilization,
         distributed_executor_backend=args.distributed_executor_backend,
         enable_expert_parallel=enable_expert_parallel,
+        enforce_eager=args.enforce_eager,
         speculative_config={
             "method": "mtp",
             "num_speculative_tokens": args.num_speculative_tokens,

--- a/tools/run_mtp_spec_sampling_dump.py
+++ b/tools/run_mtp_spec_sampling_dump.py
@@ -7,9 +7,7 @@ from pathlib import Path
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Run one minimal MTP generation and dump one spec-sampling PoC case."
-    )
+    parser = argparse.ArgumentParser(description="Run one minimal MTP generation and dump one spec-sampling PoC case.")
     parser.add_argument(
         "--model",
         default="/home/117_share/weight/DeepSeek-V4-Flash-w8a8-mtp",

--- a/tools/spec_sampling_npu_poc.py
+++ b/tools/spec_sampling_npu_poc.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+from types import SimpleNamespace
 
 import torch
 
+import vllm_ascend.sample.rejection_sampler as rejection_sampler_module
+import vllm_ascend.sample.sampler as sampler_module
+from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
 from vllm_ascend.sample.rejection_sampler import AscendRejectionSampler
 from vllm_ascend.sample.sampler import AscendSampler
 from vllm_ascend.sample.spec_sampling_poc import load_spec_sampling_case
@@ -37,6 +41,15 @@ def main() -> int:
 
     payload = load_spec_sampling_case(args.case_path)
     device = torch.device(args.device)
+    if args.device == "npu":
+        init_device_properties_triton()
+
+    dummy_ascend_config = SimpleNamespace(
+        enable_reduce_sample=False,
+        enable_async_exponential=False,
+    )
+    sampler_module.get_ascend_config = lambda: dummy_ascend_config
+    rejection_sampler_module.get_ascend_config = lambda: dummy_ascend_config
 
     logits = payload["logits"].to(device)
     draft_probs = payload["draft_probs"]
@@ -74,4 +87,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/tools/spec_sampling_npu_poc.py
+++ b/tools/spec_sampling_npu_poc.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+
+from vllm_ascend.sample.rejection_sampler import AscendRejectionSampler
+from vllm_ascend.sample.sampler import AscendSampler
+from vllm_ascend.sample.spec_sampling_poc import load_spec_sampling_case
+
+
+def _move_tensors(obj, device):
+    if torch.is_tensor(obj):
+        return obj.to(device)
+    if hasattr(obj, "__dataclass_fields__"):
+        kwargs = {name: _move_tensors(getattr(obj, name), device) for name in obj.__dataclass_fields__}
+        return type(obj)(**kwargs)
+    if hasattr(obj, "_fields") and hasattr(obj, "_asdict"):
+        values = {name: _move_tensors(getattr(obj, name), device) for name in obj._fields}
+        return type(obj)(**values)
+    if isinstance(obj, dict):
+        return {key: _move_tensors(value, device) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [_move_tensors(item, device) for item in obj]
+    if isinstance(obj, tuple):
+        return tuple(_move_tensors(item, device) for item in obj)
+    return obj
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Replay one dumped MTP spec-sampling case on NPU.")
+    parser.add_argument("case_path", type=Path, help="Path to case.pt or its containing directory")
+    parser.add_argument("--device", default="npu", help="Replay device, default: npu")
+    args = parser.parse_args()
+
+    payload = load_spec_sampling_case(args.case_path)
+    device = torch.device(args.device)
+
+    logits = payload["logits"].to(device)
+    draft_probs = payload["draft_probs"]
+    draft_probs = None if draft_probs is None else draft_probs.to(device)
+    sampling_metadata = _move_tensors(payload["sampling_metadata"], device)
+    spec_decode_metadata = _move_tensors(payload["spec_decode_metadata"], device)
+    expected = payload["sampler_output"].sampled_token_ids
+    expected = None if expected is None else expected.to(device)
+    prepared_top_k = payload.get("prepared_top_k")
+
+    sampler = AscendSampler()
+    rejection_sampler = AscendRejectionSampler(sampler)
+    rejection_sampler.prepare_sampling(prepared_top_k)
+
+    replay_output = rejection_sampler(
+        spec_decode_metadata,
+        draft_probs,
+        logits,
+        sampling_metadata,
+    )
+
+    actual = replay_output.sampled_token_ids
+    if expected is not None and torch.equal(actual, expected):
+        print("Replay matched expected sampled_token_ids.")
+        return 0
+
+    print("Replay mismatch.")
+    if expected is not None:
+        print(f"expected shape: {tuple(expected.shape)}")
+        print(f"actual shape:   {tuple(actual.shape)}")
+        print(f"expected: {expected}")
+    print(f"actual:   {actual}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tools/spec_sampling_npu_poc.py
+++ b/tools/spec_sampling_npu_poc.py
@@ -12,6 +12,7 @@ import vllm_ascend.sample.sampler as sampler_module
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
 from vllm_ascend.sample.rejection_sampler import AscendRejectionSampler
 from vllm_ascend.sample.sampler import AscendSampler
+from vllm_ascend.sample.spec_sampling_executor import SpecSamplingNPUExecutor
 from vllm_ascend.sample.spec_sampling_poc import load_spec_sampling_case
 
 
@@ -62,14 +63,15 @@ def main() -> int:
 
     sampler = AscendSampler()
     rejection_sampler = AscendRejectionSampler(sampler)
-    rejection_sampler.prepare_sampling(prepared_top_k)
-
-    replay_output = rejection_sampler(
-        spec_decode_metadata,
-        draft_probs,
-        logits,
-        sampling_metadata,
+    executor = SpecSamplingNPUExecutor(sampler, rejection_sampler)
+    inputs = executor.build_inputs(
+        metadata=spec_decode_metadata,
+        sampling_metadata=sampling_metadata,
+        logits=logits,
+        draft_probs=draft_probs,
+        prepared_top_k=prepared_top_k,
     )
+    replay_output = executor.execute(inputs)
 
     actual = replay_output.sampled_token_ids
     if expected is not None and torch.equal(actual, expected):

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -481,10 +481,18 @@ class KVCacheRecvingThread(threading.Thread):
         with self.failed_recv_requests_lock:
             return request_id in self.failed_recv_requests
 
-    def _mark_failed_recv_request(self, request_id: str, local_block_ids: list[int]) -> None:
+    def _mark_failed_recv_request(self, request_id: str, local_block_ids: BlockIds | list[int]) -> None:
+        if local_block_ids and isinstance(local_block_ids[0], (list, tuple)):
+            flattened_block_ids: set[int] = {
+                block_id
+                for group_block_ids in local_block_ids
+                for block_id in group_block_ids
+            }
+        else:
+            flattened_block_ids = set(local_block_ids) if local_block_ids else set()
         with self.failed_recv_requests_lock:
             self.failed_recv_requests.add(request_id)
-            self.invalid_block_ids.update(local_block_ids)
+            self.invalid_block_ids.update(flattened_block_ids)
 
     def _clear_failed_recv_request(self, request_id: str) -> None:
         with self.failed_recv_requests_lock:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -104,6 +104,7 @@ class ReqMeta:
     remote_ptp_size: int | None
     remote_multi_nodes_meta_mapping: dict[str, dict[str, Any]]
     num_prompt_blocks: int
+    num_committed_blocks: int = 0
 
 
 @dataclass(frozen=True)
@@ -1194,6 +1195,10 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
             remote_ptp_size=kv_transfer_params.get("remote_ptp_size"),
             remote_multi_nodes_meta_mapping=kv_transfer_params.get("remote_multi_nodes_meta_mapping", {}),
             num_prompt_blocks=kv_transfer_params.get("num_prompt_blocks", 0),
+            num_committed_blocks=kv_transfer_params.get(
+                "num_committed_blocks",
+                kv_transfer_params.get("num_prompt_blocks", 0),
+            ),
         )
 
 
@@ -1473,7 +1478,7 @@ class MooncakeConnectorScheduler:
         num_prompt_blocks = math.ceil(len(request.prompt_token_ids) / self.block_size)
         num_committed_blocks = math.ceil(committed_token_count / self.block_size)
         computed_block_ids = tuple(
-            block_ids[:num_prompt_blocks]
+            block_ids[:num_committed_blocks]
             if not isinstance(self.kv_cache_groups[i].kv_cache_spec, MambaSpec)
             else block_ids
             for i, block_ids in enumerate(computed_block_ids)
@@ -2048,19 +2053,20 @@ class MooncakeConnectorWorker:
             f"num_external_blocks({num_external_blocks}), cp_size({self.pcp_size * self.dcp_size}), "
             f"local_block_ids_len ({len(meta.local_block_ids[sequence_group_idx])})"
         )
-        assert meta.num_prompt_blocks >= num_external_blocks, (
-            f"meta.num_prompt_blocks({meta.num_prompt_blocks}), num_external_blocks({num_external_blocks})"
+        total_committed_blocks = meta.num_committed_blocks or meta.num_prompt_blocks
+        assert total_committed_blocks >= num_external_blocks, (
+            f"total_committed_blocks({total_committed_blocks}), num_external_blocks({num_external_blocks})"
         )
 
         remote_cp_size = meta.remote_pcp_size * meta.remote_dcp_size
-        remote_block_nums_all = [meta.num_prompt_blocks // remote_cp_size] * remote_cp_size
-        num_remain_blocks = meta.num_prompt_blocks % remote_cp_size
+        remote_block_nums_all = [total_committed_blocks // remote_cp_size] * remote_cp_size
+        num_remain_blocks = total_committed_blocks % remote_cp_size
         for i in range(num_remain_blocks):
             remote_block_nums_all[i] += 1
         last_block_location = (num_remain_blocks + remote_cp_size - 1) % remote_cp_size
 
         # Considering prefix cache, the remote_block_nums_all should be revised
-        num_prefix_cached_blocks = meta.num_prompt_blocks - num_external_blocks
+        num_prefix_cached_blocks = total_committed_blocks - num_external_blocks
         remote_block_nums_all = [num - num_prefix_cached_blocks // remote_cp_size for num in remote_block_nums_all]
         num_remain_blocks = num_prefix_cached_blocks % remote_cp_size
         for i in range(num_remain_blocks):

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -14,7 +14,7 @@ from collections import OrderedDict, defaultdict, deque
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict, cast
 
 import msgspec
 import numpy as np
@@ -70,6 +70,9 @@ if TYPE_CHECKING:
 
 GET_META_MSG = b"get_meta_msg"
 DONE_RECVING_MSG = b"done_recving_msg"
+
+FlatBlockIds: TypeAlias = list[int]
+NestedBlockIds: TypeAlias = list[list[int]] | list[tuple[int, ...]]
 
 
 class RemotePortInfo(TypedDict):
@@ -481,13 +484,17 @@ class KVCacheRecvingThread(threading.Thread):
         with self.failed_recv_requests_lock:
             return request_id in self.failed_recv_requests
 
-    def _mark_failed_recv_request(self, request_id: str, local_block_ids: BlockIds | list[int]) -> None:
+    def _mark_failed_recv_request(self, request_id: str, local_block_ids: BlockIds | FlatBlockIds) -> None:
         if local_block_ids and isinstance(local_block_ids[0], (list, tuple)):
+            grouped_block_ids = cast(NestedBlockIds, local_block_ids)
             flattened_block_ids: set[int] = {
-                block_id for group_block_ids in local_block_ids for block_id in group_block_ids
+                block_id
+                for group_block_ids in grouped_block_ids
+                for block_id in group_block_ids
             }
         else:
-            flattened_block_ids = set(local_block_ids) if local_block_ids else set()
+            flat_block_ids = cast(FlatBlockIds, local_block_ids)
+            flattened_block_ids = set(flat_block_ids) if flat_block_ids else set()
         with self.failed_recv_requests_lock:
             self.failed_recv_requests.add(request_id)
             self.invalid_block_ids.update(flattened_block_ids)

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1350,6 +1350,11 @@ class MooncakeConnectorScheduler:
         self.multi_nodes_meta_mapping: dict[str, dict[str, Any]] = {}
         self.kv_cache_groups = kv_cache_config.kv_cache_groups
 
+    @staticmethod
+    def _get_committed_token_count(request: "Request") -> int:
+        prompt_len = len(request.prompt_token_ids or [])
+        return prompt_len + len(request.output_token_ids)
+
     def get_num_new_matched_tokens(self, request: "Request", num_computed_tokens: int) -> tuple[int, bool]:
         """
         For remote prefill, pull all prompt blocks from remote
@@ -1464,7 +1469,9 @@ class MooncakeConnectorScheduler:
             logger.info("Delaying free of %d blocks for request %s", len(computed_block_ids), request.request_id)
             self._reqs_need_send[request.request_id] = time.time()
 
+        committed_token_count = self._get_committed_token_count(request)
         num_prompt_blocks = math.ceil(len(request.prompt_token_ids) / self.block_size)
+        num_committed_blocks = math.ceil(committed_token_count / self.block_size)
         computed_block_ids = tuple(
             block_ids[:num_prompt_blocks]
             if not isinstance(self.kv_cache_groups[i].kv_cache_spec, MambaSpec)
@@ -1486,6 +1493,7 @@ class MooncakeConnectorScheduler:
             last_token_id=request.output_token_ids[-1],
             remote_multi_nodes_meta_mapping=self.multi_nodes_meta_mapping,
             num_prompt_blocks=num_prompt_blocks,
+            num_committed_blocks=num_committed_blocks,
         )
 
     def set_xfer_handshake_metadata(self, metadata: dict[int, KVConnectorHandshakeMetadata]) -> None:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -488,9 +488,7 @@ class KVCacheRecvingThread(threading.Thread):
         if local_block_ids and isinstance(local_block_ids[0], (list, tuple)):
             grouped_block_ids = cast(NestedBlockIds, local_block_ids)
             flattened_block_ids: set[int] = {
-                block_id
-                for group_block_ids in grouped_block_ids
-                for block_id in group_block_ids
+                block_id for group_block_ids in grouped_block_ids for block_id in group_block_ids
             }
         else:
             flat_block_ids = cast(FlatBlockIds, local_block_ids)

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -484,9 +484,7 @@ class KVCacheRecvingThread(threading.Thread):
     def _mark_failed_recv_request(self, request_id: str, local_block_ids: BlockIds | list[int]) -> None:
         if local_block_ids and isinstance(local_block_ids[0], (list, tuple)):
             flattened_block_ids: set[int] = {
-                block_id
-                for group_block_ids in local_block_ids
-                for block_id in group_block_ids
+                block_id for group_block_ids in local_block_ids for block_id in group_block_ids
             }
         else:
             flattened_block_ids = set(local_block_ids) if local_block_ids else set()

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -97,6 +97,7 @@ class ReqMeta:
     remote_ptp_size: int | None
     remote_multi_nodes_meta_mapping: dict[str, dict[str, Any]]
     num_prompt_blocks: int
+    num_committed_blocks: int = 0
 
 
 @dataclass
@@ -898,6 +899,10 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
             remote_ptp_size=kv_transfer_params.get("remote_ptp_size"),
             remote_multi_nodes_meta_mapping=kv_transfer_params.get("remote_multi_nodes_meta_mapping", {}),
             num_prompt_blocks=kv_transfer_params.get("num_prompt_blocks", 0),
+            num_committed_blocks=kv_transfer_params.get(
+                "num_committed_blocks",
+                kv_transfer_params.get("num_prompt_blocks", 0),
+            ),
         )
 
 
@@ -1280,7 +1285,7 @@ class MooncakeConnectorScheduler:
         committed_token_count = self._get_committed_token_count(request)
         num_prompt_blocks = math.ceil(len(request.prompt_token_ids) / self.block_size)
         num_committed_blocks = math.ceil(committed_token_count / self.block_size)
-        computed_block_ids = self._compute_transfer_block_ids(computed_block_ids, len(request.prompt_token_ids))
+        computed_block_ids = self._compute_transfer_block_ids(computed_block_ids, committed_token_count)
 
         return delay_free_blocks, dict(
             do_remote_prefill=True,

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -1154,6 +1154,11 @@ class MooncakeConnectorScheduler:
                 transfer_block_ids.append(blocks)
         return tuple(transfer_block_ids)
 
+    @staticmethod
+    def _get_committed_token_count(request: "Request") -> int:
+        prompt_len = len(request.prompt_token_ids or [])
+        return prompt_len + len(request.output_token_ids)
+
     def get_num_new_matched_tokens(self, request: "Request", num_computed_tokens: int) -> tuple[int, bool]:
         """
         For remote prefill, pull all prompt blocks from remote
@@ -1272,7 +1277,9 @@ class MooncakeConnectorScheduler:
             self._reqs_need_send[request.request_id] = time.time()
             computed_block_ids = self.get_sw_clipped_blocks(computed_block_ids)
 
+        committed_token_count = self._get_committed_token_count(request)
         num_prompt_blocks = math.ceil(len(request.prompt_token_ids) / self.block_size)
+        num_committed_blocks = math.ceil(committed_token_count / self.block_size)
         computed_block_ids = self._compute_transfer_block_ids(computed_block_ids, len(request.prompt_token_ids))
 
         return delay_free_blocks, dict(
@@ -1287,6 +1294,7 @@ class MooncakeConnectorScheduler:
             last_token_id=request.output_token_ids[-1],
             remote_multi_nodes_meta_mapping=self.multi_nodes_meta_mapping,
             num_prompt_blocks=num_prompt_blocks,
+            num_committed_blocks=num_committed_blocks,
         )
 
     def set_xfer_handshake_metadata(self, metadata: dict[int, KVConnectorHandshakeMetadata]) -> None:

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -68,6 +68,14 @@ class BalanceScheduler(Scheduler):
         running_tensor = torch.tensor([len(self.running)], dtype=torch.int, device="cpu")
         dist.all_gather(self.balance_queue, running_tensor, group=dp_group)
 
+    def _request_has_allocated_blocks(self, req_id: str) -> bool:
+        if not hasattr(self, "kv_cache_manager") or not hasattr(self.kv_cache_manager, "coordinator"):
+            return False
+        return any(
+            req_id in manager.req_to_blocks
+            for manager in self.kv_cache_manager.coordinator.single_type_managers
+        )
+
     def _update_from_kv_xfer_finished(self, kv_connector_output):
         """Handle duplicate finished KV notifications idempotently.
 
@@ -90,7 +98,8 @@ class BalanceScheduler(Scheduler):
                 self.finished_recving_kv_req_ids.add(req_id)
             else:
                 assert RequestStatus.is_finished(req.status)
-                self._free_blocks(req)
+                if self._request_has_allocated_blocks(req_id):
+                    self._free_blocks(req)
 
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
@@ -98,7 +107,8 @@ class BalanceScheduler(Scheduler):
             if req is None:
                 logger.debug("Ignoring duplicate finished_sending for freed request %s", req_id)
                 continue
-            self._free_blocks(req)
+            if self._request_has_allocated_blocks(req_id):
+                self._free_blocks(req)
 
     def schedule(self) -> SchedulerOutput:
         if not self._balance_enabled:

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -68,6 +68,38 @@ class BalanceScheduler(Scheduler):
         running_tensor = torch.tensor([len(self.running)], dtype=torch.int, device="cpu")
         dist.all_gather(self.balance_queue, running_tensor, group=dp_group)
 
+    def _update_from_kv_xfer_finished(self, kv_connector_output):
+        """Handle duplicate finished KV notifications idempotently.
+
+        The upstream scheduler assumes finished_sending / finished_recving
+        request ids are always still present in self.requests. In our delayed
+        free / rollback paths, duplicated connector signals can legitimately
+        arrive after the request has already been fully freed. Treat those
+        duplicates as no-ops instead of asserting.
+        """
+        if self.connector is not None:
+            self.connector.update_connector_output(kv_connector_output)
+
+        for req_id in kv_connector_output.finished_recving or ():
+            logger.debug("Finished recving KV transfer for request %s", req_id)
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.debug("Ignoring duplicate finished_recving for freed request %s", req_id)
+                continue
+            if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                self.finished_recving_kv_req_ids.add(req_id)
+            else:
+                assert RequestStatus.is_finished(req.status)
+                self._free_blocks(req)
+
+        for req_id in kv_connector_output.finished_sending or ():
+            logger.debug("Finished sending KV transfer for request %s", req_id)
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.debug("Ignoring duplicate finished_sending for freed request %s", req_id)
+                continue
+            self._free_blocks(req)
+
     def schedule(self) -> SchedulerOutput:
         if not self._balance_enabled:
             return super().schedule()

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -72,8 +72,7 @@ class BalanceScheduler(Scheduler):
         if not hasattr(self, "kv_cache_manager") or not hasattr(self.kv_cache_manager, "coordinator"):
             return False
         return any(
-            req_id in manager.req_to_blocks
-            for manager in self.kv_cache_manager.coordinator.single_type_managers
+            req_id in manager.req_to_blocks for manager in self.kv_cache_manager.coordinator.single_type_managers
         )
 
     def _update_from_kv_xfer_finished(self, kv_connector_output):

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -168,7 +168,7 @@ class AscendRejectionSampler(RejectionSampler):
 
         logprobs_tensors = None
         if sampling_metadata.max_num_logprobs is not None:
-            logprobs_tensors = self._get_logprobs_tensors(
+            logprobs_tensors = self.build_logprobs_tensors_from_prepared_inputs(
                 sampling_metadata.max_num_logprobs,
                 metadata,
                 logits,
@@ -180,6 +180,26 @@ class AscendRejectionSampler(RejectionSampler):
         return SamplerOutput(
             sampled_token_ids=output_token_ids,
             logprobs_tensors=logprobs_tensors,
+        )
+
+    def build_logprobs_tensors_from_prepared_inputs(
+        self,
+        max_num_logprobs: int | None,
+        metadata: SpecDecodeMetadata,
+        logits: torch.Tensor,
+        target_logits_for_logprobs: torch.Tensor,
+        bonus_logprobs: torch.Tensor,
+        output_token_ids: torch.Tensor,
+    ):
+        if max_num_logprobs is None:
+            return None
+        return self._get_logprobs_tensors(
+            max_num_logprobs,
+            metadata,
+            logits,
+            target_logits_for_logprobs,
+            bonus_logprobs,
+            output_token_ids,
         )
 
 

--- a/vllm_ascend/sample/spec_sampling_executor.py
+++ b/vllm_ascend/sample/spec_sampling_executor.py
@@ -8,9 +8,9 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 
 from vllm_ascend.sample.rejection_sampler import (
-    AscendRejectionSampler,
     MAX_SPEC_LEN,
     PLACEHOLDER_TOKEN_ID,
+    AscendRejectionSampler,
     apply_sampling_constraints,
     rejection_sample,
 )
@@ -130,9 +130,7 @@ class SpecSamplingNPUExecutor:
             ),
             predict_bonus_token=True,
             logprobs_mode_override=(
-                "processed_logits"
-                if self.rejection_sampler.is_processed_logprobs_mode
-                else "raw_logits"
+                "processed_logits" if self.rejection_sampler.is_processed_logprobs_mode else "raw_logits"
             ),
         )
         bonus_token_ids = bonus_sampler_output.sampled_token_ids

--- a/vllm_ascend/sample/spec_sampling_executor.py
+++ b/vllm_ascend/sample/spec_sampling_executor.py
@@ -41,6 +41,23 @@ class SpecSamplingNPUExecutor:
         self.sampler = sampler
         self.rejection_sampler = rejection_sampler
 
+    @staticmethod
+    def build_inputs(
+        *,
+        metadata: SpecDecodeMetadata,
+        sampling_metadata: SamplingMetadata,
+        logits: torch.Tensor,
+        draft_probs: torch.Tensor | None = None,
+        prepared_top_k: int | None = None,
+    ) -> PreparedSpecSamplingInputs:
+        return PreparedSpecSamplingInputs(
+            metadata=metadata,
+            sampling_metadata=sampling_metadata,
+            logits=logits,
+            draft_probs=draft_probs,
+            prepared_top_k=prepared_top_k,
+        )
+
     def execute(self, inputs: PreparedSpecSamplingInputs) -> SamplerOutput:
         metadata = inputs.metadata
         sampling_metadata = inputs.sampling_metadata

--- a/vllm_ascend/sample/spec_sampling_executor.py
+++ b/vllm_ascend/sample/spec_sampling_executor.py
@@ -10,6 +10,7 @@ from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm_ascend.sample.rejection_sampler import (
     AscendRejectionSampler,
     MAX_SPEC_LEN,
+    PLACEHOLDER_TOKEN_ID,
     apply_sampling_constraints,
     rejection_sample,
 )
@@ -24,6 +25,12 @@ class PreparedSpecSamplingInputs:
     logits: torch.Tensor
     draft_probs: torch.Tensor | None = None
     prepared_top_k: int | None = None
+
+
+@dataclass
+class SpecSamplingExecutionResult:
+    sampler_output: SamplerOutput
+    num_output_tokens_per_req: torch.Tensor
 
 
 class SpecSamplingNPUExecutor:
@@ -84,6 +91,9 @@ class SpecSamplingNPUExecutor:
         )
 
     def execute(self, inputs: PreparedSpecSamplingInputs) -> SamplerOutput:
+        return self.execute_detailed(inputs).sampler_output
+
+    def execute_detailed(self, inputs: PreparedSpecSamplingInputs) -> SpecSamplingExecutionResult:
         metadata = inputs.metadata
         sampling_metadata = inputs.sampling_metadata
         logits = inputs.logits
@@ -147,9 +157,14 @@ class SpecSamplingNPUExecutor:
                 output_token_ids,
             )
 
-        return SamplerOutput(
+        sampler_output = SamplerOutput(
             sampled_token_ids=output_token_ids,
             logprobs_tensors=logprobs_tensors,
+        )
+        num_output_tokens_per_req = output_token_ids.ne(PLACEHOLDER_TOKEN_ID).sum(dim=-1).to(torch.int32)
+        return SpecSamplingExecutionResult(
+            sampler_output=sampler_output,
+            num_output_tokens_per_req=num_output_tokens_per_req,
         )
 
     def execute_from_runtime(
@@ -165,7 +180,7 @@ class SpecSamplingNPUExecutor:
         write_markers: bool = False,
         num_reqs: int | None = None,
         num_spec_tokens: int | None = None,
-    ) -> SamplerOutput:
+    ) -> SpecSamplingExecutionResult:
         if write_markers:
             write_spec_sampling_marker(
                 "entered_mtp_sample",
@@ -185,12 +200,13 @@ class SpecSamplingNPUExecutor:
             enable_reduce_sample=enable_reduce_sample,
             draft_probs=draft_probs,
         )
-        sampler_output = self.execute(inputs)
+        result = self.execute_detailed(inputs)
         if write_markers:
             write_spec_sampling_marker(
                 "finished_mtp_sample",
                 {
-                    "sampled_token_ids_shape": list(sampler_output.sampled_token_ids.shape),
+                    "sampled_token_ids_shape": list(result.sampler_output.sampled_token_ids.shape),
+                    "num_output_tokens_per_req": result.num_output_tokens_per_req.tolist(),
                 },
             )
-        return sampler_output
+        return result

--- a/vllm_ascend/sample/spec_sampling_executor.py
+++ b/vllm_ascend/sample/spec_sampling_executor.py
@@ -150,3 +150,26 @@ class SpecSamplingNPUExecutor:
             sampled_token_ids=output_token_ids,
             logprobs_tensors=logprobs_tensors,
         )
+
+    def execute_from_runtime(
+        self,
+        *,
+        metadata: SpecDecodeMetadata,
+        sampling_metadata: SamplingMetadata,
+        logits: torch.Tensor,
+        top_k_cpu: torch.Tensor | None,
+        enable_reduce_sample: bool,
+        trim_logits_to_indices: bool = False,
+        draft_probs: torch.Tensor | None = None,
+    ) -> SamplerOutput:
+        if trim_logits_to_indices:
+            logits = logits[: len(metadata.logits_indices)]
+        inputs = self.build_inputs_from_runtime(
+            metadata=metadata,
+            sampling_metadata=sampling_metadata,
+            logits=logits,
+            top_k_cpu=top_k_cpu,
+            enable_reduce_sample=enable_reduce_sample,
+            draft_probs=draft_probs,
+        )
+        return self.execute(inputs)

--- a/vllm_ascend/sample/spec_sampling_executor.py
+++ b/vllm_ascend/sample/spec_sampling_executor.py
@@ -50,6 +50,19 @@ class SpecSamplingNPUExecutor:
         self.rejection_sampler = rejection_sampler
 
     @staticmethod
+    def _ensure_index_tensor(
+        indices: torch.Tensor | list[int],
+        device: torch.device,
+    ) -> torch.Tensor:
+        if not isinstance(indices, torch.Tensor):
+            return torch.tensor(indices, device=device, dtype=torch.long)
+        if indices.device != device:
+            return indices.to(device=device, dtype=torch.long)
+        if indices.dtype != torch.long:
+            return indices.to(dtype=torch.long)
+        return indices
+
+    @staticmethod
     def build_inputs(
         *,
         metadata: SpecDecodeMetadata,
@@ -99,8 +112,14 @@ class SpecSamplingNPUExecutor:
         logits = inputs.logits
 
         assert metadata.max_spec_len <= MAX_SPEC_LEN
-        bonus_logits_indices = metadata.bonus_logits_indices
-        target_logits_indices = metadata.target_logits_indices
+        bonus_logits_indices = self._ensure_index_tensor(
+            metadata.bonus_logits_indices,
+            logits.device,
+        )
+        target_logits_indices = self._ensure_index_tensor(
+            metadata.target_logits_indices,
+            logits.device,
+        )
 
         bonus_logits = logits[bonus_logits_indices]
         bonus_sampler_output = self.sampler(

--- a/vllm_ascend/sample/spec_sampling_executor.py
+++ b/vllm_ascend/sample/spec_sampling_executor.py
@@ -96,7 +96,7 @@ class SpecSamplingNPUExecutor:
 
         logprobs_tensors = None
         if sampling_metadata.max_num_logprobs is not None:
-            logprobs_tensors = self.rejection_sampler._get_logprobs_tensors(
+            logprobs_tensors = self.rejection_sampler.build_logprobs_tensors_from_prepared_inputs(
                 sampling_metadata.max_num_logprobs,
                 metadata,
                 logits,

--- a/vllm_ascend/sample/spec_sampling_executor.py
+++ b/vllm_ascend/sample/spec_sampling_executor.py
@@ -58,6 +58,30 @@ class SpecSamplingNPUExecutor:
             prepared_top_k=prepared_top_k,
         )
 
+    @classmethod
+    def build_inputs_from_runtime(
+        cls,
+        *,
+        metadata: SpecDecodeMetadata,
+        sampling_metadata: SamplingMetadata,
+        logits: torch.Tensor,
+        top_k_cpu: torch.Tensor | None,
+        enable_reduce_sample: bool,
+        draft_probs: torch.Tensor | None = None,
+    ) -> PreparedSpecSamplingInputs:
+        prepared_top_k = None
+        if top_k_cpu is not None and enable_reduce_sample:
+            valid_top_k = top_k_cpu[top_k_cpu < logits.shape[1]]
+            if len(valid_top_k) > 0:
+                prepared_top_k = int(valid_top_k.max())
+        return cls.build_inputs(
+            metadata=metadata,
+            sampling_metadata=sampling_metadata,
+            logits=logits,
+            draft_probs=draft_probs,
+            prepared_top_k=prepared_top_k,
+        )
+
     def execute(self, inputs: PreparedSpecSamplingInputs) -> SamplerOutput:
         metadata = inputs.metadata
         sampling_metadata = inputs.sampling_metadata

--- a/vllm_ascend/sample/spec_sampling_executor.py
+++ b/vllm_ascend/sample/spec_sampling_executor.py
@@ -14,6 +14,7 @@ from vllm_ascend.sample.rejection_sampler import (
     rejection_sample,
 )
 from vllm_ascend.sample.sampler import AscendSampler
+from vllm_ascend.sample.spec_sampling_poc import write_spec_sampling_marker
 
 
 @dataclass
@@ -161,7 +162,19 @@ class SpecSamplingNPUExecutor:
         enable_reduce_sample: bool,
         trim_logits_to_indices: bool = False,
         draft_probs: torch.Tensor | None = None,
+        write_markers: bool = False,
+        num_reqs: int | None = None,
+        num_spec_tokens: int | None = None,
     ) -> SamplerOutput:
+        if write_markers:
+            write_spec_sampling_marker(
+                "entered_mtp_sample",
+                {
+                    "logits_shape": list(logits.shape),
+                    "num_reqs": num_reqs,
+                    "num_spec_tokens": num_spec_tokens,
+                },
+            )
         if trim_logits_to_indices:
             logits = logits[: len(metadata.logits_indices)]
         inputs = self.build_inputs_from_runtime(
@@ -172,4 +185,12 @@ class SpecSamplingNPUExecutor:
             enable_reduce_sample=enable_reduce_sample,
             draft_probs=draft_probs,
         )
-        return self.execute(inputs)
+        sampler_output = self.execute(inputs)
+        if write_markers:
+            write_spec_sampling_marker(
+                "finished_mtp_sample",
+                {
+                    "sampled_token_ids_shape": list(sampler_output.sampled_token_ids.shape),
+                },
+            )
+        return sampler_output

--- a/vllm_ascend/sample/spec_sampling_executor.py
+++ b/vllm_ascend/sample/spec_sampling_executor.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+import torch
+from vllm.v1.outputs import SamplerOutput
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
+
+from vllm_ascend.sample.rejection_sampler import (
+    AscendRejectionSampler,
+    MAX_SPEC_LEN,
+    apply_sampling_constraints,
+    rejection_sample,
+)
+from vllm_ascend.sample.sampler import AscendSampler
+
+
+@dataclass
+class PreparedSpecSamplingInputs:
+    metadata: SpecDecodeMetadata
+    sampling_metadata: SamplingMetadata
+    logits: torch.Tensor
+    draft_probs: torch.Tensor | None = None
+    prepared_top_k: int | None = None
+
+
+class SpecSamplingNPUExecutor:
+    """Execute the speculative sampling pipeline with prepared inputs.
+
+    This first version intentionally mirrors the current real sampling path,
+    but makes the pipeline boundary explicit so later stages can migrate more
+    work out of ``model_runner_v1`` without re-deriving the input contract.
+    """
+
+    def __init__(
+        self,
+        sampler: AscendSampler,
+        rejection_sampler: AscendRejectionSampler,
+    ) -> None:
+        self.sampler = sampler
+        self.rejection_sampler = rejection_sampler
+
+    def execute(self, inputs: PreparedSpecSamplingInputs) -> SamplerOutput:
+        metadata = inputs.metadata
+        sampling_metadata = inputs.sampling_metadata
+        logits = inputs.logits
+
+        assert metadata.max_spec_len <= MAX_SPEC_LEN
+        bonus_logits_indices = metadata.bonus_logits_indices
+        target_logits_indices = metadata.target_logits_indices
+
+        bonus_logits = logits[bonus_logits_indices]
+        bonus_sampler_output = self.sampler(
+            logits=bonus_logits,
+            sampling_metadata=replace(
+                sampling_metadata,
+                max_num_logprobs=-1,
+            ),
+            predict_bonus_token=True,
+            logprobs_mode_override=(
+                "processed_logits"
+                if self.rejection_sampler.is_processed_logprobs_mode
+                else "raw_logits"
+            ),
+        )
+        bonus_token_ids = bonus_sampler_output.sampled_token_ids
+
+        raw_target_logits = logits[target_logits_indices].to(torch.float32)
+        target_logits = raw_target_logits
+        if not self.rejection_sampler.is_processed_logprobs_mode:
+            target_logits = target_logits.clone()
+
+        target_logits = self.rejection_sampler.apply_logits_processors(
+            target_logits,
+            sampling_metadata,
+            metadata,
+        )
+        target_logits = apply_sampling_constraints(
+            target_logits,
+            metadata.cu_num_draft_tokens,
+            sampling_metadata,
+            inputs.prepared_top_k,
+        )
+
+        output_token_ids = rejection_sample(
+            metadata.draft_token_ids,
+            metadata.num_draft_tokens,
+            metadata.max_spec_len,
+            metadata.cu_num_draft_tokens,
+            inputs.draft_probs,
+            target_logits,
+            bonus_token_ids,
+            sampling_metadata,
+        )
+
+        logprobs_tensors = None
+        if sampling_metadata.max_num_logprobs is not None:
+            logprobs_tensors = self.rejection_sampler._get_logprobs_tensors(
+                sampling_metadata.max_num_logprobs,
+                metadata,
+                logits,
+                target_logits if self.rejection_sampler.is_processed_logprobs_mode else raw_target_logits,
+                bonus_sampler_output.logprobs_tensors.logprobs,
+                output_token_ids,
+            )
+
+        return SamplerOutput(
+            sampled_token_ids=output_token_ids,
+            logprobs_tensors=logprobs_tensors,
+        )

--- a/vllm_ascend/sample/spec_sampling_poc.py
+++ b/vllm_ascend/sample/spec_sampling_poc.py
@@ -50,6 +50,23 @@ def _allocate_case_dir() -> Path | None:
     return case_dir
 
 
+def write_spec_sampling_marker(stage: str, extra: dict[str, Any] | None = None) -> Path | None:
+    dump_dir = _get_dump_dir()
+    if dump_dir is None:
+        return None
+    dump_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "timestamp": time.time(),
+        "stage": stage,
+    }
+    if extra:
+        payload["extra"] = extra
+    marker_path = dump_dir / f"marker_{stage}.json"
+    with open(marker_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    return marker_path
+
+
 def _move_tensors(obj: Any, device: str | torch.device) -> Any:
     if torch.is_tensor(obj):
         return obj.detach().to(device)
@@ -130,5 +147,4 @@ def load_spec_sampling_case(case_path: str | os.PathLike[str]) -> dict[str, Any]
     case_path = Path(case_path)
     if case_path.is_dir():
         case_path = case_path / "case.pt"
-    return torch.load(case_path, map_location="cpu")
-
+    return torch.load(case_path, map_location="cpu", weights_only=False)

--- a/vllm_ascend/sample/spec_sampling_poc.py
+++ b/vllm_ascend/sample/spec_sampling_poc.py
@@ -16,13 +16,17 @@ ENV_POC_DUMP_MAX_CASES = "VLLM_ASCEND_SPEC_SAMPLING_POC_MAX_CASES"
 
 _dump_lock = threading.Lock()
 _dump_case_count = 0
+_dump_dir_cached: Path | None = None
+_dump_dir_initialized = False
 
 
 def _get_dump_dir() -> Path | None:
-    dump_dir = os.getenv(ENV_POC_DUMP_DIR)
-    if not dump_dir:
-        return None
-    return Path(dump_dir)
+    global _dump_dir_cached, _dump_dir_initialized
+    if not _dump_dir_initialized:
+        dump_dir = os.getenv(ENV_POC_DUMP_DIR)
+        _dump_dir_cached = Path(dump_dir) if dump_dir else None
+        _dump_dir_initialized = True
+    return _dump_dir_cached
 
 
 def _get_max_cases() -> int:
@@ -61,7 +65,8 @@ def write_spec_sampling_marker(stage: str, extra: dict[str, Any] | None = None) 
     }
     if extra:
         payload["extra"] = extra
-    marker_path = dump_dir / f"marker_{stage}.json"
+    rank = os.getenv("RANK", "0")
+    marker_path = dump_dir / f"marker_{stage}_rank{rank}.json"
     with open(marker_path, "w", encoding="utf-8") as f:
         json.dump(payload, f, ensure_ascii=False, indent=2)
     return marker_path

--- a/vllm_ascend/sample/spec_sampling_poc.py
+++ b/vllm_ascend/sample/spec_sampling_poc.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from dataclasses import fields, is_dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+ENV_POC_DUMP_DIR = "VLLM_ASCEND_SPEC_SAMPLING_POC_DIR"
+ENV_POC_DUMP_MAX_CASES = "VLLM_ASCEND_SPEC_SAMPLING_POC_MAX_CASES"
+
+_dump_lock = threading.Lock()
+_dump_case_count = 0
+
+
+def _get_dump_dir() -> Path | None:
+    dump_dir = os.getenv(ENV_POC_DUMP_DIR)
+    if not dump_dir:
+        return None
+    return Path(dump_dir)
+
+
+def _get_max_cases() -> int:
+    raw = os.getenv(ENV_POC_DUMP_MAX_CASES, "1")
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 1
+
+
+def _allocate_case_dir() -> Path | None:
+    global _dump_case_count
+    dump_dir = _get_dump_dir()
+    if dump_dir is None:
+        return None
+
+    with _dump_lock:
+        if _dump_case_count >= _get_max_cases():
+            return None
+        case_id = _dump_case_count
+        _dump_case_count += 1
+
+    case_dir = dump_dir / f"case_{case_id:03d}"
+    case_dir.mkdir(parents=True, exist_ok=True)
+    return case_dir
+
+
+def _move_tensors(obj: Any, device: str | torch.device) -> Any:
+    if torch.is_tensor(obj):
+        return obj.detach().to(device)
+    if isinstance(obj, np.ndarray):
+        tensor = torch.from_numpy(obj.copy())
+        return tensor.to(device) if device != "cpu" else tensor
+    if is_dataclass(obj) and not isinstance(obj, type):
+        kwargs = {field.name: _move_tensors(getattr(obj, field.name), device) for field in fields(obj)}
+        return type(obj)(**kwargs)
+    if hasattr(obj, "_fields") and hasattr(obj, "_asdict"):
+        values = {name: _move_tensors(getattr(obj, name), device) for name in obj._fields}
+        return type(obj)(**values)
+    if isinstance(obj, dict):
+        return {key: _move_tensors(value, device) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [_move_tensors(item, device) for item in obj]
+    if isinstance(obj, tuple):
+        return tuple(_move_tensors(item, device) for item in obj)
+    return obj
+
+
+def _tensor_shape(obj: Any) -> list[int] | None:
+    if torch.is_tensor(obj):
+        return list(obj.shape)
+    if isinstance(obj, np.ndarray):
+        return list(obj.shape)
+    return None
+
+
+def dump_spec_sampling_case(
+    *,
+    logits: torch.Tensor,
+    sampling_metadata: Any,
+    spec_decode_metadata: Any,
+    sampler_output: Any,
+    draft_probs: torch.Tensor | None,
+    prepared_top_k: int | None,
+    positions: torch.Tensor | None,
+    slot_mapping: torch.Tensor | None,
+    input_token_ids: np.ndarray | torch.Tensor | None,
+) -> Path | None:
+    case_dir = _allocate_case_dir()
+    if case_dir is None:
+        return None
+
+    payload = {
+        "timestamp": time.time(),
+        "logits": _move_tensors(logits, "cpu"),
+        "draft_probs": _move_tensors(draft_probs, "cpu"),
+        "sampling_metadata": _move_tensors(sampling_metadata, "cpu"),
+        "spec_decode_metadata": _move_tensors(spec_decode_metadata, "cpu"),
+        "sampler_output": _move_tensors(sampler_output, "cpu"),
+        "prepared_top_k": prepared_top_k,
+        "positions": _move_tensors(positions, "cpu"),
+        "slot_mapping": _move_tensors(slot_mapping, "cpu"),
+        "input_token_ids": _move_tensors(input_token_ids, "cpu"),
+    }
+
+    torch.save(payload, case_dir / "case.pt")
+
+    summary = {
+        "timestamp": payload["timestamp"],
+        "logits_shape": _tensor_shape(payload["logits"]),
+        "draft_probs_shape": _tensor_shape(payload["draft_probs"]),
+        "positions_shape": _tensor_shape(payload["positions"]),
+        "slot_mapping_shape": _tensor_shape(payload["slot_mapping"]),
+        "input_token_ids_shape": _tensor_shape(payload["input_token_ids"]),
+        "sampled_token_ids_shape": _tensor_shape(payload["sampler_output"].sampled_token_ids),
+        "prepared_top_k": prepared_top_k,
+    }
+    with open(case_dir / "summary.json", "w", encoding="utf-8") as f:
+        json.dump(summary, f, ensure_ascii=False, indent=2)
+
+    return case_dir
+
+
+def load_spec_sampling_case(case_path: str | os.PathLike[str]) -> dict[str, Any]:
+    case_path = Path(case_path)
+    if case_path.is_dir():
+        case_path = case_path / "case.pt"
+    return torch.load(case_path, map_location="cpu")
+

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -899,7 +899,10 @@ _ascend_device_type = None
 
 def _init_ascend_device_type():
     global _ascend_device_type
-    from vllm_ascend import _build_info  # type: ignore
+    try:
+        from vllm_ascend import _build_info  # type: ignore
+    except ImportError:
+        _build_info = None
 
     device_type = getattr(_build_info, "__device_type__", None)
     if device_type is None:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2385,9 +2385,6 @@ class NPUModelRunner(GPUModelRunner):
 
         if lmhead_tp_enable() and logits is not None:
             logits = logits[: len(spec_decode_metadata.logits_indices)]
-        prepared_top_k = None
-        if self.input_batch.sampling_metadata.top_k is not None and get_ascend_config().enable_reduce_sample:
-            prepared_top_k = self.input_batch.top_k_cpu[self.input_batch.top_k_cpu < logits.shape[1]].max()
         if self.speculative_config and self.speculative_config.method == "mtp":
             write_spec_sampling_marker(
                 "entered_mtp_sample",
@@ -2398,15 +2395,21 @@ class NPUModelRunner(GPUModelRunner):
                 },
             )
         if self.speculative_config and self.speculative_config.method == "mtp":
-            inputs = self.spec_sampling_executor.build_inputs(
+            inputs = self.spec_sampling_executor.build_inputs_from_runtime(
                 metadata=spec_decode_metadata,
                 sampling_metadata=sampling_metadata,
                 logits=logits,
+                top_k_cpu=self.input_batch.top_k_cpu
+                if self.input_batch.sampling_metadata.top_k is not None
+                else None,
+                enable_reduce_sample=get_ascend_config().enable_reduce_sample,
                 draft_probs=None,
-                prepared_top_k=int(prepared_top_k) if prepared_top_k is not None else None,
             )
             sampler_output = self.spec_sampling_executor.execute(inputs)
         else:
+            prepared_top_k = None
+            if self.input_batch.sampling_metadata.top_k is not None and get_ascend_config().enable_reduce_sample:
+                prepared_top_k = self.input_batch.top_k_cpu[self.input_batch.top_k_cpu < logits.shape[1]].max()
             if prepared_top_k is not None:
                 self.rejection_sampler.prepare_sampling(prepared_top_k)
             sampler_output = self.rejection_sampler(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1460,6 +1460,7 @@ class NPUModelRunner(GPUModelRunner):
         aux_hidden_states: torch.Tensor = None,
         sample_hidden_states: torch.Tensor = None,
         target_model_batch_desc: BatchDescriptor = None,
+        valid_sampled_tokens_count_override: torch.Tensor | None = None,
     ) -> list[list[int]] | None:
         if not self.drafter:
             # Speculative decoding is not enabled.
@@ -1543,6 +1544,8 @@ class NPUModelRunner(GPUModelRunner):
                     self.num_discarded_requests,
                 )
             )
+            if valid_sampled_tokens_count_override is not None:
+                valid_sampled_tokens_count = valid_sampled_tokens_count_override
             self._copy_valid_sampled_token_count(next_token_ids, valid_sampled_tokens_count)
         elif self.speculative_config.use_eagle() or self.speculative_config.uses_draft_model():
             common_attn_metadata = spec_decode_common_attn_metadata
@@ -1575,6 +1578,8 @@ class NPUModelRunner(GPUModelRunner):
                     self.discard_request_indices.gpu,
                     self.num_discarded_requests,
                 )
+                if valid_sampled_tokens_count_override is not None:
+                    valid_sampled_tokens_count = valid_sampled_tokens_count_override
 
             req_scheduled_tokens = scheduler_output.num_scheduled_tokens
             if self.use_cp:
@@ -2222,6 +2227,7 @@ class NPUModelRunner(GPUModelRunner):
                 aux_hidden_states,
                 sample_hidden_states,
                 batch_desc,
+                self._last_spec_num_output_tokens_per_req,
             )
             self._copy_draft_token_ids_to_cpu(scheduler_output)
 
@@ -2273,6 +2279,12 @@ class NPUModelRunner(GPUModelRunner):
                                     self.discard_request_indices.gpu,
                                     self.num_discarded_requests,
                                 )
+                            if (
+                                self.speculative_config
+                                and self.speculative_config.method == "mtp"
+                                and self._last_spec_num_output_tokens_per_req is not None
+                            ):
+                                valid_sampled_tokens_count = self._last_spec_num_output_tokens_per_req
                             self._copy_valid_sampled_token_count(
                                 next_token_ids, valid_sampled_tokens_count
                             )
@@ -2372,6 +2384,7 @@ class NPUModelRunner(GPUModelRunner):
         # Sample the next token and get logprobs if needed.
         sampling_metadata = self.input_batch.sampling_metadata
         self.input_batch.update_async_output_token_ids()
+        self._last_spec_num_output_tokens_per_req = None
         if spec_decode_metadata is None:
             if lmhead_tp_enable() and logits is not None:
                 logits = logits[: self.input_batch.num_reqs]
@@ -2384,7 +2397,7 @@ class NPUModelRunner(GPUModelRunner):
             )
 
         if self.speculative_config and self.speculative_config.method == "mtp":
-            sampler_output = self.spec_sampling_executor.execute_from_runtime(
+            spec_sampling_result = self.spec_sampling_executor.execute_from_runtime(
                 metadata=spec_decode_metadata,
                 sampling_metadata=sampling_metadata,
                 logits=logits,
@@ -2398,6 +2411,8 @@ class NPUModelRunner(GPUModelRunner):
                 num_reqs=self.input_batch.num_reqs,
                 num_spec_tokens=self.num_spec_tokens,
             )
+            self._last_spec_num_output_tokens_per_req = spec_sampling_result.num_output_tokens_per_req
+            sampler_output = spec_sampling_result.sampler_output
         else:
             prepared_top_k = None
             if self.input_batch.sampling_metadata.top_k is not None and get_ascend_config().enable_reduce_sample:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -525,6 +525,7 @@ class NPUModelRunner(GPUModelRunner):
         self.query_lens: torch.Tensor | None = None
         self.cpu_slot_mapping = None
         self.sampling_done_event: torch.npu.Event | None = None
+        self.valid_sampled_token_count_gpu: torch.Tensor | None = None
 
         # self.cudagraph_batch_sizes sorts in ascending order.
         if (
@@ -2253,8 +2254,6 @@ class NPUModelRunner(GPUModelRunner):
 
             assert self.sampling_done_event is not None
             self.sampling_done_event.record()
-
-        self.valid_sampled_token_count_gpu: torch.Tensor | None = None # type: ignore[no-redef]
 
         def propose_draft_token_ids(sampled_token_ids):
             assert spec_decode_common_attn_metadata is not None

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -166,7 +166,6 @@ from vllm.model_executor.layers.fused_moe.routed_experts_capturer import RoutedE
 
 from vllm_ascend.sample.rejection_sampler import AscendRejectionSampler
 from vllm_ascend.sample.spec_sampling_executor import (
-    PreparedSpecSamplingInputs,
     SpecSamplingNPUExecutor,
 )
 from vllm_ascend.sample.spec_sampling_poc import dump_spec_sampling_case, write_spec_sampling_marker
@@ -2399,7 +2398,7 @@ class NPUModelRunner(GPUModelRunner):
                 },
             )
         if self.speculative_config and self.speculative_config.method == "mtp":
-            inputs = PreparedSpecSamplingInputs(
+            inputs = self.spec_sampling_executor.build_inputs(
                 metadata=spec_decode_metadata,
                 sampling_metadata=sampling_metadata,
                 logits=logits,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -165,6 +165,7 @@ from vllm_ascend.ascend_forward_context import (  # isort: skip
 from vllm.model_executor.layers.fused_moe.routed_experts_capturer import RoutedExpertsCapturer
 
 from vllm_ascend.sample.rejection_sampler import AscendRejectionSampler
+from vllm_ascend.sample.spec_sampling_poc import dump_spec_sampling_case
 
 if TYPE_CHECKING:
     import xgrammar as xgr  # type: ignore[import-untyped]
@@ -2183,6 +2184,13 @@ class NPUModelRunner(GPUModelRunner):
 
         with record_function_or_nullcontext("sample_token"):
             sampler_output = self._sample(logits, spec_decode_metadata)
+            self._maybe_dump_mtp_spec_sampling_case(
+                logits=logits,
+                sampler_output=sampler_output,
+                spec_decode_metadata=spec_decode_metadata,
+                spec_decode_common_attn_metadata=spec_decode_common_attn_metadata,
+                positions=positions,
+            )
 
         if self.need_accepted_tokens:
             if self.sampling_done_event is None:
@@ -2380,6 +2388,49 @@ class NPUModelRunner(GPUModelRunner):
             sampling_metadata,
         )
         return sampler_output
+
+    def _maybe_dump_mtp_spec_sampling_case(
+        self,
+        *,
+        logits: torch.Tensor,
+        sampler_output: SamplerOutput,
+        spec_decode_metadata: SpecDecodeMetadata | None,
+        spec_decode_common_attn_metadata: AscendCommonAttentionMetadata | None,
+        positions: torch.Tensor,
+    ) -> None:
+        if not self.speculative_config or self.speculative_config.method != "mtp":
+            return
+        if spec_decode_metadata is None:
+            return
+
+        sampling_metadata = self.input_batch.sampling_metadata
+        prepared_top_k = None
+        if sampling_metadata.top_k is not None and get_ascend_config().enable_reduce_sample:
+            valid_top_k = self.input_batch.top_k_cpu[self.input_batch.top_k_cpu < logits.shape[1]]
+            if len(valid_top_k) > 0:
+                prepared_top_k = int(valid_top_k.max())
+
+        num_reqs = self.input_batch.num_reqs
+        max_tokens = int(self.input_batch.num_tokens[:num_reqs].max()) if num_reqs > 0 else 0
+        input_token_ids = None
+        if max_tokens > 0:
+            input_token_ids = self.input_batch.token_ids_cpu[:num_reqs, :max_tokens].copy()
+
+        slot_mapping = None
+        if spec_decode_common_attn_metadata is not None:
+            slot_mapping = spec_decode_common_attn_metadata.slot_mapping
+
+        dump_spec_sampling_case(
+            logits=logits,
+            sampling_metadata=sampling_metadata,
+            spec_decode_metadata=spec_decode_metadata,
+            sampler_output=sampler_output,
+            draft_probs=None,
+            prepared_top_k=prepared_top_k,
+            positions=positions,
+            slot_mapping=slot_mapping,
+            input_token_ids=input_token_ids,
+        )
 
     # TODO: remove this func after eagle_proposer is refactored and
     #  _bookkeeping_sync is moved after propose_draft_token_ids

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1462,9 +1462,15 @@ class NPUModelRunner(GPUModelRunner):
         tp_group = get_tp_group()
         if tp_group.world_size <= 1:
             return spec_num_output_tokens_per_req
-        synced = spec_num_output_tokens_per_req.clone()
-        torch.distributed.broadcast(synced, src=0, group=tp_group.device_group)
-        return synced
+        # In-place broadcast is sufficient here: the synchronized tensor is
+        # only consumed after this point, so we can avoid an extra device-side
+        # clone on every MTP step.
+        torch.distributed.broadcast(
+            spec_num_output_tokens_per_req,
+            src=0,
+            group=tp_group.device_group,
+        )
+        return spec_num_output_tokens_per_req
 
     # TODO: Once the PCP features are complete, it will fully inherit the classes from the VLLM community.
     def propose_draft_token_ids(
@@ -2556,8 +2562,12 @@ class NPUModelRunner(GPUModelRunner):
                 )
         else:
             valid_sampled_token_ids = []
-            invalid_req_indices = discard_sampled_tokens_req_indices.tolist()
-            invalid_req_indices_set = set(invalid_req_indices)
+            if discard_sampled_tokens_req_indices.numel() > 0:
+                invalid_req_indices = discard_sampled_tokens_req_indices.tolist()
+                invalid_req_indices_set = set(invalid_req_indices)
+            else:
+                invalid_req_indices = []
+                invalid_req_indices_set = set()
 
             if self.num_spec_tokens <= 0:
                 assert sampled_token_ids.shape[-1] == 1

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2195,7 +2195,9 @@ class NPUModelRunner(GPUModelRunner):
             logits = logits.to(self.device).to(logits_dtype)
 
         with record_function_or_nullcontext("sample_token"):
-            sampler_output = self._sample(logits, spec_decode_metadata)
+            sampler_output, spec_num_output_tokens_per_req = self._sample(
+                logits, spec_decode_metadata
+            )
             self._maybe_dump_mtp_spec_sampling_case(
                 logits=logits,
                 sampler_output=sampler_output,
@@ -2227,7 +2229,7 @@ class NPUModelRunner(GPUModelRunner):
                 aux_hidden_states,
                 sample_hidden_states,
                 batch_desc,
-                self._last_spec_num_output_tokens_per_req,
+                spec_num_output_tokens_per_req,
             )
             self._copy_draft_token_ids_to_cpu(scheduler_output)
 
@@ -2282,9 +2284,9 @@ class NPUModelRunner(GPUModelRunner):
                             if (
                                 self.speculative_config
                                 and self.speculative_config.method == "mtp"
-                                and self._last_spec_num_output_tokens_per_req is not None
+                                and spec_num_output_tokens_per_req is not None
                             ):
-                                valid_sampled_tokens_count = self._last_spec_num_output_tokens_per_req
+                                valid_sampled_tokens_count = spec_num_output_tokens_per_req
                             self._copy_valid_sampled_token_count(
                                 next_token_ids, valid_sampled_tokens_count
                             )
@@ -2384,16 +2386,18 @@ class NPUModelRunner(GPUModelRunner):
         # Sample the next token and get logprobs if needed.
         sampling_metadata = self.input_batch.sampling_metadata
         self.input_batch.update_async_output_token_ids()
-        self._last_spec_num_output_tokens_per_req = None
         if spec_decode_metadata is None:
             if lmhead_tp_enable() and logits is not None:
                 logits = logits[: self.input_batch.num_reqs]
             if self.input_batch.sampling_metadata.top_k is not None and get_ascend_config().enable_reduce_sample:
                 max_topk = self.input_batch.top_k_cpu[self.input_batch.top_k_cpu < logits.shape[1]].max()
                 self.sampler.prepare_sampling(max_topk)
-            return self.sampler(
-                logits=logits,
-                sampling_metadata=sampling_metadata,
+            return (
+                self.sampler(
+                    logits=logits,
+                    sampling_metadata=sampling_metadata,
+                ),
+                None,
             )
 
         if self.speculative_config and self.speculative_config.method == "mtp":
@@ -2411,8 +2415,10 @@ class NPUModelRunner(GPUModelRunner):
                 num_reqs=self.input_batch.num_reqs,
                 num_spec_tokens=self.num_spec_tokens,
             )
-            self._last_spec_num_output_tokens_per_req = spec_sampling_result.num_output_tokens_per_req
-            sampler_output = spec_sampling_result.sampler_output
+            return (
+                spec_sampling_result.sampler_output,
+                spec_sampling_result.num_output_tokens_per_req,
+            )
         else:
             prepared_top_k = None
             if self.input_batch.sampling_metadata.top_k is not None and get_ascend_config().enable_reduce_sample:
@@ -2425,7 +2431,7 @@ class NPUModelRunner(GPUModelRunner):
                 logits,
                 sampling_metadata,
             )
-        return sampler_output
+        return sampler_output, None
 
     def _maybe_dump_mtp_spec_sampling_case(
         self,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1451,6 +1451,21 @@ class NPUModelRunner(GPUModelRunner):
             self.valid_sampled_token_count_gpu = valid_sampled_tokens_count # type: ignore[no-redef]
         self.input_batch.prev_sampled_token_ids = next_token_ids.unsqueeze(1)
 
+    def _sync_mtp_output_counts_across_tp(
+        self,
+        spec_num_output_tokens_per_req: torch.Tensor | None,
+    ) -> torch.Tensor | None:
+        if spec_num_output_tokens_per_req is None:
+            return None
+        if not self.speculative_config or self.speculative_config.method != "mtp":
+            return spec_num_output_tokens_per_req
+        tp_group = get_tp_group()
+        if tp_group.world_size <= 1:
+            return spec_num_output_tokens_per_req
+        synced = spec_num_output_tokens_per_req.clone()
+        torch.distributed.broadcast(synced, src=0, group=tp_group.device_group)
+        return synced
+
     # TODO: Once the PCP features are complete, it will fully inherit the classes from the VLLM community.
     def propose_draft_token_ids(
         self,
@@ -2202,6 +2217,9 @@ class NPUModelRunner(GPUModelRunner):
         with record_function_or_nullcontext("sample_token"):
             sampler_output, spec_num_output_tokens_per_req = self._sample(
                 logits, spec_decode_metadata
+            )
+            spec_num_output_tokens_per_req = self._sync_mtp_output_counts_across_tp(
+                spec_num_output_tokens_per_req
             )
             self._maybe_dump_mtp_spec_sampling_case(
                 logits=logits,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -168,7 +168,7 @@ from vllm_ascend.sample.rejection_sampler import AscendRejectionSampler
 from vllm_ascend.sample.spec_sampling_executor import (
     SpecSamplingNPUExecutor,
 )
-from vllm_ascend.sample.spec_sampling_poc import dump_spec_sampling_case, write_spec_sampling_marker
+from vllm_ascend.sample.spec_sampling_poc import dump_spec_sampling_case
 
 if TYPE_CHECKING:
     import xgrammar as xgr  # type: ignore[import-untyped]
@@ -2384,15 +2384,6 @@ class NPUModelRunner(GPUModelRunner):
             )
 
         if self.speculative_config and self.speculative_config.method == "mtp":
-            write_spec_sampling_marker(
-                "entered_mtp_sample",
-                {
-                    "logits_shape": list(logits.shape) if logits is not None else None,
-                    "num_reqs": self.input_batch.num_reqs,
-                    "num_spec_tokens": self.num_spec_tokens,
-                },
-            )
-        if self.speculative_config and self.speculative_config.method == "mtp":
             sampler_output = self.spec_sampling_executor.execute_from_runtime(
                 metadata=spec_decode_metadata,
                 sampling_metadata=sampling_metadata,
@@ -2403,6 +2394,9 @@ class NPUModelRunner(GPUModelRunner):
                 enable_reduce_sample=get_ascend_config().enable_reduce_sample,
                 trim_logits_to_indices=lmhead_tp_enable() and logits is not None,
                 draft_probs=None,
+                write_markers=True,
+                num_reqs=self.input_batch.num_reqs,
+                num_spec_tokens=self.num_spec_tokens,
             )
         else:
             prepared_top_k = None
@@ -2415,13 +2409,6 @@ class NPUModelRunner(GPUModelRunner):
                 None,  # draft_probs
                 logits,
                 sampling_metadata,
-            )
-        if self.speculative_config and self.speculative_config.method == "mtp":
-            write_spec_sampling_marker(
-                "finished_mtp_sample",
-                {
-                    "sampled_token_ids_shape": list(sampler_output.sampled_token_ids.shape),
-                },
             )
         return sampler_output
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1439,6 +1439,11 @@ class NPUModelRunner(GPUModelRunner):
             counts_cpu = self.valid_sampled_token_count_cpu
             assert counts_cpu is not None
             counts_cpu[: counts.shape[0]].copy_(counts, non_blocking=True)
+            # Keep the CPU-side accepted-token view aligned with the same
+            # authoritative counts that drive the drafter path.
+            self.input_batch.num_accepted_tokens_cpu_tensor[: counts.shape[0]].copy_(
+                counts, non_blocking=True
+            )
             self.valid_sampled_token_count_event.record()
 
         if self.use_async_spec_decode:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2383,8 +2383,6 @@ class NPUModelRunner(GPUModelRunner):
                 sampling_metadata=sampling_metadata,
             )
 
-        if lmhead_tp_enable() and logits is not None:
-            logits = logits[: len(spec_decode_metadata.logits_indices)]
         if self.speculative_config and self.speculative_config.method == "mtp":
             write_spec_sampling_marker(
                 "entered_mtp_sample",
@@ -2395,7 +2393,7 @@ class NPUModelRunner(GPUModelRunner):
                 },
             )
         if self.speculative_config and self.speculative_config.method == "mtp":
-            inputs = self.spec_sampling_executor.build_inputs_from_runtime(
+            sampler_output = self.spec_sampling_executor.execute_from_runtime(
                 metadata=spec_decode_metadata,
                 sampling_metadata=sampling_metadata,
                 logits=logits,
@@ -2403,9 +2401,9 @@ class NPUModelRunner(GPUModelRunner):
                 if self.input_batch.sampling_metadata.top_k is not None
                 else None,
                 enable_reduce_sample=get_ascend_config().enable_reduce_sample,
+                trim_logits_to_indices=lmhead_tp_enable() and logits is not None,
                 draft_probs=None,
             )
-            sampler_output = self.spec_sampling_executor.execute(inputs)
         else:
             prepared_top_k = None
             if self.input_batch.sampling_metadata.top_k is not None and get_ascend_config().enable_reduce_sample:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -973,7 +973,11 @@ class NPUModelRunner(GPUModelRunner):
 
         # Sync num_accepted_tokens from CPU only when the current step is
         # actually running a spec path that consumes accepted-token semantics.
-        if self._step_needs_accepted_tokens(use_spec_decode) and self.num_accepted_tokens_event is not None:
+        if (
+            self._step_needs_accepted_tokens(use_spec_decode)
+            and self.use_async_scheduling
+            and self.num_accepted_tokens_event is not None
+        ):
             self.num_accepted_tokens_event.synchronize()
             # Async mode: condense() reordered indices, use prev_positions mapping
             if self.use_async_scheduling and prev_req_id_to_index:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2573,8 +2573,17 @@ class NPUModelRunner(GPUModelRunner):
                 )
         else:
             valid_sampled_token_ids = []
-            if discard_sampled_tokens_req_indices.numel() > 0:
-                invalid_req_indices = discard_sampled_tokens_req_indices.tolist()
+            num_invalid_req_indices = (
+                discard_sampled_tokens_req_indices.numel()
+                if hasattr(discard_sampled_tokens_req_indices, "numel")
+                else len(discard_sampled_tokens_req_indices)
+            )
+            if num_invalid_req_indices > 0:
+                invalid_req_indices = (
+                    discard_sampled_tokens_req_indices.tolist()
+                    if hasattr(discard_sampled_tokens_req_indices, "tolist")
+                    else list(discard_sampled_tokens_req_indices)
+                )
                 invalid_req_indices_set = set(invalid_req_indices)
             else:
                 invalid_req_indices = []

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -971,9 +971,9 @@ class NPUModelRunner(GPUModelRunner):
         self.discard_request_indices.np[: self.num_discarded_requests] = discard_request_indices
         self.discard_request_indices.copy_to_gpu(self.num_discarded_requests)
 
-        # Sync num_accepted_tokens from CPU (set by
-        # _update_states_after_model_execute for hybrid models).
-        if self.num_accepted_tokens_event is not None:
+        # Sync num_accepted_tokens from CPU only when the current step is
+        # actually running a spec path that consumes accepted-token semantics.
+        if self._step_needs_accepted_tokens(use_spec_decode) and self.num_accepted_tokens_event is not None:
             self.num_accepted_tokens_event.synchronize()
             # Async mode: condense() reordered indices, use prev_positions mapping
             if self.use_async_scheduling and prev_req_id_to_index:
@@ -1471,6 +1471,9 @@ class NPUModelRunner(GPUModelRunner):
             group=tp_group.device_group,
         )
         return spec_num_output_tokens_per_req
+
+    def _step_needs_accepted_tokens(self, use_spec_decode: bool) -> bool:
+        return bool(use_spec_decode and self.need_accepted_tokens)
 
     # TODO: Once the PCP features are complete, it will fully inherit the classes from the VLLM community.
     def propose_draft_token_ids(
@@ -2235,7 +2238,8 @@ class NPUModelRunner(GPUModelRunner):
                 positions=positions,
             )
 
-        if self.need_accepted_tokens:
+        step_needs_accepted_tokens = self._step_needs_accepted_tokens(spec_decode_metadata is not None)
+        if step_needs_accepted_tokens:
             if self.sampling_done_event is None:
                 self.sampling_done_event = torch.npu.Event()
 
@@ -2377,7 +2381,7 @@ class NPUModelRunner(GPUModelRunner):
 
         self._finalize_dump_data()
 
-        if self.need_accepted_tokens:
+        if step_needs_accepted_tokens:
             assert self.sampling_done_event is not None
             with (
                 record_function_or_nullcontext("async_state_update"),
@@ -3636,9 +3640,13 @@ class NPUModelRunner(GPUModelRunner):
         # NOTE(cmq): initialize_attn_backend must before using self.attn_groups
         self.initialize_attn_backend(kv_cache_config)
         self.use_hybrid_blocks = len(self.attn_groups) > 1
-        # NOTE: Currently, we determine whether we need `num_accepted_tokens` through `MambaSpec`.
+        # accepted-token semantics are consumed by Mamba paths and by GDN
+        # speculative attention metadata. Keep this conservative, but avoid
+        # enabling it for unrelated backends.
         self.need_accepted_tokens = any(
-            [isinstance(attn_group[0].kv_cache_spec, MambaSpec) for attn_group in self.attn_groups]
+            isinstance(attn_group[0].kv_cache_spec, MambaSpec)
+            or isinstance(attn_group[0].get_metadata_builder(0), GDNAttentionMetadataBuilder)
+            for attn_group in self.attn_groups
         )
 
         self.may_reinitialize_input_batch(kv_cache_config)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1008,9 +1008,10 @@ class NPUModelRunner(GPUModelRunner):
         # CPU values are optimistic (all drafts accepted). The kernel
         # corrects on GPU using the previous step's
         # valid_sampled_token_count_gpu. Otherwise, just copy from CPU.
+        valid_sampled_token_count_gpu = self.valid_sampled_token_count_gpu
         if (
             self.use_async_spec_decode
-            and self.valid_sampled_token_count_gpu is not None
+            and valid_sampled_token_count_gpu is not None
             and prev_req_id_to_index
         ):
             self.prev_positions.copy_to_gpu(num_reqs)
@@ -1022,7 +1023,7 @@ class NPUModelRunner(GPUModelRunner):
                 self.num_computed_tokens,
                 self.num_accepted_tokens.gpu[:num_reqs],
                 self.prev_positions.gpu[:num_reqs],
-                self.valid_sampled_token_count_gpu,
+                valid_sampled_token_count_gpu,
                 self.prev_num_draft_tokens.gpu,
                 cpu_values,
             )

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -165,7 +165,7 @@ from vllm_ascend.ascend_forward_context import (  # isort: skip
 from vllm.model_executor.layers.fused_moe.routed_experts_capturer import RoutedExpertsCapturer
 
 from vllm_ascend.sample.rejection_sampler import AscendRejectionSampler
-from vllm_ascend.sample.spec_sampling_poc import dump_spec_sampling_case
+from vllm_ascend.sample.spec_sampling_poc import dump_spec_sampling_case, write_spec_sampling_marker
 
 if TYPE_CHECKING:
     import xgrammar as xgr  # type: ignore[import-untyped]
@@ -2381,12 +2381,28 @@ class NPUModelRunner(GPUModelRunner):
         if self.input_batch.sampling_metadata.top_k is not None and get_ascend_config().enable_reduce_sample:
             max_topk = self.input_batch.top_k_cpu[self.input_batch.top_k_cpu < logits.shape[1]].max()
             self.rejection_sampler.prepare_sampling(max_topk)
+        if self.speculative_config and self.speculative_config.method == "mtp":
+            write_spec_sampling_marker(
+                "entered_mtp_sample",
+                {
+                    "logits_shape": list(logits.shape) if logits is not None else None,
+                    "num_reqs": self.input_batch.num_reqs,
+                    "num_spec_tokens": self.num_spec_tokens,
+                },
+            )
         sampler_output = self.rejection_sampler(
             spec_decode_metadata,
             None,  # draft_probs
             logits,
             sampling_metadata,
         )
+        if self.speculative_config and self.speculative_config.method == "mtp":
+            write_spec_sampling_marker(
+                "finished_mtp_sample",
+                {
+                    "sampled_token_ids_shape": list(sampler_output.sampled_token_ids.shape),
+                },
+            )
         return sampler_output
 
     def _maybe_dump_mtp_spec_sampling_case(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -721,6 +721,7 @@ class NPUModelRunner(GPUModelRunner):
         assert total_num_scheduled_tokens > 0
         num_reqs = self.input_batch.num_reqs
         assert num_reqs > 0
+        use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
 
         # OPTIMIZATION: Start copying the block table first.
         # This way, we can overlap the copy with the following CPU operations.
@@ -1068,12 +1069,7 @@ class NPUModelRunner(GPUModelRunner):
         # attention backends (which use _seq_lens_cpu) get the right values.
         # Use non_blocking copy to pinned memory and record an event;
         # _build_attention_metadata will synchronize before reading.
-        if (
-            self._needs_seq_lens_cpu_sync
-            and self.use_async_spec_decode
-            and self.valid_sampled_token_count_gpu is not None
-            and prev_req_id_to_index
-        ):
+        if self._step_needs_seq_lens_cpu_sync(use_spec_decode, prev_req_id_to_index):
             self.optimistic_seq_lens_cpu[:num_reqs].copy_(
                 self.seq_lens[:num_reqs], non_blocking=True
             )
@@ -1087,12 +1083,7 @@ class NPUModelRunner(GPUModelRunner):
         num_computed_tokens_for_compress = (
             self.input_batch.num_computed_tokens_cpu[:num_reqs]
         )
-        if (
-            self.use_compress
-            and self.use_async_spec_decode
-            and self.valid_sampled_token_count_gpu is not None
-            and prev_req_id_to_index
-        ):
+        if self.use_compress and self._step_needs_seq_lens_cpu_sync(use_spec_decode, prev_req_id_to_index):
             # Async spec decode keeps the CPU counter optimistic until after
             # target forward is launched. DSV4 compressed KV slot mapping is
             # CPU-built today, so use the GPU-corrected counter before
@@ -1138,7 +1129,6 @@ class NPUModelRunner(GPUModelRunner):
             target = self.mrope_positions if self.uses_mrope else self.xdrope_positions
             target.gpu[:, :total_num_scheduled_tokens] += drift
 
-        use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
         if not use_spec_decode:
             # NOTE(woosuk): Due to chunked prefills, the batch may contain
             # partial requests. While we should not sample any token
@@ -1478,6 +1468,19 @@ class NPUModelRunner(GPUModelRunner):
 
     def _step_needs_accepted_tokens(self, use_spec_decode: bool) -> bool:
         return bool(use_spec_decode and self.need_accepted_tokens)
+
+    def _step_needs_seq_lens_cpu_sync(
+        self,
+        use_spec_decode: bool,
+        prev_req_id_to_index,
+    ) -> bool:
+        return bool(
+            use_spec_decode
+            and self._needs_seq_lens_cpu_sync
+            and self.use_async_spec_decode
+            and self.valid_sampled_token_count_gpu is not None
+            and prev_req_id_to_index
+        )
 
     # TODO: Once the PCP features are complete, it will fully inherit the classes from the VLLM community.
     def propose_draft_token_ids(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2239,7 +2239,7 @@ class NPUModelRunner(GPUModelRunner):
             )
 
         step_needs_accepted_tokens = self._step_needs_accepted_tokens(spec_decode_metadata is not None)
-        if step_needs_accepted_tokens:
+        if step_needs_accepted_tokens and self.use_async_scheduling:
             if self.sampling_done_event is None:
                 self.sampling_done_event = torch.npu.Event()
 
@@ -2381,7 +2381,7 @@ class NPUModelRunner(GPUModelRunner):
 
         self._finalize_dump_data()
 
-        if step_needs_accepted_tokens:
+        if step_needs_accepted_tokens and self.use_async_scheduling:
             assert self.sampling_done_event is not None
             with (
                 record_function_or_nullcontext("async_state_update"),

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -165,6 +165,10 @@ from vllm_ascend.ascend_forward_context import (  # isort: skip
 from vllm.model_executor.layers.fused_moe.routed_experts_capturer import RoutedExpertsCapturer
 
 from vllm_ascend.sample.rejection_sampler import AscendRejectionSampler
+from vllm_ascend.sample.spec_sampling_executor import (
+    PreparedSpecSamplingInputs,
+    SpecSamplingNPUExecutor,
+)
 from vllm_ascend.sample.spec_sampling_poc import dump_spec_sampling_case, write_spec_sampling_marker
 
 if TYPE_CHECKING:
@@ -580,6 +584,10 @@ class NPUModelRunner(GPUModelRunner):
                     assert isinstance(self.drafter, AscendExtractHiddenStatesProposer)
                     self.use_aux_hidden_state_outputs = True
                 self.rejection_sampler = AscendRejectionSampler(self.sampler)
+                self.spec_sampling_executor = SpecSamplingNPUExecutor(
+                    self.sampler,
+                    self.rejection_sampler,
+                )
         self.discard_request_indices = self._make_buffer(self.max_num_reqs, dtype=torch.int64)
         self.num_discarded_requests = 0
 
@@ -2378,9 +2386,9 @@ class NPUModelRunner(GPUModelRunner):
 
         if lmhead_tp_enable() and logits is not None:
             logits = logits[: len(spec_decode_metadata.logits_indices)]
+        prepared_top_k = None
         if self.input_batch.sampling_metadata.top_k is not None and get_ascend_config().enable_reduce_sample:
-            max_topk = self.input_batch.top_k_cpu[self.input_batch.top_k_cpu < logits.shape[1]].max()
-            self.rejection_sampler.prepare_sampling(max_topk)
+            prepared_top_k = self.input_batch.top_k_cpu[self.input_batch.top_k_cpu < logits.shape[1]].max()
         if self.speculative_config and self.speculative_config.method == "mtp":
             write_spec_sampling_marker(
                 "entered_mtp_sample",
@@ -2390,12 +2398,24 @@ class NPUModelRunner(GPUModelRunner):
                     "num_spec_tokens": self.num_spec_tokens,
                 },
             )
-        sampler_output = self.rejection_sampler(
-            spec_decode_metadata,
-            None,  # draft_probs
-            logits,
-            sampling_metadata,
-        )
+        if self.speculative_config and self.speculative_config.method == "mtp":
+            inputs = PreparedSpecSamplingInputs(
+                metadata=spec_decode_metadata,
+                sampling_metadata=sampling_metadata,
+                logits=logits,
+                draft_probs=None,
+                prepared_top_k=int(prepared_top_k) if prepared_top_k is not None else None,
+            )
+            sampler_output = self.spec_sampling_executor.execute(inputs)
+        else:
+            if prepared_top_k is not None:
+                self.rejection_sampler.prepare_sampling(prepared_top_k)
+            sampler_output = self.rejection_sampler(
+                spec_decode_metadata,
+                None,  # draft_probs
+                logits,
+                sampling_metadata,
+            )
         if self.speculative_config and self.speculative_config.method == "mtp":
             write_spec_sampling_marker(
                 "finished_mtp_sample",


### PR DESCRIPTION
### What this PR does / why we need it?

  This PR refactors the MTP speculative sampling path on Ascend into an explicit execution boundary and aligns the downstream lifecycle/rollback paths around the executor result.

  Main changes:

  - Introduce SpecSamplingNPUExecutor as the explicit MTP speculative sampling execution path.
  - Move bonus sampling, target-logits preprocessing, rejection sampling, and sampler output assembly behind the executor boundary.
  - Make the executor return an explicit per-request result (num_output_tokens_per_req) instead of relying on downstream re-derivation.
  - Feed executor results back into the drafter path, host accepted-token state, and scheduler rollback flow.
  - Align KV transfer finish sizing with committed-block semantics instead of prompt-block-only semantics.
  - Cover delay-free -> finished_sending -> true free lifecycle with deterministic audit tooling and focused unit tests.
  - Add rollback coverage for invalid block load, delayed-send abort, worker/scheduler half-commit cases, and duplicate completion signal idempotency.
  - Add a minimal TP rank0 authority sync for num_output_tokens_per_req under MTP.
  - Add a first round of low-risk sync-boundary optimizations to reduce unnecessary speculative-path synchronization overhead.

  Why this is needed:

  - The previous path already had some sampling kernels on NPU, but the full MTP sampling/result/lifecycle chain was still spread across multiple layers with implicit state flow
    and repeated result derivation.

  - That made it difficult to reason about correctness for rollback, drafter input preparation, KV lifecycle, and TP consistency.
  - This PR turns the MTP path into an explicit execution/result boundary, so later lifecycle/state consumers use one authoritative step result.
  - It also establishes the first production-oriented rollback/lifecycle protocol for committed-block transfer and delayed free handling.

  This PR is intentionally scoped to the first full engineeringization stage of the MTP speculative sampling path. It does not claim that all control-plane/state-plane logic is
  fully device-side; instead, it makes the current hybrid NPU/host path explicit, consistent, and testable.

  ### Does this PR introduce any user-facing change?

  No API or interface change is intended.

  Behaviorally, this PR changes the internal MTP speculative sampling execution path, lifecycle alignment, and rollback handling on Ascend. It is intended to preserve or improve
  correctness and stability while slightly changing low-level performance tradeoffs in some scenarios.

  ### How was this patch tested?

  Tested with a mix of:

  - focused unit tests
  - deterministic KV lifecycle audit
  - real MTP remote regression on target hardware

  Focused unit tests:

  cd /vllm-workspace/vllm-ascend

  pytest -q tests/ut/worker/a2/test_model_runner_v1.py -q
  pytest -q tests/ut/core/test_profiling_chunk.py::TestProfilingChunkScheduler::test_update_from_output_rolls_back_rejected_spec_tokens -q
  pytest -q tests/ut/kv_offload/test_mooncake_connector.py -q
  pytest -q tests/ut/kv_offload/a2/test_remote_decode_lifecycle.py -q
  pytest -q tests/ut/kv_offload/a2/test_remote_prefill_lifecycle.py -q

  Deterministic KV lifecycle audit:

  cd /vllm-workspace/vllm-ascend

  python3 tools/run_kv_lifecycle_audit.py \
    --iterations 10 \
    --block-size 2 \
    --max-num-batched-tokens 32 \
    --num-tokens 4 \
    --out /tmp/kv_lifecycle_audit.json

  Observed audit result:

  - passed=True
  - failures=0

  Real MTP remote regressions were run in the target container environment on syn-116:

  - Qwen3___5-27B-w8a8-mtp with TP=2
  - DeepSeek-V4-Flash-w8a8-mtp with TP=8

  These regressions successfully:

  - entered the MTP sampling path
  - produced marker_runner_start.json
  - produced marker_entered_mtp_sample.json
  - produced marker_finished_mtp_sample.json
  - dumped case_000/case.pt

  Replay verification was also run with the dumped MTP cases, and the replay matched expected sampled_token_ids.

  Additional notes for reviewers:

  - This branch was rebased onto the latest upstream main before push.
  - The PR contains a relatively long local history because it captures the full progression from PoC tooling to executor/lifecycle/rollback alignment. Review is easiest if
    grouped by:
      1. PoC/sample dump tooling
      2. first executor introduction
      3. mainline result flow
      4. committed-block/KV lifecycle alignment
      5. rollback and TP authority sync

  ### author
  - [calyoung](zsucal@hotmail)
  - [BobQiu1981](qiumingbo81@163.com)

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
