### PR TITLE
[Feature][20.2] Support AscendStore load masks

### DIFF
--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -17,9 +17,10 @@
 
 import hashlib
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store import config_data as config_data_mod
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     AscendConnectorMetadata,
     ChunkedTokenDatabase,
@@ -30,6 +31,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     PoolKey,
     ReqMeta,
     RequestTracker,
+    _get_manager_class_for_spec,
     get_block_hashes,
 )
 
@@ -245,6 +247,47 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         self.assertEqual(len(new_keys), 2)
         self.assertIn("@pp_rank:0", new_keys[0])
         self.assertIn("@pp_rank:1", new_keys[1])
+
+
+class TestManagerClassResolution(unittest.TestCase):
+    def tearDown(self):
+        self._clear_resolver_cache()
+
+    @staticmethod
+    def _clear_resolver_cache():
+        for attr in ("_compress_manager", "_registry", "_spec_manager_map"):
+            if hasattr(_get_manager_class_for_spec, attr):
+                delattr(_get_manager_class_for_spec, attr)
+
+    def test_manager_resolution_caches_imported_modules(self):
+        class FakeManager:
+            pass
+
+        class FakeSpec:
+            pass
+
+        self._clear_resolver_cache()
+        spec = FakeSpec()
+        registry_module = MagicMock()
+        registry_module.KVCacheSpecRegistry.get_manager_class.return_value = None
+        manager_module = MagicMock()
+        manager_module.spec_manager_map = {FakeSpec: FakeManager}
+        import_names: list[str] = []
+
+        def fake_import_module(name: str):
+            import_names.append(name)
+            if name == "vllm.v1.kv_cache_spec_registry":
+                return registry_module
+            if name == "vllm.v1.core.single_type_kv_cache_manager":
+                return manager_module
+            raise ImportError(name)
+
+        with patch.object(config_data_mod.importlib, "import_module", side_effect=fake_import_module):
+            self.assertIs(_get_manager_class_for_spec(spec), FakeManager)
+            self.assertIs(_get_manager_class_for_spec(spec), FakeManager)
+
+        self.assertEqual(import_names.count("vllm.v1.kv_cache_spec_registry"), 1)
+        self.assertEqual(import_names.count("vllm.v1.core.single_type_kv_cache_manager"), 1)
 
 
 class TestLoadSpec(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -255,7 +255,7 @@ class TestManagerClassResolution(unittest.TestCase):
 
     @staticmethod
     def _clear_resolver_cache():
-        for attr in ("_compress_manager", "_registry", "_spec_manager_map"):
+        for attr in ("_manager_class_cache",):
             if hasattr(_get_manager_class_for_spec, attr):
                 delattr(_get_manager_class_for_spec, attr)
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import importlib
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any, cast
@@ -9,7 +10,7 @@ import torch
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
 from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
-from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashList
+from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashList, KVCacheBlock
 from vllm.v1.core.sched.output import NewRequestData
 
 _GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
@@ -137,6 +138,62 @@ def get_cache_family_granularity(block_size: int, cache_family: str | None) -> i
     return block_size * infer_cache_family_ratio(cache_family)
 
 
+def _unwrap_spec(kv_cache_spec: Any) -> Any:
+    kv_cache_specs = getattr(kv_cache_spec, "kv_cache_specs", None)
+    if kv_cache_specs is None:
+        return kv_cache_spec
+    return next(iter(kv_cache_specs.values()))
+
+
+def _get_manager_class_for_spec(spec: Any) -> Any | None:
+    compress_ratio = getattr(spec, "compress_ratio", None)
+    if compress_ratio is not None and compress_ratio > 1:
+        try:
+            from vllm_ascend.core.single_type_kv_cache_manager import CompressAttentionManager
+
+            return CompressAttentionManager
+        except ImportError:
+            pass
+
+    try:
+        registry_module = importlib.import_module("vllm.v1.kv_cache_spec_registry")
+        registry = getattr(registry_module, "KVCacheSpecRegistry", None)
+    except ImportError:
+        registry = None
+    if registry is not None:
+        manager_cls = registry.get_manager_class(spec)
+        if manager_cls is not None:
+            return manager_cls
+
+    try:
+        manager_module = importlib.import_module("vllm.v1.core.single_type_kv_cache_manager")
+        spec_manager_map = getattr(manager_module, "spec_manager_map", {})
+    except ImportError:
+        return None
+    manager_cls = spec_manager_map.get(type(spec))
+    if manager_cls is not None:
+        return manager_cls
+    for spec_cls, candidate in spec_manager_map.items():
+        if isinstance(spec, spec_cls):
+            return candidate
+    return None
+
+
+class ExternalCachedBlockPool:
+    """BlockPool stand-in that treats every requested external block as cached."""
+
+    def __init__(self) -> None:
+        self.null_block = KVCacheBlock(block_id=0)
+        self._present_block = KVCacheBlock(block_id=1)
+
+    def get_cached_block(
+        self,
+        block_hash: BlockHash,
+        group_ids: list[int],
+    ) -> list[KVCacheBlock]:
+        return [self._present_block] * len(group_ids)
+
+
 def _get_layer_compress_ratio(
     layer_name: str,
     compress_ratios: Sequence[int] | None,
@@ -207,9 +264,12 @@ class ChunkedTokenDatabase:
         partitions: list[int] | None,
         use_hybrid: bool = False,
         hash_block_size: int | None = None,
+        kv_cache_groups: Sequence[Any] | None = None,
+        alignment_tokens: int | None = None,
     ):
         self.metadata = metadata
         self.block_size = block_size if isinstance(block_size, list) else [block_size]
+        self.kv_cache_groups = list(kv_cache_groups or [])
         self.kv_caches_base_addr: list[int] = []
         self.block_len: list[int] = []
         self.block_stride: list[int] = []
@@ -227,6 +287,7 @@ class ChunkedTokenDatabase:
         self.partitions = partitions
         self.use_hybrid = use_hybrid
         self.hash_block_size = self.block_size[0] if hash_block_size is None else hash_block_size
+        self.alignment_tokens = alignment_tokens if alignment_tokens is not None else max(self.block_size)
 
     def _make_key_by_hash(
         self,
@@ -266,6 +327,67 @@ class ChunkedTokenDatabase:
         if kv_cache_group_id >= len(self.block_size):
             return self.block_size[0]
         return self.block_size[kv_cache_group_id]
+
+    def load_mask(
+        self,
+        block_hashes: BlockHashList | list[str],
+        token_len: int,
+        kv_cache_group_id: int,
+        cache_role: str = "kv",
+    ) -> list[bool] | None:
+        if cache_role != "kv" or not block_hashes or kv_cache_group_id >= len(self.kv_cache_groups):
+            return None
+
+        cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
+        if infer_cache_family_ratio(cache_family) > 1:
+            return None
+
+        spec = _unwrap_spec(self.kv_cache_groups[kv_cache_group_id].kv_cache_spec)
+        manager_cls = _get_manager_class_for_spec(spec)
+        if manager_cls is None:
+            return None
+
+        group_hashes = get_block_hashes(
+            block_hashes,
+            getattr(spec, "block_size", self.get_block_size(kv_cache_group_id)),
+            self.hash_block_size,
+        )
+        block_pool = ExternalCachedBlockPool()
+        base_kwargs = dict(
+            block_hashes=group_hashes,
+            max_length=token_len,
+            kv_cache_group_ids=[kv_cache_group_id],
+            block_pool=block_pool,
+            kv_cache_spec=spec,
+            alignment_tokens=self.alignment_tokens,
+        )
+
+        last_error: TypeError | None = None
+        for eagle_kwarg in ({"drop_eagle_block": False}, {"use_eagle": False}, {}):
+            try:
+                hit_blocks = manager_cls.find_longest_cache_hit(**base_kwargs, **eagle_kwarg)
+                return [block is not block_pool.null_block for block in hit_blocks[0]]
+            except TypeError as err:
+                last_error = err
+
+        logger.debug(
+            "KV pool load mask disabled for group %d because manager %s rejected the call: %s",
+            kv_cache_group_id,
+            getattr(manager_cls, "__name__", manager_cls),
+            last_error,
+        )
+        return None
+
+    def mask_allows_chunk(
+        self,
+        mask: list[bool] | None,
+        kv_cache_group_id: int,
+        start: int,
+    ) -> bool:
+        if mask is None:
+            return True
+        chunk_idx = start // self.get_block_size(kv_cache_group_id)
+        return chunk_idx < len(mask) and mask[chunk_idx]
 
     def set_group_buffers(
         self,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -16,6 +16,7 @@ from vllm.v1.core.sched.output import NewRequestData
 _GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
 _GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
 _CACHE_MISSING = object()
+_MANAGER_CLASS_CACHE_ATTR = "_manager_class_cache"
 
 
 # Parameters related to the key
@@ -146,10 +147,19 @@ def _unwrap_spec(kv_cache_spec: Any) -> Any:
     return next(iter(kv_cache_specs.values()))
 
 
+def _get_manager_class_cache() -> dict[str, Any]:
+    cache = getattr(_get_manager_class_for_spec, _MANAGER_CLASS_CACHE_ATTR, None)
+    if not isinstance(cache, dict):
+        cache = {}
+        setattr(_get_manager_class_for_spec, _MANAGER_CLASS_CACHE_ATTR, cache)
+    return cast(dict[str, Any], cache)
+
+
 def _get_manager_class_for_spec(spec: Any) -> Any | None:
+    cache = _get_manager_class_cache()
     compress_ratio = getattr(spec, "compress_ratio", None)
     if compress_ratio is not None and compress_ratio > 1:
-        compress_manager = getattr(_get_manager_class_for_spec, "_compress_manager", _CACHE_MISSING)
+        compress_manager = cache.get("compress_manager", _CACHE_MISSING)
         if compress_manager is _CACHE_MISSING:
             try:
                 from vllm_ascend.core.single_type_kv_cache_manager import CompressAttentionManager
@@ -157,31 +167,31 @@ def _get_manager_class_for_spec(spec: Any) -> Any | None:
                 compress_manager = None
             else:
                 compress_manager = CompressAttentionManager
-            _get_manager_class_for_spec._compress_manager = compress_manager
+            cache["compress_manager"] = compress_manager
         if compress_manager is not None:
             return compress_manager
 
-    registry = getattr(_get_manager_class_for_spec, "_registry", _CACHE_MISSING)
+    registry = cache.get("registry", _CACHE_MISSING)
     if registry is _CACHE_MISSING:
         try:
             registry_module = importlib.import_module("vllm.v1.kv_cache_spec_registry")
             registry = getattr(registry_module, "KVCacheSpecRegistry", None)
         except ImportError:
             registry = None
-        _get_manager_class_for_spec._registry = registry
+        cache["registry"] = registry
     if registry is not None:
         manager_cls = registry.get_manager_class(spec)
         if manager_cls is not None:
             return manager_cls
 
-    spec_manager_map = getattr(_get_manager_class_for_spec, "_spec_manager_map", _CACHE_MISSING)
+    spec_manager_map = cache.get("spec_manager_map", _CACHE_MISSING)
     if spec_manager_map is _CACHE_MISSING:
         try:
             manager_module = importlib.import_module("vllm.v1.core.single_type_kv_cache_manager")
             spec_manager_map = getattr(manager_module, "spec_manager_map", {})
         except ImportError:
             spec_manager_map = None
-        _get_manager_class_for_spec._spec_manager_map = spec_manager_map
+        cache["spec_manager_map"] = spec_manager_map
     if not spec_manager_map:
         return None
     manager_cls = spec_manager_map.get(type(spec))

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -15,6 +15,7 @@ from vllm.v1.core.sched.output import NewRequestData
 
 _GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
 _GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
+_CACHE_MISSING = object()
 
 
 # Parameters related to the key
@@ -148,27 +149,40 @@ def _unwrap_spec(kv_cache_spec: Any) -> Any:
 def _get_manager_class_for_spec(spec: Any) -> Any | None:
     compress_ratio = getattr(spec, "compress_ratio", None)
     if compress_ratio is not None and compress_ratio > 1:
+        compress_manager = getattr(_get_manager_class_for_spec, "_compress_manager", _CACHE_MISSING)
+        if compress_manager is _CACHE_MISSING:
+            try:
+                from vllm_ascend.core.single_type_kv_cache_manager import CompressAttentionManager
+            except ImportError:
+                compress_manager = None
+            else:
+                compress_manager = CompressAttentionManager
+            _get_manager_class_for_spec._compress_manager = compress_manager
+        if compress_manager is not None:
+            return compress_manager
+
+    registry = getattr(_get_manager_class_for_spec, "_registry", _CACHE_MISSING)
+    if registry is _CACHE_MISSING:
         try:
-            from vllm_ascend.core.single_type_kv_cache_manager import CompressAttentionManager
-
-            return CompressAttentionManager
+            registry_module = importlib.import_module("vllm.v1.kv_cache_spec_registry")
+            registry = getattr(registry_module, "KVCacheSpecRegistry", None)
         except ImportError:
-            pass
-
-    try:
-        registry_module = importlib.import_module("vllm.v1.kv_cache_spec_registry")
-        registry = getattr(registry_module, "KVCacheSpecRegistry", None)
-    except ImportError:
-        registry = None
+            registry = None
+        _get_manager_class_for_spec._registry = registry
     if registry is not None:
         manager_cls = registry.get_manager_class(spec)
         if manager_cls is not None:
             return manager_cls
 
-    try:
-        manager_module = importlib.import_module("vllm.v1.core.single_type_kv_cache_manager")
-        spec_manager_map = getattr(manager_module, "spec_manager_map", {})
-    except ImportError:
+    spec_manager_map = getattr(_get_manager_class_for_spec, "_spec_manager_map", _CACHE_MISSING)
+    if spec_manager_map is _CACHE_MISSING:
+        try:
+            manager_module = importlib.import_module("vllm.v1.core.single_type_kv_cache_manager")
+            spec_manager_map = getattr(manager_module, "spec_manager_map", {})
+        except ImportError:
+            spec_manager_map = None
+        _get_manager_class_for_spec._spec_manager_map = spec_manager_map
+    if not spec_manager_map:
         return None
     manager_cls = spec_manager_map.get(type(spec))
     if manager_cls is not None:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -205,6 +205,28 @@ class KVTransferThread(threading.Thread):
         except TypeError:
             return self.token_database.decode_adaptor_prefill_pp(keys, addrs, sizes)
 
+    def _load_mask(
+        self,
+        block_hashes,
+        token_len: int,
+        kv_cache_group_id: int,
+    ) -> list[bool] | None:
+        load_mask = getattr(self.token_database, "load_mask", None)
+        if load_mask is None:
+            return None
+        return load_mask(block_hashes, token_len, kv_cache_group_id)
+
+    def _mask_allows_chunk(
+        self,
+        mask: list[bool] | None,
+        kv_cache_group_id: int,
+        start: int,
+    ) -> bool:
+        mask_allows_chunk = getattr(self.token_database, "mask_allows_chunk", None)
+        if mask_allows_chunk is None:
+            return True
+        return mask_allows_chunk(mask, kv_cache_group_id, start)
+
 
 class KVCacheStoreSendingThread(KVTransferThread):
     def __init__(
@@ -390,6 +412,11 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         for group_id in req_meta.kv_cache_group_ids or [0]:
             block_ids = req_meta.block_ids_by_group[group_id]
             group_block_size = self._get_block_size(group_id)
+            load_mask = self._load_mask(
+                req_meta.block_hashes,
+                token_len,
+                group_id,
+            )
             mask_num = (
                 req_meta.load_spec.vllm_cached_tokens  # type: ignore[union-attr]
                 // group_block_size
@@ -403,6 +430,8 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 kv_cache_group_id=group_id,
                 skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
             ):
+                if not self._mask_allows_chunk(load_mask, group_id, start):
+                    continue
                 addr, size, _ = self._prepare_value(
                     start,
                     end,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -167,12 +167,17 @@ class KVPoolWorker:
                     for i in range(2, remaining_layers + 2):
                         partitions[-i] += 1
 
+        kv_cache_groups = (
+            list(self.kv_cache_config.kv_cache_groups) if self.kv_cache_config is not None and self.use_hybrid else None
+        )
         self.token_database = ChunkedTokenDatabase(
             self.metadata,
             self.grouped_block_size,
             partitions,
             use_hybrid=self.use_hybrid,
             hash_block_size=self.hash_block_size,
+            kv_cache_groups=kv_cache_groups,
+            alignment_tokens=self.cache_transfer_granularity,
         )
 
         backend = backend_map.get(self.backend.lower())
@@ -486,6 +491,11 @@ class KVPoolWorker:
                     for group_id in load_group_ids:
                         block_ids = request.block_ids_by_group[group_id]
                         group_block_size = self.grouped_block_size[group_id]
+                        load_mask = self.token_database.load_mask(
+                            request.block_hashes,
+                            token_len,
+                            group_id,
+                        )
                         mask_num = request.load_spec.vllm_cached_tokens // group_block_size * group_block_size
                         skip_null = (
                             group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]
@@ -498,6 +508,8 @@ class KVPoolWorker:
                             kv_cache_group_id=group_id,
                             skip_null_blocks=skip_null,
                         ):
+                            if not self.token_database.mask_allows_chunk(load_mask, group_id, start):
+                                continue
                             addr, size, _ = self.token_database.prepare_value(
                                 start,
                                 end,


### PR DESCRIPTION
## What

Backport the AscendStore load-only mask support from the main-branch PR to the v0.20.2rc release branch.

## Why

Hybrid/sliding-window groups such as DSV4 C1 should not fetch chunks that the local KV cache manager would not populate. This keeps the release-branch change focused on reducing unnecessary get-side reads without introducing store-side retention semantics.

## Changes

- Resolve the per-group KV cache manager from kv_cache_config when available.
- Generate per-group load masks using an all-present external block pool.
- Apply the mask in both synchronous worker get and asynchronous recv-thread get paths.
- Preserve the existing store path and fall back to full load if no compatible manager is available.

## Validation

vLLM version: v0.20.1
vLLM main: vllm-project/vllm@c7aa186
