### PR TITLE
[Feature][DSv4] Support compressor block size [32,64,128] to improve APC

### DIFF
--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -207,7 +207,7 @@ class AscendDSABackend(AttentionBackend):
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int]:
-        return [8, 32, 128]
+        return [2, 4, 8, 16, 32, 64, 128]
 
 
 @dataclass

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -226,6 +226,14 @@ class DeepseekV2MLP(nn.Module):
         return x
 
 
+def _dsv4_block_sizes():
+    # Lazy import to avoid the circular import chain (layer -> dsa_v1 ->
+    # attention_v1 -> device_op) hit during vLLM subprocess model inspection.
+    from vllm_ascend.models.layer.attention.layer import DSV4_BLOCK_SIZES
+
+    return DSV4_BLOCK_SIZES
+
+
 class DeepseekV4MoE(nn.Module):
     def __init__(
         self,
@@ -520,7 +528,7 @@ class Compressor(nn.Module):
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=8,
+                block_size=_dsv4_block_sizes()[cache_config.block_size][0][2],  # type: ignore[union-attr]
             )
         elif compress_ratio == 128:
             self.state_cache = CompressorStateCache(
@@ -528,7 +536,7 @@ class Compressor(nn.Module):
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=32,
+                block_size=_dsv4_block_sizes()[cache_config.block_size][0][3],  # type: ignore[union-attr]
             )
         else:
             raise ValueError(

--- a/vllm_ascend/models/layer/attention/layer.py
+++ b/vllm_ascend/models/layer/attention/layer.py
@@ -22,6 +22,28 @@ from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec
 
 from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.dsa_v1 import AscendDSABackend
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
+
+def get_dsv4_block_sizes():
+    # cache_config.block_size: [mla, swa, c4 state, c128 state], [page_size_padded_t1, page_size_padded_t2]
+    _DSV4_BLOCK_SIZES = {
+        128: [[128, 128, 8, 32], [16640, 131072]],
+        64: [[64, 64, 4, 16], [8320, 65536]],
+        32: [[32, 32, 2, 8], [4160, 32768]],
+    }
+    _DSV4_BLOCK_SIZES_A5 = {
+        128: [[128, 128, 8, 16], [16896, 81920]],
+        64: [[64, 64, 4, 8], [8448, 40960]],
+        32: [[32, 32, 2, 4], [4224, 20480]],
+    }
+    if get_ascend_device_type() in {AscendDeviceType.A5}:
+        return _DSV4_BLOCK_SIZES_A5
+    else:
+        return _DSV4_BLOCK_SIZES
+
+
+DSV4_BLOCK_SIZES = get_dsv4_block_sizes()
 
 
 class DSAAttention(nn.Module, AttentionLayerBase):
@@ -151,7 +173,7 @@ class DSAAttention(nn.Module, AttentionLayerBase):
             return None
         kv_cache_dtype = kv_cache_dtype_str_to_dtype(self.kv_cache_dtype, vllm_config.model_config)
         return MLAAttentionSpec(
-            block_size=128,
+            block_size=DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][0][0],
             num_kv_heads=1,
             head_size=self.head_size,
             dtype=kv_cache_dtype,

--- a/vllm_ascend/patch/worker/patch_deepseek_compressor.py
+++ b/vllm_ascend/patch/worker/patch_deepseek_compressor.py
@@ -9,6 +9,7 @@ from vllm.v1.kv_cache_interface import (
 )
 
 from vllm_ascend.attention.dsa_v1 import AscendDSABackend
+from vllm_ascend.models.layer.attention.layer import DSV4_BLOCK_SIZES
 from vllm_ascend.patch.platform.patch_kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.utils import vllm_version_is
 
@@ -53,7 +54,11 @@ class AscendCompressorStateCache(CompressorStateCache):
         self.block_size = block_size
 
     def get_kv_cache_spec(self, vllm_config) -> KVCacheSpec:
-        page_size_padded = 16640 if self.state_dim == 2 * 256 and self.compress_ratio == 4 else 131072
+        if self.state_dim == 2 * 256 and self.compress_ratio == 4:
+            page_size_padded = DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][1][0]
+        else:
+            page_size_padded = DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][1][1]
+
         return SlidingWindowMLASpec(  # only has one vector instead of K + V
             block_size=self.block_size,
             num_kv_heads=1,
@@ -83,7 +88,7 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
         return AscendMLAAttentionSpec(  # Only has one vector instead of K + V
-            block_size=128,
+            block_size=DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][0][0],
             num_kv_heads=1,
             head_size=self.head_dim,
             dtype=self.dtype,
@@ -117,7 +122,7 @@ class AscendDeepseekV4SWACache(DeepseekV4SWACache):
         # same page size. The C4A KV block shape [256//4, head_dim] = [64, head_dim]
         # determines the SWA block size of 64 tokens per block.
         # TODO(cmq): make SWA block size automatically determined and configurable.
-        self.block_size = 128
+        self.block_size = DSV4_BLOCK_SIZES[cache_config.block_size][0][1]
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
         # TODO(cmq): alignment = 0 if A3 else 128

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1317,8 +1317,15 @@ def refresh_block_size(vllm_config):
         cache_config.block_size = 128
 
     if model_config.hf_config.model_type == "deepseek_v4":
-        # TODO(qcs): generalize the block_size
-        cache_config.block_size = 128
+        if cache_config.block_size is None:
+            cache_config.block_size = 32
+        elif cache_config.block_size not in [32, 64, 128]:
+            logger.warning(
+                "For deepseek_v4 model, block size should be 32, 64 or 128. "
+                "Setting block size to 32 for better performance."
+            )
+            cache_config.block_size = 32
+        return
 
     if not scheduler_config or not model_config:
         return


### PR DESCRIPTION
## What this PR does / why we need it?
Makes the DeepSeek V4 compressor KV-cache block_size configurable (32 / 64 /
128) instead of hard-pinned to 128, via a lookup table that scales the MLA /
SWA / C4-state / C128-state block sizes and page-size padding together. A
smaller block size shrinks the alignment requirement of the compressed KV
cache, so more prompt prefixes can hit the prefix cache (better APC hit rate).

## Does this PR introduce any user-facing change?
Block size defaults to 32 for deepseek_v4; pass --block-size 128 to keep the
legacy layout (bit-for-bit identical to the previous behavior).

---
Co-authored with @wangzhao-11a and @MengqingCao.