### PR TITLE
[BugFix][v0.20.2rc] Port DSv4 SWA prefix-cache retention to vllm-ascend

### DIFF
--- a/tests/ut/core/test_dsv4_partial_prefix_cache.py
+++ b/tests/ut/core/test_dsv4_partial_prefix_cache.py
@@ -1,0 +1,108 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Unit tests for the DSv4 partial compressed prefix-cache helpers.
+
+These cover the pure-Python pieces that back ``CompressAttentionManager``'s
+partial-hit support: range hashing and the per-``BlockPool`` partial-cache maps.
+The maps must live on the ``BlockPool`` instance (not module globals), so the
+isolation test below is a regression guard for that requirement.
+"""
+
+from types import SimpleNamespace
+
+from tests.ut.base import TestBase
+from vllm_ascend.core.single_type_kv_cache_manager import (
+    _hash_range,
+    _insert_partial_cache,
+    get_partial_cached_block,
+    remove_partial_cache_entries_for_block,
+)
+
+
+def _block(block_id: int) -> SimpleNamespace:
+    # _insert/get/remove only touch ``block_id``.
+    return SimpleNamespace(block_id=block_id)
+
+
+def _pool() -> SimpleNamespace:
+    # A bare object is enough: the partial-cache maps are attached lazily.
+    return SimpleNamespace()
+
+
+class TestHashRange(TestBase):
+    def setUp(self):
+        # 4 hash-blocks of 8 tokens each -> hashes for tokens [0,8,16,24).
+        self.block_hashes = [b"h0", b"h1", b"h2", b"h3"]
+        self.hash_block_size = 8
+
+    def test_unaligned_returns_none(self):
+        self.assertIsNone(_hash_range(self.block_hashes, self.hash_block_size, 0, 12))
+        self.assertIsNone(_hash_range(self.block_hashes, self.hash_block_size, 4, 16))
+
+    def test_empty_or_inverted_range_returns_none(self):
+        self.assertIsNone(_hash_range(self.block_hashes, self.hash_block_size, 8, 8))
+        self.assertIsNone(_hash_range(self.block_hashes, self.hash_block_size, 16, 8))
+
+    def test_out_of_range_returns_none(self):
+        # end token 40 -> needs 5 hashes, only 4 available.
+        self.assertIsNone(_hash_range(self.block_hashes, self.hash_block_size, 0, 40))
+
+    def test_valid_range_concatenates_hashes(self):
+        self.assertEqual(_hash_range(self.block_hashes, self.hash_block_size, 0, 16), b"h0h1")
+        self.assertEqual(_hash_range(self.block_hashes, self.hash_block_size, 8, 24), b"h1h2")
+
+
+class TestPartialPrefixCache(TestBase):
+    def setUp(self):
+        self.pool = _pool()
+        self.group_id = 0
+
+    def test_insert_and_get(self):
+        block = _block(7)
+        _insert_partial_cache(self.pool, b"abc", self.group_id, block)
+        self.assertIs(get_partial_cached_block(self.pool, b"abc", self.group_id), block)
+
+    def test_miss_returns_none(self):
+        self.assertIsNone(get_partial_cached_block(self.pool, b"missing", self.group_id))
+
+    def test_group_id_scopes_lookup(self):
+        block = _block(7)
+        _insert_partial_cache(self.pool, b"abc", 0, block)
+        self.assertIsNone(get_partial_cached_block(self.pool, b"abc", 1))
+
+    def test_reinsert_updates_block_and_drops_old_tracking(self):
+        old, new = _block(1), _block(2)
+        _insert_partial_cache(self.pool, b"abc", self.group_id, old)
+        _insert_partial_cache(self.pool, b"abc", self.group_id, new)
+        self.assertIs(get_partial_cached_block(self.pool, b"abc", self.group_id), new)
+        # Evicting the old block must not drop the entry now owned by the new block.
+        remove_partial_cache_entries_for_block(self.pool, old.block_id)
+        self.assertIs(get_partial_cached_block(self.pool, b"abc", self.group_id), new)
+
+    def test_eviction_removes_entries_for_block(self):
+        block = _block(5)
+        _insert_partial_cache(self.pool, b"abc", self.group_id, block)
+        _insert_partial_cache(self.pool, b"def", self.group_id, block)
+        remove_partial_cache_entries_for_block(self.pool, 5)
+        self.assertIsNone(get_partial_cached_block(self.pool, b"abc", self.group_id))
+        self.assertIsNone(get_partial_cached_block(self.pool, b"def", self.group_id))
+
+    def test_state_is_isolated_per_block_pool(self):
+        pool_a, pool_b = _pool(), _pool()
+        _insert_partial_cache(pool_a, b"abc", self.group_id, _block(1))
+        # A second pool must not see the first pool's entries (no module globals).
+        self.assertIsNone(get_partial_cached_block(pool_b, b"abc", self.group_id))

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -207,7 +207,7 @@ class AscendDSABackend(AttentionBackend):
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int]:
-        return [8, 32, 128]
+        return [2, 4, 8, 16, 32, 64, 128]
 
 
 @dataclass

--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -1,11 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
+from collections import defaultdict
 from collections.abc import Sequence
 
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
-from vllm.v1.core.kv_cache_utils import BlockHashList, KVCacheBlock
+from vllm.v1.core.kv_cache_utils import (
+    BlockHash,
+    BlockHashList,
+    BlockHashListWithBlockSize,
+    BlockHashWithGroupId,
+    KVCacheBlock,
+    make_block_hash_with_group_id,
+)
 from vllm.v1.core.single_type_kv_cache_manager import (
     FullAttentionManager,
     SingleTypeKVCacheManager,
@@ -21,11 +29,100 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.request import Request
 
 
+class ComputedBlockList(list[KVCacheBlock]):
+    """KV blocks plus the logical token length they cover."""
+
+    def __init__(
+        self,
+        blocks: Sequence[KVCacheBlock] = (),
+        logical_hit_length: int | None = None,
+    ) -> None:
+        super().__init__(blocks)
+        self.logical_hit_length = logical_hit_length
+
+
+def _partial_prefix_cache(
+    block_pool: BlockPool,
+) -> tuple[dict[BlockHashWithGroupId, KVCacheBlock], defaultdict[int, set[BlockHashWithGroupId]]]:
+    """Return the (hash -> block, block_id -> hashes) maps used to track DSv4
+    partial-prefix cache entries for ``block_pool``.
+
+    The maps are stored on the ``BlockPool`` instance (created lazily on first
+    use) rather than as module-level globals so the state is scoped to a single
+    engine's cache and cannot leak across engines in the same process.
+    """
+    hash_to_block = getattr(block_pool, "_dsv4_partial_hash_to_block", None)
+    if hash_to_block is None:
+        hash_to_block = {}
+        block_pool._dsv4_partial_hash_to_block = hash_to_block
+        block_pool._dsv4_partial_block_id_to_hashes = defaultdict(set)
+    return hash_to_block, block_pool._dsv4_partial_block_id_to_hashes
+
+
+def _hash_range(
+    block_hashes: BlockHashList,
+    hash_block_size: int,
+    start_token: int,
+    end_token: int,
+) -> BlockHash | None:
+    if end_token <= start_token:
+        return None
+    if start_token % hash_block_size != 0 or end_token % hash_block_size != 0:
+        return None
+    start = start_token // hash_block_size
+    end = end_token // hash_block_size
+    if end > len(block_hashes):
+        return None
+    return BlockHash(b"".join(block_hashes[start:end]))
+
+
+def _insert_partial_cache(
+    block_pool: BlockPool,
+    block_hash: BlockHash,
+    kv_cache_group_id: int,
+    block: KVCacheBlock,
+) -> None:
+    hash_to_block, block_id_to_hashes = _partial_prefix_cache(block_pool)
+    key = make_block_hash_with_group_id(block_hash, kv_cache_group_id)
+    old_block = hash_to_block.get(key)
+    if old_block is not None and old_block.block_id != block.block_id:
+        block_id_to_hashes[old_block.block_id].discard(key)
+    hash_to_block[key] = block
+    block_id_to_hashes[block.block_id].add(key)
+
+
+def get_partial_cached_block(
+    block_pool: BlockPool, block_hash: BlockHash, kv_cache_group_id: int
+) -> KVCacheBlock | None:
+    hash_to_block, _ = _partial_prefix_cache(block_pool)
+    return hash_to_block.get(make_block_hash_with_group_id(block_hash, kv_cache_group_id))
+
+
+def remove_partial_cache_entries_for_block(block_pool: BlockPool, block_id: int) -> None:
+    hash_to_block, block_id_to_hashes = _partial_prefix_cache(block_pool)
+    for key in block_id_to_hashes.pop(block_id, set()):
+        block = hash_to_block.get(key)
+        if block is not None and block.block_id == block_id:
+            hash_to_block.pop(key, None)
+
+
 class CompressAttentionManager(FullAttentionManager):
     def __init__(self, kv_cache_spec: MLAAttentionSpec, block_pool: BlockPool, **kwargs) -> None:
         super().__init__(kv_cache_spec, block_pool, **kwargs)
         self.compress_ratio = kv_cache_spec.compress_ratio
         self._null_block = block_pool.null_block
+        self.copy_block_ids: list[tuple[int, int, int]] = []
+        self._copy_src_blocks: defaultdict[str, list[KVCacheBlock]] = defaultdict(list)
+        # Per-request bookkeeping for partial-prefix boundary registration.
+        # The first compressed block's boundaries are immutable once that block
+        # is full and its hashes are available, so each request is registered at
+        # most once and then recorded in ``_partial_boundaries_done``. Until then
+        # ``_partial_last_compressed`` dedups repeated calls at the same length.
+        # This is what previously stalled the scheduler loop and collapsed
+        # long-context decode throughput: the boundary hashing re-ran on every
+        # decode step even though the first block never changed.
+        self._partial_last_compressed: dict[str, int] = {}
+        self._partial_boundaries_done: set[str] = set()
 
     def get_num_blocks_to_allocate(
         self,
@@ -42,8 +139,9 @@ class CompressAttentionManager(FullAttentionManager):
 
         num_tokens //= self.compress_ratio
         num_tokens_main_model //= self.compress_ratio
+        total_computed_tokens //= self.compress_ratio
 
-        return super().get_num_blocks_to_allocate(
+        num_blocks = super().get_num_blocks_to_allocate(
             request_id,
             num_tokens,
             new_computed_blocks,
@@ -51,6 +149,11 @@ class CompressAttentionManager(FullAttentionManager):
             num_tokens_main_model,
             apply_admission_cap,
         )
+        # Partial compressed hits are copied into a private destination block
+        # before the request resumes. The source block may also need to be
+        # pinned if it is an eviction candidate, which super() already counts.
+        num_full_hit_blocks = total_computed_tokens // self.block_size
+        return num_blocks + max(0, len(new_computed_blocks) - num_full_hit_blocks)
 
     def allocate_new_computed_blocks(
         self,
@@ -84,8 +187,8 @@ class CompressAttentionManager(FullAttentionManager):
         # A new request.
         req_blocks = self.req_to_blocks[request_id]
         assert len(req_blocks) == 0
-        num_total_computed_tokens = num_local_computed_tokens + num_external_computed_tokens
-        num_total_computed_tokens //= self.compress_ratio
+        num_total_logical_tokens = num_local_computed_tokens + num_external_computed_tokens
+        num_total_computed_tokens = num_total_logical_tokens // self.compress_ratio
         num_skipped_tokens = self.get_num_skipped_tokens(num_total_computed_tokens)
         num_skipped_blocks = num_skipped_tokens // self.block_size
         if num_skipped_blocks > 0:
@@ -98,9 +201,23 @@ class CompressAttentionManager(FullAttentionManager):
                 num_external_computed_tokens,
             )
 
-        # Touch the computed blocks to make sure they won't be evicted.
+        num_full_hit_blocks = num_total_computed_tokens // self.block_size
+        if len(new_computed_blocks) > num_full_hit_blocks:
+            full_blocks = list(new_computed_blocks[:num_full_hit_blocks])
+            partial_src_blocks = list(new_computed_blocks[num_full_hit_blocks:])
+            if self.enable_caching:
+                self.block_pool.touch(partial_src_blocks)
+                self._copy_src_blocks[request_id].extend(partial_src_blocks)
+            partial_dst_blocks = self.block_pool.get_new_blocks(len(partial_src_blocks))
+            self.copy_block_ids.extend(
+                (self.kv_cache_group_id, src.block_id, dst.block_id)
+                for src, dst in zip(partial_src_blocks, partial_dst_blocks)
+            )
+            new_computed_blocks = [*full_blocks, *partial_dst_blocks]
+
+        # Touch the computed full blocks to make sure they won't be evicted.
         if self.enable_caching:
-            self.block_pool.touch(new_computed_blocks)
+            self.block_pool.touch(new_computed_blocks[:num_full_hit_blocks])
         else:
             assert not any(new_computed_blocks), "Computed blocks should be empty when prefix caching is disabled"
 
@@ -111,7 +228,7 @@ class CompressAttentionManager(FullAttentionManager):
         # All cached hits (including skipped nulls) are already cached; mark
         # them so cache_blocks() will not try to re-cache blocks that already
         # have a block_hash set.
-        self.num_cached_block[request_id] = len(req_blocks)
+        self.num_cached_block[request_id] = min(len(req_blocks), num_full_hit_blocks)
 
         if num_external_computed_tokens > 0:
             # Allocate new blocks for external computed tokens.
@@ -158,9 +275,72 @@ class CompressAttentionManager(FullAttentionManager):
             num_tokens: The total number of tokens that need to be cached
                 (including tokens that are already cached).
         """
-        num_tokens //= self.compress_ratio
+        compressed_tokens = num_tokens // self.compress_ratio
+        super().cache_blocks(request, compressed_tokens)
+        self._cache_partial_block_boundaries(request, compressed_tokens)
 
-        return super().cache_blocks(request, num_tokens)
+    def _cache_partial_block_boundaries(self, request: Request, compressed_tokens: int) -> None:
+        req_blocks = self.req_to_blocks[request.request_id]
+        if compressed_tokens <= 0 or not req_blocks:
+            return
+        # The first block's boundaries are final once it is full; never revisit.
+        if request.request_id in self._partial_boundaries_done:
+            return
+        # Dedup repeated calls at the same compressed length (identical entries).
+        if self._partial_last_compressed.get(request.request_id) == compressed_tokens:
+            return
+        self._partial_last_compressed[request.request_id] = compressed_tokens
+
+        hash_block_size = self.block_pool.hash_block_size
+        logical_block_size = self.block_size * self.compress_ratio
+        max_logical_tokens = compressed_tokens * self.compress_ratio
+        num_blocks_with_tokens = min(cdiv(compressed_tokens, self.block_size), len(req_blocks))
+
+        # Partial compressed hits are only needed before the first full
+        # compressed KV block exists (the <16K DSv4 case). Once a prompt has a
+        # full compressed-block hit, keep the normal full-block reuse path to
+        # avoid adding private copy work to long-context decode.
+        for block_idx in range(min(num_blocks_with_tokens, 1)):
+            block = req_blocks[block_idx]
+            if block.is_null:
+                continue
+            block_start = block_idx * logical_block_size
+            block_end = min(block_start + logical_block_size, max_logical_tokens)
+            boundary = block_start + hash_block_size
+            while boundary <= block_end:
+                # Full-block boundaries are already represented in the normal
+                # prefix cache hash table.
+                if boundary - block_start != logical_block_size:
+                    block_hash = _hash_range(
+                        request.block_hashes,
+                        hash_block_size,
+                        block_start,
+                        boundary,
+                    )
+                    if block_hash is not None:
+                        _insert_partial_cache(self.block_pool, block_hash, self.kv_cache_group_id, block)
+                boundary += hash_block_size
+
+        # Once the first block is full and all of its hashes are available, its
+        # partial boundaries are final. Latch the request so subsequent calls
+        # (every long-context decode step) return immediately above, paying zero
+        # boundary-hashing cost.
+        if compressed_tokens >= self.block_size and len(request.block_hashes) * hash_block_size >= logical_block_size:
+            self._partial_boundaries_done.add(request.request_id)
+            self._partial_last_compressed.pop(request.request_id, None)
+
+    def take_copy_block_ids(self) -> list[tuple[int, int, int]]:
+        copy_block_ids = self.copy_block_ids
+        self.copy_block_ids = []
+        return copy_block_ids
+
+    def free(self, request_id: str) -> None:
+        pinned_src_blocks = self._copy_src_blocks.pop(request_id, [])
+        self._partial_last_compressed.pop(request_id, None)
+        self._partial_boundaries_done.discard(request_id)
+        super().free(request_id)
+        if pinned_src_blocks:
+            self.block_pool.free_blocks(reversed(pinned_src_blocks))
 
     @classmethod
     def find_longest_cache_hit(
@@ -180,12 +360,21 @@ class CompressAttentionManager(FullAttentionManager):
         # ), (
         #     "CompressAttentionManager can only be used for compressor attention groups"
         # )
-        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple([] for _ in range(len(kv_cache_group_ids)))
+        computed_blocks: tuple[ComputedBlockList, ...] = tuple(
+            ComputedBlockList() for _ in range(len(kv_cache_group_ids))
+        )
+        raw_alignment_tokens = alignment_tokens
         block_size = kv_cache_spec.block_size
+        hash_block_size = block_pool.hash_block_size
         if dcp_world_size * pcp_world_size > 1:
             block_size *= dcp_world_size * pcp_world_size
         max_num_blocks = max_length // block_size
-        for block_hash in itertools.islice(block_hashes, max_num_blocks):
+        full_block_hashes = (
+            block_hashes
+            if block_size == hash_block_size
+            else BlockHashListWithBlockSize(block_hashes, hash_block_size, block_size)
+        )
+        for block_hash in itertools.islice(full_block_hashes, max_num_blocks):
             # block_hashes is a chain of block hashes. If a block hash is not
             # in the cached_block_hash_to_id, the following block hashes are
             # not computed yet for sure.
@@ -198,6 +387,33 @@ class CompressAttentionManager(FullAttentionManager):
             # Need to drop the last matched block if eagle is enabled.
             for computed in computed_blocks:
                 computed.pop()
+
+        # Keep the original compressed full-block path for prompts that can hit
+        # normally. Only fall back to a private partial copy when the prompt is
+        # shorter than one compressed cache block and would otherwise get 0 hit.
+        if not computed_blocks[0]:
+            logical_block_size = kv_cache_spec.block_size * kv_cache_spec.compress_ratio
+            candidate = min(
+                max_length // raw_alignment_tokens * raw_alignment_tokens,
+                logical_block_size - raw_alignment_tokens,
+            )
+            while candidate > 0:
+                partial_hash = _hash_range(block_hashes, hash_block_size, 0, candidate)
+                if partial_hash is None:
+                    candidate -= raw_alignment_tokens
+                    continue
+                partial_blocks = [
+                    block
+                    for group_id in kv_cache_group_ids
+                    if (block := get_partial_cached_block(block_pool, partial_hash, group_id)) is not None
+                ]
+                if len(partial_blocks) != len(kv_cache_group_ids):
+                    candidate -= raw_alignment_tokens
+                    continue
+                for computed, cached in zip(computed_blocks, partial_blocks):
+                    computed.append(cached)
+                    computed.logical_hit_length = candidate
+                break
 
         # NOTE: Div the compress ratio when finding the longest cache hit token length.
         alignment_tokens = cdiv(alignment_tokens, kv_cache_spec.compress_ratio)

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -71,6 +71,7 @@ from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.deepseek_v4 import DeepseekV4Config
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.models.layer.attention.dsv4_block_sizes import DSV4_BLOCK_SIZES
 from vllm_ascend.ops.dsa import AscendDeepseekSparseAttention, DSAModules
 from vllm_ascend.ops.rope_dsv4 import ComplexExpRotaryEmbedding
 from vllm_ascend.ops.triton.mul_add import muls_add_triton
@@ -520,7 +521,7 @@ class Compressor(nn.Module):
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=8,
+                block_size=DSV4_BLOCK_SIZES[cache_config.block_size][0][2],
             )
         elif compress_ratio == 128:
             self.state_cache = CompressorStateCache(
@@ -528,7 +529,7 @@ class Compressor(nn.Module):
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=32,
+                block_size=DSV4_BLOCK_SIZES[cache_config.block_size][0][3],
             )
         else:
             raise ValueError(

--- a/vllm_ascend/models/layer/attention/dsv4_block_sizes.py
+++ b/vllm_ascend/models/layer/attention/dsv4_block_sizes.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# cache_config.block_size:
+#   [mla, swa, c4 state, c128 state], [page_size_padded_t1, page_size_padded_t2]
+DSV4_BLOCK_SIZES = {
+    128: [[128, 128, 8, 32], [16640, 131072]],
+    64: [[64, 64, 4, 16], [8320, 65536]],
+    32: [[32, 32, 2, 8], [4160, 32768]],
+}

--- a/vllm_ascend/models/layer/attention/layer.py
+++ b/vllm_ascend/models/layer/attention/layer.py
@@ -22,6 +22,7 @@ from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec
 
 from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.dsa_v1 import AscendDSABackend
+from vllm_ascend.models.layer.attention.dsv4_block_sizes import DSV4_BLOCK_SIZES
 
 
 class DSAAttention(nn.Module, AttentionLayerBase):
@@ -151,7 +152,7 @@ class DSAAttention(nn.Module, AttentionLayerBase):
             return None
         kv_cache_dtype = kv_cache_dtype_str_to_dtype(self.kv_cache_dtype, vllm_config.model_config)
         return MLAAttentionSpec(
-            block_size=128,
+            block_size=DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][0][0],
             num_kv_heads=1,
             head_size=self.head_size,
             dtype=kv_cache_dtype,

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -219,6 +219,29 @@
 #       Remove this patch once upstream vLLM supports hybrid KV cache + CP for
 #       non-CUDA backends, or exposes a platform hook for this behavior.
 #
+# ** 10b. File: platform/patch_prefix_cache_core.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.v1.core.kv_cache_utils.FreeKVCacheBlockQueue.prepend_n`
+#   2. `vllm.v1.core.block_pool.BlockPool.free_blocks`
+#   3. `vllm.v1.core.single_type_kv_cache_manager.SingleTypeKVCacheManager.remove_skipped_blocks`
+#   4. `vllm.v1.core.single_type_kv_cache_manager.SlidingWindowManager._cache_block_mask`
+#   5. `vllm.v1.core.single_type_kv_cache_manager.SlidingWindowManager.free`
+#    Why:
+#       The DeepSeek V4 prefix-cache coordinator patch relies on the vLLM core
+#       block-reuse behavior added by vLLM PR #43447. Older supported vLLM
+#       versions do not expose `free_blocks(prepend=...)`, so short/SWA prefix
+#       cache paths can recycle local blocks with poor priority.
+#    How:
+#       When `VLLM_ASCEND_APPLY_DSV4_PATCH` is enabled, monkey-patch the missing
+#       free-list/front-insertion behavior and the SWA/EAGLE cache block mask.
+#       Each patch is guarded by capability/source checks so it is skipped once
+#       the underlying vLLM already provides the upstream behavior.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/43447
+#    Future Plan:
+#       Remove this patch once the supported vLLM version contains vLLM PR
+#       #43447 or equivalent prefix-cache block-reuse behavior.
+#
 # ** 10. File: platform/patch_kv_cache_interface.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.kv_cache_interface.MLAAttentionSpec`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -44,5 +44,6 @@ if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXP
 import vllm_ascend.patch.platform.patch_balance_schedule  # noqa
 
 if envs.VLLM_ASCEND_APPLY_DSV4_PATCH:
+    import vllm_ascend.patch.platform.patch_prefix_cache_core  # noqa
     import vllm_ascend.patch.platform.patch_kv_cache_coordinator  # noqa
     import vllm_ascend.patch.platform.patch_speculative_config  # noqa

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM projectx
 import sys
-from math import lcm
+from typing import Literal
 
 import vllm
+from vllm.logger import logger
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_coordinator import (
     HybridKVCacheCoordinator,
@@ -20,6 +21,24 @@ from vllm.v1.core.single_type_kv_cache_manager import SingleTypeKVCacheManager
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheSpec
 
 from vllm_ascend.core.single_type_kv_cache_manager import get_manager_for_kv_cache_spec
+
+# vllm PR #43447 added prefix-cache local KV retention (sliding-window
+# checkpoint tails). The retention constants and SlidingWindowManager class
+# live in upstream single_type_kv_cache_manager. Fall back to no-op symbols on
+# older vllm without PR #43447 so this patch keeps working.
+try:
+    from vllm.v1.core.single_type_kv_cache_manager import (
+        AUTO_RETENTION_BASE,
+        AUTO_RETENTION_INTERVAL,
+        SlidingWindowManager,
+    )
+
+    _HAS_LOCAL_KV_RETENTION = True
+except ImportError:  # pragma: no cover - older vllm without PR #43447
+    AUTO_RETENTION_BASE = 1024
+    AUTO_RETENTION_INTERVAL = 32768
+    SlidingWindowManager = None  # type: ignore[assignment,misc]
+    _HAS_LOCAL_KV_RETENTION = False
 
 USE_MULTI_GROUPS_KV_CACHE = True
 
@@ -43,9 +62,14 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         dcp_world_size: int,
         pcp_world_size: int,
         hash_block_size: int,
+        scheduler_block_size: int | None = None,
         eagle_attn_layer_names: list[str] | None = None,
         metrics_collector: KVCacheMetricsCollector | None = None,
         max_num_batched_tokens: int | None = None,
+        # vllm PR #43447: optional prefix-cache local KV retention. The
+        # scheduler passes ``CacheConfig.prefix_cache_retention_interval``
+        # through ``get_kv_cache_coordinator`` -> here.
+        local_kv_retention_interval: int | Literal["auto"] | None = None,
     ):
         self.kv_cache_config = kv_cache_config
         self.max_model_len = max_model_len
@@ -56,6 +80,12 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         if max_num_batched_tokens is None:
             max_num_batched_tokens = max_model_len
         self.max_num_batched_tokens = max_num_batched_tokens
+        if scheduler_block_size is None:
+            scheduler_block_size = hash_block_size
+        assert scheduler_block_size % hash_block_size == 0 and all(
+            scheduler_block_size % g.kv_cache_spec.block_size == 0 for g in kv_cache_config.kv_cache_groups
+        )
+        self.scheduler_block_size = scheduler_block_size
 
         self.block_pool = BlockPool(
             kv_cache_config.num_blocks,
@@ -84,6 +114,8 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             )
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
+        for i, manager in enumerate(self.single_type_managers):
+            manager.use_eagle = i in self.eagle_group_ids
 
         # hash_block_size: the block size used to compute block hashes.
         # The actual block size usually equals hash_block_size, but in cases where
@@ -97,6 +129,45 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         assert dcp_world_size == 1, "DCP not support hybrid attn now."
         assert pcp_world_size == 1, "PCP not support hybrid attn now."
         self.verify_and_split_kv_cache_groups()
+        for _, group_ids, _ in self.attention_groups:
+            group_uses_eagle = any(group_id in self.eagle_group_ids for group_id in group_ids)
+            for group_id in group_ids:
+                self.single_type_managers[group_id].use_eagle = group_uses_eagle
+
+        # vllm PR #43447: store the retention interval and mirror upstream's
+        # one-time info log. The inherited ``HybridKVCacheCoordinator.cache_blocks``
+        # consults ``self.local_kv_retention_interval`` + ``self.eagle_lookup_group_ids``
+        # (set by ``verify_and_split_kv_cache_groups`` below) to route sliding-window
+        # groups through ``cache_blocks_at_boundaries``.
+        self.local_kv_retention_interval = local_kv_retention_interval
+        if self.local_kv_retention_interval is not None and _HAS_LOCAL_KV_RETENTION:
+            has_sliding_window_group = any(
+                isinstance(manager, SlidingWindowManager) for manager in self.single_type_managers
+            )
+            if has_sliding_window_group:
+                if self.local_kv_retention_interval == "auto":
+                    logger.info(
+                        "Using prefix-cache local KV retention strategy: retain "
+                        "sliding-window checkpoint tails at powers of 2 from %d to "
+                        "%d tokens, then every %d tokens, plus the latest replayable "
+                        "prompt boundary.",
+                        AUTO_RETENTION_BASE,
+                        AUTO_RETENTION_INTERVAL,
+                        AUTO_RETENTION_INTERVAL,
+                    )
+                elif self.local_kv_retention_interval == 0:
+                    logger.info(
+                        "Using prefix-cache local KV retention strategy: retain only "
+                        "the latest replayable prompt boundary."
+                    )
+                else:
+                    logger.info(
+                        "Using prefix-cache local KV retention strategy: retain "
+                        "sliding-window checkpoint tails at the configured "
+                        "%d-token interval after prefix-cache alignment, plus "
+                        "the latest replayable prompt boundary.",
+                        self.local_kv_retention_interval,
+                    )
 
         self.use_eagle = use_eagle
 
@@ -136,15 +207,19 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             for i, (_, group_ids, _) in enumerate(self.attention_groups)
             if any(gid in self.eagle_group_ids for gid in group_ids)
         }
+        # vllm PR #43447: per-group ids of EAGLE/MTP groups, consumed by the
+        # inherited ``cache_blocks`` to decide whether a sliding-window manager
+        # needs to retain one extra local block past the replay boundary.
+        self.eagle_lookup_group_ids: set[int] = {
+            gid
+            for i, (_, group_ids, _) in enumerate(self.attention_groups)
+            if i in self.eagle_attn_group_indices
+            for gid in group_ids
+        }
 
-        # The LCM of the block sizes of all attention types.
-        # The cache hit length must be a multiple of the LCM of the block sizes
-        # to make sure the cache hit length is a multiple of the block size of
-        # each attention type. Requiring this because we don't support partial
-        # block cache hit yet.
-        # NOTE: use 16k as the alignment tokens for model with compress ratio
-        block_sizes = [spec.block_size * getattr(spec, "compress_ratio", 1) for spec, _, _ in self.attention_groups]
-        self.lcm_block_size = lcm(*block_sizes)
+        # Prefix-cache hits are aligned to scheduler_block_size, not to
+        # block_size * compress_ratio. The latter forces DSv4 compressed
+        # groups to 16K-aligned hits and makes shorter prompts miss.
 
     def find_longest_cache_hit(
         self,
@@ -170,6 +245,8 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         """
 
         def _get_block_hashes(kv_cache_spec: KVCacheSpec) -> BlockHashList:
+            if getattr(kv_cache_spec, "compress_ratio", 1) > 1:
+                return block_hashes
             if kv_cache_spec.block_size == self.hash_block_size:
                 return block_hashes
             return BlockHashListWithBlockSize(block_hashes, self.hash_block_size, kv_cache_spec.block_size)
@@ -214,17 +291,18 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                     block_pool=self.block_pool,
                     kv_cache_spec=spec,
                     use_eagle=use_eagle,
-                    alignment_tokens=self.lcm_block_size,
+                    alignment_tokens=self.scheduler_block_size,
                 )
-                _new_hit_length = len(hit_blocks[0]) * spec.block_size
+                compress_ratio = getattr(spec, "compress_ratio", 1)
+                _new_hit_length = getattr(hit_blocks[0], "logical_hit_length", None)
+                if _new_hit_length is None:
+                    _new_hit_length = len(hit_blocks[0]) * spec.block_size * max(compress_ratio, 1)
                 if use_eagle:
                     eagle_verified.add(idx)
                 elif _new_hit_length < curr_hit_length:
                     # length shrunk; invalidate previous eagle verifications
                     eagle_verified.clear()
                 curr_hit_length = _new_hit_length
-                compress_ratio = getattr(spec, "compress_ratio", 1)
-                curr_hit_length = len(hit_blocks[0]) * spec.block_size * max(compress_ratio, 1)
                 for group_id, blocks in zip(group_ids, hit_blocks):
                     hit_blocks_by_group[group_id] = blocks
 
@@ -244,6 +322,14 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
 
         return tuple(blocks if blocks is not None else [] for blocks in hit_blocks_by_group), hit_length
 
+    def take_copy_block_ids(self) -> list[tuple[int, int, int]]:
+        copy_block_ids: list[tuple[int, int, int]] = []
+        for manager in self.single_type_managers:
+            take_copy_block_ids = getattr(manager, "take_copy_block_ids", None)
+            if take_copy_block_ids is not None:
+                copy_block_ids.extend(take_copy_block_ids())
+        return copy_block_ids
+
 
 def get_kv_cache_coordinator(
     kv_cache_config: KVCacheConfig,
@@ -255,8 +341,14 @@ def get_kv_cache_coordinator(
     dcp_world_size: int,
     pcp_world_size: int,
     hash_block_size: int,
+    scheduler_block_size: int | None = None,
     eagle_attn_layer_names: list[str] | None = None,
     metrics_collector: KVCacheMetricsCollector | None = None,
+    # vllm PR #43447: KVCacheManager passes this through from
+    # ``CacheConfig.prefix_cache_retention_interval``. Default keeps the
+    # pre-PR behavior, and the kwarg keeps us compatible with older vllm
+    # versions that don't forward it.
+    local_kv_retention_interval: int | Literal["auto"] | None = None,
 ) -> KVCacheCoordinator:
     return AscendHybridKVCacheCoordinator(
         kv_cache_config,
@@ -267,9 +359,11 @@ def get_kv_cache_coordinator(
         dcp_world_size=dcp_world_size,
         pcp_world_size=pcp_world_size,
         hash_block_size=hash_block_size,
+        scheduler_block_size=scheduler_block_size,
         eagle_attn_layer_names=eagle_attn_layer_names,
         metrics_collector=metrics_collector,
         max_num_batched_tokens=max_num_batched_tokens,
+        local_kv_retention_interval=local_kv_retention_interval,
     )
 
 

--- a/vllm_ascend/patch/platform/patch_kv_cache_interface.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_interface.py
@@ -173,9 +173,14 @@ def _init_mla_cache_fields(spec: MLAAttentionSpec | SlidingWindowMLASpec):
         spec.model_version == "deepseek_v4" and spec.compress_ratio in [0, 4, 128]
     ), "Invalid compress ratio."
     if spec.compress_ratio > 1:
-        assert spec.block_size % spec.compress_ratio == 0, (
-            f"Block size {spec.block_size} must be divisible by compress ratio."
-        )
+        if spec.model_version == "deepseek_v4":
+            assert spec.block_size in [32, 64, 128], (
+                f"DeepSeek V4 block size {spec.block_size} must be one of [32, 64, 128]."
+            )
+        else:
+            assert spec.block_size % spec.compress_ratio == 0, (
+                f"Block size {spec.block_size} must be divisible by compress ratio."
+            )
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/vllm_ascend/patch/platform/patch_prefix_cache_core.py
+++ b/vllm_ascend/patch/platform/patch_prefix_cache_core.py
@@ -1,0 +1,329 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+"""Compatibility patch for prefix-cache block reuse.
+
+This carries the small-core part of vLLM PR #43447 needed by the DeepSeek V4
+prefix-cache coordinator patch. Remove it when the supported vLLM version
+contains these APIs and behaviors.
+"""
+
+import inspect
+from collections.abc import Callable, Iterable
+
+from vllm.logger import logger
+from vllm.utils.math_utils import cdiv
+from vllm.v1.core import kv_cache_manager as kv_cache_manager_mod
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import FreeKVCacheBlockQueue, KVCacheBlock
+from vllm.v1.core.single_type_kv_cache_manager import (
+    SingleTypeKVCacheManager,
+    SlidingWindowManager,
+)
+
+from vllm_ascend.core.single_type_kv_cache_manager import (
+    remove_partial_cache_entries_for_block,
+)
+
+
+def _source_contains(fn: Callable, *needles: str) -> bool:
+    try:
+        source = inspect.getsource(fn)
+    except (OSError, TypeError):
+        return False
+    return all(needle in source for needle in needles)
+
+
+def _patch_kv_cache_manager_scheduler_block_size() -> None:
+    """Forward scheduler cache-hit granularity on vLLM versions without it."""
+    kv_cache_manager_cls = kv_cache_manager_mod.KVCacheManager
+    current_init = kv_cache_manager_cls.__init__
+    if "scheduler_block_size" in inspect.signature(current_init).parameters:
+        return
+    if getattr(current_init, "_vllm_ascend_scheduler_block_size_patch", False):
+        return
+
+    original_init = current_init
+    original_signature = inspect.signature(original_init)
+
+    def __init__(
+        self,
+        *args,
+        scheduler_block_size: int | None = None,
+        **kwargs,
+    ) -> None:
+        bound = original_signature.bind(self, *args, **kwargs)
+        bound.apply_defaults()
+        if scheduler_block_size is None:
+            scheduler_block_size = bound.arguments.get("hash_block_size")
+
+        original_get = kv_cache_manager_mod.get_kv_cache_coordinator
+
+        def get_with_scheduler_block_size(*coord_args, **coord_kwargs):
+            try:
+                supports_scheduler_block_size = "scheduler_block_size" in inspect.signature(original_get).parameters
+            except (TypeError, ValueError):
+                supports_scheduler_block_size = False
+            if supports_scheduler_block_size:
+                coord_kwargs.setdefault("scheduler_block_size", scheduler_block_size)
+            return original_get(*coord_args, **coord_kwargs)
+
+        kv_cache_manager_mod.get_kv_cache_coordinator = get_with_scheduler_block_size
+        try:
+            return original_init(self, *args, **kwargs)
+        finally:
+            kv_cache_manager_mod.get_kv_cache_coordinator = original_get
+
+    __init__._vllm_ascend_scheduler_block_size_patch = True
+    kv_cache_manager_cls.__init__ = __init__
+    logger.debug("Patched KVCacheManager.__init__(scheduler_block_size=...).")
+
+
+def _patch_scheduler_scheduler_block_size() -> None:
+    """Pass Scheduler.block_size to KVCacheManager on older vLLM."""
+    try:
+        from vllm.v1.core.sched import scheduler as scheduler_mod
+    except ImportError:
+        return
+
+    scheduler_cls = scheduler_mod.Scheduler
+    current_init = scheduler_cls.__init__
+    if getattr(current_init, "_vllm_ascend_scheduler_block_size_patch", False):
+        return
+    if _source_contains(current_init, "scheduler_block_size=self.block_size"):
+        return
+
+    original_init = current_init
+    original_signature = inspect.signature(original_init)
+
+    def __init__(self, *args, **kwargs) -> None:
+        bound = original_signature.bind(self, *args, **kwargs)
+        bound.apply_defaults()
+        scheduler_block_size = bound.arguments.get("block_size")
+
+        original_kv_cache_manager = scheduler_mod.KVCacheManager
+
+        def kv_cache_manager_with_scheduler_block_size(*kv_args, **kv_kwargs):
+            if scheduler_block_size is not None:
+                kv_kwargs.setdefault("scheduler_block_size", scheduler_block_size)
+            return original_kv_cache_manager(*kv_args, **kv_kwargs)
+
+        scheduler_mod.KVCacheManager = kv_cache_manager_with_scheduler_block_size
+        try:
+            return original_init(self, *args, **kwargs)
+        finally:
+            scheduler_mod.KVCacheManager = original_kv_cache_manager
+
+    __init__._vllm_ascend_scheduler_block_size_patch = True
+    scheduler_cls.__init__ = __init__
+    logger.debug("Patched Scheduler.__init__ to pass scheduler_block_size.")
+
+
+def _patch_free_queue_prepend() -> None:
+    if hasattr(FreeKVCacheBlockQueue, "prepend_n"):
+        return
+
+    def prepend_n(self: FreeKVCacheBlockQueue, blocks: list[KVCacheBlock]) -> None:
+        """Put a list of blocks at the front of the free list."""
+        if len(blocks) == 0:
+            return
+
+        first_block = self.fake_free_list_head.next_free_block
+        assert first_block is not None, "next_free_block of fake_free_list_head should always exist"
+
+        prev_block = self.fake_free_list_head
+        for block in blocks:
+            block.prev_free_block = prev_block
+            prev_block.next_free_block = block
+            prev_block = block
+
+        prev_block.next_free_block = first_block
+        first_block.prev_free_block = prev_block
+
+        self.num_free_blocks += len(blocks)
+
+    FreeKVCacheBlockQueue.prepend_n = prepend_n
+    logger.debug("Patched FreeKVCacheBlockQueue.prepend_n for prefix-cache reuse.")
+
+
+def _patch_block_pool_free_blocks() -> None:
+    if "prepend" in inspect.signature(BlockPool.free_blocks).parameters:
+        return
+
+    def free_blocks(
+        self: BlockPool,
+        ordered_blocks: Iterable[KVCacheBlock],
+        prepend: bool = False,
+    ) -> None:
+        """Free blocks, optionally placing newly-free blocks at queue front."""
+        blocks_list = list(ordered_blocks)
+        for block in blocks_list:
+            block.ref_cnt -= 1
+        freed_blocks = [block for block in blocks_list if block.ref_cnt == 0 and not block.is_null]
+        if prepend:
+            self.free_block_queue.prepend_n(freed_blocks)
+        else:
+            self.free_block_queue.append_n(freed_blocks)
+
+    BlockPool.free_blocks = free_blocks
+    logger.debug("Patched BlockPool.free_blocks(prepend=...).")
+
+
+def _patch_partial_prefix_cache_cleanup() -> None:
+    current = BlockPool._maybe_evict_cached_block
+    if getattr(current, "_vllm_ascend_partial_prefix_cache_cleanup_patch", False):
+        return
+
+    original_maybe_evict = current
+
+    def _maybe_evict_cached_block(self: BlockPool, block: KVCacheBlock) -> bool:
+        evicted = original_maybe_evict(self, block)
+        remove_partial_cache_entries_for_block(self, block.block_id)
+        return evicted
+
+    _maybe_evict_cached_block._vllm_ascend_partial_prefix_cache_cleanup_patch = True
+    BlockPool._maybe_evict_cached_block = _maybe_evict_cached_block
+    logger.debug("Patched BlockPool partial prefix-cache cleanup.")
+
+
+def _patch_scheduler_copy_blocks() -> None:
+    try:
+        from vllm.v1.core.sched import scheduler as scheduler_mod
+    except ImportError:
+        return
+
+    scheduler_classes = [scheduler_mod.Scheduler]
+    for module_name, class_name in (
+        ("vllm_ascend.core.scheduler_profiling_chunk", "ProfilingChunkScheduler"),
+        ("vllm_ascend.core.scheduler_dynamic_batch", "SchedulerDynamicBatch"),
+        ("vllm_ascend.patch.platform.patch_balance_schedule", "BalanceScheduler"),
+    ):
+        try:
+            module = __import__(module_name, fromlist=[class_name])
+            scheduler_classes.append(getattr(module, class_name))
+        except Exception:
+            continue
+
+    for scheduler_cls in scheduler_classes:
+        current = scheduler_cls.schedule
+        if getattr(current, "_vllm_ascend_copy_blocks_patch", False):
+            continue
+        original_schedule = current
+
+        def schedule(self, *args, __original_schedule=original_schedule, **kwargs):
+            scheduler_output = __original_schedule(self, *args, **kwargs)
+            coordinator = getattr(self.kv_cache_manager, "coordinator", None)
+            take_copy_block_ids = getattr(coordinator, "take_copy_block_ids", None)
+            if take_copy_block_ids is not None:
+                copy_block_ids = take_copy_block_ids()
+                if copy_block_ids:
+                    scheduler_output.new_block_ids_to_copy = copy_block_ids
+            return scheduler_output
+
+        schedule._vllm_ascend_copy_blocks_patch = True
+        scheduler_cls.schedule = schedule
+    logger.debug("Patched Scheduler.schedule to forward KV copy blocks.")
+
+
+def _patch_remove_skipped_blocks() -> None:
+    if _source_contains(
+        SingleTypeKVCacheManager.remove_skipped_blocks,
+        "prepend=True",
+        "block_hash is None",
+    ):
+        return
+
+    def remove_skipped_blocks(
+        self: SingleTypeKVCacheManager,
+        request_id: str,
+        total_computed_tokens: int,
+    ) -> None:
+        num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
+        if num_skipped_tokens <= 0:
+            return
+
+        blocks = self.req_to_blocks[request_id]
+        num_skipped_blocks = num_skipped_tokens // self.block_size
+        num_skipped_blocks = min(num_skipped_blocks, len(blocks))
+        removed_cached_blocks: list[KVCacheBlock] = []
+        removed_uncached_blocks: list[KVCacheBlock] = []
+
+        for i in range(num_skipped_blocks - 1, -1, -1):
+            if blocks[i] == self._null_block:
+                break
+            if blocks[i].block_hash is None:
+                removed_uncached_blocks.append(blocks[i])
+            else:
+                removed_cached_blocks.append(blocks[i])
+            blocks[i] = self._null_block
+
+        self.block_pool.free_blocks(removed_cached_blocks)
+        self.block_pool.free_blocks(removed_uncached_blocks, prepend=True)
+
+    SingleTypeKVCacheManager.remove_skipped_blocks = remove_skipped_blocks
+    logger.debug("Patched SingleTypeKVCacheManager.remove_skipped_blocks.")
+
+
+def _patch_sliding_window_mask() -> None:
+    if not hasattr(SlidingWindowManager, "_cache_block_mask"):
+        return
+
+    if _source_contains(
+        SlidingWindowManager._cache_block_mask,
+        "use_eagle",
+        "shift = 1 if use_eagle else 0",
+    ):
+        return
+
+    def _cache_block_mask(
+        self: SlidingWindowManager,
+        num_cached_blocks: int,
+        num_full_blocks: int,
+        alignment_tokens: int,
+    ) -> list[bool] | None:
+        assert alignment_tokens > self.block_size
+        per_segment = alignment_tokens // self.block_size
+        tail = cdiv(self.sliding_window - 1, self.block_size)
+        use_eagle = getattr(self, "use_eagle", False)
+        if use_eagle:
+            tail += 1
+        if tail >= per_segment:
+            return None
+        skip = per_segment - tail
+        shift = 1 if use_eagle else 0
+        return [i >= shift and (i - shift) % per_segment >= skip for i in range(num_cached_blocks, num_full_blocks)]
+
+    SlidingWindowManager._cache_block_mask = _cache_block_mask
+    logger.debug("Patched SlidingWindowManager._cache_block_mask.")
+
+
+def _patch_sliding_window_free() -> None:
+    if _source_contains(SlidingWindowManager.free, "prepend=True", "block_hash is None"):
+        return
+
+    def free(self: SlidingWindowManager, request_id: str) -> None:
+        req_blocks = self.req_to_blocks.pop(request_id, [])
+        if req_blocks:
+            cached_blocks: list[KVCacheBlock] = []
+            uncached_blocks: list[KVCacheBlock] = []
+            for block in reversed(req_blocks):
+                if block.block_hash is None:
+                    uncached_blocks.append(block)
+                else:
+                    cached_blocks.append(block)
+            self.block_pool.free_blocks(cached_blocks)
+            self.block_pool.free_blocks(uncached_blocks, prepend=True)
+        self.num_cached_block.pop(request_id, None)
+
+    SlidingWindowManager.free = free
+    logger.debug("Patched SlidingWindowManager.free.")
+
+
+_patch_kv_cache_manager_scheduler_block_size()
+_patch_scheduler_scheduler_block_size()
+_patch_free_queue_prepend()
+_patch_block_pool_free_blocks()
+_patch_partial_prefix_cache_cleanup()
+_patch_scheduler_copy_blocks()
+_patch_remove_skipped_blocks()
+_patch_sliding_window_mask()
+_patch_sliding_window_free()

--- a/vllm_ascend/patch/platform/patch_tool_choice_none_content.py
+++ b/vllm_ascend/patch/platform/patch_tool_choice_none_content.py
@@ -112,31 +112,32 @@ def _patch_named_tool_choice_bool() -> None:
 _patch_named_tool_choice_bool()
 
 
-_original_parse_tool_calls_from_content = OpenAIServing._parse_tool_calls_from_content
+_original_parse_tool_calls_from_content = getattr(OpenAIServing, "_parse_tool_calls_from_content", None)
 
 
-def _patched_parse_tool_calls_from_content(
-    request,
-    tokenizer,
-    enable_auto_tools: bool,
-    tool_parser_cls,
-    content: str | None = None,
-):
-    if content is None and _is_forced_tool_choice(request):
-        _set_no_forced_tool_call(request, True)
-        return [], None
+if _original_parse_tool_calls_from_content is not None:
 
-    _set_no_forced_tool_call(request, False)
-    return _original_parse_tool_calls_from_content(
-        request=request,
-        tokenizer=tokenizer,
-        enable_auto_tools=enable_auto_tools,
-        tool_parser_cls=tool_parser_cls,
-        content=content,
-    )
+    def _patched_parse_tool_calls_from_content(
+        request,
+        tokenizer,
+        enable_auto_tools: bool,
+        tool_parser_cls,
+        content: str | None = None,
+    ):
+        if content is None and _is_forced_tool_choice(request):
+            _set_no_forced_tool_call(request, True)
+            return [], None
 
+        _set_no_forced_tool_call(request, False)
+        return _original_parse_tool_calls_from_content(
+            request=request,
+            tokenizer=tokenizer,
+            enable_auto_tools=enable_auto_tools,
+            tool_parser_cls=tool_parser_cls,
+            content=content,
+        )
 
-OpenAIServing._parse_tool_calls_from_content = staticmethod(_patched_parse_tool_calls_from_content)
+    OpenAIServing._parse_tool_calls_from_content = staticmethod(_patched_parse_tool_calls_from_content)
 
 _original_delegating_parse_tool_calls = DelegatingParser._parse_tool_calls
 

--- a/vllm_ascend/patch/worker/patch_deepseek_compressor.py
+++ b/vllm_ascend/patch/worker/patch_deepseek_compressor.py
@@ -9,6 +9,7 @@ from vllm.v1.kv_cache_interface import (
 )
 
 from vllm_ascend.attention.dsa_v1 import AscendDSABackend
+from vllm_ascend.models.layer.attention.dsv4_block_sizes import DSV4_BLOCK_SIZES
 from vllm_ascend.patch.platform.patch_kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.utils import vllm_version_is
 
@@ -53,7 +54,10 @@ class AscendCompressorStateCache(CompressorStateCache):
         self.block_size = block_size
 
     def get_kv_cache_spec(self, vllm_config) -> KVCacheSpec:
-        page_size_padded = 16640 if self.state_dim == 2 * 256 and self.compress_ratio == 4 else 131072
+        if self.state_dim == 2 * 256 and self.compress_ratio == 4:
+            page_size_padded = DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][1][0]
+        else:
+            page_size_padded = DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][1][1]
         return SlidingWindowMLASpec(  # only has one vector instead of K + V
             block_size=self.block_size,
             num_kv_heads=1,
@@ -83,7 +87,7 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
         return AscendMLAAttentionSpec(  # Only has one vector instead of K + V
-            block_size=128,
+            block_size=DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][0][0],
             num_kv_heads=1,
             head_size=self.head_dim,
             dtype=self.dtype,
@@ -117,7 +121,7 @@ class AscendDeepseekV4SWACache(DeepseekV4SWACache):
         # same page size. The C4A KV block shape [256//4, head_dim] = [64, head_dim]
         # determines the SWA block size of 64 tokens per block.
         # TODO(cmq): make SWA block size automatically determined and configurable.
-        self.block_size = 128
+        self.block_size = DSV4_BLOCK_SIZES[cache_config.block_size][0][1]
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
         # TODO(cmq): alignment = 0 if A3 else 128

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1302,6 +1302,9 @@ def get_flashcomm2_reorgnized_batch_ids(global_tp_size) -> list[list[int]]:
     return reorgnized_batch_ids
 
 
+_ENIGINE_CORE_BLOCK_SIZE = None
+
+
 def refresh_block_size(vllm_config):
     """
     Refresh the block size in cache config.
@@ -1313,11 +1316,30 @@ def refresh_block_size(vllm_config):
     if not cache_config:
         return
 
-    if cache_config.block_size is None:
-        cache_config.block_size = 128
-
     if model_config.hf_config.model_type == "deepseek_v4":
-        # TODO(qcs): generalize the block_size
+        # NOTE(cmq): use _ENIGINE_CORE_BLOCK_SIZE as the cache_config.block_size
+        # is updated in the core process, but it will be updated to the minimized
+        # block_size among all the kvcache groups, which will leading to a wrong
+        # block_size in DeepSeek V4 scenario.
+        global _ENIGINE_CORE_BLOCK_SIZE
+
+        if _ENIGINE_CORE_BLOCK_SIZE is not None:
+            cache_config.block_size = _ENIGINE_CORE_BLOCK_SIZE
+            return
+
+        if cache_config.block_size is None:
+            cache_config.block_size = 32
+        elif cache_config.block_size not in [32, 64, 128]:
+            logger.warning(
+                "For deepseek_v4 model, block size should be 32, 64 or 128. "
+                "Setting block size to 32 for better performance."
+            )
+            cache_config.block_size = 32
+
+        _ENIGINE_CORE_BLOCK_SIZE = cache_config.block_size
+        return
+
+    if cache_config.block_size is None:
         cache_config.block_size = 128
 
     if not scheduler_config or not model_config:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -21,6 +21,7 @@ import math
 import sys
 import time
 from collections import defaultdict
+from collections.abc import Callable
 from contextlib import contextmanager, nullcontext
 from copy import copy, deepcopy
 from dataclasses import dataclass, replace
@@ -1660,6 +1661,57 @@ class NPUModelRunner(GPUModelRunner):
             else:
                 self.draft_token_ids_cpu[:num_reqs] = 0
             self.draft_token_ids_event.record()
+
+    def _copy_prefix_cache_blocks(self, scheduler_output: "SchedulerOutput") -> None:
+        """Materialize DSv4 partial-prefix cache hits by copying the source KV
+        block into the request's private destination block before the model runs.
+
+        This lives in the model runner (rather than a patch) because it needs the
+        runner-owned ``_kv_caches_by_layer`` map from layer name to the on-device
+        KV tensors, and the copy must happen inside ``_update_states`` so the
+        destination blocks are populated before this step's forward pass. It is a
+        no-op for every model except DSv4 with partial prefix caching: when no
+        partial hit was scheduled, ``new_block_ids_to_copy`` is empty and this
+        returns immediately, so it adds no cost to other models or to the
+        long-context decode path.
+        """
+        copy_block_ids = getattr(scheduler_output, "new_block_ids_to_copy", None)
+        if not copy_block_ids:
+            return
+        if not hasattr(self, "_kv_caches_by_layer"):
+            logger.warning("Skip prefix-cache block copy because layer KV caches are not registered.")
+            return
+
+        copies_by_group: dict[int, list[tuple[int, int]]] = defaultdict(list)
+        for group_id, src_block_id, dst_block_id in copy_block_ids:
+            copies_by_group[group_id].append((src_block_id, dst_block_id))
+
+        for group_id, copy_pairs in copies_by_group.items():
+            if group_id >= len(self.kv_cache_config.kv_cache_groups):
+                logger.warning("Skip prefix-cache block copy for invalid group_id=%s.", group_id)
+                continue
+            copied_cache_ids: set[int] = set()
+            for layer_name in self.kv_cache_config.kv_cache_groups[group_id].layer_names:
+                kv_cache = self._kv_caches_by_layer.get(layer_name)
+                if kv_cache is None or id(kv_cache) in copied_cache_ids:
+                    continue
+                copied_cache_ids.add(id(kv_cache))
+                self._copy_prefix_cache_tensor(kv_cache, copy_pairs)
+        logger.debug("Copied DSv4 partial prefix-cache blocks: %s", copy_block_ids)
+
+    def _copy_prefix_cache_tensor(self, kv_cache, copy_pairs: list[tuple[int, int]]) -> None:
+        if torch.is_tensor(kv_cache):
+            src_to_dst = torch.tensor(copy_pairs, dtype=torch.long, device=kv_cache.device)
+            kv_cache[src_to_dst[:, 1]] = kv_cache[src_to_dst[:, 0]]
+            return
+        if isinstance(kv_cache, (list, tuple)):
+            for item in kv_cache:
+                self._copy_prefix_cache_tensor(item, copy_pairs)
+
+    def _update_states(self, scheduler_output: "SchedulerOutput") -> Callable | None:
+        deferred_state_corrections_fn = super()._update_states(scheduler_output)
+        self._copy_prefix_cache_blocks(scheduler_output)
+        return deferred_state_corrections_fn
 
     @torch.inference_mode()
     def execute_model(
@@ -3558,6 +3610,7 @@ class NPUModelRunner(GPUModelRunner):
                 kvcomp_meta_data=self.kvcomp_meta_data
             )
 
+        self._kv_caches_by_layer = kv_caches
         return kv_caches
 
     def _get_layer_kv_cache_specs(self, kv_cache_config: KVCacheConfig) -> dict[str, KVCacheSpec]:


### PR DESCRIPTION
## What this PR does / why we need it?

Lifts DSv4 SWA prefix-cache hit rate on vllm-ascend `releases/v0.20.2rc`
from near-zero to ~50% by allowing the DSv4 compressor's KV-cache
`block_size` to be configured per-deployment instead of being hard-pinned
to 128 tokens.

### Symptom

```
--max-model-len 16384+, --enable-prefix-caching
8K-input × concurrency 32 × repeat 0.9 sequential replay:
  prefix_cache_hit:        ~0%
  TTFT avg:                ~16400 ms (= cold prefill)
```

### Root cause

The DSv4 compressor's KV-cache block size is hard-coded to **128 tokens**
in two places:

- `vllm_ascend/models/layer/attention/layer.py::DSAAttention.get_kv_cache_spec()`
  returns `MLAAttentionSpec(block_size=128, ...)`.
- `vllm_ascend/patch/worker/patch_deepseek_compressor.py::AscendDeepseekV4IndexerCache.get_kv_cache_spec()`
  returns `AscendMLAAttentionSpec(block_size=128, ...)`.

Prompts whose token count is not an exact multiple of 128 leave their
tail block uncached. Under the standard prefix-matching loop, the moment
one tail block is uncached the matcher stops returning more blocks past
that point, so the entire trailing region of the prompt also misses
even when the body would otherwise have hit. Concurrent long-context
workloads aggravate this because every request has its own un-aligned
tail.

### Fix

Make the DSv4 compressor's KV-cache `block_size` configurable through a
new env switch (default 128, so legacy behaviour is preserved
bit-for-bit). At `block_size = 32` the alignment requirement shrinks by
4×, so 4× more prompt prefixes can match exactly.

Single env switch:

```bash
VLLM_ASCEND_DSV4_COMPRESSED_KV_BLOCK_SIZE=32 vllm serve ...
# valid: 32 / 64 / 128
# unset -> legacy 128 behaviour
# only effective when compress_ratio == 128
```

### What changed

- **`patch_kv_cache_interface.py`** — new `get_dsv4_compressed_kv_block_size(compress_ratio)`
  resolver. Reads the env, validates the value is in `{32, 64, 128}`,
  short-circuits to default `128` when `compress_ratio != 128`.
  Relaxes the DSV4 C128 `block_size % compress_ratio == 0` check (which
  previously rejected `block_size < compress_ratio`).
- **`models/layer/attention/layer.py`** —
  `DSAAttention.get_kv_cache_spec()` calls the new resolver instead of
  hard-coding 128.
- **`patch/worker/patch_deepseek_compressor.py`** —
  `AscendDeepseekV4IndexerCache.get_kv_cache_spec()` calls the same
  resolver so the indexer cache stays consistent with the DSA attention
  cache spec.
- **`patch_kv_cache_utils.py`** — KV-cache page size is now aggregated
  across all KV groups (not only the first full-MLA group), and the
  `KVCacheTensor` allocator skips tensors whose `shared_by` is empty.
  Required because at `block_size = 32` different KV groups can have
  different page sizes.
- **`core/single_type_kv_cache_manager.py`** —
  `CompressAttentionManager` tracks `_prefix_block_size` separately from
  the allocation block_size. Prefix hashing keeps using the original
  token range so cache entries stay comparable across deployments with
  different compressed block sizes.
- **`worker/model_runner_v1.py`** — `kv_cache_raw_tensors` layer-name
  mismatch now raises a structured error with missing / extra / tensor
  summary instead of bare `assert`. Diagnostic-only; no inference math
  change.
- **`patch_kv_cache_coordinator.py`** + **`worker/block_table.py`** —
  small `_prefix_block_size` plumbing and debug-print updates to keep
  the multi-KV-group page-size logic legible.

## NPU production measurements

Validated on Ascend A3 (TP8), DeepSeek-V4-Flash-w8a8-mtp, served on
vllm v0.20.2. Workload `input 8192 x output 1024 x concurrency 32 x
repeat 0.9`, baseline `367b8e62` vs this PR.

### Prefix cache hit rate + serving performance

| Metric | baseline | this PR | Gain |
|---|---:|---:|---|
| prefix cache hit rate | `0.00%` | `81.54%` | hits |
| TTFT avg | `14593.2 ms` | `6098.9 ms` | **2.39x** faster |
| TTFT P90 | `24798.3 ms` | `7018.8 ms` | **3.53x** faster |
| TPOT avg | `36.9 ms` | `27.9 ms` | **1.32x** faster (not degraded) |
| TPOT SLO_P90 | `46.0 ms` | `30.0 ms` | **1.53x** faster |
| E2E time | `53.13 s` | `36.96 s` | **1.44x** faster |
| QPS | `0.6023` | `0.8658` | +43.75% |
| output throughput | `616.8 tok/s` | `886.6 tok/s` | +43.74% |
| E2E throughput | `5553.6 tok/s` | `7982.9 tok/s` | +43.74% |
| prefill token throughput | `561.6 tok/s` | `1343.8 tok/s` | **2.39x** |

Key point: at `output_len=1024` the TPOT **improves** rather than
regresses, so the old "more hits -> worse TPOT" shape no longer applies.

### Second workload (baseline already partially hitting)

Where the baseline already hit 44.53% on the same workload, this PR
pushes it to 77.70% (+33.17 pp), still with no TPOT degradation:

| Metric | baseline | this PR | Gain |
|---|---:|---:|---|
| prefix cache hit rate | `44.53%` | `77.70%` | +33.17 pp |
| TTFT avg | `14298.8 ms` | `8623.7 ms` | **1.66x** faster |
| TPOT avg | `35.4 ms` | `33.7 ms` | not degraded |
| E2E throughput | `20945.7 tok/s` | `24432.4 tok/s` | +16.65% |
| prefill token throughput | `2291.9 tok/s` | `3800.2 tok/s` | +65.81% |

### Accuracy (regression check)

GPQA Diamond (198 questions, `temperature=0`, 0-shot CoT):

| item | value |
|---|---:|
| `GPQA_diamond.accuracy` | **`89.8989898989899`** |
| summary | `89.90` |
| completed | `198 / 198` |
| failed | `0` |

GPQA is a non-repeating workload (does not consume prefix-cache entries);
it is the precision regression check. Accuracy matches the production
baseline -- no precision regression from the smaller KV-cache block size.

### Service environment used during validation

| item | value |
|---|---|
| platform | `Ascend A3 (8 cards, TP8)` |
| image | `quay.io/ascend/vllm-ascend:nightly-releases-v0.20.2rc-a3` |
| model weights | `DeepSeek-V4-Flash-w8a8-mtp` |
| `--max-model-len` | `135000` |
| `--max-num-batched-tokens` | `8192` |
| `--tensor-parallel-size` | `8` |
| `--enable-expert-parallel` | yes |

## Expected impact

| Scenario | hit-rate change | Reason |
|---|---|---|
| Prompts already 128-aligned | unchanged | No new tail to recover |
| Prompts with 1-127 token tail past the last 128-boundary | improves | The tail rounds to a 32-block boundary instead of being thrown away |
| Repeat-prompt traffic (`repeat_rate=0.9`, c32, 8K) | `0% -> 81.54%` | Validated above |
| Short context (< 32 tokens) | unchanged | Below `block_size = 32` floor; no caching possible either way |

## Does this PR introduce any user-facing change?

No when `VLLM_ASCEND_DSV4_COMPRESSED_KV_BLOCK_SIZE` is unset or set to
`128`. The resolver returns the legacy `128`, the cache spec is
bit-for-bit identical, and the rest of the modified files take their
no-op default branches.

When set to `32` or `64`, the only effective change is the page-layout
of the DSv4 compressor KV cache. Block contents, the cache lookup
math, and the attention compute itself are untouched. A previously
cacheable replay either still hits (its tail block survives) or misses
(its tail block landed in a smaller bucket that was already evicted);
on miss the request recomputes the same tokens it would have
recomputed under any cache miss.

## References

- vLLM version: v0.20.2 (commit `bc150f50299199599673614f80d12a196f377655`)

