### PR TITLE
[BugFix] Fix layer index mapping and block ID flattening in Mooncake connector

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -344,13 +344,13 @@ class TestKVCacheRecvingThreadBasic(unittest.TestCase):
         self.assertEqual(queued["num_computed_tokens"], 0)
 
     def test_mark_and_is_failed(self):
-        self.thread._mark_failed_recv_request("req1", [10, 20])
+        self.thread._mark_failed_recv_request("req1", [[10, 20]])
         self.assertTrue(self.thread._is_failed_recv_request("req1"))
         self.assertIn(10, self.thread.invalid_block_ids)
         self.assertIn(20, self.thread.invalid_block_ids)
 
     def test_clear_failed_recv_request(self):
-        self.thread._mark_failed_recv_request("req2", [30])
+        self.thread._mark_failed_recv_request("req2", [[30]])
         self.thread._clear_failed_recv_request("req2")
         self.assertFalse(self.thread._is_failed_recv_request("req2"))
 

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1710,12 +1710,25 @@ class MooncakeConnectorWorker:
         next_mtp_layer_idx = self.total_layers
         for group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups):
             layer_indices = []
+            # For eagle3 method there is no "mtp" in layer names, and upstream model initiation assigns the layer id 
+            # that is sliced by Pipeline Parallel. So the eagle layer id will confilt with target model layers. 
+            # Here we determine whether the current layer is an eagle layer based on whether the layer id has been 
+            # assigned to previous layers. If the layer id has been assigned, we treat the current layer as 
+            # an eagle layer and assign a new layer id starting from total_layers.
+            assigned_indices = set()
             for layer_name in group_spec.layer_names:
                 if "mtp" in layer_name:
                     layer_idx = next_mtp_layer_idx
                     next_mtp_layer_idx += 1
                 else:
                     layer_idx = extract_layer_index(layer_name, num_attn_module)
+                    if (
+                        assigned_indices and layer_idx < min(assigned_indices)
+                        or layer_idx in assigned_indices
+                    ):
+                        layer_idx = next_mtp_layer_idx
+                        next_mtp_layer_idx += 1
+                assigned_indices.add(layer_idx)
                 layer_indices.append(layer_idx)
             kv_group2layeridx[group_id] = (self._serialize_kv_group_spec(group_spec), layer_indices)
         return kv_group2layeridx

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -539,14 +539,10 @@ class KVCacheRecvingThread(threading.Thread):
         with self.failed_recv_requests_lock:
             return request_id in self.failed_recv_requests
 
-    def _mark_failed_recv_request(self, request_id: str, local_block_ids: list[int]) -> None:
+    def _mark_failed_recv_request(self, request_id: str, local_block_ids: BlockIds) -> None:
         with self.failed_recv_requests_lock:
             self.failed_recv_requests.add(request_id)
-            if isinstance(local_block_ids, (list, tuple)):
-                flat = [bid for group in local_block_ids for bid in group]
-            else:
-                flat = local_block_ids
-            self.invalid_block_ids.update(flat)
+            self.invalid_block_ids.update(local_block_ids[0])
 
     def _clear_failed_recv_request(self, request_id: str) -> None:
         with self.failed_recv_requests_lock:
@@ -1595,7 +1591,7 @@ class MooncakeConnectorWorker:
         self.kv_caches: dict[str, torch.Tensor] = {}
         self.side_channel_host = get_ip()
         self.pcp_size = get_pcp_group().world_size
-        self.total_layers = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
+        self.total_layers = vllm_config.model_config.get_total_num_hidden_layers()
         # Assert that pp_size and pcp_size cannot both be greater than 1
         assert not (self.pp_size > 1 and self.pcp_size > 1), "pp and pcp cannot open in same time"
         self.pcp_rank = get_pcp_group().rank_in_group if self.pcp_size > 1 else 0
@@ -1711,28 +1707,15 @@ class MooncakeConnectorWorker:
 
         kv_group2layeridx: dict[int, tuple[dict[str, Any], list[int]]] = {}
         num_attn_module = 2 if self.vllm_config.model_config.hf_text_config.model_type == "longcat_flash" else 1
-        all_base_indices = set()
-        for group_spec in self.kv_cache_config.kv_cache_groups:
-            for layer_name in group_spec.layer_names:
-                if "mtp" not in layer_name:
-                    all_base_indices.add(extract_layer_index(layer_name, num_attn_module))
-
-        max_base_idx = max(all_base_indices) if all_base_indices else self.total_layers - 1
-        global_next_mtp = max(self.total_layers, max_base_idx + 1)
+        next_mtp_layer_idx = self.total_layers
         for group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups):
-            next_mtp_layer_idx = global_next_mtp
             layer_indices = []
             for layer_name in group_spec.layer_names:
                 if "mtp" in layer_name:
                     layer_idx = next_mtp_layer_idx
                     next_mtp_layer_idx += 1
                 else:
-                    extracted = extract_layer_index(layer_name, num_attn_module)
-                    if extracted in layer_indices:
-                        layer_idx = next_mtp_layer_idx
-                        next_mtp_layer_idx += 1
-                    else:
-                        layer_idx = extracted
+                    layer_idx = extract_layer_index(layer_name, num_attn_module)
                 layer_indices.append(layer_idx)
             kv_group2layeridx[group_id] = (self._serialize_kv_group_spec(group_spec), layer_indices)
         return kv_group2layeridx
@@ -1808,12 +1791,11 @@ class MooncakeConnectorWorker:
         # layer indices: {group_id: (group_spec, [layer_idx0, layer_idx1, ...])}.
         self.kv_group2layeridx = self._build_kv_group2layeridx()
         has_mamba_group = self._has_mamba_group()
-        layer_name_to_idx: dict[str, int] = {}
-        for _, (group_spec, layer_indices) in self.kv_group2layeridx.items():
-            for layer_name, assigned_idx in zip(group_spec["layer_names"], layer_indices):
-                if layer_name in layer_name_to_idx:
-                    continue
-                layer_name_to_idx[layer_name] = assigned_idx
+        layer_name_to_idx = {
+            layer_name: layer_idx
+            for _, (group_spec, layer_indices) in self.kv_group2layeridx.items()
+            for layer_name, layer_idx in zip(group_spec["layer_names"], layer_indices)
+        }
         metadata_layers = max(layer_name_to_idx.values(), default=-1) + 1
         # Per-layer registered KV cache base addresses:
         # [layer_idx][cache_idx] -> data_ptr of one cache tensor, e.g. K/V.

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1710,22 +1710,19 @@ class MooncakeConnectorWorker:
         next_mtp_layer_idx = self.total_layers
         for group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups):
             layer_indices = []
-            # For eagle3 method there is no "mtp" in layer names, and upstream model initiation assigns the layer id 
-            # that is sliced by Pipeline Parallel. So the eagle layer id will confilt with target model layers. 
-            # Here we determine whether the current layer is an eagle layer based on whether the layer id has been 
-            # assigned to previous layers. If the layer id has been assigned, we treat the current layer as 
+            # For eagle3 method there is no "mtp" in layer names, and upstream model initiation assigns the layer id
+            # that is sliced by Pipeline Parallel. So the eagle layer id will confilt with target model layers.
+            # Here we determine whether the current layer is an eagle layer based on whether the layer id has been
+            # assigned to previous layers. If the layer id has been assigned, we treat the current layer as
             # an eagle layer and assign a new layer id starting from total_layers.
-            assigned_indices = set()
+            assigned_indices: set[int] = set()
             for layer_name in group_spec.layer_names:
                 if "mtp" in layer_name:
                     layer_idx = next_mtp_layer_idx
                     next_mtp_layer_idx += 1
                 else:
                     layer_idx = extract_layer_index(layer_name, num_attn_module)
-                    if (
-                        assigned_indices and layer_idx < min(assigned_indices)
-                        or layer_idx in assigned_indices
-                    ):
+                    if assigned_indices and layer_idx < min(assigned_indices) or layer_idx in assigned_indices:
                         layer_idx = next_mtp_layer_idx
                         next_mtp_layer_idx += 1
                 assigned_indices.add(layer_idx)

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -542,7 +542,11 @@ class KVCacheRecvingThread(threading.Thread):
     def _mark_failed_recv_request(self, request_id: str, local_block_ids: list[int]) -> None:
         with self.failed_recv_requests_lock:
             self.failed_recv_requests.add(request_id)
-            self.invalid_block_ids.update(local_block_ids)
+            if isinstance(local_block_ids, (list, tuple)):
+                flat = [bid for group in local_block_ids for bid in group]
+            else:
+                flat = local_block_ids
+            self.invalid_block_ids.update(flat)
 
     def _clear_failed_recv_request(self, request_id: str) -> None:
         with self.failed_recv_requests_lock:
@@ -1707,15 +1711,28 @@ class MooncakeConnectorWorker:
 
         kv_group2layeridx: dict[int, tuple[dict[str, Any], list[int]]] = {}
         num_attn_module = 2 if self.vllm_config.model_config.hf_text_config.model_type == "longcat_flash" else 1
-        next_mtp_layer_idx = self.total_layers
+        all_base_indices = set()
+        for group_spec in self.kv_cache_config.kv_cache_groups:
+            for layer_name in group_spec.layer_names:
+                if "mtp" not in layer_name:
+                    all_base_indices.add(extract_layer_index(layer_name, num_attn_module))
+
+        max_base_idx = max(all_base_indices) if all_base_indices else self.total_layers - 1
+        global_next_mtp = max(self.total_layers, max_base_idx + 1)
         for group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups):
+            next_mtp_layer_idx = global_next_mtp
             layer_indices = []
             for layer_name in group_spec.layer_names:
                 if "mtp" in layer_name:
                     layer_idx = next_mtp_layer_idx
                     next_mtp_layer_idx += 1
                 else:
-                    layer_idx = extract_layer_index(layer_name, num_attn_module)
+                    extracted = extract_layer_index(layer_name, num_attn_module)
+                    if extracted in layer_indices:
+                        layer_idx = next_mtp_layer_idx
+                        next_mtp_layer_idx += 1
+                    else:
+                        layer_idx = extracted
                 layer_indices.append(layer_idx)
             kv_group2layeridx[group_id] = (self._serialize_kv_group_spec(group_spec), layer_indices)
         return kv_group2layeridx
@@ -1791,11 +1808,12 @@ class MooncakeConnectorWorker:
         # layer indices: {group_id: (group_spec, [layer_idx0, layer_idx1, ...])}.
         self.kv_group2layeridx = self._build_kv_group2layeridx()
         has_mamba_group = self._has_mamba_group()
-        layer_name_to_idx = {
-            layer_name: layer_idx
-            for _, (group_spec, layer_indices) in self.kv_group2layeridx.items()
-            for layer_name, layer_idx in zip(group_spec["layer_names"], layer_indices)
-        }
+        layer_name_to_idx: dict[str, int] = {}
+        for _, (group_spec, layer_indices) in self.kv_group2layeridx.items():
+            for layer_name, assigned_idx in zip(group_spec["layer_names"], layer_indices):
+                if layer_name in layer_name_to_idx:
+                    continue
+                layer_name_to_idx[layer_name] = assigned_idx
         metadata_layers = max(layer_name_to_idx.values(), default=-1) + 1
         # Per-layer registered KV cache base addresses:
         # [layer_idx][cache_idx] -> data_ptr of one cache tensor, e.g. K/V.


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes a KV transfer failure in the Mooncake connector under Pipeline Parallel (PP) configurations.
**Root cause**: `self.total_layers` was initialized via `get_num_layers()`, which returns the **per-stage** layer count
(divided by PP rank). However, `extract_layer_index()` returns **global** layer numbers. For example, with a 48-layer model and PP=2, each stage sees `total_layers=24`, but PP rank 1 holds layers 24–47. `next_mtp_layer_idx` was initialized to 24, causing MTP virtual-layer indices to collide with actual base-layer indices. This corrupted per-layer KV cache metadata and produced incorrect KV transfers in P/D scenarios.
**Fix**:
- Use `get_total_num_hidden_layers()` instead of `get_num_layers()` to obtain the global layer count when initializing `self.total_layers`, so MTP virtual-layer indices always start above all base-layer indices.
- Fix `_mark_failed_recv_request` to only invalidate blocks in the full-attention group (`local_block_ids[0]`), as invalidation is only meaningful for the full-attention KV cache group.
### Does this PR introduce _any_ user-facing change?
No.
### How was this patch tested?
Verified manually in a PP=2, TP=2 (Prefill) + DP=2, TP=2 (Decode)
deployment with a 48-layer model and 1 MTP layer.


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/efc347f1b2e635753ae8a594e9714109c200fcd3
