### PR TITLE
[Draft][Bugfix] DSV4 A5 PP Support

### DIFF
--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -944,12 +944,15 @@ class DeepseekV4Model(nn.Module):
         # Pre-hc_head residual stream buffer for the MTP draft. Stable
         # address (outside the cudagraph pool) so the copy_ in forward()
         # refreshes it correctly across captured shapes.
-        self._mtp_hidden_buffer = torch.empty(
-            vllm_config.scheduler_config.max_num_batched_tokens,
-            hc_dim,
-            dtype=vllm_config.model_config.dtype,
-            device=self.device,
-        )
+        if get_pp_group().is_last_rank:
+            self._mtp_hidden_buffer = torch.empty(
+                vllm_config.scheduler_config.max_num_batched_tokens,
+                hc_dim,
+                dtype=vllm_config.model_config.dtype,
+                device=self.device,
+            )
+        else:
+            self._mtp_hidden_buffer = None
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
@@ -998,6 +1001,13 @@ class DeepseekV4Model(nn.Module):
         for layer in islice(self.layers, self.start_layer, self.end_layer):
             hidden_states, residual = layer(positions, hidden_states, residual, llama_4_scaling)
 
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors(
+                {
+                    "hidden_states": hidden_states,
+                }
+            )
+
         # Stash pre-hc_head residual for the MTP draft (captured copy_).
         # When FlashComm1 (sequence parallelism) is enabled, tokens are
         # partitioned across TP ranks via reduce_scatter in each layer's
@@ -1018,13 +1028,6 @@ class DeepseekV4Model(nn.Module):
         else:
             num_tokens = hidden_states.shape[0]
             self._mtp_hidden_buffer[:num_tokens].copy_(hidden_states.flatten(1))
-
-        if not get_pp_group().is_last_rank:
-            return IntermediateTensors(
-                {
-                    "hidden_states": hidden_states,
-                }
-            )
 
         hidden_states = self.hc_head(hidden_states, self.hc_head_fn, self.hc_head_scale, self.hc_head_base)
 

--- a/vllm_ascend/patch/worker/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_distributed.py
@@ -22,7 +22,12 @@ from typing import Any, cast
 import torch
 import vllm
 from torch.distributed import Backend
-from vllm.distributed.parallel_state import GroupCoordinator, _get_unique_name, _register_group
+from vllm.distributed.parallel_state import (
+    GroupCoordinator,
+    TensorMetadata,
+    _get_unique_name,
+    _register_group,
+)
 
 from vllm_ascend.distributed.device_communicators.npu_communicator import NPUCommunicator
 from vllm_ascend.patch.worker._hccl_pg_registry import HcclPgRegistry, make_hccl_pg_key
@@ -97,6 +102,15 @@ def _patch_destroy_distributed_environment():
     vllm.distributed.destroy_distributed_environment = destroy_fn
 
 
+def _is_tensor_dict_metadata(obj: Any) -> bool:
+    return isinstance(obj, list) and any(
+        isinstance(item, tuple)
+        and len(item) == 2
+        and isinstance(item[1], TensorMetadata)
+        for item in obj
+    )
+
+
 class GroupCoordinatorPatch(GroupCoordinator):
     def __init__(
         self,
@@ -124,6 +138,10 @@ class GroupCoordinatorPatch(GroupCoordinator):
         self.device = None
         self.use_custom_op_call = True
         self.use_cpu_custom_send_recv = False
+        self._preforward_tensor_dict_metadata = (
+            self.backend == "hccl" and group_name == "pp"
+        )
+        self._preforwarded_tensor_dict_metadata: dict[int, Any] = {}
 
         reuse_domain = _resolve_reuse_domain(group_name)
 
@@ -177,6 +195,29 @@ class GroupCoordinatorPatch(GroupCoordinator):
             except Exception:
                 logger.exception("Failed to clean up partially initialized GroupCoordinatorPatch")
             raise
+
+    def recv_object(self, src: int) -> Any:
+        obj = super().recv_object(src)
+        if (
+            self._preforward_tensor_dict_metadata
+            and not self.is_last_rank
+            and _is_tensor_dict_metadata(obj)
+        ):
+            # HCCL PP P2P needs downstream ranks to post tensor recv before
+            # upstream tensor send starts waiting.
+            dst = (self.rank_in_group + 1) % self.world_size
+            super().send_object(obj, dst=dst)
+            self._preforwarded_tensor_dict_metadata[self.ranks[dst]] = obj
+        return obj
+
+    def send_object(self, obj: Any, dst: int) -> None:
+        dst_global_rank = self.ranks[dst]
+        if (
+            self._preforward_tensor_dict_metadata
+            and self._preforwarded_tensor_dict_metadata.pop(dst_global_rank, None) == obj
+        ):
+            return None
+        return super().send_object(obj, dst)
 
     def destroy(self):
         cpu_group = getattr(self, "cpu_group", None)


### PR DESCRIPTION
### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

```shell
TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
LOG_FILE="logs/test_${TIMESTAMP}.log"

mkdir -p ./logs

export OMP_PROC_BIND=false
export OMP_NUM_THREADS=8
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True

export VLLM_USE_V1=1

export TASK_QUEUE_ENABLE=1
export HCCL_BUFFSIZE=1024
export VLLM_VERSION="0.20.0"

export USE_MULTI_BLOCK_POOL=1
export USE_MULTI_GROUPS_KV_CACHE=1

MODEL_WEIGHT=/data2/weights/DeepSeek-V4-Flash

vllm serve $MODEL_WEIGHT \
  --max-model-len 1048576 \
  --max-num-batched-tokens 16384 \
  --served-model-name ds \
  --gpu-memory-utilization 0.90 \
  --max-num-seqs 32 \
  --pipeline-parallel-size 4 \
  --data-parallel-size 1 \
  --prefill-context-parallel-size 1 \
  --tensor-parallel-size 1 \
  --enable-expert-parallel \
  --port 8000 \
  --block-size 128 \
  --enable-chunked-prefill \
  --no-async-scheduling \
  --tokenizer-mode deepseek_v4 \
  --tool-call-parser deepseek_v4 \
  --enable-auto-tool-choice \
  --reasoning-parser deepseek_v4 \
  --no-enable-prefix-caching \
  --additional-config '{
                "enable_cpu_binding":true,
                "multistream_overlap_shared_expert":true,
                "multistream_dsa_preprocess":true,
                "enable_flashcomm1": false,
                "enable_dsa_cp": false
        }' \
  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
  2>&1 | tee "$LOG_FILE"
```


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
