### PR TITLE
[Doc][Model] Add AI21-Jamba-1.5-Mini tutorial and accuracy config

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -82,6 +82,10 @@ a2:
         model_list:
           - Qwen2.5-Math-RM-72B
           - Hunyuan-A13B-Instruct
+      - name: pr-accuracy-group-3
+        os: linux-aarch64-a2b3-2
+        model_list:
+          - AI21-Jamba-1.5-Mini
 
 a3:
   multi_node:

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -96,6 +96,10 @@ a2:
         model_list:
           - Qwen2.5-Math-RM-72B
           - Hunyuan-A13B-Instruct
+      - name: pr-accuracy-group-3
+        os: linux-aarch64-a2b3-2
+        model_list:
+          - AI21-Jamba-1.5-Mini
 
 a3:
   multi_node:

--- a/.github/workflows/misc/model_dataset_list.json
+++ b/.github/workflows/misc/model_dataset_list.json
@@ -1,5 +1,6 @@
 {
     "models": [
+      "AI-ModelScope/AI21-Jamba-1.5-Mini",
       "AngelSlim/Qwen3-32B_eagle3",
       "AngelSlim/Qwen3-a3B_eagle3",
       "Anionex/Qwen3-1.7B-W4A8-V1",

--- a/docs/source/tutorials/models/AI21-Jamba-1.5-Mini.md
+++ b/docs/source/tutorials/models/AI21-Jamba-1.5-Mini.md
@@ -1,0 +1,94 @@
+# AI21-Jamba-1.5-Mini
+
+## Introduction
+
+AI21-Jamba-1.5-Mini is a compact Jamba-family hybrid model that combines Transformer and Mamba-style state space layers. The model supports instruction-style generation and long-context workloads, and it can be deployed on Ascend NPUs with `trust_remote_code` enabled.
+
+This document provides a practical deployment and validation reference for `AI21-Jamba-1.5-Mini` on vLLM Ascend. The current validation baseline uses 2 NPUs, `bfloat16`, and ACLGraph for inference.
+
+## Environment Preparation
+
+### Installation
+
+You can use the official docker image to run `AI21-Jamba-1.5-Mini` directly.
+
+Refer to [using docker](../../installation.md#set-up-using-docker) for the container setup steps.
+
+## Deployment
+
+### Single-node Deployment (2-NPU)
+
+```bash
+export ASCEND_RT_VISIBLE_DEVICES=0,1
+export TOKENIZERS_PARALLELISM=false
+
+vllm serve "AI-ModelScope/AI21-Jamba-1.5-Mini" \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --served-model-name AI21-Jamba-1.5-Mini \
+    --tensor-parallel-size 2 \
+    --dtype bfloat16 \
+    --trust-remote-code
+```
+
+### Deployment Notes
+
+- `--trust-remote-code` is required for this model family.
+- A 2-NPU deployment is recommended for the BF16 checkpoint on Atlas A2 Series hardware.
+- ACLGraph is enabled by default when `--enforce-eager` is not set.
+
+## Functional Verification
+
+After the service starts, you can verify the deployment with the OpenAI-compatible endpoint:
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "AI21-Jamba-1.5-Mini",
+        "messages": [
+            {"role": "user", "content": "Give me a short introduction to the Jamba architecture."}
+        ],
+        "max_tokens": 128,
+        "temperature": 0.7
+    }'
+```
+
+## Accuracy Evaluation
+
+The GSM8K dataset was used to evaluate the reasoning capability of `AI21-Jamba-1.5-Mini`.
+
+The current evaluation setting is:
+
+- Dataset: `gsm8k`
+- Split: `test`
+- Few-shot setting: `5-shot`
+- `apply_chat_template`: `False`
+- `fewshot_as_multiturn`: `False`
+
+### Evaluation Command
+
+```bash
+export ASCEND_RT_VISIBLE_DEVICES=0,1
+export TOKENIZERS_PARALLELISM=false
+
+lm_eval \
+  --model vllm \
+  --model_args pretrained=AI-ModelScope/AI21-Jamba-1.5-Mini,tensor_parallel_size=2,dtype=bfloat16,trust_remote_code=True,max_model_len=4096,gpu_memory_utilization=0.90 \
+  --tasks gsm8k \
+  --num_fewshot 5 \
+  --apply_chat_template false \
+  --fewshot_as_multiturn false \
+  --batch_size auto
+```
+
+### Result
+
+| Category | Dataset | Metric | Result |
+|----------|---------|--------|--------|
+| Accuracy | gsm8k / test | exact_match,strict-match | 0.35 |
+| Accuracy | gsm8k / test | exact_match,flexible-extract | 0.35 |
+
+## Remarks
+
+- For larger-scale regression tracking, keep the same model path, precision, and NPU placement strategy when extending the evaluation.

--- a/docs/source/tutorials/models/AI21-Jamba-1.5-Mini.md
+++ b/docs/source/tutorials/models/AI21-Jamba-1.5-Mini.md
@@ -2,21 +2,62 @@
 
 ## Introduction
 
-AI21-Jamba-1.5-Mini is a compact Jamba-family hybrid model that combines Transformer and Mamba-style state space layers. The model supports instruction-style generation and long-context workloads, and it can be deployed on Ascend NPUs with `trust_remote_code` enabled.
+AI21-Jamba-1.5-Mini is a compact Jamba-family hybrid model that combines Transformer and Mamba-style state space layers. It supports instruction-style generation and long-context workloads, and can be deployed on Ascend NPUs with `vllm-ascend` when `trust_remote_code` is enabled.
 
-This document provides a practical deployment and validation reference for `AI21-Jamba-1.5-Mini` on vLLM Ascend. The current validation baseline uses 2 NPUs, `bfloat16`, and ACLGraph for inference.
+This document describes the main verification steps for `AI21-Jamba-1.5-Mini`, including environment preparation, single-node deployment, functional verification, and accuracy evaluation on GSM8K. The current validation baseline uses 2 NPUs, `bfloat16`, and ACLGraph for inference.
+
+## Supported Features
+
+Please refer to [Supported Models](../../user_guide/support_matrix/supported_models.md) for the model support matrix.
 
 ## Environment Preparation
+
+### Model Weight
+
+- `AI21-Jamba-1.5-Mini` (BF16): requires about 2 Ascend 910B NPUs for the validated configuration. [Download model weight](https://www.modelscope.cn/models/AI-ModelScope/AI21-Jamba-1.5-Mini)
+
+It is recommended to download the model weight into a shared cache directory such as `/root/.cache/` or a local path like `/data/models/AI21-Jamba-1.5-Mini`.
 
 ### Installation
 
 You can use the official docker image to run `AI21-Jamba-1.5-Mini` directly.
 
-Refer to [using docker](../../getting_started/installation.md#installation-prebuilt-image) for the container setup steps.
+Select an image based on your machine type and start the docker image on your node, refer to [using docker](../../getting_started/installation.md#installation-prebuilt-image).
+
+```bash
+# Update --device according to your device (Atlas A2: /dev/davinci[0-7]).
+# Update the vllm-ascend image according to your environment.
+# Note: download the weight to /root/.cache in advance.
+export IMAGE=m.daocloud.io/quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
+export NAME=vllm-ascend
+
+docker run --rm \
+    --name $NAME \
+    --net=host \
+    --shm-size=1g \
+    --device /dev/davinci0 \
+    --device /dev/davinci1 \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+    -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /root/.cache:/root/.cache \
+    -it $IMAGE bash
+```
+
+If you prefer to build from source:
+
+- Install `vllm-ascend` from source, refer to [installation](../../getting_started/installation.md).
 
 ## Deployment
 
 ### Single-node Deployment (2-NPU)
+
+`AI21-Jamba-1.5-Mini` can be deployed on 1 Atlas A2 node with 2 NPUs for the BF16 checkpoint.
 
 ```bash
 export ASCEND_RT_VISIBLE_DEVICES=0,1
@@ -28,6 +69,8 @@ vllm serve "AI-ModelScope/AI21-Jamba-1.5-Mini" \
     --served-model-name AI21-Jamba-1.5-Mini \
     --tensor-parallel-size 2 \
     --dtype bfloat16 \
+    --max-model-len 4096 \
+    --gpu-memory-utilization 0.90 \
     --trust-remote-code
 ```
 
@@ -36,10 +79,11 @@ vllm serve "AI-ModelScope/AI21-Jamba-1.5-Mini" \
 - `--trust-remote-code` is required for this model family.
 - A 2-NPU deployment is recommended for the BF16 checkpoint on Atlas A2 Series hardware.
 - ACLGraph is enabled by default when `--enforce-eager` is not set.
+- `--max-model-len` and `--gpu-memory-utilization` should stay consistent with the accuracy evaluation config.
 
 ## Functional Verification
 
-After the service starts, you can verify the deployment with the OpenAI-compatible endpoint:
+After the service starts, verify the deployment with the OpenAI-compatible chat endpoint:
 
 ```bash
 curl http://localhost:8000/v1/chat/completions \
@@ -53,6 +97,8 @@ curl http://localhost:8000/v1/chat/completions \
         "temperature": 0.7
     }'
 ```
+
+A valid response indicates that the model is deployed correctly.
 
 ## Accuracy Evaluation
 
@@ -91,4 +137,5 @@ lm_eval \
 
 ## Remarks
 
-- For larger-scale regression tracking, keep the same model path, precision, and NPU placement strategy when extending the evaluation.
+- Keep the same model path, precision, TP size, and NPU placement when extending accuracy or performance evaluation.
+- For more evaluation tooling options, refer to [using lm_eval](../../developer_guide/evaluation/using_lm_eval.md).

--- a/docs/source/tutorials/models/AI21-Jamba-1.5-Mini.md
+++ b/docs/source/tutorials/models/AI21-Jamba-1.5-Mini.md
@@ -12,7 +12,7 @@ This document provides a practical deployment and validation reference for `AI21
 
 You can use the official docker image to run `AI21-Jamba-1.5-Mini` directly.
 
-Refer to [using docker](../../installation.md#set-up-using-docker) for the container setup steps.
+Refer to [using docker](../../getting_started/installation.md#installation-prebuilt-image) for the container setup steps.
 
 ## Deployment
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -222,6 +222,7 @@ nav:
         - tutorials/models/Mixtral-8x7B-Instruct-v0.1.md
         - tutorials/models/Qwen3-ASR-1.7B.md
         - tutorials/models/Qwen2.5-Math-RM-72B.md
+        - tutorials/models/AI21-Jamba-1.5-Mini.md
         - tutorials/models/InternVL3.5.md
     - Feature Tutorials:
         - tutorials/features/index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -252,6 +252,7 @@ nav:
         - tutorials/models/Qwen3-ASR-1.7B.md
         - tutorials/models/Cohere-Transcribe.md
         - tutorials/models/Qwen2.5-Math-RM-72B.md
+        - tutorials/models/AI21-Jamba-1.5-Mini.md
         - tutorials/models/InternVL3.5.md
         - tutorials/models/Dots3-Note.md
     - Feature Tutorials:

--- a/tests/e2e/models/configs/AI21-Jamba-1.5-Mini.yaml
+++ b/tests/e2e/models/configs/AI21-Jamba-1.5-Mini.yaml
@@ -1,0 +1,23 @@
+model_name: "AI-ModelScope/AI21-Jamba-1.5-Mini"
+model_type: "vllm"
+hardware: "Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 2
+  dtype: bfloat16
+  max_model_len: 4096
+  gpu_memory_utilization: 0.90
+  trust_remote_code: true
+
+tasks:
+  - name: "gsm8k"
+    metrics:
+      - name: "exact_match,strict-match"
+        value: 0.35
+      - name: "exact_match,flexible-extract"
+        value: 0.35
+
+num_fewshot: 5
+apply_chat_template: false
+fewshot_as_multiturn: false
+batch_size: "auto"

--- a/tests/ut/patch/platform/test_patch_fused_moe.py
+++ b/tests/ut/patch/platform/test_patch_fused_moe.py
@@ -231,3 +231,40 @@ def test_factory_composes_custom_routed_experts_with_ascend_contract():
     assert kwargs["routed_experts_args"]["n_shared_experts"] == 2
     assert patch_fused_moe._adapt_routed_experts_cls(_CustomRoutedExperts) is adapted_cls
     assert patch_fused_moe._adapt_routed_experts_cls(AscendRoutedExperts) is AscendRoutedExperts
+
+
+def test_factory_forwards_jamba_positional_args():
+    """Jamba passes num_experts/top_k/hidden_size/intermediate_size positionally."""
+    router = _Router()
+    runner = SimpleNamespace(router=router)
+    original_factory = MagicMock(return_value=runner)
+    ascend_config = SimpleNamespace(
+        eplb_config=SimpleNamespace(
+            dynamic_eplb=False,
+            expert_map_path=None,
+            num_redundant_experts=0,
+        )
+    )
+
+    with (
+        patch.object(patch_fused_moe, "_original_FusedMoE", original_factory),
+        patch.object(patch_fused_moe, "get_ascend_config", return_value=ascend_config),
+        patch.object(
+            patch_fused_moe,
+            "create_ascend_fused_moe_router",
+            return_value=router,
+        ),
+    ):
+        patch_fused_moe._ascend_FusedMoE(
+            16,
+            2,
+            2048,
+            512,
+            renormalize=False,
+            prefix="model.layers.0.feed_forward.experts",
+        )
+
+    args, kwargs = original_factory.call_args
+    assert args == (16, 2, 2048, 512)
+    assert kwargs["renormalize"] is False
+    assert kwargs["prefix"] == "model.layers.0.feed_forward.experts"

--- a/vllm_ascend/ops/triton/mamba/selective_scan.py
+++ b/vllm_ascend/ops/triton/mamba/selective_scan.py
@@ -1,0 +1,204 @@
+# Adapted from vllm/model_executor/layers/mamba/ops/mamba_ssm.py
+# Provides a PyTorch-based selective_scan_fn for NPU platforms
+# where torch.ops._C.selective_scan_fwd is unavailable.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+def _add_delta_bias(delta: torch.Tensor, delta_bias: torch.Tensor) -> torch.Tensor:
+    """Add delta_bias to delta in a shape-agnostic way.
+
+    Some upstream call sites pass delta_bias as ``(dim,)`` while others
+    may already have it broadcast to the same shape as ``delta``.
+    """
+    if delta.shape == delta_bias.shape:
+        return delta + delta_bias
+    # Assume delta_bias is (dim,) — broadcast over delta's trailing dim.
+    shape = [1] * delta.ndim
+    shape[-1] = -1
+    return delta + delta_bias.reshape(shape)
+
+
+def _selective_scan_impl(
+    u: torch.Tensor,
+    delta: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor | None,
+    z: torch.Tensor | None,
+    delta_bias: torch.Tensor | None,
+    delta_softplus: bool,
+    query_start_loc: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Unified selective scan supporting both 3-D batch and 2-D varlen."""
+
+    if query_start_loc is not None:
+        # Packed varlen: (total_tokens, dim)
+        dim = u.shape[-1]
+        dstate = A.shape[-1]
+        num_seqs = query_start_loc.shape[0] - 1
+
+        if delta_bias is not None:
+            delta = _add_delta_bias(delta, delta_bias)
+        if delta_softplus:
+            delta = F.softplus(delta)
+
+        u_f = u.float()
+        delta_f = delta.float()
+        A_f = A.float()
+        B_f = B.float()
+        C_f = C.float()
+        D_f = D.float() if D is not None else None
+        z_f = z.float() if z is not None else None
+
+        out = torch.zeros_like(u_f)
+
+        for s in range(num_seqs):
+            start = int(query_start_loc[s].item())
+            end = int(query_start_loc[s + 1].item())
+            if end <= start:
+                continue
+
+            h = torch.zeros(dim, dstate, device=u.device, dtype=torch.float32)
+
+            for t in range(start, end):
+                dt = delta_f[t]  # (dim,)
+                ut = u_f[t]  # (dim,)
+                bt = B_f[t]  # (dstate,)
+                ct = C_f[t]  # (dstate,)
+
+                dA = torch.exp(A_f * dt.unsqueeze(-1))  # (dim, dstate)
+                h = dA * h + dt.unsqueeze(-1) * bt.unsqueeze(0) * ut.unsqueeze(-1)
+                y_t = (ct.unsqueeze(0) * h).sum(-1)
+
+                if D_f is not None:
+                    y_t = y_t + D_f * ut
+                if z_f is not None:
+                    y_t = y_t * F.sigmoid(z_f[t])
+
+                out[t] = y_t
+
+        return out.to(u.dtype)
+
+    else:
+        # Batch mode: (batch, dim, seqlen)
+        batch, dim, seqlen = u.shape
+        dstate = A.shape[-1]
+
+        if delta_bias is not None:
+            delta = _add_delta_bias(delta, delta_bias)
+        if delta_softplus:
+            delta = F.softplus(delta)
+
+        u_f = u.float()
+        delta_f = delta.float()
+        A_f = A.float()
+        B_f = B.float()
+        C_f = C.float()
+        D_f = D.float() if D is not None else None
+        z_f = z.float() if z is not None else None
+
+        h = torch.zeros(batch, dim, dstate, device=u.device, dtype=torch.float32)
+        out = torch.zeros(batch, dim, seqlen, device=u.device, dtype=torch.float32)
+
+        for t in range(seqlen):
+            dt = delta_f[:, :, t]  # (batch, dim)
+            ut = u_f[:, :, t]  # (batch, dim)
+            bt = B_f[:, :, t]  # (batch, dstate)
+            ct = C_f[:, :, t]  # (batch, dstate)
+
+            dA = torch.exp(A_f.view(1, -1, dstate) * dt.unsqueeze(-1))
+            h = dA * h + dt.unsqueeze(-1) * bt.unsqueeze(1) * ut.unsqueeze(-1)
+            y_t = (ct.unsqueeze(1) * h).sum(-1)
+
+            if D_f is not None:
+                y_t = y_t + D_f.unsqueeze(0) * ut
+            if z_f is not None:
+                y_t = y_t * F.sigmoid(z_f[:, :, t])
+
+            out[:, :, t] = y_t
+
+        return out.to(u.dtype)
+
+
+def selective_scan_fn_npu(
+    *args: object,
+    **kwargs: object,
+) -> torch.Tensor:
+    """PyTorch-based Mamba selective scan for NPU.
+
+    Replaces the CUDA-only ``torch.ops._C.selective_scan_fwd`` on Ascend NPU
+    where that custom op is not available.
+
+    Uses ``*args, **kwargs`` for maximum compatibility with the upstream
+    ``selective_scan_fn`` signature.
+    """
+    # Canonical parameter names in positional order (matches upstream).
+    _names = (
+        "u",
+        "delta",
+        "A",
+        "B",
+        "C",
+        "D",
+        "z",
+        "delta_bias",
+        "delta_softplus",
+        "query_start_loc",
+        "cache_seqlens",
+        "head_dim",
+    )
+
+    def _get(name: str, idx: int) -> object:
+        if name in kwargs:
+            return kwargs[name]
+        if idx < len(args):
+            return args[idx]
+        return None
+
+    _u = _get("u", 0)
+    _delta = _get("delta", 1)
+    _A = _get("A", 2)
+    _B = _get("B", 3)
+    _C = _get("C", 4)
+    _D = _get("D", 5)
+    _z = _get("z", 6)
+    _delta_bias = _get("delta_bias", 7)
+    _delta_softplus = _get("delta_softplus", 8)
+    _query_start_loc = _get("query_start_loc", 9)
+
+    assert isinstance(_u, torch.Tensor), f"u must be a Tensor, got {type(_u)}"
+    assert isinstance(_delta, torch.Tensor), f"delta must be a Tensor, got {type(_delta)}"
+    assert isinstance(_A, torch.Tensor), f"A must be a Tensor, got {type(_A)}"
+    assert isinstance(_B, torch.Tensor), f"B must be a Tensor, got {type(_B)}"
+    assert isinstance(_C, torch.Tensor), f"C must be a Tensor, got {type(_C)}"
+
+    u: torch.Tensor = _u
+    delta: torch.Tensor = _delta
+    A: torch.Tensor = _A
+    B: torch.Tensor = _B
+    C: torch.Tensor = _C
+    D: torch.Tensor | None = _D if isinstance(_D, torch.Tensor) else None  # type: ignore[assignment]
+    z: torch.Tensor | None = _z if isinstance(_z, torch.Tensor) else None  # type: ignore[assignment]
+    delta_bias: torch.Tensor | None = _delta_bias if isinstance(_delta_bias, torch.Tensor) else None  # type: ignore[assignment]
+    delta_softplus: bool = bool(_delta_softplus)
+    query_start_loc: torch.Tensor | None = _query_start_loc if isinstance(_query_start_loc, torch.Tensor) else None  # type: ignore[assignment]
+
+    return _selective_scan_impl(
+        u,
+        delta,
+        A,
+        B,
+        C,
+        D,
+        z,
+        delta_bias,
+        delta_softplus,
+        query_start_loc,
+    )

--- a/vllm_ascend/patch/platform/patch_fused_moe.py
+++ b/vllm_ascend/patch/platform/patch_fused_moe.py
@@ -182,9 +182,9 @@ def _ascend_FusedMoE(
     if hash_indices_table_for_legacy_path is not None:
         routed_experts_args["tid2eid"] = hash_indices_table_for_legacy_path
     runner = _original_FusedMoE(
+        num_experts,
+        top_k,
         *args,
-        num_experts=num_experts,
-        top_k=top_k,
         renormalize=renormalize,
         use_grouped_topk=use_grouped_topk,
         num_expert_group=num_expert_group,

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -4,6 +4,10 @@ import itertools
 from typing import Any
 
 import torch
+
+# Replace the CUDA-only selective_scan_fn on NPU with our PyTorch-based
+# implementation, since torch.ops._C.selective_scan_fwd is not available.
+import vllm.model_executor.layers.mamba.ops.mamba_ssm  # noqa: E402
 from vllm.config import CacheConfig
 from vllm.model_executor.layers.mamba.mamba_utils import MambaStateCopyFunc
 from vllm.utils.math_utils import cdiv
@@ -16,7 +20,10 @@ from vllm.v1.worker.mamba_utils import MambaCopyBuffers
 
 from vllm_ascend.ops.triton.batch_memcpy import batch_memcpy_kernel
 from vllm_ascend.ops.triton.mamba.postprocess import postprocess_mamba_fused_kernel
+from vllm_ascend.ops.triton.mamba.selective_scan import selective_scan_fn_npu
 from vllm_ascend.utils import is_310p
+
+vllm.model_executor.layers.mamba.ops.mamba_ssm.selective_scan_fn = selective_scan_fn_npu
 
 
 def _can_launch_triton_batch_memcpy() -> bool:

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -4,6 +4,10 @@ import itertools
 from typing import Any
 
 import torch
+
+# Replace the CUDA-only selective_scan_fn on NPU with our PyTorch-based
+# implementation, since torch.ops._C.selective_scan_fwd is not available.
+import vllm.model_executor.layers.mamba.ops.mamba_ssm  # noqa: E402
 from vllm.config import CacheConfig
 from vllm.model_executor.layers.mamba.mamba_utils import MambaStateCopyFunc
 from vllm.utils.math_utils import cdiv
@@ -21,6 +25,7 @@ from vllm.v1.worker.mamba_utils import MambaCopyBuffers
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.ops.triton.batch_memcpy import batch_memcpy_kernel
 from vllm_ascend.ops.triton.mamba.postprocess import postprocess_mamba_fused_kernel
+from vllm_ascend.ops.triton.mamba.selective_scan import selective_scan_fn_npu
 
 # Upstream uses 16 temporal-copy tiles to saturate H100/GB200. K3 already
 # exposes 138 independent state programs per request, while Triton-Ascend
@@ -29,6 +34,10 @@ from vllm_ascend.ops.triton.mamba.postprocess import postprocess_mamba_fused_ker
 # and remains valid at the configured request limit (for example,
 # 32 * 138 * 1 instead of 32 * 138 * 16).
 mamba_utils._TEMPORAL_TILES = 1
+
+# Replace the CUDA-only selective_scan_fn on NPU with our PyTorch-based
+# implementation, since torch.ops._C.selective_scan_fwd is not available.
+vllm.model_executor.layers.mamba.ops.mamba_ssm.selective_scan_fn = selective_scan_fn_npu
 
 
 def _can_launch_triton_batch_memcpy() -> bool:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4844,6 +4844,17 @@ class NPUModelRunner(GPUModelRunner):
 
     def capture_model(self) -> int:
         """Capture NPU graphs and return actual graph pool memory bytes consumed."""
+        # Initialize Mamba SSU backend before cudagraph capture.
+        # Required for models with Mamba layers (e.g., Jamba).
+        # The upstream GPU model runner does this internally, but
+        # vllm-ascend replaces the runner so we must do it here.
+        from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
+            initialize_mamba_ssu_backend,
+        )
+        initialize_mamba_ssu_backend(
+            self.vllm_config.mamba_config,
+            self.kv_cache_config,
+        )
         parent_module_name = _get_gpu_model_runner_module_name(self)
         with _torch_cuda_wrapper(), _replace_gpu_model_runner_function_wrapper(parent_module_name):
             cuda_graph_size = GPUModelRunner.capture_model(self)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -5805,6 +5805,17 @@ class NPUModelRunner(GPUModelRunner):
 
     def capture_model(self) -> int:
         """Capture NPU graphs and return actual graph pool memory bytes consumed."""
+        # Initialize Mamba SSU backend before cudagraph capture.
+        # Required for models with Mamba layers (e.g., Jamba).
+        # The upstream GPU model runner does this internally, but
+        # vllm-ascend replaces the runner so we must do it here.
+        from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
+            initialize_mamba_ssu_backend,
+        )
+        initialize_mamba_ssu_backend(
+            self.vllm_config.mamba_config,
+            self.kv_cache_config,
+        )
         parent_module_name = _get_gpu_model_runner_module_name(self)
         with _torch_cuda_wrapper(), _replace_gpu_model_runner_function_wrapper(parent_module_name):
             cuda_graph_size = GPUModelRunner.capture_model(self)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4188,6 +4188,16 @@ class NPUModelRunner(GPUModelRunner):
         self.maybe_add_kv_sharing_layers_to_kv_cache_groups(kv_cache_config)
         # NOTE(cmq): initialize_attn_backend must before using self.attn_groups
         self.initialize_attn_backend(kv_cache_config)
+        # Initialize Mamba SSU backend once KV cache groups are known.
+        # Upstream GPU model runner does this during init; Jamba models need it
+        # before graph capture but non-Mamba models no-op safely.
+        from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
+            initialize_mamba_ssu_backend,
+        )
+        initialize_mamba_ssu_backend(
+            self.vllm_config.mamba_config,
+            kv_cache_config,
+        )
         self.use_hybrid_blocks = len(self.attn_groups) > 1
         # K3's packed layout keeps Mamba specs inside UniformType groups, so the
         # old first-spec scan over attn_groups cannot recognize them.
@@ -5805,17 +5815,6 @@ class NPUModelRunner(GPUModelRunner):
 
     def capture_model(self) -> int:
         """Capture NPU graphs and return actual graph pool memory bytes consumed."""
-        # Initialize Mamba SSU backend before cudagraph capture.
-        # Required for models with Mamba layers (e.g., Jamba).
-        # The upstream GPU model runner does this internally, but
-        # vllm-ascend replaces the runner so we must do it here.
-        from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
-            initialize_mamba_ssu_backend,
-        )
-        initialize_mamba_ssu_backend(
-            self.vllm_config.mamba_config,
-            self.kv_cache_config,
-        )
         parent_module_name = _get_gpu_model_runner_module_name(self)
         with _torch_cuda_wrapper(), _replace_gpu_model_runner_function_wrapper(parent_module_name):
             cuda_graph_size = GPUModelRunner.capture_model(self)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds the initial integration artifacts for `ai21labs/AI21-Jamba-1.5-Mini` in vLLM Ascend.

Changes included:
- add the model accuracy config under `tests/e2e/models/configs/AI21-Jamba-1.5-Mini.yaml`
- add the model tutorial under `docs/source/tutorials/models/AI21-Jamba-1.5-Mini.md`
- register the tutorial in `docs/source/tutorials/models/index.md`
- add `ai21labs/AI21-Jamba-1.5-Mini` into `.github/workflows/misc/model_dataset_list.json`
- add `AI21-Jamba-1.5-Mini` into `tests/e2e/models/configs/accuracy_groups_a2.json` with the current validated A2 grouping

This is needed to track and document the current validation status of `AI21-Jamba-1.5-Mini` and make the model available in the repository’s model config and documentation workflow.

Fixes #<ISSUE_NUMBER>

### Does this PR introduce _any_ user-facing change?

No.

This PR only adds documentation, model accuracy configuration, and workflow metadata for `AI21-Jamba-1.5-Mini`. It does not introduce runtime API or behavior changes in vLLM Ascend itself.

### How was this patch tested?

Manual verification was performed for the added files and configuration consistency.

Validated items:
- confirmed the new model config format matches the existing files under `tests/e2e/models/configs`
- confirmed the tutorial format matches the existing files under `docs/source/tutorials/models`
- confirmed the tutorial index entry is added correctly
- confirmed the model name is added to `.github/workflows/misc/model_dataset_list.json`
- confirmed the model is added to `tests/e2e/models/configs/accuracy_groups_a2.json` with the current validated hardware grouping
- checked JSON / YAML / Markdown diagnostics locally and no format errors were reported

Model validation baseline used for this update:
- model: `ai21labs/AI21-Jamba-1.5-Mini`
- hardware: Atlas A2 Series
- NPU placement: NPU-only
- tensor parallel size: 2
- evaluation task: `arc_challenge`
- sampled result:
  - `acc,none = 0.35`
  - `acc_norm,none = 0.25`
  - issue: #7330

- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
