### PR TITLE
[Feature] Auto-compute LOCAL_WORLD_SIZE when static_kernel is enabled

### DIFF
--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -85,6 +85,28 @@ def _configure_backend(
     vllm_config: VllmConfig,
     process_kwargs_options: Callable | None = None,
 ) -> None:
+    if ascend_compilation_config.enable_static_kernel:
+        # npugraph_ex's static_kernel requires LOCAL_WORLD_SIZE to determine the
+        # physical node topology for creating per-node Gloo groups, which
+        # coordinate static kernel compilation and .run package installation.
+        # vLLM does not set this env var by default (unlike torchrun), so we
+        # compute it from parallel config:
+        #   local_world_size: processes per node for one DP replica
+        #   data_parallel_size_local: number of DP replicas on this node
+        #   actual_local_world_size: total processes on this physical machine
+        if "LOCAL_WORLD_SIZE" not in os.environ:
+            actual_local_world_size = (
+                vllm_config.parallel_config.local_world_size * vllm_config.parallel_config.data_parallel_size_local
+            )
+            os.environ["LOCAL_WORLD_SIZE"] = str(actual_local_world_size)
+            logger.info_once(
+                "Setting LOCAL_WORLD_SIZE=%d for static kernel (local_world_size=%d * data_parallel_size_local=%d).",
+                actual_local_world_size,
+                vllm_config.parallel_config.local_world_size,
+                vllm_config.parallel_config.data_parallel_size_local,
+                scope="global",
+            )
+
     if process_kwargs_options is not None:
         # npugraph_ex (both old and new): build options dict and use _process_kwargs_options.
         # It maps flat option names to nested config paths for old versions,
@@ -94,6 +116,8 @@ def _configure_backend(
         options: dict[str, Any] = {
             "force_eager": True,
             "inplace_pass": False,
+            "clone_input": False,
+            "clone_output": False,
         }
         if ascend_compilation_config.enable_static_kernel:
             logger.info_once(


### PR DESCRIPTION
- Set LOCAL_WORLD_SIZE env var for static kernel Gloo group coordination
- Add clone_input=False and clone_output=False options to npugraph_ex

### What this PR does / why we need it?

1. Auto-compute LOCAL_WORLD_SIZE for static kernel coordination
- npugraph_ex's static kernel feature requires LOCAL_WORLD_SIZE to create per-node Gloo groups for coordinating compilation and .run package installation across ranks. vLLM does not set this env var by default (unlike torchrun), so we compute it from parallel config (local_world_size * data_parallel_size_local) when enable_static_kernel is True and LOCAL_WORLD_SIZE is not already set.
2. Add clone_input=False and clone_output=False to npugraph_ex options
- Setting clone_input=False avoids redundant input tensor cloning (torch.empty_like + copy) during graph capture/replay. clone_output=False is explicitly declared for clarity (matches npugraph_ex default).

### Does this PR introduce _any_ user-facing change?
No. These are internal optimizations that do not change default behavior or require user configuration changes.

### How was this patch tested?

- Updated existing unit test in `tests/ut/test_ascend_config.py` to reflect the new default value (`assertTrue` instead of `assertFalse` for `enable_static_kernel`).
- CI passed with the updated test.

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
