### PR TITLE
[BugFix][CI] Enable chat template for InternVL and LLaVA accuracy configs

### DIFF
--- a/tests/e2e/models/configs/InternVL3_5-8B-hf.yaml
+++ b/tests/e2e/models/configs/InternVL3_5-8B-hf.yaml
@@ -16,6 +16,6 @@ tasks:
       value: 0.58
 
 num_fewshot: 0
-apply_chat_template: false
+apply_chat_template: true
 fewshot_as_multiturn: false
 batch_size: "auto"

--- a/tests/e2e/models/configs/llava-onevision-qwen2-0.5b-ov-hf.yaml
+++ b/tests/e2e/models/configs/llava-onevision-qwen2-0.5b-ov-hf.yaml
@@ -16,6 +16,6 @@ tasks:
     value: 0.42
 
 num_fewshot: 0
-apply_chat_template: false
+apply_chat_template: true
 fewshot_as_multiturn: false
 batch_size: "auto"


### PR DESCRIPTION
### What this PR does / why we need it?

This PR enables `apply_chat_template` for additional VLM accuracy test configs:

- `InternVL3_5-8B-hf.yaml`
- `llava-onevision-qwen2-0.5b-ov-hf.yaml`

PR #9829 fixed the same class of issue for Qwen3-VL / Qwen3-Omni MMMU accuracy tests. Those models require their chat templates to inject multimodal placeholder tokens into prompts before vLLM's multimodal processor applies image token replacement.

For VLM accuracy configs, keeping `apply_chat_template: false` can make multimodal evaluation prompts miss model-specific image placeholders. This may cause failures when the evaluation task includes image inputs, because the multimodal processor cannot find where to replace the image placeholders.

This PR proactively aligns the remaining VLM accuracy configs with that behavior by enabling chat templates for InternVL3.5 and LLaVA-OneVision.

### Does this PR introduce _any_ user-facing change?

No.

This only updates CI accuracy test configurations. It does not change production vLLM Ascend inference behavior or public APIs.

### How was this patch tested?

Not tested locally.

This change needs to be validated by the vLLM Ascend accuracy CI on NPU hardware. The purpose of this PR is to trigger official CI accuracy validation for the updated VLM configs.
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
