### PR TITLE
[Feature]Add pcp+dp validation interception

### DIFF
--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -28,6 +28,12 @@ class TestNPUPlatform(TestBase):
         mock_vllm_config.device_config = MagicMock()
         mock_vllm_config.device_config.device_type = "npu"
         mock_vllm_config.parallel_config = MagicMock()
+        mock_vllm_config.parallel_config.data_parallel_size = 1
+        mock_vllm_config.parallel_config.prefill_context_parallel_size = 1
+        mock_vllm_config.parallel_config.tensor_parallel_size = 1
+        mock_vllm_config.parallel_config.pipeline_parallel_size = 1
+        mock_vllm_config.parallel_config.context_parallel_size = 1
+        mock_vllm_config.parallel_config.decode_context_parallel_size = 1
         mock_vllm_config.cache_config = MagicMock()
         mock_vllm_config.scheduler_config = MagicMock()
         mock_vllm_config.scheduler_config.max_num_seqs = None
@@ -695,6 +701,35 @@ class TestNPUPlatform(TestBase):
 
         with pytest.raises(ValueError, match="layer_sharding can only be enabled in PD-disaggregated's P node"):
             self.platform._validate_layer_sharding_config(vllm_config)
+
+    def test_validate_parallel_config_rejects_pcp_plus_dp(self):
+        vllm_config = TestNPUPlatform.mock_vllm_config()
+        vllm_config.parallel_config.data_parallel_size = 2
+        vllm_config.parallel_config.prefill_context_parallel_size = 2
+
+        with pytest.raises(ValueError, match="PCP \(Prefill Context Parallelism\) and DP \(Data Parallelism\)"):
+            self.platform._validate_parallel_config(vllm_config)
+
+    def test_validate_parallel_config_accepts_dp_only(self):
+        vllm_config = TestNPUPlatform.mock_vllm_config()
+        vllm_config.parallel_config.data_parallel_size = 2
+        vllm_config.parallel_config.prefill_context_parallel_size = 1
+
+        self.platform._validate_parallel_config(vllm_config)
+
+    def test_validate_parallel_config_accepts_pcp_only(self):
+        vllm_config = TestNPUPlatform.mock_vllm_config()
+        vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.parallel_config.prefill_context_parallel_size = 2
+
+        self.platform._validate_parallel_config(vllm_config)
+
+    def test_validate_parallel_config_accepts_neither(self):
+        vllm_config = TestNPUPlatform.mock_vllm_config()
+        vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.parallel_config.prefill_context_parallel_size = 1
+
+        self.platform._validate_parallel_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -348,7 +348,7 @@ class NPUPlatform(Platform):
         kv_transfer_config = vllm_config.kv_transfer_config
         if kv_transfer_config is None or kv_transfer_config.kv_role != "kv_producer":
             raise ValueError("additional_config.layer_sharding can only be enabled in PD-disaggregated's P node.")
-    
+
     @classmethod
     def _validate_parallel_config(cls, vllm_config: VllmConfig) -> None:
         parallel_config = vllm_config.parallel_config

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -348,6 +348,7 @@ class NPUPlatform(Platform):
         kv_transfer_config = vllm_config.kv_transfer_config
         if kv_transfer_config is None or kv_transfer_config.kv_role != "kv_producer":
             raise ValueError("additional_config.layer_sharding can only be enabled in PD-disaggregated's P node.")
+    
     @classmethod
     def _validate_parallel_config(cls, vllm_config: VllmConfig) -> None:
         parallel_config = vllm_config.parallel_config
@@ -359,6 +360,7 @@ class NPUPlatform(Platform):
                 f"prefill_context_parallel_size={parallel_config.prefill_context_parallel_size}. "
                 "Please set either --data-parallel-size 1 or --prefill-context-parallel-size 1."
             )
+
     @classmethod
     def _validate_draft_decode_context_parallel_config(
         cls,

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -348,7 +348,17 @@ class NPUPlatform(Platform):
         kv_transfer_config = vllm_config.kv_transfer_config
         if kv_transfer_config is None or kv_transfer_config.kv_role != "kv_producer":
             raise ValueError("additional_config.layer_sharding can only be enabled in PD-disaggregated's P node.")
-
+    @classmethod
+    def _validate_parallel_config(cls, vllm_config: VllmConfig) -> None:
+        parallel_config = vllm_config.parallel_config
+        if parallel_config.data_parallel_size > 1 and parallel_config.prefill_context_parallel_size > 1:
+            raise ValueError(
+                "PCP (Prefill Context Parallelism) and DP (Data Parallelism) "
+                "cannot be enabled simultaneously in the current version of vLLM Ascend. "
+                f"Got data_parallel_size={parallel_config.data_parallel_size} and "
+                f"prefill_context_parallel_size={parallel_config.prefill_context_parallel_size}. "
+                "Please set either --data-parallel-size 1 or --prefill-context-parallel-size 1."
+            )
     @classmethod
     def _validate_draft_decode_context_parallel_config(
         cls,
@@ -430,7 +440,7 @@ class NPUPlatform(Platform):
 
         cls._validate_layer_sharding_config(vllm_config)
         cls._validate_draft_decode_context_parallel_config(vllm_config)
-
+        cls._validate_parallel_config(vllm_config)
         # initialize ascend config from vllm additional_config
         cls._fix_incompatible_config(vllm_config)
 


### PR DESCRIPTION
### What this PR does / why we need it?
Adds validation to NPUPlatform preventing simultaneous PCP + DP configuration, completes ParallelConfig mock in tests, and adds test cases to verify the logic. Needed to avoid invalid configurations and provide clear user guidance.
### Does this PR introduce _any_ user-facing change?
Yes. Users will now see a clear ValueError when attempting to use both PCP and DP together.
### How was this patch tested?
Tested by running the new unit test cases and the full platform test suite, all passing successfully.
- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
