### PR TITLE
[CI] fix mypy error

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1087,7 +1087,7 @@ class NPUModelRunner(GPUModelRunner):
         should_rebuild_async_inputs = (
             self.use_cp
             and self.use_async_spec_decode
-            and self.valid_sampled_token_count_gpu is not None
+            and self.valid_sampled_token_count_gpu is not None # type: ignore[has-type]
             and prev_req_id_to_index
             and has_decode_req
         )


### PR DESCRIPTION
### What this PR does / why we need it?
fix `Error: vllm_ascend/worker/model_runner_v1.py:1075: error: Cannot determine type of "valid_sampled_token_count_gpu"  [has-type]`

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
