### PR TITLE
[Performance]earse the synconize when enable sampling params

### DIFF
--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -7,7 +7,9 @@ from vllm.distributed.parallel_state import get_tp_group
 from vllm.logger import logger
 from vllm.triton_utils import HAS_TRITON
 from vllm.v1.outputs import SamplerOutput
+from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.ops.bad_words import apply_bad_words_with_drafts
 from vllm.v1.sample.rejection_sampler import (
     GREEDY_TEMPERATURE,
     MAX_SPEC_LEN,
@@ -94,6 +96,55 @@ class AscendRejectionSampler(RejectionSampler):
             HAS_TRITON,
             get_ascend_config().enable_reduce_sample,
         )
+
+    def apply_logits_processors(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+        metadata: SpecDecodeMetadata,
+    ) -> torch.Tensor:
+        has_penalties = not sampling_metadata.no_penalties
+        any_penalties_or_bad_words = sampling_metadata.bad_words_token_ids or has_penalties
+
+        output_token_ids = sampling_metadata.output_token_ids
+        if any_penalties_or_bad_words:
+            output_token_ids = self._combine_outputs_with_spec_tokens(
+                output_token_ids,
+                sampling_metadata.spec_token_ids,
+            )
+
+        # Calculate indices of target logits.
+        if sampling_metadata.allowed_token_ids_mask is not None or has_penalties:
+            # num_requests = len(metadata.num_draft_tokens)
+            # num_draft_tokens = torch.tensor(metadata.num_draft_tokens, device="cpu")
+            # original_indices = torch.arange(num_requests, device="cpu")
+            # repeat_indices_cpu = original_indices.repeat_interleave(num_draft_tokens)
+            # repeat_indices = repeat_indices_cpu.to(
+            #     device=logits.device, non_blocking=True
+            # )
+            num_requests = len(metadata.num_draft_tokens)
+            original_indices = torch.arange(num_requests, device=logits.device, dtype=torch.long)
+            repeat_indices = expand_batch_to_tokens(
+                original_indices,
+                metadata.cu_num_draft_tokens,
+                logits.shape[0],
+            )
+            logits = self.apply_penalties(logits, sampling_metadata, metadata, repeat_indices, output_token_ids)
+
+            # Apply allowed token ids.
+            if sampling_metadata.allowed_token_ids_mask is not None:
+                token_mask = sampling_metadata.allowed_token_ids_mask[repeat_indices]
+                logits.masked_fill_(token_mask, float("-inf"))
+
+        # Apply bad words exclusion.
+        if bad_words_token_ids := sampling_metadata.bad_words_token_ids:
+            apply_bad_words_with_drafts(logits, bad_words_token_ids, output_token_ids, metadata.num_draft_tokens)
+
+        for processor in sampling_metadata.logitsprocs.non_argmax_invariant:
+            if isinstance(processor, MinTokensLogitsProcessor):
+                logits = processor.apply_with_spec_decode(logits, metadata.num_draft_tokens)
+
+        return logits
 
     def forward(
         self,

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -115,13 +115,6 @@ class AscendRejectionSampler(RejectionSampler):
 
         # Calculate indices of target logits.
         if sampling_metadata.allowed_token_ids_mask is not None or has_penalties:
-            # num_requests = len(metadata.num_draft_tokens)
-            # num_draft_tokens = torch.tensor(metadata.num_draft_tokens, device="cpu")
-            # original_indices = torch.arange(num_requests, device="cpu")
-            # repeat_indices_cpu = original_indices.repeat_interleave(num_draft_tokens)
-            # repeat_indices = repeat_indices_cpu.to(
-            #     device=logits.device, non_blocking=True
-            # )
             num_requests = len(metadata.num_draft_tokens)
             original_indices = torch.arange(num_requests, device=logits.device, dtype=torch.long)
             repeat_indices = expand_batch_to_tokens(

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -116,6 +116,10 @@ class AscendRejectionSampler(RejectionSampler):
         # Calculate indices of target logits.
         if sampling_metadata.allowed_token_ids_mask is not None or has_penalties:
             num_requests = len(metadata.num_draft_tokens)
+            # TODO: The apply_logits_processors function originally reused the base class from the
+            # upper-level vLLM module. However, the current vLLM implementation introduces synchronous
+            # host-to-device (H2D) copy operations. This function will be removed once PR
+            # https://github.com/vllm-project/vllm/pull/46323 is merged into the upstream vLLM repository.
             original_indices = torch.arange(num_requests, device=logits.device, dtype=torch.long)
             repeat_indices = expand_batch_to_tokens(
                 original_indices,


### PR DESCRIPTION
### What this PR does / why we need it?
The func apply_logits_processors will cause a h2d copy when enable sampling params.
Replace the repeat_interleave with an existing triton kernel to avoid the synconize.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
