### PR TITLE
[BugFix] [Kimi] Fix dense draft model (Kimi-MLA) misidentified as MoE

### DIFF
--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -894,7 +894,7 @@ def is_drafter_moe_model(vllm_config: VllmConfig):
         model_configs = vllm_config.speculative_config.draft_model_config.hf_text_config.to_dict()
         _IS_DRAFTER_MOE_MODEL = _is_contain_expert(model_configs)
         if not model_configs or not model_configs.get("architectures"):
-            return _IS_DRAFTER_MOE_MODEL       
+            return _IS_DRAFTER_MOE_MODEL
         if "Eagle3DeepseekV2ForCausalLM" in model_configs["architectures"]:
             _IS_DRAFTER_MOE_MODEL = False
     return _IS_DRAFTER_MOE_MODEL

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -893,8 +893,9 @@ def is_drafter_moe_model(vllm_config: VllmConfig):
     if _IS_DRAFTER_MOE_MODEL is None:
         model_configs = vllm_config.speculative_config.draft_model_config.hf_text_config.to_dict()
         _IS_DRAFTER_MOE_MODEL = _is_contain_expert(model_configs)
-        architectures = (model_configs or {}).get("architectures") or []  
-        if "Eagle3DeepseekV2ForCausalLM" in architectures:
+        if not model_configs or not model_configs.get("architectures"):
+            return _IS_DRAFTER_MOE_MODEL       
+        if "Eagle3DeepseekV2ForCausalLM" in model_configs["architectures"]:
             _IS_DRAFTER_MOE_MODEL = False
     return _IS_DRAFTER_MOE_MODEL
 

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -893,6 +893,8 @@ def is_drafter_moe_model(vllm_config: VllmConfig):
     if _IS_DRAFTER_MOE_MODEL is None:
         model_configs = vllm_config.speculative_config.draft_model_config.hf_text_config.to_dict()
         _IS_DRAFTER_MOE_MODEL = _is_contain_expert(model_configs)
+        if "architectures" in model_configs and "Eagle3DeepseekV2ForCausalLM" in model_configs["architectures"]:
+            _IS_DRAFTER_MOE_MODEL = False
     return _IS_DRAFTER_MOE_MODEL
 
 

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -893,12 +893,8 @@ def is_drafter_moe_model(vllm_config: VllmConfig):
     if _IS_DRAFTER_MOE_MODEL is None:
         model_configs = vllm_config.speculative_config.draft_model_config.hf_text_config.to_dict()
         _IS_DRAFTER_MOE_MODEL = _is_contain_expert(model_configs)
-        if (
-            model_configs 
-            and "architectures" in model_configs 
-            and model_configs["architectures"] 
-            and "Eagle3DeepseekV2ForCausalLM" in model_configs["architectures"]
-        ):
+        architectures = (model_configs or {}).get("architectures") or []  
+        if "Eagle3DeepseekV2ForCausalLM" in architectures:
             _IS_DRAFTER_MOE_MODEL = False
     return _IS_DRAFTER_MOE_MODEL
 

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -896,7 +896,7 @@ def is_drafter_moe_model(vllm_config: VllmConfig):
         if (
             model_configs 
             and "architectures" in model_configs 
-            and model_configs["architectures"]  # 确保不为 None 且不为空
+            and model_configs["architectures"] 
             and "Eagle3DeepseekV2ForCausalLM" in model_configs["architectures"]
         ):
             _IS_DRAFTER_MOE_MODEL = False

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -893,7 +893,12 @@ def is_drafter_moe_model(vllm_config: VllmConfig):
     if _IS_DRAFTER_MOE_MODEL is None:
         model_configs = vllm_config.speculative_config.draft_model_config.hf_text_config.to_dict()
         _IS_DRAFTER_MOE_MODEL = _is_contain_expert(model_configs)
-        if "architectures" in model_configs and "Eagle3DeepseekV2ForCausalLM" in model_configs["architectures"]:
+        if (
+            model_configs 
+            and "architectures" in model_configs 
+            and model_configs["architectures"]  # 确保不为 None 且不为空
+            and "Eagle3DeepseekV2ForCausalLM" in model_configs["architectures"]
+        ):
             _IS_DRAFTER_MOE_MODEL = False
     return _IS_DRAFTER_MOE_MODEL
 


### PR DESCRIPTION
### What this PR does / why we need it?

Background & Issue:
Currently, vLLM's configuration loading mechanism automatically propagates the target (main) model's configuration attributes to the draft model during speculative decoding setup.

This causes a critical issue when using Kimi-K2.6 based speculative draft models (specifically lightseekorg/kimi-k2.6-eagle3-mla) alongside an MoE main model in an Ascend (NPU) environment where Sequence Parallelism is enabled via export VLLM_ASCEND_ENABLE_FLASHCOMM1=1.

Although Kimi-K2.6 is a dense model utilizing the Eagle3 architecture, the configuration inheritance erroneously passes the main model's MoE attributes to it. As a result, vLLM misidentifies the dense draft model as an MoE model.

Under the VLLM_ASCEND_ENABLE_FLASHCOMM1=1 environment, vLLM executes specialized optimization and communication pathways for MoE models. Because the draft model is misclassified as MoE, it illegally enters these pathways during initialization, throwing fatal errors and failing to boot.

### Does this PR introduce _any_ user-facing change?
No. This is an internal bugfix for the configuration propagation logic in speculative decoding. It does not alter any public APIs, but it enables proper out-of-the-box support for Kimi-K2.6 as a draft model.

### How was this patch tested?

1. Manual Verification:Verified by launching the vLLM server on an Ascend environment with an MoE main model and `lightseekorg/kimi-k2.6-eagle3-mla` as the speculative draft model.
   
   Environment Setup:
```bash
     export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
  ```
   Before this patch:The initialization failed because the draft model was misidentified as MoE, causing the `VLLM_ASCEND_ENABLE_FLASHCOMM1` workflow to throw a configuration/runtime error on the dense draft model.
   After this patch: The server launched successfully; the draft model was correctly treated as dense and successfully bypassed the MoE-FlashComm execution path.

2. Regression Testing:Checked against other standard dense/MoE draft model combinations to ensure no side effects on standard speculative decoding pipelines.

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
