### PR TITLE
[Feature] Add SFA MLA prolog v3 path

### DIFF
--- a/docs/source/developer_guide/Design_Documents/index.md
+++ b/docs/source/developer_guide/Design_Documents/index.md
@@ -16,5 +16,6 @@ add_custom_aclnn_op
 context_parallel
 dynamic_chunked_pipeline_parallel
 quantization
+sfa_mla_prolog_v3_kv_quant
 npugraph_ex
 :::

--- a/docs/source/developer_guide/Design_Documents/sfa_mla_prolog_v3_kv_quant.md
+++ b/docs/source/developer_guide/Design_Documents/sfa_mla_prolog_v3_kv_quant.md
@@ -1,0 +1,120 @@
+# SFA MLA Prolog V3 With KV-Quant Sparse Attention
+
+This document describes the SFA path that connects `npu_mla_prolog_v3`
+with `npu_kv_quant_sparse_flash_attention`.
+
+## Goal
+
+The feature is enabled by:
+
+```bash
+VLLM_ASCEND_ENABLE_SFA_PROLOG_V3=1
+VLLM_ASCEND_ENABLE_SFA_KV_QUANT_SPARSE_ATTENTION=1
+```
+
+It is independent from `enable_fa_quant`. The KV cache quantization is
+produced by `npu_mla_prolog_v3` with per-tile packed cache mode, then consumed
+directly by `npu_kv_quant_sparse_flash_attention`.
+
+## Data Flow
+
+```text
+hidden_states
+    |
+    v
+npu_mla_prolog_v3
+    |                 \
+    |                  \-- q_norm -> DSA indexer -> sparse_indices
+    |
+    +-- q_nope + q_rope
+    |
+    +-- packed int8 KV cache
+            |
+            v
+npu_kv_quant_sparse_flash_attention
+    |
+    v
+latent attention output -> W_UV -> o_proj
+```
+
+## Cache Layout
+
+The packed KV cache is stored in `kv_cache[0]`. `kv_cache[1]` is an empty
+`kr_cache` placeholder because rope and per-tile scales are combined into the
+packed cache. DSA indexer cache still uses the later tuple entries.
+
+```text
+kv_cache tuple
+
+normal SFA:
+  [0] kv_lora        bf16/fp16
+  [1] k_rope         bf16/fp16
+  [2] dsa_index_key  bf16/fp16
+
+SFA KV-quant sparse attention:
+  [0] packed_kv      int8
+      = kv_lora_int8
+        + k_rope_bf16.view(int8)
+        + tile_scales_fp32.view(int8)
+  [1] empty kr_cache bf16, last_dim = 0
+  [2] dsa_index_key  bf16/fp16 or int8 when Sparse C8 indexer is enabled
+  [3] dsa_index_scale only when Sparse C8 indexer is enabled
+```
+
+For the common MLA shape, the packed KV last dimension is:
+
+```text
+kv_lora_rank + qk_rope_head_dim * 2 + (kv_lora_rank / 128) * 4
+
+512 + 64 * 2 + 4 * 4 = 656
+```
+
+## Operator Parameters
+
+`npu_mla_prolog_v3` uses:
+
+```text
+kv_cache_quant_mode=3
+ckvkr_repo_mode=1
+quant_scale_repo_mode=1
+tile_size=128
+query_quant_mode=0
+weight_quant_mode=2
+```
+
+`npu_kv_quant_sparse_flash_attention` uses:
+
+```text
+query = cat(q_nope, q_rope)
+key = packed_kv
+value = packed_kv
+layout_query="TND"
+layout_kv="PA_BSND"
+key_quant_mode=2
+value_quant_mode=2
+attention_mode=2
+quant_scale_repo_mode=1
+tile_size=128
+rope_head_dim=qk_rope_head_dim
+```
+
+The attention output last dimension is `kv_lora_rank`, so the existing MLA
+`W_UV` up-projection remains unchanged.
+
+## Context Parallel
+
+For DSA-CP or PCP, packed KV and DSA indexer cache are communicated separately.
+This avoids concatenating tensors with different dtypes and preserves the
+packed int8 cache format before writing back to paged cache.
+
+```text
+local prolog packed_kv(int8)  --gather--> scatter to kv_cache[0]
+local dsa_index_key          --gather--> scatter to kv_cache[2]
+```
+
+## Current Scope
+
+The int8 path is enabled for non-A5 devices. A5 keeps the existing Sparse C8
+FP8 CKV behavior. If the SFA prolog v3 weight and layernorm requirements are
+not met while this feature is enabled, initialization fails fast instead of
+falling back to an incompatible unpacked cache layout.

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -1,4 +1,5 @@
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -13,6 +14,7 @@ if "torch_npu._inductor" not in sys.modules:
     sys.modules["torch_npu._inductor"] = MagicMock()
 
 from vllm_ascend.attention.sfa_v1 import AscendSFABackend, AscendSFAImpl, AscendSFAMetadata, AscendSFAMetadataBuilder
+from vllm_ascend.core.kv_cache_interface import get_sfa_qsfa_packed_head_dim
 from vllm_ascend.utils import enable_dsa_cp
 
 
@@ -56,6 +58,124 @@ class TestAscendSFABackend(TestBase):
         mock_enable_cp.return_value = True
         impl_cls = AscendSFABackend.get_impl_cls()
         self.assertIsNotNone(impl_cls)
+
+
+class TestAscendSFAKVQuantSparseAttention(TestBase):
+    def test_execute_kv_quant_sparse_flash_attention(self):
+        impl = AscendSFAImpl.__new__(AscendSFAImpl)
+        impl.enable_sfa_kv_quant_sparse_attention = True
+        impl.scale = 0.125
+        impl.sfa_qsfa_tile_size = 128
+        impl.qk_rope_head_dim = 16
+
+        ql_nope = torch.randn(3, 2, 32)
+        q_pe = torch.randn(3, 2, 16)
+        kv_cache = (
+            torch.empty(4, 16, 1, 80, dtype=torch.int8),
+            torch.empty(4, 16, 1, 0, dtype=torch.bfloat16),
+            torch.randn(4, 16, 1, 32),
+        )
+        topk_indices = torch.zeros(3, 1, dtype=torch.int32)
+        attn_metadata = MagicMock()
+        attn_metadata.block_table = torch.zeros(1, 4, dtype=torch.int32)
+        actual_seq_lengths_query = torch.tensor([3], dtype=torch.int32)
+        actual_seq_lengths_key = torch.tensor([3], dtype=torch.int32)
+        expected = torch.randn(3, 2, 32)
+
+        with patch(
+            "vllm_ascend.attention.sfa_v1.torch_npu.npu_kv_quant_sparse_flash_attention",
+            create=True,
+            return_value=expected,
+        ) as mock_qsfa:
+            result = impl._execute_sparse_flash_attention_process(
+                ql_nope,
+                q_pe,
+                kv_cache,
+                topk_indices,
+                attn_metadata,
+                actual_seq_lengths_query,
+                actual_seq_lengths_key,
+            )
+
+        self.assertIs(result, expected)
+        call_kwargs = mock_qsfa.call_args.kwargs
+        self.assertEqual(call_kwargs["query"].shape, (3, 2, 48))
+        self.assertIs(call_kwargs["key"], kv_cache[0])
+        self.assertIs(call_kwargs["value"], kv_cache[0])
+        self.assertEqual(call_kwargs["key_quant_mode"], 2)
+        self.assertEqual(call_kwargs["value_quant_mode"], 2)
+        self.assertEqual(call_kwargs["quant_scale_repo_mode"], 1)
+        self.assertEqual(call_kwargs["tile_size"], 128)
+        self.assertEqual(call_kwargs["rope_head_dim"], 16)
+
+    def test_prolog_v3_enables_packed_int8_kv_cache(self):
+        impl = AscendSFAImpl.__new__(AscendSFAImpl)
+        impl.enable_sfa_kv_quant_sparse_attention = True
+        impl.sfa_qsfa_tile_size = 128
+        impl.local_num_heads = 2
+        impl.num_kv_heads = 1
+        impl.kv_lora_rank = 128
+        impl.qk_rope_head_dim = 16
+        impl.q_lora_rank = 8
+        impl.q_a_layernorm = SimpleNamespace(
+            weight=SimpleNamespace(data=torch.ones(8)),
+            variance_epsilon=1e-5,
+        )
+        impl.kv_a_layernorm = SimpleNamespace(
+            weight=SimpleNamespace(data=torch.ones(128)),
+            variance_epsilon=1e-5,
+        )
+        impl.weight_dq = torch.empty(1)
+        impl.weight_uq_qr = torch.empty(1)
+        impl.W_UK_T = torch.empty(1)
+        impl.weight_dkv_kr = torch.empty(1)
+        impl.dequant_scale_w_dq = torch.empty(1)
+        impl.dequant_scale_w_uq_qr = torch.empty(1)
+        impl.dequant_scale_w_dkv_kr = torch.empty(1)
+
+        hidden_states = torch.randn(2, 8)
+        k_cache = torch.empty(4, 16, 1, get_sfa_qsfa_packed_head_dim(128, 16), dtype=torch.int8)
+        kr_cache = torch.empty(4, 16, 1, 0, dtype=torch.bfloat16)
+
+        with (
+            patch.object(
+                impl,
+                "_format_prolog_v3_inputs",
+                return_value=(
+                    torch.empty(2, 8, dtype=torch.int8),
+                    torch.ones(2, 1),
+                    torch.randn(2, 16),
+                    torch.randn(2, 16),
+                ),
+            ),
+            patch(
+                "vllm_ascend.attention.sfa_v1.torch_npu.npu_mla_prolog_v3",
+                create=True,
+                return_value=(
+                    torch.randn(2, 2, 128),
+                    torch.randn(2, 2, 16),
+                    None,
+                    torch.randn(2, 8),
+                    None,
+                ),
+            ) as mock_prolog,
+        ):
+            impl._sfa_preprocess_with_prolog_v3(
+                hidden_states=hidden_states,
+                kv_cache=(k_cache, kr_cache),
+                cos=torch.randn(2, 1, 1, 16),
+                sin=torch.randn(2, 1, 1, 16),
+                slot_mapping=torch.arange(2),
+                cache_mode="PA_BSND",
+            )
+
+        call_kwargs = mock_prolog.call_args.kwargs
+        self.assertIs(call_kwargs["kv_cache"], k_cache)
+        self.assertIs(call_kwargs["kr_cache"], kr_cache)
+        self.assertEqual(call_kwargs["kv_cache_quant_mode"], 3)
+        self.assertEqual(call_kwargs["ckvkr_repo_mode"], 1)
+        self.assertEqual(call_kwargs["quant_scale_repo_mode"], 1)
+        self.assertEqual(call_kwargs["tile_size"], 128)
 
 
 class TestAscendSFAMetadata(TestBase):

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -107,6 +107,7 @@ class TestAscendConfig(TestBase):
                 "VLLM_ASCEND_ENABLE_FUSED_MC2": "2",
                 "VLLM_ASCEND_ENABLE_MLAPO": "0",
                 "VLLM_ASCEND_ENABLE_SFA_PROLOG_V3": "1",
+                "VLLM_ASCEND_ENABLE_SFA_KV_QUANT_SPARSE_ATTENTION": "1",
                 "VLLM_ASCEND_ENABLE_FLASHCOMM1": "1",
                 "VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE": "2",
                 "MSMONITOR_USE_DAEMON": "1",
@@ -120,6 +121,7 @@ class TestAscendConfig(TestBase):
         self.assertEqual(ascend_config.enable_fused_mc2, 2)
         self.assertFalse(ascend_config.enable_mlapo)
         self.assertTrue(ascend_config.enable_sfa_prolog_v3)
+        self.assertTrue(ascend_config.enable_sfa_kv_quant_sparse_attention)
         self.assertTrue(ascend_config.enable_flashcomm1)
         self.assertEqual(ascend_config.enable_flashcomm2_parallel_size, 2)
         self.assertTrue(ascend_config.msmonitor_use_daemon)
@@ -134,6 +136,12 @@ class TestAscendConfig(TestBase):
             "AscendConfig.enable_sfa_prolog_v3 falls back to environment variable "
             "VLLM_ASCEND_ENABLE_SFA_PROLOG_V3 with value True. Please use additional_config.enable_sfa_prolog_v3 "
             "instead, because VLLM_ASCEND_ENABLE_SFA_PROLOG_V3 will be removed in the next release."
+        )
+        mock_info_once.assert_any_call(
+            "AscendConfig.enable_sfa_kv_quant_sparse_attention falls back to environment variable "
+            "VLLM_ASCEND_ENABLE_SFA_KV_QUANT_SPARSE_ATTENTION with value True. Please use "
+            "additional_config.enable_sfa_kv_quant_sparse_attention instead, because "
+            "VLLM_ASCEND_ENABLE_SFA_KV_QUANT_SPARSE_ATTENTION will be removed in the next release."
         )
         mock_info_once.assert_any_call(
             "AscendConfig.weight_nz_mode falls back to environment variable VLLM_ASCEND_ENABLE_NZ with value 2. "
@@ -166,6 +174,7 @@ class TestAscendConfig(TestBase):
             "enable_fused_mc2": 0,
             "enable_mlapo": True,
             "enable_sfa_prolog_v3": True,
+            "enable_sfa_kv_quant_sparse_attention": True,
             "enable_flashcomm1": False,
             "enable_flashcomm2_parallel_size": 0,
             "msmonitor_use_daemon": False,
@@ -179,6 +188,7 @@ class TestAscendConfig(TestBase):
                 "VLLM_ASCEND_ENABLE_FUSED_MC2": "2",
                 "VLLM_ASCEND_ENABLE_MLAPO": "0",
                 "VLLM_ASCEND_ENABLE_SFA_PROLOG_V3": "0",
+                "VLLM_ASCEND_ENABLE_SFA_KV_QUANT_SPARSE_ATTENTION": "0",
                 "VLLM_ASCEND_ENABLE_FLASHCOMM1": "1",
                 "VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE": "2",
                 "MSMONITOR_USE_DAEMON": "1",
@@ -192,6 +202,7 @@ class TestAscendConfig(TestBase):
         self.assertEqual(ascend_config.enable_fused_mc2, 0)
         self.assertTrue(ascend_config.enable_mlapo)
         self.assertTrue(ascend_config.enable_sfa_prolog_v3)
+        self.assertTrue(ascend_config.enable_sfa_kv_quant_sparse_attention)
         self.assertFalse(ascend_config.enable_flashcomm1)
         self.assertEqual(ascend_config.enable_flashcomm2_parallel_size, 0)
         self.assertFalse(ascend_config.msmonitor_use_daemon)
@@ -200,6 +211,9 @@ class TestAscendConfig(TestBase):
         mock_info_once.assert_any_call("AscendConfig.enable_mlapo is set from additional_config with value True.")
         mock_info_once.assert_any_call(
             "AscendConfig.enable_sfa_prolog_v3 is set from additional_config with value True."
+        )
+        mock_info_once.assert_any_call(
+            "AscendConfig.enable_sfa_kv_quant_sparse_attention is set from additional_config with value True."
         )
         mock_info_once.assert_any_call("AscendConfig.weight_nz_mode is set from additional_config with value 1.")
 

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -106,6 +106,7 @@ class TestAscendConfig(TestBase):
                 "VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE": "1",
                 "VLLM_ASCEND_ENABLE_FUSED_MC2": "2",
                 "VLLM_ASCEND_ENABLE_MLAPO": "0",
+                "VLLM_ASCEND_ENABLE_SFA_PROLOG_V3": "1",
                 "VLLM_ASCEND_ENABLE_FLASHCOMM1": "1",
                 "VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE": "2",
                 "MSMONITOR_USE_DAEMON": "1",
@@ -118,6 +119,7 @@ class TestAscendConfig(TestBase):
         self.assertTrue(ascend_config.enable_matmul_allreduce)
         self.assertEqual(ascend_config.enable_fused_mc2, 2)
         self.assertFalse(ascend_config.enable_mlapo)
+        self.assertTrue(ascend_config.enable_sfa_prolog_v3)
         self.assertTrue(ascend_config.enable_flashcomm1)
         self.assertEqual(ascend_config.enable_flashcomm2_parallel_size, 2)
         self.assertTrue(ascend_config.msmonitor_use_daemon)
@@ -127,6 +129,11 @@ class TestAscendConfig(TestBase):
             "AscendConfig.enable_mlapo falls back to environment variable VLLM_ASCEND_ENABLE_MLAPO with value False. "
             "Please use additional_config.enable_mlapo instead, because VLLM_ASCEND_ENABLE_MLAPO will be "
             "removed in the next release."
+        )
+        mock_info_once.assert_any_call(
+            "AscendConfig.enable_sfa_prolog_v3 falls back to environment variable "
+            "VLLM_ASCEND_ENABLE_SFA_PROLOG_V3 with value True. Please use additional_config.enable_sfa_prolog_v3 "
+            "instead, because VLLM_ASCEND_ENABLE_SFA_PROLOG_V3 will be removed in the next release."
         )
         mock_info_once.assert_any_call(
             "AscendConfig.weight_nz_mode falls back to environment variable VLLM_ASCEND_ENABLE_NZ with value 2. "
@@ -158,6 +165,7 @@ class TestAscendConfig(TestBase):
             "enable_matmul_allreduce": False,
             "enable_fused_mc2": 0,
             "enable_mlapo": True,
+            "enable_sfa_prolog_v3": True,
             "enable_flashcomm1": False,
             "enable_flashcomm2_parallel_size": 0,
             "msmonitor_use_daemon": False,
@@ -170,6 +178,7 @@ class TestAscendConfig(TestBase):
                 "VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE": "1",
                 "VLLM_ASCEND_ENABLE_FUSED_MC2": "2",
                 "VLLM_ASCEND_ENABLE_MLAPO": "0",
+                "VLLM_ASCEND_ENABLE_SFA_PROLOG_V3": "0",
                 "VLLM_ASCEND_ENABLE_FLASHCOMM1": "1",
                 "VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE": "2",
                 "MSMONITOR_USE_DAEMON": "1",
@@ -182,12 +191,16 @@ class TestAscendConfig(TestBase):
         self.assertFalse(ascend_config.enable_matmul_allreduce)
         self.assertEqual(ascend_config.enable_fused_mc2, 0)
         self.assertTrue(ascend_config.enable_mlapo)
+        self.assertTrue(ascend_config.enable_sfa_prolog_v3)
         self.assertFalse(ascend_config.enable_flashcomm1)
         self.assertEqual(ascend_config.enable_flashcomm2_parallel_size, 0)
         self.assertFalse(ascend_config.msmonitor_use_daemon)
         self.assertTrue(ascend_config.enable_transpose_kv_cache_by_block)
         self.assertEqual(ascend_config.weight_nz_mode, 1)
         mock_info_once.assert_any_call("AscendConfig.enable_mlapo is set from additional_config with value True.")
+        mock_info_once.assert_any_call(
+            "AscendConfig.enable_sfa_prolog_v3 is set from additional_config with value True."
+        )
         mock_info_once.assert_any_call("AscendConfig.weight_nz_mode is set from additional_config with value 1.")
 
     @_clean_up_ascend_config

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -6,6 +6,7 @@ import numpy as np
 import torch
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheGroupSpec, KVCacheTensor
 
+from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, get_sfa_qsfa_packed_head_dim
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
 
@@ -84,6 +85,60 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
 
         self.assertEqual(k_cache.shape, (2, 16, 8, 64))
         self.assertEqual(v_cache.shape, (2, 16, 8, 64))
+
+    def test_sparse_qsfa_int8_cache_allocates_packed_cache(self):
+        runner = self._build_runner()
+        runner.use_sparse = True
+        runner.model_config.hf_text_config.index_head_dim = 128
+        runner.attn_backend.get_kv_cache_shape.side_effect = (
+            lambda num_blocks, block_size, num_kv_heads, head_size: (
+                num_blocks,
+                block_size,
+                num_kv_heads,
+                head_size,
+            )
+        )
+        runner._get_attention_kv_cache_dims = lambda layer_name, spec: (512, 64)
+
+        packed_head_dim = get_sfa_qsfa_packed_head_dim(512, 64)
+        kv_cache_spec = AscendMLAAttentionSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=packed_head_dim + 128,
+            sparse_head_dim=(packed_head_dim, 0, 128),
+            dtype=torch.bfloat16,
+            cache_dtype_str="auto",
+            cache_sfa_kv_quant_sparse_attention=True,
+        )
+        layer_name = "model.layers.0.self_attn"
+        kv_cache_config = KVCacheConfig(
+            num_blocks=2,
+            kv_cache_tensors=[KVCacheTensor(size=kv_cache_spec.page_size_bytes * 2, shared_by=[layer_name])],
+            kv_cache_groups=[KVCacheGroupSpec(layer_names=[layer_name], kv_cache_spec=kv_cache_spec)],
+        )
+
+        kv_cache_raw_tensors = runner._allocate_kv_cache_tensors(kv_cache_config)
+        k_cache_raw, kr_cache_raw, dsa_k_cache_raw = kv_cache_raw_tensors[layer_name]
+
+        self.assertEqual(k_cache_raw.numel(), 2 * 16 * packed_head_dim)
+        self.assertEqual(kr_cache_raw.numel(), 0)
+        self.assertEqual(dsa_k_cache_raw.numel(), 2 * 16 * 128 * torch.empty((), dtype=torch.bfloat16).element_size())
+
+        runner._kv_cache_spec_attn_group_iterator = lambda: [
+            SimpleNamespace(
+                kv_cache_spec=kv_cache_spec,
+                backend=runner.attn_backend,
+                layer_names=[layer_name],
+            )
+        ]
+        kv_caches = runner._reshape_kv_cache_tensors(kv_cache_config, kv_cache_raw_tensors)
+        packed_cache, kr_cache, dsa_k_cache = kv_caches[layer_name]
+
+        self.assertEqual(packed_cache.dtype, torch.int8)
+        self.assertEqual(packed_cache.shape, (2, 16, 1, packed_head_dim))
+        self.assertEqual(kr_cache.shape, (2, 16, 1, 0))
+        self.assertEqual(dsa_k_cache.dtype, torch.bfloat16)
+        self.assertEqual(dsa_k_cache.shape, (2, 16, 1, 128))
 
 
 class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -140,6 +140,71 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         self.assertEqual(dsa_k_cache.dtype, torch.bfloat16)
         self.assertEqual(dsa_k_cache.shape, (2, 16, 1, 128))
 
+    def test_sparse_qsfa_int8_cache_uses_exact_segment_sizes(self):
+        runner = self._build_runner()
+        runner.use_sparse = True
+        runner.model_config.hf_text_config.index_head_dim = 36
+        runner.attn_backend.get_kv_cache_shape.side_effect = (
+            lambda num_blocks, block_size, num_kv_heads, head_size: (
+                num_blocks,
+                block_size,
+                num_kv_heads,
+                head_size,
+            )
+        )
+        runner._get_attention_kv_cache_dims = lambda layer_name, spec: (512, 64)
+
+        packed_head_dim = get_sfa_qsfa_packed_head_dim(512, 64)
+        kv_cache_spec = AscendMLAAttentionSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=packed_head_dim + 36,
+            sparse_head_dim=(packed_head_dim, 0, 36),
+            dtype=torch.bfloat16,
+            cache_dtype_str="auto",
+            cache_sfa_kv_quant_sparse_attention=True,
+        )
+        layer_name = "model.layers.0.self_attn"
+        kv_cache_config = KVCacheConfig(
+            num_blocks=1,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=kv_cache_spec.page_size_bytes,
+                    shared_by=[layer_name],
+                )
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=[layer_name],
+                    kv_cache_spec=kv_cache_spec,
+                )
+            ],
+        )
+
+        kv_cache_raw_tensors = runner._allocate_kv_cache_tensors(kv_cache_config)
+        k_cache_raw, kr_cache_raw, dsa_k_cache_raw = kv_cache_raw_tensors[layer_name]
+
+        self.assertEqual(k_cache_raw.numel(), 16 * packed_head_dim)
+        self.assertEqual(kr_cache_raw.numel(), 0)
+        self.assertEqual(
+            dsa_k_cache_raw.numel(),
+            16 * 36 * torch.empty((), dtype=torch.bfloat16).element_size(),
+        )
+
+        runner._kv_cache_spec_attn_group_iterator = lambda: [
+            SimpleNamespace(
+                kv_cache_spec=kv_cache_spec,
+                backend=runner.attn_backend,
+                layer_names=[layer_name],
+            )
+        ]
+        kv_caches = runner._reshape_kv_cache_tensors(kv_cache_config, kv_cache_raw_tensors)
+        packed_cache, kr_cache, dsa_k_cache = kv_caches[layer_name]
+
+        self.assertEqual(packed_cache.shape, (1, 16, 1, packed_head_dim))
+        self.assertEqual(kr_cache.shape, (1, 16, 1, 0))
+        self.assertEqual(dsa_k_cache.shape, (1, 16, 1, 36))
+
 
 class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
     def _build_runner(self):

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -161,6 +161,12 @@ class AscendConfig:
             "VLLM_ASCEND_ENABLE_MLAPO",
             ascend_envs.VLLM_ASCEND_ENABLE_MLAPO,
         )
+        self.enable_sfa_prolog_v3 = self._get_config_value(
+            additional_config,
+            "enable_sfa_prolog_v3",
+            "VLLM_ASCEND_ENABLE_SFA_PROLOG_V3",
+            ascend_envs.VLLM_ASCEND_ENABLE_SFA_PROLOG_V3,
+        )
         self.enable_flashcomm2_parallel_size = self._get_config_value(
             additional_config,
             "enable_flashcomm2_parallel_size",

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -167,6 +167,12 @@ class AscendConfig:
             "VLLM_ASCEND_ENABLE_SFA_PROLOG_V3",
             ascend_envs.VLLM_ASCEND_ENABLE_SFA_PROLOG_V3,
         )
+        self.enable_sfa_kv_quant_sparse_attention = self._get_config_value(
+            additional_config,
+            "enable_sfa_kv_quant_sparse_attention",
+            "VLLM_ASCEND_ENABLE_SFA_KV_QUANT_SPARSE_ATTENTION",
+            ascend_envs.VLLM_ASCEND_ENABLE_SFA_KV_QUANT_SPARSE_ATTENTION,
+        )
         self.enable_flashcomm2_parallel_size = self._get_config_value(
             additional_config,
             "enable_flashcomm2_parallel_size",

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -354,6 +354,16 @@ class AscendSFACPImpl(AscendSFAImpl):
     def _execute_sparse_flash_attention(
         self, ql_nope, q_pe, kv, key_rope, block_table, topk_indices, actual_seq_lengths_query, actual_seq_lengths_key
     ):
+        if self.enable_sfa_kv_quant_sparse_attention:
+            return self._execute_kv_quant_sparse_flash_attention(
+                ql_nope=ql_nope,
+                q_pe=q_pe,
+                kv=kv,
+                block_table=block_table,
+                topk_indices=topk_indices,
+                actual_seq_lengths_query=actual_seq_lengths_query,
+                actual_seq_lengths_key=actual_seq_lengths_key,
+            )
         attn_output, _, _ = torch.ops._C_ascend.npu_sparse_flash_attention(
             query=ql_nope,
             key=kv,

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -49,9 +49,14 @@ from vllm_ascend.ops.layer_shard_linear import (
 )
 from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_mla
 from vllm_ascend.ops.triton.rope import rope_forward_triton_siso
-from vllm_ascend.quantization.methods import AscendW8A8LinearMethod, AscendW8A8MXFP8DynamicLinearMethod
+from vllm_ascend.quantization.methods import (
+    AscendW8A8DynamicLinearMethod,
+    AscendW8A8LinearMethod,
+    AscendW8A8MXFP8DynamicLinearMethod,
+)
 from vllm_ascend.utils import (
     ACL_FORMAT_FRACTAL_ND,
+    ACL_FORMAT_FRACTAL_NZ,
     AscendDeviceType,
     _round_up,
     dispose_layer,
@@ -493,7 +498,8 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         # The MLAPO operator fuses the pre-processing steps on Q/K/V in MLA into a single operator
         # NOTE: it imposes a limit on the number of input tokens and conflicts with FlashComm
-        self.enable_mlapo = get_ascend_config().enable_mlapo
+        self.enable_mlapo = ascend_config.enable_mlapo
+        self.enable_sfa_prolog_v3 = ascend_config.enable_sfa_prolog_v3
 
         assert self.indexer is not None, "Indexer is required for DSA."
 
@@ -619,7 +625,26 @@ class AscendSFAImpl(MLAAttentionImpl):
             else:
                 self._init_o_proj_tp_full_params()
 
-        if self.enable_mlapo:
+        if self.enable_sfa_prolog_v3:
+            self.enable_mlapo = False
+            reasons = []
+            if self.fused_qkv_a_proj is None or not self._is_w8a8_dynamic_linear(self.fused_qkv_a_proj):
+                reasons.append(
+                    "Currently SFA mla_prolog_v3 only supports W8A8 dynamic quantization for fused_qkv_a_proj."
+                )
+            if self.q_proj is None or not self._is_w8a8_dynamic_linear(self.q_proj):
+                reasons.append("Currently SFA mla_prolog_v3 only supports W8A8 dynamic quantization for q_proj.")
+            if self.kv_a_layernorm is None or self.q_a_layernorm is None:
+                reasons.append("SFA mla_prolog_v3 requires q_a_layernorm and kv_a_layernorm.")
+            if getattr(self.q_proj, "_chunk_size", 0):
+                reasons.append("SFA mla_prolog_v3 does not support chunked q_proj weights yet.")
+            if reasons:
+                self.enable_sfa_prolog_v3 = False
+                for msg in reasons:
+                    logger.warning_once(msg)
+            else:
+                self._process_weights_for_fused_prolog_v3()
+        elif self.enable_mlapo:
             quant_method = getattr(
                 getattr(self.fused_qkv_a_proj, "quant_method", None),
                 "quant_method",
@@ -656,7 +681,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                 self.c8_k_cache_dtype = act_dtype
                 self.c8_k_scale_cache_dtype = act_dtype
 
-        if not self.enable_mlapo:
+        if not self.enable_mlapo and not self.enable_sfa_prolog_v3:
             # if mlapo, W_UK_T can't trans nz
             self.W_UK_T = maybe_trans_nz(self.W_UK_T)
 
@@ -668,6 +693,30 @@ class AscendSFAImpl(MLAAttentionImpl):
             AscendSFAImpl.k_hadamard = torch.tensor(scipy.linalg.hadamard(128), dtype=torch.bfloat16, device="npu") / (
                 128**0.5
             )
+
+    @staticmethod
+    def _is_w8a8_dynamic_linear(layer: torch.nn.Module) -> bool:
+        quant_method = getattr(getattr(layer, "quant_method", None), "quant_method", None)
+        return isinstance(quant_method, AscendW8A8DynamicLinearMethod)
+
+    def _process_weights_for_fused_prolog_v3(self) -> None:
+        assert self.fused_qkv_a_proj is not None
+        assert self.q_proj is not None
+
+        fused_weight = torch_npu.npu_format_cast(self.fused_qkv_a_proj.weight.data, ACL_FORMAT_FRACTAL_ND)
+        weight_dq = fused_weight[..., : self.q_lora_rank].contiguous()
+        weight_dkv_kr = fused_weight[..., self.q_lora_rank :].contiguous()
+        self.weight_dq = torch_npu.npu_format_cast(weight_dq, ACL_FORMAT_FRACTAL_NZ)
+        self.weight_dkv_kr = torch_npu.npu_format_cast(weight_dkv_kr, ACL_FORMAT_FRACTAL_NZ)
+
+        weight_uq_qr = torch_npu.npu_format_cast(self.q_proj.weight.data, ACL_FORMAT_FRACTAL_ND).contiguous()
+        self.weight_uq_qr = torch_npu.npu_format_cast(weight_uq_qr, ACL_FORMAT_FRACTAL_NZ)
+
+        q_a_proj_deq_scl = self.fused_qkv_a_proj.weight_scale[: self.q_lora_rank].contiguous()
+        kv_a_proj_deq_scl = self.fused_qkv_a_proj.weight_scale[self.q_lora_rank :].contiguous()
+        self.dequant_scale_w_dq = q_a_proj_deq_scl.view(1, -1).to(torch.float)
+        self.dequant_scale_w_dkv_kr = kv_a_proj_deq_scl.view(1, -1).to(torch.float)
+        self.dequant_scale_w_uq_qr = self.q_proj.weight_scale.data.view(1, -1).to(torch.float)
 
     # Processing the input parameters for MLAPO by reordering and transposing
     # QKV(and part of Q) weight, applying RoPE-related dimension transformations,
@@ -1071,6 +1120,192 @@ class AscendSFAImpl(MLAAttentionImpl):
             num_input_tokens,
         )
 
+    def _format_prolog_v3_inputs(
+        self,
+        hidden_states: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        token_x, dynamic_scale = torch_npu.npu_dynamic_quant(hidden_states.contiguous())
+        dynamic_scale = dynamic_scale.view(-1, 1)
+        rope_cos = cos.view(cos.shape[0], cos.shape[-1])
+        rope_sin = sin.view(sin.shape[0], sin.shape[-1])
+        return token_x, dynamic_scale, rope_cos, rope_sin
+
+    def _maybe_dequant_query_norm(
+        self,
+        q_c: torch.Tensor,
+        q_c_scale: torch.Tensor | None,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        if q_c_scale is None or q_c_scale.numel() == 0 or q_c.dtype not in (torch.int8, torch.uint8):
+            return q_c
+        return q_c.to(dtype) * q_c_scale.view(-1, 1).to(dtype)
+
+    def _sfa_preprocess_with_prolog_v3(
+        self,
+        hidden_states: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, torch.Tensor],
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        cache_mode: str,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+        assert self.q_a_layernorm is not None
+        assert self.kv_a_layernorm is not None
+
+        token_x, dynamic_scale, rope_cos, rope_sin = self._format_prolog_v3_inputs(hidden_states, cos, sin)
+        prolog_kwargs = {
+            "token_x": token_x,
+            "weight_dq": self.weight_dq,
+            "weight_uq_qr": self.weight_uq_qr,
+            "weight_uk": self.W_UK_T,
+            "weight_dkv_kr": self.weight_dkv_kr,
+            "rmsnorm_gamma_cq": self.q_a_layernorm.weight.data,
+            "rmsnorm_gamma_ckv": self.kv_a_layernorm.weight.data,
+            "rope_sin": rope_sin,
+            "rope_cos": rope_cos,
+            "kv_cache": kv_cache[0],
+            "kr_cache": kv_cache[1],
+            "dequant_scale_x": dynamic_scale,
+            "dequant_scale_w_dq": self.dequant_scale_w_dq,
+            "dequant_scale_w_uq_qr": self.dequant_scale_w_uq_qr,
+            "dequant_scale_w_dkv_kr": self.dequant_scale_w_dkv_kr,
+            "cache_mode": cache_mode,
+            "query_quant_mode": 0,
+            "weight_quant_mode": 2,
+            "kv_cache_quant_mode": 0,
+            "query_norm_flag": True,
+            "rmsnorm_epsilon_cq": self.q_a_layernorm.variance_epsilon,
+            "rmsnorm_epsilon_ckv": self.kv_a_layernorm.variance_epsilon,
+            "qc_qr_scale": 1.0,
+            "kc_scale": 1.0,
+        }
+        if cache_mode == "PA_BSND":
+            prolog_kwargs["cache_index"] = slot_mapping.view(-1).to(torch.int64)
+
+        ql_nope, q_pe, _, q_c, q_c_scale = torch_npu.npu_mla_prolog_v3(**prolog_kwargs)
+        ql_nope = ql_nope.view(-1, self.local_num_heads, self.kv_lora_rank)
+        q_pe = q_pe.view(-1, self.local_num_heads, self.qk_rope_head_dim)
+        if q_c is None:
+            raise RuntimeError("npu_mla_prolog_v3 did not return query_norm for SFA.")
+        q_c = self._maybe_dequant_query_norm(q_c, q_c_scale, hidden_states.dtype)
+        q_c = q_c.view(-1, self.q_lora_rank)
+        k_nope = kv_cache[0] if cache_mode == "TND" else None
+        k_pe = kv_cache[1] if cache_mode == "TND" else None
+        return hidden_states, ql_nope, q_pe, q_c, k_nope, k_pe
+
+    def _sfa_preprocess_with_prolog_v3_tnd_cache(
+        self,
+        hidden_states: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        k_nope = torch.empty(
+            (hidden_states.shape[0], self.num_kv_heads, self.kv_lora_rank),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        k_pe = torch.empty(
+            (hidden_states.shape[0], self.num_kv_heads, self.qk_rope_head_dim),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        hidden_states, ql_nope, q_pe, q_c, k_nope, k_pe = self._sfa_preprocess_with_prolog_v3(
+            hidden_states=hidden_states,
+            kv_cache=(k_nope, k_pe),
+            cos=cos,
+            sin=sin,
+            slot_mapping=torch.empty(0, dtype=torch.int64, device=hidden_states.device),
+            cache_mode="TND",
+        )
+        assert k_nope is not None
+        assert k_pe is not None
+        return hidden_states, ql_nope, q_pe, q_c, k_nope, k_pe
+
+    def _all_gather_and_cache_dsa_cp_kv(
+        self,
+        k_pe: torch.Tensor,
+        k_nope: torch.Tensor,
+        k_li: torch.Tensor,
+        k_li_scale: torch.Tensor | None,
+        kv_cache: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+        slot_mapping: torch.Tensor,
+        attn_metadata: M,
+        full_gather_o_proj_enabled: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.distributed.Work | None]:
+        async_op = self.enable_dsa_cp_with_layer_shard or full_gather_o_proj_enabled
+        if not self.use_sparse_c8_indexer:
+            fused_kv_no_split, kv_ag_handle = all_gather_async(
+                torch.cat(
+                    [
+                        k_pe.view(-1, k_pe.shape[-1]),
+                        k_nope.view(-1, k_nope.shape[-1]),
+                        k_li.view(-1, k_li.shape[-1]),
+                    ],
+                    dim=1,
+                ),
+                get_tp_group(),
+                async_op=async_op,
+            )
+        else:
+            assert k_li_scale is not None
+            fused_kv_no_split, _ = all_gather_async(
+                torch.cat(
+                    [
+                        k_pe.view(-1, k_pe.shape[-1]),
+                        k_nope.view(-1, k_nope.shape[-1]),
+                    ],
+                    dim=1,
+                ),
+                get_tp_group(),
+                async_op=async_op,
+            )
+            k_li, _ = all_gather_async(
+                k_li,
+                get_tp_group(),
+                async_op=async_op,
+            )
+            k_li_scale, kv_ag_handle = all_gather_async(
+                k_li_scale,
+                get_tp_group(),
+                async_op=async_op,
+            )
+
+        if kv_ag_handle is not None:
+            kv_ag_handle.wait()
+
+        o_proj_full_handle = None
+        if self.enable_dsa_cp_with_layer_shard:
+            for layer in self.layer_sharding_kwargs or []:
+                if is_hidden_layer(layer):
+                    reach_layer_for_shard_weight_series(layer)
+        elif full_gather_o_proj_enabled:
+            _, o_proj_full_handle = all_gather_async(
+                self.o_proj_tp_weight,
+                get_tp_group(),
+                output=AscendSFAImpl.o_proj_full_pool,
+            )
+
+        if kv_cache is not None:
+            assert fused_kv_no_split is not None
+            if not self.use_sparse_c8_indexer:
+                k_pe, k_nope, k_li = fused_kv_no_split.split(
+                    [self.qk_rope_head_dim, self.kv_lora_rank, self.head_dim], dim=-1
+                )
+            else:
+                k_pe, k_nope = fused_kv_no_split.split([self.qk_rope_head_dim, self.kv_lora_rank], dim=-1)
+            k_nope = k_nope.view(k_nope.shape[0], 1, -1)
+            k_pe = k_pe.view(k_pe.shape[0], 1, -1)
+            DeviceOperator.reshape_and_cache(
+                key=k_nope[: attn_metadata.num_actual_tokens],
+                value=k_pe[: attn_metadata.num_actual_tokens],
+                key_cache=kv_cache[0],
+                value_cache=kv_cache[1],
+                slot_mapping=slot_mapping[: attn_metadata.num_actual_tokens],
+            )
+        return k_li, k_li_scale, o_proj_full_handle
+
     def indexer_select_pre_process(
         self,
         x: torch.Tensor,
@@ -1263,8 +1498,59 @@ class AscendSFAImpl(MLAAttentionImpl):
             AscendAttentionState.SpecDecoding,
         }
 
+        if self.enable_sfa_prolog_v3:
+            if self.enable_dsa_cp:
+                hidden_states, ql_nope, q_pe, q_c, k_nope, k_pe = self._sfa_preprocess_with_prolog_v3_tnd_cache(
+                    hidden_states=hidden_states,
+                    cos=cos,
+                    sin=sin,
+                )
+                k_li, k_li_scale = self.indexer_select_pre_process(x=hidden_states, cos=cos, sin=sin)
+                wait_for_kv_layer_from_connector(layer_name)
+                k_li, k_li_scale, o_proj_full_handle = self._all_gather_and_cache_dsa_cp_kv(
+                    k_pe=k_pe,
+                    k_nope=k_nope,
+                    k_li=k_li,
+                    k_li_scale=k_li_scale,
+                    kv_cache=kv_cache,
+                    slot_mapping=slot_mapping,
+                    attn_metadata=attn_metadata,
+                    full_gather_o_proj_enabled=full_gather_o_proj_enabled,
+                )
+                k_li = self._get_full_kv(k_li, attn_metadata)
+            elif getattr(self, "pcp_size", 1) > 1:
+                hidden_states, ql_nope, q_pe, q_c, k_nope, k_pe = self._sfa_preprocess_with_prolog_v3_tnd_cache(
+                    hidden_states=hidden_states,
+                    cos=cos,
+                    sin=sin,
+                )
+                k_li, k_li_scale = self.indexer_select_pre_process(x=hidden_states, cos=cos, sin=sin)
+                wait_for_kv_layer_from_connector(layer_name)
+                kv_c_k_pe = torch.cat([k_nope, k_pe], dim=-1)
+                kv_c_k_pe = self._get_full_kv(kv_c_k_pe, attn_metadata)
+                k_nope, k_pe = kv_c_k_pe.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
+                torch_npu._npu_reshape_and_cache(
+                    key=k_nope,
+                    value=k_pe,
+                    key_cache=kv_cache[0],
+                    value_cache=kv_cache[1],
+                    slot_indices=slot_mapping,
+                )
+                k_li = self._get_full_kv(k_li, attn_metadata)
+            else:
+                hidden_states, ql_nope, q_pe, q_c, _, _ = self._sfa_preprocess_with_prolog_v3(
+                    hidden_states=hidden_states,
+                    kv_cache=kv_cache[:2],
+                    cos=cos,
+                    sin=sin,
+                    slot_mapping=slot_mapping,
+                    cache_mode="PA_BSND",
+                )
+                k_li, k_li_scale = self.indexer_select_pre_process(x=hidden_states, cos=cos, sin=sin)
+                wait_for_kv_layer_from_connector(layer_name)
+                k_li = self._get_full_kv(k_li, attn_metadata)
         # run mlapo ops when dsa-cp is disabled, and ensure that num_tokens satisfies the count limitation
-        if self.enable_mlapo and (
+        elif self.enable_mlapo and (
             get_ascend_device_type() == AscendDeviceType.A5 or num_input_tokens <= MLAPO_MAX_SUPPORTED_TOKENS
         ):
             hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -24,6 +24,7 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.context_parallel.common_cp import AscendPCPMetadata
+from vllm_ascend.core.kv_cache_interface import SFA_QSFA_TILE_SIZE, get_sfa_qsfa_packed_head_dim
 from vllm_ascend.attention.mla_v1 import MAX_O_PROJ_PREFETCH_SIZE, MLAPO_MAX_SUPPORTED_TOKENS
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
@@ -500,6 +501,27 @@ class AscendSFAImpl(MLAAttentionImpl):
         # NOTE: it imposes a limit on the number of input tokens and conflicts with FlashComm
         self.enable_mlapo = ascend_config.enable_mlapo
         self.enable_sfa_prolog_v3 = ascend_config.enable_sfa_prolog_v3
+        enable_sfa_qsfa = getattr(ascend_config, "enable_sfa_kv_quant_sparse_attention", False)
+        enable_sfa_qsfa = enable_sfa_qsfa if isinstance(enable_sfa_qsfa, bool) else False
+        self.enable_sfa_kv_quant_sparse_attention = (
+            enable_sfa_qsfa
+            and self.enable_sfa_prolog_v3
+            and get_ascend_device_type() != AscendDeviceType.A5
+        )
+        if enable_sfa_qsfa and not self.enable_sfa_prolog_v3:
+            logger.warning_once("SFA KV-quant sparse attention requires SFA mla_prolog_v3 and is disabled.")
+        if enable_sfa_qsfa and get_ascend_device_type() == AscendDeviceType.A5:
+            logger.warning_once("SFA KV-quant sparse attention currently targets int8 KV cache and is disabled on A5.")
+        self.sfa_qsfa_tile_size = SFA_QSFA_TILE_SIZE
+        self.sfa_qsfa_packed_kv_head_dim = (
+            get_sfa_qsfa_packed_head_dim(
+                self.kv_lora_rank,
+                self.qk_rope_head_dim,
+                self.sfa_qsfa_tile_size,
+            )
+            if self.enable_sfa_kv_quant_sparse_attention
+            else 0
+        )
 
         assert self.indexer is not None, "Indexer is required for DSA."
 
@@ -639,7 +661,13 @@ class AscendSFAImpl(MLAAttentionImpl):
             if getattr(self.q_proj, "_chunk_size", 0):
                 reasons.append("SFA mla_prolog_v3 does not support chunked q_proj weights yet.")
             if reasons:
+                if self.enable_sfa_kv_quant_sparse_attention:
+                    raise RuntimeError(
+                        "SFA KV-quant sparse attention requires a valid mla_prolog_v3 path: "
+                        + " ".join(reasons)
+                    )
                 self.enable_sfa_prolog_v3 = False
+                self.enable_sfa_kv_quant_sparse_attention = False
                 for msg in reasons:
                     logger.warning_once(msg)
             else:
@@ -1181,6 +1209,15 @@ class AscendSFAImpl(MLAAttentionImpl):
             "qc_qr_scale": 1.0,
             "kc_scale": 1.0,
         }
+        if self.enable_sfa_kv_quant_sparse_attention:
+            prolog_kwargs.update(
+                {
+                    "kv_cache_quant_mode": 3,
+                    "ckvkr_repo_mode": 1,
+                    "quant_scale_repo_mode": 1,
+                    "tile_size": self.sfa_qsfa_tile_size,
+                }
+            )
         if cache_mode == "PA_BSND":
             prolog_kwargs["cache_index"] = slot_mapping.view(-1).to(torch.int64)
 
@@ -1201,16 +1238,28 @@ class AscendSFAImpl(MLAAttentionImpl):
         cos: torch.Tensor,
         sin: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        k_nope = torch.empty(
-            (hidden_states.shape[0], self.num_kv_heads, self.kv_lora_rank),
-            dtype=hidden_states.dtype,
-            device=hidden_states.device,
-        )
-        k_pe = torch.empty(
-            (hidden_states.shape[0], self.num_kv_heads, self.qk_rope_head_dim),
-            dtype=hidden_states.dtype,
-            device=hidden_states.device,
-        )
+        if self.enable_sfa_kv_quant_sparse_attention:
+            k_nope = torch.empty(
+                (hidden_states.shape[0], self.num_kv_heads, self.sfa_qsfa_packed_kv_head_dim),
+                dtype=torch.int8,
+                device=hidden_states.device,
+            )
+            k_pe = torch.empty(
+                (hidden_states.shape[0], self.num_kv_heads, 0),
+                dtype=torch.bfloat16,
+                device=hidden_states.device,
+            )
+        else:
+            k_nope = torch.empty(
+                (hidden_states.shape[0], self.num_kv_heads, self.kv_lora_rank),
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+            k_pe = torch.empty(
+                (hidden_states.shape[0], self.num_kv_heads, self.qk_rope_head_dim),
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
         hidden_states, ql_nope, q_pe, q_c, k_nope, k_pe = self._sfa_preprocess_with_prolog_v3(
             hidden_states=hidden_states,
             kv_cache=(k_nope, k_pe),
@@ -1235,6 +1284,50 @@ class AscendSFAImpl(MLAAttentionImpl):
         full_gather_o_proj_enabled: bool,
     ) -> tuple[torch.Tensor, torch.Tensor | None, torch.distributed.Work | None]:
         async_op = self.enable_dsa_cp_with_layer_shard or full_gather_o_proj_enabled
+        if self.enable_sfa_kv_quant_sparse_attention:
+            packed_kv, packed_kv_handle = all_gather_async(
+                k_nope.view(-1, k_nope.shape[-1]),
+                get_tp_group(),
+                async_op=async_op,
+            )
+            k_li, k_li_handle = all_gather_async(
+                k_li,
+                get_tp_group(),
+                async_op=async_op,
+            )
+            k_li_scale_handle = None
+            if self.use_sparse_c8_indexer:
+                assert k_li_scale is not None
+                k_li_scale, k_li_scale_handle = all_gather_async(
+                    k_li_scale,
+                    get_tp_group(),
+                    async_op=async_op,
+                )
+
+            for handle in (packed_kv_handle, k_li_handle, k_li_scale_handle):
+                if handle is not None:
+                    handle.wait()
+
+            o_proj_full_handle = None
+            if self.enable_dsa_cp_with_layer_shard:
+                for layer in self.layer_sharding_kwargs or []:
+                    if is_hidden_layer(layer):
+                        reach_layer_for_shard_weight_series(layer)
+            elif full_gather_o_proj_enabled:
+                _, o_proj_full_handle = all_gather_async(
+                    self.o_proj_tp_weight,
+                    get_tp_group(),
+                    output=AscendSFAImpl.o_proj_full_pool,
+                )
+
+            if kv_cache is not None:
+                torch_npu.npu_scatter_nd_update_(
+                    kv_cache[0].view(-1, packed_kv.shape[-1]),
+                    slot_mapping[: attn_metadata.num_actual_tokens].view(-1, 1),
+                    packed_kv[: attn_metadata.num_actual_tokens].view(-1, packed_kv.shape[-1]),
+                )
+            return k_li, k_li_scale, o_proj_full_handle
+
         if not self.use_sparse_c8_indexer:
             fused_kv_no_split, kv_ag_handle = all_gather_async(
                 torch.cat(
@@ -1442,6 +1535,16 @@ class AscendSFAImpl(MLAAttentionImpl):
     def _execute_sparse_flash_attention_process(
         self, ql_nope, q_pe, kv_cache, topk_indices, attn_metadata, actual_seq_lengths_query, actual_seq_lengths_key
     ):
+        if self.enable_sfa_kv_quant_sparse_attention:
+            return self._execute_kv_quant_sparse_flash_attention(
+                ql_nope=ql_nope,
+                q_pe=q_pe,
+                kv=kv_cache[0],
+                block_table=attn_metadata.block_table,
+                topk_indices=topk_indices,
+                actual_seq_lengths_query=actual_seq_lengths_query,
+                actual_seq_lengths_key=actual_seq_lengths_key,
+            )
         return DeviceOperator.execute_sparse_flash_attention_process(
             self,
             ql_nope,
@@ -1451,6 +1554,40 @@ class AscendSFAImpl(MLAAttentionImpl):
             attn_metadata,
             actual_seq_lengths_query,
             actual_seq_lengths_key,
+        )
+
+    def _execute_kv_quant_sparse_flash_attention(
+        self,
+        ql_nope: torch.Tensor,
+        q_pe: torch.Tensor,
+        kv: torch.Tensor,
+        block_table: torch.Tensor,
+        topk_indices: torch.Tensor,
+        actual_seq_lengths_query: torch.Tensor,
+        actual_seq_lengths_key: torch.Tensor,
+    ) -> torch.Tensor:
+        query = torch.cat([ql_nope, q_pe], dim=-1).contiguous()
+        return torch_npu.npu_kv_quant_sparse_flash_attention(
+            query=query,
+            key=kv,
+            value=kv,
+            sparse_indices=topk_indices,
+            scale_value=self.scale,
+            key_dequant_scale=None,
+            value_dequant_scale=None,
+            sparse_block_size=1,
+            block_table=block_table,
+            actual_seq_lengths_query=actual_seq_lengths_query,
+            actual_seq_lengths_kv=actual_seq_lengths_key,
+            layout_query="TND",
+            layout_kv="PA_BSND",
+            sparse_mode=3,
+            attention_mode=2,
+            quant_scale_repo_mode=1,
+            tile_size=self.sfa_qsfa_tile_size,
+            key_quant_mode=2,
+            value_quant_mode=2,
+            rope_head_dim=self.qk_rope_head_dim,
         )
 
     def forward(
@@ -1526,16 +1663,24 @@ class AscendSFAImpl(MLAAttentionImpl):
                 )
                 k_li, k_li_scale = self.indexer_select_pre_process(x=hidden_states, cos=cos, sin=sin)
                 wait_for_kv_layer_from_connector(layer_name)
-                kv_c_k_pe = torch.cat([k_nope, k_pe], dim=-1)
-                kv_c_k_pe = self._get_full_kv(kv_c_k_pe, attn_metadata)
-                k_nope, k_pe = kv_c_k_pe.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
-                torch_npu._npu_reshape_and_cache(
-                    key=k_nope,
-                    value=k_pe,
-                    key_cache=kv_cache[0],
-                    value_cache=kv_cache[1],
-                    slot_indices=slot_mapping,
-                )
+                if self.enable_sfa_kv_quant_sparse_attention:
+                    packed_kv = self._get_full_kv(k_nope, attn_metadata)
+                    torch_npu.npu_scatter_nd_update_(
+                        kv_cache[0].view(-1, packed_kv.shape[-1]),
+                        slot_mapping.view(-1, 1),
+                        packed_kv.view(-1, packed_kv.shape[-1]),
+                    )
+                else:
+                    kv_c_k_pe = torch.cat([k_nope, k_pe], dim=-1)
+                    kv_c_k_pe = self._get_full_kv(kv_c_k_pe, attn_metadata)
+                    k_nope, k_pe = kv_c_k_pe.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
+                    torch_npu._npu_reshape_and_cache(
+                        key=k_nope,
+                        value=k_pe,
+                        key_cache=kv_cache[0],
+                        value_cache=kv_cache[1],
+                        slot_indices=slot_mapping,
+                    )
                 k_li = self._get_full_kv(k_li, attn_metadata)
             else:
                 hidden_states, ql_nope, q_pe, q_c, _, _ = self._sfa_preprocess_with_prolog_v3(

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -522,6 +522,7 @@ class AscendSFAImpl(MLAAttentionImpl):
             if self.enable_sfa_kv_quant_sparse_attention
             else 0
         )
+        self.sfa_qsfa_k_nope_clip_alpha: torch.Tensor | None = None
 
         assert self.indexer is not None, "Indexer is required for DSA."
 
@@ -661,15 +662,15 @@ class AscendSFAImpl(MLAAttentionImpl):
             if getattr(self.q_proj, "_chunk_size", 0):
                 reasons.append("SFA mla_prolog_v3 does not support chunked q_proj weights yet.")
             if reasons:
-                if self.enable_sfa_kv_quant_sparse_attention:
-                    raise RuntimeError(
-                        "SFA KV-quant sparse attention requires a valid mla_prolog_v3 path: "
-                        + " ".join(reasons)
-                    )
                 self.enable_sfa_prolog_v3 = False
                 self.enable_sfa_kv_quant_sparse_attention = False
+                self.sfa_qsfa_packed_kv_head_dim = 0
+
                 for msg in reasons:
-                    logger.warning_once(msg)
+                    logger.warning_once(
+                        f"{msg} Disable SFA mla_prolog_v3 / KV-quant sparse attention "
+                        f"for layer {self.layer_name}; fallback to original sparse attention."
+                    )
             else:
                 self._process_weights_for_fused_prolog_v3()
         elif self.enable_mlapo:
@@ -745,7 +746,12 @@ class AscendSFAImpl(MLAAttentionImpl):
         self.dequant_scale_w_dq = q_a_proj_deq_scl.view(1, -1).to(torch.float)
         self.dequant_scale_w_dkv_kr = kv_a_proj_deq_scl.view(1, -1).to(torch.float)
         self.dequant_scale_w_uq_qr = self.q_proj.weight_scale.data.view(1, -1).to(torch.float)
-
+        if self.enable_sfa_kv_quant_sparse_attention:
+            self.sfa_qsfa_k_nope_clip_alpha = torch.ones(
+                1,
+                dtype=torch.float32,
+                device=self.weight_dq.device,
+            )
     # Processing the input parameters for MLAPO by reordering and transposing
     # QKV(and part of Q) weight, applying RoPE-related dimension transformations,
     # and handling quantization parameters.
@@ -1216,6 +1222,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                     "ckvkr_repo_mode": 1,
                     "quant_scale_repo_mode": 1,
                     "tile_size": self.sfa_qsfa_tile_size,
+                    "k_nope_clip_alpha": self.sfa_qsfa_k_nope_clip_alpha,
                 }
             )
         if cache_mode == "PA_BSND":

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -24,6 +24,24 @@ def _get_c8_k_scale_cache_dtype() -> torch.dtype:
     return torch.float32 if get_ascend_device_type() == AscendDeviceType.A5 else torch.float16
 
 
+SFA_QSFA_TILE_SIZE = 128
+SFA_QSFA_KV_CACHE_DTYPE = torch.int8
+
+
+def get_sfa_qsfa_packed_head_dim(
+    kv_lora_rank: int,
+    qk_rope_head_dim: int,
+    tile_size: int = SFA_QSFA_TILE_SIZE,
+) -> int:
+    if kv_lora_rank % tile_size != 0:
+        raise ValueError(
+            f"kv_lora_rank must be divisible by tile_size for SFA QSFA packed cache, "
+            f"got {kv_lora_rank=} and {tile_size=}."
+        )
+    scale_metadata_bytes = (kv_lora_rank // tile_size) * get_dtype_size(torch.float32)
+    return kv_lora_rank + qk_rope_head_dim * get_dtype_size(torch.bfloat16) + scale_metadata_bytes
+
+
 @dataclass(frozen=True, kw_only=True)
 class AscendMLAAttentionSpec(MLAAttentionSpec):
     """MLAAttentionSpec extended to support DSA models, with optional Sparse C8 support.
@@ -54,11 +72,33 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
     scale_dtype: torch.dtype = torch.int8
     sparse_head_dim: tuple[int, ...] | None = None
     cache_sparse_c8: bool = False
+    cache_sfa_kv_quant_sparse_attention: bool = False
     c8_k_cache_dtype: torch.dtype = field(default_factory=_get_c8_k_cache_dtype)
     c8_k_scale_cache_dtype: torch.dtype = field(default_factory=_get_c8_k_scale_cache_dtype)
+    sfa_qsfa_kv_cache_dtype: torch.dtype = SFA_QSFA_KV_CACHE_DTYPE
 
     @property
     def page_size_bytes(self) -> int:
+        if self.cache_sfa_kv_quant_sparse_attention:
+            assert self.sparse_head_dim is not None
+            assert len(self.sparse_head_dim) == 3
+            num_heads_per_page = self.block_size * self.num_kv_heads
+            packed_kv_head_dim, qk_rope_head_dim, index_head_dim = self.sparse_head_dim
+            assert qk_rope_head_dim == 0
+
+            kv_bytes = (
+                num_heads_per_page
+                * packed_kv_head_dim
+                * get_dtype_size(self.sfa_qsfa_kv_cache_dtype)
+            )
+            index_dtype = self.c8_k_cache_dtype if self.cache_sparse_c8 else self.dtype
+            qli_bytes = num_heads_per_page * index_head_dim * get_dtype_size(index_dtype)
+            if not self.cache_sparse_c8:
+                return kv_bytes + qli_bytes
+
+            qli_scale_bytes = num_heads_per_page * get_dtype_size(self.c8_k_scale_cache_dtype)
+            return kv_bytes + qli_bytes + qli_scale_bytes
+
         if self.cache_sparse_c8:
             assert self.sparse_head_dim is not None
             assert len(self.sparse_head_dim) == 3
@@ -87,7 +127,7 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
         )
 
     @property
-    def sparse_kv_cache_ratio(self) -> tuple[float, float, float, float | None]:
+    def sparse_kv_cache_ratio(self) -> tuple[float, float | None, float, float | None]:
         """
         Compute the relative byte share of each KV cache entry.
 
@@ -100,6 +140,30 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
         """
 
         assert self.sparse_head_dim is not None
+
+        if self.cache_sfa_kv_quant_sparse_attention:
+            packed_kv_head_dim, qk_rope_head_dim, index_k_head_dim = self.sparse_head_dim
+            assert qk_rope_head_dim == 0
+
+            packed_kv_virtual = packed_kv_head_dim * get_dtype_size(self.sfa_qsfa_kv_cache_dtype)
+            index_dtype = self.c8_k_cache_dtype if self.cache_sparse_c8 else self.dtype
+            index_k_virtual = index_k_head_dim * get_dtype_size(index_dtype)
+            scale_virtual = (
+                get_dtype_size(self.c8_k_scale_cache_dtype)
+                if self.cache_sparse_c8
+                else 0
+            )
+            total_virtual_head_dim = packed_kv_virtual + index_k_virtual + scale_virtual
+            return (
+                total_virtual_head_dim / packed_kv_virtual,  # kv_cache[0]: packed int8 MLA cache
+                None,  # kv_cache[1]: empty kr_cache placeholder
+                total_virtual_head_dim / index_k_virtual,  # kv_cache[2]: DSA indexer key
+                (
+                    total_virtual_head_dim / scale_virtual
+                    if self.cache_sparse_c8
+                    else None
+                ),
+            )
 
         def get_sparse_head_dim_virtual() -> tuple[int, int, int, int]:
             assert self.sparse_head_dim is not None
@@ -170,6 +234,10 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
         assert len(cache_sparse_c8_set) == 1, (
             "All attention layers in the same KV cache group must use the same sparse C8 setting."
         )
+        cache_sfa_qsfa_set = set(spec.cache_sfa_kv_quant_sparse_attention for spec in specs)
+        assert len(cache_sfa_qsfa_set) == 1, (
+            "All attention layers in the same KV cache group must use the same SFA KV-quant sparse attention setting."
+        )
         return cls(
             block_size=specs[0].block_size,
             num_kv_heads=specs[0].num_kv_heads,
@@ -180,6 +248,8 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
             dtype=specs[0].dtype,
             cache_dtype_str=cache_dtype_str_set.pop(),
             cache_sparse_c8=specs[0].cache_sparse_c8,
+            cache_sfa_kv_quant_sparse_attention=specs[0].cache_sfa_kv_quant_sparse_attention,
+            sfa_qsfa_kv_cache_dtype=specs[0].sfa_qsfa_kv_cache_dtype,
         )
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -85,6 +85,8 @@ env_variables: dict[str, Callable[[], Any]] = {
     # it will consume more NPU memory. If reducing NPU memory usage is a higher priority
     # for your DeepSeek W8A8 scene, then disable it.
     "VLLM_ASCEND_ENABLE_MLAPO": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_MLAPO", "1"))),
+    # Whether to enable SFA preprocessing with mla_prolog_v3.
+    "VLLM_ASCEND_ENABLE_SFA_PROLOG_V3": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_SFA_PROLOG_V3", "0"))),
     # Whether to enable weight cast format to FRACTAL_NZ.
     # 0: close nz;
     # 1: only quant case enable nz;

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -87,6 +87,10 @@ env_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ASCEND_ENABLE_MLAPO": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_MLAPO", "1"))),
     # Whether to enable SFA preprocessing with mla_prolog_v3.
     "VLLM_ASCEND_ENABLE_SFA_PROLOG_V3": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_SFA_PROLOG_V3", "0"))),
+    # Whether to enable SFA attention with MLA-prolog packed int8 KV cache.
+    "VLLM_ASCEND_ENABLE_SFA_KV_QUANT_SPARSE_ATTENTION": lambda: bool(
+        int(os.getenv("VLLM_ASCEND_ENABLE_SFA_KV_QUANT_SPARSE_ATTENTION", "0"))
+    ),
     # Whether to enable weight cast format to FRACTAL_NZ.
     # 0: close nz;
     # 1: only quant case enable nz;

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1583,6 +1583,14 @@ def kv_cache_spec_uses_sparse_c8(kv_cache_spec) -> bool:
     return isinstance(kv_cache_spec, AscendMLAAttentionSpec) and bool(getattr(kv_cache_spec, "cache_sparse_c8", False))
 
 
+def kv_cache_spec_uses_sfa_kv_quant_sparse_attention(kv_cache_spec) -> bool:
+    from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
+
+    return isinstance(kv_cache_spec, AscendMLAAttentionSpec) and bool(
+        getattr(kv_cache_spec, "cache_sfa_kv_quant_sparse_attention", False)
+    )
+
+
 def is_hidden_state_cache_spec(spec) -> bool:
     """Whether ``spec`` marks an ``extract_hidden_states`` cache-only layer."""
     from vllm.v1.kv_cache_interface import HiddenStateCacheSpec

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -154,6 +154,7 @@ from vllm_ascend.utils import (
     global_stream,
     is_hidden_state_cache_spec,
     kv_cache_spec_uses_sparse_c8,
+    kv_cache_spec_uses_sfa_kv_quant_sparse_attention,
     lmhead_tp_enable,
     set_weight_prefetch_method,
     should_skip_allreduce_across_dp_group,
@@ -182,7 +183,11 @@ else:
 
 from vllm.model_executor.layers.attention import Attention, MLAAttention
 
-from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSlidingWindowMLASpec
+from vllm_ascend.core.kv_cache_interface import (
+    AscendMLAAttentionSpec,
+    AscendSlidingWindowMLASpec,
+    get_sfa_qsfa_packed_head_dim,
+)
 
 # if true, allow tensor initialization and casting with internal format (e.g., NZ)
 torch.npu.config.allow_internal_format = True
@@ -352,8 +357,33 @@ class NPUModelRunner(GPUModelRunner):
         ) and not hasattr(
             vllm_config.model_config.hf_text_config, "compress_ratios"
         )
+        enable_sfa_qsfa = getattr(self.ascend_config, "enable_sfa_kv_quant_sparse_attention", False)
+        enable_sfa_qsfa = enable_sfa_qsfa if isinstance(enable_sfa_qsfa, bool) else False
+        self.enable_sfa_kv_quant_sparse_attention = (
+            enable_sfa_qsfa
+            and self.ascend_config.enable_sfa_prolog_v3
+            and get_ascend_device_type() != AscendDeviceType.A5
+        )
+        if enable_sfa_qsfa and not self.ascend_config.enable_sfa_prolog_v3:
+            logger.warning_once(
+                "SFA KV-quant sparse attention requires SFA mla_prolog_v3 and is disabled."
+            )
+        if enable_sfa_qsfa and get_ascend_device_type() == AscendDeviceType.A5:
+            logger.warning_once(
+                "SFA KV-quant sparse attention currently targets int8 KV cache and is disabled on A5."
+            )
         if self.use_sparse:
-            if get_ascend_device_type() == AscendDeviceType.A5 and self.ascend_config.enable_sparse_c8:
+            if self.enable_sfa_kv_quant_sparse_attention:
+                packed_kv_head_dim = get_sfa_qsfa_packed_head_dim(
+                    self.model_config.hf_text_config.kv_lora_rank,
+                    self.model_config.hf_text_config.qk_rope_head_dim,
+                )
+                self.sparse_head_dim = (
+                    packed_kv_head_dim,
+                    0,
+                    self.model_config.hf_text_config.index_head_dim,
+                )
+            elif get_ascend_device_type() == AscendDeviceType.A5 and self.ascend_config.enable_sparse_c8:
                 # A5 sparse C8: kv_lora and k_rope are merged into a single CKV FP8 tensor.
                 # qk_rope_head_dim = 0 signals the merged layout.
                 # ckv_dim = kv_lora_rank                    (fp8, 1 byte/elem)
@@ -4136,11 +4166,17 @@ class NPUModelRunner(GPUModelRunner):
                         # for deepseek v3.2, we split the kv cache according to the corresponding ratio
                         kv_cache_spec = layer_kv_cache_spec[layer_name]
                         current_sparse_c8 = kv_cache_spec_uses_sparse_c8(kv_cache_spec)
+                        current_sfa_qsfa = kv_cache_spec_uses_sfa_kv_quant_sparse_attention(kv_cache_spec)
                         sparse_kv_cache_ratio = kv_cache_spec.sparse_kv_cache_ratio
                         
                         # A5 sparse C8: (ckv_ratio, qli_ratio, qli_scale_ratio, None)
                         # A3 sparse C8: (k_ratio, v_ratio, qli_ratio, qli_scale_ratio)
-                        if current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
+                        if current_sfa_qsfa:
+                            k_tensor_split_factor = sparse_kv_cache_ratio[0]  # packed int8 MLA cache
+                            v_tensor_split_factor = None  # empty kr_cache placeholder
+                            dsa_k_tensor_split_factor = sparse_kv_cache_ratio[2]
+                            dsa_k_scale_tensor_split_factor = sparse_kv_cache_ratio[3] if current_sparse_c8 else None
+                        elif current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
                             k_tensor_split_factor = sparse_kv_cache_ratio[0]  # ckv
                             v_tensor_split_factor = None  # merged
                             dsa_k_tensor_split_factor = sparse_kv_cache_ratio[1]  # qli_tensor
@@ -4192,6 +4228,8 @@ class NPUModelRunner(GPUModelRunner):
                             v_tensor_size,
                             alignment,
                         )
+                    elif self.use_sparse and current_sfa_qsfa:
+                        v_tensor = torch.empty(0, dtype=torch.int8, device=self.device)
 
                     if self.use_sparse:
                         assert dsa_k_tensor_size is not None
@@ -4365,10 +4403,24 @@ class NPUModelRunner(GPUModelRunner):
                     # unpack them as a (k, v, dsa_k[, scale]) tuple.
                     if self.use_sparse and "cache_only_layers" not in layer_name:
                         current_sparse_c8 = kv_cache_spec_uses_sparse_c8(current_kv_cache_spec)
+                        current_sfa_qsfa = kv_cache_spec_uses_sfa_kv_quant_sparse_attention(current_kv_cache_spec)
                         if current_sparse_c8:
-                            if get_ascend_device_type() == AscendDeviceType.A5:
-                                raw_k_tensor, raw_dsa_k_tensor, raw_dsa_k_scale_tensor = kv_cache_raw_tensors[  # type: ignore
-                                    layer_name]
+                            if current_sfa_qsfa:
+                                raw_k_tensor, raw_v_tensor, raw_dsa_k_tensor, raw_dsa_k_scale_tensor = (
+                                    kv_cache_raw_tensors[layer_name]  # type: ignore
+                                )
+                                assert raw_dsa_k_tensor is not None
+                                assert raw_dsa_k_scale_tensor is not None
+                                sum_page_size_bytes = (
+                                    raw_k_tensor.numel()
+                                    + raw_v_tensor.numel()
+                                    + raw_dsa_k_tensor.numel()
+                                    + raw_dsa_k_scale_tensor.numel()
+                                )
+                            elif get_ascend_device_type() == AscendDeviceType.A5:
+                                raw_k_tensor, raw_dsa_k_tensor, raw_dsa_k_scale_tensor = (
+                                    kv_cache_raw_tensors[layer_name]  # type: ignore
+                                )
                                 assert raw_dsa_k_tensor is not None
                                 assert raw_dsa_k_scale_tensor is not None
                                 sum_page_size_bytes = (
@@ -4513,7 +4565,16 @@ class NPUModelRunner(GPUModelRunner):
                             num_kv_heads,
                             k_dim,
                         )
-                        if self.use_sparse and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
+                        if self.use_sparse and current_sfa_qsfa:
+                            assert current_kv_cache_spec.sparse_head_dim is not None
+                            k_shape = (
+                                mla_num_blocks,
+                                mla_block_size,
+                                num_kv_heads,
+                                current_kv_cache_spec.sparse_head_dim[0],
+                            )
+                            v_dim = 0
+                        elif self.use_sparse and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
                             # A5 sparse C8: CKV tensor = kv_lora(fp8) + k_rope(bf16→fp8) + quant_scale_metadata
                             #   kv_lora_rank                    : fp8, 1 byte/elem
                             #   qk_rope_head_dim * 2            : bf16→fp8 ratio (2/1 bytes)
@@ -4538,8 +4599,11 @@ class NPUModelRunner(GPUModelRunner):
                             layer_name, current_kv_cache_spec.dtype, self.model_config
                         )
                     
+                    if self.use_sparse and current_sfa_qsfa:
+                        k_cache_dtype = current_kv_cache_spec.sfa_qsfa_kv_cache_dtype
+                        v_cache_dtype = torch.bfloat16
                     # A5 sparse C8: ckv uses float8_e4m3fn
-                    if self.use_sparse and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
+                    elif self.use_sparse and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
                         k_cache_dtype = self.c8_k_cache_dtype
                     
                     k_cache = raw_k_tensor.view(k_cache_dtype).view(k_shape)
@@ -4865,6 +4929,9 @@ class NPUModelRunner(GPUModelRunner):
                         dtype=self.kv_cache_dtype,
                         cache_dtype_str=self.vllm_config.cache_config.cache_dtype,
                         cache_sparse_c8=self.ascend_config.is_sparse_c8_layer(layer_name),
+                        cache_sfa_kv_quant_sparse_attention=(
+                            self.enable_sfa_kv_quant_sparse_attention
+                        ),
                     )
                 elif spec := attn_module.get_kv_cache_spec(self.vllm_config):
                     if getattr(attn_module.impl, "fa_quant_layer", False):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -373,17 +373,7 @@ class NPUModelRunner(GPUModelRunner):
                 "SFA KV-quant sparse attention currently targets int8 KV cache and is disabled on A5."
             )
         if self.use_sparse:
-            if self.enable_sfa_kv_quant_sparse_attention:
-                packed_kv_head_dim = get_sfa_qsfa_packed_head_dim(
-                    self.model_config.hf_text_config.kv_lora_rank,
-                    self.model_config.hf_text_config.qk_rope_head_dim,
-                )
-                self.sparse_head_dim = (
-                    packed_kv_head_dim,
-                    0,
-                    self.model_config.hf_text_config.index_head_dim,
-                )
-            elif get_ascend_device_type() == AscendDeviceType.A5 and self.ascend_config.enable_sparse_c8:
+            if get_ascend_device_type() == AscendDeviceType.A5 and self.ascend_config.enable_sparse_c8:
                 # A5 sparse C8: kv_lora and k_rope are merged into a single CKV FP8 tensor.
                 # qk_rope_head_dim = 0 signals the merged layout.
                 # ckv_dim = kv_lora_rank                    (fp8, 1 byte/elem)
@@ -4167,25 +4157,70 @@ class NPUModelRunner(GPUModelRunner):
                         kv_cache_spec = layer_kv_cache_spec[layer_name]
                         current_sparse_c8 = kv_cache_spec_uses_sparse_c8(kv_cache_spec)
                         current_sfa_qsfa = kv_cache_spec_uses_sfa_kv_quant_sparse_attention(kv_cache_spec)
-                        sparse_kv_cache_ratio = kv_cache_spec.sparse_kv_cache_ratio
-                        
-                        # A5 sparse C8: (ckv_ratio, qli_ratio, qli_scale_ratio, None)
-                        # A3 sparse C8: (k_ratio, v_ratio, qli_ratio, qli_scale_ratio)
                         if current_sfa_qsfa:
-                            k_tensor_split_factor = sparse_kv_cache_ratio[0]  # packed int8 MLA cache
-                            v_tensor_split_factor = None  # empty kr_cache placeholder
-                            dsa_k_tensor_split_factor = sparse_kv_cache_ratio[2]
-                            dsa_k_scale_tensor_split_factor = sparse_kv_cache_ratio[3] if current_sparse_c8 else None
-                        elif current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
-                            k_tensor_split_factor = sparse_kv_cache_ratio[0]  # ckv
-                            v_tensor_split_factor = None  # merged
-                            dsa_k_tensor_split_factor = sparse_kv_cache_ratio[1]  # qli_tensor
-                            dsa_k_scale_tensor_split_factor = sparse_kv_cache_ratio[2]  # qli_scale
+                            assert isinstance(kv_cache_spec, AscendMLAAttentionSpec)
+                            assert kv_cache_spec.sparse_head_dim is not None
+                            assert kv_cache_tensor.size % kv_cache_spec.page_size_bytes == 0, (
+                                "SFA QSFA KV cache tensor size must be a multiple of page_size_bytes, "
+                                f"got size={kv_cache_tensor.size}, page_size_bytes={kv_cache_spec.page_size_bytes}"
+                            )
+                            num_blocks_for_tensor = kv_cache_tensor.size // kv_cache_spec.page_size_bytes
+                            packed_kv_head_dim, qk_rope_head_dim, index_head_dim = kv_cache_spec.sparse_head_dim
+                            assert qk_rope_head_dim == 0
+                            num_heads_per_page = kv_cache_spec.block_size * kv_cache_spec.num_kv_heads
+
+                            k_tensor_size = (
+                                num_blocks_for_tensor
+                                * num_heads_per_page
+                                * packed_kv_head_dim
+                                * get_dtype_size(kv_cache_spec.sfa_qsfa_kv_cache_dtype)
+                            )
+                            v_tensor_size = None
+                            index_dtype = kv_cache_spec.c8_k_cache_dtype if current_sparse_c8 else kv_cache_spec.dtype
+                            dsa_k_tensor_size = (
+                                num_blocks_for_tensor
+                                * num_heads_per_page
+                                * index_head_dim
+                                * get_dtype_size(index_dtype)
+                            )
+                            dsa_k_scale_tensor_size = (
+                                num_blocks_for_tensor
+                                * num_heads_per_page
+                                * get_dtype_size(kv_cache_spec.c8_k_scale_cache_dtype)
+                                if current_sparse_c8
+                                else None
+                            )
                         else:
-                            k_tensor_split_factor = sparse_kv_cache_ratio[0]
-                            v_tensor_split_factor = sparse_kv_cache_ratio[1]
-                            dsa_k_tensor_split_factor = sparse_kv_cache_ratio[2]
-                            dsa_k_scale_tensor_split_factor = sparse_kv_cache_ratio[3] if current_sparse_c8 else None
+                            sparse_kv_cache_ratio = kv_cache_spec.sparse_kv_cache_ratio
+
+                            # A5 sparse C8: (ckv_ratio, qli_ratio, qli_scale_ratio, None)
+                            # A3 sparse C8: (k_ratio, v_ratio, qli_ratio, qli_scale_ratio)
+                            if current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
+                                k_tensor_split_factor = sparse_kv_cache_ratio[0]  # ckv
+                                v_tensor_split_factor = None  # merged
+                                dsa_k_tensor_split_factor = sparse_kv_cache_ratio[1]  # qli_tensor
+                                dsa_k_scale_tensor_split_factor = sparse_kv_cache_ratio[2]  # qli_scale
+                            else:
+                                k_tensor_split_factor = sparse_kv_cache_ratio[0]
+                                v_tensor_split_factor = sparse_kv_cache_ratio[1]
+                                dsa_k_tensor_split_factor = sparse_kv_cache_ratio[2]
+                                dsa_k_scale_tensor_split_factor = (
+                                    sparse_kv_cache_ratio[3]
+                                    if current_sparse_c8
+                                    else None
+                                )
+
+                            k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
+                            if v_tensor_split_factor is not None:
+                                v_tensor_size = int(kv_cache_tensor.size // v_tensor_split_factor)
+                            else:
+                                v_tensor_size = None
+                            dsa_k_tensor_size = int(kv_cache_tensor.size // dsa_k_tensor_split_factor)
+                            dsa_k_scale_tensor_size = (
+                                int(kv_cache_tensor.size // dsa_k_scale_tensor_split_factor)
+                                if current_sparse_c8
+                                else None
+                            )
                     else:
                         k_dim, v_dim = self._get_attention_kv_cache_dims(layer_name, current_kv_cache_spec)
                         assert k_dim > 0 and v_dim > 0
@@ -4200,18 +4235,13 @@ class NPUModelRunner(GPUModelRunner):
                         else:
                             k_tensor_split_factor, v_tensor_split_factor = calc_split_factor(kv_head_dim_list)
 
-                    k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
-                    if v_tensor_split_factor is not None:
-                        v_tensor_size = int(kv_cache_tensor.size // v_tensor_split_factor)
-                    else:
-                        v_tensor_size = None
-                    dsa_k_tensor_size = None
-                    dsa_k_scale_tensor_size = None
-                    #### for deepseek sparse attention
-                    if self.use_sparse:
-                        dsa_k_tensor_size = int(kv_cache_tensor.size // dsa_k_tensor_split_factor)
-                    if self.use_sparse and current_sparse_c8:
-                        dsa_k_scale_tensor_size = int(kv_cache_tensor.size // dsa_k_scale_tensor_split_factor)
+                        k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
+                        if v_tensor_split_factor is not None:
+                            v_tensor_size = int(kv_cache_tensor.size // v_tensor_split_factor)
+                        else:
+                            v_tensor_size = None
+                        dsa_k_tensor_size = None
+                        dsa_k_scale_tensor_size = None
 
                     # Allocate raw int8 tensors. Even bf16/fp16 KV cache entries
                     # are allocated as int8 raw bytes first and then viewed as
@@ -4921,17 +4951,37 @@ class NPUModelRunner(GPUModelRunner):
 
             elif isinstance(attn_module, MLAAttention):
                 if self.use_sparse:
+                    impl = attn_module.impl
+
+                    enable_sfa_qsfa_for_layer = bool(
+                        getattr(impl, "enable_sfa_kv_quant_sparse_attention", False)
+                    )
+
+                    if enable_sfa_qsfa_for_layer:
+                        packed_kv_head_dim = getattr(impl, "sfa_qsfa_packed_kv_head_dim", 0)
+                        if packed_kv_head_dim <= 0:
+                            packed_kv_head_dim = get_sfa_qsfa_packed_head_dim(
+                                self.model_config.hf_text_config.kv_lora_rank,
+                                self.model_config.hf_text_config.qk_rope_head_dim,
+                            )
+
+                        sparse_head_dim = (
+                            packed_kv_head_dim,
+                            0,
+                            self.model_config.hf_text_config.index_head_dim,
+                        )
+                    else:
+                        sparse_head_dim = self.sparse_head_dim
+
                     kv_cache_spec[layer_name] = AscendMLAAttentionSpec(
                         block_size=self.block_size,
                         num_kv_heads=1,
-                        head_size=sum(self.sparse_head_dim),
-                        sparse_head_dim=self.sparse_head_dim,
+                        head_size=sum(sparse_head_dim),
+                        sparse_head_dim=sparse_head_dim,
                         dtype=self.kv_cache_dtype,
                         cache_dtype_str=self.vllm_config.cache_config.cache_dtype,
                         cache_sparse_c8=self.ascend_config.is_sparse_c8_layer(layer_name),
-                        cache_sfa_kv_quant_sparse_attention=(
-                            self.enable_sfa_kv_quant_sparse_attention
-                        ),
+                        cache_sfa_kv_quant_sparse_attention=enable_sfa_qsfa_for_layer,
                     )
                 elif spec := attn_module.get_kv_cache_spec(self.vllm_config):
                     if getattr(attn_module.impl, "fa_quant_layer", False):


### PR DESCRIPTION
## Summary

Adds an SFA-specific `mla_prolog_v3` path and extends it to the packed int8 KV-cache case consumed by `torch_npu.npu_kv_quant_sparse_flash_attention`.

This path is intentionally independent from `enable_fa_quant` and the existing `mla_v1.py` flow. It is enabled with:

```bash
VLLM_ASCEND_ENABLE_SFA_PROLOG_V3=1
VLLM_ASCEND_ENABLE_SFA_KV_QUANT_SPARSE_ATTENTION=1
```

## Changes

- Rebased the PR branch onto current `main` (`ab065ffb`) and resolved the `sfa_v1.py` conflict.
- Adds `enable_sfa_prolog_v3` / `VLLM_ASCEND_ENABLE_SFA_PROLOG_V3` config plumbing.
- Adds `enable_sfa_kv_quant_sparse_attention` / `VLLM_ASCEND_ENABLE_SFA_KV_QUANT_SPARSE_ATTENTION` config plumbing.
- Prepares `mla_prolog_v3` weight handles from W8A8 dynamic loaded weights in `sfa_v1.py`.
- Adds the non-quantized KV-cache prolog path with `kv_cache_quant_mode=0`.
- Adds the packed int8 KV-cache path with `kv_cache_quant_mode=3`, `ckvkr_repo_mode=1`, `quant_scale_repo_mode=1`, and `tile_size=128`.
- Extends MLA sparse KV cache spec and model runner allocation so `kv_cache[0]` is packed int8 cache, `kv_cache[1]` is an empty `kr_cache`, and DSA indexer cache remains in later tuple entries.
- Routes SFA and SFA-CP attention to `torch_npu.npu_kv_quant_sparse_flash_attention` when the packed int8 cache path is enabled.
- Keeps A5 on the existing Sparse C8 FP8 CKV path; the new switch targets non-A5 int8 KV cache.
- Adds design documentation under `docs/source/developer_guide/Design_Documents/sfa_mla_prolog_v3_kv_quant.md`.
- Adds unit coverage for config plumbing, packed KV cache allocation, prolog kwargs, and QSFA operator dispatch.

## Validation

- `git diff --check`
- Not run: unit tests, because this local PowerShell environment does not have `python`, `py`, or `uv` on PATH.

## Notes

The packed cache dimension is computed as:

```text
kv_lora_rank + qk_rope_head_dim * 2 + (kv_lora_rank / 128) * 4
```

For the common MLA shape this is `512 + 64 * 2 + 4 * 4 = 656`.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
