### PR TITLE
[0.21][Patch][BugFix] Align custom schedulers with vLLM 0.21 skipped_waiting queue for structured output

### DIFF
--- a/vllm_ascend/core/scheduler_dynamic_batch.py
+++ b/vllm_ascend/core/scheduler_dynamic_batch.py
@@ -300,39 +300,32 @@ class SchedulerDynamicBatch(Scheduler):
             )
             assert len(scheduled_loras) <= self.lora_config.max_loras
 
-        # Use a temporary RequestQueue to collect requests that need to be
-        # skipped and put back at the head of the waiting queue later
-        skipped_waiting_requests = create_request_queue(self.policy)
-
         # Next, schedule the WAITING requests.
         if not preempted_reqs:
-            while self.waiting and token_budget > 0:
+            step_skipped_waiting = create_request_queue(self.policy)
+
+            while (self.waiting or self.skipped_waiting) and token_budget > 0:
                 if len(self.running) == self.max_num_running_reqs:
                     break
 
-                request = self.waiting.peek_request()
+                request_queue = self._select_waiting_queue_for_scheduling()
+                if request_queue is None:
+                    break
 
-                # KVTransfer: skip request if still waiting for remote kvs.
-                if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
-                    is_ready = self._update_waiting_for_remote_kv(request)
-                    if is_ready:
-                        request.status = RequestStatus.WAITING
-                    else:
-                        logger.debug("%s is still in WAITING_FOR_REMOTE_KVS state.", request.request_id)
-                        self.waiting.pop_request()
-                        skipped_waiting_requests.prepend_request(request)
-                        continue
+                request = request_queue.peek_request()
 
-                # Skip request if the structured output request is still waiting
-                # for FSM compilation.
-                if request.status == RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR:
-                    structured_output_req = request.structured_output_request
-                    if structured_output_req and structured_output_req.grammar:
-                        request.status = RequestStatus.WAITING
-                    else:
-                        self.waiting.pop_request()
-                        skipped_waiting_requests.prepend_request(request)
-                        continue
+                # try to promote blocked statuses while traversing skipped queue.
+                if self._is_blocked_waiting_status(request.status) and not self._try_promote_blocked_waiting_request(
+                    request
+                ):
+                    if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                        logger.debug(
+                            "%s is still in WAITING_FOR_REMOTE_KVS state.",
+                            request.request_id,
+                        )
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
+                    continue
 
                 # Check that adding the request still respects the max_loras
                 # constraint.
@@ -345,8 +338,8 @@ class SchedulerDynamicBatch(Scheduler):
                     )
                 ):
                     # Scheduling would exceed max_loras, skip.
-                    self.waiting.pop_request()
-                    skipped_waiting_requests.prepend_request(request)
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
                     continue
 
                 num_external_computed_tokens = 0
@@ -369,8 +362,8 @@ class SchedulerDynamicBatch(Scheduler):
                             # The request cannot be scheduled because
                             # the KVConnector couldn't determine
                             # the number of matched tokens.
-                            self.waiting.pop_request()
-                            skipped_waiting_requests.prepend_request(request)
+                            request_queue.pop_request()
+                            step_skipped_waiting.prepend_request(request)
                             continue
 
                     # Total computed tokens (local + external).
@@ -401,8 +394,8 @@ class SchedulerDynamicBatch(Scheduler):
                     # chunked prefill has to be enabled explicitly to allow
                     # pooling requests to be chunked
                     if not self.scheduler_config.enable_chunked_prefill and num_new_tokens > token_budget:
-                        self.waiting.pop_request()
-                        skipped_waiting_requests.prepend_request(request)
+                        request_queue.pop_request()
+                        step_skipped_waiting.prepend_request(request)
                         continue
 
                     num_new_tokens = min(num_new_tokens, token_budget)
@@ -461,14 +454,13 @@ class SchedulerDynamicBatch(Scheduler):
                         num_external_computed_tokens,
                     )
 
-                # Request was already popped from self.waiting
-                # unless it was re-added above due to new_blocks being None.
-                request = self.waiting.pop_request()
+                request = request_queue.pop_request()
                 if load_kv_async:
                     # If loading async, allocate memory and put request
                     # into the WAITING_FOR_REMOTE_KV state.
-                    skipped_waiting_requests.prepend_request(request)
                     request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+                    step_skipped_waiting.prepend_request(request)
+                    request.num_computed_tokens = num_computed_tokens
                     continue
 
                 req_index += 1
@@ -497,9 +489,9 @@ class SchedulerDynamicBatch(Scheduler):
                         self.encoder_cache_manager.allocate(request, i)
                     encoder_compute_budget = new_encoder_compute_budget
 
-        # Put back any skipped requests at the head of the waiting queue
-        if skipped_waiting_requests:
-            self.waiting.prepend_requests(skipped_waiting_requests)
+            # re-queue requests skipped in this pass ahead of older skipped items.
+            if step_skipped_waiting:
+                self.skipped_waiting.prepend_requests(step_skipped_waiting)
 
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -273,11 +273,9 @@ class BalanceScheduler(Scheduler):
 
         # Next, schedule the WAITING requests.
         if not preempted_reqs and self._pause_state == PauseState.UNPAUSED:
-            # Use a temporary RequestQueue to collect requests that need to be
-            # skipped and put back at the head of the waiting queue later
-            skipped_waiting_requests = create_request_queue(self.policy)
+            step_skipped_waiting = create_request_queue(self.policy)
 
-            while self.waiting and token_budget > 0:
+            while (self.waiting or self.skipped_waiting) and token_budget > 0:
                 if len(self.running) == self.max_num_running_reqs:
                     break
 
@@ -285,43 +283,24 @@ class BalanceScheduler(Scheduler):
                 if balance_flag:
                     break
 
-                request = self.waiting.peek_request()
+                request_queue = self._select_waiting_queue_for_scheduling()
+                if request_queue is None:
+                    break
+
+                request = request_queue.peek_request()
                 request_id = request.request_id
 
-                # KVTransfer: skip request if still waiting for remote kvs.
-                if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
-                    if request.request_id not in self.finished_recving_kv_req_ids:
+                # try to promote blocked statuses while traversing skipped queue.
+                if self._is_blocked_waiting_status(request.status) and not self._try_promote_blocked_waiting_request(
+                    request
+                ):
+                    if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                         logger.debug(
                             "%s is still in WAITING_FOR_REMOTE_KVS state.",
                             request_id,
                         )
-                        self.waiting.pop_request()
-                        skipped_waiting_requests.prepend_request(request)
-                        continue
-                    self._update_waiting_for_remote_kv(request)
-                    if request.num_preemptions:
-                        # We must be loading for a resumed preemption
-                        # rather than a new request.
-                        request.status = RequestStatus.PREEMPTED
-                    else:
-                        request.status = RequestStatus.WAITING
-
-                # Skip request if the structured output request is still waiting
-                # for FSM compilation.
-                if request.status == RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR:
-                    structured_output_req = request.structured_output_request
-                    if structured_output_req and structured_output_req.grammar:
-                        request.status = RequestStatus.WAITING
-                    else:
-                        self.waiting.pop_request()
-                        skipped_waiting_requests.prepend_request(request)
-                        continue
-
-                # Streaming: skip request if still waiting for next streaming req.
-                if request.status == RequestStatus.WAITING_FOR_STREAMING_REQ:
-                    assert not request.streaming_queue
-                    self.waiting.pop_request()
-                    skipped_waiting_requests.prepend_request(request)
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
                     continue
 
                 # Check that adding the request still respects the max_loras
@@ -335,8 +314,8 @@ class BalanceScheduler(Scheduler):
                     )
                 ):
                     # Scheduling would exceed max_loras, skip.
-                    self.waiting.pop_request()
-                    skipped_waiting_requests.prepend_request(request)
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
                     continue
 
                 num_external_computed_tokens = 0
@@ -360,8 +339,8 @@ class BalanceScheduler(Scheduler):
                             # The request cannot be scheduled because
                             # the KVConnector couldn't determine
                             # the number of matched tokens.
-                            self.waiting.pop_request()
-                            skipped_waiting_requests.prepend_request(request)
+                            request_queue.pop_request()
+                            step_skipped_waiting.prepend_request(request)
                             continue
 
                         num_external_computed_tokens = ext_tokens
@@ -489,14 +468,13 @@ class BalanceScheduler(Scheduler):
                             preempted=request.num_preemptions > 0,
                         )
 
-                # Request was already popped from self.waiting
-                # unless it was re-added above due to new_blocks being None.
-                request = self.waiting.pop_request()
+                request = request_queue.pop_request()
                 if load_kv_async:
                     # If loading async, allocate memory and put request
                     # into the WAITING_FOR_REMOTE_KV state.
-                    skipped_waiting_requests.prepend_request(request)
                     request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+                    step_skipped_waiting.prepend_request(request)
+                    request.num_computed_tokens = num_computed_tokens
                     continue
 
                 self.running.append(request)
@@ -530,9 +508,9 @@ class BalanceScheduler(Scheduler):
                         if self.ec_connector is not None:
                             self.ec_connector.update_state_after_alloc(request, i)
 
-            # Put back any skipped requests at the head of the waiting queue
-            if skipped_waiting_requests:
-                self.waiting.prepend_requests(skipped_waiting_requests)
+            # re-queue requests skipped in this pass ahead of older skipped items.
+            if step_skipped_waiting:
+                self.skipped_waiting.prepend_requests(step_skipped_waiting)
 
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())


### PR DESCRIPTION
### What this PR does / why we need it?

vLLM 0.18+ routes blocked waiting requests (including `response_format` → `WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR`) into `skipped_waiting` via `_enqueue_waiting_request()`. `BalanceScheduler` and `SchedulerDynamicBatch` still used pre-0.18 waiting-loop logic:

- Only iterated `self.waiting`, never `self.skipped_waiting`
- Re-queued skipped requests back to `self.waiting` instead of `self.skipped_waiting`
- Inlined blocked-status handling instead of upstream `_is_blocked_waiting_status()` / `_try_promote_blocked_waiting_request()`

As a result, requests with structured output could hang indefinitely when balance scheduling (`--additional-config '{"enable_balance_scheduling": true}'`) or dynamic batch scheduling was enabled.

This PR aligns both schedulers with upstream vLLM 0.20 and the existing `recompute_scheduler` / `ProfilingChunkScheduler` pattern:

- `while (self.waiting or self.skipped_waiting)` with `_select_waiting_queue_for_scheduling()`
- Blocked-status promotion via `_is_blocked_waiting_status()` and `_try_promote_blocked_waiting_request()`
- Re-queue skipped requests to `self.skipped_waiting` via `step_skipped_waiting`
- Set `request.num_computed_tokens` on async KV load path

Fixes structured output hang for balance scheduling and dynamic batch paths. Default deployment (balance off, dynamic batch off) was already unaffected via `super().schedule()`.

Fixes #10537 

### Does this PR introduce _any_ user-facing change?

Yes. Requests using `response_format` no longer hang when balance scheduling or dynamic batch scheduling is enabled. No API or CLI changes.

### How was this patch tested?

- Code review against upstream `vllm/v1/core/sched/scheduler.py` and aligned schedulers (`recompute_scheduler.py`, `scheduler_profiling_chunk.py`).
- Manual verification scenario: serve with `--additional-config '{"enable_balance_scheduling": true}'`, send `/v1/chat/completions` with `"response_format": {"type": "json_object"}` — request completes instead of hanging.
- Existing CI unit tests pass; no dedicated UT for `BalanceScheduler` / `SchedulerDynamicBatch` structured-output scheduling path yet.

**Startup**
```
vllm serve /mnt/weight/Qwen3-0.6B/ \
  --served-model-name "qwen" \
  --tensor-parallel-size 1 \
  --enforce-eager \
  --additional-config '{"enable_balance_scheduling": true}'
```

**Request**
```
curl http://localhost:8000/v1/chat/completions \
-H "Content-Type: application/json" \
-d '{
"model": "qwen",
"messages": [
{"role": "system", "content": "你是专业的白酒商品信息提取专家，严格按照规则提取信息并输出JSON格式"},
{"role": "user", "content": "山西杏花村汾酒53度黄盖475ml*6瓶，整箱玻汾清香型国产高度白酒，66.00，汾酒官方旗舰店"}
],
"response_format": {"type":"json_object"},
"chat_template_kwargs":{"enable_thinking":false}
}'
```

**Response**
```
{"id":"chatcmpl-a6ee5ced946baace","object":"chat.completion","created":1781580457,"model":"qwen","choices":[{"index":0,"message":{"role":"assistant","content":"{\n  \"product_name\": \"山西杏花村汾酒\",\n  \"degree\": \"53度\",\n  \"volume\": \"475ml\",\n  \"quantity\": \"6瓶\",\n  \"type\": \"整箱玻汾清香型国产高度白酒\",\n  \"price\": \"66.00\",\n  \"brand\": \"汾酒官方旗舰店\"\n}","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":72,"total_tokens":151,"completion_tokens":79,"prompt_tokens_details":null,"completion_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}
```