### PR TITLE
[DOC] Fix accuracy evaluation description in Qwen3.5-27B tutorialUpdate Qwen3.5-27B.md

### DIFF
--- a/docs/source/tutorials/models/Qwen3.5-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B.md
@@ -156,7 +156,7 @@ curl http://localhost:8000/v1/completions \
 
 ## Accuracy Evaluation
 
-Here are two accuracy evaluation methods.
+Here is the accuracy evaluation method.
 
 ### Using AISBench
 


### PR DESCRIPTION
[DOC] Fix accuracy evaluation description in Qwen3.5-27B tutorial
     
     Fixes #10389
     
     The documentation incorrectly stated 'two accuracy evaluation methods' 
     when only one method (Using AISBench) is documented.

### What this PR does / why we need it?
This PR fixes a documentation error in the Qwen3.5-27B tutorial.
**Changes:**
- Fixed the incorrect description "Here are two accuracy evaluation methods" 
- Changed to "Here is the accuracy evaluation method" 
- File: docs/source/tutorials/models/Qwen3.5-27B.md
- Line: 159
**Why needed:**
- The documentation incorrectly stated there were "two" accuracy evaluation methods
- However, only one method (Using AISBench) is documented in the Accuracy Evaluation section
- The Performance section has two methods (AISBench and vLLM Benchmark), but those are for performance evaluation, not accuracy evaluation
- This creates confusion for users reading the tutorial
Fixes #10389
### Does this PR introduce _any_ user-facing change?
No user-facing change.
This is a documentation-only update that corrects a misleading description text. 
No API, interface, or behavior changes are introduced.
### How was this patch tested?
No tests required.
This is a documentation text fix. Verified by:
1. Reading the Accuracy Evaluation section to confirm only one method (Using AISBench) is documented
2. Checking the Performance section to confirm the two methods there are for performance, not accuracy
3. Locating the error line (159) in Qwen3.5-27B.md
4. Making the correction: "two accuracy evaluation methods" → "the accuracy evaluation method"
Manual verification confirmed the fix is accurate and resolves the issue described in #10389.

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
