### PR TITLE
[CI][Test] Add MTP speculative decoding test for DeepSeek V4

### DIFF
--- a/tests/e2e/pull_request/four_card/test_deepseek_v4.py
+++ b/tests/e2e/pull_request/four_card/test_deepseek_v4.py
@@ -36,7 +36,6 @@ def test_deepseek_v4_w4a8_tp4_basic_greedy():
     """Verify DeepSeek V4 W4A8 basic greedy generation with TP4 and EP."""
     example_prompts = [
         "Hello, my name is",
-        "The capital of France is",
         "What is the meaning of life?",
     ]
     max_tokens = 5
@@ -56,13 +55,18 @@ def test_deepseek_v4_w4a8_tp4_basic_greedy():
         compilation_config={
             "cudagraph_mode": "FULL_DECODE_ONLY",
         },
+        speculative_config={"num_speculative_tokens": 1, "method": "mtp", "enforce_eager": True},
     ) as vllm_model:
         outputs = vllm_model.generate_greedy(example_prompts, max_tokens)
-
+        expected_token_ids = [
+            [19923, 14, 1026, 2329, 344, 680, 2852, 95, 305, 342],
+            [3085, 344, 270, 5281, 294, 1988, 33, 3955, 361, 582, 3085, 344],
+        ]
         assert len(outputs) == len(example_prompts)
-        for output_ids, output_str in outputs:
+        for i, (output_ids, output_str) in enumerate(outputs):
             assert len(output_str) > 0
             assert len(output_ids) > 0
+            assert output_ids == expected_token_ids[i]
 
 
 @patch.dict(


### PR DESCRIPTION
### What this PR does / why we need it?

This PR enhances the DeepSeek V4 e2e test case by adding MTP (Multi-Token Prediction) speculative decoding validation and deterministic token-level output checks.

Main changes:

- Add `speculative_config` with MTP method (`num_speculative_tokens=1`, `enforce_eager=True`) to the `test_deepseek_v4_w4a8_tp4_basic_greedy` test case
- Add expected token IDs validation to verify deterministic output correctness
- Remove redundant test prompt to streamline the test

### Does this PR introduce *any* user-facing change?

No. This PR only modifies CI test code and does not change runtime behavior, APIs, or model behavior.

### How was this patch tested?

Tested via e2e test execution on Ascend NPU with TP4 configuration.

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
