### PR TITLE
[Feature] Support AscendStore retention masks

### DIFF
--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -83,11 +83,13 @@ _vllm_mock_modules = [
     "vllm.v1.attention",
     "vllm.v1.attention.backend",
     "vllm.v1.core",
+    "vllm.v1.core.block_pool",
     "vllm.v1.core.kv_cache_manager",
     "vllm.v1.core.kv_cache_utils",
     "vllm.v1.core.sched",
     "vllm.v1.core.sched.output",
     "vllm.v1.kv_cache_interface",
+    "vllm.v1.kv_cache_spec_registry",
     "vllm.v1.outputs",
     "vllm.v1.request",
     "vllm.v1.serial_utils",
@@ -129,7 +131,39 @@ _events_mod.BlockStored = type(  # type: ignore[attr-defined]
 
 _kv_cache_utils_mod = sys.modules["vllm.v1.core.kv_cache_utils"]
 _kv_cache_utils_mod.BlockHash = bytes  # type: ignore[attr-defined]
+_kv_cache_utils_mod.BlockHashList = list  # type: ignore[attr-defined]
 _kv_cache_utils_mod.maybe_convert_block_hash = lambda x: x  # type: ignore[attr-defined]
+
+
+class _BlockHashListWithBlockSize(list):
+    def __init__(self, block_hashes, hash_block_size, block_size):
+        super().__init__(block_hashes)
+        self.hash_block_size = hash_block_size
+        self.block_size = block_size
+
+
+_kv_cache_utils_mod.BlockHashListWithBlockSize = _BlockHashListWithBlockSize  # type: ignore[attr-defined]
+
+_block_pool_mod = sys.modules["vllm.v1.core.block_pool"]
+_block_pool_mod.BlockPool = type("BlockPool", (), {})  # type: ignore[attr-defined]
+
+
+class _KVCacheBlock:
+    def __init__(self, block_id=0, **kwargs):
+        self.block_id = block_id
+        self.__dict__.update(kwargs)
+
+
+_kv_cache_utils_mod.KVCacheBlock = _KVCacheBlock  # type: ignore[attr-defined]
+
+
+class _KVCacheSpecRegistry:
+    @staticmethod
+    def get_manager_class(spec):
+        return getattr(spec, "manager_cls", None)
+
+
+sys.modules["vllm.v1.kv_cache_spec_registry"].KVCacheSpecRegistry = _KVCacheSpecRegistry  # type: ignore[attr-defined]
 
 _sched_output_mod = sys.modules["vllm.v1.core.sched.output"]
 _sched_output_mod.NewRequestData = MagicMock  # type: ignore[attr-defined]

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -241,6 +241,14 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         self.assertEqual(hit_call["max_length"], 32)
         self.assertEqual(hit_call["alignment_tokens"], 64)
 
+    def test_mask_allows_chunk_uses_group_block_size(self):
+        db = ChunkedTokenDatabase([self.meta], block_size=[8], partitions=None)
+
+        self.assertTrue(db.mask_allows_chunk(None, start=128, kv_cache_group_id=0))
+        self.assertFalse(db.mask_allows_chunk([False, True], start=0, kv_cache_group_id=0))
+        self.assertTrue(db.mask_allows_chunk([False, True], start=8, kv_cache_group_id=0))
+        self.assertFalse(db.mask_allows_chunk([False, True], start=16, kv_cache_group_id=0))
+
     def test_get_block_hashes_rehashes_grouped_str_hashes(self):
         result = get_block_hashes(["a", "b", "c", "d"], group_block_size=32, hash_block_size=16)
         self.assertEqual(

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -213,11 +213,13 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         mask = db.store_mask(128, kv_cache_group_id=0, num_prompt_tokens=100)
 
         self.assertEqual(mask, [False, True, False, True])
-        self.assertEqual(_FakeMaskManager.last_reachable_call["end_block"], 4)
-        self.assertEqual(_FakeMaskManager.last_reachable_call["kv_cache_spec"].block_size, 32)
-        self.assertEqual(_FakeMaskManager.last_reachable_call["alignment_tokens"], 32)
-        self.assertEqual(_FakeMaskManager.last_reachable_call["retention_interval"], 64)
-        self.assertEqual(_FakeMaskManager.last_reachable_call["num_prompt_tokens"], 100)
+        reachable_call = _FakeMaskManager.last_reachable_call
+        assert reachable_call is not None
+        self.assertEqual(reachable_call["end_block"], 4)
+        self.assertEqual(reachable_call["kv_cache_spec"].block_size, 32)
+        self.assertEqual(reachable_call["alignment_tokens"], 32)
+        self.assertEqual(reachable_call["retention_interval"], 64)
+        self.assertEqual(reachable_call["num_prompt_tokens"], 100)
 
     def test_load_mask_uses_manager_hit_semantics(self):
         spec = _FakeSpec(block_size=16, manager_cls=_FakeMaskManager)
@@ -234,8 +236,10 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         mask = db.load_mask([b"h0", b"h1"], token_len=32, kv_cache_group_id=0)
 
         self.assertEqual(mask, [False, True])
-        self.assertEqual(_FakeMaskManager.last_hit_call["max_length"], 32)
-        self.assertEqual(_FakeMaskManager.last_hit_call["alignment_tokens"], 64)
+        hit_call = _FakeMaskManager.last_hit_call
+        assert hit_call is not None
+        self.assertEqual(hit_call["max_length"], 32)
+        self.assertEqual(hit_call["alignment_tokens"], 64)
 
     def test_get_block_hashes_rehashes_grouped_str_hashes(self):
         result = get_block_hashes(["a", "b", "c", "d"], group_block_size=32, hash_block_size=16)

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -17,6 +17,7 @@
 
 import hashlib
 import unittest
+from dataclasses import dataclass
 from unittest.mock import MagicMock
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
@@ -35,6 +36,35 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
 
 _GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
 _GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
+
+
+@dataclass
+class _FakeSpec:
+    block_size: int
+    manager_cls: type
+
+
+@dataclass
+class _FakeGroup:
+    kv_cache_spec: _FakeSpec
+    is_eagle_group: bool = False
+
+
+class _FakeMaskManager:
+    last_reachable_call = None
+    last_hit_call = None
+
+    @classmethod
+    def reachable_block_mask(cls, **kwargs):
+        cls.last_reachable_call = kwargs
+        return [idx % 2 == 1 for idx in range(kwargs["end_block"] - kwargs["start_block"])]
+
+    @classmethod
+    def find_longest_cache_hit(cls, **kwargs):
+        cls.last_hit_call = kwargs
+        block_pool = kwargs["block_pool"]
+        present = block_pool.get_cached_block(kwargs["block_hashes"][0], kwargs["kv_cache_group_ids"])[0]
+        return ([block_pool.null_block, present],)
 
 
 def _expected_grouped_hash(*block_hashes):
@@ -163,6 +193,50 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         self.assertEqual(result[0][2].chunk_hash, _expected_grouped_hash("a", "b").hex())
         self.assertEqual(len(result[0][2].chunk_hash), 64)
 
+    def test_store_mask_uses_cache_family_store_granularity(self):
+        spec = _FakeSpec(block_size=8, manager_cls=_FakeMaskManager)
+        db = ChunkedTokenDatabase(
+            [self.meta],
+            block_size=[8],
+            partitions=None,
+            hash_block_size=8,
+            kv_cache_groups=[_FakeGroup(spec)],
+            alignment_tokens=32,
+            retention_interval=64,
+        )
+        db.set_group_buffers(
+            {0: [1000]},
+            {0: [80]},
+            group_cache_families={0: "c4"},
+        )
+
+        mask = db.store_mask(128, kv_cache_group_id=0, num_prompt_tokens=100)
+
+        self.assertEqual(mask, [False, True, False, True])
+        self.assertEqual(_FakeMaskManager.last_reachable_call["end_block"], 4)
+        self.assertEqual(_FakeMaskManager.last_reachable_call["kv_cache_spec"].block_size, 32)
+        self.assertEqual(_FakeMaskManager.last_reachable_call["alignment_tokens"], 32)
+        self.assertEqual(_FakeMaskManager.last_reachable_call["retention_interval"], 64)
+        self.assertEqual(_FakeMaskManager.last_reachable_call["num_prompt_tokens"], 100)
+
+    def test_load_mask_uses_manager_hit_semantics(self):
+        spec = _FakeSpec(block_size=16, manager_cls=_FakeMaskManager)
+        db = ChunkedTokenDatabase(
+            [self.meta],
+            block_size=[16],
+            partitions=None,
+            hash_block_size=16,
+            kv_cache_groups=[_FakeGroup(spec)],
+            alignment_tokens=64,
+        )
+        db.set_group_buffers({0: [1000]}, {0: [160]})
+
+        mask = db.load_mask([b"h0", b"h1"], token_len=32, kv_cache_group_id=0)
+
+        self.assertEqual(mask, [False, True])
+        self.assertEqual(_FakeMaskManager.last_hit_call["max_length"], 32)
+        self.assertEqual(_FakeMaskManager.last_hit_call["alignment_tokens"], 64)
+
     def test_get_block_hashes_rehashes_grouped_str_hashes(self):
         result = get_block_hashes(["a", "b", "c", "d"], group_block_size=32, hash_block_size=16)
         self.assertEqual(
@@ -253,6 +327,7 @@ class TestRequestTracker(unittest.TestCase):
         self.assertEqual(tracker.allocated_block_ids, [10, 20, 30])
         self.assertEqual(len(tracker.token_ids), 48)
         self.assertEqual(tracker.num_saved_tokens, 0)
+        self.assertEqual(tracker.num_prompt_tokens, 100)
 
     def test_from_new_request_nested_block_ids(self):
         new_req = MagicMock()
@@ -292,6 +367,7 @@ class TestReqMeta(unittest.TestCase):
             allocated_block_ids=[0, 1],
             num_saved_tokens=0,
             token_ids=list(range(32)),
+            num_prompt_tokens=40,
         )
         meta = ReqMeta.from_request_tracker(tracker, cache_transfer_granularity=16, block_hashes=[b"h1", b"h2"])
         self.assertIsNotNone(meta)
@@ -299,6 +375,7 @@ class TestReqMeta(unittest.TestCase):
         self.assertTrue(meta.can_save)
         self.assertEqual(meta.token_len_chunk, 32)
         self.assertIsNone(meta.load_spec)
+        self.assertEqual(meta.num_prompt_tokens, 40)
 
     def test_from_request_tracker_skip_save(self):
         tracker = RequestTracker(

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -93,6 +93,23 @@ class FakeTokenDatabase:
         return keys, addrs, sizes
 
 
+class MaskedFakeTokenDatabase(FakeTokenDatabase):
+    def __init__(self, block_size=16, store_mask=None, load_mask=None):
+        super().__init__(block_size)
+        self._store_mask = store_mask
+        self._load_mask = load_mask
+        self.store_mask_calls = []
+        self.load_mask_calls = []
+
+    def store_mask(self, token_len, kv_cache_group_id, num_prompt_tokens=None):
+        self.store_mask_calls.append((token_len, kv_cache_group_id, num_prompt_tokens))
+        return self._store_mask
+
+    def load_mask(self, block_hashes, token_len, kv_cache_group_id):
+        self.load_mask_calls.append((block_hashes, token_len, kv_cache_group_id))
+        return self._load_mask
+
+
 class TestKVTransferThread(unittest.TestCase):
     def _make_thread(self, exists_result=None):
         store = FakeStore(exists_result or [])
@@ -203,6 +220,38 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         self.assertEqual(len(store.put_calls), 1)
         keys, _, _ = store.put_calls[0]
         self.assertEqual(len(keys), 2)
+
+    def test_handle_request_applies_store_mask_before_put(self):
+        store = FakeStore([0, 0])
+        db = MaskedFakeTokenDatabase(store_mask=[False, True, False, True])
+        t = KVCacheStoreSendingThread(
+            m_store=store,
+            token_database=db,
+            block_size=16,
+            tp_rank=0,
+            dcp_size=1,
+            put_step=1,
+            kv_role="kv_producer",
+            ready_event=threading.Event(),
+            group_uses_align_state=[False],
+        )
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=64,
+            block_ids=[0, 1, 2, 3],
+            block_hashes=[b"h0", b"h1", b"h2", b"h3"],  # type: ignore[arg-type]
+            current_event=None,
+            num_prompt_tokens=64,
+        )
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+
+        self.assertEqual(db.store_mask_calls, [(64, 0, 64)])
+        keys, _, _ = store.put_calls[0]
+        self.assertEqual(len(keys), 2)
+        self.assertTrue(keys[0].endswith("@k1"))
+        self.assertTrue(keys[1].endswith("@k3"))
 
     def test_handle_request_all_exist_no_put(self):
         t, store = self._make_thread([1, 1])
@@ -350,6 +399,35 @@ class TestKVCacheStoreRecvingThread(unittest.TestCase):
         self.assertEqual(len(store.get_calls), 1)
         finished = t.get_and_clear_finished_requests()
         self.assertIn("r1", finished)
+
+    def test_handle_request_applies_load_mask_before_get(self):
+        store = FakeStore()
+        db = MaskedFakeTokenDatabase(load_mask=[False, True])
+        t = KVCacheStoreRecvingThread(
+            m_store=store,
+            token_database=db,
+            block_size=16,
+            tp_rank=0,
+            dcp_size=1,
+            ready_event=threading.Event(),
+            invalid_block_ids=set(),
+            invalid_block_ids_lock=threading.Lock(),
+        )
+        load_spec = LoadSpec(vllm_cached_tokens=0, kvpool_cached_tokens=32, can_load=True, token_len=32)
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=32,
+            block_ids=[0, 1],
+            block_hashes=[b"h0", b"h1"],  # type: ignore[arg-type]
+            load_spec=load_spec,
+        )
+        t.request_queue.put(req)
+        t._handle_request(req)
+
+        self.assertEqual(db.load_mask_calls, [([b"h0", b"h1"], 32, 0)])
+        keys, _, _ = store.get_calls[0]
+        self.assertEqual(len(keys), 1)
+        self.assertTrue(keys[0].endswith("@k1"))
 
 
 class TestKVCacheStoreLayerSendingThread(unittest.TestCase):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -443,6 +443,17 @@ class ChunkedTokenDatabase:
         )
         return [block is not cached_block_pool.null_block for block in hit_blocks[0]]
 
+    def mask_allows_chunk(
+        self,
+        mask: list[bool] | None,
+        start: int,
+        kv_cache_group_id: int,
+    ) -> bool:
+        if mask is None:
+            return True
+        chunk_idx = start // self.get_block_size(kv_cache_group_id)
+        return chunk_idx < len(mask) and mask[chunk_idx]
+
     def _get_group_buffers(
         self, kv_cache_group_id: int, cache_role: str = "kv"
     ) -> tuple[list[int], list[int], list[int] | None]:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
@@ -9,8 +10,10 @@ import torch
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata, KVConnectorWorkerMetadata
 from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
-from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashList
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashList, BlockHashListWithBlockSize, KVCacheBlock
 from vllm.v1.core.sched.output import NewRequestData
+from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 
 _GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
 _GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
@@ -137,6 +140,28 @@ def get_cache_family_granularity(block_size: int, cache_family: str | None) -> i
     return block_size * infer_cache_family_ratio(cache_family)
 
 
+def _unwrap_spec(kv_cache_spec: Any) -> Any:
+    kv_cache_specs = getattr(kv_cache_spec, "kv_cache_specs", None)
+    if kv_cache_specs is None:
+        return kv_cache_spec
+    return next(iter(kv_cache_specs.values()))
+
+
+class ExternalCachedBlockPool:
+    """Tiny BlockPool stand-in used for connector-side load masks."""
+
+    def __init__(self) -> None:
+        self.null_block = KVCacheBlock(block_id=0)
+        self._present_block = KVCacheBlock(block_id=1)
+
+    def get_cached_block(
+        self,
+        block_hash: BlockHash,
+        group_ids: list[int],
+    ) -> list[KVCacheBlock]:
+        return [self._present_block] * len(group_ids)
+
+
 def _get_layer_compress_ratio(
     layer_name: str,
     compress_ratios: Sequence[int] | None,
@@ -207,9 +232,14 @@ class ChunkedTokenDatabase:
         partitions: list[int] | None,
         use_hybrid: bool = False,
         hash_block_size: int | None = None,
+        kv_cache_groups: Sequence[Any] | None = None,
+        alignment_tokens: int | None = None,
+        retention_interval: int | None = None,
+        use_eagle: bool = False,
     ):
         self.metadata = metadata
         self.block_size = block_size
+        self.kv_cache_groups = list(kv_cache_groups or [])
         self.group_kv_caches_base_addr: dict[int, list[int]] = {}
         self.group_block_len: dict[int, list[int]] = {}
         self.group_block_stride: dict[int, list[int]] = {}
@@ -224,6 +254,13 @@ class ChunkedTokenDatabase:
         self.partitions = partitions
         self.use_hybrid = use_hybrid
         self.hash_block_size = self.block_size[0] if hash_block_size is None else hash_block_size
+        self.alignment_tokens = alignment_tokens if alignment_tokens is not None else max(self.block_size)
+        self.retention_interval = retention_interval
+        self.eagle_group_ids = {
+            idx for idx, group in enumerate(self.kv_cache_groups) if getattr(group, "is_eagle_group", False)
+        }
+        if use_eagle and not self.eagle_group_ids:
+            self.eagle_group_ids = set(range(len(self.kv_cache_groups)))
 
     def _make_key_by_hash(
         self,
@@ -277,6 +314,106 @@ class ChunkedTokenDatabase:
             self.group_cache_families[cache_role] = group_cache_families.copy()
         if group_num_layers is not None:
             self.group_num_layers[cache_role] = group_num_layers.copy()
+
+    def _get_group_cache_family(self, kv_cache_group_id: int, cache_role: str = "kv") -> str:
+        return self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
+
+    def _get_store_granularity(self, kv_cache_group_id: int, cache_role: str = "kv") -> int:
+        return get_cache_family_granularity(
+            self.get_block_size(kv_cache_group_id),
+            self._get_group_cache_family(kv_cache_group_id, cache_role),
+        )
+
+    def _get_effective_group_spec(self, kv_cache_group_id: int, cache_role: str = "kv") -> Any | None:
+        if cache_role != "kv" or kv_cache_group_id >= len(self.kv_cache_groups):
+            return None
+        spec = _unwrap_spec(self.kv_cache_groups[kv_cache_group_id].kv_cache_spec)
+        store_granularity = self._get_store_granularity(kv_cache_group_id, cache_role)
+        if getattr(spec, "block_size", None) == store_granularity:
+            return spec
+        try:
+            return dataclasses.replace(spec, block_size=store_granularity)
+        except TypeError:
+            return spec
+
+    def _block_hashes_for_spec(
+        self,
+        block_hashes: BlockHashList | list[str],
+        spec: Any,
+    ) -> BlockHashList | list[str]:
+        block_size = getattr(spec, "block_size", self.hash_block_size)
+        if block_size == self.hash_block_size:
+            return block_hashes
+        if isinstance(block_hashes[0], str):
+            return get_block_hashes(block_hashes, block_size, self.hash_block_size)
+        return BlockHashListWithBlockSize(block_hashes, self.hash_block_size, block_size)
+
+    def store_mask(
+        self,
+        aligned_token_len: int,
+        kv_cache_group_id: int,
+        num_prompt_tokens: int | None = None,
+        cache_role: str = "kv",
+    ) -> list[bool] | None:
+        """Return per-store-chunk retention mask for a KV cache group.
+
+        None means every chunk is reachable and should be stored. The block
+        size used here is AscendStore's key granularity, including DSV4 cache
+        family ratios such as c4/c128.
+        """
+        spec = self._get_effective_group_spec(kv_cache_group_id, cache_role)
+        if spec is None:
+            return None
+        manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+        reachable_block_mask = getattr(manager_cls, "reachable_block_mask", None)
+        if reachable_block_mask is None:
+            return None
+        store_granularity = self._get_store_granularity(kv_cache_group_id, cache_role)
+        if aligned_token_len == 0:
+            return []
+        num_chunks = cdiv(aligned_token_len, store_granularity)
+        return reachable_block_mask(
+            start_block=0,
+            end_block=num_chunks,
+            alignment_tokens=self.alignment_tokens,
+            kv_cache_spec=spec,
+            use_eagle=kv_cache_group_id in self.eagle_group_ids,
+            retention_interval=self.retention_interval,
+            num_prompt_tokens=num_prompt_tokens,
+        )
+
+    def load_mask(
+        self,
+        block_hashes: BlockHashList | list[str],
+        token_len: int,
+        kv_cache_group_id: int,
+        cache_role: str = "kv",
+    ) -> list[bool] | None:
+        """Return per-store-chunk load mask for a KV cache group.
+
+        This mirrors MooncakeStore's load mask: only chunks a local manager
+        would populate at the external hit length are loaded.
+        """
+        if not block_hashes:
+            return []
+        spec = self._get_effective_group_spec(kv_cache_group_id, cache_role)
+        if spec is None:
+            return None
+        manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+        if manager_cls is None:
+            return None
+        hashes = self._block_hashes_for_spec(block_hashes, spec)
+        cached_block_pool = ExternalCachedBlockPool()
+        hit_blocks = manager_cls.find_longest_cache_hit(
+            block_hashes=hashes,
+            max_length=token_len,
+            kv_cache_group_ids=[kv_cache_group_id],
+            block_pool=cast(BlockPool, cached_block_pool),
+            kv_cache_spec=spec,
+            drop_eagle_block=False,
+            alignment_tokens=self.alignment_tokens,
+        )
+        return [block is not cached_block_pool.null_block for block in hit_blocks[0]]
 
     def _get_group_buffers(
         self, kv_cache_group_id: int, cache_role: str = "kv"
@@ -511,6 +648,9 @@ class RequestTracker:
     # NOTE: This field will only be used when you enable kv-event
     token_ids: list[int] | None = None
 
+    # Full prompt length used by retention-aware external store masks.
+    num_prompt_tokens: int | None = None
+
     def __init__(
         self,
         req_id: str,
@@ -519,6 +659,7 @@ class RequestTracker:
         allocated_block_ids: list[int] | list[list[int]] | None = None,
         num_saved_tokens: int = 0,
         token_ids: list[int] | None = None,
+        num_prompt_tokens: int | None = None,
     ) -> None:
         self.req_id = req_id
         self.token_len = token_len
@@ -528,6 +669,7 @@ class RequestTracker:
         self.allocated_block_ids_by_group = block_ids
         self.num_saved_tokens = num_saved_tokens
         self.token_ids = token_ids
+        self.num_prompt_tokens = num_prompt_tokens
 
     @property
     def allocated_block_ids(self) -> list[int]:
@@ -549,6 +691,7 @@ class RequestTracker:
             token_len=num_tokens_to_compute,
             allocated_block_ids_by_group=normalize_block_ids_by_group(new_request.block_ids),
             num_saved_tokens=0,
+            num_prompt_tokens=len(new_request.prompt_token_ids),
         )
 
     def update(
@@ -592,6 +735,7 @@ class ReqMeta:
     # TODO: add lora_request which used for gen lora_id/lora_name in kv event
     token_ids: list[int] | None = None
     original_block_size: list[int] | int | None = None
+    num_prompt_tokens: int | None = None
 
     event_id: int | None = None
 
@@ -611,6 +755,7 @@ class ReqMeta:
         disable_tp_key_sharding: bool = False,
         token_ids: list[int] | None = None,
         original_block_size: list[int] | int | None = None,
+        num_prompt_tokens: int | None = None,
         block_ids: list[int] | list[list[int]] | None = None,
         event_id: int | None = None,
     ) -> None:
@@ -630,6 +775,7 @@ class ReqMeta:
         self.disable_tp_key_sharding = disable_tp_key_sharding
         self.token_ids = token_ids
         self.original_block_size = original_block_size
+        self.num_prompt_tokens = num_prompt_tokens
         self.event_id = event_id
 
     @property
@@ -701,6 +847,7 @@ class ReqMeta:
             is_last_chunk=is_last_chunk,
             token_ids=token_ids,
             original_block_size=original_block_size,
+            num_prompt_tokens=tracker.num_prompt_tokens,
             kv_cache_group_ids=list(range(len(tracker.allocated_block_ids_by_group))),
             kv_cache_families_by_group=kv_cache_group_families,
         )

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import hashlib
+import importlib
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import Any, cast
@@ -13,7 +14,6 @@ from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashList, BlockHashListWithBlockSize, KVCacheBlock
 from vllm.v1.core.sched.output import NewRequestData
-from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 
 _GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
 _GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
@@ -145,6 +145,32 @@ def _unwrap_spec(kv_cache_spec: Any) -> Any:
     if kv_cache_specs is None:
         return kv_cache_spec
     return next(iter(kv_cache_specs.values()))
+
+
+def _get_manager_class_for_spec(spec: Any) -> Any | None:
+    """Resolve the vLLM manager class across 0.20.x and 0.21.x APIs."""
+    try:
+        registry_module = importlib.import_module("vllm.v1.kv_cache_spec_registry")
+        registry = getattr(registry_module, "KVCacheSpecRegistry", None)
+    except ImportError:
+        registry = None
+    if registry is not None:
+        manager_cls = registry.get_manager_class(spec)
+        if manager_cls is not None:
+            return manager_cls
+
+    try:
+        manager_module = importlib.import_module("vllm.v1.core.single_type_kv_cache_manager")
+        spec_manager_map = getattr(manager_module, "spec_manager_map", {})
+    except ImportError:
+        return None
+    manager_cls = spec_manager_map.get(type(spec))
+    if manager_cls is not None:
+        return manager_cls
+    for spec_cls, candidate in spec_manager_map.items():
+        if isinstance(spec, spec_cls):
+            return candidate
+    return None
 
 
 class ExternalCachedBlockPool:
@@ -364,7 +390,9 @@ class ChunkedTokenDatabase:
         spec = self._get_effective_group_spec(kv_cache_group_id, cache_role)
         if spec is None:
             return None
-        manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+        manager_cls = _get_manager_class_for_spec(spec)
+        if manager_cls is None:
+            return None
         reachable_block_mask = getattr(manager_cls, "reachable_block_mask", None)
         if reachable_block_mask is None:
             return None
@@ -399,7 +427,7 @@ class ChunkedTokenDatabase:
         spec = self._get_effective_group_spec(kv_cache_group_id, cache_role)
         if spec is None:
             return None
-        manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+        manager_cls = _get_manager_class_for_spec(spec)
         if manager_cls is None:
             return None
         hashes = self._block_hashes_for_spec(block_hashes, spec)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -214,6 +214,9 @@ class KVTransferThread(threading.Thread):
             return self.token_database.decode_adaptor_prefill_pp(keys, addrs, sizes)
 
     def _chunk_mask_allows(self, mask: list[bool] | None, start: int, kv_cache_group_id: int) -> bool:
+        mask_allows_chunk = getattr(self.token_database, "mask_allows_chunk", None)
+        if mask_allows_chunk is not None:
+            return mask_allows_chunk(mask, start, kv_cache_group_id)
         if mask is None:
             return True
         chunk_idx = start // self._get_block_size(kv_cache_group_id)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -213,6 +213,38 @@ class KVTransferThread(threading.Thread):
         except TypeError:
             return self.token_database.decode_adaptor_prefill_pp(keys, addrs, sizes)
 
+    def _chunk_mask_allows(self, mask: list[bool] | None, start: int, kv_cache_group_id: int) -> bool:
+        if mask is None:
+            return True
+        chunk_idx = start // self._get_block_size(kv_cache_group_id)
+        return chunk_idx < len(mask) and mask[chunk_idx]
+
+    def _store_mask(
+        self,
+        token_len: int,
+        kv_cache_group_id: int,
+        num_prompt_tokens: int | None = None,
+    ) -> list[bool] | None:
+        store_mask = getattr(self.token_database, "store_mask", None)
+        if store_mask is None:
+            return None
+        return store_mask(
+            token_len,
+            kv_cache_group_id,
+            num_prompt_tokens=num_prompt_tokens,
+        )
+
+    def _load_mask(
+        self,
+        block_hashes,
+        token_len: int,
+        kv_cache_group_id: int,
+    ) -> list[bool] | None:
+        load_mask = getattr(self.token_database, "load_mask", None)
+        if load_mask is None:
+            return None
+        return load_mask(block_hashes, token_len, kv_cache_group_id)
+
 
 class KVCacheStoreSendingThread(KVTransferThread):
     def __init__(
@@ -282,6 +314,11 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 block_hashes = []
                 block_ids = req_meta.block_ids_by_group[group_id]
                 group_block_size = self._get_block_size(group_id)
+                store_mask = self._store_mask(
+                    token_len,
+                    group_id,
+                    num_prompt_tokens=req_meta.num_prompt_tokens,
+                )
                 group_block_hashes = get_block_hashes(
                     req_meta.block_hashes,
                     group_block_size,
@@ -295,6 +332,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     kv_cache_group_id=group_id,
                     skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
                 ):
+                    if not self._chunk_mask_allows(store_mask, start, group_id):
+                        continue
                     starts.append(start)
                     ends.append(end)
                     keys.append(key.to_string())
@@ -429,6 +468,11 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         for group_id in group_ids:
             block_ids = req_meta.block_ids_by_group[group_id]
             group_block_size = self._get_block_size(group_id)
+            load_mask = self._load_mask(
+                req_meta.block_hashes,
+                token_len,
+                group_id,
+            )
             mask_num = (
                 req_meta.load_spec.vllm_cached_tokens  # type: ignore[union-attr]
                 // group_block_size
@@ -442,6 +486,8 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 kv_cache_group_id=group_id,
                 skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
             ):
+                if not self._chunk_mask_allows(load_mask, start, group_id):
+                    continue
                 addr, size, block_id = self._prepare_value(
                     start,
                     end,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -394,6 +394,7 @@ class KVPoolScheduler:
                 allocated_block_ids_by_group=normalize_block_ids_by_group(request.block_ids),
                 num_saved_tokens=0,
                 token_ids=request.prompt_token_ids[:num_tokens_to_compute].copy(),
+                num_prompt_tokens=len(request.prompt_token_ids),
             )
             self._request_trackers[request.req_id] = request_tracker
             last_chunk_tokens_num = (
@@ -438,6 +439,7 @@ class KVPoolScheduler:
                         allocated_block_ids_by_group=normalize_block_ids_by_group(new_block_ids),
                         num_saved_tokens=0,
                         token_ids=request_real.prompt_token_ids[:num_tokens_to_compute].copy(),
+                        num_prompt_tokens=len(request_real.prompt_token_ids),
                     )
                     self._request_trackers[req_id] = request_tracker
                     last_chunk_tokens_num = (
@@ -512,6 +514,7 @@ class KVPoolScheduler:
                     token_len=num_tokens_to_compute,
                     allocated_block_ids_by_group=block_ids,
                     num_saved_tokens=0,
+                    num_prompt_tokens=len(request.prompt_token_ids),
                 )
 
                 self._request_trackers[request_id] = request_tracker

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -525,6 +525,11 @@ class KVPoolWorker:
                     for group_id in load_group_ids:
                         block_ids = request.block_ids_by_group[group_id]
                         group_block_size = self.grouped_block_size[group_id]
+                        load_mask = self.token_database.load_mask(
+                            request.block_hashes,
+                            token_len,
+                            group_id,
+                        )
                         mask_num = request.load_spec.vllm_cached_tokens // group_block_size * group_block_size
                         skip_null = (
                             group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]
@@ -537,6 +542,8 @@ class KVPoolWorker:
                             kv_cache_group_id=group_id,
                             skip_null_blocks=skip_null,
                         ):
+                            if not self.token_database.mask_allows_chunk(load_mask, start, group_id):
+                                continue
                             addr, size, block_id = self.token_database.prepare_value(
                                 start,
                                 end,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -6,6 +6,7 @@ import threading
 from collections.abc import Generator
 
 import torch
+import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.distributed import (
     get_decode_context_model_parallel_rank,
@@ -188,8 +189,23 @@ class KVPoolWorker:
                 )
             )
 
+        spec_cfg = getattr(vllm_config, "speculative_config", None)
+        use_eagle = bool(
+            spec_cfg.use_eagle() if spec_cfg is not None and callable(getattr(spec_cfg, "use_eagle", None)) else False
+        )
+        kv_cache_groups = (
+            list(kv_cache_config.kv_cache_groups) if kv_cache_config is not None and self.use_hybrid else None
+        )
         self.token_database = ChunkedTokenDatabase(
-            self.metadata, self.grouped_block_size, partitions, self.use_hybrid, self.hash_block_size
+            self.metadata,
+            self.grouped_block_size,
+            partitions,
+            self.use_hybrid,
+            self.hash_block_size,
+            kv_cache_groups=kv_cache_groups,
+            alignment_tokens=self.cache_transfer_granularity,
+            retention_interval=getattr(envs, "VLLM_PREFIX_CACHE_RETENTION_INTERVAL", None),
+            use_eagle=use_eagle,
         )
 
         backend = backend_map.get(self.backend.lower())


### PR DESCRIPTION
## What

Adapt AscendStore KV Pool to use prefix-cache retention masks for external store save/load, following the MooncakeStore direction in vllm-project/vllm#44774.

This adds retention-aware store/load masking for AscendStore while preserving DeepSeek V4 compressed-family store granularity.

## Why

DeepSeek V4 sparse/sliding-window attention should not require saving/loading every external KV chunk for long contexts. AscendStore needs the same reachable-block retention semantics as the vLLM-side MooncakeStore integration, but mapped onto AscendStore's group-aware keys and cache-family granularity.

## Changes

- Add store/load mask support around AscendStore send/recv paths.
- Pass prompt token counts through scheduler metadata so retention decisions can match vLLM prefix-cache behavior.
- Reuse vLLM cache-manager mask semantics via lightweight test doubles and external-hit adapters.
- Preserve DSV4 C4/C128 cache-family granularity for external store keys.
- Add unit coverage for mask generation and transfer filtering.

## Validation

vLLM version: v0.20.1
vLLM main: vllm-project/vllm@c7aa186

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/efc347f1b2e635753ae8a594e9714109c200fcd3
