### PR TITLE
[BugFix]fix w4a8 mxfp quantization in shared experts

### DIFF
--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -786,17 +786,7 @@ class AscendFusedMoE(FusedMoE):
                 # Execute the gate projection and activation concurrently with the
                 # dispatch communication.
                 maybe_wait_event(fused_moe_evts.before_dispatch)
-                hidden_states = torch_npu.npu_quant_matmul(
-                    quantized_x,
-                    self._shared_experts.gate_up_proj.weight,
-                    self._shared_experts.gate_up_proj.weight_scale,
-                    scale_dtype=torch_npu.float8_e8m0fnu,
-                    pertoken_scale=pertoken_scale,
-                    pertoken_scale_dtype=torch_npu.float8_e8m0fnu,
-                    bias=None,
-                    output_dtype=original_dtype,
-                    group_sizes=[1, 1, 32],
-                )
+                hidden_states = self._shared_experts.gate_up_proj((quantized_x, pertoken_scale))[0]
                 # Execute activation concurrently with gmm2.
                 maybe_wait_event(fused_moe_evts.before_gmm2)
                 quantized_x, swiglu_out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
@@ -810,17 +800,7 @@ class AscendFusedMoE(FusedMoE):
                 # Execute the down projection concurrently with the combine
                 # communication.
                 maybe_wait_event(fused_moe_evts.before_combine)
-                shared_out = torch_npu.npu_quant_matmul(
-                    quantized_x,
-                    self._shared_experts.down_proj.weight,
-                    self._shared_experts.down_proj.weight_scale,
-                    scale_dtype=torch_npu.float8_e8m0fnu,
-                    pertoken_scale=swiglu_out_scale,
-                    pertoken_scale_dtype=torch_npu.float8_e8m0fnu,
-                    bias=None,
-                    output_dtype=original_dtype,
-                    group_sizes=[1, 1, 32],
-                )
+                shared_out = self._shared_experts.down_proj((quantized_x, swiglu_out_scale))[0]
             else:
                 # Ensure the shared experts wait for hidden_states to be ready.
                 torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)

--- a/vllm_ascend/quantization/methods/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8_mxfp4.py
@@ -65,9 +65,12 @@ class AscendW4A8MXFPDynamicLinearMethod(AscendLinearScheme):
         bias: torch.Tensor | None = None,
         tp_rank: int | None = 0,
     ) -> torch.Tensor:
-        quantized_x, dynamic_scale = torch_npu.npu_dynamic_mx_quant(x, dst_type=torch.float8_e4m3fn)
-
-        output_dtype = x.dtype if not isinstance(x, tuple) else x[0].dtype
+        if isinstance(x, tuple):
+            quantized_x, dynamic_scale = x
+            output_dtype = torch.bfloat16
+        else:
+            quantized_x, dynamic_scale = torch_npu.npu_dynamic_mx_quant(x, dst_type=torch.float8_e4m3fn)
+            output_dtype = x.dtype
 
         output = torch_npu.npu_quant_matmul(
             quantized_x,

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -76,9 +76,9 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
         tp_rank: int | None = 0,
     ) -> torch.Tensor:
         if isinstance(x, tuple):
-           quantized_x, pertoken_scale = x
-           original_shape = quantized_x.shape
-           output_dtype = torch.bfloat16
+            quantized_x, pertoken_scale = x
+            original_shape = quantized_x.shape
+            output_dtype = torch.bfloat16
         else:
             # reshape x for Qwen VL models
             original_shape = x.shape
@@ -92,7 +92,7 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
             layer.weight,
             layer.weight_scale,
             scale_dtype=FLOAT8_E8M0FNU_DTYPE,
-            pertoken_scale=dynamic_scale,
+            pertoken_scale=pertoken_scale,
             pertoken_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
             bias=bias,
             output_dtype=output_dtype,

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -71,18 +71,21 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
     def apply(
         self,
         layer: torch.nn.Module,
-        x: torch.Tensor,
+        x: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
         bias: torch.Tensor | None = None,
         tp_rank: int | None = 0,
     ) -> torch.Tensor:
-        # reshape x for Qwen VL models
-        original_shape = x.shape
-        if x.dim() > 2:
-            x = x.view(-1, x.shape[-1])
-        quantized_x, dynamic_scale = torch_npu.npu_dynamic_mx_quant(x, dst_type=torch.float8_e4m3fn)
-        output_dtype = x.dtype
-        if bias is not None and bias.dtype != torch.float32:
-            bias = bias.to(torch.float32)
+        if isinstance(x, tuple):
+           quantized_x, pertoken_scale = x
+           original_shape = quantized_x.shape
+           output_dtype = torch.bfloat16
+        else:
+            # reshape x for Qwen VL models
+            original_shape = x.shape
+            if x.dim() > 2:
+                x = x.view(-1, x.shape[-1])
+            quantized_x, pertoken_scale = torch_npu.npu_dynamic_mx_quant(x, dst_type=torch.float8_e4m3fn)
+            output_dtype = x.dtype
 
         output = torch_npu.npu_quant_matmul(
             quantized_x,

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -87,6 +87,9 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
             quantized_x, pertoken_scale = torch_npu.npu_dynamic_mx_quant(x, dst_type=torch.float8_e4m3fn)
             output_dtype = x.dtype
 
+        if bias is not None and bias.dtype != torch.float32:
+            bias = bias.to(torch.float32)
+
         output = torch_npu.npu_quant_matmul(
             quantized_x,
             layer.weight,


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request refactors the shared experts gate and down projection calls in fused_moe.py to use the unified .apply() method of the quantization schemes, passing the quantized inputs and scales as a tuple. It also updates the apply methods in w4a8_mxfp4.py and w8a8_mxfp8.py to handle tuple inputs and set the appropriate output data type. Feedback highlights a critical NameError in w8a8_mxfp8.py where dynamic_scale was renamed to pertoken_scale but still referenced by its old name, as well as minor indentation issues. Additionally, the reviewer requested updating the PR title and description to comply with the repository's style guide.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
