### PR TITLE
[Feature] [BugFix] Support fine-grained Tensor Parallelism (OTP and Embedding TP) in DSA

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -139,6 +139,25 @@ class AscendConfig:
         self.multistream_overlap_gate = additional_config.get("multistream_overlap_gate", False)
         # PD-disaggregated only (kv_producer/kv_consumer); invalid in PD-mixed (kv_both / no kv_transfer_config).
         self.recompute_scheduler_enable = additional_config.get("recompute_scheduler_enable", False)
+        # DSV4 oproj / embedding fine-grained TP (oproj_tensor_parallel_size /
+        # embedding_tensor_parallel_size) use static, graph-stable exchange
+        # buffers and run cross-DP HCCL collectives (all_to_all / all_gather /
+        # reduce_scatter) that require uniform num_tokens across all DP ranks.
+        # Only the recompute scheduler balances num_tokens across DP ranks; the
+        # MC2 uneven-token skip path leaves each rank at its own num_tokens and
+        # would deadlock these collectives on a shape mismatch. So bind both
+        # features to recompute_scheduler_enable: they are only supported when
+        # recompute is on.
+        if (
+            self.finegrained_tp_config.oproj_tensor_parallel_size > 0
+            or self.finegrained_tp_config.embedding_tensor_parallel_size > 0
+        ) and not self.recompute_scheduler_enable:
+            raise AssertionError(
+                "oproj_tensor_parallel_size / embedding_tensor_parallel_size "
+                "require recompute_scheduler_enable=true: their cross-DP HCCL "
+                "collectives need uniform num_tokens across DP ranks, which is "
+                "only guaranteed when the recompute scheduler is enabled."
+            )
         self.enable_cpu_binding = additional_config.get("enable_cpu_binding", True)
         self.enable_sleep_mode_extra_cleanup = additional_config.get("enable_sleep_mode_extra_cleanup", False)
         self.multistream_dsv4_dsa_overlap = additional_config.get("multistream_dsv4_dsa_overlap", True)
@@ -447,8 +466,22 @@ class FinegrainedTPConfig:
         enabled_configs = []
         if self.oproj_tensor_parallel_size > 0:
             enabled_configs.append(f"oproj_tensor_parallel_size={self.oproj_tensor_parallel_size}")
-            # dummy_run does not run the entire attention module in eager mode,
-            # so the o_proj tp split can only be used in graph mode.
+            # wo_a/wo_b are sharded solely by the OTP group (which splits DP,
+            # orthogonal to the standard TP group), but _forward_o_proj reshapes
+            # the attention output with n_local_groups = n_groups // tp_size
+            # (standard TP). When tp_size > 1 the weight-shard and input-shard
+            # operate on different axes of the rank grid and no longer align,
+            # so oproj TP currently requires standard tp_size == 1.
+            if vllm_config.parallel_config.tensor_parallel_size > 1:
+                raise AssertionError(
+                    "oproj_tensor_parallel_size currently requires "
+                    "tensor_parallel_size == 1, got "
+                    f"{vllm_config.parallel_config.tensor_parallel_size}."
+                )
+            # The static all_to_all / reduce_scatter exchange buffers used by
+            # _forward_o_proj are sized for graph replay and require ACL graph
+            # capture; dummy_run does not run the entire attention module in
+            # eager mode, so o_proj tp split can only be used in graph mode.
             if vllm_config.model_config and vllm_config.model_config.enforce_eager:
                 raise AssertionError("oproj_tensor_parallel_size is only supported in graph mode")
             if vllm_config.kv_transfer_config is None or not vllm_config.kv_transfer_config.is_kv_consumer:

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar, TypeAlias
 
 import torch
+import torch.distributed as dist
 import torch.nn.functional as F
 import torch_npu
 import vllm.envs as envs_vllm
@@ -20,6 +21,7 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.distributed.parallel_state import get_otp_group
 from vllm_ascend.ops.cv_linear import CVLinearWrapper
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
@@ -27,8 +29,10 @@ from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinea
 from vllm_ascend.utils import (
     AscendDeviceType,
     get_ascend_device_type,
+    get_potential_max_tokens,
     npu_stream_switch,
     olora_tp_enable,
+    oproj_tp_enable,
 )
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 
@@ -1514,6 +1518,10 @@ class AscendDSAImpl(DSAAttentionImpl):
         topk_indices_buffer.copy_(topk_indices_to_cache)
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
+        # Attention impls are not walked by vllm's process_weights_after_loading
+        # dispatcher (only LinearMethodBase subclasses are). OTP buffers are
+        # allocated lazily on the first _forward_o_proj call, which always runs
+        # before ACL graph capture (profiling run triggers it).
         pass
 
     # TODO: cast to bfloat16 to speed up
@@ -1535,6 +1543,115 @@ class AscendDSAImpl(DSAAttentionImpl):
             x = x_rot.reshape(1, num_tokens, -1, rotary_dim)
         return x
 
+    def _forward_o_proj(self, o_proj_input: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
+        num_tokens = o_proj_input.shape[0]
+        group_hidden_dim = o_proj_input.shape[1] * o_proj_input.shape[2] // self.n_local_groups
+        o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, group_hidden_dim)
+        # A5 (Ascend950) uses an FP8-quantized o_proj path (dynamic MX quant
+        # + quantized batch matmul). Preserve it as-is: it predates and is
+        # orthogonal to the OTP / olora_tp paths below, so it must win first.
+        if get_ascend_device_type() in {AscendDeviceType.A5}:
+            o = o_proj_input
+            o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
+            o = torch_npu.npu_transpose_quant_batchmatmul(
+                o,
+                self.wo_a.weight,
+                dtype=torch.bfloat16,
+                bias=None,
+                group_sizes=(0, 0, 32),
+                x1_scale=swiglu_out_scale.view(torch.float8_e8m0fnu),
+                x2_scale=self.wo_a.weight_scale.view(torch.float8_e8m0fnu),
+                perm_x1=(1, 0, 2),
+                perm_x2=(0, 1, 2),
+                perm_y=(1, 0, 2),
+            )
+            o = o.reshape(num_tokens, -1)
+            output[...] = self.wo_b(o)
+        elif oproj_tp_enable():
+            oproj_group = get_otp_group()
+            oproj_tp_size = oproj_group.world_size
+            if self.n_local_groups % oproj_tp_size != 0:
+                raise ValueError(
+                    "n_local_groups must be divisible by "
+                    f"oproj_tensor_parallel_size, got {self.n_local_groups} "
+                    f"and {oproj_tp_size}."
+                )
+
+            groups_per_rank = self.n_local_groups // oproj_tp_size
+
+            o_proj_input = o_proj_input.view(num_tokens, oproj_tp_size, groups_per_rank, group_hidden_dim)
+            # Pad to a static exchange size so the all_to_all / reduce_scatter
+            # shapes are identical across all ACL graph buckets — variable
+            # shapes desync the HCCL communicator during graph replay.
+            # potential_max_tokens is computed once in the model runner __init__,
+            # so reading it here is a cheap global lookup.
+            exchange_num_tokens = get_potential_max_tokens()
+            if exchange_num_tokens < num_tokens:
+                raise ValueError(
+                    "oproj static exchange capacity must cover local tokens, "
+                    f"got {exchange_num_tokens} and {num_tokens}."
+                )
+            # Lazily allocate static send/recv buffers on first call. The
+            # profiling run hits this path before ACL graph capture, so the
+            # buffers exist and keep a stable device address across all later
+            # capture/replay cycles (graph replay requires the same address
+            # that was recorded at capture; new_zeros per call would desync
+            # the HCCL operator).
+            if not hasattr(self, "_oproj_send_buf"):
+                buf_shape = (oproj_tp_size, exchange_num_tokens, groups_per_rank, group_hidden_dim)
+                self._oproj_send_buf = torch.zeros(buf_shape, dtype=o_proj_input.dtype, device=o_proj_input.device)
+                self._oproj_recv_buf = torch.empty_like(self._oproj_send_buf)
+            send = self._oproj_send_buf
+            recv = self._oproj_recv_buf
+            # In-place fill into the address-stable buffer: zero the padding
+            # tail, then copy the real tokens.
+            send.zero_()
+            send[:, :num_tokens].copy_(o_proj_input.transpose(1, 0))
+            dist.all_to_all_single(recv.view(-1), send.view(-1), group=oproj_group.device_group)
+            o_proj_input = recv.view(oproj_tp_size * exchange_num_tokens, groups_per_rank, group_hidden_dim)
+            o_proj_input = torch_npu.npu_transpose_batchmatmul(
+                o_proj_input,
+                self.wo_a.weight,
+                bias=None,
+                scale=None,
+                perm_x1=(1, 0, 2),
+                perm_x2=(0, 1, 2),
+                perm_y=(1, 0, 2),
+                batch_split_factor=1,
+            )
+            o_proj_input = o_proj_input.reshape(oproj_tp_size * exchange_num_tokens, -1)
+            o_proj_output = self.wo_b(o_proj_input)
+            # reduce_scatter via a raw dist collective into an address-stable
+            # static buffer. oproj_group.reduce_scatter is a list-based wrapper
+            # that allocates per call, which desyncs the HCCL operator recorded
+            # at capture during ACL graph replay — the same reason all_to_all
+            # and the embedding TP path use raw dist + static buffers.
+            if not hasattr(self, "_oproj_rs_out_buf"):
+                self._oproj_rs_out_buf = torch.empty(
+                    (exchange_num_tokens, o_proj_output.shape[-1]),
+                    dtype=o_proj_output.dtype,
+                    device=o_proj_output.device,
+                )
+            dist.reduce_scatter_tensor(self._oproj_rs_out_buf, o_proj_output, group=oproj_group.device_group)
+            output[...] = self._oproj_rs_out_buf[:num_tokens]
+        elif olora_tp_enable():
+            o_proj_input = self.wo_a(o_proj_input)
+            output[...] = self.wo_b(o_proj_input)
+        else:
+            o_proj_input = torch_npu.npu_transpose_batchmatmul(
+                o_proj_input,
+                self.wo_a.weight,
+                bias=None,
+                scale=None,
+                perm_x1=(1, 0, 2),
+                perm_x2=(0, 1, 2),
+                perm_y=(1, 0, 2),
+                batch_split_factor=1,
+            )
+            o_proj_input = o_proj_input.reshape(num_tokens, -1)
+            output[...] = self.wo_b(o_proj_input)
+        return output
+
     def forward(  # type: ignore[override]
         self,
         layer_name,
@@ -1545,11 +1662,20 @@ class AscendDSAImpl(DSAAttentionImpl):
         output: torch.Tensor | None = None,
     ) -> torch.Tensor:
         assert output is not None, "Output tensor must be provided."
+        output_padded = output
+        forward_context = get_forward_context()
+        o_proj_input_shape = (forward_context.num_tokens, self.n_local_heads, self.head_dim)
         if attn_metadata is None:
-            return output.fill_(0)
+            # Profiling run: run o_proj on zero input so HCCL collectives are
+            # captured by the ACL graph.  Non-OTP just zeros the output.
+            if oproj_tp_enable():
+                o_proj_input = torch.zeros(o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device)
+                self._forward_o_proj(o_proj_input, output)
+            else:
+                output.fill_(0)
+            return output
         if not isinstance(attn_metadata, list):
             attn_metadata = [attn_metadata]
-        output_padded = output
         # Process for Flash Comm V1
         has_prefill = attn_metadata[0].num_prefills > 0
         has_decode = attn_metadata[0].num_decodes > 0
@@ -1561,8 +1687,6 @@ class AscendDSAImpl(DSAAttentionImpl):
         prefill_hidden_states = hidden_states[decode_tokens:actual_tokens]
         decode_hidden_states = hidden_states[:decode_tokens]
 
-        forward_context = get_forward_context()
-        o_proj_input_shape = (forward_context.num_tokens, self.n_local_heads, self.head_dim)
         o_proj_input = torch.empty(o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device)
         assert kv_cache is not None, "kv_cache tensor tuple must be provided."
         if has_prefill:
@@ -1586,7 +1710,6 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         cos = attn_metadata[0].cos[layer_name]
         sin = attn_metadata[0].sin[layer_name]
-        num_tokens = o_proj_input.shape[0]
 
         torch.ops._C_ascend.inplace_partial_rotary_mul(
             o_proj_input.unsqueeze(1),
@@ -1597,42 +1720,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         )
 
         # o
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
-            o = o_proj_input.view(num_tokens, self.n_local_groups, -1)
-            o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
-            o = torch_npu.npu_transpose_quant_batchmatmul(
-                o,
-                self.wo_a.weight,
-                dtype=torch.bfloat16,
-                bias=None,
-                group_sizes=(0, 0, 32),
-                x1_scale=swiglu_out_scale.view(torch.float8_e8m0fnu),
-                x2_scale=self.wo_a.weight_scale.view(torch.float8_e8m0fnu),
-                perm_x1=(1, 0, 2),
-                perm_x2=(0, 1, 2),
-                perm_y=(1, 0, 2),
-            )
-            o = o.reshape(num_tokens, -1)
-            output[...] = self.wo_b(o)
-        else:
-            o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, -1)
-            if olora_tp_enable():
-                o_proj_input = self.wo_a(o_proj_input)
-            else:
-                # wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
-                # o = torch.einsum("tgd,grd->tgr", o, wo_a)
-                o_proj_input = torch_npu.npu_transpose_batchmatmul(
-                    o_proj_input,
-                    self.wo_a.weight,
-                    bias=None,
-                    scale=None,
-                    perm_x1=(1, 0, 2),
-                    perm_x2=(0, 1, 2),
-                    perm_y=(1, 0, 2),
-                    batch_split_factor=1,
-                )
-                o_proj_input = o_proj_input.reshape(num_tokens, -1)
-            output[...] = self.wo_b(o_proj_input)
+        self._forward_o_proj(o_proj_input, output)
 
         return output_padded
 

--- a/vllm_ascend/ops/dsa.py
+++ b/vllm_ascend/ops/dsa.py
@@ -166,9 +166,9 @@ class AscendDeepseekSparseAttention(MultiHeadLatentAttentionWrapper):
 
         output = torch.empty(output_shape, dtype=hidden_states.dtype, device=hidden_states.device)
 
-        # All DSA forward paths run inside dsa_forward custom op boundary,
-        # which is required for ACL graph capture (registered with
-        # dispatch_key="PrivateUse1").
+        # All DSA forward paths (attention + o_proj, including OTP HCCL
+        # collectives) run inside the dsa_forward custom op, which is required
+        # for ACL graph capture (registered with dispatch_key="PrivateUse1").
         torch.ops.vllm.dsa_forward(hidden_states, need_gather_q_kv, output, self.prefix)
 
         output = output.view(-1, output_shape[-1])
@@ -189,7 +189,9 @@ def dsa_forward(
         attn_metadata = forward_context.attn_metadata
 
     if attn_metadata is None:
-        output.fill_(0)
+        # Profiling run: forward() handles OTP by running _forward_o_proj on a
+        # zero input so HCCL collectives are captured by the ACL graph.
+        self.dsa_attn.impl.forward(self.dsa_attn.layer_name, hidden_states, None, None, need_gather_q_kv, output)
         return
 
     kv_cache = _build_kv_cache(self, forward_context)

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -221,6 +221,39 @@ class MLPRowParallelOp(CustomRowParallelOp):
         return output, output_bias
 
 
+class DSV4OProjColumnParallelOp(CustomColumnParallelOp):
+    @property
+    def comm_group(self):
+        return get_otp_group()
+
+    def apply_impl(
+        self,
+        input_: torch.Tensor,
+    ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
+        bias = self.bias if not self.skip_bias_add else None
+        assert self.quant_method is not None
+        output_parallel = self.quant_method.apply(self.layer, input_, bias)
+        output_bias = self.bias if self.skip_bias_add else None
+        return output_parallel, output_bias
+
+
+class DSV4OProjRowParallelOp(CustomRowParallelOp):
+    @property
+    def comm_group(self):
+        return get_otp_group()
+
+    def apply_impl(
+        self,
+        input_: torch.Tensor,
+    ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
+        input_parallel = self.get_input_parallel(input_)
+        bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
+        assert self.quant_method is not None
+        output_parallel = self.quant_method.apply(self.layer, input_parallel, bias=bias_)
+        output_bias = self.bias if self.skip_bias_add else None
+        return output_parallel, output_bias
+
+
 class OProjRowParallelOp(CustomRowParallelOp):
     def __init__(self, layer):
         super().__init__(layer)
@@ -632,9 +665,18 @@ class ShardedCPColumnParallelOp(CustomColumnParallelOp):
 
 def _get_column_parallel_op(
     prefix, layer
-) -> MLPColumnParallelOp | SequenceColumnParallelOp | ShardedCPColumnParallelOp | Flashcomm2OshardQKVParallelOp | None:
+) -> (
+    MLPColumnParallelOp
+    | DSV4OProjColumnParallelOp
+    | SequenceColumnParallelOp
+    | ShardedCPColumnParallelOp
+    | Flashcomm2OshardQKVParallelOp
+    | None
+):
     if enable_dsa_cp() and ("q_b_proj" in prefix or "kv_b_proj" in prefix):
         return ShardedCPColumnParallelOp(layer)
+    if "wo_a" in prefix and oproj_tp_enable():
+        return DSV4OProjColumnParallelOp(layer)
     if "gate_up_proj" in prefix and mlp_tp_enable() and not is_moe_layer(prefix):
         return MLPColumnParallelOp(layer)
     if flashcomm2_oshard_manager.flashcomm2_oshard_enable():
@@ -662,12 +704,15 @@ def _get_row_parallel_op(
 ) -> (
     MLPRowParallelOp
     | OProjRowParallelOp
+    | DSV4OProjRowParallelOp
     | Flashcomm2OProjRowParallelOp
     | MatmulAllreduceRowParallelOp
     | SequenceRowParallelOp
     | ShardedCPRowParallelOp
     | None
 ):
+    if "wo_b" in prefix and oproj_tp_enable():
+        return DSV4OProjRowParallelOp(layer)
     if enable_dsa_cp_with_layer_shard() and "o_proj" in prefix:
         return ShardedCPRowParallelOp(layer)
     if "down_proj" in prefix and mlp_tp_enable() and not is_moe_layer(prefix):
@@ -705,9 +750,11 @@ def get_parallel_op(disable_tp, prefix, layer, direct):
         return None, 0, 1
     custom_op: (
         MLPColumnParallelOp
+        | DSV4OProjColumnParallelOp
         | SequenceColumnParallelOp
         | MLPRowParallelOp
         | OProjRowParallelOp
+        | DSV4OProjRowParallelOp
         | Flashcomm2OProjRowParallelOp
         | Flashcomm2OshardQKVParallelOp
         | MatmulAllreduceRowParallelOp

--- a/vllm_ascend/ops/vocab_parallel_embedding.py
+++ b/vllm_ascend/ops/vocab_parallel_embedding.py
@@ -17,6 +17,7 @@
 
 
 import torch
+import torch.distributed as dist
 from torch import nn
 from torch.nn.parameter import Parameter
 from vllm.distributed import divide
@@ -38,7 +39,7 @@ from vllm.model_executor.utils import set_weight_attrs
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.distributed.parallel_state import get_embed_tp_group, get_lmhead_tp_group
-from vllm_ascend.utils import embedding_tp_enable, lmhead_tp_enable
+from vllm_ascend.utils import embedding_tp_enable, get_potential_max_tokens, lmhead_tp_enable
 
 
 class AscendVocabParallelEmbedding(VocabParallelEmbedding):
@@ -167,7 +168,45 @@ class AscendVocabParallelEmbedding(VocabParallelEmbedding):
             return self._forward_origin(input_)
 
     def _forward_embed_tp(self, input_):
-        complete_input = self.comm_group.all_gather(input_, dim=0)
+        num_tokens = input_.shape[0]
+
+        # potential_max_tokens is computed once in the model runner __init__, so
+        # reading it here is a cheap global lookup. Validate before allocating so
+        # an oversized batch fails fast.
+        capacity = get_potential_max_tokens()
+        if num_tokens > capacity:
+            raise ValueError(
+                f"embedding_tp static capacity {capacity} < num_tokens "
+                f"{num_tokens}; increase max_cudagraph_capture_size or "
+                f"max_num_batched_tokens."
+            )
+
+        # Lazy init on first call (profiling run, which precedes ACL graph
+        # capture). Static buffers keep a stable device address across all
+        # later capture/replay cycles — graph replay requires the same
+        # address that was recorded at capture (comm_group.all_gather and
+        # reduce_scatter internally torch.empty() per call, which would
+        # desync the HCCL operator recorded at capture).
+        # Mirrors the OTP v13 fix in dsa_v1.py:_forward_o_proj.
+        if not hasattr(self, "_embed_ag_in_buf"):
+            device = input_.device
+            # all_gather buffers carry token IDs (int64).
+            self._embed_ag_in_buf = torch.zeros((capacity,), dtype=input_.dtype, device=device)
+            self._embed_ag_out_buf = torch.empty((self.tp_size * capacity,), dtype=input_.dtype, device=device)
+            # reduce_scatter buffers carry bf16 embeddings.
+            self._embed_rs_in_buf = torch.empty(
+                (self.tp_size * capacity, self.embedding_dim), dtype=self.params_dtype, device=device
+            )
+            self._embed_rs_out_buf = torch.empty((capacity, self.embedding_dim), dtype=self.params_dtype, device=device)
+
+        # Pad input into the address-stable all_gather input buffer.
+        self._embed_ag_in_buf.zero_()
+        self._embed_ag_in_buf[:num_tokens].copy_(input_)
+        dist.all_gather_into_tensor(self._embed_ag_out_buf, self._embed_ag_in_buf, group=self.comm_group.device_group)
+        complete_input = self._embed_ag_out_buf
+
+        # Masking unchanged; padding rows map to OOB and get masked to 0
+        # via masked_fill_ below (token_id=0 stays in-range after shift).
         masked_input, input_mask = self._get_masked_input_and_mask(
             complete_input,
             self.shard_indices.org_vocab_start_index,
@@ -176,12 +215,16 @@ class AscendVocabParallelEmbedding(VocabParallelEmbedding):
             self.shard_indices.added_vocab_start_index,
             self.shard_indices.added_vocab_end_index,
         )
-        # Get the embeddings.
+        # Embedding lookup is a local op (F.embedding); its fresh allocation
+        # does not affect ACL graph replay. Copy into the static rs_in
+        # buffer so reduce_scatter reads from a stable address.
         output_parallel = self.quant_method.embedding(self, masked_input.long())
-        output_parallel.masked_fill_(input_mask.unsqueeze(-1), 0)
-        output = self.comm_group.reduce_scatter(output_parallel, dim=0)
-        output = output.view(input_.shape[0], -1)
-        return output
+        self._embed_rs_in_buf.copy_(output_parallel)
+        self._embed_rs_in_buf.masked_fill_(input_mask.unsqueeze(-1), 0)
+        dist.reduce_scatter_tensor(self._embed_rs_out_buf, self._embed_rs_in_buf, group=self.comm_group.device_group)
+
+        # Strip padding rows; preserve the original return shape.
+        return self._embed_rs_out_buf[:num_tokens].view(num_tokens, -1)
 
     def _forward_origin(self, input_):
         if self.tp_size > 1:

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1114,6 +1114,66 @@ def is_pd_decode_recompute_scheduler_enabled(vllm_config: VllmConfig | None = No
         return False
 
 
+def _compute_potential_max_tokens(vllm_config) -> int:
+    """Maximal decode token count, pure arithmetic over config.
+
+    The formula lives in exactly one place; it is evaluated once via
+    set_potential_max_tokens (model runner __init__) and then reused everywhere
+    via get_potential_max_tokens. Cheap (no select_moe_comm_method).
+    """
+    compilation_config = vllm_config.compilation_config
+    scheduler_config = vllm_config.scheduler_config
+    speculative_config = vllm_config.speculative_config
+    uniform_decode_query_len = 1 if not speculative_config else 1 + speculative_config.num_speculative_tokens
+    decode_max_num_seqs = getattr(scheduler_config, "decode_max_num_seqs", 0)
+    max_num_reqs = max(scheduler_config.max_num_seqs, decode_max_num_seqs)
+
+    # Use max cudagraph capture size if available, otherwise the maximal uniform
+    # decode token count.
+    if compilation_config.cudagraph_capture_sizes:
+        potential_max_tokens = max(
+            compilation_config.max_cudagraph_capture_size,
+            min(
+                scheduler_config.max_num_batched_tokens,
+                scheduler_config.max_num_seqs * uniform_decode_query_len,
+            ),
+        )
+        if potential_max_tokens != compilation_config.max_cudagraph_capture_size:
+            logger.warning_once(
+                "The max_cudagraph_capture_size (%d) is smaller than the potential max tokens required for "
+                "decode (%d). This may lead to suboptimal performance. Consider adjusting"
+                "max_cudagraph_capture_size or scheduler_config (max_num_batched_tokens or max_num_seqs)"
+                "to ensure max_cudagraph_capture_size can accommodate the decode workload. For more details, "
+                "see the issue #8240(https://github.com/vllm-project/vllm-ascend/issues/8240).",
+                compilation_config.max_cudagraph_capture_size,
+                potential_max_tokens,
+            )
+    else:
+        potential_max_tokens = min(max_num_reqs * uniform_decode_query_len, 512)
+    return potential_max_tokens
+
+
+# potential_max_tokens is computed once in the model runner __init__ and reused by
+# both the skip-allreduce decision and the o_proj static-exchange buffer sizing, so
+# neither path recomputes it. Mirrors the _mc2_tokens_capacity set/get pattern in
+# ascend_forward_context.py.
+_potential_max_tokens: int | None = None
+
+
+def set_potential_max_tokens(vllm_config) -> None:
+    """Compute and cache potential_max_tokens once (called from model runner __init__)."""
+    global _potential_max_tokens
+    if _potential_max_tokens is not None:
+        return
+    _potential_max_tokens = _compute_potential_max_tokens(vllm_config)
+
+
+def get_potential_max_tokens() -> int:
+    # Set once in NPUModelRunner.__init__ before any caller reads it.
+    assert _potential_max_tokens is not None
+    return _potential_max_tokens
+
+
 def should_skip_allreduce_across_dp_group(vllm_config, is_draft_model: bool = False) -> bool:
     """Decide whether to skip the all-reduce across the DP group.
 
@@ -1127,6 +1187,10 @@ def should_skip_allreduce_across_dp_group(vllm_config, is_draft_model: bool = Fa
 
     Returns False when hierarchy comm is enabled because hierarchy requires
     global_bs=0 (uniform tokens), which is incompatible with skipping allreduce.
+
+    Recomputed per call (no memoization): potential_max_tokens is a set/get global
+    computed once in init, and select_moe_comm_method is just config lookups, so
+    this is cheap and avoids id-reuse / stale-cache / init-ordering hazards.
     """
     if is_hierarchical_communication_enabled():
         return False
@@ -1148,37 +1212,9 @@ def should_skip_allreduce_across_dp_group(vllm_config, is_draft_model: bool = Fa
     def needs_mc2(n: int) -> bool:
         return select_moe_comm_method(n, vllm_config) in {MoECommType.MC2, MoECommType.FUSED_MC2}
 
-    compilation_config = vllm_config.compilation_config
     scheduler_config = vllm_config.scheduler_config
-    speculative_config = vllm_config.speculative_config
-    uniform_decode_query_len = 1 if not speculative_config else 1 + speculative_config.num_speculative_tokens
-    decode_max_num_seqs = getattr(scheduler_config, "decode_max_num_seqs", 0)
-    max_num_reqs = max(scheduler_config.max_num_seqs, decode_max_num_seqs)
-
-    # Determine whether decode must use MC2. Use max cudagraph capture size
-    # if available, otherwise use the maximal uniform decode token count.
-    if compilation_config.cudagraph_capture_sizes:
-        potential_max_tokens = max(
-            compilation_config.max_cudagraph_capture_size,
-            min(
-                vllm_config.scheduler_config.max_num_batched_tokens,
-                vllm_config.scheduler_config.max_num_seqs * uniform_decode_query_len,
-            ),
-        )
-        if potential_max_tokens != compilation_config.max_cudagraph_capture_size:
-            logger.warning_once(
-                "The max_cudagraph_capture_size (%d) is smaller than the potential max tokens required for "
-                "decode (%d). This may lead to suboptimal performance. Consider adjusting"
-                "max_cudagraph_capture_size or scheduler_config (max_num_batched_tokens or max_num_seqs)"
-                "to ensure max_cudagraph_capture_size can accommodate the decode workload. For more details, "
-                "see the issue #8240(https://github.com/vllm-project/vllm-ascend/issues/8240).",
-                compilation_config.max_cudagraph_capture_size,
-                potential_max_tokens,
-            )
-    else:
-        potential_max_tokens = min(max_num_reqs * uniform_decode_query_len, 512)
-
-    decode_must_use_mc2 = needs_mc2(potential_max_tokens)
+    # potential_max_tokens is read from the set/get global (computed once in init).
+    decode_must_use_mc2 = needs_mc2(get_potential_max_tokens())
     # For prefill, use the scheduler's max_num_batched_tokens for a single batch.
     prefill_must_use_mc2 = needs_mc2(scheduler_config.max_num_batched_tokens)
     # Skip all-reduce if decode requires MC2 and either prefill also

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -146,6 +146,7 @@ from vllm_ascend.utils import (
     AscendDeviceType,
     calc_split_factor,
     check_gdn_layer,
+    embedding_tp_enable,
     enable_sp,
     enable_sp_by_pass,
     get_ascend_device_type,
@@ -155,6 +156,8 @@ from vllm_ascend.utils import (
     is_hidden_state_cache_spec,
     kv_cache_spec_uses_sparse_c8,
     lmhead_tp_enable,
+    oproj_tp_enable,
+    set_potential_max_tokens,
     set_weight_prefetch_method,
     should_skip_allreduce_across_dp_group,
 )
@@ -321,6 +324,7 @@ class NPUModelRunner(GPUModelRunner):
         # Ascend-specific configurations
         self.ascend_config = get_ascend_config()
         set_weight_prefetch_method(self.ascend_config.weight_prefetch_config)
+
         # Dump / PrecisionDebugger configuration now comes from AscendConfig
         dump_cfg = self.ascend_config.dump_config_path
         self.debugger = None
@@ -484,6 +488,9 @@ class NPUModelRunner(GPUModelRunner):
         set_cos_and_sin(vllm_config, self.max_num_reqs, self.uniform_decode_query_len, self.dtype, self.device)
         set_mc2_tokens_capacity(vllm_config, self.max_num_reqs, self.uniform_decode_query_len)
         set_mc2_mask(vllm_config, self.device)
+        # Compute potential_max_tokens once here; it is reused by the skip-allreduce
+        # decision and the o_proj static-exchange buffer sizing (see get_potential_max_tokens).
+        set_potential_max_tokens(vllm_config)
         self.decode_threshold = 1 + (self.speculative_config.num_speculative_tokens if self.speculative_config else 0)
 
         self.use_aclgraph = self._use_aclgraph()
@@ -2983,7 +2990,10 @@ class NPUModelRunner(GPUModelRunner):
             _, num_tokens_across_dp, synced_cudagraph_mode = self._sync_metadata_across_dp(
                 num_tokens=num_tokens_padded,
                 cudagraph_mode=cudagraph_mode,
-                allow_dp_padding=(cudagraph_mode != CUDAGraphMode.NONE) or enable_sp(self.vllm_config),
+                allow_dp_padding=((cudagraph_mode != CUDAGraphMode.NONE)
+                                  or enable_sp(self.vllm_config)
+                                  or oproj_tp_enable()
+                                  or embedding_tp_enable()),
             )
 
             # Extract DP padding if there is any


### PR DESCRIPTION
Enable fine-grained tensor parallelism on the o_proj (wo_a/wo_b) weights of DeepSeek-V4's DSA (DeepSeek Attention) module via static-buffer all_to_all/reduce_scatter across the OTP group, and rewrite the embedding TP path to use graph-stable static raw-dist buffers so both run correctly under ACL graph capture/replay.

#### Key changes

- Fine-grained Tensor Parallelism for O-Proj: Implemented fine-grained TP for DSA o_proj (wo_a/wo_b) via the OTP group using graph-stable static send/recv buffers padded to the max capture size, with dist.all_to_all_single + raw dist.reduce_scatter_tensor into an address-stable output buffer for efficient, ACL-graph-safe distribution.
- Fine-grained Tensor Parallelism for Embedding: Rewrote input-embedding TP to use static all_gather_into_tensor / reduce_scatter_tensor buffers (allocated once to the max capture capacity), improving performance and fixing the accuracy regression caused by the previous list-based wrappers.
- Recompute-Scheduler Binding for DP Tokens: Bound oproj/embedding TP to recompute_scheduler_enable and forced allow_dp_padding under oproj TP, so cross-DP num_tokens stays uniform and the collectives don't deadlock — enforced as a config-time assertion rather than a runtime hang.

### What this PR does / why we need it?

Enables oproj_tensor_parallel_size support in the DSA attention backend and makes the embedding_tensor_parallel_size path correct and faster under ACL graph mode — using graph-stable static exchange buffers rather than per-call dynamic allocation. o_proj (wo_a/wo_b) is sharded across the OTP group via raw dist.all_to_all_single + dist.reduce_scatter_tensor into static buffers, with new DSV4OProjColumnParallelOp / DSV4OProjRowParallelOp routing wo through the OTP group; embedding TP is rewritten with static all_gather_into_tensor / reduce_scatter_tensor buffers. Because both paths' cross-DP collectives require uniform num_tokens across DP ranks, the features are bound to recompute_scheduler_enable and enforced at config load instead of deadlocking at runtime.

### Does this PR introduce any user-facing change?

Yes. It enables tensor-parallel support for the o_proj operator in the DSA backend (currently constrained to tensor_parallel_size == 1) and makes embedding TP correct and faster under ACL graph mode. Both oproj_tensor_parallel_size and embedding_tensor_parallel_size now require recompute_scheduler_enable = true; enabling either without recompute raises a clear config-time error instead of a runtime collective deadlock.

### How was this patch tested?

CI passed with existing tests.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
