### PR TITLE
[BugFix][PD] Fix memory leak from key mismatch in proc_not_transfer_request cleanup

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -589,8 +589,8 @@ class KVCacheRecvingThread(threading.Thread):
         finally:
             if all_task_done:
                 self.task_tracker.update_done_task_count(request_id)
-                if request_id in self.proc_not_transfer_request:
-                    del self.proc_not_transfer_request[request_id]
+                if remote_request_id in self.proc_not_transfer_request:
+                    del self.proc_not_transfer_request[remote_request_id]
                 self._clear_failed_recv_request(request_id)
             self.request_queue.task_done()
             self._send_done_signal_to_free_remote_port(remote_request_id, remote_host, remote_port_send_num)

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -520,8 +520,8 @@ class KVCacheRecvingThread(threading.Thread):
             if all_task_done:
                 if len(req_meta["local_block_ids"]) > 0:
                     self.task_tracker.update_done_task_count(request_id)
-                if request_id in self.proc_not_transfer_request:
-                    del self.proc_not_transfer_request[request_id]
+                if remote_request_id in self.proc_not_transfer_request:
+                    del self.proc_not_transfer_request[remote_request_id]
             self.request_queue.task_done()
             # Always send the done signal to the remote host to ensure proper
             # resource cleanup. Failing to do so may cause a memory leak on the


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes a memory leak in `KVCacheRecvingThread` caused by a key mismatch when cleaning up `proc_not_transfer_request`.

**Root cause:**

`_send_done_signal_to_free_remote_port()` is called with `remote_request_id` as the first argument (line 596 in `mooncake_connector.py`, line 519 in `mooncake_hybrid_connector.py`). Inside this function, the parameter is named `request_id` and is used to write entries into `self.proc_not_transfer_request`.

However, in `_handle_request()`'s finally block, the cleanup code uses `request_id` (i.e., `req_meta["request_id"]`) to delete from the dict — which is a **different value** from `remote_request_id`.

Since the write key (`remote_request_id`) never matches the delete key (`request_id`), entries are never removed, causing the dict to grow unboundedly over the process lifetime.

**Fix:**

Use `remote_request_id` consistently for cleanup in both `mooncake_connector.py` and `mooncake_hybrid_connector.py`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Code inspection. The fix is a one-line key correction in each file — changing `request_id` to `remote_request_id` in the `del` statement to match the key used by `_send_done_signal_to_free_remote_port`.
- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
