### PR TITLE
[CI] Extend PR-triggered nightly timeout to 240 minutes

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -92,7 +92,9 @@ concurrency:
 jobs:
   e2e:
     name: ${{ inputs.config_file_path }}
-    timeout-minutes: 120
+    # PR-triggered nightly runs carry a request_id and use a 4-hour timeout;
+    # workflow-triggered nightly runs keep the default 2-hour timeout.
+    timeout-minutes: ${{ inputs.request_id != '' && 240 || 120 }}
     # This is the runner with no NPU for k8s controller
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.should_run }}

--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -83,7 +83,9 @@ jobs:
     name: ${{ inputs.name || inputs.config_file_path || inputs.tests }}
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.should_run }}
-    timeout-minutes: 120
+    # PR-triggered nightly runs carry a request_id and use a 4-hour timeout;
+    # workflow-triggered nightly runs keep the default 2-hour timeout.
+    timeout-minutes: ${{ inputs.request_id != '' && 240 || 120 }}
     container:
       image: ${{ inputs.image }}
     env:

--- a/.github/workflows/_e2e_nightly_single_node_models.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_models.yaml
@@ -74,6 +74,9 @@ jobs:
     name: ${{inputs.model_list}} accuracy test
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.is_run }}
+    # PR-triggered nightly runs carry a request_id and use a 4-hour timeout;
+    # workflow-triggered nightly runs keep the default 2-hour timeout.
+    timeout-minutes: ${{ inputs.request_id != '' && 240 || 120 }}
     container:
       image: "${{ inputs.image }}"
       env:


### PR DESCRIPTION
### What this PR does / why we need it?

PR-triggered nightly tests may need additional time to check out and install the PR code before running the selected test cases. The reusable nightly workflows currently either hard-code a 120-minute timeout or do not define a consistent job timeout, causing long-running PR nightly jobs to be cancelled before completion.

This PR applies the same request-aware timeout to all reusable nightly test workflows:

- use 240 minutes when `request_id` is non-empty, which identifies a PR `/nightly` dispatch;
- keep 120 minutes for scheduled nightly runs and regular manual dispatches without a `request_id`.

The change covers single-node, multi-node, and single-node model accuracy nightly tests. Image build and orchestration jobs are unchanged because they do not execute nightly test cases, and PR `/nightly` dispatches already skip image builds.

### Does this PR introduce _any_ user-facing change?

No. This only changes GitHub Actions timeout behavior for nightly CI jobs.

### How was this patch tested?

- Ran `actionlint` v1.7.12 against all three changed workflow files.
- Parsed all three workflow files with Ruby's YAML parser.
- Ran `git diff --check`.

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
