### PR TITLE
[BugFix][UT] Mock AscendConfig in SFA metadata builder tests

### DIFF
--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -127,6 +127,17 @@ class TestAscendSFAMetadataBuilder(TestBase):
         self.patcher = patch("vllm.config.get_current_vllm_config", return_value=self.mock_cfg)
         self.patcher.start()
 
+        mock_ascend_config = MagicMock()
+        mock_ascend_config.c8_enable_reshape_optim = False
+        mock_ascend_config.enable_mlapo = True
+        mock_ascend_config.enable_shared_expert_dp = False
+        mock_ascend_config.layer_sharding = None
+        self.ascend_config_patcher = patch(
+            "vllm_ascend.attention.sfa_v1.get_ascend_config",
+            return_value=mock_ascend_config,
+        )
+        self.ascend_config_patcher.start()
+
         # Mock parent class __init__ to avoid complex initialization,
         # but still set the essential attributes that child class needs
         def mock_parent_init(
@@ -154,6 +165,7 @@ class TestAscendSFAMetadataBuilder(TestBase):
 
     def tearDown(self):
         self.patcher.stop()
+        self.ascend_config_patcher.stop()
         self.parent_init_patcher.stop()
 
     @patch_distributed_groups(dcp_size=2, pcp_size=2, needs_mocks=False)

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -15,6 +15,7 @@ from vllm_ascend.attention.sfa_v1 import AscendSFABackend, AscendSFAImpl, Ascend
 from vllm_ascend.utils import enable_dsa_cp
 
 
+# test on CI
 class TestAscendSFABackend(TestBase):
     def setUp(self):
         self.mock_config = MagicMock()

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -15,7 +15,6 @@ from vllm_ascend.attention.sfa_v1 import AscendSFABackend, AscendSFAImpl, Ascend
 from vllm_ascend.utils import enable_dsa_cp
 
 
-# test on CI
 class TestAscendSFABackend(TestBase):
     def setUp(self):
         self.mock_config = MagicMock()


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes `tests/ut/attention/a2/test_sfa_v1.py` by explicitly mocking
`get_ascend_config()` in `TestAscendSFAMetadataBuilder`.
- https://github.com/vllm-project/vllm-ascend/actions/runs/27336219650/job/80761760016#step:13:229

Fix bug in vllm-ascend PR #10292:

That PR added a new `AscendConfig` field:

```python
self.c8_enable_reshape_optim = ...
```

and introduced this access in `vllm_ascend/attention/sfa_v1.py`:

```python
if get_ascend_config().c8_enable_reshape_optim:
```

However, `tests/ut/attention/a2/test_sfa_v1.py` directly constructs
`AscendSFAMetadataBuilder` and calls `build()` / `build_for_graph_capture()`
without initializing or mocking `AscendConfig`. As a result, the tests can fail
with:

```text
RuntimeError: Ascend config is not initialized. Please call init_ascend_config first.
```

This is a UT isolation issue. The SFA metadata builder tests should not depend
on process-global Ascend platform initialization side effects.

This PR fixes the tests by mocking:

```python
vllm_ascend.attention.sfa_v1.get_ascend_config
```

and setting the fields required by the SFA path, including:

```python
c8_enable_reshape_optim = False
```

This keeps the test focused on SFA metadata builder behavior and avoids relying
on global `AscendConfig` state.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
