### PR TITLE
[Feature] add ascendc ops store_kv_block

### DIFF
--- a/csrc/attention/store_kv_block/CMakeLists.txt
+++ b/csrc/attention/store_kv_block/CMakeLists.txt
@@ -1,0 +1,19 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2025 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+file(GLOB CURRENT_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+if(NOT ENABLE_TEST AND NOT BENCHMARK)
+    list(REMOVE_ITEM CURRENT_DIRS tests)
+endif()
+foreach(SUB_DIR ${CURRENT_DIRS})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SUB_DIR}/CMakeLists.txt")
+        add_subdirectory(${SUB_DIR})
+    endif()
+endforeach()

--- a/csrc/attention/store_kv_block/op_host/CMakeLists.txt
+++ b/csrc/attention/store_kv_block/op_host/CMakeLists.txt
@@ -1,0 +1,67 @@
+# This program is free software, you can redistribute it and/or modify it.
+# Copyright (c) 2025 Huawei Technologies Co., Ltd.
+# This file is a part of the CANN Open Software.
+# Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# ======================================================================================================================
+#add_definitions(-DMAX_BLOCK_NUM_=3)
+# add_ops_compile_options(
+#         OP_NAME StoreKVBlock
+#         OPTIONS --cce-auto-sync=on
+#                 -Wno-deprecated-declarations
+#                 -Werror
+# )
+
+# # -o0
+# # -g
+# # --cce-ignore-always-inline=true
+# target_sources(op_host_aclnn PRIVATE
+#         store_kv_block_def.cpp
+# )
+
+# target_sources(optiling PRIVATE
+#         store_kv_block_tiling.cpp
+#         store_kv_block_common.cpp
+# )
+
+# if (NOT BUILD_OPEN_PROJECT)
+#     target_sources(opmaster_ct PRIVATE
+#         store_kv_block_tiling.cpp
+#     )
+# endif ()
+
+# target_include_directories(optiling PRIVATE
+#         ${CMAKE_CURRENT_SOURCE_DIR}
+# )
+
+# target_sources(opsproto PRIVATE
+#        store_kv_block_infershape.cpp
+# )
+
+# target_link_libraries(optiling
+#     PRIVATE
+# )
+add_op_to_compiled_list()
+
+if (BUILD_OPEN_PROJECT)
+    target_sources(op_host_aclnn PRIVATE
+        store_kv_block_def.cpp
+    )
+endif()
+
+add_ops_compile_options(
+    OP_NAME StoreKVBlock
+    OPTIONS
+        --cce-auto-sync=off
+        -Wno-deprecated-declarations
+        -Werror
+)
+
+if (NOT BUILD_OPS_RTY_KERNEL)
+    add_modules_sources(OPTYPE store_kv_block ACLNNTYPE aclnn)
+    target_include_directories(${OPHOST_NAME}_tiling_obj PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()

--- a/csrc/attention/store_kv_block/op_host/store_kv_block_def.cpp
+++ b/csrc/attention/store_kv_block/op_host/store_kv_block_def.cpp
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file store_kv_block_def.cpp
+ * \brief Operator definition for StoreKVBlock
+ */
+#include "register/op_def_registry.h"
+
+namespace ops {
+class StoreKVBlock : public OpDef {
+ public:
+  explicit StoreKVBlock(const char* name) : OpDef(name) {
+    this->Input("keyIn")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_INT8, ge::DT_FLOAT16, ge::DT_BF16})
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Input("keyCacheIn")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_INT8, ge::DT_FLOAT16, ge::DT_BF16})
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Input("groupLen")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_INT32 , ge::DT_INT32 , ge::DT_INT32 })
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Input("groupKeyIdx")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_INT32 , ge::DT_INT32 , ge::DT_INT32 })
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Input("groupKeyCacheIdx")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_INT32 , ge::DT_INT32 , ge::DT_INT32 })
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Attr("blockSize").Int();
+    this->AICore().AddConfig("ascend910b");
+    this->AICore().AddConfig("ascend910_93");
+  }
+};
+
+OP_ADD(StoreKVBlock);
+}  // namespace ops

--- a/csrc/attention/store_kv_block/op_host/store_kv_block_infershape.cpp
+++ b/csrc/attention/store_kv_block/op_host/store_kv_block_infershape.cpp
@@ -1,0 +1,40 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file store_kv_block_infershape.cpp
+ * \brief InferShape implementation for StoreKVBlock
+ */
+#include <graph/utils/type_utils.h>
+#include <register/op_impl_registry.h>
+
+#include "error/ops_error.h"
+
+static constexpr int IDX_0 = 0;
+static constexpr int IDX_1 = 1;
+static constexpr int IDX_2 = 2;
+
+using namespace ge;
+// using namespace Ops::Base;
+
+namespace ops {
+
+static ge::graphStatus InferShape4StoreKVBlock(gert::InferShapeContext* context)
+{
+    return GRAPH_SUCCESS;
+}
+
+static graphStatus InferDataType4StoreKVBlock(gert::InferDataTypeContext* context)
+{
+    return GRAPH_SUCCESS;
+}
+
+IMPL_OP_INFERSHAPE(StoreKVBlock).InferShape(InferShape4StoreKVBlock).InferDataType(InferDataType4StoreKVBlock);
+} // namespace ops

--- a/csrc/attention/store_kv_block/op_host/store_kv_block_tiling.cpp
+++ b/csrc/attention/store_kv_block/op_host/store_kv_block_tiling.cpp
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "store_kv_block_tiling.h"
+#include "register/op_def_registry.h"
+#include "tiling/platform/platform_ascendc.h"
+#include "tiling_base/error_log.h"
+
+namespace optiling {
+
+constexpr uint32_t DIM_0 = 0;
+constexpr uint32_t DIM_1 = 1;
+constexpr uint32_t DIM_2 = 2;
+constexpr int32_t MAX_UB_USE_SIZE = 180 * 1024;
+
+struct StoreKVBlockParams {
+    uint32_t numTokens{0};
+    uint32_t numCache{0};
+    uint32_t numHeads{1};
+    uint32_t headSize[5]{1, 1, 1, 1, 1};
+    uint32_t blockTableSize{0};
+    uint32_t typeByte{0};
+    uint32_t tokenSize{1};
+    uint32_t tilingKey{0};
+    uint64_t workspaceSize{0};
+    uint64_t groupInfoLen{0};
+    uint32_t corepernum{0};
+    uint32_t coretail{0};
+    uint64_t sysWorkspaceSize{0};
+    uint32_t coreNum{0};
+};
+
+static ge::graphStatus DoCommonTiling(gert::TilingContext* context, StoreKVBlockParams& params) {
+    auto kShape = context->GetInputShape(DIM_0);
+    auto kDimNum = kShape->GetStorageShape().GetDimNum();
+    if (kDimNum < 2 || kDimNum > 7) {
+        OP_LOGE(context->GetNodeName(), "StoreKVBlock Input kDimNum dim < 2 || kDimNum>7");
+        return ge::GRAPH_FAILED;
+    }
+
+    for (int i = 0; i < kDimNum; i++) {
+        if (i == 0) params.numTokens = static_cast<uint32_t>(kShape->GetStorageShape().GetDim(i));
+        else if (i == 1) params.numHeads = static_cast<uint32_t>(kShape->GetStorageShape().GetDim(i));
+        else if (static_cast<uint32_t>(kShape->GetStorageShape().GetDim(i)) != 0)
+            params.headSize[i - 2] = static_cast<uint32_t>(kShape->GetStorageShape().GetDim(i));
+    }
+
+    auto kCacheShape = context->GetInputShape(DIM_1);
+    auto kCacheDimNum = kCacheShape->GetStorageShape().GetDimNum();
+    if (kCacheDimNum < 2 || kCacheDimNum > 7) {
+        OP_LOGE(context->GetNodeName(), "StoreKVBlock Input kCacheDimNum < 2");
+        return ge::GRAPH_FAILED;
+    }
+    params.numCache = kCacheShape->GetStorageShape().GetDim(0) * kCacheShape->GetStorageShape().GetDim(1);
+
+    const int64_t* blockSizePtr = context->GetAttrs()->GetInt(0);
+    uint32_t blockSize = static_cast<uint32_t>(*blockSizePtr);
+    params.tokenSize = params.numHeads * params.headSize[0] * params.headSize[1] * params.headSize[2] * params.headSize[3] * params.headSize[4];
+    params.blockTableSize = blockSize;
+
+    uint32_t typeByte = 0;
+    auto xDataType = context->GetInputDesc(DIM_0)->GetDataType();
+    if (xDataType == ge::DataType::DT_INT8) {
+        typeByte = sizeof(int8_t);
+        params.tilingKey = 1;
+    } else if (xDataType == ge::DataType::DT_FLOAT16 || xDataType == ge::DataType::DT_BF16) {
+        typeByte = sizeof(uint16_t);
+        params.tilingKey = 2;
+    } else if (xDataType == ge::DataType::DT_INT32 || xDataType == ge::DataType::DT_UINT32) {
+        typeByte = sizeof(uint32_t);
+        params.tilingKey = 4;
+    } else {
+        OP_LOGE(context->GetNodeName(), "Unsupported type.");
+        return ge::GRAPH_FAILED;
+    }
+
+    params.typeByte = typeByte;
+
+    auto groupInfoShape = context->GetInputShape(DIM_2);
+    params.groupInfoLen = static_cast<uint32_t>(groupInfoShape->GetStorageShape().GetDim(0));
+    params.corepernum = params.groupInfoLen / params.coreNum;
+    params.coretail = params.groupInfoLen % params.coreNum;
+
+    uint32_t pageBlockEleSize = params.blockTableSize * params.tokenSize;
+    if (pageBlockEleSize > MAX_UB_USE_SIZE) {
+        OP_LOGE(context->GetNodeName(), "pageBlockEleSize > MaxUBSize");
+        return ge::GRAPH_FAILED;
+    }
+    return ge::GRAPH_SUCCESS;
+}
+
+static ge::graphStatus StoreKVBlockTilingFunc(gert::TilingContext* context) {
+    StoreKVBlockParams params;
+
+    auto platformInfo = context->GetPlatformInfo();
+    OP_CHECK_NULL_WITH_CONTEXT(context, platformInfo);
+    auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfo);
+    params.coreNum = ascendcPlatform.GetCoreNum();
+    if (params.coreNum == 0) {
+        OP_LOGE(context->GetNodeName(), "Failed to get core num.");
+        return ge::GRAPH_FAILED;
+    }
+    params.sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
+
+    auto ret = DoCommonTiling(context, params);
+    if (ret != ge::GRAPH_SUCCESS) {
+        return ret;
+    }
+
+    StoreKVBlockTilingData tilingData;
+    if (params.blockTableSize > 0) tilingData.set_blockTableSize(params.blockTableSize);
+    if (params.typeByte > 0) tilingData.set_typeByte(params.typeByte);
+    if (params.tokenSize > 0) tilingData.set_tokenSize(params.tokenSize);
+    if (params.corepernum > 0 || params.coretail != 0) tilingData.set_corePerNum(params.corepernum);
+    if (params.coretail < 48) tilingData.set_coreTail(params.coretail);
+    if (params.numTokens > 0) tilingData.set_numTokens(params.numTokens);
+    if (params.numCache > 0) tilingData.set_numCache(params.numCache);
+    if (params.groupInfoLen > 0) tilingData.set_groupInfoLen(params.groupInfoLen);
+
+    size_t* workspaceSize = context->GetWorkspaceSizes(1);
+    *workspaceSize = params.workspaceSize + params.sysWorkspaceSize;
+    context->SetTilingKey(params.tilingKey);
+    if (params.coreNum > 0) context->SetBlockDim(params.coreNum);
+
+    tilingData.SaveToBuffer(context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
+    context->GetRawTilingData()->SetDataSize(tilingData.GetDataSize());
+
+    return ge::GRAPH_SUCCESS;
+}
+
+static ge::graphStatus TilingParseForStoreKVBlock(gert::TilingParseContext* context) {
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(StoreKVBlock)
+    .Tiling(StoreKVBlockTilingFunc)
+    .TilingParse<StoreKVBlockCompileInfo>(TilingParseForStoreKVBlock);
+
+} // namespace optiling

--- a/csrc/attention/store_kv_block/op_host/store_kv_block_tiling.h
+++ b/csrc/attention/store_kv_block/op_host/store_kv_block_tiling.h
@@ -1,0 +1,23 @@
+#include "register/tilingdata_base.h"
+
+namespace optiling {
+BEGIN_TILING_DATA_DEF(StoreKVBlockTilingData)
+    TILING_DATA_FIELD_DEF(uint32_t, blockTableSize);
+    TILING_DATA_FIELD_DEF(uint32_t, typeByte);
+    TILING_DATA_FIELD_DEF(uint32_t, tokenSize);
+    TILING_DATA_FIELD_DEF(uint32_t, corePerNum);
+    TILING_DATA_FIELD_DEF(uint32_t, coreTail);
+    TILING_DATA_FIELD_DEF(uint32_t, numTokens);
+    TILING_DATA_FIELD_DEF(uint32_t, numCache);
+    TILING_DATA_FIELD_DEF(uint32_t, groupInfoLen);
+END_TILING_DATA_DEF;
+
+REGISTER_TILING_DATA_CLASS(StoreKVBlock, StoreKVBlockTilingData)
+
+struct StoreKVBlockCompileInfo {
+    uint32_t coreNum;
+    uint64_t ubSizePlatForm;
+    uint32_t sysWorkspaceSize;
+};
+
+} // namespace optiling

--- a/csrc/attention/store_kv_block/op_kernel/store_kv_block.cpp
+++ b/csrc/attention/store_kv_block/op_kernel/store_kv_block.cpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file store_kv_block.cpp
+ * \brief Kernel entry for StoreKVBlock operator
+ */
+#include "store_kv_block.h"
+
+extern "C" __global__ __aicore__ void store_kv_block(
+    GM_ADDR keyIn, GM_ADDR keyCacheIn, GM_ADDR groupLen, GM_ADDR groupKeyIdx, GM_ADDR groupKeyCacheIdx, GM_ADDR workspace, GM_ADDR tiling)
+{
+    AscendC::TPipe pipe;
+    REGISTER_TILING_DEFAULT(StoreKVBlock::StoreKVBlockTilingData);
+    GET_TILING_DATA(tilingData, tiling);
+
+    if (TILING_KEY_IS(1)) {
+        StoreKVBlock::StoreKVBlockBase<uint8_t> op;
+        op.Init( &pipe, &tilingData);
+        op.Process(keyIn,keyCacheIn, groupLen, groupKeyIdx, groupKeyCacheIdx);
+    } else if (TILING_KEY_IS(2)) {
+        StoreKVBlock::StoreKVBlockBase<half> op;
+        op.Init( &pipe, &tilingData);
+        op.Process(keyIn,keyCacheIn, groupLen, groupKeyIdx, groupKeyCacheIdx);
+    } else if (TILING_KEY_IS(4)) {
+        StoreKVBlock::StoreKVBlockBase<int32_t> op;
+        op.Init( &pipe, &tilingData);
+        op.Process(keyIn,keyCacheIn, groupLen, groupKeyIdx, groupKeyCacheIdx);
+    }
+}

--- a/csrc/attention/store_kv_block/op_kernel/store_kv_block.h
+++ b/csrc/attention/store_kv_block/op_kernel/store_kv_block.h
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file store_kv_block.h
+ * \brief StoreKVBlock kernel operator
+ */
+
+#ifndef ASCEND_STORE_KV_BLOCK_H
+#define ASCEND_STORE_KV_BLOCK_H
+
+#include "kernel_operator.h"
+
+namespace StoreKVBlock {
+using namespace AscendC;
+
+
+#ifndef STORE_KV_BLOCK_TILING_DATA_H_
+#define STORE_KV_BLOCK_TILING_DATA_H_
+struct StoreKVBlockTilingData{
+    uint32_t blockTableSize;    
+    uint32_t typeByte;
+    uint32_t tokenSize;
+    uint32_t corePerNum;
+    uint32_t coreTail;
+    uint32_t numTokens;
+    uint32_t numCache;
+    uint32_t groupInfoLen;
+
+};
+#endif
+template <typename T>
+class StoreKVBlockBase {
+public:
+
+    uint32_t tokenSize = 0;
+    uint32_t tokenByteSize = 0;
+    uint32_t blockTableSize = 0;
+    uint32_t typeByte = 0;
+    uint32_t numTokens = 0;
+    uint32_t numCache = 0;
+    uint32_t groupInfoLen = 0;
+
+    uint32_t coreId = 0;
+    uint32_t coreTail = 0;
+    uint32_t corePerNum = 0;
+    uint32_t blockNum = 0;
+    AscendC::TPipe* pipeThis;
+    AscendC::LocalTensor<T> tokenLocal;
+    AscendC::GlobalTensor<T> keyInputGt;
+    AscendC::GlobalTensor<T> keyCacheInputGt;
+    AscendC::GlobalTensor<uint32_t> groupLenGt;
+    AscendC::GlobalTensor<uint32_t> groupKeyIdxGt;
+    AscendC::GlobalTensor<uint32_t> groupKeyCacheIdxGt;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> tokenBuf;
+    __aicore__ inline StoreKVBlockBase() {}
+
+    __aicore__ inline uint32_t RoundUp(uint32_t x, uint32_t y = 16)
+    {
+        return y == 0 ? 0 : (x + y - 1) / y * y;
+    }
+
+    __aicore__ inline void Init( AscendC::TPipe *pipe, StoreKVBlockTilingData *tilingData)
+    {
+        pipeThis = pipe;
+        typeByte = tilingData->typeByte;
+        tokenSize = tilingData->tokenSize;
+        tokenByteSize = tokenSize*typeByte;
+        blockTableSize = tilingData->blockTableSize;
+        numTokens = tilingData->numTokens;
+        numCache = tilingData->numCache;
+        groupInfoLen = tilingData->groupInfoLen;
+
+
+        coreId = AscendC::GetBlockIdx();
+        coreTail = tilingData->coreTail;
+        blockNum = AscendC::GetBlockNum();
+        if (coreId < coreTail){
+            // Not all cores have corePerNum+1 items; only coreTail cores get one extra.
+            // If corePerNum is 0, cores beyond coreTail have no work and will not access any address.
+            corePerNum = tilingData->corePerNum+1;
+        }else {
+            corePerNum = tilingData->corePerNum;
+        }
+    }
+    __aicore__ inline void Process(GM_ADDR keyIn, GM_ADDR keyCacheIn, GM_ADDR groupLen, GM_ADDR groupKeyIdx, GM_ADDR groupKeyCacheIdx)
+    {
+        
+        keyInputGt.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(keyIn));
+        keyCacheInputGt.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(keyCacheIn));
+        groupLenGt.SetGlobalBuffer(reinterpret_cast<__gm__ uint32_t*>(groupLen));
+        groupKeyIdxGt.SetGlobalBuffer(reinterpret_cast<__gm__ uint32_t*>(groupKeyIdx));
+        groupKeyCacheIdxGt.SetGlobalBuffer(reinterpret_cast<__gm__ uint32_t*>(groupKeyCacheIdx));
+
+        pipeThis->InitBuffer(tokenBuf,  blockTableSize*tokenByteSize);
+        tokenLocal = tokenBuf.Get<T>();
+
+        AscendC::DataCopyExtParams copyParams{1, 0,  0, 0, 0}; // todo: full block length
+        AscendC::DataCopyPadExtParams<T> padParams{false, 0, 0, 0};
+        for (uint32_t i = 0; i < corePerNum; i++) {
+            uint32_t idx = (coreId+i*blockNum);
+         
+            // if( groupLenGt.GetValue(idx)<= 0 || groupKeyIdxGt.GetValue(idx)<0 || groupKeyCacheIdxGt.GetValue(idx)<0){
+            //     continue;
+            // }
+           
+            copyParams.blockLen = groupLenGt.GetValue(idx)*tokenByteSize; // in bytes
+            DataCopyPad(tokenLocal, keyInputGt[ groupKeyIdxGt.GetValue(idx)*tokenSize], copyParams, padParams); // note: offset order
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(EVENT_ID1);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(EVENT_ID1);
+            DataCopyPad(keyCacheInputGt[groupKeyCacheIdxGt.GetValue(idx)*tokenSize], tokenLocal, copyParams);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
+        }
+
+    }
+
+};
+}
+
+#endif

--- a/csrc/attention/store_kv_block/store_kv_block_torch_adpt.h
+++ b/csrc/attention/store_kv_block/store_kv_block_torch_adpt.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//  #include "../aclnn_torch_adapter/op_api_common.h"
+
+#ifndef STORE_KV_BLOCK_TORCH_ADPT_H
+#define STORE_KV_BLOCK_TORCH_ADPT_H
+#include <climits>  
+namespace vllm_ascend {
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> store_kv_block_pre(
+    const at::Tensor &slot_mapping_npu,
+    at::IntArrayRef slot_mapping_list,
+    int64_t block_size)
+{
+
+    int64_t slot_mapping_len =  slot_mapping_list.size();
+
+    std::vector<int32_t> length(16, 0);
+    std::vector<int32_t> key_idx(16, 0);
+    std::vector<int32_t> key_cache_idx(16, 0);
+    int32_t idx_slotmap = 0;
+    int32_t idx_groups = 0;
+
+    while (idx_slotmap < slot_mapping_len) {
+
+        int32_t current_idx = slot_mapping_list[idx_slotmap];
+        if(current_idx <0){
+            idx_slotmap++;
+            continue;
+        }
+
+        int32_t block_id = current_idx / block_size; 
+        int32_t y= current_idx % block_size;
+
+        key_idx[idx_groups] = idx_slotmap;
+        key_cache_idx[idx_groups] = current_idx;    
+
+        int32_t j = idx_slotmap;
+
+        if(j+1 < slot_mapping_len &&slot_mapping_list[j+1]!=slot_mapping_list[j]+1 ) {
+            j++;
+
+        }else{
+            int32_t idx_stride = std::min(block_size-y,slot_mapping_len-idx_slotmap)-1;
+            int32_t expected_last =  current_idx + idx_stride;
+            int32_t expected_last_idx = idx_slotmap + (expected_last-current_idx);
+
+            if (expected_last == slot_mapping_list[expected_last_idx]){
+                j = expected_last_idx+1;
+            }else{
+
+                while(j+1 < slot_mapping_len && slot_mapping_list[j] / block_size == block_id && slot_mapping_list[j+1] ==slot_mapping_list[j]+1) {
+                    j++;
+                }
+            }
+        }
+
+        length[idx_groups] = (j - idx_slotmap);
+        idx_slotmap = j;
+        idx_groups++;
+
+        if(idx_groups>=length.capacity()){
+            int32_t new_capacity = length.capacity() * 2;
+            length.reserve(new_capacity);
+            key_idx.reserve(new_capacity);
+            key_cache_idx.reserve(new_capacity);
+
+            for (int32_t k = idx_groups; k < new_capacity; ++k){
+                length.emplace_back(0);
+                key_idx.emplace_back(0);
+                key_cache_idx.emplace_back(0);
+            } 
+        }
+    }
+
+    at::Tensor group_len = at::empty({idx_groups},
+        at::TensorOptions(slot_mapping_npu.options().device()).dtype(torch::kInt32)
+        );
+    void* group_len_addr = group_len.data_ptr();
+
+    at::Tensor group_key_idx = at::empty({idx_groups},
+        at::TensorOptions(slot_mapping_npu.options().device()).dtype(torch::kInt32)
+        );
+    void* group_key_idx_addr = group_key_idx.data_ptr();
+    
+    at::Tensor group_key_cache_idx = at::empty({idx_groups},
+        at::TensorOptions(slot_mapping_npu.options().device()).dtype(torch::kInt32)
+        );
+    void* group_key_cache_idx_addr = group_key_cache_idx.data_ptr();
+
+    uint32_t device_size=idx_groups*sizeof(length[0]);
+    aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
+    aclrtMemcpyKind memcpy_type=ACL_MEMCPY_HOST_TO_DEVICE;
+    aclrtMemcpyAsync(group_len_addr, device_size, &length[0], device_size, ACL_MEMCPY_HOST_TO_DEVICE, stream); 
+    aclrtMemcpyAsync(group_key_idx_addr, device_size, &key_idx[0], device_size, ACL_MEMCPY_HOST_TO_DEVICE, stream);  
+    aclrtMemcpyAsync(group_key_cache_idx_addr, device_size, &key_cache_idx[0], device_size, ACL_MEMCPY_HOST_TO_DEVICE, stream);   
+
+    return std::tuple<at::Tensor, at::Tensor, at::Tensor>(group_len, group_key_idx, group_key_cache_idx);
+
+}
+
+void store_kv_block(
+    const at::Tensor &key_in,
+    const at::Tensor &key_cache_in,
+    const at::Tensor &group_len,
+    const at::Tensor &group_key_idx,
+    const at::Tensor &group_key_cache_idx,
+    int64_t block_size)
+{
+
+    EXEC_NPU_CMD(aclnnStoreKVBlock, key_in, key_cache_in,group_len, group_key_idx, group_key_cache_idx, block_size);
+    
+} 
+
+}
+#endif

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -120,6 +120,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
         "ngram_spec_decode"
         "chunk_fwd_o"
         "chunk_gated_delta_rule_fwd_h"
+        "store_kv_block"
     )
 
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
@@ -183,6 +184,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
         "ngram_spec_decode"
         "chunk_fwd_o"
         "chunk_gated_delta_rule_fwd_h"
+        "store_kv_block"
     )
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
     SOC_ARG="ascend910_93"

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -49,6 +49,7 @@
 #include "moe/causal_conv1d_v310/causal_conv1d_310_torch_adpt.h"
 #include "attention/recurrent_gated_delta_rule/recurrent_gated_delta_rule_torch_adpt.h"
 #include "attention/recurrent_gated_delta_rule_v310/recurrent_gated_delta_rule_310_torch_adpt.h"
+#include "attention/store_kv_block/store_kv_block_torch_adpt.h"
 #include "attention/fused_gdn_gating/fused_gdn_gating_torch_adpt.h"
 #include <c10/core/Device.h>
 #include <c10/core/Scalar.h>
@@ -2798,6 +2799,17 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
     );
     ops.impl("chunk_fwd_o", torch::kPrivateUse1, &vllm_ascend::chunk_fwd_o);
 
+    //store_kv_block
+    ops.def(
+        "store_kv_block_pre(Tensor slot_mapping_npu, int[2] slot_mapping_list =[], int block_size=0)"
+         "-> (Tensor group_len ,Tensor group_key_idx, Tensor group_key_cache_idx)"
+    );
+    ops.impl("store_kv_block_pre", torch::kPrivateUse1, &vllm_ascend::store_kv_block_pre);
+
+    ops.def(
+        "store_kv_block(Tensor key_in, Tensor key_cache_in, Tensor group_len, Tensor group_key_idx,Tensor group_key_cache_idx, int block_size=0) -> ()"
+    );
+    ops.impl("store_kv_block", torch::kPrivateUse1, &vllm_ascend::store_kv_block);
     // Fused GDN gating.
     ops.def(
         "npu_fused_gdn_gating(Tensor A_log, "

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -1601,6 +1601,31 @@ at::Tensor chunk_fwd_o_meta(
     return o;
 }
 
+std::tuple<at::Tensor, at::Tensor, at::Tensor> store_kv_block_pre(
+    const at::Tensor &slot_mapping_npu,
+    at::IntArrayRef slot_mapping_list,
+    int64_t block_size)
+{
+    auto s_size = slot_mapping_npu.sizes();
+    at::Tensor group_len = at::empty({s_size[0]}, slot_mapping_npu.options());
+    at::Tensor group_key_idx = at::empty({s_size[0]}, slot_mapping_npu.options());
+    at::Tensor group_key_cache_idx = at::empty({s_size[0]}, slot_mapping_npu.options());
+    return std::tuple<at::Tensor, at::Tensor, at::Tensor>(group_len, group_key_idx, group_key_cache_idx);
+
+}
+
+void store_kv_block(
+    const at::Tensor &key_in,
+    const at::Tensor &key_cache_in,
+    const at::Tensor &group_len,
+    const at::Tensor &group_key_idx,
+    const at::Tensor &group_key_cache_idx,
+    int64_t block_size)
+{
+    return;
+
+} 
+
 } // namespace meta
 } // namespace vllm_ascend
 
@@ -1709,6 +1734,9 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     ops.impl("chunk_gated_delta_rule_fwd_h", &vllm_ascend::meta::chunk_gated_delta_rule_fwd_h_meta);
     // chunk_fwd_o
     ops.impl("chunk_fwd_o", &vllm_ascend::meta::chunk_fwd_o_meta);
+     // store_kv_block
+    ops.impl("store_kv_block_pre", &vllm_ascend::meta::store_kv_block_pre);
+    ops.impl("store_kv_block", &vllm_ascend::meta::store_kv_block);
     // npu_fused_gdn_gating
     ops.impl("npu_fused_gdn_gating", &vllm_ascend::meta::npu_fused_gdn_gating_meta);
 }

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -86,6 +86,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `enable_kv_nz`                      | bool | `False` | Whether to enable KV cache NZ layout. This option only takes effects on models using MLA (e.g., DeepSeek).                                      |
 | `layer_sharding`                    | dict | `{}`    | Configuration options for Layer Sharding Linear. Layer Sharding can only be enabled in PD-disaggregated's P node. |
 | `enable_sparse_c8`                  | bool | `False` | Whether to enable KV cache C8 in DSA models (e.g., DeepSeekV3.2 and GLM5). Not supported on A5 devices now |
+| `c8_enable_reshape_optim`           | bool | `False` | Whether to enable StoreKVBlock operator achieves acceleration under the C8 feature (this means that enable_sparse_c8 needs to be enabled). In the PD separation scenario, only the P node is enabled. |
 | `enable_mc2_hierarchy_comm`         | bool | `False` | Enable dispatch/combine op inter-node communication by ROCE. |
 | `profiling_chunk_config`            | dict | `{}`    | Configuration options for dynamic chunked pipeline parallel. See [Dynamic Chunked Pipeline Parallel](../feature_guide/dynamic_chunk_pipeline_parallel.md) for details. |
 | `enable_balance_scheduling`         | bool | `False` | Whether to enable balance scheduling. Can also be configured via `VLLM_ASCEND_BALANCE_SCHEDULING` environment variable (deprecated). |

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_store_kv_block.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_store_kv_block.py
@@ -1,0 +1,152 @@
+import gc
+import time
+
+import numpy as np
+import pytest
+import torch
+import torch_npu
+
+from vllm_ascend.utils import enable_custom_op
+
+torch.set_printoptions(threshold=np.inf)
+
+enable_custom_op()
+
+
+def cal_slot(key, key_cache, slot_mapping, block_size):
+    key_expect = key_cache.clone()
+    for i, slot in enumerate(slot_mapping):
+        if slot < 0:
+            continue
+        token_key = key[i]
+        block_index = slot // block_size
+        block_offset = slot % block_size
+        key_expect[block_index][block_offset] = token_key
+    return key_expect.npu()
+
+
+def cal_scatternd(key, key_cache, slot_mapping, block_size):
+    key_expect = key_cache.clone()
+    for i, slot in enumerate(slot_mapping):
+        if slot < 0:
+            continue
+        token_key = key[i]
+        key_expect[slot] = token_key
+
+    return key_expect.npu()
+
+
+# slot_mapping[].shape=torch.Size([4])
+@pytest.mark.parametrize("num_tokens", [16])  # 6398
+@pytest.mark.parametrize("num_head", [1])  # 512
+@pytest.mark.parametrize("block_size", [128])  # 128
+@pytest.mark.parametrize("num_blocks", [1773])  # 1599
+@pytest.mark.parametrize("count", [1])
+def test_siso(num_tokens, num_head, block_size, num_blocks, count):
+    head_size_k = 1
+    key = torch.rand((num_tokens, num_head, head_size_k), dtype=torch.float16).npu()
+    # key = torch.randint(low=0,high=128,size=(num_tokens,head_size_k), dtype=torch.int8 )
+    key_cache = torch.rand((num_blocks, block_size, num_head, head_size_k), dtype=torch.float16).npu()
+    # key_cache = torch.randint(low=0,high=128,size=(num_blocks, block_size, num_head,head_size_k), dtype=torch.int8 )
+
+    slot_list = []
+    for i in range(0, num_tokens):
+        slot_list.append(2 + i)
+    assert num_tokens == len(slot_list)
+    slot_list_np = np.array(slot_list)
+    slot_mapping_npu = torch.from_numpy(slot_list_np).to(torch.int32).npu()
+
+    key_expect = cal_slot(key, key_cache, slot_mapping_npu, block_size)
+
+    warm_up = 0
+    for _ in range(warm_up):
+        torch_npu._npu_reshape_and_cache_siso(key, key_cache, slot_mapping_npu)
+    N = 101
+
+    for _ in range(N):
+        torch_npu._npu_reshape_and_cache_siso(key, key_cache, slot_mapping_npu)
+
+    torch.testing.assert_close(key_expect, key_cache, atol=0.001, rtol=0.1)
+
+
+@pytest.mark.parametrize("num_tokens", [16])  # 6398
+@pytest.mark.parametrize("num_head", [1])  # 512
+@pytest.mark.parametrize("block_size", [128])  # 128
+@pytest.mark.parametrize("num_blocks", [1773])  # 1599
+@pytest.mark.parametrize("count", [1])
+def test_scatter(num_tokens, num_head, block_size, num_blocks, count):
+    head_size_k = 64
+    key = torch.randint(low=0, high=128, size=(num_tokens, num_head, head_size_k), dtype=torch.int8).npu()
+    # key = torch.rand((num_tokens, num_head,head_size_k), dtype=torch.float16).npu()
+
+    key_cache = torch.randint(
+        low=0, high=128, size=(num_blocks * block_size, num_head, head_size_k), dtype=torch.int8
+    ).npu()
+    # key_cache = torch.rand((num_blocks* block_size, num_head,head_size_k), dtype=torch.float16).npu()
+    slot_list = []
+    for i in range(0, num_tokens):
+        slot_list.append([2 + i])
+        # slot_list.append(6+i)
+    assert num_tokens == len(slot_list)
+    slot_list_np = np.array(slot_list)
+    slot_mapping_npu = torch.from_numpy(slot_list_np).to(torch.int32).npu()
+
+    key_expect = cal_scatternd(key, key_cache, slot_mapping_npu, block_size)
+    N = 101
+    for i in range(N):
+        torch_npu.npu_scatter_nd_update_(key_cache, slot_mapping_npu, key)
+    torch.testing.assert_close(key_expect, key_cache, atol=0.001, rtol=0.1)
+
+
+@pytest.mark.parametrize("num_tokens", [16])  # 6398
+@pytest.mark.parametrize("num_head", [1])  # 512
+@pytest.mark.parametrize("block_size", [128])  # 128
+@pytest.mark.parametrize("num_blocks", [1773])  # 1599
+@pytest.mark.parametrize("count", [1])
+def test_myops(num_tokens, num_head, block_size, num_blocks, count):
+    head_size_k = 64
+    # key_cache = torch.rand((num_blocks, block_size, num_head,head_size_k), dtype=torch.float16)
+    key_cache = torch.randint(low=0, high=128, size=(num_blocks, block_size, num_head, head_size_k), dtype=torch.int8)
+    key_cache_npu = key_cache.npu()
+
+    slot_list = []
+    for i in range(0, num_tokens):
+        slot_list.append(2 + i)
+
+    slot_list_np = np.array(slot_list)
+    slot_mapping_npu = torch.from_numpy(slot_list_np).to(torch.int32).npu()
+    # slot_mapping_cpu = slot_mapping_npu.to("cpu",non_blocking=True)
+    # num_draft_tensor = slot_mapping_npu.to("cpu", non_blocking=True)
+    slot_mapping_cpu = torch.empty_like(slot_mapping_npu, device="cpu").pin_memory()
+    slot_mapping_cpu.copy_(slot_mapping_npu, non_blocking=True)
+
+    # key = torch.rand((num_tokens, num_head,head_size_k), dtype=torch.float16)
+    key = torch.randint(low=0, high=128, size=(num_tokens, head_size_k), dtype=torch.int8)
+    key_npu = key.npu()
+    key_expect = cal_slot(key_npu, key_cache_npu, slot_list_np, block_size)
+
+    time.sleep(0.1)
+
+    slot_mapping_list = slot_mapping_cpu.tolist()
+    warm_up = 0
+    for _ in range(warm_up):
+        group_len, group_key_idx, group_key_cache_idx = torch.ops._C_ascend.store_kv_block_pre(
+            slot_mapping_npu, slot_mapping_list, block_size
+        )
+        torch.ops._C_ascend.store_kv_block(
+            key_npu, key_cache_npu, group_len, group_key_idx, group_key_cache_idx, block_size
+        )
+    N = 101
+    for zt_i in range(N):
+        group_len, group_key_idx, group_key_cache_idx = torch.ops._C_ascend.store_kv_block_pre(
+            slot_mapping_npu, slot_mapping_list, block_size
+        )
+        torch.ops._C_ascend.store_kv_block(
+            key_npu, key_cache_npu, group_len, group_key_idx, group_key_cache_idx, block_size
+        )
+
+    torch.testing.assert_close(key_expect, key_cache_npu, atol=0.001, rtol=0.1)
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -239,6 +239,7 @@ class AscendConfig:
                 )
 
         self.enable_sparse_c8 = additional_config.get("enable_sparse_c8", False) and use_sparse
+        self.c8_enable_reshape_optim = self.enable_sparse_c8 and additional_config.get("c8_enable_reshape_optim", False)
         quant_config = getattr(vllm_config, "quant_config", None)
         self._sparse_c8_layer_ids, self._sparse_c8_layer_names = self._parse_sparse_c8_layers_from_quant_config(
             quant_config

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -158,6 +158,10 @@ class AscendSFAMetadata:
     num_decodes: int = 0
     num_decode_tokens: int = 0
     num_prefills: int = 0
+    block_size: int = 0
+    group_len: torch.Tensor | None = None
+    group_key_idx: torch.Tensor | None = None
+    group_key_cache_idx: torch.Tensor | None = None
 
 
 M = TypeVar("M", bound=AscendSFAMetadata)
@@ -240,6 +244,10 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
         block_table = common_attn_metadata.block_table_tensor[:num_reqs]
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
         input_positions = common_attn_metadata.positions[:num_input_tokens].long()
+
+        block_size = 128
+        if get_ascend_config().c8_enable_reshape_optim:
+            slot_mapping_cpu = common_attn_metadata.slot_mapping_cpu[:num_input_tokens]
 
         cum_query_lens = common_attn_metadata.query_start_loc[1 : num_reqs + 1]
         seq_lens = common_attn_metadata.seq_lens[:num_reqs]
@@ -334,6 +342,14 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
                 actual_seq_lengths_key=actual_seq_lengths_key,
             )
 
+        if get_ascend_config().c8_enable_reshape_optim:
+            slot_mapping_list = slot_mapping_cpu.tolist()
+            group_len, group_key_idx, group_key_cache_idx = torch.ops._C_ascend.store_kv_block_pre(
+                slot_mapping, slot_mapping_list, block_size
+            )
+        else:
+            group_len, group_key_idx, group_key_cache_idx = None, None, None
+
         return self.metadata_cls(  # type: ignore
             num_input_tokens=common_attn_metadata.num_input_tokens,
             num_actual_tokens=num_actual_tokens,
@@ -348,6 +364,10 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
             sin=sin[:num_input_tokens],
             cos=cos[:num_input_tokens],
             dsa_cp_context=dsa_cp_context,
+            block_size=block_size,
+            group_len=group_len,
+            group_key_idx=group_key_idx,
+            group_key_cache_idx=group_key_cache_idx,
         )
 
     def build_for_graph_capture(
@@ -1265,22 +1285,43 @@ class AscendSFAImpl(MLAAttentionImpl):
                 dsa_k_cache_idx = 2
                 dsa_k_scale_cache_idx = 3
 
-            torch_npu.npu_scatter_nd_update_(
-                kv_cache[dsa_k_cache_idx].view(-1, k_li.shape[-1]),
-                slot_mapping.view(-1, 1),
-                k_li.view(-1, k_li.shape[-1]),
-            )  # b, s, n, d
+            if self.is_kv_producer and get_ascend_config().c8_enable_reshape_optim:
+                torch.ops._C_ascend.store_kv_block(
+                    k_li,
+                    kv_cache[dsa_k_cache_idx],
+                    attn_metadata.group_len,
+                    attn_metadata.group_key_idx,
+                    attn_metadata.group_key_cache_idx,
+                    attn_metadata.block_size,
+                )
+            else:
+                torch_npu.npu_scatter_nd_update_(
+                    kv_cache[dsa_k_cache_idx].view(-1, k_li.shape[-1]),
+                    slot_mapping.view(-1, 1),
+                    k_li.view(-1, k_li.shape[-1]),
+                )  # b, s, n, d
             if self.use_sparse_c8_indexer:
                 if get_ascend_device_type() == AscendDeviceType.A5:
                     assert len(kv_cache) == 3
                 else:
                     assert len(kv_cache) == 4
                 if k_li_scale is not None:
-                    torch_npu.npu_scatter_nd_update_(
-                        kv_cache[dsa_k_scale_cache_idx].view(-1, k_li_scale.shape[-1]),
-                        slot_mapping.view(-1, 1),
-                        k_li_scale.view(-1, k_li_scale.shape[-1]),
-                    )
+                    if self.is_kv_producer and get_ascend_config().c8_enable_reshape_optim:
+                        torch.ops._C_ascend.store_kv_block(
+                            k_li_scale,
+                            kv_cache[dsa_k_scale_cache_idx],
+                            attn_metadata.group_len,
+                            attn_metadata.group_key_idx,
+                            attn_metadata.group_key_cache_idx,
+                            attn_metadata.block_size,
+                        )
+                    else:
+                        torch_npu.npu_scatter_nd_update_(
+                            kv_cache[dsa_k_scale_cache_idx].view(-1, k_li_scale.shape[-1]),
+                            slot_mapping.view(-1, 1),
+                            k_li_scale.view(-1, k_li_scale.shape[-1]),
+                        )
+
             if self.is_kv_producer:
                 attn_metadata.reshape_cache_event.record()
 

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -174,6 +174,9 @@ class AscendCommonAttentionMetadata(CommonAttentionMetadata):
     positions: torch.Tensor = None
     positions_cpu: torch.Tensor = None
 
+    # CPU tensor of slot mapping for host-side operations.
+    slot_mapping_cpu: torch.Tensor = None
+
     # Current attention state (e.g., ChunkedPrefill, DecodeOnly).
     attn_state: Any = None
 
@@ -209,6 +212,7 @@ class AscendCommonAttentionMetadata(CommonAttentionMetadata):
             # This is really strange since vLLM slices them as well
             block_table_tensor=self.block_table_tensor,
             slot_mapping=self.slot_mapping,
+            slot_mapping_cpu=self.slot_mapping_cpu,
             causal=self.causal,
             actual_seq_lengths_q=self.actual_seq_lengths_q[:num_actual_tokens],
             positions=self.positions,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -528,6 +528,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 block_table_tensor=self.runner.input_batch.block_table[0].get_device_tensor()[:num_reqs],
                 # This is used to hold a position.
                 slot_mapping=self.runner.input_batch.block_table[0].slot_mapping.gpu,
+                slot_mapping_cpu=self.runner.input_batch.block_table[0].slot_mapping.cpu,
                 positions=self.runner.positions,
                 attn_state=self.runner.attn_state,
                 decode_token_per_req=self.runner.decode_token_per_req,
@@ -1809,6 +1810,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             max_query_len=new_query_len_per_req.max().item(),
             block_table_tensor=common_attn_metadata.block_table_tensor,
             slot_mapping=common_attn_metadata.slot_mapping,
+            slot_mapping_cpu=common_attn_metadata.slot_mapping_cpu,
             actual_seq_lengths_q=self.runner.actual_seq_lengths_q,
             positions=common_attn_metadata.positions[token_indices],
             positions_cpu=common_attn_metadata.positions_cpu[token_indices]
@@ -1900,6 +1902,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             actual_seq_lengths_q=self.runner.actual_seq_lengths_q,
             block_table_tensor=common_attn_metadata.block_table_tensor,
             slot_mapping=common_attn_metadata.slot_mapping,
+            slot_mapping_cpu=common_attn_metadata.slot_mapping_cpu,
             positions=common_attn_metadata.positions,
             positions_cpu=common_attn_metadata.positions_cpu,
             attn_state=self.runner.attn_state,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2984,8 +2984,8 @@ class NPUModelRunner(GPUModelRunner):
             else:
                 blk_table = self.input_batch.block_table[kv_cache_gid]
                 slot_mapping = blk_table.slot_mapping.gpu[:maybe_pcp_full_tokens]
-                blk_table_tensor = blk_table.get_device_tensor()[:num_reqs_padded]
-
+                self.cpu_slot_mapping = blk_table.slot_mapping.cpu[:maybe_pcp_full_tokens]
+                blk_table_tensor = blk_table.get_device_tensor()[:num_reqs_padded]          
                 # Fill unused with -1. Needed for reshape_and_cache in full cuda
                 # graph mode. `blk_table_tensor` -1 to match mamba PAD_SLOT_ID
                 if self.pcp_size == 1:
@@ -3071,6 +3071,7 @@ class NPUModelRunner(GPUModelRunner):
             max_seq_len=max_seq_len,
             block_table_tensor=block_table_gid_0,
             slot_mapping=slot_mapping_gid_0,
+            slot_mapping_cpu=self.cpu_slot_mapping,
             causal=True,
             is_prefilling=is_prefilling,
             num_input_tokens=num_tokens_padded,


### PR DESCRIPTION
### What this PR does / why we need it?
add ascendc ops store_kv_block
Control whether to use the operator by using additional-config '{"enable_sparse_c8":true,"c8_enable_reshape_optim":true}'. It is only used on the P node.

### Does this PR introduce _any_ user-facing change?
By enabling c8_enable_reshape_optim on the P node

### How was this patch tested?
nightly custom op
- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
