### PR TITLE
[BugFix][PrefixCache] Fix DeepSeek-V4 compressed prefix lookup

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -180,6 +180,7 @@
     - vllm_ascend/core
   tests:
     - tests/ut/core
+    - tests/ut/test_compressed_prefix_cache.py
 
 # Device
 - name: device
@@ -370,6 +371,7 @@
     - vllm_ascend/patch
   tests:
     - tests/ut/patch
+    - tests/ut/test_compressed_prefix_cache.py
     - tests/e2e/pull_request/one_card/test_qwen3_0_6b.py
     - tests/e2e/pull_request/one_card/test_qwen3_5_0_8b.py
 

--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+
+import pytest
+import torch
+from vllm.sampling_params import SamplingParams
+from vllm.utils.hashing import sha256
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import (
+    BlockHashListWithBlockSize,
+    get_block_hash,
+    get_request_block_hasher,
+    init_none_hash,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MLAAttentionSpec,
+)
+from vllm.v1.request import Request
+
+from vllm_ascend.core.single_type_kv_cache_manager import CompressAttentionManager
+from vllm_ascend.patch.platform.patch_kv_cache_coordinator import AscendHybridKVCacheCoordinator
+
+pytestmark = pytest.mark.cpu_test
+
+
+@pytest.fixture(autouse=True)
+def _init_hash_seed():
+    init_none_hash(sha256)
+
+
+def _make_request(request_id: str, token_ids: list[int], hash_block_size: int) -> Request:
+    sampling_params = SamplingParams(max_tokens=1)
+    sampling_params.update_from_generation_config({}, eos_token_id=100)
+    return Request(
+        request_id=request_id,
+        prompt_token_ids=token_ids,
+        sampling_params=sampling_params,
+        pooling_params=None,
+        block_hasher=get_request_block_hasher(hash_block_size, sha256),
+    )
+
+
+def _make_compress_manager(
+    block_size: int = 128,
+    compress_ratio: int = 4,
+) -> tuple[MLAAttentionSpec, BlockPool, CompressAttentionManager]:
+    spec = MLAAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        compress_ratio=compress_ratio,
+        model_version="deepseek_v4",
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=8,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    manager = CompressAttentionManager(
+        spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+    )
+    return spec, block_pool, manager
+
+
+def test_compressed_prefix_cache_uses_logical_block_hash() -> None:
+    block_size = 128
+    compress_ratio = 4
+    logical_block_size = block_size * compress_ratio
+    spec, block_pool, manager = _make_compress_manager(block_size, compress_ratio)
+
+    request_a_tokens = list(range(logical_block_size))
+    request_b_tokens = request_a_tokens.copy()
+    request_b_tokens[block_size + 7] = 999_999
+
+    request_a = _make_request("a", request_a_tokens, block_size)
+    request_b = _make_request("b", request_b_tokens, block_size)
+
+    manager.allocate_new_blocks(
+        request_a.request_id,
+        num_tokens=logical_block_size,
+        num_tokens_main_model=logical_block_size,
+    )
+    manager.cache_blocks(request_a, num_tokens=logical_block_size)
+
+    cached_hash = get_block_hash(manager.req_to_blocks[request_a.request_id][0].block_hash)
+    expected_hash = BlockHashListWithBlockSize(
+        request_a.block_hashes,
+        block_size,
+        logical_block_size,
+    )[0]
+    assert cached_hash == expected_hash
+
+    hit_blocks = CompressAttentionManager.find_longest_cache_hit(
+        block_hashes=request_b.block_hashes,
+        max_length=logical_block_size,
+        kv_cache_group_ids=[0],
+        block_pool=block_pool,
+        kv_cache_spec=spec,
+        use_eagle=False,
+        alignment_tokens=logical_block_size,
+    )[0]
+
+    assert hit_blocks == []
+
+
+def test_compressed_prefix_cache_hits_identical_logical_block() -> None:
+    block_size = 128
+    compress_ratio = 4
+    logical_block_size = block_size * compress_ratio
+    spec, block_pool, manager = _make_compress_manager(block_size, compress_ratio)
+
+    request = _make_request("a", list(range(logical_block_size)), block_size)
+    manager.allocate_new_blocks(
+        request.request_id,
+        num_tokens=logical_block_size,
+        num_tokens_main_model=logical_block_size,
+    )
+    manager.cache_blocks(request, num_tokens=logical_block_size)
+
+    hit_blocks = CompressAttentionManager.find_longest_cache_hit(
+        block_hashes=request.block_hashes,
+        max_length=logical_block_size,
+        kv_cache_group_ids=[0],
+        block_pool=block_pool,
+        kv_cache_spec=spec,
+        use_eagle=False,
+        alignment_tokens=logical_block_size,
+    )[0]
+
+    assert hit_blocks == manager.req_to_blocks[request.request_id]
+
+
+def test_hybrid_coordinator_rejects_partial_compressed_prefix_hit() -> None:
+    block_size = 128
+    compress_ratio = 4
+    logical_block_size = block_size * compress_ratio
+    request_a_tokens = list(range(logical_block_size))
+    request_b_tokens = request_a_tokens.copy()
+    request_b_tokens[block_size + 7] = 999_999
+
+    request_a = _make_request("a", request_a_tokens, block_size)
+    request_b = _make_request("b", request_b_tokens, block_size)
+    compressed_spec = MLAAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        compress_ratio=compress_ratio,
+        model_version="deepseek_v4",
+    )
+    full_spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    coordinator = AscendHybridKVCacheCoordinator(
+        kv_cache_config=KVCacheConfig(
+            num_blocks=16,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(["compressed"], compressed_spec),
+                KVCacheGroupSpec(["full"], full_spec),
+            ],
+        ),
+        max_model_len=logical_block_size,
+        use_eagle=False,
+        enable_caching=True,
+        enable_kv_cache_events=False,
+        dcp_world_size=1,
+        pcp_world_size=1,
+        hash_block_size=block_size,
+        max_num_batched_tokens=logical_block_size,
+    )
+
+    for manager in coordinator.single_type_managers:
+        manager.allocate_new_blocks(
+            request_a.request_id,
+            num_tokens=logical_block_size,
+            num_tokens_main_model=logical_block_size,
+        )
+        manager.cache_blocks(request_a, num_tokens=logical_block_size)
+
+    hit_blocks, hit_length = coordinator.find_longest_cache_hit(
+        request_b.block_hashes,
+        max_cache_hit_length=logical_block_size,
+    )
+
+    assert hit_length == 0
+    assert hit_blocks == ([], [])

--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -5,7 +5,11 @@ from collections.abc import Sequence
 
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
-from vllm.v1.core.kv_cache_utils import BlockHashList, KVCacheBlock
+from vllm.v1.core.kv_cache_utils import (
+    BlockHashList,
+    BlockHashListWithBlockSize,
+    KVCacheBlock,
+)
 from vllm.v1.core.single_type_kv_cache_manager import (
     FullAttentionManager,
     SingleTypeKVCacheManager,
@@ -19,8 +23,6 @@ from vllm.v1.kv_cache_interface import (
     SlidingWindowSpec,
 )
 from vllm.v1.request import Request
-
-from vllm_ascend.utils import vllm_version_is
 
 
 class CompressAttentionManager(FullAttentionManager):
@@ -172,8 +174,6 @@ class CompressAttentionManager(FullAttentionManager):
 
         if num_cached_blocks >= num_full_blocks:
             return
-        if vllm_version_is("0.21.0"):
-            return super().cache_blocks(request, num_tokens)
 
         self.block_pool.cache_full_blocks(
             request=request,
@@ -204,11 +204,13 @@ class CompressAttentionManager(FullAttentionManager):
         #     "CompressAttentionManager can only be used for compressor attention groups"
         # )
         computed_blocks: tuple[list[KVCacheBlock], ...] = tuple([] for _ in range(len(kv_cache_group_ids)))
-        block_size = kv_cache_spec.block_size * kv_cache_spec.compress_ratio
+        block_size = kv_cache_spec.block_size
         if dcp_world_size * pcp_world_size > 1:
             block_size *= dcp_world_size * pcp_world_size
-        max_num_blocks = max_length // block_size
-        for block_hash in itertools.islice(block_hashes, max_num_blocks):
+        logical_block_size = block_size * kv_cache_spec.compress_ratio
+        logical_block_hashes = BlockHashListWithBlockSize(block_hashes, block_size, logical_block_size)
+        max_num_blocks = max_length // logical_block_size
+        for block_hash in itertools.islice(logical_block_hashes, max_num_blocks):
             # block_hashes is a chain of block hashes. If a block hash is not
             # in the cached_block_hash_to_id, the following block hashes are
             # not computed yet for sure.
@@ -222,11 +224,9 @@ class CompressAttentionManager(FullAttentionManager):
             for computed in computed_blocks:
                 computed.pop()
 
-        # NOTE: Div the compress ratio when finding the longest cache hit token length.
-        alignment_tokens = cdiv(alignment_tokens, kv_cache_spec.compress_ratio)
         while (
-            block_size != alignment_tokens  # Faster for common case.
-            and len(computed_blocks[0]) * block_size % alignment_tokens != 0
+            logical_block_size != alignment_tokens  # Faster for common case.
+            and len(computed_blocks[0]) * logical_block_size % alignment_tokens != 0
         ):
             for computed in computed_blocks:
                 computed.pop()

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -116,7 +116,8 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         if self.dcp_world_size * self.pcp_world_size > 1:
             block_size *= self.dcp_world_size * self.pcp_world_size
         if hasattr(kv_cache_spec, "compress_ratio"):
-            compress_ratio = kv_cache_spec.compress_ratio if kv_cache_spec.compress_ratio >= 1 else 1
+            compress_ratio = kv_cache_spec.compress_ratio or 1
+            compress_ratio = compress_ratio if compress_ratio >= 1 else 1
             block_size *= compress_ratio
         return block_size
 
@@ -190,10 +191,12 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         """
 
         def _get_block_hashes(kv_cache_spec: KVCacheSpec) -> BlockHashList:
-            effective_block_size = self._get_effective_block_size(kv_cache_spec)
-            if kv_cache_spec.block_size == self.hash_block_size:
+            target_block_size = kv_cache_spec.block_size
+            if not isinstance(kv_cache_spec, MambaSpec) and self.dcp_world_size * self.pcp_world_size > 1:
+                target_block_size *= self.dcp_world_size * self.pcp_world_size
+            if target_block_size == self.hash_block_size:
                 return block_hashes
-            return BlockHashListWithBlockSize(block_hashes, self.hash_block_size, effective_block_size)
+            return BlockHashListWithBlockSize(block_hashes, self.hash_block_size, target_block_size)
 
         num_groups = len(self.kv_cache_config.kv_cache_groups)
         hit_length = max_cache_hit_length


### PR DESCRIPTION
### What this PR does / why we need it?

Related issue: #10296

PR #9903 fixed the compressed KV prefix-cache write path to use `block_size * compress_ratio`, but the compressed manager lookup path can still iterate the incoming physical-granularity `block_hashes` directly.

For DeepSeek-V4 compressed KV groups, one physical KV block covers `block_size * compress_ratio` original tokens. The lookup path must therefore convert the incoming physical hash list to the same logical block size before checking cached blocks.

This PR adds that manager-side conversion in `CompressAttentionManager.find_longest_cache_hit()` and adds CPU regression coverage for:

- rejecting a partial compressed logical-block hit when requests diverge after the first physical block;
- keeping identical compressed logical blocks hittable;
- preventing a full-attention partial hit from hiding a compressed group miss in hybrid coordination.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```bash
python3 -m py_compile \
  vllm_ascend/core/single_type_kv_cache_manager.py \
  vllm_ascend/patch/platform/patch_kv_cache_coordinator.py \
  tests/ut/test_compressed_prefix_cache.py

ruff check \
  vllm_ascend/core/single_type_kv_cache_manager.py \
  vllm_ascend/patch/platform/patch_kv_cache_coordinator.py \
  tests/ut/test_compressed_prefix_cache.py
```

Local targeted pytest collection for `main` is blocked by the local vLLM checkout being older than current vllm-ascend main (`vllm.model_executor.layers.fused_moe.expert_map_manager` and `vllm.v1.attention.backends.mla.prefill` are missing locally). To still validate the changed logic, I ran a standalone check against this branch that verifies:

```text
cached compressed block hash == logical BlockHashListWithBlockSize hash
identical logical block hits
partial logical block divergence misses
```

Result:

```text
standalone main compressed prefix cache checks passed
```

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
