### PR TITLE
[0.21.0][MISC][KV Pool] Avoid logging KV store keys at error level

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -116,12 +116,15 @@ class MemcacheBackend(Backend):
         assert self.store is not None
         try:
             res = self.store.batch_get_into_layers(key, addr, size, MmcDirect.COPY_G2L.value)
-            failed_count = sum(1 for value in res if value != 0)
+            failed_codes = [int(value) for value in res if value != 0]
+            failed_count = len(failed_codes)
             if failed_count:
+                error_codes = sorted(set(failed_codes))
                 logger.error(
-                    "Failed to get %d keys out of %d. Check key existence and memory state.",
+                    "Failed to get %d keys out of %d. error_codes=%s. Check key existence and memory state.",
                     failed_count,
                     len(key),
+                    error_codes,
                 )
                 logger.debug("Failed to get key details. keys=%s, result=%s", key, res)
             return res
@@ -144,12 +147,15 @@ class MemcacheBackend(Backend):
             self._ensure_initialized()
             assert self.store is not None
             res = self.store.batch_put_from_layers(key, addr, size, MmcDirect.COPY_L2G.value)
-            failed_count = sum(1 for value in res if value != 0)
+            failed_codes = [int(value) for value in res if value != 0]
+            failed_count = len(failed_codes)
             if failed_count:
+                error_codes = sorted(set(failed_codes))
                 logger.error(
-                    "Failed to put %d keys out of %d. Check memory and store capacity.",
+                    "Failed to put %d keys out of %d. error_codes=%s. Check memory and store capacity.",
                     failed_count,
                     len(key),
+                    error_codes,
                 )
                 logger.debug("Failed to put key details. keys=%s, result=%s", key, res)
                 if self._lazy_init:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -105,20 +105,34 @@ class MemcacheBackend(Backend):
 
     def get(self, key: list[str], addr: list[list[int]], size: list[list[int]]):
         if self._lazy_init and not self._store_initialized:
-            logger.error("get() called before store init. keys=%s. Call put() first to trigger initialization.", key)
+            logger.error(
+                "Failed to get %d keys out of %d. Store is not initialized; "
+                "call put() first to trigger initialization.",
+                len(key),
+                len(key),
+            )
+            logger.debug("Failed to get key details. keys=%s", key)
             return
         assert self.store is not None
         try:
             res = self.store.batch_get_into_layers(key, addr, size, MmcDirect.COPY_G2L.value)
-            for value in res:
-                if value != 0:
-                    logger.error(
-                        "Failed to get key. keys=%s, result=%s. Check key existence and memory state.", key, res
-                    )
+            failed_count = sum(1 for value in res if value != 0)
+            if failed_count:
+                logger.error(
+                    "Failed to get %d keys out of %d. Check key existence and memory state.",
+                    failed_count,
+                    len(key),
+                )
+                logger.debug("Failed to get key details. keys=%s, result=%s", key, res)
             return res
         except Exception as e:
             logger.error(
-                "Failed to get key. keys=%s, type=%s, error=%s. Check store state and network.",
+                "Failed to get %d keys out of %d. Check store state and network.",
+                len(key),
+                len(key),
+            )
+            logger.debug(
+                "Failed to get key details. keys=%s, type=%s, error=%s",
                 key,
                 type(e).__name__,
                 e,
@@ -130,14 +144,27 @@ class MemcacheBackend(Backend):
             self._ensure_initialized()
             assert self.store is not None
             res = self.store.batch_put_from_layers(key, addr, size, MmcDirect.COPY_L2G.value)
-            for value in res:
-                if value != 0:
-                    logger.error("Failed to put key. keys=%s, result=%s. Check memory and store capacity.", key, res)
-                    if self._lazy_init:
-                        logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
+            failed_count = sum(1 for value in res if value != 0)
+            if failed_count:
+                logger.error(
+                    "Failed to put %d keys out of %d. Check memory and store capacity.",
+                    failed_count,
+                    len(key),
+                )
+                logger.debug("Failed to put key details. keys=%s, result=%s", key, res)
+                if self._lazy_init:
+                    logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
         except Exception as e:
             logger.error(
-                "Failed to put key. keys=%s, type=%s, error=%s. Check store state and memory.", key, type(e).__name__, e
+                "Failed to put %d keys out of %d. Check store state and memory.",
+                len(key),
+                len(key),
+            )
+            logger.debug(
+                "Failed to put key details. keys=%s, type=%s, error=%s",
+                key,
+                type(e).__name__,
+                e,
             )
             if self._lazy_init:
                 logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -236,13 +236,6 @@ class MooncakeBackend(Backend):
             failed_codes = [int(value) for value in res_list if value < 0]
             failed_count = len(failed_codes)
             error_codes = sorted(set(failed_codes))
-            logger.debug(
-                "MooncakeBackend.get result keys=%d result_sample=%s negative_count=%d error_codes=%s",
-                len(keys),
-                res_list[:12],
-                failed_count,
-                error_codes,
-            )
             if failed_count:
                 logger.error(
                     "Failed to get %d keys out of %d. error_codes=%s. Check key existence and memory state.",

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -186,12 +186,15 @@ class MooncakeBackend(Backend):
                 config.preferred_segment = self.local_seg
             config.prefer_alloc_in_same_node = self.config.prefer_alloc_in_same_node
             res = self.store.batch_put_from_multi_buffers(keys, addrs, sizes, config)
-            failed_count = sum(1 for value in res if value < 0)
+            failed_codes = [int(value) for value in res if value < 0]
+            failed_count = len(failed_codes)
             if failed_count:
+                error_codes = sorted(set(failed_codes))
                 logger.error(
-                    "Failed to put %d keys out of %d. Check memory and store capacity.",
+                    "Failed to put %d keys out of %d. error_codes=%s. Check memory and store capacity.",
                     failed_count,
                     len(keys),
+                    error_codes,
                 )
                 logger.debug("Failed to put key details. keys=%s, result=%s", keys, res)
                 if self._lazy_init:
@@ -230,18 +233,22 @@ class MooncakeBackend(Backend):
         try:
             res = self.store.batch_get_into_multi_buffers(keys, addrs, sizes)
             res_list = list(res)
-            failed_count = sum(1 for value in res_list if value < 0)
+            failed_codes = [int(value) for value in res_list if value < 0]
+            failed_count = len(failed_codes)
+            error_codes = sorted(set(failed_codes))
             logger.debug(
-                "MooncakeBackend.get result keys=%d result_sample=%s negative_count=%d",
+                "MooncakeBackend.get result keys=%d result_sample=%s negative_count=%d error_codes=%s",
                 len(keys),
                 res_list[:12],
                 failed_count,
+                error_codes,
             )
             if failed_count:
                 logger.error(
-                    "Failed to get %d keys out of %d. Check key existence and memory state.",
+                    "Failed to get %d keys out of %d. error_codes=%s. Check key existence and memory state.",
                     failed_count,
                     len(keys),
+                    error_codes,
                 )
                 logger.debug("Failed to get key details. keys=%s, result=%s", keys, res_list)
             for i, value in enumerate(res_list):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -230,13 +230,13 @@ class MooncakeBackend(Backend):
         try:
             res = self.store.batch_get_into_multi_buffers(keys, addrs, sizes)
             res_list = list(res)
+            failed_count = sum(1 for value in res_list if value < 0)
             logger.debug(
                 "MooncakeBackend.get result keys=%d result_sample=%s negative_count=%d",
                 len(keys),
                 res_list[:12],
-                sum(1 for value in res_list if value < 0),
+                failed_count,
             )
-            failed_count = sum(1 for value in res_list if value < 0)
             if failed_count:
                 logger.error(
                     "Failed to get %d keys out of %d. Check key existence and memory state.",

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -186,14 +186,24 @@ class MooncakeBackend(Backend):
                 config.preferred_segment = self.local_seg
             config.prefer_alloc_in_same_node = self.config.prefer_alloc_in_same_node
             res = self.store.batch_put_from_multi_buffers(keys, addrs, sizes, config)
-            for value in res:
-                if value < 0:
-                    logger.error("Failed to put key. keys=%s, result=%s. Check memory and store capacity.", keys, res)
-                    if self._lazy_init:
-                        logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
+            failed_count = sum(1 for value in res if value < 0)
+            if failed_count:
+                logger.error(
+                    "Failed to put %d keys out of %d. Check memory and store capacity.",
+                    failed_count,
+                    len(keys),
+                )
+                logger.debug("Failed to put key details. keys=%s, result=%s", keys, res)
+                if self._lazy_init:
+                    logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
         except Exception as e:
             logger.error(
-                "Failed to put key. keys=%s, type=%s, error=%s. Check store state and memory.",
+                "Failed to put %d keys out of %d. Check store state and memory.",
+                len(keys),
+                len(keys),
+            )
+            logger.debug(
+                "Failed to put key details. keys=%s, type=%s, error=%s",
                 keys,
                 type(e).__name__,
                 e,
@@ -203,7 +213,13 @@ class MooncakeBackend(Backend):
 
     def get(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         if self._lazy_init and not self._store_initialized:
-            logger.error("get() called before store init. keys=%s. Call put() first to trigger initialization.", keys)
+            logger.error(
+                "Failed to get %d keys out of %d. Store is not initialized; "
+                "call put() first to trigger initialization.",
+                len(keys),
+                len(keys),
+            )
+            logger.debug("Failed to get key details. keys=%s", keys)
             return
         assert self.store is not None
         logger.debug(
@@ -220,17 +236,26 @@ class MooncakeBackend(Backend):
                 res_list[:12],
                 sum(1 for value in res_list if value < 0),
             )
+            failed_count = sum(1 for value in res_list if value < 0)
+            if failed_count:
+                logger.error(
+                    "Failed to get %d keys out of %d. Check key existence and memory state.",
+                    failed_count,
+                    len(keys),
+                )
+                logger.debug("Failed to get key details. keys=%s, result=%s", keys, res_list)
             for i, value in enumerate(res_list):
-                if value < 0:
-                    logger.error(
-                        "Failed to get key. keys=%s, result=%s. Check key existence and memory state.", keys, res_list
-                    )
-                elif value > 0:
+                if value > 0:
                     res_list[i] = 0
             return res_list
         except Exception as e:
             logger.error(
-                "Failed to get key. keys=%s, type=%s, error=%s. Check store state and network.",
+                "Failed to get %d keys out of %d. Check store state and network.",
+                len(keys),
+                len(keys),
+            )
+            logger.debug(
+                "Failed to get key details. keys=%s, type=%s, error=%s",
                 keys,
                 type(e).__name__,
                 e,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
@@ -155,9 +155,11 @@ class YuanrongBackend(Backend):
     def get(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         if len(keys) == 0:
             return
+        failed_keys_for_log = keys
         try:
             self._ensure_device_ready()
             keys = self._helper.normalize_keys(keys)
+            failed_keys_for_log = keys
             blob_lists = self._helper.make_blob_lists(addrs, sizes)
             failed_keys: list[str] = []
             if len(keys) <= self._DS_MAX_BATCH_KEYS:
@@ -166,6 +168,7 @@ class YuanrongBackend(Backend):
                 )
             else:
                 for start, end in _iter_slices(len(keys), self._DS_MAX_BATCH_KEYS):
+                    failed_keys_for_log = keys[start:end]
                     failed_keys.extend(
                         self._hetero_client.mget_h2d(  # type: ignore[union-attr]
                             keys[start:end], blob_lists[start:end], 0
@@ -173,14 +176,20 @@ class YuanrongBackend(Backend):
                     )
             if failed_keys:
                 logger.error(
-                    "Failed to get keys. failed_count=%d, sample_keys=%s. Check key existence and memory state.",
+                    "Failed to get %d keys out of %d. Check key existence and memory state.",
                     len(failed_keys),
-                    failed_keys[:10],
+                    len(keys),
                 )
+                logger.debug("Failed to get key details. failed_keys=%s", failed_keys)
         except Exception as exc:
             logger.error(
-                "Failed to get keys. keys_count=%d, type=%s, error=%s. Check network and yuanrong service.",
+                "Failed to get %d keys out of %d. Check network and yuanrong service.",
+                len(failed_keys_for_log),
                 len(keys),
+            )
+            logger.debug(
+                "Failed to get key details. keys=%s, type=%s, error=%s",
+                failed_keys_for_log,
                 type(exc).__name__,
                 exc,
             )
@@ -188,9 +197,11 @@ class YuanrongBackend(Backend):
     def put(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         if len(keys) == 0:
             return
+        failed_keys_for_log = keys
         try:
             self._ensure_device_ready()
             keys = self._helper.normalize_keys(keys)
+            failed_keys_for_log = keys
             blob_lists = self._helper.make_blob_lists(addrs, sizes)
             if len(keys) <= self._DS_MAX_BATCH_KEYS:
                 self._hetero_client.mset_d2h(  # type: ignore[union-attr]
@@ -198,13 +209,19 @@ class YuanrongBackend(Backend):
                 )
             else:
                 for start, end in _iter_slices(len(keys), self._DS_MAX_BATCH_KEYS):
+                    failed_keys_for_log = keys[start:end]
                     self._hetero_client.mset_d2h(  # type: ignore[union-attr]
                         keys[start:end], blob_lists[start:end], self._ds_set_param
                     )
         except Exception as exc:
             logger.error(
-                "Failed to put keys. keys_count=%d, type=%s, error=%s. Check network and yuanrong service.",
+                "Failed to put %d keys out of %d. Check network and yuanrong service.",
+                len(failed_keys_for_log),
                 len(keys),
+            )
+            logger.debug(
+                "Failed to put key details. keys=%s, type=%s, error=%s",
+                failed_keys_for_log,
                 type(exc).__name__,
                 exc,
             )


### PR DESCRIPTION
## What

- Avoid logging full KV store keys at error level in Mooncake, Memcache, and Yuanrong backends.
- Log failed key counts and unique result error codes for KV store result failures.
- Keep detailed key/result information at debug level.

Related main-branch PR: #10329

## Validation

vLLM version: v0.21.0
vLLM main: vllm-project/vllm@9090368b650896bf5fc990c921df7eb4c20355a5
