### PR TITLE
[CI ]Fix schedule_update_estimated_times permission

### DIFF
--- a/.github/workflows/schedule_update_estimated_times.yaml
+++ b/.github/workflows/schedule_update_estimated_times.yaml
@@ -40,6 +40,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: update-estimated-times-${{ github.ref }}


### PR DESCRIPTION
Fix schedule_update_estimated_times permission
- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/efc347f1b2e635753ae8a594e9714109c200fcd3
