### PR TITLE
[Feature][EPLB] Support MiniMax (block_sparse_moe) experts in EPLB adaptor

### DIFF
--- a/vllm_ascend/eplb/adaptor/vllm_adaptor.py
+++ b/vllm_ascend/eplb/adaptor/vllm_adaptor.py
@@ -23,6 +23,7 @@ import torch.distributed as dist
 from vllm.logger import logger
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.eplb.utils import _resolve_moe_attr
 from vllm_ascend.quantization.methods.base import QuantType
 
 
@@ -42,7 +43,10 @@ class VllmEplbAdaptor:
 
         self.expert_map_per_layer_cpu = dict()  # copy of expert map on CPU to avoid device synchronize frequently
 
-        self.num_local_experts = self.model.model.layers[-1].mlp.experts.local_num_experts
+        # MiniMax names its MoE block `block_sparse_moe`; DeepSeek et al. use `mlp`.
+        self.moe_attr = _resolve_moe_attr(self.model.model.layers[-1])
+        last_moe_layer = getattr(self.model.model.layers[-1], self.moe_attr)
+        self.num_local_experts = last_moe_layer.experts.local_num_experts
         self.expert_param_per_layer = dict()
         self.init_expert_param_per_layer()
 
@@ -59,7 +63,7 @@ class VllmEplbAdaptor:
     def init_buffer_tensor(self, num_buffer_tensor):
         for buffer_id in range(num_buffer_tensor):
             for name in self.expert_weight_names:
-                complete_name = "model.layers." + str(self.num_dense_layers) + ".mlp.experts." + name
+                complete_name = f"model.layers.{self.num_dense_layers}.{self.moe_attr}.experts.{name}"
                 expert_tensor = self.param_dict[complete_name][0]
                 buffer_tensor = torch.empty_like(expert_tensor)
                 self.buffer_tensor_list[buffer_id].append(buffer_tensor)
@@ -67,7 +71,8 @@ class VllmEplbAdaptor:
     def init_expert_param_per_layer(self):
         self.param_dict = dict()
         if self.model.quant_config is not None:
-            quant_type = self.model.model.layers[self.num_dense_layers].mlp.experts.quant_type
+            first_moe_layer = getattr(self.model.model.layers[self.num_dense_layers], self.moe_attr)
+            quant_type = first_moe_layer.experts.quant_type
             if quant_type == QuantType.W8A8:
                 self.expert_weight_names = [
                     "w13_weight_list",
@@ -105,15 +110,16 @@ class VllmEplbAdaptor:
 
         for layer_idx in range(self.num_dense_layers, self.config.num_hidden_layers):
             self.expert_param_per_layer[layer_idx] = list()
+            moe_layer = getattr(self.model.model.layers[layer_idx], self.moe_attr)
             for name in self.expert_weight_names:
-                param_key = f"model.layers.{layer_idx}.mlp.experts.{name}"
-                param_value = getattr(self.model.model.layers[layer_idx].mlp.experts, name)
+                param_key = f"model.layers.{layer_idx}.{self.moe_attr}.experts.{name}"
+                param_value = getattr(moe_layer.experts, name)
                 self.param_dict[param_key] = param_value
             for local_expert_id in range(self.num_local_experts):
                 per_expert_param = list()
                 for name in self.expert_weight_names:
                     per_expert_param.append(
-                        self.param_dict["model.layers." + str(layer_idx) + ".mlp.experts." + name][local_expert_id]
+                        self.param_dict[f"model.layers.{layer_idx}.{self.moe_attr}.experts.{name}"][local_expert_id]
                     )
                 self.expert_param_per_layer[layer_idx].append(per_expert_param)
 
@@ -162,7 +168,8 @@ class VllmEplbAdaptor:
     def get_global_expert_map(self):
         all_layer_global_expert_map = []
         for layer_id in range(self.num_moe_layers):
-            map_cpu = self.model.model.layers[self.num_dense_layers + layer_id].mlp.experts.global_expert_map.cpu()
+            moe_layer = getattr(self.model.model.layers[self.num_dense_layers + layer_id], self.moe_attr)
+            map_cpu = moe_layer.experts.global_expert_map.cpu()
             all_layer_global_expert_map.append(map_cpu)
             self.expert_map_per_layer_cpu[self.num_dense_layers + layer_id] = map_cpu[self.rank_id]
 

--- a/vllm_ascend/eplb/utils.py
+++ b/vllm_ascend/eplb/utils.py
@@ -20,19 +20,33 @@ import types
 import torch
 
 
+def _resolve_moe_attr(layer) -> str:
+    # MiniMax names its MoE block `block_sparse_moe`; DeepSeek et al. use `mlp`.
+    for attr in ("mlp", "block_sparse_moe"):
+        block = getattr(layer, attr, None)
+        if block is not None and hasattr(block, "experts"):
+            return attr
+    raise AttributeError("EPLB: no MoE block found on layer (tried 'mlp', 'block_sparse_moe')")
+
+
 def get_expert_map(self, layer_id):
-    return self.model.layers[layer_id].mlp.experts.expert_map
+    moe = getattr(self.model.layers[layer_id], self._moe_attr)
+    return moe.experts.expert_map
 
 
 def get_log2phy_map(self, layer_id):
-    return self.model.layers[layer_id].mlp.experts.get_log2phy_map()
+    moe = getattr(self.model.layers[layer_id], self._moe_attr)
+    return moe.experts.get_log2phy_map()
 
 
 def get_all_moe_loads(self):
     num_dense_layers = getattr(self.model.config, "first_k_dense_replace", 0)
     num_layers = self.model.config.num_hidden_layers
     all_moe_loads = torch.stack(
-        [self.model.layers[layer_id].mlp.experts.moe_load for layer_id in range(num_dense_layers, num_layers)],
+        [
+            getattr(self.model.layers[layer_id], self._moe_attr).experts.moe_load
+            for layer_id in range(num_dense_layers, num_layers)
+        ],
         dim=0,
     )
     return all_moe_loads
@@ -42,12 +56,13 @@ def clear_all_moe_loads(self):
     num_dense_layers = getattr(self.model.config, "first_k_dense_replace", 0)
     num_layers = self.model.config.num_hidden_layers
     for layer_id in range(num_dense_layers, num_layers):
-        self.model.layers[layer_id].mlp.experts.clear_moe_load()
+        getattr(self.model.layers[layer_id], self._moe_attr).experts.clear_moe_load()
 
 
 def model_register(model):
     if hasattr(model, "language_model"):
         model = model.language_model
+    model._moe_attr = _resolve_moe_attr(model.model.layers[-1])
     model.get_expert_map = types.MethodType(get_expert_map, model)
     model.get_log2phy_map = types.MethodType(get_log2phy_map, model)
     model.get_all_moe_loads = types.MethodType(get_all_moe_loads, model)


### PR DESCRIPTION
MiniMax names its MoE block `block_sparse_moe` while DeepSeek et al. use `mlp`, but the EPLB model register and adaptor hardcoded `.mlp.experts`, so EPLB could not run on MiniMax.

Detect the MoE attribute at runtime (block_sparse_moe vs mlp) and use it everywhere experts are accessed, in both eplb/utils.py (get_expert_map / get_log2phy_map / get_all_moe_loads / clear_all_moe_loads) and eplb/adaptor/vllm_adaptor.py (num_local_experts, buffer/param init, get_global_expert_map).

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
