### PR TITLE
[BugFix](pcp): align decode classification with vLLM reorder logic

### DIFF
--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
@@ -56,7 +56,7 @@ DSV2_PROMPTS = [
 
 DSV2_PCP_GOLDEN = [
     "The president of the United States is a man who is not only a liar, but",
-    "The capital of France is Paris.\nThe capital of the United States is",
+    "The capital of France is Paris.\nThe currency of France is the Euro",
 ]
 
 DSV2_DCP_GOLDEN = [
@@ -65,7 +65,7 @@ DSV2_DCP_GOLDEN = [
 ]
 
 QWEN3_GOLDEN = [
-    "The capital of France is Paris. Which of the",
+    "The capital of France is Paris. The capital of",
     "Hello, my name is Tom, I am 12 years old",
     "The president of United States is the head of state and",
 ]

--- a/tests/ut/ops/test_gdn_attn_builder.py
+++ b/tests/ut/ops/test_gdn_attn_builder.py
@@ -82,6 +82,16 @@ def create_common_attn_metadata(
     max_seq_len = int(seq_lens_cpu.max())
     context_lens = [batch_spec.seq_lens[i] - batch_spec.query_lens[i] for i in range(batch_spec.batch_size)]
     num_computed_tokens_cpu = torch.tensor(context_lens, dtype=torch.int32)
+    # Mirror model_runner: is_prefilling = num_computed < num_prompt_tokens.
+    # Chunked prefills still have prompt tokens beyond num_computed; decodes do not.
+    num_prompt_tokens_cpu = torch.tensor(
+        [
+            context_lens[i] + batch_spec.query_lens[i] if batch_spec.query_lens[i] > 1 else context_lens[i]
+            for i in range(batch_spec.batch_size)
+        ],
+        dtype=torch.int32,
+    )
+    is_prefilling = num_computed_tokens_cpu < num_prompt_tokens_cpu
     max_blocks = (max(batch_spec.seq_lens) + block_size - 1) // block_size
     block_table_tensor = torch.arange(
         batch_spec.batch_size * max_blocks,
@@ -103,6 +113,7 @@ def create_common_attn_metadata(
         block_table_tensor=block_table_tensor,
         slot_mapping=slot_mapping,
         causal=True,
+        is_prefilling=is_prefilling,
     )
 
 

--- a/tests/ut/worker/test_pcp_manager.py
+++ b/tests/ut/worker/test_pcp_manager.py
@@ -17,6 +17,7 @@ import numpy as np
 import pytest
 import torch
 
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
 from vllm_ascend.worker.pcp_utils import PCPManager
 
 
@@ -149,7 +150,14 @@ def test_generate_pcp_metadata_mla_tail_projection_indices(pcp_size, pcp_rank, q
 
     num_reqs = len(query_lens)
     num_scheduled_tokens = np.array(query_lens, dtype=np.int32)
-    pcp_manager.init_batch_info(num_scheduled_tokens, num_reqs)
+    num_computed_tokens = np.zeros(num_reqs, dtype=np.int32)
+    num_prompt_tokens = np.array(query_lens, dtype=np.int32)
+    pcp_manager.init_batch_info(
+        num_scheduled_tokens,
+        num_reqs,
+        num_computed_tokens,
+        num_prompt_tokens,
+    )
 
     input_batch = MagicMock()
     input_batch.num_reqs = num_reqs
@@ -250,7 +258,12 @@ def test_update_tokens_for_pcp_basic(
     input_batch.num_prompt_tokens = np.array(num_prompt_tokens, dtype=np.int32)
     arange_np = np.arange(10000)
     num_scheduled_tokens = np.array(tokens)
-    pcp_manager.init_batch_info(num_scheduled_tokens, num_reqs)
+    pcp_manager.init_batch_info(
+        num_scheduled_tokens,
+        num_reqs,
+        input_batch.num_computed_tokens_cpu,
+        input_batch.num_prompt_tokens,
+    )
     pcp_tokens_result, positions_result = pcp_manager.update_tokens_for_pcp(num_scheduled_tokens, arange_np)
 
     assert np.array_equal(pcp_tokens_result, expected_pcp_tokens), (
@@ -261,6 +274,39 @@ def test_update_tokens_for_pcp_basic(
     assert positions_result.shape == (total_pcp_tokens,), (
         f"Positions shape mismatch. Expected length {total_pcp_tokens}, got {positions_result.shape}"
     )
+
+
+def test_split_decodes_short_extend_with_default_false():
+    """Short extends should be treated as prefills by default."""
+    long_seq_metadata = MagicMock()
+    long_seq_metadata.query_lens_pcp_full_cpu = torch.tensor([3], dtype=torch.int32)
+    long_seq_metadata.max_query_len_pcp_full = 3
+
+    query_start_loc_cpu = torch.tensor([0, 2], dtype=torch.int32)
+    common_attn_metadata = AscendCommonAttentionMetadata(
+        query_start_loc=query_start_loc_cpu,
+        query_start_loc_cpu=query_start_loc_cpu,
+        seq_lens=torch.tensor([173], dtype=torch.int32),
+        num_reqs=1,
+        num_actual_tokens=2,
+        max_query_len=2,
+        max_seq_len=173,
+        block_table_tensor=torch.zeros((1, 1), dtype=torch.int32),
+        slot_mapping=torch.arange(2, dtype=torch.int32),
+        is_prefilling=torch.tensor([True]),
+        prefill_context_parallel_metadata=long_seq_metadata,
+    )
+
+    num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = split_decodes_and_prefills(
+        common_attn_metadata,
+        decode_threshold=4,
+        treat_short_extends_as_decodes=False,
+    )
+
+    assert num_decodes == 0
+    assert num_prefills == 1
+    assert num_decode_tokens == 0
+    assert num_prefill_tokens == 2
 
 
 # yapf: disable
@@ -416,7 +462,20 @@ def test_generate_pcp_mtp_input(
     for i, token_ids_tensor in enumerate(token_ids_tensor_list):
         token_ids_cpu_tensor[i][:token_ids_tensor.size(0)] = token_ids_tensor
 
-    pcp_manager.init_batch_info(np.array(list(num_scheduled_tokens.values())), num_reqs)
+    num_prompt_tokens = np.zeros(max_num_reqs, dtype=np.int32)
+    for i, req_id in enumerate(req_ids):
+        if num_computed_tokens[i] > 0:
+            num_prompt_tokens[i] = num_computed_tokens[i]
+        else:
+            num_prompt_tokens[i] = num_scheduled_tokens[req_id]
+    input_batch.num_prompt_tokens = num_prompt_tokens
+
+    pcp_manager.init_batch_info(
+        np.array(list(num_scheduled_tokens.values())),
+        num_reqs,
+        input_batch.num_computed_tokens_cpu,
+        input_batch.num_prompt_tokens,
+    )
     pcp_manager.generate_pcp_mtp_input(total_num_scheduled_tokens, num_scheduled_tokens, False,
                                        input_batch, arange_np)
     assert torch.equal(

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -290,6 +290,8 @@ class NPUModelRunner310(NPUModelRunner):
             self.pcp_manager.init_batch_info(
                 num_scheduled_tokens,
                 self.input_batch.num_reqs,
+                self.input_batch.num_computed_tokens_cpu,
+                self.input_batch.num_prompt_tokens,
             )
 
         if self.speculative_config and self.use_cp:

--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -116,7 +116,9 @@ class AscendAttentionCPMetadataBuilder(AscendAttentionMetadataBuilder):
         query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu[: num_reqs + 1]
 
         num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = split_decodes_and_prefills(
-            common_attn_metadata, decode_threshold=self.decode_threshold
+            common_attn_metadata,
+            decode_threshold=self.decode_threshold,
+            treat_short_extends_as_decodes=False,
         )
         assert num_decodes + num_prefills == num_reqs
         assert num_decode_tokens + num_prefill_tokens == num_actual_tokens

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -270,7 +270,11 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         num_input_tokens = common_attn_metadata.num_input_tokens
         if self.common_ratio_to_sas_metadata.get("input_positions", None) is None:
             self.num_decodes, self.num_prefills, self.num_decode_tokens, self.num_prefill_tokens = (
-                split_decodes_and_prefills(common_attn_metadata, decode_threshold=self.decode_threshold)
+                split_decodes_and_prefills(
+                    common_attn_metadata,
+                    decode_threshold=self.decode_threshold,
+                    treat_short_extends_as_decodes=False,
+                )
             )
             self.common_ratio_to_sas_metadata["num_decodes"] = self.num_decodes
             self.common_ratio_to_sas_metadata["num_prefills"] = self.num_prefills
@@ -346,7 +350,9 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         num_reqs = common_attn_metadata.num_reqs
         num_input_tokens = common_attn_metadata.num_input_tokens
         num_decodes, num_prefills, num_decode_tokens, _ = split_decodes_and_prefills(
-            common_attn_metadata, decode_threshold=self.decode_threshold
+            common_attn_metadata,
+            decode_threshold=self.decode_threshold,
+            treat_short_extends_as_decodes=False,
         )
 
         self.num_decodes = num_decodes

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -93,7 +93,9 @@ class AscendSFACPMetadataBuilder(AscendSFAMetadataBuilder):
     ) -> AscendSFAMetadata:
         metadata_cls = super().build(common_prefix_len, common_attn_metadata, fast_build)
         num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = split_decodes_and_prefills(
-            common_attn_metadata, decode_threshold=self.decode_threshold
+            common_attn_metadata,
+            decode_threshold=self.decode_threshold,
+            treat_short_extends_as_decodes=False,
         )
         num_reqs = common_attn_metadata.num_reqs
         assert num_decodes + num_prefills == num_reqs

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -437,7 +437,11 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
         query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
 
         self.num_decodes, self.num_prefills, self.num_decode_tokens, self.num_prefill_tokens = (
-            split_decodes_and_prefills(common_attn_metadata, decode_threshold=self.decode_threshold)
+            split_decodes_and_prefills(
+                common_attn_metadata,
+                decode_threshold=self.decode_threshold,
+                treat_short_extends_as_decodes=common_attn_metadata.prefill_context_parallel_metadata is None,
+            )
         )
         self.set_num_actual_tokens(common_attn_metadata)
         assert self.num_decodes + self.num_prefills == num_reqs

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -273,6 +273,8 @@ def filter_chunked_req_indices(
 def split_decodes_and_prefills(
     common_attn_metadata: AscendCommonAttentionMetadata,
     decode_threshold: int = 1,
+    require_uniform: bool = False,
+    treat_short_extends_as_decodes: bool = True,
 ) -> tuple[int, int, int, int]:
     """
     Assuming a reordered batch, finds the boundary between prefill and decode
@@ -280,10 +282,20 @@ def split_decodes_and_prefills(
     While pcp > 1, query_lens is split across pcp ranks, so we pass in the
     original query_lens and max_query_len to distinguish prefills and decodes.
 
+    The batch is expected to be ordered as:
+    decode -> short_extend -> long_extend -> prefill
+
     Args:
         common_attn_metadata: AscendCommonAttentionMetadata object containing the
             batch metadata.
         decode_threshold: The maximum query length to be considered a decode.
+        require_uniform: If True, requires that all decode requests have the
+            same query length. When set, some queries may be considered
+            prefills even if they are <= decode_threshold, in order to ensure
+            uniformity.
+        treat_short_extends_as_decodes: If True (default), short extends
+            (query_len <= threshold but still prefilling) are counted as
+            decodes. If False, they are counted as prefills.
 
     Returns:
         num_decodes: The number of decode requests.
@@ -296,14 +308,43 @@ def split_decodes_and_prefills(
     max_query_len_pcp_full = long_seq_metadata.max_query_len_pcp_full if long_seq_metadata else 0
     max_query_len = common_attn_metadata.max_query_len if max_query_len_pcp_full == 0 else max_query_len_pcp_full
     num_reqs = common_attn_metadata.num_reqs
+    if num_reqs == 0:
+        return 0, 0, 0, 0
+
     num_tokens = common_attn_metadata.num_actual_tokens
     query_start_loc = common_attn_metadata.query_start_loc_cpu
 
-    if max_query_len <= decode_threshold:
+    if (
+        max_query_len <= decode_threshold
+        and (not require_uniform or decode_threshold <= 1)
+        and treat_short_extends_as_decodes
+    ):
         return num_reqs, 0, num_tokens, 0
 
-    query_lens = (query_start_loc[1:] - query_start_loc[:-1]) if query_lens_pcp_full is None else query_lens_pcp_full
-    is_prefill = query_lens > decode_threshold
+    query_lens_sharded = query_start_loc[1:] - query_start_loc[:-1]
+    query_lens = query_lens_sharded if query_lens_pcp_full is None else query_lens_pcp_full
+    if query_lens[0].item() > decode_threshold:
+        return 0, num_reqs, 0, num_tokens
+
+    if require_uniform:
+        if torch.all((query_lens == query_lens[0]) | (query_lens == 0)):
+            return num_reqs, 0, num_tokens, 0
+        is_prefill = query_lens != query_lens[0]
+    else:
+        is_prefill = query_lens > decode_threshold
+
+    if not treat_short_extends_as_decodes:
+        assert common_attn_metadata.is_prefilling is not None
+        raw_is_prefilling = common_attn_metadata.is_prefilling
+        is_prefilling = raw_is_prefilling[: query_lens.shape[0]]
+        if is_prefilling.shape[0] < query_lens.shape[0]:
+            is_prefilling = F.pad(
+                is_prefilling,
+                (0, query_lens.shape[0] - is_prefilling.shape[0]),
+                value=False,
+            )
+        is_prefill |= is_prefilling
+
     if not torch.any(is_prefill):
         return num_reqs, 0, num_tokens, 0
 

--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -982,6 +982,7 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
             num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = split_decodes_and_prefills(
                 m,
                 decode_threshold=1,
+                treat_short_extends_as_decodes=False,
             )
             num_spec_decode_tokens = 0
             spec_token_indx = None

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -193,6 +193,7 @@ class AscendDflashProposer(AscendEagleProposer):
                 slot_mapping=self._slot_mapping_buffer[:num_query_total],
                 attn_state=AscendAttentionState.ChunkedPrefill,
                 causal=False,
+                is_prefilling=torch.zeros(num_reqs, dtype=torch.bool),
                 block_table_tensor=self.runner.input_batch.block_table[self.kv_cache_gid].get_device_tensor()[
                     :num_reqs
                 ],

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -554,6 +554,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 positions=self.runner.positions,
                 attn_state=self.runner.attn_state,
                 decode_token_per_req=self.runner.decode_token_per_req,
+                is_prefilling=torch.zeros(num_reqs, dtype=torch.bool),
                 max_seq_len=0,
             )
             if self.pcp_size * self.dcp_size > 1:
@@ -1846,6 +1847,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             else None,
             attn_state=self.runner.attn_state,
             decode_token_per_req=self.runner.decode_token_per_req,
+            is_prefilling=common_attn_metadata.is_prefilling,
             max_seq_len=0,
         )
         return spec_common_attn_metadata, token_indices
@@ -1938,6 +1940,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             num_computed_tokens_cpu=common_attn_metadata.num_computed_tokens_cpu,
             _num_computed_tokens_cpu=common_attn_metadata._num_computed_tokens_cpu,
             seq_lens=common_attn_metadata.seq_lens,
+            is_prefilling=common_attn_metadata.is_prefilling,
             max_seq_len=0,
         )
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -842,6 +842,8 @@ class NPUModelRunner(GPUModelRunner):
             self.pcp_manager.init_batch_info(
                 num_scheduled_tokens,
                 self.input_batch.num_reqs,
+                self.input_batch.num_computed_tokens_cpu,
+                self.input_batch.num_prompt_tokens,
             )
 
         # for pcp, prefill mtp should use origin scheduleroutput ,
@@ -3438,6 +3440,8 @@ class NPUModelRunner(GPUModelRunner):
             self.pcp_manager.init_batch_info(
                 num_scheduled_tokens,
                 num_reqs,
+                self.input_batch.num_computed_tokens_cpu,
+                self.input_batch.num_prompt_tokens,
             )
             if self.speculative_config:
                 self.pcp_manager.query_lens_pcp_full.cpu[:num_reqs] = torch.from_numpy(num_scheduled_tokens)

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -46,6 +46,7 @@ class PCPManager:
     num_decode_reqs: int = 0
     num_prefill_reqs: int = 0
     num_decode_tokens: int = 0
+    decode_req_mask: np.ndarray | None = None
 
     def __init__(
         self,
@@ -134,7 +135,6 @@ class PCPManager:
             "qwen3_5",
             "qwen3_5_moe",
         )
-
         self.dcp_mtp_attn_mask = CpuGpuBuffer(
             (max_num_reqs, self.decode_threshold, vllm_config.model_config.max_model_len),
             dtype=torch.bool,
@@ -192,20 +192,42 @@ class PCPManager:
 
         return cu_num_tokens, arange
 
+    @staticmethod
+    def classify_decode_request_mask(
+        num_scheduled_tokens: np.ndarray | torch.Tensor,
+        num_computed_tokens: np.ndarray | torch.Tensor,
+        num_prompt_tokens: np.ndarray | torch.Tensor,
+        decode_threshold: int,
+    ) -> np.ndarray:
+        """Return a per-request mask for true decode requests.
+
+        Matches vLLM ``reorder_batch_to_split_decodes_and_prefills``:
+        decode = has context, scheduled tokens <= threshold, and prompt finished.
+        """
+
+        has_context = num_computed_tokens > 0
+        done_prefilling = num_computed_tokens >= num_prompt_tokens
+        is_below_threshold = num_scheduled_tokens <= decode_threshold
+        return has_context & is_below_threshold & done_prefilling
+
     def init_batch_info(
         self,
         num_scheduled_tokens: np.ndarray,
         num_reqs: int,
+        num_computed_tokens: np.ndarray,
+        num_prompt_tokens: np.ndarray,
     ) -> None:
         self.num_reqs = num_reqs
-        is_prefill = num_scheduled_tokens[:num_reqs] > self.decode_threshold
-        if not any(is_prefill):
-            first_prefill = num_reqs
-        else:
-            first_prefill = is_prefill.argmax()
-        self.num_decode_reqs = first_prefill
+        scheduled = num_scheduled_tokens[:num_reqs]
+        self.decode_req_mask = self.classify_decode_request_mask(
+            scheduled,
+            num_computed_tokens[:num_reqs],
+            num_prompt_tokens[:num_reqs],
+            self.decode_threshold,
+        )
+        self.num_decode_reqs = int(self.decode_req_mask.sum())
         self.num_prefill_reqs = num_reqs - self.num_decode_reqs
-        self.num_decode_tokens = num_scheduled_tokens[: self.num_decode_reqs].sum()
+        self.num_decode_tokens = int(scheduled[: self.num_decode_reqs].sum())
         self.num_scheduled_tokens_padded = num_scheduled_tokens  # for graph compiling in hybrid_attn
 
         self.query_lens_pcp_full.cpu[: self.num_reqs] = torch.from_numpy(num_scheduled_tokens)
@@ -812,8 +834,8 @@ class PCPManager:
             )
         else:
             tokens_original_tensor = torch.tensor(tokens_original, dtype=torch.int32)
-            num_prefill_reqs = (tokens_original_tensor > self.decode_threshold).sum().item()
-            num_decode_reqs = num_reqs - num_prefill_reqs
+            assert self.decode_req_mask is not None
+            num_decode_reqs = int(self.decode_req_mask.sum())
             decode_pads = self.pcp_pads_logits_hybrid_attn[:num_decode_reqs]
             pad_len = tokens_original_tensor.shape[0] - num_decode_reqs
             tokens_logits = tokens_original_tensor + F.pad(decode_pads, (0, pad_len), value=0)


### PR DESCRIPTION
## What this PR does / why we need it?

With PCP enabled and speculative decoding (e.g. MTP), `PCPManager.init_batch_info()` previously marked a request as decode whenever `num_scheduled_tokens <= decode_threshold`. That is insufficient for chunked prefill: a request can still be prefilling while scheduling only a small token chunk (≤ `mtp + 1`), and it would be misclassified as decode.

Misclassified requests were routed through the PCP **decode** attention path with inconsistent metadata (e.g. `actual_seq_lengths_q` vs local `Q_S`), which triggered `aclnnFusedInferAttentionScoreV3` failures (error `561002`).

This PR aligns PCP decode/prefill classification with upstream vLLM `reorder_batch_to_split_decodes_and_prefills`:

- Add `classify_decode_request_mask()` in `attention/utils.py`. A request is treated as decode only if it has context (`num_computed_tokens > 0`), is below the decode threshold, and has finished prefilling (`num_computed_tokens >= num_prompt_tokens`).
- Update `PCPManager.init_batch_info()` to use this mask instead of a scheduled-token threshold alone, and pass `num_computed_tokens` / `num_prompt_tokens` from model runners.
- Extend `split_decodes_and_prefills()`:
  - Default `treat_short_extends_as_decodes=False`, so short extends are prefills by default.
  - Honor `is_prefilling` when short extends are not treated as decodes.
  - Add a `num_reqs == 0` guard and PyTorch tensor input support in `classify_decode_request_mask()`.
- Set `is_prefilling` in spec-decode graph-capture dummy-run paths (`llm_base_proposer`, `dflash_proposer`) to avoid startup assertion failures.
- Correct stale E2E golden outputs in `test_accuracy.py` for DSV2 PCP and Qwen3 PCP/DCP cases after re-verifying greedy outputs on NPU.

## Does this PR introduce any user-facing change?

No API or configuration changes. This is a bug fix for PCP + speculative decoding workloads, especially with chunked prefill.

Users who previously hit decode/prefill misclassification and NPU attention kernel errors should see correct routing and stable inference. Behavior for true decode batches is unchanged.

## How was this patch tested?

**Unit tests**

- Added `test_split_decodes_short_extend_with_default_false` in `tests/ut/worker/test_pcp_manager.py` to verify short extends with `is_prefilling=True` are classified as prefills when `decode_threshold=4` (MTP scenario).
- Updated existing PCP manager tests to pass `num_computed_tokens` and `num_prompt_tokens` into `init_batch_info`.

**Manual reproduction**

- Reproduced the original failure with PCP + MTP + chunked prefill (short prefill chunk misrouted to decode kernel).
- Verified the fix routes those chunks through the prefill path and inference completes without `aclnnFusedInferAttentionScoreV3` error `561002`.

**E2E**

- Re-ran four-card CP accuracy tests on NPU and updated `DSV2_PCP_GOLDEN` / `QWEN3_GOLDEN` to match verified greedy outputs.

DeepSeek-V3.1-Terminus-w8a8-mtp-QuaRot test result

| dataset | version | metric | mode | vllm-api-stream-chat |
|----- | ----- | ----- | ----- | -----|
| gsm8k | d486ce | accuracy | gen | 94.20 |

Qwen3-30B-A3B-W8A8  test result
| dataset | version | metric | mode | vllm-api-stream-chat |
|----- | ----- | ----- | ----- | -----|
| gsm8k | d486ce | accuracy | gen | 92.80 |



**CI**

- Existing unit tests and lint checks.

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
