### PR TITLE
[CI] Support /nightly slash command to trigger PR-based nightly tests

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -63,6 +63,11 @@ on:
         type: string
         default: ''
         description: branch name used as prefix in artifact names to distinguish dual-branch test runs
+      request_id:
+        required: false
+        type: string
+        default: ''
+        description: non-empty when triggered by PR /nightly command
     secrets:
       KUBECONFIG_B64:
         required: true
@@ -99,7 +104,7 @@ jobs:
     steps:
       - name: Decode kubeconfig
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ -n "${{ inputs.request_id }}" ]; then
             if [ "${{ inputs.soc_version }}" = "a3" ]; then
               # NOTE: This is too hack, we should find a better way to manage kubeconfig for pr tests.
               cp /root/.cache/.kube/kubeconfig.yaml "$KUBECONFIG"
@@ -193,7 +198,7 @@ jobs:
           config_file_path="${{ inputs.config_file_path }}"
           config_base_path="${{ inputs.config_base_path }}"
           fail_tag="FAIL_TAG_${{ inputs.config_file_path }}"
-          is_pr_test="${{ github.event_name == 'pull_request' }}"
+          is_pr_test="${{ inputs.request_id != '' }}"
           vllm_ascend_ref="${{ inputs.vllm_ascend_ref }}"
           vllm_ascend_remote_url="${{ inputs.vllm_ascend_remote_url }}"
           runner="${{ inputs.soc_version }}"

--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -49,6 +49,16 @@ on:
         type: string
         default: ''
         description: branch name used as prefix in artifact/benchmark names to distinguish dual-branch test runs
+      request_id:
+        required: false
+        type: string
+        default: ''
+        description: non-empty when triggered by PR /nightly command
+      vllm_ascend_ref:
+        required: false
+        type: string
+        default: ''
+        description: PR commit SHA for PR-triggered checkout
     secrets:
       OBS_ACCESS_KEY:
         required: false
@@ -96,21 +106,22 @@ jobs:
           pip install uv
 
       - name: uninstall vlm vllm-ascend and remove code (if pr test)
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ inputs.request_id != '' }}
         run: |
           pip uninstall -y vllm-ascend || true
           cp -r /vllm-workspace/vllm-ascend/benchmark /tmp/aisbench-backup || true
           rm -rf  /vllm-workspace/vllm-ascend
 
       - name: Checkout vllm-project/vllm-ascend repo
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ inputs.request_id != '' }}
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.vllm_ascend_ref }}
           path: ./temp-vllm-ascend
           fetch-depth: 1
 
       - name: Move code to /vllm-workspace
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ inputs.request_id != '' }}
         run: |
           mv ./temp-vllm-ascend /vllm-workspace/vllm-ascend
           ls -R /vllm-workspace
@@ -121,7 +132,7 @@ jobs:
           echo "MAX_JOBS=$((CARDS * 23))" >> $GITHUB_ENV
 
       - name: Install vllm-project/vllm-ascend
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ inputs.request_id != '' }}
         working-directory: /vllm-workspace/vllm-ascend
         env:
           MAX_JOBS: ${{ env.MAX_JOBS }}
@@ -133,7 +144,7 @@ jobs:
           uv pip install -e .
 
       - name: Install aisbench
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ inputs.request_id != '' }}
         shell: bash -l {0}
         run: |
           cp -r /tmp/aisbench-backup /vllm-workspace/vllm-ascend/benchmark

--- a/.github/workflows/_e2e_nightly_single_node_models.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_models.yaml
@@ -40,6 +40,16 @@ on:
       is_run:
         required: true
         type: boolean
+      request_id:
+        required: false
+        type: string
+        default: ''
+        description: non-empty when triggered by PR /nightly command
+      vllm_ascend_ref:
+        required: false
+        type: string
+        default: ''
+        description: PR commit SHA for PR-triggered checkout
     secrets:
       OBS_ACCESS_KEY:
         required: false
@@ -84,20 +94,21 @@ jobs:
           pip install uv
 
       - name: Uninstall vllm and remove code (if pr test)
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ inputs.request_id != '' }}
         run: |
           pip uninstall -y vllm-ascend || true
           rm -rf  /vllm-workspace/vllm-ascend
 
       - name: Checkout vllm-project/vllm-ascend repo
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ inputs.request_id != '' }}
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.vllm_ascend_ref }}
           path: ./temp-vllm-ascend
           fetch-depth: 1
 
       - name: Move vllm-ascend code to /vllm-workspace
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ inputs.request_id != '' }}
         run: |
           mv ./temp-vllm-ascend /vllm-workspace/vllm-ascend
 
@@ -107,7 +118,7 @@ jobs:
           echo "MAX_JOBS=$((CARDS * 23))" >> $GITHUB_ENV
 
       - name: Install vllm-project/vllm-ascend
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ inputs.request_id != '' }}
         working-directory: /vllm-workspace/vllm-ascend
         env:
           MAX_JOBS: ${{ env.MAX_JOBS }}

--- a/.github/workflows/pr_nightly_command.yml
+++ b/.github/workflows/pr_nightly_command.yml
@@ -35,19 +35,30 @@ jobs:
       test_cases: ${{ steps.resolve.outputs.test_cases }}
       branch: ${{ steps.resolve.outputs.branch }}
       is_authorized: ${{ steps.auth.outputs.is_authorized }}
+      dispatch_a2: ${{ steps.resolve.outputs.dispatch_a2 }}
+      dispatch_a3: ${{ steps.resolve.outputs.dispatch_a3 }}
+      vllm_ascend_ref: ${{ steps.resolve.outputs.vllm_ascend_ref }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          sparse-checkout: |
+            .github/workflows/scripts/resolve_nightly_tests.py
+          sparse-checkout-cone-mode: false
+
       - name: Check user authorization
         id: auth
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           ACTOR='${{ github.event.client_payload.github.payload.comment.user.login }}'
           REPO='${{ github.event.client_payload.github.payload.repository.full_name }}'
 
-          PERMISSION=$(gh api "repos/$REPO/collaborators/$ACTOR/permission" --jq '.permission')
-          case "$PERMISSION" in
+          ROLE_NAME=$(gh api "repos/$REPO/collaborators/$ACTOR/permission" --jq '.role_name')
+          case "$ROLE_NAME" in
             triage|write|maintain|admin)
-              echo "User $ACTOR has $PERMISSION permission, authorized."
+              echo "User $ACTOR has $ROLE_NAME role, authorized."
               echo "is_authorized=true" >> "$GITHUB_OUTPUT"
               ;;
             *)
@@ -56,26 +67,15 @@ jobs:
               ;;
           esac
 
-      - name: Post workflow URL
-        if: steps.auth.outputs.is_authorized == 'true'
-        uses: peter-evans/create-or-update-comment@v5
-        with:
-          token: ${{ secrets.PAT_TOKEN }}
-          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
-          body: |
-            nightly command triggered. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
-          reactions: rocket
-
       - name: Post unauthorized comment
         if: steps.auth.outputs.is_authorized == 'false'
         uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ secrets.PAT_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
-            nightly command failed: you do not have permission. Only users with triage+ permission can trigger /nightly.
+            [Bot]: nightly command failed: you do not have permission. Only users with triage+ permission can trigger /nightly.
           reactions: confused
 
       - name: Fail if unauthorized
@@ -85,12 +85,17 @@ jobs:
       - name: Resolve test cases and branch
         id: resolve
         if: steps.auth.outputs.is_authorized == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          ALL_ARGS: ${{ github.event.client_payload.slash_command.args.all }}
+          PR_URL: ${{ github.event.client_payload.github.payload.issue.pull_request.url }}
         run: |
-          ALL_ARGS=$(echo '${{ github.event.client_payload.slash_command.args.all }}' | xargs)
+          ALL_ARGS=$(echo "$ALL_ARGS" | xargs)
           if [ -z "$ALL_ARGS" ]; then
-            echo "test_cases=all" >> "$GITHUB_OUTPUT"
-            echo "branch=main" >> "$GITHUB_OUTPUT"
-            exit 0
+            gh api "repos/${{ github.event.client_payload.github.payload.repository.full_name }}/issues/${{ github.event.client_payload.github.payload.issue.number }}/comments" \
+              -f body="[Bot]: \`/nightly\` without test names will not dispatch. Please specify test names, e.g. \`/nightly all\` or \`/nightly test_custom_op\`." \
+              --silent
+            exit 1
           fi
 
           BRANCH="main"
@@ -111,49 +116,128 @@ jobs:
             fi
           done
 
-          # If --branch was the last word (no branch name given), ignore it
-          if [ "$NEXT_IS_BRANCH" = "1" ]; then
-            NEXT_IS_BRANCH=0
+          if [ -z "$TEST_CASES" ]; then
+            gh api "repos/${{ github.event.client_payload.github.payload.repository.full_name }}/issues/${{ github.event.client_payload.github.payload.issue.number }}/comments" \
+              -f body="[Bot]: \`/nightly\` without test names will not dispatch. Please specify test names, e.g. \`/nightly all\` or \`/nightly test_custom_op\`." \
+              --silent
+            exit 1
           fi
 
-          if [ -z "$TEST_CASES" ]; then
-            TEST_CASES="all"
-          fi
+
           echo "test_cases=$TEST_CASES" >> "$GITHUB_OUTPUT"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+          PR_BRANCH=$(gh api "$PR_URL" --jq '.head.ref')
+          HEAD_REPO=$(gh api "$PR_URL" --jq '.head.repo.full_name')
+          PR_SHA=$(gh api "$PR_URL" --jq '.head.sha')
+          echo "vllm_ascend_ref=$PR_SHA" >> "$GITHUB_OUTPUT"
+
+          if [ "$TEST_CASES" = "all" ]; then
+            echo "dispatch_a2=true" >> "$GITHUB_OUTPUT"
+            echo "dispatch_a3=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Parse test matrices from the PR branch's workflow YAML files
+          pip install pyyaml -q 2>/dev/null
+
+          A2_RAW=$(gh api "repos/$HEAD_REPO/contents/.github/workflows/schedule_nightly_test_a2.yaml?ref=$PR_BRANCH" --jq '.content' 2>/dev/null || echo "")
+          export A2_RAW
+          A3_RAW=$(gh api "repos/$HEAD_REPO/contents/.github/workflows/schedule_nightly_test_a3.yaml?ref=$PR_BRANCH" --jq '.content' 2>/dev/null || echo "")
+          export A3_RAW
+          A2_ACC_GROUPS=$(gh api "repos/$HEAD_REPO/contents/tests/e2e/models/configs/accuracy_groups_a2.json?ref=$PR_BRANCH" --jq '.content' 2>/dev/null || echo "")
+          export A2_ACC_GROUPS
+          export TEST_CASES
+
+          python3 .github/workflows/scripts/resolve_nightly_tests.py
 
   dispatch-a2:
     name: Trigger Nightly-A2
     needs: [authorize]
-    if: needs.authorize.outputs.is_authorized == 'true'
+    if: needs.authorize.outputs.is_authorized == 'true' && needs.authorize.outputs.dispatch_a2 == 'true'
     runs-on: ubuntu-latest
+    outputs:
+      a2_run_id: ${{ steps.dispatch_a2.outputs.a2_run_id }}
     steps:
       - name: Dispatch nightly-a2 workflow
+        id: dispatch_a2
         env:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           REPO='${{ github.event.client_payload.github.payload.repository.full_name }}'
+          REQUEST_ID='${{ github.run_id }}'
           gh workflow run schedule_nightly_test_a2.yaml \
             --repo "$REPO" \
             --ref main \
             -f test_cases='${{ needs.authorize.outputs.test_cases }}' \
-            -f vllm_ascend_branch='${{ needs.authorize.outputs.branch }}'
+            -f vllm_ascend_branch='${{ needs.authorize.outputs.branch }}' \
+            -f request_id="$REQUEST_ID" \
+            -f skip_build_image=true \
+            -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}'
+          sleep 8
+          A2_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_nightly_test_a2.yaml/runs?per_page=1" \
+            --jq '.workflow_runs[0].id')
+          echo "a2_run_id=$A2_RUN_ID" >> "$GITHUB_OUTPUT"
           echo "Dispatched Nightly-A2 with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}'"
 
   dispatch-a3:
     name: Trigger Nightly-A3
     needs: [authorize]
-    if: needs.authorize.outputs.is_authorized == 'true'
+    if: needs.authorize.outputs.is_authorized == 'true' && needs.authorize.outputs.dispatch_a3 == 'true'
     runs-on: ubuntu-latest
+    outputs:
+      a3_run_id: ${{ steps.dispatch_a3.outputs.a3_run_id }}
     steps:
       - name: Dispatch nightly-a3 workflow
+        id: dispatch_a3
         env:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           REPO='${{ github.event.client_payload.github.payload.repository.full_name }}'
+          REQUEST_ID='${{ github.run_id }}'
           gh workflow run schedule_nightly_test_a3.yaml \
             --repo "$REPO" \
             --ref main \
             -f test_cases='${{ needs.authorize.outputs.test_cases }}' \
-            -f vllm_ascend_branch='${{ needs.authorize.outputs.branch }}'
+            -f vllm_ascend_branch='${{ needs.authorize.outputs.branch }}' \
+            -f request_id="$REQUEST_ID" \
+            -f skip_build_image=true \
+            -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}'
+          sleep 8
+          A3_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_nightly_test_a3.yaml/runs?per_page=1" \
+            --jq '.workflow_runs[0].id')
+          echo "a3_run_id=$A3_RUN_ID" >> "$GITHUB_OUTPUT"
           echo "Dispatched Nightly-A3 with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}'"
+
+  post-links:
+    name: Post nightly workflow links
+    needs: [authorize, dispatch-a2, dispatch-a3]
+    if: always() && needs.authorize.outputs.is_authorized == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build comment body
+        id: body
+        run: |
+          BODY="nightly command triggered."
+          if [[ "${{ needs.dispatch-a2.result }}" == "success" ]]; then
+            BODY="$BODY
+          - Nightly-A2: [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ needs.dispatch-a2.outputs.a2_run_id }})"
+          fi
+          if [[ "${{ needs.dispatch-a3.result }}" == "success" ]]; then
+            BODY="$BODY
+          - Nightly-A3: [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ needs.dispatch-a3.outputs.a3_run_id }})"
+          fi
+          {
+            echo "body<<EOF"
+            echo "$BODY"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post workflow URLs
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          body: ${{ steps.body.outputs.body }}
+          reactions: rocket

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -35,6 +35,21 @@ on:
         required: false
         default: 'all'
         type: string
+      request_id:
+        description: 'Unique request ID from the triggering workflow for run identification'
+        required: false
+        default: ''
+        type: string
+      skip_build_image:
+        description: 'Skip build-image job (used when triggered by /nightly command)'
+        required: false
+        default: 'false'
+        type: string
+      vllm_ascend_ref:
+        description: 'PR commit SHA for PR-triggered tests'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: read
@@ -50,7 +65,7 @@ defaults:
 
 # only cancel in-progress runs of the same workflow
 concurrency:
-  group: ascend-nightly-${{ github.ref }}-a2
+  group: ascend-nightly-${{ github.ref }}-a2${{ github.event.inputs.request_id && format('-{0}', github.event.inputs.request_id) || '' }}
   cancel-in-progress: true
 
 env:
@@ -127,7 +142,9 @@ jobs:
 
   build-image:
     name: Build nightly-a2 image
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.skip_build_image != 'true')
     strategy:
       matrix:
         vllm_ascend_branch: >-
@@ -186,6 +203,8 @@ jobs:
       config_file_path: ${{ matrix.test_config.config_file_path }}
       name: ${{ matrix.test_config.name }}
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
+      request_id: ${{ inputs.request_id || '' }}
+      vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
       should_run: >-
         ${{
           needs.parse-trigger.outputs.run == 'true' && (
@@ -226,11 +245,12 @@ jobs:
       image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a2'
       ascend_log_prefix: ${{ needs.setup-vars.outputs.ascend_log_prefix }}/${{ matrix.vllm_ascend_branch }}
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
+      request_id: ${{ inputs.request_id || '' }}
       replicas: 1
       size: ${{ matrix.test_config.size }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
       name: ${{ matrix.test_config.name }}
-      vllm_ascend_ref: ${{ needs.parse-trigger.outputs.ref }}
+      vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       should_run: >-
         ${{
           needs.parse-trigger.outputs.run == 'true' && (
@@ -294,6 +314,8 @@ jobs:
             contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
           )
         }}
+      request_id: ${{ inputs.request_id || '' }}
+      vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
       upload: false
 
   single-node-accuracy-tests-pr-only:
@@ -321,6 +343,8 @@ jobs:
           needs.parse-trigger.outputs.filter != 'all' &&
           contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
         }}
+      request_id: ${{ inputs.request_id || '' }}
+      vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
       upload: false
 
   clear-pre-logs:

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -36,6 +36,21 @@ on:
         required: false
         default: 'all'
         type: string
+      request_id:
+        description: 'Unique request ID from the triggering workflow for run identification'
+        required: false
+        default: ''
+        type: string
+      skip_build_image:
+        description: 'Skip build-image job (used when triggered by /nightly command)'
+        required: false
+        default: 'false'
+        type: string
+      vllm_ascend_ref:
+        description: 'PR commit SHA for PR-triggered tests'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: read
@@ -50,7 +65,7 @@ defaults:
     shell: bash -el {0}
 
 concurrency:
-  group: ascend-nightly-${{ github.ref }}-a3
+  group: ascend-nightly-${{ github.ref }}-a3${{ github.event.inputs.request_id && format('-{0}', github.event.inputs.request_id) || '' }}
   cancel-in-progress: true
 
 env:
@@ -124,7 +139,9 @@ jobs:
 
   build-image:
     name: Build nightly-a3 image
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.skip_build_image != 'true')
     strategy:
       matrix:
         vllm_ascend_branch: >-
@@ -167,7 +184,8 @@ jobs:
       size: ${{ matrix.test_config.size }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
       name: ${{ matrix.test_config.name }}
-      vllm_ascend_ref: ${{ needs.parse-trigger.outputs.ref }}
+      vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
+      request_id: ${{ inputs.request_id || '' }}
       should_run: >-
         ${{
           needs.parse-trigger.outputs.run == 'true' && (
@@ -234,7 +252,8 @@ jobs:
       size: ${{ matrix.test_config.size }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
       name: ${{ matrix.test_config.name }}
-      vllm_ascend_ref: ${{ needs.parse-trigger.outputs.ref }}
+      vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
+      request_id: ${{ inputs.request_id || '' }}
       should_run: >-
         ${{
           needs.parse-trigger.outputs.run == 'true' && (
@@ -324,6 +343,8 @@ jobs:
             contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
           )
         }}
+      request_id: ${{ inputs.request_id || '' }}
+      vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
 
   multi-card-tests:
     name: single-node
@@ -377,6 +398,8 @@ jobs:
             contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
           )
         }}
+      request_id: ${{ inputs.request_id || '' }}
+      vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
     secrets:
       OBS_ACCESS_KEY: ${{ secrets.OBS_ACCESS_KEY }}
       OBS_SECRET_KEY: ${{ secrets.OBS_SECRET_KEY }}
@@ -393,7 +416,7 @@ jobs:
 
   merge-benchmark-artifacts:
     name: Merge benchmark artifacts into nightly-a3.zip
-    needs: [parse-trigger, single-node-tests, multi-node-tests, double-node-tests]
+    needs: [parse-trigger, single-node-tests, multi-node-tests, double-node-tests, multi-card-tests]
     if: >-
       always() &&
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&

--- a/.github/workflows/scripts/resolve_nightly_tests.py
+++ b/.github/workflows/scripts/resolve_nightly_tests.py
@@ -1,0 +1,81 @@
+import base64
+import json
+import os
+import subprocess
+
+try:
+    import yaml
+except ImportError:
+    subprocess.check_call(["pip", "install", "pyyaml", "-q"])
+    import yaml
+
+
+def parse_names(b64_content):
+    if not b64_content:
+        return set()
+    try:
+        content = base64.b64decode(b64_content).decode()
+        parsed = yaml.safe_load(content)
+        names = set()
+        for job in parsed.get("jobs", {}).values():
+            tc = job.get("strategy", {}).get("matrix", {}).get("test_config", [])
+            if isinstance(tc, list):
+                for entry in tc:
+                    if isinstance(entry, dict) and "name" in entry:
+                        names.add(entry["name"])
+        return names
+    except Exception:
+        return set()
+
+
+def parse_accuracy_names(b64_content):
+    if not b64_content:
+        return set()
+    try:
+        parsed = json.loads(base64.b64decode(b64_content).decode())
+        names = set()
+        for group_list in parsed.values():
+            if isinstance(group_list, list):
+                for group in group_list:
+                    if isinstance(group, dict) and "name" in group:
+                        names.add(group["name"])
+        return names
+    except Exception:
+        return set()
+
+
+def main():
+    a2_names = parse_names(os.environ.get("A2_RAW", ""))
+    a2_names |= parse_accuracy_names(os.environ.get("A2_ACC_GROUPS", ""))
+    a3_names = parse_names(os.environ.get("A3_RAW", ""))
+
+    raw_test_cases = os.environ.get("TEST_CASES", "")
+    test_cases = [tc.strip() for tc in raw_test_cases.split(",") if tc.strip()]
+
+    da2, da3 = False, False
+    transformed_tc = None
+    for tc in test_cases:
+        if "/" in tc:
+            parts = tc.split("/", 1)
+            group_name, model_name = parts[0], parts[1]
+            if group_name in a2_names:
+                da2 = True
+                transformed_tc = f"{group_name},{model_name}"
+            break
+        elif tc == "accuracy-group":
+            da2 = True
+        else:
+            if tc in a2_names:
+                da2 = True
+            if tc in a3_names:
+                da3 = True
+
+    with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+        if transformed_tc:
+            f.write(f"test_cases={transformed_tc}\n")
+        f.write(f"dispatch_a2={str(da2).lower()}\n")
+        f.write(f"dispatch_a3={str(da3).lower()}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### What this PR does / why we need it?

Previously, the `/nightly` slash command only dispatched nightly workflows with a branch name and test case filter, but always tested the `main` branch image. This made it impossible to validate PR code changes via nightly tests before merging.

**`pr_nightly_command.yml`**
- Fetch the PR's HEAD SHA (`vllm_ascend_ref`) and pass it to downstream workflows
- Add selective dispatch: parse which test cases belong to a2/a3 via  `resolve_nightly_tests.py`; set `dispatch_a2`/`dispatch_a3`   outputs accordingly
- Add `post-links` job: post per-workflow run URLs back to the PR comment after dispatch (replaces the premature "workflow   URL" comment)
- Fix authorization: use `.role_name` instead of `.permission` so `triage` and `maintain` roles are correctly recognized
- Require explicit test names; bare `/nightly` without args posts a usage hint and exits instead of silently running all tests

**`schedule_nightly_test_a2/a3.yaml`**
- Add `request_id`, `skip_build_image`, `vllm_ascend_ref` inputs
- Skip `build-image` job when `skip_build_image=true` (PR-triggered runs reuse the existing nightly image)
- Pass `vllm_ascend_ref` and `request_id` through to all sub-workflow calls
- Differentiate concurrency group by `request_id` so PR-triggered runs don't cancel scheduled nightly runs
- Fix `merge-benchmark-artifacts`: add missing `multi-card-tests` dependency

**`_e2e_nightly_single_node.yaml` / `_e2e_nightly_single_node_models.yaml`**
- Replace `github.event_name == 'pull_request'` guards with `inputs.request_id != ''` since PR tests now arrive via `workflow_dispatch`
- Add `vllm_ascend_ref` and `request_id` inputs
- Pass `ref: ${{ inputs.vllm_ascend_ref }}` to checkout step so the PR commit is tested rather than the default branch

**`_e2e_nightly_multi_node.yaml`**
- Same `request_id`-based PR detection and input forwarding as single-node

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
