### PR TITLE
[Feature][DSv4] Support compressor block size [32,64,128] to improve automatic prefix cache hit rate

### DIFF
--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -6,6 +6,7 @@ from vllm.distributed.parallel_state import GroupCoordinator
 
 from tests.ut.attention.utils import patch_distributed_groups
 from tests.ut.base import TestBase
+from vllm_ascend.ascend_config import init_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 
 if "torch_npu._inductor" not in sys.modules:
@@ -122,6 +123,9 @@ class TestAscendSFAMetadataBuilder(TestBase):
         self.mock_cfg.compilation_config.pass_config.enable_sp = False
 
         self.mock_cfg.speculative_config.num_speculative_tokens = 0
+
+        self.mock_cfg.additional_config = {"refresh": True}
+        init_ascend_config(self.mock_cfg)
 
         self.patcher = patch("vllm.config.get_current_vllm_config", return_value=self.mock_cfg)
         self.patcher.start()

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -208,8 +208,7 @@ class AscendDSABackend(AttentionBackend):
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int]:
-        kernel_block_sizes = DeviceOperator.get_dsa_kernel_block_sizes()
-        return kernel_block_sizes
+        return [2, 4, 8, 16, 32, 64, 128]
 
 
 @dataclass

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -102,6 +102,14 @@ def _get_ascend_dsa_backend():
     return AscendDSABackend
 
 
+def _dsv4_block_sizes():
+    # Lazy import to avoid the circular import chain (layer -> dsa_v1 ->
+    # attention_v1 -> device_op) hit during vLLM subprocess model inspection.
+    from vllm_ascend.models.layer.attention.layer import DSV4_BLOCK_SIZES
+
+    return DSV4_BLOCK_SIZES
+
+
 class AscendCompressorStateCache(CompressorStateCache):
     def __init__(
         self,
@@ -116,10 +124,8 @@ class AscendCompressorStateCache(CompressorStateCache):
         self.block_size = block_size
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
-            page_size_padded = 16896 if self.state_dim == 2 * 256 and self.compress_ratio == 4 else 81920
-        else:
-            page_size_padded = 16640 if self.state_dim == 2 * 256 and self.compress_ratio == 4 else 131072
+        pads = _dsv4_block_sizes()[vllm_config.cache_config.block_size][1]
+        page_size_padded = pads[0] if self.state_dim == 2 * 256 and self.compress_ratio == 4 else pads[1]
 
         return SlidingWindowMLASpec(
             block_size=self.block_size,
@@ -156,7 +162,7 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
         from vllm.v1.kv_cache_interface import MLAAttentionSpec
 
         return MLAAttentionSpec(
-            block_size=128,
+            block_size=_dsv4_block_sizes()[vllm_config.cache_config.block_size][0][0],
             num_kv_heads=1,
             head_size=self.head_dim,
             dtype=self.dtype,
@@ -185,7 +191,7 @@ class AscendDeepseekV4SWACache(VllmDeepseekV4SWACache):
         super().__init__(head_dim, window_size, torch.uint8, prefix, cache_config)
         self.dtype = dtype
 
-        self.block_size = 128
+        self.block_size = _dsv4_block_sizes()[cache_config.block_size][0][1]
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
         if get_ascend_device_type() in {AscendDeviceType.A5}:
@@ -644,7 +650,7 @@ class Compressor(nn.Module):
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=8,
+                block_size=_dsv4_block_sizes()[cache_config.block_size][0][2],  # type: ignore[union-attr]
             )
         elif compress_ratio == 128:
             self.state_cache = AscendCompressorStateCache(
@@ -652,7 +658,7 @@ class Compressor(nn.Module):
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=16 if get_ascend_device_type() in {AscendDeviceType.A5} else 32,
+                block_size=_dsv4_block_sizes()[cache_config.block_size][0][3],  # type: ignore[union-attr]
             )
         else:
             raise ValueError(

--- a/vllm_ascend/models/layer/attention/layer.py
+++ b/vllm_ascend/models/layer/attention/layer.py
@@ -28,6 +28,27 @@ from vllm_ascend.utils import (
 )
 
 
+def get_dsv4_block_sizes():
+    # cache_config.block_size: [mla, swa, c4 state, c128 state], [page_size_padded_t1, page_size_padded_t2]
+    _DSV4_BLOCK_SIZES = {
+        128: [[128, 128, 8, 32], [16640, 131072]],
+        64: [[64, 64, 4, 16], [8320, 65536]],
+        32: [[32, 32, 2, 8], [4160, 32768]],
+    }
+    _DSV4_BLOCK_SIZES_A5 = {
+        128: [[128, 128, 8, 16], [16896, 81920]],
+        64: [[64, 64, 4, 8], [8448, 40960]],
+        32: [[32, 32, 2, 4], [4224, 20480]],
+    }
+    if get_ascend_device_type() in {AscendDeviceType.A5}:
+        return _DSV4_BLOCK_SIZES_A5
+    else:
+        return _DSV4_BLOCK_SIZES
+
+
+DSV4_BLOCK_SIZES = get_dsv4_block_sizes()
+
+
 class DSAAttention(nn.Module, AttentionLayerBase):
     """Multi-Head Latent Attention layer.
 
@@ -162,7 +183,7 @@ class DSAAttention(nn.Module, AttentionLayerBase):
             (self.head_size + 128) if get_ascend_device_type() in {AscendDeviceType.A5} else self.head_size
         )
         return MLAAttentionSpec(
-            block_size=128,
+            block_size=DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][0][0],
             num_kv_heads=1,
             head_size=cached_head_size,
             dtype=kv_cache_dtype,

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1261,8 +1261,15 @@ def refresh_block_size(vllm_config):
         return
 
     if model_config.hf_config.model_type == "deepseek_v4":
-        # TODO(qcs): generalize the block_size
-        cache_config.block_size = 128
+        if cache_config.block_size is None:
+            cache_config.block_size = 32
+        elif cache_config.block_size not in [32, 64, 128]:
+            logger.warning(
+                "For deepseek_v4 model, block size should be 32, 64 or 128. "
+                "Setting block size to 32 for better performance."
+            )
+            cache_config.block_size = 32
+        return
 
     if model_config.is_hybrid:
         # Hybrid attention+mamba models rely on the model-specific sizing


### PR DESCRIPTION
### What this PR does / why we need it?
Makes the DeepSeek V4 compressor KV-cache block_size configurable (32 / 64 / 128) instead of hard-pinned to 128, via a lookup table that scales the MLA / SWA / C4-state / C128-state block sizes and page-size padding together. A smaller block size shrinks the alignment requirement of the compressed KV cache, so more prompt prefixes can hit the prefix cache (better automatic prefix cache hit rate).

### Does this PR introduce any user-facing change?
For DeepSeek V4, `--block-size` now accepts 32 / 64 / 128.

- **Unset**: vLLM's `CacheConfig.DEFAULT_BLOCK_SIZE` is 16, which is not in the allowed set; `refresh_block_size` resets it to **32** with a warning log. This means **the effective default for DeepSeek V4 has changed from 128 (pre-PR, hard override) to 32 (this PR)**. `--block-size 32` is also the recommended setting for prefix-cache workloads (best automatic prefix cache hit rate; see benchmarks below).
- `--block-size 32 / 64 / 128`: respected as-is.
- Any other explicit value: falls back to **32** with a warning log.

If you want to preserve the previous behavior (block_size = 128), pass `--block-size 128` explicitly.

> ⚠️ **PD-disaggregated deployments**: The Prefiller (P) and Decoder (D) instances **must use the same `--block-size`**. Mismatched block sizes produce incompatible KV-cache page layouts and the D side will fail to consume the KV cache transferred from P. When upgrading to this PR in a PD setup, either set `--block-size 128` on both sides (preserve old behavior) or set `--block-size 32` on both sides (recommended for prefix-cache workloads) — do not leave one side unset while the other is pinned.

### How was this patch tested?
Validated on DeepSeek-V4 (w8a8 + MTP) with vLLM 0.21.0, prefix caching enabled, tensor-parallel 8, `num_speculative_tokens=1`, `--max-model-len 150000`, `--max-num-batched-tokens 8192`, `--max-num-seqs 32`. Service `/health` returned 200.

**Block-size comparison** — 32k input / 1k output, concurrency 8, repeat_rate 0.9, prefix-cache enabled:

| block-size | HBM hit rate | Total Token Throughput | Avg TTFT | Avg TPOT |
|---:|---:|---:|---:|---:|
| **32** | **87.49%** | **8906 tok/s** | **1471 ms** | **27.9 ms** |
| 64 | 74.99% | 7922 tok/s | 2661 ms | 30.6 ms |
| 128 | 45.31% | 6612 tok/s | 5430 ms | 34.3 ms |

Smaller block size gives finer cache-key granularity and higher automatic prefix cache hit rate. Ordering: hit rate & throughput **32 > 64 > 128**; TTFT/TPOT **32 < 64 < 128**. `--block-size 32` is recommended for prefix-cache workloads.

**Latest PR HEAD validation** (block-size 32):

| Scenario | input/output | concurrency | HBM hit rate | Total Token Throughput | Avg TTFT | Avg TPOT |
|---|---|---:|---:|---:|---:|---:|
| 8k/1k | 8192/1024 | 32 | 48.80% | 5996 tok/s | 3297 ms | 44.3 ms |
| 32k/1k | 32768/1024 | 8 | 87.49% | 8711 tok/s | 1832 ms | 28.3 ms |

- All requests succeeded (128/128 and 32/32); all prefix-cache hits were local HBM (no external hits).
- CI: `lint-and-select-tests` and `a3-4card` DSv4 e2e passed.

---
Co-authored with @MengqingCao.


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
