### PR TITLE
[BugFix][Misc] Report prefiller cached tokens in PD proxy

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -161,9 +161,37 @@ class InstanceInfo:
     decoder_score: float
     decoder_host: str
     decoder_port: int
+    prefiller_cached_tokens: int | None = None
 
 
 TAINT_PRIORITY = 1e15
+
+
+def extract_cached_tokens(response_json: dict) -> int | None:
+    usage = response_json.get("usage") or {}
+    prompt_tokens_details = usage.get("prompt_tokens_details") or {}
+    cached_tokens = prompt_tokens_details.get("cached_tokens")
+    return cached_tokens if isinstance(cached_tokens, int) else None
+
+
+def update_cached_tokens_in_chunk(chunk_json: dict, cached_tokens: int | None) -> bool:
+    if cached_tokens is None:
+        return False
+    usage = chunk_json.get("usage")
+    if not isinstance(usage, dict):
+        return False
+    prompt_tokens_details = usage.get("prompt_tokens_details")
+    if not isinstance(prompt_tokens_details, dict):
+        prompt_tokens_details = {}
+        usage["prompt_tokens_details"] = prompt_tokens_details
+    prompt_tokens_details["cached_tokens"] = cached_tokens
+    return True
+
+
+def encode_response_chunk(chunk_json: dict, is_sse: bool) -> bytes:
+    chunk = json.dumps(chunk_json, ensure_ascii=False).encode("utf-8")
+    return b"data: " + chunk + b"\n\n" if is_sse else chunk
+
 
 global_args: argparse.Namespace | None = None
 shared_scheduler: "SharedProxyScheduler | None" = None
@@ -922,9 +950,11 @@ async def assign_instances(
         await _abort_prefill_selection(runtime, prefiller_key, prefiller_score, is_initial_request=is_initial_request)
         raise
 
-    kv_transfer_params = response.json().get("kv_transfer_params", {})
+    response_json = response.json()
+    kv_transfer_params = response_json.get("kv_transfer_params", {})
     if kv_transfer_params:
         req_data["kv_transfer_params"] = kv_transfer_params
+    prefiller_cached_tokens = extract_cached_tokens(response_json)
 
     try:
         decoder = await runtime.schedule("pick_decoder", decoder_score)
@@ -943,6 +973,7 @@ async def assign_instances(
         decoder_score=decoder_score,
         decoder_host=decoder["host"],
         decoder_port=decoder["port"],
+        prefiller_cached_tokens=prefiller_cached_tokens,
     )
 
 
@@ -987,6 +1018,7 @@ async def handle_completions_impl(api: str, request: Request):
             retry_count = 0
             retry = True
             completion_tokens = 0
+            final_prefiller_cached_tokens = instance_info.prefiller_cached_tokens
 
             async def release_prefill_kv_once() -> None:
                 nonlocal released_kv
@@ -1018,7 +1050,8 @@ async def handle_completions_impl(api: str, request: Request):
                             continue
                         if not chunk_str:
                             continue
-                        if chunk_str.startswith("data: "):
+                        is_sse = chunk_str.startswith("data: ")
+                        if is_sse:
                             chunk_str = chunk_str[len("data: ") :]
                         try:
                             chunk_json = json.loads(chunk_str)
@@ -1028,6 +1061,8 @@ async def handle_completions_impl(api: str, request: Request):
                             continue
                         choices = chunk_json.get("choices", [])
                         if not choices:
+                            if update_cached_tokens_in_chunk(chunk_json, final_prefiller_cached_tokens):
+                                chunk = encode_response_chunk(chunk_json, is_sse)
                             yield chunk
                             continue
 
@@ -1054,6 +1089,7 @@ async def handle_completions_impl(api: str, request: Request):
                             req_data["max_tokens"] = origin_max_tokens - completion_tokens + retry_count
                             tmp_request_length = len(json.dumps(req_data).encode("utf-8"))
                             instance_info = await reassign_instances(api, req_data, tmp_request_length, instance_info)
+                            final_prefiller_cached_tokens = instance_info.prefiller_cached_tokens
                             released_kv = False
                             break
                         if retry_count > 0 and not stream_flag:
@@ -1061,7 +1097,8 @@ async def handle_completions_impl(api: str, request: Request):
                                 choice["message"]["content"] = generated_token
                             else:
                                 choice["text"] = generated_token
-                            chunk = json.dumps(chunk_json).encode("utf-8")
+                        if update_cached_tokens_in_chunk(chunk_json, final_prefiller_cached_tokens):
+                            chunk = encode_response_chunk(chunk_json, is_sse)
                         yield chunk
             except asyncio.CancelledError:
                 logger.warning(

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -1092,12 +1092,16 @@ async def handle_completions_impl(api: str, request: Request):
                             final_prefiller_cached_tokens = instance_info.prefiller_cached_tokens
                             released_kv = False
                             break
+                        chunk_updated = False
                         if retry_count > 0 and not stream_flag:
                             if chat_flag:
                                 choice["message"]["content"] = generated_token
                             else:
                                 choice["text"] = generated_token
+                            chunk_updated = True
                         if update_cached_tokens_in_chunk(chunk_json, final_prefiller_cached_tokens):
+                            chunk_updated = True
+                        if chunk_updated:
                             chunk = encode_response_chunk(chunk_json, is_sse)
                         yield chunk
             except asyncio.CancelledError:

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -1018,7 +1018,7 @@ async def handle_completions_impl(api: str, request: Request):
             retry_count = 0
             retry = True
             completion_tokens = 0
-            final_prefiller_cached_tokens = instance_info.prefiller_cached_tokens
+            reported_prefiller_cached_tokens = instance_info.prefiller_cached_tokens
 
             async def release_prefill_kv_once() -> None:
                 nonlocal released_kv
@@ -1061,7 +1061,7 @@ async def handle_completions_impl(api: str, request: Request):
                             continue
                         choices = chunk_json.get("choices", [])
                         if not choices:
-                            if update_cached_tokens_in_chunk(chunk_json, final_prefiller_cached_tokens):
+                            if update_cached_tokens_in_chunk(chunk_json, reported_prefiller_cached_tokens):
                                 chunk = encode_response_chunk(chunk_json, is_sse)
                             yield chunk
                             continue
@@ -1089,7 +1089,6 @@ async def handle_completions_impl(api: str, request: Request):
                             req_data["max_tokens"] = origin_max_tokens - completion_tokens + retry_count
                             tmp_request_length = len(json.dumps(req_data).encode("utf-8"))
                             instance_info = await reassign_instances(api, req_data, tmp_request_length, instance_info)
-                            final_prefiller_cached_tokens = instance_info.prefiller_cached_tokens
                             released_kv = False
                             break
                         chunk_updated = False
@@ -1099,7 +1098,7 @@ async def handle_completions_impl(api: str, request: Request):
                             else:
                                 choice["text"] = generated_token
                             chunk_updated = True
-                        if update_cached_tokens_in_chunk(chunk_json, final_prefiller_cached_tokens):
+                        if update_cached_tokens_in_chunk(chunk_json, reported_prefiller_cached_tokens):
                             chunk_updated = True
                         if chunk_updated:
                             chunk = encode_response_chunk(chunk_json, is_sse)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes the cached token usage reported by the disaggregated prefill load-balance proxy, as mentioned in #8910 and #10403.

When the proxy sends a request to the prefiller, it now extracts `usage.prompt_tokens_details.cached_tokens` from the prefiller response and keeps it in the selected `InstanceInfo`. When forwarding decoder responses back to the client, the proxy writes that prefiller-side cached token count into response chunks that contain `usage`, while preserving both SSE streaming chunks and non-streaming JSON responses.

This is needed because in PD disaggregated serving the decoder response does not have enough context to report the P node's prefix-cache hits. As a result, clients of the proxy could observe missing or incorrect `cached_tokens` in `usage.prompt_tokens_details`, especially in streaming responses. The reported value should reflect the prefiller's cache-hit tokens.

For example, before this PR the proxy could pass through the decoder-side `cached_tokens` even though the prefiller had a different cache-hit count:

```text
Prefill usage:
{'prompt_tokens': 8193, 'total_tokens': 8194, 'completion_tokens': 1, 'prompt_tokens_details': {'cached_tokens': 6144}, 'completion_tokens_details': None}

decode usage chunk:
{'prompt_tokens': 8193, 'total_tokens': 8201, 'completion_tokens': 8, 'prompt_tokens_details': {'cached_tokens': 8192}}

Final usage chunk before this PR:
{'prompt_tokens': 8193, 'total_tokens': 8201, 'completion_tokens': 8, 'prompt_tokens_details': {'cached_tokens': 8192}}

Correct final usage chunk after this PR:
{"prompt_tokens":8193,"total_tokens":8201,"completion_tokens":8,"prompt_tokens_details":{"cached_tokens":6144}}
```

The change also keeps the cached token value up to date when the proxy retries and reassigns prefiller/decoder instances.

### Does this PR introduce _any_ user-facing change?

Yes. For users of `examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py`, responses that include `usage` now report `usage.prompt_tokens_details.cached_tokens` from the prefiller side of the PD request.

This makes the OpenAI-compatible usage metadata more accurate for disaggregated prefill proxy requests. No new API fields are introduced.

### How was this patch tested?

Syntax check:

```bash
python3 -c "from pathlib import Path; p=Path('examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py'); compile(p.read_text(), str(p), 'exec')"
```

`ruff` was not run locally because the `ruff` command is not available in the current environment:

```bash
ruff check examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
```

No new unit test was added because this change is limited to the example PD proxy path and depends on prefiller/decoder backend response integration. The expected behavior can be verified manually by running the disaggregated prefill example with prefix caching enabled and checking that the proxy response includes the prefiller-reported `usage.prompt_tokens_details.cached_tokens` for both streaming and non-streaming requests.

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
