### PR TITLE
[BugFix] Fix w4a8 per channel bug for compressed tensor

### DIFF
--- a/tests/ut/quantization/methods/a2/test_w4a8.py
+++ b/tests/ut/quantization/methods/a2/test_w4a8.py
@@ -337,11 +337,10 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
     @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
     @patch("torch_npu.npu_format_cast")
     @patch("torch_npu.npu_quantize")
-    @patch("torch.Tensor.npu")
+    @patch("torch.Tensor.npu", new=lambda self: self)
     def test_process_weights_after_loading_compressed_tensors(
-        self, mock_npu, mock_npu_quantize, mock_npu_format_cast, mock_maybe_trans_nz
+        self, mock_npu_quantize, mock_npu_format_cast, mock_maybe_trans_nz
     ):
-        mock_npu.return_value = torch.Tensor()
         mock_npu_quantize.return_value = torch.Tensor()
         mock_npu_format_cast.side_effect = identity
         mock_maybe_trans_nz.side_effect = identity
@@ -353,6 +352,13 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
         self.assertTrue(hasattr(layer, "w13_scale_bias"))
         self.assertEqual(layer.w13_scale_bias.data.shape, (self.experts, 2 * self.input_size))
         self.assertEqual(layer.w13_scale_bias.data.dtype, torch.float32)
+
+        self.quant_method.is_per_channel_weight = True
+        self.quant_method.weight_strategy = "channel"
+        per_channel_layer = self.build_layer(is_new_quant_version=False)
+        self.quant_method.process_weights_after_loading(per_channel_layer)
+        self.assertEqual(per_channel_layer.w13_weight_scale.data.shape, (self.experts, 2 * self.input_size))
+        self.assertEqual(per_channel_layer.w2_weight_scale.data.shape, (self.experts, 1, self.output_size))
 
     @patch("vllm_ascend.quantization.methods.w4a8._EXTRA_CTX")
     @patch("vllm_ascend.quantization.methods.w4a8.select_experts")

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -674,12 +674,12 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
         layer.w13_weight.data = layer.w13_weight.data.transpose(1, 2).contiguous()
         layer.w2_weight.data = layer.w2_weight.data.transpose(1, 2).contiguous()
 
-        def process_scale_compressed_tensors(scale: torch.Tensor):
+        def process_scale_compressed_tensors(scale: torch.Tensor, squeeze: bool = True):
             scale = scale.transpose(1, 2).to(torch.float32).contiguous()
             scale_np = scale.cpu().numpy()
             scale_np.dtype = np.uint32
             scale_uint64_tensor = torch.from_numpy(scale_np.astype(np.int64)).npu()
-            if self.is_per_channel_weight:
+            if self.is_per_channel_weight and squeeze:
                 return self.maybe_squeeze_per_channel_weight_scale(scale_uint64_tensor)
             return scale_uint64_tensor
 
@@ -708,7 +708,8 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
         w2_bias = update_bias_compressed_tensors(layer.w2_weight.data, layer.w2_weight_scale.data, self.weight_strategy)
 
         layer.w13_weight_scale.data = process_scale_compressed_tensors(layer.w13_weight_scale.data)
-        layer.w2_weight_scale.data = process_scale_compressed_tensors(layer.w2_weight_scale.data)
+        # To use torch_npu.npu_grouped_matmul, keep w2_weigh_scale unsqueezed
+        layer.w2_weight_scale.data = process_scale_compressed_tensors(layer.w2_weight_scale.data, False)
 
         w13_scale_bias = torch.nn.Parameter(w13_bias, requires_grad=False)
         layer.register_parameter("w13_scale_bias", w13_scale_bias)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR introduces a `squeeze` parameter (defaulting to `True`) to the `process_scale_compressed_tensors` helper function in the W4A8 quantization method. This allows disabling the squeezing of per-channel weight scales when processing `w2_weight_scale`.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
