### PR TITLE
[Test]update upstream workflow

### DIFF
--- a/.github/workflows/schedule_vllm_e2e_test.yaml
+++ b/.github/workflows/schedule_vllm_e2e_test.yaml
@@ -35,7 +35,7 @@ concurrency:
 
 env:
   UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-  UV_EXTRA_INDEX_URL: https://repo.huaweicloud.com/ascend/repos/pypi
+  UV_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu/"
   UV_INDEX_STRATEGY: unsafe-best-match
   UV_INSECURE_HOST: cache-service.nginx-pypi-cache.svc.cluster.local
   UV_HTTP_TIMEOUT: 120
@@ -43,23 +43,33 @@ env:
   UV_SYSTEM_PYTHON: 1
 
 jobs:
+    resolve-tag:
+        runs-on: ubuntu-latest
+        outputs:
+            release_tag: ${{ steps.vllm.outputs.release_tag }}
+        steps:
+          - uses: actions/checkout@v6
+          - name: Read vLLM release tag
+            id: vllm
+            uses: ./.github/actions/read-vllm-release-tag
+
     e2e-upstream_singlecard:
         runs-on: linux-aarch64-a2b3-1
+        needs: resolve-tag
         strategy:
           fail-fast: false
           matrix:
             part: [0, 1, 2, 3]
+            image_tag: [9.0.0-910b-ubuntu22.04-py3.12]
+            num_npus: [1]
         container:
-          image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.0-910b-ubuntu22.04-py3.12
+          image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.image_tag }}
           env:
             VLLM_LOGGING_LEVEL: ERROR
             HF_HUB_OFFLINE: 1
         steps:
           - name: Checkout vllm-project/vllm-ascend repo
             uses: actions/checkout@v6
-          - name: Read vLLM release tag
-            id: vllm
-            uses: ./.github/actions/read-vllm-release-tag
           - name: Check npu and CANN info
             run: |
               npu-smi info
@@ -86,7 +96,7 @@ jobs:
             uses: actions/checkout@v6
             with:
               repository: vllm-project/vllm
-              ref: ${{ steps.vllm.outputs.release_tag }}
+              ref: ${{ needs.resolve-tag.outputs.release_tag }}
               path: ./vllm-empty
               fetch-depth: 1
 
@@ -99,19 +109,54 @@ jobs:
               pip install -e tests/plugins/prithvi_io_processor_plugin
               sed -i '5i\import vllm_ascend.patch.platform\nimport vllm_ascend.patch.worker' tests/conftest.py
 
-          - name: Install vllm-project/vllm-ascend
-            env:
-              MAX_JOBS: "23"
+          - name: Get csrc hash
+            id: get_csrc_hash
             run: |
+              CSRC_HASH=$(find ./csrc ./setup.py ./CMakeLists.txt ./cmake \
+                -type f -not -path '*/.*' | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+              echo "CSRC_HASH=$CSRC_HASH" >> $GITHUB_OUTPUT
+
+          - name: Get architecture
+            id: get_arch
+            run: |
+              ARCH=$(uname -m)
+              case "$ARCH" in
+                x86_64) echo "arch=X64" >> $GITHUB_OUTPUT ;;
+                aarch64) echo "arch=ARM64" >> $GITHUB_OUTPUT ;;
+                *) echo "arch=$ARCH" >> $GITHUB_OUTPUT ;;
+              esac
+          
+          - name: Restore vllm-ascend csrc cache
+            id: cache-csrc
+            uses: runs-on/cache@v5
+            with:
+              path: |
+                vllm_ascend/_cann_ops_custom
+                vllm_ascend/*.so
+                vllm_ascend/lib
+                vllm_ascend/include
+              key: vllm-ascend-build-v1-${{ steps.get_arch.outputs.arch }}-${{ matrix.image_tag }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
+              restore-keys: |
+                vllm-ascend-build-v1-${{ steps.get_arch.outputs.arch }}-${{ matrix.image_tag }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
+           
+          - name: Install vllm-project/vllm-ascend with device
+            run: |
+              export MAX_JOBS=$(( ${{ matrix.num_npus }} * 23 ))
               pip install uc-manager
-              uv pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --extra-index-url  http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu/
               uv pip install -r requirements-dev.txt
               uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
-              uv pip install -e .
+              if find vllm_ascend -maxdepth 1 -name '*.so' -type f 2>/dev/null | grep -q .; then
+                echo "CSRC cache hit: .so files found, skip kernel compilation"
+                COMPILE_CUSTOM_KERNELS=0 uv pip install -e .
+              else
+                echo "CSRC cache miss: no .so files found, compile kernels"
+                uv pip install -e . --no-build-isolation
+              fi
               uv pip install tblib 
-              uv pip install runai_model_streamer pqdm timm schemathesis==3.39.15 "vllm[helion]" "runai-model-streamer[s3,gcs]"
+              uv pip install pqdm timm schemathesis==3.39.15 "vllm[helion]" "runai-model-streamer[s3,gcs]"
               uv pip install "mteb[bm25s]" open_clip_torch terratorch==1.2.2 imagehash
               uv pip install "lm-eval[api]" num2words "vllm[grpc]" "vllm[audio]"
+
           - name: Run vllm-project/vllm test
             working-directory: ./vllm-empty
             env:
@@ -127,24 +172,24 @@ jobs:
                 --auto-partition-id "${{ matrix.part }}" \
                 --auto-partition-size 4 \
                 --continue-on-error
-              
-    e2e-upstream_a2_2:
-        runs-on: linux-aarch64-a2b3-2
+
+    e2e-upstream_multicard:
+        runs-on: linux-aarch64-a2b3-${{ matrix.num_npus }}
+        needs: resolve-tag
         strategy:
           fail-fast: false
           matrix:
             part: [0]
+            image_tag: [9.0.0-910b-ubuntu22.04-py3.12]
+            num_npus: [2, 4]
         container:
-          image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.0-910b-ubuntu22.04-py3.12
+          image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.image_tag }}
           env:
             VLLM_LOGGING_LEVEL: ERROR
             HF_HUB_OFFLINE: 1
         steps:
           - name: Checkout vllm-project/vllm-ascend repo
             uses: actions/checkout@v6
-          - name: Read vLLM release tag
-            id: vllm
-            uses: ./.github/actions/read-vllm-release-tag
           - name: Check npu and CANN info
             run: |
               npu-smi info
@@ -171,7 +216,7 @@ jobs:
             uses: actions/checkout@v6
             with:
               repository: vllm-project/vllm
-              ref: ${{ steps.vllm.outputs.release_tag }}
+              ref: ${{ needs.resolve-tag.outputs.release_tag }}
               path: ./vllm-empty
               fetch-depth: 1
 
@@ -182,16 +227,51 @@ jobs:
               pip uninstall -y triton
               sed -i '5i\import vllm_ascend.patch.platform\nimport vllm_ascend.patch.worker' tests/conftest.py
 
-          - name: Install vllm-project/vllm-ascend
-            env:
-              MAX_JOBS: "46"
+          - name: Get csrc hash
+            id: get_csrc_hash
             run: |
+              CSRC_HASH=$(find ./csrc ./setup.py ./CMakeLists.txt ./cmake \
+                -type f -not -path '*/.*' | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+              echo "CSRC_HASH=$CSRC_HASH" >> $GITHUB_OUTPUT
+
+          - name: Get architecture
+            id: get_arch
+            run: |
+              ARCH=$(uname -m)
+              case "$ARCH" in
+                x86_64) echo "arch=X64" >> $GITHUB_OUTPUT ;;
+                aarch64) echo "arch=ARM64" >> $GITHUB_OUTPUT ;;
+                *) echo "arch=$ARCH" >> $GITHUB_OUTPUT ;;
+              esac
+          
+          - name: Restore vllm-ascend csrc cache
+            id: cache-csrc
+            uses: runs-on/cache@v5
+            with:
+              path: |
+                vllm_ascend/_cann_ops_custom
+                vllm_ascend/*.so
+                vllm_ascend/lib
+                vllm_ascend/include
+              key: vllm-ascend-build-v1-${{ steps.get_arch.outputs.arch }}-${{ matrix.image_tag }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
+              restore-keys: |
+                vllm-ascend-build-v1-${{ steps.get_arch.outputs.arch }}-${{ matrix.image_tag }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
+           
+          - name: Install vllm-project/vllm-ascend with device
+            run: |
+              export MAX_JOBS=$(( ${{ matrix.num_npus }} * 23 ))
               pip install uc-manager
               uv pip install -r requirements-dev.txt
               uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
-              uv pip install -e .
-              uv pip install tblib
-              
+              if find vllm_ascend -maxdepth 1 -name '*.so' -type f 2>/dev/null | grep -q .; then
+                echo "CSRC cache hit: .so files found, skip kernel compilation"
+                COMPILE_CUSTOM_KERNELS=0 uv pip install -e .
+              else
+                echo "CSRC cache miss: no .so files found, compile kernels"
+                uv pip install -e . --no-build-isolation
+              fi
+              uv pip install tblib 
+
           - name: Run vllm-project/vllm test
             working-directory: ./vllm-empty
             env:
@@ -199,28 +279,28 @@ jobs:
               VLLM_WORKER_MULTIPROC_METHOD: spawn
             run: |
               python3 ../.github/workflows/scripts/run_suite.py \
-                --suite e2e-upstream_a2_2 \
+                --suite e2e-upstream_a2_${{ matrix.num_npus }} \
                 --auto-partition-id "${{ matrix.part }}" \
                 --auto-partition-size 1 \
                 --continue-on-error
-
-    e2e-upstream_a2_4:
-        runs-on: linux-aarch64-a2b3-4
+              
+    e2e-upstream_online:
+        runs-on: linux-aarch64-a2b3-${{ matrix.num_npus }}
+        needs: resolve-tag
         strategy:
           fail-fast: false
           matrix:
             part: [0]
+            image_tag: [9.0.0-910b-ubuntu22.04-py3.12]
+            num_npus: [1]
         container:
-          image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.0-910b-ubuntu22.04-py3.12
+          image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.image_tag }}
           env:
             VLLM_LOGGING_LEVEL: ERROR
-            HF_HUB_OFFLINE: 1
+            HF_HUB_OFFLINE: 0
         steps:
           - name: Checkout vllm-project/vllm-ascend repo
             uses: actions/checkout@v6
-          - name: Read vLLM release tag
-            id: vllm
-            uses: ./.github/actions/read-vllm-release-tag
           - name: Check npu and CANN info
             run: |
               npu-smi info
@@ -247,7 +327,7 @@ jobs:
             uses: actions/checkout@v6
             with:
               repository: vllm-project/vllm
-              ref: ${{ steps.vllm.outputs.release_tag }}
+              ref: ${{ needs.resolve-tag.outputs.release_tag }}
               path: ./vllm-empty
               fetch-depth: 1
 
@@ -258,15 +338,53 @@ jobs:
               pip uninstall -y triton
               sed -i '5i\import vllm_ascend.patch.platform\nimport vllm_ascend.patch.worker' tests/conftest.py
 
-          - name: Install vllm-project/vllm-ascend
-            env:
-              MAX_JOBS: "92"
+          - name: Get csrc hash
+            id: get_csrc_hash
             run: |
+              CSRC_HASH=$(find ./csrc ./setup.py ./CMakeLists.txt ./cmake \
+                -type f -not -path '*/.*' | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+              echo "CSRC_HASH=$CSRC_HASH" >> $GITHUB_OUTPUT
+
+          - name: Get architecture
+            id: get_arch
+            run: |
+              ARCH=$(uname -m)
+              case "$ARCH" in
+                x86_64) echo "arch=X64" >> $GITHUB_OUTPUT ;;
+                aarch64) echo "arch=ARM64" >> $GITHUB_OUTPUT ;;
+                *) echo "arch=$ARCH" >> $GITHUB_OUTPUT ;;
+              esac
+          
+          - name: Restore vllm-ascend csrc cache
+            id: cache-csrc
+            uses: runs-on/cache@v5
+            with:
+              path: |
+                vllm_ascend/_cann_ops_custom
+                vllm_ascend/*.so
+                vllm_ascend/lib
+                vllm_ascend/include
+              key: vllm-ascend-build-v1-${{ steps.get_arch.outputs.arch }}-${{ matrix.image_tag }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
+              restore-keys: |
+                vllm-ascend-build-v1-${{ steps.get_arch.outputs.arch }}-${{ matrix.image_tag }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
+           
+          - name: Install vllm-project/vllm-ascend with device
+            run: |
+              export MAX_JOBS=$(( ${{ matrix.num_npus }} * 23 ))
               pip install uc-manager
               uv pip install -r requirements-dev.txt
               uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
-              uv pip install -e .
-              uv pip install tblib
+              if find vllm_ascend -maxdepth 1 -name '*.so' -type f 2>/dev/null | grep -q .; then
+                echo "CSRC cache hit: .so files found, skip kernel compilation"
+                COMPILE_CUSTOM_KERNELS=0 uv pip install -e .
+              else
+                echo "CSRC cache miss: no .so files found, compile kernels"
+                uv pip install -e . --no-build-isolation
+              fi
+              uv pip install tblib 
+              uv pip install pqdm timm schemathesis==3.39.15 "vllm[helion]" "runai-model-streamer[s3,gcs]"
+              uv pip install "mteb[bm25s]" open_clip_torch terratorch==1.2.2 imagehash
+              uv pip install "lm-eval[api]" num2words "vllm[grpc]" "vllm[audio]"
 
           - name: Run vllm-project/vllm test
             working-directory: ./vllm-empty
@@ -275,7 +393,7 @@ jobs:
               VLLM_WORKER_MULTIPROC_METHOD: spawn
             run: |
               python3 ../.github/workflows/scripts/run_suite.py \
-                --suite e2e-upstream_a2_4 \
+                --suite e2e-upstream_online_${{ matrix.num_npus }} \
                 --auto-partition-id "${{ matrix.part }}" \
                 --auto-partition-size 1 \
                 --continue-on-error

--- a/.github/workflows/scripts/run_suite.py
+++ b/.github/workflows/scripts/run_suite.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import multiprocessing
 import os
 import subprocess
 import sys
@@ -10,6 +11,8 @@ from pathlib import Path
 
 import tabulate
 import yaml
+
+multiprocessing.set_start_method("spawn", force=True)
 
 _CONFIG_UPSTREAM = Path(__file__).parent / "upstream_config.yaml"
 

--- a/.github/workflows/scripts/upstream_config.yaml
+++ b/.github/workflows/scripts/upstream_config.yaml
@@ -71,8 +71,6 @@ e2e-upstream_singlecard:
     estimated_time: 20
   - name: tests/lora/test_utils.py
     estimated_time: 20
-  - name: tests/model_executor/model_loader/runai_streamer_loader/test_runai_model_streamer_s3.py
-    estimated_time: 20
   - name: tests/model_executor/model_loader/runai_streamer_loader/test_weight_utils.py
     estimated_time: 20
   - name: tests/model_executor/model_loader/test_registry.py
@@ -151,10 +149,6 @@ e2e-upstream_singlecard:
     estimated_time: 20
   - name: tests/reasoning/test_minimax_m2_reasoning_parser.py
     estimated_time: 20
-  - name: tests/reasoning/test_mistral_reasoning_parser.py
-    estimated_time: 20
-  - name: tests/reasoning/test_olmo3_reasoning_parser.py
-    estimated_time: 20
   - name: tests/reasoning/test_qwen3_reasoning_parser.py
     estimated_time: 20
   - name: tests/test_embedded_commit.py
@@ -177,11 +171,7 @@ e2e-upstream_singlecard:
     estimated_time: 20
   - name: tests/test_vllm_port.py
     estimated_time: 20
-  - name: tests/tokenizers_/test_basic.py
-    estimated_time: 20
   - name: tests/tokenizers_/test_hf.py
-    estimated_time: 20
-  - name: tests/tokenizers_/test_mistral.py
     estimated_time: 20
   - name: tests/tokenizers_/test_registry.py
     estimated_time: 20
@@ -194,8 +184,6 @@ e2e-upstream_singlecard:
   - name: tests/tool_parsers/test_kimi_k2_tool_parser.py
     estimated_time: 20
   - name: tests/tool_parsers/test_minimax_tool_parser.py
-    estimated_time: 20
-  - name: tests/tool_parsers/test_mistral_tool_parser.py
     estimated_time: 20
   - name: tests/tool_parsers/test_qwen3coder_tool_parser.py
     estimated_time: 20
@@ -273,15 +261,11 @@ e2e-upstream_singlecard:
     estimated_time: 20
   - name: tests/v1/engine/test_parallel_sampling.py
     estimated_time: 20
-  - name: tests/v1/kv_connector/unit/test_backwards_compatibility.py
-    estimated_time: 20
   - name: tests/v1/kv_connector/unit/test_lmcache_connector.py
     estimated_time: 20
   - name: tests/v1/kv_connector/unit/test_lmcache_integration.py
     estimated_time: 20
   - name: tests/v1/kv_connector/unit/test_output_aggregator.py
-    estimated_time: 20
-  - name: tests/v1/kv_offload/test_cpu_manager.py
     estimated_time: 20
   - name: tests/v1/kv_offload/test_worker.py
     estimated_time: 20
@@ -298,8 +282,6 @@ e2e-upstream_singlecard:
   - name: tests/v1/spec_decode/test_mtp.py
     estimated_time: 20
   - name: tests/v1/spec_decode/test_ngram.py
-    estimated_time: 20
-  - name: tests/v1/structured_output/test_backend_guidance.py
     estimated_time: 20
   - name: tests/v1/structured_output/test_reasoning_structured_output.py
     estimated_time: 20
@@ -334,8 +316,6 @@ e2e-upstream_singlecard:
   - name: tests/multimodal/media/test_video.py
     estimated_time: 20
   - name: tests/multimodal/test_embedding_shape_validation_unit.py
-    estimated_time: 20
-  - name: tests/renderers/test_mistral.py
     estimated_time: 20
   - name: tests/test_attention_backend_registry.py
     estimated_time: 20
@@ -384,8 +364,6 @@ e2e-upstream_singlecard:
   - name: tests/models/multimodal/processing/test_qwen2_5_omni_embed.py
     estimated_time: 20
   - name: tests/multimodal/test_inputs.py
-    estimated_time: 20
-  - name: tests/plugins/lora_resolvers/test_hf_hub_resolver.py
     estimated_time: 20
   - name: tests/reasoning/test_step3p5_reasoning_parser.py
     estimated_time: 20
@@ -494,10 +472,6 @@ e2e-upstream_singlecard:
   - name: tests/v1/ec_connector/unit/test_ec_example_connector.py
     estimated_time: 20
   - name: tests/v1/worker/test_late_interaction_runner.py
-    estimated_time: 20
-  - name: tests/compile/fullgraph/test_multiple_graphs.py
-    estimated_time: 20
-  - name: tests/compile/fullgraph/test_toy_llama.py
     estimated_time: 20
   - name: tests/detokenizer/test_stop_reason.py
     estimated_time: 20
@@ -679,8 +653,6 @@ e2e-upstream_singlecard:
     estimated_time: 20
   - name: tests/entrypoints/openai/responses/test_serving_responses.py
     estimated_time: 20
-  - name: tests/entrypoints/openai/completion/test_token_in_token_out.py
-    estimated_time: 20
   - name: tests/entrypoints/openai/completion/test_completion_error.py
     estimated_time: 20
   - name: tests/entrypoints/openai/completion/test_lora_resolvers.py
@@ -779,8 +751,6 @@ e2e-upstream_singlecard:
     estimated_time: 20
   - name: tests/v1/kv_connector/unit/test_hf3fs_metadata_server.py
     estimated_time: 20
-  - name: tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
-    estimated_time: 20
   - name: tests/v1/sample/test_batched_count_greater_than.py
     estimated_time: 20
   - name: tests/v1/executor/test_ray_utils.py
@@ -800,8 +770,6 @@ e2e-upstream_singlecard:
   - name: tests/kernels/moe/test_moe_weight_loading_padded.py
     estimated_time: 20
   - name: tests/kernels/moe/test_topk_softplus_sqrt.py
-    estimated_time: 20
-  - name: tests/quantization/test_quark_maybe_update_config.py
     estimated_time: 20
   - name: tests/quantization/test_turboquant.py
     estimated_time: 20
@@ -877,8 +845,6 @@ e2e-upstream_singlecard:
     estimated_time: 20
   - name: tests/entrypoints/pooling/test_utils.py
     estimated_time: 20
-  - name: tests/evals/mrcr/test_mrcr_correctness.py
-    estimated_time: 20
   - name: tests/benchmarks/test_custom_dataset_seed.py
     estimated_time: 20
   - name: tests/model_executor/test_gemma_hidden_act.py
@@ -890,8 +856,6 @@ e2e-upstream_singlecard:
   - name: tests/compile/test_codegen.py
     estimated_time: 20
   - name: tests/tools/test_docker_build_metadata_args.py
-    estimated_time: 20
-  - name: tests/models/multimodal/processing/test_moondream3.py
     estimated_time: 20
   - name: tests/models/multimodal/processing/test_molmo2.py
     estimated_time: 20
@@ -938,6 +902,31 @@ e2e-upstream_singlecard:
   - name: tests/v1/kv_connector/unit/test_remote_decode_lifecycle.py
     estimated_time: 20
   - name: tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
+    estimated_time: 20
+e2e-upstream_online_1:
+  - name: tests/model_executor/model_loader/runai_streamer_loader/test_runai_model_streamer_s3.py
+    estimated_time: 20
+  - name: tests/reasoning/test_mistral_reasoning_parser.py
+    estimated_time: 20
+  - name: tests/renderers/test_mistral.py
+    estimated_time: 20
+  - name: tests/entrypoints/openai/completion/test_token_in_token_out.py
+    estimated_time: 20
+  - name: tests/reasoning/test_olmo3_reasoning_parser.py
+    estimated_time: 20
+  - name: tests/tokenizers_/test_basic.py
+    estimated_time: 20
+  - name: tests/plugins/lora_resolvers/test_hf_hub_resolver.py
+    estimated_time: 20
+  - name: tests/tool_parsers/test_mistral_tool_parser.py
+    estimated_time: 20
+  - name: tests/v1/structured_output/test_backend_guidance.py
+    estimated_time: 20
+  - name: tests/models/multimodal/processing/test_moondream3.py
+    estimated_time: 20
+  - name: tests/tokenizers_/test_mistral.py
+    estimated_time: 20
+  - name: tests/evals/mrcr/test_mrcr_correctness.py
     estimated_time: 20
 e2e-upstream_a2_2:
   - name: tests/v1/distributed/test_async_llm_dp.py


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the upstream workflow by adding hf online workflow and cache the compile of vllm-ascend, which improves the quality of the workflow.
This PR also removes some cases that no longer available on vllm 0.21.0
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
by running the test
- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
