### PR TITLE
[BugFix][Worker] Detect silent device-mask shrink before set_device

### DIFF
--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -485,3 +485,102 @@ def test_is_pd_decode_recompute_scheduler_enabled_decode_consumer_disabled():
     ascend_config.recompute_scheduler_enable = False
     with mock.patch("vllm_ascend.utils.get_ascend_config", return_value=ascend_config):
         assert utils.is_pd_decode_recompute_scheduler_enabled(vllm_config) is False
+
+
+class TestCheckAscendRtVisibleDevices(TestBase):
+    """Tests for utils.check_ascend_rt_visible_devices.
+
+    The CANN runtime silently drops ids from ASCEND_RT_VISIBLE_DEVICES that
+    are not valid indices into the host's physical NPU enumeration and
+    re-numbers the remainder. The worker only crashes later, at the first
+    rank whose logical id exceeds the surviving count, with the misleading
+    ``open device N failed, runtime result = 107001``. The helper detects
+    both this size shrink and the related ``local_world_size > device_count``
+    case before ``torch.npu.set_device`` is ever called.
+    """
+
+    def _patches(self, available: bool = True, device_count: int = 4):
+        return (
+            mock.patch("torch.npu.is_available", return_value=available),
+            mock.patch("torch.npu.device_count", return_value=device_count),
+        )
+
+    def test_npu_unavailable_short_circuits(self):
+        # Without NPUs the helper is a no-op; nothing to validate.
+        is_avail, dev_count = self._patches(available=False, device_count=0)
+        with is_avail, dev_count, mock.patch.dict(os.environ, {"ASCEND_RT_VISIBLE_DEVICES": "0,1,3,4"}):
+            utils.check_ascend_rt_visible_devices(local_world_size=4)
+
+    def test_env_unset_local_world_fits(self):
+        is_avail, dev_count = self._patches(device_count=4)
+        env = {k: v for k, v in os.environ.items() if k != "ASCEND_RT_VISIBLE_DEVICES"}
+        with is_avail, dev_count, mock.patch.dict(os.environ, env, clear=True):
+            utils.check_ascend_rt_visible_devices(local_world_size=4)
+            utils.check_ascend_rt_visible_devices(local_world_size=1)
+
+    def test_env_unset_local_world_exceeds_visible_count(self):
+        is_avail, dev_count = self._patches(device_count=2)
+        env = {k: v for k, v in os.environ.items() if k != "ASCEND_RT_VISIBLE_DEVICES"}
+        with (
+            is_avail,
+            dev_count,
+            mock.patch.dict(os.environ, env, clear=True),
+            self.assertRaisesRegex(RuntimeError, "local_world_size"),
+        ):
+            utils.check_ascend_rt_visible_devices(local_world_size=4)
+
+    def test_mask_size_matches_device_count_passes(self):
+        # All ids in the mask are valid; CANN keeps the requested count.
+        is_avail, dev_count = self._patches(device_count=4)
+        with is_avail, dev_count, mock.patch.dict(os.environ, {"ASCEND_RT_VISIBLE_DEVICES": "0,1,2,3"}):
+            utils.check_ascend_rt_visible_devices(local_world_size=4)
+
+    def test_mask_size_shrunk_by_cann_raises(self):
+        # User asked for 4 NPUs but CANN silently dropped one id; the
+        # error must surface both the requested count and what survived.
+        is_avail, dev_count = self._patches(device_count=3)
+        with (
+            is_avail,
+            dev_count,
+            mock.patch.dict(os.environ, {"ASCEND_RT_VISIBLE_DEVICES": "0,1,3,4"}),
+            self.assertRaisesRegex(RuntimeError, r"requested 4 .*accepted only 3"),
+        ):
+            utils.check_ascend_rt_visible_devices(local_world_size=3)
+
+    def test_negative_id_dropped_by_cann_raises(self):
+        # Negative ids are also dropped by CANN; same size-mismatch signal.
+        is_avail, dev_count = self._patches(device_count=2)
+        with (
+            is_avail,
+            dev_count,
+            mock.patch.dict(os.environ, {"ASCEND_RT_VISIBLE_DEVICES": "0,-1,2"}),
+            self.assertRaisesRegex(RuntimeError, "requested 3"),
+        ):
+            utils.check_ascend_rt_visible_devices(local_world_size=2)
+
+    def test_malformed_env_raises(self):
+        is_avail, dev_count = self._patches(device_count=4)
+        with (
+            is_avail,
+            dev_count,
+            mock.patch.dict(os.environ, {"ASCEND_RT_VISIBLE_DEVICES": "0,foo,2"}),
+            self.assertRaisesRegex(RuntimeError, "Failed to parse"),
+        ):
+            utils.check_ascend_rt_visible_devices(local_world_size=2)
+
+    def test_visible_smaller_than_local_world_size(self):
+        # Mask exposes 2 NPUs but caller requested TP/PP=4 worker pool.
+        is_avail, dev_count = self._patches(device_count=2)
+        with (
+            is_avail,
+            dev_count,
+            mock.patch.dict(os.environ, {"ASCEND_RT_VISIBLE_DEVICES": "0,1"}),
+            self.assertRaisesRegex(RuntimeError, "local_world_size"),
+        ):
+            utils.check_ascend_rt_visible_devices(local_world_size=4)
+
+    def test_empty_env_passes(self):
+        # An empty value triggers neither parse nor size checks.
+        is_avail, dev_count = self._patches(device_count=4)
+        with is_avail, dev_count, mock.patch.dict(os.environ, {"ASCEND_RT_VISIBLE_DEVICES": ""}):
+            utils.check_ascend_rt_visible_devices(local_world_size=2)

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -541,6 +541,70 @@ def adapt_patch(is_global_patch: bool = False):
         from vllm_ascend.patch import worker  # noqa: F401
 
 
+def check_ascend_rt_visible_devices(local_world_size: int) -> None:
+    """Validate ``ASCEND_RT_VISIBLE_DEVICES`` before any ``set_device`` call.
+
+    The CANN runtime silently drops every raw id in
+    ``ASCEND_RT_VISIBLE_DEVICES`` that is not a valid index into the host's
+    physical NPU enumeration and re-numbers the remaining ids. The worker
+    then crashes the first time a rank whose logical id is ``>=`` the
+    surviving count calls ``torch.npu.set_device`` -- the cryptic
+    ``open device N failed, runtime result = 107001`` -- because the
+    ``N`` reported is the failing worker's ``local_rank``, not the
+    offending raw id.
+
+    Two things go wrong in practice and should be caught early:
+
+    1. ``local_world_size > torch.npu.device_count()``: the existing
+       assertion at :func:`NPUWorker._init_device` only fires when
+       ``data_parallel_size > 1``, so single-node TP-only setups silently
+       miss it. This helper enforces it unconditionally.
+
+    2. CANN silently shrank the mask. When a user copies ids straight out
+       of ``npu-smi info`` on a host whose NPU slots are not a contiguous
+       prefix (e.g. slots ``0/1/3/4`` with slot ``2`` missing), the
+       natural mask ``"0,1,3,4"`` parses as four ids but ``device_count``
+       reports three. Detect the size mismatch and surface the surviving
+       count so the user can switch to the logical-id form.
+    """
+    if not torch.npu.is_available():
+        return
+    visible_device_count = torch.npu.device_count()
+    if local_world_size > visible_device_count:
+        raise RuntimeError(
+            f"local_world_size ({local_world_size}) exceeds the number of "
+            f"NPU devices visible to this process ({visible_device_count}). "
+            f"Either reduce tensor-parallel-size / pipeline-parallel-size, "
+            f"or expose more NPUs via ASCEND_RT_VISIBLE_DEVICES (note that "
+            f"the CANN runtime silently drops ids that do not exist on this "
+            f"host, so check the mask if you expected more devices)."
+        )
+
+    visible = os.getenv("ASCEND_RT_VISIBLE_DEVICES")
+    if visible is None:
+        return
+    try:
+        raw_ids = [int(x) for x in visible.split(",") if x.strip()]
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Failed to parse ASCEND_RT_VISIBLE_DEVICES={visible!r}: expected a comma-separated list of integers."
+        ) from exc
+    if not raw_ids:
+        return
+    if len(raw_ids) != visible_device_count:
+        raise RuntimeError(
+            f"ASCEND_RT_VISIBLE_DEVICES={visible!r} requested "
+            f"{len(raw_ids)} NPU(s) but the CANN runtime accepted only "
+            f"{visible_device_count}; ids that are not valid indices into "
+            f"this host's physical NPU enumeration are silently dropped, "
+            f"which causes the surviving worker pool to be smaller than "
+            f"the requested parallelism and the corresponding rank to fail "
+            f"at rtSetDevice with error 107001. Use the logical-id form "
+            f'"0,1,...,{visible_device_count - 1}" and let the driver '
+            f"map those onto the underlying physical NPUs."
+        )
+
+
 def setup_ascend_local_comm_res(local_rank: int, kv_transfer_config: Any | None) -> None:
     """Load the local A5 endpoint config into ASCEND_LOCAL_COMM_RES."""
     if kv_transfer_config is None:

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -600,7 +600,7 @@ def check_ascend_rt_visible_devices(local_world_size: int) -> None:
             f"which causes the surviving worker pool to be smaller than "
             f"the requested parallelism and the corresponding rank to fail "
             f"at rtSetDevice with error 107001. Use the logical-id form "
-            f'"0,1,...,{visible_device_count - 1}" and let the driver '
+            f'"0,1,...,{len(raw_ids) - 1}" and let the driver '
             f"map those onto the underlying physical NPUs."
         )
 

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -67,6 +67,7 @@ from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
 from vllm_ascend.utils import (
     AscendDeviceType,
     check_ascend_device_type,
+    check_ascend_rt_visible_devices,
     enable_sp,
     get_ascend_device_type,
     register_ascend_customop,
@@ -445,8 +446,17 @@ class NPUWorker(WorkerBase):
             visible_device_index = current_platform.logical_device_id_to_visible_device_id(self.local_rank)
             device = torch.device(f"{current_platform.device_type}:{visible_device_index}")
         else:
+            parallel_config = self.parallel_config
             device = torch.device(f"npu:{self.local_rank}")
 
+        # Detect CANN silently shrinking ASCEND_RT_VISIBLE_DEVICES before we
+        # hit rtSetDevice error 107001. Skip when the parent process
+        # pre-sharded via --device-ids (assigned_physical_gpu_ids), because
+        # each child then legitimately sees fewer devices than
+        # local_world_size and the helper's own local_world_size check would
+        # spurious-fail.
+        if parallel_config.assigned_physical_gpu_ids is None:
+            check_ascend_rt_visible_devices(parallel_config.local_world_size)
         torch.npu.set_device(device)
 
         # Import _inductor for graph mode execution with triton
@@ -480,20 +490,6 @@ class NPUWorker(WorkerBase):
                 f"({self.cache_config.gpu_memory_utilization}, "
                 f"{GiB(self.requested_memory)} GiB). Decrease GPU memory "
                 f"utilization or reduce GPU memory used by other processes."
-            )
-
-        if (
-            self.parallel_config.data_parallel_size > 1
-            and self.parallel_config.data_parallel_size_local > 0
-            and self.parallel_config.distributed_executor_backend not in ["ray", "external_launcher"]
-            and self.vllm_config.parallel_config.data_parallel_backend != "ray"
-            and self.vllm_config.parallel_config.nnodes_within_dp == 1
-        ):
-            visible_device_count = torch.npu.device_count() if torch.npu.is_available() else 0
-            assert self.parallel_config.local_world_size <= visible_device_count, (
-                f"local_world_size ({self.parallel_config.local_world_size}) must "
-                f"be less than or equal to the number of visible devices "
-                f"({visible_device_count})."
             )
 
         # Initialize the distributed environment.


### PR DESCRIPTION
The CANN runtime silently drops every raw id in
ASCEND_RT_VISIBLE_DEVICES that is not a valid index into the host's physical NPU enumeration. A user who copies ids straight from ``npu-smi info`` on a host with non-contiguous slots (e.g. slots 0/1/3/4 with slot 2 missing) writes ASCEND_RT_VISIBLE_DEVICES="0,1,3,4" and gets torch.npu.device_count()==3, with the dropped id reappearing only at worker init as ``open device N failed, runtime result = 107001``. The ``N`` in that error message is the failing worker's local_rank, not the offending raw id, so the message does not point at the cause.

This change adds vllm_ascend.utils.check_ascend_rt_visible_devices and calls it from NPUWorker._init_device before torch.npu.set_device. The helper raises with an actionable message when:

  * local_world_size > torch.npu.device_count() -- the existing assertion in _init_device only fires when data_parallel_size > 1, so single-node TP-only setups currently miss this case;
  * the number of ids in ASCEND_RT_VISIBLE_DEVICES does not match torch.npu.device_count(), which proves CANN silently dropped some ids and the surviving pool is smaller than requested;
  * ASCEND_RT_VISIBLE_DEVICES cannot be parsed as a list of ints.

Verified on a 4x910B2 host with physical slots 0/1/3/4 (slot 2 missing): the mask "0,1,3,4" now fails at init with a clear error naming the size mismatch, while "0,1,2,3" (the working logical-id form) and "1,3" (a non-contiguous but in-range two-card mask) still pass.

Related issues: #2557, #454.

### What this PR does / why we need it?
When ASCEND_RT_VISIBLE_DEVICES contains an id that is not a valid index into the host's physical NPU enumeration (e.g. "0,1,3,4" on a 4-card box where the kernel enumerates four contiguous NPUs as 0..3), the CANN runtime silently drops the invalid id and renumbers the survivors. After that, torch.npu.device_count() returns the post-mask survivor count, which is smaller than the count the user requested via the mask. NPUWorker._init_device then calls torch.npu.set_device(npu:local_rank) and the worker whose local_rank >= device_count() dies at init with:
                                                                                                                                                                                                               
  NPU function error: c10_npu::SetDevice(device), error code is 107001
    Invalid device ID. rtSetDevice execution failed, device id error
    open device <local_rank> failed, runtime result = 107001
                                                                                                                                                                                                               The number reported in open device N failed is the logical local_rank that failed to bind, not the offending raw id from the mask, which makes the symptom genuinely confusing to triage on multi-NPU hosts.
                                                                                                                                                                                                               
A guard for this case already exists in _init_device (local_world_size <= visible_device_count), but it is gated behind data_parallel_size > 1, so pure-TP DP=1 single-node serving (the most common deployment shape) skips it entirely.                                                                                                                                                                         
                                                                                                                                                                                                               
This PR:                                                                                                                                                                                                     
                                                                                                                                                                                                               
1. Adds a small helper check_ascend_rt_visible_devices(local_world_size) in vllm_ascend/utils.py that, before any set_device call, fails fast with a clear RuntimeError in three cases:
    - local_world_size > torch.npu.device_count() — not enough NPUs visible for the requested parallelism;                                                                                                     
    - len(parsed_ids) != torch.npu.device_count() — CANN silently dropped at least one id from the user-supplied mask, proving the requested device pool is smaller than expected;
    - ASCEND_RT_VISIBLE_DEVICES is malformed (non-integer tokens).                                                                                                                                             
2. Calls the helper as the first statement of NPUWorker._init_device, so the failure happens before torch.npu.set_device and the user sees a message that explicitly names the silent-drop mechanism and suggests the logical-id form ("0,1,...,N-1") as the fix, instead of the misleading open device N failed text.
3. Removes the now-redundant gated check at worker.py so DP=1 and DP>1 paths use the same validation.                                                                                                        
                                                       
Net effect: deployments with a misconfigured ASCEND_RT_VISIBLE_DEVICES (typically because a host has a missing/offline NPU slot and the user copied the OS-reported ids verbatim) get an actionable error pointing at the mask, instead of a 107001 crash that looks like a runtime/driver problem.

### Does this PR introduce _any_ user-facing change?
Yes, but only in the error-path:    
                                                                                                                                                                         
- Misconfigured ASCEND_RT_VISIBLE_DEVICES now raises a RuntimeError from NPUWorker._init_device with a message that names the silent-drop mechanism and recommends the logical-id form, instead of failing later at rtSetDevice with code 107001 / open device <local_rank> failed.                                                                                                                                     
- The gated local_world_size <= visible_device_count check that previously only ran when data_parallel_size > 1 now runs unconditionally (subsumed by the new helper). Configurations that were already valid
continue to work unchanged; configurations that previously silently failed at rtSetDevice now fail earlier with a clearer message.
                                                                                                                                                                                                               
No public API, no CLI flag, no behavior change for valid configurations.

### How was this patch tested?
1. Unit tests added in tests/ut/test_utils.py (TestCheckAscendRtVisibleDevices, 9 cases) covering:                                                                                                           
    - NPU unavailable (helper short-circuits);         
    - ASCEND_RT_VISIBLE_DEVICES unset, local_world_size fits / exceeds visible count;                                                                                                                          
    - mask size matches device_count() (passes);       
    - mask shrunk by CANN ("0,1,3,4" on a host where one id is invalid → len(parsed) != device_count() → raises);                                                                                              
    - mask contains an out-of-range id that CANN dropped (raises);
    - malformed env ("0,foo,2" → raises with parse error);                                                                                                                                                     
    - visible smaller than local_world_size (raises);  
    - empty env string (passes).                                                                                                                                                                               
                                                                                                                                                                                                               
  Run locally with pytest tests/ut/test_utils.py::TestCheckAscendRtVisibleDevices -v — 9/9 pass.                                                                                                               
2. Live integration test on a 4×910B2 host whose OS-visible NPU ids are 0,1,3,4 (slot 2 missing):                                                                                                            
    - ASCEND_RT_VISIBLE_DEVICES="0,1,3,4", local_world_size=4 → helper raises with the new message (was: SetDevice 107001 crash on open device 3 failed). ✓                                                    
    - ASCEND_RT_VISIBLE_DEVICES="0,1,2,3", local_world_size=4 → helper passes; full Mixtral-8x7B TP=4 12-cell concurrency × long-context sweep completes end-to-end. ✓                                         
    - ASCEND_RT_VISIBLE_DEVICES="1,3", local_world_size=2 → helper passes (CANN keeps both, device_count()=2, len(parsed)=2), workload runs cleanly. ✓ (confirms the helper is NOT over-restrictive on         
  non-contiguous masks whose ids are all valid.)                                                                                                                                                               
    - ASCEND_RT_VISIBLE_DEVICES="3,4", local_world_size=2 → helper raises (CANN drops 4, device_count()=1, len(parsed)=2). ✓                                                                                   
    - Malformed ("0,foo,2") → helper raises with parse error. ✓
3. Ruff (ruff check vllm_ascend/utils.py vllm_ascend/worker/worker.py tests/ut/test_utils.py) and ruff format both clean.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
