### PR TITLE
[CI]add recompute scheduler to fix mpt+pcp shape error

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-R1-W8A8-longseq.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-R1-W8A8-longseq.yaml
@@ -83,6 +83,7 @@ deployment:
         --compilation_config '{"cudagraph_capture_sizes":[4,8,16,32],"cudagraph_mode": "FULL_DECODE_ONLY"}'
         --enable-chunked-prefill
         --speculative-config '{"num_speculative_tokens": 3, "method":"mtp"}'
+        --additional-config '{"recompute_scheduler_enable":true}'
         --kv-transfer-config
         '{"kv_connector": "MooncakeConnectorV1",
         "kv_role": "kv_consumer",


### PR DESCRIPTION
### What this PR does / why we need it?
Currently, when PCP is combined with MTP, a recalculation is required. The issue of shape misalignment after combining PCP with MTP has been fixed.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
