### PR TITLE
[CI] Remove MiniMax M2.5 W8A8 QuaRot A2 nightly case

### DIFF
--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -183,9 +183,6 @@ jobs:
           - name: qwen3-32b-int8
             os: linux-aarch64-a2b3-4
             config_file_path: Qwen3-32B-Int8-A2.yaml
-          - name: MiniMax-M2.5-w8a8-QuaRot-A2
-            os: linux-aarch64-a2b3-8
-            config_file_path: MiniMax-M2.5-w8a8-QuaRot-A2.yaml
           - name: Qwen3.5-27B-w8a8-A2
             os: linux-aarch64-a2b3-2
             config_file_path: Qwen3.5-27B-w8a8-A2.yaml


### PR DESCRIPTION
### What this PR does / why we need it?

This PR removes the `MiniMax-M2.5-w8a8-QuaRot-A2` entry from the A2 single-node nightly test matrix.

The change retires the standalone `linux-aarch64-a2b3-8` job from scheduled Nightly-A2 runs and from `workflow_dispatch` runs that select all test cases. The underlying YAML test configuration is retained.

### Does this PR introduce _any_ user-facing change?

No. This is a CI-only change. Nightly-A2 will no longer schedule the `MiniMax-M2.5-w8a8-QuaRot-A2` single-node case.

### How was this patch tested?

- `actionlint v1.7.7 .github/workflows/schedule_nightly_test_a2.yaml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/schedule_nightly_test_a2.yaml")'`
- `git diff --check`

The commit includes a DCO `Signed-off-by` line matching the commit author.

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
