### PR TITLE
[BugFix] Fix reorder_batch_threshold issue for Qwen3.5 with DCP and MTP

### DIFF
--- a/vllm_ascend/patch/worker/patch_gdn_attn.py
+++ b/vllm_ascend/patch/worker/patch_gdn_attn.py
@@ -802,6 +802,18 @@ def _init_reorder_batch_threshold(
         ):
             self.reorder_batch_threshold = 1 + speculative_config.num_speculative_tokens
 
+    if (
+        self.reorder_batch_threshold == 1
+        and supports_spec_as_decode
+        and self.vllm_config.parallel_config.decode_context_parallel_size > 1
+    ):
+        # For the Qwen3.5 GDN module, align reorder_batch_threshold with
+        # the Ascend attention CP module when DCP and MTP are enabled.
+        # This avoids incompatibility between different attention backend groups.
+        speculative_config = self.vllm_config.speculative_config
+        if speculative_config is not None and speculative_config.num_speculative_tokens is not None:
+            self.reorder_batch_threshold = 1 + speculative_config.num_speculative_tokens
+
 
 def _patched_build_spec(
     self,


### PR DESCRIPTION

### What this PR does / why we need it?

This PR fixes the `reorder_batch_threshold` issue when running Qwen3.5 with DCP + MTP enabled.

The issue was found while testing Qwen3.5 based on PR #9678. This patch updates the related logic to make the DCP + MTP path work correctly.

### Does this PR introduce *any* user-facing change?

No.

This is an internal bug fix and does not introduce any API, CLI, or configuration changes.

### How was this patch tested?

Tested together with PR #9678 on the Ascend environment.

Manually launched Qwen3.5 with DCP + MTP enabled and sent OpenAI-compatible completion/chat completion requests. The model ran without hitting the `reorder_batch_threshold` issue.


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
