### PR TITLE
[Refactor][Op] Align fused_gdn_gating API and softplus semantics

### DIFF
--- a/csrc/attention/fused_gdn_gating/fused_gdn_gating_torch_adpt.h
+++ b/csrc/attention/fused_gdn_gating/fused_gdn_gating_torch_adpt.h
@@ -16,7 +16,8 @@ std::tuple<at::Tensor, at::Tensor> npu_fused_gdn_gating(
     const at::Tensor& a,
     const at::Tensor& b,
     const at::Tensor& dt_bias,
-    double beta = 1.0)
+    double beta = 1.0,
+    double threshold = 20.0)
 {
     TORCH_CHECK(A_log.dim() == 1, "A_log should be 1-D [num_heads], got ", A_log.dim(), "D");
     TORCH_CHECK(dt_bias.dim() == 1, "dt_bias should be 1-D [num_heads], got ", dt_bias.dim(), "D");
@@ -24,6 +25,12 @@ std::tuple<at::Tensor, at::Tensor> npu_fused_gdn_gating(
     TORCH_CHECK(b.dim() == 2, "b should be 2-D [batch, num_heads], got ", b.dim(), "D");
     TORCH_CHECK(b.size(0) == a.size(0) && b.size(1) == a.size(1),
                 "a and b must have the same shape, got a=", a.sizes(), " b=", b.sizes());
+    TORCH_CHECK(a.scalar_type() == b.scalar_type(),
+                "a and b must have the same dtype, got a=", a.scalar_type(),
+                " b=", b.scalar_type());
+    TORCH_CHECK(A_log.scalar_type() == dt_bias.scalar_type(),
+                "A_log and dt_bias must have the same dtype, got A_log=",
+                A_log.scalar_type(), " dt_bias=", dt_bias.scalar_type());
     TORCH_CHECK(a.size(1) == A_log.size(0),
                 "a second dim (num_heads) must equal A_log first dim, got a.size(1)=",
                 a.size(1), " A_log.size(0)=", A_log.size(0));
@@ -36,10 +43,12 @@ std::tuple<at::Tensor, at::Tensor> npu_fused_gdn_gating(
     at::Tensor beta_output = at::empty({1, batch, num_heads}, b.options());
 
     float beta_val = static_cast<float>(beta);
+    float threshold_val = static_cast<float>(threshold);
 
     EXEC_NPU_CMD(aclnnFusedGdnGating,
                  A_log, a, b, dt_bias,
                  beta_val,
+                 threshold_val,
                  g, beta_output);
 
     return std::make_tuple(g, beta_output);

--- a/csrc/attention/fused_gdn_gating/op_host/fused_gdn_gating_def.cpp
+++ b/csrc/attention/fused_gdn_gating/op_host/fused_gdn_gating_def.cpp
@@ -19,36 +19,37 @@ public:
     {
         this->Input("a_log")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_FLOAT, ge::DT_FLOAT})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
         this->Input("a")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_BF16, ge::DT_FLOAT16})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
         this->Input("b")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_BF16, ge::DT_FLOAT16})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
         this->Input("dt_bias")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_FLOAT, ge::DT_FLOAT})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
         this->Output("g")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_FLOAT, ge::DT_FLOAT})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
         this->Output("beta_output")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_BF16, ge::DT_FLOAT16})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
 
         this->Attr("beta").AttrType(OPTIONAL).Float(1.0f);
+        this->Attr("threshold").AttrType(OPTIONAL).Float(20.0f);
 
         OpAICoreConfig aicConfig;
         aicConfig.DynamicCompileStaticFlag(true)

--- a/csrc/attention/fused_gdn_gating/op_host/fused_gdn_gating_tiling.cpp
+++ b/csrc/attention/fused_gdn_gating/op_host/fused_gdn_gating_tiling.cpp
@@ -27,7 +27,11 @@ namespace {
 
 constexpr uint64_t TILING_KEY_BF16 = 1;
 constexpr uint64_t TILING_KEY_FP16 = 2;
+constexpr uint64_t TILING_KEY_PARAM_BF16_OFFSET = 2;
+constexpr uint64_t TILING_KEY_PARAM_FP16_OFFSET = 4;
+constexpr size_t INPUT_INDEX_A_LOG = 0;
 constexpr size_t INPUT_INDEX_A = 1;
+constexpr size_t INPUT_INDEX_DT_BIAS = 3;
 
 } // namespace
 
@@ -64,20 +68,35 @@ ge::graphStatus FusedGdnGatingTilingFunc(gert::TilingContext *context)
     }
 
     float beta = 1.0f;
+    float threshold = 20.0f;
     auto *attrs = context->GetAttrs();
     if (attrs != nullptr) {
         const float *betaAttr = attrs->GetAttrPointer<float>(0);
         if (betaAttr != nullptr)      { beta      = *betaAttr; }
+        const float *thresholdAttr = attrs->GetAttrPointer<float>(1);
+        if (thresholdAttr != nullptr) { threshold = *thresholdAttr; }
     }
 
     auto *aDesc = context->GetInputDesc(INPUT_INDEX_A);
-    if (aDesc == nullptr) {
+    auto *aLogDesc = context->GetInputDesc(INPUT_INDEX_A_LOG);
+    auto *dtBiasDesc = context->GetInputDesc(INPUT_INDEX_DT_BIAS);
+    if (aDesc == nullptr || aLogDesc == nullptr || dtBiasDesc == nullptr) {
         return ge::GRAPH_FAILED;
     }
     ge::DataType aDtype = aDesc->GetDataType();
+    ge::DataType aLogDtype = aLogDesc->GetDataType();
+    ge::DataType dtBiasDtype = dtBiasDesc->GetDataType();
+    if (aLogDtype != dtBiasDtype) {
+        return ge::GRAPH_FAILED;
+    }
     uint64_t tilingKey = TILING_KEY_BF16;
     if (aDtype == ge::DT_FLOAT16) {
         tilingKey = TILING_KEY_FP16;
+    }
+    if (aLogDtype == ge::DT_BF16) {
+        tilingKey += TILING_KEY_PARAM_BF16_OFFSET;
+    } else if (aLogDtype == ge::DT_FLOAT16) {
+        tilingKey += TILING_KEY_PARAM_FP16_OFFSET;
     }
 
     uint32_t blockDim = static_cast<uint32_t>(numBatches);
@@ -117,6 +136,7 @@ ge::graphStatus FusedGdnGatingTilingFunc(gert::TilingContext *context)
     td.rowsPerIter   = rowsPerIter;
     td.useBulkDma    = useBulkDma ? 1u : 0u;
     td.beta          = beta;
+    td.threshold     = threshold;
 
     const size_t tilingSize = sizeof(FusedGdnGatingTilingData);
     auto *rawTilingData = context->GetRawTilingData();

--- a/csrc/attention/fused_gdn_gating/op_host/fused_gdn_gating_tiling_utils.h
+++ b/csrc/attention/fused_gdn_gating/op_host/fused_gdn_gating_tiling_utils.h
@@ -20,6 +20,7 @@ namespace FusedGdnGating {
 constexpr uint32_t VECTOR_BYTES_PER_ITER = 256;
 constexpr uint32_t DATACOPY_MIN_BYTES = 32;
 constexpr uint32_t BF16_PER_BLOCK = DATACOPY_MIN_BYTES / 2;  // 16
+constexpr uint32_t MASK_ALIGN_ELEMS = 64;
 
 /// Align count to vector unit width (256 bytes) for given dtype size.
 inline uint32_t AlignCountToVectorBytes(uint32_t count, uint32_t dtypeSize)
@@ -64,11 +65,10 @@ inline uint32_t ComputeRowsPerIter(uint32_t numHeads, uint64_t ubBudget,
                                    uint32_t ubDim = 0)
 {
     if (ubDim == 0) {
-        // Use DMA-friendly alignment matching kernel's DMA_ALIGN_ELEMS=16.
-        // 16 bf16/fp16 elements = 32 bytes = 1 DMA block (min alignment).
-        // 16 fp32 elements = 64 bytes = 2 DMA blocks.
-        ubDim = ((numHeads + BF16_PER_BLOCK - 1) / BF16_PER_BLOCK) * BF16_PER_BLOCK;
+        // Match the kernel's fp32 compute/mask alignment.
+        ubDim = ((numHeads + MASK_ALIGN_ELEMS - 1) / MASK_ALIGN_ELEMS) * MASK_ALIGN_ELEMS;
     }
+    uint32_t maskUbDim = ubDim;
 
     // 2 parameter input queues + 2 fp32 constant buffers, each 1 row.
     // Use fp32 for the parameter queues as a conservative upper bound.
@@ -81,7 +81,7 @@ inline uint32_t ComputeRowsPerIter(uint32_t numHeads, uint64_t ubBudget,
     // Per-row (per-chunk): 3 bf16/fp16 buffers + 5 fp32 buffers + 1 uint8 mask buffer.
     uint32_t perRowBytes = 3 * ubDim * static_cast<uint32_t>(sizeof(int16_t))   // a, b, betaOut
                          + 5 * ubDim * static_cast<uint32_t>(sizeof(float))     // g, x, betaX, tmp, betaFp32
-                         + 1 * ubDim * static_cast<uint32_t>(sizeof(uint8_t));   // threshold mask
+                         + 1 * maskUbDim * static_cast<uint32_t>(sizeof(uint8_t)); // threshold mask
 
     if (perRowBytes == 0) {
         return 1;

--- a/csrc/attention/fused_gdn_gating/op_host/fused_gdn_gating_tiling_utils.h
+++ b/csrc/attention/fused_gdn_gating/op_host/fused_gdn_gating_tiling_utils.h
@@ -70,16 +70,18 @@ inline uint32_t ComputeRowsPerIter(uint32_t numHeads, uint64_t ubBudget,
         ubDim = ((numHeads + BF16_PER_BLOCK - 1) / BF16_PER_BLOCK) * BF16_PER_BLOCK;
     }
 
-    // 3 fp32 constant buffers, each 1 row.
-    uint32_t sharedBytes = 3 * ubDim * static_cast<uint32_t>(sizeof(float));
+    // 2 parameter input queues + 2 fp32 constant buffers, each 1 row.
+    // Use fp32 for the parameter queues as a conservative upper bound.
+    uint32_t sharedBytes = 4 * ubDim * static_cast<uint32_t>(sizeof(float));
 
     // Multi-row constant buffers (precomputed once, scaled by R):
     //   dtBiasMultiBuf_ + negExpMultiBuf_: 2 fp32 buffers.
     uint32_t constPerRowBytes = 2 * ubDim * static_cast<uint32_t>(sizeof(float));
 
-    // Per-row (per-chunk): 3 bf16/fp16 buffers + 6 fp32 buffers.
+    // Per-row (per-chunk): 3 bf16/fp16 buffers + 5 fp32 buffers + 1 uint8 mask buffer.
     uint32_t perRowBytes = 3 * ubDim * static_cast<uint32_t>(sizeof(int16_t))   // a, b, betaOut
-                         + 6 * ubDim * static_cast<uint32_t>(sizeof(float));    // g, x, betaX, abs, tmp, betaFp32
+                         + 5 * ubDim * static_cast<uint32_t>(sizeof(float))     // g, x, betaX, tmp, betaFp32
+                         + 1 * ubDim * static_cast<uint32_t>(sizeof(uint8_t));   // threshold mask
 
     if (perRowBytes == 0) {
         return 1;

--- a/csrc/attention/fused_gdn_gating/op_host/op_api/aclnn_fused_gdn_gating.cpp
+++ b/csrc/attention/fused_gdn_gating/op_host/op_api/aclnn_fused_gdn_gating.cpp
@@ -37,6 +37,7 @@ struct FusedGdnGatingParams {
     const aclTensor *b{nullptr};
     const aclTensor *dtBias{nullptr};
     float beta{1.0f};
+    float threshold{20.0f};
     aclTensor *g{nullptr};
     aclTensor *betaOutput{nullptr};
 };
@@ -45,6 +46,8 @@ static const std::initializer_list<op::DataType> AB_TYPE_SUPPORT_LIST =
     {op::DataType::DT_BF16, op::DataType::DT_FLOAT16};
 static const std::initializer_list<op::DataType> FP32_TYPE_SUPPORT_LIST =
     {op::DataType::DT_FLOAT};
+static const std::initializer_list<op::DataType> PARAM_TYPE_SUPPORT_LIST =
+    {op::DataType::DT_FLOAT, op::DataType::DT_BF16, op::DataType::DT_FLOAT16};
 
 static inline bool CheckNotNull(const FusedGdnGatingParams &params)
 {
@@ -59,12 +62,21 @@ static inline bool CheckNotNull(const FusedGdnGatingParams &params)
 
 static inline bool CheckDtype(const FusedGdnGatingParams &params)
 {
-    OP_CHECK_DTYPE_NOT_SUPPORT(params.aLog,       FP32_TYPE_SUPPORT_LIST, return false);
-    OP_CHECK_DTYPE_NOT_SUPPORT(params.dtBias,     FP32_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.aLog,       PARAM_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.dtBias,     PARAM_TYPE_SUPPORT_LIST, return false);
     OP_CHECK_DTYPE_NOT_SUPPORT(params.a,          AB_TYPE_SUPPORT_LIST,   return false);
     OP_CHECK_DTYPE_NOT_SUPPORT(params.b,          AB_TYPE_SUPPORT_LIST,   return false);
     OP_CHECK_DTYPE_NOT_SUPPORT(params.g,          FP32_TYPE_SUPPORT_LIST, return false);
     OP_CHECK_DTYPE_NOT_SUPPORT(params.betaOutput, AB_TYPE_SUPPORT_LIST,   return false);
+    OP_CHECK(params.a->GetDataType() == params.b->GetDataType(),
+             OP_LOGE(ACLNN_ERR_PARAM_INVALID, "a and b must have the same dtype."),
+             return false);
+    OP_CHECK(params.aLog->GetDataType() == params.dtBias->GetDataType(),
+             OP_LOGE(ACLNN_ERR_PARAM_INVALID, "aLog and dtBias must have the same dtype."),
+             return false);
+    OP_CHECK(params.betaOutput->GetDataType() == params.b->GetDataType(),
+             OP_LOGE(ACLNN_ERR_PARAM_INVALID, "betaOutput and b must have the same dtype."),
+             return false);
     return true;
 }
 
@@ -79,18 +91,18 @@ static aclnnStatus CheckParams(const FusedGdnGatingParams &params)
 
 aclnnStatus aclnnFusedGdnGatingGetWorkspaceSize(
     const aclTensor *aLog, const aclTensor *a, const aclTensor *b,
-    const aclTensor *dtBias, float beta,
+    const aclTensor *dtBias, float beta, float threshold,
     aclTensor *g, aclTensor *betaOutput,
     uint64_t *workspaceSize, aclOpExecutor **executor)
 {
     L2_DFX_PHASE_1(aclnnFusedGdnGating,
-                   DFX_IN(aLog, a, b, dtBias, beta),
+                   DFX_IN(aLog, a, b, dtBias, beta, threshold),
                    DFX_OUT(g, betaOutput));
 
     auto uniqueExecutor = CREATE_EXECUTOR();
     CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);
 
-    FusedGdnGatingParams params{aLog, a, b, dtBias, beta, g, betaOutput};
+    FusedGdnGatingParams params{aLog, a, b, dtBias, beta, threshold, g, betaOutput};
     CHECK_RET(CheckParams(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
 
     // Bring inputs to a contiguous form that the kernel expects.
@@ -104,7 +116,7 @@ aclnnStatus aclnnFusedGdnGatingGetWorkspaceSize(
     CHECK_RET(dtBiasContig != nullptr, ACLNN_ERR_INNER_NULLPTR);
 
     auto result = l0op::FusedGdnGating(aLogContig, aContig, bContig, dtBiasContig,
-                                       beta, uniqueExecutor.get());
+                                       beta, threshold, uniqueExecutor.get());
     CHECK_RET(result.g != nullptr && result.beta_output != nullptr,
               ACLNN_ERR_INNER_NULLPTR);
 

--- a/csrc/attention/fused_gdn_gating/op_host/op_api/aclnn_fused_gdn_gating.h
+++ b/csrc/attention/fused_gdn_gating/op_host/op_api/aclnn_fused_gdn_gating.h
@@ -20,11 +20,12 @@ extern "C" {
 
 /**
  * @brief FusedGdnGating phase-1: compute required workspace size.
- * @param [in]  aLog        : A_log,       [num_heads],           dtype fp32.
+ * @param [in]  aLog        : A_log,       [num_heads],           dtype fp32/bf16/fp16.
  * @param [in]  a           : a,           [batch, num_heads],    dtype bf16/fp16.
  * @param [in]  b           : b,           [batch, num_heads],    dtype bf16/fp16.
- * @param [in]  dtBias      : dt_bias,     [num_heads],           dtype fp32.
+ * @param [in]  dtBias      : dt_bias,     [num_heads],           same dtype as aLog.
  * @param [in]  beta        : softplus beta (default 1.0).
+ * @param [in]  threshold   : softplus threshold (default 20.0).
  * @param [out] g           : output gate,   [1, batch, num_heads], dtype fp32.
  * @param [out] betaOutput  : sigmoid(b),    [1, batch, num_heads], same dtype as a/b.
  * @param [out] workspaceSize: required workspace bytes on device.
@@ -32,7 +33,7 @@ extern "C" {
  */
 __attribute__((visibility("default"))) aclnnStatus aclnnFusedGdnGatingGetWorkspaceSize(
     const aclTensor *aLog, const aclTensor *a, const aclTensor *b,
-    const aclTensor *dtBias, float beta,
+    const aclTensor *dtBias, float beta, float threshold,
     aclTensor *g, aclTensor *betaOutput,
     uint64_t *workspaceSize, aclOpExecutor **executor);
 

--- a/csrc/attention/fused_gdn_gating/op_host/op_api/fused_gdn_gating.cpp
+++ b/csrc/attention/fused_gdn_gating/op_host/op_api/fused_gdn_gating.cpp
@@ -28,10 +28,10 @@ static constexpr FusedGdnGatingOutput kNullOutput{nullptr, nullptr};
 
 FusedGdnGatingOutput FusedGdnGating(const aclTensor *aLog, const aclTensor *a,
                                     const aclTensor *b, const aclTensor *dtBias,
-                                    float beta,
+                                    float beta, float threshold,
                                     aclOpExecutor *executor)
 {
-    L0_DFX(FusedGdnGating, aLog, a, b, dtBias, beta);
+    L0_DFX(FusedGdnGating, aLog, a, b, dtBias, beta, threshold);
 
     const DataType betaDtype = b->GetDataType();
     const Format format = Format::FORMAT_ND;
@@ -48,14 +48,14 @@ FusedGdnGatingOutput FusedGdnGating(const aclTensor *aLog, const aclTensor *a,
     auto ret = INFER_SHAPE(FusedGdnGating,
                            OP_INPUT(aLog, a, b, dtBias),
                            OP_OUTPUT(g, betaOutput),
-                           OP_ATTR(beta));
+                           OP_ATTR(beta, threshold));
     OP_CHECK_INFERSHAPE(ret != ACLNN_SUCCESS, return kNullOutput,
                         "FusedGdnGating InferShape failed.");
 
     ret = ADD_TO_LAUNCHER_LIST_AICORE(FusedGdnGating,
                                       OP_INPUT(aLog, a, b, dtBias),
                                       OP_OUTPUT(g, betaOutput),
-                                      OP_ATTR(beta));
+                                      OP_ATTR(beta, threshold));
     OP_CHECK_ADD_TO_LAUNCHER_LIST_AICORE(ret != ACLNN_SUCCESS, return kNullOutput,
         "FusedGdnGating ADD_TO_LAUNCHER_LIST_AICORE failed.");
 

--- a/csrc/attention/fused_gdn_gating/op_host/op_api/fused_gdn_gating.h
+++ b/csrc/attention/fused_gdn_gating/op_host/op_api/fused_gdn_gating.h
@@ -19,7 +19,7 @@ struct FusedGdnGatingOutput {
 
 FusedGdnGatingOutput FusedGdnGating(const aclTensor *aLog, const aclTensor *a,
                                     const aclTensor *b, const aclTensor *dtBias,
-                                    float beta,
+                                    float beta, float threshold,
                                     aclOpExecutor *executor);
 
 } // namespace l0op

--- a/csrc/attention/fused_gdn_gating/op_kernel/fused_gdn_gating.cpp
+++ b/csrc/attention/fused_gdn_gating/op_kernel/fused_gdn_gating.cpp
@@ -27,11 +27,27 @@ fused_gdn_gating(GM_ADDR a_log, GM_ADDR a, GM_ADDR b, GM_ADDR dt_bias,
     TPipe pipe;
 
     if (TILING_KEY_IS(1)) {
-        KernelFusedGdnGating<bfloat16_t> op;
+        KernelFusedGdnGating<bfloat16_t, float> op;
         op.Init(a_log, a, b, dt_bias, g, beta_output, &tilingData, &pipe);
         op.Process();
     } else if (TILING_KEY_IS(2)) {
-        KernelFusedGdnGating<half> op;
+        KernelFusedGdnGating<half, float> op;
+        op.Init(a_log, a, b, dt_bias, g, beta_output, &tilingData, &pipe);
+        op.Process();
+    } else if (TILING_KEY_IS(3)) {
+        KernelFusedGdnGating<bfloat16_t, bfloat16_t> op;
+        op.Init(a_log, a, b, dt_bias, g, beta_output, &tilingData, &pipe);
+        op.Process();
+    } else if (TILING_KEY_IS(4)) {
+        KernelFusedGdnGating<half, bfloat16_t> op;
+        op.Init(a_log, a, b, dt_bias, g, beta_output, &tilingData, &pipe);
+        op.Process();
+    } else if (TILING_KEY_IS(5)) {
+        KernelFusedGdnGating<bfloat16_t, half> op;
+        op.Init(a_log, a, b, dt_bias, g, beta_output, &tilingData, &pipe);
+        op.Process();
+    } else if (TILING_KEY_IS(6)) {
+        KernelFusedGdnGating<half, half> op;
         op.Init(a_log, a, b, dt_bias, g, beta_output, &tilingData, &pipe);
         op.Process();
     }

--- a/csrc/attention/fused_gdn_gating/op_kernel/fused_gdn_gating.h
+++ b/csrc/attention/fused_gdn_gating/op_kernel/fused_gdn_gating.h
@@ -29,6 +29,7 @@ using namespace AscendC;
 constexpr uint32_t BYTES_PER_BLOCK = 32;
 constexpr uint32_t BF16_PER_BLOCK  = BYTES_PER_BLOCK / sizeof(int16_t);  // 16
 constexpr uint32_t FP32_PER_BLOCK  = BYTES_PER_BLOCK / sizeof(float);    // 8
+constexpr uint32_t MASK_ALIGN_ELEMS = 64;
 
 // DMA-friendly alignment: 16 elements = 32 bytes = 1 DMA block.
 // Vector ops use count=numHeads_ with partial-iteration masking,
@@ -64,8 +65,9 @@ public:
         threshold_ = tiling->threshold;
 
         // Aligned dimensions for UB tensors.
-        alignedHeadsHalf_  = AlignUp<uint32_t>(numHeads_, DMA_ALIGN_ELEMS);
-        alignedHeadsFloat_ = AlignUp<uint32_t>(numHeads_, DMA_ALIGN_ELEMS);
+        alignedHeadsHalf_  = AlignUp<uint32_t>(numHeads_, MASK_ALIGN_ELEMS);
+        alignedHeadsFloat_ = AlignUp<uint32_t>(numHeads_, MASK_ALIGN_ELEMS);
+        alignedHeadsMask_ = alignedHeadsFloat_;
         constexpr uint32_t paramAlignElems = BYTES_PER_BLOCK / sizeof(ParamDtype);
         alignedHeadsParam_ = AlignUp<uint32_t>(numHeads_, paramAlignElems);
 
@@ -103,7 +105,7 @@ public:
         pipe_->InitBuffer(xBuf_, rowsPerIter_ * alignedHeadsFloat_ * sizeof(float));
         pipe_->InitBuffer(betaXBuf_, rowsPerIter_ * alignedHeadsFloat_ * sizeof(float));
         pipe_->InitBuffer(softplusTmpBuf_, rowsPerIter_ * alignedHeadsFloat_ * sizeof(float));
-        pipe_->InitBuffer(thresholdMaskBuf_, rowsPerIter_ * alignedHeadsFloat_ * sizeof(uint8_t));
+        pipe_->InitBuffer(thresholdMaskBuf_, rowsPerIter_ * alignedHeadsMask_ * sizeof(uint8_t));
         pipe_->InitBuffer(betaFp32Buf_, rowsPerIter_ * alignedHeadsFloat_ * sizeof(float));
     }
 
@@ -240,6 +242,7 @@ private:
         LocalTensor<float> betaFp32    = betaFp32Buf_.Get<float>();
 
         const uint32_t multiCount = validRows * alignedHeadsFloat_;
+        const uint32_t maskCount = validRows * alignedHeadsMask_;
 
         // Batch Cast a→fp32, b→fp32.
         Cast(x,        aLocal, RoundMode::CAST_NONE, multiCount);
@@ -264,7 +267,7 @@ private:
             PipeBarrier<PIPE_V>();
             Muls(softplusTmp, softplusTmp, 1.0f / beta_, multiCount);
             PipeBarrier<PIPE_V>();
-            CompareScalar(thresholdMask, betaX, threshold_, CMPMODE::LE, multiCount);
+            CompareScalar(thresholdMask, betaX, threshold_, CMPMODE::LE, maskCount);
             PipeBarrier<PIPE_V>();
             Select(gLocal, thresholdMask, softplusTmp, x, SELMODE::VSEL_TENSOR_TENSOR_MODE, multiCount);
             PipeBarrier<PIPE_V>();
@@ -286,7 +289,7 @@ private:
             PipeBarrier<PIPE_V>();
             Muls(softplusTmp, softplusTmp, 1.0f / beta_, multiCount);
             PipeBarrier<PIPE_V>();
-            CompareScalar(thresholdMask, betaX, threshold_, CMPMODE::LE, multiCount);
+            CompareScalar(thresholdMask, betaX, threshold_, CMPMODE::LE, maskCount);
             PipeBarrier<PIPE_V>();
             Select(gLocal, thresholdMask, softplusTmp, x, SELMODE::VSEL_TENSOR_TENSOR_MODE, multiCount);
             PipeBarrier<PIPE_V>();
@@ -382,6 +385,7 @@ private:
     bool     useBulkDma_{false};
     uint32_t alignedHeadsHalf_{0};
     uint32_t alignedHeadsFloat_{0};
+    uint32_t alignedHeadsMask_{0};
     uint32_t alignedHeadsParam_{0};
     float    beta_{1.0f};
     float    threshold_{20.0f};

--- a/csrc/attention/fused_gdn_gating/op_kernel/fused_gdn_gating.h
+++ b/csrc/attention/fused_gdn_gating/op_kernel/fused_gdn_gating.h
@@ -9,12 +9,14 @@
  * \brief AscendC kernel for fused GDN gating.
  *
  * Per-row math:
- *   g = -exp(A_log) * softplus(cast(a,fp32) + dt_bias)
+ *   g = -exp(A_log) * softplus(cast(a,fp32) + dt_bias, beta, threshold)
  *   beta_output = sigmoid(cast(b, fp32)) -> cast back to InDtype
  */
 
 #ifndef FUSED_GDN_GATING_KERNEL_H
 #define FUSED_GDN_GATING_KERNEL_H
+
+#include <type_traits>
 
 #include "kernel_operator.h"
 #include "fused_gdn_gating_tiling_data.h"
@@ -39,7 +41,7 @@ __aicore__ inline T CeilDiv(T a, T b) { return (a + b - 1) / b; }
 template <typename T>
 __aicore__ inline T AlignUp(T a, T b) { return CeilDiv(a, b) * b; }
 
-template <typename InDtype>
+template <typename InDtype, typename ParamDtype>
 class KernelFusedGdnGating {
 public:
     __aicore__ inline KernelFusedGdnGating() {}
@@ -59,13 +61,16 @@ public:
         rowsPerIter_ = tiling->rowsPerIter;
         useBulkDma_ = (tiling->useBulkDma != 0);
         beta_ = tiling->beta;
+        threshold_ = tiling->threshold;
 
         // Aligned dimensions for UB tensors.
         alignedHeadsHalf_  = AlignUp<uint32_t>(numHeads_, DMA_ALIGN_ELEMS);
         alignedHeadsFloat_ = AlignUp<uint32_t>(numHeads_, DMA_ALIGN_ELEMS);
+        constexpr uint32_t paramAlignElems = BYTES_PER_BLOCK / sizeof(ParamDtype);
+        alignedHeadsParam_ = AlignUp<uint32_t>(numHeads_, paramAlignElems);
 
-        aLogGm_.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(aLogGm), numHeads_);
-        dtBiasGm_.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(dtBiasGm), numHeads_);
+        aLogGm_.SetGlobalBuffer(reinterpret_cast<__gm__ ParamDtype *>(aLogGm), numHeads_);
+        dtBiasGm_.SetGlobalBuffer(reinterpret_cast<__gm__ ParamDtype *>(dtBiasGm), numHeads_);
         aGm_.SetGlobalBuffer(reinterpret_cast<__gm__ InDtype *>(aGm),
                              static_cast<uint64_t>(numBatches_) * numHeads_);
         bGm_.SetGlobalBuffer(reinterpret_cast<__gm__ InDtype *>(bGm),
@@ -82,8 +87,9 @@ public:
         pipe_->InitBuffer(betaOutQue_, 1, rowsPerIter_ * alignedHeadsHalf_ * sizeof(InDtype));
 
         // Constant queues (single-row).
-        pipe_->InitBuffer(aLogInQue_, 1, 1 * alignedHeadsFloat_ * sizeof(float));
-        pipe_->InitBuffer(dtBiasInQue_, 1, 1 * alignedHeadsFloat_ * sizeof(float));
+        pipe_->InitBuffer(aLogInQue_, 1, 1 * alignedHeadsParam_ * sizeof(ParamDtype));
+        pipe_->InitBuffer(dtBiasInQue_, 1, 1 * alignedHeadsParam_ * sizeof(ParamDtype));
+        pipe_->InitBuffer(negExpInQue_, 1, 1 * alignedHeadsFloat_ * sizeof(float));
         pipe_->InitBuffer(dtBiasPreloadQue_, 1, 1 * alignedHeadsFloat_ * sizeof(float));
 
         // Multi-row constants: dt_bias and neg_exp(A_log) replicated R times.
@@ -96,8 +102,8 @@ public:
         // Scratch buffers (V-only access).
         pipe_->InitBuffer(xBuf_, rowsPerIter_ * alignedHeadsFloat_ * sizeof(float));
         pipe_->InitBuffer(betaXBuf_, rowsPerIter_ * alignedHeadsFloat_ * sizeof(float));
-        pipe_->InitBuffer(softplusAbsBuf_, rowsPerIter_ * alignedHeadsFloat_ * sizeof(float));
         pipe_->InitBuffer(softplusTmpBuf_, rowsPerIter_ * alignedHeadsFloat_ * sizeof(float));
+        pipe_->InitBuffer(thresholdMaskBuf_, rowsPerIter_ * alignedHeadsFloat_ * sizeof(uint8_t));
         pipe_->InitBuffer(betaFp32Buf_, rowsPerIter_ * alignedHeadsFloat_ * sizeof(float));
     }
 
@@ -127,34 +133,49 @@ private:
      */
     __aicore__ inline void PreloadConstants()
     {
-        LocalTensor<float> tmpALog = aLogInQue_.template AllocTensor<float>();
-        dtBiasTensor_ = dtBiasInQue_.template AllocTensor<float>();
+        LocalTensor<ParamDtype> tmpALog = aLogInQue_.template AllocTensor<ParamDtype>();
+        dtBiasTensor_ = negExpInQue_.template AllocTensor<float>();
 
-        DataCopyExtParams fp32CopyParams{1, static_cast<uint32_t>(numHeads_ * sizeof(float)),
+        DataCopyExtParams paramCopyParams{1, static_cast<uint32_t>(numHeads_ * sizeof(ParamDtype)),
                                          0, 0, 0};
-        DataCopyPadExtParams<float> fp32PadParams{false, 0, 0, 0.0f};
+        DataCopyPadExtParams<ParamDtype> paramPadParams{false, 0, 0, static_cast<ParamDtype>(0)};
 
         // Load A_log.
-        DataCopyPad(tmpALog, aLogGm_, fp32CopyParams, fp32PadParams);
-        aLogInQue_.template EnQue<float>(tmpALog);
-        tmpALog = aLogInQue_.template DeQue<float>();
+        DataCopyPad(tmpALog, aLogGm_, paramCopyParams, paramPadParams);
+        aLogInQue_.template EnQue<ParamDtype>(tmpALog);
+        tmpALog = aLogInQue_.template DeQue<ParamDtype>();
+
+        if constexpr (std::is_same<ParamDtype, float>()) {
+            Adds(dtBiasTensor_, tmpALog, 0.0f, numHeads_);
+        } else {
+            Cast(dtBiasTensor_, tmpALog, RoundMode::CAST_NONE, numHeads_);
+        }
+        PipeBarrier<PIPE_V>();
 
         // neg_exp(A_log).
-        Exp(dtBiasTensor_, tmpALog, numHeads_);
+        Exp(dtBiasTensor_, dtBiasTensor_, numHeads_);
         PipeBarrier<PIPE_V>();
         Muls(dtBiasTensor_, dtBiasTensor_, -1.0f, numHeads_);
         PipeBarrier<PIPE_V>();
 
         aLogInQue_.FreeTensor(tmpALog);
 
-        dtBiasInQue_.template EnQue<float>(dtBiasTensor_);
-        dtBiasTensor_ = dtBiasInQue_.template DeQue<float>();
+        negExpInQue_.template EnQue<float>(dtBiasTensor_);
+        dtBiasTensor_ = negExpInQue_.template DeQue<float>();
 
         // Load dt_bias.
+        LocalTensor<ParamDtype> tmpDtBias = dtBiasInQue_.template AllocTensor<ParamDtype>();
         dtBiasPreloaded_ = dtBiasPreloadQue_.template AllocTensor<float>();
-        DataCopyExtParams dtBiasCopyParams{1, static_cast<uint32_t>(numHeads_ * sizeof(float)), 0, 0, 0};
-        DataCopyPadExtParams<float> dtBiasPadParams{false, 0, 0, 0.0f};
-        DataCopyPad(dtBiasPreloaded_, dtBiasGm_, dtBiasCopyParams, dtBiasPadParams);
+        DataCopyPad(tmpDtBias, dtBiasGm_, paramCopyParams, paramPadParams);
+        dtBiasInQue_.template EnQue<ParamDtype>(tmpDtBias);
+        tmpDtBias = dtBiasInQue_.template DeQue<ParamDtype>();
+        if constexpr (std::is_same<ParamDtype, float>()) {
+            Adds(dtBiasPreloaded_, tmpDtBias, 0.0f, numHeads_);
+        } else {
+            Cast(dtBiasPreloaded_, tmpDtBias, RoundMode::CAST_NONE, numHeads_);
+        }
+        PipeBarrier<PIPE_V>();
+        dtBiasInQue_.FreeTensor(tmpDtBias);
         dtBiasPreloadQue_.template EnQue<float>(dtBiasPreloaded_);
         dtBiasPreloaded_ = dtBiasPreloadQue_.template DeQue<float>();
 
@@ -214,8 +235,8 @@ private:
 
         LocalTensor<float> x           = xBuf_.Get<float>();
         LocalTensor<float> betaX       = betaXBuf_.Get<float>();
-        LocalTensor<float> softplusAbs = softplusAbsBuf_.Get<float>();
         LocalTensor<float> softplusTmp = softplusTmpBuf_.Get<float>();
+        LocalTensor<uint8_t> thresholdMask = thresholdMaskBuf_.Get<uint8_t>();
         LocalTensor<float> betaFp32    = betaFp32Buf_.Get<float>();
 
         const uint32_t multiCount = validRows * alignedHeadsFloat_;
@@ -233,9 +254,7 @@ private:
             PipeBarrier<PIPE_V>();
             Muls(betaX, x, beta_, multiCount);
             PipeBarrier<PIPE_V>();
-            Abs(softplusAbs, betaX, multiCount);
-            PipeBarrier<PIPE_V>();
-            Muls(softplusTmp, softplusAbs, -1.0f, multiCount);
+            Mins(softplusTmp, betaX, threshold_, multiCount);
             PipeBarrier<PIPE_V>();
             Exp(softplusTmp, softplusTmp, multiCount);
             PipeBarrier<PIPE_V>();
@@ -245,9 +264,9 @@ private:
             PipeBarrier<PIPE_V>();
             Muls(softplusTmp, softplusTmp, 1.0f / beta_, multiCount);
             PipeBarrier<PIPE_V>();
-            Maxs(gLocal, x, 0.0f, multiCount);
+            CompareScalar(thresholdMask, betaX, threshold_, CMPMODE::LE, multiCount);
             PipeBarrier<PIPE_V>();
-            Add(gLocal, gLocal, softplusTmp, multiCount);
+            Select(gLocal, thresholdMask, softplusTmp, x, SELMODE::VSEL_TENSOR_TENSOR_MODE, multiCount);
             PipeBarrier<PIPE_V>();
             Mul(gLocal, gLocal, negExpMulti, multiCount);
             PipeBarrier<PIPE_V>();
@@ -257,11 +276,7 @@ private:
             PipeBarrier<PIPE_V>();
             Muls(betaX, x, beta_, multiCount);
             PipeBarrier<PIPE_V>();
-            Abs(softplusAbs, betaX, multiCount);
-            PipeBarrier<PIPE_V>();
-            Adds(betaX, dtBiasTensor_, 0.0f, numHeads_);
-            PipeBarrier<PIPE_V>();
-            Muls(softplusTmp, softplusAbs, -1.0f, multiCount);
+            Mins(softplusTmp, betaX, threshold_, multiCount);
             PipeBarrier<PIPE_V>();
             Exp(softplusTmp, softplusTmp, multiCount);
             PipeBarrier<PIPE_V>();
@@ -271,11 +286,11 @@ private:
             PipeBarrier<PIPE_V>();
             Muls(softplusTmp, softplusTmp, 1.0f / beta_, multiCount);
             PipeBarrier<PIPE_V>();
-            Maxs(gLocal, x, 0.0f, multiCount);
+            CompareScalar(thresholdMask, betaX, threshold_, CMPMODE::LE, multiCount);
             PipeBarrier<PIPE_V>();
-            Add(gLocal, gLocal, softplusTmp, multiCount);
+            Select(gLocal, thresholdMask, softplusTmp, x, SELMODE::VSEL_TENSOR_TENSOR_MODE, multiCount);
             PipeBarrier<PIPE_V>();
-            Mul(gLocal, gLocal, betaX, multiCount);
+            Mul(gLocal, gLocal, dtBiasTensor_, multiCount);
             PipeBarrier<PIPE_V>();
         }
 
@@ -334,8 +349,8 @@ private:
 private:
     TPipe *pipe_{nullptr};
 
-    GlobalTensor<float>   aLogGm_;
-    GlobalTensor<float>   dtBiasGm_;
+    GlobalTensor<ParamDtype> aLogGm_;
+    GlobalTensor<ParamDtype> dtBiasGm_;
     GlobalTensor<InDtype> aGm_;
     GlobalTensor<InDtype> bGm_;
     GlobalTensor<float>   gGm_;
@@ -345,6 +360,7 @@ private:
     TQue<QuePosition::VECIN,  1> bInQue_;
     TQue<QuePosition::VECIN,  1> aLogInQue_;
     TQue<QuePosition::VECIN,  1> dtBiasInQue_;
+    TQue<QuePosition::VECIN,  1> negExpInQue_;
     TQue<QuePosition::VECIN,  1> dtBiasPreloadQue_;
     TQue<QuePosition::VECOUT, 1> gOutQue_;
     TQue<QuePosition::VECOUT, 1> betaOutQue_;
@@ -353,8 +369,8 @@ private:
     TBuf<TPosition::VECCALC> negExpMultiBuf_;
     TBuf<TPosition::VECCALC> xBuf_;
     TBuf<TPosition::VECCALC> betaXBuf_;
-    TBuf<TPosition::VECCALC> softplusAbsBuf_;
     TBuf<TPosition::VECCALC> softplusTmpBuf_;
+    TBuf<TPosition::VECCALC> thresholdMaskBuf_;
     TBuf<TPosition::VECCALC> betaFp32Buf_;
 
     LocalTensor<float> dtBiasTensor_;     // neg_exp(A_log), 1 row
@@ -366,7 +382,9 @@ private:
     bool     useBulkDma_{false};
     uint32_t alignedHeadsHalf_{0};
     uint32_t alignedHeadsFloat_{0};
+    uint32_t alignedHeadsParam_{0};
     float    beta_{1.0f};
+    float    threshold_{20.0f};
 };
 
 } // namespace FusedGdnGating

--- a/csrc/attention/fused_gdn_gating/op_kernel/fused_gdn_gating_tiling_data.h
+++ b/csrc/attention/fused_gdn_gating/op_kernel/fused_gdn_gating_tiling_data.h
@@ -23,6 +23,7 @@ struct alignas(8) FusedGdnGatingTilingData {
     uint32_t rowsPerIter;
     uint32_t useBulkDma;
     float    beta;
+    float    threshold;
 };
 #pragma pack(pop)
 

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -2814,7 +2814,8 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "                     Tensor a, "
         "                     Tensor b, "
         "                     Tensor dt_bias, "
-        "                     float beta=1.0) -> (Tensor g, Tensor beta_output)");
+        "                     float beta=1.0, "
+        "                     float threshold=20.0) -> (Tensor g, Tensor beta_output)");
     ops.impl("npu_fused_gdn_gating", torch::kPrivateUse1, &vllm_ascend::npu_fused_gdn_gating);
 }
 #endif

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -703,8 +703,11 @@ std::tuple<at::Tensor, at::Tensor> npu_fused_gdn_gating_meta(
     const at::Tensor& a,
     const at::Tensor& b,
     const at::Tensor& dt_bias,
-    double beta)
+    double beta,
+    double threshold)
 {
+    (void)beta;
+    (void)threshold;
     int64_t batch = a.size(0);
     int64_t num_heads = a.size(1);
 

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_fused_gdn_gating.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_fused_gdn_gating.py
@@ -24,6 +24,12 @@ SEED = 42
 NUM_HEADS_VALUES = [4, 6, 8, 12, 16, 24, 32, 48, 64, 128]
 BATCH_SIZES = [1, 7, 37, 128, 512, 4096, 16384]
 DTYPES = [torch.bfloat16, torch.float16]
+PARAM_DTYPES = [torch.float32, torch.bfloat16, torch.float16]
+DTYPE_COMBINATIONS = [
+    (dtype, param_dtype)
+    for dtype in DTYPES
+    for param_dtype in PARAM_DTYPES
+]
 
 
 # ---------------------------------------------------------------------------
@@ -37,11 +43,12 @@ def _golden_fused_gdn_gating(
     b: torch.Tensor,
     dt_bias: torch.Tensor,
     beta: float = 1.0,
+    threshold: float = 20.0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """CPU golden reference for fused_gdn_gating.
 
-    Uses the same numerically stable softplus form as the AscendC kernel:
-        softplus_o = max(x, 0) + log(1 + exp(-|beta*x|)) / beta
+    Uses the same softplus threshold semantics as the Triton kernel:
+        where(beta * x <= threshold, log(1 + exp(beta * x)) / beta, x)
 
     Returns:
         g:           [1, batch, num_heads], fp32.
@@ -60,7 +67,11 @@ def _golden_fused_gdn_gating(
 
     x = a_f + dt_bias_expanded
     beta_x = beta * x
-    softplus_o = torch.maximum(x, torch.tensor(0.0)) + torch.log(1.0 + torch.exp(-torch.abs(beta_x))) / beta
+    softplus_o = torch.where(
+        beta_x <= threshold,
+        torch.log1p(torch.exp(beta_x)) / beta,
+        x,
+    )
 
     g = -torch.exp(A_log_expanded) * softplus_o
     g = g.unsqueeze(0)
@@ -80,15 +91,34 @@ def _make_inputs(
     num_heads: int,
     batch: int,
     dtype: torch.dtype,
+    param_dtype: torch.dtype = torch.float32,
     seed: int = SEED,
 ):
     """Build random tensors on CPU for both golden and NPU execution."""
     torch.manual_seed(seed)
-    A_log = torch.randn(num_heads, dtype=torch.float32)
-    dt_bias = torch.randn(num_heads, dtype=torch.float32)
+    A_log = torch.randn(num_heads, dtype=param_dtype)
+    dt_bias = torch.randn(num_heads, dtype=param_dtype)
     a = torch.randn(batch, num_heads, dtype=dtype)
     b = torch.randn(batch, num_heads, dtype=dtype)
     return A_log, a, b, dt_bias
+
+
+def _force_softplus_threshold_cases(
+    a: torch.Tensor,
+    dt_bias: torch.Tensor,
+    beta: float,
+    threshold: float,
+) -> None:
+    """Force beta * (a + dt_bias) to cover threshold and non-threshold paths."""
+    if a.shape[0] < 4 or a.shape[1] < 4:
+        return
+
+    dt_bias[:4] = 0
+    boundary = threshold / beta
+    a[0, 0] = boundary + 2.0   # linear branch
+    a[1, 1] = boundary         # softplus branch at equality
+    a[2, 2] = boundary - 0.5   # softplus branch below threshold
+    a[3, 3] = -boundary - 2.0  # negative softplus input
 
 
 def _npu_op_exec(
@@ -97,13 +127,10 @@ def _npu_op_exec(
     b: torch.Tensor,
     dt_bias: torch.Tensor,
     beta: float = 1.0,
+    threshold: float = 20.0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Execute the AscendC operator on NPU and return CPU tensors."""
-    # Ensure correct dtypes and contiguity for the NPU operator.
-    if A_log.dtype != torch.float32:
-        A_log = A_log.to(torch.float32)
-    if dt_bias.dtype != torch.float32:
-        dt_bias = dt_bias.to(torch.float32)
+    # Ensure contiguity for the NPU operator.
     if not A_log.is_contiguous():
         A_log = A_log.contiguous()
     if not dt_bias.is_contiguous():
@@ -115,6 +142,7 @@ def _npu_op_exec(
         b.npu(),
         dt_bias.npu(),
         float(beta),
+        float(threshold),
     )
     return g.cpu(), beta_output.cpu()
 
@@ -161,6 +189,7 @@ def test_fused_gdn_gating_vs_reference(num_heads, batch, dtype):
 @pytest.mark.parametrize("batch", [1, 37])
 def test_fused_gdn_gating_non_default_params(num_heads, batch):
     A_log, a, b, dt_bias = _make_inputs(num_heads, batch, torch.bfloat16)
+    _force_softplus_threshold_cases(a, dt_bias, beta=0.5, threshold=1.0)
 
     ref_g, ref_beta = _golden_fused_gdn_gating(
         A_log,
@@ -168,6 +197,7 @@ def test_fused_gdn_gating_non_default_params(num_heads, batch):
         b,
         dt_bias,
         beta=0.5,
+        threshold=1.0,
     )
     npu_g, npu_beta = _npu_op_exec(
         A_log,
@@ -175,6 +205,39 @@ def test_fused_gdn_gating_non_default_params(num_heads, batch):
         b,
         dt_bias,
         beta=0.5,
+        threshold=1.0,
+    )
+
+    _assert_close(npu_g, npu_beta, ref_g, ref_beta)
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+@pytest.mark.parametrize(("dtype", "param_dtype"), DTYPE_COMBINATIONS)
+def test_fused_gdn_gating_dtype_matrix(dtype, param_dtype):
+    A_log, a, b, dt_bias = _make_inputs(
+        32,
+        37,
+        dtype,
+        param_dtype=param_dtype,
+    )
+    _force_softplus_threshold_cases(a, dt_bias, beta=1.0, threshold=2.0)
+
+    ref_g, ref_beta = _golden_fused_gdn_gating(
+        A_log,
+        a,
+        b,
+        dt_bias,
+        threshold=2.0,
+    )
+    npu_g, npu_beta = _npu_op_exec(
+        A_log,
+        a,
+        b,
+        dt_bias,
+        threshold=2.0,
     )
 
     _assert_close(npu_g, npu_beta, ref_g, ref_beta)

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_fused_gdn_gating.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_fused_gdn_gating.py
@@ -25,11 +25,7 @@ NUM_HEADS_VALUES = [4, 6, 8, 12, 16, 24, 32, 48, 64, 128]
 BATCH_SIZES = [1, 7, 37, 128, 512, 4096, 16384]
 DTYPES = [torch.bfloat16, torch.float16]
 PARAM_DTYPES = [torch.float32, torch.bfloat16, torch.float16]
-DTYPE_COMBINATIONS = [
-    (dtype, param_dtype)
-    for dtype in DTYPES
-    for param_dtype in PARAM_DTYPES
-]
+DTYPE_COMBINATIONS = [(dtype, param_dtype) for dtype in DTYPES for param_dtype in PARAM_DTYPES]
 
 
 # ---------------------------------------------------------------------------
@@ -115,9 +111,9 @@ def _force_softplus_threshold_cases(
 
     dt_bias[:4] = 0
     boundary = threshold / beta
-    a[0, 0] = boundary + 2.0   # linear branch
-    a[1, 1] = boundary         # softplus branch at equality
-    a[2, 2] = boundary - 0.5   # softplus branch below threshold
+    a[0, 0] = boundary + 2.0  # linear branch
+    a[1, 1] = boundary  # softplus branch at equality
+    a[2, 2] = boundary - 0.5  # softplus branch below threshold
     a[3, 3] = -boundary - 2.0  # negative softplus input
 
 

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -750,7 +750,7 @@ class BaseDeviceAdaptor:
 
     @staticmethod
     def fused_gdn_gating(A_log: torch.Tensor, a: torch.Tensor, b: torch.Tensor, dt_bias: torch.Tensor):
-        return torch.ops._C_ascend.npu_fused_gdn_gating(A_log, a, b, dt_bias.to(torch.float32))
+        return torch.ops._C_ascend.npu_fused_gdn_gating(A_log, a, b, dt_bias.to(A_log.dtype))
 
     @staticmethod
     def split_qkv_rmsnorm_rope(


### PR DESCRIPTION
### What this PR does / why we need it?
This PR aligns the AscendC `fused_gdn_gating` operator with the Triton implementation.

It adds the `softplus_threshold` parameter through the full AscendC op stack, updates the softplus computation to match Triton semantics, and supports fp32/bf16/fp16 `A_log` and `dt_bias` inputs while keeping the actual computation in fp32.

### How was this patch tested?
- Script
``` bash
pytest test/e2e/nightly/single_node/ops/singlecard_ops/test_fused_gdn_gating.py
```
- Result
``` bash
========================== 177 passed in 64.32s (0:01:04) ========================== 
```

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
