### PR TITLE
[EPLB][Test] Change mooncake port

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-W8A8-EPLB.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-W8A8-EPLB.yaml
@@ -1,4 +1,4 @@
-test_name: "test Qwen3-235B-A22B-W8A8 disaggregated_prefill"
+test_name: "test Qwen3-235B-A22B-W8A8 EPLB"
 model: "vllm-ascend/Qwen3-235B-A22B-W8A8"
 num_nodes: 2
 npu_per_node: 16
@@ -39,7 +39,7 @@ deployment:
         --kv-transfer-config
         '{"kv_connector": "MooncakeConnectorV1",
         "kv_role": "kv_producer",
-        "kv_port": "36000",
+        "kv_port": "30000",
         "kv_connector_extra_config": {
                   "prefill": {
                           "dp_size": 2,
@@ -52,7 +52,7 @@ deployment:
             }
         }'
         --additional-config
-        '{"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":2048,"algorithm_execution_interval":200}}'
+        '{"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":50,"algorithm_execution_interval":5}}'
 
   -
     envs:
@@ -76,7 +76,7 @@ deployment:
         --kv-transfer-config
         '{"kv_connector": "MooncakeConnectorV1",
         "kv_role": "kv_consumer",
-        "kv_port": "36100",
+        "kv_port": "30200",
         "kv_connector_extra_config": {
                   "prefill": {
                           "dp_size": 2,
@@ -89,5 +89,5 @@ deployment:
             }
         }'
         --additional-config
-        '{"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":2048,"algorithm_execution_interval":200}}'
+        '{"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":600,"algorithm_execution_interval":50}}'
 benchmarks:


### PR DESCRIPTION
### What this PR does / why we need it?
If mooncake uses port 36000, it is prone to being occupied. Therefore, the port is changed to 30000 to remain consistent with other use cases.

The port occupation issue is tracked by issue #8938 .

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
