### PR TITLE
[CI] Remove A2 accuracy group 2 from nightly matrix

### DIFF
--- a/tests/e2e/models/configs/accuracy_groups_a2.json
+++ b/tests/e2e/models/configs/accuracy_groups_a2.json
@@ -13,17 +13,6 @@
       ]
     },
     {
-      "name": "accuracy-group-2",
-      "os": "linux-aarch64-a2b3-1",
-      "model_list": [
-        "ERNIE-4.5-21B-A3B-PT",
-        "InternVL3_5-8B-hf",
-        "Molmo-7B-D-0924",
-        "Llama-3.2-3B-Instruct",
-        "llava-onevision-qwen2-0.5b-ov-hf"
-      ]
-    },
-    {
       "name": "accuracy-group-3",
       "os": "linux-aarch64-a2b3-2",
       "model_list": [


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request removes the `accuracy-group-2` configuration block from `tests/e2e/models/configs/accuracy_groups_a2.json` to clean up the A2 nightly accuracy matrix.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- `jq empty tests/e2e/models/configs/accuracy_groups_a2.json`
- Verified the PR diff only changes `tests/e2e/models/configs/accuracy_groups_a2.json`.

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
