### PR TITLE
[CI] Adjust test case timeout to fit different scenarios

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -98,7 +98,7 @@ jobs:
   e2e:
     name: ${{ inputs.config_file_path }}
     # timeout-minutes: 120
-    timeout-minutes: ${{ inputs.request_id != '' && 240 || (inputs.testcase_timeout != '' && inputs.testcase_timeout || 120) }}
+    timeout-minutes: ${{ inputs.request_id != '' && 240 || fromJSON(inputs.testcase_timeout) }}
     # This is the runner with no NPU for k8s controller
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.should_run }}

--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -68,6 +68,11 @@ on:
         type: string
         default: ''
         description: non-empty when triggered by PR /nightly command
+      testcase_timeout:
+        required: false
+        default: 120
+        type: string
+        description: test case execution timeout period,default:120 minutes
     secrets:
       KUBECONFIG_B64:
         required: true
@@ -92,7 +97,8 @@ concurrency:
 jobs:
   e2e:
     name: ${{ inputs.config_file_path }}
-    timeout-minutes: 120
+    # timeout-minutes: 120
+    timeout-minutes: ${{ inputs.request_id != '' && 240 || (inputs.testcase_timeout != '' && inputs.testcase_timeout || 120) }}
     # This is the runner with no NPU for k8s controller
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.should_run }}

--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -97,7 +97,6 @@ concurrency:
 jobs:
   e2e:
     name: ${{ inputs.config_file_path }}
-    # timeout-minutes: 120
     timeout-minutes: ${{ inputs.request_id != '' && 240 || fromJSON(inputs.testcase_timeout) }}
     # This is the runner with no NPU for k8s controller
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -88,7 +88,6 @@ jobs:
     name: ${{ inputs.name || inputs.config_file_path || inputs.tests }}
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.should_run }}
-    # timeout-minutes: 120
     timeout-minutes: ${{ inputs.request_id != '' && 240 || fromJSON(inputs.testcase_timeout) }}
     container:
       image: ${{ inputs.image }}

--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -59,6 +59,11 @@ on:
         type: string
         default: ''
         description: PR commit SHA for PR-triggered checkout
+      testcase_timeout:
+        required: false
+        default: 120
+        type: string
+        description: test case execution timeout period,default:120 minutes
     secrets:
       OBS_ACCESS_KEY:
         required: false
@@ -83,7 +88,8 @@ jobs:
     name: ${{ inputs.name || inputs.config_file_path || inputs.tests }}
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.should_run }}
-    timeout-minutes: 120
+    # timeout-minutes: 120
+    timeout-minutes: ${{ inputs.request_id != '' && 240 || (inputs.testcase_timeout != '' && inputs.testcase_timeout || 120) }}
     container:
       image: ${{ inputs.image }}
     env:

--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.should_run }}
     # timeout-minutes: 120
-    timeout-minutes: ${{ inputs.request_id != '' && 240 || (inputs.testcase_timeout != '' && inputs.testcase_timeout || 120) }}
+    timeout-minutes: ${{ inputs.request_id != '' && 240 || fromJSON(inputs.testcase_timeout) }}
     container:
       image: ${{ inputs.image }}
     env:

--- a/.github/workflows/_e2e_nightly_single_node_models.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_models.yaml
@@ -50,6 +50,11 @@ on:
         type: string
         default: ''
         description: PR commit SHA for PR-triggered checkout
+      testcase_timeout:
+        required: false
+        default: 120
+        type: string
+        description: test case execution timeout period,default:120 minutes
     secrets:
       OBS_ACCESS_KEY:
         required: false
@@ -74,6 +79,7 @@ jobs:
     name: ${{inputs.model_list}} accuracy test
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.is_run }}
+    timeout-minutes: ${{ inputs.request_id != '' && 240 || fromJSON(inputs.testcase_timeout) }}
     container:
       image: "${{ inputs.image }}"
       env:

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -209,6 +209,7 @@ jobs:
       config_file_path: ${{ matrix.test_config.config_file_path }}
       config_base_path: tests/e2e/weekly/single_node/configs/
       name: ${{ matrix.test_config.name }}
+      testcase_timeout: 600
       should_run: >-
         ${{
           needs.setup-vars.outputs.filter == 'all' ||

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -145,6 +145,7 @@ jobs:
       config_base_path: tests/e2e/weekly/multi_node/internal_dp/config
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ github.sha }}
+      testcase_timeout: 600
       should_run: >-
         ${{
           needs.setup-vars.outputs.filter == 'all' ||


### PR DESCRIPTION
### What this PR does / why we need it?

Background: 
1. Before running the selected test cases, the nightly test triggered by PR may require additional time to check and install the PR code. Currently, the reusable nightly workflow either hardcodes a timeout of 120 minutes or does not define a consistent job timeout. As a result, the long-running PR nightly job is canceled before it is completed. 
2. In the current weekly workflow, a test case is configured with more than 10 performance scenarios, and the execution times out and is interrupted.
 
Modification: 
- When the request_id is not empty (PR or nightly scheduling), the timeout is set to 240 minutes.
- For scheduled nightly running and regular manual scheduling without request_id, if a value is passed, the timeout of the passed value is used. If no value is passed, the default timeout of 120 minutes is used.
- The timeout is set to 600 minutes during the scheduling of the weekly scheduled task.
### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?
by the running the test


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
