### PR TITLE
[Feature] Selectively collect eplb heat for prefill/decode requests.

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -150,6 +150,7 @@ The details of each configuration option are as follows:
 | `expert_map_record_path`         | str | `None` | Save the expert load calculation results to a new expert table in the specified directory.|
 | `num_redundant_experts`          | int | `0`    | Specify redundant experts during initialization. |
 | `eplb_policy_type`               | int | `1`    | EPLB balancing policy: `0`=Random, `1`=DefaultEplb (open-source algorithm), `2`=SwiftBalanceEplb (optimized for low-bandwidth), `3`=FlashLB (statistical method with sliding windows). |
+| `eplb_heat_collection_stage`      | str | `"all"`| Stage to collect EPLB heat: `"prefill"` collects only during prefill, `"decode"` collects only during decode, `"all"` collects during both stages. In PD colocation scenarios, prefill and decode requests may produce different expert workloads. Selectively collecting heat on one stage can reduce expert imbalance more effectively. |
 
 **profiling_chunk_config**
 

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -652,7 +652,12 @@ class TestAscendFusedMoE:
         monkeypatch.setattr(
             fused_moe_module,
             "_EXTRA_CTX",
-            SimpleNamespace(in_profile_run=True, moe_comm_method=moe_comm_method, flash_comm_v1_enabled=True),
+            SimpleNamespace(
+                in_profile_run=True,
+                moe_comm_method=moe_comm_method,
+                flash_comm_v1_enabled=True,
+                eplb_heat_collection_status=False,
+            ),
         )
 
         result = layer.forward_impl(hidden_states, router_logits, return_with_event=return_with_event)
@@ -723,7 +728,12 @@ class TestAscendFusedMoE:
         monkeypatch.setattr(
             fused_moe_module,
             "_EXTRA_CTX",
-            SimpleNamespace(in_profile_run=False, moe_comm_method=moe_comm_method, flash_comm_v1_enabled=False),
+            SimpleNamespace(
+                in_profile_run=False,
+                moe_comm_method=moe_comm_method,
+                flash_comm_v1_enabled=False,
+                eplb_heat_collection_status=True,
+            ),
         )
 
         layer.forward_impl(torch.zeros(2, 4), torch.zeros(2, 2))

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -656,7 +656,7 @@ class TestAscendFusedMoE:
                 in_profile_run=True,
                 moe_comm_method=moe_comm_method,
                 flash_comm_v1_enabled=True,
-                eplb_heat_collection_status=False,
+                eplb_heat_collection_status=True,
             ),
         )
 

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -723,6 +723,7 @@ class EplbConfig:
         "expert_map_record_path": None,
         "num_redundant_experts": 0,
         "eplb_policy_type": 1,
+        "eplb_heat_collection_stage": "all",
     }
 
     def __init__(self, user_config: dict | None = None):
@@ -768,6 +769,8 @@ class EplbConfig:
                 os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1")
                 or os.getenv("EXPERT_MAP_RECORD", "false") == "true"
             ), "The environment variable DYNAMIC_EPLB or EXPERT_MAP_RECORD of the EPLB must be set to true."
+        if self.eplb_heat_collection_stage not in ["all", "prefill", "decode"]:
+            raise ValueError('eplb_heat_collection_stage must be one of ["all", "prefill", "decode"]')
 
         logger.info("Dynamic EPLB is %s", self.config["dynamic_eplb"])
         logger.info("The number of redundant experts is %s", self.config["num_redundant_experts"])

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -70,7 +70,7 @@ def set_ascend_forward_context(
     draft_attn_metadatas=None,
     has_sinks=False,
     input_ids=None,
-    eplb_heat_collection_status: bool = True,
+    eplb_heat_collection_status: bool = False,
 ):
     """A context manager that stores the current forward context,
     can be attention metadata, etc.

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -70,6 +70,7 @@ def set_ascend_forward_context(
     draft_attn_metadatas=None,
     has_sinks=False,
     input_ids=None,
+    eplb_heat_collection_status: bool = True,
 ):
     """A context manager that stores the current forward context,
     can be attention metadata, etc.
@@ -173,6 +174,8 @@ def set_ascend_forward_context(
 
         forward_context.max_tokens_across_dp = max_tokens_across_dp
         forward_context.max_tokens_across_pcp = max_tokens_across_pcp
+
+        forward_context.eplb_heat_collection_status = eplb_heat_collection_status
 
         if num_tokens is not None:
             if num_actual_tokens is None:
@@ -346,6 +349,7 @@ class _ExtraForwardContextProxy:
         "in_profile_run",
         "padded_num_tokens",
         "sinks",
+        "eplb_heat_collection_status",
     )
 
     def check_extra_attr(self, name: str):

--- a/vllm_ascend/eplb/eplb_updator.py
+++ b/vllm_ascend/eplb/eplb_updator.py
@@ -124,7 +124,7 @@ class EplbUpdator:
                 self.reqs = []
                 self.eplb_loader.asyn_expert_weight_transfer(self.reqs)
 
-    def forward_end(self, needs_dynamic_eplb: bool = False):
+    def forward_end(self, eplb_heat_collection_status: bool = True):
         if self.wakeup_eplb_worker_flag():
             with record_function_or_nullcontext("EPLB gather moe load"):
                 self.compute_and_set_moe_load()
@@ -133,7 +133,11 @@ class EplbUpdator:
         if self.update_expert_weight_flag() and self.expert_map_record_path is None:
             self.eplb_loader.update_expert_map_and_weight(self.reqs)
 
-        if self.cur_iterations >= self.expert_heat_collection_interval - 1 or needs_dynamic_eplb:
+        # One circle of eplb update includes expert_heat_collection_interval + algorithm_execution_interval
+        # + num_moe_layers (for weight update). In expert_heat_collection stage, we only update the counter
+        # when eplb_heat_collection_status is True. In later stages, the counter is always updated.
+        # TODO(Angazenn): Decouple algorithm execution && weight update with heat collection iterations.
+        if self.cur_iterations >= self.expert_heat_collection_interval - 1 or eplb_heat_collection_status:
             self.update_iteration()
 
     def compute_and_set_moe_load(self):

--- a/vllm_ascend/eplb/eplb_updator.py
+++ b/vllm_ascend/eplb/eplb_updator.py
@@ -124,7 +124,7 @@ class EplbUpdator:
                 self.reqs = []
                 self.eplb_loader.asyn_expert_weight_transfer(self.reqs)
 
-    def forward_end(self):
+    def forward_end(self, needs_dynamic_eplb: bool = False):
         if self.wakeup_eplb_worker_flag():
             with record_function_or_nullcontext("EPLB gather moe load"):
                 self.compute_and_set_moe_load()
@@ -133,7 +133,8 @@ class EplbUpdator:
         if self.update_expert_weight_flag() and self.expert_map_record_path is None:
             self.eplb_loader.update_expert_map_and_weight(self.reqs)
 
-        self.update_iteration()
+        if self.cur_iterations >= self.expert_heat_collection_interval - 1 or needs_dynamic_eplb:
+            self.update_iteration()
 
     def compute_and_set_moe_load(self):
         local_load = self.adaptor.get_rank_expert_workload().unsqueeze(1)

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -696,7 +696,7 @@ class AscendFusedMoE(FusedMoE):
             mc2_mask=mc2_mask,
         )
 
-        if self.dynamic_eplb:
+        if self.dynamic_eplb and _EXTRA_CTX.eplb_heat_collection_status:
             expert_tokens = fused_experts_results.expert_tokens
             group_list_type = fused_experts_results.group_list_type
             assert expert_tokens is not None and group_list_type is not None, (

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2241,7 +2241,7 @@ class NPUModelRunner(GPUModelRunner):
                 skip_compiled=has_encoder_input,
                 has_sinks=self._has_sinks,
                 input_ids=input_ids,
-                eplb_heat_collection_status=self.eplb_heat_collection_status if self.self.dynamic_eplb else False,
+                eplb_heat_collection_status=self.eplb_heat_collection_status if self.dynamic_eplb else False,
             ),
             self.maybe_get_kv_connector_output(
                 scheduler_output,
@@ -3522,7 +3522,7 @@ class NPUModelRunner(GPUModelRunner):
                 model_instance=self.model,
                 has_sinks = self._has_sinks,
                 input_ids=input_ids,
-                eplb_heat_collection_status=self.eplb_heat_collection_status if self.self.dynamic_eplb else False,
+                eplb_heat_collection_status=self.eplb_heat_collection_status if self.dynamic_eplb else False,
             ):
                 outputs = self._model_forward(
                     num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2241,7 +2241,7 @@ class NPUModelRunner(GPUModelRunner):
                 skip_compiled=has_encoder_input,
                 has_sinks=self._has_sinks,
                 input_ids=input_ids,
-                eplb_heat_collection_status=self.eplb_heat_collection_status,
+                eplb_heat_collection_status=self.eplb_heat_collection_status if self.self.dynamic_eplb else False,
             ),
             self.maybe_get_kv_connector_output(
                 scheduler_output,
@@ -3522,7 +3522,7 @@ class NPUModelRunner(GPUModelRunner):
                 model_instance=self.model,
                 has_sinks = self._has_sinks,
                 input_ids=input_ids,
-                eplb_heat_collection_status=self.eplb_heat_collection_status,
+                eplb_heat_collection_status=self.eplb_heat_collection_status if self.self.dynamic_eplb else False,
             ):
                 outputs = self._model_forward(
                     num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -499,10 +499,10 @@ class NPUModelRunner(GPUModelRunner):
             self.process = self.eplb_process._launch_process()
             self.eplb_updator = EplbUpdator(eplb_config, self.eplb_loader, self.eplb_process, self.process)
             # In pd colocation scenarios, we find that prefill/decode requests result in different
-            # expert worloads. To reduce expert imbalance more effectively, we can coolect eplb
+            # expert workloads. To reduce expert imbalance more effectively, we can coolect eplb
             # heat exclusively on a single stage rather than both prefill/decode.
             self.eplb_heat_collection_stage = eplb_config.eplb_heat_collection_stage
-            # Currently, we set the maxinum of tokens in decode stage as the threshold to distinguish
+            # Currently, we set the maximum of tokens in decode stage as the threshold to distinguish
             # prefill with decode.
             self.eplb_pd_thresholds = self.max_num_reqs * self.uniform_decode_query_len
             self.eplb_heat_collection_status = True

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3601,13 +3601,13 @@ class NPUModelRunner(GPUModelRunner):
     def update_eplb_heat_collection_status(self, num_tokens_padded: int):
         if self.eplb_heat_collection_stage == "prefill":
             # collect eplb heat for prefill requests.
-            return num_tokens_padded > self.eplb_pd_thresholds
+            self.eplb_heat_collection_status = num_tokens_padded > self.eplb_pd_thresholds
         elif self.eplb_heat_collection_stage == "decode":
             # collect eplb heat for decode requests.
-            return num_tokens_padded <= self.eplb_pd_thresholds
+            self.eplb_heat_collection_status = num_tokens_padded <= self.eplb_pd_thresholds
         else:
             # collect eplb heat for all requests.
-            return True
+            self.eplb_heat_collection_status =  True
 
     def load_model(self) -> None:
         logger.info("Starting to load model %s...", self.model_config.model)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -498,6 +498,15 @@ class NPUModelRunner(GPUModelRunner):
             self.eplb_process = EplbProcess(shared_dict=self.shared_dict, policy_type=self.policy_type, enable_d2d=True)
             self.process = self.eplb_process._launch_process()
             self.eplb_updator = EplbUpdator(eplb_config, self.eplb_loader, self.eplb_process, self.process)
+            # In pd colocation scenarios, we find that prefill/decode requests result in different
+            # expert worloads. To reduce expert imbalance more effectively, we can coolect eplb
+            # heat exclusively on a single stage rather than both prefill/decode.
+            self.eplb_heat_collection_stage = eplb_config.eplb_heat_collection_stage
+            # Currently, we set the maxinum of tokens in decode stage as the threshold to distinguish
+            # prefill with decode.
+            self.eplb_pd_thresholds = self.max_num_reqs * self.uniform_decode_query_len
+            self.eplb_heat_collection_status = True
+
         # Input Batch
         # NOTE(Chen): Ideally, we should initialize the input batch inside
         # `initialize_kv_cache` based on the kv cache config. However, as in
@@ -2078,6 +2087,9 @@ class NPUModelRunner(GPUModelRunner):
                     self.parallel_config.num_ubatches,
                 )
 
+                if self.dynamic_eplb:
+                    self.update_eplb_heat_collection_status(num_tokens_padded)
+
                 pad_attn = cudagraph_mode == CUDAGraphMode.FULL
 
                 # NOTE(Angazenn): According to https://github.com/vllm-project/vllm/pull/30877,
@@ -2229,6 +2241,7 @@ class NPUModelRunner(GPUModelRunner):
                 skip_compiled=has_encoder_input,
                 has_sinks=self._has_sinks,
                 input_ids=input_ids,
+                eplb_heat_collection_status=self.eplb_heat_collection_status,
             ),
             self.maybe_get_kv_connector_output(
                 scheduler_output,
@@ -2477,7 +2490,7 @@ class NPUModelRunner(GPUModelRunner):
             model_runner_output.execution_time_ms = (time.perf_counter() - self._execution_start_time) * 1000.0
 
         if self.dynamic_eplb:
-            self.eplb_updator.forward_end()
+            self.eplb_updator.forward_end(self.eplb_heat_collection_status)
 
         self._finalize_dump_data()
 
@@ -3365,6 +3378,10 @@ class NPUModelRunner(GPUModelRunner):
             # pad is needed if the pad of `num_tokens` is triggered inside CudagraphDispatcher
             num_tokens_across_dp[:] = num_tokens_padded
             num_scheduled_tokens = num_scheduled_tokens.repeat(num_reqs_padded)
+        
+        if self.dynamic_eplb:
+            self.update_eplb_heat_collection_status(num_tokens_padded)
+        
         # vllm-ascend does not support ubatch now
         ubatch_slices, ubatch_slices_padded = None, None
         attn_metadata: PerLayerAttnMetadata | None = None
@@ -3505,6 +3522,7 @@ class NPUModelRunner(GPUModelRunner):
                 model_instance=self.model,
                 has_sinks = self._has_sinks,
                 input_ids=input_ids,
+                eplb_heat_collection_status=self.eplb_heat_collection_status,
             ):
                 outputs = self._model_forward(
                     num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds
@@ -3530,8 +3548,8 @@ class NPUModelRunner(GPUModelRunner):
             if is_profile and self.dynamic_eplb:
                 target = self.model.language_model if hasattr(self.model, "language_model") else self.model
                 target.clear_all_moe_loads()
-            if self.dynamic_eplb:
-                self.eplb_updator.forward_end()
+            if not is_profile and self.dynamic_eplb:
+                self.eplb_updator.forward_end(self.eplb_heat_collection_status)
             self._finalize_dump_data(dump=False)
             if self.use_compress and force_attention:
                 self.positions.fill_(0)
@@ -3579,6 +3597,17 @@ class NPUModelRunner(GPUModelRunner):
             self.eplb_loader.set_adator(self.eplb_adaptor)
             self.eplb_updator.set_adaptor(self.eplb_adaptor)
             self.eplb_updator.warm_up_eplb()
+
+    def update_eplb_heat_collection_status(self, num_tokens_padded: int):
+        if self.eplb_heat_collection_stage == "prefill":
+            # collect eplb heat for prefill requests.
+            return num_tokens_padded > self.eplb_pd_thresholds
+        elif self.eplb_heat_collection_stage == "decode":
+            # collect eplb heat for decode requests.
+            return num_tokens_padded <= self.eplb_pd_thresholds
+        else:
+            # collect eplb heat for all requests.
+            return True
 
     def load_model(self) -> None:
         logger.info("Starting to load model %s...", self.model_config.model)


### PR DESCRIPTION
### What this PR does / why we need it?
This PR supports to selectively collect expert heat on a specific stage (prefill/decode). 
We observe that the expert hotness is different between prefill(usually with a large number of tokens)/decode(usually with a small number of tokens) stages. In PD colocation scenarios, simply collecting hotness for all requests does not decrease expert load imbalance effectively. By collecting hotness exclusively at prefill or decode stages, we can balance expert workload to reduce TTFT/TPOT.

### Does this PR introduce _any_ user-facing change?
Yes. We introduce "eplb_heat_collection_stage" to choose stages.

### How was this patch tested?


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
