### PR TITLE
[BugFix][v0.20.2rc] Fix DeepSeek-V4 compressed prefix lookup

### DIFF
--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+
+import pytest
+import torch
+from vllm.sampling_params import SamplingParams
+from vllm.utils.hashing import sha256
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import (
+    BlockHashListWithBlockSize,
+    get_block_hash,
+    get_request_block_hasher,
+    init_none_hash,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MLAAttentionSpec,
+)
+from vllm.v1.request import Request
+
+from vllm_ascend.core.single_type_kv_cache_manager import CompressAttentionManager
+from vllm_ascend.patch.platform.patch_kv_cache_coordinator import AscendHybridKVCacheCoordinator
+
+pytestmark = pytest.mark.cpu_test
+
+
+@pytest.fixture(autouse=True)
+def _init_hash_seed():
+    init_none_hash(sha256)
+
+
+def _make_request(request_id: str, token_ids: list[int], hash_block_size: int) -> Request:
+    sampling_params = SamplingParams(max_tokens=1)
+    sampling_params.update_from_generation_config({}, eos_token_id=100)
+    return Request(
+        request_id=request_id,
+        prompt_token_ids=token_ids,
+        sampling_params=sampling_params,
+        pooling_params=None,
+        block_hasher=get_request_block_hasher(hash_block_size, sha256),
+    )
+
+
+def _make_compress_manager(
+    block_size: int = 128,
+    compress_ratio: int = 4,
+) -> tuple[MLAAttentionSpec, BlockPool, CompressAttentionManager]:
+    spec = MLAAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        compress_ratio=compress_ratio,
+        model_version="deepseek_v4",
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=8,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    manager = CompressAttentionManager(
+        spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+    )
+    return spec, block_pool, manager
+
+
+def test_compressed_prefix_cache_uses_logical_block_hash() -> None:
+    block_size = 128
+    compress_ratio = 4
+    logical_block_size = block_size * compress_ratio
+    spec, block_pool, manager = _make_compress_manager(block_size, compress_ratio)
+
+    request_a_tokens = list(range(logical_block_size))
+    request_b_tokens = request_a_tokens.copy()
+    request_b_tokens[block_size + 7] = 999_999
+
+    request_a = _make_request("a", request_a_tokens, block_size)
+    request_b = _make_request("b", request_b_tokens, block_size)
+
+    manager.allocate_new_blocks(
+        request_a.request_id,
+        num_tokens=logical_block_size,
+        num_tokens_main_model=logical_block_size,
+    )
+    manager.cache_blocks(request_a, num_tokens=logical_block_size)
+
+    cached_hash = get_block_hash(manager.req_to_blocks[request_a.request_id][0].block_hash)
+    expected_hash = BlockHashListWithBlockSize(
+        request_a.block_hashes,
+        block_size,
+        logical_block_size,
+    )[0]
+    assert cached_hash == expected_hash
+
+    hit_blocks = CompressAttentionManager.find_longest_cache_hit(
+        block_hashes=request_b.block_hashes,
+        max_length=logical_block_size,
+        kv_cache_group_ids=[0],
+        block_pool=block_pool,
+        kv_cache_spec=spec,
+        use_eagle=False,
+        alignment_tokens=logical_block_size,
+    )[0]
+
+    assert hit_blocks == []
+
+
+def test_compressed_prefix_cache_hits_identical_logical_block() -> None:
+    block_size = 128
+    compress_ratio = 4
+    logical_block_size = block_size * compress_ratio
+    spec, block_pool, manager = _make_compress_manager(block_size, compress_ratio)
+
+    request = _make_request("a", list(range(logical_block_size)), block_size)
+    manager.allocate_new_blocks(
+        request.request_id,
+        num_tokens=logical_block_size,
+        num_tokens_main_model=logical_block_size,
+    )
+    manager.cache_blocks(request, num_tokens=logical_block_size)
+
+    hit_blocks = CompressAttentionManager.find_longest_cache_hit(
+        block_hashes=request.block_hashes,
+        max_length=logical_block_size,
+        kv_cache_group_ids=[0],
+        block_pool=block_pool,
+        kv_cache_spec=spec,
+        use_eagle=False,
+        alignment_tokens=logical_block_size,
+    )[0]
+
+    assert hit_blocks == manager.req_to_blocks[request.request_id]
+
+
+def test_hybrid_coordinator_rejects_partial_compressed_prefix_hit() -> None:
+    block_size = 128
+    compress_ratio = 4
+    logical_block_size = block_size * compress_ratio
+    request_a_tokens = list(range(logical_block_size))
+    request_b_tokens = request_a_tokens.copy()
+    request_b_tokens[block_size + 7] = 999_999
+
+    request_a = _make_request("a", request_a_tokens, block_size)
+    request_b = _make_request("b", request_b_tokens, block_size)
+    compressed_spec = MLAAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        compress_ratio=compress_ratio,
+        model_version="deepseek_v4",
+    )
+    full_spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    coordinator = AscendHybridKVCacheCoordinator(
+        kv_cache_config=KVCacheConfig(
+            num_blocks=16,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(["compressed"], compressed_spec),
+                KVCacheGroupSpec(["full"], full_spec),
+            ],
+        ),
+        max_model_len=logical_block_size,
+        use_eagle=False,
+        enable_caching=True,
+        enable_kv_cache_events=False,
+        dcp_world_size=1,
+        pcp_world_size=1,
+        hash_block_size=block_size,
+        max_num_batched_tokens=logical_block_size,
+    )
+
+    for manager in coordinator.single_type_managers:
+        manager.allocate_new_blocks(
+            request_a.request_id,
+            num_tokens=logical_block_size,
+            num_tokens_main_model=logical_block_size,
+        )
+        manager.cache_blocks(request_a, num_tokens=logical_block_size)
+
+    hit_blocks, hit_length = coordinator.find_longest_cache_hit(
+        request_b.block_hashes,
+        max_cache_hit_length=logical_block_size,
+    )
+
+    assert hit_length == 0
+    assert hit_blocks == ([], [])

--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -5,7 +5,11 @@ from collections.abc import Sequence
 
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
-from vllm.v1.core.kv_cache_utils import BlockHashList, KVCacheBlock
+from vllm.v1.core.kv_cache_utils import (
+    BlockHashList,
+    BlockHashListWithBlockSize,
+    KVCacheBlock,
+)
 from vllm.v1.core.single_type_kv_cache_manager import (
     FullAttentionManager,
     SingleTypeKVCacheManager,
@@ -158,9 +162,22 @@ class CompressAttentionManager(FullAttentionManager):
             num_tokens: The total number of tokens that need to be cached
                 (including tokens that are already cached).
         """
-        num_tokens //= self.compress_ratio
+        num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
+        logical_block_size = self.block_size * self.compress_ratio
+        num_full_blocks = num_tokens // logical_block_size
 
-        return super().cache_blocks(request, num_tokens)
+        if num_cached_blocks >= num_full_blocks:
+            return
+
+        self.block_pool.cache_full_blocks(
+            request=request,
+            blocks=self.req_to_blocks[request.request_id],
+            num_cached_blocks=num_cached_blocks,
+            num_full_blocks=num_full_blocks,
+            block_size=logical_block_size,
+            kv_cache_group_id=self.kv_cache_group_id,
+        )
+        self.num_cached_block[request.request_id] = num_full_blocks
 
     @classmethod
     def find_longest_cache_hit(
@@ -184,8 +201,10 @@ class CompressAttentionManager(FullAttentionManager):
         block_size = kv_cache_spec.block_size
         if dcp_world_size * pcp_world_size > 1:
             block_size *= dcp_world_size * pcp_world_size
-        max_num_blocks = max_length // block_size
-        for block_hash in itertools.islice(block_hashes, max_num_blocks):
+        logical_block_size = block_size * kv_cache_spec.compress_ratio
+        logical_block_hashes = BlockHashListWithBlockSize(block_hashes, block_size, logical_block_size)
+        max_num_blocks = max_length // logical_block_size
+        for block_hash in itertools.islice(logical_block_hashes, max_num_blocks):
             # block_hashes is a chain of block hashes. If a block hash is not
             # in the cached_block_hash_to_id, the following block hashes are
             # not computed yet for sure.
@@ -199,11 +218,9 @@ class CompressAttentionManager(FullAttentionManager):
             for computed in computed_blocks:
                 computed.pop()
 
-        # NOTE: Div the compress ratio when finding the longest cache hit token length.
-        alignment_tokens = cdiv(alignment_tokens, kv_cache_spec.compress_ratio)
         while (
-            block_size != alignment_tokens  # Faster for common case.
-            and len(computed_blocks[0]) * block_size % alignment_tokens != 0
+            logical_block_size != alignment_tokens  # Faster for common case.
+            and len(computed_blocks[0]) * logical_block_size % alignment_tokens != 0
         ):
             for computed in computed_blocks:
                 computed.pop()

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -91,14 +91,20 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         # can be a multiple of hash_block_size.
         self.hash_block_size = hash_block_size
         if enable_caching:
-            assert all(g.kv_cache_spec.block_size % hash_block_size == 0 for g in kv_cache_config.kv_cache_groups), (
-                "block_size must be divisible by hash_block_size"
-            )
+            assert all(
+                self._logical_block_size(g.kv_cache_spec) % hash_block_size == 0
+                for g in kv_cache_config.kv_cache_groups
+            ), "block_size must be divisible by hash_block_size"
         assert dcp_world_size == 1, "DCP not support hybrid attn now."
         assert pcp_world_size == 1, "PCP not support hybrid attn now."
         self.verify_and_split_kv_cache_groups()
 
         self.use_eagle = use_eagle
+
+    @staticmethod
+    def _logical_block_size(kv_cache_spec: KVCacheSpec) -> int:
+        compress_ratio = getattr(kv_cache_spec, "compress_ratio", 1) or 1
+        return kv_cache_spec.block_size * max(compress_ratio, 1)
 
     def verify_and_split_kv_cache_groups(self) -> None:
         """
@@ -143,7 +149,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         # each attention type. Requiring this because we don't support partial
         # block cache hit yet.
         # NOTE: use 16k as the alignment tokens for model with compress ratio
-        block_sizes = [spec.block_size * getattr(spec, "compress_ratio", 1) for spec, _, _ in self.attention_groups]
+        block_sizes = [self._logical_block_size(spec) for spec, _, _ in self.attention_groups]
         self.lcm_block_size = lcm(*block_sizes)
 
     def find_longest_cache_hit(
@@ -198,7 +204,8 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                     # Full attention is downward-closed: we only need to look
                     # up cached blocks once; on subsequent iterations just trim
                     # to the (reduced) current hit length.
-                    curr_hit_length = curr_hit_length // spec.block_size * spec.block_size
+                    logical_block_size = self._logical_block_size(spec)
+                    curr_hit_length = curr_hit_length // logical_block_size * logical_block_size
                     continue
 
                 use_eagle = idx in self.eagle_attn_group_indices and idx not in eagle_verified
@@ -206,7 +213,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                 _max_length = curr_hit_length
                 if use_eagle:
                     # Eagle needs to match one more block and then pop the last.
-                    _max_length = min(curr_hit_length + spec.block_size, max_cache_hit_length)
+                    _max_length = min(curr_hit_length + self._logical_block_size(spec), max_cache_hit_length)
                 hit_blocks = manager_cls.find_longest_cache_hit(
                     block_hashes=_get_block_hashes(spec),
                     max_length=_max_length,
@@ -216,15 +223,13 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                     use_eagle=use_eagle,
                     alignment_tokens=self.lcm_block_size,
                 )
-                _new_hit_length = len(hit_blocks[0]) * spec.block_size
+                _new_hit_length = len(hit_blocks[0]) * self._logical_block_size(spec)
                 if use_eagle:
                     eagle_verified.add(idx)
                 elif _new_hit_length < curr_hit_length:
                     # length shrunk; invalidate previous eagle verifications
                     eagle_verified.clear()
                 curr_hit_length = _new_hit_length
-                compress_ratio = getattr(spec, "compress_ratio", 1)
-                curr_hit_length = len(hit_blocks[0]) * spec.block_size * max(compress_ratio, 1)
                 for group_id, blocks in zip(group_ids, hit_blocks):
                     hit_blocks_by_group[group_id] = blocks
 
@@ -237,7 +242,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         # Truncate full attention blocks to final hit_length (if present)
         spec, group_ids, _ = self.attention_groups[0]
         if isinstance(spec, FullAttentionSpec):
-            num_blocks = hit_length // spec.block_size
+            num_blocks = hit_length // self._logical_block_size(spec)
             for group_id in group_ids:
                 if (blks := hit_blocks_by_group[group_id]) is not None:
                     del blks[num_blocks:]


### PR DESCRIPTION
### What this PR does / why we need it?

Related issue: #10296

This is the `releases/v0.20.2rc` backport for the DeepSeek-V4 compressed KV prefix-cache hash issue.

PR #9903 fixed the right root-cause direction on `main`, but it is not sufficient as-is for this release line:

- the #9903 patch does not apply cleanly to current `releases/v0.20.2rc`;
- a #9903-style semantic port still needs manager-side logical hash conversion so lookup uses the same `block_size * compress_ratio` granularity as cache write;
- the hybrid coordinator also needs to compute alignment, hit length, EAGLE extra length, and truncation with compressed logical block size.

This PR keeps the fix scoped to:

- `CompressAttentionManager.cache_blocks()` writing compressed logical block hashes;
- `CompressAttentionManager.find_longest_cache_hit()` converting incoming physical-granularity hashes with `BlockHashListWithBlockSize(..., block_size, block_size * compress_ratio)`;
- `AscendHybridKVCacheCoordinator` using logical block size for compressed groups;
- CPU regression coverage for partial miss, identical hit, and hybrid coordinator behavior.

There is an existing release backport attempt (#9904). I opened this separate PR because this branch is based on current `origin/releases/v0.20.2rc`, is a single signed-off commit, removes the need for debug logging, and includes focused regression tests.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```bash
python3 -m py_compile \
  vllm_ascend/core/single_type_kv_cache_manager.py \
  vllm_ascend/patch/platform/patch_kv_cache_coordinator.py \
  tests/ut/test_compressed_prefix_cache.py

ruff check \
  vllm_ascend/core/single_type_kv_cache_manager.py \
  vllm_ascend/patch/platform/patch_kv_cache_coordinator.py \
  tests/ut/test_compressed_prefix_cache.py

pytest -q tests/ut/test_compressed_prefix_cache.py tests/ut/worker/test_dsv4_compressed_positions.py
```

Result:

```text
4 passed
```