### PR TITLE
[CI][BugFix] Checkout PR ref instead of default branch in /e2e workflow

### DIFF
--- a/.github/workflows/pr_e2e_command.yml
+++ b/.github/workflows/pr_e2e_command.yml
@@ -110,6 +110,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.client_payload.pull_request.head.sha }}
           fetch-depth: 1
 
       - name: Read verified vLLM refs


### PR DESCRIPTION
### What this PR does / why we need it?

The Checkout repo step previously checked out the repository's default branch, causing new test files added in a PR to fail validation since they did not exist on the default branch. This prevented PR authors from running /e2e on newly added test cases.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
