### PR TITLE
[BugFix][SpecDecode] Sanitize MTP placeholders before model forward

### DIFF
--- a/tests/ut/sample/test_rejection_sampler.py
+++ b/tests/ut/sample/test_rejection_sampler.py
@@ -152,6 +152,42 @@ class TestAscendRejectionSampler(TestBase):
     @patch("torch.ones", new=mock_pin_memory(torch.ones))
     @patch("torch.full", new=mock_pin_memory(torch.full))
     @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
+    def test_rejection_random_sample_pytorch_rejects_all_placeholder_mtp3(self):
+        batch_size = 1
+        max_spec_len = 3
+        output_token_ids = torch.full((batch_size, max_spec_len + 1), PLACEHOLDER_TOKEN_ID)
+
+        cu_num_draft_tokens = torch.tensor([3])
+        draft_token_ids = torch.tensor([PLACEHOLDER_TOKEN_ID, PLACEHOLDER_TOKEN_ID, PLACEHOLDER_TOKEN_ID])
+        # Placeholder draft tokens must reject regardless of target probability.
+        # The recovered token is passed in after recovery sampling.
+        target_probs = torch.zeros((max_spec_len, 3))
+        bonus_token_ids = torch.tensor([[100]])
+        recovered_token_ids = torch.tensor([2, 1, 0])
+        uniform_probs = torch.tensor([0.0, 0.0, 0.0])
+        is_greedy = torch.tensor([False])
+
+        rejection_random_sample_pytorch(
+            output_token_ids,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            None,
+            target_probs,
+            bonus_token_ids,
+            recovered_token_ids,
+            uniform_probs,
+            is_greedy,
+            max_spec_len,
+            vocab_size=3,
+            IS_NGRAM=True,
+        )
+
+        assert output_token_ids.tolist() == [[2, PLACEHOLDER_TOKEN_ID, PLACEHOLDER_TOKEN_ID, PLACEHOLDER_TOKEN_ID]]
+
+    @patch("torch.arange", new=mock_pin_memory(torch.arange))
+    @patch("torch.ones", new=mock_pin_memory(torch.ones))
+    @patch("torch.full", new=mock_pin_memory(torch.full))
+    @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
     def test_sample_recovered_tokens_pytorch_keeps_placeholder_distribution(self):
         output_token_ids = torch.empty(1, dtype=torch.int32)
         cu_num_draft_tokens = torch.tensor([1])

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -2,6 +2,7 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import torch
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheGroupSpec, KVCacheTensor
 
@@ -109,6 +110,7 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
             [1, 2, 3, -1],
             [4, 5, -1],
         ]
+        input_batch.sampling_metadata.top_k = None
         input_batch.num_reqs = 2
         input_batch.top_k_cpu = None
         input_batch.prev_req_id_to_index = {
@@ -151,6 +153,68 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
         actual_output_token_ids = actual_sampling_metadata.output_token_ids
         self.assertEqual(actual_output_token_ids[0], [1, 2, 3, 6])
         self.assertEqual(actual_output_token_ids[1], [4, 5, 7])
+
+    def test_placeholder_spec_tokens_are_sanitized_only_for_forward(self):
+        runner = self._build_runner()
+        runner.input_ids = SimpleNamespace(
+            cpu=torch.tensor([11, -1, 33, -1], dtype=torch.int32),
+            gpu=torch.tensor([11, -1, 33, -1], dtype=torch.int32),
+        )
+        scheduler_output = SimpleNamespace(
+            scheduled_spec_decode_tokens={"req0": [-1]},
+        )
+
+        runner._sanitize_placeholder_input_ids_for_forward(
+            scheduler_output,
+            num_forward_tokens=4,
+        )
+
+        self.assertEqual(runner.input_ids.gpu.tolist(), [11, 0, 33, 0])
+        self.assertEqual(runner.input_ids.cpu.tolist(), [11, -1, 33, -1])
+
+    def test_placeholder_sanitization_is_scoped_to_current_forward(self):
+        runner = self._build_runner()
+        runner.input_ids = SimpleNamespace(
+            cpu=torch.tensor([11, -1, 33, -1], dtype=torch.int32),
+            gpu=torch.tensor([11, -1, 33, -1], dtype=torch.int32),
+        )
+        scheduler_output = SimpleNamespace(
+            scheduled_spec_decode_tokens={"req0": [-1]},
+        )
+
+        runner._sanitize_placeholder_input_ids_for_forward(
+            scheduler_output,
+            num_forward_tokens=2,
+        )
+
+        self.assertEqual(runner.input_ids.gpu.tolist(), [11, 0, 33, -1])
+
+    def test_mtp3_placeholder_metadata_is_preserved_before_sanitizing_forward(self):
+        runner = self._build_runner()
+        runner.pcp_size = 1
+        runner.arange_np = np.arange(8, dtype=np.int32)
+        runner._arange_scratch = np.empty(8, dtype=np.int32)
+        runner.input_ids = SimpleNamespace(
+            cpu=torch.tensor([11, -1, -1, -1], dtype=torch.int32),
+            gpu=torch.tensor([11, -1, -1, -1], dtype=torch.int32),
+        )
+        scheduler_output = SimpleNamespace(
+            scheduled_spec_decode_tokens={"req0": [-1, -1, -1]},
+        )
+
+        spec_decode_metadata = runner._calc_spec_decode_metadata(
+            num_draft_tokens=np.array([3], dtype=np.int32),
+            cu_num_scheduled_tokens=np.array([4], dtype=np.int32),
+            num_pcp_pads=None,
+        )
+        runner._sanitize_placeholder_input_ids_for_forward(
+            scheduler_output,
+            num_forward_tokens=4,
+        )
+
+        self.assertEqual(spec_decode_metadata.draft_token_ids.tolist(), [-1, -1, -1])
+        self.assertEqual(runner.input_ids.gpu.tolist(), [11, 0, 0, 0])
+        self.assertEqual(runner.input_ids.cpu.tolist(), [11, -1, -1, -1])
 
 
 class TestNPUModelRunnerDebugger(unittest.TestCase):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -92,7 +92,7 @@ else:
     from vllm.v1.outputs import RoutedExpertsLists
 from vllm.v1.sample.logits_processor import build_logitsprocs
 from vllm.v1.sample.metadata import SamplingMetadata
-from vllm.v1.sample.rejection_sampler import RejectionSampler
+from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID, RejectionSampler
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.spec_decode.ngram_proposer_gpu import copy_num_valid_draft_tokens
 from vllm.v1.structured_output.utils import apply_grammar_bitmask
@@ -1522,6 +1522,23 @@ class NPUModelRunner(GPUModelRunner):
 
         return attn_state
 
+    def _sanitize_placeholder_input_ids_for_forward(
+        self,
+        scheduler_output: "SchedulerOutput",
+        num_forward_tokens: int,
+    ) -> None:
+        scheduled_spec_tokens = scheduler_output.scheduled_spec_decode_tokens
+        if not scheduled_spec_tokens:
+            return
+        if not any(
+            PLACEHOLDER_TOKEN_ID in token_ids
+            for token_ids in scheduled_spec_tokens.values()
+        ):
+            return
+
+        input_ids = self.input_ids.gpu[:num_forward_tokens]
+        input_ids.masked_fill_(input_ids == PLACEHOLDER_TOKEN_ID, 0)
+
     def _calc_spec_decode_metadata(
         self,
         num_draft_tokens: np.ndarray,
@@ -2160,6 +2177,13 @@ class NPUModelRunner(GPUModelRunner):
                     num_scheduled_tokens_np=num_scheduled_tokens_np,
                     cascade_attn_prefix_lens=cascade_attn_prefix_lens,
                     num_scheduled_tokens_compressed_list=num_scheduled_tokens_compressed_list,
+                )
+
+                self._sanitize_placeholder_input_ids_for_forward(
+                    scheduler_output,
+                    num_tokens_padded
+                    if not (self.use_cp and self.pcp_manager.pcp_use_hybrid_attn)
+                    else total_num_scheduled_tokens,
                 )
 
             (


### PR DESCRIPTION
### What this PR does
Fixes #10305.

MTP placeholder token IDs are valid scheduler/sampler metadata, especially on the PD kv-consumer first step, but they must not reach model forward `input_ids` because embedding kernels reject `-1` token IDs.

This PR sanitizes only the current forward GPU input buffer after `SpecDecodeMetadata` has been built, replacing `PLACEHOLDER_TOKEN_ID` with token id `0`. It complements the sampler-side placeholder handling in #10043 and #10259.

### Why it is safe
- `SpecDecodeMetadata.draft_token_ids` is computed before sanitization, so sampler/rejection metadata keeps the original placeholders.
- Only `self.input_ids.gpu[:num_forward_tokens]` is mutated; CPU token history is unchanged.
- Tokens outside the current forward range are unchanged.

### Validation
Real-machine smoke: DeepSeek V4 Flash PD 1P1D, P `dp2tp4` on devices `0-7`, D `dp8tp1` on devices `8-15`, D launched with `--max-num-batched-tokens 8 --max-num-seqs 4`; single `hi` and 4 concurrent `hi` requests completed, D metrics returned `running=0 waiting=0`, and logs had no `507011`, `GatherV2`, `out of range`, or scheduler dump.


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
