### PR TITLE
[BugFix] Disable get_device_total_memory on Ascend

### DIFF
--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -234,32 +234,6 @@ class TestNPUPlatform(TestBase):
         mock_get_device_name.assert_called_once_with(0)
 
     @patch("torch.npu.get_device_properties")
-    @patch("vllm_ascend.platform.subprocess.check_output")
-    def test_get_device_total_memory_prefers_npu_smi(self, mock_check_output, mock_get_device_properties):
-        mock_check_output.return_value = (
-            "        DDR Capacity(MB)               : 0\n        HBM Capacity(MB)               : 32768\n"
-        )
-
-        self.assertEqual(self.platform.get_device_total_memory(0), 32768 * 1024 * 1024)
-        mock_check_output.assert_called_once_with(
-            ["npu-smi", "info", "-t", "memory", "-i", "0"],
-            stderr=-3,
-            text=True,
-        )
-        mock_get_device_properties.assert_not_called()
-
-    @patch("torch.npu.get_device_properties")
-    @patch("vllm_ascend.platform.subprocess.check_output", side_effect=PermissionError)
-    def test_get_device_total_memory_falls_back_on_permission_error(
-        self, mock_check_output, mock_get_device_properties
-    ):
-        mock_get_device_properties.return_value.total_memory = 16 * 1024 * 1024
-
-        self.assertEqual(self.platform.get_device_total_memory(0), 16 * 1024 * 1024)
-        mock_check_output.assert_called_once()
-        mock_get_device_properties.assert_called_once_with(0)
-
-    @patch("torch.npu.get_device_properties")
     def test_get_device_uuid(self, mock_get_device_properties):
         device_id = 0
         device_properties = MagicMock()

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import math
 import os
-import subprocess
 from importlib import import_module, util
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
@@ -73,34 +72,6 @@ else:
 _CUSTOM_OP_REGISTERED = False
 # Delete after the driver is released; temporarily hard-coded to 4
 MAX_CAPTURE_SIZES_FOR_950 = 4
-
-
-def _get_npu_smi_field(lines: list[str], key: str) -> str | None:
-    for line in lines:
-        normalized = " ".join(line.split())
-        if normalized.startswith(f"{key} :"):
-            return normalized.split(":", 1)[1].strip()
-    return None
-
-
-def _get_npu_smi_hbm_capacity_mb(device_id: int) -> int | None:
-    try:
-        output = subprocess.check_output(
-            ["npu-smi", "info", "-t", "memory", "-i", str(device_id)],
-            stderr=subprocess.DEVNULL,
-            text=True,
-        )
-    except (OSError, subprocess.CalledProcessError):
-        return None
-
-    value = _get_npu_smi_field(output.splitlines(), "HBM Capacity(MB)")
-    if value is None:
-        return None
-
-    try:
-        return int(value)
-    except ValueError:
-        return None
 
 
 def config_deprecated_logging():
@@ -300,18 +271,12 @@ class NPUPlatform(Platform):
 
     @classmethod
     def get_device_total_memory(cls, device_id: int = 0) -> int:
-        """
-        Return total memory of the device in bytes.
-        """
-        hbm_capacity_mb = _get_npu_smi_hbm_capacity_mb(device_id)
-        if hbm_capacity_mb is not None:
-            return hbm_capacity_mb * 1024 * 1024
-
-        device_props = torch.npu.get_device_properties(device_id)
-        total_memory = getattr(device_props, "total_memory", None)
-        if total_memory is not None:
-            return int(total_memory)
-        raise RuntimeError(f"Unable to determine total memory for device {device_id}.")
+        '''
+        Do not implement this interface. It causes get_device_name() to be called
+        early, prematurely initializing torch_npu, which cannot be initialized
+        more than once.
+        '''  # fmt: skip
+        raise NotImplementedError
 
     def num_compute_units(cls, device_id: int = 0) -> int:
         """Return the number of Cube Cores on the NPU device.

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -271,11 +271,11 @@ class NPUPlatform(Platform):
 
     @classmethod
     def get_device_total_memory(cls, device_id: int = 0) -> int:
-        '''
-        Do not implement this interface. It causes get_device_name() to be called
-        early, prematurely initializing torch_npu, which cannot be initialized
-        more than once.
-        '''  # fmt: skip
+        """
+        Get the total memory of the NPU device in bytes.
+        DO NOT IMPLEMENT: Implementing it calls get_device_name() in advance and initializes torch_npu too early.
+        torch_npu allows global initialization only once; duplicate initialization causes errors.
+        """
         raise NotImplementedError
 
     def num_compute_units(cls, device_id: int = 0) -> int:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR intentionally disables `NPUPlatform.get_device_total_memory()` by making the override raise `NotImplementedError`. It also removes the `npu-smi` memory-query helpers and their obsolete unit tests.

When this API returns successfully, upstream `EngineArgs.get_batch_defaults()` immediately calls `current_platform.get_device_name()`. On Ascend, that query can initialize the NPU runtime before DP ranks finish binding their devices, causing multiple ranks to initialize the same NPUs.

The explicit override and comment preserve this platform contract and warn future maintainers not to reimplement the query. Raising `NotImplementedError` keeps upstream vLLM on its safe fallback path. A runtime-safe device metadata solution can be handled separately.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
