### PR TITLE
[E2E] Add E2E tests for VWN Eagle3

### DIFF
--- a/tests/e2e/pull_request/four_card/spec_decode/test_vwn_eagle3.py
+++ b/tests/e2e/pull_request/four_card/spec_decode/test_vwn_eagle3.py
@@ -1,0 +1,411 @@
+"""E2E acceptance tests for VWN-Eagle3 speculative decoding (TP=4, 4 NPU).
+
+Test Matrix
+-----------
++----------------------------------------------+-------------+-------------+------------+---------------------+
+| Test                                         | Scheduling   | Padded Batch | max_tokens | Assertion           |
++----------------------------------------------+-------------+-------------+------------+---------------------+
+| test_vwn_eagle3_acceptance_tp4               | async=True  | enabled     | 256        | acceptance vs golden |
+| test_vwn_eagle3_correctness_tp4              | default     | enabled     | 64         | non-empty output    |
+| test_vwn_eagle3_acceptance_tp4_async_false   | async=False | enabled     | 256        | acceptance vs golden |
+| test_vwn_eagle3_disable_padded_drafter_batch | default     | disabled    | 64         | non-empty output    |
+| test_vwn_eagle3_longer_generation_tp4        | default     | enabled     | 512        | non-empty output    |
++----------------------------------------------+-------------+-------------+------------+---------------------+
+
+Config: main=Qwen/Qwen3-30B-A3B, draft=ascend/vwn_eagle3, TP=4, num_speculative_tokens=3
+
+Run:
+    pytest tests/e2e/pull_request/four_card/spec_decode/test_vwn_eagle3.py
+"""
+
+import os
+
+import pytest
+from transformers import AutoTokenizer
+from vllm import SamplingParams
+from vllm.config import CompilationConfig
+from vllm.tokenizers.registry import resolve_tokenizer_args
+from vllm.v1.metrics.reader import Counter, Vector
+
+from tests.e2e.conftest import VllmRunner, cleanup_dist_env_and_memory
+
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+MAIN_MODEL = "Qwen/Qwen3-30B-A3B"
+SPEC_MODEL = "ascend/vwn_eagle3"
+
+
+@pytest.mark.parametrize("async_scheduling", [True])
+def test_vwn_eagle3_acceptance_tp4(async_scheduling):
+    """Test VWN-Eagle3 acceptance rate with TP=4.
+
+    Validates that the acceptance-per-position metric is within reasonable
+    bounds. Golden values are established from baseline runs and may need
+    updating when the model or serving config changes.
+    """
+    # Golden acceptance-per-position (3 speculative tokens).
+    # Update after first run if values shift.
+    golden = [0.50, 0.25, 0.10]
+
+    tokenizer_path = resolve_tokenizer_args(MAIN_MODEL)[1]
+    tokenizer = AutoTokenizer.from_pretrained(
+        tokenizer_path,
+        trust_remote_code=True,
+    )
+
+    example_prompts = [
+        {"role": "user", "content": "Hello, my name is"},
+        {"role": "user", "content": "The president of the United States is"},
+        {"role": "user", "content": "The capital of France is"},
+        {"role": "user", "content": "The future of AI is"},
+    ]
+    prompts = [
+        tokenizer.apply_chat_template(
+            [p],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        for p in example_prompts
+    ]
+
+    sampling_params = SamplingParams(
+        temperature=0,
+        ignore_eos=False,
+        max_tokens=256,
+    )
+
+    speculative_config = {
+        "method": "eagle3",
+        "model": SPEC_MODEL,
+        "num_speculative_tokens": 3,
+        "draft_tensor_parallel_size": 1,
+        "disable_padded_drafter_batch": False,
+    }
+
+    compilation_config = CompilationConfig(
+        cudagraph_mode="FULL_DECODE_ONLY",
+        cudagraph_capture_sizes=[20],
+    )
+
+    with VllmRunner(
+        MAIN_MODEL,
+        tensor_parallel_size=4,
+        max_model_len=4096,
+        gpu_memory_utilization=0.8,
+        disable_log_stats=False,
+        distributed_executor_backend="mp",
+        speculative_config=speculative_config,
+        compilation_config=compilation_config,
+        async_scheduling=async_scheduling,
+    ) as llm:
+        outputs = llm.model.generate(prompts, sampling_params)
+        metrics = llm.model.get_metrics()
+
+    for output in outputs:
+        print(f"Prompt: {output.prompt!r}")
+        print(f"Generated: {output.outputs[0].text!r}")
+
+    # Calculate acceptance per position
+    num_drafts = 0
+    num_accepted_tokens_per_pos = [0] * 3
+    for metric in metrics:
+        if metric.name == "vllm:spec_decode_num_drafts":
+            assert isinstance(metric, Counter)
+            num_drafts += metric.value
+        elif metric.name == "vllm:spec_decode_num_accepted_tokens_per_pos":
+            assert isinstance(metric, Vector)
+            for pos in range(len(metric.values)):
+                num_accepted_tokens_per_pos[pos] += metric.values[pos]
+
+    acceptance_per_pos = [
+        n / num_drafts for n in num_accepted_tokens_per_pos
+    ]
+
+    print(f"acceptance_per_pos: {acceptance_per_pos}")
+    print(f"golden: {golden}")
+    assert len(acceptance_per_pos) == 3
+
+    # Validate acceptance rates are within tolerance of golden values.
+    # Use a wide tolerance initially; tighten after collecting baseline data.
+    match = all(abs(a - b) < 0.15 for a, b in zip(acceptance_per_pos, golden))
+    if not match:
+        print("WARNING: acceptance rates differ from golden baseline.")
+        print("Update golden values in this test if the new values are correct.")
+
+    assert match, (
+        f"Acceptance rates {acceptance_per_pos} differ significantly "
+        f"from golden {golden}. Update golden if needed."
+    )
+
+    cleanup_dist_env_and_memory()
+
+
+def test_vwn_eagle3_correctness_tp4():
+    """Test VWN-Eagle3 greedy generation produces non-empty output."""
+    tokenizer_path = resolve_tokenizer_args(MAIN_MODEL)[1]
+    tokenizer = AutoTokenizer.from_pretrained(
+        tokenizer_path,
+        trust_remote_code=True,
+    )
+
+    prompts = [
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": "What is the capital of France?"}],
+            tokenize=False,
+            add_generation_prompt=True,
+        ),
+    ]
+
+    sampling_params = SamplingParams(
+        temperature=0,
+        max_tokens=64,
+    )
+
+    speculative_config = {
+        "method": "eagle3",
+        "model": SPEC_MODEL,
+        "num_speculative_tokens": 3,
+        "draft_tensor_parallel_size": 1,
+        "disable_padded_drafter_batch": False,
+    }
+
+    with VllmRunner(
+        MAIN_MODEL,
+        tensor_parallel_size=4,
+        max_model_len=4096,
+        gpu_memory_utilization=0.8,
+        distributed_executor_backend="mp",
+        speculative_config=speculative_config,
+        compilation_config=CompilationConfig(
+            cudagraph_mode="FULL_DECODE_ONLY",
+            cudagraph_capture_sizes=[20],
+        ),
+    ) as llm:
+        outputs = llm.model.generate(prompts, sampling_params)
+
+    for output in outputs:
+        generated_text = output.outputs[0].text
+        print(f"Prompt: {output.prompt!r}, Generated: {generated_text!r}")
+        assert len(generated_text) > 0, "Generated text should not be empty"
+
+    cleanup_dist_env_and_memory()
+
+
+def test_vwn_eagle3_acceptance_tp4_async_false():
+    """Test VWN-Eagle3 acceptance rate with async_scheduling=False.
+
+    Validates that the synchronous scheduling mode produces acceptance
+    rates within reasonable bounds. Uses wider tolerance since this
+    configuration may differ from the default async mode.
+    """
+    golden = [0.50, 0.25, 0.10]
+
+    tokenizer_path = resolve_tokenizer_args(MAIN_MODEL)[1]
+    tokenizer = AutoTokenizer.from_pretrained(
+        tokenizer_path,
+        trust_remote_code=True,
+    )
+
+    example_prompts = [
+        {"role": "user", "content": "Hello, my name is"},
+        {"role": "user", "content": "The president of the United States is"},
+        {"role": "user", "content": "The capital of France is"},
+        {"role": "user", "content": "The future of AI is"},
+    ]
+    prompts = [
+        tokenizer.apply_chat_template(
+            [p],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        for p in example_prompts
+    ]
+
+    sampling_params = SamplingParams(
+        temperature=0,
+        ignore_eos=False,
+        max_tokens=256,
+    )
+
+    speculative_config = {
+        "method": "eagle3",
+        "model": SPEC_MODEL,
+        "num_speculative_tokens": 3,
+        "draft_tensor_parallel_size": 1,
+        "disable_padded_drafter_batch": False,
+    }
+
+    with VllmRunner(
+        MAIN_MODEL,
+        tensor_parallel_size=4,
+        max_model_len=4096,
+        gpu_memory_utilization=0.8,
+        disable_log_stats=False,
+        distributed_executor_backend="mp",
+        speculative_config=speculative_config,
+        compilation_config=CompilationConfig(
+            cudagraph_mode="FULL_DECODE_ONLY",
+            cudagraph_capture_sizes=[20],
+        ),
+        async_scheduling=False,
+    ) as llm:
+        outputs = llm.model.generate(prompts, sampling_params)
+        metrics = llm.model.get_metrics()
+
+    for output in outputs:
+        print(f"Prompt: {output.prompt!r}")
+        print(f"Generated: {output.outputs[0].text!r}")
+
+    num_drafts = 0
+    num_accepted_tokens_per_pos = [0] * 3
+    for metric in metrics:
+        if metric.name == "vllm:spec_decode_num_drafts":
+            assert isinstance(metric, Counter)
+            num_drafts += metric.value
+        elif metric.name == "vllm:spec_decode_num_accepted_tokens_per_pos":
+            assert isinstance(metric, Vector)
+            for pos in range(len(metric.values)):
+                num_accepted_tokens_per_pos[pos] += metric.values[pos]
+
+    acceptance_per_pos = [
+        n / num_drafts for n in num_accepted_tokens_per_pos
+    ]
+
+    print(f"acceptance_per_pos (async=False): {acceptance_per_pos}")
+    print(f"golden: {golden}")
+    assert len(acceptance_per_pos) == 3
+
+    match = all(abs(a - b) < 0.20 for a, b in zip(acceptance_per_pos, golden))
+    if not match:
+        print("WARNING: acceptance rates differ from golden baseline.")
+        print("Update golden values in this test if the new values are correct.")
+
+    assert match, (
+        f"Acceptance rates {acceptance_per_pos} differ significantly "
+        f"from golden {golden}. Update golden if needed."
+    )
+
+    cleanup_dist_env_and_memory()
+
+
+def test_vwn_eagle3_disable_padded_drafter_batch_tp4():
+    """Test VWN-Eagle3 with disable_padded_drafter_batch=True.
+
+    Verifies correctness under the alternative batching mode that disables
+    padded drafter batching.
+    """
+    tokenizer_path = resolve_tokenizer_args(MAIN_MODEL)[1]
+    tokenizer = AutoTokenizer.from_pretrained(
+        tokenizer_path,
+        trust_remote_code=True,
+    )
+
+    example_prompts = [
+        {"role": "user", "content": "What is the capital of France?"},
+        {"role": "user", "content": "Who wrote Romeo and Juliet?"},
+    ]
+    prompts = [
+        tokenizer.apply_chat_template(
+            [p],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        for p in example_prompts
+    ]
+
+    sampling_params = SamplingParams(
+        temperature=0,
+        max_tokens=64,
+    )
+
+    speculative_config = {
+        "method": "eagle3",
+        "model": SPEC_MODEL,
+        "num_speculative_tokens": 3,
+        "draft_tensor_parallel_size": 1,
+        "disable_padded_drafter_batch": True,
+    }
+
+    with VllmRunner(
+        MAIN_MODEL,
+        tensor_parallel_size=4,
+        max_model_len=4096,
+        gpu_memory_utilization=0.8,
+        distributed_executor_backend="mp",
+        speculative_config=speculative_config,
+        compilation_config=CompilationConfig(
+            cudagraph_mode="FULL_DECODE_ONLY",
+            cudagraph_capture_sizes=[20],
+        ),
+    ) as llm:
+        outputs = llm.model.generate(prompts, sampling_params)
+
+    for output in outputs:
+        generated_text = output.outputs[0].text
+        print(f"Prompt: {output.prompt!r}, Generated: {generated_text!r}")
+        assert len(generated_text) > 0, "Generated text should not be empty"
+
+    cleanup_dist_env_and_memory()
+
+
+def test_vwn_eagle3_longer_generation_tp4():
+    """Test VWN-Eagle3 with longer generation (max_tokens=512).
+
+    Verifies stability of the speculative decoding loop over more decode
+    steps and that output is non-trivial.
+    """
+    tokenizer_path = resolve_tokenizer_args(MAIN_MODEL)[1]
+    tokenizer = AutoTokenizer.from_pretrained(
+        tokenizer_path,
+        trust_remote_code=True,
+    )
+
+    example_prompts = [
+        {"role": "user", "content": "Explain the theory of relativity in detail."},
+        {"role": "user", "content": "Write a short essay about artificial intelligence."},
+    ]
+    prompts = [
+        tokenizer.apply_chat_template(
+            [p],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        for p in example_prompts
+    ]
+
+    sampling_params = SamplingParams(
+        temperature=0,
+        max_tokens=512,
+    )
+
+    speculative_config = {
+        "method": "eagle3",
+        "model": SPEC_MODEL,
+        "num_speculative_tokens": 3,
+        "draft_tensor_parallel_size": 1,
+        "disable_padded_drafter_batch": False,
+    }
+
+    with VllmRunner(
+        MAIN_MODEL,
+        tensor_parallel_size=4,
+        max_model_len=4096,
+        gpu_memory_utilization=0.8,
+        distributed_executor_backend="mp",
+        speculative_config=speculative_config,
+        compilation_config=CompilationConfig(
+            cudagraph_mode="FULL_DECODE_ONLY",
+            cudagraph_capture_sizes=[20],
+        ),
+    ) as llm:
+        outputs = llm.model.generate(prompts, sampling_params)
+
+    for output in outputs:
+        generated_text = output.outputs[0].text
+        output_tokens = output.outputs[0].token_ids
+        print(f"Prompt: {output.prompt!r}")
+        print(f"Generated ({len(output_tokens)} tokens): {generated_text!r}")
+        assert len(generated_text) > 0, "Generated text should not be empty"
+        assert len(output_tokens) > 0, "Should generate at least one token"
+
+    cleanup_dist_env_and_memory()

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -5,3 +5,4 @@ def register_model():
     ModelRegistry.register_model("DeepseekV4ForCausalLM", "vllm_ascend.models.deepseek_v4:AscendDeepseekV4ForCausalLM")
 
     ModelRegistry.register_model("DeepSeekV4MTPModel", "vllm_ascend.models.deepseek_v4_mtp:DeepSeekV4MTP")
+    ModelRegistry.register_model("LlamaForCausalLMVwnEagle3", "vllm_ascend.models.llama_eagle3_vwn:Eagle3VwnLlamaForCausalLM")

--- a/vllm_ascend/models/llama_eagle3_vwn.py
+++ b/vllm_ascend/models/llama_eagle3_vwn.py
@@ -1,0 +1,616 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Iterable
+
+import torch
+import torch.nn as nn
+from transformers import LlamaConfig
+
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.logger import init_logger
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.model_loader.weight_utils import (
+    default_weight_loader,
+    maybe_remap_kv_scale_name,
+)
+from vllm.model_executor.models.llama import LlamaForCausalLM, LlamaDecoderLayer
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM, LlamaModel
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.multimodal.inputs import NestedTensors
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    get_draft_quant_config,
+    maybe_prefix,
+    process_eagle_weight,
+)
+
+logger = init_logger(__name__)
+
+class PreVwnLayerV0(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+        config: LlamaConfig | None = None,
+        quant_config: QuantizationConfig = None,
+    ) -> None:
+        super().__init__()
+        config = config or vllm_config.model_config.hf_config
+        hidden_size = config.hidden_size
+        m = getattr(config, "vwn_m", 1)
+        expanded_factor = getattr(config, "vwn_r", 1)
+        wider_dim = int(hidden_size * expanded_factor)
+
+        self.wider_dim = wider_dim
+        
+        self.upward = ReplicatedLinear(
+            input_size=hidden_size,
+            output_size=wider_dim,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "upward"),
+            return_bias=False,
+        )
+        extend_size = 2 * wider_dim
+        self.extend = ReplicatedLinear(
+            input_size=wider_dim,
+            output_size=extend_size,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "extend"),
+            return_bias=False,
+        )
+        self.input_layernorm = RMSNorm(wider_dim, eps=config.rms_norm_eps)
+        self.hidden_norm = RMSNorm(wider_dim, eps=config.rms_norm_eps)
+        self.fc = ReplicatedLinear(
+            input_size=extend_size,
+            output_size=wider_dim,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "fc"),
+            return_bias=False,
+        )
+        self.full_connected = ReplicatedLinear(
+            input_size=wider_dim,
+            output_size=wider_dim,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "extend"),
+            return_bias=False,
+        )
+
+    def forward(
+        self,
+        embeds: torch.Tensor,
+        hidden_states: torch.Tensor
+    ):
+        wider_embeds = self.upward(embeds)
+        wider_hidden_states = self.upward(hidden_states)
+
+        extended_hidden_states = self.extend(wider_hidden_states)
+        hidden_states_to_cat, hidden_residual = torch.split(
+            extended_hidden_states,
+            [self.wider_dim, extended_hidden_states.shape[-1] - self.wider_dim],
+            dim=-1
+        )
+        norm_wider_embeds = self.input_layernorm(wider_embeds)
+        hidden_states_to_cat = self.hidden_norm(hidden_states_to_cat)
+        hidden_to_fc = torch.cat([norm_wider_embeds, hidden_states_to_cat], dim=-1)
+        hidden_after_fc = self.fc(hidden_to_fc)
+        hidden_before_residual = self.full_connected(hidden_after_fc)
+        wider_hidden_states = hidden_before_residual + hidden_residual
+
+        return wider_hidden_states
+
+class PreVwnLayerV1(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+        config: LlamaConfig | None = None,
+        quant_config: QuantizationConfig = None,
+    ) -> None:
+        super().__init__()
+        config = config or vllm_config.model_config.hf_config
+        hidden_size = config.hidden_size
+        m = getattr(config, "vwn_m", 1)
+        expanded_factor = getattr(config, "vwn_r", 1)
+        wider_dim = int(hidden_size * expanded_factor)
+        self.wider_dim = wider_dim
+
+        self.input_layernorm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
+        self.hidden_norm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
+        fc_input_size = 2 * hidden_size
+        self.fc = ReplicatedLinear(
+            input_size=fc_input_size,
+            output_size=hidden_size,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "fc"),
+            return_bias=False,
+        )
+        upward_input_size = hidden_size // m
+        upward_output_size = wider_dim // m
+        self.upward = ReplicatedLinear(
+            input_size=upward_input_size,
+            output_size=upward_output_size,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "upward"),
+            return_bias=False,
+        )
+        self.m = m
+        self.hidden_size = hidden_size
+        self.wider_dim = wider_dim
+
+    def forward(
+        self,
+        embeds: torch.Tensor,
+        hidden_states: torch.Tensor
+    ):
+        norm_embeds = self.input_layernorm(embeds)
+        norm_hidden = self.hidden_norm(hidden_states)
+        hidden_to_fc = torch.cat([norm_embeds, norm_hidden], dim=-1)
+        hidden_after_fc = self.fc(hidden_to_fc)
+        hidden_after_fc_new = hidden_after_fc.view(-1 , self.hidden_size // self.m)
+        wider_hidden_states_tmp = self.upward(hidden_after_fc_new)
+        wider_hidden_states = wider_hidden_states_tmp.view(-1 , self.wider_dim)
+
+        return wider_hidden_states
+
+class PreVwnLayerV2(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+        config: LlamaConfig | None = None,
+        quant_config: QuantizationConfig = None,
+    ) -> None:
+        super().__init__()
+        config = config or vllm_config.model_config.hf_config
+        hidden_size = config.hidden_size
+
+        self.input_layernorm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
+        self.hidden_norm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
+        fc_input_size = 2 * hidden_size
+        self.fc = ReplicatedLinear(
+            input_size=fc_input_size,
+            output_size=hidden_size,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "fc"),
+            return_bias=False,
+        )
+
+    def forward(
+        self,
+        embeds: torch.Tensor,
+        hidden_states: torch.Tensor
+    ):
+        norm_embeds = self.input_layernorm(embeds)
+        norm_hidden = self.hidden_norm(hidden_states)
+        hidden_to_fc = torch.cat([norm_embeds, norm_hidden], dim=-1)
+        hidden_after_fc = self.fc(hidden_to_fc)
+        return hidden_after_fc
+
+
+class VwnLlamaDecoderLayer(LlamaDecoderLayer):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+        config: LlamaConfig | None = None,
+        layer_idx: int = 0,
+    ) -> None:
+        super().__init__(vllm_config, prefix=prefix, config=config)
+
+        config = config or vllm_config.model_config.hf_config
+        quant_config = self.get_quant_config(vllm_config)
+        m = getattr(config, "vwn_m", 1)
+        expanded_factor = getattr(config, "vwn_r", 1)
+        n = int(expanded_factor * m)
+        wider_dim = int(self.hidden_size * expanded_factor)
+        self.wider_dim = wider_dim
+        self.m = m
+        upward_input_size = self.hidden_size // m
+        upward_output_size = wider_dim // m
+        pre_vwn_version = getattr(config, "pre_vwn_version", 0)
+        self.pre_vwn_version = pre_vwn_version
+        if pre_vwn_version == 0:
+            self.pre_vwn_layer = PreVwnLayerV0(
+                vllm_config,
+                prefix=maybe_prefix(prefix, f"layers.pre_vwn_layer"),
+                config=config,
+                quant_config=quant_config
+            )
+        elif pre_vwn_version == 1:
+            self.pre_vwn_layer = PreVwnLayerV1(
+                vllm_config,
+                prefix=maybe_prefix(prefix, f"layers.pre_vwn_layer"),
+                config=config,
+                quant_config=quant_config
+            )
+        else:
+            self.pre_vwn_layer = PreVwnLayerV2(
+                vllm_config,
+                prefix=maybe_prefix(prefix, f"layers.pre_vwn_layer"),
+                config=config,
+                quant_config=quant_config
+            )
+
+        self.downward_and_forgot = ReplicatedLinear(
+            input_size=wider_dim,
+            output_size=self.hidden_size + wider_dim,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "downward_and_forgot"),
+            return_bias=False,
+        )
+        
+        self.pre_attention_layernorm = RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+        self.upward_after_attn = ReplicatedLinear(
+            input_size=upward_input_size,
+            output_size=upward_output_size,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "upward_after_attn"),
+            return_bias=False,
+        )
+        self.downward_and_forgot_after_attn = ReplicatedLinear(
+            input_size=wider_dim,
+            output_size=self.hidden_size + wider_dim,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "downward_and_forgot"),
+            return_bias=False,
+        )
+        self.post_attention_layernorm = RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+        self.upward_after_mlp = ReplicatedLinear(
+            input_size=upward_input_size,
+            output_size=upward_output_size,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "upward_after_mlp"),
+            return_bias=False,
+        )
+        self.downward = ReplicatedLinear(
+            input_size=upward_output_size,
+            output_size=upward_input_size,
+            bias=False,
+            params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "downward"),
+            return_bias=False,
+        )
+
+        self.layer_idx = layer_idx
+
+    def get_quant_config(self, vllm_config: VllmConfig) -> QuantizationConfig | None:
+        """Use drafter's quantization config instead of verifier's."""
+        return get_draft_quant_config(vllm_config)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        embeds: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.layer_idx == 0:
+            # First layer: preVwn + vwn layer
+            wider_hidden_states = self.pre_vwn_layer(embeds, hidden_states)
+
+            # attn
+            total_hidden_states = self.downward_and_forgot(wider_hidden_states)
+            hidden_states, hidden_residual = torch.split(
+                total_hidden_states,
+                [self.hidden_size, total_hidden_states.shape[-1] - self.hidden_size],
+                dim=-1
+            )
+            hidden_states = self.pre_attention_layernorm(hidden_states)
+            hidden_states = self.self_attn(
+                positions=positions,
+                hidden_states=hidden_states,
+            )
+            hidden_states_view = hidden_states.view(-1, self.hidden_size // self.m)
+            upward_hidden_states_tmp = self.upward_after_attn(hidden_states_view)
+            upward_hidden_states = upward_hidden_states_tmp.view(-1, self.wider_dim)
+            wider_hidden_states = upward_hidden_states + hidden_residual
+
+            # mlp
+            total_hidden_states = self.downward_and_forgot_after_attn(wider_hidden_states)
+            hidden_states, hidden_residual = torch.split(
+                total_hidden_states,
+                [self.hidden_size, total_hidden_states.shape[-1] - self.hidden_size],
+                dim=-1
+            )
+            hidden_states = self.post_attention_layernorm(hidden_states)
+            hidden_states = self.mlp(hidden_states)
+            hidden_states_view = hidden_states.view(-1, self.hidden_size // self.m)
+            upward_hidden_states_tmp = self.upward_after_mlp(hidden_states_view)
+            upward_hidden_states = upward_hidden_states_tmp.view(-1, self.wider_dim)
+            hidden_states = upward_hidden_states + hidden_residual
+
+            # downward
+            if self.pre_vwn_version != 2:
+                wider_hidden_states_view = hidden_states.view(-1, self.wider_dim // self.m)
+                hidden_state_tmp = self.downward(wider_hidden_states_view)
+                hidden_states = hidden_state_tmp.view(-1, self.hidden_size)
+
+        return hidden_states, residual
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "hidden_states": 0,
+        "input_embeds": 0,
+    }
+)
+class VwnLlamaModel(nn.Module):
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        start_layer_id: int = 0,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.vocab_size = self.config.vocab_size
+
+        # Get drafter's quantization config
+        self.quant_config = get_draft_quant_config(vllm_config)
+
+        eagle_config = getattr(self.config, "eagle_config", None)
+        if eagle_config is not None and "use_aux_hidden_state" in eagle_config:
+            self.use_aux_hidden_state = eagle_config["use_aux_hidden_state"]
+        else:
+            self.use_aux_hidden_state = True
+
+        current_vllm_config = get_current_vllm_config()
+
+        self.embed_tokens = VocabParallelEmbedding(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            prefix=maybe_prefix(prefix, "embed_tokens"),
+        )
+
+        self.layers = nn.ModuleList(
+            [
+                VwnLlamaDecoderLayer(
+                    current_vllm_config,
+                    prefix=maybe_prefix(prefix, f"layers.{layer_idx + start_layer_id}"),
+                    config=self.config,
+                    layer_idx=layer_idx,
+                )
+                for layer_idx in range(self.config.num_hidden_layers)
+            ]
+        )
+        if self.use_aux_hidden_state:
+            if hasattr(self.config, "target_hidden_size"):
+                fc_input_size = self.config.target_hidden_size * 3
+            else:
+                fc_input_size = self.config.hidden_size * 3
+            self.fc = ReplicatedLinear(
+                input_size=fc_input_size,
+                output_size=self.config.hidden_size,
+                bias=False,
+                params_dtype=vllm_config.model_config.dtype,
+                quant_config=self.quant_config,
+                prefix=maybe_prefix(prefix, "fc"),
+                return_bias=False,
+            )
+        self.norm = RMSNorm(
+            self.config.hidden_size,
+            eps=self.config.rms_norm_eps,
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        input_embeds: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if input_embeds is None:
+            input_embeds = self.embed_input_ids(input_ids)
+        assert hidden_states.shape[-1] == input_embeds.shape[-1]
+
+        residual = None
+        for layer in self.layers:
+            hidden_states, residual = layer(
+                positions=positions,
+                embeds=input_embeds,
+                hidden_states=hidden_states,
+                residual=residual,
+            )
+        hidden_prenorm = hidden_states
+        hidden_states = self.norm(hidden_states, residual)
+        return hidden_states, hidden_prenorm
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            (".qkv_proj", ".q_proj", "q"),
+            (".qkv_proj", ".k_proj", "k"),
+            (".qkv_proj", ".v_proj", "v"),
+            (".gate_up_proj", ".gate_proj", 0),
+            (".gate_up_proj", ".up_proj", 1),
+        ]
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        for name, loaded_weight in weights:
+            if "midlayer." in name:
+                name = name.replace("midlayer.", "layers.0.")
+            # Handle kv cache quantization scales
+            if self.quant_config is not None and (
+                scale_name := self.quant_config.get_cache_scale(name)
+            ):
+                # Loading kv cache quantization scales
+                param = params_dict[scale_name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                loaded_weight = (
+                    loaded_weight if loaded_weight.dim() == 0 else loaded_weight[0]
+                )
+                weight_loader(param, loaded_weight)
+                loaded_params.add(scale_name)
+                continue
+            # Remapping the name FP8 kv-scale or zero point.
+            if "scale" in name or "zero_point" in name:
+                name = maybe_remap_kv_scale_name(name, params_dict)
+                if name is None:
+                    continue
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
+
+
+class Eagle3VwnLlamaForCausalLM(LlamaForCausalLM):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        nn.Module.__init__(self)
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        # Ensure draft_vocab_size is set
+        # default to the base vocab size when absent
+        if getattr(self.config, "draft_vocab_size", None) is None:
+            base_vocab_size = getattr(self.config, "vocab_size", None)
+            self.config.draft_vocab_size = base_vocab_size
+        target_layer_num = vllm_config.model_config.get_num_layers(
+            vllm_config.parallel_config
+        )
+
+        # Store target layer count in draft config for
+        # proper layer_types indexing in draft models
+        self.config.target_layer_count = target_layer_num
+        self.model = VwnLlamaModel(
+            vllm_config=vllm_config, prefix="model", start_layer_id=target_layer_num
+        )
+
+        logit_scale = getattr(self.config, "logit_scale", 1.0)
+        self.lm_head = ParallelLMHead(
+            self.config.draft_vocab_size,
+            self.config.hidden_size,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
+        self.logits_processor = LogitsProcessor(
+            self.config.draft_vocab_size, scale=logit_scale
+        )
+        self.draft_id_to_target_id = nn.Parameter(
+            torch.zeros(self.config.draft_vocab_size, dtype=torch.long),
+            requires_grad=False,
+        )
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: NestedTensors | None = None,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.model(input_ids, positions, hidden_states, inputs_embeds)
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor | None:
+        logits = self.logits_processor(self.lm_head, hidden_states)
+        if self.draft_id_to_target_id is None:
+            assert logits.shape[1] == self.config.vocab_size, (
+                "Expected logits to have shape "
+                f"(*, {self.config.vocab_size}), but got {logits.shape}"
+            )
+            return logits
+
+        base = torch.arange(self.config.draft_vocab_size, device=logits.device)
+        targets = base + self.draft_id_to_target_id
+        logits_new = logits.new_full(
+            (
+                logits.shape[0],
+                self.config.vocab_size,
+            ),
+            float("-inf"),
+        )
+        logits_new[:, targets] = logits
+        return logits_new
+
+    def combine_hidden_states(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        if not self.model.use_aux_hidden_state:
+            return hidden_states
+        # combine multiple auxiliary hidden states returned by eagle3
+        return self.model.fc(hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        model_weights = {}
+        includes_draft_id_mapping = False
+        includes_embed_tokens = False
+        for name, loaded_weight in weights:
+            if "t2d" in name:
+                continue
+            if "d2t" in name:
+                name = name.replace("d2t", "draft_id_to_target_id")
+                includes_draft_id_mapping = True
+            elif "lm_head" not in name:
+                name = "model." + name
+            if "embed_tokens" in name:
+                includes_embed_tokens = True
+            model_weights[name] = loaded_weight
+            process_eagle_weight(self, name)
+
+        skip_substrs = []
+        if not includes_draft_id_mapping:
+            skip_substrs.append("draft_id_to_target_id")
+        if not includes_embed_tokens:
+            skip_substrs.append("embed_tokens")
+        if not self.model.use_aux_hidden_state:
+            skip_substrs.append("fc.")
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=None,
+            skip_substrs=skip_substrs,
+        )
+        loader.load_weights(model_weights.items())

--- a/vllm_ascend/models/llama_eagle3_vwn.py
+++ b/vllm_ascend/models/llama_eagle3_vwn.py
@@ -1,583 +1,134 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from collections.abc import Iterable
-
 import torch
 import torch.nn as nn
 from transformers import LlamaConfig
 
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig, get_current_vllm_config
-from vllm.logger import init_logger
-from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.layernorm import RMSNorm
-from vllm.model_executor.layers.linear import ReplicatedLinear
-from vllm.model_executor.model_loader.weight_utils import (
-    default_weight_loader,
-    maybe_remap_kv_scale_name,
+from vllm.model_executor.layers.linear import QKVParallelLinear, ReplicatedLinear
+from vllm.model_executor.models.llama_eagle3 import (
+    Eagle3LlamaForCausalLM,
+    LlamaDecoderLayer as Eagle3LlamaDecoderLayer,
+    LlamaModel as Eagle3LlamaModel,
 )
-from vllm.model_executor.models.llama import LlamaForCausalLM, LlamaDecoderLayer
-from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
-from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM, LlamaModel
-from vllm.model_executor.layers.vocab_parallel_embedding import (
-    ParallelLMHead,
-    VocabParallelEmbedding,
-)
-from vllm.multimodal.inputs import NestedTensors
-from vllm.model_executor.models.utils import (
-    AutoWeightsLoader,
-    get_draft_quant_config,
-    maybe_prefix,
-    process_eagle_weight,
-)
+from vllm.model_executor.models.utils import maybe_prefix
 
-logger = init_logger(__name__)
 
-class PreVwnLayerV0(nn.Module):
-    def __init__(
-        self,
-        vllm_config: VllmConfig,
-        prefix: str = "",
-        config: LlamaConfig | None = None,
-        quant_config: QuantizationConfig = None,
-    ) -> None:
-        super().__init__()
-        config = config or vllm_config.model_config.hf_config
-        hidden_size = config.hidden_size
-        m = getattr(config, "vwn_m", 1)
-        expanded_factor = getattr(config, "vwn_r", 1)
-        wider_dim = int(hidden_size * expanded_factor)
+def _linear(inp, out, vc, qc, pfx):
+    return ReplicatedLinear(
+        input_size=inp, output_size=out, bias=False,
+        params_dtype=vc.model_config.dtype,
+        quant_config=qc, prefix=pfx, return_bias=False)
 
-        self.wider_dim = wider_dim
-        
-        self.upward = ReplicatedLinear(
-            input_size=hidden_size,
-            output_size=wider_dim,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "upward"),
-            return_bias=False,
-        )
-        extend_size = 2 * wider_dim
-        self.extend = ReplicatedLinear(
-            input_size=wider_dim,
-            output_size=extend_size,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "extend"),
-            return_bias=False,
-        )
-        self.input_layernorm = RMSNorm(wider_dim, eps=config.rms_norm_eps)
-        self.hidden_norm = RMSNorm(wider_dim, eps=config.rms_norm_eps)
-        self.fc = ReplicatedLinear(
-            input_size=extend_size,
-            output_size=wider_dim,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "fc"),
-            return_bias=False,
-        )
-        self.full_connected = ReplicatedLinear(
-            input_size=wider_dim,
-            output_size=wider_dim,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "extend"),
-            return_bias=False,
-        )
-
-    def forward(
-        self,
-        embeds: torch.Tensor,
-        hidden_states: torch.Tensor
-    ):
-        wider_embeds = self.upward(embeds)
-        wider_hidden_states = self.upward(hidden_states)
-
-        extended_hidden_states = self.extend(wider_hidden_states)
-        hidden_states_to_cat, hidden_residual = torch.split(
-            extended_hidden_states,
-            [self.wider_dim, extended_hidden_states.shape[-1] - self.wider_dim],
-            dim=-1
-        )
-        norm_wider_embeds = self.input_layernorm(wider_embeds)
-        hidden_states_to_cat = self.hidden_norm(hidden_states_to_cat)
-        hidden_to_fc = torch.cat([norm_wider_embeds, hidden_states_to_cat], dim=-1)
-        hidden_after_fc = self.fc(hidden_to_fc)
-        hidden_before_residual = self.full_connected(hidden_after_fc)
-        wider_hidden_states = hidden_before_residual + hidden_residual
-
-        return wider_hidden_states
 
 class PreVwnLayerV1(nn.Module):
-    def __init__(
-        self,
-        vllm_config: VllmConfig,
-        prefix: str = "",
-        config: LlamaConfig | None = None,
-        quant_config: QuantizationConfig = None,
-    ) -> None:
+    def __init__(self, vllm_config, prefix="", config=None, quant_config=None):
         super().__init__()
-        config = config or vllm_config.model_config.hf_config
-        hidden_size = config.hidden_size
-        m = getattr(config, "vwn_m", 1)
-        expanded_factor = getattr(config, "vwn_r", 1)
-        self.expnded_factor = expanded_factor
-        wider_dim = int(hidden_size * expanded_factor)
-        self.wider_dim = wider_dim
+        cfg = config or vllm_config.model_config.hf_config
+        hs, m, r = cfg.hidden_size, getattr(cfg, "vwn_m", 1), getattr(cfg, "vwn_r", 1)
+        wd = int(hs * r)
+        self.m, self.hidden_size, self.wider_dim = m, hs, wd
+        self.input_layernorm = RMSNorm(hs, eps=cfg.rms_norm_eps)
+        self.hidden_norm = RMSNorm(hs, eps=cfg.rms_norm_eps)
+        self.fc = _linear(2 * hs, hs, vllm_config, quant_config, maybe_prefix(prefix, "fc"))
+        self.upward = _linear(hs // m, wd // m, vllm_config, quant_config,
+                              maybe_prefix(prefix, "upward"))
 
-        self.input_layernorm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
-        self.hidden_norm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
-        fc_input_size = 2 * hidden_size
-        self.fc = ReplicatedLinear(
-            input_size=fc_input_size,
-            output_size=hidden_size,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "fc"),
-            return_bias=False,
-        )
-        if expanded_factor != 1:
-            upward_input_size = hidden_size // m
-            upward_output_size = wider_dim // m
-            self.upward = ReplicatedLinear(
-                input_size=upward_input_size,
-                output_size=upward_output_size,
-                bias=False,
-                params_dtype=vllm_config.model_config.dtype,
-                quant_config=quant_config,
-                prefix=maybe_prefix(prefix, "upward"),
-                return_bias=False,
-            )
-        self.m = m
-        self.hidden_size = hidden_size
-        self.wider_dim = wider_dim
+    def forward(self, embeds, hidden_states):
+        x = self.fc(torch.cat([self.input_layernorm(embeds),
+                               self.hidden_norm(hidden_states)], dim=-1))
+        return self.upward(x.view(-1, self.hidden_size // self.m)).view(-1, self.wider_dim)
 
-    def forward(
-        self,
-        embeds: torch.Tensor,
-        hidden_states: torch.Tensor
-    ):
-        norm_embeds = self.input_layernorm(embeds)
-        norm_hidden = self.hidden_norm(hidden_states)
-        hidden_to_fc = torch.cat([norm_embeds, norm_hidden], dim=-1)
-        hidden_after_fc = self.fc(hidden_to_fc)
-        if self.expnded_factor != 1:
-            hidden_after_fc_new = hidden_after_fc.view(-1 , self.hidden_size // self.m)
-            wider_hidden_states_tmp = self.upward(hidden_after_fc_new)
-            wider_hidden_states = wider_hidden_states_tmp.view(-1 , self.wider_dim)
-        else:
-            wider_hidden_states = hidden_after_fc
-        return wider_hidden_states
 
-class VwnLlamaDecoderLayer(LlamaDecoderLayer):
-    def __init__(
-        self,
-        vllm_config: VllmConfig,
-        prefix: str = "",
-        config: LlamaConfig | None = None,
-        layer_idx: int = 0,
-    ) -> None:
-        super().__init__(vllm_config, prefix=prefix, config=config)
+class VwnLlamaDecoderLayer(Eagle3LlamaDecoderLayer):
 
-        config = config or vllm_config.model_config.hf_config
-        quant_config = self.get_quant_config(vllm_config)
-        m = getattr(config, "vwn_m", 1)
-        expanded_factor = getattr(config, "vwn_r", 1)
-        self.expanded_factor = expanded_factor
-        wider_dim = int(self.hidden_size * expanded_factor)
-        self.wider_dim = wider_dim
-        self.m = m
-        upward_input_size = self.hidden_size // m
-        upward_output_size = wider_dim // m
-        downward_input_size = wider_dim // m
-        downard_output_size = (self.hidden_size + wider_dim) // m
-        pre_vwn_version = getattr(config, "pre_vwn_version", 0)
-        self.pre_vwn_version = pre_vwn_version
-        if pre_vwn_version == 0:
-            self.pre_vwn_layer = PreVwnLayerV0(
-                vllm_config,
-                prefix=maybe_prefix(prefix, f"layers.pre_vwn_layer"),
-                config=config,
-                quant_config=quant_config
-            )
-        elif pre_vwn_version == 1:
-            self.pre_vwn_layer = PreVwnLayerV1(
-                vllm_config,
-                prefix=maybe_prefix(prefix, f"layers.pre_vwn_layer"),
-                config=config,
-                quant_config=quant_config
-            )
+    def __init__(self, vllm_config, prefix="", config=None, layer_idx=0):
+        super().__init__(vllm_config, prefix=prefix, config=config, layer_idx=layer_idx)
+        cfg = config or vllm_config.model_config.hf_config
+        qc = self.get_quant_config(vllm_config)
+        m, r = getattr(cfg, "vwn_m", 1), getattr(cfg, "vwn_r", 1)
+        hs, wd = self.hidden_size, int(self.hidden_size * r)
+        self.m, self.wider_dim, self.layer_idx = m, wd, layer_idx
 
-        self.downward_and_forgot = ReplicatedLinear(
-            input_size=downward_input_size,
-            output_size=downard_output_size,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "downward_and_forgot"),
-            return_bias=False,
-        )
-        
-        self.pre_attention_layernorm = RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
-        self.upward_after_attn = ReplicatedLinear(
-            input_size=upward_input_size,
-            output_size=upward_output_size,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "upward_after_attn"),
-            return_bias=False,
-        )
-        self.downward_and_forgot_after_attn = ReplicatedLinear(
-            input_size=downward_input_size,
-            output_size=downard_output_size,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "downward_and_forgot"),
-            return_bias=False,
-        )
-        self.post_attention_layernorm = RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
-        self.upward_after_mlp = ReplicatedLinear(
-            input_size=upward_input_size,
-            output_size=upward_output_size,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "upward_after_mlp"),
-            return_bias=False,
-        )
-        if self.expanded_factor != 1:
-            self.downward = ReplicatedLinear(
-                input_size=upward_output_size,
-                output_size=upward_input_size,
-                bias=False,
-                params_dtype=vllm_config.model_config.dtype,
-                quant_config=quant_config,
-                prefix=maybe_prefix(prefix, "downward"),
-                return_bias=False,
-            )
+        # VWN feeds hidden_size (not 2*hidden_size) into attention,
+        # restore qkv_proj overridden by the parent eagle3 decoder.
+        if layer_idx == 0:
+            self.self_attn.qkv_proj = QKVParallelLinear(
+                hs, self.self_attn.head_dim,
+                self.self_attn.total_num_heads, self.self_attn.total_num_kv_heads,
+                bias=getattr(cfg, "attention_bias", False), quant_config=qc,
+                prefix=maybe_prefix(prefix, "self_attn.qkv_proj"))
 
-        self.layer_idx = layer_idx
+        mp = maybe_prefix
+        self.pre_vwn_layer = PreVwnLayerV1(vllm_config, mp(prefix, "layers.pre_vwn_layer"),
+                                           cfg, qc)
+        self.downward_and_forgot = _linear(wd // m, (hs + wd) // m, vllm_config, qc,
+                                           mp(prefix, "downward_and_forgot"))
+        self.pre_attention_layernorm = RMSNorm(hs, eps=cfg.rms_norm_eps)
+        self.upward_after_attn = _linear(hs // m, wd // m, vllm_config, qc,
+                                         mp(prefix, "upward_after_attn"))
+        self.downward_and_forgot_after_attn = _linear(
+            wd // m, (hs + wd) // m, vllm_config, qc, mp(prefix, "downward_and_forgot"))
+        self.post_attention_layernorm = RMSNorm(hs, eps=cfg.rms_norm_eps)
+        self.upward_after_mlp = _linear(hs // m, wd // m, vllm_config, qc,
+                                        mp(prefix, "upward_after_mlp"))
+        self.downward = _linear(wd // m, hs // m, vllm_config, qc, mp(prefix, "downward"))
 
-    def get_quant_config(self, vllm_config: VllmConfig) -> QuantizationConfig | None:
-        """Use drafter's quantization config instead of verifier's."""
-        return get_draft_quant_config(vllm_config)
-
-    def forward(
-        self,
-        positions: torch.Tensor,
-        embeds: torch.Tensor,
-        hidden_states: torch.Tensor,
-        residual: torch.Tensor | None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    def forward(self, positions, embeds, hidden_states, residual):
         if self.layer_idx == 0:
-            # First layer: preVwn + vwn layer
-            wider_hidden_states = self.pre_vwn_layer(embeds, hidden_states)
-
-            # attn
-            wider_hidden_states_view = wider_hidden_states.view(-1, self.wider_dim // self.m)
-            downward_wider_hidden_states_tmp = self.downward_and_forgot(wider_hidden_states_view)
-            total_hidden_states = downward_wider_hidden_states_tmp.view(-1, self.hidden_size + self.wider_dim)
-            hidden_states, hidden_residual = torch.split(
-                total_hidden_states,
-                [self.hidden_size, total_hidden_states.shape[-1] - self.hidden_size],
-                dim=-1
-            )
-            hidden_states = self.pre_attention_layernorm(hidden_states)
-            hidden_states = self.self_attn(
+            hs, wd, m = self.hidden_size, self.wider_dim, self.m
+            wider = self.pre_vwn_layer(embeds, hidden_states)
+            # Attention
+            out = self.downward_and_forgot(wider.view(-1, wd // m)).view(-1, hs + wd)
+            hidden, res = out.split([hs, wd], dim=-1)
+            hidden = self.self_attn(
                 positions=positions,
-                hidden_states=hidden_states,
-            )
-            hidden_states_view = hidden_states.view(-1, self.hidden_size // self.m)
-            upward_hidden_states_tmp = self.upward_after_attn(hidden_states_view)
-            upward_hidden_states = upward_hidden_states_tmp.view(-1, self.wider_dim)
-            wider_hidden_states = upward_hidden_states + hidden_residual
-
-            # mlp
-            wider_hidden_states_view =  wider_hidden_states.view(-1, self.wider_dim//self.m)
-            downward_wider_hidden_states_tmp = self.downward_and_forgot_after_attn(wider_hidden_states_view)
-            total_hidden_states = downward_wider_hidden_states_tmp.view(-1, self.hidden_size + self.wider_dim)
-            hidden_states, hidden_residual = torch.split(
-                total_hidden_states,
-                [self.hidden_size, total_hidden_states.shape[-1] - self.hidden_size],
-                dim=-1
-            )
-            hidden_states = self.post_attention_layernorm(hidden_states)
-            hidden_states = self.mlp(hidden_states)
-            hidden_states_view = hidden_states.view(-1, self.hidden_size // self.m)
-            upward_hidden_states_tmp = self.upward_after_mlp(hidden_states_view)
-            upward_hidden_states = upward_hidden_states_tmp.view(-1, self.wider_dim)
-            hidden_states = upward_hidden_states + hidden_residual
-
-            # downward
-            if self.expanded_factor != 1:
-                wider_hidden_states_view = hidden_states.view(-1, self.wider_dim // self.m)
-                hidden_state_tmp = self.downward(wider_hidden_states_view)
-                hidden_states = hidden_state_tmp.view(-1, self.hidden_size)
-
+                hidden_states=self.pre_attention_layernorm(hidden))
+            wider = self.upward_after_attn(hidden.view(-1, hs // m)).view(-1, wd) + res
+            # MLP
+            out = self.downward_and_forgot_after_attn(
+                wider.view(-1, wd // m)).view(-1, hs + wd)
+            hidden, res = out.split([hs, wd], dim=-1)
+            wider = self.upward_after_mlp(
+                self.mlp(self.post_attention_layernorm(hidden)).view(-1, hs // m)
+                ).view(-1, wd) + res
+            # Downward
+            hidden_states = self.downward(wider.view(-1, wd // m)).view(-1, hs)
         return hidden_states, residual
 
 
 @support_torch_compile(
-    dynamic_arg_dims={
-        "input_ids": 0,
-        "positions": -1,
-        "hidden_states": 0,
-        "input_embeds": 0,
-    }
-)
-class VwnLlamaModel(nn.Module):
-    def __init__(
-        self,
-        *,
-        vllm_config: VllmConfig,
-        start_layer_id: int = 0,
-        prefix: str = "",
-    ) -> None:
-        super().__init__()
-        self.config = vllm_config.speculative_config.draft_model_config.hf_config
-        self.vocab_size = self.config.vocab_size
+    dynamic_arg_dims={"input_ids": 0, "positions": -1,
+                      "hidden_states": 0, "input_embeds": 0})
+class VwnLlamaModel(Eagle3LlamaModel):
 
-        # Get drafter's quantization config
-        self.quant_config = get_draft_quant_config(vllm_config)
+    def __init__(self, *, vllm_config, start_layer_id=0, prefix=""):
+        super().__init__(vllm_config=vllm_config, start_layer_id=start_layer_id,
+                         prefix=prefix)
+        vc = get_current_vllm_config()
+        self.layers = nn.ModuleList([
+            VwnLlamaDecoderLayer(vc, maybe_prefix(prefix, f"layers.{i + start_layer_id}"),
+                                 self.config, layer_idx=i)
+            for i in range(self.config.num_hidden_layers)])
 
-        eagle_config = getattr(self.config, "eagle_config", None)
-        if eagle_config is not None and "use_aux_hidden_state" in eagle_config:
-            self.use_aux_hidden_state = eagle_config["use_aux_hidden_state"]
-        else:
-            self.use_aux_hidden_state = True
-
-        current_vllm_config = get_current_vllm_config()
-
-        self.embed_tokens = VocabParallelEmbedding(
-            self.config.vocab_size,
-            self.config.hidden_size,
-            prefix=maybe_prefix(prefix, "embed_tokens"),
-        )
-
-        self.layers = nn.ModuleList(
-            [
-                VwnLlamaDecoderLayer(
-                    current_vllm_config,
-                    prefix=maybe_prefix(prefix, f"layers.{layer_idx + start_layer_id}"),
-                    config=self.config,
-                    layer_idx=layer_idx,
-                )
-                for layer_idx in range(self.config.num_hidden_layers)
-            ]
-        )
-        if self.use_aux_hidden_state:
-            if hasattr(self.config, "target_hidden_size"):
-                fc_input_size = self.config.target_hidden_size * 3
-            else:
-                fc_input_size = self.config.hidden_size * 3
-            self.fc = ReplicatedLinear(
-                input_size=fc_input_size,
-                output_size=self.config.hidden_size,
-                bias=False,
-                params_dtype=vllm_config.model_config.dtype,
-                quant_config=self.quant_config,
-                prefix=maybe_prefix(prefix, "fc"),
-                return_bias=False,
-            )
-        self.norm = RMSNorm(
-            self.config.hidden_size,
-            eps=self.config.rms_norm_eps,
-        )
-
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.embed_tokens(input_ids)
-
-    def forward(
-        self,
-        input_ids: torch.Tensor,
-        positions: torch.Tensor,
-        hidden_states: torch.Tensor,
-        input_embeds: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    def forward(self, input_ids, positions, hidden_states, input_embeds=None):
         if input_embeds is None:
             input_embeds = self.embed_input_ids(input_ids)
-        assert hidden_states.shape[-1] == input_embeds.shape[-1]
-
         residual = None
         for layer in self.layers:
             hidden_states, residual = layer(
-                positions=positions,
-                embeds=input_embeds,
-                hidden_states=hidden_states,
-                residual=residual,
-            )
-        hidden_prenorm = hidden_states
-        hidden_states = self.norm(hidden_states, residual)
-        return hidden_states, hidden_prenorm
-
-    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        stacked_params_mapping = [
-            # (param_name, shard_name, shard_id)
-            (".qkv_proj", ".q_proj", "q"),
-            (".qkv_proj", ".k_proj", "k"),
-            (".qkv_proj", ".v_proj", "v"),
-            (".gate_up_proj", ".gate_proj", 0),
-            (".gate_up_proj", ".up_proj", 1),
-        ]
-        params_dict = dict(self.named_parameters())
-        loaded_params: set[str] = set()
-        for name, loaded_weight in weights:
-            if "midlayer." in name:
-                name = name.replace("midlayer.", "layers.0.")
-            # Handle kv cache quantization scales
-            if self.quant_config is not None and (
-                scale_name := self.quant_config.get_cache_scale(name)
-            ):
-                # Loading kv cache quantization scales
-                param = params_dict[scale_name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                loaded_weight = (
-                    loaded_weight if loaded_weight.dim() == 0 else loaded_weight[0]
-                )
-                weight_loader(param, loaded_weight)
-                loaded_params.add(scale_name)
-                continue
-            # Remapping the name FP8 kv-scale or zero point.
-            if "scale" in name or "zero_point" in name:
-                name = maybe_remap_kv_scale_name(name, params_dict)
-                if name is None:
-                    continue
-            for param_name, weight_name, shard_id in stacked_params_mapping:
-                if weight_name not in name:
-                    continue
-                name = name.replace(weight_name, param_name)
-                param = params_dict[name]
-                weight_loader = param.weight_loader
-                weight_loader(param, loaded_weight, shard_id)
-                break
-            else:
-                param = params_dict[name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                weight_loader(param, loaded_weight)
-            loaded_params.add(name)
-        return loaded_params
+                positions=positions, embeds=input_embeds,
+                hidden_states=hidden_states, residual=residual)
+        return self.norm(hidden_states, residual), hidden_states
 
 
-class Eagle3VwnLlamaForCausalLM(LlamaForCausalLM):
-    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
-        nn.Module.__init__(self)
-        self.config = vllm_config.speculative_config.draft_model_config.hf_config
-        # Ensure draft_vocab_size is set
-        # default to the base vocab size when absent
-        if getattr(self.config, "draft_vocab_size", None) is None:
-            base_vocab_size = getattr(self.config, "vocab_size", None)
-            self.config.draft_vocab_size = base_vocab_size
-        target_layer_num = vllm_config.model_config.get_num_layers(
-            vllm_config.parallel_config
-        )
+class Eagle3VwnLlamaForCausalLM(Eagle3LlamaForCausalLM):
 
-        # Store target layer count in draft config for
-        # proper layer_types indexing in draft models
-        self.config.target_layer_count = target_layer_num
-        self.model = VwnLlamaModel(
-            vllm_config=vllm_config, prefix="model", start_layer_id=target_layer_num
-        )
-
-        logit_scale = getattr(self.config, "logit_scale", 1.0)
-        self.lm_head = ParallelLMHead(
-            self.config.draft_vocab_size,
-            self.config.hidden_size,
-            prefix=maybe_prefix(prefix, "lm_head"),
-        )
-        self.logits_processor = LogitsProcessor(
-            self.config.draft_vocab_size, scale=logit_scale
-        )
-        self.draft_id_to_target_id = nn.Parameter(
-            torch.zeros(self.config.draft_vocab_size, dtype=torch.long),
-            requires_grad=False,
-        )
-
-    def embed_input_ids(
-        self,
-        input_ids: torch.Tensor,
-        multimodal_embeddings: NestedTensors | None = None,
-        is_multimodal: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        return self.model.embed_input_ids(input_ids)
-
-    def forward(
-        self,
-        input_ids: torch.Tensor,
-        positions: torch.Tensor,
-        hidden_states: torch.Tensor,
-        inputs_embeds: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        return self.model(input_ids, positions, hidden_states, inputs_embeds)
-
-    def compute_logits(
-        self,
-        hidden_states: torch.Tensor,
-    ) -> torch.Tensor | None:
-        logits = self.logits_processor(self.lm_head, hidden_states)
-        if self.draft_id_to_target_id is None:
-            assert logits.shape[1] == self.config.vocab_size, (
-                "Expected logits to have shape "
-                f"(*, {self.config.vocab_size}), but got {logits.shape}"
-            )
-            return logits
-
-        base = torch.arange(self.config.draft_vocab_size, device=logits.device)
-        targets = base + self.draft_id_to_target_id
-        logits_new = logits.new_full(
-            (
-                logits.shape[0],
-                self.config.vocab_size,
-            ),
-            float("-inf"),
-        )
-        logits_new[:, targets] = logits
-        return logits_new
-
-    def combine_hidden_states(
-        self,
-        hidden_states: torch.Tensor,
-    ) -> torch.Tensor:
-        if not self.model.use_aux_hidden_state:
-            return hidden_states
-        # combine multiple auxiliary hidden states returned by eagle3
-        return self.model.fc(hidden_states)
-
-    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
-        model_weights = {}
-        includes_draft_id_mapping = False
-        includes_embed_tokens = False
-        for name, loaded_weight in weights:
-            if "t2d" in name:
-                continue
-            if "d2t" in name:
-                name = name.replace("d2t", "draft_id_to_target_id")
-                includes_draft_id_mapping = True
-            elif "lm_head" not in name:
-                name = "model." + name
-            if "embed_tokens" in name:
-                includes_embed_tokens = True
-            model_weights[name] = loaded_weight
-            process_eagle_weight(self, name)
-
-        skip_substrs = []
-        if not includes_draft_id_mapping:
-            skip_substrs.append("draft_id_to_target_id")
-        if not includes_embed_tokens:
-            skip_substrs.append("embed_tokens")
-        if not self.model.use_aux_hidden_state:
-            skip_substrs.append("fc.")
-        loader = AutoWeightsLoader(
-            self,
-            skip_prefixes=None,
-            skip_substrs=skip_substrs,
-        )
-        loader.load_weights(model_weights.items())
+    def __init__(self, *, vllm_config, prefix=""):
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        n = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
+        self.model = VwnLlamaModel(vllm_config=vllm_config, prefix="model",
+                                   start_layer_id=n)

--- a/vllm_ascend/models/llama_eagle3_vwn.py
+++ b/vllm_ascend/models/llama_eagle3_vwn.py
@@ -127,6 +127,7 @@ class PreVwnLayerV1(nn.Module):
         hidden_size = config.hidden_size
         m = getattr(config, "vwn_m", 1)
         expanded_factor = getattr(config, "vwn_r", 1)
+        self.expnded_factor = expanded_factor
         wider_dim = int(hidden_size * expanded_factor)
         self.wider_dim = wider_dim
 
@@ -142,17 +143,18 @@ class PreVwnLayerV1(nn.Module):
             prefix=maybe_prefix(prefix, "fc"),
             return_bias=False,
         )
-        upward_input_size = hidden_size // m
-        upward_output_size = wider_dim // m
-        self.upward = ReplicatedLinear(
-            input_size=upward_input_size,
-            output_size=upward_output_size,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "upward"),
-            return_bias=False,
-        )
+        if expanded_factor != 1:
+            upward_input_size = hidden_size // m
+            upward_output_size = wider_dim // m
+            self.upward = ReplicatedLinear(
+                input_size=upward_input_size,
+                output_size=upward_output_size,
+                bias=False,
+                params_dtype=vllm_config.model_config.dtype,
+                quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "upward"),
+                return_bias=False,
+            )
         self.m = m
         self.hidden_size = hidden_size
         self.wider_dim = wider_dim
@@ -166,48 +168,13 @@ class PreVwnLayerV1(nn.Module):
         norm_hidden = self.hidden_norm(hidden_states)
         hidden_to_fc = torch.cat([norm_embeds, norm_hidden], dim=-1)
         hidden_after_fc = self.fc(hidden_to_fc)
-        hidden_after_fc_new = hidden_after_fc.view(-1 , self.hidden_size // self.m)
-        wider_hidden_states_tmp = self.upward(hidden_after_fc_new)
-        wider_hidden_states = wider_hidden_states_tmp.view(-1 , self.wider_dim)
-
+        if self.expnded_factor != 1:
+            hidden_after_fc_new = hidden_after_fc.view(-1 , self.hidden_size // self.m)
+            wider_hidden_states_tmp = self.upward(hidden_after_fc_new)
+            wider_hidden_states = wider_hidden_states_tmp.view(-1 , self.wider_dim)
+        else:
+            wider_hidden_states = hidden_after_fc
         return wider_hidden_states
-
-class PreVwnLayerV2(nn.Module):
-    def __init__(
-        self,
-        vllm_config: VllmConfig,
-        prefix: str = "",
-        config: LlamaConfig | None = None,
-        quant_config: QuantizationConfig = None,
-    ) -> None:
-        super().__init__()
-        config = config or vllm_config.model_config.hf_config
-        hidden_size = config.hidden_size
-
-        self.input_layernorm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
-        self.hidden_norm = RMSNorm(hidden_size, eps=config.rms_norm_eps)
-        fc_input_size = 2 * hidden_size
-        self.fc = ReplicatedLinear(
-            input_size=fc_input_size,
-            output_size=hidden_size,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "fc"),
-            return_bias=False,
-        )
-
-    def forward(
-        self,
-        embeds: torch.Tensor,
-        hidden_states: torch.Tensor
-    ):
-        norm_embeds = self.input_layernorm(embeds)
-        norm_hidden = self.hidden_norm(hidden_states)
-        hidden_to_fc = torch.cat([norm_embeds, norm_hidden], dim=-1)
-        hidden_after_fc = self.fc(hidden_to_fc)
-        return hidden_after_fc
-
 
 class VwnLlamaDecoderLayer(LlamaDecoderLayer):
     def __init__(
@@ -223,12 +190,14 @@ class VwnLlamaDecoderLayer(LlamaDecoderLayer):
         quant_config = self.get_quant_config(vllm_config)
         m = getattr(config, "vwn_m", 1)
         expanded_factor = getattr(config, "vwn_r", 1)
-        n = int(expanded_factor * m)
+        self.expanded_factor = expanded_factor
         wider_dim = int(self.hidden_size * expanded_factor)
         self.wider_dim = wider_dim
         self.m = m
         upward_input_size = self.hidden_size // m
         upward_output_size = wider_dim // m
+        downward_input_size = wider_dim // m
+        downard_output_size = (self.hidden_size + wider_dim) // m
         pre_vwn_version = getattr(config, "pre_vwn_version", 0)
         self.pre_vwn_version = pre_vwn_version
         if pre_vwn_version == 0:
@@ -245,17 +214,10 @@ class VwnLlamaDecoderLayer(LlamaDecoderLayer):
                 config=config,
                 quant_config=quant_config
             )
-        else:
-            self.pre_vwn_layer = PreVwnLayerV2(
-                vllm_config,
-                prefix=maybe_prefix(prefix, f"layers.pre_vwn_layer"),
-                config=config,
-                quant_config=quant_config
-            )
 
         self.downward_and_forgot = ReplicatedLinear(
-            input_size=wider_dim,
-            output_size=self.hidden_size + wider_dim,
+            input_size=downward_input_size,
+            output_size=downard_output_size,
             bias=False,
             params_dtype=vllm_config.model_config.dtype,
             quant_config=quant_config,
@@ -274,8 +236,8 @@ class VwnLlamaDecoderLayer(LlamaDecoderLayer):
             return_bias=False,
         )
         self.downward_and_forgot_after_attn = ReplicatedLinear(
-            input_size=wider_dim,
-            output_size=self.hidden_size + wider_dim,
+            input_size=downward_input_size,
+            output_size=downard_output_size,
             bias=False,
             params_dtype=vllm_config.model_config.dtype,
             quant_config=quant_config,
@@ -292,15 +254,16 @@ class VwnLlamaDecoderLayer(LlamaDecoderLayer):
             prefix=maybe_prefix(prefix, "upward_after_mlp"),
             return_bias=False,
         )
-        self.downward = ReplicatedLinear(
-            input_size=upward_output_size,
-            output_size=upward_input_size,
-            bias=False,
-            params_dtype=vllm_config.model_config.dtype,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "downward"),
-            return_bias=False,
-        )
+        if self.expanded_factor != 1:
+            self.downward = ReplicatedLinear(
+                input_size=upward_output_size,
+                output_size=upward_input_size,
+                bias=False,
+                params_dtype=vllm_config.model_config.dtype,
+                quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "downward"),
+                return_bias=False,
+            )
 
         self.layer_idx = layer_idx
 
@@ -320,7 +283,9 @@ class VwnLlamaDecoderLayer(LlamaDecoderLayer):
             wider_hidden_states = self.pre_vwn_layer(embeds, hidden_states)
 
             # attn
-            total_hidden_states = self.downward_and_forgot(wider_hidden_states)
+            wider_hidden_states_view = wider_hidden_states.view(-1, self.wider_dim // self.m)
+            downward_wider_hidden_states_tmp = self.downward_and_forgot(wider_hidden_states_view)
+            total_hidden_states = downward_wider_hidden_states_tmp.view(-1, self.hidden_size + self.wider_dim)
             hidden_states, hidden_residual = torch.split(
                 total_hidden_states,
                 [self.hidden_size, total_hidden_states.shape[-1] - self.hidden_size],
@@ -337,7 +302,9 @@ class VwnLlamaDecoderLayer(LlamaDecoderLayer):
             wider_hidden_states = upward_hidden_states + hidden_residual
 
             # mlp
-            total_hidden_states = self.downward_and_forgot_after_attn(wider_hidden_states)
+            wider_hidden_states_view =  wider_hidden_states.view(-1, self.wider_dim//self.m)
+            downward_wider_hidden_states_tmp = self.downward_and_forgot_after_attn(wider_hidden_states_view)
+            total_hidden_states = downward_wider_hidden_states_tmp.view(-1, self.hidden_size + self.wider_dim)
             hidden_states, hidden_residual = torch.split(
                 total_hidden_states,
                 [self.hidden_size, total_hidden_states.shape[-1] - self.hidden_size],
@@ -351,7 +318,7 @@ class VwnLlamaDecoderLayer(LlamaDecoderLayer):
             hidden_states = upward_hidden_states + hidden_residual
 
             # downward
-            if self.pre_vwn_version != 2:
+            if self.expanded_factor != 1:
                 wider_hidden_states_view = hidden_states.view(-1, self.wider_dim // self.m)
                 hidden_state_tmp = self.downward(wider_hidden_states_view)
                 hidden_states = hidden_state_tmp.view(-1, self.hidden_size)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -44,6 +44,7 @@ from vllm.v1.spec_decode.utils import (
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.models.llama_eagle3_vwn import Eagle3VwnLlamaForCausalLM
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
@@ -612,7 +613,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         if self.method in ("eagle3", "dflash"):
             assert isinstance(
-                self.get_model(), (Eagle3LlamaForCausalLM, DFlashQwen3ForCausalLM, Eagle3DeepseekV2ForCausalLM)
+                self.get_model(), (Eagle3LlamaForCausalLM,
+                                                 DFlashQwen3ForCausalLM,
+                                                 Eagle3VwnLlamaForCausalLM,
+                                                 Eagle3DeepseekV2ForCausalLM)
             )
             target_hidden_states = self.model.combine_hidden_states(target_hidden_states)
             assert target_hidden_states.shape[-1] == self.hidden_size


### PR DESCRIPTION
### What this PR does / why we need it?
增添E2E用例看护VWN Eagle3性能，具体增加的E2E用例，以及其看护范围如下：

| Test Method| Scheduling Mode | Batch Configuration| max\_tokens | Assertion Method| Coverage Scope|
| -----------| --------- | ----------------- | ----------- | ------------------ | ------------------------------------|
| `test_vwn_eagle3_acceptance_tp4`                   | async=True      | padded batch              | 256         | acceptance-per-pos vs golden \[0.50, 0.25, 0.10], tolerance=0.15 | Acceptance rate regression under default async scheduling  |
| `test_vwn_eagle3_correctness_tp4`                  | default         | padded batch              | 64          | Greedy decoding output non-empty                                 | Basic functional correctness                               |
| `test_vwn_eagle3_acceptance_tp4_async_false`       | async=False     | padded batch              | 256         | acceptance-per-pos vs golden, tolerance=0.20                     | Acceptance rate under synchronous scheduling mode          |
| `test_vwn_eagle3_disable_padded_drafter_batch_tp4` | default         | padded batch **disabled** | 64          | Greedy decoding output non-empty                                 | Correctness with padded drafter batch disabled             |
| `test_vwn_eagle3_longer_generation_tp4`            | default         | padded batch              | 512         | Output non-empty + token count > 0                               | Spec decode loop stability under long generation scenarios |


### Does this PR introduce _any_ user-facing change?
Nope

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
