### PR TITLE
[CI] Move from github runner to self-host runner to speed up CI

### DIFF
--- a/.github/workflows/bot_issue_manage.yaml
+++ b/.github/workflows/bot_issue_manage.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     if: |
       startsWith(github.event.issue.title, '[Bug]:') ||
       startsWith(github.event.issue.title, '[Installation]:') ||

--- a/.github/workflows/bot_merge_conflict.yaml
+++ b/.github/workflows/bot_merge_conflict.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     steps:
       - name: check if prs are dirty
         uses: eps1lon/actions-label-merge-conflict@v3

--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -33,13 +33,17 @@ jobs:
       contents: read
       pull-requests: write
     name: PR create action
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4.2.2
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -y && sudo apt-get install -y jq gh
 
       - name: Install docs dependencies
         run: |

--- a/.github/workflows/pr_close_cancel_job.yaml
+++ b/.github/workflows/pr_close_cancel_job.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   cancel:
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     steps:
       - uses: actions/github-script@v9
         with:

--- a/.github/workflows/pr_e2e_command.yml
+++ b/.github/workflows/pr_e2e_command.yml
@@ -34,7 +34,7 @@ permissions:
 jobs:
   e2e-test:
     name: Run /e2e tests
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     outputs:
       pr_sha: ${{ steps.resolve.outputs.pr_sha }}
       test_groups: ${{ steps.groups.outputs.test_groups }}
@@ -43,6 +43,10 @@ jobs:
       main_commit: ${{ steps.vllm.outputs.main_commit }}
       release_tag: ${{ steps.vllm.outputs.release_tag }}
     steps:
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -y && sudo apt-get install -y gh
+
       - name: Check user authorization
         id: auth
         env:
@@ -183,7 +187,7 @@ jobs:
     name: Report result
     needs: [e2e-test, trigger-selected-tests]
     if: always() && needs.e2e-test.result == 'success' && needs.e2e-test.outputs.notify_comment_id != ''
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     steps:
       - name: Update comment with result
         uses: peter-evans/create-or-update-comment@v5

--- a/.github/workflows/pr_nightly_command.yml
+++ b/.github/workflows/pr_nightly_command.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   authorize:
     name: Check user authorization
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     outputs:
       test_cases: ${{ steps.resolve.outputs.test_cases }}
       branch: ${{ steps.resolve.outputs.branch }}
@@ -39,6 +39,10 @@ jobs:
       dispatch_a3: ${{ steps.resolve.outputs.dispatch_a3 }}
       vllm_ascend_ref: ${{ steps.resolve.outputs.vllm_ascend_ref }}
     steps:
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -y && sudo apt-get install -y gh
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -155,7 +159,7 @@ jobs:
     name: Trigger Nightly-A2
     needs: [authorize]
     if: needs.authorize.outputs.is_authorized == 'true' && needs.authorize.outputs.dispatch_a2 == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     outputs:
       a2_run_id: ${{ steps.dispatch_a2.outputs.a2_run_id }}
     steps:
@@ -184,7 +188,7 @@ jobs:
     name: Trigger Nightly-A3
     needs: [authorize]
     if: needs.authorize.outputs.is_authorized == 'true' && needs.authorize.outputs.dispatch_a3 == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     outputs:
       a3_run_id: ${{ steps.dispatch_a3.outputs.a3_run_id }}
     steps:
@@ -213,7 +217,7 @@ jobs:
     name: Post nightly workflow links
     needs: [authorize, dispatch-a2, dispatch-a3]
     if: always() && needs.authorize.outputs.is_authorized == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     steps:
       - name: Build comment body
         id: body

--- a/.github/workflows/pr_rerun_command.yml
+++ b/.github/workflows/pr_rerun_command.yml
@@ -30,10 +30,14 @@ permissions:
 jobs:
   rerun:
     name: Re-run failed CI jobs
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     outputs:
       rerun_count: ${{ steps.rerun.outputs.rerun_count }}
     steps:
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -y && sudo apt-get install -y jq gh
+
       - name: Check user authorization
         id: auth
         env:
@@ -147,7 +151,7 @@ jobs:
             if [ -n "$RERUNNED" ]; then
               echo "[Bot]: rerun completed."
               echo ""
-              echo "**Re-ran:**$RERUNNED"
+              echo "**Rerun:**$RERUNNED"
               echo ""
             fi
             if [ -n "$FAILED" ]; then

--- a/.github/workflows/schedule_stale_manage.yaml
+++ b/.github/workflows/schedule_stale_manage.yaml
@@ -8,17 +8,20 @@ on:
 jobs:
   remove-wait-feedback-on-comment:
     if: ${{ github.event_name == 'issue_comment' && contains(github.event.issue.labels.*.name, 'wait-feedback') }}
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     permissions:
       issues: write
     steps:
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -y && sudo apt-get install -y gh
       # When an issue tagged with "wait-feedback" receives a new response, the "wait-feedback" tag will be removed.
       - run: gh issue edit "${{ github.event.issue.number }}" --remove-label "wait-feedback" --repo "${{ github.repository }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   stale:
     if: ${{ github.event_name == 'schedule' }}
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     permissions:
       actions: write
       issues: write

--- a/.github/workflows/slash_command_dispatch.yml
+++ b/.github/workflows/slash_command_dispatch.yml
@@ -23,7 +23,8 @@ on:
 
 jobs:
   slashCommandDispatch:
-    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request != null && github.event.comment.user.type == 'User'
+    runs-on: linux-amd64-cpu-8-hk
     steps:
       - name: Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@v5
@@ -52,6 +53,6 @@ jobs:
               {
                 "command": "nightly",
                 "permission": "none",
-                "issue_type": "both"
+                "issue_type": "pull-request"
               }
             ]


### PR DESCRIPTION
Move some jobs' runner from github to selfhost to speed up CI.

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
