### PR TITLE
[CI] Fix delete wait-feedback label progress

### DIFF
--- a/.github/workflows/schedule_stale_manage.yaml
+++ b/.github/workflows/schedule_stale_manage.yaml
@@ -7,13 +7,13 @@ on:
 
 jobs:
   remove-wait-feedback-on-comment:
-    if: ${{ github.event_name == 'issue_comment' }}
+    if: ${{ github.event_name == 'issue_comment' && contains(github.event.issue.labels.*.name, 'wait-feedback') }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
     steps:
       # When an issue tagged with "wait-feedback" receives a new response, the "wait-feedback" tag will be removed.
-      - run: gh issue edit "${{ github.event.issue.number }}" --remove-label "wait-feedback"
+      - run: gh issue edit "${{ github.event.issue.number }}" --remove-label "wait-feedback" --repo "${{ github.repository }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   stale:


### PR DESCRIPTION
### What this PR does / why we need it?
Background：
Fixed an issue that caused a batch of actions to fail when submitting a PR.
The above problem was fixed by specifying the repository for the .git command.

Purpose：
The wait-feedback tag will automatically close when there are comments or replies to the issue.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
