### PR TITLE
[Doc] Fix and supplement some explanations for batch_invariance

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -234,7 +234,7 @@ If you are building in a CPU-only environment where `npu-smi` is unavailable, yo
 ```
 
 ```{note}
-To enable the batch invariance feature, set the environment variable `VLLM_BATCH_INVARIANT=1` before building `vllm-ascend`. And the `batch_invariant_ops` will be compiled and installed after setting `VLLM_BATCH_INVARIANT=1`.
+To enable the batch invariance feature, set `VLLM_BATCH_INVARIANT=1` before building vllm-ascend to install the batch invariance custom operator library during the installation process.
 
 For usage guidance on the batch invariance feature, see <https://github.com/vllm-project/vllm-ascend/blob/main/docs/source/user_guide/feature_guide/batch_invariance.md>
 ```

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -234,7 +234,9 @@ If you are building in a CPU-only environment where `npu-smi` is unavailable, yo
 ```
 
 ```{note}
-To enable the batch invariance feature, set the environment variable `VLLM_BATCH_INVARIANT=1` before building `vllm-ascend`. And the `batch_invariant_ops` will be compiled and installed after setting `VLLM_BATCH_INVARIANT=1`. For usage guidance on the batch invariance feature, see <https://github.com/vllm-project/vllm-ascend/blob/main/docs/source/user_guide/feature_guide/batch_invariance.md>
+To enable the batch invariance feature, set the environment variable `VLLM_BATCH_INVARIANT=1` before building `vllm-ascend`. And the `batch_invariant_ops` will be compiled and installed after setting `VLLM_BATCH_INVARIANT=1`.
+
+For usage guidance on the batch invariance feature, see <https://github.com/vllm-project/vllm-ascend/blob/main/docs/source/user_guide/feature_guide/batch_invariance.md>
 ```
 
 ## Set up using Docker

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -235,7 +235,6 @@ If you are building in a CPU-only environment where `npu-smi` is unavailable, yo
 
 ```{note}
 To enable the batch invariance feature, set `VLLM_BATCH_INVARIANT=1` before building vllm-ascend to install the batch invariance custom operator library during the installation process.
-
 For usage guidance on the batch invariance feature, see <https://github.com/vllm-project/vllm-ascend/blob/main/docs/source/user_guide/feature_guide/batch_invariance.md>
 ```
 

--- a/docs/source/user_guide/feature_guide/batch_invariance.md
+++ b/docs/source/user_guide/feature_guide/batch_invariance.md
@@ -6,7 +6,6 @@ Track progress and planned improvements at <https://github.com/vllm-project/vllm
 ```
 ```{note}
 To install the batch invariance custom operator library, set `VLLM_BATCH_INVARIANT=1` before building vllm-ascend.
-
 For installation instructions, see <https://github.com/vllm-project/vllm-ascend/blob/main/docs/source/installation.md#set-up-using-python>
 ```
 

--- a/docs/source/user_guide/feature_guide/batch_invariance.md
+++ b/docs/source/user_guide/feature_guide/batch_invariance.md
@@ -4,6 +4,7 @@
 Batch invariance is currently in beta. Some features are still under active development.
 Track progress and planned improvements at <https://github.com/vllm-project/vllm-ascend/issues/5487>
 ```
+
 ```{note}
 To install the batch invariance custom operator library, set `VLLM_BATCH_INVARIANT=1` before building vllm-ascend.
 For installation instructions, see <https://github.com/vllm-project/vllm-ascend/blob/main/docs/source/installation.md#set-up-using-python>

--- a/docs/source/user_guide/feature_guide/batch_invariance.md
+++ b/docs/source/user_guide/feature_guide/batch_invariance.md
@@ -4,6 +4,11 @@
 Batch invariance is currently in beta. Some features are still under active development.
 Track progress and planned improvements at <https://github.com/vllm-project/vllm-ascend/issues/5487>
 ```
+```{note}
+To install the batch invariance custom operator library, set `VLLM_BATCH_INVARIANT=1` before building vllm-ascend.
+
+For installation instructions, see <https://github.com/vllm-project/vllm-ascend/blob/main/docs/source/installation.md#set-up-using-python>
+```
 
 This document shows how to enable batch invariance in vLLM-Ascend. Batch invariance ensures that the output of a model is deterministic and independent of the batch size or the order of requests in a batch.
 
@@ -23,8 +28,7 @@ We will support Atlas A5 and other NPUs in the future.
 
 ## Software Requirements
 
-Batch invariance requires a custom operator library for Atlas A2 and A3 inference products.
-The operator library is automatically installed as part of the standard vllm-ascend installation process.
+Batch invariance requires a custom operator library for Atlas A2 and A3 inference products, and users need to set `VLLM_BATCH_INVARIANT=1` before building vllm-ascend to install the batch invariance custom operator library during the installation process.
 
 ## Enabling Batch Invariance
 
@@ -107,7 +111,7 @@ for output in outputs:
 Batch invariance has been tested and verified on the following models:
 
 - **Qwen3 (Dense)**: `Qwen/Qwen3-1.7B`, `Qwen/Qwen3-8B`
-- **Qwen3 (MoE)**: `Qwen/Qwen3-30B-A3B`
+- **Qwen3 (MoE)**: `Qwen/Qwen3-30B-A3B`, `Qwen/Qwen3-235B-A22B`
 
 Other models may also work, but these have been explicitly validated. If you encounter issues with a specific model, please report them on the [GitHub issue tracker](https://github.com/vllm-project/vllm-ascend/issues/new/choose).
 


### PR DESCRIPTION

### What this PR does / why we need it?

Fix and supplement some explanations for batch_invariance:
- installation.md : Updated the note clarifying that VLLM_BATCH_INVARIANT=1 must be set before building vllm-ascend to install batch_invariant_ops , with a link to the batch invariance feature guide.
- batch_invariance.md : Updated Software Requirements to clarify that users need to set VLLM_BATCH_INVARIANT=1 before building to install the custom operator library. Added installation instructions in the top note with links to the installation guide.

### Does this PR introduce _any_ user-facing change?
Yes. Documentation update : Added installation instructions and cross-references between installation.md and batch_invariance.md to guide users on how to enable the feature.
### How was this patch tested?


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
