### PR TITLE
[Misc][Ops] Fix a bug inside a triton operator fused_sigmoid_gating_delta_rule_update_kernel

### DIFF
--- a/vllm_ascend/ops/triton/fla/sigmoid_gating.py
+++ b/vllm_ascend/ops/triton/fla/sigmoid_gating.py
@@ -243,13 +243,9 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_INITIAL_STATE:
         idx = tl.load(h0_indices + i_n)
-        # if idx >= 0:
-        tmp0 = tl.where(idx < 0, 0, idx)
-        p_h0 = h0_source + tmp0 * HV * K * V + i_hv * K * V + o_k[:, None] * V + o_v[None, :]
-        temp1 = tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
-        temp2 = tl.zeros_like(temp1)
-        value0 = tl.where(idx < 0, temp2, temp1)
-        b_h += value0  # tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
+        if idx >= 0:
+            p_h0 = h0_source + idx * HV * K * V + i_hv * K * V + o_k[:, None] * V + o_v[None, :]
+            b_h += tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
 
     for i in range(0, T):
         # Load inputs


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes an Ascend Triton compilation failure in `fused_sigmoid_gating_delta_rule_update_kernel`, which can be triggered by Qwen3.5 in some decoding cases.

The previous implementation handled invalid initial state indices by:

1. mapping negative `h0_indices` to `0`,
2. loading from `h0_source`,
3. then using `tl.where` to discard the loaded value when the original index was invalid.

Although the logic is correct, this creates a more complex IR pattern involving `tl.load`, `tl.zeros_like`, and post-load `tl.where`. On Ascend Triton, this can trigger an MLIR lowering failure during kernel compilation.

This PR moves the validity condition directly into the `tl.load` mask:

```python
idx = tl.load(h0_indices + i_n)
tmp0 = tl.where(idx < 0, 0, idx)
p_h0 = h0_source + tmp0 * HV * K * V + i_hv * K * V + o_k[:, None] * V + o_v[None, :]
value0 = tl.load(p_h0, mask=mask_h & (idx >= 0), other=0).to(tl.float32)
b_h += value0

vllm-ascend version : 0.18.0


