### PR TITLE
[Feature] support Flash Attention 3 (FA3) for training-inference consistency.

### DIFF
--- a/.github/workflows/scripts/config.yaml
+++ b/.github/workflows/scripts/config.yaml
@@ -6,7 +6,7 @@ e2e-singlecard:
 - name: tests/e2e/singlecard/test_auto_fit_max_mode_len.py
   estimated_time: 70
 - name: tests/e2e/singlecard/test_attention_fa3.py
-  estimated_time: 250
+  estimated_time: 198
 - name: tests/e2e/singlecard/test_eager_mode_acc.py
   estimated_time: 255
 - name: tests/e2e/singlecard/test_aclgraph_accuracy.py

--- a/.github/workflows/scripts/config.yaml
+++ b/.github/workflows/scripts/config.yaml
@@ -5,6 +5,8 @@ e2e-singlecard:
   estimated_time: 69
 - name: tests/e2e/singlecard/test_auto_fit_max_mode_len.py
   estimated_time: 70
+- name: tests/e2e/singlecard/test_attention_fa3.py
+  estimated_time: 250
 - name: tests/e2e/singlecard/test_eager_mode_acc.py
   estimated_time: 255
 - name: tests/e2e/singlecard/test_aclgraph_accuracy.py

--- a/docs/source/user_guide/feature_guide/flash_attention.md
+++ b/docs/source/user_guide/feature_guide/flash_attention.md
@@ -1,0 +1,164 @@
+# Flash Attention 3
+
+```{note}
+Flash Attention 3 on Ascend is currently in beta. The `flash_attn_npu` package required for FA3 has been open-sourced on GitHub.
+Please refer to the [flash-attention-npu repository](https://github.com/MinghuasLab/flash-attention-npu) for more details.
+```
+
+This document shows how to enable Flash Attention 3 (FA3) in vLLM-Ascend. FA3 provides a training-inference consistent attention implementation for Ascend NPUs.
+
+## Motivation
+
+In RL training frameworks such as veRL, the attention computation during training uses Flash Attention. When vLLM-Ascend serves as the inference backend, the default Fused Infer Attention (FIA) implementation differs from the training-side Flash Attention, which can lead to training-inference inconsistency. To address this, vLLM-Ascend introduces the FA3 attention backend to maintain consistency with the training side.
+
+FA3 is crucial for the following scenarios:
+
+- **Training-inference consistency**: Ensures that the attention computation during inference matches the training side, which is essential for RL workflows (e.g., veRL) where inference results are used to compute training signals.
+- **Framework debugging**: Consistent attention implementations make it easier to debug issues by eliminating discrepancies between training and inference.
+- **Reinforcement Learning (RL)**: RL training often requires deterministic and consistent rollouts for reproducibility and stable training.
+
+## Feature Comparison
+
+The following table compares the features of `flash_attn_with_kvcache` between GPU FA3 and Ascend NPU FA3:
+
+| Feature | GPU FA3 | NPU FA3 |
+|---------|---------|---------|
+| FP16 (float16) | ✅ | ✅ |
+| BF16 (bfloat16) | ✅ | ✅ |
+| Causal Attention | ✅ | ✅ |
+| Sliding Window Attention | ✅ | - |
+| MQA/GQA | ✅ | ✅ |
+| Paged KV Cache | ✅ | ✅ |
+| Rotary Position Embedding (RoPE) | ✅ | - |
+| ALiBi | - | - |
+| Softcapping | ✅ | - |
+| FP8 Quantization | ✅ | - |
+| Variable-length Sequences | ✅ | ✅ |
+
+### Differences from GPU Implementation
+
+The `flash_attn_with_kvcache` interface on NPU is semantically consistent with the GPU FA3 version in terms of API parameters. The key differences are:
+
+1. **Unsupported features on NPU FA3**: Sliding window attention, RoPE, ALiBi, Softcapping, and FP8 quantization are not yet supported.
+2. **Graph capture**: The tiling of `flash_attn_with_kvcache` is processed on the host side and is currently being optimized. It does not support ACL graph capture (i.e., cannot be captured into a computational graph for acceleration). Please use `enforce_eager=True` when enabling FA3.
+
+## Hardware Requirements
+
+FA3 currently requires Ascend Atlas A2 and A3 inference products NPUs.
+We will support other NPUs in the future.
+
+## Software Requirements
+
+FA3 requires the `flash_attn_npu` package, which provides the `flash_attn_npu_v3` module with the `flash_attn_with_kvcache` operator.
+
+### Installation
+
+Install the `flash_attn_npu` wheel package refer to: <https://github.com/MinghuasLab/flash-attention-npu/blob/main/README.md#installation>.
+
+## Enabling Flash Attention 3
+
+To enable FA3, you need to:
+
+1. Set the environment variable `export VLLM_BATCH_INVARIANT=1` to enable batch invariant mode
+2. Specify the attention backend as `FLASH_ATTN` via the LLM parameter `attention_backend="FLASH_ATTN"`
+
+### Online Inference (Server Mode)
+
+To start a vLLM server with FA3 enabled:
+
+```bash
+VLLM_BATCH_INVARIANT=1 vllm serve Qwen/Qwen3-8B --attention-backend FLASH_ATTN
+```
+
+Then use the OpenAI-compatible client:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="EMPTY",
+    base_url="http://localhost:8000/v1",
+)
+
+response = client.completions.create(
+    model="Qwen/Qwen3-8B",
+    prompt="The future of AI is",
+    max_tokens=100,
+    temperature=0.7,
+    seed=42,
+)
+
+print(response.choices[0].text)
+```
+
+### Offline Inference
+
+For offline batch inference with FA3:
+
+```python
+import os
+os.environ["VLLM_BATCH_INVARIANT"] = "1"
+
+from vllm import LLM, SamplingParams
+
+prompts = [
+    "The future of AI is",
+    "Machine learning enables",
+    "Deep learning models can",
+]
+
+sampling_params = SamplingParams(
+    temperature=0.7,
+    max_tokens=100,
+    seed=42,
+)
+
+llm = LLM(
+    model="Qwen/Qwen3-8B",
+    tensor_parallel_size=1,
+    attention_backend="FLASH_ATTN",
+)
+
+outputs = llm.generate(prompts, sampling_params)
+
+for output in outputs:
+    prompt = output.prompt
+    generated_text = output.outputs[0].text
+    print(f"Prompt: {prompt!r}")
+    print(f"Generated: {generated_text!r}\n")
+```
+
+## Limitations
+
+- **Package not yet open-sourced**: The `flash_attn_npu` package required for FA3 has not yet been released. External users cannot use FA3 until the package is available.
+- **Sliding window not supported**: FA3 does not support sliding window attention. Models that require sliding window need to use the default FIA backend.
+- **ACL graph capture not supported**: The tiling of `flash_attn_with_kvcache` is processed on the host side and currently does not support ACL graph capture. Please use `enforce_eager=True` when enabling FA3.
+- **RoPE not supported**: FA3 does not support rotary position embedding within the attention kernel. vLLM-Ascend patches this by using the PyTorch native RoPE fallback instead.
+- **ALiBi not supported**: FA3 does not support ALiBi (Attention with Linear Biases).
+- **Softcapping not supported**: FA3 does not support attention logit softcapping.
+- **FP8 quantization not supported**: FA3 does not support FP8 quantized attention.
+- **MLA and SFA not supported**: FA3 does not support Multi-head Latent Attention (MLA) or Sparse Flash Attention (SFA).
+
+```{note}
+Enabling FA3 may cause performance degradation compared to the default FIA backend. This trade-off is intentional to guarantee training-inference consistency.
+```
+
+## Tested Models
+
+FA3 has been tested and verified on the following models:
+
+- **Qwen3 (Dense)**: `Qwen/Qwen3-0.6B`, `Qwen/Qwen3-1.7B`, `Qwen/Qwen3-8B`
+- **Qwen3 (MoE)**: `Qwen/Qwen3-30B-A3B`
+
+Other models have not been tested yet and will be supported in the future if not supported after been tested.
+
+## Future Improvements
+
+The FA3 feature is under active development. Planned improvements include:
+
+- Open-source the `flash_attn_npu` package
+- Support ACL graph capture (host-side tiling optimization)
+- Support for additional NPUs series
+- Expanded model coverage
+- Performance optimizations
+- Additional testing and validation

--- a/docs/source/user_guide/feature_guide/index.md
+++ b/docs/source/user_guide/feature_guide/index.md
@@ -30,4 +30,5 @@ weight_prefetch
 sequence_parallelism
 batch_invariance
 lmcache_ascend_deployment
+flash_attention
 :::

--- a/tests/e2e/singlecard/test_attention_fa3.py
+++ b/tests/e2e/singlecard/test_attention_fa3.py
@@ -1,0 +1,153 @@
+"""
+End-to-end test for Flash Attention 3 (FA3) on Ascend.
+
+This test verifies that FA3 produces correct results by comparing its output
+with the default Fused Infer Attention (FIA) backend. Both backends are run
+with the same model and prompts in eager mode, and the generated token ids
+are compared for consistency.
+"""
+
+import os
+from importlib import import_module, util
+
+import pytest
+
+from tests.e2e.conftest import VllmRunner
+
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+os.environ["VLLM_BATCH_INVARIANT"] = "1"
+
+MODEL_NAME = "Qwen/Qwen3-0.6B"
+MAX_MODEL_LEN = 512
+MAX_TOKENS = 32
+
+SHORT_PROMPTS = [
+    "The capital of France is",
+    "In a hole in the ground there lived a hobbit.",
+    "The meaning of life is",
+    "To be or not to be, that is the",
+]
+
+LONG_PROMPT = "The quick brown fox jumps over the lazy dog. " * 50
+
+
+def _fa3_available() -> bool:
+    try:
+        if util.find_spec("flash_attn_npu_v3") is None:
+            return False
+        mod = import_module("flash_attn_npu_v3")
+        return hasattr(mod, "flash_attn_with_kvcache")
+    except ImportError:
+        return False
+
+
+def _generate_with_backend(prompts, max_tokens=MAX_TOKENS, **runner_kwargs):
+    with VllmRunner(
+        MODEL_NAME,
+        max_model_len=MAX_MODEL_LEN,
+        enforce_eager=True,
+        gpu_memory_utilization=0.7,
+        **runner_kwargs,
+    ) as runner:
+        return runner.generate_greedy(prompts, max_tokens)
+
+
+def _generate_logprobs_with_backend(prompts, max_tokens=5, num_logprobs=5, **runner_kwargs):
+    with VllmRunner(
+        MODEL_NAME,
+        max_model_len=MAX_MODEL_LEN,
+        enforce_eager=True,
+        gpu_memory_utilization=0.7,
+        **runner_kwargs,
+    ) as runner:
+        return runner.generate_greedy_logprobs(prompts, max_tokens=max_tokens, num_logprobs=num_logprobs)
+
+
+def _assert_outputs_match(fia_outputs, fa3_outputs, label=""):
+    for i, (fia_out, fa3_out) in enumerate(zip(fia_outputs, fa3_outputs)):
+        fia_ids, fia_text = fia_out
+        fa3_ids, fa3_text = fa3_out
+        assert fia_ids == fa3_ids, (
+            f"{label}Prompt {i}: FA3 and FIA token ids differ.\n"
+            f"  FIA ids: {fia_ids}\n"
+            f"  FA3 ids: {fa3_ids}\n"
+            f"  FIA text: {fia_text}\n"
+            f"  FA3 text: {fa3_text}"
+        )
+
+
+@pytest.mark.skipif(not _fa3_available(), reason="flash_attn_npu_v3 is not installed")
+def test_fa3_vs_fia_single_prompt():
+    """Compare FA3 and FIA with a single prompt (minimal batch size).
+
+    This is an edge case that verifies FA3 works correctly when there
+    is only one sequence in the batch, which may exercise different
+    code paths in the attention kernel.
+    """
+    single_prompt = ["Explain quantum computing in simple terms."]
+    fia_outputs = _generate_with_backend(single_prompt)
+    fa3_outputs = _generate_with_backend(single_prompt, attention_backend="FLASH_ATTN")
+    _assert_outputs_match(fia_outputs, fa3_outputs, label="[SinglePrompt] ")
+
+
+@pytest.mark.skipif(not _fa3_available(), reason="flash_attn_npu_v3 is not installed")
+def test_fa3_vs_fia_mixed_lengths():
+    """Compare FA3 and FIA with mixed prompt lengths in the same batch.
+
+    This exercises both prefill and decode paths within a single batch,
+    verifying that FA3 handles variable-length sequences correctly.
+    """
+    mixed_prompts = [
+        "Hi",
+        "The capital of France is",
+        LONG_PROMPT[:256],
+        "What is 2+2?",
+        LONG_PROMPT[:MAX_MODEL_LEN],
+    ]
+    fia_outputs = _generate_with_backend(mixed_prompts)
+    fa3_outputs = _generate_with_backend(mixed_prompts, attention_backend="FLASH_ATTN")
+    _assert_outputs_match(fia_outputs, fa3_outputs, label="[MixedLen] ")
+
+
+@pytest.mark.skipif(not _fa3_available(), reason="flash_attn_npu_v3 is not installed")
+def test_fa3_vs_fia_with_chunkprefill():
+    """Compare FA3 and FIA with single token generation where chunkprefill is used."""
+    fia_outputs = _generate_with_backend(SHORT_PROMPTS, max_tokens=2, max_num_seqs=2, max_num_batched_tokens=5)
+    fa3_outputs = _generate_with_backend(
+        SHORT_PROMPTS, attention_backend="FLASH_ATTN", max_tokens=2, max_num_seqs=2, max_num_batched_tokens=5
+    )
+    _assert_outputs_match(fia_outputs, fa3_outputs, label="[Chunkprefill] ")
+
+
+@pytest.mark.skipif(not _fa3_available(), reason="flash_attn_npu_v3 is not installed")
+def test_fa3_vs_fia_logprobs():
+    """Compare FA3 and FIA logprobs for fine-grained numerical verification."""
+    fia_logprobs = _generate_logprobs_with_backend(SHORT_PROMPTS[:1])
+    fa3_logprobs = _generate_logprobs_with_backend(SHORT_PROMPTS[:1], attention_backend="FLASH_ATTN")
+
+    for i, (fia_out, fa3_out) in enumerate(zip(fia_logprobs, fa3_logprobs)):
+        fia_ids, _, fia_lp = fia_out
+        fa3_ids, _, fa3_lp = fa3_out
+
+        assert fia_ids == fa3_ids, (
+            f"Prompt {i}: FA3 and FIA token ids differ.\n  FIA ids: {fia_ids}\n  FA3 ids: {fa3_ids}"
+        )
+
+        assert len(fia_lp) == len(fa3_lp), (
+            f"Prompt {i}: Different number of logprob steps: FIA {len(fia_lp)} vs FA3 {len(fa3_lp)}"
+        )
+
+        for t, (fia_token_lp, fa3_token_lp) in enumerate(zip(fia_lp, fa3_lp)):
+            assert set(fia_token_lp.keys()) == set(fa3_token_lp.keys()), (
+                f"Prompt {i}, token {t}: Logprob token sets differ.\n"
+                f"  FIA keys: {sorted(fia_token_lp.keys())}\n"
+                f"  FA3 keys: {sorted(fa3_token_lp.keys())}"
+            )
+            for token_id in fia_token_lp:
+                fia_logprob = fia_token_lp[token_id].logprob
+                fa3_logprob = fa3_token_lp[token_id].logprob
+                assert abs(fia_logprob - fa3_logprob) < 1e-3, (
+                    f"Prompt {i}, token {t}, token_id {token_id} ("
+                    f"'{fia_token_lp[token_id].decoded_token}'): "
+                    f"logprobs differ: FIA {fia_logprob:.6f} vs FA3 {fa3_logprob:.6f}"
+                )

--- a/tests/ut/attention/test_attention_fa3.py
+++ b/tests/ut/attention/test_attention_fa3.py
@@ -1,0 +1,205 @@
+from importlib import import_module, util
+
+import numpy as np
+import pytest
+import torch
+import torch_npu
+
+
+def _fa3_available() -> bool:
+    try:
+        if util.find_spec("flash_attn_npu_v3") is None:
+            return False
+        mod = import_module("flash_attn_npu_v3")
+        return hasattr(mod, "flash_attn_with_kvcache")
+    except ImportError:
+        return False
+
+
+def ref_fused_infer_attention(
+    query,
+    key,
+    value,
+    block_table,
+    block_size,
+    actual_seq_lengths_q,
+    actual_seq_lengths_kv,
+    num_heads,
+    num_kv_heads,
+    head_size,
+    scale,
+    attn_mask,
+    causal,
+):
+    if not causal:
+        attn_output, _ = torch_npu.npu_fused_infer_attention_score(
+            query=query,
+            key=key,
+            value=value,
+            block_table=block_table,
+            input_layout="TND",
+            block_size=block_size,
+            actual_seq_lengths=actual_seq_lengths_q,
+            actual_seq_lengths_kv=actual_seq_lengths_kv,
+            num_key_value_heads=num_kv_heads,
+            num_heads=num_heads,
+            scale=scale,
+            sparse_mode=0,
+        )
+    else:
+        attn_output, _ = torch_npu.npu_fused_infer_attention_score(
+            query=query,
+            key=key,
+            value=value,
+            atten_mask=attn_mask,
+            block_table=block_table,
+            input_layout="TND",
+            block_size=block_size,
+            actual_seq_lengths=actual_seq_lengths_q,
+            actual_seq_lengths_kv=actual_seq_lengths_kv,
+            num_key_value_heads=num_kv_heads,
+            num_heads=num_heads,
+            scale=scale,
+            sparse_mode=3,
+        )
+
+    attn_output = attn_output.view(-1, num_heads, head_size)
+    return attn_output
+
+
+test_cases = [
+    # (data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, block_size, is_causal)
+    (torch.bfloat16, 1, 1, 1, 1024, 1024, 128, 128, False),
+    (torch.bfloat16, 5, 4, 1, 1024, 1024, 128, 128, True),
+    (torch.float16, 7, 16, 8, 512, 512, 128, 128, False),
+]
+
+
+@pytest.mark.skipif(not _fa3_available(), reason="flash_attn_npu_v3 is not installed")
+@pytest.mark.parametrize(
+    "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, block_size, is_causal", test_cases
+)
+def test_fa_custom_ops_tnd(
+    data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, block_size, is_causal
+):
+    q_min_range = -1.0
+    q_max_range = 1.0
+    kv_min_range = -1.0
+    kv_max_range = 1.0
+    block_size = 128
+    num_blocks = 64
+
+    q_sequences = sorted(
+        torch.randint(low=1, high=q_seqlen + 1, size=(batch_size,)).tolist(), reverse=False
+    )  # actual_seq_lengths in fia need in ascending order
+    kv_sequences = [torch.randint(low=q, high=kv_seqlen + 1, size=(1,)).item() for q in q_sequences]
+
+    t_q_sum = sum(q_sequences)
+
+    query = (q_min_range + (q_max_range - q_min_range) * torch.rand(t_q_sum, num_heads, head_size)).to(data_type).npu()
+
+    key_cache = None
+    value_cache = None
+    block_tables = []
+
+    key_cache = (
+        (kv_min_range + (kv_max_range - kv_min_range) * torch.rand(num_blocks, block_size, kv_heads, head_size))
+        .to(data_type)
+        .npu()
+    )
+    value_cache = (
+        (kv_min_range + (kv_max_range - kv_min_range) * torch.rand(num_blocks, block_size, kv_heads, head_size))
+        .to(data_type)
+        .npu()
+    )
+    max_num_blocks_per_seq = (kv_seqlen + block_size - 1) // block_size
+    for i in range(batch_size):
+        block_table = [max_num_blocks_per_seq * i + j for j in range(max_num_blocks_per_seq)]
+        block_tables.append(block_table)
+    block_tables = torch.tensor(block_tables, dtype=torch.int32).npu()
+
+    q_seqlen_list = q_sequences
+    kv_seqlen_list = kv_sequences
+
+    scale = 1.0 / (head_size**0.5)
+    window_size_left = -1
+    window_size_right = -1
+    is_rotary_interleaved = False
+    num_splits = 0
+    kv_seqlen_list = torch.tensor(kv_seqlen_list, dtype=torch.int32).npu()
+    rotary_cos = None
+    rotary_sin = None
+    cache_batch_idx = None
+    leftpad_k = None
+    new_q_seqlen_list = None
+
+    new_q_seqlen_list = [0]
+    pre_seq_sum = 0
+    for i in range(batch_size):
+        pre_seq_sum += q_seqlen_list[i]
+        new_q_seqlen_list.append(pre_seq_sum)
+    new_q_seqlen_list = torch.tensor(new_q_seqlen_list, dtype=torch.int32).npu()
+
+    from flash_attn_npu_v3 import flash_attn_with_kvcache  # type: ignore[import-not-found]
+
+    out_out = flash_attn_with_kvcache(
+        query,
+        key_cache,
+        value_cache,
+        None,
+        None,
+        None,
+        rotary_cos=rotary_cos,
+        rotary_sin=rotary_sin,
+        cache_seqlens=kv_seqlen_list,
+        cache_batch_idx=cache_batch_idx,
+        cache_leftpad=leftpad_k,
+        page_table=block_tables,
+        cu_seqlens_q=new_q_seqlen_list,
+        cu_seqlens_k_new=None,
+        max_seqlen_q=q_seqlen,
+        rotary_seqlens=None,
+        q_descale=None,
+        k_descale=None,
+        v_descale=None,
+        softmax_scale=None,
+        causal=is_causal,
+        window_size=[window_size_left, window_size_right],
+        attention_chunk=0,
+        softcap=0.0,
+        rotary_interleaved=is_rotary_interleaved,
+        scheduler_metadata=None,
+        num_splits=num_splits,
+        pack_gqa=None,
+        sm_margin=0,
+        return_softmax_lse=False,
+    )
+
+    ref_out = torch.empty((t_q_sum, num_heads, head_size), dtype=data_type)
+
+    if is_causal:
+        attn_mask = torch.triu(torch.ones(2048, 2048), diagonal=1).to(torch.int8).to(query.device)
+    else:
+        attn_mask = None
+
+    q_cumsum = torch.tensor(np.cumsum(q_sequences), dtype=torch.int32, device=query.device)
+
+    ref_out = ref_fused_infer_attention(
+        query,
+        key_cache.permute(0, 2, 1, 3).contiguous(),  # [num_blocks, num_kv_heads, block_size, head_size]
+        value_cache.permute(0, 2, 1, 3).contiguous(),
+        block_tables,
+        block_size,
+        q_cumsum,
+        kv_seqlen_list,
+        num_heads,
+        kv_heads,
+        head_size,
+        scale,
+        attn_mask,
+        is_causal,
+    )
+
+    rtol = 1e-2
+    atol = 1e-2
+    torch.testing.assert_close(out_out.cpu(), ref_out.cpu(), rtol=rtol, atol=atol)

--- a/vllm_ascend/attention/fa3_v1.py
+++ b/vllm_ascend/attention/fa3_v1.py
@@ -1,0 +1,145 @@
+import torch
+import vllm.envs as envs_vllm
+from flash_attn_npu_v3 import flash_attn_with_kvcache as _fa3_fn  # type: ignore[import-not-found]
+from vllm.v1.attention.backend import AttentionBackend  # type: ignore
+
+from vllm_ascend.attention.attention_v1 import (
+    AscendAttentionBackendImpl,
+    AscendAttentionMetadataBuilder,
+)
+
+
+class AscendFABackend(AttentionBackend):
+    def __init__(self):
+        super().__init__()
+
+    @staticmethod
+    def get_name() -> str:
+        return "CUSTOM" if not envs_vllm.VLLM_USE_V2_MODEL_RUNNER else "FLASH_ATTN"
+
+    @staticmethod
+    def get_impl_cls() -> type["AscendFAImpl"]:
+        return AscendFAImpl
+
+    @staticmethod
+    def get_builder_cls() -> type["AscendAttentionMetadataBuilder"]:
+        return AscendAttentionMetadataBuilder
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_type: str = "",
+    ) -> tuple[int, ...]:
+        return (2, num_blocks, block_size, num_kv_heads, head_size)
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int]:
+        return [128]
+
+
+class AscendFAImpl(AscendAttentionBackendImpl):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.sliding_window is not None:
+            raise ValueError(
+                "AscendFAImpl does not support sliding window attention. "
+                "Please disable sliding window or use the default FIA backend."
+            )
+        if not self.vllm_config.model_config.enforce_eager:
+            from vllm.config.compilation import CUDAGraphMode
+
+            cudagraph_mode = self.vllm_config.compilation_config.cudagraph_mode
+            if cudagraph_mode == CUDAGraphMode.FULL_DECODE_ONLY:
+                raise ValueError(
+                    "AscendFAImpl does not support ACL graph capture with "
+                    "FULL_DECODE_ONLY mode. Please set enforce_eager=True or "
+                    "not set FULL_DECODE_ONLY or use the default FIA backend."
+                )
+
+    def _flash_attn_with_kvcache(
+        self,
+        query: torch.Tensor,
+        block_table: torch.Tensor,
+        actual_seq_lengths: torch.Tensor,
+        seq_lens: torch.Tensor,
+        is_causal: bool,
+        max_seq_len: int,
+    ):
+        num_block, block_size, _, _ = self.key_cache.shape  # type: ignore
+        key_fa_blk = self.key_cache.view(  # type: ignore
+            num_block, block_size, self.num_kv_heads, self.head_size
+        )
+        value_fa_blk = self.value_cache.view(  # type: ignore
+            num_block, block_size, self.num_kv_heads, self.head_size
+        )
+
+        attn_output = _fa3_fn(
+            query,
+            key_fa_blk,
+            value_fa_blk,
+            cache_seqlens=seq_lens,  # kv sequence length for each individual request (NOT cumulative)
+            page_table=block_table,  # must match the block table for the corresponding q
+            cu_seqlens_q=actual_seq_lengths,  # cumulative sequence length for q
+            max_seqlen_q=max_seq_len,
+            causal=is_causal,
+            window_size=[-1, -1],
+            rotary_interleaved=False,
+            num_splits=1,
+            softcap=0.0,
+            attention_chunk=0,
+            sm_margin=0,
+            return_softmax_lse=False,
+        )
+
+        return attn_output
+
+    def forward_impl(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: tuple[torch.Tensor],
+        attn_metadata,
+        output: torch.Tensor,
+    ):
+        num_tokens = attn_metadata.actual_seq_lengths_q[-1]
+        query = query[:num_tokens]
+
+        num_decodes = attn_metadata.num_decodes
+        num_decode_tokens = attn_metadata.num_decode_tokens
+        num_prefills = attn_metadata.num_prefills
+        outputs = []
+
+        if num_decodes > 0:
+            outputs.append(
+                self._flash_attn_with_kvcache(
+                    query[:num_decode_tokens],
+                    attn_metadata.block_tables[:num_decodes, :],
+                    attn_metadata.query_start_loc[: num_decodes + 1],
+                    attn_metadata.seq_lens[:num_decodes].npu(),
+                    False,
+                    max(attn_metadata.seq_lens[:num_decodes]),
+                )
+            )
+
+        if num_prefills > 0:
+            outputs.append(
+                self._flash_attn_with_kvcache(
+                    query[num_decode_tokens:],
+                    attn_metadata.block_tables[num_decode_tokens:, :],
+                    attn_metadata.query_start_loc[num_decodes:],
+                    attn_metadata.seq_lens[num_decodes:].npu(),
+                    True,  # enable causal for prefill
+                    max(attn_metadata.seq_lens[num_decodes:]),
+                )
+            )
+
+        if not outputs:
+            raise ValueError("No attention output available")
+
+        attn_output_fa = outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=0)
+        output[:num_tokens] = attn_output_fa[:num_tokens]
+        return output

--- a/vllm_ascend/attention/fa3_v1.py
+++ b/vllm_ascend/attention/fa3_v1.py
@@ -10,6 +10,8 @@ from vllm_ascend.attention.attention_v1 import (
 
 
 class AscendFABackend(AttentionBackend):
+    accept_output_buffer: bool = True
+
     def __init__(self):
         super().__init__()
 

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import math
 import os
+from importlib import import_module, util
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
@@ -29,6 +30,8 @@ from vllm.platforms import Platform, PlatformEnum
 
 # todo: please remove it when solve cuda hard code in vllm
 os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
+
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_config import init_ascend_config
@@ -583,6 +586,9 @@ class NPUPlatform(Platform):
     def get_attn_backend_cls(cls, selected_backend, attn_selector_config, num_heads: int | None = None):
         key = (attn_selector_config.use_mla, attn_selector_config.use_sparse)
 
+        if selected_backend == AttentionBackendEnum.FLASH_ATTN and cls._validate_fa3_backend(key, attn_selector_config):
+            return "vllm_ascend.attention.fa3_v1.AscendFABackend"
+
         backend_map = {
             (True, False): "vllm_ascend.attention.mla_v1.AscendMLABackend",
             (False, False): "vllm_ascend.attention.attention_v1.AscendAttentionBackend",
@@ -602,6 +608,33 @@ class NPUPlatform(Platform):
             return backend_map_310.get(key, backend_map_310[(False, False)])
 
         return backend_map[key]
+
+    @classmethod
+    def _validate_fa3_backend(cls, key, attn_selector_config):
+        if not envs_vllm.VLLM_BATCH_INVARIANT:
+            logger.info(
+                "FA3 will not be enabled when not in training-inference consistency scenario. "
+                "Note that Ascend NPU will use its registered plugin backend instead."
+            )
+            return False
+        if key != (False, False):
+            raise ValueError("FA3 backend does not support MLA and SFA.")
+        if util.find_spec("flash_attn_npu_v3") is None:
+            raise ValueError(
+                "flash_attn_npu_v3 is not installed but FA3 backend is requested. "
+                "Please install flash_attn_npu_v3 to enable FA3."
+            )
+        mod = import_module("flash_attn_npu_v3")
+        if not hasattr(mod, "flash_attn_with_kvcache"):
+            raise ValueError(
+                "flash_attn_npu_v3 is installed but does not provide "
+                "flash_attn_with_kvcache. Please check flash_attn_npu_v3 "
+                "whether it supports flash_attn_with_kvcache."
+            )
+        logger.info(
+            "In training-inference consistency scenario, FA3 will be enabled, which may cause performance degradation."
+        )
+        return True
 
     @classmethod
     def get_punica_wrapper(cls) -> str:
@@ -883,14 +916,20 @@ class NPUPlatform(Platform):
                 )
                 att_config.flash_attn_version = None
 
-            # Notify user that the backend will be managed by Ascend plugins
-            if getattr(att_config, "backend", None) is not None:
-                logger.info(
-                    "User specified attention backend '%s'. Note that Ascend NPU "
-                    "will use its registered plugin backend instead. Resetting to None.",
-                    att_config.backend,
-                )
-                att_config.backend = None
+            # Notify user that the backend will be managed by Ascend plugins,
+            # and for training-inference consistency, when att_config.backend
+            # == AttentionBackendEnum.FLASH_ATTN,it is NOT reset to None
+            if (
+                getattr(att_config, "backend", None) is not None
+                and att_config.backend != AttentionBackendEnum.FLASH_ATTN
+            ):
+                if getattr(att_config, "backend", None) is not None:
+                    logger.info(
+                        "User specified attention backend '%s'. Note that Ascend NPU "
+                        "will use its registered plugin backend instead. Resetting to None.",
+                        att_config.backend,
+                    )
+                    att_config.backend = None
 
             # CUDA Graph specific split points are not applicable
             if getattr(att_config, "flash_attn_max_num_splits_for_cuda_graph", 32) != 32:

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -586,7 +586,7 @@ class NPUPlatform(Platform):
     def get_attn_backend_cls(cls, selected_backend, attn_selector_config, num_heads: int | None = None):
         key = (attn_selector_config.use_mla, attn_selector_config.use_sparse)
 
-        if selected_backend == AttentionBackendEnum.FLASH_ATTN and cls._validate_fa3_backend(key, attn_selector_config):
+        if selected_backend == AttentionBackendEnum.FLASH_ATTN and cls._validate_fa3_backend(key):
             return "vllm_ascend.attention.fa3_v1.AscendFABackend"
 
         backend_map = {
@@ -610,7 +610,7 @@ class NPUPlatform(Platform):
         return backend_map[key]
 
     @classmethod
-    def _validate_fa3_backend(cls, key, attn_selector_config):
+    def _validate_fa3_backend(cls, key):
         enable_batch_invariant = int(os.getenv("VLLM_BATCH_INVARIANT", "0")) != 0
         if not enable_batch_invariant:
             logger.info(

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -611,7 +611,8 @@ class NPUPlatform(Platform):
 
     @classmethod
     def _validate_fa3_backend(cls, key, attn_selector_config):
-        if not envs_vllm.VLLM_BATCH_INVARIANT:
+        enable_batch_invariant = int(os.getenv("VLLM_BATCH_INVARIANT", "0")) != 0
+        if not enable_batch_invariant:
             logger.info(
                 "FA3 will not be enabled when not in training-inference consistency scenario. "
                 "Note that Ascend NPU will use its registered plugin backend instead."


### PR DESCRIPTION
### What this PR does / why we need it?
This PR introduces support for Flash Attention 3 (FA3) on Ascend NPUs, providing a FA3 attention backend for training-inference consistency. It includes the implementation of the FA3 backend, integration into the platform's attention selector, and comprehensive tests to ensure correctness with existing backends.([issue 10072](https://github.com/vllm-project/vllm-ascend/issues/10072))

### Does this PR introduce _any_ user-facing change?
Users can use Flash Attention 3 by specifying the flash_attn backend (by setting the LLM parameter **attention_backend="FLASH_ATTN"**) and enabling batch invariance (set **VLLM_BATCH_INVARIANT=1**).

### How was this patch tested?
- End-to-end tests comparing FA3 output with Fused Infer Attention (FIA) for consistency across various prompt lengths and batch sizes.
- Unit tests for the custom FA3 operations.


- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/bcf2be96120005e9aea171927f85055a6a5c0cf6
