### PR TITLE
[UT] Add UT for VWN Eagle3

### DIFF
--- a/tests/e2e/pull_request/one_card/spec_decode/utils.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/utils.py
@@ -28,6 +28,13 @@ DFLASH = {
     }
 }
 
+VWN_MODELS = {
+    "vwn_eagle3_m4_r1_5": {
+        "main": "Qwen/Qwen3-30B-A3B",
+        "spec": "ascend/vwn_eagle3",
+    },
+}
+
 BASELINES = {
     "eagle": [0.74, 0.44, 0.29],
     "eagle3": [0.68, 0.40, 0.18],

--- a/tests/ut/spec_decode/test_vwn_eagle3_model.py
+++ b/tests/ut/spec_decode/test_vwn_eagle3_model.py
@@ -1,0 +1,759 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for VWN-Eagle3 model components.
+
+Tests cover PreVwnLayerV1, VwnLlamaDecoderLayer, VwnLlamaModel, and
+Eagle3VwnLlamaForCausalLM using CPU-only execution with mocked VllmConfig.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+import torch.nn as nn
+from vllm.config import CacheConfig, CompilationMode, VllmConfig, set_current_vllm_config
+
+from vllm_ascend.ascend_config import init_ascend_config
+from vllm_ascend.models.llama_eagle3_vwn import (
+    Eagle3VwnLlamaForCausalLM,
+    PreVwnLayerV1,
+    VwnLlamaDecoderLayer,
+    VwnLlamaModel,
+)
+
+# ---------------------------------------------------------------------------
+# Helper: nn.Module that returns a fixed-shape tensor (replaces NPU-only ops)
+# ---------------------------------------------------------------------------
+
+
+class _PassthroughAttn(nn.Module):
+    """Replaces self_attn for CPU tests — returns input-like tensor."""
+
+    def __init__(self, hs):
+        super().__init__()
+        self.hs = hs
+
+    def forward(self, *, positions, hidden_states, **kwargs):
+        return hidden_states
+
+
+class _PassthroughMLP(nn.Module):
+    """Replaces mlp for CPU tests — returns input-like tensor."""
+
+    def __init__(self, hs):
+        super().__init__()
+        self.hs = hs
+
+    def forward(self, hidden_states):
+        return hidden_states
+
+
+def _mock_npu_ops_on_layer(layer, hs, num_tokens):
+    """Replace self_attn and mlp with passthrough modules for CPU testing."""
+    layer.self_attn = _PassthroughAttn(hs)
+    layer.mlp = _PassthroughMLP(hs)
+
+
+# ---------------------------------------------------------------------------
+# Autouse fixture: mock TP group so ReplicatedLinear works on CPU
+# ---------------------------------------------------------------------------
+
+
+class _MockTPGroup:
+    """Minimal mock for get_tp_group() when TP=1."""
+
+    rank_in_group = 0
+    world_size = 1
+
+    def all_reduce(self, *args, **kwargs):
+        pass
+
+    def all_gather(self, x, *args, **kwargs):
+        return x.unsqueeze(0)
+
+    def reduce_scatter(self, x, *args, **kwargs):
+        return x
+
+
+@pytest.fixture(autouse=True)
+def _mock_tp_group():
+    """Patch get_tp_group so CustomLinearOp.tp_rank/tp_size work on CPU."""
+    _mock = _MockTPGroup()
+    with patch("vllm_ascend.ops.linear_op.get_tp_group", return_value=_mock), \
+         patch("vllm.distributed.parallel_state.get_tp_group", return_value=_mock), \
+         patch("vllm_ascend.ops.vocab_parallel_embedding.get_tp_group", return_value=_mock):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _mock_ascend_config():
+    """Patch get_ascend_config so Ascend linear ops work on CPU."""
+    mock_cfg = MagicMock()
+    mock_cfg.enable_flashcomm2_parallel_size = 0
+    mock_cfg.enable_context_parallel = False
+    mock_cfg.enable_flashcomm1 = False
+    mock_cfg.enable_matmul_allreduce = False
+    mock_cfg.weight_nz_mode = 1
+    mock_cfg.enable_mlapo = True
+    mock_cfg.enable_fused_mc2 = 0
+    mock_cfg.msmonitor_use_daemon = False
+    mock_cfg.enable_transpose_kv_cache_by_block = True
+    mock_cfg.finegrained_tp_config = MagicMock()
+    # All finegrained_tp fields default to 0 (disabled)
+    mock_cfg.finegrained_tp_config.lmhead_tensor_parallel_size = 0
+    mock_cfg.finegrained_tp_config.embedding_tensor_parallel_size = 0
+    mock_cfg.finegrained_tp_config.oproj_tensor_parallel_size = 0
+    mock_cfg.finegrained_tp_config.olora_tensor_parallel_size = 0
+    mock_cfg.finegrained_tp_config.mlp_tensor_parallel_size = 0
+    with patch("vllm_ascend.utils.get_ascend_config", return_value=mock_cfg):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _mock_gemm_op():
+    """Patch NPU-only vllm custom ops to work on CPU."""
+    import torch.nn.functional as F
+
+    def _cpu_gemm(input, weight, bias=None):
+        return F.linear(input, weight, bias)
+
+    def _cpu_maybe_calc_kv_scales(*args, **kwargs):
+        return None
+
+    def _cpu_maybe_pad_and_reduce(x, *args, **kwargs):
+        return x
+
+    with patch.object(torch.ops.vllm, "unquantized_gemm", _cpu_gemm), \
+         patch.object(torch.ops.vllm, "maybe_calc_kv_scales", _cpu_maybe_calc_kv_scales), \
+         patch.object(torch.ops.vllm, "maybe_pad_and_reduce", _cpu_maybe_pad_and_reduce):
+        yield
+
+# ---------------------------------------------------------------------------
+# Helper: build a VllmConfig suitable for instantiating VWN components on CPU
+# ---------------------------------------------------------------------------
+
+# Default dimensions matching the real VWN checkpoint config.json
+_HIDDEN = 2048
+_INTERMEDIATE = 6144
+_VOCAB = 151936
+_DRAFT_VOCAB = 35000
+_NUM_HEADS = 32
+_NUM_KV_HEADS = 4
+_HEAD_DIM = 128
+_RMS_EPS = 1e-6
+
+
+def _make_hf_config(
+    hidden_size=_HIDDEN,
+    intermediate_size=_INTERMEDIATE,
+    vocab_size=_VOCAB,
+    draft_vocab_size=_DRAFT_VOCAB,
+    num_hidden_layers=1,
+    num_attention_heads=_NUM_HEADS,
+    num_key_value_heads=_NUM_KV_HEADS,
+    head_dim=_HEAD_DIM,
+    rms_norm_eps=_RMS_EPS,
+    vwn_m=4,
+    vwn_r=1.5,
+    **extra,
+):
+    """Create a real LlamaConfig with VWN attributes.
+
+    Using a real config object instead of MagicMock avoids whack-a-mole
+    with missing attributes that the deep init chain of LlamaDecoderLayer
+    expects (rope_parameters, max_position_embeddings, etc.).
+    """
+    from transformers import LlamaConfig
+
+    cfg = LlamaConfig(
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_attention_heads=num_attention_heads,
+        num_key_value_heads=num_key_value_heads,
+        num_hidden_layers=num_hidden_layers,
+        vocab_size=vocab_size,
+        rms_norm_eps=rms_norm_eps,
+        max_position_embeddings=40960,
+    )
+    # VWN-specific attributes (not in LlamaConfig schema)
+    cfg.vwn_m = vwn_m
+    cfg.vwn_r = vwn_r
+    cfg.draft_vocab_size = draft_vocab_size
+    for k, v in extra.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+def _create_vllm_config_for_vwn(
+    vwn_m=4,
+    vwn_r=1.5,
+    hidden_size=_HIDDEN,
+    num_hidden_layers=1,
+    draft_vocab_size=_DRAFT_VOCAB,
+    vocab_size=_VOCAB,
+    num_target_layers=48,
+):
+    """Create a fully mocked VllmConfig for VWN model instantiation.
+
+    Pattern follows test_eagle_proposer.py and
+    test_extract_hidden_states_proposer.py.
+    """
+    hf_config = _make_hf_config(
+        hidden_size=hidden_size,
+        vwn_m=vwn_m,
+        vwn_r=vwn_r,
+        num_hidden_layers=num_hidden_layers,
+        draft_vocab_size=draft_vocab_size,
+        vocab_size=vocab_size,
+    )
+
+    vllm_config = MagicMock(spec=VllmConfig)
+
+    # speculative_config
+    vllm_config.speculative_config = MagicMock()
+    vllm_config.speculative_config.method = "eagle3"
+    vllm_config.speculative_config.num_speculative_tokens = 3
+    vllm_config.speculative_config.draft_tensor_parallel_size = 1
+    vllm_config.speculative_config.draft_model_config = MagicMock()
+    vllm_config.speculative_config.draft_model_config.hf_config = hf_config
+    vllm_config.speculative_config.draft_model_config.get_hidden_size = MagicMock(
+        return_value=hidden_size,
+    )
+    vllm_config.speculative_config.draft_model_config.get_inputs_embeds_size = MagicMock(
+        return_value=hidden_size,
+    )
+    vllm_config.speculative_config.draft_model_config.uses_mrope = False
+    vllm_config.speculative_config.draft_model_config.uses_xdrope_dim = 0
+    vllm_config.speculative_config.draft_model_config.quantization = None
+    vllm_config.speculative_config.draft_model_config.load_config = MagicMock()
+    vllm_config.speculative_config.disable_padded_drafter_batch = False
+    vllm_config.speculative_config.parallel_drafting = False
+    vllm_config.speculative_config.speculative_token_tree = str(
+        [(i + 1) * (0,) for i in range(3)],
+    )
+
+    # cache_config
+    vllm_config.cache_config = MagicMock(spec=CacheConfig)
+    vllm_config.cache_config.block_size = 16
+    vllm_config.cache_config.kv_cache_dtype_skip_layers = None
+    vllm_config.cache_config.cache_dtype = "auto"
+
+    # scheduler_config
+    vllm_config.scheduler_config = MagicMock()
+    vllm_config.scheduler_config.max_num_batched_tokens = 1024
+    vllm_config.scheduler_config.max_num_seqs = 32
+    vllm_config.scheduler_config.async_scheduling = True
+
+    # model_config — use float32 for CPU testing
+    vllm_config.model_config = MagicMock()
+    vllm_config.model_config.dtype = torch.float32
+    vllm_config.model_config.max_model_len = 2048
+    vllm_config.model_config.uses_mrope = False
+    vllm_config.model_config.uses_xdrope_dim = 0
+    vllm_config.model_config.enforce_eager = True
+    vllm_config.model_config.hf_text_config = MagicMock(spec=[])
+    vllm_config.model_config.hf_text_config.to_dict = MagicMock(return_value={})
+    vllm_config.model_config.hf_config = hf_config
+    vllm_config.model_config.get_num_layers = MagicMock(return_value=num_target_layers)
+
+    # compilation_config
+    vllm_config.compilation_config = MagicMock()
+    vllm_config.compilation_config.mode = CompilationMode.NONE
+    vllm_config.compilation_config.pass_config = MagicMock()
+    vllm_config.compilation_config.pass_config.enable_sp = False
+    vllm_config.compilation_config.custom_ops = ["none"]  # Required by CustomOp.default_on()
+
+    # parallel_config
+    vllm_config.parallel_config = MagicMock()
+    vllm_config.parallel_config.tensor_parallel_size = 1
+    vllm_config.parallel_config.data_parallel_rank = 0
+    vllm_config.parallel_config.data_parallel_size = 1
+    vllm_config.parallel_config.prefill_context_parallel_size = 1
+    vllm_config.parallel_config.decode_context_parallel_size = 1
+    vllm_config.parallel_config.enable_expert_parallel = False
+
+    vllm_config.additional_config = None
+
+    init_ascend_config(vllm_config)
+    return vllm_config
+
+
+# ---------------------------------------------------------------------------
+# Helper: create a full model with mocked NPU ops, ready for forward pass
+# ---------------------------------------------------------------------------
+
+
+def _make_model_with_mocked_ops(**kwargs):
+    """Create Eagle3VwnLlamaForCausalLM with mocked attention/MLP for CPU."""
+    vllm_config = _create_vllm_config_for_vwn(**kwargs)
+    hs = vllm_config.speculative_config.draft_model_config.hf_config.hidden_size
+    ctx = set_current_vllm_config(vllm_config)
+    ctx.__enter__()
+    try:
+        model = Eagle3VwnLlamaForCausalLM(vllm_config=vllm_config, prefix="")
+        for layer in model.model.layers:
+            _mock_npu_ops_on_layer(layer, hs, 1)
+        return model, vllm_config, hs, ctx
+    except Exception:
+        ctx.__exit__(None, None, None)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Test: PreVwnLayerV1
+# ---------------------------------------------------------------------------
+
+
+class TestPreVwnLayerV1:
+    """Tests for the pre-VWN projection layer — init + forward merged."""
+
+    @pytest.mark.parametrize("vwn_m,vwn_r", [(1, 1.5), (4, 1.5), (4, 1.0), (1, 1.0)])
+    def test_init_and_forward(self, vwn_m, vwn_r):
+        """Verify layer init (dims, submodules) and forward output shape."""
+        vllm_config = _create_vllm_config_for_vwn(vwn_m=vwn_m, vwn_r=vwn_r)
+        hs = _HIDDEN
+        wd = int(hs * vwn_r)
+        batch = 4
+
+        with set_current_vllm_config(vllm_config):
+            layer = PreVwnLayerV1(
+                vllm_config=vllm_config,
+                prefix="test_prevwn",
+                config=vllm_config.speculative_config.draft_model_config.hf_config,
+            )
+            # Init checks
+            assert layer.hidden_size == hs
+            assert layer.wider_dim == wd
+            assert layer.m == vwn_m
+            assert hasattr(layer, "input_layernorm")
+            assert hasattr(layer, "hidden_norm")
+            assert hasattr(layer, "fc")
+            assert hasattr(layer, "upward")
+
+            # Forward check
+            out = layer(torch.randn(batch, hs), torch.randn(batch, hs))
+
+        assert out.shape == (batch, wd)
+
+
+# ---------------------------------------------------------------------------
+# Test: VwnLlamaDecoderLayer
+# ---------------------------------------------------------------------------
+
+
+class TestVwnLlamaDecoderLayer:
+    """Tests for the VWN-augmented Llama decoder layer."""
+
+    @pytest.mark.parametrize("vwn_m,vwn_r", [(4, 1.5), (4, 1.0), (1, 1.5)])
+    def test_init_vwn_projections(self, vwn_m, vwn_r):
+        """VWN-specific submodules and dimension bookkeeping."""
+        vllm_config = _create_vllm_config_for_vwn(vwn_m=vwn_m, vwn_r=vwn_r)
+
+        with set_current_vllm_config(vllm_config):
+            layer = VwnLlamaDecoderLayer(
+                vllm_config=vllm_config,
+                prefix="model.layers.48",
+                config=vllm_config.speculative_config.draft_model_config.hf_config,
+                layer_idx=0,
+            )
+
+        hs = _HIDDEN
+        wd = int(hs * vwn_r)
+        assert isinstance(layer.pre_vwn_layer, PreVwnLayerV1)
+        assert hasattr(layer, "downward_and_forgot")
+        assert hasattr(layer, "upward_after_attn")
+        assert hasattr(layer, "upward_after_mlp")
+        assert hasattr(layer, "downward")
+        assert layer.m == vwn_m
+        assert layer.wider_dim == wd
+
+    @pytest.mark.parametrize("vwn_m,vwn_r,batch", [
+        (4, 1.5, 4), (4, 1.0, 4), (1, 1.5, 4), (4, 1.5, 1),
+    ])
+    def test_forward_layer0(self, vwn_m, vwn_r, batch):
+        """VWN forward with various m/r configs and batch sizes."""
+        vllm_config = _create_vllm_config_for_vwn(vwn_m=vwn_m, vwn_r=vwn_r)
+        hs = _HIDDEN
+
+        with set_current_vllm_config(vllm_config):
+            layer = VwnLlamaDecoderLayer(
+                vllm_config=vllm_config,
+                prefix="model.layers.48",
+                config=vllm_config.speculative_config.draft_model_config.hf_config,
+                layer_idx=0,
+            )
+            _mock_npu_ops_on_layer(layer, hs, batch)
+
+            embeds = torch.randn(batch, hs)
+            hidden = torch.randn(batch, hs)
+            positions = torch.arange(batch, dtype=torch.long)
+
+            out_hidden, out_residual = layer(positions, embeds, hidden, None)
+
+        assert out_hidden.shape == (batch, hs)
+
+    def test_forward_layer_nonzero_passthrough(self):
+        """Non-zero layer_idx returns hidden_states unchanged."""
+        vllm_config = _create_vllm_config_for_vwn()
+        hs = _HIDDEN
+        batch = 2
+
+        with set_current_vllm_config(vllm_config):
+            layer = VwnLlamaDecoderLayer(
+                vllm_config=vllm_config,
+                prefix="model.layers.48",
+                config=vllm_config.speculative_config.draft_model_config.hf_config,
+                layer_idx=1,
+            )
+            embeds = torch.randn(batch, hs)
+            hidden = torch.randn(batch, hs)
+
+            out_hidden, out_residual = layer(
+                torch.arange(batch, dtype=torch.long), embeds, hidden, None,
+            )
+
+        assert out_hidden.shape == (batch, hs)
+
+    def test_qkv_proj_input_size_layer0(self):
+        """VWN layer 0 restores qkv_proj input to hidden_size (not 2*hs).
+
+        This is the critical VWN-vs-Eagle3 difference: the parent class
+        overrides qkv_proj to accept 2*hidden_size (concatenating embeds +
+        hidden), but VWN feeds hidden_size into attention via the
+        downward_and_forgot projection instead.
+        """
+        vllm_config = _create_vllm_config_for_vwn()
+
+        with set_current_vllm_config(vllm_config):
+            layer = VwnLlamaDecoderLayer(
+                vllm_config=vllm_config,
+                prefix="model.layers.48",
+                config=vllm_config.speculative_config.draft_model_config.hf_config,
+                layer_idx=0,
+            )
+
+        assert layer.self_attn.qkv_proj.input_size == _HIDDEN
+
+
+# ---------------------------------------------------------------------------
+# Test: VwnLlamaModel
+# ---------------------------------------------------------------------------
+
+
+class TestVwnLlamaModel:
+    """Tests for the full VWN model body."""
+
+    @pytest.mark.parametrize("num_hidden_layers", [1, 2])
+    def test_init_and_forward(self, num_hidden_layers):
+        """Verify layer count/type and forward output shapes."""
+        vllm_config = _create_vllm_config_for_vwn(num_hidden_layers=num_hidden_layers)
+        hs = _HIDDEN
+        num_tokens = 4
+
+        with set_current_vllm_config(vllm_config):
+            model = VwnLlamaModel(
+                vllm_config=vllm_config,
+                prefix="model",
+                start_layer_id=48,
+            )
+
+            assert len(model.layers) == num_hidden_layers
+            for i, layer in enumerate(model.layers):
+                assert isinstance(layer, VwnLlamaDecoderLayer)
+                assert layer.layer_idx == i
+
+            for layer in model.layers:
+                _mock_npu_ops_on_layer(layer, hs, num_tokens)
+
+            input_ids = torch.randint(0, _VOCAB, (num_tokens,))
+            positions = torch.arange(num_tokens, dtype=torch.long)
+            hidden_states = torch.randn(num_tokens, hs)
+
+            postnorm, prenorm = model(input_ids, positions, hidden_states)
+
+        assert postnorm.shape == (num_tokens, hs)
+        assert prenorm.shape == (num_tokens, hs)
+
+    def test_forward_with_input_embeds(self):
+        """Forward with explicit input_embeds bypasses embedding lookup."""
+        vllm_config = _create_vllm_config_for_vwn(num_hidden_layers=1)
+        hs = _HIDDEN
+        num_tokens = 3
+
+        with set_current_vllm_config(vllm_config):
+            model = VwnLlamaModel(
+                vllm_config=vllm_config,
+                prefix="model",
+                start_layer_id=48,
+            )
+            for layer in model.layers:
+                _mock_npu_ops_on_layer(layer, hs, num_tokens)
+
+            input_ids = torch.randint(0, _VOCAB, (num_tokens,))
+            positions = torch.arange(num_tokens, dtype=torch.long)
+            hidden_states = torch.randn(num_tokens, hs)
+            input_embeds = torch.randn(num_tokens, hs)
+
+            postnorm, prenorm = model(
+                input_ids, positions, hidden_states, input_embeds=input_embeds,
+            )
+
+        assert postnorm.shape == (num_tokens, hs)
+        assert prenorm.shape == (num_tokens, hs)
+
+
+# ---------------------------------------------------------------------------
+# Test: Eagle3VwnLlamaForCausalLM
+# ---------------------------------------------------------------------------
+
+
+class TestEagle3VwnLlamaForCausalLM:
+    """Tests for the top-level VWN-Eagle3 CausalLM model."""
+
+    @pytest.mark.parametrize("vwn_m", [4, 1])
+    def test_init_and_forward(self, vwn_m):
+        """Init creates VwnLlamaModel; forward returns (postnorm, prenorm)."""
+        model, vllm_config, hs, ctx = _make_model_with_mocked_ops(vwn_m=vwn_m)
+        try:
+            assert isinstance(model.model, VwnLlamaModel)
+            num_tokens = 3
+
+            input_ids = torch.randint(0, _VOCAB, (num_tokens,))
+            positions = torch.arange(num_tokens, dtype=torch.long)
+            hidden_states = torch.randn(num_tokens, hs)
+
+            postnorm, prenorm = model(input_ids, positions, hidden_states)
+
+            assert postnorm.shape == (num_tokens, hs)
+            assert prenorm.shape == (num_tokens, hs)
+        finally:
+            ctx.__exit__(None, None, None)
+
+    def test_embed_input_ids(self):
+        vllm_config = _create_vllm_config_for_vwn()
+        num_tokens = 3
+
+        with set_current_vllm_config(vllm_config):
+            model = Eagle3VwnLlamaForCausalLM(vllm_config=vllm_config, prefix="")
+            input_ids = torch.randint(0, _VOCAB, (num_tokens,))
+            embeds = model.embed_input_ids(input_ids)
+
+        assert embeds.shape == (num_tokens, _HIDDEN)
+
+    def test_compute_logits_output_shape_and_mapping(self):
+        """compute_logits maps draft vocab logits to target vocab positions."""
+        vllm_config = _create_vllm_config_for_vwn()
+        hs = _HIDDEN
+        batch = 2
+
+        with set_current_vllm_config(vllm_config):
+            model = Eagle3VwnLlamaForCausalLM(vllm_config=vllm_config, prefix="")
+            model.draft_id_to_target_id.data.copy_(
+                torch.arange(_DRAFT_VOCAB, dtype=torch.long),
+            )
+
+            # Patch logits_processor.forward to bypass ParallelLMHead (needs
+            # real TP group coordinator).
+            draft_logits = torch.randn(batch, _DRAFT_VOCAB)
+            with patch.object(type(model.logits_processor), "forward",
+                              return_value=draft_logits):
+                logits = model.compute_logits(torch.randn(batch, hs))
+
+        assert logits.shape == (batch, _VOCAB)
+        # Mapped positions should have finite values
+        mapped = torch.arange(_DRAFT_VOCAB) + model.draft_id_to_target_id
+        assert logits[0, mapped[0]].item() != float("-inf")
+        # Unmapped positions should be -inf
+        assert logits[0, _VOCAB - 1].item() == float("-inf")
+
+    @pytest.mark.parametrize("use_aux", [True, False])
+    def test_combine_hidden_states(self, use_aux):
+        """combine_hidden_states: FC projection when aux=True, identity when False."""
+        vllm_config = _create_vllm_config_for_vwn()
+        hs = _HIDDEN
+        batch = 2
+
+        if not use_aux:
+            hf_config = vllm_config.speculative_config.draft_model_config.hf_config
+            hf_config.eagle_config = {"use_aux_hidden_state": False}
+
+        with set_current_vllm_config(vllm_config):
+            model = Eagle3VwnLlamaForCausalLM(vllm_config=vllm_config, prefix="")
+            assert model.model.use_aux_hidden_state == use_aux
+
+            if use_aux:
+                hidden = torch.randn(batch, hs * 3)
+                combined = model.combine_hidden_states(hidden)
+                assert combined.shape == (batch, hs)
+            else:
+                hidden = torch.randn(batch, hs)
+                combined = model.combine_hidden_states(hidden)
+                assert torch.equal(combined, hidden)
+
+    def test_vwn_parameters_and_count(self):
+        """Verify VWN parameters exist and total count matches expectation."""
+        vllm_config = _create_vllm_config_for_vwn(vwn_m=4, vwn_r=1.5)
+
+        with set_current_vllm_config(vllm_config):
+            model = Eagle3VwnLlamaForCausalLM(vllm_config=vllm_config, prefix="")
+
+        param_names = {name for name, _ in model.named_parameters()}
+
+        # VWN-specific prefixes must all have registered parameters
+        for prefix in ("pre_vwn_layer", "downward_and_forgot", "upward_after_attn",
+                       "upward_after_mlp", "downward"):
+            assert any(prefix in n for n in param_names), (
+                f"No parameters found for VWN prefix '{prefix}'"
+            )
+
+        # draft_id_to_target_id exists and does not require grad
+        assert "draft_id_to_target_id" in param_names
+        assert not dict(model.named_parameters())["draft_id_to_target_id"].requires_grad
+
+        # Total parameter count (update if architecture changes)
+        total = sum(p.numel() for p in model.parameters())
+        assert total == 454_607_032, (
+            f"Parameter count mismatch: got {total}, expected 454_607_032. "
+            "Update if model architecture changed."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: Weight loading integration
+# ---------------------------------------------------------------------------
+
+
+def _make_synthetic_weights_m4_r15():
+    """Synthetic weights matching vwn_eagle3_full_m_4_r_1_5 checkpoint shapes."""
+    hs, wd, m = _HIDDEN, int(_HIDDEN * 1.5), 4
+    dv = _DRAFT_VOCAB
+    v = _VOCAB
+    inter = _INTERMEDIATE
+    nkv = _NUM_KV_HEADS
+    nq = _NUM_HEADS
+    hd = _HEAD_DIM
+    return {
+        "d2t": torch.zeros(dv, dtype=torch.long),
+        "embed_tokens.weight": torch.randn(v, hs, dtype=torch.float32),
+        "fc.weight": torch.randn(hs, hs * 3, dtype=torch.float32),
+        "layers.0.downward.weight": torch.randn(hs // m, wd // m, dtype=torch.float32),
+        "layers.0.downward_and_forgot.weight": torch.randn(
+            (hs + wd) // m, wd // m, dtype=torch.float32,
+        ),
+        "layers.0.downward_and_forgot_after_attn.weight": torch.randn(
+            (hs + wd) // m, wd // m, dtype=torch.float32,
+        ),
+        "layers.0.mlp.gate_proj.weight": torch.randn(inter, hs, dtype=torch.float32),
+        "layers.0.mlp.up_proj.weight": torch.randn(inter, hs, dtype=torch.float32),
+        "layers.0.mlp.down_proj.weight": torch.randn(hs, inter, dtype=torch.float32),
+        "layers.0.post_attention_layernorm.weight": torch.randn(hs, dtype=torch.float32),
+        "layers.0.pre_attention_layernorm.weight": torch.randn(hs, dtype=torch.float32),
+        "layers.0.pre_vwn_layer.fc.weight": torch.randn(hs, 2 * hs, dtype=torch.float32),
+        "layers.0.pre_vwn_layer.hidden_norm.weight": torch.randn(hs, dtype=torch.float32),
+        "layers.0.pre_vwn_layer.input_layernorm.weight": torch.randn(hs, dtype=torch.float32),
+        "layers.0.pre_vwn_layer.upward.weight": torch.randn(
+            wd // m, hs // m, dtype=torch.float32,
+        ),
+        "layers.0.self_attn.q_proj.weight": torch.randn(nq * hd, hs, dtype=torch.float32),
+        "layers.0.self_attn.k_proj.weight": torch.randn(nkv * hd, hs, dtype=torch.float32),
+        "layers.0.self_attn.v_proj.weight": torch.randn(nkv * hd, hs, dtype=torch.float32),
+        "layers.0.self_attn.o_proj.weight": torch.randn(hs, nq * hd, dtype=torch.float32),
+        "layers.0.upward_after_attn.weight": torch.randn(wd // m, hs // m, dtype=torch.float32),
+        "layers.0.upward_after_mlp.weight": torch.randn(wd // m, hs // m, dtype=torch.float32),
+        "lm_head.weight": torch.randn(dv, hs, dtype=torch.float32),
+        "norm.weight": torch.randn(hs, dtype=torch.float32),
+    }
+
+
+def _make_synthetic_weights_m4_r10():
+    """Synthetic weights for m=4, r=1.0 (no downward.weight, no pre_vwn upward)."""
+    hs, m = _HIDDEN, 4
+    wd = hs  # r=1.0 => wider_dim == hidden_size
+    dv = _DRAFT_VOCAB
+    v = _VOCAB
+    inter = _INTERMEDIATE
+    nkv = _NUM_KV_HEADS
+    nq = _NUM_HEADS
+    hd = _HEAD_DIM
+    return {
+        "d2t": torch.zeros(dv, dtype=torch.long),
+        "embed_tokens.weight": torch.randn(v, hs, dtype=torch.float32),
+        "fc.weight": torch.randn(hs, hs * 3, dtype=torch.float32),
+        "layers.0.downward_and_forgot.weight": torch.randn(
+            (hs + wd) // m, wd // m, dtype=torch.float32,
+        ),
+        "layers.0.downward_and_forgot_after_attn.weight": torch.randn(
+            (hs + wd) // m, wd // m, dtype=torch.float32,
+        ),
+        "layers.0.mlp.gate_proj.weight": torch.randn(inter, hs, dtype=torch.float32),
+        "layers.0.mlp.up_proj.weight": torch.randn(inter, hs, dtype=torch.float32),
+        "layers.0.mlp.down_proj.weight": torch.randn(hs, inter, dtype=torch.float32),
+        "layers.0.post_attention_layernorm.weight": torch.randn(hs, dtype=torch.float32),
+        "layers.0.pre_attention_layernorm.weight": torch.randn(hs, dtype=torch.float32),
+        "layers.0.pre_vwn_layer.fc.weight": torch.randn(hs, 2 * hs, dtype=torch.float32),
+        "layers.0.pre_vwn_layer.hidden_norm.weight": torch.randn(hs, dtype=torch.float32),
+        "layers.0.pre_vwn_layer.input_layernorm.weight": torch.randn(hs, dtype=torch.float32),
+        "layers.0.self_attn.q_proj.weight": torch.randn(nq * hd, hs, dtype=torch.float32),
+        "layers.0.self_attn.k_proj.weight": torch.randn(nkv * hd, hs, dtype=torch.float32),
+        "layers.0.self_attn.v_proj.weight": torch.randn(nkv * hd, hs, dtype=torch.float32),
+        "layers.0.self_attn.o_proj.weight": torch.randn(hs, nq * hd, dtype=torch.float32),
+        "layers.0.upward_after_attn.weight": torch.randn(wd // m, hs // m, dtype=torch.float32),
+        "layers.0.upward_after_mlp.weight": torch.randn(wd // m, hs // m, dtype=torch.float32),
+        "lm_head.weight": torch.randn(dv, hs, dtype=torch.float32),
+        "norm.weight": torch.randn(hs, dtype=torch.float32),
+    }
+
+
+class TestWeightLoadingIntegration:
+    """Weight loading tests using synthetic weight dicts with real shapes."""
+
+    def test_load_weights_r15(self):
+        """Load all weights for m=4, r=1.5: d2t remap, t2d skip, fc loaded."""
+        vllm_config = _create_vllm_config_for_vwn(vwn_m=4, vwn_r=1.5)
+        weights = _make_synthetic_weights_m4_r15()
+        # Set d2t to non-trivial values
+        weights["d2t"] = torch.arange(_DRAFT_VOCAB, dtype=torch.long)
+        # Add a t2d entry — should be skipped without error
+        weights["t2d"] = torch.zeros(_VOCAB, dtype=torch.bool)
+        # Use a distinctive fc.weight
+        weights["fc.weight"] = torch.ones(_HIDDEN, _HIDDEN * 3, dtype=torch.float32)
+
+        with set_current_vllm_config(vllm_config):
+            model = Eagle3VwnLlamaForCausalLM(vllm_config=vllm_config, prefix="")
+            model.load_weights(weights.items())
+
+        # d2t remapped to draft_id_to_target_id
+        dit = dict(model.named_parameters())["draft_id_to_target_id"]
+        assert torch.equal(dit.data, torch.arange(_DRAFT_VOCAB, dtype=torch.long))
+
+        # fc weight loaded
+        assert model.model.fc.weight.data.abs().sum() > 0
+        assert model.model.fc.weight.shape == (_HIDDEN, _HIDDEN * 3)
+
+        # Key parameters loaded (not all-zero)
+        for name, param in model.named_parameters():
+            if "draft_id_to_target_id" in name:
+                continue
+            if "embed_tokens" in name or "lm_head" in name:
+                assert param.data.abs().sum() > 0, f"{name} not loaded"
+
+    def test_load_weights_r10(self):
+        """Load weights for m=4, r=1.0: no downward/pre_vwn upward in checkpoint.
+
+        When vwn_r=1.0, wider_dim == hidden_size, so downward and pre_vwn
+        projections are identity-sized (hs//m, hs//m).
+        """
+        vllm_config = _create_vllm_config_for_vwn(vwn_m=4, vwn_r=1.0)
+        weights = _make_synthetic_weights_m4_r10()
+        hs, m = _HIDDEN, 4
+
+        with set_current_vllm_config(vllm_config):
+            model = Eagle3VwnLlamaForCausalLM(vllm_config=vllm_config, prefix="")
+            model.load_weights(weights.items())
+
+        layer = model.model.layers[0]
+        # wd == hs when r=1.0, so dimensions are identity-sized
+        assert layer.downward.weight.shape == (hs // m, hs // m)
+        assert layer.pre_vwn_layer.upward.weight.shape == (hs // m, hs // m)

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -5,3 +5,4 @@ def register_model():
     ModelRegistry.register_model("DeepseekV4ForCausalLM", "vllm_ascend.models.deepseek_v4:AscendDeepseekV4ForCausalLM")
 
     ModelRegistry.register_model("DeepSeekV4MTPModel", "vllm_ascend.models.deepseek_v4_mtp:DeepSeekV4MTP")
+    ModelRegistry.register_model("LlamaForCausalLMVwnEagle3", "vllm_ascend.models.llama_eagle3_vwn:Eagle3VwnLlamaForCausalLM")

--- a/vllm_ascend/models/llama_eagle3_vwn.py
+++ b/vllm_ascend/models/llama_eagle3_vwn.py
@@ -1,0 +1,616 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Iterable
+
+import torch
+import torch.nn as nn
+from transformers import LlamaConfig
+
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.logger import init_logger
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.model_loader.weight_utils import (
+    default_weight_loader,
+    maybe_remap_kv_scale_name,
+)
+from vllm.model_executor.models.llama import LlamaForCausalLM, LlamaDecoderLayer
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM, LlamaModel
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.multimodal.inputs import NestedTensors
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    get_draft_quant_config,
+    maybe_prefix,
+    process_eagle_weight,
+)
+
+logger = init_logger(__name__)
+
+class PreVwnLayerV0(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+        config: LlamaConfig | None = None,
+        quant_config: QuantizationConfig = None,
+    ) -> None:
+        super().__init__()
+        config = config or vllm_config.model_config.hf_config
+        hidden_size = config.hidden_size
+        m = getattr(config, "vwn_m", 1)
+        expanded_factor = getattr(config, "vwn_r", 1)
+        wider_dim = int(hidden_size * expanded_factor)
+
+        self.wider_dim = wider_dim
+        
+        self.upward = ReplicatedLinear(
+            input_size=hidden_size,
+            output_size=wider_dim,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "upward"),
+            return_bias=False,
+        )
+        extend_size = 2 * wider_dim
+        self.extend = ReplicatedLinear(
+            input_size=wider_dim,
+            output_size=extend_size,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "extend"),
+            return_bias=False,
+        )
+        self.input_layernorm = RMSNorm(wider_dim, eps=config.rms_norm_eps)
+        self.hidden_norm = RMSNorm(wider_dim, eps=config.rms_norm_eps)
+        self.fc = ReplicatedLinear(
+            input_size=extend_size,
+            output_size=wider_dim,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "fc"),
+            return_bias=False,
+        )
+        self.full_connected = ReplicatedLinear(
+            input_size=wider_dim,
+            output_size=wider_dim,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "extend"),
+            return_bias=False,
+        )
+
+    def forward(
+        self,
+        embeds: torch.Tensor,
+        hidden_states: torch.Tensor
+    ):
+        wider_embeds = self.upward(embeds)
+        wider_hidden_states = self.upward(hidden_states)
+
+        extended_hidden_states = self.extend(wider_hidden_states)
+        hidden_states_to_cat, hidden_residual = torch.split(
+            extended_hidden_states,
+            [self.wider_dim, extended_hidden_states.shape[-1] - self.wider_dim],
+            dim=-1
+        )
+        norm_wider_embeds = self.input_layernorm(wider_embeds)
+        hidden_states_to_cat = self.hidden_norm(hidden_states_to_cat)
+        hidden_to_fc = torch.cat([norm_wider_embeds, hidden_states_to_cat], dim=-1)
+        hidden_after_fc = self.fc(hidden_to_fc)
+        hidden_before_residual = self.full_connected(hidden_after_fc)
+        wider_hidden_states = hidden_before_residual + hidden_residual
+
+        return wider_hidden_states
+
+class PreVwnLayerV1(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+        config: LlamaConfig | None = None,
+        quant_config: QuantizationConfig = None,
+    ) -> None:
+        super().__init__()
+        config = config or vllm_config.model_config.hf_config
+        hidden_size = config.hidden_size
+        m = getattr(config, "vwn_m", 1)
+        expanded_factor = getattr(config, "vwn_r", 1)
+        wider_dim = int(hidden_size * expanded_factor)
+        self.wider_dim = wider_dim
+
+        self.input_layernorm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
+        self.hidden_norm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
+        fc_input_size = 2 * hidden_size
+        self.fc = ReplicatedLinear(
+            input_size=fc_input_size,
+            output_size=hidden_size,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "fc"),
+            return_bias=False,
+        )
+        upward_input_size = hidden_size // m
+        upward_output_size = wider_dim // m
+        self.upward = ReplicatedLinear(
+            input_size=upward_input_size,
+            output_size=upward_output_size,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "upward"),
+            return_bias=False,
+        )
+        self.m = m
+        self.hidden_size = hidden_size
+        self.wider_dim = wider_dim
+
+    def forward(
+        self,
+        embeds: torch.Tensor,
+        hidden_states: torch.Tensor
+    ):
+        norm_embeds = self.input_layernorm(embeds)
+        norm_hidden = self.hidden_norm(hidden_states)
+        hidden_to_fc = torch.cat([norm_embeds, norm_hidden], dim=-1)
+        hidden_after_fc = self.fc(hidden_to_fc)
+        hidden_after_fc_new = hidden_after_fc.view(-1 , self.hidden_size // self.m)
+        wider_hidden_states_tmp = self.upward(hidden_after_fc_new)
+        wider_hidden_states = wider_hidden_states_tmp.view(-1 , self.wider_dim)
+
+        return wider_hidden_states
+
+class PreVwnLayerV2(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+        config: LlamaConfig | None = None,
+        quant_config: QuantizationConfig = None,
+    ) -> None:
+        super().__init__()
+        config = config or vllm_config.model_config.hf_config
+        hidden_size = config.hidden_size
+
+        self.input_layernorm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
+        self.hidden_norm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
+        fc_input_size = 2 * hidden_size
+        self.fc = ReplicatedLinear(
+            input_size=fc_input_size,
+            output_size=hidden_size,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "fc"),
+            return_bias=False,
+        )
+
+    def forward(
+        self,
+        embeds: torch.Tensor,
+        hidden_states: torch.Tensor
+    ):
+        norm_embeds = self.input_layernorm(embeds)
+        norm_hidden = self.hidden_norm(hidden_states)
+        hidden_to_fc = torch.cat([norm_embeds, norm_hidden], dim=-1)
+        hidden_after_fc = self.fc(hidden_to_fc)
+        return hidden_after_fc
+
+
+class VwnLlamaDecoderLayer(LlamaDecoderLayer):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+        config: LlamaConfig | None = None,
+        layer_idx: int = 0,
+    ) -> None:
+        super().__init__(vllm_config, prefix=prefix, config=config)
+
+        config = config or vllm_config.model_config.hf_config
+        quant_config = self.get_quant_config(vllm_config)
+        m = getattr(config, "vwn_m", 1)
+        expanded_factor = getattr(config, "vwn_r", 1)
+        n = int(expanded_factor * m)
+        wider_dim = int(self.hidden_size * expanded_factor)
+        self.wider_dim = wider_dim
+        self.m = m
+        upward_input_size = self.hidden_size // m
+        upward_output_size = wider_dim // m
+        pre_vwn_version = getattr(config, "pre_vwn_version", 0)
+        self.pre_vwn_version = pre_vwn_version
+        if pre_vwn_version == 0:
+            self.pre_vwn_layer = PreVwnLayerV0(
+                vllm_config,
+                prefix=maybe_prefix(prefix, f"layers.pre_vwn_layer"),
+                config=config,
+                quant_config=quant_config
+            )
+        elif pre_vwn_version == 1:
+            self.pre_vwn_layer = PreVwnLayerV1(
+                vllm_config,
+                prefix=maybe_prefix(prefix, f"layers.pre_vwn_layer"),
+                config=config,
+                quant_config=quant_config
+            )
+        else:
+            self.pre_vwn_layer = PreVwnLayerV2(
+                vllm_config,
+                prefix=maybe_prefix(prefix, f"layers.pre_vwn_layer"),
+                config=config,
+                quant_config=quant_config
+            )
+
+        self.downward_and_forgot = ReplicatedLinear(
+            input_size=wider_dim,
+            output_size=self.hidden_size + wider_dim,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "downward_and_forgot"),
+            return_bias=False,
+        )
+        
+        self.pre_attention_layernorm = RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+        self.upward_after_attn = ReplicatedLinear(
+            input_size=upward_input_size,
+            output_size=upward_output_size,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "upward_after_attn"),
+            return_bias=False,
+        )
+        self.downward_and_forgot_after_attn = ReplicatedLinear(
+            input_size=wider_dim,
+            output_size=self.hidden_size + wider_dim,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "downward_and_forgot"),
+            return_bias=False,
+        )
+        self.post_attention_layernorm = RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+        self.upward_after_mlp = ReplicatedLinear(
+            input_size=upward_input_size,
+            output_size=upward_output_size,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "upward_after_mlp"),
+            return_bias=False,
+        )
+        self.downward = ReplicatedLinear(
+            input_size=upward_output_size,
+            output_size=upward_input_size,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "downward"),
+            return_bias=False,
+        )
+
+        self.layer_idx = layer_idx
+
+    def get_quant_config(self, vllm_config: VllmConfig) -> QuantizationConfig | None:
+        """Use drafter's quantization config instead of verifier's."""
+        return get_draft_quant_config(vllm_config)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        embeds: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.layer_idx == 0:
+            # First layer: preVwn + vwn layer
+            wider_hidden_states = self.pre_vwn_layer(embeds, hidden_states)
+
+            # attn
+            total_hidden_states = self.downward_and_forgot(wider_hidden_states)
+            hidden_states, hidden_residual = torch.split(
+                total_hidden_states,
+                [self.hidden_size, total_hidden_states.shape[-1] - self.hidden_size],
+                dim=-1
+            )
+            hidden_states = self.pre_attention_layernorm(hidden_states)
+            hidden_states = self.self_attn(
+                positions=positions,
+                hidden_states=hidden_states,
+            )
+            hidden_states_view = hidden_states.view(-1, self.hidden_size // self.m)
+            upward_hidden_states_tmp = self.upward_after_attn(hidden_states_view)
+            upward_hidden_states = upward_hidden_states_tmp.view(-1, self.wider_dim)
+            wider_hidden_states = upward_hidden_states + hidden_residual
+
+            # mlp
+            total_hidden_states = self.downward_and_forgot_after_attn(wider_hidden_states)
+            hidden_states, hidden_residual = torch.split(
+                total_hidden_states,
+                [self.hidden_size, total_hidden_states.shape[-1] - self.hidden_size],
+                dim=-1
+            )
+            hidden_states = self.post_attention_layernorm(hidden_states)
+            hidden_states = self.mlp(hidden_states)
+            hidden_states_view = hidden_states.view(-1, self.hidden_size // self.m)
+            upward_hidden_states_tmp = self.upward_after_mlp(hidden_states_view)
+            upward_hidden_states = upward_hidden_states_tmp.view(-1, self.wider_dim)
+            hidden_states = upward_hidden_states + hidden_residual
+
+            # downward
+            if self.pre_vwn_version != 2:
+                wider_hidden_states_view = hidden_states.view(-1, self.wider_dim // self.m)
+                hidden_state_tmp = self.downward(wider_hidden_states_view)
+                hidden_states = hidden_state_tmp.view(-1, self.hidden_size)
+
+        return hidden_states, residual
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "hidden_states": 0,
+        "input_embeds": 0,
+    }
+)
+class VwnLlamaModel(nn.Module):
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        start_layer_id: int = 0,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.vocab_size = self.config.vocab_size
+
+        # Get drafter's quantization config
+        self.quant_config = get_draft_quant_config(vllm_config)
+
+        eagle_config = getattr(self.config, "eagle_config", None)
+        if eagle_config is not None and "use_aux_hidden_state" in eagle_config:
+            self.use_aux_hidden_state = eagle_config["use_aux_hidden_state"]
+        else:
+            self.use_aux_hidden_state = True
+
+        current_vllm_config = get_current_vllm_config()
+
+        self.embed_tokens = VocabParallelEmbedding(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            prefix=maybe_prefix(prefix, "embed_tokens"),
+        )
+
+        self.layers = nn.ModuleList(
+            [
+                VwnLlamaDecoderLayer(
+                    current_vllm_config,
+                    prefix=maybe_prefix(prefix, f"layers.{layer_idx + start_layer_id}"),
+                    config=self.config,
+                    layer_idx=layer_idx,
+                )
+                for layer_idx in range(self.config.num_hidden_layers)
+            ]
+        )
+        if self.use_aux_hidden_state:
+            if hasattr(self.config, "target_hidden_size"):
+                fc_input_size = self.config.target_hidden_size * 3
+            else:
+                fc_input_size = self.config.hidden_size * 3
+            self.fc = ReplicatedLinear(
+                input_size=fc_input_size,
+                output_size=self.config.hidden_size,
+                bias=False,
+                params_dtype=vllm_config.model_config.dtype,
+                quant_config=self.quant_config,
+                prefix=maybe_prefix(prefix, "fc"),
+                return_bias=False,
+            )
+        self.norm = RMSNorm(
+            self.config.hidden_size,
+            eps=self.config.rms_norm_eps,
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        input_embeds: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if input_embeds is None:
+            input_embeds = self.embed_input_ids(input_ids)
+        assert hidden_states.shape[-1] == input_embeds.shape[-1]
+
+        residual = None
+        for layer in self.layers:
+            hidden_states, residual = layer(
+                positions=positions,
+                embeds=input_embeds,
+                hidden_states=hidden_states,
+                residual=residual,
+            )
+        hidden_prenorm = hidden_states
+        hidden_states = self.norm(hidden_states, residual)
+        return hidden_states, hidden_prenorm
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            (".qkv_proj", ".q_proj", "q"),
+            (".qkv_proj", ".k_proj", "k"),
+            (".qkv_proj", ".v_proj", "v"),
+            (".gate_up_proj", ".gate_proj", 0),
+            (".gate_up_proj", ".up_proj", 1),
+        ]
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        for name, loaded_weight in weights:
+            if "midlayer." in name:
+                name = name.replace("midlayer.", "layers.0.")
+            # Handle kv cache quantization scales
+            if self.quant_config is not None and (
+                scale_name := self.quant_config.get_cache_scale(name)
+            ):
+                # Loading kv cache quantization scales
+                param = params_dict[scale_name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                loaded_weight = (
+                    loaded_weight if loaded_weight.dim() == 0 else loaded_weight[0]
+                )
+                weight_loader(param, loaded_weight)
+                loaded_params.add(scale_name)
+                continue
+            # Remapping the name FP8 kv-scale or zero point.
+            if "scale" in name or "zero_point" in name:
+                name = maybe_remap_kv_scale_name(name, params_dict)
+                if name is None:
+                    continue
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
+
+
+class Eagle3VwnLlamaForCausalLM(LlamaForCausalLM):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        nn.Module.__init__(self)
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        # Ensure draft_vocab_size is set
+        # default to the base vocab size when absent
+        if getattr(self.config, "draft_vocab_size", None) is None:
+            base_vocab_size = getattr(self.config, "vocab_size", None)
+            self.config.draft_vocab_size = base_vocab_size
+        target_layer_num = vllm_config.model_config.get_num_layers(
+            vllm_config.parallel_config
+        )
+
+        # Store target layer count in draft config for
+        # proper layer_types indexing in draft models
+        self.config.target_layer_count = target_layer_num
+        self.model = VwnLlamaModel(
+            vllm_config=vllm_config, prefix="model", start_layer_id=target_layer_num
+        )
+
+        logit_scale = getattr(self.config, "logit_scale", 1.0)
+        self.lm_head = ParallelLMHead(
+            self.config.draft_vocab_size,
+            self.config.hidden_size,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
+        self.logits_processor = LogitsProcessor(
+            self.config.draft_vocab_size, scale=logit_scale
+        )
+        self.draft_id_to_target_id = nn.Parameter(
+            torch.zeros(self.config.draft_vocab_size, dtype=torch.long),
+            requires_grad=False,
+        )
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: NestedTensors | None = None,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.model(input_ids, positions, hidden_states, inputs_embeds)
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor | None:
+        logits = self.logits_processor(self.lm_head, hidden_states)
+        if self.draft_id_to_target_id is None:
+            assert logits.shape[1] == self.config.vocab_size, (
+                "Expected logits to have shape "
+                f"(*, {self.config.vocab_size}), but got {logits.shape}"
+            )
+            return logits
+
+        base = torch.arange(self.config.draft_vocab_size, device=logits.device)
+        targets = base + self.draft_id_to_target_id
+        logits_new = logits.new_full(
+            (
+                logits.shape[0],
+                self.config.vocab_size,
+            ),
+            float("-inf"),
+        )
+        logits_new[:, targets] = logits
+        return logits_new
+
+    def combine_hidden_states(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        if not self.model.use_aux_hidden_state:
+            return hidden_states
+        # combine multiple auxiliary hidden states returned by eagle3
+        return self.model.fc(hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        model_weights = {}
+        includes_draft_id_mapping = False
+        includes_embed_tokens = False
+        for name, loaded_weight in weights:
+            if "t2d" in name:
+                continue
+            if "d2t" in name:
+                name = name.replace("d2t", "draft_id_to_target_id")
+                includes_draft_id_mapping = True
+            elif "lm_head" not in name:
+                name = "model." + name
+            if "embed_tokens" in name:
+                includes_embed_tokens = True
+            model_weights[name] = loaded_weight
+            process_eagle_weight(self, name)
+
+        skip_substrs = []
+        if not includes_draft_id_mapping:
+            skip_substrs.append("draft_id_to_target_id")
+        if not includes_embed_tokens:
+            skip_substrs.append("embed_tokens")
+        if not self.model.use_aux_hidden_state:
+            skip_substrs.append("fc.")
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=None,
+            skip_substrs=skip_substrs,
+        )
+        loader.load_weights(model_weights.items())

--- a/vllm_ascend/models/llama_eagle3_vwn.py
+++ b/vllm_ascend/models/llama_eagle3_vwn.py
@@ -1,583 +1,134 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from collections.abc import Iterable
-
 import torch
 import torch.nn as nn
 from transformers import LlamaConfig
 
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig, get_current_vllm_config
-from vllm.logger import init_logger
-from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.layernorm import RMSNorm
-from vllm.model_executor.layers.linear import ReplicatedLinear
-from vllm.model_executor.model_loader.weight_utils import (
-    default_weight_loader,
-    maybe_remap_kv_scale_name,
+from vllm.model_executor.layers.linear import QKVParallelLinear, ReplicatedLinear
+from vllm.model_executor.models.llama_eagle3 import (
+    Eagle3LlamaForCausalLM,
+    LlamaDecoderLayer as Eagle3LlamaDecoderLayer,
+    LlamaModel as Eagle3LlamaModel,
 )
-from vllm.model_executor.models.llama import LlamaForCausalLM, LlamaDecoderLayer
-from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
-from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM, LlamaModel
-from vllm.model_executor.layers.vocab_parallel_embedding import (
-    ParallelLMHead,
-    VocabParallelEmbedding,
-)
-from vllm.multimodal.inputs import NestedTensors
-from vllm.model_executor.models.utils import (
-    AutoWeightsLoader,
-    get_draft_quant_config,
-    maybe_prefix,
-    process_eagle_weight,
-)
+from vllm.model_executor.models.utils import maybe_prefix
 
-logger = init_logger(__name__)
 
-class PreVwnLayerV0(nn.Module):
-    def __init__(
-        self,
-        vllm_config: VllmConfig,
-        prefix: str = "",
-        config: LlamaConfig | None = None,
-        quant_config: QuantizationConfig = None,
-    ) -> None:
-        super().__init__()
-        config = config or vllm_config.model_config.hf_config
-        hidden_size = config.hidden_size
-        m = getattr(config, "vwn_m", 1)
-        expanded_factor = getattr(config, "vwn_r", 1)
-        wider_dim = int(hidden_size * expanded_factor)
+def _linear(inp, out, vc, qc, pfx):
+    return ReplicatedLinear(
+        input_size=inp, output_size=out, bias=False,
+        params_dtype=vc.model_config.dtype,
+        quant_config=qc, prefix=pfx, return_bias=False)
 
-        self.wider_dim = wider_dim
-        
-        self.upward = ReplicatedLinear(
-            input_size=hidden_size,
-            output_size=wider_dim,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "upward"),
-            return_bias=False,
-        )
-        extend_size = 2 * wider_dim
-        self.extend = ReplicatedLinear(
-            input_size=wider_dim,
-            output_size=extend_size,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "extend"),
-            return_bias=False,
-        )
-        self.input_layernorm = RMSNorm(wider_dim, eps=config.rms_norm_eps)
-        self.hidden_norm = RMSNorm(wider_dim, eps=config.rms_norm_eps)
-        self.fc = ReplicatedLinear(
-            input_size=extend_size,
-            output_size=wider_dim,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "fc"),
-            return_bias=False,
-        )
-        self.full_connected = ReplicatedLinear(
-            input_size=wider_dim,
-            output_size=wider_dim,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "extend"),
-            return_bias=False,
-        )
-
-    def forward(
-        self,
-        embeds: torch.Tensor,
-        hidden_states: torch.Tensor
-    ):
-        wider_embeds = self.upward(embeds)
-        wider_hidden_states = self.upward(hidden_states)
-
-        extended_hidden_states = self.extend(wider_hidden_states)
-        hidden_states_to_cat, hidden_residual = torch.split(
-            extended_hidden_states,
-            [self.wider_dim, extended_hidden_states.shape[-1] - self.wider_dim],
-            dim=-1
-        )
-        norm_wider_embeds = self.input_layernorm(wider_embeds)
-        hidden_states_to_cat = self.hidden_norm(hidden_states_to_cat)
-        hidden_to_fc = torch.cat([norm_wider_embeds, hidden_states_to_cat], dim=-1)
-        hidden_after_fc = self.fc(hidden_to_fc)
-        hidden_before_residual = self.full_connected(hidden_after_fc)
-        wider_hidden_states = hidden_before_residual + hidden_residual
-
-        return wider_hidden_states
 
 class PreVwnLayerV1(nn.Module):
-    def __init__(
-        self,
-        vllm_config: VllmConfig,
-        prefix: str = "",
-        config: LlamaConfig | None = None,
-        quant_config: QuantizationConfig = None,
-    ) -> None:
+    def __init__(self, vllm_config, prefix="", config=None, quant_config=None):
         super().__init__()
-        config = config or vllm_config.model_config.hf_config
-        hidden_size = config.hidden_size
-        m = getattr(config, "vwn_m", 1)
-        expanded_factor = getattr(config, "vwn_r", 1)
-        self.expnded_factor = expanded_factor
-        wider_dim = int(hidden_size * expanded_factor)
-        self.wider_dim = wider_dim
+        cfg = config or vllm_config.model_config.hf_config
+        hs, m, r = cfg.hidden_size, getattr(cfg, "vwn_m", 1), getattr(cfg, "vwn_r", 1)
+        wd = int(hs * r)
+        self.m, self.hidden_size, self.wider_dim = m, hs, wd
+        self.input_layernorm = RMSNorm(hs, eps=cfg.rms_norm_eps)
+        self.hidden_norm = RMSNorm(hs, eps=cfg.rms_norm_eps)
+        self.fc = _linear(2 * hs, hs, vllm_config, quant_config, maybe_prefix(prefix, "fc"))
+        self.upward = _linear(hs // m, wd // m, vllm_config, quant_config,
+                              maybe_prefix(prefix, "upward"))
 
-        self.input_layernorm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
-        self.hidden_norm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
-        fc_input_size = 2 * hidden_size
-        self.fc = ReplicatedLinear(
-            input_size=fc_input_size,
-            output_size=hidden_size,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "fc"),
-            return_bias=False,
-        )
-        if expanded_factor != 1:
-            upward_input_size = hidden_size // m
-            upward_output_size = wider_dim // m
-            self.upward = ReplicatedLinear(
-                input_size=upward_input_size,
-                output_size=upward_output_size,
-                bias=False,
-                params_dtype=vllm_config.model_config.dtype,
-                quant_config=quant_config,
-                prefix=maybe_prefix(prefix, "upward"),
-                return_bias=False,
-            )
-        self.m = m
-        self.hidden_size = hidden_size
-        self.wider_dim = wider_dim
+    def forward(self, embeds, hidden_states):
+        x = self.fc(torch.cat([self.input_layernorm(embeds),
+                               self.hidden_norm(hidden_states)], dim=-1))
+        return self.upward(x.view(-1, self.hidden_size // self.m)).view(-1, self.wider_dim)
 
-    def forward(
-        self,
-        embeds: torch.Tensor,
-        hidden_states: torch.Tensor
-    ):
-        norm_embeds = self.input_layernorm(embeds)
-        norm_hidden = self.hidden_norm(hidden_states)
-        hidden_to_fc = torch.cat([norm_embeds, norm_hidden], dim=-1)
-        hidden_after_fc = self.fc(hidden_to_fc)
-        if self.expnded_factor != 1:
-            hidden_after_fc_new = hidden_after_fc.view(-1 , self.hidden_size // self.m)
-            wider_hidden_states_tmp = self.upward(hidden_after_fc_new)
-            wider_hidden_states = wider_hidden_states_tmp.view(-1 , self.wider_dim)
-        else:
-            wider_hidden_states = hidden_after_fc
-        return wider_hidden_states
 
-class VwnLlamaDecoderLayer(LlamaDecoderLayer):
-    def __init__(
-        self,
-        vllm_config: VllmConfig,
-        prefix: str = "",
-        config: LlamaConfig | None = None,
-        layer_idx: int = 0,
-    ) -> None:
-        super().__init__(vllm_config, prefix=prefix, config=config)
+class VwnLlamaDecoderLayer(Eagle3LlamaDecoderLayer):
 
-        config = config or vllm_config.model_config.hf_config
-        quant_config = self.get_quant_config(vllm_config)
-        m = getattr(config, "vwn_m", 1)
-        expanded_factor = getattr(config, "vwn_r", 1)
-        self.expanded_factor = expanded_factor
-        wider_dim = int(self.hidden_size * expanded_factor)
-        self.wider_dim = wider_dim
-        self.m = m
-        upward_input_size = self.hidden_size // m
-        upward_output_size = wider_dim // m
-        downward_input_size = wider_dim // m
-        downard_output_size = (self.hidden_size + wider_dim) // m
-        pre_vwn_version = getattr(config, "pre_vwn_version", 0)
-        self.pre_vwn_version = pre_vwn_version
-        if pre_vwn_version == 0:
-            self.pre_vwn_layer = PreVwnLayerV0(
-                vllm_config,
-                prefix=maybe_prefix(prefix, f"layers.pre_vwn_layer"),
-                config=config,
-                quant_config=quant_config
-            )
-        elif pre_vwn_version == 1:
-            self.pre_vwn_layer = PreVwnLayerV1(
-                vllm_config,
-                prefix=maybe_prefix(prefix, f"layers.pre_vwn_layer"),
-                config=config,
-                quant_config=quant_config
-            )
+    def __init__(self, vllm_config, prefix="", config=None, layer_idx=0):
+        super().__init__(vllm_config, prefix=prefix, config=config, layer_idx=layer_idx)
+        cfg = config or vllm_config.model_config.hf_config
+        qc = self.get_quant_config(vllm_config)
+        m, r = getattr(cfg, "vwn_m", 1), getattr(cfg, "vwn_r", 1)
+        hs, wd = self.hidden_size, int(self.hidden_size * r)
+        self.m, self.wider_dim, self.layer_idx = m, wd, layer_idx
 
-        self.downward_and_forgot = ReplicatedLinear(
-            input_size=downward_input_size,
-            output_size=downard_output_size,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "downward_and_forgot"),
-            return_bias=False,
-        )
-        
-        self.pre_attention_layernorm = RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
-        self.upward_after_attn = ReplicatedLinear(
-            input_size=upward_input_size,
-            output_size=upward_output_size,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "upward_after_attn"),
-            return_bias=False,
-        )
-        self.downward_and_forgot_after_attn = ReplicatedLinear(
-            input_size=downward_input_size,
-            output_size=downard_output_size,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "downward_and_forgot"),
-            return_bias=False,
-        )
-        self.post_attention_layernorm = RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
-        self.upward_after_mlp = ReplicatedLinear(
-            input_size=upward_input_size,
-            output_size=upward_output_size,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "upward_after_mlp"),
-            return_bias=False,
-        )
-        if self.expanded_factor != 1:
-            self.downward = ReplicatedLinear(
-                input_size=upward_output_size,
-                output_size=upward_input_size,
-                bias=False,
-                params_dtype=vllm_config.model_config.dtype,
-                quant_config=quant_config,
-                prefix=maybe_prefix(prefix, "downward"),
-                return_bias=False,
-            )
+        # VWN feeds hidden_size (not 2*hidden_size) into attention,
+        # restore qkv_proj overridden by the parent eagle3 decoder.
+        if layer_idx == 0:
+            self.self_attn.qkv_proj = QKVParallelLinear(
+                hs, self.self_attn.head_dim,
+                self.self_attn.total_num_heads, self.self_attn.total_num_kv_heads,
+                bias=getattr(cfg, "attention_bias", False), quant_config=qc,
+                prefix=maybe_prefix(prefix, "self_attn.qkv_proj"))
 
-        self.layer_idx = layer_idx
+        mp = maybe_prefix
+        self.pre_vwn_layer = PreVwnLayerV1(vllm_config, mp(prefix, "layers.pre_vwn_layer"),
+                                           cfg, qc)
+        self.downward_and_forgot = _linear(wd // m, (hs + wd) // m, vllm_config, qc,
+                                           mp(prefix, "downward_and_forgot"))
+        self.pre_attention_layernorm = RMSNorm(hs, eps=cfg.rms_norm_eps)
+        self.upward_after_attn = _linear(hs // m, wd // m, vllm_config, qc,
+                                         mp(prefix, "upward_after_attn"))
+        self.downward_and_forgot_after_attn = _linear(
+            wd // m, (hs + wd) // m, vllm_config, qc, mp(prefix, "downward_and_forgot"))
+        self.post_attention_layernorm = RMSNorm(hs, eps=cfg.rms_norm_eps)
+        self.upward_after_mlp = _linear(hs // m, wd // m, vllm_config, qc,
+                                        mp(prefix, "upward_after_mlp"))
+        self.downward = _linear(wd // m, hs // m, vllm_config, qc, mp(prefix, "downward"))
 
-    def get_quant_config(self, vllm_config: VllmConfig) -> QuantizationConfig | None:
-        """Use drafter's quantization config instead of verifier's."""
-        return get_draft_quant_config(vllm_config)
-
-    def forward(
-        self,
-        positions: torch.Tensor,
-        embeds: torch.Tensor,
-        hidden_states: torch.Tensor,
-        residual: torch.Tensor | None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    def forward(self, positions, embeds, hidden_states, residual):
         if self.layer_idx == 0:
-            # First layer: preVwn + vwn layer
-            wider_hidden_states = self.pre_vwn_layer(embeds, hidden_states)
-
-            # attn
-            wider_hidden_states_view = wider_hidden_states.view(-1, self.wider_dim // self.m)
-            downward_wider_hidden_states_tmp = self.downward_and_forgot(wider_hidden_states_view)
-            total_hidden_states = downward_wider_hidden_states_tmp.view(-1, self.hidden_size + self.wider_dim)
-            hidden_states, hidden_residual = torch.split(
-                total_hidden_states,
-                [self.hidden_size, total_hidden_states.shape[-1] - self.hidden_size],
-                dim=-1
-            )
-            hidden_states = self.pre_attention_layernorm(hidden_states)
-            hidden_states = self.self_attn(
+            hs, wd, m = self.hidden_size, self.wider_dim, self.m
+            wider = self.pre_vwn_layer(embeds, hidden_states)
+            # Attention
+            out = self.downward_and_forgot(wider.view(-1, wd // m)).view(-1, hs + wd)
+            hidden, res = out.split([hs, wd], dim=-1)
+            hidden = self.self_attn(
                 positions=positions,
-                hidden_states=hidden_states,
-            )
-            hidden_states_view = hidden_states.view(-1, self.hidden_size // self.m)
-            upward_hidden_states_tmp = self.upward_after_attn(hidden_states_view)
-            upward_hidden_states = upward_hidden_states_tmp.view(-1, self.wider_dim)
-            wider_hidden_states = upward_hidden_states + hidden_residual
-
-            # mlp
-            wider_hidden_states_view =  wider_hidden_states.view(-1, self.wider_dim//self.m)
-            downward_wider_hidden_states_tmp = self.downward_and_forgot_after_attn(wider_hidden_states_view)
-            total_hidden_states = downward_wider_hidden_states_tmp.view(-1, self.hidden_size + self.wider_dim)
-            hidden_states, hidden_residual = torch.split(
-                total_hidden_states,
-                [self.hidden_size, total_hidden_states.shape[-1] - self.hidden_size],
-                dim=-1
-            )
-            hidden_states = self.post_attention_layernorm(hidden_states)
-            hidden_states = self.mlp(hidden_states)
-            hidden_states_view = hidden_states.view(-1, self.hidden_size // self.m)
-            upward_hidden_states_tmp = self.upward_after_mlp(hidden_states_view)
-            upward_hidden_states = upward_hidden_states_tmp.view(-1, self.wider_dim)
-            hidden_states = upward_hidden_states + hidden_residual
-
-            # downward
-            if self.expanded_factor != 1:
-                wider_hidden_states_view = hidden_states.view(-1, self.wider_dim // self.m)
-                hidden_state_tmp = self.downward(wider_hidden_states_view)
-                hidden_states = hidden_state_tmp.view(-1, self.hidden_size)
-
+                hidden_states=self.pre_attention_layernorm(hidden))
+            wider = self.upward_after_attn(hidden.view(-1, hs // m)).view(-1, wd) + res
+            # MLP
+            out = self.downward_and_forgot_after_attn(
+                wider.view(-1, wd // m)).view(-1, hs + wd)
+            hidden, res = out.split([hs, wd], dim=-1)
+            wider = self.upward_after_mlp(
+                self.mlp(self.post_attention_layernorm(hidden)).view(-1, hs // m)
+                ).view(-1, wd) + res
+            # Downward
+            hidden_states = self.downward(wider.view(-1, wd // m)).view(-1, hs)
         return hidden_states, residual
 
 
 @support_torch_compile(
-    dynamic_arg_dims={
-        "input_ids": 0,
-        "positions": -1,
-        "hidden_states": 0,
-        "input_embeds": 0,
-    }
-)
-class VwnLlamaModel(nn.Module):
-    def __init__(
-        self,
-        *,
-        vllm_config: VllmConfig,
-        start_layer_id: int = 0,
-        prefix: str = "",
-    ) -> None:
-        super().__init__()
-        self.config = vllm_config.speculative_config.draft_model_config.hf_config
-        self.vocab_size = self.config.vocab_size
+    dynamic_arg_dims={"input_ids": 0, "positions": -1,
+                      "hidden_states": 0, "input_embeds": 0})
+class VwnLlamaModel(Eagle3LlamaModel):
 
-        # Get drafter's quantization config
-        self.quant_config = get_draft_quant_config(vllm_config)
+    def __init__(self, *, vllm_config, start_layer_id=0, prefix=""):
+        super().__init__(vllm_config=vllm_config, start_layer_id=start_layer_id,
+                         prefix=prefix)
+        vc = get_current_vllm_config()
+        self.layers = nn.ModuleList([
+            VwnLlamaDecoderLayer(vc, maybe_prefix(prefix, f"layers.{i + start_layer_id}"),
+                                 self.config, layer_idx=i)
+            for i in range(self.config.num_hidden_layers)])
 
-        eagle_config = getattr(self.config, "eagle_config", None)
-        if eagle_config is not None and "use_aux_hidden_state" in eagle_config:
-            self.use_aux_hidden_state = eagle_config["use_aux_hidden_state"]
-        else:
-            self.use_aux_hidden_state = True
-
-        current_vllm_config = get_current_vllm_config()
-
-        self.embed_tokens = VocabParallelEmbedding(
-            self.config.vocab_size,
-            self.config.hidden_size,
-            prefix=maybe_prefix(prefix, "embed_tokens"),
-        )
-
-        self.layers = nn.ModuleList(
-            [
-                VwnLlamaDecoderLayer(
-                    current_vllm_config,
-                    prefix=maybe_prefix(prefix, f"layers.{layer_idx + start_layer_id}"),
-                    config=self.config,
-                    layer_idx=layer_idx,
-                )
-                for layer_idx in range(self.config.num_hidden_layers)
-            ]
-        )
-        if self.use_aux_hidden_state:
-            if hasattr(self.config, "target_hidden_size"):
-                fc_input_size = self.config.target_hidden_size * 3
-            else:
-                fc_input_size = self.config.hidden_size * 3
-            self.fc = ReplicatedLinear(
-                input_size=fc_input_size,
-                output_size=self.config.hidden_size,
-                bias=False,
-                params_dtype=vllm_config.model_config.dtype,
-                quant_config=self.quant_config,
-                prefix=maybe_prefix(prefix, "fc"),
-                return_bias=False,
-            )
-        self.norm = RMSNorm(
-            self.config.hidden_size,
-            eps=self.config.rms_norm_eps,
-        )
-
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.embed_tokens(input_ids)
-
-    def forward(
-        self,
-        input_ids: torch.Tensor,
-        positions: torch.Tensor,
-        hidden_states: torch.Tensor,
-        input_embeds: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    def forward(self, input_ids, positions, hidden_states, input_embeds=None):
         if input_embeds is None:
             input_embeds = self.embed_input_ids(input_ids)
-        assert hidden_states.shape[-1] == input_embeds.shape[-1]
-
         residual = None
         for layer in self.layers:
             hidden_states, residual = layer(
-                positions=positions,
-                embeds=input_embeds,
-                hidden_states=hidden_states,
-                residual=residual,
-            )
-        hidden_prenorm = hidden_states
-        hidden_states = self.norm(hidden_states, residual)
-        return hidden_states, hidden_prenorm
-
-    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        stacked_params_mapping = [
-            # (param_name, shard_name, shard_id)
-            (".qkv_proj", ".q_proj", "q"),
-            (".qkv_proj", ".k_proj", "k"),
-            (".qkv_proj", ".v_proj", "v"),
-            (".gate_up_proj", ".gate_proj", 0),
-            (".gate_up_proj", ".up_proj", 1),
-        ]
-        params_dict = dict(self.named_parameters())
-        loaded_params: set[str] = set()
-        for name, loaded_weight in weights:
-            if "midlayer." in name:
-                name = name.replace("midlayer.", "layers.0.")
-            # Handle kv cache quantization scales
-            if self.quant_config is not None and (
-                scale_name := self.quant_config.get_cache_scale(name)
-            ):
-                # Loading kv cache quantization scales
-                param = params_dict[scale_name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                loaded_weight = (
-                    loaded_weight if loaded_weight.dim() == 0 else loaded_weight[0]
-                )
-                weight_loader(param, loaded_weight)
-                loaded_params.add(scale_name)
-                continue
-            # Remapping the name FP8 kv-scale or zero point.
-            if "scale" in name or "zero_point" in name:
-                name = maybe_remap_kv_scale_name(name, params_dict)
-                if name is None:
-                    continue
-            for param_name, weight_name, shard_id in stacked_params_mapping:
-                if weight_name not in name:
-                    continue
-                name = name.replace(weight_name, param_name)
-                param = params_dict[name]
-                weight_loader = param.weight_loader
-                weight_loader(param, loaded_weight, shard_id)
-                break
-            else:
-                param = params_dict[name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                weight_loader(param, loaded_weight)
-            loaded_params.add(name)
-        return loaded_params
+                positions=positions, embeds=input_embeds,
+                hidden_states=hidden_states, residual=residual)
+        return self.norm(hidden_states, residual), hidden_states
 
 
-class Eagle3VwnLlamaForCausalLM(LlamaForCausalLM):
-    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
-        nn.Module.__init__(self)
-        self.config = vllm_config.speculative_config.draft_model_config.hf_config
-        # Ensure draft_vocab_size is set
-        # default to the base vocab size when absent
-        if getattr(self.config, "draft_vocab_size", None) is None:
-            base_vocab_size = getattr(self.config, "vocab_size", None)
-            self.config.draft_vocab_size = base_vocab_size
-        target_layer_num = vllm_config.model_config.get_num_layers(
-            vllm_config.parallel_config
-        )
+class Eagle3VwnLlamaForCausalLM(Eagle3LlamaForCausalLM):
 
-        # Store target layer count in draft config for
-        # proper layer_types indexing in draft models
-        self.config.target_layer_count = target_layer_num
-        self.model = VwnLlamaModel(
-            vllm_config=vllm_config, prefix="model", start_layer_id=target_layer_num
-        )
-
-        logit_scale = getattr(self.config, "logit_scale", 1.0)
-        self.lm_head = ParallelLMHead(
-            self.config.draft_vocab_size,
-            self.config.hidden_size,
-            prefix=maybe_prefix(prefix, "lm_head"),
-        )
-        self.logits_processor = LogitsProcessor(
-            self.config.draft_vocab_size, scale=logit_scale
-        )
-        self.draft_id_to_target_id = nn.Parameter(
-            torch.zeros(self.config.draft_vocab_size, dtype=torch.long),
-            requires_grad=False,
-        )
-
-    def embed_input_ids(
-        self,
-        input_ids: torch.Tensor,
-        multimodal_embeddings: NestedTensors | None = None,
-        is_multimodal: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        return self.model.embed_input_ids(input_ids)
-
-    def forward(
-        self,
-        input_ids: torch.Tensor,
-        positions: torch.Tensor,
-        hidden_states: torch.Tensor,
-        inputs_embeds: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        return self.model(input_ids, positions, hidden_states, inputs_embeds)
-
-    def compute_logits(
-        self,
-        hidden_states: torch.Tensor,
-    ) -> torch.Tensor | None:
-        logits = self.logits_processor(self.lm_head, hidden_states)
-        if self.draft_id_to_target_id is None:
-            assert logits.shape[1] == self.config.vocab_size, (
-                "Expected logits to have shape "
-                f"(*, {self.config.vocab_size}), but got {logits.shape}"
-            )
-            return logits
-
-        base = torch.arange(self.config.draft_vocab_size, device=logits.device)
-        targets = base + self.draft_id_to_target_id
-        logits_new = logits.new_full(
-            (
-                logits.shape[0],
-                self.config.vocab_size,
-            ),
-            float("-inf"),
-        )
-        logits_new[:, targets] = logits
-        return logits_new
-
-    def combine_hidden_states(
-        self,
-        hidden_states: torch.Tensor,
-    ) -> torch.Tensor:
-        if not self.model.use_aux_hidden_state:
-            return hidden_states
-        # combine multiple auxiliary hidden states returned by eagle3
-        return self.model.fc(hidden_states)
-
-    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
-        model_weights = {}
-        includes_draft_id_mapping = False
-        includes_embed_tokens = False
-        for name, loaded_weight in weights:
-            if "t2d" in name:
-                continue
-            if "d2t" in name:
-                name = name.replace("d2t", "draft_id_to_target_id")
-                includes_draft_id_mapping = True
-            elif "lm_head" not in name:
-                name = "model." + name
-            if "embed_tokens" in name:
-                includes_embed_tokens = True
-            model_weights[name] = loaded_weight
-            process_eagle_weight(self, name)
-
-        skip_substrs = []
-        if not includes_draft_id_mapping:
-            skip_substrs.append("draft_id_to_target_id")
-        if not includes_embed_tokens:
-            skip_substrs.append("embed_tokens")
-        if not self.model.use_aux_hidden_state:
-            skip_substrs.append("fc.")
-        loader = AutoWeightsLoader(
-            self,
-            skip_prefixes=None,
-            skip_substrs=skip_substrs,
-        )
-        loader.load_weights(model_weights.items())
+    def __init__(self, *, vllm_config, prefix=""):
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        n = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
+        self.model = VwnLlamaModel(vllm_config=vllm_config, prefix="model",
+                                   start_layer_id=n)

--- a/vllm_ascend/models/llama_eagle3_vwn.py
+++ b/vllm_ascend/models/llama_eagle3_vwn.py
@@ -127,6 +127,7 @@ class PreVwnLayerV1(nn.Module):
         hidden_size = config.hidden_size
         m = getattr(config, "vwn_m", 1)
         expanded_factor = getattr(config, "vwn_r", 1)
+        self.expnded_factor = expanded_factor
         wider_dim = int(hidden_size * expanded_factor)
         self.wider_dim = wider_dim
 
@@ -142,17 +143,18 @@ class PreVwnLayerV1(nn.Module):
             prefix=maybe_prefix(prefix, "fc"),
             return_bias=False,
         )
-        upward_input_size = hidden_size // m
-        upward_output_size = wider_dim // m
-        self.upward = ReplicatedLinear(
-            input_size=upward_input_size,
-            output_size=upward_output_size,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "upward"),
-            return_bias=False,
-        )
+        if expanded_factor != 1:
+            upward_input_size = hidden_size // m
+            upward_output_size = wider_dim // m
+            self.upward = ReplicatedLinear(
+                input_size=upward_input_size,
+                output_size=upward_output_size,
+                bias=False,
+                params_dtype=vllm_config.model_config.dtype,
+                quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "upward"),
+                return_bias=False,
+            )
         self.m = m
         self.hidden_size = hidden_size
         self.wider_dim = wider_dim
@@ -166,48 +168,13 @@ class PreVwnLayerV1(nn.Module):
         norm_hidden = self.hidden_norm(hidden_states)
         hidden_to_fc = torch.cat([norm_embeds, norm_hidden], dim=-1)
         hidden_after_fc = self.fc(hidden_to_fc)
-        hidden_after_fc_new = hidden_after_fc.view(-1 , self.hidden_size // self.m)
-        wider_hidden_states_tmp = self.upward(hidden_after_fc_new)
-        wider_hidden_states = wider_hidden_states_tmp.view(-1 , self.wider_dim)
-
+        if self.expnded_factor != 1:
+            hidden_after_fc_new = hidden_after_fc.view(-1 , self.hidden_size // self.m)
+            wider_hidden_states_tmp = self.upward(hidden_after_fc_new)
+            wider_hidden_states = wider_hidden_states_tmp.view(-1 , self.wider_dim)
+        else:
+            wider_hidden_states = hidden_after_fc
         return wider_hidden_states
-
-class PreVwnLayerV2(nn.Module):
-    def __init__(
-        self,
-        vllm_config: VllmConfig,
-        prefix: str = "",
-        config: LlamaConfig | None = None,
-        quant_config: QuantizationConfig = None,
-    ) -> None:
-        super().__init__()
-        config = config or vllm_config.model_config.hf_config
-        hidden_size = config.hidden_size
-
-        self.input_layernorm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
-        self.hidden_norm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
-        fc_input_size = 2 * hidden_size
-        self.fc = ReplicatedLinear(
-            input_size=fc_input_size,
-            output_size=hidden_size,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "fc"),
-            return_bias=False,
-        )
-
-    def forward(
-        self,
-        embeds: torch.Tensor,
-        hidden_states: torch.Tensor
-    ):
-        norm_embeds = self.input_layernorm(embeds)
-        norm_hidden = self.hidden_norm(hidden_states)
-        hidden_to_fc = torch.cat([norm_embeds, norm_hidden], dim=-1)
-        hidden_after_fc = self.fc(hidden_to_fc)
-        return hidden_after_fc
-
 
 class VwnLlamaDecoderLayer(LlamaDecoderLayer):
     def __init__(
@@ -223,12 +190,14 @@ class VwnLlamaDecoderLayer(LlamaDecoderLayer):
         quant_config = self.get_quant_config(vllm_config)
         m = getattr(config, "vwn_m", 1)
         expanded_factor = getattr(config, "vwn_r", 1)
-        n = int(expanded_factor * m)
+        self.expanded_factor = expanded_factor
         wider_dim = int(self.hidden_size * expanded_factor)
         self.wider_dim = wider_dim
         self.m = m
         upward_input_size = self.hidden_size // m
         upward_output_size = wider_dim // m
+        downward_input_size = wider_dim // m
+        downard_output_size = (self.hidden_size + wider_dim) // m
         pre_vwn_version = getattr(config, "pre_vwn_version", 0)
         self.pre_vwn_version = pre_vwn_version
         if pre_vwn_version == 0:
@@ -245,17 +214,10 @@ class VwnLlamaDecoderLayer(LlamaDecoderLayer):
                 config=config,
                 quant_config=quant_config
             )
-        else:
-            self.pre_vwn_layer = PreVwnLayerV2(
-                vllm_config,
-                prefix=maybe_prefix(prefix, f"layers.pre_vwn_layer"),
-                config=config,
-                quant_config=quant_config
-            )
 
         self.downward_and_forgot = ReplicatedLinear(
-            input_size=wider_dim,
-            output_size=self.hidden_size + wider_dim,
+            input_size=downward_input_size,
+            output_size=downard_output_size,
             bias=False,
             params_dtype=vllm_config.model_config.dtype,
             quant_config=quant_config,
@@ -274,8 +236,8 @@ class VwnLlamaDecoderLayer(LlamaDecoderLayer):
             return_bias=False,
         )
         self.downward_and_forgot_after_attn = ReplicatedLinear(
-            input_size=wider_dim,
-            output_size=self.hidden_size + wider_dim,
+            input_size=downward_input_size,
+            output_size=downard_output_size,
             bias=False,
             params_dtype=vllm_config.model_config.dtype,
             quant_config=quant_config,
@@ -292,15 +254,16 @@ class VwnLlamaDecoderLayer(LlamaDecoderLayer):
             prefix=maybe_prefix(prefix, "upward_after_mlp"),
             return_bias=False,
         )
-        self.downward = ReplicatedLinear(
-            input_size=upward_output_size,
-            output_size=upward_input_size,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "downward"),
-            return_bias=False,
-        )
+        if self.expanded_factor != 1:
+            self.downward = ReplicatedLinear(
+                input_size=upward_output_size,
+                output_size=upward_input_size,
+                bias=False,
+                params_dtype=vllm_config.model_config.dtype,
+                quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "downward"),
+                return_bias=False,
+            )
 
         self.layer_idx = layer_idx
 
@@ -320,7 +283,9 @@ class VwnLlamaDecoderLayer(LlamaDecoderLayer):
             wider_hidden_states = self.pre_vwn_layer(embeds, hidden_states)
 
             # attn
-            total_hidden_states = self.downward_and_forgot(wider_hidden_states)
+            wider_hidden_states_view = wider_hidden_states.view(-1, self.wider_dim // self.m)
+            downward_wider_hidden_states_tmp = self.downward_and_forgot(wider_hidden_states_view)
+            total_hidden_states = downward_wider_hidden_states_tmp.view(-1, self.hidden_size + self.wider_dim)
             hidden_states, hidden_residual = torch.split(
                 total_hidden_states,
                 [self.hidden_size, total_hidden_states.shape[-1] - self.hidden_size],
@@ -337,7 +302,9 @@ class VwnLlamaDecoderLayer(LlamaDecoderLayer):
             wider_hidden_states = upward_hidden_states + hidden_residual
 
             # mlp
-            total_hidden_states = self.downward_and_forgot_after_attn(wider_hidden_states)
+            wider_hidden_states_view =  wider_hidden_states.view(-1, self.wider_dim//self.m)
+            downward_wider_hidden_states_tmp = self.downward_and_forgot_after_attn(wider_hidden_states_view)
+            total_hidden_states = downward_wider_hidden_states_tmp.view(-1, self.hidden_size + self.wider_dim)
             hidden_states, hidden_residual = torch.split(
                 total_hidden_states,
                 [self.hidden_size, total_hidden_states.shape[-1] - self.hidden_size],
@@ -351,7 +318,7 @@ class VwnLlamaDecoderLayer(LlamaDecoderLayer):
             hidden_states = upward_hidden_states + hidden_residual
 
             # downward
-            if self.pre_vwn_version != 2:
+            if self.expanded_factor != 1:
                 wider_hidden_states_view = hidden_states.view(-1, self.wider_dim // self.m)
                 hidden_state_tmp = self.downward(wider_hidden_states_view)
                 hidden_states = hidden_state_tmp.view(-1, self.hidden_size)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -44,6 +44,7 @@ from vllm.v1.spec_decode.utils import (
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.models.llama_eagle3_vwn import Eagle3VwnLlamaForCausalLM
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
@@ -612,7 +613,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         if self.method in ("eagle3", "dflash"):
             assert isinstance(
-                self.get_model(), (Eagle3LlamaForCausalLM, DFlashQwen3ForCausalLM, Eagle3DeepseekV2ForCausalLM)
+                self.get_model(), (Eagle3LlamaForCausalLM,
+                                                 DFlashQwen3ForCausalLM,
+                                                 Eagle3VwnLlamaForCausalLM,
+                                                 Eagle3DeepseekV2ForCausalLM)
             )
             target_hidden_states = self.model.combine_hidden_states(target_hidden_states)
             assert target_hidden_states.shape[-1] == self.hidden_size


### PR DESCRIPTION
### What this PR does / why we need it?

We add UT for our customized speculative model 'VWN Eagle3' (https://github.com/vllm-project/vllm-ascend/pull/10042)
具体用例以及作用汇总如下：

| 类别 | 测试方法 | 涵盖范围 |
|------|---------|---------|
| **TestPreVwnLayerV1** (1→4) | `test_init_and_forward[m=1,r=1.5]` — init dims + forward shape | 无微分割 + 宽度扩展 |
| | `test_init_and_forward[m=4,r=1.5]` — init dims + forward shape | 标准微分割 + 宽度扩展 |
| | `test_init_and_forward[m=4,r=1.0]` — init dims + forward shape | 微分割 + 无宽度扩展 (wd==hs) |
| | `test_init_and_forward[m=1,r=1.0]` — init dims + forward shape | 最简配置 |
| **TestVwnLlamaDecoderLayer** (4→7) | `test_init_vwn_projections[m=4,r=1.5]` — VWN 子模块 + 维度簿记 | 标准配置初始化 |
| | `test_init_vwn_projections[m=4,r=1.0]` — VWN 子模块 + 维度簿记 | r=1.0 初始化 |
| | `test_init_vwn_projections[m=1,r=1.5]` — VWN 子模块 + 维度簿记 | 无微分割初始化 |
| | `test_forward_layer0[m=4,r=1.5,batch=4]` — VWN 前向传播 | 标准 forward |
| | `test_forward_layer0[m=4,r=1.0,batch=4]` — VWN 前向传播 | r=1.0 forward |
| | `test_forward_layer0[m=1,r=1.5,batch=4]` — VWN 前向传播 | 无微分割 forward |
| | `test_forward_layer0[m=4,r=1.5,batch=1]` — VWN 前向传播 | 单 token decode 场景 |
| | `test_forward_layer_nonzero_passthrough` — layer_idx≠0 跳过 VWN | layer 路由：非零层直通 |
| | `test_qkv_proj_input_size_layer0` — 断言 qkv_proj.input_size==hs | **关键** VWN 对 Eagle3 的覆盖差异 |
| **TestVwnLlamaModel** (2→3) | `test_init_and_forward[layers=1]` — 层数/类型 + forward | 单层模型主体 |
| | `test_init_and_forward[layers=2]` — layer_idx 路由 + forward | 多层：仅 layer0 执行 VWN |
| | `test_forward_with_input_embeds` — 显式 input_embeds | 跳过 embedding lookup |
| **TestEagle3VwnLlamaForCausalLM** (5→8) | `test_init_and_forward[m=4]` — 创建 VwnLlamaModel + forward | 标准完整模型 |
| | `test_init_and_forward[m=1]` — 无微分割 forward | 最简完整模型 |
| | `test_embed_input_ids` — embedding 输出 shape | token → embedding |
| | `test_compute_logits_output_shape_and_mapping` — mock logits_processor，验证 shape + -inf 映射 | draft→target 词表映射 |
| | `test_combine_hidden_states[use_aux=True]` — 3×hs → hs | FC 投影路径 |
| | `test_combine_hidden_states[use_aux=False]` — 返回输入不变 | 恒等返回路径 |
| | `test_vwn_parameters_and_count` — VWN 参数存在 + 总数=454,607,032 | 结构正确性 + 参数计数 |
| **TestWeightLoadingIntegration** (2) | `test_load_weights_r15` — d2t 重映射 + t2d 跳过 + fc 加载 + 关键参数非零 | r=1.5 全量权重加载 |
| | `test_load_weights_r10` — 无 downward/upward + shape=(512,512) | r=1.0 降级权重加载 |

### Does this PR introduce _any_ user-facing change?
Nope

### How was this patch tested?
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
