### PR TITLE
[Refactor] enable npugraph_ex in PIECEWISE and FULL_AND_PIECEWISE modes

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -81,7 +81,6 @@ The following table lists additional configuration options available in vLLM Asc
 | `recompute_scheduler_enable`        | bool | `False` | Whether to enable the recompute scheduler. **Only valid in PD-disaggregated mode** (`kv_role` is `kv_producer` or `kv_consumer`). **Do not enable in PD-mixed mode** (no `kv_transfer_config`, or `kv_role` is `kv_both`); startup will fail with a clear error. |
 | `enable_cpu_binding`                | bool | `True`  | Enables Ascend-native CPU binding on ARM servers. Set to `False` to disable. See [CPU Binding](../feature_guide/cpu_binding.md). |
 | `SLO_limits_for_dynamic_batch`      | int  | `-1`    | SLO limits for dynamic batch. This is new scheduler to support dynamic batch feature                            |
-| `enable_npugraph_ex`                | bool | `False` | Whether to enable npugraph_ex graph mode.                                                                 |
 | `pa_shape_list`                     | list | `[]`    | The custom shape list of page attention ops.                                                              |
 | `enable_kv_nz`                      | bool | `False` | Whether to enable KV cache NZ layout. This option only takes effects on models using MLA (e.g., DeepSeek).                                      |
 | `layer_sharding`                    | dict | `{}`    | Configuration options for Layer Sharding Linear. Layer Sharding can only be enabled in PD-disaggregated's P node. |

--- a/docs/source/user_guide/feature_guide/graph_mode.md
+++ b/docs/source/user_guide/feature_guide/graph_mode.md
@@ -15,7 +15,7 @@ This document focuses on the Ascend-specific view: how graph mode works on Ascen
 
 - Graph mode is currently available only on the **V1 Engine**.
 - **ACLGraph** (capture/replay via `torch.npu.NPUGraph`) is the runtime graph execution mechanism used by the default graph path on Ascend.
-- **Npugraph_ex** is a compile-time FX graph optimization layer, enabled by default in FULL/FULL_DECODE_ONLY modes. It optimizes the graph before ACLGraph captures it.
+- **Npugraph_ex** is a compile-time FX graph optimization layer, enabled by default in all graph modes except NONE. It optimizes the graph before ACLGraph captures it.
 - **XliteGraph** is an optional graph path for selected model families and environments.
 - In context parallel scenarios, `cudagraph_mode="FULL"` is not sufficiently supported yet.
 
@@ -32,16 +32,16 @@ vLLM Ascend provides two graph paths:
 
 The default graph path on Ascend involves two stages: **compile-time optimization** and **runtime capture/replay**. ACLGraph handles the runtime capture/replay. The compile-time stage differs by `cudagraph_mode`:
 
-- **FULL_AND_PIECEWISE**: Default mode, same as the upstream vLLM strategy. The compile-time path follows PIECEWISE compilation, while the runtime may still use full-graph behavior for uniform decode batches.
+- **FULL_AND_PIECEWISE**: Default mode, same as the upstream vLLM strategy. The compile-time path follows PIECEWISE compilation with Npugraph_ex FX optimization. The runtime may still use full-graph behavior for uniform decode batches.
 - **FULL / FULL_DECODE_ONLY**: Npugraph_ex optimizes the FX graph via npugraph_ex (`force_eager=True`, compile-time only, no capture). The optimized callable is then captured and replayed by ACLGraph at runtime.
-- **PIECEWISE**: Npugraph_ex is disabled. Only basic FX fusion passes are applied at compile-time. ACLGraph captures and replays the resulting callable at runtime.
+- **PIECEWISE**: Npugraph_ex optimizes each FX subgraph at compile-time. ACLGraph captures and replays the resulting callable at runtime.
 - **NONE**: No compilation or graph capture. The model runs in eager mode.
 
 | `cudagraph_mode` | Compile-time | Runtime | Npugraph_ex |
 |---|---|---|---|
-| FULL_AND_PIECEWISE | Piecewise compilation path | Mixed: PIECEWISE for mixed batches, FULL-capable for uniform decode batches | Disabled |
+| FULL_AND_PIECEWISE | Piecewise compilation with Npugraph_ex FX optimization | Mixed: PIECEWISE for mixed batches, FULL-capable for uniform decode batches | Enabled |
 | FULL / FULL_DECODE_ONLY | Npugraph_ex FX optimization | ACLGraph capture/replay | Enabled |
-| PIECEWISE | Fusion pass only | ACLGraph capture/replay | Disabled |
+| PIECEWISE | Npugraph_ex FX optimization per subgraph | ACLGraph capture/replay | Enabled |
 | NONE | None | Eager execution | Disabled |
 
 Additionally, **XliteGraph** is available as an optional alternative graph path for selected model families (see [Using XliteGraph](#using-xlitegraph)).
@@ -125,14 +125,14 @@ As introduced in the [RFC](https://github.com/vllm-project/vllm-ascend/issues/47
 
 ### Default behavior
 
-Npugraph_ex is **enabled by default** when `cudagraph_mode` is `FULL` or `FULL_DECODE_ONLY`. It is automatically disabled in `PIECEWISE` or `NONE` modes.
+Npugraph_ex is **enabled by default** when `cudagraph_mode` is `FULL`, `FULL_DECODE_ONLY`, `FULL_AND_PIECEWISE`, or `PIECEWISE`. It is automatically disabled only in `NONE` mode.
 
 This means for most users, Npugraph_ex is active without any explicit configuration:
 
 ```python
 from vllm import LLM
 
-# Npugraph_ex is enabled by default in FULL/FULL_DECODE_ONLY mode
+# Npugraph_ex is enabled by default in all graph modes except NONE
 llm = LLM(model="path/to/Qwen2-7B-Instruct")
 outputs = llm.generate("Hello, how are you?")
 ```

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -652,7 +652,6 @@ class NPUPlatform(Platform):
             # TODO(2026/7/15): Delete the reduced gear after the new driver is released.
             if get_ascend_device_type() == AscendDeviceType.A5:
                 prune_capture_sizes_for_950(vllm_config)
-            ascend_config.ascend_compilation_config.enable_npugraph_ex = False
         elif compilation_config.cudagraph_mode.has_full_cudagraphs():
             # We don't want to have our FX graph split for the sake of static kernel feature,
             # because it will compile multiple times, so we set splitting_ops to empty manually.


### PR DESCRIPTION
- Remove force-disable of enable_npugraph_ex in piecewise compilation branch

- Update graph_mode.md to reflect npugraph_ex enabled in all modes except NONE

- Remove stale duplicate enable_npugraph_ex row in additional_config.md

### What this PR does / why we need it?
Enable npugraph_ex FX graph optimization for PIECEWISE and FULL_AND_PIECEWISE cudagraph modes. Previously, npugraph_ex was force-disabled in the piecewise compilation branch, meaning the default FULL_AND_PIECEWISE mode missed compile-time FX optimizations. This change removes that restriction, allowing npugraph_ex to optimize FX subgraphs before ACLGraph captures them.

### Does this PR introduce _any_ user-facing change?
npugraph_ex is now active in PIECEWISE and FULL_AND_PIECEWISE modes by default (previously only FULL/FULL_DECODE_ONLY). Since FULL_AND_PIECEWISE is the default cudagraph_mode, most users will get npugraph_ex FX optimization without any configuration change. No action required from users.

### How was this patch tested?
CI passed with existing tests. 

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
