### PR TITLE
[BugFix] Guard against all-placeholder speculative output

### DIFF
--- a/tests/ut/sample/test_rejection_sampler.py
+++ b/tests/ut/sample/test_rejection_sampler.py
@@ -4,6 +4,7 @@ import torch
 
 from tests.ut.base import TestBase
 from vllm_ascend.sample.rejection_sampler import (
+    _repair_empty_output_rows,
     expand_batch_to_tokens,
     expand_pytorch,
     rejection_greedy_sample_pytorch,
@@ -29,6 +30,58 @@ def mock_pin_memory(original_func):
 
 
 class TestAscendRejectionSampler(TestBase):
+    def test_repair_empty_output_rows(self):
+        output_token_ids = torch.tensor(
+            [
+                [-1, -1, -1, -1],
+                [7, -1, -1, -1],
+                [-1, -1, -1, -1],
+                [-1, -1, -1, -1],
+            ],
+            dtype=torch.int32,
+        )
+        num_draft_tokens = [2, 1, 1, 0]
+        cu_num_draft_tokens = torch.tensor([2, 3, 4, 4])
+        target_logits = torch.tensor(
+            [
+                [0.1, 0.2, 0.3],
+                [0.3, 0.2, 0.1],
+                [0.2, 0.3, 0.1],
+                [0.1, 0.9, 0.2],
+            ],
+        )
+        target_indices = torch.tensor(
+            [
+                [10, 11, 12],
+                [20, 21, 22],
+                [30, 31, 32],
+                [80, 88, 89],
+            ],
+        )
+        recovered_token_ids = torch.tensor([42, 43, 44, PLACEHOLDER_TOKEN_ID])
+        bonus_token_ids = torch.tensor([[100], [200], [300], [400]])
+
+        _repair_empty_output_rows(
+            output_token_ids,
+            num_draft_tokens,
+            cu_num_draft_tokens,
+            target_logits,
+            target_indices,
+            recovered_token_ids,
+            bonus_token_ids,
+        )
+
+        expected = torch.tensor(
+            [
+                [42, -1, -1, -1],
+                [7, -1, -1, -1],
+                [88, -1, -1, -1],
+                [400, -1, -1, -1],
+            ],
+            dtype=torch.int32,
+        )
+        assert torch.equal(output_token_ids, expected)
+
     @patch("torch.arange", new=mock_pin_memory(torch.arange))
     @patch("torch.ones", new=mock_pin_memory(torch.ones))
     @patch("torch.full", new=mock_pin_memory(torch.full))

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -387,6 +387,16 @@ def rejection_sample(
                     is_greedy,
                 )
         if sampling_metadata.all_greedy:
+            _repair_empty_output_rows(
+                output_token_ids,
+                num_draft_tokens,
+                cu_num_draft_tokens,
+                target_logits,
+                target_indices,
+                None,
+                bonus_token_ids,
+                target_token_ids=target_argmax,
+            )
             return output_token_ids
 
     # For random sampling with selected logits
@@ -613,7 +623,69 @@ def rejection_sample(
                     enable_reduce_sampling=False,
                 )
 
+    _repair_empty_output_rows(
+        output_token_ids,
+        num_draft_tokens,
+        cu_num_draft_tokens,
+        target_logits,
+        target_indices,
+        recovered_token_ids,
+        bonus_token_ids,
+    )
     return output_token_ids
+
+
+def _repair_empty_output_rows(
+    output_token_ids: torch.Tensor,
+    num_draft_tokens: list[int],
+    cu_num_draft_tokens: torch.Tensor,
+    target_logits: torch.Tensor,
+    target_indices: torch.Tensor | None,
+    recovered_token_ids: torch.Tensor | None,
+    bonus_token_ids: torch.Tensor,
+    target_token_ids: torch.Tensor | None = None,
+) -> None:
+    """Ensure every spec decode row returns at least one real token."""
+    batch_size = output_token_ids.shape[0]
+    if batch_size == 0:
+        return
+
+    device = output_token_ids.device
+    output_dtype = output_token_ids.dtype
+    empty_rows = (output_token_ids == PLACEHOLDER_TOKEN_ID).all(dim=1)
+    draft_counts = torch.tensor(num_draft_tokens, device=device, dtype=torch.long)
+    has_draft = draft_counts > 0
+    first_token_indices = (cu_num_draft_tokens.to(torch.long) - draft_counts).clamp(
+        min=0,
+        max=max(target_logits.shape[0] - 1, 0),
+    )
+
+    bonus_fallback = bonus_token_ids.squeeze(1).to(dtype=output_dtype)
+    if target_token_ids is not None and target_token_ids.shape[0] > 0:
+        target_fallback = target_token_ids[first_token_indices].to(dtype=output_dtype)
+    elif target_logits.shape[0] == 0:
+        target_fallback = bonus_fallback
+    else:
+        local_argmax = target_logits[first_token_indices].argmax(dim=-1)
+        if target_indices is None:
+            target_fallback = local_argmax
+        else:
+            target_fallback = target_indices[first_token_indices, local_argmax]
+        target_fallback = target_fallback.to(dtype=output_dtype)
+
+    fallback = target_fallback
+    if recovered_token_ids is not None and recovered_token_ids.shape[0] > 0:
+        recovered_indices = first_token_indices.clamp(max=recovered_token_ids.shape[0] - 1)
+        recovered_fallback = recovered_token_ids[recovered_indices].to(dtype=output_dtype)
+        fallback = torch.where(has_draft, recovered_fallback, bonus_fallback)
+
+    fallback = torch.where(
+        has_draft & (fallback == PLACEHOLDER_TOKEN_ID),
+        target_fallback,
+        fallback,
+    )
+    fallback = torch.where(has_draft, fallback, bonus_fallback)
+    output_token_ids[:, 0] = torch.where(empty_rows, fallback, output_token_ids[:, 0])
 
 
 def expand_batch_to_tokens(


### PR DESCRIPTION
### Problem
Speculative rejection sampling can silently return a row that is entirely `PLACEHOLDER_TOKEN_ID` (`-1`). When `RejectionSampler.parse_output` filters that row, the scheduler receives an empty token list, so the request can remain `RUNNING` without making progress in PD serving.


This has been observed under parallel PD workloads; using TP=2 only lowers the reproduction probability and does not eliminate the failure, so this guard is still needed as a defensive fallback while the hidden-state NaN root cause is investigated.

### Fix
Add a final guard before `rejection_sample` returns `output_token_ids`. The guard only repairs rows that are all placeholders:

- rows with draft tokens first use the corresponding first `recovered_token_ids` entry
- if that recovered token is still `-1`, fall back to the target argmax token, including `target_indices` mapping for reduce sampling
- rows without draft tokens use `bonus_token_ids`
- rows that already contain any real token are left unchanged

### Verification
- `python -m py_compile vllm_ascend/sample/rejection_sampler.py tests/ut/sample/test_rejection_sampler.py`
- `python -m pytest tests/ut/sample/test_rejection_sampler.py::TestAscendRejectionSampler::test_repair_empty_output_rows -q`
- `python -m pytest tests/ut/sample/test_rejection_sampler.py -q`
- `python -m ruff check vllm_ascend/sample/rejection_sampler.py tests/ut/sample/test_rejection_sampler.py`
- `python -m ruff format --check vllm_ascend/sample/rejection_sampler.py tests/ut/sample/test_rejection_sampler.py`
