### PR TITLE
[Misc] Drop vLLM v0.22.1 compatibility from main

### DIFF
--- a/.github/workflows/nightly_image_build.yaml
+++ b/.github/workflows/nightly_image_build.yaml
@@ -26,10 +26,11 @@ on:
       vllm_ascend_branch:
         description: 'Branch to nightly test'
         required: true
-        default: 'main'
+        default: 'releases/v0.22.1rc'
         type: choice
         options:
           - main
+          - releases/v0.22.1rc
           - releases/v0.18.0
 
 jobs:

--- a/.github/workflows/pr_e2e_command.yml
+++ b/.github/workflows/pr_e2e_command.yml
@@ -181,7 +181,10 @@ jobs:
       matrix:
         vllm_version:
           - ${{ needs.e2e-test.outputs.main_commit }}
-          - ${{ needs.e2e-test.outputs.release_tag }}
+          # Dropped vLLM v0.22.1 (release-tag) compatibility from main. Uncomment
+          # the line below to re-enable release-tag e2e when maintaining a new
+          # release tag (update .github/vllm-release-tag.commit accordingly).
+          # - ${{ needs.e2e-test.outputs.release_tag }}
     needs: [e2e-test]
     if: ${{ needs.e2e-test.outputs.has_tests == 'true' }}
     uses: ./.github/workflows/_selected_tests.yaml

--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -207,7 +207,10 @@ jobs:
       matrix:
         vllm_version:
           - ${{ needs.lint-and-select-tests.outputs.main_commit }}
-          - ${{ needs.lint-and-select-tests.outputs.release_tag }}
+          # Dropped vLLM v0.22.1 (release-tag) compatibility from main. Uncomment
+          # the line below to re-enable release-tag CI when maintaining a new
+          # release tag (update .github/vllm-release-tag.commit accordingly).
+          # - ${{ needs.lint-and-select-tests.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -41,6 +41,7 @@ on:
         type: choice
         options:
           - main
+          - releases/v0.22.1rc
           - releases/v0.21.0rc
           - releases/v0.20.2rc
           - releases/v0.18.0

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -25,7 +25,7 @@ on:
       vllm_ascend_branch:
         description: 'Branch to test'
         required: true
-        default: 'main'
+        default: 'releases/v0.22.1rc'
         type: string
       test_cases:
         description: 'Test cases to run (comma-separated, e.g., "test_custom_op,qwen3-32b,accuracy-group" or "all" for all tests)'

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -26,7 +26,7 @@ on:
       vllm_ascend_branch:
         description: 'Branch to test'
         required: true
-        default: 'main'
+        default: 'releases/v0.22.1rc'
         type: string
       test_cases:
         description: 'Test cases to run (comma-separated, e.g., "test_custom_op,qwen3-32b,accuracy-group" or "all" for all tests)'

--- a/.github/workflows/schedule_update_estimated_times.yaml
+++ b/.github/workflows/schedule_update_estimated_times.yaml
@@ -109,18 +109,22 @@ jobs:
       upload_timing: true
       continue_on_error: true
 
-  run-tests-release:
-    needs: select-tests
-    if: ${{ needs.select-tests.outputs.has_tests == 'true' }}
-    uses: ./.github/workflows/_selected_tests.yaml
-    with:
-      vllm: ${{ needs.select-tests.outputs.release_tag }}
-      test_groups: ${{ needs.select-tests.outputs.test_groups }}
-      upload_timing: true
-      continue_on_error: true
+  # Dropped vLLM v0.22.1 (release-tag) compatibility from main. Uncomment this
+  # job to re-enable release-tag timing collection when maintaining a new
+  # release tag (update .github/vllm-release-tag.commit accordingly).
+  # run-tests-release:
+  #   needs: select-tests
+  #   if: ${{ needs.select-tests.outputs.has_tests == 'true' }}
+  #   uses: ./.github/workflows/_selected_tests.yaml
+  #   with:
+  #     vllm: ${{ needs.select-tests.outputs.release_tag }}
+  #     test_groups: ${{ needs.select-tests.outputs.test_groups }}
+  #     upload_timing: true
+  #     continue_on_error: true
 
   update-estimated-times:
-    needs: [run-tests-main, run-tests-release]
+    needs: [run-tests-main]
+    # needs: [run-tests-main, run-tests-release]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/schedule_vllm_e2e_test.yaml
+++ b/.github/workflows/schedule_vllm_e2e_test.yaml
@@ -18,8 +18,14 @@
 name: E2E-upstream
 
 on:
-  schedule:
-    - cron: '0 8 * * 0' # every Sunday at 8:00
+  # Dropped vLLM v0.22.1 (release-tag) compatibility from main. This workflow
+  # runs vllm-ascend main against the v0.22.1 release tag and would now fail, so
+  # the weekly schedule is disabled (left manually runnable via workflow_dispatch).
+  # Re-enable the cron below and update .github/vllm-release-tag.commit when
+  # maintaining a new release tag.
+  workflow_dispatch:
+  # schedule:
+  #   - cron: '0 8 * * 0' # every Sunday at 8:00
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
 # It's used to activate ascend-toolkit environment variables.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Below are the maintained branches:
 
 | Branch           | Status       | Note                                 |
 |------------------|--------------|--------------------------------------|
-| main             | Maintained   | CI commitment for vLLM main branch and vLLM v0.22.1 tag |
+| main             | Maintained   | CI commitment for vLLM main branch |
 | v0.7.1-dev       | Unmaintained | Outdated, no longer maintained. |
 | v0.7.3-dev       | Unmaintained | Only bug fixes are allowed, and no new release tags anymore. |
 | v0.9.1-dev       | Unmaintained | Only bug fixes are allowed, and no new release tags anymore. |

--- a/README.zh.md
+++ b/README.zh.md
@@ -80,7 +80,7 @@ vllm-ascend有主干分支和开发分支。
 
 | 分支              | 状态         | 备注                  |
 |------------------|--------------|----------------------|
-| main             | Maintained   | 基于vLLM main分支和vLLM最新版本（v0.22.1）CI看护   |
+| main             | Maintained   | 基于vLLM main分支CI看护   |
 | v0.7.1-dev       | Unmaintained | 不再维护 |
 | v0.7.3-dev       | Unmaintained | 只允许Bug修复，不会再发布新版本 |
 | v0.9.1-dev       | Unmaintained | 只允许Bug修复，不会再发布新版本 |

--- a/tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py
+++ b/tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py
@@ -22,17 +22,11 @@ import pytest
 from vllm import SamplingParams
 
 from tests.e2e.conftest import VllmRunner
-from vllm_ascend.utils import vllm_version_is
 
 MODELS = ["Qwen/Qwen3-0.6B", "vllm-ascend/DeepSeek-V2-Lite-W8A8"]
 
 MAIN_MODELS = ["LLM-Research/Meta-Llama-3.1-8B-Instruct"]
 EGALE_MODELS = ["vllm-ascend/EAGLE-LLaMA3.1-Instruct-8B"]
-
-pytestmark = pytest.mark.skipif(
-    vllm_version_is("0.22.1"),
-    reason="v2 model runner patches not supported on v0.22.1",
-)
 
 
 @pytest.mark.skipif(True, reason="Fix me, it's broken after CANN and trition-ascend are upgraded.")

--- a/tests/e2e/pull_request/one_card/test_guided_decoding.py
+++ b/tests/e2e/pull_request/one_card/test_guided_decoding.py
@@ -28,7 +28,6 @@ from vllm.outputs import RequestOutput
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 
 from tests.e2e.conftest import VllmRunner
-from vllm_ascend.utils import vllm_version_is
 
 MODEL_NAME = "Qwen/Qwen3-0.6B"
 
@@ -38,9 +37,6 @@ GuidedDecodingBackend = ["xgrammar", "guidance", "outlines"]
 @pytest.fixture(params=[False, True], ids=["v1", "v2"])
 def model_runner_env(request):
     use_v2_model_runner = request.param
-    if use_v2_model_runner and vllm_version_is("0.22.1"):
-        pytest.skip("No need to support v2 model runner for vLLM tag version.")
-
     with patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1" if use_v2_model_runner else "0"}):
         yield
 

--- a/tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py
+++ b/tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py
@@ -5,24 +5,21 @@ from unittest.mock import MagicMock
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+
+# vLLM main removed the ``_WrappedParser`` helper; the base ``Parser``
+# already instantiates from ``reasoning_parser_cls`` / ``tool_parser_cls``
+# class attributes, so a thin ``DelegatingParser`` subclass is equivalent.
+from vllm.parser.abstract_parser import DelegatingParser  # type: ignore[import-not-found]
 from vllm.reasoning.deepseek_v3_reasoning_parser import (
     DeepSeekV3ReasoningWithThinkingParser,
 )
 from vllm.tool_parsers.glm47_moe_tool_parser import Glm47MoeModelToolParser
 
 from vllm_ascend.patch.platform import patch_glm47_tool_call_parser  # noqa: F401
-from vllm_ascend.utils import vllm_version_is
 
-if vllm_version_is("0.22.1"):
-    from vllm.parser.abstract_parser import _WrappedParser  # type: ignore[import-not-found]
-else:
-    # vLLM main removed the ``_WrappedParser`` helper; the base ``Parser``
-    # already instantiates from ``reasoning_parser_cls`` / ``tool_parser_cls``
-    # class attributes, so a thin ``DelegatingParser`` subclass is equivalent.
-    from vllm.parser.abstract_parser import DelegatingParser  # type: ignore[import-not-found]
 
-    class _WrappedParser(DelegatingParser):  # type: ignore[no-redef]
-        pass
+class _WrappedParser(DelegatingParser):
+    pass
 
 
 MOCK_TOKENIZER = MagicMock()
@@ -64,10 +61,6 @@ def _collect_tool_args(tool_calls):
 
 
 def _parse_delta(parser, *args, finished=False, **kwargs):
-    # vLLM main added a required keyword-only ``finished`` arg to
-    # ``parse_delta``; v0.22.1 has no such parameter.
-    if vllm_version_is("0.22.1"):
-        return parser.parse_delta(*args, **kwargs)
     return parser.parse_delta(*args, finished=finished, **kwargs)
 
 

--- a/tests/ut/patch/platform/test_patch_tool_choice_none_content.py
+++ b/tests/ut/patch/platform/test_patch_tool_choice_none_content.py
@@ -1,10 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
 from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatCompletion
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 from vllm.entrypoints.openai.chat_completion.protocol import (
-    ChatCompletionRequest,
     ChatCompletionResponse,
     ChatCompletionResponseChoice,
     ChatCompletionResponseStreamChoice,
@@ -19,12 +17,10 @@ from vllm.entrypoints.openai.engine.protocol import (
     ToolCall,
     UsageInfo,
 )
-from vllm.entrypoints.openai.engine.serving import OpenAIServing
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.parser.abstract_parser import DelegatingParser
 
 from vllm_ascend.patch.platform import patch_tool_choice_none_content  # noqa: F401
-from vllm_ascend.utils import vllm_version_is
 
 
 class _DummyDelegatingParser(DelegatingParser):
@@ -50,55 +46,6 @@ class _DummyDelegatingParser(DelegatingParser):
 
     def extract_tool_calls(self, model_output: str, request):
         return None
-
-
-@pytest.mark.skipif(
-    not vllm_version_is("0.22.1"), reason="OpenAIServing._parse_tool_calls_from_content exists only in v0.22.1"
-)
-def test_parse_tool_calls_from_content_allows_named_tool_choice_with_none_content():
-    request = ChatCompletionRequest.model_validate(
-        {
-            "model": "test-model",
-            "messages": [{"role": "user", "content": "test"}],
-            "tools": [
-                {
-                    "type": "function",
-                    "function": {
-                        "name": "get_weather",
-                        "parameters": {"type": "object", "properties": {}},
-                    },
-                }
-            ],
-            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
-        }
-    )
-
-    tool_calls, content = OpenAIServing._parse_tool_calls_from_content(
-        request=request,
-        tokenizer=None,
-        enable_auto_tools=True,
-        tool_parser_cls=None,
-        content=None,
-    )
-
-    assert content is None
-    assert tool_calls == []
-    assert not request.tool_choice
-
-    tool_calls, content = OpenAIServing._parse_tool_calls_from_content(
-        request=request,
-        tokenizer=None,
-        enable_auto_tools=True,
-        tool_parser_cls=None,
-        content='{"city": "Beijing"}',
-    )
-
-    assert content is None
-    assert request.tool_choice
-    assert tool_calls is not None
-    assert len(tool_calls) == 1
-    assert tool_calls[0].name == "get_weather"
-    assert tool_calls[0].arguments == '{"city": "Beijing"}'
 
 
 def test_responses_parser_allows_named_tool_choice_with_none_content():

--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -26,7 +26,6 @@ from vllm_ascend.patch.platform.patch_kv_cache_utils import (
     _ascend_resolve_kv_cache_block_sizes,
 )
 from vllm_ascend.patch.platform.patch_mamba_manager import AscendMambaManager
-from vllm_ascend.utils import vllm_version_is
 
 
 def _make_hybrid_kv_cache_config(
@@ -340,10 +339,7 @@ def test_ascend_mamba_manager_uses_logical_block_size_with_prefix_caching() -> N
         dcp_world_size=2,
         pcp_world_size=2,
     )
-    # vLLM main added a required ``scheduler_block_size`` arg to
-    # ``SingleTypeKVCacheManager.__init__``; v0.22.1 has no such parameter.
-    if not vllm_version_is("0.22.1"):
-        manager_kwargs["scheduler_block_size"] = mamba_spec.block_size
+    manager_kwargs["scheduler_block_size"] = mamba_spec.block_size
     manager = AscendMambaManager(**manager_kwargs)
 
     assert manager.block_size == mamba_spec.block_size

--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -21,19 +21,13 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
-from vllm_ascend.utils import enable_custom_op, vllm_version_is
+from vllm_ascend.utils import enable_custom_op
 
 enable_custom_op()
 
 # vLLM #40732 moved `SpecDecodeBaseProposer` (and its `CpuGpuBuffer` import)
 # out of `vllm.v1.spec_decode.eagle` into `vllm.v1.spec_decode.llm_base_proposer`.
-# Pick the right patch path depending on the installed vllm version so the
-# tests can mock the buffer factory.
-_CPU_GPU_BUFFER_TARGET = (
-    "vllm.v1.spec_decode.eagle.CpuGpuBuffer"
-    if vllm_version_is("0.19.1")
-    else "vllm.v1.spec_decode.llm_base_proposer.CpuGpuBuffer"
-)
+_CPU_GPU_BUFFER_TARGET = "vllm.v1.spec_decode.llm_base_proposer.CpuGpuBuffer"
 
 BLOCK_SIZE = 16
 
@@ -2429,12 +2423,9 @@ class TestRunMergedDraft(TestBase):
 
         # `CpuGpuBuffer` was re-exported from `eagle` until vLLM #40732 moved
         # `SpecDecodeBaseProposer` (and the import) into `llm_base_proposer`.
-        if vllm_version_is("0.19.1"):
-            assert hasattr(vllm.v1.spec_decode.eagle, "CpuGpuBuffer")
-        else:
-            import vllm.v1.spec_decode.llm_base_proposer
+        import vllm.v1.spec_decode.llm_base_proposer
 
-            assert hasattr(vllm.v1.spec_decode.llm_base_proposer, "CpuGpuBuffer")
+        assert hasattr(vllm.v1.spec_decode.llm_base_proposer, "CpuGpuBuffer")
         RunnerCls = vllm.v1.spec_decode.eagle.SpecDecodeBaseProposer
         for attr in ("_get_positions", "_set_positions"):
             assert hasattr(RunnerCls, attr), f"SpecDecodeBaseProposer.{attr} not found"

--- a/tests/ut/spec_decode/test_extract_hidden_states_proposer.py
+++ b/tests/ut/spec_decode/test_extract_hidden_states_proposer.py
@@ -40,8 +40,6 @@ def _no_pin_memory():
     # pin_memory=True) triggers aclInit and fails.  Patch
     # is_pin_memory_available so vllm's ExtractHiddenStatesProposer.__init__
     # creates CpuGpuBuffer with pin_memory=False.
-    # is_pin_memory_available was introduced in vllm after v0.22.1;
-    # v0.22.1 and older don't use CpuGpuBuffer, so no patch needed.
     with patch(
         "vllm.v1.spec_decode.extract_hidden_states.is_pin_memory_available",
         return_value=False,

--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -22,7 +22,6 @@ from vllm.v1.request import Request
 
 from vllm_ascend.core.single_type_kv_cache_manager import CompressAttentionManager
 from vllm_ascend.patch.platform.patch_kv_cache_coordinator import AscendHybridKVCacheCoordinator
-from vllm_ascend.utils import vllm_version_is
 
 pytestmark = pytest.mark.cpu_test
 
@@ -61,21 +60,13 @@ def _make_compress_manager(
         enable_caching=True,
         hash_block_size=block_size,
     )
-    if vllm_version_is("0.22.1"):
-        manager = CompressAttentionManager(
-            spec,
-            block_pool=block_pool,
-            enable_caching=True,
-            kv_cache_group_id=0,
-        )
-    else:
-        manager = CompressAttentionManager(
-            spec,
-            block_pool=block_pool,
-            enable_caching=True,
-            kv_cache_group_id=0,
-            scheduler_block_size=block_size,
-        )
+    manager = CompressAttentionManager(
+        spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+        scheduler_block_size=block_size,
+    )
     return spec, block_pool, manager
 
 
@@ -113,7 +104,7 @@ def test_compressed_prefix_cache_uses_logical_block_hash() -> None:
         kv_cache_group_ids=[0],
         block_pool=block_pool,
         kv_cache_spec=spec,
-        use_eagle=False,
+        drop_eagle_block=False,
         alignment_tokens=logical_block_size,
     )[0]
 
@@ -140,7 +131,7 @@ def test_compressed_prefix_cache_hits_identical_logical_block() -> None:
         kv_cache_group_ids=[0],
         block_pool=block_pool,
         kv_cache_spec=spec,
-        use_eagle=False,
+        drop_eagle_block=False,
         alignment_tokens=logical_block_size,
     )[0]
 

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -210,6 +210,31 @@ class TestUtils(TestBase):
         with mock.patch("vllm_ascend.utils.enable_dsa_cp", return_value=False):
             self.assertFalse(utils.enable_dsa_cp_with_o_proj_tp())
 
+    def test_vllm_version_is(self):
+        with mock.patch.dict(os.environ, {"VLLM_VERSION": "1.0.0"}):
+            with mock.patch("vllm.__version__", "1.0.0"):
+                self.assertTrue(utils.vllm_version_is.__wrapped__("1.0.0"))
+                self.assertFalse(utils.vllm_version_is.__wrapped__("2.0.0"))
+            with mock.patch("vllm.__version__", "2.0.0"):
+                self.assertTrue(utils.vllm_version_is.__wrapped__("1.0.0"))
+                self.assertFalse(utils.vllm_version_is.__wrapped__("2.0.0"))
+        with mock.patch("vllm.__version__", "1.0.0"):
+            self.assertTrue(utils.vllm_version_is.__wrapped__("1.0.0"))
+            self.assertFalse(utils.vllm_version_is.__wrapped__("2.0.0"))
+        with mock.patch("vllm.__version__", "2.0.0"):
+            self.assertTrue(utils.vllm_version_is.__wrapped__("2.0.0"))
+            self.assertFalse(utils.vllm_version_is.__wrapped__("1.0.0"))
+        # Test caching takes effect
+        utils.vllm_version_is.cache_clear()
+        utils.vllm_version_is("1.0.0")
+        misses = utils.vllm_version_is.cache_info().misses
+        hits = utils.vllm_version_is.cache_info().hits
+        self.assertEqual(misses, 1)
+        self.assertEqual(hits, 0)
+        utils.vllm_version_is("1.0.0")
+        hits = utils.vllm_version_is.cache_info().hits
+        self.assertEqual(hits, 1)
+
     def test_get_max_hidden_layers(self):
         from transformers import PretrainedConfig
 

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -210,31 +210,6 @@ class TestUtils(TestBase):
         with mock.patch("vllm_ascend.utils.enable_dsa_cp", return_value=False):
             self.assertFalse(utils.enable_dsa_cp_with_o_proj_tp())
 
-    def test_vllm_version_is(self):
-        with mock.patch.dict(os.environ, {"VLLM_VERSION": "1.0.0"}):
-            with mock.patch("vllm.__version__", "1.0.0"):
-                self.assertTrue(utils.vllm_version_is.__wrapped__("1.0.0"))
-                self.assertFalse(utils.vllm_version_is.__wrapped__("2.0.0"))
-            with mock.patch("vllm.__version__", "2.0.0"):
-                self.assertTrue(utils.vllm_version_is.__wrapped__("1.0.0"))
-                self.assertFalse(utils.vllm_version_is.__wrapped__("2.0.0"))
-        with mock.patch("vllm.__version__", "1.0.0"):
-            self.assertTrue(utils.vllm_version_is.__wrapped__("1.0.0"))
-            self.assertFalse(utils.vllm_version_is.__wrapped__("2.0.0"))
-        with mock.patch("vllm.__version__", "2.0.0"):
-            self.assertTrue(utils.vllm_version_is.__wrapped__("2.0.0"))
-            self.assertFalse(utils.vllm_version_is.__wrapped__("1.0.0"))
-        # Test caching takes effect
-        utils.vllm_version_is.cache_clear()
-        utils.vllm_version_is("1.0.0")
-        misses = utils.vllm_version_is.cache_info().misses
-        hits = utils.vllm_version_is.cache_info().hits
-        self.assertEqual(misses, 1)
-        self.assertEqual(hits, 0)
-        utils.vllm_version_is("1.0.0")
-        hits = utils.vllm_version_is.cache_info().hits
-        self.assertEqual(hits, 1)
-
     def test_get_max_hidden_layers(self):
         from transformers import PretrainedConfig
 

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -47,33 +47,6 @@ from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.utils import ConstantList, record_function_or_nullcontext
 
-from vllm_ascend.utils import vllm_version_is
-
-
-# `spec_manager_map` in single_type_kv_cache_manager is a module-level dict
-# whose keys are class objects bound at import time.  When the async
-# recompute scheduler is enabled, `recompute_scheduler.py` is imported by
-# `check_and_update_config()` (via AsyncScheduler → scheduler.py →
-# kv_cache_coordinator → single_type_kv_cache_manager) *before*
-# this patch file is executed a second time (e.g. triggered by
-# unpickling an AscendMLAAttentionSpec in the EngineCoreProc subprocess).
-# In that case the dict already contains the original MLAAttentionSpec
-# class as a key, so a subsequent lookup with type(AscendMLAAttentionSpec
-# instance) raises KeyError.
-#
-# Fix: whenever this patch is applied, register AscendMLAAttentionSpec as
-# an additional key in spec_manager_map (if the module is already loaded).
-def register_ascend_mla_spec_in_manager():
-    from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager
-    from vllm.v1.kv_cache_interface import MLAAttentionSpec as AscendMLAAttentionSpec
-
-    if vllm_version_is("0.22.1"):
-        import sys as _sys
-
-        _stm = _sys.modules.get("vllm.v1.core.single_type_kv_cache_manager")
-        if _stm is not None and AscendMLAAttentionSpec not in _stm.spec_manager_map:
-            _stm.spec_manager_map[AscendMLAAttentionSpec] = FullAttentionManager
-
 
 @dataclass
 class RecomputeSchedulerConfig(SchedulerConfig):
@@ -112,8 +85,6 @@ class RecomputeScheduler(Scheduler):
     running: list[Request]
 
     def __init__(self, *args, **kwargs):
-        register_ascend_mla_spec_in_manager()
-
         super().__init__(*args, **kwargs)
         # When is_mtp_kv_consumer is true, we will fill request.spec_token_ids
         # with placeholder tokens to enable full graph when decode nodes pull
@@ -1044,6 +1015,4 @@ class RecomputeScheduler(Scheduler):
 
 class AsyncRecomputeScheduler(AsyncScheduler, RecomputeScheduler):
     def __init__(self, *args, **kwargs):
-        register_ascend_mla_spec_in_manager()
-
         super().__init__(*args, **kwargs)

--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -23,8 +23,6 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.request import Request
 
-from vllm_ascend.utils import vllm_version_is
-
 
 class CompressAttentionManager(FullAttentionManager):
     def __init__(self, kv_cache_spec: MLAAttentionSpec, block_pool: BlockPool, **kwargs) -> None:
@@ -201,11 +199,9 @@ class CompressAttentionManager(FullAttentionManager):
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
-        use_eagle: bool = False,
         drop_eagle_block: bool = False,
     ) -> tuple[list[KVCacheBlock], ...]:
-        # vLLM B renamed ``use_eagle`` to ``drop_eagle_block``; accept both.
-        eagle_drop = use_eagle if vllm_version_is("0.22.1") else drop_eagle_block
+        eagle_drop = drop_eagle_block
         # assert isinstance(
         #     kv_cache_spec, Compress4AttentionSpec | Compress128AttentionSpec | C4IndexerSpec
         # ), (
@@ -264,15 +260,10 @@ def get_manager_for_kv_cache_spec(
     this value matches the pool sizer and makes admission consistent with the
     block budget actually held.
     """
-    if vllm_version_is("0.22.1"):
-        from vllm.v1.core.single_type_kv_cache_manager import spec_manager_map  # type: ignore[import-not-found]
+    from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry  # type: ignore[import-not-found]
 
-        manager_class = spec_manager_map[type(kv_cache_spec)]
-    else:
-        from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry  # type: ignore[import-not-found]
-
-        manager_class = KVCacheSpecRegistry.get_manager_class(kv_cache_spec)
-        assert manager_class is not None, f"No KV cache manager registered for {type(kv_cache_spec).__name__}"
+    manager_class = KVCacheSpecRegistry.get_manager_class(kv_cache_spec)
+    assert manager_class is not None, f"No KV cache manager registered for {type(kv_cache_spec).__name__}"
     if isinstance(kv_cache_spec, MLAAttentionSpec) and kv_cache_spec.compress_ratio > 1:
         manager_class = CompressAttentionManager
         if max_model_len is not None:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/cpu_kv_cache_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/cpu_kv_cache_manager.py
@@ -10,7 +10,6 @@ from vllm.v1.metrics.stats import CachingMetrics, PrefixCacheStats
 from vllm.v1.request import Request
 
 from vllm_ascend.core.single_type_kv_cache_manager import get_manager_for_kv_cache_spec
-from vllm_ascend.utils import vllm_version_is
 
 
 class CPUCacheStats:
@@ -77,8 +76,7 @@ class CPUKVCacheManager:
             max_num_batched_tokens=max_model_len,
             max_model_len=max_model_len,
         )
-        if not vllm_version_is("0.22.1"):
-            manager_kwargs["scheduler_block_size"] = kv_cache_spec.block_size
+        manager_kwargs["scheduler_block_size"] = kv_cache_spec.block_size
         self.single_type_manager = get_manager_for_kv_cache_spec(**manager_kwargs)
         # Record kv block hashes, avoid redundant computation.
         self.req_to_block_hashes: defaultdict[str, list[BlockHash]] = defaultdict(list)
@@ -103,10 +101,7 @@ class CPUKVCacheManager:
             block_hashes = request.block_hashes
             self.req_to_block_hashes[request_id] = block_hashes
         max_cache_hit_length = request.num_tokens - 1
-        if vllm_version_is("0.22.1"):
-            eagle_kwarg = {"use_eagle": self.use_eagle}
-        else:
-            eagle_kwarg = {"drop_eagle_block": self.use_eagle}
+        eagle_kwarg = {"drop_eagle_block": self.use_eagle}
         computed_blocks = self.single_type_manager.find_longest_cache_hit(
             block_hashes=block_hashes,
             max_length=max_cache_hit_length,

--- a/vllm_ascend/distributed/weight_transfer/hccl_engine.py
+++ b/vllm_ascend/distributed/weight_transfer/hccl_engine.py
@@ -24,7 +24,6 @@ from vllm_ascend.distributed.weight_transfer.packed_tensor import (
     DEFAULT_PACKED_NUM_BUFFERS,
     packed_broadcast_consumer,
 )
-from vllm_ascend.utils import vllm_version_is
 
 
 @dataclass
@@ -128,12 +127,8 @@ class HCCLWeightTransferEngine(WeightTransferEngine[HCCLWeightTransferInitInfo, 
             config: The configuration for the weight transfer engine
             parallel_config: The configuration for the parallel setup
             model: The local model instance which will receive the weights.
-                   Not available on v0.21.0 (base class does not accept it).
         """
-        if vllm_version_is("0.21.0"):
-            super().__init__(config, parallel_config)
-        else:
-            super().__init__(config, parallel_config, model)
+        super().__init__(config, parallel_config, model)
         self.model_update_group: PyHcclCommunicator | None = None
 
     def init_transfer_engine(self, init_info: HCCLWeightTransferInitInfo) -> None:

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -59,13 +59,6 @@ env_variables: dict[str, Callable[[], Any]] = {
     # The path for HCCL library, it's used by pyhccl communicator backend. If
     # not set, the default value is libhccl.so.
     "HCCL_SO_PATH": lambda: os.getenv("HCCL_SO_PATH", None),
-    # The version of vllm is installed. This value is used for developers who
-    # installed vllm from source locally. In this case, the version of vllm is
-    # usually changed. For example, if the version of vllm is "0.9.0", but when
-    # it's installed from source, the version of vllm is usually set to "0.9.1".
-    # In this case, developers need to set this value to "0.9.0" to make sure
-    # that the correct package is installed.
-    "VLLM_VERSION": lambda: os.getenv("VLLM_VERSION", None),
     # Whether to enable MatmulAllReduce fusion kernel when tensor parallel is enabled.
     # this feature is supported in A2, and eager mode will get better performance.
     "VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE", "0"))),

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -59,6 +59,13 @@ env_variables: dict[str, Callable[[], Any]] = {
     # The path for HCCL library, it's used by pyhccl communicator backend. If
     # not set, the default value is libhccl.so.
     "HCCL_SO_PATH": lambda: os.getenv("HCCL_SO_PATH", None),
+    # The version of vllm is installed. This value is used for developers who
+    # installed vllm from source locally. In this case, the version of vllm is
+    # usually changed. For example, if the version of vllm is "0.9.0", but when
+    # it's installed from source, the version of vllm is usually set to "0.9.1".
+    # In this case, developers need to set this value to "0.9.0" to make sure
+    # that the correct package is installed.
+    "VLLM_VERSION": lambda: os.getenv("VLLM_VERSION", None),
     # Whether to enable MatmulAllReduce fusion kernel when tensor parallel is enabled.
     # this feature is supported in A2, and eager mode will get better performance.
     "VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE", "0"))),

--- a/vllm_ascend/ops/bailing_moe_linear_attn.py
+++ b/vllm_ascend/ops/bailing_moe_linear_attn.py
@@ -27,25 +27,16 @@ import torch
 import torch.nn.functional as F
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.fla.ops.layernorm_guard import layernorm_fn
+from vllm.model_executor.layers.mamba.linear.minimax_linear_attn import (  # type: ignore[import-not-found]
+    clear_linear_attention_cache_for_new_sequences,
+    linear_attention_decode,
+    linear_attention_prefill_and_mix,
+)
 from vllm.model_executor.models.bailing_moe_linear import BailingMoELinearAttention
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.attention.backends.linear_attn import LinearAttentionMetadata
 
 from vllm_ascend.ops.triton.mamba.lightning_attn import AscendLightningAttentionKernel
-from vllm_ascend.utils import vllm_version_is
-
-if vllm_version_is("0.22.1"):
-    from vllm.model_executor.layers.mamba.linear_attn import (  # type: ignore[import-not-found]
-        clear_linear_attention_cache_for_new_sequences,
-        linear_attention_decode,
-        linear_attention_prefill_and_mix,
-    )
-else:
-    from vllm.model_executor.layers.mamba.linear.minimax_linear_attn import (  # type: ignore[import-not-found]
-        clear_linear_attention_cache_for_new_sequences,
-        linear_attention_decode,
-        linear_attention_prefill_and_mix,
-    )
 
 
 class AscendBailingMoELinearAttention(BailingMoELinearAttention):

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -40,7 +40,7 @@ from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
 from vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape import fused_qkvzba_split_reshape_cat
 from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
 from vllm_ascend.ops.triton.mamba.causal_conv1d import causal_conv1d_fn
-from vllm_ascend.utils import vllm_version_is, weak_ref_tensors
+from vllm_ascend.utils import weak_ref_tensors
 
 
 def to_int64_tuple(tensor: torch.Tensor) -> tuple[int, ...]:
@@ -304,10 +304,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             ba, _ = self.in_proj_ba(hidden_states)
             z, _ = self.in_proj_z(hidden_states)
             z = z.reshape(z.size(0), -1, self.head_v_dim)
-            if vllm_version_is("0.22.1"):
-                b, a = ba.chunk(2, dim=-1)
-            else:
-                b, a = self._split_ba_for_tp(ba)
+            b, a = self._split_ba_for_tp(ba)
             b = b.contiguous()
             a = a.contiguous()
         else:
@@ -319,10 +316,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)
                 z = z.reshape(z.size(0), -1, self.head_v_dim)
                 ba, _ = self.in_proj_ba(hidden_states)
-                if vllm_version_is("0.22.1"):
-                    b, a = ba.chunk(2, dim=-1)
-                else:
-                    b, a = self._split_ba_for_tp(ba)
+                b, a = self._split_ba_for_tp(ba)
 
                 b = b.contiguous()
                 a = a.contiguous()
@@ -351,24 +345,14 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             device=hidden_states.device,
         )
 
-        if vllm_version_is("0.22.1"):
-            torch.ops.vllm.qwen_gdn_attention_core(
-                mixed_qkv,
-                b,
-                a,
-                core_attn_out,
-                False,
-                self.prefix,
-            )
-        else:
-            torch.ops.vllm.qwen_gdn_attention_core(
-                mixed_qkv,
-                b,
-                a,
-                core_attn_out,
-                self.prefix,
-                False,
-            )
+        torch.ops.vllm.qwen_gdn_attention_core(
+            mixed_qkv,
+            b,
+            a,
+            core_attn_out,
+            self.prefix,
+            False,
+        )
 
         # ============================================================
         # Part 3: Output Projection

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -28,7 +28,6 @@ from vllm.v1.kv_cache_interface import (
 )
 
 from vllm_ascend.core.single_type_kv_cache_manager import get_manager_for_kv_cache_spec
-from vllm_ascend.utils import vllm_version_is
 
 USE_MULTI_GROUPS_KV_CACHE = True
 
@@ -118,10 +117,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         if use_eagle and not self.eagle_group_ids:
             self.eagle_group_ids = set(range(len(kv_cache_config.kv_cache_groups)))
 
-        # v0.22.1 managers don't accept `scheduler_block_size`.
-        extra_mgr_kwargs: dict = {}
-        if not vllm_version_is("0.22.1"):
-            extra_mgr_kwargs["scheduler_block_size"] = scheduler_block_size
+        extra_mgr_kwargs: dict = {"scheduler_block_size": scheduler_block_size}
         self.single_type_managers = tuple(
             get_manager_for_kv_cache_spec(
                 kv_cache_spec=kv_cache_group.kv_cache_spec,
@@ -274,11 +270,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                 if use_eagle:
                     # Eagle needs to match one more block and then pop the last.
                     _max_length = min(curr_hit_length + spec.block_size, max_cache_hit_length)
-                # vLLM B renamed the ``use_eagle`` kwarg to ``drop_eagle_block``.
-                if vllm_version_is("0.22.1"):
-                    eagle_kwarg = {"use_eagle": use_eagle}
-                else:
-                    eagle_kwarg = {"drop_eagle_block": use_eagle}
+                eagle_kwarg = {"drop_eagle_block": use_eagle}
                 hit_blocks = manager_cls.find_longest_cache_hit(
                     block_hashes=_get_block_hashes(spec),
                     max_length=_max_length,
@@ -380,11 +372,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                 if use_eagle:
                     # Eagle needs to match one more block and then pop the last.
                     _max_length = min(curr_hit_length + spec.block_size, max_cache_hit_length)
-                # vLLM B renamed the ``use_eagle`` kwarg to ``drop_eagle_block``.
-                if vllm_version_is("0.22.1"):
-                    eagle_kwarg = {"use_eagle": use_eagle}
-                else:
-                    eagle_kwarg = {"drop_eagle_block": use_eagle}
+                eagle_kwarg = {"drop_eagle_block": use_eagle}
                 hit_blocks = manager_cls.find_longest_cache_hit(
                     block_hashes=_get_block_hashes(spec),
                     max_length=_max_length,
@@ -473,8 +461,7 @@ def get_kv_cache_coordinator(
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
         )
-        if not vllm_version_is("0.22.1"):
-            orig_kwargs["scheduler_block_size"] = scheduler_block_size
+        orig_kwargs["scheduler_block_size"] = scheduler_block_size
         return _orig_get_kv_cache_coordinator(**orig_kwargs)
 
     return AscendHybridKVCacheCoordinator(

--- a/vllm_ascend/patch/platform/patch_mamba_manager.py
+++ b/vllm_ascend/patch/platform/patch_mamba_manager.py
@@ -14,8 +14,6 @@ from vllm.v1.core.single_type_kv_cache_manager import (
     MambaSpec,
 )
 
-from vllm_ascend.utils import vllm_version_is
-
 
 class AscendMambaManager(MambaManager):
     def __init__(self, kv_cache_spec: MambaSpec, block_pool: BlockPool, **kwargs) -> None:
@@ -34,7 +32,6 @@ class AscendMambaManager(MambaManager):
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
-        use_eagle: bool = False,
         drop_eagle_block: bool = False,
     ) -> tuple[list[KVCacheBlock], ...]:
         assert isinstance(kv_cache_spec, MambaSpec), "MambaManager can only be used for mamba groups"
@@ -53,5 +50,3 @@ class AscendMambaManager(MambaManager):
 
 
 single_type_kv_cache_manager.MambaManager = AscendMambaManager
-if vllm_version_is("0.22.1"):
-    single_type_kv_cache_manager.spec_manager_map[MambaSpec] = AscendMambaManager

--- a/vllm_ascend/patch/platform/patch_tool_choice_none_content.py
+++ b/vllm_ascend/patch/platform/patch_tool_choice_none_content.py
@@ -30,10 +30,6 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
 )
 from vllm.parser.abstract_parser import DelegatingParser
 
-from vllm_ascend.utils import vllm_version_is
-
-_NO_FORCED_TOOL_CALL = "_vllm_ascend_no_forced_tool_call"
-
 _original_chat_completion_response_model_dump = ChatCompletionResponse.model_dump
 _original_chat_completion_stream_response_model_dump = ChatCompletionStreamResponse.model_dump
 
@@ -87,31 +83,6 @@ def _is_forced_tool_choice(request) -> bool:
     )
 
 
-def _set_no_forced_tool_call(request, value: bool) -> None:
-    tool_choice = getattr(request, "tool_choice", None)
-    if isinstance(tool_choice, ChatCompletionNamedToolChoiceParam):
-        setattr(tool_choice, _NO_FORCED_TOOL_CALL, value)
-
-
-def _patch_named_tool_choice_bool() -> None:
-    if getattr(ChatCompletionNamedToolChoiceParam, "_vllm_ascend_bool_patched", False):
-        return
-
-    original_bool = getattr(ChatCompletionNamedToolChoiceParam, "__bool__", None)
-
-    def _patched_named_tool_choice_bool(self) -> bool:
-        if getattr(self, _NO_FORCED_TOOL_CALL, False):
-            return False
-        if original_bool is not None:
-            return original_bool(self)
-        return True
-
-    ChatCompletionNamedToolChoiceParam.__bool__ = _patched_named_tool_choice_bool
-    ChatCompletionNamedToolChoiceParam._vllm_ascend_bool_patched = True
-
-
-_patch_named_tool_choice_bool()
-
 _original_delegating_parse_tool_calls = DelegatingParser._parse_tool_calls
 
 
@@ -133,30 +104,3 @@ def _patched_delegating_parse_tool_calls(
 
 
 DelegatingParser._parse_tool_calls = _patched_delegating_parse_tool_calls
-
-if vllm_version_is("0.22.1"):
-    from vllm.entrypoints.openai.engine.serving import OpenAIServing  # type: ignore[import-not-found]
-
-    _original_parse_tool_calls_from_content = OpenAIServing._parse_tool_calls_from_content
-
-    def _patched_parse_tool_calls_from_content(
-        request,
-        tokenizer,
-        enable_auto_tools: bool,
-        tool_parser_cls,
-        content: str | None = None,
-    ):
-        if content is None and _is_forced_tool_choice(request):
-            _set_no_forced_tool_call(request, True)
-            return [], None
-
-        _set_no_forced_tool_call(request, False)
-        return _original_parse_tool_calls_from_content(
-            request=request,
-            tokenizer=tokenizer,
-            enable_auto_tools=enable_auto_tools,
-            tool_parser_cls=tool_parser_cls,
-            content=content,
-        )
-
-    OpenAIServing._parse_tool_calls_from_content = staticmethod(_patched_parse_tool_calls_from_content)

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -17,21 +17,11 @@
 
 from vllm.triton_utils import HAS_TRITON
 
-from vllm_ascend.utils import is_310p, vllm_version_is
-
-# The v2 model runner is intentionally NOT made compatible with the v0.22.1
-# release. vLLM v0.22.1 and the verified main commit are diverged, and the v2
-# worker patches target main-only APIs; rather than maintain a separate v0.22.1
-# compatibility path we keep v2 main-only. With v0.22.1 installed this flag is
-# False, so none of the patch_v2.* / routed-experts-capture patches below are
-# imported and the v2 worker stays dormant (the release uses the v1 runner).
-_V2_MODEL_RUNNER_SUPPORTED = not vllm_version_is("0.22.1")
+from vllm_ascend.utils import is_310p
 
 if HAS_TRITON:
     import vllm_ascend.patch.worker.patch_triton
-
-    if _V2_MODEL_RUNNER_SUPPORTED:
-        import vllm_ascend.patch.worker.patch_v2.patch_triton  # noqa
+    import vllm_ascend.patch.worker.patch_v2.patch_triton  # noqa
 
 
 import vllm_ascend.patch.worker.patch_weight_utils  # noqa
@@ -62,13 +52,9 @@ import vllm_ascend.patch.worker.patch_cudagraph  # noqa
 import vllm_ascend.patch.worker.patch_deepseek_mtp  # noqa
 import vllm_ascend.patch.worker.patch_gqa_c8  # noqa
 
-if _V2_MODEL_RUNNER_SUPPORTED:
-    import vllm_ascend.patch.worker.patch_v2.patch_uva  # noqa
-    import vllm_ascend.patch.worker.patch_v2.patch_input_batch  # noqa
-    import vllm_ascend.patch.worker.patch_v2.patch_model_state  # noqa
-    import vllm_ascend.patch.worker.patch_v2.patch_block_table  # noqa
-    import vllm_ascend.patch.worker.patch_v2.patch_attn_utils  # noqa
-
-# only patch routed experts capture in main2main.
-if _V2_MODEL_RUNNER_SUPPORTED:
-    import vllm_ascend.patch.worker.patch_routed_experts_capture  # noqa
+import vllm_ascend.patch.worker.patch_v2.patch_uva  # noqa
+import vllm_ascend.patch.worker.patch_v2.patch_input_batch  # noqa
+import vllm_ascend.patch.worker.patch_v2.patch_model_state  # noqa
+import vllm_ascend.patch.worker.patch_v2.patch_block_table  # noqa
+import vllm_ascend.patch.worker.patch_v2.patch_attn_utils  # noqa
+import vllm_ascend.patch.worker.patch_routed_experts_capture  # noqa

--- a/vllm_ascend/patch/worker/patch_minimax_m2.py
+++ b/vllm_ascend/patch/worker/patch_minimax_m2.py
@@ -25,6 +25,9 @@ from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
+from vllm.model_executor.layers.minimax_rms_norm import (  # type: ignore[import-not-found]
+    MiniMaxText01RMSNormTP,
+)
 from vllm.model_executor.models.minimax_m2 import (
     MiniMaxM2Attention,
     MiniMaxM2ForCausalLM,
@@ -35,16 +38,6 @@ from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
 from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_slice
-from vllm_ascend.utils import vllm_version_is
-
-if vllm_version_is("0.22.1"):
-    from vllm.model_executor.layers.mamba.linear_attn import (  # type: ignore[import-not-found]
-        MiniMaxText01RMSNormTP,
-    )
-else:
-    from vllm.model_executor.layers.minimax_rms_norm import (  # type: ignore[import-not-found]
-        MiniMaxText01RMSNormTP,
-    )
 
 FP8_DTYPES = tuple(
     getattr(torch, dtype_name)

--- a/vllm_ascend/patch/worker/patch_minimax_m2_linear_attn.py
+++ b/vllm_ascend/patch/worker/patch_minimax_m2_linear_attn.py
@@ -28,18 +28,10 @@ from vllm.distributed import (
     tensor_model_parallel_all_reduce,
 )
 from vllm.model_executor.custom_op import CustomOp
+from vllm.model_executor.layers.minimax_rms_norm import (  # type: ignore[import-not-found]
+    MiniMaxText01RMSNormTP,
+)
 from vllm.platforms import current_platform
-
-from vllm_ascend.utils import vllm_version_is
-
-if vllm_version_is("0.22.1"):
-    from vllm.model_executor.layers.mamba.linear_attn import (  # type: ignore[import-not-found]
-        MiniMaxText01RMSNormTP,
-    )
-else:
-    from vllm.model_executor.layers.minimax_rms_norm import (  # type: ignore[import-not-found]
-        MiniMaxText01RMSNormTP,
-    )
 
 logger = logging.getLogger(__name__)
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -9,6 +9,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import vllm.distributed.parallel_state as _ps  # type: ignore[import-not-found]
 from vllm.config import CompilationMode, CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
 from vllm.distributed.parallel_state import (
     get_pcp_group,
@@ -51,29 +52,25 @@ from vllm_ascend.compilation.acl_graph import ACLGraphWrapper, update_full_graph
 from vllm_ascend.distributed.parallel_state import get_lmhead_tp_group
 from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
-from vllm_ascend.utils import enable_sp, lmhead_tp_enable, shared_expert_dp_enabled, vllm_version_is
+from vllm_ascend.utils import enable_sp, lmhead_tp_enable, shared_expert_dp_enabled
 
-if vllm_version_is("0.22.1"):
-    from vllm.distributed.parallel_state import patch_tensor_parallel_group  # type: ignore[import-not-found]
-else:
-    import vllm.distributed.parallel_state as _ps  # type: ignore[import-not-found]
 
-    @contextmanager
-    def patch_tensor_parallel_group(tp_group):
-        """Temporarily swap the global TP group for draft-model spec decode.
+@contextmanager
+def patch_tensor_parallel_group(tp_group):
+    """Temporarily swap the global TP group for draft-model spec decode.
 
-        Backports vllm 0.21's ``patch_tensor_parallel_group`` which was removed
-        on vLLM main. Used so the draft model can run with a TP degree that
-        differs from the target model.
-        """
-        old_tp_group = _ps.get_tp_group()
-        _ps._TP_STATE_PATCHED = True
-        _ps._TP = tp_group
-        try:
-            yield
-        finally:
-            _ps._TP_STATE_PATCHED = False
-            _ps._TP = old_tp_group
+    Backports vllm 0.21's ``patch_tensor_parallel_group`` which was removed
+    on vLLM main. Used so the draft model can run with a TP degree that
+    differs from the target model.
+    """
+    old_tp_group = _ps.get_tp_group()
+    _ps._TP_STATE_PATCHED = True
+    _ps._TP = tp_group
+    try:
+        yield
+    finally:
+        _ps._TP_STATE_PATCHED = False
+        _ps._TP = old_tp_group
 
 
 # Currently we will fix block size to a small one since `num_reqs` can't be too large
@@ -190,7 +187,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 use_message_queue_broadcaster=True,
                 group_name="tp",
             )
-            self.tp_group_context = patch_tensor_parallel_group(tp_group)
+            self.tp_group_context: AbstractContextManager[Any] = patch_tensor_parallel_group(tp_group)
         else:
             self.tp_group_context = nullcontext()
 

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -19,7 +19,6 @@
 
 from __future__ import annotations
 
-import functools
 import json
 import math
 import os
@@ -32,7 +31,6 @@ import numpy as np
 import regex as re
 import torch
 import torch_npu  # noqa: F401
-from packaging.version import InvalidVersion, Version
 from vllm.logger import logger
 from vllm.sequence import IntermediateTensors
 
@@ -552,25 +550,6 @@ def setup_ascend_local_comm_res(local_rank: int, kv_transfer_config: Any | None)
         raise ValueError(f"Failed to parse endpoint config file: {local_comm_res_file}") from e
 
     os.environ["ASCEND_LOCAL_COMM_RES"] = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
-
-
-@functools.cache
-def vllm_version_is(target_vllm_version: str):
-    if envs_ascend.VLLM_VERSION is not None:
-        vllm_version = envs_ascend.VLLM_VERSION
-    else:
-        import vllm
-
-        vllm_version = vllm.__version__
-    try:
-        return Version(vllm_version) == Version(target_vllm_version)
-    except InvalidVersion:
-        raise ValueError(
-            f"Invalid vllm version {vllm_version} found. A dev version of vllm "
-            "is installed probably. Set the environment variable VLLM_VERSION "
-            "to control it by hand. And please make sure the value follows the "
-            "format of x.y.z."
-        )
 
 
 def get_max_hidden_layers(hf_config) -> int:

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+import functools
 import json
 import math
 import os
@@ -31,6 +32,7 @@ import numpy as np
 import regex as re
 import torch
 import torch_npu  # noqa: F401
+from packaging.version import InvalidVersion, Version
 from vllm.logger import logger
 from vllm.sequence import IntermediateTensors
 
@@ -550,6 +552,25 @@ def setup_ascend_local_comm_res(local_rank: int, kv_transfer_config: Any | None)
         raise ValueError(f"Failed to parse endpoint config file: {local_comm_res_file}") from e
 
     os.environ["ASCEND_LOCAL_COMM_RES"] = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+
+
+@functools.cache
+def vllm_version_is(target_vllm_version: str):
+    if envs_ascend.VLLM_VERSION is not None:
+        vllm_version = envs_ascend.VLLM_VERSION
+    else:
+        import vllm
+
+        vllm_version = vllm.__version__
+    try:
+        return Version(vllm_version) == Version(target_vllm_version)
+    except InvalidVersion:
+        raise ValueError(
+            f"Invalid vllm version {vllm_version} found. A dev version of vllm "
+            "is installed probably. Set the environment variable VLLM_VERSION "
+            "to control it by hand. And please make sure the value follows the "
+            "format of x.y.z."
+        )
 
 
 def get_max_hidden_layers(hf_config) -> int:

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -70,7 +70,6 @@ from vllm_ascend.utils import (
     get_ascend_device_type,
     register_ascend_customop,
     setup_ascend_local_comm_res,
-    vllm_version_is,
 )
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
@@ -160,9 +159,6 @@ class NPUWorker(WorkerBase):
             WEIGHT_LOADER_V2_SUPPORTED.remove("UnquantizedLinearMethod")
 
         self.use_v2_model_runner = envs_vllm.VLLM_USE_V2_MODEL_RUNNER
-        if self.use_v2_model_runner and vllm_version_is("0.22.1"):
-            logger.warning("VLLM_USE_V2_MODEL_RUNNER is not supported on vllm 0.22.1; falling back to v1 model runner.")
-            self.use_v2_model_runner = False
         self._pp_send_work: list[Handle] = []
 
         ascend_compilation_config = get_ascend_config().ascend_compilation_config
@@ -575,8 +571,8 @@ class NPUWorker(WorkerBase):
             if envs_vllm.VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS:
                 equiv_util = round(current_util - ng_util_delta, 4)
                 logger.info(
-                    "ACL graph memory profiling is enabled (default since "
-                    "v0.22.1). The current --gpu-memory-utilization=%.4f is "
+                    "ACL graph memory profiling is enabled (default). "
+                    "The current --gpu-memory-utilization=%.4f is "
                     "equivalent to --gpu-memory-utilization=%.4f without "
                     "ACL graph memory profiling. To maintain the same "
                     "effective KV cache size as before, increase "
@@ -593,7 +589,7 @@ class NPUWorker(WorkerBase):
                     "Without it, ACL graph memory is not accounted for "
                     "during KV cache allocation, which may require lowering "
                     "--gpu-memory-utilization to avoid OOM. Consider "
-                    "re-enabling it (the default as of v0.22.1) and increasing "
+                    "re-enabling it (the default) and increasing "
                     "--gpu-memory-utilization from %.4f to %.4f.",
                     current_util,
                     suggested_util,
@@ -896,9 +892,6 @@ class NPUWorker(WorkerBase):
         if (metadata := connector.get_handshake_metadata()) is None:
             return None
         tp_rank = get_tp_group().rank_in_group
-        if vllm_version_is("0.22.1"):
-            return {tp_rank: metadata}
-
         pp_rank = get_pp_group().rank_in_group
         return {(pp_rank, tp_rank): metadata}
 

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -571,8 +571,8 @@ class NPUWorker(WorkerBase):
             if envs_vllm.VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS:
                 equiv_util = round(current_util - ng_util_delta, 4)
                 logger.info(
-                    "ACL graph memory profiling is enabled (default). "
-                    "The current --gpu-memory-utilization=%.4f is "
+                    "ACL graph memory profiling is enabled (default since "
+                    "v0.22.1). The current --gpu-memory-utilization=%.4f is "
                     "equivalent to --gpu-memory-utilization=%.4f without "
                     "ACL graph memory profiling. To maintain the same "
                     "effective KV cache size as before, increase "
@@ -589,7 +589,7 @@ class NPUWorker(WorkerBase):
                     "Without it, ACL graph memory is not accounted for "
                     "during KV cache allocation, which may require lowering "
                     "--gpu-memory-utilization to avoid OOM. Consider "
-                    "re-enabling it (the default) and increasing "
+                    "re-enabling it (the default as of v0.22.1) and increasing "
                     "--gpu-memory-utilization from %.4f to %.4f.",
                     current_util,
                     suggested_util,


### PR DESCRIPTION
### What this PR does / why we need it?

Upstream has cut the `releases/v0.22.1rc` release branch off `main`. From now on
`main` only needs to track vLLM `main`, so the dual-version compatibility shims
added during the main2main upgrade are dead weight on the `main` line. This PR:

1. Removes **every** `vllm_version_is(...)` branch, keeping only the vLLM-`main`
   path, and deletes the now-unused helper and its supporting machinery.
2. Repoints the nightly CI at the new `releases/v0.22.1rc` branch (following the
   pattern of #9778, which did this for `releases/v0.20.2rc`).

#### 1. Drop v0.22.1 (and stale 0.21.0 / 0.19.1) version branching

- Collapse all `vllm_version_is(...)` conditionals to the vLLM-`main` side across
  core / KV-cache / ops / spec-decode / patch / worker modules. This also clears
  leftover `0.21.0` and `0.19.1` checks.
- Align override signatures with upstream main (e.g. drop the legacy `use_eagle`
  kwarg from `find_longest_cache_hit` overrides in favor of `drop_eagle_block`).
- Remove the helper and scaffolding now that all uses are gone:
  - `vllm_version_is` in `vllm_ascend/utils.py` (and the now-unused
    `packaging.version` import).
  - the `VLLM_VERSION` env entry in `vllm_ascend/envs.py`.
  - the helper self-test in `tests/ut/test_utils.py`.
  - dead flag machinery in `patch_tool_choice_none_content.py` whose only setter
    lived in the removed 0.22.1 patch.
- Update the README / README.zh support matrix to advertise "vLLM main branch"
  only.

#### 2. CI: keep the release-tag legs restorable, switch nightly to the rc

- **Comment out (not delete)** the v0.22.1 release-tag CI legs so the next
  version-compat round can restore them easily (restore notes point at
  `.github/vllm-release-tag.commit`):
  - `release_tag` matrix legs in `pr_test.yaml` and `pr_e2e_command.yml`.
  - the `E2E-upstream` schedule cron in `schedule_vllm_e2e_test.yaml` (kept
    `workflow_dispatch`).
  - the `run-tests-release` job in `schedule_update_estimated_times.yaml`.
- **Switch nightly to `releases/v0.22.1rc`:**
  - `schedule_nightly_test_a2.yaml` / `schedule_nightly_test_a3.yaml`: switch the
    `vllm_ascend_branch` input default from `main` to `releases/v0.22.1rc`.
  - `nightly_image_build.yaml` (layer-cache warm-up): add `releases/v0.22.1rc`
    and make it the default.
  - `schedule_image_build_and_push.yaml`: add `releases/v0.22.1rc` to the
    `branch` build/push choices.

### Does this PR introduce any user-facing change?

No. This removes internal version-compat shims (collapsing to the vLLM-main
behavior that was already taken on main builds) and adjusts CI. The
`VLLM_VERSION` env var, which was only consumed by the removed helper, is gone.

### How was this patch tested?
test link: https://github.com/vllm-project/vllm-ascend/actions/runs/27744232089?pr=10704


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
