### PR TITLE
[Performance] Skip compute_slot_mapping for mamba group

### DIFF
--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -48,6 +48,11 @@ class BlockTable:
         self.pin_memory = pin_memory
         self.device = device
         self.physical_block_size = block_size
+        self.is_mamba_group = (
+            kv_cache_group is not None
+            and hasattr(kv_cache_group, "kv_cache_spec")
+            and isinstance(kv_cache_group.kv_cache_spec, MambaSpec)
+        )
 
         # If kernel_sizes is None or [0], use physical block size (no splitting)
         if kernel_sizes is None or kernel_sizes == [0]:
@@ -374,6 +379,8 @@ class MultiGroupBlockTable:
         req_indices_compressed_list: list[np.ndarray] | None = None,
     ) -> None:
         for i, block_table in enumerate(self.block_tables):
+            if block_table.is_mamba_group:
+                continue
             if positions_compressed_list and req_indices_compressed_list:
                 block_table.compute_slot_mapping_draft(req_indices_compressed_list[i], positions_compressed_list[i])
             else:
@@ -387,6 +394,8 @@ class MultiGroupBlockTable:
         req_indices_compressed_list: list[np.ndarray] | None = None,
     ) -> None:
         for i, block_table in enumerate(self.block_tables):
+            if block_table.is_mamba_group:
+                continue
             if positions_compressed_list and req_indices_compressed_list:
                 block_table.compute_slot_mapping_draft(req_indices_compressed_list[i], positions_compressed_list[i])
             else:


### PR DESCRIPTION
### What this PR does / why we need it?
This PR optimizes slot mapping preparation for hybrid Attention + Mamba KV cache groups, such as Qwen3.5.

  For MambaSpec groups, the block table now skips compute_slot_mapping / compute_slot_mapping_draft, since the generated slot mapping is not consumed later by the Mamba path. This avoids unnecessary slot mapping work during input preparation while keeping the existing behavior unchanged for attention groups.

<img width="2506" height="1594" alt="PR" src="https://github.com/user-attachments/assets/213bd772-7b45-497c-a130-c3f86253b1fd" />

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

``` bash
vllm bench serve Qwen/Qwen3.6-35B-A3B \
  --dataset-name random \
  --num-prompt 50 \
  --max-concurrency 1 \
  --random-input-len 1024 \
  --random-output-len 100
```

TPOT：21.75ms -> 21.09ms (-3.03%)

### Main
```bash 
+-----------------+-----------+----------+----------+-------+---------+---------+
 | Model           | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
+=================+===========+==========+==========+=======+=========+=========+
 | Qwen3.6-35B-A3B | gsm8k     | mean_acc | main     |  1319 |  0.9659 | default |
+-----------------+-----------+----------+----------+-------+---------+---------+
```
```bash
+-----------------+--------------+----------+----------+-------+---------+---------+
| Model           | Dataset      | Metric   | Subset   |   Num |   Score | Cat.0   |
+=================+==============+==========+==========+=======+=========+=========+
 | Qwen3.6-35B-A3B | gpqa_diamond | mean_acc | default  |   198 |  0.8485 | default |
+-----------------+--------------+----------+----------+-------+---------+---------+
```

### This PR
```bash
+-----------------+-----------+----------+----------+-------+---------+---------+
| Model           | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
+=================+===========+==========+==========+=======+=========+=========+
| Qwen3.6-35B-A3B | gsm8k     | mean_acc | main     |  1319 |  0.9697 | default |
+-----------------+-----------+----------+----------+-------+---------+---------+
```
```bash
+-----------------+--------------+----------+----------+-------+---------+---------+
 | Model           | Dataset      | Metric   | Subset   |   Num |   Score | Cat.0   |
+=================+==============+==========+==========+=======+=========+=========+
 | Qwen3.6-35B-A3B | gpqa_diamond | mean_acc | default  |   198 |  0.8434 | default |
+-----------------+--------------+----------+----------+-------+---------+---------+
```

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
