### PR TITLE
[Doc][Misc] Update release config for v0.21.0rc1

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ copyright = "2025, vllm-ascend team"
 author = "the vllm-ascend team"
 
 # The full version, including alpha/beta/rc tags
-release = "0.20.2rc1"
+release = "0.21.0rc1"
 
 # -- General configuration ---------------------------------------------------
 
@@ -74,15 +74,15 @@ myst_substitutions = {
     # the branch of vllm, used in vllm clone
     # - main branch: 'main'
     # - vX.Y.Z branch: 'vX.Y.Z'
-    "vllm_version": "v0.20.2",
+    "vllm_version": "v0.21.0",
     # the branch of vllm-ascend, used in vllm-ascend clone and image tag
     # - main branch: 'main'
     # - vX.Y.Z branch: latest vllm-ascend release tag
-    "vllm_ascend_version": "v0.20.2rc1",
+    "vllm_ascend_version": "v0.21.0rc1",
     # the newest release version of vllm-ascend and matched vLLM, used in pip install.
     # This value should be updated when cut down release.
-    "pip_vllm_ascend_version": "0.20.2rc1",
-    "pip_vllm_version": "0.20.2",
+    "pip_vllm_ascend_version": "0.21.0rc1",
+    "pip_vllm_version": "0.21.0",
     # CANN image tag paired with the vllm_ascend_version above
     "cann_image_tag": "9.0.0-910b-ubuntu22.04-py3.11",
     # vLLM commit hash for main branch


### PR DESCRIPTION
### What this PR does / why we need it?
Update docs/source/conf.py release metadata and version substitutions for the v0.21.0rc1 release line.

### Does this PR introduce _any_ user-facing change?
No. Documentation configuration only.

### How was this patch tested?
Not run; configuration-only documentation update.
- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
