### PR TITLE
[CI] Remove github action schedule job for image and nightly

### DIFF
--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -12,9 +12,6 @@
 #   - Publish when tag with v* (pep440 version)  ===>  vllm-ascend:v1.2.3 / vllm-ascend:v1.2.3rc1
 name: Image Build and Push
 on:
-  schedule:
-    # UTC+8: 12pm, 21pm
-    - cron: '0 4,13 * * *'
   push:
     tags:
       - 'v*'
@@ -64,7 +61,7 @@ permissions:
 jobs:
   image_build:
     name: Image Build and Push
-    if: ${{ ((github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'image-build')) && github.event_name != 'schedule')
+    if: ${{ !((github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'image-build')))
         && !(github.event_name == 'workflow_dispatch' && inputs.vllm_commit != '' && inputs.vllm_ascend_commit != '') }}
     strategy:
       matrix:
@@ -142,48 +139,4 @@ jobs:
       workflow_dispatch_tag: ''
       branch_ref: ''
     secrets:
-      QUAY_TEMP_PASSWORD: ${{ secrets.QUAY_TEMP_PASSWORD }}
-
-  schedule_image_build:
-    name: Image Build and Push
-    if: ${{ github.event_name == 'schedule' }}
-    strategy:
-      max-parallel: 6
-      matrix:
-        branch_meta:
-          - branch_ref: main
-            schedule_tag_pattern: main
-            artifact_prefix: digests
-        build_meta:
-          - name: A2 Ubuntu
-            dockerfile: Dockerfile
-            suffix: ''
-          - name: A2 openeuler
-            dockerfile: Dockerfile.openEuler
-            suffix: 'openeuler'
-          - name: A3 Ubuntu
-            dockerfile: Dockerfile.a3
-            suffix: 'a3'
-          - name: A3 openEuler
-            dockerfile: Dockerfile.a3.openEuler
-            suffix: 'a3-openeuler'
-          - name: 310P Ubuntu
-            dockerfile: Dockerfile.310p
-            suffix: '310p'
-          - name: 310P openEuler
-            dockerfile: Dockerfile.310p.openEuler
-            suffix: '310p-openeuler'
-    uses: ./.github/workflows/_schedule_image_build.yaml
-    with:
-      dockerfile: ${{ matrix.build_meta.dockerfile }}
-      suffix: ${{ matrix.build_meta.suffix }}
-      quay_username: ${{ vars.QUAY_USERNAME }}
-      quay_temp_username: ${{ vars.QUAY_TEMP_USERNAME }}
-      should_push: ${{ github.repository_owner == 'vllm-project' && (github.event_name != 'pull_request') }}
-      workflow_dispatch_tag: ${{ inputs.tag != 'none' && inputs.tag || '' }}
-      branch_ref: ${{ matrix.branch_meta.branch_ref }}
-      schedule_tag_pattern: ${{ matrix.branch_meta.schedule_tag_pattern }}
-      artifact_prefix: ${{ matrix.branch_meta.artifact_prefix }}
-    secrets:
-      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
       QUAY_TEMP_PASSWORD: ${{ secrets.QUAY_TEMP_PASSWORD }}

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -20,9 +20,6 @@
 name: Nightly-A2
 
 on:
-  schedule:
-      # Run test at 23:45 Beijing time (UTC+8)
-      - cron: "45 15 * * *"
   workflow_dispatch:
     inputs:
       vllm_ascend_branch:
@@ -79,7 +76,6 @@ jobs:
   parse-trigger:
     name: Parse trigger and determine test scope
     if: >-
-      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch'
     runs-on: linux-aarch64-a2b3-0
     outputs:
@@ -93,23 +89,17 @@ jobs:
         with:
           script: |
             const eventName = context.eventName;
-            const testCases = '${{ github.event_name == 'workflow_dispatch' && inputs.test_cases || '' }}'.trim();
+            const testCases = '${{ inputs.test_cases }}'.trim();
 
             core.setOutput('ref', context.sha || 'unknown');
 
-            if (eventName === 'workflow_dispatch' && testCases) {
+            if (testCases) {
               core.setOutput('run', 'true');
               if (testCases === 'all') {
                 core.setOutput('filter', 'all');
               } else {
                 core.setOutput('filter', ',' + testCases.split(',').map(s => s.trim()).join(',') + ',');
               }
-              return;
-            }
-
-            if (eventName === 'schedule') {
-              core.setOutput('run', 'true');
-              core.setOutput('filter', 'all');
               return;
             }
 
@@ -130,27 +120,19 @@ jobs:
           {
             echo "cann_image=${{ env.CANN_IMAGE }}"
             echo "ascend_log_prefix=${{ env.ASCEND_LOG_PREFIX }}"
-            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-              input_branch="${{ inputs.vllm_ascend_branch }}"
-              # Normalize branch name for image tag (replace '/' with '-')
-              normalized=$(echo "$input_branch" | tr '/' '-')
-              echo "vllm_ascend_branches=[\"${normalized}\"]"
-            else
-              echo 'vllm_ascend_branches=["main"]'
-            fi
+            input_branch="${{ inputs.vllm_ascend_branch }}"
+            normalized=$(echo "$input_branch" | tr '/' '-')
+            echo "vllm_ascend_branches=[\"${normalized}\"]"
           } >> $GITHUB_OUTPUT
 
   build-image:
     name: Build nightly-a2 image
     if: >-
-      github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.skip_build_image != 'true')
     strategy:
       matrix:
         vllm_ascend_branch: >-
-          ${{ github.event_name == 'workflow_dispatch' 
-              && fromJSON(format('["{0}"]', inputs.vllm_ascend_branch))
-              || fromJSON('["main"]') }}
+          ${{ fromJSON(format('["{0}"]', inputs.vllm_ascend_branch)) }}
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: a2
@@ -344,7 +326,7 @@ jobs:
   clear-pre-logs:
     needs: [parse-trigger, multi-node-tests]
     runs-on: linux-aarch64-a2b3-0
-    if: github.event_name == 'schedule' && needs.multi-node-tests.result != 'skipped'
+    if: needs.multi-node-tests.result != 'skipped'
     steps:
       - name: Clear pre-logs on pvc
         run: |
@@ -356,7 +338,7 @@ jobs:
     needs: [parse-trigger, single-node-tests, multi-node-tests]
     if: >-
       always() &&
-      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      github.event_name == 'workflow_dispatch' &&
       needs.parse-trigger.result == 'success'
     runs-on: linux-aarch64-a2b3-0
     steps:

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -21,9 +21,6 @@
 name: Nightly-A3
 
 on:
-  schedule:
-      # Run test at 23:45 Beijing time (UTC+8)
-      - cron: "45 15 * * *"
   workflow_dispatch:
     inputs:
       vllm_ascend_branch:
@@ -78,7 +75,6 @@ jobs:
   parse-trigger:
     name: Parse trigger and determine test scope
     if: >-
-      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch'
     runs-on: linux-aarch64-a2b3-0
     outputs:
@@ -92,23 +88,17 @@ jobs:
         with:
           script: |
             const eventName = context.eventName;
-            const testCases = '${{ github.event_name == 'workflow_dispatch' && inputs.test_cases || '' }}'.trim();
+            const testCases = '${{ inputs.test_cases }}'.trim();
 
             core.setOutput('ref', context.sha || 'unknown');
 
-            if (eventName === 'workflow_dispatch' && testCases) {
+            if (testCases) {
               core.setOutput('run', 'true');
               if (testCases === 'all') {
                 core.setOutput('filter', 'all');
               } else {
                 core.setOutput('filter', ',' + testCases.split(',').map(s => s.trim()).join(',') + ',');
               }
-              return;
-            }
-
-            if (eventName === 'schedule') {
-              core.setOutput('run', 'true');
-              core.setOutput('filter', 'all');
               return;
             }
 
@@ -127,27 +117,19 @@ jobs:
         run: |
           {
             echo "ascend_log_prefix=${{ env.ASCEND_LOG_PREFIX }}"
-            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-              input_branch="${{ inputs.vllm_ascend_branch }}"
-              # Normalize branch name for image tag (replace '/' with '-')
-              normalized=$(echo "$input_branch" | tr '/' '-')
-              echo "vllm_ascend_branches=[\"${normalized}\"]"
-            else
-              echo 'vllm_ascend_branches=["main"]'
-            fi
+            input_branch="${{ inputs.vllm_ascend_branch }}"
+            normalized=$(echo "$input_branch" | tr '/' '-')
+            echo "vllm_ascend_branches=[\"${normalized}\"]"
           } >> $GITHUB_OUTPUT
 
   build-image:
     name: Build nightly-a3 image
     if: >-
-      github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.skip_build_image != 'true')
     strategy:
       matrix:
         vllm_ascend_branch: >-
-          ${{ github.event_name == 'workflow_dispatch' 
-              && fromJSON(format('["{0}"]', inputs.vllm_ascend_branch))
-              || fromJSON('["main"]') }}
+          ${{ fromJSON(format('["{0}"]', inputs.vllm_ascend_branch)) }}
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: a3
@@ -396,7 +378,7 @@ jobs:
   clear-pre-logs:
     runs-on: linux-aarch64-a3-0
     needs: [multi-node-tests, double-node-tests]
-    if: github.event_name == 'schedule' && (needs.multi-node-tests.result != 'skipped' || needs.double-node-tests.result != 'skipped')
+    if: (needs.multi-node-tests.result != 'skipped' || needs.double-node-tests.result != 'skipped')
     steps:
       - name: Clear pre-logs on pvc
         run: |
@@ -408,7 +390,7 @@ jobs:
     needs: [parse-trigger, single-node-tests, multi-node-tests, double-node-tests, multi-card-tests]
     if: >-
       always() &&
-      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      github.event_name == 'workflow_dispatch' &&
       needs.parse-trigger.result == 'success'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
github action schedule job doesn't work on time  usually. It makes the image build and nighlty test works unexpected. We take another way to trigger the schedule job now. Let's remove the github action way.

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
