### PR TITLE
[Ascend950] [Bugfix] Fix triton kernel performance fluctuation issue for ascend950

### DIFF
--- a/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_rope_simt.py
+++ b/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_rope_simt.py
@@ -13,10 +13,10 @@ def precompute_rope_cos_sin_kernel(
     cos_sin_cache_gm_ptr,
     out_cos_sin_gm_ptr,
     batch_size,
+    N,
     batch_size_per_vec: tl.constexpr,
     ROPE_DIM: tl.constexpr,
     num_vectorcore: tl.constexpr,
-    N,
 ):
     row_pid = tl.program_id(0)
     input_batch_offset = row_pid * batch_size_per_vec
@@ -317,10 +317,10 @@ def split_qkv_rmsnorm_rope_simt_impl(
         cos_sin_cache,
         cos_sin_precomputed,
         batch_size,
+        N,
         batch_size_per_vec_cos_sin,
         rope_dim,
         num_vectorcore,
-        N,
         force_simt_only=True,
     )
 

--- a/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_rope_simt.py
+++ b/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_rope_simt.py
@@ -16,7 +16,7 @@ def precompute_rope_cos_sin_kernel(
     batch_size_per_vec: tl.constexpr,
     ROPE_DIM: tl.constexpr,
     num_vectorcore: tl.constexpr,
-    N: tl.constexpr,
+    N,
 ):
     row_pid = tl.program_id(0)
     input_batch_offset = row_pid * batch_size_per_vec


### PR DESCRIPTION
Change-Id: Icfffcd2c998866903dea35861b3bb0038e8e51f8

[Ascend950] [Bugfix] Fix Triton kernel performance fluctuation issue

### What this PR does / why we need it?

This PR fixes the Triton kernel performance fluctuation issue observed on Qwen3-32B and Qwen3-235B for Ascend950.

**Background & Motivation**
The Triton kernel `split_qkv_rmsnorm_rope_simt` was always recompiled when the batch size changed, because the input parameter `N` of the `precompute_rope_cos_sin_kernel` kernel changes with the batch size. This recompilation causes intolerable compilation overhead.

**Changes Made**
1. **Removed the `tl.constexpr` compile-time constant qualifier from parameter `N` of `precompute_rope_cos_sin_kernel`**
   - Replaced `N: tl.constexpr` with `N`.

### Does this PR introduce _any_ user-facing change?

No. All changes are backend compilation and operator registration fixes. No Python API or CLI behavior is changed.

### How was this PR tested?

**Environment**

**Ascend 950 (A5)**
- Model: Qwen3-32B
- Before the change:
  output token throughput: 1670 ~ 2042, non-deterministic regardless of how many times the dataset was run
- After the change:
  running the dataset 3 times, the output token throughput was between 1999 and 2043

---------

Signed-off-by: Bybbbb11 <171289168@qq.com>
Signed-off-by: CXMT <liubaoyang3@huawei.com>


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
