### PR TITLE
[Feature] [BugFix] DSV3.1-style fine-grained TP for DeepSeek-V4 DSA o_proj and embedding (backup) 

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -448,10 +448,18 @@ class FinegrainedTPConfig:
         enabled_configs = []
         if self.oproj_tensor_parallel_size > 0:
             enabled_configs.append(f"oproj_tensor_parallel_size={self.oproj_tensor_parallel_size}")
-            # dummy_run does not run the entire attention module in eager mode,
-            # so the o_proj tp split can only be used in graph mode.
-            if vllm_config.model_config and vllm_config.model_config.enforce_eager:
-                raise AssertionError("oproj_tensor_parallel_size is only supported in graph mode")
+            # wo_a/wo_b are sharded solely by the OTP group (which splits DP,
+            # orthogonal to the standard TP group), but _forward_o_proj reshapes
+            # the attention output with n_local_groups = n_groups // tp_size
+            # (standard TP). When tp_size > 1 the weight-shard and input-shard
+            # operate on different axes of the rank grid and no longer align,
+            # so oproj TP currently requires standard tp_size == 1.
+            if vllm_config.parallel_config.tensor_parallel_size > 1:
+                raise AssertionError(
+                    "oproj_tensor_parallel_size currently requires "
+                    "tensor_parallel_size == 1, got "
+                    f"{vllm_config.parallel_config.tensor_parallel_size}."
+                )
             if vllm_config.kv_transfer_config is None or not vllm_config.kv_transfer_config.is_kv_consumer:
                 raise AssertionError(
                     "oproj_tensor_parallel_size is only supported in pd scenario and can only be used in D node."

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar, TypeAlias
 
 import torch
+import torch.distributed as dist
 import torch.nn.functional as F
 import torch_npu
 import vllm.envs as envs_vllm
@@ -19,6 +20,7 @@ from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.distributed.parallel_state import get_otp_group
 from vllm_ascend.ops.cv_linear import CVLinearWrapper
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
@@ -29,6 +31,7 @@ from vllm_ascend.utils import (
     get_ascend_device_type,
     npu_stream_switch,
     olora_tp_enable,
+    oproj_tp_enable,
 )
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 
@@ -1550,6 +1553,10 @@ class AscendDSAImpl(DSAAttentionImpl):
         topk_indices_buffer.copy_(topk_indices_to_cache)
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
+        # Attention impls are not walked by vllm's process_weights_after_loading
+        # dispatcher (only LinearMethodBase subclasses are). OTP buffers are
+        # allocated lazily on the first _forward_o_proj call, which always runs
+        # before ACL graph capture (profiling run triggers it).
         pass
 
     # TODO: cast to bfloat16 to speed up
@@ -1571,6 +1578,94 @@ class AscendDSAImpl(DSAAttentionImpl):
             x = x_rot.reshape(1, num_tokens, -1, rotary_dim)
         return x
 
+    def _forward_o_proj(self, o_proj_input: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
+        num_tokens = o_proj_input.shape[0]
+        group_hidden_dim = o_proj_input.shape[1] * o_proj_input.shape[2] // self.n_local_groups
+        o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, group_hidden_dim)
+        # A5 (Ascend950) uses an FP8-quantized o_proj path (dynamic MX quant
+        # + quantized batch matmul). Preserve it as-is: it predates and is
+        # orthogonal to the OTP / olora_tp paths below, so it must win first.
+        if get_ascend_device_type() in {AscendDeviceType.A5}:
+            o = o_proj_input
+            o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
+            o = torch_npu.npu_transpose_quant_batchmatmul(
+                o,
+                self.wo_a.weight,
+                dtype=torch.bfloat16,
+                bias=None,
+                group_sizes=(0, 0, 32),
+                x1_scale=swiglu_out_scale.view(torch.float8_e8m0fnu),
+                x2_scale=self.wo_a.weight_scale.view(torch.float8_e8m0fnu),
+                perm_x1=(1, 0, 2),
+                perm_x2=(0, 1, 2),
+                perm_y=(1, 0, 2),
+            )
+            o = o.reshape(num_tokens, -1)
+            output[...] = self.wo_b(o)
+        elif oproj_tp_enable():
+            oproj_group = get_otp_group()
+            oproj_tp_size = oproj_group.world_size
+            if self.n_local_groups % oproj_tp_size != 0:
+                raise ValueError(
+                    "n_local_groups must be divisible by "
+                    f"oproj_tensor_parallel_size, got {self.n_local_groups} "
+                    f"and {oproj_tp_size}."
+                )
+
+            groups_per_rank = self.n_local_groups // oproj_tp_size
+
+            # DSV3.1 O-matrix pattern (mirrors
+            # vllm_ascend.ops.linear_op.OProjRowParallelOp): redistribute the
+            # tokens across the OTP group with a dynamic all_to_all — a fresh
+            # recv buffer per call, no static max-padded buffer and no capacity
+            # padding. Variable token counts are carried per ACL graph bucket
+            # the same way the standard o_proj (OProjRowParallelOp) carries
+            # them, so this path does not pin a fixed exchange size.
+            # [num_tokens, n_local_groups, gh]
+            # -> [num_tokens, oproj_tp_size, groups_per_rank, gh]
+            o_proj_input = o_proj_input.view(num_tokens, oproj_tp_size, groups_per_rank, group_hidden_dim)
+            # Lay the OTP-rank split on dim 0 for all_to_all_single.
+            send_buf = o_proj_input.permute(1, 0, 2, 3).contiguous().view(-1)
+            recv_buf = torch.empty(
+                oproj_tp_size * num_tokens * groups_per_rank * group_hidden_dim,
+                dtype=o_proj_input.dtype,
+                device=o_proj_input.device,
+            )
+            dist.all_to_all_single(recv_buf, send_buf, group=oproj_group.device_group)
+            # Rank r now owns groups-slice r for every rank's tokens.
+            o_proj_input = recv_buf.view(oproj_tp_size * num_tokens, groups_per_rank, group_hidden_dim)
+            o_proj_input = torch_npu.npu_transpose_batchmatmul(
+                o_proj_input,
+                self.wo_a.weight,
+                bias=None,
+                scale=None,
+                perm_x1=(1, 0, 2),
+                perm_x2=(0, 1, 2),
+                perm_y=(1, 0, 2),
+                batch_split_factor=1,
+            )
+            o_proj_input = o_proj_input.reshape(oproj_tp_size * num_tokens, -1)
+            o_proj_output = self.wo_b(o_proj_input)
+            o_proj_output = oproj_group.reduce_scatter(o_proj_output, dim=0)
+            output[...] = o_proj_output
+        elif olora_tp_enable():
+            o_proj_input = self.wo_a(o_proj_input)
+            output[...] = self.wo_b(o_proj_input)
+        else:
+            o_proj_input = torch_npu.npu_transpose_batchmatmul(
+                o_proj_input,
+                self.wo_a.weight,
+                bias=None,
+                scale=None,
+                perm_x1=(1, 0, 2),
+                perm_x2=(0, 1, 2),
+                perm_y=(1, 0, 2),
+                batch_split_factor=1,
+            )
+            o_proj_input = o_proj_input.reshape(num_tokens, -1)
+            output[...] = self.wo_b(o_proj_input)
+        return output
+
     def forward(  # type: ignore[override]
         self,
         layer_name,
@@ -1581,11 +1676,20 @@ class AscendDSAImpl(DSAAttentionImpl):
         output: torch.Tensor | None = None,
     ) -> torch.Tensor:
         assert output is not None, "Output tensor must be provided."
+        output_padded = output
+        forward_context = get_forward_context()
+        o_proj_input_shape = (forward_context.num_tokens, self.n_local_heads, self.head_dim)
         if attn_metadata is None:
-            return output.fill_(0)
+            # Profiling run: run o_proj on zero input so HCCL collectives are
+            # captured by the ACL graph.  Non-OTP just zeros the output.
+            if oproj_tp_enable():
+                o_proj_input = torch.zeros(o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device)
+                self._forward_o_proj(o_proj_input, output)
+            else:
+                output.fill_(0)
+            return output
         if not isinstance(attn_metadata, list):
             attn_metadata = [attn_metadata]
-        output_padded = output
         # Process for Flash Comm V1
         has_prefill = attn_metadata[0].num_prefills > 0
         has_decode = attn_metadata[0].num_decodes > 0
@@ -1612,8 +1716,6 @@ class AscendDSAImpl(DSAAttentionImpl):
             prefill_hidden_states = hidden_states[decode_tokens:actual_tokens]
             decode_hidden_states = hidden_states[:decode_tokens]
 
-        forward_context = get_forward_context()
-        o_proj_input_shape = (forward_context.num_tokens, self.n_local_heads, self.head_dim)
         o_proj_input = torch.empty(o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device)
         assert kv_cache is not None, "kv_cache tensor tuple must be provided."
         if has_prefill:
@@ -1638,7 +1740,6 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         cos = attn_metadata[0].cos[layer_name]
         sin = attn_metadata[0].sin[layer_name]
-        num_tokens = o_proj_input.shape[0]
 
         torch.ops._C_ascend.inplace_partial_rotary_mul(
             o_proj_input.unsqueeze(1),
@@ -1649,42 +1750,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         )
 
         # o
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
-            o = o_proj_input.view(num_tokens, self.n_local_groups, -1)
-            o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
-            o = torch_npu.npu_transpose_quant_batchmatmul(
-                o,
-                self.wo_a.weight,
-                dtype=torch.bfloat16,
-                bias=None,
-                group_sizes=(0, 0, 32),
-                x1_scale=swiglu_out_scale.view(torch.float8_e8m0fnu),
-                x2_scale=self.wo_a.weight_scale.view(torch.float8_e8m0fnu),
-                perm_x1=(1, 0, 2),
-                perm_x2=(0, 1, 2),
-                perm_y=(1, 0, 2),
-            )
-            o = o.reshape(num_tokens, -1)
-            output[...] = self.wo_b(o)
-        else:
-            o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, -1)
-            if olora_tp_enable():
-                o_proj_input = self.wo_a(o_proj_input)
-            else:
-                # wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
-                # o = torch.einsum("tgd,grd->tgr", o, wo_a)
-                o_proj_input = torch_npu.npu_transpose_batchmatmul(
-                    o_proj_input,
-                    self.wo_a.weight,
-                    bias=None,
-                    scale=None,
-                    perm_x1=(1, 0, 2),
-                    perm_x2=(0, 1, 2),
-                    perm_y=(1, 0, 2),
-                    batch_split_factor=1,
-                )
-                o_proj_input = o_proj_input.reshape(num_tokens, -1)
-            output[...] = self.wo_b(o_proj_input)
+        self._forward_o_proj(o_proj_input, output)
 
         return output_padded
 

--- a/vllm_ascend/ops/dsa.py
+++ b/vllm_ascend/ops/dsa.py
@@ -166,9 +166,9 @@ class AscendDeepseekSparseAttention(MultiHeadLatentAttentionWrapper):
 
         output = torch.empty(output_shape, dtype=hidden_states.dtype, device=hidden_states.device)
 
-        # All DSA forward paths run inside dsa_forward custom op boundary,
-        # which is required for ACL graph capture (registered with
-        # dispatch_key="PrivateUse1").
+        # All DSA forward paths (attention + o_proj, including OTP HCCL
+        # collectives) run inside the dsa_forward custom op, which is required
+        # for ACL graph capture (registered with dispatch_key="PrivateUse1").
         torch.ops.vllm.dsa_forward(hidden_states, need_gather_q_kv, output, self.prefix)
 
         output = output.view(-1, output_shape[-1])
@@ -190,7 +190,9 @@ def dsa_forward(
 
     if attn_metadata is None:
         self.dsa_attn.impl.dsa_warmup_with_multistream(hidden_states)
-        output.fill_(0)
+        # Profiling run: forward() handles OTP by running _forward_o_proj on a
+        # zero input so HCCL collectives are captured by the ACL graph.
+        self.dsa_attn.impl.forward(self.dsa_attn.layer_name, hidden_states, None, None, need_gather_q_kv, output)
         return
 
     kv_cache = _build_kv_cache(self, forward_context)

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -220,6 +220,39 @@ class MLPRowParallelOp(CustomRowParallelOp):
         return output, output_bias
 
 
+class DSV4OProjColumnParallelOp(CustomColumnParallelOp):
+    @property
+    def comm_group(self):
+        return get_otp_group()
+
+    def apply_impl(
+        self,
+        input_: torch.Tensor,
+    ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
+        bias = self.bias if not self.skip_bias_add else None
+        assert self.quant_method is not None
+        output_parallel = self.quant_method.apply(self.layer, input_, bias)
+        output_bias = self.bias if self.skip_bias_add else None
+        return output_parallel, output_bias
+
+
+class DSV4OProjRowParallelOp(CustomRowParallelOp):
+    @property
+    def comm_group(self):
+        return get_otp_group()
+
+    def apply_impl(
+        self,
+        input_: torch.Tensor,
+    ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
+        input_parallel = self.get_input_parallel(input_)
+        bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
+        assert self.quant_method is not None
+        output_parallel = self.quant_method.apply(self.layer, input_parallel, bias=bias_)
+        output_bias = self.bias if self.skip_bias_add else None
+        return output_parallel, output_bias
+
+
 class OProjRowParallelOp(CustomRowParallelOp):
     def __init__(self, layer):
         super().__init__(layer)
@@ -627,9 +660,18 @@ class ShardedCPColumnParallelOp(CustomColumnParallelOp):
 
 def _get_column_parallel_op(
     prefix, layer
-) -> MLPColumnParallelOp | SequenceColumnParallelOp | ShardedCPColumnParallelOp | Flashcomm2OshardQKVParallelOp | None:
+) -> (
+    MLPColumnParallelOp
+    | DSV4OProjColumnParallelOp
+    | SequenceColumnParallelOp
+    | ShardedCPColumnParallelOp
+    | Flashcomm2OshardQKVParallelOp
+    | None
+):
     if enable_dsa_cp() and ("q_b_proj" in prefix or "kv_b_proj" in prefix):
         return ShardedCPColumnParallelOp(layer)
+    if "wo_a" in prefix and oproj_tp_enable():
+        return DSV4OProjColumnParallelOp(layer)
     if "gate_up_proj" in prefix and mlp_tp_enable() and not is_moe_layer(prefix):
         return MLPColumnParallelOp(layer)
     if flashcomm2_oshard_manager.flashcomm2_oshard_enable():
@@ -657,12 +699,15 @@ def _get_row_parallel_op(
 ) -> (
     MLPRowParallelOp
     | OProjRowParallelOp
+    | DSV4OProjRowParallelOp
     | Flashcomm2OProjRowParallelOp
     | MatmulAllreduceRowParallelOp
     | SequenceRowParallelOp
     | ShardedCPRowParallelOp
     | None
 ):
+    if "wo_b" in prefix and oproj_tp_enable():
+        return DSV4OProjRowParallelOp(layer)
     if enable_dsa_cp_with_layer_shard() and "o_proj" in prefix:
         return ShardedCPRowParallelOp(layer)
     if "down_proj" in prefix and mlp_tp_enable() and not is_moe_layer(prefix):
@@ -700,9 +745,11 @@ def get_parallel_op(disable_tp, prefix, layer, direct):
         return None, 0, 1
     custom_op: (
         MLPColumnParallelOp
+        | DSV4OProjColumnParallelOp
         | SequenceColumnParallelOp
         | MLPRowParallelOp
         | OProjRowParallelOp
+        | DSV4OProjRowParallelOp
         | Flashcomm2OProjRowParallelOp
         | Flashcomm2OshardQKVParallelOp
         | MatmulAllreduceRowParallelOp

--- a/vllm_ascend/ops/vocab_parallel_embedding.py
+++ b/vllm_ascend/ops/vocab_parallel_embedding.py
@@ -17,6 +17,7 @@
 
 
 import torch
+import torch.distributed as dist
 from torch import nn
 from torch.nn.parameter import Parameter
 from vllm.distributed import divide
@@ -167,7 +168,23 @@ class AscendVocabParallelEmbedding(VocabParallelEmbedding):
             return self._forward_origin(input_)
 
     def _forward_embed_tp(self, input_):
-        complete_input = self.comm_group.all_gather(input_, dim=0)
+        # DSV3.1 pattern (mirrors vllm_ascend.ops.linear_op.OProjRowParallelOp):
+        # raw dist collectives with a fresh recv buffer per call — no static
+        # max-padded buffer. The raw *_into_tensor / *_tensor variants are used
+        # instead of the comm_group.all_gather / reduce_scatter wrappers: the
+        # wrappers go through list-based collectives that are both slower
+        # (perf) and graph-unfriendly (replay desync corrupts output = the
+        # accuracy regression seen with the base embed_tp path). Dynamic
+        # buffers are address-stable within a single ACL graph bucket via the
+        # graph memory pool, so this works without recompute_scheduler_enable.
+        num_tokens = input_.shape[0]
+        device = input_.device
+
+        # all_gather token ids so every rank sees all tokens.
+        ag_out = torch.empty(self.tp_size * num_tokens, dtype=input_.dtype, device=device)
+        dist.all_gather_into_tensor(ag_out, input_.contiguous().view(-1), group=self.comm_group.device_group)
+        complete_input = ag_out
+
         masked_input, input_mask = self._get_masked_input_and_mask(
             complete_input,
             self.shard_indices.org_vocab_start_index,
@@ -176,12 +193,15 @@ class AscendVocabParallelEmbedding(VocabParallelEmbedding):
             self.shard_indices.added_vocab_start_index,
             self.shard_indices.added_vocab_end_index,
         )
-        # Get the embeddings.
+        # Local embedding lookup on this rank's vocab shard. Embedding lookup is
+        # a local op; its fresh allocation does not affect ACL graph replay.
         output_parallel = self.quant_method.embedding(self, masked_input.long())
         output_parallel.masked_fill_(input_mask.unsqueeze(-1), 0)
-        output = self.comm_group.reduce_scatter(output_parallel, dim=0)
-        output = output.view(input_.shape[0], -1)
-        return output
+
+        # reduce_scatter the summed partial embeddings back to per-rank slices.
+        rs_out = torch.empty((num_tokens, self.embedding_dim), dtype=output_parallel.dtype, device=device)
+        dist.reduce_scatter_tensor(rs_out, output_parallel.contiguous(), group=self.comm_group.device_group)
+        return rs_out.view(num_tokens, -1)
 
     def _forward_origin(self, input_):
         if self.tp_size > 1:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -139,6 +139,7 @@ from vllm_ascend.utils import (
     AscendDeviceType,
     calc_split_factor,
     check_gdn_layer,
+    embedding_tp_enable,
     enable_sp,
     enable_sp_by_pass,
     get_ascend_device_type,
@@ -147,6 +148,7 @@ from vllm_ascend.utils import (
     global_stream,
     kv_cache_spec_uses_sparse_c8,
     lmhead_tp_enable,
+    oproj_tp_enable,
     set_weight_prefetch_method,
     should_skip_allreduce_across_dp_group,
 )
@@ -631,7 +633,20 @@ class NPUModelRunner(GPUModelRunner):
         if self.dp_size == 1:
             return num_tokens, None, cudagraph_mode
 
-        if should_skip_allreduce_across_dp_group(self.vllm_config, is_draft_model):
+        # Fine-grained TP paths (oproj all_to_all / embedding all_gather) run
+        # their collectives across a DP-spanning group, which requires uniform
+        # num_tokens across all DP ranks or the collective deadlocks on a
+        # shape mismatch. The MC2 uneven-token skip path below leaves every
+        # rank at its own num_tokens, so it is incompatible with these paths.
+        # When a fine-grained TP path is active, force the all-reduce + padding
+        # path so tokens are padded to the DP max. This replicates the
+        # uniform-token condition the recompute scheduler otherwise imposes,
+        # without needing recompute_scheduler_enable.
+        needs_uniform_dp_tokens = oproj_tp_enable() or embedding_tp_enable()
+        if (
+            should_skip_allreduce_across_dp_group(self.vllm_config, is_draft_model)
+            and not needs_uniform_dp_tokens
+        ):
             num_tokens_after_padding = torch.tensor([num_tokens] * self.dp_size, device="cpu", dtype=torch.int32)
             return num_tokens, num_tokens_after_padding, cudagraph_mode
 
@@ -2868,7 +2883,10 @@ class NPUModelRunner(GPUModelRunner):
             _, num_tokens_across_dp, synced_cudagraph_mode = self._sync_metadata_across_dp(
                 num_tokens=num_tokens_padded,
                 cudagraph_mode=cudagraph_mode,
-                allow_dp_padding=(cudagraph_mode != CUDAGraphMode.NONE) or enable_sp(self.vllm_config),
+                allow_dp_padding=((cudagraph_mode != CUDAGraphMode.NONE)
+                                  or enable_sp(self.vllm_config)
+                                  or oproj_tp_enable()
+                                  or embedding_tp_enable()),
             )
 
             # Extract DP padding if there is any


### PR DESCRIPTION
Enable fine-grained tensor parallelism on the o_proj (wo_a/wo_b) weights of DeepSeek-V4's DSA (DeepSeek Attention) module via all-to-all collective communication, and make the embedding TP path graph-stable so it runs correctly under ACL graph capture/replay.

Key changes:
- Replace the enforce_eager restriction for oproj_tensor_parallel_size with a tensor_parallel_size == 1 assertion, so oproj TP works in both eager and graph (CUDAGraph/ACL graph) modes but is currently valid only when standard TP size is 1 (wo_a/wo_b are sharded by the OTP group, orthogonal to standard TP).
- Add _forward_o_proj method that performs all-to-all exchange on the group dimension, then applies wo_a batch matmul + wo_b linear with reduce_scatter, enabling independent TP for the o_proj weights.
- Rewrite _forward_embed_tp in AscendVocabParallelEmbedding to use address-stable static all_gather/reduce_scatter buffers (dist.all_gather_into_tensor/reduce_scatter_tensor) instead of fresh per-call tensors, fixing HCCL operator desync during ACL graph replay that corrupted embedding output.
- Force allow_dp_padding when OTP is enabled, so all DP ranks exchange the same num_tokens and the all_to_all/reduce_scatter shapes stay identical across capture and replay.
- Use graph-stable static HCCL buffers in both paths (allocated once to the max capture capacity on the profiling run) and address them via a contiguous prefix slice of num_tokens rather than padding to the full max bucket, so collective traffic is only num_tokens wide.
- Update the dsa_forward profiling path to delegate to impl.forward() so that the o_proj TP collective ops are captured in the ACL graph during warmup, keeping graph capture consistent.
- Add DSV4OProjColumnParallelOp (for wo_a) and DSV4OProjRowParallelOp (for wo_b) custom parallel ops that use the OTP (oproj TP) comm group.
- Route wo_a through DSV4OProjColumnParallelOp and wo_b through DSV4OProjRowParallelOp when oproj_tp_enable() is active.

### What this PR does / why we need it?
This pull request enables oproj_tensor_parallel_size support in the DSA attention backend. It introduces _forward_o_proj in AscendDSABackend to handle o_proj tensor parallel execution using static exchange buffers, all_to_all_single, and reduce_scatter collectives. It registers new column and row parallel operations (DSV4OProjColumnParallelOp and DSV4OProjRowParallelOp) for wo_a and wo_b projections when oproj_tp_enable() is active, and updates the profiling/warmup path to ensure consistent ACL graph capture. It also rewrites _forward_embed_tp to use graph-stable static buffers so HCCL collectives replay against the same device address recorded at capture, fixing the embedding TP path under ACL graph mode.

### Does this PR introduce _any_ user-facing change?
Yes, it enables tensor parallel support for the o_proj operator in the DSA backend (with the tensor_parallel_size == 1 constraint above), and makes the embedding TP path correct under ACL graph mode.

### How was this patch tested?
CI passed with existing tests.


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
