### PR TITLE
[Performance] Optimize chunk_gated_delta_relu_fwd operator

### DIFF
--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -21,6 +21,7 @@ from einops import rearrange
 from vllm.distributed import get_pcp_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.fla.ops.l2norm import l2norm_fwd
+from typing import List, Optional
 
 from vllm_ascend.utils import vllm_version_is
 
@@ -93,6 +94,16 @@ def get_spec_causal_conv1d_update_host_args(attn_metadata) -> tuple[tuple[int, .
         to_int64_tuple(causal_conv1d_meta.query_start_loc_cpu),
         to_int64_tuple(causal_conv1d_meta.cache_indices_cpu),
         to_int64_tuple(causal_conv1d_meta.num_accepted_tokens_cpu),
+    )
+
+
+def get_chunk_list_host_args(attn_metadata) -> tuple[Optional[List[int]], Optional[List[int]]]:
+    fallback_meta = _check_and_get_host_args(attn_metadata, "chunk_list_meta", "chunk_list")
+    chunk_list_meta = fallback_meta.chunk_list
+
+    return (
+        chunk_list_meta.non_spec_query_start_loc_list,
+        chunk_list_meta.chunk_indices_list,
     )
 
 
@@ -666,6 +677,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
         if attn_metadata.num_prefills > 0:
             initial_state = ssm_state[non_spec_state_indices_tensor].transpose(-1, -2).contiguous()
             clear_ssm_states(initial_state, has_initial_state)
+            (non_spec_query_start_loc_list, chunk_indices_list) = get_chunk_list_host_args(attn_metadata)
             (core_attn_out_non_spec, last_recurrent_state) = chunk_gated_delta_rule(
                 q=query_non_spec,
                 k=key_non_spec,
@@ -678,6 +690,8 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 prebuilt_meta=get_non_spec_chunked_prefill_meta(attn_metadata),
                 head_first=False,
                 use_qk_l2norm_in_kernel=True,
+                non_spec_query_start_loc_list=non_spec_query_start_loc_list,
+                chunk_indices_list=chunk_indices_list,
             )
             ssm_state[non_spec_state_indices_tensor] = (
                 last_recurrent_state.transpose(-1, -2).contiguous().to(ssm_state.dtype)

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -11,6 +11,7 @@
 import warnings
 
 import torch
+from typing import List, Optional
 from einops import rearrange
 from vllm.distributed import get_pcp_group
 from vllm.forward_context import get_forward_context
@@ -39,6 +40,8 @@ def chunk_gated_delta_rule_fwd(
     output_final_state: bool,
     cu_seqlens: torch.LongTensor | None = None,
     prebuilt_meta=None,
+    non_spec_query_start_loc_list: Optional[List[int]] = None,
+    chunk_indices_list: Optional[List[int]] = None,
 ):
     forward_context = get_forward_context()
     num_decodes = 0
@@ -92,7 +95,6 @@ def chunk_gated_delta_rule_fwd(
     g_ascendc = g.transpose(1, 2).contiguous()
     q_ascendc = q.to(torch.bfloat16).transpose(1, 2).contiguous()
 
-    cu_seqlens = cu_seqlens.to(torch.int64)
     chunk_indices = None if chunk_indices_chunk64 is None else chunk_indices_chunk64.to(torch.int64)
     h, v_new, final_state = torch.ops._C_ascend.chunk_gated_delta_rule_fwd_h(
         k_ascendc,
@@ -104,13 +106,14 @@ def chunk_gated_delta_rule_fwd(
         output_final_state=True,
         chunk_size=64,
         save_new_value=True,
-        cu_seqlens=cu_seqlens.tolist() if cu_seqlens is not None else None,
-        chunk_indices=chunk_indices.flatten().tolist() if chunk_indices is not None else None,
+        cu_seqlens=non_spec_query_start_loc_list if cu_seqlens is not None else None,
+        chunk_indices=chunk_indices_list if chunk_indices is not None else None,
         use_exp2=False,
         transpose_state_layout=False,
     )
 
     if get_pcp_group().world_size > 1:
+        cu_seqlens = cu_seqlens.to(torch.int64)
         h_update = chunk_gated_delta_rule_fwd_hupdate(
             k=k,
             w=w,
@@ -170,8 +173,8 @@ def chunk_gated_delta_rule_fwd(
         scale,
         g=g_ascendc,
         g_gamma=None,
-        cu_seqlens=cu_seqlens.tolist() if cu_seqlens is not None else None,
-        chunk_indices=chunk_indices.flatten().tolist() if chunk_indices is not None else None,
+        cu_seqlens=non_spec_query_start_loc_list if cu_seqlens is not None else None,
+        chunk_indices=chunk_indices_list if chunk_indices is not None else None,
         chunk_size=64,
         transpose_state_layout=False,
     )
@@ -202,6 +205,8 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         cu_seqlens: torch.LongTensor | None = None,
         prebuilt_meta=None,
         use_qk_l2norm_in_kernel: bool = False,
+        non_spec_query_start_loc_list: Optional[List[int]] = None,
+        chunk_indices_list: Optional[List[int]] = None,
     ):
         logger.debug(
             "[TritonOps] chunk_gated_delta_rule_fwd: q.shape=%s, k.shape=%s, "
@@ -233,6 +238,8 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
             output_final_state=output_final_state,
             cu_seqlens=cu_seqlens,
             prebuilt_meta=prebuilt_meta,
+            non_spec_query_start_loc_list=non_spec_query_start_loc_list,
+            chunk_indices_list=chunk_indices_list,
         )
         ctx.scale = scale
         ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
@@ -256,6 +263,8 @@ def chunk_gated_delta_rule(
     chunk_indices: torch.Tensor | None = None,
     chunk_offsets: torch.Tensor | None = None,
     core_attn_out: torch.Tensor | None = None,
+    non_spec_query_start_loc_list: Optional[List[int]] = None,
+    chunk_indices_list: Optional[List[int]] = None,
 ):
     r"""
     Args:
@@ -364,6 +373,8 @@ def chunk_gated_delta_rule(
         cu_seqlens,
         prebuilt_meta,
         use_qk_l2norm_in_kernel,
+        non_spec_query_start_loc_list,
+        chunk_indices_list,
     )
     if head_first:
         o = rearrange(o, "b t h ... -> b h t ...")

--- a/vllm_ascend/patch/worker/patch_gdn_attn.py
+++ b/vllm_ascend/patch/worker/patch_gdn_attn.py
@@ -16,6 +16,7 @@
 from dataclasses import dataclass
 
 import torch
+from typing import List, Optional
 import vllm.v1.attention.backends.gdn_attn as gdn_attn
 from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 
@@ -77,6 +78,17 @@ class GDNDecodeFallbackMeta:
 @dataclass
 class GDNSpecDecodeFallbackMeta:
     spec_causal_conv1d: GDNSpecCausalConv1dHostMetadata
+
+
+@dataclass
+class GDNChunkedPrefillReluListMeta:
+    chunk_list: _GDNChunkedReluListMeta
+
+
+@dataclass
+class _GDNChunkedReluListMeta:
+    non_spec_query_start_loc_list: Optional[List[int]] = None,
+    chunk_indices_list: Optional[List[int]] = None,
 
 
 @dataclass
@@ -706,6 +718,19 @@ def _build_non_spec_chunked_prefill_meta(
     return _build_chunked_prefill_metadata(builder, tensors, slot=slot)
 
 
+def _build_chunked_list_meta(
+    builder,
+    cu_seqlens,
+    chunk_indices,
+) -> _GDNChunkedReluListMeta:
+    cu_seqlens_list: Optional[List[int]] = cu_seqlens.to(torch.int64).tolist()
+    chunk_indices_list: Optional[List[int]] = chunk_indices.flatten().tolist()
+    return _GDNChunkedReluListMeta(
+        non_spec_query_start_loc_list=cu_seqlens_list,
+        chunk_indices_list=chunk_indices_list,
+    )
+
+
 def _patched_build(
     self,
     common_prefix_len: int,
@@ -725,6 +750,7 @@ def _patched_build(
     attn_metadata.non_spec_prefill_fallback_meta = None
     attn_metadata.non_spec_decode_fallback_meta = None
     attn_metadata.spec_decode_fallback_meta = None
+    attn_metadata.chunk_list_meta = None
     if attn_metadata.spec_sequence_masks is not None:
         _patched_build_spec(self, attn_metadata, common_attn_metadata, num_decode_draft_tokens_cpu)
 
@@ -776,6 +802,13 @@ def _patched_build_prefill(
             non_spec_query_start_loc_cpu,
             attn_metadata.non_spec_query_start_loc,
         ),
+    )
+    attn_metadata.chunk_list_meta = GDNChunkedPrefillReluListMeta(
+        chunk_list=_build_chunked_list_meta(
+            self,
+            non_spec_query_start_loc_cpu,
+            attn_metadata.non_spec_prefill_fallback_meta.chunk.chunk_indices_chunk64,
+        )
     )
     return attn_metadata
 
@@ -864,6 +897,7 @@ if not _IS_PATCHED and not is_310p():
     gdn_attn.GDNChunkedPrefillMetadata = GDNChunkedPrefillMetadata
     gdn_attn.GDNCausalConv1dHostMetadata = GDNCausalConv1dHostMetadata
     gdn_attn.GDNPrefillFallbackMeta = GDNPrefillFallbackMeta
+    gdn_attn.GDNChunkedPrefillReluListMeta = GDNChunkedPrefillReluListMeta
     gdn_attn.GDNAttentionMetadataBuilder.build = _patched_build
     gdn_attn.GDNAttentionMetadataBuilder._init_reorder_batch_threshold = _init_reorder_batch_threshold
     _IS_PATCHED = True


### PR DESCRIPTION
### What this PR does / why we need it?
In chunk_gated_delta_relu_fwd, vllm-ascend use triton and ascendc operators. triton need tentor, ascendc need list. in every gdn layer do tolist(). This PR moves the tolist to the front of GDN, so that it only needs to be calculated once per round.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
It test in Atlas 800T A2, use qwen3.5-0.8b model
- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
