### PR TITLE
[Performance] causal_conv1d: FP32 cast-once ring — up to 1.44× device

### DIFF
--- a/csrc/moe/causal_conv1d/op_host/causal_conv1d_tiling_planner.h
+++ b/csrc/moe/causal_conv1d/op_host/causal_conv1d_tiling_planner.h
@@ -98,7 +98,7 @@ inline int64_t ComputeFnUbLimitedBaseDim(uint64_t ubSize)
         return 0;
     }
 
-    const int64_t bytesPerElem = (RING_SLOT_CNT * BF16_FP16_ELEM_BYTES) + (FN_OUT_SLOT_CNT * BF16_FP16_ELEM_BYTES) +
+    const int64_t bytesPerElem = (RING_SLOT_CNT * static_cast<int64_t>(sizeof(float))) + (FN_OUT_SLOT_CNT * BF16_FP16_ELEM_BYTES) +
                                  (FN_CALC_FP32_SLOT_CNT * static_cast<int64_t>(sizeof(float)));
     const int64_t budgetBytes = static_cast<int64_t>(ubSize) - FN_UB_RESERVED_BYTES;
     const int64_t ubLimitedBaseDim = AlignDownInt64(budgetBytes / bytesPerElem, DIM_ALIGN_ELEMS);

--- a/csrc/moe/causal_conv1d/op_host/causal_conv1d_tiling_planner.h
+++ b/csrc/moe/causal_conv1d/op_host/causal_conv1d_tiling_planner.h
@@ -22,7 +22,7 @@ using namespace Ops::Transformer::OpTiling;
 inline DimTileChoice ChooseCanonicalUpdateBaseDimChoice(gert::TilingContext *context, int64_t batch, int64_t dim,
                                                         uint32_t coreNum)
 {
-    const int64_t candidates[] = {4096, 2048, 1024, 512, 384, 192};
+    const int64_t candidates[] = {3072, 2048, 1024, 512, 384, 192};
 
     auto chooseOnce = [&](bool requireExactDiv) -> DimTileChoice {
         DimTileChoice bestOver;

--- a/csrc/moe/causal_conv1d/op_host/causal_conv1d_tiling_utils.h
+++ b/csrc/moe/causal_conv1d/op_host/causal_conv1d_tiling_utils.h
@@ -89,7 +89,7 @@ struct FnHostPlan {
 constexpr int64_t DIM_ALIGN_BYTES = 32;
 constexpr int64_t BF16_FP16_ELEM_BYTES = 2;
 constexpr int64_t DIM_ALIGN_ELEMS = DIM_ALIGN_BYTES / BF16_FP16_ELEM_BYTES;
-constexpr int64_t MAX_DIM_TILE_SIZE = 4096;
+constexpr int64_t MAX_DIM_TILE_SIZE = 3072;
 constexpr int64_t FN_UB_RESERVED_BYTES = 512;
 constexpr int64_t RING_SLOT_CNT = 5;
 constexpr int64_t FN_OUT_SLOT_CNT = 2;

--- a/csrc/moe/causal_conv1d/op_kernel/arch35/causal_conv1d_regbase.h
+++ b/csrc/moe/causal_conv1d/op_kernel/arch35/causal_conv1d_regbase.h
@@ -25,11 +25,12 @@ constexpr uint16_t V_LENGTH = VECTOR_REG_WIDTH / sizeof(float);
 constexpr CastTrait castTraitB16ToB32 = {
     RegLayout::ZERO, SatMode::UNKNOWN, MaskMergeMode::ZEROING, RoundMode::UNKNOWN};
 
-template <typename T, bool hasActivation>
-__aicore__ inline void ComputeFnRollingOutputRegbase(LocalTensor<T> ring, LocalTensor<float> currF, 
+
+template <bool hasActivation>
+__aicore__ inline void ComputeFnRollingOutputRegbase(LocalTensor<float> ring, LocalTensor<float> currF, 
     LocalTensor<float> state0F, LocalTensor<float> weightF, uint32_t dataCount) 
 {
-    __ubuf__ T* ringAddr = (__ubuf__ T*)ring.GetPhyAddr();
+    __ubuf__ float* ringAddr = (__ubuf__ float*)ring.GetPhyAddr();
     __ubuf__ float* currFAddr = (__ubuf__ float*)currF.GetPhyAddr();
     __ubuf__ float* state0FAddr = (__ubuf__ float*)state0F.GetPhyAddr();
     __ubuf__ float* weightFAddr = (__ubuf__ float*)weightF.GetPhyAddr();
@@ -37,7 +38,6 @@ __aicore__ inline void ComputeFnRollingOutputRegbase(LocalTensor<T> ring, LocalT
     uint16_t colLoopTimes = static_cast<uint16_t>(Ceil(dataCount, V_LENGTH));
     __VEC_SCOPE__
     {
-        RegTensor<T> ring;
         RegTensor<float> currF;
         RegTensor<float> state0F;
         RegTensor<float> weightF;
@@ -45,10 +45,9 @@ __aicore__ inline void ComputeFnRollingOutputRegbase(LocalTensor<T> ring, LocalT
         MaskReg pregLoop;
         for (uint16_t j = 0; j < colLoopTimes; j++) {
             pregLoop = UpdateMask<float>(dataCount);
-            DataCopy<T, LoadDist::DIST_UNPACK_B16>(ring, ringAddr + j * V_LENGTH);
+            DataCopy(currF, ringAddr + j * V_LENGTH);
             DataCopy(state0F, state0FAddr + j * V_LENGTH);
             DataCopy(weightF, weightFAddr + j * V_LENGTH);
-            Cast<float, T, castTraitB16ToB32>(currF, ring, pregLoop);
             Mul(currF, currF, weightF, pregLoop);
             Add(state0F, state0F, currF, pregLoop);
             if constexpr (hasActivation) {
@@ -64,31 +63,26 @@ __aicore__ inline void ComputeFnRollingOutputRegbase(LocalTensor<T> ring, LocalT
     }
 }
 
-template <typename T>
-static __simd_vf__ inline void AdvanceFnLocalPartialsWidthTwo(__ubuf__ T* ringAddr, __ubuf__ float* weight0FAddr, 
+static __simd_vf__ inline void AdvanceFnLocalPartialsWidthTwo(__ubuf__ float* ringAddr, __ubuf__ float* weight0FAddr,
     __ubuf__ float* state0FAddr, uint32_t dataCount, uint16_t colLoopTimes)
 {
-    RegTensor<T> ring;
     RegTensor<float> currF;
     RegTensor<float> weight0F;
     RegTensor<float> state0F;
     MaskReg pregLoop;
     for (uint16_t j = 0; j < colLoopTimes; j++) {
         pregLoop = UpdateMask<float>(dataCount);
-        DataCopy<T, LoadDist::DIST_UNPACK_B16>(ring, ringAddr + j * V_LENGTH);
+        DataCopy(currF, ringAddr + j * V_LENGTH);
         DataCopy(weight0F, weight0FAddr + j * V_LENGTH);
-        Cast<float, T, castTraitB16ToB32>(currF, ring, pregLoop);
         Mul(state0F, currF, weight0F, pregLoop);
         DataCopy(state0FAddr + j * V_LENGTH, state0F, pregLoop);
     }
 }
 
-template <typename T>
-static __simd_vf__ inline void AdvanceFnLocalPartialsWidthThree(__ubuf__ T* ringAddr, __ubuf__ float* weight0FAddr, 
-    __ubuf__ float* weight1FAddr, __ubuf__ float* state0FAddr, __ubuf__ float* state1FAddr, uint32_t dataCount, 
+static __simd_vf__ inline void AdvanceFnLocalPartialsWidthThree(__ubuf__ float* ringAddr, __ubuf__ float* weight0FAddr,
+    __ubuf__ float* weight1FAddr, __ubuf__ float* state0FAddr, __ubuf__ float* state1FAddr, uint32_t dataCount,
     uint16_t colLoopTimes)
 {
-    RegTensor<T> ring;
     RegTensor<float> currF;
     RegTensor<float> weight0F;
     RegTensor<float> weight1F;
@@ -97,9 +91,8 @@ static __simd_vf__ inline void AdvanceFnLocalPartialsWidthThree(__ubuf__ T* ring
     MaskReg pregLoop;
     for (uint16_t j = 0; j < colLoopTimes; j++) {
         pregLoop = UpdateMask<float>(dataCount);
-        DataCopy<T, LoadDist::DIST_UNPACK_B16>(ring, ringAddr + j * V_LENGTH);
+        DataCopy(currF, ringAddr + j * V_LENGTH);
         DataCopy(state1F, state1FAddr + j * V_LENGTH);
-        Cast<float, T, castTraitB16ToB32>(currF, ring, pregLoop);
         DataCopy(weight1F, weight1FAddr + j * V_LENGTH);
         Mul(state0F, currF, weight1F, pregLoop);
         DataCopy(weight0F, weight0FAddr + j * V_LENGTH);
@@ -110,12 +103,10 @@ static __simd_vf__ inline void AdvanceFnLocalPartialsWidthThree(__ubuf__ T* ring
     }
 }
 
-template <typename T>
-static __simd_vf__ inline void AdvanceFnLocalPartialsWidthFour(__ubuf__ T* ringAddr, __ubuf__ float* weight0FAddr, 
-    __ubuf__ float* weight1FAddr, __ubuf__ float* weight2FAddr, __ubuf__ float* state0FAddr, __ubuf__ float* state1FAddr, 
+static __simd_vf__ inline void AdvanceFnLocalPartialsWidthFour(__ubuf__ float* ringAddr, __ubuf__ float* weight0FAddr,
+    __ubuf__ float* weight1FAddr, __ubuf__ float* weight2FAddr, __ubuf__ float* state0FAddr, __ubuf__ float* state1FAddr,
     __ubuf__ float* state2FAddr, uint32_t dataCount, uint16_t colLoopTimes)
 {
-    RegTensor<T> ring;
     RegTensor<float> currF;
     RegTensor<float> weight0F;
     RegTensor<float> weight1F;
@@ -126,10 +117,9 @@ static __simd_vf__ inline void AdvanceFnLocalPartialsWidthFour(__ubuf__ T* ringA
     MaskReg pregLoop;
     for (uint16_t j = 0; j < colLoopTimes; j++) {
         pregLoop = UpdateMask<float>(dataCount);
-        DataCopy<T, LoadDist::DIST_UNPACK_B16>(ring, ringAddr + j * V_LENGTH);
+        DataCopy(currF, ringAddr + j * V_LENGTH);
         DataCopy(state1F, state1FAddr + j * V_LENGTH);
         DataCopy(state2F, state2FAddr + j * V_LENGTH);
-        Cast<float, T, castTraitB16ToB32>(currF, ring, pregLoop);
         DataCopy(weight2F, weight2FAddr + j * V_LENGTH);
         Mul(state0F, currF, weight2F, pregLoop);
         DataCopy(weight1F, weight1FAddr + j * V_LENGTH);
@@ -144,29 +134,29 @@ static __simd_vf__ inline void AdvanceFnLocalPartialsWidthFour(__ubuf__ T* ringA
     }
 }
 
-template <typename T, int32_t kTemplateWidth>
-__aicore__ inline void AdvanceFnLocalPartialsRegbase(LocalTensor<T> ring, LocalTensor<float> weightF, 
-    LocalTensor<float> state0F, LocalTensor<float> state1F, LocalTensor<float> state2F, uint32_t dataCount, 
+template <int32_t kTemplateWidth>
+__aicore__ inline void AdvanceFnLocalPartialsRegbase(LocalTensor<float> ring, LocalTensor<float> weightF,
+    LocalTensor<float> state0F, LocalTensor<float> state1F, LocalTensor<float> state2F, uint32_t dataCount,
     uint32_t weightStep)
 {
     uint16_t colLoopTimes = static_cast<uint16_t>(Ceil(dataCount, V_LENGTH));
 
-    __ubuf__ T* ringAddr = (__ubuf__ T*)ring.GetPhyAddr();
+    __ubuf__ float* ringAddr = (__ubuf__ float*)ring.GetPhyAddr();
     __ubuf__ float* weight0FAddr = (__ubuf__ float*)weightF.GetPhyAddr();
     __ubuf__ float* state0FAddr = (__ubuf__ float*)state0F.GetPhyAddr();
     if constexpr (kTemplateWidth == 2) {
-        AscendC::VF_CALL<AdvanceFnLocalPartialsWidthTwo<T>>(ringAddr, weight0FAddr, state0FAddr, dataCount, colLoopTimes);
+        AscendC::VF_CALL<AdvanceFnLocalPartialsWidthTwo>(ringAddr, weight0FAddr, state0FAddr, dataCount, colLoopTimes);
     } else if constexpr (kTemplateWidth == 3) {
         __ubuf__ float* weight1FAddr = weight0FAddr + weightStep;
         __ubuf__ float* state1FAddr = (__ubuf__ float*)state1F.GetPhyAddr();
-        AscendC::VF_CALL<AdvanceFnLocalPartialsWidthThree<T>>(ringAddr, weight0FAddr, weight1FAddr, state0FAddr, 
+        AscendC::VF_CALL<AdvanceFnLocalPartialsWidthThree>(ringAddr, weight0FAddr, weight1FAddr, state0FAddr,
             state1FAddr, dataCount, colLoopTimes);
     } else if constexpr (kTemplateWidth == 4) {
         __ubuf__ float* weight1FAddr = weight0FAddr + weightStep;
         __ubuf__ float* weight2FAddr = weight1FAddr + weightStep;
         __ubuf__ float* state1FAddr = (__ubuf__ float*)state1F.GetPhyAddr();
         __ubuf__ float* state2FAddr = (__ubuf__ float*)state2F.GetPhyAddr();
-        AscendC::VF_CALL<AdvanceFnLocalPartialsWidthFour<T>>(ringAddr, weight0FAddr, weight1FAddr, weight2FAddr, 
+        AscendC::VF_CALL<AdvanceFnLocalPartialsWidthFour>(ringAddr, weight0FAddr, weight1FAddr, weight2FAddr,
             state0FAddr, state1FAddr, state2FAddr, dataCount, colLoopTimes);
     }
 }

--- a/csrc/moe/causal_conv1d/op_kernel/causal_conv1d.h
+++ b/csrc/moe/causal_conv1d/op_kernel/causal_conv1d.h
@@ -25,997 +25,1005 @@
 #include "arch35/causal_conv1d_regbase.h"
 #endif
  
- namespace NsCausalConv1d {
- 
- using namespace AscendC;
- using namespace NsCausalConv1dCommon;
- 
- #define CAUSAL_CONV1D_TEMPLATE_ARGS typename T, uint32_t runModeKey, uint32_t widthKey, uint32_t fnPlanKey
- #define CAUSAL_CONV1D_CLASS CausalConv1d<T, runModeKey, widthKey, fnPlanKey>
- 
- enum SeqTaskWindowMode : int32_t {
-     SEQ_TASK_WINDOW_MODE_VARLEN = 0,
-     SEQ_TASK_WINDOW_MODE_BATCH = 1,
-     SEQ_TASK_WINDOW_MODE_DECODE2D = 2,
- };
- 
- inline constexpr int32_t INIT_STATE_SYNCALL_NEED_SIZE = 8;
- inline constexpr int32_t INIT_STATE_SYNCALL_MAX_BLOCKS = 64;
- 
- struct SeqTaskWindow {
-     bool valid = false;
-     int32_t start = 0;
-     int32_t len = 0;
- };
- 
- __aicore__ inline int32_t GetSeqTaskWindowMode(int32_t inputMode)
- {
-     if (inputMode == 0) {
-         return SEQ_TASK_WINDOW_MODE_VARLEN;
-     }
-     if (inputMode == 2) {
-         return SEQ_TASK_WINDOW_MODE_DECODE2D;
-     }
-     return SEQ_TASK_WINDOW_MODE_BATCH;
- }
- 
- __aicore__ inline SeqTaskWindow BuildSeqTaskWindowVarlen(int32_t startVal, int32_t endVal)
- {
-     SeqTaskWindow window;
-     window.start = startVal;
-     window.len = endVal - startVal;
-     window.valid = (window.len > 0);
-     return window;
- }
- 
- __aicore__ inline int32_t RetreatRingSlot(int32_t slot, int32_t delta)
- {
-     int32_t prev = slot - delta;
-     return (prev >= 0) ? prev : (prev + RING_SLOTS);
- }
- 
- __aicore__ inline SeqTaskWindow BuildSeqTaskWindowBatch(int32_t seq, int32_t seqLen)
- {
-     SeqTaskWindow window;
-     window.start = seq * seqLen;
-     window.len = seqLen;
-     window.valid = (window.len > 0);
-     return window;
- }
- 
- __aicore__ inline SeqTaskWindow BuildSeqTaskWindowDecode2D(int32_t seq)
- {
-     SeqTaskWindow window;
-     window.valid = true;
-     window.start = seq;
-     window.len = 1;
-     return window;
- }
- 
- __aicore__ inline constexpr int32_t DecodeWidthTplKey(uint32_t widthKey)
- {
-     switch (widthKey) {
-         case CAUSAL_CONV1D_TPL_WIDTH_2:
-             return 2;
-         case CAUSAL_CONV1D_TPL_WIDTH_3:
-             return 3;
-         case CAUSAL_CONV1D_TPL_WIDTH_4:
-             return 4;
-         default:
-             return 0;
-     }
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- class CausalConv1d {
- public:
-     __aicore__ inline CausalConv1d() = default;
- 
- protected:
-     static constexpr bool kIsUpdateMode = (runModeKey == CAUSAL_CONV1D_TPL_RUN_MODE_UPDATE);
-     static constexpr int32_t kTemplateWidth = DecodeWidthTplKey(widthKey);
-     static constexpr bool kHasCompileTimeWidth =
-         (runModeKey == CAUSAL_CONV1D_TPL_RUN_MODE_FN) && (kTemplateWidth >= 2) && (kTemplateWidth <= MAX_WIDTH);
-     static constexpr FnExecutionPlan kFnExecutionPlan = static_cast<FnExecutionPlan>(fnPlanKey);
- 
-     __aicore__ inline void ResetRuntimeState(const CausalConv1dTilingData *tilingData);
-     __aicore__ inline void InitSharedBuffersAndEvents();
-     __aicore__ inline void LoadWeightAndBias(int32_t channelStart, int32_t baseDim);
-     __aicore__ inline void InitRing(int32_t cacheIdx, bool hasInit, int32_t stateTokenOffset, int32_t start,
-                                     int32_t len, int32_t channelStart, int32_t baseDim, int32_t dim);
-     __aicore__ inline void InitRingSeqSplit(int32_t seq, int32_t cacheIdx, bool hasInit, int32_t seqStart,
-                                             int32_t tileStart, int32_t tileLen, int32_t channelStart, int32_t baseDim,
-                                             int32_t dim);
-     __aicore__ inline void PrefetchInitStatesToWorkspace(int32_t channelStart, int32_t baseDimSize);
-     __aicore__ inline void RestoreFnLocalPartials(int32_t baseDim);
-     __aicore__ inline void ComputeFnRollingOutput(int32_t slotCurr, int32_t baseDim);
-     __aicore__ inline void AdvanceFnLocalPartials(int32_t slotCurr, int32_t baseDim);
-     __aicore__ inline void RunSeqFnRolling(int32_t start, int32_t len, int32_t channelStart, int32_t baseDim,
+namespace NsCausalConv1d {
+
+using namespace AscendC;
+using namespace NsCausalConv1dCommon;
+
+#define CAUSAL_CONV1D_TEMPLATE_ARGS typename T, uint32_t runModeKey, uint32_t widthKey, uint32_t fnPlanKey
+#define CAUSAL_CONV1D_CLASS CausalConv1d<T, runModeKey, widthKey, fnPlanKey>
+
+enum SeqTaskWindowMode : int32_t {
+    SEQ_TASK_WINDOW_MODE_VARLEN = 0,
+    SEQ_TASK_WINDOW_MODE_BATCH = 1,
+    SEQ_TASK_WINDOW_MODE_DECODE2D = 2,
+};
+
+inline constexpr int32_t INIT_STATE_SYNCALL_NEED_SIZE = 8;
+inline constexpr int32_t INIT_STATE_SYNCALL_MAX_BLOCKS = 64;
+
+struct SeqTaskWindow {
+    bool valid = false;
+    int32_t start = 0;
+    int32_t len = 0;
+};
+
+__aicore__ inline int32_t GetSeqTaskWindowMode(int32_t inputMode)
+{
+    if (inputMode == 0) {
+        return SEQ_TASK_WINDOW_MODE_VARLEN;
+    }
+    if (inputMode == 2) {
+        return SEQ_TASK_WINDOW_MODE_DECODE2D;
+    }
+    return SEQ_TASK_WINDOW_MODE_BATCH;
+}
+
+__aicore__ inline SeqTaskWindow BuildSeqTaskWindowVarlen(int32_t startVal, int32_t endVal)
+{
+    SeqTaskWindow window;
+    window.start = startVal;
+    window.len = endVal - startVal;
+    window.valid = (window.len > 0);
+    return window;
+}
+
+__aicore__ inline int32_t RetreatRingSlot(int32_t slot, int32_t delta)
+{
+    int32_t prev = slot - delta;
+    return (prev >= 0) ? prev : (prev + RING_SLOTS);
+}
+
+__aicore__ inline SeqTaskWindow BuildSeqTaskWindowBatch(int32_t seq, int32_t seqLen)
+{
+    SeqTaskWindow window;
+    window.start = seq * seqLen;
+    window.len = seqLen;
+    window.valid = (window.len > 0);
+    return window;
+}
+
+__aicore__ inline SeqTaskWindow BuildSeqTaskWindowDecode2D(int32_t seq)
+{
+    SeqTaskWindow window;
+    window.valid = true;
+    window.start = seq;
+    window.len = 1;
+    return window;
+}
+
+__aicore__ inline constexpr int32_t DecodeWidthTplKey(uint32_t widthKey)
+{
+    switch (widthKey) {
+        case CAUSAL_CONV1D_TPL_WIDTH_2:
+            return 2;
+        case CAUSAL_CONV1D_TPL_WIDTH_3:
+            return 3;
+        case CAUSAL_CONV1D_TPL_WIDTH_4:
+            return 4;
+        default:
+            return 0;
+    }
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+class CausalConv1d {
+public:
+    __aicore__ inline CausalConv1d() = default;
+
+protected:
+    static constexpr bool kIsUpdateMode = (runModeKey == CAUSAL_CONV1D_TPL_RUN_MODE_UPDATE);
+    static constexpr int32_t kTemplateWidth = DecodeWidthTplKey(widthKey);
+    static constexpr bool kHasCompileTimeWidth =
+        (runModeKey == CAUSAL_CONV1D_TPL_RUN_MODE_FN) && (kTemplateWidth >= 2) && (kTemplateWidth <= MAX_WIDTH);
+    static constexpr FnExecutionPlan kFnExecutionPlan = static_cast<FnExecutionPlan>(fnPlanKey);
+
+    __aicore__ inline void ResetRuntimeState(const CausalConv1dTilingData *tilingData);
+    __aicore__ inline void InitSharedBuffersAndEvents();
+    __aicore__ inline void LoadWeightAndBias(int32_t channelStart, int32_t baseDim);
+    __aicore__ inline void InitRing(int32_t cacheIdx, bool hasInit, int32_t stateTokenOffset, int32_t start,
+                                    int32_t len, int32_t channelStart, int32_t baseDim, int32_t dim);
+    __aicore__ inline void InitRingSeqSplit(int32_t seq, int32_t cacheIdx, bool hasInit, int32_t seqStart,
+                                            int32_t tileStart, int32_t tileLen, int32_t channelStart, int32_t baseDim,
                                             int32_t dim);
-     __aicore__ inline void RunSeq(int32_t start, int32_t len, int32_t channelStart, int32_t baseDim, int32_t dim);
-     __aicore__ inline void WriteBackState(int32_t cacheIdx, int32_t len, int32_t channelStart, int32_t baseDim,
-                                           int32_t dim);
-     __aicore__ inline void WriteBackStateSpec(int32_t cacheIdx, bool hasInit, int32_t stateTokenOffset, int32_t start,
-                                               int32_t len, int32_t channelStart, int32_t baseDim, int32_t dim);
-     __aicore__ inline void DrainTaskMte3();
-     __aicore__ inline void AllocEvents();
-     __aicore__ inline void ReleaseEvents();
-     __aicore__ inline int32_t FindVarlenSeqByToken(int32_t tokenIdx) const;
-     __aicore__ inline bool ResolveExplicitTokenTileSeqRange(int32_t tokenTileId, int32_t &startSeq, int32_t &endSeq) const;
-     __aicore__ inline bool ResolveSeqTaskWindow(int32_t seq, int32_t inputMode, int32_t seqLen, int32_t &start,
-                                                 int32_t &len) const;
-     template <int32_t kWindowMode>
-     __aicore__ inline bool ResolveSeqTaskWindowByMode(int32_t seq, int32_t seqLen, int32_t &start, int32_t &len) const;
-     __aicore__ inline bool ResolveSeqCacheIndex(int32_t seq, bool hasCacheIndices, int32_t &cacheIdx) const;
-     __aicore__ inline bool ResolveSeqHasInit(int32_t seq, bool hasInitialStateMode) const;
-     __aicore__ inline void MaybeWriteBackSeqSplitTailChunk(int32_t chunkStart, int32_t chunkLen, int32_t seqStart,
-                                                            int32_t seqLen, int32_t cacheIdx, int32_t channelStart,
-                                                            int32_t baseDim, int32_t dim);
-     __aicore__ inline void ProcessDefault();
-     template <int32_t kWindowMode>
-     __aicore__ inline void ProcessDefaultByWindowMode();
-     __aicore__ inline void ProcessVarlenTokenTiled();
-     __aicore__ inline void ProcessFnChunk(int32_t seq, int32_t cacheIdx, bool hasInit, int32_t seqStart,
-                                           int32_t seqLen, int32_t chunkStart, int32_t chunkLen, int32_t channelStart,
-                                           int32_t baseDim, int32_t dim);
-     __aicore__ inline const CausalConv1dTilingData *GetTilingData() const;
-     __aicore__ inline bool HasActivation() const;
-     __aicore__ inline bool HasBias() const;
-     __aicore__ inline bool IsUpdateMode() const;
-     __aicore__ inline bool IsFnRollingFastPathEnabled() const;
-     __aicore__ inline bool HasExplicitFnTokenSeqRanges() const;
-     __aicore__ inline bool IsUpdateSpecDecodingEnabled() const;
- 
- protected:
-     TPipe pipe;
-     TBuf<QuePosition::VECIN> inBuf;
-     TBuf<QuePosition::VECOUT> outBuf;
-     TBuf<QuePosition::VECCALC> calcBuf;
- 
-     TEventID weightBiasMte2ToVEvent_;
-     TEventID stateMte2ToVEvent_;
-     TEventID inputMte2ToVEvent_[RING_SLOTS];
-     TEventID inputVToMte2Event_;
-     TEventID outMte3ToVEvent_[2];
-     TEventID outVToMte3Event_[2];
-     TEventID stateWritebackMte3ToVEvent_;
-     TEventID stateWritebackMte3ToMte2Event_;
-     TEventID stateShiftMte2ToMte3Event_;
-     TEventID stateShiftVToMte3Event_;
-     TEventID stateShiftMte3ToMte2Event_;
-     TEventID initSnapshotMte2ToMte3Event_;
-     TEventID initSnapshotMte3ToMte2Event_;
-     TEventID initSyncVToMte3Event_;
-     TEventID initSyncMte3ToVEvent_;
-     TEventID specWritebackMte2ToMte3Event_[2];
-     TEventID specWritebackMte3ToMte2Event_[2];
- 
-     GlobalTensor<T> xGm;
-     GlobalTensor<T> weightGm;
-     GlobalTensor<T> biasGm;
-     GlobalTensor<T> convStatesGm;
-     GlobalTensor<int64_t> queryStartLocGm;
-     GlobalTensor<int64_t> cacheIndicesGm;
-     GlobalTensor<int64_t> initialStateModeGm;
-     GlobalTensor<int64_t> numAcceptedTokensGm;
-     GlobalTensor<T> yGm;
-     GlobalTensor<int32_t> initStateSyncGm_;
-     GlobalTensor<T> initStateWorkspaceGm_;
- 
-     const CausalConv1dTilingData *tilingData_{nullptr};
- };
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline void CAUSAL_CONV1D_CLASS::ResetRuntimeState(const CausalConv1dTilingData *tilingData)
- {
-     tilingData_ = tilingData;
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline void CAUSAL_CONV1D_CLASS::InitSharedBuffersAndEvents()
- {
-     pipe.InitBuffer(inBuf, RING_SLOTS * MAX_BLOCK_DIM * sizeof(T));
-     pipe.InitBuffer(outBuf, 2 * MAX_BLOCK_DIM * sizeof(T));
-     pipe.InitBuffer(calcBuf, (MAX_WIDTH + 4) * MAX_BLOCK_DIM * sizeof(float));
-     AllocEvents();
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline void CAUSAL_CONV1D_CLASS::AllocEvents()
- {
-     weightBiasMte2ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>();
-     stateMte2ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>();
-     for (int32_t i = 0; i < RING_SLOTS; ++i) {
-         inputMte2ToVEvent_[i] = GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>();
-     }
-     inputVToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::V_MTE2>();
-     outMte3ToVEvent_[0] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
-     outMte3ToVEvent_[1] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
-     outVToMte3Event_[0] = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
-     outVToMte3Event_[1] = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
-     stateWritebackMte3ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
-     stateWritebackMte3ToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
-     stateShiftMte2ToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
-     stateShiftVToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
-     stateShiftMte3ToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
-     initSnapshotMte2ToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
-     initSnapshotMte3ToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
-     initSyncVToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
-     initSyncMte3ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
-     specWritebackMte2ToMte3Event_[0] = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
-     specWritebackMte2ToMte3Event_[1] = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
-     specWritebackMte3ToMte2Event_[0] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
-     specWritebackMte3ToMte2Event_[1] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline void CAUSAL_CONV1D_CLASS::ReleaseEvents()
- {
-     GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(weightBiasMte2ToVEvent_);
-     GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(stateMte2ToVEvent_);
-     for (int32_t i = 0; i < RING_SLOTS; ++i) {
-         GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(inputMte2ToVEvent_[i]);
-     }
-     GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE2>(inputVToMte2Event_);
-     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(outMte3ToVEvent_[0]);
-     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(outMte3ToVEvent_[1]);
-     GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(outVToMte3Event_[0]);
-     GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(outVToMte3Event_[1]);
-     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(stateWritebackMte3ToVEvent_);
-     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(stateWritebackMte3ToMte2Event_);
-     GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(stateShiftMte2ToMte3Event_);
-     GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(stateShiftVToMte3Event_);
-     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
-     GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(initSnapshotMte2ToMte3Event_);
-     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(initSnapshotMte3ToMte2Event_);
-     GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(initSyncVToMte3Event_);
-     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(initSyncMte3ToVEvent_);
-     GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[0]);
-     GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[1]);
-     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[0]);
-     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[1]);
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline void CAUSAL_CONV1D_CLASS::LoadWeightAndBias(int32_t channelStart, int32_t baseDim)
- {
-     const int32_t dim = tilingData_->dim;
-     const int32_t width = static_cast<int32_t>(tilingData_->width);
-     const int32_t jStart = MAX_WIDTH - width;
-     const bool hasBias = HasBias();
-     auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
-     LocalTensor<float> &weightF = cl.weightF;
-     LocalTensor<float> &biasF = cl.biasF;
-     LocalTensor<T> weightT;
-     LocalTensor<T> biasT;
- 
-     if constexpr (!std::is_same<T, float>::value) {
-         weightT = weightF.ReinterpretCast<T>();
-         biasT = biasF.ReinterpretCast<T>();
-     }
- 
-     for (int32_t j = 0; j < jStart; ++j) {
-         Duplicate(weightF[j * MAX_BLOCK_DIM], 0.0f, baseDim);
-     }
- 
-     for (int32_t j = 0; j < width; ++j) {
-         const int32_t jDst = jStart + j;
-         const int64_t weightOffset = static_cast<int64_t>(j) * dim + channelStart;
- 
-         if constexpr (std::is_same<T, float>::value) {
-             DataCopy(weightF[jDst * MAX_BLOCK_DIM], weightGm[weightOffset], baseDim);
-         } else {
-             DataCopy(weightT[jDst * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], weightGm[weightOffset], baseDim);
-         }
-     }
- 
-     if (hasBias) {
-         if constexpr (std::is_same<T, float>::value) {
-             DataCopy(biasF, biasGm[channelStart], baseDim);
-         } else {
-             DataCopy(biasT[MAX_BLOCK_DIM], biasGm[channelStart], baseDim);
-         }
-     }
- 
-     SetFlag<HardEvent::MTE2_V>(weightBiasMte2ToVEvent_);
-     WaitFlag<HardEvent::MTE2_V>(weightBiasMte2ToVEvent_);
- 
-     if constexpr (!std::is_same<T, float>::value) {
-         for (int32_t j = 0; j < width; ++j) {
-             const int32_t jDst = jStart + j;
-             Cast(weightF[jDst * MAX_BLOCK_DIM], weightT[jDst * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], RoundMode::CAST_NONE,
-                  baseDim);
-         }
-         if (hasBias) {
-             Cast(biasF, biasT[MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
-         }
-         PipeBarrier<PIPE_V>();
-     }
- 
-     if (!hasBias) {
-         Duplicate(biasF, 0.0f, baseDim);
-     }
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline void CAUSAL_CONV1D_CLASS::InitRing(int32_t cacheIdx, bool hasInit, int32_t stateTokenOffset,
-                                                      int32_t start, int32_t len, int32_t channelStart,
-                                                      int32_t baseDim, int32_t dim)
- {
-     const int32_t stateLen = tilingData_->stateLen;
-     const int32_t width = static_cast<int32_t>(tilingData_->width);
-     const int32_t ringStart = MAX_WIDTH - width;
-     LocalTensor<T> ring = inBuf.Get<T>();
- 
-     for (int32_t i = 0; i < ringStart; ++i) {
-         Duplicate(ring[i * MAX_BLOCK_DIM], static_cast<T>(0), baseDim);
-     }
-     if (ringStart > 0) {
-         PipeBarrier<PIPE_V>();
-     }
- 
-     if (hasInit) {
-         for (int32_t i = 0; i < (width - 1); ++i) {
-             const int32_t pos = stateTokenOffset + i;
-             const int64_t stateOffset =
-                 static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(pos) * dim + channelStart;
-             DataCopy(ring[(ringStart + i) * MAX_BLOCK_DIM], convStatesGm[stateOffset], baseDim);
-         }
-         SetFlag<HardEvent::MTE2_V>(stateMte2ToVEvent_);
-         WaitFlag<HardEvent::MTE2_V>(stateMte2ToVEvent_);
-     } else {
-         for (int32_t i = 0; i < (width - 1); ++i) {
-             Duplicate(ring[(ringStart + i) * MAX_BLOCK_DIM], static_cast<T>(0), baseDim);
-         }
-         PipeBarrier<PIPE_V>();
-     }
- 
-     if (len > 0) {
-         const int32_t slot0 = SlotCurr(0);
-         const int64_t xOffset = static_cast<int64_t>(start) * dim + channelStart;
-         DataCopy(ring[slot0 * MAX_BLOCK_DIM], xGm[xOffset], baseDim);
-         SetFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slot0]);
-     }
- 
-     if (len > 1) {
-         SetFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
-     }
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline void CAUSAL_CONV1D_CLASS::RunSeq(int32_t start, int32_t len, int32_t channelStart,
-                                                    int32_t baseDim, int32_t dim)
- {
-     if (IsFnRollingFastPathEnabled()) {
-         RunSeqFnRolling(start, len, channelStart, baseDim, dim);
-         return;
-     }
- 
-     const int32_t width = static_cast<int32_t>(tilingData_->width);
-     const int32_t jStart = MAX_WIDTH - width;
-     auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
-     LocalTensor<float> &weightF = cl.weightF;
-     LocalTensor<float> &biasF = cl.biasF;
-     LocalTensor<float> &accF = cl.accF;
-     LocalTensor<float> &tmpF = cl.tmpF;
-     LocalTensor<T> ring = inBuf.Get<T>();
-     LocalTensor<T> outT = outBuf.Get<T>();
-     const bool hasBias = HasBias();
-     const bool hasActivation = HasActivation();
-     for (int32_t t = 0; t < len; ++t) {
-         const int32_t slotCurr = SlotCurr(t);
- 
-         WaitFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotCurr]);
- 
-         if (t + 1 < len) {
-             const int32_t slotNext = SlotPrefetch(t);
-             const int64_t xOffsetNext = static_cast<int64_t>(start + t + 1) * dim + channelStart;
-             WaitFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
-             DataCopy(ring[slotNext * MAX_BLOCK_DIM], xGm[xOffsetNext], baseDim);
-             SetFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotNext]);
-         }
- 
-         bool accInitialized = false;
-         if (hasBias) {
-             Adds(accF, biasF, 0.0f, baseDim);
-             PipeBarrier<PIPE_V>();
-             accInitialized = true;
-         }
- 
-         for (int32_t j = jStart; j < MAX_WIDTH; ++j) {
-             const int32_t tap = (MAX_WIDTH - 1) - j;
-             const int32_t slot = (tap == 0) ? slotCurr : SlotHist(t, tap);
-             Cast(tmpF, ring[slot * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
-             PipeBarrier<PIPE_V>();
-             if (!accInitialized) {
-                 Mul(accF, tmpF, weightF[j * MAX_BLOCK_DIM], baseDim);
-                 accInitialized = true;
-             } else {
-                 MulAddDst(accF, tmpF, weightF[j * MAX_BLOCK_DIM], baseDim);
-             }
-         }
- 
-         PipeBarrier<PIPE_V>();
- 
-         if (hasActivation) {
-             Silu(tmpF, accF, baseDim);
-         }
- 
-         const int32_t outSlot = t & 1;
-         LocalTensor<T> outSlotT = outT[outSlot * MAX_BLOCK_DIM];
-         if (t >= 2) {
-             WaitFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
-         }
- 
-         if constexpr (IsSameType<T, float>::value) {
-             if (hasActivation) {
-                 DataCopy(outSlotT, tmpF, baseDim);
-             } else {
-                 DataCopy(outSlotT, accF, baseDim);
-             }
-         } else {
-             if (hasActivation) {
-                 Cast(outSlotT, tmpF, RoundMode::CAST_RINT, baseDim);
-             } else {
-                 Cast(outSlotT, accF, RoundMode::CAST_RINT, baseDim);
-             }
-         }
- 
-         SetFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
- 
-         const int64_t outOffset = static_cast<int64_t>(start + t) * dim + channelStart;
-         WaitFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
-         DataCopy(yGm[outOffset], outSlotT, baseDim);
-         if (t + 2 < len) {
-             SetFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
-         }
- 
-         if (t + 2 < len) {
-             SetFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
-         }
-     }
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline void CAUSAL_CONV1D_CLASS::RestoreFnLocalPartials(int32_t baseDim)
- {
-     if constexpr (!kHasCompileTimeWidth) {
-         return;
-     }
- 
-     auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
-     LocalTensor<float> &weightF = cl.weightF;
-     LocalTensor<float> &state2F = cl.biasF;
-     LocalTensor<float> &state1F = cl.accF;
-     LocalTensor<float> &state0F = cl.tmpF;
-     LocalTensor<float> &currF = cl.currF;
-     LocalTensor<T> ring = inBuf.Get<T>();
-     constexpr int32_t ringStart = MAX_WIDTH - kTemplateWidth;
-     constexpr int32_t w0Idx = MAX_WIDTH - kTemplateWidth;
- 
-     if constexpr (kTemplateWidth == 2) {
-         Duplicate(state2F, 0.0f, baseDim);
-         Duplicate(state1F, 0.0f, baseDim);
-         PipeBarrier<PIPE_V>();
- 
-         Cast(currF, ring[ringStart * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
-         PipeBarrier<PIPE_V>();
-         Mul(state0F, currF, weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
-         PipeBarrier<PIPE_V>();
-     } else if constexpr (kTemplateWidth == 3) {
-         Duplicate(state2F, 0.0f, baseDim);
-         PipeBarrier<PIPE_V>();
- 
-         Cast(currF, ring[ringStart * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
-         PipeBarrier<PIPE_V>();
-         Mul(state0F, currF, weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
-         PipeBarrier<PIPE_V>();
- 
-         Cast(currF, ring[(ringStart + 1) * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
-         PipeBarrier<PIPE_V>();
-         Mul(state1F, currF, weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
-         PipeBarrier<PIPE_V>();
-         MulAddDst(state0F, currF, weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
-         PipeBarrier<PIPE_V>();
-     } else if constexpr (kTemplateWidth == 4) {
-         Cast(currF, ring[ringStart * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
-         PipeBarrier<PIPE_V>();
-         Mul(state0F, currF, weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
-         PipeBarrier<PIPE_V>();
- 
-         Cast(currF, ring[(ringStart + 1) * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
-         PipeBarrier<PIPE_V>();
-         Mul(state1F, currF, weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
-         PipeBarrier<PIPE_V>();
-         MulAddDst(state0F, currF, weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
-         PipeBarrier<PIPE_V>();
- 
-         Cast(currF, ring[(ringStart + 2) * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
-         PipeBarrier<PIPE_V>();
-         Mul(state2F, currF, weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
-         PipeBarrier<PIPE_V>();
-         MulAddDst(state1F, currF, weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
-         PipeBarrier<PIPE_V>();
-         MulAddDst(state0F, currF, weightF[(w0Idx + 2) * MAX_BLOCK_DIM], baseDim);
-         PipeBarrier<PIPE_V>();
-     }
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline void CAUSAL_CONV1D_CLASS::ComputeFnRollingOutput(int32_t slotCurr, int32_t baseDim)
- {
-     if constexpr (!kHasCompileTimeWidth) {
-         return;
-     }
- 
-     auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
-     LocalTensor<float> &weightF = cl.weightF;
-     LocalTensor<float> &state0F = cl.tmpF;
-     LocalTensor<float> &currF = cl.currF;
-     LocalTensor<T> ring = inBuf.Get<T>();
- 
-#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
-    const bool hasActivation = HasActivation();
-    if (hasActivation) {
-        ComputeFnRollingOutputRegbase<T, true>(ring[slotCurr * MAX_BLOCK_DIM], currF, state0F, weightF[3 * MAX_BLOCK_DIM], baseDim);
-    } else {
-        ComputeFnRollingOutputRegbase<T, false>(ring[slotCurr * MAX_BLOCK_DIM], currF, state0F, weightF[3 * MAX_BLOCK_DIM], baseDim);
-    }
-#else
-    Cast(currF, ring[slotCurr * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
-    PipeBarrier<PIPE_V>();
-    MulAddDst(state0F, currF, weightF[3 * MAX_BLOCK_DIM], baseDim);
-    PipeBarrier<PIPE_V>();
+    __aicore__ inline void PrefetchInitStatesToWorkspace(int32_t channelStart, int32_t baseDimSize);
+    __aicore__ inline void RestoreFnLocalPartials(int32_t baseDim);
+    __aicore__ inline void ComputeFnRollingOutput(int32_t slotCurr, int32_t baseDim);
+    __aicore__ inline void AdvanceFnLocalPartials(int32_t slotCurr, int32_t baseDim);
+    __aicore__ inline void RunSeqFnRolling(int32_t start, int32_t len, int32_t channelStart, int32_t baseDim,
+                                        int32_t dim);
+    __aicore__ inline void RunSeq(int32_t start, int32_t len, int32_t channelStart, int32_t baseDim, int32_t dim);
+    __aicore__ inline void WriteBackState(int32_t cacheIdx, int32_t len, int32_t channelStart, int32_t baseDim,
+                                        int32_t dim);
+    __aicore__ inline void WriteBackStateSpec(int32_t cacheIdx, bool hasInit, int32_t stateTokenOffset, int32_t start,
+                                            int32_t len, int32_t channelStart, int32_t baseDim, int32_t dim);
+    __aicore__ inline void DrainTaskMte3();
+    __aicore__ inline void AllocEvents();
+    __aicore__ inline void ReleaseEvents();
+    __aicore__ inline int32_t FindVarlenSeqByToken(int32_t tokenIdx) const;
+    __aicore__ inline bool ResolveExplicitTokenTileSeqRange(int32_t tokenTileId, int32_t &startSeq, int32_t &endSeq) const;
+    __aicore__ inline bool ResolveSeqTaskWindow(int32_t seq, int32_t inputMode, int32_t seqLen, int32_t &start,
+                                                int32_t &len) const;
+    template <int32_t kWindowMode>
+    __aicore__ inline bool ResolveSeqTaskWindowByMode(int32_t seq, int32_t seqLen, int32_t &start, int32_t &len) const;
+    __aicore__ inline bool ResolveSeqCacheIndex(int32_t seq, bool hasCacheIndices, int32_t &cacheIdx) const;
+    __aicore__ inline bool ResolveSeqHasInit(int32_t seq, bool hasInitialStateMode) const;
+    __aicore__ inline void MaybeWriteBackSeqSplitTailChunk(int32_t chunkStart, int32_t chunkLen, int32_t seqStart,
+                                                        int32_t seqLen, int32_t cacheIdx, int32_t channelStart,
+                                                        int32_t baseDim, int32_t dim);
+    __aicore__ inline void ProcessDefault();
+    template <int32_t kWindowMode>
+    __aicore__ inline void ProcessDefaultByWindowMode();
+    __aicore__ inline void ProcessVarlenTokenTiled();
+    __aicore__ inline void ProcessFnChunk(int32_t seq, int32_t cacheIdx, bool hasInit, int32_t seqStart,
+                                        int32_t seqLen, int32_t chunkStart, int32_t chunkLen, int32_t channelStart,
+                                        int32_t baseDim, int32_t dim);
+    __aicore__ inline const CausalConv1dTilingData *GetTilingData() const;
+    __aicore__ inline bool HasActivation() const;
+    __aicore__ inline bool HasBias() const;
+    __aicore__ inline bool IsUpdateMode() const;
+    __aicore__ inline bool IsFnRollingFastPathEnabled() const;
+    __aicore__ inline bool HasExplicitFnTokenSeqRanges() const;
+    __aicore__ inline bool IsUpdateSpecDecodingEnabled() const;
 
-    const bool hasActivation = HasActivation();
-    if (hasActivation) {
+protected:
+    TPipe pipe;
+    TBuf<QuePosition::VECIN> inBuf;
+    TBuf<QuePosition::VECOUT> outBuf;
+    TBuf<QuePosition::VECCALC> calcBuf;
+
+    TEventID weightBiasMte2ToVEvent_;
+    TEventID stateMte2ToVEvent_;
+    TEventID inputMte2ToVEvent_[RING_SLOTS];
+    TEventID inputVToMte2Event_;
+    TEventID outMte3ToVEvent_[2];
+    TEventID outVToMte3Event_[2];
+    TEventID stateWritebackVToMte3Event_;
+    TEventID stateWritebackMte3ToVEvent_;
+    TEventID stateWritebackMte3ToMte2Event_;
+    TEventID stateShiftMte2ToMte3Event_;
+    TEventID stateShiftVToMte3Event_;
+    TEventID stateShiftMte3ToMte2Event_;
+    TEventID initSnapshotMte2ToMte3Event_;
+    TEventID initSnapshotMte3ToMte2Event_;
+    TEventID initSyncVToMte3Event_;
+    TEventID initSyncMte3ToVEvent_;
+    TEventID specWritebackMte2ToMte3Event_[2];
+    TEventID specWritebackMte3ToMte2Event_[2];
+
+    GlobalTensor<T> xGm;
+    GlobalTensor<T> weightGm;
+    GlobalTensor<T> biasGm;
+    GlobalTensor<T> convStatesGm;
+    GlobalTensor<int64_t> queryStartLocGm;
+    GlobalTensor<int64_t> cacheIndicesGm;
+    GlobalTensor<int64_t> initialStateModeGm;
+    GlobalTensor<int64_t> numAcceptedTokensGm;
+    GlobalTensor<T> yGm;
+    GlobalTensor<int32_t> initStateSyncGm_;
+    GlobalTensor<T> initStateWorkspaceGm_;
+
+    const CausalConv1dTilingData *tilingData_{nullptr};
+};
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline void CAUSAL_CONV1D_CLASS::ResetRuntimeState(const CausalConv1dTilingData *tilingData)
+{
+    tilingData_ = tilingData;
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline void CAUSAL_CONV1D_CLASS::InitSharedBuffersAndEvents()
+{
+    pipe.InitBuffer(inBuf, RING_SLOTS * MAX_BLOCK_DIM * sizeof(float));
+    pipe.InitBuffer(outBuf, 2 * MAX_BLOCK_DIM * sizeof(T));
+    pipe.InitBuffer(calcBuf, (MAX_WIDTH + 4) * MAX_BLOCK_DIM * sizeof(float));
+    AllocEvents();
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline void CAUSAL_CONV1D_CLASS::AllocEvents()
+{
+    weightBiasMte2ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>();
+    stateMte2ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>();
+    for (int32_t i = 0; i < RING_SLOTS; ++i) {
+        inputMte2ToVEvent_[i] = GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>();
+    }
+    inputVToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::V_MTE2>();
+    outMte3ToVEvent_[0] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
+    outMte3ToVEvent_[1] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
+    outVToMte3Event_[0] = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
+    outVToMte3Event_[1] = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
+    stateWritebackVToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
+    stateWritebackMte3ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
+    stateWritebackMte3ToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
+    stateShiftMte2ToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
+    stateShiftVToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
+    stateShiftMte3ToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
+    initSnapshotMte2ToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
+    initSnapshotMte3ToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
+    initSyncVToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
+    initSyncMte3ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
+    specWritebackMte2ToMte3Event_[0] = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
+    specWritebackMte2ToMte3Event_[1] = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
+    specWritebackMte3ToMte2Event_[0] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
+    specWritebackMte3ToMte2Event_[1] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline void CAUSAL_CONV1D_CLASS::ReleaseEvents()
+{
+    GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(weightBiasMte2ToVEvent_);
+    GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(stateMte2ToVEvent_);
+    for (int32_t i = 0; i < RING_SLOTS; ++i) {
+        GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(inputMte2ToVEvent_[i]);
+    }
+    GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE2>(inputVToMte2Event_);
+    GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(outMte3ToVEvent_[0]);
+    GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(outMte3ToVEvent_[1]);
+    GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(outVToMte3Event_[0]);
+    GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(outVToMte3Event_[1]);
+    GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(stateWritebackVToMte3Event_);
+    GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(stateWritebackMte3ToVEvent_);
+    GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(stateWritebackMte3ToMte2Event_);
+    GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(stateShiftMte2ToMte3Event_);
+    GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(stateShiftVToMte3Event_);
+    GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
+    GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(initSnapshotMte2ToMte3Event_);
+    GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(initSnapshotMte3ToMte2Event_);
+    GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(initSyncVToMte3Event_);
+    GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(initSyncMte3ToVEvent_);
+    GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[0]);
+    GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[1]);
+    GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[0]);
+    GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[1]);
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline void CAUSAL_CONV1D_CLASS::LoadWeightAndBias(int32_t channelStart, int32_t baseDim)
+{
+    const int32_t dim = tilingData_->dim;
+    const int32_t width = static_cast<int32_t>(tilingData_->width);
+    const int32_t jStart = MAX_WIDTH - width;
+    const bool hasBias = HasBias();
+    auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
+    LocalTensor<float> &weightF = cl.weightF;
+    LocalTensor<float> &biasF = cl.biasF;
+    LocalTensor<T> weightT;
+    LocalTensor<T> biasT;
+
+    if constexpr (!std::is_same<T, float>::value) {
+        weightT = weightF.ReinterpretCast<T>();
+        biasT = biasF.ReinterpretCast<T>();
+    }
+
+    for (int32_t j = 0; j < jStart; ++j) {
+        Duplicate(weightF[j * MAX_BLOCK_DIM], 0.0f, baseDim);
+    }
+
+    for (int32_t j = 0; j < width; ++j) {
+        const int32_t jDst = jStart + j;
+        const int64_t weightOffset = static_cast<int64_t>(j) * dim + channelStart;
+
+        if constexpr (std::is_same<T, float>::value) {
+            DataCopy(weightF[jDst * MAX_BLOCK_DIM], weightGm[weightOffset], baseDim);
+        } else {
+            DataCopy(weightT[jDst * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], weightGm[weightOffset], baseDim);
+        }
+    }
+
+    if (hasBias) {
+        if constexpr (std::is_same<T, float>::value) {
+            DataCopy(biasF, biasGm[channelStart], baseDim);
+        } else {
+            DataCopy(biasT[MAX_BLOCK_DIM], biasGm[channelStart], baseDim);
+        }
+    }
+
+    SetFlag<HardEvent::MTE2_V>(weightBiasMte2ToVEvent_);
+    WaitFlag<HardEvent::MTE2_V>(weightBiasMte2ToVEvent_);
+
+    if constexpr (!std::is_same<T, float>::value) {
+        for (int32_t j = 0; j < width; ++j) {
+            const int32_t jDst = jStart + j;
+            Cast(weightF[jDst * MAX_BLOCK_DIM], weightT[jDst * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], RoundMode::CAST_NONE,
+                baseDim);
+        }
+        if (hasBias) {
+            Cast(biasF, biasT[MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+        }
         PipeBarrier<PIPE_V>();
-        Silu(currF, state0F, baseDim);
     }
-#endif
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline void CAUSAL_CONV1D_CLASS::AdvanceFnLocalPartials(int32_t slotCurr, int32_t baseDim)
- {
-     if constexpr (!kHasCompileTimeWidth) {
-         return;
-     }
- 
-     auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
-     LocalTensor<float> &weightF = cl.weightF;
-     LocalTensor<float> &state2F = cl.biasF;
-     LocalTensor<float> &state1F = cl.accF;
-     LocalTensor<float> &state0F = cl.tmpF;
-     LocalTensor<float> &currF = cl.currF;
-     LocalTensor<T> ring = inBuf.Get<T>();
-     constexpr int32_t w0Idx = MAX_WIDTH - kTemplateWidth;
 
-#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
-    AdvanceFnLocalPartialsRegbase<T, kTemplateWidth>(ring[slotCurr * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], 
-        state0F, state1F, state2F, baseDim, MAX_BLOCK_DIM);
-#else
-    Cast(currF, ring[slotCurr * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
-    PipeBarrier<PIPE_V>();
+    if (!hasBias) {
+        Duplicate(biasF, 0.0f, baseDim);
+    }
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline void CAUSAL_CONV1D_CLASS::InitRing(int32_t cacheIdx, bool hasInit, int32_t stateTokenOffset,
+                                                    int32_t start, int32_t len, int32_t channelStart,
+                                                    int32_t baseDim, int32_t dim)
+{
+    const int32_t stateLen = tilingData_->stateLen;
+    const int32_t width = static_cast<int32_t>(tilingData_->width);
+    const int32_t ringStart = MAX_WIDTH - width;
+    LocalTensor<float> ringF = inBuf.Get<float>();
+    LocalTensor<T> ringT = ringF.ReinterpretCast<T>();
+
+    for (int32_t i = 0; i < ringStart; ++i) {
+        Duplicate(ringF[i * MAX_BLOCK_DIM], 0.0f, baseDim);
+    }
+    if (ringStart > 0) {
+        PipeBarrier<PIPE_V>();
+    }
+
+    if (hasInit) {
+        for (int32_t i = 0; i < (width - 1); ++i) {
+            const int32_t pos = stateTokenOffset + i;
+            const int64_t stateOffset =
+                static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(pos) * dim + channelStart;
+            DataCopy(ringT[(ringStart + i) * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], convStatesGm[stateOffset], baseDim);
+        }
+        SetFlag<HardEvent::MTE2_V>(stateMte2ToVEvent_);
+        WaitFlag<HardEvent::MTE2_V>(stateMte2ToVEvent_);
+        for (int32_t i = 0; i < (width - 1); ++i) {
+            const int32_t pos = ringStart + i;
+            Cast(ringF[pos * MAX_BLOCK_DIM], ringT[pos * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+        }
+        PipeBarrier<PIPE_V>();
+    } else {
+        for (int32_t i = 0; i < (width - 1); ++i) {
+            Duplicate(ringF[(ringStart + i) * MAX_BLOCK_DIM], 0.0f, baseDim);
+        }
+        PipeBarrier<PIPE_V>();
+    }
+
+    if (len > 0) {
+        const int32_t slot0 = SlotCurr(0);
+        const int64_t xOffset = static_cast<int64_t>(start) * dim + channelStart;
+        DataCopy(ringT[slot0 * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], xGm[xOffset], baseDim);
+        SetFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slot0]);
+    }
+
+    if (len > 1) {
+        SetFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
+    }
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline void CAUSAL_CONV1D_CLASS::RunSeq(int32_t start, int32_t len, int32_t channelStart,
+                                                int32_t baseDim, int32_t dim)
+{
+    if (IsFnRollingFastPathEnabled()) {
+        RunSeqFnRolling(start, len, channelStart, baseDim, dim);
+        return;
+    }
+
+    const int32_t width = static_cast<int32_t>(tilingData_->width);
+    const int32_t jStart = MAX_WIDTH - width;
+    auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
+    LocalTensor<float> &weightF = cl.weightF;
+    LocalTensor<float> &biasF = cl.biasF;
+    LocalTensor<float> &accF = cl.accF;
+    LocalTensor<float> &tmpF = cl.tmpF;
+    LocalTensor<float> ringF = inBuf.Get<float>();
+    LocalTensor<T> ringT = ringF.ReinterpretCast<T>();
+    LocalTensor<T> outT = outBuf.Get<T>();
+    const bool hasBias = HasBias();
+    const bool hasActivation = HasActivation();
+    for (int32_t t = 0; t < len; ++t) {
+        const int32_t slotCurr = SlotCurr(t);
+
+        WaitFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotCurr]);
+        Cast(ringF[slotCurr * MAX_BLOCK_DIM], ringT[slotCurr * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+        PipeBarrier<PIPE_V>();
+
+        if (t + 1 < len) {
+            const int32_t slotNext = SlotPrefetch(t);
+            const int64_t xOffsetNext = static_cast<int64_t>(start + t + 1) * dim + channelStart;
+            WaitFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
+            DataCopy(ringT[slotNext * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], xGm[xOffsetNext], baseDim);
+            SetFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotNext]);
+        }
+
+        bool accInitialized = false;
+        if (hasBias) {
+            DataCopy(accF, biasF, baseDim);
+            PipeBarrier<PIPE_V>();
+            accInitialized = true;
+        }
+
+        for (int32_t j = jStart; j < MAX_WIDTH; ++j) {
+            const int32_t tap = (MAX_WIDTH - 1) - j;
+            const int32_t slot = (tap == 0) ? slotCurr : SlotHist(t, tap);
+            if (!accInitialized) {
+                Mul(accF, ringF[slot * MAX_BLOCK_DIM], weightF[j * MAX_BLOCK_DIM], baseDim);
+                accInitialized = true;
+            } else {
+                MulAddDst(accF, ringF[slot * MAX_BLOCK_DIM], weightF[j * MAX_BLOCK_DIM], baseDim);
+            }
+        }
+
+        PipeBarrier<PIPE_V>();
+
+        if (hasActivation) {
+            Silu(tmpF, accF, baseDim);
+        }
+
+        const int32_t outSlot = t & 1;
+        LocalTensor<T> outSlotT = outT[outSlot * MAX_BLOCK_DIM];
+        if (t >= 2) {
+            WaitFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
+        }
+
+        if constexpr (IsSameType<T, float>::value) {
+            if (hasActivation) {
+                DataCopy(outSlotT, tmpF, baseDim);
+            } else {
+                DataCopy(outSlotT, accF, baseDim);
+            }
+        } else {
+            if (hasActivation) {
+                Cast(outSlotT, tmpF, RoundMode::CAST_RINT, baseDim);
+            } else {
+                Cast(outSlotT, accF, RoundMode::CAST_RINT, baseDim);
+            }
+        }
+
+        SetFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
+
+        const int64_t outOffset = static_cast<int64_t>(start + t) * dim + channelStart;
+        WaitFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
+        DataCopy(yGm[outOffset], outSlotT, baseDim);
+        if (t + 2 < len) {
+            SetFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
+        }
+
+        if (t + 2 < len) {
+            SetFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
+        }
+    }
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline void CAUSAL_CONV1D_CLASS::RestoreFnLocalPartials(int32_t baseDim)
+{
+    if constexpr (!kHasCompileTimeWidth) {
+        return;
+    }
+
+    auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
+    LocalTensor<float> &weightF = cl.weightF;
+    LocalTensor<float> &state2F = cl.biasF;
+    LocalTensor<float> &state1F = cl.accF;
+    LocalTensor<float> &state0F = cl.tmpF;
+    LocalTensor<float> &currF = cl.currF;
+    LocalTensor<float> ringF = inBuf.Get<float>();
+    constexpr int32_t ringStart = MAX_WIDTH - kTemplateWidth;
+    constexpr int32_t w0Idx = MAX_WIDTH - kTemplateWidth;
 
     if constexpr (kTemplateWidth == 2) {
-        Mul(state0F, currF, weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+        Duplicate(state2F, 0.0f, baseDim);
+        Duplicate(state1F, 0.0f, baseDim);
+        PipeBarrier<PIPE_V>();
+
+        Mul(state0F, ringF[ringStart * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
         PipeBarrier<PIPE_V>();
     } else if constexpr (kTemplateWidth == 3) {
-        Mul(state0F, currF, weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
-        PipeBarrier<PIPE_V>();
-        Add(state0F, state0F, state1F, baseDim);
+        Duplicate(state2F, 0.0f, baseDim);
         PipeBarrier<PIPE_V>();
 
-        Mul(state1F, currF, weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+        Mul(state0F, ringF[ringStart * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+        PipeBarrier<PIPE_V>();
+
+        Mul(state1F, ringF[(ringStart + 1) * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+        PipeBarrier<PIPE_V>();
+        MulAddDst(state0F, ringF[(ringStart + 1) * MAX_BLOCK_DIM], weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
         PipeBarrier<PIPE_V>();
     } else if constexpr (kTemplateWidth == 4) {
-        Mul(state0F, currF, weightF[(w0Idx + 2) * MAX_BLOCK_DIM], baseDim);
-        PipeBarrier<PIPE_V>();
-        Add(state0F, state0F, state1F, baseDim);
+        Mul(state0F, ringF[ringStart * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
         PipeBarrier<PIPE_V>();
 
-        Mul(state1F, currF, weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
+        Mul(state1F, ringF[(ringStart + 1) * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
         PipeBarrier<PIPE_V>();
-        Add(state1F, state1F, state2F, baseDim);
+        MulAddDst(state0F, ringF[(ringStart + 1) * MAX_BLOCK_DIM], weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
         PipeBarrier<PIPE_V>();
 
-        Mul(state2F, currF, weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+        Mul(state2F, ringF[(ringStart + 2) * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+        PipeBarrier<PIPE_V>();
+        MulAddDst(state1F, ringF[(ringStart + 2) * MAX_BLOCK_DIM], weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
+        PipeBarrier<PIPE_V>();
+        MulAddDst(state0F, ringF[(ringStart + 2) * MAX_BLOCK_DIM], weightF[(w0Idx + 2) * MAX_BLOCK_DIM], baseDim);
         PipeBarrier<PIPE_V>();
     }
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline void CAUSAL_CONV1D_CLASS::ComputeFnRollingOutput(int32_t slotCurr, int32_t baseDim)
+{
+    if constexpr (!kHasCompileTimeWidth) {
+        return;
+    }
+
+    auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
+    LocalTensor<float> &weightF = cl.weightF;
+    LocalTensor<float> &state0F = cl.tmpF;
+    LocalTensor<float> &currF = cl.currF;
+    LocalTensor<float> ringF = inBuf.Get<float>();
+
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+const bool hasActivation = HasActivation();
+if (hasActivation) {
+    ComputeFnRollingOutputRegbase<true>(ringF[slotCurr * MAX_BLOCK_DIM], currF, state0F, weightF[3 * MAX_BLOCK_DIM], baseDim);
+} else {
+    ComputeFnRollingOutputRegbase<false>(ringF[slotCurr * MAX_BLOCK_DIM], currF, state0F, weightF[3 * MAX_BLOCK_DIM], baseDim);
+}
+#else
+MulAddDst(state0F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[3 * MAX_BLOCK_DIM], baseDim);
+PipeBarrier<PIPE_V>();
+
+const bool hasActivation = HasActivation();
+if (hasActivation) {
+    Silu(currF, state0F, baseDim);
+    PipeBarrier<PIPE_V>();
+}
 #endif
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline void CAUSAL_CONV1D_CLASS::RunSeqFnRolling(int32_t start, int32_t len, int32_t channelStart,
-                                                             int32_t baseDim, int32_t dim)
- {
-     if constexpr (!kHasCompileTimeWidth) {
-         return;
-     }
- 
-     auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
-     LocalTensor<float> &state0F = cl.tmpF;
-     LocalTensor<float> &currF = cl.currF;
-     LocalTensor<T> ring = inBuf.Get<T>();
-     LocalTensor<T> outT = outBuf.Get<T>();
-     const bool hasActivation = HasActivation();
-     RestoreFnLocalPartials(baseDim);
- 
-     for (int32_t t = 0; t < len; ++t) {
-         const int32_t slotCurr = SlotCurr(t);
- 
-         WaitFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotCurr]);
- 
-         if (t + 1 < len) {
-             const int32_t slotNext = SlotPrefetch(t);
-             const int64_t xOffsetNext = static_cast<int64_t>(start + t + 1) * dim + channelStart;
-             WaitFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
-             DataCopy(ring[slotNext * MAX_BLOCK_DIM], xGm[xOffsetNext], baseDim);
-             SetFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotNext]);
-         }
- 
-         ComputeFnRollingOutput(slotCurr, baseDim);
- 
-         const int32_t outSlot = t & 1;
-         LocalTensor<T> outSlotT = outT[outSlot * MAX_BLOCK_DIM];
-         if (t >= 2) {
-             WaitFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
-         }
- 
-         if constexpr (IsSameType<T, float>::value) {
-             if (hasActivation) {
-                 DataCopy(outSlotT, currF, baseDim);
-             } else {
-                 DataCopy(outSlotT, state0F, baseDim);
-             }
-         } else {
-             if (hasActivation) {
-                 Cast(outSlotT, currF, RoundMode::CAST_RINT, baseDim);
-             } else {
-                 Cast(outSlotT, state0F, RoundMode::CAST_RINT, baseDim);
-             }
-         }
- 
-         AdvanceFnLocalPartials(slotCurr, baseDim);
- 
-         SetFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
- 
-         const int64_t outOffset = static_cast<int64_t>(start + t) * dim + channelStart;
-         WaitFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
-         DataCopy(yGm[outOffset], outSlotT, baseDim);
-         if (t + 2 < len) {
-             SetFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
-         }
- 
-         if (t + 2 < len) {
-             SetFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
-         }
-     }
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline void CAUSAL_CONV1D_CLASS::DrainTaskMte3()
- {
-     SetFlag<HardEvent::MTE3_V>(stateWritebackMte3ToVEvent_);
-     WaitFlag<HardEvent::MTE3_V>(stateWritebackMte3ToVEvent_);
-     SetFlag<HardEvent::MTE3_MTE2>(stateWritebackMte3ToMte2Event_);
-     WaitFlag<HardEvent::MTE3_MTE2>(stateWritebackMte3ToMte2Event_);
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline void CAUSAL_CONV1D_CLASS::WriteBackState(int32_t cacheIdx, int32_t len, int32_t channelStart,
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline void CAUSAL_CONV1D_CLASS::AdvanceFnLocalPartials(int32_t slotCurr, int32_t baseDim)
+{
+    if constexpr (!kHasCompileTimeWidth) {
+        return;
+    }
+
+    auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
+    LocalTensor<float> &weightF = cl.weightF;
+    LocalTensor<float> &state2F = cl.biasF;
+    LocalTensor<float> &state1F = cl.accF;
+    LocalTensor<float> &state0F = cl.tmpF;
+    LocalTensor<float> &currF = cl.currF;
+    LocalTensor<float> ringF = inBuf.Get<float>();
+    constexpr int32_t w0Idx = MAX_WIDTH - kTemplateWidth;
+
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+AdvanceFnLocalPartialsRegbase<kTemplateWidth>(ringF[slotCurr * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], 
+    state0F, state1F, state2F, baseDim, MAX_BLOCK_DIM);
+#else
+if constexpr (kTemplateWidth == 2) {
+    Mul(state0F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+    PipeBarrier<PIPE_V>();
+} else if constexpr (kTemplateWidth == 3) {
+    Mul(state0F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
+    PipeBarrier<PIPE_V>();
+    Add(state0F, state0F, state1F, baseDim);
+    PipeBarrier<PIPE_V>();
+
+    Mul(state1F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+    PipeBarrier<PIPE_V>();
+} else if constexpr (kTemplateWidth == 4) {
+    Mul(state0F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[(w0Idx + 2) * MAX_BLOCK_DIM], baseDim);
+    PipeBarrier<PIPE_V>();
+    Add(state0F, state0F, state1F, baseDim);
+    PipeBarrier<PIPE_V>();
+
+    Mul(state1F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
+    PipeBarrier<PIPE_V>();
+    Add(state1F, state1F, state2F, baseDim);
+    PipeBarrier<PIPE_V>();
+
+    Mul(state2F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+    PipeBarrier<PIPE_V>();
+}
+#endif
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline void CAUSAL_CONV1D_CLASS::RunSeqFnRolling(int32_t start, int32_t len, int32_t channelStart,
                                                             int32_t baseDim, int32_t dim)
- {
-     const int32_t stateLen = tilingData_->stateLen;
-     const int32_t width = static_cast<int32_t>(tilingData_->width);
-     if (len <= 0) {
-         return;
-     }
- 
-     const int32_t lastT = len - 1;
-     LocalTensor<T> ring = inBuf.Get<T>();
-     const int32_t lastSlot = SlotCurr(lastT);
-     const int64_t stateBaseOffset = static_cast<int64_t>(cacheIdx) * stateLen * dim + channelStart;
- 
-     for (int32_t pos = 0; pos < (width - 1); ++pos) {
-         const int32_t tap = (width - 2) - pos;
-         const int32_t slot = RetreatRingSlot(lastSlot, tap);
-         const int64_t stateOffset = stateBaseOffset + static_cast<int64_t>(pos) * dim;
-         DataCopy(convStatesGm[stateOffset], ring[slot * MAX_BLOCK_DIM], baseDim);
-     }
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline void CAUSAL_CONV1D_CLASS::WriteBackStateSpec(int32_t cacheIdx, bool hasInit,
-                                                                int32_t stateTokenOffset, int32_t start, int32_t len,
-                                                                int32_t channelStart, int32_t baseDim, int32_t dim)
- {
-     const int32_t width = static_cast<int32_t>(tilingData_->width);
-     const int32_t stateLen = tilingData_->stateLen;
-     if (len <= 0) {
-         return;
-     }
- 
-     if (width != 4) {
-         WriteBackState(cacheIdx, len, channelStart, baseDim, dim);
-         return;
-     }
- 
-     constexpr int32_t keep = MAX_WIDTH - 2;
-     const int32_t reqStateLen = keep + len;
-     if (reqStateLen > stateLen) {
-         WriteBackState(cacheIdx, len, channelStart, baseDim, dim);
-         return;
-     }
- 
-     LocalTensor<T> ring = inBuf.Get<T>();
-     LocalTensor<T> buf0 = ring[0 * MAX_BLOCK_DIM];
-     LocalTensor<T> buf1 = ring[1 * MAX_BLOCK_DIM];
- 
-     if (hasInit) {
-         const int32_t srcPos0 = stateTokenOffset + 1;
-         const int32_t srcPos1 = stateTokenOffset + 2;
-         const int64_t srcOffset0 =
-             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(srcPos0) * dim + channelStart;
-         const int64_t srcOffset1 =
-             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(srcPos1) * dim + channelStart;
-         DataCopy(buf0, convStatesGm[srcOffset0], baseDim);
-         DataCopy(buf1, convStatesGm[srcOffset1], baseDim);
-         SetFlag<HardEvent::MTE2_MTE3>(stateShiftMte2ToMte3Event_);
-         WaitFlag<HardEvent::MTE2_MTE3>(stateShiftMte2ToMte3Event_);
-         const int64_t dstOffset0 =
-             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(0) * dim + channelStart;
-         const int64_t dstOffset1 =
-             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(1) * dim + channelStart;
-         DataCopy(convStatesGm[dstOffset0], buf0, baseDim);
-         DataCopy(convStatesGm[dstOffset1], buf1, baseDim);
-         SetFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
-         WaitFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
-     } else {
-         Duplicate(buf0, static_cast<T>(0), baseDim);
-         SetFlag<HardEvent::V_MTE3>(stateShiftVToMte3Event_);
-         WaitFlag<HardEvent::V_MTE3>(stateShiftVToMte3Event_);
-         const int64_t dstOffset0 =
-             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(0) * dim + channelStart;
-         const int64_t dstOffset1 =
-             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(1) * dim + channelStart;
-         DataCopy(convStatesGm[dstOffset0], buf0, baseDim);
-         DataCopy(convStatesGm[dstOffset1], buf0, baseDim);
-         SetFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
-         WaitFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
-     }
- 
-     const int64_t xOffset0 = static_cast<int64_t>(start) * dim + channelStart;
-     DataCopy(buf0, xGm[xOffset0], baseDim);
-     SetFlag<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[0]);
- 
-     for (int32_t t = 0; t < len; ++t) {
-         const int32_t curr = t & 1;
-         const int32_t next = curr ^ 1;
-         LocalTensor<T> currBuf = (curr == 0) ? buf0 : buf1;
-         LocalTensor<T> nextBuf = (next == 0) ? buf0 : buf1;
- 
-         WaitFlag<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[curr]);
- 
-         if (t + 1 < len) {
-             const int64_t xOffsetNext = static_cast<int64_t>(start + t + 1) * dim + channelStart;
-             if (t > 0) {
-                 WaitFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[next]);
-             }
-             DataCopy(nextBuf, xGm[xOffsetNext], baseDim);
-             SetFlag<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[next]);
-         }
- 
-         const int64_t dstOffset =
-             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(keep + t) * dim + channelStart;
-         DataCopy(convStatesGm[dstOffset], currBuf, baseDim);
-         SetFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[curr]);
-     }
- 
-     WaitFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[0]);
-     if (len > 1) {
-         WaitFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[1]);
-     }
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqTaskWindow(int32_t seq, int32_t inputMode, int32_t seqLen,
-                                                                  int32_t &start, int32_t &len) const
- {
-     switch (GetSeqTaskWindowMode(inputMode)) {
-         case SEQ_TASK_WINDOW_MODE_VARLEN:
-             return ResolveSeqTaskWindowByMode<SEQ_TASK_WINDOW_MODE_VARLEN>(seq, seqLen, start, len);
-         case SEQ_TASK_WINDOW_MODE_DECODE2D:
-             return ResolveSeqTaskWindowByMode<SEQ_TASK_WINDOW_MODE_DECODE2D>(seq, seqLen, start, len);
-         default:
-             return ResolveSeqTaskWindowByMode<SEQ_TASK_WINDOW_MODE_BATCH>(seq, seqLen, start, len);
-     }
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- template <int32_t kWindowMode>
- __aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqTaskWindowByMode(int32_t seq, int32_t seqLen, int32_t &start,
-                                                                        int32_t &len) const
- {
-     SeqTaskWindow window;
-     if constexpr (kWindowMode == SEQ_TASK_WINDOW_MODE_VARLEN) {
-         const int32_t startVal = queryStartLocGm.GetValue(seq);
-         const int32_t endVal = queryStartLocGm.GetValue(seq + 1);
-         window = BuildSeqTaskWindowVarlen(startVal, endVal);
-     } else if constexpr (kWindowMode == SEQ_TASK_WINDOW_MODE_DECODE2D) {
-         window = BuildSeqTaskWindowDecode2D(seq);
-     } else {
-         window = BuildSeqTaskWindowBatch(seq, seqLen);
-     }
- 
-     if (!window.valid) {
-         return false;
-     }
-     start = window.start;
-     len = window.len;
-     return true;
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqCacheIndex(int32_t seq, bool hasCacheIndices,
-                                                                  int32_t &cacheIdx) const
- {
-     cacheIdx = seq;
-     if (!hasCacheIndices) {
-         return true;
-     }
- 
-     const int64_t cacheIdx64 = cacheIndicesGm.GetValue(seq);
-     if (cacheIdx64 == tilingData_->padSlotId) {
-         return false;
-     }
-     cacheIdx = static_cast<int32_t>(cacheIdx64);
-     return true;
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqHasInit(int32_t seq, bool hasInitialStateMode) const
- {
-     return hasInitialStateMode ? (initialStateModeGm.GetValue(seq) != 0) : false;
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline void CAUSAL_CONV1D_CLASS::ProcessDefault()
- {
-     switch (GetSeqTaskWindowMode(tilingData_->inputMode)) {
-         case SEQ_TASK_WINDOW_MODE_VARLEN:
-             ProcessDefaultByWindowMode<SEQ_TASK_WINDOW_MODE_VARLEN>();
-             return;
-         case SEQ_TASK_WINDOW_MODE_DECODE2D:
-             ProcessDefaultByWindowMode<SEQ_TASK_WINDOW_MODE_DECODE2D>();
-             return;
-         default:
-             ProcessDefaultByWindowMode<SEQ_TASK_WINDOW_MODE_BATCH>();
-             return;
-     }
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- template <int32_t kWindowMode>
- __aicore__ inline void CAUSAL_CONV1D_CLASS::ProcessDefaultByWindowMode()
- {
-     const int32_t dim = tilingData_->dim;
-     const int32_t batch = tilingData_->batch;
-     const int32_t seqLen = tilingData_->seqLen;
-     const int32_t baseDim = static_cast<int32_t>(tilingData_->baseDim);
-     const int32_t baseDimCnt = static_cast<int32_t>(tilingData_->baseDimCnt);
-     const int32_t width = static_cast<int32_t>(tilingData_->width);
-     const bool hasCacheIndices = (tilingData_->hasCacheIndices != 0);
-     const bool hasInit = true;
-     const bool isSpecDecodingGlobal = IsUpdateSpecDecodingEnabled();
- 
-     const uint32_t blockIdx = GetBlockIdx();
-     const uint32_t blockNum = GetBlockNum();
- 
-     if (baseDim <= 0 || baseDimCnt <= 0 || baseDim > MAX_BLOCK_DIM || width < 2 || width > MAX_WIDTH) {
-         ReleaseEvents();
-         return;
-     }
- 
-     const int64_t gridSize = static_cast<int64_t>(batch) * baseDimCnt;
-     for (int64_t task = static_cast<int64_t>(blockIdx); task < gridSize; task += static_cast<int64_t>(blockNum)) {
-         const int32_t seq = static_cast<int32_t>(task / baseDimCnt);
-         const int32_t baseDimIdx = static_cast<int32_t>(task % baseDimCnt);
-         const int32_t channelStart = baseDimIdx * baseDim;
-         if (channelStart >= dim) {
-             continue;
-         }
-         const int32_t curBaseDim = (channelStart + baseDim <= dim) ? baseDim : (dim - channelStart);
- 
-         int32_t start = 0;
-         int32_t len = 0;
-         if (!ResolveSeqTaskWindowByMode<kWindowMode>(seq, seqLen, start, len)) {
-             continue;
-         }
- 
-         int32_t cacheIdx = 0;
-         if (!ResolveSeqCacheIndex(seq, hasCacheIndices, cacheIdx)) {
-             continue;
-         }
- 
-         int32_t stateTokenOffset = 0;
-         if (isSpecDecodingGlobal) {
-             int32_t accepted = static_cast<int32_t>(numAcceptedTokensGm.GetValue(seq));
-             stateTokenOffset = accepted - 1;
-             const int32_t maxOffset = static_cast<int32_t>(tilingData_->stateLen - (width - 1));
-             if (stateTokenOffset < 0) {
-                 stateTokenOffset = 0;
-             } else if (stateTokenOffset > maxOffset) {
-                 stateTokenOffset = maxOffset;
-             }
-         }
- 
-         LoadWeightAndBias(channelStart, curBaseDim);
- 
-         InitRing(cacheIdx, hasInit, stateTokenOffset, start, len, channelStart, curBaseDim, dim);
-         RunSeq(start, len, channelStart, curBaseDim, dim);
- 
-         if (isSpecDecodingGlobal) {
-             DrainTaskMte3();
-             WriteBackStateSpec(cacheIdx, hasInit, stateTokenOffset, start, len, channelStart, curBaseDim, dim);
-         } else {
-             WriteBackState(cacheIdx, len, channelStart, curBaseDim, dim);
-         }
- 
-         DrainTaskMte3();
-     }
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline const CausalConv1dTilingData *CAUSAL_CONV1D_CLASS::GetTilingData() const
- {
-     return tilingData_;
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline bool CAUSAL_CONV1D_CLASS::HasActivation() const
- {
-     return (tilingData_ != nullptr) && (tilingData_->activationMode != 0);
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline bool CAUSAL_CONV1D_CLASS::HasBias() const
- {
-     return (tilingData_ != nullptr) && (tilingData_->hasBias != 0);
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline bool CAUSAL_CONV1D_CLASS::IsUpdateMode() const
- {
-     return kIsUpdateMode;
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline bool CAUSAL_CONV1D_CLASS::IsFnRollingFastPathEnabled() const
- {
-     return !kIsUpdateMode && (tilingData_ != nullptr) && (kFnExecutionPlan != FN_EXECUTION_PLAN_INVALID) &&
-            (tilingData_->hasNumAcceptedTokens == 0) && !HasBias();
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline bool CAUSAL_CONV1D_CLASS::HasExplicitFnTokenSeqRanges() const
- {
-     return !kIsUpdateMode && (tilingData_ != nullptr) && (tilingData_->inputMode == 0) &&
-            (tilingData_->hasExplicitTokenSeqRanges != 0) &&
-            (tilingData_->explicitTokenSeqRangeCount >= tilingData_->tokenBlockCnt);
- }
- 
- template <CAUSAL_CONV1D_TEMPLATE_ARGS>
- __aicore__ inline bool CAUSAL_CONV1D_CLASS::IsUpdateSpecDecodingEnabled() const
- {
-     return kIsUpdateMode && (tilingData_->hasNumAcceptedTokens != 0) && (tilingData_->width == 4);
- }
- 
- #include "causal_conv1d_fn_tasks.h"
- 
- #undef CAUSAL_CONV1D_CLASS
- #undef CAUSAL_CONV1D_TEMPLATE_ARGS
+{
+    if constexpr (!kHasCompileTimeWidth) {
+        return;
+    }
+
+    auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
+    LocalTensor<float> &state0F = cl.tmpF;
+    LocalTensor<float> &currF = cl.currF;
+    LocalTensor<float> ringF = inBuf.Get<float>();
+    LocalTensor<T> ringT = ringF.ReinterpretCast<T>();
+    LocalTensor<T> outT = outBuf.Get<T>();
+    const bool hasActivation = HasActivation();
+    RestoreFnLocalPartials(baseDim);
+
+    for (int32_t t = 0; t < len; ++t) {
+        const int32_t slotCurr = SlotCurr(t);
+
+        WaitFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotCurr]);
+        Cast(ringF[slotCurr * MAX_BLOCK_DIM], ringT[slotCurr * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+
+        if (t + 1 < len) {
+            const int32_t slotNext = SlotPrefetch(t);
+            const int64_t xOffsetNext = static_cast<int64_t>(start + t + 1) * dim + channelStart;
+            WaitFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
+            DataCopy(ringT[slotNext * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], xGm[xOffsetNext], baseDim);
+            SetFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotNext]);
+        }
+
+        ComputeFnRollingOutput(slotCurr, baseDim);
+
+        const int32_t outSlot = t & 1;
+        LocalTensor<T> outSlotT = outT[outSlot * MAX_BLOCK_DIM];
+        if (t >= 2) {
+            WaitFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
+        }
+
+        if constexpr (IsSameType<T, float>::value) {
+            if (hasActivation) {
+                DataCopy(outSlotT, currF, baseDim);
+            } else {
+                DataCopy(outSlotT, state0F, baseDim);
+            }
+        } else {
+            if (hasActivation) {
+                Cast(outSlotT, currF, RoundMode::CAST_RINT, baseDim);
+            } else {
+                Cast(outSlotT, state0F, RoundMode::CAST_RINT, baseDim);
+            }
+        }
+
+        AdvanceFnLocalPartials(slotCurr, baseDim);
+
+        SetFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
+
+        const int64_t outOffset = static_cast<int64_t>(start + t) * dim + channelStart;
+        WaitFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
+        DataCopy(yGm[outOffset], outSlotT, baseDim);
+        if (t + 2 < len) {
+            SetFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
+        }
+
+        if (t + 2 < len) {
+            SetFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
+        }
+    }
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline void CAUSAL_CONV1D_CLASS::DrainTaskMte3()
+{
+    SetFlag<HardEvent::MTE3_V>(stateWritebackMte3ToVEvent_);
+    WaitFlag<HardEvent::MTE3_V>(stateWritebackMte3ToVEvent_);
+    SetFlag<HardEvent::MTE3_MTE2>(stateWritebackMte3ToMte2Event_);
+    WaitFlag<HardEvent::MTE3_MTE2>(stateWritebackMte3ToMte2Event_);
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline void CAUSAL_CONV1D_CLASS::WriteBackState(int32_t cacheIdx, int32_t len, int32_t channelStart,
+                                                        int32_t baseDim, int32_t dim)
+{
+    const int32_t stateLen = tilingData_->stateLen;
+    const int32_t width = static_cast<int32_t>(tilingData_->width);
+    if (len <= 0) {
+        return;
+    }
+
+    const int32_t lastT = len - 1;
+    LocalTensor<float> ringF = inBuf.Get<float>();
+    LocalTensor<T> ringT = ringF.ReinterpretCast<T>();
+    const int32_t lastSlot = SlotCurr(lastT);
+    const int64_t stateBaseOffset = static_cast<int64_t>(cacheIdx) * stateLen * dim + channelStart;
+
+    for (int32_t pos = 0; pos < (width - 1); ++pos) {
+        const int32_t tap = (width - 2) - pos;
+        const int32_t slot = RetreatRingSlot(lastSlot, tap);
+        Cast(ringT[slot * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], ringF[slot * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+    }
+
+    SetFlag<HardEvent::V_MTE3>(stateWritebackVToMte3Event_);
+    WaitFlag<HardEvent::V_MTE3>(stateWritebackVToMte3Event_);
+
+    for (int32_t pos = 0; pos < (width - 1); ++pos) {
+        const int32_t tap = (width - 2) - pos;
+        const int32_t slot = RetreatRingSlot(lastSlot, tap);
+        const int64_t stateOffset = stateBaseOffset + static_cast<int64_t>(pos) * dim;
+        DataCopy(convStatesGm[stateOffset], ringT[slot * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], baseDim);
+    }
+}
+
+// TODO
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline void CAUSAL_CONV1D_CLASS::WriteBackStateSpec(int32_t cacheIdx, bool hasInit,
+                                                            int32_t stateTokenOffset, int32_t start, int32_t len,
+                                                            int32_t channelStart, int32_t baseDim, int32_t dim)
+{
+    const int32_t width = static_cast<int32_t>(tilingData_->width);
+    const int32_t stateLen = tilingData_->stateLen;
+    if (len <= 0) {
+        return;
+    }
+
+    if (width != 4) {
+        WriteBackState(cacheIdx, len, channelStart, baseDim, dim);
+        return;
+    }
+
+    constexpr int32_t keep = MAX_WIDTH - 2;
+    const int32_t reqStateLen = keep + len;
+    if (reqStateLen > stateLen) {
+        WriteBackState(cacheIdx, len, channelStart, baseDim, dim);
+        return;
+    }
+
+    LocalTensor<float> ringF = inBuf.Get<float>();
+    LocalTensor<T> ringT = ringF.ReinterpretCast<T>();
+    LocalTensor<T> buf0T = ringT[0 * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM];
+    LocalTensor<T> buf1T = ringT[1 * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM];
+
+    if (hasInit) {
+        const int32_t srcPos0 = stateTokenOffset + 1;
+        const int32_t srcPos1 = stateTokenOffset + 2;
+        const int64_t srcOffset0 =
+            static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(srcPos0) * dim + channelStart;
+        const int64_t srcOffset1 =
+            static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(srcPos1) * dim + channelStart;
+        DataCopy(buf0T, convStatesGm[srcOffset0], baseDim);
+        DataCopy(buf1T, convStatesGm[srcOffset1], baseDim);
+        SetFlag<HardEvent::MTE2_MTE3>(stateShiftMte2ToMte3Event_);
+        WaitFlag<HardEvent::MTE2_MTE3>(stateShiftMte2ToMte3Event_);
+        const int64_t dstOffset0 =
+            static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(0) * dim + channelStart;
+        const int64_t dstOffset1 =
+            static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(1) * dim + channelStart;
+        DataCopy(convStatesGm[dstOffset0], buf0T, baseDim);
+        DataCopy(convStatesGm[dstOffset1], buf1T, baseDim);
+        SetFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
+        WaitFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
+    } else {
+        Duplicate(buf0T, static_cast<T>(0), baseDim);
+        SetFlag<HardEvent::V_MTE3>(stateShiftVToMte3Event_);
+        WaitFlag<HardEvent::V_MTE3>(stateShiftVToMte3Event_);
+        const int64_t dstOffset0 =
+            static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(0) * dim + channelStart;
+        const int64_t dstOffset1 =
+            static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(1) * dim + channelStart;
+        DataCopy(convStatesGm[dstOffset0], buf0T, baseDim);
+        DataCopy(convStatesGm[dstOffset1], buf0T, baseDim);
+        SetFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
+        WaitFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
+    }
+
+    const int64_t xOffset0 = static_cast<int64_t>(start) * dim + channelStart;
+    DataCopy(buf0T, xGm[xOffset0], baseDim);
+    SetFlag<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[0]);
+
+    for (int32_t t = 0; t < len; ++t) {
+        const int32_t curr = t & 1;
+        const int32_t next = curr ^ 1;
+        LocalTensor<T> currBuf = (curr == 0) ? buf0T : buf1T;
+        LocalTensor<T> nextBuf = (next == 0) ? buf0T : buf1T;
+
+        WaitFlag<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[curr]);
+
+        if (t + 1 < len) {
+            const int64_t xOffsetNext = static_cast<int64_t>(start + t + 1) * dim + channelStart;
+            if (t > 0) {
+                WaitFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[next]);
+            }
+            DataCopy(nextBuf, xGm[xOffsetNext], baseDim);
+            SetFlag<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[next]);
+        }
+
+        const int64_t dstOffset =
+            static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(keep + t) * dim + channelStart;
+        DataCopy(convStatesGm[dstOffset], currBuf, baseDim);
+        SetFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[curr]);
+    }
+
+    WaitFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[0]);
+    if (len > 1) {
+        WaitFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[1]);
+    }
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqTaskWindow(int32_t seq, int32_t inputMode, int32_t seqLen,
+                                                                int32_t &start, int32_t &len) const
+{
+    switch (GetSeqTaskWindowMode(inputMode)) {
+        case SEQ_TASK_WINDOW_MODE_VARLEN:
+            return ResolveSeqTaskWindowByMode<SEQ_TASK_WINDOW_MODE_VARLEN>(seq, seqLen, start, len);
+        case SEQ_TASK_WINDOW_MODE_DECODE2D:
+            return ResolveSeqTaskWindowByMode<SEQ_TASK_WINDOW_MODE_DECODE2D>(seq, seqLen, start, len);
+        default:
+            return ResolveSeqTaskWindowByMode<SEQ_TASK_WINDOW_MODE_BATCH>(seq, seqLen, start, len);
+    }
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+template <int32_t kWindowMode>
+__aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqTaskWindowByMode(int32_t seq, int32_t seqLen, int32_t &start,
+                                                                    int32_t &len) const
+{
+    SeqTaskWindow window;
+    if constexpr (kWindowMode == SEQ_TASK_WINDOW_MODE_VARLEN) {
+        const int32_t startVal = queryStartLocGm.GetValue(seq);
+        const int32_t endVal = queryStartLocGm.GetValue(seq + 1);
+        window = BuildSeqTaskWindowVarlen(startVal, endVal);
+    } else if constexpr (kWindowMode == SEQ_TASK_WINDOW_MODE_DECODE2D) {
+        window = BuildSeqTaskWindowDecode2D(seq);
+    } else {
+        window = BuildSeqTaskWindowBatch(seq, seqLen);
+    }
+
+    if (!window.valid) {
+        return false;
+    }
+    start = window.start;
+    len = window.len;
+    return true;
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqCacheIndex(int32_t seq, bool hasCacheIndices,
+                                                                int32_t &cacheIdx) const
+{
+    cacheIdx = seq;
+    if (!hasCacheIndices) {
+        return true;
+    }
+
+    const int64_t cacheIdx64 = cacheIndicesGm.GetValue(seq);
+    if (cacheIdx64 == tilingData_->padSlotId) {
+        return false;
+    }
+    cacheIdx = static_cast<int32_t>(cacheIdx64);
+    return true;
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqHasInit(int32_t seq, bool hasInitialStateMode) const
+{
+    return hasInitialStateMode ? (initialStateModeGm.GetValue(seq) != 0) : false;
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline void CAUSAL_CONV1D_CLASS::ProcessDefault()
+{
+    switch (GetSeqTaskWindowMode(tilingData_->inputMode)) {
+        case SEQ_TASK_WINDOW_MODE_VARLEN:
+            ProcessDefaultByWindowMode<SEQ_TASK_WINDOW_MODE_VARLEN>();
+            return;
+        case SEQ_TASK_WINDOW_MODE_DECODE2D:
+            ProcessDefaultByWindowMode<SEQ_TASK_WINDOW_MODE_DECODE2D>();
+            return;
+        default:
+            ProcessDefaultByWindowMode<SEQ_TASK_WINDOW_MODE_BATCH>();
+            return;
+    }
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+template <int32_t kWindowMode>
+__aicore__ inline void CAUSAL_CONV1D_CLASS::ProcessDefaultByWindowMode()
+{
+    const int32_t dim = tilingData_->dim;
+    const int32_t batch = tilingData_->batch;
+    const int32_t seqLen = tilingData_->seqLen;
+    const int32_t baseDim = static_cast<int32_t>(tilingData_->baseDim);
+    const int32_t baseDimCnt = static_cast<int32_t>(tilingData_->baseDimCnt);
+    const int32_t width = static_cast<int32_t>(tilingData_->width);
+    const bool hasCacheIndices = (tilingData_->hasCacheIndices != 0);
+    const bool hasInit = true;
+    const bool isSpecDecodingGlobal = IsUpdateSpecDecodingEnabled();
+
+    const uint32_t blockIdx = GetBlockIdx();
+    const uint32_t blockNum = GetBlockNum();
+
+    if (baseDim <= 0 || baseDimCnt <= 0 || baseDim > MAX_BLOCK_DIM || width < 2 || width > MAX_WIDTH) {
+        ReleaseEvents();
+        return;
+    }
+
+    const int64_t gridSize = static_cast<int64_t>(batch) * baseDimCnt;
+    for (int64_t task = static_cast<int64_t>(blockIdx); task < gridSize; task += static_cast<int64_t>(blockNum)) {
+        const int32_t seq = static_cast<int32_t>(task / baseDimCnt);
+        const int32_t baseDimIdx = static_cast<int32_t>(task % baseDimCnt);
+        const int32_t channelStart = baseDimIdx * baseDim;
+        if (channelStart >= dim) {
+            continue;
+        }
+        const int32_t curBaseDim = (channelStart + baseDim <= dim) ? baseDim : (dim - channelStart);
+
+        int32_t start = 0;
+        int32_t len = 0;
+        if (!ResolveSeqTaskWindowByMode<kWindowMode>(seq, seqLen, start, len)) {
+            continue;
+        }
+
+        int32_t cacheIdx = 0;
+        if (!ResolveSeqCacheIndex(seq, hasCacheIndices, cacheIdx)) {
+            continue;
+        }
+
+        int32_t stateTokenOffset = 0;
+        if (isSpecDecodingGlobal) {
+            int32_t accepted = static_cast<int32_t>(numAcceptedTokensGm.GetValue(seq));
+            stateTokenOffset = accepted - 1;
+            const int32_t maxOffset = static_cast<int32_t>(tilingData_->stateLen - (width - 1));
+            if (stateTokenOffset < 0) {
+                stateTokenOffset = 0;
+            } else if (stateTokenOffset > maxOffset) {
+                stateTokenOffset = maxOffset;
+            }
+        }
+
+        LoadWeightAndBias(channelStart, curBaseDim);
+
+        InitRing(cacheIdx, hasInit, stateTokenOffset, start, len, channelStart, curBaseDim, dim);
+        RunSeq(start, len, channelStart, curBaseDim, dim);
+
+        PipeBarrier<PIPE_V>();
+        if (isSpecDecodingGlobal) {
+            DrainTaskMte3();
+            WriteBackStateSpec(cacheIdx, hasInit, stateTokenOffset, start, len, channelStart, curBaseDim, dim);
+        } else {
+            WriteBackState(cacheIdx, len, channelStart, curBaseDim, dim);
+        }
+
+        DrainTaskMte3();
+    }
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline const CausalConv1dTilingData *CAUSAL_CONV1D_CLASS::GetTilingData() const
+{
+    return tilingData_;
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline bool CAUSAL_CONV1D_CLASS::HasActivation() const
+{
+    return (tilingData_ != nullptr) && (tilingData_->activationMode != 0);
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline bool CAUSAL_CONV1D_CLASS::HasBias() const
+{
+    return (tilingData_ != nullptr) && (tilingData_->hasBias != 0);
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline bool CAUSAL_CONV1D_CLASS::IsUpdateMode() const
+{
+    return kIsUpdateMode;
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline bool CAUSAL_CONV1D_CLASS::IsFnRollingFastPathEnabled() const
+{
+    return !kIsUpdateMode && (tilingData_ != nullptr) && (kFnExecutionPlan != FN_EXECUTION_PLAN_INVALID) &&
+        (tilingData_->hasNumAcceptedTokens == 0) && !HasBias();
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline bool CAUSAL_CONV1D_CLASS::HasExplicitFnTokenSeqRanges() const
+{
+    return !kIsUpdateMode && (tilingData_ != nullptr) && (tilingData_->inputMode == 0) &&
+        (tilingData_->hasExplicitTokenSeqRanges != 0) &&
+        (tilingData_->explicitTokenSeqRangeCount >= tilingData_->tokenBlockCnt);
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline bool CAUSAL_CONV1D_CLASS::IsUpdateSpecDecodingEnabled() const
+{
+    return kIsUpdateMode && (tilingData_->hasNumAcceptedTokens != 0) && (tilingData_->width == 4);
+}
+
+#include "causal_conv1d_fn_tasks.h"
+
+#undef CAUSAL_CONV1D_CLASS
+#undef CAUSAL_CONV1D_TEMPLATE_ARGS
 
 } // namespace NsCausalConv1d
 #endif // CAUSAL_CONV1D_H

--- a/csrc/moe/causal_conv1d/op_kernel/causal_conv1d.h
+++ b/csrc/moe/causal_conv1d/op_kernel/causal_conv1d.h
@@ -25,106 +25,112 @@
 #include "arch35/causal_conv1d_regbase.h"
 #endif
  
-namespace NsCausalConv1d {
-
-using namespace AscendC;
-using namespace NsCausalConv1dCommon;
-
-#define CAUSAL_CONV1D_TEMPLATE_ARGS typename T, uint32_t runModeKey, uint32_t widthKey, uint32_t fnPlanKey
-#define CAUSAL_CONV1D_CLASS CausalConv1d<T, runModeKey, widthKey, fnPlanKey>
-
-enum SeqTaskWindowMode : int32_t {
-    SEQ_TASK_WINDOW_MODE_VARLEN = 0,
-    SEQ_TASK_WINDOW_MODE_BATCH = 1,
-    SEQ_TASK_WINDOW_MODE_DECODE2D = 2,
-};
-
-inline constexpr int32_t INIT_STATE_SYNCALL_NEED_SIZE = 8;
-inline constexpr int32_t INIT_STATE_SYNCALL_MAX_BLOCKS = 64;
-
-struct SeqTaskWindow {
-    bool valid = false;
-    int32_t start = 0;
-    int32_t len = 0;
-};
-
-__aicore__ inline int32_t GetSeqTaskWindowMode(int32_t inputMode)
-{
-    if (inputMode == 0) {
-        return SEQ_TASK_WINDOW_MODE_VARLEN;
-    }
-    if (inputMode == 2) {
-        return SEQ_TASK_WINDOW_MODE_DECODE2D;
-    }
-    return SEQ_TASK_WINDOW_MODE_BATCH;
-}
-
-__aicore__ inline SeqTaskWindow BuildSeqTaskWindowVarlen(int32_t startVal, int32_t endVal)
-{
-    SeqTaskWindow window;
-    window.start = startVal;
-    window.len = endVal - startVal;
-    window.valid = (window.len > 0);
-    return window;
-}
-
-__aicore__ inline int32_t RetreatRingSlot(int32_t slot, int32_t delta)
-{
-    int32_t prev = slot - delta;
-    return (prev >= 0) ? prev : (prev + RING_SLOTS);
-}
-
-__aicore__ inline SeqTaskWindow BuildSeqTaskWindowBatch(int32_t seq, int32_t seqLen)
-{
-    SeqTaskWindow window;
-    window.start = seq * seqLen;
-    window.len = seqLen;
-    window.valid = (window.len > 0);
-    return window;
-}
-
-__aicore__ inline SeqTaskWindow BuildSeqTaskWindowDecode2D(int32_t seq)
-{
-    SeqTaskWindow window;
-    window.valid = true;
-    window.start = seq;
-    window.len = 1;
-    return window;
-}
-
-__aicore__ inline constexpr int32_t DecodeWidthTplKey(uint32_t widthKey)
-{
-    switch (widthKey) {
-        case CAUSAL_CONV1D_TPL_WIDTH_2:
-            return 2;
-        case CAUSAL_CONV1D_TPL_WIDTH_3:
-            return 3;
-        case CAUSAL_CONV1D_TPL_WIDTH_4:
-            return 4;
-        default:
-            return 0;
-    }
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-class CausalConv1d {
-public:
-    __aicore__ inline CausalConv1d() = default;
-
-protected:
-    static constexpr bool kIsUpdateMode = (runModeKey == CAUSAL_CONV1D_TPL_RUN_MODE_UPDATE);
-    static constexpr int32_t kTemplateWidth = DecodeWidthTplKey(widthKey);
-    static constexpr bool kHasCompileTimeWidth =
-        (runModeKey == CAUSAL_CONV1D_TPL_RUN_MODE_FN) && (kTemplateWidth >= 2) && (kTemplateWidth <= MAX_WIDTH);
-    static constexpr FnExecutionPlan kFnExecutionPlan = static_cast<FnExecutionPlan>(fnPlanKey);
-
-    __aicore__ inline void ResetRuntimeState(const CausalConv1dTilingData *tilingData);
-    __aicore__ inline void InitSharedBuffersAndEvents();
-    __aicore__ inline void LoadWeightAndBias(int32_t channelStart, int32_t baseDim);
-    __aicore__ inline void InitRing(int32_t cacheIdx, bool hasInit, int32_t stateTokenOffset, int32_t start,
-                                    int32_t len, int32_t channelStart, int32_t baseDim, int32_t dim);
-    __aicore__ inline void InitRingSeqSplit(int32_t seq, int32_t cacheIdx, bool hasInit, int32_t seqStart,
-                                            int32_t tileStart, int32_t tileLen, int32_t channelStart, int32_t baseDim,
+ namespace NsCausalConv1d {
+ 
+ using namespace AscendC;
+ using namespace NsCausalConv1dCommon;
+ 
+ #define CAUSAL_CONV1D_TEMPLATE_ARGS typename T, uint32_t runModeKey, uint32_t widthKey, uint32_t fnPlanKey
+ #define CAUSAL_CONV1D_CLASS CausalConv1d<T, runModeKey, widthKey, fnPlanKey>
+ 
+ enum SeqTaskWindowMode : int32_t {
+     SEQ_TASK_WINDOW_MODE_VARLEN = 0,
+     SEQ_TASK_WINDOW_MODE_BATCH = 1,
+     SEQ_TASK_WINDOW_MODE_DECODE2D = 2,
+ };
+ 
+ inline constexpr int32_t INIT_STATE_SYNCALL_NEED_SIZE = 8;
+ inline constexpr int32_t INIT_STATE_SYNCALL_MAX_BLOCKS = 64;
+ 
+ struct SeqTaskWindow {
+     bool valid = false;
+     int32_t start = 0;
+     int32_t len = 0;
+ };
+ 
+ __aicore__ inline int32_t GetSeqTaskWindowMode(int32_t inputMode)
+ {
+     if (inputMode == 0) {
+         return SEQ_TASK_WINDOW_MODE_VARLEN;
+     }
+     if (inputMode == 2) {
+         return SEQ_TASK_WINDOW_MODE_DECODE2D;
+     }
+     return SEQ_TASK_WINDOW_MODE_BATCH;
+ }
+ 
+ __aicore__ inline SeqTaskWindow BuildSeqTaskWindowVarlen(int32_t startVal, int32_t endVal)
+ {
+     SeqTaskWindow window;
+     window.start = startVal;
+     window.len = endVal - startVal;
+     window.valid = (window.len > 0);
+     return window;
+ }
+ 
+ __aicore__ inline int32_t RetreatRingSlot(int32_t slot, int32_t delta)
+ {
+     int32_t prev = slot - delta;
+     return (prev >= 0) ? prev : (prev + RING_SLOTS);
+ }
+ 
+ __aicore__ inline SeqTaskWindow BuildSeqTaskWindowBatch(int32_t seq, int32_t seqLen)
+ {
+     SeqTaskWindow window;
+     window.start = seq * seqLen;
+     window.len = seqLen;
+     window.valid = (window.len > 0);
+     return window;
+ }
+ 
+ __aicore__ inline SeqTaskWindow BuildSeqTaskWindowDecode2D(int32_t seq)
+ {
+     SeqTaskWindow window;
+     window.valid = true;
+     window.start = seq;
+     window.len = 1;
+     return window;
+ }
+ 
+ __aicore__ inline constexpr int32_t DecodeWidthTplKey(uint32_t widthKey)
+ {
+     switch (widthKey) {
+         case CAUSAL_CONV1D_TPL_WIDTH_2:
+             return 2;
+         case CAUSAL_CONV1D_TPL_WIDTH_3:
+             return 3;
+         case CAUSAL_CONV1D_TPL_WIDTH_4:
+             return 4;
+         default:
+             return 0;
+     }
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ class CausalConv1d {
+ public:
+     __aicore__ inline CausalConv1d() = default;
+ 
+ protected:
+     static constexpr bool kIsUpdateMode = (runModeKey == CAUSAL_CONV1D_TPL_RUN_MODE_UPDATE);
+     static constexpr int32_t kTemplateWidth = DecodeWidthTplKey(widthKey);
+     static constexpr bool kHasCompileTimeWidth =
+         (runModeKey == CAUSAL_CONV1D_TPL_RUN_MODE_FN) && (kTemplateWidth >= 2) && (kTemplateWidth <= MAX_WIDTH);
+     static constexpr FnExecutionPlan kFnExecutionPlan = static_cast<FnExecutionPlan>(fnPlanKey);
+ 
+     __aicore__ inline void ResetRuntimeState(const CausalConv1dTilingData *tilingData);
+     __aicore__ inline void InitSharedBuffersAndEvents();
+     __aicore__ inline void LoadWeightAndBias(int32_t channelStart, int32_t baseDim);
+     __aicore__ inline void InitRing(int32_t cacheIdx, bool hasInit, int32_t stateTokenOffset, int32_t start,
+                                     int32_t len, int32_t channelStart, int32_t baseDim, int32_t dim);
+     __aicore__ inline void InitRingSeqSplit(int32_t seq, int32_t cacheIdx, bool hasInit, int32_t seqStart,
+                                             int32_t tileStart, int32_t tileLen, int32_t channelStart, int32_t baseDim,
+                                             int32_t dim);
+     __aicore__ inline void PrefetchInitStatesToWorkspace(int32_t channelStart, int32_t baseDimSize);
+     __aicore__ inline void RestoreFnLocalPartials(int32_t baseDim);
+     __aicore__ inline void ComputeFnRollingOutput(int32_t slotCurr, int32_t baseDim);
+     __aicore__ inline void AdvanceFnLocalPartials(int32_t slotCurr, int32_t baseDim);
+     __aicore__ inline void RunSeqFnRolling(int32_t start, int32_t len, int32_t channelStart, int32_t baseDim,
                                             int32_t dim);
      __aicore__ inline void RunSeq(int32_t start, int32_t len, int32_t channelStart, int32_t baseDim, int32_t dim);
      __aicore__ inline void WriteBackState(int32_t cacheIdx, int32_t len, int32_t channelStart, int32_t baseDim,
@@ -604,43 +610,12 @@ protected:
 
         Mul(state1F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
         PipeBarrier<PIPE_V>();
-        MulAddDst(state0F, ringF[(ringStart + 1) * MAX_BLOCK_DIM], weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
+        Add(state1F, state1F, state2F, baseDim);
         PipeBarrier<PIPE_V>();
 
         Mul(state2F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
         PipeBarrier<PIPE_V>();
     }
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline void CAUSAL_CONV1D_CLASS::ComputeFnRollingOutput(int32_t slotCurr, int32_t baseDim)
-{
-    if constexpr (!kHasCompileTimeWidth) {
-        return;
-    }
-
-    auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
-    LocalTensor<float> &weightF = cl.weightF;
-    LocalTensor<float> &state0F = cl.tmpF;
-    LocalTensor<float> &currF = cl.currF;
-    LocalTensor<float> ringF = inBuf.Get<float>();
-
-#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
-const bool hasActivation = HasActivation();
-if (hasActivation) {
-    ComputeFnRollingOutputRegbase<true>(ringF[slotCurr * MAX_BLOCK_DIM], currF, state0F, weightF[3 * MAX_BLOCK_DIM], baseDim);
-} else {
-    ComputeFnRollingOutputRegbase<false>(ringF[slotCurr * MAX_BLOCK_DIM], currF, state0F, weightF[3 * MAX_BLOCK_DIM], baseDim);
-}
-#else
-MulAddDst(state0F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[3 * MAX_BLOCK_DIM], baseDim);
-PipeBarrier<PIPE_V>();
-
-const bool hasActivation = HasActivation();
-if (hasActivation) {
-    Silu(currF, state0F, baseDim);
-    PipeBarrier<PIPE_V>();
-}
 #endif
  }
  

--- a/csrc/moe/causal_conv1d/op_kernel/causal_conv1d.h
+++ b/csrc/moe/causal_conv1d/op_kernel/causal_conv1d.h
@@ -126,415 +126,488 @@ protected:
     __aicore__ inline void InitRingSeqSplit(int32_t seq, int32_t cacheIdx, bool hasInit, int32_t seqStart,
                                             int32_t tileStart, int32_t tileLen, int32_t channelStart, int32_t baseDim,
                                             int32_t dim);
-    __aicore__ inline void PrefetchInitStatesToWorkspace(int32_t channelStart, int32_t baseDimSize);
-    __aicore__ inline void RestoreFnLocalPartials(int32_t baseDim);
-    __aicore__ inline void ComputeFnRollingOutput(int32_t slotCurr, int32_t baseDim);
-    __aicore__ inline void AdvanceFnLocalPartials(int32_t slotCurr, int32_t baseDim);
-    __aicore__ inline void RunSeqFnRolling(int32_t start, int32_t len, int32_t channelStart, int32_t baseDim,
-                                        int32_t dim);
-    __aicore__ inline void RunSeq(int32_t start, int32_t len, int32_t channelStart, int32_t baseDim, int32_t dim);
-    __aicore__ inline void WriteBackState(int32_t cacheIdx, int32_t len, int32_t channelStart, int32_t baseDim,
-                                        int32_t dim);
-    __aicore__ inline void WriteBackStateSpec(int32_t cacheIdx, bool hasInit, int32_t stateTokenOffset, int32_t start,
-                                            int32_t len, int32_t channelStart, int32_t baseDim, int32_t dim);
-    __aicore__ inline void DrainTaskMte3();
-    __aicore__ inline void AllocEvents();
-    __aicore__ inline void ReleaseEvents();
-    __aicore__ inline int32_t FindVarlenSeqByToken(int32_t tokenIdx) const;
-    __aicore__ inline bool ResolveExplicitTokenTileSeqRange(int32_t tokenTileId, int32_t &startSeq, int32_t &endSeq) const;
-    __aicore__ inline bool ResolveSeqTaskWindow(int32_t seq, int32_t inputMode, int32_t seqLen, int32_t &start,
-                                                int32_t &len) const;
-    template <int32_t kWindowMode>
-    __aicore__ inline bool ResolveSeqTaskWindowByMode(int32_t seq, int32_t seqLen, int32_t &start, int32_t &len) const;
-    __aicore__ inline bool ResolveSeqCacheIndex(int32_t seq, bool hasCacheIndices, int32_t &cacheIdx) const;
-    __aicore__ inline bool ResolveSeqHasInit(int32_t seq, bool hasInitialStateMode) const;
-    __aicore__ inline void MaybeWriteBackSeqSplitTailChunk(int32_t chunkStart, int32_t chunkLen, int32_t seqStart,
-                                                        int32_t seqLen, int32_t cacheIdx, int32_t channelStart,
-                                                        int32_t baseDim, int32_t dim);
-    __aicore__ inline void ProcessDefault();
-    template <int32_t kWindowMode>
-    __aicore__ inline void ProcessDefaultByWindowMode();
-    __aicore__ inline void ProcessVarlenTokenTiled();
-    __aicore__ inline void ProcessFnChunk(int32_t seq, int32_t cacheIdx, bool hasInit, int32_t seqStart,
-                                        int32_t seqLen, int32_t chunkStart, int32_t chunkLen, int32_t channelStart,
-                                        int32_t baseDim, int32_t dim);
-    __aicore__ inline const CausalConv1dTilingData *GetTilingData() const;
-    __aicore__ inline bool HasActivation() const;
-    __aicore__ inline bool HasBias() const;
-    __aicore__ inline bool IsUpdateMode() const;
-    __aicore__ inline bool IsFnRollingFastPathEnabled() const;
-    __aicore__ inline bool HasExplicitFnTokenSeqRanges() const;
-    __aicore__ inline bool IsUpdateSpecDecodingEnabled() const;
-
-protected:
-    TPipe pipe;
-    TBuf<QuePosition::VECIN> inBuf;
-    TBuf<QuePosition::VECOUT> outBuf;
-    TBuf<QuePosition::VECCALC> calcBuf;
-
-    TEventID weightBiasMte2ToVEvent_;
-    TEventID stateMte2ToVEvent_;
-    TEventID inputMte2ToVEvent_[RING_SLOTS];
-    TEventID inputVToMte2Event_;
-    TEventID outMte3ToVEvent_[2];
-    TEventID outVToMte3Event_[2];
-    TEventID stateWritebackVToMte3Event_;
-    TEventID stateWritebackMte3ToVEvent_;
-    TEventID stateWritebackMte3ToMte2Event_;
-    TEventID stateShiftMte2ToMte3Event_;
-    TEventID stateShiftVToMte3Event_;
-    TEventID stateShiftMte3ToMte2Event_;
-    TEventID initSnapshotMte2ToMte3Event_;
-    TEventID initSnapshotMte3ToMte2Event_;
-    TEventID initSyncVToMte3Event_;
-    TEventID initSyncMte3ToVEvent_;
-    TEventID specWritebackMte2ToMte3Event_[2];
-    TEventID specWritebackMte3ToMte2Event_[2];
-
-    GlobalTensor<T> xGm;
-    GlobalTensor<T> weightGm;
-    GlobalTensor<T> biasGm;
-    GlobalTensor<T> convStatesGm;
-    GlobalTensor<int64_t> queryStartLocGm;
-    GlobalTensor<int64_t> cacheIndicesGm;
-    GlobalTensor<int64_t> initialStateModeGm;
-    GlobalTensor<int64_t> numAcceptedTokensGm;
-    GlobalTensor<T> yGm;
-    GlobalTensor<int32_t> initStateSyncGm_;
-    GlobalTensor<T> initStateWorkspaceGm_;
-
-    const CausalConv1dTilingData *tilingData_{nullptr};
-};
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline void CAUSAL_CONV1D_CLASS::ResetRuntimeState(const CausalConv1dTilingData *tilingData)
-{
-    tilingData_ = tilingData;
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline void CAUSAL_CONV1D_CLASS::InitSharedBuffersAndEvents()
-{
-    pipe.InitBuffer(inBuf, RING_SLOTS * MAX_BLOCK_DIM * sizeof(float));
-    pipe.InitBuffer(outBuf, 2 * MAX_BLOCK_DIM * sizeof(T));
-    pipe.InitBuffer(calcBuf, (MAX_WIDTH + 4) * MAX_BLOCK_DIM * sizeof(float));
-    AllocEvents();
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline void CAUSAL_CONV1D_CLASS::AllocEvents()
-{
-    weightBiasMte2ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>();
-    stateMte2ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>();
-    for (int32_t i = 0; i < RING_SLOTS; ++i) {
-        inputMte2ToVEvent_[i] = GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>();
-    }
-    inputVToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::V_MTE2>();
-    outMte3ToVEvent_[0] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
-    outMte3ToVEvent_[1] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
-    outVToMte3Event_[0] = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
-    outVToMte3Event_[1] = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
-    stateWritebackVToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
-    stateWritebackMte3ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
-    stateWritebackMte3ToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
-    stateShiftMte2ToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
-    stateShiftVToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
-    stateShiftMte3ToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
-    initSnapshotMte2ToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
-    initSnapshotMte3ToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
-    initSyncVToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
-    initSyncMte3ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
-    specWritebackMte2ToMte3Event_[0] = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
-    specWritebackMte2ToMte3Event_[1] = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
-    specWritebackMte3ToMte2Event_[0] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
-    specWritebackMte3ToMte2Event_[1] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline void CAUSAL_CONV1D_CLASS::ReleaseEvents()
-{
-    GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(weightBiasMte2ToVEvent_);
-    GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(stateMte2ToVEvent_);
-    for (int32_t i = 0; i < RING_SLOTS; ++i) {
-        GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(inputMte2ToVEvent_[i]);
-    }
-    GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE2>(inputVToMte2Event_);
-    GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(outMte3ToVEvent_[0]);
-    GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(outMte3ToVEvent_[1]);
-    GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(outVToMte3Event_[0]);
-    GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(outVToMte3Event_[1]);
-    GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(stateWritebackVToMte3Event_);
-    GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(stateWritebackMte3ToVEvent_);
-    GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(stateWritebackMte3ToMte2Event_);
-    GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(stateShiftMte2ToMte3Event_);
-    GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(stateShiftVToMte3Event_);
-    GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
-    GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(initSnapshotMte2ToMte3Event_);
-    GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(initSnapshotMte3ToMte2Event_);
-    GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(initSyncVToMte3Event_);
-    GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(initSyncMte3ToVEvent_);
-    GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[0]);
-    GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[1]);
-    GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[0]);
-    GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[1]);
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline void CAUSAL_CONV1D_CLASS::LoadWeightAndBias(int32_t channelStart, int32_t baseDim)
-{
-    const int32_t dim = tilingData_->dim;
-    const int32_t width = static_cast<int32_t>(tilingData_->width);
-    const int32_t jStart = MAX_WIDTH - width;
-    const bool hasBias = HasBias();
-    auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
-    LocalTensor<float> &weightF = cl.weightF;
-    LocalTensor<float> &biasF = cl.biasF;
-    LocalTensor<T> weightT;
-    LocalTensor<T> biasT;
-
-    if constexpr (!std::is_same<T, float>::value) {
-        weightT = weightF.ReinterpretCast<T>();
-        biasT = biasF.ReinterpretCast<T>();
-    }
-
-    for (int32_t j = 0; j < jStart; ++j) {
-        Duplicate(weightF[j * MAX_BLOCK_DIM], 0.0f, baseDim);
-    }
-
-    for (int32_t j = 0; j < width; ++j) {
-        const int32_t jDst = jStart + j;
-        const int64_t weightOffset = static_cast<int64_t>(j) * dim + channelStart;
-
-        if constexpr (std::is_same<T, float>::value) {
-            DataCopy(weightF[jDst * MAX_BLOCK_DIM], weightGm[weightOffset], baseDim);
-        } else {
-            DataCopy(weightT[jDst * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], weightGm[weightOffset], baseDim);
-        }
-    }
-
-    if (hasBias) {
-        if constexpr (std::is_same<T, float>::value) {
-            DataCopy(biasF, biasGm[channelStart], baseDim);
-        } else {
-            DataCopy(biasT[MAX_BLOCK_DIM], biasGm[channelStart], baseDim);
-        }
-    }
-
-    SetFlag<HardEvent::MTE2_V>(weightBiasMte2ToVEvent_);
-    WaitFlag<HardEvent::MTE2_V>(weightBiasMte2ToVEvent_);
-
-    if constexpr (!std::is_same<T, float>::value) {
-        for (int32_t j = 0; j < width; ++j) {
-            const int32_t jDst = jStart + j;
-            Cast(weightF[jDst * MAX_BLOCK_DIM], weightT[jDst * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], RoundMode::CAST_NONE,
-                baseDim);
-        }
-        if (hasBias) {
-            Cast(biasF, biasT[MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
-        }
-        PipeBarrier<PIPE_V>();
-    }
-
-    if (!hasBias) {
-        Duplicate(biasF, 0.0f, baseDim);
-    }
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline void CAUSAL_CONV1D_CLASS::InitRing(int32_t cacheIdx, bool hasInit, int32_t stateTokenOffset,
-                                                    int32_t start, int32_t len, int32_t channelStart,
+     __aicore__ inline void RunSeq(int32_t start, int32_t len, int32_t channelStart, int32_t baseDim, int32_t dim);
+     __aicore__ inline void WriteBackState(int32_t cacheIdx, int32_t len, int32_t channelStart, int32_t baseDim,
+                                           int32_t dim);
+     __aicore__ inline void WriteBackStateSpec(int32_t cacheIdx, bool hasInit, int32_t stateTokenOffset, int32_t start,
+                                               int32_t len, int32_t channelStart, int32_t baseDim, int32_t dim);
+     __aicore__ inline void DrainTaskMte3();
+     __aicore__ inline void AllocEvents();
+     __aicore__ inline void ReleaseEvents();
+     __aicore__ inline int32_t FindVarlenSeqByToken(int32_t tokenIdx) const;
+     __aicore__ inline bool ResolveExplicitTokenTileSeqRange(int32_t tokenTileId, int32_t &startSeq, int32_t &endSeq) const;
+     __aicore__ inline bool ResolveSeqTaskWindow(int32_t seq, int32_t inputMode, int32_t seqLen, int32_t &start,
+                                                 int32_t &len) const;
+     template <int32_t kWindowMode>
+     __aicore__ inline bool ResolveSeqTaskWindowByMode(int32_t seq, int32_t seqLen, int32_t &start, int32_t &len) const;
+     __aicore__ inline bool ResolveSeqCacheIndex(int32_t seq, bool hasCacheIndices, int32_t &cacheIdx) const;
+     __aicore__ inline bool ResolveSeqHasInit(int32_t seq, bool hasInitialStateMode) const;
+     __aicore__ inline void MaybeWriteBackSeqSplitTailChunk(int32_t chunkStart, int32_t chunkLen, int32_t seqStart,
+                                                            int32_t seqLen, int32_t cacheIdx, int32_t channelStart,
+                                                            int32_t baseDim, int32_t dim);
+     __aicore__ inline void ProcessDefault();
+     template <int32_t kWindowMode>
+     __aicore__ inline void ProcessDefaultByWindowMode();
+     __aicore__ inline void ProcessVarlenTokenTiled();
+     __aicore__ inline void ProcessFnChunk(int32_t seq, int32_t cacheIdx, bool hasInit, int32_t seqStart,
+                                           int32_t seqLen, int32_t chunkStart, int32_t chunkLen, int32_t channelStart,
+                                           int32_t baseDim, int32_t dim);
+     __aicore__ inline const CausalConv1dTilingData *GetTilingData() const;
+     __aicore__ inline bool HasActivation() const;
+     __aicore__ inline bool HasBias() const;
+     __aicore__ inline bool IsUpdateMode() const;
+     __aicore__ inline bool IsFnRollingFastPathEnabled() const;
+     __aicore__ inline bool HasExplicitFnTokenSeqRanges() const;
+     __aicore__ inline bool IsUpdateSpecDecodingEnabled() const;
+ 
+ protected:
+     TPipe pipe;
+     TBuf<QuePosition::VECIN> inBuf;
+     TBuf<QuePosition::VECOUT> outBuf;
+     TBuf<QuePosition::VECCALC> calcBuf;
+ 
+     TEventID weightBiasMte2ToVEvent_;
+     TEventID stateMte2ToVEvent_;
+     TEventID inputMte2ToVEvent_[RING_SLOTS];
+     TEventID inputVToMte2Event_;
+     TEventID outMte3ToVEvent_[2];
+     TEventID outVToMte3Event_[2];
+     TEventID stateWritebackVToMte3Event_;
+     TEventID stateWritebackMte3ToVEvent_;
+     TEventID stateWritebackMte3ToMte2Event_;
+     TEventID stateShiftMte2ToMte3Event_;
+     TEventID stateShiftVToMte3Event_;
+     TEventID stateShiftMte3ToMte2Event_;
+     TEventID initSnapshotMte2ToMte3Event_;
+     TEventID initSnapshotMte3ToMte2Event_;
+     TEventID initSyncVToMte3Event_;
+     TEventID initSyncMte3ToVEvent_;
+     TEventID specWritebackMte2ToMte3Event_[2];
+     TEventID specWritebackMte3ToMte2Event_[2];
+ 
+     GlobalTensor<T> xGm;
+     GlobalTensor<T> weightGm;
+     GlobalTensor<T> biasGm;
+     GlobalTensor<T> convStatesGm;
+     GlobalTensor<int64_t> queryStartLocGm;
+     GlobalTensor<int64_t> cacheIndicesGm;
+     GlobalTensor<int64_t> initialStateModeGm;
+     GlobalTensor<int64_t> numAcceptedTokensGm;
+     GlobalTensor<T> yGm;
+     GlobalTensor<int32_t> initStateSyncGm_;
+     GlobalTensor<T> initStateWorkspaceGm_;
+ 
+     const CausalConv1dTilingData *tilingData_{nullptr};
+ };
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::ResetRuntimeState(const CausalConv1dTilingData *tilingData)
+ {
+     tilingData_ = tilingData;
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::InitSharedBuffersAndEvents()
+ {
+     pipe.InitBuffer(inBuf, RING_SLOTS * MAX_BLOCK_DIM * sizeof(float));
+     pipe.InitBuffer(outBuf, 2 * MAX_BLOCK_DIM * sizeof(T));
+     pipe.InitBuffer(calcBuf, (MAX_WIDTH + 4) * MAX_BLOCK_DIM * sizeof(float));
+     AllocEvents();
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::AllocEvents()
+ {
+     weightBiasMte2ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>();
+     stateMte2ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>();
+     for (int32_t i = 0; i < RING_SLOTS; ++i) {
+         inputMte2ToVEvent_[i] = GetTPipePtr()->AllocEventID<HardEvent::MTE2_V>();
+     }
+     inputVToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::V_MTE2>();
+     outMte3ToVEvent_[0] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
+     outMte3ToVEvent_[1] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
+     outVToMte3Event_[0] = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
+     outVToMte3Event_[1] = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
+     stateWritebackVToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
+     stateWritebackMte3ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
+     stateWritebackMte3ToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
+     stateShiftMte2ToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
+     stateShiftVToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
+     stateShiftMte3ToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
+     initSnapshotMte2ToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
+     initSnapshotMte3ToMte2Event_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
+     initSyncVToMte3Event_ = GetTPipePtr()->AllocEventID<HardEvent::V_MTE3>();
+     initSyncMte3ToVEvent_ = GetTPipePtr()->AllocEventID<HardEvent::MTE3_V>();
+     specWritebackMte2ToMte3Event_[0] = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
+     specWritebackMte2ToMte3Event_[1] = GetTPipePtr()->AllocEventID<HardEvent::MTE2_MTE3>();
+     specWritebackMte3ToMte2Event_[0] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
+     specWritebackMte3ToMte2Event_[1] = GetTPipePtr()->AllocEventID<HardEvent::MTE3_MTE2>();
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::ReleaseEvents()
+ {
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(weightBiasMte2ToVEvent_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(stateMte2ToVEvent_);
+     for (int32_t i = 0; i < RING_SLOTS; ++i) {
+         GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_V>(inputMte2ToVEvent_[i]);
+     }
+     GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE2>(inputVToMte2Event_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(outMte3ToVEvent_[0]);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(outMte3ToVEvent_[1]);
+     GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(outVToMte3Event_[0]);
+     GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(outVToMte3Event_[1]);
+     GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(stateWritebackVToMte3Event_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(stateWritebackMte3ToVEvent_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(stateWritebackMte3ToMte2Event_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(stateShiftMte2ToMte3Event_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(stateShiftVToMte3Event_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(initSnapshotMte2ToMte3Event_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(initSnapshotMte3ToMte2Event_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::V_MTE3>(initSyncVToMte3Event_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_V>(initSyncMte3ToVEvent_);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[0]);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[1]);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[0]);
+     GetTPipePtr()->ReleaseEventID<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[1]);
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::LoadWeightAndBias(int32_t channelStart, int32_t baseDim)
+ {
+     const int32_t dim = tilingData_->dim;
+     const int32_t width = static_cast<int32_t>(tilingData_->width);
+     const int32_t jStart = MAX_WIDTH - width;
+     const bool hasBias = HasBias();
+     auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
+     LocalTensor<float> &weightF = cl.weightF;
+     LocalTensor<float> &biasF = cl.biasF;
+     LocalTensor<T> weightT;
+     LocalTensor<T> biasT;
+ 
+     if constexpr (!std::is_same<T, float>::value) {
+         weightT = weightF.ReinterpretCast<T>();
+         biasT = biasF.ReinterpretCast<T>();
+     }
+ 
+     for (int32_t j = 0; j < jStart; ++j) {
+         Duplicate(weightF[j * MAX_BLOCK_DIM], 0.0f, baseDim);
+     }
+ 
+     for (int32_t j = 0; j < width; ++j) {
+         const int32_t jDst = jStart + j;
+         const int64_t weightOffset = static_cast<int64_t>(j) * dim + channelStart;
+ 
+         if constexpr (std::is_same<T, float>::value) {
+             DataCopy(weightF[jDst * MAX_BLOCK_DIM], weightGm[weightOffset], baseDim);
+         } else {
+             DataCopy(weightT[jDst * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], weightGm[weightOffset], baseDim);
+         }
+     }
+ 
+     if (hasBias) {
+         if constexpr (std::is_same<T, float>::value) {
+             DataCopy(biasF, biasGm[channelStart], baseDim);
+         } else {
+             DataCopy(biasT[MAX_BLOCK_DIM], biasGm[channelStart], baseDim);
+         }
+     }
+ 
+     SetFlag<HardEvent::MTE2_V>(weightBiasMte2ToVEvent_);
+     WaitFlag<HardEvent::MTE2_V>(weightBiasMte2ToVEvent_);
+ 
+     if constexpr (!std::is_same<T, float>::value) {
+         for (int32_t j = 0; j < width; ++j) {
+             const int32_t jDst = jStart + j;
+             Cast(weightF[jDst * MAX_BLOCK_DIM], weightT[jDst * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], RoundMode::CAST_NONE,
+                  baseDim);
+         }
+         if (hasBias) {
+             Cast(biasF, biasT[MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+         }
+         PipeBarrier<PIPE_V>();
+     }
+ 
+     if (!hasBias) {
+         Duplicate(biasF, 0.0f, baseDim);
+     }
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::InitRing(int32_t cacheIdx, bool hasInit, int32_t stateTokenOffset,
+                                                      int32_t start, int32_t len, int32_t channelStart,
+                                                      int32_t baseDim, int32_t dim)
+ {
+     const int32_t stateLen = tilingData_->stateLen;
+     const int32_t width = static_cast<int32_t>(tilingData_->width);
+     const int32_t ringStart = MAX_WIDTH - width;
+     LocalTensor<float> ringF = inBuf.Get<float>();
+     LocalTensor<T> ringT = ringF.ReinterpretCast<T>();
+ 
+     for (int32_t i = 0; i < ringStart; ++i) {
+         Duplicate(ringF[i * MAX_BLOCK_DIM], 0.0f, baseDim);
+     }
+     if (ringStart > 0) {
+         PipeBarrier<PIPE_V>();
+     }
+ 
+     if (hasInit) {
+         for (int32_t i = 0; i < (width - 1); ++i) {
+             const int32_t pos = stateTokenOffset + i;
+             const int64_t stateOffset =
+                 static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(pos) * dim + channelStart;
+             DataCopy(ringT[(ringStart + i) * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], convStatesGm[stateOffset], baseDim);
+         }
+         SetFlag<HardEvent::MTE2_V>(stateMte2ToVEvent_);
+         WaitFlag<HardEvent::MTE2_V>(stateMte2ToVEvent_);
+         for (int32_t i = 0; i < (width - 1); ++i) {
+             const int32_t pos = ringStart + i;
+             Cast(ringF[pos * MAX_BLOCK_DIM], ringT[pos * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+         }
+         PipeBarrier<PIPE_V>();
+     } else {
+         for (int32_t i = 0; i < (width - 1); ++i) {
+             Duplicate(ringF[(ringStart + i) * MAX_BLOCK_DIM], 0.0f, baseDim);
+         }
+         PipeBarrier<PIPE_V>();
+     }
+ 
+     if (len > 0) {
+         const int32_t slot0 = SlotCurr(0);
+         const int64_t xOffset = static_cast<int64_t>(start) * dim + channelStart;
+         DataCopy(ringT[slot0 * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], xGm[xOffset], baseDim);
+         SetFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slot0]);
+     }
+ 
+     if (len > 1) {
+         SetFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
+     }
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::RunSeq(int32_t start, int32_t len, int32_t channelStart,
                                                     int32_t baseDim, int32_t dim)
-{
-    const int32_t stateLen = tilingData_->stateLen;
-    const int32_t width = static_cast<int32_t>(tilingData_->width);
-    const int32_t ringStart = MAX_WIDTH - width;
-    LocalTensor<float> ringF = inBuf.Get<float>();
-    LocalTensor<T> ringT = ringF.ReinterpretCast<T>();
-
-    for (int32_t i = 0; i < ringStart; ++i) {
-        Duplicate(ringF[i * MAX_BLOCK_DIM], 0.0f, baseDim);
-    }
-    if (ringStart > 0) {
-        PipeBarrier<PIPE_V>();
-    }
-
-    if (hasInit) {
-        for (int32_t i = 0; i < (width - 1); ++i) {
-            const int32_t pos = stateTokenOffset + i;
-            const int64_t stateOffset =
-                static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(pos) * dim + channelStart;
-            DataCopy(ringT[(ringStart + i) * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], convStatesGm[stateOffset], baseDim);
-        }
-        SetFlag<HardEvent::MTE2_V>(stateMte2ToVEvent_);
-        WaitFlag<HardEvent::MTE2_V>(stateMte2ToVEvent_);
-        for (int32_t i = 0; i < (width - 1); ++i) {
-            const int32_t pos = ringStart + i;
-            Cast(ringF[pos * MAX_BLOCK_DIM], ringT[pos * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
-        }
-        PipeBarrier<PIPE_V>();
-    } else {
-        for (int32_t i = 0; i < (width - 1); ++i) {
-            Duplicate(ringF[(ringStart + i) * MAX_BLOCK_DIM], 0.0f, baseDim);
-        }
-        PipeBarrier<PIPE_V>();
-    }
-
-    if (len > 0) {
-        const int32_t slot0 = SlotCurr(0);
-        const int64_t xOffset = static_cast<int64_t>(start) * dim + channelStart;
-        DataCopy(ringT[slot0 * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], xGm[xOffset], baseDim);
-        SetFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slot0]);
-    }
-
-    if (len > 1) {
-        SetFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
-    }
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline void CAUSAL_CONV1D_CLASS::RunSeq(int32_t start, int32_t len, int32_t channelStart,
-                                                int32_t baseDim, int32_t dim)
-{
-    if (IsFnRollingFastPathEnabled()) {
-        RunSeqFnRolling(start, len, channelStart, baseDim, dim);
-        return;
-    }
-
-    const int32_t width = static_cast<int32_t>(tilingData_->width);
-    const int32_t jStart = MAX_WIDTH - width;
-    auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
-    LocalTensor<float> &weightF = cl.weightF;
-    LocalTensor<float> &biasF = cl.biasF;
-    LocalTensor<float> &accF = cl.accF;
-    LocalTensor<float> &tmpF = cl.tmpF;
-    LocalTensor<float> ringF = inBuf.Get<float>();
-    LocalTensor<T> ringT = ringF.ReinterpretCast<T>();
-    LocalTensor<T> outT = outBuf.Get<T>();
-    const bool hasBias = HasBias();
+ {
+     if (IsFnRollingFastPathEnabled()) {
+         RunSeqFnRolling(start, len, channelStart, baseDim, dim);
+         return;
+     }
+ 
+     const int32_t width = static_cast<int32_t>(tilingData_->width);
+     const int32_t jStart = MAX_WIDTH - width;
+     auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
+     LocalTensor<float> &weightF = cl.weightF;
+     LocalTensor<float> &biasF = cl.biasF;
+     LocalTensor<float> &accF = cl.accF;
+     LocalTensor<float> &tmpF = cl.tmpF;
+     LocalTensor<float> ringF = inBuf.Get<float>();
+     LocalTensor<T> ringT = ringF.ReinterpretCast<T>();
+     LocalTensor<T> outT = outBuf.Get<T>();
+     const bool hasBias = HasBias();
+     const bool hasActivation = HasActivation();
+     for (int32_t t = 0; t < len; ++t) {
+         const int32_t slotCurr = SlotCurr(t);
+ 
+         WaitFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotCurr]);
+         Cast(ringF[slotCurr * MAX_BLOCK_DIM], ringT[slotCurr * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+         PipeBarrier<PIPE_V>();
+ 
+         if (t + 1 < len) {
+             const int32_t slotNext = SlotPrefetch(t);
+             const int64_t xOffsetNext = static_cast<int64_t>(start + t + 1) * dim + channelStart;
+             WaitFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
+             DataCopy(ringT[slotNext * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], xGm[xOffsetNext], baseDim);
+             SetFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotNext]);
+         }
+ 
+         bool accInitialized = false;
+         if (hasBias) {
+             DataCopy(accF, biasF, baseDim);
+             PipeBarrier<PIPE_V>();
+             accInitialized = true;
+         }
+ 
+         for (int32_t j = jStart; j < MAX_WIDTH; ++j) {
+             const int32_t tap = (MAX_WIDTH - 1) - j;
+             const int32_t slot = (tap == 0) ? slotCurr : SlotHist(t, tap);
+             if (!accInitialized) {
+                 Mul(accF, ringF[slot * MAX_BLOCK_DIM], weightF[j * MAX_BLOCK_DIM], baseDim);
+                 accInitialized = true;
+             } else {
+                 MulAddDst(accF, ringF[slot * MAX_BLOCK_DIM], weightF[j * MAX_BLOCK_DIM], baseDim);
+             }
+         }
+ 
+         PipeBarrier<PIPE_V>();
+ 
+         if (hasActivation) {
+             Silu(tmpF, accF, baseDim);
+         }
+ 
+         const int32_t outSlot = t & 1;
+         LocalTensor<T> outSlotT = outT[outSlot * MAX_BLOCK_DIM];
+         if (t >= 2) {
+             WaitFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
+         }
+ 
+         if constexpr (IsSameType<T, float>::value) {
+             if (hasActivation) {
+                 DataCopy(outSlotT, tmpF, baseDim);
+             } else {
+                 DataCopy(outSlotT, accF, baseDim);
+             }
+         } else {
+             if (hasActivation) {
+                 Cast(outSlotT, tmpF, RoundMode::CAST_RINT, baseDim);
+             } else {
+                 Cast(outSlotT, accF, RoundMode::CAST_RINT, baseDim);
+             }
+         }
+ 
+         SetFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
+ 
+         const int64_t outOffset = static_cast<int64_t>(start + t) * dim + channelStart;
+         WaitFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
+         DataCopy(yGm[outOffset], outSlotT, baseDim);
+         if (t + 2 < len) {
+             SetFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
+         }
+ 
+         if (t + 2 < len) {
+             SetFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
+         }
+     }
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::RestoreFnLocalPartials(int32_t baseDim)
+ {
+     if constexpr (!kHasCompileTimeWidth) {
+         return;
+     }
+ 
+     auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
+     LocalTensor<float> &weightF = cl.weightF;
+     LocalTensor<float> &state2F = cl.biasF;
+     LocalTensor<float> &state1F = cl.accF;
+     LocalTensor<float> &state0F = cl.tmpF;
+     LocalTensor<float> &currF = cl.currF;
+     LocalTensor<float> ringF = inBuf.Get<float>();
+     constexpr int32_t ringStart = MAX_WIDTH - kTemplateWidth;
+     constexpr int32_t w0Idx = MAX_WIDTH - kTemplateWidth;
+ 
+     if constexpr (kTemplateWidth == 2) {
+         Duplicate(state2F, 0.0f, baseDim);
+         Duplicate(state1F, 0.0f, baseDim);
+         PipeBarrier<PIPE_V>();
+ 
+         Mul(state0F, ringF[ringStart * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+     } else if constexpr (kTemplateWidth == 3) {
+         Duplicate(state2F, 0.0f, baseDim);
+         PipeBarrier<PIPE_V>();
+ 
+         Mul(state0F, ringF[ringStart * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+ 
+         Mul(state1F, ringF[(ringStart + 1) * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+         MulAddDst(state0F, ringF[(ringStart + 1) * MAX_BLOCK_DIM], weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+     } else if constexpr (kTemplateWidth == 4) {
+         Mul(state0F, ringF[ringStart * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+ 
+         Mul(state1F, ringF[(ringStart + 1) * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+         MulAddDst(state0F, ringF[(ringStart + 1) * MAX_BLOCK_DIM], weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+ 
+         Mul(state2F, ringF[(ringStart + 2) * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+         MulAddDst(state1F, ringF[(ringStart + 2) * MAX_BLOCK_DIM], weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+         MulAddDst(state0F, ringF[(ringStart + 2) * MAX_BLOCK_DIM], weightF[(w0Idx + 2) * MAX_BLOCK_DIM], baseDim);
+         PipeBarrier<PIPE_V>();
+     }
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::ComputeFnRollingOutput(int32_t slotCurr, int32_t baseDim)
+ {
+     if constexpr (!kHasCompileTimeWidth) {
+         return;
+     }
+ 
+     auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
+     LocalTensor<float> &weightF = cl.weightF;
+     LocalTensor<float> &state0F = cl.tmpF;
+     LocalTensor<float> &currF = cl.currF;
+     LocalTensor<float> ringF = inBuf.Get<float>();
+ 
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
     const bool hasActivation = HasActivation();
-    for (int32_t t = 0; t < len; ++t) {
-        const int32_t slotCurr = SlotCurr(t);
-
-        WaitFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotCurr]);
-        Cast(ringF[slotCurr * MAX_BLOCK_DIM], ringT[slotCurr * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
-        PipeBarrier<PIPE_V>();
-
-        if (t + 1 < len) {
-            const int32_t slotNext = SlotPrefetch(t);
-            const int64_t xOffsetNext = static_cast<int64_t>(start + t + 1) * dim + channelStart;
-            WaitFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
-            DataCopy(ringT[slotNext * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], xGm[xOffsetNext], baseDim);
-            SetFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotNext]);
-        }
-
-        bool accInitialized = false;
-        if (hasBias) {
-            DataCopy(accF, biasF, baseDim);
-            PipeBarrier<PIPE_V>();
-            accInitialized = true;
-        }
-
-        for (int32_t j = jStart; j < MAX_WIDTH; ++j) {
-            const int32_t tap = (MAX_WIDTH - 1) - j;
-            const int32_t slot = (tap == 0) ? slotCurr : SlotHist(t, tap);
-            if (!accInitialized) {
-                Mul(accF, ringF[slot * MAX_BLOCK_DIM], weightF[j * MAX_BLOCK_DIM], baseDim);
-                accInitialized = true;
-            } else {
-                MulAddDst(accF, ringF[slot * MAX_BLOCK_DIM], weightF[j * MAX_BLOCK_DIM], baseDim);
-            }
-        }
-
-        PipeBarrier<PIPE_V>();
-
-        if (hasActivation) {
-            Silu(tmpF, accF, baseDim);
-        }
-
-        const int32_t outSlot = t & 1;
-        LocalTensor<T> outSlotT = outT[outSlot * MAX_BLOCK_DIM];
-        if (t >= 2) {
-            WaitFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
-        }
-
-        if constexpr (IsSameType<T, float>::value) {
-            if (hasActivation) {
-                DataCopy(outSlotT, tmpF, baseDim);
-            } else {
-                DataCopy(outSlotT, accF, baseDim);
-            }
-        } else {
-            if (hasActivation) {
-                Cast(outSlotT, tmpF, RoundMode::CAST_RINT, baseDim);
-            } else {
-                Cast(outSlotT, accF, RoundMode::CAST_RINT, baseDim);
-            }
-        }
-
-        SetFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
-
-        const int64_t outOffset = static_cast<int64_t>(start + t) * dim + channelStart;
-        WaitFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
-        DataCopy(yGm[outOffset], outSlotT, baseDim);
-        if (t + 2 < len) {
-            SetFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
-        }
-
-        if (t + 2 < len) {
-            SetFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
-        }
+    if (hasActivation) {
+        ComputeFnRollingOutputRegbase<true>(ringF[slotCurr * MAX_BLOCK_DIM], currF, state0F, weightF[3 * MAX_BLOCK_DIM], baseDim);
+    } else {
+        ComputeFnRollingOutputRegbase<false>(ringF[slotCurr * MAX_BLOCK_DIM], currF, state0F, weightF[3 * MAX_BLOCK_DIM], baseDim);
     }
-}
+#else
+    MulAddDst(state0F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[3 * MAX_BLOCK_DIM], baseDim);
+    PipeBarrier<PIPE_V>();
 
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline void CAUSAL_CONV1D_CLASS::RestoreFnLocalPartials(int32_t baseDim)
-{
-    if constexpr (!kHasCompileTimeWidth) {
-        return;
+    const bool hasActivation = HasActivation();
+    if (hasActivation) {
+        Silu(currF, state0F, baseDim);
+        PipeBarrier<PIPE_V>();
     }
+#endif
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::AdvanceFnLocalPartials(int32_t slotCurr, int32_t baseDim)
+ {
+     if constexpr (!kHasCompileTimeWidth) {
+         return;
+     }
+ 
+     auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
+     LocalTensor<float> &weightF = cl.weightF;
+     LocalTensor<float> &state2F = cl.biasF;
+     LocalTensor<float> &state1F = cl.accF;
+     LocalTensor<float> &state0F = cl.tmpF;
+     LocalTensor<float> &currF = cl.currF;
+     LocalTensor<float> ringF = inBuf.Get<float>();
+     constexpr int32_t w0Idx = MAX_WIDTH - kTemplateWidth;
 
-    auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
-    LocalTensor<float> &weightF = cl.weightF;
-    LocalTensor<float> &state2F = cl.biasF;
-    LocalTensor<float> &state1F = cl.accF;
-    LocalTensor<float> &state0F = cl.tmpF;
-    LocalTensor<float> &currF = cl.currF;
-    LocalTensor<float> ringF = inBuf.Get<float>();
-    constexpr int32_t ringStart = MAX_WIDTH - kTemplateWidth;
-    constexpr int32_t w0Idx = MAX_WIDTH - kTemplateWidth;
-
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    AdvanceFnLocalPartialsRegbase<kTemplateWidth>(ringF[slotCurr * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], 
+        state0F, state1F, state2F, baseDim, MAX_BLOCK_DIM);
+#else
     if constexpr (kTemplateWidth == 2) {
-        Duplicate(state2F, 0.0f, baseDim);
-        Duplicate(state1F, 0.0f, baseDim);
-        PipeBarrier<PIPE_V>();
-
-        Mul(state0F, ringF[ringStart * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+        Mul(state0F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
         PipeBarrier<PIPE_V>();
     } else if constexpr (kTemplateWidth == 3) {
-        Duplicate(state2F, 0.0f, baseDim);
+        Mul(state0F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
+        PipeBarrier<PIPE_V>();
+        Add(state0F, state0F, state1F, baseDim);
         PipeBarrier<PIPE_V>();
 
-        Mul(state0F, ringF[ringStart * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
-        PipeBarrier<PIPE_V>();
-
-        Mul(state1F, ringF[(ringStart + 1) * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
-        PipeBarrier<PIPE_V>();
-        MulAddDst(state0F, ringF[(ringStart + 1) * MAX_BLOCK_DIM], weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
+        Mul(state1F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
         PipeBarrier<PIPE_V>();
     } else if constexpr (kTemplateWidth == 4) {
-        Mul(state0F, ringF[ringStart * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+        Mul(state0F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[(w0Idx + 2) * MAX_BLOCK_DIM], baseDim);
+        PipeBarrier<PIPE_V>();
+        Add(state0F, state0F, state1F, baseDim);
         PipeBarrier<PIPE_V>();
 
-        Mul(state1F, ringF[(ringStart + 1) * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
+        Mul(state1F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
         PipeBarrier<PIPE_V>();
         MulAddDst(state0F, ringF[(ringStart + 1) * MAX_BLOCK_DIM], weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
         PipeBarrier<PIPE_V>();
 
-        Mul(state2F, ringF[(ringStart + 2) * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
-        PipeBarrier<PIPE_V>();
-        MulAddDst(state1F, ringF[(ringStart + 2) * MAX_BLOCK_DIM], weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
-        PipeBarrier<PIPE_V>();
-        MulAddDst(state0F, ringF[(ringStart + 2) * MAX_BLOCK_DIM], weightF[(w0Idx + 2) * MAX_BLOCK_DIM], baseDim);
+        Mul(state2F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
         PipeBarrier<PIPE_V>();
     }
 }
@@ -569,461 +642,412 @@ if (hasActivation) {
     PipeBarrier<PIPE_V>();
 }
 #endif
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline void CAUSAL_CONV1D_CLASS::AdvanceFnLocalPartials(int32_t slotCurr, int32_t baseDim)
-{
-    if constexpr (!kHasCompileTimeWidth) {
-        return;
-    }
-
-    auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
-    LocalTensor<float> &weightF = cl.weightF;
-    LocalTensor<float> &state2F = cl.biasF;
-    LocalTensor<float> &state1F = cl.accF;
-    LocalTensor<float> &state0F = cl.tmpF;
-    LocalTensor<float> &currF = cl.currF;
-    LocalTensor<float> ringF = inBuf.Get<float>();
-    constexpr int32_t w0Idx = MAX_WIDTH - kTemplateWidth;
-
-#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
-AdvanceFnLocalPartialsRegbase<kTemplateWidth>(ringF[slotCurr * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], 
-    state0F, state1F, state2F, baseDim, MAX_BLOCK_DIM);
-#else
-if constexpr (kTemplateWidth == 2) {
-    Mul(state0F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
-    PipeBarrier<PIPE_V>();
-} else if constexpr (kTemplateWidth == 3) {
-    Mul(state0F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
-    PipeBarrier<PIPE_V>();
-    Add(state0F, state0F, state1F, baseDim);
-    PipeBarrier<PIPE_V>();
-
-    Mul(state1F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
-    PipeBarrier<PIPE_V>();
-} else if constexpr (kTemplateWidth == 4) {
-    Mul(state0F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[(w0Idx + 2) * MAX_BLOCK_DIM], baseDim);
-    PipeBarrier<PIPE_V>();
-    Add(state0F, state0F, state1F, baseDim);
-    PipeBarrier<PIPE_V>();
-
-    Mul(state1F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[(w0Idx + 1) * MAX_BLOCK_DIM], baseDim);
-    PipeBarrier<PIPE_V>();
-    Add(state1F, state1F, state2F, baseDim);
-    PipeBarrier<PIPE_V>();
-
-    Mul(state2F, ringF[slotCurr * MAX_BLOCK_DIM], weightF[w0Idx * MAX_BLOCK_DIM], baseDim);
-    PipeBarrier<PIPE_V>();
-}
-#endif
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline void CAUSAL_CONV1D_CLASS::RunSeqFnRolling(int32_t start, int32_t len, int32_t channelStart,
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::RunSeqFnRolling(int32_t start, int32_t len, int32_t channelStart,
+                                                             int32_t baseDim, int32_t dim)
+ {
+     if constexpr (!kHasCompileTimeWidth) {
+         return;
+     }
+ 
+     auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
+     LocalTensor<float> &state0F = cl.tmpF;
+     LocalTensor<float> &currF = cl.currF;
+     LocalTensor<float> ringF = inBuf.Get<float>();
+     LocalTensor<T> ringT = ringF.ReinterpretCast<T>();
+     LocalTensor<T> outT = outBuf.Get<T>();
+     const bool hasActivation = HasActivation();
+     RestoreFnLocalPartials(baseDim);
+ 
+     for (int32_t t = 0; t < len; ++t) {
+         const int32_t slotCurr = SlotCurr(t);
+ 
+         WaitFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotCurr]);
+         Cast(ringF[slotCurr * MAX_BLOCK_DIM], ringT[slotCurr * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
+ 
+         if (t + 1 < len) {
+             const int32_t slotNext = SlotPrefetch(t);
+             const int64_t xOffsetNext = static_cast<int64_t>(start + t + 1) * dim + channelStart;
+             WaitFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
+             DataCopy(ringT[slotNext * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], xGm[xOffsetNext], baseDim);
+             SetFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotNext]);
+         }
+ 
+         ComputeFnRollingOutput(slotCurr, baseDim);
+ 
+         const int32_t outSlot = t & 1;
+         LocalTensor<T> outSlotT = outT[outSlot * MAX_BLOCK_DIM];
+         if (t >= 2) {
+             WaitFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
+         }
+ 
+         if constexpr (IsSameType<T, float>::value) {
+             if (hasActivation) {
+                 DataCopy(outSlotT, currF, baseDim);
+             } else {
+                 DataCopy(outSlotT, state0F, baseDim);
+             }
+         } else {
+             if (hasActivation) {
+                 Cast(outSlotT, currF, RoundMode::CAST_RINT, baseDim);
+             } else {
+                 Cast(outSlotT, state0F, RoundMode::CAST_RINT, baseDim);
+             }
+         }
+ 
+         AdvanceFnLocalPartials(slotCurr, baseDim);
+ 
+         SetFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
+ 
+         const int64_t outOffset = static_cast<int64_t>(start + t) * dim + channelStart;
+         WaitFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
+         DataCopy(yGm[outOffset], outSlotT, baseDim);
+         if (t + 2 < len) {
+             SetFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
+         }
+ 
+         if (t + 2 < len) {
+             SetFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
+         }
+     }
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::DrainTaskMte3()
+ {
+     SetFlag<HardEvent::MTE3_V>(stateWritebackMte3ToVEvent_);
+     WaitFlag<HardEvent::MTE3_V>(stateWritebackMte3ToVEvent_);
+     SetFlag<HardEvent::MTE3_MTE2>(stateWritebackMte3ToMte2Event_);
+     WaitFlag<HardEvent::MTE3_MTE2>(stateWritebackMte3ToMte2Event_);
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::WriteBackState(int32_t cacheIdx, int32_t len, int32_t channelStart,
                                                             int32_t baseDim, int32_t dim)
-{
-    if constexpr (!kHasCompileTimeWidth) {
-        return;
-    }
-
-    auto cl = CalcBufLayout::FromCalcBuf(calcBuf);
-    LocalTensor<float> &state0F = cl.tmpF;
-    LocalTensor<float> &currF = cl.currF;
-    LocalTensor<float> ringF = inBuf.Get<float>();
-    LocalTensor<T> ringT = ringF.ReinterpretCast<T>();
-    LocalTensor<T> outT = outBuf.Get<T>();
-    const bool hasActivation = HasActivation();
-    RestoreFnLocalPartials(baseDim);
-
-    for (int32_t t = 0; t < len; ++t) {
-        const int32_t slotCurr = SlotCurr(t);
-
-        WaitFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotCurr]);
-        Cast(ringF[slotCurr * MAX_BLOCK_DIM], ringT[slotCurr * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
-
-        if (t + 1 < len) {
-            const int32_t slotNext = SlotPrefetch(t);
-            const int64_t xOffsetNext = static_cast<int64_t>(start + t + 1) * dim + channelStart;
-            WaitFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
-            DataCopy(ringT[slotNext * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], xGm[xOffsetNext], baseDim);
-            SetFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slotNext]);
-        }
-
-        ComputeFnRollingOutput(slotCurr, baseDim);
-
-        const int32_t outSlot = t & 1;
-        LocalTensor<T> outSlotT = outT[outSlot * MAX_BLOCK_DIM];
-        if (t >= 2) {
-            WaitFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
-        }
-
-        if constexpr (IsSameType<T, float>::value) {
-            if (hasActivation) {
-                DataCopy(outSlotT, currF, baseDim);
-            } else {
-                DataCopy(outSlotT, state0F, baseDim);
-            }
-        } else {
-            if (hasActivation) {
-                Cast(outSlotT, currF, RoundMode::CAST_RINT, baseDim);
-            } else {
-                Cast(outSlotT, state0F, RoundMode::CAST_RINT, baseDim);
-            }
-        }
-
-        AdvanceFnLocalPartials(slotCurr, baseDim);
-
-        SetFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
-
-        const int64_t outOffset = static_cast<int64_t>(start + t) * dim + channelStart;
-        WaitFlag<HardEvent::V_MTE3>(outVToMte3Event_[outSlot]);
-        DataCopy(yGm[outOffset], outSlotT, baseDim);
-        if (t + 2 < len) {
-            SetFlag<HardEvent::MTE3_V>(outMte3ToVEvent_[outSlot]);
-        }
-
-        if (t + 2 < len) {
-            SetFlag<HardEvent::V_MTE2>(inputVToMte2Event_);
-        }
-    }
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline void CAUSAL_CONV1D_CLASS::DrainTaskMte3()
-{
-    SetFlag<HardEvent::MTE3_V>(stateWritebackMte3ToVEvent_);
-    WaitFlag<HardEvent::MTE3_V>(stateWritebackMte3ToVEvent_);
-    SetFlag<HardEvent::MTE3_MTE2>(stateWritebackMte3ToMte2Event_);
-    WaitFlag<HardEvent::MTE3_MTE2>(stateWritebackMte3ToMte2Event_);
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline void CAUSAL_CONV1D_CLASS::WriteBackState(int32_t cacheIdx, int32_t len, int32_t channelStart,
-                                                        int32_t baseDim, int32_t dim)
-{
-    const int32_t stateLen = tilingData_->stateLen;
-    const int32_t width = static_cast<int32_t>(tilingData_->width);
-    if (len <= 0) {
-        return;
-    }
-
-    const int32_t lastT = len - 1;
-    LocalTensor<float> ringF = inBuf.Get<float>();
-    LocalTensor<T> ringT = ringF.ReinterpretCast<T>();
-    const int32_t lastSlot = SlotCurr(lastT);
-    const int64_t stateBaseOffset = static_cast<int64_t>(cacheIdx) * stateLen * dim + channelStart;
-
-    for (int32_t pos = 0; pos < (width - 1); ++pos) {
-        const int32_t tap = (width - 2) - pos;
-        const int32_t slot = RetreatRingSlot(lastSlot, tap);
-        Cast(ringT[slot * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], ringF[slot * MAX_BLOCK_DIM], RoundMode::CAST_NONE, baseDim);
-    }
-
-    SetFlag<HardEvent::V_MTE3>(stateWritebackVToMte3Event_);
-    WaitFlag<HardEvent::V_MTE3>(stateWritebackVToMte3Event_);
-
-    for (int32_t pos = 0; pos < (width - 1); ++pos) {
-        const int32_t tap = (width - 2) - pos;
-        const int32_t slot = RetreatRingSlot(lastSlot, tap);
-        const int64_t stateOffset = stateBaseOffset + static_cast<int64_t>(pos) * dim;
-        DataCopy(convStatesGm[stateOffset], ringT[slot * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], baseDim);
-    }
-}
-
-// TODO
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline void CAUSAL_CONV1D_CLASS::WriteBackStateSpec(int32_t cacheIdx, bool hasInit,
-                                                            int32_t stateTokenOffset, int32_t start, int32_t len,
-                                                            int32_t channelStart, int32_t baseDim, int32_t dim)
-{
-    const int32_t width = static_cast<int32_t>(tilingData_->width);
-    const int32_t stateLen = tilingData_->stateLen;
-    if (len <= 0) {
-        return;
-    }
-
-    if (width != 4) {
-        WriteBackState(cacheIdx, len, channelStart, baseDim, dim);
-        return;
-    }
-
-    constexpr int32_t keep = MAX_WIDTH - 2;
-    const int32_t reqStateLen = keep + len;
-    if (reqStateLen > stateLen) {
-        WriteBackState(cacheIdx, len, channelStart, baseDim, dim);
-        return;
-    }
-
-    LocalTensor<float> ringF = inBuf.Get<float>();
-    LocalTensor<T> ringT = ringF.ReinterpretCast<T>();
-    LocalTensor<T> buf0T = ringT[0 * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM];
-    LocalTensor<T> buf1T = ringT[1 * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM];
-
-    if (hasInit) {
-        const int32_t srcPos0 = stateTokenOffset + 1;
-        const int32_t srcPos1 = stateTokenOffset + 2;
-        const int64_t srcOffset0 =
-            static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(srcPos0) * dim + channelStart;
-        const int64_t srcOffset1 =
-            static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(srcPos1) * dim + channelStart;
-        DataCopy(buf0T, convStatesGm[srcOffset0], baseDim);
-        DataCopy(buf1T, convStatesGm[srcOffset1], baseDim);
-        SetFlag<HardEvent::MTE2_MTE3>(stateShiftMte2ToMte3Event_);
-        WaitFlag<HardEvent::MTE2_MTE3>(stateShiftMte2ToMte3Event_);
-        const int64_t dstOffset0 =
-            static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(0) * dim + channelStart;
-        const int64_t dstOffset1 =
-            static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(1) * dim + channelStart;
-        DataCopy(convStatesGm[dstOffset0], buf0T, baseDim);
-        DataCopy(convStatesGm[dstOffset1], buf1T, baseDim);
-        SetFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
-        WaitFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
-    } else {
-        Duplicate(buf0T, static_cast<T>(0), baseDim);
-        SetFlag<HardEvent::V_MTE3>(stateShiftVToMte3Event_);
-        WaitFlag<HardEvent::V_MTE3>(stateShiftVToMte3Event_);
-        const int64_t dstOffset0 =
-            static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(0) * dim + channelStart;
-        const int64_t dstOffset1 =
-            static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(1) * dim + channelStart;
-        DataCopy(convStatesGm[dstOffset0], buf0T, baseDim);
-        DataCopy(convStatesGm[dstOffset1], buf0T, baseDim);
-        SetFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
-        WaitFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
-    }
-
-    const int64_t xOffset0 = static_cast<int64_t>(start) * dim + channelStart;
-    DataCopy(buf0T, xGm[xOffset0], baseDim);
-    SetFlag<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[0]);
-
-    for (int32_t t = 0; t < len; ++t) {
-        const int32_t curr = t & 1;
-        const int32_t next = curr ^ 1;
-        LocalTensor<T> currBuf = (curr == 0) ? buf0T : buf1T;
-        LocalTensor<T> nextBuf = (next == 0) ? buf0T : buf1T;
-
-        WaitFlag<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[curr]);
-
-        if (t + 1 < len) {
-            const int64_t xOffsetNext = static_cast<int64_t>(start + t + 1) * dim + channelStart;
-            if (t > 0) {
-                WaitFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[next]);
-            }
-            DataCopy(nextBuf, xGm[xOffsetNext], baseDim);
-            SetFlag<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[next]);
-        }
-
-        const int64_t dstOffset =
-            static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(keep + t) * dim + channelStart;
-        DataCopy(convStatesGm[dstOffset], currBuf, baseDim);
-        SetFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[curr]);
-    }
-
-    WaitFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[0]);
-    if (len > 1) {
-        WaitFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[1]);
-    }
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqTaskWindow(int32_t seq, int32_t inputMode, int32_t seqLen,
-                                                                int32_t &start, int32_t &len) const
-{
-    switch (GetSeqTaskWindowMode(inputMode)) {
-        case SEQ_TASK_WINDOW_MODE_VARLEN:
-            return ResolveSeqTaskWindowByMode<SEQ_TASK_WINDOW_MODE_VARLEN>(seq, seqLen, start, len);
-        case SEQ_TASK_WINDOW_MODE_DECODE2D:
-            return ResolveSeqTaskWindowByMode<SEQ_TASK_WINDOW_MODE_DECODE2D>(seq, seqLen, start, len);
-        default:
-            return ResolveSeqTaskWindowByMode<SEQ_TASK_WINDOW_MODE_BATCH>(seq, seqLen, start, len);
-    }
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-template <int32_t kWindowMode>
-__aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqTaskWindowByMode(int32_t seq, int32_t seqLen, int32_t &start,
-                                                                    int32_t &len) const
-{
-    SeqTaskWindow window;
-    if constexpr (kWindowMode == SEQ_TASK_WINDOW_MODE_VARLEN) {
-        const int32_t startVal = queryStartLocGm.GetValue(seq);
-        const int32_t endVal = queryStartLocGm.GetValue(seq + 1);
-        window = BuildSeqTaskWindowVarlen(startVal, endVal);
-    } else if constexpr (kWindowMode == SEQ_TASK_WINDOW_MODE_DECODE2D) {
-        window = BuildSeqTaskWindowDecode2D(seq);
-    } else {
-        window = BuildSeqTaskWindowBatch(seq, seqLen);
-    }
-
-    if (!window.valid) {
-        return false;
-    }
-    start = window.start;
-    len = window.len;
-    return true;
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqCacheIndex(int32_t seq, bool hasCacheIndices,
-                                                                int32_t &cacheIdx) const
-{
-    cacheIdx = seq;
-    if (!hasCacheIndices) {
-        return true;
-    }
-
-    const int64_t cacheIdx64 = cacheIndicesGm.GetValue(seq);
-    if (cacheIdx64 == tilingData_->padSlotId) {
-        return false;
-    }
-    cacheIdx = static_cast<int32_t>(cacheIdx64);
-    return true;
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqHasInit(int32_t seq, bool hasInitialStateMode) const
-{
-    return hasInitialStateMode ? (initialStateModeGm.GetValue(seq) != 0) : false;
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline void CAUSAL_CONV1D_CLASS::ProcessDefault()
-{
-    switch (GetSeqTaskWindowMode(tilingData_->inputMode)) {
-        case SEQ_TASK_WINDOW_MODE_VARLEN:
-            ProcessDefaultByWindowMode<SEQ_TASK_WINDOW_MODE_VARLEN>();
-            return;
-        case SEQ_TASK_WINDOW_MODE_DECODE2D:
-            ProcessDefaultByWindowMode<SEQ_TASK_WINDOW_MODE_DECODE2D>();
-            return;
-        default:
-            ProcessDefaultByWindowMode<SEQ_TASK_WINDOW_MODE_BATCH>();
-            return;
-    }
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-template <int32_t kWindowMode>
-__aicore__ inline void CAUSAL_CONV1D_CLASS::ProcessDefaultByWindowMode()
-{
-    const int32_t dim = tilingData_->dim;
-    const int32_t batch = tilingData_->batch;
-    const int32_t seqLen = tilingData_->seqLen;
-    const int32_t baseDim = static_cast<int32_t>(tilingData_->baseDim);
-    const int32_t baseDimCnt = static_cast<int32_t>(tilingData_->baseDimCnt);
-    const int32_t width = static_cast<int32_t>(tilingData_->width);
-    const bool hasCacheIndices = (tilingData_->hasCacheIndices != 0);
-    const bool hasInit = true;
-    const bool isSpecDecodingGlobal = IsUpdateSpecDecodingEnabled();
-
-    const uint32_t blockIdx = GetBlockIdx();
-    const uint32_t blockNum = GetBlockNum();
-
-    if (baseDim <= 0 || baseDimCnt <= 0 || baseDim > MAX_BLOCK_DIM || width < 2 || width > MAX_WIDTH) {
-        ReleaseEvents();
-        return;
-    }
-
-    const int64_t gridSize = static_cast<int64_t>(batch) * baseDimCnt;
-    for (int64_t task = static_cast<int64_t>(blockIdx); task < gridSize; task += static_cast<int64_t>(blockNum)) {
-        const int32_t seq = static_cast<int32_t>(task / baseDimCnt);
-        const int32_t baseDimIdx = static_cast<int32_t>(task % baseDimCnt);
-        const int32_t channelStart = baseDimIdx * baseDim;
-        if (channelStart >= dim) {
-            continue;
-        }
-        const int32_t curBaseDim = (channelStart + baseDim <= dim) ? baseDim : (dim - channelStart);
-
-        int32_t start = 0;
-        int32_t len = 0;
-        if (!ResolveSeqTaskWindowByMode<kWindowMode>(seq, seqLen, start, len)) {
-            continue;
-        }
-
-        int32_t cacheIdx = 0;
-        if (!ResolveSeqCacheIndex(seq, hasCacheIndices, cacheIdx)) {
-            continue;
-        }
-
-        int32_t stateTokenOffset = 0;
-        if (isSpecDecodingGlobal) {
-            int32_t accepted = static_cast<int32_t>(numAcceptedTokensGm.GetValue(seq));
-            stateTokenOffset = accepted - 1;
-            const int32_t maxOffset = static_cast<int32_t>(tilingData_->stateLen - (width - 1));
-            if (stateTokenOffset < 0) {
-                stateTokenOffset = 0;
-            } else if (stateTokenOffset > maxOffset) {
-                stateTokenOffset = maxOffset;
-            }
-        }
-
-        LoadWeightAndBias(channelStart, curBaseDim);
-
-        InitRing(cacheIdx, hasInit, stateTokenOffset, start, len, channelStart, curBaseDim, dim);
-        RunSeq(start, len, channelStart, curBaseDim, dim);
-
-        PipeBarrier<PIPE_V>();
-        if (isSpecDecodingGlobal) {
-            DrainTaskMte3();
-            WriteBackStateSpec(cacheIdx, hasInit, stateTokenOffset, start, len, channelStart, curBaseDim, dim);
-        } else {
-            WriteBackState(cacheIdx, len, channelStart, curBaseDim, dim);
-        }
-
-        DrainTaskMte3();
-    }
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline const CausalConv1dTilingData *CAUSAL_CONV1D_CLASS::GetTilingData() const
-{
-    return tilingData_;
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline bool CAUSAL_CONV1D_CLASS::HasActivation() const
-{
-    return (tilingData_ != nullptr) && (tilingData_->activationMode != 0);
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline bool CAUSAL_CONV1D_CLASS::HasBias() const
-{
-    return (tilingData_ != nullptr) && (tilingData_->hasBias != 0);
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline bool CAUSAL_CONV1D_CLASS::IsUpdateMode() const
-{
-    return kIsUpdateMode;
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline bool CAUSAL_CONV1D_CLASS::IsFnRollingFastPathEnabled() const
-{
-    return !kIsUpdateMode && (tilingData_ != nullptr) && (kFnExecutionPlan != FN_EXECUTION_PLAN_INVALID) &&
-        (tilingData_->hasNumAcceptedTokens == 0) && !HasBias();
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline bool CAUSAL_CONV1D_CLASS::HasExplicitFnTokenSeqRanges() const
-{
-    return !kIsUpdateMode && (tilingData_ != nullptr) && (tilingData_->inputMode == 0) &&
-        (tilingData_->hasExplicitTokenSeqRanges != 0) &&
-        (tilingData_->explicitTokenSeqRangeCount >= tilingData_->tokenBlockCnt);
-}
-
-template <CAUSAL_CONV1D_TEMPLATE_ARGS>
-__aicore__ inline bool CAUSAL_CONV1D_CLASS::IsUpdateSpecDecodingEnabled() const
-{
-    return kIsUpdateMode && (tilingData_->hasNumAcceptedTokens != 0) && (tilingData_->width == 4);
-}
-
-#include "causal_conv1d_fn_tasks.h"
-
-#undef CAUSAL_CONV1D_CLASS
-#undef CAUSAL_CONV1D_TEMPLATE_ARGS
+ {
+     const int32_t stateLen = tilingData_->stateLen;
+     const int32_t width = static_cast<int32_t>(tilingData_->width);
+     if (len <= 0) {
+         return;
+     }
+ 
+     const int32_t lastT = len - 1;
+     LocalTensor<float> ringF = inBuf.Get<float>();
+     LocalTensor<T> ringT = ringF.ReinterpretCast<T>();
+     const int32_t lastSlot = SlotCurr(lastT);
+     const int64_t stateBaseOffset = static_cast<int64_t>(cacheIdx) * stateLen * dim + channelStart;
+ 
+     for (int32_t pos = 0; pos < (width - 1); ++pos) {
+         const int32_t tap = (width - 2) - pos;
+         const int32_t slot = RetreatRingSlot(lastSlot, tap);
+         Cast(ringT[slot * MAX_BLOCK_DIM * 2], ringF[slot * MAX_BLOCK_DIM], RoundMode::CAST_RINT, baseDim);
+     }
+ 
+     SetFlag<HardEvent::V_MTE3>(stateWritebackVToMte3Event_);
+     WaitFlag<HardEvent::V_MTE3>(stateWritebackVToMte3Event_);
+ 
+     for (int32_t pos = 0; pos < (width - 1); ++pos) {
+         const int32_t tap = (width - 2) - pos;
+         const int32_t slot = RetreatRingSlot(lastSlot, tap);
+         const int64_t stateOffset = stateBaseOffset + static_cast<int64_t>(pos) * dim;
+         DataCopy(convStatesGm[stateOffset], ringT[slot * MAX_BLOCK_DIM * 2], baseDim);
+     }
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::WriteBackStateSpec(int32_t cacheIdx, bool hasInit,
+                                                                int32_t stateTokenOffset, int32_t start, int32_t len,
+                                                                int32_t channelStart, int32_t baseDim, int32_t dim)
+ {
+     const int32_t width = static_cast<int32_t>(tilingData_->width);
+     const int32_t stateLen = tilingData_->stateLen;
+     if (len <= 0) {
+         return;
+     }
+ 
+     if (width != 4) {
+         WriteBackState(cacheIdx, len, channelStart, baseDim, dim);
+         return;
+     }
+ 
+     constexpr int32_t keep = MAX_WIDTH - 2;
+     const int32_t reqStateLen = keep + len;
+     if (reqStateLen > stateLen) {
+         WriteBackState(cacheIdx, len, channelStart, baseDim, dim);
+         return;
+     }
+ 
+     LocalTensor<float> ringF = inBuf.Get<float>();
+     LocalTensor<T> ringT = ringF.ReinterpretCast<T>();
+     LocalTensor<T> buf0T = ringT[0 * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM];
+     LocalTensor<T> buf1T = ringT[1 * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM];
+ 
+     if (hasInit) {
+         const int32_t srcPos0 = stateTokenOffset + 1;
+         const int32_t srcPos1 = stateTokenOffset + 2;
+         const int64_t srcOffset0 =
+             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(srcPos0) * dim + channelStart;
+         const int64_t srcOffset1 =
+             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(srcPos1) * dim + channelStart;
+         DataCopy(buf0T, convStatesGm[srcOffset0], baseDim);
+         DataCopy(buf1T, convStatesGm[srcOffset1], baseDim);
+         SetFlag<HardEvent::MTE2_MTE3>(stateShiftMte2ToMte3Event_);
+         WaitFlag<HardEvent::MTE2_MTE3>(stateShiftMte2ToMte3Event_);
+         const int64_t dstOffset0 =
+             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(0) * dim + channelStart;
+         const int64_t dstOffset1 =
+             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(1) * dim + channelStart;
+         DataCopy(convStatesGm[dstOffset0], buf0T, baseDim);
+         DataCopy(convStatesGm[dstOffset1], buf1T, baseDim);
+         SetFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
+         WaitFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
+     } else {
+         Duplicate(buf0T, static_cast<T>(0), baseDim);
+         SetFlag<HardEvent::V_MTE3>(stateShiftVToMte3Event_);
+         WaitFlag<HardEvent::V_MTE3>(stateShiftVToMte3Event_);
+         const int64_t dstOffset0 =
+             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(0) * dim + channelStart;
+         const int64_t dstOffset1 =
+             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(1) * dim + channelStart;
+         DataCopy(convStatesGm[dstOffset0], buf0T, baseDim);
+         DataCopy(convStatesGm[dstOffset1], buf0T, baseDim);
+         SetFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
+         WaitFlag<HardEvent::MTE3_MTE2>(stateShiftMte3ToMte2Event_);
+     }
+ 
+     const int64_t xOffset0 = static_cast<int64_t>(start) * dim + channelStart;
+     DataCopy(buf0T, xGm[xOffset0], baseDim);
+     SetFlag<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[0]);
+ 
+     for (int32_t t = 0; t < len; ++t) {
+         const int32_t curr = t & 1;
+         const int32_t next = curr ^ 1;
+         LocalTensor<T> currBuf = (curr == 0) ? buf0T : buf1T;
+         LocalTensor<T> nextBuf = (next == 0) ? buf0T : buf1T;
+ 
+         WaitFlag<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[curr]);
+ 
+         if (t + 1 < len) {
+             const int64_t xOffsetNext = static_cast<int64_t>(start + t + 1) * dim + channelStart;
+             if (t > 0) {
+                 WaitFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[next]);
+             }
+             DataCopy(nextBuf, xGm[xOffsetNext], baseDim);
+             SetFlag<HardEvent::MTE2_MTE3>(specWritebackMte2ToMte3Event_[next]);
+         }
+ 
+         const int64_t dstOffset =
+             static_cast<int64_t>(cacheIdx) * stateLen * dim + static_cast<int64_t>(keep + t) * dim + channelStart;
+         DataCopy(convStatesGm[dstOffset], currBuf, baseDim);
+         SetFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[curr]);
+     }
+ 
+     WaitFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[0]);
+     if (len > 1) {
+         WaitFlag<HardEvent::MTE3_MTE2>(specWritebackMte3ToMte2Event_[1]);
+     }
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqTaskWindow(int32_t seq, int32_t inputMode, int32_t seqLen,
+                                                                  int32_t &start, int32_t &len) const
+ {
+     switch (GetSeqTaskWindowMode(inputMode)) {
+         case SEQ_TASK_WINDOW_MODE_VARLEN:
+             return ResolveSeqTaskWindowByMode<SEQ_TASK_WINDOW_MODE_VARLEN>(seq, seqLen, start, len);
+         case SEQ_TASK_WINDOW_MODE_DECODE2D:
+             return ResolveSeqTaskWindowByMode<SEQ_TASK_WINDOW_MODE_DECODE2D>(seq, seqLen, start, len);
+         default:
+             return ResolveSeqTaskWindowByMode<SEQ_TASK_WINDOW_MODE_BATCH>(seq, seqLen, start, len);
+     }
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ template <int32_t kWindowMode>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqTaskWindowByMode(int32_t seq, int32_t seqLen, int32_t &start,
+                                                                        int32_t &len) const
+ {
+     SeqTaskWindow window;
+     if constexpr (kWindowMode == SEQ_TASK_WINDOW_MODE_VARLEN) {
+         const int32_t startVal = queryStartLocGm.GetValue(seq);
+         const int32_t endVal = queryStartLocGm.GetValue(seq + 1);
+         window = BuildSeqTaskWindowVarlen(startVal, endVal);
+     } else if constexpr (kWindowMode == SEQ_TASK_WINDOW_MODE_DECODE2D) {
+         window = BuildSeqTaskWindowDecode2D(seq);
+     } else {
+         window = BuildSeqTaskWindowBatch(seq, seqLen);
+     }
+ 
+     if (!window.valid) {
+         return false;
+     }
+     start = window.start;
+     len = window.len;
+     return true;
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqCacheIndex(int32_t seq, bool hasCacheIndices,
+                                                                  int32_t &cacheIdx) const
+ {
+     cacheIdx = seq;
+     if (!hasCacheIndices) {
+         return true;
+     }
+ 
+     const int64_t cacheIdx64 = cacheIndicesGm.GetValue(seq);
+     if (cacheIdx64 == tilingData_->padSlotId) {
+         return false;
+     }
+     cacheIdx = static_cast<int32_t>(cacheIdx64);
+     return true;
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::ResolveSeqHasInit(int32_t seq, bool hasInitialStateMode) const
+ {
+     return hasInitialStateMode ? (initialStateModeGm.GetValue(seq) != 0) : false;
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::ProcessDefault()
+ {
+     switch (GetSeqTaskWindowMode(tilingData_->inputMode)) {
+         case SEQ_TASK_WINDOW_MODE_VARLEN:
+             ProcessDefaultByWindowMode<SEQ_TASK_WINDOW_MODE_VARLEN>();
+             return;
+         case SEQ_TASK_WINDOW_MODE_DECODE2D:
+             ProcessDefaultByWindowMode<SEQ_TASK_WINDOW_MODE_DECODE2D>();
+             return;
+         default:
+             ProcessDefaultByWindowMode<SEQ_TASK_WINDOW_MODE_BATCH>();
+             return;
+     }
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ template <int32_t kWindowMode>
+ __aicore__ inline void CAUSAL_CONV1D_CLASS::ProcessDefaultByWindowMode()
+ {
+     const int32_t dim = tilingData_->dim;
+     const int32_t batch = tilingData_->batch;
+     const int32_t seqLen = tilingData_->seqLen;
+     const int32_t baseDim = static_cast<int32_t>(tilingData_->baseDim);
+     const int32_t baseDimCnt = static_cast<int32_t>(tilingData_->baseDimCnt);
+     const int32_t width = static_cast<int32_t>(tilingData_->width);
+     const bool hasCacheIndices = (tilingData_->hasCacheIndices != 0);
+     const bool hasInit = true;
+     const bool isSpecDecodingGlobal = IsUpdateSpecDecodingEnabled();
+ 
+     const uint32_t blockIdx = GetBlockIdx();
+     const uint32_t blockNum = GetBlockNum();
+ 
+     if (baseDim <= 0 || baseDimCnt <= 0 || baseDim > MAX_BLOCK_DIM || width < 2 || width > MAX_WIDTH) {
+         ReleaseEvents();
+         return;
+     }
+ 
+     const int64_t gridSize = static_cast<int64_t>(batch) * baseDimCnt;
+     for (int64_t task = static_cast<int64_t>(blockIdx); task < gridSize; task += static_cast<int64_t>(blockNum)) {
+         const int32_t seq = static_cast<int32_t>(task / baseDimCnt);
+         const int32_t baseDimIdx = static_cast<int32_t>(task % baseDimCnt);
+         const int32_t channelStart = baseDimIdx * baseDim;
+         if (channelStart >= dim) {
+             continue;
+         }
+         const int32_t curBaseDim = (channelStart + baseDim <= dim) ? baseDim : (dim - channelStart);
+ 
+         int32_t start = 0;
+         int32_t len = 0;
+         if (!ResolveSeqTaskWindowByMode<kWindowMode>(seq, seqLen, start, len)) {
+             continue;
+         }
+ 
+         int32_t cacheIdx = 0;
+         if (!ResolveSeqCacheIndex(seq, hasCacheIndices, cacheIdx)) {
+             continue;
+         }
+ 
+         int32_t stateTokenOffset = 0;
+         if (isSpecDecodingGlobal) {
+             int32_t accepted = static_cast<int32_t>(numAcceptedTokensGm.GetValue(seq));
+             stateTokenOffset = accepted - 1;
+             const int32_t maxOffset = static_cast<int32_t>(tilingData_->stateLen - (width - 1));
+             if (stateTokenOffset < 0) {
+                 stateTokenOffset = 0;
+             } else if (stateTokenOffset > maxOffset) {
+                 stateTokenOffset = maxOffset;
+             }
+         }
+ 
+         LoadWeightAndBias(channelStart, curBaseDim);
+ 
+         InitRing(cacheIdx, hasInit, stateTokenOffset, start, len, channelStart, curBaseDim, dim);
+         RunSeq(start, len, channelStart, curBaseDim, dim);
+ 
+         PipeBarrier<PIPE_V>();
+         if (isSpecDecodingGlobal) {
+             DrainTaskMte3();
+             WriteBackStateSpec(cacheIdx, hasInit, stateTokenOffset, start, len, channelStart, curBaseDim, dim);
+         } else {
+             WriteBackState(cacheIdx, len, channelStart, curBaseDim, dim);
+         }
+ 
+         DrainTaskMte3();
+     }
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline const CausalConv1dTilingData *CAUSAL_CONV1D_CLASS::GetTilingData() const
+ {
+     return tilingData_;
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::HasActivation() const
+ {
+     return (tilingData_ != nullptr) && (tilingData_->activationMode != 0);
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::HasBias() const
+ {
+     return (tilingData_ != nullptr) && (tilingData_->hasBias != 0);
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::IsUpdateMode() const
+ {
+     return kIsUpdateMode;
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::IsFnRollingFastPathEnabled() const
+ {
+     return !kIsUpdateMode && (tilingData_ != nullptr) && (kFnExecutionPlan != FN_EXECUTION_PLAN_INVALID) &&
+            (tilingData_->hasNumAcceptedTokens == 0) && !HasBias();
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::HasExplicitFnTokenSeqRanges() const
+ {
+     return !kIsUpdateMode && (tilingData_ != nullptr) && (tilingData_->inputMode == 0) &&
+            (tilingData_->hasExplicitTokenSeqRanges != 0) &&
+            (tilingData_->explicitTokenSeqRangeCount >= tilingData_->tokenBlockCnt);
+ }
+ 
+ template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+ __aicore__ inline bool CAUSAL_CONV1D_CLASS::IsUpdateSpecDecodingEnabled() const
+ {
+     return kIsUpdateMode && (tilingData_->hasNumAcceptedTokens != 0) && (tilingData_->width == 4);
+ }
+ 
+ #include "causal_conv1d_fn_tasks.h"
+ 
+ #undef CAUSAL_CONV1D_CLASS
+ #undef CAUSAL_CONV1D_TEMPLATE_ARGS
 
 } // namespace NsCausalConv1d
 #endif // CAUSAL_CONV1D_H

--- a/csrc/moe/causal_conv1d/op_kernel/causal_conv1d_common.h
+++ b/csrc/moe/causal_conv1d/op_kernel/causal_conv1d_common.h
@@ -21,7 +21,7 @@
 namespace NsCausalConv1dCommon {
 
 constexpr int32_t MAX_WIDTH = 4;
-constexpr int32_t MAX_BLOCK_DIM = 4096;
+constexpr int32_t MAX_BLOCK_DIM = 3072;
 constexpr int32_t RING_SLOTS = 5;
 
 __aicore__ inline int32_t SlotCurr(int32_t t)

--- a/csrc/moe/causal_conv1d/op_kernel/causal_conv1d_common.h
+++ b/csrc/moe/causal_conv1d/op_kernel/causal_conv1d_common.h
@@ -24,19 +24,27 @@ constexpr int32_t MAX_WIDTH = 4;
 constexpr int32_t MAX_BLOCK_DIM = 3072;
 constexpr int32_t RING_SLOTS = 5;
 
-__aicore__ inline int32_t SlotCurr(int32_t t)
-{
-    return (t + 3) % RING_SLOTS;
+// This function should only be called if one KNOWS that the input is non-negative.
+template <uint32_t N>
+__aicore__ inline constexpr int32_t UnsignedMod(int32_t num) {
+    const uint32_t uNum = static_cast<uint32_t>(num);
+    const int32_t ans = static_cast<int32_t>(uNum % N);
+    return ans;
 }
 
-__aicore__ inline int32_t SlotHist(int32_t t, int32_t i)
+__aicore__ inline constexpr int32_t SlotCurr(int32_t t)
 {
-    return (t + 3 - i) % RING_SLOTS;
+    return UnsignedMod<RING_SLOTS>(t + 3);
 }
 
-__aicore__ inline int32_t SlotPrefetch(int32_t t)
+__aicore__ inline constexpr int32_t SlotHist(int32_t t, int32_t i)
 {
-    return (t + 4) % RING_SLOTS;
+    return UnsignedMod<RING_SLOTS>(t + 3 - i);
+}
+
+__aicore__ inline constexpr int32_t SlotPrefetch(int32_t t)
+{
+    return UnsignedMod<RING_SLOTS>(t + 4);
 }
 
 struct CalcBufLayout {

--- a/csrc/moe/causal_conv1d/op_kernel/causal_conv1d_common.h
+++ b/csrc/moe/causal_conv1d/op_kernel/causal_conv1d_common.h
@@ -28,8 +28,8 @@ constexpr int32_t RING_SLOTS = 5;
 template <uint32_t N>
 __aicore__ inline constexpr int32_t UnsignedMod(int32_t num) {
     const uint32_t uNum = static_cast<uint32_t>(num);
-    const int32_t ans = static_cast<int32_t>(uNum % N);
-    return ans;
+    const int32_t retVal = static_cast<int32_t>(uNum % N);
+    return retVal;
 }
 
 __aicore__ inline constexpr int32_t SlotCurr(int32_t t)

--- a/csrc/moe/causal_conv1d/op_kernel/causal_conv1d_fn_tasks.h
+++ b/csrc/moe/causal_conv1d/op_kernel/causal_conv1d_fn_tasks.h
@@ -104,19 +104,20 @@
      const int32_t historyCount = width - 1;
      const int32_t ringStart = MAX_WIDTH - width;
      const int32_t historyStartTok = tileStart - historyCount;
-     LocalTensor<T> ring = inBuf.Get<T>();
+     LocalTensor<float> ringF = inBuf.Get<float>();
+     LocalTensor<T> ringT = ringF.ReinterpretCast<T>();
      bool hasGmHistoryCopy = false;
      bool hasVectorInit = false;
      const int64_t stateBaseOffset = static_cast<int64_t>(cacheIdx) * stateLen * dim + channelStart;
      int64_t xHistoryOffset = static_cast<int64_t>(historyStartTok) * dim + channelStart;
  
      for (int32_t i = 0; i < ringStart; ++i) {
-         Duplicate(ring[i * MAX_BLOCK_DIM], static_cast<T>(0), baseDim);
+         Duplicate(ringF[i * MAX_BLOCK_DIM], 0.0f, baseDim);
          hasVectorInit = true;
      }
  
      for (int32_t i = 0, srcTok = historyStartTok; i < historyCount; ++i, ++srcTok, xHistoryOffset += dim) {
-         LocalTensor<T> histSlot = ring[(ringStart + i) * MAX_BLOCK_DIM];
+         LocalTensor<T> histSlot = ringT[(ringStart + i) * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM];
          if (srcTok >= seqStart) {
              DataCopy(histSlot, xGm[xHistoryOffset], baseDim);
              hasGmHistoryCopy = true;
@@ -132,7 +133,7 @@
              }
              hasGmHistoryCopy = true;
          } else {
-             Duplicate(histSlot, static_cast<T>(0), baseDim);
+             Duplicate(ringF[(ringStart + i) * MAX_BLOCK_DIM], 0.0f, baseDim);
              hasVectorInit = true;
          }
      }
@@ -140,6 +141,14 @@
      if (hasGmHistoryCopy) {
          SetFlag<HardEvent::MTE2_V>(stateMte2ToVEvent_);
          WaitFlag<HardEvent::MTE2_V>(stateMte2ToVEvent_);
+         for (int32_t i = 0, srcTok = historyStartTok; i < historyCount; ++i, ++srcTok) {
+             if (srcTok >= seqStart || hasInit) {
+                 const int32_t pos = ringStart + i;
+                 Cast(ringF[pos * MAX_BLOCK_DIM], ringT[pos * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM],
+                      RoundMode::CAST_NONE, baseDim);
+             }
+         }
+         hasVectorInit = true;
      }
      if (hasVectorInit) {
          PipeBarrier<PIPE_V>();
@@ -148,7 +157,7 @@
      if (tileLen > 0) {
          const int32_t slot0 = SlotCurr(0);
          const int64_t xOffset = static_cast<int64_t>(tileStart) * dim + channelStart;
-         DataCopy(ring[slot0 * MAX_BLOCK_DIM], xGm[xOffset], baseDim);
+         DataCopy(ringT[slot0 * MAX_BLOCK_DIM * 2 + MAX_BLOCK_DIM], xGm[xOffset], baseDim);
          SetFlag<HardEvent::MTE2_V>(inputMte2ToVEvent_[slot0]);
      }
  


### PR DESCRIPTION

# What this PR does / why we need it?

# causal_conv1d: FP32 cast-once ring

Optimizes the AscendC `causal_conv1d` kernel (`csrc/moe/causal_conv1d`). **Bit-exact to `main`** (zero numerical change) while running **1.251× faster on device / 1.215× end-to-end across a full 48-config sweep, and up to 1.44× at the production width `dim=6144`.** Validated inside vllm-ascend's real Qwen3.5 GDN layer.

## What changed

Three complementary changes, all preserving the exact output:

1. **FP32 "cast-once" ring buffer.** The conv state/history ring is kept in **FP32** through the rolling prefill path; we cast **once** at history load and once at final state writeback, instead of casting `bf16 ↔ fp32` on every per-token use. This removes the dominant redundant cast traffic from the inner loop (`bias=true`/generic accumulation benefits most — that's where the 1.34–1.44× comes from).
2. **Even `3072 + 3072` tiling.** `MAX_DIM_TILE_SIZE` `4096 → 3072`, so the production width `dim=6144` splits into **two equal 3072 tiles** instead of one 4096 tile + a 2048 remainder — balanced tiles, better locality.
3. **Register-base rolling-output compute.** FP32 ring values are loaded straight into registers and fed to `MulAdd` without an intermediate cast + pipe barrier.

**Correctness is preserved by design:** the single-token decode/update path stays byte-identical to `main`, the persisted `conv_state` remains `bf16`, and the FP32→bf16 round-trip uses the same rounding as `main`'s cast — so every config is bit-exact.

Files: `op_kernel/causal_conv1d.h` (main rewrite), `op_kernel/arch35/causal_conv1d_regbase.h`, `op_kernel/causal_conv1d_fn_tasks.h`, `op_kernel/causal_conv1d_common.h`, `op_host/causal_conv1d_tiling_{utils,planner}.h`.

## Benchmark setup — the 48-config sweep
We performed the following 48-config sweep in a Ascend 910B2.

Every config is `d{dim}_b{batch}_s{seqlen}_bias{0|1}_silu{0|1}`. The sweep is the full cross-product
**48 = dim{6144, 2304, 384} × seqlen{4096, 16384} × batch{1, 8} × bias{off, on} × silu{on, off}** (3·2·2·2·2),
run identically for `main` and `fewer_casts`:

- **dim 6144** is the real Qwen GDN conv width; **2304 / 384** are synthetic smaller stress points.
- **bias off** exercises the FN rolling fast-path (the optimization target); **bias on** the generic path.
- `speedup = main / branch` (>1 = branch faster). Kernel-only = pure device µs (msprof, 20 iters/config, median);
  end-to-end = full per-call wall time incl. host launch (50 iters/config, median).

## Performance — kernel-only (pure device µs)

Device time the AI cores actually spend (`speedup = main/branch`), summarized by dim:

| dim | `bias=false` (FN fast-path) | `bias=true` (generic) |
|---|---|---|
| **6144** (production / Qwen GDN width) | **1.21–1.28×** | **1.34–1.44×** |
| 2304 | 1.02–1.04× | 1.06–1.14× |
| 384 | 0.98–1.06× | 1.05–1.20× |
| **all 48 configs (Σ medians)** | colspan | **1.251×** (53427.6 → 42704.5 µs) |

<details>
<summary><b>Full 48-config device-µs table</b> (peak <code>1.438×</code> at <code>d6144_b8_s16384_bias1_silu0</code>)</summary>

```
config                               main us  branch us   speedup
------------------------------------------------------------------
d6144_b1_s4096_bias0_silu1             214.5      176.7    1.214x
d6144_b8_s4096_bias0_silu1            1609.6     1259.4    1.278x
d6144_b1_s16384_bias0_silu1            811.9      638.8    1.271x
d6144_b8_s16384_bias0_silu1           6383.9     4972.9    1.284x
d6144_b1_s4096_bias0_silu0             155.8      128.1    1.216x
d6144_b8_s4096_bias0_silu0            1139.2      886.3    1.285x
d6144_b1_s16384_bias0_silu0            576.4      451.3    1.277x
d6144_b8_s16384_bias0_silu0           4507.5     3604.9    1.250x
d6144_b1_s4096_bias1_silu1             282.7      211.0    1.340x
d6144_b8_s4096_bias1_silu1            2163.6     1557.2    1.389x
d6144_b1_s16384_bias1_silu1           1088.7      787.8    1.382x
d6144_b8_s16384_bias1_silu1           8605.7     6167.1    1.395x
d6144_b1_s4096_bias1_silu0             223.8      164.5    1.360x
d6144_b8_s4096_bias1_silu0            1692.5     1184.1    1.429x
d6144_b1_s16384_bias1_silu0            853.0      600.7    1.420x
d6144_b8_s16384_bias1_silu0           6721.4     4674.3    1.438x
d2304_b1_s4096_bias0_silu1              78.8       77.2    1.020x
d2304_b8_s4096_bias0_silu1             522.9      513.3    1.019x
d2304_b1_s16384_bias0_silu1            268.8      263.7    1.020x
d2304_b8_s16384_bias0_silu1           2041.8     2006.4    1.018x
d2304_b1_s4096_bias0_silu0              59.8       57.6    1.038x
d2304_b8_s4096_bias0_silu0             374.7      361.2    1.037x
d2304_b1_s16384_bias0_silu0            193.5      185.5    1.044x
d2304_b8_s16384_bias0_silu0           1469.9     1433.9    1.025x
d2304_b1_s4096_bias1_silu1              98.7       93.2    1.059x
d2304_b8_s4096_bias1_silu1             684.8      624.3    1.097x
d2304_b1_s16384_bias1_silu1            349.9      321.1    1.090x
d2304_b8_s16384_bias1_silu1           2694.1     2443.3    1.103x
d2304_b1_s4096_bias1_silu0              79.9       73.0    1.096x
d2304_b8_s4096_bias1_silu0             534.5      474.1    1.127x
d2304_b1_s16384_bias1_silu0            274.6      244.8    1.121x
d2304_b8_s16384_bias1_silu0           2093.3     1844.8    1.135x
d384_b1_s4096_bias0_silu1               38.9       39.8    0.977x
d384_b8_s4096_bias0_silu1              209.5      206.6    1.014x
d384_b1_s16384_bias0_silu1             112.0      111.8    1.002x
d384_b8_s16384_bias0_silu1             814.6      804.5    1.013x
d384_b1_s4096_bias0_silu0               31.6       31.9    0.991x
d384_b8_s4096_bias0_silu0              151.1      142.4    1.061x
d384_b1_s16384_bias0_silu0              82.8       79.7    1.039x
d384_b8_s16384_bias0_silu0             649.5      629.4    1.032x
d384_b1_s4096_bias1_silu1               44.0       42.1    1.046x
d384_b8_s4096_bias1_silu1              251.3      219.6    1.144x
d384_b1_s16384_bias1_silu1             132.8      118.3    1.122x
d384_b8_s16384_bias1_silu1             967.7      844.6    1.146x
d384_b1_s4096_bias1_silu0               36.8       34.4    1.071x
d384_b8_s4096_bias1_silu0              193.1      161.3    1.197x
d384_b1_s16384_bias1_silu0             103.6       88.5    1.170x
d384_b8_s16384_bias1_silu0             758.1      667.1    1.136x
```
</details>

## Performance — end-to-end (full per-call wall time, host launch included)

| dim | `bias=false` | `bias=true` |
|---|---|---|
| **6144** | 1.14–1.28× | 1.17–1.42× |
| **all 48 configs (Σ medians)** | colspan | **1.215×** (62436.9 → 51399.8 µs) |

Slightly below the device number because the ~fixed host/launch overhead dilutes it (most at small shapes); at `dim=6144` the kernel still gives **~1.15–1.42×** wall.

<details>
<summary><b>Full 48-config end-to-end-µs table</b></summary>

```
config                               main us  branch us   speedup
------------------------------------------------------------------
d6144_b1_s4096_bias0_silu1             393.9      342.5    1.150x
d6144_b8_s4096_bias0_silu1            1792.0     1433.8    1.250x
d6144_b1_s16384_bias0_silu1            994.6      811.9    1.225x
d6144_b8_s16384_bias0_silu1           6569.8     5152.1    1.275x
d6144_b1_s4096_bias0_silu0             333.9      293.7    1.137x
d6144_b8_s4096_bias0_silu0            1323.7     1070.2    1.237x
d6144_b1_s16384_bias0_silu0            781.1      626.8    1.246x
d6144_b8_s16384_bias0_silu0           4697.4     3742.6    1.255x
d6144_b1_s4096_bias1_silu1             475.4      381.5    1.246x
d6144_b8_s4096_bias1_silu1            2355.3     1779.1    1.324x
d6144_b1_s16384_bias1_silu1           1279.8      990.1    1.293x
d6144_b8_s16384_bias1_silu1           8803.6     6364.7    1.383x
d6144_b1_s4096_bias1_silu0             405.2      346.6    1.169x
d6144_b8_s4096_bias1_silu0            1885.7     1378.4    1.368x
d6144_b1_s16384_bias1_silu0           1042.1      786.7    1.325x
d6144_b8_s16384_bias1_silu0           6919.1     4870.7    1.421x
d2304_b1_s4096_bias0_silu1             264.8      265.8    0.996x
d2304_b8_s4096_bias0_silu1             711.5      706.4    1.007x
d2304_b1_s16384_bias0_silu1            456.4      455.3    1.002x
d2304_b8_s16384_bias0_silu1           2234.5     2207.4    1.012x
d2304_b1_s4096_bias0_silu0             243.8      244.5    0.997x
d2304_b8_s4096_bias0_silu0             567.0      557.6    1.017x
d2304_b1_s16384_bias0_silu0            379.0      373.0    1.016x
d2304_b8_s16384_bias0_silu0           1680.8     1633.1    1.029x
d2304_b1_s4096_bias1_silu1             289.7      273.6    1.059x
d2304_b8_s4096_bias1_silu1             876.2      809.7    1.082x
d2304_b1_s16384_bias1_silu1            539.4      503.6    1.071x
d2304_b8_s16384_bias1_silu1           2893.9     2627.8    1.101x
d2304_b1_s4096_bias1_silu0             263.7      249.0    1.059x
d2304_b8_s4096_bias1_silu0             723.1      658.3    1.099x
d2304_b1_s16384_bias1_silu0            463.2      423.3    1.094x
d2304_b8_s16384_bias1_silu0           2284.6     2027.1    1.127x
d384_b1_s4096_bias0_silu1              220.2      214.6    1.026x
d384_b8_s4096_bias0_silu1              393.3      386.7    1.017x
d384_b1_s16384_bias0_silu1             292.9      285.4    1.026x
d384_b8_s16384_bias0_silu1            1000.9      988.4    1.013x
d384_b1_s4096_bias0_silu0              217.6      211.8    1.028x
d384_b8_s4096_bias0_silu0              333.8      318.4    1.048x
d384_b1_s16384_bias0_silu0             265.2      252.3    1.051x
d384_b8_s16384_bias0_silu0             827.2      805.7    1.027x
d384_b1_s4096_bias1_silu1              222.8      212.2    1.050x
d384_b8_s4096_bias1_silu1              438.6      392.9    1.117x
d384_b1_s16384_bias1_silu1             312.5      286.9    1.089x
d384_b8_s16384_bias1_silu1            1154.3     1019.9    1.132x
d384_b1_s4096_bias1_silu0              219.3      207.6    1.056x
d384_b8_s4096_bias1_silu0             377.1      332.6    1.134x
d384_b1_s16384_bias1_silu0            284.1      261.5    1.086x
d384_b8_s16384_bias1_silu0            952.9      836.2    1.140x
```
</details>

## Correctness

- **48/48 bit-exact** — output *and* persisted `conv_state` are byte-identical to `main` on every config (`dim{6144,2304,384} × seqlen{4096,16384} × batch{1,8} × bias{0,1} × silu{1,0}`).
- **vLLM tests pass**

## Real-model validation (vllm-ascend GDN layer)

In `AscendGatedDeltaNetAttention`'s prefill forward (CANN 9, single NPU / PCP=1, where GDN dispatches to this exact kernel), the conv is a robust **1.27–1.28× faster, GDN output bit-exact**.

### Does this PR introduce _any_ user-facing change?
- No

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
