### PR TITLE
[BugFix][v0.20.2rc] Backport MTP placeholder sampler fix

### DIFF
--- a/tests/ut/core/test_recompute_scheduler.py
+++ b/tests/ut/core/test_recompute_scheduler.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import MethodType
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.request import Request
+from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID
+
+from vllm_ascend.core.recompute_scheduler import RecomputeScheduler
+
+
+def test_pd_consumer_first_step_injects_placeholder_spec_tokens():
+    scheduler = RecomputeScheduler.__new__(RecomputeScheduler)
+    scheduler.requests = {}
+    scheduler.is_kv_producer = False
+    scheduler.is_hybrid_model = False
+    scheduler.is_mtp_kv_consumer = True
+    scheduler.num_spec_tokens = 1
+    scheduler.max_model_len = 1024
+    scheduler.log_stats = False
+
+    enqueued_requests = []
+
+    def enqueue_waiting_request(self, request):
+        enqueued_requests.append(request)
+
+    scheduler._enqueue_waiting_request = MethodType(enqueue_waiting_request, scheduler)
+
+    request = Request(
+        request_id="pd-consumer-first-step",
+        prompt_token_ids=[1, 2, 3, 4],
+        sampling_params=SamplingParams(max_tokens=8),
+        pooling_params=None,
+    )
+
+    scheduler.add_request(request)
+
+    assert enqueued_requests == [request]
+    assert scheduler.requests[request.request_id] is request
+    assert request.spec_token_ids == [PLACEHOLDER_TOKEN_ID]
+    assert request.num_tokens_with_spec == request.num_tokens + 1

--- a/tests/ut/sample/test_rejection_sampler.py
+++ b/tests/ut/sample/test_rejection_sampler.py
@@ -118,6 +118,64 @@ class TestAscendRejectionSampler(TestBase):
     @patch("torch.ones", new=mock_pin_memory(torch.ones))
     @patch("torch.full", new=mock_pin_memory(torch.full))
     @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
+    def test_rejection_random_sample_pytorch_rejects_placeholder(self):
+        batch_size = 1
+        max_spec_len = 1
+        output_token_ids = torch.full((batch_size, max_spec_len + 1), PLACEHOLDER_TOKEN_ID)
+
+        cu_num_draft_tokens = torch.tensor([1])
+        draft_token_ids = torch.tensor([PLACEHOLDER_TOKEN_ID])
+        target_probs = torch.tensor([[0.0, 0.0, 1.0]])
+        bonus_token_ids = torch.tensor([[100]])
+        recovered_token_ids = torch.tensor([2])
+        uniform_probs = torch.tensor([0.0])
+        is_greedy = torch.tensor([False])
+
+        rejection_random_sample_pytorch(
+            output_token_ids,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            None,
+            target_probs,
+            bonus_token_ids,
+            recovered_token_ids,
+            uniform_probs,
+            is_greedy,
+            max_spec_len,
+            vocab_size=3,
+            IS_NGRAM=True,
+        )
+
+        assert output_token_ids.tolist() == [[2, PLACEHOLDER_TOKEN_ID]]
+
+    @patch("torch.arange", new=mock_pin_memory(torch.arange))
+    @patch("torch.ones", new=mock_pin_memory(torch.ones))
+    @patch("torch.full", new=mock_pin_memory(torch.full))
+    @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
+    def test_sample_recovered_tokens_pytorch_keeps_placeholder_distribution(self):
+        output_token_ids = torch.empty(1, dtype=torch.int32)
+        cu_num_draft_tokens = torch.tensor([1])
+        draft_token_ids = torch.tensor([PLACEHOLDER_TOKEN_ID])
+        target_probs = torch.tensor([[0.1, 0.2, 0.7]])
+        q = torch.ones((1, 3), dtype=torch.float32)
+
+        sample_recovered_tokens_pytorch(
+            output_token_ids,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            None,
+            target_probs,
+            q,
+            vocab_size=3,
+            IS_NGRAM=True,
+        )
+
+        assert output_token_ids.tolist() == [2]
+
+    @patch("torch.arange", new=mock_pin_memory(torch.arange))
+    @patch("torch.ones", new=mock_pin_memory(torch.ones))
+    @patch("torch.full", new=mock_pin_memory(torch.full))
+    @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
     def test_expand_pytorch(self):
         """Test expand_pytorch functionality"""
         input_ptr = torch.tensor([10, 20, 30], dtype=torch.int32)

--- a/vllm_ascend/ops/triton/reject_sample.py
+++ b/vllm_ascend/ops/triton/reject_sample.py
@@ -183,69 +183,76 @@ def rejection_random_sample_kernel(
                         token_idx = start_idx + pos
                         draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
 
-                        target_prob = 0.0
-                        found = False
-
-                        for v_offset in range(0, vocab_size, VOCAB_BLOCK_SIZE):
-                            if not found:
-                                vocab_offsets = v_offset + tl.arange(0, VOCAB_BLOCK_SIZE)
-                                vocab_mask = vocab_offsets < vocab_size
-
-                                candidate_indices = tl.load(
-                                    target_indices_ptr + token_idx * vocab_size + vocab_offsets,
-                                    mask=vocab_mask,
-                                    other=-1,
-                                )
-
-                                match_mask = candidate_indices == draft_token_id
-
-                                candidate_probs = tl.load(
-                                    target_probs_ptr + token_idx * vocab_size + vocab_offsets,
-                                    mask=vocab_mask,
-                                    other=0.0,
-                                )
-
-                                current_match_prob = tl.sum(candidate_probs * match_mask, axis=0)
-                                if current_match_prob > 0.0:
-                                    target_prob = current_match_prob
-                                    found = True
-
-                        if NO_DRAFT_PROBS:
-                            draft_prob = 1
-                        else:
-                            draft_prob = tl.load(draft_probs_ptr + token_idx * global_vocab_size + draft_token_id)
-
-                        uniform_prob = tl.load(uniform_probs_ptr + token_idx)
-
-                        # Acceptance condition
-                        if draft_prob > 0 and target_prob / draft_prob >= uniform_prob:
-                            # Accept
-                            token_id = draft_token_id
-                        else:
-                            # Reject - use recovered token
+                        if draft_token_id == -1:
                             rejected = True
                             token_id = tl.load(recovered_token_ids_ptr + token_idx)
+                        else:
+                            target_prob = 0.0
+                            found = False
+
+                            for v_offset in range(0, vocab_size, VOCAB_BLOCK_SIZE):
+                                if not found:
+                                    vocab_offsets = v_offset + tl.arange(0, VOCAB_BLOCK_SIZE)
+                                    vocab_mask = vocab_offsets < vocab_size
+
+                                    candidate_indices = tl.load(
+                                        target_indices_ptr + token_idx * vocab_size + vocab_offsets,
+                                        mask=vocab_mask,
+                                        other=-1,
+                                    )
+
+                                    match_mask = candidate_indices == draft_token_id
+
+                                    candidate_probs = tl.load(
+                                        target_probs_ptr + token_idx * vocab_size + vocab_offsets,
+                                        mask=vocab_mask,
+                                        other=0.0,
+                                    )
+
+                                    current_match_prob = tl.sum(candidate_probs * match_mask, axis=0)
+                                    if current_match_prob > 0.0:
+                                        target_prob = current_match_prob
+                                        found = True
+
+                            if NO_DRAFT_PROBS:
+                                draft_prob = 1
+                            else:
+                                draft_prob = tl.load(draft_probs_ptr + token_idx * global_vocab_size + draft_token_id)
+
+                            uniform_prob = tl.load(uniform_probs_ptr + token_idx)
+
+                            # Acceptance condition
+                            if draft_prob > 0 and target_prob / draft_prob >= uniform_prob:
+                                # Accept
+                                token_id = draft_token_id
+                            else:
+                                # Reject - use recovered token
+                                rejected = True
+                                token_id = tl.load(recovered_token_ids_ptr + token_idx)
 
                         tl.store(output_token_ids_ptr + req_idx * (max_spec_len + 1) + pos, token_id)
                     else:
-                        draft_token_id = tl.load(draft_token_ids_ptr + start_idx + pos)
-                        target_prob = tl.load(target_probs_ptr + (start_idx + pos) * global_vocab_size + draft_token_id)
-                        if NO_DRAFT_PROBS:
-                            draft_prob = 1
-                        else:
-                            draft_prob = tl.load(
-                                draft_probs_ptr + (start_idx + pos) * global_vocab_size + draft_token_id
-                            )
-                        uniform_prob = tl.load(uniform_probs_ptr + start_idx + pos)
-                        # NOTE(woosuk): While the draft probability should never be 0,
-                        # we check it to avoid NaNs. If it happens to be 0, we reject.
-                        if draft_prob > 0 and target_prob / draft_prob >= uniform_prob:
-                            # Accept.
-                            token_id = draft_token_id
-                        else:
-                            # Reject. Use recovered token.
+                        token_idx = start_idx + pos
+                        draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
+                        if draft_token_id == -1:
                             rejected = True
-                            token_id = tl.load(recovered_token_ids_ptr + start_idx + pos)
+                            token_id = tl.load(recovered_token_ids_ptr + token_idx)
+                        else:
+                            target_prob = tl.load(target_probs_ptr + token_idx * global_vocab_size + draft_token_id)
+                            if NO_DRAFT_PROBS:
+                                draft_prob = 1
+                            else:
+                                draft_prob = tl.load(draft_probs_ptr + token_idx * global_vocab_size + draft_token_id)
+                            uniform_prob = tl.load(uniform_probs_ptr + token_idx)
+                            # NOTE(woosuk): While the draft probability should never be 0,
+                            # we check it to avoid NaNs. If it happens to be 0, we reject.
+                            if draft_prob > 0 and target_prob / draft_prob >= uniform_prob:
+                                # Accept.
+                                token_id = draft_token_id
+                            else:
+                                # Reject. Use recovered token.
+                                rejected = True
+                                token_id = tl.load(recovered_token_ids_ptr + token_idx)
                         tl.store(output_token_ids_ptr + req_idx * (max_spec_len + 1) + pos, token_id)
 
             if not rejected:
@@ -369,15 +376,18 @@ def sample_recovered_tokens_kernel(
             for prev_pos in range(pos):
                 prev_token_idx = start_idx + prev_pos
                 prev_draft_token_id = tl.load(draft_token_ids_ptr + prev_token_idx)
-                prev_target_prob = tl.load(target_probs_ptr + prev_token_idx * vocab_size + prev_draft_token_id)
-                if NO_DRAFT_PROBS:
-                    prev_draft_prob = 1.0
-                else:
-                    prev_draft_prob = tl.load(draft_probs_ptr + prev_token_idx * vocab_size + prev_draft_token_id)
-                if prev_draft_prob > 0:
-                    prefix_prob = min(prefix_prob * prev_target_prob / prev_draft_prob, 1.0)
-                else:
+                if prev_draft_token_id == -1:
                     prefix_prob = 0.0
+                else:
+                    prev_target_prob = tl.load(target_probs_ptr + prev_token_idx * vocab_size + prev_draft_token_id)
+                    if NO_DRAFT_PROBS:
+                        prev_draft_prob = 1.0
+                    else:
+                        prev_draft_prob = tl.load(draft_probs_ptr + prev_token_idx * vocab_size + prev_draft_token_id)
+                    if prev_draft_prob > 0:
+                        prefix_prob = min(prefix_prob * prev_target_prob / prev_draft_prob, 1.0)
+                    else:
+                        prefix_prob = 0.0
 
         draft_token_id = tl.load(draft_token_ids_ptr + start_idx + pos)
         for loop_i in range(loop):
@@ -515,41 +525,48 @@ def rejection_random_sample_block_verify_kernel(
                     token_idx = start_idx + pos
                     draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
 
-                    target_prob = 0.0
-                    found = False
-
-                    for v_offset in range(0, vocab_size, SUB_BLOCK):
-                        if not found:
-                            vocab_offsets = v_offset + tl.arange(0, SUB_BLOCK)
-                            vocab_mask = vocab_offsets < vocab_size
-
-                            candidate_indices = tl.load(
-                                target_indices_ptr + token_idx * vocab_size + vocab_offsets, mask=vocab_mask, other=-1
-                            )
-
-                            match_mask = candidate_indices == draft_token_id
-
-                            candidate_probs = tl.load(
-                                target_probs_ptr + token_idx * vocab_size + vocab_offsets, mask=vocab_mask, other=0.0
-                            )
-
-                            current_match_prob = tl.sum(candidate_probs * match_mask, axis=0)
-
-                            if current_match_prob > 0.0:
-                                target_prob = current_match_prob
-                                found = True
-
-                    tmp_uniform_prob = tl.load(uniform_probs_ptr + token_idx)
-                    uniform_prob = uniform_prob * tmp_uniform_prob
-
-                    if NO_DRAFT_PROBS:
-                        draft_prob = 1.0
+                    if draft_token_id == -1:
+                        pi = 0.0
                     else:
-                        draft_prob = tl.load(draft_probs_ptr + token_idx * global_vocab_size + draft_token_id)
+                        target_prob = 0.0
+                        found = False
 
-                    pi = min(pi * target_prob / draft_prob, 1.0)
-                    if draft_prob > 0 and pi >= uniform_prob:
-                        last_accepted_token_pos = pos
+                        for v_offset in range(0, vocab_size, SUB_BLOCK):
+                            if not found:
+                                vocab_offsets = v_offset + tl.arange(0, SUB_BLOCK)
+                                vocab_mask = vocab_offsets < vocab_size
+
+                                candidate_indices = tl.load(
+                                    target_indices_ptr + token_idx * vocab_size + vocab_offsets,
+                                    mask=vocab_mask,
+                                    other=-1,
+                                )
+
+                                match_mask = candidate_indices == draft_token_id
+
+                                candidate_probs = tl.load(
+                                    target_probs_ptr + token_idx * vocab_size + vocab_offsets,
+                                    mask=vocab_mask,
+                                    other=0.0,
+                                )
+
+                                current_match_prob = tl.sum(candidate_probs * match_mask, axis=0)
+
+                                if current_match_prob > 0.0:
+                                    target_prob = current_match_prob
+                                    found = True
+
+                        tmp_uniform_prob = tl.load(uniform_probs_ptr + token_idx)
+                        uniform_prob = uniform_prob * tmp_uniform_prob
+
+                        if NO_DRAFT_PROBS:
+                            draft_prob = 1.0
+                        else:
+                            draft_prob = tl.load(draft_probs_ptr + token_idx * global_vocab_size + draft_token_id)
+
+                        pi = min(pi * target_prob / draft_prob, 1.0)
+                        if draft_prob > 0 and pi >= uniform_prob:
+                            last_accepted_token_pos = pos
 
                 # Store accepted tokens
                 if last_accepted_token_pos > -1:
@@ -591,47 +608,55 @@ def rejection_random_sample_block_verify_kernel(
                 for pos in range(num_draft_tokens):
                     token_idx = start_idx + pos
                     draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
-                    target_prob = tl.load(target_probs_ptr + token_idx * vocab_size + draft_token_id)
-
-                    if NO_DRAFT_PROBS:
-                        draft_prob = 1.0
-                    else:
-                        draft_prob = tl.load(draft_probs_ptr + token_idx * vocab_size + draft_token_id)
-
-                    if draft_prob > 0:
-                        prefix_prob = min(prefix_prob * target_prob / draft_prob, 1.0)
-                    else:
+                    if draft_token_id == -1:
                         prefix_prob = 0.0
-
-                    if pos == num_draft_tokens - 1:
-                        h_block = prefix_prob
+                        h_block = 0.0
                     else:
-                        next_token_idx = token_idx + 1
+                        target_prob = tl.load(target_probs_ptr + token_idx * vocab_size + draft_token_id)
                         if NO_DRAFT_PROBS:
-                            next_draft_token_id = tl.load(draft_token_ids_ptr + next_token_idx)
-                            next_target_prob = tl.load(
-                                target_probs_ptr + next_token_idx * vocab_size + next_draft_token_id
-                            )
-                            residual_mass = prefix_prob * (1.0 - next_target_prob)
+                            draft_prob = 1.0
                         else:
-                            residual_mass = 0.0
-                            for loop_i in range(loop):
-                                vocab_start = loop_i * SUB_BLOCK
-                                vocab_offset = vocab_start + tl.arange(0, SUB_BLOCK)
-                                next_draft_prob = tl.load(
-                                    draft_probs_ptr + next_token_idx * vocab_size + vocab_offset,
-                                    mask=vocab_offset < vocab_size,
-                                    other=0,
-                                )
+                            draft_prob = tl.load(draft_probs_ptr + token_idx * vocab_size + draft_token_id)
+
+                        if draft_prob > 0:
+                            prefix_prob = min(prefix_prob * target_prob / draft_prob, 1.0)
+                        else:
+                            prefix_prob = 0.0
+
+                        if pos == num_draft_tokens - 1:
+                            h_block = prefix_prob
+                        else:
+                            next_token_idx = token_idx + 1
+                            if NO_DRAFT_PROBS:
+                                next_draft_token_id = tl.load(draft_token_ids_ptr + next_token_idx)
+                                safe_next_draft_token_id = tl.where(next_draft_token_id == -1, 0, next_draft_token_id)
                                 next_target_prob = tl.load(
-                                    target_probs_ptr + next_token_idx * vocab_size + vocab_offset,
-                                    mask=vocab_offset < vocab_size,
-                                    other=0,
+                                    target_probs_ptr + next_token_idx * vocab_size + safe_next_draft_token_id
                                 )
-                                residual_prob = tl.maximum(prefix_prob * next_target_prob - next_draft_prob, 0.0)
-                                residual_mass += tl.sum(residual_prob, axis=0)
-                        denom = residual_mass + 1.0 - prefix_prob
-                        h_block = residual_mass / denom if denom > 0 else 0.0
+                                residual_mass = tl.where(
+                                    next_draft_token_id == -1,
+                                    prefix_prob,
+                                    prefix_prob * (1.0 - next_target_prob),
+                                )
+                            else:
+                                residual_mass = 0.0
+                                for loop_i in range(loop):
+                                    vocab_start = loop_i * SUB_BLOCK
+                                    vocab_offset = vocab_start + tl.arange(0, SUB_BLOCK)
+                                    next_draft_prob = tl.load(
+                                        draft_probs_ptr + next_token_idx * vocab_size + vocab_offset,
+                                        mask=vocab_offset < vocab_size,
+                                        other=0,
+                                    )
+                                    next_target_prob = tl.load(
+                                        target_probs_ptr + next_token_idx * vocab_size + vocab_offset,
+                                        mask=vocab_offset < vocab_size,
+                                        other=0,
+                                    )
+                                    residual_prob = tl.maximum(prefix_prob * next_target_prob - next_draft_prob, 0.0)
+                                    residual_mass += tl.sum(residual_prob, axis=0)
+                            denom = residual_mass + 1.0 - prefix_prob
+                            h_block = residual_mass / denom if denom > 0 else 0.0
 
                     uniform_prob = tl.load(uniform_probs_ptr + token_idx)
                     if uniform_prob <= h_block:

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -865,13 +865,15 @@ def rejection_random_sample_pytorch(
     global_token_indices = cu_start[:, None] + pos_indices
     global_token_indices = global_token_indices.clamp(0, draft_token_ids.shape[0] - 1)
     draft_tokens = draft_token_ids[global_token_indices]  # [batch_size, max_draft_len]
+    placeholder_mask = draft_tokens == PLACEHOLDER_TOKEN_ID
+    safe_draft_tokens = draft_tokens.masked_fill(placeholder_mask, 0)
 
     if IS_NGRAM:
         ones_cpu = torch.ones(1, pin_memory=True, dtype=torch.float32)
         draft_token_probs = ones_cpu.to(device, non_blocking=True).expand_as(draft_tokens)
     else:
         flat_indices = global_token_indices.flatten()
-        flat_draft_tokens = draft_tokens.flatten()
+        flat_draft_tokens = safe_draft_tokens.flatten()
         flat_draft_probs = draft_probs[flat_indices, flat_draft_tokens]
         draft_token_probs = flat_draft_probs.view(batch_size, max_draft_len)
 
@@ -896,7 +898,7 @@ def rejection_random_sample_pytorch(
         target_token_probs = target_token_probs_flat.view(batch_size, max_draft_len)
     else:
         flat_indices = global_token_indices.flatten()
-        flat_draft_tokens = draft_tokens.flatten()
+        flat_draft_tokens = safe_draft_tokens.flatten()
         flat_target_probs = target_probs[flat_indices, flat_draft_tokens]
         target_token_probs = flat_target_probs.view(batch_size, max_draft_len)
 
@@ -909,6 +911,7 @@ def rejection_random_sample_pytorch(
     acceptance_condition = (draft_token_probs > zero_threshold) & (
         target_token_probs / draft_token_probs >= uniform_token_probs
     )
+    acceptance_condition = acceptance_condition & (~placeholder_mask)
 
     first_rejection = (~acceptance_condition) & valid_mask
 
@@ -1073,8 +1076,9 @@ def sample_recovered_tokens_pytorch(
             prob = target_probs.clone()
             for i in range(num_tokens):
                 draft_id = draft_token_ids[i]
-                mask = target_indices[i] == draft_id
-                prob[i, mask] = 0
+                if draft_id != PLACEHOLDER_TOKEN_ID:
+                    mask = target_indices[i] == draft_id
+                    prob[i, mask] = 0
         else:
             # Gather draft probs at candidate indices
             flat_indices = target_indices.flatten()
@@ -1098,7 +1102,8 @@ def sample_recovered_tokens_pytorch(
             token_indices = torch.arange(num_tokens, device=device)
 
             modified_target_probs = target_probs.clone()
-            modified_target_probs[token_indices, draft_token_ids] = 0
+            valid_draft_mask = draft_token_ids != PLACEHOLDER_TOKEN_ID
+            modified_target_probs[token_indices[valid_draft_mask], draft_token_ids[valid_draft_mask]] = 0
             prob = modified_target_probs
 
         else:
@@ -1158,13 +1163,15 @@ def rejection_random_sample_block_verify_pytorch(
     global_token_indices = cu_start[:, None] + pos_indices
     global_token_indices = global_token_indices.clamp(0, draft_token_ids.shape[0] - 1)
     draft_tokens = draft_token_ids[global_token_indices]
+    placeholder_mask = draft_tokens == PLACEHOLDER_TOKEN_ID
+    safe_draft_tokens = draft_tokens.masked_fill(placeholder_mask, 0)
 
     if IS_NGRAM:
         ones_cpu = torch.ones(1, pin_memory=True, dtype=torch.float32)
         draft_token_probs = ones_cpu.to(device, non_blocking=True).expand_as(draft_tokens)
     else:
         flat_indices = global_token_indices.flatten()
-        flat_draft_tokens = draft_tokens.flatten()
+        flat_draft_tokens = safe_draft_tokens.flatten()
         flat_draft_probs = draft_probs[flat_indices, flat_draft_tokens]
         draft_token_probs = flat_draft_probs.view(batch_size, max_spec_len)
 
@@ -1189,7 +1196,7 @@ def rejection_random_sample_block_verify_pytorch(
         target_token_probs = target_token_probs_flat.view(batch_size, max_spec_len)
     else:
         flat_indices = global_token_indices.flatten()
-        flat_draft_tokens = draft_tokens.flatten()
+        flat_draft_tokens = safe_draft_tokens.flatten()
         flat_target_probs = target_probs[flat_indices, flat_draft_tokens]
         target_token_probs = flat_target_probs.view(batch_size, max_spec_len)
 
@@ -1201,7 +1208,7 @@ def rejection_random_sample_block_verify_pytorch(
     pi = torch.cumprod(pi, dim=-1)
     uniform_token_probs = torch.cumprod(uniform_token_probs, dim=-1)
     legal_mask = (draft_token_probs > 0) & (pi >= uniform_token_probs)
-    legal_mask = legal_mask & valid_mask
+    legal_mask = legal_mask & valid_mask & (~placeholder_mask)
 
     last_accept_pos = torch.where(
         legal_mask.any(dim=-1, keepdim=True),
@@ -1264,7 +1271,14 @@ def sample_recovered_tokens_blockwise_pytorch(
     if IS_NGRAM:
         draft_token_scalar_probs = torch.ones(num_tokens, device=device, dtype=torch.float32)
     else:
-        draft_token_scalar_probs = draft_probs[token_indices, draft_token_ids]
+        valid_draft_mask = draft_token_ids != PLACEHOLDER_TOKEN_ID
+        safe_draft_token_ids = draft_token_ids.masked_fill(~valid_draft_mask, 0)
+        draft_token_scalar_probs = draft_probs[token_indices, safe_draft_token_ids]
+        draft_token_scalar_probs = torch.where(
+            valid_draft_mask,
+            draft_token_scalar_probs,
+            torch.zeros_like(draft_token_scalar_probs),
+        )
 
     # Get target probability for each draft token
     if enable_reduce_sampling:
@@ -1279,7 +1293,14 @@ def sample_recovered_tokens_blockwise_pytorch(
             torch.tensor(0.0, device=device),
         ).sum(dim=1)  # [num_tokens]
     else:
-        target_token_scalar_probs = target_probs[token_indices, draft_token_ids]
+        valid_draft_mask = draft_token_ids != PLACEHOLDER_TOKEN_ID
+        safe_draft_token_ids = draft_token_ids.masked_fill(~valid_draft_mask, 0)
+        target_token_scalar_probs = target_probs[token_indices, safe_draft_token_ids]
+        target_token_scalar_probs = torch.where(
+            valid_draft_mask,
+            target_token_scalar_probs,
+            torch.zeros_like(target_token_scalar_probs),
+        )
 
     per_token_ratio = torch.where(
         draft_token_scalar_probs > 0,
@@ -1304,8 +1325,9 @@ def sample_recovered_tokens_blockwise_pytorch(
             prob = target_probs.clone()
             for i in range(num_tokens):
                 draft_id = draft_token_ids[i]
-                mask = target_indices[i] == draft_id
-                prob[i, mask] = 0
+                if draft_id != PLACEHOLDER_TOKEN_ID:
+                    mask = target_indices[i] == draft_id
+                    prob[i, mask] = 0
             residual = torch.clamp(p_i_expanded * prob, min=0.0)
         else:
             # Gather draft probs at candidate indices (same as sample_recovered_tokens_pytorch)
@@ -1325,7 +1347,8 @@ def sample_recovered_tokens_blockwise_pytorch(
         # normal mode
         if IS_NGRAM:
             modified_target = target_probs.clone()
-            modified_target[token_indices, draft_token_ids] = 0.0
+            valid_draft_mask = draft_token_ids != PLACEHOLDER_TOKEN_ID
+            modified_target[token_indices[valid_draft_mask], draft_token_ids[valid_draft_mask]] = 0.0
             residual = torch.clamp(p_i_expanded * modified_target, min=0.0)
         else:
             residual = torch.clamp(p_i_expanded * target_probs - draft_probs, min=0.0)


### PR DESCRIPTION
### What this PR does / why we need it?
This PR backports the PD kv-consumer MTP placeholder sampling fix from #10043 onto `releases/v0.20.2rc`.

On the first decode step of the D node, PD kv-consumer MTP must keep `PLACEHOLDER_TOKEN_ID` (`-1`) in `spec_token_ids` to preserve the required full-graph decode shape. That value is a scheduling placeholder, not a real vocabulary token. The sampler must not use it as an index into target or draft probability tables.

The fix keeps the D-side MTP scheduling contract intact and moves the guard to rejection sampling:
- reject placeholder draft tokens directly and use the recovered token path;
- avoid reading target or draft probability tables with token id `-1` in Triton kernels;
- avoid Python fallback negative indexing so `-1` is not interpreted as the last vocabulary entry;
- add regression coverage for the PD consumer placeholder scheduling contract and placeholder-safe random rejection sampling.

Related: #10045, #10043

### Does this PR introduce _any_ user-facing change?
No API, configuration, or interface change.

This only changes bug behavior in the release branch: PD kv-consumer MTP placeholder draft tokens are rejected instead of being used as probability-table indices.

### How was this patch tested?
- `python -m py_compile tests/ut/core/test_recompute_scheduler.py tests/ut/sample/test_rejection_sampler.py vllm_ascend/ops/triton/reject_sample.py vllm_ascend/sample/rejection_sampler.py`
- `python -m pre_commit run --files tests/ut/core/test_recompute_scheduler.py tests/ut/sample/test_rejection_sampler.py vllm_ascend/ops/triton/reject_sample.py vllm_ascend/sample/rejection_sampler.py`
- `python -m pytest -q tests/ut/sample/test_rejection_sampler.py tests/ut/core/test_recompute_scheduler.py`