### PR TITLE
[CI][Build] Rerun nightly with Docker env fix on 971d50b3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,11 +60,11 @@ ARG COMPILE_CUSTOM_KERNELS=1
 ENV DEBIAN_FRONTEND=noninteractive
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1 \
-    VLLM_BATCH_INVARIANT=1
+    OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
 RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+    export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -62,11 +62,11 @@ ARG COMPILE_CUSTOM_KERNELS=1
 ENV DEBIAN_FRONTEND=noninteractive
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1 \
-    VLLM_BATCH_INVARIANT=1
+    OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
 RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+    export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -59,11 +59,11 @@ ARG SOC_VERSION="ascend910_9391"
 ARG COMPILE_CUSTOM_KERNELS=1
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1 \
-    VLLM_BATCH_INVARIANT=1
+    OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
 RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+    export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -59,11 +59,11 @@ ARG SOC_VERSION="ascend910b1"
 ARG COMPILE_CUSTOM_KERNELS=1
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1 \
-    VLLM_BATCH_INVARIANT=1
+    OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
 RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+    export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \


### PR DESCRIPTION
### What this PR does / why we need it?

This PR prepares a nightly CI rerun on top of commit `971d50b3f982fd2ba7d9ffdee35e985fc54cd808` and reapplies the Docker environment fix from #10423.

The change moves `VLLM_BATCH_INVARIANT=1` out of the global `ENV` block and exports it only during the vLLM Ascend installation step. This keeps the variable available to `pip install` without persisting it in the final image.

The change is applied consistently to:

- `Dockerfile`
- `Dockerfile.a3`
- `Dockerfile.a3.openEuler`
- `Dockerfile.openEuler`

### Does this PR introduce _any_ user-facing change?

No. This PR is intended to rerun CI against the specified historical baseline with the Docker build fix applied.

### How was this patch tested?

- Verified the branch is based on `971d50b3f982fd2ba7d9ffdee35e985fc54cd808`.
- Verified the four-file diff matches #10423.
- Docker build and nightly suites were not run locally; this PR is intended to exercise those CI jobs.
- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/efc347f1b2e635753ae8a594e9714109c200fcd3
