### PR TITLE
[Feature][310p]Qwen3.5 Support MTP and Graphmode

### DIFF
--- a/tests/e2e/pull_request/one_card/_310p/test_spec_decode_mtp_310p.py
+++ b/tests/e2e/pull_request/one_card/_310p/test_spec_decode_mtp_310p.py
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+from tests.e2e.conftest import VllmRunner
+
+
+def test_qwen3_5_mtp_tp1_eager():
+    example_prompts = ["Hello, my name is"]
+    with VllmRunner(
+        "Qwen/Qwen3.5-4B",
+        tensor_parallel_size=1,
+        enforce_eager=True,
+        dtype="float16",
+        max_model_len=2048,
+        mamba_ssm_cache_dtype="float16",
+        speculative_config={
+            "method": "qwen3_5_mtp",
+            "num_speculative_tokens": 1,
+        },
+    ) as vllm_model:
+        vllm_model.generate_greedy(example_prompts, max_tokens=8)

--- a/tests/ut/_310p/attention/test_attention_v1_310.py
+++ b/tests/ut/_310p/attention/test_attention_v1_310.py
@@ -212,11 +212,16 @@ class TestAscendAttentionBackendImpl310(TestBase):
 
         mock_paged_attention.assert_called_once()
 
-    def test_forward_mtp_310(self):
+    @patch("vllm_ascend._310p.attention.attention_v1.AscendAttentionBackendImpl310.forward_chunked_prefill_310")
+    def test_forward_mtp_310(self, mock_chunked_prefill):
         query = torch.randn(4, 8 * 64)
         key, value = None, None
         output = torch.empty_like(query)
         metadata = self.attn_metadata
         metadata.attn_state = AscendAttentionState.SpecDecoding
-        with self.assertRaises(NotImplementedError):
-            output = self.impl.forward_impl(query, key, value, None, metadata, output)
+        mock_chunked_prefill.return_value = output
+
+        result = self.impl.forward_impl(query, key, value, None, metadata, output)
+
+        mock_chunked_prefill.assert_called_once_with(query, metadata, output)
+        self.assertIs(result, output)

--- a/tests/ut/_310p/sample/test_sampler_310.py
+++ b/tests/ut/_310p/sample/test_sampler_310.py
@@ -56,12 +56,22 @@ class _FakeQ:
     def npu(self):
         return self
 
-    def exponential_(self):
-        self.default_exponential_called = True
+    def exponential_(self, generator=None):
+        if generator is None:
+            self.default_exponential_called = True
         return self
 
     def __getitem__(self, idx):
         return self.rows[idx]
+
+    def __setitem__(self, idx, value):
+        self.rows[idx] = value
+
+
+def _empty_like_side_effect(q_instances, template):
+    if isinstance(template, _FakeRow):
+        return _FakeRow()
+    return next(q_instances)
 
 
 class _FakeCPUGenerator:
@@ -90,6 +100,7 @@ class TestSampler310pStandalone(unittest.TestCase):
 
         fake_q_first = _FakeQ(batch_size=2)
         fake_q_second = _FakeQ(batch_size=2)
+        q_instances = iter([fake_q_first, fake_q_second])
 
         npu_stream = MagicMock()
         generator = MagicMock()
@@ -100,7 +111,11 @@ class TestSampler310pStandalone(unittest.TestCase):
         with (
             patch.object(sampler_310p, "npu_stream_switch", return_value=nullcontext()),
             patch.object(sampler_310p, "global_stream", return_value=MagicMock()),
-            patch.object(sampler_310p.torch, "empty_like", side_effect=[fake_q_first, fake_q_second]),
+            patch.object(
+                sampler_310p.torch,
+                "empty_like",
+                side_effect=lambda template: _empty_like_side_effect(q_instances, template),
+            ),
             patch.object(sampler_310p.torch, "Generator", side_effect=_FakeCPUGenerator) as gen_ctor,
             patch.object(
                 sampler_310p.torch,
@@ -131,6 +146,7 @@ class TestSampler310pStandalone(unittest.TestCase):
         probs.view.return_value = torch.tensor([1])
 
         fake_q = _FakeQ(batch_size=1)
+        q_instances = iter([fake_q])
         npu_stream = MagicMock()
         generator = MagicMock()
         generator.get_state.side_effect = RuntimeError("state read failed")
@@ -144,7 +160,11 @@ class TestSampler310pStandalone(unittest.TestCase):
         with (
             patch.object(sampler_310p, "npu_stream_switch", return_value=nullcontext()),
             patch.object(sampler_310p, "global_stream", return_value=MagicMock()),
-            patch.object(sampler_310p.torch, "empty_like", return_value=fake_q),
+            patch.object(
+                sampler_310p.torch,
+                "empty_like",
+                side_effect=lambda template: _empty_like_side_effect(q_instances, template),
+            ),
             patch.object(sampler_310p.torch, "Generator", side_effect=_FailSetStateCPUGenerator),
             patch.object(
                 sampler_310p.torch,
@@ -171,6 +191,7 @@ class TestSampler310pStandalone(unittest.TestCase):
 
         fake_q_first = _FakeQ(batch_size=1)
         fake_q_second = _FakeQ(batch_size=1)
+        q_instances = iter([fake_q_first, fake_q_second])
         npu_stream = MagicMock()
 
         generator_first = MagicMock()
@@ -184,7 +205,11 @@ class TestSampler310pStandalone(unittest.TestCase):
         with (
             patch.object(sampler_310p, "npu_stream_switch", return_value=nullcontext()),
             patch.object(sampler_310p, "global_stream", return_value=MagicMock()),
-            patch.object(sampler_310p.torch, "empty_like", side_effect=[fake_q_first, fake_q_second]),
+            patch.object(
+                sampler_310p.torch,
+                "empty_like",
+                side_effect=lambda template: _empty_like_side_effect(q_instances, template),
+            ),
             patch.object(sampler_310p.torch, "Generator", side_effect=_FakeCPUGenerator) as gen_ctor,
             patch.object(
                 sampler_310p.torch,

--- a/tests/ut/_310p/test_kv_block_zeroer_310p.py
+++ b/tests/ut/_310p/test_kv_block_zeroer_310p.py
@@ -1,0 +1,73 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+from types import SimpleNamespace
+
+import torch
+from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+from tests.ut.base import TestBase
+from vllm_ascend._310p.kv_block_zeroer import AscendKVBlockZeroer310
+
+
+class TestAscendKVBlockZeroer310(TestBase):
+    def setUp(self):
+        self.zeroer = AscendKVBlockZeroer310(torch.device("cpu"), pin_memory=False)
+
+    def test_zero_block_ids_noop_when_empty(self):
+        kv = torch.ones(4, 2, 3)
+        self.zeroer._kv_tensors = [kv]
+        self.zeroer._logical_page_ratio = 1
+
+        self.zeroer.zero_block_ids([])
+        self.assertTrue(torch.all(kv == 1))
+
+    def test_zero_block_ids_zeros_target_slices(self):
+        kv = torch.ones(6, 2, 3)
+        self.zeroer._kv_tensors = [kv]
+        self.zeroer._logical_page_ratio = 2
+
+        self.zeroer.zero_block_ids([1])
+
+        self.assertTrue(torch.all(kv[:2] == 1))
+        self.assertTrue(torch.all(kv[2:4] == 0))
+        self.assertTrue(torch.all(kv[4:] == 1))
+
+    def test_init_meta_deduplicates_kv_pointers(self):
+        k_cache = torch.zeros(4, 2, 3)
+        v_cache = k_cache
+        layer_context = SimpleNamespace(kv_cache=(k_cache, v_cache))
+        spec = FullAttentionSpec(
+            block_size=128,
+            num_kv_heads=2,
+            head_size=64,
+            dtype=torch.float16,
+        )
+        group = SimpleNamespace(
+            kv_cache_spec=spec,
+            kv_cache_group_id=0,
+            layer_names=["layer_0"],
+        )
+
+        self.zeroer.init_meta(
+            attn_groups_iter=[group],
+            kernel_block_sizes=[[64]],
+            cache_dtype="float16",
+            runner_only_attn_layers=set(),
+            static_forward_context={"layer_0": layer_context},
+        )
+
+        self.assertEqual(len(self.zeroer._kv_tensors), 1)
+        self.assertEqual(self.zeroer._logical_page_ratio, 2)

--- a/vllm_ascend/_310p/attention/attention_v1.py
+++ b/vllm_ascend/_310p/attention/attention_v1.py
@@ -24,7 +24,10 @@ from vllm.v1.attention.backends.registry import (  # type: ignore
     register_backend,
 )
 
-from vllm_ascend._310p.attention.attention_mask import AttentionMaskBuilder310, is_compressed_mask_supported
+from vllm_ascend._310p.attention.attention_mask import (
+    AttentionMaskBuilder310,
+    is_compressed_mask_supported,
+)
 from vllm_ascend._310p.attention.metadata_builder import AscendAttentionMetadataBuilder310
 from vllm_ascend.attention.attention_v1 import (
     AscendAttentionBackend,
@@ -99,7 +102,7 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
     optimized for the Ascend 310P architecture.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.support_compressed_mask = is_compressed_mask_supported()
 
@@ -241,19 +244,31 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
         """
         num_actual_tokens = int(attn_metadata.num_actual_tokens)
         query = query[:num_actual_tokens]
-        output = output[:num_actual_tokens]
+        output_slice = output[:num_actual_tokens]
 
-        # Calculate query lengths from start locations
-        qsl_cpu = attn_metadata.query_start_loc.cpu()
-        qlens = qsl_cpu[1:] - qsl_cpu[:-1]
+        # Host qLens filled in AscendAttentionMetadataBuilder310.build(); eager fallback only.
+        qlens = getattr(attn_metadata, "query_lens_cpu", None)
+        if qlens is None:
+            from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 
-        context_lens = attn_metadata.seq_lens
+            if _EXTRA_CTX.capturing:
+                raise RuntimeError(
+                    "310P splitfuse requires attn_metadata.query_lens_cpu during graph capture; "
+                    "ensure AscendAttentionMetadataBuilder310.build() ran before forward."
+                )
+            qsl_cpu = attn_metadata.query_start_loc.cpu()
+            qlens = qsl_cpu[1:] - qsl_cpu[:-1]
+
         block_table = attn_metadata.block_tables
 
-        if context_lens.device != query.device:
-            context_lens = context_lens.to(query.device, non_blocking=True)
+        if attn_metadata.seq_lens.device != query.device:
+            attn_metadata.seq_lens = attn_metadata.seq_lens.to(
+                device=query.device,
+                non_blocking=True,
+            )
 
         if self.support_compressed_mask:
+            # splitfuse_v2 requires fixed ND [2048, 2048]; parent build() may set FRACTAL_NZ mask.
             mask = AttentionMaskBuilder310.get_compressed_splitfuse_mask(query.device)
             torch_npu._npu_paged_attention_splitfuse_v2(
                 query=query,
@@ -262,12 +277,12 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
                 mask=mask,
                 block_table=block_table,
                 seq_len=qlens,
-                context_lens=context_lens,
+                context_lens=attn_metadata.seq_lens,
                 num_kv_heads=self.num_kv_heads,
                 num_heads=self.num_heads,
                 scale_value=self.scale,
                 mask_type=MASK_TYPE_NORM_COMPRESS_PAGED_ATTENTION,
-                out=output,
+                out=output_slice,
             )
             return output
 
@@ -280,11 +295,11 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
             mask=mask,
             block_table=block_table,
             seq_len=qlens,
-            context_lens=context_lens,
+            context_lens=attn_metadata.seq_lens,
             num_kv_heads=self.num_kv_heads,
             num_heads=self.num_heads,
             scale_value=self.scale,
-            out=output,
+            out=output_slice,
         )
 
         return output
@@ -321,7 +336,9 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
         # Condition for PrefillCacheHit: Indicates prefill with some cached tokens already processed
         elif state in [AscendAttentionState.ChunkedPrefill, AscendAttentionState.PrefillCacheHit]:
             output = self.forward_chunked_prefill_310(query, attn_metadata, output)
-        # Condition for SpecDecoding: Specified for mtp, which is not supported yet.
+        # Condition for SpecDecoding: MTP spec verify (splitfuse v2 when compressed mask supported).
+        elif state == AscendAttentionState.SpecDecoding:
+            output = self.forward_chunked_prefill_310(query, attn_metadata, output)
         else:
             raise NotImplementedError(f"AscendAttentionState: {state} is not supported for 310P currently.")
         return output

--- a/vllm_ascend/_310p/attention/attention_v1.py
+++ b/vllm_ascend/_310p/attention/attention_v1.py
@@ -28,6 +28,7 @@ from vllm_ascend._310p.attention.attention_mask import (
     AttentionMaskBuilder310,
     is_compressed_mask_supported,
 )
+from vllm_ascend._310p.attention.metadata import get_query_lens_cpu
 from vllm_ascend._310p.attention.metadata_builder import AscendAttentionMetadataBuilder310
 from vllm_ascend.attention.attention_v1 import (
     AscendAttentionBackend,
@@ -247,7 +248,7 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
         output_slice = output[:num_actual_tokens]
 
         # Host qLens filled in AscendAttentionMetadataBuilder310.build(); eager fallback only.
-        qlens = getattr(attn_metadata, "query_lens_cpu", None)
+        qlens = get_query_lens_cpu(attn_metadata)
         if qlens is None:
             from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 

--- a/vllm_ascend/_310p/attention/attention_v1.py
+++ b/vllm_ascend/_310p/attention/attention_v1.py
@@ -330,14 +330,12 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
         # Condition for DecodeOnly: Pure decoding phase where each request generates one token
         elif state == AscendAttentionState.DecodeOnly:
             output = self.forward_paged_attention(query, attn_metadata, output)
-        # Condition for ChunkedPrefill:
-        # 1. During speculative decoding scenarios (except mtp)
-        # 2. Processing large prefill requests in chunks
-        # Condition for PrefillCacheHit: Indicates prefill with some cached tokens already processed
-        elif state in [AscendAttentionState.ChunkedPrefill, AscendAttentionState.PrefillCacheHit]:
-            output = self.forward_chunked_prefill_310(query, attn_metadata, output)
-        # Condition for SpecDecoding: MTP spec verify (splitfuse v2 when compressed mask supported).
-        elif state == AscendAttentionState.SpecDecoding:
+        # ChunkedPrefill / PrefillCacheHit: chunked prefill or mixed batches.
+        # SpecDecoding: MTP uniform spec verify (splitfuse on 310P).
+        elif (
+            state in [AscendAttentionState.ChunkedPrefill, AscendAttentionState.PrefillCacheHit]
+            or state == AscendAttentionState.SpecDecoding
+        ):
             output = self.forward_chunked_prefill_310(query, attn_metadata, output)
         else:
             raise NotImplementedError(f"AscendAttentionState: {state} is not supported for 310P currently.")

--- a/vllm_ascend/_310p/attention/metadata.py
+++ b/vllm_ascend/_310p/attention/metadata.py
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+"""Dynamic 310P fields attached to AscendMetadata at runtime."""
+
+import torch
+
+from vllm_ascend.attention.attention_v1 import AscendMetadata
+
+QUERY_LENS_CPU_ATTR = "query_lens_cpu"
+
+
+def set_query_lens_cpu(attn_metadata: AscendMetadata, query_lens_cpu: torch.Tensor) -> None:
+    """Attach host qLens for ATB splitfuse without extending upstream AscendMetadata."""
+    setattr(attn_metadata, QUERY_LENS_CPU_ATTR, query_lens_cpu)
+
+
+def get_query_lens_cpu(attn_metadata: AscendMetadata) -> torch.Tensor | None:
+    value = getattr(attn_metadata, QUERY_LENS_CPU_ATTR, None)
+    if value is None:
+        return None
+    return value

--- a/vllm_ascend/_310p/attention/metadata_builder.py
+++ b/vllm_ascend/_310p/attention/metadata_builder.py
@@ -25,9 +25,11 @@ from vllm_ascend._310p.attention.attention_mask import (
     AttentionMaskBuilder310,
     is_compressed_mask_supported,
 )
+from vllm_ascend._310p.attention.metadata import set_query_lens_cpu
 from vllm_ascend.attention.attention_v1 import (
     AscendAttentionMetadataBuilder,
     AscendAttentionState,
+    AscendMetadata,
 )
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 
@@ -64,14 +66,10 @@ class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
         max_model_len = vllm_config.model_config.max_model_len
         self.attn_mask_builder: Any = AttentionMaskBuilder310(self.device, max_model_len)
 
-        self._query_lens_cpu_pool: list[torch.Tensor] = []
-        self._query_lens_cpu_pool_idx = -1
+        self._query_lens_cpu_buffer: torch.Tensor | None = None
         if device.type != "cpu":
             max_num_seqs = vllm_config.scheduler_config.max_num_seqs
-            self._query_lens_cpu_pool = [
-                torch.empty(max_num_seqs, dtype=torch.int32, device="cpu", pin_memory=True),
-                torch.empty(max_num_seqs, dtype=torch.int32, device="cpu", pin_memory=True),
-            ]
+            self._query_lens_cpu_buffer = torch.empty(max_num_seqs, dtype=torch.int32, device="cpu", pin_memory=True)
 
     def _fill_query_lens_cpu(
         self,
@@ -79,13 +77,15 @@ class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
         query_start_loc_cpu: torch.Tensor,
     ) -> torch.Tensor:
         """Pinned CPU per-request query lengths for ATB splitfuse (host qLensTensor)."""
-        query_lens_cpu = query_start_loc_cpu[1 : num_reqs + 1] - query_start_loc_cpu[:num_reqs]
-        if not self._query_lens_cpu_pool:
-            return query_lens_cpu.contiguous()
+        if self._query_lens_cpu_buffer is None:
+            return (query_start_loc_cpu[1 : num_reqs + 1] - query_start_loc_cpu[:num_reqs]).contiguous()
 
-        self._query_lens_cpu_pool_idx = (self._query_lens_cpu_pool_idx + 1) % len(self._query_lens_cpu_pool)
-        buffer = self._query_lens_cpu_pool[self._query_lens_cpu_pool_idx]
-        buffer[:num_reqs].copy_(query_lens_cpu)
+        buffer = self._query_lens_cpu_buffer
+        torch.sub(
+            query_start_loc_cpu[1 : num_reqs + 1],
+            query_start_loc_cpu[:num_reqs],
+            out=buffer[:num_reqs],
+        )
         return buffer[:num_reqs]
 
     def build(
@@ -93,7 +93,7 @@ class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
         common_prefix_len: int,
         common_attn_metadata: AscendCommonAttentionMetadata,
         fast_build: bool = False,
-    ):
+    ) -> AscendMetadata:
         attn_metadata = super().build(common_prefix_len, common_attn_metadata, fast_build)
 
         num_reqs = common_attn_metadata.num_reqs
@@ -107,7 +107,10 @@ class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
 
         query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu[: num_reqs + 1]
         # ATB splitfuse qLensTensor must be host; filled here (outside graph forward).
-        attn_metadata.query_lens_cpu = self._fill_query_lens_cpu(num_reqs, query_start_loc_cpu)
+        set_query_lens_cpu(
+            attn_metadata,
+            self._fill_query_lens_cpu(num_reqs, query_start_loc_cpu),
+        )
 
         # Bind device-side views for in-place graph replay updates.
         attn_metadata.seq_lens = common_attn_metadata.seq_lens[:num_reqs]

--- a/vllm_ascend/_310p/attention/metadata_builder.py
+++ b/vllm_ascend/_310p/attention/metadata_builder.py
@@ -21,8 +21,15 @@ import torch
 from vllm.config import VllmConfig
 from vllm.v1.kv_cache_interface import AttentionSpec
 
-from vllm_ascend._310p.attention.attention_mask import AttentionMaskBuilder310
-from vllm_ascend.attention.attention_v1 import AscendAttentionMetadataBuilder
+from vllm_ascend._310p.attention.attention_mask import (
+    AttentionMaskBuilder310,
+    is_compressed_mask_supported,
+)
+from vllm_ascend.attention.attention_v1 import (
+    AscendAttentionMetadataBuilder,
+    AscendAttentionState,
+)
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 
 
 class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
@@ -56,3 +63,57 @@ class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
         # Override the mask builder with the 310P-specific version
         max_model_len = vllm_config.model_config.max_model_len
         self.attn_mask_builder: Any = AttentionMaskBuilder310(self.device, max_model_len)
+
+        self._query_lens_cpu_pool: list[torch.Tensor] = []
+        self._query_lens_cpu_pool_idx = -1
+        if device.type != "cpu":
+            max_num_seqs = vllm_config.scheduler_config.max_num_seqs
+            self._query_lens_cpu_pool = [
+                torch.empty(max_num_seqs, dtype=torch.int32, device="cpu", pin_memory=True),
+                torch.empty(max_num_seqs, dtype=torch.int32, device="cpu", pin_memory=True),
+            ]
+
+    def _fill_query_lens_cpu(
+        self,
+        num_reqs: int,
+        query_start_loc_cpu: torch.Tensor,
+    ) -> torch.Tensor:
+        """Pinned CPU per-request query lengths for ATB splitfuse (host qLensTensor)."""
+        query_lens_cpu = query_start_loc_cpu[1 : num_reqs + 1] - query_start_loc_cpu[:num_reqs]
+        if not self._query_lens_cpu_pool:
+            return query_lens_cpu.contiguous()
+
+        self._query_lens_cpu_pool_idx = (self._query_lens_cpu_pool_idx + 1) % len(self._query_lens_cpu_pool)
+        buffer = self._query_lens_cpu_pool[self._query_lens_cpu_pool_idx]
+        buffer[:num_reqs].copy_(query_lens_cpu)
+        return buffer[:num_reqs]
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+        fast_build: bool = False,
+    ):
+        attn_metadata = super().build(common_prefix_len, common_attn_metadata, fast_build)
+
+        num_reqs = common_attn_metadata.num_reqs
+
+        splitfuse_states = (
+            AscendAttentionState.SpecDecoding,
+            AscendAttentionState.ChunkedPrefill,
+        )
+        if attn_metadata.attn_state not in splitfuse_states:
+            return attn_metadata
+
+        query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu[: num_reqs + 1]
+        # ATB splitfuse qLensTensor must be host; filled here (outside graph forward).
+        attn_metadata.query_lens_cpu = self._fill_query_lens_cpu(num_reqs, query_start_loc_cpu)
+
+        # Bind device-side views for in-place graph replay updates.
+        attn_metadata.seq_lens = common_attn_metadata.seq_lens[:num_reqs]
+        attn_metadata.query_start_loc = common_attn_metadata.query_start_loc[: num_reqs + 1]
+
+        if is_compressed_mask_supported():
+            attn_metadata.attn_mask = AttentionMaskBuilder310.get_compressed_splitfuse_mask(self.device)
+
+        return attn_metadata

--- a/vllm_ascend/_310p/compile_warmup.py
+++ b/vllm_ascend/_310p/compile_warmup.py
@@ -1,0 +1,69 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+from collections.abc import Iterable
+from typing import Any
+
+from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.logger import logger
+
+from vllm_ascend.utils import check_gdn_layer
+
+
+def mtp_full_decode_only_skips_piecewise_compile_warmup(vllm_config: VllmConfig) -> bool:
+    """Whether 310P MTP FULL_DECODE_ONLY should skip piecewise compile dummy runs.
+
+    ACL graph only captures uniform spec-decode batches. Piecewise warmup at
+    compile_range.end (e.g. 2048 tokens) exercises ChunkedPrefill + GDN prefill
+    paths that remain eager at runtime and lack 310P GDN metadata patches.
+    """
+    if vllm_config.model_config.enforce_eager:
+        return False
+    spec = vllm_config.speculative_config
+    if spec is None or spec.method != "mtp":
+        return False
+    if vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.FULL_DECODE_ONLY:
+        return False
+    return check_gdn_layer(vllm_config)
+
+
+def build_piecewise_compile_warmup_sizes(
+    vllm_config: VllmConfig,
+    warmup_sizes: list[int],
+    cg_capture_sizes: list[int],
+    compile_ranges: Iterable[Any],
+) -> list[int]:
+    """Build token sizes for piecewise compile warmup on 310P."""
+    if vllm_config.model_config.enforce_eager:
+        return warmup_sizes
+
+    warmup_sizes = [x for x in warmup_sizes if x not in cg_capture_sizes]
+    if mtp_full_decode_only_skips_piecewise_compile_warmup(vllm_config):
+        if warmup_sizes:
+            logger.info_once(
+                "310P MTP FULL_DECODE_ONLY with GDN: skipping piecewise compile warmup "
+                "for token sizes %s. Prefill remains eager; ACL graph capture covers "
+                "uniform spec-decode batches only.",
+                warmup_sizes,
+            )
+        return []
+
+    all_sizes = set(cg_capture_sizes)
+    all_sizes.update([x for x in warmup_sizes if isinstance(x, int)])
+    for compile_range in compile_ranges:
+        if not any(x in compile_range for x in all_sizes):
+            warmup_sizes.append(compile_range.end)
+    return warmup_sizes

--- a/vllm_ascend/_310p/kv_block_zeroer.py
+++ b/vllm_ascend/_310p/kv_block_zeroer.py
@@ -1,0 +1,81 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+from vllm.v1.kv_cache_interface import FullAttentionSpec
+from vllm.v1.worker.utils import AttentionGroup, KVBlockZeroer
+
+
+class AscendKVBlockZeroer310(KVBlockZeroer):
+    """310P KV block zeroer without Triton.
+
+    Atlas 300I DUO does not support Triton. For MTP >= 2 hybrid models, newly
+    allocated attention KV blocks must be zeroed via direct tensor writes.
+    """
+
+    def __init__(self, device: torch.device, pin_memory: bool) -> None:
+        super().__init__(device, pin_memory)
+        self._kv_tensors: list[torch.Tensor] = []
+        self._logical_page_ratio: int = 1
+
+    def init_meta(
+        self,
+        attn_groups_iter: Iterable["AttentionGroup"],
+        kernel_block_sizes: list[list[int]],
+        cache_dtype: str,
+        runner_only_attn_layers: set[str],
+        static_forward_context: dict[str, Any],
+    ) -> None:
+        seen_ptrs: set[int] = set()
+        self._kv_tensors = []
+        self._logical_page_ratio = 1
+
+        for group in attn_groups_iter:
+            spec = group.kv_cache_spec
+            if not isinstance(spec, FullAttentionSpec):
+                continue
+            if group.kv_cache_group_id >= len(kernel_block_sizes):
+                continue
+            kernel_bs = kernel_block_sizes[group.kv_cache_group_id][0]
+            ratio = spec.block_size // kernel_bs
+            if not self._kv_tensors:
+                self._logical_page_ratio = ratio
+
+            for layer_name in group.layer_names:
+                if layer_name in runner_only_attn_layers:
+                    continue
+                kv_tuple = static_forward_context[layer_name].kv_cache
+                assert len(kv_tuple) == 2, "K and V are not stored separately"
+                for kv in kv_tuple:
+                    dp = kv.data_ptr()
+                    if dp in seen_ptrs:
+                        continue
+                    seen_ptrs.add(dp)
+                    self._kv_tensors.append(kv)
+
+    def zero_block_ids(self, block_ids: list[int]) -> None:
+        if not block_ids or not self._kv_tensors:
+            return
+
+        ratio = self._logical_page_ratio
+        for block_id in block_ids:
+            start = block_id * ratio
+            end = start + ratio
+            for kv in self._kv_tensors:
+                kv[start:end].zero_()

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -46,9 +46,9 @@ from vllm_ascend._310p.block_table import MultiGroupBlockTable as MultiGroupBloc
 from vllm_ascend._310p.kv_block_zeroer import AscendKVBlockZeroer310
 from vllm_ascend._310p.npu_input_batch import NPUInputBatch310 as NPUInputBatch
 from vllm_ascend._310p.ops.rotary_embedding import prepare_mrope_cos_sin_slices_from_runner
+from vllm_ascend._310p.sample.rejection_sampler import AscendRejectionSampler310
 from vllm_ascend._310p.sample.sampler import AscendSampler310
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.sample.rejection_sampler import AscendRejectionSampler
 from vllm_ascend.spec_decode.utils import update_num_computed_tokens_for_batch_change
 from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, lmhead_tp_enable
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
@@ -96,7 +96,7 @@ class NPUModelRunner310(NPUModelRunner):
         logger.info_once("Weight layout uses FRACTAL_NZ.")
         self.sampler = AscendSampler310()
         if getattr(self, "rejection_sampler", None) is not None:
-            self.rejection_sampler = AscendRejectionSampler(self.sampler)
+            self.rejection_sampler = AscendRejectionSampler310(self.sampler)
         if self.speculative_config is not None and self.speculative_config.method == "ngram":
             # 310P ngram requires decode-only graph shapes to be built with q_len=1.
             # Keep dispatcher's internal query_len in sync to avoid key-init assert.

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -39,15 +39,16 @@ from vllm.v1.kv_cache_interface import (
     MambaSpec,
     UniformTypeKVCacheSpecs,
 )
-from vllm.v1.sample.rejection_sampler import RejectionSampler
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.worker.cp_utils import get_total_cp_world_size
 
 from vllm_ascend._310p.block_table import MultiGroupBlockTable as MultiGroupBlockTable310
+from vllm_ascend._310p.kv_block_zeroer import AscendKVBlockZeroer310
 from vllm_ascend._310p.npu_input_batch import NPUInputBatch310 as NPUInputBatch
 from vllm_ascend._310p.ops.rotary_embedding import prepare_mrope_cos_sin_slices_from_runner
 from vllm_ascend._310p.sample.sampler import AscendSampler310
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.sample.rejection_sampler import AscendRejectionSampler
 from vllm_ascend.spec_decode.utils import update_num_computed_tokens_for_batch_change
 from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, lmhead_tp_enable
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
@@ -57,8 +58,20 @@ _ATTENTION_BLOCK_SIZE_LIMIT = 128 * 128
 
 
 class NPUModelRunner310(NPUModelRunner):
+    """
+    310P model runner with a distinct ACL graph capture/replay contract from 910B:
+
+    - Capture: ACLGraphWrapper records the full forward inside ``torch.npu.graph``.
+      310P attention calls NPU ops directly (paged / splitfuse), without mainline
+      ``full_graph_fia`` / ``full_graph_pa`` graph_task registration.
+    - Replay: refresh shared runner buffers (block_table, seq_lens, query_start_loc,
+      slot_mapping via CPU prepare + copy_to_gpu) so tensor addresses stay stable,
+      then ``aclgraph.replay()``.
+    """
+
     # Inherited from parent runner; annotated here to satisfy strict type checks.
     uniform_decode_query_len: int
+    _mtp_spec_dummy_capture: bool = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -83,7 +96,7 @@ class NPUModelRunner310(NPUModelRunner):
         logger.info_once("Weight layout uses FRACTAL_NZ.")
         self.sampler = AscendSampler310()
         if getattr(self, "rejection_sampler", None) is not None:
-            self.rejection_sampler = RejectionSampler(self.sampler)
+            self.rejection_sampler = AscendRejectionSampler(self.sampler)
         if self.speculative_config is not None and self.speculative_config.method == "ngram":
             # 310P ngram requires decode-only graph shapes to be built with q_len=1.
             # Keep dispatcher's internal query_len in sync to avoid key-init assert.
@@ -137,6 +150,18 @@ class NPUModelRunner310(NPUModelRunner):
         if self.attn_state in (AscendAttentionState.ChunkedPrefill, AscendAttentionState.PrefillCacheHit):
             force_eager = True
 
+        # MTP graph replay is only valid for uniform spec-decode batches (q_len = 1 + K).
+        if (
+            self.speculative_config is not None
+            and self.speculative_config.method == "mtp"
+            and (
+                self.attn_state != AscendAttentionState.SpecDecoding
+                or max_num_scheduled_tokens != self.uniform_decode_query_len
+                or num_tokens != max_num_scheduled_tokens * num_reqs
+            )
+        ):
+            force_eager = True
+
         if force_uniform_decode is None and self.attn_state == AscendAttentionState.DecodeOnly:
             decode_query_len = _NGRAM_GRAPH_UNIFORM_DECODE_QUERY_LEN
             if (
@@ -160,6 +185,13 @@ class NPUModelRunner310(NPUModelRunner):
             force_num_active_loras=force_num_active_loras,
             num_encoder_reqs=num_encoder_reqs,
         )
+
+    def _build_attention_metadata(self, *args: Any, **kwargs: Any):
+        # Parent dummy_run assigns ChunkedPrefill for non-MLA MTP (910B FIA graph).
+        # 310P must capture SpecDecoding + splitfuse for MTP uniform decode graphs.
+        if self._mtp_spec_dummy_capture:
+            self.attn_state = AscendAttentionState.SpecDecoding
+        return super()._build_attention_metadata(*args, **kwargs)
 
     def _pad_query_start_loc_for_fia(
         self,
@@ -193,6 +225,18 @@ class NPUModelRunner310(NPUModelRunner):
 
         self.query_start_loc.copy_to_gpu()
         return num_reqs_padded
+
+    def _build_attn_state(self, num_reqs, num_scheduled_tokens, num_valid_tokens):
+        attn_state = super()._build_attn_state(num_reqs, num_scheduled_tokens, num_valid_tokens)
+        if (
+            self.speculative_config is not None
+            and self.speculative_config.method == "mtp"
+            and not np.all(self.input_batch.num_computed_tokens_cpu[:num_reqs] == 0)
+            and np.all(num_scheduled_tokens == self.uniform_decode_query_len)
+        ):
+            attn_state = AscendAttentionState.SpecDecoding
+            self.attn_state = attn_state
+        return attn_state
 
     def _prepare_inputs(  # type: ignore[override]
         self,
@@ -552,22 +596,33 @@ class NPUModelRunner310(NPUModelRunner):
         profile_seq_lens: int | None = None,
     ):
         temporary_context = self.temporary_modify_uniform_decode_query_len() if uniform_decode else nullcontext()
+        mtp_spec_dummy_capture = (
+            uniform_decode
+            and not is_profile
+            and self.speculative_config is not None
+            and self.speculative_config.method == "mtp"
+            and not self.vllm_config.model_config.use_mla
+        )
         with temporary_context:
-            return super()._dummy_run(
-                num_tokens=num_tokens,
-                with_prefill=with_prefill,
-                cudagraph_runtime_mode=cudagraph_runtime_mode,
-                force_attention=force_attention,
-                uniform_decode=uniform_decode,
-                is_profile=is_profile,
-                create_mixed_batch=create_mixed_batch,
-                allow_microbatching=allow_microbatching,
-                skip_eplb=skip_eplb,
-                remove_lora=remove_lora,
-                is_graph_capturing=is_graph_capturing,
-                num_active_loras=num_active_loras,
-                profile_seq_lens=profile_seq_lens,
-            )
+            self._mtp_spec_dummy_capture = mtp_spec_dummy_capture
+            try:
+                return super()._dummy_run(
+                    num_tokens=num_tokens,
+                    with_prefill=with_prefill,
+                    cudagraph_runtime_mode=cudagraph_runtime_mode,
+                    force_attention=force_attention,
+                    uniform_decode=uniform_decode,
+                    is_profile=is_profile,
+                    create_mixed_batch=create_mixed_batch,
+                    allow_microbatching=allow_microbatching,
+                    skip_eplb=skip_eplb,
+                    remove_lora=remove_lora,
+                    is_graph_capturing=is_graph_capturing,
+                    num_active_loras=num_active_loras,
+                    profile_seq_lens=profile_seq_lens,
+                )
+            finally:
+                self._mtp_spec_dummy_capture = False
 
     def _model_forward(
         self,
@@ -600,6 +655,17 @@ class NPUModelRunner310(NPUModelRunner):
         # naturally consistent there. 310P ngram needs temporary alignment.
         with self.temporary_modify_uniform_decode_query_len():
             super()._check_and_update_cudagraph_mode(attention_backends, kv_cache_groups)
+
+    def _init_kv_zero_meta(self) -> None:
+        """310P uses torch zeroing because Triton is not available."""
+        self._kv_block_zeroer = AscendKVBlockZeroer310(self.device, self.pin_memory)
+        self._kv_block_zeroer.init_meta(
+            attn_groups_iter=self._kv_cache_spec_attn_group_iterator(),
+            kernel_block_sizes=self.kernel_block_sizes,
+            cache_dtype=self.cache_config.cache_dtype,
+            runner_only_attn_layers=self.runner_only_attn_layers,
+            static_forward_context=(self.compilation_config.static_forward_context),
+        )
 
     def initialize_kv_cache_tensors(self, kv_cache_config: KVCacheConfig) -> dict[str, torch.Tensor]:
         """
@@ -766,7 +832,7 @@ class NPUModelRunner310(NPUModelRunner):
                 prev_common_req_indices.append(prev_index)
                 draft_len = len(scheduled_spec_tokens.get(req_id, ()))
                 total_num_spec_tokens += draft_len
-                flattened_index = cu_num_tokens[cur_index].item() - 1
+                flattened_index = int(cu_num_tokens[cur_index]) - 1
                 sample_flattened_indices.append(flattened_index - draft_len)
                 spec_flattened_indices.extend(range(flattened_index - draft_len + 1, flattened_index + 1))
                 start = prev_index * self.num_spec_tokens

--- a/vllm_ascend/_310p/ops/fla/gdn_310.py
+++ b/vllm_ascend/_310p/ops/fla/gdn_310.py
@@ -22,7 +22,9 @@ import torch.nn.functional as F
 from vllm.forward_context import get_forward_context
 from vllm.v1.attention.backend import AttentionMetadata  # type: ignore
 
-from vllm_ascend.utils import enable_sp, vllm_version_is
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.compilation.acl_graph import get_draft_graph_params, get_graph_params
+from vllm_ascend.utils import enable_sp, vllm_version_is, weak_ref_tensors
 
 if vllm_version_is("0.21.0"):
     from vllm.model_executor.layers.mamba.gdn_linear_attn import (  # type: ignore[import-not-found]
@@ -38,6 +40,86 @@ from vllm_ascend._310p.ops.fla.fused_gdn_gating import fused_gdn_gating_pytorch
 from vllm_ascend.attention.utils import maybe_save_kv_layer_to_connector
 
 
+_CONV1D_310_OP_BACKEND = "310"
+_CONV1D_310_BUFFER_REPLAY = "buffer_replay"
+
+
+def _copy_host_tuple_to_int64_buffer(
+    buffer: torch.Tensor,
+    host_tuple: tuple[int, ...],
+) -> None:
+    if not host_tuple:
+        return
+    num_elements = len(host_tuple)
+    cpu_values = torch.tensor(host_tuple, dtype=torch.int64, device="cpu", pin_memory=buffer.is_pinned())
+    buffer[:num_elements].copy_(cpu_values, non_blocking=True)
+
+
+def _as_int64_device_view(tensor: torch.Tensor) -> torch.Tensor:
+    if tensor.dtype == torch.int64:
+        return tensor
+    return tensor.to(torch.int64)
+
+
+def _get_spec_causal_conv1d_device_args(
+    attn_metadata: GDNAttentionMetadata,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    num_spec_decodes = attn_metadata.num_spec_decodes
+    query_start_loc_buf = _as_int64_device_view(attn_metadata.spec_query_start_loc)
+    cache_indices_buf = _as_int64_device_view(attn_metadata.spec_state_indices_tensor[:, 0])
+    num_accepted_buf = _as_int64_device_view(attn_metadata.num_accepted_tokens)
+    return (
+        query_start_loc_buf[: num_spec_decodes + 1],
+        cache_indices_buf[:num_spec_decodes],
+        num_accepted_buf[:num_spec_decodes],
+        query_start_loc_buf,
+        cache_indices_buf,
+        num_accepted_buf,
+    )
+
+
+def _register_310_conv1d_buffer_replay(
+    graph_params,
+    num_actual_tokens: int,
+    *,
+    mixed_qkv,
+    conv_weights,
+    conv_state,
+    bias,
+    activation_num: int,
+    run_mode: int,
+    branch: str,
+    layer_prefix: str,
+    qsl_dev: torch.Tensor,
+    cidx_dev: torch.Tensor,
+    nat_dev: torch.Tensor | None,
+    q_per_seq: int,
+) -> None:
+    graph_params.conv1d_params[num_actual_tokens].append(
+        (
+            None,
+            weak_ref_tensors(mixed_qkv),
+            weak_ref_tensors(conv_weights),
+            weak_ref_tensors(conv_state),
+            bias,
+            activation_num,
+            PAD_SLOT_ID,
+            run_mode,
+            branch,
+            layer_prefix,
+            weak_ref_tensors(qsl_dev),
+            weak_ref_tensors(cidx_dev),
+            weak_ref_tensors(nat_dev) if nat_dev is not None else None,
+            q_per_seq,
+            _CONV1D_310_OP_BACKEND,
+            _CONV1D_310_BUFFER_REPLAY,
+        )
+    )
+    graph_params.conv1d_handles[num_actual_tokens].append(None)
+    graph_params.conv1d_events[num_actual_tokens].append(None)
+
+
+
 def _l2norm(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
     return F.normalize(x.to(torch.float32), p=2, dim=-1, eps=eps).to(x.dtype)
 
@@ -50,15 +132,29 @@ def _flatten_state_indices(
     if ssm_state_indices.ndim == 1:
         return ssm_state_indices[:total_tokens].to(torch.int32).contiguous()
 
-    seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
-    ssm_state_indices = ssm_state_indices[: seq_lens.shape[0]]
-    positions = torch.arange(
-        ssm_state_indices.shape[1],
-        device=ssm_state_indices.device,
-        dtype=seq_lens.dtype,
-    )
-    valid = positions.unsqueeze(0) < seq_lens.unsqueeze(1)
-    return ssm_state_indices.masked_select(valid)[:total_tokens].to(torch.int32).contiguous()
+    num_seqs = (cu_seqlens[1:] - cu_seqlens[:-1]).shape[0]
+    seq_lens = cu_seqlens[1 : num_seqs + 1] - cu_seqlens[:num_seqs]
+    ssm_state_indices = ssm_state_indices[:num_seqs]
+
+    # Uniform spec-decode ACL graph uses fixed q_len per request; reshape avoids
+    # NPU masked_select which breaks stream capture (aclnnMaskedSelect / 107027).
+    if _EXTRA_CTX.capturing or (seq_lens.numel() > 0 and torch.all(seq_lens == seq_lens[0])):
+        q_per_seq = ssm_state_indices.shape[1]
+        flat = ssm_state_indices[:, :q_per_seq].reshape(-1)
+        return flat[:total_tokens].to(torch.int32).contiguous()
+
+    # Eager mixed batches with variable seq_lens: compact on CPU, copy back async.
+    ssm_cpu = ssm_state_indices.cpu()
+    seq_lens_cpu = seq_lens.cpu()
+    q_per_seq = ssm_cpu.shape[1]
+    positions = torch.arange(q_per_seq)
+    valid = positions.unsqueeze(0) < seq_lens_cpu.unsqueeze(1)
+    flat_cpu = ssm_cpu.masked_select(valid).to(torch.int32).contiguous()[:total_tokens]
+    if not flat_cpu.is_pinned:
+        flat_cpu = flat_cpu.pin_memory()
+    flat_dev = torch.empty(flat_cpu.numel(), dtype=torch.int32, device=ssm_state_indices.device)
+    flat_dev.copy_(flat_cpu, non_blocking=True)
+    return flat_dev.contiguous()
 
 
 def npu_recurrent_gated_delta_rule_310(
@@ -106,6 +202,38 @@ def _310p_get_state_dtype(self) -> tuple[torch.dtype, torch.dtype]:
 
 
 _original_get_state_dtype = GatedDeltaNetAttention.get_state_dtype
+
+
+def _merge_spec_and_non_spec_outputs_310(
+    core_attn_out: torch.Tensor,
+    num_actual_tokens: int,
+    spec_token_indx: torch.Tensor,
+    non_spec_token_indx: torch.Tensor,
+    core_attn_out_spec: torch.Tensor,
+    core_attn_out_non_spec: torch.Tensor,
+) -> None:
+    """Merge spec/non-spec GDN outputs back into the batch layout.
+
+    Avoid NPU ``index_copy_`` (IndexPutV2) which fails on some layouts; use
+    direct indexing instead. Validate lengths so mixed prefill+spec batches
+    do not pass mismatched tensors from spec ops.
+    """
+    spec_out = core_attn_out_spec.squeeze(0)
+    non_spec_out = core_attn_out_non_spec.squeeze(0)
+    n_spec = spec_token_indx.numel()
+    n_non_spec = non_spec_token_indx.numel()
+    if spec_out.shape[0] != n_spec:
+        raise RuntimeError(
+            f"GDN spec output length {spec_out.shape[0]} != spec_token_indx {n_spec}"
+        )
+    if non_spec_out.shape[0] != n_non_spec:
+        raise RuntimeError(
+            f"GDN non-spec output length {non_spec_out.shape[0]} != "
+            f"non_spec_token_indx {n_non_spec}"
+        )
+    out = core_attn_out[:num_actual_tokens]
+    out[spec_token_indx] = spec_out
+    out[non_spec_token_indx] = non_spec_out
 
 
 class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
@@ -171,19 +299,65 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
 
         # 1.1: Process the multi-query part
         if spec_sequence_masks is not None:
-            mixed_qkv_spec = torch.ops._C_ascend.npu_causal_conv1d_310(
-                mixed_qkv_spec,
-                conv_weights,
-                bias=self.conv1d.bias,
-                conv_states=conv_state,
-                query_start_loc=spec_query_start_loc.to(torch.int64),
-                cache_indices=spec_state_indices_tensor[:, 0][: attn_metadata.num_spec_decodes].to(torch.int64),
-                initial_state_mode=None,
-                num_accepted_tokens=num_accepted_tokens.to(torch.int64),
-                activation_mode=activation_num,
-                pad_slot_id=PAD_SLOT_ID,
-                run_mode=1,
+            # Align with spec sub-batch only (mixed prefill+spec has fewer spec decodes
+            # than total requests; full-batch tensor fails tiling / wrong state offset).
+            spec_num_accepted = num_accepted_tokens[: attn_metadata.num_spec_decodes].to(torch.int64)
+            uniform_spec_only = (
+                attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0
             )
+            if _EXTRA_CTX.capturing and uniform_spec_only:
+                qsl_dev, cidx_dev, nat_dev, qsl_buf, cidx_buf, nat_buf = (
+                    _get_spec_causal_conv1d_device_args(attn_metadata)
+                )
+                spec_q_per_seq = int(attn_metadata.spec_state_indices_tensor.size(-1))
+                graph_params = (
+                    get_draft_graph_params() if _EXTRA_CTX.is_draft_model else get_graph_params()
+                )
+                _register_310_conv1d_buffer_replay(
+                    graph_params,
+                    num_actual_tokens,
+                    mixed_qkv=mixed_qkv_spec,
+                    conv_weights=conv_weights,
+                    conv_state=conv_state,
+                    bias=self.conv1d.bias,
+                    activation_num=activation_num,
+                    run_mode=1,
+                    branch="spec",
+                    layer_prefix=self.prefix,
+                    qsl_dev=qsl_buf,
+                    cidx_dev=cidx_buf,
+                    nat_dev=nat_buf,
+                    q_per_seq=spec_q_per_seq,
+                )
+                mixed_qkv_spec = torch.ops._C_ascend.npu_causal_conv1d_310(
+                    mixed_qkv_spec,
+                    conv_weights,
+                    bias=self.conv1d.bias,
+                    conv_states=conv_state,
+                    query_start_loc=qsl_dev,
+                    cache_indices=cidx_dev,
+                    initial_state_mode=None,
+                    num_accepted_tokens=nat_dev,
+                    activation_mode=activation_num,
+                    pad_slot_id=PAD_SLOT_ID,
+                    run_mode=1,
+                )
+            else:
+                mixed_qkv_spec = torch.ops._C_ascend.npu_causal_conv1d_310(
+                    mixed_qkv_spec,
+                    conv_weights,
+                    bias=self.conv1d.bias,
+                    conv_states=conv_state,
+                    query_start_loc=spec_query_start_loc.to(torch.int64),
+                    cache_indices=spec_state_indices_tensor[:, 0][: attn_metadata.num_spec_decodes].to(
+                        torch.int64
+                    ),
+                    initial_state_mode=None,
+                    num_accepted_tokens=spec_num_accepted,
+                    activation_mode=activation_num,
+                    pad_slot_id=PAD_SLOT_ID,
+                    run_mode=1,
+                )
 
         # 1.2: Process the remaining part
         if attn_metadata.num_prefills > 0:
@@ -252,7 +426,7 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
                     state=ssm_state,
                     cu_seqlens=spec_query_start_loc[: attn_metadata.num_spec_decodes + 1],
                     ssm_state_indices=spec_state_indices_tensor,
-                    num_accepted_tokens=num_accepted_tokens,
+                    num_accepted_tokens=spec_num_accepted,
                     use_qk_l2norm_in_kernel=True,
                 )
             else:
@@ -309,17 +483,14 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
             )
         # 3. Merge core attention output
         if spec_sequence_masks is not None and core_attn_out_non_spec is not None:
-            merged_out = torch.empty(
-                (1, num_actual_tokens, *core_attn_out_spec.shape[2:]),
-                dtype=core_attn_out_non_spec.dtype,
-                device=core_attn_out_non_spec.device,
+            _merge_spec_and_non_spec_outputs_310(
+                core_attn_out,
+                num_actual_tokens,
+                spec_token_indx,
+                non_spec_token_indx,
+                core_attn_out_spec,
+                core_attn_out_non_spec,
             )
-            merged_out.index_copy_(1, spec_token_indx, core_attn_out_spec)
-            merged_out.index_copy_(1, non_spec_token_indx, core_attn_out_non_spec)
-            if not enable_sp():
-                core_attn_out[:num_actual_tokens] = merged_out.squeeze(0)
-            else:
-                core_attn_out[:num_actual_tokens] = merged_out.squeeze(0)[:num_actual_tokens]
         elif spec_sequence_masks is not None:
             if not enable_sp():
                 core_attn_out[:num_actual_tokens] = core_attn_out_spec.squeeze(0)
@@ -331,3 +502,96 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
             else:
                 core_attn_out[:num_actual_tokens] = core_attn_out_non_spec.squeeze(0)[:num_actual_tokens]
         maybe_save_kv_layer_to_connector("", [])
+
+
+
+def _get_spec_causal_conv1d_update_host_args_310p(
+    attn_metadata: GDNAttentionMetadata,
+) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+    """Build spec conv1d host args from GDN metadata without patch_gdn_attn."""
+    from vllm_ascend.ops.gdn import to_int64_tuple
+
+    num_spec_decodes = attn_metadata.num_spec_decodes
+    return (
+        to_int64_tuple(attn_metadata.spec_query_start_loc[: num_spec_decodes + 1]),
+        to_int64_tuple(attn_metadata.spec_state_indices_tensor[:, 0][:num_spec_decodes]),
+        to_int64_tuple(attn_metadata.num_accepted_tokens[:num_spec_decodes]),
+    )
+
+def update_conv1d_graph_params_310p(
+    update_stream,
+    forward_context,
+    num_tokens,
+    vllm_config,
+    is_draft_model=False,
+    draft_attn_metadatas=None,
+):
+    """310P uniform spec-decode GDN conv1d graph replay via device buffer updates."""
+    from vllm_ascend.ops.gdn import _pad_conv1d_host_args_to_capture
+
+    graph_params = get_draft_graph_params() if is_draft_model else get_graph_params()
+
+    if (
+        graph_params is None
+        or num_tokens not in graph_params.conv1d_params
+        or len(graph_params.conv1d_params[num_tokens]) == 0
+    ):
+        return
+
+    attn_metadata = forward_context.attn_metadata
+    if is_draft_model and draft_attn_metadatas is not None:
+        attn_metadata = draft_attn_metadatas
+
+    with torch.npu.stream(update_stream):
+        for param in graph_params.conv1d_params[num_tokens]:
+            param_list = list(param)
+            if len(param_list) < 16:
+                continue
+            op_backend = param_list[14]
+            replay_mode = param_list[15]
+            if op_backend != _CONV1D_310_OP_BACKEND or replay_mode != _CONV1D_310_BUFFER_REPLAY:
+                continue
+
+            (
+                _output,
+                mixed_qkv,
+                _conv_weights,
+                _conv_state,
+                _bias,
+                _activation_num,
+                _pad_slot_id,
+                run_mode,
+                branch,
+                layer_prefix,
+                qsl_dev,
+                cidx_dev,
+                nat_dev,
+                q_per_seq,
+            ) = param_list[:14]
+
+            if run_mode != 1 or branch != "spec" or attn_metadata is None:
+                continue
+
+            meta = attn_metadata
+            if isinstance(meta, dict):
+                meta = meta.get(layer_prefix, None)
+            if not isinstance(meta, GDNAttentionMetadata):
+                continue
+            if meta.spec_sequence_masks is None:
+                continue
+
+            cap_x_dim0 = int(mixed_qkv.size(0))
+            qsl_host, cidx_host, num_accepted_host = _get_spec_causal_conv1d_update_host_args_310p(meta)
+            new_query_start_loc, new_cache_indices, new_num_accepted = _pad_conv1d_host_args_to_capture(
+                qsl_host,
+                cidx_host,
+                num_accepted_host,
+                cap_x_dim0=cap_x_dim0,
+                q_per_seq=q_per_seq,
+                with_num_accepted=True,
+            )
+            _copy_host_tuple_to_int64_buffer(qsl_dev, new_query_start_loc)
+            _copy_host_tuple_to_int64_buffer(cidx_dev, new_cache_indices)
+            if nat_dev is not None:
+                _copy_host_tuple_to_int64_buffer(nat_dev, new_num_accepted)
+

--- a/vllm_ascend/_310p/ops/fla/gdn_310.py
+++ b/vllm_ascend/_310p/ops/fla/gdn_310.py
@@ -39,7 +39,6 @@ from vllm_ascend._310p.ops.fla.chunk_gated_delta_rule import chunk_gated_delta_r
 from vllm_ascend._310p.ops.fla.fused_gdn_gating import fused_gdn_gating_pytorch
 from vllm_ascend.attention.utils import maybe_save_kv_layer_to_connector
 
-
 _CONV1D_310_OP_BACKEND = "310"
 _CONV1D_310_BUFFER_REPLAY = "buffer_replay"
 
@@ -117,7 +116,6 @@ def _register_310_conv1d_buffer_replay(
     )
     graph_params.conv1d_handles[num_actual_tokens].append(None)
     graph_params.conv1d_events[num_actual_tokens].append(None)
-
 
 
 def _l2norm(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
@@ -223,14 +221,9 @@ def _merge_spec_and_non_spec_outputs_310(
     n_spec = spec_token_indx.numel()
     n_non_spec = non_spec_token_indx.numel()
     if spec_out.shape[0] != n_spec:
-        raise RuntimeError(
-            f"GDN spec output length {spec_out.shape[0]} != spec_token_indx {n_spec}"
-        )
+        raise RuntimeError(f"GDN spec output length {spec_out.shape[0]} != spec_token_indx {n_spec}")
     if non_spec_out.shape[0] != n_non_spec:
-        raise RuntimeError(
-            f"GDN non-spec output length {non_spec_out.shape[0]} != "
-            f"non_spec_token_indx {n_non_spec}"
-        )
+        raise RuntimeError(f"GDN non-spec output length {non_spec_out.shape[0]} != non_spec_token_indx {n_non_spec}")
     out = core_attn_out[:num_actual_tokens]
     out[spec_token_indx] = spec_out
     out[non_spec_token_indx] = non_spec_out
@@ -302,17 +295,13 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
             # Align with spec sub-batch only (mixed prefill+spec has fewer spec decodes
             # than total requests; full-batch tensor fails tiling / wrong state offset).
             spec_num_accepted = num_accepted_tokens[: attn_metadata.num_spec_decodes].to(torch.int64)
-            uniform_spec_only = (
-                attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0
-            )
+            uniform_spec_only = attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0
             if _EXTRA_CTX.capturing and uniform_spec_only:
-                qsl_dev, cidx_dev, nat_dev, qsl_buf, cidx_buf, nat_buf = (
-                    _get_spec_causal_conv1d_device_args(attn_metadata)
+                qsl_dev, cidx_dev, nat_dev, qsl_buf, cidx_buf, nat_buf = _get_spec_causal_conv1d_device_args(
+                    attn_metadata
                 )
                 spec_q_per_seq = int(attn_metadata.spec_state_indices_tensor.size(-1))
-                graph_params = (
-                    get_draft_graph_params() if _EXTRA_CTX.is_draft_model else get_graph_params()
-                )
+                graph_params = get_draft_graph_params() if _EXTRA_CTX.is_draft_model else get_graph_params()
                 _register_310_conv1d_buffer_replay(
                     graph_params,
                     num_actual_tokens,
@@ -349,9 +338,7 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
                     bias=self.conv1d.bias,
                     conv_states=conv_state,
                     query_start_loc=spec_query_start_loc.to(torch.int64),
-                    cache_indices=spec_state_indices_tensor[:, 0][: attn_metadata.num_spec_decodes].to(
-                        torch.int64
-                    ),
+                    cache_indices=spec_state_indices_tensor[:, 0][: attn_metadata.num_spec_decodes].to(torch.int64),
                     initial_state_mode=None,
                     num_accepted_tokens=spec_num_accepted,
                     activation_mode=activation_num,
@@ -504,7 +491,6 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
         maybe_save_kv_layer_to_connector("", [])
 
 
-
 def _get_spec_causal_conv1d_update_host_args_310p(
     attn_metadata: GDNAttentionMetadata,
 ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
@@ -517,6 +503,7 @@ def _get_spec_causal_conv1d_update_host_args_310p(
         to_int64_tuple(attn_metadata.spec_state_indices_tensor[:, 0][:num_spec_decodes]),
         to_int64_tuple(attn_metadata.num_accepted_tokens[:num_spec_decodes]),
     )
+
 
 def update_conv1d_graph_params_310p(
     update_stream,
@@ -594,4 +581,3 @@ def update_conv1d_graph_params_310p(
             _copy_host_tuple_to_int64_buffer(cidx_dev, new_cache_indices)
             if nat_dev is not None:
                 _copy_host_tuple_to_int64_buffer(nat_dev, new_num_accepted)
-

--- a/vllm_ascend/_310p/sample/rejection_sampler.py
+++ b/vllm_ascend/_310p/sample/rejection_sampler.py
@@ -1,0 +1,111 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+from contextlib import contextmanager
+
+import torch
+from vllm.v1.outputs import SamplerOutput
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
+
+import vllm_ascend.sample.rejection_sampler as rejection_sampler_module
+from vllm_ascend._310p.sample.sampler import fill_exponential_310p
+from vllm_ascend.sample.rejection_sampler import (
+    AscendRejectionSampler,
+    sample_recovered_tokens_blockwise_pytorch,
+    sample_recovered_tokens_pytorch,
+)
+
+
+@contextmanager
+def _bind_sample_recovered_tokens(fn):
+    original = rejection_sampler_module.sample_recovered_tokens
+    rejection_sampler_module.sample_recovered_tokens = fn
+    try:
+        yield
+    finally:
+        rejection_sampler_module.sample_recovered_tokens = original
+
+
+class AscendRejectionSampler310(AscendRejectionSampler):
+    """310P rejection sampler: PyTorch recovered-token path with CPU RNG (no Triton)."""
+
+    def forward(
+        self,
+        metadata: SpecDecodeMetadata,
+        draft_probs: torch.Tensor | None,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> SamplerOutput:
+        with _bind_sample_recovered_tokens(self.sample_recovered_tokens):
+            return super().forward(metadata, draft_probs, logits, sampling_metadata)
+
+    def sample_recovered_tokens(
+        self,
+        max_spec_len: int,
+        num_draft_tokens: list[int],
+        cu_num_draft_tokens: torch.Tensor,
+        draft_token_ids: torch.Tensor,
+        draft_probs: torch.Tensor | None,
+        target_probs: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+        device: torch.device,
+        use_block_verify: bool = False,
+        target_indices: torch.Tensor | None = None,
+        global_vocab_size: int | None = None,
+        enable_reduce_sampling: bool = False,
+    ) -> torch.Tensor:
+        batch_size = len(num_draft_tokens)
+        vocab_size = target_probs.shape[-1]
+
+        q = torch.empty(
+            (batch_size, vocab_size),
+            dtype=torch.float32,
+            device=device,
+        )
+        num_draft_tensor = torch.tensor(num_draft_tokens, pin_memory=True).to(device, non_blocking=True)
+        has_draft_mask = num_draft_tensor > 0
+        fill_exponential_310p(q, sampling_metadata.generators, has_draft_mask)
+
+        recovered_token_ids = torch.empty_like(draft_token_ids)
+        if use_block_verify:
+            sample_recovered_tokens_blockwise_pytorch(
+                recovered_token_ids,
+                cu_num_draft_tokens,
+                draft_token_ids,
+                draft_probs,
+                target_probs,
+                q,
+                vocab_size,
+                IS_NGRAM=draft_probs is None,
+                target_indices=target_indices,
+                enable_reduce_sampling=enable_reduce_sampling,
+            )
+        else:
+            sample_recovered_tokens_pytorch(
+                recovered_token_ids,
+                cu_num_draft_tokens,
+                draft_token_ids,
+                draft_probs,
+                target_probs,
+                q,
+                vocab_size,
+                IS_NGRAM=draft_probs is None,
+                target_indices=target_indices,
+                enable_reduce_sampling=enable_reduce_sampling,
+            )
+        return recovered_token_ids

--- a/vllm_ascend/_310p/sample/sampler.py
+++ b/vllm_ascend/_310p/sample/sampler.py
@@ -29,30 +29,61 @@ from vllm_ascend.utils import global_stream, npu_stream_switch
 _CPU_GENERATOR_CACHE_310P: dict[int, tuple[torch.Generator, int]] = {}
 
 
+def _get_cpu_generator_310p(i: int, generator: torch.Generator) -> torch.Generator:
+    cache_entry = _CPU_GENERATOR_CACHE_310P.get(i)
+    if cache_entry is None or cache_entry[1] != id(generator):
+        cpu_generator = torch.Generator(device="cpu")
+        try:
+            # Keep RNG stream consistent with the original generator.
+            cpu_generator.set_state(generator.get_state())
+        except Exception:
+            cpu_generator.manual_seed(generator.initial_seed())
+        cache_entry = (cpu_generator, id(generator))
+        _CPU_GENERATOR_CACHE_310P[i] = cache_entry
+    return cache_entry[0]
+
+
+def _fill_cpu_exponential_310p(
+    q_cpu: torch.Tensor,
+    generators: dict[int, torch.Generator],
+    has_draft_mask: torch.Tensor | None = None,
+) -> None:
+    """Fill a CPU tensor with exponential values for 310P stability."""
+    if len(generators) != q_cpu.shape[0]:
+        q_cpu.exponential_()
+    if not generators:
+        return
+    for i, generator in generators.items():
+        cpu_gen = _get_cpu_generator_310p(i, generator)
+        if has_draft_mask is not None:
+            temp_q = torch.empty_like(q_cpu[i])
+            temp_q.exponential_(generator=cpu_gen)
+            q_cpu[i] = torch.where(has_draft_mask[i], temp_q, q_cpu[i])
+        else:
+            q_cpu[i].exponential_(generator=cpu_gen)
+
+
+def fill_exponential_310p(
+    q: torch.Tensor,
+    generators: dict[int, torch.Generator],
+    has_draft_mask: torch.Tensor | None = None,
+) -> None:
+    """Fill ``q`` with exponential values using CPU RNG for 310P stability."""
+    with npu_stream_switch(global_stream()):
+        q_cpu = q.cpu()
+        _fill_cpu_exponential_310p(q_cpu, generators, has_draft_mask)
+        q.copy_(q_cpu.to(q.device))
+    torch.npu.current_stream().wait_stream(global_stream())
+
+
 def _random_sample_310p(
     probs: torch.Tensor,
     generators: dict[int, torch.Generator],
 ) -> torch.Tensor:
     """310P-specific random sampling with CPU exponential generation for q."""
     with npu_stream_switch(global_stream()):
-        q = torch.empty_like(probs)
-        q = q.cpu()
-        if len(generators) != q.shape[0]:
-            q.exponential_()
-        if generators:
-            for i, generator in generators.items():
-                cache_entry = _CPU_GENERATOR_CACHE_310P.get(i)
-                if cache_entry is None or cache_entry[1] != id(generator):
-                    cpu_generator = torch.Generator(device="cpu")
-                    try:
-                        # Keep RNG stream consistent with the original generator.
-                        cpu_generator.set_state(generator.get_state())
-                    except Exception:
-                        cpu_generator.manual_seed(generator.initial_seed())
-                    cache_entry = (cpu_generator, id(generator))
-                    _CPU_GENERATOR_CACHE_310P[i] = cache_entry
-                cpu_generator, _ = cache_entry
-                q[i].exponential_(generator=cpu_generator)
+        q = torch.empty_like(probs).cpu()
+        _fill_cpu_exponential_310p(q, generators)
         q = q.npu()
     torch.npu.current_stream().wait_stream(global_stream())
     return probs.div_(q).argmax(dim=-1).view(-1)

--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -30,9 +30,9 @@ from vllm.v1.worker.worker_base import CompilationTimes
 from vllm_ascend._310p.compile_warmup import build_piecewise_compile_warmup_sizes
 from vllm_ascend._310p.model_runner_310p import NPUModelRunner310
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.cpu_binding import bind_cpus
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 from vllm_ascend.worker.worker import NPUWorker, init_workspace_manager
-from vllm_ascend.cpu_binding import bind_cpus
 
 _IS_RC_DEVICE: bool | None = None
 

--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -20,13 +20,19 @@ import subprocess
 import psutil
 import torch
 import torch_npu
+from vllm.config import CUDAGraphMode
 from vllm.logger import logger
 from vllm.utils.mem_constants import GiB_bytes
-from vllm.utils.mem_utils import MemorySnapshot, memory_profiling
+from vllm.utils.mem_utils import MemorySnapshot, format_gib, memory_profiling
 from vllm.utils.torch_utils import set_random_seed  # noqa: E402
+from vllm.v1.worker.worker_base import CompilationTimes
 
+from vllm_ascend._310p.compile_warmup import build_piecewise_compile_warmup_sizes
 from vllm_ascend._310p.model_runner_310p import NPUModelRunner310
+from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 from vllm_ascend.worker.worker import NPUWorker, init_workspace_manager
+from vllm_ascend.cpu_binding import bind_cpus
 
 _IS_RC_DEVICE: bool | None = None
 
@@ -140,6 +146,90 @@ class NPUWorker310(NPUWorker):
     def _warm_up_atb(self):
         # 310p device do not support torch_npu._npu_matmul_add_fp32 atb ops
         logger.info_once("Skip warm-up atb ops for 310P device.")
+
+    def compile_or_warm_up_model(self) -> CompilationTimes:
+        warmup_sizes = (self.vllm_config.compilation_config.compile_sizes or []).copy()
+        cg_capture_sizes: list[int] = []
+        if not self.model_config.enforce_eager:
+            if self.vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
+                cg_sizes = self.vllm_config.compilation_config.cudagraph_capture_sizes
+                cg_capture_sizes = [] if cg_sizes is None else cg_sizes
+
+            compile_ranges = self.vllm_config.compilation_config.get_compile_ranges()
+            warmup_sizes = build_piecewise_compile_warmup_sizes(
+                self.vllm_config,
+                warmup_sizes,
+                cg_capture_sizes,
+                compile_ranges,
+            )
+
+        for size in sorted(warmup_sizes, reverse=True):
+            logger.info("Compile and warming up model for size %d", size)
+            self.model_runner._dummy_run(size)
+
+        npugraph_memory_bytes = 0
+        if not self.model_config.enforce_eager:
+            npugraph_memory_bytes = self.model_runner.capture_model()
+
+        if hasattr(self, "npugraph_memory_estimate") and self.npugraph_memory_estimate > 0:
+            GiB = lambda b: round(b / GiB_bytes, 2)
+            diff = abs(npugraph_memory_bytes - self.npugraph_memory_estimate)
+            logger.info(
+                "ACL graph pool memory: %s GiB (actual), %s GiB (estimated), difference: %s GiB (%.1f%%).",
+                GiB(npugraph_memory_bytes),
+                GiB(self.npugraph_memory_estimate),
+                GiB(diff),
+                100 * diff / max(npugraph_memory_bytes, 1),
+            )
+
+        if self.cache_config.kv_cache_memory_bytes is None and hasattr(self, "peak_activation_memory"):
+            redundancy_buffer = 150 * (1 << 20)
+            non_kv_memory = (
+                self.model_runner.model_memory_usage
+                + self.peak_activation_memory
+                + self.non_torch_memory
+                + npugraph_memory_bytes
+            )
+            self.npugraph_memory_bytes = npugraph_memory_bytes
+            suggested_to_requested = int(self.requested_memory) - non_kv_memory - redundancy_buffer
+            suggested_to_gpu_limit = int(self.init_snapshot.free_memory) - non_kv_memory - redundancy_buffer
+            msg = (
+                f"Free memory on device "
+                f"({format_gib(self.init_snapshot.free_memory)}/"
+                f"{format_gib(self.init_snapshot.total_memory)} GiB) on startup. "
+                f"Desired GPU memory utilization is "
+                f"({self.cache_config.gpu_memory_utilization}, "
+                f"{format_gib(self.requested_memory)} GiB). "
+                f"Actual usage: {format_gib(self.model_runner.model_memory_usage)} GiB "
+                f"for weights, {format_gib(self.peak_activation_memory)} GiB for peak "
+                f"activation, {format_gib(self.non_torch_memory)} GiB for non-torch "
+                f"memory, {format_gib(npugraph_memory_bytes)} GiB for NPU graph memory. "
+                f"Replace gpu_memory_utilization with "
+                f"`--kv-cache-memory={suggested_to_requested}` "
+                f"({format_gib(suggested_to_requested)} GiB) to fit into requested "
+                f"memory, or `--kv-cache-memory={suggested_to_gpu_limit}` "
+                f"({format_gib(suggested_to_gpu_limit)} GiB) to fully utilize NPU "
+                f"free memory. Current KV cache memory: "
+                f"{format_gib(self.available_kv_cache_memory_bytes)} GiB."
+            )
+            logger.info(msg)
+
+        if get_ascend_device_type() != AscendDeviceType.A5:
+            self._warm_up_atb()
+        if get_ascend_config().enable_cpu_binding:
+            try:
+                bind_cpus(self.local_rank)
+            except Exception as e:
+                logger.warning("Bind cpus failed in rank%s: %s Skip binding cpu.", self.local_rank, e)
+        set_random_seed(self.model_config.seed)
+        return CompilationTimes(
+            language_model=self.vllm_config.compilation_config.compilation_time,
+            encoder=getattr(
+                self.vllm_config.compilation_config,
+                "encoder_compilation_time",
+                0.0,
+            ),
+        )
 
     def _init_device(self):
         device = torch.device(f"npu:{self.local_rank}")

--- a/vllm_ascend/compilation/graph_fusion_pass_manager.py
+++ b/vllm_ascend/compilation/graph_fusion_pass_manager.py
@@ -66,7 +66,7 @@ class GraphFusionPassManager:
 
             self.passes.append(MatmulAllReduceAddRMSNormPass(config))
 
-        if self.ascend_compilation_config.get("fuse_muls_add", True):
+        if self.ascend_compilation_config.get("fuse_muls_add", True) and not is_310p():
             from .passes.muls_add_pass import MulsAddFusionPass
 
             self.passes.append(MulsAddFusionPass(config))

--- a/vllm_ascend/patch/worker/patch_idex_310.py
+++ b/vllm_ascend/patch/worker/patch_idex_310.py
@@ -1,6 +1,6 @@
 import vllm
-import vllm_ascend.ops.gdn as gdn_ops
 
+import vllm_ascend.ops.gdn as gdn_ops
 from vllm_ascend._310p.ops.fla.gdn_310 import (
     AscendGatedDeltaNetAttention310,
     update_conv1d_graph_params_310p,

--- a/vllm_ascend/patch/worker/patch_idex_310.py
+++ b/vllm_ascend/patch/worker/patch_idex_310.py
@@ -1,6 +1,10 @@
 import vllm
+import vllm_ascend.ops.gdn as gdn_ops
 
-from vllm_ascend._310p.ops.fla.gdn_310 import AscendGatedDeltaNetAttention310
+from vllm_ascend._310p.ops.fla.gdn_310 import (
+    AscendGatedDeltaNetAttention310,
+    update_conv1d_graph_params_310p,
+)
 from vllm_ascend._310p.ops.fla.idex import (
     prepare_chunk_indices_310,
     prepare_chunk_offsets_310,
@@ -10,6 +14,9 @@ from vllm_ascend.utils import vllm_version_is
 vllm.model_executor.layers.fla.ops.index.prepare_chunk_indices = prepare_chunk_indices_310
 
 vllm.model_executor.layers.fla.ops.index.prepare_chunk_offsets = prepare_chunk_offsets_310
+
+# 310P GDN causal conv1d uses buffer_replay; keep shared gdn.py unchanged.
+gdn_ops.update_conv1d_graph_params = update_conv1d_graph_params_310p
 
 # Patch _warmup_prefill_kernels to no-op on 310P: triton.next_power_of_2 does
 # not exist in the triton version used on 310P CI, and NPU does not use these

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -29,6 +29,7 @@ from vllm_ascend.ops.triton.reject_sample import (
 )
 from vllm_ascend.sample.penalties import apply_all_penalties
 from vllm_ascend.sample.sampler import apply_top_k_top_p
+from vllm_ascend.utils import is_310p
 
 
 class AscendRejectionSampler(RejectionSampler):
@@ -789,15 +790,19 @@ def sample_recovered_tokens(
         dtype=torch.float32,
         device=device,
     )
-    q.exponential_()
-
     num_draft_tensor = torch.tensor(num_draft_tokens, pin_memory=True).to(device, non_blocking=True)
     has_draft_mask = num_draft_tensor > 0
+    if is_310p():
+        from vllm_ascend._310p.sample.sampler import fill_exponential_310p
 
-    for i, generator in sampling_metadata.generators.items():
-        temp_q = torch.empty_like(q[i])
-        temp_q.exponential_(generator=generator)
-        q[i] = torch.where(has_draft_mask[i], temp_q, q[i])
+        fill_exponential_310p(q, sampling_metadata.generators, has_draft_mask)
+    else:
+        q.exponential_()
+
+        for i, generator in sampling_metadata.generators.items():
+            temp_q = torch.empty_like(q[i])
+            temp_q.exponential_(generator=generator)
+            q[i] = torch.where(has_draft_mask[i], temp_q, q[i])
 
     recovered_token_ids = torch.empty_like(draft_token_ids)
     if HAS_TRITON:

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -29,7 +29,6 @@ from vllm_ascend.ops.triton.reject_sample import (
 )
 from vllm_ascend.sample.penalties import apply_all_penalties
 from vllm_ascend.sample.sampler import apply_top_k_top_p
-from vllm_ascend.utils import is_310p
 
 
 class AscendRejectionSampler(RejectionSampler):
@@ -790,19 +789,15 @@ def sample_recovered_tokens(
         dtype=torch.float32,
         device=device,
     )
+    q.exponential_()
+
     num_draft_tensor = torch.tensor(num_draft_tokens, pin_memory=True).to(device, non_blocking=True)
     has_draft_mask = num_draft_tensor > 0
-    if is_310p():
-        from vllm_ascend._310p.sample.sampler import fill_exponential_310p
 
-        fill_exponential_310p(q, sampling_metadata.generators, has_draft_mask)
-    else:
-        q.exponential_()
-
-        for i, generator in sampling_metadata.generators.items():
-            temp_q = torch.empty_like(q[i])
-            temp_q.exponential_(generator=generator)
-            q[i] = torch.where(has_draft_mask[i], temp_q, q[i])
+    for i, generator in sampling_metadata.generators.items():
+        temp_q = torch.empty_like(q[i])
+        temp_q.exponential_(generator=generator)
+        q[i] = torch.where(has_draft_mask[i], temp_q, q[i])
 
     recovered_token_ids = torch.empty_like(draft_token_ids)
     if HAS_TRITON:

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1672,7 +1672,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         discard_sampled_tokens_req_indices = discard_request_indices[:num_discarded_requests]
 
         valid_sampled_token_ids_gpu = sampled_token_ids.clone()
-        valid_sampled_token_ids_gpu.index_fill_(0, discard_sampled_tokens_req_indices, -1)
+        if discard_sampled_tokens_req_indices.numel() != 0:
+            valid_sampled_token_ids_gpu.index_fill_(0, discard_sampled_tokens_req_indices, -1)
 
         # Generate a mask for all valid tokens within those requests
         valid_mask = (valid_sampled_token_ids_gpu != -1) & (valid_sampled_token_ids_gpu < gpu_input_batch.vocab_size)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -342,6 +342,8 @@ class NPUModelRunner(GPUModelRunner):
         # use_hybrid_blocks: if hybrid blocks is used.
         self.use_hybrid_blocks: bool = False
         self.need_accepted_tokens: bool = False
+        # Stashed by _copy_valid_sampled_token_count for async spec decode.
+        self.valid_sampled_token_count_gpu: torch.Tensor | None = None
 
         self.is_multimodal_model = self.model_config.is_multimodal_model
         self.block_size = vllm_config.cache_config.block_size
@@ -1618,7 +1620,7 @@ class NPUModelRunner(GPUModelRunner):
 
         if self.use_async_spec_decode:
             # Stash for GPU-side correction in _prepare_inputs.
-            self.valid_sampled_token_count_gpu = valid_sampled_tokens_count # type: ignore[no-redef]
+            self.valid_sampled_token_count_gpu = valid_sampled_tokens_count
         self.input_batch.prev_sampled_token_ids = next_token_ids.unsqueeze(1)
 
     # TODO: Once the PCP features are complete, it will fully inherit the classes from the VLLM community.
@@ -2372,7 +2374,7 @@ class NPUModelRunner(GPUModelRunner):
             assert self.sampling_done_event is not None
             self.sampling_done_event.record()
 
-        self.valid_sampled_token_count_gpu: torch.Tensor | None = None # type: ignore[no-redef]
+        self.valid_sampled_token_count_gpu = None
 
         def propose_draft_token_ids(sampled_token_ids):
             assert spec_decode_common_attn_metadata is not None


### PR DESCRIPTION
### What this PR does / why we need it?
This PR enables Multi-Token Prediction (MTP) speculative decoding on the Ascend 310P architecture. It introduces `AscendKVBlockZeroer310` to zero newly allocated KV blocks directly via tensor writes since Triton is not supported on 310P. It also updates the 310P attention backend to support the `SpecDecoding` state, adapts the model runner for MTP graph capture/replay, and updates the sampler to use CPU RNG for exponential value generation.

Feedback on the changes:
- In `vllm_ascend/_310p/sample/sampler.py`, `has_draft_mask` is a GPU tensor and must be moved to CPU before being used in `_fill_cpu_exponential_310p` to avoid a device mismatch `RuntimeError`.
- Multiple checks in `model_runner_310p.py` and `compile_warmup.py` check for `method == "mtp"`, which will fail to match `"qwen3_5_mtp"`. These checks should be updated to support both methods.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
An end-to-end test `test_qwen3_5_mtp_tp1_eager` was added, along with unit tests for `AscendKVBlockZeroer310` and updates to existing sampler/attention unit tests.

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
