### PR TITLE
[Feature][DSv4] Support partial compressed prefix cache hits

### DIFF
--- a/tests/ut/core/test_dsv4_partial_prefix_cache.py
+++ b/tests/ut/core/test_dsv4_partial_prefix_cache.py
@@ -1,0 +1,109 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Unit tests for the DSv4 partial compressed prefix-cache helpers.
+
+These cover the pure-Python pieces that back ``CompressAttentionManager``'s
+partial-hit support: range hashing and the per-``BlockPool`` partial-cache maps.
+The maps must live on the ``BlockPool`` instance (not module globals), so the
+isolation test below is a regression guard for that requirement.
+"""
+from types import SimpleNamespace
+
+from tests.ut.base import TestBase
+from vllm_ascend.core.single_type_kv_cache_manager import (
+    _hash_range,
+    _insert_partial_cache,
+    get_partial_cached_block,
+    remove_partial_cache_entries_for_block,
+)
+
+
+def _block(block_id: int) -> SimpleNamespace:
+    # _insert/get/remove only touch ``block_id``.
+    return SimpleNamespace(block_id=block_id)
+
+
+def _pool() -> SimpleNamespace:
+    # A bare object is enough: the partial-cache maps are attached lazily.
+    return SimpleNamespace()
+
+
+class TestHashRange(TestBase):
+
+    def setUp(self):
+        # 4 hash-blocks of 8 tokens each -> hashes for tokens [0,8,16,24).
+        self.block_hashes = [b"h0", b"h1", b"h2", b"h3"]
+        self.hash_block_size = 8
+
+    def test_unaligned_returns_none(self):
+        self.assertIsNone(_hash_range(self.block_hashes, self.hash_block_size, 0, 12))
+        self.assertIsNone(_hash_range(self.block_hashes, self.hash_block_size, 4, 16))
+
+    def test_empty_or_inverted_range_returns_none(self):
+        self.assertIsNone(_hash_range(self.block_hashes, self.hash_block_size, 8, 8))
+        self.assertIsNone(_hash_range(self.block_hashes, self.hash_block_size, 16, 8))
+
+    def test_out_of_range_returns_none(self):
+        # end token 40 -> needs 5 hashes, only 4 available.
+        self.assertIsNone(_hash_range(self.block_hashes, self.hash_block_size, 0, 40))
+
+    def test_valid_range_concatenates_hashes(self):
+        self.assertEqual(_hash_range(self.block_hashes, self.hash_block_size, 0, 16), b"h0h1")
+        self.assertEqual(_hash_range(self.block_hashes, self.hash_block_size, 8, 24), b"h1h2")
+
+
+class TestPartialPrefixCache(TestBase):
+
+    def setUp(self):
+        self.pool = _pool()
+        self.group_id = 0
+
+    def test_insert_and_get(self):
+        block = _block(7)
+        _insert_partial_cache(self.pool, b"abc", self.group_id, block)
+        self.assertIs(get_partial_cached_block(self.pool, b"abc", self.group_id), block)
+
+    def test_miss_returns_none(self):
+        self.assertIsNone(get_partial_cached_block(self.pool, b"missing", self.group_id))
+
+    def test_group_id_scopes_lookup(self):
+        block = _block(7)
+        _insert_partial_cache(self.pool, b"abc", 0, block)
+        self.assertIsNone(get_partial_cached_block(self.pool, b"abc", 1))
+
+    def test_reinsert_updates_block_and_drops_old_tracking(self):
+        old, new = _block(1), _block(2)
+        _insert_partial_cache(self.pool, b"abc", self.group_id, old)
+        _insert_partial_cache(self.pool, b"abc", self.group_id, new)
+        self.assertIs(get_partial_cached_block(self.pool, b"abc", self.group_id), new)
+        # Evicting the old block must not drop the entry now owned by the new block.
+        remove_partial_cache_entries_for_block(self.pool, old.block_id)
+        self.assertIs(get_partial_cached_block(self.pool, b"abc", self.group_id), new)
+
+    def test_eviction_removes_entries_for_block(self):
+        block = _block(5)
+        _insert_partial_cache(self.pool, b"abc", self.group_id, block)
+        _insert_partial_cache(self.pool, b"def", self.group_id, block)
+        remove_partial_cache_entries_for_block(self.pool, 5)
+        self.assertIsNone(get_partial_cached_block(self.pool, b"abc", self.group_id))
+        self.assertIsNone(get_partial_cached_block(self.pool, b"def", self.group_id))
+
+    def test_state_is_isolated_per_block_pool(self):
+        pool_a, pool_b = _pool(), _pool()
+        _insert_partial_cache(pool_a, b"abc", self.group_id, _block(1))
+        # A second pool must not see the first pool's entries (no module globals).
+        self.assertIsNone(get_partial_cached_block(pool_b, b"abc", self.group_id))

--- a/tests/ut/core/test_prefix_cache_retention.py
+++ b/tests/ut/core/test_prefix_cache_retention.py
@@ -1,0 +1,303 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Unit tests for the SWA prefix-cache retention three-state (vLLM PR #43447).
+
+These cover the parts that the DSv4 prefix-cache patch backports onto vLLM
+v0.21.0:
+
+* ``SlidingWindowManager.reachable_block_mask`` (the pure mask algorithm,
+  including the deliberate deviation that env-unset / ``None`` keeps the dense
+  cache-all behavior),
+* ``BlockPool.cache_full_blocks(block_mask=...)`` (the null-swap mask plumbing
+  that v0.21.0 lacks),
+* ``_validate_prefix_cache_retention_interval`` (the no-SWA-group / negative /
+  non-multiple failure modes, incl. the SlidingWindowMLASpec acceptance fix).
+
+The patches attach methods onto the upstream vLLM classes, so importing this
+module requires vLLM (as on the CI / NPU environment); ``TestBase`` applies the
+ascend patches for us.
+"""
+from types import SimpleNamespace
+
+from tests.ut.base import TestBase
+from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
+from vllm.v1.kv_cache_interface import SlidingWindowSpec
+
+from vllm_ascend.patch.platform.patch_kv_cache_coordinator import (
+    _SLIDING_WINDOW_SPECS,
+    _validate_prefix_cache_retention_interval,
+)
+
+
+def _swa_spec(block_size: int, sliding_window: int) -> SlidingWindowSpec:
+    """Build a minimal ``SlidingWindowSpec`` instance.
+
+    ``reachable_block_mask`` only reads ``block_size`` and ``sliding_window`` and
+    asserts ``isinstance(spec, SlidingWindowSpec)``. ``SlidingWindowSpec`` is a
+    frozen dataclass with many required fields, so we bypass ``__init__`` and set
+    just the two attributes the algorithm touches.
+    """
+    spec = object.__new__(SlidingWindowSpec)
+    object.__setattr__(spec, "block_size", block_size)
+    object.__setattr__(spec, "sliding_window", sliding_window)
+    return spec
+
+
+def _mask(
+    *,
+    start_block,
+    end_block,
+    alignment_tokens,
+    block_size,
+    sliding_window,
+    use_eagle=False,
+    retention_interval=None,
+    num_prompt_tokens=None,
+):
+    return SlidingWindowManager.reachable_block_mask(
+        start_block=start_block,
+        end_block=end_block,
+        alignment_tokens=alignment_tokens,
+        kv_cache_spec=_swa_spec(block_size, sliding_window),
+        use_eagle=use_eagle,
+        retention_interval=retention_interval,
+        num_prompt_tokens=num_prompt_tokens,
+    )
+
+
+def _cached_set(mask, start_block=0):
+    """Indices (absolute block ids) whose mask entry is True."""
+    return {start_block + i for i, keep in enumerate(mask) if keep}
+
+
+class TestReachableBlockMask(TestBase):
+    """Pure-function coverage of the three-state mask algorithm."""
+
+    def test_default_none_caches_all_swa(self):
+        # Deviation from PR #43447 + our hard requirement: env unset (None) must
+        # return None so cache_full_blocks caches every block (dense cache-all).
+        mask = _mask(
+            start_block=0,
+            end_block=16,
+            alignment_tokens=128,
+            block_size=8,
+            sliding_window=8,
+            retention_interval=None,
+            num_prompt_tokens=128,
+        )
+        self.assertIsNone(mask)
+
+    def test_dense_equivalence_path_ignores_alignment(self):
+        # The dense safety net (None) must not depend on scheduler_block_size:
+        # even with alignment_tokens=None it returns None.
+        mask = _mask(
+            start_block=0,
+            end_block=8,
+            alignment_tokens=None,
+            block_size=8,
+            sliding_window=8,
+            retention_interval=None,
+            num_prompt_tokens=64,
+        )
+        self.assertIsNone(mask)
+
+    def test_interval_64_segment_tails_plus_replay(self):
+        # interval=64, block_size=8 -> per_segment=8; sliding_window=8 -> need=1.
+        # Each 8-block segment keeps only its last block (offset 7 within the
+        # segment), plus the replay tail near the latest prompt boundary.
+        mask = _mask(
+            start_block=0,
+            end_block=16,
+            alignment_tokens=64,
+            block_size=8,
+            sliding_window=8,
+            retention_interval=64,
+            num_prompt_tokens=128,
+        )
+        # Segment tails: block 7 (segment 0) and block 15 (segment 1).
+        # latest = (128-1)//64*64 = 64 -> prompt_end_block = 64//8 = 8 ->
+        # replay range [8-1, 8) = {7}. So cached = {7, 15}.
+        self.assertEqual(_cached_set(mask), {7, 15})
+
+    def test_latest_only_zero(self):
+        # retention=0 -> no per-segment tails, only the replay tail survives.
+        mask = _mask(
+            start_block=0,
+            end_block=16,
+            alignment_tokens=64,
+            block_size=8,
+            sliding_window=8,
+            retention_interval=0,
+            num_prompt_tokens=128,
+        )
+        # latest = 64, prompt_end_block = 8, need = 1 -> replay {7}.
+        self.assertEqual(_cached_set(mask), {7})
+
+    def test_eagle_zero(self):
+        # use_eagle=True, 127 tokens, block_size=8, window=8 -> need=2, shift=1,
+        # latest=96, prompt_end_block=96//8 + 1 = 13 -> cached={11,12}.
+        mask = _mask(
+            start_block=0,
+            end_block=16,
+            alignment_tokens=32,
+            block_size=8,
+            sliding_window=8,
+            use_eagle=True,
+            retention_interval=0,
+            num_prompt_tokens=127,
+        )
+        self.assertEqual(_cached_set(mask), {11, 12})
+
+    def test_need_ge_per_segment_folds_to_none(self):
+        # window large enough that need >= per_segment: the whole segment is in
+        # reach, so nothing can be dropped -> dense fallback (None).
+        mask = _mask(
+            start_block=0,
+            end_block=16,
+            alignment_tokens=16,
+            block_size=8,
+            sliding_window=64,  # need = cdiv(63, 8) = 8 >= per_segment(=2)
+            retention_interval=16,
+            num_prompt_tokens=128,
+        )
+        self.assertIsNone(mask)
+
+    def test_start_block_offset_respected(self):
+        # Already-cached prefix (start_block>0): mask length == end-start and
+        # indices stay absolute. interval=64 -> per_segment=8, need=1.
+        mask = _mask(
+            start_block=8,
+            end_block=16,
+            alignment_tokens=64,
+            block_size=8,
+            sliding_window=8,
+            retention_interval=64,
+            num_prompt_tokens=128,
+        )
+        self.assertEqual(len(mask), 8)
+        # Segment-1 tail is block 15; replay tail (latest=64 -> end_block 8) is
+        # below start_block=8, so only {15} remains.
+        self.assertEqual(_cached_set(mask, start_block=8), {15})
+
+
+class TestCacheFullBlocksMask(TestBase):
+    """Directly exercise the BlockPool.cache_full_blocks(block_mask=...) patch."""
+
+    def _make_block_pool(self):
+        from vllm.v1.core.block_pool import BlockPool
+
+        # Small real pool: caching enabled, no KV events.
+        return BlockPool(
+            num_gpu_blocks=16,
+            enable_caching=True,
+            hash_block_size=8,
+            enable_kv_cache_events=False,
+        )
+
+    def _request(self, num_blocks, block_size):
+        # cache_full_blocks reads request.block_hashes / all_token_ids; provide
+        # enough distinct chained hashes for num_blocks full blocks.
+        block_hashes = [bytes([i]) * 4 for i in range(num_blocks + 2)]
+        return SimpleNamespace(
+            request_id="req-mask",
+            block_hashes=block_hashes,
+            all_token_ids=list(range(num_blocks * block_size)),
+            lora_request=None,
+        )
+
+    def test_mask_caches_only_unmasked_and_restores_blocks(self):
+        block_pool = self._make_block_pool()
+        block_size = 8
+        blocks = block_pool.get_new_blocks(3)
+        original = list(blocks)
+        request = self._request(num_blocks=3, block_size=block_size)
+
+        block_pool.cache_full_blocks(
+            request=request,
+            blocks=blocks,
+            num_cached_blocks=0,
+            num_full_blocks=3,
+            block_size=block_size,
+            kv_cache_group_id=0,
+            block_mask=[True, False, True],
+        )
+
+        # Unmasked blocks (0, 2) get a block_hash; masked block (1) stays None.
+        self.assertIsNotNone(blocks[0].block_hash)
+        self.assertIsNone(blocks[1].block_hash)
+        self.assertIsNotNone(blocks[2].block_hash)
+        # The request's block list is restored verbatim (no null pollution).
+        self.assertEqual(blocks, original)
+
+    def test_mask_none_caches_all(self):
+        block_pool = self._make_block_pool()
+        block_size = 8
+        blocks = block_pool.get_new_blocks(2)
+        request = self._request(num_blocks=2, block_size=block_size)
+
+        block_pool.cache_full_blocks(
+            request=request,
+            blocks=blocks,
+            num_cached_blocks=0,
+            num_full_blocks=2,
+            block_size=block_size,
+            kv_cache_group_id=0,
+            block_mask=None,
+        )
+
+        self.assertIsNotNone(blocks[0].block_hash)
+        self.assertIsNotNone(blocks[1].block_hash)
+
+
+class TestValidateRetentionInterval(TestBase):
+    """Validation failure modes (vLLM PR #43447 (3))."""
+
+    def _config_with_specs(self, specs):
+        groups = [SimpleNamespace(kv_cache_spec=s) for s in specs]
+        return SimpleNamespace(kv_cache_groups=groups)
+
+    def test_none_is_noop(self):
+        cfg = self._config_with_specs([SimpleNamespace()])  # no SWA group
+        # None must never raise, even without an SWA group.
+        _validate_prefix_cache_retention_interval(None, 128, cfg)
+
+    def test_reject_no_sliding_window_group(self):
+        cfg = self._config_with_specs([SimpleNamespace()])
+        with self.assertRaisesRegex(ValueError, "no sliding-window KV cache group"):
+            _validate_prefix_cache_retention_interval(64, 64, cfg)
+
+    def test_reject_non_multiple(self):
+        cfg = self._config_with_specs([_swa_spec(8, 8)])
+        with self.assertRaisesRegex(ValueError, "multiple of scheduler_block_size"):
+            _validate_prefix_cache_retention_interval(33, 32, cfg)
+
+    def test_reject_negative(self):
+        cfg = self._config_with_specs([_swa_spec(8, 8)])
+        # -32 % 32 == 0 but must still be rejected by the explicit < 0 check.
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            _validate_prefix_cache_retention_interval(-32, 32, cfg)
+
+    def test_mla_swa_spec_accepted(self):
+        # DSv4 SWA is SlidingWindowMLASpec; the validator must treat it as an
+        # SWA group (else DSv4 + retention wrongly reports "no SWA group").
+        mla_spec_cls = _SLIDING_WINDOW_SPECS[-1]
+        spec = object.__new__(mla_spec_cls)
+        object.__setattr__(spec, "block_size", 128)
+        object.__setattr__(spec, "sliding_window", 128)
+        cfg = self._config_with_specs([spec])
+        # A valid multiple should not raise for an MLA-SWA group.
+        _validate_prefix_cache_retention_interval(128, 128, cfg)

--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -69,7 +69,7 @@ def _make_compress_manager(
     return spec, block_pool, manager
 
 
-def test_compressed_prefix_cache_uses_logical_block_hash() -> None:
+def test_compressed_prefix_cache_uses_short_key_and_subblock_partial() -> None:
     block_size = 128
     compress_ratio = 4
     logical_block_size = block_size * compress_ratio
@@ -90,10 +90,13 @@ def test_compressed_prefix_cache_uses_logical_block_hash() -> None:
     manager.cache_blocks(request_a, num_tokens=logical_block_size)
 
     cached_hash = get_block_hash(manager.req_to_blocks[request_a.request_id][0].block_hash)
+    # vllm-ascend uses the short-key convention: the i-th compressed block keys on
+    # the per-hash-block hash, not the full logical-span combined hash. This is what
+    # enables the correct sub-block partial hit asserted below.
     expected_hash = BlockHashListWithBlockSize(
         request_a.block_hashes,
         block_size,
-        logical_block_size,
+        block_size,
     )[0]
     assert cached_hash == expected_hash
 
@@ -107,7 +110,12 @@ def test_compressed_prefix_cache_uses_logical_block_hash() -> None:
         alignment_tokens=logical_block_size,
     )[0]
 
-    assert hit_blocks == []
+    # request_b diverges at token block_size+7 (in the 2nd hash-block). The first
+    # hash-block (tokens [0, block_size)) is identical, and compressed KV is causal,
+    # so that prefix's KV is independent of the later divergence -> a correct 1-block
+    # sub-block partial hit (vllm-ascend short-key), not the conservative full-block
+    # miss. This is a deliberate improvement over the upstream #10298 behavior.
+    assert len(hit_blocks) == 1
 
 
 def test_compressed_prefix_cache_hits_identical_logical_block() -> None:
@@ -137,7 +145,7 @@ def test_compressed_prefix_cache_hits_identical_logical_block() -> None:
     assert hit_blocks == manager.req_to_blocks[request.request_id]
 
 
-def test_hybrid_coordinator_rejects_partial_compressed_prefix_hit() -> None:
+def test_hybrid_coordinator_subblock_partial_compressed_prefix_hit() -> None:
     block_size = 128
     compress_ratio = 4
     logical_block_size = block_size * compress_ratio
@@ -193,5 +201,8 @@ def test_hybrid_coordinator_rejects_partial_compressed_prefix_hit() -> None:
         max_cache_hit_length=logical_block_size,
     )
 
-    assert hit_length == 0
-    assert hit_blocks == ([], [])
+    # The first hash-block matches and its compressed KV is causally independent of
+    # the later divergence, so the coordinator returns a correct sub-block partial
+    # hit of block_size tokens (vllm-ascend short-key) rather than rejecting it.
+    assert hit_length == block_size
+    assert hit_blocks != ([], [])

--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -1,14 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
+from collections import defaultdict
 from collections.abc import Sequence
 
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (
+    BlockHash,
     BlockHashList,
     BlockHashListWithBlockSize,
+    BlockHashWithGroupId,
     KVCacheBlock,
+    make_block_hash_with_group_id,
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     FullAttentionManager,
@@ -25,11 +29,100 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.request import Request
 
 
+class ComputedBlockList(list[KVCacheBlock]):
+    """KV blocks plus the logical token length they cover."""
+
+    def __init__(
+        self,
+        blocks: Sequence[KVCacheBlock] = (),
+        logical_hit_length: int | None = None,
+    ) -> None:
+        super().__init__(blocks)
+        self.logical_hit_length = logical_hit_length
+
+
+def _partial_prefix_cache(
+    block_pool: BlockPool,
+) -> tuple[dict[BlockHashWithGroupId, KVCacheBlock], defaultdict[int, set[BlockHashWithGroupId]]]:
+    """Return the (hash -> block, block_id -> hashes) maps used to track DSv4
+    partial-prefix cache entries for ``block_pool``.
+
+    The maps are stored on the ``BlockPool`` instance (created lazily on first
+    use) rather than as module-level globals so the state is scoped to a single
+    engine's cache and cannot leak across engines in the same process.
+    """
+    hash_to_block = getattr(block_pool, "_dsv4_partial_hash_to_block", None)
+    if hash_to_block is None:
+        hash_to_block = {}
+        block_pool._dsv4_partial_hash_to_block = hash_to_block
+        block_pool._dsv4_partial_block_id_to_hashes = defaultdict(set)
+    return hash_to_block, block_pool._dsv4_partial_block_id_to_hashes
+
+
+def _hash_range(
+    block_hashes: BlockHashList,
+    hash_block_size: int,
+    start_token: int,
+    end_token: int,
+) -> BlockHash | None:
+    if end_token <= start_token:
+        return None
+    if start_token % hash_block_size != 0 or end_token % hash_block_size != 0:
+        return None
+    start = start_token // hash_block_size
+    end = end_token // hash_block_size
+    if end > len(block_hashes):
+        return None
+    return BlockHash(b"".join(block_hashes[start:end]))
+
+
+def _insert_partial_cache(
+    block_pool: BlockPool,
+    block_hash: BlockHash,
+    kv_cache_group_id: int,
+    block: KVCacheBlock,
+) -> None:
+    hash_to_block, block_id_to_hashes = _partial_prefix_cache(block_pool)
+    key = make_block_hash_with_group_id(block_hash, kv_cache_group_id)
+    old_block = hash_to_block.get(key)
+    if old_block is not None and old_block.block_id != block.block_id:
+        block_id_to_hashes[old_block.block_id].discard(key)
+    hash_to_block[key] = block
+    block_id_to_hashes[block.block_id].add(key)
+
+
+def get_partial_cached_block(
+    block_pool: BlockPool, block_hash: BlockHash, kv_cache_group_id: int
+) -> KVCacheBlock | None:
+    hash_to_block, _ = _partial_prefix_cache(block_pool)
+    return hash_to_block.get(make_block_hash_with_group_id(block_hash, kv_cache_group_id))
+
+
+def remove_partial_cache_entries_for_block(block_pool: BlockPool, block_id: int) -> None:
+    hash_to_block, block_id_to_hashes = _partial_prefix_cache(block_pool)
+    for key in block_id_to_hashes.pop(block_id, set()):
+        block = hash_to_block.get(key)
+        if block is not None and block.block_id == block_id:
+            hash_to_block.pop(key, None)
+
+
 class CompressAttentionManager(FullAttentionManager):
     def __init__(self, kv_cache_spec: MLAAttentionSpec, block_pool: BlockPool, **kwargs) -> None:
         super().__init__(kv_cache_spec, block_pool, **kwargs)
         self.compress_ratio = kv_cache_spec.compress_ratio
         self._null_block = block_pool.null_block
+        self.copy_block_ids: list[tuple[int, int, int]] = []
+        self._copy_src_blocks: defaultdict[str, list[KVCacheBlock]] = defaultdict(list)
+        # Per-request bookkeeping for partial-prefix boundary registration.
+        # The first compressed block's boundaries are immutable once that block
+        # is full and its hashes are available, so each request is registered at
+        # most once and then recorded in ``_partial_boundaries_done``. Until then
+        # ``_partial_last_compressed`` dedups repeated calls at the same length.
+        # This is what previously stalled the scheduler loop and collapsed
+        # long-context decode throughput: the boundary hashing re-ran on every
+        # decode step even though the first block never changed.
+        self._partial_last_compressed: dict[str, int] = {}
+        self._partial_boundaries_done: set[str] = set()
 
     def get_num_blocks_to_allocate(
         self,
@@ -46,8 +139,9 @@ class CompressAttentionManager(FullAttentionManager):
 
         num_tokens //= self.compress_ratio
         num_tokens_main_model //= self.compress_ratio
+        total_computed_tokens //= self.compress_ratio
 
-        return super().get_num_blocks_to_allocate(
+        num_blocks = super().get_num_blocks_to_allocate(
             request_id,
             num_tokens,
             new_computed_blocks,
@@ -55,6 +149,11 @@ class CompressAttentionManager(FullAttentionManager):
             num_tokens_main_model,
             apply_admission_cap,
         )
+        # Partial compressed hits are copied into a private destination block
+        # before the request resumes. The source block may also need to be
+        # pinned if it is an eviction candidate, which super() already counts.
+        num_full_hit_blocks = total_computed_tokens // self.block_size
+        return num_blocks + max(0, len(new_computed_blocks) - num_full_hit_blocks)
 
     def allocate_new_computed_blocks(
         self,
@@ -88,8 +187,8 @@ class CompressAttentionManager(FullAttentionManager):
         # A new request.
         req_blocks = self.req_to_blocks[request_id]
         assert len(req_blocks) == 0
-        num_total_computed_tokens = num_local_computed_tokens + num_external_computed_tokens
-        num_total_computed_tokens //= self.compress_ratio
+        num_total_logical_tokens = num_local_computed_tokens + num_external_computed_tokens
+        num_total_computed_tokens = num_total_logical_tokens // self.compress_ratio
         num_skipped_tokens = self.get_num_skipped_tokens(num_total_computed_tokens)
         num_skipped_blocks = num_skipped_tokens // self.block_size
         if num_skipped_blocks > 0:
@@ -102,9 +201,23 @@ class CompressAttentionManager(FullAttentionManager):
                 num_external_computed_tokens,
             )
 
-        # Touch the computed blocks to make sure they won't be evicted.
+        num_full_hit_blocks = num_total_computed_tokens // self.block_size
+        if len(new_computed_blocks) > num_full_hit_blocks:
+            full_blocks = list(new_computed_blocks[:num_full_hit_blocks])
+            partial_src_blocks = list(new_computed_blocks[num_full_hit_blocks:])
+            if self.enable_caching:
+                self.block_pool.touch(partial_src_blocks)
+                self._copy_src_blocks[request_id].extend(partial_src_blocks)
+            partial_dst_blocks = self.block_pool.get_new_blocks(len(partial_src_blocks))
+            self.copy_block_ids.extend(
+                (self.kv_cache_group_id, src.block_id, dst.block_id)
+                for src, dst in zip(partial_src_blocks, partial_dst_blocks)
+            )
+            new_computed_blocks = [*full_blocks, *partial_dst_blocks]
+
+        # Touch the computed full blocks to make sure they won't be evicted.
         if self.enable_caching:
-            self.block_pool.touch(new_computed_blocks)
+            self.block_pool.touch(new_computed_blocks[:num_full_hit_blocks])
         else:
             assert not any(new_computed_blocks), "Computed blocks should be empty when prefix caching is disabled"
 
@@ -115,7 +228,7 @@ class CompressAttentionManager(FullAttentionManager):
         # All cached hits (including skipped nulls) are already cached; mark
         # them so cache_blocks() will not try to re-cache blocks that already
         # have a block_hash set.
-        self.num_cached_block[request_id] = len(req_blocks)
+        self.num_cached_block[request_id] = min(len(req_blocks), num_full_hit_blocks)
 
         if num_external_computed_tokens > 0:
             # Allocate new blocks for external computed tokens.
@@ -162,22 +275,72 @@ class CompressAttentionManager(FullAttentionManager):
             num_tokens: The total number of tokens that need to be cached
                 (including tokens that are already cached).
         """
-        num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
-        logical_block_size = self.block_size * self.compress_ratio
-        num_full_blocks = num_tokens // logical_block_size
+        compressed_tokens = num_tokens // self.compress_ratio
+        super().cache_blocks(request, compressed_tokens)
+        self._cache_partial_block_boundaries(request, compressed_tokens)
 
-        if num_cached_blocks >= num_full_blocks:
+    def _cache_partial_block_boundaries(self, request: Request, compressed_tokens: int) -> None:
+        req_blocks = self.req_to_blocks[request.request_id]
+        if compressed_tokens <= 0 or not req_blocks:
             return
+        # The first block's boundaries are final once it is full; never revisit.
+        if request.request_id in self._partial_boundaries_done:
+            return
+        # Dedup repeated calls at the same compressed length (identical entries).
+        if self._partial_last_compressed.get(request.request_id) == compressed_tokens:
+            return
+        self._partial_last_compressed[request.request_id] = compressed_tokens
 
-        self.block_pool.cache_full_blocks(
-            request=request,
-            blocks=self.req_to_blocks[request.request_id],
-            num_cached_blocks=num_cached_blocks,
-            num_full_blocks=num_full_blocks,
-            block_size=logical_block_size,
-            kv_cache_group_id=self.kv_cache_group_id,
-        )
-        self.num_cached_block[request.request_id] = num_full_blocks
+        hash_block_size = self.block_pool.hash_block_size
+        logical_block_size = self.block_size * self.compress_ratio
+        max_logical_tokens = compressed_tokens * self.compress_ratio
+        num_blocks_with_tokens = min(cdiv(compressed_tokens, self.block_size), len(req_blocks))
+
+        # Partial compressed hits are only needed before the first full
+        # compressed KV block exists (the <16K DSv4 case). Once a prompt has a
+        # full compressed-block hit, keep the normal full-block reuse path to
+        # avoid adding private copy work to long-context decode.
+        for block_idx in range(min(num_blocks_with_tokens, 1)):
+            block = req_blocks[block_idx]
+            if block.is_null:
+                continue
+            block_start = block_idx * logical_block_size
+            block_end = min(block_start + logical_block_size, max_logical_tokens)
+            boundary = block_start + hash_block_size
+            while boundary <= block_end:
+                # Full-block boundaries are already represented in the normal
+                # prefix cache hash table.
+                if boundary - block_start != logical_block_size:
+                    block_hash = _hash_range(
+                        request.block_hashes,
+                        hash_block_size,
+                        block_start,
+                        boundary,
+                    )
+                    if block_hash is not None:
+                        _insert_partial_cache(self.block_pool, block_hash, self.kv_cache_group_id, block)
+                boundary += hash_block_size
+
+        # Once the first block is full and all of its hashes are available, its
+        # partial boundaries are final. Latch the request so subsequent calls
+        # (every long-context decode step) return immediately above, paying zero
+        # boundary-hashing cost.
+        if compressed_tokens >= self.block_size and len(request.block_hashes) * hash_block_size >= logical_block_size:
+            self._partial_boundaries_done.add(request.request_id)
+            self._partial_last_compressed.pop(request.request_id, None)
+
+    def take_copy_block_ids(self) -> list[tuple[int, int, int]]:
+        copy_block_ids = self.copy_block_ids
+        self.copy_block_ids = []
+        return copy_block_ids
+
+    def free(self, request_id: str) -> None:
+        pinned_src_blocks = self._copy_src_blocks.pop(request_id, [])
+        self._partial_last_compressed.pop(request_id, None)
+        self._partial_boundaries_done.discard(request_id)
+        super().free(request_id)
+        if pinned_src_blocks:
+            self.block_pool.free_blocks(reversed(pinned_src_blocks))
 
     @classmethod
     def find_longest_cache_hit(
@@ -197,14 +360,21 @@ class CompressAttentionManager(FullAttentionManager):
         # ), (
         #     "CompressAttentionManager can only be used for compressor attention groups"
         # )
-        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple([] for _ in range(len(kv_cache_group_ids)))
+        computed_blocks: tuple[ComputedBlockList, ...] = tuple(
+            ComputedBlockList() for _ in range(len(kv_cache_group_ids))
+        )
+        raw_alignment_tokens = alignment_tokens
         block_size = kv_cache_spec.block_size
+        hash_block_size = block_pool.hash_block_size
         if dcp_world_size * pcp_world_size > 1:
             block_size *= dcp_world_size * pcp_world_size
-        logical_block_size = block_size * kv_cache_spec.compress_ratio
-        logical_block_hashes = BlockHashListWithBlockSize(block_hashes, block_size, logical_block_size)
-        max_num_blocks = max_length // logical_block_size
-        for block_hash in itertools.islice(logical_block_hashes, max_num_blocks):
+        max_num_blocks = max_length // block_size
+        full_block_hashes = (
+            block_hashes
+            if block_size == hash_block_size
+            else BlockHashListWithBlockSize(block_hashes, hash_block_size, block_size)
+        )
+        for block_hash in itertools.islice(full_block_hashes, max_num_blocks):
             # block_hashes is a chain of block hashes. If a block hash is not
             # in the cached_block_hash_to_id, the following block hashes are
             # not computed yet for sure.
@@ -218,9 +388,38 @@ class CompressAttentionManager(FullAttentionManager):
             for computed in computed_blocks:
                 computed.pop()
 
+        # Keep the original compressed full-block path for prompts that can hit
+        # normally. Only fall back to a private partial copy when the prompt is
+        # shorter than one compressed cache block and would otherwise get 0 hit.
+        if not computed_blocks[0]:
+            logical_block_size = kv_cache_spec.block_size * kv_cache_spec.compress_ratio
+            candidate = min(
+                max_length // raw_alignment_tokens * raw_alignment_tokens,
+                logical_block_size - raw_alignment_tokens,
+            )
+            while candidate > 0:
+                partial_hash = _hash_range(block_hashes, hash_block_size, 0, candidate)
+                if partial_hash is None:
+                    candidate -= raw_alignment_tokens
+                    continue
+                partial_blocks = [
+                    block
+                    for group_id in kv_cache_group_ids
+                    if (block := get_partial_cached_block(block_pool, partial_hash, group_id)) is not None
+                ]
+                if len(partial_blocks) != len(kv_cache_group_ids):
+                    candidate -= raw_alignment_tokens
+                    continue
+                for computed, cached in zip(computed_blocks, partial_blocks):
+                    computed.append(cached)
+                    computed.logical_hit_length = candidate
+                break
+
+        # NOTE: Div the compress ratio when finding the longest cache hit token length.
+        alignment_tokens = cdiv(alignment_tokens, kv_cache_spec.compress_ratio)
         while (
-            logical_block_size != alignment_tokens  # Faster for common case.
-            and len(computed_blocks[0]) * logical_block_size % alignment_tokens != 0
+            block_size != alignment_tokens  # Faster for common case.
+            and len(computed_blocks[0]) * block_size % alignment_tokens != 0
         ):
             for computed in computed_blocks:
                 computed.pop()

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -114,6 +114,16 @@ env_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
     # Whether to use MultiBlockPool for KV cache management
     "VLLM_ASCEND_APPLY_DSV4_PATCH": lambda: bool(int(os.getenv("VLLM_ASCEND_APPLY_DSV4_PATCH", "0"))),
+    # Retain sparse sliding-window KV checkpoints for prefix caching.
+    # Unset (None, default): dense local checkpointing (current behavior, byte-for-byte).
+    # 0: keep only the latest completed prompt (replay) boundary.
+    # >0: keep one tail per interval-sized segment (must be a multiple of
+    #     scheduler_block_size). Applies to SWA only, not Mamba/linear attn.
+    "VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL": lambda: (
+        int(os.environ["VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL"])
+        if "VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL" in os.environ
+        else None
+    ),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -219,6 +219,29 @@
 #       Remove this patch once upstream vLLM supports hybrid KV cache + CP for
 #       non-CUDA backends, or exposes a platform hook for this behavior.
 #
+# ** 10b. File: platform/patch_prefix_cache_core.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.v1.core.kv_cache_utils.FreeKVCacheBlockQueue.prepend_n`
+#   2. `vllm.v1.core.block_pool.BlockPool.free_blocks`
+#   3. `vllm.v1.core.single_type_kv_cache_manager.SingleTypeKVCacheManager.remove_skipped_blocks`
+#   4. `vllm.v1.core.single_type_kv_cache_manager.SlidingWindowManager._cache_block_mask`
+#   5. `vllm.v1.core.single_type_kv_cache_manager.SlidingWindowManager.free`
+#    Why:
+#       The DeepSeek V4 prefix-cache coordinator patch relies on the vLLM core
+#       block-reuse behavior added by vLLM PR #43447. Older supported vLLM
+#       versions do not expose `free_blocks(prepend=...)`, so short/SWA prefix
+#       cache paths can recycle local blocks with poor priority.
+#    How:
+#       When `VLLM_ASCEND_APPLY_DSV4_PATCH` is enabled, monkey-patch the missing
+#       free-list/front-insertion behavior and the SWA/EAGLE cache block mask.
+#       Each patch is guarded by capability/source checks so it is skipped once
+#       the underlying vLLM already provides the upstream behavior.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/43447
+#    Future Plan:
+#       Remove this patch once the supported vLLM version contains vLLM PR
+#       #43447 or equivalent prefix-cache block-reuse behavior.
+#
 # ** 10. File: platform/patch_kv_cache_interface.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.kv_cache_interface.MLAAttentionSpec`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -44,5 +44,6 @@ if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXP
 import vllm_ascend.patch.platform.patch_balance_schedule  # noqa
 
 if envs.VLLM_ASCEND_APPLY_DSV4_PATCH:
+    import vllm_ascend.patch.platform.patch_prefix_cache_core  # noqa
     import vllm_ascend.patch.platform.patch_kv_cache_coordinator  # noqa
     import vllm_ascend.patch.platform.patch_speculative_config  # noqa

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM projectx
 import sys
-from math import lcm
 
 import vllm
 from vllm.v1.core.block_pool import BlockPool
@@ -16,12 +15,61 @@ from vllm.v1.core.kv_cache_utils import (
     BlockHashListWithBlockSize,
     KVCacheBlock,
 )
-from vllm.v1.core.single_type_kv_cache_manager import SingleTypeKVCacheManager
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheSpec
+from vllm.v1.core.single_type_kv_cache_manager import (
+    SingleTypeKVCacheManager,
+    SlidingWindowManager,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheSpec,
+    SlidingWindowSpec,
+)
+from vllm.v1.request import Request
 
+from vllm_ascend import envs
 from vllm_ascend.core.single_type_kv_cache_manager import get_manager_for_kv_cache_spec
 
+try:
+    from vllm.v1.kv_cache_interface import SlidingWindowMLASpec
+except ImportError:  # pragma: no cover - older vLLM without DSv4 MLA SWA spec
+    SlidingWindowMLASpec = SlidingWindowSpec
+
+# SWA-family specs that honor the prefix-cache retention knob (incl. DSv4
+# SlidingWindowMLASpec), so validation does not wrongly report "no SWA group".
+_SLIDING_WINDOW_SPECS = (SlidingWindowSpec, SlidingWindowMLASpec)
+
 USE_MULTI_GROUPS_KV_CACHE = True
+
+
+def _validate_prefix_cache_retention_interval(
+    retention_interval: int | None,
+    scheduler_block_size: int,
+    kv_cache_config: KVCacheConfig,
+) -> None:
+    """Validate VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL (vLLM PR #43447 (3)).
+
+    No-op when unset. When set, the model must have at least one sliding-window
+    KV cache group (otherwise retention has no effect), and the value must be a
+    non-negative multiple of ``scheduler_block_size``.
+    """
+    if retention_interval is None:
+        return
+    if not any(
+        isinstance(g.kv_cache_spec, _SLIDING_WINDOW_SPECS)
+        for g in kv_cache_config.kv_cache_groups
+    ):
+        raise ValueError(
+            "VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL is set but this "
+            "model has no sliding-window KV cache group, so retention has no "
+            "effect."
+        )
+    if retention_interval < 0 or retention_interval % scheduler_block_size != 0:
+        raise ValueError(
+            f"VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL ({retention_interval}) "
+            f"must be non-negative and a multiple of scheduler_block_size "
+            f"({scheduler_block_size})."
+        )
 
 
 class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
@@ -43,6 +91,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         dcp_world_size: int,
         pcp_world_size: int,
         hash_block_size: int,
+        scheduler_block_size: int | None = None,
         eagle_attn_layer_names: list[str] | None = None,
         metrics_collector: KVCacheMetricsCollector | None = None,
         max_num_batched_tokens: int | None = None,
@@ -56,6 +105,13 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         if max_num_batched_tokens is None:
             max_num_batched_tokens = max_model_len
         self.max_num_batched_tokens = max_num_batched_tokens
+        if scheduler_block_size is None:
+            scheduler_block_size = hash_block_size
+        assert scheduler_block_size % hash_block_size == 0 and all(
+            scheduler_block_size % g.kv_cache_spec.block_size == 0
+            for g in kv_cache_config.kv_cache_groups
+        )
+        self.scheduler_block_size = scheduler_block_size
 
         self.block_pool = BlockPool(
             kv_cache_config.num_blocks,
@@ -84,6 +140,9 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             )
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
+        for i, manager in enumerate(self.single_type_managers):
+            manager.use_eagle = i in self.eagle_group_ids
+            manager.scheduler_block_size = self.scheduler_block_size
 
         # hash_block_size: the block size used to compute block hashes.
         # The actual block size usually equals hash_block_size, but in cases where
@@ -91,20 +150,43 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         # can be a multiple of hash_block_size.
         self.hash_block_size = hash_block_size
         if enable_caching:
-            assert all(
-                self._logical_block_size(g.kv_cache_spec) % hash_block_size == 0
-                for g in kv_cache_config.kv_cache_groups
-            ), "block_size must be divisible by hash_block_size"
+            assert all(g.kv_cache_spec.block_size % hash_block_size == 0 for g in kv_cache_config.kv_cache_groups), (
+                "block_size must be divisible by hash_block_size"
+            )
         assert dcp_world_size == 1, "DCP not support hybrid attn now."
         assert pcp_world_size == 1, "PCP not support hybrid attn now."
         self.verify_and_split_kv_cache_groups()
+        for _, group_ids, _ in self.attention_groups:
+            group_uses_eagle = any(group_id in self.eagle_group_ids for group_id in group_ids)
+            for group_id in group_ids:
+                self.single_type_managers[group_id].use_eagle = group_uses_eagle
 
         self.use_eagle = use_eagle
 
-    @staticmethod
-    def _logical_block_size(kv_cache_spec: KVCacheSpec) -> int:
-        compress_ratio = getattr(kv_cache_spec, "compress_ratio", 1) or 1
-        return kv_cache_spec.block_size * max(compress_ratio, 1)
+        # Prefix-cache SWA retention (vLLM PR #43447). None (env unset) keeps the
+        # dense cache-all behavior byte-for-byte.
+        self.retention_interval = envs.VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL
+        _validate_prefix_cache_retention_interval(
+            self.retention_interval, self.scheduler_block_size, kv_cache_config
+        )
+
+    def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
+        """Cache blocks for the request, forwarding the SWA retention knob.
+
+        SWA managers accept ``retention_interval``; other managers (compress /
+        full-attention) accept it only to keep a uniform signature and ignore
+        it. We dispatch on ``isinstance(..., SlidingWindowManager)`` rather than
+        signature reflection to avoid per-request overhead.
+        """
+        for manager in self.single_type_managers:
+            if isinstance(manager, SlidingWindowManager):
+                manager.cache_blocks(
+                    request,
+                    num_computed_tokens,
+                    retention_interval=self.retention_interval,
+                )
+            else:
+                manager.cache_blocks(request, num_computed_tokens)
 
     def verify_and_split_kv_cache_groups(self) -> None:
         """
@@ -143,14 +225,9 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             if any(gid in self.eagle_group_ids for gid in group_ids)
         }
 
-        # The LCM of the block sizes of all attention types.
-        # The cache hit length must be a multiple of the LCM of the block sizes
-        # to make sure the cache hit length is a multiple of the block size of
-        # each attention type. Requiring this because we don't support partial
-        # block cache hit yet.
-        # NOTE: use 16k as the alignment tokens for model with compress ratio
-        block_sizes = [self._logical_block_size(spec) for spec, _, _ in self.attention_groups]
-        self.lcm_block_size = lcm(*block_sizes)
+        # Prefix-cache hits are aligned to scheduler_block_size, not to
+        # block_size * compress_ratio. The latter forces DSv4 compressed
+        # groups to 16K-aligned hits and makes shorter prompts miss.
 
     def find_longest_cache_hit(
         self,
@@ -176,6 +253,8 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         """
 
         def _get_block_hashes(kv_cache_spec: KVCacheSpec) -> BlockHashList:
+            if getattr(kv_cache_spec, "compress_ratio", 1) > 1:
+                return block_hashes
             if kv_cache_spec.block_size == self.hash_block_size:
                 return block_hashes
             return BlockHashListWithBlockSize(block_hashes, self.hash_block_size, kv_cache_spec.block_size)
@@ -204,8 +283,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                     # Full attention is downward-closed: we only need to look
                     # up cached blocks once; on subsequent iterations just trim
                     # to the (reduced) current hit length.
-                    logical_block_size = self._logical_block_size(spec)
-                    curr_hit_length = curr_hit_length // logical_block_size * logical_block_size
+                    curr_hit_length = curr_hit_length // spec.block_size * spec.block_size
                     continue
 
                 use_eagle = idx in self.eagle_attn_group_indices and idx not in eagle_verified
@@ -213,7 +291,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                 _max_length = curr_hit_length
                 if use_eagle:
                     # Eagle needs to match one more block and then pop the last.
-                    _max_length = min(curr_hit_length + self._logical_block_size(spec), max_cache_hit_length)
+                    _max_length = min(curr_hit_length + spec.block_size, max_cache_hit_length)
                 hit_blocks = manager_cls.find_longest_cache_hit(
                     block_hashes=_get_block_hashes(spec),
                     max_length=_max_length,
@@ -221,9 +299,12 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                     block_pool=self.block_pool,
                     kv_cache_spec=spec,
                     use_eagle=use_eagle,
-                    alignment_tokens=self.lcm_block_size,
+                    alignment_tokens=self.scheduler_block_size,
                 )
-                _new_hit_length = len(hit_blocks[0]) * self._logical_block_size(spec)
+                compress_ratio = getattr(spec, "compress_ratio", 1)
+                _new_hit_length = getattr(hit_blocks[0], "logical_hit_length", None)
+                if _new_hit_length is None:
+                    _new_hit_length = len(hit_blocks[0]) * spec.block_size * max(compress_ratio, 1)
                 if use_eagle:
                     eagle_verified.add(idx)
                 elif _new_hit_length < curr_hit_length:
@@ -242,12 +323,20 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         # Truncate full attention blocks to final hit_length (if present)
         spec, group_ids, _ = self.attention_groups[0]
         if isinstance(spec, FullAttentionSpec):
-            num_blocks = hit_length // self._logical_block_size(spec)
+            num_blocks = hit_length // spec.block_size
             for group_id in group_ids:
                 if (blks := hit_blocks_by_group[group_id]) is not None:
                     del blks[num_blocks:]
 
         return tuple(blocks if blocks is not None else [] for blocks in hit_blocks_by_group), hit_length
+
+    def take_copy_block_ids(self) -> list[tuple[int, int, int]]:
+        copy_block_ids: list[tuple[int, int, int]] = []
+        for manager in self.single_type_managers:
+            take_copy_block_ids = getattr(manager, "take_copy_block_ids", None)
+            if take_copy_block_ids is not None:
+                copy_block_ids.extend(take_copy_block_ids())
+        return copy_block_ids
 
 
 def get_kv_cache_coordinator(
@@ -260,6 +349,7 @@ def get_kv_cache_coordinator(
     dcp_world_size: int,
     pcp_world_size: int,
     hash_block_size: int,
+    scheduler_block_size: int | None = None,
     eagle_attn_layer_names: list[str] | None = None,
     metrics_collector: KVCacheMetricsCollector | None = None,
 ) -> KVCacheCoordinator:
@@ -272,6 +362,7 @@ def get_kv_cache_coordinator(
         dcp_world_size=dcp_world_size,
         pcp_world_size=pcp_world_size,
         hash_block_size=hash_block_size,
+        scheduler_block_size=scheduler_block_size,
         eagle_attn_layer_names=eagle_attn_layer_names,
         metrics_collector=metrics_collector,
         max_num_batched_tokens=max_num_batched_tokens,

--- a/vllm_ascend/patch/platform/patch_prefix_cache_core.py
+++ b/vllm_ascend/patch/platform/patch_prefix_cache_core.py
@@ -1,0 +1,520 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+"""Compatibility patch for prefix-cache block reuse.
+
+This carries the small-core part of vLLM PR #43447 needed by the DeepSeek V4
+prefix-cache coordinator patch. Remove it when the supported vLLM version
+contains these APIs and behaviors.
+"""
+
+import inspect
+from collections.abc import Callable, Iterable
+
+from vllm.logger import logger
+from vllm.utils.math_utils import cdiv
+from vllm.v1.core import kv_cache_manager as kv_cache_manager_mod
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import FreeKVCacheBlockQueue, KVCacheBlock
+from vllm.v1.core.single_type_kv_cache_manager import (
+    SingleTypeKVCacheManager,
+    SlidingWindowManager,
+)
+from vllm.v1.kv_cache_interface import SlidingWindowSpec
+
+try:
+    from vllm.v1.kv_cache_interface import SlidingWindowMLASpec
+except ImportError:  # pragma: no cover - older vLLM without DSv4 MLA SWA spec
+    SlidingWindowMLASpec = SlidingWindowSpec
+from vllm_ascend.core.single_type_kv_cache_manager import (
+    remove_partial_cache_entries_for_block,
+)
+
+
+def _source_contains(fn: Callable, *needles: str) -> bool:
+    try:
+        source = inspect.getsource(fn)
+    except (OSError, TypeError):
+        return False
+    return all(needle in source for needle in needles)
+
+
+def _patch_kv_cache_manager_scheduler_block_size() -> None:
+    """Forward scheduler cache-hit granularity on vLLM versions without it."""
+    kv_cache_manager_cls = kv_cache_manager_mod.KVCacheManager
+    current_init = kv_cache_manager_cls.__init__
+    if "scheduler_block_size" in inspect.signature(current_init).parameters:
+        return
+    if getattr(current_init, "_vllm_ascend_scheduler_block_size_patch", False):
+        return
+
+    original_init = current_init
+    original_signature = inspect.signature(original_init)
+
+    def __init__(
+        self,
+        *args,
+        scheduler_block_size: int | None = None,
+        **kwargs,
+    ) -> None:
+        bound = original_signature.bind(self, *args, **kwargs)
+        bound.apply_defaults()
+        if scheduler_block_size is None:
+            scheduler_block_size = bound.arguments.get("hash_block_size")
+
+        original_get = kv_cache_manager_mod.get_kv_cache_coordinator
+
+        def get_with_scheduler_block_size(*coord_args, **coord_kwargs):
+            try:
+                supports_scheduler_block_size = (
+                    "scheduler_block_size"
+                    in inspect.signature(original_get).parameters
+                )
+            except (TypeError, ValueError):
+                supports_scheduler_block_size = False
+            if supports_scheduler_block_size:
+                coord_kwargs.setdefault(
+                    "scheduler_block_size", scheduler_block_size
+                )
+            return original_get(*coord_args, **coord_kwargs)
+
+        kv_cache_manager_mod.get_kv_cache_coordinator = (
+            get_with_scheduler_block_size
+        )
+        try:
+            return original_init(self, *args, **kwargs)
+        finally:
+            kv_cache_manager_mod.get_kv_cache_coordinator = original_get
+
+    __init__._vllm_ascend_scheduler_block_size_patch = True
+    kv_cache_manager_cls.__init__ = __init__
+    logger.debug("Patched KVCacheManager.__init__(scheduler_block_size=...).")
+
+
+def _patch_scheduler_scheduler_block_size() -> None:
+    """Pass Scheduler.block_size to KVCacheManager on older vLLM."""
+    try:
+        from vllm.v1.core.sched import scheduler as scheduler_mod
+    except ImportError:
+        return
+
+    scheduler_cls = scheduler_mod.Scheduler
+    current_init = scheduler_cls.__init__
+    if getattr(current_init, "_vllm_ascend_scheduler_block_size_patch", False):
+        return
+    if _source_contains(current_init, "scheduler_block_size=self.block_size"):
+        return
+
+    original_init = current_init
+    original_signature = inspect.signature(original_init)
+
+    def __init__(self, *args, **kwargs) -> None:
+        bound = original_signature.bind(self, *args, **kwargs)
+        bound.apply_defaults()
+        scheduler_block_size = bound.arguments.get("block_size")
+
+        original_kv_cache_manager = scheduler_mod.KVCacheManager
+
+        def kv_cache_manager_with_scheduler_block_size(*kv_args, **kv_kwargs):
+            if scheduler_block_size is not None:
+                kv_kwargs.setdefault("scheduler_block_size", scheduler_block_size)
+            return original_kv_cache_manager(*kv_args, **kv_kwargs)
+
+        scheduler_mod.KVCacheManager = kv_cache_manager_with_scheduler_block_size
+        try:
+            return original_init(self, *args, **kwargs)
+        finally:
+            scheduler_mod.KVCacheManager = original_kv_cache_manager
+
+    __init__._vllm_ascend_scheduler_block_size_patch = True
+    scheduler_cls.__init__ = __init__
+    logger.debug("Patched Scheduler.__init__ to pass scheduler_block_size.")
+
+
+def _patch_free_queue_prepend() -> None:
+    if hasattr(FreeKVCacheBlockQueue, "prepend_n"):
+        return
+
+    def prepend_n(self: FreeKVCacheBlockQueue, blocks: list[KVCacheBlock]) -> None:
+        """Put a list of blocks at the front of the free list."""
+        if len(blocks) == 0:
+            return
+
+        first_block = self.fake_free_list_head.next_free_block
+        assert first_block is not None, (
+            "next_free_block of fake_free_list_head should always exist"
+        )
+
+        prev_block = self.fake_free_list_head
+        for block in blocks:
+            block.prev_free_block = prev_block
+            prev_block.next_free_block = block
+            prev_block = block
+
+        prev_block.next_free_block = first_block
+        first_block.prev_free_block = prev_block
+
+        self.num_free_blocks += len(blocks)
+
+    FreeKVCacheBlockQueue.prepend_n = prepend_n
+    logger.debug("Patched FreeKVCacheBlockQueue.prepend_n for prefix-cache reuse.")
+
+
+def _patch_block_pool_free_blocks() -> None:
+    if "prepend" in inspect.signature(BlockPool.free_blocks).parameters:
+        return
+
+    def free_blocks(
+        self: BlockPool,
+        ordered_blocks: Iterable[KVCacheBlock],
+        prepend: bool = False,
+    ) -> None:
+        """Free blocks, optionally placing newly-free blocks at queue front."""
+        blocks_list = list(ordered_blocks)
+        for block in blocks_list:
+            block.ref_cnt -= 1
+        freed_blocks = [
+            block for block in blocks_list if block.ref_cnt == 0 and not block.is_null
+        ]
+        if prepend:
+            self.free_block_queue.prepend_n(freed_blocks)
+        else:
+            self.free_block_queue.append_n(freed_blocks)
+
+    BlockPool.free_blocks = free_blocks
+    logger.debug("Patched BlockPool.free_blocks(prepend=...).")
+
+
+def _patch_partial_prefix_cache_cleanup() -> None:
+    current = BlockPool._maybe_evict_cached_block
+    if getattr(current, "_vllm_ascend_partial_prefix_cache_cleanup_patch", False):
+        return
+
+    original_maybe_evict = current
+
+    def _maybe_evict_cached_block(self: BlockPool, block: KVCacheBlock) -> bool:
+        evicted = original_maybe_evict(self, block)
+        remove_partial_cache_entries_for_block(self, block.block_id)
+        return evicted
+
+    _maybe_evict_cached_block._vllm_ascend_partial_prefix_cache_cleanup_patch = True
+    BlockPool._maybe_evict_cached_block = _maybe_evict_cached_block
+    logger.debug("Patched BlockPool partial prefix-cache cleanup.")
+
+
+def _patch_scheduler_copy_blocks() -> None:
+    try:
+        from vllm.v1.core.sched import scheduler as scheduler_mod
+    except ImportError:
+        return
+
+    scheduler_classes = [scheduler_mod.Scheduler]
+    for module_name, class_name in (
+        ("vllm_ascend.core.scheduler_profiling_chunk", "ProfilingChunkScheduler"),
+        ("vllm_ascend.core.scheduler_dynamic_batch", "SchedulerDynamicBatch"),
+        ("vllm_ascend.patch.platform.patch_balance_schedule", "BalanceScheduler"),
+    ):
+        try:
+            module = __import__(module_name, fromlist=[class_name])
+            scheduler_classes.append(getattr(module, class_name))
+        except Exception:
+            continue
+
+    for scheduler_cls in scheduler_classes:
+        current = scheduler_cls.schedule
+        if getattr(current, "_vllm_ascend_copy_blocks_patch", False):
+            continue
+        original_schedule = current
+
+        def schedule(self, *args, __original_schedule=original_schedule, **kwargs):
+            scheduler_output = __original_schedule(self, *args, **kwargs)
+            coordinator = getattr(self.kv_cache_manager, "coordinator", None)
+            take_copy_block_ids = getattr(coordinator, "take_copy_block_ids", None)
+            if take_copy_block_ids is not None:
+                copy_block_ids = take_copy_block_ids()
+                if copy_block_ids:
+                    scheduler_output.new_block_ids_to_copy = copy_block_ids
+            return scheduler_output
+
+        schedule._vllm_ascend_copy_blocks_patch = True
+        scheduler_cls.schedule = schedule
+    logger.debug("Patched Scheduler.schedule to forward KV copy blocks.")
+
+
+def _patch_remove_skipped_blocks() -> None:
+    if _source_contains(
+        SingleTypeKVCacheManager.remove_skipped_blocks,
+        "prepend=True",
+        "block_hash is None",
+    ):
+        return
+
+    def remove_skipped_blocks(
+        self: SingleTypeKVCacheManager,
+        request_id: str,
+        total_computed_tokens: int,
+    ) -> None:
+        num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
+        if num_skipped_tokens <= 0:
+            return
+
+        blocks = self.req_to_blocks[request_id]
+        num_skipped_blocks = num_skipped_tokens // self.block_size
+        num_skipped_blocks = min(num_skipped_blocks, len(blocks))
+        removed_cached_blocks: list[KVCacheBlock] = []
+        removed_uncached_blocks: list[KVCacheBlock] = []
+
+        for i in range(num_skipped_blocks - 1, -1, -1):
+            if blocks[i] == self._null_block:
+                break
+            if blocks[i].block_hash is None:
+                removed_uncached_blocks.append(blocks[i])
+            else:
+                removed_cached_blocks.append(blocks[i])
+            blocks[i] = self._null_block
+
+        self.block_pool.free_blocks(removed_cached_blocks)
+        self.block_pool.free_blocks(removed_uncached_blocks, prepend=True)
+
+    SingleTypeKVCacheManager.remove_skipped_blocks = remove_skipped_blocks
+    logger.debug("Patched SingleTypeKVCacheManager.remove_skipped_blocks.")
+
+
+def _patch_cache_full_blocks_mask() -> None:
+    """Add a ``block_mask`` argument to ``BlockPool.cache_full_blocks``.
+
+    The vLLM v0.21.0 base ``cache_full_blocks`` has no ``block_mask`` parameter
+    (vLLM PR #43447 is built on a newer base that already carries it), so the
+    sparse SWA retention mask computed in ``SlidingWindowManager.cache_blocks``
+    would have nowhere to land. This wraps the original so that:
+
+    * ``block_mask is None`` -> the original function is called verbatim, i.e.
+      every full block is cached exactly as before (byte-for-byte safety net for
+      the env-unset / dense path).
+    * ``block_mask`` provided -> blocks whose ``mask[j]`` is ``False`` (``j`` is
+      the 0-based index into ``new_full_blocks``, i.e. the ``blocks`` slice
+      ``[num_cached_blocks:num_full_blocks]``) are temporarily replaced with the
+      null block so the original function's ``is_null`` branch skips them. The
+      ``blocks`` list is restored afterwards so the request's block table is not
+      polluted; masked-out blocks keep ``block_hash is None`` (scratch) and are
+      reclaimed with front-insert priority by the existing free patches.
+    """
+    if "block_mask" in inspect.signature(BlockPool.cache_full_blocks).parameters:
+        return
+    if getattr(BlockPool.cache_full_blocks, "_vllm_ascend_block_mask_patch", False):
+        return
+
+    original_cache_full_blocks = BlockPool.cache_full_blocks
+
+    def cache_full_blocks(
+        self: BlockPool,
+        *,
+        request,
+        blocks: list[KVCacheBlock],
+        num_cached_blocks: int,
+        num_full_blocks: int,
+        block_size: int,
+        kv_cache_group_id: int,
+        block_mask: list[bool] | None = None,
+    ) -> None:
+        if block_mask is None:
+            return original_cache_full_blocks(
+                self,
+                request=request,
+                blocks=blocks,
+                num_cached_blocks=num_cached_blocks,
+                num_full_blocks=num_full_blocks,
+                block_size=block_size,
+                kv_cache_group_id=kv_cache_group_id,
+            )
+
+        # Mask mode: temporarily swap masked blocks for the null block so the
+        # original function's "skip null" branch leaves them uncached, then
+        # restore the request's block list verbatim.
+        saved: list[tuple[int, KVCacheBlock]] = []
+        null_block = self.null_block
+        for j in range(num_full_blocks - num_cached_blocks):
+            if not block_mask[j]:
+                idx = num_cached_blocks + j
+                saved.append((idx, blocks[idx]))
+                blocks[idx] = null_block
+        try:
+            original_cache_full_blocks(
+                self,
+                request=request,
+                blocks=blocks,
+                num_cached_blocks=num_cached_blocks,
+                num_full_blocks=num_full_blocks,
+                block_size=block_size,
+                kv_cache_group_id=kv_cache_group_id,
+            )
+        finally:
+            for idx, blk in saved:
+                blocks[idx] = blk
+
+    cache_full_blocks._vllm_ascend_block_mask_patch = True
+    BlockPool.cache_full_blocks = cache_full_blocks
+    logger.debug("Patched BlockPool.cache_full_blocks(block_mask=...).")
+
+
+def _patch_sliding_window_mask() -> None:
+    """Inject the retention three-state mask onto ``SlidingWindowManager``.
+
+    vLLM v0.21.0's ``SlidingWindowManager`` has neither ``reachable_block_mask``
+    nor ``_contiguous_blocks_for_hit`` (the cache-hit side inlines
+    ``cdiv(sliding_window-1, block_size)`` + EAGLE ``+1``), and the base
+    ``cache_blocks`` takes no retention argument. We therefore inject all three
+    pieces of vLLM PR #43447's algorithm here.
+
+    Deliberate deviation from PR #43447 (see §2c of the design): when
+    ``retention_interval is None`` (env unset) we return ``None`` to keep the
+    prior dense "cache every full block" behavior byte-for-byte, rather than the
+    PR's dense-per-segment sparsification which would tighten the existing SWA
+    hit rate. Only the 0 / >0 states walk the sparse path.
+    """
+    if hasattr(SlidingWindowManager, "reachable_block_mask") and _source_contains(
+        SlidingWindowManager.cache_blocks, "retention_interval"
+    ):
+        return
+
+    @staticmethod
+    def _contiguous_blocks_for_hit(
+        window_size: int, block_size: int, use_eagle: bool
+    ) -> int:
+        # Mirror find_longest_cache_hit's hit granularity exactly:
+        # cdiv(sliding_window-1, block_size), +1 when EAGLE is enabled. Keeping
+        # this identical to the lookup side avoids cache-vs-hit misalignment.
+        need = cdiv(window_size - 1, block_size)
+        return need + 1 if use_eagle else need
+
+    @classmethod
+    def reachable_block_mask(
+        cls,
+        start_block: int,
+        end_block: int,
+        alignment_tokens: int | None,
+        kv_cache_spec,
+        use_eagle: bool,
+        retention_interval: int | None = None,
+        num_prompt_tokens: int | None = None,
+    ) -> list[bool] | None:
+        assert isinstance(kv_cache_spec, SlidingWindowSpec)
+        # Deviation from PR #43447: env-unset (None) keeps the dense cache-all
+        # path so existing hit behavior is unchanged. cache_full_blocks receives
+        # block_mask=None and runs verbatim.
+        if retention_interval is None:
+            return None
+        if alignment_tokens is None:
+            return None
+        assert alignment_tokens % kv_cache_spec.block_size == 0
+        block_size = kv_cache_spec.block_size
+        need = cls._contiguous_blocks_for_hit(
+            window_size=kv_cache_spec.sliding_window,
+            block_size=block_size,
+            use_eagle=use_eagle,
+        )
+        shift = 1 if use_eagle else 0
+        mask = [False] * (end_block - start_block)
+
+        # retention_interval == 0 -> only the latest replay boundary is kept
+        # (segment tail loop disabled); >0 -> keep one tail per interval segment.
+        segment_tokens = None if retention_interval == 0 else retention_interval
+        if segment_tokens is not None:
+            per_segment = segment_tokens // block_size
+            if need >= per_segment:
+                # The whole segment is within reach; nothing can be dropped, so
+                # fall back to caching everything (dense).
+                return None
+            for i in range(start_block, end_block):
+                if i >= shift and (i - shift) % per_segment >= per_segment - need:
+                    mask[i - start_block] = True
+
+        # Replay tail: always retain the contiguous tail covering the latest
+        # completed prompt boundary so a replay of the prompt still hits. This
+        # only runs when retention is enabled (matches PR #43447: the dense None
+        # path never adds a replay tail).
+        if num_prompt_tokens is not None:
+            latest = (num_prompt_tokens - 1) // alignment_tokens * alignment_tokens
+            prompt_end_block = latest // block_size + shift
+            for i in range(
+                max(start_block, prompt_end_block - need),
+                min(end_block, prompt_end_block),
+            ):
+                mask[i - start_block] = True
+        return mask
+
+    def cache_blocks(
+        self: SlidingWindowManager,
+        request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+    ) -> None:
+        num_cached = self.num_cached_block.get(request.request_id, 0)
+        num_full = num_tokens // self.block_size
+        if num_cached >= num_full:
+            return
+        # The coordinator injects scheduler_block_size / use_eagle onto each
+        # manager; fall back conservatively so pure-SWA (unitary) coordinators
+        # that bypass the Ascend coordinator still behave (dense) correctly.
+        alignment_tokens = getattr(self, "scheduler_block_size", self.block_size)
+        use_eagle = getattr(self, "use_eagle", False)
+        block_mask = self.reachable_block_mask(
+            start_block=num_cached,
+            end_block=num_full,
+            alignment_tokens=alignment_tokens,
+            kv_cache_spec=self.kv_cache_spec,
+            use_eagle=use_eagle,
+            retention_interval=retention_interval,
+            num_prompt_tokens=request.num_prompt_tokens,
+        )
+        self.block_pool.cache_full_blocks(
+            request=request,
+            blocks=self.req_to_blocks[request.request_id],
+            num_cached_blocks=num_cached,
+            num_full_blocks=num_full,
+            block_size=self.block_size,
+            kv_cache_group_id=self.kv_cache_group_id,
+            block_mask=block_mask,
+        )
+        self.num_cached_block[request.request_id] = num_full
+
+    SlidingWindowManager._contiguous_blocks_for_hit = _contiguous_blocks_for_hit
+    SlidingWindowManager.reachable_block_mask = reachable_block_mask
+    SlidingWindowManager.cache_blocks = cache_blocks
+    logger.debug(
+        "Patched SlidingWindowManager.reachable_block_mask / cache_blocks "
+        "(prefix-cache retention)."
+    )
+
+
+def _patch_sliding_window_free() -> None:
+    if _source_contains(SlidingWindowManager.free, "prepend=True", "block_hash is None"):
+        return
+
+    def free(self: SlidingWindowManager, request_id: str) -> None:
+        req_blocks = self.req_to_blocks.pop(request_id, [])
+        if req_blocks:
+            cached_blocks: list[KVCacheBlock] = []
+            uncached_blocks: list[KVCacheBlock] = []
+            for block in reversed(req_blocks):
+                if block.block_hash is None:
+                    uncached_blocks.append(block)
+                else:
+                    cached_blocks.append(block)
+            self.block_pool.free_blocks(cached_blocks)
+            self.block_pool.free_blocks(uncached_blocks, prepend=True)
+        self.num_cached_block.pop(request_id, None)
+
+    SlidingWindowManager.free = free
+    logger.debug("Patched SlidingWindowManager.free.")
+
+
+_patch_kv_cache_manager_scheduler_block_size()
+_patch_scheduler_scheduler_block_size()
+_patch_free_queue_prepend()
+_patch_block_pool_free_blocks()
+_patch_cache_full_blocks_mask()
+_patch_partial_prefix_cache_cleanup()
+_patch_scheduler_copy_blocks()
+_patch_remove_skipped_blocks()
+_patch_sliding_window_mask()
+_patch_sliding_window_free()

--- a/vllm_ascend/patch/platform/patch_tool_choice_none_content.py
+++ b/vllm_ascend/patch/platform/patch_tool_choice_none_content.py
@@ -112,31 +112,32 @@ def _patch_named_tool_choice_bool() -> None:
 _patch_named_tool_choice_bool()
 
 
-_original_parse_tool_calls_from_content = OpenAIServing._parse_tool_calls_from_content
+_original_parse_tool_calls_from_content = getattr(OpenAIServing, "_parse_tool_calls_from_content", None)
 
 
-def _patched_parse_tool_calls_from_content(
-    request,
-    tokenizer,
-    enable_auto_tools: bool,
-    tool_parser_cls,
-    content: str | None = None,
-):
-    if content is None and _is_forced_tool_choice(request):
-        _set_no_forced_tool_call(request, True)
-        return [], None
+if _original_parse_tool_calls_from_content is not None:
 
-    _set_no_forced_tool_call(request, False)
-    return _original_parse_tool_calls_from_content(
-        request=request,
-        tokenizer=tokenizer,
-        enable_auto_tools=enable_auto_tools,
-        tool_parser_cls=tool_parser_cls,
-        content=content,
-    )
+    def _patched_parse_tool_calls_from_content(
+        request,
+        tokenizer,
+        enable_auto_tools: bool,
+        tool_parser_cls,
+        content: str | None = None,
+    ):
+        if content is None and _is_forced_tool_choice(request):
+            _set_no_forced_tool_call(request, True)
+            return [], None
 
+        _set_no_forced_tool_call(request, False)
+        return _original_parse_tool_calls_from_content(
+            request=request,
+            tokenizer=tokenizer,
+            enable_auto_tools=enable_auto_tools,
+            tool_parser_cls=tool_parser_cls,
+            content=content,
+        )
 
-OpenAIServing._parse_tool_calls_from_content = staticmethod(_patched_parse_tool_calls_from_content)
+    OpenAIServing._parse_tool_calls_from_content = staticmethod(_patched_parse_tool_calls_from_content)
 
 _original_delegating_parse_tool_calls = DelegatingParser._parse_tool_calls
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -26,7 +26,7 @@ from copy import copy, deepcopy
 from dataclasses import dataclass, replace
 from functools import partial
 from multiprocessing import Manager
-from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple, TypeAlias
 
 import numpy as np
 import torch
@@ -1660,6 +1660,57 @@ class NPUModelRunner(GPUModelRunner):
             else:
                 self.draft_token_ids_cpu[:num_reqs] = 0
             self.draft_token_ids_event.record()
+
+    def _copy_prefix_cache_blocks(self, scheduler_output: "SchedulerOutput") -> None:
+        """Materialize DSv4 partial-prefix cache hits by copying the source KV
+        block into the request's private destination block before the model runs.
+
+        This lives in the model runner (rather than a patch) because it needs the
+        runner-owned ``_kv_caches_by_layer`` map from layer name to the on-device
+        KV tensors, and the copy must happen inside ``_update_states`` so the
+        destination blocks are populated before this step's forward pass. It is a
+        no-op for every model except DSv4 with partial prefix caching: when no
+        partial hit was scheduled, ``new_block_ids_to_copy`` is empty and this
+        returns immediately, so it adds no cost to other models or to the
+        long-context decode path.
+        """
+        copy_block_ids = getattr(scheduler_output, "new_block_ids_to_copy", None)
+        if not copy_block_ids:
+            return
+        if not hasattr(self, "_kv_caches_by_layer"):
+            logger.warning("Skip prefix-cache block copy because layer KV caches are not registered.")
+            return
+
+        copies_by_group: dict[int, list[tuple[int, int]]] = defaultdict(list)
+        for group_id, src_block_id, dst_block_id in copy_block_ids:
+            copies_by_group[group_id].append((src_block_id, dst_block_id))
+
+        for group_id, copy_pairs in copies_by_group.items():
+            if group_id >= len(self.kv_cache_config.kv_cache_groups):
+                logger.warning("Skip prefix-cache block copy for invalid group_id=%s.", group_id)
+                continue
+            copied_cache_ids: set[int] = set()
+            for layer_name in self.kv_cache_config.kv_cache_groups[group_id].layer_names:
+                kv_cache = self._kv_caches_by_layer.get(layer_name)
+                if kv_cache is None or id(kv_cache) in copied_cache_ids:
+                    continue
+                copied_cache_ids.add(id(kv_cache))
+                self._copy_prefix_cache_tensor(kv_cache, copy_pairs)
+        logger.debug("Copied DSv4 partial prefix-cache blocks: %s", copy_block_ids)
+
+    def _copy_prefix_cache_tensor(self, kv_cache, copy_pairs: list[tuple[int, int]]) -> None:
+        if torch.is_tensor(kv_cache):
+            src_to_dst = torch.tensor(copy_pairs, dtype=torch.long, device=kv_cache.device)
+            kv_cache[src_to_dst[:, 1]] = kv_cache[src_to_dst[:, 0]]
+            return
+        if isinstance(kv_cache, (list, tuple)):
+            for item in kv_cache:
+                self._copy_prefix_cache_tensor(item, copy_pairs)
+
+    def _update_states(self, scheduler_output: "SchedulerOutput") -> Callable | None:
+        deferred_state_corrections_fn = super()._update_states(scheduler_output)
+        self._copy_prefix_cache_blocks(scheduler_output)
+        return deferred_state_corrections_fn
 
     @torch.inference_mode()
     def execute_model(
@@ -3535,6 +3586,7 @@ class NPUModelRunner(GPUModelRunner):
                 kvcomp_meta_data=self.kvcomp_meta_data
             )
 
+        self._kv_caches_by_layer = kv_caches
         return kv_caches
 
     def _get_layer_kv_cache_specs(self, kv_cache_config: KVCacheConfig) -> dict[str, KVCacheSpec]:


### PR DESCRIPTION
## What this PR does / why we need it?
Adds partial compressed prefix-cache hits for DeepSeek V4. When a prompt is
shorter than one compressed cache block and gets zero full-block hits, the
first block's prefix boundaries are registered in a private partial table; a
later request then reuses the longest matching prefix by copying the source KV
into a private block (in-cache device-to-device copy) before the forward pass.
Boundary registration is latched once per request to avoid per-decode-step
re-hashing. Builds on the prefix-cache core block-reuse patch and aligns hits
to the scheduler block size.

## Does this PR introduce any user-facing change?
No.

---
Co-authored with @wangzhao-11a.