### PR TITLE
[RoPE][BugFix] Make Triton RoPE head tiling UB-aware

### DIFF
--- a/vllm_ascend/ops/triton/rope.py
+++ b/vllm_ascend/ops/triton/rope.py
@@ -279,18 +279,54 @@ def rope_forward_triton(
 
     num_tokens, n_q_head, head_dim = q.shape
     n_kv_head = k.shape[1]
-    # TODO: use a more robust method to get BLOCK_SIZE_HEAD
-    if is_neox_style:
-        BLOCK_SIZE_HEAD = 64
+    use_cos_sin_cache = cos_sin_cache is not None and positions is not None
+    use_cos_sin = cos is not None and sin is not None
+    if use_cos_sin_cache:
+        assert positions.shape[0] == num_tokens
+        if rope_dim == -1:
+            rope_dim = cos_sin_cache.shape[-1]
+    elif use_cos_sin:
+        assert cos.shape[0] == num_tokens and sin.shape[0] == num_tokens
+        cos = cos.view(num_tokens, -1)
+        sin = sin.view(num_tokens, -1)
+        if rope_dim == -1:
+            rope_dim = cos.shape[-1] * 2
     else:
-        BLOCK_SIZE_HEAD = 32
+        raise ValueError(
+            "Currently, rope_forward_triton supports passing:\n"
+            "1. positions and original cos_sin_cache.\n"
+            "2. cos and sin which are already selected by positions\n"
+            "Please check whether you call rope_forward_triton correctly."
+        )
+    assert rope_dim <= head_dim
+    pad_rope_dim = triton.next_power_of_2(rope_dim)
+    elements_per_head = max(1, pad_rope_dim // 2 if is_neox_style else pad_rope_dim)
+    # legacy tiling
+    legacy_layout_cap = 64 if is_neox_style else 32
+
+    # tiling by ub budget
+    ub_size_bytes = 192 * 1024
+    ub_reserve_bytes = 8 * 1024
+    # Empirical UB budget factor for one logical RoPE tile element. If a
+    # larger-rope model still hits UB overflow here, increase this factor to
+    # make ub_cap and BLOCK_SIZE_HEAD more conservative.
+    ub_bytes_per_tile_element = 32
+    ub_tile_elements = (ub_size_bytes - ub_reserve_bytes) // ub_bytes_per_tile_element
+    raw_ub_cap = ub_tile_elements // elements_per_head
+    if raw_ub_cap < 1:
+        raise ValueError(f"rope_dim={rope_dim} is too large for the Triton RoPE kernel UB budget.")
+
+    # Round UB cap down to a power-of-two tile; e.g. 48 falls back to 32.
+    ub_cap = 1 << (raw_ub_cap.bit_length() - 1)
+
+    BLOCK_SIZE_HEAD = min(
+        legacy_layout_cap,
+        ub_cap,
+    )
     num_vectorcore = get_vectorcore_num()
     n_row = min(num_tokens, num_vectorcore)
 
-    if cos_sin_cache is not None and positions is not None:
-        assert positions.shape[0] == num_tokens
-        assert rope_dim <= head_dim
-        pad_rope_dim = triton.next_power_of_2(rope_dim)
+    if use_cos_sin_cache:
         _triton_rope[(n_row,)](
             q,
             q.stride(0),
@@ -313,16 +349,7 @@ def rope_forward_triton(
             IS_NEOX_STYLE=is_neox_style,
             USE_COS_SIN=True,
         )
-    elif cos is not None and sin is not None:
-        assert cos.shape[0] == num_tokens and sin.shape[0] == num_tokens
-        cos = cos.view(num_tokens, -1)
-        sin = sin.view(num_tokens, -1)
-        if rope_dim == -1:
-            # If rope_dim is not specified, we assume that input cos/sin is not
-            # duplicated to rope_dim, which means rope_dim == cos.shape[-1] * 2
-            rope_dim = cos.shape[-1] * 2
-        assert rope_dim <= head_dim
-        pad_rope_dim = triton.next_power_of_2(rope_dim)
+    else:
         _triton_rope[(n_row,)](
             q,
             q.stride(0),
@@ -344,13 +371,6 @@ def rope_forward_triton(
             BLOCK_SIZE_HEAD=BLOCK_SIZE_HEAD,
             IS_NEOX_STYLE=is_neox_style,
             USE_COS_SIN=False,
-        )
-    else:
-        raise ValueError(
-            "Currently, rope_forward_triton supports passing:\n"
-            "1. positions and original cos_sin_cache.\n"
-            "2. cos and sin which are already selected by positions\n"
-            "Please check whether you call rope_forward_triton correctly."
         )
     return q, k
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR makes the Triton RoPE `BLOCK_SIZE_HEAD` selection UB-aware on Ascend NPU.

Previously, the RoPE kernel used fixed head tile sizes:

```python
BLOCK_SIZE_HEAD = 64  # NeoX layout
BLOCK_SIZE_HEAD = 32  # interleaved layout
```
This only considered the RoPE layout and did not account for larger rope_dim values. For models such as Gemma4, a large rope_dim can make the fixed tile exceed the 192 KiB UB limit and trigger UB overflow.
The new logic computes BLOCK_SIZE_HEAD from:
- the legacy layout cap,
- the UB budget derived from rope_dim / pad_rope_dim,
- an NPU-friendly 32x tiling preference when UB allows it.

This keeps common small-rope_dim cases close to the previous behavior, while automatically reducing the tile size for larger RoPE dimensions to avoid UB overflow.

- NeoX Layout
`legacy_layout_cap = 64`，`elements_per_head = pad_rope_dim / 2`。

| rope_dim | pad_rope_dim | elements_per_head | legacy_layout_cap | raw_ub_cap | ub_cap | BLOCK_SIZE_HEAD |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 64 | 64 | 32 | 64 | 184 | 128 | 64 |
| 128 | 128 | 64 | 64 | 92 | 64 | 64 |
| 256 | 256 | 128 | 64 | 46 | 32 | 32 |
| 512 | 512 | 256 | 64 | 23 | 16 | 16 |
| 1024 | 1024 | 512 | 64 | 11 | 8 | 8 |

- Interleaved Layout
`legacy_layout_cap = 32`，`elements_per_head = pad_rope_dim`。

| rope_dim | pad_rope_dim | elements_per_head | legacy_layout_cap | raw_ub_cap | ub_cap | BLOCK_SIZE_HEAD |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 64 | 64 | 64 | 32 | 92 | 64 | 32 |
| 128 | 128 | 128 | 32 | 46 | 32 | 32 |
| 256 | 256 | 256 | 32 | 23 | 16 | 16 |
| 512 | 512 | 512 | 32 | 11 | 8 | 8 |
| 1024 | 1024 | 1024 | 32 | 5 | 4 | 4 |
### Does this PR introduce any user-facing change?
No

### How was this patch tested?
hardware: atlas 910C
model: gemma-4-26b-a4b-it/deepseek-v4-flash-w8a8-mtp
- Verified that the Gemma4 model can start successfully with the updated RoPE tiling logic.
- Verified that the Triton RoPE kernel can be compiled successfully on Ascend NPU.
- Verified that the model accuracy test passes with the patch applied.

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
