### PR TITLE
[Feature] Support Step3P7/Step3P5 with Step3P5 MTP on Ascend

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -516,6 +516,13 @@
     - vllm_ascend/spec_decode/medusa_proposer.py
   tests: []
 
+- name: spec_decode_step3p5
+  optional: false
+  base: spec_decode_base
+  source_file_dependencies:
+    - vllm_ascend/spec_decode/step3p5.py
+  tests: []
+
 # Worker
 - name: worker_v1
   optional: false

--- a/tests/ut/ops/a3_2/test_activation.py
+++ b/tests/ut/ops/a3_2/test_activation.py
@@ -24,7 +24,7 @@ from vllm_ascend.ops.activation import (
     AscendQuickGELU,
     AscendSiluAndMul,
     AscendSwigluOAIAndMul,
-    swiglustep_and_mul,
+    AscendSwigluStepAndMul,
 )
 from vllm_ascend.utils import is_310p as is_310p_hw
 
@@ -207,7 +207,7 @@ class TestAscendSwigluOAIAndMul:
 class TestSwiglustepAndMul:
     def test_swiglustep_and_mul_matches_reference_formula(self):
         x = torch.tensor([[1.0, 2.0, -3.0, 4.0, 5.0, -6.0, 7.0, -8.0]], dtype=torch.float32)
-        result = swiglustep_and_mul(x)
+        result = AscendSwigluStepAndMul.swiglustep_forward(x)
         expected = _swiglustep_and_mul_reference(x)
 
         assert result.shape == (1, x.shape[-1] // 2)
@@ -218,7 +218,7 @@ class TestSwiglustepAndMul:
         # gate = first half, up = second half (contiguous split via chunk),
         # NOT the interleaved layout used by SwigluOAI.
         x = torch.tensor([[1.0, 2.0, 3.0, 4.0, 10.0, 20.0, 30.0, 40.0]], dtype=torch.float32)
-        result = swiglustep_and_mul(x, limit=100.0)
+        result = AscendSwigluStepAndMul.swiglustep_forward(x, limit=100.0)
         expected = _swiglustep_and_mul_reference(x, limit=100.0)
         interleaved = torch.nn.functional.silu(x[..., ::2]) * x[..., 1::2]
 
@@ -228,7 +228,7 @@ class TestSwiglustepAndMul:
     def test_swiglustep_and_mul_with_custom_limit_matches_reference(self):
         x = torch.tensor([[9.0, 8.0, -5.0, -9.0]], dtype=torch.float32)
         limit = 3.0
-        result = swiglustep_and_mul(x, limit=limit)
+        result = AscendSwigluStepAndMul.swiglustep_forward(x, limit=limit)
         expected = _swiglustep_and_mul_reference(x, limit=limit)
 
         assert torch.allclose(result, expected, atol=1e-6)
@@ -237,7 +237,7 @@ class TestSwiglustepAndMul:
         # gate = [100, 100] -> silu(~100) clamped to 7.0;
         # up   = [-100, -100] -> clamped to -7.0  =>  7.0 * -7.0 = -49.0
         x = torch.tensor([[100.0, 100.0, -100.0, -100.0]], dtype=torch.float32)
-        result = swiglustep_and_mul(x)
+        result = AscendSwigluStepAndMul.swiglustep_forward(x)
         expected = _swiglustep_and_mul_reference(x)
 
         assert torch.allclose(result, expected, atol=1e-5)
@@ -247,12 +247,17 @@ class TestSwiglustepAndMul:
 
     def test_swiglustep_and_mul_large_input(self):
         x = torch.randn(64, 128, dtype=torch.float32)
-        result = swiglustep_and_mul(x)
+        result = AscendSwigluStepAndMul.swiglustep_forward(x)
         expected = _swiglustep_and_mul_reference(x)
 
         assert result.shape == (64, 64)
         assert torch.allclose(result, expected, atol=1e-5)
         assert not torch.isnan(result).any()
+
+    def test_swiglustep_and_mul_validates_limit(self):
+        x = torch.tensor([[8.0, 9.0, -2.0, -8.0]], dtype=torch.float32)
+        with pytest.raises(ValueError, match="requires limit"):
+            AscendSwigluStepAndMul.swiglustep_forward(x, limit=None)
 
 
 class TestActivationNPUPrecision:
@@ -331,7 +336,7 @@ class TestActivationNPUPrecision:
         x_cpu = torch.randn(16, 16, dtype=torch.float32) * 4
         x_npu = x_cpu.to(dtype=dtype, device="npu")
 
-        result = swiglustep_and_mul(x_npu).cpu()
+        result = AscendSwigluStepAndMul.swiglustep_forward(x_npu).cpu()
         expected = _swiglustep_and_mul_reference(x_cpu.to(dtype=dtype)).float()
 
         assert result.shape == (16, 8)

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -3,6 +3,7 @@ from typing import ClassVar
 from unittest.mock import patch
 
 import torch
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
 from vllm_ascend.ops.fused_moe.moe_mlp import cumsum_group_list, unified_apply_mlp
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
@@ -179,6 +180,38 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
         self.assertTrue(output is expected)
         quant_kwargs = mock_quant.call_args.kwargs
         self.assertTrue(quant_kwargs["use_w4a8_per_channel_gmm_swiglu"])
+        mock_unquant.assert_not_called()
+
+    def test_request_quant_path_passes_swiglustep_activation(self):
+        expected = torch.randn(1, 2)
+        mlp_compute_input = MoEMlpComputeInput(
+            hidden_states=torch.ones((1, 2), dtype=torch.float32),
+            group_list=torch.tensor([1], dtype=torch.int64),
+            group_list_type=1,
+            dynamic_scale=None,
+            topk_scales=None,
+            weights=MoEWeights(
+                w1=[torch.ones((1, 2, 4), dtype=torch.float32)],
+                w2=[torch.ones((1, 2, 2), dtype=torch.float32)],
+                w1_scale=[torch.ones((1,), dtype=torch.float32)],
+                w2_scale=[torch.ones((1,), dtype=torch.float32)],
+            ),
+            quant=MoEQuantParams(quant_type=QuantType.W8A8),
+            fusion=True,
+            activation=MoEActivation.SWIGLUSTEP,
+            swiglu_limit=5.0,
+        )
+
+        with (
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.quant_apply_mlp", return_value=expected) as mock_quant,
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.unquant_apply_mlp") as mock_unquant,
+        ):
+            output = unified_apply_mlp(mlp_compute_input=mlp_compute_input)
+
+        self.assertTrue(output is expected)
+        quant_kwargs = mock_quant.call_args.kwargs
+        self.assertEqual(quant_kwargs["activation"], MoEActivation.SWIGLUSTEP)
+        self.assertEqual(quant_kwargs["swiglu_limit"], 5.0)
         mock_unquant.assert_not_called()
 
 

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -273,10 +273,14 @@ class TestAscendModelSlimConfig(TestBase):
         config = AscendModelSlimConfig()
         config.quant_description = {
             "model.layers.0.shared_head.weight": "INT8",
+            "transformer.shared_head.output.weight": "INT8",
+            "transformer.shared_head.norm.weight": "INT8",
         }
         config._apply_extra_quant_adaptations()
         self.assertIn("model.layers.0.weight", config.quant_description)
         self.assertEqual(config.quant_description["model.layers.0.weight"], "INT8")
+        self.assertIn("shared_head.head.weight", config.quant_description)
+        self.assertIn("shared_head.norm.weight", config.quant_description)
 
     def test_apply_extra_quant_adaptations_weight_packed(self):
         config = AscendModelSlimConfig()
@@ -319,6 +323,34 @@ class TestQuantPrefixMapper(TestBase):
         prefix = config.quant_prefix_mapper("qwen3_5_moe", "lm_head")
 
         self.assertEqual(prefix, "lm_head")
+
+    def test_step3p5_mtp_maps_direct_and_step3p7_wrapped_quant_keys(self):
+        cases = [
+            (
+                "model.layers.45.self_attn",
+                "model.layers.45.self_attn.qkv_proj",
+            ),
+            (
+                "language_model.model.layers.45.self_attn",
+                "language_model.model.layers.45.self_attn.qkv_proj",
+            ),
+        ]
+        for quant_prefix, expected in cases:
+            with self.subTest(quant_prefix=quant_prefix):
+                config = AscendModelSlimConfig(
+                    {
+                        f"{quant_prefix}.q_proj.weight": "FLOAT",
+                        f"{quant_prefix}.k_proj.weight": "FLOAT",
+                        f"{quant_prefix}.v_proj.weight": "FLOAT",
+                    }
+                )
+
+                prefix = config.quant_prefix_mapper(
+                    "step3p5_mtp",
+                    "model.layers.45.mtp_block.self_attn.qkv_proj",
+                )
+
+                self.assertEqual(prefix, expected)
 
 
 class TestGetCacheScale(TestBase):

--- a/tests/ut/spec_decode/test_step3p5_source_regression.py
+++ b/tests/ut/spec_decode/test_step3p5_source_regression.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source-level regressions for Step3.5 MTP Ascend glue.
+
+Importing the Step3.5 proposer can initialize runtime/device state in this
+branch. Keep these checks focused on cross-file contracts that are hard to
+exercise in a lightweight unit test, and avoid pinning the exact implementation
+sequence inside the proposer.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+STEP3P5 = ROOT / "vllm_ascend" / "spec_decode" / "step3p5.py"
+BASE_PROPOSER = ROOT / "vllm_ascend" / "spec_decode" / "llm_base_proposer.py"
+PATCH_SPEC_CFG = ROOT / "vllm_ascend" / "patch" / "platform" / "patch_speculative_config.py"
+WORKER_PATCH_INIT = ROOT / "vllm_ascend" / "patch" / "worker" / "__init__.py"
+LEGACY_STEP3P7_PATCH = ROOT / "vllm_ascend" / "patch" / "worker" / "patch_step3p5_mtp.py"
+
+
+def _tree(path: Path) -> ast.Module:
+    return ast.parse(path.read_text())
+
+
+def _class(path: Path, name: str) -> ast.ClassDef:
+    for node in _tree(path).body:
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"class {name} not found in {path}")
+
+
+def _method(path: Path, cls_name: str, method_name: str) -> ast.FunctionDef:
+    cls = _class(path, cls_name)
+    for node in cls.body:
+        if isinstance(node, ast.FunctionDef) and node.name == method_name:
+            return node
+    raise AssertionError(f"method {cls_name}.{method_name} not found")
+
+
+def _func(path: Path, name: str) -> ast.FunctionDef:
+    for node in _tree(path).body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"function {name} not found in {path}")
+
+
+def _src(node: ast.AST) -> str:
+    return ast.unparse(node)
+
+
+def test_step3p5_first_pass_forwards_rejected_token_counts() -> None:
+    # set_inputs_first_pass is inherited from the base proposer; the base
+    # simple-path is the canonical Step3.5 behaviour. Step3.5 only needs to
+    # forward num_rejected_tokens_gpu through _propose.
+    set_inputs = _method(BASE_PROPOSER, "AscendSpecDecodeBaseProposer", "set_inputs_first_pass")
+    propose = _method(STEP3P5, "AscendStep3p5MTPProposer", "_propose")
+
+    assert "num_rejected_tokens_gpu" in [arg.arg for arg in set_inputs.args.args]
+    assert "num_rejected_tokens_gpu=num_rejected_tokens_gpu" in _src(propose)
+
+    # Guard against the override creeping back: the previous step3p5 simple-path
+    # was byte-equivalent to the base's `not needs_extra_input_slots and
+    # pcp_size <= 1` branch, so a re-override is almost certainly redundant.
+    step_methods = {n.name for n in _class(STEP3P5, "AscendStep3p5MTPProposer").body if isinstance(n, ast.FunctionDef)}
+    assert "set_inputs_first_pass" not in step_methods
+
+
+def test_step3p5_draft_window_and_config_contracts() -> None:
+    base_run = _method(BASE_PROPOSER, "AscendSpecDecodeBaseProposer", "_run_merged_draft")
+    step_run = _method(STEP3P5, "AscendStep3p5MTPProposer", "_run_merged_draft")
+    run_window = _src(_method(STEP3P5, "AscendStep3p5MTPProposer", "_run_window_draft_steps"))
+    build_metadata = _src(_method(STEP3P5, "AscendStep3p5MTPProposer", "_build_step_attn_metadatas"))
+    roll_inputs = _src(_method(STEP3P5, "AscendStep3p5MTPProposer", "_roll_window_inputs_only"))
+    ensure_layer_types = _src(
+        _method(
+            STEP3P5,
+            "AscendStep3p5MTPProposer",
+            "_ensure_draft_layer_types_cover_mtp_layers",
+        )
+    )
+    create_config = _src(_method(STEP3P5, "AscendStep3p5MTPProposer", "_create_draft_vllm_config"))
+
+    assert [arg.arg for arg in step_run.args.args] == [arg.arg for arg in base_run.args.args]
+    assert "multi_steps_attn_metadata.append(per_step_attn_metadata)" in build_metadata
+    assert "multi_steps_attn_metadata[spec_step_idx]" in run_window
+    assert "self.input_ids[token_indices_to_sample]" in roll_inputs
+    assert "_ensure_draft_layer_types_cover_mtp_layers()" in create_config
+    assert "self.draft_model_config.hf_config" in ensure_layer_types
+    assert "self.vllm_config.model_config.hf_config" not in ensure_layer_types
+    assert "sliding_attention" in ensure_layer_types
+
+
+def test_step3p7_uses_step3p5_mtp_override_without_legacy_runtime_patch() -> None:
+    override_src = _src(_func(PATCH_SPEC_CFG, "hf_config_override"))
+
+    assert "step3p7" in override_src
+    assert "Step3p7ForConditionalGeneration" in override_src
+    assert "step3p5_mtp" in override_src
+    assert "Step3p5MTP" in override_src
+    assert "patch_step3p5_mtp" not in WORKER_PATCH_INIT.read_text()
+    assert not LEGACY_STEP3P7_PATCH.exists()

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -519,7 +519,12 @@ class AscendAttentionBackendImpl(AttentionImpl):
             if _EXTRA_CTX.is_draft_model:
                 graph_params = get_draft_graph_params()
                 attn_metadata = draft_attn_metadatas
-                attn_keys = list(attn_metadata[0].keys())
+                draft_attn_key_steps = [
+                    (draft_step, key)
+                    for draft_step, per_step_metadata in enumerate(attn_metadata)
+                    for key in per_step_metadata
+                ]
+                attn_keys = [key for _, key in draft_attn_key_steps]
             else:
                 graph_params = get_graph_params()
                 attn_metadata = forward_context.attn_metadata
@@ -540,7 +545,12 @@ class AscendAttentionBackendImpl(AttentionImpl):
             graph_param_count = len(captured_attn_params)
             workspace = graph_params.workspaces.get(num_tokens)
             if _EXTRA_CTX.is_draft_model:
-                attn_keys = attn_keys * (graph_param_count // num_layers)
+                if graph_param_count > len(draft_attn_key_steps):
+                    repeat_count = cdiv(graph_param_count, len(draft_attn_key_steps))
+                    draft_attn_key_steps = (draft_attn_key_steps * repeat_count)[:graph_param_count]
+                else:
+                    draft_attn_key_steps = draft_attn_key_steps[:graph_param_count]
+                attn_keys = [key for _, key in draft_attn_key_steps]
             elif use_layer_aware_replay:
                 # One graph size can contain captured FIA ops from all layers.
                 # Repeat attn keys to match the captured op count, then use the
@@ -574,7 +584,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     ) = param
 
                     if _EXTRA_CTX.is_draft_model:
-                        draft_step = attn_count // num_layers
+                        draft_step, key = draft_attn_key_steps[attn_count]
                         seq_lens = attn_metadata[draft_step][key].seq_lens_list
                         actual_seq_lengths_q = attn_metadata[draft_step][key].actual_seq_lengths_q
                         attn_count = attn_count + 1
@@ -614,27 +624,56 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 else:
                     graph_params = get_draft_graph_params()
                 attn_metadata = draft_attn_metadatas
-                attn_keys = list(attn_metadata[0].keys())
+                draft_attn_key_steps = [
+                    (draft_step, key)
+                    for draft_step, per_step_metadata in enumerate(attn_metadata)
+                    for key in per_step_metadata
+                ]
+                attn_keys = [key for _, key in draft_attn_key_steps]
             else:
                 graph_params = get_graph_params()
                 attn_metadata = forward_context.attn_metadata
                 attn_keys = list(attn_metadata.keys())
                 if not use_layer_aware_replay:
-                    # Keep the original speculative-decoding ordering for
-                    # other models so EAGLE/DFlash graph replay keeps the
-                    # original ordering.
+                    # In some speculative methods (such as DFlash), the order of
+                    # attn_keys in the Target model will be disrupted instead of
+                    # increasing by layer index, so need regular expressions to
+                    # reorder the attn_keys and store the results in
+                    # _ATTN_KEYS_BUFFER.
                     attn_keys_length = len(graph_params.attn_params[num_tokens])
                     global _ATTN_KEYS_BUFFER
-                    if _ATTN_KEYS_BUFFER is None:
+                    if attn_keys_length == 0:
+                        return
+                    if _ATTN_KEYS_BUFFER is None or len(_ATTN_KEYS_BUFFER) != attn_keys_length:
                         import regex as re
 
                         def extract_layer_index(key: str) -> int:
-                            match = re.search(r"(\d+)", key)
+                            match = re.search(r"(?:^|\.)layers\.(\d+)(?:\.|$)", key)
                             return int(match.group(1)) if match else 0
 
-                        attn_keys_tmp = attn_keys[:attn_keys_length]
+                        def is_direct_target_attn_key(key: str) -> bool:
+                            return (
+                                re.search(
+                                    r"(?:^|\.)layers\.(\d+)\.self_attn\.attn$",
+                                    key,
+                                )
+                                is not None
+                            )
+
+                        attn_keys_to_order = attn_keys[:attn_keys_length]
+                        if getattr(speculative_config, "method", None) == "mtp":
+                            # Step3.5 MTP can expose draft KV-cache groups in the
+                            # target runtime metadata.  The target FULL graph only
+                            # captures direct base-model self-attention handles, so
+                            # select that target key domain instead of depending on
+                            # the current draft module name.
+                            direct_target_attn_keys = [key for key in attn_keys if is_direct_target_attn_key(key)]
+                            if len(direct_target_attn_keys) >= attn_keys_length:
+                                attn_keys_to_order = direct_target_attn_keys
+
+                        attn_keys_tmp = attn_keys_to_order
                         attn_keys_tmp.sort(key=extract_layer_index)
-                        _ATTN_KEYS_BUFFER = attn_keys_tmp
+                        _ATTN_KEYS_BUFFER = attn_keys_tmp[:attn_keys_length]
                     attn_keys[:attn_keys_length] = _ATTN_KEYS_BUFFER
             # For Qwen3-next, since the kv_cache_config has already categorized
             # linear_attn and self_attn, the attn_metadata is first arranged with
@@ -652,7 +691,12 @@ class AscendAttentionBackendImpl(AttentionImpl):
             graph_param_count = len(captured_attn_params)
             workspace = graph_params.workspaces.get(num_tokens)
             if _EXTRA_CTX.is_draft_model:
-                attn_keys = attn_keys * (graph_param_count // num_layers)
+                if graph_param_count > len(draft_attn_key_steps):
+                    repeat_count = cdiv(graph_param_count, len(draft_attn_key_steps))
+                    draft_attn_key_steps = (draft_attn_key_steps * repeat_count)[:graph_param_count]
+                else:
+                    draft_attn_key_steps = draft_attn_key_steps[:graph_param_count]
+                attn_keys = [key for _, key in draft_attn_key_steps]
             elif use_layer_aware_replay:
                 # Keep the replay loop length aligned with captured FIA ops;
                 # layer-specific metadata lookup below prevents global/sliding
@@ -691,12 +735,13 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     ) = param
 
                     if _EXTRA_CTX.is_draft_model:
-                        draft_step = attn_count // num_layers
-                        seq_lens = attn_metadata[draft_step][key].seq_lens_list
-                        actual_seq_lengths_q = attn_metadata[draft_step][key].actual_seq_lengths_q
-                        block_tables = attn_metadata[draft_step][key].block_tables
+                        draft_step, key = draft_attn_key_steps[attn_count]
+                        metadata = attn_metadata[draft_step][key]
+                        seq_lens = metadata.seq_lens_list
+                        actual_seq_lengths_q = metadata.actual_seq_lengths_q
+                        block_tables = metadata.block_tables
                         attn_count = attn_count + 1
-                        if not attn_metadata[draft_step][key].causal:
+                        if not metadata.causal:
                             sparse_mode = 0
                     else:
                         metadata_key = layer_name if layer_name is not None and layer_name in attn_metadata else key

--- a/vllm_ascend/ops/activation.py
+++ b/vllm_ascend/ops/activation.py
@@ -17,7 +17,13 @@
 
 import torch
 import torch_npu
-from vllm.model_executor.layers.activation import QuickGELU, SiluAndMul, SiluAndMulWithClamp, SwigluOAIAndMul
+from vllm.model_executor.layers.activation import (
+    QuickGELU,
+    SiluAndMul,
+    SiluAndMulWithClamp,
+    SwigluOAIAndMul,
+    SwigluStepAndMul,
+)
 
 from vllm_ascend.utils import get_weight_prefetch_method
 
@@ -61,18 +67,14 @@ class AscendSwigluOAIAndMul:
         return SwigluOAIAndMul.forward_native(layer, x)
 
 
-def swiglustep_and_mul(x: torch.Tensor, limit: float = 7.0) -> torch.Tensor:
-    """Out-variant of swiglustep activation.
+class AscendSwigluStepAndMul:
+    def swiglustep_forward(x: torch.Tensor, limit: float = 7.0) -> torch.Tensor:
+        if limit is None:
+            raise ValueError("SwigluStepAndMul requires limit to be set.")
 
-    Computes:
-     silu(x[:d]).clamp(max=limit) * x[d:].clamp(-limit, limit)
+        class MinimalSwigluStepAndMul:
+            def __init__(self):
+                self.limit = limit
 
-    This is the custom activation used by Step-3.7-Flash's final MoE layers
-    (layers 43-44) to prevent numerical overflow via clamp truncation.
-    """
-    gate, up = x.chunk(2, dim=-1)
-    gate = torch.nn.functional.silu(gate)
-    gate = gate.clamp(max=limit)
-    up = up.clamp(min=-limit, max=limit)
-    out = gate * up
-    return out
+        layer = MinimalSwigluStepAndMul()
+        return SwigluStepAndMul.forward_native(layer, x)

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -18,6 +18,7 @@
 import torch
 import torch_npu
 from torch.nn.functional import pad
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.triton_utils import HAS_TRITON
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
@@ -25,7 +26,7 @@ from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.device.mxfp_compat import (
     ensure_mxfp8_moe_available,
 )
-from vllm_ascend.ops.activation import AscendSwigluOAIAndMul, swiglustep_and_mul
+from vllm_ascend.ops.activation import AscendSwigluOAIAndMul, AscendSwigluStepAndMul
 from vllm_ascend.ops.fused_moe.moe_runtime_args import MoEMlpComputeInput
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import (
@@ -106,6 +107,7 @@ def quant_apply_mlp(
     scale_type: torch.dtype | None = None,
     per_token_scale_type: torch.dtype | None = None,
     use_bf16: bool = True,
+    activation: str | None = None,
     swiglu_limit: float = 0.0,
     use_w4a8_per_channel_gmm_swiglu: bool = False,
 ) -> torch.Tensor:
@@ -237,7 +239,10 @@ def quant_apply_mlp(
         )[0]
         dispose_tensor(unquantized_hidden_states)
         # act_fn: swiglu
-        hidden_states = torch_npu.npu_swiglu(hidden_states)
+        if activation == MoEActivation.SWIGLUSTEP:
+            hidden_states = AscendSwigluStepAndMul.swiglustep_forward(hidden_states, limit=swiglu_limit or 7.0)
+        else:
+            hidden_states = torch_npu.npu_swiglu(hidden_states)
         before_gmm2_evt = torch.npu.current_stream().record_event()
         # gmm2: down_proj
         hidden_states = torch_npu.npu_grouped_matmul(
@@ -261,7 +266,7 @@ def quant_apply_mlp(
             # TODO w4a8 scene: dynamic acquisition of dtype in the future
             _output_dtype = torch.bfloat16
 
-        if use_w4a8_per_channel_gmm_swiglu and enable_custom_op():
+        if use_w4a8_per_channel_gmm_swiglu and enable_custom_op() and activation != MoEActivation.SWIGLUSTEP:
             hidden_states, swiglu_out_scale = torch.ops._C_ascend.grouped_matmul_swiglu_quant_v2(
                 x=hidden_states,
                 weight=w1,
@@ -284,7 +289,7 @@ def quant_apply_mlp(
                 bias=bias1,
                 swiglu_limit=swiglu_limit,
             )
-        elif use_gmm_swiglu_quant_fusion:
+        elif use_gmm_swiglu_quant_fusion and activation != MoEActivation.SWIGLUSTEP:
             hidden_states, swiglu_out_scale, _ = DeviceOperator.npu_grouped_matmul_swiglu_quant(
                 x=hidden_states,
                 weight=_require_single_tensor_for_swiglu_quant(w1, name="w1"),
@@ -318,7 +323,10 @@ def quant_apply_mlp(
             if quantized_hidden_states is not None:
                 dispose_tensor(quantized_hidden_states)
             # act_fn: swiglu
-            if HAS_TRITON:
+            if activation == MoEActivation.SWIGLUSTEP:
+                hidden_states = AscendSwigluStepAndMul.swiglustep_forward(hidden_states, limit=swiglu_limit or 7.0)
+                hidden_states, swiglu_out_scale = torch_npu.npu_dynamic_quant(hidden_states)
+            elif HAS_TRITON:
                 from vllm_ascend.ops.triton.activation.swiglu_quant import swiglu_quant
 
                 hidden_states, swiglu_out_scale = swiglu_quant(
@@ -367,8 +375,6 @@ def unquant_apply_mlp(
         w1 = w1.transpose(1, 2)
         w2 = w2.transpose(1, 2)
 
-    act_name = getattr(activation, "value", activation)
-
     gate_up_out = torch_npu.npu_grouped_matmul(
         x=[hidden_states],
         weight=[w1],
@@ -379,16 +385,15 @@ def unquant_apply_mlp(
         group_list=group_list,
     )[0]
 
-    if act_name == "swigluoai":
+    if activation == MoEActivation.SWIGLUOAI:
         num_experts, _, hidden_size = w1.shape
         gate_up_out = AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out.view(-1, hidden_size))
-    elif act_name == "swiglustep":
-        limit = swiglu_limit if swiglu_limit > 0 else 7.0
-        gate_up_out = swiglustep_and_mul(gate_up_out, limit=limit)
-    elif act_name == "gelu":
+    elif activation == MoEActivation.SWIGLUSTEP:
+        gate_up_out = AscendSwigluStepAndMul.swiglustep_forward(gate_up_out, limit=swiglu_limit or 7.0)
+    elif activation == MoEActivation.GELU:
         gate, up = gate_up_out.chunk(2, dim=-1)
         gate_up_out = torch.nn.functional.gelu(gate) * up
-    elif act_name == "gelu_tanh":
+    elif activation == MoEActivation.GELU_TANH:
         gate, up = gate_up_out.chunk(2, dim=-1)
         gate_up_out = torch.nn.functional.gelu(gate, approximate="tanh") * up
     else:
@@ -496,6 +501,7 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
         scale_type=scale_type,
         per_token_scale_type=per_token_scale_type,
         use_bf16=use_bf16,
+        activation=activation,
         swiglu_limit=swiglu_limit,
         use_w4a8_per_channel_gmm_swiglu=mlp_compute_input.quant.use_w4a8_per_channel_gmm_swiglu,
     )

--- a/vllm_ascend/ops/weight_prefetch.py
+++ b/vllm_ascend/ops/weight_prefetch.py
@@ -95,8 +95,11 @@ class WeightPrefetchMethod:
         if not forward_context or _EXTRA_CTX.model_instance is None:
             return
 
-        # layer_idx is subtracted by 1 because layer_idx was incremented by 1 at layernorm.
-        weight = _EXTRA_CTX.model_instance.model.layers[_EXTRA_CTX.layer_idx - 1].mlp.experts.w13_weight  # type: ignore  # type: ignore
+        weight = self._get_moe_gate_up_prefetch_weight()
+        if weight is None:
+            self.moe.is_active_this_forward = False
+            return
+
         weight_size = weight.data.element_size() * weight.data.numel() * self.moe.prefetch_ratio.get(prefix, 0)
         torch.ops.vllm.prefetch_preprocess(weight=weight, start_flag=None, max_weight_size=int(weight_size))
 
@@ -105,6 +108,27 @@ class WeightPrefetchMethod:
             return
 
         torch.ops.vllm.prefetch_postprocess(stop_flag)
+
+    def _get_moe_gate_up_prefetch_weight(self) -> torch.Tensor | None:
+        layer_idx = _EXTRA_CTX.layer_idx
+        model_instance = _EXTRA_CTX.model_instance
+        if layer_idx is None or layer_idx <= 0 or model_instance is None:
+            return None
+
+        # layer_idx is subtracted by 1 because it was incremented by 1 at layernorm.
+        layer = model_instance.model.layers[layer_idx - 1]
+        experts = None
+        if hasattr(layer, "mlp") and hasattr(layer.mlp, "experts"):
+            experts = layer.mlp.experts
+        elif hasattr(layer, "moe") and hasattr(layer.moe, "experts"):
+            experts = layer.moe.experts
+        elif hasattr(layer, "block_sparse_moe") and hasattr(layer.block_sparse_moe, "experts"):
+            experts = layer.block_sparse_moe.experts
+
+        if experts is None:
+            return None
+
+        return getattr(experts, "w13_weight", None)
 
     # x_dependency only eager mode can pass None
     def maybe_prefetch_mlp_weight_preprocess(

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -116,7 +116,14 @@ def hf_config_override(hf_config: PretrainedConfig) -> PretrainedConfig:
         n_predict = getattr(hf_config, "num_nextn_predict_layers", 1)
         hf_config.update({"n_predict": n_predict, "architectures": ["LongCatFlashMTPModel"]})
 
-    if hf_config.model_type == "step3p5":
+    if hf_config.model_type in ("step3p5", "step3p7") or hf_config.architectures[0] in (
+        "Step3p5ForCausalLM",
+        "Step3p7ForConditionalGeneration",
+    ):
+        quantization_config = getattr(hf_config, "quantization_config", None)
+        hf_config = getattr(hf_config, "text_config", hf_config)
+        if quantization_config is not None and getattr(hf_config, "quantization_config", None) is None:
+            hf_config.update({"quantization_config": quantization_config})
         hf_config.model_type = "step3p5_mtp"
         n_predict = getattr(hf_config, "num_nextn_predict_layers", 1)
         hf_config.update({"n_predict": n_predict, "architectures": ["Step3p5MTP"]})

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -274,6 +274,32 @@ packed_modules_model_mapping: dict[str, dict[str, list[str]]] = {
         "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],
         "o_proj": ["dense"],
     },
+    "step3p5": {
+        "qkv_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
+        "experts": ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
+    },
+    # The step3.5 MTP draft (speculative.py sets model_type="step3p5_mtp")
+    # reuses the same fused module layout as the verifier.
+    "step3p5_mtp": {
+        "qkv_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
+        "experts": ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
+    },
 }
 
 
@@ -295,6 +321,13 @@ QUANT_MODEL_SUBSTR_MAPPINGS = {
         ".ffn.": ".mlp.",
         ".ffn_norm.": ".post_attention_layernorm.",
         ".attn_norm.": ".input_layernorm.",
+    },
+    # The step3.5 MTP draft nests its decoder block under ".mtp_block.", but the
+    # checkpoint's quant_model_description.json keys it without that infix
+    # (e.g. "model.layers.45.self_attn.q_proj.weight"). Strip it so the quant
+    # lookup matches the on-disk naming.
+    "step3p5_mtp": {
+        ".mtp_block.": ".",
     },
 }
 
@@ -513,6 +546,15 @@ class AscendModelSlimConfig(QuantizationConfig):
                 return name[: -len(src_suffix)] + dst_suffix
         return None
 
+    def _has_quant_weight(self, prefix: str, packed_modules_mapping: Mapping[str, list[str]]) -> bool:
+        proj_name = prefix.split(".")[-1]
+        if proj_name in packed_modules_mapping:
+            return all(
+                f"{prefix.replace(proj_name, shard_proj_name)}.weight" in self.quant_description
+                for shard_proj_name in packed_modules_mapping[proj_name]
+            )
+        return f"{prefix}.weight" in self.quant_description
+
     def quant_prefix_mapper(self, model_type: str, prefix: str) -> str:
         self.model_type = model_type
         # Some model paths, e.g. qwen3-vl and qwen3_5_moe MTP drafter,
@@ -526,9 +568,26 @@ class AscendModelSlimConfig(QuantizationConfig):
             prefix = "language_model.lm_head"
         prefix_mapping = QUANT_MODEL_PREFIX_MAPPINGS.get(model_type)
         substr_mapping = QUANT_MODEL_SUBSTR_MAPPINGS.get(model_type)
-        if prefix_mapping:
-            hf_to_vllm_mapper = WeightsMapper(orig_to_new_prefix=prefix_mapping, orig_to_new_substr=substr_mapping)
-            return hf_to_vllm_mapper._map_name(prefix)
+        if prefix_mapping or substr_mapping:
+            hf_to_vllm_mapper = WeightsMapper(
+                orig_to_new_prefix=prefix_mapping or {},
+                orig_to_new_substr=substr_mapping or {},
+            )
+            prefix = hf_to_vllm_mapper._map_name(prefix)
+
+        if model_type == "step3p5_mtp" and prefix.startswith("model.layers."):
+            # Step3P5 MTP and newly generated Step3P7 W8A8 MTP checkpoints use
+            # ``model.layers.*``.  The Step3P7 vLLM wrapper mapper rewrites
+            # current ``model.layers.*`` quant descriptions to
+            # ``language_model.model.layers.*``.  The MTP draft module itself
+            # is still Step3P5-shaped and queries ``model.layers.*``, so try
+            # the Step3P7 wrapper alias only when the direct Step3P5/new-key
+            # lookup misses.
+            packed_modules_mapping = get_packed_modules_mapping(model_type)
+            if not self._has_quant_weight(prefix, packed_modules_mapping):
+                for candidate in (prefix.replace("model.layers.", "language_model.model.layers.", 1),):
+                    if self._has_quant_weight(candidate, packed_modules_mapping):
+                        return candidate
         return prefix
 
     def get_quant_method(self, layer: torch.nn.Module, prefix: str, tid2eid=None) -> Optional["QuantizeMethodBase"]:
@@ -834,6 +893,21 @@ class AscendModelSlimConfig(QuantizationConfig):
         for k in self.quant_description:
             if "shared_head" in k:
                 new_k = k.replace(".shared_head.", ".")
+                extra_quant_dict[new_k] = self.quant_description[k]
+            if "transformer.shared_head.output." in k:
+                # Step3.5 MTP checkpoints describe per-layer draft logits heads
+                # as ``transformer.shared_head.output``. The vLLM model module
+                # exposes the same parameter as ``shared_head.head``.
+                new_k = k.replace(
+                    "transformer.shared_head.output.",
+                    "shared_head.head.",
+                )
+                extra_quant_dict[new_k] = self.quant_description[k]
+            if "transformer.shared_head.norm." in k:
+                new_k = k.replace(
+                    "transformer.shared_head.norm.",
+                    "shared_head.norm.",
+                )
                 extra_quant_dict[new_k] = self.quant_description[k]
             if "weight_packed" in k:
                 new_k = k.replace("weight_packed", "weight")

--- a/vllm_ascend/spec_decode/__init__.py
+++ b/vllm_ascend/spec_decode/__init__.py
@@ -27,6 +27,7 @@ from vllm_ascend.spec_decode.extract_hidden_states_proposer import (
 from vllm_ascend.spec_decode.medusa_proposer import AscendMedusaProposer
 from vllm_ascend.spec_decode.ngram_proposer import AscendNgramProposer
 from vllm_ascend.spec_decode.ngram_proposer_npu import AscendNgramProposerNPU
+from vllm_ascend.spec_decode.step3p5 import AscendStep3p5MTPProposer
 from vllm_ascend.spec_decode.suffix_proposer import AscendSuffixDecodingProposer
 
 
@@ -40,6 +41,9 @@ def get_spec_decode_method(method, vllm_config, device, runner):
     elif method == "medusa":
         return AscendMedusaProposer(vllm_config, device)
     elif method in ("eagle", "eagle3", "mtp"):
+        speculative_config = vllm_config.speculative_config
+        if speculative_config is not None and speculative_config.use_step3p5_mtp():
+            return AscendStep3p5MTPProposer(vllm_config, device, runner)
         return AscendEagleProposer(vllm_config, device, runner)
     elif method == "dflash":
         return AscendDflashProposer(vllm_config, device, runner)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -308,6 +308,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "Qwen3VLMoeForConditionalGeneration",
                 "Qwen3_5ForConditionalGeneration",
                 "Qwen3_5MoeForConditionalGeneration",
+                "Step3p7ForConditionalGeneration",
             ]:
                 self.model.config.image_token_index = model.config.image_token_id
             elif self.get_model_name(model) == "PixtralForConditionalGeneration":

--- a/vllm_ascend/spec_decode/step3p5.py
+++ b/vllm_ascend/spec_decode/step3p5.py
@@ -1,0 +1,830 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Callable
+from functools import partial
+from typing import Any
+
+import torch
+from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config, replace
+from vllm.forward_context import BatchDescriptor, get_forward_context
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.model_executor.models.utils import get_draft_quant_config
+from vllm.v1.attention.backends.utils import CommonAttentionMetadata
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec, UniformTypeKVCacheSpecs
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.spec_decode.llm_base_proposer import compute_probs_and_sample_next_token
+from vllm.v1.spec_decode.utils import PADDING_SLOT_ID
+from vllm.v1.worker.utils import AttentionGroup
+
+from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+from vllm_ascend.distributed.parallel_state import get_lmhead_tp_group
+from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
+from vllm_ascend.utils import lmhead_tp_enable
+
+
+class AscendStep3p5MTPProposer(AscendEagleProposer):
+    """Step3.5 MTP proposer with per-MTP-layer independent KV cache groups.
+
+    Each Step3.5 MTP layer owns a different attention/KV-cache group. The
+    generic Ascend MTP proposer assumes one draft KV-cache group and builds one
+    attention metadata object for all draft layers. Step3.5 therefore keeps the
+    whole propose flow in this subclass: it builds per-group metadata for all MTP
+    layers, reuses that step0 metadata across layer calls, and refreshes the
+    metadata tensors after each in-graph input update.
+    """
+
+    _runnable: Callable
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        device: torch.device,
+        runner=None,
+    ) -> None:
+        super().__init__(vllm_config, device, runner=runner)
+        # Per KV cache group block tables / slot mappings captured from the
+        # model runner each step (see set_per_group_attn_metadata).
+        self._per_group_block_tables: dict[int, torch.Tensor] = {}
+        self._per_group_slot_mappings: dict[int, torch.Tensor] = {}
+        # Slot-mapping buffers for additional KV cache groups. FULL graph
+        # capture records tensor addresses for reshape/cache, so every group
+        # that can appear in the shared step0 metadata needs a persistent
+        # buffer.
+        self._group_slot_buffers: dict[int, torch.Tensor] = {}
+
+    def set_per_group_attn_metadata(
+        self,
+        gid: int,
+        block_table: torch.Tensor,
+        slot_mapping: torch.Tensor,
+    ) -> None:
+        self._per_group_block_tables[gid] = block_table
+        self._per_group_slot_mappings[gid] = slot_mapping
+
+    def _seed_graph_capture_per_group_metadata(
+        self,
+        num_reqs: int,
+        num_tokens: int,
+    ) -> None:
+        if self.runner is None or not self.draft_attn_groups:
+            return
+
+        block_tables = self.runner.input_batch.block_table
+        for attn_group in self.draft_attn_groups:
+            gid = attn_group.kv_cache_group_id
+            try:
+                block_table = block_tables[gid]
+            except (IndexError, KeyError):
+                continue
+            block_table_tensor = block_table.get_device_tensor()
+            if num_reqs > 0:
+                block_table_tensor = block_table_tensor[:num_reqs]
+            slot_mapping = block_table.slot_mapping.gpu[:num_tokens]
+            self.set_per_group_attn_metadata(gid, block_table_tensor, slot_mapping)
+
+    def _slot_mapping_buffer_for_group(
+        self,
+        attn_group: AttentionGroup,
+    ) -> torch.Tensor:
+        gid = attn_group.kv_cache_group_id
+        if gid == self.kv_cache_gid:
+            return self.slot_mapping_group[0]
+        buf = self._group_slot_buffers.get(gid)
+        if buf is None:
+            buf = torch.zeros_like(self.slot_mapping_group[0])
+            self._group_slot_buffers[gid] = buf
+        return buf
+
+    def _common_attn_metadata_for_group(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        attn_group: AttentionGroup,
+    ) -> CommonAttentionMetadata:
+        group_common_attn_metadata = self.shallow_copy_metadata(common_attn_metadata)
+        gid = attn_group.kv_cache_group_id
+
+        block_table = self._per_group_block_tables.get(gid)
+        if block_table is not None:
+            group_common_attn_metadata.block_table_tensor = block_table[: group_common_attn_metadata.num_reqs]
+
+        slot_mapping = self._per_group_slot_mappings.get(gid)
+        if slot_mapping is None:
+            return group_common_attn_metadata
+        slot_mapping_buffer = self._slot_mapping_buffer_for_group(attn_group)
+        slot_mapping_len = slot_mapping.shape[0]
+        if slot_mapping.data_ptr() != slot_mapping_buffer.data_ptr():
+            slot_mapping_buffer[:slot_mapping_len].copy_(slot_mapping.to(torch.int32))
+        slot_mapping_buffer[slot_mapping_len:].fill_(PADDING_SLOT_ID)
+        slot_mapping_view = slot_mapping_buffer[: group_common_attn_metadata.num_actual_tokens]
+        self._per_group_slot_mappings[gid] = slot_mapping_view
+        group_common_attn_metadata.slot_mapping = slot_mapping_view
+
+        return group_common_attn_metadata
+
+    def _build_step_attn_metadatas(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        *,
+        graph_capture: bool = False,
+    ) -> tuple[list[Any], list[dict[str, Any]]]:
+        """Build base-proposer-style per-step metadata for Step3.5 MTP.
+
+        The full-window path still reuses the same logical window for every MTP
+        layer, but graph-param update/replay expects draft metadata to be
+        indexed by speculative step.  Each Step3.5 MTP attention group maps to
+        one draft step/KV-cache group, so return:
+
+        ``[{layer0: meta0}, {layer1: meta1}, {layer2: meta2}]``
+
+        instead of one dict containing all MTP layers.
+        """
+        per_group_attn_metadata: list[Any] = []
+        multi_steps_attn_metadata: list[dict[str, Any]] = []
+        extra_attn_metadata_args: dict[str, Any] = {}
+        if self.use_compress:
+            extra_attn_metadata_args = dict(
+                prefill_ratio_to_sas_metadata=dict(),
+                decode_ratio_to_sas_metadata=dict(),
+                common_ratio_to_sas_metadata=dict(),
+                block_size=self.draft_attn_groups[0].kv_cache_spec.block_size,
+            )
+
+        for attn_group in self.draft_attn_groups:
+            group_common_attn_metadata = self._common_attn_metadata_for_group(common_attn_metadata, attn_group)
+            builder = attn_group.get_metadata_builder()
+            if graph_capture:
+                attn_metadata = builder.build_for_graph_capture(
+                    group_common_attn_metadata,
+                    AscendAttentionState.SpecDecoding,
+                )
+            else:
+                attn_metadata = builder.build(
+                    0,
+                    group_common_attn_metadata,
+                    self.runner.get_model(),
+                    **extra_attn_metadata_args,
+                )
+                if hasattr(attn_metadata, "causal") and not attn_metadata.causal:
+                    attn_metadata.attn_mask = None
+            per_group_attn_metadata.append(attn_metadata)
+            per_step_attn_metadata: dict[str, Any] = {}
+            for layer_name in attn_group.layer_names:
+                per_step_attn_metadata[layer_name] = attn_metadata
+            multi_steps_attn_metadata.append(per_step_attn_metadata)
+        return per_group_attn_metadata, multi_steps_attn_metadata
+
+    def _sample_draft_tokens_for_step(
+        self,
+        hidden_states: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+        spec_step_idx: int,
+        num_indices: int,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """GPU Step3.5 sampling semantics with Ascend TP/reduce-sample paths."""
+        logits: torch.Tensor | None = None
+        if get_ascend_config().enable_reduce_sample and self.method == "mtp":
+            if not hasattr(self.model.model, "compute_logits"):
+                draft_token_ids = self.compute_draft_token_ids(hidden_states)
+                if lmhead_tp_enable() and num_indices < draft_token_ids.shape[0]:
+                    draft_token_ids = draft_token_ids[:num_indices]
+                return draft_token_ids, None
+            logits = self.model.compute_logits(hidden_states, spec_step_idx=spec_step_idx)
+            if lmhead_tp_enable():
+                logits = get_lmhead_tp_group().all_to_all(logits)
+            else:
+                logits = self.model.model.logits_processor._gather_logits(logits)
+        else:
+            logits = self.model.compute_logits(hidden_states, spec_step_idx=spec_step_idx)
+
+        if lmhead_tp_enable() and num_indices < logits.shape[0]:
+            logits = logits[:num_indices]
+        if not self._enable_probabilistic_draft_probs or sampling_metadata.all_greedy:
+            return logits.argmax(dim=-1), None
+        return compute_probs_and_sample_next_token(logits, sampling_metadata)
+
+    @torch.inference_mode()
+    def dummy_run(
+        self,
+        num_tokens: int,
+        with_prefill: bool = False,
+        in_graph_capturing: bool = False,
+        num_reqs: int = 0,
+        num_tokens_across_dp: torch.Tensor | None = None,
+        aclgraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+        batch_descriptor=None,
+        dummy_compute_logits=lambda hidden_states: None,
+        is_profile=False,
+    ):
+        (
+            num_tokens,
+            num_tokens_across_dp,
+            _,
+        ) = self.runner._sync_metadata_across_dp(num_tokens, is_draft_model=True)
+
+        multi_steps_attn_metadata: list[dict[str, Any]] = []
+        if not self.use_cuda_graph:
+            aclgraph_runtime_mode = CUDAGraphMode.NONE
+
+        if (
+            self.pcp_size * self.dcp_size > 1
+            and self.use_cuda_graph
+            and not is_profile
+            and self.block_table_tensor_clone is None
+        ):
+            self.block_table_tensor_clone = torch.zeros(
+                (
+                    self.runner.max_num_tokens + 2 * self.pcp_size * self.runner.max_num_reqs,
+                    self.runner.input_batch.block_table[0].get_device_tensor().shape[1],
+                ),
+                dtype=torch.int32,
+                device=self.device,
+                pin_memory=self.runner.pin_memory,
+            )
+
+        batch_size = max(num_tokens // (self.num_speculative_tokens + 1), 1)
+        if is_profile:
+            batch_size = min(batch_size, self.runner.max_num_reqs)
+
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL and len(self.runner.attn_groups) > 0:
+            num_computed_tokens_cpu = self.runner.input_batch.num_computed_tokens_cpu_tensor[:num_reqs]
+
+            self.query_start_loc.cpu[: num_reqs + 1].copy_(self.runner.query_start_loc.cpu[: num_reqs + 1])
+            self.query_start_loc.copy_to_gpu()
+
+            common_attn_metadata = AscendCommonAttentionMetadata(
+                query_start_loc=self.query_start_loc.gpu[: num_reqs + 1],
+                query_start_loc_cpu=self.query_start_loc.cpu[: num_reqs + 1],
+                seq_lens_cpu=self.runner.optimistic_seq_lens_cpu,
+                seq_lens_cpu_upper_bound=self.runner.optimistic_seq_lens_cpu,
+                seq_lens=self.runner.seq_lens[:num_reqs],
+                num_reqs=num_reqs,
+                num_actual_tokens=num_tokens,
+                num_input_tokens=num_tokens,
+                max_query_len=self.num_speculative_tokens + 1,
+                num_computed_tokens_cpu=num_computed_tokens_cpu,
+                actual_seq_lengths_q=self.runner.actual_seq_lengths_q,
+                block_table_tensor=self.runner.input_batch.block_table[0].get_device_tensor()[:num_reqs],
+                slot_mapping=self.runner.input_batch.block_table[0].slot_mapping.gpu,
+                slot_mapping_cpu=self.runner.input_batch.block_table[0].slot_mapping.cpu,
+                positions=self.runner.positions,
+                attn_state=self.runner.attn_state,
+                decode_token_per_req=self.runner.decode_token_per_req,
+                max_seq_len=0,
+            )
+            if self.pcp_size * self.dcp_size > 1:
+                common_attn_metadata.prefill_context_parallel_metadata = self.runner.pcp_manager.long_seq_metadata
+
+            common_attn_metadata = self.shallow_copy_metadata(common_attn_metadata)
+            common_attn_metadata.slot_mapping = self.slot_mapping_group[0]
+            common_attn_metadata.seq_lens = self.seq_lens_group[0][:num_reqs]
+            common_attn_metadata.query_start_loc = self.query_start_loc_group[0][: num_reqs + 1]
+            self._seed_graph_capture_per_group_metadata(num_reqs, num_tokens)
+            _, multi_steps_attn_metadata = self._build_step_attn_metadatas(common_attn_metadata, graph_capture=True)
+
+        model_positions = self._get_positions(num_tokens)
+
+        if self.supports_mm_inputs:
+            inputs_embeds = self.model.embed_input_ids(self.input_ids[:num_tokens])
+            self.inputs_embeds[:num_tokens] = inputs_embeds
+            inputs_embeds = self.inputs_embeds[:num_tokens]
+        else:
+            inputs_embeds = None
+
+        self.token_indices_to_sample.fill_(0)
+
+        with set_ascend_forward_context(
+            multi_steps_attn_metadata[0] if multi_steps_attn_metadata else None,
+            self.vllm_config,
+            num_tokens=num_tokens,
+            num_tokens_across_dp=num_tokens_across_dp,
+            num_actual_tokens=0,
+            in_profile_run=is_profile,
+            batch_descriptor=batch_descriptor,
+            aclgraph_runtime_mode=aclgraph_runtime_mode,
+            is_draft_model=True,
+            draft_attn_metadatas=multi_steps_attn_metadata,
+        ):
+            forward_context = get_forward_context()
+            if forward_context is not None:
+                forward_context.moe_layer_index = 0
+
+            self._runnable(
+                num_input_tokens=num_tokens,
+                batch_size=batch_size,
+                token_indices_to_sample=self.token_indices_to_sample[: batch_size * self.extra_slots_per_request],
+                target_positions=model_positions,
+                inputs_embeds=inputs_embeds,
+                multi_steps_attn_metadata=multi_steps_attn_metadata,
+                num_tokens=num_tokens,
+            )
+            forward_context = get_forward_context()
+            if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing:
+                self._update_full_graph_params(forward_context, num_tokens, multi_steps_attn_metadata)
+
+    def _propose(
+        self,
+        target_token_ids: torch.Tensor,
+        target_positions: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        next_token_ids: torch.Tensor,
+        token_indices_to_sample: torch.Tensor | None,
+        common_attn_metadata: CommonAttentionMetadata,
+        target_model_batch_desc: BatchDescriptor,
+        sampling_metadata: SamplingMetadata,
+        mm_embed_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
+        req_scheduled_tokens=None,
+        long_seq_metadata=None,
+        num_prefill_reqs=0,
+        num_decode_reqs=0,
+        scheduler_output: SchedulerOutput = None,
+        num_scheduled_tokens: int = 0,
+        num_rejected_tokens_gpu: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        self._last_draft_probs = None
+        batch_size = common_attn_metadata.batch_size()
+
+        if token_indices_to_sample is None:
+            token_indices_to_sample = common_attn_metadata.query_start_loc[1:] - 1
+
+        num_tokens, token_indices_to_sample, common_attn_metadata, long_seq_args = self.set_inputs_first_pass(
+            target_token_ids=target_token_ids,
+            next_token_ids=next_token_ids,
+            target_positions=target_positions,
+            target_hidden_states=target_hidden_states,
+            token_indices_to_sample=token_indices_to_sample,
+            cad=common_attn_metadata,
+            num_rejected_tokens_gpu=num_rejected_tokens_gpu,
+            req_scheduled_tokens=req_scheduled_tokens,
+            long_seq_metadata=long_seq_metadata,
+            num_prefill_reqs=num_prefill_reqs,
+            num_decode_reqs=num_decode_reqs,
+        )
+        if self.pcp_size * self.dcp_size > 1:
+            assert long_seq_args is not None
+        assert self.runner is not None
+
+        has_lora = len(self.runner.input_batch.lora_id_to_lora_request) > 0
+        uniform_decode = target_model_batch_desc.uniform
+
+        if self.use_cuda_graph:
+            _, batch_descriptor = self.runner.cudagraph_dispatcher.dispatch(
+                num_tokens=num_tokens,
+                uniform_decode=uniform_decode,
+                has_lora=has_lora,
+            )
+            num_input_tokens = batch_descriptor.num_tokens
+        else:
+            num_input_tokens = num_tokens
+
+        (
+            num_input_tokens,
+            num_tokens_across_dp,
+            _,
+        ) = self.runner._sync_metadata_across_dp(num_input_tokens, is_draft_model=True)
+
+        if self.use_cuda_graph:
+            aclgraph_runtime_mode, batch_descriptor = self.runner.cudagraph_dispatcher.dispatch(
+                num_tokens=num_input_tokens,
+                uniform_decode=uniform_decode,
+                has_lora=has_lora,
+            )
+            num_input_tokens = batch_descriptor.num_tokens
+        else:
+            aclgraph_runtime_mode = CUDAGraphMode.NONE
+            batch_descriptor = None
+
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL:
+            num_reqs_padded = self.runner._pad_query_start_loc_for_fia(
+                num_input_tokens,
+                batch_descriptor.num_reqs if batch_descriptor.num_reqs is not None else common_attn_metadata.num_reqs,
+                common_attn_metadata.num_reqs,
+                aclgraph_runtime_mode,
+                batch_descriptor.num_reqs,
+            )
+            common_attn_metadata.num_reqs = num_reqs_padded
+            common_attn_metadata.query_start_loc = self.runner.query_start_loc.gpu[: num_reqs_padded + 1]
+            common_attn_metadata.query_start_loc_cpu = self.runner.query_start_loc.cpu[: num_reqs_padded + 1]
+            slicing_length = (
+                num_reqs_padded * self.decode_threshold if self.pcp_size * self.dcp_size > 1 else num_reqs_padded
+            )
+            common_attn_metadata.block_table_tensor = self._adjust_tensor(
+                common_attn_metadata.block_table_tensor, slicing_length
+            )
+            common_attn_metadata.seq_lens = self._adjust_tensor(self.runner.seq_lens, num_reqs_padded)
+            common_attn_metadata.seq_lens_cpu = self._adjust_tensor(
+                self.runner.optimistic_seq_lens_cpu, num_reqs_padded
+            )
+            if common_attn_metadata._seq_lens_cpu is not None:
+                common_attn_metadata._seq_lens_cpu = common_attn_metadata.seq_lens_cpu.clone()
+            if common_attn_metadata.num_computed_tokens_cpu is not None:
+                common_attn_metadata.num_computed_tokens_cpu = self._adjust_tensor(
+                    common_attn_metadata.num_computed_tokens_cpu, num_reqs_padded
+                )
+
+            if self.pcp_size > 1:
+                pcp_allgather_restore_idx = (
+                    common_attn_metadata.prefill_context_parallel_metadata.pcp_allgather_restore_idx
+                )
+                index = torch.arange(
+                    pcp_allgather_restore_idx.shape[0],
+                    device=pcp_allgather_restore_idx.device,
+                )
+                mask = (index % (self.pcp_size * self.decode_threshold)) >= self.decode_threshold
+                pcp_allgather_restore_idx[mask] = 0
+                self.runner.pcp_manager.pcp_allgather_restore_idx.gpu[: pcp_allgather_restore_idx.shape[0]] = (
+                    pcp_allgather_restore_idx
+                )
+                self.runner.pcp_manager.pcp_allgather_restore_idx.gpu[pcp_allgather_restore_idx.shape[0] :] = 0
+        else:
+            num_reqs_padded = common_attn_metadata.num_reqs
+            if not self.vllm_config.model_config.use_mla and self.pcp_size * self.dcp_size == 1:
+                common_attn_metadata.block_table_tensor = self._adjust_tensor(
+                    common_attn_metadata.block_table_tensor, num_reqs_padded
+                )
+
+        if self.supports_mm_inputs:
+            inputs_embeds = self.model.embed_input_ids(self.input_ids[:num_tokens])
+            self.inputs_embeds[:num_tokens] = inputs_embeds
+            inputs_embeds = self.inputs_embeds[:num_input_tokens]
+        else:
+            inputs_embeds = None
+
+        slot_mapping_len = common_attn_metadata.slot_mapping.shape[0]
+        self.slot_mapping_group[0][:slot_mapping_len].copy_(common_attn_metadata.slot_mapping)
+        self.slot_mapping_group[0][slot_mapping_len:].fill_(PADDING_SLOT_ID)
+        common_attn_metadata.slot_mapping = self.slot_mapping_group[0]
+        self._per_group_slot_mappings[self.kv_cache_gid] = self.slot_mapping_group[0][
+            : common_attn_metadata.num_actual_tokens
+        ]
+
+        self.seq_lens_group[0][:num_reqs_padded].copy_(common_attn_metadata.seq_lens)
+        self.seq_lens_group[0][num_reqs_padded:].fill_(0)
+        common_attn_metadata.seq_lens = self.seq_lens_group[0][:num_reqs_padded]
+
+        self.query_start_loc_group[0][: num_reqs_padded + 1].copy_(common_attn_metadata.query_start_loc)
+        self.query_start_loc_group[0][num_reqs_padded + 1 :].fill_(0)
+        common_attn_metadata.query_start_loc = self.query_start_loc_group[0][: num_reqs_padded + 1]
+        common_attn_metadata.num_input_tokens = num_input_tokens
+        _, multi_steps_attn_metadata = self._build_step_attn_metadatas(common_attn_metadata)
+        attn_metadata_i = next(iter(multi_steps_attn_metadata[0].values()))
+
+        if not self.use_cuda_graph:
+            common_attn_metadata.block_table_tensor = common_attn_metadata.block_table_tensor.clone()
+
+        token_indices_to_sample_len = token_indices_to_sample.shape[0]
+        self.token_indices_to_sample[:token_indices_to_sample_len].copy_(token_indices_to_sample)
+        self.token_indices_to_sample[token_indices_to_sample_len:].fill_(0)
+
+        with set_ascend_forward_context(
+            multi_steps_attn_metadata[0],
+            self.vllm_config,
+            num_tokens=num_input_tokens,
+            num_tokens_across_dp=num_tokens_across_dp,
+            num_actual_tokens=num_tokens,
+            batch_descriptor=batch_descriptor,
+            aclgraph_runtime_mode=aclgraph_runtime_mode,
+            is_draft_model=True,
+            draft_attn_metadatas=multi_steps_attn_metadata,
+        ):
+            forward_context = get_forward_context()
+            if forward_context is not None:
+                forward_context.moe_layer_index = 0
+
+            model_inputs: dict[str, Any] = {
+                "num_input_tokens": num_input_tokens,
+                "batch_size": batch_size,
+                "token_indices_to_sample": self.token_indices_to_sample[:token_indices_to_sample_len],
+                "target_positions": target_positions,
+                "inputs_embeds": inputs_embeds,
+                "multi_steps_attn_metadata": multi_steps_attn_metadata,
+                "num_tokens": num_tokens,
+                "is_prefill": attn_metadata_i.num_prefills,
+            }
+            run_draft = partial(self._runnable, **model_inputs)
+            if self.enable_enpu:
+                self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
+                draft_token_ids = run_draft()
+            else:
+                draft_token_ids = run_draft()
+                self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
+        return draft_token_ids
+
+    def _run_merged_draft(
+        self,
+        num_input_tokens,
+        batch_size,
+        token_indices_to_sample,
+        target_positions,
+        inputs_embeds,
+        multi_steps_attn_metadata,
+        num_tokens,
+        is_prefill=None,
+    ) -> torch.Tensor:
+        """Base MTP execution flow with Step3.5 step-aware layer/head selection."""
+        self._last_draft_probs = None
+        sampling_metadata = self.runner.input_batch.sampling_metadata
+        model_input_ids = self.input_ids[:num_input_tokens]
+        model_positions = self._get_positions(num_input_tokens)
+        model_kwargs = {
+            "input_ids": model_input_ids,
+            "positions": model_positions,
+            "inputs_embeds": inputs_embeds,
+            "spec_step_idx": 0,
+        }
+        if self.pass_hidden_states_to_model:
+            model_hidden_states = self.hidden_states[:num_input_tokens]
+            model_hidden_states, model_positions = self.maybe_pad_and_reduce(model_hidden_states, model_positions)
+            model_kwargs["hidden_states"] = model_hidden_states
+            model_kwargs["positions"] = model_positions
+
+        ret_hidden_states = self.model(**model_kwargs)
+        if not self.model_returns_tuple():
+            last_hidden_states = ret_hidden_states
+            hidden_states = last_hidden_states
+        else:
+            last_hidden_states, hidden_states = ret_hidden_states
+
+        last_hidden_states, model_positions, hidden_states = self.maybe_all_gather_and_unpad(
+            last_hidden_states, model_positions, hidden_states
+        )
+
+        num_indices = token_indices_to_sample.shape[0]
+        if lmhead_tp_enable():
+            max_num_reqs_across_dp = (
+                self.vllm_config.scheduler_config.max_num_seqs * self.runner.uniform_decode_query_len
+            )
+            token_indices_to_sample = torch.nn.functional.pad(
+                token_indices_to_sample, (0, max_num_reqs_across_dp - num_indices)
+            )
+
+        sample_hidden_states = last_hidden_states[token_indices_to_sample]
+        draft_token_ids, draft_probs = self._sample_draft_tokens_for_step(
+            sample_hidden_states,
+            sampling_metadata,
+            spec_step_idx=0,
+            num_indices=num_indices,
+        )
+        if self.num_speculative_tokens == 1 or self.parallel_drafting:
+            if draft_probs is not None:
+                self._last_draft_probs = draft_probs.view(
+                    -1, self.num_speculative_tokens, draft_probs.shape[-1]
+                ).contiguous()
+            return draft_token_ids.view(-1, self.num_speculative_tokens)
+
+        if self.pcp_size * self.dcp_size > 1 and is_prefill:
+            draft_token_ids_list = [draft_token_ids for _ in range(self.num_speculative_tokens)]
+            return torch.stack(draft_token_ids_list, dim=1)
+
+        return self._run_window_draft_steps(
+            first_draft_token_ids=draft_token_ids,
+            first_draft_probs=draft_probs,
+            first_hidden_states=hidden_states,
+            num_input_tokens=num_input_tokens,
+            batch_size=batch_size,
+            token_indices_to_sample=token_indices_to_sample,
+            target_positions=target_positions,
+            num_tokens=num_tokens,
+            multi_steps_attn_metadata=multi_steps_attn_metadata,
+            inputs_embeds=inputs_embeds,
+            sampling_metadata=sampling_metadata,
+        )
+
+    def _roll_window_inputs_only(
+        self,
+        *,
+        prev_token_ids: torch.Tensor,
+        next_token_ids: torch.Tensor,
+        previous_hidden_states: torch.Tensor,
+        token_indices_to_sample: torch.Tensor,
+        num_tokens: int,
+        input_batch_size: int,
+    ) -> torch.Tensor | None:
+        self.input_ids[: num_tokens - 1] = prev_token_ids[1:]
+        self.input_ids[token_indices_to_sample] = next_token_ids
+        self.hidden_states[:num_tokens] = previous_hidden_states.view(num_tokens, -1)
+
+        if self.supports_mm_inputs:
+            self.inputs_embeds[:num_tokens] = self.model.embed_input_ids(self.input_ids[:num_tokens])
+            return self.inputs_embeds[:input_batch_size]
+        return None
+
+    def _run_window_draft_steps(
+        self,
+        *,
+        first_draft_token_ids: torch.Tensor,
+        first_draft_probs: torch.Tensor | None,
+        first_hidden_states: torch.Tensor,
+        num_input_tokens: int,
+        batch_size: int,
+        token_indices_to_sample: torch.Tensor,
+        target_positions: torch.Tensor,
+        num_tokens: int,
+        multi_steps_attn_metadata,
+        inputs_embeds,
+        sampling_metadata: SamplingMetadata,
+    ) -> torch.Tensor:
+        """Run the Step3.5 MTP full-window layer chain.
+
+        This is the canonical Step3.5 MTP draft path, matching the full-window
+        multi-layer proposer loop: every MTP layer reprocesses the whole draft
+        window so each independent KV-cache group is seeded over the full
+        window. Attention metadata is built once before this loop; layer-to-layer
+        state transition only rolls the model input buffers by shifting the
+        previous window and placing the newly drafted token at
+        token_indices_to_sample.
+        """
+        draft_probs_list = None if first_draft_probs is None else [first_draft_probs]
+        draft_token_ids_list = [first_draft_token_ids]
+        full_hidden_states = first_hidden_states[:num_tokens]
+        input_batch_size = num_input_tokens
+
+        forward_context = get_forward_context()
+        _EXTRA_CTX.num_tokens = input_batch_size
+        _EXTRA_CTX.num_accept_tokens = batch_size
+
+        for draft_step in range(self.num_speculative_tokens - 1):
+            forward_context = get_forward_context()
+            if forward_context is not None:
+                forward_context.moe_layer_index = 0
+
+            spec_step_idx = draft_step + 1
+            prev_token_ids = self.input_ids[:num_tokens].clone()
+            next_token_ids = draft_token_ids_list[-1].int()
+            inputs_embeds = self._roll_window_inputs_only(
+                prev_token_ids=prev_token_ids,
+                next_token_ids=next_token_ids,
+                previous_hidden_states=full_hidden_states,
+                token_indices_to_sample=token_indices_to_sample,
+                num_tokens=num_tokens,
+                input_batch_size=input_batch_size,
+            )
+
+            model_input_ids = self.input_ids[:input_batch_size]
+            model_positions = self._get_positions(input_batch_size)
+            model_hidden_states = self.hidden_states[:input_batch_size]
+            model_hidden_states, model_positions = self.maybe_pad_and_reduce(
+                model_hidden_states,
+                model_positions,
+            )
+            if forward_context is not None and multi_steps_attn_metadata:
+                if spec_step_idx >= len(multi_steps_attn_metadata):
+                    raise AssertionError("Step3.5 MTP metadata must contain one entry per draft step")
+                forward_context.attn_metadata = multi_steps_attn_metadata[spec_step_idx]
+
+            model_kwargs = {
+                "input_ids": model_input_ids,
+                "positions": model_positions,
+                "inputs_embeds": inputs_embeds,
+                "spec_step_idx": spec_step_idx,
+            }
+            if self.pass_hidden_states_to_model:
+                model_kwargs["hidden_states"] = model_hidden_states
+
+            ret_hidden_states = self.model(**model_kwargs)
+            if not self.model_returns_tuple():
+                last_hidden_states = ret_hidden_states
+                hidden_states = ret_hidden_states
+            else:
+                last_hidden_states, hidden_states = ret_hidden_states
+
+            last_hidden_states, model_positions, hidden_states = self.maybe_all_gather_and_unpad(
+                last_hidden_states,
+                model_positions,
+                hidden_states,
+            )
+
+            num_indices = token_indices_to_sample.shape[0]
+            sample_hidden_states = last_hidden_states[token_indices_to_sample]
+            draft_token_ids, draft_probs = self._sample_draft_tokens_for_step(
+                sample_hidden_states,
+                sampling_metadata,
+                spec_step_idx=spec_step_idx,
+                num_indices=num_indices,
+            )
+            if draft_probs is not None:
+                assert draft_probs_list is not None
+                draft_probs_list.append(draft_probs)
+            full_hidden_states = hidden_states[:num_tokens]
+            draft_token_ids_list.append(draft_token_ids)
+
+        draft_token_ids = torch.stack(draft_token_ids_list, dim=1)
+        if draft_probs_list is not None:
+            self._last_draft_probs = torch.stack(draft_probs_list, dim=1).contiguous()
+        return draft_token_ids
+
+    # -- overrides matching the GPU Step3p5MTPProposer ----------------------
+
+    def _ensure_draft_layer_types_cover_mtp_layers(self) -> None:
+        hf_config = self.draft_model_config.hf_config
+        layer_types = getattr(hf_config, "layer_types", None)
+        num_hidden_layers = getattr(hf_config, "num_hidden_layers", None)
+        num_mtp_layers = getattr(hf_config, "num_nextn_predict_layers", 0)
+
+        if layer_types is None or num_hidden_layers is None or num_mtp_layers is None:
+            return
+
+        needed_num_layer_types = num_hidden_layers + num_mtp_layers
+        if len(layer_types) >= needed_num_layer_types:
+            return
+
+        hf_config.layer_types = list(layer_types) + ["sliding_attention"] * (needed_num_layer_types - len(layer_types))
+
+    def _create_draft_vllm_config(self) -> VllmConfig:
+        base = super()._create_draft_vllm_config()
+        # Transformers validates Step3.5 layer_types against num_hidden_layers
+        # and may leave only the base-layer entries. The MTP draft model builds
+        # layers at num_hidden_layers + k, so make the draft config cover those
+        # layer indices before the model is constructed.
+        self._ensure_draft_layer_types_cover_mtp_layers()
+        # Ascend ModelSlim keeps quant metadata in quant_model_description.json,
+        # not in config.json's quantization_config, so get_quant_config falls
+        # through to the hf_overrides branch. The verifier model_config has
+        # hf_overrides={}, but the draft_model_config leaves it None, which that
+        # branch rejects. Normalize to {} so the draft takes the verifier's path.
+        if not isinstance(getattr(self.draft_model_config, "hf_overrides", None), dict):
+            self.draft_model_config.hf_overrides = {}
+        return replace(
+            base,
+            model_config=self.draft_model_config,
+            quant_config=get_draft_quant_config(base),
+        )
+
+    def validate_same_kv_cache_group(self, kv_cache_config: KVCacheConfig) -> None:
+        """Step3.5 MTP draft layers may span multiple KV cache groups."""
+        return
+
+    def initialize_attn_backend(
+        self,
+        kv_cache_config: KVCacheConfig,
+        kernel_block_sizes: list[int] | None = None,
+    ) -> None:
+        all_attn_layers = get_layers_from_vllm_config(
+            self.vllm_config,
+            AttentionLayerBase,  # type: ignore[type-abstract]
+        )
+
+        layer_to_gid: dict[str, int] = {}
+        layer_to_spec: dict[str, KVCacheSpec] = {}
+        for gid, group in enumerate(kv_cache_config.kv_cache_groups):
+            group_spec = group.kv_cache_spec
+            for layer_name in group.layer_names:
+                layer_to_gid[layer_name] = gid
+                if isinstance(group_spec, UniformTypeKVCacheSpecs):
+                    if layer_name in group_spec.kv_cache_specs:
+                        layer_to_spec[layer_name] = group_spec.kv_cache_specs[layer_name]
+                    else:
+                        target_layer_name = getattr(
+                            all_attn_layers.get(layer_name),
+                            "kv_sharing_target_layer_name",
+                            None,
+                        )
+                        if target_layer_name and target_layer_name in group_spec.kv_cache_specs:
+                            layer_to_spec[layer_name] = group_spec.kv_cache_specs[target_layer_name]
+                        else:
+                            layer_to_spec[layer_name] = group_spec
+                else:
+                    layer_to_spec[layer_name] = group_spec
+
+        attention_groups: dict[tuple[str, int], AttentionGroup] = {}
+        for layer_name in sorted(self._draft_attn_layer_names):
+            if layer_name not in layer_to_spec:
+                continue
+            attn_layer = all_attn_layers[layer_name]
+            attn_backend = attn_layer.get_attn_backend()
+            spec = layer_to_spec[layer_name]
+            gid = layer_to_gid[layer_name]
+            group_key = (attn_backend.full_cls_name(), gid)
+
+            if group_key not in attention_groups:
+                kernel_block_size = (
+                    kernel_block_sizes[gid]
+                    if kernel_block_sizes is not None and gid < len(kernel_block_sizes)
+                    else None
+                )
+                attn_group = AttentionGroup(
+                    backend=attn_backend,
+                    layer_names=[layer_name],
+                    kv_cache_spec=spec,
+                    kv_cache_group_id=gid,
+                )
+                attn_group.create_metadata_builders(
+                    self.vllm_config,
+                    self.device,
+                    kernel_block_size=kernel_block_size,
+                )
+                attention_groups[group_key] = attn_group
+            else:
+                attention_groups[group_key].layer_names.append(layer_name)
+
+        self.draft_attn_groups = list(attention_groups.values())
+        if self.draft_attn_groups:
+            self.kv_cache_gid = self.draft_attn_groups[0].kv_cache_group_id
+            self.block_size = self.draft_attn_groups[0].get_metadata_builder().kv_cache_spec.block_size
+        else:
+            self.kv_cache_gid = 0
+            self.block_size = kv_cache_config.kv_cache_groups[0].kv_cache_spec.block_size

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -137,6 +137,7 @@ from vllm_ascend.spec_decode.extract_hidden_states_proposer import (
 from vllm_ascend.spec_decode.medusa_proposer import AscendMedusaProposer
 from vllm_ascend.spec_decode.ngram_proposer import AscendNgramProposer
 from vllm_ascend.spec_decode.ngram_proposer_npu import AscendNgramProposerNPU
+from vllm_ascend.spec_decode.step3p5 import AscendStep3p5MTPProposer
 from vllm_ascend.spec_decode.suffix_proposer import AscendSuffixDecodingProposer
 from vllm_ascend.spec_decode.utils import (
     correct_optimistic_seq_lens_cpu,
@@ -611,6 +612,7 @@ class NPUModelRunner(GPUModelRunner):
             AscendNgramProposer
             | AscendNgramProposerNPU
             | AscendEagleProposer
+            | AscendStep3p5MTPProposer
             | AscendDraftModelProposer
             | AscendDflashProposer
             | AscendSuffixDecodingProposer
@@ -3271,6 +3273,12 @@ class NPUModelRunner(GPUModelRunner):
                 cm.block_table_tensor, cm.slot_mapping = _get_block_table_and_slot_mapping(
                     kv_cache_gid
                 )
+            if self.speculative_config and isinstance(self.drafter, AscendStep3p5MTPProposer):
+                # step3p5 MTP draft layers span multiple KV cache groups; capture
+                # each group's block table / slot mapping so the proposer can
+                # build per-step attention metadata for the active MTP layer.
+                self.drafter.set_per_group_attn_metadata(
+                    kv_cache_gid, cm.block_table_tensor, cm.slot_mapping)
             if self.speculative_config and spec_decode_common_attn_metadata is None:
                 if isinstance(self.drafter, AscendEagleProposer | AscendDraftModelProposer | AscendDflashProposer):
                     if self.drafter.attn_layer_names[0] in kv_cache_group.layer_names:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds Ascend support for Step3P5 and Step3P7 models with MTP speculative decoding.

With this change, Step3P5 and Step3P7 checkpoints can run on Ascend with `--speculative_config '{"method": "mtp", "num_speculative_tokens": 3}'` enabled for Step3p5 MTP, allowing the model to draft multiple tokens and use speculative decoding to improve generation performance.

This is needed to support Step-family MTP checkpoints on Ascend and align Ascend speculative decoding capability with the model architecture used by Step3P5/Step3P7.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

e2e:
```
export HCCL_CONNECT_TIMEOUT=7200
export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
export HCCL_OP_EXPANSION_MODE="AIV"
export HCCL_BUFFSIZE=512
export CPU_AFFINITY_CONF=1
export TASK_QUEUE_ENABLE=0
export SHM_BARRIER="true"
export VLLM_ASCEND_ENABLE_FLASHCOMM1=0
LD_PRELOAD=/lib/x86_64-linux-gnu/libjemalloc.so.2
capture_size=$(echo {1..64} | tr ' ' ',')
vllm serve path/to/model \
  --trust-remote-code \
  --tensor-parallel-size 8 \
  --pipeline-parallel-size 1 \
  --port 8000 \
  --compilation-config "{\"cudagraph_mode\": \"FULL_DECODE_ONLY\", \"cudagraph_capture_sizes\": [$capture_size]}" \
  --reasoning-parser step3p5 \
  --enable-auto-tool-choice \
  --tool-call-parser step3p5 \
  --gpu-memory-utilization 0.96 \
  --no-enable-prefix-caching \
  --served-model-name "step3p7" \
  --max-num-seqs 16 \
  --async-scheduling \
  --max-num-batched-tokens 65536 \
  --enable-expert-parallel \
  --additional-config '{"weight_prefetch_config":{"enabled":true}}'  \
  --speculative_config '{"method": "mtp", "num_speculative_tokens": 3}' 
```

- 精度

```
evalscope eval \
 --model step3p7 \
 --api-url http://0.0.0.0:8000/v1/chat/completions \
 --generation-config do_sample=true,temperature=1.0,top_p=0.95,stream=true \
 --eval-batch-size 16 \
 --dataset-args '{"aime25":{"shuffle": false}}' \
 --datasets aime25 \
 --repeat 16 \
 --timeout 5400
```

<img width="1364" height="230" alt="image" src="https://github.com/user-attachments/assets/0c2469e7-bce1-45eb-bca8-804b2bb60931" />
<img width="2494" height="348" alt="image" src="https://github.com/user-attachments/assets/890dfdad-8d7c-4bb5-93a2-5b88dc1c374d" />


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
