### PR TITLE
[Performance][DSA-CP] Reduce alltoall communication 4x by moving it after wo_a

### DIFF
--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -990,7 +990,8 @@ class AscendDSACPImpl(DSAAttentionImpl):
         # o_proj_input: [N/TP, num_heads, head_dim] → [N/TP, n_group, heads_per_group * head_dim]
         o_proj_input = o_proj_input.view(num_tokens, self.n_group, -1)
         if olora_tp_enable():
-            # TODO: olora tp is not ready yet; `_get_row_parallel_op` does not currently include the required adaptation.
+            # TODO: olora tp is not ready yet; `_get_row_parallel_op` does not
+            # currently include the required adaptation.
             o_proj_tmp = self.wo_a(o_proj_input)
         else:
             # wo_a = self.wo_a.weight.view(self.n_groups, self.o_lora_rank, -1)

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -983,15 +983,17 @@ class AscendDSACPImpl(DSAAttentionImpl):
         if not isinstance(attn_metadata, list):
             attn_metadata = [attn_metadata]
         local_attn_output = self._forward(layer_name, hidden_states, kv_cache, attn_metadata, need_gather_q_kv)
-        o_proj_input = self._restore_tp_head_layout(local_attn_output, layer_name, attn_metadata[0])
+        o_proj_input = self._apply_inv_rope(local_attn_output, layer_name, attn_metadata[0])
         num_tokens = o_proj_input.shape[0]
 
-        # o
-        o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, -1)
+        # wo_a: full-group matmul on local tokens, all groups
+        # o_proj_input: [N/TP, num_heads, head_dim] → [N/TP, n_group, heads_per_group * head_dim]
+        o_proj_input = o_proj_input.view(num_tokens, self.n_group, -1)
         if olora_tp_enable():
+            # TODO: olora tp is not ready yet; `_get_row_parallel_op` does not currently include the required adaptation.
             o_proj_tmp = self.wo_a(o_proj_input)
         else:
-            # wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
+            # wo_a = self.wo_a.weight.view(self.n_groups, self.o_lora_rank, -1)
             # o = torch.einsum("tgd,grd->tgr", o, wo_a)
             o_proj_tmp = torch_npu.npu_transpose_batchmatmul(
                 o_proj_input,
@@ -1002,8 +1004,23 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 perm_x2=(0, 1, 2),
                 perm_y=(1, 0, 2),
                 batch_split_factor=1,
-            ).view(num_tokens, -1)
-        output[...] = self.wo_b(o_proj_tmp)
+            )
+        # o_proj_tmp: [N/TP, n_group, o_lora_rank]
+
+        # alltoall: redistribute from local-tokens/all-groups to all-tokens/local-groups
+        if self.tp_size > 1:
+            send = (
+                o_proj_tmp.view(num_tokens, self.tp_size, self.n_local_groups, self.o_lora_rank)
+                .permute(1, 0, 2, 3)
+                .contiguous()
+                .view(-1, self.n_local_groups, self.o_lora_rank)
+            )
+            recv = torch.empty_like(send)
+            dist.all_to_all_single(recv, send, group=self.tp_group.device_group)
+            o_proj_tmp = recv
+        # o_proj_tmp: [N, n_local_groups, o_lora_rank]
+
+        output[...] = self.wo_b(o_proj_tmp.reshape(-1, self.n_local_groups * self.o_lora_rank))
 
         return output
 
@@ -1233,7 +1250,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             )[0]
         return attn_output
 
-    def _restore_tp_head_layout(
+    def _apply_inv_rope(
         self,
         local_attn_output: torch.Tensor,
         layer_name: str,
@@ -1242,7 +1259,6 @@ class AscendDSACPImpl(DSAAttentionImpl):
         assert attn_metadata.req_metadata is not None
         req_metadata = attn_metadata.req_metadata
         cp_metadata = req_metadata.cp_metadata
-        num_tokens = local_attn_output.shape[0]
         torch.ops._C_ascend.inplace_partial_rotary_mul(
             local_attn_output.unsqueeze(1),
             cp_metadata.local_cos[layer_name],
@@ -1250,19 +1266,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             rotary_mode="interleave",
             partial_slice=[self.nope_head_dim, self.head_dim],
         )
-
-        if self.tp_size == 1:
-            return local_attn_output
-
-        send = (
-            local_attn_output.view(num_tokens, self.tp_size, self.n_local_heads, self.head_dim)
-            .permute(1, 0, 2, 3)
-            .contiguous()
-            .view(-1, self.n_local_heads, self.head_dim)
-        )
-        recv = torch.empty_like(send)
-        dist.all_to_all_single(recv, send, group=self.tp_group.device_group)
-        return recv
+        return local_attn_output
 
     def _update_indexer_cache(
         self,

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -765,7 +765,8 @@ class DeepseekV4Attention(nn.Module):
             return_bias=False,
         )
         self.kv_norm = RMSNorm(self.head_dim, self.norm_eps)
-        self.wo_a = ColumnParallelLinear(
+        wo_a_cls = ReplicatedLinear if self.enable_dsa_cp else ColumnParallelLinear
+        self.wo_a = wo_a_cls(
             self.n_heads * self.head_dim // self.n_groups,
             self.n_groups * config.o_lora_rank,
             bias=False,

--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -562,6 +562,11 @@ class AscendReplicatedLinear(ReplicatedLinear):
         if self.custom_op is not None:
             self.custom_op.update_attrs()
 
+        if "wo_a" in prefix:
+            hf_config = get_current_vllm_config().model_config.hf_text_config
+            self.n_groups = getattr(hf_config, "o_groups", 0)
+            self.o_lora_rank = getattr(hf_config, "o_lora_rank", 0)
+
     def forward(
         self,
         input_,
@@ -570,3 +575,18 @@ class AscendReplicatedLinear(ReplicatedLinear):
             return self.custom_op.apply(input_)
 
         return super().forward(input_)
+
+    def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
+        if "wo_a" in self.prefix and get_ascend_device_type() != AscendDeviceType.A5:
+            if self.weight.ndim == 2:
+                super().weight_loader(param, loaded_weight)
+                self.weight.data = (
+                    self.weight.data.view(self.n_groups, self.o_lora_rank, -1).transpose(2, 1).contiguous()
+                )
+            else:
+                # In RL update flows, wo_a can be loaded again after being
+                # transformed into [n_groups, hidden_size, o_lora_rank].
+                loaded_weight = loaded_weight.view(self.n_groups, self.o_lora_rank, -1).transpose(2, 1).contiguous()
+                self.weight.data.copy_(loaded_weight)
+        else:
+            super().weight_loader(param, loaded_weight)


### PR DESCRIPTION
### What this PR does / why we need it?

In DSA Context-Parallel mode, the output projection path is:

```
attn_output [N/TP, num_heads, head_dim]
  → alltoall (redistribute: local-tokens/all-heads → all-tokens/local-heads)
  → wo_a (ColumnParallel, per-group compress: heads_per_group × head_dim → o_lora_rank)
  → wo_b (RowParallel + allreduce)
```

The alltoall transmits the full attention output (`num_heads × head_dim` per token), but `wo_a` is a 4:1 compression (`4096 → 1024` per group). By moving the alltoall **after** `wo_a`, we transmit the compressed representation instead:

```
attn_output [N/TP, num_heads, head_dim]
  → wo_a (Replicated, full-group compress on local tokens)
  → alltoall (redistribute: local-tokens/all-groups → all-tokens/local-groups)
  → wo_b (RowParallel + allreduce, unchanged)
```

**Communication reduction**: alltoall data per token drops from `num_heads × head_dim = 64 × 512 = 32768` to `n_groups × o_lora_rank = 8 × 1024 = 8192`, a **4x reduction**.

**Trade-off**: `wo_a` weight changes from `ColumnParallelLinear` (1/TP sharded) to `ReplicatedLinear` (full weights on each rank), increasing per-layer weight memory by `(TP-1)/TP × n_groups × o_lora_rank × head_dim_per_group × dtype_size`.

Changes:
- `wo_a` uses `ReplicatedLinear` in DSA CP mode (full-group weights per rank)
- alltoall moved from `_restore_tp_head_layout` into `forward`, after `wo_a`
- `_restore_tp_head_layout` renamed to `_apply_inv_rope` (now only does inverse RoPE)
- `AscendReplicatedLinear` gains `wo_a` weight_loader for `npu_transpose_batchmatmul` layout

### Does this PR introduce _any_ user-facing change?

No. This is an internal optimization that reduces communication volume in DSA CP mode.

### How was this patch tested?

Deployed DeepSeek-V4-Flash prefill with TP=4, DP=4, max_num_batched_tokens=8192:

| Stage | Before | After | Speedup |
|---|---|---|---|
| alltoall + wo_a | 1.30 ms | 0.89 ms | **31% faster** |

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
