### PR TITLE
[20.2][BugFix][KV Pool] Avoid logging KV store keys at error level

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -105,28 +105,72 @@ class MemcacheBackend(Backend):
 
     def get(self, key: list[str], addr: list[list[int]], size: list[list[int]]):
         if self._lazy_init and not self._store_initialized:
-            logger.error("MemcacheBackend.get called before store initialization, keys=%s", key)
+            logger.error(
+                "Failed to get %d keys out of %d. Store is not initialized; "
+                "call put() first to trigger initialization.",
+                len(key),
+                len(key),
+            )
+            logger.debug("Failed to get key details. keys=%s", key)
             return
         assert self.store is not None
         try:
             res = self.store.batch_get_into_layers(key, addr, size, MmcDirect.COPY_G2L.value)
-            for value in res:
-                if value != 0:
-                    logger.error("Failed to get key %s,res:%s", key, res)
+            failed_codes = [int(value) for value in res if value != 0]
+            failed_count = len(failed_codes)
+            if failed_count:
+                error_codes = sorted(set(failed_codes))
+                logger.error(
+                    "Failed to get %d keys out of %d. error_codes=%s. Check key existence and memory state.",
+                    failed_count,
+                    len(key),
+                    error_codes,
+                )
+                logger.debug("Failed to get key details. keys=%s, result=%s", key, res)
+            return res
         except Exception as e:
-            logger.error("Failed to get key %s. %s", key, e)
+            logger.error(
+                "Failed to get %d keys out of %d. Check store state and network.",
+                len(key),
+                len(key),
+            )
+            logger.debug(
+                "Failed to get key details. keys=%s, type=%s, error=%s",
+                key,
+                type(e).__name__,
+                e,
+            )
+            return None
 
     def put(self, key: list[str], addr: list[list[int]], size: list[list[int]]):
         self.ensure_initialized()
         assert self.store is not None
         try:
             res = self.store.batch_put_from_layers(key, addr, size, MmcDirect.COPY_L2G.value)
-            for value in res:
-                if value != 0:
-                    logger.error("Failed to put key %s,res:%s", key, res)
-                    if self._lazy_init:
-                        logger.error("If this is the first DSV4(compress) request, this failure is expected.")
+            failed_codes = [int(value) for value in res if value != 0]
+            failed_count = len(failed_codes)
+            if failed_count:
+                error_codes = sorted(set(failed_codes))
+                logger.error(
+                    "Failed to put %d keys out of %d. error_codes=%s. Check memory and store capacity.",
+                    failed_count,
+                    len(key),
+                    error_codes,
+                )
+                logger.debug("Failed to put key details. keys=%s, result=%s", key, res)
+                if self._lazy_init:
+                    logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
         except Exception as e:
-            logger.error("Failed to put key %s,error:%s", key, e)
+            logger.error(
+                "Failed to put %d keys out of %d. Check store state and memory.",
+                len(key),
+                len(key),
+            )
+            logger.debug(
+                "Failed to put key details. keys=%s, type=%s, error=%s",
+                key,
+                type(e).__name__,
+                e,
+            )
             if self._lazy_init:
-                logger.error("If this is the first DSV4(compress) request, this failure is expected.")
+                logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -127,19 +127,43 @@ class MooncakeBackend(Backend):
                 config.preferred_segment = self.local_seg
             config.prefer_alloc_in_same_node = self.config.prefer_alloc_in_same_node
             res = self.store.batch_put_from_multi_buffers(keys, addrs, sizes, config)
-            for value in res:
-                if value < 0:
-                    logger.error("Failed to put key %s,res:%s", keys, res)
-                    if self._lazy_init:
-                        logger.error("If this is the first DSV4(compress) request, this failure is expected.")
+            failed_codes = [int(value) for value in res if value < 0]
+            failed_count = len(failed_codes)
+            if failed_count:
+                error_codes = sorted(set(failed_codes))
+                logger.error(
+                    "Failed to put %d keys out of %d. error_codes=%s. Check memory and store capacity.",
+                    failed_count,
+                    len(keys),
+                    error_codes,
+                )
+                logger.debug("Failed to put key details. keys=%s, result=%s", keys, res)
+                if self._lazy_init:
+                    logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
         except Exception as e:
-            logger.error("Failed to put key %s,error:%s", keys, e)
+            logger.error(
+                "Failed to put %d keys out of %d. Check store state and memory.",
+                len(keys),
+                len(keys),
+            )
+            logger.debug(
+                "Failed to put key details. keys=%s, type=%s, error=%s",
+                keys,
+                type(e).__name__,
+                e,
+            )
             if self._lazy_init:
-                logger.error("If this is the first DSV4(compress) request, this failure is expected.")
+                logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
 
     def get(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         if self._lazy_init and not self._store_initialized:
-            logger.error("MooncakeBackend.get called before store initialization, keys=%s", keys)
+            logger.error(
+                "Failed to get %d keys out of %d. Store is not initialized; "
+                "call put() first to trigger initialization.",
+                len(keys),
+                len(keys),
+            )
+            logger.debug("Failed to get key details. keys=%s", keys)
             return
         assert self.store is not None
         logger.debug(
@@ -150,17 +174,34 @@ class MooncakeBackend(Backend):
         try:
             res = self.store.batch_get_into_multi_buffers(keys, addrs, sizes)
             res_list = list(res)
-            logger.debug(
-                "MooncakeBackend.get result keys=%d result_sample=%s negative_count=%d",
-                len(keys),
-                res_list[:12],
-                sum(1 for value in res_list if value < 0),
-            )
-            for value in res_list:
-                if value < 0:
-                    logger.error("Failed to get key %s, res:%s", keys, res_list)
+            failed_codes = [int(value) for value in res_list if value < 0]
+            failed_count = len(failed_codes)
+            error_codes = sorted(set(failed_codes))
+            if failed_count:
+                logger.error(
+                    "Failed to get %d keys out of %d. error_codes=%s. Check key existence and memory state.",
+                    failed_count,
+                    len(keys),
+                    error_codes,
+                )
+                logger.debug("Failed to get key details. keys=%s, result=%s", keys, res_list)
+            for i, value in enumerate(res_list):
+                if value > 0:
+                    res_list[i] = 0
+            return res_list
         except Exception as e:
-            logger.error("Failed to get key %s, error:%s", keys, e)
+            logger.error(
+                "Failed to get %d keys out of %d. Check store state and network.",
+                len(keys),
+                len(keys),
+            )
+            logger.debug(
+                "Failed to get key details. keys=%s, type=%s, error=%s",
+                keys,
+                type(e).__name__,
+                e,
+            )
+            return None
 
 
 @dataclass

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
@@ -144,15 +144,22 @@ class YuanrongBackend(Backend):
                 results.extend(1 if value else 0 for value in exists)
             return results
         except Exception as exc:
-            logger.error("Failed to check keys %s: %s", keys, exc)
+            logger.error(
+                "Failed to check keys. keys_count=%d, type=%s, error=%s. Check network and yuanrong service.",
+                len(keys),
+                type(exc).__name__,
+                exc,
+            )
             return [0] * len(keys)
 
     def get(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         if len(keys) == 0:
             return
+        failed_keys_for_log = keys
         try:
             self._ensure_device_ready()
             keys = self._helper.normalize_keys(keys)
+            failed_keys_for_log = keys
             blob_lists = self._helper.make_blob_lists(addrs, sizes)
             failed_keys: list[str] = []
             if len(keys) <= self._DS_MAX_BATCH_KEYS:
@@ -161,22 +168,40 @@ class YuanrongBackend(Backend):
                 )
             else:
                 for start, end in _iter_slices(len(keys), self._DS_MAX_BATCH_KEYS):
+                    failed_keys_for_log = keys[start:end]
                     failed_keys.extend(
                         self._hetero_client.mget_h2d(  # type: ignore[union-attr]
                             keys[start:end], blob_lists[start:end], 0
                         )
                     )
             if failed_keys:
-                logger.error("Failed to get %d keys. First few: %s", len(failed_keys), failed_keys[:10])
+                logger.error(
+                    "Failed to get %d keys out of %d. Check key existence and memory state.",
+                    len(failed_keys),
+                    len(keys),
+                )
+                logger.debug("Failed to get key details. failed_keys=%s", failed_keys)
         except Exception as exc:
-            logger.error("Failed to get keys %s: %s", keys, exc)
+            logger.error(
+                "Failed to get %d keys out of %d. Check network and yuanrong service.",
+                len(failed_keys_for_log),
+                len(keys),
+            )
+            logger.debug(
+                "Failed to get key details. keys=%s, type=%s, error=%s",
+                failed_keys_for_log,
+                type(exc).__name__,
+                exc,
+            )
 
     def put(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         if len(keys) == 0:
             return
+        failed_keys_for_log = keys
         try:
             self._ensure_device_ready()
             keys = self._helper.normalize_keys(keys)
+            failed_keys_for_log = keys
             blob_lists = self._helper.make_blob_lists(addrs, sizes)
             if len(keys) <= self._DS_MAX_BATCH_KEYS:
                 self._hetero_client.mset_d2h(  # type: ignore[union-attr]
@@ -184,8 +209,19 @@ class YuanrongBackend(Backend):
                 )
             else:
                 for start, end in _iter_slices(len(keys), self._DS_MAX_BATCH_KEYS):
+                    failed_keys_for_log = keys[start:end]
                     self._hetero_client.mset_d2h(  # type: ignore[union-attr]
                         keys[start:end], blob_lists[start:end], self._ds_set_param
                     )
         except Exception as exc:
-            logger.error("Failed to put keys %s: %s", keys, exc)
+            logger.error(
+                "Failed to put %d keys out of %d. Check network and yuanrong service.",
+                len(failed_keys_for_log),
+                len(keys),
+            )
+            logger.debug(
+                "Failed to put key details. keys=%s, type=%s, error=%s",
+                failed_keys_for_log,
+                type(exc).__name__,
+                exc,
+            )


### PR DESCRIPTION
### What this PR does / why we need it?

Backport of #10425 to `releases/v0.20.2rc`.

- Avoid logging full KV store keys at error level in Mooncake, Memcache, and Yuanrong backends.
- Log failed key counts and unique result error codes for KV store result failures.
- Keep detailed key/result information at debug level.

### Does this PR introduce _any_ user-facing change?

No. This only changes log verbosity and log content.

### How was this patch tested?

- Based on the `releases/v0.20.2rc` branch for vLLM 0.20.2.
- Local touched-file lint, formatting check, and Python compile check passed.
