### PR TITLE
[BugFix][v0.20.2rc] Preserve no-group dequant SwiGLU clamp

### DIFF
--- a/csrc/moe/dequant_swiglu_quant/op_host/dequant_swiglu_quant_tiling.cpp
+++ b/csrc/moe/dequant_swiglu_quant/op_host/dequant_swiglu_quant_tiling.cpp
@@ -521,7 +521,7 @@ ge::graphStatus DequantSwigluQuantDskTiling::GetShapeAttrsInfoInner() {
   // set the relevant param of group, hasGroupIndex_, groupNum_ and speGroupType_
   auto shapeGroupIndex = context_->GetOptionalInputShape(INPUT_GROUP_INDEX);
   hasGroupIndex_ = shapeGroupIndex != nullptr;
-  groupNum_ = 0;
+  groupNum_ = 1;
   speGroupType_ = false;
   if (hasGroupIndex_) {
     const gert::Shape& inputShapeGroupIndex = shapeGroupIndex->GetStorageShape();
@@ -557,7 +557,14 @@ bool DequantSwigluQuantDskTiling::IsPerformanceAndGroupIndexBrach() {
   if (shapeGroupIndex != nullptr) {
     return true;
   }
-  return false;
+
+  auto xPtr = context_->GetInputDesc(X_INDEX);
+  auto attrs = context_->GetAttrs();
+  if (xPtr == nullptr || attrs == nullptr) {
+    return false;
+  }
+  auto* swigluMode = attrs->GetAttrPointer<int>(SWIGLU_MODE_INDEX);
+  return xPtr->GetDataType() == ge::DT_INT32 && swigluMode != nullptr && *swigluMode == 1;
 }
 
 bool DequantSwigluQuantDskTiling::IsCapable() {

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -2141,9 +2141,7 @@ std::tuple<at::Tensor, at::Tensor> npu_dequant_swiglu_quant(
     const at::Tensor& bias_opt = c10::value_or_else(bias, [] { return at::Tensor(); });
     const at::Tensor& quant_scale_opt = c10::value_or_else(quant_scale, [] { return at::Tensor(); });
     const at::Tensor& quant_offset_opt = c10::value_or_else(quant_offset, [] { return at::Tensor(); });
-    const at::Tensor& group_index_value = c10::value_or_else(group_index, [&x] {
-        return at::empty({1}, x.options().dtype(c10::ScalarType::Long)).fill_(x.size(0));
-    });
+    const at::Tensor& group_index_opt = c10::value_or_else(group_index, [] { return at::Tensor(); });
 
     static const bool is_v2_available =
         GetOpApiFuncAddr("aclnnDequantSwigluQuantV2") != nullptr &&
@@ -2151,13 +2149,13 @@ std::tuple<at::Tensor, at::Tensor> npu_dequant_swiglu_quant(
 
     if (swiglu_mode == 0 && !is_v2_available) {
         EXEC_NPU_CMD(aclnnDequantSwigluQuant, x, weight_scale_value, activation_scale_opt, bias_opt, quant_scale_opt,
-                     quant_offset_opt, group_index_value, activate_left, quant_mode_ptr, y, scale);
+                     quant_offset_opt, group_index_opt, activate_left, quant_mode_ptr, y, scale);
     } else {
         int64_t dst_type = 2;
         char* round_mode = const_cast<char*>("rint");
         int64_t activate_dim = -1;
         EXEC_NPU_CMD(aclnnDequantSwigluQuantV2, x, weight_scale_value, activation_scale_opt, bias_opt, quant_scale_opt,
-                     quant_offset_opt, group_index_value, activate_left, quant_mode_ptr, dst_type, round_mode,
+                     quant_offset_opt, group_index_opt, activate_left, quant_mode_ptr, dst_type, round_mode,
                      activate_dim, swiglu_mode, clamp_limit, glu_alpha, glu_bias, y, scale);
     }
 


### PR DESCRIPTION
## Summary
- Preserve omitted `group_index` for `npu_dequant_swiglu_quant` as an absent optional tensor instead of synthesizing `[x.size(0)]`.
- Route the arch32 int32 no-group `swiglu_mode=1` path into the DSK no-group kernel so `clamp_limit` is honored while the tiling key remains `200000000+`.
- Leave `glu_alpha` / `glu_bias` defaults unchanged in this PR.

## Context
#9600 fixed the important #9589 precision issue, but its wrapper-side synthetic `group_index` changed the DeepSeek-V4-Pro shared-expert path from no-group to has-group. The Python call site passes `group_index=None`, `quant_mode=1`, `swiglu_mode=1`, and `clamp_limit=...`, so the kernel path needs to preserve no-group semantics and still execute clamp.

The previous no-group path did not enter the DSK tiling because capability was gated on an optional `group_index` shape. Removing the synthetic `group_index` alone therefore avoided the has-group branch, but also left the no-group path without the required clamp semantics. This PR makes the arch32 int32 no-group `swiglu_mode=1` case DSK-capable and uses `groupNum_=1` for no-group tiling checks.

## Why not synthesize `group_index`
Synthesizing a one-element group tensor changes the tiling key from the no-group `200000000+` family to the has-group `100000000+` family. In the has-group kernel, `groupIndexGm_(groupIdx)` is read on device and drives `realDimx_` / `groupOffset_`. For the real no-group case, the kernel should instead use the `TGroup=float` no-group specialization and process `tl_->inDimx` directly.

The observed DeepSeek-V4-Pro failure is decode-stage corruption: the first token is correct (`4`), then the second token drifts into random text under no-MTP `FULL_DECODE_ONLY` graph replay. The fix avoids using a wrapper-created temporary group tensor as custom-op input metadata for a semantic no-group case. This does not claim real caller-provided `group_index` inputs are broken.

## Validation
Build:
- `cmake --build build/temp.linux-aarch64-cpython-311 --target vllm_ascend_C -j 32`
- `cmake --install build/temp.linux-aarch64-cpython-311`

Checks:
- `git diff --check -- csrc/moe/dequant_swiglu_quant/op_host/dequant_swiglu_quant_tiling.cpp`
- `_C_ascend::npu_dequant_swiglu_quant` schema still reports `Tensor? group_index=None`, `float glu_alpha=1.`, `float glu_bias=0.`

Bad baseline evidence:
- Artifact prefix: `runs/pro_split/pro_bad_baseline_20260608T073210Z`
- no-MTP graph: `speculative_config=None`, `FULL_DECODE_ONLY`, `Replaying aclgraph`
- Short 2-token output: `4OTS`, tokens `['4', 'OTS']`
- Long 2-token output: `4andal`

DeepSeek-V4-Pro W4A8 no-MTP graph after this fix:
- Command: `LABEL=pro_dsk_nomtp_clamp PORT=8901 OUT_DIR=runs/pro_split INCLUDE_LONG_PROMPT=1 PYTHONPATH_PREFIX=<vllm-ascend-repo> ./run_nomtp_graph_case.sh`
- Artifact prefix: `runs/pro_split/pro_dsk_nomtp_clamp_20260609T021747Z`
- Evidence: `speculative_config=None`, `FULL_DECODE_ONLY`, `Replaying aclgraph`
- Result: short and long graph outputs are `4` followed by EOS
- Short prompt: 1tok `4` / length, 2tok `4` / stop with `['4', EOS]`, 8tok `4` / stop; `prompt_tokens=17`
- Longer prompt: 2tok `4` / stop with `['4', EOS]`, 8tok `4` / stop; `prompt_tokens=120`

DeepSeek-V4-Pro W4A8 MTP graph after this fix:
- Command: `LABEL=pro_dsk_mtp_clamp PORT=8902 OUT_DIR=runs/pro_split INCLUDE_LONG_PROMPT=1 PYTHONPATH_PREFIX=<vllm-ascend-repo> SPEC_CONFIG='{"num_speculative_tokens":1,"method":"mtp","enforce_eager":true}' ./run_nomtp_graph_case.sh`
- Artifact prefix: `runs/pro_split/pro_dsk_mtp_clamp_20260609T022802Z`
- Evidence: `SpeculativeConfig(method='mtp', ...)`, `FULL_DECODE_ONLY`, `Replaying aclgraph`
- Result: short and long graph outputs are `4` followed by EOS
- Short prompt: 1tok `4` / length, 2tok `4` / stop with `['4', EOS]`, 8tok `4` / stop; `prompt_tokens=17`
- Longer prompt: 2tok `4` / stop with `['4', EOS]`, 8tok `4` / stop; `prompt_tokens=120`

Related to #9589, #9590, and #9600.
