### PR TITLE
[Misc]Fix AttributeError in RecomputeScheduler due to missing routed experts extraction logic

### DIFF
--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -46,6 +46,8 @@ from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.utils import ConstantList, record_function_or_nullcontext
 
+from vllm_ascend.utils import vllm_version_is
+
 
 # `spec_manager_map` in single_type_kv_cache_manager is a module-level dict
 # whose keys are class objects bound at import time.  When the async
@@ -838,6 +840,26 @@ class RecomputeScheduler(Scheduler):
                     )
                 )
 
+        # Persist per-step routed experts into the scheduler-side slot buffer.
+        # MUST precede the per-request routing reads below.
+        routing_data = None
+        routing_offsets: dict[str, int] = {}
+        if (
+            not vllm_version_is("0.21.0")
+            and getattr(self, "enable_return_routed_experts", False)
+            and model_runner_output.routed_experts is not None
+        ):
+            re = model_runner_output.routed_experts
+            self.routed_experts_mgr.store_batch(re.routing_data, re.slot_mapping)
+            routing_data = re.routing_data.astype(
+                self.routed_experts_mgr.routed_experts_by_slot.dtype,
+                copy=False,
+            )
+            offset = 0
+            for rid in model_runner_output.req_ids:
+                routing_offsets[rid] = offset
+                offset += num_scheduled_tokens[rid]
+
         # NOTE(woosuk): As len(num_scheduled_tokens) can be up to 1K or more,
         # the below loop can be a performance bottleneck. We should do our best
         # to avoid expensive operations inside the loop.
@@ -892,6 +914,7 @@ class RecomputeScheduler(Scheduler):
             pooler_output = pooler_outputs[req_index] if pooler_outputs else None
             kv_transfer_params = None
             status_before_stop = request.status
+            num_output_tokens_before = len(request._output_token_ids)
 
             # Check for stop and update request status.
             if new_token_ids:
@@ -902,10 +925,41 @@ class RecomputeScheduler(Scheduler):
                 stopped = True
 
             routed_experts = None
+            if vllm_version_is("0.21.0"):
+                if (
+                    model_runner_output.routed_experts_dict is not None
+                    and req_id in model_runner_output.routed_experts_dict
+                ):
+                    routed_experts = model_runner_output.routed_experts_dict[req_id]
+            elif (
+                getattr(self, "enable_return_routed_experts", False)
+                and routing_data is not None
+                and new_token_ids
+            ):
+                req_offset = routing_offsets[req_id]
+                end = req_offset + num_tokens_scheduled
+                block_ids = self._re_block_ids.pop(req_id, [])
+                if num_output_tokens_before == 0:
+                    if (
+                        request.sampling_params is not None
+                        and request.sampling_params.routed_experts_prompt_start is not None
+                    ):
+                        prompt_start = request.sampling_params.routed_experts_prompt_start
+                        assert prompt_start < request.num_prompt_tokens
+                    else:
+                        prompt_start = 0
+                    routed_experts = self.routed_experts_mgr.get(
+                        block_ids,
+                        request.num_prompt_tokens,
+                        token_start=prompt_start,
+                    )
+                elif scheduled_spec_token_ids:
+                    routed_experts = routing_data[req_offset : req_offset + len(new_token_ids)]
+                else:
+                    routed_experts = routing_data[end - len(new_token_ids) : end]
+
             finish_reason = None
             if stopped:
-                routed_experts = self._get_routed_experts(request)
-
                 # Capture finish_reason BEFORE _handle_stopped_request, which may
                 # reset the status to WAITING for streaming requests that continue.
                 finish_reason = request.get_finished_reason()

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -931,11 +931,7 @@ class RecomputeScheduler(Scheduler):
                     and req_id in model_runner_output.routed_experts_dict
                 ):
                     routed_experts = model_runner_output.routed_experts_dict[req_id]
-            elif (
-                getattr(self, "enable_return_routed_experts", False)
-                and routing_data is not None
-                and new_token_ids
-            ):
+            elif getattr(self, "enable_return_routed_experts", False) and routing_data is not None and new_token_ids:
                 req_offset = routing_offsets[req_id]
                 end = req_offset + num_tokens_scheduled
                 block_ids = self._re_block_ids.pop(req_id, [])


### PR DESCRIPTION
### What this PR does / why we need it?
part of #10215 

Summary
Fixes a crash in RecomputeScheduler / AsyncRecomputeScheduler when a request finishes, caused by calling a non-existent _get_routed_experts() method:

AttributeError: 'AsyncRecomputeScheduler' object has no attribute '_get_routed_experts'
This is triggered when all of the following are true:

Async scheduling is enabled (uses AsyncRecomputeScheduler)
A request stops in the current step (stopped=True)
Reproducible on both vLLM v0.21.0 and main commit 9090368b650896bf5fc990c921df7eb4c20355a5.
### Does this PR introduce _any_ user-facing change?
Yes. After this fix, in async scheduling + recompute scheduler scenarios:

The service no longer crashes due to the missing _get_routed_experts method
When enable_return_routed_experts=True, routed experts are correctly returned via EngineCoreOutput
No API or interface changes.

### How was this patch tested?

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
