### PR TITLE
[BugFix] A00282: force ALLGATHER on A2 to isolate MC2 accuracy regression

### DIFF
--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -275,7 +275,12 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig, is_draft_mo
             vllm_config.parallel_config.world_size_across_dp // vllm_config.parallel_config.pipeline_parallel_size
         )
         num_experts_per_device = num_experts // ep_world_size
-        if num_experts_per_device <= 24 and ep_world_size >= 16 and num_tokens <= mc2_tokens_capacity:
+        # A00282: force ALLGATHER to bypass MC2 and check whether the A2
+        # multi-concurrency accuracy regression is in the MC2 path.
+        # Original condition:
+        #   if num_experts_per_device <= 24 and ep_world_size >= 16
+        #       and num_tokens <= mc2_tokens_capacity:
+        if False:
             moe_comm_type = MoECommType.MC2
         else:
             moe_comm_type = MoECommType.ALLGATHER


### PR DESCRIPTION
## What & Why

Qwen3-235B-A22B-A2 (TP=8/DP=2/EP=16) GSM8K accuracy dropped to **0%~3%** since 2026-05-10 (Nightly-A2). Single-request inference is correct; only multi-concurrency ais_bench produces garbled output. No NCCL/NaN/crash in logs.

## Diagnosis so far

- Regression introduced by `7fd2cede` (Main2Main upgrade vLLM to 0427), which bumped vLLM from `d886c26d4` to `4d51588e2`.
- On A2 the MoE path selects **MC2** (`npu_moe_distribute_dispatch` + shared `mc2_mask` buffer) when `num_experts_per_device <= 24 and ep_world_size >= 16 and num_tokens <= mc2_tokens_capacity`.
- Qwen3-235B-A22B (128 routed experts, 0 shared, EP=16) hits this MC2 path under multi-concurrency.

## This PR (temporary diagnostic patch)

Force ALLGATHER to **bypass the MC2 path entirely** on A2, so the nightly A2 accuracy case can isolate whether the regression lives in MC2:

- **If accuracy recovers (~96%)** → regression is in the MC2 path (mask buffer timing or `npu_moe_distribute_dispatch` op).
- **If accuracy stays at 0%** → MC2 is exonerated; focus shifts to routing (`npu_moe_gating_top_k`) or scheduler.

> ⚠️ This is a **temporary diagnostic change**, not a permanent fix. It disables MC2 on A2 (performance regression). Will be reverted or replaced once root cause is confirmed.

## Testing

Needs nightly-A2 multi-node run (`Qwen3-235B-A22B-A2.yaml` accuracy case) to verify. Requesting `nightly-test` label.

## Issue

DTS2026060451978
- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
