### PR TITLE
[Ascend950][Feature] Add support for W8A8FP8 dynamic quantization on Ascend950

### DIFF
--- a/tests/ut/quantization/methods/test_w8a8fp8_dynamic.py
+++ b/tests/ut/quantization/methods/test_w8a8fp8_dynamic.py
@@ -1,0 +1,136 @@
+from unittest.mock import MagicMock, Mock, patch
+
+import torch
+
+from tests.ut.base import TestBase
+from tests.ut.quantization.conftest_quantization import (
+    create_mock_ascend_config,
+    create_mock_vllm_config,
+)
+from vllm_ascend.ascend_forward_context import MoECommType
+from vllm_ascend.quantization.methods.w8a8fp8_dynamic import (
+    AscendW8A8FP8DynamicFusedMoEMethod,
+    AscendW8A8FP8DynamicLinearMethod,
+)
+
+
+class TestAscendW8A8FP8DynamicLinearMethod(TestBase):
+    def setUp(self):
+        self.method = AscendW8A8FP8DynamicLinearMethod()
+
+    def test_act_quant_type(self):
+        self.assertEqual(self.method.act_quant_type, torch.float8_e4m3fn)
+
+    def test_get_weight_various_sizes(self):
+        sizes = [(64, 128), (256, 512), (1024, 2048)]
+        for input_size, output_size in sizes:
+            weight = self.method.get_weight(input_size, output_size, torch.bfloat16)
+            self.assertEqual(weight["weight"].dtype, torch.float8_e4m3fn)
+            self.assertEqual(weight["weight"].shape, (output_size, input_size))
+
+    def test_get_perchannel_param_dtype_variations(self):
+        dtypes = [torch.bfloat16, torch.float16]
+        for dtype in dtypes:
+            params = self.method.get_perchannel_param(128, dtype)
+            self.assertEqual(params["weight_scale"].dtype, torch.float32)
+            self.assertEqual(params["weight_offset"].dtype, dtype)
+            self.assertEqual(params["weight_scale"].shape, (128, 1))
+            self.assertEqual(params["weight_offset"].shape, (128, 1))
+
+
+class TestAscendW8A8FP8FusedMoEMethod(TestBase):
+    num_experts = 8
+    hidden_size = 128
+    intermediate_size = 128
+
+    @patch("torch.distributed.get_rank")
+    @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_mc2_group")
+    @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_ascend_config")
+    def setUp(self, mock_ascend, mock_mc2, mock_rank):
+        with patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_current_vllm_config") as mock_vllm:
+            mock_vllm.return_value = create_mock_vllm_config()
+            mock_ascend.return_value = create_mock_ascend_config()
+            mock_mc2.return_value = MagicMock(
+                device_group=Mock(
+                    _get_backend=Mock(return_value=Mock(get_hccl_comm_name=Mock(return_value="test_comm")))
+                )
+            )
+            mock_rank.return_value = 0
+            self.quant_method = AscendW8A8FP8DynamicFusedMoEMethod()
+
+    def test_quant_type_is_w8a8fp8(self):
+        from vllm_ascend.quantization.quant_type import QuantType
+
+        self.assertEqual(self.quant_method.quant_type, QuantType.W8A8FP8)
+
+    def test_get_weight_dtype_is_float8_e4m3fn(self):
+        param_dict = self.quant_method.get_weight(
+            self.num_experts, self.intermediate_size, self.hidden_size, torch.bfloat16
+        )
+        self.assertEqual(param_dict["w13_weight"].dtype, torch.float8_e4m3fn)
+        self.assertEqual(param_dict["w2_weight"].dtype, torch.float8_e4m3fn)
+        self.assertEqual(
+            param_dict["w13_weight"].shape, (self.num_experts, 2 * self.intermediate_size, self.hidden_size)
+        )
+        self.assertEqual(param_dict["w2_weight"].shape, (self.num_experts, self.hidden_size, self.intermediate_size))
+
+    def test_get_weight_various_expert_counts(self):
+        expert_counts = [4, 8, 16, 32]
+        for num_experts in expert_counts:
+            param_dict = self.quant_method.get_weight(
+                num_experts, self.intermediate_size, self.hidden_size, torch.bfloat16
+            )
+            self.assertEqual(param_dict["w13_weight"].shape[0], num_experts)
+            self.assertEqual(param_dict["w2_weight"].shape[0], num_experts)
+
+    @patch("vllm_ascend.quantization.methods.w8a8_dynamic._EXTRA_CTX")
+    @patch("vllm_ascend.quantization.methods.w8a8_dynamic.select_experts")
+    def test_apply_uses_explicit_dispatch_and_mlp_args(self, mock_select_experts, mock_extra_ctx):
+        tokens = 4
+        hidden_size = self.hidden_size
+        layer = torch.nn.Module()
+        layer.w13_weight = torch.randn(
+            self.num_experts, 2 * self.intermediate_size, hidden_size, dtype=torch.bfloat16
+        ).to(torch.float8_e4m3fn)
+        layer.w2_weight = torch.randn(self.num_experts, hidden_size, self.intermediate_size, dtype=torch.bfloat16).to(
+            torch.float8_e4m3fn
+        )
+        layer.w13_weight_scale_fp32 = torch.ones(self.num_experts, 2 * self.intermediate_size, dtype=torch.float32)
+        layer.w2_weight_scale = torch.ones(self.num_experts, hidden_size, dtype=torch.float32)
+        layer.swiglu_limit = 1000000
+
+        x = torch.randn(tokens, hidden_size, dtype=torch.float32)
+        router_logits = torch.randn(tokens, self.num_experts, dtype=torch.float32)
+        topk_weights = torch.randn(tokens, 2, dtype=torch.float32)
+        topk_ids = torch.randint(0, self.num_experts, (tokens, 2), dtype=torch.int64)
+        mc2_mask = torch.tensor([1, 0, 1, 0], dtype=torch.bool)
+        pertoken_scale = torch.randn(tokens, dtype=torch.float32)
+
+        mock_select_experts.return_value = (topk_weights, topk_ids)
+        mock_comm = Mock()
+        mock_comm.fused_experts.return_value = torch.randn(tokens, hidden_size, dtype=torch.float32)
+        mock_extra_ctx.moe_comm_method = mock_comm
+        mock_extra_ctx.moe_comm_type = MoECommType.ALLGATHER
+        self.quant_method.multistream_overlap_gate = False
+        self.quant_method.in_dtype = torch.float32
+
+        self.quant_method.apply(
+            layer=layer,
+            x=x,
+            router_logits=router_logits,
+            top_k=2,
+            renormalize=True,
+            num_experts=self.num_experts,
+            activation="gelu",
+            apply_router_weight_on_input=True,
+            mc2_mask=mc2_mask,
+            pertoken_scale=pertoken_scale,
+        )
+
+        fused_experts_input = mock_comm.fused_experts.call_args.kwargs["fused_experts_input"]
+        self.assertEqual(fused_experts_input.activation, "gelu")
+        self.assertTrue(fused_experts_input.routing.apply_router_weight_on_input)
+        self.assertIs(fused_experts_input.routing.mc2_mask, mc2_mask)
+        self.assertIs(fused_experts_input.routing.pertoken_scale, pertoken_scale)
+        self.assertIs(fused_experts_input.topk_weights, topk_weights)
+        self.assertIs(fused_experts_input.topk_ids, topk_ids)

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -117,7 +117,7 @@ class BaseDeviceAdaptor:
             raise RuntimeError("MXFP MoE quantization is only supported on Ascend A5.")
 
         if dynamic_scale is None:
-            return torch_npu.npu_dynamic_quant(hidden_states)
+            return torch_npu.npu_dynamic_quant(hidden_states, dst_type=act_quant_type)
 
         return hidden_states, dynamic_scale
 
@@ -896,16 +896,28 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         mxfp_quant_dtype: QuantType | None = None,
     ):
         if not use_mxfp_quant:
-            return torch_npu.npu_grouped_matmul_swiglu_quant_v2(
-                x=x,
-                weight=weight,
-                group_list=group_list,
-                weight_scale=weight_scale,
-                x_scale=x_scale,
-                bias=bias,
-                swiglu_limit=swiglu_limit,
-                use_mxfp_quant=False,
-            )
+            if act_quant_type == torch.float8_e4m3fn:
+                out, out_scale = torch_npu.npu_grouped_matmul_swiglu_quant_v2(
+                    x=x,
+                    weight=[weight],
+                    weight_scale=[weight_scale],
+                    x_scale=x_scale,
+                    group_list=group_list,
+                    quant_dtype=torch.float8_e4m3fn,
+                    dequant_dtype=torch.float32,
+                )
+                return out, out_scale, None
+            else:
+                return torch_npu.npu_grouped_matmul_swiglu_quant_v2(
+                    x=x,
+                    weight=weight,
+                    group_list=group_list,
+                    weight_scale=weight_scale,
+                    x_scale=x_scale,
+                    bias=bias,
+                    swiglu_limit=swiglu_limit,
+                    use_mxfp_quant=False,
+                )
 
         # W4A8 mxfp
         if mxfp_quant_dtype == QuantType.W4A8MXFP:
@@ -1009,6 +1021,8 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         mxfp_quant_dtype: QuantType | None = None,
     ) -> torch.Tensor:
         if not use_mxfp_quant:
+            if act_quant_type == torch.float8_e4m3fn:
+                fallback_output_dtype = torch.bfloat16
             return BaseDeviceAdaptor.npu_grouped_matmul_gmm2(
                 hidden_states=hidden_states,
                 weight=weight,

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -440,7 +440,7 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
         )
 
     assert w1_scale is not None and w2_scale is not None
-    act_quant_type = torch.float8_e4m3fn
+    act_quant_type = torch.int8 if mlp_compute_input.quant.is_int_quant else torch.float8_e4m3fn
     weight_quant_type = torch.float8_e4m3fn
     scale_type = None
     per_token_scale_type = None

--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -223,7 +223,7 @@ def build_mlp_compute_input(
         weights=fused_experts_input.weights,
         quant=fused_experts_input.quant,
         fusion=fused_experts_input.quant.quant_type
-        in (QuantType.W8A8, QuantType.MXFP8, QuantType.MXFP4, QuantType.W4A8MXFP)
+        in (QuantType.W8A8, QuantType.MXFP8, QuantType.MXFP4, QuantType.W4A8MXFP, QuantType.W8A8FP8)
         and use_fusion_ops,
         activation=fused_experts_input.activation,
         need_trans=fused_experts_input.need_trans,

--- a/vllm_ascend/ops/fused_moe/moe_stage_params.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_params.py
@@ -76,12 +76,23 @@ class MoEQuantParams:
         return self.quant_type in (QuantType.W8A8, QuantType.W4A8)
 
     @property
+    def is_fp8(self) -> bool:
+        return self.quant_type == QuantType.W8A8FP8
+
+    @property
     def use_w4a8_per_channel_gmm_swiglu(self) -> bool:
         return self.quant_type == QuantType.W4A8 and self.is_per_channel_weight
 
     @property
     def dispatch_with_quant(self) -> bool:
-        return self.quant_type in (QuantType.W8A8, QuantType.W4A8, QuantType.MXFP8, QuantType.MXFP4, QuantType.W4A8MXFP)
+        return self.quant_type in (
+            QuantType.W8A8,
+            QuantType.W4A8,
+            QuantType.MXFP8,
+            QuantType.MXFP4,
+            QuantType.W4A8MXFP,
+            QuantType.W8A8FP8,
+        )
 
 
 __all__ = [

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -201,7 +201,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         # Only dispatch-enabled MXFP paths pass y_dtype through MC2.
         if (
             self.a5_need_extra_args
-            and token_dispatch_input.quant.is_mxfp
+            and (token_dispatch_input.quant.is_mxfp or token_dispatch_input.quant.is_fp8)
             and token_dispatch_input.quant.dispatch_with_quant
         ):
             y_dtype = torch.float8_e4m3fn
@@ -356,7 +356,9 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
         # TODO: After AllGather MXFP4 communication quantization thorough verification, remove this judgment.
         #  MXFP4 keeps dispatch unquantized in AllGather path, and quantizes again inside the MLP path.
         with_quant = (
-            token_dispatch_input.quant.dispatch_with_quant and token_dispatch_input.quant.quant_type != QuantType.MXFP4
+            token_dispatch_input.quant.dispatch_with_quant
+            and token_dispatch_input.quant.quant_type != QuantType.MXFP4
+            and token_dispatch_input.quant.quant_type != QuantType.W8A8FP8
         )
         is_mxfp = token_dispatch_input.quant.is_mxfp
         hidden_states = token_dispatch_input.hidden_states
@@ -466,7 +468,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         self,
         token_dispatch_input: MoETokenDispatchInput,
     ):
-        with_quant = token_dispatch_input.quant.is_int_quant
+        with_quant = token_dispatch_input.quant.is_int_quant or token_dispatch_input.quant.is_fp8
         hidden_states = token_dispatch_input.hidden_states
         topk_weights = token_dispatch_input.topk_weights
         topk_ids = token_dispatch_input.topk_ids
@@ -484,7 +486,10 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
 
         dynamic_scale_after_all2all = None
         if with_quant:
-            permutated_local_input_tokens, dynamic_scale = torch_npu.npu_dynamic_quant(permutated_local_input_tokens)
+            dst_type = torch.float8_e4m3fn if token_dispatch_input.quant.is_fp8 else torch.int8
+            permutated_local_input_tokens, dynamic_scale = torch_npu.npu_dynamic_quant(
+                permutated_local_input_tokens, dst_type=dst_type
+            )
             _, dynamic_scale_after_all2all, permute2_ep_all_to_all_handle = async_all_to_all(
                 dynamic_scale, output_splits, input_splits, self.ep_group
             )

--- a/vllm_ascend/quantization/compressed_tensors_config.py
+++ b/vllm_ascend/quantization/compressed_tensors_config.py
@@ -353,7 +353,10 @@ class AscendCompressedTensorsConfig(QuantizationConfig):
                 return "W8A8"
 
             if self._is_dynamic_token_w8a8(weight_quant, input_quant):
-                return "W8A8_DYNAMIC"
+                if weight_quant.type == QuantizationType.FLOAT and input_quant.type == QuantizationType.FLOAT:
+                    return "W8A8FP8_DYNAMIC"
+                else:
+                    return "W8A8_DYNAMIC"
 
             if self._is_dynamic_token_w4a8(weight_quant, input_quant):
                 return "W4A8_DYNAMIC"

--- a/vllm_ascend/quantization/methods/__init__.py
+++ b/vllm_ascend/quantization/methods/__init__.py
@@ -45,7 +45,12 @@ from .w4a4_mxfp4_flatquant import AscendW4A4MXFP4FlatQuantDynamicLinearMethod
 from .w4a8 import AscendW4A8DynamicFusedMoEMethod, AscendW4A8DynamicLinearMethod
 from .w4a8_mxfp4 import AscendW4A8MXFPDynamicFusedMoEMethod, AscendW4A8MXFPDynamicLinearMethod
 from .w4a16 import AscendW4A16FusedMoEMethod
-from .w8a8_dynamic import AscendW8A8DynamicFusedMoEMethod, AscendW8A8DynamicLinearMethod
+from .w8a8_dynamic import (
+    AscendW8A8DynamicFusedMoEMethod,
+    AscendW8A8DynamicLinearMethod,
+    AscendW8A8FP8DynamicFusedMoEMethod,
+    AscendW8A8FP8DynamicLinearMethod,
+)
 from .w8a8_mxfp8 import AscendW8A8MXFP8DynamicLinearMethod
 from .w8a8_pdmix import AscendW8A8PDMixFusedMoeMethod, AscendW8A8PDMixLinearMethod
 from .w8a8_static import AscendW8A8LinearMethod
@@ -80,6 +85,8 @@ __all__ = [
     "AscendW8A8LinearMethod",
     "AscendW8A8DynamicLinearMethod",
     "AscendW8A8DynamicFusedMoEMethod",
+    "AscendW8A8FP8DynamicLinearMethod",
+    "AscendW8A8FP8DynamicFusedMoEMethod",
     "AscendW8A8MXFP8DynamicLinearMethod",
     "AscendW8A8PDMixLinearMethod",
     "AscendW8A8PDMixFusedMoeMethod",

--- a/vllm_ascend/quantization/methods/__init__.py
+++ b/vllm_ascend/quantization/methods/__init__.py
@@ -45,15 +45,11 @@ from .w4a4_mxfp4_flatquant import AscendW4A4MXFP4FlatQuantDynamicLinearMethod
 from .w4a8 import AscendW4A8DynamicFusedMoEMethod, AscendW4A8DynamicLinearMethod
 from .w4a8_mxfp4 import AscendW4A8MXFPDynamicFusedMoEMethod, AscendW4A8MXFPDynamicLinearMethod
 from .w4a16 import AscendW4A16FusedMoEMethod
-from .w8a8_dynamic import (
-    AscendW8A8DynamicFusedMoEMethod,
-    AscendW8A8DynamicLinearMethod,
-    AscendW8A8FP8DynamicFusedMoEMethod,
-    AscendW8A8FP8DynamicLinearMethod,
-)
+from .w8a8_dynamic import AscendW8A8DynamicFusedMoEMethod, AscendW8A8DynamicLinearMethod
 from .w8a8_mxfp8 import AscendW8A8MXFP8DynamicLinearMethod
 from .w8a8_pdmix import AscendW8A8PDMixFusedMoeMethod, AscendW8A8PDMixLinearMethod
 from .w8a8_static import AscendW8A8LinearMethod
+from .w8a8fp8_dynamic import AscendW8A8FP8DynamicFusedMoEMethod, AscendW8A8FP8DynamicLinearMethod
 from .w8a16 import AscendW8A16LinearMethod
 
 

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -54,10 +54,11 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
     """
 
     def __init__(self):
-        pass
+        self.is_fp8 = False
 
     def get_weight(self, input_size: int, output_size: int, params_dtype: torch.dtype) -> dict[str, Any]:
-        params_dict = {"weight": torch.empty(output_size, input_size, dtype=torch.int8)}
+        weight_dtype = torch.float8_e4m3fn if self.is_fp8 else torch.int8
+        params_dict = {"weight": torch.empty(output_size, input_size, dtype=weight_dtype)}
         return params_dict
 
     def get_perchannel_param(
@@ -77,7 +78,8 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
         bias: torch.Tensor | None = None,
         tp_rank: int | None = 0,
     ) -> torch.Tensor:
-        quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(x)
+        dst_type = torch.float8_e4m3fn if self.is_fp8 else torch.int8
+        quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(x, dst_type=dst_type)
         need_unsqz = False
         if pertoken_scale.dim() == 2:
             need_unsqz = True
@@ -110,14 +112,19 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
                 dim=-1,
             )
         else:
+            weight_scale = layer.weight_scale_fp32 if self.is_fp8 else layer.weight_scale
             output = torch_npu.npu_quant_matmul(
                 quantized_x,
                 layer.weight,
-                layer.weight_scale,
+                weight_scale,
                 pertoken_scale=pertoken_scale,
-                bias=bias,
+                bias=bias if not self.is_fp8 else None,
                 output_dtype=x.dtype,
             )
+            # there is a bug in npu_quant_matmul for fp8 with bias
+            # remove this fallback if the bug is fixed
+            if self.is_fp8 and bias is not None:
+                output = (output + bias).to(x.dtype)
         if need_unsqz:
             output = output.unsqueeze(dim=1)
         return output
@@ -143,7 +150,8 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
             del layer.weight_offset
         else:
             # cast quantized weight tensors in NZ format for higher inference speed
-            layer.weight.data = maybe_trans_nz(layer.weight.data)
+            if not self.is_fp8:
+                layer.weight.data = maybe_trans_nz(layer.weight.data)
             layer.weight_scale.data = layer.weight_scale.data.flatten()
             layer.weight_scale_fp32 = layer.weight_scale.data.to(torch.float32)
             layer.weight_offset.data = layer.weight_offset.data.flatten()
@@ -153,10 +161,9 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
 class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
     """FusedMoE method for Ascend W8A8_DYNAMIC."""
 
-    # Declare the quantization type for this scheme
-    quant_type: QuantType = QuantType.W8A8
-
     def __init__(self):
+        self.quant_type: QuantType = QuantType.W8A8
+        self.is_fp8 = False
         vllm_config = get_current_vllm_config()
         ascend_config = get_ascend_config()
         self.use_aclgraph = (
@@ -185,12 +192,13 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
     def get_weight(
         self, num_experts: int, intermediate_size_per_partition: int, hidden_sizes: int, params_dtype: torch.dtype
     ) -> dict[str, Any]:
+        weight_dtype = torch.float8_e4m3fn if self.is_fp8 else torch.int8
         param_dict = {}
         param_dict["w13_weight"] = torch.empty(
-            num_experts, 2 * intermediate_size_per_partition, hidden_sizes, dtype=torch.int8
+            num_experts, 2 * intermediate_size_per_partition, hidden_sizes, dtype=weight_dtype
         )
         param_dict["w2_weight"] = torch.empty(
-            num_experts, hidden_sizes, intermediate_size_per_partition, dtype=torch.int8
+            num_experts, hidden_sizes, intermediate_size_per_partition, dtype=weight_dtype
         )
         return param_dict
 
@@ -315,7 +323,13 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
             w1 = [layer.w13_weight]
             w1_scale = [layer.fused_w1_scale] if fused_scale_flag else [layer.w13_weight_scale_fp32]
             w2 = [layer.w2_weight]
-            w2_scale = [layer.fused_w2_scale] if fused_scale_flag else [layer.w2_weight_scale]
+            w2_scale = (
+                [layer.fused_w2_scale]
+                if fused_scale_flag
+                else [layer.w2_weight_scale_fp32]
+                if self.is_fp8
+                else [layer.w2_weight_scale]
+            )
 
         w1_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
         w2_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
@@ -352,12 +366,15 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
         layer.w2_weight.data = layer.w2_weight.data.transpose(1, 2).contiguous()
         # TODO(zzzzwwjj): Currently, `torch_npu.npu_grouped_matmul_swiglu_quant`
         # can only support weight nz.
-        layer.w13_weight.data = torch_npu.npu_format_cast(layer.w13_weight.data, ACL_FORMAT_FRACTAL_NZ)
-        layer.w2_weight.data = torch_npu.npu_format_cast(layer.w2_weight.data, ACL_FORMAT_FRACTAL_NZ)
+        if not self.is_fp8:
+            layer.w13_weight.data = torch_npu.npu_format_cast(layer.w13_weight.data, ACL_FORMAT_FRACTAL_NZ)
+            layer.w2_weight.data = torch_npu.npu_format_cast(layer.w2_weight.data, ACL_FORMAT_FRACTAL_NZ)
         layer.w13_weight_scale.data = layer.w13_weight_scale.data.view(layer.w13_weight_scale.data.shape[0], -1)
         layer.w13_weight_scale_fp32 = layer.w13_weight_scale.data.to(torch.float32)
         layer.w13_weight_offset.data = layer.w13_weight_offset.data.view(layer.w13_weight_offset.data.shape[0], -1)
         layer.w2_weight_scale.data = layer.w2_weight_scale.data.view(layer.w2_weight_scale.data.shape[0], -1)
+        if self.is_fp8:
+            layer.w2_weight_scale_fp32 = layer.w2_weight_scale.data.to(torch.float32)
         layer.w2_weight_offset.data = layer.w2_weight_offset.data.view(layer.w2_weight_offset.data.shape[0], -1)
 
         if get_ascend_config().enable_fused_mc2 == 1:
@@ -389,3 +406,25 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
                 del layer.fused_w1_scale
                 del layer.fused_w2_scale
             torch.npu.empty_cache()
+
+
+@register_scheme("W8A8FP8_DYNAMIC", "linear")
+class AscendW8A8FP8DynamicLinearMethod(AscendW8A8DynamicLinearMethod):
+    """Linear method for Ascend W8A8FP8_DYNAMIC.
+
+    This scheme uses FP8 dynamic per-token quantization for activations
+    and FP8 per-channel quantization for weights.
+    """
+
+    def __init__(self):
+        self.is_fp8 = True
+
+
+@register_scheme("W8A8FP8_DYNAMIC", "moe")
+class AscendW8A8FP8DynamicFusedMoEMethod(AscendW8A8DynamicFusedMoEMethod):
+    """FusedMoE method for Ascend W8A8FP8_DYNAMIC."""
+
+    def __init__(self):
+        super().__init__()
+        self.quant_type: QuantType = QuantType.W8A8FP8
+        self.is_fp8 = True

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -53,12 +53,13 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
     and per-channel quantization for weights.
     """
 
+    act_quant_type: torch.dtype = torch.int8
+
     def __init__(self):
-        self.is_fp8 = False
+        pass
 
     def get_weight(self, input_size: int, output_size: int, params_dtype: torch.dtype) -> dict[str, Any]:
-        weight_dtype = torch.float8_e4m3fn if self.is_fp8 else torch.int8
-        params_dict = {"weight": torch.empty(output_size, input_size, dtype=weight_dtype)}
+        params_dict = {"weight": torch.empty(output_size, input_size, dtype=torch.int8)}
         return params_dict
 
     def get_perchannel_param(
@@ -78,8 +79,7 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
         bias: torch.Tensor | None = None,
         tp_rank: int | None = 0,
     ) -> torch.Tensor:
-        dst_type = torch.float8_e4m3fn if self.is_fp8 else torch.int8
-        quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(x, dst_type=dst_type)
+        quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(x, dst_type=self.act_quant_type)
         need_unsqz = False
         if pertoken_scale.dim() == 2:
             need_unsqz = True
@@ -112,19 +112,14 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
                 dim=-1,
             )
         else:
-            weight_scale = layer.weight_scale_fp32 if self.is_fp8 else layer.weight_scale
             output = torch_npu.npu_quant_matmul(
                 quantized_x,
                 layer.weight,
-                weight_scale,
+                layer.weight_scale,
                 pertoken_scale=pertoken_scale,
-                bias=bias if not self.is_fp8 else None,
+                bias=bias if self.act_quant_type == torch.int8 else None,
                 output_dtype=x.dtype,
             )
-            # there is a bug in npu_quant_matmul for fp8 with bias
-            # remove this fallback if the bug is fixed
-            if self.is_fp8 and bias is not None:
-                output = (output + bias).to(x.dtype)
         if need_unsqz:
             output = output.unsqueeze(dim=1)
         return output
@@ -150,7 +145,7 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
             del layer.weight_offset
         else:
             # cast quantized weight tensors in NZ format for higher inference speed
-            if not self.is_fp8:
+            if self.act_quant_type == torch.int8:
                 layer.weight.data = maybe_trans_nz(layer.weight.data)
             layer.weight_scale.data = layer.weight_scale.data.flatten()
             layer.weight_scale_fp32 = layer.weight_scale.data.to(torch.float32)
@@ -161,9 +156,10 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
 class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
     """FusedMoE method for Ascend W8A8_DYNAMIC."""
 
+    # Declare the quantization type for this scheme
+    quant_type: QuantType = QuantType.W8A8
+
     def __init__(self):
-        self.quant_type: QuantType = QuantType.W8A8
-        self.is_fp8 = False
         vllm_config = get_current_vllm_config()
         ascend_config = get_ascend_config()
         self.use_aclgraph = (
@@ -192,13 +188,12 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
     def get_weight(
         self, num_experts: int, intermediate_size_per_partition: int, hidden_sizes: int, params_dtype: torch.dtype
     ) -> dict[str, Any]:
-        weight_dtype = torch.float8_e4m3fn if self.is_fp8 else torch.int8
         param_dict = {}
         param_dict["w13_weight"] = torch.empty(
-            num_experts, 2 * intermediate_size_per_partition, hidden_sizes, dtype=weight_dtype
+            num_experts, 2 * intermediate_size_per_partition, hidden_sizes, dtype=torch.int8
         )
         param_dict["w2_weight"] = torch.empty(
-            num_experts, hidden_sizes, intermediate_size_per_partition, dtype=weight_dtype
+            num_experts, hidden_sizes, intermediate_size_per_partition, dtype=torch.int8
         )
         return param_dict
 
@@ -323,13 +318,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
             w1 = [layer.w13_weight]
             w1_scale = [layer.fused_w1_scale] if fused_scale_flag else [layer.w13_weight_scale_fp32]
             w2 = [layer.w2_weight]
-            w2_scale = (
-                [layer.fused_w2_scale]
-                if fused_scale_flag
-                else [layer.w2_weight_scale_fp32]
-                if self.is_fp8
-                else [layer.w2_weight_scale]
-            )
+            w2_scale = [layer.fused_w2_scale] if fused_scale_flag else [layer.w2_weight_scale]
 
         w1_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
         w2_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
@@ -366,15 +355,13 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
         layer.w2_weight.data = layer.w2_weight.data.transpose(1, 2).contiguous()
         # TODO(zzzzwwjj): Currently, `torch_npu.npu_grouped_matmul_swiglu_quant`
         # can only support weight nz.
-        if not self.is_fp8:
+        if self.quant_type == QuantType.W8A8:
             layer.w13_weight.data = torch_npu.npu_format_cast(layer.w13_weight.data, ACL_FORMAT_FRACTAL_NZ)
             layer.w2_weight.data = torch_npu.npu_format_cast(layer.w2_weight.data, ACL_FORMAT_FRACTAL_NZ)
         layer.w13_weight_scale.data = layer.w13_weight_scale.data.view(layer.w13_weight_scale.data.shape[0], -1)
         layer.w13_weight_scale_fp32 = layer.w13_weight_scale.data.to(torch.float32)
         layer.w13_weight_offset.data = layer.w13_weight_offset.data.view(layer.w13_weight_offset.data.shape[0], -1)
         layer.w2_weight_scale.data = layer.w2_weight_scale.data.view(layer.w2_weight_scale.data.shape[0], -1)
-        if self.is_fp8:
-            layer.w2_weight_scale_fp32 = layer.w2_weight_scale.data.to(torch.float32)
         layer.w2_weight_offset.data = layer.w2_weight_offset.data.view(layer.w2_weight_offset.data.shape[0], -1)
 
         if get_ascend_config().enable_fused_mc2 == 1:
@@ -406,25 +393,3 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
                 del layer.fused_w1_scale
                 del layer.fused_w2_scale
             torch.npu.empty_cache()
-
-
-@register_scheme("W8A8FP8_DYNAMIC", "linear")
-class AscendW8A8FP8DynamicLinearMethod(AscendW8A8DynamicLinearMethod):
-    """Linear method for Ascend W8A8FP8_DYNAMIC.
-
-    This scheme uses FP8 dynamic per-token quantization for activations
-    and FP8 per-channel quantization for weights.
-    """
-
-    def __init__(self):
-        self.is_fp8 = True
-
-
-@register_scheme("W8A8FP8_DYNAMIC", "moe")
-class AscendW8A8FP8DynamicFusedMoEMethod(AscendW8A8DynamicFusedMoEMethod):
-    """FusedMoE method for Ascend W8A8FP8_DYNAMIC."""
-
-    def __init__(self):
-        super().__init__()
-        self.quant_type: QuantType = QuantType.W8A8FP8
-        self.is_fp8 = True

--- a/vllm_ascend/quantization/methods/w8a8fp8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8fp8_dynamic.py
@@ -1,0 +1,102 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from typing import Any
+
+import torch
+
+from .base import QuantType
+from .registry import register_scheme
+from .w8a8_dynamic import AscendW8A8DynamicFusedMoEMethod, AscendW8A8DynamicLinearMethod
+
+
+@register_scheme("W8A8FP8_DYNAMIC", "linear")
+class AscendW8A8FP8DynamicLinearMethod(AscendW8A8DynamicLinearMethod):
+    """Linear method for Ascend W8A8FP8_DYNAMIC.
+
+    This scheme uses FP8 dynamic per-token quantization for activations
+    and FP8 per-channel quantization for weights.
+    """
+
+    act_quant_type: torch.dtype = torch.float8_e4m3fn
+
+    def __init__(self):
+        pass
+
+    def get_weight(self, input_size: int, output_size: int, params_dtype: torch.dtype) -> dict[str, Any]:
+        params_dict = {"weight": torch.empty(output_size, input_size, dtype=torch.float8_e4m3fn)}
+        return params_dict
+
+    def get_perchannel_param(
+        self,
+        output_size: int,
+        params_dtype: torch.dtype,
+    ) -> dict[str, Any]:
+        params_dict = {}
+        params_dict["weight_scale"] = torch.empty(output_size, 1, dtype=torch.float32)
+        params_dict["weight_offset"] = torch.empty(output_size, 1, dtype=params_dtype)
+        return params_dict
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+        tp_rank: int | None = 0,
+    ) -> torch.Tensor:
+        output = super().apply(layer, x, bias, tp_rank)
+        # TODO: there is a bug in npu_quant_matmul for fp8 with bias
+        # after the bug is fixed, the whole apply method can be removed.
+        if bias is not None:
+            output = (output + bias).to(x.dtype)
+        return output
+
+
+@register_scheme("W8A8FP8_DYNAMIC", "moe")
+class AscendW8A8FP8DynamicFusedMoEMethod(AscendW8A8DynamicFusedMoEMethod):
+    """FusedMoE method for Ascend W8A8FP8_DYNAMIC."""
+
+    quant_type: QuantType = QuantType.W8A8FP8
+
+    def __init__(self):
+        super().__init__()
+
+    def get_weight(
+        self, num_experts: int, intermediate_size_per_partition: int, hidden_sizes: int, params_dtype: torch.dtype
+    ) -> dict[str, Any]:
+        param_dict = {}
+        param_dict["w13_weight"] = torch.empty(
+            num_experts, 2 * intermediate_size_per_partition, hidden_sizes, dtype=torch.float8_e4m3fn
+        )
+        param_dict["w2_weight"] = torch.empty(
+            num_experts, hidden_sizes, intermediate_size_per_partition, dtype=torch.float8_e4m3fn
+        )
+        return param_dict
+
+    def get_dynamic_quant_param(
+        self, num_experts: int, intermediate_size_per_partition: int, hidden_sizes: int, params_dtype: torch.dtype
+    ) -> dict[str, Any]:
+        param_dict = {}
+        param_dict["w13_weight_scale"] = torch.empty(
+            num_experts, 2 * intermediate_size_per_partition, 1, dtype=torch.float32
+        )
+        param_dict["w13_weight_offset"] = torch.empty(
+            num_experts, 2 * intermediate_size_per_partition, 1, dtype=params_dtype
+        )
+        param_dict["w2_weight_scale"] = torch.empty(num_experts, hidden_sizes, 1, dtype=torch.float32)
+        param_dict["w2_weight_offset"] = torch.empty(num_experts, hidden_sizes, 1, dtype=params_dtype)
+        return param_dict

--- a/vllm_ascend/quantization/quant_type.py
+++ b/vllm_ascend/quantization/quant_type.py
@@ -33,3 +33,4 @@ class QuantType(Enum):
     W4A16 = 4
     MXFP4 = 5
     W4A8MXFP = 6
+    W8A8FP8 = 7


### PR DESCRIPTION
### What this PR does / why we need it?
This PR introduces support for `W8A8FP8` dynamic quantization on Ascend NPU devices. It adds the `W8A8FP8` quantization type to the `QuantType` enum and implements the corresponding linear and fused MoE schemes (`AscendW8A8FP8DynamicLinearMethod` and `AscendW8A8FP8DynamicFusedMoEMethod`). The changes update device operations, token dispatching, and compressed tensor configurations to handle FP8 dynamic per-token quantization for activations and FP8 per-channel quantization for weights.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Test on models like GLM-4.7-FP8, Qwen3.6-35B-A3B-FP8-dynamic


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
