### PR TITLE
[BugFix][IndexCache] Use per-rank q_pe length for SFA sparse_indices tiling

### DIFF
--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1325,7 +1325,16 @@ class AscendSFAImpl(MLAAttentionImpl):
             if self.is_kv_producer:
                 attn_metadata.reshape_cache_event.record()
 
-        topk_num_tokens = num_input_tokens or hidden_states.shape[0]
+        # IndexCache + SFA tiling fix: use per-rank q_pe length, not the global
+        # padded-to-tp num_input_tokens. SFA's aclnnSparseFlashAttention tiling
+        # expects sparse_indices shape [tokens_per_rank, 1, topk]; on PD分离 +
+        # TP>1 num_input_tokens is the prefill batch token count pre-shard
+        # while q_pe is already per-rank, so feeding the global number causes
+        # "sparse_indices shape [N*tp, 1, 2048] expected [N, 1, 2048]" tiling
+        # errors (e.g. TP=8 → exact 8x ratio). PD混步 happens to be safe
+        # because q_pe.shape[0] == num_input_tokens there, so this is a no-op
+        # for it.
+        topk_num_tokens = q_pe.shape[0]
         if self.skip_topk:
             topk_indices = self._get_indexcache_topk_indices(topk_num_tokens)
         else:


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes a hard `aclnnSparseFlashAttention` tiling error that happens on PD-disaggregated + TP > 1 + IndexCache on GLM-5 / DSA models, e.g.:

```
RuntimeError: call aclnnSparseFlashAttention failed, detail:EZ9999: Inner Error!
EZ9999 sparse_indices layout is TND, shape is [4096, 1, 2048],
       expected shape is [512, 1, 2048].
       [FUNC:CompareShape][FILE:sparse_flash_attention_tiling.cpp][LINE:570]
       SparseFlashAttention do tiling failed, ret is -1.
```

Two reproductions on GLM-5 PD-分离 TP=8 with `--hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}'`:

| PBT  | TP | IndexCache produced | SFA expected   | Ratio |
|------|----|---------------------|----------------|-------|
| 4096 | 8  | `[4096, 1, 2048]`   | `[512, 1, 2048]` | **8x** |
| 512  | 8  | `[512, 1, 2048]`    | `[64, 1, 2048]`  | **8x** |

The exact TP-fold ratio (=`TP=8`) between produced and expected shapes rules out "PBT too big" as a cause. Root cause: IndexCache's `topk_num_tokens` was using the **global** `num_input_tokens` (prefill batch tokens, pre-TP-shard) while `aclnnSparseFlashAttention` tiling expects the **per-rank** query length.

### Fix

In `vllm_ascend/attention/sfa_v1.py` at the IndexCache topk branch:

```python
- topk_num_tokens = num_input_tokens or hidden_states.shape[0]
+ topk_num_tokens = q_pe.shape[0]
```

By the time we reach this line `q_pe` has already gone through `_q_proj_and_k_up_proj` (`sfa_v1.py:1241`), which performs the TP shard, so its leading dim is exactly the per-rank token count SFA expects.

### Does this PR introduce any user-facing change?

No new API. Just fixes a hard crash on the existing IndexCache + PD-disaggregated + TP > 1 path.

### Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| PD混步 (mixed prefill+decode), TP ≥ 1, IndexCache on | OK (q_pe.shape[0] == num_input_tokens, no-op) | OK (still no-op, byte-identical) |
| PD分离, TP=1, IndexCache on | OK | OK (no-op for TP=1) |
| **PD分离, TP > 1, IndexCache on** | ❌ **SFA tiling crash** | ✅ **Works** |
| IndexCache off (default) | OK | OK (line not reached) |

### How was this patch tested?

- Reproduced both `PBT=4096` and `PBT=512` failures on GLM-5 PD-分离 TP=8 with `--hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}'`.
- After this fix both PBT values stop emitting the `SparseFlashAttention do tiling failed, ret is -1` tiling error and inference proceeds.
- PD混步 path verified byte-identical (`q_pe.shape[0] == num_input_tokens` so the value at this line is unchanged).

### Related

- IndexCache feature PR on vllm-ascend: #8398 (`[Feature] IndexCache support for DSA models`)
- IndexCache feature PR on upstream vllm: vllm-project/vllm#37735

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
