### PR TITLE
[BugFix] Align AscendStore grouped hash lookup encoding

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -476,8 +476,11 @@ def _rehash_block_hash_group(block_hashes: Sequence[BlockHash | str]) -> BlockHa
 
 def _block_hash_to_bytes(block_hash: BlockHash | str) -> bytes:
     if isinstance(block_hash, str):
-        if len(block_hash) == 64 and all(char in "0123456789abcdefABCDEF" for char in block_hash):
-            return bytes.fromhex(block_hash)
+        if len(block_hash) == 64:
+            try:
+                return bytes.fromhex(block_hash)
+            except ValueError:
+                return block_hash.encode("utf-8")
         return block_hash.encode("utf-8")
     return bytes(block_hash)
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -476,11 +476,8 @@ def _rehash_block_hash_group(block_hashes: Sequence[BlockHash | str]) -> BlockHa
 
 def _block_hash_to_bytes(block_hash: BlockHash | str) -> bytes:
     if isinstance(block_hash, str):
-        if len(block_hash) == 64:
-            try:
-                return bytes.fromhex(block_hash)
-            except ValueError:
-                pass
+        if len(block_hash) == 64 and all(char in "0123456789abcdefABCDEF" for char in block_hash):
+            return bytes.fromhex(block_hash)
         return block_hash.encode("utf-8")
     return bytes(block_hash)
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -476,10 +476,11 @@ def _rehash_block_hash_group(block_hashes: Sequence[BlockHash | str]) -> BlockHa
 
 def _block_hash_to_bytes(block_hash: BlockHash | str) -> bytes:
     if isinstance(block_hash, str):
-        try:
-            return bytes.fromhex(block_hash)
-        except ValueError:
-            pass
+        if len(block_hash) == 64:
+            try:
+                return bytes.fromhex(block_hash)
+            except ValueError:
+                pass
         return block_hash.encode("utf-8")
     return bytes(block_hash)
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -476,6 +476,10 @@ def _rehash_block_hash_group(block_hashes: Sequence[BlockHash | str]) -> BlockHa
 
 def _block_hash_to_bytes(block_hash: BlockHash | str) -> bytes:
     if isinstance(block_hash, str):
+        try:
+            return bytes.fromhex(block_hash)
+        except ValueError:
+            pass
         return block_hash.encode("utf-8")
     return bytes(block_hash)
 


### PR DESCRIPTION
### What this PR does / why we need it?

Follow-up to #9789. The scheduler lookup RPC serializes block hashes as hex strings, while the worker store path rehashes raw `BlockHash` bytes. After grouped rehashing was introduced, hashing hex string bytes and raw bytes produced different grouped digests, so lookup and store keys could diverge.

This PR minimally updates `_block_hash_to_bytes()` to decode hex strings back to raw bytes before rehashing, while preserving the existing UTF-8 fallback for non-hex strings.

### Does this PR introduce _any_ user-facing change?

No. This only fixes internal AscendStore KV pool key generation consistency.

### Validation

vLLM version: v0.20.1
vLLM main: vllm-project/vllm@c7aa186

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
