### PR TITLE
[Feature] Support Ascend 950 CPU binding

### DIFF
--- a/docs/source/developer_guide/Design_Documents/cpu_binding.md
+++ b/docs/source/developer_guide/Design_Documents/cpu_binding.md
@@ -33,8 +33,8 @@ The allocator derives its plan from runtime host state:
 | Input | Source | Purpose |
 | --- | --- | --- |
 | Allowed CPUs | `/proc/self/status` `Cpus_allowed_list` | The only CPUs eligible for binding. Container cpusets are respected. |
-| Logical NPU map | `npu-smi info -m` | Maps card/chip IDs to global logical NPU IDs and gives `total_logic_npus`. |
-| Running NPUs | `npu-smi info` process table, filtered by `ASCEND_RT_VISIBLE_DEVICES` | Identifies the logical NPUs used by this worker process. |
+| Logical NPU map | `npu-smi info -m` | Maps card/chip IDs to global logical NPU IDs and gives `total_logic_npus`. On A5, `Chip Logic ID` is not reported, so `NPU ID` is used as the logical ID. |
+| Running NPUs | `npu-smi info` process table, filtered by `ASCEND_RT_VISIBLE_DEVICES` | Identifies the logical NPUs used by this worker process. A2/A3 process rows use `NPU Chip`; A5 process rows use `NPU ID`. |
 | Topology affinity | `npu-smi info -t topo` | Provides NPU-to-CPU affinity for `topo_affinity` mode. |
 | CPU NUMA map | `lscpu -e=CPU,NODE` | Used to extend single-NUMA affinity pools to the next NUMA node. |
 
@@ -45,7 +45,8 @@ The binding strategy is selected by Ascend device type:
 | Device type | Strategy | Reason |
 | --- | --- | --- |
 | A3 | `global_slice` | A3 uses HCCS card-to-card interconnect. Each NPU is nearly equidistant from all NUMA nodes, so there is no strong NPU-to-NUMA affinity signal. Global logical NPU ID based slicing gives deterministic, non-overlapping CPU pools and CPU/NUMA isolation between workers. |
-| A2, Atlas 300 inference products, and other non-A3 device types | `topo_affinity` | A2 and Atlas 300 inference products provide NPU-to-CPU affinity information through `npu-smi info -t topo`. Non-A3 device types use this topology signal when available. |
+| A5 | `global_slice` | A5 reports NPU-to-NPU/NIC topology but does not report NPU-to-CPU affinity in `npu-smi info -t topo`. It also reports process rows by `NPU ID` instead of `NPU Chip`. Global logical NPU ID based slicing keeps CPU pools deterministic without relying on missing affinity data. |
+| A2 and Atlas 300 inference products | `topo_affinity` | A2 and Atlas 300 inference products provide NPU-to-CPU affinity information through `npu-smi info -t topo`, so they use this topology signal when available. |
 
 If `topo_affinity` is selected but topo affinity is unavailable, the allocator falls back to `global_slice`.
 
@@ -53,10 +54,12 @@ If `topo_affinity` is selected but topo affinity is unavailable, the allocator f
 
 #### global_slice
 
-`global_slice` is designed for A3. Because A3's **HCCS interconnect makes the
-distance from each NPU to each NUMA node nearly the same**, topology affinity is
-not a useful placement signal. The allocator therefore partitions the sorted
-`allowed_cpus` list by global logical NPU ID.
+`global_slice` is designed for devices without a useful NPU-to-CPU affinity
+signal, including A3 and A5. Because A3's **HCCS interconnect makes the distance
+from each NPU to each NUMA node nearly the same**, topology affinity is not a
+useful placement signal. A5 similarly exposes UB/NIC topology but not CPU
+affinity. The allocator therefore partitions the sorted `allowed_cpus` list by
+global logical NPU ID.
 
 1. Determine `total_npus` in this order:
    - `total_logic_npus` from `npu-smi info -m`
@@ -76,12 +79,14 @@ both processes slice against the same global NPU ID space. With a NUMA-aligned
 cpuset, this also provides **CPU/NUMA isolation between workers**, so one worker
 does not share the same CPU or NUMA slice with another worker.
 
-`global_slice` requires `base >= 5`, because every NPU pool reserves:
+`global_slice` requires enough CPUs for the selected device's role split:
 
-- 2 CPUs for SQ/CQ IRQ binding
-- at least 1 CPU for the main worker
-- 1 CPU for ACL thread
-- 1 CPU for release thread
+- Devices with IRQ binding require `base >= 5`:
+  2 CPUs for SQ/CQ IRQ binding, at least 1 CPU for the main worker, 1 CPU for
+  ACL thread, and 1 CPU for release thread.
+- A5 skips IRQ binding and does not reserve SQ/CQ IRQ CPUs, so it requires
+  `base >= 3`: at least 1 CPU for the main worker, 1 CPU for ACL thread, and
+  1 CPU for release thread.
 
 #### topo_affinity
 
@@ -108,6 +113,8 @@ share the same topology affinity.
 
 After a CPU pool is built, the allocator splits it by role:
 
+For devices with IRQ binding:
+
 | Role | CPUs |
 | --- | --- |
 | SQ/CQ IRQ | `pool[0]`, `pool[1]` |
@@ -115,7 +122,17 @@ After a CPU pool is built, the allocator splits it by role:
 | ACL thread | `pool[-2]` |
 | Release thread | `pool[-1]` |
 
-If a final pool has fewer than 5 CPUs, binding fails for this rank and the worker logs a warning from the caller.
+For A5:
+
+| Role | CPUs |
+| --- | --- |
+| Main worker process and subthreads | `pool[:-2]` |
+| ACL thread | `pool[-2]` |
+| Release thread | `pool[-1]` |
+
+If a final pool has fewer CPUs than the selected role split requires, binding
+fails for this rank and the worker logs a warning from the caller. The minimum
+is 5 CPUs per NPU for devices with IRQ binding, and 3 CPUs per NPU for A5.
 
 ## Conditional Host Tuning
 
@@ -127,6 +144,7 @@ steps when the environment supports them:
   reads and reduces remote-NUMA memory read latency.
 - IRQ binding places NPU IRQ handling on the CPUs reserved for the corresponding
   NPU when `/proc/irq` is writable and IRQ files can be resolved.
+  A5 skips this step and gives those CPUs to the main worker instead.
 
 These are conditional parts of CPU binding, not separate feature switches. If a
 host prerequisite is missing, that step is skipped while CPU thread binding
@@ -215,12 +233,15 @@ NPU0: main=[...] acl=[...] release=[...]
 ## Limitations
 
 - CPU binding runs only on ARM. It is skipped on x86_64.
-- Each final NPU pool must have at least 5 CPUs.
+- Each final NPU pool must have enough CPUs for its role split: at least 5 CPUs
+  for devices with IRQ binding, and at least 3 CPUs for A5.
 - `global_slice` is deterministic and provides CPU/NUMA isolation when the
   cpuset is NUMA-aligned, but it cannot guarantee NUMA-local pools when CPU
   numbering or cpuset layout crosses NUMA boundaries.
 - `topo_affinity` depends on usable output from `npu-smi info -t topo`.
 - IRQ binding requires writable `/proc/irq` and resolvable PCI/IRQ information.
+  A5 skips IRQ binding even when `/proc/irq` is writable, and does not reserve
+  IRQ CPUs in its role split.
 - Memory migration requires `migratepages`; otherwise only memory migration is
   skipped. CPU affinity still applies, but performance may degrade because
   existing pages are not moved to the target NUMA node and may be read through

--- a/docs/source/developer_guide/Design_Documents/cpu_binding.md
+++ b/docs/source/developer_guide/Design_Documents/cpu_binding.md
@@ -33,8 +33,8 @@ The allocator derives its plan from runtime host state:
 | Input | Source | Purpose |
 | --- | --- | --- |
 | Allowed CPUs | `/proc/self/status` `Cpus_allowed_list` | The only CPUs eligible for binding. Container cpusets are respected. |
-| Logical NPU map | `npu-smi info -m` | Maps card/chip IDs to global logical NPU IDs and gives `total_logic_npus`. On A5, `Chip Logic ID` is not reported, so `NPU ID` is used as the logical ID. |
-| Running NPUs | `npu-smi info` process table, filtered by `ASCEND_RT_VISIBLE_DEVICES` | Identifies the logical NPUs used by this worker process. A2/A3 process rows use `NPU Chip`; A5 process rows use `NPU ID`. |
+| Logical NPU map | `npu-smi info -m` | Maps card/chip IDs to global logical NPU IDs and gives `total_logic_npus`. On Ascend 950, `Chip Logic ID` is not reported, so `NPU ID` is used as the logical ID. |
+| Running NPUs | `npu-smi info` process table, filtered by `ASCEND_RT_VISIBLE_DEVICES` | Identifies the logical NPUs used by this worker process. A2/A3 process rows use `NPU Chip`; Ascend 950 process rows use `NPU ID`. |
 | Topology affinity | `npu-smi info -t topo` | Provides NPU-to-CPU affinity for `topo_affinity` mode. |
 | CPU NUMA map | `lscpu -e=CPU,NODE` | Used to extend single-NUMA affinity pools to the next NUMA node. |
 
@@ -45,7 +45,7 @@ The binding strategy is selected by Ascend device type:
 | Device type | Strategy | Reason |
 | --- | --- | --- |
 | A3 | `global_slice` | A3 uses HCCS card-to-card interconnect. Each NPU is nearly equidistant from all NUMA nodes, so there is no strong NPU-to-NUMA affinity signal. Global logical NPU ID based slicing gives deterministic, non-overlapping CPU pools and CPU/NUMA isolation between workers. |
-| A5 | `global_slice` | A5 reports NPU-to-NPU/NIC topology but does not report NPU-to-CPU affinity in `npu-smi info -t topo`. It also reports process rows by `NPU ID` instead of `NPU Chip`. Global logical NPU ID based slicing keeps CPU pools deterministic without relying on missing affinity data. |
+| Ascend 950 | `global_slice` | Ascend 950 reports NPU-to-NPU/NIC topology but does not report NPU-to-CPU affinity in `npu-smi info -t topo`. It also reports process rows by `NPU ID` instead of `NPU Chip`. Global logical NPU ID based slicing keeps CPU pools deterministic without relying on missing affinity data. |
 | A2 and Atlas 300 inference products | `topo_affinity` | A2 and Atlas 300 inference products provide NPU-to-CPU affinity information through `npu-smi info -t topo`, so they use this topology signal when available. |
 
 If `topo_affinity` is selected but topo affinity is unavailable, the allocator falls back to `global_slice`.
@@ -55,9 +55,9 @@ If `topo_affinity` is selected but topo affinity is unavailable, the allocator f
 #### global_slice
 
 `global_slice` is designed for devices without a useful NPU-to-CPU affinity
-signal, including A3 and A5. Because A3's **HCCS interconnect makes the distance
+signal, including A3 and Ascend 950. Because A3's **HCCS interconnect makes the distance
 from each NPU to each NUMA node nearly the same**, topology affinity is not a
-useful placement signal. A5 similarly exposes UB/NIC topology but not CPU
+useful placement signal. Ascend 950 similarly exposes UB/NIC topology but not CPU
 affinity. The allocator therefore partitions the sorted `allowed_cpus` list by
 global logical NPU ID.
 
@@ -84,7 +84,7 @@ does not share the same CPU or NUMA slice with another worker.
 - Devices with IRQ binding require `base >= 5`:
   2 CPUs for SQ/CQ IRQ binding, at least 1 CPU for the main worker, 1 CPU for
   ACL thread, and 1 CPU for release thread.
-- A5 skips IRQ binding and does not reserve SQ/CQ IRQ CPUs, so it requires
+- Ascend 950 skips IRQ binding and does not reserve SQ/CQ IRQ CPUs, so it requires
   `base >= 3`: at least 1 CPU for the main worker, 1 CPU for ACL thread, and
   1 CPU for release thread.
 
@@ -122,7 +122,7 @@ For devices with IRQ binding:
 | ACL thread | `pool[-2]` |
 | Release thread | `pool[-1]` |
 
-For A5:
+For Ascend 950:
 
 | Role | CPUs |
 | --- | --- |
@@ -132,7 +132,7 @@ For A5:
 
 If a final pool has fewer CPUs than the selected role split requires, binding
 fails for this rank and the worker logs a warning from the caller. The minimum
-is 5 CPUs per NPU for devices with IRQ binding, and 3 CPUs per NPU for A5.
+is 5 CPUs per NPU for devices with IRQ binding, and 3 CPUs per NPU for Ascend 950.
 
 ## Conditional Host Tuning
 
@@ -144,7 +144,7 @@ steps when the environment supports them:
   reads and reduces remote-NUMA memory read latency.
 - IRQ binding places NPU IRQ handling on the CPUs reserved for the corresponding
   NPU when `/proc/irq` is writable and IRQ files can be resolved.
-  A5 skips this step and gives those CPUs to the main worker instead.
+  Ascend 950 skips this step and gives those CPUs to the main worker instead.
 
 These are conditional parts of CPU binding, not separate feature switches. If a
 host prerequisite is missing, that step is skipped while CPU thread binding
@@ -234,13 +234,13 @@ NPU0: main=[...] acl=[...] release=[...]
 
 - CPU binding runs only on ARM. It is skipped on x86_64.
 - Each final NPU pool must have enough CPUs for its role split: at least 5 CPUs
-  for devices with IRQ binding, and at least 3 CPUs for A5.
+  for devices with IRQ binding, and at least 3 CPUs for Ascend 950.
 - `global_slice` is deterministic and provides CPU/NUMA isolation when the
   cpuset is NUMA-aligned, but it cannot guarantee NUMA-local pools when CPU
   numbering or cpuset layout crosses NUMA boundaries.
 - `topo_affinity` depends on usable output from `npu-smi info -t topo`.
 - IRQ binding requires writable `/proc/irq` and resolvable PCI/IRQ information.
-  A5 skips IRQ binding even when `/proc/irq` is writable, and does not reserve
+  Ascend 950 skips IRQ binding even when `/proc/irq` is writable, and does not reserve
   IRQ CPUs in its role split.
 - Memory migration requires `migratepages`; otherwise only memory migration is
   skipped. CPU affinity still applies, but performance may degrade because

--- a/docs/source/user_guide/feature_guide/cpu_binding.md
+++ b/docs/source/user_guide/feature_guide/cpu_binding.md
@@ -90,10 +90,10 @@ degrade latency or throughput.**
 For optimal locality, use a cpuset that is evenly distributed across NUMA
 nodes. Unbalanced cpusets may reduce the locality benefit of CPU binding.
 
-On A5, CPU binding uses deterministic global CPU slicing because A5 does not
-report NPU-to-CPU affinity in `npu-smi info -t topo`. A5 still pins worker,
+On Ascend 950, CPU binding uses deterministic global CPU slicing because Ascend 950 does not
+report NPU-to-CPU affinity in `npu-smi info -t topo`. Ascend 950 still pins worker,
 ACL, and release threads and can still migrate memory pages when `migratepages`
-is available. Because A5 skips IRQ binding, it does not reserve the first two
+is available. Because Ascend 950 skips IRQ binding, it does not reserve the first two
 CPUs in each NPU pool for IRQ handling. Those CPUs are assigned to the main
 worker instead.
 
@@ -103,8 +103,8 @@ can use `systemctl`, vLLM Ascend stops it before applying IRQ affinity. In
 containers where `systemctl` is unavailable, stop `irqbalance` on the host when
 IRQ affinity matters.
 
-A5 does not apply IRQ binding. When running on A5, the log contains
-`[irq] IRQ binding skipped on A5.` and no `/proc/irq/*/smp_affinity` files are
+Ascend 950 does not apply IRQ binding. When running on Ascend 950, the log contains
+`[irq] IRQ binding skipped on Ascend 950.` and no `/proc/irq/*/smp_affinity` files are
 written by this feature.
 
 On the host, stop `irqbalance` before starting vLLM when you need stable IRQ
@@ -127,8 +127,8 @@ sudo systemctl start irqbalance
 | --- | --- | --- |
 | `CPU binding skipped: non-ARM CPU detected.` | CPU binding only runs on ARM. | No action needed on x86_64. |
 | `Can not get running npu info.` | No running NPU was found, or `ASCEND_RT_VISIBLE_DEVICES` filtered all NPUs. | Check visible NPU IDs and `npu-smi info`. |
-| `Insufficient CPUs for binding...` | Fewer CPUs are available than the role split requires. Devices with IRQ binding need at least 5 CPUs per logical NPU; A5 needs at least 3. | Expand the cpuset or reduce visible NPUs. |
+| `Insufficient CPUs for binding...` | Fewer CPUs are available than the role split requires. Devices with IRQ binding need at least 5 CPUs per logical NPU; Ascend 950 needs at least 3. | Expand the cpuset or reduce visible NPUs. |
 | `NPU topo affinity not found...` | Topology affinity is unavailable. | vLLM Ascend falls back to `global_slice`; check `npu-smi info -t topo` only if topology affinity is expected on this device. |
 | `The 'migratepages' command is not available...` | Memory migration is skipped, while CPU thread binding still proceeds. | Install `numactl` if NUMA locality or performance is affected. |
-| `[irq] IRQ binding skipped on A5.` | A5 does not use the IRQ binding step. | No action needed. Worker, ACL, release thread binding and memory migration still proceed. |
+| `[irq] IRQ binding skipped on Ascend 950.` | Ascend 950 does not use the IRQ binding step. | No action needed. Worker, ACL, release thread binding and memory migration still proceed. |
 | `Bind cpus failed in rank...` | A binding step failed and CPU binding was skipped for that rank. | Check `taskset`, `lscpu`, `npu-smi`, cpuset size, and `/proc/irq` permissions. |

--- a/docs/source/user_guide/feature_guide/cpu_binding.md
+++ b/docs/source/user_guide/feature_guide/cpu_binding.md
@@ -90,11 +90,22 @@ degrade latency or throughput.**
 For optimal locality, use a cpuset that is evenly distributed across NUMA
 nodes. Unbalanced cpusets may reduce the locality benefit of CPU binding.
 
+On A5, CPU binding uses deterministic global CPU slicing because A5 does not
+report NPU-to-CPU affinity in `npu-smi info -t topo`. A5 still pins worker,
+ACL, and release threads and can still migrate memory pages when `migratepages`
+is available. Because A5 skips IRQ binding, it does not reserve the first two
+CPUs in each NPU pool for IRQ handling. Those CPUs are assigned to the main
+worker instead.
+
 For IRQ binding, the process also needs permission to read `/proc/interrupts`
 and write `/proc/irq/*/smp_affinity`. If `irqbalance` is running and the process
 can use `systemctl`, vLLM Ascend stops it before applying IRQ affinity. In
 containers where `systemctl` is unavailable, stop `irqbalance` on the host when
 IRQ affinity matters.
+
+A5 does not apply IRQ binding. When running on A5, the log contains
+`[irq] IRQ binding skipped on A5.` and no `/proc/irq/*/smp_affinity` files are
+written by this feature.
 
 On the host, stop `irqbalance` before starting vLLM when you need stable IRQ
 affinity:
@@ -116,7 +127,8 @@ sudo systemctl start irqbalance
 | --- | --- | --- |
 | `CPU binding skipped: non-ARM CPU detected.` | CPU binding only runs on ARM. | No action needed on x86_64. |
 | `Can not get running npu info.` | No running NPU was found, or `ASCEND_RT_VISIBLE_DEVICES` filtered all NPUs. | Check visible NPU IDs and `npu-smi info`. |
-| `Insufficient CPUs for binding...` | Fewer than 5 CPUs are available per logical NPU. | Expand the cpuset or reduce visible NPUs. |
+| `Insufficient CPUs for binding...` | Fewer CPUs are available than the role split requires. Devices with IRQ binding need at least 5 CPUs per logical NPU; A5 needs at least 3. | Expand the cpuset or reduce visible NPUs. |
 | `NPU topo affinity not found...` | Topology affinity is unavailable. | vLLM Ascend falls back to `global_slice`; check `npu-smi info -t topo` only if topology affinity is expected on this device. |
 | `The 'migratepages' command is not available...` | Memory migration is skipped, while CPU thread binding still proceeds. | Install `numactl` if NUMA locality or performance is affected. |
+| `[irq] IRQ binding skipped on A5.` | A5 does not use the IRQ binding step. | No action needed. Worker, ACL, release thread binding and memory migration still proceed. |
 | `Bind cpus failed in rank...` | A binding step failed and CPU binding was skipped for that rank. | Check `taskset`, `lscpu`, `npu-smi`, cpuset size, and `/proc/irq` permissions. |

--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -253,7 +253,6 @@ class TestDeviceInfo(unittest.TestCase):
 
         self.assertEqual(device_info.resolve_logic_id("0", "1"), 1)
 
-
     def test_expand_cpu_list(self):
         result = self.device_info.expand_cpu_list("0-2, 4, 6-8")
         self.assertEqual(result, [0, 1, 2, 4, 6, 7, 8])
@@ -293,9 +292,7 @@ class TestCpuAlloc(unittest.TestCase):
         visible_devices_patcher.start()
         self.addCleanup(visible_devices_patcher.stop)
 
-        device_type_patcher = patch(
-            "vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2
-        )
+        device_type_patcher = patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
         device_type_patcher.start()
         self.addCleanup(device_type_patcher.stop)
 
@@ -561,9 +558,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         visible_devices_patcher.start()
         self.addCleanup(visible_devices_patcher.stop)
 
-        device_type_patcher = patch(
-            "vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2
-        )
+        device_type_patcher = patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
         device_type_patcher.start()
         self.addCleanup(device_type_patcher.stop)
 

--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -452,7 +452,7 @@ class TestCpuAlloc(unittest.TestCase):
             self.cpu_alloc.build_global_slice_cpu_pool()
 
     @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
-    def test_build_global_slice_cpu_pool_allows_a5_without_irq_reservation(self, _mock_get_device_type):
+    def test_build_global_slice_cpu_pool_allows_ascend_950_without_irq_reservation(self, _mock_get_device_type):
         self.cpu_alloc.device_info.running_npu_list = [0, 1]
         self.cpu_alloc.device_info.allowed_cpus = list(range(6))
         self.cpu_alloc.device_info.total_logic_npus = 2
@@ -495,7 +495,7 @@ class TestCpuAlloc(unittest.TestCase):
             self.cpu_alloc.allocate()
 
     @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
-    def test_allocate_a5_uses_unreserved_cpus_for_main(self, _mock_get_device_type):
+    def test_allocate_ascend_950_uses_unreserved_cpus_for_main(self, _mock_get_device_type):
         self.cpu_alloc.device_info.running_npu_list = [0]
         self.cpu_alloc.npu_cpu_pool = {0: [0, 1, 2, 3, 4]}
 
@@ -824,7 +824,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
     @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
     @patch("vllm_ascend.cpu_binding.os.access")
     @patch("vllm_ascend.cpu_binding.execute_command")
-    def test_bind_npu_irq_skips_on_a5(self, mock_execute_command, mock_access, _mock_get_device_type):
+    def test_bind_npu_irq_skips_on_ascend_950(self, mock_execute_command, mock_access, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [0]
         cpu_alloc.npu_cpu_pool = {0: [8, 9, 10]}

--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -84,6 +84,10 @@ class TestDeviceInfo(unittest.TestCase):
 
     @patch("vllm_ascend.cpu_binding.execute_command")
     def setUp(self, mock_execute_command):
+        visible_devices_patcher = patch("vllm_ascend.cpu_binding.ASCEND_RT_VISIBLE_DEVICES", None)
+        visible_devices_patcher.start()
+        self.addCleanup(visible_devices_patcher.stop)
+
         mock_execute_command.side_effect = [
             ("NPU ID  Chip ID  Chip Logic ID  Chip Name\n0 0 0 Ascend\n0 1 - Mcu\n1 0 1 Ascend", 0),
             ("| NPU Chip | Process id |\n| 0 0 | 1234 | vllm | 56000 |\n| 1 0 | 1235 | vllm | 56000 |", 0),
@@ -106,6 +110,25 @@ class TestDeviceInfo(unittest.TestCase):
             npu_map_info = self.device_info.get_npu_map_info()
             expected = result_list.pop(0)
             self.assertEqual(npu_map_info, expected)
+
+    @patch("vllm_ascend.cpu_binding.execute_command")
+    def test_get_npu_map_info_without_chip_logic_id_uses_npu_id(self, mock_execute_command):
+        mock_execute_command.return_value = (
+            "NPU ID  Slot ID  Chip ID  Chip Phy-ID  Chip Name\n"
+            "0 0 0 0 Ascend950DT\n"
+            "1 1 0 1 Ascend950DT\n"
+            "2 2 0 2 Ascend950DT",
+            0,
+        )
+
+        self.assertEqual(
+            self.device_info.get_npu_map_info(),
+            {
+                "0": {"0": "0"},
+                "1": {"0": "1"},
+                "2": {"0": "2"},
+            },
+        )
 
     @patch("vllm_ascend.cpu_binding.execute_command")
     def test_get_running_npus(self, mock_execute_command):
@@ -150,6 +173,45 @@ class TestDeviceInfo(unittest.TestCase):
         self.assertEqual(device_info.get_running_npus(), [0])
 
     @patch("vllm_ascend.cpu_binding.execute_command")
+    def test_get_running_npus_from_npu_only_process_table(self, mock_execute_command):
+        device_info = object.__new__(DeviceInfo)
+        device_info.npu_map_info = {"0": {"0": "0"}, "1": {"0": "1"}}
+        mock_execute_command.return_value = (
+            "| NPU ID                    | Process id    | Process name             | Process memory(MB)       |\n"
+            "| 0                          | 2018733       | VLLMWorker_TP            | 30212                   |\n"
+            "| 1                          | 2018734       | VLLMWorker_TP            | 30212                   |",
+            0,
+        )
+
+        self.assertEqual(device_info.get_running_npus(), [0, 1])
+
+    @patch("vllm_ascend.cpu_binding.execute_command")
+    def test_get_running_npus_from_npu_chip_process_table_with_extra_spaces(self, mock_execute_command):
+        device_info = object.__new__(DeviceInfo)
+        device_info.npu_map_info = {"0": {"0": "0"}, "1": {"0": "1"}}
+        mock_execute_command.return_value = (
+            "| NPU     Chip              | Process id    | Process name             | Process memory(MB)      |\n"
+            "| 0       0                 | 3428811       | python3.10               | 56600                   |\n"
+            "| 1       0                 | 3428818       | python3.10               | 56474                   |",
+            0,
+        )
+
+        self.assertEqual(device_info.get_running_npus(), [0, 1])
+
+    @patch("vllm_ascend.cpu_binding.execute_command")
+    def test_get_running_npus_raises_for_ambiguous_npu_only_map(self, mock_execute_command):
+        device_info = object.__new__(DeviceInfo)
+        device_info.npu_map_info = {"0": {"0": "0", "1": "1"}}
+        mock_execute_command.return_value = (
+            "| NPU ID | Process id | Process name | Process memory(MB) |\n"
+            "| 0      | 1234       | vllm         | 56000              |",
+            0,
+        )
+
+        with self.assertRaises(RuntimeError):
+            device_info.get_running_npus()
+
+    @patch("vllm_ascend.cpu_binding.execute_command")
     def test_parse_topo_affinity(self, mock_execute_command):
         mock_execute_command.return_value = ("NPU0 X HCCS HCCS HCCS HCCS HCCS HCCS HCCS 0-3", 0)
         affinity = self.device_info.parse_topo_affinity()
@@ -164,7 +226,33 @@ class TestDeviceInfo(unittest.TestCase):
             0,
         )
 
-        self.assertEqual(device_info.parse_topo_affinity(), {1: [2, 3]})
+        self.assertEqual(device_info.parse_topo_affinity(), {0: [2, 3]})
+
+    @patch("vllm_ascend.cpu_binding.execute_command")
+    def test_parse_topo_affinity_skips_topo_matrix_without_cpu_affinity(self, mock_execute_command):
+        device_info = object.__new__(DeviceInfo)
+        mock_execute_command.return_value = (
+            "       NPU0       NPU1       NIC0\n"
+            "NPU0       X          UB         NA\n"
+            "NPU1       UB         X          NA\n"
+            "NIC0       NA         NA         X",
+            0,
+        )
+
+        self.assertEqual(device_info.parse_topo_affinity(), {})
+
+    def test_resolve_logic_id_from_npu_only_single_chip_map(self):
+        device_info = object.__new__(DeviceInfo)
+        device_info.npu_map_info = {"7": {"0": "7"}}
+
+        self.assertEqual(device_info.resolve_logic_id("7", None), 7)
+
+    def test_resolve_logic_id_from_chip_aware_map(self):
+        device_info = object.__new__(DeviceInfo)
+        device_info.npu_map_info = {"0": {"0": "0", "1": "1"}}
+
+        self.assertEqual(device_info.resolve_logic_id("0", "1"), 1)
+
 
     def test_expand_cpu_list(self):
         result = self.device_info.expand_cpu_list("0-2, 4, 6-8")
@@ -201,6 +289,16 @@ class TestDeviceInfo(unittest.TestCase):
 class TestCpuAlloc(unittest.TestCase):
     @patch("vllm_ascend.cpu_binding.execute_command")
     def setUp(self, mock_execute_command):
+        visible_devices_patcher = patch("vllm_ascend.cpu_binding.ASCEND_RT_VISIBLE_DEVICES", None)
+        visible_devices_patcher.start()
+        self.addCleanup(visible_devices_patcher.stop)
+
+        device_type_patcher = patch(
+            "vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2
+        )
+        device_type_patcher.start()
+        self.addCleanup(device_type_patcher.stop)
+
         mock_execute_command.side_effect = [
             ("NPU ID  Chip ID  Chip Logic ID  Chip Name\n0 0 0 Ascend\n0 1 - Mcu\n1 0 1 Ascend", 0),
             ("| NPU Chip | Process id |\n| 0 0 | 1234 | vllm | 56000 |\n| 1 0 | 1235 | vllm | 56000 |", 0),
@@ -235,6 +333,8 @@ class TestCpuAlloc(unittest.TestCase):
         mock_get_device_type.return_value = AscendDeviceType.A2
         self.assertEqual(self.cpu_alloc._binding_mode(), "topo_affinity")
         mock_get_device_type.return_value = AscendDeviceType.A3
+        self.assertEqual(self.cpu_alloc._binding_mode(), "global_slice")
+        mock_get_device_type.return_value = AscendDeviceType.A5
         self.assertEqual(self.cpu_alloc._binding_mode(), "global_slice")
 
     @patch("vllm_ascend.cpu_binding.get_ascend_device_type")
@@ -345,13 +445,25 @@ class TestCpuAlloc(unittest.TestCase):
         self.assertEqual(self.cpu_alloc.npu_cpu_pool[0], [0, 1, 2, 3, 4, 5])
         self.assertEqual(self.cpu_alloc.npu_cpu_pool[1], [6, 7, 8, 9, 10, 11])
 
-    def test_build_global_slice_cpu_pool_raises_when_cpu_insufficient(self):
+    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    def test_build_global_slice_cpu_pool_raises_when_cpu_insufficient(self, _mock_get_device_type):
         self.cpu_alloc.device_info.running_npu_list = [0, 1]
         self.cpu_alloc.device_info.allowed_cpus = list(range(8))
         self.cpu_alloc.device_info.total_logic_npus = 2
 
         with self.assertRaises(RuntimeError):
             self.cpu_alloc.build_global_slice_cpu_pool()
+
+    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    def test_build_global_slice_cpu_pool_allows_a5_without_irq_reservation(self, _mock_get_device_type):
+        self.cpu_alloc.device_info.running_npu_list = [0, 1]
+        self.cpu_alloc.device_info.allowed_cpus = list(range(6))
+        self.cpu_alloc.device_info.total_logic_npus = 2
+
+        self.cpu_alloc.build_global_slice_cpu_pool()
+
+        self.assertEqual(self.cpu_alloc.npu_cpu_pool[0], [0, 1, 2])
+        self.assertEqual(self.cpu_alloc.npu_cpu_pool[1], [3, 4, 5])
 
     def test_build_global_slice_cpu_pool_raises_invalid_npu_id(self):
         self.cpu_alloc.device_info.running_npu_list = [2]
@@ -372,14 +484,39 @@ class TestCpuAlloc(unittest.TestCase):
         self.cpu_alloc.build_global_slice_cpu_pool()
         self.assertEqual(self.cpu_alloc.npu_cpu_pool, {})
 
+    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
     @patch("vllm_ascend.cpu_binding.execute_command")
-    def test_allocate(self, _mock_execute_command):
+    def test_allocate(self, _mock_execute_command, _mock_get_device_type):
         self.cpu_alloc.device_info.running_npu_list = [0]
         self.cpu_alloc.npu_cpu_pool = {0: [0, 1, 2, 3, 4]}
         self.cpu_alloc.allocate()
         self.assertEqual(self.cpu_alloc.assign_main[0], [2])
         self.assertEqual(self.cpu_alloc.assign_acl[0], [3])
         self.assertEqual(self.cpu_alloc.assign_rel[0], [4])
+        self.cpu_alloc.npu_cpu_pool = {0: [0, 1]}
+        with self.assertRaises(RuntimeError):
+            self.cpu_alloc.allocate()
+
+    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    def test_allocate_a5_uses_unreserved_cpus_for_main(self, _mock_get_device_type):
+        self.cpu_alloc.device_info.running_npu_list = [0]
+        self.cpu_alloc.npu_cpu_pool = {0: [0, 1, 2, 3, 4]}
+
+        self.cpu_alloc.allocate()
+
+        self.assertEqual(self.cpu_alloc.assign_main[0], [0, 1, 2])
+        self.assertEqual(self.cpu_alloc.assign_acl[0], [3])
+        self.assertEqual(self.cpu_alloc.assign_rel[0], [4])
+
+        self.cpu_alloc.assign_main = {}
+        self.cpu_alloc.assign_acl = {}
+        self.cpu_alloc.assign_rel = {}
+        self.cpu_alloc.npu_cpu_pool = {0: [0, 1, 2]}
+        self.cpu_alloc.allocate()
+        self.assertEqual(self.cpu_alloc.assign_main[0], [0])
+        self.assertEqual(self.cpu_alloc.assign_acl[0], [1])
+        self.assertEqual(self.cpu_alloc.assign_rel[0], [2])
+
         self.cpu_alloc.npu_cpu_pool = {0: [0, 1]}
         with self.assertRaises(RuntimeError):
             self.cpu_alloc.allocate()
@@ -419,6 +556,17 @@ class TestCpuAlloc(unittest.TestCase):
 
 
 class TestCpuBindingSupplemental(unittest.TestCase):
+    def setUp(self):
+        visible_devices_patcher = patch("vllm_ascend.cpu_binding.ASCEND_RT_VISIBLE_DEVICES", None)
+        visible_devices_patcher.start()
+        self.addCleanup(visible_devices_patcher.stop)
+
+        device_type_patcher = patch(
+            "vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2
+        )
+        device_type_patcher.start()
+        self.addCleanup(device_type_patcher.stop)
+
     def test_cpu_to_mask_handles_single_and_multi_group_masks(self):
         self.assertEqual(CpuAlloc.cpu_to_mask(3), "00000008")
         self.assertEqual(CpuAlloc.cpu_to_mask(35), "00000008,00000000")
@@ -667,17 +815,36 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         )
         mock_bind_memory.assert_called_once_with("1000", 0)
 
+    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
     @patch("vllm_ascend.cpu_binding.os.access", return_value=False)
     @patch("vllm_ascend.cpu_binding.execute_command")
-    def test_bind_npu_irq_returns_when_irq_path_not_writable(self, mock_execute_command, _mock_access):
+    def test_bind_npu_irq_returns_when_irq_path_not_writable(
+        self, mock_execute_command, _mock_access, _mock_get_device_type
+    ):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.bind_npu_irq()
 
         mock_execute_command.assert_not_called()
 
+    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch("vllm_ascend.cpu_binding.os.access")
+    @patch("vllm_ascend.cpu_binding.execute_command")
+    def test_bind_npu_irq_skips_on_a5(self, mock_execute_command, mock_access, _mock_get_device_type):
+        cpu_alloc = make_cpu_alloc()
+        cpu_alloc.device_info.running_npu_list = [0]
+        cpu_alloc.npu_cpu_pool = {0: [8, 9, 10]}
+
+        cpu_alloc.bind_npu_irq()
+
+        mock_access.assert_not_called()
+        mock_execute_command.assert_not_called()
+
+    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
     @patch("vllm_ascend.cpu_binding.os.access", return_value=True)
     @patch("vllm_ascend.cpu_binding.execute_command")
-    def test_bind_npu_irq_returns_when_current_npu_has_no_cpu_pool(self, mock_execute_command, _mock_access):
+    def test_bind_npu_irq_returns_when_current_npu_has_no_cpu_pool(
+        self, mock_execute_command, _mock_access, _mock_get_device_type
+    ):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [0]
         cpu_alloc.npu_cpu_pool = {}

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -7,12 +7,14 @@ import subprocess
 from collections import defaultdict
 
 import psutil
+import regex as re
 from vllm.logger import logger
 
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 MASK_BIT = 32  # Number of bits in a CPU affinity mask group
 MIN_CPUS_PER_NPU = 5  # 2(IRQ) + 1(main, at least 1 CPU) + 1(acl) + 1(release) = 5 CPUs per NPU
+MIN_CPUS_PER_NPU_WITHOUT_IRQ = 3  # 1(main, at least 1 CPU) + 1(acl) + 1(release)
 ALLOWED_CPUS_PATH = "/proc/self/status"
 ASCEND_RT_VISIBLE_DEVICES = os.getenv("ASCEND_RT_VISIBLE_DEVICES")
 
@@ -23,7 +25,9 @@ DEVICE_BINDING_MODE: dict["AscendDeviceType", str] = {
     AscendDeviceType.A2: TOPO_AFFINITY_MODE,
     AscendDeviceType.A3: GLOBAL_SLICE_MODE,
     AscendDeviceType._310P: TOPO_AFFINITY_MODE,
+    AscendDeviceType.A5: GLOBAL_SLICE_MODE,
 }
+NO_IRQ_BINDING_DEVICE_TYPES = {AscendDeviceType.A5}
 
 
 def is_arm_cpu() -> bool:
@@ -64,6 +68,14 @@ class DeviceInfo:
         self.total_logic_npus: int = len(self.all_logic_npus)
 
     @staticmethod
+    def split_npu_smi_header(line: str) -> list[str]:
+        return [item.strip() for item in re.split(r"\s{2,}", line.strip()) if item.strip()]
+
+    @staticmethod
+    def is_cpu_list(cpu_list_str: str) -> bool:
+        return bool(re.fullmatch(r"\d+(?:-\d+)?(?:,\s*\d+(?:-\d+)?)*", cpu_list_str))
+
+    @staticmethod
     def expand_cpu_list(allowed_list_str: str) -> list[int]:
         allowed_cpus_list: list[int] = []
         for per_range in allowed_list_str.split(","):
@@ -92,9 +104,38 @@ class DeviceInfo:
     def get_npu_map_info() -> dict[str, dict[str, str]]:
         npu_map_info: dict[str, dict[str, str]] = {}
         npu_info, _ = execute_command(["npu-smi", "info", "-m"])
-        npu_map = npu_info.strip().split("\n")[1:]
-        for line in npu_map:
-            npu_id, chip_id, chip_logic_id = line.strip().split()[:3]
+        npu_map = [line.strip() for line in npu_info.splitlines() if line.strip()]
+        if not npu_map:
+            return npu_map_info
+
+        header = DeviceInfo.split_npu_smi_header(npu_map[0])
+        try:
+            npu_id_idx = header.index("NPU ID")
+        except ValueError:
+            return npu_map_info
+        chip_id_idx = header.index("Chip ID") if "Chip ID" in header else None
+        chip_logic_id_idx = header.index("Chip Logic ID") if "Chip Logic ID" in header else None
+
+        for line in npu_map[1:]:
+            parts = line.split()
+            if len(parts) <= npu_id_idx:
+                continue
+            npu_id = parts[npu_id_idx]
+            if not npu_id.isdigit():
+                continue
+
+            chip_id = "0"
+            if chip_id_idx is not None:
+                if len(parts) <= chip_id_idx or not parts[chip_id_idx].isdigit():
+                    continue
+                chip_id = parts[chip_id_idx]
+
+            if chip_logic_id_idx is not None:
+                if len(parts) <= chip_logic_id_idx:
+                    continue
+                chip_logic_id = parts[chip_logic_id_idx]
+            else:
+                chip_logic_id = npu_id
             if not chip_logic_id.isdigit():
                 continue
             if npu_id not in npu_map_info:
@@ -102,13 +143,33 @@ class DeviceInfo:
             npu_map_info[npu_id][chip_id] = chip_logic_id
         return npu_map_info
 
+    def resolve_logic_id(self, npu_id: str, chip_id: str | None) -> int:
+        chip_map = self.npu_map_info.get(npu_id, {})
+        if chip_id is not None:
+            chip_logic_id = chip_map.get(chip_id)
+        elif len(chip_map) == 1:
+            chip_logic_id = next(iter(chip_map.values()))
+        else:
+            raise RuntimeError(
+                "Failed to resolve chip_logic_id because the process table does not contain chip_id "
+                f"and NPU {npu_id} has {len(chip_map)} mapped chips."
+            )
+        if not chip_logic_id or not chip_logic_id.isdigit():
+            raise RuntimeError("Failed to get correct chip_logic_id from command 'npu-smi info -m'.")
+        return int(chip_logic_id)
+
     def get_running_npus(self) -> list[int]:
         npu_message, _ = execute_command(["npu-smi", "info"])
         in_proc_section = False
+        proc_npu_field = ""
         running_npu_set = set()
         for line in npu_message.splitlines():
             line = line.strip()
             if line.startswith("| NPU") and "Process id" in line:
+                parts = [p.strip() for p in line.strip("|").split("|")]
+                if not parts:
+                    continue
+                proc_npu_field = " ".join(parts[0].split())
                 in_proc_section = True
                 continue
             if not in_proc_section:
@@ -117,14 +178,18 @@ class DeviceInfo:
                 parts = [p.strip() for p in line.strip("|").split("|")]
                 if len(parts) < 2:
                     continue
-                npu_id = parts[0].split()[0]
-                chip_id = parts[0].split()[1]
-                if not npu_id.isdigit() or not chip_id.isdigit():
+                npu_chip_parts = parts[0].split()
+                if not npu_chip_parts:
                     continue
-                chip_logic_id = self.npu_map_info.get(npu_id, {}).get(chip_id)
-                if not chip_logic_id or not chip_logic_id.isdigit():
-                    raise RuntimeError("Failed to get correct chip_logic_id from command 'npu-smi info -m'.")
-                running_npu_set.add(int(chip_logic_id))
+                npu_id = npu_chip_parts[0]
+                chip_id = None
+                if proc_npu_field == "NPU Chip":
+                    if len(npu_chip_parts) < 2:
+                        continue
+                    chip_id = npu_chip_parts[1]
+                if not npu_id.isdigit() or (chip_id is not None and not chip_id.isdigit()):
+                    continue
+                running_npu_set.add(self.resolve_logic_id(npu_id, chip_id))
         if ASCEND_RT_VISIBLE_DEVICES:
             devices_str = ASCEND_RT_VISIBLE_DEVICES
             devices_list = [int(x) for x in devices_str.split(",")]
@@ -143,16 +208,17 @@ class DeviceInfo:
         raise RuntimeError("Can not found specific 'Cpus_allowed_list' in the '/proc/self/status' file.")
 
     def parse_topo_affinity(self) -> dict[int, list[int]]:
-        chip_logic_id = 0
         affinity: dict[int, list[int]] = {}
         affinity_message, _ = execute_command(["npu-smi", "info", "-t", "topo"])
         for line in affinity_message.splitlines():
             if line.startswith("NPU"):
                 parts = line.split()
+                npu_match = re.fullmatch(r"NPU(\d+)", parts[0])
+                if not npu_match:
+                    continue
                 last_part = parts[-1]
-                if last_part != "Affinity":
-                    affinity[chip_logic_id] = self.expand_cpu_list(last_part)
-                chip_logic_id += 1
+                if self.is_cpu_list(last_part):
+                    affinity[int(npu_match.group(1))] = self.expand_cpu_list(last_part)
         return affinity
 
 
@@ -258,7 +324,7 @@ class CpuAlloc:
         Notes:
           - This strategy does NOT rely on npu-smi topo affinity.
           - NUMA locality is achieved only if CPU numbering aligns with NUMA layout.
-          - Requires per-NPU slice size >= 5 (IRQ(2) + main(>=1) + acl(1) + release(1)).
+          - Requires enough CPUs for each device's role split.
         """
         running = list(self.device_info.running_npu_list)
         if not running:
@@ -295,15 +361,16 @@ class CpuAlloc:
             allowed[-16:],
         )
 
-        # Enforce per-NPU slice length >= 5.
+        min_cpus_per_npu = self._min_cpus_per_npu()
+        # Enforce the minimum per-NPU slice length.
         # Because with remainder distribution, some NPUs may get 'base' cores and some get 'base+1'.
         # The minimum slice size is 'base'.
-        if base < MIN_CPUS_PER_NPU:
+        if base < min_cpus_per_npu:
             raise RuntimeError(
-                "Insufficient CPUs for binding with IRQ/ACL/REL reservations: "
+                "Insufficient CPUs for binding with CPU role reservations: "
                 f"total_allowed={total_cpu}, total_npus={total_npus}, "
-                f"min_per_npu={base} (<{MIN_CPUS_PER_NPU}). "
-                f"Need at least {total_npus * MIN_CPUS_PER_NPU} CPUs in cpuset."
+                f"min_per_npu={base} (<{min_cpus_per_npu}). "
+                f"Need at least {total_npus * min_cpus_per_npu} CPUs in cpuset."
             )
 
         def _slice_for_npu(global_npu_id: int) -> list[int]:
@@ -323,6 +390,16 @@ class CpuAlloc:
     def _binding_mode() -> str:
         device_type = get_ascend_device_type()
         return DEVICE_BINDING_MODE.get(device_type, TOPO_AFFINITY_MODE)
+
+    @staticmethod
+    def _reserve_irq_cpus() -> bool:
+        return get_ascend_device_type() not in NO_IRQ_BINDING_DEVICE_TYPES
+
+    @staticmethod
+    def _min_cpus_per_npu() -> int:
+        if CpuAlloc._reserve_irq_cpus():
+            return MIN_CPUS_PER_NPU
+        return MIN_CPUS_PER_NPU_WITHOUT_IRQ
 
     def build_cpu_pools(self) -> None:
         self.build_cpu_node_map()
@@ -374,14 +451,19 @@ class CpuAlloc:
         self.npu_cpu_pool = {npu: final[npu] for npu in self.device_info.running_npu_list}
 
     def allocate(self) -> None:
+        reserve_irq_cpus = self._reserve_irq_cpus()
+        min_cpus_per_npu = self._min_cpus_per_npu()
         for npu, pool in self.npu_cpu_pool.items():
-            if len(pool) >= MIN_CPUS_PER_NPU:
-                main = pool[2:-2]
+            if len(pool) >= min_cpus_per_npu:
+                if reserve_irq_cpus:
+                    main = pool[2:-2]
+                else:
+                    main = pool[:-2]
                 acl = [pool[-2]]
                 rel = [pool[-1]]
             else:
                 raise RuntimeError(
-                    f"The number of CPUs is insufficient. Each NPU requires at least {MIN_CPUS_PER_NPU} CPUs."
+                    f"The number of CPUs is insufficient. Each NPU requires at least {min_cpus_per_npu} CPUs."
                 )
             self.assign_main[npu] = main
             self.assign_acl[npu] = acl
@@ -443,6 +525,10 @@ class CpuAlloc:
         self.bind_memory(main_pid, current_npu)
 
     def bind_npu_irq(self) -> None:
+        if not self._reserve_irq_cpus():
+            logger.info("[irq] IRQ binding skipped on A5.")
+            return
+
         if not os.access("/proc/irq", os.W_OK):
             return
 

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -507,7 +507,7 @@ class CpuAlloc:
 
     def bind_npu_irq(self) -> None:
         if not self._reserve_irq_cpus():
-            logger.info("[irq] IRQ binding skipped on A5.")
+            logger.info("[irq] IRQ binding skipped on Ascend 950.")
             return
 
         if not os.access("/proc/irq", os.W_OK):

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -105,34 +105,21 @@ class DeviceInfo:
         npu_map_info: dict[str, dict[str, str]] = {}
         npu_info, _ = execute_command(["npu-smi", "info", "-m"])
         npu_map = [line.strip() for line in npu_info.splitlines() if line.strip()]
-        if not npu_map:
-            return npu_map_info
 
         header = DeviceInfo.split_npu_smi_header(npu_map[0])
-        try:
-            npu_id_idx = header.index("NPU ID")
-        except ValueError:
-            return npu_map_info
+        npu_id_idx = header.index("NPU ID")
         chip_id_idx = header.index("Chip ID") if "Chip ID" in header else None
         chip_logic_id_idx = header.index("Chip Logic ID") if "Chip Logic ID" in header else None
 
         for line in npu_map[1:]:
             parts = line.split()
-            if len(parts) <= npu_id_idx:
-                continue
             npu_id = parts[npu_id_idx]
-            if not npu_id.isdigit():
-                continue
 
             chip_id = "0"
             if chip_id_idx is not None:
-                if len(parts) <= chip_id_idx or not parts[chip_id_idx].isdigit():
-                    continue
                 chip_id = parts[chip_id_idx]
 
             if chip_logic_id_idx is not None:
-                if len(parts) <= chip_logic_id_idx:
-                    continue
                 chip_logic_id = parts[chip_logic_id_idx]
             else:
                 chip_logic_id = npu_id
@@ -167,8 +154,6 @@ class DeviceInfo:
             line = line.strip()
             if line.startswith("| NPU") and "Process id" in line:
                 parts = [p.strip() for p in line.strip("|").split("|")]
-                if not parts:
-                    continue
                 proc_npu_field = " ".join(parts[0].split())
                 in_proc_section = True
                 continue
@@ -179,13 +164,9 @@ class DeviceInfo:
                 if len(parts) < 2:
                     continue
                 npu_chip_parts = parts[0].split()
-                if not npu_chip_parts:
-                    continue
                 npu_id = npu_chip_parts[0]
                 chip_id = None
                 if proc_npu_field == "NPU Chip":
-                    if len(npu_chip_parts) < 2:
-                        continue
                     chip_id = npu_chip_parts[1]
                 if not npu_id.isdigit() or (chip_id is not None and not chip_id.isdigit()):
                     continue


### PR DESCRIPTION
This PR updates CPU binding logic to support Ascend A5 servers.

Key changes:
- Parse `npu-smi info -m` by header so devices without `Chip Logic ID` can use `NPU ID` as the logical id.
- Support both `NPU Chip` and `NPU ID` process table formats from `npu-smi info`.
- Ignore A5 topo matrix rows that do not contain CPU affinity lists.
- Select `global_slice` mode for A5.
- Skip IRQ binding on A5 and do not reserve the first two CPUs for IRQ; A5 assigns `pool[:-2]` to the main worker, `pool[-2]` to ACL, and `pool[-1]` to release.

UT and documentation updates are intentionally kept out of this PR branch for separate follow-up work.

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
