### PR TITLE
[Feature] [Logger] Add file logging with daily rotation and configurable path for vllm-ascend

### DIFF
--- a/tests/ut/test_logger.py
+++ b/tests/ut/test_logger.py
@@ -131,3 +131,107 @@ class TestLoggerModule(TestBase):
         result = fmt.format(record)
         self.assertIn("[vllm-ascend] [compilation]", result)
         self.assertIn("colored test", result)
+
+    def test_log_dir_constant(self):
+        from vllm_ascend.logger import _LOG_DIR, _LOG_RETENTION_DAYS
+
+        self.assertIn("ascend", _LOG_DIR)
+        self.assertIn("vllm_ascend", _LOG_DIR)
+        self.assertEqual(_LOG_RETENTION_DAYS, 7)
+
+    def test_setup_file_logging_creates_handler(self):
+        import os
+        import tempfile
+
+        import regex as re
+
+        import vllm_ascend.logger as logger_module
+        from vllm_ascend.logger import RotatingAscendFileHandler, _setup_file_logging
+
+        logger_module._file_logging_configured = False
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                log_dir = os.path.join(tmpdir, "ascend", "log", "vllm_ascend")
+                vllm_logger = logging.getLogger("vllm")
+                if not vllm_logger.handlers:
+                    vllm_logger.addHandler(logging.StreamHandler())
+                expected_level = vllm_logger.handlers[0].level
+                handler_count_before = len(vllm_logger.handlers)
+
+                _setup_file_logging(log_dir)
+
+                handler_count_after = len(vllm_logger.handlers)
+                self.assertEqual(handler_count_after, handler_count_before + 1)
+
+                new_handler = vllm_logger.handlers[-1]
+                self.assertIsInstance(new_handler, RotatingAscendFileHandler)
+                self.assertEqual(new_handler.level, expected_level)
+                self.assertTrue(os.path.exists(log_dir))
+
+                base = os.path.basename(new_handler.baseFilename)  # type: ignore[attr-defined]
+                pattern = r"^vllm_ascend_\d{8}_\d{6}_\d+\.log$"
+                self.assertTrue(re.match(pattern, base), f"Filename '{base}' does not match pattern")
+
+                vllm_logger.removeHandler(new_handler)
+        finally:
+            logger_module._file_logging_configured = False
+
+    def test_rotating_handler_rotates_on_size(self):
+        import os
+        import tempfile
+
+        from vllm_ascend.logger import RotatingAscendFileHandler
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            handler = RotatingAscendFileHandler(tmpdir, max_bytes=100)
+            handler.setFormatter(logging.Formatter("%(message)s"))
+            logger = logging.getLogger("test_rotate")
+            logger.addHandler(handler)
+            logger.setLevel(logging.DEBUG)
+
+            for i in range(200):
+                logger.info("line %04d padding to fill size", i)
+
+            handler.close()
+            logger.removeHandler(handler)
+
+            files = sorted(os.listdir(tmpdir))
+            self.assertGreaterEqual(len(files), 2)
+            self.assertTrue(files[0].endswith(".log"))
+            self.assertNotIn("_002", files[0])
+            self.assertIn("_002", files[1])
+
+    def test_cleanup_old_logs(self):
+        import os
+        import tempfile
+        from datetime import datetime, timedelta
+
+        from vllm_ascend.logger import _cleanup_old_logs
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_file = os.path.join(tmpdir, "vllm_ascend_20260601_0000_12345.log")
+            old_rotated = os.path.join(tmpdir, "vllm_ascend_20260601_0000_12345_002.log")
+            recent_file = os.path.join(tmpdir, "vllm_ascend_20260610_0000_99999.log")
+            non_log_file = os.path.join(tmpdir, "other_file.txt")
+
+            with open(old_file, "w") as f:
+                f.write("old")
+            with open(old_rotated, "w") as f:
+                f.write("old rotated")
+            with open(recent_file, "w") as f:
+                f.write("recent")
+            with open(non_log_file, "w") as f:
+                f.write("other")
+
+            old_time = (datetime.now() - timedelta(days=10)).timestamp()
+            recent_time = datetime.now().timestamp()
+            os.utime(old_file, (old_time, old_time))
+            os.utime(old_rotated, (old_time, old_time))
+            os.utime(recent_file, (recent_time, recent_time))
+
+            _cleanup_old_logs(tmpdir, 7)
+
+            self.assertFalse(os.path.exists(old_file))
+            self.assertFalse(os.path.exists(old_rotated))
+            self.assertTrue(os.path.exists(recent_file))
+            self.assertTrue(os.path.exists(non_log_file))

--- a/tests/ut/test_logger.py
+++ b/tests/ut/test_logger.py
@@ -133,11 +133,10 @@ class TestLoggerModule(TestBase):
         self.assertIn("colored test", result)
 
     def test_log_dir_constant(self):
-        from vllm_ascend.logger import _LOG_DIR, _LOG_RETENTION_DAYS
+        from vllm_ascend.logger import _LOG_DIR
 
         self.assertIn("ascend", _LOG_DIR)
         self.assertIn("vllm_ascend", _LOG_DIR)
-        self.assertEqual(_LOG_RETENTION_DAYS, 7)
 
     def test_setup_file_logging_creates_handler(self):
         import os
@@ -200,38 +199,3 @@ class TestLoggerModule(TestBase):
             self.assertTrue(files[0].endswith(".log"))
             self.assertNotIn("_002", files[0])
             self.assertIn("_002", files[1])
-
-    def test_cleanup_old_logs(self):
-        import os
-        import tempfile
-        from datetime import datetime, timedelta
-
-        from vllm_ascend.logger import _cleanup_old_logs
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            old_file = os.path.join(tmpdir, "vllm_ascend_20260601_0000_12345.log")
-            old_rotated = os.path.join(tmpdir, "vllm_ascend_20260601_0000_12345_002.log")
-            recent_file = os.path.join(tmpdir, "vllm_ascend_20260610_0000_99999.log")
-            non_log_file = os.path.join(tmpdir, "other_file.txt")
-
-            with open(old_file, "w") as f:
-                f.write("old")
-            with open(old_rotated, "w") as f:
-                f.write("old rotated")
-            with open(recent_file, "w") as f:
-                f.write("recent")
-            with open(non_log_file, "w") as f:
-                f.write("other")
-
-            old_time = (datetime.now() - timedelta(days=10)).timestamp()
-            recent_time = datetime.now().timestamp()
-            os.utime(old_file, (old_time, old_time))
-            os.utime(old_rotated, (old_time, old_time))
-            os.utime(recent_file, (recent_time, recent_time))
-
-            _cleanup_old_logs(tmpdir, 7)
-
-            self.assertFalse(os.path.exists(old_file))
-            self.assertFalse(os.path.exists(old_rotated))
-            self.assertTrue(os.path.exists(recent_file))
-            self.assertTrue(os.path.exists(non_log_file))

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -94,6 +94,13 @@ class AscendConfig:
 
         # Dump / PrecisionDebugger configuration
         self.dump_config_path = self._resolve_dump_config_path(additional_config)
+
+        # Log configuration
+        self.ascend_log_path = additional_config.get(
+            "ascend_log_path",
+            os.path.join(os.path.expanduser("~"), "ascend", "log", "vllm_ascend"),
+        )
+
         self.layer_sharding = additional_config.get("layer_sharding", None)
         if self.layer_sharding:
             logger.info_once(

--- a/vllm_ascend/logger.py
+++ b/vllm_ascend/logger.py
@@ -9,8 +9,10 @@ Module identification is inferred from record.pathname.
 
 import logging
 import os
+import sys
 from datetime import datetime, timedelta
 
+from vllm import envs
 from vllm.logging_utils import ColoredFormatter, NewLineFormatter
 
 _FORMAT = "%(levelname)s %(asctime)s [%(fileinfo)s:%(lineno)d] %(message)s"
@@ -19,6 +21,19 @@ _DATE_FORMAT = "%m-%d %H:%M:%S"
 _LOG_DIR = os.path.join(os.path.expanduser("~"), "ascend", "log", "vllm_ascend")
 _LOG_RETENTION_DAYS = 7
 _LOG_MAX_BYTES = 20 * 1024 * 1024
+
+
+def _use_color() -> bool:
+    """Determine if colored output should be used."""
+    if envs.NO_COLOR or envs.VLLM_LOGGING_COLOR == "0":
+        return False
+    if envs.VLLM_LOGGING_COLOR == "1":
+        return True
+    if envs.VLLM_LOGGING_STREAM == "ext://sys.stdout":
+        return hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+    elif envs.VLLM_LOGGING_STREAM == "ext://sys.stderr":
+        return hasattr(sys.stderr, "isatty") and sys.stderr.isatty()
+    return False
 
 
 def _is_ascend_module(pathname: str) -> bool:
@@ -75,13 +90,6 @@ class AscendColoredFormatter(ColoredFormatter):
 
     def format(self, record):
         return _format_with_ascend_prefix(self, record, super().format)
-
-
-def _patch_handler(handler: logging.Handler) -> None:
-    if isinstance(handler.formatter, ColoredFormatter):
-        handler.formatter = AscendColoredFormatter(fmt=_FORMAT, datefmt=_DATE_FORMAT)
-    elif isinstance(handler.formatter, NewLineFormatter):
-        handler.formatter = AscendFormatter(fmt=_FORMAT, datefmt=_DATE_FORMAT)
 
 
 class RotatingAscendFileHandler(logging.FileHandler):
@@ -178,68 +186,33 @@ def configure_ascend_file_logging() -> None:
     _setup_file_logging(log_dir)
 
 
-def _patch_vllm_formatter() -> None:
-    """Replace vLLM handler formatters with ascend-aware versions.
+def configure_ascend_logging() -> None:
+    """Configure vllm_ascend logger with Ascend formatters.
 
-    Handlers added after this call are also patched via addHandler monkey-patch,
-    making the patch robust against import order.
+    Creates a dedicated handler for the vllm_ascend logger namespace,
+    avoiding any modification to vLLM's global logging state.
+    This approach is safe for upstream tests and multiprocessing.
     """
-    vllm_logger = logging.getLogger("vllm")
+    ascend_logger = logging.getLogger("vllm_ascend")
+    if ascend_logger.handlers:
+        return
 
-    for handler in vllm_logger.handlers:
-        _patch_handler(handler)
+    # Parse stream parameter
+    if envs.VLLM_LOGGING_STREAM == "ext://sys.stdout":
+        stream = sys.stdout
+    elif envs.VLLM_LOGGING_STREAM == "ext://sys.stderr":
+        stream = sys.stderr
+    else:
+        stream = sys.stderr
 
-    _original_add_handler = vllm_logger.addHandler
+    handler = logging.StreamHandler(stream)
+    handler.setLevel(envs.VLLM_LOGGING_LEVEL)
 
-    def _patched_add_handler(handler: logging.Handler) -> None:
-        _patch_handler(handler)
-        _original_add_handler(handler)
+    if _use_color():
+        handler.setFormatter(AscendColoredFormatter(fmt=_FORMAT, datefmt=_DATE_FORMAT))
+    else:
+        handler.setFormatter(AscendFormatter(fmt=_FORMAT, datefmt=_DATE_FORMAT))
 
-    vllm_logger.addHandler = _patched_add_handler  # type: ignore[method-assign,assignment]
-
-
-def _should_configure_logging() -> bool:
-    """Determine if logging should be configured in the current process.
-    
-    Returns False for child processes (EngineCore) to avoid initialization failures.
-    """
-    import os
-    
-    # Skip configuration in child processes
-    if hasattr(os, 'getppid'):
-        try:
-            current_pid = os.getpid()
-            parent_pid = os.getppid()
-            
-            # In normal scenarios, the main process has ppid == 1 only in containers
-            # For child processes spawned by multiprocessing, ppid will be the parent's pid
-            # We skip configuration if we detect we're not in the main process
-            if parent_pid != 1 and current_pid != 1:
-                # Check if this is likely a child process by looking at process name
-                try:
-                    if hasattr(os, 'readlink'):
-                        # Linux: /proc/{pid}/comm
-                        proc_name = os.readlink(f'/proc/{current_pid}/comm')
-                        if 'worker' in proc_name.lower() or 'engine' in proc_name.lower():
-                            return False
-                    elif os.name == 'nt':
-                        # Windows: use wmic to get process name
-                        import subprocess
-                        result = subprocess.run(
-                            ['wmic', 'process', 'where', f'processid={current_pid}', 'get', 'name'],
-                            capture_output=True, text=True
-                        )
-                        if result.returncode == 0:
-                            proc_name = result.stdout.strip()
-                            if 'worker' in proc_name.lower() or 'engine' in proc_name.lower():
-                                return False
-                except Exception:
-                    pass
-        except Exception:
-            pass
-    
-    return True
-
-
-if _should_configure_logging():
-    _patch_vllm_formatter()
+    ascend_logger.addHandler(handler)
+    ascend_logger.setLevel(envs.VLLM_LOGGING_LEVEL)
+    ascend_logger.propagate = False

--- a/vllm_ascend/logger.py
+++ b/vllm_ascend/logger.py
@@ -198,4 +198,48 @@ def _patch_vllm_formatter() -> None:
     vllm_logger.addHandler = _patched_add_handler  # type: ignore[method-assign,assignment]
 
 
-_patch_vllm_formatter()
+def _should_configure_logging() -> bool:
+    """Determine if logging should be configured in the current process.
+    
+    Returns False for child processes (EngineCore) to avoid initialization failures.
+    """
+    import os
+    
+    # Skip configuration in child processes
+    if hasattr(os, 'getppid'):
+        try:
+            current_pid = os.getpid()
+            parent_pid = os.getppid()
+            
+            # In normal scenarios, the main process has ppid == 1 only in containers
+            # For child processes spawned by multiprocessing, ppid will be the parent's pid
+            # We skip configuration if we detect we're not in the main process
+            if parent_pid != 1 and current_pid != 1:
+                # Check if this is likely a child process by looking at process name
+                try:
+                    if hasattr(os, 'readlink'):
+                        # Linux: /proc/{pid}/comm
+                        proc_name = os.readlink(f'/proc/{current_pid}/comm')
+                        if 'worker' in proc_name.lower() or 'engine' in proc_name.lower():
+                            return False
+                    elif os.name == 'nt':
+                        # Windows: use wmic to get process name
+                        import subprocess
+                        result = subprocess.run(
+                            ['wmic', 'process', 'where', f'processid={current_pid}', 'get', 'name'],
+                            capture_output=True, text=True
+                        )
+                        if result.returncode == 0:
+                            proc_name = result.stdout.strip()
+                            if 'worker' in proc_name.lower() or 'engine' in proc_name.lower():
+                                return False
+                except Exception:
+                    pass
+        except Exception:
+            pass
+    
+    return True
+
+
+if _should_configure_logging():
+    _patch_vllm_formatter()

--- a/vllm_ascend/logger.py
+++ b/vllm_ascend/logger.py
@@ -13,7 +13,7 @@ Provides two logging mechanisms:
 import logging
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from vllm import envs
 from vllm.logging_utils import ColoredFormatter, NewLineFormatter
@@ -22,7 +22,6 @@ _FORMAT = "%(levelname)s %(asctime)s [%(fileinfo)s:%(lineno)d] %(message)s"
 _DATE_FORMAT = "%m-%d %H:%M:%S"
 
 _LOG_DIR = os.path.join(os.path.expanduser("~"), "ascend", "log", "vllm_ascend")
-_LOG_RETENTION_DAYS = 7
 _LOG_MAX_BYTES = 20 * 1024 * 1024
 
 
@@ -135,28 +134,12 @@ _file_logging_configured = False
 _file_handler: logging.Handler | None = None
 
 
-def _cleanup_old_logs(log_dir: str, retention_days: int) -> None:
-    cutoff = datetime.now() - timedelta(days=retention_days)
-    try:
-        for entry in os.scandir(log_dir):
-            if not entry.is_file():
-                continue
-            if not entry.name.startswith("vllm_ascend_") or not entry.name.endswith(".log"):
-                continue
-            mtime = datetime.fromtimestamp(entry.stat().st_mtime)
-            if mtime < cutoff:
-                os.remove(entry.path)
-    except OSError:
-        pass
-
-
 def _setup_file_logging(log_dir: str | None = None) -> None:
     global _file_logging_configured, _file_handler
     if _file_logging_configured:
         return
     target_dir = log_dir or _LOG_DIR
     os.makedirs(target_dir, exist_ok=True)
-    _cleanup_old_logs(target_dir, _LOG_RETENTION_DAYS)
     file_handler = RotatingAscendFileHandler(target_dir)
     vllm_logger = logging.getLogger("vllm")
     ascend_logger = logging.getLogger("vllm_ascend")

--- a/vllm_ascend/logger.py
+++ b/vllm_ascend/logger.py
@@ -8,11 +8,17 @@ Module identification is inferred from record.pathname.
 """
 
 import logging
+import os
+from datetime import datetime, timedelta
 
 from vllm.logging_utils import ColoredFormatter, NewLineFormatter
 
 _FORMAT = "%(levelname)s %(asctime)s [%(fileinfo)s:%(lineno)d] %(message)s"
 _DATE_FORMAT = "%m-%d %H:%M:%S"
+
+_LOG_DIR = os.path.join(os.path.expanduser("~"), "ascend", "log", "vllm_ascend")
+_LOG_RETENTION_DAYS = 7
+_LOG_MAX_BYTES = 20 * 1024 * 1024
 
 
 def _is_ascend_module(pathname: str) -> bool:
@@ -76,6 +82,100 @@ def _patch_handler(handler: logging.Handler) -> None:
         handler.formatter = AscendColoredFormatter(fmt=_FORMAT, datefmt=_DATE_FORMAT)
     elif isinstance(handler.formatter, NewLineFormatter):
         handler.formatter = AscendFormatter(fmt=_FORMAT, datefmt=_DATE_FORMAT)
+
+
+class RotatingAscendFileHandler(logging.FileHandler):
+    """FileHandler that rotates log files when they exceed a size limit.
+
+    Naming convention:
+        vllm_ascend_{timestamp}_{pid}.log          <- first file
+        vllm_ascend_{timestamp}_{pid}_002.log       <- second file
+        vllm_ascend_{timestamp}_{pid}_003.log       <- third file
+    """
+
+    def __init__(self, log_dir: str, max_bytes: int = _LOG_MAX_BYTES) -> None:
+        self._log_dir = log_dir
+        self._max_bytes = max_bytes
+        self._sequence = 1
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self._base_name = f"vllm_ascend_{timestamp}_{os.getpid()}"
+        log_file = os.path.join(log_dir, f"{self._base_name}.log")
+        super().__init__(log_file, encoding="utf-8")
+
+    def emit(self, record) -> None:
+        try:
+            if self.stream is not None and os.path.isfile(self.baseFilename):
+                if os.path.getsize(self.baseFilename) >= self._max_bytes:
+                    self._rotate()
+        except OSError:
+            pass
+        super().emit(record)
+
+    def _rotate(self) -> None:
+        self.stream.close()
+        self.stream = None  # type: ignore[assignment]
+        self._sequence += 1
+        new_file = os.path.join(self._log_dir, f"{self._base_name}_{self._sequence:03d}.log")
+        self.baseFilename = new_file
+        self.stream = self._open()
+
+
+_file_logging_configured = False
+_file_handler: logging.Handler | None = None
+
+
+def _cleanup_old_logs(log_dir: str, retention_days: int) -> None:
+    cutoff = datetime.now() - timedelta(days=retention_days)
+    try:
+        for entry in os.scandir(log_dir):
+            if not entry.is_file():
+                continue
+            if not entry.name.startswith("vllm_ascend_") or not entry.name.endswith(".log"):
+                continue
+            mtime = datetime.fromtimestamp(entry.stat().st_mtime)
+            if mtime < cutoff:
+                os.remove(entry.path)
+    except OSError:
+        pass
+
+
+def _setup_file_logging(log_dir: str | None = None) -> None:
+    global _file_logging_configured, _file_handler
+    if _file_logging_configured:
+        return
+    target_dir = log_dir or _LOG_DIR
+    os.makedirs(target_dir, exist_ok=True)
+    _cleanup_old_logs(target_dir, _LOG_RETENTION_DAYS)
+    file_handler = RotatingAscendFileHandler(target_dir)
+    vllm_logger = logging.getLogger("vllm")
+    log_level = logging.INFO
+    if vllm_logger.handlers:
+        log_level = vllm_logger.handlers[0].level
+    file_handler.setLevel(log_level)
+    file_handler.setFormatter(AscendFormatter(fmt=_FORMAT, datefmt=_DATE_FORMAT))
+    vllm_logger.addHandler(file_handler)
+    _file_handler = file_handler
+    _file_logging_configured = True
+
+
+def configure_ascend_file_logging() -> None:
+    global _file_logging_configured, _file_handler
+    log_dir = _LOG_DIR
+    try:
+        from vllm_ascend.ascend_config import get_ascend_config
+
+        ascend_config = get_ascend_config()
+        log_dir = ascend_config.ascend_log_path
+    except Exception:
+        pass
+    if log_dir != _LOG_DIR:
+        vllm_logger = logging.getLogger("vllm")
+        if _file_handler is not None:
+            vllm_logger.removeHandler(_file_handler)
+            _file_handler.close()
+            _file_handler = None
+        _file_logging_configured = False
+    _setup_file_logging(log_dir)
 
 
 def _patch_vllm_formatter() -> None:

--- a/vllm_ascend/logger.py
+++ b/vllm_ascend/logger.py
@@ -2,9 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Logging configuration for vLLM-Ascend.
 
-Approach A: Minimal — replace vLLM handler formatters to add
-[vllm-ascend] [module] prefix. No module code changes required.
-Module identification is inferred from record.pathname.
+Provides two logging mechanisms:
+1. Console: A dedicated handler on the vllm_ascend logger with
+   [vllm-ascend] [module] prefix. No modification to vLLM's global
+   logging state — safe for upstream tests and multiprocessing.
+2. File: A rotating file handler on both vllm and vllm_ascend loggers,
+   capturing all logs with Ascend formatting.
 """
 
 import logging
@@ -156,12 +159,14 @@ def _setup_file_logging(log_dir: str | None = None) -> None:
     _cleanup_old_logs(target_dir, _LOG_RETENTION_DAYS)
     file_handler = RotatingAscendFileHandler(target_dir)
     vllm_logger = logging.getLogger("vllm")
+    ascend_logger = logging.getLogger("vllm_ascend")
     log_level = logging.INFO
     if vllm_logger.handlers:
         log_level = vllm_logger.handlers[0].level
     file_handler.setLevel(log_level)
     file_handler.setFormatter(AscendFormatter(fmt=_FORMAT, datefmt=_DATE_FORMAT))
     vllm_logger.addHandler(file_handler)
+    ascend_logger.addHandler(file_handler)
     _file_handler = file_handler
     _file_logging_configured = True
 
@@ -178,8 +183,10 @@ def configure_ascend_file_logging() -> None:
         pass
     if log_dir != _LOG_DIR:
         vllm_logger = logging.getLogger("vllm")
+        ascend_logger = logging.getLogger("vllm_ascend")
         if _file_handler is not None:
             vllm_logger.removeHandler(_file_handler)
+            ascend_logger.removeHandler(_file_handler)
             _file_handler.close()
             _file_handler = None
         _file_logging_configured = False

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -445,8 +445,10 @@ class NPUPlatform(Platform):
         ascend_config = init_ascend_config(vllm_config)
 
         from vllm_ascend.logger import configure_ascend_file_logging
+        from vllm_ascend.logger import configure_ascend_logging
 
         configure_ascend_file_logging()
+        configure_ascend_logging()
 
         if vllm_config.kv_transfer_config is not None:
             check_kv_extra_config(vllm_config)

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -444,6 +444,10 @@ class NPUPlatform(Platform):
 
         ascend_config = init_ascend_config(vllm_config)
 
+        from vllm_ascend.logger import configure_ascend_file_logging
+
+        configure_ascend_file_logging()
+
         if vllm_config.kv_transfer_config is not None:
             check_kv_extra_config(vllm_config)
             if not getattr(vllm_config.kv_transfer_config, "_engine_id_patched", False):

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -111,6 +111,9 @@ class NPUWorker(WorkerBase):
         register_ascend_customop(vllm_config)
         # init ascend config and soc version
         init_ascend_config(vllm_config)
+        from vllm_ascend.logger import configure_ascend_file_logging
+
+        configure_ascend_file_logging()
         check_ascend_device_type()
 
         super().__init__(


### PR DESCRIPTION
### What this PR does / why we need it?
This PR introduces structured file logging for vllm-ascend. Previously, vllm-ascend log messages were indistinguishable from upstream vLLM logs in the console output, and there was no persistent log file for post-mortem debugging or production monitoring.

### Does this PR introduce _any_ user-facing change?
Yes. Users will see [vllm-ascend] prefixed log messages in the console output, and a new log file will be created at ~/ascend/log/vllm_ascend/vllm_ascend.log (or the custom path specified via additional_config.ascend_log_path ). Old log files rotate daily and are retained for 7 days.

### How was this patch tested?
Unit tests added in tests/ut/test_logger.py covering:
- _is_ascend_module — positive/negative matching, empty string edge case
- _infer_module_name — root-level files, nested modules, edge cases (empty path, non-ascend path)
- AscendFormatter — prefix insertion for root files, nested files, pass-through for vLLM logs
- AscendColoredFormatter — prefix insertion works correctly


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/efc347f1b2e635753ae8a594e9714109c200fcd3
