### PR TITLE
[Feature] Adapt GLM-5.2

### DIFF
--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -223,6 +223,9 @@ jobs:
           - name: multi-node-GLM-5.1-w8a8-A3
             config_file_path: GLM5_1-W8A8-A3-dual-nodes.yaml
             size: 2
+          - name: multi-node-GLM-5.2-w8a8-A3
+            config_file_path: GLM5_2-W8A8-A3-dual-nodes.yaml
+            size: 2
     uses: ./.github/workflows/_e2e_nightly_multi_node.yaml
     with:
       soc_version: a3

--- a/docs/source/developer_guide/contribution/nightly_ci_test.md
+++ b/docs/source/developer_guide/contribution/nightly_ci_test.md
@@ -115,6 +115,7 @@ events — it will **not** run on PR-triggered runs even with `/nightly all`.
 | `multi-node-kimi-k2-instruct-w8a8` | Kimi-K2-Instruct-W8A8, 2-node |
 | `multi-node-deepseek-v3.1` | DeepSeek-V3.1-BF16, 2-node |
 | `multi-node-deepseek-v3.2-W8A8-EP` | DeepSeek-V3.2-W8A8 with EP, 4-node |
+| `multi-node-glm-5.2` | GLM-5.1-W8A8, 2-node |
 
 **Single-node tests** (run after multi-node tests complete):
 

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_2-W8A8-A3-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_2-W8A8-A3-dual-nodes.yaml
@@ -1,0 +1,92 @@
+test_name: "multi-node-GLM-5.2-w8a8-A3"
+model: "Eco-Tech/GLM-5.2-w8a8"
+num_nodes: 2
+npu_per_node: 16
+env_common: &env_common
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  OMP_PROC_BIND: false
+  VLLM_USE_MODELSCOPE: true
+  OMP_NUM_THREADS: 1
+  HCCL_BUFFSIZE: 200
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+  VLLM_ASCEND_BALANCE_SCHEDULING: 0
+  VLLM_ASCEND_ENABLE_MLAPO: 1
+  VLLM_ENGINE_READY_TIMEOUT_S: "3000"
+  VLLM_RPC_TIMEOUT: "600"
+  SERVER_PORT: 8080
+
+special_dependencies:
+  transformers: "5.12.0"
+# TODO: need to identify why TP and mtp+1 divisibility rules break on dual-node case
+
+deployment:
+  - envs:
+      <<: *env_common
+    server_cmd: >
+      vllm serve Eco-Tech/GLM-5.2-w8a8
+      --host 0.0.0.0
+      --port $SERVER_PORT
+      --data-parallel-size 2
+      --tensor-parallel-size 16
+      --data-parallel-rpc-port 13389
+      --data-parallel-size-local 1
+      --data-parallel-start-rank 0
+      --data-parallel-address $LOCAL_IP
+      --enable-expert-parallel
+      --seed 1024
+      --max-num-seqs 16
+      --max-model-len 133120
+      --max-num-batched-tokens 4096
+      --trust-remote-code
+      --gpu-memory-utilization 0.95
+      --quantization ascend
+      --additional-config '{"fuse_muls_add":true,"multistream_overlap_shared_expert":true,"enable_dsa_cp": true}'
+      --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+      --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
+  -
+    envs:
+      <<: *env_common
+    server_cmd: >
+      vllm serve Eco-Tech/GLM-5.1-w8a8
+      --host 0.0.0.0
+      --port $SERVER_PORT
+      --data-parallel-size 2
+      --tensor-parallel-size 16
+      --data-parallel-size-local 1
+      --data-parallel-start-rank 1
+      --data-parallel-rpc-port 13389
+      --headless
+      --data-parallel-address $MASTER_IP
+      --enable-expert-parallel
+      --seed 1024
+      --max-num-seqs 16
+      --max-model-len 133120
+      --max-num-batched-tokens 4096
+      --trust-remote-code
+      --gpu-memory-utilization 0.95
+      --quantization ascend
+      --additional-config '{"fuse_muls_add":true,"multistream_overlap_shared_expert":true,"enable_dsa_cp": true}'
+      --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+      --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
+benchmarks:
+  acc_aime2025:
+    case_type: accuracy
+    dataset_path: vllm-ascend/aime2025
+    request_conf: vllm_api_general_chat
+    dataset_conf: aime2025/aime2025_gen_0_shot_chat_prompt
+    max_out_len: 72348
+    batch_size: 32
+    baseline: 90
+    threshold: 10
+
+  perf:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K_prefix90_in131072_bs100_glm
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 12
+    max_out_len: 1024
+    batch_size: 3
+    request_rate: 0
+    baseline: 1
+    threshold: 0.97

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import scipy  # type: ignore
 import torch
@@ -73,6 +73,30 @@ O_PROJ_ACLNN_INPUT_PARAMS = (
     "aclnn_input_offset",
 )
 O_PROJ_INPUT_SHARDED_QUANT_PARAMS = ("weight_scale_second", "weight_scale")
+
+
+def _get_indexer_types(configs: tuple[Any, ...]) -> Any | None:
+    for config in configs:
+        if config is None:
+            continue
+        indexer_types = getattr(config, "indexer_types", None)
+        if indexer_types is not None:
+            return indexer_types
+    return None
+
+
+def _has_shared_indexer_layers(configs: tuple[Any, ...]) -> bool:
+    indexer_types = _get_indexer_types(configs)
+    if indexer_types is None:
+        return False
+    return any(isinstance(indexer_type, str) and indexer_type.lower() == "shared" for indexer_type in indexer_types)
+
+
+def _get_config_bool(configs: tuple[Any, ...], attr: str) -> bool:
+    for config in configs:
+        if config is not None and hasattr(config, attr):
+            return bool(getattr(config, attr))
+    return False
 
 
 class AscendSFABackend(AttentionBackend):
@@ -491,26 +515,47 @@ class AscendSFAImpl(MLAAttentionImpl):
         # NOTE: it imposes a limit on the number of input tokens and conflicts with FlashComm
         self.enable_mlapo = get_ascend_config().enable_mlapo
 
-        assert self.indexer is not None, "Indexer is required for DSA."
-
         self.local_num_heads = self.num_heads
         self.vllm_config = get_current_vllm_config()
-        self.use_index_cache = self.skip_topk or getattr(
-            self.vllm_config.model_config.hf_config,
+        self.layer_name = kwargs.get("layer_name")
+        hf_config = self.vllm_config.model_config.hf_config
+        hf_text_config = getattr(self.vllm_config.model_config, "hf_text_config", None)
+        config_candidates = (hf_config, hf_text_config)
+        self.index_cache_enabled = _get_config_bool(
+            config_candidates,
             "use_index_cache",
-            False,
-        )
+        ) or _has_shared_indexer_layers(config_candidates)
+        self.use_index_cache = self.skip_topk or self.index_cache_enabled
         self.is_kv_producer = (
             self.vllm_config.kv_transfer_config is not None and self.vllm_config.kv_transfer_config.is_kv_producer
         )
-        self.layer_name = kwargs.get("layer_name")
+
+        self.has_indexer = self.indexer is not None
+        if not self.has_indexer and not self.skip_topk:
+            raise ValueError(
+                "Indexer is required for DSA unless skip_topk is enabled. "
+                f"Got indexer=None, skip_topk={self.skip_topk}, "
+                f"layer_name={self.layer_name}."
+            )
+        if not self.has_indexer and self.topk_indices_buffer is None:
+            raise ValueError(
+                "topk_indices_buffer is required when indexer is None and "
+                f"skip_topk is enabled. layer_name={self.layer_name}."
+            )
 
         # indexer param
-        self.n_head: int = self.indexer.n_head  # 64
-        self.head_dim: int = self.indexer.head_dim  # 128
-        self.wq_b = self.indexer.wq_b
-        self.wk_weights_proj = self.indexer.wk_weights_proj
-        self.k_norm = self.indexer.k_norm
+        if self.has_indexer:
+            self.n_head: int = self.indexer.n_head  # 64
+            self.head_dim: int = self.indexer.head_dim  # 128
+            self.wq_b = self.indexer.wq_b
+            self.wk_weights_proj = self.indexer.wk_weights_proj
+            self.k_norm = self.indexer.k_norm
+        else:
+            self.n_head = getattr(hf_config, "index_n_heads", 0)
+            self.head_dim = getattr(hf_config, "index_head_dim", 0)
+            self.wq_b = None
+            self.wk_weights_proj = None
+            self.k_norm = None
         self.cp_size = 1
         self.is_rope_neox_style = True
         self.use_torch_npu_lightning_indexer = False
@@ -519,7 +564,7 @@ class AscendSFAImpl(MLAAttentionImpl):
             self.use_torch_npu_lightning_indexer = True
 
         # dsa c8
-        self.use_sparse_c8_indexer = ascend_config.is_sparse_c8_layer(self.layer_name)
+        self.use_sparse_c8_indexer = self.has_indexer and ascend_config.is_sparse_c8_layer(self.layer_name)
         self.use_a5_sparse_c8_indexer = self.use_sparse_c8_indexer and (get_ascend_device_type() == AscendDeviceType.A5)
         if self.use_sparse_c8_indexer:
             if get_ascend_device_type() == AscendDeviceType.A5:
@@ -1073,6 +1118,14 @@ class AscendSFAImpl(MLAAttentionImpl):
         cos: torch.Tensor,
         sin: torch.Tensor,
     ):
+        if not self.has_indexer:
+            raise RuntimeError(
+                f"indexer_select_pre_process should not be called when indexer is None. layer_name={self.layer_name}."
+            )
+
+        assert self.wk_weights_proj is not None
+        assert self.k_norm is not None
+
         kw, _ = self.wk_weights_proj(x)
         k_li = kw[:, : self.head_dim]
         k_li = self.k_norm(k_li).unsqueeze(1)
@@ -1119,6 +1172,14 @@ class AscendSFAImpl(MLAAttentionImpl):
         actual_seq_lengths_query: torch.Tensor,
         actual_seq_lengths_key: torch.Tensor,
     ):
+        if not self.has_indexer:
+            raise RuntimeError(
+                f"indexer_select_post_process should not be called when indexer is None. layer_name={self.layer_name}."
+            )
+
+        assert self.wk_weights_proj is not None
+        assert self.wq_b is not None
+
         kw, _ = self.wk_weights_proj(x)
         weights = kw[:, self.head_dim :]
         if isinstance(q_c, tuple):
@@ -1273,7 +1334,14 @@ class AscendSFAImpl(MLAAttentionImpl):
                 slot_mapping=slot_mapping,
                 num_input_tokens=num_input_tokens,
             )
-            k_li, k_li_scale = self.indexer_select_pre_process(x=hidden_states, cos=cos, sin=sin)
+            if self.has_indexer:
+                k_li, k_li_scale = self.indexer_select_pre_process(
+                    x=hidden_states,
+                    cos=cos,
+                    sin=sin,
+                )
+            else:
+                k_li, k_li_scale = None, None
             wait_for_kv_layer_from_connector(layer_name)
         # native
         else:
@@ -1294,7 +1362,14 @@ class AscendSFAImpl(MLAAttentionImpl):
             assert self.q_a_layernorm is not None, "q_a_layernorm must be initialized"
             q_c = self.q_a_layernorm(q_c)
 
-            k_li, k_li_scale = self.indexer_select_pre_process(x=hidden_states, cos=cos, sin=sin)
+            if self.has_indexer:
+                k_li, k_li_scale = self.indexer_select_pre_process(
+                    x=hidden_states,
+                    cos=cos,
+                    sin=sin,
+                )
+            else:
+                k_li, k_li_scale = None, None
 
             wait_for_kv_layer_from_connector(layer_name)
 
@@ -1309,10 +1384,23 @@ class AscendSFAImpl(MLAAttentionImpl):
             if self.enable_dsa_cp:
                 assert k_pe is not None
                 assert k_nope is not None
-                assert k_li is not None
                 async_op = self.enable_dsa_cp_with_layer_shard or full_gather_o_proj_enabled
+
                 # support all_gather kv async for communication calculation overlap
-                if not self.use_sparse_c8_indexer:
+                if not self.has_indexer:
+                    fused_kv_no_split, kv_ag_handle = all_gather_async(
+                        torch.cat(
+                            [
+                                k_pe.view(-1, k_pe.shape[-1]),
+                                k_nope.view(-1, k_nope.shape[-1]),
+                            ],
+                            dim=1,
+                        ),
+                        get_tp_group(),
+                        async_op=async_op,
+                    )
+                elif not self.use_sparse_c8_indexer:
+                    assert k_li is not None
                     fused_kv_no_split, kv_ag_handle = all_gather_async(
                         torch.cat(
                             [
@@ -1353,6 +1441,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                     )
                 else:
                     # due to different dtypes, we have to split commu pass
+                    assert k_li is not None
                     assert k_li_scale is not None
                     fused_kv_no_split, _ = all_gather_async(
                         torch.cat(
@@ -1404,9 +1493,15 @@ class AscendSFAImpl(MLAAttentionImpl):
 
                 if kv_cache is not None:
                     assert fused_kv_no_split is not None
-                    if not self.use_sparse_c8_indexer:
+                    if not self.has_indexer:
+                        k_pe, k_nope = fused_kv_no_split.split(
+                            [self.qk_rope_head_dim, self.kv_lora_rank],
+                            dim=-1,
+                        )
+                    elif not self.use_sparse_c8_indexer:
                         k_pe, k_nope, k_li = fused_kv_no_split.split(
-                            [self.qk_rope_head_dim, self.kv_lora_rank, self.head_dim], dim=-1
+                            [self.qk_rope_head_dim, self.kv_lora_rank, self.head_dim],
+                            dim=-1,
                         )
                     elif self.use_a5_sparse_c8_indexer:
                         torch_npu.npu_scatter_nd_update_(
@@ -1417,8 +1512,13 @@ class AscendSFAImpl(MLAAttentionImpl):
                         k_pe = None
                         k_nope = None
                     else:
-                        k_pe, k_nope = fused_kv_no_split.split([self.qk_rope_head_dim, self.kv_lora_rank], dim=-1)
+                        k_pe, k_nope = fused_kv_no_split.split(
+                            [self.qk_rope_head_dim, self.kv_lora_rank],
+                            dim=-1,
+                        )
                     if not self.use_a5_sparse_c8_indexer:
+                        assert k_pe is not None
+                        assert k_nope is not None
                         k_nope = k_nope.view(k_nope.shape[0], 1, -1)
                         k_pe = k_pe.view(k_pe.shape[0], 1, -1)
                         DeviceOperator.reshape_and_cache(
@@ -1429,12 +1529,15 @@ class AscendSFAImpl(MLAAttentionImpl):
                             slot_mapping=slot_mapping[: attn_metadata.num_actual_tokens],
                         )
 
-            k_li = self._get_full_kv(k_li, attn_metadata)
+            if self.has_indexer:
+                assert k_li is not None
+                k_li = self._get_full_kv(k_li, attn_metadata)
 
-        if kv_cache is not None:
-            if self.is_kv_producer:
-                attn_metadata.reshape_cache_event = torch.npu.Event()
+        if kv_cache is not None and self.is_kv_producer:
+            attn_metadata.reshape_cache_event = torch.npu.Event()
 
+        if kv_cache is not None and self.has_indexer:
+            assert k_li is not None
             if self.use_sparse_c8_indexer and get_ascend_device_type() == AscendDeviceType.A5:
                 dsa_k_cache_idx = 1
                 dsa_k_scale_cache_idx = 2
@@ -1489,6 +1592,8 @@ class AscendSFAImpl(MLAAttentionImpl):
         if self.skip_topk:
             topk_indices = self._get_indexcache_topk_indices(topk_num_tokens)
         else:
+            if not self.has_indexer:
+                raise RuntimeError(f"skip_topk is False but indexer is None. layer_name={self.layer_name}.")
             topk_indices = self.indexer_select_post_process(
                 x=hidden_states,
                 q_c=q_c,

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -768,6 +768,22 @@
 #       https://github.com/vllm-project/vllm/pull/41706
 #    Future Plan:
 #       Remove this patch when vllm supports rotary quant or pluggable `MultiTokenPredictorLayer`.
+# ** 19a. File: worker/patch_deepseek_v2.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.model_executor.models.deepseek_v2.DeepseekV2Attention.__init__`
+#    Why:
+#       GLM/DeepSeek DSA models can skip topk on selected layers. Those layers
+#       should not initialize `Indexer`, while MTP layers still need full indexer
+#       initialization.
+#    How:
+#       Wrap `DeepseekV2Attention.__init__` and skip `Indexer` construction on
+#       backbone layers whose config marks topk as skipped.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/45895
+#    Future Plan:
+#       Remove this patch when vLLM Ascend depends on a vLLM version that includes
+#       PR #45895.
+#
 # ** 19b. File: worker/model_runner_v1.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `NPUModelRunner._check_and_update_cudagraph_mode`

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -61,6 +61,7 @@ import vllm_ascend.patch.worker.patch_draft_quarot  # noqa
 import vllm_ascend.patch.worker.patch_eagle3_init  # noqa
 import vllm_ascend.patch.worker.patch_cudagraph  # noqa
 import vllm_ascend.patch.worker.patch_deepseek_mtp  # noqa
+import vllm_ascend.patch.worker.patch_deepseek_v2  # noqa
 import vllm_ascend.patch.worker.patch_gqa_c8  # noqa
 
 if _V2_MODEL_RUNNER_SUPPORTED:

--- a/vllm_ascend/patch/worker/patch_deepseek_v2.py
+++ b/vllm_ascend/patch/worker/patch_deepseek_v2.py
@@ -1,0 +1,271 @@
+import torch
+from torch import nn
+from transformers import DeepseekV2Config, DeepseekV3Config
+from vllm.config import CacheConfig, VllmConfig
+from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.mla import (
+    MLAModules,
+    MultiHeadLatentAttentionWrapper,
+)
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.model_executor.models.deepseek_v2 import (
+    DeepSeekV2FusedQkvAProjLinear,
+    DeepseekV2MLAAttention,
+    Indexer,
+    yarn_get_mscale,
+)
+from vllm.model_executor.models.utils import extract_layer_index
+
+
+def _deepseek_v2_mla_attention_init(
+    self,
+    vllm_config: VllmConfig,
+    config: DeepseekV2Config | DeepseekV3Config,
+    hidden_size: int,
+    num_heads: int,
+    qk_nope_head_dim: int,
+    qk_rope_head_dim: int,
+    v_head_dim: int,
+    q_lora_rank: int | None,
+    kv_lora_rank: int,
+    max_position_embeddings: int = 8192,
+    cache_config: CacheConfig | None = None,
+    quant_config: QuantizationConfig | None = None,
+    prefix: str = "",
+    topk_indices_buffer: torch.Tensor | None = None,
+    input_size: int | None = None,
+) -> None:
+    # 这里不能使用 super().__init__()，因为当前函数定义在原类之外，
+    # 最后通过赋值的方式替换 DeepseekV2MLAAttention.__init__。
+    nn.Module.__init__(self)
+
+    self.hidden_size = hidden_size
+    self.qk_nope_head_dim = qk_nope_head_dim
+    self.qk_rope_head_dim = qk_rope_head_dim
+    self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
+    self.v_head_dim = v_head_dim
+
+    self.q_lora_rank = q_lora_rank
+    self.kv_lora_rank = kv_lora_rank
+
+    self.num_heads = num_heads
+    tp_size = get_tensor_model_parallel_world_size()
+    assert num_heads % tp_size == 0
+    self.num_local_heads = num_heads // tp_size
+
+    self.scaling = self.qk_head_dim**-0.5
+    self.max_position_embeddings = max_position_embeddings
+
+    # Use input_size for projection input dimensions if provided,
+    # otherwise default to hidden_size (used in Eagle3 Deepseek with MLA).
+    proj_input_size = input_size if input_size is not None else self.hidden_size
+
+    if self.q_lora_rank is not None:
+        self.fused_qkv_a_proj = DeepSeekV2FusedQkvAProjLinear(
+            proj_input_size,
+            [
+                self.q_lora_rank,
+                self.kv_lora_rank + self.qk_rope_head_dim,
+            ],
+            quant_config=quant_config,
+            prefix=f"{prefix}.fused_qkv_a_proj",
+        )
+    else:
+        self.kv_a_proj_with_mqa = ReplicatedLinear(
+            proj_input_size,
+            self.kv_lora_rank + self.qk_rope_head_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.kv_a_proj_with_mqa",
+        )
+
+    if self.q_lora_rank is not None:
+        self.q_a_layernorm = RMSNorm(
+            self.q_lora_rank,
+            eps=config.rms_norm_eps,
+        )
+        self.q_b_proj = ColumnParallelLinear(
+            self.q_lora_rank,
+            self.num_heads * self.qk_head_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.q_b_proj",
+        )
+    else:
+        self.q_proj = ColumnParallelLinear(
+            proj_input_size,
+            self.num_heads * self.qk_head_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.q_proj",
+        )
+
+    self.kv_a_layernorm = RMSNorm(
+        self.kv_lora_rank,
+        eps=config.rms_norm_eps,
+    )
+
+    self.kv_b_proj = ColumnParallelLinear(
+        self.kv_lora_rank,
+        self.num_heads * (self.qk_nope_head_dim + self.v_head_dim),
+        bias=False,
+        quant_config=quant_config,
+        prefix=f"{prefix}.kv_b_proj",
+    )
+
+    self.o_proj = RowParallelLinear(
+        self.num_heads * self.v_head_dim,
+        self.hidden_size,
+        bias=False,
+        quant_config=quant_config,
+        prefix=f"{prefix}.o_proj",
+    )
+
+    if config.rope_parameters["rope_type"] != "default":
+        config.rope_parameters["rope_type"] = (
+            "deepseek_yarn"
+            if config.rope_parameters.get(
+                "apply_yarn_scaling",
+                True,
+            )
+            else "deepseek_llama_scaling"
+        )
+
+    self.rotary_emb = get_rope(
+        qk_rope_head_dim,
+        max_position=max_position_embeddings,
+        rope_parameters=config.rope_parameters,
+        is_neox_style=False,
+    )
+
+    if config.rope_parameters["rope_type"] != "default" and config.rope_parameters["rope_type"] == "deepseek_yarn":
+        mscale_all_dim = config.rope_parameters.get(
+            "mscale_all_dim",
+            False,
+        )
+        scaling_factor = config.rope_parameters["factor"]
+        mscale = yarn_get_mscale(
+            scaling_factor,
+            float(mscale_all_dim),
+        )
+        self.scaling = self.scaling * mscale * mscale
+
+    self.is_v32 = hasattr(config, "index_topk")
+
+    # IndexCache config.
+    #
+    # PR #45895 的关键修改是：
+    # 1. 在创建 Indexer 前先计算当前层是否 skip_topk；
+    # 2. skip_topk 的 backbone 层不创建 Indexer；
+    # 3. MTP/nextn 层即使命中 skip pattern，也必须创建完整 Indexer。
+    _skip_topk = False
+    _index_topk_freq = getattr(
+        config,
+        "index_topk_freq",
+        1,
+    )
+    _index_topk_pattern = getattr(
+        config,
+        "index_topk_pattern",
+        None,
+    )
+    _index_skip_topk_offset = getattr(
+        config,
+        "index_skip_topk_offset",
+        2,
+    )
+
+    layer_id = extract_layer_index(prefix)
+
+    if _index_topk_pattern is None:
+        _skip_topk = (
+            max(
+                layer_id - _index_skip_topk_offset + 1,
+                0,
+            )
+            % _index_topk_freq
+            != 0
+        )
+    elif 0 <= layer_id < len(_index_topk_pattern):
+        _skip_topk = _index_topk_pattern[layer_id] == "S"
+
+    # Skip pattern only governs backbone layers.
+    #
+    # MTP/nextn layers must always build a complete Indexer. The MTP
+    # implementation computes top-k indices at draft step 0, then changes
+    # skip_topk dynamically during the remaining speculative iterations.
+    _num_hidden_layers = getattr(
+        config,
+        "num_hidden_layers",
+        None,
+    )
+    is_mtp_layer = _num_hidden_layers is not None and layer_id >= _num_hidden_layers
+
+    if self.is_v32 and (not _skip_topk or is_mtp_layer):
+        self.indexer_rope_emb = get_rope(
+            qk_rope_head_dim,
+            max_position=max_position_embeddings,
+            rope_parameters=config.rope_parameters,
+            is_neox_style=not getattr(
+                config,
+                "indexer_rope_interleave",
+                False,
+            ),
+        )
+
+        self.indexer = Indexer(
+            vllm_config,
+            config,
+            hidden_size,
+            q_lora_rank,
+            quant_config,
+            cache_config,
+            topk_indices_buffer,
+            f"{prefix}.indexer",
+            is_inplace_rope=self.indexer_rope_emb.enabled(),
+        )
+    else:
+        self.indexer_rope_emb = None
+        self.indexer = None
+
+    mla_modules = MLAModules(
+        kv_a_layernorm=self.kv_a_layernorm,
+        kv_b_proj=self.kv_b_proj,
+        rotary_emb=self.rotary_emb,
+        o_proj=self.o_proj,
+        fused_qkv_a_proj=(self.fused_qkv_a_proj if self.q_lora_rank is not None else None),
+        kv_a_proj_with_mqa=(self.kv_a_proj_with_mqa if self.q_lora_rank is None else None),
+        q_a_layernorm=(self.q_a_layernorm if self.q_lora_rank is not None else None),
+        q_b_proj=(self.q_b_proj if self.q_lora_rank is not None else None),
+        q_proj=(self.q_proj if self.q_lora_rank is None else None),
+        indexer=self.indexer,
+        indexer_rotary_emb=self.indexer_rope_emb,
+        is_sparse=self.is_v32,
+        topk_indices_buffer=topk_indices_buffer,
+    )
+
+    self.mla_attn = MultiHeadLatentAttentionWrapper(
+        self.hidden_size,
+        self.num_local_heads,
+        self.scaling,
+        self.qk_nope_head_dim,
+        self.qk_rope_head_dim,
+        self.v_head_dim,
+        self.q_lora_rank,
+        self.kv_lora_rank,
+        mla_modules,
+        cache_config,
+        quant_config,
+        prefix,
+        skip_topk=_skip_topk,
+    )
+
+
+DeepseekV2MLAAttention.__init__ = _deepseek_v2_mla_attention_init


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds support for GLM-5.2 on Ascend.

GLM-5.2 uses a layer-wise DSA indexer pattern. Some backbone layers skip Lightning Indexer computation and reuse top-k indices generated by shared indexer layers through the index cache. However, the existing SFA implementation assumes that every DSA attention layer owns an Indexer, which causes initialization and runtime failures for layers configured with skip_topk.

The main changes include: 
- Support DSA layers without a local `Indexer` when `skip_topk` is enabled. 
- Reuse cached top-k indices for shared indexer layers. 
- Adapt SFA and DSA-CP paths to handle layers without indexer KV cache. 
- Add a temporary vLLM patch and a multi-node GLM-5.2 W8A8 nightly test.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
