### PR TITLE
[BugFix] Fix ACL graph dispatch for base LoRA batches

### DIFF
--- a/tests/e2e/pull_request/one_card/lora/test_llama32_lora.py
+++ b/tests/e2e/pull_request/one_card/lora/test_llama32_lora.py
@@ -134,7 +134,6 @@ def test_llama_lora(llama32_lora_files):
         max_num_seqs=7,
         max_model_len=1024,
         max_loras=4,
-        compilation_config={"cudagraph_mode": "PIECEWISE"},
     )
     llm = vllm_model.model
     generate_and_test(llm, llama32_lora_files)

--- a/tests/e2e/pull_request/two_card/lora/test_llama32_lora_tp2.py
+++ b/tests/e2e/pull_request/two_card/lora/test_llama32_lora_tp2.py
@@ -24,7 +24,6 @@ def test_llama_lora_tp2(llama32_lora_files, fully_sharded_loras):
         max_loras=4,
         tensor_parallel_size=2,
         fully_sharded_loras=fully_sharded_loras,
-        compilation_config={"cudagraph_mode": "PIECEWISE"},
     ) as vllm_model:
         llm = vllm_model.model
         generate_and_test(llm, llama32_lora_files)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2675,7 +2675,11 @@ class NPUModelRunner(GPUModelRunner):
                 num_active_loras=num_active_loras,
             )
 
-        cudagraph_mode, batch_descriptor = dispatch_cudagraph(num_tokens_padded, use_cascade_attn or has_encoder_output)
+        disable_full_for_lora_base_runtime = (
+            force_has_lora is None and self.lora_config is not None and not has_lora
+        )
+        disable_full = use_cascade_attn or has_encoder_output or disable_full_for_lora_base_runtime
+        cudagraph_mode, batch_descriptor = dispatch_cudagraph(num_tokens_padded, disable_full)
         num_tokens_padded = batch_descriptor.num_tokens
         if enable_sp(self.vllm_config):
             assert batch_descriptor.num_tokens % self.vllm_config.parallel_config.tensor_parallel_size == 0, (
@@ -3239,6 +3243,13 @@ class NPUModelRunner(GPUModelRunner):
                 num_scheduled_tokens_np=num_scheduled_tokens,
             )
 
+        if num_active_loras == 0:
+            dummy_num_active_loras = 0
+        elif self.lora_config is not None:
+            dummy_num_active_loras = self.lora_config.max_loras
+        else:
+            dummy_num_active_loras = num_active_loras
+
         with self.maybe_dummy_run_with_lora(
             self.lora_config,
             num_scheduled_tokens,
@@ -3247,7 +3258,7 @@ class NPUModelRunner(GPUModelRunner):
             # TODO: The next line is a temporary workaround
             # to fix the accuracy issue of test_llama32_lora.py,
             # which is introduced by vllm-project/vllm#32005
-            num_active_loras=(self.lora_config.max_loras if self.lora_config is not None else num_active_loras),
+            num_active_loras=dummy_num_active_loras,
         ):
             # Make sure padding doesn't exceed max_num_tokens
             assert num_tokens_padded <= self.max_num_tokens


### PR DESCRIPTION
## Summary
- avoid FULL ACL graph dispatch for base/no-LoRA runtime batches when LoRA is enabled
- keep no-LoRA dummy capture from activating dummy LoRAs

## Verification
- python3 -m py_compile vllm-ascend/vllm_ascend/worker/model_runner_v1.py

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
