### PR TITLE
[BugFix] Failed to determine MLA for draft model config due to insuff…

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -368,7 +368,8 @@ class NPUPlatform(Platform):
             return
 
         # MLA draft models do not use the GQA/MQA DCP head-sharding rule.
-        has_draft_mla_config = getattr(draft_model_config.hf_text_config, "kv_lora_rank", None) is not None
+        hf_text_config = getattr(draft_model_config, "hf_text_config", None)
+        has_draft_mla_config = getattr(hf_text_config, "kv_lora_rank", None) is not None
         if draft_model_config.use_mla or has_draft_mla_config:
             return
 

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -368,7 +368,8 @@ class NPUPlatform(Platform):
             return
 
         # MLA draft models do not use the GQA/MQA DCP head-sharding rule.
-        if draft_model_config.use_mla:
+        has_draft_mla_config = getattr(draft_model_config.hf_text_config,"kv_lora_rank",None) is not None
+        if draft_model_config.use_mla or has_draft_mla_config:
             return
 
         draft_parallel_config = speculative_config.draft_parallel_config

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -368,7 +368,7 @@ class NPUPlatform(Platform):
             return
 
         # MLA draft models do not use the GQA/MQA DCP head-sharding rule.
-        has_draft_mla_config = getattr(draft_model_config.hf_text_config,"kv_lora_rank",None) is not None
+        has_draft_mla_config = getattr(draft_model_config.hf_text_config, "kv_lora_rank", None) is not None
         if draft_model_config.use_mla or has_draft_mla_config:
             return
 


### PR DESCRIPTION
…icient scope

### What this PR does / why we need it?
This PR improves the robustness of MLA (Multi-Head Latent Attention) architecture detection during speculative decoding.
Background:
The previous implementation relied solely on the draft_model_config.use_mla flag to identify MLA-based models. However, some newer models (such as Kimi) do not explicitly set this flag in their configuration. As a result, these models are incorrectly identified as GQA (Grouped Query Attention) models, leading to architectural mismatches and runtime failures.

Changes:
I have updated the detection logic to also check for the kv_lora_rank attribute within hf_text_config. The existence of kv_lora_rank is a reliable indicator that a model utilizes the MLA architecture. By updating the condition to check for either use_mla OR the presence of kv_lora_rank, the system can now correctly identify and support MLA-based models without requiring manual whitelist additions.
### Does this PR introduce _any_ user-facing change?
No，this pr revise the dismiss of model type decision.

### How was this patch tested?
please use the mla eagle model
- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/efc347f1b2e635753ae8a594e9714109c200fcd3
