### PR TITLE
[Feature] SSD support multiple DP in each machine

### DIFF
--- a/tests/ut/distributed/test_parallel_state.py
+++ b/tests/ut/distributed/test_parallel_state.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,6 +14,7 @@ from vllm_ascend.distributed.parallel_state import (
     destroy_ascend_model_parallel,
     get_flashcomm2_odp_group,
     get_flashcomm2_otp_group,
+    get_global_rank,
     get_lmhead_tp_group,
     get_mc2_group,
     get_otp_group,
@@ -88,3 +90,68 @@ def test_init_ascend_model_parallel(mock_distributed, parallel_config):
         assert _FLASHCOMM2_OTP is None
         assert _FLASHCOMM2_ODP is None
         assert _P_TP is None
+
+
+def _build_parallel_config(
+    tensor_parallel_size=1,
+    pipeline_parallel_size=1,
+    prefill_context_parallel_size=1,
+    data_parallel_index=0,
+):
+    return SimpleNamespace(
+        tensor_parallel_size=tensor_parallel_size,
+        pipeline_parallel_size=pipeline_parallel_size,
+        prefill_context_parallel_size=prefill_context_parallel_size,
+        data_parallel_index=data_parallel_index,
+    )
+
+
+@pytest.mark.parametrize(
+    "parallel_config_kwargs, rank_in_group, expected",
+    [
+        # No parallelism at all (single card): replica_size == 1.
+        (dict(tensor_parallel_size=1), 0, 0),
+        # TP only: rank_in_group is the local rank within the single replica.
+        (dict(tensor_parallel_size=4), 0, 0),
+        (dict(tensor_parallel_size=4), 3, 3),
+        # Dense DP: world group spans one replica, rank_in_group is local and
+        # data_parallel_index supplies the DP offset.
+        (dict(tensor_parallel_size=4, data_parallel_index=0), 2, 2),
+        (dict(tensor_parallel_size=4, data_parallel_index=1), 2, 6),
+        # MoE DP / external_launcher: world group spans all DP ranks, so
+        # rank_in_group is already global; the modulo strips the DP offset and
+        # data_parallel_index re-adds it (result equals rank_in_group).
+        (dict(tensor_parallel_size=4, data_parallel_index=1), 6, 6),
+        (dict(tensor_parallel_size=4, data_parallel_index=1), 7, 7),
+        # TP * PP * prefill-CP all contribute to replica_size; DCP/EP do not.
+        (dict(tensor_parallel_size=2, pipeline_parallel_size=2, data_parallel_index=1), 1, 5),
+        (
+            dict(
+                tensor_parallel_size=2, pipeline_parallel_size=2, prefill_context_parallel_size=2, data_parallel_index=1
+            ),
+            3,
+            11,
+        ),
+    ],
+)
+def test_get_global_rank(parallel_config_kwargs, rank_in_group, expected):
+    parallel_config = _build_parallel_config(**parallel_config_kwargs)
+    with patch("vllm_ascend.distributed.parallel_state.get_world_group") as mock_group:
+        mock_group.return_value.rank_in_group = rank_in_group
+        assert get_global_rank(parallel_config) == expected
+
+
+def test_get_global_rank_defaults_to_current_config():
+    parallel_config = _build_parallel_config(tensor_parallel_size=4, data_parallel_index=1)
+    mock_vllm_config = MagicMock()
+    mock_vllm_config.parallel_config = parallel_config
+    with (
+        patch(
+            "vllm_ascend.distributed.parallel_state.get_current_vllm_config",
+            return_value=mock_vllm_config,
+        ),
+        patch("vllm_ascend.distributed.parallel_state.get_world_group") as mock_group,
+    ):
+        mock_group.return_value.rank_in_group = 3
+        # data_parallel_index(1) * replica_size(4) + 3 == 7
+        assert get_global_rank() == 7

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -18,6 +18,7 @@ from vllm.utils.network_utils import get_ip
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend import Backend
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
+from vllm_ascend.distributed.parallel_state import get_global_rank
 
 DEFAULT_GLOBAL_SEGMENT_SIZE = 1073741824  # 1.0 GiB
 DEFAULT_LOCAL_BUFFER_SIZE = 1073741824  # 1.0 GiB
@@ -100,12 +101,11 @@ class MooncakeBackend(Backend):
         store = MooncakeDistributedStore()
         local_hostname = get_ip()
         ssd_kwargs = _ssd_setup_kwargs(self.config)
-        # Each TP rank must use a separate SSD directory to avoid bucket file
-        # collisions (independent BucketStorageBackend instances generate the
-        # same bucket_id sequence and would overwrite each other's data).
         if ssd_kwargs and ssd_kwargs.get("ssd_offload_path"):
-            local_rank = get_world_group().local_rank
-            rank_path = os.path.join(str(ssd_kwargs["ssd_offload_path"]), f"rank_{local_rank}")
+            # Per-rank SSD directory keyed by the globally unique rank so that
+            # DP/TP/PP/CP replicas never share a directory (dense and MoE alike).
+            global_rank = get_global_rank()
+            rank_path = os.path.join(str(ssd_kwargs["ssd_offload_path"]), f"rank_{global_rank}")
             try:
                 os.makedirs(rank_path, exist_ok=True)
             except OSError as e:

--- a/vllm_ascend/distributed/parallel_state.py
+++ b/vllm_ascend/distributed/parallel_state.py
@@ -339,3 +339,36 @@ def destroy_ascend_model_parallel():
     if _DYNAMIC_EPLB:
         _DYNAMIC_EPLB.destroy()
     _DYNAMIC_EPLB = None
+
+
+def get_global_rank(parallel_config: ParallelConfig | None = None) -> int:
+    """Return a globally unique rank for the current worker across all parallel
+     dimensions (TP/PP/CP/DP), compatible with both dense and MoE models.
+
+     vLLM does not expose a single ready-to-use cross-DP global rank:
+       - For dense models each DP rank is launched as an independent DP=1 engine,
+         so ``data_parallel_rank`` is reset to 0 and ``get_world_group()`` only
+         spans one replica (``rank_in_group`` is the local rank in the replica).
+       - For MoE DP / external_launcher the world group spans all DP ranks, so
+         ``rank_in_group`` already encodes the DP offset.
+
+     ``data_parallel_index`` always keeps the true DP rank (it is never reset),
+     and ``rank_in_group % replica_size`` yields the local rank within a replica
+     in both cases, so the formula below is correct everywhere. It mirrors vLLM's
+     own ``data_parallel_rank * world_size + rank`` (see
+     vllm/distributed/parallel_state.py).
+
+    Note: DCP (decode context parallel) reuses the TP NPUs and EP overlays
+    TP/DP, so neither adds new ranks and they are intentionally excluded from
+    ``replica_size``.
+    """
+    if parallel_config is None:
+        parallel_config = get_current_vllm_config().parallel_config
+    # Number of NPUs in a single DP replica (TP * PP * prefill-CP).
+    replica_size = (
+        parallel_config.tensor_parallel_size
+        * parallel_config.pipeline_parallel_size
+        * parallel_config.prefill_context_parallel_size
+    )
+    rank_in_replica = get_world_group().rank_in_group % replica_size
+    return parallel_config.data_parallel_index * replica_size + rank_in_replica


### PR DESCRIPTION
### What this PR does / why we need it?
support multiple DP in each machine. 
In a single-machine multi-DP scenario, if the names of SSD subdirectories are the same, they will overwrite each other. To resolve the issue in the multi-DP scenario, the names of the subdirectories should be used by global rank instead of local rank.

### Does this PR introduce _any_ user-facing change?
No.  depends on #9731

### How was this patch tested?
pytest tests/ut/distributed/test_parallel_state.py -k get_global_rank -p no:cacheprovider --noconftest -v
```text
tests/ut/distributed/test_parallel_state.py::test_get_global_rank[parallel_config_kwargs0-0-0] PASSED                                                    [ 10%]
tests/ut/distributed/test_parallel_state.py::test_get_global_rank[parallel_config_kwargs1-0-0] PASSED                                                    [ 20%]
tests/ut/distributed/test_parallel_state.py::test_get_global_rank[parallel_config_kwargs2-3-3] PASSED                                                    [ 30%]
tests/ut/distributed/test_parallel_state.py::test_get_global_rank[parallel_config_kwargs3-2-2] PASSED                                                    [ 40%]
tests/ut/distributed/test_parallel_state.py::test_get_global_rank[parallel_config_kwargs4-2-6] PASSED                                                    [ 50%]
tests/ut/distributed/test_parallel_state.py::test_get_global_rank[parallel_config_kwargs5-6-6] PASSED                                                    [ 60%]
tests/ut/distributed/test_parallel_state.py::test_get_global_rank[parallel_config_kwargs6-7-7] PASSED                                                    [ 70%]
tests/ut/distributed/test_parallel_state.py::test_get_global_rank[parallel_config_kwargs7-1-5] PASSED                                                    [ 80%]
tests/ut/distributed/test_parallel_state.py::test_get_global_rank[parallel_config_kwargs8-3-11] PASSED                                                   [ 90%]
tests/ut/distributed/test_parallel_state.py::test_get_global_rank_defaults_to_current_config PASSED                                                      [100%]
```

### Verification
#### Before, multiple DP in one machine
```text
E20260613 09:46:52.048179 15282 real_client.cpp:5592] Failed to invoke batch_get_offload_object, client_addr = 7.150.3.11:40751, error is: FILE_OPEN_FAIL
E20260613 09:46:52.048270 15282 real_client.cpp:5520] Batch get offload object failed with error: FILE_OPEN_FAIL
E20260613 09:46:52.048293 15282 real_client.cpp:5023] SSD read failed for key 'GLM-5.1-w4a8@pcp0@dcp0@head_or_tp_rank:0@pp_rank:0@6539c242274c30715bdc8bd80d38c0260c718a973470fd6aa9855a72b204126d': FILE_OPEN_FAIL
E20260613 09:46:52.048301 15282 real_client.cpp:5023] SSD read failed for key 'GLM-5.1-w4a8@pcp0@dcp0@head_or_tp_rank:0@pp_rank:0@5c04a4ca1fac40d2f9d7b3e38ba5062656727ff7268b4f236a39544dcebca1e3': FILE OPEN_FAIL
E20260613 09:46:52.048308 15282 real_client.cpp:5023] SSD read failed for key 'GLM-5.1-w4a8@pcp0@dcp0@head_or_tp_rank:0@pp_rank:0@4783b2d7d44ca62158833b6e0d15eeb9553cd5fd685e89de92f2a4f8c47fdb6': FILE OPEN_FAIL
(Worker DP0_TP0_FP0_pid=151911) ERROR06_13_09:46:52 [mooncakе backend py:216] Failed to get key ['GLM-5.1-w4a8@cpu0@cdn@head or tp_rank:0@pp_rank:0@4783d30e1319b21c63ca30845064bf0906ac2290f8e5ac2c10901b57f5d864cf'
```
#### Before, Machine subdirectory structure. (e.g. DP2TP4), DP0 and DP1 has the same subdirectory（local rank）, conflict with each other. 
```text
root@ai-lm-service07:/opt/XXXX/mtp/mooncake_offload# ll
total 40
drwxr-x--- 10 root root 4096 Jun 15 12:36 ./
drwxr-x--- 21 root root 4096 Jun 12 16:37 ../
drwxr-x---  2 root root 4096 Jun 15 12:36 rank_0/
drwxr-x---  2 root root 4096 Jun 15 12:36 rank_1/
drwxr-x---  2 root root 4096 Jun 15 12:36 rank_2/
drwxr-x---  2 root root 4096 Jun 15 12:36 rank_3/
```

#### After, multiple DP in one machine
No ERROR like 'FILE_OPEN_FAIL'

#### After, Machine subdirectory structure. (e.g. DP2TP4), global_rank
```text
root@ai-lm-service07:/opt/XXXX/mtp/mooncake_offload# ll
total 40
drwxr-x--- 10 root root 4096 Jun 15 12:36 ./
drwxr-x--- 21 root root 4096 Jun 12 16:37 ../
drwxr-x---  2 root root 4096 Jun 15 12:36 rank_0/
drwxr-x---  2 root root 4096 Jun 15 12:36 rank_1/
drwxr-x---  2 root root 4096 Jun 15 12:36 rank_2/
drwxr-x---  2 root root 4096 Jun 15 12:36 rank_3/
drwxr-x---  2 root root 4096 Jun 15 12:36 rank_4/
drwxr-x---  2 root root 4096 Jun 15 12:36 rank_5/
drwxr-x---  2 root root 4096 Jun 15 12:36 rank_6/
drwxr-x---  2 root root 4096 Jun 15 12:36 rank_7/
```

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
