### PR TITLE
[BugFix] fix w4a8 weight loading of DSACP in sfa_v1.py

### DIFF
--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -911,7 +911,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         attn_output: torch.Tensor,
         output: torch.Tensor,
         o_proj_full_handle: torch.distributed.Work | None,
-        o_proj_full_weight_scale_handle: torch.distributed.Work | None,
+        o_proj_full_weight_scale_handles: list[torch.distributed.Work] | None,
         should_shard_weight: bool,
     ) -> tuple[torch.Tensor, bool]:
         """
@@ -922,8 +922,9 @@ class AscendSFAImpl(MLAAttentionImpl):
             # Wait for the completion of o_proj weight all-gather operation
             if o_proj_full_handle is not None:
                 o_proj_full_handle.wait()
-            if o_proj_full_weight_scale_handle is not None:
-                o_proj_full_weight_scale_handle.wait()
+            if o_proj_full_weight_scale_handles is not None:
+                for handle in o_proj_full_weight_scale_handles:
+                    handle.wait()
 
             # Switch o_proj to Full-mode (gathered weight from all TP ranks)
             self.o_proj.weight.set_(AscendSFAImpl.o_proj_full_pool)
@@ -1307,7 +1308,7 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         # all-gather o_proj weight for prefill stage of PD mix node
         o_proj_full_handle = None
-        o_proj_full_weight_scale_handle = None
+        o_proj_full_weight_scale_handles = None
         # if is PD mix stage, using original TP o_proj weight, and also need to full gather for o_proj
         # weight for prefill stage.
         full_gather_o_proj_enabled = self.enable_dsa_cp_with_o_proj_tp and attn_metadata.attn_state not in {
@@ -1448,14 +1449,14 @@ class AscendSFAImpl(MLAAttentionImpl):
                     _, o_proj_full_handle = all_gather_async(
                         self.o_proj_tp_weight, get_tp_group(), output=AscendSFAImpl.o_proj_full_pool
                     )
-                    o_proj_full_weight_scale_handle = []
+                    o_proj_full_weight_scale_handles = []
                     for param_name, param in self.o_proj_tp_input_sharded_quant_params.items():
                         _, param_handle = all_gather_async(
                             param,
                             get_tp_group(),
                             output=self.o_proj_full_input_sharded_quant_params[param_name],
                         )
-                        o_proj_full_weight_scale_handle.append(param_handle)
+                        o_proj_full_weight_scale_handles.append(param_handle)
 
                 if kv_cache is not None:
                     assert fused_kv_no_split is not None
@@ -1574,7 +1575,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                     attn_output=attn_output,
                     output=output,
                     o_proj_full_handle=o_proj_full_handle,
-                    o_proj_full_weight_scale_handle=o_proj_full_weight_scale_handle,
+                    o_proj_full_weight_scale_handles=o_proj_full_weight_scale_handles,
                     should_shard_weight=full_gather_o_proj_enabled,
                 )
             else:

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -869,6 +869,11 @@ class AscendSFAImpl(MLAAttentionImpl):
         for param_name, param in params.items():
             getattr(self.o_proj, param_name).set_(param)
 
+    def _apply_o_proj_full_weight(self, attn_output: torch.Tensor) -> torch.Tensor:
+        quant_method = self.o_proj.quant_method
+        linear_method = getattr(quant_method, "quant_method", quant_method)
+        return linear_method.apply(self.o_proj, attn_output)
+
     def _handle_o_proj_weight_switch_and_forward(
         self,
         attn_output: torch.Tensor,
@@ -895,7 +900,7 @@ class AscendSFAImpl(MLAAttentionImpl):
             self._switch_o_proj_params(self.o_proj_full_input_sharded_quant_params)
 
             # Apply quantization method and execute forward computation
-            output[...] = self.o_proj.quant_method.quant_method.apply(self.o_proj, attn_output)
+            output[...] = self._apply_o_proj_full_weight(attn_output)
 
             # Switch o_proj back to TP-mode for subsequent decode operations
             self.o_proj.weight.set_(self.o_proj_tp_weight)

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -439,7 +439,7 @@ class AscendSFAImpl(MLAAttentionImpl):
     """
 
     # Supports forward using the all-gather o_proj weight for decode requests when Sharded CP is enabled.
-    o_proj_full_pool: torch.Tensor | None = None
+    o_proj_full_pools: dict[tuple[str, int | None, torch.dtype, tuple[int, ...]], torch.Tensor] = {}
 
     # q_hadamard and k_hadamard tensor shared when dsa c8 enabled
     q_hadamard: torch.Tensor | None = None
@@ -827,11 +827,14 @@ class AscendSFAImpl(MLAAttentionImpl):
         - Use original TP o_proj weight for decode phase
         - Need full-gather o_proj weight from all TP ranks for prefill phase
         """
-        if AscendSFAImpl.o_proj_full_pool is None:
-            sample = self.o_proj.weight
-            AscendSFAImpl.o_proj_full_pool = torch.empty(
-                (sample.shape[0] * self.tp_size, sample.shape[1]), dtype=sample.dtype, device=sample.device
+        sample = self.o_proj.weight
+        full_shape = (sample.shape[0] * self.tp_size, sample.shape[1])
+        pool_key = (sample.device.type, sample.device.index, sample.dtype, full_shape)
+        if pool_key not in AscendSFAImpl.o_proj_full_pools:
+            AscendSFAImpl.o_proj_full_pools[pool_key] = torch.empty(
+                full_shape, dtype=sample.dtype, device=sample.device
             )
+        self.o_proj_full_pool = AscendSFAImpl.o_proj_full_pools[pool_key]
 
         # Save TP-mode parameters (original sharded weights)
         self.o_proj_tp_weight = self.o_proj.weight.clone().detach()
@@ -885,7 +888,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                     handle.wait()
 
             # Switch o_proj to Full-mode (gathered weight from all TP ranks)
-            self.o_proj.weight.set_(AscendSFAImpl.o_proj_full_pool)
+            self.o_proj.weight.set_(self.o_proj_full_pool)
             self._switch_o_proj_params(self.o_proj_full_aclnn_input_params)
             self._switch_o_proj_params(self.o_proj_full_input_sharded_quant_params)
 
@@ -1359,7 +1362,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                             reach_layer_for_shard_weight_series(layer)
                 elif full_gather_o_proj_enabled:
                     _, o_proj_full_handle = all_gather_async(
-                        self.o_proj_tp_weight, get_tp_group(), output=AscendSFAImpl.o_proj_full_pool
+                        self.o_proj_tp_weight, get_tp_group(), output=self.o_proj_full_pool
                     )
                     o_proj_full_param_handles = []
                     for param_name, param in self.o_proj_tp_input_sharded_quant_params.items():

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -829,6 +829,8 @@ class AscendSFAImpl(MLAAttentionImpl):
         """
         sample = self.o_proj.weight
         full_shape = (sample.shape[0] * self.tp_size, sample.shape[1])
+        # Main and MTP layers can use different quantized o_proj weight dtypes,
+        # so key the shared full-gather pool by dtype and shape.
         pool_key = (sample.device.type, sample.device.index, sample.dtype, full_shape)
         if pool_key not in AscendSFAImpl.o_proj_full_pools:
             AscendSFAImpl.o_proj_full_pools[pool_key] = torch.empty(

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -439,7 +439,7 @@ class AscendSFAImpl(MLAAttentionImpl):
     """
 
     # Supports forward using the all-gather o_proj weight for decode requests when Sharded CP is enabled.
-    o_proj_full_pools: dict[tuple[str, int | None, torch.dtype, tuple[int, ...]], torch.Tensor] = {}
+    o_proj_full_pools: dict[tuple[str, int | None, torch.dtype, int, tuple[int, ...]], torch.Tensor] = {}
 
     # q_hadamard and k_hadamard tensor shared when dsa c8 enabled
     q_hadamard: torch.Tensor | None = None
@@ -828,18 +828,40 @@ class AscendSFAImpl(MLAAttentionImpl):
         - Need full-gather o_proj weight from all TP ranks for prefill phase
         """
         sample = self.o_proj.weight
-        full_shape = (sample.shape[0] * self.tp_size, sample.shape[1])
-        # Main and MTP layers can use different quantized o_proj weight dtypes,
-        # so key the shared full-gather pool by dtype and shape.
-        pool_key = (sample.device.type, sample.device.index, sample.dtype, full_shape)
+        self.o_proj_full_weight_gather_dim = 1 if self._is_o_proj_unquantized() else 0
+        if self.o_proj_full_weight_gather_dim == 0:
+            full_shape = (sample.shape[0] * self.tp_size, sample.shape[1])
+            gather_shape = full_shape
+        else:
+            full_shape = (sample.shape[0], sample.shape[1] * self.tp_size)
+            gather_shape = (sample.shape[1] * self.tp_size, sample.shape[0])
+        # Main and MTP layers can use different quantized o_proj weight layouts,
+        # so key the shared full-gather pool by gather dimension, dtype, and shape.
+        pool_key = (
+            sample.device.type,
+            sample.device.index,
+            sample.dtype,
+            self.o_proj_full_weight_gather_dim,
+            full_shape,
+        )
         if pool_key not in AscendSFAImpl.o_proj_full_pools:
             AscendSFAImpl.o_proj_full_pools[pool_key] = torch.empty(
-                full_shape, dtype=sample.dtype, device=sample.device
+                gather_shape, dtype=sample.dtype, device=sample.device
             )
-        self.o_proj_full_pool = AscendSFAImpl.o_proj_full_pools[pool_key]
+        self.o_proj_full_gather_pool = AscendSFAImpl.o_proj_full_pools[pool_key]
+        if self.o_proj_full_weight_gather_dim == 0:
+            self.o_proj_full_pool = self.o_proj_full_gather_pool
+        else:
+            self.o_proj_full_pool = self.o_proj_full_gather_pool.transpose(0, 1)
 
         # Save TP-mode parameters (original sharded weights)
         self.o_proj_tp_weight = self.o_proj.weight.clone().detach()
+        if self.o_proj_full_weight_gather_dim == 0:
+            self.o_proj_tp_weight_gather_input = self.o_proj_tp_weight
+        else:
+            self.o_proj_tp_weight_gather_input = (
+                self.o_proj_tp_weight.transpose(0, 1).contiguous()
+            )
         self.o_proj_tp_aclnn_input_params = {}
         self.o_proj_full_aclnn_input_params = {}
         for param_name in O_PROJ_ACLNN_INPUT_PARAMS:
@@ -869,10 +891,15 @@ class AscendSFAImpl(MLAAttentionImpl):
         for param_name, param in params.items():
             getattr(self.o_proj, param_name).set_(param)
 
-    def _apply_o_proj_full_weight(self, attn_output: torch.Tensor) -> torch.Tensor:
+    def _get_o_proj_linear_method(self):
         quant_method = self.o_proj.quant_method
-        linear_method = getattr(quant_method, "quant_method", quant_method)
-        return linear_method.apply(self.o_proj, attn_output)
+        return getattr(quant_method, "quant_method", quant_method)
+
+    def _is_o_proj_unquantized(self) -> bool:
+        return isinstance(self._get_o_proj_linear_method(), UnquantizedLinearMethod)
+
+    def _apply_o_proj_full_weight(self, attn_output: torch.Tensor) -> torch.Tensor:
+        return self._get_o_proj_linear_method().apply(self.o_proj, attn_output)
 
     def _handle_o_proj_weight_switch_and_forward(
         self,
@@ -1369,7 +1396,9 @@ class AscendSFAImpl(MLAAttentionImpl):
                             reach_layer_for_shard_weight_series(layer)
                 elif full_gather_o_proj_enabled:
                     _, o_proj_full_handle = all_gather_async(
-                        self.o_proj_tp_weight, get_tp_group(), output=self.o_proj_full_pool
+                        self.o_proj_tp_weight_gather_input,
+                        get_tp_group(),
+                        output=self.o_proj_full_gather_pool,
                     )
                     o_proj_full_param_handles = []
                     for param_name, param in self.o_proj_tp_input_sharded_quant_params.items():

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -71,6 +71,13 @@ if TYPE_CHECKING:
 # token count limits within bmm_transpose operator
 BMM_TRANS_MAX_SUPPORTED_TOKENS = 1024
 
+O_PROJ_ACLNN_INPUT_PARAMS = (
+    "aclnn_input_scale",
+    "aclnn_input_scale_reciprocal",
+    "aclnn_input_offset",
+)
+O_PROJ_INPUT_SHARDED_QUANT_PARAMS = ("weight_scale_second", "weight_scale")
+
 
 class AscendSFABackend(AttentionBackend):
     accept_output_buffer: bool = True
@@ -870,20 +877,34 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         # Save TP-mode parameters (original sharded weights)
         self.o_proj_tp_weight = self.o_proj.weight.clone().detach()
-        self.o_proj_tp_aclnn_input_scale = self.o_proj.aclnn_input_scale.clone().detach()
-        self.o_proj_tp_aclnn_input_scale_reciprocal = self.o_proj.aclnn_input_scale_reciprocal.clone().detach()
-        self.o_proj_tp_aclnn_input_offset = self.o_proj.aclnn_input_offset.clone().detach()
+        self.o_proj_tp_aclnn_input_params = {}
+        self.o_proj_full_aclnn_input_params = {}
+        for param_name in O_PROJ_ACLNN_INPUT_PARAMS:
+            param = getattr(self.o_proj, param_name, None)
+            if param is None:
+                continue
+            self.o_proj_tp_aclnn_input_params[param_name] = param.clone().detach()
+            self.o_proj_full_aclnn_input_params[param_name] = param.repeat(self.tp_size)
+
+        self.o_proj_tp_input_sharded_quant_params = {}
+        self.o_proj_full_input_sharded_quant_params = {}
+        for param_name in O_PROJ_INPUT_SHARDED_QUANT_PARAMS:
+            param = getattr(self.o_proj, param_name, None)
+            if param is None or getattr(param, "input_dim", None) != 1:
+                continue
+            self.o_proj_tp_input_sharded_quant_params[param_name] = param.clone().detach()
+            self.o_proj_full_input_sharded_quant_params[param_name] = torch.empty(
+                (param.shape[0] * self.tp_size, *param.shape[1:]), dtype=param.dtype, device=param.device
+            )
 
         # Initially switch to TP mode for graph capture
         self.o_proj.weight.set_(self.o_proj_tp_weight)
-        self.o_proj.aclnn_input_scale.set_(self.o_proj_tp_aclnn_input_scale)
-        self.o_proj.aclnn_input_scale_reciprocal.set_(self.o_proj_tp_aclnn_input_scale_reciprocal)
-        self.o_proj.aclnn_input_offset.set_(self.o_proj_tp_aclnn_input_offset)
+        self._switch_o_proj_params(self.o_proj_tp_aclnn_input_params)
+        self._switch_o_proj_params(self.o_proj_tp_input_sharded_quant_params)
 
-        # Precompute Full-mode quantization parameters by repeating TP parameters across all TP ranks
-        self.o_proj_full_aclnn_input_scale = self.o_proj.aclnn_input_scale.repeat(self.tp_size)
-        self.o_proj_full_aclnn_input_scale_reciprocal = self.o_proj.aclnn_input_scale_reciprocal.repeat(self.tp_size)
-        self.o_proj_full_aclnn_input_offset = self.o_proj.aclnn_input_offset.repeat(self.tp_size)
+    def _switch_o_proj_params(self, params: dict[str, torch.Tensor]):
+        for param_name, param in params.items():
+            getattr(self.o_proj, param_name).set_(param)
 
     def _handle_dynamic_quant_o_proj_weight_switch_and_forward(
         self,
@@ -935,6 +956,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         attn_output: torch.Tensor,
         output: torch.Tensor,
         o_proj_full_handle: torch.distributed.Work | None,
+        o_proj_full_param_handles: list[torch.distributed.Work | None] | None,
         should_shard_weight: bool,
     ) -> tuple[torch.Tensor, bool]:
         """
@@ -945,21 +967,22 @@ class AscendSFAImpl(MLAAttentionImpl):
             # Wait for the completion of o_proj weight all-gather operation
             if o_proj_full_handle is not None:
                 o_proj_full_handle.wait()
+            for handle in o_proj_full_param_handles or []:
+                if handle is not None:
+                    handle.wait()
 
             # Switch o_proj to Full-mode (gathered weight from all TP ranks)
             self.o_proj.weight.set_(AscendSFAImpl.o_proj_full_pool)
-            self.o_proj.aclnn_input_scale.set_(self.o_proj_full_aclnn_input_scale)
-            self.o_proj.aclnn_input_scale_reciprocal.set_(self.o_proj_full_aclnn_input_scale_reciprocal)
-            self.o_proj.aclnn_input_offset.set_(self.o_proj_full_aclnn_input_offset)
+            self._switch_o_proj_params(self.o_proj_full_aclnn_input_params)
+            self._switch_o_proj_params(self.o_proj_full_input_sharded_quant_params)
 
             # Apply quantization method and execute forward computation
             output[...] = self.o_proj.quant_method.quant_method.apply(self.o_proj, attn_output)
 
             # Switch o_proj back to TP-mode for subsequent decode operations
             self.o_proj.weight.set_(self.o_proj_tp_weight)
-            self.o_proj.aclnn_input_scale.set_(self.o_proj_tp_aclnn_input_scale)
-            self.o_proj.aclnn_input_scale_reciprocal.set_(self.o_proj_tp_aclnn_input_scale_reciprocal)
-            self.o_proj.aclnn_input_offset.set_(self.o_proj_tp_aclnn_input_offset)
+            self._switch_o_proj_params(self.o_proj_tp_aclnn_input_params)
+            self._switch_o_proj_params(self.o_proj_tp_input_sharded_quant_params)
 
             return output, False
         else:
@@ -1425,12 +1448,14 @@ class AscendSFAImpl(MLAAttentionImpl):
                     _, o_proj_full_handle = all_gather_async(
                         self.o_proj_tp_weight, get_tp_group(), output=AscendSFAImpl.o_proj_full_pool
                     )
-                    if self._o_proj_dynamic_quant:
-                        _, o_proj_full_weight_scale_handle = all_gather_async(
-                            self.o_proj_tp_weight_scale,
+                    o_proj_full_weight_scale_handle = []
+                    for param_name, param in self.o_proj_tp_input_sharded_quant_params.items():
+                        _, param_handle = all_gather_async(
+                            param,
                             get_tp_group(),
-                            output=AscendSFAImpl.o_proj_full_weight_scale_pool,
+                            output=self.o_proj_full_input_sharded_quant_params[param_name],
                         )
+                        o_proj_full_weight_scale_handle.append(param_handle)
 
                 if kv_cache is not None:
                     assert fused_kv_no_split is not None

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -440,7 +440,6 @@ class AscendSFAImpl(MLAAttentionImpl):
 
     # Supports forward using the all-gather o_proj weight for decode requests when Sharded CP is enabled.
     o_proj_full_pool: torch.Tensor | None = None
-    o_proj_full_weight_scale_pool: torch.Tensor | None = None
 
     # q_hadamard and k_hadamard tensor shared when dsa c8 enabled
     q_hadamard: torch.Tensor | None = None
@@ -544,7 +543,6 @@ class AscendSFAImpl(MLAAttentionImpl):
         # use original TP o_proj weight in PD mix stage, and full gather
         # for o_proj weight for prefill stage.
         self.enable_dsa_cp_with_o_proj_tp = enable_dsa_cp_with_o_proj_tp()
-        self._o_proj_dynamic_quant = False
 
         if self.enable_dsa_cp:
             self.local_num_heads = self.num_heads * self.tp_size
@@ -619,7 +617,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                     if is_hidden_layer(layer):
                         post_process_after_loading_for_shard_weight_series(layer)
             else:
-                self._maybe_init_o_proj_tp_full_params()
+                self._init_o_proj_tp_full_params()
 
         if self.enable_mlapo:
             quant_method = getattr(
@@ -820,46 +818,6 @@ class AscendSFAImpl(MLAAttentionImpl):
         x = torch_npu.npu_interleave_rope(x, cos, sin)
         return x.view(B, N, D)
 
-    def _check_o_proj_dynamic_quant(self) -> bool:
-        return hasattr(self.o_proj, "weight_scale")
-
-    def _maybe_init_o_proj_tp_full_params(self):
-        if self._check_o_proj_dynamic_quant():
-            self._o_proj_dynamic_quant = True
-            self._init_dynamic_quant_o_proj_tp_full_params()
-        else:
-            self._init_o_proj_tp_full_params()
-
-    def _init_dynamic_quant_o_proj_tp_full_params(self):
-        """
-        Initialize TP-mode and Full-mode parameters for o_proj weight,
-        preparing for weight switching in PD mix stage.
-
-        For PD mix stage:
-        - Use original TP o_proj weight for decode phase
-        - Need full-gather o_proj weight from all TP ranks for prefill phase
-        """
-        if AscendSFAImpl.o_proj_full_pool is None:
-            sample = self.o_proj.weight
-            AscendSFAImpl.o_proj_full_pool = torch.empty(
-                (sample.shape[0] * self.tp_size, sample.shape[1]), dtype=sample.dtype, device=sample.device
-            )
-        if AscendSFAImpl.o_proj_full_weight_scale_pool is None:
-            sample = self.o_proj.weight_scale
-            AscendSFAImpl.o_proj_full_weight_scale_pool = torch.empty(
-                (sample.shape[0] * self.tp_size, sample.shape[1], sample.shape[2]),
-                dtype=sample.dtype,
-                device=sample.device,
-            )
-
-        # Save TP-mode parameters (original sharded weights)
-        self.o_proj_tp_weight = self.o_proj.weight.clone().detach()
-        self.o_proj_tp_weight_scale = self.o_proj.weight_scale.clone().detach()
-
-        # Initially switch to TP mode for graph capture
-        self.o_proj.weight.set_(self.o_proj_tp_weight)
-        self.o_proj.weight_scale.set_(self.o_proj_tp_weight_scale)
-
     def _init_o_proj_tp_full_params(self):
         """
         Initialize TP-mode and Full-mode parameters for o_proj weight,
@@ -905,52 +863,6 @@ class AscendSFAImpl(MLAAttentionImpl):
     def _switch_o_proj_params(self, params: dict[str, torch.Tensor]):
         for param_name, param in params.items():
             getattr(self.o_proj, param_name).set_(param)
-
-    def _handle_dynamic_quant_o_proj_weight_switch_and_forward(
-        self,
-        attn_output: torch.Tensor,
-        output: torch.Tensor,
-        o_proj_full_handle: torch.distributed.Work | None,
-        o_proj_full_weight_scale_handles: list[torch.distributed.Work] | None,
-        should_shard_weight: bool,
-    ) -> tuple[torch.Tensor, bool]:
-        """
-        Handle o_proj weight switching between TP-mode and Full-mode, and execute forward computation.
-        """
-        # Gather o_proj weight from all TP ranks for Full-mode computation
-        if should_shard_weight:
-            # Wait for the completion of o_proj weight all-gather operation
-            if o_proj_full_handle is not None:
-                o_proj_full_handle.wait()
-            if o_proj_full_weight_scale_handles is not None:
-                for handle in o_proj_full_weight_scale_handles:
-                    handle.wait()
-
-            # Switch o_proj to Full-mode (gathered weight from all TP ranks)
-            self.o_proj.weight.set_(AscendSFAImpl.o_proj_full_pool)
-            self.o_proj.weight_scale.set_(AscendSFAImpl.o_proj_full_weight_scale_pool)
-
-            # Apply quantization method and execute forward computation
-            output[...] = self.o_proj.quant_method.quant_method.apply(self.o_proj, attn_output)
-
-            # Switch o_proj back to TP-mode for subsequent decode operations
-            self.o_proj.weight.set_(self.o_proj_tp_weight)
-            self.o_proj.weight_scale.set_(self.o_proj_tp_weight_scale)
-
-            return output, False
-        else:
-            # For decode scenario: perform all-to-all communication on o_proj input activations
-            # Reshape for all-to-all: [batch * seq, tp_size, head_dim] -> [tp_size, batch * seq, head_dim]
-            send = (
-                attn_output.view(-1, self.tp_size, self.num_heads * self.v_head_dim)
-                .permute(1, 0, 2)
-                .reshape(-1, self.num_heads * self.v_head_dim)
-            )
-
-            attn_output = torch.empty_like(send)
-            torch.distributed.all_to_all_single(attn_output, send, group=get_tp_group().device_group)
-
-            return attn_output, True
 
     def _handle_o_proj_weight_switch_and_forward(
         self,
@@ -1308,7 +1220,7 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         # all-gather o_proj weight for prefill stage of PD mix node
         o_proj_full_handle = None
-        o_proj_full_weight_scale_handles = None
+        o_proj_full_param_handles = None
         # if is PD mix stage, using original TP o_proj weight, and also need to full gather for o_proj
         # weight for prefill stage.
         full_gather_o_proj_enabled = self.enable_dsa_cp_with_o_proj_tp and attn_metadata.attn_state not in {
@@ -1449,14 +1361,14 @@ class AscendSFAImpl(MLAAttentionImpl):
                     _, o_proj_full_handle = all_gather_async(
                         self.o_proj_tp_weight, get_tp_group(), output=AscendSFAImpl.o_proj_full_pool
                     )
-                    o_proj_full_weight_scale_handles = []
+                    o_proj_full_param_handles = []
                     for param_name, param in self.o_proj_tp_input_sharded_quant_params.items():
                         _, param_handle = all_gather_async(
                             param,
                             get_tp_group(),
                             output=self.o_proj_full_input_sharded_quant_params[param_name],
                         )
-                        o_proj_full_weight_scale_handles.append(param_handle)
+                        o_proj_full_param_handles.append(param_handle)
 
                 if kv_cache is not None:
                     assert fused_kv_no_split is not None
@@ -1570,21 +1482,13 @@ class AscendSFAImpl(MLAAttentionImpl):
             # When using SFA-CP with pd mixed, o_proj has two cases:
             # 1. prefill: o_proj is a TP weight, we need to all-gather o_proj weight to switch TP=1.
             # 2. decode: all-to-all the hidden_state before the o_proj forward.
-            if self._o_proj_dynamic_quant:
-                result, require_o_proj_forward = self._handle_dynamic_quant_o_proj_weight_switch_and_forward(
-                    attn_output=attn_output,
-                    output=output,
-                    o_proj_full_handle=o_proj_full_handle,
-                    o_proj_full_weight_scale_handles=o_proj_full_weight_scale_handles,
-                    should_shard_weight=full_gather_o_proj_enabled,
-                )
-            else:
-                result, require_o_proj_forward = self._handle_o_proj_weight_switch_and_forward(
-                    attn_output=attn_output,
-                    output=output,
-                    o_proj_full_handle=o_proj_full_handle,
-                    should_shard_weight=full_gather_o_proj_enabled,
-                )
+            result, require_o_proj_forward = self._handle_o_proj_weight_switch_and_forward(
+                attn_output=attn_output,
+                output=output,
+                o_proj_full_handle=o_proj_full_handle,
+                o_proj_full_param_handles=o_proj_full_param_handles,
+                should_shard_weight=full_gather_o_proj_enabled,
+            )
             if not require_o_proj_forward:
                 return result
             attn_output = result

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -859,9 +859,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         if self.o_proj_full_weight_gather_dim == 0:
             self.o_proj_tp_weight_gather_input = self.o_proj_tp_weight
         else:
-            self.o_proj_tp_weight_gather_input = (
-                self.o_proj_tp_weight.transpose(0, 1).contiguous()
-            )
+            self.o_proj_tp_weight_gather_input = self.o_proj_tp_weight.transpose(0, 1).contiguous()
         self.o_proj_tp_aclnn_input_params = {}
         self.o_proj_full_aclnn_input_params = {}
         for param_name in O_PROJ_ACLNN_INPUT_PARAMS:


### PR DESCRIPTION
### What this PR does / why we need it?
This PR refactors the parameter switching mechanism for `o_proj` in the Ascend SFA attention backend. Instead of hardcoding specific parameters like `aclnn_input_scale`, it introduces configurable parameter groups (`O_PROJ_ACLNN_INPUT_PARAMS` and `O_PROJ_INPUT_SHARDED_QUANT_PARAMS`) and a helper method `_switch_o_proj_params` to dynamically switch between TP-mode and Full-mode.

Feedback:
- There is a potential correctness issue when gathering multi-dimensional sharded quantization parameters (e.g., 2-D tensors), as the current shape allocation and gathering assume dimension 0 is the sharded dimension, which might not be correct if `input_dim == 1`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

GSM8K accuracy test for glm5-w4a8 weight:

| dataset | version | metric | mode | vllm-api-general-chat |
|----- | ----- | ----- | ----- | -----|
| gsm8k | 50861a | accuracy | gen | 93.25 |

Wait for MXFP8's accuracy test.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
