### PR TITLE
[BugFix] Fix the main2main caused prefix-mamba-cache error

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -363,6 +363,13 @@
     - tests/e2e/pull_request/one_card/test_qwen3_0_6b.py
     - tests/e2e/pull_request/one_card/test_qwen3_5_0_8b.py
 
+- name: patch_mamba_utils_310p
+  optional: true
+  source_file_dependencies:
+    - vllm_ascend/patch/worker/patch_mamba_utils.py
+  tests:
+    - tests/e2e/pull_request/one_card/_310p/test_dense_model_310p.py::test_qwen3_5_dense_prefix_mamba_cache_tp1_fp16
+
 # Profiler
 - name: profiler
   optional: true

--- a/tests/e2e/pull_request/one_card/_310p/test_dense_model_310p.py
+++ b/tests/e2e/pull_request/one_card/_310p/test_dense_model_310p.py
@@ -19,13 +19,11 @@
 from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
 from tests.e2e.model_utils import check_outputs_equal
 
-
 QWEN3_5_PREFIX_MAMBA_PROMPT = (
     "You are reading a compact synthetic operations ledger. "
     "Use only the rows below when answering the final question.\n"
     + "\n".join(
-        f"Row {i}: route R{i:03d} moves cargo from zone {i % 11} to zone {(i * 7) % 13}; "
-        f"priority is {i % 5}."
+        f"Row {i}: route R{i:03d} moves cargo from zone {i % 11} to zone {(i * 7) % 13}; priority is {i % 5}."
         for i in range(64)
     )
     + "\n"

--- a/tests/e2e/pull_request/one_card/_310p/test_dense_model_310p.py
+++ b/tests/e2e/pull_request/one_card/_310p/test_dense_model_310p.py
@@ -36,22 +36,35 @@ QWEN3_5_PREFIX_MAMBA_PROMPTS = [
 
 
 def _generate_qwen3_5_prefix_mamba_outputs(enable_prefix_caching: bool) -> list[tuple[list[int], str]]:
-    outputs = []
-    runner_kwargs = {
-        "tensor_parallel_size": 1,
-        "enforce_eager": True,
-        "dtype": "float16",
-        "max_model_len": 2048,
-        "max_num_batched_tokens": 2048,
-        "enable_prefix_caching": enable_prefix_caching,
-        "mamba_ssm_cache_dtype": "float16",
-    }
-    if enable_prefix_caching:
-        runner_kwargs["mamba_cache_mode"] = "align"
+    outputs: list[tuple[list[int], str]] = []
 
-    with VllmRunner("Qwen/Qwen3.5-4B", **runner_kwargs) as vllm_model:
-        for prompt in QWEN3_5_PREFIX_MAMBA_PROMPTS:
-            outputs.extend(vllm_model.generate_greedy([prompt], max_tokens=8))
+    if enable_prefix_caching:
+        with VllmRunner(
+            "Qwen/Qwen3.5-4B",
+            tensor_parallel_size=1,
+            enforce_eager=True,
+            dtype="float16",
+            max_model_len=2048,
+            max_num_batched_tokens=2048,
+            enable_prefix_caching=True,
+            mamba_cache_mode="align",
+            mamba_ssm_cache_dtype="float16",
+        ) as vllm_model:
+            for prompt in QWEN3_5_PREFIX_MAMBA_PROMPTS:
+                outputs.extend(vllm_model.generate_greedy([prompt], max_tokens=8))
+    else:
+        with VllmRunner(
+            "Qwen/Qwen3.5-4B",
+            tensor_parallel_size=1,
+            enforce_eager=True,
+            dtype="float16",
+            max_model_len=2048,
+            max_num_batched_tokens=2048,
+            enable_prefix_caching=False,
+            mamba_ssm_cache_dtype="float16",
+        ) as vllm_model:
+            for prompt in QWEN3_5_PREFIX_MAMBA_PROMPTS:
+                outputs.extend(vllm_model.generate_greedy([prompt], max_tokens=8))
     return outputs
 
 

--- a/tests/e2e/pull_request/one_card/_310p/test_dense_model_310p.py
+++ b/tests/e2e/pull_request/one_card/_310p/test_dense_model_310p.py
@@ -17,6 +17,44 @@
 
 
 from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+from tests.e2e.model_utils import check_outputs_equal
+
+
+QWEN3_5_PREFIX_MAMBA_PROMPT = (
+    "You are reading a compact synthetic operations ledger. "
+    "Use only the rows below when answering the final question.\n"
+    + "\n".join(
+        f"Row {i}: route R{i:03d} moves cargo from zone {i % 11} to zone {(i * 7) % 13}; "
+        f"priority is {i % 5}."
+        for i in range(64)
+    )
+    + "\n"
+)
+
+QWEN3_5_PREFIX_MAMBA_PROMPTS = [
+    QWEN3_5_PREFIX_MAMBA_PROMPT + "Question: What route is listed in row 17? Answer briefly.",
+    QWEN3_5_PREFIX_MAMBA_PROMPT + "Question: What priority is listed in row 42? Answer briefly.",
+]
+
+
+def _generate_qwen3_5_prefix_mamba_outputs(enable_prefix_caching: bool) -> list[tuple[list[int], str]]:
+    outputs = []
+    runner_kwargs = {
+        "tensor_parallel_size": 1,
+        "enforce_eager": True,
+        "dtype": "float16",
+        "max_model_len": 2048,
+        "max_num_batched_tokens": 2048,
+        "enable_prefix_caching": enable_prefix_caching,
+        "mamba_ssm_cache_dtype": "float16",
+    }
+    if enable_prefix_caching:
+        runner_kwargs["mamba_cache_mode"] = "align"
+
+    with VllmRunner("Qwen/Qwen3.5-4B", **runner_kwargs) as vllm_model:
+        for prompt in QWEN3_5_PREFIX_MAMBA_PROMPTS:
+            outputs.extend(vllm_model.generate_greedy([prompt], max_tokens=8))
+    return outputs
 
 
 def test_qwen3_dense_tp1_fp16():
@@ -85,6 +123,20 @@ def test_qwen3_5_dense_tp1_fp16():
         max_model_len=16384,
     ) as vllm_model:
         vllm_model.generate_greedy(example_prompts, max_tokens)
+
+
+@wait_until_npu_memory_free(0.7)
+def test_qwen3_5_dense_prefix_mamba_cache_tp1_fp16():
+    prefix_cache_outputs = _generate_qwen3_5_prefix_mamba_outputs(enable_prefix_caching=True)
+    no_prefix_cache_outputs = _generate_qwen3_5_prefix_mamba_outputs(enable_prefix_caching=False)
+
+    assert len(prefix_cache_outputs) == len(no_prefix_cache_outputs) == len(QWEN3_5_PREFIX_MAMBA_PROMPTS)
+    check_outputs_equal(
+        outputs_0_lst=no_prefix_cache_outputs,
+        outputs_1_lst=prefix_cache_outputs,
+        name_0="no_prefix_cache_outputs",
+        name_1="prefix_cache_outputs",
+    )
 
 
 @wait_until_npu_memory_free(0.7)

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -1,5 +1,6 @@
 # mypy: ignore-errors
 
+import itertools
 from typing import Any
 
 import torch
@@ -140,7 +141,11 @@ def preprocess_mamba(
     # TODO(Chen): we need to optimize this function a lot
     # assert cache_config.enable_prefix_caching
     block_size = mamba_spec.block_size
-    mamba_utils.cleanup_mamba_state_idx(scheduler_output, mamba_state_idx)
+    finished_req_ids = scheduler_output.finished_req_ids
+    preempted_req_ids = scheduler_output.preempted_req_ids or set()
+    resumed_req_ids = scheduler_output.scheduled_cached_reqs.resumed_req_ids
+    for req_id in itertools.chain(finished_req_ids, preempted_req_ids, resumed_req_ids):
+        mamba_state_idx.pop(req_id, None)
 
     copy_bufs.offset = 0
     for i, req_id in enumerate(input_batch.req_ids):


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request addresses a bug related to prefix-mamba-cache errors. The changes involve refining how Mamba state indices are cleaned up during the scheduling process to ensure consistency across request lifecycles, and introducing a validation test to prevent future regressions in prefix caching behavior.

the error info ：`AttributeError: module 'vllm.v1.worker.mamba_utils' has no attribute 'cleanup_mamba_state_idx'`

### Does this PR introduce _any_ user-facing change?
NA
### How was this patch tested?
CI and local test


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
