### PR TITLE
[BugFix] Fix deepcopy crash in netloader when loading draft model

### DIFF
--- a/tests/ut/model_loader/netloader/test_netloader.py
+++ b/tests/ut/model_loader/netloader/test_netloader.py
@@ -38,6 +38,7 @@ class DummyVllmConfig:
     device_config = DummyDeviceConfig()
     parallel_config = DummyParallelConfig()
     additional_config = None
+    quant_config = None
 
 
 class DummyModelConfig:

--- a/vllm_ascend/model_loader/netloader/netloader.py
+++ b/vllm_ascend/model_loader/netloader/netloader.py
@@ -178,7 +178,7 @@ class ModelNetLoaderElastic(BaseModelLoader):
         else:
             target_device = torch.device(device_config.device)
 
-            vllm_config_backup = deepcopy(vllm_config)
+            _quant_config = deepcopy(vllm_config.quant_config) if vllm_config.quant_config is not None else None
             model_config_backup = deepcopy(model_config)
 
             with set_default_torch_dtype(model_config.dtype):
@@ -220,7 +220,7 @@ class ModelNetLoaderElastic(BaseModelLoader):
                 if model is None:
                     logger.warning("Netloader elastic loading fails, use load format DefaultModelLoader")
 
-                    vllm_config = vllm_config_backup
+                    vllm_config.quant_config = _quant_config
                     model_config = model_config_backup
 
                     del model

--- a/vllm_ascend/model_loader/netloader/netloader.py
+++ b/vllm_ascend/model_loader/netloader/netloader.py
@@ -221,7 +221,8 @@ class ModelNetLoaderElastic(BaseModelLoader):
                 if model is None:
                     logger.warning("Netloader elastic loading fails, use load format DefaultModelLoader")
 
-                    vllm_config.quant_config = _quant_config
+                    if hasattr(vllm_config, "quant_config"):
+                        vllm_config.quant_config = _quant_config
                     model_config = model_config_backup
 
                     del model

--- a/vllm_ascend/model_loader/netloader/netloader.py
+++ b/vllm_ascend/model_loader/netloader/netloader.py
@@ -178,7 +178,8 @@ class ModelNetLoaderElastic(BaseModelLoader):
         else:
             target_device = torch.device(device_config.device)
 
-            _quant_config = deepcopy(vllm_config.quant_config) if vllm_config.quant_config is not None else None
+            _quant_config = getattr(vllm_config, "quant_config", None)
+            _quant_config = deepcopy(_quant_config) if _quant_config is not None else None
             model_config_backup = deepcopy(model_config)
 
             with set_default_torch_dtype(model_config.dtype):


### PR DESCRIPTION

  ### What this PR does / why we need it?

  Fix a `deepcopy(vllm_config)` crash that occurs when loading a draft model via netloader.

  **Root cause**: `d7bca903` introduced `vllm_config_backup = deepcopy(vllm_config)` in `load_model()` so the original config could be restored on elastic-load fallback. However, the draft model's `VllmConfig` (created by `_create_draft_vllm_config()`) shallow-copies sub-configs  that may already contain `BasevLLMParameter` objects embedded by the target model's loading path. `deepcopy` then traverses into these Parameter objects, whose `__deepcopy__` calls `type(self)(data, requires_grad=...)`, but `BasevLLMParameter.__new__()` only accepts 2  positional arguments — crash.

  **Fix**:
1. Replace `deepcopy(vllm_config)` with saving only `vllm_config.quant_config` (the sole field modified during model loading that needs restoration on rollback).
2. In `revert_to_default()`, deepcopy `self.load_config` before mutation instead of mutating the instance directly.

fixes #10242

  ### Does this PR introduce _any_ user-facing change?

  No.

  ### How was this patch tested?

  Unit tests passed (`tests/ut/model_loader/netloader/`).
  Manually verified draft model D2D loading no longer crashes with `BasevLLMParameter.__new__()` TypeError.

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
