### PR TITLE
[Ops][Misc] Modify triton ops logs

### DIFF
--- a/vllm_ascend/ops/triton/activation/swiglu_quant.py
+++ b/vllm_ascend/ops/triton/activation/swiglu_quant.py
@@ -78,7 +78,9 @@ def swiglu_quant(x, group_list, group_list_type, need_quant=True):
     elif group_list.dtype == torch.int32:
         num_experts_algin = (num_experts + 15) // 16 * 16
     else:
-        raise ValueError(f"swiglu_quant: group_list dtype must be torch.int32 or torch.int64, but got {group_list.dtype}")
+        raise ValueError(
+            f"swiglu_quant: group_list dtype must be torch.int32 or torch.int64, but got {group_list.dtype}"
+        )
 
     num_vectorcore = get_vectorcore_num()
     _swiglu_quant_kernel[(num_vectorcore,)](

--- a/vllm_ascend/ops/triton/activation/swiglu_quant.py
+++ b/vllm_ascend/ops/triton/activation/swiglu_quant.py
@@ -66,7 +66,7 @@ def _swiglu_quant_kernel(
 def swiglu_quant(x, group_list, group_list_type, need_quant=True):
     # group_list_type must be 0 cusum or 1 count
     if group_list_type not in [0, 1]:
-        raise ValueError(f"group_list_type must be 0 or 1, but got {group_list_type}")
+        raise ValueError(f"swiglu_quant: group_list_type must be 0 or 1, but got {group_list_type}")
     s, h = x.shape
     out_dtype = torch.int8 if need_quant else x.dtype
     out = torch.empty((s, h // 2), dtype=out_dtype, device=x.device)
@@ -78,7 +78,7 @@ def swiglu_quant(x, group_list, group_list_type, need_quant=True):
     elif group_list.dtype == torch.int32:
         num_experts_algin = (num_experts + 15) // 16 * 16
     else:
-        raise ValueError(f"group_list dtype must be torch.int32 or torch.int64, but got {group_list.dtype}")
+        raise ValueError(f"swiglu_quant: group_list dtype must be torch.int32 or torch.int64, but got {group_list.dtype}")
 
     num_vectorcore = get_vectorcore_num()
     _swiglu_quant_kernel[(num_vectorcore,)](

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -309,14 +309,14 @@ def chunk_gated_delta_rule(
 
     if head_first:
         raise DeprecationWarning(
-            "head_first is deprecated and will be removed in a future version. "
+            "chunk_gated_delta_rule: head_first is deprecated and will be removed in a future version. "
             "Please use head_first=False for now instead.",
             stacklevel=2,
         )
         q, k, v, beta, g = map(lambda x: rearrange(x, "b h t ... -> b t h ..."), (q, k, v, beta, g))
     if not head_first and q.shape[1] < q.shape[2]:
         warnings.warn(
-            f"Input tensor shape suggests potential format mismatch: seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). "
+            f"chunk_gated_delta_rule: Input tensor shape suggests potential format mismatch: seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). "
             "This may indicate the inputs were passed in head-first format [B, H, T, ...] "
             "when head_first=False was specified. "
             "Please verify your input tensor format matches the expected shape [B, T, H, ...].",
@@ -325,12 +325,12 @@ def chunk_gated_delta_rule(
     if cu_seqlens is not None:
         if q.shape[0] != 1:
             raise ValueError(
-                f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
+                f"chunk_gated_delta_rule: The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
                 f"Please flatten variable-length inputs before processing."
             )
         if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
             raise ValueError(
-                f"The number of initial states is expected to be equal to the number of input sequences, "
+                f"chunk_gated_delta_rule: The number of initial states is expected to be equal to the number of input sequences, "
                 f"i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}."
             )
     if scale is None:

--- a/vllm_ascend/ops/triton/fla/cumsum.py
+++ b/vllm_ascend/ops/triton/fla/cumsum.py
@@ -138,7 +138,7 @@ def chunk_local_cumsum(
         )
     else:
         raise ValueError(
-            f"Unsupported input shape {g.shape}, "
+            f"chunk_local_cumsum: Unsupported input shape {g.shape}, "
             f"which should be (B, T, H, D) if `head_first=False` "
             f"or (B, H, T, D) otherwise"
         )

--- a/vllm_ascend/ops/triton/fla/l2norm.py
+++ b/vllm_ascend/ops/triton/fla/l2norm.py
@@ -45,7 +45,7 @@ def l2norm_fwd(x: torch.Tensor, eps: float = 1e-6, output_dtype: torch.dtype | N
     MAX_FUSED_SIZE = 65536 // x.element_size()
     BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
     if D > BD:
-        raise RuntimeError("This layer doesn't support feature dim >= 64KB.")
+        raise RuntimeError(f"l2norm_fwd: This layer doesn't support feature dim >= 64KB, got {D}.")
 
     MBLOCK = 69
     # M, N = x.shape

--- a/vllm_ascend/ops/triton/fla/layernorm_guard.py
+++ b/vllm_ascend/ops/triton/fla/layernorm_guard.py
@@ -128,7 +128,7 @@ def _layer_norm_fwd(
     MAX_FUSED_SIZE = 65536 // x.element_size()
     BLOCK_N = min(MAX_FUSED_SIZE, triton.next_power_of_2(group_size))
     if group_size > BLOCK_N:
-        raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
+        raise RuntimeError(f"_layer_norm_fwd: This layer norm doesn't support feature dim >= 64KB, got {group_size}.")
     # heuristics for number of warps
     num_warps = min(max(BLOCK_N // 256, 1), 8)
     grid = (M if M < MAX_CORES else MAX_CORES, ngroups)

--- a/vllm_ascend/ops/triton/fla/utils.py
+++ b/vllm_ascend/ops/triton/fla/utils.py
@@ -115,8 +115,7 @@ def clear_ssm_states(ssm_states: torch.Tensor, has_initial_state: torch.Tensor) 
     if num_rows == 0:
         return
     if has_initial_state.numel() != num_rows:
-        raise ValueError(f"has_initial_state size mismatch: expected {num_rows}, got {has_initial_state.numel()}")
-
+        raise ValueError(f"clear_ssm_states: has_initial_state size mismatch: expected {num_rows}, got {has_initial_state.numel()}")
     inner_size = ssm_states.numel() // num_rows
     if inner_size == 0:
         return

--- a/vllm_ascend/ops/triton/fla/utils.py
+++ b/vllm_ascend/ops/triton/fla/utils.py
@@ -115,7 +115,9 @@ def clear_ssm_states(ssm_states: torch.Tensor, has_initial_state: torch.Tensor) 
     if num_rows == 0:
         return
     if has_initial_state.numel() != num_rows:
-        raise ValueError(f"clear_ssm_states: has_initial_state size mismatch: expected {num_rows}, got {has_initial_state.numel()}")
+        raise ValueError(
+            f"clear_ssm_states: has_initial_state size mismatch: expected {num_rows}, got {has_initial_state.numel()}"
+        )
     inner_size = ssm_states.numel() // num_rows
     if inner_size == 0:
         return

--- a/vllm_ascend/ops/triton/gdn_chunk_meta.py
+++ b/vllm_ascend/ops/triton/gdn_chunk_meta.py
@@ -92,13 +92,17 @@ def _validate_optional_output(
     if tensor is None:
         return
     if tensor.device != expected_device:
-        raise ValueError(f"chunk_gated_delta_rule meta: {name} must be on device {expected_device}, got {tensor.device}")
+        raise ValueError(
+            f"chunk_gated_delta_rule meta: {name} must be on device {expected_device}, got {tensor.device}"
+        )
     if tensor.dtype not in (torch.int32, torch.int64):
         raise ValueError(f"chunk_gated_delta_rule meta: {name} must have int32 or int64 dtype, got {tensor.dtype}")
     if not tensor.is_contiguous():
         raise ValueError(f"chunk_gated_delta_rule meta: {name} must be contiguous")
     if expected_shape is not None and tuple(tensor.shape) != expected_shape:
-        raise ValueError(f"chunk_gated_delta_rule meta: {name} must have shape {expected_shape}, got {tuple(tensor.shape)}")
+        raise ValueError(
+            f"chunk_gated_delta_rule meta: {name} must have shape {expected_shape}, got {tuple(tensor.shape)}"
+        )
 
 
 def _validate_cu_seqlens(cu_seqlens: torch.Tensor, chunk_size: int) -> None:
@@ -107,13 +111,15 @@ def _validate_cu_seqlens(cu_seqlens: torch.Tensor, chunk_size: int) -> None:
     if cu_seqlens.device.type != "npu":
         raise ValueError(f"chunk_gated_delta_rule meta: cu_seqlens must be on NPU, got {cu_seqlens.device}")
     if cu_seqlens.dtype not in (torch.int32, torch.int64):
-        raise ValueError(f"chunk_gated_delta_rule meta: cu_seqlens must have int32 or int64 dtype, got {cu_seqlens.dtype}")
+        raise ValueError(
+            f"chunk_gated_delta_rule meta: cu_seqlens must have int32 or int64 dtype, got {cu_seqlens.dtype}"
+        )
     if cu_seqlens.ndim != 1:
         raise ValueError(f"chunk_gated_delta_rule meta: cu_seqlens must be 1D, got shape {tuple(cu_seqlens.shape)}")
     if cu_seqlens.shape[0] < 1:
-        raise ValueError(f"chunk_gated_delta_rule meta: cu_seqlens must contain at least one element")
+        raise ValueError("chunk_gated_delta_rule meta: cu_seqlens must contain at least one element")
     if not cu_seqlens.is_contiguous():
-        raise ValueError(f"chunk_gated_delta_rule meta: cu_seqlens must be contiguous")
+        raise ValueError("chunk_gated_delta_rule meta: cu_seqlens must be contiguous")
     if chunk_size <= 0:
         raise ValueError(f"chunk_gated_delta_rule meta: chunk_size must be positive, got {chunk_size}")
 
@@ -199,7 +205,9 @@ def _build_chunk_meta_device_from_seq_lens(
         expected_device=seq_lens.device,
     )
     if out_chunk_indices is not None and (out_chunk_indices.ndim != 2 or out_chunk_indices.shape[1] != 2):
-        raise ValueError(f"chunk_gated_delta_rule meta: out_chunk_indices must have shape [num_chunks, 2], got {tuple(out_chunk_indices.shape)}")
+        raise ValueError(
+            f"chunk_gated_delta_rule meta: out_chunk_indices must have shape [num_chunks, 2], got {tuple(out_chunk_indices.shape)}"
+        )
     _validate_optional_output(
         "out_chunk_offsets",
         out_chunk_offsets,

--- a/vllm_ascend/ops/triton/gdn_chunk_meta.py
+++ b/vllm_ascend/ops/triton/gdn_chunk_meta.py
@@ -92,30 +92,30 @@ def _validate_optional_output(
     if tensor is None:
         return
     if tensor.device != expected_device:
-        raise ValueError(f"{name} must be on device {expected_device}, got {tensor.device}")
+        raise ValueError(f"chunk_gated_delta_rule meta: {name} must be on device {expected_device}, got {tensor.device}")
     if tensor.dtype not in (torch.int32, torch.int64):
-        raise ValueError(f"{name} must have int32 or int64 dtype, got {tensor.dtype}")
+        raise ValueError(f"chunk_gated_delta_rule meta: {name} must have int32 or int64 dtype, got {tensor.dtype}")
     if not tensor.is_contiguous():
-        raise ValueError(f"{name} must be contiguous")
+        raise ValueError(f"chunk_gated_delta_rule meta: {name} must be contiguous")
     if expected_shape is not None and tuple(tensor.shape) != expected_shape:
-        raise ValueError(f"{name} must have shape {expected_shape}, got {tuple(tensor.shape)}")
+        raise ValueError(f"chunk_gated_delta_rule meta: {name} must have shape {expected_shape}, got {tuple(tensor.shape)}")
 
 
 def _validate_cu_seqlens(cu_seqlens: torch.Tensor, chunk_size: int) -> None:
     if not isinstance(cu_seqlens, torch.Tensor):
-        raise TypeError("cu_seqlens must be a torch.Tensor")
+        raise TypeError("chunk_gated_delta_rule meta: cu_seqlens must be a torch.Tensor")
     if cu_seqlens.device.type != "npu":
-        raise ValueError(f"cu_seqlens must be on NPU, got {cu_seqlens.device}")
+        raise ValueError(f"chunk_gated_delta_rule meta: cu_seqlens must be on NPU, got {cu_seqlens.device}")
     if cu_seqlens.dtype not in (torch.int32, torch.int64):
-        raise ValueError(f"cu_seqlens must have int32 or int64 dtype, got {cu_seqlens.dtype}")
+        raise ValueError(f"chunk_gated_delta_rule meta: cu_seqlens must have int32 or int64 dtype, got {cu_seqlens.dtype}")
     if cu_seqlens.ndim != 1:
-        raise ValueError(f"cu_seqlens must be 1D, got shape {tuple(cu_seqlens.shape)}")
+        raise ValueError(f"chunk_gated_delta_rule meta: cu_seqlens must be 1D, got shape {tuple(cu_seqlens.shape)}")
     if cu_seqlens.shape[0] < 1:
-        raise ValueError("cu_seqlens must contain at least one element")
+        raise ValueError(f"chunk_gated_delta_rule meta: cu_seqlens must contain at least one element")
     if not cu_seqlens.is_contiguous():
-        raise ValueError("cu_seqlens must be contiguous")
+        raise ValueError(f"chunk_gated_delta_rule meta: cu_seqlens must be contiguous")
     if chunk_size <= 0:
-        raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+        raise ValueError(f"chunk_gated_delta_rule meta: chunk_size must be positive, got {chunk_size}")
 
 
 def _build_seq_lens(cu_seqlens: torch.Tensor) -> torch.Tensor:
@@ -199,7 +199,7 @@ def _build_chunk_meta_device_from_seq_lens(
         expected_device=seq_lens.device,
     )
     if out_chunk_indices is not None and (out_chunk_indices.ndim != 2 or out_chunk_indices.shape[1] != 2):
-        raise ValueError(f"out_chunk_indices must have shape [num_chunks, 2], got {tuple(out_chunk_indices.shape)}")
+        raise ValueError(f"chunk_gated_delta_rule meta: out_chunk_indices must have shape [num_chunks, 2], got {tuple(out_chunk_indices.shape)}")
     _validate_optional_output(
         "out_chunk_offsets",
         out_chunk_offsets,
@@ -284,7 +284,7 @@ def build_chunk_meta_device(
     if validate_inputs:
         _validate_cu_seqlens(cu_seqlens, chunk_size)
     elif chunk_size <= 0:
-        raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+        raise ValueError(f"chunk_gated_delta_rule meta: chunk_size must be positive, got {chunk_size}")
     _build_chunk_meta_device_from_seq_lens(
         _build_seq_lens(cu_seqlens) if seq_lens is None else seq_lens,
         chunk_size,

--- a/vllm_ascend/ops/triton/gdn_chunk_meta.py
+++ b/vllm_ascend/ops/triton/gdn_chunk_meta.py
@@ -206,7 +206,8 @@ def _build_chunk_meta_device_from_seq_lens(
     )
     if out_chunk_indices is not None and (out_chunk_indices.ndim != 2 or out_chunk_indices.shape[1] != 2):
         raise ValueError(
-            f"chunk_gated_delta_rule meta: out_chunk_indices must have shape [num_chunks, 2], got {tuple(out_chunk_indices.shape)}"
+            f"chunk_gated_delta_rule meta: out_chunk_indices must have shape [num_chunks, 2],"
+            f"got {tuple(out_chunk_indices.shape)}"
         )
     _validate_optional_output(
         "out_chunk_offsets",

--- a/vllm_ascend/ops/triton/layernorm_gated.py
+++ b/vllm_ascend/ops/triton/layernorm_gated.py
@@ -138,7 +138,7 @@ def layer_norm_fwd_npu(
     MAX_FUSED_SIZE = 65536 // x.element_size()
     BLOCK_N = min(MAX_FUSED_SIZE, triton.next_power_of_2(group_size))
     if group_size > BLOCK_N:
-        raise RuntimeError("Feature dim too large.")
+        raise RuntimeError(f"layer_norm_fwd_npu: Feature dim too large, got {group_size}, max supported is {BLOCK_N}.")
 
     # Choose BLOCK_M: e.g., 16, 32, 64 — depends on NPU vector core capacity
     BLOCK_M = 64  # Tune this based on your NPU's register/shared memory

--- a/vllm_ascend/ops/triton/mamba/causal_conv1d.py
+++ b/vllm_ascend/ops/triton/mamba/causal_conv1d.py
@@ -653,8 +653,6 @@ def causal_conv1d_update_npu(
 
     # -------- tiling heuristic--------
     # keep program count around ~[80..160]
-    # vector core 40
-    # TODO: use driver to get the vector core num
     CORE_HINT = get_vectorcore_num()
     # channel tile: 512 when dim large (reduce tasks), else 256
     block_n = 512 if dim >= 512 else 256

--- a/vllm_ascend/ops/triton/mamba/causal_conv1d.py
+++ b/vllm_ascend/ops/triton/mamba/causal_conv1d.py
@@ -16,6 +16,8 @@ from vllm.forward_context import get_forward_context
 from vllm.triton_utils import HAS_TRITON, tl, triton
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID  # type: ignore
 
+from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
+
 if not HAS_TRITON:
     from vllm_ascend._310p.ops.causal_conv1d import (
         causal_conv1d_update as _pytorch_update,
@@ -42,7 +44,7 @@ def causal_conv1d_ref(
     out: (batch, dim, seqlen)
     """
     if activation not in [None, "silu", "swish"]:
-        raise NotImplementedError("activation must be None, silu, or swish")
+        raise NotImplementedError(f"causal_conv1d_ref activation must be None, silu, or swish, got {activation}")
     dtype_in = x.dtype
     x = x.to(weight.dtype)
     seqlen = x.shape[-1]
@@ -113,7 +115,7 @@ def causal_conv1d_fn(
         num_decodes = attn_metadata.num_decodes
 
     if activation not in [None, "silu", "swish"]:
-        raise NotImplementedError("activation must be None, silu, or swish")
+        raise NotImplementedError(f"causal_conv1d_fn: activation must be None, silu, or swish, got {activation}")
     if x.stride(-1) != 1:
         x = x.contiguous()
     bias = bias.contiguous() if bias is not None else None
@@ -653,7 +655,7 @@ def causal_conv1d_update_npu(
     # keep program count around ~[80..160]
     # vector core 40
     # TODO: use driver to get the vector core num
-    CORE_HINT = 40
+    CORE_HINT = get_vectorcore_num()
     # channel tile: 512 when dim large (reduce tasks), else 256
     block_n = 512 if dim >= 512 else 256
     g = triton.cdiv(dim, block_n)

--- a/vllm_ascend/ops/triton/rms_norm.py
+++ b/vllm_ascend/ops/triton/rms_norm.py
@@ -42,7 +42,7 @@ def triton_q_rms(
     q = q.view(total_batch, dim)
 
     if dim > 2048:
-        raise NotImplementedError("dim > 2048 not supported")
+        raise NotImplementedError(f"triton_q_rms: dim > 2048 not supported, got {dim}")
 
     device_properties = triton.runtime.driver.active.utils.get_device_properties(q.device)
     num_vectorcore = device_properties.get("num_vectorcore", -1)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR improves error and warning messages across various Triton operations (such as 'swiglu_quant', 'chunk_gated_delta_rule', 'chunk_local_cumsum', 'l2norm_fwd', '_layer_norm_fwd', 'clear_ssm_states', 'causal_conv1d', and 'triton_q_rms') by prefixing them with the respective function/operation name to facilitate debugging. Additionally, it updates 'causal_conv1d_update_npu' to dynamically query the number of vector cores using 'get_vectorcore_num()' instead of using a hardcoded value of 40.

However, there is an issue in 'vllm_ascend/ops/triton/fla/chunk.py' where raising 'DeprecationWarning' with a 'stacklevel' keyword argument will raise a 'TypeError' at runtime. It is recommended to use 'warnings.warn' with 'DeprecationWarning' and then raise a standard exception like 'ValueError'.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing unit tests for Triton ops.

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
