### PR TITLE
[Feature] WeightTransfer: Add NPUIPCWeightTransferEngine backend for Ascend NPU

### DIFF
--- a/examples/rl/rlhf_http_hccl.py
+++ b/examples/rl/rlhf_http_hccl.py
@@ -13,7 +13,7 @@ assumes you have already started a vLLM server using `vllm serve`. It uses:
 Prerequisites:
     Start a vLLM server with weight transfer enabled:
 
-    $ VLLM_SERVER_DEV_MODE=1 vllm serve qwen/qwen3-0.6b \
+    $ VLLM_SERVER_DEV_MODE=1 vllm serve Qwen/Qwen3-0.6b \
         --enforce-eager \
         --weight-transfer-config '{"backend": "nccl"}' \
         --load-format dummy
@@ -45,7 +45,7 @@ from vllm_ascend.distributed.weight_transfer.hccl_engine import (
 )
 
 BASE_URL = "http://localhost:8000"
-MODEL_NAME = "qwen/qwen3-0.6b"
+MODEL_NAME = "Qwen/Qwen3-0.6B"
 
 
 def generate_completions(client: OpenAI, model: str, prompts: list[str]) -> list[str]:

--- a/examples/rl/rlhf_http_npu_ipc.py
+++ b/examples/rl/rlhf_http_npu_ipc.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Demonstrates reinforcement learning from human feedback (RLHF) using vLLM
+via HTTP API, with NPU IPC-based weight syncing APIs.
+
+Unlike rlhf_http_hccl.py which uses HCCL and can use separate NPUs, this script
+uses Ascend NPU IPC which requires the training model and vLLM server to be on
+the same physical NPU. Memory must be carefully managed to fit both models.
+
+Prerequisites:
+    Start a vLLM server with weight transfer enabled and reduced NPU memory
+    utilization to leave room for the training model:
+
+    $ VLLM_SERVER_DEV_MODE=1 VLLM_ALLOW_INSECURE_SERIALIZATION=1 \
+        vllm serve Qwen/Qwen3-0.6b --enforce-eager \
+        --weight-transfer-config '{"backend": "ipc"}' \
+        --load-format dummy \
+        --gpu-memory-utilization 0.5
+
+    Then run this script:
+
+    $ python rlhf_http_npu_ipc.py
+
+The example performs the following steps:
+
+* Load the training model on NPU 0 (same NPU as the vLLM server).
+* Generate text using the vLLM server via OpenAI-compatible API. The output
+  is expected to be nonsense because the server is initialized with dummy weights.
+* Initialize weight transfer via HTTP endpoint (no-op for NPU IPC).
+* Pause generation and broadcast the real weights from the training model to
+  the vLLM server using NPU IPC handles (via HTTP). The pause/resume is
+  handled by ``trainer_send_weights`` — it calls ``update_weights`` internally.
+* Generate text again to show normal output after the weight update.
+"""
+
+import os
+
+import requests
+import torch
+from openai import OpenAI
+from transformers import AutoModelForCausalLM
+
+from vllm_ascend.distributed.weight_transfer.npu_ipc_engine import (
+    NPUIPCTrainerSendWeightsArgs,
+    NPUIPCWeightTransferEngine,
+)
+
+BASE_URL = "http://localhost:8000"
+MODEL_NAME = "Qwen/Qwen3-0.6B"
+
+# Enable insecure serialization for IPC handle serialization over HTTP
+os.environ["VLLM_ALLOW_INSECURE_SERIALIZATION"] = "1"
+
+
+def generate_completions(client: OpenAI, model: str, prompts: list[str]) -> list[str]:
+    """Generate completions using the OpenAI-compatible API."""
+    results = []
+    for prompt in prompts:
+        response = client.completions.create(
+            model=model,
+            prompt=prompt,
+            max_tokens=32,
+            temperature=0,
+        )
+        results.append(response.choices[0].text)
+    return results
+
+
+def init_weight_transfer_engine(base_url: str) -> None:
+    """Initialize weight transfer via HTTP endpoint (no-op for NPU IPC)."""
+    url = f"{base_url}/init_weight_transfer_engine"
+    payload: dict[str, dict] = {"init_info": {}}
+    response = requests.post(url, json=payload, timeout=60)
+    response.raise_for_status()
+
+
+def start_weight_update(base_url: str, is_checkpoint_format: bool = True) -> None:
+    """Start weight update via HTTP endpoint.
+
+    Prepares the model for layerwise reload on the vLLM server side.
+    Must be called before update_weights.
+    """
+    url = f"{base_url}/start_weight_update"
+    payload = {"is_checkpoint_format": is_checkpoint_format}
+    response = requests.post(url, json=payload, timeout=60)
+    response.raise_for_status()
+
+
+def finish_weight_update(base_url: str) -> None:
+    """Finish weight update via HTTP endpoint.
+
+    Finalizes layerwise reload on the vLLM server side.
+    Must be called after all update_weights calls are complete.
+    """
+    url = f"{base_url}/finish_weight_update"
+    response = requests.post(url, timeout=60)
+    response.raise_for_status()
+
+
+def pause_generation(base_url: str) -> None:
+    """Pause generation via HTTP endpoint."""
+    url = f"{base_url}/pause"
+    response = requests.post(url, timeout=60)
+    response.raise_for_status()
+
+
+def resume_generation(base_url: str) -> None:
+    """Resume generation via HTTP endpoint."""
+    url = f"{base_url}/resume"
+    response = requests.post(url, timeout=60)
+    response.raise_for_status()
+
+
+def main():
+    # NPU IPC requires the training model to be on the same NPU as the vLLM server.
+    # The server should be started on NPU 0 with reduced memory utilization.
+    device = "npu:0"
+    torch.accelerator.set_device_index(device)
+
+    # Load the training model on the same NPU as the server.
+    # Use bfloat16 to reduce memory footprint.
+    print(f"Loading training model: {MODEL_NAME} on {device}")
+    print(
+        "Note: Ensure the vLLM server was started with --gpu-memory-utilization 0.5 "
+        "or lower to leave room for the training model."
+    )
+    train_model = AutoModelForCausalLM.from_pretrained(MODEL_NAME, dtype=torch.bfloat16)
+    train_model.to(device)
+    train_model.eval()
+
+    # Create OpenAI client pointing to the vLLM server
+    client = OpenAI(
+        base_url=f"{BASE_URL}/v1",
+        api_key="EMPTY",
+    )
+
+    # Test prompts
+    prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+
+    # Generate text before weight update. The output is expected to be nonsense
+    # because the server is initialized with dummy weights.
+    print("-" * 50)
+    print("Generating text BEFORE weight update (expect nonsense):")
+    print("-" * 50)
+    outputs = generate_completions(client, MODEL_NAME, prompts)
+    for prompt, generated_text in zip(prompts, outputs):
+        print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
+        print("-" * 50)
+
+    # Initialize weight transfer on vLLM server (no-op for NPU IPC)
+    print("Initializing weight transfer (NPU IPC backend)...")
+    init_weight_transfer_engine(BASE_URL)
+
+    # Pause generation before weight sync
+    pause_generation(BASE_URL)
+
+    # Start weight update (prepares layerwise reload on the vLLM server)
+    start_weight_update(BASE_URL)
+
+    # Send weights via NPU IPC handles using HTTP mode.
+    # trainer_send_weights internally collects all parameters,
+    # creates IPC handles, and POSTs them to /update_weights.
+    print("Broadcasting weights via NPU IPC (HTTP)...")
+    trainer_args = NPUIPCTrainerSendWeightsArgs(send_mode="http", url=BASE_URL)
+    NPUIPCWeightTransferEngine.trainer_send_weights(
+        iterator=train_model.named_parameters(),
+        trainer_args=trainer_args,
+    )
+
+    # Finish weight update (finalizes layerwise reload on the vLLM server)
+    finish_weight_update(BASE_URL)
+
+    # Resume generation after weight sync
+    resume_generation(BASE_URL)
+
+    # Generate text after weight update. The output is expected to be normal
+    # because the real weights are now loaded.
+    print("-" * 50)
+    print("Generating text AFTER weight update:")
+    print("-" * 50)
+    outputs_updated = generate_completions(client, MODEL_NAME, prompts)
+    for prompt, generated_text in zip(prompts, outputs_updated):
+        print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
+        print("-" * 50)
+
+    # Note: The training model and IPC handles remain in memory.
+    # In a real RLHF training loop, you would update the training model
+    # and create new IPC handles for each weight update.
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check_forbidden_imports.py
+++ b/tools/check_forbidden_imports.py
@@ -41,6 +41,8 @@ CHECK_IMPORTS = {
         tip=("Avoid using pickle or cloudpickle or add this file to tools/check_forbidden_imports.py."),
         allowed_files={
             "vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/metadata.py",
+            "vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py",
+            "tests/ut/distributed/test_hccl_weight_transfer.py",
         },
     ),
     "re": ForbiddenImport(

--- a/vllm_ascend/distributed/weight_transfer/__init__.py
+++ b/vllm_ascend/distributed/weight_transfer/__init__.py
@@ -19,9 +19,14 @@ from vllm.distributed.weight_transfer.factory import WeightTransferEngineFactory
 
 
 def register_engine():
-    """Register HCCL weight transfer engine as a vLLM plugin."""
+    """Register Ascend weight transfer engines as vLLM plugins."""
     WeightTransferEngineFactory.register_engine(
         "hccl",
         "vllm_ascend.distributed.weight_transfer.hccl_engine",
         "HCCLWeightTransferEngine",
+    )
+    WeightTransferEngineFactory.register_engine(
+        "npu_ipc",
+        "vllm_ascend.distributed.weight_transfer.npu_ipc_engine",
+        "NPUIPCWeightTransferEngine",
     )

--- a/vllm_ascend/distributed/weight_transfer/hccl_engine.py
+++ b/vllm_ascend/distributed/weight_transfer/hccl_engine.py
@@ -73,8 +73,11 @@ class HCCLWeightTransferUpdateInfo(WeightTransferUpdateInfo):
     """Update info for HCCL weight transfer backend."""
 
     names: list[str]
+    """Names of the parameters to transfer (e.g. ``model.layers.0.weight``)."""
     dtype_names: list[str]
+    """Torch dtype names (e.g. ``bfloat16``, ``float32``) for each parameter."""
     shapes: list[list[int]]
+    """Shapes of each parameter as integer lists."""
     packed: bool = False
     """Whether to use packed tensor broadcasting for efficiency.
     When True, multiple tensors are batched together before broadcasting

--- a/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
+++ b/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
@@ -1,0 +1,393 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""NPU IPC-based weight transfer engine using Ascend IPC for communication."""
+
+import os
+import pickle
+import socket
+from collections.abc import Callable, Iterator
+from dataclasses import asdict, dataclass
+from functools import lru_cache
+from typing import Any
+
+import pybase64 as base64
+import requests
+import torch
+from torch.multiprocessing.reductions import reduce_tensor
+from vllm import envs
+from vllm.config.parallel import ParallelConfig
+from vllm.config.weight_transfer import WeightTransferConfig
+from vllm.distributed.weight_transfer.base import (
+    WeightTransferEngine,
+    WeightTransferInitInfo,
+)
+from vllm.distributed.weight_transfer.ipc_engine import (
+    IPCTrainerSendWeightsArgs,
+    IPCWeightTransferUpdateInfo,
+)
+
+from vllm_ascend.distributed.weight_transfer.packed_tensor import (
+    packed_npu_ipc_consumer,
+    packed_npu_ipc_producer,
+)
+
+
+@dataclass
+class NPUIPCTrainerSendWeightsArgs(IPCTrainerSendWeightsArgs):
+    """NPU IPC variant — inherits all fields and validation from the CUDA IPC
+    base class.  Only the ``send_mode`` callable type is widened to accept the
+    NPU update-info type."""
+
+    send_mode: str | Callable[["NPUIPCWeightTransferUpdateInfo"], None]
+
+
+@dataclass
+class NPUIPCWeightTransferInitInfo(WeightTransferInitInfo):
+    """Initialization info for NPU IPC weight transfer backend.
+
+    No initialization needed for NPU IPC.
+    """
+
+    pass
+
+
+@dataclass
+class NPUIPCWeightTransferUpdateInfo(IPCWeightTransferUpdateInfo):
+    """NPU IPC variant — inherits all fields and validation from the CUDA IPC
+    base class.  No overrides needed; the field types and ``__post_init__`` are
+    identical."""
+
+
+@lru_cache(maxsize=1)
+def get_ip() -> str:
+    try:
+        # try to get ip from network interface
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            return s.getsockname()[0]
+    except Exception:  # noqa: BLE001
+        # fallback to get ip from hostname
+        return socket.gethostbyname(socket.gethostname())
+
+
+@lru_cache(maxsize=1)
+def npu_generate_uuid() -> str:
+    """Generate a unique identifier for the current process's physical NPU chip.
+
+    Returns ``{host_ip}-{physical_chip_id}`` where ``host_ip`` is the local
+    machine's IP address and ``physical_chip_id`` is derived from the current
+    logical device index mapped through ``ASCEND_RT_VISIBLE_DEVICES``.
+
+    On Ascend NPU, ``torch.accelerator.current_device_index()`` returns the
+    *logical* device index. When ``ASCEND_RT_VISIBLE_DEVICES`` is set, it
+    maps logical indices to physical chip IDs (e.g., ``ASCEND_RT_VISIBLE_DEVICES=2,3``
+    means logical device 0 → physical chip 2, logical device 1 → physical chip 3).
+    If the env var is not set, the logical index is used directly as the
+    physical chip ID (identity mapping).
+
+    The result is cached because it is constant for the lifetime of the
+    process. Both the trainer and inference worker processes co-located
+    on the same physical NPU chip will produce the same UUID, which is
+    required for NPU IPC handle matching.
+    """
+    logical_device = torch.accelerator.current_device_index()
+    visible_devices = os.environ.get("ASCEND_RT_VISIBLE_DEVICES", None)
+    if visible_devices:
+        physical_device = int(visible_devices.split(",")[logical_device].strip())
+    else:
+        physical_device = logical_device
+    return f"{get_ip()}-{physical_device}"
+
+
+class NPUIPCWeightTransferEngine(WeightTransferEngine[NPUIPCWeightTransferInitInfo, NPUIPCWeightTransferUpdateInfo]):
+    """
+    Weight transfer engine using NPU IPC for communication between
+    trainer and workers.
+
+    This implementation uses Ascend NPU IPC to transfer weights from the
+    trainer (rank 0) to all inference workers. IPC handles are used to
+    share memory between processes on the same node.
+
+    Requires ``torch_npu`` to be imported (which patches
+    ``torch.multiprocessing.reductions.reduce_tensor`` to support
+    NPU tensors via ``_share_npu_()`` / ``rebuild_npu_tensor``).
+    """
+
+    init_info_cls = NPUIPCWeightTransferInitInfo
+    update_info_cls = NPUIPCWeightTransferUpdateInfo
+
+    def __init__(self, config: WeightTransferConfig, parallel_config: ParallelConfig) -> None:
+        super().__init__(config, parallel_config)
+
+    def parse_update_info(self, update_dict: dict[str, Any]) -> NPUIPCWeightTransferUpdateInfo:
+        """Parse update dict, deserializing pickled IPC handles if present.
+
+        HTTP transport sends IPC handles as a base64-encoded pickle under the
+        key ``ipc_handles_pickled``. This method deserializes them back into
+        ``ipc_handles`` before constructing the typed dataclass, keeping
+        serialization concerns out of the dataclass itself.
+
+        Requires ``VLLM_ALLOW_INSECURE_SERIALIZATION=1`` because the
+        payload is deserialized via ``pickle.loads``.
+        """
+        if "ipc_handles_pickled" in update_dict:
+            if "ipc_handles" in update_dict:
+                raise ValueError("Cannot specify both `ipc_handles` and `ipc_handles_pickled`")
+
+            if not envs.VLLM_ALLOW_INSECURE_SERIALIZATION:
+                raise ValueError(
+                    "Refusing to deserialize `ipc_handles_pickled` without VLLM_ALLOW_INSECURE_SERIALIZATION=1"
+                )
+
+            pickled = update_dict.pop("ipc_handles_pickled")
+            update_dict["ipc_handles"] = pickle.loads(base64.b64decode(pickled))
+
+        return super().parse_update_info(update_dict)
+
+    def init_transfer_engine(self, init_info: NPUIPCWeightTransferInitInfo) -> None:
+        """No initialization needed for NPU IPC backend."""
+        pass
+
+    def receive_weights(
+        self,
+        update_info: NPUIPCWeightTransferUpdateInfo,
+        load_weights: Callable[[list[tuple[str, torch.Tensor]]], None],
+    ) -> None:
+        """Receive weights from the trainer via NPU IPC handles.
+
+        Args:
+            update_info: NPU IPC update info containing parameter names,
+                dtypes, shapes, and IPC handles.
+            load_weights: Callable that loads weights into the model.
+        """
+        device_index = torch.accelerator.current_device_index()
+        physical_npu_id = npu_generate_uuid()
+
+        if update_info.packed:
+            assert update_info.tensor_sizes is not None
+            assert isinstance(update_info.ipc_handles, dict)
+            weights = packed_npu_ipc_consumer(
+                ipc_handle=update_info.ipc_handles,
+                physical_npu_id=physical_npu_id,
+                names=update_info.names,
+                shapes=update_info.shapes,
+                dtype_names=update_info.dtype_names,
+                tensor_sizes=update_info.tensor_sizes,
+                device_index=device_index,
+            )
+            load_weights(weights)
+        else:
+            assert isinstance(update_info.ipc_handles, list)
+            weights = []
+            for name, ipc_handle in zip(
+                update_info.names,
+                update_info.ipc_handles,
+            ):
+                if physical_npu_id not in ipc_handle:
+                    raise ValueError(
+                        f"IPC handle not found for NPU UUID {physical_npu_id}. "
+                        f"Available UUIDs: {list(ipc_handle.keys())}. "
+                        f"This may indicate that the trainer and worker are "
+                        f"not co-located on the same physical NPU (node)."
+                    )
+
+                func, args = ipc_handle[physical_npu_id]
+                list_args = list(args)
+                # Index 6 is the device_index parameter in torch's
+                # IPC handle tuple (rebuild_npu_tensor). Update it
+                # to the current device since the logical index can
+                # differ between sender and receiver.
+                list_args[6] = device_index
+                weight = func(*list_args)
+                weights.append((name, weight))
+
+            load_weights(weights)
+
+    def shutdown(self) -> None:
+        pass
+
+    @staticmethod
+    def trainer_send_weights(
+        iterator: Iterator[tuple[str, torch.Tensor]],
+        trainer_args: dict[str, Any] | NPUIPCTrainerSendWeightsArgs,
+    ) -> None:
+        """Send weights from trainer to inference workers via NPU IPC.
+
+        Supports two transport modes ('ray' and 'http') and two transfer
+        strategies:
+        - Non-packed (default): all weights in a single API call.
+        - Packed (packed=True): chunked transfer with bounded NPU memory.
+
+        For multi-NPU training, all ranks must call this method in
+        parallel. IPC handles are all-gathered across ranks and merged
+        so that each vLLM worker can find its own NPU UUID. Only rank 0
+        sends the payload to vLLM.
+
+        .. note::
+            This method calls ``update_weights`` internally. The caller must
+            handle ``pause`` / ``start_weight_update`` / ``finish_weight_update``
+            / ``resume`` before and after this method.
+
+        Args:
+            iterator: Iterator of (name, tensor) pairs.
+            trainer_args: NPUIPCTrainerSendWeightsArgs or equivalent dict.
+        """
+        args = NPUIPCTrainerSendWeightsArgs(**trainer_args) if isinstance(trainer_args, dict) else trainer_args
+        npu_uuid = npu_generate_uuid()
+        if args.packed:
+            NPUIPCWeightTransferEngine._send_packed(iterator, args, npu_uuid)
+        else:
+            NPUIPCWeightTransferEngine._send_unpacked(iterator, args, npu_uuid)
+
+    @staticmethod
+    def _is_rank_zero() -> bool:
+        """Return True if this is rank 0 or no distributed group exists."""
+        if not torch.distributed.is_initialized():
+            return True
+        return torch.distributed.get_rank() == 0
+
+    @staticmethod
+    def _all_gather_and_merge_handles(
+        handles: list[dict[str, tuple]],
+    ) -> list[dict[str, tuple]]:
+        """All-gather and merge IPC handle dicts across ranks.
+
+        Each rank contributes a list of ``{npu_uuid: ipc_args}`` dicts.
+        Rank 0 collects and merges per-index; other ranks receive a list
+        of empty dicts. No-op when no distributed group exists.
+        """
+        if not torch.distributed.is_initialized() or torch.distributed.get_world_size() == 1:
+            return handles
+
+        world_size = torch.distributed.get_world_size()
+        gathered: list[list[dict[str, tuple]] | None] = [None] * world_size
+        torch.distributed.all_gather_object(gathered, handles)
+        torch.distributed.barrier()
+        torch.npu.synchronize()
+
+        if torch.distributed.get_rank() == 0:
+            merged: list[dict[str, tuple]] = []
+            for param_idx in range(len(handles)):
+                m: dict[str, tuple] = {}
+                for rank_handles in gathered:
+                    if rank_handles is not None:
+                        m.update(rank_handles[param_idx])
+                merged.append(m)
+            return merged
+        return [{} for _ in handles]
+
+    @staticmethod
+    def _post_send_sync() -> None:
+        """Barrier + synchronize after a send; no-op if single-NPU."""
+        if torch.distributed.is_initialized() and torch.distributed.get_world_size() > 1:
+            torch.distributed.barrier()
+        torch.npu.synchronize()
+
+    @staticmethod
+    def _send_unpacked(
+        iterator: Iterator[tuple[str, torch.Tensor]],
+        args: NPUIPCTrainerSendWeightsArgs,
+        npu_uuid: str,
+    ) -> None:
+        """Send all weights in a single API call (non-packed mode)."""
+        names: list[str] = []
+        dtype_names: list[str] = []
+        shapes: list[list[int]] = []
+        ipc_handles: list[dict[str, tuple]] = []
+        # Hold strong refs to every contiguous copy until the send + post-send
+        # sync completes.  ``reduce_tensor``'s returned args do NOT keep
+        # storage alive.
+        weight_refs: list[torch.Tensor] = []
+
+        for name, tensor in iterator:
+            names.append(name)
+            dtype_names.append(str(tensor.dtype).split(".")[-1])
+            shapes.append(list(tensor.shape))
+
+            weight = tensor.detach().contiguous()
+            weight_refs.append(weight)
+            _, ipc_args = reduce_tensor(weight)
+            ipc_handles.append({npu_uuid: ipc_args})
+
+        ipc_handles = NPUIPCWeightTransferEngine._all_gather_and_merge_handles(ipc_handles)
+
+        if NPUIPCWeightTransferEngine._is_rank_zero():
+            NPUIPCWeightTransferEngine._do_send(
+                args=args,
+                names=names,
+                dtype_names=dtype_names,
+                shapes=shapes,
+                ipc_handles=ipc_handles,
+            )
+
+        NPUIPCWeightTransferEngine._post_send_sync()
+
+    @staticmethod
+    def _send_packed(
+        iterator: Iterator[tuple[str, torch.Tensor]],
+        args: NPUIPCTrainerSendWeightsArgs,
+        npu_uuid: str,
+    ) -> None:
+        """Send weights in bounded-memory chunks (packed mode)."""
+        post_iter_func: Callable = lambda item: item[1]
+
+        for chunk in packed_npu_ipc_producer(
+            iterator=iterator,
+            npu_uuid=npu_uuid,
+            post_iter_func=post_iter_func,
+            buffer_size_bytes=args.packed_buffer_size_bytes,
+        ):
+            ipc_handle = NPUIPCWeightTransferEngine._all_gather_and_merge_handles([chunk["ipc_handle"]])[0]
+
+            if NPUIPCWeightTransferEngine._is_rank_zero():
+                NPUIPCWeightTransferEngine._do_send(
+                    args=args,
+                    names=chunk["names"],
+                    dtype_names=chunk["dtype_names"],
+                    shapes=chunk["shapes"],
+                    ipc_handles=ipc_handle,
+                    tensor_sizes=chunk["tensor_sizes"],
+                    packed=True,
+                )
+
+            NPUIPCWeightTransferEngine._post_send_sync()
+
+    @staticmethod
+    def _do_send(
+        args: NPUIPCTrainerSendWeightsArgs,
+        names: list[str],
+        dtype_names: list[str],
+        shapes: list[list[int]],
+        ipc_handles: list[dict[str, tuple]] | dict[str, tuple],
+        tensor_sizes: list[int] | None = None,
+        packed: bool = False,
+    ) -> None:
+        """Send a single update payload via the configured transport."""
+        update_fields: dict[str, Any] = {
+            "names": names,
+            "dtype_names": dtype_names,
+            "shapes": shapes,
+            "packed": packed,
+        }
+        if tensor_sizes is not None:
+            update_fields["tensor_sizes"] = tensor_sizes
+
+        update_fields["ipc_handles"] = ipc_handles
+        update_info = NPUIPCWeightTransferUpdateInfo(**update_fields)
+
+        if callable(args.send_mode):
+            args.send_mode(update_info)
+        elif args.send_mode == "ray":
+            import ray
+
+            handles = args.llm_handle if isinstance(args.llm_handle, list) else [args.llm_handle]
+            ray.get([h.update_weights.remote(dict(update_info=asdict(update_info))) for h in handles])
+        elif args.send_mode == "http":
+            pickled_handles = base64.b64encode(pickle.dumps(ipc_handles)).decode("utf-8")
+            http_fields = {k: v for k, v in update_fields.items() if k != "ipc_handles"}
+            http_fields["ipc_handles_pickled"] = pickled_handles
+
+            url = f"{args.url}/update_weights"
+            payload = {"update_info": http_fields}
+            response = requests.post(url, json=payload, timeout=300)
+            response.raise_for_status()

--- a/vllm_ascend/distributed/weight_transfer/packed_tensor.py
+++ b/vllm_ascend/distributed/weight_transfer/packed_tensor.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Iterator
 from typing import Any
 
 import torch
+from torch.multiprocessing.reductions import reduce_tensor
 
 # Default values for packed tensor configuration.
 # These are imported by HCCLWeightTransferUpdateInfo and trainer_send_weights.
@@ -192,3 +193,127 @@ def packed_broadcast_consumer(
     # Otherwise NPU tensor cleanup at exit may hang.
     for s in streams:
         s.synchronize()
+
+
+# ── NPU IPC packed transfer ────────────────────────────────────────────
+
+
+def packed_npu_ipc_producer(
+    iterator: Iterator[tuple[str, torch.Tensor]],
+    npu_uuid: str,
+    post_iter_func: Callable[[tuple[str, torch.Tensor]], torch.Tensor],
+    buffer_size_bytes: int = DEFAULT_PACKED_BUFFER_SIZE_BYTES,
+) -> Iterator[dict[str, Any]]:
+    """Pack tensors into a reusable NPU IPC buffer and yield chunks.
+
+    Allocates a single NPU buffer of ``buffer_size_bytes`` and registers
+    it for IPC once via ``reduce_tensor``.  Each chunk's packed data is
+    copied into this buffer before yielding, so only one IPC-shared
+    allocation exists for the lifetime of the transfer.
+
+    Args:
+        iterator: Iterator of (name, tensor) pairs.
+        npu_uuid: Physical NPU UUID string for this rank.
+        post_iter_func: Applied to each (name, tensor) before packing.
+        buffer_size_bytes: Exact capacity of the reusable IPC buffer.
+    """
+    ipc_buffer = torch.empty(buffer_size_bytes, dtype=torch.uint8, device="npu")
+    _, ipc_args = reduce_tensor(ipc_buffer)
+
+    names: list[str] = []
+    shapes: list[list[int]] = []
+    dtypes: list[torch.dtype] = []
+    tensor_sizes: list[int] = []
+    total_bytes = 0
+
+    for name, orig_tensor in iterator:
+        flat = post_iter_func((name, orig_tensor)).contiguous().view(torch.uint8).view(-1)
+
+        if flat.numel() > buffer_size_bytes:
+            raise ValueError(
+                f"Tensor '{name}' has size {flat.numel()} bytes, "
+                f"which exceeds buffer_size_bytes={buffer_size_bytes}. "
+                f"Increase buffer_size_bytes to at least {flat.numel()}."
+            )
+
+        if total_bytes and total_bytes + flat.numel() > buffer_size_bytes:
+            torch.npu.current_stream().synchronize()
+            yield {
+                "names": names,
+                "shapes": shapes,
+                "dtype_names": [str(d).split(".")[-1] for d in dtypes],
+                "tensor_sizes": tensor_sizes,
+                "ipc_handle": {npu_uuid: ipc_args},
+            }
+            names, shapes, dtypes, tensor_sizes = [], [], [], []
+            total_bytes = 0
+
+        ipc_buffer[total_bytes : total_bytes + flat.numel()].copy_(flat)
+        names.append(name)
+        shapes.append(list(orig_tensor.shape))
+        dtypes.append(orig_tensor.dtype)
+        tensor_sizes.append(flat.numel())
+        total_bytes += flat.numel()
+
+    if total_bytes:
+        torch.npu.current_stream().synchronize()
+        yield {
+            "names": names,
+            "shapes": shapes,
+            "dtype_names": [str(d).split(".")[-1] for d in dtypes],
+            "tensor_sizes": tensor_sizes,
+            "ipc_handle": {npu_uuid: ipc_args},
+        }
+
+
+def packed_npu_ipc_consumer(
+    ipc_handle: dict[str, tuple],
+    physical_npu_id: str,
+    names: list[str],
+    shapes: list[list[int]],
+    dtype_names: list[str],
+    tensor_sizes: list[int],
+    device_index: int,
+) -> list[tuple[str, torch.Tensor]]:
+    """Unpack a single packed IPC chunk into named tensors.
+
+    Reconstructs the packed buffer via the IPC handle, unpacks into
+    individual tensors, and clones each into independent storage before
+    returning.  The clone is required because the producer reuses one
+    IPC buffer across chunks.
+
+    Args:
+        ipc_handle: Mapping of NPU UUID to a (func, args) tuple from
+            ``reduce_tensor``.
+        physical_npu_id: Physical NPU UUID string for the current process.
+        names: Parameter names in the packed buffer.
+        shapes: Parameter shapes.
+        dtype_names: Parameter dtype name strings (e.g. "float16").
+        tensor_sizes: Size in bytes of each parameter in the packed buffer.
+        device_index: Local NPU device index.
+    """
+    if physical_npu_id not in ipc_handle:
+        raise ValueError(
+            f"IPC handle not found for NPU UUID {physical_npu_id}. Available UUIDs: {list(ipc_handle.keys())}"
+        )
+
+    func, args = ipc_handle[physical_npu_id]
+    list_args = list(args)
+    # Index 6 of the args from reduce_tensor is the device_index.
+    # Overwrite it with the receiver's device index.
+    list_args[6] = device_index
+    packed = func(*list_args)
+
+    content_size = sum(tensor_sizes)
+    packed = packed[:content_size]
+
+    dtypes = [getattr(torch, dn) for dn in dtype_names]
+    weights: list[tuple[str, torch.Tensor]] = []
+    offset = 0
+    for name, shape, dtype, size in zip(names, shapes, dtypes, tensor_sizes):
+        raw = packed[offset : offset + size]
+        tensor = raw.contiguous().view(dtype).view(*shape).clone()
+        weights.append((name, tensor))
+        offset += size
+
+    return weights

--- a/vllm_ascend/patch/platform/patch_weight_transfer_engine.py
+++ b/vllm_ascend/patch/platform/patch_weight_transfer_engine.py
@@ -15,15 +15,17 @@
 #
 # Patch target: vllm.distributed.weight_transfer.factory.WeightTransferEngineFactory
 #
-# Replace the "nccl" factory entry with HCCLWeightTransferEngine so that
-# --weight-transfer-config '{"backend": "nccl"}' loads the HCCL engine
-# instead of the (unavailable) NCCL engine on Ascend NPU.
+# Replace the "nccl" and "ipc" factory entries with Ascend equivalents so that
+# --weight-transfer-config '{"backend": "nccl"}' loads HCCLWeightTransferEngine
+# and '{"backend": "ipc"}' loads NPUIPCWeightTransferEngine instead of the
+# (unavailable) NCCL / CUDA IPC engines on Ascend NPU.
 #
 # Why this approach (factory swap) instead of patching Literal["nccl", "ipc"]:
 #   WeightTransferConfig.backend is a pydantic Literal["nccl", "ipc"].
-#   Adding "hccl" would require modifying pydantic core schemas — fragile
-#   across pydantic versions.  Swapping the factory entry means users pass
-#   the already-accepted "nccl" string, but the factory resolves it to HCCL.
+#   Adding "hccl" / "npu_ipc" would require modifying pydantic core schemas —
+#   fragile across pydantic versions. Swapping the factory entries means users
+#   pass the already-accepted "nccl" / "ipc" strings, but the factory resolves
+#   them to HCCL / NPU IPC.
 #
 # Timing — guaranteed to run before first factory usage:
 #
@@ -52,5 +54,9 @@ from vllm.distributed.weight_transfer.factory import WeightTransferEngineFactory
 from vllm_ascend.distributed.weight_transfer.hccl_engine import (
     HCCLWeightTransferEngine,
 )
+from vllm_ascend.distributed.weight_transfer.npu_ipc_engine import (
+    NPUIPCWeightTransferEngine,
+)
 
 WeightTransferEngineFactory._registry["nccl"] = lambda: HCCLWeightTransferEngine
+WeightTransferEngineFactory._registry["ipc"] = lambda: NPUIPCWeightTransferEngine

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -683,19 +683,12 @@ class NPUWorker(WorkerBase):
                 WeightTransferEngineFactory,
             )
 
-            if vllm_version_is("0.21.0"):
-                # v0.21.0: create_engine takes (config, parallel_config)
-                self.weight_transfer_engine = WeightTransferEngineFactory.create_engine(
-                    self.vllm_config.weight_transfer_config,
-                    self.vllm_config.parallel_config,
-                )
-            else:
-                # main: create_engine takes (config, parallel_config, model)
-                self.weight_transfer_engine = WeightTransferEngineFactory.create_engine(
-                    self.vllm_config.weight_transfer_config,
-                    self.vllm_config.parallel_config,
-                    self.model_runner.get_model(),
-                )
+            # main: create_engine takes (config, parallel_config, model)
+            self.weight_transfer_engine = WeightTransferEngineFactory.create_engine(
+                self.vllm_config.weight_transfer_config,
+                self.vllm_config.parallel_config,
+                self.model_runner.get_model(),
+            )
 
     def compile_or_warm_up_model(self) -> CompilationTimes:
         # Note: need to adapt for graph mode.


### PR DESCRIPTION
### What this PR does / why we need it?

See  #9152 
See #9406 

- Add NPU IPC weight transfer engine (`NPUIPCWeightTransferEngine`) for Ascend NPU, enabling zero-copy weight synchronization from trainer to inference workers via shared memory
- Map the "ipc" backend to `NPUIPCWeightTransferEngine` using the factory swap strategy, so users pass the already-accepted "ipc" string without needing upstream pydantic schema changes
- Add `rlhf_http_npu_ipc.py` example script demonstrating the full RLHF workflow with NPU IPC weight sync over HTTP

#### Key Changes

vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py (new)

- NPUIPCWeightTransferEngine: Full implementation of the WeightTransferEngine interface — init_transfer_engine (no-op), receive_weights (rebuilds NPU tensors from IPC handles), and trainer_send_weights (creates IPC handles and sends them via Ray RPC or HTTP POST)
- NPUIPCWeightTransferUpdateInfo: Supports two transport modes — ipc_handles (direct Ray) and ipc_handles_pickled (HTTP via base64+pickle), with `VLLM_ALLOW_INSECURE_SERIALIZATION `safety gate
- npu_generate_uuid: Resolves the logical device index to a physical chip ID using `ASCEND_RT_VISIBLE_DEVICES`, producing a **{host_ip}-{physical_chip_id}** UUID for IPC handle matching between trainer and worker processes
- receive_weights: Matches IPC handles by UUID, rebuilds tensors via torch's `rebuild_npu_tensor`, and loads them into the model

vllm_ascend/patch/platform/patch_weight_transfer_engine.py (modified)

- Extend factory swap: add "ipc" → `NPUIPCWeightTransferEngine` mapping alongside the existing "nccl" → `HCCLWeightTransferEngine` mapping

vllm_ascend/distributed/weight_transfer/__init__.py (modified)

- Register the npu_ipc engine with `WeightTransferEngineFactory`

#### How It Works

```shell
  Trainer (Python process)              vLLM Worker
        |                                     |
        |-- reduce_tensor(weight) --> IPC handle
        |-- POST /update_weights -------->    |
        |   {names, shapes,                  |
        |    ipc_handles_pickled}            |
        |                              unpickle → rebuild_npu_tensor(handle)
        |                                     |
        |                              load_weights(weights)
```

Unlike the HCCL backend, NPU IPC requires the training model and vLLM server to be **co-located** on the same physical NPU. The `ASCEND_RT_VISIBLE_DEVICES` mapping ensures both sides produce matching UUIDs for IPC handle lookup.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

`examples/rl/rlhf_http_npu_ipc.py`

End-to-end RLHF example: load training model → generate nonsense text → init weight transfer → pause generation → sync weights via NPU IPC → resume generation → verify coherent output

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
