### PR TITLE
[BugFix][CI] Fix ACLGraph memory test failures

### DIFF
--- a/tests/e2e/pull_request/one_card/aclgraph/test_aclgraph_mem.py
+++ b/tests/e2e/pull_request/one_card/aclgraph/test_aclgraph_mem.py
@@ -63,18 +63,19 @@ def test_aclgraph_mem_use(model: str, max_tokens: int) -> None:
         ]
         sampling_params = SamplingParams(max_tokens=max_tokens, temperature=0.0)
         if model == "vllm-ascend/DeepSeek-V2-Lite-W8A8":
-            vllm_model = VllmRunner(
+            with VllmRunner(
                 model,
                 max_model_len=1024,
                 quantization="ascend",
                 compilation_config={"cudagraph_mode": "PIECEWISE"},
-            )
+            ) as vllm_model:
+                _ = vllm_model.generate(prompts, sampling_params)
         else:
-            vllm_model = VllmRunner(
+            with VllmRunner(
                 model,
                 compilation_config={"cudagraph_mode": "PIECEWISE"},
-            )
-        _ = vllm_model.generate(prompts, sampling_params)
+            ) as vllm_model:
+                _ = vllm_model.generate(prompts, sampling_params)
 
     assert capture_called.value == 1, "capture_model was not called during test"
     assert capture_mem_before.value != -1, "capture_mem_before not set"

--- a/tests/e2e/pull_request/one_card/aclgraph/test_aclgraph_mem.py
+++ b/tests/e2e/pull_request/one_card/aclgraph/test_aclgraph_mem.py
@@ -31,10 +31,10 @@ MODELS = ["Qwen/Qwen3-0.6B", "vllm-ascend/DeepSeek-V2-Lite-W8A8"]
 
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [4])
+@patch.dict(os.environ, {"VLLM_ENABLE_V1_MULTIPROCESSING": "0"})
 @patch.dict(os.environ, {"VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE": "0"})
 @patch.dict(os.environ, {"ASCEND_RT_VISIBLE_DEVICES": "0,1"})
 def test_aclgraph_mem_use(model: str, max_tokens: int) -> None:
-    del os.environ["VLLM_WORKER_MULTIPROC_METHOD"]
     capture_called = multiprocessing.Value("i", 0)  # int, 0 or 1
     capture_mem_before = multiprocessing.Value("q", -1)  # long long (64-bit)
     capture_mem_after = multiprocessing.Value("q", -1)  # long long
@@ -100,4 +100,3 @@ def test_aclgraph_mem_use(model: str, max_tokens: int) -> None:
         f"Used: {mem_used_by_capture / (1024**3):.2f} GiB, "
         f"Expected: < {max_capture_mem_gib:.2f} GiB"
     )
-    os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"

--- a/tests/e2e/pull_request/one_card/aclgraph/test_aclgraph_mem.py
+++ b/tests/e2e/pull_request/one_card/aclgraph/test_aclgraph_mem.py
@@ -24,6 +24,7 @@ import torch
 from vllm import SamplingParams
 
 from tests.e2e.conftest import VllmRunner
+from tests.e2e.utils import fork_new_process_for_each_test
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
 MODELS = ["Qwen/Qwen3-0.6B", "vllm-ascend/DeepSeek-V2-Lite-W8A8"]
@@ -31,6 +32,7 @@ MODELS = ["Qwen/Qwen3-0.6B", "vllm-ascend/DeepSeek-V2-Lite-W8A8"]
 
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [4])
+@fork_new_process_for_each_test
 @patch.dict(os.environ, {"VLLM_ENABLE_V1_MULTIPROCESSING": "0"})
 @patch.dict(os.environ, {"VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE": "0"})
 @patch.dict(os.environ, {"ASCEND_RT_VISIBLE_DEVICES": "0,1"})


### PR DESCRIPTION
### What this PR does / why we need it?

break:
https://github.com/vllm-project/vllm-ascend/actions/runs/27338811059/job/80770819107?pr=10312#step:13:3438

This PR fixes the ACLGraph memory e2e test failure in: ```tests/e2e/pull_request/one_card/aclgraph/test_aclgraph_mem.py```

error:
``` bash
    File "/__w/vllm-ascend/vllm-ascend/vllm_ascend/worker/worker.py", line 113, in __init__
      check_ascend_device_type()
    File "/__w/vllm-ascend/vllm-ascend/vllm_ascend/utils.py", line 794, in check_ascend_device_type
      soc_version = torch_npu.npu.get_soc_version()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/python3.12.13/lib/python3.12/site-packages/torch_npu/npu/_backends.py", line 97, in get_soc_version
      torch_npu.npu._lazy_init()
    File "/usr/local/python3.12.13/lib/python3.12/site-packages/torch_npu/npu/__init__.py", line 272, in _lazy_init
      raise RuntimeError(
  RuntimeError: Cannot re-initialize NPU in forked subprocess. To use NPU with multiprocessing, you must use the 'spawn' start method [92224,91917][core.py:1186,run_engine_core]
```

The test previously deleted `VLLM_WORKER_MULTIPROC_METHOD` to force vLLM to use `fork`, so the monkeypatch on `NPUModelRunner.capture_model` could be inherited by the worker process.

However, this is unsafe on Ascend. If the parent pytest process has already initialized NPU before forking, the forked child process may fail with:

```text
RuntimeError: Cannot re-initialize NPU in forked subprocess
```

To avoid relying on the unsafe fork path, this PR sets:

```python
VLLM_ENABLE_V1_MULTIPROCESSING=0
```

for this test. This keeps the vLLM V1 engine in the current process, so the `capture_model` monkeypatch still works without triggering the NPU fork re-initialization issue.

After disabling V1 multiprocessing, both parametrized model cases run in the same pytest process. In practice, NPU/CANN/ACLGraph runtime resources may not be fully released by Python-level cleanup alone, so the second model case could still fail with insufficient free NPU memory.

To make the test isolation stronger, this PR also adds:

```python
@fork_new_process_for_each_test
```

so each parametrized case runs in its own test subprocess. When the subprocess exits, process-level NPU resources are released by the runtime/OS.

Finally, `VllmRunner` is changed to use the standard context manager form:

```python
with VllmRunner(...) as vllm_model:
    _ = vllm_model.generate(prompts, sampling_params)
```

so normal vLLM/Ascend cleanup is still performed before the subprocess exits.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
