### PR TITLE
[BugFix] Skip NZ conversion for unsupported narrow linear weights

### DIFF
--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -88,6 +88,19 @@ class TestAscendUnquantizedLinearMethod(TestBase):
         self.method.process_weights_after_loading(self.layer)
         mock_format_cast.assert_called_once()
 
+    @patch("vllm_ascend.utils.get_ascend_config")
+    @mock.patch("torch_npu.npu_format_cast")
+    def test_process_weights_after_loading_with_nz2_skips_narrow_weight(self, mock_format_cast, mock_get_config):
+        mock_config = MagicMock()
+        mock_config.weight_nz_mode = 2
+        mock_get_config.return_value = mock_config
+        self.layer.prefix = "expert_gate"
+        self.layer.weight.data = torch.randn(1, 2048, dtype=torch.bfloat16)
+
+        self.method.process_weights_after_loading(self.layer)
+
+        mock_format_cast.assert_not_called()
+
 
 class TestAscendRowParallelLinear(BaseLinearTest):
     @patch("vllm_ascend.ops.linear_op.get_weight_prefetch_method", return_value=MagicMock())

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -388,3 +388,34 @@ class TestUtils(TestBase):
             result = utils.maybe_trans_nz(weight)
             self.assertIs(result, weight)
             assert_nz_cast(weight)
+
+    @mock.patch("torch_npu.npu_format_cast")
+    def test_maybe_trans_nz_linear_weight_skips_unsupported_narrow_shapes(self, mock_npu_format_cast):
+        from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ
+
+        mock_npu_format_cast.side_effect = lambda weight, fmt: weight
+        mock_config = mock.MagicMock()
+        mock_config.weight_nz_mode = 2
+
+        with (
+            mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
+            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+        ):
+            out_features_one = torch.randn(1, 2048, dtype=torch.bfloat16)
+            result = utils.maybe_trans_nz_linear_weight(out_features_one)
+            self.assertIs(result, out_features_one)
+            mock_npu_format_cast.assert_not_called()
+
+            in_features_one = torch.randn(2048, 1, dtype=torch.bfloat16)
+            result = utils.maybe_trans_nz_linear_weight(in_features_one)
+            self.assertIs(result, in_features_one)
+            mock_npu_format_cast.assert_not_called()
+
+            supported_weight = torch.randn(32, 64, dtype=torch.bfloat16)
+            result = utils.maybe_trans_nz_linear_weight(supported_weight)
+            self.assertIs(result, supported_weight)
+            mock_npu_format_cast.assert_called_once()
+            args, kwargs = mock_npu_format_cast.call_args
+            self.assertIs(args[0], supported_weight)
+            self.assertEqual(args[1], ACL_FORMAT_FRACTAL_NZ)
+            self.assertEqual(kwargs, {})

--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -46,6 +46,7 @@ from vllm_ascend.utils import (
     enable_sp,
     get_ascend_device_type,
     maybe_trans_nz,
+    maybe_trans_nz_linear_weight,
 )
 
 
@@ -84,7 +85,7 @@ class AscendUnquantizedLinearMethod(UnquantizedLinearMethod):
         if getattr(layer, "precast_fp32_weight", False):
             layer.weight_fp32 = maybe_trans_nz(layer.weight.data.to(torch.float32))
         if "conv1d" not in layer.prefix:
-            layer.weight.data = maybe_trans_nz(layer.weight.data)
+            layer.weight.data = maybe_trans_nz_linear_weight(layer.weight.data)
 
     def apply(
         self,

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -246,6 +246,12 @@ def maybe_trans_nz(weight: torch.Tensor) -> torch.Tensor:
     return torch_npu.npu_format_cast(weight, ACL_FORMAT_FRACTAL_NZ)
 
 
+def maybe_trans_nz_linear_weight(weight: torch.Tensor) -> torch.Tensor:
+    if weight.ndim == 2 and (weight.shape[0] == 1 or weight.shape[1] == 1):
+        return weight
+    return maybe_trans_nz(weight)
+
+
 def _round_up(x: int, align: int):
     # round up x to align, for example, if align is 16, x will be rounded up to 16, 32, 48, etc.
     # input: 15, 16 -> output: 16


### PR DESCRIPTION
### What this PR does / why we need it?

This PR avoids converting unsupported narrow unquantized linear weights to FRACTAL_NZ.

When `weight_nz_mode=2` or `VLLM_ASCEND_ENABLE_NZ=2` is used, BF16/FP16 linear weights are converted to FRACTAL_NZ as much as possible. However, `aclnnMatmulWeightNz` does not support cases where the second matmul input has `n == 1` or `k == 1`.

For `torch.nn.functional.linear(x, weight)`, a linear weight with shape `(out_features, in_features)` is used as mat2 with shape `[in_features, out_features]`. Therefore, weights with `out_features == 1` or `in_features == 1` can hit the unsupported NZ matmul case.

This happens with Qwen3.5-35B-A3B shared expert gate projection:

- `expert_gate.weight.shape = (1, 2048)`
- linear matmul sees `mat2: [2048, 1]`
- `aclnnMatmulWeightNz` fails with: `Not support mat2 n = 1 or k = 1 when format is FRACTAL_NZ`

This PR adds a linear-weight-specific NZ conversion helper and keeps such narrow linear weights in normal layout, while preserving FRACTAL_NZ conversion for supported linear weight shapes.

Fixes #10014

### Does this PR introduce _any_ user-facing change?

No API or configuration change.

For `weight_nz_mode=2`, unsupported narrow unquantized linear weights now automatically fall back to normal layout instead of being converted to FRACTAL_NZ and failing at runtime.

This is more targeted than setting `VLLM_ASCEND_ENABLE_NZ=1` or `VLLM_ASCEND_ENABLE_NZ=0`, because supported BF16/FP16 linear weights can still use FRACTAL_NZ.

### How was this patch tested?

Added unit test coverage for the new linear weight NZ conversion guard:

- verifies `(1, 2048)` is not converted to FRACTAL_NZ
- verifies `(2048, 1)` is not converted to FRACTAL_NZ
- verifies a supported shape such as `(32, 64)` is still converted when `weight_nz_mode=2`
- verifies `AscendUnquantizedLinearMethod.process_weights_after_loading()` skips FRACTAL_NZ conversion for a narrow `expert_gate`-like weight

Local checks:

- `python -m py_compile vllm_ascend/utils.py vllm_ascend/ops/linear.py tests/ut/test_utils.py tests/ut/ops/test_linear.py`
- `git diff --check`

Manual verification:

- Tested Qwen3.5-35B-A3B in the latest v0.20.2-based environment with `VLLM_ASCEND_ENABLE_NZ=2`
- Without this patch, model loading fails in `_validate_shared_expert_consistency()` at the shared expert `expert_gate` path with `aclnnMatmulWeightNz` and `mat2: [2048, 1]`
- With this patch, the model loads successfully with `VLLM_ASCEND_ENABLE_NZ=2`

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
