### PR TITLE
[Misc][0.20.2] Rehash AscendStore grouped keys

### DIFF
--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -68,6 +68,7 @@ _vllm_mock_modules = [
     "vllm.distributed.parallel_state",
     "vllm.envs",
     "vllm.forward_context",
+    "vllm.logger",
     "vllm.model_executor",
     "vllm.model_executor.layers",
     "vllm.model_executor.layers.linear",

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -164,6 +164,14 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         self.assertEqual(result[0][2].chunk_hash, _expected_grouped_hash("a", "b").hex())
         self.assertEqual(len(result[0][2].chunk_hash), 64)
 
+    def test_process_tokens_rehashes_trailing_partial_group(self):
+        db = ChunkedTokenDatabase(self.meta, block_size=16, partitions=None, hash_block_size=8)
+        result = list(db.process_tokens(24, ["a", "b", "c"]))
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[1][0], 16)
+        self.assertEqual(result[1][1], 24)
+        self.assertEqual(result[1][2].chunk_hash, _expected_grouped_hash("c").hex())
+
     def test_get_block_hashes_rehashes_grouped_str_hashes(self):
         result = get_block_hashes(["a", "b", "c", "d"], group_block_size=32, hash_block_size=16)
         self.assertEqual(
@@ -171,6 +179,16 @@ class TestChunkedTokenDatabase(unittest.TestCase):
             [
                 _expected_grouped_hash("a", "b"),
                 _expected_grouped_hash("c", "d"),
+            ],
+        )
+
+    def test_get_block_hashes_rehashes_trailing_partial_group(self):
+        result = get_block_hashes(["a", "b", "c"], group_block_size=32, hash_block_size=16)
+        self.assertEqual(
+            result,
+            [
+                _expected_grouped_hash("a", "b"),
+                _expected_grouped_hash("c"),
             ],
         )
 

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -172,6 +172,16 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         self.assertEqual(result[1][1], 24)
         self.assertEqual(result[1][2].chunk_hash, _expected_grouped_hash("c").hex())
 
+    def test_process_tokens_rehashes_raw_bytes_and_hex_strings_consistently(self):
+        db = ChunkedTokenDatabase(self.meta, block_size=16, partitions=None, hash_block_size=8)
+        raw_hashes = [bytes([idx]) * 32 for idx in range(1, 5)]
+        hex_hashes = [block_hash.hex() for block_hash in raw_hashes]
+
+        raw_keys = [key.to_string() for _, _, key in db.process_tokens(32, raw_hashes)]
+        hex_keys = [key.to_string() for _, _, key in db.process_tokens(32, hex_hashes)]
+
+        self.assertEqual(raw_keys, hex_keys)
+
     def test_get_block_hashes_rehashes_grouped_str_hashes(self):
         result = get_block_hashes(["a", "b", "c", "d"], group_block_size=32, hash_block_size=16)
         self.assertEqual(
@@ -190,6 +200,15 @@ class TestChunkedTokenDatabase(unittest.TestCase):
                 _expected_grouped_hash("a", "b"),
                 _expected_grouped_hash("c"),
             ],
+        )
+
+    def test_get_block_hashes_rehashes_raw_bytes_and_hex_strings_consistently(self):
+        raw_hashes = [bytes([idx]) * 32 for idx in range(1, 5)]
+        hex_hashes = [block_hash.hex() for block_hash in raw_hashes]
+
+        self.assertEqual(
+            get_block_hashes(hex_hashes, group_block_size=32, hash_block_size=16),
+            get_block_hashes(raw_hashes, group_block_size=32, hash_block_size=16),
         )
 
     def test_get_block_hashes_rehashes_grouped_bytes_hashes(self):

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -164,14 +164,6 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         self.assertEqual(result[0][2].chunk_hash, _expected_grouped_hash("a", "b").hex())
         self.assertEqual(len(result[0][2].chunk_hash), 64)
 
-    def test_process_tokens_rehashes_trailing_partial_group(self):
-        db = ChunkedTokenDatabase(self.meta, block_size=16, partitions=None, hash_block_size=8)
-        result = list(db.process_tokens(24, ["a", "b", "c"]))
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[1][0], 16)
-        self.assertEqual(result[1][1], 24)
-        self.assertEqual(result[1][2].chunk_hash, _expected_grouped_hash("c").hex())
-
     def test_process_tokens_rehashes_raw_bytes_and_hex_strings_consistently(self):
         db = ChunkedTokenDatabase(self.meta, block_size=16, partitions=None, hash_block_size=8)
         raw_hashes = [bytes([idx]) * 32 for idx in range(1, 5)]
@@ -189,16 +181,6 @@ class TestChunkedTokenDatabase(unittest.TestCase):
             [
                 _expected_grouped_hash("a", "b"),
                 _expected_grouped_hash("c", "d"),
-            ],
-        )
-
-    def test_get_block_hashes_rehashes_trailing_partial_group(self):
-        result = get_block_hashes(["a", "b", "c"], group_block_size=32, hash_block_size=16)
-        self.assertEqual(
-            result,
-            [
-                _expected_grouped_hash("a", "b"),
-                _expected_grouped_hash("c"),
             ],
         )
 

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -15,6 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
+import hashlib
 import unittest
 from unittest.mock import MagicMock
 
@@ -29,7 +30,22 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     PoolKey,
     ReqMeta,
     RequestTracker,
+    get_block_hashes,
 )
+
+_GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
+_GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
+
+
+def _expected_grouped_hash(*block_hashes):
+    hasher = hashlib.sha256()
+    hasher.update(_GROUPED_BLOCK_HASH_DOMAIN)
+    hasher.update(len(block_hashes).to_bytes(_GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES, "big"))
+    for block_hash in block_hashes:
+        hash_bytes = block_hash.encode("utf-8") if isinstance(block_hash, str) else bytes(block_hash)
+        hasher.update(len(hash_bytes).to_bytes(_GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES, "big"))
+        hasher.update(hash_bytes)
+    return hasher.digest()
 
 
 class TestKeyMetadata(unittest.TestCase):
@@ -93,8 +109,9 @@ class TestLayerPoolKey(unittest.TestCase):
         meta = KeyMetadata("model", 0, 0, 0, 0)
         k = LayerPoolKey(meta, "h1", 5)
         s = k.to_string()
-        self.assertIn("@5", s)
+        self.assertIn("@layer_id:5", s)
         self.assertIn("model", s)
+        self.assertTrue(s.endswith("@h1"))
 
 
 class TestChunkedTokenDatabase(unittest.TestCase):
@@ -139,6 +156,34 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         # token_len=32 means only first 2 blocks valid
         result = list(self.db.process_tokens(32, hashes))
         self.assertEqual(len(result), 2)
+
+    def test_process_tokens_rehashes_grouped_hashes(self):
+        db = ChunkedTokenDatabase(self.meta, block_size=16, partitions=None, hash_block_size=8)
+        result = list(db.process_tokens(32, ["a", "b", "c", "d"]))
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0][2].chunk_hash, _expected_grouped_hash("a", "b").hex())
+        self.assertEqual(len(result[0][2].chunk_hash), 64)
+
+    def test_get_block_hashes_rehashes_grouped_str_hashes(self):
+        result = get_block_hashes(["a", "b", "c", "d"], group_block_size=32, hash_block_size=16)
+        self.assertEqual(
+            result,
+            [
+                _expected_grouped_hash("a", "b"),
+                _expected_grouped_hash("c", "d"),
+            ],
+        )
+
+    def test_get_block_hashes_rehashes_grouped_bytes_hashes(self):
+        result = get_block_hashes([b"a", b"b", b"c", b"d"], group_block_size=32, hash_block_size=16)
+        self.assertEqual(
+            result,
+            [
+                _expected_grouped_hash(b"a", b"b"),
+                _expected_grouped_hash(b"c", b"d"),
+            ],
+        )
+        self.assertEqual(len(result[0]), 32)
 
     def test_prepare_value(self):
         addr, size, block_id = self.db.prepare_value(0, 16, [5, 6, 7])

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -484,6 +484,10 @@ def _rehash_block_hash_group(block_hashes: Sequence[BlockHash | str]) -> BlockHa
 
 def _block_hash_to_bytes(block_hash: BlockHash | str) -> bytes:
     if isinstance(block_hash, str):
+        try:
+            return bytes.fromhex(block_hash)
+        except ValueError:
+            pass
         return block_hash.encode("utf-8")
     return bytes(block_hash)
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -467,7 +467,7 @@ def get_block_hashes(
     scale_factor = group_block_size // hash_block_size
     return [
         _rehash_block_hash_group(block_hashes[idx : idx + scale_factor])
-        for idx in range(0, len(block_hashes) // scale_factor * scale_factor, scale_factor)
+        for idx in range(0, len(block_hashes), scale_factor)
     ]
 
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any, cast
@@ -8,8 +9,11 @@ import torch
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
 from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
-from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashList, BlockHashListWithBlockSize
+from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashList
 from vllm.v1.core.sched.output import NewRequestData
+
+_GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
+_GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
 
 
 # Parameters related to the key
@@ -109,7 +113,8 @@ class LayerPoolKey(PoolKey):
             f"@group:{self.key_metadata.kv_cache_group_id}"
             f"@cache_role:{self.key_metadata.cache_role}"
             f"@cache_family:{self.key_metadata.cache_family}"
-            f"@{self.chunk_hash}@{self.layer_id}"
+            f"@layer_id:{self.layer_id}"
+            f"@{self.chunk_hash}"
         )
 
 
@@ -459,13 +464,28 @@ def get_block_hashes(
     if group_block_size == hash_block_size:
         return block_hashes
     assert group_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
-    if isinstance(block_hashes[0], str):
-        scale_factor = group_block_size // hash_block_size
-        return [
-            "".join(block_hashes[idx : idx + scale_factor])
-            for idx in range(0, len(block_hashes) // scale_factor * scale_factor, scale_factor)
-        ]
-    return BlockHashListWithBlockSize(block_hashes, hash_block_size, group_block_size)
+    scale_factor = group_block_size // hash_block_size
+    return [
+        _rehash_block_hash_group(block_hashes[idx : idx + scale_factor])
+        for idx in range(0, len(block_hashes) // scale_factor * scale_factor, scale_factor)
+    ]
+
+
+def _rehash_block_hash_group(block_hashes: Sequence[BlockHash | str]) -> BlockHash:
+    hasher = hashlib.sha256()
+    hasher.update(_GROUPED_BLOCK_HASH_DOMAIN)
+    hasher.update(len(block_hashes).to_bytes(_GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES, "big"))
+    for block_hash in block_hashes:
+        hash_bytes = _block_hash_to_bytes(block_hash)
+        hasher.update(len(hash_bytes).to_bytes(_GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES, "big"))
+        hasher.update(hash_bytes)
+    return BlockHash(hasher.digest())
+
+
+def _block_hash_to_bytes(block_hash: BlockHash | str) -> bytes:
+    if isinstance(block_hash, str):
+        return block_hash.encode("utf-8")
+    return bytes(block_hash)
 
 
 # Parameters related to the connector metadata

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -467,7 +467,7 @@ def get_block_hashes(
     scale_factor = group_block_size // hash_block_size
     return [
         _rehash_block_hash_group(block_hashes[idx : idx + scale_factor])
-        for idx in range(0, len(block_hashes), scale_factor)
+        for idx in range(0, len(block_hashes) // scale_factor * scale_factor, scale_factor)
     ]
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

This backports the AscendStore grouped block-hash rehash logic to `releases/v0.20.2rc`.

- Rehash grouped block hashes with a domain-separated SHA-256 digest instead of concatenating long hash strings.
- Put the layer id before the final block hash segment in layer keys, so the block hash remains the last key component.
- Keep the 0.20.2rc old setter/fallback path (`set_kv_caches_base_addr`, `set_block_len`, `set_block_stride`) intact; this PR does not migrate `pool_worker.py` to the main-branch-only `set_group_buffers` flow.

### Does this PR introduce _any_ user-facing change?

No. This only changes internal AscendStore KV pool key construction for grouped block hashes.

### How was this patch tested?

vLLM version: v0.20.2
vLLM main: vllm-project/vllm@39910f2b25aacc09f5e7f166cdf0030b19f8b9e8