### PR TITLE
[Doc] Add API parameter support matrix for Ascend NPU

### DIFF
--- a/docs/source/user_guide/configuration/api_support.md
+++ b/docs/source/user_guide/configuration/api_support.md
@@ -2,8 +2,8 @@
 
 vLLM Ascend is fully compatible with the upstream vLLM API. The vast majority of `vllm serve` CLI parameters work on Ascend NPU out of the box, with no additional configuration required. For general usage instructions, please refer to the vLLM community documentation:
 
-- [vLLM Serving Documentation](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html)
-- [vLLM Engine Arguments](https://docs.vllm.ai/en/latest/serving/engine_args.html)
+- [vLLM Serving Documentation](https://docs.vllm.ai/en/latest/serving/online_serving.html)
+- [vLLM CLI Reference](https://docs.vllm.ai/en/latest/cli/.html)
 - [vLLM API Reference](https://docs.vllm.ai/en/latest/api/index.html)
 
 This page **only** documents the parameters that are **not supported**, **silently reset**, or **partially limited** on Ascend NPU due to hardware differences or missing backend support. For any parameters not listed below, they are supported by default — please refer to the vLLM documentation above for usage instructions.
@@ -12,7 +12,7 @@ Some GPU-specific parameters have Ascend-native equivalents exposed via `--addit
 
 ## Parameters Silently Reset by Ascend
 
-When any of the following parameters are set, vLLM Ascend will log a warning and automatically reset them to a safe default. The service will still start normally. The reset logic is implemented in [`vllm_ascend/platform.py` → `_fix_incompatible_config`](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/platform.py).
+When any of the following parameters are set, vLLM Ascend will log a warning and automatically reset them to a safe default. The service will still start normally. The reset logic is implemented in [`vllm_ascend/platform.py` → `_fix_incompatible_config`](https://github.com/vllm-project/vllm-ascend/tree/main/vllm_ascend/platform.py).
 
 ### ModelConfig
 

--- a/docs/source/user_guide/configuration/api_support.md
+++ b/docs/source/user_guide/configuration/api_support.md
@@ -1,0 +1,96 @@
+# API Parameter Support
+
+vLLM Ascend is fully compatible with the upstream vLLM API. The vast majority of `vllm serve` CLI parameters work on Ascend NPU out of the box, with no additional configuration required. For general usage instructions, please refer to the vLLM community documentation:
+
+- [vLLM Serving Documentation](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html)
+- [vLLM Engine Arguments](https://docs.vllm.ai/en/latest/serving/engine_args.html)
+- [vLLM API Reference](https://docs.vllm.ai/en/latest/api/index.html)
+
+This page **only** documents the parameters that are **not supported**, **silently reset**, or **partially limited** on Ascend NPU due to hardware differences or missing backend support. For any parameters not listed below, they are supported by default — please refer to the vLLM documentation above for usage instructions.
+
+Some GPU-specific parameters have Ascend-native equivalents exposed via `--additional-config`. See [Additional Configuration](additional_config.md) for the full list of Ascend-specific options.
+
+## Parameters Silently Reset by Ascend
+
+When any of the following parameters are set, vLLM Ascend will log a warning and automatically reset them to a safe default. The service will still start normally. The reset logic is implemented in [`vllm_ascend/platform.py` → `_fix_incompatible_config`](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/platform.py).
+
+### ModelConfig
+
+| Parameter | Default Reset | Reason |
+|-----------|--------------|--------|
+| `--disable-cascade-attn` | `False` | Cascade Attention is a GPU-specific feature not available on Ascend NPU. |
+
+### CacheConfig
+
+| Parameter | Default Reset | Reason |
+|-----------|--------------|--------|
+| `--cpu-kvcache-space` | `None` | CPU KV cache space configuration is tied to an incompatible memory backend. |
+
+### MultiModalConfig
+
+| Parameter | Default Reset | Reason |
+|-----------|--------------|--------|
+| `--mm-encoder-attn-backend` | `None` | Ascend uses a different mechanism for multi-modal encoder attention; this parameter is ignored. |
+
+### ObservabilityConfig
+
+| Parameter | Default Reset | Reason |
+|-----------|--------------|--------|
+| `--enable-layerwise-nvtx-tracing` | `False` | NVTX tracing is an NVIDIA-specific profiling tool not available on Ascend. |
+
+### SchedulerConfig
+
+| Parameter | Default Reset | Reason |
+|-----------|--------------|--------|
+| `--max-num-partial-prefills` | `1` | Partial prefill optimization targets ROCm and is not applicable on Ascend. |
+
+### ParallelConfig
+
+| Parameter | Default Reset | Reason |
+|-----------|--------------|--------|
+| `--ray-workers-use-nsight` | `False` | NVIDIA Nsight profiler is not available on Ascend NPU. |
+| `--numa-bind` | `False` (converted) | GPU-to-NUMA topology detection is unavailable. Automatically converted to Ascend-native CPU binding, see [`enable_cpu_binding`](additional_config.md#configuration-options). |
+| `--numa-bind-nodes` | `None` | Ignored on Ascend; Ascend-native CPU binding performs automatic topo-affinity allocation internally. |
+| `--numa-bind-cpus` | `None` | Same as above. |
+| `--enable-dbo` | `False` | Dynamic Batch Optimization is not yet supported on Ascend. |
+| `--ubatch-size` | `0` | Micro-batch size tuning is not yet supported on Ascend. |
+
+### AttentionConfig (`--attention-config`)
+
+| Subfield | Default Reset | Reason |
+|----------|--------------|--------|
+| `use_prefill_decode_attention` | `False` | GPU-specific attention path. |
+| `use_cudnn_prefill` | `False` | cuDNN is NVIDIA-only. |
+| `use_trtllm_ragged_deepseek_prefill` | `False` | TensorRT-LLM feature, NVIDIA-only. |
+| `use_trtllm_attention` | `False` | TensorRT-LLM feature, NVIDIA-only. |
+| `disable_flashinfer_prefill` | `False` | FlashInfer is NVIDIA-specific; flag has no effect on Ascend. |
+| `disable_flashinfer_q_quantization` | `False` | Same as above. |
+| `flash_attn_version` | `None` | Ascend uses its own attention backend; FlashAttention version selection is ignored. |
+| `flash_attn_max_num_splits_for_cuda_graph` | `32` | CUDA Graph split-point tuning is not applicable on Ascend. |
+
+### KVTransferConfig (`--kv-transfer-config`)
+
+| Subfield | Default Reset | Reason |
+|----------|--------------|--------|
+| `kv_buffer_size` | `1e9` | Buffer size tuning is optimized for NCCL/GPU backends. |
+| `enable_permute_local_kv` | `False` | Tied to an incompatible KV transfer backend (NIXL). |
+
+### SpeculativeConfig (`--speculative-config`)
+
+| Subfield | Default Reset | Reason |
+|----------|--------------|--------|
+| `quantization` | `None` | Ascend automatically inherits the main model's quantization method; separate speculative quantization is ignored. |
+
+---
+
+## Summary
+
+| Category | Count |
+|----------|-------|
+| Parameters silently reset (GPU/NVIDIA-specific) | 22 |
+
+For parameters that are silently reset, the service starts normally — users may observe warnings in the logs.
+
+For any other parameters not specified in this document, they are supported by default on Ascend NPU — please refer directly to the [vLLM community documentation](https://docs.vllm.ai/en/latest/) for usage instructions.
+
+If you encounter a parameter not listed here that fails on Ascend, please open an issue at [vllm-project/vllm-ascend](https://github.com/vllm-project/vllm-ascend/issues).

--- a/docs/source/user_guide/configuration/index.md
+++ b/docs/source/user_guide/configuration/index.md
@@ -6,5 +6,6 @@ This section provides a detailed configuration guide of vLLM Ascend.
 :caption: Configuration Guide
 :maxdepth: 1
 env_vars
+api_support
 additional_config
 :::


### PR DESCRIPTION
### What this PR does / why we need it?

Add a new documentation page `api_support.md` under `user_guide/configuration/` that documents the compatibility status of `vllm serve` CLI parameters on Ascend NPU.

The page is divided into two sections:
1. **Parameters silently reset by Ascend** — GPU/NVIDIA-specific parameters (22 total) that are automatically reset to safe defaults at startup, covering ModelConfig, CacheConfig, ObservabilityConfig, SchedulerConfig, ParallelConfig, AttentionConfig, KVTransferConfig, and SpeculativeConfig.

Cross-references to `additional_config` are included for parameters that have Ascend-native alternatives (e.g. `--numa-bind` → `enable_cpu_binding`).

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

- Docs build without warnings (`sphinx-build`)
- All links to `additional_config.md` resolve correctly
- Page appears in the Configuration Guide toctree

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
