### PR TITLE
[Feature][DSv4] Patch vLLM prefix-cache core reuse and align prefix hits to scheduler block size

### DIFF
--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -219,6 +219,29 @@
 #       Remove this patch once upstream vLLM supports hybrid KV cache + CP for
 #       non-CUDA backends, or exposes a platform hook for this behavior.
 #
+# ** 10b. File: platform/patch_prefix_cache_core.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.v1.core.kv_cache_utils.FreeKVCacheBlockQueue.prepend_n`
+#   2. `vllm.v1.core.block_pool.BlockPool.free_blocks`
+#   3. `vllm.v1.core.single_type_kv_cache_manager.SingleTypeKVCacheManager.remove_skipped_blocks`
+#   4. `vllm.v1.core.single_type_kv_cache_manager.SlidingWindowManager._cache_block_mask`
+#   5. `vllm.v1.core.single_type_kv_cache_manager.SlidingWindowManager.free`
+#    Why:
+#       The DeepSeek V4 prefix-cache coordinator patch relies on the vLLM core
+#       block-reuse behavior added by vLLM PR #43447. Older supported vLLM
+#       versions do not expose `free_blocks(prepend=...)`, so short/SWA prefix
+#       cache paths can recycle local blocks with poor priority.
+#    How:
+#       When `VLLM_ASCEND_APPLY_DSV4_PATCH` is enabled, monkey-patch the missing
+#       free-list/front-insertion behavior and the SWA/EAGLE cache block mask.
+#       Each patch is guarded by capability/source checks so it is skipped once
+#       the underlying vLLM already provides the upstream behavior.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/43447
+#    Future Plan:
+#       Remove this patch once the supported vLLM version contains vLLM PR
+#       #43447 or equivalent prefix-cache block-reuse behavior.
+#
 # ** 10. File: platform/patch_kv_cache_interface.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.kv_cache_interface.MLAAttentionSpec`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -44,5 +44,6 @@ if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXP
 import vllm_ascend.patch.platform.patch_balance_schedule  # noqa
 
 if envs.VLLM_ASCEND_APPLY_DSV4_PATCH:
+    import vllm_ascend.patch.platform.patch_prefix_cache_core  # noqa
     import vllm_ascend.patch.platform.patch_kv_cache_coordinator  # noqa
     import vllm_ascend.patch.platform.patch_speculative_config  # noqa

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM projectx
 import sys
-from math import lcm
 
 import vllm
 from vllm.v1.core.block_pool import BlockPool
@@ -43,6 +42,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         dcp_world_size: int,
         pcp_world_size: int,
         hash_block_size: int,
+        scheduler_block_size: int | None = None,
         eagle_attn_layer_names: list[str] | None = None,
         metrics_collector: KVCacheMetricsCollector | None = None,
         max_num_batched_tokens: int | None = None,
@@ -56,6 +56,12 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         if max_num_batched_tokens is None:
             max_num_batched_tokens = max_model_len
         self.max_num_batched_tokens = max_num_batched_tokens
+        if scheduler_block_size is None:
+            scheduler_block_size = hash_block_size
+        assert scheduler_block_size % hash_block_size == 0 and all(
+            scheduler_block_size % g.kv_cache_spec.block_size == 0 for g in kv_cache_config.kv_cache_groups
+        )
+        self.scheduler_block_size = scheduler_block_size
 
         self.block_pool = BlockPool(
             kv_cache_config.num_blocks,
@@ -84,6 +90,8 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             )
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
+        for i, manager in enumerate(self.single_type_managers):
+            manager.use_eagle = i in self.eagle_group_ids
 
         # hash_block_size: the block size used to compute block hashes.
         # The actual block size usually equals hash_block_size, but in cases where
@@ -91,20 +99,18 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         # can be a multiple of hash_block_size.
         self.hash_block_size = hash_block_size
         if enable_caching:
-            assert all(
-                self._logical_block_size(g.kv_cache_spec) % hash_block_size == 0
-                for g in kv_cache_config.kv_cache_groups
-            ), "block_size must be divisible by hash_block_size"
+            assert all(g.kv_cache_spec.block_size % hash_block_size == 0 for g in kv_cache_config.kv_cache_groups), (
+                "block_size must be divisible by hash_block_size"
+            )
         assert dcp_world_size == 1, "DCP not support hybrid attn now."
         assert pcp_world_size == 1, "PCP not support hybrid attn now."
         self.verify_and_split_kv_cache_groups()
+        for _, group_ids, _ in self.attention_groups:
+            group_uses_eagle = any(group_id in self.eagle_group_ids for group_id in group_ids)
+            for group_id in group_ids:
+                self.single_type_managers[group_id].use_eagle = group_uses_eagle
 
         self.use_eagle = use_eagle
-
-    @staticmethod
-    def _logical_block_size(kv_cache_spec: KVCacheSpec) -> int:
-        compress_ratio = getattr(kv_cache_spec, "compress_ratio", 1) or 1
-        return kv_cache_spec.block_size * max(compress_ratio, 1)
 
     def verify_and_split_kv_cache_groups(self) -> None:
         """
@@ -143,14 +149,9 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             if any(gid in self.eagle_group_ids for gid in group_ids)
         }
 
-        # The LCM of the block sizes of all attention types.
-        # The cache hit length must be a multiple of the LCM of the block sizes
-        # to make sure the cache hit length is a multiple of the block size of
-        # each attention type. Requiring this because we don't support partial
-        # block cache hit yet.
-        # NOTE: use 16k as the alignment tokens for model with compress ratio
-        block_sizes = [self._logical_block_size(spec) for spec, _, _ in self.attention_groups]
-        self.lcm_block_size = lcm(*block_sizes)
+        # Prefix-cache hits are aligned to scheduler_block_size, not to
+        # block_size * compress_ratio. The latter forces DSv4 compressed
+        # groups to 16K-aligned hits and makes shorter prompts miss.
 
     def find_longest_cache_hit(
         self,
@@ -204,8 +205,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                     # Full attention is downward-closed: we only need to look
                     # up cached blocks once; on subsequent iterations just trim
                     # to the (reduced) current hit length.
-                    logical_block_size = self._logical_block_size(spec)
-                    curr_hit_length = curr_hit_length // logical_block_size * logical_block_size
+                    curr_hit_length = curr_hit_length // spec.block_size * spec.block_size
                     continue
 
                 use_eagle = idx in self.eagle_attn_group_indices and idx not in eagle_verified
@@ -213,7 +213,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                 _max_length = curr_hit_length
                 if use_eagle:
                     # Eagle needs to match one more block and then pop the last.
-                    _max_length = min(curr_hit_length + self._logical_block_size(spec), max_cache_hit_length)
+                    _max_length = min(curr_hit_length + spec.block_size, max_cache_hit_length)
                 hit_blocks = manager_cls.find_longest_cache_hit(
                     block_hashes=_get_block_hashes(spec),
                     max_length=_max_length,
@@ -221,15 +221,17 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                     block_pool=self.block_pool,
                     kv_cache_spec=spec,
                     use_eagle=use_eagle,
-                    alignment_tokens=self.lcm_block_size,
+                    alignment_tokens=self.scheduler_block_size,
                 )
-                _new_hit_length = len(hit_blocks[0]) * self._logical_block_size(spec)
+                _new_hit_length = len(hit_blocks[0]) * spec.block_size
                 if use_eagle:
                     eagle_verified.add(idx)
                 elif _new_hit_length < curr_hit_length:
                     # length shrunk; invalidate previous eagle verifications
                     eagle_verified.clear()
                 curr_hit_length = _new_hit_length
+                compress_ratio = getattr(spec, "compress_ratio", 1)
+                curr_hit_length = len(hit_blocks[0]) * spec.block_size * max(compress_ratio, 1)
                 for group_id, blocks in zip(group_ids, hit_blocks):
                     hit_blocks_by_group[group_id] = blocks
 
@@ -242,7 +244,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         # Truncate full attention blocks to final hit_length (if present)
         spec, group_ids, _ = self.attention_groups[0]
         if isinstance(spec, FullAttentionSpec):
-            num_blocks = hit_length // self._logical_block_size(spec)
+            num_blocks = hit_length // spec.block_size
             for group_id in group_ids:
                 if (blks := hit_blocks_by_group[group_id]) is not None:
                     del blks[num_blocks:]
@@ -260,6 +262,7 @@ def get_kv_cache_coordinator(
     dcp_world_size: int,
     pcp_world_size: int,
     hash_block_size: int,
+    scheduler_block_size: int | None = None,
     eagle_attn_layer_names: list[str] | None = None,
     metrics_collector: KVCacheMetricsCollector | None = None,
 ) -> KVCacheCoordinator:
@@ -272,6 +275,7 @@ def get_kv_cache_coordinator(
         dcp_world_size=dcp_world_size,
         pcp_world_size=pcp_world_size,
         hash_block_size=hash_block_size,
+        scheduler_block_size=scheduler_block_size,
         eagle_attn_layer_names=eagle_attn_layer_names,
         metrics_collector=metrics_collector,
         max_num_batched_tokens=max_num_batched_tokens,

--- a/vllm_ascend/patch/platform/patch_prefix_cache_core.py
+++ b/vllm_ascend/patch/platform/patch_prefix_cache_core.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+"""Compatibility patch for prefix-cache block reuse.
+
+This carries the small-core part of vLLM PR #43447 needed by the DeepSeek V4
+prefix-cache coordinator patch. Remove it when the supported vLLM version
+contains these APIs and behaviors.
+"""
+
+import inspect
+from collections.abc import Callable, Iterable
+
+from vllm.logger import logger
+from vllm.utils.math_utils import cdiv
+from vllm.v1.core import kv_cache_manager as kv_cache_manager_mod
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import FreeKVCacheBlockQueue, KVCacheBlock
+from vllm.v1.core.single_type_kv_cache_manager import (
+    SingleTypeKVCacheManager,
+    SlidingWindowManager,
+)
+
+
+def _source_contains(fn: Callable, *needles: str) -> bool:
+    try:
+        source = inspect.getsource(fn)
+    except (OSError, TypeError):
+        return False
+    return all(needle in source for needle in needles)
+
+
+def _patch_kv_cache_manager_scheduler_block_size() -> None:
+    """Forward scheduler cache-hit granularity on vLLM versions without it."""
+    kv_cache_manager_cls = kv_cache_manager_mod.KVCacheManager
+    current_init = kv_cache_manager_cls.__init__
+    if "scheduler_block_size" in inspect.signature(current_init).parameters:
+        return
+    if getattr(current_init, "_vllm_ascend_scheduler_block_size_patch", False):
+        return
+
+    original_init = current_init
+    original_signature = inspect.signature(original_init)
+
+    def __init__(
+        self,
+        *args,
+        scheduler_block_size: int | None = None,
+        **kwargs,
+    ) -> None:
+        bound = original_signature.bind(self, *args, **kwargs)
+        bound.apply_defaults()
+        if scheduler_block_size is None:
+            scheduler_block_size = bound.arguments.get("hash_block_size")
+
+        original_get = kv_cache_manager_mod.get_kv_cache_coordinator
+
+        def get_with_scheduler_block_size(*coord_args, **coord_kwargs):
+            try:
+                supports_scheduler_block_size = "scheduler_block_size" in inspect.signature(original_get).parameters
+            except (TypeError, ValueError):
+                supports_scheduler_block_size = False
+            if supports_scheduler_block_size:
+                coord_kwargs.setdefault("scheduler_block_size", scheduler_block_size)
+            return original_get(*coord_args, **coord_kwargs)
+
+        kv_cache_manager_mod.get_kv_cache_coordinator = get_with_scheduler_block_size
+        try:
+            return original_init(self, *args, **kwargs)
+        finally:
+            kv_cache_manager_mod.get_kv_cache_coordinator = original_get
+
+    __init__._vllm_ascend_scheduler_block_size_patch = True  # type: ignore[attr-defined]
+    kv_cache_manager_cls.__init__ = __init__
+    logger.debug("Patched KVCacheManager.__init__(scheduler_block_size=...).")
+
+
+def _patch_scheduler_scheduler_block_size() -> None:
+    """Pass Scheduler.block_size to KVCacheManager on older vLLM."""
+    try:
+        from vllm.v1.core.sched import scheduler as scheduler_mod
+    except ImportError:
+        return
+
+    scheduler_cls = scheduler_mod.Scheduler
+    current_init = scheduler_cls.__init__
+    if getattr(current_init, "_vllm_ascend_scheduler_block_size_patch", False):
+        return
+    if _source_contains(current_init, "scheduler_block_size=self.block_size"):
+        return
+
+    original_init = current_init
+    original_signature = inspect.signature(original_init)
+
+    def __init__(self, *args, **kwargs) -> None:
+        bound = original_signature.bind(self, *args, **kwargs)
+        bound.apply_defaults()
+        scheduler_block_size = bound.arguments.get("block_size")
+
+        original_kv_cache_manager = scheduler_mod.KVCacheManager
+
+        def kv_cache_manager_with_scheduler_block_size(*kv_args, **kv_kwargs):
+            if scheduler_block_size is not None:
+                kv_kwargs.setdefault("scheduler_block_size", scheduler_block_size)
+            return original_kv_cache_manager(*kv_args, **kv_kwargs)
+
+        scheduler_mod.KVCacheManager = kv_cache_manager_with_scheduler_block_size
+        try:
+            return original_init(self, *args, **kwargs)
+        finally:
+            scheduler_mod.KVCacheManager = original_kv_cache_manager
+
+    __init__._vllm_ascend_scheduler_block_size_patch = True  # type: ignore[attr-defined]
+    scheduler_cls.__init__ = __init__
+    logger.debug("Patched Scheduler.__init__ to pass scheduler_block_size.")
+
+
+def _patch_free_queue_prepend() -> None:
+    if hasattr(FreeKVCacheBlockQueue, "prepend_n"):
+        return
+
+    def prepend_n(self: FreeKVCacheBlockQueue, blocks: list[KVCacheBlock]) -> None:
+        """Put a list of blocks at the front of the free list."""
+        if len(blocks) == 0:
+            return
+
+        first_block = self.fake_free_list_head.next_free_block
+        assert first_block is not None, "next_free_block of fake_free_list_head should always exist"
+
+        prev_block = self.fake_free_list_head
+        for block in blocks:
+            block.prev_free_block = prev_block
+            prev_block.next_free_block = block
+            prev_block = block
+
+        prev_block.next_free_block = first_block
+        first_block.prev_free_block = prev_block
+
+        self.num_free_blocks += len(blocks)
+
+    FreeKVCacheBlockQueue.prepend_n = prepend_n
+    logger.debug("Patched FreeKVCacheBlockQueue.prepend_n for prefix-cache reuse.")
+
+
+def _patch_block_pool_free_blocks() -> None:
+    if "prepend" in inspect.signature(BlockPool.free_blocks).parameters:
+        return
+
+    def free_blocks(
+        self: BlockPool,
+        ordered_blocks: Iterable[KVCacheBlock],
+        prepend: bool = False,
+    ) -> None:
+        """Free blocks, optionally placing newly-free blocks at queue front."""
+        blocks_list = list(ordered_blocks)
+        for block in blocks_list:
+            block.ref_cnt -= 1
+        freed_blocks = [block for block in blocks_list if block.ref_cnt == 0 and not block.is_null]
+        if prepend:
+            self.free_block_queue.prepend_n(freed_blocks)
+        else:
+            self.free_block_queue.append_n(freed_blocks)
+
+    BlockPool.free_blocks = free_blocks
+    logger.debug("Patched BlockPool.free_blocks(prepend=...).")
+
+
+def _patch_remove_skipped_blocks() -> None:
+    if _source_contains(
+        SingleTypeKVCacheManager.remove_skipped_blocks,
+        "prepend=True",
+        "block_hash is None",
+    ):
+        return
+
+    def remove_skipped_blocks(
+        self: SingleTypeKVCacheManager,
+        request_id: str,
+        total_computed_tokens: int,
+    ) -> None:
+        num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
+        if num_skipped_tokens <= 0:
+            return
+
+        blocks = self.req_to_blocks[request_id]
+        num_skipped_blocks = num_skipped_tokens // self.block_size
+        num_skipped_blocks = min(num_skipped_blocks, len(blocks))
+        removed_cached_blocks: list[KVCacheBlock] = []
+        removed_uncached_blocks: list[KVCacheBlock] = []
+
+        for i in range(num_skipped_blocks - 1, -1, -1):
+            if blocks[i] == self._null_block:
+                break
+            if blocks[i].block_hash is None:
+                removed_uncached_blocks.append(blocks[i])
+            else:
+                removed_cached_blocks.append(blocks[i])
+            blocks[i] = self._null_block
+
+        self.block_pool.free_blocks(removed_cached_blocks)
+        self.block_pool.free_blocks(removed_uncached_blocks, prepend=True)
+
+    SingleTypeKVCacheManager.remove_skipped_blocks = remove_skipped_blocks
+    logger.debug("Patched SingleTypeKVCacheManager.remove_skipped_blocks.")
+
+
+def _patch_sliding_window_mask() -> None:
+    if not hasattr(SlidingWindowManager, "_cache_block_mask"):
+        return
+
+    if _source_contains(
+        SlidingWindowManager._cache_block_mask,
+        "use_eagle",
+        "shift = 1 if use_eagle else 0",
+    ):
+        return
+
+    def _cache_block_mask(
+        self: SlidingWindowManager,
+        num_cached_blocks: int,
+        num_full_blocks: int,
+        alignment_tokens: int,
+    ) -> list[bool] | None:
+        assert alignment_tokens > self.block_size
+        per_segment = alignment_tokens // self.block_size
+        tail = cdiv(self.sliding_window - 1, self.block_size)
+        use_eagle = getattr(self, "use_eagle", False)
+        if use_eagle:
+            tail += 1
+        if tail >= per_segment:
+            return None
+        skip = per_segment - tail
+        shift = 1 if use_eagle else 0
+        return [i >= shift and (i - shift) % per_segment >= skip for i in range(num_cached_blocks, num_full_blocks)]
+
+    SlidingWindowManager._cache_block_mask = _cache_block_mask
+    logger.debug("Patched SlidingWindowManager._cache_block_mask.")
+
+
+def _patch_sliding_window_free() -> None:
+    if _source_contains(SlidingWindowManager.free, "prepend=True", "block_hash is None"):
+        return
+
+    def free(self: SlidingWindowManager, request_id: str) -> None:
+        req_blocks = self.req_to_blocks.pop(request_id, [])
+        if req_blocks:
+            cached_blocks: list[KVCacheBlock] = []
+            uncached_blocks: list[KVCacheBlock] = []
+            for block in reversed(req_blocks):
+                if block.block_hash is None:
+                    uncached_blocks.append(block)
+                else:
+                    cached_blocks.append(block)
+            self.block_pool.free_blocks(cached_blocks)
+            self.block_pool.free_blocks(uncached_blocks, prepend=True)
+        self.num_cached_block.pop(request_id, None)
+
+    SlidingWindowManager.free = free
+    logger.debug("Patched SlidingWindowManager.free.")
+
+
+_patch_kv_cache_manager_scheduler_block_size()
+_patch_scheduler_scheduler_block_size()
+_patch_free_queue_prepend()
+_patch_block_pool_free_blocks()
+_patch_remove_skipped_blocks()
+_patch_sliding_window_mask()
+_patch_sliding_window_free()

--- a/vllm_ascend/patch/platform/patch_tool_choice_none_content.py
+++ b/vllm_ascend/patch/platform/patch_tool_choice_none_content.py
@@ -112,31 +112,32 @@ def _patch_named_tool_choice_bool() -> None:
 _patch_named_tool_choice_bool()
 
 
-_original_parse_tool_calls_from_content = OpenAIServing._parse_tool_calls_from_content
+_original_parse_tool_calls_from_content = getattr(OpenAIServing, "_parse_tool_calls_from_content", None)
 
 
-def _patched_parse_tool_calls_from_content(
-    request,
-    tokenizer,
-    enable_auto_tools: bool,
-    tool_parser_cls,
-    content: str | None = None,
-):
-    if content is None and _is_forced_tool_choice(request):
-        _set_no_forced_tool_call(request, True)
-        return [], None
+if _original_parse_tool_calls_from_content is not None:
 
-    _set_no_forced_tool_call(request, False)
-    return _original_parse_tool_calls_from_content(
-        request=request,
-        tokenizer=tokenizer,
-        enable_auto_tools=enable_auto_tools,
-        tool_parser_cls=tool_parser_cls,
-        content=content,
-    )
+    def _patched_parse_tool_calls_from_content(
+        request,
+        tokenizer,
+        enable_auto_tools: bool,
+        tool_parser_cls,
+        content: str | None = None,
+    ):
+        if content is None and _is_forced_tool_choice(request):
+            _set_no_forced_tool_call(request, True)
+            return [], None
 
+        _set_no_forced_tool_call(request, False)
+        return _original_parse_tool_calls_from_content(  # type: ignore[misc]
+            request=request,
+            tokenizer=tokenizer,
+            enable_auto_tools=enable_auto_tools,
+            tool_parser_cls=tool_parser_cls,
+            content=content,
+        )
 
-OpenAIServing._parse_tool_calls_from_content = staticmethod(_patched_parse_tool_calls_from_content)
+    OpenAIServing._parse_tool_calls_from_content = staticmethod(_patched_parse_tool_calls_from_content)
 
 _original_delegating_parse_tool_calls = DelegatingParser._parse_tool_calls
 


### PR DESCRIPTION
## What this PR does / why we need it?
Backports the prefix-cache block-reuse behavior required by the DeepSeek V4
prefix-cache path on releases/v0.20.2rc, and aligns DSv4 prefix-cache hits to
the scheduler block size.

On vLLM versions that lack the newer block-reuse APIs, short / SWA prefix-cache
paths can recycle local blocks with poor priority. This PR monkey-patches the
missing free-list / front-insertion behavior and the SWA/EAGLE cache block
mask. Each patch is guarded by capability/source checks, so it is automatically
skipped once the underlying vLLM already provides the behavior.

## Does this PR introduce any user-facing change?
No. All patches are guarded and skipped when upstream already provides them.

---
Co-authored with @wangzhao-11a.