### PR TITLE
[Feature] Mooncake connectot support dsv4

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -70,6 +70,7 @@ from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector import (  # n
     ensure_zmq_recv,
     ensure_zmq_send,
     group_concurrent_contiguous,
+    split_if_not_byte_contiguous,
     string_to_int64_hash,
     zmq_ctx,
 )
@@ -565,6 +566,52 @@ class TestCoreFunctionality(unittest.TestCase):
         self.assertEqual(call_args[3], [2 * 1024])
         mock_get_meta.assert_not_called()
 
+    @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
+    def test_transfer_kv_cache_uses_block_stride_for_block_offsets(self, mock_get_meta):
+        req = dict(self.test_req)
+        req["local_block_ids"] = [[1, 2]]
+        req["remote_block_ids"] = [[3, 4]]
+        with patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ascend_config") as mock_config:
+            mock_config.return_value.enable_kv_nz = False
+            self.thread.kv_caches_base_addr["remote_engine"] = {6666: [[0x3000]]}
+            self.thread.remote_block_size_scale["remote_engine"] = {6666: [[1]]}
+            self.thread.block_len_per_addr = [[1024]]
+            self.thread.block_stride_per_addr = [[2048]]
+            self.thread.remote_block_stride_per_addr["remote_engine"][6666] = [[4096]]
+
+            self.thread._transfer_kv_cache_all_groups(req)
+
+        call_args, _ = self.engine.batch_transfer_sync_read.call_args
+        self.assertEqual(call_args[1], [0x1000 + 1 * 2048, 0x1000 + 2 * 2048])
+        self.assertEqual(call_args[2], [0x3000 + 3 * 4096, 0x3000 + 4 * 4096])
+        self.assertEqual(call_args[3], [1024, 1024])
+        mock_get_meta.assert_not_called()
+
+    def test_append_mamba_transfer_meta_uses_block_stride_for_block_offsets(self):
+        src_list: list[int] = []
+        dst_list: list[int] = []
+        length_list: list[int] = []
+
+        self.thread._append_mamba_transfer_meta(
+            src_list,
+            dst_list,
+            length_list,
+            group_spec={"kv_cache_spec_type": "MambaSpec"},
+            src_layer_base_addr=[0x1000, 0x2000],
+            dst_layer_base_addr=[0x3000, 0x4000],
+            block_len=[100, 200],
+            block_stride=[128, 256],
+            remote_block_stride=[160, 512],
+            remote_block_id=3,
+            local_block_id=2,
+            tp_num_need_pulls=1,
+            remote_tp_offset=0,
+        )
+
+        self.assertEqual(src_list, [0x1000 + 2 * 128, 0x2000 + 2 * 256])
+        self.assertEqual(dst_list, [0x3000 + 3 * 160, 0x4000 + 3 * 512])
+        self.assertEqual(length_list, [100, 200])
+
     def test_transfer_kv_cache_failure(self):
         self.engine.batch_transfer_sync_read.return_value = -1
         self.thread.kv_caches_base_addr["remote_engine"] = {6666: [[0x3000]]}
@@ -619,6 +666,7 @@ class TestMetadataHandling(unittest.TestCase):
             mock_send.assert_called_once_with(mock_socket, self.thread.encoder.encode((GET_META_MSG, "")), "host1:5555")
             mock_recv.assert_called_once_with(mock_socket, self.thread.remote_poller, "host1:5555")
             self.assertEqual(self.thread.kv_caches_base_addr["remote_engine"][5555], [[0x3000], [0x4000]])
+            self.assertEqual(self.thread.remote_block_stride_per_addr["remote_engine"][5555], [[1024]])
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.ensure_zmq_send")
     @patch(
@@ -920,6 +968,36 @@ class TestHelperFunctions(unittest.TestCase):
         src_groups, dst_groups = group_concurrent_contiguous(src, dst)
         self.assertEqual(src_groups, [])
         self.assertEqual(dst_groups, [])
+
+    def test_group_concurrent_contiguous_uses_stride_for_memory_contiguity(self):
+        src: list[int] = [1, 2]
+        dst: list[int] = [10, 11]
+
+        src_groups, dst_groups = group_concurrent_contiguous(
+            src,
+            dst,
+            src_block_stride=4096,
+            dst_block_stride=2048,
+            block_len=1024,
+        )
+
+        self.assertEqual(src_groups, [[1], [2]])
+        self.assertEqual(dst_groups, [[10], [11]])
+
+    def test_split_if_not_byte_contiguous_fast_path(self):
+        src_groups = [[1, 2]]
+        dst_groups = [[10, 11]]
+
+        src_result, dst_result = split_if_not_byte_contiguous(
+            src_groups,
+            dst_groups,
+            src_block_stride=1024,
+            dst_block_stride=1024,
+            block_len=1024,
+        )
+
+        self.assertIs(src_result, src_groups)
+        self.assertIs(dst_result, dst_groups)
 
     def test_string_to_int64_hash(self):
         hash1 = string_to_int64_hash("test_string")

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -91,6 +91,7 @@ def make_agent_metadata(**overrides: Any) -> MooncakeAgentMetadata:
         "block_size_scale": [[1]],
         "num_blocks": 2,
         "block_lens": [[1024]],
+        "block_strides": [[1024]],
     }
     metadata.update(overrides)
     return MooncakeAgentMetadata(**metadata)
@@ -309,6 +310,7 @@ class TestKVCacheRecvingThreadBasic(unittest.TestCase):
             side_channel_port=30000,
             local_kv_caches_base_addr=[[0x1000], [0x2000]],
             block_len_per_addr=[[1024], [2048]],
+            block_stride_per_addr=[[1024], [2048]],
             ready_event=self.ready_event,
             vllm_config=self.vllm_config,
             kv_caches=self.kv_caches,
@@ -383,6 +385,7 @@ class TestSocketManagement(unittest.TestCase):
             side_channel_port=30000,
             local_kv_caches_base_addr=[[0x1000], [0x2000]],
             block_len_per_addr=[[1024], [2048]],
+            block_stride_per_addr=[[1024], [2048]],
             ready_event=self.ready_event,
             vllm_config=self.vllm_config,
             kv_caches=self.kv_caches,
@@ -439,6 +442,7 @@ class TestCoreFunctionality(unittest.TestCase):
             side_channel_port=30000,
             local_kv_caches_base_addr=[[0x1000], [0x2000]],
             block_len_per_addr=[[1024], [2048]],
+            block_stride_per_addr=[[1024], [2048]],
             ready_event=self.ready_event,
             vllm_config=self.vllm_config,
             kv_caches=self.kv_caches,
@@ -458,6 +462,7 @@ class TestCoreFunctionality(unittest.TestCase):
             "all_task_done": True,
         }
         self.thread.kv_group2layeridx = {0: ({"kv_cache_spec_type": "FullAttentionSpec"}, [0])}
+        self.thread.group_compress_ratios = {0: 1}
         self.thread.block_size_scale = [[1]]
         self.thread.task_tracker = MagicMock()
         self.engine.batch_transfer_sync_read.return_value = 0
@@ -499,6 +504,35 @@ class TestCoreFunctionality(unittest.TestCase):
         req["local_block_ids"] = [[1, 2]]
         req["remote_block_ids"] = [[3, 4]]
         req["num_computed_tokens"] = 8
+        with patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ascend_config") as mock_config:
+            mock_config.return_value.enable_kv_nz = False
+            self.thread.kv_caches_base_addr["remote_engine"] = {6666: [[0x3000]]}
+            self.thread.block_size_scale = [[2]]
+            self.thread.remote_block_size_scale["remote_engine"] = {6666: [[2]]}
+            self.thread._transfer_kv_cache_all_groups(req)
+
+        call_args, _ = self.engine.batch_transfer_sync_read.call_args
+        self.assertEqual(call_args[1], [0x1000 + 2 * 1024])
+        self.assertEqual(call_args[2], [0x3000 + 7 * 1024])
+        self.assertEqual(call_args[3], [3 * 1024])
+        mock_get_meta.assert_not_called()
+
+    @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
+    def test_transfer_prefix_cache_offset_uses_compress_ratio(self, mock_get_meta):
+        req = dict(self.test_req)
+        req["local_block_ids"] = [[1, 2]]
+        req["remote_block_ids"] = [[3, 4]]
+        req["num_computed_tokens"] = 32
+        self.thread.kv_group2layeridx = {
+            0: (
+                {
+                    "kv_cache_spec_type": "UniformTypeKVCacheSpecs",
+                    "kv_cache_spec": {"layer_0": {"compress_ratio": 4}},
+                },
+                [0],
+            )
+        }
+        self.thread.group_compress_ratios = {0: 4}
         with patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ascend_config") as mock_config:
             mock_config.return_value.enable_kv_nz = False
             self.thread.kv_caches_base_addr["remote_engine"] = {6666: [[0x3000]]}
@@ -556,6 +590,7 @@ class TestMetadataHandling(unittest.TestCase):
             side_channel_port=30000,
             local_kv_caches_base_addr=[[0x1000], [0x2000]],
             block_len_per_addr=[[1024], [2048]],
+            block_stride_per_addr=[[1024], [2048]],
             ready_event=self.ready_event,
             vllm_config=self.vllm_config,
             kv_caches=self.kv_caches,
@@ -621,6 +656,7 @@ class TestMainThreadLoop(unittest.TestCase):
             side_channel_port=30000,
             local_kv_caches_base_addr=[[0x1000], [0x2000]],
             block_len_per_addr=[[1024], [2048]],
+            block_stride_per_addr=[[1024], [2048]],
             ready_event=self.ready_event,
             vllm_config=self.vllm_config,
             kv_caches=self.kv_caches,
@@ -1068,6 +1104,71 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         delay_free, params = self.scheduler.request_finished(request, [1, 2, 3])
         self.assertFalse(delay_free)
         self.assertIsNone(params)
+
+    def test_get_transfer_block_ids_trims_attention_mtp_blocks(self):
+        self.scheduler.group_transfer_info = [
+            types.SimpleNamespace(
+                tokens_per_block=16,
+                blocks_per_window=0,
+                is_state_group=False,
+            )
+        ]
+
+        block_ids = self.scheduler._get_transfer_block_ids(([10, 11, 12, 13, 14],), prompt_len=33)
+
+        self.assertEqual(block_ids, ([10, 11, 12],))
+
+    def test_get_transfer_block_ids_keeps_state_group(self):
+        self.scheduler.group_transfer_info = [
+            types.SimpleNamespace(
+                tokens_per_block=16,
+                blocks_per_window=0,
+                is_state_group=True,
+            )
+        ]
+
+        block_ids = self.scheduler._get_transfer_block_ids(([20, 21, 22, 23],), prompt_len=16)
+
+        self.assertEqual(block_ids, ([20, 21, 22, 23],))
+
+    def test_get_transfer_block_ids_uses_compressed_prompt_len(self):
+        self.scheduler.group_transfer_info = [
+            types.SimpleNamespace(
+                tokens_per_block=32,
+                blocks_per_window=0,
+                is_state_group=False,
+            )
+        ]
+
+        block_ids = self.scheduler._get_transfer_block_ids(([30, 31, 32, 33],), prompt_len=64)
+
+        self.assertEqual(block_ids, ([30, 31],))
+
+    def test_get_transfer_block_ids_clips_sliding_window_group(self):
+        self.scheduler.group_transfer_info = [
+            types.SimpleNamespace(
+                tokens_per_block=16,
+                blocks_per_window=3,
+                is_state_group=False,
+            )
+        ]
+
+        block_ids = self.scheduler._get_transfer_block_ids(([40, 41, 42, 43, 44],), prompt_len=80)
+
+        self.assertEqual(block_ids, ([42, 43, 44],))
+
+    def test_get_transfer_block_ids_drops_zero_from_sliding_window_group(self):
+        self.scheduler.group_transfer_info = [
+            types.SimpleNamespace(
+                tokens_per_block=16,
+                blocks_per_window=2,
+                is_state_group=False,
+            )
+        ]
+
+        block_ids = self.scheduler._get_transfer_block_ids(([0, 10],), prompt_len=32)
+
+        self.assertEqual(block_ids, ([10],))
 
 
 class TestUtils(unittest.TestCase):

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -468,6 +468,7 @@ class TestCoreFunctionality(unittest.TestCase):
         self.thread.task_tracker = MagicMock()
         self.engine.batch_transfer_sync_read.return_value = 0
         self.thread.remote_te_port = {"remote_engine": {6666: 7777}}
+        self.thread.remote_block_stride_per_addr["remote_engine"][6666] = [[1024]]
 
     @patch.object(KVCacheRecvingThread, "_transfer_kv_cache_all_groups")
     @patch.object(KVCacheRecvingThread, "_send_done_recv_signal")
@@ -1222,7 +1223,7 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
 
         self.assertEqual(block_ids, ([30, 31],))
 
-    def test_get_transfer_block_ids_clips_sliding_window_group(self):
+    def test_get_transfer_block_ids_trims_sliding_window_mtp_blocks(self):
         self.scheduler.group_transfer_info = [
             types.SimpleNamespace(
                 tokens_per_block=16,
@@ -1231,11 +1232,24 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
             )
         ]
 
-        block_ids = self.scheduler._get_transfer_block_ids(([40, 41, 42, 43, 44],), prompt_len=80)
+        block_ids = self.scheduler._get_transfer_block_ids(([40, 41, 42, 43, 44],), prompt_len=48)
+
+        self.assertEqual(block_ids, ([40, 41, 42],))
+
+    def test_get_swa_transfer_block_ids_clips_sliding_window_group(self):
+        self.scheduler.group_transfer_info = [
+            types.SimpleNamespace(
+                tokens_per_block=16,
+                blocks_per_window=3,
+                is_state_group=False,
+            )
+        ]
+
+        block_ids = self.scheduler._get_swa_transfer_block_ids(([40, 41, 42, 43, 44],))
 
         self.assertEqual(block_ids, ([42, 43, 44],))
 
-    def test_get_transfer_block_ids_drops_zero_from_sliding_window_group(self):
+    def test_get_swa_transfer_block_ids_drops_zero_from_sliding_window_tail(self):
         self.scheduler.group_transfer_info = [
             types.SimpleNamespace(
                 tokens_per_block=16,
@@ -1244,7 +1258,21 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
             )
         ]
 
-        block_ids = self.scheduler._get_transfer_block_ids(([0, 10],), prompt_len=32)
+        block_ids = self.scheduler._get_swa_transfer_block_ids(([0, 10],))
+
+        self.assertEqual(block_ids, ([10],))
+
+    def test_transfer_block_ids_trims_mtp_before_swa_zero_filter(self):
+        self.scheduler.group_transfer_info = [
+            types.SimpleNamespace(
+                tokens_per_block=16,
+                blocks_per_window=3,
+                is_state_group=False,
+            )
+        ]
+
+        block_ids = self.scheduler._get_transfer_block_ids(([0, 10, 11, 12, 13],), prompt_len=32)
+        block_ids = self.scheduler._get_swa_transfer_block_ids(block_ids)
 
         self.assertEqual(block_ids, ([10],))
 

--- a/tests/ut/kv_offload/test_mooncake_layerwise_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_layerwise_connector.py
@@ -1,4 +1,5 @@
 import contextlib
+import importlib.util
 import os
 import sys
 import threading
@@ -13,6 +14,17 @@ import zmq
 fake_engine = types.ModuleType("mooncake.engine")
 fake_engine.TransferEngine = MagicMock()  # type: ignore[attr-defined]
 sys.modules["mooncake.engine"] = fake_engine
+fake_torch_npu = types.ModuleType("torch_npu")
+fake_torch_npu.__spec__ = importlib.util.spec_from_loader("torch_npu", loader=None)
+fake_torch_npu.npu = MagicMock()  # type: ignore[attr-defined]
+fake_torch_npu.npu.current_device = MagicMock(return_value=0)  # type: ignore[attr-defined]
+fake_torch_npu.npu.Stream = MagicMock  # type: ignore[attr-defined]
+fake_torch_npu.npu_fusion_attention = MagicMock()  # type: ignore[attr-defined]
+sys.modules.setdefault("torch_npu", fake_torch_npu)
+torch.npu = fake_torch_npu.npu  # type: ignore[attr-defined]
+fake_uvloop = types.ModuleType("uvloop")
+fake_uvloop.__spec__ = importlib.util.spec_from_loader("uvloop", loader=None)
+sys.modules.setdefault("uvloop", fake_uvloop)
 
 # Clean up stale mock modules installed by other test files
 # (e.g., ascend_store/_mock_deps.py) that replace real kv_transfer
@@ -603,12 +615,16 @@ class MockRequest:
     def __init__(self, request_id, prompt_token_ids=None, kv_transfer_params=None, status=None):
         self.request_id = request_id
         self.prompt_token_ids = prompt_token_ids or [1, 2, 3, 4]
+        self.prompt_embeds = None
         self.kv_transfer_params = kv_transfer_params or {}
         self.status = status or "running"
         self.output_token_ids = [101, 102]
         self.num_computed_tokens = 0
+        self.num_prompt_tokens = len(self.prompt_token_ids)
+        self.max_tokens = 16
 
         self.all_token_ids = list(self.prompt_token_ids)
+        self._all_token_ids = list(self.prompt_token_ids)
 
 
 class TestMooncakeLayerwiseConnectorMetadata(unittest.TestCase):
@@ -655,6 +671,29 @@ class TestMooncakeLayerwiseConnectorSchedulerMatchedTokens(unittest.TestCase):
         self.assertEqual(tokens, 4)
         self.assertTrue(async_flag)
 
+    def test_get_num_new_matched_tokens_hybrid_excludes_last_token(self):
+        self.scheduler.need_truncate = True
+        request = MockRequest("req1", prompt_token_ids=list(range(17)), kv_transfer_params={"do_remote_prefill": True})
+
+        tokens, async_flag = self.scheduler.get_num_new_matched_tokens(request, 0)
+
+        self.assertEqual(tokens, 16)
+        self.assertTrue(async_flag)
+
+    def test_get_num_new_matched_tokens_hybrid_truncates_prefill_request(self):
+        self.scheduler.need_truncate = True
+        request = MockRequest("req1", prompt_token_ids=list(range(4)), kv_transfer_params={"do_remote_decode": True})
+
+        tokens, async_flag = self.scheduler.get_num_new_matched_tokens(request, 0)
+
+        self.assertEqual(tokens, 0)
+        self.assertFalse(async_flag)
+        self.assertEqual(request.prompt_token_ids, [0, 1, 2])
+        self.assertEqual(request._all_token_ids, [0, 1, 2])
+        self.assertEqual(request.num_prompt_tokens, 3)
+        self.assertEqual(request.max_tokens, 1)
+        self.assertTrue(request.kv_transfer_params["_p_side_truncated"])
+
     def test_build_connector_meta(self):
         self.scheduler.vllm_config.kv_transfer_config.is_kv_consumer = True
         request = MockRequest("req1")
@@ -674,6 +713,21 @@ class TestMooncakeLayerwiseConnectorSchedulerMatchedTokens(unittest.TestCase):
         self.assertEqual(meta.requests["req1"].local_block_ids, [[4, 5, 6]])
         self.assertEqual(meta.requests["req1"].remote_block_ids, [[1, 2, 3]])
         self.assertEqual(len(self.scheduler._reqs_need_recv), 0)
+
+    def test_update_state_after_alloc_hybrid_trims_remote_block_with_only_last_token(self):
+        self.scheduler.need_truncate = True
+        request = MockRequest(
+            "req1",
+            prompt_token_ids=list(range(17)),
+            kv_transfer_params={"do_remote_prefill": True, "metaserver": "http://meta"},
+        )
+        blocks = _MockBlocks(unhashed=[], block_ids_tuple=([4, 5],))
+        self.scheduler.executor.submit = MagicMock()
+
+        self.scheduler.update_state_after_alloc(request, blocks, num_external_tokens=16)
+
+        _, kwargs = self.scheduler.executor.submit.call_args
+        self.assertEqual(kwargs["message"]["remote_block_ids"], ([4],))
 
 
 class _MockBlocks:

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -147,70 +147,12 @@ class RecomputeScheduler(Scheduler):
                 request.streaming_queue = deque()
             # Fill in placeholder tokens to enable full graph compatibility. Without
             # placeholders, graph matching may fail, forcing eager mode execution.
-            if self.is_kv_producer and self.is_hybrid_model and request.num_tokens > 1:
-                request.prompt_token_ids.pop()
-                request._all_token_ids.pop()
-                request.num_prompt_tokens -= 1
             if self.is_mtp_kv_consumer and (self.max_model_len >= (request.num_tokens + self.num_spec_tokens)):
                 request.spec_token_ids = [PLACEHOLDER_TOKEN_ID] * self.num_spec_tokens
             self._enqueue_waiting_request(request)
             self.requests[request.request_id] = request
             if self.log_stats:
                 request.record_event(EngineCoreEventType.QUEUED)
-
-    def _update_waiting_for_remote_kv(self, request: Request) -> None:
-        """
-        KV Connector: update request state after async recv is finished.
-
-        The finished_recving_kv_req_ids list is populated
-        on the previous steps()'s update_from_output based
-        on the worker side connector.
-
-        When the kv transfer is ready, we cache the blocks
-        and the request state will be moved back to WAITING from
-        WAITING_FOR_REMOTE_KV.
-
-        NOTE: The check for whether request.request_id is in
-        finished_recving_kv_req_ids is now done by the caller
-        (_try_promote_blocked_waiting_request in the parent Scheduler),
-        so this method is only called when the recv is confirmed finished.
-        """
-        assert self.connector is not None
-
-        if request.request_id in self.failed_recving_kv_req_ids:
-            # Request had KV load failures; num_computed_tokens was already
-            # updated in _update_requests_with_invalid_blocks
-            if request.num_computed_tokens:
-                # Cache any valid computed tokens.
-                self.kv_cache_manager.cache_blocks(request, request.num_computed_tokens)
-            else:
-                # No valid computed tokens, release allocated blocks.
-                # There may be a local cache hit on retry.
-                self.kv_cache_manager.free(request)
-
-            self.failed_recving_kv_req_ids.remove(request.request_id)
-        else:
-            # Now that the blocks are ready, actually cache them.
-            # Use Ascend-specific block_ids logic to handle multi-group KV
-            # cache configurations (e.g. MLA) where len(block_ids) > 1.
-            block_ids = self.kv_cache_manager.get_block_ids(request.request_id)
-            if len(block_ids) == 1:
-                num_computed_tokens = len(block_ids[0]) * self.block_size
-                # Handle the case where num request tokens less than one block.
-                num_computed_tokens = min(num_computed_tokens, request.num_tokens)
-            else:
-                num_computed_tokens = request.num_tokens
-            # on a full prompt hit, we need to re-compute the last token
-            # in order to be able to sample the next token
-            if num_computed_tokens == request.num_tokens:
-                num_computed_tokens -= 1
-            # This will cache the blocks iff caching is enabled.
-            self.kv_cache_manager.cache_blocks(request, num_computed_tokens)
-
-            # Update the request state for scheduling.
-            request.num_computed_tokens = num_computed_tokens
-
-        self.finished_recving_kv_req_ids.remove(request.request_id)
 
     def schedule(self) -> RecomputeSchedulerOutput:
         # NOTE(woosuk) on the scheduling algorithm:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -2003,6 +2003,8 @@ class MooncakeConnectorWorker:
         # [layer_idx][cache_idx] -> stride(0) * element_size.
         self.block_stride_per_addr: list[list[int]] = [[] for _ in range(metadata_layers)]
 
+        # TODO: For DSV4 use_compress, metadata/transfer can be optimized by
+        # aggregating layer views that share the same raw KVCacheTensor.
         for layer_name, kv_cache_tuple in kv_caches.items():
             layer_idx = layer_name_to_idx[layer_name]
             for single_kv_cache in self._as_kv_cache_tuple(kv_cache_tuple):

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -449,6 +449,7 @@ class KVCacheRecvingThread(threading.Thread):
             self.group_compress_ratios[group_id] = compress_ratio
         self.remote_te_port: dict[str, dict[int, int]] = SizedDict()
         self.remote_block_size_scale: dict[str, dict[int, list[list[int]]]] = SizedDict()
+        self.remote_block_stride_per_addr: dict[str, dict[int, list[list[int]]]] = SizedDict()
         self.remote_kv_group2layeridx: dict[str, dict[int, dict[int, tuple[dict[str, Any], list[int]]]]] = SizedDict()
 
         self.request_queue: queue.Queue[Any] = queue.Queue()
@@ -661,6 +662,7 @@ class KVCacheRecvingThread(threading.Thread):
         local_kv_caches_base_addrs = self.kv_caches_base_addr[self.local_engine_id][self.local_handshake_port]
         remote_transfer_port = self.remote_te_port[remote_engine_id][remote_handshake_port]
         remote_block_size_scale = self.remote_block_size_scale[remote_engine_id][remote_handshake_port]
+        remote_block_stride_per_addr = self.remote_block_stride_per_addr[remote_engine_id][remote_handshake_port]
         session_id = f"{remote_host}:{remote_transfer_port}"
 
         req_start_time = time.perf_counter()
@@ -739,6 +741,8 @@ class KVCacheRecvingThread(threading.Thread):
                         src_layer_base_addr=local_kv_caches_base_addrs[layer_idx],
                         dst_layer_base_addr=remote_kv_caches_base_addrs[layer_idx],
                         block_len=self.block_len_per_addr[layer_idx],
+                        block_stride=self.block_stride_per_addr[layer_idx],
+                        remote_block_stride=remote_block_stride_per_addr[layer_idx],
                         remote_block_id=grouped_remote_block_ids[0][0],
                         local_block_id=grouped_local_block_ids[0][0],
                         tp_num_need_pulls=tp_num_need_pulls,
@@ -769,10 +773,18 @@ class KVCacheRecvingThread(threading.Thread):
                     dst_layer_base_addr = remote_kv_caches_base_addrs[layer_idx][cache_idx]
                     block_len = self.block_len_per_addr[layer_idx][cache_idx]
                     block_stride = self.block_stride_per_addr[layer_idx][cache_idx]
+                    remote_block_stride = remote_block_stride_per_addr[layer_idx][cache_idx]
                     inner_block_len = block_len // tp_num_need_pulls
-                    for remote_block_id, local_block_id in zip(grouped_remote_block_ids, grouped_local_block_ids):
+                    transfer_remote_block_ids, transfer_local_block_ids = split_if_not_byte_contiguous(
+                        grouped_remote_block_ids,
+                        grouped_local_block_ids,
+                        src_block_stride=remote_block_stride,
+                        dst_block_stride=block_stride,
+                        block_len=inner_block_len,
+                    )
+                    for remote_block_id, local_block_id in zip(transfer_remote_block_ids, transfer_local_block_ids):
                         src = src_layer_base_addr + local_block_id[0] * block_stride + inner_offset * inner_block_len
-                        dst = dst_layer_base_addr + remote_block_id[0] * block_stride
+                        dst = dst_layer_base_addr + remote_block_id[0] * remote_block_stride
                         length = inner_block_len * len(local_block_id)
                         src_list.append(src)
                         dst_list.append(dst)
@@ -915,6 +927,8 @@ class KVCacheRecvingThread(threading.Thread):
         src_layer_base_addr: list[int],
         dst_layer_base_addr: list[int],
         block_len: list[int],
+        block_stride: list[int],
+        remote_block_stride: list[int],
         remote_block_id: int,
         local_block_id: int,
         tp_num_need_pulls: int,
@@ -927,6 +941,8 @@ class KVCacheRecvingThread(threading.Thread):
         remote_conv_addr, remote_ssm_addr = dst_layer_base_addr[:2]
         local_conv_addr, local_ssm_addr = src_layer_base_addr[:2]
         local_conv_len, local_ssm_len = block_len[:2]
+        local_conv_stride, local_ssm_stride = block_stride[:2]
+        remote_conv_stride, remote_ssm_stride = remote_block_stride[:2]
 
         tp_ratio = tp_num_need_pulls
         remote_conv_len = local_conv_len // tp_ratio
@@ -935,14 +951,14 @@ class KVCacheRecvingThread(threading.Thread):
         if tp_ratio == 1:
             src_list.extend(
                 [
-                    local_conv_addr + local_block_id * local_conv_len,
-                    local_ssm_addr + local_block_id * local_ssm_len,
+                    local_conv_addr + local_block_id * local_conv_stride,
+                    local_ssm_addr + local_block_id * local_ssm_stride,
                 ]
             )
             dst_list.extend(
                 [
-                    remote_conv_addr + remote_block_id * remote_conv_len,
-                    remote_ssm_addr + remote_block_id * remote_ssm_len,
+                    remote_conv_addr + remote_block_id * remote_conv_stride,
+                    remote_ssm_addr + remote_block_id * remote_ssm_stride,
                 ]
             )
             length_list.extend([remote_conv_len, remote_ssm_len])
@@ -977,14 +993,16 @@ class KVCacheRecvingThread(threading.Thread):
                 local_addr_offset = (
                     (i * remote_conv_width + remote_conv_offset) * tp_ratio + remote_tp_offset * remote_conv_size
                 ) * conv_dtype_size
-                src_list.append(local_conv_addr + local_block_id * local_conv_len + local_addr_offset)
-                dst_list.append(remote_conv_addr + remote_block_id * remote_conv_len + remote_addr_offset)
+                src_list.append(local_conv_addr + local_block_id * local_conv_stride + local_addr_offset)
+                dst_list.append(remote_conv_addr + remote_block_id * remote_conv_stride + remote_addr_offset)
                 length_list.append(remote_conv_size * conv_dtype_size)
 
         src_list.append(
-            local_ssm_addr + local_block_id * local_ssm_len + remote_tp_offset * local_ssm_len // tp_num_need_pulls
+            local_ssm_addr
+            + local_block_id * local_ssm_stride
+            + remote_tp_offset * local_ssm_len // tp_num_need_pulls
         )
-        dst_list.append(remote_ssm_addr + remote_block_id * remote_ssm_len)
+        dst_list.append(remote_ssm_addr + remote_block_id * remote_ssm_stride)
         length_list.append(remote_ssm_len)
 
     def _get_group_kv_caches(self, group_idx: int, layer_indices: list[int] | None = None) -> dict[str, Any]:
@@ -1180,6 +1198,7 @@ class KVCacheRecvingThread(threading.Thread):
             self.kv_caches_base_addr[engine_id][remote_handshake_port] = agent_meta.kv_caches_base_addr
             self.remote_te_port[engine_id][remote_handshake_port] = agent_meta.te_rpc_port
             self.remote_block_size_scale[engine_id][remote_handshake_port] = agent_meta.block_size_scale
+            self.remote_block_stride_per_addr[engine_id][remote_handshake_port] = agent_meta.block_strides
         finally:
             if sock is not None:
                 self._return_remote_socket(sock, remote_host, remote_handshake_port)
@@ -2712,16 +2731,22 @@ def zmq_ctx(socket_type: Any, addr: str) -> Iterator[zmq.Socket]:  # type: ignor
 
 
 def group_concurrent_contiguous(
-    src: list[int], dst: list[int]
-) -> tuple[list[npt.NDArray[np.int64]], list[npt.NDArray[np.int64]]]:
-    """Vectorised NumPy implementation."""
+    src: list[int],
+    dst: list[int],
+    src_block_stride: int = 1,
+    dst_block_stride: int = 1,
+    block_len: int = 1,
+) -> tuple[list[list[int]], list[list[int]]]:
+    """Group block ids that are contiguous in both id space and memory."""
     src_indices: npt.NDArray[np.int64] = np.array(src, dtype=np.int64)
     dst_indices: npt.NDArray[np.int64] = np.array(dst, dtype=np.int64)
 
     if src_indices.size == 0:
         return [], []
 
-    brk = np.where((np.diff(src_indices) != 1) | (np.diff(dst_indices) != 1))[0] + 1
+    src_byte_contiguous = np.diff(src_indices) * src_block_stride == block_len
+    dst_byte_contiguous = np.diff(dst_indices) * dst_block_stride == block_len
+    brk = np.where(~(src_byte_contiguous & dst_byte_contiguous))[0] + 1
     src_groups = np.split(src_indices, brk)
     dst_groups = np.split(dst_indices, brk)
 
@@ -2729,6 +2754,27 @@ def group_concurrent_contiguous(
     dst_groups = [g.tolist() for g in dst_groups]
 
     return src_groups, dst_groups
+
+
+def split_if_not_byte_contiguous(
+    src_groups: list[list[int]],
+    dst_groups: list[list[int]],
+    src_block_stride: int,
+    dst_block_stride: int,
+    block_len: int,
+) -> tuple[list[list[int]], list[list[int]]]:
+    if src_block_stride == block_len and dst_block_stride == block_len:
+        return src_groups, dst_groups
+
+    src = [bid for group in src_groups for bid in group]
+    dst = [bid for group in dst_groups for bid in group]
+    return group_concurrent_contiguous(
+        src,
+        dst,
+        src_block_stride=src_block_stride,
+        dst_block_stride=dst_block_stride,
+        block_len=block_len,
+    )
 
 
 def string_to_int64_hash(input_str):

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -42,12 +42,14 @@ from vllm.distributed.parallel_state import (
 )
 from vllm.distributed.utils import get_pp_indices
 from vllm.logger import logger
+from vllm.utils.math_utils import cdiv
 from vllm.utils.network_utils import get_ip, make_zmq_path, make_zmq_socket
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     MambaSpec,
+    SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.request import RequestStatus
@@ -93,6 +95,7 @@ class MooncakeAgentMetadata(msgspec.Struct, omit_defaults=True, dict=True):
     block_size_scale: list[list[int]]
     num_blocks: int
     block_lens: list[list[int]]
+    block_strides: list[list[int]]
     local_ip: str = ""
 
 
@@ -120,6 +123,13 @@ class GroupPull:
     num_group_pulls: int
     prefill_pp_rank: int = 0
     is_group_transfer_end: bool = False
+
+
+@dataclass(frozen=True)
+class GroupTransferInfo:
+    tokens_per_block: int
+    blocks_per_window: int
+    is_state_group: bool
 
 
 @dataclass
@@ -396,6 +406,7 @@ class KVCacheRecvingThread(threading.Thread):
         side_channel_port: int,
         local_kv_caches_base_addr: list[list[int]],
         block_len_per_addr: list[list[int]],
+        block_stride_per_addr: list[list[int]],
         is_hma_required=False,
         ready_event: threading.Event | None = None,
         vllm_config: VllmConfig | None = None,
@@ -422,9 +433,20 @@ class KVCacheRecvingThread(threading.Thread):
         self.kv_caches_base_addr: dict[str, dict[int, list[list[int]]]] = SizedDict()
         self.kv_caches_base_addr[local_engine_id][local_handshake_port] = local_kv_caches_base_addr
         self.block_len_per_addr = block_len_per_addr
+        self.block_stride_per_addr = block_stride_per_addr
         if kv_group2layeridx is None:
             kv_group2layeridx = {}
         self.kv_group2layeridx = kv_group2layeridx
+        self.group_compress_ratios: dict[int, int] = {}
+        for group_id, (group_spec, _) in self.kv_group2layeridx.items():
+            compress_ratio = 1
+            kv_cache_spec = group_spec.get("kv_cache_spec")
+            if isinstance(kv_cache_spec, dict):
+                for spec in kv_cache_spec.values():
+                    if isinstance(spec, dict) and isinstance(spec.get("compress_ratio"), int):
+                        compress_ratio = max(1, spec["compress_ratio"])
+                        break
+            self.group_compress_ratios[group_id] = compress_ratio
         self.remote_te_port: dict[str, dict[int, int]] = SizedDict()
         self.remote_block_size_scale: dict[str, dict[int, list[list[int]]]] = SizedDict()
         self.remote_kv_group2layeridx: dict[str, dict[int, dict[int, tuple[dict[str, Any], list[int]]]]] = SizedDict()
@@ -678,7 +700,8 @@ class KVCacheRecvingThread(threading.Thread):
                 # For FullAttentionSpec prefix cache with hybrid kernel blocks.
                 num_computed_tokens = req_meta.get("num_computed_tokens", 0)
                 remote_kernel_block_size = self.block_size // remote_scale
-                remote_start_idx = num_computed_tokens // remote_kernel_block_size
+                remote_kernel_token_size = remote_kernel_block_size * self.group_compress_ratios[group_idx]
+                remote_start_idx = num_computed_tokens // remote_kernel_token_size
                 kernel_remote_block_ids = kernel_remote_block_ids[remote_start_idx:]
                 num_kernel_blocks = min(len(kernel_remote_block_ids), len(kernel_local_block_ids))
                 kernel_remote_block_ids = kernel_remote_block_ids[:num_kernel_blocks]
@@ -745,10 +768,11 @@ class KVCacheRecvingThread(threading.Thread):
                     src_layer_base_addr = local_kv_caches_base_addrs[layer_idx][cache_idx]
                     dst_layer_base_addr = remote_kv_caches_base_addrs[layer_idx][cache_idx]
                     block_len = self.block_len_per_addr[layer_idx][cache_idx]
+                    block_stride = self.block_stride_per_addr[layer_idx][cache_idx]
                     inner_block_len = block_len // tp_num_need_pulls
                     for remote_block_id, local_block_id in zip(grouped_remote_block_ids, grouped_local_block_ids):
-                        src = src_layer_base_addr + local_block_id[0] * block_len + inner_offset * inner_block_len
-                        dst = dst_layer_base_addr + remote_block_id[0] * inner_block_len
+                        src = src_layer_base_addr + local_block_id[0] * block_stride + inner_offset * inner_block_len
+                        dst = dst_layer_base_addr + remote_block_id[0] * block_stride
                         length = inner_block_len * len(local_block_id)
                         src_list.append(src)
                         dst_list.append(dst)
@@ -1414,6 +1438,110 @@ class MooncakeConnectorScheduler:
         # master-slave meta information for cross-nodes
         self.multi_nodes_meta_mapping: dict[str, dict[str, Any]] = {}
         self.kv_cache_groups = kv_cache_config.kv_cache_groups
+        self.use_hybrid = (
+            not vllm_config.scheduler_config.disable_hybrid_kv_cache_manager
+            and any(not isinstance(g.kv_cache_spec, FullAttentionSpec) for g in kv_cache_config.kv_cache_groups)
+            and len(kv_cache_config.kv_cache_groups) > 1
+        )
+        self.use_compress = self._model_uses_compress()
+        self.group_transfer_info = [self._get_group_transfer_info(group) for group in kv_cache_config.kv_cache_groups]
+        self.need_truncate = self.use_compress or any(info.is_state_group for info in self.group_transfer_info)
+
+    def _model_uses_compress(self) -> bool:
+        hf_config = getattr(self.vllm_config.model_config, "hf_config", None)
+        compress_ratios = getattr(hf_config, "compress_ratios", None)
+        return isinstance(compress_ratios, (list, tuple, dict))
+
+    def _get_group_transfer_info(self, group: Any) -> GroupTransferInfo:
+        specs = self._get_group_unique_specs(group)
+        first_spec = specs[0] if specs else group.kv_cache_spec
+        block_size = getattr(group.kv_cache_spec, "block_size", getattr(first_spec, "block_size", self.block_size))
+        is_state_group = any(isinstance(spec, MambaSpec) for spec in specs)
+        sliding_window = 0
+        compress_ratio = 1
+        for spec in specs:
+            if isinstance(spec, SlidingWindowSpec):
+                sliding_window = spec.sliding_window
+            elif hasattr(spec, "compress_ratio"):
+                compress_ratio = spec.compress_ratio
+
+        return GroupTransferInfo(
+            tokens_per_block=block_size * max(1, int(compress_ratio)),
+            blocks_per_window=cdiv(sliding_window, block_size) + 1 if sliding_window else 0,
+            is_state_group=is_state_group,
+        )
+
+    def _get_group_unique_specs(self, group: Any) -> list[Any]:
+        if not isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs):
+            return [group.kv_cache_spec]
+
+        specs = []
+        for layer_name in group.layer_names:
+            layer_spec = group.kv_cache_spec.kv_cache_specs[layer_name]
+            if layer_spec not in specs:
+                specs.append(layer_spec)
+        return specs
+
+    def _get_transfer_block_ids(self, block_ids: BlockIds, prompt_len: int) -> BlockIds:
+        """Return the P-side blocks that contain transferable prompt KV.
+
+        Attention KV can have extra blocks allocated by MTP. State groups such
+        as Mamba are not context-block aligned with attention KV, so keep them
+        unchanged and only clip attention-like groups.
+        """
+        if len(block_ids) == 0:
+            return block_ids
+
+        assert len(block_ids) == len(self.group_transfer_info), "Number of KV cache groups must match"
+
+        transfer_block_ids = []
+        for blocks, group_info in zip(block_ids, self.group_transfer_info):
+            if group_info.is_state_group:
+                transfer_block_ids.append(blocks)
+            elif group_info.blocks_per_window > 0:
+                window_blocks = blocks[-group_info.blocks_per_window :]
+                if len(window_blocks) > 1:
+                    window_blocks = [block_id for block_id in window_blocks if block_id != 0]
+                transfer_block_ids.append(window_blocks)
+            else:
+                num_prompt_blocks = cdiv(prompt_len, group_info.tokens_per_block)
+                transfer_block_ids.append(blocks[:num_prompt_blocks])
+        return tuple(transfer_block_ids)
+
+    def _state_prefill_token_count(self, num_prompt_tokens: int) -> int:
+        """D-side only. Returns N-1 for Mamba models since the decoder
+        always recomputes the last token and must start from h(N-1)."""
+        # logger.info(f"[===] enter _state_prefill_token_count")
+        if self.need_truncate and num_prompt_tokens > 1:
+            return num_prompt_tokens - 1
+        return num_prompt_tokens
+
+    def _truncate_request_for_prefill(self, request: "Request") -> None:
+        """P-side only: drop the last prompt token so the prefiller computes
+        h(N-1) instead of h(N). The decoder recomputes the last token to
+        derive h(N) correctly.
+
+        Guarded by ``_p_side_truncated`` to avoid repeated truncation if the
+        request is preempted and rescheduled."""
+        # logger.info(f"[===] enter _truncate_request_for_prefill")
+        params = request.kv_transfer_params
+        if (
+            params is not None
+            # Guard against repeated truncation after preemption/reschedule.
+            and not params.get("_p_side_truncated")
+            and request.num_prompt_tokens > 1
+        ):
+            if request.prompt_token_ids is not None:
+                request.prompt_token_ids.pop()
+            elif request.prompt_embeds is not None:
+                request.prompt_embeds = request.prompt_embeds[:-1]
+            else:
+                return
+
+            request._all_token_ids.pop()
+            request.num_prompt_tokens -= 1
+            request.max_tokens = 1
+            params["_p_side_truncated"] = True
 
     def get_num_new_matched_tokens(self, request: "Request", num_computed_tokens: int) -> tuple[int, bool]:
         """
@@ -1440,11 +1568,15 @@ class MooncakeConnectorScheduler:
 
         if params is not None and params.get("do_remote_prefill"):
             # Remote prefill: get all prompt blocks from remote.
-            assert num_computed_tokens % self.block_size == 0
+            token_ids = request.prompt_token_ids or []
+            actual = self._state_prefill_token_count(len(token_ids))
             params["num_computed_tokens"] = num_computed_tokens
-            # Note: We use the full token count as transmit data here.
-            count = max(len(request.prompt_token_ids) - num_computed_tokens, 0)
-            return count, count > 0
+            count = max(actual - num_computed_tokens, 0)
+            if count > 0:
+                return count, True
+
+        if params is not None and params.get("do_remote_decode") and self.need_truncate:
+            self._truncate_request_for_prefill(request)
 
         # No remote prefill for this request.
         return 0, False
@@ -1530,12 +1662,7 @@ class MooncakeConnectorScheduler:
             self._reqs_need_send[request.request_id] = time.time()
 
         num_prompt_blocks = math.ceil(len(request.prompt_token_ids) / self.block_size)
-        computed_block_ids = tuple(
-            block_ids[:num_prompt_blocks]
-            if not isinstance(self.kv_cache_groups[i].kv_cache_spec, MambaSpec)
-            else block_ids
-            for i, block_ids in enumerate(computed_block_ids)
-        )
+        computed_block_ids = self._get_transfer_block_ids(computed_block_ids, len(request.prompt_token_ids))
 
         return delay_free_blocks, dict(
             do_remote_prefill=True,
@@ -1608,6 +1735,11 @@ class MooncakeConnectorWorker:
         self.kv_cache_config = kv_cache_config
         self.num_blocks: int = kv_cache_config.num_blocks
         self.kv_group2layeridx: dict[int, tuple[dict[str, Any], list[int]]] = {}
+        self.use_hybrid = (
+            not self.vllm_config.scheduler_config.disable_hybrid_kv_cache_manager
+            and any(not isinstance(g.kv_cache_spec, FullAttentionSpec) for g in self.kv_cache_config.kv_cache_groups)
+            and len(self.kv_cache_config.kv_cache_groups) > 1
+        )
         self._is_hma_required = not vllm_config.scheduler_config.disable_hybrid_kv_cache_manager and any(
             not isinstance(g.kv_cache_spec, FullAttentionSpec) for g in kv_cache_config.kv_cache_groups
         )
@@ -1780,6 +1912,27 @@ class MooncakeConnectorWorker:
 
         return ptrs, lengths
 
+    def _get_registered_kv_tensor_buffers_hybrid(
+        self, kv_caches: dict[str, torch.Tensor]
+    ) -> tuple[list[int], list[int]]:
+        ptrs: list[int] = []
+        lengths: list[int] = []
+
+        for kv_cache_tensor in self.kv_cache_config.kv_cache_tensors:
+            shared_addrs: list[int] = []
+            for layer_name in kv_cache_tensor.shared_by:
+                for single_kv_cache in self._as_kv_cache_tuple(kv_caches[layer_name]):
+                    shared_addrs.append(single_kv_cache.data_ptr())
+
+            if not shared_addrs:
+                continue
+            base_addr = min(shared_addrs)
+            assert base_addr % (2 * 1024 * 1024) == 0, f"Tensor start addr {base_addr} is not align with 2M."
+            ptrs.append(base_addr)
+            lengths.append(kv_cache_tensor.size)
+
+        return ptrs, lengths
+
     def _get_registered_layer_buffers(self, kv_caches: dict[str, torch.Tensor]) -> tuple[list[int], list[int]]:
         ptrs: list[int] = []
         lengths: list[int] = []
@@ -1818,6 +1971,8 @@ class MooncakeConnectorWorker:
         # Per-layer byte length of one tensor block:
         # [layer_idx][cache_idx] -> element_size * prod(block_shape).
         self.block_len_per_addr: list[list[int]] = [[] for _ in range(metadata_layers)]
+        self.block_shape_per_addr: list[list[int]] = [[] for _ in range(metadata_layers)]
+        self.block_stride_per_addr: list[list[int]] = [[] for _ in range(metadata_layers)]
 
         for layer_name, kv_cache_tuple in kv_caches.items():
             layer_idx = layer_name_to_idx[layer_name]
@@ -1826,11 +1981,16 @@ class MooncakeConnectorWorker:
                 block_size_scale = tensor_num_blocks // self.num_blocks
                 block_shape = single_kv_cache.shape[1:]
                 self.block_len_per_addr[layer_idx].append(single_kv_cache.element_size() * math.prod(block_shape))
+                self.block_stride_per_addr[layer_idx].append(single_kv_cache.stride(0) * single_kv_cache.element_size())
+                self.block_shape_per_addr[layer_idx].append(single_kv_cache.shape)
                 self.block_size_scale[layer_idx].append(block_size_scale)
                 self.kv_caches_base_addr[layer_idx].append(single_kv_cache.data_ptr())
 
         if has_mamba_group:
             ptrs, lengths = self._get_registered_kv_tensor_buffers(kv_caches)
+            register_regions = RegisterRegions(ptrs=ptrs, lengths=lengths)
+        elif self.use_hybrid:
+            ptrs, lengths = self._get_registered_kv_tensor_buffers_hybrid(kv_caches)
             register_regions = RegisterRegions(ptrs=ptrs, lengths=lengths)
         else:
             # For normal attention / sparse-c8 KV cache, keep metadata at the
@@ -1843,10 +2003,13 @@ class MooncakeConnectorWorker:
 
         logger.debug(
             "Mooncake register kv caches metadata: kv_group2layeridx=%s, kv_caches_base_addr=%s, "
-            "block_len_per_addr=%s, block_size_scale=%s, ptrs=%s, lengths=%s",
+            "block_len_per_addr=%s, block_stride_per_addr=%s, block_shape_per_addr=%s, "
+            "block_size_scale=%s, ptrs=%s, lengths=%s",
             self.kv_group2layeridx,
             self.kv_caches_base_addr,
             self.block_len_per_addr,
+            self.block_stride_per_addr,
+            self.block_shape_per_addr,
             self.block_size_scale,
             register_regions.ptrs,
             register_regions.lengths,
@@ -1861,6 +2024,7 @@ class MooncakeConnectorWorker:
             block_size_scale=self.block_size_scale,
             num_blocks=self.num_blocks,
             block_lens=self.block_len_per_addr,
+            block_strides=self.block_stride_per_addr,
             local_ip=get_ip(),
         )
         self.xfer_handshake_metadata = metadata
@@ -1891,6 +2055,7 @@ class MooncakeConnectorWorker:
                 self.side_channel_port,
                 self.kv_caches_base_addr,
                 self.block_len_per_addr,
+                self.block_stride_per_addr,
                 self._is_hma_required,
                 ready_event,
                 self.vllm_config,

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -219,7 +219,7 @@ class KVCacheTaskTracker:
                 self.delayed_free_requests.popitem(last=False)
                 self.reqs_to_process.discard(request_id)
                 expired_requests.add(request_id)
-                logger.info(
+                logger.error(
                     "Force freed expired request: %s. "
                     "Reason: Request exceeded timeout threshold (%s seconds). "
                     "Action: Resources have been forcibly released to prevent memory leak.",
@@ -998,9 +998,7 @@ class KVCacheRecvingThread(threading.Thread):
                 length_list.append(remote_conv_size * conv_dtype_size)
 
         src_list.append(
-            local_ssm_addr
-            + local_block_id * local_ssm_stride
-            + remote_tp_offset * local_ssm_len // tp_num_need_pulls
+            local_ssm_addr + local_block_id * local_ssm_stride + remote_tp_offset * local_ssm_len // tp_num_need_pulls
         )
         dst_list.append(remote_ssm_addr + remote_block_id * remote_ssm_stride)
         length_list.append(remote_ssm_len)
@@ -1502,11 +1500,11 @@ class MooncakeConnectorScheduler:
         return specs
 
     def _get_transfer_block_ids(self, block_ids: BlockIds, prompt_len: int) -> BlockIds:
-        """Return the P-side blocks that contain transferable prompt KV.
+        """Return blocks that contain prompt KV, dropping MTP extra blocks.
 
-        Attention KV can have extra blocks allocated by MTP. State groups such
-        as Mamba are not context-block aligned with attention KV, so keep them
-        unchanged and only clip attention-like groups.
+        State groups such as Mamba are not context-block aligned with attention
+        KV, so keep them unchanged and only clip attention-like groups here.
+        SWA tail clipping is handled as a separate step after this.
         """
         if len(block_ids) == 0:
             return block_ids
@@ -1517,20 +1515,30 @@ class MooncakeConnectorScheduler:
         for blocks, group_info in zip(block_ids, self.group_transfer_info):
             if group_info.is_state_group:
                 transfer_block_ids.append(blocks)
-            elif group_info.blocks_per_window > 0:
-                window_blocks = blocks[-group_info.blocks_per_window :]
-                if len(window_blocks) > 1:
-                    window_blocks = [block_id for block_id in window_blocks if block_id != 0]
-                transfer_block_ids.append(window_blocks)
             else:
                 num_prompt_blocks = cdiv(prompt_len, group_info.tokens_per_block)
                 transfer_block_ids.append(blocks[:num_prompt_blocks])
         return tuple(transfer_block_ids)
 
+    def _get_swa_transfer_block_ids(self, block_ids: BlockIds) -> BlockIds:
+        """Clip SWA groups to their window tail and drop placeholder block 0."""
+        if len(block_ids) == 0:
+            return block_ids
+
+        assert len(block_ids) == len(self.group_transfer_info), "Number of KV cache groups must match"
+
+        transfer_block_ids = []
+        for blocks, group_info in zip(block_ids, self.group_transfer_info):
+            if group_info.is_state_group or group_info.blocks_per_window == 0:
+                transfer_block_ids.append(blocks)
+            else:
+                window_blocks = blocks[-group_info.blocks_per_window :]
+                transfer_block_ids.append([block_id for block_id in window_blocks if block_id != 0])
+        return tuple(transfer_block_ids)
+
     def _state_prefill_token_count(self, num_prompt_tokens: int) -> int:
         """D-side only. Returns N-1 for Mamba models since the decoder
         always recomputes the last token and must start from h(N-1)."""
-        # logger.info(f"[===] enter _state_prefill_token_count")
         if self.need_truncate and num_prompt_tokens > 1:
             return num_prompt_tokens - 1
         return num_prompt_tokens
@@ -1542,7 +1550,6 @@ class MooncakeConnectorScheduler:
 
         Guarded by ``_p_side_truncated`` to avoid repeated truncation if the
         request is preempted and rescheduled."""
-        # logger.info(f"[===] enter _truncate_request_for_prefill")
         params = request.kv_transfer_params
         if (
             params is not None
@@ -1673,15 +1680,14 @@ class MooncakeConnectorScheduler:
         ):
             return False, None
 
-        computed_block_ids = block_ids
+        num_prompt_blocks = math.ceil(len(request.prompt_token_ids) / self.block_size)
+        computed_block_ids = self._get_transfer_block_ids(block_ids, len(request.prompt_token_ids))
+        computed_block_ids = self._get_swa_transfer_block_ids(computed_block_ids)
         computed_block_lens = [len(block_id_list) for block_id_list in computed_block_ids]
         delay_free_blocks = sum(computed_block_lens) > 0
         if delay_free_blocks:
-            logger.info("Delaying free of %d blocks for request %s", len(computed_block_ids), request.request_id)
+            logger.info("Delaying free of %d blocks for request %s", sum(computed_block_lens), request.request_id)
             self._reqs_need_send[request.request_id] = time.time()
-
-        num_prompt_blocks = math.ceil(len(request.prompt_token_ids) / self.block_size)
-        computed_block_ids = self._get_transfer_block_ids(computed_block_ids, len(request.prompt_token_ids))
 
         return delay_free_blocks, dict(
             do_remote_prefill=True,
@@ -1990,7 +1996,11 @@ class MooncakeConnectorWorker:
         # Per-layer byte length of one tensor block:
         # [layer_idx][cache_idx] -> element_size * prod(block_shape).
         self.block_len_per_addr: list[list[int]] = [[] for _ in range(metadata_layers)]
+        # Per-layer full tensor shape for each registered KV cache address:
+        # [layer_idx][cache_idx] -> cache tensor shape, including num_blocks.
         self.block_shape_per_addr: list[list[int]] = [[] for _ in range(metadata_layers)]
+        # Per-layer byte stride between consecutive tensor blocks:
+        # [layer_idx][cache_idx] -> stride(0) * element_size.
         self.block_stride_per_addr: list[list[int]] = [[] for _ in range(metadata_layers)]
 
         for layer_name, kv_cache_tuple in kv_caches.items():

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -808,6 +808,7 @@ class MooncakeLayerwiseConnectorScheduler:
         # the scheduler. Used to make metadata passed to Worker.
         self._reqs_need_recv: dict[str, tuple[Request, list[int], list[list[int]]]] = {}
         self._reqs_need_send_layerwise: dict[str, SendReqInfo] = {}
+        self.need_truncate = self._has_attn_mamba_hybrid_cache(kv_cache_config)
         self.executor = ThreadPoolExecutor(32)
         tls_config: dict[str, Any] = vllm_config.kv_transfer_config.get_from_extra_config("tls_config", {})
         ssl_keyfile = tls_config.get("ssl_keyfile")
@@ -823,6 +824,63 @@ class MooncakeLayerwiseConnectorScheduler:
             )
         else:
             self.metaserver_client = httpx.Client(limits=httpx.Limits(max_connections=100000), timeout=None)
+
+    @staticmethod
+    def _iter_kv_cache_specs(kv_cache_config: KVCacheConfig):
+        for kv_cache_group in kv_cache_config.kv_cache_groups:
+            kv_cache_spec = kv_cache_group.kv_cache_spec
+            if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+                yield from kv_cache_spec.kv_cache_specs.values()
+            else:
+                yield kv_cache_spec
+
+    @classmethod
+    def _has_attn_mamba_hybrid_cache(cls, kv_cache_config: KVCacheConfig) -> bool:
+        has_attn = False
+        has_mamba = False
+        for kv_cache_spec in cls._iter_kv_cache_specs(kv_cache_config):
+            has_attn = has_attn or isinstance(kv_cache_spec, AttentionSpec)
+            has_mamba = has_mamba or isinstance(kv_cache_spec, MambaSpec)
+        return has_attn and has_mamba
+
+    def _hybrid_prefill_token_count(self, num_prompt_tokens: int) -> int:
+        if self.need_truncate and num_prompt_tokens > 1:
+            return num_prompt_tokens - 1
+        return num_prompt_tokens
+
+    def _truncate_request_for_hybrid_prefill(self, request: "Request") -> None:
+        params = request.kv_transfer_params
+        if (
+            params is None
+            or not self.need_truncate
+            or params.get("_p_side_truncated")
+            or getattr(request, "num_prompt_tokens", len(request.prompt_token_ids or [])) <= 1
+        ):
+            return
+
+        if request.prompt_token_ids is not None:
+            request.prompt_token_ids.pop()
+        elif request.prompt_embeds is not None:
+            request.prompt_embeds = request.prompt_embeds[:-1]
+        else:
+            return
+
+        request._all_token_ids.pop()
+        request.num_prompt_tokens -= 1
+        request.max_tokens = 1
+        params["_p_side_truncated"] = True
+
+    def _trim_hybrid_remote_block_ids(self, block_ids: tuple[list[int], ...], prompt_len: int) -> tuple[list[int], ...]:
+        if not self.need_truncate or prompt_len <= 1:
+            return block_ids
+
+        trimmed_block_ids: list[list[int]] = []
+        for group_block_ids, block_size in zip(block_ids, self.block_size):
+            if prompt_len % block_size == 1:
+                trimmed_block_ids.append(list(group_block_ids[:-1]))
+            else:
+                trimmed_block_ids.append(list(group_block_ids))
+        return tuple(trimmed_block_ids)
 
     def get_num_new_matched_tokens(self, request: "Request", num_computed_tokens: int) -> tuple[int, bool]:
         """
@@ -850,9 +908,11 @@ class MooncakeLayerwiseConnectorScheduler:
         if params is not None and params.get("do_remote_prefill"):
             # Remote prefill: get all prompt blocks from remote.
             assert num_computed_tokens % min(self.block_size) == 0
-            # Note: We use the full token count as transmit data here.
-            count = max(len(request.prompt_token_ids) - num_computed_tokens, 0)
+            count = max(self._hybrid_prefill_token_count(len(request.prompt_token_ids)) - num_computed_tokens, 0)
             return count, count > 0
+
+        if params is not None and params.get("do_remote_decode"):
+            self._truncate_request_for_hybrid_prefill(request)
 
         # No remote prefill for this request.
         return 0, False
@@ -868,6 +928,7 @@ class MooncakeLayerwiseConnectorScheduler:
         if params is not None and params.get("do_remote_prefill"):
             do_virtual = params.get("do_virtual", False)
             local_block_ids = (blocks.get_block_ids()) if num_external_tokens > 0 else []
+            remote_block_ids = self._trim_hybrid_remote_block_ids(local_block_ids, len(request.prompt_token_ids))
             remote_cached_tokens = request.num_computed_tokens
             # Get unhashed blocks to pull from remote.
             logger.debug(
@@ -891,7 +952,7 @@ class MooncakeLayerwiseConnectorScheduler:
                 request_id=external_req_id,
                 do_remote_prefill=False,
                 do_remote_decode=True,
-                remote_block_ids=local_block_ids,
+                remote_block_ids=remote_block_ids,
                 remote_block_size=self.block_size,
                 remote_engine_id=self.engine_id,
                 remote_host=self.side_channel_host,


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds Mooncake connector support for DeepSeek V4 / hybrid KV cache scenarios.

DeepSeek V4 introduces mixed KV cache layouts, including attention KV, compressed KV, sliding-window KV, and Mamba/state cache groups. The previous Mooncake transfer logic assumed that block ids could be translated with a simple `block_id * block_len` offset and that prompt blocks were aligned in the same way across all KV groups. That assumption is not always valid for DSV4/hybrid cache, and can lead to transferring extra blocks, using incorrect byte offsets, or computing one extra state token on the P side.

Main changes:

- Add per-block byte stride metadata to Mooncake handshake metadata.
  - `MooncakeAgentMetadata` now carries `block_strides`.
  - Sender/receiver use `stride(0) * element_size` for block offsets instead of assuming `block_len`.
  - Transfer grouping now checks byte contiguity with both block id continuity and actual memory stride.

- Support compressed and hybrid KV transfer block calculation.
  - Add per-group transfer metadata for `tokens_per_block`, sliding-window size, and state-group detection.
  - Use `compress_ratio` when calculating how many prompt blocks should be transferred.
  - Keep Mamba/state groups intact, while trimming attention-like groups to the blocks that actually contain transferable prompt KV.
  - Handle sliding-window groups by keeping only the active window blocks and dropping placeholder zero blocks where needed.

- Fix P/D-side token alignment for hybrid attention + Mamba prefill.
  - For remote prefill, the D side only counts `N - 1` prompt tokens when state cache requires the decoder to recompute the last token.
  - For remote decode on the P side, truncate the last prompt token once and mark the request with `_p_side_truncated` to avoid repeated truncation after preemption/reschedule.
  - Move this logic out of `RecomputeScheduler` and into the Mooncake connector scheduler where the KV-transfer semantics are known.

- Improve failure handling for multi-group block ids.
  - Failed receive requests now mark invalid block ids from the first block-id group instead of treating the full multi-group `BlockIds` tuple as a flat list.

- Update Mooncake worker metadata registration for hybrid KV cache.
  - Use total hidden layer count from model config.
  - Register shared hybrid KV tensor buffers when hybrid cache is enabled.

### Does this PR introduce _any_ user-facing change?

Yes. Mooncake connector can now correctly support DeepSeek V4 / hybrid KV cache disaggregated prefill scenarios.

There is no new public API or configuration option. Existing Mooncake metadata is extended internally with block stride information, so both sides of the connector should run with this updated code.

### How was this patch tested?

Added and updated unit tests for Mooncake connector and layerwise connector:

- `tests/ut/kv_offload/test_mooncake_connector.py`
  - compressed KV prefix-cache offset calculation
  - block-stride-based transfer offsets
  - Mamba transfer metadata offsets with block stride
  - byte-contiguous grouping and split behavior
  - attention MTP block trimming
  - state-group block preservation
  - compressed prompt length block calculation
  - sliding-window block clipping and zero-block filtering
  - remote metadata propagation of `block_strides`

- `tests/ut/kv_offload/test_mooncake_layerwise_connector.py`
  - hybrid prefill token count excludes the last token
  - P-side hybrid prefill request truncation
  - remote block trimming when the last token occupies a new block

Suggested commands:

```bash
pytest -sv tests/ut/kv_offload/test_mooncake_connector.py
pytest -sv tests/ut/kv_offload/test_mooncake_layerwise_connector.py


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
