### PR TITLE
[Feature] Add Kimi-Linear-48B-A3B-Instruct model support

### DIFF
--- a/.github/workflows/misc/model_dataset_list.json
+++ b/.github/workflows/misc/model_dataset_list.json
@@ -173,6 +173,7 @@
       "rhymes-ai/Aria",
       "sentence-transformers/all-MiniLM-L12-v2",
       "tencent/HunyuanOCR",
+      "Kimi-Linear-48B-A3B-Instruct",
       "unsloth/DeepSeek-V3.1-BF16",
       "unsloth/Kimi-K2-Thinking-BF16",
       "unsloth/gpt-oss-20b-BF16",

--- a/docs/source/tutorials/models/Kimi-Linear-48B-A3B-Instruct.md
+++ b/docs/source/tutorials/models/Kimi-Linear-48B-A3B-Instruct.md
@@ -1,0 +1,168 @@
+# Kimi-Linear-48B-A3B-Instruct
+
+## Introduction
+
+Kimi-Linear-48B-A3B-Instruct is a hybrid-architecture language model developed by Moonshot AI. It combines Multi-head Latent Attention (MLA) with Kimi Delta Attention (KDA) linear attention mechanism, achieving efficient long-context inference with reduced memory requirements.
+
+Key features of Kimi-Linear-48B-A3B-Instruct include:
+
+- ~48B total parameters with ~3B activated (Mixture-of-Experts)
+- Hybrid architecture: 7 MLA layers + 20 KDA linear attention layers
+- Support for up to 1M context length
+- KDA linear attention for efficient sequence processing
+
+This document will show the main verification steps of the model, including supported features, feature configuration, environment preparation, single-node deployment, accuracy and performance evaluation.
+
+The `Kimi-Linear-48B-A3B-Instruct` model is experimentally supported in vllm-ascend.
+
+## Environment Preparation
+
+### Model Weight
+
+- `Kimi-Linear-48B-A3B-Instruct`(BF16 version): [Download model weight](https://huggingface.co/moonshotai/Kimi-Linear-48B-A3B-Instruct)
+
+It is recommended to download the model weight to a local directory, such as `/data/models/`.
+
+### Installation
+
+You can use our official docker image to run `Kimi-Linear-48B-A3B-Instruct` directly.
+
+Select an image based on your machine type and start the docker image on your node, refer to [using docker](../../installation.md#set-up-using-docker).
+
+```{code-block} bash
+   :substitutions:
+# Update --device according to your device (Atlas A2: /dev/davinci[0-7] Atlas A3:/dev/davinci[0-15]).
+# Update the vllm-ascend image according to your environment.
+# Note you should download the weight to /root/.cache in advance.
+# Update the vllm-ascend image
+export IMAGE=m.daocloud.io/quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+export NAME=vllm-ascend
+
+# Run the container using the defined variables
+# Note: If you are running bridge network with docker, please expose available ports for multiple nodes communication in advance.
+docker run --rm \
+    --name $NAME \
+    --net=host \
+    --shm-size=1g \
+    --device /dev/davinci0 \
+    --device /dev/davinci1 \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+    -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /root/.cache:/root/.cache \
+    -it $IMAGE bash
+```
+
+## Deployment
+
+### Single-node Deployment
+
+- `Kimi-Linear-48B-A3B-Instruct` can be deployed on 1 Atlas 800 A2 (64G x 2) or above.
+
+Run the following script to execute online inference.
+
+``` bash
+
+export HCCL_OP_EXPANSION_MODE="AIV"
+export OMP_PROC_BIND=false
+export OMP_NUM_THREADS=10
+export VLLM_USE_V1=1
+export HCCL_BUFFSIZE=200
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+```
+
+``` bash
+
+vllm serve "moonshotai/Kimi-Linear-48B-A3B-Instruct" \
+  --tensor-parallel-size 2 \
+  --max-model-len 4096 \
+  --dtype bfloat16 \
+  --trust-remote-code \
+  --enforce-eager \
+  --block-size 128 \
+  --gpu-memory-utilization 0.7
+```
+
+**Notice:**
+The parameters are explained as follows:
+
+- `--max-model-len` specifies the maximum context length - that is, the sum of input and output tokens for a single request. For testing purposes, a value of `4096` is used here.
+- `--dtype bfloat16` specifies the data type for model weights and computations.
+- `--trust-remote-code` allows loading models with custom code.
+- `--enforce-eager` forces the use of eager execution mode instead of graph compilation, which is more stable for experimental models.
+- `--block-size` specifies the block size for KV cache management, with a value of `128` used here. The actual block size may be adjusted at runtime to align MLA and KDA layer page sizes.
+- `--gpu-memory-utilization` sets the proportion of NPU memory to use for the model, with a value of `0.7` used here to reduce memory usage.
+
+## Functional Verification
+
+Once your server is started, you can query the model with input prompts.
+
+```shell
+curl http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "moonshotai/Kimi-Linear-48B-A3B-Instruct",
+        "messages": [
+            {"role": "user", "content": "你好，介绍一下你自己"}
+        ],
+        "max_tokens": 100,
+        "temperature": 0.7
+    }'
+```
+
+### Using AISBench
+
+1. Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) for details.
+
+2. After execution, you can get the result.
+
+## Performance
+
+### Using AISBench
+
+Refer to [Using AISBench for performance evaluation](../../developer_guide/evaluation/using_ais_bench.md#execute-performance-evaluation) for details.
+
+### Using vLLM Benchmark
+
+Run performance evaluation of `Kimi-Linear-48B-A3B-Instruct` as an example.
+
+Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/benchmarking/) for more details.
+
+There are three `vllm bench` subcommands:
+
+- `latency`: Benchmark the latency of a single batch of requests.
+- `serve`: Benchmark the online serving throughput.
+- `throughput`: Benchmark offline inference throughput.
+
+Take the `serve` as an example. First, start the server:
+
+```shell
+python -m vllm.entrypoints.openai.api_server \
+    --model moonshotai/Kimi-Linear-48B-A3B-Instruct \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --tensor-parallel-size 2 \
+    --max-model-len 512 \
+    --dtype bfloat16 \
+    --trust-remote-code \
+    --enforce-eager \
+    --block-size 128 \
+    --gpu-memory-utilization 0.7
+```
+
+## Known Limitations
+
+- This model is experimentally supported. The KDA (Kimi Delta Attention) linear attention layers use a PyTorch fallback for the chunk_kda operation, which may impact prefill performance.
+- The mixed KV cache (MLA + KDA) page size alignment is handled automatically at runtime.
+
+## Conclusion
+
+Kimi-Linear-48B-A3B-Instruct is an innovative hybrid-attention MoE model that combines the strengths of standard MLA attention and KDA linear attention. With proper deployment on Ascend hardware using vllm-ascend, you can leverage its efficient long-context capabilities.
+
+For more details about model capabilities and best practices, refer to the official Moonshot AI documentation and vllm-ascend user guide.

--- a/docs/source/tutorials/models/index.md
+++ b/docs/source/tutorials/models/index.md
@@ -44,5 +44,6 @@ gpt-oss-120b.md
 Mixtral-8x7B-Instruct-v0.1.md
 Qwen3-ASR-1.7B.md
 Qwen2.5-Math-RM-72B.md
+Kimi-Linear-48B-A3B-Instruct.md
 InternVL3.5
 :::

--- a/tests/e2e/models/configs/Kimi-Linear-48B-A3B-Instruct.yaml
+++ b/tests/e2e/models/configs/Kimi-Linear-48B-A3B-Instruct.yaml
@@ -1,0 +1,30 @@
+model_name: "moonshotai/Kimi-Linear-48B-A3B-Instruct"
+hardware: "Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 2
+  dtype: bfloat16
+  max_model_len: 4096
+  gpu_memory_utilization: 0.7
+  trust_remote_code: true
+  enforce_eager: true
+  block_size: 128
+
+envs:
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  OMP_PROC_BIND: "false"
+  OMP_NUM_THREADS: "10"
+  VLLM_USE_V1: "1"
+  HCCL_BUFFSIZE: "200"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+
+tasks:
+  - name: "ceval-valid"
+    metrics:
+      - name: "acc,none"
+        value: 0.30
+
+num_fewshot: 5
+apply_chat_template: true
+fewshot_as_multiturn: false
+batch_size: 32

--- a/tests/e2e/models/configs/accuracy_groups_a2.json
+++ b/tests/e2e/models/configs/accuracy_groups_a2.json
@@ -36,7 +36,8 @@
       "model_list": [
         "Qwen3-Next-80B-A3B-Instruct",
         "Qwen3-Omni-30B-A3B-Instruct",
-        "Mixtral-8x7B-Instruct-v0.1"
+        "Mixtral-8x7B-Instruct-v0.1",
+        "Kimi-Linear-48B-A3B-Instruct"
       ]
     }
   ],

--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -75,6 +75,12 @@ def set_cos_and_sin(vllm_config, max_num_reqs, decode_token_per_req, dtype, devi
         rope_dim = model_config.hf_text_config.qk_rope_head_dim
         _cos_mla = torch.ones(max_num_batched_tokens, 1, 1, rope_dim, dtype=dtype, device=device)
         _sin_mla = torch.zeros(max_num_batched_tokens, 1, 1, rope_dim, dtype=dtype, device=device)
+    elif hasattr(model_config.hf_text_config, "qk_rope_head_dim"):
+        # Hybrid models (e.g. KimiLinear) with MLA layers may not set use_mla.
+        # Lazy-init MLA cos/sin buffers based on qk_rope_head_dim.
+        rope_dim = model_config.hf_text_config.qk_rope_head_dim
+        _cos_mla = torch.ones(max_num_batched_tokens, 1, 1, rope_dim, dtype=dtype, device=device)
+        _sin_mla = torch.zeros(max_num_batched_tokens, 1, 1, rope_dim, dtype=dtype, device=device)
     elif not is_vl_model(vllm_config) and has_rope(vllm_config):
         rope_dim = model_config.get_head_size()
         # For models using partial rope like Qwen3-Next.

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -12,6 +12,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheSpec,
     KVCacheTensor,
+    MambaSpec,
     MLAAttentionSpec,
     SlidingWindowMLASpec,
     UniformTypeKVCacheSpecs,
@@ -63,18 +64,25 @@ def group_and_unify_kv_cache_specs(
 ) -> list[UniformTypeKVCacheSpecs] | None:
     """
     Group the KV cache specs and unify each group into one UniformTypeKVCacheSpecs.
-    Currently, this is only used for DeepseekV4.
+    Used for DeepseekV4 (MLA + SWA-MLA) and KimiLinear (MLA + MambaSpec/KDA).
     """
-    if not any(isinstance(spec, SlidingWindowMLASpec) for spec in kv_cache_spec.values()):
+    has_swa_mla = any(isinstance(spec, SlidingWindowMLASpec) for spec in kv_cache_spec.values())
+    has_mamba = any(isinstance(spec, MambaSpec) for spec in kv_cache_spec.values())
+    has_mla = any(isinstance(spec, MLAAttentionSpec) for spec in kv_cache_spec.values())
+
+    if not has_swa_mla and not (has_mla and has_mamba):
         return None
 
     ratio_specs: dict[int, dict[str, KVCacheSpec]] = defaultdict(dict)
     grouped_swa_mla_specs: dict[int, dict[str, KVCacheSpec]] = defaultdict(dict)
+    mamba_specs: dict[str, KVCacheSpec] = {}
     for name, spec in kv_cache_spec.items():
         if isinstance(spec, SlidingWindowMLASpec):
             grouped_swa_mla_specs[spec.block_size][name] = spec
         elif isinstance(spec, MLAAttentionSpec):
             ratio_specs[spec.compress_ratio][name] = spec
+        elif isinstance(spec, MambaSpec):
+            mamba_specs[name] = spec
 
     mla_uniform_specs = []
     for ratio in sorted(ratio_specs, key=lambda r: (r != 4, r)):
@@ -89,7 +97,13 @@ def group_and_unify_kv_cache_specs(
         assert uniform_spec is not None
         swa_uniform_specs.append(uniform_spec)
 
-    return [*mla_uniform_specs, *swa_uniform_specs]
+    mamba_uniform_specs: list[UniformTypeKVCacheSpecs] = []
+    if mamba_specs:
+        uniform_spec = UniformTypeKVCacheSpecs.from_specs(mamba_specs)
+        assert uniform_spec is not None
+        mamba_uniform_specs.append(uniform_spec)
+
+    return [*mla_uniform_specs, *swa_uniform_specs, *mamba_uniform_specs]
 
 
 def _get_kv_cache_groups_uniform_groups(
@@ -102,13 +116,27 @@ def _get_kv_cache_groups_uniform_groups(
     # For now, we restrict the first grouped_spec to be UniformTypeKVCacheSpecs
     # containing only MLAAttentionSpec.
     full_mla_spec = grouped_specs[0]
-    full_mla_c128_spec = grouped_specs[1]
 
     assert all(isinstance(spec, MLAAttentionSpec) for spec in full_mla_spec.kv_cache_specs.values())
     full_mla_group = KVCacheGroupSpec(
         layer_names=list(full_mla_spec.kv_cache_specs.keys()),
         kv_cache_spec=full_mla_spec,
     )
+
+    # KimiLinear: single MLA group + MambaSpec groups (no C128 MLA, no SWA-MLA)
+    has_mamba = any(isinstance(spec, MambaSpec) for g in grouped_specs[1:] for spec in g.kv_cache_specs.values())
+    if has_mamba:
+        mamba_groups = []
+        for g_spec in grouped_specs[1:]:
+            mamba_groups.append(
+                KVCacheGroupSpec(
+                    layer_names=list(g_spec.kv_cache_specs.keys()),
+                    kv_cache_spec=g_spec,
+                )
+            )
+        return [full_mla_group, *mamba_groups]
+
+    full_mla_c128_spec = grouped_specs[1]
     full_mla_c128_group = KVCacheGroupSpec(
         layer_names=list(full_mla_c128_spec.kv_cache_specs.keys()),
         kv_cache_spec=full_mla_c128_spec,


### PR DESCRIPTION
**What this PR does / why we need it?**

Kimi-Linear-48B-A3B-Instruct is a hybrid-architecture model from Moonshot AI combining MLA (7 layers) and KDA linear attention (20 layers). Currently vllm-ascend does not support this model. Two blocking issues prevent it from running:

1. **Mixed KV cache page size**: KimiLinear has two KV cache groups with ~25x page size difference (MLA ~22KB/page, KDA/MambaSpec ~561KB/page). The current `patch_kv_cache_utils.py` only handles DeepseekV4 (MLA + SWA-MLA). When `group_and_unify_kv_cache_specs` returns `None` for KimiLinear, it falls through to the default vLLM path which cannot handle mixed page sizes. This PR adds a KimiLinear branch that detects MLA + MambaSpec layers and routes them through the specialized KV cache planning functions.

2. **MLA RoPE initialization**: `rotary_embedding.py` checks `model_config.use_mla` to initialize MLA cos/sin buffers. KimiLinear, as a hybrid model, may not set this flag even though its MLA layers require `qk_rope_head_dim=64`. This PR adds a lazy initialization fallback that detects `qk_rope_head_dim` from the HuggingFace config.

Additionally, this PR adds e2e test configuration and model tutorial documentation.

**Does this PR introduce _any_ user-facing change?**

No user-facing API changes. The model `moonshotai/Kimi-Linear-48B-A3B-Instruct` becomes servable on Ascend NPU with `vllm serve`. Existing models are unaffected — the KimiLinear branch only activates when both `MLAAttentionSpec` and `MambaSpec` layers coexist without `SlidingWindowMLASpec`.

**How was this patch tested?**

- Initial verification completed on 2×Ascend 910B2 (64GB), CANN 8.5.1: model weights load successfully (TP2), warmup forward pass produces reasonable hidden_states (mean=0.014, max=22.75, NaN=False)
- e2e test config added to `accuracy_groups_a2` for CI validation (ceval-valid benchmark)
- The KDA triton kernel NaN issue (blocking inference) is addressed separately via the PyTorch fallback in PR #9035; this PR focuses on the KV cache and RoPE infrastructure gaps
issue:https://github.com/vllm-project/vllm-ascend/issues/6695

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
