### PR TITLE
[DSv4][MTP] Enable MTP drafter cudagraph capture under DSA (graph-mode MTP without enforce_eager)

### DIFF
--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -873,6 +873,21 @@ class AscendDSACPImpl(DSAAttentionImpl):
     understand this class
     """
 
+    @staticmethod
+    def update_graph_params(
+        update_stream,
+        forward_context,
+        num_tokens,
+        vllm_config=None,
+        speculative_config=None,
+        num_dcp_pcp_tokens=None,
+        draft_attn_metadatas=None,
+    ):
+        # MTP graph-mode fix: DSA-CP does not need per-step graph param updates
+        # (same as SFA). Required so the generic full-graph drafter path does
+        # not raise AttributeError under FULL_DECODE_ONLY + MTP.
+        pass
+
     def __init__(
         self,
         n_heads: int,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1381,6 +1381,22 @@ class AscendDSAImpl(DSAAttentionImpl):
     understand this class
     """
 
+    @staticmethod
+    def update_graph_params(
+        update_stream,
+        forward_context,
+        num_tokens,
+        vllm_config=None,
+        speculative_config=None,
+        num_dcp_pcp_tokens=None,
+        draft_attn_metadatas=None,
+    ):
+        # MTP graph-mode fix: DSA does not need per-step graph param updates
+        # (same as SFA). The generic full-graph drafter path calls
+        # impl_cls.update_graph_params(...), so this no-op must exist or it
+        # raises AttributeError under FULL_DECODE_ONLY + MTP.
+        pass
+
     def __init__(
         self,
         n_heads: int,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -530,6 +530,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 slot_mapping=self.runner.input_batch.block_table[0].slot_mapping.gpu,
                 slot_mapping_cpu=self.runner.input_batch.block_table[0].slot_mapping.cpu,
                 positions=self.runner.positions,
+                # MTP graph-mode fix: DSA build_decode_metadata indexes positions_cpu;
+                # mirror main model (model_runner_v1.py) so drafter graph capture doesn't hit None.
+                positions_cpu=self.runner._dsa_positions_cpu_buf if self.use_compress else None,
                 attn_state=self.runner.attn_state,
                 decode_token_per_req=self.runner.decode_token_per_req,
                 max_seq_len=0,
@@ -550,9 +553,20 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 if self.pcp_size * self.dcp_size > 1 and draft_step > 0:
                     assert self.block_table_tensor_clone is not None, "block_table_tensor_clone is not init"
                     common_attn_metadata.block_table_tensor = self.block_table_tensor_clone[:num_reqs]
+                # MTP graph-mode fix: DSA build() asserts *_ratio_to_sas_metadata is not None;
+                # mirror _propose() so drafter graph capture passes empty sas_metadata dicts.
+                extra_attn_metadata_args: dict = {}
+                if self.use_compress:
+                    extra_attn_metadata_args = dict(
+                        prefill_ratio_to_sas_metadata=dict(),
+                        decode_ratio_to_sas_metadata=dict(),
+                        common_ratio_to_sas_metadata=dict(),
+                        block_size=self.draft_attn_groups[0].kv_cache_spec.block_size,
+                    )
                 attn_metadata_eagle = builder.build_for_graph_capture(
                     common_attn_metadata,
                     AscendAttentionState.SpecDecoding if self.method == "mtp" else AscendAttentionState.ChunkedPrefill,
+                    **extra_attn_metadata_args,
                 )
                 per_layer_attn_metadata = dict()
                 for layer_name in self.attn_layer_names:


### PR DESCRIPTION
## Summary

DeepSeek-V4 (Flash/Pro) MTP speculative decoding crashes under cudagraph (`--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'`) because the **drafter graph-capture path** in `llm_base_proposer.dummy_run` does not populate the DSA metadata that `dsa_v1` requires:

- `dsa_v1.build_decode_metadata` indexes `common_attn_metadata.positions_cpu`, but the drafter's `AscendCommonAttentionMetadata` in the graph-capture branch never sets `positions_cpu` -> `None` indexing crash.
- `dsa_v1.build` asserts `prefill/decode/common_ratio_to_sas_metadata is not None`, but the drafter graph-capture path passes none of them -> empty `AssertionError`.

The main-model path already handles both (`model_runner_v1` sets `positions_cpu=_dsa_positions_cpu_buf` when `use_compress`, and the non-graph `_propose()` builds `extra_attn_metadata_args`); only the drafter graph-capture branch was missing them. As a consequence DeepSeek-V4 MTP could previously only run with speculative `enforce_eager`.

## Fix

Mirror the non-graph `_propose()` path inside the graph-capture branch of `dummy_run`:

- pass `positions_cpu = runner._dsa_positions_cpu_buf` when `use_compress`;
- build empty `prefill/decode/common_ratio_to_sas_metadata` + `block_size` and forward them into `build_for_graph_capture` (passed through to `build` via `**kwargs`).

This lets the MTP drafter complete cudagraph capture, so DeepSeek-V4 MTP runs in graph mode without `enforce_eager`. The change is confined to `spec_decode/llm_base_proposer.py` (14 lines); model layers are unchanged, so the fix is model-agnostic and covers both DeepSeek-V4 Flash and Pro.

## Testing

- `python -m py_compile` and `import vllm_ascend` pass.
- Serve config: `--speculative-config '{"method":"mtp","num_speculative_tokens":1}'` (no `enforce_eager`) + `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'`.
- End-to-end serve validation (graph capture 8/8, acceptance rate, accuracy) in progress.
