### PR TITLE
[CI] Add commit-pinned image build mode for vllm + vllm-ascend

### DIFF
--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -42,6 +42,21 @@ on:
         required: false
         type: string
         default: 'digests'
+      vllm_commit:
+        description: 'vLLM commit hash to checkout (used when set; mutually exclusive with tag/branch).'
+        required: false
+        type: string
+        default: ''
+      vllm_ascend_commit:
+        description: 'vllm-ascend commit hash to checkout (used when set; mutually exclusive with tag/branch).'
+        required: false
+        type: string
+        default: ''
+      temp_only:
+        description: 'If true, push only to QUAY_TEMP_REPO and skip the merge-image job (no push to QUAY_REPO).'
+        required: false
+        type: boolean
+        default: false
     secrets:
         QUAY_PASSWORD:
             description: 'Quay password for pushing images'
@@ -79,14 +94,46 @@ jobs:
       run: |
         tag="${{ inputs.workflow_dispatch_tag }}"
         branch="${{ inputs.branch_ref }}"
-        if [[ -n "$tag" && -n "$branch" ]]; then
-          echo "Error: 'tag' and 'branch' are mutually exclusive. Please specify only one."
-          exit 1
+        vllm_commit="${{ inputs.vllm_commit }}"
+        vllm_ascend_commit="${{ inputs.vllm_ascend_commit }}"
+
+        commit_mode="false"
+        if [[ -n "$vllm_commit" || -n "$vllm_ascend_commit" ]]; then
+          if [[ -z "$vllm_commit" || -z "$vllm_ascend_commit" ]]; then
+            echo "Error: 'vllm_commit' and 'vllm_ascend_commit' must be specified together."
+            exit 1
+          fi
+          for c in "$vllm_commit" "$vllm_ascend_commit"; do
+            if ! echo "$c" | grep -Eq '^[0-9a-f]{7,40}$'; then
+              echo "Error: invalid commit format: $c (expected 7-40 hex chars)."
+              exit 1
+            fi
+          done
+          commit_mode="true"
         fi
-        if [[ -z "$tag" && -z "$branch" ]]; then
-          echo "Error: Either 'tag' or 'branch' must be specified."
-          exit 1
+
+        if [[ "$commit_mode" == "true" ]]; then
+          if [[ -n "$tag" || -n "$branch" ]]; then
+            echo "Error: commit mode is mutually exclusive with 'tag'/'branch'."
+            exit 1
+          fi
+        else
+          if [[ -n "$tag" && -n "$branch" ]]; then
+            echo "Error: 'tag' and 'branch' are mutually exclusive. Please specify only one."
+            exit 1
+          fi
+          if [[ -z "$tag" && -z "$branch" ]]; then
+            echo "Error: Either 'tag', 'branch', or (vllm_commit + vllm_ascend_commit) must be specified."
+            exit 1
+          fi
         fi
+
+    - uses: actions/checkout@v6
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.vllm_ascend_commit != '' }}
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+        ref: ${{ inputs.vllm_ascend_commit }}
 
     - uses: actions/checkout@v6
       if: ${{ github.event_name != 'workflow_dispatch' }}
@@ -103,7 +150,7 @@ jobs:
         ref: ${{ inputs.workflow_dispatch_tag }}
 
     - uses: actions/checkout@v6
-      if: ${{ github.event_name == 'workflow_dispatch' && inputs.workflow_dispatch_tag == '' }}
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.workflow_dispatch_tag == '' && inputs.vllm_ascend_commit == '' }}
       with:
         fetch-depth: 0
         persist-credentials: false
@@ -186,6 +233,7 @@ jobs:
         build-args: |
           PIP_INDEX_URL=https://pypi.org/simple
           COMPILE_CUSTOM_KERNELS=${{ steps.cache-csrc.outputs.cache-hit == 'true' && '0' || '1' }}
+          VLLM_COMMIT=${{ inputs.vllm_commit }}
         provenance: false
         # To speed up the build, we use registry cache. The cache tag is determined by the suffix and architecture, and shared across different workflow runs.
         # For example, the cache tag for arm64 image with suffix "openeuler" will be "buildcache-openeuler-arm64".
@@ -202,7 +250,13 @@ jobs:
         if [ -n "${{ inputs.suffix }}" ]; then
           SUFFIX="-${{ inputs.suffix }}"
         fi
-        TAG="nightly-${{ inputs.schedule_tag_pattern }}${SUFFIX}-${{ matrix.tag }}-temp"
+        if [ "${{ inputs.temp_only }}" = "true" ]; then
+          VLLM_SHORT=$(echo "${{ inputs.vllm_commit }}" | cut -c1-7)
+          ASCEND_SHORT=$(echo "${{ inputs.vllm_ascend_commit }}" | cut -c1-7)
+          TAG="vllm-ascend-${VLLM_SHORT}-${ASCEND_SHORT}${SUFFIX}-${{ matrix.tag }}-temp"
+        else
+          TAG="nightly-${{ inputs.schedule_tag_pattern }}${SUFFIX}-${{ matrix.tag }}-temp"
+        fi
         echo "Creating temp tag: ${{ env.QUAY_TEMP_REPO }}:$TAG"
         docker buildx imagetools create \
           -t "${{ env.QUAY_TEMP_REPO }}:$TAG" \
@@ -227,7 +281,7 @@ jobs:
   merge-image:
     runs-on: ubuntu-latest
     needs: build-push-digest
-    if: ${{ inputs.should_push }}
+    if: ${{ inputs.should_push && !inputs.temp_only }}
     steps:
       - name: Checkout branch
         uses: actions/checkout@v6
@@ -326,3 +380,52 @@ jobs:
               -t "$tag" \
               $DIGESTS
           done
+
+  merge-image-temp:
+    name: merge-image-temp
+    runs-on: ubuntu-latest
+    needs: build-push-digest
+    if: ${{ inputs.should_push && inputs.temp_only }}
+    steps:
+      - name: Download arm64 digests
+        uses: actions/download-artifact@v8
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: ${{ inputs.artifact_prefix }}-${{ inputs.suffix }}-arm64
+          merge-multiple: true
+
+      - name: Download amd64 digests
+        uses: actions/download-artifact@v8
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: ${{ inputs.artifact_prefix }}-${{ inputs.suffix }}-amd64
+          merge-multiple: true
+
+      - name: Login to Quay Temp
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ inputs.quay_temp_username }}
+          password: ${{ secrets.QUAY_TEMP_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Merge and push multi-arch manifest to QUAY_TEMP_REPO
+        env:
+          IMAGE: ${{ env.QUAY_TEMP_REPO }}
+        run: |
+          set -euo pipefail
+          SUFFIX=""
+          if [ -n "${{ inputs.suffix }}" ]; then
+            SUFFIX="-${{ inputs.suffix }}"
+          fi
+          VLLM_SHORT=$(echo "${{ inputs.vllm_commit }}" | cut -c1-7)
+          ASCEND_SHORT=$(echo "${{ inputs.vllm_ascend_commit }}" | cut -c1-7)
+          TAG="${IMAGE}:vllm-ascend-${VLLM_SHORT}-${ASCEND_SHORT}${SUFFIX}"
+          DIGESTS=$(printf "$IMAGE@sha256:%s " $(ls ${{ runner.temp }}/digests))
+          echo "Digests: $DIGESTS"
+          echo "Creating multi-arch manifest tag: $TAG"
+          docker buildx imagetools create \
+            -t "$TAG" \
+            $DIGESTS

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -45,6 +45,16 @@ on:
           - releases/v0.20.2rc
           - releases/v0.18.0
           - none
+      vllm_commit:
+        description: 'vLLM commit hash (must be paired with vllm_ascend_commit; mutually exclusive with tag/branch). Image will be pushed only to QUAY_TEMP_USERNAME.'
+        required: false
+        default: ''
+        type: string
+      vllm_ascend_commit:
+        description: 'vllm-ascend commit hash (must be paired with vllm_commit; mutually exclusive with tag/branch). Image will be pushed only to QUAY_TEMP_USERNAME.'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   packages: write
@@ -53,7 +63,8 @@ permissions:
 jobs:
   image_build:
     name: Image Build and Push
-    if: ${{ (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'image-build')) && github.event_name != 'schedule' }}
+    if: ${{ ((github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'image-build')) && github.event_name != 'schedule')
+        && !(github.event_name == 'workflow_dispatch' && inputs.vllm_commit != '' && inputs.vllm_ascend_commit != '') }}
     strategy:
       matrix:
         build_meta:
@@ -86,6 +97,50 @@ jobs:
       branch_ref: ${{ inputs.branch != 'none' && inputs.branch || '' }}
     secrets:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      QUAY_TEMP_PASSWORD: ${{ secrets.QUAY_TEMP_PASSWORD }}
+
+  image_build_by_commit:
+    name: Image Build (commit mode) and Push to QUAY_TEMP
+    if: ${{ github.event_name == 'workflow_dispatch'
+        && inputs.vllm_commit != ''
+        && inputs.vllm_ascend_commit != ''
+        && inputs.tag == 'none'
+        && inputs.branch == 'none' }}
+    strategy:
+      matrix:
+        build_meta:
+          - name: A2 Ubuntu
+            dockerfile: Dockerfile
+            suffix: ''
+          - name: A2 openeuler
+            dockerfile: Dockerfile.openEuler
+            suffix: 'openeuler'
+          - name: A3 Ubuntu
+            dockerfile: Dockerfile.a3
+            suffix: 'a3'
+          - name: A3 openEuler
+            dockerfile: Dockerfile.a3.openEuler
+            suffix: 'a3-openeuler'
+          - name: 310P Ubuntu
+            dockerfile: Dockerfile.310p
+            suffix: '310p'
+          - name: 310P openEuler
+            dockerfile: Dockerfile.310p.openEuler
+            suffix: '310p-openeuler'
+    uses: ./.github/workflows/_schedule_image_build.yaml
+    with:
+      dockerfile: ${{ matrix.build_meta.dockerfile }}
+      suffix: ${{ matrix.build_meta.suffix }}
+      quay_temp_username: ${{ vars.QUAY_TEMP_USERNAME }}
+      # Commit mode always pushes (to QUAY_TEMP_REPO only) and never promotes
+      # the image to QUAY_REPO via merge-image, so quay_username is intentionally omitted.
+      should_push: true
+      temp_only: true
+      vllm_commit: ${{ inputs.vllm_commit }}
+      vllm_ascend_commit: ${{ inputs.vllm_ascend_commit }}
+      workflow_dispatch_tag: ''
+      branch_ref: ''
+    secrets:
       QUAY_TEMP_PASSWORD: ${{ secrets.QUAY_TEMP_PASSWORD }}
 
   schedule_image_build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,14 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.22.1
-RUN git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
+ARG VLLM_COMMIT=""
+RUN if [ -n "$VLLM_COMMIT" ]; then \
+      git init /vllm-workspace/vllm && \
+      git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
+      git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
+    else \
+      git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
+    fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -34,7 +34,14 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.22.1
-RUN git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
+ARG VLLM_COMMIT=""
+RUN if [ -n "$VLLM_COMMIT" ]; then \
+      git init /vllm-workspace/vllm && \
+      git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
+      git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
+    else \
+      git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
+    fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -33,7 +33,14 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.22.1
-RUN git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
+ARG VLLM_COMMIT=""
+RUN if [ -n "$VLLM_COMMIT" ]; then \
+      git init /vllm-workspace/vllm && \
+      git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
+      git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
+    else \
+      git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
+    fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -50,7 +50,14 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.22.1
-RUN git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
+ARG VLLM_COMMIT=""
+RUN if [ -n "$VLLM_COMMIT" ]; then \
+      git init /vllm-workspace/vllm && \
+      git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
+      git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
+    else \
+      git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
+    fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -48,7 +48,14 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.22.1
-RUN git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
+ARG VLLM_COMMIT=""
+RUN if [ -n "$VLLM_COMMIT" ]; then \
+      git init /vllm-workspace/vllm && \
+      git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
+      git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
+    else \
+      git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
+    fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -48,7 +48,14 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.22.1
-RUN git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
+ARG VLLM_COMMIT=""
+RUN if [ -n "$VLLM_COMMIT" ]; then \
+      git init /vllm-workspace/vllm && \
+      git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
+      git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
+    else \
+      git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
+    fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \


### PR DESCRIPTION
### What this PR does / why we need it?

Add a new "commit mode" to the image build workflow that allows building and pushing Docker images pinned to specific commit hashes of both vllm and vllm-ascend, instead of only supporting tag/branch-based builds.

Images built in commit mode are pushed exclusively to `QUAY_TEMP_REPO` and are never promoted to the main `QUAY_REPO`.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
