### PR TITLE
[BugFix] Fix garbled output for Qwen3.6-27B with dflash/suffix num_speculative_tokens > 7

### DIFF
--- a/csrc/attention/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.cpp
+++ b/csrc/attention/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.cpp
@@ -49,7 +49,7 @@ const size_t DIM_1 = 1;
 const size_t DIM_2 = 2;
 const size_t DIM_3 = 3;
 
-const size_t MAX_MTP = 8;
+const size_t MAX_MTP = 16;
 
 template <typename T1, typename T2>
 static T1 CeilDiv(T1 a, T2 b)

--- a/csrc/attention/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule.h
+++ b/csrc/attention/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule.h
@@ -25,7 +25,7 @@ using namespace matmul;
 using namespace AscendC;
 constexpr uint64_t BUFFER_NUM = 1;
 constexpr uint32_t MAX_OUT_BUFFER_NUM = 2;
-constexpr uint64_t MAX_MTP = 8;
+constexpr uint64_t MAX_MTP = 16;
 constexpr uint64_t BF16_NUM_PER_BLOCK = 16;
 constexpr uint64_t FP32_NUM_PER_BLOCK = 8;
 constexpr uint32_t REPEAT_LENTH = 64; // 256Byte for float

--- a/csrc/attention/recurrent_gated_delta_rule_v310/op_host/recurrent_gated_delta_rule_v310_tiling.cpp
+++ b/csrc/attention/recurrent_gated_delta_rule_v310/op_host/recurrent_gated_delta_rule_v310_tiling.cpp
@@ -46,7 +46,7 @@ const size_t DIM_1 = 1;
 const size_t DIM_2 = 2;
 const size_t DIM_3 = 3;
 
-const size_t MAX_MTP = 8;
+const size_t MAX_MTP = 16;
 
 void RecurrentGatedDeltaRuleV310Tiling::InitCompileInfo()
 {

--- a/csrc/attention/recurrent_gated_delta_rule_v310/op_kernel/recurrent_gated_delta_rule_v310.h
+++ b/csrc/attention/recurrent_gated_delta_rule_v310/op_kernel/recurrent_gated_delta_rule_v310.h
@@ -23,7 +23,7 @@ namespace RecurrentGatedDeltaRuleV310 {
 using namespace AscendC;
 constexpr uint64_t BUFFER_NUM = 1;
 constexpr uint32_t MAX_OUT_BUFFER_NUM = 2;
-constexpr uint64_t MAX_MTP = 8;
+constexpr uint64_t MAX_MTP = 16;
 constexpr uint64_t BF16_NUM_PER_BLOCK = 16;
 constexpr uint64_t FP32_NUM_PER_BLOCK = 8;
 constexpr uint32_t REPEAT_LENTH = 64; // 256Byte for float


### PR DESCRIPTION
Fix garbled output for Qwen3.6-27B with dflash/suffix when num_speculative_tokens > 7

### What this PR does / why we need it?

This PR fixes garbled output for Qwen3.6-27B when using dflash/suffix speculative decoding with num_speculative_tokens > 7. The root cause is that the UB (Unified Buffer) memory allocation in the recurrent gated delta rule tiling logic did not correctly account for cases where the actual speculative token count exceeds certain internal buffer limits (8), leading to memory corruption during attention computation. This fix ensures correct buffer sizing and output correctness for all valid num_speculative_tokens values (1–15).

### Does this PR introduce _any_ user-facing change?

No. This is a bugfix with no API or interface changes. Users can now correctly set num_speculative_tokens to values greater than 7 without encountering garbled output.

### How was this patch tested?

Tested manually on Ascend 910B with Qwen3.6-27B using dflash/suffix speculative decoding:

- Run inference with num_speculative_tokens=8 (previously garbled) → output is now correct.
- Run inference with num_speculative_tokens=7 (previously working) → output unchanged, no regression.

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
