### PR TITLE
[Performance] Optimize the ngram_spec_decode kernel

### DIFF
--- a/csrc/attention/ngram_spec_decode/op_host/ngram_spec_decode_tiling.cpp
+++ b/csrc/attention/ngram_spec_decode/op_host/ngram_spec_decode_tiling.cpp
@@ -63,7 +63,7 @@ static ge::graphStatus NgramSpecDecodeTilingFunc(gert::TilingContext *context)
     uint32_t aivNum = ascendcPlatform.GetCoreNumAiv();
     int64_t block_dim = std::min(batch_size, static_cast<int64_t>(aivNum));
     int64_t rows_per_core = (block_dim > 0) ? (batch_size / block_dim) : 0;
-    int64_t former_num = batch_size % block_dim;
+    int64_t former_num = (block_dim > 0) ? batch_size % block_dim : 0;
 
     tilingData->ngramInfo.batchSize = static_cast<uint32_t>(batch_size);
     tilingData->ngramInfo.maxSeqLen = static_cast<uint32_t>(max_seq_len);

--- a/csrc/attention/ngram_spec_decode/op_host/ngram_spec_decode_tiling.cpp
+++ b/csrc/attention/ngram_spec_decode/op_host/ngram_spec_decode_tiling.cpp
@@ -79,7 +79,7 @@ static ge::graphStatus NgramSpecDecodeTilingFunc(gert::TilingContext *context)
 
     int64_t block_dim = std::min(batch_size, static_cast<int64_t>(aivNum));
     int64_t rows_per_core = (block_dim > 0) ? (batch_size / block_dim) : 0;
-    int64_t former_num = (block_dim > 0) ? (block_dim - 1) : 0;
+    int64_t former_num = batch_size % block_dim;
     int64_t tail_rows = batch_size - former_num * rows_per_core;
     int64_t block_rows = std::min(rows_per_core, max_block_rows);
 

--- a/csrc/attention/ngram_spec_decode/op_host/ngram_spec_decode_tiling.cpp
+++ b/csrc/attention/ngram_spec_decode/op_host/ngram_spec_decode_tiling.cpp
@@ -61,27 +61,9 @@ static ge::graphStatus NgramSpecDecodeTilingFunc(gert::TilingContext *context)
 
     auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
     uint32_t aivNum = ascendcPlatform.GetCoreNumAiv();
-    uint64_t ubSize = 0UL;
-    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
-    int64_t ub_size_limit = static_cast<int64_t>(ubSize);
-
-    int64_t align_elems = 32 / ELEM_SIZE;
-    int64_t max_seq_len_align = ((max_seq_len + align_elems - 1) / align_elems) * align_elems;
-    int64_t max_new_tokens_align = ((max_new_tokens + align_elems - 1) / align_elems) * align_elems;
-    int64_t k_align = ((k + align_elems - 1) / align_elems) * align_elems;
-
-    int64_t ub_per_row = (max_seq_len_align + max_new_tokens_align + k_align) * ELEM_SIZE;
-    int64_t ub_overhead = 4 * 32 + static_cast<int64_t>(max_n) * ELEM_SIZE
-        + ((max_seq_len_align + 7) / 8);  // maskBuf
-    int64_t ub_available = ub_size_limit - ub_overhead;
-    int64_t max_block_rows = (ub_available > 0) ? (ub_available / ub_per_row) : 1;
-    max_block_rows = std::max(max_block_rows, static_cast<int64_t>(1));
-
     int64_t block_dim = std::min(batch_size, static_cast<int64_t>(aivNum));
     int64_t rows_per_core = (block_dim > 0) ? (batch_size / block_dim) : 0;
     int64_t former_num = batch_size % block_dim;
-    int64_t tail_rows = batch_size - former_num * rows_per_core;
-    int64_t block_rows = std::min(rows_per_core, max_block_rows);
 
     tilingData->ngramInfo.batchSize = static_cast<uint32_t>(batch_size);
     tilingData->ngramInfo.maxSeqLen = static_cast<uint32_t>(max_seq_len);
@@ -92,13 +74,11 @@ static ge::graphStatus NgramSpecDecodeTilingFunc(gert::TilingContext *context)
     tilingData->ngramInfo.k = static_cast<uint32_t>(k);
     tilingData->ngramInfo.formerNum = static_cast<uint32_t>(former_num);
     tilingData->ngramInfo.rowsPerCore = static_cast<uint32_t>(rows_per_core);
-    tilingData->ngramInfo.tailRows = static_cast<uint32_t>(tail_rows);
-    tilingData->ngramInfo.blockRows = static_cast<uint32_t>(block_rows);
 
     context->SetBlockDim(static_cast<uint32_t>(block_dim));
 
-    OPS_LOG_D(nodeName, "batchSize=%lu, maxSeqLen=%lu, maxNewTokens=%lu, k=%lu, blockDim=%lu, blockRows=%lu",
-        batch_size, max_seq_len, max_new_tokens, k, block_dim, block_rows);
+    OPS_LOG_D(nodeName, "batchSize=%lu, maxSeqLen=%lu, maxNewTokens=%lu, k=%lu, blockDim=%lu",
+        batch_size, max_seq_len, max_new_tokens, k, block_dim);
 
     return ge::GRAPH_SUCCESS;
 }

--- a/csrc/attention/ngram_spec_decode/op_host/ngram_spec_decode_tiling.h
+++ b/csrc/attention/ngram_spec_decode/op_host/ngram_spec_decode_tiling.h
@@ -13,8 +13,6 @@ struct NgramSpecDecodeInfo {
     uint32_t k;
     uint32_t formerNum;
     uint32_t rowsPerCore;
-    uint32_t tailRows;
-    uint32_t blockRows;
 };
 
 struct NgramSpecDecodeTilingData {

--- a/csrc/attention/ngram_spec_decode/op_kernel/ngram_spec_decode.cpp
+++ b/csrc/attention/ngram_spec_decode/op_kernel/ngram_spec_decode.cpp
@@ -11,9 +11,47 @@
 #include "kernel_operator.h"
 #include "ngram_spec_decode.h"
 
-constexpr int32_t ELEM_SIZE = sizeof(int32_t);  // 4 bytes
-// Safety UB buffer size：32768(128KB)
-constexpr uint32_t SAFE_CHUNK = 32768u;
+const uint32_t ELEM_SIZE = 4;  // int32
+constexpr uint32_t SAFE_CHUNK = 8192u;
+
+#define COPY_GM_TO_UB(dst, src, src_offset, count, T)                      \
+    do {                                                                   \
+        if ((count) > 0) {                                                 \
+            constexpr uint32_t __align_elem = 8u;                          \
+            uint32_t __c = static_cast<uint32_t>(count);                   \
+            uint32_t __aligned = ((__c + __align_elem - 1u) / __align_elem) \
+                                 * __align_elem;                           \
+            uint8_t __pad = static_cast<uint8_t>(__aligned - __c);          \
+            AscendC::DataCopyExtParams __p{                                \
+                1,                                                         \
+                static_cast<uint32_t>(__c * sizeof(T)),                    \
+                0,                                                         \
+                0,                                                         \
+                0};                                                        \
+            AscendC::DataCopyPadExtParams<T> __pp{true, 0, __pad, -1};     \
+            AscendC::DataCopyPad((dst), (src)[(src_offset)], __p, __pp);    \
+        }                                                                  \
+    } while (0)
+
+#define COPY_UB_TO_GM(dst, src, dst_offset, count, T)                      \
+    do {                                                                   \
+        if ((count) > 0) {                                                 \
+            constexpr uint32_t __store_max = 16383u;                       \
+            uint32_t __c = static_cast<uint32_t>(count);                   \
+            for (uint32_t __off = 0; __off < __c; __off += __store_max) {  \
+                uint32_t __chunk = (__off + __store_max <= __c)            \
+                                    ? __store_max                          \
+                                    : (__c - __off);                       \
+                AscendC::DataCopyParams __p{                               \
+                    1,                                                     \
+                    static_cast<uint16_t>(__chunk * sizeof(T)),          \
+                    0,                                                     \
+                    0};                                                    \
+                AscendC::DataCopyPad(                                      \
+                    (dst)[(dst_offset) + __off], (src)[__off], __p);       \
+            }                                                              \
+        }                                                                  \
+    } while (0)
 
 class KernelNgramSpecDecode {
 public:
@@ -39,582 +77,435 @@ public:
         this->tail_rows = static_cast<int32_t>(tilingData.ngramInfo.tailRows);
         this->block_rows = static_cast<int32_t>(tilingData.ngramInfo.blockRows);
 
-        int32_t align_elems = 32 / ELEM_SIZE;  // = 8
+        // Align dimensions to 32-byte boundaries (8 elements for int32)
+        int32_t align_elems = 32 / ELEM_SIZE;
         this->max_seq_len_align = ((this->max_seq_len + align_elems - 1) / align_elems) * align_elems;
         this->max_new_tokens_align = ((this->max_new_tokens + align_elems - 1) / align_elems) * align_elems;
         this->k_align = ((this->k_val + align_elems - 1) / align_elems) * align_elems;
 
         this->is_large_row = (this->max_seq_len_align > static_cast<int32_t>(SAFE_CHUNK));
 
+        // Compute row distribution across cores
         uint32_t blockIdx = AscendC::GetBlockIdx();
         if (blockIdx < static_cast<uint32_t>(this->former_num)) {
-            this->my_rows = static_cast<uint32_t>(this->rows_per_core);
-            this->row_offset = static_cast<uint32_t>(this->rows_per_core) * blockIdx;
+            this->my_rows = static_cast<uint32_t>(this->rows_per_core) + 1;
+            this->row_offset = (static_cast<uint32_t>(this->rows_per_core) + 1) * blockIdx;
         } else {
-            this->my_rows = static_cast<uint32_t>(this->tail_rows);
-            this->row_offset = static_cast<uint32_t>(this->rows_per_core) * static_cast<uint32_t>(this->former_num);
+            this->my_rows = static_cast<uint32_t>(this->rows_per_core);
+            this->row_offset = static_cast<uint32_t>(this->rows_per_core + 1)
+                             * static_cast<uint32_t>(this->former_num)
+                             + this->my_rows * (blockIdx - static_cast<uint32_t>(this->former_num));
         }
 
-        tokenGm.SetGlobalBuffer((__gm__ int32_t *)token_ids_gm,
+        // Bind Global Memory tensors
+        tokenGm.SetGlobalBuffer(
+            (__gm__ int32_t *)token_ids_gm,
             static_cast<uint64_t>(this->batch_size) * this->max_seq_len);
-        numTokensGm.SetGlobalBuffer((__gm__ int32_t *)num_tokens_gm,
+        numTokensGm.SetGlobalBuffer(
+            (__gm__ int32_t *)num_tokens_gm,
             static_cast<uint64_t>(this->batch_size));
-        sampledGm.SetGlobalBuffer((__gm__ int32_t *)sampled_gm,
+        sampledGm.SetGlobalBuffer(
+            (__gm__ int32_t *)sampled_gm,
             static_cast<uint64_t>(this->batch_size) * this->max_new_tokens);
-        discardGm.SetGlobalBuffer((__gm__ int32_t *)discard_gm,
+        discardGm.SetGlobalBuffer(
+            (__gm__ int32_t *)discard_gm,
             static_cast<uint64_t>(this->batch_size));
-        nextTokensGm.SetGlobalBuffer((__gm__ int32_t *)next_tokens_gm,
+        nextTokensGm.SetGlobalBuffer(
+            (__gm__ int32_t *)next_tokens_gm,
             static_cast<uint64_t>(this->batch_size));
-        draftTokensGm.SetGlobalBuffer((__gm__ int32_t *)draft_tokens_gm,
+        draftTokensGm.SetGlobalBuffer(
+            (__gm__ int32_t *)draft_tokens_gm,
             static_cast<uint64_t>(this->batch_size) * this->k_val);
-        numValidGm.SetGlobalBuffer((__gm__ int32_t *)num_valid_gm,
+        numValidGm.SetGlobalBuffer(
+            (__gm__ int32_t *)num_valid_gm,
             static_cast<uint64_t>(this->batch_size));
 
-        uint32_t br = static_cast<uint32_t>(this->block_rows);
-        uint32_t br_align = ((br * ELEM_SIZE + 31) / 32) * 32 / ELEM_SIZE;
+        // ============================================================
+        // TQue Initialization (depth=1, single-buffer, EnQue/DeQue for event sync)
+        // ============================================================
+        uint32_t mnta = static_cast<uint32_t>(this->max_new_tokens_align);
+        uint32_t ka = static_cast<uint32_t>(this->k_align);
+        uint32_t my_rows_align = ((this->my_rows + 7u) / 8u) * 8u;
 
+        uint32_t token_buf_size = 0;
         if (!this->is_large_row) {
-            pipe.InitBuffer(tokenTileBuf, br * static_cast<uint32_t>(this->max_seq_len_align) * ELEM_SIZE);
+            token_buf_size = static_cast<uint32_t>(this->max_seq_len_align) * ELEM_SIZE;
         } else {
             uint32_t chunk_ub = SAFE_CHUNK + static_cast<uint32_t>(this->max_n_val);
             uint32_t chunk_ub_align = ((chunk_ub + 7u) / 8u) * 8u;
-            pipe.InitBuffer(tokenTileBuf, chunk_ub_align * ELEM_SIZE);
+            token_buf_size = chunk_ub_align * ELEM_SIZE;
         }
 
-        uint32_t mask_bytes = ((SAFE_CHUNK + 7u) / 8u);
-        pipe.InitBuffer(maskBuf, mask_bytes);
+        // VECIN: Input data queues (GM -> UB, MTE2 direction)
+        pipe.InitBuffer(tokenInQue, 1, token_buf_size);
+        pipe.InitBuffer(sampledInQue, 1, this->my_rows * mnta * ELEM_SIZE);
+        pipe.InitBuffer(numTokensInQue, 1, my_rows_align * ELEM_SIZE);
+        pipe.InitBuffer(discardInQue, 1, my_rows_align * ELEM_SIZE);
+        pipe.InitBuffer(suffixInQue, 1, static_cast<uint32_t>(this->max_n_val) * ELEM_SIZE);
 
-        pipe.InitBuffer(sampledTileBuf, br * static_cast<uint32_t>(this->max_new_tokens_align) * ELEM_SIZE);
-        pipe.InitBuffer(numTokensBuf, br_align * ELEM_SIZE);
-        pipe.InitBuffer(discardTileBuf, br_align * ELEM_SIZE);
-        pipe.InitBuffer(nextTokenBuf, br_align * ELEM_SIZE);
-        pipe.InitBuffer(draftBuf, br * static_cast<uint32_t>(this->k_align) * ELEM_SIZE);
-        pipe.InitBuffer(numValidBuf, br_align * ELEM_SIZE);
-        pipe.InitBuffer(suffixBuf, static_cast<uint32_t>(this->max_n_val) * ELEM_SIZE);
+        // VECOUT: Output data queues (UB -> GM, MTE3 direction)
+        pipe.InitBuffer(nextOutQue, 1, my_rows_align * ELEM_SIZE);
+        pipe.InitBuffer(draftOutQue, 1, this->my_rows * ka * ELEM_SIZE);
+        pipe.InitBuffer(numValidOutQue, 1, my_rows_align * ELEM_SIZE);
+
+        // Pure UB computation buffers (no GM traffic, keep as TBuf)
+        pipe.InitBuffer(ngramCalcBuf, token_buf_size);
+        pipe.InitBuffer(ngramTempBuf, token_buf_size);
+        pipe.InitBuffer(ngramGatherBuf, token_buf_size);
+
+        uint32_t reduce_count = this->is_large_row
+                              ? SAFE_CHUNK
+                              : (static_cast<uint32_t>(this->max_seq_len) - 1);
+        uint32_t reduce_tmp_elems = CalcReduceMinTmpSize(reduce_count, ELEM_SIZE);
+        uint32_t reduce_tmp_bytes = ((reduce_tmp_elems * ELEM_SIZE + 31) / 32) * 32;
+        pipe.InitBuffer(ngramReduceBuf, reduce_tmp_bytes);
     }
 
     __aicore__ inline void Process()
     {
-        uint32_t remaining = this->my_rows;
-        uint32_t cur_offset = 0;
-        while (remaining > 0) {
-            uint32_t cur_rows = (remaining > static_cast<uint32_t>(this->block_rows))
-                                ? static_cast<uint32_t>(this->block_rows) : remaining;
-            if (this->is_large_row) {
-                ProcessChunkedRows(this->row_offset + cur_offset, cur_rows);
-            } else {
-                CopyIn(this->row_offset + cur_offset, cur_rows);
-                Compute(cur_rows);
-                CopyOut(this->row_offset + cur_offset, cur_rows);
-            }
-            cur_offset += cur_rows;
-            remaining -= cur_rows;
+        // Step 1: Enqueue input data (MTE2 transfer in)
+        CopyInMetadata();
+
+        // Step 2: Dequeue input tensors before loop (sync point: ensure MTE2 done)
+        auto sampledLocal = sampledInQue.DeQue<int32_t>();
+        auto numTokensLocal = numTokensInQue.DeQue<int32_t>();
+        auto discardLocal = discardInQue.DeQue<int32_t>();
+
+        // Step 3: Allocate output tensors (not enqueued yet, only reserve UB space)
+        auto nextTensor = nextOutQue.AllocTensor<int32_t>();
+        auto draftTensor = draftOutQue.AllocTensor<int32_t>();
+        auto numValidTensor = numValidOutQue.AllocTensor<int32_t>();
+
+        // Step 4: Row-by-row computation (output tensors passed by reference, written directly)
+        for (uint32_t r = 0; r < this->my_rows; ++r) {
+            uint32_t global_row = this->row_offset + r;
+            ProcessOneRow(
+                r, global_row,
+                sampledLocal, numTokensLocal, discardLocal,
+                nextTensor, draftTensor, numValidTensor);
         }
+
+        // Step 5: Free input tensors
+        sampledInQue.FreeTensor(sampledLocal);
+        numTokensInQue.FreeTensor(numTokensLocal);
+        discardInQue.FreeTensor(discardLocal);
+
+        // Step 6: Enqueue output data (sync point: mark vector compute done, allow MTE3 out)
+        nextOutQue.EnQue(nextTensor);
+        draftOutQue.EnQue(draftTensor);
+        numValidOutQue.EnQue(numValidTensor);
+
+        // Step 7: Dequeue output and copy to GM
+        CopyOutMetadata();
     }
 
 private:
+    __aicore__ inline void CopyInMetadata()
+    {
+        uint32_t mnta = static_cast<uint32_t>(this->max_new_tokens_align);
 
-    __aicore__ inline void ProcessChunkedRows(uint32_t start_row, uint32_t rows)
+        // sampled: Bulk copy of my_rows lines (repeat mode)
+        auto sampledTensor = sampledInQue.AllocTensor<int32_t>();
+        uint32_t srcRowBytes = static_cast<uint32_t>(this->max_new_tokens) * ELEM_SIZE;
+        AscendC::DataCopyExtParams sampledParams{
+            static_cast<uint16_t>(this->my_rows),  
+            srcRowBytes,                            
+            0,                                     
+            0,                                     
+            0};
+        AscendC::DataCopyPadExtParams<int32_t> padParams{
+            true, 0, static_cast<uint8_t>(mnta - this->max_new_tokens), 0};
+        AscendC::DataCopyPad(
+            sampledTensor,
+            sampledGm[static_cast<uint64_t>(this->row_offset) * this->max_new_tokens],
+            sampledParams, padParams);
+        sampledInQue.EnQue(sampledTensor);
+
+        // numTokens / discard: 1D array copy (32-byte aligned)
+        auto numTokensTensor = numTokensInQue.AllocTensor<int32_t>();
+        uint32_t metaBytes = static_cast<uint32_t>(this->my_rows) * ELEM_SIZE;
+        AscendC::DataCopyExtParams metaParams{1, metaBytes, 0, metaBytes, 0};
+        AscendC::DataCopyPadExtParams<int32_t> noPadT{false, 0, 0, 0};
+        AscendC::DataCopyPad(numTokensTensor, numTokensGm[this->row_offset], metaParams, noPadT);
+        numTokensInQue.EnQue(numTokensTensor);
+
+        auto discardTensor = discardInQue.AllocTensor<int32_t>();
+        AscendC::DataCopyPad(discardTensor, discardGm[this->row_offset], metaParams, noPadT);
+        discardInQue.EnQue(discardTensor);
+    }
+
+    __aicore__ inline void CopyOutMetadata()
+    {
+        // Dequeue output data (sync point: ensure vector computation completed)
+        auto nextLocal = nextOutQue.DeQue<int32_t>();
+        auto draftLocal = draftOutQue.DeQue<int32_t>();
+        auto numValidLocal = numValidOutQue.DeQue<int32_t>();
+
+        // nextToken / numValid: 1D array write-back
+        uint16_t metaBytes16 = static_cast<uint16_t>(this->my_rows) * ELEM_SIZE;
+        AscendC::DataCopyParams nextParams{1, metaBytes16, 0, 0};
+        AscendC::DataCopyPad(nextTokensGm[this->row_offset], nextLocal, nextParams);
+        AscendC::DataCopyPad(numValidGm[this->row_offset], numValidLocal, nextParams);
+
+        // draftTokens: 2D array write-back (repeat mode, handle UB k_align padding)
+        uint32_t kBytes = static_cast<uint32_t>(this->k_val) * ELEM_SIZE;
+        AscendC::DataCopyParams draftParams{
+            static_cast<uint16_t>(this->my_rows),  
+            static_cast<uint16_t>(kBytes),          
+            0,                                     
+            0};                                 
+        AscendC::DataCopyPad(
+            draftTokensGm[static_cast<uint64_t>(this->row_offset) * this->k_val],
+            draftLocal,
+            draftParams);
+
+        nextOutQue.FreeTensor(nextLocal);
+        draftOutQue.FreeTensor(draftLocal);
+        numValidOutQue.FreeTensor(numValidLocal);
+    }
+
+    __aicore__ inline void ProcessOneRow(
+        uint32_t local_idx, uint32_t global_row,
+        AscendC::LocalTensor<int32_t>& sampledLocal,
+        AscendC::LocalTensor<int32_t>& numTokensLocal,
+        AscendC::LocalTensor<int32_t>& discardLocal,
+        AscendC::LocalTensor<int32_t>& nextTensor,
+        AscendC::LocalTensor<int32_t>& draftTensor,
+        AscendC::LocalTensor<int32_t>& numValidTensor)
     {
         uint32_t msl = static_cast<uint32_t>(this->max_seq_len);
         uint32_t mnta = static_cast<uint32_t>(this->max_new_tokens_align);
         uint32_t ka = static_cast<uint32_t>(this->k_align);
+        uint64_t gmRow = static_cast<uint64_t>(global_row) * msl;
 
-        auto sampledLocal = sampledTileBuf.Get<int32_t>();
-        auto numTokensLocal = numTokensBuf.Get<int32_t>();
-        auto discardLocal = discardTileBuf.Get<int32_t>();
-        auto nextLocal = nextTokenBuf.Get<int32_t>();
-        auto draftLocal = draftBuf.Get<int32_t>();
-        auto numValidLocal = numValidBuf.Get<int32_t>();
-        auto suffixLocal = suffixBuf.Get<int32_t>();
-        auto tokenLocal = tokenTileBuf.Get<int32_t>();
-        auto maskLocal = maskBuf.Get<uint8_t>();
+        // Step 1: Load pre-fetched metadata
+        int32_t seq_len = numTokensLocal.GetValue(local_idx);
+        int32_t discard = discardLocal.GetValue(local_idx);
+        int32_t valid_count = 0;
+        uint32_t sampled_offset = local_idx * mnta;
 
-        uint32_t metaBytes = rows * ELEM_SIZE;
-        AscendC::DataCopyExtParams metaParams{1, metaBytes, 0, metaBytes, 0};
-        AscendC::DataCopyPadExtParams<int32_t> noPadT{false, 0, 0, 0};
-        AscendC::DataCopyPad(numTokensLocal, numTokensGm[start_row], metaParams, noPadT);
-        AscendC::DataCopyPad(discardLocal, discardGm[start_row], metaParams, noPadT);
-
-        uint32_t srcRowBytes2 = static_cast<uint32_t>(this->max_new_tokens) * ELEM_SIZE;
-        uint32_t dstRowBytes2 = mnta * ELEM_SIZE;
-        AscendC::DataCopyExtParams sampledParams{1, srcRowBytes2, 0, dstRowBytes2, 0};
-        AscendC::DataCopyPadExtParams<int32_t> sampledPad{
-            false, 0, static_cast<uint8_t>(mnta - this->max_new_tokens), 0};
-        for (uint32_t r = 0; r < rows; ++r) {
-            AscendC::DataCopyPad(sampledLocal[static_cast<uint64_t>(r) * mnta],
-                sampledGm[static_cast<uint64_t>(start_row + r) * this->max_new_tokens],
-                sampledParams, sampledPad);
-        }
-
-        for (uint32_t i = 0; i < rows; ++i) {
-            uint64_t gmRow = static_cast<uint64_t>(start_row + i) * msl;
-            int32_t seq_len = numTokensLocal.GetValue(i);
-            int32_t discard = discardLocal.GetValue(i);
-            int32_t valid_count = 0;
-
-            int32_t backup_pos = (seq_len > 0) ? (seq_len - 1) : 0;
-
+        // Step 2: Process sampled tokens (validation & truncation)
+        if (discard != 0) {
+            AscendC::Duplicate(sampledLocal[sampled_offset], -1, this->max_new_tokens_align);
+        } else {
             for (int32_t j = 0; j < this->max_new_tokens; ++j) {
-                int32_t val = sampledLocal.GetValue(i * mnta + j);
-                if (discard != 0) {
-                    sampledLocal.SetValue(i * mnta + j, -1);
-                } else if (val != -1 && val < this->vocab_size_val) {
-                    valid_count++;
-                } else {
-                    sampledLocal.SetValue(i * mnta + j, -1);
-                }
-            }
-
-            int32_t avail_space = this->max_seq_len - seq_len;
-            if (avail_space < 0) avail_space = 0;
-            if (valid_count > avail_space) valid_count = avail_space;
-
-            LoadGmElements(gmRow + backup_pos, 1);
-            int32_t backup_token = tokenLocal.GetValue(0);
-
-            if (valid_count > 0) {
-                nextLocal.SetValue(i, sampledLocal.GetValue(i * mnta + valid_count - 1));
-            } else {
-                nextLocal.SetValue(i, backup_token);
-            }
-
-            int32_t nt = seq_len + valid_count;
-            if (valid_count > 0) {
-                for (int32_t j = 0; j < valid_count; ++j) {
-                    tokenLocal.SetValue(j, sampledLocal.GetValue(i * mnta + j));
-                }
-                StoreGmElements(gmRow + seq_len, valid_count);
-            }
-
-            int32_t best_match_pos = -1;
-            int32_t best_ngram_len = 0;
-
-            if (valid_count > 0 && nt >= this->min_n_val) {
-                int32_t suffix_gm_start = nt - this->max_n_val;
-                if (suffix_gm_start < 0) suffix_gm_start = 0;
-                LoadGmElements(gmRow + suffix_gm_start, this->max_n_val);
-                for (int32_t s = 0; s < this->max_n_val; ++s) {
-                    suffixLocal.SetValue(static_cast<uint32_t>(s), tokenLocal.GetValue(static_cast<uint32_t>(s)));
-                }
-
-                for (int32_t ngram_len = this->min_n_val; ngram_len <= this->max_n_val; ++ngram_len) {
-                    if (ngram_len > nt) break;
-                    int32_t wc = nt - ngram_len;
-                    if (wc <= 0) break;
-
-                    int32_t suffix_offset = this->max_n_val - ngram_len;
-                    int32_t suffix0 = suffixLocal.GetValue(static_cast<uint32_t>(suffix_offset));
-
-                    for (int32_t chunk_start = 0; chunk_start < wc; chunk_start += SAFE_CHUNK) {
-                        int32_t chunk_count = (chunk_start + SAFE_CHUNK <= wc) ? SAFE_CHUNK : (wc - chunk_start);
-                        int32_t load_count = chunk_count + (ngram_len - 1);
-                        if (chunk_start + load_count > nt) load_count = nt - chunk_start;
-                        LoadGmElements(gmRow + chunk_start, load_count);
-
-                        uint32_t cmp_count = ((static_cast<uint32_t>(chunk_count) + 63u) / 64u) * 64u;
-                        uint32_t max_cmp = SAFE_CHUNK > 8192u ? 8192u : SAFE_CHUNK;
-                        if (cmp_count > max_cmp) cmp_count = max_cmp;
-                        if (cmp_count > static_cast<uint32_t>(load_count)) {
-                            cmp_count = ((static_cast<uint32_t>(load_count) + 63u) / 64u) * 64u;
-                        }
-
-                        for (uint32_t cmp_off = 0; cmp_off < static_cast<uint32_t>(chunk_count); cmp_off += cmp_count) {
-                            uint32_t rem = static_cast<uint32_t>(chunk_count) - cmp_off;
-                            uint32_t elements = (rem >= cmp_count) ? cmp_count : rem;
-                            uint32_t aligned = ((elements + 63u) / 64u) * 64u;
-
-                            AscendC::CompareScalar<int32_t, uint8_t>(
-                                maskLocal, tokenLocal[cmp_off],
-                                suffix0, AscendC::CMPMODE::EQ, aligned);
-
-                            for (uint32_t p = 0; p < elements; ++p) {
-                                uint8_t bv = maskLocal.GetValue(p >> 3);
-                                if (bv & (1u << (p & 7u))) {
-                                    bool all_match = true;
-                                    for (int32_t s = 1; s < ngram_len; ++s) {
-                                        int32_t sv = suffixLocal.GetValue(static_cast<uint32_t>(suffix_offset + s));
-                                        if (cmp_off + p + s < static_cast<uint32_t>(load_count)) {
-                                            int32_t tv = tokenLocal.GetValue(cmp_off + p + static_cast<uint32_t>(s));
-                                            if (tv != sv) { all_match = false; break; }
-                                        } else {
-                                            all_match = false; break;
-                                        }
-                                    }
-                                    if (all_match) {
-                                        best_match_pos = chunk_start + static_cast<int32_t>(cmp_off + p);
-                                        best_ngram_len = ngram_len;
-                                        break;
-                                    }
-                                }
-                            }
-                            if (best_match_pos >= 0) break;
-                        }
-                        if (best_match_pos >= 0) break;
+                int32_t val = sampledLocal.GetValue(sampled_offset + j);
+                if (val == -1 || val >= this->vocab_size_val) {
+                    for (int32_t k = j; k < this->max_new_tokens; ++k) {
+                        sampledLocal.SetValue(sampled_offset + k, -1);
                     }
-                    if (best_match_pos >= 0) break;
-                }
-            }
-
-            if (best_match_pos >= 0) {
-                int32_t draft_start = best_match_pos + best_ngram_len;
-                int32_t tokens_available = nt - draft_start;
-                int32_t draft_load = (tokens_available < this->k_val) ? tokens_available : this->k_val;
-                if (draft_load > 0) {
-                    LoadGmElements(gmRow + draft_start, draft_load);
-                    for (int32_t j = 0; j < this->k_val; ++j) {
-                        if (j < draft_load) {
-                            draftLocal.SetValue(i * ka + j, tokenLocal.GetValue(static_cast<uint32_t>(j)));
-                        } else {
-                            draftLocal.SetValue(i * ka + j, -1);
-                        }
-                    }
-                } else {
-                    for (int32_t j = 0; j < this->k_val; ++j) {
-                        draftLocal.SetValue(i * ka + j, -1);
-                    }
-                }
-            } else {
-                for (int32_t j = 0; j < this->k_val; ++j) {
-                    draftLocal.SetValue(i * ka + j, -1);
-                }
-            }
-
-            int32_t valid_draft_count = 0;
-            for (int32_t j = 0; j < this->k_val; ++j) {
-                if (draftLocal.GetValue(i * ka + j) != -1) {
-                    valid_draft_count++;
-                } else {
                     break;
                 }
-            }
-            numValidLocal.SetValue(i, valid_draft_count);
-        }
-
-        uint32_t metaBytes32 = static_cast<uint32_t>(rows) * ELEM_SIZE;
-        AscendC::DataCopyExtParams nextParams{1, metaBytes32, 0, 0, 0};
-        AscendC::DataCopyPad(nextTokensGm[start_row], nextLocal, nextParams);
-
-        uint32_t kBytes = static_cast<uint32_t>(this->k_val) * ELEM_SIZE;
-        for (uint32_t r = 0; r < rows; ++r) {
-            AscendC::DataCopyExtParams draftRowParams{1, kBytes, 0, 0, 0};
-            AscendC::DataCopyPad(
-                draftTokensGm[static_cast<uint64_t>(start_row + r) * this->k_val],
-                draftLocal[static_cast<uint64_t>(r) * this->k_align], draftRowParams);
-        }
-
-        AscendC::DataCopyPad(numValidGm[start_row], numValidLocal, nextParams);
-    }
-
-    __aicore__ inline void LoadGmElements(uint64_t gm_offset, int32_t count)
-    {
-        if (count <= 0) return;
-        auto tokenLocal = tokenTileBuf.Get<int32_t>();
-        uint32_t c = static_cast<uint32_t>(count);
-        uint32_t aligned = ((c + 7u) / 8u) * 8u;
-        uint8_t pad = static_cast<uint8_t>(aligned - c);
-        AscendC::DataCopyExtParams p{1, c * ELEM_SIZE, 0, aligned * ELEM_SIZE, 0};
-        AscendC::DataCopyPadExtParams<int32_t> pp{false, 0, pad, 0};
-        AscendC::DataCopyPad(tokenLocal[0], tokenGm[gm_offset], p, pp);
-    }
-
-    __aicore__ inline void StoreGmElements(uint64_t gm_offset, int32_t count)
-    {
-        if (count <= 0) return;
-        auto tokenLocal = tokenTileBuf.Get<int32_t>();
-        constexpr uint32_t STORE_MAX = 16383u;
-        uint32_t c = static_cast<uint32_t>(count);
-        for (uint32_t off = 0; off < c; off += STORE_MAX) {
-            uint32_t chunk = (off + STORE_MAX <= c) ? STORE_MAX : (c - off);
-            AscendC::DataCopyExtParams p{1, chunk * ELEM_SIZE, 0, 0, 0};
-            AscendC::DataCopyPad(tokenGm[gm_offset + off], tokenLocal[off], p);
-        }
-    }
-
-
-    __aicore__ inline void CopyIn(uint32_t start_row, uint32_t rows)
-    {
-        uint32_t msa = static_cast<uint32_t>(this->max_seq_len_align);
-        uint32_t mnta = static_cast<uint32_t>(this->max_new_tokens_align);
-        constexpr uint32_t MAX_CHUNK_ELEMS = 8192u;
-
-        auto tokenLocal = tokenTileBuf.Get<int32_t>();
-        uint32_t msl = static_cast<uint32_t>(this->max_seq_len);
-        for (uint32_t r = 0; r < rows; ++r) {
-            uint64_t gmRow = static_cast<uint64_t>(start_row + r) * msl;
-            uint32_t ubRow = r * msa;
-            for (uint32_t off = 0; off < msl; off += MAX_CHUNK_ELEMS) {
-                uint32_t chunk = (off + MAX_CHUNK_ELEMS <= msl) ? MAX_CHUNK_ELEMS : (msl - off);
-                uint32_t isLast = (off + chunk >= msl) ? 1u : 0u;
-                uint32_t dstChunk = isLast ? (msa - off) : MAX_CHUNK_ELEMS;
-                uint8_t pad = static_cast<uint8_t>(dstChunk - chunk);
-                AscendC::DataCopyExtParams p{1, chunk * ELEM_SIZE, 0, dstChunk * ELEM_SIZE, 0};
-                AscendC::DataCopyPadExtParams<int32_t> pp{false, 0, pad, 0};
-                AscendC::DataCopyPad(tokenLocal[ubRow + off], tokenGm[gmRow + off], p, pp);
-            }
-        }
-
-        auto sampledLocal = sampledTileBuf.Get<int32_t>();
-        uint32_t srcRowBytes2 = static_cast<uint32_t>(this->max_new_tokens) * ELEM_SIZE;
-        uint32_t dstRowBytes2 = mnta * ELEM_SIZE;
-        AscendC::DataCopyExtParams sampledParams{1, srcRowBytes2, 0, dstRowBytes2, 0};
-        AscendC::DataCopyPadExtParams<int32_t> sampledPad{
-            false, 0, static_cast<uint8_t>(mnta - this->max_new_tokens), 0};
-        for (uint32_t r = 0; r < rows; ++r) {
-            AscendC::DataCopyPad(sampledLocal[static_cast<uint64_t>(r) * mnta],
-                sampledGm[static_cast<uint64_t>(start_row + r) * this->max_new_tokens],
-                sampledParams, sampledPad);
-        }
-
-        auto numTokensLocal = numTokensBuf.Get<int32_t>();
-        uint32_t metaBytes = static_cast<uint32_t>(rows) * ELEM_SIZE;
-        AscendC::DataCopyExtParams metaParams{1, metaBytes, 0, metaBytes, 0};
-        AscendC::DataCopyPadExtParams<int32_t> noPadT{false, 0, 0, 0};
-        AscendC::DataCopyPad(numTokensLocal, numTokensGm[start_row], metaParams, noPadT);
-
-        auto discardLocal = discardTileBuf.Get<int32_t>();
-        AscendC::DataCopyPad(discardLocal, discardGm[start_row], metaParams, noPadT);
-    }
-
-    __aicore__ inline void Compute(uint32_t rows)
-    {
-        auto tokenLocal = tokenTileBuf.Get<int32_t>();
-        auto sampledLocal = sampledTileBuf.Get<int32_t>();
-        auto numTokensLocal = numTokensBuf.Get<int32_t>();
-        auto discardLocal = discardTileBuf.Get<int32_t>();
-        auto nextLocal = nextTokenBuf.Get<int32_t>();
-        auto draftLocal = draftBuf.Get<int32_t>();
-        auto numValidLocal = numValidBuf.Get<int32_t>();
-        auto suffixLocal = suffixBuf.Get<int32_t>();
-        auto maskLocal = maskBuf.Get<uint8_t>();
-
-        for (uint32_t i = 0; i < rows; ++i) {
-            ComputeOneRow(i, tokenLocal, sampledLocal, numTokensLocal,
-                          discardLocal, nextLocal, draftLocal, numValidLocal,
-                          suffixLocal, maskLocal);
-        }
-    }
-
-    __aicore__ inline void ComputeOneRow(
-        uint32_t idx,
-        AscendC::LocalTensor<int32_t> &tokenLocal,
-        AscendC::LocalTensor<int32_t> &sampledLocal,
-        AscendC::LocalTensor<int32_t> &numTokensLocal,
-        AscendC::LocalTensor<int32_t> &discardLocal,
-        AscendC::LocalTensor<int32_t> &nextLocal,
-        AscendC::LocalTensor<int32_t> &draftLocal,
-        AscendC::LocalTensor<int32_t> &numValidLocal,
-        AscendC::LocalTensor<int32_t> &suffixLocal,
-        AscendC::LocalTensor<uint8_t> &maskLocal)
-    {
-        uint32_t msa = this->max_seq_len_align;
-        uint32_t mnta = this->max_new_tokens_align;
-        uint32_t ka = this->k_align;
-
-        int32_t seq_len = numTokensLocal.GetValue(idx);
-        int32_t discard = discardLocal.GetValue(idx);
-        int32_t valid_count = 0;
-
-        int32_t backup_pos = (seq_len > 0) ? (seq_len - 1) : 0;
-        int32_t backup_token = tokenLocal.GetValue(idx * msa + backup_pos);
-
-        for (int32_t j = 0; j < this->max_new_tokens; ++j) {
-            int32_t val = sampledLocal.GetValue(idx * mnta + j);
-            if (discard != 0) {
-                sampledLocal.SetValue(idx * mnta + j, -1);
-            } else if (val != -1 && val < this->vocab_size_val) {
                 valid_count++;
-            } else {
-                sampledLocal.SetValue(idx * mnta + j, -1);
             }
         }
 
         int32_t avail_space = this->max_seq_len - seq_len;
-        if (avail_space < 0) avail_space = 0;
-        if (valid_count > avail_space) valid_count = avail_space;
+        if (avail_space < 0) {
+            avail_space = 0;
+        }
+        if (valid_count > avail_space) {
+            valid_count = avail_space;
+        }
 
+        // Step 4: Append sampled tokens to history sequence (sampled -> tokenGm) — MTE3
+        int32_t nt = seq_len + valid_count;
         if (valid_count > 0) {
-            nextLocal.SetValue(idx, sampledLocal.GetValue(idx * mnta + valid_count - 1));
-        } else {
-            nextLocal.SetValue(idx, backup_token);
+            COPY_UB_TO_GM(tokenGm, sampledLocal[sampled_offset], gmRow + seq_len, valid_count, int32_t);
+            AscendC::TQueSync<PIPE_MTE3, PIPE_S> sync;
+            AscendC::TEventID eventID = GetTPipePtr()->AllocEventID<AscendC::HardEvent::MTE3_S>();
+            sync.SetFlag(eventID);
+            sync.WaitFlag(eventID);
+            GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::MTE3_S>(eventID);
         }
 
-        int32_t num_tokens_tmp = seq_len + valid_count;
-        for (int32_t j = 0; j < valid_count; ++j) {
-            tokenLocal.SetValue(idx * msa + seq_len + j, sampledLocal.GetValue(idx * mnta + j));
-        }
+        // Leverage GetValue blocking semantics for implicit MTE3 -> MTE2 synchronization
+        // Read the last token of current sequence as nextToken
+        int32_t backup_pos = (nt > 0) ? (nt - 1) : 0;
+        int32_t backup_token = tokenGm.GetValue(gmRow + backup_pos);
+        nextTensor.SetValue(local_idx, backup_token);
 
+        // Step 5: N-gram vectorized recursive matching
         int32_t best_match_pos = -1;
         int32_t best_ngram_len = 0;
 
-        if (valid_count > 0 && num_tokens_tmp >= this->min_n_val) {
-            if (this->block_rows <= 1) {
-                int32_t nt = num_tokens_tmp;
-                constexpr uint32_t CMP_MAX = 8192u;
+        if (valid_count > 0 && nt >= this->min_n_val) {
+            int32_t suffix_gm_start = nt - this->max_n_val;
+            if (suffix_gm_start < 0) {
+                suffix_gm_start = 0;
+            }
+            int32_t suffix_load = this->max_n_val;
+            if (suffix_gm_start + suffix_load > nt) {
+                suffix_load = nt - suffix_gm_start;
+            }
 
-                for (int32_t ngram_len = this->min_n_val; ngram_len <= this->max_n_val; ++ngram_len) {
-                    if (ngram_len > nt) break;
-                    int32_t wc = nt - ngram_len;
-                    if (wc <= 0) break;
+            // Synchronous suffix load
+            auto suffixTensor = suffixInQue.AllocTensor<int32_t>();
+            COPY_GM_TO_UB(suffixTensor, tokenGm, gmRow + suffix_gm_start, suffix_load, int32_t);
+            suffixInQue.EnQue(suffixTensor);
+            auto suffixLocal = suffixInQue.DeQue<int32_t>();
 
-                    int32_t suffix0 = tokenLocal.GetValue(static_cast<uint32_t>(nt - ngram_len));
-                    uint32_t msa_cmp = static_cast<uint32_t>(msa);
+            auto ngramResult = ngramCalcBuf.Get<int32_t>();
+            auto ngramTemp = ngramTempBuf.Get<int32_t>();
+            auto ngramTempF = ngramTempBuf.Get<float>();
+            auto ngramGather = ngramGatherBuf.Get<int32_t>();
+            auto ngramReduce = ngramReduceBuf.Get<float>();
 
-                    for (int32_t cmp_off = 0; cmp_off < wc; cmp_off += CMP_MAX) {
-                        uint32_t remaining = static_cast<uint32_t>(wc - cmp_off);
-                        uint32_t elements = (remaining >= CMP_MAX) ? CMP_MAX : remaining;
-                        uint32_t count_aligned = ((elements + 63u) / 64u) * 64u;
-                        uint32_t buf_avail = msa_cmp - static_cast<uint32_t>(cmp_off);
-                        if (count_aligned > buf_avail) {
-                            count_aligned = (buf_avail / 64u) * 64u;
-                        }
+            uint32_t max_gather_len = this->is_large_row
+                                    ? (SAFE_CHUNK + static_cast<uint32_t>(this->max_n_val))
+                                    : static_cast<uint32_t>(this->max_seq_len);
+            if (this->max_n_val > 1) {
+                AscendC::Arange<int32_t>(
+                    ngramGather,
+                    static_cast<int32_t>(sizeof(int32_t)),
+                    static_cast<int32_t>(sizeof(int32_t)),
+                    static_cast<int32_t>(max_gather_len));
+            }
 
-                        if (count_aligned == 0) {
-                            for (int32_t p = 0; p < static_cast<int32_t>(elements); ++p) {
-                                if (tokenLocal.GetValue(static_cast<uint32_t>(cmp_off + p)) == suffix0) {
-                                    bool all_match = true;
-                                    for (int32_t s = 1; s < ngram_len; ++s) {
-                                        int32_t sv = tokenLocal.GetValue(static_cast<uint32_t>(nt - ngram_len + s));
-                                        int32_t tv = tokenLocal.GetValue(static_cast<uint32_t>(cmp_off + p + s));
-                                        if (tv != sv) { all_match = false; break; }
-                                    }
-                                    if (all_match) {
-                                        best_match_pos = cmp_off + p;
-                                        best_ngram_len = ngram_len;
-                                        break;
-                                    }
-                                }
-                            }
-                        } else {
-                            AscendC::CompareScalar<int32_t, uint8_t>(
-                                maskLocal, tokenLocal[static_cast<uint32_t>(cmp_off)],
-                                suffix0, AscendC::CMPMODE::EQ, count_aligned);
+            bool found_global_max = false;
 
-                            for (int32_t p = 0; p < static_cast<int32_t>(elements); ++p) {
-                                uint8_t byte_val = maskLocal.GetValue(static_cast<uint32_t>(p) >> 3);
-                                if (byte_val & (1u << (static_cast<uint32_t>(p) & 7u))) {
-                                    bool all_match = true;
-                                    for (int32_t s = 1; s < ngram_len; ++s) {
-                                        int32_t sv = tokenLocal.GetValue(static_cast<uint32_t>(nt - ngram_len + s));
-                                        int32_t tv = tokenLocal.GetValue(static_cast<uint32_t>(cmp_off + p + s));
-                                        if (tv != sv) { all_match = false; break; }
-                                    }
-                                    if (all_match) {
-                                        best_match_pos = cmp_off + p;
-                                        best_ngram_len = ngram_len;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                        if (best_match_pos >= 0) break;
-                    }
+            for (int32_t chunk_start = 0;
+                 chunk_start < nt - this->min_n_val && !found_global_max;
+                 chunk_start += SAFE_CHUNK)
+            {
+                int32_t chunk_count = (chunk_start + SAFE_CHUNK <= nt - this->min_n_val)
+                                      ? SAFE_CHUNK
+                                      : (nt - this->min_n_val - chunk_start);
+                if (chunk_count <= 0) {
+                    break;
                 }
-            } else {
-                int32_t row_base = static_cast<int32_t>(idx) * static_cast<int32_t>(msa);
 
-                for (int32_t ngram_len = this->min_n_val; ngram_len <= this->max_n_val; ++ngram_len) {
-                    if (ngram_len > num_tokens_tmp) break;
+                int32_t load_count = chunk_count + this->max_n_val;
+                if (chunk_start + load_count > nt) {
+                    load_count = nt - chunk_start;
+                }
+                if (load_count <= 0) {
+                    continue;
+                }
 
-                    for (int32_t s = 0; s < ngram_len; ++s) {
-                        suffixLocal.SetValue(static_cast<uint32_t>(s),
-                            tokenLocal.GetValue(static_cast<uint32_t>(
-                                row_base + num_tokens_tmp - ngram_len + s)));
+                // Synchronous chunk load
+                auto chunkTensor = tokenInQue.AllocTensor<int32_t>();
+                COPY_GM_TO_UB(chunkTensor, tokenGm, gmRow + chunk_start, load_count, int32_t);
+                tokenInQue.EnQue(chunkTensor);
+                auto tokenLocal = tokenInQue.DeQue<int32_t>();
+
+                for (int32_t n = 1; n <= this->max_n_val; ++n) {
+                    int32_t valid_len = load_count - n;
+                    if (valid_len <= 0) {
+                        break;
                     }
 
-                    int32_t max_pos = num_tokens_tmp - ngram_len - 1;
-                    for (int32_t pos = 0; pos <= max_pos; ++pos) {
-                        bool match = true;
-                        for (int32_t s = 0; s < ngram_len; ++s) {
-                            if (tokenLocal.GetValue(static_cast<uint32_t>(row_base + pos + s))
-                                != suffixLocal.GetValue(static_cast<uint32_t>(s))) {
-                                match = false;
+                    if (n > 1) {
+                        AscendC::Gather<int32_t>(
+                            ngramTemp, ngramResult,
+                            ngramGather.ReinterpretCast<uint32_t>(), 0, valid_len);
+                    }
+
+                    int32_t s_val = suffixLocal.GetValue(static_cast<uint32_t>(suffix_load - n));
+                    AscendC::Adds<int32_t>(ngramResult, tokenLocal, -s_val, valid_len);
+
+                    if (n > 1) {
+                        AscendC::Or<uint16_t>(
+                            ngramResult.ReinterpretCast<uint16_t>(),
+                            ngramResult.ReinterpretCast<uint16_t>(),
+                            ngramTemp.ReinterpretCast<uint16_t>(),
+                            valid_len * 2);
+                    }
+
+                    if (n >= this->min_n_val) {
+                        int32_t check_count = (chunk_start + chunk_count <= nt - n)
+                                            ? chunk_count
+                                            : (nt - n - chunk_start);
+                        if (check_count > 0) {
+                            AscendC::Cast<float, int32_t>(
+                                ngramTempF, ngramResult,
+                                AscendC::RoundMode::CAST_CEIL, check_count);
+                            AscendC::Abs<float>(ngramTempF, ngramTempF, check_count);
+                            AscendC::ReduceMin<float>(
+                                ngramReduce, ngramTempF, ngramReduce, check_count, true);
+
+                            float min_val_f = ngramReduce.GetValue(0);
+                            if (min_val_f == 0.0f) {
+                                if (n > best_ngram_len) {
+                                    float min_idx_f = ngramReduce.GetValue(1);
+                                    uint32_t pos = *reinterpret_cast<uint32_t*>(&min_idx_f);
+                                    best_match_pos = chunk_start + static_cast<int32_t>(pos);
+                                    best_ngram_len = n;
+
+                                    if (n == this->max_n_val) {
+                                        found_global_max = true;
+                                        break;
+                                    }
+                                }
+                            } else {
+                                // Current chunk failed for this n; larger n impossible
                                 break;
                             }
                         }
-                        if (match) {
-                            best_match_pos = pos;
-                            best_ngram_len = ngram_len;
-                            break;
-                        }
                     }
                 }
+
+                tokenInQue.FreeTensor(tokenLocal);
             }
+
+            suffixInQue.FreeTensor(suffixLocal);
         }
+
+        // Step 6: Draft generation (write directly to VECOUT tensor)
+        uint32_t draft_offset = local_idx * ka;
+        int32_t valid_draft_count = 0;
+        AscendC::Duplicate(draftTensor[draft_offset], -1, this->k_align);
 
         if (best_match_pos >= 0) {
             int32_t draft_start = best_match_pos + best_ngram_len;
-            int32_t tokens_available = num_tokens_tmp - draft_start;
-            for (int32_t j = 0; j < this->k_val; ++j) {
-                if (j < tokens_available) {
-                    draftLocal.SetValue(idx * ka + j, tokenLocal.GetValue(idx * msa + draft_start + j));
-                } else {
-                    draftLocal.SetValue(idx * ka + j, -1);
-                }
-            }
-        } else {
-            for (int32_t j = 0; j < this->k_val; ++j) {
-                draftLocal.SetValue(idx * ka + j, -1);
+            int32_t tokens_available = nt - draft_start;
+            valid_draft_count = (tokens_available < this->k_val) ? tokens_available : this->k_val;
+            if (valid_draft_count > 0) {
+                COPY_GM_TO_UB(
+                    draftTensor[draft_offset], tokenGm, gmRow + draft_start, valid_draft_count, int32_t);
             }
         }
 
-        int32_t valid_draft_count = 0;
-        for (int32_t j = 0; j < this->k_val; ++j) {
-            if (draftLocal.GetValue(idx * ka + j) != -1) {
-                valid_draft_count++;
-            } else {
-                break;
-            }
-        }
-        numValidLocal.SetValue(idx, valid_draft_count);
+        numValidTensor.SetValue(local_idx, valid_draft_count >= 0 ? valid_draft_count : 0);
     }
 
-    __aicore__ inline void CopyOut(uint32_t start_row, uint32_t rows)
+    __aicore__ inline uint32_t CalcReduceMinTmpSize(uint32_t count, uint32_t typeSize)
     {
-        uint32_t msa = static_cast<uint32_t>(this->max_seq_len_align);
-        uint32_t msl = static_cast<uint32_t>(this->max_seq_len);
-        constexpr uint32_t OUT_CHUNK_ELEMS = 8192u;
-
-        auto tokenLocal = tokenTileBuf.Get<int32_t>();
-        for (uint32_t r = 0; r < rows; ++r) {
-            uint64_t gmRow = static_cast<uint64_t>(start_row + r) * msl;
-            uint32_t ubRow = r * msa;
-            for (uint32_t off = 0; off < msl; off += OUT_CHUNK_ELEMS) {
-                uint32_t chunk = (off + OUT_CHUNK_ELEMS <= msl) ? OUT_CHUNK_ELEMS : (msl - off);
-                AscendC::DataCopyExtParams p{1, chunk * ELEM_SIZE, 0, 0, 0};
-                AscendC::DataCopyPad(tokenGm[gmRow + off], tokenLocal[ubRow + off], p);
-            }
-        }
-
-        auto nextLocal = nextTokenBuf.Get<int32_t>();
-        uint32_t metaBytes32 = static_cast<uint32_t>(rows) * ELEM_SIZE;
-        AscendC::DataCopyExtParams nextParams{1, metaBytes32, 0, 0, 0};
-        AscendC::DataCopyPad(nextTokensGm[start_row], nextLocal, nextParams);
-
-        auto draftLocal = draftBuf.Get<int32_t>();
-        uint32_t kBytes = static_cast<uint32_t>(this->k_val) * ELEM_SIZE;
-        for (uint32_t r = 0; r < rows; ++r) {
-            AscendC::DataCopyExtParams draftRowParams{1, kBytes, 0, 0, 0};
-            AscendC::DataCopyPad(
-                draftTokensGm[static_cast<uint64_t>(start_row + r) * this->k_val],
-                draftLocal[static_cast<uint64_t>(r) * this->k_align], draftRowParams);
-        }
-
-        auto numValidLocal = numValidBuf.Get<int32_t>();
-        AscendC::DataCopyPad(numValidGm[start_row], numValidLocal, nextParams);
+        uint32_t elementsPerBlock = 32 / typeSize;
+        uint32_t elementsPerRepeat = 256 / typeSize;
+        auto RoundUp = [](uint32_t x, uint32_t unit) -> uint32_t {
+            return (x + unit - 1) / unit;
+        };
+        uint32_t firstMaxRepeat = RoundUp(count, elementsPerRepeat);
+        uint32_t iter1OutputCount = firstMaxRepeat * 2;
+        uint32_t iter2AlignStart = RoundUp(iter1OutputCount, elementsPerBlock) * elementsPerBlock;
+        uint32_t iter2OutputCount = RoundUp(iter1OutputCount, elementsPerRepeat) * 2;
+        uint32_t iter3AlignStart = RoundUp(iter2OutputCount, elementsPerBlock) * elementsPerBlock;
+        uint32_t iter3OutputCount = RoundUp(iter2OutputCount, elementsPerRepeat) * 2;
+        uint32_t iter3AlignEnd = RoundUp(iter3OutputCount, elementsPerBlock) * elementsPerBlock;
+        return iter2AlignStart + iter3AlignStart + iter3AlignEnd;
     }
 
 private:
     AscendC::TPipe pipe;
-    AscendC::TBuf<AscendC::TPosition::VECCALC> tokenTileBuf;
-    AscendC::TBuf<AscendC::TPosition::VECCALC> sampledTileBuf;
-    AscendC::TBuf<AscendC::TPosition::VECCALC> numTokensBuf;
-    AscendC::TBuf<AscendC::TPosition::VECCALC> discardTileBuf;
-    AscendC::TBuf<AscendC::TPosition::VECCALC> nextTokenBuf;
-    AscendC::TBuf<AscendC::TPosition::VECCALC> draftBuf;
-    AscendC::TBuf<AscendC::TPosition::VECCALC> numValidBuf;
-    AscendC::TBuf<AscendC::TPosition::VECCALC> suffixBuf;
-    AscendC::TBuf<AscendC::TPosition::VECCALC> maskBuf;
+
+    // Input queues (VECIN): EnQue after MTE2 in, DeQue guarantees transfer completion
+    AscendC::TQue<AscendC::TPosition::VECIN, 1> tokenInQue;
+    AscendC::TQue<AscendC::TPosition::VECIN, 1> sampledInQue;
+    AscendC::TQue<AscendC::TPosition::VECIN, 1> numTokensInQue;
+    AscendC::TQue<AscendC::TPosition::VECIN, 1> discardInQue;
+    AscendC::TQue<AscendC::TPosition::VECIN, 1> suffixInQue;
+
+    // Output queues (VECOUT): EnQue after compute, DeQue guarantees MTE3 out sync
+    AscendC::TQue<AscendC::TPosition::VECOUT, 1> nextOutQue;
+    AscendC::TQue<AscendC::TPosition::VECOUT, 1> draftOutQue;
+    AscendC::TQue<AscendC::TPosition::VECOUT, 1> numValidOutQue;
+
+    // Pure UB computation buffers (no GM traffic, kept as TBuf)
+    AscendC::TBuf<AscendC::TPosition::VECCALC> ngramCalcBuf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> ngramTempBuf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> ngramGatherBuf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> ngramReduceBuf;
 
     AscendC::GlobalTensor<int32_t> tokenGm;
     AscendC::GlobalTensor<int32_t> numTokensGm;

--- a/csrc/attention/ngram_spec_decode/op_kernel/ngram_spec_decode.cpp
+++ b/csrc/attention/ngram_spec_decode/op_kernel/ngram_spec_decode.cpp
@@ -14,43 +14,47 @@
 const uint32_t ELEM_SIZE = 4;  // int32
 constexpr uint32_t SAFE_CHUNK = 8192u;
 
-#define COPY_GM_TO_UB(dst, src, src_offset, count, T)                      \
-    do {                                                                   \
-        if ((count) > 0) {                                                 \
-            constexpr uint32_t __align_elem = 8u;                          \
-            uint32_t __c = static_cast<uint32_t>(count);                   \
+// ----------------------------------------------------------------------------
+// GM -> UB copy macro with automatic alignment padding.
+// Handles unaligned GM addresses via DataCopyPad.
+// ----------------------------------------------------------------------------
+#define COPY_GM_TO_UB(dst, src, src_offset, count, T)                          \
+    do {                                                                      \
+        if ((count) > 0) {                                                    \
+            constexpr uint32_t __align_elem = 8u;                             \
+            uint32_t __c = static_cast<uint32_t>(count);                    \
             uint32_t __aligned = ((__c + __align_elem - 1u) / __align_elem) \
-                                 * __align_elem;                           \
-            uint8_t __pad = static_cast<uint8_t>(__aligned - __c);          \
-            AscendC::DataCopyExtParams __p{                                \
-                1,                                                         \
-                static_cast<uint32_t>(__c * sizeof(T)),                    \
-                0,                                                         \
-                0,                                                         \
-                0};                                                        \
-            AscendC::DataCopyPadExtParams<T> __pp{true, 0, __pad, -1};     \
+                                 * __align_elem;                              \
+            uint8_t __pad = static_cast<uint8_t>(__aligned - __c);           \
+            AscendC::DataCopyExtParams __p{                                   \
+                1,                                                            \
+                static_cast<uint32_t>(__c * sizeof(T)),                       \
+                0, 0, 0};                                                     \
+            AscendC::DataCopyPadExtParams<T> __pp{true, 0, __pad, -1};       \
             AscendC::DataCopyPad((dst), (src)[(src_offset)], __p, __pp);    \
-        }                                                                  \
+        }                                                                     \
     } while (0)
 
-#define COPY_UB_TO_GM(dst, src, dst_offset, count, T)                      \
-    do {                                                                   \
-        if ((count) > 0) {                                                 \
-            constexpr uint32_t __store_max = 16383u;                       \
-            uint32_t __c = static_cast<uint32_t>(count);                   \
-            for (uint32_t __off = 0; __off < __c; __off += __store_max) {  \
-                uint32_t __chunk = (__off + __store_max <= __c)            \
-                                    ? __store_max                          \
-                                    : (__c - __off);                       \
-                AscendC::DataCopyParams __p{                               \
-                    1,                                                     \
-                    static_cast<uint16_t>(__chunk * sizeof(T)),          \
-                    0,                                                     \
-                    0};                                                    \
-                AscendC::DataCopyPad(                                      \
-                    (dst)[(dst_offset) + __off], (src)[__off], __p);       \
-            }                                                              \
-        }                                                                  \
+// ----------------------------------------------------------------------------
+// UB -> GM copy macro with chunking for large transfers.
+// Ascend UB store has a single-transfer limit (16383 elements).
+// ----------------------------------------------------------------------------
+#define COPY_UB_TO_GM(dst, dst_offset, src, src_offset, count, T)           \
+    do {                                                                      \
+        if ((count) > 0) {                                                    \
+            constexpr uint32_t __store_max = 16383u;                          \
+            uint32_t __c = static_cast<uint32_t>(count);                    \
+            for (uint32_t __off = 0; __off < __c; __off += __store_max) {    \
+                uint32_t __chunk = (__off + __store_max <= __c)              \
+                                       ? __store_max                          \
+                                       : (__c - __off);                       \
+                AscendC::DataCopyParams __p{                                  \
+                    1, static_cast<uint16_t>(__chunk * sizeof(T)), 0, 0};  \
+                AscendC::DataCopyPad(                                         \
+                    (dst)[(dst_offset) + __off],                              \
+                    (src)[(src_offset) + __off], __p);                        \
+            }                                                                 \
+        }                                                                     \
     } while (0)
 
 class KernelNgramSpecDecode {
@@ -65,232 +69,349 @@ public:
         REGISTER_TILING_DEFAULT(NgramSpecDecodeTilingData);
         GET_TILING_DATA_WITH_STRUCT(NgramSpecDecodeTilingData, tilingData, tiling);
 
-        this->batch_size = static_cast<int32_t>(tilingData.ngramInfo.batchSize);
-        this->max_seq_len = static_cast<int32_t>(tilingData.ngramInfo.maxSeqLen);
-        this->max_new_tokens = static_cast<int32_t>(tilingData.ngramInfo.maxNewTokens);
-        this->vocab_size_val = static_cast<int32_t>(tilingData.ngramInfo.vocabSize);
-        this->min_n_val = static_cast<int32_t>(tilingData.ngramInfo.minN);
-        this->max_n_val = static_cast<int32_t>(tilingData.ngramInfo.maxN);
-        this->k_val = static_cast<int32_t>(tilingData.ngramInfo.k);
-        this->former_num = static_cast<int32_t>(tilingData.ngramInfo.formerNum);
-        this->rows_per_core = static_cast<int32_t>(tilingData.ngramInfo.rowsPerCore);
-        
-        // Align dimensions to 32-byte boundaries (8 elements for int32)
+        // --------------------------------------------------------------------
+        // Extract tiling parameters
+        // --------------------------------------------------------------------
+        this->batch_size      = tilingData.ngramInfo.batchSize;
+        this->max_seq_len     = tilingData.ngramInfo.maxSeqLen;
+        this->max_new_tokens  = tilingData.ngramInfo.maxNewTokens;
+        this->vocab_size_val  = tilingData.ngramInfo.vocabSize;
+        this->min_n_val       = tilingData.ngramInfo.minN;
+        this->max_n_val       = tilingData.ngramInfo.maxN;
+        this->k_val           = tilingData.ngramInfo.k;
+        this->former_num      = tilingData.ngramInfo.formerNum;
+        this->rows_per_core   = tilingData.ngramInfo.rowsPerCore;
+
+        // --------------------------------------------------------------------
+        // Compute alignment paddings (32-byte aligned for vector engine)
+        // --------------------------------------------------------------------
         int32_t align_elems = 32 / ELEM_SIZE;
-        this->max_seq_len_align = ((this->max_seq_len + align_elems - 1) / align_elems) * align_elems;
+        this->max_seq_len_align    = ((this->max_seq_len    + align_elems - 1) / align_elems) * align_elems;
         this->max_new_tokens_align = ((this->max_new_tokens + align_elems - 1) / align_elems) * align_elems;
-        this->k_align = ((this->k_val + align_elems - 1) / align_elems) * align_elems;
+        this->k_align              = ((this->k_val          + align_elems - 1) / align_elems) * align_elems;
 
-        this->is_large_row = (this->max_seq_len_align > static_cast<int32_t>(SAFE_CHUNK));
-
-        // Compute row distribution across cores
+        // --------------------------------------------------------------------
+        // Compute row distribution for this AI Core
+        // --------------------------------------------------------------------
         uint32_t blockIdx = AscendC::GetBlockIdx();
         if (blockIdx < static_cast<uint32_t>(this->former_num)) {
-            this->my_rows = static_cast<uint32_t>(this->rows_per_core) + 1;
-            this->row_offset = (static_cast<uint32_t>(this->rows_per_core) + 1) * blockIdx;
+            this->my_row_count = static_cast<uint32_t>(this->rows_per_core) + 1;
+            this->my_row_offset = (static_cast<uint32_t>(this->rows_per_core) + 1) * blockIdx;
         } else {
-            this->my_rows = static_cast<uint32_t>(this->rows_per_core);
-            this->row_offset = static_cast<uint32_t>(this->rows_per_core + 1)
-                             * static_cast<uint32_t>(this->former_num)
-                             + this->my_rows * (blockIdx - static_cast<uint32_t>(this->former_num));
+            this->my_row_count  = static_cast<uint32_t>(this->rows_per_core);
+            this->my_row_offset = static_cast<uint32_t>(this->rows_per_core + 1)
+                            * static_cast<uint32_t>(this->former_num)
+                            + this->my_row_count * (blockIdx - static_cast<uint32_t>(this->former_num));
         }
 
-        // Bind Global Memory tensors
-        tokenGm.SetGlobalBuffer(
-            (__gm__ int32_t *)token_ids_gm,
-            static_cast<uint64_t>(this->batch_size) * this->max_seq_len);
-        numTokensGm.SetGlobalBuffer(
-            (__gm__ int32_t *)num_tokens_gm,
-            static_cast<uint64_t>(this->batch_size));
-        sampledGm.SetGlobalBuffer(
-            (__gm__ int32_t *)sampled_gm,
-            static_cast<uint64_t>(this->batch_size) * this->max_new_tokens);
-        discardGm.SetGlobalBuffer(
-            (__gm__ int32_t *)discard_gm,
-            static_cast<uint64_t>(this->batch_size));
-        nextTokensGm.SetGlobalBuffer(
-            (__gm__ int32_t *)next_tokens_gm,
-            static_cast<uint64_t>(this->batch_size));
-        draftTokensGm.SetGlobalBuffer(
-            (__gm__ int32_t *)draft_tokens_gm,
-            static_cast<uint64_t>(this->batch_size) * this->k_val);
-        numValidGm.SetGlobalBuffer(
-            (__gm__ int32_t *)num_valid_gm,
-            static_cast<uint64_t>(this->batch_size));
+        // --------------------------------------------------------------------
+        // Bind GM buffers
+        // --------------------------------------------------------------------
+        tokenGm.SetGlobalBuffer((__gm__ int32_t *)token_ids_gm,
+                                static_cast<uint64_t>(this->batch_size) * this->max_seq_len);
+        numTokensGm.SetGlobalBuffer((__gm__ int32_t *)num_tokens_gm,
+                                    static_cast<uint64_t>(this->batch_size));
+        sampledGm.SetGlobalBuffer((__gm__ int32_t *)sampled_gm,
+                                  static_cast<uint64_t>(this->batch_size) * this->max_new_tokens);
+        discardGm.SetGlobalBuffer((__gm__ int32_t *)discard_gm,
+                                static_cast<uint64_t>(this->batch_size));
+        nextTokensGm.SetGlobalBuffer((__gm__ int32_t *)next_tokens_gm,
+                                static_cast<uint64_t>(this->batch_size));
+        draftTokensGm.SetGlobalBuffer((__gm__ int32_t *)draft_tokens_gm,
+                                static_cast<uint64_t>(this->batch_size) * this->k_val);
+        numValidGm.SetGlobalBuffer((__gm__ int32_t *)num_valid_gm,
+                                static_cast<uint64_t>(this->batch_size));
 
-        // ============================================================
-        // TQue Initialization (depth=1, single-buffer, EnQue/DeQue for event sync)
-        // ============================================================
-        uint32_t mnta = static_cast<uint32_t>(this->max_new_tokens_align);
-        uint32_t ka = static_cast<uint32_t>(this->k_align);
-        uint32_t my_rows_align = ((this->my_rows + 7u) / 8u) * 8u;
+        // --------------------------------------------------------------------
+        // Compute UB buffer sizes
+        // --------------------------------------------------------------------
+        uint32_t mnta_aligned = static_cast<uint32_t>(this->max_new_tokens_align);
+        uint32_t k_aligned    = static_cast<uint32_t>(this->k_align);
+        uint32_t my_rows_aligned = ((this->my_row_count + 7u) / 8u) * 8u;
 
-        uint32_t token_buf_size = 0;
-        if (!this->is_large_row) {
-            token_buf_size = static_cast<uint32_t>(this->max_seq_len_align) * ELEM_SIZE;
-        } else {
-            uint32_t chunk_ub = SAFE_CHUNK + static_cast<uint32_t>(this->max_n_val);
-            uint32_t chunk_ub_align = ((chunk_ub + 7u) / 8u) * 8u;
-            token_buf_size = chunk_ub_align * ELEM_SIZE;
-        }
+        uint32_t chunk_ub       = SAFE_CHUNK + static_cast<uint32_t>(this->max_n_val);
+        uint32_t chunk_ub_align = ((chunk_ub + 7u) / 8u) * 8u;
+        uint32_t token_buf_size = chunk_ub_align * ELEM_SIZE;
 
-        // VECIN: Input data queues (GM -> UB, MTE2 direction)
-        pipe.InitBuffer(tokenInQue, 1, token_buf_size);
-        pipe.InitBuffer(sampledInQue, 1, this->my_rows * mnta * ELEM_SIZE);
-        pipe.InitBuffer(numTokensInQue, 1, my_rows_align * ELEM_SIZE);
-        pipe.InitBuffer(discardInQue, 1, my_rows_align * ELEM_SIZE);
-        pipe.InitBuffer(suffixInQue, 1, static_cast<uint32_t>(this->max_n_val) * ELEM_SIZE);
+        // --------------------------------------------------------------------
+        // Initialize TQue / TBuf pipelines
+        // --------------------------------------------------------------------
+        // Input queues
+        pipe.InitBuffer(tokenInQue,    2, token_buf_size);          // Double-buffered tokens
+        pipe.InitBuffer(sampledInQue,  1, this->my_row_count * mnta_aligned * ELEM_SIZE);
+        pipe.InitBuffer(numTokensInQue,1, my_rows_aligned * ELEM_SIZE);
+        pipe.InitBuffer(discardInQue,  1, my_rows_aligned * ELEM_SIZE);
+        pipe.InitBuffer(suffixInQue,   1, static_cast<uint32_t>(this->max_n_val) * ELEM_SIZE);
 
-        // VECOUT: Output data queues (UB -> GM, MTE3 direction)
-        pipe.InitBuffer(nextOutQue, 1, my_rows_align * ELEM_SIZE);
-        pipe.InitBuffer(draftOutQue, 1, this->my_rows * ka * ELEM_SIZE);
-        pipe.InitBuffer(numValidOutQue, 1, my_rows_align * ELEM_SIZE);
+        // Output queues
+        pipe.InitBuffer(nextOutQue,    1, my_rows_aligned * ELEM_SIZE);
+        pipe.InitBuffer(draftOutQue,   1, this->my_row_count * k_aligned * ELEM_SIZE);
+        pipe.InitBuffer(numValidOutQue,1, my_rows_aligned * ELEM_SIZE);
 
-        // Pure UB computation buffers (no GM traffic, keep as TBuf)
-        pipe.InitBuffer(ngramCalcBuf, token_buf_size);
-        pipe.InitBuffer(ngramTempBuf, token_buf_size);
+        // Calculation buffers
+        pipe.InitBuffer(validCountBuf,  my_rows_aligned * ELEM_SIZE);
+        pipe.InitBuffer(ngramCalcBuf,   token_buf_size);
+        pipe.InitBuffer(ngramTempBuf,   token_buf_size);
         pipe.InitBuffer(ngramGatherBuf, token_buf_size);
 
-        uint32_t reduce_count = this->is_large_row
-                              ? SAFE_CHUNK
-                              : (static_cast<uint32_t>(this->max_seq_len) - 1);
+        // ReduceMin requires extra scratch space for multi-iteration reduction
+        uint32_t reduce_count    = SAFE_CHUNK;
         uint32_t reduce_tmp_elems = CalcReduceMinTmpSize(reduce_count, ELEM_SIZE);
         uint32_t reduce_tmp_bytes = ((reduce_tmp_elems * ELEM_SIZE + 31) / 32) * 32;
         pipe.InitBuffer(ngramReduceBuf, reduce_tmp_bytes);
+
     }
 
+    // ------------------------------------------------------------------------
+    // Main processing pipeline
+    // ------------------------------------------------------------------------
     __aicore__ inline void Process()
     {
-        // Step 1: Enqueue input data (MTE2 transfer in)
+        // Initialize gather indices for n-gram recurrence (byte offsets)
+        auto gatherLocal = ngramGatherBuf.Get<int32_t>();
+        const uint32_t gather_size = (((SAFE_CHUNK + static_cast<uint32_t>(this->max_n_val)) + 7u) / 8u) * 8u;
+        AscendC::Arange<int32_t>(gatherLocal,
+                                static_cast<int32_t>(sizeof(int32_t)),
+                                static_cast<int32_t>(sizeof(int32_t)),
+                                gather_size);
+
+        // Stage 1: Load per-row metadata from GM to UB
         CopyInMetadata();
 
-        // Step 2: Dequeue input tensors before loop (sync point: ensure MTE2 done)
-        auto sampledLocal = sampledInQue.DeQue<int32_t>();
+        auto sampledLocal   = sampledInQue.DeQue<int32_t>();
         auto numTokensLocal = numTokensInQue.DeQue<int32_t>();
-        auto discardLocal = discardInQue.DeQue<int32_t>();
+        auto discardLocal   = discardInQue.DeQue<int32_t>();
 
-        // Step 3: Allocate output tensors (not enqueued yet, only reserve UB space)
-        auto nextTensor = nextOutQue.AllocTensor<int32_t>();
-        auto draftTensor = draftOutQue.AllocTensor<int32_t>();
-        auto numValidTensor = numValidOutQue.AllocTensor<int32_t>();
+        auto nextLocal     = nextOutQue.AllocTensor<int32_t>();
+        auto draftLocal    = draftOutQue.AllocTensor<int32_t>();
+        auto numValidLocal = numValidOutQue.AllocTensor<int32_t>();
+        auto validCountLocal = validCountBuf.Get<int32_t>();
 
-        // Step 4: Row-by-row computation (output tensors passed by reference, written directly)
-        for (uint32_t r = 0; r < this->my_rows; ++r) {
-            uint32_t global_row = this->row_offset + r;
-            ProcessOneRow(
-                r, global_row,
-                sampledLocal, numTokensLocal, discardLocal,
-                nextTensor, draftTensor, numValidTensor);
+        // Stage 2: Validate sampled tokens and clamp valid counts by avail space
+        for (uint32_t r = 0; r < this->my_row_count; ++r) {
+            int32_t valid_count = ValidateTokens(r, this->my_row_offset + r,
+                                                sampledLocal, numTokensLocal,
+                                                discardLocal, nextLocal);
+            validCountLocal.SetValue(r, valid_count);
         }
 
-        // Step 5: Free input tensors
+        // Stage 3: Synchronize MTE3 (store) and MTE2 (load)
+        AscendC::TQueSync<PIPE_MTE3, PIPE_MTE2> sync_a;
+        auto event = GetTPipePtr()->AllocEventID<AscendC::HardEvent::MTE3_MTE2>();
+        sync_a.SetFlag(event);
+        sync_a.WaitFlag(event);
+        GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::MTE3_MTE2>(event);
+
+        // Stage 4: N-gram matching per row with double-buffered token loading
+        int32_t preloaded_row = -1;  // Row index preloaded into tokenInQue's second slot
+        for (uint32_t r = 0; r < this->my_row_count; ++r) {
+            uint32_t global_row = this->my_row_offset + r;
+            int32_t valid_count = validCountLocal.GetValue(r);
+            int32_t seq_len     = numTokensLocal.GetValue(r);
+            int32_t total_len   = seq_len + valid_count;
+            bool is_short       = (total_len > 0 && total_len <= static_cast<int32_t>(SAFE_CHUNK));
+
+            // Prefetch metadata for the next row to overlap memory with compute
+            int32_t next_valid_count = -1;
+            int32_t next_seq_len     = -1;
+            int32_t next_total_len   = -1;
+            if (r + 1 < this->my_row_count) {
+                next_valid_count = validCountLocal.GetValue(r + 1);
+                next_seq_len     = numTokensLocal.GetValue(r + 1);
+                next_total_len   = next_seq_len + next_valid_count;
+            }
+
+            uint32_t draft_offset = r * static_cast<uint32_t>(this->k_align);
+            AscendC::Duplicate(draftLocal[draft_offset], static_cast<int32_t>(-1),
+                            static_cast<uint32_t>(this->k_align));
+
+            // Skip rows that have no valid draft space or are shorter than min_n
+            if (valid_count <= 0 || total_len < this->min_n_val) {
+                numValidLocal.SetValue(r, 0);
+                continue;
+            }
+
+            bool this_row_preloaded = (preloaded_row == static_cast<int32_t>(r));
+            preloaded_row = -1;
+
+            int32_t best_match_pos  = -1;
+            int32_t best_ngram_len  = 0;
+            int32_t draft_load      = 0;
+
+            if (is_short) {
+                // Short path: entire sequence fits in UB
+                AscendC::LocalTensor<int32_t> tokenLocal;
+                if (this_row_preloaded) {
+                    tokenLocal = tokenInQue.DeQue<int32_t>();
+                } else {
+                    tokenLocal = LoadOneRowToken(global_row, total_len);
+                }
+
+                // Preload next row into the second buffer slot
+                if (r + 1 < this->my_row_count && next_valid_count > 0 && next_total_len >= this->min_n_val) {
+                    uint32_t next_global_row = this->my_row_offset + r + 1;
+                    if (next_total_len <= static_cast<int32_t>(SAFE_CHUNK)) {
+                        LaunchPreloadNextRow(next_global_row, next_total_len);
+                    } else {
+                        LaunchPreloadNextLongFirstChunk(next_global_row, next_total_len);
+                    }
+                    preloaded_row = static_cast<int32_t>(r + 1);
+                }
+
+                NgramMatchRowShort(total_len, tokenLocal, best_match_pos, best_ngram_len);
+
+                if (best_match_pos >= 0) {
+                    int32_t draft_start = best_match_pos + best_ngram_len;
+                    int32_t avail       = total_len - draft_start;
+                    draft_load = (avail < this->k_val) ? avail : this->k_val;
+                    for (int32_t j = 0; j < draft_load; ++j) {
+                        draftLocal.SetValue(draft_offset + static_cast<uint32_t>(j),
+                                            tokenLocal.GetValue(static_cast<uint32_t>(draft_start + j)));
+                    }
+                }
+                tokenInQue.FreeTensor(tokenLocal);
+            } else {
+                // Long path: chunk-based matching with double buffering
+                int32_t next_global_row = (r + 1 < this->my_row_count)
+                                        ? static_cast<int32_t>(this->my_row_offset + r + 1)
+                                        : -1;
+                int32_t preloaded_out = -1;
+                NgramMatchRowLong(global_row, total_len, this_row_preloaded,
+                                next_global_row, next_total_len, next_valid_count,
+                                preloaded_out, best_match_pos, best_ngram_len);
+                if (preloaded_out >= 0) {
+                    preloaded_row = static_cast<int32_t>(r + 1);
+                }
+
+                if (best_match_pos >= 0) {
+                    int32_t avail = total_len - (best_match_pos + best_ngram_len);
+                    draft_load = (avail < this->k_val) ? avail : this->k_val;
+                    if (draft_load > 0) {
+                        uint64_t gm_row_offset = static_cast<uint64_t>(global_row)
+                                                 * static_cast<uint32_t>(this->max_seq_len);
+                        COPY_GM_TO_UB(draftLocal[draft_offset], tokenGm,
+                                    gm_row_offset + best_match_pos + best_ngram_len,
+                                    draft_load, int32_t);
+                    }
+                }
+            }
+
+            numValidLocal.SetValue(r, draft_load > 0 ? draft_load : 0);
+        }
+
+        // Discard any remaining preloaded tensor that was never consumed
+        if (preloaded_row >= 0) {
+            auto unused_token = tokenInQue.DeQue<int32_t>();
+            tokenInQue.FreeTensor(unused_token);
+        }
+
+        // Release metadata and enqueue outputs
         sampledInQue.FreeTensor(sampledLocal);
         numTokensInQue.FreeTensor(numTokensLocal);
         discardInQue.FreeTensor(discardLocal);
+        nextOutQue.EnQue(nextLocal);
+        draftOutQue.EnQue(draftLocal);
+        numValidOutQue.EnQue(numValidLocal);
 
-        // Step 6: Enqueue output data (sync point: mark vector compute done, allow MTE3 out)
-        nextOutQue.EnQue(nextTensor);
-        draftOutQue.EnQue(draftTensor);
-        numValidOutQue.EnQue(numValidTensor);
-
-        // Step 7: Dequeue output and copy to GM
+        // Stage 5: Write results back to GM
         CopyOutMetadata();
     }
 
 private:
+    // ------------------------------------------------------------------------
+    // Load metadata tensors from GM into UB input queues
+    // ------------------------------------------------------------------------
     __aicore__ inline void CopyInMetadata()
     {
-        uint32_t mnta = static_cast<uint32_t>(this->max_new_tokens_align);
+        uint32_t mnta_aligned = static_cast<uint32_t>(this->max_new_tokens_align);
 
-        // sampled: Bulk copy of my_rows lines (repeat mode)
+        // sampled tokens: [my_row_count, max_new_tokens] -> padded to mnta_aligned
         auto sampledTensor = sampledInQue.AllocTensor<int32_t>();
-        uint32_t srcRowBytes = static_cast<uint32_t>(this->max_new_tokens) * ELEM_SIZE;
+        uint32_t src_row_bytes = static_cast<uint32_t>(this->max_new_tokens) * ELEM_SIZE;
         AscendC::DataCopyExtParams sampledParams{
-            static_cast<uint16_t>(this->my_rows),  
-            srcRowBytes,                            
-            0,                                     
-            0,                                     
-            0};
+            static_cast<uint16_t>(this->my_row_count), src_row_bytes, 0, 0, 0};
         AscendC::DataCopyPadExtParams<int32_t> padParams{
-            true, 0, static_cast<uint8_t>(mnta - this->max_new_tokens), 0};
+            true, 0, static_cast<uint8_t>(mnta_aligned - this->max_new_tokens), 0};
         AscendC::DataCopyPad(
             sampledTensor,
-            sampledGm[static_cast<uint64_t>(this->row_offset) * this->max_new_tokens],
+            sampledGm[static_cast<uint64_t>(this->my_row_offset) * this->max_new_tokens],
             sampledParams, padParams);
         sampledInQue.EnQue(sampledTensor);
 
-        // numTokens / discard: 1D array copy (32-byte aligned)
+        // num_tokens and discard: 1D int32 arrays
         auto numTokensTensor = numTokensInQue.AllocTensor<int32_t>();
-        uint32_t metaBytes = static_cast<uint32_t>(this->my_rows) * ELEM_SIZE;
-        AscendC::DataCopyExtParams metaParams{1, metaBytes, 0, metaBytes, 0};
-        AscendC::DataCopyPadExtParams<int32_t> noPadT{false, 0, 0, 0};
-        AscendC::DataCopyPad(numTokensTensor, numTokensGm[this->row_offset], metaParams, noPadT);
+        uint32_t meta_bytes = static_cast<uint32_t>(this->my_row_count) * ELEM_SIZE;
+        AscendC::DataCopyExtParams metaParams{1, meta_bytes, 0, meta_bytes, 0};
+        AscendC::DataCopyPadExtParams<int32_t> no_pad{false, 0, 0, 0};
+        AscendC::DataCopyPad(numTokensTensor, numTokensGm[this->my_row_offset], metaParams, no_pad);
         numTokensInQue.EnQue(numTokensTensor);
 
         auto discardTensor = discardInQue.AllocTensor<int32_t>();
-        AscendC::DataCopyPad(discardTensor, discardGm[this->row_offset], metaParams, noPadT);
+        AscendC::DataCopyPad(discardTensor, discardGm[this->my_row_offset], metaParams, no_pad);
         discardInQue.EnQue(discardTensor);
     }
 
+    // ------------------------------------------------------------------------
+    // Write output metadata from UB queues back to GM
+    // ------------------------------------------------------------------------
     __aicore__ inline void CopyOutMetadata()
     {
-        // Dequeue output data (sync point: ensure vector computation completed)
-        auto nextLocal = nextOutQue.DeQue<int32_t>();
-        auto draftLocal = draftOutQue.DeQue<int32_t>();
+        auto nextLocal     = nextOutQue.DeQue<int32_t>();
+        auto draftLocal    = draftOutQue.DeQue<int32_t>();
         auto numValidLocal = numValidOutQue.DeQue<int32_t>();
 
-        // nextToken / numValid: 1D array write-back
-        uint16_t metaBytes16 = static_cast<uint16_t>(this->my_rows) * ELEM_SIZE;
-        AscendC::DataCopyParams nextParams{1, metaBytes16, 0, 0};
-        AscendC::DataCopyPad(nextTokensGm[this->row_offset], nextLocal, nextParams);
-        AscendC::DataCopyPad(numValidGm[this->row_offset], numValidLocal, nextParams);
+        uint16_t meta_bytes16 = static_cast<uint16_t>(this->my_row_count) * ELEM_SIZE;
+        AscendC::DataCopyParams nextParams{1, meta_bytes16, 0, 0};
+        AscendC::DataCopyPad(nextTokensGm[this->my_row_offset], nextLocal, nextParams);
+        AscendC::DataCopyPad(numValidGm[this->my_row_offset], numValidLocal, nextParams);
 
-        // draftTokens: 2D array write-back (repeat mode, handle UB k_align padding)
-        uint32_t kBytes = static_cast<uint32_t>(this->k_val) * ELEM_SIZE;
-        AscendC::DataCopyParams draftParams{
-            static_cast<uint16_t>(this->my_rows),  
-            static_cast<uint16_t>(kBytes),          
-            0,                                     
-            0};                                 
-        AscendC::DataCopyPad(
-            draftTokensGm[static_cast<uint64_t>(this->row_offset) * this->k_val],
-            draftLocal,
-            draftParams);
+        // Draft tokens: write k_val elements per row (each row has k_align stride in UB)
+        uint32_t k_aligned = static_cast<uint32_t>(this->k_align);
+        for (uint32_t r = 0; r < this->my_row_count; ++r) {
+            uint32_t k_bytes = static_cast<uint32_t>(this->k_val) * ELEM_SIZE;
+            AscendC::DataCopyExtParams rowParams{1, k_bytes, 0, 0, 0};
+            AscendC::DataCopyPad(
+                draftTokensGm[static_cast<uint64_t>(this->my_row_offset + r) * this->k_val],
+                draftLocal[r * k_aligned], rowParams);
+        }
 
         nextOutQue.FreeTensor(nextLocal);
         draftOutQue.FreeTensor(draftLocal);
         numValidOutQue.FreeTensor(numValidLocal);
     }
 
-    __aicore__ inline void ProcessOneRow(
+    // ------------------------------------------------------------------------
+    // Validate sampled tokens for one row.
+    // - If discard flag is set, invalidate all sampled tokens.
+    // - Clamp valid_count to available sequence space.
+    // - Write the "next" token (last valid sampled, or last context token).
+    // - Append valid sampled tokens back to the context token GM buffer.
+    // ------------------------------------------------------------------------
+    __aicore__ inline int32_t ValidateTokens(
         uint32_t local_idx, uint32_t global_row,
         AscendC::LocalTensor<int32_t>& sampledLocal,
         AscendC::LocalTensor<int32_t>& numTokensLocal,
         AscendC::LocalTensor<int32_t>& discardLocal,
-        AscendC::LocalTensor<int32_t>& nextTensor,
-        AscendC::LocalTensor<int32_t>& draftTensor,
-        AscendC::LocalTensor<int32_t>& numValidTensor)
+        AscendC::LocalTensor<int32_t>& nextLocal)
     {
-        uint32_t msl = static_cast<uint32_t>(this->max_seq_len);
-        uint32_t mnta = static_cast<uint32_t>(this->max_new_tokens_align);
-        uint32_t ka = static_cast<uint32_t>(this->k_align);
-        uint64_t gmRow = static_cast<uint64_t>(global_row) * msl;
+        uint32_t msl          = static_cast<uint32_t>(this->max_seq_len);
+        uint32_t mnta_aligned = static_cast<uint32_t>(this->max_new_tokens_align);
+        uint64_t gm_row       = static_cast<uint64_t>(global_row) * msl;
+        uint32_t sampled_off  = local_idx * mnta_aligned;
 
-        // Step 1: Load pre-fetched metadata
-        int32_t seq_len = numTokensLocal.GetValue(local_idx);
-        int32_t discard = discardLocal.GetValue(local_idx);
+        int32_t seq_len   = numTokensLocal.GetValue(local_idx);
+        int32_t discard   = discardLocal.GetValue(local_idx);
         int32_t valid_count = 0;
-        uint32_t sampled_offset = local_idx * mnta;
 
-        // Step 2: Process sampled tokens (validation & truncation)
         if (discard != 0) {
-            AscendC::Duplicate(sampledLocal[sampled_offset], -1, this->max_new_tokens_align);
+            AscendC::Duplicate(sampledLocal[sampled_off], -1, mnta_aligned);
         } else {
             for (int32_t j = 0; j < this->max_new_tokens; ++j) {
-                int32_t val = sampledLocal.GetValue(sampled_offset + j);
+                int32_t val = sampledLocal.GetValue(sampled_off + j);
                 if (val == -1 || val >= this->vocab_size_val) {
+                    // Invalidate remainder on first invalid token
                     for (int32_t k = j; k < this->max_new_tokens; ++k) {
-                        sampledLocal.SetValue(sampled_offset + k, -1);
+                        sampledLocal.SetValue(sampled_off + k, -1);
                     }
                     break;
                 }
@@ -298,213 +419,367 @@ private:
             }
         }
 
+        // Clamp valid count by remaining sequence capacity
         int32_t avail_space = this->max_seq_len - seq_len;
-        if (avail_space < 0) {
-            avail_space = 0;
-        }
-        if (valid_count > avail_space) {
-            valid_count = avail_space;
-        }
+        avail_space = (avail_space < 0) ? 0 : avail_space;
+        valid_count = (valid_count > avail_space) ? avail_space : valid_count;
+        int32_t total_len = seq_len + valid_count;
 
-        // Step 4: Append sampled tokens to history sequence (sampled -> tokenGm) — MTE3
-        int32_t nt = seq_len + valid_count;
+        // Determine next token for this position
         if (valid_count > 0) {
-            COPY_UB_TO_GM(tokenGm, sampledLocal[sampled_offset], gmRow + seq_len, valid_count, int32_t);
-            AscendC::TQueSync<PIPE_MTE3, PIPE_S> sync;
-            AscendC::TEventID eventID = GetTPipePtr()->AllocEventID<AscendC::HardEvent::MTE3_S>();
-            sync.SetFlag(eventID);
-            sync.WaitFlag(eventID);
-            GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::MTE3_S>(eventID);
+            int32_t last_sampled = sampledLocal.GetValue(
+                sampled_off + static_cast<uint32_t>(valid_count - 1));
+            nextLocal.SetValue(local_idx, last_sampled);
+        } else {
+            int32_t backtrack_pos = (total_len > 0) ? (total_len - 1) : 0;
+            nextLocal.SetValue(local_idx, tokenGm.GetValue(gm_row + backtrack_pos));
         }
 
-        // Leverage GetValue blocking semantics for implicit MTE3 -> MTE2 synchronization
-        // Read the last token of current sequence as nextToken
-        int32_t backup_pos = (nt > 0) ? (nt - 1) : 0;
-        int32_t backup_token = tokenGm.GetValue(gmRow + backup_pos);
-        nextTensor.SetValue(local_idx, backup_token);
-
-        // Step 5: N-gram vectorized recursive matching
-        int32_t best_match_pos = -1;
-        int32_t best_ngram_len = 0;
-
-        if (valid_count > 0 && nt >= this->min_n_val) {
-            int32_t suffix_gm_start = nt - this->max_n_val;
-            if (suffix_gm_start < 0) {
-                suffix_gm_start = 0;
-            }
-            int32_t suffix_load = this->max_n_val;
-            if (suffix_gm_start + suffix_load > nt) {
-                suffix_load = nt - suffix_gm_start;
-            }
-
-            // Synchronous suffix load
-            auto suffixTensor = suffixInQue.AllocTensor<int32_t>();
-            COPY_GM_TO_UB(suffixTensor, tokenGm, gmRow + suffix_gm_start, suffix_load, int32_t);
-            suffixInQue.EnQue(suffixTensor);
-            auto suffixLocal = suffixInQue.DeQue<int32_t>();
-
-            auto ngramResult = ngramCalcBuf.Get<int32_t>();
-            auto ngramTemp = ngramTempBuf.Get<int32_t>();
-            auto ngramTempF = ngramTempBuf.Get<float>();
-            auto ngramGather = ngramGatherBuf.Get<int32_t>();
-            auto ngramReduce = ngramReduceBuf.Get<float>();
-
-            uint32_t max_gather_len = this->is_large_row
-                                    ? (SAFE_CHUNK + static_cast<uint32_t>(this->max_n_val))
-                                    : static_cast<uint32_t>(this->max_seq_len);
-            if (this->max_n_val > 1) {
-                AscendC::Arange<int32_t>(
-                    ngramGather,
-                    static_cast<int32_t>(sizeof(int32_t)),
-                    static_cast<int32_t>(sizeof(int32_t)),
-                    static_cast<int32_t>(max_gather_len));
-            }
-
-            bool found_global_max = false;
-
-            for (int32_t chunk_start = 0;
-                 chunk_start < nt - this->min_n_val && !found_global_max;
-                 chunk_start += SAFE_CHUNK)
-            {
-                int32_t chunk_count = (chunk_start + SAFE_CHUNK <= nt - this->min_n_val)
-                                      ? SAFE_CHUNK
-                                      : (nt - this->min_n_val - chunk_start);
-                if (chunk_count <= 0) {
-                    break;
-                }
-
-                int32_t load_count = chunk_count + this->max_n_val;
-                if (chunk_start + load_count > nt) {
-                    load_count = nt - chunk_start;
-                }
-                if (load_count <= 0) {
-                    continue;
-                }
-
-                // Synchronous chunk load
-                auto chunkTensor = tokenInQue.AllocTensor<int32_t>();
-                COPY_GM_TO_UB(chunkTensor, tokenGm, gmRow + chunk_start, load_count, int32_t);
-                tokenInQue.EnQue(chunkTensor);
-                auto tokenLocal = tokenInQue.DeQue<int32_t>();
-
-                for (int32_t n = 1; n <= this->max_n_val; ++n) {
-                    int32_t valid_len = load_count - n;
-                    if (valid_len <= 0) {
-                        break;
-                    }
-
-                    if (n > 1) {
-                        AscendC::Gather<int32_t>(
-                            ngramTemp, ngramResult,
-                            ngramGather.ReinterpretCast<uint32_t>(), 0, valid_len);
-                    }
-
-                    int32_t s_val = suffixLocal.GetValue(static_cast<uint32_t>(suffix_load - n));
-                    AscendC::Adds<int32_t>(ngramResult, tokenLocal, -s_val, valid_len);
-
-                    if (n > 1) {
-                        AscendC::Or<uint16_t>(
-                            ngramResult.ReinterpretCast<uint16_t>(),
-                            ngramResult.ReinterpretCast<uint16_t>(),
-                            ngramTemp.ReinterpretCast<uint16_t>(),
-                            valid_len * 2);
-                    }
-
-                    if (n >= this->min_n_val) {
-                        int32_t check_count = (chunk_start + chunk_count <= nt - n)
-                                            ? chunk_count
-                                            : (nt - n - chunk_start);
-                        if (check_count > 0) {
-                            AscendC::Cast<float, int32_t>(
-                                ngramTempF, ngramResult,
-                                AscendC::RoundMode::CAST_CEIL, check_count);
-                            AscendC::Abs<float>(ngramTempF, ngramTempF, check_count);
-                            AscendC::ReduceMin<float>(
-                                ngramReduce, ngramTempF, ngramReduce, check_count, true);
-
-                            float min_val_f = ngramReduce.GetValue(0);
-                            if (min_val_f == 0.0f) {
-                                if (n > best_ngram_len) {
-                                    float min_idx_f = ngramReduce.GetValue(1);
-                                    uint32_t pos = *reinterpret_cast<uint32_t*>(&min_idx_f);
-                                    best_match_pos = chunk_start + static_cast<int32_t>(pos);
-                                    best_ngram_len = n;
-
-                                    if (n == this->max_n_val) {
-                                        found_global_max = true;
-                                        break;
-                                    }
-                                }
-                            } else {
-                                // Current chunk failed for this n; larger n impossible
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                tokenInQue.FreeTensor(tokenLocal);
-            }
-
-            suffixInQue.FreeTensor(suffixLocal);
+        // Append valid sampled tokens to context GM
+        if (valid_count > 0) {
+            COPY_UB_TO_GM(tokenGm, gm_row + seq_len,
+                        sampledLocal, sampled_off, valid_count, int32_t);
         }
-
-        // Step 6: Draft generation (write directly to VECOUT tensor)
-        uint32_t draft_offset = local_idx * ka;
-        int32_t valid_draft_count = 0;
-        AscendC::Duplicate(draftTensor[draft_offset], -1, this->k_align);
-
-        if (best_match_pos >= 0) {
-            int32_t draft_start = best_match_pos + best_ngram_len;
-            int32_t tokens_available = nt - draft_start;
-            valid_draft_count = (tokens_available < this->k_val) ? tokens_available : this->k_val;
-            if (valid_draft_count > 0) {
-                COPY_GM_TO_UB(
-                    draftTensor[draft_offset], tokenGm, gmRow + draft_start, valid_draft_count, int32_t);
-            }
-        }
-
-        numValidTensor.SetValue(local_idx, valid_draft_count >= 0 ? valid_draft_count : 0);
+        return valid_count;
     }
 
+    // ------------------------------------------------------------------------
+    // Load one full row of context tokens from GM to UB (short sequences).
+    // ------------------------------------------------------------------------
+    __aicore__ inline AscendC::LocalTensor<int32_t> LoadOneRowToken(
+        uint32_t global_row, int32_t count)
+    {
+        auto tensor = tokenInQue.AllocTensor<int32_t>();
+        uint64_t gm_row = static_cast<uint64_t>(global_row) * static_cast<uint32_t>(this->max_seq_len);
+        COPY_GM_TO_UB(tensor, tokenGm, gm_row, count, int32_t);
+        tokenInQue.EnQue(tensor);
+        return tokenInQue.DeQue<int32_t>();
+    }
+
+    // ------------------------------------------------------------------------
+    // Preload an entire short row into tokenInQue for double buffering.
+    // ------------------------------------------------------------------------
+    __aicore__ inline void LaunchPreloadNextRow(uint32_t global_row, int32_t count)
+    {
+        auto tensor = tokenInQue.AllocTensor<int32_t>();
+        uint64_t gm_row = static_cast<uint64_t>(global_row) * static_cast<uint32_t>(this->max_seq_len);
+        COPY_GM_TO_UB(tensor, tokenGm, gm_row, count, int32_t);
+        tokenInQue.EnQue(tensor);
+    }
+
+    // ------------------------------------------------------------------------
+    // Preload only the first chunk of a long row (SAFE_CHUNK + max_n_val).
+    // ------------------------------------------------------------------------
+    __aicore__ inline void LaunchPreloadNextLongFirstChunk(uint32_t global_row, int32_t total_len)
+    {
+        int32_t load_count = SAFE_CHUNK + this->max_n_val;
+        if (load_count > total_len) load_count = total_len;
+
+        auto tensor = tokenInQue.AllocTensor<int32_t>();
+        uint64_t gm_row = static_cast<uint64_t>(global_row) * static_cast<uint32_t>(this->max_seq_len);
+        COPY_GM_TO_UB(tensor, tokenGm, gm_row, load_count, int32_t);
+        tokenInQue.EnQue(tensor);
+    }
+
+    // ------------------------------------------------------------------------
+    // Short-sequence n-gram match (entire row fits in UB).
+    // Uses vectorized recurrence: diff_n = diff_{n-1} | (token - suffix[n]).
+    // ------------------------------------------------------------------------
+    __aicore__ inline void NgramMatchRowShort(
+        int32_t total_len,
+        AscendC::LocalTensor<int32_t>& tokenLocal,
+        int32_t& best_match_pos,
+        int32_t& best_ngram_len)
+    {
+        best_match_pos = -1;
+        best_ngram_len = 0;
+
+        auto ngramResult = ngramCalcBuf.Get<int32_t>();
+        auto ngramTemp   = ngramTempBuf.Get<int32_t>();
+        auto ngramTempF  = ngramTempBuf.Get<float>();
+        auto ngramGather = ngramGatherBuf.Get<uint32_t>();
+        auto ngramReduce = ngramReduceBuf.Get<float>();
+
+        for (int32_t n = 1; n <= this->max_n_val; ++n) {
+            int32_t valid_len = total_len - n;
+            if (valid_len <= 0) break;
+
+            // Recurrence: shift previous comparison result by one position
+            if (n > 1) {
+                AscendC::Gather<int32_t>(ngramTemp, ngramResult, ngramGather, 0, valid_len);
+            }
+
+            // Compare all positions against the n-th suffix token
+            AscendC::Adds<int32_t>(ngramResult, tokenLocal,
+                                -tokenLocal.GetValue(static_cast<uint32_t>(total_len - n)),
+                                valid_len);
+
+            // Merge with previous length-(n-1) match mask
+            if (n > 1) {
+                AscendC::Or<uint16_t>(ngramResult.ReinterpretCast<uint16_t>(),
+                                    ngramResult.ReinterpretCast<uint16_t>(),
+                                    ngramTemp.ReinterpretCast<uint16_t>(),
+                                      static_cast<uint32_t>(valid_len * 2));
+            }
+
+            if (n < this->min_n_val) continue;
+
+            // Reduce: find if any position has exact match (min abs diff == 0)
+            AscendC::Cast<float, int32_t>(ngramTempF, ngramResult,
+                                        AscendC::RoundMode::CAST_CEIL, valid_len);
+            AscendC::Abs<float>(ngramTempF, ngramTempF, valid_len);
+            AscendC::ReduceMin<float>(ngramReduce, ngramTempF, ngramReduce,
+                                    static_cast<uint32_t>(valid_len), true);
+
+            float min_val_f = ngramReduce.GetValue(0);
+            if (min_val_f == 0.0f) {
+                float min_idx_f = ngramReduce.GetValue(1);
+                best_match_pos = static_cast<int32_t>(
+                    *reinterpret_cast<uint32_t*>(&min_idx_f));
+                best_ngram_len = n;
+            } else {
+                break;  // No match for length n; longer n-grams impossible
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // Long-sequence n-gram match (chunked with double-buffered token loading).
+    //
+    // Algorithm:
+    //   1. Load suffix (last max_n_val tokens) as query anchor.
+    //   2. Iterate over the row in SAFE_CHUNK chunks.
+    //   3. For each chunk, evaluate n = 1 .. max_n_val via vectorized recurrence.
+    //   4. Overlap computation with preloading of next chunk or next row.
+    // ------------------------------------------------------------------------
+    __aicore__ inline void NgramMatchRowLong(
+        uint32_t global_row,
+        int32_t total_len,
+        bool first_chunk_preloaded,
+        int32_t next_global_row,
+        int32_t next_total_len,
+        int32_t next_valid_count,
+        int32_t& preloaded_row_out,
+        int32_t& best_match_pos,
+        int32_t& best_ngram_len)
+    {
+        best_match_pos   = -1;
+        best_ngram_len   = 0;
+        preloaded_row_out = -1;
+
+        // Load suffix: the trailing max_n_val tokens of the sequence
+        int32_t suffix_gm_start = total_len - this->max_n_val;
+        if (suffix_gm_start < 0) suffix_gm_start = 0;
+        int32_t suffix_load = this->max_n_val;
+        if (suffix_gm_start + suffix_load > total_len) {
+            suffix_load = total_len - suffix_gm_start;
+        }
+
+        uint64_t gm_row_offset = static_cast<uint64_t>(global_row)
+                                 * static_cast<uint32_t>(this->max_seq_len);
+        auto suffixTensor = suffixInQue.AllocTensor<int32_t>();
+        COPY_GM_TO_UB(suffixTensor, tokenGm, gm_row_offset + suffix_gm_start,
+                    suffix_load, int32_t);
+        suffixInQue.EnQue(suffixTensor);
+        auto suffixLocal = suffixInQue.DeQue<int32_t>();
+
+        // Vector calculation buffers
+        auto ngramResult = ngramCalcBuf.Get<int32_t>();
+        auto ngramTemp   = ngramTempBuf.Get<int32_t>();
+        auto ngramTempF  = ngramTempBuf.Get<float>();
+        auto ngramGather = ngramGatherBuf.Get<uint32_t>();
+        auto ngramReduce = ngramReduceBuf.Get<float>();
+
+        // Determine if next row is eligible for preloading
+        bool has_next_row  = (next_total_len >= this->min_n_val) && (next_valid_count > 0);
+        bool next_is_short = (next_total_len > 0 && next_total_len <= static_cast<int32_t>(SAFE_CHUNK));
+        bool found_global_max = false;
+        int32_t search_limit = total_len - this->min_n_val;  // Last valid n-gram start index
+
+        // Initialize first chunk
+        AscendC::LocalTensor<int32_t> tokenLocal;
+        int32_t chunk_start  = 0;
+        int32_t chunk_count  = (SAFE_CHUNK <= search_limit) ? SAFE_CHUNK : search_limit;
+        int32_t load_count   = chunk_count + this->max_n_val;
+        if (chunk_start + load_count > total_len) {
+            load_count = total_len - chunk_start;
+        }
+
+        if (first_chunk_preloaded) {
+            tokenLocal = tokenInQue.DeQue<int32_t>();
+        } else {
+            auto t0 = tokenInQue.AllocTensor<int32_t>();
+            COPY_GM_TO_UB(t0, tokenGm, gm_row_offset + chunk_start, load_count, int32_t);
+            tokenInQue.EnQue(t0);
+            tokenLocal = tokenInQue.DeQue<int32_t>();
+        }
+
+        bool has_preloaded    = false;   // Next chunk tensor is waiting in tokenInQue
+        bool preloaded_next_row = false; // The waiting tensor belongs to the next row
+
+        // Chunked matching loop
+        while (!found_global_max) {
+            int32_t next_chunk_start = chunk_start + SAFE_CHUNK;
+            bool has_next_chunk = (next_chunk_start < search_limit);
+
+            // Preload priority: next chunk of current row > next row's first chunk
+            if (has_next_chunk) {
+                int32_t next_chunk_count = (next_chunk_start + SAFE_CHUNK <= search_limit)
+                                        ? SAFE_CHUNK
+                                        : (search_limit - next_chunk_start);
+                int32_t next_load_count = next_chunk_count + this->max_n_val;
+                if (next_chunk_start + next_load_count > total_len) {
+                    next_load_count = total_len - next_chunk_start;
+                }
+                auto tn = tokenInQue.AllocTensor<int32_t>();
+                COPY_GM_TO_UB(tn, tokenGm, gm_row_offset + next_chunk_start,
+                            next_load_count, int32_t);
+                tokenInQue.EnQue(tn);
+                has_preloaded = true;
+            } else if (has_next_row) {
+                uint32_t next_gr = static_cast<uint32_t>(next_global_row);
+                if (next_is_short) {
+                    LaunchPreloadNextRow(next_gr, next_total_len);
+                } else {
+                    LaunchPreloadNextLongFirstChunk(next_gr, next_total_len);
+                }
+                preloaded_next_row = true;
+                preloaded_row_out  = 1;  // Signal caller that next row is ready
+            }
+
+            // Evaluate n-gram lengths 1..max_n_val on current chunk
+            for (int32_t n = 1; n <= this->max_n_val; ++n) {
+                int32_t valid_len = load_count - n;
+                if (valid_len <= 0) break;
+
+                // Recurrence: shift previous comparison result
+                if (n > 1) {
+                    AscendC::Gather<int32_t>(ngramTemp, ngramResult,
+                                            ngramGather, 0, valid_len);
+                }
+
+                // Vectorized subtraction against n-th suffix token
+                int32_t suffix_idx = suffix_load - n;
+                AscendC::Adds<int32_t>(ngramResult, tokenLocal,
+                                    -suffixLocal.GetValue(static_cast<uint32_t>(suffix_idx)),
+                                    valid_len);
+
+                // Merge match masks across n-gram lengths
+                if (n > 1) {
+                    AscendC::Or<uint16_t>(ngramResult.ReinterpretCast<uint16_t>(),
+                                        ngramResult.ReinterpretCast<uint16_t>(),
+                                        ngramTemp.ReinterpretCast<uint16_t>(),
+                                          static_cast<uint32_t>(valid_len * 2));
+                }
+
+                if (n < this->min_n_val) continue;
+
+                // Clamp evaluation to actual chunk boundary (exclude overflow tail)
+                int32_t eval_count = (chunk_start + chunk_count <= total_len - n)
+                                    ? chunk_count
+                                    : (total_len - n - chunk_start);
+                if (eval_count <= 0) break;
+
+                // Reduce to check for exact match in this chunk
+                AscendC::Cast<float, int32_t>(ngramTempF, ngramResult,
+                                            AscendC::RoundMode::CAST_CEIL, eval_count);
+                AscendC::Abs<float>(ngramTempF, ngramTempF, eval_count);
+                AscendC::ReduceMin<float>(ngramReduce, ngramTempF, ngramReduce,
+                                        static_cast<uint32_t>(eval_count), true);
+
+                float min_val_f = ngramReduce.GetValue(0);
+                if (min_val_f == 0.0f) {
+                    if (n > best_ngram_len) {
+                        float min_idx_f = ngramReduce.GetValue(1);
+                        uint32_t pos_u  = *reinterpret_cast<uint32_t*>(&min_idx_f);
+                        best_match_pos  = chunk_start + static_cast<int32_t>(pos_u);
+                        best_ngram_len  = n;
+                        if (n == this->max_n_val) {
+                            found_global_max = true;
+                            break;
+                        }
+                    }
+                } else {
+                    break;  // No match for this n; longer n-grams cannot match
+                }
+            }
+
+            if (found_global_max || !has_next_chunk) break;
+
+            // Advance to next chunk, consuming the preloaded tensor
+            tokenInQue.FreeTensor(tokenLocal);
+            tokenLocal   = tokenInQue.DeQue<int32_t>();
+            has_preloaded = false;
+
+            chunk_start = next_chunk_start;
+            chunk_count = (chunk_start + SAFE_CHUNK <= search_limit)
+                        ? SAFE_CHUNK
+                        : (search_limit - chunk_start);
+            load_count  = chunk_count + this->max_n_val;
+            if (chunk_start + load_count > total_len) {
+                load_count = total_len - chunk_start;
+            }
+        }
+
+        // Clean up unconsumed preloaded chunk (if it was a chunk, not next row)
+        if (has_preloaded && !preloaded_next_row) {
+            auto extra = tokenInQue.DeQue<int32_t>();
+            tokenInQue.FreeTensor(extra);
+        }
+
+        tokenInQue.FreeTensor(tokenLocal);
+        suffixInQue.FreeTensor(suffixLocal);
+    }
+
+    // ------------------------------------------------------------------------
+    // Compute scratch-space size for AscendC::ReduceMin (multi-iteration).
+    // ------------------------------------------------------------------------
     __aicore__ inline uint32_t CalcReduceMinTmpSize(uint32_t count, uint32_t typeSize)
     {
-        uint32_t elementsPerBlock = 32 / typeSize;
+        uint32_t elementsPerBlock  = 32 / typeSize;
         uint32_t elementsPerRepeat = 256 / typeSize;
+
         auto RoundUp = [](uint32_t x, uint32_t unit) -> uint32_t {
             return (x + unit - 1) / unit;
         };
-        uint32_t firstMaxRepeat = RoundUp(count, elementsPerRepeat);
+
+        uint32_t firstMaxRepeat   = RoundUp(count, elementsPerRepeat);
         uint32_t iter1OutputCount = firstMaxRepeat * 2;
-        uint32_t iter2AlignStart = RoundUp(iter1OutputCount, elementsPerBlock) * elementsPerBlock;
+        uint32_t iter2AlignStart  = RoundUp(iter1OutputCount, elementsPerBlock) * elementsPerBlock;
         uint32_t iter2OutputCount = RoundUp(iter1OutputCount, elementsPerRepeat) * 2;
-        uint32_t iter3AlignStart = RoundUp(iter2OutputCount, elementsPerBlock) * elementsPerBlock;
+        uint32_t iter3AlignStart  = RoundUp(iter2OutputCount, elementsPerBlock) * elementsPerBlock;
         uint32_t iter3OutputCount = RoundUp(iter2OutputCount, elementsPerRepeat) * 2;
-        uint32_t iter3AlignEnd = RoundUp(iter3OutputCount, elementsPerBlock) * elementsPerBlock;
+        uint32_t iter3AlignEnd    = RoundUp(iter3OutputCount, elementsPerBlock) * elementsPerBlock;
+
         return iter2AlignStart + iter3AlignStart + iter3AlignEnd;
     }
 
 private:
+    // ------------------------------------------------------------------------
+    // TPipe and TQue/TBuf declarations
+    // ------------------------------------------------------------------------
     AscendC::TPipe pipe;
 
-    // Input queues (VECIN): EnQue after MTE2 in, DeQue guarantees transfer completion
-    AscendC::TQue<AscendC::TPosition::VECIN, 1> tokenInQue;
+    // Input queues
+    AscendC::TQue<AscendC::TPosition::VECIN, 2> tokenInQue;
     AscendC::TQue<AscendC::TPosition::VECIN, 1> sampledInQue;
     AscendC::TQue<AscendC::TPosition::VECIN, 1> numTokensInQue;
     AscendC::TQue<AscendC::TPosition::VECIN, 1> discardInQue;
     AscendC::TQue<AscendC::TPosition::VECIN, 1> suffixInQue;
 
-    // Output queues (VECOUT): EnQue after compute, DeQue guarantees MTE3 out sync
+    // Output queues
     AscendC::TQue<AscendC::TPosition::VECOUT, 1> nextOutQue;
     AscendC::TQue<AscendC::TPosition::VECOUT, 1> draftOutQue;
     AscendC::TQue<AscendC::TPosition::VECOUT, 1> numValidOutQue;
 
-    // Pure UB computation buffers (no GM traffic, kept as TBuf)
+    // Calculation buffers
     AscendC::TBuf<AscendC::TPosition::VECCALC> ngramCalcBuf;
     AscendC::TBuf<AscendC::TPosition::VECCALC> ngramTempBuf;
     AscendC::TBuf<AscendC::TPosition::VECCALC> ngramGatherBuf;
     AscendC::TBuf<AscendC::TPosition::VECCALC> ngramReduceBuf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> validCountBuf;
 
+    // GM tensors
     AscendC::GlobalTensor<int32_t> tokenGm;
     AscendC::GlobalTensor<int32_t> numTokensGm;
     AscendC::GlobalTensor<int32_t> sampledGm;
@@ -513,6 +788,7 @@ private:
     AscendC::GlobalTensor<int32_t> draftTokensGm;
     AscendC::GlobalTensor<int32_t> numValidGm;
 
+    // Tiling scalars
     int32_t batch_size;
     int32_t max_seq_len;
     int32_t max_seq_len_align;
@@ -525,9 +801,8 @@ private:
     int32_t max_n_val;
     int32_t former_num;
     int32_t rows_per_core;
-    uint32_t my_rows;
-    uint32_t row_offset;
-    bool is_large_row;
+    uint32_t my_row_count;
+    uint32_t my_row_offset;
 };
 
 extern "C" __global__ __aicore__ void ngram_spec_decode(

--- a/csrc/attention/ngram_spec_decode/op_kernel/ngram_spec_decode.cpp
+++ b/csrc/attention/ngram_spec_decode/op_kernel/ngram_spec_decode.cpp
@@ -74,9 +74,7 @@ public:
         this->k_val = static_cast<int32_t>(tilingData.ngramInfo.k);
         this->former_num = static_cast<int32_t>(tilingData.ngramInfo.formerNum);
         this->rows_per_core = static_cast<int32_t>(tilingData.ngramInfo.rowsPerCore);
-        this->tail_rows = static_cast<int32_t>(tilingData.ngramInfo.tailRows);
-        this->block_rows = static_cast<int32_t>(tilingData.ngramInfo.blockRows);
-
+        
         // Align dimensions to 32-byte boundaries (8 elements for int32)
         int32_t align_elems = 32 / ELEM_SIZE;
         this->max_seq_len_align = ((this->max_seq_len + align_elems - 1) / align_elems) * align_elems;
@@ -527,8 +525,6 @@ private:
     int32_t max_n_val;
     int32_t former_num;
     int32_t rows_per_core;
-    int32_t tail_rows;
-    int32_t block_rows;
     uint32_t my_rows;
     uint32_t row_offset;
     bool is_large_row;

--- a/csrc/attention/ngram_spec_decode/op_kernel/ngram_spec_decode.cpp
+++ b/csrc/attention/ngram_spec_decode/op_kernel/ngram_spec_decode.cpp
@@ -11,17 +11,15 @@
 #include "kernel_operator.h"
 #include "ngram_spec_decode.h"
 
-const uint32_t ELEM_SIZE = 4;  // int32
+constexpr uint32_t ELEM_SIZE = 4;  // int32
+constexpr uint32_t ALIGN_BYTES = 32u;
+constexpr uint32_t ALIGN_ELEMS = ALIGN_BYTES / ELEM_SIZE;
 constexpr uint32_t SAFE_CHUNK = 8192u;
 
-// ----------------------------------------------------------------------------
-// GM -> UB copy macro with automatic alignment padding.
-// Handles unaligned GM addresses via DataCopyPad.
-// ----------------------------------------------------------------------------
 #define COPY_GM_TO_UB(dst, src, src_offset, count, T)                          \
     do {                                                                      \
         if ((count) > 0) {                                                    \
-            constexpr uint32_t __align_elem = 8u;                             \
+            constexpr uint32_t __align_elem = ALIGN_ELEMS;                    \
             uint32_t __c = static_cast<uint32_t>(count);                    \
             uint32_t __aligned = ((__c + __align_elem - 1u) / __align_elem) \
                                  * __align_elem;                              \
@@ -35,10 +33,6 @@ constexpr uint32_t SAFE_CHUNK = 8192u;
         }                                                                     \
     } while (0)
 
-// ----------------------------------------------------------------------------
-// UB -> GM copy macro with chunking for large transfers.
-// Ascend UB store has a single-transfer limit (16383 elements).
-// ----------------------------------------------------------------------------
 #define COPY_UB_TO_GM(dst, dst_offset, src, src_offset, count, T)           \
     do {                                                                      \
         if ((count) > 0) {                                                    \
@@ -69,9 +63,6 @@ public:
         REGISTER_TILING_DEFAULT(NgramSpecDecodeTilingData);
         GET_TILING_DATA_WITH_STRUCT(NgramSpecDecodeTilingData, tilingData, tiling);
 
-        // --------------------------------------------------------------------
-        // Extract tiling parameters
-        // --------------------------------------------------------------------
         this->batch_size      = tilingData.ngramInfo.batchSize;
         this->max_seq_len     = tilingData.ngramInfo.maxSeqLen;
         this->max_new_tokens  = tilingData.ngramInfo.maxNewTokens;
@@ -82,17 +73,11 @@ public:
         this->former_num      = tilingData.ngramInfo.formerNum;
         this->rows_per_core   = tilingData.ngramInfo.rowsPerCore;
 
-        // --------------------------------------------------------------------
-        // Compute alignment paddings (32-byte aligned for vector engine)
-        // --------------------------------------------------------------------
-        int32_t align_elems = 32 / ELEM_SIZE;
+        constexpr int32_t align_elems = static_cast<int32_t>(ALIGN_ELEMS);
         this->max_seq_len_align    = ((this->max_seq_len    + align_elems - 1) / align_elems) * align_elems;
         this->max_new_tokens_align = ((this->max_new_tokens + align_elems - 1) / align_elems) * align_elems;
         this->k_align              = ((this->k_val          + align_elems - 1) / align_elems) * align_elems;
 
-        // --------------------------------------------------------------------
-        // Compute row distribution for this AI Core
-        // --------------------------------------------------------------------
         uint32_t blockIdx = AscendC::GetBlockIdx();
         if (blockIdx < static_cast<uint32_t>(this->former_num)) {
             this->my_row_count = static_cast<uint32_t>(this->rows_per_core) + 1;
@@ -104,9 +89,6 @@ public:
                             + this->my_row_count * (blockIdx - static_cast<uint32_t>(this->former_num));
         }
 
-        // --------------------------------------------------------------------
-        // Bind GM buffers
-        // --------------------------------------------------------------------
         tokenGm.SetGlobalBuffer((__gm__ int32_t *)token_ids_gm,
                                 static_cast<uint64_t>(this->batch_size) * this->max_seq_len);
         numTokensGm.SetGlobalBuffer((__gm__ int32_t *)num_tokens_gm,
@@ -122,72 +104,56 @@ public:
         numValidGm.SetGlobalBuffer((__gm__ int32_t *)num_valid_gm,
                                 static_cast<uint64_t>(this->batch_size));
 
-        // --------------------------------------------------------------------
-        // Compute UB buffer sizes
-        // --------------------------------------------------------------------
         uint32_t mnta_aligned = static_cast<uint32_t>(this->max_new_tokens_align);
         uint32_t k_aligned    = static_cast<uint32_t>(this->k_align);
-        uint32_t my_rows_aligned = ((this->my_row_count + 7u) / 8u) * 8u;
+        uint32_t my_rows_aligned = AlignUp(this->my_row_count, ALIGN_ELEMS);
 
         uint32_t chunk_ub       = SAFE_CHUNK + static_cast<uint32_t>(this->max_n_val);
-        uint32_t chunk_ub_align = ((chunk_ub + 7u) / 8u) * 8u;
+        uint32_t chunk_ub_align = AlignUp(chunk_ub, ALIGN_ELEMS);
         uint32_t token_buf_size = chunk_ub_align * ELEM_SIZE;
 
-        // --------------------------------------------------------------------
-        // Initialize TQue / TBuf pipelines
-        // --------------------------------------------------------------------
-        // Input queues
-        pipe.InitBuffer(tokenInQue,    2, token_buf_size);          // Double-buffered tokens
+        pipe.InitBuffer(tokenInQue,    2, token_buf_size);
         pipe.InitBuffer(sampledInQue,  1, this->my_row_count * mnta_aligned * ELEM_SIZE);
         pipe.InitBuffer(numTokensInQue,1, my_rows_aligned * ELEM_SIZE);
         pipe.InitBuffer(discardInQue,  1, my_rows_aligned * ELEM_SIZE);
         pipe.InitBuffer(suffixInQue,   1, static_cast<uint32_t>(this->max_n_val) * ELEM_SIZE);
-
-        // Output queues
         pipe.InitBuffer(nextOutQue,    1, my_rows_aligned * ELEM_SIZE);
         pipe.InitBuffer(draftOutQue,   1, this->my_row_count * k_aligned * ELEM_SIZE);
         pipe.InitBuffer(numValidOutQue,1, my_rows_aligned * ELEM_SIZE);
-
-        // Calculation buffers
         pipe.InitBuffer(validCountBuf,  my_rows_aligned * ELEM_SIZE);
         pipe.InitBuffer(ngramCalcBuf,   token_buf_size);
         pipe.InitBuffer(ngramTempBuf,   token_buf_size);
         pipe.InitBuffer(ngramGatherBuf, token_buf_size);
 
-        // ReduceMin requires extra scratch space for multi-iteration reduction
         uint32_t reduce_count    = SAFE_CHUNK;
         uint32_t reduce_tmp_elems = CalcReduceMinTmpSize(reduce_count, ELEM_SIZE);
-        uint32_t reduce_tmp_bytes = ((reduce_tmp_elems * ELEM_SIZE + 31) / 32) * 32;
+        uint32_t reduce_tmp_bytes = AlignUp(reduce_tmp_elems * ELEM_SIZE, ALIGN_BYTES);
         pipe.InitBuffer(ngramReduceBuf, reduce_tmp_bytes);
 
     }
 
-    // ------------------------------------------------------------------------
-    // Main processing pipeline
-    // ------------------------------------------------------------------------
     __aicore__ inline void Process()
     {
-        // Initialize gather indices for n-gram recurrence (byte offsets)
         auto gatherLocal = ngramGatherBuf.Get<int32_t>();
-        const uint32_t gather_size = (((SAFE_CHUNK + static_cast<uint32_t>(this->max_n_val)) + 7u) / 8u) * 8u;
+        const uint32_t gather_size = AlignUp(
+            SAFE_CHUNK + static_cast<uint32_t>(this->max_n_val), ALIGN_ELEMS);
         AscendC::Arange<int32_t>(gatherLocal,
                                 static_cast<int32_t>(sizeof(int32_t)),
                                 static_cast<int32_t>(sizeof(int32_t)),
                                 gather_size);
 
-        // Stage 1: Load per-row metadata from GM to UB
+        //Load per-row metadata from GM to UB
         CopyInMetadata();
 
         auto sampledLocal   = sampledInQue.DeQue<int32_t>();
         auto numTokensLocal = numTokensInQue.DeQue<int32_t>();
         auto discardLocal   = discardInQue.DeQue<int32_t>();
-
         auto nextLocal     = nextOutQue.AllocTensor<int32_t>();
         auto draftLocal    = draftOutQue.AllocTensor<int32_t>();
         auto numValidLocal = numValidOutQue.AllocTensor<int32_t>();
         auto validCountLocal = validCountBuf.Get<int32_t>();
 
-        // Stage 2: Validate sampled tokens and clamp valid counts by avail space
+        //Validate sampled tokens and clamp valid counts by avail space
         for (uint32_t r = 0; r < this->my_row_count; ++r) {
             int32_t valid_count = ValidateTokens(r, this->my_row_offset + r,
                                                 sampledLocal, numTokensLocal,
@@ -195,14 +161,13 @@ public:
             validCountLocal.SetValue(r, valid_count);
         }
 
-        // Stage 3: Synchronize MTE3 (store) and MTE2 (load)
         AscendC::TQueSync<PIPE_MTE3, PIPE_MTE2> sync_a;
         auto event = GetTPipePtr()->AllocEventID<AscendC::HardEvent::MTE3_MTE2>();
         sync_a.SetFlag(event);
         sync_a.WaitFlag(event);
         GetTPipePtr()->ReleaseEventID<AscendC::HardEvent::MTE3_MTE2>(event);
 
-        // Stage 4: N-gram matching per row with double-buffered token loading
+        //N-gram matching per row with double-buffered token loading
         int32_t preloaded_row = -1;  // Row index preloaded into tokenInQue's second slot
         for (uint32_t r = 0; r < this->my_row_count; ++r) {
             uint32_t global_row = this->my_row_offset + r;
@@ -233,7 +198,6 @@ public:
 
             bool this_row_preloaded = (preloaded_row == static_cast<int32_t>(r));
             preloaded_row = -1;
-
             int32_t best_match_pos  = -1;
             int32_t best_ngram_len  = 0;
             int32_t draft_load      = 0;
@@ -248,13 +212,9 @@ public:
                 }
 
                 // Preload next row into the second buffer slot
-                if (r + 1 < this->my_row_count && next_valid_count > 0 && next_total_len >= this->min_n_val) {
+                if (r + 1 < this->my_row_count && CanPreloadRow(next_valid_count, next_total_len)) {
                     uint32_t next_global_row = this->my_row_offset + r + 1;
-                    if (next_total_len <= static_cast<int32_t>(SAFE_CHUNK)) {
-                        LaunchPreloadNextRow(next_global_row, next_total_len);
-                    } else {
-                        LaunchPreloadNextLongFirstChunk(next_global_row, next_total_len);
-                    }
+                    LaunchPreloadRowFirstBlock(next_global_row, next_total_len);
                     preloaded_row = static_cast<int32_t>(r + 1);
                 }
 
@@ -275,11 +235,11 @@ public:
                 int32_t next_global_row = (r + 1 < this->my_row_count)
                                         ? static_cast<int32_t>(this->my_row_offset + r + 1)
                                         : -1;
-                int32_t preloaded_out = -1;
+                bool preloaded_next_row = false;
                 NgramMatchRowLong(global_row, total_len, this_row_preloaded,
                                 next_global_row, next_total_len, next_valid_count,
-                                preloaded_out, best_match_pos, best_ngram_len);
-                if (preloaded_out >= 0) {
+                                preloaded_next_row, best_match_pos, best_ngram_len);
+                if (preloaded_next_row) {
                     preloaded_row = static_cast<int32_t>(r + 1);
                 }
 
@@ -287,8 +247,7 @@ public:
                     int32_t avail = total_len - (best_match_pos + best_ngram_len);
                     draft_load = (avail < this->k_val) ? avail : this->k_val;
                     if (draft_load > 0) {
-                        uint64_t gm_row_offset = static_cast<uint64_t>(global_row)
-                                                 * static_cast<uint32_t>(this->max_seq_len);
+                        uint64_t gm_row_offset = RowTokenOffset(global_row);
                         COPY_GM_TO_UB(draftLocal[draft_offset], tokenGm,
                                     gm_row_offset + best_match_pos + best_ngram_len,
                                     draft_load, int32_t);
@@ -313,19 +272,42 @@ public:
         draftOutQue.EnQue(draftLocal);
         numValidOutQue.EnQue(numValidLocal);
 
-        // Stage 5: Write results back to GM
+        //Write results back to GM
         CopyOutMetadata();
     }
 
 private:
-    // ------------------------------------------------------------------------
-    // Load metadata tensors from GM into UB input queues
-    // ------------------------------------------------------------------------
+    __aicore__ inline uint32_t AlignUp(uint32_t value, uint32_t unit)
+    {
+        return ((value + unit - 1u) / unit) * unit;
+    }
+
+    __aicore__ inline uint64_t RowTokenOffset(uint32_t global_row)
+    {
+        return static_cast<uint64_t>(global_row)
+               * static_cast<uint32_t>(this->max_seq_len);
+    }
+
+    __aicore__ inline bool CanPreloadRow(int32_t valid_count, int32_t total_len)
+    {
+        return valid_count > 0 && total_len >= this->min_n_val;
+    }
+
+    __aicore__ inline int32_t FirstBlockLoadCount(int32_t total_len)
+    {
+        int32_t load_count = total_len;
+        if (total_len > static_cast<int32_t>(SAFE_CHUNK)) {
+            load_count = static_cast<int32_t>(SAFE_CHUNK) + this->max_n_val;
+            if (load_count > total_len) {
+                load_count = total_len;
+            }
+        }
+        return load_count;
+    }
+
     __aicore__ inline void CopyInMetadata()
     {
         uint32_t mnta_aligned = static_cast<uint32_t>(this->max_new_tokens_align);
-
-        // sampled tokens: [my_row_count, max_new_tokens] -> padded to mnta_aligned
         auto sampledTensor = sampledInQue.AllocTensor<int32_t>();
         uint32_t src_row_bytes = static_cast<uint32_t>(this->max_new_tokens) * ELEM_SIZE;
         AscendC::DataCopyExtParams sampledParams{
@@ -338,38 +320,31 @@ private:
             sampledParams, padParams);
         sampledInQue.EnQue(sampledTensor);
 
-        // num_tokens and discard: 1D int32 arrays
         auto numTokensTensor = numTokensInQue.AllocTensor<int32_t>();
         uint32_t meta_bytes = static_cast<uint32_t>(this->my_row_count) * ELEM_SIZE;
         AscendC::DataCopyExtParams metaParams{1, meta_bytes, 0, meta_bytes, 0};
         AscendC::DataCopyPadExtParams<int32_t> no_pad{false, 0, 0, 0};
         AscendC::DataCopyPad(numTokensTensor, numTokensGm[this->my_row_offset], metaParams, no_pad);
         numTokensInQue.EnQue(numTokensTensor);
-
         auto discardTensor = discardInQue.AllocTensor<int32_t>();
         AscendC::DataCopyPad(discardTensor, discardGm[this->my_row_offset], metaParams, no_pad);
         discardInQue.EnQue(discardTensor);
     }
 
-    // ------------------------------------------------------------------------
-    // Write output metadata from UB queues back to GM
-    // ------------------------------------------------------------------------
     __aicore__ inline void CopyOutMetadata()
     {
         auto nextLocal     = nextOutQue.DeQue<int32_t>();
         auto draftLocal    = draftOutQue.DeQue<int32_t>();
         auto numValidLocal = numValidOutQue.DeQue<int32_t>();
-
         uint16_t meta_bytes16 = static_cast<uint16_t>(this->my_row_count) * ELEM_SIZE;
         AscendC::DataCopyParams nextParams{1, meta_bytes16, 0, 0};
         AscendC::DataCopyPad(nextTokensGm[this->my_row_offset], nextLocal, nextParams);
         AscendC::DataCopyPad(numValidGm[this->my_row_offset], numValidLocal, nextParams);
 
-        // Draft tokens: write k_val elements per row (each row has k_align stride in UB)
         uint32_t k_aligned = static_cast<uint32_t>(this->k_align);
+        uint32_t k_bytes = static_cast<uint32_t>(this->k_val) * ELEM_SIZE;
+        AscendC::DataCopyExtParams rowParams{1, k_bytes, 0, 0, 0};
         for (uint32_t r = 0; r < this->my_row_count; ++r) {
-            uint32_t k_bytes = static_cast<uint32_t>(this->k_val) * ELEM_SIZE;
-            AscendC::DataCopyExtParams rowParams{1, k_bytes, 0, 0, 0};
             AscendC::DataCopyPad(
                 draftTokensGm[static_cast<uint64_t>(this->my_row_offset + r) * this->k_val],
                 draftLocal[r * k_aligned], rowParams);
@@ -380,13 +355,6 @@ private:
         numValidOutQue.FreeTensor(numValidLocal);
     }
 
-    // ------------------------------------------------------------------------
-    // Validate sampled tokens for one row.
-    // - If discard flag is set, invalidate all sampled tokens.
-    // - Clamp valid_count to available sequence space.
-    // - Write the "next" token (last valid sampled, or last context token).
-    // - Append valid sampled tokens back to the context token GM buffer.
-    // ------------------------------------------------------------------------
     __aicore__ inline int32_t ValidateTokens(
         uint32_t local_idx, uint32_t global_row,
         AscendC::LocalTensor<int32_t>& sampledLocal,
@@ -394,38 +362,28 @@ private:
         AscendC::LocalTensor<int32_t>& discardLocal,
         AscendC::LocalTensor<int32_t>& nextLocal)
     {
-        uint32_t msl          = static_cast<uint32_t>(this->max_seq_len);
         uint32_t mnta_aligned = static_cast<uint32_t>(this->max_new_tokens_align);
-        uint64_t gm_row       = static_cast<uint64_t>(global_row) * msl;
+        uint64_t gm_row       = RowTokenOffset(global_row);
         uint32_t sampled_off  = local_idx * mnta_aligned;
-
         int32_t seq_len   = numTokensLocal.GetValue(local_idx);
         int32_t discard   = discardLocal.GetValue(local_idx);
         int32_t valid_count = 0;
 
-        if (discard != 0) {
-            AscendC::Duplicate(sampledLocal[sampled_off], -1, mnta_aligned);
-        } else {
+        if (discard == 0) {
             for (int32_t j = 0; j < this->max_new_tokens; ++j) {
                 int32_t val = sampledLocal.GetValue(sampled_off + j);
                 if (val == -1 || val >= this->vocab_size_val) {
-                    // Invalidate remainder on first invalid token
-                    for (int32_t k = j; k < this->max_new_tokens; ++k) {
-                        sampledLocal.SetValue(sampled_off + k, -1);
-                    }
                     break;
                 }
                 valid_count++;
             }
         }
 
-        // Clamp valid count by remaining sequence capacity
         int32_t avail_space = this->max_seq_len - seq_len;
         avail_space = (avail_space < 0) ? 0 : avail_space;
         valid_count = (valid_count > avail_space) ? avail_space : valid_count;
         int32_t total_len = seq_len + valid_count;
 
-        // Determine next token for this position
         if (valid_count > 0) {
             int32_t last_sampled = sampledLocal.GetValue(
                 sampled_off + static_cast<uint32_t>(valid_count - 1));
@@ -435,7 +393,6 @@ private:
             nextLocal.SetValue(local_idx, tokenGm.GetValue(gm_row + backtrack_pos));
         }
 
-        // Append valid sampled tokens to context GM
         if (valid_count > 0) {
             COPY_UB_TO_GM(tokenGm, gm_row + seq_len,
                         sampledLocal, sampled_off, valid_count, int32_t);
@@ -443,48 +400,27 @@ private:
         return valid_count;
     }
 
-    // ------------------------------------------------------------------------
-    // Load one full row of context tokens from GM to UB (short sequences).
-    // ------------------------------------------------------------------------
+    __aicore__ inline void EnqueueTokenBlock(
+        uint32_t global_row, int32_t start_pos, int32_t count)
+    {
+        auto tensor = tokenInQue.AllocTensor<int32_t>();
+        uint64_t gm_offset = RowTokenOffset(global_row) + static_cast<uint32_t>(start_pos);
+        COPY_GM_TO_UB(tensor, tokenGm, gm_offset, count, int32_t);
+        tokenInQue.EnQue(tensor);
+    }
+
     __aicore__ inline AscendC::LocalTensor<int32_t> LoadOneRowToken(
         uint32_t global_row, int32_t count)
     {
-        auto tensor = tokenInQue.AllocTensor<int32_t>();
-        uint64_t gm_row = static_cast<uint64_t>(global_row) * static_cast<uint32_t>(this->max_seq_len);
-        COPY_GM_TO_UB(tensor, tokenGm, gm_row, count, int32_t);
-        tokenInQue.EnQue(tensor);
+        EnqueueTokenBlock(global_row, 0, count);
         return tokenInQue.DeQue<int32_t>();
     }
 
-    // ------------------------------------------------------------------------
-    // Preload an entire short row into tokenInQue for double buffering.
-    // ------------------------------------------------------------------------
-    __aicore__ inline void LaunchPreloadNextRow(uint32_t global_row, int32_t count)
+    __aicore__ inline void LaunchPreloadRowFirstBlock(uint32_t global_row, int32_t total_len)
     {
-        auto tensor = tokenInQue.AllocTensor<int32_t>();
-        uint64_t gm_row = static_cast<uint64_t>(global_row) * static_cast<uint32_t>(this->max_seq_len);
-        COPY_GM_TO_UB(tensor, tokenGm, gm_row, count, int32_t);
-        tokenInQue.EnQue(tensor);
+        EnqueueTokenBlock(global_row, 0, FirstBlockLoadCount(total_len));
     }
 
-    // ------------------------------------------------------------------------
-    // Preload only the first chunk of a long row (SAFE_CHUNK + max_n_val).
-    // ------------------------------------------------------------------------
-    __aicore__ inline void LaunchPreloadNextLongFirstChunk(uint32_t global_row, int32_t total_len)
-    {
-        int32_t load_count = SAFE_CHUNK + this->max_n_val;
-        if (load_count > total_len) load_count = total_len;
-
-        auto tensor = tokenInQue.AllocTensor<int32_t>();
-        uint64_t gm_row = static_cast<uint64_t>(global_row) * static_cast<uint32_t>(this->max_seq_len);
-        COPY_GM_TO_UB(tensor, tokenGm, gm_row, load_count, int32_t);
-        tokenInQue.EnQue(tensor);
-    }
-
-    // ------------------------------------------------------------------------
-    // Short-sequence n-gram match (entire row fits in UB).
-    // Uses vectorized recurrence: diff_n = diff_{n-1} | (token - suffix[n]).
-    // ------------------------------------------------------------------------
     __aicore__ inline void NgramMatchRowShort(
         int32_t total_len,
         AscendC::LocalTensor<int32_t>& tokenLocal,
@@ -493,7 +429,6 @@ private:
     {
         best_match_pos = -1;
         best_ngram_len = 0;
-
         auto ngramResult = ngramCalcBuf.Get<int32_t>();
         auto ngramTemp   = ngramTempBuf.Get<int32_t>();
         auto ngramTempF  = ngramTempBuf.Get<float>();
@@ -503,34 +438,24 @@ private:
         for (int32_t n = 1; n <= this->max_n_val; ++n) {
             int32_t valid_len = total_len - n;
             if (valid_len <= 0) break;
-
-            // Recurrence: shift previous comparison result by one position
             if (n > 1) {
                 AscendC::Gather<int32_t>(ngramTemp, ngramResult, ngramGather, 0, valid_len);
             }
-
-            // Compare all positions against the n-th suffix token
             AscendC::Adds<int32_t>(ngramResult, tokenLocal,
                                 -tokenLocal.GetValue(static_cast<uint32_t>(total_len - n)),
                                 valid_len);
-
-            // Merge with previous length-(n-1) match mask
             if (n > 1) {
                 AscendC::Or<uint16_t>(ngramResult.ReinterpretCast<uint16_t>(),
                                     ngramResult.ReinterpretCast<uint16_t>(),
                                     ngramTemp.ReinterpretCast<uint16_t>(),
                                       static_cast<uint32_t>(valid_len * 2));
             }
-
             if (n < this->min_n_val) continue;
-
-            // Reduce: find if any position has exact match (min abs diff == 0)
             AscendC::Cast<float, int32_t>(ngramTempF, ngramResult,
                                         AscendC::RoundMode::CAST_CEIL, valid_len);
             AscendC::Abs<float>(ngramTempF, ngramTempF, valid_len);
             AscendC::ReduceMin<float>(ngramReduce, ngramTempF, ngramReduce,
                                     static_cast<uint32_t>(valid_len), true);
-
             float min_val_f = ngramReduce.GetValue(0);
             if (min_val_f == 0.0f) {
                 float min_idx_f = ngramReduce.GetValue(1);
@@ -538,20 +463,11 @@ private:
                     *reinterpret_cast<uint32_t*>(&min_idx_f));
                 best_ngram_len = n;
             } else {
-                break;  // No match for length n; longer n-grams impossible
+                break;
             }
         }
     }
 
-    // ------------------------------------------------------------------------
-    // Long-sequence n-gram match (chunked with double-buffered token loading).
-    //
-    // Algorithm:
-    //   1. Load suffix (last max_n_val tokens) as query anchor.
-    //   2. Iterate over the row in SAFE_CHUNK chunks.
-    //   3. For each chunk, evaluate n = 1 .. max_n_val via vectorized recurrence.
-    //   4. Overlap computation with preloading of next chunk or next row.
-    // ------------------------------------------------------------------------
     __aicore__ inline void NgramMatchRowLong(
         uint32_t global_row,
         int32_t total_len,
@@ -559,15 +475,13 @@ private:
         int32_t next_global_row,
         int32_t next_total_len,
         int32_t next_valid_count,
-        int32_t& preloaded_row_out,
+        bool& preloaded_next_row_out,
         int32_t& best_match_pos,
         int32_t& best_ngram_len)
     {
         best_match_pos   = -1;
         best_ngram_len   = 0;
-        preloaded_row_out = -1;
-
-        // Load suffix: the trailing max_n_val tokens of the sequence
+        preloaded_next_row_out = false;
         int32_t suffix_gm_start = total_len - this->max_n_val;
         if (suffix_gm_start < 0) suffix_gm_start = 0;
         int32_t suffix_load = this->max_n_val;
@@ -575,28 +489,21 @@ private:
             suffix_load = total_len - suffix_gm_start;
         }
 
-        uint64_t gm_row_offset = static_cast<uint64_t>(global_row)
-                                 * static_cast<uint32_t>(this->max_seq_len);
+        uint64_t gm_row_offset = RowTokenOffset(global_row);
         auto suffixTensor = suffixInQue.AllocTensor<int32_t>();
         COPY_GM_TO_UB(suffixTensor, tokenGm, gm_row_offset + suffix_gm_start,
                     suffix_load, int32_t);
         suffixInQue.EnQue(suffixTensor);
         auto suffixLocal = suffixInQue.DeQue<int32_t>();
-
-        // Vector calculation buffers
         auto ngramResult = ngramCalcBuf.Get<int32_t>();
         auto ngramTemp   = ngramTempBuf.Get<int32_t>();
         auto ngramTempF  = ngramTempBuf.Get<float>();
         auto ngramGather = ngramGatherBuf.Get<uint32_t>();
         auto ngramReduce = ngramReduceBuf.Get<float>();
-
-        // Determine if next row is eligible for preloading
-        bool has_next_row  = (next_total_len >= this->min_n_val) && (next_valid_count > 0);
-        bool next_is_short = (next_total_len > 0 && next_total_len <= static_cast<int32_t>(SAFE_CHUNK));
+        bool can_preload_next_row = CanPreloadRow(next_valid_count, next_total_len);
         bool found_global_max = false;
-        int32_t search_limit = total_len - this->min_n_val;  // Last valid n-gram start index
+        int32_t search_limit = total_len - this->min_n_val;
 
-        // Initialize first chunk
         AscendC::LocalTensor<int32_t> tokenLocal;
         int32_t chunk_start  = 0;
         int32_t chunk_count  = (SAFE_CHUNK <= search_limit) ? SAFE_CHUNK : search_limit;
@@ -608,21 +515,16 @@ private:
         if (first_chunk_preloaded) {
             tokenLocal = tokenInQue.DeQue<int32_t>();
         } else {
-            auto t0 = tokenInQue.AllocTensor<int32_t>();
-            COPY_GM_TO_UB(t0, tokenGm, gm_row_offset + chunk_start, load_count, int32_t);
-            tokenInQue.EnQue(t0);
+            EnqueueTokenBlock(global_row, chunk_start, load_count);
             tokenLocal = tokenInQue.DeQue<int32_t>();
         }
 
-        bool has_preloaded    = false;   // Next chunk tensor is waiting in tokenInQue
-        bool preloaded_next_row = false; // The waiting tensor belongs to the next row
+        bool has_preloaded_chunk = false;
 
-        // Chunked matching loop
         while (!found_global_max) {
             int32_t next_chunk_start = chunk_start + SAFE_CHUNK;
             bool has_next_chunk = (next_chunk_start < search_limit);
 
-            // Preload priority: next chunk of current row > next row's first chunk
             if (has_next_chunk) {
                 int32_t next_chunk_count = (next_chunk_start + SAFE_CHUNK <= search_limit)
                                         ? SAFE_CHUNK
@@ -631,62 +533,40 @@ private:
                 if (next_chunk_start + next_load_count > total_len) {
                     next_load_count = total_len - next_chunk_start;
                 }
-                auto tn = tokenInQue.AllocTensor<int32_t>();
-                COPY_GM_TO_UB(tn, tokenGm, gm_row_offset + next_chunk_start,
-                            next_load_count, int32_t);
-                tokenInQue.EnQue(tn);
-                has_preloaded = true;
-            } else if (has_next_row) {
-                uint32_t next_gr = static_cast<uint32_t>(next_global_row);
-                if (next_is_short) {
-                    LaunchPreloadNextRow(next_gr, next_total_len);
-                } else {
-                    LaunchPreloadNextLongFirstChunk(next_gr, next_total_len);
-                }
-                preloaded_next_row = true;
-                preloaded_row_out  = 1;  // Signal caller that next row is ready
+                EnqueueTokenBlock(global_row, next_chunk_start, next_load_count);
+                has_preloaded_chunk = true;
+            } else if (can_preload_next_row) {
+                LaunchPreloadRowFirstBlock(static_cast<uint32_t>(next_global_row), next_total_len);
+                preloaded_next_row_out = true;
             }
 
-            // Evaluate n-gram lengths 1..max_n_val on current chunk
             for (int32_t n = 1; n <= this->max_n_val; ++n) {
                 int32_t valid_len = load_count - n;
                 if (valid_len <= 0) break;
-
-                // Recurrence: shift previous comparison result
                 if (n > 1) {
                     AscendC::Gather<int32_t>(ngramTemp, ngramResult,
                                             ngramGather, 0, valid_len);
                 }
-
-                // Vectorized subtraction against n-th suffix token
                 int32_t suffix_idx = suffix_load - n;
                 AscendC::Adds<int32_t>(ngramResult, tokenLocal,
                                     -suffixLocal.GetValue(static_cast<uint32_t>(suffix_idx)),
                                     valid_len);
-
-                // Merge match masks across n-gram lengths
                 if (n > 1) {
                     AscendC::Or<uint16_t>(ngramResult.ReinterpretCast<uint16_t>(),
                                         ngramResult.ReinterpretCast<uint16_t>(),
                                         ngramTemp.ReinterpretCast<uint16_t>(),
                                           static_cast<uint32_t>(valid_len * 2));
                 }
-
                 if (n < this->min_n_val) continue;
-
-                // Clamp evaluation to actual chunk boundary (exclude overflow tail)
                 int32_t eval_count = (chunk_start + chunk_count <= total_len - n)
                                     ? chunk_count
                                     : (total_len - n - chunk_start);
                 if (eval_count <= 0) break;
-
-                // Reduce to check for exact match in this chunk
                 AscendC::Cast<float, int32_t>(ngramTempF, ngramResult,
                                             AscendC::RoundMode::CAST_CEIL, eval_count);
                 AscendC::Abs<float>(ngramTempF, ngramTempF, eval_count);
                 AscendC::ReduceMin<float>(ngramReduce, ngramTempF, ngramReduce,
                                         static_cast<uint32_t>(eval_count), true);
-
                 float min_val_f = ngramReduce.GetValue(0);
                 if (min_val_f == 0.0f) {
                     if (n > best_ngram_len) {
@@ -700,17 +580,15 @@ private:
                         }
                     }
                 } else {
-                    break;  // No match for this n; longer n-grams cannot match
+                    break;
                 }
             }
 
             if (found_global_max || !has_next_chunk) break;
 
-            // Advance to next chunk, consuming the preloaded tensor
             tokenInQue.FreeTensor(tokenLocal);
             tokenLocal   = tokenInQue.DeQue<int32_t>();
-            has_preloaded = false;
-
+            has_preloaded_chunk = false;
             chunk_start = next_chunk_start;
             chunk_count = (chunk_start + SAFE_CHUNK <= search_limit)
                         ? SAFE_CHUNK
@@ -721,19 +599,14 @@ private:
             }
         }
 
-        // Clean up unconsumed preloaded chunk (if it was a chunk, not next row)
-        if (has_preloaded && !preloaded_next_row) {
+        if (has_preloaded_chunk) {
             auto extra = tokenInQue.DeQue<int32_t>();
             tokenInQue.FreeTensor(extra);
         }
-
         tokenInQue.FreeTensor(tokenLocal);
         suffixInQue.FreeTensor(suffixLocal);
     }
 
-    // ------------------------------------------------------------------------
-    // Compute scratch-space size for AscendC::ReduceMin (multi-iteration).
-    // ------------------------------------------------------------------------
     __aicore__ inline uint32_t CalcReduceMinTmpSize(uint32_t count, uint32_t typeSize)
     {
         uint32_t elementsPerBlock  = 32 / typeSize;
@@ -755,31 +628,24 @@ private:
     }
 
 private:
-    // ------------------------------------------------------------------------
-    // TPipe and TQue/TBuf declarations
-    // ------------------------------------------------------------------------
     AscendC::TPipe pipe;
 
-    // Input queues
     AscendC::TQue<AscendC::TPosition::VECIN, 2> tokenInQue;
     AscendC::TQue<AscendC::TPosition::VECIN, 1> sampledInQue;
     AscendC::TQue<AscendC::TPosition::VECIN, 1> numTokensInQue;
     AscendC::TQue<AscendC::TPosition::VECIN, 1> discardInQue;
     AscendC::TQue<AscendC::TPosition::VECIN, 1> suffixInQue;
 
-    // Output queues
     AscendC::TQue<AscendC::TPosition::VECOUT, 1> nextOutQue;
     AscendC::TQue<AscendC::TPosition::VECOUT, 1> draftOutQue;
     AscendC::TQue<AscendC::TPosition::VECOUT, 1> numValidOutQue;
 
-    // Calculation buffers
     AscendC::TBuf<AscendC::TPosition::VECCALC> ngramCalcBuf;
     AscendC::TBuf<AscendC::TPosition::VECCALC> ngramTempBuf;
     AscendC::TBuf<AscendC::TPosition::VECCALC> ngramGatherBuf;
     AscendC::TBuf<AscendC::TPosition::VECCALC> ngramReduceBuf;
     AscendC::TBuf<AscendC::TPosition::VECCALC> validCountBuf;
 
-    // GM tensors
     AscendC::GlobalTensor<int32_t> tokenGm;
     AscendC::GlobalTensor<int32_t> numTokensGm;
     AscendC::GlobalTensor<int32_t> sampledGm;
@@ -788,7 +654,6 @@ private:
     AscendC::GlobalTensor<int32_t> draftTokensGm;
     AscendC::GlobalTensor<int32_t> numValidGm;
 
-    // Tiling scalars
     int32_t batch_size;
     int32_t max_seq_len;
     int32_t max_seq_len_align;

--- a/csrc/attention/ngram_spec_decode/op_kernel/ngram_spec_decode.h
+++ b/csrc/attention/ngram_spec_decode/op_kernel/ngram_spec_decode.h
@@ -13,8 +13,6 @@ struct NgramSpecDecodeInfo {
     uint32_t k;
     uint32_t formerNum;
     uint32_t rowsPerCore;
-    uint32_t tailRows;
-    uint32_t blockRows;
 };
 
 struct NgramSpecDecodeTilingData {

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_ngram_spec_decode.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_ngram_spec_decode.py
@@ -61,7 +61,9 @@ def golden_ngram_spec_decode(
             elif val != -1 and val < vocab_size:
                 valid_count += 1
             else:
-                sampled_token_ids[i, j] = -1
+                for tail_idx in range(j, sampled_token_ids.shape[1]):
+                    sampled_token_ids[i, tail_idx] = -1
+                break
 
         avail_space = M - seq_len
         if avail_space < 0:
@@ -92,16 +94,12 @@ def golden_ngram_spec_decode(
                     break
 
                 suffix = token_ids[i, nt - ngram_len : nt].tolist()
-                found = False
                 for pos in range(wc):
                     window = token_ids[i, pos : pos + ngram_len].tolist()
                     if window == suffix:
                         best_match_pos = pos
                         best_ngram_len = ngram_len
-                        found = True
                         break
-                if found:
-                    break
 
         # Stage 4: get draft tokens
         if best_match_pos >= 0:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR builds on #9008 and optimizes the ngram_spec_decode  kernel implementation by replacing frequent `GetValue()` / `SetValue()` operations with vectorized operations. This significantly improves kernel performance, especially when the sequence length is large.

### How was this patch tested?

**Platform: 910B A2**

**Correctness test:**
```
pytest tests/e2e/nightly/single_node/ops/singlecard_ops/test_ngram_spec_decode.py -s -v
```


```
root@huawei:/home/t00970481/vllm-ascend# pytest tests/e2e/nightly/single_node/ops/singlecard_ops/test_ngram_spec_decode.py
====================================================================================================================================== test session starts ======================================================================================================================================
platform linux -- Python 3.11.10, pytest-8.3.2, pluggy-1.6.0
rootdir: /home/t00970481/vllm-ascend
configfile: pyproject.toml
plugins: xdist-3.6.1, anyio-4.13.0
collected 21 items

tests/e2e/nightly/single_node/ops/singlecard_ops/test_ngram_spec_decode.py

================================================================================================================================ 21 passed, 16 warnings in 0.70s ================================================================================================================================
```

**Op performance test:**
add following cases in `tests/e2e/nightly/single_node/ops/singlecard_ops/test_ngram_spec_decode.py::test_ngram_spec_decode_basic`
```
@pytest.mark.parametrize("batch_size,seq_len,max_new_tokens,k", [
    (2, 64, 16, 5),
    (2, 128, 16, 5),
    (2, 512, 16, 5),
    (2, 1024, 16, 5),
    (2, 8192, 16, 5),
    (2, 32768, 16, 5),
    (8, 64, 16, 5),
    (8, 128, 16, 5),
    (8, 512, 16, 5),
    (8, 1024, 16, 5),
    (8, 8192, 16, 5),
    (8, 32768, 16, 5),
    (64, 64, 16, 5),
    (64, 128, 16, 5),
    (64, 512, 16, 5),
    (64, 1024, 16, 5),
    (64, 8192, 16, 5),
    (64, 32768, 16, 5),
    (128, 64, 16, 5),
    (128, 128, 16, 5),
    (128, 512, 16, 5),
    (128, 1024, 16, 5),
    (128, 8192, 16, 5),
    (128, 32768, 16, 5),
    (287, 64, 16, 5),
    (287, 128, 16, 5),
    (287, 512, 16, 5),
    (287, 1024, 16, 5),
    (287, 8192, 16, 5),
    (287, 32768, 16, 5),
])
```
current performance:
```
[perf] B=2 M=64 N=16 k=5 min_n=3 max_n=5 -> 59.6 us/call
[perf] B=2 M=128 N=16 k=5 min_n=3 max_n=5 -> 59.6 us/call
[perf] B=2 M=512 N=16 k=5 min_n=3 max_n=5 -> 58.9 us/call
[perf] B=2 M=1024 N=16 k=5 min_n=3 max_n=5 -> 58.2 us/call
[perf] B=2 M=8192 N=16 k=5 min_n=3 max_n=5 -> 284.1 us/call
[perf] B=2 M=32768 N=16 k=5 min_n=3 max_n=5 -> 1377.1 us/call
[perf] B=8 M=64 N=16 k=5 min_n=3 max_n=5 -> 59.7 us/call
[perf] B=8 M=128 N=16 k=5 min_n=3 max_n=5 -> 59.7 us/call
[perf] B=8 M=512 N=16 k=5 min_n=3 max_n=5 -> 59.9 us/call
[perf] B=8 M=1024 N=16 k=5 min_n=3 max_n=5 -> 61.2 us/call
[perf] B=8 M=8192 N=16 k=5 min_n=3 max_n=5 -> 390.8 us/call
[perf] B=8 M=32768 N=16 k=5 min_n=3 max_n=5 -> 1275.2 us/call
[perf] B=64 M=64 N=16 k=5 min_n=3 max_n=5 -> 84.3 us/call
[perf] B=64 M=128 N=16 k=5 min_n=3 max_n=5 -> 119.6 us/call
[perf] B=64 M=512 N=16 k=5 min_n=3 max_n=5 -> 331.1 us/call
[perf] B=64 M=1024 N=16 k=5 min_n=3 max_n=5 -> 691.1 us/call
[perf] B=64 M=8192 N=16 k=5 min_n=3 max_n=5 -> 4969.1 us/call
[perf] B=64 M=32768 N=16 k=5 min_n=3 max_n=5 -> 23820.1 us/call
[perf] B=128 M=64 N=16 k=5 min_n=3 max_n=5 -> 66.2 us/call
[perf] B=128 M=128 N=16 k=5 min_n=3 max_n=5 -> 70.9 us/call
[perf] B=128 M=512 N=16 k=5 min_n=3 max_n=5 -> 199.5 us/call
[perf] B=128 M=1024 N=16 k=5 min_n=3 max_n=5 -> 349.1 us/call
[perf] B=128 M=8192 N=16 k=5 min_n=3 max_n=5 -> 2767.6 us/call
[perf] B=128 M=32768 N=16 k=5 min_n=3 max_n=5 -> 7059.9 us/call
[perf] B=287 M=64 N=16 k=5 min_n=3 max_n=5 -> 66.0 us/call
[perf] B=287 M=128 N=16 k=5 min_n=3 max_n=5 -> 83.6 us/call
[perf] B=287 M=512 N=16 k=5 min_n=3 max_n=5 -> 290.1 us/call
[perf] B=287 M=1024 N=16 k=5 min_n=3 max_n=5 -> 459.9 us/call
[perf] B=287 M=8192 N=16 k=5 min_n=3 max_n=5 -> 4123.9 us/call
[perf] B=287 M=32768 N=16 k=5 min_n=3 max_n=5 -> 11097.0 us/call
```

this PR performance:
```
[perf] B=2 M=64 N=16 k=5 min_n=3 max_n=5 -> 59.6 us/call
[perf] B=2 M=128 N=16 k=5 min_n=3 max_n=5 -> 58.9 us/call
[perf] B=2 M=512 N=16 k=5 min_n=3 max_n=5 -> 57.8 us/call
[perf] B=2 M=1024 N=16 k=5 min_n=3 max_n=5 -> 57.3 us/call
[perf] B=2 M=8192 N=16 k=5 min_n=3 max_n=5 -> 58.4 us/call
[perf] B=2 M=32768 N=16 k=5 min_n=3 max_n=5 -> 59.3 us/call
[perf] B=8 M=64 N=16 k=5 min_n=3 max_n=5 -> 60.4 us/call
[perf] B=8 M=128 N=16 k=5 min_n=3 max_n=5 -> 60.0 us/call
[perf] B=8 M=512 N=16 k=5 min_n=3 max_n=5 -> 59.4 us/call
[perf] B=8 M=1024 N=16 k=5 min_n=3 max_n=5 -> 58.9 us/call
[perf] B=8 M=8192 N=16 k=5 min_n=3 max_n=5 -> 62.8 us/call
[perf] B=8 M=32768 N=16 k=5 min_n=3 max_n=5 -> 61.3 us/call
[perf] B=64 M=64 N=16 k=5 min_n=3 max_n=5 -> 61.9 us/call
[perf] B=64 M=128 N=16 k=5 min_n=3 max_n=5 -> 62.0 us/call
[perf] B=64 M=512 N=16 k=5 min_n=3 max_n=5 -> 62.2 us/call
[perf] B=64 M=1024 N=16 k=5 min_n=3 max_n=5 -> 62.5 us/call
[perf] B=64 M=8192 N=16 k=5 min_n=3 max_n=5 -> 62.2 us/call
[perf] B=64 M=32768 N=16 k=5 min_n=3 max_n=5 -> 68.0 us/call
[perf] B=128 M=64 N=16 k=5 min_n=3 max_n=5 -> 67.0 us/call
[perf] B=128 M=128 N=16 k=5 min_n=3 max_n=5 -> 68.4 us/call
[perf] B=128 M=512 N=16 k=5 min_n=3 max_n=5 -> 68.4 us/call
[perf] B=128 M=1024 N=16 k=5 min_n=3 max_n=5 -> 67.9 us/call
[perf] B=128 M=8192 N=16 k=5 min_n=3 max_n=5 -> 67.1 us/call
[perf] B=128 M=32768 N=16 k=5 min_n=3 max_n=5 -> 69.1 us/call
[perf] B=287 M=64 N=16 k=5 min_n=3 max_n=5 -> 63.5 us/call
[perf] B=287 M=128 N=16 k=5 min_n=3 max_n=5 -> 68.0 us/call
[perf] B=287 M=512 N=16 k=5 min_n=3 max_n=5 -> 64.3 us/call
[perf] B=287 M=1024 N=16 k=5 min_n=3 max_n=5 -> 64.1 us/call
[perf] B=287 M=8192 N=16 k=5 min_n=3 max_n=5 -> 65.4 us/call
[perf] B=287 M=32768 N=16 k=5 min_n=3 max_n=5 -> 107.5 us/call
```

speedup:
|   B\M   |   64  |  128  |    512    |    1024    |    8192    |    32768    |
| :-----: | :---: | :---: | :-------: | :--------: | :--------: | :---------: |
|  **2**  | 1.00x | 1.01x |   1.02x   |    1.02x   |  **4.86x** |  **23.22x** |
|  **8**  | 0.99x | 0.99x |   1.01x   |    1.04x   |  **6.22x** |  **20.80x** |
|  **64** | 1.36x | 1.93x | **5.32x** | **11.06x** | **79.89x** | **350.30x** |
| **128** | 0.99x | 1.04x | **2.92x** |  **5.14x** | **41.25x** | **102.17x** |
| **287** | 1.04x | 1.23x | **4.51x** |  **7.17x** | **63.06x** | **103.23x** |


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
