### PR TITLE
[BugFix] Add compatibility guard for unsupported CLI params on Ascend NPU

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -1205,7 +1205,7 @@ class NPUPlatform(Platform):
             if getattr(vllm_config.compilation_config, "use_inductor_graph_partition", False) is not None:
                 logger.warning(
                     "Parameter is not supported on Ascend NPU (use_inductor is False). "
-                    "parameter=use_inductor_graph_partition, action: resetting to None."
+                    "parameter=use_inductor_graph_partition, action: resetting to False."
                 )
                 vllm_config.compilation_config.use_inductor_graph_partition = False
 

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -1018,6 +1018,13 @@ class NPUPlatform(Platform):
                 )
                 vllm_config.cache_config.cpu_kvcache_space_bytes = None
 
+            if getattr(vllm_config.cache_config, "calculate_kv_scales", False):
+                logger.warning(
+                    "Parameter is not supported on Ascend NPU. "
+                    "parameter=calculate_kv_scales, action: resetting to False."
+                )
+                vllm_config.cache_config.calculate_kv_scales = False
+
         # ==================== 3. MultiModal Config ====================
         multimodal_config = getattr(model_config, "multimodal_config", None) if model_config else None
         if multimodal_config:
@@ -1192,6 +1199,34 @@ class NPUPlatform(Platform):
                     ubatch_size,
                 )
                 vllm_config.parallel_config.ubatch_size = 0
+
+            if getattr(vllm_config.parallel_config, "enable_eplb", False):
+                logger.warning(
+                    "'--enable-eplb' is not supported on Ascend NPU. "
+                    "Please use '--additional-config "
+                    "'{\"eplb_config\": {\"expert_map_path\": \"...\", "
+                    "\"num_redundant_experts\": N}}' instead. "
+                    "action: resetting to False."
+                )
+                vllm_config.parallel_config.enable_eplb = False
+
+            if getattr(vllm_config.parallel_config, "enable_elastic_ep", False):
+                logger.warning(
+                    "'--enable-elastic-ep' is not supported on Ascend NPU. "
+                    "Please use '--additional-config "
+                    "'{\"eplb_config\": {...}}' instead. "
+                    "action: resetting to False."
+                )
+                vllm_config.parallel_config.enable_elastic_ep = False
+
+        # ==================== 10. Compilation Config ====================
+        if vllm_config.compilation_config:
+            if getattr(vllm_config.compilation_config, "use_inductor_graph_partition", False) is not None:
+                logger.warning(
+                    "Parameter is not supported on Ascend NPU (use_inductor is False). "
+                    "parameter=use_inductor_graph_partition, action: resetting to None."
+                )
+                vllm_config.compilation_config.use_inductor_graph_partition = False
 
     @classmethod
     def use_custom_op_collectives(cls) -> bool:

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -1204,8 +1204,8 @@ class NPUPlatform(Platform):
                 logger.warning(
                     "'--enable-eplb' is not supported on Ascend NPU. "
                     "Please use '--additional-config "
-                    "'{\"eplb_config\": {\"expert_map_path\": \"...\", "
-                    "\"num_redundant_experts\": N}}' instead. "
+                    '\'{"eplb_config": {"expert_map_path": "...", '
+                    '"num_redundant_experts": N}}\' instead. '
                     "action: resetting to False."
                 )
                 vllm_config.parallel_config.enable_eplb = False

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -1200,25 +1200,6 @@ class NPUPlatform(Platform):
                 )
                 vllm_config.parallel_config.ubatch_size = 0
 
-            if getattr(vllm_config.parallel_config, "enable_eplb", False):
-                logger.warning(
-                    "'--enable-eplb' is not supported on Ascend NPU. "
-                    "Please use '--additional-config "
-                    '\'{"eplb_config": {"expert_map_path": "...", '
-                    '"num_redundant_experts": N}}\' instead. '
-                    "action: resetting to False."
-                )
-                vllm_config.parallel_config.enable_eplb = False
-
-            if getattr(vllm_config.parallel_config, "enable_elastic_ep", False):
-                logger.warning(
-                    "'--enable-elastic-ep' is not supported on Ascend NPU. "
-                    "Please use '--additional-config "
-                    "'{\"eplb_config\": {...}}' instead. "
-                    "action: resetting to False."
-                )
-                vllm_config.parallel_config.enable_elastic_ep = False
-
         # ==================== 10. Compilation Config ====================
         if vllm_config.compilation_config:
             if getattr(vllm_config.compilation_config, "use_inductor_graph_partition", False) is not None:

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -1202,7 +1202,7 @@ class NPUPlatform(Platform):
 
         # ==================== 10. Compilation Config ====================
         if vllm_config.compilation_config:
-            if getattr(vllm_config.compilation_config, "use_inductor_graph_partition", False) is not None:
+            if getattr(vllm_config.compilation_config, "use_inductor_graph_partition", False):
                 logger.warning(
                     "Parameter is not supported on Ascend NPU (use_inductor is False). "
                     "parameter=use_inductor_graph_partition, action: resetting to False."


### PR DESCRIPTION
## What this PR does

Add silent reset handling in `_fix_incompatible_config` for four upstream CLI parameters that are incompatible with Ascend NPU:

| Parameter | Config Section | Reset Value | Reason |
|-----------|---------------|-------------|--------|
| `--calculate-kv-scales` | Cache Config | `False` | Deprecated upstream; not supported on Ascend |
| `--compilation-config.use_inductor_graph_partition` | Compilation Config | `False` | Ascend forces `use_inductor=False`, making this irrelevant |

## User-facing change

Users who pass `--calculate-kv-scales`, `--compilation-config '{"use_inductor_graph_partition": true}'` on Ascend NPU will now see a warning log and the parameter will be silently reset to its safe default, rather than potentially causing errors or undefined behavior.

## How was this patch tested

- Code review of the `_fix_incompatible_config` method to verify the pattern matches existing silent-reset entries.


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
