### PR TITLE
[Doc] Add supported vllm-ascend version in the Introduction chapter

### DIFF
--- a/docs/source/tutorials/models/MiniMax-M2.5.md
+++ b/docs/source/tutorials/models/MiniMax-M2.5.md
@@ -1,6 +1,6 @@
 # MiniMax-M2.5
 
-## Introduction
+## 1. Introduction
 
 MiniMax‑M2.5 is MiniMax’s flagship large language model, reinforced for high‑value scenarios such as code generation, agentic tool calling/search, and complex office workflows, with an emphasis on reasoning efficiency and end‑to‑end speed on challenging tasks.
 
@@ -13,15 +13,15 @@ The `Minimax M2.5` model is first supported in `vllm-ascend:v0.17.0rc1`, and all
 
 This document will show the main verification steps of the model, including supported features, feature configuration, environment preparation, single-node and multi-node deployment.
 
-## Supported Features
+## 2. Supported Features
 
 Refer to [supported features](../../user_guide/support_matrix/supported_models.md) to get the model's supported feature matrix.
 
 Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the feature's configuration.
 
-## Environment Preparation
+## 3. Environment Preparation
 
-### Model Weights
+### 3.1 Model Weights
 
 - `MiniMax-M2.5` (fp8 checkpoint): recommended to use **1× Atlas 800 A3** or **1× Atlas 800I A2** nodes. Download the model weights from [MiniMax/MiniMax-M2.5](https://modelscope.cn/models/MiniMax/MiniMax-M2.5).
 - `MiniMax-M2.5-w8a8-QuaRot` : Download the model weights from [Eco-Tech/MiniMax-M2.5-w8a8-QuaRot](https://modelscope.cn/models/Eco-Tech/MiniMax-M2.5-w8a8-QuaRot).
@@ -29,9 +29,107 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 
 It is recommended to download the model weights to a shared directory, such as `/mnt/sfs_turbo/.cache/`. The current release automatically detects the MiniMax-M2 fp8 checkpoint, disables fp8 quantization kernels on NPU, and loads the weights by dequantizing to bf16. This behavior may be removed once public bf16 weights are available.
 
-### Installation
+### 3.2 Verify Multi-node Communication (Optional)
+If multi-node deployment is required, please follow the [Verify Multi-node Communication Environment](../../installation.md#verify-multi-node-communication) guide for communication verification.
 
+
+## 4. Installation
+
+### 4.1 Docker Image Installation
 You can use the official docker image to run `MiniMax-M2.5` directly.
+
+:::::{tab-set}
+:sync-group: install
+
+::::{tab-item} A3 series
+:sync: A3
+
+Start the docker image on your each node.
+
+```{code-block} bash
+   :substitutions:
+
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|-a3
+export NAME=vllm-ascend
+
+# Run the container using the defined variables
+# Note: If you are running bridge network with docker, please expose available ports for multiple nodes communication in advance
+docker run --rm \
+--name $NAME \
+--net=host \
+--shm-size=1g \
+--device /dev/davinci0 \
+--device /dev/davinci1 \
+--device /dev/davinci2 \
+--device /dev/davinci3 \
+--device /dev/davinci4 \
+--device /dev/davinci5 \
+--device /dev/davinci6 \
+--device /dev/davinci7 \
+--device /dev/davinci8 \
+--device /dev/davinci9 \
+--device /dev/davinci10 \
+--device /dev/davinci11 \
+--device /dev/davinci12 \
+--device /dev/davinci13 \
+--device /dev/davinci14 \
+--device /dev/davinci15 \
+--device /dev/davinci_manager \
+--device /dev/devmm_svm \
+--device /dev/hisi_hdc \
+-v /usr/local/dcmi:/usr/local/dcmi \
+-v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
+-v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+-v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+-v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+-v /etc/ascend_install.info:/etc/ascend_install.info \
+-v /root/.cache:/root/.cache \
+-it $IMAGE bash
+```
+
+::::
+::::{tab-item} A2 series
+:sync: A2
+
+Start the docker image on your each node.
+
+```{code-block} bash
+   :substitutions:
+
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+docker run --rm \
+    --name vllm-ascend \
+    --shm-size=1g \
+    --net=host \
+    --device /dev/davinci0 \
+    --device /dev/davinci1 \
+    --device /dev/davinci2 \
+    --device /dev/davinci3 \
+    --device /dev/davinci4 \
+    --device /dev/davinci5 \
+    --device /dev/davinci6 \
+    --device /dev/davinci7 \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+    -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /root/.cache:/root/.cache \
+    -it $IMAGE bash
+```
+
+::::
+:::::
+
+If you want to deploy multi-node environment, you need to set up environment on each node.
+
+To verify the successful installation of the environment, please refer to [installation](../../installation.md).
+
+
 
 Select an image based on your machine type and start the container on your node. See [using docker](../../installation.md#set-up-using-docker).
 
@@ -121,10 +219,19 @@ docker run -itd -u 0 --ipc=host --privileged \
 # bash minimax25-docker-run.sh
 # docker exec -it minimax2_5 bash
 ```
+### 4.2 Source Code Installation
 
-## Online Inference on Multi-NPU
+In addition, if you don't want to use the docker image as above, you can also build all from source:
 
-### A3 (single node)
+- Install `vllm-ascend` from source, refer to [installation](../../installation.md).
+
+If you want to deploy multi-node environment, you need to set up environment on each node.
+
+
+
+## 5. Online Inference on Multi-NPU
+
+### 5.1 A3 (single node)
 
 Below is a recommended startup configuration for short-context condition like 3.5k/1.5k to reach a good performance.
 
@@ -194,7 +301,7 @@ Remarks:
     --reasoning-parser minimax_m2_append_think \
 ```
 
-### A2 (single node)
+### 5.2 A2 (single node)
 
 ```{code-block} bash
 export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
@@ -240,9 +347,9 @@ Remarks:
 - `--max-num-batched-tokens 16384` is applicable to the input sequence length of 16k.
 - `--max-num-batched-tokens 6144` is applicable to short sequence input scenarios such as 2k and 3.5k.
 
-## Verify the Service
+## 6. Verify the Service
 
-### A3 (single node)
+### 6.1 A3 (single node)
 
 Test with an OpenAI-compatible client:
 
@@ -288,7 +395,7 @@ curl http://localhost:8000/v1/chat/completions \
   }'
 ```
 
-### A2 (single node)
+### 6.2 A2 (single node)
 
 Run the following from any machine that can reach the service node (replace `{NodeIP}` with the real IP):
 
@@ -306,7 +413,7 @@ curl http://{NodeIP}:8000/v1/chat/completions \
   }'
 ```
 
-## FAQ
+## 7. FAQ
 
 - **Q: What should I do if the output is garbled in EP mode?**
 

--- a/docs/source/tutorials/models/MiniMax-M2.5.md
+++ b/docs/source/tutorials/models/MiniMax-M2.5.md
@@ -9,6 +9,10 @@ This document provides a unified deployment guide for `MiniMax-M2.5` on vLLM Asc
 - **A3 single-node** deployment (Atlas 800 A3)
 - **A2 single-node** deployment (Atlas 800I A2)
 
+The `Minimax M2.5` model is first supported in `vllm-ascend:v0.17.0rc1`, and all v0.17.0rc1 and later versions can run stably. To use the latest features (e.g., PD separation), it is recommended to use v0.18.0 or a later version.
+
+This document will show the main verification steps of the model, including supported features, feature configuration, environment preparation, single-node and multi-node deployment.
+
 ## Supported Features
 
 Refer to [supported features](../../user_guide/support_matrix/supported_models.md) to get the model's supported feature matrix.

--- a/docs/source/tutorials/models/MiniMax-M2.5.md
+++ b/docs/source/tutorials/models/MiniMax-M2.5.md
@@ -30,8 +30,8 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 It is recommended to download the model weights to a shared directory, such as `/mnt/sfs_turbo/.cache/`. The current release automatically detects the MiniMax-M2 fp8 checkpoint, disables fp8 quantization kernels on NPU, and loads the weights by dequantizing to bf16. This behavior may be removed once public bf16 weights are available.
 
 ### 3.2 Verify Multi-node Communication (Optional)
-If multi-node deployment is required, please follow the [Verify Multi-node Communication Environment](../../installation.md#verify-multi-node-communication) guide for communication verification.
 
+If multi-node deployment is required, please follow the [Verify Multi-node Communication Environment](../../installation.md#verify-multi-node-communication) guide for communication verification.
 
 ## 4. Installation
 
@@ -123,6 +123,7 @@ docker run -itd -u 0 --ipc=host --privileged \
 # bash minimax25-docker-run.sh
 # docker exec -it minimax2_5 bash
 ```
+
 ### 4.2 Source Code Installation
 
 In addition, if you don't want to use the docker image as above, you can also build all from source:
@@ -130,8 +131,6 @@ In addition, if you don't want to use the docker image as above, you can also bu
 - Install `vllm-ascend` from source, refer to [installation](../../installation.md).
 
 If you want to deploy multi-node environment, you need to set up environment on each node.
-
-
 
 ## 5. Online Inference on Multi-NPU
 

--- a/docs/source/tutorials/models/MiniMax-M2.5.md
+++ b/docs/source/tutorials/models/MiniMax-M2.5.md
@@ -36,106 +36,10 @@ If multi-node deployment is required, please follow the [Verify Multi-node Commu
 ## 4. Installation
 
 ### 4.1 Docker Image Installation
-You can use the official docker image to run `MiniMax-M2.5` directly.
 
-:::::{tab-set}
-:sync-group: install
+You can use our official docker image to run Minimax M2.5 directly.
 
-::::{tab-item} A3 series
-:sync: A3
-
-Start the docker image on your each node.
-
-```{code-block} bash
-   :substitutions:
-
-export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|-a3
-export NAME=vllm-ascend
-
-# Run the container using the defined variables
-# Note: If you are running bridge network with docker, please expose available ports for multiple nodes communication in advance
-docker run --rm \
---name $NAME \
---net=host \
---shm-size=1g \
---device /dev/davinci0 \
---device /dev/davinci1 \
---device /dev/davinci2 \
---device /dev/davinci3 \
---device /dev/davinci4 \
---device /dev/davinci5 \
---device /dev/davinci6 \
---device /dev/davinci7 \
---device /dev/davinci8 \
---device /dev/davinci9 \
---device /dev/davinci10 \
---device /dev/davinci11 \
---device /dev/davinci12 \
---device /dev/davinci13 \
---device /dev/davinci14 \
---device /dev/davinci15 \
---device /dev/davinci_manager \
---device /dev/devmm_svm \
---device /dev/hisi_hdc \
--v /usr/local/dcmi:/usr/local/dcmi \
--v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
--v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
--v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
--v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
--v /etc/ascend_install.info:/etc/ascend_install.info \
--v /root/.cache:/root/.cache \
--it $IMAGE bash
-```
-
-::::
-::::{tab-item} A2 series
-:sync: A2
-
-Start the docker image on your each node.
-
-```{code-block} bash
-   :substitutions:
-
-export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
-docker run --rm \
-    --name vllm-ascend \
-    --shm-size=1g \
-    --net=host \
-    --device /dev/davinci0 \
-    --device /dev/davinci1 \
-    --device /dev/davinci2 \
-    --device /dev/davinci3 \
-    --device /dev/davinci4 \
-    --device /dev/davinci5 \
-    --device /dev/davinci6 \
-    --device /dev/davinci7 \
-    --device /dev/davinci_manager \
-    --device /dev/devmm_svm \
-    --device /dev/hisi_hdc \
-    -v /usr/local/dcmi:/usr/local/dcmi \
-    -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
-    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
-    -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
-    -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
-    -v /etc/ascend_install.info:/etc/ascend_install.info \
-    -v /root/.cache:/root/.cache \
-    -it $IMAGE bash
-```
-
-::::
-:::::
-
-If you want to deploy multi-node environment, you need to set up environment on each node.
-
-To verify the successful installation of the environment, please refer to [installation](../../installation.md).
-
-
-
-Select an image based on your machine type and start the container on your node. See [using docker](../../installation.md#set-up-using-docker).
-
-## Run with Docker
-
-### A3 (single node)
+#### A3 (single node)
 
 ```{code-block} bash
    :substitutions:
@@ -178,7 +82,7 @@ docker run --rm \
 -it $IMAGE bash
 ```
 
-### A2 (single node)
+#### A2 (single node)
 
 Create and run `minimax25-docker-run.sh`.
 


### PR DESCRIPTION
### What this PR does / why we need it?
Add  supported vllm-ascend version in the Introduction chapter of Minimax M2.5.

### Does this PR introduce _any_ user-facing change?
none

### How was this patch tested?
vLLM version: v0.20.2

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
