### PR TITLE
[0.18][Patch][BugFix] Align custom schedulers with vLLM 0.18 skipped_waiting queue for structured output

### DIFF
--- a/tests/ut/compilation/test_acl_graph.py
+++ b/tests/ut/compilation/test_acl_graph.py
@@ -770,7 +770,7 @@ class TestPCPDCPGraphParams(TestBase):
             self.graph_params = get_graph_params()
         else:
             self.graph_params = graph_params
-        mock_event = torch.npu.ExternalEvent()
+        mock_event = MagicMock()
         mock_event.record = MagicMock()
         self.graph_params.events[4] = []
         self.graph_params.handles[4] = []

--- a/vllm_ascend/core/scheduler_dynamic_batch.py
+++ b/vllm_ascend/core/scheduler_dynamic_batch.py
@@ -299,39 +299,32 @@ class SchedulerDynamicBatch(Scheduler):
             )
             assert len(scheduled_loras) <= self.lora_config.max_loras
 
-        # Use a temporary RequestQueue to collect requests that need to be
-        # skipped and put back at the head of the waiting queue later
-        skipped_waiting_requests = create_request_queue(self.policy)
-
         # Next, schedule the WAITING requests.
         if not preempted_reqs:
-            while self.waiting and token_budget > 0:
+            step_skipped_waiting = create_request_queue(self.policy)
+
+            while (self.waiting or self.skipped_waiting) and token_budget > 0:
                 if len(self.running) == self.max_num_running_reqs:
                     break
 
-                request = self.waiting.peek_request()
+                request_queue = self._select_waiting_queue_for_scheduling()
+                if request_queue is None:
+                    break
 
-                # KVTransfer: skip request if still waiting for remote kvs.
-                if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
-                    is_ready = self._update_waiting_for_remote_kv(request)
-                    if is_ready:
-                        request.status = RequestStatus.WAITING
-                    else:
-                        logger.debug("%s is still in WAITING_FOR_REMOTE_KVS state.", request.request_id)
-                        self.waiting.pop_request()
-                        skipped_waiting_requests.prepend_request(request)
-                        continue
+                request = request_queue.peek_request()
 
-                # Skip request if the structured output request is still waiting
-                # for FSM compilation.
-                if request.status == RequestStatus.WAITING_FOR_FSM:
-                    structured_output_req = request.structured_output_request
-                    if structured_output_req and structured_output_req.grammar:
-                        request.status = RequestStatus.WAITING
-                    else:
-                        self.waiting.pop_request()
-                        skipped_waiting_requests.prepend_request(request)
-                        continue
+                # try to promote blocked statuses while traversing skipped queue.
+                if self._is_blocked_waiting_status(request.status) and not self._try_promote_blocked_waiting_request(
+                    request
+                ):
+                    if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                        logger.debug(
+                            "%s is still in WAITING_FOR_REMOTE_KVS state.",
+                            request.request_id,
+                        )
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
+                    continue
 
                 # Check that adding the request still respects the max_loras
                 # constraint.
@@ -344,8 +337,8 @@ class SchedulerDynamicBatch(Scheduler):
                     )
                 ):
                     # Scheduling would exceed max_loras, skip.
-                    self.waiting.pop_request()
-                    skipped_waiting_requests.prepend_request(request)
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
                     continue
 
                 num_external_computed_tokens = 0
@@ -368,8 +361,8 @@ class SchedulerDynamicBatch(Scheduler):
                             # The request cannot be scheduled because
                             # the KVConnector couldn't determine
                             # the number of matched tokens.
-                            self.waiting.pop_request()
-                            skipped_waiting_requests.prepend_request(request)
+                            request_queue.pop_request()
+                            step_skipped_waiting.prepend_request(request)
                             continue
 
                     # Total computed tokens (local + external).
@@ -400,8 +393,8 @@ class SchedulerDynamicBatch(Scheduler):
                     # chunked prefill has to be enabled explicitly to allow
                     # pooling requests to be chunked
                     if not self.scheduler_config.enable_chunked_prefill and num_new_tokens > token_budget:
-                        self.waiting.pop_request()
-                        skipped_waiting_requests.prepend_request(request)
+                        request_queue.pop_request()
+                        step_skipped_waiting.prepend_request(request)
                         continue
 
                     num_new_tokens = min(num_new_tokens, token_budget)
@@ -460,14 +453,13 @@ class SchedulerDynamicBatch(Scheduler):
                         num_external_computed_tokens,
                     )
 
-                # Request was already popped from self.waiting
-                # unless it was re-added above due to new_blocks being None.
-                request = self.waiting.pop_request()
+                request = request_queue.pop_request()
                 if load_kv_async:
                     # If loading async, allocate memory and put request
                     # into the WAITING_FOR_REMOTE_KV state.
-                    skipped_waiting_requests.prepend_request(request)
                     request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+                    step_skipped_waiting.prepend_request(request)
+                    request.num_computed_tokens = num_computed_tokens
                     continue
 
                 req_index += 1
@@ -499,9 +491,9 @@ class SchedulerDynamicBatch(Scheduler):
                         self.encoder_cache_manager.allocate(request, i)
                     encoder_compute_budget = new_encoder_compute_budget
 
-        # Put back any skipped requests at the head of the waiting queue
-        if skipped_waiting_requests:
-            self.waiting.prepend_requests(skipped_waiting_requests)
+            # re-queue requests skipped in this pass ahead of older skipped items.
+            if step_skipped_waiting:
+                self.skipped_waiting.prepend_requests(step_skipped_waiting)
 
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -258,11 +258,9 @@ class BalanceScheduler(Scheduler):
 
         # Next, schedule the WAITING requests.
         if not preempted_reqs and self._pause_state == PauseState.UNPAUSED:
-            # Use a temporary RequestQueue to collect requests that need to be
-            # skipped and put back at the head of the waiting queue later
-            skipped_waiting_requests = create_request_queue(self.policy)
+            step_skipped_waiting = create_request_queue(self.policy)
 
-            while self.waiting and token_budget > 0:
+            while (self.waiting or self.skipped_waiting) and token_budget > 0:
                 if len(self.running) == self.max_num_running_reqs:
                     break
 
@@ -270,43 +268,24 @@ class BalanceScheduler(Scheduler):
                 if balance_flag:
                     break
 
-                request = self.waiting.peek_request()
+                request_queue = self._select_waiting_queue_for_scheduling()
+                if request_queue is None:
+                    break
+
+                request = request_queue.peek_request()
                 request_id = request.request_id
 
-                # KVTransfer: skip request if still waiting for remote kvs.
-                if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
-                    if request.request_id not in self.finished_recving_kv_req_ids:
+                # try to promote blocked statuses while traversing skipped queue.
+                if self._is_blocked_waiting_status(request.status) and not self._try_promote_blocked_waiting_request(
+                    request
+                ):
+                    if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                         logger.debug(
                             "%s is still in WAITING_FOR_REMOTE_KVS state.",
                             request_id,
                         )
-                        self.waiting.pop_request()
-                        skipped_waiting_requests.prepend_request(request)
-                        continue
-                    self._update_waiting_for_remote_kv(request)
-                    if request.num_preemptions:
-                        # We must be loading for a resumed preemption
-                        # rather than a new request.
-                        request.status = RequestStatus.PREEMPTED
-                    else:
-                        request.status = RequestStatus.WAITING
-
-                # Skip request if the structured output request is still waiting
-                # for FSM compilation.
-                if request.status == RequestStatus.WAITING_FOR_FSM:
-                    structured_output_req = request.structured_output_request
-                    if structured_output_req and structured_output_req.grammar:
-                        request.status = RequestStatus.WAITING
-                    else:
-                        self.waiting.pop_request()
-                        skipped_waiting_requests.prepend_request(request)
-                        continue
-
-                # Streaming: skip request if still waiting for next streaming req.
-                if request.status == RequestStatus.WAITING_FOR_STREAMING_REQ:
-                    assert not request.streaming_queue
-                    self.waiting.pop_request()
-                    skipped_waiting_requests.prepend_request(request)
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
                     continue
 
                 # Check that adding the request still respects the max_loras
@@ -320,8 +299,8 @@ class BalanceScheduler(Scheduler):
                     )
                 ):
                     # Scheduling would exceed max_loras, skip.
-                    self.waiting.pop_request()
-                    skipped_waiting_requests.prepend_request(request)
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
                     continue
 
                 num_external_computed_tokens = 0
@@ -345,8 +324,8 @@ class BalanceScheduler(Scheduler):
                             # The request cannot be scheduled because
                             # the KVConnector couldn't determine
                             # the number of matched tokens.
-                            self.waiting.pop_request()
-                            skipped_waiting_requests.prepend_request(request)
+                            request_queue.pop_request()
+                            step_skipped_waiting.prepend_request(request)
                             continue
 
                         request.num_external_computed_tokens = ext_tokens
@@ -357,6 +336,7 @@ class BalanceScheduler(Scheduler):
 
                     # Total computed tokens (local + external).
                     num_computed_tokens = num_new_local_computed_tokens + num_external_computed_tokens
+                    assert num_computed_tokens <= request.num_tokens
                 else:
                     # KVTransfer: WAITING reqs have num_computed_tokens > 0
                     # after async KV recvs are completed.
@@ -469,14 +449,13 @@ class BalanceScheduler(Scheduler):
                             preempted=request.num_preemptions > 0,
                         )
 
-                # Request was already popped from self.waiting
-                # unless it was re-added above due to new_blocks being None.
-                request = self.waiting.pop_request()
+                request = request_queue.pop_request()
                 if load_kv_async:
                     # If loading async, allocate memory and put request
                     # into the WAITING_FOR_REMOTE_KV state.
-                    skipped_waiting_requests.prepend_request(request)
                     request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+                    step_skipped_waiting.prepend_request(request)
+                    request.num_computed_tokens = num_computed_tokens
                     continue
 
                 self.running.append(request)
@@ -513,9 +492,9 @@ class BalanceScheduler(Scheduler):
                         if self.ec_connector is not None:
                             self.ec_connector.update_state_after_alloc(request, i)
 
-            # Put back any skipped requests at the head of the waiting queue
-            if skipped_waiting_requests:
-                self.waiting.prepend_requests(skipped_waiting_requests)
+            # re-queue requests skipped in this pass ahead of older skipped items.
+            if step_skipped_waiting:
+                self.skipped_waiting.prepend_requests(step_skipped_waiting)
 
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())


### PR DESCRIPTION
### What this PR does / why we need it?

vLLM 0.18 routes blocked waiting requests (including structured output requests in `WAITING_FOR_FSM`) into a persistent `skipped_waiting` queue via `_enqueue_waiting_request`, while `BalanceScheduler.schedule()` still followed the v0.17 logic: it only iterated `self.waiting` and re-queued skipped requests back to `self.waiting`. As a result, requests with `response_format` (e.g. `{"type": "json_object"}`) could remain stuck in `skipped_waiting` forever when `VLLM_ASCEND_BALANCE_SCHEDULING=1`, causing chat completions to hang with no response.

This PR aligns `BalanceScheduler`'s waiting-request scheduling with upstream vLLM 0.18:

- Schedule from both `self.waiting` and `self.skipped_waiting`
- Use `_select_waiting_queue_for_scheduling()` for queue selection
- Use `_is_blocked_waiting_status()` and `_try_promote_blocked_waiting_request()` instead of duplicated inline handlers for `WAITING_FOR_FSM`, `WAITING_FOR_REMOTE_KVS`, and `WAITING_FOR_STREAMING_REQ`
- Re-queue skipped requests to `self.skipped_waiting` (not `self.waiting`)
- Set `request.num_computed_tokens` on async KV load, matching upstream behavior

Fixes structured output hang under balance scheduling; no change to `WAITING_FOR_FSM` naming (still used in vLLM 0.18).

Fixes #10537 

### Does this PR introduce _any_ user-facing change?

Yes. With `VLLM_ASCEND_BALANCE_SCHEDULING=1`, chat/completion requests that use top-level `response_format` (structured output) should no longer hang indefinitely and can return responses after grammar compilation completes.

### How was this patch tested?

Manual test with balance scheduling enabled (`VLLM_ASCEND_BALANCE_SCHEDULING=1`):

1. Start vLLM Ascend service with the same deployment flags as the reproduction case (including balance scheduling).
2. Send a POST to `/v1/chat/completions` with top-level `"response_format": {"type": "json_object"}`.
3. Verify the request completes and returns structured JSON instead of hanging.

Compare against pre-patch behavior where the same request received right response:
```
curl http://localhost:8000/v1/chat/completions \
> -H "Content-Type: application/json" \
> -d '{
> "model": "qwen",
> "messages": [
> {"role": "system", "content": "你是专业的白酒商品信息提取专家，严格按照规则提取信息并输出JSON格式"},
> {"role": "user", "content": "山西杏花村汾酒53度黄盖475ml*6瓶，整箱玻汾清香型国产高度白酒，66.00，汾酒官方旗舰店"}
> ],
> "response_format": {"type":"json_object"},
> "chat_template_kwargs":{"enable_thinking":false}
> }'
{"id":"chatcmpl-a085c6938c7f0c94","object":"chat.completion","created":1781517656,"model":"qwen","choices":[{"index":0,"message":{"role":"assistant","content":"{\n  \"product_name\": \"山西杏花村汾酒\",\n  \"degree\": \"53度\",\n  \"volume\": \"475ml\",\n  \"quantity\": \"6瓶\",\n  \"type\": \"整箱玻汾清香型国产高度白酒\",\n  \"price\": \"66.00\",\n  \"brand\": \"汾酒官方旗舰店\"\n}","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":72,"total_tokens":151,"completion_tokens":79,"prompt_tokens_details":null,"completion_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}
```