### PR TITLE
[Feature] Support Step3.5/3.7 Flash for Ascend950

### DIFF
--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -309,7 +309,7 @@ def _mock_w8a8_gelu_compute(gate_up, *, gmm2_out=None, capture_quant=False):
     stream_patch, evt = _patch_npu_stream()
     captured = {}
 
-    def _dynamic_quant(x):
+    def _dynamic_quant(x, dst_type=None):
         if capture_quant:
             captured["x"] = x.detach().clone()
             scale = torch.ones(1, dtype=torch.float32)

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -24,6 +24,7 @@ from vllm.triton_utils import HAS_TRITON
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.device.mxfp_compat import (
+    FLOAT8_E8M0FNU_DTYPE,
     ensure_mxfp8_moe_available,
 )
 from vllm_ascend.ops.activation import AscendSwigluOAIAndMul, AscendSwigluStepAndMul
@@ -166,7 +167,7 @@ def quant_apply_mlp(
                 group_list=cumsum_group_list(group_list, group_list_type, 0),
                 swiglu_limit=swiglu_limit,
             )
-        elif use_gmm_swiglu_quant_fusion:
+        elif use_gmm_swiglu_quant_fusion and activation != MoEActivation.SWIGLUSTEP:
             # gmm1: gate_up_proj & act_fn: swiglu
             hidden_states, swiglu_out_scale, _ = DeviceOperator.npu_grouped_matmul_swiglu_quant(
                 x=hidden_states,
@@ -183,6 +184,31 @@ def quant_apply_mlp(
             )
             if quantized_hidden_states is not None:
                 dispose_tensor(quantized_hidden_states)
+        elif activation == MoEActivation.SWIGLUSTEP:
+            # Step3.5/3.7 needs to clamp in swiglu: out = silu(gate).clamp(max=limit) * up.clamp(-limit, limit)
+            gmm1_kwargs = {
+                "x": [hidden_states],
+                "weight": w1 if isinstance(w1, list) else [w1],
+                "scale": [w1_scale[0].to(w2_scale[0].dtype)] if isinstance(w1_scale, list) else [w1_scale],
+                "bias": None,
+                "per_token_scale": [pertoken_scale],
+                "split_item": 2,
+                "group_type": 0,
+                "group_list": group_list,
+                "output_dtype": torch.bfloat16,
+            }
+            if use_mxfp_quant:
+                gmm1_kwargs.update(
+                    {
+                        "scale_dtype": FLOAT8_E8M0FNU_DTYPE,
+                        "per_token_scale_dtype": FLOAT8_E8M0FNU_DTYPE,
+                    }
+                )
+            hidden_states = torch_npu.npu_grouped_matmul(**gmm1_kwargs)[0]
+            hidden_states = AscendSwigluStepAndMul.swiglustep_forward(hidden_states, limit=7.0)
+            hidden_states, swiglu_out_scale = DeviceOperator.npu_dynamic_quant(
+                hidden_states, act_quant_type=act_quant_type, use_mxfp_quant=use_mxfp_quant
+            )
         else:
             if w1_scale[0].dtype != torch.float32:
                 w1_scale[0] = w1_scale[0].to(torch.float32)
@@ -321,26 +347,36 @@ def quant_apply_mlp(
             if quantized_hidden_states is not None:
                 dispose_tensor(quantized_hidden_states)
         else:
-            w1_scale[0] = w1_scale[0].to(w2_scale[0].dtype)
             # gmm1: gate_up_proj
-            hidden_states = torch_npu.npu_grouped_matmul(
-                x=[hidden_states],
-                weight=w1,
-                scale=w1_scale,
-                bias=bias1,
-                per_token_scale=[pertoken_scale],
-                split_item=2,
-                group_list_type=group_list_type,
-                group_type=0,
-                group_list=group_list,
-                output_dtype=_output_dtype,
-            )[0]
+            gmm1_kwargs = {
+                "x": [hidden_states],
+                "weight": w1 if isinstance(w1, list) else [w1],
+                "scale": [w1_scale[0].to(w2_scale[0].dtype)] if isinstance(w1_scale, list) else [w1_scale],
+                "bias": bias1,
+                "per_token_scale": [pertoken_scale],
+                "split_item": 2,
+                "group_type": 0,
+                "group_list": group_list,
+                "group_list_type": group_list_type,
+                "output_dtype": _output_dtype,
+            }
+            if use_mxfp_quant:
+                gmm1_kwargs.update(
+                    {
+                        "scale_dtype": FLOAT8_E8M0FNU_DTYPE,
+                        "per_token_scale_dtype": FLOAT8_E8M0FNU_DTYPE,
+                        "output_dtype": torch.bfloat16,
+                    }
+                )
+            hidden_states = torch_npu.npu_grouped_matmul(**gmm1_kwargs)[0]
             if quantized_hidden_states is not None:
                 dispose_tensor(quantized_hidden_states)
             # act_fn: swiglu
             if activation == MoEActivation.SWIGLUSTEP:
                 hidden_states = AscendSwigluStepAndMul.swiglustep_forward(hidden_states, limit=swiglu_limit or 7.0)
-                hidden_states, swiglu_out_scale = torch_npu.npu_dynamic_quant(hidden_states)
+                hidden_states, swiglu_out_scale = DeviceOperator.npu_dynamic_quant(
+                    hidden_states, act_quant_type=act_quant_type, use_mxfp_quant=use_mxfp_quant
+                )
             elif is_gelu_activation:
                 gate, up = hidden_states.chunk(2, dim=-1)
                 approximate = "tanh" if activation == MoEActivation.GELU_TANH else "none"

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -1156,3 +1156,20 @@
 #    Future Plan:
 #       Remove this patch once vllm-ascend fully supports the v2 model
 #       runner.
+#
+# ** 32. File: worker/patch_step3p5.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.model_executor.models.step3p5.Step3p5Attention.forward`
+#    Why:
+#       Add split_qkv_rmsnorm_rope support for step3.5/3.7. This model can't use
+#       fusion pass to enable this op because of 2 reasons: 1) Step uses
+#       Gemmanorm instead of normal norm, so existing fusion pass can't be
+#       matched. 2) Step has 2 kinds of attention layer (full attention and
+#       sliding window attention), each has different number of q_head. Right
+#       now, torch.compile will use same pattern to match different attention
+#       layer so there will be shape mismatch in split op.
+#    How:
+#       Monkey-patch Step3p5Attention.forward to enable split_qkv_rmsnorm_rope.
+#    Future Plan:
+#       Remove this patch once torch.compile fully supports matching pattern from
+#       op's params.

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -44,6 +44,7 @@ import vllm_ascend.patch.worker.patch_minimax_m2  # noqa
 import vllm_ascend.patch.worker.patch_minimax_m2_linear_attn  # noqa
 import vllm_ascend.patch.worker.patch_mamba_utils  # noqa
 import vllm_ascend.patch.worker.patch_qwen3_next_mtp  # noqa
+import vllm_ascend.patch.worker.patch_step3p5  # noqa
 
 if not is_310p():
     import vllm_ascend.patch.worker.patch_qwen3_5  # noqa

--- a/vllm_ascend/patch/worker/patch_step3p5.py
+++ b/vllm_ascend/patch/worker/patch_step3p5.py
@@ -1,0 +1,69 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Step3.5/3.7 on Ascend: Attention.
+#
+
+import torch
+from vllm.model_executor.models.step3p5 import Step3p5Attention
+
+from vllm_ascend.device.device_op import DeviceOperator
+
+
+def _patched_attention_forward(
+    self,
+    positions: torch.Tensor,
+    hidden_states: torch.Tensor,
+) -> torch.Tensor:
+    qkv, _ = self.qkv_proj(hidden_states)
+    if self.use_rope:
+        q, k, v = DeviceOperator.split_qkv_rmsnorm_rope(
+            input=qkv,
+            q_weight=self.q_norm.weight + 1.0,
+            k_weight=self.k_norm.weight + 1.0,
+            q_hidden_size=self.q_size,
+            kv_hidden_size=self.kv_size,
+            head_dim=self.head_dim,
+            eps=self.q_norm.variance_epsilon,
+            q_bias=None,
+            k_bias=None,
+            cos_sin_cache=self.rotary_emb.cos_sin_cache,
+            positions=positions,
+        )
+    else:
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        # Add qk-norm inline similar to Qwen3 MOE attention
+        q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
+        q_by_head = self.q_norm(q_by_head.contiguous())
+        q = q_by_head.view(q.shape)
+
+        k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
+        k_by_head = self.k_norm(k_by_head.contiguous())
+        k = k_by_head.view(k.shape)
+
+    attn_output = self.attn(q, k, v)
+    if self.use_head_wise_attn_gate:
+        extra_dims, _ = self.g_proj(hidden_states)
+        output = (
+            attn_output.view(*attn_output.shape[:-1], self.num_heads, self.head_dim)
+            * extra_dims.unsqueeze(-1).sigmoid()
+        )
+        attn_output = output.view(*attn_output.shape)
+    output, _ = self.o_proj(attn_output)
+    return output
+
+
+Step3p5Attention.forward = _patched_attention_forward

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -962,6 +962,8 @@ def is_drafter_moe_model(vllm_config: VllmConfig):
             return _IS_DRAFTER_MOE_MODEL
         if "Eagle3DeepseekV2ForCausalLM" in model_configs["architectures"]:
             _IS_DRAFTER_MOE_MODEL = False
+        if "Step3p5MTP" in model_configs["architectures"]:
+            _IS_DRAFTER_MOE_MODEL = False
     return _IS_DRAFTER_MOE_MODEL
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds support step3.5/step3.7 in Ascend950, and add flashcomm1 support for step3.5 and split_qk_norm_rope support for step3.5/step3.7.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ascend950:
Step3.5 aime25 acc:
<img width="446" height="49" alt="image" src="https://github.com/user-attachments/assets/622ed677-fe81-4fdb-82ec-2a22d2b148f8" />
Step3.7 function ok:
(APIServer pid=49678) INFO:     Started server process [49678]
(APIServer pid=49678) INFO:     Waiting for application startup.
(APIServer pid=49678) INFO:     Application startup complete.
(Worker_TP0_EP0 pid=50303) INFO 07-07 11:54:23 [acl_graph.py:259] Replaying aclgraph
(APIServer pid=49678) INFO:     127.0.0.1:55086 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=49678) INFO 07-07 11:54:29 [loggers.py:271] Engine 000: Avg prompt throughput: 18.9 tokens/s, Avg generation throughput: 84.9 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%, MM cache hit rate: 0.0%
(APIServer pid=49678) INFO 07-07 11:54:29 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 2.82, Accepted throughput: 22.29 tokens/s, Drafted throughput: 36.73 tokens/s, Accepted: 548 tokens, Drafted: 903 tokens, Per-position acceptance rate: 0.811, 0.591, 0.419, Avg Draft acceptance rate: 60.7%

A3:
Step3.5 aime25 acc:
<img width="442" height="80" alt="image" src="https://github.com/user-attachments/assets/f07d167c-42e0-4bdc-a951-2bb1091395ba" />
Step3.7 function ok:
(APIServer pid=114450) INFO:     Started server process [114450]
(APIServer pid=114450) INFO:     Waiting for application startup.
(APIServer pid=114450) INFO:     Application startup complete.
(Worker_TP0_EP0 pid=115008) INFO 07-07 15:20:40 [acl_graph.py:259] Replaying aclgraph
(APIServer pid=114450) INFO:     127.0.0.1:48572 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=114450) INFO 07-07 15:20:45 [loggers.py:271] Engine 000: Avg prompt throughput: 1.6 tokens/s, Avg generation throughput: 2.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=114450) INFO 07-07 15:20:45 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 3.33, Accepted throughput: 0.11 tokens/s, Drafted throughput: 0.14 tokens/s, Accepted: 14 tokens, Drafted: 18 tokens, Per-position acceptance rate: 1.000, 0.833, 0.500, Avg Draft acceptance rate: 77.8%


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
