### PR TITLE
[Feat][Attention] Support DSA-CP o-proj TP allgather

### DIFF
--- a/csrc/attention/quant_lightning_indexer/op_host/quant_lightning_indexer_tiling.cpp
+++ b/csrc/attention/quant_lightning_indexer/op_host/quant_lightning_indexer_tiling.cpp
@@ -873,13 +873,20 @@ ge::graphStatus QuantLightningIndexerTiling::DoTiling(QLITilingInfo *tilingInfo)
     constexpr uint32_t TOPK_MAX_SIZE = 2048;           // TopK选取个数
     uint32_t workspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
     // 主流程需Workspace大小
-    uint32_t mm1ResSize = M_BASE_SIZE * S2_BASE_SIZE;
-    workspaceSize += mm1ResSize * MM1_RES_ELEM_SIZE * DOUBLE_BUFFER * aicNum;
-    // Decode流程(LD)需要Workspace大小
-    // 临时存储Decode中间结果大小: 2(头/尾)*8(s1Base)*2(idx/value)*2048(K)*sizeof(int32)*24=6M
-    workspaceSize += V1_DECODE_DATA_NUM * S1_BASE_SIZE * V1_RES_ELEM_TYPE * TOPK_MAX_SIZE * V1_RES_ELEM_SIZE * aicNum;
-    // 临时存储Decode中间参数信息大小: 2(头/尾)*8(s1Base)*16(paramNum)*sizeof(int64_t)*24=48k
-    workspaceSize += V1_DECODE_DATA_NUM * S1_BASE_SIZE * V1_DECODE_PARAM_NUM * V1_DECODE_PARAM_ELEM_SIZE * aicNum;
+    platform_ascendc::SocVersion socVersion_ = ascendcPlatform.GetSocVersion();
+    if (socVersion_ == platform_ascendc::SocVersion::ASCEND950) {
+        constexpr uint32_t s1Base = 4;
+        constexpr uint32_t s2Base = 128;
+        workspaceSize += s1Base * ((tilingInfo->s2Size + s2Base - 1) / s2Base) * s2Base * sizeof(uint32_t) * aicNum;
+    } else {
+        uint32_t mm1ResSize = M_BASE_SIZE * S2_BASE_SIZE;
+        workspaceSize += mm1ResSize * MM1_RES_ELEM_SIZE * DOUBLE_BUFFER * aicNum;
+        // Decode流程(LD)需要Workspace大小
+        // 临时存储Decode中间结果大小: 2(头/尾)*8(s1Base)*2(idx/value)*2048(K)*sizeof(int32)*24=6M
+        workspaceSize += V1_DECODE_DATA_NUM * S1_BASE_SIZE * V1_RES_ELEM_TYPE * TOPK_MAX_SIZE * V1_RES_ELEM_SIZE * aicNum;
+        // 临时存储Decode中间参数信息大小: 2(头/尾)*8(s1Base)*16(paramNum)*sizeof(int64_t)*24=48k
+        workspaceSize += V1_DECODE_DATA_NUM * S1_BASE_SIZE * V1_DECODE_PARAM_NUM * V1_DECODE_PARAM_ELEM_SIZE * aicNum;
+    }
     size_t *workSpaces = context_->GetWorkspaceSizes(1);
     workSpaces[0] = workspaceSize;
 

--- a/csrc/attention/quant_lightning_indexer/op_kernel/arch35/quant_lightning_indexer_kernel.h
+++ b/csrc/attention/quant_lightning_indexer/op_kernel/arch35/quant_lightning_indexer_kernel.h
@@ -398,9 +398,11 @@ __aicore__ inline void QLIPreload<QLIT>::Init(__gm__ uint8_t *query, __gm__ uint
     uint64_t offset = 0;
     //vec 把整个s2的score存储在GM，大小为s1BaseSize * 16K * 4
     GlobalTensor<SCORE_T> scoreGm; //存放vec核写出的score
-    uint64_t singleCoreScoreSize = constInfo.s1BaseSize * QLICommon::Align((uint64_t)constInfo.kSeqSize, (uint64_t)constInfo.s2BaseSize)  * sizeof(SCORE_T);
-    scoreGm.SetGlobalBuffer((__gm__ SCORE_T *)(workspace + aiCoreIdx * singleCoreScoreSize));
-    offset += GetBlockNum() * singleCoreScoreSize;
+    if ASCEND_IS_AIV {
+        uint64_t singleCoreScoreSize = constInfo.s1BaseSize * QLICommon::Align((uint64_t)constInfo.kSeqSize, (uint64_t)constInfo.s2BaseSize)  * sizeof(SCORE_T);
+        scoreGm.SetGlobalBuffer((__gm__ SCORE_T *)(workspace + aiCoreIdx * singleCoreScoreSize));
+        offset += GetBlockNum() * singleCoreScoreSize;
+    }
 
     if ASCEND_IS_AIV {
         vectorService.InitParams(constInfo, tiling);

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -8,7 +8,6 @@ import torch.nn.functional as F
 import torch_npu
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import get_tp_group
-from vllm.triton_utils import HAS_TRITON
 from vllm.v1.attention.backend import AttentionCGSupport, AttentionMetadataBuilder
 from vllm.v1.kv_cache_interface import AttentionSpec, MLAAttentionSpec
 
@@ -16,6 +15,7 @@ from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
 from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
@@ -26,11 +26,6 @@ from vllm_ascend.utils import (
     npu_stream_switch,
     olora_tp_enable,
 )
-
-if HAS_TRITON:
-    from vllm_ascend.ops.triton.rms_norm import triton_q_rms  # noqa: F811
-else:
-    triton_q_rms = None  # type: ignore
 
 
 def hadamard_transform_ref(
@@ -203,6 +198,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.cu_seqlens_ori_kv = torch.tensor([], device=self.device)
         self.cu_seqlens_cmp_kv = torch.tensor([], device=self.device)
         self.seqused_q = torch.tensor([], device=self.device)
+        self._zero_i32 = torch.tensor([0], device=self.device, dtype=torch.int32)
         self.local_query_start_loc = torch.zeros(
             scheduler_config.max_num_seqs + 1, dtype=torch.int32, device=self.device
         )
@@ -302,9 +298,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             self.seq_lens = self.common_ratio_to_sas_metadata["seq_lens"]
 
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
-        self.slot_mapping[:num_input_tokens] = torch.stack(
-            [slot_mapping // self.block_size, slot_mapping % self.block_size], dim=-1
-        )
+        self.slot_mapping = DeviceOperator.format_dsa_slot_mapping(slot_mapping, self.block_size)
 
         self.block_table = common_attn_metadata.block_table_tensor[:num_reqs]
 
@@ -359,8 +353,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
 
         assert self.spec_slot_mapping is not None
-        self.spec_slot_mapping[draft_step - 1][:num_input_tokens] = torch.stack(
-            [slot_mapping // self.block_size, slot_mapping % self.block_size], dim=-1
+        self.spec_slot_mapping[draft_step - 1] = DeviceOperator.format_dsa_slot_mapping(
+            slot_mapping, self.block_size
         )
 
         self.block_table = common_attn_metadata.block_table_tensor[:num_reqs]
@@ -435,13 +429,31 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         slot_mapping = self.spec_slot_mapping[draft_step - 1][: self.num_actual_tokens]
 
         num_heads = self.model_config.hf_config.num_attention_heads
-        sas_metadata = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
+        metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
+        metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
+        cu_seqlens_ori_kv = (
+            local_query_start_loc
+            if has_prefill
+            else DeviceOperator.get_dsa_decode_cu_seqlens_ori_kv(
+                None,
+                "draft_cu_seqlens_ori_kv",
+                local_seq_lens,
+                num_reqs,
+                self._zero_i32,
+                self.cu_seqlens_ori_kv,
+            )
+        )
+        cu_seqlens_cmp_kv = None if has_prefill else DeviceOperator.get_dsa_decode_cu_seqlens_cmp_kv(
+            self.cu_seqlens_cmp_kv
+        )
+        sas_metadata = metadata_op(
+            **metadata_kwargs,
             num_heads_q=num_heads,
             num_heads_kv=1,
             head_dim=self.model_config.get_head_size(),
             cu_seqlens_q=local_query_start_loc,
-            cu_seqlens_ori_kv=local_query_start_loc if has_prefill else self.cu_seqlens_ori_kv,
-            cu_seqlens_cmp_kv=None,
+            cu_seqlens_ori_kv=cu_seqlens_ori_kv,
+            cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
             seqused_q=self.seqused_q,
             seqused_kv=local_seq_lens,
             max_seqlen_q=max_local_query_len,
@@ -543,17 +555,21 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         # --- Compressed positions ---
         compress_cos, compress_sin = None, None
         cu_cmp_seqlens = self._get_cmp_seqlens_for_metadata(has_prefill)
+        actual_num_tokens = self.num_actual_tokens
+        actual_input_positions_cpu = input_positions_cpu[:actual_num_tokens]
 
         if self.compressor_ratio > 1:
             layer_name = f"c{self.compressor_ratio}"
             compressed_input_positions = self._get_padded_compressed_position(
-                input_positions_cpu, self.compressor_ratio, num_reqs, num_input_tokens
+                actual_input_positions_cpu, self.compressor_ratio, num_reqs, actual_num_tokens
             )
             compress_cos, compress_sin = get_cos_and_sin_dsa(
                 {layer_name: compressed_input_positions}, use_cache=not has_prefill
             )
 
-        slot_mapping_size = self._get_slot_mapping_size(input_positions_cpu, self.compressor_ratio)
+        slot_mapping_size = self._get_slot_mapping_size(
+            actual_input_positions_cpu, self.compressor_ratio, num_reqs, actual_num_tokens
+        )
         slot_mapping = self.slot_mapping[:slot_mapping_size]
 
         # --- SAS metadata (all requests combined) ---
@@ -695,13 +711,14 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             return None
         if has_prefill:
             return None
-        return self.cu_seqlens_cmp_kv
+        return DeviceOperator.get_dsa_decode_cu_seqlens_cmp_kv(self.cu_seqlens_cmp_kv)
 
-    def _get_slot_mapping_size(self, input_positions, compress_ratio):
+    def _get_slot_mapping_size(self, input_positions, compress_ratio, num_reqs, num_input_tokens):
         if compress_ratio <= 1:
             return self.num_actual_tokens
-        mask = ((input_positions + 1) % compress_ratio) == 0
-        return mask.sum()
+        return self._get_padded_compressed_position(
+            input_positions, compress_ratio, num_reqs, num_input_tokens
+        ).shape[0]
 
     def _build_sas_metadata(
         self,
@@ -720,9 +737,25 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         cache_key = f"cp_sas_c{cmp_ratio}"
         metadata = self.common_ratio_to_sas_metadata.get(cache_key)
         if metadata is None:
-            cu_seqlens_ori_kv = query_start_loc if has_prefill else self.cu_seqlens_ori_kv
-            cu_seqlens_cmp_kv = None if has_prefill else self.cu_seqlens_cmp_kv
+            cu_seqlens_ori_kv = (
+                query_start_loc
+                if has_prefill
+                else DeviceOperator.get_dsa_decode_cu_seqlens_ori_kv(
+                    self.common_ratio_to_sas_metadata,
+                    f"{cache_key}_cu_seqlens_ori_kv",
+                    seq_lens,
+                    num_reqs,
+                    self._zero_i32,
+                    self.cu_seqlens_ori_kv,
+                )
+            )
+            cu_seqlens_cmp_kv = None if has_prefill else DeviceOperator.get_dsa_decode_cu_seqlens_cmp_kv(
+                self.cu_seqlens_cmp_kv
+            )
+            metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
+            metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
             kw = dict(
+                **metadata_kwargs,
                 num_heads_q=num_heads,
                 num_heads_kv=1,
                 head_dim=self.model_config.get_head_size(),
@@ -756,7 +789,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 kw["cmp_ratio"] = cmp_ratio
                 kw["has_cmp_kv"] = False
 
-            metadata = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(**kw)
+            metadata = metadata_op(**kw)
         self.common_ratio_to_sas_metadata[cache_key] = metadata
         self.req_sas_metadata[:1024] = metadata
         return self.req_sas_metadata[:1024]
@@ -861,6 +894,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         self.wq_b = kwargs["wq_b"]
         self.wkv = kwargs["wkv"]
         self.q_norm = kwargs["q_norm"]
+        self.q_norm_without_weight = kwargs.get("q_norm_without_weight")
         self.kv_norm = kwargs["kv_norm"]
 
         self.indexer = kwargs.get("indexer")
@@ -937,23 +971,42 @@ class AscendDSACPImpl(DSAAttentionImpl):
         num_tokens = o_proj_input.shape[0]
 
         # o
-        o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, -1)
-        if olora_tp_enable():
-            o_proj_tmp = self.wo_a(o_proj_input)
-        else:
-            # wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
-            # o = torch.einsum("tgd,grd->tgr", o, wo_a)
-            o_proj_tmp = torch_npu.npu_transpose_batchmatmul(
-                o_proj_input,
+        if get_ascend_device_type() in {AscendDeviceType.A5}:
+            o = o_proj_input.view(num_tokens, self.n_local_groups, -1)
+            o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
+            o = torch_npu.npu_transpose_quant_batchmatmul(
+                o,
                 self.wo_a.weight,
+                dtype=torch.bfloat16,
                 bias=None,
-                scale=None,
+                group_sizes=(0, 0, 32),
+                x1_scale=swiglu_out_scale.view(torch.float8_e8m0fnu),
+                x2_scale=self.wo_a.weight_scale.view(torch.float8_e8m0fnu),
                 perm_x1=(1, 0, 2),
                 perm_x2=(0, 1, 2),
                 perm_y=(1, 0, 2),
-                batch_split_factor=1,
-            ).view(num_tokens, -1)
-        output[...] = self.wo_b(o_proj_tmp)
+            )
+            o = o.reshape(num_tokens, -1)
+            output[...] = self.wo_b(o)
+        else:
+            o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, -1)
+            if olora_tp_enable():
+                o_proj_input = self.wo_a(o_proj_input)
+            else:
+                # wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
+                # o = torch.einsum("tgd,grd->tgr", o, wo_a)
+                o_proj_input = torch_npu.npu_transpose_batchmatmul(
+                    o_proj_input,
+                    self.wo_a.weight,
+                    bias=None,
+                    scale=None,
+                    perm_x1=(1, 0, 2),
+                    perm_x2=(0, 1, 2),
+                    perm_y=(1, 0, 2),
+                    batch_split_factor=1,
+                )
+            o_proj_input = o_proj_input.reshape(num_tokens, -1)
+            output[...] = self.wo_b(o_proj_input)
 
         return output
 
@@ -966,14 +1019,14 @@ class AscendDSACPImpl(DSAAttentionImpl):
         need_gather_q_kv: bool = False,
     ):
         """Run full-sequence KV cache updates and local-token attention."""
+        (compress_kv_cache, swa_kv_cache, state_cache, _, _, _) = DeviceOperator.unpack_dsa_forward_kv_cache(
+            kv_cache, self.compress_ratio
+        )
         if self.compress_ratio == 4:
-            (compress_kv_cache, swa_kv_cache, state_cache, _, _, _) = kv_cache
             (compressor_attn_metadata, compressor_kv_state_metadata, _, _, swa_metadata) = attn_metadata
         elif self.compress_ratio == 128:
-            (compress_kv_cache, swa_kv_cache, state_cache, _, _, _) = kv_cache
             (compressor_attn_metadata, compressor_kv_state_metadata, swa_metadata) = attn_metadata
         else:
-            (_, swa_kv_cache, _, _, _, _) = kv_cache
             (swa_metadata,) = attn_metadata
         common_attn_metadata = attn_metadata[0]
 
@@ -1001,6 +1054,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         local_seq_lengths_query = cp_metadata.local_query_start_loc
         local_seq_lengths_key = cp_metadata.local_seq_lens
         has_prefill = _has_prefill(common_attn_metadata.attn_state)
+        hidden_states_cache = hidden_states[: common_attn_metadata.num_actual_tokens]
 
         if (not isinstance(self.wq_b.quant_method, AscendUnquantizedLinearMethod)) and isinstance(
             self.wq_b.quant_method.quant_method, AscendW8A8DynamicLinearMethod
@@ -1051,7 +1105,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
 
         q = q.unflatten(-1, (self.num_heads, self.head_dim))
 
-        q = triton_q_rms(q, self.eps)
+        q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
         torch.ops._C_ascend.inplace_partial_rotary_mul(
             q.unsqueeze(1),
             local_cos,
@@ -1063,18 +1117,18 @@ class AscendDSACPImpl(DSAAttentionImpl):
         if wait_hidden_states_allgather_event:
             torch.npu.current_stream().wait_event(wait_hidden_states_allgather_event)
 
-        kv = self.wkv(hidden_states)
+        kv = self.wkv(hidden_states_cache)
         kv = self.kv_norm(kv)
         assert self.rope_head_dim is not None
         kv = kv.view(-1, 1, self.nope_head_dim + self.rope_head_dim)
         torch.ops._C_ascend.inplace_partial_rotary_mul(
             kv.unsqueeze(1),
-            cos,
-            sin,
+            cos[: kv.shape[0]],
+            sin[: kv.shape[0]],
             rotary_mode="interleave",
             partial_slice=[self.nope_head_dim, self.head_dim],
         )
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(swa_kv_cache, swa_metadata.req_metadata.slot_mapping, kv)
+        DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, swa_metadata.req_metadata.slot_mapping)
 
         compress_topk_idxs = None
         if self.compress_ratio > 1:
@@ -1084,7 +1138,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             compress_sin = req_metadata.compress_sin[layer_name]
             if self.compress_ratio == 4:
                 self._update_indexer_cache(
-                    x=hidden_states,
+                    x=hidden_states_cache,
                     kv_cache=kv_cache,
                     attn_metadata=attn_metadata,
                     compressed_cos=compress_cos,
@@ -1105,7 +1159,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
 
             coff = 2 if self.compressor_overlap else 1
             compressed_kv = torch.ops._C_ascend.compressor(
-                hidden_states,
+                hidden_states_cache,
                 self.compressor_wkv.weight,
                 self.compressor_wgate.weight,
                 state_cache.squeeze(-2),
@@ -1127,8 +1181,15 @@ class AscendDSACPImpl(DSAAttentionImpl):
 
             if compressed_kv.numel() == 0:
                 compressed_kv = None
-            torch.ops._C_ascend.npu_scatter_nd_update_v2(
-                compress_kv_cache, compressor_attn_metadata.req_metadata.slot_mapping, compressed_kv
+            DeviceOperator.dsa_kv_compress_scatter(
+                compress_kv_cache, compressed_kv, compressor_attn_metadata.req_metadata.slot_mapping
+            )
+
+        attn_op = DeviceOperator.get_dsa_sparse_attn_op()
+        extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
+        if has_prefill:
+            DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
+                extra_attn_kwargs, cu_seqlens_ori_kv=local_seq_lengths_query
             )
 
         common_attn_kwargs = dict(
@@ -1136,18 +1197,17 @@ class AscendDSACPImpl(DSAAttentionImpl):
             seqused_kv=local_seq_lengths_key,
             sinks=self.attn_sink,
             softmax_scale=self.softmax_scale,
-            cmp_ratio=self.compress_ratio,
+            cmp_ratio=max(self.compress_ratio, 1),
             ori_mask_mode=4,
             ori_win_left=self.window_size - 1,
             ori_win_right=0,
             layout_q="TND",
             layout_kv="PA_ND",
+            **extra_attn_kwargs,
         )
-        if has_prefill:
-            common_attn_kwargs["cu_seqlens_ori_kv"] = local_seq_lengths_query
 
         if self.compress_ratio <= 1:
-            attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
+            attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,
                 ori_block_table=swa_metadata.req_metadata.block_table,
@@ -1156,27 +1216,31 @@ class AscendDSACPImpl(DSAAttentionImpl):
             )[0]
         elif self.compress_ratio == 4:
             assert compressor_attn_metadata.req_metadata is not None
-            attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
+            DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
+                common_attn_kwargs, cu_seqlens_cmp_kv=req_metadata.cu_cmp_seqlen_list
+            )
+            attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,
                 cmp_kv=compress_kv_cache,
                 cmp_sparse_indices=compress_topk_idxs,
                 ori_block_table=swa_metadata.req_metadata.block_table,
                 cmp_block_table=compressor_attn_metadata.req_metadata.block_table,
-                cu_seqlens_cmp_kv=req_metadata.cu_cmp_seqlen_list,
                 metadata=req_metadata.sas_metadata,
                 cmp_mask_mode=3,
                 **common_attn_kwargs,
             )[0]
         else:
             assert compressor_attn_metadata.req_metadata is not None
-            attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
+            DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
+                common_attn_kwargs, cu_seqlens_cmp_kv=req_metadata.cu_cmp_seqlen_list
+            )
+            attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,
                 cmp_kv=compress_kv_cache,
                 ori_block_table=swa_metadata.req_metadata.block_table,
                 cmp_block_table=compressor_attn_metadata.req_metadata.block_table,
-                cu_seqlens_cmp_kv=req_metadata.cu_cmp_seqlen_list,
                 metadata=compressor_attn_metadata.req_metadata.sas_metadata,
                 cmp_mask_mode=3,
                 **common_attn_kwargs,
@@ -1223,7 +1287,9 @@ class AscendDSACPImpl(DSAAttentionImpl):
         compressed_sin: torch.Tensor,
         actual_seq_lengths_query: torch.Tensor,
     ) -> None:
-        (_, _, _, indexer_state_cache, indexer_k_cache, indexer_scale_cache) = kv_cache
+        (indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
+            DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
+        )
         (_, _, indexer_kv_state_metadata, indexer_kv_scale_metadata, _) = attn_metadata
         coff = 2 if self.compressor_overlap else 1
         assert indexer_kv_scale_metadata is not None
@@ -1257,19 +1323,18 @@ class AscendDSACPImpl(DSAAttentionImpl):
         if self.indexer.compressor.rotate:
             kv = rotate_activation(kv, indexer_kv_scale_metadata.hadamard)
 
-        soc_version = get_ascend_device_type()
-        dst_type = torch.float8_e4m3fn if soc_version in {AscendDeviceType.A5} else torch.int8
-        kv, kv_scale = torch_npu.npu_dynamic_quant(kv, dst_type=dst_type)
-        kv_scale = kv_scale.unsqueeze(-1)
-        if soc_version not in {AscendDeviceType.A5}:
-            kv_scale = kv_scale.to(torch.float16).unsqueeze(-1)
-
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(
-            indexer_k_cache, indexer_kv_scale_metadata.req_metadata.slot_mapping, kv
+        _, kv_scale = DeviceOperator.indexer_quant_scatter_part1(
+            kv,
+            indexer_k_cache,
+            indexer_full_cache,
+            indexer_kv_scale_metadata.req_metadata.slot_mapping,
         )
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(
-            indexer_scale_cache, indexer_kv_scale_metadata.req_metadata.slot_mapping, kv_scale
-        )
+        if kv_scale is not None:
+            DeviceOperator.dsa_indexer_scatter_scale_part3(
+                kv_scale,
+                indexer_scale_cache,
+                indexer_kv_scale_metadata.req_metadata.slot_mapping,
+            )
 
     def _indexer_select_topk(
         self,
@@ -1283,7 +1348,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         actual_seq_lengths_key: torch.Tensor,
         qr_pertoken_scale: torch.Tensor = None,
     ):
-        (_, _, _, _, indexer_k_cache, indexer_scale_cache) = kv_cache
+        (_, indexer_k_cache, indexer_scale_cache, _) = DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
         (_, _, _, indexer_kv_scale_metadata, _) = attn_metadata
         assert indexer_kv_scale_metadata is not None
 
@@ -1291,6 +1356,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             (not isinstance(self.inderxer_wq_b.quant_method, AscendUnquantizedLinearMethod))
             and isinstance(self.inderxer_wq_b.quant_method.quant_method, AscendW8A8DynamicLinearMethod)
             and qr_pertoken_scale is not None
+            and get_ascend_device_type() not in {AscendDeviceType.A5}
         ):
             q = torch_npu.npu_quant_matmul(
                 qr,
@@ -1313,11 +1379,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         q = rotate_activation(q, indexer_kv_scale_metadata.hadamard)
         weights = self.weights_proj(x) * (self.indexer_softmax_scale * self.indexer_heads**-0.5)
 
-        soc_version = get_ascend_device_type()
-        dst_type = torch.float8_e4m3fn if soc_version in {AscendDeviceType.A5} else torch.int8
-        q, q_scale = torch_npu.npu_dynamic_quant(q, dst_type=dst_type)
-        if soc_version not in {AscendDeviceType.A5}:
-            q_scale = q_scale.to(torch.float16)
+        q, q_scale = DeviceOperator.indexer_quantize_query(q)
 
         assert indexer_kv_scale_metadata.req_metadata is not None
         qli_metadata = indexer_kv_scale_metadata.req_metadata.qli_metadata
@@ -1325,9 +1387,9 @@ class AscendDSACPImpl(DSAAttentionImpl):
         topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer(
             query=q,
             key=indexer_k_cache,
-            weights=weights.to(torch.float16),
-            query_dequant_scale=q_scale,
-            key_dequant_scale=indexer_scale_cache.squeeze(-2),
+            weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
+            query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
+            key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
             actual_seq_lengths_query=actual_seq_lengths_query[1:],
             actual_seq_lengths_key=actual_seq_lengths_key,
             block_table=block_table,

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1245,6 +1245,10 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 cmp_mask_mode=3,
                 **common_attn_kwargs,
             )[0]
+        if has_prefill:
+            valid_local_tokens = int(local_seq_lengths_query[-1].item())
+            if valid_local_tokens < attn_output.shape[0]:
+                attn_output[valid_local_tokens:].zero_()
         return attn_output
 
     def _restore_tp_head_layout(

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1111,8 +1111,14 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 AscendAttentionState.SpecDecoding,
             }
         )
-        o_proj_full_handles = self._maybe_all_gather_o_proj_full_weight(full_gather_wo_a_enabled)
-        local_attn_output = self._forward(layer_name, hidden_states, kv_cache, attn_metadata, need_gather_q_kv)
+        local_attn_output, o_proj_full_handles = self._forward(
+            layer_name,
+            hidden_states,
+            kv_cache,
+            attn_metadata,
+            need_gather_q_kv,
+            full_gather_wo_a_enabled,
+        )
         o_proj_input = self._restore_tp_head_layout(
             local_attn_output,
             layer_name,
@@ -1175,6 +1181,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         kv_cache: tuple,
         attn_metadata: list[M],
         need_gather_q_kv: bool = False,
+        full_gather_wo_a_enabled: bool = False,
     ):
         """Run full-sequence KV cache updates and local-token attention."""
         (compress_kv_cache, swa_kv_cache, state_cache, _, _, _) = DeviceOperator.unpack_dsa_forward_kv_cache(
@@ -1274,6 +1281,8 @@ class AscendDSACPImpl(DSAAttentionImpl):
 
         if wait_hidden_states_allgather_event:
             torch.npu.current_stream().wait_event(wait_hidden_states_allgather_event)
+
+        o_proj_full_handles = self._maybe_all_gather_o_proj_full_weight(full_gather_wo_a_enabled)
 
         kv = self.wkv(hidden_states_cache)
         kv = self.kv_norm(kv)
@@ -1407,7 +1416,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             valid_local_tokens = int(local_seq_lengths_query[-1].item())
             if valid_local_tokens < attn_output.shape[0]:
                 attn_output[valid_local_tokens:].zero_()
-        return attn_output
+        return attn_output, o_proj_full_handles
 
     def _restore_tp_head_layout(
         self,

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -16,12 +16,14 @@ from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.distributed.utils import all_gather_async
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
 from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.utils import (
     AscendDeviceType,
     attention_calculation_stream,
+    enable_dsa_cp_with_o_proj_tp,
     get_ascend_device_type,
     npu_stream_switch,
     olora_tp_enable,
@@ -856,6 +858,11 @@ class AscendDSACPImpl(DSAAttentionImpl):
     understand this class
     """
 
+    wo_a_full_pool: ClassVar[torch.Tensor | None] = None
+    wo_a_full_weight_scale_pool: ClassVar[torch.Tensor | None] = None
+    wo_b_full_pool: ClassVar[torch.Tensor | None] = None
+    wo_b_full_weight_scale_pool: ClassVar[torch.Tensor | None] = None
+
     def __init__(
         self,
         n_heads: int,
@@ -902,6 +909,9 @@ class AscendDSACPImpl(DSAAttentionImpl):
 
         self.wo_a = kwargs["wo_a"]
         self.wo_b = kwargs["wo_b"]
+        self.enable_dsa_cp_with_o_proj_tp = enable_dsa_cp_with_o_proj_tp()
+        self._wo_a_dynamic_quant = False
+        self._wo_b_dynamic_quant = False
 
         self.eps = kwargs["eps"]
 
@@ -950,6 +960,132 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 "DSA-CP expects full-head attn_sink loaded on every TP rank, "
                 f"got {self.attn_sink.numel()} heads, expected {self.num_heads}."
             )
+        if self.enable_dsa_cp_with_o_proj_tp:
+            self._maybe_init_o_proj_tp_full_params()
+
+    @staticmethod
+    def _check_dynamic_quant(layer: torch.nn.Module) -> bool:
+        return get_ascend_device_type() in {AscendDeviceType.A5} and hasattr(layer, "weight_scale")
+
+    def _maybe_init_o_proj_tp_full_params(self) -> None:
+        self._wo_a_dynamic_quant = type(self)._check_dynamic_quant(self.wo_a)
+        self._wo_b_dynamic_quant = type(self)._check_dynamic_quant(self.wo_b)
+        if AscendDSACPImpl.wo_a_full_pool is None:
+            sample = self.wo_a.weight
+            AscendDSACPImpl.wo_a_full_pool = torch.empty(
+                (sample.shape[0] * self.tp_size, *sample.shape[1:]),
+                dtype=sample.dtype,
+                device=sample.device,
+            )
+        self.wo_a_tp_weight = self.wo_a.weight.clone().detach().contiguous()
+        self.wo_a.weight.set_(self.wo_a_tp_weight)
+        if AscendDSACPImpl.wo_b_full_pool is None:
+            sample = self.wo_b.weight
+            AscendDSACPImpl.wo_b_full_pool = torch.empty(
+                (sample.shape[0] * self.tp_size, *sample.shape[1:]),
+                dtype=sample.dtype,
+                device=sample.device,
+            )
+        self.wo_b_tp_weight = self.wo_b.weight.clone().detach().contiguous()
+        self.wo_b.weight.set_(self.wo_b_tp_weight)
+
+        if self._wo_a_dynamic_quant:
+            if AscendDSACPImpl.wo_a_full_weight_scale_pool is None:
+                sample = self.wo_a.weight_scale
+                AscendDSACPImpl.wo_a_full_weight_scale_pool = torch.empty(
+                    (sample.shape[0] * self.tp_size, *sample.shape[1:]),
+                    dtype=sample.dtype,
+                    device=sample.device,
+                )
+            self.wo_a_tp_weight_scale = self.wo_a.weight_scale.clone().detach().contiguous()
+            self.wo_a.weight_scale.set_(self.wo_a_tp_weight_scale)
+        if self._wo_b_dynamic_quant:
+            if AscendDSACPImpl.wo_b_full_weight_scale_pool is None:
+                sample = self.wo_b.weight_scale
+                AscendDSACPImpl.wo_b_full_weight_scale_pool = torch.empty(
+                    (sample.shape[0] * self.tp_size, *sample.shape[1:]),
+                    dtype=sample.dtype,
+                    device=sample.device,
+                )
+            self.wo_b_tp_weight_scale = self.wo_b.weight_scale.clone().detach().contiguous()
+            self.wo_b.weight_scale.set_(self.wo_b_tp_weight_scale)
+
+    def _maybe_all_gather_o_proj_full_weight(
+        self,
+        enabled: bool,
+    ) -> list[torch.distributed.Work]:
+        if not enabled:
+            return []
+        handles = []
+        assert AscendDSACPImpl.wo_a_full_pool is not None
+        _, weight_handle = all_gather_async(
+            self.wo_a_tp_weight,
+            self.tp_group,
+            output=AscendDSACPImpl.wo_a_full_pool,
+        )
+        if weight_handle is not None:
+            handles.append(weight_handle)
+        assert AscendDSACPImpl.wo_b_full_pool is not None
+        _, wo_b_weight_handle = all_gather_async(
+            self.wo_b_tp_weight,
+            self.tp_group,
+            output=AscendDSACPImpl.wo_b_full_pool,
+        )
+        if wo_b_weight_handle is not None:
+            handles.append(wo_b_weight_handle)
+        if self._wo_a_dynamic_quant:
+            assert AscendDSACPImpl.wo_a_full_weight_scale_pool is not None
+            _, weight_scale_handle = all_gather_async(
+                self.wo_a_tp_weight_scale,
+                self.tp_group,
+                output=AscendDSACPImpl.wo_a_full_weight_scale_pool,
+            )
+            if weight_scale_handle is not None:
+                handles.append(weight_scale_handle)
+        if self._wo_b_dynamic_quant:
+            assert AscendDSACPImpl.wo_b_full_weight_scale_pool is not None
+            _, wo_b_weight_scale_handle = all_gather_async(
+                self.wo_b_tp_weight_scale,
+                self.tp_group,
+                output=AscendDSACPImpl.wo_b_full_weight_scale_pool,
+            )
+            if wo_b_weight_scale_handle is not None:
+                handles.append(wo_b_weight_scale_handle)
+        return handles
+
+    def _switch_o_proj_to_full_weight(
+        self,
+        handles: list[torch.distributed.Work],
+    ) -> None:
+        for handle in handles:
+            handle.wait()
+        assert AscendDSACPImpl.wo_a_full_pool is not None
+        self.wo_a.weight.set_(AscendDSACPImpl.wo_a_full_pool)
+        if self._wo_a_dynamic_quant:
+            assert AscendDSACPImpl.wo_a_full_weight_scale_pool is not None
+            self.wo_a.weight_scale.set_(AscendDSACPImpl.wo_a_full_weight_scale_pool)
+        assert AscendDSACPImpl.wo_b_full_pool is not None
+        self.wo_b.weight.set_(AscendDSACPImpl.wo_b_full_pool)
+        if self._wo_b_dynamic_quant:
+            assert AscendDSACPImpl.wo_b_full_weight_scale_pool is not None
+            self.wo_b.weight_scale.set_(AscendDSACPImpl.wo_b_full_weight_scale_pool)
+
+    def _switch_o_proj_to_tp_weight(self) -> None:
+        self.wo_a.weight.set_(self.wo_a_tp_weight)
+        if self._wo_a_dynamic_quant:
+            self.wo_a.weight_scale.set_(self.wo_a_tp_weight_scale)
+        self.wo_b.weight.set_(self.wo_b_tp_weight)
+        if self._wo_b_dynamic_quant:
+            self.wo_b.weight_scale.set_(self.wo_b_tp_weight_scale)
+
+    def _apply_wo_b(
+        self,
+        o_proj_input: torch.Tensor,
+        full_weight: bool,
+    ) -> torch.Tensor:
+        if not full_weight:
+            return self.wo_b(o_proj_input)
+        return self.wo_b.quant_method.apply(self.wo_b, o_proj_input, bias=None)
 
     def forward(  # type: ignore[override]
         self,
@@ -966,47 +1102,69 @@ class AscendDSACPImpl(DSAAttentionImpl):
             return output.fill_(0)
         if not isinstance(attn_metadata, list):
             attn_metadata = [attn_metadata]
+        full_gather_wo_a_enabled = (
+            self.tp_size > 1
+            and self.enable_dsa_cp_with_o_proj_tp
+            and attn_metadata[0].attn_state
+            not in {
+                AscendAttentionState.DecodeOnly,
+                AscendAttentionState.SpecDecoding,
+            }
+        )
+        o_proj_full_handles = self._maybe_all_gather_o_proj_full_weight(full_gather_wo_a_enabled)
         local_attn_output = self._forward(layer_name, hidden_states, kv_cache, attn_metadata, need_gather_q_kv)
-        o_proj_input = self._restore_tp_head_layout(local_attn_output, layer_name, attn_metadata[0])
+        o_proj_input = self._restore_tp_head_layout(
+            local_attn_output,
+            layer_name,
+            attn_metadata[0],
+            skip_all_to_all=full_gather_wo_a_enabled,
+        )
         num_tokens = o_proj_input.shape[0]
 
         # o
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
-            o = o_proj_input.view(num_tokens, self.n_local_groups, -1)
-            o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
-            o = torch_npu.npu_transpose_quant_batchmatmul(
-                o,
-                self.wo_a.weight,
-                dtype=torch.bfloat16,
-                bias=None,
-                group_sizes=(0, 0, 32),
-                x1_scale=swiglu_out_scale.view(torch.float8_e8m0fnu),
-                x2_scale=self.wo_a.weight_scale.view(torch.float8_e8m0fnu),
-                perm_x1=(1, 0, 2),
-                perm_x2=(0, 1, 2),
-                perm_y=(1, 0, 2),
-            )
-            o = o.reshape(num_tokens, -1)
-            output[...] = self.wo_b(o)
-        else:
-            o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, -1)
-            if olora_tp_enable():
-                o_proj_input = self.wo_a(o_proj_input)
-            else:
-                # wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
-                # o = torch.einsum("tgd,grd->tgr", o, wo_a)
-                o_proj_input = torch_npu.npu_transpose_batchmatmul(
-                    o_proj_input,
+        if full_gather_wo_a_enabled:
+            self._switch_o_proj_to_full_weight(o_proj_full_handles)
+        o_proj_groups = self.n_group if full_gather_wo_a_enabled else self.n_local_groups
+        try:
+            if get_ascend_device_type() in {AscendDeviceType.A5}:
+                o = o_proj_input.view(num_tokens, o_proj_groups, -1)
+                o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
+                o = torch_npu.npu_transpose_quant_batchmatmul(
+                    o,
                     self.wo_a.weight,
+                    dtype=torch.bfloat16,
                     bias=None,
-                    scale=None,
+                    group_sizes=(0, 0, 32),
+                    x1_scale=swiglu_out_scale.view(torch.float8_e8m0fnu),
+                    x2_scale=self.wo_a.weight_scale.view(torch.float8_e8m0fnu),
                     perm_x1=(1, 0, 2),
                     perm_x2=(0, 1, 2),
                     perm_y=(1, 0, 2),
-                    batch_split_factor=1,
                 )
-            o_proj_input = o_proj_input.reshape(num_tokens, -1)
-            output[...] = self.wo_b(o_proj_input)
+                o = o.reshape(num_tokens, -1)
+                output[...] = self._apply_wo_b(o, full_gather_wo_a_enabled)
+            else:
+                o_proj_input = o_proj_input.view(num_tokens, o_proj_groups, -1)
+                if olora_tp_enable():
+                    o_proj_input = self.wo_a(o_proj_input)
+                else:
+                    # wo_a = self.wo_a.weight.view(o_proj_groups, self.o_lora_rank, -1)
+                    # o = torch.einsum("tgd,grd->tgr", o, wo_a)
+                    o_proj_input = torch_npu.npu_transpose_batchmatmul(
+                        o_proj_input,
+                        self.wo_a.weight,
+                        bias=None,
+                        scale=None,
+                        perm_x1=(1, 0, 2),
+                        perm_x2=(0, 1, 2),
+                        perm_y=(1, 0, 2),
+                        batch_split_factor=1,
+                    )
+                o_proj_input = o_proj_input.reshape(num_tokens, -1)
+                output[...] = self._apply_wo_b(o_proj_input, full_gather_wo_a_enabled)
+        finally:
+            if full_gather_wo_a_enabled:
+                self._switch_o_proj_to_tp_weight()
 
         return output
 
@@ -1256,6 +1414,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         local_attn_output: torch.Tensor,
         layer_name: str,
         attn_metadata: M,
+        skip_all_to_all: bool = False,
     ) -> torch.Tensor:
         assert attn_metadata.req_metadata is not None
         req_metadata = attn_metadata.req_metadata
@@ -1269,7 +1428,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             partial_slice=[self.nope_head_dim, self.head_dim],
         )
 
-        if self.tp_size == 1:
+        if self.tp_size == 1 or skip_all_to_all:
             return local_attn_output
 
         send = (

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -709,7 +709,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             ]
 
         prefill_slot_mapping = self.slot_mapping[
-            compressed_tokens_start : compressed_tokens_end + compressed_tokens_start
+            compressed_tokens_start : compressed_tokens_start + compressed_tokens_end
         ]
 
         assert self.start_pos_prefill is not None
@@ -958,7 +958,10 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             ]
 
         slot_mapping = DeviceOperator.pad_dsa_decode_slot_mapping(
-            self.slot_mapping[:compressed_tokens_start], self.num_decode_tokens, self.compressor_ratio, self.num_decodes
+            self.slot_mapping[:compressed_tokens_start],
+            self.num_decode_tokens,
+            self.compressor_ratio,
+            self.num_decodes,
         )
 
         assert self.start_pos_decode is not None

--- a/vllm_ascend/core/kv_cache_block_copy.py
+++ b/vllm_ascend/core/kv_cache_block_copy.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Helpers for carrying DSv4 KV block copy pairs through SchedulerOutput.
+
+``SchedulerOutput`` is defined in upstream vLLM. To keep vLLM-Ascend from
+adding fields to that dataclass, copy-pairs are packed into the existing
+``new_block_ids_to_zero`` list using an integer sentinel. The worker unpacks
+them before forwarding the remaining block ids to upstream zeroing.
+"""
+
+from __future__ import annotations
+
+
+KV_CACHE_COPY_PAIR_SENTINEL = -1
+KV_CACHE_COPY_PAIR_WIDTH = 6
+KVCacheCopyPair = tuple[int, int, int, int, int]
+
+
+def attach_kv_cache_block_copy_pairs(scheduler_output, copy_pairs: list[KVCacheCopyPair] | None) -> None:
+    if not copy_pairs:
+        return
+
+    encoded = list(scheduler_output.new_block_ids_to_zero or [])
+    for group_id, src_block_id, dst_block_id, compressed_slots, original_slots in copy_pairs:
+        encoded.extend(
+            [
+                KV_CACHE_COPY_PAIR_SENTINEL,
+                group_id,
+                src_block_id,
+                dst_block_id,
+                compressed_slots,
+                original_slots,
+            ]
+        )
+    scheduler_output.new_block_ids_to_zero = encoded
+
+
+def extract_kv_cache_block_copy_pairs(scheduler_output) -> list[KVCacheCopyPair] | None:
+    block_ids = scheduler_output.new_block_ids_to_zero
+    if not block_ids:
+        return getattr(scheduler_output, "kv_cache_block_copy_pairs", None)
+
+    copy_pairs = list(getattr(scheduler_output, "kv_cache_block_copy_pairs", None) or [])
+    zero_block_ids: list[int] = []
+    i = 0
+    while i < len(block_ids):
+        item = block_ids[i]
+        if item == KV_CACHE_COPY_PAIR_SENTINEL:
+            if i + KV_CACHE_COPY_PAIR_WIDTH > len(block_ids):
+                raise RuntimeError("Malformed KV cache block copy-pair payload")
+            copy_pairs.append(tuple(block_ids[i + 1 : i + KV_CACHE_COPY_PAIR_WIDTH]))  # type: ignore[arg-type]
+            i += KV_CACHE_COPY_PAIR_WIDTH
+        else:
+            zero_block_ids.append(item)
+            i += 1
+
+    scheduler_output.new_block_ids_to_zero = zero_block_ids or None
+    return copy_pairs or None

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -22,6 +22,7 @@ import time
 from collections import defaultdict, deque
 from dataclasses import dataclass, fields
 
+from vllm_ascend.core.kv_cache_block_copy import attach_kv_cache_block_copy_pairs
 from vllm.config import SchedulerConfig, VllmConfig
 from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorMetadata
 from vllm.distributed.kv_events import KVEventBatch
@@ -754,6 +755,8 @@ class RecomputeScheduler(Scheduler):
             (self.kv_cache_manager.take_new_block_ids() or None) if self.needs_kv_cache_zeroing else None
         )
 
+        kv_cache_block_copy_pairs = self.kv_cache_manager.take_block_copy_pairs() or None
+
         scheduler_output = RecomputeSchedulerOutput(
             scheduled_new_reqs=new_reqs_data,
             scheduled_cached_reqs=cached_reqs_data,
@@ -772,6 +775,7 @@ class RecomputeScheduler(Scheduler):
             new_block_ids_to_zero=new_block_ids_to_zero,
             recomputed_reqs=recomputed_reqs,
         )
+        attach_kv_cache_block_copy_pairs(scheduler_output, kv_cache_block_copy_pairs)
 
         # NOTE(Kuntai): this function is designed for multiple purposes:
         # 1. Plan the KV cache store

--- a/vllm_ascend/core/scheduler_profiling_chunk.py
+++ b/vllm_ascend/core/scheduler_profiling_chunk.py
@@ -24,6 +24,7 @@ import inspect
 import time
 
 from vllm.config import VllmConfig
+from vllm_ascend.core.kv_cache_block_copy import attach_kv_cache_block_copy_pairs
 from vllm.logger import logger
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
@@ -719,6 +720,8 @@ class ProfilingChunkScheduler(Scheduler):
             (self.kv_cache_manager.take_new_block_ids() or None) if self.needs_kv_cache_zeroing else None
         )
 
+        kv_cache_block_copy_pairs = self.kv_cache_manager.take_block_copy_pairs() or None
+
         scheduler_output = SchedulerOutput(
             scheduled_new_reqs=new_reqs_data,
             scheduled_cached_reqs=cached_reqs_data,
@@ -732,6 +735,7 @@ class ProfilingChunkScheduler(Scheduler):
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
             new_block_ids_to_zero=new_block_ids_to_zero,
         )
+        attach_kv_cache_block_copy_pairs(scheduler_output, kv_cache_block_copy_pairs)
 
         if self.connector is not None:
             meta = self._build_kv_connector_meta(self.connector, scheduler_output)

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -498,7 +498,7 @@ class BaseDeviceAdaptor:
     @staticmethod
     def get_dsa_kernel_block_sizes():
         """Non-A5: return supported kernel block sizes."""
-        return [8, 32, 128]
+        return [2, 4, 8, 16, 32, 64, 128]
 
     @staticmethod
     def chunk_scaled_dot_kkt_fwd(NT, k, beta, g_cumsum, A, cu_seqlens, chunk_indices, T, B, H, Hg, K, BT, BK):
@@ -1101,7 +1101,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
     @staticmethod
     def get_dsa_kernel_block_sizes():
         """A5: return supported kernel block sizes."""
-        return [8, 16, 128]
+        return [2, 4, 8, 16, 32, 64, 128]
 
     def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):
         seq_lens_cpu = list(seq_lens_cpu.cumsum(0))

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -80,6 +80,7 @@ from vllm_ascend.utils import (
     get_dsv4_compress_ratio,
     vllm_version_is,
 )
+from vllm_ascend.models.layer.attention.layer import DSV4_BLOCK_SIZES
 
 if vllm_version_is("0.20.2"):
     from vllm.model_executor.layers.deepseek_compressor import CompressorStateCache  # type:ignore
@@ -524,7 +525,7 @@ class Compressor(nn.Module):
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=8,
+                block_size=DSV4_BLOCK_SIZES[config.cache_config.block_size][0][2],
             )
         elif compress_ratio == 128:
             self.state_cache = CompressorStateCache(
@@ -532,7 +533,7 @@ class Compressor(nn.Module):
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=16 if get_ascend_device_type() in {AscendDeviceType.A5} else 32,
+                block_size=DSV4_BLOCK_SIZES[config.cache_config.block_size][0][3],
             )
         else:
             raise ValueError(

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -525,7 +525,7 @@ class Compressor(nn.Module):
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=DSV4_BLOCK_SIZES[config.cache_config.block_size][0][2],
+                block_size=DSV4_BLOCK_SIZES[cache_config.block_size][0][2],
             )
         elif compress_ratio == 128:
             self.state_cache = CompressorStateCache(
@@ -533,7 +533,7 @@ class Compressor(nn.Module):
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=DSV4_BLOCK_SIZES[config.cache_config.block_size][0][3],
+                block_size=DSV4_BLOCK_SIZES[cache_config.block_size][0][3],
             )
         else:
             raise ValueError(

--- a/vllm_ascend/models/layer/attention/layer.py
+++ b/vllm_ascend/models/layer/attention/layer.py
@@ -28,6 +28,27 @@ from vllm_ascend.utils import (
 )
 
 
+def get_dsv4_block_sizes():
+    _DSV4_BLOCK_SIZES = {
+        128: [[128, 128, 8, 32], [16640, 131072]],
+        64: [[64, 64, 4, 16], [8320, 65536]],
+        32: [[32, 32, 2, 8], [4160, 32768]],
+    }
+
+    _DSV4_BLOCK_SIZES_A5 = {
+        128: [[128, 128, 8, 16], [16896, 81920]],
+        64: [[64, 64, 4, 8], [8448, 40960]],
+        32: [[32, 32, 2, 4], [4224, 20480]],
+    }
+
+    if get_ascend_device_type() in {AscendDeviceType.A5}:
+        return _DSV4_BLOCK_SIZES_A5
+    else:
+        return _DSV4_BLOCK_SIZES
+
+DSV4_BLOCK_SIZES = get_dsv4_block_sizes()
+
+
 class DSAAttention(nn.Module, AttentionLayerBase):
     """Multi-Head Latent Attention layer.
 
@@ -162,7 +183,7 @@ class DSAAttention(nn.Module, AttentionLayerBase):
             (self.head_size + 128) if get_ascend_device_type() in {AscendDeviceType.A5} else self.head_size
         )
         return MLAAttentionSpec(
-            block_size=128,
+            block_size=DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][0][0],
             num_kv_heads=1,
             head_size=cached_head_size,
             dtype=kv_cache_dtype,

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -43,6 +43,8 @@ if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXP
 
 import vllm_ascend.patch.platform.patch_balance_schedule  # noqa
 
+import vllm_ascend.patch.platform.patch_dsv4_prefix_cache_cow  # noqa
+
 if envs.VLLM_ASCEND_APPLY_DSV4_PATCH:
     import vllm_ascend.patch.platform.patch_kv_cache_coordinator  # noqa
     import vllm_ascend.patch.platform.patch_speculative_config  # noqa

--- a/vllm_ascend/patch/platform/patch_dsv4_prefix_cache_cow.py
+++ b/vllm_ascend/patch/platform/patch_dsv4_prefix_cache_cow.py
@@ -1,0 +1,78 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""DSv4 compressed prefix-cache copy-on-write patches.
+
+Keep the upstream vLLM package independent from vLLM-Ascend by installing the
+compressed KV manager and scheduler copy-pair plumbing from this plugin.
+"""
+
+from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.core.sched.scheduler import Scheduler
+
+from vllm_ascend.core.kv_cache_block_copy import attach_kv_cache_block_copy_pairs
+from vllm_ascend.core.single_type_kv_cache_manager import (
+    get_manager_for_kv_cache_spec as ascend_get_manager_for_kv_cache_spec,
+)
+
+
+def _take_block_copy_pairs(self: KVCacheManager) -> list[tuple[int, int, int, int, int]]:
+    pairs: list[tuple[int, int, int, int, int]] = []
+    for mgr in self.coordinator.single_type_managers:
+        take_pairs = getattr(mgr, "take_block_copy_pairs", None)
+        if take_pairs is not None:
+            pairs.extend(take_pairs())
+    return pairs
+
+
+def _patch_kv_manager_factory() -> None:
+    import vllm.v1.core.kv_cache_coordinator as kv_cache_coordinator
+    import vllm.v1.core.single_type_kv_cache_manager as single_type_kv_cache_manager
+
+    single_type_kv_cache_manager.get_manager_for_kv_cache_spec = ascend_get_manager_for_kv_cache_spec
+    # kv_cache_coordinator imports the factory into its module namespace, so
+    # patch that reference too.
+    kv_cache_coordinator.get_manager_for_kv_cache_spec = ascend_get_manager_for_kv_cache_spec
+
+
+def _patch_kv_cache_manager() -> None:
+    if not hasattr(KVCacheManager, "take_block_copy_pairs"):
+        KVCacheManager.take_block_copy_pairs = _take_block_copy_pairs
+
+
+def _patch_scheduler_output() -> None:
+    if getattr(Scheduler.schedule, "_vllm_ascend_dsv4_cow_patched", False):
+        return
+
+    original_schedule = Scheduler.schedule
+
+    def _wrapped_schedule(self):
+        output = original_schedule(self)
+        if output is not None:
+            take_pairs = getattr(self.kv_cache_manager, "take_block_copy_pairs", None)
+            if take_pairs is not None:
+                pairs = take_pairs() or None
+                if pairs is not None:
+                    attach_kv_cache_block_copy_pairs(output, pairs)
+        return output
+
+    _wrapped_schedule._vllm_ascend_dsv4_cow_patched = True
+    Scheduler.schedule = _wrapped_schedule
+
+
+_patch_kv_manager_factory()
+_patch_kv_cache_manager()
+_patch_scheduler_output()

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -29,6 +29,7 @@ if HAS_TRITON:
         import vllm_ascend.patch.worker.patch_v2.patch_triton  # noqa
 
 
+import vllm_ascend.patch.worker.patch_process_weights_after_loading  # noqa
 import vllm_ascend.patch.worker.patch_weight_utils  # noqa
 import vllm_ascend.patch.worker.patch_distributed  # noqa
 import vllm_ascend.patch.worker.patch_minimax_m2  # noqa

--- a/vllm_ascend/patch/worker/patch_deepseek_compressor.py
+++ b/vllm_ascend/patch/worker/patch_deepseek_compressor.py
@@ -11,6 +11,7 @@ from vllm.v1.kv_cache_interface import (
 from vllm_ascend.attention.dsa_v1 import AscendDSABackend
 from vllm_ascend.patch.platform.patch_kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type, vllm_version_is
+from vllm_ascend.models.layer.attention.layer import DSV4_BLOCK_SIZES
 
 if vllm_version_is("0.20.2"):
     from vllm.model_executor.layers import (
@@ -54,10 +55,10 @@ class AscendCompressorStateCache(CompressorStateCache):
         self.block_size = block_size
 
     def get_kv_cache_spec(self, vllm_config) -> KVCacheSpec:
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
-            page_size_padded = 16896 if self.state_dim == 2 * 256 and self.compress_ratio == 4 else 81920
+        if self.state_dim == 2 * 256 and self.compress_ratio == 4 :
+            page_size_padded = DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][1][0]
         else:
-            page_size_padded = 16640 if self.state_dim == 2 * 256 and self.compress_ratio == 4 else 131072
+            page_size_padded = DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][1][1]
 
         return SlidingWindowMLASpec(  # only has one vector instead of K + V
             block_size=self.block_size,
@@ -92,7 +93,7 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
             vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
 
         return AscendMLAAttentionSpec(  # Only has one vector instead of K + V
-            block_size=128,
+            block_size=DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][0][0],
             num_kv_heads=1,
             head_size=self.head_dim,
             dtype=self.dtype,
@@ -126,7 +127,7 @@ class AscendDeepseekV4SWACache(DeepseekV4SWACache):
         # same page size. The C4A KV block shape [256//4, head_dim] = [64, head_dim]
         # determines the SWA block size of 64 tokens per block.
         # TODO(cmq): make SWA block size automatically determined and configurable.
-        self.block_size = 128
+        self.block_size = DSV4_BLOCK_SIZES[cache_config.block_size][0][1]
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
         if get_ascend_device_type() in {AscendDeviceType.A5}:

--- a/vllm_ascend/patch/worker/patch_process_weights_after_loading.py
+++ b/vllm_ascend/patch/worker/patch_process_weights_after_loading.py
@@ -1,0 +1,63 @@
+import sys
+
+import torch
+from torch import nn
+
+from vllm.config import ModelConfig
+from vllm.model_executor.layers.attention import (
+    Attention,
+    MLAAttention,
+    MMEncoderAttention,
+)
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizeMethodBase,
+)
+from vllm.model_executor.model_loader import base_loader, utils
+from vllm.model_executor.model_loader.utils import device_loading_context
+from vllm.model_executor.model_loader.reload import set_torchao_reload_attrs
+
+from vllm_ascend.models.layer.attention.layer import DSAAttention
+
+
+def ascend_process_weights_after_loading(
+    model: nn.Module, model_config: ModelConfig, target_device: torch.device
+) -> None:
+    for _, module in model.named_modules():
+        quant_method = getattr(module, "quant_method", None)
+        if isinstance(quant_method, QuantizeMethodBase):
+            # When quant methods need to process weights after loading
+            # (for repacking, quantizing, etc), they expect parameters
+            # to be on the global target device. This scope is for the
+            # case where cpu offloading is used, where we will move the
+            # parameters onto device for processing and back off after.
+            with device_loading_context(module, target_device):
+                quant_method.process_weights_after_loading(module)
+
+    # Initialize post-load attention weights for Attention, MLA, and MM encoder.
+    # NOTE: Happens after other modules so we can easily decompress weights.
+    for _, module in model.named_modules():
+        if isinstance(
+            module, (Attention, MLAAttention, MMEncoderAttention, DSAAttention)
+        ) and hasattr(module, "process_weights_after_loading"):
+            # TODO(lucas): see if there is a way to unify the signatures
+            # of process_weights_after_loading
+            with device_loading_context(module, target_device):
+                module.process_weights_after_loading(model_config.dtype)
+
+    # Needed for torchao model reloading via model.reload_weights
+    # @kylesayrs @jerryzh168 this can be removed if callers move to `reload_weights`
+    if model_config.quantization == "torchao":
+        set_torchao_reload_attrs(model, model_config)
+
+
+utils.process_weights_after_loading = ascend_process_weights_after_loading
+base_loader.process_weights_after_loading = ascend_process_weights_after_loading
+
+vllm_ascend_loaders = [
+    "vllm_ascend.model_loader.netloader.netloader",
+    "vllm_ascend.model_loader.rfork.rfork_loader",
+]
+for loader_module in vllm_ascend_loaders:
+    loader = sys.modules.get(loader_module)
+    if loader is not None:
+        setattr(loader, "process_weights_after_loading", ascend_process_weights_after_loading)

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1360,6 +1360,7 @@ def get_flashcomm2_reorgnized_batch_ids(global_tp_size) -> list[list[int]]:
 
     return reorgnized_batch_ids
 
+_ENIGINE_CORE_BLOCK_SIZE = None
 
 def refresh_block_size(vllm_config):
     """
@@ -1379,8 +1380,27 @@ def refresh_block_size(vllm_config):
         return
 
     if model_config.hf_config.model_type == "deepseek_v4":
-        # TODO(qcs): generalize the block_size
-        cache_config.block_size = 128
+        # NOTE(cmq): use _ENIGINE_CORE_BLOCK_SIZE as the cache_config.block_size
+        # is updated in the core process, but it will be updated to the minimized
+        # block_size among all the kvcache groups, which will leading to a wrong
+        # block_size in DeepSeek V4 scenario.
+        global _ENIGINE_CORE_BLOCK_SIZE
+
+        if _ENIGINE_CORE_BLOCK_SIZE is not None:
+            cache_config.block_size = _ENIGINE_CORE_BLOCK_SIZE
+            return
+
+        if cache_config.block_size is None:
+            cache_config.block_size = 32
+        elif cache_config.block_size not in [32, 64, 128]:
+            logger.warning(
+                "For deepseek_v4 model, block size should be 32, 64 or 128. "
+                "Setting block size to 32 for better performance."
+            )
+            cache_config.block_size = 32
+
+        _ENIGINE_CORE_BLOCK_SIZE = cache_config.block_size
+        return
 
     if model_config.is_hybrid:
         # Hybrid attention+mamba models rely on the model-specific sizing

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -117,6 +117,7 @@ from vllm_ascend.compilation.acl_graph import (
     set_graph_params,
     update_full_graph_params,
 )
+from vllm_ascend.core.kv_cache_block_copy import extract_kv_cache_block_copy_pairs
 from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
 from vllm_ascend.eplb.core.eplb_device_transfer_loader import D2DExpertWeightLoader
 from vllm_ascend.eplb.core.eplb_worker import EplbProcess
@@ -600,8 +601,17 @@ class NPUModelRunner(GPUModelRunner):
         max_tokens_across_dp = int(num_tokens_across_dp.max().item())
         synced_cudagraph_mode = CUDAGraphMode(_post_process_cudagraph_mode(packed_tensor))
 
-        # Create a tensor for num_tokens_after_padding
-        if allow_dp_padding or is_draft_model:
+        # DP padding for graph replay must be decided from the synchronized
+        # runtime mode. In mixed prefill-decode, decode ranks may locally choose
+        # a decode graph while prefill ranks choose eager; the synced mode is
+        # NONE, so padding decode ranks to the prefill length would make ranks
+        # run different logical batches.
+        should_dp_pad = (
+            synced_cudagraph_mode != CUDAGraphMode.NONE
+            or allow_dp_padding
+            or is_draft_model
+        )
+        if should_dp_pad:
             num_tokens_after_padding = torch.tensor(
                 [max_tokens_across_dp] * self.dp_size, device="cpu", dtype=torch.int32
             )
@@ -631,7 +641,94 @@ class NPUModelRunner(GPUModelRunner):
                 if num_computed_tokens < req_state.num_computed_tokens:
                     req_state.prev_num_draft_len = 0
 
-        return super()._update_states(scheduler_output)
+        kv_cache_block_copy_pairs = extract_kv_cache_block_copy_pairs(scheduler_output)
+        deferred = super()._update_states(scheduler_output)
+        self._copy_kv_cache_blocks(kv_cache_block_copy_pairs)
+        return deferred
+
+    def _copy_kv_cache_blocks(
+        self,
+        copy_pairs: list[tuple[int, int, int, int, int]] | None,
+    ) -> None:
+        if not copy_pairs:
+            return
+
+        pairs_by_group: dict[int, list[tuple[int, int, int, int]]] = {}
+        for pair in copy_pairs:
+            if len(pair) == 4:
+                group_id, src_block_id, dst_block_id, compressed_slots = pair
+                original_slots = compressed_slots
+            else:
+                group_id, src_block_id, dst_block_id, compressed_slots, original_slots = pair
+            pairs_by_group.setdefault(group_id, []).append(
+                (src_block_id, dst_block_id, compressed_slots, original_slots)
+            )
+
+        seen_cache_ids: set[int] = set()
+        for group_id, pairs in pairs_by_group.items():
+            for attn_group in self.attn_groups[group_id]:
+                for layer_name in attn_group.layer_names:
+                    if layer_name in self.runner_only_attn_layers:
+                        continue
+                    layer = self.compilation_config.static_forward_context[layer_name]
+                    kv_cache = layer.kv_cache[0]
+                    cache_id = id(kv_cache)
+                    if cache_id in seen_cache_ids:
+                        continue
+                    seen_cache_ids.add(cache_id)
+                    self._copy_kv_cache_one_layer(kv_cache, pairs)
+
+    def _copy_kv_cache_one_layer(
+        self,
+        kv_cache,
+        pairs: list[tuple[int, int, int, int]],
+    ) -> None:
+        if isinstance(kv_cache, torch.Tensor):
+            self._copy_kv_cache_tensor(
+                kv_cache, [(src, dst, original) for src, dst, _, original in pairs]
+            )
+            return
+
+        # DSv4 DSA packs original-window KV and compressed/indexer KV into the
+        # same per-layer page. Original-window tensors need the full 32-token
+        # prefix block, while compressed/indexer tensors must zero slots beyond
+        # the compressed prefix length to avoid stale future-prefix KV.
+        is_dsa_packed_cache = len(kv_cache) >= 3
+        compressed_tensor_indices = {0, 2, 4, 5}
+        for idx, tensor in enumerate(kv_cache):
+            if tensor is None:
+                continue
+            # On A5 the indexer full cache is an overlapping view of the
+            # indexer k/scale cache. Copying/zeroing it after the component
+            # views can corrupt the copied prefix, so preserve the component
+            # views only; later indexer scatter will rewrite the full view for
+            # newly generated slots.
+            if is_dsa_packed_cache and idx == 6:
+                continue
+            tensor_pairs = []
+            for src, dst, compressed, original in pairs:
+                valid_slots = (
+                    compressed
+                    if is_dsa_packed_cache and idx in compressed_tensor_indices
+                    else original
+                )
+                tensor_pairs.append((src, dst, valid_slots))
+            self._copy_kv_cache_tensor(tensor, tensor_pairs)
+
+    @staticmethod
+    def _copy_kv_cache_tensor(
+        tensor: torch.Tensor,
+        pairs: list[tuple[int, int, int]],
+    ) -> None:
+        # Compressed DSA cache tensors use shape (2, num_blocks, block, ...);
+        # regular K/V caches use (num_blocks, block, ...).
+        for src_block_id, dst_block_id, valid_slots in pairs:
+            if tensor.ndim >= 2 and tensor.shape[0] == 2:
+                tensor[:, dst_block_id, :valid_slots] = tensor[:, src_block_id, :valid_slots]
+                tensor[:, dst_block_id, valid_slots:].zero_()
+            else:
+                tensor[dst_block_id, :valid_slots] = tensor[src_block_id, :valid_slots]
+                tensor[dst_block_id, valid_slots:].zero_()
 
     def _pad_query_start_loc_for_fia(
         self,
@@ -2688,7 +2785,7 @@ class NPUModelRunner(GPUModelRunner):
             _, num_tokens_across_dp, synced_cudagraph_mode = self._sync_metadata_across_dp(
                 num_tokens=num_tokens_padded,
                 cudagraph_mode=cudagraph_mode,
-                allow_dp_padding=(cudagraph_mode != CUDAGraphMode.NONE) or enable_sp(self.vllm_config),
+                allow_dp_padding=enable_sp(self.vllm_config),
             )
 
             # Extract DP padding if there is any


### PR DESCRIPTION
Depends on #10026. This PR is intentionally stacked on top of the DSV4 DSA-CP A5 support from #10026; the diff will become clean after #10026 is merged into `main`.

### What this PR does / why we need it?
This PR adds the missing DSV4 DSA-CP o-proj TP full-weight allgather path for prefill.

When DSA-CP runs with o-proj TP enabled, prefill now asynchronously allgathers the TP-local `wo_a` / `wo_b` projection weights, including MXFP8 weight scales when present, switches the projection layers to the gathered full buffers for the o-proj computation, and restores the TP-local tensors afterward. Decode and spec-decode keep the existing activation all-to-all behavior.

The PR also patches post-load weight processing so `DSAAttention.process_weights_after_loading()` is invoked from the same loader hook as other attention modules, allowing DSA-CP full-weight buffers to be initialized after weights are loaded instead of lazily in forward.

### Does this PR introduce _any_ user-facing change?
No user-facing API, configuration, environment variable, or schema changes. The change only affects the internal DSV4 DSA-CP o-proj TP execution path when the existing o-proj TP enablement is active.

### How was this patch tested?
- `python -m py_compile vllm_ascend/attention/context_parallel/dsa_cp.py vllm_ascend/patch/worker/patch_process_weights_after_loading.py`
- `git diff --cached --check`

`ruff` was not run locally because it is not installed in the current environment.

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
