### PR TITLE
[Misc][Ops]Revert "add trion ops log (#10069)"

### DIFF
--- a/vllm_ascend/ops/triton/activation/swiglu_quant.py
+++ b/vllm_ascend/ops/triton/activation/swiglu_quant.py
@@ -1,5 +1,4 @@
 import torch
-from vllm.logger import logger
 from vllm.triton_utils import tl, triton
 
 from vllm_ascend.ops.triton.triton_utils import extract_slice, get_vectorcore_num
@@ -65,13 +64,6 @@ def _swiglu_quant_kernel(
 
 
 def swiglu_quant(x, group_list, group_list_type, need_quant=True):
-    logger.debug(
-        "[TritonOps] swiglu_quant: x.shape=%s, group_list.shape=%s, group_list_type=%s, need_quant=%s",
-        x.shape,
-        group_list.shape,
-        group_list_type,
-        need_quant,
-    )
     # group_list_type must be 0 cusum or 1 count
     if group_list_type not in [0, 1]:
         raise ValueError(f"group_list_type must be 0 or 1, but got {group_list_type}")

--- a/vllm_ascend/ops/triton/bincount.py
+++ b/vllm_ascend/ops/triton/bincount.py
@@ -22,7 +22,6 @@
 
 import torch
 from vllm.distributed.parallel_state import get_tp_group
-from vllm.logger import logger
 from vllm.triton_utils import tl, triton
 
 from vllm_ascend.ascend_config import get_ascend_config
@@ -97,12 +96,6 @@ def get_token_bin_counts_and_mask_triton(
         bin_counts: [num_seqs, vocab_size] int32 counts.
         mask: [num_seqs, vocab_size] bool, True where count > 0.
     """
-    logger.debug(
-        "[TritonOps] get_token_bin_counts_and_mask_triton: tokens.shape=%s, vocab_size=%s, num_seqs=%s",
-        tokens.shape,
-        vocab_size,
-        num_seqs,
-    )
     n_rows, n_cols = tokens.shape
     if num_seqs is not None and num_seqs > 0:
         assert n_rows == num_seqs, f"tokens rows must match num_seqs: tokens.shape[0]={n_rows}, num_seqs={num_seqs}"

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -14,7 +14,6 @@ import torch
 from einops import rearrange
 from vllm.distributed import get_pcp_group
 from vllm.forward_context import get_forward_context
-from vllm.logger import logger
 from vllm.model_executor.layers.fla.ops.utils import SUPPRESS_LEVEL
 
 from .chunk_delta_h import chunk_gated_delta_rule_fwd_h  # noqa: F401
@@ -203,22 +202,6 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         prebuilt_meta=None,
         use_qk_l2norm_in_kernel: bool = False,
     ):
-        logger.debug(
-            "[TritonOps] chunk_gated_delta_rule_fwd: q.shape=%s, k.shape=%s, "
-            "v.shape=%s, g.shape=%s, beta.shape=%s, scale=%s, "
-            "initial_state.shape=%s, output_final_state=%s, cu_seqlens_shape=%s, "
-            "use_qk_l2norm_in_kernel=%s.",
-            q.shape,
-            k.shape,
-            v.shape,
-            g.shape,
-            beta.shape,
-            scale,
-            initial_state.shape if initial_state is not None else None,
-            output_final_state,
-            cu_seqlens.shape if cu_seqlens is not None else None,
-            use_qk_l2norm_in_kernel,
-        )
         if use_qk_l2norm_in_kernel:
             q = l2norm_fwd(q)
             k = l2norm_fwd(k)

--- a/vllm_ascend/ops/triton/fla/fused_qkvzba_split_reshape.py
+++ b/vllm_ascend/ops/triton/fla/fused_qkvzba_split_reshape.py
@@ -10,7 +10,6 @@
 # ruff: noqa: E501
 # mypy: ignore-errors
 import torch
-from vllm.logger import logger
 from vllm.triton_utils import tl, triton
 
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
@@ -150,16 +149,6 @@ def fused_qkvzba_split_reshape_cat(
     head_qk,
     head_v,
 ):
-    logger.debug(
-        "[TritonOps] fused_qkvzba_split_reshape_cat: mixed_qkvz.shape=%s, mixed_ba.shape=%s, "
-        "num_heads_qk=%s, num_heads_v=%s, head_qk=%s, head_v=%s",
-        mixed_qkvz.shape,
-        mixed_ba.shape,
-        num_heads_qk,
-        num_heads_v,
-        head_qk,
-        head_v,
-    )
     batch, seq_len = mixed_qkvz.shape[0], 1
     total_rows = batch * seq_len
 

--- a/vllm_ascend/ops/triton/fused_gdn_gating.py
+++ b/vllm_ascend/ops/triton/fused_gdn_gating.py
@@ -3,7 +3,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import torch
-from vllm.logger import logger
 from vllm.triton_utils import tl, triton
 
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
@@ -65,16 +64,6 @@ def fused_gdn_gating_patch(
     beta: float = 1.0,
     threshold: float = 20.0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    logger.debug(
-        "[TritonOps] fused_gdn_gating_patch: A_log.shape=%s, a.shape=%s, b.shape=%s, dt_bias.shape=%s, "
-        "beta=%s, threshold=%s",
-        A_log.shape,
-        a.shape,
-        b.shape,
-        dt_bias.shape,
-        beta,
-        threshold,
-    )
     batch, num_heads = a.shape
     seq_len = 1
 

--- a/vllm_ascend/ops/triton/layernorm_gated.py
+++ b/vllm_ascend/ops/triton/layernorm_gated.py
@@ -7,7 +7,6 @@
 # mypy: ignore-errors
 
 import torch
-from vllm.logger import logger
 from vllm.triton_utils import tl, triton
 
 
@@ -139,17 +138,7 @@ def layer_norm_fwd_npu(
     MAX_FUSED_SIZE = 65536 // x.element_size()
     BLOCK_N = min(MAX_FUSED_SIZE, triton.next_power_of_2(group_size))
     if group_size > BLOCK_N:
-        logger.error(
-            "[TritonOps] Feature dim too large: group_size=%s exceeds BLOCK_N=%s (MAX_FUSED_SIZE=%s)",
-            group_size,
-            BLOCK_N,
-            MAX_FUSED_SIZE,
-        )
-        raise RuntimeError(
-            "[TritonOps] Feature dim too large: group_size={} exceeds BLOCK_N={} (MAX_FUSED_SIZE={})".format(
-                group_size, BLOCK_N, MAX_FUSED_SIZE
-            )
-        )
+        raise RuntimeError("Feature dim too large.")
 
     # Choose BLOCK_M: e.g., 16, 32, 64 — depends on NPU vector core capacity
     BLOCK_M = 64  # Tune this based on your NPU's register/shared memory

--- a/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_mrope.py
+++ b/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_mrope.py
@@ -17,7 +17,6 @@
 
 
 import torch
-from vllm.logger import logger
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import direct_register_custom_op
 
@@ -296,15 +295,6 @@ def triton_split_qkv_rmsnorm_mrope(
     k_bias: torch.Tensor | None = None,
     has_gate: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    logger.debug(
-        "[TritonOps] triton_split_qkv_rmsnorm_mrope: qkv.shape=%s, "
-        "num_q_heads=%s, num_kv_heads=%s, head_size=%s, rope_dim=%s",
-        qkv.shape,
-        num_q_heads,
-        num_kv_heads,
-        head_size,
-        rope_dim,
-    )
     core_num = get_vectorcore_num()
 
     q_size = num_q_heads * head_size

--- a/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_rope.py
+++ b/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_rope.py
@@ -16,7 +16,6 @@
 #
 
 import torch
-from vllm.logger import logger
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import direct_register_custom_op
 
@@ -275,13 +274,6 @@ def split_qkv_rmsnorm_rope_impl(
     q_bias: torch.Tensor | None = None,
     k_bias: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    logger.debug(
-        "[TritonOps] split_qkv_rmsnorm_rope_impl: input.shape=%s, q_hidden_size=%s, kv_hidden_size=%s, head_dim=%s",
-        input.shape,
-        q_hidden_size,
-        kv_hidden_size,
-        head_dim,
-    )
     # get available vector core
     num_vectorcore = get_vectorcore_num()
     rope_dim = cos_sin_cache.shape[-1]

--- a/vllm_ascend/ops/triton/linearnorm/split_qkv_tp_rmsnorm_rope.py
+++ b/vllm_ascend/ops/triton/linearnorm/split_qkv_tp_rmsnorm_rope.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import torch
 from vllm.distributed.communication_op import tensor_model_parallel_all_reduce
-from vllm.logger import logger
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import direct_register_custom_op
 
@@ -244,13 +243,6 @@ def split_qkv_tp_rmsnorm_rope_impl(
     cos: torch.Tensor,
     sin: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    logger.debug(
-        "[TritonOps] split_qkv_tp_rmsnorm_rope_impl: input.shape=%s, q_hidden_size=%s, kv_hidden_size=%s, head_dim=%s",
-        input.shape,
-        q_hidden_size,
-        kv_hidden_size,
-        head_dim,
-    )
     num_tokens = input.shape[0]
     input_2d = input.view(num_tokens, -1)
     q = torch.empty(num_tokens, q_hidden_size, device=input.device, dtype=input.dtype)

--- a/vllm_ascend/ops/triton/mamba/causal_conv1d.py
+++ b/vllm_ascend/ops/triton/mamba/causal_conv1d.py
@@ -13,11 +13,8 @@ import torch
 import torch.nn.functional as F
 from vllm.distributed import get_pcp_group
 from vllm.forward_context import get_forward_context
-from vllm.logger import logger
 from vllm.triton_utils import HAS_TRITON, tl, triton
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID  # type: ignore
-
-from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 
 if not HAS_TRITON:
     from vllm_ascend._310p.ops.causal_conv1d import (
@@ -45,8 +42,7 @@ def causal_conv1d_ref(
     out: (batch, dim, seqlen)
     """
     if activation not in [None, "silu", "swish"]:
-        logger.error("[TritonOps] activation must be None, silu, or swish, got activation=%s.", activation)
-        raise NotImplementedError("activation must be None, silu, or swish, got activation=%s.", activation)
+        raise NotImplementedError("activation must be None, silu, or swish")
     dtype_in = x.dtype
     x = x.to(weight.dtype)
     seqlen = x.shape[-1]
@@ -117,8 +113,7 @@ def causal_conv1d_fn(
         num_decodes = attn_metadata.num_decodes
 
     if activation not in [None, "silu", "swish"]:
-        logger.error("[TritonOps] activation must be None, silu, or swish, got activation=%s.", activation)
-        raise NotImplementedError("[TritonOps] activation must be None, silu, or swish, got activation=%s.", activation)
+        raise NotImplementedError("activation must be None, silu, or swish")
     if x.stride(-1) != 1:
         x = x.contiguous()
     bias = bias.contiguous() if bias is not None else None
@@ -590,13 +585,6 @@ def causal_conv1d_update_npu(
             indices 0 and 3
     out: (batch, dim) or (batch, dim, seqlen) or (num_tokens, dim), same shape as `x`
     """
-    logger.debug(
-        "[TritonOps] causal_conv1d_update_npu: x.shape=%s, conv_state.shape=%s, weight.shape=%s, activation=%s",
-        x.shape,
-        conv_state.shape,
-        weight.shape,
-        activation,
-    )
     if not HAS_TRITON:
         return _pytorch_update(
             x,
@@ -665,7 +653,7 @@ def causal_conv1d_update_npu(
     # keep program count around ~[80..160]
     # vector core 40
     # TODO: use driver to get the vector core num
-    CORE_HINT = get_vectorcore_num()
+    CORE_HINT = 40
     # channel tile: 512 when dim large (reduce tasks), else 256
     block_n = 512 if dim >= 512 else 256
     g = triton.cdiv(dim, block_n)

--- a/vllm_ascend/ops/triton/mamba/lightning_attn.py
+++ b/vllm_ascend/ops/triton/mamba/lightning_attn.py
@@ -25,7 +25,6 @@ used in BailingMoELinearAttention:
 
 import torch
 from einops import rearrange
-from vllm.logger import logger
 from vllm.triton_utils import tl, triton
 
 
@@ -545,16 +544,6 @@ def lightning_attention_npu(
     kv_history: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """lightning attention forward pass (NPU-friendly)."""
-    logger.debug(
-        "[TritonOps] lightning_attention_npu: q.shape=%s, k.shape=%s, v.shape=%s, ed.shape=%s, "
-        "block_size=%s, kv_history.shape=%s",
-        q.shape,
-        k.shape,
-        v.shape,
-        ed.shape,
-        block_size,
-        kv_history.shape if kv_history is not None else None,
-    )
     d = q.shape[-1]
     e = v.shape[-1]
 

--- a/vllm_ascend/ops/triton/mul_add.py
+++ b/vllm_ascend/ops/triton/mul_add.py
@@ -27,7 +27,7 @@ def muls_add_kernel(
 
 
 def muls_add_triton(x: torch.Tensor, y: torch.Tensor, scale: float) -> torch.Tensor:
-    assert x.shape == y.shape, f"Input tensors must have the same shape, got x.shape={x.shape} and y.shape={y.shape}"
+    assert x.shape == y.shape, "Input tensors must have the same shape."
     hidden_size = x.shape[-1]
 
     n_elements = x.numel()

--- a/vllm_ascend/ops/triton/muls_add.py
+++ b/vllm_ascend/ops/triton/muls_add.py
@@ -27,7 +27,7 @@ def muls_add_kernel(
 
 
 def muls_add_triton(x: torch.Tensor, y: torch.Tensor, scale: float) -> torch.Tensor:
-    assert x.shape == y.shape, f"Input tensors must have the same shape, got x.shape={x.shape} and y.shape={y.shape}"
+    assert x.shape == y.shape, "Input tensors must have the same shape."
     hidden_size = x.shape[-1]
 
     n_elements = x.numel()

--- a/vllm_ascend/ops/triton/penalty.py
+++ b/vllm_ascend/ops/triton/penalty.py
@@ -21,7 +21,6 @@
 # Reference: https://github.com/vllm-project/vllm-ascend/pull/6979
 
 import torch
-from vllm.logger import logger
 from vllm.triton_utils import tl, triton
 
 from vllm_ascend.ops.triton.bincount import get_token_bin_counts_and_mask_triton
@@ -105,13 +104,6 @@ def apply_penalties_triton(
     """Apply penalties to logits in place. Same interface as
     model_executor.layers.utils.apply_penalties.
     """
-    logger.debug(
-        "[TritonOps] apply_penalties_triton: logits.shape=%s, prompt_tokens_tensor.shape=%s, "
-        "output_tokens_tensor.shape=%s",
-        logits.shape,
-        prompt_tokens_tensor.shape,
-        output_tokens_tensor.shape,
-    )
     num_seqs, vocab_size = logits.shape
     _, prompt_mask = get_token_bin_counts_and_mask_triton(prompt_tokens_tensor, vocab_size, num_seqs)
     output_bin_counts, output_mask = get_token_bin_counts_and_mask_triton(

--- a/vllm_ascend/ops/triton/rms_norm.py
+++ b/vllm_ascend/ops/triton/rms_norm.py
@@ -1,5 +1,4 @@
 import torch
-from vllm.logger import logger
 from vllm.triton_utils import tl, triton
 
 
@@ -38,7 +37,6 @@ def triton_q_rms(
     q,  # bs, 64, 512
     variance_epsilon,
 ):
-    logger.debug("[TritonOps] triton_q_rms: q.shape=%s, variance_epsilon=%s", q.shape, variance_epsilon)
     bs, head_num, dim = q.shape
     total_batch = bs * head_num
     q = q.view(total_batch, dim)

--- a/vllm_ascend/ops/triton/rope.py
+++ b/vllm_ascend/ops/triton/rope.py
@@ -15,7 +15,6 @@
 # This file is a part of the vllm-ascend project.
 #
 import torch
-from vllm.logger import logger
 from vllm.triton_utils import tl, triton
 
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
@@ -269,14 +268,6 @@ def rope_forward_triton(
     if not k.is_contiguous():
         k = k.contiguous()
 
-    logger.debug(
-        "[TritonOps] rope_forward_triton: q.shape=%s, k.shape=%s, rope_dim=%s, is_neox_style=%s",
-        q.shape,
-        k.shape,
-        rope_dim,
-        is_neox_style,
-    )
-
     num_tokens, n_q_head, head_dim = q.shape
     n_kv_head = k.shape[1]
     # TODO: use a more robust method to get BLOCK_SIZE_HEAD
@@ -367,14 +358,6 @@ def rope_forward_triton_siso(
     if not qk.is_contiguous():
         qk = qk.contiguous()
 
-    logger.debug(
-        "[TritonOps] rope_forward_triton_siso: qk.shape=%s, cos.shape=%s, sin.shape=%s, rope_dim=%s, is_neox_style=%s",
-        qk.shape,
-        cos.shape if cos is not None else None,
-        sin.shape if sin is not None else None,
-        rope_dim,
-        is_neox_style,
-    )
     num_tokens, n_head, head_dim = qk.shape
     assert rope_dim <= head_dim
     pad_rope_dim = triton.next_power_of_2(rope_dim)

--- a/vllm_ascend/ops/triton/triton_utils.py
+++ b/vllm_ascend/ops/triton/triton_utils.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 import torch
-from vllm.logger import logger
 from vllm.triton_utils import HAS_TRITON, tl, triton
 
 _NUM_AICORE = -1
@@ -12,18 +11,12 @@ if HAS_TRITON:
     try:
         import triton.language.extra.cann.extension as _extension_module  # type: ignore
     except ImportError:
-        logger.warning(
-            "[TritonOps] Failed to import "
-            "triton.language.extra.cann.extension, "
-            "falling back to triton.language for op resolution."
-        )
         _extension_module = None
 
 
 def _resolve_triton_ascend_op(op_name: str):
     if not HAS_TRITON:
-        logger.error("[TritonOps] Failed to resolve Triton op '%s' because HAS_TRITON is False.", op_name)
-        raise RuntimeError("[TritonOps] Failed to resolve Triton op '{}' because HAS_TRITON is False.".format(op_name))
+        raise RuntimeError(f"Triton op '{op_name}' cannot be resolved because HAS_TRITON is False")
 
     if _extension_module is not None:
         extension_op = getattr(_extension_module, op_name, None)
@@ -34,14 +27,9 @@ def _resolve_triton_ascend_op(op_name: str):
     if tl_op is not None:
         return tl_op
 
-    logger.error(
-        "[TritonOps] Failed to resolve Triton op '%s': "
-        "neither triton.language.extra.cann.extension nor triton.language provides it.",
-        op_name,
-    )
     raise RuntimeError(
-        "[TritonOps] Failed to resolve Triton op '{}': "
-        "neither triton.language.extra.cann.extension nor triton.language provides it.".format(op_name)
+        f"Failed to resolve Triton op '{op_name}': "
+        "neither triton.language.extra.cann.extension nor triton.language provides it."
     )
 
 
@@ -49,7 +37,6 @@ if HAS_TRITON:
     insert_slice = _resolve_triton_ascend_op("insert_slice")
     extract_slice = _resolve_triton_ascend_op("extract_slice")
     get_element = _resolve_triton_ascend_op("get_element")
-    logger.debug("[TritonOps] Resolved triton ascend ops: insert_slice, extract_slice, get_element")
 else:
     insert_slice = None
     extract_slice = None
@@ -64,47 +51,16 @@ def init_device_properties_triton():
         )
         _NUM_AICORE = device_properties.get("num_aicore", -1)
         _NUM_VECTORCORE = device_properties.get("num_vectorcore", -1)
-        if _NUM_AICORE <= 0 or _NUM_VECTORCORE <= 0:
-            logger.error(
-                "[TritonOps] Failed to detect device properties: num_aicore=%s, num_vectorcore=%s",
-                _NUM_AICORE,
-                _NUM_VECTORCORE,
-            )
-            raise RuntimeError(
-                "[TritonOps] Failed to detect device properties: num_aicore={}, num_vectorcore={}".format(
-                    _NUM_AICORE, _NUM_VECTORCORE
-                )
-            )
+        assert _NUM_AICORE > 0 and _NUM_VECTORCORE > 0, "Failed to detect device properties."
 
 
 def get_aicore_num():
     global _NUM_AICORE
-    if _NUM_AICORE <= 0:
-        logger.error(
-            "[TritonOps] Device properties not initialized (num_aicore=%s). "
-            "Call init_device_properties_triton() first.",
-            _NUM_AICORE,
-        )
-        raise RuntimeError(
-            "[TritonOps] Device properties not initialized "
-            "(num_aicore={}). "
-            "Call init_device_properties_triton() first.".format(_NUM_AICORE)
-        )
+    assert _NUM_AICORE > 0, "Device properties not initialized. Please call init_device_properties_triton() first."
     return _NUM_AICORE
 
 
 def get_vectorcore_num():
     global _NUM_VECTORCORE
-    if _NUM_VECTORCORE <= 0:
-        logger.error(
-            "[TritonOps] Device properties not initialized "
-            "num_vectorcore=%s). "
-            "Call init_device_properties_triton() first.",
-            _NUM_VECTORCORE,
-        )
-        raise RuntimeError(
-            "[TritonOps] Device properties not initialized "
-            "(num_vectorcore={}). "
-            "Call init_device_properties_triton() first.".format(_NUM_VECTORCORE)
-        )
+    assert _NUM_VECTORCORE > 0, "Device properties not initialized. Please call init_device_properties_triton() first."
     return _NUM_VECTORCORE


### PR DESCRIPTION
This reverts commit 97c7f0dadf595bb766236a447735a2448dd40874.

### What this PR does / why we need it?
Revert "add trion ops log (#10069)" for CI
### Does this PR introduce _any_ user-facing change?
Does not.
### How was this patch tested?

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
