### PR TITLE
[Misc][310P] 310P device print compatibility

### DIFF
--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -2125,6 +2125,14 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "                               Tensor? gk=None) -> Tensor");
     ops.impl("npu_recurrent_gated_delta_rule", torch::kPrivateUse1, &vllm_ascend::npu_recurrent_gated_delta_rule);
 
+    ops.def("device_print(str msg) -> ()");
+    ops.impl("device_print", c10::DispatchKey::CompositeExplicitAutograd,
+             static_cast<void (*)(c10::string_view)>(&vllm_ascend::device_print));
+
+    ops.def("device_print_tensor(Tensor tensor) -> ()");
+    ops.impl("device_print_tensor", c10::DispatchKey::CompositeExplicitAutograd,
+             static_cast<void (*)(const at::Tensor&)>(&vllm_ascend::device_print));
+
 #ifdef VLLM_ENABLE_ATB_AND_DIRECT_KERNELS
     // Direct kernel custom ops
     ops.def("bgmv_shrink(Tensor! x, Tensor! weight, Tensor! indices, Tensor! y, float scale) -> ()");

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -2094,6 +2094,14 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "chunk_fwd_o(Tensor q, Tensor k, Tensor v, Tensor h, float scale, *, Tensor? g=None, Tensor? g_gamma=None, int[]? cu_seqlens=None, int[]? chunk_indices=None, int? chunk_size=None, bool? transpose_state_layout=False) -> Tensor"
     );
     ops.impl("chunk_fwd_o", torch::kPrivateUse1, &vllm_ascend::chunk_fwd_o);
+
+    ops.def("device_print(str msg) -> ()");
+    ops.impl("device_print", c10::DispatchKey::CompositeExplicitAutograd,
+             static_cast<void (*)(c10::string_view)>(&vllm_ascend::device_print));
+
+    ops.def("device_print_tensor(Tensor tensor) -> ()");
+    ops.impl("device_print_tensor", c10::DispatchKey::CompositeExplicitAutograd,
+             static_cast<void (*)(const at::Tensor&)>(&vllm_ascend::device_print));
 }
 #else
 // Pybind on other platform
@@ -2124,14 +2132,6 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "                               Tensor? g=None, "
         "                               Tensor? gk=None) -> Tensor");
     ops.impl("npu_recurrent_gated_delta_rule", torch::kPrivateUse1, &vllm_ascend::npu_recurrent_gated_delta_rule);
-
-    ops.def("device_print(str msg) -> ()");
-    ops.impl("device_print", c10::DispatchKey::CompositeExplicitAutograd,
-             static_cast<void (*)(c10::string_view)>(&vllm_ascend::device_print));
-
-    ops.def("device_print_tensor(Tensor tensor) -> ()");
-    ops.impl("device_print_tensor", c10::DispatchKey::CompositeExplicitAutograd,
-             static_cast<void (*)(const at::Tensor&)>(&vllm_ascend::device_print));
 
 #ifdef VLLM_ENABLE_ATB_AND_DIRECT_KERNELS
     // Direct kernel custom ops

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -1533,6 +1533,10 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     ops.impl("chunk_gated_delta_rule_fwd_h", &vllm_ascend::meta::chunk_gated_delta_rule_fwd_h_meta);
     // chunk_fwd_o
     ops.impl("chunk_fwd_o", &vllm_ascend::meta::chunk_fwd_o_meta);
+    // Launch host print from device
+    ops.impl("device_print", &vllm_ascend::meta::device_print_meta);
+    // launch host print from device for tensors
+    ops.impl("device_print_tensor", &vllm_ascend::meta::device_print_tensor_meta);
 }
 }
 #else

--- a/examples/device_print_demo.py
+++ b/examples/device_print_demo.py
@@ -1,16 +1,63 @@
 import torch
+import torch.nn as nn
 
 from vllm_ascend.utils import device_print
 
 
 def compute_and_print(x: torch.Tensor) -> torch.Tensor:
     y = torch.square(x) - torch.cos(x)
-    device_print("device_print from current execution mode")
-    device_print(7)
-    device_print(True)
-    device_print(y)
-    device_print(f"Compatible with f-strings: {x.dtype = }, {isinstance(x, torch.Tensor) = }")
+    # Text / scalar prints take a carrier tensor and return it (FX dataflow).
+    y = device_print("device_print from current execution mode", y)
+    y = device_print(7, y)
+    y = device_print(True, y)
+    y = device_print(y)
+    y = device_print(f"Compatible with f-strings: {x.dtype = }, {isinstance(x, torch.Tensor) = }", y)
     return y
+
+
+class LinearWithDevicePrint(nn.Module):
+    """Linear-like module used to show device_print inside a compiled layer."""
+
+    def __init__(self, in_features: int, out_features: int) -> None:
+        super().__init__()
+        self.linear = nn.Linear(in_features, out_features, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        y = self.linear(x)
+        y = device_print("device_print inside Linear.forward", y)
+        return device_print(y)
+
+
+def _run_eager_compile_graph(name: str, fn, x: torch.Tensor, modified_x: torch.Tensor) -> None:
+    print(f"=== {name}: eager ===", flush=True)
+    eager_out = fn(x)
+    torch.npu.synchronize()
+
+    print(f"=== {name}: torch.compile(backend='aot_eager') ===", flush=True)
+    compiled_fn = torch.compile(fn, backend="aot_eager")
+    compiled_out = compiled_fn(x)
+    torch.npu.synchronize()
+    assert torch.allclose(eager_out, compiled_out), f"{name}: eager vs compiled outputs mismatch."
+
+    graph = torch.npu.NPUGraph()
+    capture_stream = torch.npu.Stream()
+    x_capture = x.clone()
+
+    with torch.npu.stream(capture_stream), torch.npu.graph(graph, stream=capture_stream):
+        captured_out = compiled_fn(x_capture)
+
+    print(f"=== {name}: replay graph ===", flush=True)
+    graph.replay()
+    torch.npu.synchronize()
+    assert torch.allclose(eager_out, captured_out), f"{name}: eager vs graph outputs mismatch."
+
+    print(f"=== {name}: modify input and replay graph ===", flush=True)
+    x_capture.copy_(modified_x)
+    graph.replay()
+    torch.npu.synchronize()
+    assert not torch.allclose(eager_out, captured_out), (
+        f"{name}: outputs should change after modifying graph inputs."
+    )
 
 
 def main() -> None:
@@ -18,37 +65,17 @@ def main() -> None:
     torch.npu.set_compile_mode(jit_compile=False)
 
     x = torch.arange(1, 28, dtype=torch.float32).reshape(3, 3, 3).npu()
+    x_modified = torch.arange(28, 1, -1, dtype=torch.float32).reshape(3, 3, 3).npu()
+    _run_eager_compile_graph("compute_and_print", compute_and_print, x, x_modified)
 
-    print("=== eager ===", flush=True)
-    eager_out = compute_and_print(x)
-    torch.npu.synchronize()
+    # Prove device_print works inside Linear under compile + NPUGraph capture.
+    linear_in, linear_out = 8, 4
+    model = LinearWithDevicePrint(linear_in, linear_out).npu()
+    linear_x = torch.randn(2, linear_in, dtype=torch.float32).npu()
+    linear_x_modified = torch.randn_like(linear_x)
+    _run_eager_compile_graph("linear_with_device_print", model, linear_x, linear_x_modified)
 
-    print("=== torch.compile(backend='aot_eager') ===", flush=True)
-    compiled_compute_and_print = torch.compile(compute_and_print, backend="aot_eager")
-    compiled_out = compiled_compute_and_print(x)
-    torch.npu.synchronize()
-
-    assert torch.allclose(eager_out, compiled_out), "Outputs from eager and compiled modes do not match."
-
-    graph = torch.npu.NPUGraph()
-    capture_stream = torch.npu.Stream()
-    x_capture = x.clone()
-
-    with torch.npu.stream(capture_stream), torch.npu.graph(graph, stream=capture_stream):
-        captured_out = compiled_compute_and_print(x_capture)
-
-    print("=== replay graph ===", flush=True)
-    graph.replay()
-    torch.npu.synchronize()
-
-    assert torch.allclose(eager_out, captured_out), "Outputs from eager and graph modes do not match."
-
-    print("=== modify input and replay graph ===", flush=True)
-    x_capture.copy_(torch.arange(28, 1, -1, dtype=torch.float32).reshape(3, 3, 3).npu())
-    graph.replay()
-    torch.npu.synchronize()
-
-    assert not torch.allclose(eager_out, captured_out), "Outputs from eager and modified graph modes should not match."
+    print("All device_print demos passed.", flush=True)
 
 
 if __name__ == "__main__":

--- a/vllm_ascend/ops/register_custom_ops.py
+++ b/vllm_ascend/ops/register_custom_ops.py
@@ -194,6 +194,29 @@ def _muls_add_impl_fake(
     return torch.empty_like(x)
 
 
+def _device_print_op_impl(x: torch.Tensor) -> torch.Tensor:
+    from vllm_ascend.utils import _ensure_device_print_registered
+
+    _ensure_device_print_registered()
+    torch.ops._C_ascend.device_print_tensor(x)
+    return x
+
+
+def _device_print_op_fake(x: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(x)
+
+
+def _device_print_str_op_impl(msg: str) -> None:
+    from vllm_ascend.utils import _ensure_device_print_registered
+
+    _ensure_device_print_registered()
+    torch.ops._C_ascend.device_print(msg)
+
+
+def _device_print_str_op_fake(msg: str) -> None:
+    return
+
+
 direct_register_custom_op(
     op_name="maybe_chunk_residual",
     op_func=_maybe_chunk_residual_impl,
@@ -256,4 +279,20 @@ direct_register_custom_op(
     fake_impl=_muls_add_impl_fake,
     mutates_args=[],
     dispatch_key="PrivateUse1",
+)
+
+direct_register_custom_op(
+    op_name="device_print_op",
+    op_func=_device_print_op_impl,
+    fake_impl=_device_print_op_fake,
+    mutates_args=[],
+    dispatch_key="PrivateUse1",
+)
+
+direct_register_custom_op(
+    op_name="device_print_str_op",
+    op_func=_device_print_str_op_impl,
+    fake_impl=_device_print_str_op_fake,
+    mutates_args=[],
+    dispatch_key="CompositeExplicitAutograd",
 )

--- a/vllm_ascend/ops/register_custom_ops.py
+++ b/vllm_ascend/ops/register_custom_ops.py
@@ -195,26 +195,22 @@ def _muls_add_impl_fake(
 
 
 def _device_print_op_impl(x: torch.Tensor) -> torch.Tensor:
-    from vllm_ascend.utils import _ensure_device_print_registered
-
-    _ensure_device_print_registered()
     torch.ops._C_ascend.device_print_tensor(x)
     return x
 
 
 def _device_print_op_fake(x: torch.Tensor) -> torch.Tensor:
-    return torch.empty_like(x)
+    return x
 
 
-def _device_print_str_op_impl(msg: str) -> None:
-    from vllm_ascend.utils import _ensure_device_print_registered
-
-    _ensure_device_print_registered()
+def _device_print_str_op_impl(x: torch.Tensor, msg: str) -> torch.Tensor:
+    # Return x so the print stays on the FX dataflow without has_side_effect.
     torch.ops._C_ascend.device_print(msg)
+    return x
 
 
-def _device_print_str_op_fake(msg: str) -> None:
-    return
+def _device_print_str_op_fake(x: torch.Tensor, msg: str) -> torch.Tensor:
+    return x
 
 
 direct_register_custom_op(
@@ -294,5 +290,5 @@ direct_register_custom_op(
     op_func=_device_print_str_op_impl,
     fake_impl=_device_print_str_op_fake,
     mutates_args=[],
-    dispatch_key="CompositeExplicitAutograd",
+    dispatch_key="PrivateUse1",
 )

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -55,7 +55,7 @@ ACL_FORMAT_FRACTAL_ND = 2
 ACL_FORMAT_FRACTAL_NZ = 29
 
 _CUSTOM_OP_ENABLED = None
-_DEVICE_PRINT_OP_REGISTERED = False
+_DEVICE_PRINT_READY = False
 _CURRENT_STREAM = None
 _GLOBAL_STREAM = None
 _SHARED_EXPERTS_CALCULATION_STREAM = None
@@ -175,17 +175,17 @@ def is_950():
     return get_ascend_device_type() == AscendDeviceType.A5
 
 
-def _mark_op_side_effectful(op: Any) -> None:
-    torch.fx.node.has_side_effect(op)
-    default_overload = getattr(op, "default", None)
-    if default_overload is not None:
-        torch.fx.node.has_side_effect(default_overload)
+def _ensure_device_print_ready() -> None:
+    """Load Ascend C++ ops and register the vLLM custom-op wrappers.
 
+    Tensor/string printing goes through ``torch.ops.vllm.device_print_op`` /
+    ``device_print_str_op``, both of which return a carrier tensor so FX keeps
+    the nodes on the dataflow without ``has_side_effect``. The underlying
+    ``_C_ascend.device_print*`` kernels stay inside that custom-op boundary.
+    """
+    global _DEVICE_PRINT_READY
 
-def _ensure_device_print_registered() -> None:
-    global _DEVICE_PRINT_OP_REGISTERED
-
-    if _DEVICE_PRINT_OP_REGISTERED:
+    if _DEVICE_PRINT_READY:
         return
 
     if not enable_custom_op():
@@ -194,21 +194,28 @@ def _ensure_device_print_registered() -> None:
             "when custom ops are enabled in the current Ascend build."
         )
 
+    # Registers torch.ops.vllm.device_print_op / device_print_str_op.
+    import vllm_ascend.ops.register_custom_ops  # noqa: F401
+
     try:
-        # Mark device_print ops side-effectful so FX/Inductor does not DCE or reorder these debug callbacks.
-        _mark_op_side_effectful(torch.ops._C_ascend.device_print)
-        _mark_op_side_effectful(torch.ops._C_ascend.device_print_tensor)
-        _DEVICE_PRINT_OP_REGISTERED = True
+        _ = torch.ops._C_ascend.device_print
+        _ = torch.ops._C_ascend.device_print_tensor
+        _ = torch.ops.vllm.device_print_op
+        _ = torch.ops.vllm.device_print_str_op
     except AttributeError as exc:
         raise RuntimeError(
-            "device_print requires _C_ascend.device_print ops to be available "
+            "device_print requires _C_ascend.device_print and "
+            "vllm.device_print_op / device_print_str_op to be available "
             "when custom ops are enabled in the current Ascend build."
         ) from exc
+
+    _DEVICE_PRINT_READY = True
 
 
 def device_print(
     value: torch.Tensor | int | float | bool | str | torch.dtype | torch.device | torch.Size,
-) -> None:
+    carrier: torch.Tensor | None = None,
+) -> torch.Tensor:
     """Print one value from a device callback.
 
     This helper is intended for debugging. To stay replay-safe under
@@ -217,20 +224,29 @@ def device_print(
     Avoid using it in hot paths or long-running high-frequency loops, otherwise
     there may be memory issues due to too many retained payloads.
 
+    Both tensor and text prints go through vLLM custom ops that **return a
+    tensor**, so callers must chain the result onto the FX dataflow (no
+    ``has_side_effect`` needed)::
+
+        >>> x = device_print(x)                 # print tensor
+        >>> x = device_print("msg", x)          # print text, keep x
+        >>> y = device_print(self.linear(x))
+
     Supported usage:
 
         >>> from vllm_ascend.utils import device_print
-        >>> device_print(x)
-        >>> device_print("already formatted text")
-        >>> device_print(7)
+        >>> x = device_print(x)
+        >>> x = device_print("already formatted text", x)
+        >>> x = device_print(7, x)
 
     Unsupported usage:
 
-        >>> device_print("x =", x)
-        >>> device_print("This is ", x, "and this is ", y)
+        >>> device_print("x =", x)   # multi-arg text formatting
+        >>> device_print("msg")      # text without a carrier tensor
 
     If you need device-time tensor values, pass the tensor itself. If you need
-    text, pass one final string that is already formatted.
+    text, pass one final string that is already formatted, plus a carrier
+    tensor so the print is not dead-code-eliminated under ``torch.compile``.
 
     Tensor values are copied to host on the current stream before the callback
     prints them, so printing remains ordered with respect to the surrounding
@@ -238,20 +254,29 @@ def device_print(
 
     DO NOT FORMAT A DEVICE TENSOR INTO A STRING YOURSELF AND THEN PRINT, for example:
 
-        >>> device_print(f"x = {x}")
-        >>> device_print("x = " + str(x))
+        >>> device_print(f"x = {x}", x)
+        >>> device_print("x = " + str(x), x)
     """
-    _ensure_device_print_registered()
+    _ensure_device_print_ready()
 
     if isinstance(value, torch.Tensor):
-        torch.ops._C_ascend.device_print_tensor(value)
-    elif isinstance(value, (str, int, float, bool, torch.dtype, torch.device, torch.Size)):
-        torch.ops._C_ascend.device_print(str(value))
-    else:
-        raise TypeError(
-            f"Unsupported device_print value type: {type(value)!r}. "
-            "Use exactly one argument: device_print(tensor), device_print('formatted text')."
-        )
+        if carrier is not None:
+            raise TypeError(
+                "device_print(tensor) does not take a carrier; use device_print(x) "
+                "or device_print('msg', x) for text."
+            )
+        return torch.ops.vllm.device_print_op(value)
+    if isinstance(value, (str, int, float, bool, torch.dtype, torch.device, torch.Size)):
+        if carrier is None:
+            raise TypeError(
+                "Non-tensor device_print requires a carrier tensor so the print "
+                "stays on the FX dataflow, e.g. x = device_print('msg', x)."
+            )
+        return torch.ops.vllm.device_print_str_op(carrier, str(value))
+    raise TypeError(
+        f"Unsupported device_print value type: {type(value)!r}. "
+        "Use device_print(tensor) or device_print('formatted text', carrier_tensor)."
+    )
 
 
 def _should_trans_nz(weight: torch.Tensor) -> bool:


### PR DESCRIPTION
### What this PR does / why we need it?
310P uses a separate TORCH_LIBRARY registration path and previously did not expose device_print / device_print_tensor. This PR registers those ops on 310P (C++ binding + Meta kernels) and adds Python custom-op wrappers, so vllm_ascend.utils.device_print() works under graph capture/replay (e.g. ACL graph).

### Does this PR introduce _any_ user-facing change?
None

### How was this patch tested?


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
