### PR TITLE
[BugFix]fix A3 DSV4 precision

### DIFF
--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -369,16 +369,14 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1
         self.spec_slot_mapping = None
-        if get_ascend_device_type() in {AscendDeviceType.A5}
-            self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens,)
+        if get_ascend_device_type() in {AscendDeviceType.A5}:
+            self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens,)  # type: ignore
         else:
-            self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens, 2)
+            self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens, 2)  # type: ignore
         if self.speculative_config:
             spec_token_num = self.speculative_config.num_speculative_tokens
             self.spec_slot_mapping = [
-                torch.zeros(
-                    self.slot_mapping_shape, dtype=torch.int32, device=self.device
-                )
+                torch.zeros(self.slot_mapping_shape, dtype=torch.int32, device=self.device)
                 for _ in range(spec_token_num)
             ]
             self.decode_threshold += spec_token_num
@@ -432,9 +430,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self._zero_i32 = torch.tensor([0], device=self.device, dtype=torch.int32)
         # Note(qcs): we use two dimension slot_mapping for kvcache with shape
         # [block_nums, block_size, head_num, head_dim]
-        self.slot_mapping = torch.zeros(
-            self.slot_mapping_shape, dtype=torch.int32, device=self.device
-        )
+        self.slot_mapping = torch.zeros(self.slot_mapping_shape, dtype=torch.int32, device=self.device)
 
     @classmethod
     def get_cudagraph_support(

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -369,11 +369,15 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1
         self.spec_slot_mapping = None
+        if get_ascend_device_type() in {AscendDeviceType.A5}
+            self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens,)
+        else:
+            self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens, 2)
         if self.speculative_config:
             spec_token_num = self.speculative_config.num_speculative_tokens
             self.spec_slot_mapping = [
                 torch.zeros(
-                    (vllm_config.scheduler_config.max_num_batched_tokens, 2), dtype=torch.int32, device=self.device
+                    self.slot_mapping_shape, dtype=torch.int32, device=self.device
                 )
                 for _ in range(spec_token_num)
             ]
@@ -429,7 +433,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         # Note(qcs): we use two dimension slot_mapping for kvcache with shape
         # [block_nums, block_size, head_num, head_dim]
         self.slot_mapping = torch.zeros(
-            (vllm_config.scheduler_config.max_num_batched_tokens, 2), dtype=torch.int32, device=self.device
+            self.slot_mapping_shape, dtype=torch.int32, device=self.device
         )
 
     @classmethod

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -557,7 +557,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
         # NOTE: Currently, MTP-fullgraph is incompatibility pcp
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
-        self.slot_mapping = DeviceOperator.format_dsa_slot_mapping(slot_mapping, self.block_size)
+        self.slot_mapping[:num_input_tokens] = DeviceOperator.format_dsa_slot_mapping(slot_mapping, self.block_size)
 
         self.graph_pad_size = common_attn_metadata.graph_pad_size
         block_table_size = self.get_block_table_size(common_attn_metadata, BUILD_METADATA_STEP_PREFILL)
@@ -1134,7 +1134,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=False)
 
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
-        self.spec_slot_mapping[draft_step - 1] = DeviceOperator.format_dsa_slot_mapping(  # type: ignore[index]
+        self.spec_slot_mapping[draft_step - 1][:num_input_tokens] = DeviceOperator.format_dsa_slot_mapping(  # type: ignore[index]
             slot_mapping, self.block_size
         )
 
@@ -1675,7 +1675,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                     perm_y=(1, 0, 2),
                     batch_split_factor=1,
                 )
-            o_proj_input = o_proj_input.reshape(num_tokens, -1)
+                o_proj_input = o_proj_input.reshape(num_tokens, -1)
             output[...] = self.wo_b(o_proj_input)
 
         return output_padded

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -20,8 +20,8 @@ from typing import Any
 import torch
 import torch.nn.functional as F
 import torch_npu
-
 from vllm.triton_utils import HAS_TRITON
+
 from vllm_ascend.device.mxfp_compat import (
     FLOAT8_E8M0FNU_DTYPE,
     QUANT_DTYPES,
@@ -32,7 +32,6 @@ from vllm_ascend.ops.triton.fla.solve_tril import solve_tril_16x16_kernel
 from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
-
 
 if HAS_TRITON:
     from vllm_ascend.ops.triton.rms_norm import triton_q_rms

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -599,7 +599,14 @@ class BaseDeviceAdaptor:
     def apply_dsa_q_rms(q, eps, q_norm_without_weight=None):
         """Apply Q RMS norm. Non-A5: triton_q_rms.
         A5: uses q_norm_without_weight callable when provided."""
-        return triton_q_rms(q, eps)
+        if triton_q_rms is not None:
+            return triton_q_rms(q, eps)
+        else:
+            dtype = q.dtype
+            q = q.float()
+            variance = q.square().mean(-1, keepdim=True)
+            q = q * torch.rsqrt(variance + eps)
+            return q.to(dtype)
 
     # ===== KV Cache Helpers =====
 
@@ -1223,7 +1230,14 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         if q_norm_without_weight is not None:
             return q_norm_without_weight(q)
 
-        return triton_q_rms(q, eps)
+        if triton_q_rms is not None:
+            return triton_q_rms(q, eps)
+        else:
+            dtype = q.dtype
+            q = q.float()
+            variance = q.square().mean(-1, keepdim=True)
+            q = q * torch.rsqrt(variance + eps)
+            return q.to(dtype)
 
     # ===== KV Cache Helpers =====
 

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -34,9 +34,9 @@ from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 if HAS_TRITON:
-    from vllm_ascend.ops.triton.rms_norm import triton_q_rms
+    from vllm_ascend.ops.triton.rms_norm import triton_q_rms  # noqa: F811
 else:
-    triton_q_rms = None
+    triton_q_rms = None  # type: ignore
 
 
 class BaseDeviceAdaptor:

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -21,6 +21,7 @@ import torch
 import torch.nn.functional as F
 import torch_npu
 
+from vllm.triton_utils import HAS_TRITON
 from vllm_ascend.device.mxfp_compat import (
     FLOAT8_E8M0FNU_DTYPE,
     QUANT_DTYPES,
@@ -29,9 +30,14 @@ from vllm_ascend.device.mxfp_compat import (
 from vllm_ascend.ops.triton.fla.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd_kernel
 from vllm_ascend.ops.triton.fla.solve_tril import solve_tril_16x16_kernel
 from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
-from vllm_ascend.ops.triton.rms_norm import triton_q_rms
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
+
+if HAS_TRITON:
+    from vllm_ascend.ops.triton.rms_norm import triton_q_rms
+else:
+    triton_q_rms = None
 
 
 class BaseDeviceAdaptor:

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -29,6 +29,7 @@ from vllm_ascend.device.mxfp_compat import (
 from vllm_ascend.ops.triton.fla.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd_kernel
 from vllm_ascend.ops.triton.fla.solve_tril import solve_tril_16x16_kernel
 from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
+from vllm_ascend.ops.triton.rms_norm import triton_q_rms
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
@@ -593,13 +594,7 @@ class BaseDeviceAdaptor:
     def apply_dsa_q_rms(q, eps, q_norm_without_weight=None):
         """Apply Q RMS norm. Non-A5: triton_q_rms.
         A5: uses q_norm_without_weight callable when provided."""
-        from vllm.triton_utils import HAS_TRITON
-
-        if HAS_TRITON:
-            from vllm_ascend.ops.triton.rms_norm import triton_q_rms
-
-            return triton_q_rms(q, eps)
-        return q
+        return triton_q_rms(q, eps)
 
     # ===== KV Cache Helpers =====
 
@@ -1222,13 +1217,8 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         """Apply Q RMS norm. A5: uses q_norm_without_weight callable."""
         if q_norm_without_weight is not None:
             return q_norm_without_weight(q)
-        from vllm.triton_utils import HAS_TRITON
 
-        if HAS_TRITON:
-            from vllm_ascend.ops.triton.rms_norm import triton_q_rms
-
-            return triton_q_rms(q, eps)
-        return q
+        return triton_q_rms(q, eps)
 
     # ===== KV Cache Helpers =====
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR updates the slot mapping assignment in `dsa_v1.py` to be in-place (`[:num_input_tokens]`) and refactors `apply_dsa_q_rms` in `device_op.py` by moving the `triton_q_rms` import to the top level and removing the `HAS_TRITON` check.

However, several critical issues were identified:
- In-place assignment of slot mapping will cause a shape mismatch `RuntimeError` on A5 devices because `self.slot_mapping` is pre-allocated as a 2D tensor while `format_dsa_slot_mapping` returns a 1D tensor.
- Unconditionally importing `triton_q_rms` at the top level of `device_op.py` will raise an `ImportError` in environments without Triton. A conditional import guarded by `HAS_TRITON` and a PyTorch native fallback should be implemented.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

DeepSeek-V4-Flash-w8a8 @ A3    GPQA: 86.87
DeepSeek-V4-Flash           @ A5    GPQA: 86.87

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
