### PR TITLE
[PD Disaggregation] Add MC2 group barrier before warmup to prevent deadlock when EP spans DP groups

### DIFF
--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -563,6 +563,15 @@ class NPUWorker(WorkerBase):
                 if not any(x in compile_range for x in all_sizes):
                     warmup_sizes.append(compile_range.end)
 
+        # When EP spans DP groups, MoE all-to-all in _dummy_run requires all
+        # ranks across DP groups to participate simultaneously. Barrier ensures
+        # both DP groups enter warmup together.
+        if (self.parallel_config.enable_expert_parallel
+                and self.parallel_config.data_parallel_size_local > 1):
+            from vllm_ascend.distributed.parallel_state import get_mc2_group
+            import torch.distributed as dist
+            dist.barrier(group=get_mc2_group().device_group)
+
         for size in sorted(warmup_sizes, reverse=True):
             logger.info("Compile and warming up model for size %d", size)
             self.model_runner._dummy_run(size)


### PR DESCRIPTION
## Problem

When running PD disaggregation with MoE models where EP spans multiple DP groups, the D-node hangs during model warmup or crashes with aicore timeout. This bug is specific to PD disaggregation — in hybrid deployment, P and D start warmup synchronously, so MC2 all-to-all completes naturally.

Closes #10244

## Fix

Add `dist.barrier(group=get_mc2_group().device_group)` before the warmup loop in `worker.compile_or_warm_up_model()`. The barrier synchronizes all MC2 group ranks so both DP groups enter warmup together.

## Testing

Verified on Qwen3.5-397B-A17B-w8a8-mtp (Ascend A3 NPU). Without barrier: D-node hangs. With barrier: no deadlock.
- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
