### PR TITLE
[CI] Skip CPU test time collect

### DIFF
--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -245,19 +245,14 @@ jobs:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
           TORCH_DEVICE_BACKEND_AUTOLOAD: 0
         run: |
-          TIMING_FLAG=""
-          if [ "${{ inputs.upload_timing }}" = "true" ]; then
-            TIMING_FLAG="--timing"
-          fi
           .github/workflows/scripts/run_selected_tests.sh \
             "${{ matrix.group.npu_type }}" \
             "${{ matrix.group.num_npus }}" \
             "without-device" \
-            ${TIMING_FLAG} \
             ${{ matrix.group.tests }}
 
       - name: Upload timing data
-        if: ${{ inputs.upload_timing }}
+        if: ${{ inputs.upload_timing && matrix.group.npu_type != 'cpu' }}
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/schedule_update_estimated_times.yaml
+++ b/.github/workflows/schedule_update_estimated_times.yaml
@@ -21,11 +21,25 @@ on:
   schedule:
     - cron: '0 8 */3 * *'  # Every 3 days at 16:00 Beijing (UTC+8)
   workflow_dispatch:
+    inputs:
+      filter_npu_type:
+        description: 'Only run tests for this NPU type (e.g. a2, a3, 310p). Leave empty to run all.'
+        required: false
+        type: string
+        default: ''
+      filter_num_npus:
+        description: 'Only run tests with this NPU count (e.g. 1, 2, 4, 8). Leave empty to run all.'
+        required: false
+        type: string
+        default: ''
+      filter_partition:
+        description: 'Only run this partition (e.g. 1-3). Leave empty to run all.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: update-estimated-times-${{ github.ref }}
@@ -65,6 +79,24 @@ jobs:
           python3 .github/workflows/scripts/select_tests.py \
             --run-all-modules \
             --changed-files vllm_ascend/__init__.py
+          # Re-read outputs and strip cpu-only groups (timing data from CPU UTs
+          # is batch-level and skipped by update_estimated_times.py anyway).
+          groups_json="$(grep '^test_groups=' "$GITHUB_OUTPUT" | cut -d= -f2-)"
+          filter=".npu_type != \"cpu\""
+          if [ -n "${{ inputs.filter_npu_type }}" ]; then
+            filter="${filter} and .npu_type == \"${{ inputs.filter_npu_type }}\""
+          fi
+          if [ -n "${{ inputs.filter_num_npus }}" ]; then
+            filter="${filter} and .num_npus == ${{ inputs.filter_num_npus }}"
+          fi
+          if [ -n "${{ inputs.filter_partition }}" ]; then
+            filter="${filter} and .partition == \"${{ inputs.filter_partition }}\""
+          fi
+          filtered="$(echo "$groups_json" | jq -c "[.[] | select(${filter})]")"
+          has_tests="false"
+          if [ "$(echo "$filtered" | jq 'length')" -gt 0 ]; then has_tests="true"; fi
+          sed -i "s|^test_groups=.*|test_groups=${filtered}|" "$GITHUB_OUTPUT"
+          sed -i "s|^has_tests=.*|has_tests=${has_tests}|" "$GITHUB_OUTPUT"
 
   run-tests-main:
     needs: select-tests

--- a/.github/workflows/scripts/run_selected_tests.sh
+++ b/.github/workflows/scripts/run_selected_tests.sh
@@ -83,7 +83,7 @@ run_pytest_target() {
   set -e
   if [ "${record_timing}" = true ]; then
     local elapsed_ns=$(( $(date +%s%N) - start_time ))
-    local elapsed=$(echo "scale=1; ${elapsed_ns} / 1000000000" | bc)
+    local elapsed=$(( elapsed_ns / 1000000000 )).$(( (elapsed_ns % 1000000000) / 100000000 ))
     timing_entries+=("{\"name\":\"${target}\",\"passed\":$([ ${status} -eq 0 ] && echo true || echo false),\"elapsed\":${elapsed}}")
   fi
   echo "::endgroup::"
@@ -118,7 +118,7 @@ run_pytest_batch() {
   set -e
   if [ "${record_timing}" = true ]; then
     local elapsed_ns=$(( $(date +%s%N) - start_time ))
-    local elapsed=$(echo "scale=1; ${elapsed_ns} / 1000000000" | bc)
+    local elapsed=$(( elapsed_ns / 1000000000 )).$(( (elapsed_ns % 1000000000) / 100000000 ))
     timing_entries+=("{\"name\":\"${target}\",\"passed\":$([ ${status} -eq 0 ] && echo true || echo false),\"elapsed\":${elapsed}}")
   fi
   echo "::endgroup::"


### PR DESCRIPTION
1. Skip CPU test time collection job
2. fix time collection bug
3. allow workflow_dispatch work with input vars.


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/efc347f1b2e635753ae8a594e9714109c200fcd3
