### PR TITLE
[BugFix][Model] Fix MiniMax-M2 double TP all-reduce on v0.20+

### DIFF
--- a/vllm_ascend/patch/worker/patch_minimax_m2.py
+++ b/vllm_ascend/patch/worker/patch_minimax_m2.py
@@ -71,8 +71,17 @@ def _patched_moe_forward(
 
     # router_logits: (num_tokens, n_experts)
     router_logits, _ = self.gate(hidden_states.to(torch.float32))
-    final_hidden_states = self.experts(hidden_states=hidden_states, router_logits=router_logits)
-    if self.tp_size > 1:
+    fused_moe_out = self.experts(hidden_states=hidden_states, router_logits=router_logits)
+    fused_moe_out_is_tuple = isinstance(fused_moe_out, tuple)
+    if fused_moe_out_is_tuple:
+        final_hidden_states = fused_moe_out[1]
+    else:
+        final_hidden_states = fused_moe_out
+
+    # v0.20+ MoERunner applies TP all-reduce for tensor outputs when
+    # _fused_output_is_reduced is False (ALLGATHER without flash_comm).
+    # Only legacy tuple outputs still need reduction here (see deepseek_v4.py).
+    if self.tp_size > 1 and fused_moe_out_is_tuple:
         final_hidden_states = self.experts.maybe_all_reduce_tensor_model_parallel(final_hidden_states)
     return final_hidden_states.view(num_tokens, hidden_dim)
 


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the `_patched_moe_forward` function in `vllm_ascend/patch/worker/patch_minimax_m2.py` to correctly handle cases where `self.experts` returns either a tensor or a tuple. For tensor outputs, it avoids redundant tensor model parallel all-reduce operations, which are already handled by MoERunner in v0.20+ when `_fused_output_is_reduced` is False. For legacy tuple outputs, it extracts the hidden states and performs the reduction as before. The description of this bug is at：#10466 .
#### Root cause: double TP all-reduce
Starting from **v0.20**, upstream vLLM refactored the MoE execution path through `MoERunner.forward()`, which calls `_maybe_reduce_final_output()` before returning. Whether TP all-reduce runs depends on the backend property `_fused_output_is_reduced`.
For **ALLGATHER MoE without flash_comm**, `AscendMoERunner._fused_output_is_reduced` returns `False` in `vllm_ascend/ops/fused_moe/fused_moe.py`, so upstream performs the **first** TP all-reduce on the **tensor** returned by `experts()`.The MiniMax patch in `vllm_ascend/patch/worker/patch_minimax_m2.py` (`_patched_moe_forward`) still unconditionally performed a second TP all-reduce when `tp_size > 1`:
```python
if self.tp_size > 1:
    final_hidden_states = self.experts.maybe_all_reduce_tensor_model_parallel(final_hidden_states)
```

Fix
Only call maybe_all_reduce_tensor_model_parallel when experts() returns a legacy tuple; skip when it returns a tensor already reduced by upstream MoERunner. This matches the existing pattern in vllm_ascend/models/deepseek_v4.py.

How was this patch tested?
Manual testing on Ascend NPU:
Model: MiniMax-M2.7 w8a8 QuaRot
Config: TP=8, ALLGATHER MoE, MoE fusion off, --enforce-eager
Before fix: garbled / nonsensical generation.
After fix: correct generation.
