### PR TITLE
[Feature]Support IndexCache top-k index reuse for DeepSeek Sparse MLA's MTP Layer

### DIFF
--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -176,14 +176,15 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         
         self._share_mtp_indices = False
         spec_config = self.vllm_config.speculative_config
+        draft_model_config = getattr(spec_config, "draft_model_config", None)
         draft_hf_config = (
-            spec_config.draft_model_config.hf_config
-            if spec_config is not None
+            draft_model_config.hf_config
+            if draft_model_config is not None
             else None
         )
         self._share_mtp_indices = getattr(
             draft_hf_config, "index_share_for_mtp_iteration", False
-        )       
+        )
 
         # NOTE:
         # `draft_tensor_parallel_size` does not take effect for Eagle:

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -997,8 +997,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 draft_token_ids = run_draft()
                 self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
         # step 1+ skip indexer
-        if self._share_mtp_indices and hasattr(self.model.model, "set_skip_topk"):
-            self.model.model.set_skip_topk(True) 
+        draft_model = getattr(self.model, "model", None)
+        if self._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
+            draft_model.set_skip_topk(True)
 
         return draft_token_ids
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -173,6 +173,18 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         )
 
         self.use_sparse = hasattr(vllm_config.model_config.hf_text_config, "index_topk")
+        
+        self._share_mtp_indices = False
+        spec_config = self.vllm_config.speculative_config
+        draft_hf_config = (
+            spec_config.draft_model_config.hf_config
+            if spec_config is not None
+            else None
+        )
+        self._share_mtp_indices = getattr(
+            draft_hf_config, "index_share_for_mtp_iteration", False
+        )       
+
         # NOTE:
         # `draft_tensor_parallel_size` does not take effect for Eagle:
         # the draft model uses the same TP size as the target model in practice.
@@ -469,6 +481,12 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "[spec_decode/base] Detected MTP model with topk_indices_buffer."
                 " Sharing target model topk_indices_buffer with the draft model."
             )
+            target_buffer = target_language_model.model.topk_indices_buffer
+            if target_buffer is not None:
+                for _, module in self.model.model.named_modules():
+                    if hasattr(module, "topk_indices_buffer"):
+                        module.topk_indices_buffer = target_buffer
+
 
     def get_model(self) -> nn.Module:
         # get raw model out of the aclgraph wrapper.
@@ -937,6 +955,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.token_indices_to_sample[:token_indices_to_sample_len].copy_(token_indices_to_sample)
         self.token_indices_to_sample[token_indices_to_sample_len:].fill_(0)
 
+        # step 0   
+        if self._share_mtp_indices and hasattr(self.model.model, "set_skip_topk"):
+            self.model.model.set_skip_topk(False)
+
         with set_ascend_forward_context(
             multi_steps_attn_metadata[0],
             self.vllm_config,
@@ -971,6 +993,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             else:
                 draft_token_ids = run_draft()
                 self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
+        # step 1+ skip indexer
+        if self._share_mtp_indices and hasattr(self.model.model, "set_skip_topk"):
+            self.model.model.set_skip_topk(True) 
+
         return draft_token_ids
 
     def compute_draft_token_ids(self, hidden_states: torch.Tensor):

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -483,8 +483,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 " Sharing target model topk_indices_buffer with the draft model."
             )
             target_buffer = target_language_model.model.topk_indices_buffer
-            if target_buffer is not None:
-                for _, module in self.model.model.named_modules():
+            draft_model = getattr(self.model, "model", None)
+            if target_buffer is not None and draft_model is not None:
+                for _, module in draft_model.named_modules():
                     if hasattr(module, "topk_indices_buffer"):
                         module.topk_indices_buffer = target_buffer
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -958,8 +958,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.token_indices_to_sample[token_indices_to_sample_len:].fill_(0)
 
         # step 0   
-        if self._share_mtp_indices and hasattr(self.model.model, "set_skip_topk"):
-            self.model.model.set_skip_topk(False)
+        draft_model = getattr(self.model, "model", None)
+        if self._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
+            draft_model.set_skip_topk(False)
 
         with set_ascend_forward_context(
             multi_steps_attn_metadata[0],


### PR DESCRIPTION
What this PR does / why we need it?
This PR aligns the Ascend backend with the upstream implementation of IndexCache top-k index reuse for DeepSeek Sparse MLA's MTP Layer, inspired by IndexCache: Accelerating Sparse Attention via Cross-Layer Index Reuse.

Does this PR introduce any user-facing change?
No

How was this patch tested?
vllm serve /home/jjz/mnt/GLM-5.2-0610-Provider \
--host 0.0.0.0 \
--port 8077 \
--data-parallel-size 1 \
--tensor-parallel-size 16 \
--enable-expert-parallel \
--seed 1024 \
--served-model-name glm-5 \
--max-num-seqs 16 \
--max-model-len 40960 \
--max-num-batched-tokens 4096 \
--trust-remote-code \
--gpu-memory-utilization 0.95 \
--enable-chunked-prefill \
--enable-prefix-caching \
--additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true, "ascend_compilation_config": {"enable_npugraph_ex": true}}' \
--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
--speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'

vLLM version: v0.21.0
vLLM main: https://github.com/vllm-project/vllm/commit/efc347f1b2e635753ae8a594e9714109c200fcd3

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
