### PR TITLE
[CI][Misc] Read Dockerfile vLLM ref from verified anchor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG
-ARG VLLM_COMMIT=""
+ARG VLLM_COMMIT
 COPY .github/vllm-release-tag.commit /tmp/vllm-release-tag.commit
 RUN VLLM_REF="${VLLM_COMMIT:-${VLLM_TAG:-$(tr -d '[:space:]' < /tmp/vllm-release-tag.commit)}}" && \
     if ! echo "$VLLM_REF" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,15 +39,17 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_TAG=v0.25.1
+ARG VLLM_TAG
 ARG VLLM_COMMIT=""
-RUN if [ -n "$VLLM_COMMIT" ]; then \
-      git init /vllm-workspace/vllm && \
-      git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
-      git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
-    else \
-      git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
-    fi
+COPY .github/vllm-release-tag.commit /tmp/vllm-release-tag.commit
+RUN VLLM_REF="${VLLM_COMMIT:-${VLLM_TAG:-$(tr -d '[:space:]' < /tmp/vllm-release-tag.commit)}}" && \
+    if ! echo "$VLLM_REF" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then \
+        echo "Invalid VLLM ref: $VLLM_REF"; \
+        exit 1; \
+    fi && \
+    git init /vllm-workspace/vllm && \
+    git -C /vllm-workspace/vllm fetch --depth 1 "$VLLM_REPO" "$VLLM_REF" && \
+    git -C /vllm-workspace/vllm checkout FETCH_HEAD
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -33,15 +33,17 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_TAG=v0.25.1
+ARG VLLM_TAG
 ARG VLLM_COMMIT=""
-RUN if [ -n "$VLLM_COMMIT" ]; then \
-      git init /vllm-workspace/vllm && \
-      git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
-      git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
-    else \
-      git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
-    fi
+COPY .github/vllm-release-tag.commit /tmp/vllm-release-tag.commit
+RUN VLLM_REF="${VLLM_COMMIT:-${VLLM_TAG:-$(tr -d '[:space:]' < /tmp/vllm-release-tag.commit)}}" && \
+    if ! echo "$VLLM_REF" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then \
+        echo "Invalid VLLM ref: $VLLM_REF"; \
+        exit 1; \
+    fi && \
+    git init /vllm-workspace/vllm && \
+    git -C /vllm-workspace/vllm fetch --depth 1 "$VLLM_REPO" "$VLLM_REF" && \
+    git -C /vllm-workspace/vllm checkout FETCH_HEAD
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -34,7 +34,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG
-ARG VLLM_COMMIT=""
+ARG VLLM_COMMIT
 COPY .github/vllm-release-tag.commit /tmp/vllm-release-tag.commit
 RUN VLLM_REF="${VLLM_COMMIT:-${VLLM_TAG:-$(tr -d '[:space:]' < /tmp/vllm-release-tag.commit)}}" && \
     if ! echo "$VLLM_REF" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then \

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -32,15 +32,17 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_TAG=v0.25.1
+ARG VLLM_TAG
 ARG VLLM_COMMIT=""
-RUN if [ -n "$VLLM_COMMIT" ]; then \
-      git init /vllm-workspace/vllm && \
-      git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
-      git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
-    else \
-      git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
-    fi
+COPY .github/vllm-release-tag.commit /tmp/vllm-release-tag.commit
+RUN VLLM_REF="${VLLM_COMMIT:-${VLLM_TAG:-$(tr -d '[:space:]' < /tmp/vllm-release-tag.commit)}}" && \
+    if ! echo "$VLLM_REF" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then \
+        echo "Invalid VLLM ref: $VLLM_REF"; \
+        exit 1; \
+    fi && \
+    git init /vllm-workspace/vllm && \
+    git -C /vllm-workspace/vllm fetch --depth 1 "$VLLM_REPO" "$VLLM_REF" && \
+    git -C /vllm-workspace/vllm checkout FETCH_HEAD
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -33,7 +33,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG
-ARG VLLM_COMMIT=""
+ARG VLLM_COMMIT
 COPY .github/vllm-release-tag.commit /tmp/vllm-release-tag.commit
 RUN VLLM_REF="${VLLM_COMMIT:-${VLLM_TAG:-$(tr -d '[:space:]' < /tmp/vllm-release-tag.commit)}}" && \
     if ! echo "$VLLM_REF" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then \

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -41,15 +41,17 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_TAG=v0.25.1
+ARG VLLM_TAG
 ARG VLLM_COMMIT=""
-RUN if [ -n "$VLLM_COMMIT" ]; then \
-      git init /vllm-workspace/vllm && \
-      git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
-      git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
-    else \
-      git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
-    fi
+COPY .github/vllm-release-tag.commit /tmp/vllm-release-tag.commit
+RUN VLLM_REF="${VLLM_COMMIT:-${VLLM_TAG:-$(tr -d '[:space:]' < /tmp/vllm-release-tag.commit)}}" && \
+    if ! echo "$VLLM_REF" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then \
+        echo "Invalid VLLM ref: $VLLM_REF"; \
+        exit 1; \
+    fi && \
+    git init /vllm-workspace/vllm && \
+    git -C /vllm-workspace/vllm fetch --depth 1 "$VLLM_REPO" "$VLLM_REF" && \
+    git -C /vllm-workspace/vllm checkout FETCH_HEAD
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -42,7 +42,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG
-ARG VLLM_COMMIT=""
+ARG VLLM_COMMIT
 COPY .github/vllm-release-tag.commit /tmp/vllm-release-tag.commit
 RUN VLLM_REF="${VLLM_COMMIT:-${VLLM_TAG:-$(tr -d '[:space:]' < /tmp/vllm-release-tag.commit)}}" && \
     if ! echo "$VLLM_REF" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then \

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -39,7 +39,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG
-ARG VLLM_COMMIT=""
+ARG VLLM_COMMIT
 COPY .github/vllm-release-tag.commit /tmp/vllm-release-tag.commit
 RUN VLLM_REF="${VLLM_COMMIT:-${VLLM_TAG:-$(tr -d '[:space:]' < /tmp/vllm-release-tag.commit)}}" && \
     if ! echo "$VLLM_REF" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then \

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -38,15 +38,17 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_TAG=v0.25.1
+ARG VLLM_TAG
 ARG VLLM_COMMIT=""
-RUN if [ -n "$VLLM_COMMIT" ]; then \
-      git init /vllm-workspace/vllm && \
-      git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
-      git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
-    else \
-      git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
-    fi
+COPY .github/vllm-release-tag.commit /tmp/vllm-release-tag.commit
+RUN VLLM_REF="${VLLM_COMMIT:-${VLLM_TAG:-$(tr -d '[:space:]' < /tmp/vllm-release-tag.commit)}}" && \
+    if ! echo "$VLLM_REF" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then \
+        echo "Invalid VLLM ref: $VLLM_REF"; \
+        exit 1; \
+    fi && \
+    git init /vllm-workspace/vllm && \
+    git -C /vllm-workspace/vllm fetch --depth 1 "$VLLM_REPO" "$VLLM_REF" && \
+    git -C /vllm-workspace/vllm checkout FETCH_HEAD
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -41,8 +41,17 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_TAG=v0.25.1
-RUN git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
+ARG VLLM_TAG
+ARG VLLM_COMMIT=""
+COPY .github/vllm-release-tag.commit /tmp/vllm-release-tag.commit
+RUN VLLM_REF="${VLLM_COMMIT:-${VLLM_TAG:-$(tr -d '[:space:]' < /tmp/vllm-release-tag.commit)}}" && \
+    if ! echo "$VLLM_REF" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then \
+        echo "Invalid VLLM ref: $VLLM_REF"; \
+        exit 1; \
+    fi && \
+    git init /vllm-workspace/vllm && \
+    git -C /vllm-workspace/vllm fetch --depth 1 "$VLLM_REPO" "$VLLM_REF" && \
+    git -C /vllm-workspace/vllm checkout FETCH_HEAD
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -42,7 +42,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG
-ARG VLLM_COMMIT=""
+ARG VLLM_COMMIT
 COPY .github/vllm-release-tag.commit /tmp/vllm-release-tag.commit
 RUN VLLM_REF="${VLLM_COMMIT:-${VLLM_TAG:-$(tr -d '[:space:]' < /tmp/vllm-release-tag.commit)}}" && \
     if ! echo "$VLLM_REF" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then \

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -38,8 +38,17 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_TAG=v0.25.1
-RUN git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
+ARG VLLM_TAG
+ARG VLLM_COMMIT=""
+COPY .github/vllm-release-tag.commit /tmp/vllm-release-tag.commit
+RUN VLLM_REF="${VLLM_COMMIT:-${VLLM_TAG:-$(tr -d '[:space:]' < /tmp/vllm-release-tag.commit)}}" && \
+    if ! echo "$VLLM_REF" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then \
+        echo "Invalid VLLM ref: $VLLM_REF"; \
+        exit 1; \
+    fi && \
+    git init /vllm-workspace/vllm && \
+    git -C /vllm-workspace/vllm fetch --depth 1 "$VLLM_REPO" "$VLLM_REF" && \
+    git -C /vllm-workspace/vllm checkout FETCH_HEAD
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -39,7 +39,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG
-ARG VLLM_COMMIT=""
+ARG VLLM_COMMIT
 COPY .github/vllm-release-tag.commit /tmp/vllm-release-tag.commit
 RUN VLLM_REF="${VLLM_COMMIT:-${VLLM_TAG:-$(tr -d '[:space:]' < /tmp/vllm-release-tag.commit)}}" && \
     if ! echo "$VLLM_REF" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then \

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -39,7 +39,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG
-ARG VLLM_COMMIT=""
+ARG VLLM_COMMIT
 COPY .github/vllm-release-tag.commit /tmp/vllm-release-tag.commit
 RUN VLLM_REF="${VLLM_COMMIT:-${VLLM_TAG:-$(tr -d '[:space:]' < /tmp/vllm-release-tag.commit)}}" && \
     if ! echo "$VLLM_REF" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then \

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -38,15 +38,17 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_TAG=v0.25.1
+ARG VLLM_TAG
 ARG VLLM_COMMIT=""
-RUN if [ -n "$VLLM_COMMIT" ]; then \
-      git init /vllm-workspace/vllm && \
-      git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
-      git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
-    else \
-      git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
-    fi
+COPY .github/vllm-release-tag.commit /tmp/vllm-release-tag.commit
+RUN VLLM_REF="${VLLM_COMMIT:-${VLLM_TAG:-$(tr -d '[:space:]' < /tmp/vllm-release-tag.commit)}}" && \
+    if ! echo "$VLLM_REF" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then \
+        echo "Invalid VLLM ref: $VLLM_REF"; \
+        exit 1; \
+    fi && \
+    git init /vllm-workspace/vllm && \
+    git -C /vllm-workspace/vllm fetch --depth 1 "$VLLM_REPO" "$VLLM_REF" && \
+    git -C /vllm-workspace/vllm checkout FETCH_HEAD
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \


### PR DESCRIPTION
Fixes #9800.

## What this PR does / why we need it?

Follow-up for the review question about the runtime Dockerfiles.

The listed Dockerfiles duplicated the upstream vLLM release ref as `ARG VLLM_TAG=v0.23.0`:

- `Dockerfile`
- `Dockerfile.310p`
- `Dockerfile.310p.openEuler`
- `Dockerfile.a3`
- `Dockerfile.a3.openEuler`
- `Dockerfile.a5`
- `Dockerfile.a5.openEuler`
- `Dockerfile.openEuler`

This PR keeps manual build overrides while defaulting the vLLM ref from `.github/vllm-release-tag.commit` when no build arg is provided. The resolution priority is explicit and consistent in all touched Dockerfiles:

1. `VLLM_COMMIT` if provided by the user.
2. `VLLM_TAG` if provided by the user.
3. `.github/vllm-release-tag.commit` when neither override is provided.

The resolved value is validated as a safe git ref string, then fetched with `git fetch --depth 1` and checked out via `FETCH_HEAD`, so release tags, branches, and commit SHAs use the same path.

It intentionally does not change CANN base image tags or `MOONCAKE_TAG`; those are separate dependency/version anchors and should not follow the vLLM release-tag file.

## Does this PR introduce _any_ user-facing change?

No. It only changes the default source of the vLLM ref used during Docker image builds.

## How was this patch tested?

- `git diff --check`
- Shell simulation for default `.github/vllm-release-tag.commit` lookup.
- Shell simulation for explicit `VLLM_TAG` build-arg override.
- Shell simulation for explicit `VLLM_COMMIT` build-arg override taking priority over `VLLM_TAG`.
- Shell validation that a release tag, branch name, and commit SHA pass the safe git-ref check.
- Real `git fetch --depth 1` validation for a vLLM release tag, branch, and commit SHA.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
