### PR TITLE
[DOC] Fix model name mismatch in DeepSeek-V4-Flash Functional Verification

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V4-Flash.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Flash.md
@@ -159,7 +159,7 @@ vllm serve /mnt/nfs_hw/weight/DeepSeek-V4-Flash-w8a8-mtp \
   --safetensors-load-strategy 'prefetch' \
   --max-model-len 135168 \
   --max-num-batched-tokens 4096 \
-  --served-model-name ds \
+  --served-model-name deepseek_v4 \
   --gpu-memory-utilization 0.92 \
   --max-num-seqs 16 \
   --data-parallel-size 1 \
@@ -204,7 +204,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/DeepSeek-V4-Flash-w8a8
     --enable-prefix-caching \
     --max_model_len 1024000 \
     --max-num-batched-tokens 8192 \
-    --served-model-name dsv4 \
+    --served-model-name deepseek_v4 \
     --gpu-memory-utilization 0.9 \
     --api-server-count 1 \
     --max-num-seqs 16 \


### PR DESCRIPTION
Fixes #10411

### What this PR does / why we need it?
This PR fixes a documentation error where the model name in Single-node Deployment 
does not match the model name used in Functional Verification examples.
Users following the Single-node Deployment guide would encounter errors when 
running the Functional Verification example because:
- A2 series uses `--served-model-name 'ds'`
- A3 series uses `--served-model-name 'dsv4'`
- Functional Verification uses `"model": "deepseek_v4"`
Now all scenarios consistently use `'deepseek_v4'`, ensuring the examples work correctly.

### Does this PR introduce _any_ user-facing change?
No user-facing change. This is a documentation-only update that corrects parameter 
values to ensure consistency across examples. No API, interface, or behavior changes 
are introduced.

### How was this patch tested?
Manual verification by checking:
1. Single-node Deployment A2 series: `--served-model-name deepseek_v4`
2. Single-node Deployment A3 series: `--served-model-name deepseek_v4`
3. Functional Verification: `"model": "deepseek_v4"`
4. All scenarios now use the same model name
Confirmed the fix resolves the mismatch issue described in #10411.
