### PR TITLE
[Feature][DSv4] Backport vLLM #43447 prefix-cache (block-reuse + sliding-window retention) for vLLM 0.21.0

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -372,6 +372,7 @@
   tests:
     - tests/ut/patch
     - tests/ut/test_compressed_prefix_cache.py
+    - tests/ut/core/test_prefix_cache_retention.py
     - tests/e2e/pull_request/one_card/test_qwen3_0_6b.py
     - tests/e2e/pull_request/one_card/test_qwen3_5_0_8b.py
 

--- a/tests/ut/core/test_prefix_cache_retention.py
+++ b/tests/ut/core/test_prefix_cache_retention.py
@@ -1,0 +1,304 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Unit tests for the SWA prefix-cache retention three-state (vLLM PR #43447).
+
+These cover the parts that the DSv4 prefix-cache patch backports onto vLLM
+v0.21.0:
+
+* ``SlidingWindowManager.reachable_block_mask`` (the pure mask algorithm,
+  including the deliberate deviation that env-unset / ``None`` keeps the dense
+  cache-all behavior),
+* ``BlockPool.cache_full_blocks(block_mask=...)`` (the null-swap mask plumbing
+  that v0.21.0 lacks),
+* ``_validate_prefix_cache_retention_interval`` (the no-SWA-group / negative /
+  non-multiple failure modes, incl. the SlidingWindowMLASpec acceptance fix).
+
+The patches attach methods onto the upstream vLLM classes, so importing this
+module requires vLLM (as on the CI / NPU environment); ``TestBase`` applies the
+ascend patches for us.
+"""
+
+from types import SimpleNamespace
+
+from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
+from vllm.v1.kv_cache_interface import SlidingWindowSpec
+
+from tests.ut.base import TestBase
+from vllm_ascend.patch.platform.patch_kv_cache_coordinator import (
+    _SLIDING_WINDOW_SPECS,
+    _validate_prefix_cache_retention_interval,
+)
+
+
+def _swa_spec(block_size: int, sliding_window: int) -> SlidingWindowSpec:
+    """Build a minimal ``SlidingWindowSpec`` instance.
+
+    ``reachable_block_mask`` only reads ``block_size`` and ``sliding_window`` and
+    asserts ``isinstance(spec, SlidingWindowSpec)``. ``SlidingWindowSpec`` is a
+    frozen dataclass with many required fields, so we bypass ``__init__`` and set
+    just the two attributes the algorithm touches.
+    """
+    spec = object.__new__(SlidingWindowSpec)
+    object.__setattr__(spec, "block_size", block_size)
+    object.__setattr__(spec, "sliding_window", sliding_window)
+    return spec
+
+
+def _mask(
+    *,
+    start_block,
+    end_block,
+    alignment_tokens,
+    block_size,
+    sliding_window,
+    use_eagle=False,
+    retention_interval=None,
+    num_prompt_tokens=None,
+):
+    return SlidingWindowManager.reachable_block_mask(
+        start_block=start_block,
+        end_block=end_block,
+        alignment_tokens=alignment_tokens,
+        kv_cache_spec=_swa_spec(block_size, sliding_window),
+        use_eagle=use_eagle,
+        retention_interval=retention_interval,
+        num_prompt_tokens=num_prompt_tokens,
+    )
+
+
+def _cached_set(mask, start_block=0):
+    """Indices (absolute block ids) whose mask entry is True."""
+    return {start_block + i for i, keep in enumerate(mask) if keep}
+
+
+class TestReachableBlockMask(TestBase):
+    """Pure-function coverage of the three-state mask algorithm."""
+
+    def test_default_none_caches_all_swa(self):
+        # Deviation from PR #43447 + our hard requirement: env unset (None) must
+        # return None so cache_full_blocks caches every block (dense cache-all).
+        mask = _mask(
+            start_block=0,
+            end_block=16,
+            alignment_tokens=128,
+            block_size=8,
+            sliding_window=8,
+            retention_interval=None,
+            num_prompt_tokens=128,
+        )
+        self.assertIsNone(mask)
+
+    def test_dense_equivalence_path_ignores_alignment(self):
+        # The dense safety net (None) must not depend on scheduler_block_size:
+        # even with alignment_tokens=None it returns None.
+        mask = _mask(
+            start_block=0,
+            end_block=8,
+            alignment_tokens=None,
+            block_size=8,
+            sliding_window=8,
+            retention_interval=None,
+            num_prompt_tokens=64,
+        )
+        self.assertIsNone(mask)
+
+    def test_interval_64_segment_tails_plus_replay(self):
+        # interval=64, block_size=8 -> per_segment=8; sliding_window=8 -> need=1.
+        # Each 8-block segment keeps only its last block (offset 7 within the
+        # segment), plus the replay tail near the latest prompt boundary.
+        mask = _mask(
+            start_block=0,
+            end_block=16,
+            alignment_tokens=64,
+            block_size=8,
+            sliding_window=8,
+            retention_interval=64,
+            num_prompt_tokens=128,
+        )
+        # Segment tails: block 7 (segment 0) and block 15 (segment 1).
+        # latest = (128-1)//64*64 = 64 -> prompt_end_block = 64//8 = 8 ->
+        # replay range [8-1, 8) = {7}. So cached = {7, 15}.
+        self.assertEqual(_cached_set(mask), {7, 15})
+
+    def test_latest_only_zero(self):
+        # retention=0 -> no per-segment tails, only the replay tail survives.
+        mask = _mask(
+            start_block=0,
+            end_block=16,
+            alignment_tokens=64,
+            block_size=8,
+            sliding_window=8,
+            retention_interval=0,
+            num_prompt_tokens=128,
+        )
+        # latest = 64, prompt_end_block = 8, need = 1 -> replay {7}.
+        self.assertEqual(_cached_set(mask), {7})
+
+    def test_eagle_zero(self):
+        # use_eagle=True, 127 tokens, block_size=8, window=8 -> need=2, shift=1,
+        # latest=96, prompt_end_block=96//8 + 1 = 13 -> cached={11,12}.
+        mask = _mask(
+            start_block=0,
+            end_block=16,
+            alignment_tokens=32,
+            block_size=8,
+            sliding_window=8,
+            use_eagle=True,
+            retention_interval=0,
+            num_prompt_tokens=127,
+        )
+        self.assertEqual(_cached_set(mask), {11, 12})
+
+    def test_need_ge_per_segment_folds_to_none(self):
+        # window large enough that need >= per_segment: the whole segment is in
+        # reach, so nothing can be dropped -> dense fallback (None).
+        mask = _mask(
+            start_block=0,
+            end_block=16,
+            alignment_tokens=16,
+            block_size=8,
+            sliding_window=64,  # need = cdiv(63, 8) = 8 >= per_segment(=2)
+            retention_interval=16,
+            num_prompt_tokens=128,
+        )
+        self.assertIsNone(mask)
+
+    def test_start_block_offset_respected(self):
+        # Already-cached prefix (start_block>0): mask length == end-start and
+        # indices stay absolute. interval=64 -> per_segment=8, need=1.
+        mask = _mask(
+            start_block=8,
+            end_block=16,
+            alignment_tokens=64,
+            block_size=8,
+            sliding_window=8,
+            retention_interval=64,
+            num_prompt_tokens=128,
+        )
+        self.assertEqual(len(mask), 8)
+        # Segment-1 tail is block 15; replay tail (latest=64 -> end_block 8) is
+        # below start_block=8, so only {15} remains.
+        self.assertEqual(_cached_set(mask, start_block=8), {15})
+
+
+class TestCacheFullBlocksMask(TestBase):
+    """Directly exercise the BlockPool.cache_full_blocks(block_mask=...) patch."""
+
+    def _make_block_pool(self):
+        from vllm.v1.core.block_pool import BlockPool
+
+        # Small real pool: caching enabled, no KV events.
+        return BlockPool(
+            num_gpu_blocks=16,
+            enable_caching=True,
+            hash_block_size=8,
+            enable_kv_cache_events=False,
+        )
+
+    def _request(self, num_blocks, block_size):
+        # cache_full_blocks reads request.block_hashes / all_token_ids; provide
+        # enough distinct chained hashes for num_blocks full blocks.
+        block_hashes = [bytes([i]) * 4 for i in range(num_blocks + 2)]
+        return SimpleNamespace(
+            request_id="req-mask",
+            block_hashes=block_hashes,
+            all_token_ids=list(range(num_blocks * block_size)),
+            lora_request=None,
+        )
+
+    def test_mask_caches_only_unmasked_and_restores_blocks(self):
+        block_pool = self._make_block_pool()
+        block_size = 8
+        blocks = block_pool.get_new_blocks(3)
+        original = list(blocks)
+        request = self._request(num_blocks=3, block_size=block_size)
+
+        block_pool.cache_full_blocks(
+            request=request,
+            blocks=blocks,
+            num_cached_blocks=0,
+            num_full_blocks=3,
+            block_size=block_size,
+            kv_cache_group_id=0,
+            block_mask=[True, False, True],
+        )
+
+        # Unmasked blocks (0, 2) get a block_hash; masked block (1) stays None.
+        self.assertIsNotNone(blocks[0].block_hash)
+        self.assertIsNone(blocks[1].block_hash)
+        self.assertIsNotNone(blocks[2].block_hash)
+        # The request's block list is restored verbatim (no null pollution).
+        self.assertEqual(blocks, original)
+
+    def test_mask_none_caches_all(self):
+        block_pool = self._make_block_pool()
+        block_size = 8
+        blocks = block_pool.get_new_blocks(2)
+        request = self._request(num_blocks=2, block_size=block_size)
+
+        block_pool.cache_full_blocks(
+            request=request,
+            blocks=blocks,
+            num_cached_blocks=0,
+            num_full_blocks=2,
+            block_size=block_size,
+            kv_cache_group_id=0,
+            block_mask=None,
+        )
+
+        self.assertIsNotNone(blocks[0].block_hash)
+        self.assertIsNotNone(blocks[1].block_hash)
+
+
+class TestValidateRetentionInterval(TestBase):
+    """Validation failure modes (vLLM PR #43447 (3))."""
+
+    def _config_with_specs(self, specs):
+        groups = [SimpleNamespace(kv_cache_spec=s) for s in specs]
+        return SimpleNamespace(kv_cache_groups=groups)
+
+    def test_none_is_noop(self):
+        cfg = self._config_with_specs([SimpleNamespace()])  # no SWA group
+        # None must never raise, even without an SWA group.
+        _validate_prefix_cache_retention_interval(None, 128, cfg)
+
+    def test_reject_no_sliding_window_group(self):
+        cfg = self._config_with_specs([SimpleNamespace()])
+        with self.assertRaisesRegex(ValueError, "no sliding-window KV cache group"):
+            _validate_prefix_cache_retention_interval(64, 64, cfg)
+
+    def test_reject_non_multiple(self):
+        cfg = self._config_with_specs([_swa_spec(8, 8)])
+        with self.assertRaisesRegex(ValueError, "multiple of the cache-hit alignment"):
+            _validate_prefix_cache_retention_interval(33, 32, cfg)
+
+    def test_reject_negative(self):
+        cfg = self._config_with_specs([_swa_spec(8, 8)])
+        # -32 % 32 == 0 but must still be rejected by the explicit < 0 check.
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            _validate_prefix_cache_retention_interval(-32, 32, cfg)
+
+    def test_mla_swa_spec_accepted(self):
+        # DSv4 SWA is SlidingWindowMLASpec; the validator must treat it as an
+        # SWA group (else DSv4 + retention wrongly reports "no SWA group").
+        mla_spec_cls = _SLIDING_WINDOW_SPECS[-1]
+        spec = object.__new__(mla_spec_cls)
+        object.__setattr__(spec, "block_size", 128)
+        object.__setattr__(spec, "sliding_window", 128)
+        cfg = self._config_with_specs([spec])
+        # A valid multiple should not raise for an MLA-SWA group.
+        _validate_prefix_cache_retention_interval(128, 128, cfg)

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -110,6 +110,16 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
+    # Retain sparse sliding-window KV checkpoints for prefix caching.
+    # Unset (None, default): dense local checkpointing (current behavior, byte-for-byte).
+    # 0: keep only the latest completed prompt (replay) boundary.
+    # >0: keep one tail per interval-sized segment (must be a multiple of
+    #     scheduler_block_size). Applies to SWA only, not Mamba/linear attn.
+    "VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL": lambda: (
+        int(os.environ["VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL"])
+        if "VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL" in os.environ
+        else None
+    ),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -115,9 +115,9 @@ env_variables: dict[str, Callable[[], Any]] = {
     # 0: keep only the latest completed prompt (replay) boundary.
     # >0: keep one tail per interval-sized segment (must be a multiple of
     #     scheduler_block_size). Applies to SWA only, not Mamba/linear attn.
-    "VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL": lambda: (
-        int(os.environ["VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL"])
-        if "VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL" in os.environ
+    "VLLM_PREFIX_CACHE_RETENTION_INTERVAL": lambda: (
+        int(os.environ["VLLM_PREFIX_CACHE_RETENTION_INTERVAL"])
+        if "VLLM_PREFIX_CACHE_RETENTION_INTERVAL" in os.environ
         else None
     ),
 }

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -237,6 +237,38 @@
 #       Remove this patch once upstream vLLM supports hybrid KV cache + CP for
 #       non-CUDA backends, or exposes a platform hook for this behavior.
 #
+# ** 10b. File: platform/patch_prefix_cache_core.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.v1.core.kv_cache_utils.FreeKVCacheBlockQueue.prepend_n`
+#   2. `vllm.v1.core.block_pool.BlockPool.free_blocks`
+#   3. `vllm.v1.core.block_pool.BlockPool.cache_full_blocks`
+#   4. `vllm.v1.core.single_type_kv_cache_manager.SingleTypeKVCacheManager.remove_skipped_blocks`
+#   5. `vllm.v1.core.single_type_kv_cache_manager.SlidingWindowManager.reachable_block_mask`
+#      (+ `_contiguous_blocks_for_hit` helper and `cache_blocks` override)
+#   6. `vllm.v1.core.single_type_kv_cache_manager.SlidingWindowManager.free`
+#    Why:
+#       The DeepSeek V4 prefix-cache coordinator patch relies on the vLLM core
+#       block-reuse behavior added by vLLM PR #43447. Older supported vLLM
+#       versions do not expose `free_blocks(prepend=...)` nor a `block_mask`
+#       argument on `cache_full_blocks`, so short/SWA prefix cache paths can
+#       recycle local blocks with poor priority and have nowhere to apply a
+#       sparse SWA retention mask.
+#    How:
+#       Monkey-patch the missing free-list/front-insertion behavior, add a
+#       `block_mask` argument to `cache_full_blocks`, and inject the SWA
+#       retention three-state mask (`reachable_block_mask` + `cache_blocks`).
+#       Each patch is guarded by capability/source checks so it is skipped
+#       once the underlying vLLM already provides the upstream behavior.
+#       NOTE: When `VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL` is unset (None),
+#       the mask is None and `cache_full_blocks` runs verbatim, so the dense
+#       prefix-cache behavior is byte-for-byte unchanged (deliberate deviation
+#       from PR #43447, whose unset/dense default sparsifies per segment).
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/43447
+#    Future Plan:
+#       Remove this patch once the supported vLLM version contains vLLM PR
+#       #43447 or equivalent prefix-cache block-reuse behavior.
+#
 # ** 10. File: platform/patch_kv_cache_interface.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.kv_cache_interface.MLAAttentionSpec`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -44,6 +44,7 @@ if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXP
 
 import vllm_ascend.patch.platform.patch_balance_schedule  # noqa
 
+import vllm_ascend.patch.platform.patch_prefix_cache_core  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_coordinator  # noqa
 import vllm_ascend.patch.platform.patch_speculative_config  # noqa
 

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -73,6 +73,7 @@ def _validate_prefix_cache_retention_interval(
             f"({alignment_tokens})."
         )
 
+
 def _is_deepseek_v4_kv_cache_spec(kv_cache_spec: KVCacheSpec) -> bool:
     if getattr(kv_cache_spec, "model_version", None) == "deepseek_v4":
         return True

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -200,6 +200,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                 )
             else:
                 manager.cache_blocks(request, num_computed_tokens)
+
     def _get_effective_block_size(self, kv_cache_spec: KVCacheSpec) -> int:
         block_size = kv_cache_spec.block_size
         if isinstance(kv_cache_spec, MambaSpec) and self.enable_caching:

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -52,7 +52,7 @@ def _validate_prefix_cache_retention_interval(
     alignment_tokens: int,
     kv_cache_config: KVCacheConfig,
 ) -> None:
-    """Validate VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL (vLLM PR #43447 (3)).
+    """Validate VLLM_PREFIX_CACHE_RETENTION_INTERVAL (vLLM PR #43447 (3)).
 
     No-op when unset. When set, the model must have at least one sliding-window
     KV cache group (otherwise retention has no effect), and the value must be a
@@ -62,13 +62,13 @@ def _validate_prefix_cache_retention_interval(
         return
     if not any(isinstance(g.kv_cache_spec, _SLIDING_WINDOW_SPECS) for g in kv_cache_config.kv_cache_groups):
         raise ValueError(
-            "VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL is set but this "
+            "VLLM_PREFIX_CACHE_RETENTION_INTERVAL is set but this "
             "model has no sliding-window KV cache group, so retention has no "
             "effect."
         )
     if retention_interval < 0 or retention_interval % alignment_tokens != 0:
         raise ValueError(
-            f"VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL ({retention_interval}) "
+            f"VLLM_PREFIX_CACHE_RETENTION_INTERVAL ({retention_interval}) "
             f"must be non-negative and a multiple of the cache-hit alignment "
             f"({alignment_tokens})."
         )
@@ -181,7 +181,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
 
         # Prefix-cache SWA retention (vLLM PR #43447). None (env unset) keeps the
         # dense cache-all behavior byte-for-byte.
-        self.retention_interval = envs.VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL
+        self.retention_interval = envs.VLLM_PREFIX_CACHE_RETENTION_INTERVAL
         _validate_prefix_cache_retention_interval(self.retention_interval, self.lcm_block_size, kv_cache_config)
 
     def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -170,6 +170,36 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
 
         self.use_eagle = use_eagle
 
+        # Expose the cache-hit alignment + EAGLE flag on each manager so the SWA
+        # retention mask (vLLM PR #43447) can compute reachable blocks. One-time,
+        # zero hot-path cost. ``lcm_block_size`` is the logical/compressed hit
+        # alignment computed in verify_and_split_kv_cache_groups().
+        for i, manager in enumerate(self.single_type_managers):
+            manager.use_eagle = i in self.eagle_group_ids
+            manager.scheduler_block_size = self.lcm_block_size
+
+        # Prefix-cache SWA retention (vLLM PR #43447). None (env unset) keeps the
+        # dense cache-all behavior byte-for-byte.
+        self.retention_interval = envs.VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL
+        _validate_prefix_cache_retention_interval(self.retention_interval, self.lcm_block_size, kv_cache_config)
+
+    def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
+        """Cache blocks for the request, forwarding the SWA retention knob.
+
+        SWA managers accept ``retention_interval``; other managers (compress /
+        full-attention) accept it only to keep a uniform signature and ignore it.
+        We dispatch on ``isinstance(..., SlidingWindowManager)`` rather than
+        signature reflection to avoid per-request overhead.
+        """
+        for manager in self.single_type_managers:
+            if isinstance(manager, SlidingWindowManager):
+                manager.cache_blocks(
+                    request,
+                    num_computed_tokens,
+                    retention_interval=self.retention_interval,
+                )
+            else:
+                manager.cache_blocks(request, num_computed_tokens)
     def _get_effective_block_size(self, kv_cache_spec: KVCacheSpec) -> int:
         block_size = kv_cache_spec.block_size
         if isinstance(kv_cache_spec, MambaSpec) and self.enable_caching:

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -17,20 +17,61 @@ from vllm.v1.core.kv_cache_utils import (
     BlockHashListWithBlockSize,
     KVCacheBlock,
 )
-from vllm.v1.core.single_type_kv_cache_manager import SingleTypeKVCacheManager
+from vllm.v1.core.single_type_kv_cache_manager import (
+    SingleTypeKVCacheManager,
+    SlidingWindowManager,
+)
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheSpec,
     MambaSpec,
+    SlidingWindowSpec,
 )
+from vllm.v1.request import Request
 
+from vllm_ascend import envs
 from vllm_ascend.core.single_type_kv_cache_manager import get_manager_for_kv_cache_spec
+
+try:
+    from vllm.v1.kv_cache_interface import SlidingWindowMLASpec
+except ImportError:  # pragma: no cover - older vLLM without DSv4 MLA SWA spec
+    SlidingWindowMLASpec = SlidingWindowSpec
+
+# SWA-family specs that honor the prefix-cache retention knob (incl. DSv4
+# SlidingWindowMLASpec), so validation does not wrongly report "no SWA group".
+_SLIDING_WINDOW_SPECS = (SlidingWindowSpec, SlidingWindowMLASpec)
 
 USE_MULTI_GROUPS_KV_CACHE = True
 
 _orig_get_kv_cache_coordinator = vllm.v1.core.kv_cache_coordinator.get_kv_cache_coordinator
 
+
+def _validate_prefix_cache_retention_interval(
+    retention_interval: int | None,
+    alignment_tokens: int,
+    kv_cache_config: KVCacheConfig,
+) -> None:
+    """Validate VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL (vLLM PR #43447 (3)).
+
+    No-op when unset. When set, the model must have at least one sliding-window
+    KV cache group (otherwise retention has no effect), and the value must be a
+    non-negative multiple of the cache-hit alignment (``lcm_block_size``).
+    """
+    if retention_interval is None:
+        return
+    if not any(isinstance(g.kv_cache_spec, _SLIDING_WINDOW_SPECS) for g in kv_cache_config.kv_cache_groups):
+        raise ValueError(
+            "VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL is set but this "
+            "model has no sliding-window KV cache group, so retention has no "
+            "effect."
+        )
+    if retention_interval < 0 or retention_interval % alignment_tokens != 0:
+        raise ValueError(
+            f"VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL ({retention_interval}) "
+            f"must be non-negative and a multiple of the cache-hit alignment "
+            f"({alignment_tokens})."
+        )
 
 def _is_deepseek_v4_kv_cache_spec(kv_cache_spec: KVCacheSpec) -> bool:
     if getattr(kv_cache_spec, "model_version", None) == "deepseek_v4":

--- a/vllm_ascend/patch/platform/patch_prefix_cache_core.py
+++ b/vllm_ascend/patch/platform/patch_prefix_cache_core.py
@@ -1,0 +1,451 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+"""Compatibility patch for prefix-cache block reuse.
+
+This carries the small-core part of vLLM PR #43447 needed by the DeepSeek V4
+prefix-cache coordinator patch. Remove it when the supported vLLM version
+contains these APIs and behaviors.
+"""
+
+import inspect
+from collections.abc import Callable, Iterable
+
+from vllm.logger import logger
+from vllm.utils.math_utils import cdiv
+from vllm.v1.core import kv_cache_manager as kv_cache_manager_mod
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import FreeKVCacheBlockQueue, KVCacheBlock
+from vllm.v1.core.single_type_kv_cache_manager import (
+    SingleTypeKVCacheManager,
+    SlidingWindowManager,
+)
+from vllm.v1.kv_cache_interface import SlidingWindowSpec
+
+try:
+    from vllm.v1.kv_cache_interface import SlidingWindowMLASpec
+except ImportError:  # pragma: no cover - older vLLM without DSv4 MLA SWA spec
+    SlidingWindowMLASpec = SlidingWindowSpec
+
+
+def _source_contains(fn: Callable, *needles: str) -> bool:
+    try:
+        source = inspect.getsource(fn)
+    except (OSError, TypeError):
+        return False
+    return all(needle in source for needle in needles)
+
+
+def _patch_kv_cache_manager_scheduler_block_size() -> None:
+    """Forward scheduler cache-hit granularity on vLLM versions without it."""
+    kv_cache_manager_cls = kv_cache_manager_mod.KVCacheManager
+    current_init = kv_cache_manager_cls.__init__
+    if "scheduler_block_size" in inspect.signature(current_init).parameters:
+        return
+    if getattr(current_init, "_vllm_ascend_scheduler_block_size_patch", False):
+        return
+
+    original_init = current_init
+    original_signature = inspect.signature(original_init)
+
+    def __init__(
+        self,
+        *args,
+        scheduler_block_size: int | None = None,
+        **kwargs,
+    ) -> None:
+        bound = original_signature.bind(self, *args, **kwargs)
+        bound.apply_defaults()
+        if scheduler_block_size is None:
+            scheduler_block_size = bound.arguments.get("hash_block_size")
+
+        original_get = kv_cache_manager_mod.get_kv_cache_coordinator
+
+        def get_with_scheduler_block_size(*coord_args, **coord_kwargs):
+            try:
+                supports_scheduler_block_size = "scheduler_block_size" in inspect.signature(original_get).parameters
+            except (TypeError, ValueError):
+                supports_scheduler_block_size = False
+            if supports_scheduler_block_size:
+                coord_kwargs.setdefault("scheduler_block_size", scheduler_block_size)
+            return original_get(*coord_args, **coord_kwargs)
+
+        kv_cache_manager_mod.get_kv_cache_coordinator = get_with_scheduler_block_size
+        try:
+            return original_init(self, *args, **kwargs)
+        finally:
+            kv_cache_manager_mod.get_kv_cache_coordinator = original_get
+
+    __init__._vllm_ascend_scheduler_block_size_patch = True  # type: ignore[attr-defined]
+    kv_cache_manager_cls.__init__ = __init__
+    logger.debug("Patched KVCacheManager.__init__(scheduler_block_size=...).")
+
+
+def _patch_scheduler_scheduler_block_size() -> None:
+    """Pass Scheduler.block_size to KVCacheManager on older vLLM."""
+    try:
+        from vllm.v1.core.sched import scheduler as scheduler_mod
+    except ImportError:
+        return
+
+    scheduler_cls = scheduler_mod.Scheduler
+    current_init = scheduler_cls.__init__
+    if getattr(current_init, "_vllm_ascend_scheduler_block_size_patch", False):
+        return
+    if _source_contains(current_init, "scheduler_block_size=self.block_size"):
+        return
+    try:
+        if "scheduler_block_size" in inspect.signature(scheduler_mod.KVCacheManager.__init__).parameters:
+            # Upstream already threads the hit granularity natively; forwarding
+            # the scheduler's hash-sized block here would violate the manager's
+            # divisibility assert. Nothing to patch.
+            return
+    except (TypeError, ValueError):
+        pass
+
+    original_init = current_init
+    original_signature = inspect.signature(original_init)
+
+    def __init__(self, *args, **kwargs) -> None:
+        bound = original_signature.bind(self, *args, **kwargs)
+        bound.apply_defaults()
+        scheduler_block_size = bound.arguments.get("block_size")
+
+        original_kv_cache_manager = scheduler_mod.KVCacheManager
+
+        def kv_cache_manager_with_scheduler_block_size(*kv_args, **kv_kwargs):
+            if scheduler_block_size is not None:
+                kv_kwargs.setdefault("scheduler_block_size", scheduler_block_size)
+            return original_kv_cache_manager(*kv_args, **kv_kwargs)
+
+        scheduler_mod.KVCacheManager = kv_cache_manager_with_scheduler_block_size
+        try:
+            return original_init(self, *args, **kwargs)
+        finally:
+            scheduler_mod.KVCacheManager = original_kv_cache_manager
+
+    __init__._vllm_ascend_scheduler_block_size_patch = True  # type: ignore[attr-defined]
+    scheduler_cls.__init__ = __init__
+    logger.debug("Patched Scheduler.__init__ to pass scheduler_block_size.")
+
+
+def _patch_free_queue_prepend() -> None:
+    if hasattr(FreeKVCacheBlockQueue, "prepend_n"):
+        return
+
+    def prepend_n(self: FreeKVCacheBlockQueue, blocks: list[KVCacheBlock]) -> None:
+        """Put a list of blocks at the front of the free list."""
+        if len(blocks) == 0:
+            return
+
+        first_block = self.fake_free_list_head.next_free_block
+        assert first_block is not None, "next_free_block of fake_free_list_head should always exist"
+
+        prev_block = self.fake_free_list_head
+        for block in blocks:
+            block.prev_free_block = prev_block
+            prev_block.next_free_block = block
+            prev_block = block
+
+        prev_block.next_free_block = first_block
+        first_block.prev_free_block = prev_block
+
+        self.num_free_blocks += len(blocks)
+
+    FreeKVCacheBlockQueue.prepend_n = prepend_n
+    logger.debug("Patched FreeKVCacheBlockQueue.prepend_n for prefix-cache reuse.")
+
+
+def _patch_block_pool_free_blocks() -> None:
+    if "prepend" in inspect.signature(BlockPool.free_blocks).parameters:
+        return
+
+    def free_blocks(
+        self: BlockPool,
+        ordered_blocks: Iterable[KVCacheBlock],
+        prepend: bool = False,
+    ) -> None:
+        """Free blocks, optionally placing newly-free blocks at queue front."""
+        blocks_list = list(ordered_blocks)
+        for block in blocks_list:
+            block.ref_cnt -= 1
+        freed_blocks = [block for block in blocks_list if block.ref_cnt == 0 and not block.is_null]
+        if prepend:
+            self.free_block_queue.prepend_n(freed_blocks)
+        else:
+            self.free_block_queue.append_n(freed_blocks)
+
+    BlockPool.free_blocks = free_blocks
+    logger.debug("Patched BlockPool.free_blocks(prepend=...).")
+
+
+def _patch_remove_skipped_blocks() -> None:
+    if _source_contains(
+        SingleTypeKVCacheManager.remove_skipped_blocks,
+        "prepend=True",
+        "block_hash is None",
+    ):
+        return
+
+    def remove_skipped_blocks(
+        self: SingleTypeKVCacheManager,
+        request_id: str,
+        total_computed_tokens: int,
+    ) -> None:
+        num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
+        if num_skipped_tokens <= 0:
+            return
+
+        blocks = self.req_to_blocks[request_id]
+        num_skipped_blocks = num_skipped_tokens // self.block_size
+        num_skipped_blocks = min(num_skipped_blocks, len(blocks))
+        removed_cached_blocks: list[KVCacheBlock] = []
+        removed_uncached_blocks: list[KVCacheBlock] = []
+
+        for i in range(num_skipped_blocks - 1, -1, -1):
+            if blocks[i] == self._null_block:
+                break
+            if blocks[i].block_hash is None:
+                removed_uncached_blocks.append(blocks[i])
+            else:
+                removed_cached_blocks.append(blocks[i])
+            blocks[i] = self._null_block
+
+        self.block_pool.free_blocks(removed_cached_blocks)
+        self.block_pool.free_blocks(removed_uncached_blocks, prepend=True)
+
+    SingleTypeKVCacheManager.remove_skipped_blocks = remove_skipped_blocks
+    logger.debug("Patched SingleTypeKVCacheManager.remove_skipped_blocks.")
+
+
+def _patch_cache_full_blocks_mask() -> None:
+    """Add a ``block_mask`` argument to ``BlockPool.cache_full_blocks``.
+
+    The vLLM v0.21.0 base ``cache_full_blocks`` has no ``block_mask`` parameter
+    (vLLM PR #43447 is built on a newer base that already carries it), so the
+    sparse SWA retention mask computed in ``SlidingWindowManager.cache_blocks``
+    would have nowhere to land. This wraps the original so that:
+
+    * ``block_mask is None`` -> the original function is called verbatim, i.e.
+      every full block is cached exactly as before (byte-for-byte safety net for
+      the env-unset / dense path).
+    * ``block_mask`` provided -> blocks whose ``mask[j]`` is ``False`` (``j`` is
+      the 0-based index into ``new_full_blocks``, i.e. the ``blocks`` slice
+      ``[num_cached_blocks:num_full_blocks]``) are temporarily replaced with the
+      null block so the original function's ``is_null`` branch skips them. The
+      ``blocks`` list is restored afterwards so the request's block table is not
+      polluted; masked-out blocks keep ``block_hash is None`` (scratch) and are
+      reclaimed with front-insert priority by the existing free patches.
+    """
+    if "block_mask" in inspect.signature(BlockPool.cache_full_blocks).parameters:
+        return
+    if getattr(BlockPool.cache_full_blocks, "_vllm_ascend_block_mask_patch", False):
+        return
+
+    original_cache_full_blocks = BlockPool.cache_full_blocks
+
+    def cache_full_blocks(
+        self: BlockPool,
+        *,
+        request,
+        blocks: list[KVCacheBlock],
+        num_cached_blocks: int,
+        num_full_blocks: int,
+        block_size: int,
+        kv_cache_group_id: int,
+        block_mask: list[bool] | None = None,
+    ) -> None:
+        if block_mask is None:
+            return original_cache_full_blocks(
+                self,
+                request=request,
+                blocks=blocks,
+                num_cached_blocks=num_cached_blocks,
+                num_full_blocks=num_full_blocks,
+                block_size=block_size,
+                kv_cache_group_id=kv_cache_group_id,
+            )
+
+        # Mask mode: temporarily swap masked blocks for the null block so the
+        # original function's "skip null" branch leaves them uncached, then
+        # restore the request's block list verbatim.
+        saved: list[tuple[int, KVCacheBlock]] = []
+        null_block = self.null_block
+        for j in range(num_full_blocks - num_cached_blocks):
+            if not block_mask[j]:
+                idx = num_cached_blocks + j
+                saved.append((idx, blocks[idx]))
+                blocks[idx] = null_block
+        try:
+            original_cache_full_blocks(
+                self,
+                request=request,
+                blocks=blocks,
+                num_cached_blocks=num_cached_blocks,
+                num_full_blocks=num_full_blocks,
+                block_size=block_size,
+                kv_cache_group_id=kv_cache_group_id,
+            )
+        finally:
+            for idx, blk in saved:
+                blocks[idx] = blk
+
+    cache_full_blocks._vllm_ascend_block_mask_patch = True  # type: ignore[attr-defined]
+    BlockPool.cache_full_blocks = cache_full_blocks
+    logger.debug("Patched BlockPool.cache_full_blocks(block_mask=...).")
+
+
+def _patch_sliding_window_mask() -> None:
+    """Inject the retention three-state mask onto ``SlidingWindowManager``.
+
+    vLLM v0.21.0's ``SlidingWindowManager`` has neither ``reachable_block_mask``
+    nor ``_contiguous_blocks_for_hit`` (the cache-hit side inlines
+    ``cdiv(sliding_window-1, block_size)`` + EAGLE ``+1``), and the base
+    ``cache_blocks`` takes no retention argument. We therefore inject all three
+    pieces of vLLM PR #43447's algorithm here.
+
+    Deliberate deviation from PR #43447 (see §2c of the design): when
+    ``retention_interval is None`` (env unset) we return ``None`` to keep the
+    prior dense "cache every full block" behavior byte-for-byte, rather than the
+    PR's dense-per-segment sparsification which would tighten the existing SWA
+    hit rate. Only the 0 / >0 states walk the sparse path.
+    """
+    if hasattr(SlidingWindowManager, "reachable_block_mask") and _source_contains(
+        SlidingWindowManager.cache_blocks, "retention_interval"
+    ):
+        return
+
+    @staticmethod  # type: ignore[misc]
+    def _contiguous_blocks_for_hit(window_size: int, block_size: int, use_eagle: bool) -> int:
+        # Mirror find_longest_cache_hit's hit granularity exactly:
+        # cdiv(sliding_window-1, block_size), +1 when EAGLE is enabled. Keeping
+        # this identical to the lookup side avoids cache-vs-hit misalignment.
+        need = cdiv(window_size - 1, block_size)
+        return need + 1 if use_eagle else need
+
+    @classmethod  # type: ignore[misc]
+    def reachable_block_mask(
+        cls,
+        start_block: int,
+        end_block: int,
+        alignment_tokens: int | None,
+        kv_cache_spec,
+        use_eagle: bool,
+        retention_interval: int | None = None,
+        num_prompt_tokens: int | None = None,
+    ) -> list[bool] | None:
+        assert isinstance(kv_cache_spec, SlidingWindowSpec)
+        # Deviation from PR #43447: env-unset (None) keeps the dense cache-all
+        # path so existing hit behavior is unchanged. cache_full_blocks receives
+        # block_mask=None and runs verbatim.
+        if retention_interval is None:
+            return None
+        if alignment_tokens is None:
+            return None
+        assert alignment_tokens % kv_cache_spec.block_size == 0
+        block_size = kv_cache_spec.block_size
+        need = cls._contiguous_blocks_for_hit(
+            window_size=kv_cache_spec.sliding_window,
+            block_size=block_size,
+            use_eagle=use_eagle,
+        )
+        shift = 1 if use_eagle else 0
+        mask = [False] * (end_block - start_block)
+
+        # retention_interval == 0 -> only the latest replay boundary is kept
+        # (segment tail loop disabled); >0 -> keep one tail per interval segment.
+        segment_tokens = None if retention_interval == 0 else retention_interval
+        if segment_tokens is not None:
+            per_segment = segment_tokens // block_size
+            if need >= per_segment:
+                # The whole segment is within reach; nothing can be dropped, so
+                # fall back to caching everything (dense).
+                return None
+            for i in range(start_block, end_block):
+                if i >= shift and (i - shift) % per_segment >= per_segment - need:
+                    mask[i - start_block] = True
+
+        # Replay tail: always retain the contiguous tail covering the latest
+        # completed prompt boundary so a replay of the prompt still hits. This
+        # only runs when retention is enabled (matches PR #43447: the dense None
+        # path never adds a replay tail).
+        if num_prompt_tokens is not None:
+            latest = (num_prompt_tokens - 1) // alignment_tokens * alignment_tokens
+            prompt_end_block = latest // block_size + shift
+            for i in range(
+                max(start_block, prompt_end_block - need),
+                min(end_block, prompt_end_block),
+            ):
+                mask[i - start_block] = True
+        return mask
+
+    def cache_blocks(
+        self: SlidingWindowManager,
+        request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+    ) -> None:
+        num_cached = self.num_cached_block.get(request.request_id, 0)
+        num_full = num_tokens // self.block_size
+        if num_cached >= num_full:
+            return
+        # The coordinator injects scheduler_block_size / use_eagle onto each
+        # manager; fall back conservatively so pure-SWA (unitary) coordinators
+        # that bypass the Ascend coordinator still behave (dense) correctly.
+        alignment_tokens = getattr(self, "scheduler_block_size", self.block_size)
+        use_eagle = getattr(self, "use_eagle", False)
+        block_mask = self.reachable_block_mask(
+            start_block=num_cached,
+            end_block=num_full,
+            alignment_tokens=alignment_tokens,
+            kv_cache_spec=self.kv_cache_spec,
+            use_eagle=use_eagle,
+            retention_interval=retention_interval,
+            num_prompt_tokens=request.num_prompt_tokens,
+        )
+        self.block_pool.cache_full_blocks(
+            request=request,
+            blocks=self.req_to_blocks[request.request_id],
+            num_cached_blocks=num_cached,
+            num_full_blocks=num_full,
+            block_size=self.block_size,
+            kv_cache_group_id=self.kv_cache_group_id,
+            block_mask=block_mask,
+        )
+        self.num_cached_block[request.request_id] = num_full
+
+    SlidingWindowManager._contiguous_blocks_for_hit = _contiguous_blocks_for_hit
+    SlidingWindowManager.reachable_block_mask = reachable_block_mask
+    SlidingWindowManager.cache_blocks = cache_blocks
+    logger.debug("Patched SlidingWindowManager.reachable_block_mask / cache_blocks (prefix-cache retention).")
+
+
+def _patch_sliding_window_free() -> None:
+    if _source_contains(SlidingWindowManager.free, "prepend=True", "block_hash is None"):
+        return
+
+    def free(self: SlidingWindowManager, request_id: str) -> None:
+        req_blocks = self.req_to_blocks.pop(request_id, [])
+        if req_blocks:
+            cached_blocks: list[KVCacheBlock] = []
+            uncached_blocks: list[KVCacheBlock] = []
+            for block in reversed(req_blocks):
+                if block.block_hash is None:
+                    uncached_blocks.append(block)
+                else:
+                    cached_blocks.append(block)
+            self.block_pool.free_blocks(cached_blocks)
+            self.block_pool.free_blocks(uncached_blocks, prepend=True)
+        self.num_cached_block.pop(request_id, None)
+
+    SlidingWindowManager.free = free
+    logger.debug("Patched SlidingWindowManager.free.")
+
+
+_patch_kv_cache_manager_scheduler_block_size()
+_patch_scheduler_scheduler_block_size()
+_patch_free_queue_prepend()
+_patch_block_pool_free_blocks()
+_patch_cache_full_blocks_mask()
+_patch_remove_skipped_blocks()
+_patch_sliding_window_mask()
+_patch_sliding_window_free()


### PR DESCRIPTION
## What this PR does / why we need it?
Backports vLLM PR #43447 (DeepSeek-V4 selective prefix-cache retention for sliding-window KV cache) to vLLM versions that lack it (e.g. v0.21.0), via capability/source guarded monkey-patches. It carries two parts of #43447:

- **block-reuse**: free-list front-insertion (`prepend_n` / `free_blocks(prepend=)`), SWA/EAGLE cache-block mask, and the `remove_skipped_blocks` cached/uncached split.
- **selective prefix-cache retention** for sliding-window KV cache: retention interval + reachable block mask, controlled by the `VLLM_PREFIX_CACHE_RETENTION_INTERVAL` env.

Each patch is guarded by a capability/source check, so it is a no-op and is automatically skipped once the underlying vLLM already provides the behavior.

## Relationship to upstream PRs
- Backports [Prefix Caching] DeepSeekv4 - Support selective prefix-cache retention for sliding-window KV cache vllm-project/vllm#43447 in full (both block-reuse and retention).
- Orthogonal to the official compressed-prefix lookup fix already on main: this PR leaves the lookup / read path untouched; retention operates on the write path (`__init__` + `cache_blocks`), sharing only the read-only alignment.

## Does this PR introduce any user-facing change?
Adds an opt-in env `VLLM_ASCEND_PREFIX_CACHE_RETENTION_INTERVAL` to control sliding-window retention (unset = legacy dense behavior, bit-for-bit identical to before). All patches are guarded and skipped when the underlying vLLM already provides them.

## How was this patch tested?
- `lint-and-select-tests` passed (ruff / format / codespell / mypy).
- New unit tests `tests/ut/core/test_prefix_cache_retention.py` assert the retention reachable-block masks (EAGLE and interval cases) and run on `cpu-0card`.
- `run-selected-tests` on `cpu-0card` / `a2-1card`.

Co-authored with @wangzhao-11a and @FutureSkyFly .


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
