### PR TITLE
[BugFix] Preserve FP32 MM encoder attention support

### DIFF
--- a/tests/ut/device/test_device_op.py
+++ b/tests/ut/device/test_device_op.py
@@ -1,2 +1,119 @@
-def test_device_op_placeholder():
-    pass
+from unittest import mock
+
+import pytest
+import torch
+
+from vllm_ascend.device.device_op import A5DeviceAdaptor, BaseDeviceAdaptor
+
+
+def test_npu_flash_attention_uses_fusion_attention_for_fp32():
+    query = torch.randn(5, 4, 64, dtype=torch.float32)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    seq_lens_cpu = torch.tensor([2, 3], dtype=torch.int32)
+    expected = torch.randn_like(query)
+
+    with (
+        mock.patch(
+            "vllm_ascend.device.device_op.torch_npu.npu_fusion_attention",
+            return_value=(expected,),
+        ) as mock_fusion_attention,
+        mock.patch(
+            "vllm_ascend.device.device_op.torch_npu._npu_flash_attention_unpad",
+            create=True,
+        ) as mock_flash_attention,
+    ):
+        output = BaseDeviceAdaptor.npu_flash_attention(
+            query=query,
+            key=key,
+            value=value,
+            seq_lens_cpu=seq_lens_cpu,
+            head_num=4,
+            scale_value=0.125,
+            num_kv_heads=4,
+        )
+
+    assert output is expected
+    mock_flash_attention.assert_not_called()
+    mock_fusion_attention.assert_called_once()
+    call_kwargs = mock_fusion_attention.call_args.kwargs
+    assert call_kwargs["query"] is query
+    assert call_kwargs["key"] is key
+    assert call_kwargs["value"] is value
+    assert call_kwargs["actual_seq_qlen"] == [2, 5]
+    assert all(isinstance(seq_len, int) for seq_len in call_kwargs["actual_seq_qlen"])
+    assert call_kwargs["actual_seq_kvlen"] is call_kwargs["actual_seq_qlen"]
+    assert call_kwargs["head_num"] == 4
+    assert call_kwargs["scale"] == 0.125
+    assert call_kwargs["input_layout"] == "TND"
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_npu_flash_attention_uses_unpad_attention_for_low_precision(dtype):
+    query = torch.randn(5, 4, 64, dtype=dtype)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    seq_lens_cpu = torch.tensor([2, 3], dtype=torch.int32)
+
+    def fake_flash_attention(*, query, key, value, seq_len, scale_value, num_heads, num_kv_heads, out):
+        out.copy_(query + 1)
+
+    with (
+        mock.patch(
+            "vllm_ascend.device.device_op.torch_npu.npu_fusion_attention",
+        ) as mock_fusion_attention,
+        mock.patch(
+            "vllm_ascend.device.device_op.torch_npu._npu_flash_attention_unpad",
+            side_effect=fake_flash_attention,
+            create=True,
+        ) as mock_flash_attention,
+    ):
+        output = BaseDeviceAdaptor.npu_flash_attention(
+            query=query,
+            key=key,
+            value=value,
+            seq_lens_cpu=seq_lens_cpu,
+            head_num=4,
+            scale_value=0.125,
+            num_kv_heads=4,
+        )
+
+    mock_fusion_attention.assert_not_called()
+    mock_flash_attention.assert_called_once()
+    call_kwargs = mock_flash_attention.call_args.kwargs
+    assert call_kwargs["query"] is query
+    assert call_kwargs["key"] is key
+    assert call_kwargs["value"] is value
+    assert call_kwargs["seq_len"] is seq_lens_cpu
+    assert call_kwargs["num_heads"] == 4
+    assert call_kwargs["num_kv_heads"] == 4
+    assert call_kwargs["scale_value"] == 0.125
+    torch.testing.assert_close(output, query + 1)
+
+
+def test_a5_npu_flash_attention_uses_python_sequence_lengths():
+    query = torch.randn(5, 4, 64, dtype=torch.float16)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    seq_lens_cpu = torch.tensor([2, 3], dtype=torch.int32)
+    expected = torch.randn_like(query)
+
+    with mock.patch(
+        "vllm_ascend.device.device_op.torch_npu.npu_fusion_attention",
+        return_value=(expected,),
+    ) as mock_fusion_attention:
+        output = A5DeviceAdaptor.npu_flash_attention(
+            query=query,
+            key=key,
+            value=value,
+            seq_lens_cpu=seq_lens_cpu,
+            head_num=4,
+            scale_value=0.125,
+            num_kv_heads=4,
+        )
+
+    assert output is expected
+    call_kwargs = mock_fusion_attention.call_args.kwargs
+    assert call_kwargs["actual_seq_qlen"] == [2, 5]
+    assert all(isinstance(seq_len, int) for seq_len in call_kwargs["actual_seq_qlen"])
+    assert call_kwargs["actual_seq_kvlen"] is call_kwargs["actual_seq_qlen"]

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -461,7 +461,22 @@ class BaseDeviceAdaptor:
         )
         return attn_output
 
+    @staticmethod
     def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):
+        if query.dtype == torch.float32:
+            # _npu_flash_attention_unpad does not support FP32.
+            cumulative_seq_lens = seq_lens_cpu.cumsum(0).tolist()
+            return torch_npu.npu_fusion_attention(
+                query=query,
+                key=key,
+                value=value,
+                actual_seq_qlen=cumulative_seq_lens,
+                actual_seq_kvlen=cumulative_seq_lens,
+                head_num=head_num,
+                scale=scale_value,
+                input_layout="TND",
+            )[0]
+
         context_layer = torch.empty_like(query)
 
         torch_npu._npu_flash_attention_unpad(
@@ -1523,15 +1538,16 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             )
         return attn_output
 
+    @staticmethod
     def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):
-        seq_lens_cpu = list(seq_lens_cpu.cumsum(0))
+        cumulative_seq_lens = seq_lens_cpu.cumsum(0).tolist()
 
         context_layer = torch_npu.npu_fusion_attention(
             query=query,
             key=key,
             value=value,
-            actual_seq_qlen=seq_lens_cpu,
-            actual_seq_kvlen=seq_lens_cpu,
+            actual_seq_qlen=cumulative_seq_lens,
+            actual_seq_kvlen=cumulative_seq_lens,
             head_num=head_num,
             scale=scale_value,
             input_layout="TND",


### PR DESCRIPTION
### What this PR does / why we need it?

PR #8671 switched A2/A3 multimodal encoder attention from `npu_fusion_attention` to `_npu_flash_attention_unpad` for better performance. The unpadded operator does not support FP32 inputs, which regressed FP32 vision encoders such as SigLIP.

This PR restores dtype-aware operator selection:

- use `npu_fusion_attention` for FP32 multimodal encoder attention
- keep `_npu_flash_attention_unpad` for FP16 and BF16 so the performance improvement from #8671 is preserved
- add unit coverage for the FP32 fallback and both low-precision fast paths

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Test environment:

- Image: `quay.io/ascend/vllm-ascend:nightly-main` (2026.05.29)
- added CPU unit tests in `tests/ut/device/test_device_op.py`

Confirmed upstream test recoveries:
- `tests/models/multimodal/pooling/test_siglip.py` (9 passed)

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5

<img width="3056" height="1064" alt="image" src="https://github.com/user-attachments/assets/29fe9e5b-a9ee-4978-b615-c36d97366f7c" />
