### PR TITLE
[BugFix][Test] Fix inconsistent inputs and add value assertions in test_chunk_gated_delta_rule

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_chunk_gated_delta_rule.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_chunk_gated_delta_rule.py
@@ -14,13 +14,17 @@ class TestChunkGatedDeltaRule(PytestBase):
         mock_forward_context = MagicMock()
         mock_forward_context.attn_metadata = mock_attn_metadata
 
+        # Use self-consistent inputs:
+        # - 3 sequences with lengths [6, 6, 5] summing to T=17
+        # - cu_seqlens[-1] == 17 matches the tensor seqlen
+        # - initial_state has batch=3 matching 3 sequences
         q = torch.randn(1, 17, 4, 128, dtype=torch.bfloat16).npu()
         k = torch.randn(1, 17, 4, 128, dtype=torch.bfloat16).npu()
         v = torch.randn(1, 17, 8, 128, dtype=torch.bfloat16).npu()
         g = torch.randn(1, 17, 8, dtype=torch.float32).npu()
         beta = torch.randn(1, 17, 8, dtype=torch.bfloat16).npu()
         initial_state = torch.randn(3, 8, 128, 128, dtype=torch.bfloat16).npu()
-        q_start_loc = torch.range(0, 3, dtype=torch.int).npu()
+        cu_seqlens = torch.tensor([0, 6, 12, 17], dtype=torch.int).npu()
 
         mock_pcp_group = MagicMock()
         mock_pcp_group.world_size = 1
@@ -39,13 +43,40 @@ class TestChunkGatedDeltaRule(PytestBase):
                 beta=beta,
                 initial_state=initial_state,
                 output_final_state=True,
-                cu_seqlens=q_start_loc,
+                cu_seqlens=cu_seqlens,
                 head_first=False,
                 use_qk_l2norm_in_kernel=True,
             )
 
+        # Assert shapes
         assert core_attn_out_non_spec.shape == (1, 17, 8, 128)
         assert last_recurrent_state.shape == (3, 8, 128, 128)
+
+        # Assert numerical correctness against pytorch reference
+        ref_out, ref_state = chunk_gated_delta_rule_pytorch(
+            q=q.cpu().to(torch.float32),
+            k=k.cpu().to(torch.float32),
+            v=v.cpu().to(torch.float32),
+            g=g.cpu().to(torch.float32),
+            beta=beta.cpu().to(torch.float32),
+            initial_state=initial_state.cpu().to(torch.float32),
+            output_final_state=True,
+            cu_seqlens=cu_seqlens.cpu(),
+            head_first=False,
+            use_qk_l2norm_in_kernel=True,
+        )
+        torch.testing.assert_close(
+            core_attn_out_non_spec.cpu().to(torch.float32),
+            ref_out,
+            atol=0.05,
+            rtol=0.05,
+        )
+        torch.testing.assert_close(
+            last_recurrent_state.cpu().to(torch.float32),
+            ref_state,
+            atol=0.05,
+            rtol=0.05,
+        )
 
 
 def test_chunk_gated_delta_rule_310_state_layout_matches_vllm():


### PR DESCRIPTION
## Summary

Fix `test_chunk_gated_delta_rule::test_triton_fusion_ops` which had two issues:

1. **`cu_seqlens` inconsistent with seqlen**: `torch.range(0, 3)` produces `[0, 1, 2, 3]`, so `cu_seqlens[-1] == 3`, but the packed tensors have `T == 17`. In varlen mode the contract is `cu_seqlens[-1] == seqlen`. This mismatch caused AICORE error 507015 (MPU out-of-bounds) in `chunk_fwd_o`.

2. **Only asserts shapes, not values**: Output shapes are derived from input tensors regardless of whether the kernel computed correctly or even crashed. Because NPU execution is asynchronous, the kernel fault is not observed at the CPU-side shape assertions, so the test reports PASSED even though the kernel aborted.

## Changes

- Fix `cu_seqlens` to `torch.tensor([0, 6, 12, 17])` - 3 sequences with lengths [6, 6, 5] summing to T=17, matching `initial_state` batch of 3
- Replace deprecated `torch.range` with `torch.tensor`
- Add numerical assertions against the pytorch reference implementation (`chunk_gated_delta_rule_pytorch`) so kernel faults actually fail the test

## Testing

- ruff format: passed
- ruff check: passed
- The test now validates both shapes and numerical correctness

Fixes #10572
- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
