### PR TITLE
[Bugfix] use endswith for .scale parameter matching in MTP model

### DIFF
--- a/vllm_ascend/models/deepseek_v4_mtp.py
+++ b/vllm_ascend/models/deepseek_v4_mtp.py
@@ -306,7 +306,7 @@ class DeepSeekV4MTP(nn.Module, SupportsPP, DeepseekV2MixtureOfExperts):
             if ".w3." in name:
                 name = name.replace(".w3.", ".up_proj.")
 
-            if ".scale" in name:
+            if name.endswith(".scale"):
                 name = name.replace(".scale", ".weight_scale")
 
             if ".head." in name:


### PR DESCRIPTION
## Summary

Fix a bug in the MTP (Multi-Token Prediction) model weight loading where parameter names containing `.scale` are incorrectly matched.

## Problem

The original code uses `if ".scale" in name` for substring matching. This condition is too broad — it matches any parameter name that **contains** `.scale` as a substring, even if the name doesn't actually end with `.scale` (e.g., `foo.scale_bar`). This causes unintended renaming of parameters to `.weight_scale`.

## Fix

Replace `if ".scale" in name` with `if name.endswith(".scale")` to precisely match only parameters whose names end with `.scale`, ensuring correct weight loading behavior.

## Change

| File | Change |
|------|--------|
| `vllm_ascend/models/deepseek_v4_mtp.py:309` | `".scale" in name` → `name.endswith(".scale")` |

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
