### PR TITLE
[Ops][BugFix] Fix rowSrc offset calculation in dispatch_ffn_combine_w4_a8 kernel

### DIFF
--- a/csrc/mc2/dispatch_ffn_combine_w4_a8/op_kernel/dispatch_ffn_combine_w4_a8_kernel.hpp
+++ b/csrc/mc2/dispatch_ffn_combine_w4_a8/op_kernel/dispatch_ffn_combine_w4_a8_kernel.hpp
@@ -983,8 +983,9 @@ private:
                     if (rowStart + rows > params.maxOutputSize) {
                         rows = params.maxOutputSize - rowStart;
                     }
-                    uint32_t rowSrc = prevSum;
-                    prevSum += rows;
+                    // These tokens will be sent by dstEpIdx-rank to the groupIdx expert of this rank.
+                    // rowSrc is the start offset of these tokens in dstEpIdx-rank.
+                    uint32_t rowSrc = preSumBeforeRank(dstEpIdx * params.expertPerRank + groupIdx);
                     GM_ADDR otherRankPtr = shmem(0, dstEpIdx);
                     AscendC::GlobalTensor<ElementABefore> gmRemoteA;
                     gmRemoteA.SetGlobalBuffer(


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes a bug in the `dispatch_ffn_combine_w4_a8` kernel where `rowSrc` (the start offset of tokens in `dstEpIdx`-rank) was incorrectly calculated using a local accumulator `prevSum` instead of retrieving the correct pre-sum offset from `preSumBeforeRank`. This incorrect offset led to incorrect token dispatching across ranks.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
