### PR TITLE
[Feature][Performance] Support o-proj TP weights async allgather in DSA-CP

### DIFF
--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1196,8 +1196,14 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 AscendAttentionState.SpecDecoding,
             }
         )
-        o_proj_full_handles = self._maybe_all_gather_o_proj_full_weight(full_gather_wo_a_enabled)
-        local_attn_output = self._forward(layer_name, hidden_states, kv_cache, attn_metadata, need_gather_q_kv)
+        local_attn_output, o_proj_full_handles = self._forward(
+            layer_name,
+            hidden_states,
+            kv_cache,
+            attn_metadata,
+            need_gather_q_kv,
+            full_gather_wo_a_enabled,
+        )
         o_proj_input = self._restore_tp_head_layout(
             local_attn_output,
             layer_name,
@@ -1260,6 +1266,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         kv_cache: tuple,
         attn_metadata: list[M],
         need_gather_q_kv: bool = False,
+        full_gather_wo_a_enabled: bool = False,
     ):
         """Run full-sequence KV cache updates and local-token attention."""
         (compress_kv_cache, swa_kv_cache, state_cache, _, _, _) = DeviceOperator.unpack_dsa_forward_kv_cache(
@@ -1346,6 +1353,8 @@ class AscendDSACPImpl(DSAAttentionImpl):
             rotary_mode="interleave",
             partial_slice=[self.nope_head_dim, self.head_dim],
         )
+
+        o_proj_full_handles = self._maybe_all_gather_o_proj_full_weight(full_gather_wo_a_enabled)
 
         kv = self.wkv(hidden_states_cache)
         kv = self.kv_norm(kv)
@@ -1472,7 +1481,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 cmp_mask_mode=3,
                 **common_attn_kwargs,
             )[0]
-        return attn_output
+        return attn_output, o_proj_full_handles
 
     def _restore_tp_head_layout(
         self,

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -968,7 +968,9 @@ class AscendDSACPImpl(DSAAttentionImpl):
         self.wo_a = kwargs["wo_a"]
         self.wo_b = kwargs["wo_b"]
         
-        self.enable_dsa_cp_with_o_proj_tp = enable_dsa_cp_with_o_proj_tp() and (get_ascend_device_type() == AscendDeviceType.A5)
+        self.enable_dsa_cp_with_o_proj_tp = enable_dsa_cp_with_o_proj_tp() and (
+            get_ascend_device_type() == AscendDeviceType.A5
+        )
         self._wo_a_dynamic_quant = False
         self._wo_b_dynamic_quant = False
 

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -967,7 +967,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
 
         self.wo_a = kwargs["wo_a"]
         self.wo_b = kwargs["wo_b"]
-        
+
         self.enable_dsa_cp_with_o_proj_tp = enable_dsa_cp_with_o_proj_tp() and (
             get_ascend_device_type() == AscendDeviceType.A5
         )

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -967,7 +967,8 @@ class AscendDSACPImpl(DSAAttentionImpl):
 
         self.wo_a = kwargs["wo_a"]
         self.wo_b = kwargs["wo_b"]
-        self.enable_dsa_cp_with_o_proj_tp = enable_dsa_cp_with_o_proj_tp()
+        
+        self.enable_dsa_cp_with_o_proj_tp = enable_dsa_cp_with_o_proj_tp() and (get_ascend_device_type() == AscendDeviceType.A5)
         self._wo_a_dynamic_quant = False
         self._wo_b_dynamic_quant = False
 

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -16,11 +16,13 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.distributed.utils import all_gather_async
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa, get_full_cos_and_sin_dsa
 from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.utils import (
     AscendDeviceType,
+    enable_dsa_cp_with_o_proj_tp,
     get_ascend_device_type,
     olora_tp_enable,
 )
@@ -914,6 +916,11 @@ class AscendDSACPImpl(DSAAttentionImpl):
     understand this class
     """
 
+    wo_a_full_pool: ClassVar[torch.Tensor | None] = None
+    wo_a_full_weight_scale_pool: ClassVar[torch.Tensor | None] = None
+    wo_b_full_pool: ClassVar[torch.Tensor | None] = None
+    wo_b_full_weight_scale_pool: ClassVar[torch.Tensor | None] = None
+
     def __init__(
         self,
         n_heads: int,
@@ -960,6 +967,9 @@ class AscendDSACPImpl(DSAAttentionImpl):
 
         self.wo_a = kwargs["wo_a"]
         self.wo_b = kwargs["wo_b"]
+        self.enable_dsa_cp_with_o_proj_tp = enable_dsa_cp_with_o_proj_tp()
+        self._wo_a_dynamic_quant = False
+        self._wo_b_dynamic_quant = False
 
         self.eps = kwargs["eps"]
 
@@ -1035,6 +1045,132 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 "DSA-CP expects full-head attn_sink loaded on every TP rank, "
                 f"got {self.attn_sink.numel()} heads, expected {self.num_heads}."
             )
+        if self.enable_dsa_cp_with_o_proj_tp:
+            self._maybe_init_o_proj_tp_full_params()
+
+    @staticmethod
+    def _check_dynamic_quant(layer: torch.nn.Module) -> bool:
+        return get_ascend_device_type() in {AscendDeviceType.A5} and hasattr(layer, "weight_scale")
+
+    def _maybe_init_o_proj_tp_full_params(self) -> None:
+        self._wo_a_dynamic_quant = type(self)._check_dynamic_quant(self.wo_a)
+        self._wo_b_dynamic_quant = type(self)._check_dynamic_quant(self.wo_b)
+        if AscendDSACPImpl.wo_a_full_pool is None:
+            sample = self.wo_a.weight
+            AscendDSACPImpl.wo_a_full_pool = torch.empty(
+                (sample.shape[0] * self.tp_size, *sample.shape[1:]),
+                dtype=sample.dtype,
+                device=sample.device,
+            )
+        self.wo_a_tp_weight = self.wo_a.weight.clone().detach().contiguous()
+        self.wo_a.weight.set_(self.wo_a_tp_weight)
+        if AscendDSACPImpl.wo_b_full_pool is None:
+            sample = self.wo_b.weight
+            AscendDSACPImpl.wo_b_full_pool = torch.empty(
+                (sample.shape[0] * self.tp_size, *sample.shape[1:]),
+                dtype=sample.dtype,
+                device=sample.device,
+            )
+        self.wo_b_tp_weight = self.wo_b.weight.clone().detach().contiguous()
+        self.wo_b.weight.set_(self.wo_b_tp_weight)
+
+        if self._wo_a_dynamic_quant:
+            if AscendDSACPImpl.wo_a_full_weight_scale_pool is None:
+                sample = self.wo_a.weight_scale
+                AscendDSACPImpl.wo_a_full_weight_scale_pool = torch.empty(
+                    (sample.shape[0] * self.tp_size, *sample.shape[1:]),
+                    dtype=sample.dtype,
+                    device=sample.device,
+                )
+            self.wo_a_tp_weight_scale = self.wo_a.weight_scale.clone().detach().contiguous()
+            self.wo_a.weight_scale.set_(self.wo_a_tp_weight_scale)
+        if self._wo_b_dynamic_quant:
+            if AscendDSACPImpl.wo_b_full_weight_scale_pool is None:
+                sample = self.wo_b.weight_scale
+                AscendDSACPImpl.wo_b_full_weight_scale_pool = torch.empty(
+                    (sample.shape[0] * self.tp_size, *sample.shape[1:]),
+                    dtype=sample.dtype,
+                    device=sample.device,
+                )
+            self.wo_b_tp_weight_scale = self.wo_b.weight_scale.clone().detach().contiguous()
+            self.wo_b.weight_scale.set_(self.wo_b_tp_weight_scale)
+
+    def _maybe_all_gather_o_proj_full_weight(
+        self,
+        enabled: bool,
+    ) -> list[torch.distributed.Work]:
+        if not enabled:
+            return []
+        handles = []
+        assert AscendDSACPImpl.wo_a_full_pool is not None
+        _, weight_handle = all_gather_async(
+            self.wo_a_tp_weight,
+            self.tp_group,
+            output=AscendDSACPImpl.wo_a_full_pool,
+        )
+        if weight_handle is not None:
+            handles.append(weight_handle)
+        assert AscendDSACPImpl.wo_b_full_pool is not None
+        _, wo_b_weight_handle = all_gather_async(
+            self.wo_b_tp_weight,
+            self.tp_group,
+            output=AscendDSACPImpl.wo_b_full_pool,
+        )
+        if wo_b_weight_handle is not None:
+            handles.append(wo_b_weight_handle)
+        if self._wo_a_dynamic_quant:
+            assert AscendDSACPImpl.wo_a_full_weight_scale_pool is not None
+            _, weight_scale_handle = all_gather_async(
+                self.wo_a_tp_weight_scale,
+                self.tp_group,
+                output=AscendDSACPImpl.wo_a_full_weight_scale_pool,
+            )
+            if weight_scale_handle is not None:
+                handles.append(weight_scale_handle)
+        if self._wo_b_dynamic_quant:
+            assert AscendDSACPImpl.wo_b_full_weight_scale_pool is not None
+            _, wo_b_weight_scale_handle = all_gather_async(
+                self.wo_b_tp_weight_scale,
+                self.tp_group,
+                output=AscendDSACPImpl.wo_b_full_weight_scale_pool,
+            )
+            if wo_b_weight_scale_handle is not None:
+                handles.append(wo_b_weight_scale_handle)
+        return handles
+
+    def _switch_o_proj_to_full_weight(
+        self,
+        handles: list[torch.distributed.Work],
+    ) -> None:
+        for handle in handles:
+            handle.wait()
+        assert AscendDSACPImpl.wo_a_full_pool is not None
+        self.wo_a.weight.set_(AscendDSACPImpl.wo_a_full_pool)
+        if self._wo_a_dynamic_quant:
+            assert AscendDSACPImpl.wo_a_full_weight_scale_pool is not None
+            self.wo_a.weight_scale.set_(AscendDSACPImpl.wo_a_full_weight_scale_pool)
+        assert AscendDSACPImpl.wo_b_full_pool is not None
+        self.wo_b.weight.set_(AscendDSACPImpl.wo_b_full_pool)
+        if self._wo_b_dynamic_quant:
+            assert AscendDSACPImpl.wo_b_full_weight_scale_pool is not None
+            self.wo_b.weight_scale.set_(AscendDSACPImpl.wo_b_full_weight_scale_pool)
+
+    def _switch_o_proj_to_tp_weight(self) -> None:
+        self.wo_a.weight.set_(self.wo_a_tp_weight)
+        if self._wo_a_dynamic_quant:
+            self.wo_a.weight_scale.set_(self.wo_a_tp_weight_scale)
+        self.wo_b.weight.set_(self.wo_b_tp_weight)
+        if self._wo_b_dynamic_quant:
+            self.wo_b.weight_scale.set_(self.wo_b_tp_weight_scale)
+
+    def _apply_wo_b(
+        self,
+        o_proj_input: torch.Tensor,
+        full_weight: bool,
+    ) -> torch.Tensor:
+        if not full_weight:
+            return self.wo_b(o_proj_input)
+        return self.wo_b.quant_method.apply(self.wo_b, o_proj_input, bias=None)
 
     def forward(  # type: ignore[override]
         self,
@@ -1051,47 +1187,69 @@ class AscendDSACPImpl(DSAAttentionImpl):
             return output.fill_(0)
         if not isinstance(attn_metadata, list):
             attn_metadata = [attn_metadata]
+        full_gather_wo_a_enabled = (
+            self.tp_size > 1
+            and self.enable_dsa_cp_with_o_proj_tp
+            and attn_metadata[0].attn_state
+            not in {
+                AscendAttentionState.DecodeOnly,
+                AscendAttentionState.SpecDecoding,
+            }
+        )
+        o_proj_full_handles = self._maybe_all_gather_o_proj_full_weight(full_gather_wo_a_enabled)
         local_attn_output = self._forward(layer_name, hidden_states, kv_cache, attn_metadata, need_gather_q_kv)
-        o_proj_input = self._restore_tp_head_layout(local_attn_output, layer_name, attn_metadata[0])
+        o_proj_input = self._restore_tp_head_layout(
+            local_attn_output,
+            layer_name,
+            attn_metadata[0],
+            skip_all_to_all=full_gather_wo_a_enabled,
+        )
         num_tokens = o_proj_input.shape[0]
 
         # o
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
-            o = o_proj_input.view(num_tokens, self.n_local_groups, -1)
-            o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
-            o = torch_npu.npu_transpose_quant_batchmatmul(
-                o,
-                self.wo_a.weight,
-                dtype=torch.bfloat16,
-                bias=None,
-                group_sizes=(0, 0, 32),
-                x1_scale=swiglu_out_scale.view(torch.float8_e8m0fnu),
-                x2_scale=self.wo_a.weight_scale.view(torch.float8_e8m0fnu),
-                perm_x1=(1, 0, 2),
-                perm_x2=(0, 1, 2),
-                perm_y=(1, 0, 2),
-            )
-            o = o.reshape(num_tokens, -1)
-            output[...] = self.wo_b(o)
-        else:
-            o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, -1)
-            if olora_tp_enable():
-                o_proj_input = self.wo_a(o_proj_input)
-            else:
-                # wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
-                # o = torch.einsum("tgd,grd->tgr", o, wo_a)
-                o_proj_input = torch_npu.npu_transpose_batchmatmul(
-                    o_proj_input,
+        if full_gather_wo_a_enabled:
+            self._switch_o_proj_to_full_weight(o_proj_full_handles)
+        o_proj_groups = self.n_group if full_gather_wo_a_enabled else self.n_local_groups
+        try:
+            if get_ascend_device_type() in {AscendDeviceType.A5}:
+                o = o_proj_input.view(num_tokens, o_proj_groups, -1)
+                o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
+                o = torch_npu.npu_transpose_quant_batchmatmul(
+                    o,
                     self.wo_a.weight,
+                    dtype=torch.bfloat16,
                     bias=None,
-                    scale=None,
+                    group_sizes=(0, 0, 32),
+                    x1_scale=swiglu_out_scale.view(torch.float8_e8m0fnu),
+                    x2_scale=self.wo_a.weight_scale.view(torch.float8_e8m0fnu),
                     perm_x1=(1, 0, 2),
                     perm_x2=(0, 1, 2),
                     perm_y=(1, 0, 2),
-                    batch_split_factor=1,
                 )
-            o_proj_input = o_proj_input.reshape(num_tokens, -1)
-            output[...] = self.wo_b(o_proj_input)
+                o = o.reshape(num_tokens, -1)
+                output[...] = self._apply_wo_b(o, full_gather_wo_a_enabled)
+            else:
+                o_proj_input = o_proj_input.view(num_tokens, o_proj_groups, -1)
+                if olora_tp_enable():
+                    o_proj_input = self.wo_a(o_proj_input)
+                else:
+                    # wo_a = self.wo_a.weight.view(o_proj_groups, self.o_lora_rank, -1)
+                    # o = torch.einsum("tgd,grd->tgr", o, wo_a)
+                    o_proj_input = torch_npu.npu_transpose_batchmatmul(
+                        o_proj_input,
+                        self.wo_a.weight,
+                        bias=None,
+                        scale=None,
+                        perm_x1=(1, 0, 2),
+                        perm_x2=(0, 1, 2),
+                        perm_y=(1, 0, 2),
+                        batch_split_factor=1,
+                    )
+                o_proj_input = o_proj_input.reshape(num_tokens, -1)
+                output[...] = self._apply_wo_b(o_proj_input, full_gather_wo_a_enabled)
+        finally:
+            if full_gather_wo_a_enabled:
+                self._switch_o_proj_to_tp_weight()
 
         return output
 
@@ -1321,6 +1479,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         local_attn_output: torch.Tensor,
         layer_name: str,
         attn_metadata: M,
+        skip_all_to_all: bool = False,
     ) -> torch.Tensor:
         assert attn_metadata.req_metadata is not None
         req_metadata = attn_metadata.req_metadata
@@ -1334,7 +1493,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             partial_slice=[self.nope_head_dim, self.head_dim],
         )
 
-        if self.tp_size == 1:
+        if self.tp_size == 1 or skip_all_to_all:
             return local_attn_output
 
         send = (

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -842,6 +842,30 @@
 #    Future Plan:
 #       The maybe_remap_kv_scale_name function of the community is reconstructed to support
 #       multiple backends.
+# ** 21b. File: worker/patch_process_weights_after_loading.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.model_executor.model_loader.utils.process_weights_after_loading`
+#      `vllm.model_executor.model_loader.base_loader.process_weights_after_loading`
+#      and imported references in vllm-ascend model loaders
+#    Why:
+#       DSA attention is implemented in vllm-ascend as the plugin layer
+#       `DSAAttention`. Upstream vLLM only runs post-load attention weight
+#       processing for built-in attention classes, so
+#       `DSAAttention.process_weights_after_loading()` is skipped in the
+#       original loader flow. DSV4 DSA-CP o-proj TP initialization must run in
+#       this post-load phase rather than being initialized lazily in forward.
+#    How:
+#       Rebind the upstream `process_weights_after_loading` helper, including
+#       already-imported loader references, so `DSAAttention` participates in
+#       the same post-load traversal while preserving the original quant-method
+#       and torchao reload behavior.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm-ascend/pull/10694
+#       https://github.com/vllm-project/vllm/pull/46828
+#    Future Plan:
+#       Remove this patch once the supported vLLM version includes PR #46828.
+#       Then register `DSAAttention` through vLLM's post-load weight-processing
+#       registry instead of monkey-patching model-loader helpers.
 # ** 22. File: worker/patch_v2/patch_input_batch.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.worker.gpu.input_batch.InputBatch`

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -37,6 +37,7 @@ if HAS_TRITON:
         import vllm_ascend.patch.worker.patch_v2.patch_triton  # noqa
 
 
+import vllm_ascend.patch.worker.patch_process_weights_after_loading  # noqa
 import vllm_ascend.patch.worker.patch_weight_utils  # noqa
 import vllm_ascend.patch.worker.patch_distributed  # noqa
 import vllm_ascend.patch.worker.patch_minimax_m2  # noqa

--- a/vllm_ascend/patch/worker/patch_process_weights_after_loading.py
+++ b/vllm_ascend/patch/worker/patch_process_weights_after_loading.py
@@ -1,0 +1,63 @@
+import sys
+
+import torch
+from torch import nn
+
+from vllm.config import ModelConfig
+from vllm.model_executor.layers.attention import (
+    Attention,
+    MLAAttention,
+    MMEncoderAttention,
+)
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizeMethodBase,
+)
+from vllm.model_executor.model_loader import base_loader, utils
+from vllm.model_executor.model_loader.utils import device_loading_context
+from vllm.model_executor.model_loader.reload import set_torchao_reload_attrs
+
+from vllm_ascend.models.layer.attention.layer import DSAAttention
+
+
+def ascend_process_weights_after_loading(
+    model: nn.Module, model_config: ModelConfig, target_device: torch.device
+) -> None:
+    for _, module in model.named_modules():
+        quant_method = getattr(module, "quant_method", None)
+        if isinstance(quant_method, QuantizeMethodBase):
+            # When quant methods need to process weights after loading
+            # (for repacking, quantizing, etc), they expect parameters
+            # to be on the global target device. This scope is for the
+            # case where cpu offloading is used, where we will move the
+            # parameters onto device for processing and back off after.
+            with device_loading_context(module, target_device):
+                quant_method.process_weights_after_loading(module)
+
+    # Initialize post-load attention weights for Attention, MLA, and MM encoder.
+    # NOTE: Happens after other modules so we can easily decompress weights.
+    for _, module in model.named_modules():
+        if isinstance(
+            module, (Attention, MLAAttention, MMEncoderAttention, DSAAttention)
+        ) and hasattr(module, "process_weights_after_loading"):
+            # TODO(lucas): see if there is a way to unify the signatures
+            # of process_weights_after_loading
+            with device_loading_context(module, target_device):
+                module.process_weights_after_loading(model_config.dtype)
+
+    # Needed for torchao model reloading via model.reload_weights
+    # @kylesayrs @jerryzh168 this can be removed if callers move to `reload_weights`
+    if model_config.quantization == "torchao":
+        set_torchao_reload_attrs(model, model_config)
+
+
+utils.process_weights_after_loading = ascend_process_weights_after_loading
+base_loader.process_weights_after_loading = ascend_process_weights_after_loading
+
+vllm_ascend_loaders = [
+    "vllm_ascend.model_loader.netloader.netloader",
+    "vllm_ascend.model_loader.rfork.rfork_loader",
+]
+for loader_module in vllm_ascend_loaders:
+    loader = sys.modules.get(loader_module)
+    if loader is not None:
+        setattr(loader, "process_weights_after_loading", ascend_process_weights_after_loading)

--- a/vllm_ascend/patch/worker/patch_process_weights_after_loading.py
+++ b/vllm_ascend/patch/worker/patch_process_weights_after_loading.py
@@ -59,4 +59,4 @@ vllm_ascend_loaders = [
 for loader_module in vllm_ascend_loaders:
     loader = sys.modules.get(loader_module)
     if loader is not None:
-        loader.process_weights_after_loading = ascend_process_weights_after_loading
+        loader.__dict__["process_weights_after_loading"] = ascend_process_weights_after_loading

--- a/vllm_ascend/patch/worker/patch_process_weights_after_loading.py
+++ b/vllm_ascend/patch/worker/patch_process_weights_after_loading.py
@@ -15,7 +15,10 @@ from vllm.model_executor.model_loader import base_loader, utils
 from vllm.model_executor.model_loader.reload import set_torchao_reload_attrs
 from vllm.model_executor.model_loader.utils import device_loading_context
 
-from vllm_ascend.models.layer.attention.layer import DSAAttention
+
+def _is_dsa_attention(module: nn.Module) -> bool:
+    module_cls = type(module)
+    return module_cls.__module__ == "vllm_ascend.models.layer.attention.layer" and module_cls.__name__ == "DSAAttention"
 
 
 def ascend_process_weights_after_loading(
@@ -35,7 +38,7 @@ def ascend_process_weights_after_loading(
     # Initialize post-load attention weights for Attention, MLA, and MM encoder.
     # NOTE: Happens after other modules so we can easily decompress weights.
     for _, module in model.named_modules():
-        if isinstance(module, (Attention, MLAAttention, MMEncoderAttention, DSAAttention)) and hasattr(
+        if (isinstance(module, (Attention, MLAAttention, MMEncoderAttention)) or _is_dsa_attention(module)) and hasattr(
             module, "process_weights_after_loading"
         ):
             # TODO(lucas): see if there is a way to unify the signatures

--- a/vllm_ascend/patch/worker/patch_process_weights_after_loading.py
+++ b/vllm_ascend/patch/worker/patch_process_weights_after_loading.py
@@ -2,7 +2,6 @@ import sys
 
 import torch
 from torch import nn
-
 from vllm.config import ModelConfig
 from vllm.model_executor.layers.attention import (
     Attention,
@@ -13,8 +12,8 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from vllm.model_executor.model_loader import base_loader, utils
-from vllm.model_executor.model_loader.utils import device_loading_context
 from vllm.model_executor.model_loader.reload import set_torchao_reload_attrs
+from vllm.model_executor.model_loader.utils import device_loading_context
 
 from vllm_ascend.models.layer.attention.layer import DSAAttention
 
@@ -36,9 +35,9 @@ def ascend_process_weights_after_loading(
     # Initialize post-load attention weights for Attention, MLA, and MM encoder.
     # NOTE: Happens after other modules so we can easily decompress weights.
     for _, module in model.named_modules():
-        if isinstance(
-            module, (Attention, MLAAttention, MMEncoderAttention, DSAAttention)
-        ) and hasattr(module, "process_weights_after_loading"):
+        if isinstance(module, (Attention, MLAAttention, MMEncoderAttention, DSAAttention)) and hasattr(
+            module, "process_weights_after_loading"
+        ):
             # TODO(lucas): see if there is a way to unify the signatures
             # of process_weights_after_loading
             with device_loading_context(module, target_device):
@@ -60,4 +59,4 @@ vllm_ascend_loaders = [
 for loader_module in vllm_ascend_loaders:
     loader = sys.modules.get(loader_module)
     if loader is not None:
-        setattr(loader, "process_weights_after_loading", ascend_process_weights_after_loading)
+        loader.process_weights_after_loading = ascend_process_weights_after_loading


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds the missing DSV4 DSA-CP o-proj TP full-weight allgather path for prefill on top of the DSV4 DSA-CP A5 support merged by #10026.

When DSA-CP runs with o-proj TP enabled, prefill asynchronously allgathers the TP-local `wo_a` / `wo_b` projection weights, including MXFP8 weight scales when present, switches the projection layers to the gathered full buffers for the o-proj computation, and restores the TP-local tensors afterward. Decode and spec-decode keep the existing activation all-to-all behavior.

The weight allgather is started after hidden-state gathering and before the remaining KV projection / KV cache preparation work, so the communication can be overlapped and hidden by the following compute path instead of being paid as a fully serial step immediately before o-proj.

The PR also patches post-load weight processing so `DSAAttention.process_weights_after_loading()` is invoked from the same loader hook as other attention modules, allowing DSA-CP full-weight buffers to be initialized after weights are loaded instead of lazily in forward.

### Does this PR introduce _any_ user-facing change?
No user-facing API, configuration, environment variable, or schema changes. The change only affects the internal DSV4 DSA-CP o-proj TP execution path when the existing o-proj TP enablement is active.

### How was this patch tested?
- `python -m py_compile vllm_ascend/attention/context_parallel/dsa_cp.py vllm_ascend/patch/worker/patch_process_weights_after_loading.py`
- `git diff --check`

`ruff` was not run locally because it is not installed in the current environment.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
