### PR TITLE
[WIP][BugFix] Recompute DeepSeek V4 RoPE values to investigate cache issue

### DIFF
--- a/vllm_ascend/ops/rope_dsv4.py
+++ b/vllm_ascend/ops/rope_dsv4.py
@@ -99,21 +99,17 @@ def get_cos_and_sin_dsa(positions: torch.Tensor | dict[str, torch.Tensor], use_c
     return RopeDataProxy(batch_result, is_cos=True), RopeDataProxy(batch_result, is_cos=False)
 
 
-ROTARY_DIM = 0
-MAX_POS = 0
-BASE = 0
-SCALING_FACTOR = 0
-BETA_FAST = 0
-BETA_SLOW = 0
+_ROPE_CONFIGS = {}
 
 
 # Recompute the values to avoid the cache issue.
-def compute_cos_and_sin():
+def compute_cos_and_sin(config_key: str):
+    rotary_dim, max_pos, base, scaling_factor, beta_fast, beta_slow = _ROPE_CONFIGS[config_key]
     inv_freq = ComplexExpRotaryEmbedding.precompute_freqs_cis(
-        ROTARY_DIM, MAX_POS, MAX_POS, BASE, SCALING_FACTOR, BETA_FAST, BETA_SLOW
+        rotary_dim, max_pos, max_pos, base, scaling_factor, beta_fast, beta_slow
     )
     t = torch.arange(
-        MAX_POS * SCALING_FACTOR,
+        int(max_pos * scaling_factor),
         device=current_platform.device_type,
         dtype=torch.float32,
     )

--- a/vllm_ascend/ops/rope_dsv4.py
+++ b/vllm_ascend/ops/rope_dsv4.py
@@ -1,5 +1,4 @@
 import math
-from typing import Any
 
 import torch
 import torch.nn as nn
@@ -59,44 +58,68 @@ class RopeDataProxy:
 
 
 def get_cos_and_sin_dsa(positions: torch.Tensor | dict[str, torch.Tensor], use_cache: bool = False):
-    if isinstance(positions, torch.Tensor):
-        pos_map = {"default": positions}
-    else:
-        pos_map = positions
+    static_cos, static_sin = compute_cos_and_sin()
+    curr_cos = static_cos[positions]
+    curr_sin = static_sin[positions]
+    return curr_cos, curr_sin
 
-    batch_result: dict[Any, Any] = {}
+    # for config_key, registered_groups in _ROPE_STATE.registry_summary.items():
+    #     if config_key not in _ROPE_STATE.static_cache:
+    #         continue
+    #     static_cos, static_sin = _ROPE_STATE.static_cache[config_key]
+    #
+    #     batch_result[config_key] = {}
+    #
+    #     for group_name, pos_tensor in pos_map.items():
+    #         if group_name not in registered_groups:
+    #             continue
+    #
+    #         curr_cos = static_cos[pos_tensor]
+    #         curr_sin = static_sin[pos_tensor]
+    #
+    #         if use_cache:
+    #             group_buffers = _ROPE_STATE.runtime_buffer.get(config_key, {}).get(group_name)
+    #
+    #             if group_buffers is None:
+    #                 continue
+    #
+    #             buf_cos, buf_sin = group_buffers
+    #             num_tokens = pos_tensor.size(0)
+    #
+    #             buf_cos[:num_tokens].copy_(curr_cos)
+    #             buf_sin[:num_tokens].copy_(curr_sin)
+    #
+    #             batch_result[config_key][group_name] = (buf_cos[:num_tokens], buf_sin[:num_tokens])
+    #         else:
+    #             batch_result[config_key][group_name] = (curr_cos, curr_sin)
+    #
+    # return RopeDataProxy(batch_result, is_cos=True), RopeDataProxy(batch_result, is_cos=False)
 
-    for config_key, registered_groups in _ROPE_STATE.registry_summary.items():
-        if config_key not in _ROPE_STATE.static_cache:
-            continue
-        static_cos, static_sin = _ROPE_STATE.static_cache[config_key]
 
-        batch_result[config_key] = {}
+ROTARY_DIM = 0
+MAX_POS = 0
+BASE = 0
+SCALING_FACTOR = 0
+BETA_FAST = 0
+BETA_SLOW = 0
 
-        for group_name, pos_tensor in pos_map.items():
-            if group_name not in registered_groups:
-                continue
 
-            curr_cos = static_cos[pos_tensor]
-            curr_sin = static_sin[pos_tensor]
-
-            if use_cache:
-                group_buffers = _ROPE_STATE.runtime_buffer.get(config_key, {}).get(group_name)
-
-                if group_buffers is None:
-                    continue
-
-                buf_cos, buf_sin = group_buffers
-                num_tokens = pos_tensor.size(0)
-
-                buf_cos[:num_tokens].copy_(curr_cos)
-                buf_sin[:num_tokens].copy_(curr_sin)
-
-                batch_result[config_key][group_name] = (buf_cos[:num_tokens], buf_sin[:num_tokens])
-            else:
-                batch_result[config_key][group_name] = (curr_cos, curr_sin)
-
-    return RopeDataProxy(batch_result, is_cos=True), RopeDataProxy(batch_result, is_cos=False)
+# Recompute the values to avoid the cache issue.
+def compute_cos_and_sin():
+    inv_freq = ComplexExpRotaryEmbedding.precompute_freqs_cis(
+        ROTARY_DIM, MAX_POS, MAX_POS, BASE, SCALING_FACTOR, BETA_FAST, BETA_SLOW
+    )
+    t = torch.arange(
+        MAX_POS * SCALING_FACTOR,
+        device=current_platform.device_type,
+        dtype=torch.float32,
+    )
+    freqs = torch.einsum("i,j -> ij", t, inv_freq)
+    cos = freqs.cos().repeat_interleave(2, dim=-1)
+    sin = freqs.sin().repeat_interleave(2, dim=-1)
+    cos = cos.to(current_platform.device_type).unsqueeze(1).unsqueeze(1)
+    sin = sin.to(current_platform.device_type).unsqueeze(1).unsqueeze(1)
+    return cos, sin
 
 
 class ComplexExpRotaryEmbedding(nn.Module):
@@ -134,6 +157,13 @@ class ComplexExpRotaryEmbedding(nn.Module):
             inv_freq = self.precompute_freqs_cis(
                 rotary_dim, max_position_embeddings, max_position_embeddings, base, scaling_factor, beta_fast, beta_slow
             )
+            global ROTARY_DIM, MAX_POS, BASE, SCALING_FACTOR, BETA_FAST, BETA_SLOW
+            ROTARY_DIM = rotary_dim
+            MAX_POS = max_position_embeddings
+            BASE = base
+            SCALING_FACTOR = scaling_factor
+            BETA_FAST = beta_fast
+            BETA_SLOW = beta_slow
             t = torch.arange(
                 max_position_embeddings * scaling_factor,
                 device=current_platform.device_type,

--- a/vllm_ascend/ops/rope_dsv4.py
+++ b/vllm_ascend/ops/rope_dsv4.py
@@ -69,7 +69,7 @@ def get_cos_and_sin_dsa(positions: torch.Tensor | dict[str, torch.Tensor], use_c
     for config_key, registered_groups in _ROPE_STATE.registry_summary.items():
         if config_key not in _ROPE_STATE.static_cache:
             continue
-        static_cos, static_sin = compute_cos_and_sin()
+        static_cos, static_sin = compute_cos_and_sin(config_key)
 
         batch_result[config_key] = {}
 
@@ -156,13 +156,14 @@ class ComplexExpRotaryEmbedding(nn.Module):
             inv_freq = self.precompute_freqs_cis(
                 rotary_dim, max_position_embeddings, max_position_embeddings, base, scaling_factor, beta_fast, beta_slow
             )
-            global ROTARY_DIM, MAX_POS, BASE, SCALING_FACTOR, BETA_FAST, BETA_SLOW
-            ROTARY_DIM = rotary_dim
-            MAX_POS = max_position_embeddings
-            BASE = base
-            SCALING_FACTOR = scaling_factor
-            BETA_FAST = beta_fast
-            BETA_SLOW = beta_slow
+            _ROPE_CONFIGS[config_key] = (
+                rotary_dim,
+                max_position_embeddings,
+                base,
+                scaling_factor,
+                beta_fast,
+                beta_slow,
+            )
             t = torch.arange(
                 max_position_embeddings * scaling_factor,
                 device=current_platform.device_type,

--- a/vllm_ascend/ops/rope_dsv4.py
+++ b/vllm_ascend/ops/rope_dsv4.py
@@ -1,4 +1,5 @@
 import math
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -58,42 +59,44 @@ class RopeDataProxy:
 
 
 def get_cos_and_sin_dsa(positions: torch.Tensor | dict[str, torch.Tensor], use_cache: bool = False):
-    static_cos, static_sin = compute_cos_and_sin()
-    curr_cos = static_cos[positions]
-    curr_sin = static_sin[positions]
-    return curr_cos, curr_sin
+    if isinstance(positions, torch.Tensor):
+        pos_map = {"default": positions}
+    else:
+        pos_map = positions
 
-    # for config_key, registered_groups in _ROPE_STATE.registry_summary.items():
-    #     if config_key not in _ROPE_STATE.static_cache:
-    #         continue
-    #     static_cos, static_sin = _ROPE_STATE.static_cache[config_key]
-    #
-    #     batch_result[config_key] = {}
-    #
-    #     for group_name, pos_tensor in pos_map.items():
-    #         if group_name not in registered_groups:
-    #             continue
-    #
-    #         curr_cos = static_cos[pos_tensor]
-    #         curr_sin = static_sin[pos_tensor]
-    #
-    #         if use_cache:
-    #             group_buffers = _ROPE_STATE.runtime_buffer.get(config_key, {}).get(group_name)
-    #
-    #             if group_buffers is None:
-    #                 continue
-    #
-    #             buf_cos, buf_sin = group_buffers
-    #             num_tokens = pos_tensor.size(0)
-    #
-    #             buf_cos[:num_tokens].copy_(curr_cos)
-    #             buf_sin[:num_tokens].copy_(curr_sin)
-    #
-    #             batch_result[config_key][group_name] = (buf_cos[:num_tokens], buf_sin[:num_tokens])
-    #         else:
-    #             batch_result[config_key][group_name] = (curr_cos, curr_sin)
-    #
-    # return RopeDataProxy(batch_result, is_cos=True), RopeDataProxy(batch_result, is_cos=False)
+    batch_result: dict[Any, Any] = {}
+
+    for config_key, registered_groups in _ROPE_STATE.registry_summary.items():
+        if config_key not in _ROPE_STATE.static_cache:
+            continue
+        static_cos, static_sin = compute_cos_and_sin()
+
+        batch_result[config_key] = {}
+
+        for group_name, pos_tensor in pos_map.items():
+            if group_name not in registered_groups:
+                continue
+
+            curr_cos = static_cos[pos_tensor]
+            curr_sin = static_sin[pos_tensor]
+
+            if use_cache:
+                group_buffers = _ROPE_STATE.runtime_buffer.get(config_key, {}).get(group_name)
+
+                if group_buffers is None:
+                    continue
+
+                buf_cos, buf_sin = group_buffers
+                num_tokens = pos_tensor.size(0)
+
+                buf_cos[:num_tokens].copy_(curr_cos)
+                buf_sin[:num_tokens].copy_(curr_sin)
+
+                batch_result[config_key][group_name] = (buf_cos[:num_tokens], buf_sin[:num_tokens])
+            else:
+                batch_result[config_key][group_name] = (curr_cos, curr_sin)
+
+    return RopeDataProxy(batch_result, is_cos=True), RopeDataProxy(batch_result, is_cos=False)
 
 
 ROTARY_DIM = 0


### PR DESCRIPTION
### What this PR does / why we need it?

This Draft PR temporarily bypasses the shared DeepSeek V4 RoPE cache and recomputes cosine and sine values for each DSA position lookup. It is intended to investigate a cache-related correctness issue and gather community feedback before finalizing the implementation.

Known WIP limitations:
- Recomputing RoPE values introduces runtime overhead.
- The current implementation stores RoPE configuration in module-level mutable state.
- The original multi-configuration and dictionary-position handling is not preserved yet.
- The commented cache implementation will be cleaned up before marking the PR ready for review.

### Does this PR introduce _any_ user-facing change?

Potentially. DeepSeek V4 DSA RoPE values are recomputed instead of read from the shared cache.

### How was this patch tested?

- `python -m py_compile vllm_ascend/ops/rope_dsv4.py`
- `ruff check vllm_ascend/ops/rope_dsv4.py`
- `ruff format --check vllm_ascend/ops/rope_dsv4.py`
- `git diff --check`

NPU functional and accuracy tests have not been run yet.

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
