### PR TITLE
[Scheduler][Feature] Implement LAPS-Inspired Prefill Scheduling for vllm-ascend

### DIFF
--- a/.github/workflows/scripts/config.yaml
+++ b/.github/workflows/scripts/config.yaml
@@ -15,6 +15,8 @@ e2e-singlecard:
   estimated_time: 187
 - name: tests/e2e/singlecard/test_async_scheduling.py
   estimated_time: 252
+- name: tests/e2e/singlecard/test_laps_scheduling.py
+  estimated_time: 150
 - name: tests/e2e/singlecard/test_batch_invariant.py
   estimated_time: 506
 - name: tests/e2e/singlecard/test_camem.py

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -46,6 +46,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `layer_sharding`                    | dict | `{}`    | Configuration options for Layer Sharding Linear. In PD-disaggregated deployments, it is supported only on P nodes with `kv_role="kv_producer"`. |
 | `enable_sparse_c8`                  | bool | `False` | Whether to enable KV cache C8 in DSA models (e.g., DeepSeekV3.2 and GLM5). Not supported on A5 devices now |
 | `enable_mc2_hierarchy_comm`         | bool | `False` | Enable dispatch/combine op inter-node communication by ROCE. |
+| `laps_config`                       | dict | `{}`    | Configuration options for LAPS length-aware prefill scheduling. Requires `recompute_scheduler_enable=true`. |
 
 The details of each configuration option are as follows:
 
@@ -93,6 +94,19 @@ The details of each configuration option are as follows:
 | `algorithm_execution_interval`   | int | `30`   | The forward iterations when the EPLB worker will finish CPU tasks. |
 | `expert_map_record_path`         | str | `None` | Save the expert load calculation results to a new expert table in the specified directory.|
 | `num_redundant_experts`          | int | `0`    | Specify redundant experts during initialization. |
+
+**laps_config**
+
+LAPS-style length-aware prefill scheduling (triple-queue + token-bucket anti-starvation aging). Only takes effect together with `recompute_scheduler_enable=true` and the FCFS scheduler policy.
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `enabled`                | bool  | `False` | Whether to enable LAPS scheduling. |
+| `threshold`              | int   | `256`   | Prompt-length threshold (tokens). Requests with `num_prompt_tokens <= threshold` are treated as short prefills and prioritized over long prefills. |
+| `long_max_wait_ms`       | float | `0.0`   | Anti-starvation aging bound for long prefills, in milliseconds. A long request that has waited longer than this becomes eligible for promotion ahead of short prefills, admitted only through the token-reservation bucket (no unconditional deadline bypass). `0` disables aging (strict short-priority). When `> 0`, requires `long_token_reservation > 0`. |
+| `long_token_reservation` | float | `0.0`   | Average fraction of token throughput reserved for admitting aged-long prefills ahead of waiting shorts (token-bucket smoothing) — the only channel that promotes aged longs. Must be in `[0.0, 1.0]` (out-of-range values are rejected). Must be `> 0` whenever `long_max_wait_ms > 0`. |
+| `long_burst_steps`       | int   | `4`     | Burst window (scheduling steps) the aged-long token bucket may accumulate; bucket capacity = `long_token_reservation * per-step token budget * long_burst_steps`. Advanced knob; must be `>= 1`. |
+| `stats_log_interval_s`   | float | `0.0`   | Periodic LAPS stats logging interval, in seconds. `0` disables it. |
 
 ### Example
 

--- a/docs/source/user_guide/feature_guide/index.md
+++ b/docs/source/user_guide/feature_guide/index.md
@@ -17,6 +17,7 @@ rfork
 Multi_Token_Prediction
 dynamic_batch
 epd_disaggregation
+laps_scheduler
 kv_pool
 external_dp
 large_scale_ep

--- a/docs/source/user_guide/feature_guide/laps_scheduler.md
+++ b/docs/source/user_guide/feature_guide/laps_scheduler.md
@@ -1,0 +1,151 @@
+# LAPS-Inspired Prefill Scheduling
+
+`vllm-ascend` now provides an engine-side, NPU-oriented adaptation of the core LAPS scheduling idea from the paper *Length-Aware Prefill Scheduling for LLM Serving*.
+
+## What Was Ported
+
+The original LAPS artifact on top of SGLang contains three layers:
+
+1. Dual-queue scheduling for short and long prefills.
+2. A short-request waiting window to build better short-prefill batches.
+3. Dynamic GPU allocation in the router/load balancer.
+
+For `vllm-ascend`, the currently ported pieces are the **engine-local** mechanisms:
+
+- `triple-queue`: split the waiting queue into immediate, short, and long prompt classes.
+- `anti-starvation (aging)`: bound how long a long prefill can be held behind short prefills, so a sustained short-request stream cannot starve long requests indefinitely.
+
+The original LAPS short-request *waiting window* was **not** ported: vLLM v1 already performs continuous batching (it re-batches all running requests and admits new ones up to the token/running budget every step, with chunked prefill), so manually accumulating a short batch is redundant and only adds latency.
+
+The CUDA-specific `attention-in-graph` optimization from the LAPS SGLang branch was intentionally **not** ported, because it is tightly coupled to CUDA graph capture and FlashAttention internals (and is incompatible with the two-stage sparse attention used by models such as DeepSeek-V4). Likewise, router-level dynamic allocation has **not** been merged into the Ascend proxy layer yet.
+
+## Why It Fits `vllm-ascend`
+
+The vLLM scheduler already has a centralized waiting queue in the engine core, which makes the LAPS queueing policy portable without changing model execution code. This is a good match for NPU deployment because the main benefit here is request isolation and batching behavior, not CUDA-only kernel machinery.
+
+## Configuration
+
+LAPS is configured through `--additional-config` (the canonical source), under a `laps_config` block. It requires `recompute_scheduler_enable: true` in the same `additional_config`:
+
+```bash
+vllm serve <model> \
+  --additional-config '{
+    "recompute_scheduler_enable": true,
+    "laps_config": {
+      "enabled": true,
+      "threshold": 256,
+      "long_max_wait_ms": 2000,
+      "long_token_reservation": 0.2,
+      "stats_log_interval_s": 0
+    }
+  }'
+```
+
+### `laps_config` fields
+
+- `enabled` (bool, default `false`)
+    - `true` enables the Ascend LAPS scheduler.
+- `threshold` (int, default `256`)
+    - Prompts with `num_prompt_tokens <= threshold` are treated as short.
+- `long_max_wait_ms` (float, default `0`)
+    - Anti-starvation aging bound for long prefills, in milliseconds.
+    - `0` disables aging (strict short-priority).
+    - Once the oldest long has waited `>= long_max_wait_ms` it becomes *eligible* to be promoted ahead of waiting shorts, but the actual promotion goes through the token-reservation bucket only (see `long_token_reservation`), which rate-limits aged-long admissions. There is **no unconditional deadline bypass**: the bucket is the single admission channel, so a backlog of aged longs can never flip the queue into long-first.
+    - Requires `long_token_reservation > 0` when set (enforced by config validation); otherwise the bucket never refills and aging would be inert.
+- `long_token_reservation` (float, default `0.0`, range `[0.0, 1.0]`)
+    - Average fraction of token throughput reserved for **admitting** aged-long prefills ahead of waiting shorts. This is the *only* channel through which an aged long jumps a waiting short.
+    - Implemented as a token bucket: it refills by `reservation * per-step token budget` every scheduling step (burst capped at a few steps' worth), and admitting an aged-long ahead of shorts spends that credit. An aged-long is promoted only while the bucket has credit; once spent, shorts are preferred until the bucket refills (typically within a handful of steps). This caps the aged-long admission rate at the reservation fraction and prevents a backlog of aged longs from flipping the queue into long-first and starving shorts.
+    - Must be `> 0` whenever `long_max_wait_ms > 0` (config validation rejects the `long_max_wait_ms > 0, reservation = 0` combination). Larger values drain aged-long requests faster at the cost of short-request latency; the degradation to shorts is bounded by roughly the reservation fraction.
+    - The bucket bounds the *admission rate*, not total compute: once admitted, a long prefill proceeds chunk-by-chunk through the normal running loop.
+    - The bucket refills against `max_num_scheduled_tokens` (the full per-step budget), not the budget left after running requests. Under sustained backlog the bucket therefore tends to stay topped up, so aged longs are admitted at close to the full reservation rate. This errs toward stronger anti-starvation and is an intentional trade-off (see "Behavior under saturation" below).
+- `long_burst_steps` (int, default `4`, range `>= 1`)
+    - Burst window, in scheduling steps, the aged-long bucket may accumulate: capacity = `long_token_reservation * per-step token budget * long_burst_steps`. Advanced knob; the default suits most workloads.
+- `stats_log_interval_s` (float, default `0`)
+    - Periodic LAPS stats logging interval, in seconds. `0` disables it. Intended for benchmark observability without enabling global DEBUG logging.
+
+## How It Is Selected
+
+`vllm-ascend` selects the scheduler at config time:
+
+- `laps_config.enabled = false`
+    - Keep the normal scheduler path.
+- `laps_config.enabled = true` and `recompute_scheduler_enable = true`
+    - Keep `RecomputeScheduler`, and install the LAPS waiting queue inside it.
+- `laps_config.enabled = true` and `recompute_scheduler_enable = false`
+    - LAPS is not activated. The platform logs a warning and keeps the default scheduler path.
+- `SLO_limits_for_dynamic_batch != -1`
+    - `SchedulerDynamicBatch` takes precedence and LAPS is ignored.
+
+In other words, the effective priority is:
+
+`dynamic batch > recompute (+ optional LAPS) > default`
+
+## Minimal Examples
+
+Enable recompute scheduler together with LAPS:
+
+```bash
+vllm serve <model> \
+  --additional-config '{
+    "recompute_scheduler_enable": true,
+    "laps_config": {
+      "enabled": true,
+      "threshold": 256,
+      "long_max_wait_ms": 2000,
+      "long_token_reservation": 0.2
+    }
+  }'
+```
+
+Disable LAPS explicitly (the default):
+
+```bash
+vllm serve <model> \
+  --additional-config '{"laps_config": {"enabled": false}}'
+```
+
+## Scheduling Semantics
+
+The `LapsRequestQueue` manages three queues:
+
+- **immediate queue**: Requests that must be dispatched immediately, such as preempted requests or requests with already-computed tokens (recovery flows).
+- **short queue**: Short prefills where `num_prompt_tokens <= threshold`.
+- **long queue**: Long prefills where `num_prompt_tokens > threshold`.
+
+Dispatch priority is: immediate > aged-long > short > long.
+
+- Immediate requests are dispatched as soon as they arrive.
+- Short requests are dispatched whenever the short queue is non-empty (vLLM's continuous batching groups them together each step).
+- Long requests are normally only dispatched when no immediate or short requests are schedulable.
+- **Anti-starvation (token-bucket aging):** aging kicks in once the oldest long request has waited longer than `laps_config.long_max_wait_ms`. The aged long is then promoted ahead of shorts **only** through the token-reservation bucket: while the bucket has credit it is promoted; once the credit is spent, shorts are preferred until the bucket refills (a few steps). There is deliberately no unconditional deadline bypass, so the aged-long admission rate is capped at the reservation fraction and the scheduler can never flip into long-first.
+- **Token reservation (the single admission channel):** the bucket refills `laps_config.long_token_reservation` of the per-step token budget each step (burst capped at a few steps' worth). Admitting an aged-long ahead of shorts spends the long's **full remaining prefill** from the bucket — not just the current chunk. This matters because a long prefill monopolizes the per-step token budget for many steps; charging only the first chunk would let the per-step refill outpace the charge, so the bucket would never drain and the reservation would fail to throttle (a backlog of longs could then starve shorts entirely). Charging the full cost instead drives the bucket well below zero for a big long; the per-step refill repays that debt over the steps the long actually runs, and meanwhile shorts are preferred (a negative bucket blocks further promotions). When no short request is waiting, long is dispatched regardless of the bucket (stall avoidance) and is **not** charged or counted as a starvation promotion, since it did not jump the queue. Larger reservations drain aged-long requests faster at the cost of short-request latency; the cost to shorts is bounded by roughly the reservation fraction.
+
+### Behavior under saturation (overload)
+
+The aging signal is **absolute wall-clock wait time**. That assumes a long which has waited past `long_max_wait_ms` is being singled out by a short stream — true only when the queue is *not* saturated. Under sustained overload, where the whole queue's residence time (e.g. tens of seconds) dwarfs any practical `long_max_wait_ms`, *every* long is perpetually "aged", so the signal can no longer distinguish a starved long from a generally overloaded system.
+
+This is why the bucket is the single admission channel and the deadline bypass was removed: under overload an unconditional bypass would promote aged longs back-to-back and reintroduce the head-of-line blocking LAPS exists to remove, inflating both mean and (especially) tail TTFT. With the bucket as the sole channel, the contract is:
+
+- Aging **never** flips scheduling into long-first; shorts always retain `1 - reservation` of throughput.
+- The cost of aging to short-request latency is **bounded and tunable** at ~`reservation`. It is not free — any anti-starvation that promotes longs takes some throughput from shorts — but a small reservation (e.g. `0.05`–`0.1`) keeps the short-side impact minor while still giving longs a steady reserved drain.
+- The trade-off is that there is no hard wall-clock upper bound on an individual long's wait; under overload such a bound is unachievable anyway (the system simply cannot keep up). Long wait is instead bounded by the reserved drain rate. Tune `reservation` up if long tail latency matters more than short TTFT.
+
+## Observability
+
+LAPS behavior is exposed through a periodic, opt-in log line (`laps_config.stats_log_interval_s > 0`): an aggregate `LAPS stats: ...` line with queue sizes, dispatch/skip counters, `long_starvation_promotions`, `long_tokens_charged`, and the current bucket/capacity. A steadily rising `long_starvation_promotions` with the bucket hovering near empty indicates the reservation is fully utilized by aged-long demand; raise `long_token_reservation` if long requests still wait too long. This is useful for benchmark runs without enabling global DEBUG logging, and is disabled by default (`0`).
+
+## Current Scope and Limitations
+
+- The current implementation is enabled only for the **FCFS** scheduler policy.
+- The adaptation is **engine-local**; it does not yet rebalance prefill and decode instances across nodes or proxies.
+- The implementation targets the vLLM waiting-queue layer and is intended for PD / EPD style serving where prompt length skew is a dominant bottleneck.
+- LAPS currently requires `recompute_scheduler_enable=true`; setting only `laps_config.enabled=true` is not sufficient.
+- When dynamic batch is selected through `SLO_limits_for_dynamic_batch`, LAPS is not applied.
+
+## Design Rationale
+
+A few deliberate scoping decisions, recorded here so the trade-offs are explicit for reviewers and future maintainers.
+
+- **Why coupled to `recompute_scheduler_enable=true`.** LAPS only swaps the *waiting-queue policy*; it does not change how a request is executed. The Ascend `RecomputeScheduler` is the scheduler that PD / EPD-style reference configurations already enable, so coupling LAPS to it means the feature lands exactly where the length-skew bottleneck actually hurts, with a small, focused intrusion into `RecomputeScheduler` (a per-step `begin_step` hook plus routing waiting-queue pops through the LAPS accounting) instead of a second scheduler subclass to maintain. When `recompute_scheduler_enable=false`, LAPS stays inert and the default scheduler path is untouched.
+- **Why FCFS-only for now.** The triple-queue split and the aging promotion order assume a single, total arrival order so that "oldest long" and "shorts ahead of longs" are well defined. Under the PRIORITY policy the head-comparison semantics differ (see the base scheduler's `_select_waiting_queue_for_scheduling`), so LAPS deliberately declines to engage and logs once at config time, keeping the default queue. Extending to PRIORITY is possible later but is intentionally out of scope for the first landing.
+- **vllm-ascend first, vLLM core later.** The mechanism is a generic waiting-queue policy with no NPU-specific kernel dependency, so it could eventually live in vLLM core. We land it in vllm-ascend first to validate the policy on real Ascend PD/EPD workloads before proposing a core-level change.

--- a/tests/e2e/singlecard/test_laps_scheduling.py
+++ b/tests/e2e/singlecard/test_laps_scheduling.py
@@ -1,0 +1,96 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end consistency test for LAPS length-aware prefill scheduling.
+
+LAPS only reorders *when* prefills are admitted (short vs. long, with
+anti-starvation aging); it must not change the tokens a request produces. This
+test runs a fixed greedy workload twice — once with the default scheduler and
+once with LAPS enabled (via ``recompute_scheduler_enable`` + ``laps_config``) —
+and asserts the outputs are identical. The prompts deliberately mix lengths so
+both the short and long sub-queues, and the aging path, are exercised.
+
+Requires NPU hardware; runs as part of the singlecard e2e suite.
+"""
+
+import os
+from typing import Any
+
+from vllm import SamplingParams
+
+from tests.e2e.conftest import VllmRunner
+from tests.e2e.model_utils import check_outputs_equal
+
+MODEL = "Qwen/Qwen3-0.6B"
+
+# Mix short and long prompts so both LAPS sub-queues are populated. The long
+# prompt is repeated/padded text so it clearly exceeds the (small) threshold.
+SHORT_PROMPTS = [
+    "Hello, my name is",
+    "The capital of France is",
+    "1 + 1 equals",
+]
+LONG_PROMPTS = [
+    "The following is a long passage that should be classified as a long "
+    "prefill by the LAPS scheduler. " * 8 + "In summary, the key point is",
+    "Once upon a time in a faraway land, there lived a great many people who "
+    "told stories about the stars. " * 8 + "The moral of the story is",
+]
+PROMPTS = SHORT_PROMPTS + LONG_PROMPTS
+
+GREEDY = SamplingParams(temperature=0.0, max_tokens=32, min_tokens=16)
+
+# Short-prefill threshold (tokens): chosen so SHORT_PROMPTS land in the short
+# queue and LONG_PROMPTS in the long queue.
+LAPS_THRESHOLD = 16
+
+LAPS_ADDITIONAL_CONFIG = {
+    "recompute_scheduler_enable": True,
+    "laps_config": {
+        "enabled": True,
+        "threshold": LAPS_THRESHOLD,
+        # Exercise the anti-starvation aging + token-bucket path.
+        "long_max_wait_ms": 50.0,
+        "long_token_reservation": 0.2,
+        "long_burst_steps": 4,
+    },
+}
+
+
+def _generate(additional_config):
+    os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+    runner_kwargs: dict[str, Any] = dict(
+        max_model_len=1024,
+        enforce_eager=True,
+        dtype="float16",  # avoid precision drift between the two runs
+        gpu_memory_utilization=0.9,
+    )
+    if additional_config is not None:
+        runner_kwargs["additional_config"] = additional_config
+    with VllmRunner(MODEL, **runner_kwargs) as vllm_model:
+        return vllm_model.generate(PROMPTS, sampling_params=GREEDY)
+
+
+def test_laps_matches_default_scheduler_outputs():
+    """LAPS must not change generated tokens versus the default scheduler."""
+    baseline = _generate(additional_config=None)
+    laps = _generate(additional_config=LAPS_ADDITIONAL_CONFIG)
+
+    check_outputs_equal(
+        outputs_0_lst=baseline,
+        outputs_1_lst=laps,
+        name_0="default_scheduler",
+        name_1="laps_scheduler",
+    )

--- a/tests/ut/core/test_laps_scheduler.py
+++ b/tests/ut/core/test_laps_scheduler.py
@@ -1,0 +1,338 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the LAPS waiting queue (LapsRequestQueue) and LapsConfig.
+
+These are pure-Python tests: requests are lightweight ``SimpleNamespace``
+objects (the queue only reads ``request_id`` / ``num_prompt_tokens``), and the
+aging clock is driven by patching ``vllm_ascend.core.laps_scheduler.time``.
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from vllm.v1.core.sched.request_queue import (SchedulingPolicy,
+                                              create_request_queue)
+
+from vllm_ascend.core.laps_scheduler import LapsRequestQueue
+
+THRESHOLD = 256
+
+
+def make_request(request_id: str, prompt_len: int, **extra) -> SimpleNamespace:
+    return SimpleNamespace(request_id=request_id,
+                           num_prompt_tokens=prompt_len,
+                           **extra)
+
+
+def make_queue(long_max_wait_ms: float = 0.0,
+               long_token_reservation: float = 0.0,
+               threshold: int = THRESHOLD,
+               long_burst_steps: int = 4,
+               immediate_predicate=None) -> LapsRequestQueue:
+    return LapsRequestQueue(
+        policy=SchedulingPolicy.FCFS,
+        threshold=threshold,
+        long_max_wait_ms=long_max_wait_ms,
+        long_token_reservation=long_token_reservation,
+        long_burst_steps=long_burst_steps,
+        immediate_predicate=immediate_predicate,
+    )
+
+
+def short_req(rid="short", n=10):
+    return make_request(rid, n)
+
+
+def long_req(rid="long", n=THRESHOLD + 1000):
+    return make_request(rid, n)
+
+
+class FakeClock:
+    """Monotonic clock stub; advance with ``.advance(seconds)``."""
+
+    def __init__(self):
+        self.now = 1000.0
+
+    def monotonic(self):
+        return self.now
+
+    def advance(self, seconds: float):
+        self.now += seconds
+
+
+# --------------------------------------------------------------------------- #
+# Classification & dispatch priority
+# --------------------------------------------------------------------------- #
+def test_classify_short_and_long_by_threshold():
+    q = make_queue(threshold=256)
+    q.add_request(short_req("s", 256))      # <= threshold -> short
+    q.add_request(long_req("l", 257))       # > threshold -> long
+    assert q.num_short_requests == 1
+    assert q.num_long_requests == 1
+    assert q.num_immediate_requests == 0
+
+
+def test_immediate_predicate_routes_to_immediate_queue():
+    q = make_queue(immediate_predicate=lambda r: r.request_id == "hot")
+    q.add_request(make_request("hot", 5))
+    assert q.num_immediate_requests == 1
+    assert q.num_short_requests == 0
+
+
+def test_dispatch_priority_immediate_then_short_then_long():
+    q = make_queue()  # aging disabled
+    q.add_request(long_req("l"))
+    q.add_request(short_req("s"))
+    q.prepend_request(make_request("imm", 5), force_immediate=True)
+
+    assert q.pop_request().request_id == "imm"
+    assert q.pop_request().request_id == "s"
+    assert q.pop_request().request_id == "l"
+
+
+def test_mark_force_immediate_routes_next_add_to_immediate():
+    q = make_queue()
+    # A short-by-length request marked force-immediate lands in immediate.
+    q.mark_force_immediate("p")
+    q.add_request(make_request("p", 5))
+    assert q.num_immediate_requests == 1
+    assert q.num_short_requests == 0
+
+
+def test_short_runs_before_long_without_aging():
+    q = make_queue()
+    q.add_request(long_req("l"))
+    q.add_request(short_req("s"))
+    assert q._select_schedulable_queue() is q._short_queue
+
+
+# --------------------------------------------------------------------------- #
+# Basic queue operations
+# --------------------------------------------------------------------------- #
+def test_len_contains_iter_and_peek():
+    q = make_queue()
+    a, b = short_req("a"), long_req("b")
+    q.add_request(a)
+    q.add_request(b)
+    assert len(q) == 2
+    assert a in q and b in q
+    assert {r.request_id for r in q} == {"a", "b"}
+    # Short has priority, so peek returns the short request.
+    assert q.peek_request().request_id == "a"
+
+
+def test_remove_request_removes_tracked_request():
+    q = make_queue()
+    r = short_req("shared")
+    q.add_request(r)
+    # The sub-queue holds the canonical request object; removing it clears the
+    # queue (matched by identity, as in the base vLLM queues).
+    q.remove_request(r)
+    assert len(q) == 0
+
+
+def test_prepend_request_can_force_immediate_queue():
+    q = make_queue()
+    q.prepend_request(short_req("s"), force_immediate=True)
+    assert q.num_immediate_requests == 1
+    assert q._prepend_counters["immediate"] == 1
+
+
+def test_owns_queue_only_true_for_internal_subqueues():
+    q = make_queue()
+    assert q.owns_queue(q._immediate_queue)
+    assert q.owns_queue(q._short_queue)
+    assert q.owns_queue(q._long_queue)
+    external = create_request_queue(SchedulingPolicy.FCFS)
+    assert not q.owns_queue(external)
+    assert not q.owns_queue(None)
+
+
+# --------------------------------------------------------------------------- #
+# Skip-or-requeue accounting
+# --------------------------------------------------------------------------- #
+def test_skip_or_requeue_counts_reason():
+    q = make_queue()
+    q.add_request(short_req("s"))
+    q.pop_request_from_queue(
+        q._short_queue,
+        count_as_removal=True,
+        skip_or_requeue_reason="blocked_waiting_status",
+    )
+    assert q._skip_or_requeue_counters["blocked_waiting_status"]["short"] == 1
+    # A skip is not a dispatch.
+    assert q._dispatch_counters["short"] == 0
+
+
+def test_unknown_skip_or_requeue_reason_raises():
+    q = make_queue()
+    q.add_request(short_req("s"))
+    with pytest.raises(ValueError):
+        q.pop_request_from_queue(
+            q._short_queue,
+            count_as_removal=True,
+            skip_or_requeue_reason="bogus",
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Anti-starvation aging (token-bucket as the single admission channel)
+# --------------------------------------------------------------------------- #
+def test_soft_phase_promotes_long_only_while_bucket_has_credit():
+    clock = FakeClock()
+    with patch("vllm_ascend.core.laps_scheduler.time", clock):
+        q = make_queue(long_max_wait_ms=100.0, long_token_reservation=0.5)
+        q.add_request(long_req("l"))     # enqueued now
+        q.add_request(short_req("s"))
+        q.begin_step(100)                # bucket refills to 50 (0.5 * 100)
+
+        # 150ms is past the soft aging bound (100ms): aged-long is eligible.
+        clock.advance(0.15)
+        # Bucket has credit -> aged-long jumps the short queue.
+        assert q._select_schedulable_queue() is q._long_queue
+
+        # Exhaust the bucket -> prefer short. There is no deadline bypass, so an
+        # aged long with an empty bucket can never jump a waiting short, however
+        # long it has waited.
+        q._long_bucket = 0.0
+        assert q._select_schedulable_queue() is q._short_queue
+        clock.advance(10_000)            # arbitrarily long extra wait
+        assert q._select_schedulable_queue() is q._short_queue
+
+
+def test_zero_reservation_never_promotes_when_shorts_waiting():
+    """With reservation=0 the bucket never refills, so the only admission channel
+    is closed: an aged long can never jump a waiting short regardless of how long
+    it has waited (no deadline bypass). LapsConfig forbids this combination, but
+    the queue itself must stay short-first rather than degenerate to long-first."""
+    clock = FakeClock()
+    with patch("vllm_ascend.core.laps_scheduler.time", clock):
+        q = make_queue(long_max_wait_ms=100.0, long_token_reservation=0.0)
+        q.add_request(long_req("l"))
+        q.add_request(short_req("s"))    # short queue stays non-empty
+        q.begin_step(4096)               # bucket stays 0 (reservation=0)
+
+        clock.advance(0.05)              # 50ms < 100ms -> short preferred
+        assert q._select_schedulable_queue() is q._short_queue
+
+        clock.advance(10_000)            # far past the aging bound
+        assert q._select_schedulable_queue() is q._short_queue
+
+
+def test_stall_avoidance_admits_long_without_charge_or_promotion():
+    clock = FakeClock()
+    with patch("vllm_ascend.core.laps_scheduler.time", clock):
+        q = make_queue(long_max_wait_ms=100.0, long_token_reservation=0.5)
+        q.add_request(long_req("l"))     # no short waiting
+        q.begin_step(100)
+
+        clock.advance(0.5)
+        assert q._select_schedulable_queue() is q._long_queue
+        # Dispatch via the queue path; no short was waiting -> not counted/charged.
+        bucket_before = q._long_bucket
+        q.pop_request_from_queue(q._long_queue, long_charge_tokens=4096)
+        assert q._long_starvation_promotions == 0
+        assert q._long_bucket == bucket_before  # not charged
+
+
+def test_aged_long_dispatch_counts_and_charges_when_jumping_shorts():
+    clock = FakeClock()
+    with patch("vllm_ascend.core.laps_scheduler.time", clock):
+        q = make_queue(long_max_wait_ms=100.0, long_token_reservation=0.5)
+        q.add_request(long_req("l"))
+        q.add_request(short_req("s"))    # short waiting -> long jumps it
+        q.begin_step(100)                # bucket = 50
+
+        clock.advance(0.5)               # past the aging bound
+        # Bucket has credit -> soft-phase promotion charges the long's cost.
+        q.pop_request_from_queue(q._long_queue, long_charge_tokens=40)
+        assert q._long_starvation_promotions == 1
+        assert q._long_tokens_charged == 40
+        assert q._long_bucket == 50 - 40
+
+
+def test_no_aging_when_long_max_wait_is_zero():
+    clock = FakeClock()
+    with patch("vllm_ascend.core.laps_scheduler.time", clock):
+        q = make_queue(long_max_wait_ms=0.0, long_token_reservation=0.5)
+        q.add_request(long_req("l"))
+        q.add_request(short_req("s"))
+        q.begin_step(100)
+        clock.advance(10_000)            # arbitrarily long wait
+        # Aging disabled -> short keeps priority forever.
+        assert q._select_schedulable_queue() is q._short_queue
+
+
+# --------------------------------------------------------------------------- #
+# Token-bucket budget control (configurable burst window)
+# --------------------------------------------------------------------------- #
+def test_begin_step_caps_bucket_at_burst_capacity():
+    q = make_queue(long_max_wait_ms=100.0, long_token_reservation=0.5,
+                   long_burst_steps=2)
+    # refill_per_step = 0.5 * 100 = 50 ; capacity = 50 * 2 = 100.
+    for _ in range(10):
+        q.begin_step(100)
+    assert q._long_bucket_capacity == 100.0
+    assert q._long_bucket == 100.0
+
+
+def test_soft_charge_debt_recovers_after_refill():
+    """Charging a promotion may take the bucket below zero; subsequent per-step
+    refills repay the debt, so it is bounded (no cliff)."""
+    clock = FakeClock()
+    with patch("vllm_ascend.core.laps_scheduler.time", clock):
+        q = make_queue(long_max_wait_ms=100.0, long_token_reservation=0.5)
+        q.add_request(long_req("l"))
+        q.add_request(short_req("s"))
+        q.begin_step(100)                # bucket = 50
+        clock.advance(0.15)              # past the soft aging bound
+        q.pop_request_from_queue(q._long_queue, long_charge_tokens=80)
+        assert q._long_starvation_promotions == 1
+        assert q._long_bucket == -30.0   # charged the long's cost (50 - 80)
+        q.begin_step(100)                # one refill (+50) recovers it
+        assert q._long_bucket == 20.0
+
+
+def test_big_long_charge_blocks_next_aged_long_while_short_waits():
+    """Regression for the prefill-monopoly failure: charging a long its full
+    remaining prefill drives the bucket deeply negative, so the next aged long is
+    blocked while a short is waiting (preventing the long-first degeneration where
+    short requests starved). Once the short queue drains, stall avoidance still
+    admits the long despite the negative bucket."""
+    clock = FakeClock()
+    with patch("vllm_ascend.core.laps_scheduler.time", clock):
+        q = make_queue(long_max_wait_ms=100.0, long_token_reservation=0.2)
+        q.add_request(long_req("l0"))
+        q.add_request(long_req("l1"))
+        q.add_request(short_req("s"))
+        q.begin_step(4096)               # bucket refills to ~819 (0.2 * 4096)
+        clock.advance(0.5)               # both longs past the aging bound
+
+        # First aged long has bucket credit -> promoted ahead of the short, and is
+        # charged its full remaining prefill (long_req prompt >> bucket credit).
+        assert q._select_schedulable_queue() is q._long_queue
+        q.pop_request_from_queue(q._long_queue, long_charge_tokens=25000)
+        assert q._long_starvation_promotions == 1
+        assert q._long_bucket < 0.0      # deep debt from the big long
+
+        # Next decision: long is aged but the bucket is exhausted and a short is
+        # waiting -> short is preferred (no long-first flip).
+        assert q._select_schedulable_queue() is q._short_queue
+        q.pop_request_from_queue(q._short_queue)
+
+        # Short queue now empty -> stall avoidance admits the remaining long even
+        # though the bucket is still negative.
+        assert q._select_schedulable_queue() is q._long_queue

--- a/tests/ut/core/test_laps_scheduler_mixin.py
+++ b/tests/ut/core/test_laps_scheduler_mixin.py
@@ -1,0 +1,146 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the LAPS scheduler mixin glue (queue selection / classification).
+
+``LapsSchedulerMixin`` is injected into ``RecomputeScheduler`` via inheritance
+(not a patch). These tests exercise the mixin glue against a minimal stub
+scheduler, without constructing a full vLLM scheduler.
+"""
+from types import SimpleNamespace
+
+from vllm.v1.core.sched.request_queue import (SchedulingPolicy,
+                                              create_request_queue)
+from vllm.v1.request import RequestStatus
+
+from vllm_ascend.core.laps_scheduler import (LapsRequestQueue,
+                                             LapsSchedulerMixin)
+
+THRESHOLD = 256
+
+
+def make_request(request_id: str, prompt_len: int, computed: int = 0, *,
+                 status: RequestStatus = RequestStatus.WAITING,
+                 num_output_tokens: int = 0,
+                 num_external_computed_tokens: int = 0) -> SimpleNamespace:
+    return SimpleNamespace(request_id=request_id,
+                           num_prompt_tokens=prompt_len,
+                           num_computed_tokens=computed,
+                           status=status,
+                           num_output_tokens=num_output_tokens,
+                           num_external_computed_tokens=num_external_computed_tokens)
+
+
+class SchedulerStub(LapsSchedulerMixin):
+    """Minimal carrier for the attributes the mixin glue reads."""
+
+    def __init__(self, waiting=None, skipped_waiting=None,
+                 policy=SchedulingPolicy.FCFS):
+        self.waiting = waiting
+        self.skipped_waiting = skipped_waiting
+        self.policy = policy
+
+
+def _laps_queue(immediate_predicate=None):
+    return LapsRequestQueue(
+        policy=SchedulingPolicy.FCFS,
+        threshold=THRESHOLD,
+        long_max_wait_ms=0.0,
+        long_token_reservation=0.0,
+        immediate_predicate=immediate_predicate,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Waiting-queue selection
+# --------------------------------------------------------------------------- #
+def test_select_prefers_skipped_waiting_under_fcfs():
+    waiting = _laps_queue()
+    waiting.add_request(make_request("s", 10))
+    skipped = create_request_queue(SchedulingPolicy.FCFS)
+    skipped.add_request(make_request("skipped", 10))
+
+    stub = SchedulerStub(waiting, skipped_waiting=skipped)
+    assert stub._select_waiting_queue_for_scheduling() is skipped
+
+
+def test_select_uses_laps_subqueue_when_skipped_empty():
+    waiting = _laps_queue()
+    waiting.add_request(make_request("l", THRESHOLD + 100))
+    waiting.add_request(make_request("s", 10))
+    skipped = create_request_queue(SchedulingPolicy.FCFS)  # empty -> falsy
+
+    stub = SchedulerStub(waiting, skipped_waiting=skipped)
+    # Short has priority (no aging), so the short sub-queue is selected.
+    assert stub._select_waiting_queue_for_scheduling() is waiting._short_queue
+
+
+def test_select_returns_none_when_everything_empty():
+    waiting = _laps_queue()
+    skipped = create_request_queue(SchedulingPolicy.FCFS)
+    stub = SchedulerStub(waiting, skipped_waiting=skipped)
+    assert stub._select_waiting_queue_for_scheduling() is None
+
+
+def test_owns_queue_distinguishes_laps_subqueues_from_skipped():
+    waiting = _laps_queue()
+    skipped = create_request_queue(SchedulingPolicy.FCFS)
+    # A queue returned from LAPS is owned; skipped_waiting is not.
+    assert waiting.owns_queue(waiting._short_queue)
+    assert not waiting.owns_queue(skipped)
+
+
+# --------------------------------------------------------------------------- #
+# Recovery-request classification (immediate lane)
+#
+# When the scheduler installs the LAPS queue it wires its own
+# ``_is_recovery_request`` as the immediate predicate, so recovery/preempted
+# requests jump the short/long split and go to the immediate lane regardless of
+# prompt length. Each recovery marker is exercised independently.
+# --------------------------------------------------------------------------- #
+def test_recovery_markers_route_long_prompt_to_immediate_queue():
+    predicate = SchedulerStub()._is_recovery_request
+    long_len = THRESHOLD + 100  # would otherwise classify as long
+    cases = {
+        "preempted": make_request("preempted", long_len,
+                                   status=RequestStatus.PREEMPTED),
+        "computed": make_request("computed", long_len, computed=1),
+        "external_computed": make_request(
+            "external_computed", long_len, num_external_computed_tokens=1),
+        "output": make_request("output", long_len, num_output_tokens=1),
+    }
+    for name, request in cases.items():
+        queue = _laps_queue(immediate_predicate=predicate)
+        queue.add_request(request)
+        assert queue.num_immediate_requests == 1, name
+        assert queue.num_long_requests == 0, name
+        assert queue.num_short_requests == 0, name
+
+
+def test_non_recovery_long_prompt_stays_in_long_queue():
+    predicate = SchedulerStub()._is_recovery_request
+    queue = _laps_queue(immediate_predicate=predicate)
+    # No recovery markers set (all defaults) -> classified purely by length.
+    queue.add_request(make_request("plain_long", THRESHOLD + 100))
+    assert queue.num_long_requests == 1
+    assert queue.num_immediate_requests == 0
+
+
+def test_non_recovery_short_prompt_stays_in_short_queue():
+    predicate = SchedulerStub()._is_recovery_request
+    queue = _laps_queue(immediate_predicate=predicate)
+    queue.add_request(make_request("plain_short", 10))
+    assert queue.num_short_requests == 1
+    assert queue.num_immediate_requests == 0

--- a/tests/ut/core/test_recompute_scheduler_laps.py
+++ b/tests/ut/core/test_recompute_scheduler_laps.py
@@ -1,0 +1,233 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end integration tests for LAPS wired into ``RecomputeScheduler``.
+
+Unlike ``test_laps_scheduler.py`` (which exercises ``LapsRequestQueue`` in
+isolation) and ``test_patch_laps_scheduler.py`` (mixin selection glue), these
+build a real ``RecomputeScheduler`` and drive its ``schedule()`` to verify the
+LAPS waiting queue is actually installed and that the short-before-long priority
+(and aging promotion) shows up in the scheduling order.
+
+Pattern mirrors ``test_scheduler_dynamic_batch.py``: a CPU-only scheduler built
+with mocked ``__post_init__`` and a fake KV-cache config. The Ascend config is
+stubbed via ``get_ascend_config`` so we control ``laps_config`` directly without
+constructing a full ``AscendConfig``. The aging clock is driven by patching
+``vllm_ascend.core.laps_scheduler.time``.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import torch
+from vllm.config import (CacheConfig, ModelConfig, SchedulerConfig, VllmConfig)
+from vllm.sampling_params import SamplingParams
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import (get_request_block_hasher,
+                                         init_none_hash)
+from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
+                                        KVCacheGroupSpec)
+from vllm.v1.request import Request
+from vllm.v1.structured_output import StructuredOutputManager
+
+from tests.ut.base import TestBase
+from vllm_ascend.ascend_config import LapsConfig
+from vllm_ascend.core.laps_scheduler import LapsRequestQueue
+
+EOS_TOKEN_ID = 50256
+MODEL = "Qwen3-0.6B"
+THRESHOLD = 256
+MAX_NUM_BATCHED_TOKENS = 10000
+BLOCK_SIZE = 16
+
+
+class FakeClock:
+    """Monotonic clock stub; advance with ``.advance(seconds)``."""
+
+    def __init__(self):
+        self.now = 1000.0
+
+    def monotonic(self):
+        return self.now
+
+    def advance(self, seconds: float):
+        self.now += seconds
+
+
+def _fake_ascend_config(**laps_overrides) -> SimpleNamespace:
+    laps = {"enabled": True, "threshold": THRESHOLD}
+    laps.update(laps_overrides)
+    return SimpleNamespace(laps_config=LapsConfig(laps))
+
+
+def create_requests(num_tokens_list, max_tokens: int = 16):
+    """Build one request per entry in ``num_tokens_list`` (prompt length)."""
+    init_none_hash(sha256)
+    requests = []
+    for i, num_tokens in enumerate(num_tokens_list):
+        sampling_params = SamplingParams(ignore_eos=False,
+                                         max_tokens=max_tokens)
+        sampling_params.update_from_generation_config({}, EOS_TOKEN_ID)
+        request = Request(
+            request_id=f"{i}",
+            prompt_token_ids=[i % 50] * num_tokens,
+            sampling_params=sampling_params,
+            pooling_params=None,
+            mm_features=None,
+            block_hasher=get_request_block_hasher(BLOCK_SIZE, sha256),
+        )
+        requests.append(request)
+    return requests
+
+
+class TestRecomputeSchedulerLaps(TestBase):
+
+    @patch("vllm.config.ModelConfig.__post_init__", MagicMock())
+    @patch("vllm.config.VllmConfig.__post_init__", MagicMock())
+    # The real property calls is_encoder_decoder(self.hf_config), whose helper
+    # also probes hf_config.get_text_config(); on a MagicMock that returns a
+    # fresh (truthy) mock, so patch the property instead of the mock attrs.
+    @patch("vllm.config.ModelConfig.is_encoder_decoder",
+           PropertyMock(return_value=False))
+    def create_scheduler(self, **laps_overrides):
+        from vllm_ascend.core.recompute_scheduler import RecomputeScheduler
+
+        scheduler_config = SchedulerConfig(
+            max_num_seqs=16,
+            max_model_len=MAX_NUM_BATCHED_TOKENS,
+            long_prefill_token_threshold=0,
+            disable_chunked_mm_input=False,
+            enable_chunked_prefill=True,
+            max_num_batched_tokens=MAX_NUM_BATCHED_TOKENS,
+            is_encoder_decoder=False,
+        )
+
+        model_config = ModelConfig(
+            model=MODEL,
+            tokenizer=MODEL,
+            tokenizer_mode="auto",
+            trust_remote_code=True,
+            dtype="float16",
+            seed=42,
+            max_model_len=MAX_NUM_BATCHED_TOKENS,
+        )
+        model_config.pooler_config = MagicMock()
+        # Text-only: keeps supports_multimodal_inputs() False so the scheduler
+        # skips the MultiModalBudget path (encoder budget = 0).
+        model_config.multimodal_config = None
+        model_config.served_model_name = MODEL
+        model_config.hf_text_config = MagicMock()
+        model_config.hf_text_config.is_encoder_decoder = False
+        # is_hybrid_model checks substrings in model_type -> must be a real str.
+        model_config.hf_text_config.model_type = "qwen3"
+
+        cache_config = CacheConfig(
+            block_size=BLOCK_SIZE,
+            gpu_memory_utilization=0.9,
+            cache_dtype="auto",
+            enable_prefix_caching=False,
+        )
+
+        vllm_config = VllmConfig(
+            scheduler_config=scheduler_config,
+            model_config=model_config,
+            cache_config=cache_config,
+            kv_transfer_config=None,
+            speculative_config=None,
+        )
+
+        kv_cache_config = KVCacheConfig(
+            num_blocks=10000,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(['layer'],
+                                 FullAttentionSpec(block_size=BLOCK_SIZE,
+                                                   num_kv_heads=1,
+                                                   head_size=1,
+                                                   dtype=torch.float32))
+            ],
+        )
+        cache_config.num_gpu_blocks = 10000
+
+        fake_cfg = _fake_ascend_config(**laps_overrides)
+        with patch(
+                "vllm_ascend.core.recompute_scheduler.get_ascend_config",
+                return_value=fake_cfg), \
+             patch(
+                "vllm_ascend.core.laps_scheduler.get_ascend_config",
+                return_value=fake_cfg):
+            scheduler = RecomputeScheduler(
+                vllm_config=vllm_config,
+                kv_cache_config=kv_cache_config,
+                block_size=BLOCK_SIZE,
+                log_stats=True,
+                structured_output_manager=MagicMock(
+                    spec=StructuredOutputManager),
+            )
+
+        should_advance = MagicMock(return_value=False)
+        scheduler.structured_output_manager.should_advance = should_advance
+        return scheduler
+
+    def _running_order(self, scheduler):
+        return [req.request_id for req in scheduler.running]
+
+    # ----------------------------------------------------------------- #
+    # Wiring
+    # ----------------------------------------------------------------- #
+    def test_waiting_queue_is_laps(self):
+        scheduler = self.create_scheduler()
+        self.assertIsInstance(scheduler.waiting, LapsRequestQueue)
+
+    # ----------------------------------------------------------------- #
+    # Short-before-long priority through real schedule()
+    # ----------------------------------------------------------------- #
+    def test_short_prefill_scheduled_before_long(self):
+        scheduler = self.create_scheduler()
+        # Add a long prefill first, then a short one. Without LAPS, FCFS would
+        # schedule the long one first; LAPS must flip the order.
+        long_req, short_req = create_requests([THRESHOLD + 1000, 10])
+        scheduler.add_request(long_req)   # request_id "0" (long)
+        scheduler.add_request(short_req)  # request_id "1" (short)
+
+        scheduler.schedule()
+
+        order = self._running_order(scheduler)
+        self.assertIn("1", order)
+        self.assertIn("0", order)
+        # Short ("1") must be scheduled ahead of long ("0").
+        self.assertLess(order.index("1"), order.index("0"))
+
+    # ----------------------------------------------------------------- #
+    # Aging promotion through real schedule()
+    # ----------------------------------------------------------------- #
+    def test_aged_long_promoted_over_short_after_wait(self):
+        clock = FakeClock()
+        with patch("vllm_ascend.core.laps_scheduler.time", clock):
+            # Aging bound at 100ms with a token reservation so the aged long is
+            # admitted through the soft-phase bucket (the only admission channel).
+            scheduler = self.create_scheduler(
+                long_max_wait_ms=100.0, long_token_reservation=0.5)
+            long_req, short_req = create_requests([THRESHOLD + 1000, 10])
+            scheduler.add_request(long_req)   # "0" long, enqueued at t0
+            scheduler.add_request(short_req)  # "1" short
+
+            # Long has aged past its bound before this scheduling step.
+            clock.advance(0.2)  # 200ms >= 100ms
+            scheduler.schedule()
+
+            order = self._running_order(scheduler)
+            # The aged long ("0") must be admitted ahead of the short ("1").
+            self.assertIn("0", order)
+            self.assertLess(order.index("0"), order.index("1"))

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -18,7 +18,8 @@ from unittest.mock import patch
 from vllm.config import VllmConfig
 
 from tests.ut.base import TestBase
-from vllm_ascend.ascend_config import clear_ascend_config, get_ascend_config, init_ascend_config
+from vllm_ascend.ascend_config import (LapsConfig, clear_ascend_config,
+                                       get_ascend_config, init_ascend_config)
 
 
 class TestAscendConfig(TestBase):
@@ -112,3 +113,65 @@ class TestAscendConfig(TestBase):
         clear_ascend_config()
         with self.assertRaises(RuntimeError):
             get_ascend_config()
+
+
+class TestLapsConfig(TestBase):
+    def test_default_is_disabled(self):
+        cfg = LapsConfig({})
+        self.assertFalse(cfg.enabled)
+        self.assertEqual(cfg.threshold, 256)
+        self.assertEqual(cfg.long_max_wait_ms, 0.0)
+        self.assertEqual(cfg.long_token_reservation, 0.0)
+        self.assertEqual(cfg.long_burst_steps, 4)
+        self.assertEqual(cfg.stats_log_interval_s, 0.0)
+
+    def test_explicit_config(self):
+        cfg = LapsConfig({
+            "enabled": True,
+            "threshold": 512,
+            "long_max_wait_ms": 2000,
+            "long_token_reservation": 0.2,
+            "long_burst_steps": 8,
+            "stats_log_interval_s": 5,
+        })
+        self.assertTrue(cfg.enabled)
+        self.assertEqual(cfg.threshold, 512)
+        self.assertEqual(cfg.long_max_wait_ms, 2000.0)
+        self.assertEqual(cfg.long_token_reservation, 0.2)
+        self.assertEqual(cfg.long_burst_steps, 8)
+        self.assertEqual(cfg.stats_log_interval_s, 5.0)
+
+    def test_unknown_key_rejected(self):
+        with self.assertRaises(ValueError):
+            LapsConfig({"foo": 1})
+
+    def test_validation_rejects_out_of_range(self):
+        with self.assertRaises(ValueError):
+            LapsConfig({"long_token_reservation": 1.5})
+        with self.assertRaises(ValueError):
+            LapsConfig({"threshold": -1})
+        with self.assertRaises(ValueError):
+            LapsConfig({"long_max_wait_ms": -1})
+        with self.assertRaises(ValueError):
+            LapsConfig({"long_burst_steps": 0})
+        with self.assertRaises(ValueError):
+            LapsConfig({"stats_log_interval_s": -1})
+
+    def test_aging_requires_positive_reservation(self):
+        # long_max_wait_ms > 0 (aging on) with reservation == 0 is rejected: the
+        # token bucket is the only aged-long admission channel, so a zero
+        # reservation would make aging inert / degenerate to long-first.
+        with self.assertRaises(ValueError):
+            LapsConfig({"long_max_wait_ms": 2000})
+        with self.assertRaises(ValueError):
+            LapsConfig({"long_max_wait_ms": 2000, "long_token_reservation": 0.0})
+        # With a positive reservation it is accepted.
+        cfg = LapsConfig({"long_max_wait_ms": 2000, "long_token_reservation": 0.1})
+        self.assertEqual(cfg.long_max_wait_ms, 2000.0)
+        self.assertEqual(cfg.long_token_reservation, 0.1)
+
+    def test_none_config_is_disabled(self):
+        # No block at all (None) -> defaults, scheduling disabled.
+        cfg = LapsConfig(None)
+        self.assertFalse(cfg.enabled)
+        self.assertEqual(cfg.threshold, 256)

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -88,6 +88,7 @@ class AscendConfig:
         self.multistream_overlap_gate = additional_config.get("multistream_overlap_gate", False)
         # PD-disaggregated only (kv_producer/kv_consumer); invalid in PD-mixed (kv_both / no kv_transfer_config).
         self.recompute_scheduler_enable = additional_config.get("recompute_scheduler_enable", False)
+        self.laps_config = LapsConfig(additional_config.get("laps_config", {}))
         self.enable_cpu_binding = additional_config.get("enable_cpu_binding", True)
 
         self.pd_tp_ratio = 1
@@ -425,6 +426,71 @@ class EplbConfig:
 
         logger.info(f"Dynamic EPLB is {self.config['dynamic_eplb']}")
         logger.info(f"The number of redundant experts is {self.config['num_redundant_experts']}")
+
+
+class LapsConfig:
+    """
+    Configuration Object for laps_config from additional_config.
+
+    LAPS-style length-aware prefill scheduling (triple-queue + token-bucket
+    anti-starvation aging). Configured via ``additional_config["laps_config"]``.
+    """
+
+    _defaults = {
+        "enabled": False,
+        "threshold": 256,
+        "long_max_wait_ms": 0.0,
+        "long_token_reservation": 0.0,
+        "long_burst_steps": 4,
+        "stats_log_interval_s": 0.0,
+    }
+
+    def __init__(self, user_config: dict | None = None):
+        user_config = user_config or {}
+        unknown = set(user_config) - set(self._defaults)
+        if unknown:
+            raise ValueError(f"Unknown laps_config keys: {sorted(unknown)}")
+
+        source = user_config
+
+        self.enabled = bool(source.get("enabled", self._defaults["enabled"]))
+        self.threshold = int(source.get("threshold", self._defaults["threshold"]))
+        self.long_max_wait_ms = float(source.get("long_max_wait_ms", self._defaults["long_max_wait_ms"]))
+        self.long_token_reservation = float(
+            source.get("long_token_reservation", self._defaults["long_token_reservation"])
+        )
+        # Burst window (in scheduling steps) the aged-long admission bucket may
+        # accumulate; bucket capacity = long_token_reservation * token_budget *
+        # long_burst_steps. Advanced knob; the default suits most workloads.
+        self.long_burst_steps = int(source.get("long_burst_steps", self._defaults["long_burst_steps"]))
+        self.stats_log_interval_s = float(source.get("stats_log_interval_s", self._defaults["stats_log_interval_s"]))
+        self._validate_config()
+
+    def _validate_config(self):
+        if self.threshold < 0:
+            raise ValueError(f"laps_config.threshold must be a non-negative int; got {self.threshold}")
+        if self.long_max_wait_ms < 0:
+            raise ValueError(f"laps_config.long_max_wait_ms must be >= 0; got {self.long_max_wait_ms}")
+        if not 0.0 <= self.long_token_reservation <= 1.0:
+            raise ValueError(
+                f"laps_config.long_token_reservation must be in [0.0, 1.0]; got {self.long_token_reservation}"
+            )
+        if self.long_max_wait_ms > 0 and self.long_token_reservation <= 0:
+            # The token-reservation bucket is the only channel for admitting aged
+            # longs ahead of waiting shorts. With reservation == 0 the bucket
+            # never refills, so an enabled aging bound would either be inert or
+            # (under the removed deadline-bypass design) degenerate into long-first
+            # scheduling. Require an explicit positive reservation instead.
+            raise ValueError(
+                "laps_config.long_token_reservation must be > 0 when "
+                f"long_max_wait_ms > 0 (aging enabled); got "
+                f"long_max_wait_ms={self.long_max_wait_ms}, "
+                f"long_token_reservation={self.long_token_reservation}"
+            )
+        if self.long_burst_steps < 1:
+            raise ValueError(f"laps_config.long_burst_steps must be >= 1; got {self.long_burst_steps}")
+        if self.stats_log_interval_s < 0:
+            raise ValueError(f"laps_config.stats_log_interval_s must be >= 0; got {self.stats_log_interval_s}")
 
 
 _ASCEND_CONFIG: AscendConfig | None = None

--- a/vllm_ascend/core/laps_scheduler.py
+++ b/vllm_ascend/core/laps_scheduler.py
@@ -1,0 +1,623 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable, Iterable, Iterator
+from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
+
+from vllm.logger import logger
+from vllm.v1.core.sched.request_queue import (
+    RequestQueue,
+    SchedulingPolicy,
+    create_request_queue,
+)
+from vllm.v1.request import Request, RequestStatus
+
+from vllm_ascend.ascend_config import get_ascend_config
+
+
+@runtime_checkable
+class SteppedWaitingQueue(Protocol):
+    """Extension contract a waiting queue must satisfy for LAPS-style scheduling.
+
+    The scheduler ([`LapsSchedulerMixin`]) depends only on this surface, not on
+    `LapsRequestQueue`'s concrete internals. It is a superset of the base
+    `RequestQueue` ABC with the per-step / queue-aware hooks LAPS needs:
+
+    - `begin_step`: refill per-step admission state once per `schedule()`.
+    - `select_waiting_queue_for_scheduling`: pick the sub-queue to pop from next.
+    - `has_schedulable_requests`: whether anything can be dispatched right now.
+    - `pop_request_from_queue`: pop from a specific sub-queue with accounting
+      (dispatch vs. skip-or-requeue, token charging).
+    - `mark_force_immediate`: route a request to the immediate lane on re-add.
+    - `owns_queue`: whether a given queue object is one of its sub-queues.
+    """
+
+    def begin_step(self, token_budget: int) -> None: ...
+
+    def select_waiting_queue_for_scheduling(self) -> RequestQueue | None: ...
+
+    def has_schedulable_requests(self) -> bool: ...
+
+    def pop_request_from_queue(
+        self,
+        queue: RequestQueue,
+        *,
+        count_as_removal: bool = ...,
+        skip_or_requeue_reason: str | None = ...,
+        long_charge_tokens: int = ...,
+    ) -> Request: ...
+
+    def mark_force_immediate(self, request_id: str) -> None: ...
+
+    def owns_queue(self, queue: RequestQueue | None) -> bool: ...
+
+
+class LapsRequestQueue(RequestQueue):
+    """Two-level waiting queue for short and long prefills."""
+
+    _SKIP_OR_REQUEUE_REASONS = (
+        "blocked_waiting_status",
+        "max_loras",
+        "remote_kv_not_ready",
+    )
+
+    def __init__(
+        self,
+        policy: SchedulingPolicy,
+        threshold: int,
+        long_max_wait_ms: float,
+        long_token_reservation: float = 0.0,
+        long_burst_steps: int = 4,
+        immediate_predicate: Callable[[Request], bool] | None = None,
+        stats_log_interval_s: float = 0.0,
+    ) -> None:
+        # Inputs are assumed pre-validated: the only production caller
+        # (LapsSchedulerMixin) builds this from a LapsConfig, which is the single
+        # validation boundary (it raises on out-of-range values). This
+        # constructor therefore trusts its arguments rather than re-clamping them.
+        self.policy = policy
+        self.threshold = threshold
+        # Burst allowance for the aged-long admission bucket, in scheduling
+        # steps: the bucket caps at `reservation * token_budget *
+        # long_burst_steps`, so an idle aged-long lane accumulates at most this
+        # many steps' worth of reservation before a burst of admissions,
+        # bounding short-request impact.
+        self.long_burst_steps = long_burst_steps
+        # Anti-starvation: a long request waiting longer than this many ms becomes
+        # eligible for promotion ahead of short prefills, but only through the
+        # token-reservation bucket (see begin_step), which rate-limits aged-long
+        # admissions to the reservation fraction of token throughput. The bucket
+        # is the single admission channel, so a backlog of aged longs can never
+        # flip the queue into long-first and starve shorts. <= 0 disables aging
+        # entirely; when > 0 it requires long_token_reservation > 0 (enforced by
+        # LapsConfig), otherwise the bucket never refills and aging is inert.
+        self.long_max_wait_ms = long_max_wait_ms
+        # Average fraction of token throughput reserved for admitting aged-long
+        # prefills ahead of waiting shorts (token-bucket rate; see begin_step).
+        # This bucket is the only channel that promotes an aged long ahead of a
+        # waiting short, so it must be > 0 whenever aging is enabled (enforced by
+        # LapsConfig). Larger values drain aged-long requests sooner at the cost
+        # of short-request latency. Expected range [0.0, 1.0].
+        self.long_token_reservation = long_token_reservation
+        self.immediate_predicate = immediate_predicate
+        self._immediate_queue = create_request_queue(policy)
+        self._short_queue = create_request_queue(policy)
+        self._long_queue = create_request_queue(policy)
+        # Tracks when each request entered the long queue, for aging.
+        self._long_enqueue_at: dict[str, float] = {}
+        # Aged-long requests admitted ahead of waiting shorts (soft phase only).
+        self._long_starvation_promotions = 0
+        # Token bucket throttling aged-long admissions (see begin_step). The
+        # bucket refills by `long_token_reservation * token_budget` every
+        # scheduling step and is charged a long's full remaining prefill each time
+        # an aged long is admitted ahead of waiting shorts. Gating on `bucket > 0`
+        # caps the average aged-long admission rate at the reservation fraction of
+        # token throughput: a big long drives the bucket well below zero, and the
+        # per-step refill repays that debt over the steps the long actually runs,
+        # so shorts are preferred until it is repaid (a bounded burst, no cliff).
+        self._long_bucket = 0.0
+        self._long_bucket_capacity = 0.0
+        self._long_refill_per_step = 0.0
+        # Total tokens charged to the bucket so far (observability).
+        self._long_tokens_charged = 0
+        self._stats_log_interval_s = stats_log_interval_s
+        self._last_stats_log_at = time.monotonic()
+        self._prepend_counters = {"immediate": 0, "short": 0, "long": 0}
+        self._dispatch_counters = {"immediate": 0, "short": 0, "long": 0}
+        self._skip_or_requeue_counters = {
+            reason: {"immediate": 0, "short": 0, "long": 0} for reason in self._SKIP_OR_REQUEUE_REASONS
+        }
+        self._force_immediate_request_ids: set[str] = set()
+        self._queue_index: dict[str, RequestQueue] = {}
+
+    def _queues(self) -> tuple[RequestQueue, ...]:
+        return (self._immediate_queue, self._short_queue, self._long_queue)
+
+    @property
+    def _debug_logging_enabled(self) -> bool:
+        # Checked live (not cached at __init__) so a runtime log-level change
+        # takes effect. logger.isEnabledFor is cheap (cached effective level);
+        # the guard exists only to skip building the debug-log arguments.
+        return logger.isEnabledFor(logging.DEBUG)
+
+    def owns_queue(self, queue: RequestQueue | None) -> bool:
+        """Whether `queue` is one of this queue's internal sub-queues.
+
+        Public accessor used by the scheduler to decide whether a queue returned
+        by `select_waiting_queue_for_scheduling` should be popped through this
+        wrapper's accounting (vs. an externally-owned queue such as
+        `skipped_waiting`). Avoids reaching into `_queues()` from outside.
+        """
+        return any(queue is q for q in self._queues())
+
+    def _queue_name(self, queue: RequestQueue) -> str:
+        if queue is self._immediate_queue:
+            return "immediate"
+        if queue is self._short_queue:
+            return "short"
+        if queue is self._long_queue:
+            return "long"
+        return "unknown"
+
+    def _maybe_log_stats(self, force: bool = False) -> None:
+        if self._stats_log_interval_s <= 0:
+            return
+        now = time.monotonic()
+        if not force and (now - self._last_stats_log_at) < self._stats_log_interval_s:
+            return
+        self._last_stats_log_at = now
+        logger.info(
+            "LAPS stats: threshold=%d long_max_wait_ms=%.3f "
+            "long_token_reservation=%.3f "
+            "sizes=(immediate=%d short=%d long=%d) "
+            "prepends=%s dispatches=%s skip_or_requeues=%s "
+            "long_starvation_promotions=%d "
+            "long_tokens_charged=%d "
+            "bucket=%.0f capacity=%.0f",
+            self.threshold,
+            self.long_max_wait_ms,
+            self.long_token_reservation,
+            len(self._immediate_queue),
+            len(self._short_queue),
+            len(self._long_queue),
+            self._prepend_counters,
+            self._dispatch_counters,
+            self._skip_or_requeue_counters,
+            self._long_starvation_promotions,
+            self._long_tokens_charged,
+            self._long_bucket,
+            self._long_bucket_capacity,
+        )
+
+    def _increment_skip_or_requeue_counter(self, queue: RequestQueue, reason: str) -> None:
+        if reason not in self._skip_or_requeue_counters:
+            raise ValueError(f"Unknown skip_or_requeue reason: {reason}")
+        self._skip_or_requeue_counters[reason][self._queue_name(queue)] += 1
+
+    def _debug_state(
+        self,
+        event: str,
+        request: Request | None = None,
+        queue: RequestQueue | None = None,
+        extra: str = "",
+    ) -> None:
+        if not self._debug_logging_enabled:
+            return
+        request_id = "-" if request is None else request.request_id
+        prompt_tokens = -1 if request is None else request.num_prompt_tokens
+        queue_name = "-" if queue is None else self._queue_name(queue)
+        extra_suffix = f", {extra}" if extra else ""
+        logger.debug(
+            "LAPS queue %s: request_id=%s, prompt_tokens=%d, target_queue=%s, "
+            "sizes=(immediate=%d, short=%d, long=%d)%s",
+            event,
+            request_id,
+            prompt_tokens,
+            queue_name,
+            len(self._immediate_queue),
+            len(self._short_queue),
+            len(self._long_queue),
+            extra_suffix,
+        )
+
+    @property
+    def num_immediate_requests(self) -> int:
+        return len(self._immediate_queue)
+
+    @property
+    def num_short_requests(self) -> int:
+        return len(self._short_queue)
+
+    @property
+    def num_long_requests(self) -> int:
+        return len(self._long_queue)
+
+    def has_short_requests(self) -> bool:
+        return len(self._short_queue) > 0
+
+    def has_long_requests(self) -> bool:
+        return len(self._long_queue) > 0
+
+    def has_immediate_requests(self) -> bool:
+        return len(self._immediate_queue) > 0
+
+    def _classify_queue(self, request: Request, *, force_immediate: bool = False) -> RequestQueue:
+        if force_immediate or request.request_id in self._force_immediate_request_ids:
+            return self._immediate_queue
+        if self.immediate_predicate is not None and self.immediate_predicate(request):
+            return self._immediate_queue
+        if request.num_prompt_tokens <= self.threshold:
+            return self._short_queue
+        return self._long_queue
+
+    def _long_head_wait_ms(self) -> float | None:
+        """Milliseconds the oldest long request has waited, or None if N/A.
+
+        Single source of truth for the long-queue head age (one peek +
+        monotonic() + dict lookup), reused by the soft and hard aging checks so
+        the hot path does not recompute it.
+        """
+        if self.long_max_wait_ms <= 0 or not self._long_queue:
+            return None
+        head = self._long_queue.peek_request()  # FCFS head = oldest long request
+        enqueued_at = self._long_enqueue_at.get(head.request_id)
+        if enqueued_at is None:
+            return None
+        return (time.monotonic() - enqueued_at) * 1000.0
+
+    def begin_step(self, token_budget: int) -> None:
+        """Refill the aged-long admission token bucket for this scheduling step.
+
+        Called once at the start of each schedule(). The bucket refills by
+        `long_token_reservation * token_budget` tokens per step (capped at
+        `long_burst_steps` steps' worth), so over any window the aged-long lane
+        is admitted at an average rate of the reservation fraction of token
+        throughput. With reservation=0 the bucket stays empty, so an aged long is
+        admitted only via the stall-avoidance path (no short waiting); LapsConfig
+        therefore requires reservation > 0 whenever aging is enabled.
+        """
+        self._long_refill_per_step = self.long_token_reservation * token_budget
+        self._long_bucket_capacity = self._long_refill_per_step * self.long_burst_steps
+        self._long_bucket = min(
+            self._long_bucket_capacity,
+            self._long_bucket + self._long_refill_per_step,
+        )
+        if self._debug_logging_enabled:
+            logger.debug(
+                "LAPS begin_step: token_budget=%d long_token_reservation=%.3f "
+                "refill_per_step=%.0f bucket=%.0f capacity=%.0f",
+                token_budget,
+                self.long_token_reservation,
+                self._long_refill_per_step,
+                self._long_bucket,
+                self._long_bucket_capacity,
+            )
+
+    def _debug_select(self, event: str) -> None:
+        """Lazy debug log for a selection decision (skips f-string when off)."""
+        if self._debug_logging_enabled:
+            self._debug_state(
+                event,
+                extra=f"bucket={self._long_bucket:.0f} capacity={self._long_bucket_capacity:.0f}",
+            )
+
+    def _select_schedulable_queue(self) -> RequestQueue | None:
+        # Pure query (no side effects): called repeatedly per scheduling step.
+        if self._immediate_queue:
+            return self._immediate_queue
+        if self._long_queue:
+            # Read the long-queue head age once for the aging check.
+            wait_ms = self._long_head_wait_ms()
+            if wait_ms is not None and wait_ms >= self.long_max_wait_ms:
+                # The token-reservation bucket is the single channel for admitting
+                # aged longs ahead of waiting shorts, rate-limited to the
+                # reservation fraction of token throughput. When the short queue
+                # is non-empty, only promote long while the bucket has credit;
+                # when it is empty, always allow long (stall avoidance). There is
+                # deliberately no unconditional deadline bypass: under sustained
+                # overload every long is perpetually past any absolute wall-clock
+                # bound, so a bypass would degenerate into long-first scheduling
+                # and reintroduce the head-of-line blocking LAPS exists to remove.
+                if not self._short_queue:
+                    # Stall avoidance: allow long when no short is waiting.
+                    self._debug_select("aged-long_selected_stall_avoidance")
+                    return self._long_queue
+                if self._long_bucket > 0.0:
+                    # Reservation credit available: promote aged-long ahead.
+                    self._debug_select("aged-long_selected_with_budget")
+                    return self._long_queue
+                # Bucket exhausted and short queue non-empty: prefer short so the
+                # aged-long admission rate stays bounded by the reservation (fall
+                # through below).
+                self._debug_select("aged-long_blocked_budget_exhausted")
+        if self._short_queue:
+            return self._short_queue
+        if self._long_queue:
+            return self._long_queue
+        return None
+
+    def has_schedulable_requests(self) -> bool:
+        """Return whether a request can be dispatched right now."""
+        return self._select_schedulable_queue() is not None
+
+    def select_waiting_queue_for_scheduling(self) -> RequestQueue | None:
+        return self._select_schedulable_queue()
+
+    def mark_force_immediate(self, request_id: str) -> None:
+        self._force_immediate_request_ids.add(request_id)
+
+    @staticmethod
+    def _request_id(request: Request | object) -> str | None:
+        return getattr(request, "request_id", None)
+
+    def add_request(self, request: Request) -> None:
+        queue = self._classify_queue(request)
+        queue.add_request(request)
+        self._queue_index[request.request_id] = queue
+        if queue is self._long_queue:
+            self._long_enqueue_at.setdefault(request.request_id, time.monotonic())
+        if queue is not self._immediate_queue:
+            self._force_immediate_request_ids.discard(request.request_id)
+        self._debug_state("enqueue", request=request, queue=queue)
+        self._maybe_log_stats()
+
+    def pop_request(self) -> Request:
+        queue = self._select_schedulable_queue()
+        if queue is None:
+            raise IndexError("pop from empty LAPS queue")
+        return self.pop_request_from_queue(queue)
+
+    def pop_request_from_queue(
+        self,
+        queue: RequestQueue,
+        *,
+        count_as_removal: bool = False,
+        skip_or_requeue_reason: str | None = None,
+        long_charge_tokens: int = 0,
+    ) -> Request:
+        # `long_charge_tokens` is the cost charged to the aged-long token bucket
+        # when this dispatch is an aged-long promotion ahead of waiting shorts.
+        # The caller passes the long's *full remaining prefill* (num_tokens -
+        # num_computed_tokens), not just this step's chunk: a long monopolizes
+        # the per-step token budget for many steps, so charging only the first
+        # chunk would let the per-step bucket refill outpace the charge and the
+        # reservation would never actually throttle longs.
+        request = queue.pop_request()
+        self._queue_index.pop(request.request_id, None)
+        enqueued_at = self._long_enqueue_at.pop(request.request_id, None)
+        if count_as_removal:
+            if skip_or_requeue_reason is not None:
+                self._increment_skip_or_requeue_counter(queue, skip_or_requeue_reason)
+                event_name = f"skip_or_requeue:{skip_or_requeue_reason}"
+            else:
+                event_name = "remove"
+        else:
+            self._dispatch_counters[self._queue_name(queue)] += 1
+            event_name = "dispatch"
+            # Count long requests dispatched after aging past their bound.
+            wait_ms = (time.monotonic() - enqueued_at) * 1000.0 if enqueued_at is not None else None
+            aged = (
+                queue is self._long_queue
+                and self.long_max_wait_ms > 0
+                and wait_ms is not None
+                and wait_ms >= self.long_max_wait_ms
+            )
+            if aged:
+                # A stall-avoidance admission (no short waiting) did not jump the
+                # queue, so it counts as neither a starvation promotion nor a
+                # bucket charge; only count/charge when shorts were actually
+                # waiting and got passed. Such a jump can only have been selected
+                # via the soft phase (bucket had credit), so it is always charged
+                # the long's full remaining prefill. The bucket may dip far below
+                # zero (bounded by one long's prefill); the per-step refill repays
+                # that debt over the many steps the long actually runs, so over
+                # any window aged longs are admitted at the reservation fraction
+                # of token throughput. While the debt is outstanding, shorts are
+                # preferred (a negative bucket blocks further soft promotions),
+                # except that stall avoidance still admits a long when no short is
+                # waiting (that branch precedes the bucket check in selection).
+                jumped_shorts = len(self._short_queue) > 0
+                charged = False
+                if jumped_shorts:
+                    self._long_starvation_promotions += 1
+                    if long_charge_tokens > 0:
+                        charged = True
+                        self._long_bucket -= long_charge_tokens
+                        self._long_tokens_charged += long_charge_tokens
+                if self._debug_logging_enabled:
+                    self._debug_state(
+                        "aged-long_dispatched",
+                        request=request,
+                        queue=queue,
+                        extra=f"long_charge_tokens={long_charge_tokens} charged={charged} "
+                        f"bucket={self._long_bucket:.0f} "
+                        f"capacity={self._long_bucket_capacity:.0f}",
+                    )
+        self._force_immediate_request_ids.discard(request.request_id)
+        self._debug_state(event_name, request=request, queue=queue)
+        self._maybe_log_stats()
+        return request
+
+    def peek_request(self) -> Request:
+        queue = self._select_schedulable_queue()
+        if queue is None:
+            raise IndexError("peek from an empty LAPS queue")
+        return queue.peek_request()
+
+    def prepend_request(self, request: Request, force_immediate: bool = False) -> None:
+        if force_immediate:
+            self._force_immediate_request_ids.add(request.request_id)
+        queue = self._classify_queue(request, force_immediate=force_immediate)
+        queue.prepend_request(request)
+        self._queue_index[request.request_id] = queue
+        if queue is self._long_queue:
+            self._long_enqueue_at.setdefault(request.request_id, time.monotonic())
+        self._prepend_counters[self._queue_name(queue)] += 1
+        self._debug_state("prepend", request=request, queue=queue)
+        self._maybe_log_stats()
+
+    def prepend_requests(self, requests: RequestQueue) -> None:
+        for request in requests:
+            self.prepend_request(cast(Request, request))
+
+    def remove_request(self, request: Request) -> None:
+        queue = self._queue_index.get(request.request_id)
+        if queue is None:
+            raise ValueError("request not found in LAPS queue")
+        # `_queue_index` tracks the canonical Request object the sub-queue holds
+        # (the scheduler keeps one object per request_id), so hand it straight to
+        # the sub-queue and let it match by identity, exactly as the base vLLM
+        # queues do. Remove from the sub-queue *before* mutating our bookkeeping
+        # so a missing request raises ValueError without corrupting `_queue_index`.
+        queue.remove_request(request)
+        self._queue_index.pop(request.request_id, None)
+        self._long_enqueue_at.pop(request.request_id, None)
+        self._force_immediate_request_ids.discard(request.request_id)
+        self._debug_state("remove", request=request, queue=queue)
+        self._maybe_log_stats()
+
+    def remove_requests(self, requests: Iterable[Request]) -> None:
+        queue_to_requests: dict[int, list[Request]] = {}
+        queue_map = {id(q): q for q in self._queues()}
+        removed_count = 0
+        # Group the requests by sub-queue via `_queue_index` (O(1) each) and hand
+        # the objects straight through. A previous per-request linear scan here
+        # made this batch path O(k * queue_len); dropping it restores the base
+        # queue's single-pass O(queue_len), which matters when the waiting queue
+        # is long (i.e. exactly the overload case LAPS targets).
+        for request in requests:
+            queue = self._queue_index.get(request.request_id)
+            if queue is None:
+                continue
+            queue_to_requests.setdefault(id(queue), []).append(request)
+        for queue_id, matched_requests in queue_to_requests.items():
+            removed_count += len(matched_requests)
+            queue = queue_map[queue_id]
+            queue.remove_requests(matched_requests)
+            for matched in matched_requests:
+                self._queue_index.pop(matched.request_id, None)
+                self._long_enqueue_at.pop(matched.request_id, None)
+                self._force_immediate_request_ids.discard(matched.request_id)
+        if removed_count:
+            self._debug_state("remove_batch", extra=f"count={removed_count}")
+            self._maybe_log_stats()
+
+    def __bool__(self) -> bool:
+        # Equivalent to `_select_schedulable_queue() is not None` (that query
+        # returns None iff all three sub-queues are empty), but cheaper: this is
+        # on the scheduler's per-step hot path (the `while self.waiting` guard),
+        # so avoid the peek + monotonic() + starvation checks here. Use
+        # `has_schedulable_requests()` when the full selection logic is needed.
+        return len(self) > 0
+
+    def __len__(self) -> int:
+        return len(self._immediate_queue) + len(self._short_queue) + len(self._long_queue)
+
+    def __iter__(self) -> Iterator[Request]:
+        yield from self._immediate_queue
+        yield from self._short_queue
+        yield from self._long_queue
+
+    def __contains__(self, request: object) -> bool:
+        request_id = self._request_id(request)
+        return request_id is not None and request_id in self._queue_index
+
+
+if TYPE_CHECKING:
+    # Compile-time assertion that LapsRequestQueue satisfies the extension
+    # contract the scheduler depends on (see SteppedWaitingQueue).
+    _laps_queue_conforms: type[SteppedWaitingQueue] = LapsRequestQueue
+
+
+class LapsSchedulerMixin:
+    """Inject a LAPS-style waiting queue into vLLM's scheduler."""
+
+    if TYPE_CHECKING:
+        # `policy` is provided by vLLM's Scheduler base at runtime; the mixin is
+        # always combined with it (see RecomputeScheduler). Declared here only
+        # for the type checker so self.policy resolves without faking
+        # inheritance. The super() calls below reach Scheduler through the same
+        # combination and are annotated with type: ignore[misc] accordingly.
+        policy: SchedulingPolicy
+
+    def _is_recovery_request(self, request: Request) -> bool:
+        """Recovery-style requests are prioritized via the immediate queue."""
+        return (
+            request.status == RequestStatus.PREEMPTED
+            or request.num_computed_tokens > 0
+            or request.num_external_computed_tokens > 0
+            or request.num_output_tokens > 0
+        )
+
+    def _init_laps_waiting_queue(
+        self,
+        immediate_predicate: Callable[[Request], bool] | None = None,
+    ) -> None:
+        if self.policy != SchedulingPolicy.FCFS:
+            # The non-FCFS warning is emitted once at config time in
+            # NPUPlatform.check_and_update_config; keep this path quiet (debug
+            # only) so the same condition is not logged twice.
+            logger.debug(
+                "LAPS scheduling supports only FCFS policy (current=%s); keeping the default waiting queue.",
+                self.policy,
+            )
+            return
+
+        if immediate_predicate is None:
+            immediate_predicate = self._is_recovery_request
+        laps_config = get_ascend_config().laps_config
+        self.waiting = LapsRequestQueue(
+            policy=self.policy,
+            threshold=laps_config.threshold,
+            long_max_wait_ms=laps_config.long_max_wait_ms,
+            long_token_reservation=laps_config.long_token_reservation,
+            long_burst_steps=laps_config.long_burst_steps,
+            immediate_predicate=immediate_predicate,
+            stats_log_interval_s=laps_config.stats_log_interval_s,
+        )
+        logger.info(
+            "LAPS scheduling enabled on Ascend: threshold=%d, long_max_wait_ms=%.3f, long_token_reservation=%.3f",
+            laps_config.threshold,
+            laps_config.long_max_wait_ms,
+            laps_config.long_token_reservation,
+        )
+
+    def _laps_waiting_queue(self) -> LapsRequestQueue | None:
+        if isinstance(self.waiting, LapsRequestQueue):
+            return self.waiting
+        return None
+
+    def _select_waiting_queue_for_scheduling(self) -> RequestQueue | None:
+        waiting = getattr(self, "waiting", None)
+        if isinstance(waiting, LapsRequestQueue):
+            skipped_waiting = getattr(self, "skipped_waiting", None)
+            if self.policy == SchedulingPolicy.FCFS and skipped_waiting:
+                return skipped_waiting
+            queue = waiting.select_waiting_queue_for_scheduling()
+            if queue is not None:
+                return queue
+            return skipped_waiting or None
+        return super()._select_waiting_queue_for_scheduling()  # type: ignore[misc]
+
+    def _preempt_request(self, request: Request, timestamp: float) -> None:
+        waiting = getattr(self, "waiting", None)
+        if isinstance(waiting, LapsRequestQueue):
+            waiting.mark_force_immediate(request.request_id)
+        super()._preempt_request(request, timestamp)  # type: ignore[misc]

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -46,6 +46,9 @@ from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.utils import ConstantList, record_function_or_nullcontext
 
+from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.core.laps_scheduler import LapsSchedulerMixin
+
 
 # `spec_manager_map` in single_type_kv_cache_manager is a module-level dict
 # whose keys are class objects bound at import time.  When the async
@@ -104,7 +107,7 @@ class RecomputeSchedulerOutput(SchedulerOutput):
     recomputed_reqs: list[RecomputeReqInfo] | None = None
 
 
-class RecomputeScheduler(Scheduler):
+class RecomputeScheduler(LapsSchedulerMixin, Scheduler):
     running: list[Request]
 
     def __init__(self, *args, **kwargs):
@@ -124,6 +127,30 @@ class RecomputeScheduler(Scheduler):
             "qwen3_next" in self.vllm_config.model_config.hf_text_config.model_type
             or "qwen3_5" in self.vllm_config.model_config.hf_text_config.model_type
         )
+        if get_ascend_config().laps_config.enabled:
+            self._init_laps_waiting_queue()
+
+    def _pop_waiting_request(
+        self,
+        request_queue,
+        count_with_laps: bool,
+        *,
+        count_as_removal: bool = False,
+        skip_or_requeue_reason: str | None = None,
+        long_charge_tokens: int = 0,
+    ) -> Request:
+        if count_with_laps:
+            laps_waiting = self._laps_waiting_queue()
+            # count_with_laps is only set when the LAPS queue owns request_queue,
+            # so the LAPS waiting queue is guaranteed to be installed here.
+            assert laps_waiting is not None
+            return laps_waiting.pop_request_from_queue(
+                request_queue,
+                count_as_removal=count_as_removal,
+                skip_or_requeue_reason=skip_or_requeue_reason,
+                long_charge_tokens=long_charge_tokens,
+            )
+        return request_queue.pop_request()
 
     def add_request(self, request: Request) -> None:
         existing = self.requests.get(request.request_id)
@@ -242,6 +269,10 @@ class RecomputeScheduler(Scheduler):
 
         # For logging.
         scheduled_timestamp = time.monotonic()
+        laps_waiting = self._laps_waiting_queue()
+        if laps_waiting is not None:
+            # Reset per-step LAPS state and set the token reservation budget.
+            laps_waiting.begin_step(self.max_num_scheduled_tokens)
 
         self.kv_cache_manager.new_step_starts()
 
@@ -442,6 +473,10 @@ class RecomputeScheduler(Scheduler):
                 request_queue = self._select_waiting_queue_for_scheduling()
                 assert request_queue is not None
 
+                # skipped_waiting is not owned by LapsRequestQueue, so only route
+                # pops through LAPS when the selected queue is one of its subqueues.
+                count_with_laps = laps_waiting is not None and laps_waiting.owns_queue(request_queue)
+
                 request = request_queue.peek_request()
                 request_id = request.request_id
 
@@ -454,7 +489,12 @@ class RecomputeScheduler(Scheduler):
                             "%s is still in WAITING_FOR_REMOTE_KVS state.",
                             request_id,
                         )
-                    request_queue.pop_request()
+                    self._pop_waiting_request(
+                        request_queue,
+                        count_with_laps,
+                        count_as_removal=True,
+                        skip_or_requeue_reason="blocked_waiting_status",
+                    )
                     step_skipped_waiting.prepend_request(request)
                     continue
 
@@ -469,7 +509,12 @@ class RecomputeScheduler(Scheduler):
                     )
                 ):
                     # Scheduling would exceed max_loras, skip.
-                    request_queue.pop_request()
+                    self._pop_waiting_request(
+                        request_queue,
+                        count_with_laps,
+                        count_as_removal=True,
+                        skip_or_requeue_reason="max_loras",
+                    )
                     step_skipped_waiting.prepend_request(request)
                     continue
 
@@ -494,7 +539,12 @@ class RecomputeScheduler(Scheduler):
                             # The request cannot be scheduled because
                             # the KVConnector couldn't determine
                             # the number of matched tokens.
-                            request_queue.pop_request()
+                            self._pop_waiting_request(
+                                request_queue,
+                                count_with_laps,
+                                count_as_removal=True,
+                                skip_or_requeue_reason="remote_kv_not_ready",
+                            )
                             step_skipped_waiting.prepend_request(request)
                             continue
 
@@ -622,7 +672,14 @@ class RecomputeScheduler(Scheduler):
                             preempted=request.num_preemptions > 0,
                         )
 
-                request = request_queue.pop_request()
+                # Charge the aged-long bucket the long's full remaining prefill
+                # (not just this step's chunk num_new_tokens): a long monopolizes
+                # the token budget for many steps, so a first-chunk-only charge
+                # would be outpaced by the per-step refill and never throttle it.
+                long_charge_tokens = request.num_tokens - num_computed_tokens
+                request = self._pop_waiting_request(
+                    request_queue, count_with_laps, long_charge_tokens=long_charge_tokens
+                )
                 if load_kv_async:
                     # If loading async, allocate memory and put request
                     # into the WAITING_FOR_REMOTE_KV state.

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -458,6 +458,16 @@ class NPUPlatform(Platform):
                     "PD-disaggregated mode (kv_role='kv_producer'/'kv_consumer')."
                 )
 
+        laps_config = ascend_config.laps_config
+        enable_laps = laps_config.enabled
+        laps_supported_policy = vllm_config.scheduler_config.policy == "fcfs"
+        if enable_laps and not laps_supported_policy:
+            logger.warning_once(
+                "LAPS scheduling currently supports only FCFS scheduler policy; "
+                "current policy=%s. The default waiting queue will be used.",
+                vllm_config.scheduler_config.policy,
+            )
+
         if ascend_config.recompute_scheduler_enable:
             kv_transfer_config = vllm_config.kv_transfer_config
             kv_role = getattr(kv_transfer_config, "kv_role", None)
@@ -471,9 +481,29 @@ class NPUPlatform(Platform):
 
             recompute_scheduler_config = RecomputeSchedulerConfig.initialize_from_config(vllm_config)
             vllm_config.scheduler_config = recompute_scheduler_config
+            if enable_laps:
+                logger.info(
+                    "Ascend LAPS scheduler selected through recompute "
+                    "scheduler: scheduler_cls=%s, policy=%s, threshold=%d, "
+                    "long_max_wait_ms=%.3f, long_token_reservation=%.3f",
+                    vllm_config.scheduler_config.scheduler_cls,
+                    vllm_config.scheduler_config.policy,
+                    laps_config.threshold,
+                    laps_config.long_max_wait_ms,
+                    laps_config.long_token_reservation,
+                )
+        elif enable_laps:
+            logger.warning_once(
+                "LAPS scheduling requires recompute_scheduler_enable=true "
+                "in additional_config. LAPS scheduling will not be activated.",
+            )
 
         # Extend original scheduler_config to use SchedulerDynamicBatch.
         if ascend_config.SLO_limits_for_dynamic_batch != -1:
+            if enable_laps:
+                logger.warning_once(
+                    "LAPS scheduling is ignored because SLO_limits_for_dynamic_batch selects SchedulerDynamicBatch."
+                )
             vllm_config.scheduler_config.scheduler_cls = (
                 "vllm_ascend.core.scheduler_dynamic_batch.SchedulerDynamicBatch"
             )


### PR DESCRIPTION
### What this PR does / why we need it?

This PR implements **LAPS (Length-Aware Prefill Scheduling)** for the Ascend recompute scheduler in `vllm-ascend`.

Under FCFS prefill scheduling, a long prompt at the head of the waiting queue blocks every shorter prompt behind it (head-of-line blocking), inflating the latency of short requests under load. LAPS splits the waiting queue into three length-aware lanes (immediate, short, and long) and schedules short prefills ahead of long ones, while bounding how badly long requests can be starved using a token-bucket anti-starvation aging mechanism.

### Does this PR introduce _any_ user-facing change?

Yes, but it is **off by default** and additive:
- A new optional `additional_config["laps_config"]` block is introduced.
- When enabled without `recompute_scheduler_enable=true`, or with a non-FCFS policy, LAPS is not activated and a warning is logged.

### How was this patch tested?

- **Unit tests** (`tests/ut/core/test_laps_scheduler.py`, `test_laps_scheduler_mixin.py`, `test_recompute_scheduler_laps.py`, and `test_ascend_config.py`) covering config validation, queue routing, token-bucket aging, and recompute-scheduler integration.
- **E2E tests** (`tests/e2e/singlecard/test_laps_scheduling.py`) asserting LAPS produces output consistent with the default scheduler on a single card.
