### PR TITLE
[Refactor][MoE/MLA] Drop unreachable check + improve MLA decode_threshold error

### DIFF
--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -261,11 +261,13 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
         if self.speculative_config:
             spec_token_num = self.speculative_config.num_speculative_tokens
             self.decode_threshold += spec_token_num
-            assert self.decode_threshold <= 16, (
-                f"decode_threshold exceeded \
-                npu_fused_infer_attention_score TND layout's limit of 16, \
-                got {self.decode_threshold}"
-            )
+            if self.decode_threshold > 16:
+                raise ValueError(
+                    f"decode_threshold ({self.decode_threshold}) exceeds "
+                    "npu_fused_infer_attention_score TND layout's limit of 16. "
+                    "Reduce speculative_config.num_speculative_tokens to at most "
+                    "15."
+                )
 
         self.reorder_batch_threshold = self.decode_threshold
         self.rope_dim = self.model_config.hf_text_config.qk_rope_head_dim

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -602,8 +602,6 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
 
         global_input_tokens_local_experts_indices = None
         if self.num_local_experts > 1:
-            if num_global_tokens_per_local_expert is None:
-                raise ValueError("num_global_tokens_per_local_expert must be set before operations.")
             global_input_tokens_local_experts_indices = torch.repeat_interleave(
                 self.expert_ids_per_ep_rank, num_global_tokens_per_local_expert.ravel()
             )


### PR DESCRIPTION
…hold error

Two small cleanups in the MoE / MLA paths:

1. `ops/fused_moe/token_dispatcher.py`: drop the second `num_global_tokens_per_local_expert is None` guard inside `TokenDispatcherWithAll2AllV`. The variable is already dereferenced by `.sum(axis=-1)` and `.sum(axis=0)` a few lines above, so the second check is dead code; an actual `None` would have raised `AttributeError` long before reaching this branch.

2. `attention/mla_v1.py`: replace the bare `assert self.decode_threshold <= 16` in `AscendMLAMetadataBuilder.__init__` with an explicit `ValueError`. The previous `assert` is stripped under `python -O` and the multi-line f-string embedded literal backslash-newlines into the message, which was unintentional. The new error also tells the user exactly which knob to lower (`speculative_config.num_speculative_tokens <= 15`).

Both changes are behaviour-preserving on the happy path; no new dependencies and no test changes needed.

### What this PR does / why we need it?
Two tiny, behaviour-preserving cleanups in the MoE / MLA paths.                                                                                                                                              
                                                                                                                                                                                                               
**1. `ops/fused_moe/token_dispatcher.py` — drop unreachable `None` check**                                                                                                                                   
                                                                                                                                                                                                               
In `TokenDispatcherWithAll2AllV.preprocess`, `num_global_tokens_per_local_expert` is first sliced from a tensor a few lines above the `if self.num_local_experts > 1` branch, then `.sum(axis=-1)` and `.sum(axis=0)` are called on it unconditionally before the branch is entered. If it were ever actually `None`, those calls would already have raised `AttributeError`. The second `if … is None: raise ValueError(...)` inside the branch is therefore unreachable and can be removed.                                                                                                                                                                                                                                               
                                                                                                                                                                                                        
 **2. `attention/mla_v1.py` — replace bare `assert` with `ValueError`**                                                                                                                                       
                                                                                                                                                                                                               
`AscendMLAMetadataBuilder.__init__` validates that the speculative-decode token count keeps `decode_threshold <= 16` (the TND-layout limit of `npu_fused_infer_attention_score`). Two small issues with the current `assert`:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
- `assert` is stripped under `python -O`, so config validation silently disappears in optimised runs.                                                                                                                                                       
- The multi-line f-string included literal backslash-newlines in the message, which made the rendered error read awkwardly.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          Swap it for an explicit `ValueError` whose message also tells the user which knob to lower (`speculative_config.num_speculative_tokens <= 15`).                                                                                                                           

### Does this PR introduce _any_ user-facing change?
Only the error message text — the same configurations that fail today still fail, with a clearer message and now also under `python -O`.

### How was this patch tested?
- `ruff check vllm_ascend/attention/mla_v1.py vllm_ascend/ops/fused_moe/token_dispatcher.py` — clean
- Happy path is unchanged; the only observable difference is the wording of the thrown exception when `decode_threshold > 16`.                                                                                                                              
- No new tests added — both sites are dead-code / message-only changes.

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
