### PR TITLE
[Scheduler][Feature] Implement LAPS-Inspired Prefill Scheduling for vllm-ascend

### DIFF
--- a/docs/source/user_guide/feature_guide/index.md
+++ b/docs/source/user_guide/feature_guide/index.md
@@ -17,6 +17,7 @@ rfork
 Multi_Token_Prediction
 dynamic_batch
 epd_disaggregation
+laps_scheduler
 kv_pool
 external_dp
 large_scale_ep

--- a/docs/source/user_guide/feature_guide/laps_scheduler.md
+++ b/docs/source/user_guide/feature_guide/laps_scheduler.md
@@ -1,0 +1,127 @@
+# LAPS-Inspired Prefill Scheduling
+
+`vllm-ascend` now provides an engine-side, NPU-oriented adaptation of the core
+LAPS scheduling idea from the paper *Length-Aware Prefill Scheduling for LLM
+Serving*.
+
+## What Was Ported
+
+The original LAPS artifact on top of SGLang contains three layers:
+
+1. Dual-queue scheduling for short and long prefills.
+2. A short-request waiting window to build better short-prefill batches.
+3. Dynamic GPU allocation in the router/load balancer.
+
+For `vllm-ascend`, the currently ported pieces are the **engine-local**
+mechanisms:
+
+- `triple-queue`: split the waiting queue into immediate, short, and long prompt
+  classes.
+- `waiting window`: optionally hold an isolated short request for a small time
+  window so that more short requests can join the same batch.
+
+The CUDA-specific `attention-in-graph` optimization from the LAPS SGLang branch
+was intentionally **not** ported, because it is tightly coupled to CUDA graph
+capture and FlashAttention internals. Likewise, router-level dynamic allocation
+has **not** been merged into the Ascend proxy layer yet.
+
+## Why It Fits `vllm-ascend`
+
+The vLLM scheduler already has a centralized waiting queue in the engine core,
+which makes the LAPS queueing policy portable without changing model execution
+code. This is a good match for NPU deployment because the main benefit here is
+request isolation and batching behavior, not CUDA-only kernel machinery.
+
+## Configuration
+
+Enable the feature with environment variables before launching `vllm serve`:
+
+```bash
+export VLLM_ASCEND_LAPS_SCHEDULING=1
+export VLLM_ASCEND_LAPS_THRESHOLD=256
+export VLLM_ASCEND_LAPS_WAIT_WINDOW_MS=5
+export VLLM_ASCEND_LAPS_WAIT_MAX_BATCH=4
+```
+
+### Variables
+
+- `VLLM_ASCEND_LAPS_SCHEDULING`
+  - `1` enables the Ascend LAPS scheduler.
+  - `0` disables it.
+- `VLLM_ASCEND_LAPS_THRESHOLD`
+  - Prompts with `num_prompt_tokens <= threshold` are treated as short.
+- `VLLM_ASCEND_LAPS_WAIT_WINDOW_MS`
+  - `0` means short requests dispatch immediately.
+  - Positive values keep an isolated short batch waiting briefly.
+- `VLLM_ASCEND_LAPS_WAIT_MAX_BATCH`
+  - Dispatch short requests early once this many short requests are queued,
+    even if the wait window has not expired.
+
+## How It Is Selected
+
+`vllm-ascend` selects the scheduler at config time:
+
+- `VLLM_ASCEND_LAPS_SCHEDULING=0`
+  - Keep the normal scheduler path.
+- `VLLM_ASCEND_LAPS_SCHEDULING=1` and `recompute_scheduler_enable=true`
+  - Keep `RecomputeScheduler`, and install the LAPS waiting queue inside it.
+- `VLLM_ASCEND_LAPS_SCHEDULING=1` and `recompute_scheduler_enable=false`
+  - LAPS is not activated. The platform logs a warning and keeps the default
+    scheduler path.
+- `SLO_limits_for_dynamic_batch != -1`
+  - `SchedulerDynamicBatch` takes precedence and LAPS is ignored.
+
+In other words, the effective priority is:
+
+`dynamic batch > recompute (+ optional LAPS) > default`
+
+## Minimal Examples
+
+Enable recompute scheduler together with LAPS:
+
+```bash
+export VLLM_ASCEND_LAPS_SCHEDULING=1
+export VLLM_ASCEND_LAPS_THRESHOLD=256
+export VLLM_ASCEND_LAPS_WAIT_WINDOW_MS=5
+export VLLM_ASCEND_LAPS_WAIT_MAX_BATCH=4
+
+vllm serve <model> \
+  --additional-config '{"recompute_scheduler_enable": true}'
+```
+
+Disable LAPS explicitly:
+
+```bash
+export VLLM_ASCEND_LAPS_SCHEDULING=0
+```
+
+## Scheduling Semantics
+
+The `LAPSRequestQueue` manages three queues:
+
+- **immediate queue**: Requests that must be dispatched immediately, such as
+  preempted requests or requests with already-computed tokens (recovery flows).
+- **short queue**: Short prefills where `num_prompt_tokens <= threshold`.
+- **long queue**: Long prefills where `num_prompt_tokens > threshold`.
+
+Dispatch priority is always: immediate > short > long.
+
+- Immediate requests are dispatched as soon as they arrive.
+- Short requests accumulate in a waiting window (if configured) to form larger
+  batches, or dispatch early if `wait_max_batch` is reached.
+- Long requests are only dispatched when no immediate or short requests are
+  schedulable.
+- If only short requests are queued and the waiting window has not expired,
+  the engine stays idle briefly instead of dispatching a tiny batch.
+
+## Current Scope and Limitations
+
+- The current implementation is enabled only for the **FCFS** scheduler policy.
+- The adaptation is **engine-local**; it does not yet rebalance prefill and
+  decode instances across nodes or proxies.
+- The implementation targets the vLLM waiting-queue layer and is intended for
+  PD / EPD style serving where prompt length skew is a dominant bottleneck.
+- LAPS currently requires `recompute_scheduler_enable=true`; enabling only
+  `VLLM_ASCEND_LAPS_SCHEDULING=1` is not sufficient.
+- When dynamic batch is selected through `SLO_limits_for_dynamic_batch`,
+  LAPS is not applied.

--- a/vllm_ascend/core/laps_scheduler.py
+++ b/vllm_ascend/core/laps_scheduler.py
@@ -1,0 +1,537 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Iterable, Iterator
+from enum import Enum
+from typing import Callable, cast
+
+from vllm.logger import logger
+from vllm.v1.core.sched.request_queue import (
+    RequestQueue,
+    SchedulingPolicy,
+    create_request_queue,
+)
+from vllm.v1.request import Request
+from vllm.v1.request import RequestStatus
+
+from vllm_ascend import envs
+
+
+class LAPSRequestQueue(RequestQueue):
+    """Two-level waiting queue for short and long prefills."""
+
+    _SKIP_OR_REQUEUE_REASONS = (
+        "blocked_waiting_status",
+        "max_loras",
+        "remote_kv_not_ready",
+    )
+
+    def __init__(
+        self,
+        policy: SchedulingPolicy,
+        threshold: int,
+        wait_window_ms: float,
+        wait_max_batch: int,
+        immediate_predicate: Callable[[Request], bool] | None = None,
+    ) -> None:
+        self.policy = policy
+        self.threshold = threshold
+        self.wait_window_ms = max(wait_window_ms, 0.0)
+        self.wait_max_batch = max(wait_max_batch, 1)
+        self.immediate_predicate = immediate_predicate
+        self._immediate_queue = create_request_queue(policy)
+        self._short_queue = create_request_queue(policy)
+        self._long_queue = create_request_queue(policy)
+        self._short_wait_started_at: float | None = None
+        self._short_ready_to_dispatch = False
+        self._stats_log_interval_s = max(
+            envs.VLLM_ASCEND_LAPS_STATS_LOG_INTERVAL_S, 0.0
+        )
+        self._last_stats_log_at = time.monotonic()
+        self._prepend_counters = {"immediate": 0, "short": 0, "long": 0}
+        self._dispatch_counters = {"immediate": 0, "short": 0, "long": 0}
+        self._skip_or_requeue_counters = {
+            reason: {"immediate": 0, "short": 0, "long": 0}
+            for reason in self._SKIP_OR_REQUEUE_REASONS
+        }
+        self._short_ready_reason_counters = {
+            "no_wait_window": 0,
+            "max_batch": 0,
+            "wait_window_elapsed": 0,
+        }
+        self._debug_logging_enabled = logger.isEnabledFor(logging.DEBUG)
+        self._force_immediate_request_ids: set[str] = set()
+        self._queue_index: dict[str, RequestQueue] = {}
+
+    def _queues(self) -> tuple[RequestQueue, ...]:
+        return (self._immediate_queue, self._short_queue, self._long_queue)
+
+    def _queue_name(self, queue: RequestQueue) -> str:
+        if queue is self._immediate_queue:
+            return "immediate"
+        if queue is self._short_queue:
+            return "short"
+        if queue is self._long_queue:
+            return "long"
+        return "unknown"
+
+    def _short_wait_elapsed_ms(self) -> float | None:
+        if self._short_wait_started_at is None:
+            return None
+        return (time.monotonic() - self._short_wait_started_at) * 1000.0
+
+    def _short_wait_state(self) -> str:
+        if not self._short_queue:
+            return "empty"
+        if self._short_ready_to_dispatch:
+            return "ready"
+        if self.wait_window_ms <= 0:
+            return "no_wait"
+        elapsed_ms = self._short_wait_elapsed_ms()
+        if elapsed_ms is None:
+            return "pending"
+        return f"waiting({elapsed_ms:.3f}/{self.wait_window_ms:.3f}ms)"
+
+    def _maybe_log_stats(self, force: bool = False) -> None:
+        if self._stats_log_interval_s <= 0:
+            return
+        now = time.monotonic()
+        if not force and (now - self._last_stats_log_at) < self._stats_log_interval_s:
+            return
+        self._last_stats_log_at = now
+        logger.info(
+            "LAPS stats: threshold=%d wait_window_ms=%.3f wait_max_batch=%d "
+            "sizes=(immediate=%d short=%d long=%d) short_state=%s "
+            "prepends=%s dispatches=%s skip_or_requeues=%s "
+            "short_ready_reasons=%s",
+            self.threshold,
+            self.wait_window_ms,
+            self.wait_max_batch,
+            len(self._immediate_queue),
+            len(self._short_queue),
+            len(self._long_queue),
+            self._short_wait_state(),
+            self._prepend_counters,
+            self._dispatch_counters,
+            self._skip_or_requeue_counters,
+            self._short_ready_reason_counters,
+        )
+
+    def _record_short_ready_reason(self, reason: str) -> None:
+        if reason in self._short_ready_reason_counters:
+            self._short_ready_reason_counters[reason] += 1
+
+    def _increment_skip_or_requeue_counter(
+        self, queue: RequestQueue, reason: str
+    ) -> None:
+        if reason not in self._skip_or_requeue_counters:
+            raise ValueError(f"Unknown skip_or_requeue reason: {reason}")
+        self._skip_or_requeue_counters[reason][self._queue_name(queue)] += 1
+
+    def _debug_state(
+        self,
+        event: str,
+        request: Request | None = None,
+        queue: RequestQueue | None = None,
+        extra: str = "",
+    ) -> None:
+        if not self._debug_logging_enabled:
+            return
+        request_id = "-" if request is None else request.request_id
+        prompt_tokens = -1 if request is None else request.num_prompt_tokens
+        queue_name = "-" if queue is None else self._queue_name(queue)
+        extra_suffix = f", {extra}" if extra else ""
+        logger.debug(
+            "LAPS queue %s: request_id=%s, prompt_tokens=%d, target_queue=%s, "
+            "sizes=(immediate=%d, short=%d, long=%d), short_state=%s%s",
+            event,
+            request_id,
+            prompt_tokens,
+            queue_name,
+            len(self._immediate_queue),
+            len(self._short_queue),
+            len(self._long_queue),
+            self._short_wait_state(),
+            extra_suffix,
+        )
+
+    @property
+    def num_immediate_requests(self) -> int:
+        return len(self._immediate_queue)
+
+    @property
+    def num_short_requests(self) -> int:
+        return len(self._short_queue)
+
+    @property
+    def num_long_requests(self) -> int:
+        return len(self._long_queue)
+
+    def has_short_requests(self) -> bool:
+        return len(self._short_queue) > 0
+
+    def has_long_requests(self) -> bool:
+        return len(self._long_queue) > 0
+
+    def has_immediate_requests(self) -> bool:
+        return len(self._immediate_queue) > 0
+
+    def _classify_queue(
+        self, request: Request, *, force_immediate: bool = False
+    ) -> RequestQueue:
+        if force_immediate or request.request_id in self._force_immediate_request_ids:
+            return self._immediate_queue
+        if self.immediate_predicate is not None and self.immediate_predicate(request):
+            return self._immediate_queue
+        if request.num_prompt_tokens <= self.threshold:
+            return self._short_queue
+        return self._long_queue
+
+    def _on_short_queue_changed(self) -> None:
+        if not self._short_queue:
+            self._short_wait_started_at = None
+            self._short_ready_to_dispatch = False
+            self._debug_state("short_reset")
+            return
+        if self._short_ready_to_dispatch:
+            return
+        if self.wait_window_ms <= 0 or len(self._short_queue) >= self.wait_max_batch:
+            self._short_wait_started_at = None
+            self._short_ready_to_dispatch = True
+            reason = "no_wait_window" if self.wait_window_ms <= 0 else "max_batch"
+            self._record_short_ready_reason(reason)
+            self._debug_state("short_ready", extra=f"reason={reason}")
+            self._maybe_log_stats()
+            return
+        if self._short_wait_started_at is None:
+            self._short_wait_started_at = time.monotonic()
+            self._debug_state("short_wait_started")
+
+    def _short_batch_ready(self) -> bool:
+        if not self._short_queue:
+            self._short_wait_started_at = None
+            self._short_ready_to_dispatch = False
+            return False
+        if self._short_ready_to_dispatch:
+            return True
+        if self.wait_window_ms <= 0:
+            self._short_wait_started_at = None
+            self._short_ready_to_dispatch = True
+            self._record_short_ready_reason("no_wait_window")
+            self._debug_state("short_ready", extra="reason=no_wait_window")
+            self._maybe_log_stats()
+            return True
+        if len(self._short_queue) >= self.wait_max_batch:
+            self._short_wait_started_at = None
+            self._short_ready_to_dispatch = True
+            self._record_short_ready_reason("max_batch")
+            self._debug_state("short_ready", extra="reason=max_batch")
+            self._maybe_log_stats()
+            return True
+        if self._short_wait_started_at is None:
+            self._short_wait_started_at = time.monotonic()
+            self._debug_state("short_wait_started")
+            return False
+        elapsed_ms = (time.monotonic() - self._short_wait_started_at) * 1000.0
+        if elapsed_ms >= self.wait_window_ms:
+            self._short_wait_started_at = None
+            self._short_ready_to_dispatch = True
+            self._record_short_ready_reason("wait_window_elapsed")
+            self._debug_state(
+                "short_ready",
+                extra=f"reason=wait_window_elapsed, elapsed_ms={elapsed_ms:.3f}",
+            )
+            self._maybe_log_stats()
+            return True
+        return False
+
+    def _select_schedulable_queue(self) -> RequestQueue | None:
+        if self._immediate_queue:
+            return self._immediate_queue
+        if self._short_batch_ready():
+            return self._short_queue
+        if self._long_queue:
+            return self._long_queue
+        return None
+
+    def has_schedulable_requests(self) -> bool:
+        """Return whether a request can be dispatched right now."""
+        return self._select_schedulable_queue() is not None
+
+    def select_waiting_queue_for_scheduling(self) -> RequestQueue | None:
+        return self._select_schedulable_queue()
+
+    def mark_force_immediate(self, request_id: str) -> None:
+        self._force_immediate_request_ids.add(request_id)
+
+    @staticmethod
+    def _request_id(request: Request | object) -> str | None:
+        return getattr(request, "request_id", None)
+
+    def _find_matching_request(
+        self, queue: RequestQueue, request: Request | object
+    ) -> Request | None:
+        request_id = self._request_id(request)
+        if request_id is None:
+            return None
+        for candidate in queue:
+            if candidate.request_id == request_id:
+                return cast(Request, candidate)
+        return None
+
+    def add_request(self, request: Request) -> None:
+        queue = self._classify_queue(request)
+        queue.add_request(request)
+        self._queue_index[request.request_id] = queue
+        if queue is not self._immediate_queue:
+            self._force_immediate_request_ids.discard(request.request_id)
+        if queue is self._short_queue:
+            self._on_short_queue_changed()
+        self._debug_state("enqueue", request=request, queue=queue)
+        self._maybe_log_stats()
+
+    def pop_request(self) -> Request:
+        queue = self._select_schedulable_queue()
+        if queue is None:
+            raise IndexError("pop from empty LAPS queue")
+        return self.pop_request_from_queue(queue)
+
+    def pop_request_from_queue(
+        self,
+        queue: RequestQueue,
+        *,
+        count_as_removal: bool = False,
+        skip_or_requeue_reason: str | None = None,
+    ) -> Request:
+        request = queue.pop_request()
+        self._queue_index.pop(request.request_id, None)
+        if count_as_removal:
+            if skip_or_requeue_reason is not None:
+                self._increment_skip_or_requeue_counter(
+                    queue, skip_or_requeue_reason
+                )
+                event_name = f"skip_or_requeue:{skip_or_requeue_reason}"
+            else:
+                event_name = "remove"
+        else:
+            self._dispatch_counters[self._queue_name(queue)] += 1
+            event_name = "dispatch"
+        self._force_immediate_request_ids.discard(request.request_id)
+        if queue is self._short_queue:
+            self._on_short_queue_changed()
+        self._debug_state(event_name, request=request, queue=queue)
+        self._maybe_log_stats()
+        return request
+
+    def peek_request(self) -> Request:
+        queue = self._select_schedulable_queue()
+        if queue is None:
+            raise IndexError("peek from an empty LAPS queue")
+        return queue.peek_request()
+
+    def prepend_request(self, request: Request, force_immediate: bool = False) -> None:
+        if force_immediate:
+            self._force_immediate_request_ids.add(request.request_id)
+        queue = self._classify_queue(request, force_immediate=force_immediate)
+        queue.prepend_request(request)
+        self._queue_index[request.request_id] = queue
+        self._prepend_counters[self._queue_name(queue)] += 1
+        if queue is self._short_queue:
+            self._on_short_queue_changed()
+        self._debug_state("prepend", request=request, queue=queue)
+        self._maybe_log_stats()
+
+    def prepend_requests(self, requests: RequestQueue) -> None:
+        for request in requests:
+            self.prepend_request(cast(Request, request))
+
+    def remove_request(self, request: Request) -> None:
+        queue = self._queue_index.get(request.request_id)
+        if queue is None:
+            raise ValueError("request not found in LAPS queue")
+        matched_request = self._find_matching_request(queue, request)
+        if matched_request is None:
+            raise ValueError("request not found in LAPS queue")
+        queue.remove_request(matched_request)
+        self._queue_index.pop(request.request_id, None)
+        self._force_immediate_request_ids.discard(request.request_id)
+        if queue is self._short_queue:
+            self._on_short_queue_changed()
+        self._debug_state("remove", request=matched_request, queue=queue)
+        self._maybe_log_stats()
+
+    def remove_requests(self, requests: Iterable[Request]) -> None:
+        queue_to_requests: dict[int, list[Request]] = {}
+        queue_map = {id(q): q for q in self._queues()}
+        removed_count = 0
+        for request in requests:
+            queue = self._queue_index.get(request.request_id)
+            if queue is None:
+                continue
+            matched_request = self._find_matching_request(queue, request)
+            if matched_request is not None:
+                queue_to_requests.setdefault(id(queue), []).append(matched_request)
+        for queue_id, matched_requests in queue_to_requests.items():
+            removed_count += len(matched_requests)
+            queue = queue_map[queue_id]
+            queue.remove_requests(matched_requests)
+            for matched in matched_requests:
+                self._queue_index.pop(matched.request_id, None)
+                self._force_immediate_request_ids.discard(matched.request_id)
+        self._on_short_queue_changed()
+        if removed_count:
+            self._debug_state("remove_batch", extra=f"count={removed_count}")
+            self._maybe_log_stats()
+
+    def __bool__(self) -> bool:
+        return self._select_schedulable_queue() is not None
+
+    def __len__(self) -> int:
+        return (
+            len(self._immediate_queue)
+            + len(self._short_queue)
+            + len(self._long_queue)
+        )
+
+    def __iter__(self) -> Iterator[Request]:
+        yield from self._immediate_queue
+        yield from self._short_queue
+        yield from self._long_queue
+
+    def __contains__(self, request: object) -> bool:
+        request_id = self._request_id(request)
+        return request_id is not None and request_id in self._queue_index
+
+
+class _LAPSRequestClass(Enum):
+    SHORT_PREFILL = "short_prefill"
+    LONG_PREFILL = "long_prefill"
+
+
+class LAPSSchedulerMixin:
+    """Inject a LAPS-style waiting queue into vLLM's scheduler."""
+
+    def _get_attached_waiting_computed_tokens(self, request: Request) -> int | None:
+        return None
+
+    def _should_bypass_laps_wait_window(self, request: Request) -> bool:
+        """Recovery-style requests should not be delayed by short wait windows."""
+        return (
+            request.status == RequestStatus.PREEMPTED
+            or request.num_computed_tokens > 0
+            or request.num_external_computed_tokens > 0
+            or self._get_attached_waiting_computed_tokens(request) is not None
+            or request.num_output_tokens > 0
+        )
+
+    def _init_laps_waiting_queue(
+        self,
+        immediate_predicate: Callable[[Request], bool] | None = None,
+    ) -> None:
+        if self.policy != SchedulingPolicy.FCFS:
+            logger.warning_once(
+                "VLLM_ASCEND_LAPS_SCHEDULING currently supports only FCFS "
+                "scheduler policy; keeping the default waiting queue."
+            )
+            return
+
+        if immediate_predicate is None:
+            immediate_predicate = self._should_bypass_laps_wait_window
+        threshold = envs.VLLM_ASCEND_LAPS_THRESHOLD
+        wait_window_ms = envs.VLLM_ASCEND_LAPS_WAIT_WINDOW_MS
+        wait_max_batch = envs.VLLM_ASCEND_LAPS_WAIT_MAX_BATCH
+        self.waiting = LAPSRequestQueue(
+            policy=self.policy,
+            threshold=threshold,
+            wait_window_ms=wait_window_ms,
+            wait_max_batch=wait_max_batch,
+            immediate_predicate=immediate_predicate,
+        )
+        logger.info(
+            "LAPS scheduling enabled on Ascend: threshold=%d, "
+            "wait_window_ms=%.3f, wait_max_batch=%d",
+            threshold,
+            wait_window_ms,
+            wait_max_batch,
+        )
+
+    def _laps_waiting_queue(self) -> LAPSRequestQueue | None:
+        if isinstance(self.waiting, LAPSRequestQueue):
+            return self.waiting
+        return None
+
+    def _laps_threshold(self) -> int:
+        laps_waiting = self._laps_waiting_queue()
+        if laps_waiting is not None:
+            return laps_waiting.threshold
+        return envs.VLLM_ASCEND_LAPS_THRESHOLD
+
+    def _classify_laps_request(
+        self, request: Request, num_computed_tokens: int | None = None
+    ) -> _LAPSRequestClass | None:
+        computed = (
+            request.num_computed_tokens
+            if num_computed_tokens is None
+            else num_computed_tokens
+        )
+        if computed >= request.num_prompt_tokens:
+            return None
+        if request.num_prompt_tokens <= self._laps_threshold():
+            return _LAPSRequestClass.SHORT_PREFILL
+        return _LAPSRequestClass.LONG_PREFILL
+
+    def _is_prefill_request(
+        self, request: Request, num_computed_tokens: int | None = None
+    ) -> bool:
+        return self._classify_laps_request(request, num_computed_tokens) is not None
+
+    def _is_short_prefill_request(
+        self, request: Request, num_computed_tokens: int | None = None
+    ) -> bool:
+        return (
+            self._classify_laps_request(request, num_computed_tokens)
+            is _LAPSRequestClass.SHORT_PREFILL
+        )
+
+    def _is_long_prefill_request(
+        self, request: Request, num_computed_tokens: int | None = None
+    ) -> bool:
+        return (
+            self._classify_laps_request(request, num_computed_tokens)
+            is _LAPSRequestClass.LONG_PREFILL
+        )
+
+    def _select_waiting_queue_for_scheduling(self) -> RequestQueue | None:
+        waiting = getattr(self, "waiting", None)
+        if isinstance(waiting, LAPSRequestQueue):
+            skipped_waiting = getattr(self, "skipped_waiting", None)
+            if self.policy == SchedulingPolicy.FCFS and skipped_waiting:
+                return skipped_waiting
+            queue = waiting.select_waiting_queue_for_scheduling()
+            if queue is not None:
+                return queue
+            return skipped_waiting or None
+        return super()._select_waiting_queue_for_scheduling()
+
+    def _preempt_request(self, request: Request, timestamp: float) -> None:
+        waiting = getattr(self, "waiting", None)
+        if isinstance(waiting, LAPSRequestQueue):
+            waiting.mark_force_immediate(request.request_id)
+        super()._preempt_request(request, timestamp)

--- a/vllm_ascend/core/laps_scheduler.py
+++ b/vllm_ascend/core/laps_scheduler.py
@@ -18,9 +18,9 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from enum import Enum
-from typing import Callable, cast
+from typing import cast
 
 from vllm.logger import logger
 from vllm.v1.core.sched.request_queue import (
@@ -28,8 +28,7 @@ from vllm.v1.core.sched.request_queue import (
     SchedulingPolicy,
     create_request_queue,
 )
-from vllm.v1.request import Request
-from vllm.v1.request import RequestStatus
+from vllm.v1.request import Request, RequestStatus
 
 from vllm_ascend import envs
 
@@ -61,15 +60,12 @@ class LAPSRequestQueue(RequestQueue):
         self._long_queue = create_request_queue(policy)
         self._short_wait_started_at: float | None = None
         self._short_ready_to_dispatch = False
-        self._stats_log_interval_s = max(
-            envs.VLLM_ASCEND_LAPS_STATS_LOG_INTERVAL_S, 0.0
-        )
+        self._stats_log_interval_s = max(envs.VLLM_ASCEND_LAPS_STATS_LOG_INTERVAL_S, 0.0)
         self._last_stats_log_at = time.monotonic()
         self._prepend_counters = {"immediate": 0, "short": 0, "long": 0}
         self._dispatch_counters = {"immediate": 0, "short": 0, "long": 0}
         self._skip_or_requeue_counters = {
-            reason: {"immediate": 0, "short": 0, "long": 0}
-            for reason in self._SKIP_OR_REQUEUE_REASONS
+            reason: {"immediate": 0, "short": 0, "long": 0} for reason in self._SKIP_OR_REQUEUE_REASONS
         }
         self._short_ready_reason_counters = {
             "no_wait_window": 0,
@@ -138,9 +134,7 @@ class LAPSRequestQueue(RequestQueue):
         if reason in self._short_ready_reason_counters:
             self._short_ready_reason_counters[reason] += 1
 
-    def _increment_skip_or_requeue_counter(
-        self, queue: RequestQueue, reason: str
-    ) -> None:
+    def _increment_skip_or_requeue_counter(self, queue: RequestQueue, reason: str) -> None:
         if reason not in self._skip_or_requeue_counters:
             raise ValueError(f"Unknown skip_or_requeue reason: {reason}")
         self._skip_or_requeue_counters[reason][self._queue_name(queue)] += 1
@@ -193,9 +187,7 @@ class LAPSRequestQueue(RequestQueue):
     def has_immediate_requests(self) -> bool:
         return len(self._immediate_queue) > 0
 
-    def _classify_queue(
-        self, request: Request, *, force_immediate: bool = False
-    ) -> RequestQueue:
+    def _classify_queue(self, request: Request, *, force_immediate: bool = False) -> RequestQueue:
         if force_immediate or request.request_id in self._force_immediate_request_ids:
             return self._immediate_queue
         if self.immediate_predicate is not None and self.immediate_predicate(request):
@@ -285,9 +277,7 @@ class LAPSRequestQueue(RequestQueue):
     def _request_id(request: Request | object) -> str | None:
         return getattr(request, "request_id", None)
 
-    def _find_matching_request(
-        self, queue: RequestQueue, request: Request | object
-    ) -> Request | None:
+    def _find_matching_request(self, queue: RequestQueue, request: Request | object) -> Request | None:
         request_id = self._request_id(request)
         if request_id is None:
             return None
@@ -324,9 +314,7 @@ class LAPSRequestQueue(RequestQueue):
         self._queue_index.pop(request.request_id, None)
         if count_as_removal:
             if skip_or_requeue_reason is not None:
-                self._increment_skip_or_requeue_counter(
-                    queue, skip_or_requeue_reason
-                )
+                self._increment_skip_or_requeue_counter(queue, skip_or_requeue_reason)
                 event_name = f"skip_or_requeue:{skip_or_requeue_reason}"
             else:
                 event_name = "remove"
@@ -404,11 +392,7 @@ class LAPSRequestQueue(RequestQueue):
         return self._select_schedulable_queue() is not None
 
     def __len__(self) -> int:
-        return (
-            len(self._immediate_queue)
-            + len(self._short_queue)
-            + len(self._long_queue)
-        )
+        return len(self._immediate_queue) + len(self._short_queue) + len(self._long_queue)
 
     def __iter__(self) -> Iterator[Request]:
         yield from self._immediate_queue
@@ -465,8 +449,7 @@ class LAPSSchedulerMixin:
             immediate_predicate=immediate_predicate,
         )
         logger.info(
-            "LAPS scheduling enabled on Ascend: threshold=%d, "
-            "wait_window_ms=%.3f, wait_max_batch=%d",
+            "LAPS scheduling enabled on Ascend: threshold=%d, wait_window_ms=%.3f, wait_max_batch=%d",
             threshold,
             wait_window_ms,
             wait_max_batch,
@@ -486,37 +469,21 @@ class LAPSSchedulerMixin:
     def _classify_laps_request(
         self, request: Request, num_computed_tokens: int | None = None
     ) -> _LAPSRequestClass | None:
-        computed = (
-            request.num_computed_tokens
-            if num_computed_tokens is None
-            else num_computed_tokens
-        )
+        computed = request.num_computed_tokens if num_computed_tokens is None else num_computed_tokens
         if computed >= request.num_prompt_tokens:
             return None
         if request.num_prompt_tokens <= self._laps_threshold():
             return _LAPSRequestClass.SHORT_PREFILL
         return _LAPSRequestClass.LONG_PREFILL
 
-    def _is_prefill_request(
-        self, request: Request, num_computed_tokens: int | None = None
-    ) -> bool:
+    def _is_prefill_request(self, request: Request, num_computed_tokens: int | None = None) -> bool:
         return self._classify_laps_request(request, num_computed_tokens) is not None
 
-    def _is_short_prefill_request(
-        self, request: Request, num_computed_tokens: int | None = None
-    ) -> bool:
-        return (
-            self._classify_laps_request(request, num_computed_tokens)
-            is _LAPSRequestClass.SHORT_PREFILL
-        )
+    def _is_short_prefill_request(self, request: Request, num_computed_tokens: int | None = None) -> bool:
+        return self._classify_laps_request(request, num_computed_tokens) is _LAPSRequestClass.SHORT_PREFILL
 
-    def _is_long_prefill_request(
-        self, request: Request, num_computed_tokens: int | None = None
-    ) -> bool:
-        return (
-            self._classify_laps_request(request, num_computed_tokens)
-            is _LAPSRequestClass.LONG_PREFILL
-        )
+    def _is_long_prefill_request(self, request: Request, num_computed_tokens: int | None = None) -> bool:
+        return self._classify_laps_request(request, num_computed_tokens) is _LAPSRequestClass.LONG_PREFILL
 
     def _select_waiting_queue_for_scheduling(self) -> RequestQueue | None:
         waiting = getattr(self, "waiting", None)

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -46,6 +46,9 @@ from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.utils import ConstantList, record_function_or_nullcontext
 
+from vllm_ascend import envs
+from vllm_ascend.core.laps_scheduler import LAPSSchedulerMixin
+
 
 # `spec_manager_map` in single_type_kv_cache_manager is a module-level dict
 # whose keys are class objects bound at import time.  When the async
@@ -104,7 +107,7 @@ class RecomputeSchedulerOutput(SchedulerOutput):
     recomputed_reqs: list[RecomputeReqInfo] | None = None
 
 
-class RecomputeScheduler(Scheduler):
+class RecomputeScheduler(LAPSSchedulerMixin, Scheduler):
     running: list[Request]
 
     def __init__(self, *args, **kwargs):
@@ -124,6 +127,25 @@ class RecomputeScheduler(Scheduler):
             "qwen3_next" in self.vllm_config.model_config.hf_text_config.model_type
             or "qwen3_5" in self.vllm_config.model_config.hf_text_config.model_type
         )
+        if envs.VLLM_ASCEND_LAPS_SCHEDULING:
+            self._init_laps_waiting_queue()
+
+    def _pop_waiting_request(
+        self,
+        request_queue,
+        count_with_laps: bool,
+        *,
+        count_as_removal: bool = False,
+        skip_or_requeue_reason: str | None = None,
+    ) -> Request:
+        if count_with_laps:
+            laps_waiting = self._laps_waiting_queue()
+            return laps_waiting.pop_request_from_queue(
+                request_queue,
+                count_as_removal=count_as_removal,
+                skip_or_requeue_reason=skip_or_requeue_reason,
+            )
+        return request_queue.pop_request()
 
     def add_request(self, request: Request) -> None:
         existing = self.requests.get(request.request_id)
@@ -242,6 +264,7 @@ class RecomputeScheduler(Scheduler):
 
         # For logging.
         scheduled_timestamp = time.monotonic()
+        laps_waiting = self._laps_waiting_queue()
 
         self.kv_cache_manager.new_step_starts()
 
@@ -441,6 +464,12 @@ class RecomputeScheduler(Scheduler):
 
                 request_queue = self._select_waiting_queue_for_scheduling()
                 assert request_queue is not None
+                
+                # skipped_waiting is not owned by LAPSRequestQueue, so only route
+                # pops through LAPS when the selected queue is one of its subqueues.
+                count_with_laps = (
+                    laps_waiting is not None and request_queue in laps_waiting._queues()
+                )
 
                 request = request_queue.peek_request()
                 request_id = request.request_id
@@ -454,7 +483,12 @@ class RecomputeScheduler(Scheduler):
                             "%s is still in WAITING_FOR_REMOTE_KVS state.",
                             request_id,
                         )
-                    request_queue.pop_request()
+                    self._pop_waiting_request(
+                        request_queue,
+                        count_with_laps,
+                        count_as_removal=True,
+                        skip_or_requeue_reason="blocked_waiting_status",
+                    )
                     step_skipped_waiting.prepend_request(request)
                     continue
 
@@ -469,7 +503,12 @@ class RecomputeScheduler(Scheduler):
                     )
                 ):
                     # Scheduling would exceed max_loras, skip.
-                    request_queue.pop_request()
+                    self._pop_waiting_request(
+                        request_queue,
+                        count_with_laps,
+                        count_as_removal=True,
+                        skip_or_requeue_reason="max_loras",
+                    )
                     step_skipped_waiting.prepend_request(request)
                     continue
 
@@ -494,7 +533,12 @@ class RecomputeScheduler(Scheduler):
                             # The request cannot be scheduled because
                             # the KVConnector couldn't determine
                             # the number of matched tokens.
-                            request_queue.pop_request()
+                            self._pop_waiting_request(
+                                request_queue,
+                                count_with_laps,
+                                count_as_removal=True,
+                                skip_or_requeue_reason="remote_kv_not_ready",
+                            )
                             step_skipped_waiting.prepend_request(request)
                             continue
 
@@ -622,7 +666,7 @@ class RecomputeScheduler(Scheduler):
                             preempted=request.num_preemptions > 0,
                         )
 
-                request = request_queue.pop_request()
+                request = self._pop_waiting_request(request_queue, count_with_laps)
                 if load_kv_async:
                     # If loading async, allocate memory and put request
                     # into the WAITING_FOR_REMOTE_KV state.

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -464,12 +464,10 @@ class RecomputeScheduler(LAPSSchedulerMixin, Scheduler):
 
                 request_queue = self._select_waiting_queue_for_scheduling()
                 assert request_queue is not None
-                
+
                 # skipped_waiting is not owned by LAPSRequestQueue, so only route
                 # pops through LAPS when the selected queue is one of its subqueues.
-                count_with_laps = (
-                    laps_waiting is not None and request_queue in laps_waiting._queues()
-                )
+                count_with_laps = laps_waiting is not None and request_queue in laps_waiting._queues()
 
                 request = request_queue.peek_request()
                 request_id = request.request_id

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -122,9 +122,7 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Optional periodic LAPS stats logging interval, in seconds. Set to 0 to
     # disable aggregate stats logging. This is intended for benchmark
     # observability without enabling global DEBUG logging.
-    "VLLM_ASCEND_LAPS_STATS_LOG_INTERVAL_S": lambda: float(
-        os.getenv("VLLM_ASCEND_LAPS_STATS_LOG_INTERVAL_S", "0")
-    ),
+    "VLLM_ASCEND_LAPS_STATS_LOG_INTERVAL_S": lambda: float(os.getenv("VLLM_ASCEND_LAPS_STATS_LOG_INTERVAL_S", "0")),
     # use fused op transpose_kv_cache_by_block, default is True
     "VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK": lambda: bool(
         int(os.getenv("VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK", "1"))

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -105,6 +105,26 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Platform validation: only PD-mixed mode (`kv_role='kv_both'` or no kv_transfer_config).
     # Not supported in PD-disaggregated mode (`kv_producer` / `kv_consumer` only).
     "VLLM_ASCEND_BALANCE_SCHEDULING": lambda: bool(int(os.getenv("VLLM_ASCEND_BALANCE_SCHEDULING", "0"))),
+    # Whether to enable LAPS-style length-aware prefill scheduling on the
+    # engine side. This currently targets the FCFS waiting queue path.
+    "VLLM_ASCEND_LAPS_SCHEDULING": lambda: bool(int(os.getenv("VLLM_ASCEND_LAPS_SCHEDULING", "0"))),
+    # Prompt-length threshold used by LAPS scheduling. Requests with
+    # num_prompt_tokens <= threshold are treated as short prefills.
+    "VLLM_ASCEND_LAPS_THRESHOLD": lambda: int(os.getenv("VLLM_ASCEND_LAPS_THRESHOLD", "256")),
+    # Optional waiting window for short requests, in milliseconds. When set to
+    # 0, short requests dispatch immediately. When positive, the scheduler may
+    # hold a short batch briefly to accumulate more short prefills while still
+    # allowing long prefills to run.
+    "VLLM_ASCEND_LAPS_WAIT_WINDOW_MS": lambda: float(os.getenv("VLLM_ASCEND_LAPS_WAIT_WINDOW_MS", "0")),
+    # Maximum number of short requests to accumulate before dispatching early,
+    # even if the waiting window has not expired yet.
+    "VLLM_ASCEND_LAPS_WAIT_MAX_BATCH": lambda: int(os.getenv("VLLM_ASCEND_LAPS_WAIT_MAX_BATCH", "4")),
+    # Optional periodic LAPS stats logging interval, in seconds. Set to 0 to
+    # disable aggregate stats logging. This is intended for benchmark
+    # observability without enabling global DEBUG logging.
+    "VLLM_ASCEND_LAPS_STATS_LOG_INTERVAL_S": lambda: float(
+        os.getenv("VLLM_ASCEND_LAPS_STATS_LOG_INTERVAL_S", "0")
+    ),
     # use fused op transpose_kv_cache_by_block, default is True
     "VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK": lambda: bool(
         int(os.getenv("VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK", "1"))

--- a/vllm_ascend/eplb/core/policy/policy_flashlb.py
+++ b/vllm_ascend/eplb/core/policy/policy_flashlb.py
@@ -475,13 +475,8 @@ class FlashTree:
                 high,
                 initial_replicas,
                 width,
-                lambda mid,
-                ci=current_idx,
-                crf=current_replicas_f,
-                ri=remaind_idx,
-                rrf=remaind_replicas_f,
-                nar=num_available_replicas: get_score(
-                    _lpt_deployment, X_row, deployed_replicas, ci, crf[mid], ri, rrf[nar - mid]
+                lambda mid, ci=current_idx, crf=current_replicas_f, ri=remaind_idx, rrf=remaind_replicas_f, nar=num_available_replicas: (
+                    get_score(_lpt_deployment, X_row, deployed_replicas, ci, crf[mid], ri, rrf[nar - mid])
                 ),
             )
 

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -132,6 +132,9 @@ class NPUPlatform(Platform):
 
     @classmethod
     def pre_register_and_update(cls, parser: FlexibleArgumentParser | None = None) -> None:
+        # Register Ascend-specific env vars before vLLM validates VLLM_* names.
+        envs_vllm.environment_variables.update(envs_ascend.env_variables)
+
         # Adapt the global patch here.
         from vllm_ascend.utils import adapt_patch
 
@@ -458,6 +461,16 @@ class NPUPlatform(Platform):
                     "PD-disaggregated mode (kv_role='kv_producer'/'kv_consumer')."
                 )
 
+        enable_laps = envs_ascend.VLLM_ASCEND_LAPS_SCHEDULING
+        laps_supported_policy = vllm_config.scheduler_config.policy == "fcfs"
+        if enable_laps and not laps_supported_policy:
+            logger.warning_once(
+                "VLLM_ASCEND_LAPS_SCHEDULING currently supports only FCFS "
+                "scheduler policy; current policy=%s. The default waiting "
+                "queue will be used.",
+                vllm_config.scheduler_config.policy,
+            )
+
         if ascend_config.recompute_scheduler_enable:
             kv_transfer_config = vllm_config.kv_transfer_config
             kv_role = getattr(kv_transfer_config, "kv_role", None)
@@ -471,9 +484,30 @@ class NPUPlatform(Platform):
 
             recompute_scheduler_config = RecomputeSchedulerConfig.initialize_from_config(vllm_config)
             vllm_config.scheduler_config = recompute_scheduler_config
+            if enable_laps:
+                logger.info(
+                    "Ascend LAPS scheduler selected through recompute "
+                    "scheduler: scheduler_cls=%s, policy=%s, threshold=%d, "
+                    "wait_window_ms=%.3f, wait_max_batch=%d",
+                    vllm_config.scheduler_config.scheduler_cls,
+                    vllm_config.scheduler_config.policy,
+                    envs_ascend.VLLM_ASCEND_LAPS_THRESHOLD,
+                    envs_ascend.VLLM_ASCEND_LAPS_WAIT_WINDOW_MS,
+                    envs_ascend.VLLM_ASCEND_LAPS_WAIT_MAX_BATCH,
+                )
+        elif enable_laps:
+            logger.warning_once(
+                "VLLM_ASCEND_LAPS_SCHEDULING requires recompute_scheduler_enable=true "
+                "in ascend_config. LAPS scheduling will not be activated.",
+            )
 
         # Extend original scheduler_config to use SchedulerDynamicBatch.
         if ascend_config.SLO_limits_for_dynamic_batch != -1:
+            if enable_laps:
+                logger.warning_once(
+                    "VLLM_ASCEND_LAPS_SCHEDULING is ignored because "
+                    "SLO_limits_for_dynamic_batch selects SchedulerDynamicBatch."
+                )
             vllm_config.scheduler_config.scheduler_cls = (
                 "vllm_ascend.core.scheduler_dynamic_batch.SchedulerDynamicBatch"
             )


### PR DESCRIPTION
### What this PR does / why we need it?
This PR implements an engine-side, NPU-oriented adaptation of Length-Aware Prefill Scheduling (LAPS) for `vllm-ascend`. It introduces a triple-queue scheduling mechanism (immediate, short, and long prompt classes) and an optional waiting window to accumulate short requests into larger batches. This is integrated into the `RecomputeScheduler` and configured via environment variables.

Feedback was provided to optimize the `remove_request` and `remove_requests` methods in `LAPSRequestQueue` by removing redundant linear scans, which improves the removal complexity from $O(M)$ to $O(1)$.

### Does this PR introduce _any_ user-facing change?
Yes, it introduces new environment variables (`VLLM_ASCEND_LAPS_SCHEDULING`, `VLLM_ASCEND_LAPS_THRESHOLD`, `VLLM_ASCEND_LAPS_WAIT_WINDOW_MS`, `VLLM_ASCEND_LAPS_WAIT_MAX_BATCH`, `VLLM_ASCEND_LAPS_STATS_LOG_INTERVAL_S`) to configure and enable LAPS scheduling.

### How was this patch tested?
No new unit tests were added in this PR. Testing should be performed to verify the scheduling behavior under skewed prompt length workloads.