### PR TITLE
[CI] Added the nightly test case DeepSeek-V4-Flash-W8A8-A3 and fixed the failed weekly test case.

### DIFF
--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -319,6 +319,9 @@ jobs:
           - name: Qwen3.5-122B-A10B-W8A8-A3
             os: linux-aarch64-a3-16
             config_file_path: Qwen3.5-122B-A10B-W8A8-A3.yaml
+          - name: DeepSeek-V4-Flash-W8A8-A3
+            os: linux-aarch64-a3-16
+            config_file_path: DeepSeek-V4-Flash-W8A8-A3.yaml
     uses: ./.github/workflows/_e2e_nightly_single_node.yaml
     with:
       runner: ${{ matrix.test_config.os }}

--- a/tests/e2e/nightly/single_node/models/configs/DeepSeek-V4-Flash-W8A8-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/DeepSeek-V4-Flash-W8A8-A3.yaml
@@ -11,13 +11,12 @@ test_cases:
       OMP_PROC_BIND: "false"
       OMP_NUM_THREADS: "1"
       PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-      USE_MULTI_BLOCK_POOL: "1"
-      USE_MULTI_GROUPS_KV_CACHE: "1"
       HCCL_BUFFSIZE: "1024"
       VLLM_ASCEND_ENABLE_FUSED_MC2: "0"
       VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
       ASCEND_LAUNCH_BLOCKING: "0"
       SERVER_PORT: "DEFAULT_PORT"
+      VLLM_ENGINE_READY_TIMEOUT_S: "3000"
     server_cmd:
       - "--enable-prefix-caching"
       - "--max-model-len"
@@ -29,9 +28,9 @@ test_cases:
       - "--max-num-seqs"
       - "64"
       - "--data-parallel-size"
-      - "2"
+      - "4"
       - "--tensor-parallel-size"
-      - "8"
+      - "4"
       - "--enable-expert-parallel"
       - "--tokenizer-mode"
       - "deepseek_v4"
@@ -56,7 +55,7 @@ test_cases:
       - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       - "--async-scheduling"
       - "--additional-config"
-      - '{"ascend_compilation_config":{"enable_npugraph_ex":true,"enable_static_kernel":false},"enable_cpu_binding":"true","enable_shared_expert_dp":true,"multistream_overlap_shared_expert":true,"multistream_dsa_preprocess":false}'
+      - '{"ascend_compilation_config":{"enable_npugraph_ex":true,"enable_static_kernel":false},"enable_cpu_binding":"true","multistream_overlap_shared_expert":true,"multistream_dsa_preprocess":false}'
     benchmarks:
       acc-gpqa:
         case_type: accuracy
@@ -66,16 +65,16 @@ test_cases:
         max_out_len: 65536
         batch_size: 32
         baseline: 86.36
-        threshold: 3
+        threshold: 4
         thinking: true
       perf:
         case_type: performance
-        dataset_path: vllm-ascend/GSM8K_prefix90_in131072_bs100_deepseek
+        dataset_path: vllm-ascend/GSM8K_prefix0_in32768_bs1000_deepseek
         request_conf: vllm_api_stream_chat
         dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
-        num_prompts: 32
+        num_prompts: 64
         max_out_len: 1024
-        batch_size: 8
+        batch_size: 16
         request_rate: 0
         baseline: 1
         threshold: 0.97

--- a/tests/e2e/nightly/single_node/models/configs/DeepSeek-V4-Flash-W8A8-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/DeepSeek-V4-Flash-W8A8-A3.yaml
@@ -65,7 +65,7 @@ test_cases:
         max_out_len: 65536
         batch_size: 32
         baseline: 86.36
-        threshold: 4
+        threshold: 3
         thinking: true
       perf:
         case_type: performance

--- a/tests/e2e/weekly/single_node/configs/Kimi-K2.5.yaml
+++ b/tests/e2e/weekly/single_node/configs/Kimi-K2.5.yaml
@@ -13,6 +13,7 @@ _envs: &envs
   VLLM_ASCEND_ENABLE_MLAPO: "1"
   VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
   VLLM_ASCEND_ENABLE_NZ: "1"
+  VLLM_ENGINE_READY_TIMEOUT_S: "3000"
 
 _server_cmd: &server_cmd
   - "--enable-expert-parallel"
@@ -48,18 +49,17 @@ _benchmark_acc: &_benchmark_acc
     threshold: 5
 
 _benchmark_TPOT50_3_5k_1_5k: &_benchmark_TPOT50_3_5k_1_5k
-  perf:
-    case_type: performance
-    dataset_path: vllm-ascend/GSM8K-in3500-bs2800
-    request_conf: vllm_api_stream_chat
-    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
-    num_prompts: 392
-    max_out_len: 1500
-    batch_size: 98
-    trust_remote_code: true
-    request_rate: 0
-    baseline: 1
-    threshold: 0.97
+  case_type: performance
+  dataset_path: vllm-ascend/GSM8K-in3500-bs2800
+  request_conf: vllm_api_stream_chat
+  dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+  num_prompts: 392
+  max_out_len: 1500
+  batch_size: 98
+  trust_remote_code: true
+  request_rate: 0
+  baseline: 1
+  threshold: 0.97
 
 _benchmark_TPOT50_16K_1K: &_benchmark_TPOT50_16K_1K
   case_type: performance

--- a/tests/e2e/weekly/single_node/configs/Kimi-K2.5.yaml
+++ b/tests/e2e/weekly/single_node/configs/Kimi-K2.5.yaml
@@ -248,6 +248,8 @@ test_cases:
       HCCL_BUFFSIZE: "400"
       VLLM_ASCEND_BALANCE_SCHEDULING: "1"
     server_cmd:
+      - "--port"
+      - "$SERVER_PORT"
       - "--tool-call-parser"
       - "kimi_k2"
       - "--reasoning-parser"


### PR DESCRIPTION
### What this PR does / why we need it?

We run the nightly and weekly test case at a fixed period. Add nightly case: DeepSeek-V4-Flash-W8A8-A3. Fixed the failed weekly test case: Kimi-K2.5.yaml.

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

by running the DeepSeek-V4-Flash-W8A8-A3 test and failed weekly test.

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
