### PR TITLE
[BugFix][v0.20.2rc] Trim SWA transfer blocks before clipping

### DIFF
--- a/tests/ut/kv_connector/test_mooncake_hybrid_connector.py
+++ b/tests/ut/kv_connector/test_mooncake_hybrid_connector.py
@@ -1,7 +1,39 @@
 import sys
 import types
 import unittest
+from importlib import import_module
+from pathlib import Path
 from unittest.mock import MagicMock
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_REPO_ROOT_STR = str(_REPO_ROOT)
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
+
+
+def _prepend_package_path(module_name: str, source_path: Path) -> None:
+    module = import_module(module_name)
+    path = str(source_path)
+    if path not in module.__path__:
+        module.__path__.insert(0, path)
+
+
+# CPU smart UT installs vllm-ascend before collecting tests. Make this test use
+# the current checkout even if the package was imported from site-packages first.
+_prepend_package_path("vllm_ascend", _REPO_ROOT / "vllm_ascend")
+_prepend_package_path("vllm_ascend.distributed", _REPO_ROOT / "vllm_ascend" / "distributed")
+_prepend_package_path(
+    "vllm_ascend.distributed.kv_transfer",
+    _REPO_ROOT / "vllm_ascend" / "distributed" / "kv_transfer",
+)
+_prepend_package_path(
+    "vllm_ascend.distributed.kv_transfer.kv_p2p",
+    _REPO_ROOT / "vllm_ascend" / "distributed" / "kv_transfer" / "kv_p2p",
+)
+_prepend_package_path(
+    "vllm_ascend.distributed.kv_transfer.utils",
+    _REPO_ROOT / "vllm_ascend" / "distributed" / "kv_transfer" / "utils",
+)
 
 fake_engine = types.ModuleType("mooncake.engine")
 fake_engine.TransferEngine = MagicMock()  # type: ignore[attr-defined]

--- a/tests/ut/kv_connector/test_mooncake_hybrid_connector.py
+++ b/tests/ut/kv_connector/test_mooncake_hybrid_connector.py
@@ -15,9 +15,19 @@ from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_hybrid_connector import
 
 
 class MockRequest:
-    def __init__(self, request_id, prompt_token_ids, kv_transfer_params, status):
+    def __init__(
+        self,
+        request_id,
+        prompt_token_ids,
+        kv_transfer_params,
+        status,
+        num_prompt_tokens=None,
+    ):
         self.request_id = request_id
         self.prompt_token_ids = prompt_token_ids
+        if num_prompt_tokens is None:
+            num_prompt_tokens = len(prompt_token_ids) if prompt_token_ids is not None else 0
+        self.num_prompt_tokens = num_prompt_tokens
         self.kv_transfer_params = kv_transfer_params
         self.status = status
         self.output_token_ids = [101]
@@ -65,3 +75,21 @@ class TestMooncakeHybridConnectorScheduler(unittest.TestCase):
         self.assertEqual(params["remote_block_ids"], ([0], [100, 101]))
         self.assertEqual(params["num_prompt_blocks"], 2)
         self.assertIn("req1", scheduler._reqs_need_send)
+
+    def test_request_finished_uses_num_prompt_tokens(self):
+        scheduler = self._make_scheduler()
+        request = MockRequest(
+            "req1",
+            prompt_token_ids=None,
+            kv_transfer_params={"do_remote_decode": True},
+            status=RequestStatus.FINISHED_LENGTH_CAPPED,
+            num_prompt_tokens=129,
+        )
+        block_ids = (list(range(10)), [100, 101, 102, 103])
+
+        delay_free, params = scheduler.request_finished_all_groups(request, block_ids)
+
+        self.assertTrue(delay_free)
+        self.assertIsNotNone(params)
+        self.assertEqual(params["remote_block_ids"], ([0], [100, 101]))
+        self.assertEqual(params["num_prompt_blocks"], 2)

--- a/tests/ut/kv_connector/test_mooncake_hybrid_connector.py
+++ b/tests/ut/kv_connector/test_mooncake_hybrid_connector.py
@@ -1,0 +1,67 @@
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+fake_engine = types.ModuleType("mooncake.engine")
+fake_engine.TransferEngine = MagicMock()  # type: ignore[attr-defined]
+sys.modules["mooncake.engine"] = fake_engine
+
+from vllm.v1.request import RequestStatus  # noqa: E402
+
+from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_hybrid_connector import (  # noqa: E402
+    MooncakeConnectorScheduler,
+)
+
+
+class MockRequest:
+    def __init__(self, request_id, prompt_token_ids, kv_transfer_params, status):
+        self.request_id = request_id
+        self.prompt_token_ids = prompt_token_ids
+        self.kv_transfer_params = kv_transfer_params
+        self.status = status
+        self.output_token_ids = [101]
+
+
+class TestMooncakeHybridConnectorScheduler(unittest.TestCase):
+    def _make_scheduler(self):
+        scheduler = object.__new__(MooncakeConnectorScheduler)
+        scheduler.use_hybrid = True
+        scheduler.use_compress = True
+        scheduler.num_swa_blocks = [0, 2]
+        scheduler.group_block_size = [128, 128]
+        scheduler.group_compress_ratio = [4, 1]
+        scheduler._reqs_need_send = {}
+        scheduler.block_size = 128
+        scheduler.engine_id = "engine"
+        scheduler.side_channel_host = "127.0.0.1"
+        scheduler.side_channel_port = 12345
+        scheduler.tp_size = 1
+        scheduler.multi_nodes_meta_mapping = {}
+        return scheduler
+
+    def test_compute_transfer_block_ids_trims_swa_groups(self):
+        scheduler = self._make_scheduler()
+        block_ids = (list(range(10)), [100, 101, 102, 103])
+
+        transfer_block_ids = scheduler._compute_transfer_block_ids(block_ids, prompt_len=129)
+
+        self.assertEqual(transfer_block_ids, ([0], [100, 101]))
+
+    def test_request_finished_trims_before_swa_clip(self):
+        scheduler = self._make_scheduler()
+        request = MockRequest(
+            "req1",
+            prompt_token_ids=list(range(129)),
+            kv_transfer_params={"do_remote_decode": True},
+            status=RequestStatus.FINISHED_LENGTH_CAPPED,
+        )
+        block_ids = (list(range(10)), [100, 101, 102, 103])
+
+        delay_free, params = scheduler.request_finished_all_groups(request, block_ids)
+
+        self.assertTrue(delay_free)
+        self.assertIsNotNone(params)
+        self.assertEqual(params["remote_block_ids"], ([0], [100, 101]))
+        self.assertEqual(params["num_prompt_blocks"], 2)
+        self.assertIn("req1", scheduler._reqs_need_send)

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -1141,17 +1141,15 @@ class MooncakeConnectorScheduler:
     def _compute_transfer_block_ids(self, block_ids: BlockIds, prompt_len: int) -> BlockIds:
         transfer_block_ids = []
         for i, blocks in enumerate(block_ids):
-            if self.num_swa_blocks[i] == 0:
-                if self.use_compress:
-                    group_block_len = math.ceil((prompt_len // self.group_compress_ratio[i]) / self.group_block_size[i])
-                else:
-                    group_block_len = math.ceil(prompt_len / self.group_block_size[i])
-                if group_block_len > 0:
-                    transfer_block_ids.append(blocks[:group_block_len])
-                else:
-                    transfer_block_ids.append([])
+            if self.use_compress and self.num_swa_blocks[i] == 0:
+                group_token_len = prompt_len // self.group_compress_ratio[i]
             else:
-                transfer_block_ids.append(blocks)
+                group_token_len = prompt_len
+            group_block_len = math.ceil(group_token_len / self.group_block_size[i])
+            if group_block_len > 0:
+                transfer_block_ids.append(blocks[:group_block_len])
+            else:
+                transfer_block_ids.append([])
         return tuple(transfer_block_ids)
 
     def get_num_new_matched_tokens(self, request: "Request", num_computed_tokens: int) -> tuple[int, bool]:
@@ -1264,16 +1262,17 @@ class MooncakeConnectorScheduler:
         ):
             return False, None
 
-        computed_block_ids = block_ids
+        # P-side truncation can leave block ids allocated for the original
+        # prompt length. Drop those unwritten blocks before SWA tail clipping.
+        computed_block_ids = self._compute_transfer_block_ids(block_ids, len(request.prompt_token_ids))
+        computed_block_ids = self.get_sw_clipped_blocks(computed_block_ids)
         computed_block_lens = [len(block_id_list) for block_id_list in computed_block_ids]
         delay_free_blocks = sum(computed_block_lens) > 0
         if delay_free_blocks:
             logger.info("Delaying free of %d blocks for request %s", len(computed_block_ids), request.request_id)
             self._reqs_need_send[request.request_id] = time.time()
-            computed_block_ids = self.get_sw_clipped_blocks(computed_block_ids)
 
         num_prompt_blocks = math.ceil(len(request.prompt_token_ids) / self.block_size)
-        computed_block_ids = self._compute_transfer_block_ids(computed_block_ids, len(request.prompt_token_ids))
 
         return delay_free_blocks, dict(
             do_remote_prefill=True,

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -1264,7 +1264,7 @@ class MooncakeConnectorScheduler:
 
         # P-side truncation can leave block ids allocated for the original
         # prompt length. Drop those unwritten blocks before SWA tail clipping.
-        computed_block_ids = self._compute_transfer_block_ids(block_ids, len(request.prompt_token_ids))
+        computed_block_ids = self._compute_transfer_block_ids(block_ids, request.num_prompt_tokens)
         computed_block_ids = self.get_sw_clipped_blocks(computed_block_ids)
         computed_block_lens = [len(block_id_list) for block_id_list in computed_block_ids]
         delay_free_blocks = sum(computed_block_lens) > 0
@@ -1272,7 +1272,7 @@ class MooncakeConnectorScheduler:
             logger.info("Delaying free of %d blocks for request %s", len(computed_block_ids), request.request_id)
             self._reqs_need_send[request.request_id] = time.time()
 
-        num_prompt_blocks = math.ceil(len(request.prompt_token_ids) / self.block_size)
+        num_prompt_blocks = math.ceil(request.num_prompt_tokens / self.block_size)
 
         return delay_free_blocks, dict(
             do_remote_prefill=True,

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -1269,7 +1269,7 @@ class MooncakeConnectorScheduler:
         computed_block_lens = [len(block_id_list) for block_id_list in computed_block_ids]
         delay_free_blocks = sum(computed_block_lens) > 0
         if delay_free_blocks:
-            logger.info("Delaying free of %d blocks for request %s", len(computed_block_ids), request.request_id)
+            logger.info("Delaying free of %d blocks for request %s", sum(computed_block_lens), request.request_id)
             self._reqs_need_send[request.request_id] = time.time()
 
         num_prompt_blocks = math.ceil(request.num_prompt_tokens / self.block_size)


### PR DESCRIPTION
### What this PR does / why we need it?

Refs #10253.

This is the `releases/v0.20.2rc` version of the SWA KV transfer root fix submitted to `main` in #10254.

In PD-disaggregated serving, P-side SWA KV transfer can keep block IDs allocated for the original prompt length. The previous order clipped SWA blocks first and only then trimmed transfer blocks. Since `_compute_transfer_block_ids()` did not trim SWA groups, stale or unwritten SWA tail blocks could be sent as `remote_block_ids`.

When the decode side consumes those stale SWA blocks in `npu_sparse_attn_sharedkv`, layer-0 attention can produce all-NaN hidden states and the request can later get stuck.

Changes include:

- Trim transfer block IDs by the actual P-side prompt length for all KV cache groups.
- Preserve compressed token length handling for non-SWA compressed groups.
- Apply SWA window clipping after prompt-length trimming.
- Add a focused unit test covering `prompt_len=129`, SWA block IDs `[100, 101, 102, 103]`, and `num_swa_blocks=2`; the expected remote SWA blocks are `[100, 101]`, not stale tail blocks `[102, 103]`.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. This only corrects internal PD KV transfer metadata for hybrid/SWA KV cache.

### How was this patch tested?

```bash
python -m py_compile \
  vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py \
  tests/ut/kv_connector/test_mooncake_hybrid_connector.py

python -m pytest tests/ut/kv_connector/test_mooncake_hybrid_connector.py -q

python -m ruff check \
  vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py \
  tests/ut/kv_connector/test_mooncake_hybrid_connector.py

python -m ruff format --check \
  vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py \
  tests/ut/kv_connector/test_mooncake_hybrid_connector.py

git diff --check HEAD^..HEAD
```

Focused pytest: 2 passed.
