### PR TITLE
[Feature] ops: add FHT dynamic quant for DSA indexer

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_fast_hadamard_dynamic_quant.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_fast_hadamard_dynamic_quant.py
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+import pytest
+import torch
+import torch.nn.functional as F
+import torch_npu
+
+from vllm_ascend.ops.fast_hadamard import (
+    _fast_hadamard_dynamic_quant_int8_ref,
+    fast_hadamard_dynamic_quant_last_dim,
+)
+
+torch.manual_seed(45)
+
+BATCHES = [*range(1, 9), 16, 32, 64, 128, 256, 512, 4096]
+
+
+@pytest.mark.parametrize("batch", BATCHES)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@torch.inference_mode()
+def test_fast_hadamard_dynamic_quant_int8_matches_ref(batch: int, dtype: torch.dtype):
+    x = torch.randn(batch, 128, device="npu", dtype=dtype)
+
+    out, scale = fast_hadamard_dynamic_quant_last_dim(x)
+    torch.npu.synchronize()
+
+    ref_out, ref_scale = _fast_hadamard_dynamic_quant_int8_ref(x.cpu())
+    scale = scale.cpu()
+    out = out.cpu()
+
+    scale_rel_err = ((scale - ref_scale).abs() / ref_scale.abs().clamp_min(1e-6)).max()
+    cosine = F.cosine_similarity(out.float().reshape(1, -1), ref_out.float().reshape(1, -1))
+    max_abs_diff = (out.to(torch.int16) - ref_out.to(torch.int16)).abs().max()
+    assert scale_rel_err.item() < 0.02
+    assert cosine.item() > 0.99
+    assert max_abs_diff.item() <= 1
+
+    torch_npu.npu.empty_cache()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_fht_indexer_rotate.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_fht_indexer_rotate.py
@@ -1,0 +1,140 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""NPU parity and timing for the DeepSeek-V4 DSA indexer Hadamard rotation.
+
+Compares, on V4-Flash lightning-indexer shapes (index_head_dim=128):
+  existing: DSA rotate_activation + DeviceOperator.indexer_quantize_query
+  fused: PTO fused FHT + int8 dynamic quant kernel
+
+The FHT equals the dense rotation up to a fixed output permutation that
+cancels in indexer scores q . k^T; parity is asserted on scores. Timings
+are printed, following the singlecard_ops convention.
+"""
+
+import numpy as np
+import pytest
+import torch
+from scipy.linalg import hadamard as scipy_hadamard
+
+from vllm_ascend.attention.dsa_v1 import rotate_activation
+from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.ops.fast_hadamard import fast_hadamard_dynamic_quant_last_dim
+
+torch.manual_seed(45)
+
+N = 128  # index_head_dim
+N_HEADS = 64  # index_n_heads
+T_Q_PARITY = 1024  # keeps score-parity matmul manageable
+T_Q_BENCH = 4096  # realistic DeepSeek-V4-Pro max-num-batched-tokens chunk
+COMPRESS_RATIO = 4
+T_KV_UPDATE_BENCH = T_Q_BENCH // COMPRESS_RATIO  # compressed kv entries produced from this token batch
+T_K_CACHE = 4096  # existing compressed indexer kv cache entries used for score parity
+TOPK = 512  # index_topk
+WARMUP, ITERS = 50, 100
+
+
+def benchmark_npu(fn, num_iterations=ITERS, num_warmup_iterations=WARMUP):
+    start = torch.npu.Event(enable_timing=True)
+    end = torch.npu.Event(enable_timing=True)
+    times = np.zeros(num_iterations + num_warmup_iterations)
+    for i in range(num_iterations + num_warmup_iterations):
+        with torch.no_grad():
+            start.record()
+            fn()
+            end.record()
+        torch.npu.synchronize()
+        times[i] = start.elapsed_time(end)
+    return np.amin(times[num_warmup_iterations:]) * 1000  # us
+
+
+def existing_indexer_quantize(x: torch.Tensor, h: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    return DeviceOperator.indexer_quantize_query(rotate_activation(x, h))
+
+
+def fused_indexer_quantize(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    q, scale = fast_hadamard_dynamic_quant_last_dim(x)
+    return q, scale.to(torch.float16)
+
+
+def dequant(q: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    return q.float() * scale.reshape(-1, 1).float()
+
+
+def topk_overlap(s: torch.Tensor, s_ref: torch.Tensor) -> float:
+    top = s.topk(TOPK, dim=-1).indices
+    ref = s_ref.topk(TOPK, dim=-1).indices
+    return (top.unsqueeze(-1) == ref.unsqueeze(-2)).any(-1).float().mean().item()
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "fp16"])
+def test_fht_indexer_rotate_parity_and_perf(dtype: torch.dtype):
+    dtype_name = str(dtype).split(".")[-1]
+    torch.manual_seed(45)
+    h = torch.tensor(scipy_hadamard(N, dtype=float), dtype=torch.float32, device="npu").to(dtype)
+    q = torch.randn(T_Q_PARITY * N_HEADS, N, dtype=dtype, device="npu")
+    k_cache = torch.randn(T_K_CACHE, N, dtype=dtype, device="npu")
+    q_bench = torch.randn(T_Q_BENCH * N_HEADS, N, dtype=dtype, device="npu")
+    kv_update = torch.randn(T_KV_UPDATE_BENCH, N, dtype=dtype, device="npu")
+
+    # fp32 dense reference scores
+    s_ref = rotate_activation(q, h).float() @ rotate_activation(k_cache, h).float().T
+
+    # Existing DSA/indexer component path.
+    qq_existing, qs_existing = existing_indexer_quantize(q, h)
+    kq_existing, ks_existing = existing_indexer_quantize(k_cache, h)
+    s_existing = dequant(qq_existing, qs_existing) @ dequant(kq_existing, ks_existing).T
+
+    # Candidate replacement for rotate_activation + indexer_quantize_query.
+    qq, qs = fused_indexer_quantize(q)
+    kq, ks = fused_indexer_quantize(k_cache)
+    s_fused = dequant(qq, qs) @ dequant(kq, ks).T
+
+    assert ((s_fused - s_existing).norm() / s_existing.norm()).item() < 0.05
+    for name, s, min_ov in (
+        ("existing", s_existing, 0.98),
+        ("fused", s_fused, 0.98),
+    ):
+        ov = topk_overlap(s, s_ref)
+        rel = ((s - s_ref).norm() / s_ref.norm()).item()
+        print(f"{dtype_name} {name}: top{TOPK} overlap {ov * 100:.2f}% rel_err {rel:.4f}")
+        assert ov >= min_ov
+
+    t_current_q = benchmark_npu(lambda: existing_indexer_quantize(q_bench, h))
+    t_fused_q = benchmark_npu(lambda: fused_indexer_quantize(q_bench))
+    t_current_kv_update = benchmark_npu(lambda: existing_indexer_quantize(kv_update, h))
+    t_fused_kv_update = benchmark_npu(lambda: fused_indexer_quantize(kv_update))
+    t_current_q_kv_update = benchmark_npu(
+        lambda: (
+            existing_indexer_quantize(q_bench, h),
+            existing_indexer_quantize(kv_update, h),
+        )
+    )
+    t_fused_q_kv_update = benchmark_npu(
+        lambda: (
+            fused_indexer_quantize(q_bench),
+            fused_indexer_quantize(kv_update),
+        )
+    )
+    t_rotate = benchmark_npu(lambda: rotate_activation(q_bench, h))
+    print(f"[{dtype_name} q {T_Q_BENCH * N_HEADS}x{N}] current {t_current_q:.1f} us | fused int8 {t_fused_q:.1f} us")
+    print(
+        f"[{dtype_name} kv_update {T_KV_UPDATE_BENCH}x{N}] current {t_current_kv_update:.1f} us | "
+        f"fused int8 {t_fused_kv_update:.1f} us"
+    )
+    print(
+        f"[{dtype_name} q+kv_update {T_Q_BENCH * N_HEADS}x{N}+{T_KV_UPDATE_BENCH}x{N}] "
+        f"current {t_current_q_kv_update:.1f} us | "
+        f"fused int8 {t_fused_q_kv_update:.1f} us"
+    )
+    print(f"[{dtype_name} {T_Q_BENCH * N_HEADS}x{N}] rotate_only {t_rotate:.1f} us")

--- a/tests/ut/ops/test_fast_hadamard.py
+++ b/tests/ut/ops/test_fast_hadamard.py
@@ -1,0 +1,86 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""CPU-side correctness of the fast Hadamard transform (FHT) against the
+dense matrix Hadamard used by the DeepSeek-V4 DSA indexer.
+
+The PTO FHT computes ``x @ H`` up to a fixed output permutation P, which
+cancels in the indexer score ``q . k^T``, so equivalence is checked on
+permutation structure and inner products rather than element order.
+"""
+
+import math
+
+import torch
+from scipy.linalg import hadamard as scipy_hadamard
+
+from vllm_ascend.ops.fast_hadamard import (
+    _fast_hadamard_dynamic_quant_int8_ref,
+    fast_hadamard_pto_ref_inplace,
+)
+
+N = 128  # V4-Flash index_head_dim
+SCALE = N**-0.5
+TOPK = 512  # V4-Flash index_topk
+
+torch.manual_seed(0)
+
+
+def dense_h() -> torch.Tensor:
+    return torch.tensor(scipy_hadamard(N, dtype=float), dtype=torch.float32)
+
+
+def rotate_activation_ref(x: torch.Tensor) -> torch.Tensor:
+    # mirrors vllm_ascend/attention/dsa_v1.py::rotate_activation
+    return torch.nn.functional.linear(x, dense_h()) * SCALE
+
+
+def fht(x: torch.Tensor) -> torch.Tensor:
+    return fast_hadamard_pto_ref_inplace(x) * SCALE
+
+
+def test_fht_is_permuted_hadamard():
+    f = fast_hadamard_pto_ref_inplace(torch.eye(N))
+    assert torch.equal(f.abs(), torch.ones(N, N))
+    assert torch.allclose(f @ f.T, N * torch.eye(N))
+    match = (f @ dense_h().T / N).round()
+    assert torch.equal(match.abs().sum(0), torch.ones(N))  # bijective perm
+    assert torch.equal(match.abs().sum(1), torch.ones(N))
+
+
+def test_indexer_scores_invariant():
+    q, k = torch.randn(1024, N), torch.randn(2048, N)
+    s_ref = rotate_activation_ref(q) @ rotate_activation_ref(k).T
+    s_fht = fht(q) @ fht(k).T
+    torch.testing.assert_close(s_fht, s_ref, rtol=1e-4, atol=1e-3)
+
+
+def test_int8_quantized_score_topk_overlap():
+    q, k = torch.randn(64, N), torch.randn(2048, N)
+    s_ref = rotate_activation_ref(q) @ rotate_activation_ref(k).T
+    qq, qs = _fast_hadamard_dynamic_quant_int8_ref(q)
+    kq, ks = _fast_hadamard_dynamic_quant_int8_ref(k)
+    s = (qq.float() * qs) @ (kq.float() * ks).T
+    assert ((s - s_ref).norm() / s_ref.norm()).item() < 0.02
+    top_ref = s_ref.topk(TOPK, dim=-1).indices
+    top = s.topk(TOPK, dim=-1).indices
+    overlap = (top.unsqueeze(-1) == top_ref.unsqueeze(-2)).any(-1).float().mean()
+    assert overlap.item() >= 0.98
+
+
+def test_fht_matches_log2_structure():
+    x = torch.randn(8, N)
+    out = fast_hadamard_pto_ref_inplace(x)
+    assert out.shape == x.shape
+    assert int(math.log2(N)) == 7
+    torch.testing.assert_close(fast_hadamard_pto_ref_inplace(out) / N, x, rtol=1e-4, atol=1e-4)

--- a/vllm_ascend/ops/fast_hadamard.py
+++ b/vllm_ascend/ops/fast_hadamard.py
@@ -1,0 +1,237 @@
+import math
+import os
+import subprocess
+from functools import cache
+from pathlib import Path
+
+import torch
+from vllm.utils.torch_utils import direct_register_custom_op
+
+DEFAULT_BLOCK_DIM = 20
+HEAD_DIM = 128
+LOG2_HEAD_DIM = 7
+
+
+def _get_device_block_dim() -> int:
+    try:
+        from vllm_ascend.platform import NPUPlatform
+
+        return NPUPlatform.num_compute_units(torch.npu.current_device())
+    except Exception:
+        return DEFAULT_BLOCK_DIM
+
+
+def _get_toolkit_home():
+    toolkit = (
+        os.environ.get("PTO_LIB_PATH") or os.environ.get("ASCEND_HOME_PATH") or os.environ.get("ASCEND_TOOLKIT_HOME")
+    )
+    if not toolkit:
+        raise RuntimeError("PTO_LIB_PATH, ASCEND_HOME_PATH, or ASCEND_TOOLKIT_HOME must be set")
+    return toolkit
+
+
+def _get_cce_soc_version() -> str:
+    soc_version = os.environ.get("SOC_VERSION")
+    if not soc_version:
+        return "Ascend910B4"
+
+    normalized = soc_version.lower()
+    normalized = {
+        "910b": "ascend910b1",
+        "910c": "ascend910_9392",
+        "310p": "ascend310p1",
+    }.get(normalized, normalized)
+    if normalized.startswith("ascend910b"):
+        suffix = normalized.removeprefix("ascend910b").split("-", 1)[0]
+        return f"Ascend910B{suffix or '1'}"
+    if normalized.startswith("ascend910_"):
+        return "Ascend" + normalized.removeprefix("ascend")
+    if normalized.startswith("ascend310p"):
+        suffix = normalized.removeprefix("ascend310p")
+        return f"Ascend310P{suffix or '1'}"
+    return soc_version
+
+
+def _is_cached_lib_fresh(kernel_cpp: str, lib_path: str) -> bool:
+    src = Path(kernel_cpp)
+    lib = Path(lib_path)
+    if not lib.is_file():
+        return False
+    try:
+        return lib.stat().st_mtime >= src.stat().st_mtime
+    except FileNotFoundError:
+        return False
+
+
+def compile_cpp(
+    kernel_cpp: str,
+    verbose: bool = False,
+    timeout: int = 120,
+    output_name: str = "fast_hadamard_dynamic_quant_int8_jit.so",
+) -> str:
+    lib_path = os.path.join(os.path.dirname(kernel_cpp), output_name)
+    if _is_cached_lib_fresh(kernel_cpp, lib_path):
+        if verbose:
+            print(f"reusing cached {lib_path}")
+        return lib_path
+
+    flags = [
+        "-fPIC",
+        "-shared",
+        "-xcce",
+        "-DMEMORY_BASE",
+        "-O2",
+        "-std=c++17",
+        f"--cce-soc-version={_get_cce_soc_version()}",
+        "--cce-soc-core-type=VecCore",
+        f"-I{_get_toolkit_home()}/include",
+    ]
+
+    command = ["bisheng", *flags, kernel_cpp, "-o", lib_path]
+    if verbose:
+        print("compile command:", " ".join(command))
+    try:
+        subprocess.run(command, timeout=timeout, check=True)
+    except Exception as e:
+        raise RuntimeError(f"Compile failed: {e}") from e
+    return lib_path
+
+
+def fast_hadamard_pto_ref_inplace(x: torch.Tensor) -> torch.Tensor:
+    if x.numel() == 0:
+        return x.clone()
+    if x.shape[-1] != HEAD_DIM:
+        raise ValueError("fast_hadamard_pto_ref_inplace expects last dim 128")
+
+    out = x.clone()
+    for _ in range(LOG2_HEAD_DIM):
+        even = out[..., 0::2].clone()
+        odd = out[..., 1::2].clone()
+        out[..., :64] = even + odd
+        out[..., 64:] = even - odd
+    return out
+
+
+def _fast_hadamard_dynamic_quant_int8_ref(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    if x.ndim < 1:
+        raise ValueError("fast_hadamard_dynamic_quant_last_dim expects rank >= 1")
+    if x.shape[-1] != HEAD_DIM:
+        raise ValueError("fast_hadamard_dynamic_quant_last_dim expects last dim 128")
+
+    rows = x.reshape(-1, HEAD_DIM).to(torch.float32)
+    transformed = fast_hadamard_pto_ref_inplace(rows).to(torch.float32) / math.sqrt(float(HEAD_DIM))
+    max_abs = transformed.abs().amax(dim=-1, keepdim=True)
+    scale = torch.clamp(max_abs / 127.0, min=1e-6)
+    quant = torch.round(transformed / scale).clamp(-128, 127).to(torch.int8)
+    return quant.reshape(*x.shape[:-1], HEAD_DIM), scale.to(torch.float32).reshape(*x.shape[:-1], 1)
+
+
+def _load_dynamic_quant_int8_lib(lib_path: str):
+    import ctypes
+
+    lib_path = os.path.abspath(lib_path)
+    lib = ctypes.CDLL(lib_path)
+    lib.call_dynamic_quant_int8_kernel.argtypes = [
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+    ]
+    lib.call_dynamic_quant_int8_kernel.restype = None
+
+    def fused_kernel_func(x, quant_out, row_scales, batch, block_dim=None, stream_ptr=None):
+        if block_dim is None:
+            block_dim = _get_device_block_dim()
+        if stream_ptr is None:
+            stream_ptr = torch.npu.current_stream().npu_stream
+        lib.call_dynamic_quant_int8_kernel(
+            block_dim,
+            stream_ptr,
+            ctypes.c_void_p(x.data_ptr()),
+            ctypes.c_void_p(quant_out.data_ptr()),
+            ctypes.c_void_p(row_scales.data_ptr()),
+            batch,
+        )
+
+    return fused_kernel_func
+
+
+def _fast_hadamard_dynamic_quant_int8_custom_op_impl(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    batch = x.shape[0]
+    quant_out = torch.empty((batch, HEAD_DIM), dtype=torch.int8, device=x.device)
+    scale_out = torch.empty((batch + 7,), dtype=torch.float32, device=x.device)
+    _ensure_fast_hadamard_dynamic_quant_int8_ready_for_dispatch()
+    fused_func = _get_fast_hadamard_dynamic_quant_int8_jit_func()
+    fused_func(x, quant_out, scale_out, batch)
+    return quant_out, scale_out[:batch]
+
+
+def _fast_hadamard_dynamic_quant_int8_custom_op_fake(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    batch = x.shape[0]
+    return (
+        torch.empty((batch, HEAD_DIM), dtype=torch.int8, device=x.device),
+        torch.empty((batch,), dtype=torch.float32, device=x.device),
+    )
+
+
+direct_register_custom_op(
+    op_name="fast_hadamard_dynamic_quant_int8",
+    op_func=_fast_hadamard_dynamic_quant_int8_custom_op_impl,
+    fake_impl=_fast_hadamard_dynamic_quant_int8_custom_op_fake,
+    mutates_args=[],
+    dispatch_key="PrivateUse1",
+)
+
+
+def ensure_fast_hadamard_dynamic_quant_int8_shared_object() -> str:
+    kernel_cpp = os.path.join(os.path.dirname(__file__), "fast_hadamard_dynamic_quant_int8_pto-isa.cpp")
+    lib_path = compile_cpp(
+        kernel_cpp,
+        verbose=False,
+        timeout=120,
+        output_name="fast_hadamard_dynamic_quant_int8_jit.so",
+    )
+    return lib_path
+
+
+def _is_torch_compiling() -> bool:
+    is_compiling = getattr(torch.compiler, "is_compiling", None)
+    return bool(is_compiling()) if callable(is_compiling) else False
+
+
+def _ensure_fast_hadamard_dynamic_quant_int8_ready_for_dispatch() -> None:
+    if _get_fast_hadamard_dynamic_quant_int8_jit_func.cache_info().currsize > 0:
+        return
+    if _is_torch_compiling():
+        raise RuntimeError("fast_hadamard_dynamic_quant_int8 must be compiled and loaded before torch.compile dispatch")
+
+
+@cache
+def _get_fast_hadamard_dynamic_quant_int8_jit_func():
+    return _load_dynamic_quant_int8_lib(ensure_fast_hadamard_dynamic_quant_int8_shared_object())
+
+
+def fast_hadamard_dynamic_quant_last_dim(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    if x.ndim < 1:
+        raise ValueError("fast_hadamard_dynamic_quant_last_dim expects rank >= 1")
+    if x.shape[-1] != HEAD_DIM:
+        raise ValueError("fast_hadamard_dynamic_quant_last_dim expects last dim 128")
+    if x.numel() == 0:
+        return (
+            torch.empty(*x.shape[:-1], HEAD_DIM, dtype=torch.int8, device=x.device),
+            torch.empty(*x.shape[:-1], 1, dtype=torch.float32, device=x.device),
+        )
+
+    rows = x.reshape(-1, HEAD_DIM).contiguous()
+    if x.device.type != "npu":
+        return _fast_hadamard_dynamic_quant_int8_ref(x)
+
+    if rows.dtype == torch.bfloat16:
+        rows = rows.to(torch.float16)
+    elif rows.dtype != torch.float16:
+        raise TypeError("fast_hadamard_dynamic_quant_last_dim expects float16 or bfloat16 input")
+
+    quant_out, scale_out = torch.ops.vllm.fast_hadamard_dynamic_quant_int8(rows)
+    return quant_out.reshape(*x.shape[:-1], HEAD_DIM), scale_out.to(torch.float32).reshape(*x.shape[:-1], 1)

--- a/vllm_ascend/ops/fast_hadamard_dynamic_quant_int8_pto-isa.cpp
+++ b/vllm_ascend/ops/fast_hadamard_dynamic_quant_int8_pto-isa.cpp
@@ -1,0 +1,409 @@
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+#define DIV_ROUNDUP(x, y) (((x) + (y) - 1) / (y))
+
+// DeepSeek-V4 DSA indexer rotates 128-wide q/k rows.  Specializing the width
+// keeps the fused FHT+dynamic-quant kernel branch-free in the hot path.
+constexpr uint32_t N = 128;
+constexpr uint32_t LOG2_N = 7;
+constexpr uint32_t N_HALF = N / 2;
+
+// 32KB is the pto-kernels tile size for this FHT schedule.  With N=128 and
+// fp16 input, one tile holds 128 rows, so each worker amortizes launch and DMA
+// overhead while still leaving UB room for ping-pong output and reductions.
+constexpr uint32_t X_BUFFER_BYTES = 32 * 1024;
+constexpr uint32_t UB_HALF_BYTES = X_BUFFER_BYTES / 2;
+constexpr uint32_t ELEMENTS_PER_TILE = X_BUFFER_BYTES / sizeof(half);
+constexpr uint32_t SAMPLES_PER_LOAD = ELEMENTS_PER_TILE / N;
+constexpr uint32_t Y_BUFFER_BYTES = ELEMENTS_PER_TILE * sizeof(int8_t);
+// 184KB matches the usable UB budget used by the pto-kernels FHT examples; the
+// rest of the physical UB is reserved by the runtime/compiler.
+constexpr uint32_t UB_USABLE_BYTES = 184 * 1024;
+constexpr uint32_t DYNAMIC_SCALE_BYTES = SAMPLES_PER_LOAD * sizeof(float);
+constexpr uint32_t DYNAMIC_REDUCE_BYTES = SAMPLES_PER_LOAD * sizeof(half);
+// The Hadamard transform is normalized by folding 1/sqrt(128) into the stored
+// dynamic quant scale instead of multiplying the transformed fp16 tile.
+constexpr float INV_SQRT_N = 0.08838834764831845f;
+// Symmetric int8 dynamic quantization uses [-127, 127] with zero point 0.
+constexpr float QUANT_MAX_INT8 = 127.0f;
+// Match torch_npu dynamic quant behavior for all-zero or tiny rows.
+constexpr float SCALE_FLOOR = 1e-6f;
+// MTE3 stores float scales in 32-byte blocks.  Eight fp32 rows keep each core's
+// scale range 32-byte aligned and avoid cross-core overwrite on row_scales.
+constexpr uint32_t SCALE_ALIGNMENT_ROWS = 8;
+
+// PTO Tile objects are typed views over raw UB byte offsets.  The 0x100 guard
+// spacing follows the pto-kernels examples and keeps independently addressed
+// vector/MTE regions comfortably separated.
+constexpr unsigned UB_GUARD_BYTES = 0x100;
+
+// Ping-pong buffers let MTE2 load the next input tile and MTE3 store the current
+// output tile without waiting for the vector pipe to finish every row block.
+constexpr unsigned X_PING = 0x00000;
+constexpr unsigned Y_PING = X_PING + X_BUFFER_BYTES + UB_GUARD_BYTES;
+constexpr unsigned SCALE_PING = Y_PING + Y_BUFFER_BYTES + UB_GUARD_BYTES;
+constexpr unsigned X_PONG = SCALE_PING + DYNAMIC_SCALE_BYTES + UB_GUARD_BYTES;
+constexpr unsigned Y_PONG = X_PONG + X_BUFFER_BYTES + UB_GUARD_BYTES;
+constexpr unsigned SCALE_PONG = Y_PONG + Y_BUFFER_BYTES + UB_GUARD_BYTES;
+
+// Scratch/reduction buffers are shared by ping and pong.  Only one vector phase
+// is active per worker, so double-buffering these would consume UB without
+// increasing MTE overlap.
+constexpr unsigned EVEN_BASE = SCALE_PONG + DYNAMIC_SCALE_BYTES + UB_GUARD_BYTES;
+constexpr unsigned ODD_BASE = EVEN_BASE + UB_HALF_BYTES + UB_GUARD_BYTES;
+constexpr unsigned REDUCE_TMP_BASE = ODD_BASE + UB_HALF_BYTES + UB_GUARD_BYTES;
+constexpr unsigned SCALE_FLOOR_BASE = REDUCE_TMP_BASE + X_BUFFER_BYTES + UB_GUARD_BYTES;
+constexpr unsigned ROWMAX_BASE = SCALE_FLOOR_BASE + DYNAMIC_SCALE_BYTES + UB_GUARD_BYTES;
+constexpr unsigned ROWMIN_BASE = ROWMAX_BASE + DYNAMIC_REDUCE_BYTES + UB_GUARD_BYTES;
+static_assert(ROWMIN_BASE + DYNAMIC_REDUCE_BYTES <= UB_USABLE_BYTES,
+              "Fused Hadamard+int8 dynamic quant UB layout exceeds usable UB.");
+
+namespace {
+
+struct TileWork {
+  uint32_t gm_offset, sample_count, elements;
+};
+
+// Produce the next contiguous GM row range for this vector sub-core.  gm_offset
+// is measured in elements, not bytes, because GlobalTensor is already typed.
+AICORE bool nextTile(uint32_t& sample_done, uint32_t gm_offset_base, uint32_t samples_to_process, TileWork& tile) {
+  if (sample_done >= samples_to_process) {
+    return false;
+  }
+
+  tile.sample_count = min(SAMPLES_PER_LOAD, samples_to_process - sample_done);
+  tile.elements = tile.sample_count * N;
+  tile.gm_offset = gm_offset_base + sample_done * N;
+  sample_done += tile.sample_count;
+  return true;
+}
+
+template <typename InputT>
+AICORE void issueTLoad(__gm__ InputT* x, const TileWork& tile, unsigned x_base, event_t ev) {
+  using InShape = pto::Shape<1, 1, 1, 1, ELEMENTS_PER_TILE>;
+  using Stride = pto::Stride<1, 1, 1, 1, 1>;
+  using InGlobal = pto::GlobalTensor<InputT, InShape, Stride>;
+  using FullTile = Tile<TileType::Vec, InputT, 1, ELEMENTS_PER_TILE, BLayout::RowMajor, -1, -1>;
+
+  FullTile xBulkTile(1, tile.elements);
+  TASSIGN(xBulkTile, x_base);
+  InGlobal xGlobal(x + tile.gm_offset);
+  TASSIGN(xGlobal, (x + tile.gm_offset));
+  wait_flag(PIPE_V, PIPE_MTE2, ev);
+  TLOAD(xBulkTile, xGlobal);
+  set_flag(PIPE_MTE2, PIPE_V, ev);
+}
+
+template <typename InputT>
+AICORE void runHadamard128InPlace(unsigned x_base, uint32_t sample_count) {
+  using FullTile = Tile<TileType::Vec, InputT, SAMPLES_PER_LOAD, N, BLayout::RowMajor, DYNAMIC, N>;
+  using ScratchTile = Tile<TileType::Vec, InputT, SAMPLES_PER_LOAD, N_HALF, BLayout::RowMajor, DYNAMIC, N_HALF>;
+  using XHalfTile = Tile<TileType::Vec, InputT, SAMPLES_PER_LOAD, N, BLayout::RowMajor, DYNAMIC, N_HALF>;
+
+  FullTile xBulkTile(sample_count);
+  ScratchTile evenTile(sample_count);
+  ScratchTile oddTile(sample_count);
+  XHalfTile xFirstHalf(sample_count);
+  XHalfTile xSecondHalf(sample_count);
+  TASSIGN(xBulkTile, x_base);
+  TASSIGN(evenTile, EVEN_BASE);
+  TASSIGN(oddTile, ODD_BASE);
+  TASSIGN(xFirstHalf, x_base);
+  TASSIGN(xSecondHalf, x_base + N_HALF * sizeof(InputT));
+
+// One radix-2 Hadamard stage:
+//   1. split alternating values into even/odd scratch tiles,
+//   2. write even + odd to the first half,
+//   3. write even - odd to the second half.
+// Repeating this LOG2_N times gives a 128-point Hadamard per row.  The
+// pipe_barrier calls order vector instructions that reuse the same UB buffers.
+#define FAST_HADAMARD_128_STAGE()                                            \
+  do {                                                                       \
+    TGATHER<ScratchTile, FullTile, MaskPattern::P0101>(evenTile, xBulkTile); \
+    TGATHER<ScratchTile, FullTile, MaskPattern::P1010>(oddTile, xBulkTile);  \
+    pipe_barrier(PIPE_V);                                                    \
+    TADD(xFirstHalf, evenTile, oddTile);                                     \
+    TSUB(xSecondHalf, evenTile, oddTile);                                    \
+    pipe_barrier(PIPE_V);                                                    \
+  } while (0)
+
+  FAST_HADAMARD_128_STAGE();
+  FAST_HADAMARD_128_STAGE();
+  FAST_HADAMARD_128_STAGE();
+  FAST_HADAMARD_128_STAGE();
+  FAST_HADAMARD_128_STAGE();
+  FAST_HADAMARD_128_STAGE();
+  FAST_HADAMARD_128_STAGE();
+
+#undef FAST_HADAMARD_128_STAGE
+}
+
+template <typename InputT>
+AICORE void runHadamard128InPlaceFull(unsigned x_base) {
+  using FullTile = Tile<TileType::Vec, InputT, SAMPLES_PER_LOAD, N, BLayout::RowMajor, SAMPLES_PER_LOAD, N>;
+  using ScratchTile =
+      Tile<TileType::Vec, InputT, SAMPLES_PER_LOAD, N_HALF, BLayout::RowMajor, SAMPLES_PER_LOAD, N_HALF>;
+  using XHalfTile = Tile<TileType::Vec, InputT, SAMPLES_PER_LOAD, N, BLayout::RowMajor, SAMPLES_PER_LOAD, N_HALF>;
+
+  FullTile xBulkTile;
+  ScratchTile evenTile;
+  ScratchTile oddTile;
+  XHalfTile xFirstHalf;
+  XHalfTile xSecondHalf;
+  TASSIGN(xBulkTile, x_base);
+  TASSIGN(evenTile, EVEN_BASE);
+  TASSIGN(oddTile, ODD_BASE);
+  TASSIGN(xFirstHalf, x_base);
+  TASSIGN(xSecondHalf, x_base + N_HALF * sizeof(InputT));
+
+#define FAST_HADAMARD_128_FULL_STAGE()                                       \
+  do {                                                                       \
+    TGATHER<ScratchTile, FullTile, MaskPattern::P0101>(evenTile, xBulkTile); \
+    TGATHER<ScratchTile, FullTile, MaskPattern::P1010>(oddTile, xBulkTile);  \
+    pipe_barrier(PIPE_V);                                                    \
+    TADD(xFirstHalf, evenTile, oddTile);                                     \
+    TSUB(xSecondHalf, evenTile, oddTile);                                    \
+    pipe_barrier(PIPE_V);                                                    \
+  } while (0)
+
+  FAST_HADAMARD_128_FULL_STAGE();
+  FAST_HADAMARD_128_FULL_STAGE();
+  FAST_HADAMARD_128_FULL_STAGE();
+  FAST_HADAMARD_128_FULL_STAGE();
+  FAST_HADAMARD_128_FULL_STAGE();
+  FAST_HADAMARD_128_FULL_STAGE();
+  FAST_HADAMARD_128_FULL_STAGE();
+
+#undef FAST_HADAMARD_128_FULL_STAGE
+}
+
+template <typename InputT, typename OutputT>
+AICORE void quantizeHadamard128Tile(unsigned x_base, unsigned y_base, uint32_t sample_count) {
+  using XHalfTile = Tile<TileType::Vec, InputT, SAMPLES_PER_LOAD, N, BLayout::RowMajor, -1, N_HALF>;
+  using QuantOutHalfTile = Tile<TileType::Vec, OutputT, SAMPLES_PER_LOAD, N, BLayout::RowMajor, -1, N_HALF>;
+  using ReduceTileColMajor = Tile<TileType::Vec, InputT, SAMPLES_PER_LOAD, 1, BLayout::ColMajor, -1, -1>;
+  using ReduceTileRowMajor = Tile<TileType::Vec, InputT, 1, SAMPLES_PER_LOAD, BLayout::RowMajor, -1, -1>;
+
+  XHalfTile xFirstHalf(sample_count);
+  XHalfTile xSecondHalf(sample_count);
+  QuantOutHalfTile yFirstHalf(sample_count);
+  QuantOutHalfTile ySecondHalf(sample_count);
+  ReduceTileColMajor rowMaxTile(1, sample_count);
+  ReduceTileRowMajor rowMaxTileRm(1, sample_count);
+  ReduceTileRowMajor rowFloorTile(1, sample_count);
+  TASSIGN(xFirstHalf, x_base);
+  TASSIGN(xSecondHalf, x_base + N_HALF * sizeof(InputT));
+  TASSIGN(yFirstHalf, y_base);
+  TASSIGN(ySecondHalf, y_base + N_HALF * sizeof(OutputT));
+  TASSIGN(rowMaxTile, ROWMAX_BASE);
+  TASSIGN(rowMaxTileRm, ROWMAX_BASE);
+  TASSIGN(rowFloorTile, ODD_BASE);
+
+  TMULS(rowFloorTile, rowMaxTileRm, (InputT)0.0f);
+  pipe_barrier(PIPE_V);
+  TADDS(rowFloorTile, rowFloorTile, (InputT)SCALE_FLOOR);
+  pipe_barrier(PIPE_V);
+  TMAX(rowMaxTileRm, rowMaxTileRm, rowFloorTile);
+  pipe_barrier(PIPE_V);
+
+  TRESHAPE(rowMaxTile, rowMaxTileRm);
+  pipe_barrier(PIPE_V);
+  TROWEXPANDDIV(xFirstHalf, xFirstHalf, rowMaxTile);
+  TROWEXPANDDIV(xSecondHalf, xSecondHalf, rowMaxTile);
+  pipe_barrier(PIPE_V);
+  TMULS(xFirstHalf, xFirstHalf, (InputT)QUANT_MAX_INT8);
+  TMULS(xSecondHalf, xSecondHalf, (InputT)QUANT_MAX_INT8);
+  pipe_barrier(PIPE_V);
+  TCVT(yFirstHalf, xFirstHalf, RoundMode::CAST_RINT);
+  TCVT(ySecondHalf, xSecondHalf, RoundMode::CAST_RINT);
+  pipe_barrier(PIPE_V);
+}
+
+template <typename InputT, typename OutputT>
+AICORE void runTFastHadamardDynamicQuantInt8(__gm__ InputT* x, __gm__ OutputT* y, __gm__ float* row_scales,
+                                             uint32_t batch, uint32_t num_cores, uint32_t vid) {
+  // Configure the vector mask once for full-lane vector operations.  __DAV_VEC__
+  // in the global entry point ensures this code is compiled for the vector side
+  // of an Ascend AI Core.
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+
+  // Each vid handles a contiguous band of rows; no inter-core synchronization is needed because
+  // every row's Hadamard and dynamic quantization are independent.
+  const uint32_t samples_per_core =
+      DIV_ROUNDUP(DIV_ROUNDUP(batch, num_cores), SCALE_ALIGNMENT_ROWS) * SCALE_ALIGNMENT_ROWS;
+  const uint32_t sample_offset = samples_per_core * vid;
+  if (sample_offset >= batch) {
+    return;
+  }
+
+  uint32_t samples_to_process = samples_per_core;
+  if (sample_offset + samples_to_process > batch) {
+    samples_to_process = batch - sample_offset;
+  }
+  if (samples_to_process == 0) {
+    return;
+  }
+
+  using Shape = pto::Shape<1, 1, 1, 1, ELEMENTS_PER_TILE>;
+  using ScaleShape = pto::Shape<1, 1, 1, 1, SAMPLES_PER_LOAD>;
+  using Stride = pto::Stride<1, 1, 1, 1, 1>;
+  using OutGlobal = pto::GlobalTensor<OutputT, Shape, Stride>;
+  using ScaleGlobal = pto::GlobalTensor<float, ScaleShape, Stride>;
+  using BulkTile = Tile<TileType::Vec, InputT, SAMPLES_PER_LOAD, N, BLayout::RowMajor, DYNAMIC, N>;
+  using QuantTile = Tile<TileType::Vec, OutputT, 1, ELEMENTS_PER_TILE, BLayout::RowMajor, -1, -1>;
+  using ReduceTmpTile = Tile<TileType::Vec, InputT, SAMPLES_PER_LOAD, N, BLayout::RowMajor, DYNAMIC, N>;
+  using ReduceTileColMajor = Tile<TileType::Vec, InputT, SAMPLES_PER_LOAD, 1, BLayout::ColMajor, -1, -1>;
+  using ReduceTileRowMajor = Tile<TileType::Vec, InputT, 1, SAMPLES_PER_LOAD, BLayout::RowMajor, -1, -1>;
+  using ScaleTile = Tile<TileType::Vec, float, 1, SAMPLES_PER_LOAD, BLayout::RowMajor, -1, -1>;
+
+  // Prime both ping-pong event slots.  EVENT_ID0 protects the ping buffers and
+  // EVENT_ID1 protects the pong buffers across MTE2, vector, and MTE3 pipes.
+  set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+  set_flag(PIPE_V, PIPE_MTE2, EVENT_ID1);
+  set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+  set_flag(PIPE_MTE3, PIPE_V, EVENT_ID1);
+
+  const uint32_t gm_offset_base = sample_offset * N;
+  uint32_t sample_done = 0;
+  TileWork current_tile;
+  if (!nextTile(sample_done, gm_offset_base, samples_to_process, current_tile)) {
+    return;
+  }
+
+  bool ping = true;
+  issueTLoad(x, current_tile, X_PING, EVENT_ID0);
+
+  while (true) {
+    const event_t current_ev = ping ? (event_t)EVENT_ID0 : (event_t)EVENT_ID1;
+    const unsigned current_x_base = ping ? X_PING : X_PONG;
+    const unsigned current_y_base = ping ? Y_PING : Y_PONG;
+    const unsigned current_scale_base = ping ? SCALE_PING : SCALE_PONG;
+
+    wait_flag(PIPE_MTE2, PIPE_V, current_ev);
+
+    TileWork next_tile;
+    const bool has_next = nextTile(sample_done, gm_offset_base, samples_to_process, next_tile);
+    if (has_next) {
+      const event_t next_ev = ping ? (event_t)EVENT_ID1 : (event_t)EVENT_ID0;
+      const unsigned next_x_base = ping ? X_PONG : X_PING;
+      issueTLoad(x, next_tile, next_x_base, next_ev);
+    }
+
+    const uint32_t row_index_base = current_tile.gm_offset / N;
+
+    BulkTile xBulkTile(current_tile.sample_count);
+    QuantTile yBulkTile(1, current_tile.elements);
+    ReduceTmpTile reduceTmpTile(current_tile.sample_count);
+    ReduceTileColMajor rowMaxTile(current_tile.sample_count, 1);
+    ReduceTileColMajor rowMinTile(current_tile.sample_count, 1);
+    ReduceTileRowMajor rowMaxTileRm(1, current_tile.sample_count);
+    ReduceTileRowMajor rowMinTileRm(1, current_tile.sample_count);
+    ScaleTile scaleTile(1, current_tile.sample_count);
+    ScaleTile scaleFloorTile(1, current_tile.sample_count);
+    TASSIGN(xBulkTile, current_x_base);
+    TASSIGN(yBulkTile, current_y_base);
+    TASSIGN(reduceTmpTile, REDUCE_TMP_BASE);
+    TASSIGN(rowMaxTile, ROWMAX_BASE);
+    TASSIGN(rowMinTile, ROWMIN_BASE);
+    TASSIGN(rowMaxTileRm, EVEN_BASE);
+    TASSIGN(rowMinTileRm, ODD_BASE);
+    TASSIGN(scaleTile, current_scale_base);
+    TASSIGN(scaleFloorTile, SCALE_FLOOR_BASE);
+    wait_flag(PIPE_MTE3, PIPE_V, current_ev);
+
+    // Phase 1: transform fp16 rows in UB.  The normalized Hadamard scale is not
+    // applied to xBulkTile directly; it is folded into row_scales below.
+    runHadamard128InPlace<InputT>(current_x_base, current_tile.sample_count);
+    pipe_barrier(PIPE_V);
+
+    // Phase 2: compute the quantization scale for each transformed row:
+    //   row_scale = max(abs(Hx)) * (1 / sqrt(128)) / 127
+    // The floor keeps all-zero rows from producing a zero scale.
+    TROWMAX(rowMaxTile, xBulkTile, reduceTmpTile);
+    TROWMIN(rowMinTile, xBulkTile, reduceTmpTile);
+    pipe_barrier(PIPE_V);
+
+    TRESHAPE(rowMaxTileRm, rowMaxTile);
+    TRESHAPE(rowMinTileRm, rowMinTile);
+    pipe_barrier(PIPE_V);
+
+    TMULS(rowMinTileRm, rowMinTileRm, (InputT)-1.0f);
+    pipe_barrier(PIPE_V);
+    TMAX(rowMaxTileRm, rowMaxTileRm, rowMinTileRm);
+    pipe_barrier(PIPE_V);
+
+    TCVT(scaleTile, rowMaxTileRm, RoundMode::CAST_NONE);
+    pipe_barrier(PIPE_V);
+    TMULS(scaleTile, scaleTile, INV_SQRT_N / QUANT_MAX_INT8);
+    pipe_barrier(PIPE_V);
+
+    TMULS(scaleFloorTile, scaleTile, 0.0f);
+    pipe_barrier(PIPE_V);
+    TADDS(scaleFloorTile, scaleFloorTile, SCALE_FLOOR);
+    pipe_barrier(PIPE_V);
+    TMAX(scaleTile, scaleTile, scaleFloorTile);
+    pipe_barrier(PIPE_V);
+
+    // Phase 3: produce int8 rows.  Use the same dynamic full-tile layout as
+    // the pto-kernels dynamic-quant path for both full tiles and tails.
+    quantizeHadamard128Tile<InputT, OutputT>(current_x_base, current_y_base, current_tile.sample_count);
+
+    // Phase 4: store results.  MTE3 writes the current ping/pong Y/SCALE slots
+    // to GM while the next loop iteration can compute into the opposite slots.
+    set_flag(PIPE_V, PIPE_MTE3, current_ev);
+    wait_flag(PIPE_V, PIPE_MTE3, current_ev);
+    OutGlobal yGlobal(y + current_tile.gm_offset);
+    TASSIGN(yGlobal, (y + current_tile.gm_offset));
+    ScaleGlobal scaleGlobal(row_scales + row_index_base);
+    TASSIGN(scaleGlobal, (row_scales + row_index_base));
+    TSTORE(yGlobal, yBulkTile);
+    TSTORE(scaleGlobal, scaleTile);
+    set_flag(PIPE_MTE3, PIPE_V, current_ev);
+    set_flag(PIPE_V, PIPE_MTE2, current_ev);
+
+    if (!has_next) {
+      break;
+    }
+
+    current_tile = next_tile;
+    ping = !ping;
+  }
+
+  wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+  wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID1);
+  wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+  wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID1);
+}
+
+}  // namespace
+
+__global__ AICORE void fast_hadamard_dynamic_quant_fp16_to_int8(__gm__ void* x, __gm__ void* y, __gm__ void* row_scales,
+                                                                uint32_t batch) {
+#if defined(__DAV_VEC__)
+  // This branch is selected by compiling the PTO source for VecCore.
+  // get_block_* identifies the AI Core block, while get_subblock* identifies
+  // vector sub-cores inside that block.  Treating the pair as a flat vid gives
+  // the total number of independent workers used to partition the batch rows.
+  const uint32_t num_cores = get_block_num() * get_subblockdim();
+  const uint32_t vid = get_block_idx() * get_subblockdim() + get_subblockid();
+  runTFastHadamardDynamicQuantInt8<half, int8_t>((__gm__ half*)x, (__gm__ int8_t*)y, (__gm__ float*)row_scales, batch,
+                                                 num_cores, vid);
+#else
+  (void)x;
+  (void)y;
+  (void)row_scales;
+  (void)batch;
+#endif
+}
+
+extern "C" void call_dynamic_quant_int8_kernel(uint32_t blockDim, void* stream, uint8_t* x, uint8_t* y,
+                                               float* row_scales, uint32_t batch) {
+  // The Python wrapper passes the configured block count.  This C wrapper
+  // doubles the launch grid to match the sub-block based worker indexing used
+  // in fast_hadamard_dynamic_quant_fp16_to_int8.
+  blockDim = blockDim * 2;
+  fast_hadamard_dynamic_quant_fp16_to_int8<<<blockDim, nullptr, stream>>>(x, y, row_scales, batch);
+}


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds a specialized fused Fast Hadamard Transform + INT8 dynamic quantization path for the DeepSeek-V4 DSA lightning indexer rotation.

The existing indexer path does (cf `dsa_v1.py`):

  1. `rotate_activation(x, hadamard)` using dense Hadamard `F.linear`
  2. `DeviceOperator.indexer_quantize_query(...)` using INT8 dynamic quantization

### Does this PR introduce _any_ user-facing change?

No. This only adds an internal specialized operator and tests for the DeepSeek-V4 DSA indexer path. There is no public API or configuration behavior change in this PR.

### How was this patch tested?

```bash
python3 -m pytest tests/e2e/nightly/single_node/ops/singlecard_ops/test_fast_hadamard_dynamic_quant.py                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                         
python3 -m pytest tests/ut/ops/test_fast_hadamard.py                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                       python3 -m pytest tests/e2e/nightly/single_node/ops/singlecard_ops/test_fht_indexer_rotate.py
```

Results:

```
  [bfloat16 q 262144x128] current 1546.2 us | fused int8 882.1 us
  [bfloat16 kv_update 1024x128] current 254.8 us | fused int8 345.6 us
  [bfloat16 q+kv_update 262144x128+1024x128] current 1564.7 us | fused int8 897.9 us

  [float16 q 262144x128] current 1481.5 us | fused int8 850.4 us
  [float16 kv_update 1024x128] current 257.0 us | fused int8 315.0 us
  [float16 q+kv_update 262144x128+1024x128] current 1501.0 us | fused int8 860.5 us
```

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
