### PR TITLE
[Doc][Model] Fix model name mismatch in DeepSeek-V4-Flash functional verification

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V4-Flash.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Flash.md
@@ -783,7 +783,7 @@ Once your server is started, you can query the model with input prompts:
 curl http://<node0_ip>:<port>/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{
-        "model": "deepseek_v4",
+        "model": "dsv4",
         "messages": [
             {
                 "role": "user",


### PR DESCRIPTION
## Summary

Fix the model name mismatch in DeepSeek-V4-Flash functional verification section.

**Problem**: The functional verification example uses `"model": "deepseek_v4"` in the curl request, but the `vllm serve` command uses `--served-model-name dsv4`. This mismatch causes a 404 error when users follow the tutorial.

**Fix**: Change `"model": "deepseek_v4"` to `"model": "dsv4"` in the Functional Verification section to match the `--served-model-name dsv4` used in all deployment commands.

## Changes

- `docs/source/tutorials/models/DeepSeek-V4-Flash.md`: Fix model name in functional verification curl example

Closes #10411
- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
