### PR TITLE
[CI] optimize workflows and add test-only PR detection

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -5,5 +5,4 @@ memory_config:
 code_review:
   comment_severity_threshold: HIGH  # Reduce quantity of comments
   pull_request_opened:
-    help: true  # Add a help comment to the PR
     summary: true  # Summarize the PR in a separate comment

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -10,6 +10,8 @@ self-hosted-runner:
     - linux-aarch64-a3-4
     - linux-aarch64-a3-8
     - linux-aarch64-a3-0
+    - linux-amd64-cpu-2-hk
+    - linux-amd64-cpu-4-hk
     - linux-amd64-cpu-8-hk
     - linux-amd64-cpu-16-hk
     - linux-arm64-cpu-16

--- a/.github/workflows/bot_issue_manage.yaml
+++ b/.github/workflows/bot_issue_manage.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: linux-amd64-cpu-8-hk
+    runs-on: linux-amd64-cpu-2-hk
     if: |
       startsWith(github.event.issue.title, '[Bug]:') ||
       startsWith(github.event.issue.title, '[Installation]:') ||

--- a/.github/workflows/bot_merge_conflict.yaml
+++ b/.github/workflows/bot_merge_conflict.yaml
@@ -6,11 +6,13 @@ on:
 
 jobs:
   main:
-    runs-on: linux-amd64-cpu-8-hk
+    runs-on: linux-amd64-cpu-2-hk
     steps:
       - name: check if prs are dirty
         uses: eps1lon/actions-label-merge-conflict@v3
         with:
           dirtyLabel: "merge-conflicts"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          retryAfter: 5
+          retryMax: 1
           commentOnDirty: "This pull request has conflicts, please resolve those before we can evaluate the pull request."

--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -19,6 +19,7 @@ name: PR Create
 
 on:
   pull_request_target:
+  pull_request:
 
 permissions:
   pull-requests: write
@@ -29,11 +30,12 @@ jobs:
       contents: read
       pull-requests: write
     name: PR create action
-    runs-on: linux-amd64-cpu-8-hk
+    runs-on: linux-amd64-cpu-2-hk
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend/act-environments-ubuntu:act-22.04
     steps:
       - name: Install system dependencies
         run: |
-          sudo apt-get update -y && sudo apt-get install -y jq curl
           sudo mkdir -p -m 755 /etc/apt/keyrings
           curl -sL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
           sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
@@ -107,20 +109,44 @@ jobs:
           configuration-path: .github/labeler.yml
           sync-labels: true
 
-      - name: Remind to run full CI on PR
+      - name: Remind contributors on PR open
         if: github.event.action == 'opened'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            github.rest.issues.createComment({
+            const title = context.payload.pull_request.title.toLowerCase();
+            const isBugFix = title.includes('[bugfix]');
+            const isFeature = title.includes('[feature]');
+            const typeLabel = isBugFix && isFeature ? '[BugFix]/[Feature]' : (isBugFix ? '[BugFix]' : '[Feature]');
+
+            let body = '👋 Hi! Thank you for contributing to the vLLM Ascend project. The following points will speed up your PR merge:‌‌\n\n' +
+              '- A PR should do only one thing, smaller PRs enable faster reviews.\n' +
+              '- Every PR should include unit tests and end-to-end tests ‌to ensure it works and is not broken by other future PRs.\n' +
+              '- Write the commit message by fulfilling the PR description to help reviewer and future developers understand.\n\n' +
+              'If CI fails, you can run linting and testing checks locally according [Contributing](https://docs.vllm.ai/projects/ascend/zh-cn/latest/developer_guide/contribution/index.html) and [Testing](https://docs.vllm.ai/projects/ascend/zh-cn/latest/developer_guide/contribution/testing.html).\n';
+
+            if (isBugFix || isFeature) {
+              body += '\n---\n\n' +
+                '> [!TIP]\n' +
+                '> ## :bulb: Consider Linking a Related Issue or RFC\n' +
+                '>\n' +
+                '> Your PR title contains the **' + typeLabel + '** tag, indicating a bug fix or new feature.\n' +
+                '>\n' +
+                '> Linking a related issue or RFC in the PR description is **strongly encouraged** — it gives reviewers helpful context and speeds up the review. You can use any of these keywords:\n' +
+                '>\n' +
+                '> - `Fixes #<issue_number>`\n' +
+                '> - `Closes #<issue_number>`\n' +
+                '> - `Resolves #<issue_number>`\n' +
+                '> - `Refs #<rfc_or_issue_number>` (for RFCs)\n' +
+                '>\n' +
+                '> :pray: Thanks for helping us keep the project well-organized!\n';
+            }
+
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '👋 Hi! Thank you for contributing to the vLLM Ascend project. The following points will speed up your PR merge:‌‌\n\n' +
-                '- A PR should do only one thing, smaller PRs enable faster reviews.\n' +
-                '- Every PR should include unit tests and end-to-end tests ‌to ensure it works and is not broken by other future PRs.\n' +
-                '- Write the commit message by fulfilling the PR description to help reviewer and future developers understand.\n\n' +
-                'If CI fails, you can run linting and testing checks locally according [Contributing](https://docs.vllm.ai/projects/ascend/zh-cn/latest/developer_guide/contribution/index.html) and [Testing](https://docs.vllm.ai/projects/ascend/zh-cn/latest/developer_guide/contribution/testing.html).'
-            })
+              body: body
+            });
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_close_cancel_job.yaml
+++ b/.github/workflows/pr_close_cancel_job.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   cancel:
-    runs-on: linux-amd64-cpu-8-hk
+    runs-on: linux-amd64-cpu-2-hk
     steps:
       - uses: actions/github-script@v9
         with:

--- a/.github/workflows/pr_e2e_command.yml
+++ b/.github/workflows/pr_e2e_command.yml
@@ -34,7 +34,9 @@ permissions:
 jobs:
   e2e-test:
     name: Run /e2e tests
-    runs-on: linux-amd64-cpu-8-hk
+    runs-on: linux-amd64-cpu-4-hk
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend/act-environments-ubuntu:act-22.04
     outputs:
       pr_sha: ${{ steps.resolve.outputs.pr_sha }}
       test_groups: ${{ steps.groups.outputs.test_groups }}
@@ -45,18 +47,12 @@ jobs:
     steps:
       - name: Install system dependencies
         run: |
-          sudo apt-get update -y && sudo apt-get install -y curl
           sudo mkdir -p -m 755 /etc/apt/keyrings
           curl -sL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
           sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
           sudo apt-get update -y
           sudo apt-get install gh -y
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
 
       - name: Check user authorization
         id: auth
@@ -198,7 +194,7 @@ jobs:
     name: Report result
     needs: [e2e-test, trigger-selected-tests]
     if: always() && needs.e2e-test.result == 'success' && needs.e2e-test.outputs.notify_comment_id != ''
-    runs-on: linux-amd64-cpu-8-hk
+    runs-on: linux-amd64-cpu-2-hk
     steps:
       - name: Update comment with result
         uses: peter-evans/create-or-update-comment@v5

--- a/.github/workflows/pr_nightly_command.yml
+++ b/.github/workflows/pr_nightly_command.yml
@@ -30,7 +30,9 @@ permissions:
 jobs:
   authorize:
     name: Check user authorization
-    runs-on: linux-amd64-cpu-8-hk
+    runs-on: linux-amd64-cpu-4-hk
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend/act-environments-ubuntu:act-22.04
     outputs:
       test_cases: ${{ steps.resolve.outputs.test_cases }}
       branch: ${{ steps.resolve.outputs.branch }}
@@ -41,18 +43,12 @@ jobs:
     steps:
       - name: Install system dependencies
         run: |
-          sudo apt-get update -y && sudo apt-get install -y curl
           sudo mkdir -p -m 755 /etc/apt/keyrings
           curl -sL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
           sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
           sudo apt-get update -y
           sudo apt-get install gh -y
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
 
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -170,13 +166,14 @@ jobs:
     name: Trigger Nightly-A2
     needs: [authorize]
     if: needs.authorize.outputs.is_authorized == 'true' && needs.authorize.outputs.dispatch_a2 == 'true'
-    runs-on: linux-amd64-cpu-8-hk
+    runs-on: linux-amd64-cpu-4-hk
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend/act-environments-ubuntu:act-22.04
     outputs:
       a2_run_id: ${{ steps.dispatch_a2.outputs.a2_run_id }}
     steps:
       - name: Install system dependencies
         run: |
-          sudo apt-get update -y && sudo apt-get install -y curl
           sudo mkdir -p -m 755 /etc/apt/keyrings
           curl -sL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
           sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
@@ -209,13 +206,14 @@ jobs:
     name: Trigger Nightly-A3
     needs: [authorize]
     if: needs.authorize.outputs.is_authorized == 'true' && needs.authorize.outputs.dispatch_a3 == 'true'
-    runs-on: linux-amd64-cpu-8-hk
+    runs-on: linux-amd64-cpu-4-hk
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend/act-environments-ubuntu:act-22.04
     outputs:
       a3_run_id: ${{ steps.dispatch_a3.outputs.a3_run_id }}
     steps:
       - name: Install system dependencies
         run: |
-          sudo apt-get update -y && sudo apt-get install -y curl
           sudo mkdir -p -m 755 /etc/apt/keyrings
           curl -sL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
           sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
@@ -248,7 +246,7 @@ jobs:
     name: Post nightly workflow links
     needs: [authorize, dispatch-a2, dispatch-a3]
     if: always() && needs.authorize.outputs.is_authorized == 'true'
-    runs-on: linux-amd64-cpu-8-hk
+    runs-on: linux-amd64-cpu-2-hk
     steps:
       - name: Build comment body
         id: body

--- a/.github/workflows/pr_rerun_command.yml
+++ b/.github/workflows/pr_rerun_command.yml
@@ -30,13 +30,14 @@ permissions:
 jobs:
   rerun:
     name: Re-run failed CI jobs
-    runs-on: linux-amd64-cpu-8-hk
+    runs-on: linux-amd64-cpu-4-hk
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend/act-environments-ubuntu:act-22.04
     outputs:
       rerun_count: ${{ steps.rerun.outputs.rerun_count }}
     steps:
       - name: Install system dependencies
         run: |
-          sudo apt-get update -y && sudo apt-get install -y jq curl
           sudo mkdir -p -m 755 /etc/apt/keyrings
           curl -sL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
           sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg

--- a/.github/workflows/schedule_stale_manage.yaml
+++ b/.github/workflows/schedule_stale_manage.yaml
@@ -8,13 +8,14 @@ on:
 jobs:
   remove-wait-feedback-on-comment:
     if: ${{ github.event_name == 'issue_comment' && contains(github.event.issue.labels.*.name, 'wait-feedback') }}
-    runs-on: linux-amd64-cpu-8-hk
+    runs-on: linux-amd64-cpu-2-hk
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend/act-environments-ubuntu:act-22.04
     permissions:
       issues: write
     steps:
       - name: Install system dependencies
         run: |
-          sudo apt-get update -y && sudo apt-get install -y curl
           sudo mkdir -p -m 755 /etc/apt/keyrings
           curl -sL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
           sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
@@ -27,7 +28,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   stale:
     if: ${{ github.event_name == 'schedule' }}
-    runs-on: linux-amd64-cpu-8-hk
+    runs-on: linux-amd64-cpu-2-hk
     permissions:
       actions: write
       issues: write

--- a/.github/workflows/scripts/conftest.py
+++ b/.github/workflows/scripts/conftest.py
@@ -1,0 +1,61 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Pytest configuration for ``scripts/`` unit tests.
+
+The ``select_tests`` module stores ``runner_mapping`` in a module-level
+global that is normally populated by ``main()`` from a two-document YAML
+config. Tests that exercise the routing internals directly need this global
+to be set. The :func:`_load_runner_mapping` autouse fixture loads the real
+``test_config.yaml`` once before each test, so internal-function tests work
+in isolation.
+
+End-to-end tests that call ``main()`` with their own config still need to
+include ``runner_mapping`` in that config (see ``_write_two_doc_config``).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+import regex as re
+import yaml
+
+_SCRIPT_DIR = Path(__file__).parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+sys.modules.setdefault("regex", re)
+select_tests = importlib.import_module("select_tests")
+
+
+@pytest.fixture(autouse=True)
+def _load_runner_mapping():
+    """Pre-populate ``select_tests._RUNNER_MAPPING`` from the real config.
+
+    Tests that call internal routing functions (``_route_ut_dir``,
+    ``_scan_ut_test_dir``, etc.) depend on this global. Loading it from the
+    real ``test_config.yaml`` mirrors the production behavior of ``main()``.
+    """
+    config_path = _SCRIPT_DIR / "test_config.yaml"
+    if config_path.exists():
+        docs = list(yaml.safe_load_all(config_path.read_text()))
+        meta = docs[1] if len(docs) >= 2 and docs[1] else {}
+        select_tests._load_runner_mapping(meta)
+    yield

--- a/.github/workflows/scripts/select_tests.py
+++ b/.github/workflows/scripts/select_tests.py
@@ -36,6 +36,13 @@ Pipeline (PR-driven mode):
   5. Partition  -- split test groups across parallel runners by estimated time.
   6. Output     -- write test_groups / has_tests / matched_modules.
 
+Test-only optimization:
+  If a PR changes only files under ``tests/`` (no source code touched), the
+  module-matching step is bypassed. Only the ``default_cpu_ut`` module (which
+  is always-on) and the changed test files themselves are run. This avoids
+  the broad regression triggered by ``optional: false`` modules when the
+  intent of the PR is purely to add or adjust tests.
+
 Routing is driven by ``test_config.yaml`` ``runner_mapping:`` (regex patterns).
 Partition sizing by ``partition:`` config block.
 See ``test_config.yaml`` for details.
@@ -68,7 +75,7 @@ class NpuType(str, Enum):
     CPU = "cpu"
 
 
-@dataclass
+@dataclass(frozen=True)
 class RunnerInfo:
     num_npus: int
     npu_type: NpuType
@@ -78,6 +85,10 @@ class RunnerInfo:
 
 RunnerKey = tuple[int, NpuType]
 _DEFAULT_KEY: RunnerKey = (0, NpuType.CPU)
+
+# The always-on CPU UT module. In test-only changes, only this module
+# is selected for UT runs (along with the changed test files).
+DEFAULT_CPU_UT_MODULE = "default_cpu_ut"
 
 # Populated by _load_runner_mapping(). Ordered list of (regex, {key: RunnerKey}).
 _RUNNER_MAPPING: list[tuple[re.Pattern, dict[str, RunnerKey]]] = []
@@ -94,8 +105,8 @@ def _parse_runner_key(runner_key: str) -> RunnerKey:
     return (num_npus, npu_type)
 
 
-def _load_runner_mapping(config_path: Path) -> None:
-    """Load runner mapping from the second YAML document into ``_RUNNER_MAPPING``.
+def _load_runner_mapping(meta: dict) -> None:
+    """Load runner mapping from the config meta dict into ``_RUNNER_MAPPING``.
 
     Config format::
 
@@ -108,19 +119,13 @@ def _load_runner_mapping(config_path: Path) -> None:
     """
     global _RUNNER_MAPPING
     _RUNNER_MAPPING = []
-    try:
-        docs = list(yaml.safe_load_all(config_path.read_text()))
-        if len(docs) >= 2:
-            meta = docs[1] or {}
-            raw = list((meta.get("runner_mapping", {}) or {}).items())
-            raw.sort(key=lambda x: -len(x[0]))
-            for pattern_str, runner_config in raw:
-                runners: dict[str, RunnerKey] = {}
-                for key, val in runner_config.items():
-                    runners[key] = _parse_runner_key(val)
-                _RUNNER_MAPPING.append((re.compile(pattern_str), runners))
-    except Exception:
-        pass
+    raw = list((meta.get("runner_mapping", {}) or {}).items())
+    raw.sort(key=lambda x: -len(x[0]))
+    for pattern_str, runner_config in raw:
+        runners: dict[str, RunnerKey] = {}
+        for key, val in runner_config.items():
+            runners[key] = _parse_runner_key(val)
+        _RUNNER_MAPPING.append((re.compile(pattern_str), runners))
 
 
 def _resolve_runner(file_path: str) -> RunnerKey | None:
@@ -182,7 +187,7 @@ def _get_changed_files(base_ref: str) -> list[str]:
         text=True,
         check=True,
     )
-    return [f for f in result.stdout.strip().split("\n") if f]
+    return [f for f in result.stdout.strip().splitlines() if f]
 
 
 def _matches_path_dependency(file_path: str, dependency: str) -> bool:
@@ -198,7 +203,7 @@ def _as_base_list(base: str | list[str] | None) -> list[str]:
     return base
 
 
-def _merge_unique(parent: list, child: list) -> list:
+def _merge_unique(parent: list[str], child: list[str]) -> list[str]:
     result = list(parent)
     for item in child:
         if item not in result:
@@ -329,6 +334,20 @@ def _is_e2e_path(path: str) -> bool:
     return path == "tests/e2e" or path.startswith("tests/e2e/")
 
 
+def _is_test_path(path: str) -> bool:
+    return _is_ut_path(path) or _is_e2e_path(path)
+
+
+def _is_test_only_change(changed_files: list[str]) -> bool:
+    """Return True if *changed_files* contains only files under ``tests/``.
+
+    When a PR touches nothing but test files, there is no source change
+    requiring broad regression; only the changed tests (and the always-on
+    ``default_cpu_ut`` module) need to run.
+    """
+    return bool(changed_files) and all(_is_test_path(f) for f in changed_files)
+
+
 def _scan_ut_test_dir(
     dir_path: str,
     groups: dict[RunnerKey, list[str]],
@@ -353,12 +372,17 @@ def _scan_ut_test_dir(
     if path.is_file():
         key = _route_ut_dir(dir_path)
         if cpu_only and key != _DEFAULT_KEY:
+            print(
+                f"Warning: cpu_only module test {dir_path} routes to NPU runner;"
+                " check test_config.yaml for misconfigured cpu_only tests.",
+                file=sys.stderr,
+            )
             return
         groups[key].append(dir_path)
         return
 
     for f in sorted(path.rglob("test_*.py")):
-        if any(part in ("__pycache__",) for part in f.parts):
+        if "__pycache__" in f.parts:
             continue
         key = _route_ut_dir(str(f))
         if cpu_only and key != _DEFAULT_KEY:
@@ -441,42 +465,21 @@ def _find_runner(
     return candidates[0] if candidates else None
 
 
-def _load_estimated_times(
-    config_path: Path,
-) -> dict[str, float]:
-    """Load per-test estimated times from the second YAML document.
+def _load_estimated_times(meta: dict) -> dict[str, float]:
+    """Load per-test estimated times from the config meta dict.
 
     Tests not listed default to 600s when used by _partition_tests.
     """
-    estimated_times: dict[str, float] = {}
-    try:
-        docs = list(yaml.safe_load_all(config_path.read_text()))
-        if len(docs) >= 2:
-            meta = docs[1] or {}
-            for k, v in meta.get("estimated_times", {}).items():
-                estimated_times[k] = float(v)
-    except Exception:
-        pass
-    return estimated_times
+    return {k: float(v) for k, v in meta.get("estimated_times", {}).items()}
 
 
-def _load_partition_config(
-    config_path: Path,
-) -> dict[str, int]:
-    """Load partition configuration from the second YAML document.
+def _load_partition_config(meta: dict) -> dict[str, int]:
+    """Load partition configuration from the config meta dict.
 
     Returns a dict mapping runner keys (e.g. ``a2_x1``) to partition
     counts.  Runner keys not listed default to 1.
     """
-    partition: dict[str, int] = {}
-    try:
-        docs = list(yaml.safe_load_all(config_path.read_text()))
-        if len(docs) >= 2:
-            meta = docs[1] or {}
-            partition = {k: int(v) for k, v in meta.get("partition", {}).items()}
-    except Exception:
-        pass
-    return partition
+    return {k: int(v) for k, v in meta.get("partition", {}).items()}
 
 
 def _lookup_estimated_time(
@@ -542,6 +545,25 @@ def _partition_tests(
     return result
 
 
+def _build_test_group(
+    num_npus: int,
+    npu_type: NpuType,
+    runner: RunnerInfo,
+    tests: list[str],
+    partition: str,
+) -> dict:
+    group: dict = {
+        "num_npus": num_npus,
+        "npu_type": npu_type.value,
+        "runner": runner.label,
+        "tests": " ".join(sorted(tests)),
+        "partition": partition,
+    }
+    if runner.image_tag:
+        group["image_tag"] = runner.image_tag
+    return group
+
+
 def _resolve_to_runners(
     all_groups: dict[RunnerKey, list[str]],
     runners: list[RunnerInfo],
@@ -577,33 +599,17 @@ def _resolve_to_runners(
             for i, bucket in enumerate(buckets):
                 if not bucket:
                     continue
-                group: dict = {
-                    "num_npus": num_npus,
-                    "npu_type": npu_type.value,
-                    "runner": runner.label,
-                    "tests": " ".join(sorted(bucket)),
-                    "partition": f"{i + 1}-{psize}",
-                }
-                if runner.image_tag:
-                    group["image_tag"] = runner.image_tag
-                result.append(group)
+                result.append(_build_test_group(num_npus, npu_type, runner, bucket, f"{i + 1}-{psize}"))
         else:
-            group = {
-                "num_npus": num_npus,
-                "npu_type": npu_type.value,
-                "runner": runner.label,
-                "tests": " ".join(sorted(tests)),
-                "partition": "1-1",
-            }
-            if runner.image_tag:
-                group["image_tag"] = runner.image_tag
-            result.append(group)
+            result.append(_build_test_group(num_npus, npu_type, runner, tests, "1-1"))
 
     if errors:
+        details = "".join(errors)
         print(
-            "\nERROR: The following test groups cannot be routed to any runner"
-            " in runner_label.json:" + "".join(errors) + "\n\nPlease fix the directory structure or add the"
-            " missing runner to runner_label.json.\n",
+            f"\nERROR: The following test groups cannot be routed to any runner"
+            f" in runner_label.json:\n{details}\n\n"
+            "Please fix the directory structure or add the missing runner"
+            " to runner_label.json.\n",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -702,8 +708,10 @@ def main():
     )
 
     args = parser.parse_args()
-    _load_runner_mapping(args.config)
-    config = _resolve_config_inheritance(next(yaml.safe_load_all(args.config.read_text())))
+    docs = list(yaml.safe_load_all(args.config.read_text()))
+    config = _resolve_config_inheritance(docs[0])
+    meta = docs[1] if len(docs) >= 2 and docs[1] else {}
+    _load_runner_mapping(meta)
 
     skip_tests: set[str] = set()
     for module in config:
@@ -723,18 +731,28 @@ def main():
             _scan_e2e_test_dir(path, all_groups)
     else:
         changed_files = _get_changed_files(args.diff_base) if args.diff_base else args.changed_files
-        matched_modules = (
-            [module["name"] for module in config] if args.run_all_modules else _match_modules(changed_files, config)
-        )
+        test_only_change = _is_test_only_change(changed_files)
+        if test_only_change:
+            print(
+                "Detected test-only change: running only default_cpu_ut"
+                " and the changed test files (skipping source-driven modules).",
+                file=sys.stderr,
+            )
+        if args.run_all_modules:
+            matched_modules = [module["name"] for module in config]
+        elif test_only_change:
+            matched_modules = [m["name"] for m in config if m["name"] == DEFAULT_CPU_UT_MODULE]
+        else:
+            matched_modules = _match_modules(changed_files, config)
         test_dirs, cpu_only_dirs = _collect_test_dirs(matched_modules, config)
 
-        changed_test_files = [
-            f
-            for f in changed_files
-            if (_is_ut_path(f) or _is_e2e_path(f))
-            and Path(_pytest_node_file_path(f)).name.startswith("test_")
-            and Path(_pytest_node_file_path(f)).exists()
-        ]
+        changed_test_files = []
+        for f in changed_files:
+            if not _is_test_path(f):
+                continue
+            target = Path(_pytest_node_file_path(f))
+            if target.name.startswith("test_") and target.exists():
+                changed_test_files.append(f)
 
         ut_dirs = [d for d in test_dirs if _is_ut_path(d)]
         cpu_only_ut_dirs = [d for d in cpu_only_dirs if _is_ut_path(d)]
@@ -798,8 +816,8 @@ def main():
         _dedup_groups(all_groups)
 
     runners = _load_runners()
-    estimated_times = _load_estimated_times(args.config)
-    partition_config = _load_partition_config(args.config)
+    estimated_times = _load_estimated_times(meta)
+    partition_config = _load_partition_config(meta)
     test_groups = _resolve_to_runners(all_groups, runners, partition_config, estimated_times)
 
     _write_output(test_groups, matched_modules)

--- a/.github/workflows/scripts/test_select_tests.py
+++ b/.github/workflows/scripts/test_select_tests.py
@@ -137,6 +137,25 @@ def test_collect_paths_and_basic_path_helpers():
 
 
 def test_route_helpers():
+    # Use a controlled runner_mapping that covers all convention directories
+    # documented in test_config.yaml (a2_2, a2, a3_4, a3_2, 310p). The real
+    # config only defines a subset because the corresponding test directories
+    # don't exist in the repo today, but the routing logic supports all of them.
+    select_tests._load_runner_mapping(
+        {
+            "runner_mapping": {
+                "tests/ut/.+/a2_2": {"default": "a2_x2"},
+                "tests/ut/.+/a2": {"default": "a2_x1"},
+                "tests/ut/.+/a3_4": {"default": "a3_x4"},
+                "tests/ut/.+/a3_2": {"default": "a3_x2"},
+                "tests/ut/.+/310p": {"default": "310p_x1"},
+                "tests/e2e/pull_request/one_card": {"default": "a2_x1", "310p": "310p_x1"},
+                "tests/e2e/pull_request/two_card": {"default": "a3_x2"},
+                "tests/e2e/pull_request/four_card": {"default": "a3_x4", "310p": "310p_x4"},
+            }
+        }
+    )
+
     assert select_tests._pytest_node_file_path("tests/e2e/test_x.py::TestCase::test_a") == "tests/e2e/test_x.py"
     assert select_tests._route_ut_dir("tests/ut/mod/a2_2/test_x.py") == (2, select_tests.NpuType.A2)
     assert select_tests._route_ut_dir("tests/ut/mod/a2_2/test_x.py::test_case") == (2, select_tests.NpuType.A2)
@@ -265,8 +284,16 @@ def test_dedup_runner_resolution_and_output(tmp_path, monkeypatch, capsys):
             "runner": "cpu-runner",
             "tests": "tests/ut/a.py tests/ut/b.py",
             "image_tag": "cpu-img",
+            "partition": "1-1",
         },
-        {"num_npus": 1, "npu_type": "a2", "runner": "a2-runner", "tests": "e2e.py", "image_tag": "a2-img"},
+        {
+            "num_npus": 1,
+            "npu_type": "a2",
+            "runner": "a2-runner",
+            "tests": "e2e.py",
+            "image_tag": "a2-img",
+            "partition": "1-1",
+        },
     ]
     with pytest.raises(SystemExit):
         select_tests._resolve_to_runners({(2, select_tests.NpuType.A2): ["x"]}, runners)
@@ -340,7 +367,12 @@ def test_main_end_to_end_changed_files_options_and_skip(tmp_path, monkeypatch, c
         },
     ]
     config_path = tmp_path / "config.yaml"
-    config_path.write_text(yaml.safe_dump(config))
+    runner_mapping = {
+        "tests/ut/.+/a2": {"default": "a2_x1"},
+        "tests/e2e/pull_request/one_card": {"default": "a2_x1", "310p": "310p_x1"},
+        "tests/e2e/pull_request/two_card": {"default": "a3_x2"},
+    }
+    _write_two_doc_config(config_path, config, {"runner_mapping": runner_mapping})
     runner_file = tmp_path / "runner_label.json"
     runner_file.write_text(
         json.dumps(
@@ -462,7 +494,8 @@ def test_default_cpu_ut_always_runs(tmp_path, monkeypatch, capsys):
         },
     ]
     config_path = tmp_path / "config.yaml"
-    config_path.write_text(yaml.safe_dump(config))
+    runner_mapping = {"tests/ut/.+/a2": {"default": "a2_x1"}}
+    _write_two_doc_config(config_path, config, {"runner_mapping": runner_mapping})
     runner_file = tmp_path / "runner_label.json"
     runner_file.write_text(
         json.dumps(

--- a/.github/workflows/slash_command_dispatch.yml
+++ b/.github/workflows/slash_command_dispatch.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   slashCommandDispatch:
     if: github.event.issue.pull_request != null && github.event.comment.user.type == 'User'
-    runs-on: linux-amd64-cpu-8-hk
+    runs-on: linux-amd64-cpu-2-hk
     steps:
       - name: Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@v5


### PR DESCRIPTION
Workflow runner migration:
- Switch bot/pr workflows from cpu-8-hk to smaller cpu-2/4-hk runners
  with prebuilt act-environments-ubuntu container images; drop redundant
  apt and Python setup steps.

select_tests: test-only optimization
- When a PR changes only files under tests/, skip source-driven module
  matching and run only default_cpu_ut plus the changed test files,
  avoiding broad regression triggered by optional:false modules.
- Refactor loader helpers to take meta dict directly; add conftest.py
  to pre-populate _RUNNER_MAPPING for internal-function tests.

bot_pr_create: title-driven issue/RFC reminder
- When the PR title contains [BugFix] or [Feature] (case-insensitive),
  append a friendly tip encouraging authors to link a related issue or
  RFC via Fixes/Closes/Resolves/Refs keywords.

Misc:
- bot_merge_conflict: add retryAfter/retryMax to reduce flakiness.
- .gemini/config.yaml: drop the help comment on PR open.
- actionlint: register the new cpu-2-hk and cpu-4-hk runner labels.

---
- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
