### PR TITLE
[UT] Add UT for sliding window Eagle3

### DIFF
--- a/tests/ut/spec_decode/test_sliding_window.py
+++ b/tests/ut/spec_decode/test_sliding_window.py
@@ -1,0 +1,260 @@
+"""Unit tests for ``_apply_sliding_window`` in ``AscendSpecDecodeBaseProposer``.
+
+Tests verify the core sliding-window invariants:
+  - ``block_table_tensor`` is cropped to the window region [start_block, start_block + needed)
+  - ``seq_lens`` is clamped to ``min(L, W)``
+  - ``_sliding_window_full_block_table`` preserves the original (uncropped) table
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from vllm.config import CacheConfig, CompilationMode, VllmConfig, set_current_vllm_config
+
+from vllm_ascend.ascend_config import clear_ascend_config, init_ascend_config
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
+from vllm_ascend.utils import vllm_version_is
+
+_CPU_GPU_BUFFER_TARGET = (
+    "vllm.v1.spec_decode.eagle.CpuGpuBuffer"
+    if vllm_version_is("0.19.1")
+    else "vllm.v1.spec_decode.llm_base_proposer.CpuGpuBuffer"
+)
+
+BLOCK_SIZE = 16
+DEVICE = torch.device("cpu")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _patch_deps():
+    with (
+        patch(_CPU_GPU_BUFFER_TARGET),
+        patch("vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs", return_value=False),
+    ):
+        yield
+    clear_ascend_config()
+    set_current_vllm_config(None)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_vllm_config(
+    *,
+    block_size: int = BLOCK_SIZE,
+    num_speculative_tokens: int = 2,
+    draft_window_size: int | None = None,
+):
+    """Create a mock ``VllmConfig`` with sliding-window parameters."""
+    from vllm.config import SpeculativeConfig
+
+    vllm_config = MagicMock(spec=VllmConfig)
+    sc = vllm_config.speculative_config
+    sc.method = "eagle3"
+    sc.num_speculative_tokens = num_speculative_tokens
+    sc.parallel_drafting = False
+    sc.draft_tensor_parallel_size = 1
+    sc.draft_model_config = MagicMock()
+    sc.draft_model_config.uses_xdrope_dim = 0
+    sc.draft_model_config.uses_mrope = False
+    sc.draft_model_config.get_hidden_size.return_value = 2048
+    sc.draft_model_config.get_inputs_embeds_size.return_value = 2048
+    sc.disable_padded_drafter_batch = False
+    sc.draft_window_size = draft_window_size
+    if "speculative_token_tree" in SpeculativeConfig.__dataclass_fields__:
+        sc.speculative_token_tree = str([(i + 1) * (0,) for i in range(num_speculative_tokens)])
+
+    vllm_config.cache_config = MagicMock(spec=CacheConfig)
+    vllm_config.cache_config.block_size = block_size
+    vllm_config.scheduler_config.max_num_batched_tokens = 1024
+    vllm_config.scheduler_config.max_num_seqs = 32
+    vllm_config.model_config.dtype = torch.float16
+    vllm_config.model_config.max_model_len = 2048
+    vllm_config.model_config.uses_mrope = False
+    vllm_config.model_config.uses_xdrope_dim = 0
+    vllm_config.model_config.use_mla = False
+    vllm_config.model_config.enforce_eager = True
+    vllm_config.model_config.is_deepseek_mla = False
+    vllm_config.model_config.hf_text_config = MagicMock(spec=[])
+    vllm_config.model_config.hf_text_config.to_dict = MagicMock(return_value={})
+    vllm_config.parallel_config.tensor_parallel_size = 1
+    vllm_config.parallel_config.data_parallel_rank = 0
+    vllm_config.parallel_config.data_parallel_size = 1
+    vllm_config.parallel_config.prefill_context_parallel_size = 1
+    vllm_config.parallel_config.enable_expert_parallel = False
+    vllm_config.pipeline_parallel_size = 1
+    vllm_config.kv_transfer_config = None
+    vllm_config.compilation_config = MagicMock()
+    vllm_config.compilation_config.mode = CompilationMode.NONE
+    vllm_config.compilation_config.pass_config = MagicMock()
+    vllm_config.compilation_config.pass_config.enable_sp = False
+    vllm_config.additional_config = (
+        {"draft_window_size": draft_window_size} if draft_window_size is not None else None
+    )
+
+    init_ascend_config(vllm_config)
+    return vllm_config
+
+
+def _create_proposer(
+    *,
+    block_size: int = BLOCK_SIZE,
+    num_speculative_tokens: int = 2,
+    draft_window_size: int | None = None,
+) -> AscendEagleProposer:
+    """Create an ``AscendEagleProposer`` with the given sliding-window config."""
+    vllm_config = _create_vllm_config(
+        block_size=block_size,
+        num_speculative_tokens=num_speculative_tokens,
+        draft_window_size=draft_window_size,
+    )
+    runner = MagicMock()
+    runner.block_size = block_size
+    runner.pin_memory = False
+    runner.pcp_size = 1
+    runner.dcp_size = 1
+    runner.max_num_tokens = 1024
+    runner.max_num_reqs = 32
+
+    with set_current_vllm_config(vllm_config):
+        proposer = AscendEagleProposer(vllm_config=vllm_config, device=DEVICE, runner=runner)
+
+    # Fallback: if __init__ didn't pick up draft_window_size, set it manually.
+    if draft_window_size is not None and getattr(proposer, "draft_window_size", None) is None:
+        proposer.draft_window_size = draft_window_size
+        proposer.block_size = block_size
+        proposer.window_blocks = (draft_window_size + block_size - 1) // block_size
+        proposer.max_window_blocks = proposer.window_blocks + 1
+        proposer._sliding_window_full_block_table = None
+        proposer._sliding_window_start_block_indices = None
+
+    return proposer
+
+
+def _build_metadata(
+    seq_lens: list[int],
+    block_size: int,
+) -> AscendCommonAttentionMetadata:
+    """Build a minimal ``AscendCommonAttentionMetadata`` with deterministic
+    block indices (``arange``) for easy assertion."""
+    bs = len(seq_lens)
+    max_blocks = (max(seq_lens) + block_size - 1) // block_size
+    block_table_tensor = torch.arange(bs * max_blocks, dtype=torch.int32).view(bs, max_blocks)
+    seq_lens_t = torch.tensor(seq_lens, dtype=torch.int32)
+    return AscendCommonAttentionMetadata(
+        query_start_loc=torch.zeros(bs + 1, dtype=torch.int32),
+        query_start_loc_cpu=torch.zeros(bs + 1, dtype=torch.int32),
+        seq_lens=seq_lens_t,
+        seq_lens_cpu=seq_lens_t.cpu(),
+        num_computed_tokens_cpu=torch.zeros(bs, dtype=torch.int32),
+        num_reqs=bs,
+        num_actual_tokens=bs,
+        max_query_len=1,
+        max_seq_len=max(seq_lens),
+        block_table_tensor=block_table_tensor,
+        slot_mapping=torch.arange(bs, dtype=torch.int64),
+        causal=True,
+        positions=torch.zeros(bs, dtype=torch.int64),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "W, B, K, L",
+    [
+        (64,  16, 2,   50),  # L+K=52  < W  — full coverage
+        (64,  16, 2,   62),  # L+K=64  == W — exact boundary
+        (64,  16, 2,  100),  # L+K=102 > W  — window crops
+        (512, 128, 4, 800),  # B=128, K=4
+        (32,  16, 8,  100),  # K=8, tiny W
+        (1,   16, 2,  100),  # W=1 extreme
+    ],
+)
+def test_block_table_and_seq_lens(W, B, K, L):
+    """Verify block-table cropping and seq_lens clamping for various (W, B, K, L)."""
+    proposer = _create_proposer(draft_window_size=W, num_speculative_tokens=K, block_size=B)
+    meta = _build_metadata([L], B)
+    orig_bt = meta.block_table_tensor.clone()
+    full_seq_lens = meta.seq_lens.clone()
+
+    proposer._apply_sliding_window(meta, full_seq_lens)
+
+    # --- expected values ---
+    final_len = L + K
+    start_token = max(0, final_len - W)
+    start_block = (start_token // B) * B
+    start_block_idx = start_block // B
+    tokens_to_cover = final_len - start_block
+    needed_blocks = (tokens_to_cover + B - 1) // B
+    max_blocks = proposer.max_window_blocks
+
+    # --- seq_lens clamped to min(L, W) ---
+    assert meta.seq_lens[0].item() == min(L, W)
+
+    # --- block_table content matches original[start_block_idx : start_block_idx + needed] ---
+    actual_needed = min(needed_blocks, max_blocks)
+    end_idx = start_block_idx + actual_needed
+    if end_idx <= orig_bt.shape[1]:
+        assert torch.equal(meta.block_table_tensor[0, :actual_needed], orig_bt[0, start_block_idx:end_idx])
+    # trailing positions are zero
+    assert torch.all(meta.block_table_tensor[0, actual_needed:] == 0)
+
+    # --- output shape is fixed at max_window_blocks (graph compat) ---
+    assert meta.block_table_tensor.shape[1] == max_blocks
+
+    # --- original full block table is preserved for slot-mapping ---
+    assert torch.equal(proposer._sliding_window_full_block_table, orig_bt)
+
+
+def test_multi_request_batch():
+    """Each request in a batch gets an independently cropped block table."""
+    W, B, K = 128, BLOCK_SIZE, 2
+    proposer = _create_proposer(draft_window_size=W, num_speculative_tokens=K, block_size=B)
+    # L = [50, 200, 130]  →  L+K = [52, 202, 132]
+    meta = _build_metadata([50, 200, 130], B)
+    orig_bt = meta.block_table_tensor.clone()
+
+    proposer._apply_sliding_window(meta, meta.seq_lens.clone())
+
+    # seq_lens clamped independently
+    assert torch.equal(meta.seq_lens, torch.tensor([50, 128, 128], dtype=torch.int32))
+
+    # block table content for each request
+    # req0: start=0, needed=ceil(52/16)=4  → blocks [0:4]
+    assert torch.equal(meta.block_table_tensor[0, :4], orig_bt[0, :4])
+    # req1: start_token=74, start_block=64, idx=4, needed=ceil(138/16)=9 → blocks [4:13]
+    assert torch.equal(meta.block_table_tensor[1, :9], orig_bt[1, 4:13])
+
+    # full block table preserved
+    assert torch.equal(proposer._sliding_window_full_block_table, orig_bt)
+
+
+def test_block_table_underflow_pads_zeros():
+    """When the full block table has fewer columns than the window needs,
+    valid blocks are copied and missing positions are filled with zeros."""
+    W, B, K = 256, BLOCK_SIZE, 2
+    proposer = _create_proposer(draft_window_size=W, num_speculative_tokens=K, block_size=B)
+    # L=300 → needs 17 blocks, but table only has 10
+    meta = _build_metadata([300], B)
+    meta.block_table_tensor = meta.block_table_tensor[:, :10]
+
+    proposer._apply_sliding_window(meta, meta.seq_lens.clone())
+
+    # blocks 2..9 present, rest zero
+    assert torch.equal(meta.block_table_tensor[0, :8], torch.arange(2, 10, dtype=torch.int32))
+    assert torch.all(meta.block_table_tensor[0, 8:] == 0)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -207,6 +207,22 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.enable_enpu = self.runner.enable_enpu
         self.use_eagle = self.runner.use_eagle
 
+        # Sliding window attention for draft model
+        draft_window_size = getattr(self.speculative_config, 'draft_window_size', None)
+        if draft_window_size is None and self.vllm_config.additional_config:
+            draft_window_size = self.vllm_config.additional_config.get('draft_window_size')
+        if isinstance(draft_window_size, int):
+            self.draft_window_size = int(draft_window_size)
+            self.block_size = self.runner.block_size
+            self.window_blocks = (self.draft_window_size + self.block_size - 1) // self.block_size
+            # max needed blocks is window_blocks + 1 because tokens_to_cover can be
+            # up to W + B (when start_tokens is just inside a new block boundary)
+            self.max_window_blocks = self.window_blocks + 1
+            self._sliding_window_full_block_table: torch.Tensor | None = None
+            self._sliding_window_start_block_indices: torch.Tensor | None = None
+        else:
+            self.draft_window_size = None
+
     def _get_model(self) -> nn.Module:
         """
         Default method to call get_model(). Can be overridden by subclasses which
@@ -406,10 +422,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             if hasattr(self.model.model, "topk_indices_buffer"):
                 del self.model.model.topk_indices_buffer
             self.model.model.topk_indices_buffer = target_language_model.model.topk_indices_buffer
-            logger.info(
-                "Detecting MTP model with topk_indices_buffer."
-                "Sharing target model topk_indices_buffer with the draft model."
-            )
 
     def get_model(self) -> nn.Module:
         # get raw model out of the aclgraph wrapper.
@@ -503,6 +515,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     : num_reqs * self.decode_threshold
                 ]
 
+            # Apply sliding window for graph capture so shapes match runtime
+            if self.draft_window_size is not None:
+                self._apply_sliding_window(common_attn_metadata, self.runner.seq_lens[:num_reqs].clone())
+
             assert len(self.draft_attn_groups) > 0
             builder = self.draft_attn_groups[0].get_metadata_builder()
             # update the tensor's address for each step.
@@ -512,7 +528,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 common_attn_metadata.slot_mapping = self.slot_mapping_group[draft_step]
                 common_attn_metadata.seq_lens = self.seq_lens_group[draft_step][:num_reqs]
                 common_attn_metadata.query_start_loc = self.query_start_loc_group[draft_step][: num_reqs + 1]
-                if self.pcp_size * self.dcp_size > 1 and draft_step > 0:
+                if self.draft_window_size is None and self.pcp_size * self.dcp_size > 1 and draft_step > 0:
                     assert self.block_table_tensor_clone is not None, "block_table_tensor_clone is not init"
                     slicing_length = num_reqs * self.decode_threshold
                     common_attn_metadata.block_table_tensor = self.block_table_tensor_clone[:slicing_length]
@@ -582,6 +598,82 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL:
             self._update_full_graph_params(forward_context, num_input_tokens, multi_steps_attn_metadata)
 
+    def _apply_sliding_window(self, common_attn_metadata, full_seq_lens):
+        """Apply sliding window to draft model attention metadata.
+
+        Limits the draft model's attention to the most recent W tokens by
+        cropping block_table_tensor and clamping seq_lens. The original full
+        block table is saved so that slot-mapping (KV-cache write indices)
+        can still use the full KV cache.
+        """
+        if self.draft_window_size is None:
+            return
+        full_block_table = common_attn_metadata.block_table_tensor
+        num_reqs = full_seq_lens.shape[0]
+        K = self.num_speculative_tokens
+        W = self.draft_window_size
+        B = self.block_size
+
+
+        # Final length L+K
+        final_seq_lens = full_seq_lens + K
+        # Window start token
+        start_tokens = (final_seq_lens - W).clamp(min=0)
+        # Align to block boundary
+        start_blocks = (start_tokens // B) * B
+        start_block_indices = (start_blocks // B).to(torch.int64)
+
+        # Dynamically calculate needed blocks per request to handle boundary
+        # misalignment. e.g., W=512, B=128, final_seq_lens=515, start_blocks=0
+        # needs ceil(515/128)=5 blocks, not fixed window_blocks=4.
+        tokens_to_cover = final_seq_lens - start_blocks
+        needed_blocks_per_req = ((tokens_to_cover + B - 1) // B).to(torch.int64)
+        max_needed_blocks = int(needed_blocks_per_req.max().item())
+
+
+        # Use fixed max_window_blocks so tensor shape is constant across
+        # dummy_run (graph capture) and runtime, avoiding ACL graph mismatch.
+        max_blocks = self.max_window_blocks
+        window_block_table = torch.zeros(
+            num_reqs, max_blocks,
+            dtype=full_block_table.dtype, device=full_block_table.device
+        )
+        for i in range(num_reqs):
+            start_idx = start_block_indices[i].item()
+            needed = min(needed_blocks_per_req[i].item(), max_blocks)
+            end_idx = start_idx + needed
+            if end_idx <= full_block_table.shape[1]:
+                window_block_table[i, :needed] = full_block_table[i, start_idx:end_idx]
+            else:
+                valid = full_block_table.shape[1] - start_idx
+                window_block_table[i, :valid] = full_block_table[i, start_idx:]
+
+        # Save original block table and start indices for slot-mapping
+        self._sliding_window_full_block_table = full_block_table
+        self._sliding_window_start_block_indices = start_block_indices
+
+        # Replace common_attn_metadata fields
+        common_attn_metadata.block_table_tensor = window_block_table
+        windowed_seq_lens = torch.min(
+            full_seq_lens,
+            torch.full_like(full_seq_lens, W)
+        )
+        common_attn_metadata.seq_lens = windowed_seq_lens
+        # Sync CPU-side mirrors so attention backends on host see the same lengths
+        if getattr(common_attn_metadata, "seq_lens_cpu", None) is not None:
+            common_attn_metadata.seq_lens_cpu = windowed_seq_lens.cpu()
+        if getattr(common_attn_metadata, "_seq_lens_cpu", None) is not None:
+            common_attn_metadata._seq_lens_cpu = windowed_seq_lens.cpu().clone()
+        if getattr(common_attn_metadata, "seq_lens_cpu_upper_bound", None) is not None:
+            common_attn_metadata.seq_lens_cpu_upper_bound = windowed_seq_lens.cpu().clone()
+
+        # Pre-fill seq_lens_group for multi-step loop
+        for step in range(K):
+            current_len = full_seq_lens + step
+            windowed_len = torch.min(current_len, torch.full_like(current_len, W))
+            self.seq_lens_group[step][:num_reqs].copy_(windowed_len)
+            self.seq_lens_group[step][num_reqs:].fill_(0)
+
     def _propose(
         self,
         # [num_tokens]
@@ -630,6 +722,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             num_prefill_reqs=num_prefill_reqs,
             num_decode_reqs=num_decode_reqs,
         )
+
+        # Save original seq_lens and apply sliding window before any CP adjustments
+        full_seq_lens = common_attn_metadata.seq_lens.clone()
+        self._apply_sliding_window(common_attn_metadata, full_seq_lens)
+
         if self.pcp_size * self.dcp_size > 1:
             assert long_seq_args is not None
             query_lens_d, ori_token_indices_to_sample = long_seq_args
@@ -784,7 +881,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # Clone the data so that when calculating the data at position 2 and position 3
         # in the merged graph, it does not affect position 1
         # FIXME(lilinsiman)
-        if self.pcp_size * self.dcp_size > 1 and self.use_cuda_graph:
+        if self.draft_window_size is None and self.pcp_size * self.dcp_size > 1 and self.use_cuda_graph:
             assert self.block_table_tensor_clone is not None, "block_table_tensor_clone is not init"
             self.block_table_tensor_clone[: common_attn_metadata.block_table_tensor.shape[0]] = (
                 common_attn_metadata.block_table_tensor
@@ -1504,7 +1601,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # operations in case they are modified in next step's `prepare_input`
         # of main model.
         # Increment the sequence lengths.
-        common_attn_metadata.seq_lens[:batch_size] += 1
+        if self.draft_window_size is not None:
+            old_lens = common_attn_metadata.seq_lens[:batch_size].clone()
+            new_lens = common_attn_metadata.seq_lens[:batch_size] + 1
+            new_lens.clamp_(max=self.draft_window_size)
+            common_attn_metadata.seq_lens[:batch_size] = new_lens
+        else:
+            common_attn_metadata.seq_lens[:batch_size] += 1
         # For the requests that exceed the max model length, we set the
         # sequence length to 1 to minimize their overheads in attention.
         common_attn_metadata.seq_lens[:batch_size].masked_fill_(exceeds_max_model_len, 1)
@@ -1545,11 +1648,19 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 block_size = 128
 
             # Compute the slot mapping.
+            # When sliding window is enabled, block_table_tensor may be cropped
+            # for attention, but slot mapping needs the full block table to
+            # address the absolute KV cache positions.
+            if self.draft_window_size is not None and self._sliding_window_full_block_table is not None:
+                block_table_for_slot = self._sliding_window_full_block_table
+            else:
+                block_table_for_slot = old_common_metadata.block_table_tensor
+
             if self.uses_mrope:
                 block_numbers = clamped_positions[0] // block_size
             else:
                 block_numbers = clamped_positions // block_size
-            block_ids = old_common_metadata.block_table_tensor.gather(dim=1, index=block_numbers.view(-1, 1))
+            block_ids = block_table_for_slot.gather(dim=1, index=block_numbers.view(-1, 1))
             block_ids = block_ids.view(-1)
             if self.uses_mrope:
                 slot_mapping = block_ids * block_size + clamped_positions[0] % block_size


### PR DESCRIPTION
### What this PR does / why we need it?

We add UT tests for sliding window Eagle3, the functions of each tests are concluded as following:

| # | Test Case | Description | Scenario | Parameters |
|---|-----------|-------------|----------|------------|
| 1 | test_block_table_and_seq_lens `[64-16-2-50]` | L+K=52 < W=64: window covers full history; block_table unchanged, seq_lens=L, start_block_idx=0 | L+K < W (full coverage) | W=64, B=16, K=2, L=50 |
| 2 | test_block_table_and_seq_lens `[64-16-2-62]` | L+K=64 == W=64: exact boundary; start_token=0, seq_lens=L not truncated | L+K == W (exact boundary) | W=64, B=16, K=2, L=62 |
| 3 | test_block_table_and_seq_lens `[64-16-2-100]` | L+K=102 > W=64: window crops block_table from start_block_idx, seq_lens clamped to W, trailing zeros | L+K > W (window cropping) | W=64, B=16, K=2, L=100 |
| 4 | test_block_table_and_seq_lens `[512-128-4-800]` | B=128 large block_size + K=4 speculative steps; verifies block alignment and seq_lens_group integrity | Non-standard block_size + multi-step | W=512, B=128, K=4, L=800 |
| 5 | test_block_table_and_seq_lens `[32-16-8-100]` | K=8 steps + W=32 small window; seq_lens_group clamps to W progressively across all 8 steps | Many speculative steps + small window | W=32, B=16, K=8, L=100 |
| 6 | test_block_table_and_seq_lens `[1-16-2-100]` | W=1 extreme minimum: seq_lens=1, only 1 block retained | Extreme minimum window | W=1, B=16, K=2, L=100 |
| 7 | test_multi_request_batch | 3 heterogeneous requests (L=50/200/130) each get independently cropped block_table, clamped seq_lens; original full block_table is preserved | Multi-request batch | W=128, B=16, K=2, L=[50,200,130] |
| 8 | test_block_table_underflow_pads_zeros | When block_table columns (10) are fewer than window needs (17), valid blocks are copied and missing positions padded with zeros | Block-table underflow | W=256, B=16, K=2, 10 blocks |

### Does this PR introduce _any_ user-facing change?
Nope

### How was this patch tested?
vLLM version: v0.20.2
vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
