### PR TITLE
[BugFix] Align vllm-ascend with upstream vLLM UT expectation

### DIFF
--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -291,3 +291,20 @@ class TestAscendConfig(TestBase):
         test_vllm_config.additional_config = {"dump_config": "/tmp/config.json"}
         with self.assertRaises(ValueError):
             init_ascend_config(test_vllm_config)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_init_ascend_config_recreates_for_new_vllm_config(self, mock_fix_incompatible_config):
+        first_vllm_config = VllmConfig()
+        first_vllm_config.additional_config = {
+            "ascend_compilation_config": {
+                "enable_npugraph_ex": False,
+            }
+        }
+        first_ascend_config = init_ascend_config(first_vllm_config)
+        self.assertFalse(first_ascend_config.ascend_compilation_config.enable_npugraph_ex)
+
+        second_vllm_config = VllmConfig()
+        second_ascend_config = init_ascend_config(second_vllm_config)
+        self.assertIsNot(first_ascend_config, second_ascend_config)
+        self.assertTrue(second_ascend_config.ascend_compilation_config.enable_npugraph_ex)

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -1,5 +1,4 @@
 import importlib
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -316,10 +315,7 @@ class TestNPUPlatform(TestBase):
     def test_check_and_update_config_basic_config_update(
         self, mock_init_recompute, mock_soc_version, mock_init_ascend, mock_auto_detect
     ):
-        ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
-        ascend_config.ascend_compilation_config = SimpleNamespace(enable_npugraph_ex=True)
-        ascend_config.ascend_fusion_config = SimpleNamespace(fusion_ops_gmmswigluquant=True)
-        mock_init_ascend.return_value = ascend_config
+        mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
         vllm_config.parallel_config.enable_expert_parallel = False
         vllm_config.parallel_config.decode_context_parallel_size = 1
@@ -340,8 +336,6 @@ class TestNPUPlatform(TestBase):
         self.platform.check_and_update_config(vllm_config)
 
         mock_init_ascend.assert_called_once_with(vllm_config)
-        self.assertFalse(vllm_config.additional_config["ascend_compilation_config"]["enable_npugraph_ex"])
-        self.assertTrue(vllm_config.additional_config["ascend_fusion_config"]["fusion_ops_gmmswigluquant"])
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -236,7 +236,7 @@ class TestNPUPlatform(TestBase):
 
         self.assertEqual(self.platform.get_device_total_memory(0), 32768 * 1024 * 1024)
         mock_check_output.assert_called_once_with(
-            ["npu-smi", "info", "-t", "memory", "-i", "0", "-c", "0"],
+            ["npu-smi", "info", "-t", "memory", "-i", "0"],
             stderr=-3,
             text=True,
         )

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -25,6 +25,8 @@ class TestNPUPlatform(TestBase):
         mock_vllm_config.model_config = MagicMock()
         mock_vllm_config.model_config.is_hybrid = False
         mock_vllm_config.model_config.is_encoder_decoder = False
+        mock_vllm_config.device_config = MagicMock()
+        mock_vllm_config.device_config.device_type = "npu"
         mock_vllm_config.parallel_config = MagicMock()
         mock_vllm_config.cache_config = MagicMock()
         mock_vllm_config.scheduler_config = MagicMock()
@@ -224,6 +226,21 @@ class TestNPUPlatform(TestBase):
         mock_get_device_name.return_value = device_name
         self.assertEqual(self.platform.get_device_name(device_id), device_name)
         mock_get_device_name.assert_called_once_with(0)
+
+    @patch("torch.npu.get_device_properties")
+    @patch("vllm_ascend.platform.subprocess.check_output")
+    def test_get_device_total_memory_prefers_npu_smi(self, mock_check_output, mock_get_device_properties):
+        mock_check_output.return_value = (
+            "        DDR Capacity(MB)               : 0\n        HBM Capacity(MB)               : 32768\n"
+        )
+
+        self.assertEqual(self.platform.get_device_total_memory(0), 32768 * 1024 * 1024)
+        mock_check_output.assert_called_once_with(
+            ["npu-smi", "info", "-t", "memory", "-i", "0", "-c", "0"],
+            stderr=-3,
+            text=True,
+        )
+        mock_get_device_properties.assert_not_called()
 
     @patch("torch.npu.get_device_properties")
     def test_get_device_uuid(self, mock_get_device_properties):

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -243,6 +243,17 @@ class TestNPUPlatform(TestBase):
         mock_get_device_properties.assert_not_called()
 
     @patch("torch.npu.get_device_properties")
+    @patch("vllm_ascend.platform.subprocess.check_output", side_effect=PermissionError)
+    def test_get_device_total_memory_falls_back_on_permission_error(
+        self, mock_check_output, mock_get_device_properties
+    ):
+        mock_get_device_properties.return_value.total_memory = 16 * 1024 * 1024
+
+        self.assertEqual(self.platform.get_device_total_memory(0), 16 * 1024 * 1024)
+        mock_check_output.assert_called_once()
+        mock_get_device_properties.assert_called_once_with(0)
+
+    @patch("torch.npu.get_device_properties")
     def test_get_device_uuid(self, mock_get_device_properties):
         device_id = 0
         device_properties = MagicMock()

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -1,4 +1,5 @@
 import importlib
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -315,7 +316,10 @@ class TestNPUPlatform(TestBase):
     def test_check_and_update_config_basic_config_update(
         self, mock_init_recompute, mock_soc_version, mock_init_ascend, mock_auto_detect
     ):
-        mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
+        ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
+        ascend_config.ascend_compilation_config = SimpleNamespace(enable_npugraph_ex=True)
+        ascend_config.ascend_fusion_config = SimpleNamespace(fusion_ops_gmmswigluquant=True)
+        mock_init_ascend.return_value = ascend_config
         vllm_config = TestNPUPlatform.mock_vllm_config()
         vllm_config.parallel_config.enable_expert_parallel = False
         vllm_config.parallel_config.decode_context_parallel_size = 1
@@ -336,6 +340,8 @@ class TestNPUPlatform(TestBase):
         self.platform.check_and_update_config(vllm_config)
 
         mock_init_ascend.assert_called_once_with(vllm_config)
+        self.assertFalse(vllm_config.additional_config["ascend_compilation_config"]["enable_npugraph_ex"])
+        self.assertTrue(vllm_config.additional_config["ascend_fusion_config"]["fusion_ops_gmmswigluquant"])
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -31,7 +31,6 @@ class AscendConfig:
 
     def __init__(self, vllm_config: "VllmConfig"):
         self.vllm_config = vllm_config
-        model_config = vllm_config.model_config
         additional_config = vllm_config.additional_config if vllm_config.additional_config is not None else {}
 
         xlite_graph_config = additional_config.get("xlite_graph_config", {})
@@ -178,14 +177,18 @@ class AscendConfig:
         self.pd_tp_ratio = 1
         self.pd_head_ratio = 1
         self.num_head_replica = 1
-        if vllm_config.kv_transfer_config is not None and model_config is not None and not model_config.is_deepseek_mla:
+        if (
+            vllm_config.kv_transfer_config is not None
+            and vllm_config.model_config is not None
+            and not vllm_config.model_config.is_deepseek_mla
+        ):
             prefill_tp_size = vllm_config.kv_transfer_config.get_from_extra_config("prefill", {"tp_size": 1})["tp_size"]
             decode_tp_size = vllm_config.kv_transfer_config.get_from_extra_config("decode", {"tp_size": 1})["tp_size"]
             assert prefill_tp_size % decode_tp_size == 0, "Prefill TP size must be divisible by Decode TP size."
             self.pd_tp_ratio = prefill_tp_size // decode_tp_size
             if self.pd_tp_ratio > 1:
                 # Total KV heads from vLLM's resolved architecture (ModelArchConfigConvertor).
-                num_kv_head = model_config.get_total_num_kv_heads()
+                num_kv_head = vllm_config.model_config.get_total_num_kv_heads()
                 if not num_kv_head or num_kv_head < 1:
                     raise ValueError(
                         "Could not determine a positive total KV head count for PD "
@@ -227,16 +230,16 @@ class AscendConfig:
         )
 
         use_sparse = (
-            model_config is not None
-            and hasattr(model_config, "hf_text_config")
-            and hasattr(model_config.hf_text_config, "index_topk")
+            vllm_config.model_config is not None
+            and hasattr(vllm_config.model_config, "hf_text_config")
+            and hasattr(vllm_config.model_config.hf_text_config, "index_topk")
         )
 
         self.enable_kv_nz = additional_config.get("enable_kv_nz", False)
         if self.enable_kv_nz:
-            if model_config is None:
+            if vllm_config.model_config is None:
                 raise RuntimeError("enable_kv_nz requires a valid model_config.")
-            if not model_config.is_deepseek_mla or use_sparse:
+            if not vllm_config.model_config.is_deepseek_mla or use_sparse:
                 raise RuntimeError("enable_kv_nz is only supported for mla currently.")
             if vllm_config.kv_transfer_config is None or not vllm_config.kv_transfer_config.is_kv_consumer:
                 raise NotImplementedError(
@@ -250,8 +253,8 @@ class AscendConfig:
         )
         self._sparse_c8_layer_filter_enabled = self._has_sparse_c8_layer_config(quant_config)
         self.enable_sp_by_pass = (
-            model_config is not None
-            and not model_config.enforce_eager
+            vllm_config.model_config is not None
+            and not vllm_config.model_config.enforce_eager
             and vllm_config.compilation_config.pass_config.enable_sp
         )
 
@@ -424,7 +427,6 @@ class FinegrainedTPConfig:
     """
 
     def __init__(self, finegrained_tp_config: dict, vllm_config):
-        model_config = vllm_config.model_config
         self.oproj_tensor_parallel_size = finegrained_tp_config.get("oproj_tensor_parallel_size", 0)
         self.lmhead_tensor_parallel_size = finegrained_tp_config.get("lmhead_tensor_parallel_size", 0)
         self.embedding_tensor_parallel_size = finegrained_tp_config.get("embedding_tensor_parallel_size", 0)
@@ -436,7 +438,7 @@ class FinegrainedTPConfig:
             enabled_configs.append(f"oproj_tensor_parallel_size={self.oproj_tensor_parallel_size}")
             # dummy_run does not run the entire attention module in eager mode,
             # so the o_proj tp split can only be used in graph mode.
-            if model_config and model_config.enforce_eager:
+            if vllm_config.model_config and vllm_config.model_config.enforce_eager:
                 raise AssertionError("oproj_tensor_parallel_size is only supported in graph mode")
             if vllm_config.kv_transfer_config is None or not vllm_config.kv_transfer_config.is_kv_consumer:
                 raise AssertionError(
@@ -446,7 +448,7 @@ class FinegrainedTPConfig:
             enabled_configs.append(f"olora_tensor_parallel_size={self.olora_tensor_parallel_size}")
             # dummy_run does not run the entire attention module in eager mode,
             # so the o_lora tp split can only be used in graph mode.
-            if model_config and model_config.enforce_eager:
+            if vllm_config.model_config and vllm_config.model_config.enforce_eager:
                 raise AssertionError("olora_tensor_parallel_size is only supported in graph mode")
             if vllm_config.kv_transfer_config is None or not vllm_config.kv_transfer_config.is_kv_consumer:
                 raise AssertionError(

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -31,6 +31,7 @@ class AscendConfig:
 
     def __init__(self, vllm_config: "VllmConfig"):
         self.vllm_config = vllm_config
+        model_config = vllm_config.model_config
         additional_config = vllm_config.additional_config if vllm_config.additional_config is not None else {}
 
         xlite_graph_config = additional_config.get("xlite_graph_config", {})
@@ -177,14 +178,14 @@ class AscendConfig:
         self.pd_tp_ratio = 1
         self.pd_head_ratio = 1
         self.num_head_replica = 1
-        if vllm_config.kv_transfer_config is not None and not vllm_config.model_config.is_deepseek_mla:
+        if vllm_config.kv_transfer_config is not None and model_config is not None and not model_config.is_deepseek_mla:
             prefill_tp_size = vllm_config.kv_transfer_config.get_from_extra_config("prefill", {"tp_size": 1})["tp_size"]
             decode_tp_size = vllm_config.kv_transfer_config.get_from_extra_config("decode", {"tp_size": 1})["tp_size"]
             assert prefill_tp_size % decode_tp_size == 0, "Prefill TP size must be divisible by Decode TP size."
             self.pd_tp_ratio = prefill_tp_size // decode_tp_size
             if self.pd_tp_ratio > 1:
                 # Total KV heads from vLLM's resolved architecture (ModelArchConfigConvertor).
-                num_kv_head = vllm_config.model_config.get_total_num_kv_heads()
+                num_kv_head = model_config.get_total_num_kv_heads()
                 if not num_kv_head or num_kv_head < 1:
                     raise ValueError(
                         "Could not determine a positive total KV head count for PD "
@@ -225,13 +226,17 @@ class AscendConfig:
             bool(additional_config.get("enable_async_exponential", False)) and not envs.VLLM_BATCH_INVARIANT
         )
 
-        use_sparse = hasattr(vllm_config.model_config, "hf_text_config") and hasattr(
-            vllm_config.model_config.hf_text_config, "index_topk"
+        use_sparse = (
+            model_config is not None
+            and hasattr(model_config, "hf_text_config")
+            and hasattr(model_config.hf_text_config, "index_topk")
         )
 
         self.enable_kv_nz = additional_config.get("enable_kv_nz", False)
         if self.enable_kv_nz:
-            if not vllm_config.model_config.is_deepseek_mla or use_sparse:
+            if model_config is None:
+                raise RuntimeError("enable_kv_nz requires a valid model_config.")
+            if not model_config.is_deepseek_mla or use_sparse:
                 raise RuntimeError("enable_kv_nz is only supported for mla currently.")
             if vllm_config.kv_transfer_config is None or not vllm_config.kv_transfer_config.is_kv_consumer:
                 raise NotImplementedError(
@@ -245,8 +250,8 @@ class AscendConfig:
         )
         self._sparse_c8_layer_filter_enabled = self._has_sparse_c8_layer_config(quant_config)
         self.enable_sp_by_pass = (
-            vllm_config.model_config is not None
-            and not vllm_config.model_config.enforce_eager
+            model_config is not None
+            and not model_config.enforce_eager
             and vllm_config.compilation_config.pass_config.enable_sp
         )
 
@@ -419,6 +424,7 @@ class FinegrainedTPConfig:
     """
 
     def __init__(self, finegrained_tp_config: dict, vllm_config):
+        model_config = vllm_config.model_config
         self.oproj_tensor_parallel_size = finegrained_tp_config.get("oproj_tensor_parallel_size", 0)
         self.lmhead_tensor_parallel_size = finegrained_tp_config.get("lmhead_tensor_parallel_size", 0)
         self.embedding_tensor_parallel_size = finegrained_tp_config.get("embedding_tensor_parallel_size", 0)
@@ -430,7 +436,7 @@ class FinegrainedTPConfig:
             enabled_configs.append(f"oproj_tensor_parallel_size={self.oproj_tensor_parallel_size}")
             # dummy_run does not run the entire attention module in eager mode,
             # so the o_proj tp split can only be used in graph mode.
-            if vllm_config.model_config.enforce_eager:
+            if model_config and model_config.enforce_eager:
                 raise AssertionError("oproj_tensor_parallel_size is only supported in graph mode")
             if vllm_config.kv_transfer_config is None or not vllm_config.kv_transfer_config.is_kv_consumer:
                 raise AssertionError(
@@ -440,7 +446,7 @@ class FinegrainedTPConfig:
             enabled_configs.append(f"olora_tensor_parallel_size={self.olora_tensor_parallel_size}")
             # dummy_run does not run the entire attention module in eager mode,
             # so the o_lora tp split can only be used in graph mode.
-            if vllm_config.model_config.enforce_eager is True:
+            if model_config and model_config.enforce_eager:
                 raise AssertionError("olora_tensor_parallel_size is only supported in graph mode")
             if vllm_config.kv_transfer_config is None or not vllm_config.kv_transfer_config.is_kv_consumer:
                 raise AssertionError(
@@ -708,7 +714,12 @@ def init_ascend_config(vllm_config):
     additional_config = vllm_config.additional_config if vllm_config.additional_config is not None else {}
     refresh = additional_config.get("refresh", False) if additional_config else False
     global _ASCEND_CONFIG
-    if _ASCEND_CONFIG is not None and not refresh and _is_ascend_config_initialized(_ASCEND_CONFIG):
+    if (
+        _ASCEND_CONFIG is not None
+        and not refresh
+        and _is_ascend_config_initialized(_ASCEND_CONFIG)
+        and getattr(_ASCEND_CONFIG, "vllm_config", None) is vllm_config
+    ):
         return _ASCEND_CONFIG
     new_config = AscendConfig(vllm_config)
     if _is_ascend_config_initialized(new_config):

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -74,7 +74,7 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         w_t_all: torch.Tensor,
         scale: float,
     ):
-        self.bgmv_shrink(x, w_t_all, y, self.token_lora_indices, scale)
+        self.bgmv_shrink(x, w_t_all, y, self._get_token_lora_indices(x), scale)
 
     def _expand_prefill(
         self,
@@ -101,7 +101,7 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         w_t_all: torch.Tensor,
         add_inputs: bool,
     ):
-        self.bgmv_expand(x, w_t_all, y, self.token_lora_indices, add_inputs)
+        self.bgmv_expand(x, w_t_all, y, self._get_token_lora_indices(x), add_inputs)
 
     def _expand_slice_prefill(
         self,
@@ -134,7 +134,18 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         y_slice_size: int,
         add_inputs: bool,
     ):
-        self.bgmv_expand_slice(x, w_t_all, y, self.token_lora_indices, y_offset, y_slice_size, add_inputs)
+        self.bgmv_expand_slice(
+            x,
+            w_t_all,
+            y,
+            self._get_token_lora_indices(x),
+            y_offset,
+            y_slice_size,
+            add_inputs,
+        )
+
+    def _get_token_lora_indices(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.narrow(self._token_lora_indices, 0, 0, x.size(0))
 
     def _apply_expand(
         self,
@@ -344,7 +355,7 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         if buffer is None:
             buffer = torch.zeros((x.size(0), r), dtype=torch.float32, device=x.device)
 
-        indices = self.sampler_indices
+        indices = torch.narrow(self._sampler_indices, 0, 0, x.size(0))
 
         self.bgmv_shrink(x, lora_a_stacked, buffer, indices, scale)
         self.bgmv_expand(buffer, lora_b_stacked, y, indices, add_inputs=True)

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -447,11 +447,24 @@ class NPUPlatform(Platform):
         model_config = vllm_config.model_config
         parallel_config = vllm_config.parallel_config
         cache_config = vllm_config.cache_config
+        ascend_compilation_config = ascend_config.ascend_compilation_config
+        if ascend_compilation_config:
+            vllm_config.additional_config.setdefault("ascend_compilation_config", {}).update(
+                vars(ascend_compilation_config)
+                if not isinstance(ascend_compilation_config, dict)
+                else ascend_compilation_config
+            )
 
         ascend_config.update_compile_ranges_split_points()
 
         if model_config and hasattr(model_config.hf_text_config, "index_topk"):
             vllm_config.cache_config.cache_dtype = str(model_config.dtype).replace("torch.", "")
+
+        ascend_fusion_config = ascend_config.ascend_fusion_config
+        if ascend_fusion_config:
+            vllm_config.additional_config.setdefault("ascend_fusion_config", {}).update(
+                vars(ascend_fusion_config) if not isinstance(ascend_fusion_config, dict) else ascend_fusion_config
+            )
 
         enforce_eager = getattr(model_config, "enforce_eager", False)
 
@@ -584,20 +597,6 @@ class NPUPlatform(Platform):
                 "need ASCEND_LAUNCH_BLOCKING for debugging, consider other methods — "
                 "for example, check the plog files (default: $HOME/ascend/log/debug) "
                 "for more information about runtime errors."
-            )
-
-        ascend_compilation_config = ascend_config.ascend_compilation_config
-        if ascend_compilation_config:
-            vllm_config.additional_config.setdefault("ascend_compilation_config", {}).update(
-                vars(ascend_compilation_config)
-                if not isinstance(ascend_compilation_config, dict)
-                else ascend_compilation_config
-            )
-
-        ascend_fusion_config = ascend_config.ascend_fusion_config
-        if ascend_fusion_config:
-            vllm_config.additional_config.setdefault("ascend_fusion_config", {}).update(
-                vars(ascend_fusion_config) if not isinstance(ascend_fusion_config, dict) else ascend_fusion_config
             )
 
         if parallel_config and parallel_config.worker_cls == "auto":

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -88,7 +88,7 @@ def _get_npu_smi_hbm_capacity_mb(device_id: int) -> int | None:
             stderr=subprocess.DEVNULL,
             text=True,
         )
-    except (FileNotFoundError, subprocess.CalledProcessError):
+    except (OSError, subprocess.CalledProcessError):
         return None
 
     value = _get_npu_smi_field(output.splitlines(), "HBM Capacity(MB)")

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -84,7 +84,7 @@ def _get_npu_smi_field(lines: list[str], key: str) -> str | None:
 def _get_npu_smi_hbm_capacity_mb(device_id: int) -> int | None:
     try:
         output = subprocess.check_output(
-            ["npu-smi", "info", "-t", "memory", "-i", str(device_id), "-c", "0"],
+            ["npu-smi", "info", "-t", "memory", "-i", str(device_id)],
             stderr=subprocess.DEVNULL,
             text=True,
         )

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import math
 import os
+import subprocess
 from importlib import import_module, util
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
@@ -70,6 +71,34 @@ else:
     FlexibleArgumentParser = None
 
 _CUSTOM_OP_REGISTERED = False
+
+
+def _get_npu_smi_field(lines: list[str], key: str) -> str | None:
+    for line in lines:
+        normalized = " ".join(line.split())
+        if normalized.startswith(f"{key} :"):
+            return normalized.split(":", 1)[1].strip()
+    return None
+
+
+def _get_npu_smi_hbm_capacity_mb(device_id: int) -> int | None:
+    try:
+        output = subprocess.check_output(
+            ["npu-smi", "info", "-t", "memory", "-i", str(device_id), "-c", "0"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+    value = _get_npu_smi_field(output.splitlines(), "HBM Capacity(MB)")
+    if value is None:
+        return None
+
+    try:
+        return int(value)
+    except ValueError:
+        return None
 
 
 def config_deprecated_logging():
@@ -148,6 +177,22 @@ class NPUPlatform(Platform):
         To use graph fusion operations, we defined our own backend compiler.
         """
         return "vllm_ascend.compilation.compiler_interface.AscendCompiler"
+
+    @staticmethod
+    def _sync_additional_config(vllm_config: VllmConfig, ascend_config) -> None:
+        ascend_compilation_config = getattr(ascend_config, "ascend_compilation_config", None)
+        if ascend_compilation_config:
+            vllm_config.additional_config.setdefault("ascend_compilation_config", {}).update(
+                vars(ascend_compilation_config)
+                if not isinstance(ascend_compilation_config, dict)
+                else ascend_compilation_config
+            )
+
+        ascend_fusion_config = getattr(ascend_config, "ascend_fusion_config", None)
+        if ascend_fusion_config:
+            vllm_config.additional_config.setdefault("ascend_fusion_config", {}).update(
+                vars(ascend_fusion_config) if not isinstance(ascend_fusion_config, dict) else ascend_fusion_config
+            )
 
     @classmethod
     def pre_register_and_update(cls, parser: FlexibleArgumentParser | None = None) -> None:
@@ -241,6 +286,20 @@ class NPUPlatform(Platform):
         return device_props.uuid
 
     @classmethod
+    def get_device_total_memory(cls, device_id: int = 0) -> int:
+        """
+        Return total memory of the device in bytes.
+        """
+        hbm_capacity_mb = _get_npu_smi_hbm_capacity_mb(device_id)
+        if hbm_capacity_mb is not None:
+            return hbm_capacity_mb * 1024 * 1024
+
+        device_props = torch.npu.get_device_properties(device_id)
+        total_memory = getattr(device_props, "total_memory", None)
+        if total_memory is not None:
+            return int(total_memory)
+        raise RuntimeError(f"Unable to determine total memory for device {device_id}.")
+
     def num_compute_units(cls, device_id: int = 0) -> int:
         """Return the number of Cube Cores on the NPU device.
         This is the NPU equivalent of CUDA's ``multi_processor_count``
@@ -371,8 +430,19 @@ class NPUPlatform(Platform):
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
         from vllm_ascend.quantization.utils import maybe_auto_detect_quantization
 
-        if vllm_config.model_config is not None:
-            maybe_auto_detect_quantization(vllm_config)
+        device_config = getattr(vllm_config, "device_config", None)
+        if device_config is not None and getattr(device_config, "device_type", cls.device_type) != cls.device_type:
+            logger.debug(
+                "Skipping Ascend-specific config updates for device type %s.",
+                device_config.device_type,
+            )
+            return
+
+        if vllm_config.model_config is None:
+            logger.warning("Model config is missing. Skipping Ascend-specific config updates.")
+            return
+
+        maybe_auto_detect_quantization(vllm_config)
 
         cls._validate_layer_sharding_config(vllm_config)
         cls._validate_draft_decode_context_parallel_config(vllm_config)
@@ -393,32 +463,13 @@ class NPUPlatform(Platform):
         model_config = vllm_config.model_config
         parallel_config = vllm_config.parallel_config
         cache_config = vllm_config.cache_config
-        ascend_compilation_config = ascend_config.ascend_compilation_config
-        if ascend_compilation_config:
-            vllm_config.additional_config.setdefault("ascend_compilation_config", {}).update(
-                vars(ascend_compilation_config)
-                if not isinstance(ascend_compilation_config, dict)
-                else ascend_compilation_config
-            )
 
         ascend_config.update_compile_ranges_split_points()
 
         if model_config and hasattr(model_config.hf_text_config, "index_topk"):
             vllm_config.cache_config.cache_dtype = str(model_config.dtype).replace("torch.", "")
 
-        ascend_fusion_config = ascend_config.ascend_fusion_config
-        if ascend_fusion_config:
-            vllm_config.additional_config.setdefault("ascend_fusion_config", {}).update(
-                vars(ascend_fusion_config) if not isinstance(ascend_fusion_config, dict) else ascend_fusion_config
-            )
-
-        if model_config is None:
-            logger.info(
-                "Model config is missing. This may indicate that we are running a test case. context: model_config=None"
-            )
-            enforce_eager = False
-        else:
-            enforce_eager = getattr(model_config, "enforce_eager", False)
+        enforce_eager = getattr(model_config, "enforce_eager", False)
 
         from vllm.config.compilation import CUDAGraphMode
 
@@ -550,6 +601,8 @@ class NPUPlatform(Platform):
                 "for example, check the plog files (default: $HOME/ascend/log/debug) "
                 "for more information about runtime errors."
             )
+
+        cls._sync_additional_config(vllm_config, ascend_config)
 
         if parallel_config and parallel_config.worker_cls == "auto":
             # TODO: this is a tricky way to disable `use_sequence_parallel_moe` in vllm.

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -178,22 +178,6 @@ class NPUPlatform(Platform):
         """
         return "vllm_ascend.compilation.compiler_interface.AscendCompiler"
 
-    @staticmethod
-    def _sync_additional_config(vllm_config: VllmConfig, ascend_config) -> None:
-        ascend_compilation_config = getattr(ascend_config, "ascend_compilation_config", None)
-        if ascend_compilation_config:
-            vllm_config.additional_config.setdefault("ascend_compilation_config", {}).update(
-                vars(ascend_compilation_config)
-                if not isinstance(ascend_compilation_config, dict)
-                else ascend_compilation_config
-            )
-
-        ascend_fusion_config = getattr(ascend_config, "ascend_fusion_config", None)
-        if ascend_fusion_config:
-            vllm_config.additional_config.setdefault("ascend_fusion_config", {}).update(
-                vars(ascend_fusion_config) if not isinstance(ascend_fusion_config, dict) else ascend_fusion_config
-            )
-
     @classmethod
     def pre_register_and_update(cls, parser: FlexibleArgumentParser | None = None) -> None:
         # Adapt the global patch here.
@@ -602,7 +586,19 @@ class NPUPlatform(Platform):
                 "for more information about runtime errors."
             )
 
-        cls._sync_additional_config(vllm_config, ascend_config)
+        ascend_compilation_config = ascend_config.ascend_compilation_config
+        if ascend_compilation_config:
+            vllm_config.additional_config.setdefault("ascend_compilation_config", {}).update(
+                vars(ascend_compilation_config)
+                if not isinstance(ascend_compilation_config, dict)
+                else ascend_compilation_config
+            )
+
+        ascend_fusion_config = ascend_config.ascend_fusion_config
+        if ascend_fusion_config:
+            vllm_config.additional_config.setdefault("ascend_fusion_config", {}).update(
+                vars(ascend_fusion_config) if not isinstance(ascend_fusion_config, dict) else ascend_fusion_config
+            )
 
         if parallel_config and parallel_config.worker_cls == "auto":
             # TODO: this is a tricky way to disable `use_sequence_parallel_moe` in vllm.

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4705,7 +4705,7 @@ def _torch_cuda_wrapper():
         torch.cuda.synchronize = torch.npu.synchronize
         torch.cuda.mem_get_info = torch.npu.mem_get_info
         yield
-    except Exception as e:
+    except Exception:
         torch.cuda.Event = _EventPlaceholder
         torch.cuda.Stream = _StreamPlaceholder
         torch.cuda.default_stream = _StreamPlaceholder
@@ -4713,7 +4713,8 @@ def _torch_cuda_wrapper():
         torch.cuda.stream = _StreamPlaceholder
         torch.cuda.synchronize = _StreamPlaceholder
         torch.cuda.mem_get_info = _StreamPlaceholder
-        raise RuntimeError(f"NPUModelRunner init failed, error is {e}")
+        logger.exception("NPUModelRunner init failed inside _torch_cuda_wrapper")
+        raise
     finally:
         # if anything goes wrong, just patch it with a placeholder
         torch.cuda.Event = _EventPlaceholder

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4705,7 +4705,7 @@ def _torch_cuda_wrapper():
         torch.cuda.synchronize = torch.npu.synchronize
         torch.cuda.mem_get_info = torch.npu.mem_get_info
         yield
-    except Exception:
+    except Exception as e:
         torch.cuda.Event = _EventPlaceholder
         torch.cuda.Stream = _StreamPlaceholder
         torch.cuda.default_stream = _StreamPlaceholder
@@ -4713,8 +4713,7 @@ def _torch_cuda_wrapper():
         torch.cuda.stream = _StreamPlaceholder
         torch.cuda.synchronize = _StreamPlaceholder
         torch.cuda.mem_get_info = _StreamPlaceholder
-        logger.exception("NPUModelRunner init failed inside _torch_cuda_wrapper")
-        raise
+        raise RuntimeError(f"NPUModelRunner init failed, error is {e}")
     finally:
         # if anything goes wrong, just patch it with a placeholder
         torch.cuda.Event = _EventPlaceholder


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes upstream vLLM unit-test failures caused by Ascend-specific state or behavior leaking into generic, non-NPU, and config-only flows.

As an out-of-tree platform plugin, `vllm-ascend` should preserve upstream vLLM behavior unless a code path is genuinely owned by the Ascend backend. This PR restores that boundary in three areas:

- **platform.py**
Add early return logic to skip Ascend-specific config updates in two scenarios:
  - When device_config.device_type is not npu
  - When there is no valid model_config
This prevents Ascend platform logic from polluting CPU, config-only and other general execution paths.

- **ascend_config.py**
  - Add null safety guards for model_config related properties to avoid crashes in config-only test cases where model_config is None.
  - Optimize the global AscendConfig singleton reuse rule: the singleton is only reused for the identical VllmConfig instance, fixing cross-configuration pollution within the same process.
  - Ensure model-related attributes are only accessed when actual Ascend capabilities are used.

- **punica_npu.py**
  - Align LoRA index handling with GPU/XPU upstream implementation. Truncate LoRA indices by the actual active token count (x.size(0)) in dynamic decode and logits processing paths. This resolves the runtime error caused by dimension mismatch among x, y and indices tensors.

### Does this PR introduce _any_ user-facing change?

No API or interface change is intended.

The behavioral changes are limited to bug fixes: inactive Ascend logic no longer mutates generic configuration flows, separate `VllmConfig` instances no longer share stale Ascend state, platform memory queries have a runtime-safer path, and LoRA decode indices match the active input shape.

### How was this patch tested?

Test environment:

- Image: `quay.io/ascend/vllm-ascend:nightly-main` (2026.05.29)
- Each upstream test was run in an isolated process on a single idle NPU.

Confirmed upstream test recoveries:

- KV connector unit tests:
  - `tests/v1/kv_connector/unit/test_cache_pollution_prevention.py` (`1 passed`)
  - `tests/v1/kv_connector/unit/test_error_propagation.py` (`2 passed`)
  - `tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py` (`3 passed`)
  - `tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py` (`11 passed`)
  - `tests/v1/kv_connector/unit/test_decode_bench_connector.py` (`8 passed`)
  - `tests/v1/kv_connector/unit/test_remote_decode_lifecycle.py` (`4 passed`)
  - `tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py` (`6 passed`)
  - `tests/v1/kv_connector/unit/test_config.py` (`6 passed`)
- Config and engine tests:
  - `tests/v1/engine/test_engine_args.py` (`2 passed, 1 skipped`)
  - `tests/config/test_config_generation.py` (`3 passed`)
- LoRA and custom-op tests:
  - `tests/lora/test_add_lora.py` (`1 passed`)
  - `tests/lora/test_qwenvl.py` (`6 passed`)
  - `tests/lora/test_chatglm3_tp.py` (`1 passed`)
  - `tests/model_executor/test_enabled_custom_ops.py` (`21 passed`)
- Entrypoint and logits-processor tests:
  - `tests/v1/logits_processors/test_custom_offline.py::test_rejects_custom_logitsprocs` (6 rejection cases passed independently)
  - `tests/entrypoints/openai/test_return_tokens_as_ids.py` (`5 passed`)

Focused `vllm-ascend` unit coverage is included for `AscendConfig` instance isolation and the `npu-smi`-first memory query. Relevant pre-commit checks pass.

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5

<img width="1446" height="742" alt="image" src="https://github.com/user-attachments/assets/4b03b74d-9c24-4dab-aea5-9779b14b225f" />
