### PR TITLE
[Attention] [BugFix]Enable multistream_dsv4_dsa_overlap and remove redundant code

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -101,6 +101,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `enable_transpose_kv_cache_by_block`| bool | `True`  | Whether to enable transpose KV cache by block. Can also be configured via `VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK` environment variable (deprecated). |
 | `enable_dsa_cp`                     | bool | `False` | Whether to enable dsa_cp for DeepSeek V3.2, DeepSeek V4, and other models with the same architecture. This feature depends on FLASHCOMM1. Please ensure that FLASHCOMM1 is enabled before enabling this feature.|
 | `rejection_sampler_config`          | dict | `{}`    | Configuration options for rejection sampler (block verify and entropy verify). |
+| `multistream_dsv4_dsa_overlap`      | bool | `True`  | Whether to enable dsa multi-stream overlap for DeepSeek V4.  |
 
 The details of each configuration option are as follows:
 

--- a/tests/e2e/nightly/single_node/models/configs/DeepSeek-V4-Flash-W8A8-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/DeepSeek-V4-Flash-W8A8-A3.yaml
@@ -55,7 +55,7 @@ test_cases:
       - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       - "--async-scheduling"
       - "--additional-config"
-      - '{"ascend_compilation_config":{"enable_npugraph_ex":true,"enable_static_kernel":false},"enable_cpu_binding":"true","multistream_overlap_shared_expert":true,"multistream_dsa_preprocess":false}'
+      - '{"ascend_compilation_config":{"enable_npugraph_ex":true,"enable_static_kernel":false},"enable_cpu_binding":"true","enable_shared_expert_dp":true,"multistream_overlap_shared_expert":true}'
     benchmarks:
       acc-gpqa:
         case_type: accuracy

--- a/tests/e2e/pull_request/four_card/long_sequence/test_basic.py
+++ b/tests/e2e/pull_request/four_card/long_sequence/test_basic.py
@@ -144,7 +144,6 @@ def test_deepseek_v4_w4a8_dsa_cp_basic_greedy():
         additional_config={
             "enable_flashcomm1": True,
             "enable_dsa_cp": True,
-            "multistream_dsa_preprocess": True,
         },
     ) as runner:
         outputs = runner.generate_greedy(prompts, max_tokens)

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -140,10 +140,7 @@ class AscendConfig:
         # PD-disaggregated only (kv_producer/kv_consumer); invalid in PD-mixed (kv_both / no kv_transfer_config).
         self.recompute_scheduler_enable = additional_config.get("recompute_scheduler_enable", False)
         self.enable_cpu_binding = additional_config.get("enable_cpu_binding", True)
-        self.multistream_dsa_preprocess = additional_config.get("multistream_dsa_preprocess", False)
-        self.multistream_dsv4_dsa_overlap = additional_config.get("multistream_dsv4_dsa_overlap", False)
-        self.prefill_comm_compute_overlap = additional_config.get("prefill_comm_compute_overlap", False)
-
+        self.multistream_dsv4_dsa_overlap = additional_config.get("multistream_dsv4_dsa_overlap", True)
         self.enable_matmul_allreduce = self._get_config_value(
             additional_config,
             "enable_matmul_allreduce",

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -21,9 +21,7 @@ from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
 from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.utils import (
     AscendDeviceType,
-    attention_calculation_stream,
     get_ascend_device_type,
-    npu_stream_switch,
     olora_tp_enable,
 )
 

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1027,17 +1027,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             (swa_metadata,) = attn_metadata
         common_attn_metadata = attn_metadata[0]
 
-        overlap_hidden_states_allgather = self.multistream_dsa_preprocess and need_gather_q_kv
-        wait_hidden_states_local_event = (
-            torch.npu.current_stream().record_event() if overlap_hidden_states_allgather else None
-        )
-        with npu_stream_switch(attention_calculation_stream(), enabled=overlap_hidden_states_allgather):
-            if wait_hidden_states_local_event:
-                torch.npu.current_stream().wait_event(wait_hidden_states_local_event)
-            hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(hidden_states_local, need_gather_q_kv)
-            wait_hidden_states_allgather_event = (
-                torch.npu.current_stream().record_event() if overlap_hidden_states_allgather else None
-            )
+        hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(hidden_states_local, need_gather_q_kv)
 
         assert common_attn_metadata.req_metadata is not None
         assert swa_metadata.req_metadata is not None
@@ -1109,9 +1099,6 @@ class AscendDSACPImpl(DSAAttentionImpl):
             rotary_mode="interleave",
             partial_slice=[self.nope_head_dim, self.head_dim],
         )
-
-        if wait_hidden_states_allgather_event:
-            torch.npu.current_stream().wait_event(wait_hidden_states_allgather_event)
 
         kv = self.wkv(hidden_states)
         kv = self.kv_norm(kv)

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -922,7 +922,6 @@ class AscendDSACPImpl(DSAAttentionImpl):
         self.attn_sink = kwargs["attn_sink"]
 
         ascend_config = get_ascend_config()
-        self.multistream_dsa_preprocess = ascend_config.multistream_dsa_preprocess
 
         self.vllm_config = get_current_vllm_config()
 

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -12,7 +12,6 @@ from vllm.triton_utils import HAS_TRITON
 from vllm.v1.attention.backend import AttentionCGSupport, AttentionMetadataBuilder
 from vllm.v1.kv_cache_interface import AttentionSpec, MLAAttentionSpec
 
-from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
@@ -920,8 +919,6 @@ class AscendDSACPImpl(DSAAttentionImpl):
         self.eps = kwargs["eps"]
 
         self.attn_sink = kwargs["attn_sink"]
-
-        ascend_config = get_ascend_config()
 
         self.vllm_config = get_current_vllm_config()
 

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1841,7 +1841,14 @@ class AscendDSAImpl(DSAAttentionImpl):
                     bias=self.wq_b.bias,
                     output_dtype=hidden_states.dtype,
                 ).unflatten(-1, (self.n_local_heads, self.head_dim))
-                qr = self.q_norm(q_a) if self._indexer_should_prepare_fp_qr() else qr_quant
+                qr = (
+                    self.q_norm(q_a)
+                    if (
+                        self._indexer_should_prepare_fp_qr()
+                        and not self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale)
+                    )
+                    else qr_quant
+                )
             else:
                 qr = self.q_norm(q_a)
                 q = self.wq_b(qr).unflatten(-1, (self.n_local_heads, self.head_dim))
@@ -1947,6 +1954,8 @@ class AscendDSAImpl(DSAAttentionImpl):
                             actual_seq_lengths_query=actual_seq_lengths_query,
                             actual_seq_lengths_key=actual_seq_lengths_key,
                             with_prefill=True,
+                            qr_pertoken_scale=qr_pertoken_scale,
+                            qr_quant=qr_quant,
                         )
 
             coff = 2 if self.compressor_overlap else 1

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1521,8 +1521,23 @@ class AscendDSAImpl(DSAAttentionImpl):
     def _indexer_can_use_quantized_qr(
         self, qr_quant: torch.Tensor | None, qr_pertoken_scale: torch.Tensor | None
     ) -> bool:
+        is_w8a8_indexer_wq_b = _is_w8a8_dynamic(self.inderxer_wq_b)
         return (
-            _is_w8a8_dynamic(self.inderxer_wq_b)
+            is_w8a8_indexer_wq_b
+            and qr_quant is not None
+            and qr_pertoken_scale is not None
+            and get_ascend_device_type() not in {AscendDeviceType.A5}
+        )
+
+    def _indexer_should_prepare_fp_qr(self) -> bool:
+        return self.indexer is not None and self.compress_ratio == 4 and not self.skip_topk
+
+    def _indexer_can_use_quantized_qr(
+        self, qr_quant: torch.Tensor | None, qr_pertoken_scale: torch.Tensor | None
+    ) -> bool:
+        is_w8a8_indexer_wq_b = _is_w8a8_dynamic(self.inderxer_wq_b)
+        return (
+            is_w8a8_indexer_wq_b
             and qr_quant is not None
             and qr_pertoken_scale is not None
             and get_ascend_device_type() not in {AscendDeviceType.A5}
@@ -1666,7 +1681,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         main_stream = torch.npu.current_stream()
         aux_stream = dsv4_dsa_overlap_stream()
 
-        is_w8a8 = _is_w8a8_dynamic(self.wq_b)
+        is_w8a8_wq_b = _is_w8a8_dynamic(self.wq_b)
 
         # Part1: q_quant[V] -> q_a_down[C]  ||  kv_quant[V]
         q_quant, q_pertoken_scale = self.cv_wq_a.quantize(hidden_states)
@@ -1695,6 +1710,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             qr_pertoken_scale = None
         elif is_w8a8:
             qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+        elif is_w8a8_wq_b:
             qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                 wq_a_result, self.q_norm.weight, epsilon=self.eps
             )
@@ -1742,7 +1758,7 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         if is_prefill:
             q = self.cv_wq_b.matmul(q_b_quant, q_b_scale).unflatten(-1, (self.n_local_heads, self.head_dim))
-        elif is_w8a8:
+        elif is_w8a8_wq_b:
             q = torch_npu.npu_quant_matmul(
                 q_b_quant,
                 self.wq_b.weight,
@@ -1812,7 +1828,10 @@ class AscendDSAImpl(DSAAttentionImpl):
             )
         else:
             # mlaprolog
-            share_hs_quant = _is_w8a8_dynamic(self.wq_a) and _is_w8a8_dynamic(self.wkv)
+            is_w8a8_wq_a = _is_w8a8_dynamic(self.wq_a)
+            is_w8a8_wkv = _is_w8a8_dynamic(self.wkv)
+            is_w8a8_wq_b = _is_w8a8_dynamic(self.wq_b)
+            share_hs_quant = is_w8a8_wq_a and is_w8a8_wkv
             if share_hs_quant:
                 hs_int8, hs_pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
                 q_a = torch_npu.npu_quant_matmul(
@@ -1829,6 +1848,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             # q
             if _is_w8a8_dynamic(self.wq_b):
                 qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+            if is_w8a8_wq_b:
                 qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                     q_a, self.q_norm.weight, epsilon=self.eps
                 )
@@ -2133,14 +2153,16 @@ class AscendDSAImpl(DSAAttentionImpl):
             # Do nothing, because self.multistream_dsv4_dsa_overlap be true
             # Share one dynamic-quant of hidden_states between wq_a (main stream)
             # and wkv (attention stream) when both sides are W8A8 dynamic.
-            share_hs_quant = _is_w8a8_dynamic(self.wq_a) and _is_w8a8_dynamic(self.wkv)
+            is_w8a8_wq_a = _is_w8a8_dynamic(self.wq_a)
+            is_w8a8_wkv = _is_w8a8_dynamic(self.wkv)
+            is_w8a8_wq_b = _is_w8a8_dynamic(self.wq_b)
+            share_hs_quant = is_w8a8_wq_a and is_w8a8_wkv
             if share_hs_quant:
                 hs_int8, hs_pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
 
             # q
             qr_quant = None
-            qr_quant = None
-            if _is_w8a8_dynamic(self.wq_b):
+            if is_w8a8_wq_b:
                 if share_hs_quant:
                     q_a = torch_npu.npu_quant_matmul(
                         hs_int8,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1515,6 +1515,19 @@ class AscendDSAImpl(DSAAttentionImpl):
             and get_ascend_device_type() not in {AscendDeviceType.A5}
         )
 
+    def _indexer_should_prepare_fp_qr(self) -> bool:
+        return self.indexer is not None and self.compress_ratio == 4 and not self.skip_topk
+
+    def _indexer_can_use_quantized_qr(
+        self, qr_quant: torch.Tensor | None, qr_pertoken_scale: torch.Tensor | None
+    ) -> bool:
+        return (
+            _is_w8a8_dynamic(self.inderxer_wq_b)
+            and qr_quant is not None
+            and qr_pertoken_scale is not None
+            and get_ascend_device_type() not in {AscendDeviceType.A5}
+        )
+
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         pass
 
@@ -1675,13 +1688,24 @@ class AscendDSAImpl(DSAAttentionImpl):
             kv = self.cv_wkv.matmul(kv_quant, kv_pertoken_scale)
 
         qr_quant = None
+        qr_quant = None
         if is_prefill:
             qr = self.q_norm(wq_a_result)
             q_b_quant, q_b_scale = self.cv_wq_b.quantize(qr)
             qr_pertoken_scale = None
         elif is_w8a8:
             qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+            qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                 wq_a_result, self.q_norm.weight, epsilon=self.eps
+            )
+            q_b_quant, q_b_scale = qr_quant, qr_pertoken_scale
+            qr = (
+                self.q_norm(wq_a_result)
+                if (
+                    self._indexer_should_prepare_fp_qr()
+                    and not self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale)
+                )
+                else qr_quant
             )
             q_b_quant, q_b_scale = qr_quant, qr_pertoken_scale
             qr = (
@@ -1742,7 +1766,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             partial_slice=[self.nope_head_dim, self.head_dim],
         )
 
-        return q, qr, qr_pertoken_scale
+        return q, qr, qr_quant, qr_pertoken_scale
 
     def _forward_prefill(
         self,
@@ -1783,6 +1807,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         if self.multistream_dsv4_dsa_overlap:
             # mla prolog: q + kv dual-stream parallel
             q, qr, _, _ = self._mla_prolog_multistream(
+            q, qr, _, _ = self._mla_prolog_multistream(
                 hidden_states, cos, sin, swa_kv_cache, swa_prefill_metadata.slot_mapping, is_prefill=True
             )
         else:
@@ -1804,9 +1829,11 @@ class AscendDSAImpl(DSAAttentionImpl):
             # q
             if _is_w8a8_dynamic(self.wq_b):
                 qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+                qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                     q_a, self.q_norm.weight, epsilon=self.eps
                 )
                 q = torch_npu.npu_quant_matmul(
+                    qr_quant,
                     qr_quant,
                     self.wq_b.weight,
                     self.wq_b.weight_scale,
@@ -1814,14 +1841,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                     bias=self.wq_b.bias,
                     output_dtype=hidden_states.dtype,
                 ).unflatten(-1, (self.n_local_heads, self.head_dim))
-                qr = (
-                    self.q_norm(q_a)
-                    if (
-                        self._indexer_should_prepare_fp_qr()
-                        and not self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale)
-                    )
-                    else qr_quant
-                )
+                qr = self.q_norm(q_a) if self._indexer_should_prepare_fp_qr() else qr_quant
             else:
                 qr = self.q_norm(q_a)
                 q = self.wq_b(qr).unflatten(-1, (self.n_local_heads, self.head_dim))
@@ -1927,8 +1947,6 @@ class AscendDSAImpl(DSAAttentionImpl):
                             actual_seq_lengths_query=actual_seq_lengths_query,
                             actual_seq_lengths_key=actual_seq_lengths_key,
                             with_prefill=True,
-                            qr_pertoken_scale=qr_pertoken_scale,
-                            qr_quant=qr_quant,
                         )
 
             coff = 2 if self.compressor_overlap else 1
@@ -2099,6 +2117,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         if self.multistream_dsv4_dsa_overlap:
             # mla prolog: q + kv dual-stream parallel
             q, qr, qr_quant, qr_pertoken_scale = self._mla_prolog_multistream(
+            q, qr, qr_quant, qr_pertoken_scale = self._mla_prolog_multistream(
                 hidden_states, cos, sin, swa_kv_cache, swa_decode_metadata.slot_mapping, is_prefill=False
             )
         else:
@@ -2110,6 +2129,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 hs_int8, hs_pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
 
             # q
+            qr_quant = None
             qr_quant = None
             if _is_w8a8_dynamic(self.wq_b):
                 if share_hs_quant:
@@ -2124,9 +2144,11 @@ class AscendDSAImpl(DSAAttentionImpl):
                 else:
                     q_a = self.wq_a(hidden_states)
                 qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+                qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                     q_a, self.q_norm.weight, epsilon=self.eps
                 )
                 q = torch_npu.npu_quant_matmul(
+                    qr_quant,
                     qr_quant,
                     self.wq_b.weight,
                     self.wq_b.weight_scale,
@@ -2134,6 +2156,14 @@ class AscendDSAImpl(DSAAttentionImpl):
                     bias=self.wq_b.bias,
                     output_dtype=hidden_states.dtype,
                 ).unflatten(-1, (self.n_local_heads, self.head_dim))
+                qr = (
+                    self.q_norm(q_a)
+                    if (
+                        self._indexer_should_prepare_fp_qr()
+                        and not self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale)
+                    )
+                    else qr_quant
+                )
                 qr = (
                     self.q_norm(q_a)
                     if (
@@ -2221,6 +2251,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                             with_prefill=False,
                             qr_pertoken_scale=qr_pertoken_scale,
                             qr_quant=qr_quant,
+                            qr_quant=qr_quant,
                         )
                     else:
                         compress_topk_idxs = self.indexer_select_qli(  # original version
@@ -2236,6 +2267,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                             actual_seq_lengths_key=actual_seq_lengths_key,
                             with_prefill=False,
                             qr_pertoken_scale=qr_pertoken_scale,
+                            qr_quant=qr_quant,
                             qr_quant=qr_quant,
                         )
 
@@ -2395,6 +2427,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         with_prefill: bool = False,
         qr_pertoken_scale: torch.Tensor = None,
         qr_quant: torch.Tensor | None = None,
+        qr_quant: torch.Tensor | None = None,
     ):
         (indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
             DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
@@ -2408,7 +2441,9 @@ class AscendDSAImpl(DSAAttentionImpl):
         ) = attn_metadata
 
         if self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale):
+        if self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale):
             q = torch_npu.npu_quant_matmul(
+                qr_quant,
                 qr_quant,
                 self.inderxer_wq_b.weight,
                 self.inderxer_wq_b.weight_scale,
@@ -2590,6 +2625,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         with_prefill: bool = False,
         qr_pertoken_scale: torch.Tensor = None,
         qr_quant: torch.Tensor | None = None,
+        qr_quant: torch.Tensor | None = None,
     ):
         q, kv, ik, isc, ifc, indexer_kv_state_meta, isc_meta, wp = self._indexer_qkv_prepare(
             x,
@@ -2603,6 +2639,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             actual_seq_lengths_query,
             with_prefill,
             qr_pertoken_scale,
+            qr_quant,
             qr_quant,
         )
 
@@ -2623,6 +2660,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         actual_seq_lengths_query: torch.Tensor,
         with_prefill: bool = False,
         qr_pertoken_scale: torch.Tensor = None,
+        qr_quant: torch.Tensor | None = None,
         qr_quant: torch.Tensor | None = None,
     ):
         """
@@ -2646,6 +2684,9 @@ class AscendDSAImpl(DSAAttentionImpl):
         aux_stream = dsv4_dsa_overlap_stream()
 
         # ===== Part0: Pre-compute on main =====
+        use_quantized_qr = self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale)
+        if use_quantized_qr:
+            qr_quant_ready = qr_quant
         use_quantized_qr = self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale)
         if use_quantized_qr:
             qr_quant_ready = qr_quant
@@ -2710,6 +2751,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 )
 
         # Main: matmul q from qr (directly submit, V/C different engines dispatch naturally)
+        if use_quantized_qr:
         if use_quantized_qr:
             q = torch_npu.npu_quant_matmul(
                 qr_quant_ready,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1666,8 +1666,6 @@ class AscendDSAImpl(DSAAttentionImpl):
             qr_pertoken_scale = None
         elif is_w8a8:
             qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
-        elif is_w8a8:
-            qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                 wq_a_result, self.q_norm.weight, epsilon=self.eps
             )
             q_b_quant, q_b_scale = qr, qr_pertoken_scale
@@ -1779,8 +1777,6 @@ class AscendDSAImpl(DSAAttentionImpl):
                 q_a = self.wq_a(hidden_states)
 
             # q
-            if _is_w8a8_dynamic(self.wq_b):
-                qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
             if _is_w8a8_dynamic(self.wq_b):
                 qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                     q_a, self.q_norm.weight, epsilon=self.eps
@@ -2080,7 +2076,6 @@ class AscendDSAImpl(DSAAttentionImpl):
                 hs_int8, hs_pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
 
             # q
-            if _is_w8a8_dynamic(self.wq_b):
             if _is_w8a8_dynamic(self.wq_b):
                 if share_hs_quant:
                     q_a = torch_npu.npu_quant_matmul(

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1742,7 +1742,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             partial_slice=[self.nope_head_dim, self.head_dim],
         )
 
-        return q, qr, qr_quant, qr_pertoken_scale
+        return q, qr, qr_pertoken_scale
 
     def _forward_prefill(
         self,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1501,22 +1501,6 @@ class AscendDSAImpl(DSAAttentionImpl):
             topk_indices_to_cache = topk_indices_to_cache.squeeze(1)
         topk_indices_buffer.copy_(topk_indices_to_cache)
 
-    def _select_indexer_qr_after_dynamic_quant(
-        self,
-        q_a: torch.Tensor,
-        qr_quant: torch.Tensor,
-        qr_pertoken_scale: torch.Tensor,
-    ) -> torch.Tensor:
-        if self.indexer is None or self.compress_ratio != 4 or self.skip_topk:
-            return qr_quant
-        if (
-            _is_w8a8_dynamic(self.inderxer_wq_b)
-            and qr_pertoken_scale is not None
-            and get_ascend_device_type() not in {AscendDeviceType.A5}
-        ):
-            return qr_quant
-        return self.q_norm(q_a)
-
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         pass
 
@@ -1655,7 +1639,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         main_stream = torch.npu.current_stream()
         aux_stream = dsv4_dsa_overlap_stream()
 
-        is_w8a8_wq_b = _is_w8a8_dynamic(self.wq_b)
+        is_w8a8 = _is_w8a8_dynamic(self.wq_b)
 
         # Part1: q_quant[V] -> q_a_down[C]  ||  kv_quant[V]
         q_quant, q_pertoken_scale = self.cv_wq_a.quantize(hidden_states)
@@ -1682,10 +1666,11 @@ class AscendDSAImpl(DSAAttentionImpl):
             qr_pertoken_scale = None
         elif is_w8a8:
             qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+        elif is_w8a8:
+            qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                 wq_a_result, self.q_norm.weight, epsilon=self.eps
             )
             q_b_quant, q_b_scale = qr, qr_pertoken_scale
-            qr = self._select_indexer_qr_after_dynamic_quant(wq_a_result, qr, qr_pertoken_scale)
         else:
             qr = self.q_norm(wq_a_result)
             q_b_quant, q_b_scale = qr, None
@@ -1712,7 +1697,7 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         if is_prefill:
             q = self.cv_wq_b.matmul(q_b_quant, q_b_scale).unflatten(-1, (self.n_local_heads, self.head_dim))
-        elif is_w8a8_wq_b:
+        elif is_w8a8:
             q = torch_npu.npu_quant_matmul(
                 q_b_quant,
                 self.wq_b.weight,
@@ -1779,10 +1764,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             )
         else:
             # mlaprolog
-            is_w8a8_wq_a = _is_w8a8_dynamic(self.wq_a)
-            is_w8a8_wkv = _is_w8a8_dynamic(self.wkv)
-            is_w8a8_wq_b = _is_w8a8_dynamic(self.wq_b)
-            share_hs_quant = is_w8a8_wq_a and is_w8a8_wkv
+            share_hs_quant = _is_w8a8_dynamic(self.wq_a) and _is_w8a8_dynamic(self.wkv)
             if share_hs_quant:
                 hs_int8, hs_pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
                 q_a = torch_npu.npu_quant_matmul(
@@ -1799,6 +1781,8 @@ class AscendDSAImpl(DSAAttentionImpl):
             # q
             if _is_w8a8_dynamic(self.wq_b):
                 qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+            if _is_w8a8_dynamic(self.wq_b):
+                qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                     q_a, self.q_norm.weight, epsilon=self.eps
                 )
                 q = torch_npu.npu_quant_matmul(
@@ -1809,7 +1793,6 @@ class AscendDSAImpl(DSAAttentionImpl):
                     bias=self.wq_b.bias,
                     output_dtype=hidden_states.dtype,
                 ).unflatten(-1, (self.n_local_heads, self.head_dim))
-                qr = self._select_indexer_qr_after_dynamic_quant(q_a, qr, qr_pertoken_scale)
             else:
                 qr = self.q_norm(q_a)
                 q = self.wq_b(qr).unflatten(-1, (self.n_local_heads, self.head_dim))
@@ -2092,14 +2075,12 @@ class AscendDSAImpl(DSAAttentionImpl):
         else:
             # Share one dynamic-quant of hidden_states between wq_a (main stream)
             # and wkv (attention stream) when both sides are W8A8 dynamic.
-            is_w8a8_wq_a = _is_w8a8_dynamic(self.wq_a)
-            is_w8a8_wkv = _is_w8a8_dynamic(self.wkv)
-            is_w8a8_wq_b = _is_w8a8_dynamic(self.wq_b)
-            share_hs_quant = is_w8a8_wq_a and is_w8a8_wkv
+            share_hs_quant = _is_w8a8_dynamic(self.wq_a) and _is_w8a8_dynamic(self.wkv)
             if share_hs_quant:
                 hs_int8, hs_pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
 
             # q
+            if _is_w8a8_dynamic(self.wq_b):
             if _is_w8a8_dynamic(self.wq_b):
                 if share_hs_quant:
                     q_a = torch_npu.npu_quant_matmul(
@@ -2123,7 +2104,6 @@ class AscendDSAImpl(DSAAttentionImpl):
                     bias=self.wq_b.bias,
                     output_dtype=hidden_states.dtype,
                 ).unflatten(-1, (self.n_local_heads, self.head_dim))
-                qr = self._select_indexer_qr_after_dynamic_quant(q_a, qr, qr_pertoken_scale)
             else:
                 if share_hs_quant:
                     q_a = torch_npu.npu_quant_matmul(
@@ -2626,11 +2606,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         aux_stream = dsv4_dsa_overlap_stream()
 
         # ===== Part0: Pre-compute on main =====
-        if (
-            _is_w8a8_dynamic(self.inderxer_wq_b)
-            and qr_pertoken_scale is not None
-            and get_ascend_device_type() not in {AscendDeviceType.A5}
-        ):
+        if _is_w8a8_dynamic(self.inderxer_wq_b) and qr_pertoken_scale is not None:
             qr_quant_ready = qr
             qr_scale_ready = qr_pertoken_scale
         else:
@@ -2693,11 +2669,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 )
 
         # Main: matmul q from qr (directly submit, V/C different engines dispatch naturally)
-        if (
-            _is_w8a8_dynamic(self.inderxer_wq_b)
-            and qr_pertoken_scale is not None
-            and get_ascend_device_type() not in {AscendDeviceType.A5}
-        ):
+        if _is_w8a8_dynamic(self.inderxer_wq_b) and qr_pertoken_scale is not None:
             q = torch_npu.npu_quant_matmul(
                 qr_quant_ready,
                 self.inderxer_wq_b.weight,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -25,7 +25,6 @@ from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
 from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.utils import (
     AscendDeviceType,
-    attention_calculation_stream,
     get_ascend_device_type,
     npu_stream_switch,
     olora_tp_enable,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1778,6 +1778,8 @@ class AscendDSAImpl(DSAAttentionImpl):
         actual_seq_lengths_query = common_prefill_metadata.query_start_loc
         actual_seq_lengths_key = common_prefill_metadata.seq_lens
 
+        qr_quant = None
+        qr_pertoken_scale = None
         if self.multistream_dsv4_dsa_overlap:
             # mla prolog: q + kv dual-stream parallel
             q, qr, _, _ = self._mla_prolog_multistream(
@@ -1812,7 +1814,14 @@ class AscendDSAImpl(DSAAttentionImpl):
                     bias=self.wq_b.bias,
                     output_dtype=hidden_states.dtype,
                 ).unflatten(-1, (self.n_local_heads, self.head_dim))
-                qr = self.q_norm(q_a) if self._indexer_should_prepare_fp_qr() else qr_quant
+                qr = (
+                    self.q_norm(q_a)
+                    if (
+                        self._indexer_should_prepare_fp_qr()
+                        and not self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale)
+                    )
+                    else qr_quant
+                )
             else:
                 qr = self.q_norm(q_a)
                 q = self.wq_b(qr).unflatten(-1, (self.n_local_heads, self.head_dim))
@@ -1918,6 +1927,8 @@ class AscendDSAImpl(DSAAttentionImpl):
                             actual_seq_lengths_query=actual_seq_lengths_query,
                             actual_seq_lengths_key=actual_seq_lengths_key,
                             with_prefill=True,
+                            qr_pertoken_scale=qr_pertoken_scale,
+                            qr_quant=qr_quant,
                         )
 
             coff = 2 if self.compressor_overlap else 1

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1502,46 +1502,39 @@ class AscendDSAImpl(DSAAttentionImpl):
             topk_indices_to_cache = topk_indices_to_cache.squeeze(1)
         topk_indices_buffer.copy_(topk_indices_to_cache)
 
-    def _indexer_should_prepare_fp_qr(self) -> bool:
-        return self.indexer is not None and self.compress_ratio == 4 and not self.skip_topk
+    def _select_qr_after_dynamic_quant(
+        self,
+        q_a: torch.Tensor,
+        qr_quant: torch.Tensor,
+        qr_pertoken_scale: torch.Tensor,
+    ) -> torch.Tensor:
+        """Choose whether downstream should see quantized or fp qr.
+        Layers without an active indexer keep the fused
+        npu_rms_norm_dynamic_quant result. Only an active indexer may require
+        fp qr, and only when it cannot consume the quantized qr directly.
+        """
+        if self.indexer is None or self.compress_ratio != 4 or self.skip_topk:
+            return qr_quant
 
-    def _indexer_can_use_quantized_qr(
-        self, qr_quant: torch.Tensor | None, qr_pertoken_scale: torch.Tensor | None
-    ) -> bool:
-        return (
-            _is_w8a8_dynamic(self.inderxer_wq_b)
+        indexer_can_reuse_quantized_qr = (
+            _is_w8a8_dynamic(self.wq_b)
+            and _is_w8a8_dynamic(self.inderxer_wq_b)
             and qr_quant is not None
             and qr_pertoken_scale is not None
             and get_ascend_device_type() not in {AscendDeviceType.A5}
         )
+        if indexer_can_reuse_quantized_qr:
+            return qr_quant
 
-    def _indexer_should_prepare_fp_qr(self) -> bool:
-        return self.indexer is not None and self.compress_ratio == 4 and not self.skip_topk
+        return self.q_norm(q_a)
 
-    def _indexer_can_use_quantized_qr(
-        self, qr_quant: torch.Tensor | None, qr_pertoken_scale: torch.Tensor | None
+    def _is_quantized_qr_selected(
+        self,
+        qr: torch.Tensor,
+        qr_quant: torch.Tensor | None,
+        qr_pertoken_scale: torch.Tensor | None,
     ) -> bool:
-        is_w8a8_indexer_wq_b = _is_w8a8_dynamic(self.inderxer_wq_b)
-        return (
-            is_w8a8_indexer_wq_b
-            and qr_quant is not None
-            and qr_pertoken_scale is not None
-            and get_ascend_device_type() not in {AscendDeviceType.A5}
-        )
-
-    def _indexer_should_prepare_fp_qr(self) -> bool:
-        return self.indexer is not None and self.compress_ratio == 4 and not self.skip_topk
-
-    def _indexer_can_use_quantized_qr(
-        self, qr_quant: torch.Tensor | None, qr_pertoken_scale: torch.Tensor | None
-    ) -> bool:
-        is_w8a8_indexer_wq_b = _is_w8a8_dynamic(self.inderxer_wq_b)
-        return (
-            is_w8a8_indexer_wq_b
-            and qr_quant is not None
-            and qr_pertoken_scale is not None
-            and get_ascend_device_type() not in {AscendDeviceType.A5}
-        )
+        return qr_quant is not None and qr_pertoken_scale is not None and qr is qr_quant
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         pass
@@ -1715,23 +1708,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 wq_a_result, self.q_norm.weight, epsilon=self.eps
             )
             q_b_quant, q_b_scale = qr_quant, qr_pertoken_scale
-            qr = (
-                self.q_norm(wq_a_result)
-                if (
-                    self._indexer_should_prepare_fp_qr()
-                    and not self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale)
-                )
-                else qr_quant
-            )
-            q_b_quant, q_b_scale = qr_quant, qr_pertoken_scale
-            qr = (
-                self.q_norm(wq_a_result)
-                if (
-                    self._indexer_should_prepare_fp_qr()
-                    and not self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale)
-                )
-                else qr_quant
-            )
+            qr = self._select_qr_after_dynamic_quant(wq_a_result, qr_quant, qr_pertoken_scale)
         else:
             qr = self.q_norm(wq_a_result)
             q_b_quant, q_b_scale = qr, None
@@ -1861,14 +1838,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                     bias=self.wq_b.bias,
                     output_dtype=hidden_states.dtype,
                 ).unflatten(-1, (self.n_local_heads, self.head_dim))
-                qr = (
-                    self.q_norm(q_a)
-                    if (
-                        self._indexer_should_prepare_fp_qr()
-                        and not self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale)
-                    )
-                    else qr_quant
-                )
+                qr = self._select_qr_after_dynamic_quant(q_a, qr_quant, qr_pertoken_scale)
             else:
                 qr = self.q_norm(q_a)
                 q = self.wq_b(qr).unflatten(-1, (self.n_local_heads, self.head_dim))
@@ -2150,7 +2120,6 @@ class AscendDSAImpl(DSAAttentionImpl):
                 hidden_states, cos, sin, swa_kv_cache, swa_decode_metadata.slot_mapping, is_prefill=False
             )
         else:
-            # Do nothing, because self.multistream_dsv4_dsa_overlap be true
             # Share one dynamic-quant of hidden_states between wq_a (main stream)
             # and wkv (attention stream) when both sides are W8A8 dynamic.
             is_w8a8_wq_a = _is_w8a8_dynamic(self.wq_a)
@@ -2187,22 +2156,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                     bias=self.wq_b.bias,
                     output_dtype=hidden_states.dtype,
                 ).unflatten(-1, (self.n_local_heads, self.head_dim))
-                qr = (
-                    self.q_norm(q_a)
-                    if (
-                        self._indexer_should_prepare_fp_qr()
-                        and not self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale)
-                    )
-                    else qr_quant
-                )
-                qr = (
-                    self.q_norm(q_a)
-                    if (
-                        self._indexer_should_prepare_fp_qr()
-                        and not self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale)
-                    )
-                    else qr_quant
-                )
+                qr = self._select_qr_after_dynamic_quant(q_a, qr_quant, qr_pertoken_scale)
             else:
                 if share_hs_quant:
                     q_a = torch_npu.npu_quant_matmul(
@@ -2471,8 +2425,8 @@ class AscendDSAImpl(DSAAttentionImpl):
             _,
         ) = attn_metadata
 
-        if self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale):
-        if self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale):
+        use_quantized_qr = self._is_quantized_qr_selected(qr, qr_quant, qr_pertoken_scale)
+        if use_quantized_qr:
             q = torch_npu.npu_quant_matmul(
                 qr_quant,
                 qr_quant,
@@ -2715,10 +2669,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         aux_stream = dsv4_dsa_overlap_stream()
 
         # ===== Part0: Pre-compute on main =====
-        use_quantized_qr = self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale)
-        if use_quantized_qr:
-            qr_quant_ready = qr_quant
-        use_quantized_qr = self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale)
+        use_quantized_qr = self._is_quantized_qr_selected(qr, qr_quant, qr_pertoken_scale)
         if use_quantized_qr:
             qr_quant_ready = qr_quant
             qr_scale_ready = qr_pertoken_scale

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1435,9 +1435,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         self.attn_sink = kwargs["attn_sink"]
 
         ascend_config = get_ascend_config()
-        self.multistream_dsa_preprocess = ascend_config.multistream_dsa_preprocess
         self.multistream_dsv4_dsa_overlap = ascend_config.multistream_dsv4_dsa_overlap
-        self.prefill_comm_compute_overlap = ascend_config.prefill_comm_compute_overlap
         self.vllm_config = get_current_vllm_config()
 
         # indexer param
@@ -1484,51 +1482,6 @@ class AscendDSAImpl(DSAAttentionImpl):
             False,
         )
 
-    def dsa_warmup_with_multistream(self, hidden_states: torch.Tensor) -> None:
-        """
-        Warmup function for DSA profiling run.
-        When dual-stream is enabled, the aux stream runs ops during forward that have never been
-        exercised during profiling. This warmup ensures all aux-stream op patterns are captured
-        for ACL graph compatibility.
-        """
-        if hasattr(self, "multistream_dsv4_dsa_overlap") and self.multistream_dsv4_dsa_overlap:
-            hidden_states_dummy = torch.zeros(
-                1, hidden_states.shape[-1], dtype=hidden_states.dtype, device=hidden_states.device
-            )
-            aux_stream = dsv4_dsa_overlap_stream()
-            e_warmup = torch.npu.current_stream().record_event()
-            with npu_stream_switch(aux_stream, enabled=True):
-                torch.npu.current_stream().wait_event(e_warmup)
-                if hasattr(self.wkv, "weight_scale") and self.wkv.weight.dtype == torch.int8:
-                    kv_q_dummy, kv_s_dummy = torch_npu.npu_dynamic_quant(hidden_states_dummy)
-                    _ = torch_npu.npu_quant_matmul(
-                        kv_q_dummy,
-                        self.wkv.weight,
-                        self.wkv.weight_scale,
-                        pertoken_scale=kv_s_dummy,
-                        output_dtype=hidden_states.dtype,
-                    )
-                else:
-                    _ = self.cv_wkv.quantize(hidden_states_dummy)
-                    _ = self.cv_wkv.matmul(hidden_states_dummy, None)
-                assert self.rope_head_dim is not None
-                kv_dummy = torch.zeros(
-                    1, self.nope_head_dim + self.rope_head_dim, dtype=hidden_states.dtype, device=hidden_states.device
-                )
-                _ = self.kv_norm(kv_dummy)
-
-                # indexer module aux stream ops
-                # Part1 aux: kv_quant + scatter (device-dispatched via DeviceOperator)
-                # In profiling stage, create dummy tensors to ensure ACL graph captures scatter operator.
-                if self.compress_ratio == 4 and self.indexer is not None:
-                    slot_mapping_dummy = torch.zeros(1, dtype=torch.int64, device=hidden_states.device)
-                    DeviceOperator.warmup_indexer_quant_scatter(hidden_states_dummy, slot_mapping_dummy)
-
-                    # Warm up weights_proj on the aux stream.
-                    _ = self.weights_proj(hidden_states_dummy)
-
-            torch.npu.current_stream().wait_stream(aux_stream)
-
     def _get_indexcache_topk_indices(self, num_tokens: int, offset: int = 0) -> torch.Tensor:
         if self.topk_indices_buffer is None:
             raise RuntimeError("IndexCache requires topk_indices_buffer when skip_topk is enabled.")
@@ -1548,6 +1501,19 @@ class AscendDSAImpl(DSAAttentionImpl):
             assert topk_indices_to_cache.shape[1] == 1
             topk_indices_to_cache = topk_indices_to_cache.squeeze(1)
         topk_indices_buffer.copy_(topk_indices_to_cache)
+
+    def _indexer_should_prepare_fp_qr(self) -> bool:
+        return self.indexer is not None and self.compress_ratio == 4 and not self.skip_topk
+
+    def _indexer_can_use_quantized_qr(
+        self, qr_quant: torch.Tensor | None, qr_pertoken_scale: torch.Tensor | None
+    ) -> bool:
+        return (
+            _is_w8a8_dynamic(self.inderxer_wq_b)
+            and qr_quant is not None
+            and qr_pertoken_scale is not None
+            and get_ascend_device_type() not in {AscendDeviceType.A5}
+        )
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         pass
@@ -1592,25 +1558,10 @@ class AscendDSAImpl(DSAAttentionImpl):
         decode_tokens = attn_metadata[0].num_decode_tokens
         actual_tokens = attn_metadata[0].num_actual_tokens
 
-        # Delay allgather optimization: when prefill_comm_compute_overlap is
-        # enabled and the batch is pure-prefill, wq_a/wkv can compute on the
-        # local SP partition first, then allgather smaller intermediates.
-        # Mutually exclusive with multistream_dsv4_dsa_overlap (multistream wins).
-        need_prefill_gather = (
-            self.prefill_comm_compute_overlap
-            and not self.multistream_dsv4_dsa_overlap
-            and need_gather_q_kv
-            and has_prefill
-            and not has_decode
-        )
-        if need_prefill_gather:
-            prefill_hidden_states = hidden_states
-            decode_hidden_states = hidden_states[:0]
-        else:
-            # Process for Flash Comm V1
-            hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(hidden_states, need_gather_q_kv)
-            prefill_hidden_states = hidden_states[decode_tokens:actual_tokens]
-            decode_hidden_states = hidden_states[:decode_tokens]
+        # Process for Flash Comm V1
+        hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(hidden_states, need_gather_q_kv)
+        prefill_hidden_states = hidden_states[decode_tokens:actual_tokens]
+        decode_hidden_states = hidden_states[:decode_tokens]
 
         forward_context = get_forward_context()
         o_proj_input_shape = (forward_context.num_tokens, self.n_local_heads, self.head_dim)
@@ -1623,7 +1574,6 @@ class AscendDSAImpl(DSAAttentionImpl):
                 prefill_hidden_states,
                 kv_cache,
                 attn_metadata,
-                need_prefill_gather,
             )  # type: ignore[arg-type]
             o_proj_input[decode_tokens:actual_tokens] = output_prefill
             cos = attn_metadata[0].prefill.cos[layer_name]
@@ -1724,15 +1674,24 @@ class AscendDSAImpl(DSAAttentionImpl):
             torch.npu.current_stream().wait_event(e_part2_start)
             kv = self.cv_wkv.matmul(kv_quant, kv_pertoken_scale)
 
+        qr_quant = None
         if is_prefill:
             qr = self.q_norm(wq_a_result)
             q_b_quant, q_b_scale = self.cv_wq_b.quantize(qr)
             qr_pertoken_scale = None
         elif is_w8a8:
-            qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+            qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                 wq_a_result, self.q_norm.weight, epsilon=self.eps
             )
-            q_b_quant, q_b_scale = qr, qr_pertoken_scale
+            q_b_quant, q_b_scale = qr_quant, qr_pertoken_scale
+            qr = (
+                self.q_norm(wq_a_result)
+                if (
+                    self._indexer_should_prepare_fp_qr()
+                    and not self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale)
+                )
+                else qr_quant
+            )
         else:
             qr = self.q_norm(wq_a_result)
             q_b_quant, q_b_scale = qr, None
@@ -1783,85 +1742,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             partial_slice=[self.nope_head_dim, self.head_dim],
         )
 
-        return q, qr, qr_pertoken_scale
-
-    def _mla_prolog_prefill_overlap(self, hidden_states, cos, sin, swa_kv_cache, slot_mapping):
-        """Delayed allgather + compute-communication overlap for pure prefill.
-
-        hidden_states: [N/tp, dim] local SP partition.
-        Returns: (q, qr, full_hidden_states)
-          - q: [actual_tokens, n_local_heads, head_dim] with RoPE applied
-          - qr: [actual_tokens, q_lora_rank] for indexer
-          - full_hidden_states: [actual_tokens, dim] for compressor
-        """
-        main_stream = torch.npu.current_stream()
-        aux_stream = dsv4_dsa_overlap_stream()
-        num_actual_tokens = cos.shape[0]
-
-        # === Phase 1: q_a_down [main/C] || kv_quant [aux/V] ===
-        q_quant, q_pertoken_scale = self.cv_wq_a.quantize(hidden_states)
-        e_phase1 = main_stream.record_event()
-
-        with npu_stream_switch(aux_stream, enabled=True):
-            torch.npu.current_stream().wait_event(e_phase1)
-            kv_quant, kv_pertoken_scale = self.cv_wkv.quantize(hidden_states)
-
-        main_stream.wait_stream(aux_stream)
-        q_a_down = self.cv_wq_a.matmul(q_quant, q_pertoken_scale)
-        qr = self.q_norm(q_a_down)
-
-        # === Phase 2: allgather(qr) [main/comm] || kv_proj + kv_norm [aux/compute] ===
-        e_phase2 = main_stream.record_event()
-
-        with npu_stream_switch(aux_stream, enabled=True):
-            torch.npu.current_stream().wait_event(e_phase2)
-            kv = self.cv_wkv.matmul(kv_quant, kv_pertoken_scale)
-            kv = self.kv_norm(kv)
-
-        qr = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(qr, True)
-        qr = qr[:num_actual_tokens]
-        main_stream.wait_stream(aux_stream)
-
-        # === Phase 3: allgather(kv)+allgather(hs) [main/comm] || wq_b+q_rms [aux/compute] ===
-        e_phase3 = main_stream.record_event()
-
-        with npu_stream_switch(aux_stream, enabled=True):
-            torch.npu.current_stream().wait_event(e_phase3)
-            q_b_quant, q_b_scale = self.cv_wq_b.quantize(qr)
-            q = self.cv_wq_b.matmul(q_b_quant, q_b_scale).unflatten(-1, (self.n_local_heads, self.head_dim))
-            q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
-
-        kv = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(kv, True)
-        kv = kv[:num_actual_tokens]
-        if self.compress_ratio > 1:
-            full_hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(hidden_states, True)
-            full_hidden_states = full_hidden_states[:num_actual_tokens]
-        else:
-            full_hidden_states = hidden_states
-
-        main_stream.wait_stream(aux_stream)
-
-        # === Tail: q_rope + kv_rope + scatter (main stream, serial) ===
-        torch.ops._C_ascend.inplace_partial_rotary_mul(
-            q.unsqueeze(1),
-            cos,
-            sin,
-            rotary_mode="interleave",
-            partial_slice=[self.nope_head_dim, self.head_dim],
-        )
-
-        assert self.rope_head_dim is not None
-        kv = kv.view(-1, 1, self.nope_head_dim + self.rope_head_dim)
-        torch.ops._C_ascend.inplace_partial_rotary_mul(
-            kv.unsqueeze(1),
-            cos,
-            sin,
-            rotary_mode="interleave",
-            partial_slice=[self.nope_head_dim, self.head_dim],
-        )
-        DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, slot_mapping)
-
-        return q, qr, full_hidden_states
+        return q, qr, qr_quant, qr_pertoken_scale
 
     def _forward_prefill(
         self,
@@ -1869,7 +1750,6 @@ class AscendDSAImpl(DSAAttentionImpl):
         hidden_states: torch.Tensor,
         kv_cache: tuple[torch.Tensor, ...],
         attn_metadata: DSAMetadataList,
-        need_prefill_gather: bool = False,
     ):
         compress_common_attn_metadata = None
         (compress_kv_cache, swa_kv_cache, state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
@@ -1900,20 +1780,9 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         if self.multistream_dsv4_dsa_overlap:
             # mla prolog: q + kv dual-stream parallel
-            q, qr, _ = self._mla_prolog_multistream(
+            q, qr, _, _ = self._mla_prolog_multistream(
                 hidden_states, cos, sin, swa_kv_cache, swa_prefill_metadata.slot_mapping, is_prefill=True
             )
-        elif need_prefill_gather:
-            # Delayed allgather + compute-communication overlap
-            assert swa_metadata.prefill is not None
-            q, qr, hidden_states = self._mla_prolog_prefill_overlap(
-                hidden_states,
-                cos,
-                sin,
-                swa_kv_cache,
-                swa_prefill_metadata.slot_mapping,
-            )
-            qr_pertoken_scale = None  # noqa: F841
         else:
             # mlaprolog
             share_hs_quant = _is_w8a8_dynamic(self.wq_a) and _is_w8a8_dynamic(self.wkv)
@@ -1932,21 +1801,21 @@ class AscendDSAImpl(DSAAttentionImpl):
 
             # q
             if _is_w8a8_dynamic(self.wq_b):
-                qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+                qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                     q_a, self.q_norm.weight, epsilon=self.eps
                 )
                 q = torch_npu.npu_quant_matmul(
-                    qr,
+                    qr_quant,
                     self.wq_b.weight,
                     self.wq_b.weight_scale,
                     pertoken_scale=qr_pertoken_scale,
                     bias=self.wq_b.bias,
                     output_dtype=hidden_states.dtype,
                 ).unflatten(-1, (self.n_local_heads, self.head_dim))
+                qr = self.q_norm(q_a) if self._indexer_should_prepare_fp_qr() else qr_quant
             else:
                 qr = self.q_norm(q_a)
                 q = self.wq_b(qr).unflatten(-1, (self.n_local_heads, self.head_dim))
-                qr_pertoken_scale = None
             q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
 
             torch.ops._C_ascend.inplace_partial_rotary_mul(
@@ -2035,7 +1904,6 @@ class AscendDSAImpl(DSAAttentionImpl):
                             compressed_sin=compress_sin,
                             actual_seq_lengths_query=actual_seq_lengths_query,
                             with_prefill=True,
-                            qr_pertoken_scale=qr_pertoken_scale,
                         )
                     else:
                         compress_topk_idxs = self.indexer_select_qli(  # original version
@@ -2050,7 +1918,6 @@ class AscendDSAImpl(DSAAttentionImpl):
                             actual_seq_lengths_query=actual_seq_lengths_query,
                             actual_seq_lengths_key=actual_seq_lengths_key,
                             with_prefill=True,
-                            qr_pertoken_scale=qr_pertoken_scale,
                         )
 
             coff = 2 if self.compressor_overlap else 1
@@ -2220,21 +2087,19 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         if self.multistream_dsv4_dsa_overlap:
             # mla prolog: q + kv dual-stream parallel
-            q, qr, qr_pertoken_scale = self._mla_prolog_multistream(
+            q, qr, qr_quant, qr_pertoken_scale = self._mla_prolog_multistream(
                 hidden_states, cos, sin, swa_kv_cache, swa_decode_metadata.slot_mapping, is_prefill=False
             )
         else:
+            # Do nothing, because self.multistream_dsv4_dsa_overlap be true
             # Share one dynamic-quant of hidden_states between wq_a (main stream)
             # and wkv (attention stream) when both sides are W8A8 dynamic.
             share_hs_quant = _is_w8a8_dynamic(self.wq_a) and _is_w8a8_dynamic(self.wkv)
             if share_hs_quant:
                 hs_int8, hs_pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
 
-            wait_hidden_state_cal_event = (
-                torch.npu.current_stream().record_event() if self.multistream_dsa_preprocess else None
-            )
-
             # q
+            qr_quant = None
             if _is_w8a8_dynamic(self.wq_b):
                 if share_hs_quant:
                     q_a = torch_npu.npu_quant_matmul(
@@ -2247,17 +2112,25 @@ class AscendDSAImpl(DSAAttentionImpl):
                     )
                 else:
                     q_a = self.wq_a(hidden_states)
-                qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+                qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                     q_a, self.q_norm.weight, epsilon=self.eps
                 )
                 q = torch_npu.npu_quant_matmul(
-                    qr,
+                    qr_quant,
                     self.wq_b.weight,
                     self.wq_b.weight_scale,
                     pertoken_scale=qr_pertoken_scale,
                     bias=self.wq_b.bias,
                     output_dtype=hidden_states.dtype,
                 ).unflatten(-1, (self.n_local_heads, self.head_dim))
+                qr = (
+                    self.q_norm(q_a)
+                    if (
+                        self._indexer_should_prepare_fp_qr()
+                        and not self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale)
+                    )
+                    else qr_quant
+                )
             else:
                 if share_hs_quant:
                     q_a = torch_npu.npu_quant_matmul(
@@ -2284,43 +2157,32 @@ class AscendDSAImpl(DSAAttentionImpl):
                 partial_slice=[self.nope_head_dim, self.head_dim],
             )
 
-            with npu_stream_switch(attention_calculation_stream(), enabled=self.multistream_dsa_preprocess):
-                if wait_hidden_state_cal_event:
-                    torch.npu.current_stream().wait_event(wait_hidden_state_cal_event)
-
-                # win kv & tok_dis
-                if share_hs_quant:
-                    kv = torch_npu.npu_quant_matmul(
-                        hs_int8,
-                        self.wkv.weight,
-                        self.wkv.weight_scale,
-                        pertoken_scale=hs_pertoken_scale,
-                        bias=self.wkv.bias,
-                        output_dtype=hidden_states.dtype,
-                    )
-                else:
-                    kv = self.wkv(hidden_states)
-                kv = self.kv_norm(kv)
-                assert self.rope_head_dim is not None
-                kv = kv.view(-1, 1, self.nope_head_dim + self.rope_head_dim)
-
-                torch.ops._C_ascend.inplace_partial_rotary_mul(
-                    kv.unsqueeze(1),
-                    cos,
-                    sin,
-                    rotary_mode="interleave",
-                    partial_slice=[self.nope_head_dim, self.head_dim],
+            # win kv & tok_dis
+            if share_hs_quant:
+                kv = torch_npu.npu_quant_matmul(
+                    hs_int8,
+                    self.wkv.weight,
+                    self.wkv.weight_scale,
+                    pertoken_scale=hs_pertoken_scale,
+                    bias=self.wkv.bias,
+                    output_dtype=hidden_states.dtype,
                 )
+            else:
+                kv = self.wkv(hidden_states)
+            kv = self.kv_norm(kv)
+            assert self.rope_head_dim is not None
+            kv = kv.view(-1, 1, self.nope_head_dim + self.rope_head_dim)
 
-                # swa exec kv
-                DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, swa_decode_metadata.slot_mapping)
+            torch.ops._C_ascend.inplace_partial_rotary_mul(
+                kv.unsqueeze(1),
+                cos,
+                sin,
+                rotary_mode="interleave",
+                partial_slice=[self.nope_head_dim, self.head_dim],
+            )
 
-                wait_attention_cal_event = (
-                    torch.npu.current_stream().record_event() if self.multistream_dsa_preprocess else None
-                )
-
-            if wait_attention_cal_event:
-                torch.npu.current_stream().wait_event(wait_attention_cal_event)
+            # swa exec kv
+            DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, swa_decode_metadata.slot_mapping)
 
         if self.compress_ratio > 1:
             compressor_decode_metadata = _require_decode_metadata(compressor_attn_metadata)
@@ -2347,6 +2209,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                             actual_seq_lengths_query=actual_seq_lengths_query,
                             with_prefill=False,
                             qr_pertoken_scale=qr_pertoken_scale,
+                            qr_quant=qr_quant,
                         )
                     else:
                         compress_topk_idxs = self.indexer_select_qli(  # original version
@@ -2362,6 +2225,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                             actual_seq_lengths_key=actual_seq_lengths_key,
                             with_prefill=False,
                             qr_pertoken_scale=qr_pertoken_scale,
+                            qr_quant=qr_quant,
                         )
 
             coff = 2 if self.compressor_overlap else 1
@@ -2519,6 +2383,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         actual_seq_lengths_query: torch.Tensor,
         with_prefill: bool = False,
         qr_pertoken_scale: torch.Tensor = None,
+        qr_quant: torch.Tensor | None = None,
     ):
         (indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
             DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
@@ -2531,13 +2396,9 @@ class AscendDSAImpl(DSAAttentionImpl):
             _,
         ) = attn_metadata
 
-        if (
-            _is_w8a8_dynamic(self.inderxer_wq_b)
-            and qr_pertoken_scale is not None
-            and get_ascend_device_type() not in {AscendDeviceType.A5}
-        ):
+        if self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale):
             q = torch_npu.npu_quant_matmul(
-                qr,
+                qr_quant,
                 self.inderxer_wq_b.weight,
                 self.inderxer_wq_b.weight_scale,
                 pertoken_scale=qr_pertoken_scale,
@@ -2717,6 +2578,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         actual_seq_lengths_key: torch.Tensor | None = None,
         with_prefill: bool = False,
         qr_pertoken_scale: torch.Tensor = None,
+        qr_quant: torch.Tensor | None = None,
     ):
         q, kv, ik, isc, ifc, indexer_kv_state_meta, isc_meta, wp = self._indexer_qkv_prepare(
             x,
@@ -2730,6 +2592,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             actual_seq_lengths_query,
             with_prefill,
             qr_pertoken_scale,
+            qr_quant,
         )
 
         weights = self.weights_proj(x) * (self.indexer_softmax_scale * self.indexer_heads**-0.5)
@@ -2749,6 +2612,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         actual_seq_lengths_query: torch.Tensor,
         with_prefill: bool = False,
         qr_pertoken_scale: torch.Tensor = None,
+        qr_quant: torch.Tensor | None = None,
     ):
         """
         Multistream version: 4-block segmentation, main stream and aux stream
@@ -2771,8 +2635,9 @@ class AscendDSAImpl(DSAAttentionImpl):
         aux_stream = dsv4_dsa_overlap_stream()
 
         # ===== Part0: Pre-compute on main =====
-        if _is_w8a8_dynamic(self.inderxer_wq_b) and qr_pertoken_scale is not None:
-            qr_quant_ready = qr
+        use_quantized_qr = self._indexer_can_use_quantized_qr(qr_quant, qr_pertoken_scale)
+        if use_quantized_qr:
+            qr_quant_ready = qr_quant
             qr_scale_ready = qr_pertoken_scale
         else:
             qr_quant_ready, qr_scale_ready = self.cv_inderxer_wq_b.quantize(qr)
@@ -2834,7 +2699,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 )
 
         # Main: matmul q from qr (directly submit, V/C different engines dispatch naturally)
-        if _is_w8a8_dynamic(self.inderxer_wq_b) and qr_pertoken_scale is not None:
+        if use_quantized_qr:
             q = torch_npu.npu_quant_matmul(
                 qr_quant_ready,
                 self.inderxer_wq_b.weight,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1501,39 +1501,21 @@ class AscendDSAImpl(DSAAttentionImpl):
             topk_indices_to_cache = topk_indices_to_cache.squeeze(1)
         topk_indices_buffer.copy_(topk_indices_to_cache)
 
-    def _select_qr_after_dynamic_quant(
+    def _select_indexer_qr_after_dynamic_quant(
         self,
         q_a: torch.Tensor,
         qr_quant: torch.Tensor,
         qr_pertoken_scale: torch.Tensor,
     ) -> torch.Tensor:
-        """Choose whether downstream should see quantized or fp qr.
-        Layers without an active indexer keep the fused
-        npu_rms_norm_dynamic_quant result. Only an active indexer may require
-        fp qr, and only when it cannot consume the quantized qr directly.
-        """
         if self.indexer is None or self.compress_ratio != 4 or self.skip_topk:
             return qr_quant
-
-        indexer_can_reuse_quantized_qr = (
-            _is_w8a8_dynamic(self.wq_b)
-            and _is_w8a8_dynamic(self.inderxer_wq_b)
-            and qr_quant is not None
+        if (
+            _is_w8a8_dynamic(self.inderxer_wq_b)
             and qr_pertoken_scale is not None
             and get_ascend_device_type() not in {AscendDeviceType.A5}
-        )
-        if indexer_can_reuse_quantized_qr:
+        ):
             return qr_quant
-
         return self.q_norm(q_a)
-
-    def _is_quantized_qr_selected(
-        self,
-        qr: torch.Tensor,
-        qr_quant: torch.Tensor | None,
-        qr_pertoken_scale: torch.Tensor | None,
-    ) -> bool:
-        return qr_quant is not None and qr_pertoken_scale is not None and qr is qr_quant
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         pass
@@ -1694,20 +1676,16 @@ class AscendDSAImpl(DSAAttentionImpl):
             torch.npu.current_stream().wait_event(e_part2_start)
             kv = self.cv_wkv.matmul(kv_quant, kv_pertoken_scale)
 
-        qr_quant = None
-        qr_quant = None
         if is_prefill:
             qr = self.q_norm(wq_a_result)
             q_b_quant, q_b_scale = self.cv_wq_b.quantize(qr)
             qr_pertoken_scale = None
         elif is_w8a8:
-            qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
-        elif is_w8a8_wq_b:
-            qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+            qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                 wq_a_result, self.q_norm.weight, epsilon=self.eps
             )
-            q_b_quant, q_b_scale = qr_quant, qr_pertoken_scale
-            qr = self._select_qr_after_dynamic_quant(wq_a_result, qr_quant, qr_pertoken_scale)
+            q_b_quant, q_b_scale = qr, qr_pertoken_scale
+            qr = self._select_indexer_qr_after_dynamic_quant(wq_a_result, qr, qr_pertoken_scale)
         else:
             qr = self.q_norm(wq_a_result)
             q_b_quant, q_b_scale = qr, None
@@ -1758,7 +1736,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             partial_slice=[self.nope_head_dim, self.head_dim],
         )
 
-        return q, qr, qr_quant, qr_pertoken_scale
+        return q, qr, qr_pertoken_scale
 
     def _forward_prefill(
         self,
@@ -1794,12 +1772,9 @@ class AscendDSAImpl(DSAAttentionImpl):
         actual_seq_lengths_query = common_prefill_metadata.query_start_loc
         actual_seq_lengths_key = common_prefill_metadata.seq_lens
 
-        qr_quant = None
-        qr_pertoken_scale = None
         if self.multistream_dsv4_dsa_overlap:
             # mla prolog: q + kv dual-stream parallel
-            q, qr, _, _ = self._mla_prolog_multistream(
-            q, qr, _, _ = self._mla_prolog_multistream(
+            q, qr, _ = self._mla_prolog_multistream(
                 hidden_states, cos, sin, swa_kv_cache, swa_prefill_metadata.slot_mapping, is_prefill=True
             )
         else:
@@ -1823,24 +1798,22 @@ class AscendDSAImpl(DSAAttentionImpl):
 
             # q
             if _is_w8a8_dynamic(self.wq_b):
-                qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
-            if is_w8a8_wq_b:
-                qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+                qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                     q_a, self.q_norm.weight, epsilon=self.eps
                 )
                 q = torch_npu.npu_quant_matmul(
-                    qr_quant,
-                    qr_quant,
+                    qr,
                     self.wq_b.weight,
                     self.wq_b.weight_scale,
                     pertoken_scale=qr_pertoken_scale,
                     bias=self.wq_b.bias,
                     output_dtype=hidden_states.dtype,
                 ).unflatten(-1, (self.n_local_heads, self.head_dim))
-                qr = self._select_qr_after_dynamic_quant(q_a, qr_quant, qr_pertoken_scale)
+                qr = self._select_indexer_qr_after_dynamic_quant(q_a, qr, qr_pertoken_scale)
             else:
                 qr = self.q_norm(q_a)
                 q = self.wq_b(qr).unflatten(-1, (self.n_local_heads, self.head_dim))
+                qr_pertoken_scale = None
             q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
 
             torch.ops._C_ascend.inplace_partial_rotary_mul(
@@ -1944,7 +1917,6 @@ class AscendDSAImpl(DSAAttentionImpl):
                             actual_seq_lengths_key=actual_seq_lengths_key,
                             with_prefill=True,
                             qr_pertoken_scale=qr_pertoken_scale,
-                            qr_quant=qr_quant,
                         )
 
             coff = 2 if self.compressor_overlap else 1
@@ -2114,8 +2086,7 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         if self.multistream_dsv4_dsa_overlap:
             # mla prolog: q + kv dual-stream parallel
-            q, qr, qr_quant, qr_pertoken_scale = self._mla_prolog_multistream(
-            q, qr, qr_quant, qr_pertoken_scale = self._mla_prolog_multistream(
+            q, qr, qr_pertoken_scale = self._mla_prolog_multistream(
                 hidden_states, cos, sin, swa_kv_cache, swa_decode_metadata.slot_mapping, is_prefill=False
             )
         else:
@@ -2129,8 +2100,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 hs_int8, hs_pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
 
             # q
-            qr_quant = None
-            if is_w8a8_wq_b:
+            if _is_w8a8_dynamic(self.wq_b):
                 if share_hs_quant:
                     q_a = torch_npu.npu_quant_matmul(
                         hs_int8,
@@ -2142,20 +2112,18 @@ class AscendDSAImpl(DSAAttentionImpl):
                     )
                 else:
                     q_a = self.wq_a(hidden_states)
-                qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
-                qr_quant, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+                qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                     q_a, self.q_norm.weight, epsilon=self.eps
                 )
                 q = torch_npu.npu_quant_matmul(
-                    qr_quant,
-                    qr_quant,
+                    qr,
                     self.wq_b.weight,
                     self.wq_b.weight_scale,
                     pertoken_scale=qr_pertoken_scale,
                     bias=self.wq_b.bias,
                     output_dtype=hidden_states.dtype,
                 ).unflatten(-1, (self.n_local_heads, self.head_dim))
-                qr = self._select_qr_after_dynamic_quant(q_a, qr_quant, qr_pertoken_scale)
+                qr = self._select_indexer_qr_after_dynamic_quant(q_a, qr, qr_pertoken_scale)
             else:
                 if share_hs_quant:
                     q_a = torch_npu.npu_quant_matmul(
@@ -2234,8 +2202,6 @@ class AscendDSAImpl(DSAAttentionImpl):
                             actual_seq_lengths_query=actual_seq_lengths_query,
                             with_prefill=False,
                             qr_pertoken_scale=qr_pertoken_scale,
-                            qr_quant=qr_quant,
-                            qr_quant=qr_quant,
                         )
                     else:
                         compress_topk_idxs = self.indexer_select_qli(  # original version
@@ -2251,8 +2217,6 @@ class AscendDSAImpl(DSAAttentionImpl):
                             actual_seq_lengths_key=actual_seq_lengths_key,
                             with_prefill=False,
                             qr_pertoken_scale=qr_pertoken_scale,
-                            qr_quant=qr_quant,
-                            qr_quant=qr_quant,
                         )
 
             coff = 2 if self.compressor_overlap else 1
@@ -2410,8 +2374,6 @@ class AscendDSAImpl(DSAAttentionImpl):
         actual_seq_lengths_query: torch.Tensor,
         with_prefill: bool = False,
         qr_pertoken_scale: torch.Tensor = None,
-        qr_quant: torch.Tensor | None = None,
-        qr_quant: torch.Tensor | None = None,
     ):
         (indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
             DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
@@ -2424,11 +2386,13 @@ class AscendDSAImpl(DSAAttentionImpl):
             _,
         ) = attn_metadata
 
-        use_quantized_qr = self._is_quantized_qr_selected(qr, qr_quant, qr_pertoken_scale)
-        if use_quantized_qr:
+        if (
+            _is_w8a8_dynamic(self.inderxer_wq_b)
+            and qr_pertoken_scale is not None
+            and get_ascend_device_type() not in {AscendDeviceType.A5}
+        ):
             q = torch_npu.npu_quant_matmul(
-                qr_quant,
-                qr_quant,
+                qr,
                 self.inderxer_wq_b.weight,
                 self.inderxer_wq_b.weight_scale,
                 pertoken_scale=qr_pertoken_scale,
@@ -2608,8 +2572,6 @@ class AscendDSAImpl(DSAAttentionImpl):
         actual_seq_lengths_key: torch.Tensor | None = None,
         with_prefill: bool = False,
         qr_pertoken_scale: torch.Tensor = None,
-        qr_quant: torch.Tensor | None = None,
-        qr_quant: torch.Tensor | None = None,
     ):
         q, kv, ik, isc, ifc, indexer_kv_state_meta, isc_meta, wp = self._indexer_qkv_prepare(
             x,
@@ -2623,8 +2585,6 @@ class AscendDSAImpl(DSAAttentionImpl):
             actual_seq_lengths_query,
             with_prefill,
             qr_pertoken_scale,
-            qr_quant,
-            qr_quant,
         )
 
         weights = self.weights_proj(x) * (self.indexer_softmax_scale * self.indexer_heads**-0.5)
@@ -2644,8 +2604,6 @@ class AscendDSAImpl(DSAAttentionImpl):
         actual_seq_lengths_query: torch.Tensor,
         with_prefill: bool = False,
         qr_pertoken_scale: torch.Tensor = None,
-        qr_quant: torch.Tensor | None = None,
-        qr_quant: torch.Tensor | None = None,
     ):
         """
         Multistream version: 4-block segmentation, main stream and aux stream
@@ -2668,9 +2626,12 @@ class AscendDSAImpl(DSAAttentionImpl):
         aux_stream = dsv4_dsa_overlap_stream()
 
         # ===== Part0: Pre-compute on main =====
-        use_quantized_qr = self._is_quantized_qr_selected(qr, qr_quant, qr_pertoken_scale)
-        if use_quantized_qr:
-            qr_quant_ready = qr_quant
+        if (
+            _is_w8a8_dynamic(self.inderxer_wq_b)
+            and qr_pertoken_scale is not None
+            and get_ascend_device_type() not in {AscendDeviceType.A5}
+        ):
+            qr_quant_ready = qr
             qr_scale_ready = qr_pertoken_scale
         else:
             qr_quant_ready, qr_scale_ready = self.cv_inderxer_wq_b.quantize(qr)
@@ -2732,8 +2693,11 @@ class AscendDSAImpl(DSAAttentionImpl):
                 )
 
         # Main: matmul q from qr (directly submit, V/C different engines dispatch naturally)
-        if use_quantized_qr:
-        if use_quantized_qr:
+        if (
+            _is_w8a8_dynamic(self.inderxer_wq_b)
+            and qr_pertoken_scale is not None
+            and get_ascend_device_type() not in {AscendDeviceType.A5}
+        ):
             q = torch_npu.npu_quant_matmul(
                 qr_quant_ready,
                 self.inderxer_wq_b.weight,

--- a/vllm_ascend/ops/dsa.py
+++ b/vllm_ascend/ops/dsa.py
@@ -189,7 +189,6 @@ def dsa_forward(
         attn_metadata = forward_context.attn_metadata
 
     if attn_metadata is None:
-        self.dsa_attn.impl.dsa_warmup_with_multistream(hidden_states)
         output.fill_(0)
         return
 


### PR DESCRIPTION
### What this PR does / why we need it?

1. This PR fixes cv_parallel bug.
2. This PR removes the dedicated `prefill_comm_compute_overlap` special path in DSA v1 and keeps prefill on the unified FlashComm gather flow.
3. This PR removes `multistream_dsa_preprocess` which is useless.
4. This PR removes `dsa_warmup_with_multistream` in dsa.py and its implementation in dsa_v1.py.

### Does this PR introduce _any_ user-facing change?
No. This is an internal correctness and robustness fix for DSA v1 quantization/indexer execution paths.

### How was this patch tested?


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
