### PR TITLE
[BugFix][v0.20.2rc] Preserve GLM streaming tool call name

### DIFF
--- a/tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py
+++ b/tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import MagicMock
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
 from vllm.parser.abstract_parser import _WrappedParser
 from vllm.reasoning.deepseek_v3_reasoning_parser import (
     DeepSeekV3ReasoningWithThinkingParser,
@@ -79,6 +80,10 @@ def test_glm47_streaming_inline_zero_arg_tool_call_waits_until_complete():
     assert second.tool_calls
     assert second.tool_calls[0].function.name == "get_current_time"
     assert json.loads(_collect_tool_args(second.tool_calls)) == {}
+
+    finished = OpenAIServingChat._create_remaining_args_delta(second, "", 0)
+    assert finished.tool_calls[0].function.name == "get_current_time"
+    assert json.loads(_collect_tool_args(finished.tool_calls)) == {}
 
 
 def test_glm45_reasoning_glm47_streaming_inline_zero_arg_tool_call():

--- a/tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py
+++ b/tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py
@@ -14,7 +14,7 @@ from vllm_ascend.patch.platform import (
 )
 
 
-def test_remaining_args_delta_omits_metadata_by_default():
+def test_remaining_args_delta_preserves_metadata_by_default():
     original_delta = DeltaMessage(
         tool_calls=[
             DeltaToolCall(
@@ -37,14 +37,44 @@ def test_remaining_args_delta_omits_metadata_by_default():
 
     tc = result.tool_calls[0]
     assert tc.index == 0
-    assert tc.id is None
-    assert tc.type is None
-    assert tc.function.name is None
+    assert tc.id == "call_current"
+    assert tc.type == "function"
+    assert tc.function.name == "current_name"
     assert tc.function.arguments == "]}"
     serialized = tc.model_dump(exclude_unset=True)
-    assert "id" not in serialized
-    assert "type" not in serialized
-    assert "name" not in serialized["function"]
+    assert serialized["id"] == "call_current"
+    assert serialized["type"] == "function"
+    assert serialized["function"]["name"] == "current_name"
+
+
+def test_empty_remaining_args_delta_keeps_original_delta():
+    original_delta = DeltaMessage(
+        tool_calls=[
+            DeltaToolCall(
+                index=0,
+                id="call_current",
+                type="function",
+                function=DeltaFunctionCall(
+                    name="current_name",
+                    arguments="",
+                ),
+            ),
+            DeltaToolCall(
+                index=0,
+                function=DeltaFunctionCall(arguments="{}"),
+            ),
+        ]
+    )
+
+    result = OpenAIServingChat._create_remaining_args_delta(
+        original_delta,
+        "",
+        0,
+    )
+
+    assert result is original_delta
+    assert result.tool_calls[0].function.name == "current_name"
+    assert result.tool_calls[1].function.arguments == "{}"
 
 
 def test_remaining_args_delta_uses_explicit_fallback_metadata():

--- a/vllm_ascend/patch/platform/patch_glm_tool_call_streaming.py
+++ b/vllm_ascend/patch/platform/patch_glm_tool_call_streaming.py
@@ -39,18 +39,36 @@ def _create_remaining_args_delta(
     fallback_tool_call_type: str | None = None,
     fallback_tool_call_name: str | None = None,
 ) -> DeltaMessage:
+    if remaining_call == "":
+        return delta_message
+
+    original_tool_call = next(
+        (tool_call for tool_call in delta_message.tool_calls if tool_call.index == index),
+        None,
+    )
+    original_function = original_tool_call.function if original_tool_call else None
+
     function_kwargs: dict[str, str] = {"arguments": remaining_call}
-    if fallback_tool_call_name is not None:
-        function_kwargs["name"] = fallback_tool_call_name
+    function_name = original_function.name if original_function else None
+    if function_name is None:
+        function_name = fallback_tool_call_name
+    if function_name is not None:
+        function_kwargs["name"] = function_name
 
     tool_call_kwargs: dict[str, Any] = {
         "index": index,
         "function": DeltaFunctionCall(**function_kwargs),
     }
-    if fallback_tool_call_id is not None:
-        tool_call_kwargs["id"] = fallback_tool_call_id
-    if fallback_tool_call_type is not None:
-        tool_call_kwargs["type"] = fallback_tool_call_type
+    tool_call_id = original_tool_call.id if original_tool_call else None
+    if tool_call_id is None:
+        tool_call_id = fallback_tool_call_id
+    if tool_call_id is not None:
+        tool_call_kwargs["id"] = tool_call_id
+    tool_call_type = original_tool_call.type if original_tool_call else None
+    if tool_call_type is None:
+        tool_call_type = fallback_tool_call_type
+    if tool_call_type is not None:
+        tool_call_kwargs["type"] = tool_call_type
 
     return DeltaMessage(tool_calls=[DeltaToolCall(**tool_call_kwargs)])
 


### PR DESCRIPTION
## Summary
- backport #10361 to releases/v0.20.2rc
- preserve GLM streaming tool-call id/type/function.name when appending remaining arguments
- keep the parser-produced delta unchanged when remaining_call is empty, so zero-arg tool calls keep function.name and arguments

## Trigger condition
This is triggered when GLM streaming tool calls run with the thinking parser disabled. The GLM47 parser can emit the correct tool-call name and empty arguments, but the vllm-ascend streaming monkeypatch may rebuild the final delta via _create_remaining_args_delta. When remaining_call is empty, the old code can replace the parser delta with a new tool call whose function.name is missing/empty.

## Validation
- ruff format --check vllm_ascend/patch/platform/patch_glm_tool_call_streaming.py tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py
- ruff check vllm_ascend/patch/platform/patch_glm_tool_call_streaming.py tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py
- git diff origin/releases/v0.20.2rc --check
- python -m py_compile vllm_ascend/patch/platform/patch_glm_tool_call_streaming.py tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py
- local GLM47 inline zero-arg parser/helper smoke: PASS
- patch applyability checked on a clean origin/releases/v0.20.2rc worktree

Focused pytest was attempted but could not run locally because this container's /vllm-workspace/vllm does not match the release CI vLLM baseline and fails during tests/ut/conftest.py import before collecting these tests.