### PR TITLE
[BugFix] Fix _dummy_run warmup mismatch when using --mm-encoder-only

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3314,6 +3314,11 @@ class NPUModelRunner(GPUModelRunner):
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        mm_config = self.vllm_config.model_config.multimodal_config
+        if mm_config and mm_config.mm_encoder_only:
+            # The current dummy run only covers LM execution, so we can skip it.
+            # mm encoder dummy run may need to add in the future.
+            return torch.tensor([]), torch.tensor([])
         # only support eager mode and piecewise graph now
         assert cudagraph_runtime_mode is None or cudagraph_runtime_mode.valid_runtime_modes()
         # If cudagraph_mode.decode_mode() == FULL and
@@ -3578,6 +3583,11 @@ class NPUModelRunner(GPUModelRunner):
         self,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
+        mm_config = self.vllm_config.model_config.multimodal_config
+        if mm_config and mm_config.mm_encoder_only:
+            # MM Encoder only model no need to run sampler.
+            return torch.tensor([])
+
         output = None
 
         # For profile, have maximum num_reqs and that collectively have


### PR DESCRIPTION
## What this PR does

Fixes `NPUModelRunner` to handle multimodal encoder-only models (e.g., CLIP, ViT-only pipelines) correctly on Ascend NPU.

When `multimodal_config.mm_encoder_only` is True, the model has no language-model decoder. Previously, two code paths in `NPUModelRunner` would fail or produce incorrect results because they attempted LM-style execution on a pure-encoder model:

* **`_dummy_run`**: Dummy profiling runs LM forward + graph capture, which is meaningless and crashes for encoder-only models. Now it returns `(tensor([]), tensor([]))` immediately, skipping LM execution. *Note: A full MM encoder dummy run can be added later if needed.*
* **Sampler path**: Calling the token sampler on an encoder-only model has no semantic meaning and errors at runtime. Now it returns `tensor([])` immediately when `mm_encoder_only` is set.

---

## User-facing change

> **Fix:** Users serving MM encoder-only models (e.g., embedding/reranking models where only the vision/text encoder matters) on Ascend NPU will no longer hit crashes during startup profiling or inference sampling.

---

## How was this patch tested

* [x] Code inspection against the `mm_encoder_only` flag usage in upstream vLLM.