### PR TITLE
[PD Disaggregation] Fix execute_dummy_batch block_table corruption and MooncakeLayerwiseConnector for hybrid Mamba+Attention models

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -519,6 +519,18 @@ class KVCacheSendingLayerThread(threading.Thread):
                             else:
                                 self.callback_func(req_id, req_meta, layer_group_idx, trans_flag=True)
 
+        # For ranks that have no transfer data on the last layer (e.g.,
+        # non-attention-selected ranks in hybrid Mamba models), still send
+        # the DONE signal so the D node doesn't wait forever.
+        if send_task.layer_idx == (self.total_layers - 1):
+            handled_req_ids: set[str] = set()
+            for transfer_meta in session_meta.values():
+                if len(transfer_meta.src) > 0:
+                    handled_req_ids.update(transfer_meta.req_ids)
+            for req_id, req_meta in send_task.send_request.items():
+                if req_id not in handled_req_ids and req_meta.chunk_finish:
+                    self.callback_func(req_id, req_meta, layer_group_idx, trans_flag=True)
+
 
 class KVCacheRecvingLayerThread(threading.Thread):
     def __init__(
@@ -1281,6 +1293,9 @@ class MooncakeLayerwiseConnectorWorker:
             self.index_to_name[max(self.index_to_name.keys()) + 1].append(mtp_layer_name)
         if self.total_layers < len(self.layer_metadata.keys()):
             self.total_layers = len(self.layer_metadata.keys())
+        if self.use_attn_mamba_hybrid:
+            logger.info("use_attn_mamba_hybrid=True, total_layers=%d, layer_metadata keys=%d",
+                        self.total_layers, len(self.layer_metadata.keys()))
 
         # After KV Caches registered, start the sending or receiving thread.
         metadata = MooncakeAgentMetadata(
@@ -1419,6 +1434,18 @@ class MooncakeLayerwiseConnectorWorker:
         if cp_ratio == 0:
             selected_p_cp_groups = p_cp_group
             selected_d_cp_groups = d_cp_group
+        elif self.use_attn_mamba_hybrid and cp_ratio > 1:
+            # For hybrid attention+Mamba models, select P cp_groups at stride
+            # equal to tp_ratio so that the selected attention P ranks align
+            # with the Mamba consecutive rank mapping (tp_rank // tp_ratio).
+            # This ensures each P rank sends both attention and Mamba to the
+            # same D rank, avoiding multi-target conflicts.
+            tp_ratio = self.tp_size // remote_tp_size
+            stride = tp_ratio
+            x = req_idx % cp_ratio
+            selected_p_cp_groups = [p_cp_group[x + i * stride] for i in range(len(d_cp_group))
+                                    if (x + i * stride) < len(p_cp_group)]
+            selected_d_cp_groups = d_cp_group[:len(selected_p_cp_groups)]
         else:
             x = req_idx % cp_ratio
             start = x * len(d_cp_group)
@@ -1540,7 +1567,7 @@ class MooncakeLayerwiseConnectorWorker:
                     self.virtual_request.add(req_id)
                     continue
                 external_req_id = get_external_request_id(req_id)
-                assert self.kv_recv_layer_thread is not None
+                assert self.kv_recv_layer_thread is not None, "kv_recv_layer_thread must be initialized before loading KV"
                 self.request_map[external_req_id] = req_id
                 self._recving_metadata[req_id] = meta
         elif self.vllm_config.kv_transfer_config.is_kv_producer:
@@ -1618,6 +1645,48 @@ class MooncakeLayerwiseConnectorWorker:
                     )
                     send_task.group_seq_start_tensor[i] = torch.tensor([0], dtype=torch.int32, device=device)
 
+    def _enqueue_mamba_layers(self, connector_metadata: MooncakeLayerwiseConnectorMetadata):
+        """Enqueue SendTasks for Mamba layers that precede the current full_attention layer.
+
+        In hybrid models, gdn.py's maybe_save_kv_layer_to_connector does not
+        execute under torch.compile/cudagraph, so Mamba layers are never
+        explicitly saved. We handle them here by creating SendTasks that use
+        registered memory addresses directly (no kv_layer tensors needed).
+        """
+        while self.current_layer < self.total_layers:
+            mamba_layer_name = self.index_to_name[self.current_layer][0]
+            mamba_group_idx = self.layer_metadata[mamba_layer_name].tensor_group_idx[0]
+            if not isinstance(self.kv_cache_specs[mamba_group_idx], MambaSpec):
+                break
+            reshape_cache_event = torch.npu.Event()
+            reshape_cache_event.record()
+            send_task = connector_metadata.send_task
+            layer_send_task = SendTask(
+                wait_event=reshape_cache_event,
+                k_cache=None,
+                v_cache=None,
+                k_quant_cache=None,
+                v_quant_cache=None,
+                layer_idx=self.current_layer,
+                layer_name=mamba_layer_name,
+                group_rearrange_block_ids=send_task.group_rearrange_block_ids,
+            )
+            for req_id, req_meta in connector_metadata.requests.items():
+                if len(req_meta.local_block_ids[mamba_group_idx]) == 0:
+                    continue
+                try:
+                    req_meta_update = self.update_decoder_info(req_id, req_meta)
+                except Exception as e:
+                    logger.warning(
+                        "MooncakeLayerwiseConnector transfer fail for req_id %s in mamba layer_idx %s, "
+                        "update_decoder_info with error: %s",
+                        req_id, self.current_layer, e,
+                    )
+                    continue
+                layer_send_task.send_request[req_id] = req_meta_update
+            self.kv_send_layer_thread.send_queue.put(layer_send_task)
+            self.current_layer += 1
+
     def save_kv_layer(
         self,
         layer_name: str,
@@ -1631,6 +1700,11 @@ class MooncakeLayerwiseConnectorWorker:
             if self.current_layer >= self.total_layers:
                 self.current_layer += 1
                 return
+            if self.use_attn_mamba_hybrid:
+                self._enqueue_mamba_layers(connector_metadata)
+                if self.current_layer >= self.total_layers:
+                    self.current_layer += 1
+                    return
             # get reshape and cache event
             if layer_name == "":
                 layer_name = self.index_to_name[self.current_layer][0]
@@ -1744,7 +1818,8 @@ class MooncakeLayerwiseConnectorWorker:
                 group_rearrange_block_ids=send_task.group_rearrange_block_ids,
             )
             for req_id, req_meta in connector_metadata.requests.items():
-                if len(req_meta.local_block_ids[layer_group_idx]) == 0:
+                is_last_layer = (self.current_layer == self.total_layers - 1)
+                if len(req_meta.local_block_ids[layer_group_idx]) == 0 and not is_last_layer:
                     continue
                 try:
                     req_meta_update = self.update_decoder_info(req_id, req_meta)
@@ -1846,6 +1921,7 @@ class MooncakeLayerwiseConnectorWorker:
     def send_done_send_signal(self, req_id, req_meta, group_idx, trans_flag: bool = True):
         external_req_id = get_external_request_id(req_id)
         send_msg_type = DONE_SENDING_MSG if trans_flag else FAILED_SENDING_MSG
+        trans_count = max(req_meta.trans_count)
         logger.info(
             "Sending transmitting signal %s for request %s to %s:%d",
             send_msg_type,
@@ -1858,7 +1934,7 @@ class MooncakeLayerwiseConnectorWorker:
             msg_encoder = msgspec.msgpack.Encoder()
             side_channel_path = f"{self.side_channel_host}:{self.handshake_port}"
             encoded_data = msg_encoder.encode(
-                (send_msg_type, external_req_id, req_meta.trans_count[group_idx], side_channel_path)
+                (send_msg_type, external_req_id, trans_count, side_channel_path)
             )
             max_retries = 3
             for attempt in range(1, max_retries + 1):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2775,6 +2775,7 @@ class NPUModelRunner(GPUModelRunner):
         num_scheduled_tokens_np: np.ndarray | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
         num_scheduled_tokens_compressed_list: list[np.ndarray] | None = None,
+        for_dummy_batch: bool = False,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
         """
         :return: tuple[attn_metadata, spec_decode_common_attn_metadata]
@@ -2821,6 +2822,16 @@ class NPUModelRunner(GPUModelRunner):
         def _get_block_table_and_slot_mapping(kv_cache_gid: int, total_num_scheduled_tokens_compressed_list: list[int]):
             assert num_reqs_padded is not None and num_tokens_padded is not None
             kv_cache_spec = kv_cache_groups[kv_cache_gid].kv_cache_spec
+
+            if for_dummy_batch:
+                blk_table = self.input_batch.block_table[kv_cache_gid]
+                maybe_num_reqs_padded = num_reqs_padded * self.decode_token_per_req if self.use_cp else num_reqs_padded
+                blk_table_tensor = blk_table.get_device_tensor()[:maybe_num_reqs_padded]
+                slot_mapping = blk_table.slot_mapping.gpu[:num_tokens_padded]
+                blk_table_tensor.fill_(0)
+                slot_mapping.fill_(0)
+                return blk_table_tensor, slot_mapping
+
             if self.pcp_size > 1:
                 total_num_pcp_pads = sum(self.pcp_manager.num_pcp_pads_cpu[:num_reqs])
                 if self.pcp_manager.pcp_use_hybrid_attn:
@@ -3126,6 +3137,7 @@ class NPUModelRunner(GPUModelRunner):
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
+        for_dummy_batch: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # only support eager mode and piecewise graph now
         assert cudagraph_runtime_mode is None or cudagraph_runtime_mode.valid_runtime_modes()
@@ -3180,7 +3192,7 @@ class NPUModelRunner(GPUModelRunner):
             max_num_scheduled_tokens=max_query_len,
             use_cascade_attn=False,
             allow_microbatching=allow_microbatching,
-            force_eager=is_profile or (cudagraph_runtime_mode == CUDAGraphMode.NONE) or profile_cpp,
+            force_eager=is_profile or (cudagraph_runtime_mode == CUDAGraphMode.NONE) or profile_cpp or for_dummy_batch,
             # `force_uniform_decode` is used for cudagraph capture; because for
             # capturing mixed prefill-decode batches, we sometimes use
             # num_tokens == num_reqs which looks like a uniform decode batch to the
@@ -3274,6 +3286,7 @@ class NPUModelRunner(GPUModelRunner):
                 ubatch_slices=ubatch_slices_padded if pad_attn else ubatch_slices,
                 for_cudagraph_capture=is_graph_capturing,
                 num_scheduled_tokens_np=num_scheduled_tokens,
+                for_dummy_batch=for_dummy_batch,
             )
 
         with self.maybe_dummy_run_with_lora(

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -820,7 +820,7 @@ class NPUWorker(WorkerBase):
 
     def execute_dummy_batch(self) -> None:
         self.profile_memory()
-        self.model_runner._dummy_run(num_tokens=self.model_runner.decode_token_per_req, uniform_decode=True)
+        self.model_runner._dummy_run(num_tokens=self.model_runner.decode_token_per_req, uniform_decode=True, for_dummy_batch=True)
 
     def _init_worker_distributed_environment(self) -> None:
         """Initialize the distributed environment."""


### PR DESCRIPTION
## Changes

This PR combines fixes for Issue #10245 and Issue #10246, since the connector changes depend on the `for_dummy_batch` changes and cannot be merged independently.

### 1. execute_dummy_batch corruption fix (Closes #10245)

`execute_dummy_batch()` runs between real forward passes to keep cudagraph warm. The dummy forward populates `block_table` and `slot_mapping` with stale/invalid data, overwriting real values the KV connector needs.

**Fix**: Add `for_dummy_batch: bool = False` parameter that propagates through `_dummy_run()` → `_build_attention_metadata()` → `_get_block_table_and_slot_mapping()`. When `for_dummy_batch=True`, zero out `block_table` and `slot_mapping` to prevent dummy data from interfering with connector state. Also force eager mode for dummy batches.

### 2. MooncakeLayerwiseConnector hybrid Mamba+Attention fixes (Closes #10246)

The connector was designed for pure-attention models. Hybrid models (e.g., Qwen3.5-397B with Mamba/GDN layers) break several assumptions:

- **Mamba layers never transferred**: `gdn.py`'s `maybe_save_kv_layer_to_connector` doesn't execute under cudagraph, so conv+SSM state is never saved. Fix: `_enqueue_mamba_layers()` method enqueues preceding Mamba layers when attention `save_kv_layer()` is called.
- **Non-attention TP ranks never send DONE signal**: Some ranks skip the transfer loop and never call `callback_func` → `send_done_send_signal()`. Fix: last-layer callback for unhandled req_ids.
- **DONE signal uses per-group trans_count**: Different groups have different counts, D-node needs `max(trans_count)`. Fix: `send_done_send_signal` sends `max(req_meta.trans_count)`.
- **CP group stride misaligned**: Hybrid models need `stride=tp_ratio` to align Mamba and attention rank mappings. Fix: stride logic in `_get_kv_split_metadata`.

## Testing

Verified on Qwen3.5-397B-A17B-w8a8-mtp (Ascend A3 NPU, PD disaggregation). Without fixes: aicore timeout crashes during inference. With fixes: stable PD disaggregation operation.
- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
