### PR TITLE
[BugFix][Worker] Skip DSV4 pre-KV graph memory profiling

### DIFF
--- a/tests/ut/worker/a2/test_worker_multi_instance.py
+++ b/tests/ut/worker/a2/test_worker_multi_instance.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from vllm.config import CUDAGraphMode
@@ -56,7 +57,10 @@ class TestDetermineAvailableMemoryMultiInstance(TestBase):
 
         mock_cache_config = MagicMock()
         mock_cache_config.kv_cache_memory_bytes = None
+        mock_cache_config.gpu_memory_utilization = requested_memory / init_total_memory
         worker.cache_config = mock_cache_config
+
+        worker.model_config = SimpleNamespace(hf_config=SimpleNamespace(model_type="qwen3"))
 
         mock_snapshot = MagicMock()
         mock_snapshot.free_memory = init_free_memory
@@ -134,6 +138,67 @@ class TestDetermineAvailableMemoryMultiInstance(TestBase):
         expected = requested_memory - non_kv_cache
         self.assertEqual(result, expected)
         self.assertGreater(result, 0)
+
+    @patch("vllm_ascend.worker.worker.logger")
+    def test_deepseek_v4_compressed_skips_npugraph_memory_profile(self, mock_logger):
+        """DSV4 DSA must not run the pre-KV graph memory profiling path."""
+        total = int(64 * GiB_bytes)
+        requested_memory = int(total * 0.9)
+        init_free = int(60 * GiB_bytes)
+        non_kv_cache = int(1 * GiB_bytes)
+
+        worker = self._make_worker(requested_memory, init_free, total)
+        worker.vllm_config.compilation_config.cudagraph_mode = CUDAGraphMode.FULL_DECODE_ONLY
+        worker.model_config.hf_config.model_type = "deepseek_v4"
+        worker.model_runner.use_compress = True
+        worker.model_runner.profile_cudagraph_memory.return_value = int(2 * GiB_bytes)
+        profile_result = self._make_profile_result(
+            free_memory_after=init_free - non_kv_cache,
+            non_kv_cache_memory=non_kv_cache,
+        )
+
+        with self._patch_memory_profiling(profile_result):
+            result = worker.determine_available_memory()
+
+        worker.model_runner.profile_run.assert_called_once()
+        worker.model_runner.profile_cudagraph_memory.assert_not_called()
+        self.assertEqual(
+            worker.vllm_config.compilation_config.cudagraph_mode,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+        )
+        self.assertEqual(worker.npugraph_memory_estimate, 0)
+        self.assertEqual(result, requested_memory - non_kv_cache)
+
+    @patch("vllm_ascend.worker.worker.logger")
+    def test_non_deepseek_compressed_still_profiles_npugraph_memory(self, mock_logger):
+        """The DSV4 guard must not disable graph memory profiling globally."""
+        total = int(64 * GiB_bytes)
+        requested_memory = int(total * 0.9)
+        init_free = int(60 * GiB_bytes)
+        non_kv_cache = int(1 * GiB_bytes)
+        npugraph_memory = int(2 * GiB_bytes)
+
+        worker = self._make_worker(requested_memory, init_free, total)
+        worker.vllm_config.compilation_config.cudagraph_mode = CUDAGraphMode.FULL_DECODE_ONLY
+        worker.model_runner.use_compress = True
+        worker.model_runner.profile_cudagraph_memory.return_value = npugraph_memory
+        profile_result = self._make_profile_result(
+            free_memory_after=init_free - non_kv_cache,
+            non_kv_cache_memory=non_kv_cache,
+        )
+
+        with (
+            self._patch_memory_profiling(profile_result),
+            patch(
+                "vllm_ascend.worker.worker.envs_vllm.VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS",
+                False,
+            ),
+        ):
+            result = worker.determine_available_memory()
+
+        worker.model_runner.profile_cudagraph_memory.assert_called_once_with()
+        self.assertEqual(worker.npugraph_memory_estimate, npugraph_memory)
+        self.assertEqual(result, requested_memory - non_kv_cache)
 
     @patch("vllm_ascend.worker.worker.logger")
     def test_second_instance_on_same_card_positive_kv_cache(self, mock_logger):

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -375,7 +375,18 @@ class NPUWorker(WorkerBase):
             profile_torch_peak = torch.npu.memory_stats(self.device).get("allocated_bytes.all.peak", 0)
 
             npugraph_memory_estimate = 0
-            if self.vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
+            should_profile_npugraph_memory = self.vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
+            if should_profile_npugraph_memory and getattr(self.model_runner, "use_compress", False):
+                hf_config = self.model_config.hf_config
+                if getattr(hf_config, "model_type", None) == "deepseek_v4":
+                    logger.warning_once(
+                        "Skipping ACL graph memory profiling for DeepSeek-V4 "
+                        "DSA compressed attention. Graph mode remains enabled; "
+                        "the normal ACL graph capture still runs after KV cache "
+                        "allocation."
+                    )
+                    should_profile_npugraph_memory = False
+            if should_profile_npugraph_memory:
                 npugraph_memory_estimate = self.model_runner.profile_cudagraph_memory()
 
         # Override torch_peak_increase with the pre-graph-capture value to


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #10322.

Commit 9099b7f66d123ea704e329d7586333ad8b08db50 (#9865) added ACL graph memory estimation before KV cache allocation. For DeepSeek-V4 DSA compressed attention, that temporary pre-KV capture path can hit `aclnnScatterNdUpdateV2`/507015 before the normal KV-cache-backed graph path is available.

This PR skips only the pre-KV ACL graph memory profiling path when `model_type == "deepseek_v4"` and compressed attention is enabled. It leaves `cudagraph_mode` unchanged, so normal ACL graph capture and replay still run after KV allocation.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Local DeepSeek-V4 accuracy validation:

- 1P1D deployment on two A3 nodes
- Prefill side: `dp=16`, `tp=1`, expert parallel enabled
- Decode side: `dp=16`, `tp=1`, expert parallel enabled
- Context length: `300k`
- GPQA accuracy: `0.8838`, which matches expectation

Version context for the runtime validation:


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
