### PR TITLE
"[Ascend950] [BugFix]Fix the issue where MOE model output is garbled when communicating with allgether while SP is disabled.“

### DIFF
--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -283,6 +283,14 @@ class AscendMoERunner(MoERunner):
         # output. Skip any additional reduction here.
         return shared_output
 
+    def _maybe_reduce_final_output(
+        self,
+        states: torch.Tensor,
+        trunc_size: int,
+    ) -> torch.Tensor:
+        states = torch.ops.vllm.maybe_all_reduce_tensor_model_parallel(states)
+        return states[..., :trunc_size]
+
     # TODO: Remove this after drop v0.19.1 support
     def forward_impl(
         self,


### PR DESCRIPTION

### What this PR does / why we need it?
This PR fixes a garbled output issue for MoE models when using the ALLGATHER communication path without sequence parallelism enabled.

In the non-SP MoE scenario, the final MoE output still needs to be reduced across TP/EP ranks. However, when running in graph mode, the communication decision may be specialized during graph compilation, especially when switching between different MoE communication paths such as MC2 and ALLGATHER. As a result, the required final all-reduce for the ALLGATHER path can be skipped, which leads to incorrect MoE output and eventually garbled model responses.

To fix this, this PR moves the final MoE output reduction decision into the graph/runtime path, so the correct reduce behavior is preserved for non-sequence-parallel configurations. This ensures that MoE models produce correct results when ALLGATHER is selected while SP is disabled.

MXFP8 Deepseekv3.1 qpga AISBenchtest:
| Dataset      | Version | Metric   | Mode | vLLM API General Chat |
|--------------|---------|----------|------|------------------------|
| GPQA_diamond | 53064e  | accuracy | gen  | 76.77                 |

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
