### PR TITLE
[Feature] Support MiniMax M2 C8 cache scale in GQA load_weights

### DIFF
--- a/vllm_ascend/patch/worker/patch_gqa_c8.py
+++ b/vllm_ascend/patch/worker/patch_gqa_c8.py
@@ -21,12 +21,14 @@ from collections.abc import Callable, Iterable
 import torch
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.glm4_moe import Glm4MoeForCausalLM
+from vllm.model_executor.models.minimax_m2 import MiniMaxM2ForCausalLM
 from vllm.model_executor.models.qwen3 import Qwen3ForCausalLM
 
 logger = logging.getLogger(__name__)
 
 _orig_qwen3_causal_lm_load_weights = Qwen3ForCausalLM.load_weights
 _orig_Glm4_causal_lm_load_weights = Glm4MoeForCausalLM.load_weights
+_orig_Minimax_m2_causal_lm_load_weights = MiniMaxM2ForCausalLM.load_weights
 
 
 def _patched_causal_lm_load_weights(
@@ -70,4 +72,7 @@ Qwen3ForCausalLM.load_weights = lambda self, weights: _patched_causal_lm_load_we
 )
 Glm4MoeForCausalLM.load_weights = lambda self, weights: _patched_causal_lm_load_weights(
     self, weights, _orig_Glm4_causal_lm_load_weights
+)
+MiniMaxM2ForCausalLM.load_weights = lambda self, weights: _patched_causal_lm_load_weights(
+    self, weights, _orig_Minimax_m2_causal_lm_load_weights
 )


### PR DESCRIPTION
### What this PR does / why we need it?
Support minimax C8

-->

### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?
I have tested the precision and perfomance. 
precision: AIME2025->93.33
performance: 3.5k 1.5k DP2TP8 Concurrency256 tpot [56.5(w8a8) -> 52.7(w8a8c8)] output token throughput[3996.55(w8a8) -> 4632.68(w8a8c8)]

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/efc347f1b2e635753ae8a594e9714109c200fcd3
