### PR TITLE
[CI]Upgrade Mooncake to 0.3.9 and Image Misc

### DIFF
--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -126,7 +126,7 @@ jobs:
             libcurl4
           ldconfig
 
-          MOONCAKE_WHEEL="mooncake_transfer_engine_ascend-0.3.8.post1-cp312-cp312-manylinux_2_17_aarch64.manylinux_2_35_aarch64.whl"
+          MOONCAKE_WHEEL="mooncake_transfer_engine_ascend-0.3.9-cp312-cp312-manylinux_2_35_aarch64.whl"
           pip install --no-cache-dir --no-deps \
             "https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/vllm-ascend/${MOONCAKE_WHEEL}"
 

--- a/.github/workflows/dockerfiles/Dockerfile.buildwheel.310p
+++ b/.github/workflows/dockerfiles/Dockerfile.buildwheel.310p
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 ARG PY_VERSION=3.12
-FROM quay.io/ascend/manylinux:9.1.0-beta.1-310p-manylinux_2_28-py${PY_VERSION}
+FROM quay.io/ascend/manylinux:9.1.0-beta.1-310p-manylinux_2_34-py${PY_VERSION}
 
 ARG SOC_VERSION="ascend310p1"
 

--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM ascendai/python:3.11-ubuntu22.04
+FROM ascendai/python:3.12-ubuntu22.04
 
 ARG TARGETARCH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 FROM quay.io/ascend/cann:9.0.0-910b-ubuntu22.04-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG MOONCAKE_TAG="v0.3.8.post1"
+ARG MOONCAKE_TAG="v0.3.9"
 
 WORKDIR /workspace
 

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -18,7 +18,7 @@
 FROM quay.io/ascend/cann:9.0.0-a3-ubuntu22.04-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG MOONCAKE_TAG=v0.3.8.post1
+ARG MOONCAKE_TAG=v0.3.9
 
 COPY ./tools/mooncake_installer.sh /vllm-workspace/
 

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -18,7 +18,7 @@
 FROM quay.io/ascend/cann:9.0.0-a3-openeuler24.03-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG MOONCAKE_TAG="v0.3.8.post1"
+ARG MOONCAKE_TAG="v0.3.9"
 
 WORKDIR /workspace
 

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -18,7 +18,7 @@
 FROM quay.io/ascend/cann:9.0.0-950-ubuntu22.04-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG MOONCAKE_TAG=v0.3.8.post1
+ARG MOONCAKE_TAG=v0.3.9
 
 COPY ./tools/mooncake_installer.sh /vllm-workspace/
 

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -18,7 +18,7 @@
 FROM quay.io/ascend/cann:9.0.0-950-openeuler24.03-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG MOONCAKE_TAG="v0.3.8.post1"
+ARG MOONCAKE_TAG="v0.3.9"
 
 WORKDIR /workspace
 

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -18,7 +18,7 @@
 FROM quay.io/ascend/cann:9.0.0-910b-openeuler24.03-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG MOONCAKE_TAG="v0.3.8.post1"
+ARG MOONCAKE_TAG="v0.3.9"
 
 WORKDIR /workspace
 


### PR DESCRIPTION
### What this PR does / why we need it?
1. Upgrade mooncake version ( 0.3.9 ).
2. Modify `FROM quay.io/ascend/manylinux:9.1.0-beta.1-310p-manylinux_2_28-py` of `Dockerfile.buildwheel.310p` to “2_34”.
The newer version of cann depends on the C++ symbol `_ZSt28__throw_bad_array_new_lengthv@@GLIBCXX_3.4.29`. This symbol is missing in manylinux_2_28, so we upgraded to manylinux_2_34.
3. Upgrade `FROM ascendai/python:3.11-ubuntu22.04` of `Dockerfile.lint` to "3.12"

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
