### PR TITLE
[Feat][Ascend] update rope cache ops for external-sin/cos removal

### DIFF
--- a/tests/ut/_310p/ops/test_rotary_embedding_310.py
+++ b/tests/ut/_310p/ops/test_rotary_embedding_310.py
@@ -15,16 +15,10 @@
 
 import torch
 
-from vllm_ascend._310p.ops import rotary_embedding as rotary_310
 from vllm_ascend._310p.ops.rotary_embedding import (
     AscendMRotaryEmbedding310,
-    set_mrope_apply_rotary_slices,
+    _select_mrope_apply_rotary_slices,
 )
-
-
-def _reset_mrope_globals():
-    rotary_310._mrope_cos_slice = None
-    rotary_310._mrope_sin_slice = None
 
 
 def _build_mrope_embedding() -> AscendMRotaryEmbedding310:
@@ -32,44 +26,91 @@ def _build_mrope_embedding() -> AscendMRotaryEmbedding310:
     emb.mrope_section = [2, 2, 2]
     emb.mrope_interleaved = False
     emb.cos_sin_cache = torch.randn(64, 12, dtype=torch.float32)
+    emb.is_neox_style = True
     return emb
 
 
-def test_set_mrope_apply_rotary_slices_populates_globals():
-    _reset_mrope_globals()
+def _select_slices(emb: AscendMRotaryEmbedding310, positions: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    ref_tensor = torch.empty(positions.shape[-1], 1, 8, dtype=emb.cos_sin_cache.dtype)
+    return _select_mrope_apply_rotary_slices(emb, positions, ref_tensor)
+
+
+def test_select_mrope_apply_rotary_slices_populates_layer_buffers():
     emb = _build_mrope_embedding()
     positions = torch.randint(0, emb.cos_sin_cache.shape[0], (3, 4), dtype=torch.long)
-    set_mrope_apply_rotary_slices(
-        emb.cos_sin_cache,
-        positions,
-        mrope_section=emb.mrope_section,
-        mrope_interleaved=emb.mrope_interleaved,
-    )
+    cos, sin = _select_slices(emb, positions)
 
-    assert rotary_310._mrope_cos_slice is not None
-    assert rotary_310._mrope_sin_slice is not None
-    assert rotary_310._mrope_cos_slice.shape[1] == positions.shape[-1]
+    assert cos.shape[1] == positions.shape[-1]
+    assert sin.shape[1] == positions.shape[-1]
+    assert emb._mrope_apply_cos_buffer.shape[1] == positions.shape[-1]
 
 
-def test_set_mrope_apply_rotary_slices_reuses_buffer_address():
-    _reset_mrope_globals()
+def test_select_mrope_apply_rotary_slices_reuses_buffer_address():
     emb = _build_mrope_embedding()
     positions = torch.randint(0, emb.cos_sin_cache.shape[0], (3, 4), dtype=torch.long)
 
-    set_mrope_apply_rotary_slices(
-        emb.cos_sin_cache,
-        positions,
-        mrope_section=emb.mrope_section,
-        mrope_interleaved=emb.mrope_interleaved,
-    )
-    first_ptr = rotary_310._mrope_cos_slice.data_ptr()
+    _select_slices(emb, positions)
+    first_ptr = emb._mrope_apply_cos_buffer.data_ptr()
 
-    set_mrope_apply_rotary_slices(
-        emb.cos_sin_cache,
-        positions,
-        mrope_section=emb.mrope_section,
-        mrope_interleaved=emb.mrope_interleaved,
-    )
-    second_ptr = rotary_310._mrope_cos_slice.data_ptr()
+    _select_slices(emb, positions)
+    second_ptr = emb._mrope_apply_cos_buffer.data_ptr()
 
     assert first_ptr == second_ptr
+
+
+def test_select_mrope_apply_rotary_slices_updates_existing_buffer_for_new_positions():
+    emb = _build_mrope_embedding()
+    first_positions = torch.tensor(
+        [
+            [0, 1, 2, 3],
+            [4, 5, 6, 7],
+            [8, 9, 10, 11],
+        ],
+        dtype=torch.long,
+    )
+    second_positions = first_positions + 12
+
+    first_cos, first_sin = _select_slices(emb, first_positions)
+    first_ptr = emb._mrope_apply_cos_buffer.data_ptr()
+    first_cos_snapshot = first_cos.clone()
+    first_sin_snapshot = first_sin.clone()
+
+    second_cos, second_sin = _select_slices(emb, second_positions)
+
+    assert emb._mrope_apply_cos_buffer.data_ptr() == first_ptr
+    assert not torch.equal(second_cos, first_cos_snapshot)
+    assert not torch.equal(second_sin, first_sin_snapshot)
+    assert torch.equal(second_cos, emb._mrope_apply_cos_buffer[:, : second_positions.shape[-1]])
+    assert torch.equal(second_sin, emb._mrope_apply_sin_buffer[:, : second_positions.shape[-1]])
+
+
+def test_select_mrope_apply_rotary_slices_grows_buffer_and_reuses_capacity():
+    emb = _build_mrope_embedding()
+    short_positions = torch.randint(0, emb.cos_sin_cache.shape[0], (3, 4), dtype=torch.long)
+    long_positions = torch.randint(0, emb.cos_sin_cache.shape[0], (3, 8), dtype=torch.long)
+
+    _select_slices(emb, short_positions)
+    assert emb._mrope_apply_cos_buffer.shape[1] == short_positions.shape[-1]
+
+    _select_slices(emb, long_positions)
+    grown_ptr = emb._mrope_apply_cos_buffer.data_ptr()
+    assert emb._mrope_apply_cos_buffer.shape[1] == long_positions.shape[-1]
+
+    cos, sin = _select_slices(emb, short_positions)
+    assert emb._mrope_apply_cos_buffer.data_ptr() == grown_ptr
+    assert emb._mrope_apply_cos_buffer.shape[1] == long_positions.shape[-1]
+    assert cos.shape[1] == short_positions.shape[-1]
+    assert sin.shape[1] == short_positions.shape[-1]
+
+
+def test_select_mrope_apply_rotary_slices_supports_1d_positions():
+    emb = _build_mrope_embedding()
+    positions = torch.tensor([0, 1, 2, 3], dtype=torch.long)
+
+    cos, sin = _select_slices(emb, positions)
+    expected_cos, expected_sin = emb.cos_sin_cache[positions].chunk(2, dim=-1)
+    expected_cos = torch.cat((expected_cos, expected_cos), dim=-1).view(1, positions.shape[-1], 1, -1)
+    expected_sin = torch.cat((expected_sin, expected_sin), dim=-1).view(1, positions.shape[-1], 1, -1)
+
+    assert torch.equal(cos, expected_cos)
+    assert torch.equal(sin, expected_sin)

--- a/tests/ut/attention/a2/test_mla_precision.py
+++ b/tests/ut/attention/a2/test_mla_precision.py
@@ -86,8 +86,38 @@ class MockLayerNorm:
 
 
 class MockRotary:
-    def __init__(self):
-        pass
+    def __init__(
+        self,
+        max_seq_len: int,
+        rotary_dim: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ):
+        half_dim = rotary_dim // 2
+        cos = torch.ones(max_seq_len, half_dim, dtype=dtype, device=device)
+        sin = torch.zeros(max_seq_len, half_dim, dtype=dtype, device=device)
+        self.cos_sin_cache = torch.cat((cos, sin), dim=-1)
+        self.is_neox_style = True
+
+
+def test_mock_rotary_uses_layer_owned_rope_cache():
+    from vllm_ascend.ops.rotary_embedding import select_cos_sin_from_cache
+
+    positions = torch.tensor([0, 3], dtype=torch.long)
+    rotary = MockRotary(
+        max_seq_len=8,
+        rotary_dim=4,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+    )
+    ref_tensor = torch.empty(positions.shape[0], 1, 4, dtype=torch.float32)
+
+    cos, sin = select_cos_sin_from_cache(rotary, positions, ref_tensor, layout="T11D")
+
+    assert cos.shape == (positions.shape[0], 1, 1, 4)
+    assert sin.shape == (positions.shape[0], 1, 1, 4)
+    assert torch.equal(cos, torch.ones_like(cos))
+    assert torch.equal(sin, torch.zeros_like(sin))
 
 
 def create_mla_kv_cache(
@@ -168,15 +198,8 @@ def run_mla_attention_backend(
 
     init_ascend_config(vllm_config)
 
-    from vllm_ascend.ops import rotary_embedding
-
     hf_config = vllm_config.model_config.hf_text_config
     qk_rope_head_dim = getattr(hf_config, "qk_rope_head_dim", 64)
-
-    rotary_embedding._cos_cache = torch.ones(8192, qk_rope_head_dim, dtype=dtype, device=device)
-    rotary_embedding._sin_cache = torch.zeros(8192, qk_rope_head_dim, dtype=dtype, device=device)
-    rotary_embedding._cos_mla = torch.ones(8192, 1, 1, qk_rope_head_dim, dtype=dtype, device=device)
-    rotary_embedding._sin_mla = torch.zeros(8192, 1, 1, qk_rope_head_dim, dtype=dtype, device=device)
 
     from vllm.distributed.parallel_state import GroupCoordinator
 
@@ -256,7 +279,12 @@ def run_mla_attention_backend(
                 o_proj=MockLinear(out_features=o_proj_out_dim, in_features=o_proj_in_dim, device=device, dtype=dtype),
                 kv_a_layernorm=MockLayerNorm(normalized_shape=kv_lora_rank, device=device, dtype=dtype),
                 q_a_layernorm=MockLayerNorm(normalized_shape=q_lora_rank, device=device, dtype=dtype),
-                rotary_emb=MockRotary(),
+                rotary_emb=MockRotary(
+                    max_seq_len=8192,
+                    rotary_dim=qk_rope_head_dim,
+                    device=device,
+                    dtype=dtype,
+                ),
                 fused_qkv_a_proj=None,
                 kv_a_proj_with_mqa=MockLinear(
                     out_features=num_kv_heads * (kv_lora_rank + qk_rope_head_dim),

--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -367,12 +367,9 @@ class TestAscendMLAMetadataBuilder(TestBase):
             self.assertEqual(builder.block_size, mock_vllm_config.cache_config.block_size)
             self.assertEqual(builder.chunked_prefill_enabled, mock_vllm_config.scheduler_config.enable_chunked_prefill)
 
-    @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
     @patch("vllm_ascend.attention.attention_mask.get_pcp_group")
     @patch("vllm.distributed.parallel_state.get_pcp_group")
-    def test_ascend_mla_metadata_builder_build_full_graph(
-        self, mock_get_pcp_group, mock_get_pcp_group_mask, mock_get_cos_and_sin_mla
-    ):
+    def test_ascend_mla_metadata_builder_build_full_graph(self, mock_get_pcp_group, mock_get_pcp_group_mask):
         pcp_group = MagicMock()
         pcp_group.world_size = 1
         mock_get_pcp_group.return_value = pcp_group
@@ -408,7 +405,6 @@ class TestAscendMLAMetadataBuilder(TestBase):
         block_table = torch.Tensor([[1, 0], [2, 0], [3, 0], [4, 0]]).int()
         common_metadata.block_table_tensor = block_table
         common_metadata.prefill_context_parallel_metadata = None
-        mock_get_cos_and_sin_mla.return_value = (torch.tensor([6, 6]), torch.Tensor([6, 6]))
         metadata = builder.build(0, common_metadata)
 
         self.assertEqual(metadata.decode.actual_seq_lengths_q, [1, 2, 4, 5, 6, 6, 7, 8])
@@ -617,14 +613,13 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
     def tearDown(self):
         self.parent_init_patcher.stop()
 
-    @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
     @patch("vllm_ascend.attention.attention_mask.get_pcp_group")
     @patch("vllm.distributed.parallel_state.get_pcp_group")
     @patch("vllm_ascend.attention.mla_v1.torch.zeros", wraps=torch.zeros)
     @patch("torch.Tensor.npu", new=lambda self: self)
     @patch("torch.npu.is_available")
     def test_build_prefix_no_cache_metadata(
-        self, mock_npu_available, mock_zeros, mock_get_pcp_group, mock_get_pcp_group_mask, mock_get_cos_and_sin_mla
+        self, mock_npu_available, mock_zeros, mock_get_pcp_group, mock_get_pcp_group_mask
     ):
         mock_npu_available.return_value = False
         torch.Tensor.pin_memory = lambda x: x  # noqa
@@ -671,7 +666,6 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             vllm_config=self.mock_vllm_config,
             device=self.mock_device,
         )
-        mock_get_cos_and_sin_mla.return_value = (torch.tensor(10), torch.Tensor(10))
         metadata = builder.build(1, common_attn_metadata)
 
         self.assertIsInstance(metadata, AscendMLAMetadata)
@@ -679,14 +673,13 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         self.assertTrue(torch.all(metadata.slot_mapping == base_inputs["slot_mapping"]))
         self.assertEqual(metadata.head_dim, self.kv_cache_spec.head_size)
 
-    @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
     @patch("vllm_ascend.attention.attention_mask.get_pcp_group")
     @patch("vllm.distributed.parallel_state.get_pcp_group")
     @patch("vllm_ascend.attention.mla_v1.torch.zeros", wraps=torch.zeros)
     @patch("torch.Tensor.npu", new=lambda self: self)
     @patch("torch.npu.is_available")
     def test_build_chunked_prefix_metadata(
-        self, mock_npu_available, mock_zeros, mock_get_pcp_group, mock_get_pcp_group_mask, mock_get_cos_and_sin_mla
+        self, mock_npu_available, mock_zeros, mock_get_pcp_group, mock_get_pcp_group_mask
     ):
         mock_npu_available.return_value = False
         torch.Tensor.pin_memory = lambda x: x  # noqa
@@ -734,7 +727,6 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             vllm_config=self.mock_vllm_config,
             device=self.mock_device,
         )
-        mock_get_cos_and_sin_mla.return_value = (torch.tensor(10), torch.Tensor(10))
         metadata = builder.build(1, common_attn_metadata)
 
         self.assertIsInstance(metadata, AscendMLAMetadata)
@@ -742,10 +734,9 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         self.assertTrue(torch.all(metadata.slot_mapping == base_inputs["slot_mapping"]))
         self.assertEqual(metadata.head_dim, self.kv_cache_spec.head_size)
 
-    @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
     @patch("vllm_ascend.attention.attention_mask.get_pcp_group")
     @patch("vllm.distributed.parallel_state.get_pcp_group")
-    def test_build_decode_only_metadata(self, mock_get_pcp_group, mock_get_pcp_group_mask, mock_get_cos_and_sin_mla):
+    def test_build_decode_only_metadata(self, mock_get_pcp_group, mock_get_pcp_group_mask):
         torch.Tensor.pin_memory = lambda x: x  # noqa
         pcp_group = MagicMock()
         pcp_group.world_size = 1
@@ -784,7 +775,6 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             vllm_config=self.mock_vllm_config,
             device=self.mock_device,
         )
-        mock_get_cos_and_sin_mla.return_value = (torch.tensor([10, 10]), torch.Tensor([10, 10]))
         metadata = builder.build(1, common_attn_metadata)
 
         self.assertIsInstance(metadata, AscendMLAMetadata)
@@ -792,8 +782,7 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         self.assertTrue(torch.all(metadata.slot_mapping == base_inputs["slot_mapping"]))
         self.assertEqual(metadata.head_dim, self.kv_cache_spec.head_size)
 
-    @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
-    def test_build_decode_metadata_without_disable_padded_drafter_batch(self, mock_get_cos_and_sin_mla):
+    def test_build_decode_metadata_without_disable_padded_drafter_batch(self):
         common_attn_metadata = MagicMock()
         common_attn_metadata.num_reqs = 3
         common_attn_metadata.query_start_loc_cpu = torch.tensor([0, 1, 2, 3])
@@ -822,18 +811,13 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         builder.attn_mask_builder = MagicMock()
         builder.attn_mask_builder.get_splitfuse_attn_mask.return_value = torch.randn(1, 1, 5, 5)
 
-        mock_get_cos_and_sin_mla.return_value = (torch.randn(5, 32), torch.randn(5, 32))
-
         metadata = builder.build_decode_metadata(0, common_attn_metadata)
 
         self.assertIsInstance(metadata, AscendMLADecodeMetadata)
 
-    @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
     @patch("vllm_ascend.attention.attention_mask.get_pcp_group")
     @patch("vllm.distributed.parallel_state.get_pcp_group")
-    def test_build_for_graph_capture_decode_only(
-        self, mock_get_pcp_group, mock_get_pcp_group_mask, mock_get_cos_and_sin_mla
-    ):
+    def test_build_for_graph_capture_decode_only(self, mock_get_pcp_group, mock_get_pcp_group_mask):
         torch.Tensor.pin_memory = lambda x: x  # noqa
         pcp_group = MagicMock()
         pcp_group.world_size = 1
@@ -872,7 +856,6 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             vllm_config=self.mock_vllm_config,
             device=self.mock_device,
         )
-        mock_get_cos_and_sin_mla.return_value = (torch.tensor([10, 10]), torch.Tensor([10, 10]))
         metadata = builder.build_for_graph_capture(common_attn_metadata, AscendAttentionState.DecodeOnly)
 
         self.assertIsInstance(metadata, AscendMLAMetadata)
@@ -880,8 +863,7 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         self.assertTrue(torch.all(metadata.slot_mapping == base_inputs["slot_mapping"]))
         self.assertEqual(metadata.head_dim, self.kv_cache_spec.head_size)
 
-    @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
-    def test_build_for_graph_capture_prefill(self, mock_get_cos_and_sin_mla):
+    def test_build_for_graph_capture_prefill(self):
         torch.Tensor.pin_memory = lambda x: x  # noqa
         common_attn_metadata = AscendCommonAttentionMetadata(
             query_start_loc=torch.tensor([0, 3, 7]),
@@ -907,7 +889,6 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             vllm_config=self.mock_vllm_config,
             device=self.mock_device,
         )
-        mock_get_cos_and_sin_mla.return_value = (torch.tensor(10), torch.Tensor(10))
         with self.assertRaises(NotImplementedError) as ctx:
             builder.build_for_graph_capture(common_attn_metadata, AscendAttentionState.PrefillNoCache)
         self.assertIn(
@@ -915,10 +896,9 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             str(ctx.exception),
         )
 
-    @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
     @patch("vllm_ascend.attention.attention_mask.get_pcp_group")
     @patch("vllm.distributed.parallel_state.get_pcp_group")
-    def test_build_with_seq_lens_only(self, mock_get_pcp_group, mock_get_pcp_group_mask, mock_get_cos_and_sin_mla):
+    def test_build_with_seq_lens_only(self, mock_get_pcp_group, mock_get_pcp_group_mask):
         torch.Tensor.pin_memory = lambda x: x  # noqa
         pcp_group = MagicMock()
         pcp_group.world_size = 1
@@ -950,7 +930,6 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             vllm_config=self.mock_vllm_config,
             device=self.mock_device,
         )
-        mock_get_cos_and_sin_mla.return_value = (torch.randn(3, 32), torch.randn(3, 32))
         metadata = builder.build(0, common_attn_metadata)
 
         self.assertIsInstance(metadata, AscendMLAMetadata)
@@ -2077,10 +2056,8 @@ class TestAscendMLAImpl(TestBase):
         attn_metadata.num_actual_tokens = 4
         num_prefill_tokens = 2
         attn_metadata.slot_mapping = torch.arange(4)
-        attn_metadata.decode.cos = torch.randn(2, 64)
-        attn_metadata.decode.sin = torch.randn(2, 64)
-        attn_metadata.prefill.cos = torch.randn(2, 64)
-        attn_metadata.prefill.sin = torch.randn(2, 64)
+        attn_metadata.decode.input_positions = torch.arange(attn_metadata.num_decode_tokens)
+        attn_metadata.prefill.input_positions = torch.arange(num_prefill_tokens)
 
         self.impl.q_a_layernorm = MagicMock()
         self.impl.q_a_layernorm.return_value = torch.randn(
@@ -2104,6 +2081,12 @@ class TestAscendMLAImpl(TestBase):
         self.impl.kv_b_proj.return_value = [
             torch.randn(num_prefill_tokens, self.impl.num_heads, self.impl.v_head_dim + self.impl.qk_nope_head_dim)
         ]
+        self.impl._select_mla_cos_sin = MagicMock(
+            side_effect=lambda positions, ref_tensor: (
+                torch.randn(positions.shape[0], 1, 1, ref_tensor.shape[-1]),
+                torch.randn(positions.shape[0], 1, 1, ref_tensor.shape[-1]),
+            )
+        )
         self.impl.rope_single = MagicMock(side_effect=lambda x, cos, sin: x)
         self.impl.exec_kv_decode = MagicMock()
         self.impl.exec_kv_decode.return_value = [MagicMock(), MagicMock()]

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -65,13 +65,8 @@ class TestAscendSFAMetadata(TestBase):
         seq_lens = torch.tensor([30, 50])
         cum_query_lens = torch.tensor([0, 30, 80])
         block_table = torch.randint(0, 100, (100, 4))
-
-        rope_dim = 32
-        max_seq_len = int(seq_lens.max().item())
-        sin = torch.randn(max_seq_len, rope_dim)
-        cos = torch.randn(max_seq_len, rope_dim)
-
         num_input_tokens = 2
+        input_positions = torch.arange(num_input_tokens)
         head_dim = None
         attn_mask = None
         attn_state = AscendAttentionState.ChunkedPrefill
@@ -83,8 +78,7 @@ class TestAscendSFAMetadata(TestBase):
             seq_lens_cpu=seq_lens,
             cum_query_lens=cum_query_lens,
             block_table=block_table,
-            sin=sin,
-            cos=cos,
+            input_positions=input_positions,
             num_input_tokens=num_input_tokens,
             head_dim=head_dim,
             attn_mask=attn_mask,
@@ -96,8 +90,7 @@ class TestAscendSFAMetadata(TestBase):
         self.assertTrue(torch.equal(metadata.seq_lens, seq_lens))
         self.assertTrue(torch.equal(metadata.cum_query_lens, cum_query_lens))
         self.assertIs(metadata.block_table, block_table)
-        self.assertIs(metadata.sin, sin)
-        self.assertIs(metadata.cos, cos)
+        self.assertIs(metadata.input_positions, input_positions)
         self.assertEqual(metadata.num_input_tokens, num_input_tokens)
         self.assertIs(metadata.head_dim, head_dim)
         self.assertIs(metadata.attn_mask, attn_mask)
@@ -194,13 +187,11 @@ class TestAscendSFAMetadataBuilder(TestBase):
         assert builder.vllm_config == vllm_config
 
     @patch("vllm_ascend.attention.sfa_v1.get_current_vllm_config")
-    @patch("vllm_ascend.attention.sfa_v1.get_cos_and_sin_mla")
     @patch("vllm_ascend.attention.sfa_v1.enable_dsa_cp")
     @patch_distributed_groups(dcp_size=2, pcp_size=2, needs_mocks=False)
     def test_ascend_sfa_metadata_builder_build(
         self,
         mock_enable_dsa_cp,
-        mock_get_cos_and_sin_mla,
         mock_get_current_vllm_config,
     ):
         mock_enable_dsa_cp.return_value = False
@@ -238,11 +229,7 @@ class TestAscendSFAMetadataBuilder(TestBase):
         common_attn_metadata.attn_mask = None
         common_attn_metadata.attn_state = AscendAttentionState.ChunkedPrefill
         common_attn_metadata.block_table_tensor = torch.randn(100, 4)
-        common_attn_metadata.cos = None
-        common_attn_metadata.sin = None
         common_attn_metadata.num_input_tokens = 100
-
-        mock_get_cos_and_sin_mla.return_value = (torch.randn(100), torch.randn(100))
 
         metadata = builder.build(
             common_prefix_len=10,
@@ -254,12 +241,11 @@ class TestAscendSFAMetadataBuilder(TestBase):
         assert metadata.slot_mapping.shape == (100, 4, 1024)
 
     @patch("vllm_ascend.attention.sfa_v1.get_current_vllm_config")
-    @patch("vllm_ascend.attention.sfa_v1.get_cos_and_sin_mla")
     @patch("vllm_ascend.attention.sfa_v1.enable_dsa_cp", return_value=False)
     @patch("vllm.distributed.parallel_state.get_tp_group")
     @patch_distributed_groups(dcp_size=2, pcp_size=2, needs_mocks=False)
     def test_ascend_sfa_metadata_builder_build_for_graph_capture(
-        self, mock_get_tp_group, mock_enable_dsa_cp, mock_get_cos_and_sin_mla, mock_get_current_vllm_config
+        self, mock_get_tp_group, mock_enable_dsa_cp, mock_get_current_vllm_config
     ):
         cfg = MagicMock()
         cfg.model_config = MagicMock()
@@ -295,11 +281,7 @@ class TestAscendSFAMetadataBuilder(TestBase):
         common_attn_metadata.attn_mask = None
         common_attn_metadata.attn_state = AscendAttentionState.ChunkedPrefill
         common_attn_metadata.block_table_tensor = torch.randn(100, 4)
-        common_attn_metadata.cos = None
-        common_attn_metadata.sin = None
         common_attn_metadata.num_input_tokens = 100
-
-        mock_get_cos_and_sin_mla.return_value = (torch.randn(100), torch.randn(100))
 
         attn_metadata = builder.build_for_graph_capture(
             common_attn_metadata=common_attn_metadata,

--- a/tests/ut/attention/test_rope_sincos_static.py
+++ b/tests/ut/attention/test_rope_sincos_static.py
@@ -1,0 +1,112 @@
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _read(rel_path: str) -> str:
+    return (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+
+
+def _get_call_enclosing_functions(rel_path: str, call_name: str) -> list[str]:
+    tree = ast.parse(_read(rel_path))
+    parents: dict[ast.AST, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[child] = parent
+
+    functions: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Name) or func.id != call_name:
+            continue
+        parent = parents.get(node)
+        while parent is not None and not isinstance(parent, ast.FunctionDef):
+            parent = parents.get(parent)
+        functions.append(parent.name if isinstance(parent, ast.FunctionDef) else "<module>")
+    return functions
+
+
+def _dataclass_fields(rel_path: str, class_name_suffix: str = "Metadata") -> dict[str, set[str]]:
+    tree = ast.parse(_read(rel_path))
+    fields: dict[str, set[str]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or class_name_suffix not in node.name:
+            continue
+        class_fields: set[str] = set()
+        for item in node.body:
+            if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+                class_fields.add(item.target.id)
+        fields[node.name] = class_fields
+    return fields
+
+
+def test_runner_does_not_update_global_rope_slices():
+    for rel_path in [
+        "vllm_ascend/worker/model_runner_v1.py",
+        "vllm_ascend/worker/v2/model_runner.py",
+        "vllm_ascend/worker/v2/input_batch.py",
+    ]:
+        text = _read(rel_path)
+        assert "set_cos_and_sin" not in text
+        assert "update_cos_sin" not in text
+
+
+def test_310p_runner_does_not_prepare_external_mrope_slices():
+    for rel_path in [
+        "vllm_ascend/_310p/model_runner_310p.py",
+        "vllm_ascend/_310p/ops/rotary_embedding.py",
+    ]:
+        text = _read(rel_path)
+        assert "prepare_mrope_cos_sin_slices_from_runner" not in text
+        assert "set_mrope_apply_rotary_slices" not in text
+        assert "_mrope_cos_slice" not in text
+        assert "_mrope_sin_slice" not in text
+
+
+def test_mla_sfa_do_not_materialize_sincos_in_metadata_builders():
+    for rel_path in [
+        "vllm_ascend/attention/mla_v1.py",
+        "vllm_ascend/attention/sfa_v1.py",
+    ]:
+        text = _read(rel_path)
+        assert "get_cos_and_sin_mla" not in text
+        assert "attn_metadata.prefill.cos" not in text
+        assert "attn_metadata.prefill.sin" not in text
+        assert "attn_metadata.decode.cos" not in text
+        assert "attn_metadata.decode.sin" not in text
+        assert "attn_metadata.cos" not in text
+        assert "attn_metadata.sin" not in text
+
+
+def test_model_patches_do_not_index_cos_sin_cache_directly():
+    for rel_path in [
+        "vllm_ascend/patch/worker/patch_qwen3_5.py",
+        "vllm_ascend/patch/worker/patch_qwen3vl.py",
+    ]:
+        assert "cos_sin_cache[positions]" not in _read(rel_path)
+
+
+def test_dsa_rope_materialization_stays_in_impl_helpers():
+    allowed = {"_materialize_dsa_cos_sin"}
+    for rel_path in [
+        "vllm_ascend/attention/dsa_v1.py",
+        "vllm_ascend/attention/context_parallel/dsa_cp.py",
+    ]:
+        callers = set(_get_call_enclosing_functions(rel_path, "materialize_dsa_cos_sin"))
+        assert callers <= allowed
+
+
+def test_attention_metadata_does_not_expose_external_sincos_fields():
+    forbidden = {"sin", "cos", "compress_sin", "compress_cos", "local_sin", "local_cos"}
+    for rel_path in [
+        "vllm_ascend/attention/mla_v1.py",
+        "vllm_ascend/attention/sfa_v1.py",
+        "vllm_ascend/attention/dsa_v1.py",
+        "vllm_ascend/attention/context_parallel/dsa_cp.py",
+    ]:
+        for class_name, fields in _dataclass_fields(rel_path).items():
+            assert fields.isdisjoint(forbidden), f"{rel_path}:{class_name} exposes {fields & forbidden}"

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -39,13 +39,12 @@ from vllm.v1.kv_cache_interface import (
     MambaSpec,
     UniformTypeKVCacheSpecs,
 )
+from vllm.v1.sample.rejection_sampler import RejectionSampler
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.worker.cp_utils import get_total_cp_world_size
 
 from vllm_ascend._310p.block_table import MultiGroupBlockTable as MultiGroupBlockTable310
-from vllm_ascend._310p.kv_block_zeroer import AscendKVBlockZeroer310
 from vllm_ascend._310p.npu_input_batch import NPUInputBatch310 as NPUInputBatch
-from vllm_ascend._310p.ops.rotary_embedding import prepare_mrope_cos_sin_slices_from_runner
 from vllm_ascend._310p.sample.rejection_sampler import AscendRejectionSampler310
 from vllm_ascend._310p.sample.sampler import AscendSampler310
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
@@ -58,20 +57,8 @@ _ATTENTION_BLOCK_SIZE_LIMIT = 128 * 128
 
 
 class NPUModelRunner310(NPUModelRunner):
-    """
-    310P model runner with a distinct ACL graph capture/replay contract from 910B:
-
-    - Capture: ACLGraphWrapper records the full forward inside ``torch.npu.graph``.
-      310P attention calls NPU ops directly (paged / splitfuse), without mainline
-      ``full_graph_fia`` / ``full_graph_pa`` graph_task registration.
-    - Replay: refresh shared runner buffers (block_table, seq_lens, query_start_loc,
-      slot_mapping via CPU prepare + copy_to_gpu) so tensor addresses stay stable,
-      then ``aclgraph.replay()``.
-    """
-
     # Inherited from parent runner; annotated here to satisfy strict type checks.
     uniform_decode_query_len: int
-    _mtp_spec_dummy_capture: bool = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -93,28 +80,13 @@ class NPUModelRunner310(NPUModelRunner):
             cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
         )
         self._acl_format = ACL_FORMAT_FRACTAL_NZ
-        logger.info_once("Weight layout uses FRACTAL_NZ.")
         self.sampler = AscendSampler310()
         if getattr(self, "rejection_sampler", None) is not None:
-            self.rejection_sampler = AscendRejectionSampler310(self.sampler)
+            self.rejection_sampler = RejectionSampler(self.sampler)
         if self.speculative_config is not None and self.speculative_config.method == "ngram":
             # 310P ngram requires decode-only graph shapes to be built with q_len=1.
             # Keep dispatcher's internal query_len in sync to avoid key-init assert.
             self.cudagraph_dispatcher.uniform_decode_query_len = _NGRAM_GRAPH_UNIFORM_DECODE_QUERY_LEN
-            logger.info_once("Ngram speculative decoding uses uniform_decode_query_len=1 for graph capture.")
-
-    def _update_states(self, scheduler_output: SchedulerOutput):
-        deferred = super()._update_states(scheduler_output)
-        if scheduler_output.finished_req_ids:
-            # condense() rewrites block_table.np (move_row). Drain the previous
-            # step's ACL graph replay on the NPU stream before the condensed
-            # CPU layout is uploaded and read as attn_metadata.block_tables.
-            # Main-line Ascend relies on the end-of-_prepare_inputs Triton
-            # slot-mapping kernel (reads block_table.gpu) for stream ordering;
-            # 310P uses CPU NumPy for slot_mapping and needs this barrier on
-            # layout-change steps only.
-            torch.npu.current_stream().synchronize()
-        return deferred
 
     @contextmanager
     def temporary_modify_uniform_decode_query_len(self):
@@ -150,18 +122,6 @@ class NPUModelRunner310(NPUModelRunner):
         if self.attn_state in (AscendAttentionState.ChunkedPrefill, AscendAttentionState.PrefillCacheHit):
             force_eager = True
 
-        # MTP graph replay is only valid for uniform spec-decode batches (q_len = 1 + K).
-        if (
-            self.speculative_config is not None
-            and self.speculative_config.method == "mtp"
-            and (
-                self.attn_state != AscendAttentionState.SpecDecoding
-                or max_num_scheduled_tokens != self.uniform_decode_query_len
-                or num_tokens != max_num_scheduled_tokens * num_reqs
-            )
-        ):
-            force_eager = True
-
         if force_uniform_decode is None and self.attn_state == AscendAttentionState.DecodeOnly:
             decode_query_len = _NGRAM_GRAPH_UNIFORM_DECODE_QUERY_LEN
             if (
@@ -185,13 +145,6 @@ class NPUModelRunner310(NPUModelRunner):
             force_num_active_loras=force_num_active_loras,
             num_encoder_reqs=num_encoder_reqs,
         )
-
-    def _build_attention_metadata(self, *args: Any, **kwargs: Any):
-        # Parent dummy_run assigns ChunkedPrefill for non-MLA MTP (910B FIA graph).
-        # 310P must capture SpecDecoding + splitfuse for MTP uniform decode graphs.
-        if self._mtp_spec_dummy_capture:
-            self.attn_state = AscendAttentionState.SpecDecoding
-        return super()._build_attention_metadata(*args, **kwargs)
 
     def _pad_query_start_loc_for_fia(
         self,
@@ -225,18 +178,6 @@ class NPUModelRunner310(NPUModelRunner):
 
         self.query_start_loc.copy_to_gpu()
         return num_reqs_padded
-
-    def _build_attn_state(self, num_reqs, num_scheduled_tokens, num_valid_tokens):
-        attn_state = super()._build_attn_state(num_reqs, num_scheduled_tokens, num_valid_tokens)
-        if (
-            self.speculative_config is not None
-            and self.speculative_config.method == "mtp"
-            and not np.all(self.input_batch.num_computed_tokens_cpu[:num_reqs] == 0)
-            and np.all(num_scheduled_tokens == self.uniform_decode_query_len)
-        ):
-            attn_state = AscendAttentionState.SpecDecoding
-            self.attn_state = attn_state
-        return attn_state
 
     def _prepare_inputs(  # type: ignore[override]
         self,
@@ -596,76 +537,32 @@ class NPUModelRunner310(NPUModelRunner):
         profile_seq_lens: int | None = None,
     ):
         temporary_context = self.temporary_modify_uniform_decode_query_len() if uniform_decode else nullcontext()
-        mtp_spec_dummy_capture = (
-            uniform_decode
-            and not is_profile
-            and self.speculative_config is not None
-            and self.speculative_config.method == "mtp"
-            and not self.vllm_config.model_config.use_mla
-        )
         with temporary_context:
-            self._mtp_spec_dummy_capture = mtp_spec_dummy_capture
-            try:
-                return super()._dummy_run(
-                    num_tokens=num_tokens,
-                    with_prefill=with_prefill,
-                    cudagraph_runtime_mode=cudagraph_runtime_mode,
-                    force_attention=force_attention,
-                    uniform_decode=uniform_decode,
-                    is_profile=is_profile,
-                    create_mixed_batch=create_mixed_batch,
-                    allow_microbatching=allow_microbatching,
-                    skip_eplb=skip_eplb,
-                    remove_lora=remove_lora,
-                    is_graph_capturing=is_graph_capturing,
-                    num_active_loras=num_active_loras,
-                    profile_seq_lens=profile_seq_lens,
-                )
-            finally:
-                self._mtp_spec_dummy_capture = False
-
-    def _model_forward(
-        self,
-        num_tokens_padded: int,
-        input_ids: torch.Tensor | None = None,
-        positions: torch.Tensor | None = None,
-        intermediate_tensors=None,
-        inputs_embeds: torch.Tensor | None = None,
-        **model_kwargs,
-    ):
-        if self.uses_mrope:
-            assert positions is not None
-            prepare_mrope_cos_sin_slices_from_runner(self, positions)
-        return super()._model_forward(
-            num_tokens_padded,
-            input_ids=input_ids,
-            positions=positions,
-            intermediate_tensors=intermediate_tensors,
-            inputs_embeds=inputs_embeds,
-            **model_kwargs,
-        )
+            return super()._dummy_run(
+                num_tokens=num_tokens,
+                with_prefill=with_prefill,
+                cudagraph_runtime_mode=cudagraph_runtime_mode,
+                force_attention=force_attention,
+                uniform_decode=uniform_decode,
+                is_profile=is_profile,
+                create_mixed_batch=create_mixed_batch,
+                allow_microbatching=allow_microbatching,
+                skip_eplb=skip_eplb,
+                remove_lora=remove_lora,
+                is_graph_capturing=is_graph_capturing,
+                num_active_loras=num_active_loras,
+                profile_seq_lens=profile_seq_lens,
+            )
 
     def _check_and_update_cudagraph_mode(
         self,
         attention_backends,
         kv_cache_groups,
-        is_profiling=False,
     ) -> None:
         # 910B does not need this branch because runner/dispatcher query_len are
         # naturally consistent there. 310P ngram needs temporary alignment.
         with self.temporary_modify_uniform_decode_query_len():
             super()._check_and_update_cudagraph_mode(attention_backends, kv_cache_groups)
-
-    def _init_kv_zero_meta(self) -> None:
-        """310P uses torch zeroing because Triton is not available."""
-        self._kv_block_zeroer = AscendKVBlockZeroer310(self.device, self.pin_memory)
-        self._kv_block_zeroer.init_meta(
-            attn_groups_iter=self._kv_cache_spec_attn_group_iterator(),
-            kernel_block_sizes=self.kernel_block_sizes,
-            cache_dtype=self.cache_config.cache_dtype,
-            runner_only_attn_layers=self.runner_only_attn_layers,
-            static_forward_context=(self.compilation_config.static_forward_context),
-        )
 
     def initialize_kv_cache_tensors(self, kv_cache_config: KVCacheConfig) -> dict[str, torch.Tensor]:
         """
@@ -680,13 +577,10 @@ class NPUModelRunner310(NPUModelRunner):
         """
         # 310P limitation: KV transfer is not supported
         if self.vllm_config.kv_transfer_config is not None:
-            logger.error("KV cache transfer is not supported.")
             raise ValueError("KV cache transfer is not supported for 310P.")
         if self.use_sparse:
-            logger.error("Deepseek Sparse Attention is not supported.")
             raise ValueError("Deepseek Sparse Attention is not supported for 310P.")
         if self.model_config.use_mla:
-            logger.error("MLAAttention is not supported.")
             raise ValueError("MLAAttention is not supported for 310P.")
         # Initialize the memory buffer for KV cache
         kv_caches = self._allocate_kv_cache_tensors(kv_cache_config)
@@ -832,7 +726,7 @@ class NPUModelRunner310(NPUModelRunner):
                 prev_common_req_indices.append(prev_index)
                 draft_len = len(scheduled_spec_tokens.get(req_id, ()))
                 total_num_spec_tokens += draft_len
-                flattened_index = int(cu_num_tokens[cur_index]) - 1
+                flattened_index = cu_num_tokens[cur_index].item() - 1
                 sample_flattened_indices.append(flattened_index - draft_len)
                 spec_flattened_indices.extend(range(flattened_index - draft_len + 1, flattened_index + 1))
                 start = prev_index * self.num_spec_tokens

--- a/vllm_ascend/_310p/ops/rotary_embedding.py
+++ b/vllm_ascend/_310p/ops/rotary_embedding.py
@@ -17,19 +17,13 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import torch
 import torch_npu
 from vllm.model_executor.layers.rotary_embedding import MRotaryEmbedding
 from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
 from vllm.model_executor.layers.rotary_embedding.mrope import apply_interleaved_rope
 
-from vllm_ascend.ops.rotary_embedding import AscendRotaryEmbedding, get_cos_and_sin_slice
-
-# Filled once per model forward in NPUModelRunner310._model_forward; read by every MRoPE layer.
-_mrope_cos_slice: torch.Tensor | None = None
-_mrope_sin_slice: torch.Tensor | None = None
+from vllm_ascend.ops.rotary_embedding import AscendRotaryEmbedding, select_cos_sin_cache, select_cos_sin_from_cache
 
 
 def _apply_rotary_mrope_torch(
@@ -65,29 +59,23 @@ def merge_mrope_cos_sin_for_apply(
     )
 
 
-def set_mrope_apply_rotary_slices(
-    cos_sin_cache: torch.Tensor,
+def _select_mrope_apply_rotary_slices(
+    rotary_emb: MRotaryEmbedding,
     positions: torch.Tensor,
-    *,
-    mrope_section: list[int] | None = None,
-    mrope_interleaved: bool = False,
-    capacity_tokens: int = 0,
-) -> None:
-    """Build cos/sin views for `npu_apply_rotary_pos_emb` from positions; must run once per forward before layers."""
-    global _mrope_cos_slice
-    global _mrope_sin_slice
-
+    ref_tensor: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Resolve MRoPE cos/sin for `npu_apply_rotary_pos_emb` inside the layer."""
     assert positions.ndim in (1, 2), "M-RoPE positions must be [num_tokens] or [3, num_tokens]."
-    cos_sin = cos_sin_cache[positions]
+    cos_sin = select_cos_sin_cache(rotary_emb, positions, ref_tensor)
     cos, sin = cos_sin.chunk(2, dim=-1)
     if positions.ndim == 2:
         assert positions.shape[0] == 3, "MRoPE expects positions [3, num_tokens] (T/H/W)."
-        assert mrope_section is not None
+        assert rotary_emb.mrope_section is not None
         cos, sin = merge_mrope_cos_sin_for_apply(
             cos,
             sin,
-            list(mrope_section),
-            mrope_interleaved,
+            list(rotary_emb.mrope_section),
+            rotary_emb.mrope_interleaved,
         )
     # `npu_apply_rotary_pos_emb` follows ApplyRotaryPosEmbV2 semantics:
     # q_embed = q * cos + rotate(q) * sin, where cos/sin have full rotary dim.
@@ -99,23 +87,33 @@ def set_mrope_apply_rotary_slices(
     sin_view = sin.contiguous().view(1, num_tokens, 1, -1)
 
     # Keep stable storage across forwards for graph replay.
-    if _mrope_cos_slice is None or _mrope_sin_slice is None:
-        capacity = capacity_tokens if capacity_tokens is not None else num_tokens
-        if capacity < num_tokens:
-            capacity = num_tokens
-        _mrope_cos_slice = torch.empty(
-            (1, capacity, 1, cos_view.shape[-1]),
+    cos_buffer = getattr(rotary_emb, "_mrope_apply_cos_buffer", None)
+    sin_buffer = getattr(rotary_emb, "_mrope_apply_sin_buffer", None)
+    needs_buffer = (
+        cos_buffer is None
+        or sin_buffer is None
+        or cos_buffer.shape[1] < num_tokens
+        or cos_buffer.shape[-1] != cos_view.shape[-1]
+        or cos_buffer.dtype != cos_view.dtype
+        or cos_buffer.device != cos_view.device
+    )
+    if needs_buffer:
+        cos_buffer = torch.empty(
+            (1, num_tokens, 1, cos_view.shape[-1]),
             dtype=cos_view.dtype,
             device=cos_view.device,
         )
-        _mrope_sin_slice = torch.empty(
-            (1, capacity, 1, sin_view.shape[-1]),
+        sin_buffer = torch.empty(
+            (1, num_tokens, 1, sin_view.shape[-1]),
             dtype=sin_view.dtype,
             device=sin_view.device,
         )
+        rotary_emb._mrope_apply_cos_buffer = cos_buffer
+        rotary_emb._mrope_apply_sin_buffer = sin_buffer
 
-    _mrope_cos_slice[:, :num_tokens].copy_(cos_view)
-    _mrope_sin_slice[:, :num_tokens].copy_(sin_view)
+    cos_buffer[:, :num_tokens].copy_(cos_view)
+    sin_buffer[:, :num_tokens].copy_(sin_view)
+    return cos_buffer[:, :num_tokens], sin_buffer[:, :num_tokens]
 
 
 def _rope_forward_oot(
@@ -131,7 +129,7 @@ def _rope_forward_oot(
         self.cos_sin_cache = self.cos_sin_cache.to(query.device)
     if self.cos_sin_cache.dtype != query.dtype:
         self.cos_sin_cache = self.cos_sin_cache.to(query.dtype)
-    cos, sin = get_cos_and_sin_slice()
+    cos, sin = select_cos_sin_from_cache(self, positions, query, layout="1T1D")
     if offsets is not None:
         raise NotImplementedError("Batched rotary embedding is currently not supported on NPU.")
     rotary_mode = "half" if is_neox_style else "interleave"
@@ -193,11 +191,7 @@ class AscendMRotaryEmbedding310(MRotaryEmbedding):
         # Here `rotary_mode` matches vLLM ApplyRotaryEmb: half = neox chunk, interleave = GPT-J pairs.
         rotary_mode = "half" if self.is_neox_style else "interleave"
         num_tokens = query.shape[0]
-        if _mrope_cos_slice is None or _mrope_sin_slice is None:
-            raise RuntimeError(
-                "MRoPE cos/sin slices are not initialized. Call set_mrope_apply_rotary_slices before forward."
-            )
-        cos, sin = _mrope_cos_slice[:, :num_tokens], _mrope_sin_slice[:, :num_tokens]
+        cos, sin = _select_mrope_apply_rotary_slices(self, positions, query)
 
         is_partial_rope = self.rotary_dim < self.head_size
         if is_partial_rope:
@@ -229,22 +223,6 @@ class AscendMRotaryEmbedding310(MRotaryEmbedding):
             key = k_rot.view(key_shape)
 
         return query, key
-
-
-def prepare_mrope_cos_sin_slices_from_runner(runner: Any, positions: torch.Tensor) -> None:
-    """Resolve MRoPE embedding from the runner and populate `_mrope_cos_slice` / `_mrope_sin_slice`."""
-    emb = getattr(runner, "_mrope_embedding", None)
-    if emb is None:
-        emb = next(module for module in runner.model.modules() if isinstance(module, AscendMRotaryEmbedding310))
-        runner._mrope_embedding = emb
-    assert isinstance(emb, AscendMRotaryEmbedding310)
-    set_mrope_apply_rotary_slices(
-        emb.cos_sin_cache,
-        positions,
-        mrope_section=emb.mrope_section,
-        mrope_interleaved=emb.mrope_interleaved,
-        capacity_tokens=runner.max_num_tokens,
-    )
 
 
 class AscendRotaryEmbedding310(AscendRotaryEmbedding):

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -17,7 +17,7 @@ from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
-from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
+from vllm_ascend.ops.rope_dsv4 import materialize_dsa_cos_sin
 from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.utils import (
     AscendDeviceType,
@@ -72,8 +72,7 @@ class DSACPMetadata:
     local_end: int
     tokens_per_rank: int
     num_tokens_pad: int
-    local_sin: torch.Tensor = None
-    local_cos: torch.Tensor = None
+    local_positions: torch.Tensor = None
 
 
 @dataclass
@@ -91,10 +90,9 @@ class AscendDSAReqMetadata:
     slot_mapping: torch.Tensor
     query_start_loc: torch.Tensor
     cp_metadata: DSACPMetadata
-    sin: torch.Tensor = None
-    cos: torch.Tensor = None
-    compress_sin: torch.Tensor = None
-    compress_cos: torch.Tensor = None
+    compress_positions: torch.Tensor | dict[str, torch.Tensor] = None
+    rope_use_cache: bool = False
+    compress_rope_use_cache: bool = False
     start_pos: torch.Tensor = None
     sas_metadata: torch.Tensor = None
     qli_metadata: torch.Tensor = None
@@ -113,12 +111,12 @@ class AscendDSAMetadata:
     query_start_loc: torch.Tensor
     seq_lens: torch.Tensor
     block_tables: torch.Tensor
-    sin: torch.Tensor
-    cos: torch.Tensor
+    input_positions: torch.Tensor
 
     num_decodes: int
     num_decode_tokens: int
     num_prefills: int
+    rope_use_cache: bool = False
 
     # For logging.
     num_input_tokens: int = 0  # Number of tokens including padding.
@@ -287,9 +285,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             input_positions_cpu = common_attn_metadata.positions_cpu[:num_input_tokens].long()
             self.common_ratio_to_sas_metadata["input_positions"] = input_positions
             self.common_ratio_to_sas_metadata["input_positions_cpu"] = input_positions_cpu
-            cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=not has_prefill)
-            self.common_ratio_to_sas_metadata["cos"] = cos
-            self.common_ratio_to_sas_metadata["sin"] = sin
+            self.common_ratio_to_sas_metadata["rope_use_cache"] = not has_prefill
             self.seq_lens = common_attn_metadata.seq_lens[:num_reqs]
             self.common_ratio_to_sas_metadata["seq_lens"] = self.seq_lens
             # Prefer _seq_lens_cpu (always available, updated during draft
@@ -311,7 +307,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             )
             input_positions = self.common_ratio_to_sas_metadata["input_positions"]
             input_positions_cpu = self.common_ratio_to_sas_metadata["input_positions_cpu"]
-            cos, sin = self.common_ratio_to_sas_metadata["cos"], self.common_ratio_to_sas_metadata["sin"]
             self.seq_lens = self.common_ratio_to_sas_metadata["seq_lens"]
             self.seq_lens_cpu = self.common_ratio_to_sas_metadata["seq_lens_cpu"]
 
@@ -339,8 +334,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             query_start_loc=query_start_loc,
             block_tables=None,
             seq_lens=self.seq_lens,
-            cos=cos,
-            sin=sin,
+            input_positions=input_positions,
+            rope_use_cache=self.common_ratio_to_sas_metadata["rope_use_cache"],
             hadamard=AscendDSACPMetadataBuilder.hadamard,
         )
 
@@ -366,9 +361,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.block_size = kwargs.get("block_size", 128)
 
         input_positions = common_attn_metadata.positions[:num_input_tokens].long()
-        # Draft steps update positions independently. Reusing the global RoPE
-        # cache can let later draft steps overwrite step-0 metadata.
-        cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=False)
 
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
 
@@ -398,8 +390,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             query_start_loc=common_attn_metadata.query_start_loc,
             block_tables=None,
             seq_lens=self.seq_lens,
-            cos=cos,
-            sin=sin,
+            input_positions=input_positions,
+            rope_use_cache=False,
             hadamard=None,
         )
 
@@ -417,7 +409,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         seq_lens_q = query_start_loc[1:] - query_start_loc[:-1]
         has_prefill = _has_prefill(common_attn_metadata.attn_state)
 
-        cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=False)
         (
             local_start,
             local_end_with_pad,
@@ -425,8 +416,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             num_tokens_pad,
             local_query_start_loc,
             local_seq_lens,
-            local_cos,
-            local_sin,
+            local_positions,
         ) = self._build_local_token_metadata(
             num_reqs=num_reqs,
             num_input_tokens=num_input_tokens,
@@ -488,8 +478,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             local_end=local_end_with_pad,
             tokens_per_rank=tokens_per_rank,
             num_tokens_pad=num_tokens_pad,
-            local_sin=local_sin,
-            local_cos=local_cos,
+            local_positions=local_positions,
         )
 
         return AscendDSAReqMetadata(
@@ -499,10 +488,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             seq_lens=self.seq_lens[:num_reqs],
             query_start_loc=query_start_loc,
             cp_metadata=cp_metadata,
-            sin=sin,
-            cos=cos,
-            compress_sin=None,
-            compress_cos=None,
+            rope_use_cache=False,
             start_pos=start_pos,
             sas_metadata=sas_metadata,
             qli_metadata=None,
@@ -526,9 +512,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
         seq_lens_q = query_start_loc[1:] - query_start_loc[:-1]
 
-        # cos/sin for all tokens
-        cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=not has_prefill)
-
         (
             local_start,
             local_end_with_pad,
@@ -536,8 +519,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             num_tokens_pad,
             local_query_start_loc,
             local_seq_lens,
-            local_cos,
-            local_sin,
+            local_positions,
         ) = self._build_local_token_metadata(
             num_reqs=num_reqs,
             num_input_tokens=num_input_tokens,
@@ -550,7 +532,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         )
         local_seq_lens_q = local_query_start_loc[1 : num_reqs + 1] - local_query_start_loc[:num_reqs]
 
-        _, _, _, _, local_query_start_loc_cpu, local_seq_lens_cpu, _, _ = self._build_local_token_metadata(
+        _, _, _, _, local_query_start_loc_cpu, local_seq_lens_cpu, _ = self._build_local_token_metadata(
             num_reqs=num_reqs,
             num_input_tokens=num_input_tokens,
             input_positions=None,
@@ -574,7 +556,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             self.block_table[num_reqs_actual:num_reqs, ...].fill_(0)
 
         # --- Compressed positions ---
-        compress_cos, compress_sin = None, None
+        compress_positions = None
         cu_cmp_seqlens = self._get_cmp_seqlens_for_metadata(has_prefill)
 
         if self.compressor_ratio > 1:
@@ -582,9 +564,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             compressed_input_positions = self._get_padded_compressed_position(
                 input_positions_cpu, self.compressor_ratio, num_reqs, num_input_tokens
             )
-            compress_cos, compress_sin = get_cos_and_sin_dsa(
-                {layer_name: compressed_input_positions}, use_cache=not has_prefill
-            )
+            compress_positions = {layer_name: compressed_input_positions}
 
         slot_mapping_size = self._get_slot_mapping_size(input_positions_cpu, self.compressor_ratio)
         slot_mapping = self.slot_mapping[:slot_mapping_size]
@@ -621,8 +601,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             local_end=local_end_with_pad,
             tokens_per_rank=tokens_per_rank,
             num_tokens_pad=num_tokens_pad,
-            local_sin=local_sin,
-            local_cos=local_cos,
+            local_positions=local_positions,
         )
 
         return AscendDSAReqMetadata(
@@ -632,10 +611,9 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             seq_lens=self.seq_lens[:num_reqs],
             query_start_loc=query_start_loc,
             cp_metadata=cp_metadata,
-            sin=sin,
-            cos=cos,
-            compress_sin=compress_sin,
-            compress_cos=compress_cos,
+            compress_positions=compress_positions,
+            rope_use_cache=not has_prefill,
+            compress_rope_use_cache=not has_prefill,
             start_pos=self.start_pos_prefill[:num_reqs],
             sas_metadata=sas_metadata,
             qli_metadata=qli_metadata,
@@ -706,18 +684,15 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         else:
             local_seq_lens = (local_query_lens > 0) * (seq_lens - offset)
 
-        # RoPE tables are generated on the padded global positions first, then
-        # sliced to this rank so local tokens keep their original positions.
+        # Positions are padded globally, then sliced to this rank so local
+        # tokens keep their original RoPE positions.
         if input_positions is not None:
             pad_tokens = num_tokens_pad - input_positions.shape[0]
             if pad_tokens > 0:
                 input_positions = F.pad(input_positions, (0, pad_tokens), value=0)
-            local_cos, local_sin = get_cos_and_sin_dsa(input_positions, use_cache=use_cache)
-            local_cos = local_cos[local_start:local_end]
-            local_sin = local_sin[local_start:local_end]
+            local_positions = input_positions[local_start:local_end]
         else:
-            local_cos = None
-            local_sin = None
+            local_positions = None
         return (
             local_start,
             local_end,
@@ -725,8 +700,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             num_tokens_pad,
             local_query_start_loc[: num_reqs + 1],
             local_seq_lens[:num_reqs],
-            local_cos,
-            local_sin,
+            local_positions,
         )
 
     # --- helper: padded compressed positions ---
@@ -967,6 +941,24 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 f"got {self.attn_sink.numel()} heads, expected {self.num_heads}."
             )
 
+    @staticmethod
+    def _materialize_dsa_cos_sin(
+        positions: torch.Tensor | dict[str, torch.Tensor],
+        *,
+        use_cache: bool = False,
+    ):
+        return materialize_dsa_cos_sin(positions, use_cache=use_cache)
+
+    def _materialize_layer_cos_sin(
+        self,
+        layer_name: str,
+        positions: torch.Tensor | dict[str, torch.Tensor],
+        *,
+        use_cache: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        cos_proxy, sin_proxy = self._materialize_dsa_cos_sin(positions, use_cache=use_cache)
+        return cos_proxy[layer_name], sin_proxy[layer_name]
+
     def forward(  # type: ignore[override]
         self,
         layer_name,
@@ -1043,10 +1035,16 @@ class AscendDSACPImpl(DSAAttentionImpl):
         assert swa_metadata.req_metadata is not None
         req_metadata = common_attn_metadata.req_metadata
         cp_metadata = req_metadata.cp_metadata
-        cos = req_metadata.cos[layer_name]
-        sin = req_metadata.sin[layer_name]
-        local_cos = cp_metadata.local_cos[layer_name]
-        local_sin = cp_metadata.local_sin[layer_name]
+        cos, sin = self._materialize_layer_cos_sin(
+            layer_name,
+            req_metadata.input_positions,
+            use_cache=req_metadata.rope_use_cache,
+        )
+        local_rope_cos, local_rope_sin = self._materialize_layer_cos_sin(
+            layer_name,
+            cp_metadata.local_positions,
+            use_cache=False,
+        )
         actual_seq_lengths_query = req_metadata.query_start_loc
         local_seq_lengths_query = cp_metadata.local_query_start_loc
         local_seq_lengths_key = cp_metadata.local_seq_lens
@@ -1104,8 +1102,8 @@ class AscendDSACPImpl(DSAAttentionImpl):
         q = triton_q_rms(q, self.eps)
         torch.ops._C_ascend.inplace_partial_rotary_mul(
             q.unsqueeze(1),
-            local_cos,
-            local_sin,
+            local_rope_cos,
+            local_rope_sin,
             rotary_mode="interleave",
             partial_slice=[self.nope_head_dim, self.head_dim],
         )
@@ -1130,15 +1128,18 @@ class AscendDSACPImpl(DSAAttentionImpl):
         if self.compress_ratio > 1:
             assert compressor_attn_metadata.req_metadata is not None
             assert compressor_kv_state_metadata.req_metadata is not None
-            compress_cos = req_metadata.compress_cos[layer_name]
-            compress_sin = req_metadata.compress_sin[layer_name]
+            compressed_cos, compressed_sin = self._materialize_layer_cos_sin(
+                layer_name,
+                req_metadata.compress_positions,
+                use_cache=req_metadata.compress_rope_use_cache,
+            )
             if self.compress_ratio == 4:
                 self._update_indexer_cache(
                     x=hidden_states,
                     kv_cache=kv_cache,
                     attn_metadata=attn_metadata,
-                    compressed_cos=compress_cos,
-                    compressed_sin=compress_sin,
+                    compressed_cos=compressed_cos,
+                    compressed_sin=compressed_sin,
                     actual_seq_lengths_query=actual_seq_lengths_query,
                 )
                 compress_topk_idxs = self._indexer_select_topk(
@@ -1146,8 +1147,8 @@ class AscendDSACPImpl(DSAAttentionImpl):
                     qr=qr_local,
                     kv_cache=kv_cache,
                     attn_metadata=attn_metadata,
-                    cos=local_cos,
-                    sin=local_sin,
+                    cos=local_rope_cos,
+                    sin=local_rope_sin,
                     actual_seq_lengths_query=local_seq_lengths_query,
                     actual_seq_lengths_key=local_seq_lengths_key,
                     qr_pertoken_scale=qr_pertoken_scale_local,
@@ -1161,8 +1162,8 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 state_cache.squeeze(-2),
                 self.compressor_ape,
                 self.compressor_norm.weight,
-                compress_sin.view(-1, compress_sin.shape[-1]),
-                compress_cos.view(-1, compress_cos.shape[-1]),
+                compressed_sin.view(-1, compressed_sin.shape[-1]),
+                compressed_cos.view(-1, compressed_cos.shape[-1]),
                 state_block_table=compressor_kv_state_metadata.req_metadata.block_table,
                 cu_seqlens=actual_seq_lengths_query,
                 seqused=None,
@@ -1243,10 +1244,15 @@ class AscendDSACPImpl(DSAAttentionImpl):
         req_metadata = attn_metadata.req_metadata
         cp_metadata = req_metadata.cp_metadata
         num_tokens = local_attn_output.shape[0]
+        local_rope_cos, local_rope_sin = self._materialize_layer_cos_sin(
+            layer_name,
+            cp_metadata.local_positions,
+            use_cache=False,
+        )
         torch.ops._C_ascend.inplace_partial_rotary_mul(
             local_attn_output.unsqueeze(1),
-            cp_metadata.local_cos[layer_name],
-            -cp_metadata.local_sin[layer_name],
+            local_rope_cos,
+            -local_rope_sin,
             rotary_mode="interleave",
             partial_slice=[self.nope_head_dim, self.head_dim],
         )

--- a/vllm_ascend/attention/context_parallel/mla_cp.py
+++ b/vllm_ascend/attention/context_parallel/mla_cp.py
@@ -426,8 +426,8 @@ class AscendMlaCPImpl(AscendMLAImpl):
         prefill_q = self.q_proj(prefill_q_c)[0].view(-1, self.num_heads, self.qk_head_dim)
         prefill_q_pe = prefill_q[..., self.qk_nope_head_dim :]
         prefill_q_nope = prefill_q[..., : self.qk_nope_head_dim]
-        cos = attn_metadata.prefill.cos[: num_actual_tokens - num_decode_tokens]
-        sin = attn_metadata.prefill.sin[: num_actual_tokens - num_decode_tokens]
+        prefill_positions = attn_metadata.prefill.input_positions[: num_actual_tokens - num_decode_tokens]
+        cos, sin = self._select_mla_cos_sin(prefill_positions, prefill_q_pe)
         prefill_q_pe = self.rope_single(prefill_q_pe, cos, sin)
         prefill_kv_no_split = kv_no_split[:num_actual_tokens]
         kv_c, k_pe = prefill_kv_no_split.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
@@ -472,10 +472,9 @@ class AscendMlaCPImpl(AscendMLAImpl):
     def mla_preprocess_decode(self, q_c, kv_no_split, kv_cache, attn_metadata):
         num_decode_tokens = attn_metadata.num_decode_tokens
         decode_q_c = q_c[:num_decode_tokens]
-        cos = attn_metadata.decode.cos
-        sin = attn_metadata.decode.sin
         decode_ql_nope, decode_q_pe = self._q_proj_and_k_up_proj(decode_q_c)
         decode_ql_nope, decode_q_pe = self.reorg_decode_q(decode_ql_nope, decode_q_pe)
+        cos, sin = self._select_mla_cos_sin(attn_metadata.decode.input_positions[:num_decode_tokens], decode_q_pe)
         decode_q_pe = self.rope_single(decode_q_pe, cos, sin)
         decode_slots = attn_metadata.slot_mapping[:num_decode_tokens]
         decode_kv_no_split = kv_no_split[:num_decode_tokens]

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -18,10 +18,9 @@ from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
-from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.ops.cv_linear import CVLinearWrapper
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
-from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
+from vllm_ascend.ops.rope_dsv4 import materialize_dsa_cos_sin
 from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.utils import (
     AscendDeviceType,
@@ -106,15 +105,6 @@ def hadamard_scale(out: torch.Tensor, x_shape: tuple[int, ...], dim: int, scale:
     """
     out = out * scale
     return out[..., :dim].reshape(*x_shape)
-
-
-def _is_w8a8_dynamic(linear) -> bool:
-    """True iff ``linear`` is wired up with ``AscendW8A8DynamicLinearMethod``."""
-    qm = getattr(linear, "quant_method", None)
-    if qm is None or isinstance(qm, AscendUnquantizedLinearMethod):
-        return False
-    inner = getattr(qm, "quant_method", None)
-    return isinstance(inner, AscendW8A8DynamicLinearMethod)
 
 
 def pad_to_blocks(x: torch.Tensor, length_list: torch.Tensor, block_size: int = 128):
@@ -217,7 +207,7 @@ class AscendDSABackend(AttentionBackend):
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int]:
-        return [2, 4, 8, 16, 32, 64, 128]
+        return [8, 32, 128]
 
 
 @dataclass
@@ -235,10 +225,9 @@ class AscendDSAPrefillMetadata:
     max_query_len: int
     max_seq_lens: int
 
-    sin: torch.Tensor = None
-    cos: torch.Tensor = None
-    compress_sin: torch.Tensor = None
-    compress_cos: torch.Tensor = None
+    compress_positions: torch.Tensor | dict[str, torch.Tensor] = None
+    rope_use_cache: bool = False
+    compress_rope_use_cache: bool = False
     start_pos: torch.Tensor | None = None
     sas_metadata: torch.Tensor = None
     qli_metadata: torch.Tensor = None
@@ -262,10 +251,9 @@ class AscendDSADecodeMetadata:
     query_start_loc: torch.tensor = None
     query_start_loc_cpu: torch.tensor = None
     attn_mask: torch.Tensor | None = None
-    sin: torch.Tensor = None
-    cos: torch.Tensor = None
-    compress_sin: torch.Tensor = None
-    compress_cos: torch.Tensor = None
+    compress_positions: torch.Tensor | dict[str, torch.Tensor] = None
+    rope_use_cache: bool = False
+    compress_rope_use_cache: bool = False
     cp_seq_len: torch.Tensor = None
     batch_seq_mask: torch.Tensor = None
     start_pos: torch.Tensor = None
@@ -285,12 +273,12 @@ class AscendDSAMetadata:
     query_start_loc: torch.Tensor
     seq_lens: torch.Tensor
     block_tables: torch.Tensor
-    sin: torch.Tensor
-    cos: torch.Tensor
+    input_positions: torch.Tensor
 
     num_decodes: int
     num_decode_tokens: int
     num_prefills: int
+    rope_use_cache: bool = False
 
     # For logging.
     num_input_tokens: int = 0  # Number of tokens including padding.
@@ -377,14 +365,12 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1
         self.spec_slot_mapping = None
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
-            self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens,)  # type: ignore
-        else:
-            self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens, 2)  # type: ignore
         if self.speculative_config:
             spec_token_num = self.speculative_config.num_speculative_tokens
             self.spec_slot_mapping = [
-                torch.zeros(self.slot_mapping_shape, dtype=torch.int32, device=self.device)
+                torch.zeros(
+                    (vllm_config.scheduler_config.max_num_batched_tokens, 2), dtype=torch.int32, device=self.device
+                )
                 for _ in range(spec_token_num)
             ]
             self.decode_threshold += spec_token_num
@@ -435,10 +421,11 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.cu_seqlens_ori_kv = torch.tensor([], device=self.device)
         self.cu_seqlens_cmp_kv = torch.tensor([], device=self.device)
         self.seqused_q = torch.tensor([], device=self.device)
-        self._zero_i32 = torch.tensor([0], device=self.device, dtype=torch.int32)
-        # Note(qcs): we use two dimension slot_mapping for kvcache with shape
-        # [block_nums, block_size, head_num, head_dim]
-        self.slot_mapping = torch.zeros(self.slot_mapping_shape, dtype=torch.int32, device=self.device)
+        # Note(qcs): we use two dimension slot_mapping for kvcache with
+        # shape [block_nums, block_size, head_num, head_dim]
+        self.slot_mapping = torch.zeros(
+            (vllm_config.scheduler_config.max_num_batched_tokens, 2), dtype=torch.int32, device=self.device
+        )
 
     @classmethod
     def get_cudagraph_support(
@@ -536,12 +523,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             num_input_tokens = common_attn_metadata.num_input_tokens
             input_positions = common_attn_metadata.positions[:num_input_tokens].long()
             self.common_ratio_to_sas_metadata["input_positions"] = input_positions
-            if self.num_prefills:
-                cos, sin = get_cos_and_sin_dsa(input_positions)
-            else:
-                cos, sin = get_cos_and_sin_dsa(input_positions, True)
-            self.common_ratio_to_sas_metadata["cos"] = cos
-            self.common_ratio_to_sas_metadata["sin"] = sin
+            self.common_ratio_to_sas_metadata["rope_use_cache"] = not self.num_prefills
             self.seq_lens = common_attn_metadata.seq_lens[:num_reqs]
             self.common_ratio_to_sas_metadata["seq_lens"] = self.seq_lens
 
@@ -559,13 +541,14 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             self.set_num_actual_tokens(common_attn_metadata)
             num_input_tokens = common_attn_metadata.num_input_tokens
             input_positions = self.common_ratio_to_sas_metadata["input_positions"]
-            cos, sin = self.common_ratio_to_sas_metadata["cos"], self.common_ratio_to_sas_metadata["sin"]
             self.seq_lens = self.common_ratio_to_sas_metadata["seq_lens"]
             self.query_lens = self.common_ratio_to_sas_metadata["query_lens"]
 
         # NOTE: Currently, MTP-fullgraph is incompatibility pcp
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
-        self.slot_mapping[:num_input_tokens] = DeviceOperator.format_dsa_slot_mapping(slot_mapping, self.block_size)
+        self.slot_mapping[:num_input_tokens] = torch.stack(
+            [slot_mapping // self.block_size, slot_mapping % self.block_size], axis=-1
+        )
 
         self.graph_pad_size = common_attn_metadata.graph_pad_size
         block_table_size = self.get_block_table_size(common_attn_metadata, BUILD_METADATA_STEP_PREFILL)
@@ -596,8 +579,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             query_start_loc=query_start_loc,
             block_tables=None,
             seq_lens=self.seq_lens,
-            cos=cos,
-            sin=sin,
+            input_positions=input_positions,
+            rope_use_cache=self.common_ratio_to_sas_metadata["rope_use_cache"],
             hadamard=AscendDSAMetadataBuilder.hadamard,
         )
 
@@ -636,10 +619,6 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             self.prefill_ratio_to_sas_metadata["prefill_input_positions"] = prefill_input_positions
             self.prefill_ratio_to_sas_metadata["prefill_query_start_loc"] = prefill_query_start_loc
 
-            cos, sin = get_cos_and_sin_dsa(prefill_input_positions)
-            self.prefill_ratio_to_sas_metadata["cos"] = cos
-            self.prefill_ratio_to_sas_metadata["sin"] = sin
-
             prefill_seq_lens = self.seq_lens[reqs_start:]
             num_prefill = prefill_seq_lens.shape[0]
             self.prefill_ratio_to_sas_metadata["prefill_seq_lens"] = prefill_seq_lens
@@ -650,8 +629,6 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             max_seq_lens = self.prefill_ratio_to_sas_metadata["max_seq_lens"]
             prefill_input_positions = self.prefill_ratio_to_sas_metadata["prefill_input_positions"]
             prefill_query_start_loc = self.prefill_ratio_to_sas_metadata["prefill_query_start_loc"]
-            cos = self.prefill_ratio_to_sas_metadata["cos"]
-            sin = self.prefill_ratio_to_sas_metadata["sin"]
             prefill_seq_lens = self.prefill_ratio_to_sas_metadata["prefill_seq_lens"]
             num_prefill = self.prefill_ratio_to_sas_metadata["num_prefill"]
 
@@ -687,15 +664,12 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             end = min(self.num_prefill_tokens, self.num_prefill_tokens // compress_ratio + self.num_prefills)
             return compressed_decode_num, end
 
-        if self.prefill_ratio_to_sas_metadata.get(f"c{self.compressor_ratio}_cos", None) is None:
-            compress_cos, compress_sin = get_cos_and_sin_dsa(
-                _get_padded_compressed_position(prefill_input_positions, self.compressor_ratio)
-            )
-            self.prefill_ratio_to_sas_metadata[f"c{self.compressor_ratio}_cos"] = compress_cos
-            self.prefill_ratio_to_sas_metadata[f"c{self.compressor_ratio}_sin"] = compress_sin
+        compress_positions_key = f"c{self.compressor_ratio}_positions"
+        if self.prefill_ratio_to_sas_metadata.get(compress_positions_key, None) is None:
+            compress_positions = _get_padded_compressed_position(prefill_input_positions, self.compressor_ratio)
+            self.prefill_ratio_to_sas_metadata[compress_positions_key] = compress_positions
         else:
-            compress_cos = self.prefill_ratio_to_sas_metadata[f"c{self.compressor_ratio}_cos"]
-            compress_sin = self.prefill_ratio_to_sas_metadata[f"c{self.compressor_ratio}_sin"]
+            compress_positions = self.prefill_ratio_to_sas_metadata[compress_positions_key]
 
         if self.prefill_ratio_to_sas_metadata.get(f"compressed_c{self.compressor_ratio}_tokens_start", None) is None:
             decode_input_positions = input_positions[:tokens_start]
@@ -733,12 +707,9 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         cu_c128_cmp_seqlen_list = None
 
         layer_name = f"c{self.compressor_ratio}"
-        metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-        metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
         if self.compressor_ratio <= 1:
             if self.prefill_ratio_to_sas_metadata.get(layer_name) is None:
-                self.prefill_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
+                self.prefill_ratio_to_sas_metadata[layer_name] = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
                     num_heads_q=n_local_heads,
                     num_heads_kv=1,
                     head_dim=self.model_config.get_head_size(),
@@ -758,12 +729,12 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     layout_kv="PA_ND",
                     has_ori_kv=True,
                     has_cmp_kv=False,
+                    device=str(self.seqused_q.device),
                 )
             sas_metadata = self.prefill_ratio_to_sas_metadata[layer_name]
         elif self.compressor_ratio == 4:
             if self.prefill_ratio_to_sas_metadata.get(layer_name) is None:
-                self.prefill_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
+                self.prefill_ratio_to_sas_metadata[layer_name] = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
                     num_heads_q=n_local_heads,
                     num_heads_kv=1,
                     head_dim=self.model_config.get_head_size(),
@@ -786,12 +757,12 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     layout_kv="PA_ND",
                     has_ori_kv=True,
                     has_cmp_kv=True,
+                    device=str(self.seqused_q.device),
                 )
             sas_metadata = self.prefill_ratio_to_sas_metadata[layer_name]
         else:
             if self.prefill_ratio_to_sas_metadata.get(layer_name) is None:
-                self.prefill_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
+                self.prefill_ratio_to_sas_metadata[layer_name] = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
                     num_heads_q=n_local_heads,
                     num_heads_kv=1,
                     head_dim=self.model_config.get_head_size(),
@@ -812,6 +783,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     layout_kv="PA_ND",
                     has_ori_kv=True,
                     has_cmp_kv=True,
+                    device=str(self.seqused_q.device),
                 )
             sas_metadata = self.prefill_ratio_to_sas_metadata[layer_name]
         if self.prefill_ratio_to_sas_metadata.get("qli") is None:
@@ -848,10 +820,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             max_query_len=max_query_len,
             max_seq_lens=max_seq_lens,
             query_start_loc=prefill_query_start_loc,
-            sin=sin,
-            cos=cos,
-            compress_sin=compress_sin,
-            compress_cos=compress_cos,
+            compress_positions=compress_positions,
+            compress_rope_use_cache=False,
             start_pos=self.start_pos_prefill[:num_prefill],
             sas_metadata=sas_metadata,
             qli_metadata=qli_metadata,
@@ -871,9 +841,6 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             self.decode_ratio_to_sas_metadata["query_start_loc"] = query_start_loc
             input_positions = common_attn_metadata.positions[: self.num_decode_tokens].long()
             self.decode_ratio_to_sas_metadata["input_positions"] = input_positions
-            cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=True)
-            self.decode_ratio_to_sas_metadata["cos"] = cos
-            self.decode_ratio_to_sas_metadata["sin"] = sin
 
             query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu[: self.num_decodes + 1]
             input_positions_cpu = common_attn_metadata.positions_cpu[: self.num_decode_tokens].long()
@@ -905,8 +872,6 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         else:
             query_start_loc = self.decode_ratio_to_sas_metadata["query_start_loc"]
             input_positions = self.decode_ratio_to_sas_metadata["input_positions"]
-            cos = self.decode_ratio_to_sas_metadata["cos"]
-            sin = self.decode_ratio_to_sas_metadata["sin"]
             query_start_loc_cpu = self.decode_ratio_to_sas_metadata["query_start_loc_cpu"]
             decode_input_positions = self.decode_ratio_to_sas_metadata["decode_input_positions"]
             max_seq_lens = self.decode_ratio_to_sas_metadata["max_seq_lens"]
@@ -932,20 +897,16 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             return gpu_pad_positions
 
         layer_name = f"c{self.compressor_ratio}"
-        if self.decode_ratio_to_sas_metadata.get(layer_name + "_cos", None) is None:
-            compress_cos, compress_sin = get_cos_and_sin_dsa(
-                {
-                    layer_name: _get_padded_compressed_position(
-                        decode_input_positions, self.compressor_ratio, input_positions.device
-                    )
-                },
-                use_cache=True,
-            )
-            self.decode_ratio_to_sas_metadata[layer_name + "_cos"] = compress_cos
-            self.decode_ratio_to_sas_metadata[layer_name + "_sin"] = compress_sin
+        compress_positions_key = layer_name + "_positions"
+        if self.decode_ratio_to_sas_metadata.get(compress_positions_key, None) is None:
+            compress_positions = {
+                layer_name: _get_padded_compressed_position(
+                    decode_input_positions, self.compressor_ratio, input_positions.device
+                )
+            }
+            self.decode_ratio_to_sas_metadata[compress_positions_key] = compress_positions
         else:
-            compress_cos = self.decode_ratio_to_sas_metadata[layer_name + "_cos"]
-            compress_sin = self.decode_ratio_to_sas_metadata[layer_name + "_sin"]
+            compress_positions = self.decode_ratio_to_sas_metadata[compress_positions_key]
 
         def _get_compressed_decode_token_start(decode_input_positions, compress_ratio):
             # Note(qcs): some models use compress_ratio=0 as non-compression tag.
@@ -965,9 +926,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 "compressed_tokens_start_" + str(self.compressor_ratio)
             ]
 
-        slot_mapping = DeviceOperator.pad_dsa_decode_slot_mapping(
-            self.slot_mapping[:compressed_tokens_start], self.num_decode_tokens, self.compressor_ratio, self.num_decodes
-        )
+        slot_mapping = self.slot_mapping[:compressed_tokens_start]
 
         assert self.start_pos_decode is not None
         self.start_pos_decode.fill_(0)
@@ -982,28 +941,15 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         index_topk = self.model_config.hf_config.index_topk
 
         assert self.decode_sas_metadata is not None
-
-        cu_seqlens_ori_kv = DeviceOperator.get_dsa_decode_cu_seqlens_ori_kv(
-            self.decode_ratio_to_sas_metadata,
-            "cu_seqlens_ori_kv",
-            self.seq_lens,
-            self.num_decodes,
-            self._zero_i32,
-            self.cu_seqlens_ori_kv,
-        )
-        metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-        metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
-        cu_seqlens_cmp_kv = DeviceOperator.get_dsa_decode_cu_seqlens_cmp_kv(self.cu_seqlens_cmp_kv)
         if self.compressor_ratio <= 1:
             if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
-                self.decode_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
+                self.decode_ratio_to_sas_metadata[layer_name] = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
                     num_heads_q=n_local_heads,
                     num_heads_kv=1,
                     head_dim=self.model_config.get_head_size(),
                     cu_seqlens_q=query_start_loc,  # cached
-                    cu_seqlens_ori_kv=cu_seqlens_ori_kv,
-                    cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
+                    cu_seqlens_ori_kv=self.cu_seqlens_ori_kv,
+                    cu_seqlens_cmp_kv=self.cu_seqlens_cmp_kv,
                     seqused_q=self.seqused_q,
                     seqused_kv=self.seq_lens[: self.num_decodes],  # cached
                     max_seqlen_q=max_seqlen_q,
@@ -1018,18 +964,18 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     layout_kv="PA_ND",
                     has_ori_kv=True,
                     has_cmp_kv=False,
+                    device=str(self.seqused_q.device),
                 )
             self.decode_sas_metadata[:1024] = self.decode_ratio_to_sas_metadata[layer_name]
         elif self.compressor_ratio == 4:
             if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
-                self.decode_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
+                self.decode_ratio_to_sas_metadata[layer_name] = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
                     num_heads_q=n_local_heads,
                     num_heads_kv=1,
                     head_dim=self.model_config.get_head_size(),
                     cu_seqlens_q=query_start_loc,  # cached
-                    cu_seqlens_ori_kv=cu_seqlens_ori_kv,
-                    cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
+                    cu_seqlens_ori_kv=self.cu_seqlens_ori_kv,
+                    cu_seqlens_cmp_kv=self.cu_seqlens_cmp_kv,
                     seqused_q=self.seqused_q,
                     seqused_kv=self.seq_lens[: self.num_decodes],  # cached
                     max_seqlen_q=max_seqlen_q,
@@ -1046,18 +992,18 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     layout_kv="PA_ND",
                     has_ori_kv=True,
                     has_cmp_kv=True,
+                    device=str(self.seqused_q.device),
                 )
             self.decode_sas_metadata[:1024] = self.decode_ratio_to_sas_metadata[layer_name]
         else:
             if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
-                self.decode_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
+                self.decode_ratio_to_sas_metadata[layer_name] = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
                     num_heads_q=n_local_heads,
                     num_heads_kv=1,
                     head_dim=self.model_config.get_head_size(),
                     cu_seqlens_q=query_start_loc,
-                    cu_seqlens_ori_kv=cu_seqlens_ori_kv,
-                    cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
+                    cu_seqlens_ori_kv=self.cu_seqlens_ori_kv,
+                    cu_seqlens_cmp_kv=self.cu_seqlens_cmp_kv,
                     seqused_q=self.seqused_q,
                     seqused_kv=self.seq_lens[: self.num_decodes],
                     max_seqlen_q=max_seqlen_q,
@@ -1072,6 +1018,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     layout_kv="PA_ND",
                     has_ori_kv=True,
                     has_cmp_kv=True,
+                    device=str(self.seqused_q.device),
                 )
             self.decode_sas_metadata[:1024] = self.decode_ratio_to_sas_metadata[layer_name]
         assert self.decode_qli_metadata is not None
@@ -1109,10 +1056,9 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             attn_mask=None,
             query_start_loc=query_start_loc,  # cached
             query_start_loc_cpu=query_start_loc_cpu,
-            sin=sin[: self.num_decode_tokens, ...],
-            cos=cos[: self.num_decode_tokens, ...],
-            compress_sin=compress_sin,
-            compress_cos=compress_cos,
+            compress_positions=compress_positions,
+            rope_use_cache=True,
+            compress_rope_use_cache=True,
             cp_seq_len=cp_seq_len,
             batch_seq_mask=batch_seq_mask,
             start_pos=self.start_pos_decode[: self.num_decodes],  # cached
@@ -1134,16 +1080,10 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         )
         num_input_tokens = common_attn_metadata.num_input_tokens
         input_positions = common_attn_metadata.positions[:num_input_tokens].long()
-        if num_prefills:
-            cos, sin = get_cos_and_sin_dsa(input_positions)
-        else:
-            # disable use_cache, otherwise, draft_step>0 will override draft_step=0
-            # take care of this, if full graph is needed then rope cache is inevitable
-            cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=False)
 
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
-        self.spec_slot_mapping[draft_step - 1][:num_input_tokens] = DeviceOperator.format_dsa_slot_mapping(  # type: ignore[index]
-            slot_mapping, self.block_size
+        self.spec_slot_mapping[draft_step - 1][:num_input_tokens] = torch.stack(  # type: ignore[index]
+            [slot_mapping // self.block_size, slot_mapping % self.block_size], axis=-1
         )
 
         prefill_metadata = None
@@ -1181,8 +1121,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             query_start_loc=None,
             block_tables=None,
             seq_lens=None,
-            cos=cos,
-            sin=sin,
+            input_positions=input_positions,
+            rope_use_cache=False,
             hadamard=None,
         )
 
@@ -1206,15 +1146,11 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         input_positions = common_attn_metadata.positions[:num_actual_tokens].long()
         prefill_input_positions = input_positions[tokens_start:]
-        cos, sin = get_cos_and_sin_dsa(prefill_input_positions)
 
         prefill_slot_mapping = self.spec_slot_mapping[draft_step - 1][tokens_start:num_prefill_tokens]  # type: ignore[index]
         block_table = common_attn_metadata.block_table_tensor[: common_attn_metadata.num_reqs]
 
-        metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-        metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
-        sas_metadata = metadata_op(
-            **metadata_kwargs,
+        sas_metadata = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
             num_heads_q=n_local_heads,
             num_heads_kv=1,
             head_dim=self.model_config.get_head_size(),
@@ -1234,6 +1170,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             layout_kv="PA_ND",
             has_ori_kv=True,
             has_cmp_kv=False,
+            device=str(self.seqused_q.device),
         )
 
         return AscendDSAPrefillMetadata(
@@ -1241,16 +1178,13 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             query_lens=None,
             seq_lens=seq_lens,
             context_lens=None,
-            input_positions=None,  # type: ignore[arg-type]
+            input_positions=prefill_input_positions,
             block_table=block_table[reqs_start:, ...],
             slot_mapping=prefill_slot_mapping,
             max_query_len=None,  # type: ignore[arg-type]
             max_seq_lens=None,  # type: ignore[arg-type]
             query_start_loc=prefill_query_start_loc,
-            sin=sin,
-            cos=cos,
-            compress_sin=None,
-            compress_cos=None,
+            rope_use_cache=False,
             start_pos=None,
             sas_metadata=sas_metadata,
             qli_metadata=None,
@@ -1285,18 +1219,11 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         max_seqlen_kv = torch.max(_seq_lens_cpu[:num_decodes]).item()
 
         input_positions = common_attn_metadata.positions[:num_decode_tokens_typed].long()
-        # disable use_cache, otherwise, draft_step>0 will override draft_step=0
-        # take care of this, if full graph is needed then rope cache is inevitable
-        cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=False)
 
         slot_mapping = self.spec_slot_mapping[draft_step - 1][:num_decode_tokens_typed]  # type: ignore[index]
         block_table = common_attn_metadata.block_table_tensor
 
-        metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-        metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
-
-        decode_sas_metadata = metadata_op(
-            **metadata_kwargs,
+        decode_sas_metadata = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
             num_heads_q=n_local_heads,
             num_heads_kv=1,
             head_dim=self.model_config.get_head_size(),
@@ -1317,10 +1244,11 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             layout_kv="PA_ND",
             has_ori_kv=True,
             has_cmp_kv=False,
+            device=str(self.seqused_q.device),
         )
 
         decode_metadata = AscendDSADecodeMetadata(
-            input_positions=None,
+            input_positions=input_positions,
             block_table=block_table[:num_decodes, ...],
             slot_mapping=slot_mapping,
             seq_lens=seq_lens[:num_decodes],
@@ -1331,10 +1259,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             attn_mask=None,
             query_start_loc=query_start_loc,
             query_start_loc_cpu=None,
-            sin=sin[:num_decode_tokens, ...],
-            cos=cos[:num_decode_tokens, ...],
-            compress_sin=None,
-            compress_cos=None,
+            rope_use_cache=False,
             cp_seq_len=None,
             batch_seq_mask=None,
             start_pos=None,
@@ -1416,7 +1341,6 @@ class AscendDSAImpl(DSAAttentionImpl):
         self.wq_b = kwargs["wq_b"]
         self.wkv = kwargs["wkv"]
         self.q_norm = kwargs["q_norm"]
-        self.q_norm_without_weight = kwargs["q_norm_without_weight"]
         self.kv_norm = kwargs["kv_norm"]
 
         # CV wrapper: split wq_a/wkv/wq_b into quantize(Vector) + matmul(Cube)
@@ -1518,11 +1442,26 @@ class AscendDSAImpl(DSAAttentionImpl):
                 _ = self.kv_norm(kv_dummy)
 
                 # indexer module aux stream ops
-                # Part1 aux: kv_quant + scatter (device-dispatched via DeviceOperator)
+                # Part1 aux: kv_quant (npu_dynamic_quant)
+                soc_version = get_ascend_device_type()
+                dst_type = torch.float8_e4m3fn if soc_version in {AscendDeviceType.A5} else torch.int8
+                kv_dummy, kv_scale_dummy = torch_npu.npu_dynamic_quant(hidden_states_dummy, dst_type=dst_type)
+                kv_scale_dummy = kv_scale_dummy.unsqueeze(-1)
+                if soc_version not in {AscendDeviceType.A5}:
+                    kv_scale_dummy = kv_scale_dummy.to(torch.float16).unsqueeze(-1)
+                # Part1 aux: scatter_k_cache (npu_scatter_nd_update_v2)
                 # In profiling stage, create dummy tensors to ensure ACL graph captures scatter operator.
                 if self.compress_ratio == 4 and self.indexer is not None:
                     slot_mapping_dummy = torch.zeros(1, dtype=torch.int64, device=hidden_states.device)
-                    DeviceOperator.warmup_indexer_quant_scatter(hidden_states_dummy, slot_mapping_dummy)
+                    # Create dummy tensors for scatter warmup
+                    dummy_shape = (1, 1, 1, kv_dummy.shape[-1])  # [num_blocks, block_size, num_heads, head_dim]
+                    indexer_k_cache = torch.zeros(dummy_shape, dtype=kv_dummy.dtype, device=hidden_states.device)
+                    indexer_scale_cache = torch.zeros(dummy_shape, dtype=torch.float16, device=hidden_states.device)
+                    # Part3 aux: scatter_k_cache/scatter_scale_cache (npu_scatter_nd_update_v2)
+                    torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_k_cache, slot_mapping_dummy, kv_dummy)
+                    torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                        indexer_scale_cache, slot_mapping_dummy, kv_scale_dummy
+                    )
 
                     # Warm up weights_proj on the aux stream.
                     _ = self.weights_proj(hidden_states_dummy)
@@ -1570,6 +1509,14 @@ class AscendDSAImpl(DSAAttentionImpl):
         else:
             x = x_rot.reshape(1, num_tokens, -1, rotary_dim)
         return x
+
+    @staticmethod
+    def _materialize_dsa_cos_sin(
+        positions: torch.Tensor | dict[str, torch.Tensor],
+        *,
+        use_cache: bool = False,
+    ):
+        return materialize_dsa_cos_sin(positions, use_cache=use_cache)
 
     def forward(  # type: ignore[override]
         self,
@@ -1626,18 +1573,18 @@ class AscendDSAImpl(DSAAttentionImpl):
                 need_prefill_gather,
             )  # type: ignore[arg-type]
             o_proj_input[decode_tokens:actual_tokens] = output_prefill
-            cos = attn_metadata[0].prefill.cos[layer_name]
-            sin = attn_metadata[0].prefill.sin[layer_name]
 
         if has_decode:
             assert attn_metadata[0].decode is not None
             output_decode = self._forward_decode(layer_name, decode_hidden_states, kv_cache, attn_metadata)
             o_proj_input[:decode_tokens] = output_decode
-            cos = attn_metadata[0].decode.cos[layer_name]
-            sin = attn_metadata[0].decode.sin[layer_name]
 
-        cos = attn_metadata[0].cos[layer_name]
-        sin = attn_metadata[0].sin[layer_name]
+        cos_proxy, sin_proxy = self._materialize_dsa_cos_sin(
+            attn_metadata[0].input_positions,
+            use_cache=attn_metadata[0].rope_use_cache,
+        )
+        cos = cos_proxy[layer_name]
+        sin = sin_proxy[layer_name]
         num_tokens = o_proj_input.shape[0]
 
         torch.ops._C_ascend.inplace_partial_rotary_mul(
@@ -1649,42 +1596,24 @@ class AscendDSAImpl(DSAAttentionImpl):
         )
 
         # o
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
-            o = o_proj_input.view(num_tokens, self.n_local_groups, -1)
-            o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
-            o = torch_npu.npu_transpose_quant_batchmatmul(
-                o,
+        o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, -1)
+        if olora_tp_enable():
+            o_proj_input = self.wo_a(o_proj_input)
+        else:
+            # wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
+            # o = torch.einsum("tgd,grd->tgr", o, wo_a)
+            o_proj_input = torch_npu.npu_transpose_batchmatmul(
+                o_proj_input,
                 self.wo_a.weight,
-                dtype=torch.bfloat16,
                 bias=None,
-                group_sizes=(0, 0, 32),
-                x1_scale=swiglu_out_scale.view(torch.float8_e8m0fnu),
-                x2_scale=self.wo_a.weight_scale.view(torch.float8_e8m0fnu),
+                scale=None,
                 perm_x1=(1, 0, 2),
                 perm_x2=(0, 1, 2),
                 perm_y=(1, 0, 2),
+                batch_split_factor=1,
             )
-            o = o.reshape(num_tokens, -1)
-            output[...] = self.wo_b(o)
-        else:
-            o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, -1)
-            if olora_tp_enable():
-                o_proj_input = self.wo_a(o_proj_input)
-            else:
-                # wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
-                # o = torch.einsum("tgd,grd->tgr", o, wo_a)
-                o_proj_input = torch_npu.npu_transpose_batchmatmul(
-                    o_proj_input,
-                    self.wo_a.weight,
-                    bias=None,
-                    scale=None,
-                    perm_x1=(1, 0, 2),
-                    perm_x2=(0, 1, 2),
-                    perm_y=(1, 0, 2),
-                    batch_split_factor=1,
-                )
-                o_proj_input = o_proj_input.reshape(num_tokens, -1)
-            output[...] = self.wo_b(o_proj_input)
+            o_proj_input = o_proj_input.reshape(num_tokens, -1)
+        output[...] = self.wo_b(o_proj_input)
 
         return output_padded
 
@@ -1703,7 +1632,9 @@ class AscendDSAImpl(DSAAttentionImpl):
         main_stream = torch.npu.current_stream()
         aux_stream = dsv4_dsa_overlap_stream()
 
-        is_w8a8 = _is_w8a8_dynamic(self.wq_b)
+        is_w8a8 = (not isinstance(self.wq_b.quant_method, AscendUnquantizedLinearMethod)) and isinstance(
+            self.wq_b.quant_method.quant_method, AscendW8A8DynamicLinearMethod
+        )
 
         # Part1: q_quant[V] -> q_a_down[C]  ||  kv_quant[V]
         q_quant, q_pertoken_scale = self.cv_wq_a.quantize(hidden_states)
@@ -1755,7 +1686,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 rotary_mode="interleave",
                 partial_slice=[self.nope_head_dim, self.head_dim],
             )
-            DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, slot_mapping)
+            torch.ops._C_ascend.npu_scatter_nd_update_v2(swa_kv_cache, slot_mapping, kv)
 
         if is_prefill:
             q = self.cv_wq_b.matmul(q_b_quant, q_b_scale).unflatten(-1, (self.n_local_heads, self.head_dim))
@@ -1774,7 +1705,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         # Serial tail: wait for auxiliary stream then execute q_rms[V] + rope[V]
         main_stream.wait_stream(aux_stream)
 
-        q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
+        q = triton_q_rms(q, self.eps)
         torch.ops._C_ascend.inplace_partial_rotary_mul(
             q.unsqueeze(1),
             cos,
@@ -1829,7 +1760,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             torch.npu.current_stream().wait_event(e_phase3)
             q_b_quant, q_b_scale = self.cv_wq_b.quantize(qr)
             q = self.cv_wq_b.matmul(q_b_quant, q_b_scale).unflatten(-1, (self.n_local_heads, self.head_dim))
-            q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
+            q = triton_q_rms(q, self.eps)
 
         kv = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(kv, True)
         kv = kv[:num_actual_tokens]
@@ -1859,7 +1790,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             rotary_mode="interleave",
             partial_slice=[self.nope_head_dim, self.head_dim],
         )
-        DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, slot_mapping)
+        torch.ops._C_ascend.npu_scatter_nd_update_v2(swa_kv_cache, slot_mapping, kv)
 
         return q, qr, full_hidden_states
 
@@ -1872,29 +1803,39 @@ class AscendDSAImpl(DSAAttentionImpl):
         need_prefill_gather: bool = False,
     ):
         compress_common_attn_metadata = None
-        (compress_kv_cache, swa_kv_cache, state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
-            DeviceOperator.unpack_dsa_forward_kv_cache(kv_cache, self.compress_ratio)
-        )
-
         if self.compress_ratio == 4:
+            (compress_kv_cache, swa_kv_cache, state_cache, _, indexer_k_cache, indexer_scale_cache) = kv_cache
             # sorted keys: [attn, compressor.state_cache, indexer.compressor.state_cache, indexer.k_cache, swa_cache]
             (compressor_attn_metadata, compressor_kv_state_metadata, _, indexer_kv_scale_metadata, swa_metadata) = (
                 attn_metadata
             )
             compress_common_attn_metadata = compressor_attn_metadata
         elif self.compress_ratio == 128:
+            (compress_kv_cache, swa_kv_cache, state_cache, _, _, _) = kv_cache
             # sorted keys: [attn, compressor.state_cache, swa_cache]
             (compressor_attn_metadata, compressor_kv_state_metadata, swa_metadata) = attn_metadata
             compress_common_attn_metadata = compressor_attn_metadata
         else:
+            (
+                _,
+                swa_kv_cache,
+                _,
+                _,
+                _,
+                _,
+            ) = kv_cache
             # sorted keys: [swa_cache]
             (swa_metadata,) = attn_metadata
             compress_common_attn_metadata = swa_metadata
 
         common_prefill_metadata = _require_prefill_metadata(compress_common_attn_metadata)
         swa_prefill_metadata = _require_prefill_metadata(swa_metadata)
-        cos = common_prefill_metadata.cos[layer_name]
-        sin = common_prefill_metadata.sin[layer_name]
+        cos_proxy, sin_proxy = self._materialize_dsa_cos_sin(
+            common_prefill_metadata.input_positions,
+            use_cache=common_prefill_metadata.rope_use_cache,
+        )
+        cos = cos_proxy[layer_name]
+        sin = sin_proxy[layer_name]
         actual_seq_lengths_query = common_prefill_metadata.query_start_loc
         actual_seq_lengths_key = common_prefill_metadata.seq_lens
 
@@ -1911,43 +1852,15 @@ class AscendDSAImpl(DSAAttentionImpl):
                 cos,
                 sin,
                 swa_kv_cache,
-                swa_prefill_metadata.slot_mapping,
+                swa_metadata.prefill.slot_mapping,
             )
             qr_pertoken_scale = None  # noqa: F841
         else:
             # mlaprolog
-            share_hs_quant = _is_w8a8_dynamic(self.wq_a) and _is_w8a8_dynamic(self.wkv)
-            if share_hs_quant:
-                hs_int8, hs_pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
-                q_a = torch_npu.npu_quant_matmul(
-                    hs_int8,
-                    self.wq_a.weight,
-                    self.wq_a.weight_scale,
-                    pertoken_scale=hs_pertoken_scale,
-                    bias=self.wq_a.bias,
-                    output_dtype=hidden_states.dtype,
-                )
-            else:
-                q_a = self.wq_a(hidden_states)
-
             # q
-            if _is_w8a8_dynamic(self.wq_b):
-                qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
-                    q_a, self.q_norm.weight, epsilon=self.eps
-                )
-                q = torch_npu.npu_quant_matmul(
-                    qr,
-                    self.wq_b.weight,
-                    self.wq_b.weight_scale,
-                    pertoken_scale=qr_pertoken_scale,
-                    bias=self.wq_b.bias,
-                    output_dtype=hidden_states.dtype,
-                ).unflatten(-1, (self.n_local_heads, self.head_dim))
-            else:
-                qr = self.q_norm(q_a)
-                q = self.wq_b(qr).unflatten(-1, (self.n_local_heads, self.head_dim))
-                qr_pertoken_scale = None
-            q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
+            qr = self.q_norm(self.wq_a(hidden_states))
+            q = self.wq_b(qr).unflatten(-1, (self.n_local_heads, self.head_dim))
+            q = triton_q_rms(q, self.eps)
 
             torch.ops._C_ascend.inplace_partial_rotary_mul(
                 q.unsqueeze(1),
@@ -1957,17 +1870,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 partial_slice=[self.nope_head_dim, self.head_dim],
             )
             # win kv & tok_dis
-            if share_hs_quant:
-                kv = torch_npu.npu_quant_matmul(
-                    hs_int8,
-                    self.wkv.weight,
-                    self.wkv.weight_scale,
-                    pertoken_scale=hs_pertoken_scale,
-                    bias=self.wkv.bias,
-                    output_dtype=hidden_states.dtype,
-                )
-            else:
-                kv = self.wkv(hidden_states)
+            kv = self.wkv(hidden_states)
             kv = self.kv_norm(kv)
             assert self.rope_head_dim is not None
             kv = kv.view(-1, 1, self.nope_head_dim + self.rope_head_dim)
@@ -1981,35 +1884,15 @@ class AscendDSAImpl(DSAAttentionImpl):
             )
 
             # swa exec kv
-            DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, swa_prefill_metadata.slot_mapping)
-
-        compress_cos = common_prefill_metadata.compress_cos[layer_name]
-        compress_sin = common_prefill_metadata.compress_sin[layer_name]
-
-        attn_op = DeviceOperator.get_dsa_sparse_attn_op()
-        extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
-        DeviceOperator.add_dsa_sparse_attn_extra_kwargs(extra_attn_kwargs, cu_seqlens_ori_kv=actual_seq_lengths_query)
-
-        if self.compress_ratio <= 1:
-            return attn_op(
-                q,
-                ori_kv=swa_kv_cache,
-                ori_block_table=swa_prefill_metadata.block_table,
-                cu_seqlens_q=actual_seq_lengths_query,
-                seqused_kv=actual_seq_lengths_key,
-                sinks=self.attn_sink,
-                metadata=common_prefill_metadata.sas_metadata,
-                softmax_scale=self.softmax_scale,
-                cmp_ratio=max(self.compress_ratio, 1),
-                ori_mask_mode=4,
-                ori_win_left=self.window_size - 1,
-                ori_win_right=0,
-                layout_q="TND",
-                layout_kv="PA_ND",
-                **extra_attn_kwargs,
-            )[0]
+            torch.ops._C_ascend.npu_scatter_nd_update_v2(swa_kv_cache, swa_prefill_metadata.slot_mapping, kv)
 
         if self.compress_ratio > 1:
+            compressed_cos_proxy, compressed_sin_proxy = self._materialize_dsa_cos_sin(
+                common_prefill_metadata.compress_positions,
+                use_cache=common_prefill_metadata.compress_rope_use_cache,
+            )
+            compressed_cos = compressed_cos_proxy[layer_name]
+            compressed_sin = compressed_sin_proxy[layer_name]
             compressor_prefill_metadata = _require_prefill_metadata(compressor_attn_metadata)
             compressor_state_prefill_metadata = _require_prefill_metadata(compressor_kv_state_metadata)
             compress_topk_idxs = None
@@ -2031,11 +1914,10 @@ class AscendDSAImpl(DSAAttentionImpl):
                             attn_metadata=attn_metadata,
                             cos=cos,
                             sin=sin,
-                            compressed_cos=compress_cos,
-                            compressed_sin=compress_sin,
+                            compressed_cos=compressed_cos,
+                            compressed_sin=compressed_sin,
                             actual_seq_lengths_query=actual_seq_lengths_query,
                             with_prefill=True,
-                            qr_pertoken_scale=qr_pertoken_scale,
                         )
                     else:
                         compress_topk_idxs = self.indexer_select_qli(  # original version
@@ -2045,12 +1927,11 @@ class AscendDSAImpl(DSAAttentionImpl):
                             attn_metadata=attn_metadata,
                             cos=cos,
                             sin=sin,
-                            compressed_cos=compress_cos,
-                            compressed_sin=compress_sin,
+                            compressed_cos=compressed_cos,
+                            compressed_sin=compressed_sin,
                             actual_seq_lengths_query=actual_seq_lengths_query,
                             actual_seq_lengths_key=actual_seq_lengths_key,
                             with_prefill=True,
-                            qr_pertoken_scale=qr_pertoken_scale,
                         )
 
             coff = 2 if self.compressor_overlap else 1
@@ -2063,8 +1944,8 @@ class AscendDSAImpl(DSAAttentionImpl):
                 state_cache.squeeze(-2),
                 self.compressor_ape,
                 self.compressor_norm.weight,
-                compress_sin.view(-1, compress_sin.shape[-1]),
-                compress_cos.view(-1, compress_cos.shape[-1]),
+                compressed_sin.view(-1, compressed_sin.shape[-1]),
+                compressed_cos.view(-1, compressed_cos.shape[-1]),
                 state_block_table=compressor_state_prefill_metadata.block_table,
                 cu_seqlens=actual_seq_lengths_query,
                 seqused=None,
@@ -2091,10 +1972,14 @@ class AscendDSAImpl(DSAAttentionImpl):
                     torch.npu.current_stream().wait_event(e_compressed_kv_done)
                     weights_proj_output = self.weights_proj(hidden_states)
                 # Main stream: q_quant (between compressed_kv and kv_scatter)
-                q_quant, q_scale = DeviceOperator.indexer_quantize_query(indexer_q)
+                soc_version = get_ascend_device_type()
+                dst_type = torch.float8_e4m3fn if soc_version in {AscendDeviceType.A5} else torch.int8
+                q_quant, q_scale = torch_npu.npu_dynamic_quant(indexer_q, dst_type=dst_type)
+                if soc_version not in {AscendDeviceType.A5}:
+                    q_scale = q_scale.to(torch.float16)
 
-            DeviceOperator.dsa_kv_compress_scatter(
-                compress_kv_cache, compressed_kv, compressor_prefill_metadata.slot_mapping
+            torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                compress_kv_cache, compressor_prefill_metadata.slot_mapping, compressed_kv
             )
 
             if self.multistream_dsv4_dsa_overlap and self.compress_ratio == 4 and not self.skip_topk:
@@ -2110,9 +1995,9 @@ class AscendDSAImpl(DSAAttentionImpl):
                 compress_topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer(
                     query=q_quant,
                     key=indexer_k_cache,
-                    weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
-                    query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
-                    key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
+                    weights=weights.to(torch.float16),
+                    query_dequant_scale=q_scale,
+                    key_dequant_scale=indexer_scale_cache.squeeze(-2),
                     actual_seq_lengths_query=qlens,
                     actual_seq_lengths_key=kvlens,
                     block_table=block_table,
@@ -2132,55 +2017,69 @@ class AscendDSAImpl(DSAAttentionImpl):
             if self.compress_ratio == 4 and self.use_index_cache:
                 self._update_indexcache_topk_indices(compress_topk_idxs, offset=prefill_offset)
 
-            if self.compress_ratio == 4:
-                DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
-                    extra_attn_kwargs, cu_seqlens_cmp_kv=common_prefill_metadata.cu_c4_cmp_seqlen_list
-                )
-                attn_output = attn_op(
-                    q,
-                    ori_kv=swa_kv_cache,
-                    cmp_kv=compress_kv_cache,
-                    cmp_sparse_indices=compress_topk_idxs,
-                    ori_block_table=swa_prefill_metadata.block_table,
-                    cmp_block_table=compressor_prefill_metadata.block_table,
-                    cu_seqlens_q=actual_seq_lengths_query,
-                    seqused_kv=actual_seq_lengths_key,
-                    sinks=self.attn_sink,
-                    metadata=common_prefill_metadata.sas_metadata,
-                    softmax_scale=self.softmax_scale,
-                    cmp_ratio=self.compress_ratio,
-                    ori_mask_mode=4,
-                    cmp_mask_mode=3,
-                    ori_win_left=self.window_size - 1,
-                    ori_win_right=0,
-                    layout_q="TND",
-                    layout_kv="PA_ND",
-                    **extra_attn_kwargs,
-                )[0]
-            else:
-                DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
-                    extra_attn_kwargs, cu_seqlens_cmp_kv=common_prefill_metadata.cu_c128_cmp_seqlen_list
-                )
-                attn_output = attn_op(
-                    q,
-                    ori_kv=swa_kv_cache,
-                    cmp_kv=compress_kv_cache,
-                    ori_block_table=swa_prefill_metadata.block_table,
-                    cmp_block_table=compressor_prefill_metadata.block_table,
-                    cu_seqlens_q=actual_seq_lengths_query,
-                    seqused_kv=actual_seq_lengths_key,
-                    sinks=self.attn_sink,
-                    metadata=common_prefill_metadata.sas_metadata,
-                    softmax_scale=self.softmax_scale,
-                    cmp_ratio=self.compress_ratio,
-                    ori_mask_mode=4,
-                    cmp_mask_mode=3,
-                    ori_win_left=self.window_size - 1,
-                    ori_win_right=0,
-                    layout_q="TND",
-                    layout_kv="PA_ND",
-                    **extra_attn_kwargs,
-                )[0]
+        if self.compress_ratio <= 1:
+            attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
+                q,
+                ori_kv=swa_kv_cache,
+                ori_block_table=swa_prefill_metadata.block_table,
+                cu_seqlens_q=actual_seq_lengths_query,
+                cu_seqlens_ori_kv=actual_seq_lengths_query,
+                seqused_kv=actual_seq_lengths_key,
+                sinks=self.attn_sink,
+                metadata=common_prefill_metadata.sas_metadata,
+                softmax_scale=self.softmax_scale,
+                cmp_ratio=self.compress_ratio,
+                ori_mask_mode=4,
+                ori_win_left=self.window_size - 1,
+                ori_win_right=0,
+                layout_q="TND",
+                layout_kv="PA_ND",
+            )[0]
+        elif self.compress_ratio == 4:
+            attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
+                q,
+                ori_kv=swa_kv_cache,
+                cmp_kv=compress_kv_cache,
+                cmp_sparse_indices=compress_topk_idxs,
+                ori_block_table=swa_prefill_metadata.block_table,
+                cmp_block_table=compressor_prefill_metadata.block_table,
+                cu_seqlens_q=actual_seq_lengths_query,
+                cu_seqlens_ori_kv=actual_seq_lengths_query,
+                cu_seqlens_cmp_kv=common_prefill_metadata.cu_c4_cmp_seqlen_list,
+                seqused_kv=actual_seq_lengths_key,
+                sinks=self.attn_sink,
+                metadata=common_prefill_metadata.sas_metadata,
+                softmax_scale=self.softmax_scale,
+                cmp_ratio=self.compress_ratio,
+                ori_mask_mode=4,
+                cmp_mask_mode=3,
+                ori_win_left=self.window_size - 1,
+                ori_win_right=0,
+                layout_q="TND",
+                layout_kv="PA_ND",
+            )[0]
+        else:
+            attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
+                q,
+                ori_kv=swa_kv_cache,
+                cmp_kv=compress_kv_cache,
+                ori_block_table=swa_prefill_metadata.block_table,
+                cmp_block_table=compressor_prefill_metadata.block_table,
+                cu_seqlens_q=actual_seq_lengths_query,
+                cu_seqlens_ori_kv=actual_seq_lengths_query,
+                cu_seqlens_cmp_kv=common_prefill_metadata.cu_c128_cmp_seqlen_list,
+                seqused_kv=actual_seq_lengths_key,
+                sinks=self.attn_sink,
+                metadata=compressor_prefill_metadata.sas_metadata,
+                softmax_scale=self.softmax_scale,
+                cmp_ratio=self.compress_ratio,
+                ori_mask_mode=4,
+                cmp_mask_mode=3,
+                ori_win_left=self.window_size - 1,
+                ori_win_right=0,
+                layout_q="TND",
+                layout_kv="PA_ND",
+            )[0]
         return attn_output
 
     def _forward_decode(
@@ -2193,28 +2092,31 @@ class AscendDSAImpl(DSAAttentionImpl):
         assert attn_metadata[0].decode is not None
         compress_common_attn_metadata = None
 
-        (compress_kv_cache, swa_kv_cache, state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
-            DeviceOperator.unpack_dsa_forward_kv_cache(kv_cache, self.compress_ratio)
-        )
-
         if self.compress_ratio == 4:
+            (compress_kv_cache, swa_kv_cache, state_cache, _, indexer_k_cache, indexer_scale_cache) = kv_cache
             # sorted keys: [attn, compressor.state_cache, indexer.compressor.state_cache, indexer.k_cache, swa_cache]
             (compressor_attn_metadata, compressor_kv_state_metadata, _, indexer_kv_scale_metadata, swa_metadata) = (
                 attn_metadata
             )
             compress_common_attn_metadata = compressor_attn_metadata
         elif self.compress_ratio == 128:
+            (compress_kv_cache, swa_kv_cache, state_cache, _, _, _) = kv_cache
             # sorted keys: [attn, compressor.state_cache, swa_cache]
             (compressor_attn_metadata, compressor_kv_state_metadata, swa_metadata) = attn_metadata
             compress_common_attn_metadata = compressor_attn_metadata
         else:
+            (_, swa_kv_cache, _, _, _, _) = kv_cache
             # sorted keys: [swa_cache]
             (swa_metadata,) = attn_metadata
             compress_common_attn_metadata = swa_metadata
         common_decode_metadata = _require_decode_metadata(compress_common_attn_metadata)
         swa_decode_metadata = _require_decode_metadata(swa_metadata)
-        cos = common_decode_metadata.cos[layer_name]
-        sin = common_decode_metadata.sin[layer_name]
+        cos_proxy, sin_proxy = self._materialize_dsa_cos_sin(
+            common_decode_metadata.input_positions,
+            use_cache=common_decode_metadata.rope_use_cache,
+        )
+        cos = cos_proxy[layer_name]
+        sin = sin_proxy[layer_name]
         actual_seq_lengths_query = common_decode_metadata.query_start_loc
         actual_seq_lengths_key = common_decode_metadata.seq_lens
 
@@ -2224,29 +2126,15 @@ class AscendDSAImpl(DSAAttentionImpl):
                 hidden_states, cos, sin, swa_kv_cache, swa_decode_metadata.slot_mapping, is_prefill=False
             )
         else:
-            # Share one dynamic-quant of hidden_states between wq_a (main stream)
-            # and wkv (attention stream) when both sides are W8A8 dynamic.
-            share_hs_quant = _is_w8a8_dynamic(self.wq_a) and _is_w8a8_dynamic(self.wkv)
-            if share_hs_quant:
-                hs_int8, hs_pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
-
             wait_hidden_state_cal_event = (
                 torch.npu.current_stream().record_event() if self.multistream_dsa_preprocess else None
             )
 
             # q
-            if _is_w8a8_dynamic(self.wq_b):
-                if share_hs_quant:
-                    q_a = torch_npu.npu_quant_matmul(
-                        hs_int8,
-                        self.wq_a.weight,
-                        self.wq_a.weight_scale,
-                        pertoken_scale=hs_pertoken_scale,
-                        bias=self.wq_a.bias,
-                        output_dtype=hidden_states.dtype,
-                    )
-                else:
-                    q_a = self.wq_a(hidden_states)
+            if (not isinstance(self.wq_b.quant_method, AscendUnquantizedLinearMethod)) and isinstance(
+                self.wq_b.quant_method.quant_method, AscendW8A8DynamicLinearMethod
+            ):
+                q_a = self.wq_a(hidden_states)
                 qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                     q_a, self.q_norm.weight, epsilon=self.eps
                 )
@@ -2259,22 +2147,11 @@ class AscendDSAImpl(DSAAttentionImpl):
                     output_dtype=hidden_states.dtype,
                 ).unflatten(-1, (self.n_local_heads, self.head_dim))
             else:
-                if share_hs_quant:
-                    q_a = torch_npu.npu_quant_matmul(
-                        hs_int8,
-                        self.wq_a.weight,
-                        self.wq_a.weight_scale,
-                        pertoken_scale=hs_pertoken_scale,
-                        bias=self.wq_a.bias,
-                        output_dtype=hidden_states.dtype,
-                    )
-                    qr = q = self.q_norm(q_a)
-                else:
-                    qr = q = self.q_norm(self.wq_a(hidden_states))
+                qr = q = self.q_norm(self.wq_a(hidden_states))
                 q = self.wq_b(q).unflatten(-1, (self.n_local_heads, self.head_dim))
                 qr_pertoken_scale = None
 
-            q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
+            q = triton_q_rms(q, self.eps)
 
             torch.ops._C_ascend.inplace_partial_rotary_mul(
                 q.unsqueeze(1),
@@ -2289,17 +2166,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                     torch.npu.current_stream().wait_event(wait_hidden_state_cal_event)
 
                 # win kv & tok_dis
-                if share_hs_quant:
-                    kv = torch_npu.npu_quant_matmul(
-                        hs_int8,
-                        self.wkv.weight,
-                        self.wkv.weight_scale,
-                        pertoken_scale=hs_pertoken_scale,
-                        bias=self.wkv.bias,
-                        output_dtype=hidden_states.dtype,
-                    )
-                else:
-                    kv = self.wkv(hidden_states)
+                kv = self.wkv(hidden_states)
                 kv = self.kv_norm(kv)
                 assert self.rope_head_dim is not None
                 kv = kv.view(-1, 1, self.nope_head_dim + self.rope_head_dim)
@@ -2313,7 +2180,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 )
 
                 # swa exec kv
-                DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, swa_decode_metadata.slot_mapping)
+                torch.ops._C_ascend.npu_scatter_nd_update_v2(swa_kv_cache, swa_decode_metadata.slot_mapping, kv)
 
                 wait_attention_cal_event = (
                     torch.npu.current_stream().record_event() if self.multistream_dsa_preprocess else None
@@ -2325,8 +2192,12 @@ class AscendDSAImpl(DSAAttentionImpl):
         if self.compress_ratio > 1:
             compressor_decode_metadata = _require_decode_metadata(compressor_attn_metadata)
             compressor_state_decode_metadata = _require_decode_metadata(compressor_kv_state_metadata)
-            compress_cos = common_decode_metadata.compress_cos[layer_name]
-            compress_sin = common_decode_metadata.compress_sin[layer_name]
+            compressed_cos_proxy, compressed_sin_proxy = self._materialize_dsa_cos_sin(
+                common_decode_metadata.compress_positions,
+                use_cache=common_decode_metadata.compress_rope_use_cache,
+            )
+            compressed_cos = compressed_cos_proxy[layer_name]
+            compressed_sin = compressed_sin_proxy[layer_name]
             compress_topk_idxs = None
             if self.compress_ratio == 4:
                 # IndexCache: decode segment occupies buffer[:num_decode_tokens]
@@ -2342,8 +2213,8 @@ class AscendDSAImpl(DSAAttentionImpl):
                             attn_metadata=attn_metadata,
                             cos=cos,
                             sin=sin,
-                            compressed_cos=compress_cos,
-                            compressed_sin=compress_sin,
+                            compressed_cos=compressed_cos,
+                            compressed_sin=compressed_sin,
                             actual_seq_lengths_query=actual_seq_lengths_query,
                             with_prefill=False,
                             qr_pertoken_scale=qr_pertoken_scale,
@@ -2356,8 +2227,8 @@ class AscendDSAImpl(DSAAttentionImpl):
                             attn_metadata=attn_metadata,
                             cos=cos,
                             sin=sin,
-                            compressed_cos=compress_cos,
-                            compressed_sin=compress_sin,
+                            compressed_cos=compressed_cos,
+                            compressed_sin=compressed_sin,
                             actual_seq_lengths_query=actual_seq_lengths_query,
                             actual_seq_lengths_key=actual_seq_lengths_key,
                             with_prefill=False,
@@ -2374,8 +2245,8 @@ class AscendDSAImpl(DSAAttentionImpl):
                 state_cache.squeeze(-2),
                 self.compressor_ape,
                 self.compressor_norm.weight,
-                compress_sin.view(-1, compress_sin.shape[-1]),
-                compress_cos.view(-1, compress_cos.shape[-1]),
+                compressed_sin.view(-1, compressed_sin.shape[-1]),
+                compressed_cos.view(-1, compressed_cos.shape[-1]),
                 state_block_table=compressor_state_decode_metadata.block_table,
                 cu_seqlens=actual_seq_lengths_query,
                 seqused=None,
@@ -2399,10 +2270,14 @@ class AscendDSAImpl(DSAAttentionImpl):
                     torch.npu.current_stream().wait_event(e_compressed_kv_done)
                     weights_proj_output = self.weights_proj(hidden_states)
                 # Main stream: q_quant (between compressed_kv and kv_scatter)
-                q_quant, q_scale = DeviceOperator.indexer_quantize_query(indexer_q)
+                soc_version = get_ascend_device_type()
+                dst_type = torch.float8_e4m3fn if soc_version in {AscendDeviceType.A5} else torch.int8
+                q_quant, q_scale = torch_npu.npu_dynamic_quant(indexer_q, dst_type=dst_type)
+                if soc_version not in {AscendDeviceType.A5}:
+                    q_scale = q_scale.to(torch.float16)
 
-            DeviceOperator.dsa_kv_compress_scatter(
-                compress_kv_cache, compressed_kv, compressor_decode_metadata.slot_mapping
+            torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                compress_kv_cache, compressor_decode_metadata.slot_mapping, compressed_kv
             )
 
             if self.multistream_dsv4_dsa_overlap and self.compress_ratio == 4 and not self.skip_topk:
@@ -2418,9 +2293,9 @@ class AscendDSAImpl(DSAAttentionImpl):
                 compress_topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer(
                     query=q_quant,
                     key=indexer_k_cache,
-                    weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
-                    query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
-                    key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
+                    weights=weights.to(torch.float16),
+                    query_dequant_scale=q_scale,
+                    key_dequant_scale=indexer_scale_cache.squeeze(-2),
                     actual_seq_lengths_query=qlens,
                     actual_seq_lengths_key=kvlens,
                     block_table=block_table,
@@ -2440,11 +2315,8 @@ class AscendDSAImpl(DSAAttentionImpl):
             if self.compress_ratio == 4 and self.use_index_cache:
                 self._update_indexcache_topk_indices(compress_topk_idxs, offset=0)
 
-        attn_op = DeviceOperator.get_dsa_sparse_attn_op()
-        extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
-
         if self.compress_ratio <= 1:
-            attn_output = attn_op(
+            attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
                 q,
                 ori_kv=swa_kv_cache,
                 ori_block_table=swa_decode_metadata.block_table,
@@ -2453,16 +2325,15 @@ class AscendDSAImpl(DSAAttentionImpl):
                 sinks=self.attn_sink,
                 metadata=swa_decode_metadata.sas_metadata,
                 softmax_scale=self.softmax_scale,
-                cmp_ratio=max(self.compress_ratio, 1),
+                cmp_ratio=self.compress_ratio,
                 ori_mask_mode=4,
                 ori_win_left=self.window_size - 1,
                 ori_win_right=0,
                 layout_q="TND",
                 layout_kv="PA_ND",
-                **extra_attn_kwargs,
             )[0]
         elif self.compress_ratio == 4:
-            attn_output = attn_op(
+            attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
                 q,
                 ori_kv=swa_kv_cache,
                 cmp_kv=compress_kv_cache,
@@ -2481,10 +2352,9 @@ class AscendDSAImpl(DSAAttentionImpl):
                 ori_win_right=0,
                 layout_q="TND",
                 layout_kv="PA_ND",
-                **extra_attn_kwargs,
             )[0]
         else:
-            attn_output = attn_op(
+            attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
                 q,
                 ori_kv=swa_kv_cache,
                 cmp_kv=compress_kv_cache,
@@ -2502,7 +2372,6 @@ class AscendDSAImpl(DSAAttentionImpl):
                 ori_win_right=0,
                 layout_q="TND",
                 layout_kv="PA_ND",
-                **extra_attn_kwargs,
             )[0]
         return attn_output
 
@@ -2520,9 +2389,14 @@ class AscendDSAImpl(DSAAttentionImpl):
         with_prefill: bool = False,
         qr_pertoken_scale: torch.Tensor = None,
     ):
-        (indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
-            DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
-        )
+        (
+            _,
+            _,
+            _,
+            indexer_state_cache,
+            indexer_k_cache,
+            indexer_scale_cache,
+        ) = kv_cache
         (
             _,
             _,
@@ -2532,9 +2406,9 @@ class AscendDSAImpl(DSAAttentionImpl):
         ) = attn_metadata
 
         if (
-            _is_w8a8_dynamic(self.inderxer_wq_b)
+            (not isinstance(self.inderxer_wq_b.quant_method, AscendUnquantizedLinearMethod))
+            and isinstance(self.inderxer_wq_b.quant_method.quant_method, AscendW8A8DynamicLinearMethod)
             and qr_pertoken_scale is not None
-            and get_ascend_device_type() not in {AscendDeviceType.A5}
         ):
             q = torch_npu.npu_quant_matmul(
                 qr,
@@ -2601,7 +2475,6 @@ class AscendDSAImpl(DSAAttentionImpl):
             kv,
             indexer_k_cache,
             indexer_scale_cache,
-            indexer_full_cache,
             indexer_kv_state_metadata,
             indexer_kv_scale_metadata,
             with_prefill,
@@ -2614,7 +2487,6 @@ class AscendDSAImpl(DSAAttentionImpl):
         weights: torch.Tensor,
         indexer_k_cache: torch.Tensor,
         indexer_scale_cache: torch.Tensor,
-        indexer_full_cache: torch.Tensor | None,
         indexer_kv_state_metadata,
         indexer_kv_scale_metadata,
         with_prefill: bool,
@@ -2624,7 +2496,6 @@ class AscendDSAImpl(DSAAttentionImpl):
             kv,
             indexer_k_cache,
             indexer_scale_cache,
-            indexer_full_cache,
             indexer_kv_scale_metadata,
             with_prefill,
         )
@@ -2644,18 +2515,45 @@ class AscendDSAImpl(DSAAttentionImpl):
         kv: torch.Tensor | None,
         indexer_k_cache: torch.Tensor,
         indexer_scale_cache: torch.Tensor,
-        indexer_full_cache: torch.Tensor | None,
         indexer_kv_scale_metadata,
         with_prefill: bool,
     ):
-        slot_mapping = (
-            indexer_kv_scale_metadata.prefill.slot_mapping
-            if with_prefill
-            else indexer_kv_scale_metadata.decode.slot_mapping
-        )
-        return DeviceOperator.indexer_quant_scatter(
-            q, kv, indexer_k_cache, indexer_scale_cache, indexer_full_cache, slot_mapping
-        )
+        soc_version = get_ascend_device_type()
+        dst_type = torch.float8_e4m3fn if soc_version in {AscendDeviceType.A5} else torch.int8
+
+        q, q_scale = torch_npu.npu_dynamic_quant(q, dst_type=dst_type)
+        if kv is not None:
+            kv, kv_scale = torch_npu.npu_dynamic_quant(kv, dst_type=dst_type)
+            kv_scale = kv_scale.unsqueeze(-1)
+        else:
+            kv_scale = None
+
+        if soc_version not in {AscendDeviceType.A5}:
+            q_scale = q_scale.to(torch.float16)
+            if kv is not None:
+                kv_scale = kv_scale.to(torch.float16)
+                kv_scale = kv_scale.unsqueeze(-1)
+
+        if with_prefill:
+            assert indexer_kv_scale_metadata.prefill is not None
+            if kv is not None:
+                torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                    indexer_k_cache, indexer_kv_scale_metadata.prefill.slot_mapping, kv
+                )
+                torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                    indexer_scale_cache, indexer_kv_scale_metadata.prefill.slot_mapping, kv_scale
+                )
+        else:
+            assert indexer_kv_scale_metadata.decode is not None
+            if kv is not None:
+                torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                    indexer_k_cache, indexer_kv_scale_metadata.decode.slot_mapping, kv
+                )
+                torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                    indexer_scale_cache, indexer_kv_scale_metadata.decode.slot_mapping, kv_scale
+                )
+
+        return q, q_scale, kv, kv_scale
 
     def _indexer_qli(
         self,
@@ -2683,9 +2581,9 @@ class AscendDSAImpl(DSAAttentionImpl):
         topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer(
             query=q,
             key=indexer_k_cache,
-            weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
-            query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
-            key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
+            weights=weights.to(torch.float16),
+            query_dequant_scale=q_scale,
+            key_dequant_scale=indexer_scale_cache.squeeze(-2),
             actual_seq_lengths_query=qlens,
             actual_seq_lengths_key=kvlens,
             block_table=block_table,
@@ -2718,7 +2616,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         with_prefill: bool = False,
         qr_pertoken_scale: torch.Tensor = None,
     ):
-        q, kv, ik, isc, ifc, indexer_kv_state_meta, isc_meta, wp = self._indexer_qkv_prepare(
+        q, kv, ik, isc, indexer_kv_state_meta, isc_meta, wp = self._indexer_qkv_prepare(
             x,
             qr,
             kv_cache,
@@ -2734,7 +2632,7 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         weights = self.weights_proj(x) * (self.indexer_softmax_scale * self.indexer_heads**-0.5)
 
-        return self._indexer_qli_finish(q, kv, weights, ik, isc, ifc, indexer_kv_state_meta, isc_meta, wp)
+        return self._indexer_qli_finish(q, kv, weights, ik, isc, indexer_kv_state_meta, isc_meta, wp)
 
     def cv_indexer_select_qli(
         self,
@@ -2761,17 +2659,22 @@ class AscendDSAImpl(DSAAttentionImpl):
         - Part3: Main q_hadamard[C] ∥ Aux scatter_scale_cache[AIV]
         - Part4: Caller runs weights_proj + q_quant + indexer
         """
-        (indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
-            DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
-        )
+        (_, _, _, indexer_state_cache, indexer_k_cache, indexer_scale_cache) = kv_cache
         # sorted keys: [attn, compressor.state_cache, indexer.compressor.state_cache, indexer.k_cache, swa_cache]
         (_, _, indexer_kv_state_metadata, indexer_kv_scale_metadata, _) = attn_metadata
 
         main_stream = torch.npu.current_stream()
         aux_stream = dsv4_dsa_overlap_stream()
 
+        soc_version = get_ascend_device_type()
+        dst_type = torch.float8_e4m3fn if soc_version in {AscendDeviceType.A5} else torch.int8
+
         # ===== Part0: Pre-compute on main =====
-        if _is_w8a8_dynamic(self.inderxer_wq_b) and qr_pertoken_scale is not None:
+        if (
+            (not isinstance(self.inderxer_wq_b.quant_method, AscendUnquantizedLinearMethod))
+            and isinstance(self.inderxer_wq_b.quant_method.quant_method, AscendW8A8DynamicLinearMethod)
+            and qr_pertoken_scale is not None
+        ):
             qr_quant_ready = qr
             qr_scale_ready = qr_pertoken_scale
         else:
@@ -2822,19 +2725,25 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         # Aux: kv_quant + scatter_k_cache (parallel with main matmul + rope)
         if kv is not None:
-            slot_mapping_indexer = (
-                indexer_scale_prefill_metadata.slot_mapping
-                if with_prefill
-                else indexer_scale_decode_metadata.slot_mapping
-            )
             with npu_stream_switch(aux_stream, enabled=True):
                 torch.npu.current_stream().wait_event(e_kv_ready)
-                kv, kv_scale = DeviceOperator.indexer_quant_scatter_part1(
-                    kv, indexer_k_cache, indexer_full_cache, slot_mapping_indexer
-                )
+                kv, kv_scale = torch_npu.npu_dynamic_quant(kv, dst_type=dst_type)
+                kv_scale = kv_scale.unsqueeze(-1)
+                if with_prefill:
+                    torch.ops._C_ascend.npu_scatter_nd_update_v2(  # kv_scatter
+                        indexer_k_cache, indexer_scale_prefill_metadata.slot_mapping, kv
+                    )
+                else:
+                    torch.ops._C_ascend.npu_scatter_nd_update_v2(  # kv_scatter
+                        indexer_k_cache, indexer_scale_decode_metadata.slot_mapping, kv
+                    )
 
         # Main: matmul q from qr (directly submit, V/C different engines dispatch naturally)
-        if _is_w8a8_dynamic(self.inderxer_wq_b) and qr_pertoken_scale is not None:
+        if (
+            (not isinstance(self.inderxer_wq_b.quant_method, AscendUnquantizedLinearMethod))
+            and isinstance(self.inderxer_wq_b.quant_method.quant_method, AscendW8A8DynamicLinearMethod)
+            and qr_pertoken_scale is not None
+        ):
             q = torch_npu.npu_quant_matmul(
                 qr_quant_ready,
                 self.inderxer_wq_b.weight,
@@ -2867,20 +2776,19 @@ class AscendDSAImpl(DSAAttentionImpl):
         e_rope_done = main_stream.record_event()
 
         # ===== Part3: q_hadamard[C] ∥ scatter_scale_cache[AIV] =====
-        # Note: On A5, indexer_compress_epilog_v2 in Part1 handles both k_cache
-        # and scale_cache in one fused operation, so Part3 is skipped
-        # (kv_scale is None on A5 from indexer_quant_scatter_part1).
-        if kv is not None and kv_scale is not None:
-            slot_mapping_indexer_part3 = (
-                indexer_scale_prefill_metadata.slot_mapping
-                if with_prefill
-                else indexer_scale_decode_metadata.slot_mapping
-            )
+        if kv is not None:
             with npu_stream_switch(aux_stream, enabled=True):
                 torch.npu.current_stream().wait_event(e_rope_done)
-                DeviceOperator.dsa_indexer_scatter_scale_part3(
-                    kv_scale, indexer_scale_cache, slot_mapping_indexer_part3
-                )
+                if soc_version not in {AscendDeviceType.A5}:
+                    kv_scale = kv_scale.to(torch.float16).unsqueeze(-1)
+                if with_prefill:
+                    torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                        indexer_scale_cache, indexer_scale_prefill_metadata.slot_mapping, kv_scale
+                    )
+                else:
+                    torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                        indexer_scale_cache, indexer_scale_decode_metadata.slot_mapping, kv_scale
+                    )
 
         # Main: q_hadamard[Part1 - linear] (directly submit, C/AIV different engines dispatch naturally)
         # Part1: F.linear - parallel with aux_stream kv_scatter

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -49,7 +49,7 @@ from vllm_ascend.ops.layer_shard_linear import (
     reach_layer_for_shard_weight_series,
     register_all_layers_to_shard_weight_series,
 )
-from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_mla
+from vllm_ascend.ops.rotary_embedding import select_cos_sin_from_cache
 from vllm_ascend.quantization.methods.w8a8_mxfp8 import AscendW8A8MXFP8DynamicLinearMethod
 from vllm_ascend.quantization.methods.w8a8_static import AscendW8A8LinearMethod
 from vllm_ascend.quantization.utils import enable_fa_quant
@@ -147,8 +147,6 @@ class AscendMLAPrefillMetadata:
     max_query_len: int
     max_seq_lens: int
     chunked_context: ChunkedContextMetadata | CPChunkedContextMetadata | None = None
-    sin: torch.Tensor = None
-    cos: torch.Tensor = None
     pcp_metadata: AscendPCPMetadata | None = None
     actual_seq_lengths_q: list[int] | None = None
 
@@ -166,8 +164,6 @@ class AscendMLADecodeMetadata:
     seq_lens_list: list[int]
     actual_seq_lengths_q: list[int] | None = None
     attn_mask: torch.Tensor | None = None
-    sin: torch.Tensor = None
-    cos: torch.Tensor = None
     cp_seq_len: torch.Tensor = None
     dcp_mtp_attn_mask: torch.Tensor = None
 
@@ -560,7 +556,6 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
         prefill_query_start_loc = query_start_loc[reqs_start:] - query_start_loc[reqs_start]
 
         prefill_input_positions = input_positions[tokens_start:]
-        cos, sin = get_cos_and_sin_mla(prefill_input_positions)
         prefill_query_lens = self.query_lens[reqs_start:].to(torch.int32)
         actual_seq_lengths_q = torch.cumsum(prefill_query_lens, dim=0).tolist()
         return AscendMLAPrefillMetadata(
@@ -574,8 +569,6 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
             max_seq_lens=max_seq_lens,
             query_start_loc=prefill_query_start_loc,
             chunked_context=chunked_context_metadata,
-            sin=sin,
-            cos=cos,
             actual_seq_lengths_q=actual_seq_lengths_q,
         )
 
@@ -646,7 +639,6 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
                     num_reqs_pad_size, num_reqs, actual_seq_lengths_q, common_attn_metadata
                 )
 
-        cos, sin = get_cos_and_sin_mla(input_positions, use_cache=True)
         decode_metadata = AscendMLADecodeMetadata(
             input_positions=input_positions,
             block_table=self.block_table,
@@ -655,8 +647,6 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
             max_seq_lens=max_seq_lens,
             attn_mask=self.attn_mask_builder.get_splitfuse_attn_mask(),
             actual_seq_lengths_q=actual_seq_lengths_q,
-            sin=sin[: self.num_decode_tokens, ...],
-            cos=cos[: self.num_decode_tokens, ...],
             cp_seq_len=cp_seq_len,
         )
         return decode_metadata
@@ -1595,6 +1585,13 @@ class AscendMLAImpl(MLAAttentionImpl):
     def reorg_decode_q(self, decode_q_nope, decode_q_pe):
         return decode_q_nope, decode_q_pe
 
+    def _select_mla_cos_sin(
+        self,
+        positions: torch.Tensor,
+        ref_tensor: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return select_cos_sin_from_cache(self.rotary_emb, positions, ref_tensor, layout="T11D")
+
     def mla_preprocess_prefill(self, q_c, kv_no_split, kv_cache, attn_metadata):
         num_decode_tokens = attn_metadata.num_decode_tokens
         num_actual_tokens = attn_metadata.num_actual_tokens
@@ -1603,8 +1600,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         prefill_q = self.q_proj(prefill_q_c)[0].view(-1, self.num_heads, self.qk_head_dim)
         prefill_q_pe = prefill_q[..., self.qk_nope_head_dim :]
         prefill_q_nope = prefill_q[..., : self.qk_nope_head_dim]
-        cos = attn_metadata.prefill.cos
-        sin = attn_metadata.prefill.sin
+        cos, sin = self._select_mla_cos_sin(attn_metadata.prefill.input_positions, prefill_q_pe)
         prefill_slots = attn_metadata.slot_mapping[num_decode_tokens:num_actual_tokens]
         prefill_q_pe = self.rope_single(prefill_q_pe, cos, sin)
         prefill_k_pe, prefill_k_c_normed = self.exec_kv_prefill(prefill_kv_no_split, cos, sin, kv_cache, prefill_slots)
@@ -1620,9 +1616,8 @@ class AscendMLAImpl(MLAAttentionImpl):
     def mla_preprocess_decode(self, q_c, kv_no_split, kv_cache, attn_metadata):
         num_decode_tokens = attn_metadata.num_decode_tokens
         decode_q_c = q_c[:num_decode_tokens]
-        cos = attn_metadata.decode.cos
-        sin = attn_metadata.decode.sin
         decode_ql_nope, decode_q_pe = self._q_proj_and_k_up_proj(decode_q_c)
+        cos, sin = self._select_mla_cos_sin(attn_metadata.decode.input_positions[:num_decode_tokens], decode_q_pe)
         decode_q_pe = self.rope_single(decode_q_pe, cos, sin)
         dequant_scale_q_nope = None
         if self.fa_quant_layer and get_ascend_device_type() == AscendDeviceType.A5:

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -43,7 +43,7 @@ from vllm_ascend.ops.layer_shard_linear import (
     reach_layer_for_shard_weight_series,
     register_all_layers_to_shard_weight_series,
 )
-from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_mla
+from vllm_ascend.ops.rotary_embedding import select_cos_sin_from_cache
 from vllm_ascend.ops.triton.rope import rope_forward_triton_siso
 from vllm_ascend.quantization.methods import AscendW8A8LinearMethod, AscendW8A8MXFP8DynamicLinearMethod
 from vllm_ascend.utils import (
@@ -142,8 +142,7 @@ class AscendSFAMetadata:
     seq_lens_cpu: torch.Tensor
     cum_query_lens: torch.Tensor
     block_table: torch.Tensor
-    sin: torch.Tensor
-    cos: torch.Tensor
+    input_positions: torch.Tensor
 
     # For logging.
     num_input_tokens: int = 0  # Number of tokens including padding.
@@ -261,7 +260,7 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
         else:
             seq_lens_cpu = common_attn_metadata.seq_lens[:num_reqs].to("cpu")
 
-        cos, sin = get_cos_and_sin_mla(input_positions, True)
+        rope_positions = input_positions
 
         dsa_cp_context = None
         if self.enable_dsa_cp:
@@ -273,12 +272,9 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
             local_end_with_pad = local_start + num_tokens_per_device
             local_end = min(local_end_with_pad, num_actual_tokens)
 
-            pad_size = num_tokens_pad - cos.shape[0]
-            assert cos.shape == sin.shape, f"cos.shape must be equal to sin.shape, got {cos.shape} and {sin.shape}"
-
+            pad_size = num_tokens_pad - rope_positions.shape[0]
             if pad_size > 0:
-                cos = nn.functional.pad(cos, (0, 0, 0, 0, 0, 0, 0, pad_size))
-                sin = nn.functional.pad(sin, (0, 0, 0, 0, 0, 0, 0, pad_size))
+                rope_positions = nn.functional.pad(rope_positions, (0, pad_size), value=0)
 
             pad_size_slot = num_tokens_pad - slot_mapping.shape[0]
             if pad_size_slot > 0:
@@ -287,12 +283,11 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
                 slot_mapping = slot_mapping[:num_tokens_pad]
             slot_mapping_cp = slot_mapping[local_start:local_end_with_pad]
 
-            cos = cos[local_start:local_end_with_pad]
-            sin = sin[local_start:local_end_with_pad]
+            rope_positions = rope_positions[local_start:local_end_with_pad]
 
-            assert cos.shape[0] == num_tokens_per_device, (
-                f"cos.shape[0] must be equal to num_tokens_per_device, \
-                    got {cos.shape[0]} and {num_tokens_per_device}"
+            assert rope_positions.shape[0] == num_tokens_per_device, (
+                f"rope_positions.shape[0] must be equal to num_tokens_per_device, \
+                    got {rope_positions.shape[0]} and {num_tokens_per_device}"
             )
             assert slot_mapping_cp.shape[0] == num_tokens_per_device, (
                 f"slot_mapping_cp.shape[0] must be equal to num_tokens_per_device, \
@@ -361,8 +356,7 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
             attn_mask=self.attn_mask_builder.get_attention_mask(common_attn_metadata.causal, self.model_config),
             attn_state=common_attn_metadata.attn_state,
             block_table=block_table,
-            sin=sin[:num_input_tokens],
-            cos=cos[:num_input_tokens],
+            input_positions=rope_positions[:num_input_tokens],
             dsa_cp_context=dsa_cp_context,
             block_size=block_size,
             group_len=group_len,
@@ -772,6 +766,13 @@ class AscendSFAImpl(MLAAttentionImpl):
         x = torch_npu.npu_interleave_rope(x, cos, sin)
         return x.view(B, N, D)
 
+    def _select_sfa_cos_sin(
+        self,
+        positions: torch.Tensor,
+        ref_tensor: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return select_cos_sin_from_cache(self.rotary_emb, positions, ref_tensor, layout="T11D")
+
     def _init_o_proj_tp_full_params(self):
         """
         Initialize TP-mode and Full-mode parameters for o_proj weight,
@@ -1122,8 +1123,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                         reach_layer_for_shard_weight_series(layer)
             return output.fill_(0)
 
-        cos = attn_metadata.cos
-        sin = attn_metadata.sin
+        cos, sin = self._select_sfa_cos_sin(attn_metadata.input_positions, hidden_states)
         slot_mapping = attn_metadata.slot_mapping
         slot_mapping_cp = None
         if self.enable_dsa_cp:

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -15,28 +15,19 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
-from typing import Any
-
 import torch
-import torch.nn.functional as F
 import torch_npu
-from vllm.triton_utils import HAS_TRITON
 
 from vllm_ascend.device.mxfp_compat import (
     FLOAT8_E8M0FNU_DTYPE,
     QUANT_DTYPES,
     SCALE_DTYPES,
 )
+from vllm_ascend.ops.rotary_embedding import select_cos_sin_from_cache
 from vllm_ascend.ops.triton.fla.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd_kernel
 from vllm_ascend.ops.triton.fla.solve_tril import solve_tril_16x16_kernel
 from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
-from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
-
-if HAS_TRITON:
-    from vllm_ascend.ops.triton.rms_norm import triton_q_rms  # noqa: F811
-else:
-    triton_q_rms = None  # type: ignore
 
 
 class BaseDeviceAdaptor:
@@ -130,11 +121,10 @@ class BaseDeviceAdaptor:
         weight_scale: torch.Tensor,
         x_scale: torch.Tensor,
         bias=None,
+        swiglu_limit: int = 0,
         use_mxfp_quant: bool = False,
         act_quant_type: torch.dtype | int = torch.float8_e4m3fn,
         weight_quant_type: torch.dtype | int = torch.float8_e4m3fn,
-        swiglu_limit: float = 0.0,
-        mxfp_quant_dtype: QuantType | None = None,
     ):
         if use_mxfp_quant:
             raise RuntimeError("MXFP MoE quantization is only supported on Ascend A5.")
@@ -186,7 +176,6 @@ class BaseDeviceAdaptor:
         use_mxfp_quant: bool = False,
         bias=None,
         fallback_output_dtype: torch.dtype | None = None,
-        mxfp_quant_dtype: QuantType | None = None,
     ) -> torch.Tensor:
         if use_mxfp_quant:
             raise RuntimeError("MXFP MoE quantization is only supported on Ascend A5.")
@@ -223,9 +212,12 @@ class BaseDeviceAdaptor:
         bsz = attn_metadata.num_decode_tokens
         hidden_states = hidden_states[:bsz]
 
-        cos_shape = attn_metadata.decode.cos.shape
-        cos = attn_metadata.decode.cos.view(cos_shape[0], cos_shape[-1])
-        sin = attn_metadata.decode.sin.view(cos_shape[0], cos_shape[-1])
+        cos, sin = select_cos_sin_from_cache(
+            atten_obj.rotary_emb,
+            attn_metadata.decode.input_positions[:bsz],
+            hidden_states,
+            layout="TD",
+        )
 
         decode_k_nope, decode_k_pe = kv_cache[0], kv_cache[1]
         dequant_scale_q_nope = None
@@ -307,182 +299,7 @@ class BaseDeviceAdaptor:
         )
         return decode_preprocess_res, None
 
-    @staticmethod
-    def sfa_preprocess_with_mlapo(
-        sfa_impl,
-        hidden_states: torch.Tensor,
-        kv_cache: tuple,
-        cos: torch.Tensor,
-        sin: torch.Tensor,
-        slot_mapping: torch.Tensor,
-        num_input_tokens: int,
-    ) -> tuple:
-        k_nope, k_pe = kv_cache[0], kv_cache[1]
-        ql_nope = torch.empty(
-            (num_input_tokens, sfa_impl.W_UK_T.shape[0], k_nope.shape[-1]),
-            dtype=hidden_states.dtype,
-            device=hidden_states.device,
-        )
-        q_pe = torch.empty(
-            (num_input_tokens, sfa_impl.W_UK_T.shape[0], k_pe.shape[-1]),
-            dtype=hidden_states.dtype,
-            device=hidden_states.device,
-        )
-        q_c = torch.empty(
-            (num_input_tokens, sfa_impl.q_lora_rank),
-            dtype=hidden_states.dtype,
-            device=hidden_states.device,
-        )
-        torch.ops._C_ascend.mla_preprocess(
-            hidden_states,
-            sfa_impl.wd_qkv,
-            sfa_impl.deq_scale_qkv,
-            sfa_impl.gamma1,
-            sfa_impl.beta1,
-            sfa_impl.wu_q,
-            sfa_impl.qb_deq_scl,
-            sfa_impl.gamma2,
-            cos,
-            sin,
-            sfa_impl.W_UK_T,
-            k_nope,
-            k_pe,
-            slot_mapping,
-            quant_scale0=sfa_impl.quant_scale0,
-            quant_offset0=sfa_impl.quant_offset0,
-            bias0=sfa_impl.quant_bias_qkv,
-            quant_scale1=sfa_impl.quant_scale1,
-            quant_offset1=sfa_impl.quant_offset1,
-            bias1=sfa_impl.qb_qt_bias,
-            ctkv_scale=sfa_impl.ctkv_scale,
-            q_nope_scale=sfa_impl.q_nope_scale,
-            cache_mode="krope_ctkv",
-            quant_mode="per_tensor_quant_asymm",
-            enable_inner_out=True,
-            q_out0=ql_nope,
-            kv_cache_out0=k_nope,
-            q_out1=q_pe,
-            kv_cache_out1=k_pe,
-            inner_out=q_c,
-        )
-        return hidden_states, ql_nope, q_pe, q_c
-
-    @staticmethod
-    def indexer_select_post_process(
-        sfa_impl,
-        q_li: torch.Tensor,
-        q_li_scale: torch.Tensor | None,
-        q_li_shape_ori: tuple[Any, ...] | None,
-        weights: torch.Tensor,
-        kv_cache: tuple,
-        attn_metadata,
-        actual_seq_lengths_query: torch.Tensor,
-        actual_seq_lengths_key: torch.Tensor,
-        use_sparse_c8_indexer: bool,
-        use_torch_npu_lightning_indexer: bool,
-    ) -> torch.Tensor:
-        # DSV3.2 currently has graph compilation issues when using torch_npu.npu.lightning_indexer.
-        # So two branches are maintained temporarily.
-        # TODO: torch.ops._C_ascend.npu_lightning_indexer needs to be removed.
-        if sfa_impl.use_sparse_c8_indexer:
-            assert len(kv_cache) == 4
-            assert q_li_scale is not None
-            assert q_li_shape_ori is not None
-            weights = weights.to(torch.float16)
-            topk_indices = torch.ops._C_ascend.npu_lightning_indexer_quant(
-                query=q_li.view(q_li_shape_ori),
-                key=kv_cache[2],
-                weights=weights,
-                query_dequant_scale=q_li_scale.view(q_li_shape_ori[:-1]),
-                key_dequant_scale=kv_cache[3].squeeze(2),  # B S N D -> B S D
-                actual_seq_lengths_query=actual_seq_lengths_query,
-                actual_seq_lengths_key=actual_seq_lengths_key,
-                block_table=attn_metadata.block_table,
-                query_quant_mode=0,
-                key_quant_mode=0,
-                layout_query="TND",
-                layout_key="PA_BSND",
-                sparse_count=2048,
-                sparse_mode=3,
-            )
-        elif sfa_impl.use_torch_npu_lightning_indexer:
-            topk_indices, _ = torch_npu.npu_lightning_indexer(
-                query=q_li,
-                key=kv_cache[2],
-                weights=weights,
-                actual_seq_lengths_query=actual_seq_lengths_query,
-                actual_seq_lengths_key=actual_seq_lengths_key,
-                block_table=attn_metadata.block_table,
-                layout_query="TND",
-                layout_key="PA_BSND",
-                sparse_count=2048,
-                sparse_mode=3,
-            )
-        else:
-            topk_indices, _ = torch.ops._C_ascend.npu_lightning_indexer(
-                query=q_li,
-                key=kv_cache[2],
-                weights=weights,
-                actual_seq_lengths_query=actual_seq_lengths_query,
-                actual_seq_lengths_key=actual_seq_lengths_key,
-                block_table=attn_metadata.block_table,
-                layout_query="TND",
-                layout_key="PA_BSND",
-                sparse_count=2048,
-                sparse_mode=3,
-            )
-        return topk_indices
-
-    @staticmethod
-    def execute_sparse_flash_attention_process(
-        sfa_impl,
-        ql_nope: torch.Tensor,
-        q_pe: torch.Tensor,
-        kv_cache: tuple,
-        topk_indices: torch.Tensor,
-        attn_metadata,
-        actual_seq_lengths_query: torch.Tensor,
-        actual_seq_lengths_key: torch.Tensor,
-    ) -> torch.Tensor:
-        block_table = attn_metadata.block_table
-        kv = kv_cache[0]
-        key_rope = kv_cache[1]
-
-        attn_output, _, _ = torch.ops._C_ascend.npu_sparse_flash_attention(
-            query=ql_nope,
-            key=kv,
-            value=kv,
-            sparse_indices=topk_indices,
-            scale_value=sfa_impl.scale,
-            sparse_block_size=1,
-            block_table=block_table,
-            actual_seq_lengths_query=actual_seq_lengths_query,
-            actual_seq_lengths_kv=actual_seq_lengths_key,
-            query_rope=q_pe,
-            key_rope=key_rope,
-            layout_query="TND",
-            layout_kv="PA_BSND",
-            sparse_mode=3,
-            attention_mode=2,
-        )
-        return attn_output
-
-    @staticmethod
     def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):
-        if query.dtype == torch.float32:
-            # _npu_flash_attention_unpad does not support FP32.
-            cumulative_seq_lens = seq_lens_cpu.cumsum(0).tolist()
-            return torch_npu.npu_fusion_attention(
-                query=query,
-                key=key,
-                value=value,
-                actual_seq_qlen=cumulative_seq_lens,
-                actual_seq_kvlen=cumulative_seq_lens,
-                head_num=head_num,
-                scale=scale_value,
-                input_layout="TND",
-            )[0]
-
         context_layer = torch.empty_like(query)
 
         torch_npu._npu_flash_attention_unpad(
@@ -497,289 +314,6 @@ class BaseDeviceAdaptor:
         )
 
         return context_layer
-
-    # ===== Sparse Attention Metadata & Op Selectors =====
-
-    @staticmethod
-    def get_dsa_sparse_attn_metadata_op():
-        """Returns the metadata-building operator for sparse attention."""
-        return torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata
-
-    @staticmethod
-    def get_dsa_sparse_attn_metadata_kwargs(device):
-        """Returns kwargs for sparse attention metadata builder."""
-        return {"device": str(device)}
-
-    @staticmethod
-    def get_dsa_sparse_attn_op():
-        """Returns the sparse attention operator."""
-        return torch.ops._C_ascend.npu_sparse_attn_sharedkv
-
-    @staticmethod
-    def get_dsa_sparse_attn_base_kwargs():
-        """Returns base kwargs for sparse attention (extended by caller)."""
-        return {}
-
-    # ===== SWA / Compressor KV Scatter =====
-
-    @staticmethod
-    def dsa_kv_compress_scatter(cache, x, slot_mapping):
-        """Scatter KV into cache. Non-A5: simple scatter of pre-quantized tensor."""
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(cache, slot_mapping, x)
-
-    # ===== Indexer Quant + Scatter =====
-
-    @staticmethod
-    def indexer_quantize_query(q):
-        """Quantize indexer query for lightning_indexer.
-        Non-A5: int8 quant with float16 scale."""
-        q_quant, q_scale = torch_npu.npu_dynamic_quant(q, dst_type=torch.int8)
-        q_scale = q_scale.to(torch.float16)
-        return q_quant, q_scale
-
-    @staticmethod
-    def indexer_quant_scatter(q, kv, indexer_k_cache, indexer_scale_cache, indexer_full_cache, slot_mapping):
-        """Quantize q and scatter kv into indexer cache.
-        Non-A5: int8 quant + 2x scatter_nd_update_v2 for k_cache and scale_cache."""
-        q, q_scale = torch_npu.npu_dynamic_quant(q, dst_type=torch.int8)
-        q_scale = q_scale.to(torch.float16)
-
-        kv_out = kv
-        kv_scale_out = None
-        if kv is not None:
-            kv_out, kv_scale_out = torch_npu.npu_dynamic_quant(kv, dst_type=torch.int8)
-            kv_scale_out = kv_scale_out.unsqueeze(-1).to(torch.float16)
-            if kv_scale_out.ndim < 4:
-                kv_scale_out = kv_scale_out.unsqueeze(-1)
-            torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_k_cache, slot_mapping, kv_out)
-            torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_scale_cache, slot_mapping, kv_scale_out)
-
-        return q, q_scale, kv_out, kv_scale_out
-
-    @staticmethod
-    def indexer_quant_scatter_part1(kv, indexer_k_cache, indexer_full_cache, slot_mapping):
-        """Part1 of multi-stream indexer scatter.
-        Non-A5: quantize kv + scatter k_cache.
-        Returns (kv_quant, kv_scale) for use in Part3, or (None, None) if kv is None."""
-        if kv is None:
-            return None, None
-        kv_out, kv_scale = torch_npu.npu_dynamic_quant(kv, dst_type=torch.int8)
-        kv_scale = kv_scale.unsqueeze(-1)
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_k_cache, slot_mapping, kv_out)
-        return kv_out, kv_scale
-
-    @staticmethod
-    def dsa_indexer_scatter_scale_part3(kv_scale, indexer_scale_cache, slot_mapping):
-        """Part3 of multi-stream indexer scatter.
-        Non-A5: scatter scale_cache (float16 conversion + scatter)."""
-        kv_scale = kv_scale.to(torch.float16)
-        if kv_scale.ndim < 4:
-            kv_scale = kv_scale.unsqueeze(-1)
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_scale_cache, slot_mapping, kv_scale)
-
-    @staticmethod
-    def warmup_indexer_quant_scatter(hidden_states, slot_mapping):
-        """Warmup profiling for indexer quant+scatter.
-        Non-A5: int8 quant + 2x scatter with dummy cache tensors."""
-        kv_dummy, kv_scale_dummy = torch_npu.npu_dynamic_quant(hidden_states, dst_type=torch.int8)
-        kv_scale_dummy = kv_scale_dummy.unsqueeze(-1).to(torch.float16)
-        if kv_scale_dummy.ndim < 4:
-            kv_scale_dummy = kv_scale_dummy.unsqueeze(-1)
-        dummy_shape = (1, 1, 1, kv_dummy.shape[-1])
-        indexer_k_cache = torch.zeros(dummy_shape, dtype=kv_dummy.dtype, device=hidden_states.device)
-        indexer_scale_cache = torch.zeros(dummy_shape, dtype=torch.float16, device=hidden_states.device)
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_k_cache, slot_mapping, kv_dummy)
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_scale_cache, slot_mapping, kv_scale_dummy)
-
-    # ===== Lightning Indexer Dtype Prep =====
-
-    @staticmethod
-    def prepare_dsa_indexer_weights(weights):
-        """Non-A5: cast indexer weights to float16."""
-        return weights.to(torch.float16)
-
-    @staticmethod
-    def prepare_dsa_indexer_query_scale(q_scale):
-        """Non-A5: q_scale already float16, pass through."""
-        return q_scale
-
-    @staticmethod
-    def prepare_dsa_indexer_key_scale(indexer_scale_cache):
-        """Non-A5: cast key dequant scale to float16."""
-        return indexer_scale_cache.squeeze(-2).to(torch.float16)
-
-    # ===== Q RMS Norm =====
-
-    @staticmethod
-    def apply_dsa_q_rms(q, eps, q_norm_without_weight=None):
-        """Apply Q RMS norm. Non-A5: triton_q_rms.
-        A5: uses q_norm_without_weight callable when provided."""
-        if triton_q_rms is not None:
-            return triton_q_rms(q, eps)
-        else:
-            dtype = q.dtype
-            q = q.float()
-            variance = q.square().mean(-1, keepdim=True)
-            q = q * torch.rsqrt(variance + eps)
-            return q.to(dtype)
-
-    # ===== KV Cache Helpers =====
-
-    @staticmethod
-    def unpack_dsa_indexer_kv_cache(kv_cache):
-        """Unpack indexer kv_cache tuple.
-        Non-A5: returns (state_cache, k_cache, scale_cache, None).
-        A5: returns (state_cache, k_cache, scale_cache, full_cache)."""
-        _, _, _, indexer_state_cache, indexer_k_cache, indexer_scale_cache = kv_cache
-        return indexer_state_cache, indexer_k_cache, indexer_scale_cache, None
-
-    @staticmethod
-    def unpack_dsa_forward_kv_cache(kv_cache, compress_ratio):
-        """Unpack kv_cache for forward pass.
-        Returns 6-tuple: (compress_kv_cache, swa_kv_cache, state_cache,
-        indexer_k_cache, indexer_scale_cache, indexer_full_cache).
-        Non-A5: indexer_full_cache is always None.
-        All devices: unused slots are None.
-        """
-        idx_full = 6  # 7th element (indexer_full_cache), A5 only
-        full_cache = kv_cache[idx_full] if len(kv_cache) > idx_full else None
-        if compress_ratio == 4:
-            # [0]=compress, [1]=swa, [2]=state, [3]=unused, [4]=ik, [5]=isc
-            return (kv_cache[0], kv_cache[1], kv_cache[2], kv_cache[4], kv_cache[5], full_cache)
-        elif compress_ratio == 128:
-            return (kv_cache[0], kv_cache[1], kv_cache[2], None, None, full_cache)
-        else:
-            return (None, kv_cache[1], None, None, None, full_cache)
-
-    @staticmethod
-    def pad_dsa_decode_slot_mapping(slot_mapping, num_decode_tokens, compress_ratio, num_decodes):
-        """Pad slot_mapping for decode metadata. Non-A5: pass through."""
-        return slot_mapping
-
-    @staticmethod
-    def format_dsa_slot_mapping(slot_mapping, block_size):
-        """Format slot_mapping for metadata storage.
-        Non-A5: 2D [block_idx, offset]; A5: 1D pass-through."""
-        return torch.stack([slot_mapping // block_size, slot_mapping % block_size], axis=-1)
-
-    @staticmethod
-    def get_dsa_decode_cu_seqlens_cmp_kv(cmp_kv_tensor):
-        """Non-A5: return the cached cu_seqlens_cmp_kv tensor.
-        A5 override always returns None."""
-        return cmp_kv_tensor
-
-    @staticmethod
-    def add_dsa_sparse_attn_extra_kwargs(extra_kwargs, **kwargs_to_add):
-        """Non-A5: add extra kwargs for sparse attention. A5: no-op."""
-        extra_kwargs.update(kwargs_to_add)
-
-    @staticmethod
-    def get_dsa_decode_cu_seqlens_ori_kv(
-        decode_ratio_to_sas_metadata, cache_key, seq_lens, num_decodes, zero_i32, fallback_cu_seqlens
-    ):
-        """Non-A5: return fallback directly (self.cu_seqlens_ori_kv)."""
-        return fallback_cu_seqlens
-
-    @staticmethod
-    def get_dsa_kernel_block_sizes():
-        """Non-A5: return supported kernel block sizes."""
-        return [8, 32, 128]
-
-    @staticmethod
-    def chunk_scaled_dot_kkt_fwd(
-        num_core, bh_step, task_num, k, beta, g_cumsum, A, cu_seqlens, chunk_indices, T, B, H, Hg, K, BT, BK
-    ):
-        chunk_scaled_dot_kkt_fwd_kernel[(num_core,)](
-            k=k,
-            beta=beta,
-            g_cumsum=g_cumsum,
-            A=A,
-            cu_seqlens=cu_seqlens,
-            chunk_indices=chunk_indices,
-            T=T,
-            B=B,
-            H=H,
-            Hg=Hg,
-            K=K,
-            BT=BT,
-            BK=BK,
-            bh_step=bh_step,
-            task_num=task_num,
-            num_core=num_core,
-            num_warps=8,
-            num_stages=3,
-            multibuffer=True,
-        )
-
-        return A
-
-    @staticmethod
-    def solve_tril_16x16(
-        A,
-        Ad,
-        cu_seqlens,
-        chunk_indices,
-        T,
-        H,
-        BT,
-        LARGE_BLOCK_T,
-        NT,
-        B,
-    ):
-        extract_slice_stride_1 = LARGE_BLOCK_T // 32
-        solve_tril_16x16_kernel[NT, B * H](
-            A=A,
-            Ad=Ad,
-            cu_seqlens=cu_seqlens,
-            chunk_indices=chunk_indices,
-            T=T,
-            H=H,
-            BT=BT,
-            LARGE_BLOCK_T=LARGE_BLOCK_T,
-            EXTRACT_SLICE_STRIDE_1=extract_slice_stride_1,
-            num_warps=1,
-            num_stages=4,
-        )
-
-        return Ad
-
-    @staticmethod
-    def npu_gemma_rms_norm(x, weight, variance_epsilon):
-        x, _ = torch.ops._C_ascend.npu_gemma_rms_norm(x, weight, variance_epsilon)
-        return x
-
-    @staticmethod
-    def fused_gdn_gating(A_log: torch.Tensor, a: torch.Tensor, b: torch.Tensor, dt_bias: torch.Tensor):
-        return torch.ops._C_ascend.npu_fused_gdn_gating(A_log, a, b, dt_bias.to(torch.float32))
-
-    @staticmethod
-    def split_qkv_rmsnorm_rope(
-        input,
-        q_weight,
-        k_weight,
-        q_hidden_size,
-        kv_hidden_size,
-        head_dim,
-        eps,
-        q_bias,
-        k_bias,
-        cos_sin_cache,
-        positions,
-    ):
-        results = torch.ops.vllm.qkv_rmsnorm_rope(
-            input=input,
-            q_weight=q_weight,
-            k_weight=k_weight,
-            q_hidden_size=q_hidden_size,
-            kv_hidden_size=kv_hidden_size,
-            head_dim=head_dim,
-            eps=eps,
-            q_bias=q_bias,
-            k_bias=k_bias,
-            cos_sin_cache=cos_sin_cache,
-            positions=positions,
-        )
-        return results
 
 
 class A5DeviceAdaptor(BaseDeviceAdaptor):
@@ -889,11 +423,10 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         weight_scale: torch.Tensor,
         x_scale: torch.Tensor,
         bias=None,
+        swiglu_limit: int = 0,
         use_mxfp_quant: bool = False,
         act_quant_type: torch.dtype | int = torch.float8_e4m3fn,
         weight_quant_type: torch.dtype | int = torch.float8_e4m3fn,
-        swiglu_limit: float = 0.0,
-        mxfp_quant_dtype: QuantType | None = None,
     ):
         if not use_mxfp_quant:
             return torch_npu.npu_grouped_matmul_swiglu_quant_v2(
@@ -907,48 +440,21 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
                 use_mxfp_quant=False,
             )
 
-        # W4A8 mxfp
-        if mxfp_quant_dtype == QuantType.W4A8MXFP:
-            hidden_states = torch_npu.npu_grouped_matmul(
-                x=[x],
-                weight=[weight],
-                scale=None,
-                antiquant_scale=[weight_scale],
-                scale_dtype=None,
-                per_token_scale=[x_scale],
-                per_token_scale_dtype=torch.float8_e8m0fnu,
-                split_item=2,
-                group_type=0,
-                group_list=group_list,
-                x_dtype=torch.float8_e4m3fn,
-                weight_dtype=torch_npu.float4_e2m1fn_x2,
-                output_dtype=torch.bfloat16,
-            )[0]
-            # DSV4 need swiglu_limit input
-            out, out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
-                hidden_states,
-                topk_weight=None,
-                group_index=None,
-                dst_type=torch.float8_e4m3fn,
-                quant_mode=2,
-                clamp_value=swiglu_limit,
-            )
-        else:
-            out, out_scale = torch_npu.npu_grouped_matmul_swiglu_quant_v2(
-                x=x,
-                weight=[weight],
-                group_list=group_list,
-                weight_scale=[weight_scale],
-                x_scale=x_scale,
-                dequant_mode=2,
-                quant_mode=2,
-                dequant_dtype=torch.float32,
-                quant_dtype=act_quant_type,
-                x_dtype=act_quant_type if act_quant_type in QUANT_DTYPES else None,
-                weight_dtype=weight_quant_type if weight_quant_type in QUANT_DTYPES else None,
-                weight_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
-                x_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
-            )
+        out, out_scale = torch_npu.npu_grouped_matmul_swiglu_quant_v2(
+            x=x,
+            weight=[weight],
+            group_list=group_list,
+            weight_scale=[weight_scale],
+            x_scale=x_scale,
+            dequant_mode=2,
+            quant_mode=2,
+            dequant_dtype=torch.float32,
+            quant_dtype=act_quant_type,
+            x_dtype=act_quant_type if act_quant_type in QUANT_DTYPES else None,
+            weight_dtype=weight_quant_type if weight_quant_type in QUANT_DTYPES else None,
+            weight_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+            x_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+        )
         return out, A5DeviceAdaptor.maybe_normalize_mxfp_scale_layout(out_scale), None
 
     @staticmethod
@@ -1006,7 +512,6 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         use_mxfp_quant: bool = False,
         bias=None,
         fallback_output_dtype: torch.dtype | None = None,
-        mxfp_quant_dtype: QuantType | None = None,
     ) -> torch.Tensor:
         if not use_mxfp_quant:
             return BaseDeviceAdaptor.npu_grouped_matmul_gmm2(
@@ -1031,7 +536,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             input_dtype=input_dtype,
             act_quant_type=act_quant_type,
             weight_quant_type=weight_quant_type,
-            scale_type=scale_type if mxfp_quant_dtype != QuantType.W4A8MXFP else None,
+            scale_type=scale_type,
             per_token_scale_type=per_token_scale_type,
             use_bf16=use_bf16,
             use_mxfp_quant=True,
@@ -1044,14 +549,6 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             raise ValueError(f"w2_scale must have a single tensor in MXFP path, but got {len(weight_scale)}.")
         gmm2_weight = weight if isinstance(weight, list) else [weight]
         gmm2_scale = weight_scale if isinstance(weight_scale, list) else [weight_scale]
-
-        if mxfp_quant_dtype == QuantType.W4A8MXFP:
-            gmm2_scale = None  # type: ignore[assignment]
-            gmm2_kwargs.update({"antiquant_scale": [weight_scale]})
-
-        if mxfp_quant_dtype == QuantType.W4A8MXFP:
-            gmm2_scale = None  # type: ignore[assignment]
-            gmm2_kwargs.update({"antiquant_scale": [weight_scale]})
 
         return torch_npu.npu_grouped_matmul(
             x=[hidden_states],
@@ -1082,12 +579,18 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
     @staticmethod
     def mla_preprocess_only_decode(atten_obj, hidden_states, kv_cache, attn_metadata):
         bsz = attn_metadata.num_decode_tokens
-        hidden_states = hidden_states[:bsz].unsqueeze(1)
+        hidden_states = hidden_states[:bsz]
+        cos, sin = select_cos_sin_from_cache(
+            atten_obj.rotary_emb,
+            attn_metadata.decode.input_positions[:bsz],
+            hidden_states,
+            layout="T11D",
+        )
+        cos = cos.view(cos.shape[0], 1, cos.shape[-1])
+        sin = sin.view(sin.shape[0], 1, sin.shape[-1])
+        hidden_states = hidden_states.unsqueeze(1)
         hidden_states, dynamic_scale = torch_npu.npu_dynamic_mx_quant(hidden_states, dst_type=torch.float8_e4m3fn)
         dynamic_scale = dynamic_scale.reshape(hidden_states.shape[0] * hidden_states.shape[1], -1)
-        cos_shape = attn_metadata.decode.cos.shape
-        cos = attn_metadata.decode.cos.view(cos_shape[0], 1, cos_shape[-1])
-        sin = attn_metadata.decode.sin.view(cos_shape[0], 1, cos_shape[-1])
         decode_k_nope, decode_k_pe = kv_cache[0], kv_cache[1]
         decode_q_nope, decode_q_pe, dequant_scale_q_nope, _, _ = torch_npu.npu_mla_prolog_v3(
             token_x=hidden_states,
@@ -1123,541 +626,21 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         )
         return decode_preprocess_res, None
 
-    # ===== Sparse Attention Metadata & Op Selectors =====
-
-    @staticmethod
-    def get_dsa_sparse_attn_metadata_op():
-        return torch.ops._C_ascend.npu_kv_quant_sparse_attn_sharedkv_metadata
-
-    @staticmethod
-    def get_dsa_sparse_attn_metadata_kwargs(device):
-        return {"kv_quant_mode": 1}
-
-    @staticmethod
-    def get_dsa_sparse_attn_op():
-        return torch.ops._C_ascend.npu_kv_quant_sparse_attn_sharedkv
-
-    @staticmethod
-    def get_dsa_sparse_attn_base_kwargs():
-        return {"kv_quant_mode": 1, "tile_size": 64, "rope_head_dim": 64}
-
-    # ===== SWA / Compressor KV Scatter =====
-
-    @staticmethod
-    def dsa_kv_compress_scatter(cache, x, slot_mapping):
-        """Scatter KV into cache with fused quantization+compression.
-        A5: kv_compress_epilog handles quant/compress/scatter internally.
-        Input x is unquantized bf16; cache shape is [..., head_dim]."""
-        torch.ops._C_ascend.kv_compress_epilog(
-            kv_compress_cache=cache.view(-1, 1, cache.shape[-1]),
-            x=x.view(-1, x.shape[-1]),
-            slot_mapping=slot_mapping,
-            quant_group_size=64,
-            quant_mode=2,
-            round_scale_flag=True,
-            layout=1,
-        )
-
-    # ===== Indexer Quant + Scatter =====
-
-    @staticmethod
-    def indexer_quantize_query(q):
-        """Quantize indexer query. A5: fp8 quant, no extra scale conversion."""
-        q_quant, q_scale = torch_npu.npu_dynamic_quant(q, dst_type=torch.float8_e4m3fn)
-        return q_quant, q_scale
-
-    @staticmethod
-    def indexer_quant_scatter(q, kv, indexer_k_cache, indexer_scale_cache, indexer_full_cache, slot_mapping):
-        """Quantize q (fp8) and scatter kv via fused indexer_compress_epilog_v2.
-        On A5, the fused op handles kv quantization, k_cache scatter, and
-        scale_cache scatter internally. q is quantized separately for use
-        by lightning_indexer."""
-        q, q_scale = torch_npu.npu_dynamic_quant(q, dst_type=torch.float8_e4m3fn)
-
-        kv_out = kv
-        kv_scale_out = None
-        if kv is not None:
-            torch.ops._C_ascend.indexer_compress_epilog_v2(
-                indexer_compress_cache=indexer_full_cache.view(torch.uint8),
-                x=kv,
-                slot_mapping=slot_mapping,
-                layout=2,
-            )
-
-        return q, q_scale, kv_out, kv_scale_out
-
-    @staticmethod
-    def indexer_quant_scatter_part1(kv, indexer_k_cache, indexer_full_cache, slot_mapping):
-        """Part1 of multi-stream indexer scatter.
-        A5: fused indexer_compress_epilog_v2 handles both k_cache and scale_cache.
-        Returns (kv, None) to signal Part3 is a no-op."""
-        if kv is None:
-            return None, None
-        torch.ops._C_ascend.indexer_compress_epilog_v2(
-            indexer_compress_cache=indexer_full_cache.view(torch.uint8),
-            x=kv,
-            slot_mapping=slot_mapping,
-            layout=2,
-        )
-        return kv, None
-
-    @staticmethod
-    def dsa_indexer_scatter_scale_part3(kv_scale, indexer_scale_cache, slot_mapping):
-        """Part3 of multi-stream indexer scatter.
-        A5: no-op — fused op in Part1 already handled scale_cache."""
-        pass
-
-    @staticmethod
-    def warmup_indexer_quant_scatter(hidden_states, slot_mapping):
-        """Warmup profiling for indexer quant+scatter.
-        A5: fused indexer_compress_epilog_v2 with dummy cache tensor."""
-        dummy_cache_shape = (1, 1, 1, hidden_states.shape[-1])
-        indexer_full_cache_dummy = torch.zeros(dummy_cache_shape, dtype=torch.uint8, device=hidden_states.device)
-        torch.ops._C_ascend.indexer_compress_epilog_v2(
-            indexer_compress_cache=indexer_full_cache_dummy,
-            x=hidden_states,
-            slot_mapping=slot_mapping,
-            layout=2,
-        )
-
-    # ===== Lightning Indexer Dtype Prep =====
-
-    @staticmethod
-    def prepare_dsa_indexer_weights(weights):
-        """A5: cast indexer weights to float32 (fp8 scale format needs float)."""
-        return weights.float()
-
-    @staticmethod
-    def prepare_dsa_indexer_query_scale(q_scale):
-        """A5: cast query dequant scale to float32."""
-        return q_scale.float()
-
-    @staticmethod
-    def prepare_dsa_indexer_key_scale(indexer_scale_cache):
-        """A5: cast key dequant scale to float32."""
-        return indexer_scale_cache.squeeze(-2).float()
-
-    # ===== Q RMS Norm =====
-
-    @staticmethod
-    def apply_dsa_q_rms(q, eps, q_norm_without_weight=None):
-        """Apply Q RMS norm. A5: uses q_norm_without_weight callable."""
-        if q_norm_without_weight is not None:
-            return q_norm_without_weight(q)
-
-        if triton_q_rms is not None:
-            return triton_q_rms(q, eps)
-        else:
-            dtype = q.dtype
-            q = q.float()
-            variance = q.square().mean(-1, keepdim=True)
-            q = q * torch.rsqrt(variance + eps)
-            return q.to(dtype)
-
-    # ===== KV Cache Helpers =====
-
-    @staticmethod
-    def unpack_dsa_indexer_kv_cache(kv_cache):
-        """Unpack indexer kv_cache tuple.
-        A5: returns (state_cache, k_cache, scale_cache, full_cache)."""
-        _, _, _, indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache = kv_cache
-        return indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache
-
-    @staticmethod
-    def unpack_dsa_forward_kv_cache(kv_cache, compress_ratio):
-        """Unpack kv_cache for forward pass. A5: 7-element tuple with
-        indexer_full_cache at position 6; non-A5: 6 elements (None substituted)."""
-        idx_full = 6
-        full_cache = kv_cache[idx_full]
-        if compress_ratio == 4:
-            return (kv_cache[0], kv_cache[1], kv_cache[2], kv_cache[4], kv_cache[5], full_cache)
-        elif compress_ratio == 128:
-            return (kv_cache[0], kv_cache[1], kv_cache[2], None, None, full_cache)
-        else:
-            return (None, kv_cache[1], None, None, None, full_cache)
-
-    @staticmethod
-    def pad_dsa_decode_slot_mapping(slot_mapping, num_decode_tokens, compress_ratio, num_decodes):
-        """A5: pad slot_mapping to target shape for ACL graph compatibility."""
-        tmp = compress_ratio if compress_ratio != 0 else 1
-        target_shape = min(num_decode_tokens, num_decode_tokens // tmp + num_decodes)
-        pad_size = target_shape - slot_mapping.shape[0]
-        if pad_size > 0:
-            if slot_mapping.ndim == 1:
-                slot_mapping = F.pad(slot_mapping, (0, pad_size), value=-1)
-            else:
-                slot_mapping = F.pad(slot_mapping, (0, 0, 0, pad_size), value=-1)
-        else:
-            slot_mapping = slot_mapping[:target_shape]
-        return slot_mapping
-
-    @staticmethod
-    def format_dsa_slot_mapping(slot_mapping, block_size):
-        """A5: 1D pass-through."""
-        return slot_mapping
-
-    @staticmethod
-    def get_dsa_decode_cu_seqlens_cmp_kv(cmp_kv_tensor):
-        """A5: cu_seqlens_cmp_kv is always None."""
-        return None
-
-    @staticmethod
-    def add_dsa_sparse_attn_extra_kwargs(extra_kwargs, **kwargs_to_add):
-        """A5: no-op — A5 ops do not need extra kwargs from this path."""
-        pass
-
-    @staticmethod
-    def get_dsa_decode_cu_seqlens_ori_kv(
-        decode_ratio_to_sas_metadata, cache_key, seq_lens, num_decodes, zero_i32, fallback_cu_seqlens
-    ):
-        """A5: compute from cumsum of seq_lens, with caching."""
-        if decode_ratio_to_sas_metadata is not None and cache_key in decode_ratio_to_sas_metadata:
-            return decode_ratio_to_sas_metadata[cache_key]
-        cu_seqlens = torch.cat(
-            [
-                zero_i32,
-                torch.cumsum(seq_lens[:num_decodes], dim=0).to(torch.int32),
-            ]
-        )
-        if decode_ratio_to_sas_metadata is not None:
-            decode_ratio_to_sas_metadata[cache_key] = cu_seqlens
-        return cu_seqlens
-
-    @staticmethod
-    def get_dsa_kernel_block_sizes():
-        """A5: return supported kernel block sizes."""
-        return [8, 16, 128]
-
-    @staticmethod
-    def sfa_preprocess_with_mlapo(
-        sfa_impl,
-        hidden_states: torch.Tensor,
-        kv_cache: tuple,
-        cos: torch.Tensor,
-        sin: torch.Tensor,
-        slot_mapping: torch.Tensor,
-        num_input_tokens: int,
-    ) -> tuple:
-        bsz = num_input_tokens
-        slot_mapping = slot_mapping[:bsz]
-        hidden_states_temp = hidden_states[:bsz].unsqueeze(1)
-        cos = cos[:bsz, ...]
-        sin = sin[:bsz, ...]
-
-        is_quantized = getattr(sfa_impl, "mlapo_is_quantized", True)
-
-        cos_shape = cos.shape
-        cos = cos.view(cos_shape[0], 1, cos_shape[-1])
-        sin = sin.view(cos_shape[0], 1, cos_shape[-1])
-
-        decode_k_nope = kv_cache[0]
-        use_c8 = getattr(sfa_impl, "use_sparse_c8_indexer", False)
-        kr_cache = (
-            torch.zeros(0, 0, decode_k_nope.shape[-2], cos_shape[-1], dtype=torch.bfloat16, device=decode_k_nope.device)
-            if use_c8
-            else kv_cache[1]
-        )
-
-        if is_quantized:
-            hidden_states_temp, dynamic_scale = torch_npu.npu_dynamic_mx_quant(
-                hidden_states_temp, dst_type=torch.float8_e4m3fn
-            )
-            dynamic_scale = dynamic_scale.reshape(hidden_states_temp.shape[0] * hidden_states_temp.shape[1], -1)
-
-            decode_q_nope, q_pe, _, q_c, q_c_scale = torch_npu.npu_mla_prolog_v3(
-                token_x=hidden_states_temp,
-                weight_dq=sfa_impl.weight_dq,
-                weight_uq_qr=sfa_impl.weight_uq_qr,
-                weight_uk=sfa_impl.W_UK_T,
-                weight_dkv_kr=sfa_impl.weight_dkv_kr,
-                rmsnorm_gamma_cq=sfa_impl.q_a_layernorm.weight.data,
-                rmsnorm_gamma_ckv=sfa_impl.kv_a_layernorm.weight.data,
-                rope_sin=sin,
-                rope_cos=cos,
-                kv_cache=decode_k_nope,
-                kr_cache=kr_cache,
-                cache_index=slot_mapping[:bsz].view(bsz, -1).to(torch.int64),
-                dequant_scale_x=dynamic_scale.view(torch.float8_e8m0fnu),
-                dequant_scale_w_dq=sfa_impl.weight_dq_scale.view(torch.float8_e8m0fnu),
-                dequant_scale_w_uq_qr=sfa_impl.weight_uq_qr_scale.view(torch.float8_e8m0fnu),
-                dequant_scale_w_dkv_kr=sfa_impl.weight_dkv_kr_scale.view(torch.float8_e8m0fnu),
-                cache_mode="PA_BSND",
-                weight_quant_mode=3,
-                kv_cache_quant_mode=3 if use_c8 else 0,
-                query_quant_mode=0,
-                ckvkr_repo_mode=1 if use_c8 else 0,
-                quant_scale_repo_mode=1 if use_c8 else 0,
-                query_norm_flag=True,
-            )
-
-            decode_q_nope = decode_q_nope.view(bsz, sfa_impl.num_heads, sfa_impl.kv_lora_rank)
-            q_pe = q_pe.view(bsz, sfa_impl.num_heads, -1)
-            q_c = q_c.view(-1, q_c.shape[-1])
-            q_c_scale = q_c_scale.view(-1, q_c_scale.shape[-1])
-            return hidden_states, decode_q_nope, q_pe, (q_c, q_c_scale)
-        else:
-            decode_q_nope, q_pe, _, q_c, _ = torch_npu.npu_mla_prolog_v3(
-                token_x=hidden_states_temp,
-                weight_dq=sfa_impl.weight_dq,
-                weight_uq_qr=sfa_impl.weight_uq_qr,
-                weight_uk=sfa_impl.W_UK_T,
-                weight_dkv_kr=sfa_impl.weight_dkv_kr,
-                rmsnorm_gamma_cq=sfa_impl.q_a_layernorm.weight.data,
-                rmsnorm_gamma_ckv=sfa_impl.kv_a_layernorm.weight.data,
-                rope_sin=sin,
-                rope_cos=cos,
-                kv_cache=decode_k_nope,
-                kr_cache=kr_cache,
-                cache_index=slot_mapping[:bsz].view(bsz, -1).to(torch.int64),
-                cache_mode="PA_BSND",
-                weight_quant_mode=0,
-                kv_cache_quant_mode=0,
-                query_quant_mode=0,
-                ckvkr_repo_mode=0,
-                quant_scale_repo_mode=0,
-                query_norm_flag=True,
-            )
-
-            decode_q_nope = decode_q_nope.view(bsz, sfa_impl.num_heads, sfa_impl.kv_lora_rank)
-            q_pe = q_pe.view(bsz, sfa_impl.num_heads, -1)
-            q_c = q_c.view(-1, q_c.shape[-1])
-            return hidden_states, decode_q_nope, q_pe, q_c
-
-    @staticmethod
-    def indexer_select_post_process(
-        sfa_impl,
-        q_li: torch.Tensor,
-        q_li_scale: torch.Tensor | None,
-        q_li_shape_ori: tuple[Any, ...] | None,
-        weights: torch.Tensor,
-        kv_cache: tuple,
-        attn_metadata,
-        actual_seq_lengths_query: torch.Tensor,
-        actual_seq_lengths_key: torch.Tensor,
-        use_sparse_c8_indexer: bool,
-        use_torch_npu_lightning_indexer: bool,
-    ) -> torch.Tensor:
-        if use_sparse_c8_indexer:
-            assert len(kv_cache) == 3
-            assert q_li_shape_ori is not None
-
-            if q_li_scale is not None:
-                q_li_scale = q_li_scale.view(q_li_shape_ori[:-1])
-                key_dequant_scale = kv_cache[2].squeeze(2)
-
-                topk_indices = torch_npu.npu_quant_lightning_indexer(
-                    query=q_li.view(q_li_shape_ori),
-                    key=kv_cache[1],
-                    weights=weights,
-                    query_dequant_scale=q_li_scale,
-                    key_dequant_scale=key_dequant_scale,
-                    actual_seq_lengths_query=actual_seq_lengths_query,
-                    actual_seq_lengths_key=actual_seq_lengths_key,
-                    block_table=attn_metadata.block_table,
-                    query_quant_mode=0,
-                    key_quant_mode=0,
-                    layout_query="TND",
-                    layout_key="PA_BSND",
-                    sparse_count=2048,
-                    sparse_mode=3,
-                )
-            else:
-                topk_indices, _ = torch_npu.npu_lightning_indexer(
-                    query=q_li.view(q_li_shape_ori),
-                    key=kv_cache[1],
-                    weights=weights,
-                    actual_seq_lengths_query=actual_seq_lengths_query,
-                    actual_seq_lengths_key=actual_seq_lengths_key,
-                    block_table=attn_metadata.block_table,
-                    layout_query="TND",
-                    layout_key="PA_BSND",
-                    sparse_count=2048,
-                    sparse_mode=3,
-                )
-        else:
-            topk_indices, _ = torch_npu.npu_lightning_indexer(
-                query=q_li,
-                key=kv_cache[2],
-                weights=weights,
-                actual_seq_lengths_query=actual_seq_lengths_query,
-                actual_seq_lengths_key=actual_seq_lengths_key,
-                block_table=attn_metadata.block_table,
-                layout_query="TND",
-                layout_key="PA_BSND",
-                sparse_count=2048,
-                sparse_mode=3,
-            )
-        return topk_indices
-
-    @staticmethod
-    def execute_sparse_flash_attention_process(
-        sfa_impl,
-        ql_nope: torch.Tensor,
-        q_pe: torch.Tensor,
-        kv_cache: tuple,
-        topk_indices: torch.Tensor,
-        attn_metadata,
-        actual_seq_lengths_query: torch.Tensor,
-        actual_seq_lengths_key: torch.Tensor,
-    ) -> torch.Tensor:
-        block_table = attn_metadata.block_table
-        kv = kv_cache[0]
-        key_rope = kv_cache[1]
-
-        if kv.dtype in [torch.float8_e4m3fn, torch.float8_e5m2]:
-            query = torch.cat([ql_nope, q_pe], dim=-1)
-
-            attn_output = torch_npu.npu_kv_quant_sparse_flash_attention(
-                query=query,
-                key=kv,
-                value=kv,
-                sparse_indices=topk_indices,
-                scale_value=sfa_impl.scale,
-                sparse_block_size=1,
-                block_table=block_table,
-                actual_seq_lengths_query=actual_seq_lengths_query,
-                actual_seq_lengths_kv=actual_seq_lengths_key,
-                layout_query="TND",
-                layout_kv="PA_BSND",
-                sparse_mode=3,
-                attention_mode=2,
-                quant_scale_repo_mode=1,
-                tile_size=128,
-                key_quant_mode=2,
-                value_quant_mode=2,
-                rope_head_dim=64,
-            )
-        else:
-            attn_output, _, _ = torch_npu.npu_sparse_flash_attention(
-                query=ql_nope,
-                key=kv,
-                value=kv,
-                sparse_indices=topk_indices,
-                scale_value=sfa_impl.scale,
-                sparse_block_size=1,
-                block_table=block_table,
-                actual_seq_lengths_query=actual_seq_lengths_query,
-                actual_seq_lengths_kv=actual_seq_lengths_key,
-                query_rope=q_pe,
-                key_rope=key_rope,
-                layout_query="TND",
-                layout_kv="PA_BSND",
-                sparse_mode=3,
-                attention_mode=2,
-            )
-        return attn_output
-
-    @staticmethod
     def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):
-        cumulative_seq_lens = seq_lens_cpu.cumsum(0).tolist()
+        seq_lens_cpu = list(seq_lens_cpu.cumsum(0))
 
         context_layer = torch_npu.npu_fusion_attention(
             query=query,
             key=key,
             value=value,
-            actual_seq_qlen=cumulative_seq_lens,
-            actual_seq_kvlen=cumulative_seq_lens,
+            actual_seq_qlen=seq_lens_cpu,
+            actual_seq_kvlen=seq_lens_cpu,
             head_num=head_num,
             scale=scale_value,
             input_layout="TND",
         )[0]
 
         return context_layer
-
-    @staticmethod
-    def chunk_scaled_dot_kkt_fwd(
-        num_core, bh_step, task_num, k, beta, g_cumsum, A, cu_seqlens, chunk_indices, T, B, H, Hg, K, BT, BK
-    ):
-        chunk_scaled_dot_kkt_fwd_kernel[(num_core,)](
-            k=k,
-            beta=beta,
-            g_cumsum=g_cumsum,
-            A=A,
-            cu_seqlens=cu_seqlens,
-            chunk_indices=chunk_indices,
-            T=T,
-            B=B,
-            H=H,
-            Hg=Hg,
-            K=K,
-            BT=BT,
-            BK=BK,
-            bh_step=bh_step,
-            task_num=task_num,
-            num_core=num_core,
-            num_warps=8,
-            num_stages=3,
-            multibuffer=True,
-            disable_tightly_coupled_buffer_reuse=True,
-        )
-        return A
-
-    @staticmethod
-    def solve_tril_16x16(
-        A,
-        Ad,
-        cu_seqlens,
-        chunk_indices,
-        T,
-        H,
-        BT,
-        LARGE_BLOCK_T,
-        NT,
-        B,
-    ):
-        solve_tril_16x16_kernel[NT, B * H](
-            A=A,
-            Ad=Ad,
-            cu_seqlens=cu_seqlens,
-            chunk_indices=chunk_indices,
-            T=T,
-            H=H,
-            BT=BT,
-            LARGE_BLOCK_T=LARGE_BLOCK_T,
-            EXTRACT_SLICE_STRIDE_1=1,
-            num_warps=1,
-            num_stages=4,
-        )
-
-        return Ad
-
-    @staticmethod
-    def npu_gemma_rms_norm(x, weight, variance_epsilon):
-        x, _ = torch_npu.npu_rms_norm(x, 1.0 + weight, variance_epsilon)
-        return x
-
-    @staticmethod
-    def fused_gdn_gating(A_log: torch.Tensor, a: torch.Tensor, b: torch.Tensor, dt_bias: torch.Tensor):
-        return fused_gdn_gating_patch(A_log, a, b, dt_bias)
-
-    @staticmethod
-    def split_qkv_rmsnorm_rope(
-        input,
-        q_weight,
-        k_weight,
-        q_hidden_size,
-        kv_hidden_size,
-        head_dim,
-        eps,
-        q_bias,
-        k_bias,
-        cos_sin_cache,
-        positions,
-    ):
-        results = torch.ops.vllm.qkv_rmsnorm_rope_simt(
-            input=input,
-            q_weight=q_weight,
-            k_weight=k_weight,
-            q_hidden_size=q_hidden_size,
-            kv_hidden_size=kv_hidden_size,
-            head_dim=head_dim,
-            eps=eps,
-            q_bias=q_bias,
-            k_bias=k_bias,
-            cos_sin_cache=cos_sin_cache,
-            positions=positions,
-        )
-        return results
 
 
 def get_device_adaptor() -> type["BaseDeviceAdaptor"]:

--- a/vllm_ascend/ops/rope_dsv4.py
+++ b/vllm_ascend/ops/rope_dsv4.py
@@ -19,7 +19,9 @@ class RopeGlobalState:
 _ROPE_STATE = RopeGlobalState()
 
 
-class RopeDataProxy:
+class DSARopeDataProxy:
+    """Lazy per-layer view over DSA RoPE tensors materialized at the op boundary."""
+
     def __init__(self, data_map, is_cos=True):
         self._data = data_map
         self.idx = 0 if is_cos else 1
@@ -34,7 +36,7 @@ class RopeDataProxy:
                     s_val = item[1][index]
                     new_map[config_k][group_name] = (c_val, s_val)
 
-            return RopeDataProxy(new_map, is_cos=(self.idx == 0))
+            return DSARopeDataProxy(new_map, is_cos=(self.idx == 0))
 
         else:
             layername = index
@@ -58,7 +60,8 @@ class RopeDataProxy:
             return layer_result
 
 
-def get_cos_and_sin_dsa(positions: torch.Tensor | dict[str, torch.Tensor], use_cache: bool = False):
+def materialize_dsa_cos_sin(positions: torch.Tensor | dict[str, torch.Tensor], use_cache: bool = False):
+    """Materialize DSA cos/sin only where legacy DSA kernels still require tensors."""
     if isinstance(positions, torch.Tensor):
         pos_map = {"default": positions}
     else:
@@ -96,7 +99,7 @@ def get_cos_and_sin_dsa(positions: torch.Tensor | dict[str, torch.Tensor], use_c
             else:
                 batch_result[config_key][group_name] = (curr_cos, curr_sin)
 
-    return RopeDataProxy(batch_result, is_cos=True), RopeDataProxy(batch_result, is_cos=False)
+    return DSARopeDataProxy(batch_result, is_cos=True), DSARopeDataProxy(batch_result, is_cos=False)
 
 
 class ComplexExpRotaryEmbedding(nn.Module):

--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -32,122 +32,65 @@ from vllm.triton_utils import HAS_TRITON
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.platform import NPUPlatform
-from vllm_ascend.utils import has_rope, is_vl_model
 
 if HAS_TRITON:
     from vllm.model_executor.layers.rotary_embedding.mrope import triton_mrope
 
     from vllm_ascend.ops.triton.rope import rope_forward_triton
 
-# Currently, rope ops used on npu requires detached cos && sin as inputs.
-# However, RotaryEmbedding in vllm use cos_sin_cache as a whole variable.
-# So we have to preprocess cos_sin_cache int cos && sin. In the future,
-# we shall implement a new rope ops which accept cos_sin_cache as inputs.
-# NOTE(Angazenn): MLA && SFA models uses attn_metadata to pass cos && sin
-# to rope in AscendMLA(SFA)Impl. However, since rope is isolated from
-# AscendAttentionBackendImpl for GQA models, we cannot pass cos && sin by
-# attn_metadata. This causes that rope in GQA models must pass cos && sin
-# by different approaches.
-_cos_mla: torch.Tensor = None
-_sin_mla: torch.Tensor = None
-_cos_cache: torch.Tensor = None
-_sin_cache: torch.Tensor = None
-_cos_sin_cache: torch.Tensor = None
-_cos: torch.Tensor = None
-_sin: torch.Tensor = None
-_cos_slice: torch.Tensor = None
-_sin_slice: torch.Tensor = None
+def get_rope_cache(rotary_emb, ref_tensor: torch.Tensor) -> torch.Tensor:
+    """Return rotary_emb.cos_sin_cache matched to ref_tensor dtype/device."""
+    if hasattr(rotary_emb, "_match_cos_sin_cache_dtype"):
+        return rotary_emb._match_cos_sin_cache_dtype(ref_tensor)
+
+    cos_sin_cache = rotary_emb.cos_sin_cache
+    if cos_sin_cache.device == ref_tensor.device and cos_sin_cache.dtype == ref_tensor.dtype:
+        return cos_sin_cache
+
+    cos_sin_cache = cos_sin_cache.to(ref_tensor.device, dtype=ref_tensor.dtype)
+    if not torch.compiler.is_compiling():
+        rotary_emb.cos_sin_cache = cos_sin_cache
+    return cos_sin_cache
 
 
-def set_cos_and_sin(vllm_config, max_num_reqs, decode_token_per_req, dtype, device):
-    global _cos_mla
-    global _sin_mla
-    global _cos
-    global _sin
-
-    if _cos_mla is not None or _sin_mla is not None or _cos is not None or _sin is not None:
-        return
-
-    model_config = vllm_config.model_config
-    max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
-
-    if model_config.use_mla:
-        rope_dim = model_config.hf_text_config.qk_rope_head_dim
-        _cos_mla = torch.ones(max_num_batched_tokens, 1, 1, rope_dim, dtype=dtype, device=device)
-        _sin_mla = torch.zeros(max_num_batched_tokens, 1, 1, rope_dim, dtype=dtype, device=device)
-    elif not is_vl_model(vllm_config) and has_rope(vllm_config):
-        rope_dim = model_config.get_head_size()
-        # For models using partial rope like Qwen3-Next.
-        if hasattr(model_config.hf_text_config, "partial_rotary_factor"):
-            rope_dim = int(rope_dim * model_config.hf_text_config.partial_rotary_factor)
-        elif hasattr(model_config.hf_text_config, "rotary_dim"):
-            rope_dim = int(model_config.hf_text_config.rotary_dim)
-        _cos = torch.ones(1, max_num_batched_tokens, 1, rope_dim, dtype=dtype, device=device)
-        _sin = torch.zeros(1, max_num_batched_tokens, 1, rope_dim, dtype=dtype, device=device)
+def select_cos_sin_cache(rotary_emb, positions: torch.Tensor, ref_tensor: torch.Tensor) -> torch.Tensor:
+    """Select cos_sin_cache rows with upstream-style positions ownership."""
+    return get_rope_cache(rotary_emb, ref_tensor)[positions]
 
 
-def get_cos_and_sin_mla(positions, use_cache=False):
-    global _cos_cache
-    global _sin_cache
-    cos = _cos_cache[positions].unsqueeze(1).unsqueeze(2)
-    sin = _sin_cache[positions].unsqueeze(1).unsqueeze(2)
-    if not use_cache:
-        return cos, sin
-    global _cos_mla
-    global _sin_mla
-    num_tokens = positions.size(0)
-    _cos_mla[:num_tokens, ...] = cos
-    _sin_mla[:num_tokens, ...] = sin
-    return _cos_mla[:num_tokens, ...], _sin_mla[:num_tokens, ...]
+def _expand_rope_dim(cos: torch.Tensor, sin: torch.Tensor, *, is_neox_style: bool) -> tuple[torch.Tensor, torch.Tensor]:
+    if is_neox_style:
+        return torch.cat((cos, cos), dim=-1), torch.cat((sin, sin), dim=-1)
+    return cos.repeat_interleave(2, dim=-1), sin.repeat_interleave(2, dim=-1)
 
 
-def _record_cos_sin_cache(cos_sin_cache):
-    global _cos_sin_cache
-    if _cos_sin_cache is not None:
-        return
-    _cos_sin_cache = cos_sin_cache
+def select_cos_sin_from_cache(
+    rotary_emb,
+    positions: torch.Tensor,
+    ref_tensor: torch.Tensor,
+    *,
+    layout: str = "T11D",
+    expand_rope_dim: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Resolve cos/sin from rotary_emb for legacy NPU ops.
 
+    layout values:
+    - "TD": [num_tokens, rotary_dim]
+    - "T11D": [num_tokens, 1, 1, rotary_dim]
+    - "1T1D": [1, num_tokens, 1, rotary_dim]
+    """
+    cos_sin = select_cos_sin_cache(rotary_emb, positions, ref_tensor)
+    cos, sin = cos_sin.chunk(2, dim=-1)
+    if expand_rope_dim:
+        cos, sin = _expand_rope_dim(cos, sin, is_neox_style=getattr(rotary_emb, "is_neox_style", True))
 
-def _record_cos_and_sin_cache(cos_cache, sin_cache):
-    global _cos_cache
-    global _sin_cache
-    _cos_cache = cos_cache
-    _sin_cache = sin_cache
-
-
-def _record_cos_and_sin_cache_interleaved(cos_sin_cache):
-    global _cos_cache
-    global _sin_cache
-    if _cos_cache is not None or _sin_cache is not None:
-        return
-    hidden_dim = cos_sin_cache.shape[-1] // 2
-    cos_cache, sin_cache = cos_sin_cache.view(-1, 2, hidden_dim).repeat(1, 1, 2).chunk(2, dim=1)
-    _cos_cache = cos_cache.squeeze(1)
-    _sin_cache = sin_cache.squeeze(1)
-
-
-def update_cos_sin(positions):
-    global _cos
-    global _sin
-    global _cos_slice
-    global _sin_slice
-
-    if _cos_sin_cache is None or _cos is None or _sin is None:
-        return
-
-    num_tokens = positions.size(0)
-    _cos[:, :num_tokens] = (
-        _cos_sin_cache.index_select(0, positions).view(num_tokens, 2, -1).repeat(1, 1, 2).chunk(2, dim=-2)[0]
-    )
-    _sin[:, :num_tokens] = (
-        _cos_sin_cache.index_select(0, positions).view(num_tokens, 2, -1).repeat(1, 1, 2).chunk(2, dim=-2)[1]
-    )
-    _cos_slice = _cos[:, :num_tokens]
-    _sin_slice = _sin[:, :num_tokens]
-
-
-def get_cos_and_sin_slice():
-    return _cos_slice, _sin_slice
+    if layout == "TD":
+        return cos.contiguous().view(positions.shape[-1], -1), sin.contiguous().view(positions.shape[-1], -1)
+    if layout == "T11D":
+        return cos.contiguous().view(positions.shape[-1], 1, 1, -1), sin.contiguous().view(positions.shape[-1], 1, 1, -1)
+    if layout == "1T1D":
+        return cos.contiguous().view(1, positions.shape[-1], 1, -1), sin.contiguous().view(1, positions.shape[-1], 1, -1)
+    raise ValueError(f"Unsupported RoPE cache layout: {layout}")
 
 
 def rope_forward_oot(
@@ -227,8 +170,6 @@ class AscendRotaryEmbedding(RotaryEmbedding):
         super().__init__(head_size, rotary_dim, max_position_embeddings, base, is_neox_style, dtype, init_cache)
         vllm_config = get_current_vllm_config()
         self.use_mtp = vllm_config.speculative_config and vllm_config.speculative_config.method == "mtp"
-        _record_cos_sin_cache(self.cos_sin_cache)
-        _record_cos_and_sin_cache_interleaved(self.cos_sin_cache)
 
     def forward_oot(
         self,
@@ -282,7 +223,6 @@ class AscendYaRNRotaryEmbedding(YaRNScalingRotaryEmbedding):
         )
         vllm_config = get_current_vllm_config()
         self.use_mtp = vllm_config.speculative_config and vllm_config.speculative_config.method == "mtp"
-        _record_cos_sin_cache(self.cos_sin_cache)
 
     def forward_oot(
         self,
@@ -446,8 +386,6 @@ class AscendDeepseekScalingRotaryEmbedding(DeepseekScalingRotaryEmbedding):
         self.register_buffer("cos_sin_cache", cache, persistent=False)
         self.register_buffer("cos_cached", cos_cached, persistent=False)
         self.register_buffer("sin_cached", sin_cached, persistent=False)
-        _record_cos_sin_cache(cache)
-        _record_cos_and_sin_cache(cos_cached, sin_cached)
 
     def forward(
         self, positions: torch.Tensor, query: torch.Tensor, key: torch.Tensor, offsets: torch.Tensor | None = None
@@ -483,11 +421,10 @@ class AscendMRotaryEmbedding(MRotaryEmbedding):
         assert positions.ndim == 2
         assert key is not None
 
-        self._match_cos_sin_cache_dtype(query)
         self.cos = None
         self.sin = None
         if self.cos is None and self.sin is None:
-            cos_sin = self.cos_sin_cache[positions]  # type: ignore
+            cos_sin = select_cos_sin_cache(self, positions, query)
             cos, sin = cos_sin.chunk(2, dim=-1)
             self.cos = cos.contiguous()
             self.sin = sin.contiguous()

--- a/vllm_ascend/patch/worker/patch_minimax_m2.py
+++ b/vllm_ascend/patch/worker/patch_minimax_m2.py
@@ -34,7 +34,7 @@ from vllm.model_executor.models.minimax_m2 import (
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
-from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_slice
+from vllm_ascend.ops.rotary_embedding import select_cos_sin_from_cache
 from vllm_ascend.utils import vllm_version_is
 
 if vllm_version_is("0.21.0"):
@@ -109,7 +109,7 @@ def _patch_forward(
     hidden_states: torch.Tensor,
 ) -> torch.Tensor:
     qkv, _ = self.qkv_proj(hidden_states)
-    cos, sin = get_cos_and_sin_slice()
+    cos, sin = select_cos_sin_from_cache(self.rotary_emb, positions, qkv, layout="1T1D")
     q, k, v = torch.ops.vllm.split_qkv_tp_rmsnorm_rope(
         input=qkv,
         q_weight=self.q_norm.weight,

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -24,6 +24,7 @@ from vllm.model_executor.models.qwen3_next import Qwen3NextAttention
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
+from vllm_ascend.ops.rotary_embedding import select_cos_sin_cache
 from vllm_ascend.utils import is_310p, vllm_version_is
 
 if vllm_version_is("0.21.0"):
@@ -40,11 +41,7 @@ class AscendQwen3NextAttention(Qwen3NextAttention):
     def forward(self, positions: torch.Tensor, output: torch.Tensor, hidden_states: torch.Tensor):
         qkv, _ = self.qkv_proj(hidden_states)
         if "qwen3_5" in self.config.model_type:
-            cos_sin = self.rotary_emb.cos_sin_cache[positions]
-            if cos_sin.device != qkv.device:
-                cos_sin = cos_sin.to(qkv.device)
-            if cos_sin.dtype != qkv.dtype:
-                cos_sin = cos_sin.to(qkv.dtype)
+            cos_sin = select_cos_sin_cache(self.rotary_emb, positions, qkv)
 
             q, k, v, gate = torch.ops.vllm.triton_split_qkv_rmsnorm_mrope(
                 qkv=qkv,

--- a/vllm_ascend/patch/worker/patch_qwen3vl.py
+++ b/vllm_ascend/patch/worker/patch_qwen3vl.py
@@ -9,7 +9,7 @@ from vllm.model_executor.models.qwen3_vl import (
 )
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
-from vllm_ascend.ops.rotary_embedding import AscendMRotaryEmbedding
+from vllm_ascend.ops.rotary_embedding import AscendMRotaryEmbedding, select_cos_sin_cache
 
 
 def tensor_parallel_wrap(func):
@@ -35,11 +35,7 @@ def tensor_parallel_wrap(func):
 def forward_with_split_qkv_rmsnorm_mrope(self, positions: torch.Tensor, hidden_states: torch.Tensor):
     qkv, _ = self.qkv_proj(hidden_states)
     if isinstance(self.rotary_emb, AscendMRotaryEmbedding):
-        cos_sin = self.rotary_emb.cos_sin_cache[positions]
-        if cos_sin.device != qkv.device:
-            cos_sin = cos_sin.to(qkv.device)
-        if cos_sin.dtype != qkv.dtype:
-            cos_sin = cos_sin.to(qkv.dtype)
+        cos_sin = select_cos_sin_cache(self.rotary_emb, positions, qkv)
         q, k, v, _ = torch.ops.vllm.triton_split_qkv_rmsnorm_mrope(
             qkv=qkv,
             q_weight=self.q_norm.weight,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -130,7 +130,6 @@ from vllm_ascend.eplb.core.eplb_device_transfer_loader import D2DExpertWeightLoa
 from vllm_ascend.eplb.core.eplb_worker import EplbProcess
 from vllm_ascend.eplb.eplb_updator import EplbUpdator
 from vllm_ascend.eplb.utils import model_register
-from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
 from vllm_ascend.patch.worker.patch_draft_quarot import patch_load_weights
 from vllm_ascend.quantization.utils import enable_fa_quant
 from vllm_ascend.sample.sampler import AscendSampler
@@ -482,7 +481,6 @@ class NPUModelRunner(GPUModelRunner):
             self.is_kv_producer = vllm_config.kv_transfer_config.is_kv_producer
             self.is_kv_consumer = vllm_config.kv_transfer_config.is_kv_consumer
 
-        set_cos_and_sin(vllm_config, self.max_num_reqs, self.uniform_decode_query_len, self.dtype, self.device)
         set_mc2_tokens_capacity(vllm_config, self.max_num_reqs, self.uniform_decode_query_len)
         set_mc2_mask(vllm_config, self.device)
         self.decode_threshold = 1 + (self.speculative_config.num_speculative_tokens if self.speculative_config else 0)
@@ -2201,9 +2199,6 @@ class NPUModelRunner(GPUModelRunner):
                 intermediate_tensors,
             )
 
-            # update global cos, sin
-            update_cos_sin(positions)
-
         if self.dynamic_eplb:
             self.eplb_updator.forward_before()
 
@@ -3488,9 +3483,6 @@ class NPUModelRunner(GPUModelRunner):
                 positions = self.xdrope_positions.gpu[:, :num_tokens_padded]
             else:
                 positions = self.positions[:num_tokens_padded]
-
-            # update global cos, sin
-            update_cos_sin(positions)
 
             if get_pp_group().is_first_rank:
                 intermediate_tensors = None

--- a/vllm_ascend/worker/v2/README.md
+++ b/vllm_ascend/worker/v2/README.md
@@ -7,11 +7,11 @@ to get specific plans.
 
 ## Gaps with vLLM (To Be Addressed)
 
-- [ ] `set_cos_and_sin` & `update_cos_sin`
+- [x] global RoPE slice pre-initialization
 
-    Why: DeepSeek-like models (mla) still need cos/sin setting and updating in model_runner. These should be removed when mla can solve cos/sin internally.
+    Status: Removed from model runner. RoPE views are resolved from `input_positions` and the layer-owned rotary cache inside attention/model patch execution.
 
-    Location: `NPUModelRunner.__init__`, `NPUModelRunner.prepare_inputs`, `AscendInputBatch.make_dummy`.
+    Previous location: `NPUModelRunner.__init__`, `NPUModelRunner.prepare_inputs`, `AscendInputBatch.make_dummy`.
 
 - [ ] `_allocate_kv_cache` & `_reshape_kv_cache`
 

--- a/vllm_ascend/worker/v2/input_batch.py
+++ b/vllm_ascend/worker/v2/input_batch.py
@@ -24,7 +24,6 @@ from vllm.triton_utils import tl, triton
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.ops.rotary_embedding import update_cos_sin
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 
 
@@ -101,8 +100,6 @@ class AscendInputBatch(InputBatch):
         # attention metadata isn't needed,
         # we can also set attn_state to AscendAttentionState.DecodeOnly.
         input_batch.attn_state = AscendAttentionState.DecodeOnly
-        # For mla/sfa, update cos/sin. Here is for _dummy_run.
-        update_cos_sin(input_batch.positions)
         return cls(**asdict(input_batch), seq_lens_np=seq_lens_np)
 
 

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -44,7 +44,6 @@ from vllm_ascend.ascend_forward_context import (
     set_mc2_mask,
     set_mc2_tokens_capacity,
 )
-from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
 from vllm_ascend.utils import set_weight_prefetch_method, vllm_version_is
 from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
 from vllm_ascend.worker.v2.attn_utils import build_attn_state
@@ -121,8 +120,6 @@ class NPUModelRunner(GPUModelRunner):
         # set _WEIGHT_PREFETCH_METHOD, _mc2_tokens_capacity and _reserved_mc2_mask which
         # is necessary for weight_prfetching function, and MoE communication optimization.
         set_weight_prefetch_method(self.ascend_config.weight_prefetch_config)
-        # TODO: remove set_cos_and_sin (together with update_cos_sin) when mla can properly handle cos/sin internally
-        set_cos_and_sin(vllm_config, self.max_num_reqs, self.decode_query_len, self.dtype, self.device)
         set_mc2_tokens_capacity(vllm_config, self.max_num_reqs, self.decode_query_len)
         set_mc2_mask(vllm_config, self.device)
 
@@ -263,9 +260,9 @@ class NPUModelRunner(GPUModelRunner):
 
         query_start_loc_np = query_start_loc_np[: num_reqs_padded + 1]
         query_start_loc = self.input_buffers.query_start_loc[: num_reqs + 1]
-        prefill_len_np = self.req_states.prefill_len.np[idx_mapping_np]
-        num_computed_prefill_tokens_np = self.req_states.num_computed_prefill_tokens[idx_mapping_np]
-        is_prefilling_np = num_computed_prefill_tokens_np < prefill_len_np
+        is_prefilling_np = (
+            self.req_states.num_computed_prefill_tokens[idx_mapping_np] < self.req_states.prefill_len.np[idx_mapping_np]
+        )
 
         # Get prefill tokens if any.
         if np.any(is_prefilling_np):
@@ -319,20 +316,6 @@ class NPUModelRunner(GPUModelRunner):
         )
         seq_lens_cpu_upper_bound = torch.from_numpy(seq_lens_cpu_upper_bound_np)
 
-        version_b_fields: dict = {}
-        if not vllm_version_is("0.21.0"):
-            num_computed_tokens_np = self.req_states.num_computed_tokens_np[idx_mapping_np]
-            max_seq_len_np = None
-            if getattr(self, "use_pp", False):
-                # max_seq_len is only consumed by the PP `compute_need_sampled_mask`.
-                max_seq_len_np = self.req_states.max_seq_len[idx_mapping_np]
-            version_b_fields = dict(
-                num_computed_tokens_np=num_computed_tokens_np,
-                prefill_len_np=prefill_len_np,
-                num_computed_prefill_tokens_np=num_computed_prefill_tokens_np,
-                max_seq_len_np=max_seq_len_np,
-            )
-
         self.input_batch = AscendInputBatch(
             req_ids=req_ids,
             num_reqs=num_reqs,
@@ -352,7 +335,6 @@ class NPUModelRunner(GPUModelRunner):
             seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
             dcp_local_seq_lens=None,  # TODO(Ronald1995): support cp.
             is_prefilling_np=is_prefilling_np,
-            **version_b_fields,
             input_ids=input_ids,
             positions=positions,
             logits_indices=logits_indices,
@@ -363,9 +345,6 @@ class NPUModelRunner(GPUModelRunner):
             seq_lens_np=self.input_buffers.seq_lens_np,
             attn_state=attn_state,
         )
-
-        # For mla/sfa, update cos/sin. Here is for execute_model.
-        update_cos_sin(self.input_batch.positions)
 
         return self.input_batch
 
@@ -387,28 +366,6 @@ class NPUModelRunner(GPUModelRunner):
             num_rejected,
         )
 
-        self._copy_num_computed_tokens_to_cpu()
-
-    def postprocess_sampled(
-        self,
-        idx_mapping,
-        sampled_tokens,
-        num_sampled,
-        num_rejected,
-        query_start_loc=None,
-    ):
-        """Override GPUModelRunner.postprocess_sampled for Ascend NPUs."""
-        super().postprocess_sampled(
-            idx_mapping,
-            sampled_tokens,
-            num_sampled,
-            num_rejected,
-            query_start_loc,
-        )
-
-        self._copy_num_computed_tokens_to_cpu()
-
-    def _copy_num_computed_tokens_to_cpu(self):
         # npu attention backend still need to use seq_lens_cpu,
         # we need to copy num_computed_tokens back to cpu.
         default_stream = torch.cuda.current_stream()


### PR DESCRIPTION
## What this PR does / why we need it?

This PR updates the RoPE cache operators and removes the dependency on external `sin`/`cos` tensors from the RoPE-related paths. The key changes include:

- Refactored RoPE cache ops in `vllm_ascend/ops/rope_cache_ops.py` and related C++ kernels so that positional encoding can be computed directly from cached sin/cos values.
- Updated `dsa_v1.py`, `mla_v1.py`, and `sfa_v1.py` attention paths to consume the new cache-based RoPE interface instead of passing external sin/cos tensors.
- Adjusted context-parallel logic (`dsa_cp.py`, `mla_cp.py`, `sfa_cp.py`) and MLA preprocess kernels to align with the external-sin/cos removal.
- Added/updated unit tests covering rope cache ops (`test_rope_cache_ops.py`, `test_rope_dsv4_cache.py`, `test_qwen2_decoder_rope_cache.py`, etc.) to verify correctness.

This is a draft PR for review and is **not intended to be merged** as-is.

## Does this PR introduce _any_ user-facing change?

No user-facing API changes. The modifications are internal to the Ascend attention and RoPE operator implementations.

## How was this patch tested?

- New and updated unit tests under `tests/ut/ops/` and `tests/ut/attention/`.
- Existing CI checks.

/cc @maoxx241

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
