### PR TITLE
[Bugfix] upgrade lm-eval==0.4.12 to fix ImportError on vLLM v0.22.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ openai
 pytest >= 6.0,<9.0.0
 pytest-asyncio
 pytest-mock
-lm-eval==0.4.11
+lm-eval==0.4.12
 types-jsonschema
 xgrammar
 zmq


### PR DESCRIPTION
### What this PR does / why we need it?

Bump `lm-eval` from `0.4.11` to `0.4.12` in `requirements-dev.txt`.

After the vLLM upgrade, the Nightly-A2 `single-node-accuracy-tests` job started failing on **all** models with the same error:

```
ImportError: cannot import name 'resolve_hf_chat_template'
from 'vllm.entrypoints.chat_utils' (/vllm-workspace/vllm/vllm/entrypoints/chat_utils.py)
  at lm_eval/models/vllm_causallms.py:41
```

Failing run: Nightly-A2 #14487 `single-node-accuracy-tests`, job 81749373441
(https://github.com/vllm-project/vllm-ascend/actions/runs/27642305676/job/81749373441)

**Root cause**

`resolve_hf_chat_template` is a vLLM upstream API. #10476 upgraded vLLM from `v0.21.0`
to `v0.22.1`, where this function was moved from `vllm.entrypoints.chat_utils` to
`vllm.renderers.hf`. The pinned `lm-eval==0.4.11` (released 2026-02-13) only imports it
from the old location, so the import breaks once vLLM is bumped to `v0.22.1`.

This was the only dependency missed when #10476 raised the vLLM release tag — the repo
itself never references `resolve_hf_chat_template`; it is imported by the `lm-eval`
dependency used by the accuracy tests.

**Upstream fix**

lm-evaluation-harness already adapted to this move in commit `d800e04dc`
(PR EleutherAI/lm-evaluation-harness#3595, "Update vLLM import of resolve_hf_chat_template",
2026-03-05), importing from the new location first and falling back to the old one:

```python
if parse_version(version("vllm")) >= parse_version("0.8.3"):
    try:
        # Moved since vllm-project/vllm#30200
        from vllm.renderers.hf import resolve_chat_template as resolve_hf_chat_template
    except ImportError:
        from vllm.entrypoints.chat_utils import resolve_hf_chat_template
```

This fix is included starting from `lm-eval==0.4.12` (released 2026-05-11), the latest
stable release. The fallback branch keeps backward compatibility with older vLLM.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- `requirements-dev.txt`: `lm-eval==0.4.11` -> `lm-eval==0.4.12`
- Re-run the Nightly-A2 `single-node-accuracy-tests` job (or run a single config locally):
  ```bash
  pytest -sv tests/e2e/models/test_lm_eval_correctness.py
  ```
  The `resolve_hf_chat_template` ImportError no longer occurs and the accuracy tests run
  against vLLM v0.22.1.


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
