### PR TITLE
[Feature]Support IndexCache top-k index reuse for GLM5.2

### DIFF
--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -4382,3 +4382,120 @@ def test_split_pcp_input_hybrid_preserves_hidden_size():
     )
 
     assert out_hidden_states.shape[1] == hidden_size
+
+
+class TestDeepSeekMTPIndicesSharing(unittest.TestCase):
+    """
+    Unit tests for DeepSeek Sparse MLA MTP Layer's Top-K Index reuse feature (PR #10510)
+    """
+
+    def setUp(self):
+        # Prepare the base Config Mock
+        self.vllm_config = MagicMock(spec=VllmConfig)
+        self.vllm_config.speculative_config = MagicMock()
+        self.vllm_config.speculative_config.draft_model_config = MagicMock()
+        self.vllm_config.speculative_config.draft_model_config.hf_config = MagicMock()
+        self.device = torch.device("cpu")
+        self.runner = MagicMock()
+
+    def test_init_mtp_indices_flag(self):
+        """Test whether index_share_for_mtp_iteration is correctly read in __init__."""
+        # Scenario 1: Set to True in config
+        self.vllm_config.speculative_config.draft_model_config.hf_config.index_share_for_mtp_iteration = True
+
+        with patch.object(AscendEagleProposer, "__init__", lambda self, vllm_config, device, runner: None):
+            proposer = AscendEagleProposer(self.vllm_config, self.device, self.runner)
+            # Manually trigger the newly added initialization logic for validation
+            proposer.vllm_config = self.vllm_config
+            proposer._share_mtp_indices = getattr(
+                self.vllm_config.speculative_config.draft_model_config.hf_config, "index_share_for_mtp_iteration", False
+            )
+            self.assertTrue(proposer._share_mtp_indices, "MTP share flag should be True when configured.")
+
+        # Scenario 2: Not set in config (defaults to False)
+        del self.vllm_config.speculative_config.draft_model_config.hf_config.index_share_for_mtp_iteration
+        with patch.object(AscendEagleProposer, "__init__", lambda self, vllm_config, device, runner: None):
+            proposer2 = AscendEagleProposer(self.vllm_config, self.device, self.runner)
+            proposer2.vllm_config = self.vllm_config
+            proposer2._share_mtp_indices = getattr(
+                self.vllm_config.speculative_config.draft_model_config.hf_config, "index_share_for_mtp_iteration", False
+            )
+            self.assertFalse(proposer2._share_mtp_indices, "MTP share flag should default to False.")
+
+    def test_maybe_share_topk_indices_submodules(self):
+        """Test if _maybe_share_topk_indices correctly updates topk_indices_buffer for all submodules."""
+        # Use __new__ to bypass the complex __init__ process
+        proposer = AscendEagleProposer.__new__(AscendEagleProposer)
+
+        # 1. Mock Target Model
+        target_model = MagicMock()
+        target_buffer_mock = MagicMock()
+        target_model.model.topk_indices_buffer = target_buffer_mock
+
+        # 2. Mock Draft Model (including submodules)
+        draft_model_mock = MagicMock()
+        draft_model_mock.model.topk_indices_buffer = MagicMock()  # Old buffer
+
+        # Construct several submodules: some have topk_indices_buffer, some don't
+        mod1 = MagicMock()
+        mod1.topk_indices_buffer = MagicMock()  # This should be replaced
+        mod2 = MagicMock()
+        del mod2.topk_indices_buffer  # This doesn't have the attribute, shouldn't throw an error
+        mod3 = MagicMock()
+        mod3.topk_indices_buffer = MagicMock()  # This should also be replaced
+
+        # Mock the return value of named_modules
+        draft_model_mock.model.named_modules.return_value = [("layer.0", mod1), ("layer.1", mod2), ("layer.2", mod3)]
+        proposer.model = draft_model_mock
+
+        # Execute the target method
+        proposer._maybe_share_topk_indices(target_model)
+
+        # Assertion: The outermost draft model buffer is updated
+        self.assertEqual(proposer.model.model.topk_indices_buffer, target_buffer_mock)
+
+        # Assertion: Submodules are correctly traversed and updated
+        self.assertEqual(mod1.topk_indices_buffer, target_buffer_mock, "Module 1 buffer should be updated.")
+        self.assertEqual(mod3.topk_indices_buffer, target_buffer_mock, "Module 3 buffer should be updated.")
+        self.assertFalse(hasattr(mod2, "topk_indices_buffer"), "Module 2 should not have a buffer added.")
+
+    def test_run_merge_draft_mtp_skip_topk(self):
+        """Test the set_skip_topk calling logic in step 0 and step 1 of run_merge_draft."""
+        proposer = AscendEagleProposer.__new__(AscendEagleProposer)
+        proposer._share_mtp_indices = True
+
+        # Mock Draft Model and its set_skip_topk method
+        draft_model_mock = MagicMock()
+        proposer.model = MagicMock()
+        proposer.model.model = draft_model_mock
+
+        # Mock model inference return
+        proposer.model_returns_tuple = MagicMock(return_value=False)
+        proposer.model.return_value = MagicMock()
+
+        # Mock the run_merge_draft logic from your PR
+        # (Since this is a class method, we use an inner function to simulate and verify the core logic)
+        def mock_run_merge_draft(**model_kwargs):
+            # Step 0
+            draft_model = getattr(proposer.model, "model", None)
+            if proposer._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
+                draft_model.set_skip_topk(False)
+
+            # (Model inference...)
+            proposer.model(**model_kwargs)
+
+            # Step 1
+            if proposer._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
+                draft_model.set_skip_topk(True)
+
+        # Run the test
+        mock_run_merge_draft(input_ids=torch.tensor([1, 2, 3]))
+
+        # Assert calling conditions
+        self.assertTrue(draft_model_mock.set_skip_topk.called, "set_skip_topk should be called.")
+
+        # Verify calling order: False first, then True
+        calls = draft_model_mock.set_skip_topk.call_args_list
+        self.assertEqual(len(calls), 2, "set_skip_topk should be called exactly twice.")
+        self.assertEqual(calls[0][0][0], False, "Step 0 should call set_skip_topk(False).")
+        self.assertEqual(calls[1][0][0], True, "Step 1 should call set_skip_topk(True).")

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -170,6 +170,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         )
 
         self.use_sparse = hasattr(vllm_config.model_config.hf_text_config, "index_topk")
+
+        self._share_mtp_indices = False
+        spec_config = self.vllm_config.speculative_config
+        draft_model_config = getattr(spec_config, "draft_model_config", None)
+        draft_hf_config = draft_model_config.hf_config if draft_model_config is not None else None
+        self._share_mtp_indices = getattr(draft_hf_config, "index_share_for_mtp_iteration", False)
+
         # NOTE:
         # `draft_tensor_parallel_size` does not take effect for Eagle:
         # the draft model uses the same TP size as the target model in practice.
@@ -468,6 +475,12 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "[spec_decode/base] Detected MTP model with topk_indices_buffer."
                 " Sharing target model topk_indices_buffer with the draft model."
             )
+            target_buffer = target_language_model.model.topk_indices_buffer
+            draft_model = getattr(self.model, "model", None)
+            if target_buffer is not None and draft_model is not None:
+                for _, module in draft_model.named_modules():
+                    if hasattr(module, "topk_indices_buffer"):
+                        module.topk_indices_buffer = target_buffer
 
     def get_model(self) -> nn.Module:
         # get raw model out of the aclgraph wrapper.
@@ -1027,12 +1040,22 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 if self.method == "mtp":
                     model_kwargs["positions"] = model_positions
 
+        # step 0
+        draft_model = getattr(self.model, "model", None)
+        if self._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
+            draft_model.set_skip_topk(False)
+
         ret_hidden_states = self.model(**model_kwargs)
         if not self.model_returns_tuple():
             last_hidden_states = ret_hidden_states
             hidden_states = last_hidden_states
         else:
             last_hidden_states, hidden_states = ret_hidden_states
+
+        # step 1+ skip indexer
+        draft_model = getattr(self.model, "model", None)
+        if self._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
+            draft_model.set_skip_topk(True)
 
         if self.method != "dflash":
             last_hidden_states, model_positions, hidden_states = self.maybe_all_gather_and_unpad(


### PR DESCRIPTION

### What this PR does / why we need it?
This PR aligns the Ascend backend with the upstream implementation of IndexCache top-k index reuse for DeepSeek Sparse MLA's MTP Layer, inspired by IndexCache: Accelerating Sparse Attention via Cross-Layer Index Reuse.{GLM5.2}
vllm PR: https://github.com/vllm-project/vllm/pull/44420/changes

### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
vllm serve /home/jjz/mnt/GLM-5.2-0610-Provider
--host 0.0.0.0
--port 8077
--data-parallel-size 1
--tensor-parallel-size 16
--enable-expert-parallel
--seed 1024
--served-model-name glm-5
--max-num-seqs 16
--max-model-len 40960
--max-num-batched-tokens 4096
--trust-remote-code
--gpu-memory-utilization 0.95
--enable-chunked-prefill
--enable-prefix-caching
--additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true, "ascend_compilation_config": {"enable_npugraph_ex": true}}'
--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
--speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
