### PR TITLE
[BugFix] fix qwen3.5 accuracy bug when sett cp-kv-cache-interleave-si…

### DIFF
--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -898,7 +898,7 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
 
         pcp_unpad_mask = attn_metadata.prefill.pcp_metadata.pcp_unpad_mask[attn_metadata.num_decodes * self.pcp_size :]
         qkv_fa_padding_workspace[decode_offset:][pcp_unpad_mask] = actual_qkv[decode_offset:]
-        qkv_fa_padding_workspace[decode_offset:][~pcp_unpad_mask].fill_(0)
+        qkv_fa_padding_workspace[decode_offset:][~pcp_unpad_mask] = 0
 
         q, k, v = qkv_fa_padding_workspace.split(
             [

--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -515,4 +515,5 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
 
         if self.moe_config.pcp_size > 1:
             hidden_states = get_pcp_group().reduce_scatter(hidden_states, dim=0)
+            hidden_states = hidden_states[: self.num_tokens_pcp]
         return hidden_states

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -144,7 +144,10 @@ class BlockTable:
         total_cp_world_size = self.pcp_world_size * self.dcp_world_size
         total_cp_rank = self.pcp_rank * self.dcp_world_size + self.dcp_rank
         if self.dcp_world_size * self.pcp_world_size > 1:
-            req_indices = torch.repeat_interleave(torch.arange(num_reqs, dtype=torch.int32, device=query_start_loc.device), query_start_loc[1:] - query_start_loc[:-1])
+            req_indices = torch.repeat_interleave(
+                torch.arange(num_reqs, dtype=torch.int32, device=query_start_loc.device),
+                query_start_loc[1:] - query_start_loc[:-1],
+            )
             self._compute_pcp_dcp_slot_mapping(req_indices, positions)
         else:
             _compute_slot_mapping_kernel[(num_reqs + 1,)](
@@ -211,18 +214,12 @@ class BlockTable:
         # logical_block_idx = positions // virtual_block_size
 
         total_cp_world_size = self.dcp_world_size * self.pcp_world_size
-        # CP interleaving is defined on the physical KV cache block. Hybrid
-        # blocks then split that local physical position into kernel-sized
-        # logical blocks for block table and slot mapping.
         virtual_physical_block_size = self.physical_block_size * total_cp_world_size
         physical_block_idx = positions // virtual_physical_block_size
         virtual_block_offsets = positions % virtual_physical_block_size
 
         self.current_rank = self.dcp_world_size * self.pcp_rank + self.dcp_rank
-        mask = (
-            virtual_block_offsets // self.cp_kv_cache_interleave_size % total_cp_world_size
-            == self.current_rank
-        )
+        mask = virtual_block_offsets // self.cp_kv_cache_interleave_size % total_cp_world_size == self.current_rank
         local_physical_offsets = (
             virtual_block_offsets
             // (total_cp_world_size * self.cp_kv_cache_interleave_size)
@@ -233,9 +230,7 @@ class BlockTable:
             local_physical_offsets // self.block_size
         )
 
-        block_table_indices = (
-            req_indices * self.max_num_blocks_per_req * self.blocks_per_phys_block + logical_block_idx
-        )
+        block_table_indices = req_indices * self.max_num_blocks_per_req * self.blocks_per_phys_block + logical_block_idx
 
         block_offsets = local_physical_offsets % self.block_size
 

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -198,37 +198,55 @@ class BlockTable:
         req_indices: torch.Tensor,
         positions: torch.Tensor,
     ) -> None:
-        """Slot mapping for Prefill/Decode Context Parallelism.
-        """
+        # Note(hc): The DCP implement store kvcache with an interleave
+        # style, the kvcache for the token whose token_idx is i is
+        # always stored on the GPU whose dcp_rank equals i % pcp_world_size:
+
+        # Use a "virtual block" which equals to world_size * block_size
+        # for block_table_indices calculation.
+        # virtual_block_size = self.block_size * self.dcp_world_size * self.pcp_world_size
+
+        # IMPORTANT: In hybrid mode, positions are in logical block space,
+        # but we need to map them to the correct logical block table indices
+        # logical_block_idx = positions // virtual_block_size
+
         total_cp_world_size = self.dcp_world_size * self.pcp_world_size
-        current_rank = self.dcp_world_size * self.pcp_rank + self.dcp_rank
-        interleave = self.cp_kv_cache_interleave_size
+        # CP interleaving is defined on the physical KV cache block. Hybrid
+        # blocks then split that local physical position into kernel-sized
+        # logical blocks for block table and slot mapping.
+        virtual_physical_block_size = self.physical_block_size * total_cp_world_size
+        physical_block_idx = positions // virtual_physical_block_size
+        virtual_block_offsets = positions % virtual_physical_block_size
 
-        owner_rank = (positions // interleave) % total_cp_world_size
-        # Compact, per-rank index of this token within the rank's local KV cache.
-        local_pos = (
-            positions // (interleave * total_cp_world_size)
-        ) * interleave + (positions % interleave)
-        is_local = owner_rank == current_rank
-
-        # Map the rank-local position into the (hybrid) logical block table.
-        logical_block_idx = local_pos // self.block_size
-        block_offset = local_pos % self.block_size
-        block_table_indices = (
-            req_indices * self.max_num_blocks_per_req * self.blocks_per_phys_block
-            + logical_block_idx
+        self.current_rank = self.dcp_world_size * self.pcp_rank + self.dcp_rank
+        mask = (
+            virtual_block_offsets // self.cp_kv_cache_interleave_size % total_cp_world_size
+            == self.current_rank
         )
+        local_physical_offsets = (
+            virtual_block_offsets
+            // (total_cp_world_size * self.cp_kv_cache_interleave_size)
+            * self.cp_kv_cache_interleave_size
+            + virtual_block_offsets % self.cp_kv_cache_interleave_size
+        )
+        logical_block_idx = physical_block_idx * self.blocks_per_phys_block + (
+            local_physical_offsets // self.block_size
+        )
+
+        block_table_indices = (
+            req_indices * self.max_num_blocks_per_req * self.blocks_per_phys_block + logical_block_idx
+        )
+
+        block_offsets = local_physical_offsets % self.block_size
 
         if block_table_indices.device.type != "cpu":
             block_numbers = self.block_table.gpu.flatten()[block_table_indices]
+            slot_mapping = block_numbers * self.block_size + block_offsets
+            self.slot_mapping.gpu[: req_indices.shape[0]] = torch.where(mask, slot_mapping, -1)
         else:
             block_numbers = self.block_table.cpu.flatten()[block_table_indices]
-        slot_mapping = block_numbers * self.block_size + block_offset
-        slots = torch.where(is_local, slot_mapping, PAD_SLOT_ID)
-        if block_table_indices.device.type != "cpu":
-            self.slot_mapping.gpu[: req_indices.shape[0]] = slots
-        else:
-            self.slot_mapping.cpu[: req_indices.shape[0]] = slots
+            slot_mapping = block_numbers * self.block_size + block_offsets
+            self.slot_mapping.cpu[: req_indices.shape[0]] = torch.where(mask, slot_mapping, -1)
 
     def commit_block_table(self, num_reqs: int) -> None:
         self.block_table.copy_to_gpu(num_reqs)

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -143,21 +143,25 @@ class BlockTable:
         num_tokens = positions.shape[0]
         total_cp_world_size = self.pcp_world_size * self.dcp_world_size
         total_cp_rank = self.pcp_rank * self.dcp_world_size + self.dcp_rank
-        _compute_slot_mapping_kernel[(num_reqs + 1,)](
-            num_tokens,
-            self.max_num_batched_tokens,
-            query_start_loc,
-            positions,
-            self.block_table.gpu,
-            self.block_table.gpu.stride(0),
-            self.block_size,
-            self.slot_mapping.gpu,
-            TOTAL_CP_WORLD_SIZE=total_cp_world_size,
-            TOTAL_CP_RANK=total_cp_rank,
-            CP_KV_CACHE_INTERLEAVE_SIZE=self.cp_kv_cache_interleave_size,
-            PAD_ID=PAD_SLOT_ID,
-            BLOCK_SIZE=1024,
-        )
+        if self.dcp_world_size * self.pcp_world_size > 1:
+            req_indices = torch.repeat_interleave(torch.arange(num_reqs, dtype=torch.int32, device=query_start_loc.device), query_start_loc[1:] - query_start_loc[:-1])
+            self._compute_pcp_dcp_slot_mapping(req_indices, positions)
+        else:
+            _compute_slot_mapping_kernel[(num_reqs + 1,)](
+                num_tokens,
+                self.max_num_batched_tokens,
+                query_start_loc,
+                positions,
+                self.block_table.gpu,
+                self.block_table.gpu.stride(0),
+                self.block_size,
+                self.slot_mapping.gpu,
+                TOTAL_CP_WORLD_SIZE=total_cp_world_size,
+                TOTAL_CP_RANK=total_cp_rank,
+                CP_KV_CACHE_INTERLEAVE_SIZE=self.cp_kv_cache_interleave_size,
+                PAD_ID=PAD_SLOT_ID,
+                BLOCK_SIZE=1024,
+            )
 
     def compute_slot_mapping_draft(self, req_indices: np.ndarray, positions: np.ndarray) -> None:
         # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
@@ -168,46 +172,7 @@ class BlockTable:
         # block_size.
 
         if self.dcp_world_size * self.pcp_world_size > 1:
-            # Note(hc): The DCP implement store kvcache with an interleave
-            # style, the kvcache for the token whose token_idx is i is
-            # always stored on the GPU whose dcp_rank equals i % pcp_world_size:
-
-            # Use a "virtual block" which equals to world_size * block_size
-            # for block_table_indices calculation.
-            virtual_block_size = self.block_size * self.dcp_world_size * self.pcp_world_size
-
-            # IMPORTANT: In hybrid mode, positions are in logical block space,
-            # but we need to map them to the correct logical block table indices
-            logical_block_idx = positions // virtual_block_size
-
-            # Account for the expanded logical table
-            # (always needed with unified tensor)
-            # Each physical block is split into multiple logical blocks
-            # The logical table has been expanded to accommodate this
-            block_table_indices = (
-                req_indices * self.max_num_blocks_per_req * self.blocks_per_phys_block + logical_block_idx
-            )
-
-            block_numbers = self.block_table.np.ravel()[block_table_indices]
-            # Use virtual_block_size for mask calculation, which marks local
-            # tokens.
-            virtual_block_offsets = positions % virtual_block_size
-            self.current_rank = self.dcp_world_size * self.pcp_rank + self.dcp_rank
-            mask = (
-                virtual_block_offsets // self.cp_kv_cache_interleave_size % (self.dcp_world_size * self.pcp_world_size)
-                == self.current_rank
-            )
-            # Calculate local block_offsets
-            block_offsets = (
-                virtual_block_offsets
-                // (self.dcp_world_size * self.pcp_world_size * self.cp_kv_cache_interleave_size)
-                * self.cp_kv_cache_interleave_size
-                + virtual_block_offsets % self.cp_kv_cache_interleave_size
-            )
-            # Calculate slot_mapping
-            slot_mapping = block_numbers * self.block_size + block_offsets
-            # Write final slots, use -1 for not-local
-            self.slot_mapping.np[: req_indices.shape[0]] = np.where(mask, slot_mapping, -1)
+            self._compute_pcp_dcp_slot_mapping(torch.from_numpy(req_indices), torch.from_numpy(positions))
         else:
             assert self.kernel_sizes is not None
             assert self.block_size == self.kernel_sizes[0]
@@ -227,6 +192,66 @@ class BlockTable:
             block_offsets = positions % self.block_size
             np.add(block_numbers * self.block_size, block_offsets, out=self.slot_mapping.np[: req_indices.shape[0]])
             self.slot_mapping.copy_to_gpu(req_indices.shape[0])
+
+    def _compute_pcp_dcp_slot_mapping(
+        self,
+        req_indices: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> None:
+        # Note(hc): The DCP implement store kvcache with an interleave
+        # style, the kvcache for the token whose token_idx is i is
+        # always stored on the GPU whose dcp_rank equals i % pcp_world_size:
+
+        # Use a "virtual block" which equals to world_size * block_size
+        # for block_table_indices calculation.
+        # virtual_block_size = self.block_size * self.dcp_world_size * self.pcp_world_size
+
+        # IMPORTANT: In hybrid mode, positions are in logical block space,
+        # but we need to map them to the correct logical block table indices
+        # logical_block_idx = positions // virtual_block_size
+
+        total_cp_world_size = self.dcp_world_size * self.pcp_world_size
+        # CP interleaving is defined on the physical KV cache block. Hybrid
+        # blocks then split that local physical position into kernel-sized
+        # logical blocks for block table and slot mapping.
+        virtual_physical_block_size = self.physical_block_size * total_cp_world_size
+        physical_block_idx = positions // virtual_physical_block_size
+        virtual_block_offsets = positions % virtual_physical_block_size
+        tp_rank =  get_tensor_model_parallel_rank()
+
+        self.current_rank = self.dcp_world_size * self.pcp_rank + self.dcp_rank
+        mask = (
+            virtual_block_offsets // self.cp_kv_cache_interleave_size % total_cp_world_size
+            == self.current_rank
+        )
+        local_physical_offsets = (
+            virtual_block_offsets
+            // (total_cp_world_size * self.cp_kv_cache_interleave_size)
+            * self.cp_kv_cache_interleave_size
+            + virtual_block_offsets % self.cp_kv_cache_interleave_size
+        )
+        logical_block_idx = physical_block_idx * self.blocks_per_phys_block + (
+            local_physical_offsets // self.block_size
+        )
+
+        # Account for the expanded logical table
+        # (always needed with unified tensor)
+        # Each physical block is split into multiple logical blocks
+        # The logical table has been expanded to accommodate this
+        block_table_indices = (
+            req_indices * self.max_num_blocks_per_req * self.blocks_per_phys_block + logical_block_idx
+        )
+
+        block_offsets = local_physical_offsets % self.block_size
+
+        if block_table_indices.device.type != "cpu":
+            block_numbers = self.block_table.gpu.flatten()[block_table_indices]
+            slot_mapping = block_numbers * self.block_size + block_offsets
+            self.slot_mapping.gpu[: req_indices.shape[0]] = torch.where(mask, slot_mapping, -1)
+        else:
+            block_numbers = self.block_table.cpu.flatten()[block_table_indices]
+            slot_mapping = block_numbers * self.block_size + block_offsets
+            self.slot_mapping.cpu[: req_indices.shape[0]] = torch.where(mask, slot_mapping, -1)
 
     def commit_block_table(self, num_reqs: int) -> None:
         self.block_table.copy_to_gpu(num_reqs)

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -198,60 +198,37 @@ class BlockTable:
         req_indices: torch.Tensor,
         positions: torch.Tensor,
     ) -> None:
-        # Note(hc): The DCP implement store kvcache with an interleave
-        # style, the kvcache for the token whose token_idx is i is
-        # always stored on the GPU whose dcp_rank equals i % pcp_world_size:
-
-        # Use a "virtual block" which equals to world_size * block_size
-        # for block_table_indices calculation.
-        # virtual_block_size = self.block_size * self.dcp_world_size * self.pcp_world_size
-
-        # IMPORTANT: In hybrid mode, positions are in logical block space,
-        # but we need to map them to the correct logical block table indices
-        # logical_block_idx = positions // virtual_block_size
-
+        """Slot mapping for Prefill/Decode Context Parallelism.
+        """
         total_cp_world_size = self.dcp_world_size * self.pcp_world_size
-        # CP interleaving is defined on the physical KV cache block. Hybrid
-        # blocks then split that local physical position into kernel-sized
-        # logical blocks for block table and slot mapping.
-        virtual_physical_block_size = self.physical_block_size * total_cp_world_size
-        physical_block_idx = positions // virtual_physical_block_size
-        virtual_block_offsets = positions % virtual_physical_block_size
-        tp_rank =  get_tensor_model_parallel_rank()
+        current_rank = self.dcp_world_size * self.pcp_rank + self.dcp_rank
+        interleave = self.cp_kv_cache_interleave_size
 
-        self.current_rank = self.dcp_world_size * self.pcp_rank + self.dcp_rank
-        mask = (
-            virtual_block_offsets // self.cp_kv_cache_interleave_size % total_cp_world_size
-            == self.current_rank
-        )
-        local_physical_offsets = (
-            virtual_block_offsets
-            // (total_cp_world_size * self.cp_kv_cache_interleave_size)
-            * self.cp_kv_cache_interleave_size
-            + virtual_block_offsets % self.cp_kv_cache_interleave_size
-        )
-        logical_block_idx = physical_block_idx * self.blocks_per_phys_block + (
-            local_physical_offsets // self.block_size
-        )
+        owner_rank = (positions // interleave) % total_cp_world_size
+        # Compact, per-rank index of this token within the rank's local KV cache.
+        local_pos = (
+            positions // (interleave * total_cp_world_size)
+        ) * interleave + (positions % interleave)
+        is_local = owner_rank == current_rank
 
-        # Account for the expanded logical table
-        # (always needed with unified tensor)
-        # Each physical block is split into multiple logical blocks
-        # The logical table has been expanded to accommodate this
+        # Map the rank-local position into the (hybrid) logical block table.
+        logical_block_idx = local_pos // self.block_size
+        block_offset = local_pos % self.block_size
         block_table_indices = (
-            req_indices * self.max_num_blocks_per_req * self.blocks_per_phys_block + logical_block_idx
+            req_indices * self.max_num_blocks_per_req * self.blocks_per_phys_block
+            + logical_block_idx
         )
-
-        block_offsets = local_physical_offsets % self.block_size
 
         if block_table_indices.device.type != "cpu":
             block_numbers = self.block_table.gpu.flatten()[block_table_indices]
-            slot_mapping = block_numbers * self.block_size + block_offsets
-            self.slot_mapping.gpu[: req_indices.shape[0]] = torch.where(mask, slot_mapping, -1)
         else:
             block_numbers = self.block_table.cpu.flatten()[block_table_indices]
-            slot_mapping = block_numbers * self.block_size + block_offsets
-            self.slot_mapping.cpu[: req_indices.shape[0]] = torch.where(mask, slot_mapping, -1)
+        slot_mapping = block_numbers * self.block_size + block_offset
+        slots = torch.where(is_local, slot_mapping, PAD_SLOT_ID)
+        if block_table_indices.device.type != "cpu":
+            self.slot_mapping.gpu[: req_indices.shape[0]] = slots
+        else:
+            self.slot_mapping.cpu[: req_indices.shape[0]] = slots
 
     def commit_block_table(self, num_reqs: int) -> None:
         self.block_table.copy_to_gpu(num_reqs)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4551,6 +4551,7 @@ class NPUModelRunner(GPUModelRunner):
                 kernel_block_sizes=self.kernel_block_sizes,
                 max_num_blocks_per_req=max_num_blocks,
                 kv_cache_groups=kv_cache_config.kv_cache_groups,
+                cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
             )
 
     def initialize_attn_backend(


### PR DESCRIPTION
### What this PR does / why we need it?
Fix the issue of incorrect precision when the qwen3.5 cp-kv-cache-interleave-size setting is set to 1024.

When block_size > 1024, the block_size in the block_table is set to the kernel block size, causing issues in the calculation of slot mapping. As a result, the allocation is not evenly distributed across the cards, leading to precision problems.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
