### PR TITLE
[BugFix][CI] Fix GLM5.1-W8A8 MTP load weight error when vLLM is updated to v0.21.0

### DIFF
--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -740,6 +740,16 @@
 #       Rotary quant is a unique feature of vllm-ascend.
 #    Future Plan:
 #       Remove this patch when vllm supports rotary quant or pluggable `MultiTokenPredictorLayer`.
+#   4. `vllm.model_executor.models.deepseek_v2.GlmMoeDsaForCausalLM.load_weights`
+#    Why:
+#       After vllm PR #41706, GlmMoeDsaForCausalLM.load_weights uses `AutoWeightsLoader` which
+#       does not skip `rot.weight`, and will cause ValueError while loading weights.
+#    How：
+#       Use the `skip_prefixes` parameter to skip certain weight tensors.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/41706
+#    Future Plan:
+#       Remove this patch when vllm supports rotary quant or pluggable `MultiTokenPredictorLayer`.
 # ** 20. File: worker/patch_mamba_utils.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.worker.mamba_utils.batch_memcpy_kernel = batch_memcpy_kernel`

--- a/vllm_ascend/patch/worker/patch_deepseek_mtp.py
+++ b/vllm_ascend/patch/worker/patch_deepseek_mtp.py
@@ -4,6 +4,8 @@ import vllm
 from transformers import DeepseekV2Config, DeepseekV3Config
 from vllm.config import VllmConfig
 from vllm.model_executor.models.deepseek_mtp import DeepSeekMTP, DeepSeekMultiTokenPredictorLayer
+from vllm.model_executor.models.deepseek_v2 import GlmMoeDsaForCausalLM
+from vllm.model_executor.models.utils import AutoWeightsLoader
 
 MTP_ROT_WEIGHT_NAME = "rot.weight"
 
@@ -61,8 +63,14 @@ class AscendDeepSeekMTP(DeepSeekMTP):
             return f"model.layers.{spec_layer}.rot.weight"
 
 
+class AscendGlmMoeDsaForCausalLM(GlmMoeDsaForCausalLM):
+    def load_weights(self, weights):
+        loader = AutoWeightsLoader(self, skip_prefixes=[MTP_ROT_WEIGHT_NAME])
+        return loader.load_weights(weights)
+
+
 vllm.model_executor.models.deepseek_v2.get_spec_layer_idx_from_weight_name = get_spec_layer_idx_from_weight_name
 vllm.model_executor.models.deepseek_mtp.get_spec_layer_idx_from_weight_name = get_spec_layer_idx_from_weight_name
-
 vllm.model_executor.models.deepseek_mtp.DeepSeekMultiTokenPredictorLayer = AscendDeepSeekMultiTokenPredictorLayer
 vllm.model_executor.models.deepseek_mtp.DeepSeekMTP = AscendDeepSeekMTP
+vllm.model_executor.models.deepseek_v2.GlmMoeDsaForCausalLM = AscendGlmMoeDsaForCausalLM


### PR DESCRIPTION
### What this PR does / why we need it?
After vllm PR [#41706](https://github.com/vllm-project/vllm/pull/41706), GlmMoeDsaForCausalLM.load_weights uses `AutoWeightsLoader` which does not skip `rot.weight` of the mtp layer, and causes ValueError while loading weights.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
The model weights can be correctly loaded, and the acceptance rate of draft model is also right.

> (APIServer pid=774401) INFO 06-11 11:07:59 [loggers.py:271] Engine 000: Avg prompt throughput: 1.0 tokens/s, Avg generation throughput: 7.1 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.1%, Prefix cache hit rate: 0.0%
(APIServer pid=774401) INFO 06-11 11:07:59 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 3.50, Accepted throughput: 0.94 tokens/s, Drafted throughput: 1.13 tokens/s, Accepted: 50 tokens, Drafted: 60 tokens, Per-position acceptance rate: 1.000, 0.900, 0.600, Avg Draft acceptance rate: 83.3%
(APIServer pid=774401) INFO 06-11 11:08:09 [loggers.py:271] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 8.5 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.3%, Prefix cache hit rate: 0.0%
(APIServer pid=774401) INFO 06-11 11:08:09 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 2.58, Accepted throughput: 5.20 tokens/s, Drafted throughput: 9.90 tokens/s, Accepted: 52 tokens, Drafted: 99 tokens, Per-position acceptance rate: 0.818, 0.606, 0.152, Avg Draft acceptance rate: 52.5%
(APIServer pid=774401) INFO 06-11 11:08:19 [loggers.py:271] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 10.0 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.4%, Prefix cache hit rate: 0.0%
(APIServer pid=774401) INFO 06-11 11:08:19 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 3.03, Accepted throughput: 6.70 tokens/s, Drafted throughput: 9.90 tokens/s, Accepted: 67 tokens, Drafted: 99 tokens, Per-position acceptance rate: 0.909, 0.697, 0.424, Avg Draft acceptance rate: 67.7%
(APIServer pid=774401) INFO 06-11 11:08:29 [loggers.py:271] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 9.5 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.4%, Prefix cache hit rate: 0.0%
(APIServer pid=774401) INFO 06-11 11:08:29 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 2.79, Accepted throughput: 6.10 tokens/s, Drafted throughput: 10.20 tokens/s, Accepted: 61 tokens, Drafted: 102 tokens, Per-position acceptance rate: 0.824, 0.588, 0.382, Avg Draft acceptance rate: 59.8%


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
