### PR TITLE
[CI]: terminate parent process before children in RemoteOpenAIServer cleanup

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -426,6 +426,14 @@ class RemoteOpenAIServer:
             return
 
         children = parent.children(recursive=True)
+
+        try:
+            parent.terminate()
+            parent.wait(timeout=60)
+        except (psutil.NoSuchProcess, psutil.TimeoutExpired):
+            with contextlib.suppress(psutil.NoSuchProcess):
+                parent.kill()
+
         for child in children:
             with contextlib.suppress(psutil.NoSuchProcess):
                 child.terminate()
@@ -435,13 +443,6 @@ class RemoteOpenAIServer:
         for child in still_alive:
             with contextlib.suppress(psutil.NoSuchProcess):
                 child.kill()
-
-        try:
-            parent.terminate()
-            parent.wait(timeout=10)
-        except (psutil.NoSuchProcess, psutil.TimeoutExpired):
-            with contextlib.suppress(psutil.NoSuchProcess):
-                parent.kill()
 
     def url_for(self, *parts: str) -> str:
         return self.url_root + "/" + "/".join(parts)


### PR DESCRIPTION
Reorder cleanup in RemoteOpenAIServer.__exit__ to terminate the parent process first, preventing orphan child processes when parent termination fails or times out.

<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
