### PR TITLE
[Feature][Worker] Layerwise KV cache pool with prefill layer reuse support (Prefill offload)

### DIFF
--- a/tests/ut/distributed/ascend_store/test_layerwise_config.py
+++ b/tests/ut/distributed/ascend_store/test_layerwise_config.py
@@ -1,0 +1,165 @@
+"""Unit tests for layerwise KV cache reuse config parsing."""
+
+import pytest
+
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_config import (
+    get_layer_load_start_block,
+    get_layerwise_config,
+    get_layerwise_independent_layers,
+    get_layerwise_kv_cache_num_tensors,
+    get_layerwise_kv_cache_reuse_layers,
+    get_layerwise_num_prefetch_layers,
+    get_layerwise_num_shared_buffers,
+    get_layerwise_storage_indices,
+)
+
+
+class TestNumSharedBuffers:
+    def test_default_equals_num_layers(self):
+        assert get_layerwise_num_shared_buffers(27, None) == 27
+        assert get_layerwise_num_shared_buffers(27, {}) == 27
+
+    def test_from_extra_config(self):
+        cfg = {"layerwise_num_shared_buffers": 6}
+        assert get_layerwise_num_shared_buffers(27, cfg) == 6
+
+    def test_string_value_parsed(self):
+        cfg = {"layerwise_num_shared_buffers": "6"}
+        assert get_layerwise_num_shared_buffers(27, cfg) == 6
+
+    def test_bool_rejected(self):
+        with pytest.raises(TypeError):
+            get_layerwise_num_shared_buffers(27, {"layerwise_num_shared_buffers": True})
+
+    def test_less_than_one_rejected(self):
+        with pytest.raises(ValueError):
+            get_layerwise_num_shared_buffers(27, {"layerwise_num_shared_buffers": 0})
+
+
+class TestNumPrefetchLayers:
+    def test_default_one(self):
+        assert get_layerwise_num_prefetch_layers(None) == 1
+        assert get_layerwise_num_prefetch_layers({}) == 1
+
+    def test_from_extra_config(self):
+        assert get_layerwise_num_prefetch_layers({"layerwise_prefetch_layers": 3}) == 3
+
+    def test_less_than_one_rejected(self):
+        with pytest.raises(ValueError):
+            get_layerwise_num_prefetch_layers({"layerwise_prefetch_layers": 0})
+
+
+class TestIndependentLayers:
+    def test_default_first_and_last(self):
+        assert get_layerwise_independent_layers(27, None) == [0, 26]
+
+    def test_all(self):
+        result = get_layerwise_independent_layers(5, {"layerwise_independent_layers": "all"})
+        assert result == [0, 1, 2, 3, 4]
+
+    def test_comma_separated(self):
+        result = get_layerwise_independent_layers(27, {"layerwise_independent_layers": "3,5,10"})
+        assert result == [3, 5, 10]
+
+    def test_dedup_and_sort(self):
+        result = get_layerwise_independent_layers(27, {"layerwise_independent_layers": "10,3,3"})
+        assert result == [3, 10]
+
+    def test_negative_normalizes_to_last(self):
+        result = get_layerwise_independent_layers(27, {"layerwise_independent_layers": "-1"})
+        assert result == [26]
+
+    def test_out_of_range_rejected(self):
+        with pytest.raises(ValueError):
+            get_layerwise_independent_layers(27, {"layerwise_independent_layers": "27"})
+
+    def test_list_input(self):
+        result = get_layerwise_independent_layers(10, {"layerwise_independent_layers": [1, 4]})
+        assert result == [1, 4]
+
+
+class TestLayerwiseConfig:
+    def test_no_reuse_when_all_independent(self):
+        cfg = get_layerwise_config(27, {"layerwise_independent_layers": "all"})
+        assert cfg.has_layer_reuse is False
+        assert cfg.prefetch_layer_map == {}
+
+    def test_reuse_when_reused_exceeds_buffers(self):
+        # default independent [0, 26] → 25 reused layers, 6 buffers → reuse.
+        cfg = get_layerwise_config(27, {"layerwise_num_shared_buffers": 6})
+        assert cfg.has_layer_reuse is True
+        # prefetch: reused[6]=7 maps to reused[0]=1, reused[7]=8 to reused[1]=2.
+        assert cfg.prefetch_layer_map[7] == 1
+        assert cfg.prefetch_layer_map[8] == 2
+
+    def test_reuse_layers_none_when_no_reuse(self):
+        assert get_layerwise_kv_cache_reuse_layers(27, {"layerwise_independent_layers": "all"}) is None
+
+    def test_reuse_layers_value_when_reuse(self):
+        assert get_layerwise_kv_cache_reuse_layers(27, {"layerwise_num_shared_buffers": 6}) == 6
+
+
+class TestNumTensors:
+    def test_none_when_no_reuse(self):
+        assert get_layerwise_kv_cache_num_tensors(27, {"layerwise_independent_layers": "all"}) is None
+
+    def test_independent_plus_shared_buffers(self):
+        # default independent [0, 26] (2 layers) + 6 shared buffers = 8.
+        assert get_layerwise_kv_cache_num_tensors(27, {"layerwise_num_shared_buffers": 6}) == 8
+
+    def test_no_independent_equals_shared_buffers(self):
+        # no independent layers -> only the shared buffers.
+        assert (
+            get_layerwise_kv_cache_num_tensors(
+                27, {"layerwise_num_shared_buffers": 6, "layerwise_independent_layers": ""}
+            )
+            == 6
+        )
+
+
+class TestStorageIndices:
+    def test_full_coverage_no_duplicates(self):
+        indices = get_layerwise_storage_indices(27, {"layerwise_num_shared_buffers": 6})
+        flat = [layer for slot in indices for layer in slot]
+        assert sorted(flat) == list(range(27))
+        assert len(flat) == len(set(flat))
+
+    def test_independent_layers_own_slots(self):
+        indices = get_layerwise_storage_indices(27, {"layerwise_num_shared_buffers": 6})
+        # first two slots are the independent layers [0] and [26].
+        assert indices[0] == [0]
+        assert indices[1] == [26]
+
+    def test_reused_round_robin_grouping(self):
+        indices = get_layerwise_storage_indices(27, {"layerwise_num_shared_buffers": 6})
+        # independent [0], [26] then 6 reused slots over reused [1..25].
+        reused_slots = indices[2:]
+        assert len(reused_slots) == 6
+        # slot 0 holds reused_layers[0::6] = [1, 7, 13, 19, 25].
+        assert reused_slots[0] == [1, 7, 13, 19, 25]
+
+    def test_no_reuse_one_slot_per_layer(self):
+        indices = get_layerwise_storage_indices(5, {"layerwise_independent_layers": "all"})
+        assert indices == [[0], [1], [2], [3], [4]]
+
+
+class TestGetLayerLoadStartBlock:
+    # default independent layers are the first and last: [0, 26]
+    INDEPENDENT = [0, 26]
+    BLOCK_SIZE = 16
+
+    def test_independent_skips_hbm_cached_blocks(self):
+        # layer 0 independent, HBM has 32 tokens (2 blocks) -> start at block 2
+        assert get_layer_load_start_block(0, self.INDEPENDENT, 32, self.BLOCK_SIZE, True) == 2
+
+    def test_independent_no_hbm_hit_starts_at_zero(self):
+        assert get_layer_load_start_block(0, self.INDEPENDENT, 0, self.BLOCK_SIZE, True) == 0
+
+    def test_shared_layer_always_starts_at_zero(self):
+        # layer 5 shared: HBM hits are unreliable (time-multiplexed) -> always 0
+        assert get_layer_load_start_block(5, self.INDEPENDENT, 32, self.BLOCK_SIZE, True) == 0
+        assert get_layer_load_start_block(5, self.INDEPENDENT, 0, self.BLOCK_SIZE, True) == 0
+
+    def test_no_reuse_all_layers_skip_hbm(self):
+        # without layer reuse, even a shared layer skips HBM-cached blocks
+        assert get_layer_load_start_block(5, self.INDEPENDENT, 32, self.BLOCK_SIZE, False) == 2

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -55,6 +55,10 @@ from vllm.v1.worker.utils import extract_layer_index
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector import GET_META_MSG
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker import (
+    get_shared_layer_transfer_events,
+    set_shared_layer_transfer_events,
+)
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
 from vllm_ascend.distributed.kv_transfer.utils.utils import (
     RegisterRegions,
@@ -224,6 +228,7 @@ class KVCacheSendingLayerThread(threading.Thread):
         enable_c8_quant: bool,
         resharding_stream: torch.npu.Stream,
         callback_func: Callable[..., None] = lambda x: None,
+        layer_transfer_finished_events: list[threading.Event] | None = None,
     ):
         super().__init__(daemon=True, name="KVCacheSendingLayerThread")
         self.engine = engine
@@ -262,6 +267,7 @@ class KVCacheSendingLayerThread(threading.Thread):
         self.enable_c8_quant = enable_c8_quant
         self.ready_event = ready_event
         self.callback_func = callback_func
+        self.layer_transfer_finished_events = layer_transfer_finished_events
 
     def run(self):
         local_rank = get_world_group().local_rank
@@ -439,6 +445,10 @@ class KVCacheSendingLayerThread(threading.Thread):
 
     def _transfer_kv_cache(self, send_task: SendTask):
         layer_name = send_task.layer_name
+        if self.layer_transfer_finished_events is not None:
+            assert not self.layer_transfer_finished_events[send_task.layer_idx].is_set(), (
+                f"layer {send_task.layer_idx} transfer event already set before transfer"
+            )
         layer_group_idx = self.layer_metadata[layer_name].tensor_group_idx[0]
         key = send_task.k_cache
         value = send_task.v_cache
@@ -518,6 +528,8 @@ class KVCacheSendingLayerThread(threading.Thread):
                                 self.failed_reqs.discard(req_id)
                             else:
                                 self.callback_func(req_id, req_meta, layer_group_idx, trans_flag=True)
+        if self.layer_transfer_finished_events is not None:
+            self.layer_transfer_finished_events[send_task.layer_idx].set()
 
 
 class KVCacheRecvingLayerThread(threading.Thread):
@@ -1144,6 +1156,12 @@ class MooncakeLayerwiseConnectorWorker:
         self.kv_caches: dict[str, torch.Tensor] = {}
         self.side_channel_host = get_ip()
         self.total_layers = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
+
+        # Create and publish per-layer PD transfer-finished events so the
+        # co-located ascend_store save thread can wait for each layer's PD
+        # transfer. Only the producer sends KV, so only it needs events.
+        if vllm_config.kv_transfer_config.is_kv_producer:
+            set_shared_layer_transfer_events([threading.Event() for _ in range(self.total_layers)])
         self.use_mla = self.vllm_config.model_config.use_mla
         self.request_map = dict[str, str]()
         self.use_attn_mamba_hybrid = False
@@ -1371,6 +1389,7 @@ class MooncakeLayerwiseConnectorWorker:
                 enable_c8_quant=self.enable_c8_quant,
                 resharding_stream=self.resharding_stream,
                 callback_func=self.send_done_send_signal,
+                layer_transfer_finished_events=get_shared_layer_transfer_events(),
             )
             self.kv_send_layer_thread.start()
             ready_event.wait()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -84,6 +84,9 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         self.kv_role = vllm_config.kv_transfer_config.kv_role
 
         self.use_layerwise = vllm_config.kv_transfer_config.kv_connector_extra_config.get("use_layerwise", False)
+        backend_name = vllm_config.kv_transfer_config.kv_connector_extra_config.get("backend", "mooncake")
+        self.backend_name = backend_name.lower()
+        self.use_gva_layerwise = self.use_layerwise and self.backend_name == "memcache"
         self.consumer_is_to_put = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
             "consumer_is_to_put", False
         )
@@ -98,20 +101,21 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         self.kv_caches: dict[str, torch.Tensor] = {}
         self._kv_cache_events: AscendStoreKVEvents | None = None
 
-        self.sended_but_unfinished_reqs: set[str] = set()
-
         if role == KVConnectorRole.SCHEDULER:
-            self.connector_scheduler = KVPoolScheduler(vllm_config, self.use_layerwise, kv_cache_config)
+            assert kv_cache_config is not None
+            page_size_bytes = kv_cache_config.kv_cache_groups[0].kv_cache_spec.page_size_bytes
+            self.connector_scheduler = KVPoolScheduler(
+                vllm_config, self.use_layerwise, kv_cache_config, page_size_bytes=page_size_bytes
+            )
         else:
             self.connector_worker = KVPoolWorker(
                 vllm_config,
                 self.use_layerwise,
                 kv_cache_config,
             )
-
             assert self.connector_worker is not None
-            if vllm_config.parallel_config.rank == 0:
-                self.lookup_server = LookupKeyServer(self.connector_worker, vllm_config, self.use_layerwise)
+            if not self.use_layerwise and vllm_config.parallel_config.rank == 0:
+                self.lookup_server = LookupKeyServer(self.connector_worker, vllm_config)
 
     ############################################################
     # Scheduler Side Methods
@@ -274,10 +278,8 @@ class LookupKeyServer:
         self,
         pool_worker: KVPoolWorker,
         vllm_config: "VllmConfig",
-        use_layerwise: bool,
     ):
         self.decoder = MsgpackDecoder()
-        self.decoder_tensor = MsgpackDecoder(torch.Tensor)
         self.ctx = zmq.Context()  # type: ignore[attr-defined]
         socket_path = get_zmq_rpc_path_lookup(vllm_config)
         self.socket = make_zmq_socket(
@@ -289,7 +291,6 @@ class LookupKeyServer:
 
         self.pool_worker = pool_worker
         self.running = True
-        self.use_layerwise = use_layerwise
 
         def process_request():
             while self.running:
@@ -302,7 +303,7 @@ class LookupKeyServer:
                     token_len,
                     hashes_str,
                     kv_group_ids,
-                    self.use_layerwise,
+                    use_layerwise=False,
                 )
                 logger.debug(
                     "KV pool lookup response token_len=%d groups=%s hit_tokens=%d",
@@ -318,4 +319,3 @@ class LookupKeyServer:
 
     def close(self):
         self.socket.close(linger=0)
-        # TODO: close the thread!

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/__init__.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/__init__.py
@@ -1,1 +1,30 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
+backend_map = {
+    "mooncake": {
+        "name": "MooncakeBackend",
+        "path": "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend",
+    },
+    "memcache": {
+        "name": "MemcacheBackend",
+        "path": "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.memcache_backend",
+    },
+    "yuanrong": {
+        "name": "YuanrongBackend",
+        "path": "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.yuanrong_backend",
+    },
+}

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/backend.py
@@ -1,12 +1,21 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from typing import Any
 
 from vllm.config import ParallelConfig
 
 
 class Backend(ABC):
+    store: Any | None = None
+
     @abstractmethod
     def __init__(self, parallel_config: ParallelConfig):
         pass
+
+    @classmethod
+    def create_scheduler_client(cls, parallel_config: ParallelConfig):
+        return cls(parallel_config)
 
     @abstractmethod
     def set_device(self):
@@ -19,6 +28,15 @@ class Backend(ABC):
     @abstractmethod
     def exists(self, keys: list[str]) -> list[int]:
         pass
+
+    def batch_is_exist(self, keys: list[str]) -> list[int]:
+        return self.exists(keys)
+
+    def batch_get_key_info(self, keys: list[str]):
+        raise NotImplementedError(f"{type(self).__name__} does not support batch_get_key_info")
+
+    def batch_alloc(self, keys: list[str], sizes: list[int]) -> list[int]:
+        raise NotImplementedError(f"{type(self).__name__} does not support batch_alloc")
 
     @abstractmethod
     def put(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -1,5 +1,6 @@
 # Standard
 import threading
+import time
 from enum import Enum
 from typing import Any
 
@@ -11,6 +12,8 @@ from vllm.logger import logger
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend import Backend
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
+MEMCACHE_THREAD_START_WAIT_S = 0.1
+
 
 class MmcDirect(Enum):
     COPY_L2G = 0
@@ -20,11 +23,19 @@ class MmcDirect(Enum):
 
 
 class MemcacheBackend(Backend):
-    def __init__(self, parallel_config: ParallelConfig, lazy_init: bool = False):
-        self.local_rank = get_world_group().local_rank
-        self.store: Any | None = None
+    def __init__(
+        self,
+        parallel_config: ParallelConfig,
+        local_rank: int | None = None,
+        init_bm: bool = True,
+        lazy_init: bool = False,
+    ):
+        self.local_rank = local_rank if local_rank is not None else get_world_group().local_rank
+        self._init_bm = init_bm
         self._is_a2 = get_ascend_device_type() in {AscendDeviceType.A2}
         self._lazy_init = lazy_init and not self._is_a2
+
+        self.store: Any | None = None
         self._store_initialized = False
         self._store_init_lock = threading.Lock()
         self._registered_buffers: tuple[list[int], list[int]] | None = None
@@ -56,21 +67,41 @@ class MemcacheBackend(Backend):
                 "https://gitee.com/ascend/memfabric_hybrid "  # noqa: E501
                 "to run vLLM with MemcacheConnector."
             ) from e
+
+        if self._init_bm and self._is_a2:
+            tmp_tensor = torch.zeros(1, device="npu")
+            output_tensor_list = [torch.empty_like(tmp_tensor) for _ in range(torch.distributed.get_world_size())]
+            torch.distributed.all_gather(output_tensor_list, tmp_tensor, group=get_world_group().device_group)
+
+        store = DistributedObjectStore()
+
         try:
-            if self._is_a2:
-                tmp_tensor = torch.zeros(1, device="npu")
-                output_tensor_list = [torch.empty_like(tmp_tensor) for _ in range(torch.distributed.get_world_size())]
-                torch.distributed.all_gather(output_tensor_list, tmp_tensor, group=get_world_group().device_group)
-            store = DistributedObjectStore()
-            res = store.init(self.local_rank)
-            assert res == 0
-            return store
+            res = store.init(self.local_rank, init_bm=self._init_bm)
         except ValueError as e:
             logger.error("Configuration loading failed. error=%s. Check memcache config and environment.", e)
             raise
         except Exception as exc:
             logger.error("Store initialization failed. error=%s. Check memcache setup and dependencies.", exc)
             raise
+
+        assert res == 0
+        time.sleep(MEMCACHE_THREAD_START_WAIT_S)
+        return store
+
+    @classmethod
+    def create_scheduler_client(cls, parallel_config: ParallelConfig):
+        # The scheduler is a single metadata client. It is initialized before
+        # the world group exists and must not initialize memcache storage, so
+        # keep the old device_id=0/init_bm=False behavior here.
+        return cls(parallel_config, local_rank=0, init_bm=False)
+
+    def init_store(self, init_bm: bool = True):
+        if self.store is not None:
+            return
+        self._init_bm = init_bm
+        self.store = self._setup_store()
+        self._store_initialized = True
+        self._register_buffers_if_needed()
 
     def set_device(self):
         device = torch.device(f"npu:{self.local_rank}")
@@ -102,6 +133,14 @@ class MemcacheBackend(Backend):
             return [0] * len(keys)
         assert self.store is not None
         return self.store.batch_is_exist(keys)
+
+    def batch_get_key_info(self, keys: list[str]):
+        assert self.store is not None
+        return self.store.batch_get_key_info(keys)
+
+    def batch_alloc(self, keys: list[str], sizes: list[int]) -> list[int]:
+        assert self.store is not None
+        return self.store.batch_alloc(keys, sizes)
 
     def get(self, key: list[str], addr: list[list[int]], size: list[list[int]]):
         if self._lazy_init and not self._store_initialized:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -60,7 +60,8 @@ def _ssd_setup_kwargs(config: "MooncakeStoreConfig") -> dict[str, object]:
 
 
 class MooncakeBackend(Backend):
-    def __init__(self, parallel_config: ParallelConfig, lazy_init: bool = False):
+    def __init__(self, parallel_config: ParallelConfig, lazy_init: bool = False, contribute_memory: bool = True):
+        self.parallel_config = parallel_config
         self.config = MooncakeStoreConfig.load_from_env()
         if self.config.protocol != "ascend":
             raise NotImplementedError(f"MooncakeBackend does not support protocol {self.config.protocol!r}.")
@@ -69,6 +70,7 @@ class MooncakeBackend(Backend):
         self.local_seg: str | None = None
         self._use_fabric_mem = os.getenv("ASCEND_ENABLE_USE_FABRIC_MEM", "0") == "1"
         self._lazy_init = lazy_init and self._use_fabric_mem
+        self._contribute_memory = contribute_memory
         self._store_initialized = False
         self._store_init_lock = threading.Lock()
 
@@ -101,10 +103,12 @@ class MooncakeBackend(Backend):
         store = MooncakeDistributedStore()
         local_hostname = get_ip()
         ssd_kwargs = _ssd_setup_kwargs(self.config)
-        if ssd_kwargs and ssd_kwargs.get("ssd_offload_path"):
-            # Per-rank SSD directory keyed by the globally unique rank so that
-            # DP/TP/PP/CP replicas never share a directory (dense and MoE alike).
-            global_rank = get_global_rank()
+        # Each rank that contributes memory to the pool uses its own SSD
+        # directory to avoid bucket file collisions. Key by the globally unique
+        # rank so that DP/TP/PP/CP replicas never share a directory (dense and
+        # MoE alike); only ranks that contribute memory need an offload dir.
+        if ssd_kwargs and ssd_kwargs.get("ssd_offload_path") and self._contribute_memory:
+            global_rank = get_global_rank(self.parallel_config)
             rank_path = os.path.join(str(ssd_kwargs["ssd_offload_path"]), f"rank_{global_rank}")
             try:
                 os.makedirs(rank_path, exist_ok=True)
@@ -120,8 +124,8 @@ class MooncakeBackend(Backend):
             ret = store.setup(
                 local_hostname=self.local_seg,
                 metadata_server=self.config.metadata_server,
-                global_segment_size=self.config.global_segment_size,
-                local_buffer_size=self.config.local_buffer_size,
+                global_segment_size=self.config.global_segment_size if self._contribute_memory else 0,
+                local_buffer_size=self.config.local_buffer_size if self._contribute_memory else 0,
                 protocol=self.config.protocol,
                 rdma_devices=self.config.device_name,
                 master_server_addr=self.config.master_server_address,
@@ -133,7 +137,7 @@ class MooncakeBackend(Backend):
             ret = store.setup(
                 local_hostname=self.local_seg,
                 metadata_server=self.config.metadata_server,
-                global_segment_size=self.config.global_segment_size,
+                global_segment_size=self.config.global_segment_size if self._contribute_memory else 0,
                 local_buffer_size=0,
                 protocol=self.config.protocol,
                 rdma_devices=self.config.device_name,
@@ -155,6 +159,11 @@ class MooncakeBackend(Backend):
                 self.config.ssd_offload_path,
             )
         return store
+
+    @classmethod
+    def create_scheduler_client(cls, parallel_config: ParallelConfig):
+        torch.npu.set_device(0)
+        return cls(parallel_config, contribute_memory=False)
 
     def set_device(self):
         local_rank = get_world_group().local_rank

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -5,12 +5,15 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import Any, cast
 
+import numpy as np
 import torch
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata, KVConnectorWorkerMetadata
 from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashList
 from vllm.v1.core.sched.output import NewRequestData
+
+from vllm_ascend.memcache_comm_fence import AttentionComputeStartGate
 
 _GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
 _GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
@@ -314,6 +317,16 @@ class ChunkedTokenDatabase:
             size_list.append(size)
         return addr_list, size_list, block_id
 
+    def prepare_block_info(self, start: int, end: int, block_ids: list[int]) -> tuple[int, list[int]]:
+        block_size = self.block_size[0]
+        block_id = block_ids[start // block_size]
+        block_len = self.group_block_len.get(0, [])
+        size_list = []
+        for i in range(len(block_len)):
+            size = int(block_len[i] / block_size * (end - start))
+            size_list.append(size)
+        return block_id, size_list
+
     def prepare_value_layer(self, start: int, end: int, block_ids: list[int], layer_id: int):
         group_block_size = self.get_block_size(0)
         block_id = block_ids[start // group_block_size]
@@ -323,7 +336,7 @@ class ChunkedTokenDatabase:
         length = len(group_block_len)
         for i in range(length):
             block_stride = group_block_stride[i] if group_block_stride else group_block_len[i]
-            addr = group_addrs[layer_id * length] + block_id * block_stride
+            addr = group_addrs[layer_id * length + i] + block_id * block_stride
             size = int(group_block_len[i] / group_block_size * (end - start))
             addr_list.append(addr)
             size_list.append(size)
@@ -355,7 +368,7 @@ class ChunkedTokenDatabase:
             return
         if not isinstance(block_hashes[0], str):
             block_hashes = [
-                h.hex()  # type: ignore[union-attr]
+                h.hex() if not isinstance(h, str) else h  # type: ignore[union-attr]
                 for h in block_hashes
             ]
         start_idx = 0
@@ -516,6 +529,19 @@ class RequestTracker:
     # NOTE: This field will only be used when you enable kv-event
     token_ids: list[int] | None = None
 
+    block_gvas: list[int] = field(default_factory=list)
+    gva_block_offset: int = 0
+    last_block_gva: int | None = None
+
+    block_keys: list[str] = field(default_factory=list)
+
+    starts: list[int] | None = None
+    ends: list[int] | None = None
+
+    sizes_per_chunk: list[list[int]] | None = None
+
+    last_block_key: str | None = None
+
     mamba_group_ids: list[int] | None = None
 
     # spec blocks for mamba cache group
@@ -531,6 +557,14 @@ class RequestTracker:
         allocated_block_ids: list[int] | list[list[int]] | None = None,
         num_saved_tokens: int = 0,
         token_ids: list[int] | None = None,
+        block_gvas: list[int] | None = None,
+        gva_block_offset: int = 0,
+        last_block_gva: int | None = None,
+        block_keys: list[str] | None = None,
+        starts: list[int] | None = None,
+        ends: list[int] | None = None,
+        sizes_per_chunk: list[list[int]] | None = None,
+        last_block_key: str | None = None,
         mamba_group_ids: list[int] | None = None,
         num_speculative_blocks: int = 0,
         block_sizes: list[int] | None = None,
@@ -545,6 +579,14 @@ class RequestTracker:
         self.allocated_block_ids_by_group = block_ids
         self.num_saved_tokens = num_saved_tokens
         self.token_ids = token_ids
+        self.block_gvas = [] if block_gvas is None else block_gvas
+        self.gva_block_offset = gva_block_offset
+        self.last_block_gva = last_block_gva
+        self.block_keys = [] if block_keys is None else block_keys
+        self.starts = starts
+        self.ends = ends
+        self.sizes_per_chunk = sizes_per_chunk
+        self.last_block_key = last_block_key
         self.block_sizes = block_sizes
 
     @property
@@ -617,12 +659,17 @@ class RequestTracker:
 class ReqMeta:
     # Request id
     req_id: str
-    # Number of tokens in this chunk
-    token_len_chunk: int
+    # End token for full-block KV save.
+    save_end_token: int
+    # Token length after this scheduled step finishes.
+    target_token_len: int
 
     block_ids_by_group: list[list[int]]
 
     block_hashes: list[BlockHash]
+
+    # First token that has not been saved before this metadata was built.
+    save_start_token: int = 0
 
     can_save: bool | None = None
     # load_spec
@@ -646,7 +693,7 @@ class ReqMeta:
     def __init__(
         self,
         req_id: str,
-        token_len_chunk: int,
+        token_len_chunk: int | None = None,
         block_ids_by_group: list[list[int]] | None = None,
         block_hashes: list[BlockHash] | None = None,
         can_save: bool | None = None,
@@ -661,9 +708,25 @@ class ReqMeta:
         original_block_size: list[int] | int | None = None,
         block_ids: list[int] | list[list[int]] | None = None,
         event_id: int | None = None,
+        save_end_token: int | None = None,
+        target_token_len: int | None = None,
+        save_start_token: int = 0,
+        last_block_gva: int | None = None,
+        partial_block_index: int | None = None,
+        starts: list[int] | None = None,
+        ends: list[int] | None = None,
+        sizes_per_chunk: list[list[int]] | None = None,
+        block_ids_np: np.ndarray | None = None,
+        block_gvas_np: np.ndarray | None = None,
+        gva_block_offset: int = 0,
     ) -> None:
+        if token_len_chunk is None:
+            token_len_chunk = 0 if save_end_token is None else save_end_token
         self.req_id = req_id
         self.token_len_chunk = token_len_chunk
+        self.save_end_token = token_len_chunk if save_end_token is None else save_end_token
+        self.target_token_len = token_len_chunk if target_token_len is None else target_token_len
+        self.save_start_token = save_start_token
         if block_ids_by_group is None:
             block_ids_by_group = normalize_block_ids_by_group(block_ids or [])
         self.block_ids_by_group = block_ids_by_group
@@ -679,6 +742,14 @@ class ReqMeta:
         self.token_ids = token_ids
         self.original_block_size = original_block_size
         self.event_id = event_id
+        self.last_block_gva = last_block_gva
+        self.partial_block_index = partial_block_index
+        self.starts = starts
+        self.ends = ends
+        self.sizes_per_chunk = sizes_per_chunk
+        self.block_ids_np = block_ids_np
+        self.block_gvas_np = block_gvas_np
+        self.gva_block_offset = gva_block_offset
 
     @property
     def block_ids(self) -> list[int]:
@@ -687,6 +758,18 @@ class ReqMeta:
     @block_ids.setter
     def block_ids(self, block_ids: list[int] | list[list[int]]) -> None:
         self.block_ids_by_group = normalize_block_ids_by_group(block_ids)
+
+    last_block_gva: int | None = None
+    partial_block_index: int | None = None
+
+    starts: list[int] | None = None
+    ends: list[int] | None = None
+
+    sizes_per_chunk: list[list[int]] | None = None
+
+    block_ids_np: np.ndarray | None = None
+    block_gvas_np: np.ndarray | None = None
+    gva_block_offset: int = 0
 
     @staticmethod
     def from_request_tracker(
@@ -703,7 +786,8 @@ class ReqMeta:
         """Create the request metadata from a request tracker."""
         if block_hashes is None:
             block_hashes = []
-        input_token_len = tracker.token_len
+        target_token_len = tracker.token_len
+        previous_saved_tokens = tracker.num_saved_tokens
 
         # For save operation: do not save if the following condition is met
         # 1. has already been saved before (num_saved_tokens > 0)
@@ -714,17 +798,36 @@ class ReqMeta:
             else 0
         )
         num_tokens_to_save = (
-            (input_token_len // cache_transfer_granularity * cache_transfer_granularity)
+            (target_token_len // cache_transfer_granularity * cache_transfer_granularity)
             if discard_partial_chunks
-            else input_token_len
+            else target_token_len
         )
+        full_block_count = target_token_len // cache_transfer_granularity
+        boundary_without_hash = (
+            target_token_len > 0
+            and target_token_len % cache_transfer_granularity == 0
+            and full_block_count > len(block_hashes)
+        )
+        if boundary_without_hash:
+            num_tokens_to_save = len(block_hashes) * cache_transfer_granularity
+        if tracker.last_block_gva is not None and (
+            target_token_len % cache_transfer_granularity != 0 or boundary_without_hash
+        ):
+            partial_block_index = (
+                full_block_count if target_token_len % cache_transfer_granularity != 0 else full_block_count - 1
+            )
+        else:
+            partial_block_index = None
 
-        skip_save = skip_save or num_tokens_to_save < chunk_boundary
+        skip_save = skip_save or (num_tokens_to_save < chunk_boundary and partial_block_index is None)
         if skip_save and load_spec is None:
             return None
 
         if not skip_save:
-            tracker.num_saved_tokens = num_tokens_to_save
+            tracker.num_saved_tokens = max(
+                tracker.num_saved_tokens,
+                num_tokens_to_save,
+            )
 
         token_ids = None
         if tracker.token_ids:
@@ -742,6 +845,9 @@ class ReqMeta:
         return ReqMeta(
             req_id=tracker.req_id,
             token_len_chunk=num_tokens_to_save,
+            save_end_token=num_tokens_to_save,
+            target_token_len=target_token_len,
+            save_start_token=previous_saved_tokens,
             block_ids_by_group=tracker.allocated_block_ids_by_group,
             can_save=not skip_save,
             load_spec=load_spec,
@@ -749,20 +855,79 @@ class ReqMeta:
             is_last_chunk=is_last_chunk,
             token_ids=token_ids,
             original_block_size=original_block_size,
+            last_block_gva=tracker.last_block_gva,
+            partial_block_index=partial_block_index,
+            block_ids_np=np.asarray(tracker.allocated_block_ids, dtype=np.int64),
+            block_gvas_np=np.asarray(tracker.block_gvas, dtype=np.int64),
+            gva_block_offset=tracker.gva_block_offset,
             kv_cache_group_ids=list(range(len(tracker.allocated_block_ids_by_group))),
             kv_cache_families_by_group=kv_cache_group_families,
         )
 
 
 class AscendConnectorMetadata(KVConnectorMetadata):
-    def __init__(self, unfinished_request_ids, preempted_req_ids):
-        self.requests = []
+    def __init__(
+        self,
+        unfinished_request_ids,
+        preempted_req_ids,
+        loading_req_ids: set[str] | None = None,
+        delayed_free_req_ids: set[str] | None = None,
+    ):
+        self.requests: list[ReqMeta] = []
         self.unfinished_request_ids = unfinished_request_ids
         self.preempted_req_ids = preempted_req_ids
+        self.loading_req_ids = loading_req_ids or set()
+        self.delayed_free_req_ids = delayed_free_req_ids or set()
 
     def add_request(self, req_meta: ReqMeta) -> None:
         """Add a request to the metadata."""
         self.requests.append(req_meta)
+
+
+@dataclass
+class LayerBatchReqMeta:
+    req_ids: list[str]
+    layer_id: int
+    is_last_chunks: list[bool | None] = field(default_factory=list)
+    addr_array: np.ndarray = field(default_factory=lambda: np.empty(0, dtype=np.int64))
+    size_array: np.ndarray = field(default_factory=lambda: np.empty(0, dtype=np.int64))
+    gvas_array: np.ndarray = field(default_factory=lambda: np.empty(0, dtype=np.int64))
+
+
+@dataclass
+class LayerBlockRange:
+    request: ReqMeta
+    start_block: int
+    end_block: int
+    partial_block_index: int | None = None
+
+
+@dataclass
+class SharedBlockData:
+    """Pre-computed block data shared across all layers for the same request."""
+
+    block_ids_arr: np.ndarray
+    block_gvas_arr: np.ndarray
+    req_ids: list[str]
+    is_last_chunks: list[bool | None]
+
+
+@dataclass
+class LayerTransferTask:
+    layer_id: int
+    block_ranges: list[LayerBlockRange]
+    shared_block_data: SharedBlockData | None = None
+    # Cache for KVCacheStoreKeyLayerSendingThread:
+    # maps block_range index -> list of (start, end, key_all_layers)
+    cached_process_tokens: dict[int, list[tuple[int, int, list]]] | None = None
+
+
+@dataclass
+class LayerLoadTask:
+    wait_for_save_layer: int | None
+    transfer_tasks: list[LayerTransferTask]
+    layer_id: int
+    attention_start_gate: AttentionComputeStartGate | None = None
 
 
 @dataclass(init=False)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
+import ctypes
 import queue
 import threading
+import time
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
+import numpy as np
 import torch
 from vllm.distributed.kv_events import BlockStored
 from vllm.logger import logger
@@ -14,11 +18,208 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend im
 # isort: off
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     ChunkedTokenDatabase,
+    LayerBatchReqMeta,
+    LayerBlockRange,
+    LayerLoadTask,
     LayerMultiBlockReqMeta,
+    LayerTransferTask,
     ReqMeta,
+    SharedBlockData,
     get_block_hashes,
 )
 # isort: on
+
+
+def _circular_shift(lst: list, offset: int) -> list:
+    if not lst or offset == 0:
+        return lst
+    return lst[offset:] + lst[:offset]
+
+
+def _circular_shift_array(value: np.ndarray, offset: int) -> np.ndarray:
+    length = len(value)
+    if length == 0:
+        return value
+    offset %= length
+    if offset == 0:
+        return value
+    return np.concatenate((value[offset:], value[:offset]))
+
+
+class LayerBatchBuilder:
+    def __init__(
+        self,
+        token_database: ChunkedTokenDatabase,
+        my_key_index: int,
+        num_ranks_per_layer: int,
+        page_size_bytes: int,
+        num_layers: int,
+    ) -> None:
+        self.my_key_index = my_key_index
+        self.num_ranks_per_layer = num_ranks_per_layer
+        self.page_size_bytes = page_size_bytes
+        self.num_layers = num_layers
+        self._block_len_np = np.asarray(token_database.group_block_len[0], dtype=np.int64)
+        self._kv_caches_base_addr_np = np.asarray(
+            token_database.group_kv_caches_base_addr[0],
+            dtype=np.int64,
+        )
+        group_block_stride = token_database.group_block_stride.get(0, token_database.group_block_len[0])
+        self._block_stride_np = np.asarray(group_block_stride, dtype=np.int64)
+        # group_block_len[0] / kv_caches_base_addr[0] are laid out flat as
+        # [layer0_caches..., layer1_caches..., ...]; the per-layer stride is the
+        # total length divided by the number of layers (mirrors
+        # ChunkedTokenDatabase caches_per_layer computation).
+        self._caches_per_layer = max(1, self._block_len_np.shape[0] // max(1, num_layers))
+        self._block_ids_buf: np.ndarray | None = None
+        self._block_gvas_buf: np.ndarray | None = None
+
+    def _ensure_buf(self, capacity: int) -> tuple[np.ndarray, np.ndarray]:
+        if self._block_ids_buf is None or len(self._block_ids_buf) < capacity:
+            self._block_ids_buf = np.empty(capacity, dtype=np.int64)
+            self._block_gvas_buf = np.empty(capacity, dtype=np.int64)
+        assert self._block_ids_buf is not None and self._block_gvas_buf is not None
+        return self._block_ids_buf[:capacity], self._block_gvas_buf[:capacity]
+
+    @staticmethod
+    def _dedupe_transfer_blocks(
+        block_ids_arr: np.ndarray,
+        block_gvas_arr: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        if block_ids_arr.size <= 1:
+            return block_ids_arr, block_gvas_arr
+
+        block_transfer_array = np.column_stack((block_ids_arr, block_gvas_arr))
+        _, unique_indices = np.unique(
+            block_transfer_array,
+            axis=0,
+            return_index=True,
+        )
+        if unique_indices.size == block_ids_arr.size:
+            return block_ids_arr, block_gvas_arr
+
+        return (
+            block_ids_arr[unique_indices],
+            block_gvas_arr[unique_indices],
+        )
+
+    def _build_transfer_arrays(
+        self,
+        block_ids_arr: np.ndarray,
+        base_gvas_arr: np.ndarray,
+        layer_id: int,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        caches_per_layer = self._caches_per_layer
+        # group_* arrays are laid out flat as [layer0_caches..., layer1_caches...];
+        # slice the per-layer window for ``layer_id``. Using the full length as the
+        # stride (the old behaviour) overshoots for layer_id >= 1 and yields empty
+        # slices -> broadcast errors.
+        base_offset = layer_id * caches_per_layer
+        layer_base_addrs = self._kv_caches_base_addr_np[base_offset : base_offset + caches_per_layer]
+        layer_block_len = self._block_len_np[base_offset : base_offset + caches_per_layer]
+        layer_block_stride = self._block_stride_np[base_offset : base_offset + caches_per_layer]
+        # Per-cache inner offsets within one layer's page: [0, len0, len0+len1, ...].
+        layer_inner_offsets = np.concatenate(
+            (np.zeros(1, dtype=np.int64), np.cumsum(layer_block_len[:-1], dtype=np.int64))
+        )
+        rank_layer_offset = (layer_id * self.num_ranks_per_layer + self.my_key_index) * self.page_size_bytes
+
+        addr_arr = layer_base_addrs[None, :] + block_ids_arr[:, None] * layer_block_stride[None, :]
+        size_arr = np.broadcast_to(layer_block_len, addr_arr.shape)
+        gvas_arr = base_gvas_arr[:, None] + rank_layer_offset + layer_inner_offsets[None, :]
+
+        return (
+            addr_arr.ravel(),
+            size_arr.ravel(),
+            gvas_arr.ravel(),
+        )
+
+    @staticmethod
+    def _require_request_arrays(
+        block_range: LayerBlockRange,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        request = block_range.request
+        if request.block_ids_np is None or request.block_gvas_np is None:
+            raise RuntimeError("ReqMeta numpy block metadata is not initialized")
+        return request.block_ids_np, request.block_gvas_np
+
+    def build_shared(self, task: LayerTransferTask) -> SharedBlockData | None:
+        """Pre-compute shared block data that is identical across all layers."""
+        if not task.block_ranges:
+            return None
+
+        total = 0
+        for block_range in task.block_ranges:
+            total += block_range.end_block - block_range.start_block
+            if block_range.partial_block_index is not None:
+                total += 1
+
+        block_ids_arr, block_gvas_arr = self._ensure_buf(total)
+        req_ids: list[str] = []
+        is_last_chunks: list[bool | None] = []
+        offset = 0
+
+        for block_range in task.block_ranges:
+            request = block_range.request
+            req_ids.append(request.req_id)
+            is_last_chunks.append(request.is_last_chunk)
+            block_ids_np, block_gvas_np = self._require_request_arrays(block_range)
+
+            num_blocks = block_range.end_block - block_range.start_block
+            if num_blocks > 0:
+                gva_start = block_range.start_block - request.gva_block_offset
+                gva_end = block_range.end_block - request.gva_block_offset
+                if gva_start < 0 or gva_end > len(block_gvas_np):
+                    raise RuntimeError(
+                        "ReqMeta GVA metadata does not cover requested block "
+                        f"range [{block_range.start_block}, {block_range.end_block}) "
+                        f"with offset {request.gva_block_offset}"
+                    )
+                end = offset + num_blocks
+                block_ids_arr[offset:end] = block_ids_np[block_range.start_block : block_range.end_block]
+                block_gvas_arr[offset:end] = block_gvas_np[gva_start:gva_end]
+                offset = end
+
+            if block_range.partial_block_index is not None:
+                assert request.last_block_gva is not None
+                block_ids_arr[offset] = block_ids_np[block_range.partial_block_index]
+                block_gvas_arr[offset] = request.last_block_gva
+                offset += 1
+
+        block_ids_arr, block_gvas_arr = self._dedupe_transfer_blocks(block_ids_arr[:offset], block_gvas_arr[:offset])
+
+        return SharedBlockData(
+            block_ids_arr=block_ids_arr,
+            block_gvas_arr=block_gvas_arr,
+            req_ids=req_ids,
+            is_last_chunks=is_last_chunks,
+        )
+
+    def build_addrs(
+        self,
+        shared: SharedBlockData,
+        layer_id: int,
+    ) -> LayerBatchReqMeta:
+        """Compute per-layer addresses from pre-computed shared block data."""
+        addr_array, size_array, gvas_array = self._build_transfer_arrays(
+            shared.block_ids_arr, shared.block_gvas_arr, layer_id
+        )
+
+        return LayerBatchReqMeta(
+            req_ids=shared.req_ids,
+            layer_id=layer_id,
+            is_last_chunks=shared.is_last_chunks,
+            addr_array=addr_array,
+            size_array=size_array,
+            gvas_array=gvas_array,
+        )
+
+    def build(self, task: LayerTransferTask) -> LayerBatchReqMeta | None:
+        """Full build: shared data + per-layer addresses (backward compat)."""
+        shared = self.build_shared(task)
+        if shared is None:
+            return None
+        return self.build_addrs(shared, task.layer_id)
 
 
 class KVTransferThread(threading.Thread):
@@ -28,21 +229,23 @@ class KVTransferThread(threading.Thread):
         token_database: ChunkedTokenDatabase,
         block_size: int | list[int],
         tp_rank: int,
-        dcp_size: int,
-        ready_event: threading.Event,
-        name: str,
+        tp_size: int = 1,
+        dcp_size: int = 1,
+        ready_event: threading.Event | None = None,
+        name: str = "KVTransferThread",
     ):
         super().__init__(daemon=True, name=name)
         self.m_store = m_store
-        self.ready_event = ready_event
+        self.ready_event = ready_event or threading.Event()
         self.block_size = block_size
         self.tp_rank = tp_rank
+        self.tp_size = tp_size
         self.dcp_size = dcp_size
         self.token_database = token_database
+        self.num_addrs_per_block = len(token_database.group_block_len[0])
         self.done_task_lock = threading.Lock()
         self.request_queue: queue.Queue[Any] = queue.Queue()
-        # TODO(jianzs): make this configurable
-        self.executor = ThreadPoolExecutor(max_workers=32)
+        self.stored_requests: defaultdict[str, int] = defaultdict(int)
         self.finished_requests: set[str] = set()
         self.kv_event_lock = threading.Lock()
         self.kv_events: list[BlockStored] = []
@@ -56,27 +259,134 @@ class KVTransferThread(threading.Thread):
 
     def add_request(
         self,
-        request: ReqMeta | LayerMultiBlockReqMeta,
+        request: ReqMeta | LayerBatchReqMeta | LayerMultiBlockReqMeta,
     ) -> torch.Tensor:
         self.request_queue.put(request)
 
-    def get_and_clear_finished_requests(self) -> set[str]:
+    def get_and_clear_finished_requests(
+        self,
+        req_ids: set[str] | None = None,
+    ) -> set[str]:
         """
         Get and clear the requests that have been completed.
         Returns:
             A set of request IDs that have been completed.
         """
         with self.done_task_lock:
-            finished_requests = self.finished_requests.copy()
-            self.finished_requests.clear()
+            if req_ids is None:
+                finished_requests = self.finished_requests.copy()
+                self.finished_requests.clear()
+            else:
+                finished_requests = self.finished_requests & req_ids
+                self.finished_requests -= finished_requests
         return finished_requests
+
+    def discard_finished_requests(self, req_ids: set[str]) -> None:
+        with self.done_task_lock:
+            self.finished_requests -= req_ids
 
     def set_finished_request(self, req_id):
         with self.done_task_lock:
             self.finished_requests.add(req_id)
 
+    def add_stored_request(self, req_id: str):
+        with self.done_task_lock:
+            self.stored_requests[req_id] += 1
+
+    def dec_stored_request(self, req_id: str):
+        with self.done_task_lock:
+            if req_id in self.stored_requests:
+                self.stored_requests[req_id] -= 1
+
+    def try_finish_and_delete_stored_request(self, req_id: str) -> bool:
+        with self.done_task_lock:
+            if req_id in self.stored_requests and self.stored_requests[req_id] == 0:
+                del self.stored_requests[req_id]
+                return True
+            return False
+
+    @staticmethod
+    def _split_transfer_packets(
+        gvas: np.ndarray,
+        addrs: np.ndarray,
+        sizes: np.ndarray,
+        max_transfer_bytes: int,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        if max_transfer_bytes <= 0:
+            return gvas, addrs, sizes
+
+        split_counts: np.ndarray = (sizes + max_transfer_bytes - 1) // max_transfer_bytes
+        total_splits = int(split_counts.sum())
+        if total_splits == sizes.shape[0]:
+            return gvas, addrs, sizes
+
+        split_indices: np.ndarray = np.arange(int(split_counts.max()), dtype=np.int64)
+        split_mask = split_indices[:, None] < split_counts[None, :]
+        entry_indices = np.broadcast_to(
+            np.arange(sizes.shape[0], dtype=np.int64),
+            split_mask.shape,
+        )[split_mask]
+        transfer_offsets = np.broadcast_to(
+            split_indices[:, None] * max_transfer_bytes,
+            split_mask.shape,
+        )[split_mask]
+
+        split_gvas = gvas[entry_indices] + transfer_offsets
+        split_addrs = addrs[entry_indices] + transfer_offsets
+        split_sizes = np.minimum(
+            max_transfer_bytes,
+            sizes[entry_indices] - transfer_offsets,
+        )
+        return split_gvas, split_addrs, split_sizes
+
+    def _batch_copy_with_limits(
+        self,
+        gvas: np.ndarray,
+        addrs: np.ndarray,
+        sizes: np.ndarray,
+        direction: int,
+        max_transfer_blocks: int,
+        max_transfer_bytes: int,
+    ) -> int:
+        if len(gvas) == 0:
+            return 0
+
+        max_transfer_addrs = 0
+        if max_transfer_blocks > 0:
+            max_transfer_addrs = max_transfer_blocks * self.num_addrs_per_block
+        if max_transfer_addrs <= 0:
+            max_transfer_addrs = len(gvas)
+
+        assert self.m_store.store is not None
+        for start in range(0, len(gvas), max_transfer_addrs):
+            end = start + max_transfer_addrs
+            split_gvas, split_addrs, split_sizes = self._split_transfer_packets(
+                gvas[start:end],
+                addrs[start:end],
+                sizes[start:end],
+                max_transfer_bytes,
+            )
+            res = self.m_store.store.batch_copy(
+                split_gvas.tolist(),
+                split_addrs.tolist(),
+                split_sizes.tolist(),
+                direction,
+            )
+            if res != 0:
+                return res
+        return 0
+
+    def _set_os_thread_name(self) -> None:
+        try:
+            libc = ctypes.CDLL("libc.so.6")
+            # Linux task comm is limited to 15 visible bytes plus NUL.
+            libc.prctl(15, self.name[:15].encode(), 0, 0, 0)
+        except Exception:
+            pass
+
     def run(self):
         """Run the thread to handle KV cache transfer requests."""
+        self._set_os_thread_name()
         self.m_store.set_device()
         self.ready_event.set()
         while True:
@@ -221,32 +531,24 @@ class KVCacheStoreSendingThread(KVTransferThread):
         token_database: ChunkedTokenDatabase,
         block_size: int | list[int],
         tp_rank: int,
-        dcp_size: int,
-        put_step: int,
-        kv_role: str,
-        ready_event: threading.Event,
-        group_uses_align_state: list[bool],
+        tp_size: int = 1,
+        dcp_size: int = 1,
+        put_step: int = 1,
+        kv_role: str = "kv_producer",
+        ready_event: threading.Event | None = None,
+        group_uses_align_state: list[bool] | None = None,
         enable_kv_event: bool = False,
     ):
         super().__init__(
-            m_store, token_database, block_size, tp_rank, dcp_size, ready_event, name="KVCacheSendingThread"
+            m_store, token_database, block_size, tp_rank, tp_size, dcp_size, ready_event, name="KVCacheSendingThread"
         )
         self.put_step = put_step
         self.kv_role = kv_role
         self.stored_requests = defaultdict[str, int](int)
-        self.group_uses_align_state = group_uses_align_state
+        self.group_uses_align_state = group_uses_align_state or []
         self.enable_kv_event = enable_kv_event
         self.completed_events_lock = threading.Lock()
         self.completed_events: dict[int, int] = {}
-
-    def add_stored_request(self, req_id: str):
-        with self.done_task_lock:
-            self.stored_requests[req_id] += 1
-
-    def dec_stored_request(self, req_id: str):
-        with self.done_task_lock:
-            if req_id in self.stored_requests:
-                self.stored_requests[req_id] -= 1
 
     def delete_finished_stored_request(self, req_id: str):
         with self.done_task_lock:
@@ -397,6 +699,9 @@ class KVCacheStoreSendingThread(KVTransferThread):
             # always free blocks
             self.mark_completed_events(req_meta.event_id)
         self.dec_stored_request(req_id)
+        if self.stored_requests.get(req_id, -1) == 0:
+            self.delete_finished_stored_request(req_id)
+            self.set_finished_request(req_id)
         self.request_queue.task_done()
 
 
@@ -407,16 +712,24 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         token_database: ChunkedTokenDatabase,
         block_size: int | list[int],
         tp_rank: int,
-        dcp_size: int,
-        ready_event: threading.Event,
-        invalid_block_ids: set[int],
-        invalid_block_ids_lock: threading.Lock,
+        tp_size: int = 1,
+        dcp_size: int = 1,
+        ready_event: threading.Event | None = None,
+        invalid_block_ids: set[int] | None = None,
+        invalid_block_ids_lock: threading.Lock | None = None,
     ):
         super().__init__(
-            m_store, token_database, block_size, tp_rank, dcp_size, ready_event, name="KVCacheStoreRecvingThread"
+            m_store,
+            token_database,
+            block_size,
+            tp_rank,
+            tp_size,
+            dcp_size,
+            ready_event,
+            name="KVCacheStoreRecvingThread",
         )
-        self._invalid_block_ids = invalid_block_ids
-        self._invalid_block_ids_lock = invalid_block_ids_lock
+        self._invalid_block_ids = invalid_block_ids if invalid_block_ids is not None else set()
+        self._invalid_block_ids_lock = invalid_block_ids_lock or threading.Lock()
 
     def _handle_request(self, req_meta: ReqMeta):
         token_len = req_meta.load_spec.token_len  # type: ignore[union-attr]
@@ -476,33 +789,15 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 block_id_list_c,
                 ret,
             )
-            if len(req_meta.block_ids_by_group) == 1:
-                with self._invalid_block_ids_lock:
-                    self._invalid_block_ids.update(missing_block_ids)
-            elif missing_block_ids:
-                logger.error(
-                    "KV load failed for hybrid request %s. "
-                    "Skip invalid-block fallback to avoid scheduler crash. "
-                    "failed_blocks=%s",
-                    req_id,
-                    missing_block_ids,
-                )
+            with self._invalid_block_ids_lock:
+                self._invalid_block_ids.update(missing_block_ids)
         elif ret is None:
             missing_block_ids = record_failed_blocks(
                 block_id_list_c,
                 [1] * len(block_id_list_c),
             )
-            if len(req_meta.block_ids_by_group) == 1:
-                with self._invalid_block_ids_lock:
-                    self._invalid_block_ids.update(missing_block_ids)
-            elif missing_block_ids:
-                logger.error(
-                    "KV load failed for hybrid request %s. "
-                    "Skip invalid-block fallback to avoid scheduler crash. "
-                    "failed_blocks=%s",
-                    req_id,
-                    missing_block_ids,
-                )
+            with self._invalid_block_ids_lock:
+                self._invalid_block_ids.update(missing_block_ids)
         logger.debug(
             "KV pool async recv backend get returned request=%s token_len=%d groups=%s keys=%d",
             req_id,
@@ -514,6 +809,272 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         self.request_queue.task_done()
 
 
+class KVCacheStoreKeyLayerSendingThread(KVTransferThread):
+    def __init__(
+        self,
+        m_store: Backend,
+        token_database: ChunkedTokenDatabase,
+        block_size: int,
+        tp_rank: int,
+        tp_size: int,
+        dcp_size: int,
+        put_step: int,
+        ready_event: threading.Event,
+        num_layers: int,
+        layer_save_finished_events: list[threading.Event],
+        sync_save_events: list[torch.npu.Event],
+    ):
+        super().__init__(
+            m_store,
+            token_database,
+            block_size,
+            tp_rank,
+            tp_size,
+            dcp_size,
+            ready_event,
+            name="KVCacheStoreKeyLayerSendingThread",
+        )
+        self.final_layer_id = num_layers - 1
+        self.put_step = put_step
+        self.layer_save_finished_events = layer_save_finished_events
+        self.sync_save_events = sync_save_events
+
+    def build_cached_process_tokens(self, task: LayerTransferTask) -> dict[int, list[tuple[int, int, list]]] | None:
+        """Pre-compute process_tokens results for all layers (Key path).
+
+        Returns a dict mapping block_range index to a list of
+        (start, end, key_all_layers) tuples, where key_all_layers is the
+        result of key.split_layers().
+        """
+        if not task.block_ranges:
+            return None
+
+        group_block_size = self._get_block_size(0)
+        cache: dict[int, list[tuple[int, int, list]]] = {}
+
+        for br_idx, block_range in enumerate(task.block_ranges):
+            request = block_range.request
+            mask_num = request.save_start_token // group_block_size * group_block_size
+            entries = []
+            for start, end, key in self.token_database.process_tokens(
+                request.save_end_token,
+                request.block_hashes,
+                mask_num,
+            ):
+                block_index = start // group_block_size
+                if block_index < block_range.start_block or block_index >= block_range.end_block:
+                    continue
+                key_all = key.split_layers(self.final_layer_id + 1)
+                entries.append((start, end, key_all))
+            cache[br_idx] = entries
+
+        return cache
+
+    def add_request(  # type: ignore[override]
+        self, req_meta: list[LayerTransferTask]
+    ) -> torch.Tensor:
+        self.request_queue.put(req_meta)
+
+    def _handle_request(  # type: ignore[override]
+        self, transfer_tasks: list[LayerTransferTask]
+    ):
+        if len(transfer_tasks) == 0:
+            self.request_queue.task_done()
+            return
+        if len(transfer_tasks) > 1:
+            raise ValueError(f"Expected at most one layer transfer task, got {len(transfer_tasks)}")
+
+        transfer_task = transfer_tasks[0]
+        layer_id = transfer_task.layer_id
+        key_list = []
+        addr_list = []
+        size_list = []
+        req_ids = []
+        is_last_chunks = []
+
+        # Reuse pre-computed process_tokens results if available
+        cached_tokens = transfer_task.cached_process_tokens
+
+        for br_idx, block_range in enumerate(transfer_task.block_ranges):
+            request = block_range.request
+            req_ids.append(request.req_id)
+            is_last_chunks.append(request.is_last_chunk)
+            starts = []
+            ends = []
+            keys = []
+            group_block_size = self._get_block_size(0)
+
+            if cached_tokens is not None:
+                # Fast path: reuse cached (start, end, key_all) tuples
+                for start, end, key_all in cached_tokens[br_idx]:
+                    block_index = start // group_block_size
+                    if block_index < block_range.start_block or block_index >= block_range.end_block:
+                        continue
+                    starts.append(start)
+                    ends.append(end)
+                    keys.append(key_all[layer_id])
+            else:
+                mask_num = request.save_start_token // group_block_size * group_block_size
+                for start, end, key in self.token_database.process_tokens(
+                    request.save_end_token,
+                    request.block_hashes,
+                    mask_num,
+                ):
+                    block_index = start // group_block_size
+                    if block_index < block_range.start_block or block_index >= block_range.end_block:
+                        continue
+                    starts.append(start)
+                    ends.append(end)
+                    keys.append(key.split_layers(self.final_layer_id + 1)[layer_id])
+
+            if not self.dcp_size > 1:
+                starts = starts[self.tp_rank % self.put_step :: self.put_step]
+                ends = ends[self.tp_rank % self.put_step :: self.put_step]
+                keys = keys[self.tp_rank % self.put_step :: self.put_step]
+
+            for index, key in enumerate(keys):
+                key_list.append(key.to_string())
+                addr, size, _ = self.token_database.prepare_value_layer(
+                    starts[index],
+                    ends[index],
+                    request.block_ids,
+                    layer_id,
+                )
+                addr_list.append(addr)
+                size_list.append(size)
+
+        for req_id in req_ids:
+            self.dec_stored_request(req_id)
+
+        if key_list:
+            exists_states = self.lookup(key_list)
+            missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
+            keys_to_put = [key_list[index] for index in missing_indices]
+            addrs_to_put = [addr_list[index] for index in missing_indices]
+            sizes_to_put = [size_list[index] for index in missing_indices]
+            if keys_to_put:
+                self.sync_save_events[layer_id].synchronize()
+                self.m_store.put(keys_to_put, addrs_to_put, sizes_to_put)
+
+        if layer_id == self.final_layer_id:
+            for req_id, is_last_chunk in zip(req_ids, is_last_chunks):
+                if is_last_chunk and self.try_finish_and_delete_stored_request(req_id):
+                    self.set_finished_request(req_id)
+
+        assert not self.layer_save_finished_events[layer_id].is_set(), f"thread: {layer_id} save failed "
+        logger.debug("Key-based layer save event set: layer %d", layer_id)
+        self.layer_save_finished_events[layer_id].set()
+        transfer_tasks.clear()
+        self.request_queue.task_done()
+
+
+class KVCacheStoreKeyLayerRecvingThread(KVTransferThread):
+    def __init__(
+        self,
+        m_store: Backend,
+        token_database: ChunkedTokenDatabase,
+        block_size: int,
+        tp_rank: int,
+        tp_size: int,
+        dcp_size: int,
+        ready_event: threading.Event,
+        get_event: threading.Event,
+        layer_load_finished_events: list[threading.Event],
+        layer_save_finished_events: list[threading.Event],
+        num_layers: int,
+    ):
+        super().__init__(
+            m_store,
+            token_database,
+            block_size,
+            tp_rank,
+            tp_size,
+            dcp_size,
+            ready_event,
+            name="KVCacheStoreKeyLayerRecvingThread",
+        )
+        self.get_event = get_event
+        self.layer_load_finished_events = layer_load_finished_events
+        self.layer_save_finished_events = layer_save_finished_events
+        self.final_layer_id = num_layers - 1
+
+    def add_request(  # type: ignore[override]
+        self, req_meta: LayerLoadTask
+    ) -> torch.Tensor:
+        self.request_queue.put(req_meta)
+
+    def _wait_for_save(self, layer_id: int) -> None:
+        while not self.layer_save_finished_events[layer_id].wait(timeout=10):
+            logger.info("Layerwise %d save wait timed out, keep waiting before load", layer_id)
+        logger.debug("Key-based layer save event cleared: layer %d", layer_id)
+        self.layer_save_finished_events[layer_id].clear()
+
+    def _handle_request(  # type: ignore[override]
+        self, data: LayerLoadTask
+    ):
+        wait_for_save = data.wait_for_save_layer
+        layer_id = data.layer_id
+        if wait_for_save is not None:
+            self._wait_for_save(wait_for_save)
+
+        if data.attention_start_gate is not None:
+            while not data.attention_start_gate.wait(timeout=10):
+                logger.info("Layerwise %d load waits for attention compute start", layer_id)
+
+        key_list = []
+        addr_list = []
+        size_list = []
+        req_ids = []
+        is_last_chunks = []
+        if len(data.transfer_tasks) > 1:
+            raise ValueError(f"Expected at most one layer transfer task, got {len(data.transfer_tasks)}")
+        if data.transfer_tasks:
+            transfer_task = data.transfer_tasks[0]
+            for block_range in transfer_task.block_ranges:
+                request = block_range.request
+                req_ids.append(request.req_id)
+                is_last_chunks.append(request.is_last_chunk)
+                for block_index in range(block_range.start_block, block_range.end_block):
+                    if block_index >= len(request.block_hashes):
+                        continue
+                    block_hash = request.block_hashes[block_index]
+                    chunk_hash = block_hash if isinstance(block_hash, str) else block_hash.hex()
+                    key = self.token_database._make_key_by_hash(
+                        chunk_hash,
+                    ).split_layers(self.final_layer_id + 1)[layer_id]
+                    group_block_size = self._get_block_size(0)
+                    start = block_index * group_block_size
+                    end = start + group_block_size
+                    addr, size, _ = self.token_database.prepare_value_layer(
+                        start,
+                        end,
+                        request.block_ids,
+                        layer_id,
+                    )
+                    key_list.append(key.to_string())
+                    addr_list.append(addr)
+                    size_list.append(size)
+
+        if key_list:
+            shift = (self.tp_rank * len(key_list)) // self.tp_size
+            key_list_c = _circular_shift(key_list, shift)
+            addr_list_c = _circular_shift(addr_list, shift)
+            size_list_c = _circular_shift(size_list, shift)
+            self.m_store.get(key_list_c, addr_list_c, size_list_c)
+
+        if layer_id == self.final_layer_id:
+            for req_id, is_last_chunk in zip(req_ids, is_last_chunks):
+                if is_last_chunk:
+                    self.set_finished_request(req_id)
+
+        assert not self.layer_load_finished_events[layer_id].is_set(), f"thread: {layer_id} load failed "
+        logger.debug("Key-based layer load event set: layer %d", layer_id)
+        self.layer_load_finished_events[layer_id].set()
+        data.transfer_tasks.clear()
+        self.request_queue.task_done()
+        self.get_event.set()
+
+
 class KVCacheStoreLayerSendingThread(KVTransferThread):
     def __init__(
         self,
@@ -521,22 +1082,46 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         token_database: ChunkedTokenDatabase,
         block_size: int | list[int],
         tp_rank: int,
+        tp_size: int,
         dcp_size: int,
         put_step: int,
+        my_key_index: int,
+        num_ranks_per_layer: int,
+        page_size_bytes: int,
         ready_event: threading.Event,
         num_layers: int,
-        enable_kv_event: bool = False,
+        layer_save_finished_events: list[threading.Event],
+        sync_save_events: list[torch.npu.Event],
+        max_transfer_blocks: int = 0,
+        max_transfer_bytes: int = 0,
+        layer_transfer_finished_events: list[threading.Event] | None = None,
     ):
         super().__init__(
-            m_store, token_database, block_size, tp_rank, dcp_size, ready_event, name="KVCacheStoreLayerSendingThread"
+            m_store,
+            token_database,
+            block_size,
+            tp_rank,
+            tp_size,
+            dcp_size,
+            ready_event,
+            name="KVCacheStoreLayerSendingThread",
         )
         self.final_layer_id = num_layers - 1
         self.put_step = put_step
-        self.enable_kv_event = enable_kv_event
-        self.layerwise_event_starts: dict[str, set[int]] = defaultdict(set)
-        self.stored_requests: dict[str, int] = defaultdict(int)
+        self.stored_requests: defaultdict[str, int] = defaultdict(int)
         self.done_task_lock = threading.Lock()
-        self.layerwise_event_lock = threading.Lock()
+        self.layer_save_finished_events = layer_save_finished_events
+        self.sync_save_events = sync_save_events
+        self.layer_transfer_finished_events = layer_transfer_finished_events
+        self.max_transfer_blocks = max_transfer_blocks
+        self.max_transfer_bytes = max_transfer_bytes
+        self.layer_batch_builder = LayerBatchBuilder(
+            token_database,
+            my_key_index,
+            num_ranks_per_layer,
+            page_size_bytes,
+            num_layers,
+        )
 
     def add_stored_request(self, req_id: str):
         with self.done_task_lock:
@@ -551,149 +1136,71 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         with self.done_task_lock:
             if req_id in self.stored_requests:
                 del self.stored_requests[req_id]
-        with self.layerwise_event_lock:
-            self.layerwise_event_starts.pop(req_id, None)
 
-    def _record_layerwise_event_starts(self, req_meta: LayerMultiBlockReqMeta, starts: list[int]) -> None:
-        if self.enable_kv_event:
-            with self.layerwise_event_lock:
-                self.layerwise_event_starts[req_meta.req_id].update(starts)
-
-    def _build_stored_events(self, req_meta: LayerMultiBlockReqMeta) -> list[BlockStored]:
-        if not self.enable_kv_event or req_meta.layer_id != self.final_layer_id:
-            return []
-        block_size = (
-            req_meta.original_block_size[req_meta.kv_cache_group_id]
-            if isinstance(req_meta.original_block_size, list)
-            else req_meta.original_block_size
-        )
-        if block_size is None:
-            return []
-        stored_events: list[BlockStored] = []
-        group_block_size = self._get_block_size(req_meta.kv_cache_group_id)
-        new_block_hashes = [maybe_convert_block_hash(bh) for bh in req_meta.block_hashes]
-        with self.layerwise_event_lock:
-            starts_set = self.layerwise_event_starts.pop(req_meta.req_id, set())
-        for start in sorted(starts_set):
-            block_idx = start // group_block_size
-            if block_idx >= len(new_block_hashes):
-                continue
-            block_hash = new_block_hashes[block_idx]
-            parent_block_hash = new_block_hashes[block_idx - 1] if block_idx > 0 else None
-            end = min(start + group_block_size, len(req_meta.token_ids or []))
-            token_ids = req_meta.token_ids[start:end] if req_meta.token_ids is not None else None
-            stored_event = BlockStored(
-                block_hashes=[block_hash],
-                parent_block_hash=parent_block_hash,
-                token_ids=token_ids,
-                block_size=block_size,
-                lora_id=None,
-                medium="cpu",
-                lora_name=None,
-            )
-            stored_events.append(stored_event)
-            logger.debug("Added layerwise kv cache event '%s' to kv cache events queue", stored_event)
-        return stored_events
+    def build_shared_data(self, task: LayerTransferTask) -> SharedBlockData | None:
+        """Pre-compute shared block data for all layers (GVA path)."""
+        return self.layer_batch_builder.build_shared(task)
 
     def add_request(  # type: ignore[override]
-        self, req_meta: ReqMeta
+        self, req_meta: list[LayerTransferTask]
     ) -> torch.Tensor:
         self.request_queue.put(req_meta)
 
     def _handle_request(  # type: ignore[override]
-        self, req_meta: LayerMultiBlockReqMeta
+        self, transfer_tasks: list[LayerTransferTask]
     ):
-        starts = req_meta.starts
-        ends = req_meta.ends
-        keys = req_meta.keys
+        if len(transfer_tasks) == 0:
+            self.request_queue.task_done()
+            return
+        if len(transfer_tasks) > 1:
+            raise ValueError(f"Expected at most one layer transfer task, got {len(transfer_tasks)}")
+        task = transfer_tasks[0]
+        shared = task.shared_block_data
+        if shared is None:
+            layer_id = task.layer_id
+            if self.layer_transfer_finished_events is not None:
+                is_finish = self.layer_transfer_finished_events[layer_id].wait(timeout=30)
+                if not is_finish:
+                    logger.error("Layerwise %d PD transfer wait timed out", layer_id)
+                self.layer_transfer_finished_events[layer_id].clear()
+            assert not self.layer_save_finished_events[layer_id].is_set(), f"thread: {layer_id} save failed "
+            logger.debug("Layer save event set: layer %d", layer_id)
+            self.layer_save_finished_events[layer_id].set()
+            self.request_queue.task_done()
+            return
+        req_meta = self.layer_batch_builder.build_addrs(shared, task.layer_id)
         layer_id = req_meta.layer_id
-        current_event = req_meta.current_event
-        total_block = len(keys)
-        is_last_chunk = req_meta.is_last_chunk
-        with self.done_task_lock:
-            if req_meta.req_id not in self.stored_requests:
-                self.request_queue.task_done()
-                return
-        if not self.dcp_size > 1:
-            starts = starts[self.tp_rank % self.put_step :: self.put_step]
-            ends = ends[self.tp_rank % self.put_step :: self.put_step]
-            keys = keys[self.tp_rank % self.put_step :: self.put_step]
-
-        if not keys:
-            if layer_id == self.final_layer_id:
-                stored_events = self._build_stored_events(req_meta)
-                if stored_events:
-                    self.update_kv_event(stored_events)
-            if is_last_chunk and layer_id == self.final_layer_id:
-                self.dec_stored_request(req_meta.req_id)
-                self.set_finished_request(req_meta.req_id)
-            self.request_queue.task_done()
-            return
-
-        key_list = []
-        for key in keys:
-            key_list.append(key.to_string())
-
-        exists_states = self.lookup(key_list)
-        missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
-
-        if not missing_indices:
-            if layer_id == self.final_layer_id:
-                stored_events = self._build_stored_events(req_meta)
-                if stored_events:
-                    self.update_kv_event(stored_events)
-            if is_last_chunk and layer_id == self.final_layer_id:
-                self.dec_stored_request(req_meta.req_id)
-                self.set_finished_request(req_meta.req_id)
-            self.request_queue.task_done()
-            return
-
-        starts = [starts[index] for index in missing_indices]
-        ends = [ends[index] for index in missing_indices]
-        key_list = [key_list[index] for index in missing_indices]
-
-        addr_list = []
-        size_list = []
-        for index, key in enumerate(key_list):
-            addr, size, _ = self.token_database.prepare_value_layer(
-                starts[index], ends[index], req_meta.block_ids_by_group[0], layer_id
-            )
-            addr_list.append(addr)
-            size_list.append(size)
-
-        if current_event is not None:
-            current_event.synchronize()
-        self.m_store.put(key_list, addr_list, size_list)
-        self._record_layerwise_event_starts(req_meta, starts)
-        stored_events = self._build_stored_events(req_meta)
-        if stored_events:
-            self.update_kv_event(stored_events)
-
-        if layer_id == self.final_layer_id and is_last_chunk:
-            with self.layerwise_event_lock:
-                self.layerwise_event_starts.pop(req_meta.req_id, None)
-            self.dec_stored_request(req_meta.req_id)
-            self.set_finished_request(req_meta.req_id)
+        rank_start = self.tp_rank % self.put_step
+        addr_array = req_meta.addr_array[rank_start :: self.put_step]
+        size_array = req_meta.size_array[rank_start :: self.put_step]
+        gvas_array = req_meta.gvas_array[rank_start :: self.put_step]
+        for req_id in req_meta.req_ids:
+            self.dec_stored_request(req_id)
+        self.sync_save_events[layer_id].synchronize()
+        res = self._batch_copy_with_limits(
+            gvas_array,
+            addr_array,
+            size_array,
+            0,
+            self.max_transfer_blocks,
+            self.max_transfer_bytes,
+        )
+        # wait for KV transfer (PD)
+        if self.layer_transfer_finished_events is not None:
+            is_finish = self.layer_transfer_finished_events[layer_id].wait(timeout=30)
+            if not is_finish:
+                logger.error("Layerwise %d PD transfer wait timed out", layer_id)
+            self.layer_transfer_finished_events[layer_id].clear()
+        if res != 0:
+            logger.error("Layerwise %d save batch_copy failed with return code %d", layer_id, res)
+        for req_id in req_meta.req_ids:
+            if self.try_finish_and_delete_stored_request(req_id):
+                self.set_finished_request(req_id)
+        assert not self.layer_save_finished_events[layer_id].is_set(), f"thread: {layer_id} save failed "
+        logger.debug("Layer save event set: layer %d", layer_id)
+        self.layer_save_finished_events[layer_id].set()
+        transfer_tasks.clear()
         self.request_queue.task_done()
-
-        if layer_id == self.final_layer_id:
-            logger.info(
-                "Storing KV cache layerwise for %d out of %d blocks (missing_count=%d) for request %s, layer %d",
-                len(key_list),
-                total_block,
-                len(missing_indices),
-                req_meta.req_id,
-                layer_id,
-            )
-        else:
-            logger.debug(
-                "Storing KV cache layerwise for %d out of %d blocks (missing_count=%d) for request %s, layer %d",
-                len(key_list),
-                total_block,
-                len(missing_indices),
-                req_meta.req_id,
-                layer_id,
-            )
 
 
 class KVCacheStoreLayerRecvingThread(KVTransferThread):
@@ -703,58 +1210,145 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
         token_database: ChunkedTokenDatabase,
         block_size: int | list[int],
         tp_rank: int,
+        tp_size: int,
         dcp_size: int,
+        my_key_index: int,
+        num_ranks_per_layer: int,
+        page_size_bytes: int,
         ready_event: threading.Event,
         get_event: threading.Event,
-        invalid_block_ids: set[int],
-        invalid_block_ids_lock: threading.Lock,
+        layer_load_finished_events: list[threading.Event],
+        layer_save_finished_events: list[threading.Event],
+        num_layers: int,
+        h2d_stagger_us: int = 0,
+        max_transfer_blocks: int = 0,
+        max_transfer_bytes: int = 0,
     ):
         super().__init__(
-            m_store, token_database, block_size, tp_rank, dcp_size, ready_event, name="KVCacheStoreLayerRecvingThread"
+            m_store,
+            token_database,
+            block_size,
+            tp_rank,
+            tp_size,
+            dcp_size,
+            ready_event,
+            name="KVCacheStoreLayerRecvingThread",
         )
         self.get_event = get_event
-        self._invalid_block_ids = invalid_block_ids
-        self._invalid_block_ids_lock = invalid_block_ids_lock
+        self.layer_load_finished_events = layer_load_finished_events
+        self.layer_save_finished_events = layer_save_finished_events
+        self.final_layer_id = num_layers - 1
+        self.h2d_stagger_us = h2d_stagger_us
+        self.max_transfer_blocks = max_transfer_blocks
+        self.max_transfer_bytes = max_transfer_bytes
+        self.layer_batch_builder = LayerBatchBuilder(
+            token_database,
+            my_key_index,
+            num_ranks_per_layer,
+            page_size_bytes,
+            num_layers,
+        )
+
+    def build_shared_data(self, task: LayerTransferTask) -> SharedBlockData | None:
+        """Pre-compute shared block data for all layers (GVA path)."""
+        return self.layer_batch_builder.build_shared(task)
 
     def add_request(  # type: ignore[override]
-        self, req_meta: LayerMultiBlockReqMeta
+        self, req_meta: LayerLoadTask
     ) -> torch.Tensor:
         self.request_queue.put(req_meta)
 
+    def _get_h2d_stagger_delay_us(self, layer_id: int) -> int:
+        if self.h2d_stagger_us <= 0:
+            return 0
+        slot = (self.tp_rank + layer_id) % self.tp_size
+        return slot * self.h2d_stagger_us
+
+    def _stagger_h2d_submit(self, layer_id: int) -> None:
+        delay_us = self._get_h2d_stagger_delay_us(layer_id)
+        if delay_us <= 0:
+            return
+        deadline = time.perf_counter() + delay_us / 1_000_000
+        while time.perf_counter() < deadline:
+            pass
+
     def _handle_request(  # type: ignore[override]
-        self, req_meta: LayerMultiBlockReqMeta
+        self, data: LayerLoadTask
     ):
-        addr_list = []
-        size_list = []
-        key_list = []
-        block_id_list = []
-        for index, key in enumerate(req_meta.keys):
-            addr, size, block_id = self.token_database.prepare_value_layer(
-                req_meta.starts[index], req_meta.ends[index], req_meta.block_ids_by_group[0], req_meta.layer_id
-            )
-            key_list.append(key.to_string())
-            addr_list.append(addr)
-            size_list.append(size)
-            block_id_list.append(block_id)
+        wait_for_save = data.wait_for_save_layer
+        transfer_tasks = data.transfer_tasks
+        layer_id = data.layer_id
+        attention_start_gate = data.attention_start_gate
 
-        offset = self.tp_rank % len(key_list)
-        key_list_c = key_list[offset:] + key_list[:offset]
-        addr_list_c = addr_list[offset:] + addr_list[:offset]
-        size_list_c = size_list[offset:] + size_list[:offset]
-        block_id_list_c = block_id_list[offset:] + block_id_list[:offset]
-        ret = self.m_store.get(key_list_c, addr_list_c, size_list_c)
+        if len(transfer_tasks) == 0:
+            if wait_for_save is not None:
+                while not self.layer_save_finished_events[wait_for_save].wait(timeout=10):
+                    logger.info("Layerwise %d save wait timed out, keep waiting before load", wait_for_save)
+                logger.debug("Layer save event cleared: layer %d", wait_for_save)
+                self.layer_save_finished_events[wait_for_save].clear()
+            assert not self.layer_load_finished_events[layer_id].is_set()
+            logger.debug("Layer load event set: layer %d", layer_id)
+            self.layer_load_finished_events[layer_id].set()
+            self.request_queue.task_done()
+            return
 
-        if ret is not None and any(r != 0 for r in ret):
-            missing_block_ids = record_failed_blocks(
-                block_id_list_c,
-                ret,
-            )
-            with self._invalid_block_ids_lock:
-                self._invalid_block_ids.update(missing_block_ids)
-        elif ret is None:
-            with self._invalid_block_ids_lock:
-                self._invalid_block_ids.update(block_id_list_c)
+        if len(transfer_tasks) > 1:
+            raise ValueError(f"Expected at most one layer transfer task, got {len(transfer_tasks)}")
+        task = transfer_tasks[0]
+        shared = task.shared_block_data
+        if shared is not None:
+            req_meta: LayerBatchReqMeta | None = self.layer_batch_builder.build_addrs(shared, task.layer_id)
+        else:
+            req_meta = self.layer_batch_builder.build(task)
+        if req_meta is None:
+            assert not self.layer_load_finished_events[layer_id].is_set()
+            logger.debug("Layer load event set: layer %d", layer_id)
+            self.layer_load_finished_events[layer_id].set()
+            self.request_queue.task_done()
+            return
+        layer_id = req_meta.layer_id
 
+        if wait_for_save is not None:
+            while not self.layer_save_finished_events[wait_for_save].wait(timeout=10):
+                logger.info("Layerwise %d save wait timed out, keep waiting before load", wait_for_save)
+            logger.debug("Layer save event cleared: layer %d", wait_for_save)
+            self.layer_save_finished_events[wait_for_save].clear()
+
+        if attention_start_gate is not None:
+            while not attention_start_gate.wait(timeout=10):
+                logger.info("Layerwise %d load waits for attention compute start", layer_id)
+
+        gvas_array = _circular_shift_array(
+            req_meta.gvas_array,
+            (self.tp_rank * len(req_meta.gvas_array)) // self.tp_size,
+        )
+        addr_array = _circular_shift_array(
+            req_meta.addr_array,
+            (self.tp_rank * len(req_meta.addr_array)) // self.tp_size,
+        )
+        size_array = _circular_shift_array(
+            req_meta.size_array,
+            (self.tp_rank * len(req_meta.size_array)) // self.tp_size,
+        )
+        self._stagger_h2d_submit(layer_id)
+        res = self._batch_copy_with_limits(
+            gvas_array,
+            addr_array,
+            size_array,
+            1,
+            self.max_transfer_blocks,
+            self.max_transfer_bytes,
+        )
+        if res != 0:
+            logger.error("Layerwise %d load batch_copy failed with return code %d", layer_id, res)
+        if layer_id == self.final_layer_id:
+            for req_id, is_last_chunk in zip(req_meta.req_ids, req_meta.is_last_chunks):
+                if is_last_chunk:
+                    self.set_finished_request(req_id)
+        assert not self.layer_load_finished_events[layer_id].is_set(), f"thread: {layer_id} load failed "
+        logger.debug("Layer load event set: layer %d", layer_id)
+        self.layer_load_finished_events[layer_id].set()
+        transfer_tasks.clear()
         self.request_queue.task_done()
         self.get_event.set()
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_config.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_config.py
@@ -1,0 +1,191 @@
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+_EXTRA_CONFIG_KEY_NUM_SHARED_BUFFERS = "layerwise_num_shared_buffers"
+_EXTRA_CONFIG_KEY_PREFETCH_LAYERS = "layerwise_prefetch_layers"
+_EXTRA_CONFIG_KEY_INDEPENDENT_LAYERS = "layerwise_independent_layers"
+
+
+@dataclass(frozen=True)
+class LayerwiseConfig:
+    num_shared_buffers: int
+    num_prefetch_layers: int
+    independent_layers: list[int]
+    prefetch_layer_map: dict[int, int | None]
+    has_layer_reuse: bool
+
+
+def _parse_int_config(value: Any, name: str) -> int:
+    if isinstance(value, bool):
+        raise TypeError(f"{name} must be an integer, got bool")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as err:
+        raise TypeError(f"{name} must be an integer, got {value!r}") from err
+
+
+def get_layerwise_num_shared_buffers(
+    num_layers: int,
+    extra_config: dict[str, Any] | None = None,
+) -> int:
+    value = extra_config.get(_EXTRA_CONFIG_KEY_NUM_SHARED_BUFFERS) if extra_config else None
+    if value is None:
+        return num_layers
+    num_shared_buffers = _parse_int_config(value, _EXTRA_CONFIG_KEY_NUM_SHARED_BUFFERS)
+    if num_shared_buffers < 1:
+        raise ValueError(f"{_EXTRA_CONFIG_KEY_NUM_SHARED_BUFFERS} must be at least 1")
+    return num_shared_buffers
+
+
+def get_layerwise_num_prefetch_layers(
+    extra_config: dict[str, Any] | None = None,
+) -> int:
+    value = extra_config.get(_EXTRA_CONFIG_KEY_PREFETCH_LAYERS) if extra_config else None
+    if value is None:
+        return 1
+    num_prefetch_layers = _parse_int_config(value, _EXTRA_CONFIG_KEY_PREFETCH_LAYERS)
+    if num_prefetch_layers < 1:
+        raise ValueError(f"{_EXTRA_CONFIG_KEY_PREFETCH_LAYERS} must be at least 1")
+    return num_prefetch_layers
+
+
+def _parse_layer_indices(value: Any) -> list[int]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return []
+        return [int(index.strip()) for index in value.split(",")]
+    if isinstance(value, int) and not isinstance(value, bool):
+        return [value]
+    if isinstance(value, Iterable):
+        return [_parse_int_config(index, _EXTRA_CONFIG_KEY_INDEPENDENT_LAYERS) for index in value]
+    raise TypeError(
+        f"{_EXTRA_CONFIG_KEY_INDEPENDENT_LAYERS} must be a comma-separated string or an iterable of integers"
+    )
+
+
+def get_layerwise_independent_layers(
+    num_layers: int,
+    extra_config: dict[str, Any] | None = None,
+) -> list[int]:
+    value = extra_config.get(_EXTRA_CONFIG_KEY_INDEPENDENT_LAYERS) if extra_config else None
+    if value is None:
+        layer_indices = [0, num_layers - 1]
+    elif isinstance(value, str) and value.strip().lower() == "all":
+        layer_indices = list(range(num_layers))
+    else:
+        layer_indices = _parse_layer_indices(value)
+
+    normalized_indices = set()
+    for layer_index in layer_indices:
+        if layer_index < 0:
+            layer_index += num_layers
+        if layer_index < 0 or layer_index >= num_layers:
+            raise ValueError(
+                f"{_EXTRA_CONFIG_KEY_INDEPENDENT_LAYERS} contains "
+                f"out-of-range layer index {layer_index}; valid range is "
+                f"[0, {num_layers - 1}]"
+            )
+        normalized_indices.add(layer_index)
+
+    return sorted(normalized_indices)
+
+
+def get_layerwise_config(
+    num_layers: int,
+    extra_config: dict[str, Any] | None = None,
+) -> LayerwiseConfig:
+    num_shared_buffers = get_layerwise_num_shared_buffers(num_layers, extra_config)
+    num_prefetch_layers = get_layerwise_num_prefetch_layers(extra_config)
+    independent_layers = get_layerwise_independent_layers(num_layers, extra_config)
+    independent_layer_indices = set(independent_layers)
+    reused_layers = [i for i in range(num_layers) if i not in independent_layer_indices]
+    has_layer_reuse = len(reused_layers) > num_shared_buffers
+
+    prefetch_layer_map: dict[int, int | None] = {}
+    if has_layer_reuse:
+        for next_index in range(num_shared_buffers, len(reused_layers)):
+            prefetch_layer_map[reused_layers[next_index]] = reused_layers[next_index - num_shared_buffers]
+
+    return LayerwiseConfig(
+        num_shared_buffers=num_shared_buffers,
+        num_prefetch_layers=num_prefetch_layers,
+        independent_layers=independent_layers,
+        prefetch_layer_map=prefetch_layer_map,
+        has_layer_reuse=has_layer_reuse,
+    )
+
+
+def get_layerwise_kv_cache_reuse_layers(
+    num_layers: int,
+    extra_config: dict[str, Any] | None = None,
+) -> int | None:
+    layerwise_config = get_layerwise_config(num_layers, extra_config)
+    if not layerwise_config.has_layer_reuse:
+        return None
+    return layerwise_config.num_shared_buffers
+
+
+def get_layerwise_kv_cache_num_tensors(
+    num_layers: int,
+    extra_config: dict[str, Any] | None = None,
+) -> int | None:
+    """Number of distinct KV cache buffers after layer reuse.
+
+    Returns ``None`` when layer reuse is disabled (one buffer per layer).
+    Otherwise returns the count of merged tensors the model runner will
+    allocate: each independent layer keeps its own buffer, and the reused
+    layers share ``num_shared_buffers`` buffers. The worker uses this to size
+    the memory-inflation factor so total allocation stays within budget.
+    """
+    config = get_layerwise_config(num_layers, extra_config)
+    if not config.has_layer_reuse:
+        return None
+    return len(config.independent_layers) + config.num_shared_buffers
+
+
+def get_layerwise_storage_indices(
+    num_layers: int,
+    extra_config: dict[str, Any] | None = None,
+) -> list[list[int]]:
+    """Group layer indices into shared storage slots for layer reuse.
+
+    Each inner list holds the layer indices that time-multiplex one shared
+    buffer. Independent layers each occupy their own slot; the reused layers
+    are distributed across ``num_shared_buffers`` slots round-robin so that
+    ``reused_layers[k]`` shares a buffer with
+    ``reused_layers[k + num_shared_buffers]`` — matching the prefetch map
+    computed in :func:`get_layerwise_config`.
+    """
+    config = get_layerwise_config(num_layers, extra_config)
+    independent_set = set(config.independent_layers)
+    reused_layers = [layer for layer in range(num_layers) if layer not in independent_set]
+    storage_indices: list[list[int]] = [[layer] for layer in config.independent_layers]
+    for slot in range(config.num_shared_buffers):
+        members = list(range(slot, len(reused_layers), config.num_shared_buffers))
+        if members:
+            storage_indices.append([reused_layers[m] for m in members])
+    return storage_indices
+
+
+def get_layer_load_start_block(
+    layer_id: int,
+    independent_layers: list[int],
+    vllm_cached_tokens: int,
+    block_size: int,
+    has_layer_reuse: bool,
+) -> int:
+    """First pool block to load for ``layer_id``.
+
+    Without layer reuse every layer behaves the same and starts right after
+    the HBM-cached blocks. With layer reuse, independent layers still skip
+    HBM-cached blocks (their dedicated buffer keeps that KV valid), while
+    shared (time-multiplexed) layers must reload every block from block 0
+    because HBM hits are not reliable.
+    """
+    if not has_layer_reuse or layer_id in independent_layers:
+        return vllm_cached_tokens // block_size
+    return 0

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -1041,6 +1041,14 @@ class KVPoolScheduler:
         if self.kv_role == "kv_consumer" and not self.consumer_is_to_put:
             self._delayed_free_req_ids.discard(request.request_id)
             return False, None
+        if self.use_layerwise:
+            # Layerwise saves each layer synchronously before the request
+            # finishes (save_kv_layer waits on the last layer's save event),
+            # so blocks can be freed immediately. Delaying them here would
+            # leak: layerwise never records a sending event, so
+            # update_connector_output would never free these blocks.
+            self._delayed_free_req_ids.discard(request.request_id)
+            return False, None
         tracker = self._request_trackers.get(request.request_id)
         if tracker is not None and tracker.num_saved_tokens <= 0:
             self._delayed_free_req_ids.discard(request.request_id)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -1,3 +1,4 @@
+import importlib
 import math
 from typing import Any, cast
 
@@ -23,15 +24,23 @@ from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
 from vllm.v1.serial_utils import MsgpackEncoder
 
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
+    backend_map,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     AscendConnectorMetadata,
     AscendStoreKVConnectorWorkerMetadata,
+    KeyMetadata,
     LoadSpec,
+    PoolKey,
     ReqMeta,
     RequestTracker,
     get_cache_family_granularity,
     infer_group_cache_families,
     normalize_block_ids_by_group,
+)
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_config import (
+    get_layerwise_config,
 )
 
 
@@ -41,7 +50,12 @@ class KVPoolScheduler:
         vllm_config: "VllmConfig",
         use_layerwise,
         kv_cache_config: KVCacheConfig | None = None,
+        page_size_bytes: int = 0,
     ):
+        if isinstance(kv_cache_config, int):
+            page_size_bytes = kv_cache_config
+            kv_cache_config = None
+        self.vllm_config = vllm_config
         self.use_layerwise = use_layerwise
         self.kv_cache_config = kv_cache_config
         hf_text_config = getattr(vllm_config.model_config, "hf_text_config", None)
@@ -79,16 +93,13 @@ class KVPoolScheduler:
             "consumer_is_to_put", False
         )
         self.load_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get("load_async", False)
-        self.client = LookupKeyClient(vllm_config)
+        self.save_decode_cache = vllm_config.kv_transfer_config.kv_connector_extra_config.get("save_decode_cache", True)
         # request_id -> (vllm cached tokes, kvpool cached tokens)
         self.load_specs: dict[str, LoadSpec] = {}
         self.pcp_size = getattr(vllm_config.parallel_config, "prefill_context_parallel_size", 1)
         self.dcp_size = getattr(vllm_config.parallel_config, "decode_context_parallel_size", 1)
 
         self.mamba_group_ids = self._infer_mamba_groups()
-        self.num_speculative_blocks = (
-            vllm_config.speculative_config.num_speculative_tokens if vllm_config.speculative_config else 0
-        )
         self.original_block_size = self._infer_group_block_sizes(vllm_config, kv_cache_config)
         cp_scale = self.pcp_size * self.dcp_size
         self.grouped_block_size = [block_size * cp_scale for block_size in self.original_block_size]
@@ -110,8 +121,15 @@ class KVPoolScheduler:
         self._discard_partial_chunks = vllm_config.kv_transfer_config.get_from_extra_config(
             "discard_partial_chunks", True
         )
+        if self.use_layerwise:
+            self._discard_partial_chunks = vllm_config.kv_transfer_config.get_from_extra_config(
+                "discard_partial_chunks", False
+            )
         self._unfinished_requests: dict[str, tuple[Request, list[list[int]]]] = {}
         self._unfinished_request_ids: set[str] = set()
+        self._loading_req_ids: set[str] = set()
+        self._delayed_free_req_ids: set[str] = set()
+
         self._block_pool: BlockPool | None = None
         self.sending_event_id = 0
         # {event_id, flattened block_ids}
@@ -119,6 +137,260 @@ class KVPoolScheduler:
         # {event_id, completed_woke_count}
         self.sending_events: dict[int, int] = {}
         self._expected_worker_count = vllm_config.parallel_config.world_size
+
+        self.page_size_bytes = page_size_bytes
+        logger.info("KV pool page_size_bytes: %d", page_size_bytes)
+        backend_name = vllm_config.kv_transfer_config.kv_connector_extra_config.get("backend", "mooncake")
+        self.backend_name = backend_name.lower()
+        self.use_gva_layerwise = self.use_layerwise and self.backend_name == "memcache"
+        backend = backend_map.get(self.backend_name)
+        if backend is None:
+            raise ValueError(f"Unsupported KV pool backend: {backend_name}")
+        backend_path = backend.get("path")
+        backend_class_name = backend.get("name")
+        assert backend_path is not None and backend_class_name is not None
+        backend_module = importlib.import_module(backend_path)
+        backend_class = getattr(backend_module, backend_class_name)
+        self.store_scheduler = backend_class.create_scheduler_client(vllm_config.parallel_config)
+
+        model_config = vllm_config.model_config
+        self.tp_size = vllm_config.parallel_config.tensor_parallel_size
+        self.pp_size = vllm_config.parallel_config.pipeline_parallel_size
+        self.pp_rank = (vllm_config.parallel_config.rank // self.tp_size) % self.pp_size
+        self.use_mla = False
+        if hasattr(model_config, "use_mla") and isinstance(model_config.use_mla, bool) and model_config.use_mla:
+            self.use_mla = True
+        if self.use_mla:
+            self.num_kv_head = 1
+        else:
+            self.num_kv_head = model_config.get_total_num_kv_heads()
+        if self.num_kv_head < self.tp_size:
+            self.put_step = self.tp_size // self.num_kv_head
+        else:
+            self.put_step = 1
+        self.num_layers = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
+        self.model_name = model_config.model.split("/")[-1]
+
+        if self.use_gva_layerwise:
+            layerwise_config = get_layerwise_config(
+                self.num_layers, vllm_config.kv_transfer_config.kv_connector_extra_config
+            )
+            self.layerwise_offload = layerwise_config.has_layer_reuse
+        else:
+            self.layerwise_offload = False
+
+        # Keep this in sync with pool_worker.py because it affects GVA allocation size.
+        num_layer_keys = self.num_layers if self.use_gva_layerwise else 1
+        keys_per_block_hash = self.pcp_size * self.dcp_size * (self.tp_size // self.put_step) * num_layer_keys
+        self.keys_per_block_hash = keys_per_block_hash
+        self.client: LookupKeyClient | None = None
+
+    def _get_or_create_request_tracker(self, req_id: str) -> RequestTracker:
+        tracker = self._request_trackers.get(req_id)
+        if tracker is None:
+            tracker = RequestTracker(
+                req_id=req_id,
+                token_len=0,
+                allocated_block_ids=[],
+            )
+            self._request_trackers[req_id] = tracker
+        return tracker
+
+    def _generate_keys_and_alloc(
+        self,
+        block_hashes,
+        request_tracker: RequestTracker,
+        has_last_block=False,
+    ) -> None:
+        keys_to_alloc, last_block_key = self.generate_keys(
+            block_hashes,
+            req_id=request_tracker.req_id,
+            has_last_block=has_last_block,
+        )
+        alloc_size = self.page_size_bytes * self.keys_per_block_hash
+
+        last_block_gva = request_tracker.last_block_gva
+        num_new_block_keys = len(keys_to_alloc)
+        if last_block_key and last_block_gva is None:
+            keys_to_alloc.append(last_block_key)
+        if keys_to_alloc:
+            new_gvas = self.store_scheduler.batch_alloc(keys_to_alloc, [alloc_size] * len(keys_to_alloc))
+            if any(gva <= 0 for gva in new_gvas):
+                raise ValueError(f"Request {request_tracker.req_id}: batch_alloc failed, gvas={new_gvas}")
+
+            request_tracker.block_gvas.extend(new_gvas[:num_new_block_keys])
+            request_tracker.block_keys.extend(keys_to_alloc[:num_new_block_keys])
+            if last_block_key is not None and len(new_gvas) > num_new_block_keys:
+                request_tracker.last_block_key = last_block_key
+                request_tracker.last_block_gva = new_gvas[-1]
+
+    def _ensure_tracker_gvas_cover_blocks(
+        self,
+        request_tracker: RequestTracker,
+        block_hashes,
+    ) -> None:
+        """Ensure layerwise KV pool GVA exists for all requested full blocks.
+
+        Layerwise transfer uses batch_copy with explicit GVA addresses instead
+        of the normal key-based put/get path. Existing block keys reuse their
+        stored GVA; missing keys are allocated here so later layer load/save
+        tasks can build complete transfer arrays.
+        """
+        block_keys, _ = self.generate_keys(block_hashes)
+        if not block_keys:
+            request_tracker.block_keys = []
+            request_tracker.block_gvas = []
+            request_tracker.gva_block_offset = 0
+            return
+
+        key_infos = self.store_scheduler.batch_get_key_info(block_keys)
+        block_gvas = [0] * len(block_keys)
+        missing_keys = []
+        missing_indices = []
+        for index, key_info in enumerate(key_infos):
+            sizes = key_info.size()
+            if sizes and sizes > 0:
+                block_gvas[index] = key_info.gva_list()[0]
+            else:
+                missing_keys.append(block_keys[index])
+                missing_indices.append(index)
+
+        if missing_keys:
+            alloc_size = self.page_size_bytes * self.keys_per_block_hash
+            new_gvas = self.store_scheduler.batch_alloc(missing_keys, [alloc_size] * len(missing_keys))
+            if any(gva <= 0 for gva in new_gvas):
+                raise ValueError(f"Request {request_tracker.req_id}: batch_alloc failed, gvas={new_gvas}")
+            for index, gva in zip(missing_indices, new_gvas):
+                block_gvas[index] = gva
+
+        request_tracker.block_keys = block_keys
+        request_tracker.block_gvas = block_gvas
+        request_tracker.gva_block_offset = 0
+
+    def generate_keys(self, block_hashes, req_id="", has_last_block=False):
+        block_keys = []
+        for block_hash in block_hashes:
+            key = f"{self.model_name}@{block_hash.hex()}"
+            block_keys.append(key)
+
+        last_block_key = None
+        if has_last_block:
+            last_block_key = f"{self.model_name}@{req_id}_lastblock"
+
+        return block_keys, last_block_key
+
+    def _generate_store_query_keys(
+        self,
+        block_hashes,
+        include_layers: bool = False,
+        kv_cache_group_id: int = 0,
+    ) -> list[list[str]]:
+        head_or_tp_ranks = self.tp_size // self.put_step
+        cache_family = self._get_group_family(self.kv_cache_group_families, kv_cache_group_id)
+        keys_by_block = []
+        for block_hash in block_hashes:
+            block_keys: list[str] = []
+            chunk_hash = block_hash if isinstance(block_hash, str) else block_hash.hex()
+            pp_ranks = [self.pp_rank] if include_layers else range(self.pp_size)
+            for pcp_rank in range(self.pcp_size):
+                for dcp_rank in range(self.dcp_size):
+                    for head_or_tp_rank in range(head_or_tp_ranks):
+                        for pp_rank in pp_ranks:
+                            pool_key = PoolKey(
+                                KeyMetadata(
+                                    self.model_name,
+                                    head_or_tp_rank,
+                                    pcp_rank,
+                                    dcp_rank,
+                                    pp_rank,
+                                    kv_cache_group_id=kv_cache_group_id,
+                                    cache_family=cache_family,
+                                ),
+                                chunk_hash,
+                            )
+                            if include_layers:
+                                block_keys.extend(
+                                    layer_key.to_string() for layer_key in pool_key.split_layers(self.num_layers)
+                                )
+                            else:
+                                block_keys.append(pool_key.to_string())
+            keys_by_block.append(block_keys)
+        return keys_by_block
+
+    def _get_store_lookup_hit_tokens(
+        self,
+        request: "Request",
+        token_len: int,
+        num_computed_tokens: int,
+        include_layers: bool = False,
+    ) -> int:
+        num_blocks = token_len // self._block_size
+        # In layerwise mode, always query from block 0 because the remote
+        # pool stores per-layer data that may not match local prefix cache.
+        query_start_block = 0 if self.use_layerwise else min(num_computed_tokens // self._block_size, num_blocks)
+        block_hashes_to_query = request.block_hashes[query_start_block:num_blocks]
+        if not block_hashes_to_query:
+            return 0
+
+        query_keys_by_block = self._generate_store_query_keys(
+            block_hashes_to_query,
+            include_layers=include_layers,
+        )
+        query_keys = [key for block_keys in query_keys_by_block for key in block_keys]
+        exists_states = self.store_scheduler.batch_is_exist(query_keys)
+        if len(exists_states) != len(query_keys):
+            raise RuntimeError(
+                "KV pool exists check returned unexpected number of "
+                f"states for request {request.request_id}: "
+                f"expected={len(query_keys)}, actual={len(exists_states)}"
+            )
+
+        num_queried_hit_blocks = 0
+        offset = 0
+        for block_keys in query_keys_by_block:
+            block_states = exists_states[offset : offset + len(block_keys)]
+            offset += len(block_keys)
+            if all(exists == 1 for exists in block_states):
+                num_queried_hit_blocks += 1
+                continue
+            if any(exists == 0 for exists in block_states):
+                break
+            raise RuntimeError(f"KV pool exists check failed for request {request.request_id}: states={exists_states}")
+
+        num_hit_blocks = query_start_block + num_queried_hit_blocks
+        return num_hit_blocks * self._block_size
+
+    def _get_layerwise_gva_hit_tokens(
+        self,
+        request: "Request",
+        token_len: int,
+        num_computed_tokens: int,
+    ) -> int:
+        num_blocks = token_len // self._block_size
+        num_queried_hit_blocks = 0
+        block_hashes_to_check = request.block_hashes[:num_blocks]
+        keys_to_check = [f"{self.model_name}@{bh.hex()}" for bh in block_hashes_to_check]
+        # In layerwise mode, always query from block 0 because the remote
+        # pool stores per-layer data that may not match local prefix cache.
+        query_start_block = 0 if self.use_layerwise else min(num_computed_tokens // self._block_size, num_blocks)
+        keys_to_query = keys_to_check[query_start_block:]
+        if not keys_to_query:
+            return 0
+        tracker = self._get_or_create_request_tracker(request.request_id)
+        cached_gvas = []
+        key_infos = self.store_scheduler.batch_get_key_info(keys_to_query)
+        for key_info in key_infos:
+            sizes = key_info.size()
+            if sizes and sizes > 0:
+                cached_gvas.append(key_info.gva_list()[0])
+                num_queried_hit_blocks += 1
+            else:
+                break
+        num_hit_blocks = query_start_block + num_queried_hit_blocks
+        tracker.block_keys = keys_to_check[query_start_block:num_hit_blocks]
+        tracker.block_gvas = cached_gvas[:num_queried_hit_blocks]
+        tracker.gva_block_offset = query_start_block
+        return num_hit_blocks * self._block_size
 
     def _infer_group_families(self) -> list[str]:
         kv_cache_groups = self.kv_cache_config.kv_cache_groups if self.kv_cache_config is not None else None
@@ -252,11 +524,23 @@ class KVPoolScheduler:
         if token_len < self.cache_transfer_granularity:
             return 0, False
 
-        num_external_hit_tokens = self.client.lookup(
-            token_len,
-            request.block_hashes,
-            self.kv_cache_group_ids,
-        )
+        if self.use_gva_layerwise:
+            num_external_hit_tokens = self._get_layerwise_gva_hit_tokens(request, token_len, num_computed_tokens)
+        elif self.use_layerwise:
+            num_external_hit_tokens = self._get_store_lookup_hit_tokens(
+                request, token_len, num_computed_tokens, include_layers=True
+            )
+        else:
+            if self.client is None:
+                self.client = LookupKeyClient(self.vllm_config)
+            num_external_hit_tokens = self.client.lookup(
+                token_len,
+                request.block_hashes,
+                self.kv_cache_group_ids,
+            )
+
+        if num_external_hit_tokens == 0:
+            return 0, False
 
         if num_external_hit_tokens == request.num_tokens:
             num_external_hit_tokens -= 1
@@ -266,7 +550,7 @@ class KVPoolScheduler:
         else:
             need_to_allocate = num_external_hit_tokens - num_computed_tokens
 
-        logger.debug(
+        logger.info(
             "Reqid: %s, Total tokens %d, kvpool hit tokens: %d, need to load: %d",
             request.request_id,
             request.num_tokens,
@@ -274,13 +558,17 @@ class KVPoolScheduler:
             need_to_allocate,
         )
 
-        if need_to_allocate <= 0:
+        # In layerwise mode, even when vLLM has local cached tokens, we still
+        # need to load KV cache from the pool because layerwise transfer loads
+        # per-layer data that may not be in HBM.
+        force_layerwise_load = self.use_layerwise and num_external_hit_tokens > 0
+        if need_to_allocate <= 0 and not force_layerwise_load:
             return 0, False
 
         self.load_specs[request.request_id] = LoadSpec(
             vllm_cached_tokens=num_computed_tokens,
             kvpool_cached_tokens=num_external_hit_tokens,
-            can_load=False,
+            can_load=force_layerwise_load,
         )
         logger.info(
             "KV pool load spec created req=%s vllm_cached=%d kvpool_cached=%d "
@@ -319,10 +607,14 @@ class KVPoolScheduler:
 
         if num_external_tokens == 0:
             # No need to load anything
-            self.load_specs[request.request_id].can_load = False
+            self.load_specs[request.request_id].can_load = (
+                self.use_layerwise and self.load_specs[request.request_id].kvpool_cached_tokens > 0
+            )
             logger.debug(
-                "KV pool load spec disabled req=%s because num_external_tokens=0 vllm_cached=%d kvpool_cached=%d",
+                "KV pool load spec updated req=%s because num_external_tokens=0 "
+                "can_load=%s vllm_cached=%d kvpool_cached=%d",
                 request.request_id,
+                self.load_specs[request.request_id].can_load,
                 self.load_specs[request.request_id].vllm_cached_tokens,
                 self.load_specs[request.request_id].kvpool_cached_tokens,
             )
@@ -341,6 +633,8 @@ class KVPoolScheduler:
         )
 
         self.load_specs[request.request_id].can_load = True
+        if self.load_async and not self.use_layerwise:
+            self._loading_req_ids.add(request.request_id)
         logger.debug(
             "KV pool load spec enabled req=%s num_external_tokens=%d vllm_cached=%d kvpool_cached=%d groups=%s",
             request.request_id,
@@ -350,6 +644,240 @@ class KVPoolScheduler:
             [len(blocks) for blocks in local_block_ids],
         )
 
+    def _get_last_chunk_tokens_num(self, prompt_token_ids: list[int]) -> int:
+        if self._discard_partial_chunks:
+            return self._floor_to_cache_transfer_granularity(len(prompt_token_ids))
+        return len(prompt_token_ids)
+
+    def _allocate_gva_if_needed(
+        self,
+        request_tracker: RequestTracker,
+        block_hashes,
+        num_blocks: int,
+        has_last_block: bool,
+    ) -> None:
+        if not self.use_gva_layerwise:
+            return
+        self._ensure_tracker_gvas_cover_blocks(
+            request_tracker,
+            block_hashes[:num_blocks],
+        )
+        if has_last_block:
+            self._generate_keys_and_alloc(
+                [],
+                request_tracker=request_tracker,
+                has_last_block=True,
+            )
+
+    def _build_req_meta(
+        self,
+        request_tracker: RequestTracker,
+        block_hashes,
+        load_spec: LoadSpec | None,
+        prompt_token_ids: list[int],
+        skip_save: bool | None,
+    ):
+        last_chunk_tokens_num = self._get_last_chunk_tokens_num(prompt_token_ids)
+        return ReqMeta.from_request_tracker(
+            request_tracker,
+            self.cache_transfer_granularity,
+            load_spec=load_spec,
+            skip_save=skip_save,
+            block_hashes=block_hashes,
+            is_last_chunk=request_tracker.token_len >= last_chunk_tokens_num,
+            discard_partial_chunks=self._discard_partial_chunks,
+            original_block_size=self.original_block_size,
+            kv_cache_group_families=self.kv_cache_group_families,
+        )
+
+    def _process_new_request(
+        self,
+        request: Request,
+        scheduler_output: SchedulerOutput,
+        force_skip_save: bool,
+    ) -> ReqMeta | None:
+        load_spec = self.load_specs.pop(request.req_id, None)
+        num_tokens_to_compute = request.num_computed_tokens + scheduler_output.num_scheduled_tokens[request.req_id]
+        request_tuple = self._unfinished_requests.get(request.req_id)
+        if request_tuple is None:
+            raise ValueError(
+                f"Request {request.req_id} is not in _unfinished_requests, but it is scheduled as a new request"
+            )
+        request_real = request_tuple[0]
+        block_ids_by_group = normalize_block_ids_by_group(request.block_ids)
+        previous_tracker = self._request_trackers.get(request.req_id)
+        request_tracker = RequestTracker(
+            req_id=request.req_id,
+            token_len=num_tokens_to_compute,
+            allocated_block_ids_by_group=block_ids_by_group,
+            num_saved_tokens=0,
+            token_ids=request.prompt_token_ids[:num_tokens_to_compute].copy(),
+            block_keys=(previous_tracker.block_keys.copy() if previous_tracker else []),
+            block_gvas=(previous_tracker.block_gvas.copy() if previous_tracker else []),
+            gva_block_offset=(previous_tracker.gva_block_offset if previous_tracker else 0),
+        )
+        self._request_trackers[request.req_id] = request_tracker
+        num_blocks = num_tokens_to_compute // self._block_size
+        has_last_block = num_tokens_to_compute % self._block_size != 0
+        self._allocate_gva_if_needed(
+            request_tracker,
+            request_real.block_hashes,
+            num_blocks,
+            has_last_block,
+        )
+        return self._build_req_meta(
+            request_tracker,
+            request_real.block_hashes,
+            load_spec,
+            request.prompt_token_ids,
+            force_skip_save,
+        )
+
+    def _process_preempted_cached_request(
+        self,
+        new_block_ids,
+        req_id: str,
+        i: int,
+        cached_reqs,
+        scheduler_output: SchedulerOutput,
+        force_skip_save: bool,
+    ) -> ReqMeta | None:
+        new_block_ids_by_group = normalize_block_ids_by_group(new_block_ids)
+        self._preempted_req_ids.discard(req_id)
+        load_spec = self.load_specs.pop(req_id, None)
+        request_tuple = self._unfinished_requests.get(req_id)
+        if request_tuple is None:
+            raise ValueError(
+                f"Request {req_id} is not in _unfinished_requests, but it is scheduled as a preempted cached request"
+            )
+        request_real = request_tuple[0]
+        num_tokens_to_compute = request_real.num_computed_tokens + scheduler_output.num_scheduled_tokens[req_id]
+        previous_tracker = self._request_trackers.get(req_id)
+        request_tracker = RequestTracker(
+            req_id=req_id,
+            token_len=num_tokens_to_compute,
+            allocated_block_ids_by_group=new_block_ids_by_group,
+            num_saved_tokens=0,
+            token_ids=request_real.prompt_token_ids[:num_tokens_to_compute].copy(),
+            block_keys=(previous_tracker.block_keys.copy() if previous_tracker else []),
+            block_gvas=(previous_tracker.block_gvas.copy() if previous_tracker else []),
+            gva_block_offset=(previous_tracker.gva_block_offset if previous_tracker else 0),
+        )
+        self._request_trackers[req_id] = request_tracker
+        num_blocks = len(new_block_ids_by_group[0])
+        has_last_block = num_tokens_to_compute % self._block_size != 0
+        self._allocate_gva_if_needed(
+            request_tracker,
+            request_real.block_hashes,
+            num_blocks,
+            has_last_block,
+        )
+        return self._build_req_meta(
+            request_tracker,
+            request_real.block_hashes,
+            load_spec,
+            request_real.prompt_token_ids,
+            force_skip_save,
+        )
+
+    def _process_running_cached_request(
+        self,
+        new_block_ids,
+        req_id: str,
+        i: int,
+        cached_reqs,
+        scheduler_output: SchedulerOutput,
+        force_skip_save: bool,
+    ) -> ReqMeta | None:
+        if not self.save_decode_cache:
+            return None
+        request_tracker = self._request_trackers.get(req_id)
+        if request_tracker is None:
+            raise ValueError(f"Request {req_id} is not in _request_trackers, but it is scheduled to be cached")
+        num_new_tokens = scheduler_output.num_scheduled_tokens[req_id]
+        req_tuple = self._unfinished_requests.get(req_id)
+        if req_tuple:
+            request = req_tuple[0]
+            num_current_tokens = request_tracker.token_len
+            new_token_ids = request.all_token_ids[num_current_tokens : num_current_tokens + num_new_tokens]
+            if request_tracker.token_ids is not None and new_token_ids:
+                request_tracker.token_ids.extend(new_token_ids)
+            request_tracker.token_len += num_new_tokens
+        else:
+            raise ValueError(f"Request {req_id} is not in _unfinished_requests, but it is scheduled to be cached")
+        prev_token_count = request_tracker.token_len - num_new_tokens
+        prev_hash_count = prev_token_count // self._block_size
+        current_hash_count = request_tracker.token_len // self._block_size
+        new_hash_count = current_hash_count - prev_hash_count
+        has_last_block = request_tracker.token_len % self._block_size != 0 or current_hash_count > len(
+            request.block_hashes
+        )
+        if self.use_gva_layerwise and (new_hash_count > 0 or has_last_block):
+            self._ensure_tracker_gvas_cover_blocks(
+                request_tracker,
+                request.block_hashes[:current_hash_count],
+            )
+            if has_last_block:
+                self._generate_keys_and_alloc(
+                    [],
+                    request_tracker=request_tracker,
+                    has_last_block=True,
+                )
+        if new_block_ids is not None:
+            request_tracker.update(new_block_ids)
+        load_spec = None
+        return self._build_req_meta(
+            request_tracker,
+            request.block_hashes,
+            load_spec,
+            request.prompt_token_ids,
+            force_skip_save,
+        )
+
+    def _process_async_load_request(
+        self,
+        request_id: str,
+        request: Request,
+        block_ids: list[list[int]],
+    ) -> ReqMeta | None:
+        load_spec = self.load_specs.pop(request_id, None)
+        if not load_spec:
+            return None
+        num_tokens_to_compute = load_spec.kvpool_cached_tokens
+        if (num_tokens_to_compute % self._block_size != 0) and (
+            num_tokens_to_compute == len(request.prompt_token_ids) - 1
+        ):
+            num_tokens_to_compute = num_tokens_to_compute + 1
+        previous_tracker = self._request_trackers.get(request_id)
+        request_tracker = RequestTracker(
+            req_id=request_id,
+            token_len=num_tokens_to_compute,
+            allocated_block_ids_by_group=block_ids,
+            num_saved_tokens=0,
+            block_keys=(previous_tracker.block_keys.copy() if previous_tracker else []),
+            block_gvas=(previous_tracker.block_gvas.copy() if previous_tracker else []),
+            gva_block_offset=(previous_tracker.gva_block_offset if previous_tracker else 0),
+        )
+        self._request_trackers[request_id] = request_tracker
+        num_blocks = num_tokens_to_compute // self._block_size
+        has_last_block = num_tokens_to_compute % self._block_size != 0
+        self._allocate_gva_if_needed(
+            request_tracker,
+            request.block_hashes,
+            num_blocks,
+            has_last_block,
+        )
+        return ReqMeta.from_request_tracker(
+            request_tracker,
+            self.cache_transfer_granularity,
+            load_spec=load_spec,
+            skip_save=None,
+            block_hashes=request.block_hashes,
+            discard_partial_chunks=self._discard_partial_chunks,
+            original_block_size=self.original_block_size,
+            kv_cache_group_families=self.kv_cache_group_families,
+        )
+
     def build_connector_meta(self, scheduler_output: SchedulerOutput) -> KVConnectorMetadata:
         """Attach the connector metadata to the request object.
 
@@ -357,7 +885,6 @@ class KVPoolScheduler:
         except the `kv_connector_metadata` field.
         Also, calling this function will reset the state of the connector.
         """
-
         force_skip_save = self.kv_role == "kv_consumer" and not self.consumer_is_to_put
 
         for finished_req_id in scheduler_output.finished_req_ids:
@@ -365,60 +892,24 @@ class KVPoolScheduler:
             self._unfinished_requests.pop(finished_req_id, None)
             self._unfinished_request_ids.discard(finished_req_id)
             self._preempted_req_ids.discard(finished_req_id)
+            self._loading_req_ids.discard(finished_req_id)
 
         for req_id in scheduler_output.preempted_req_ids:
             self._preempted_req_ids.update(scheduler_output.preempted_req_ids)
             self._request_trackers.pop(req_id, None)
             self._unfinished_requests.pop(req_id, None)
+            self._loading_req_ids.discard(req_id)
+            self._delayed_free_req_ids.discard(req_id)
 
-        meta = AscendConnectorMetadata(self._unfinished_request_ids, scheduler_output.preempted_req_ids)
+        meta = AscendConnectorMetadata(
+            self._unfinished_request_ids,
+            scheduler_output.preempted_req_ids,
+            self._loading_req_ids.copy(),
+            self._delayed_free_req_ids.copy(),
+        )
 
         for request in scheduler_output.scheduled_new_reqs:
-            # Right now, we only load KV for new requests
-            load_spec = self.load_specs.pop(request.req_id, None)
-            if load_spec is not None:
-                logger.debug(
-                    "KV pool build meta attaches load spec req=%s can_load=%s "
-                    "vllm_cached=%d kvpool_cached=%d scheduled_tokens=%d "
-                    "num_computed=%d",
-                    request.req_id,
-                    load_spec.can_load,
-                    load_spec.vllm_cached_tokens,
-                    load_spec.kvpool_cached_tokens,
-                    scheduler_output.num_scheduled_tokens[request.req_id],
-                    request.num_computed_tokens,
-                )
-            num_tokens_to_compute = request.num_computed_tokens + scheduler_output.num_scheduled_tokens[request.req_id]
-            request_tuple = self._unfinished_requests.get(request.req_id)
-            request_real = request_tuple[0]  # type: ignore[index]
-            request_tracker = RequestTracker(
-                req_id=request.req_id,
-                token_len=num_tokens_to_compute,
-                allocated_block_ids_by_group=normalize_block_ids_by_group(request.block_ids),
-                num_saved_tokens=0,
-                token_ids=request.prompt_token_ids[:num_tokens_to_compute].copy(),
-                mamba_group_ids=self.mamba_group_ids,
-                num_speculative_blocks=self.num_speculative_blocks,
-                block_sizes=self.grouped_block_size,
-            )
-            self._request_trackers[request.req_id] = request_tracker
-            last_chunk_tokens_num = (
-                self._floor_to_cache_transfer_granularity(len(request.prompt_token_ids))
-                if self._discard_partial_chunks
-                else len(request.prompt_token_ids)
-            )
-
-            req_meta = ReqMeta.from_request_tracker(
-                request_tracker,
-                self.cache_transfer_granularity,
-                load_spec=load_spec,
-                skip_save=force_skip_save,
-                block_hashes=request_real.block_hashes,
-                is_last_chunk=request_tracker.token_len >= last_chunk_tokens_num,
-                discard_partial_chunks=self._discard_partial_chunks,
-                original_block_size=self.original_block_size,
-                kv_cache_group_families=self.kv_cache_group_families,
-            )
+            req_meta = self._process_new_request(request, scheduler_output, force_skip_save)
             if req_meta is not None:
                 self.touch_sending_mamba_blocks(req_meta)
                 meta.add_request(req_meta)
@@ -426,80 +917,26 @@ class KVPoolScheduler:
         cached_reqs = scheduler_output.scheduled_cached_reqs
         if not force_skip_save:
             for i, req_id in enumerate(cached_reqs.req_ids):
-                # resumed request
                 new_block_ids = cached_reqs.new_block_ids[i]
                 if not new_block_ids:
                     continue
                 if req_id in self._preempted_req_ids:
-                    self._preempted_req_ids.discard(req_id)
-                    load_spec = self.load_specs.pop(req_id, None)
-                    request_tuple = self._unfinished_requests.get(req_id)
-                    request_real = request_tuple[0]  # type: ignore[index]
-                    num_tokens_to_compute = (
-                        request_real.num_computed_tokens + scheduler_output.num_scheduled_tokens[req_id]
+                    req_meta = self._process_preempted_cached_request(
+                        new_block_ids,
+                        req_id,
+                        i,
+                        cached_reqs,
+                        scheduler_output,
+                        force_skip_save,
                     )
-                    request_tracker = RequestTracker(
-                        req_id=req_id,
-                        token_len=num_tokens_to_compute,
-                        allocated_block_ids_by_group=normalize_block_ids_by_group(new_block_ids),
-                        num_saved_tokens=0,
-                        token_ids=request_real.prompt_token_ids[:num_tokens_to_compute].copy(),
-                        mamba_group_ids=self.mamba_group_ids,
-                        num_speculative_blocks=self.num_speculative_blocks,
-                        block_sizes=self.grouped_block_size,
-                    )
-                    self._request_trackers[req_id] = request_tracker
-                    last_chunk_tokens_num = (
-                        self._floor_to_cache_transfer_granularity(len(request_real.prompt_token_ids))
-                        if self._discard_partial_chunks
-                        else len(request_real.prompt_token_ids)
-                    )
-                    req_meta = ReqMeta.from_request_tracker(
-                        request_tracker,
-                        self.cache_transfer_granularity,
-                        load_spec=load_spec,
-                        skip_save=force_skip_save,
-                        block_hashes=request_real.block_hashes,
-                        is_last_chunk=request_tracker.token_len >= last_chunk_tokens_num,
-                        discard_partial_chunks=self._discard_partial_chunks,
-                        original_block_size=self.original_block_size,
-                        kv_cache_group_families=self.kv_cache_group_families,
-                    )
-
-                # decode/chunked request
                 else:
-                    request_tracker = self._request_trackers[req_id]
-                    num_new_tokens = scheduler_output.num_scheduled_tokens[req_id]
-                    req_tuple = self._unfinished_requests.get(req_id)
-                    if req_tuple:
-                        request = req_tuple[0]
-                        num_current_tokens = request_tracker.token_len
-                        new_token_ids = request.all_token_ids[num_current_tokens : num_current_tokens + num_new_tokens]
-                        request_tracker.token_len += len(new_token_ids)
-                    else:
-                        raise ValueError(
-                            f"Request {req_id} is not in _unfinished_requests, but it is scheduled to be cached"
-                        )
-                    num_computed_token = cached_reqs.num_computed_tokens[i]
-                    if num_computed_token >= len(request.prompt_token_ids):
-                        continue
-                    request_tracker.update(new_block_ids, request.num_computed_tokens)
-
-                    last_chunk_tokens_num = (
-                        self._floor_to_cache_transfer_granularity(len(request.prompt_token_ids))
-                        if self._discard_partial_chunks
-                        else len(request.prompt_token_ids)
-                    )
-                    req_meta = ReqMeta.from_request_tracker(
-                        request_tracker,
-                        self.cache_transfer_granularity,
-                        load_spec=None,
-                        skip_save=force_skip_save,
-                        block_hashes=request.block_hashes,
-                        is_last_chunk=request_tracker.token_len >= last_chunk_tokens_num,
-                        discard_partial_chunks=self._discard_partial_chunks,
-                        original_block_size=self.original_block_size,
-                        kv_cache_group_families=self.kv_cache_group_families,
+                    req_meta = self._process_running_cached_request(
+                        new_block_ids,
+                        req_id,
+                        i,
+                        cached_reqs,
+                        scheduler_output,
+                        force_skip_save,
                     )
                 if req_meta is not None:
                     self.touch_sending_mamba_blocks(req_meta)
@@ -508,37 +945,11 @@ class KVPoolScheduler:
         request_ids = [req.req_id for req in scheduler_output.scheduled_new_reqs]
         for request_id, (request, block_ids) in self._unfinished_requests.items():
             if request_id not in request_ids and request_id not in cached_reqs.req_ids:
-                load_spec = self.load_specs.pop(request_id, None)
-                if not load_spec:
-                    continue
-                num_tokens_to_compute = load_spec.kvpool_cached_tokens
-                if (num_tokens_to_compute % self.cache_transfer_granularity != 0) and (
-                    num_tokens_to_compute == len(request.prompt_token_ids) - 1
-                ):
-                    num_tokens_to_compute = num_tokens_to_compute + 1
-                request_tracker = RequestTracker(
-                    req_id=request_id,
-                    token_len=num_tokens_to_compute,
-                    allocated_block_ids_by_group=block_ids,
-                    num_saved_tokens=0,
-                    mamba_group_ids=self.mamba_group_ids,
-                    num_speculative_blocks=self.num_speculative_blocks,
-                    block_sizes=self.grouped_block_size,
-                )
-
-                self._request_trackers[request_id] = request_tracker
-                req_meta = ReqMeta.from_request_tracker(
-                    request_tracker,
-                    self.cache_transfer_granularity,
-                    load_spec=load_spec,
-                    skip_save=None,
-                    block_hashes=request.block_hashes,
-                    discard_partial_chunks=self._discard_partial_chunks,
-                    kv_cache_group_families=self.kv_cache_group_families,
-                )
+                req_meta = self._process_async_load_request(request_id, request, block_ids)
                 if req_meta is not None:
                     self.touch_sending_mamba_blocks(req_meta)
                     meta.add_request(req_meta)
+
         return meta
 
     def get_sending_event_id(self):
@@ -573,9 +984,9 @@ class KVPoolScheduler:
         hand the connector_output, free non-null mamba blocks and so on.
         """
         meta = connector_output.kv_connector_worker_meta
-        if not isinstance(meta, AscendStoreKVConnectorWorkerMetadata) or self._block_pool is None:
+        if not isinstance(meta, AscendStoreKVConnectorWorkerMetadata):
             return
-
+        to_free_block_ids: list[int] = []
         for event_id, count in meta.completed_events.items():
             logger.debug("event %s update with %s", event_id, count)
             total = self.sending_events.get(event_id, -1)
@@ -584,13 +995,15 @@ class KVPoolScheduler:
                 continue
             total = total + count
             if total >= self._expected_worker_count:
-                to_free_block_ids = self.sending_blocks.pop(event_id, [])
+                to_free_block_ids.extend(self.sending_blocks.pop(event_id, []))
                 self.sending_events.pop(event_id, None)
-                if to_free_block_ids:
-                    logger.debug("event %s free blocks: %s", event_id, to_free_block_ids)
-                    self._block_pool.free_blocks([self._block_pool.blocks[block_id] for block_id in to_free_block_ids])
             else:
                 self.sending_events[event_id] = total
+
+        if to_free_block_ids:
+            logger.debug("free blocks: %s", to_free_block_ids)
+            assert self._block_pool is not None
+            self._block_pool.free_blocks([self._block_pool.blocks[block_id] for block_id in to_free_block_ids])
 
     def request_finished(
         self,
@@ -602,14 +1015,21 @@ class KVPoolScheduler:
         should be freed now or will be sent asynchronously and freed later.
         """
         if self.kv_role == "kv_consumer" and not self.consumer_is_to_put:
+            self._delayed_free_req_ids.discard(request.request_id)
+            return False, None
+        if self.use_layerwise:
+            self._delayed_free_req_ids.discard(request.request_id)
             return False, None
         tracker = self._request_trackers.get(request.request_id)
-        if tracker is not None and tracker.num_saved_tokens <= 0:
+        if tracker is None or tracker.num_saved_tokens <= 0:
+            self._delayed_free_req_ids.discard(request.request_id)
             return False, None
         delay_free_blocks = len(block_ids) > 0
         if delay_free_blocks:
-            if logger.isEnabledFor(10):
-                logger.debug("Delaying free of %d blocks for request %s", len(block_ids), request.request_id)
+            self._delayed_free_req_ids.add(request.request_id)
+            logger.debug("Delaying free of %d blocks for request %s", len(block_ids), request.request_id)
+        else:
+            self._delayed_free_req_ids.discard(request.request_id)
         return delay_free_blocks, None
 
     def request_finished_all_groups(
@@ -619,23 +1039,36 @@ class KVPoolScheduler:
     ) -> tuple[bool, dict[str, Any] | None]:
         """HMA path for hybrid KV cache groups."""
         if self.kv_role == "kv_consumer" and not self.consumer_is_to_put:
+            self._delayed_free_req_ids.discard(request.request_id)
             return False, None
         tracker = self._request_trackers.get(request.request_id)
         if tracker is not None and tracker.num_saved_tokens <= 0:
+            self._delayed_free_req_ids.discard(request.request_id)
             return False, None
         block_ids = cast(tuple[list[int], ...], self.get_sw_clipped_blocks(block_ids))
         valid_group_block_ids = [group_block_ids for group_block_ids in block_ids if group_block_ids]
         delay_free_blocks = bool(valid_group_block_ids)
         if delay_free_blocks:
+            self._delayed_free_req_ids.add(request.request_id)
             logger.debug(
                 "Delaying free of %d KV cache groups for request %s",
                 len(valid_group_block_ids),
                 request.request_id,
             )
+        else:
+            self._delayed_free_req_ids.discard(request.request_id)
         return delay_free_blocks, None
 
     def bind_gpu_block_pool(self, gpu_block_pool: "BlockPool") -> None:
         self._block_pool = gpu_block_pool
+
+    def update_finished_sending(self, finished_sending: set[str] | None) -> None:
+        if finished_sending:
+            self._delayed_free_req_ids.difference_update(finished_sending)
+
+    def update_finished_recving(self, finished_recving: set[str] | None) -> None:
+        if finished_recving:
+            self._loading_req_ids.difference_update(finished_recving)
 
 
 class LookupKeyClient:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -65,6 +65,21 @@ from vllm_ascend.memcache_comm_fence import (
     reset_attention_compute_start_gate,
 )
 
+# Shared per-layer transfer-finished events. Created by the mooncake
+# PD-disaggregation send thread (when it runs) and consumed by the ascend_store
+# save thread to wait for each layer's PD transfer to finish. When mooncake is
+# not running, these stay None and the save thread skips the PD wait.
+_shared_layer_transfer_events: list[threading.Event] | None = None
+
+
+def get_shared_layer_transfer_events() -> list[threading.Event] | None:
+    return _shared_layer_transfer_events
+
+
+def set_shared_layer_transfer_events(events: list[threading.Event] | None) -> None:
+    global _shared_layer_transfer_events
+    _shared_layer_transfer_events = events
+
 
 class KVPoolWorker:
     # The main class for the cache engine.
@@ -264,6 +279,7 @@ class KVPoolWorker:
         self.layer_save_tasks: list[list[LayerTransferTask]] = [[] for i in range(self.num_layers)]
         self.layer_load_finished_events: list[threading.Event] | None = None
         self.layer_save_finished_events: list[threading.Event] | None = None
+        self.layer_transfer_finished_events: list[threading.Event] | None = None
 
         layerwise_config = get_layerwise_config(
             self.num_layers,
@@ -305,6 +321,7 @@ class KVPoolWorker:
                     self.sync_save_events,
                     self.layerwise_max_transfer_blocks,
                     self.layerwise_max_transfer_bytes,
+                    layer_transfer_finished_events=get_shared_layer_transfer_events(),
                 )
                 self.kv_send_thread.start()
                 ready_event_sending.wait()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -4,8 +4,10 @@ import importlib
 import math
 import threading
 from collections.abc import Generator
+from typing import Any
 
 import torch
+from vllm import envs
 from vllm.config import VllmConfig
 from vllm.distributed import (
     get_pcp_group,
@@ -22,44 +24,46 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
+    backend_map,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     AscendConnectorMetadata,
     AscendStoreKVConnectorWorkerMetadata,
     ChunkedTokenDatabase,
     KeyMetadata,
+    LayerBlockRange,
+    LayerLoadTask,
     LayerMultiBlockReqMeta,
+    LayerTransferTask,
     ReqMeta,
     get_block_hashes,
     get_cache_family_granularity,
     infer_group_cache_families,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import (
+    KVCacheStoreKeyLayerRecvingThread,
+    KVCacheStoreKeyLayerSendingThread,
     KVCacheStoreLayerRecvingThread,
     KVCacheStoreLayerSendingThread,
     KVCacheStoreRecvingThread,
     KVCacheStoreSendingThread,
     KVTransferThread,
+    _circular_shift,
     record_failed_blocks,
+)
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_config import (
+    get_layer_load_start_block,
+    get_layerwise_config,
 )
 from vllm_ascend.distributed.utils import (
     get_decode_context_model_parallel_rank,
     get_decode_context_model_parallel_world_size,
 )
-
-backend_map = {
-    "mooncake": {
-        "name": "MooncakeBackend",
-        "path": "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend",
-    },
-    "memcache": {
-        "name": "MemcacheBackend",
-        "path": "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.memcache_backend",
-    },
-    "yuanrong": {
-        "name": "YuanrongBackend",
-        "path": "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.yuanrong_backend",
-    },
-}
+from vllm_ascend.memcache_comm_fence import (
+    get_attention_compute_start_gate,
+    reset_attention_compute_start_gate,
+)
 
 
 class KVPoolWorker:
@@ -68,11 +72,12 @@ class KVPoolWorker:
     def __init__(
         self,
         vllm_config: VllmConfig,
-        use_layerwize: bool,
+        use_layerwise: bool,
         kv_cache_config: KVCacheConfig | None = None,
     ):
         model_config = vllm_config.model_config
         parallel_config = vllm_config.parallel_config
+        extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
         self.kv_cache_config = kv_cache_config
         hf_text_config = getattr(model_config, "hf_text_config", None)
         hf_config = getattr(model_config, "hf_config", hf_text_config)
@@ -82,11 +87,24 @@ class KVPoolWorker:
             self.compress_ratios = getattr(hf_config, "compress_ratios", None)
         self.use_compress = self.compress_ratios is not None
         self.dp_rank = parallel_config.data_parallel_rank
+
+        self._init_parallelism_info(model_config, parallel_config)
+        self._init_kv_transfer_config(vllm_config, extra_config, use_layerwise, kv_cache_config)
+        self._init_key_head_config(model_config, parallel_config)
+        self._init_metadata(model_config, vllm_config, extra_config)
+        self._init_backend(parallel_config, extra_config)
+        self._init_kv_events(vllm_config)
+        self._init_state_vars()
+        self._init_layerwise_config()
+
+    def _init_parallelism_info(self, model_config, parallel_config) -> None:
+        self.local_rank = envs.LOCAL_RANK
+
         self.use_mla = False
         if hasattr(model_config, "use_mla") and isinstance(model_config.use_mla, bool) and model_config.use_mla:
             self.use_mla = True
         self.use_sparse = hasattr(model_config.hf_text_config, "index_topk")
-        self.use_layerwise = use_layerwize
+
         self.tp_rank = get_tensor_model_parallel_rank()
         self.tp_size = get_tensor_model_parallel_world_size()
         self.pp_size = parallel_config.pipeline_parallel_size
@@ -97,14 +115,17 @@ class KVPoolWorker:
         self.dcp_size = get_decode_context_model_parallel_world_size()
         self.dcp_rank = get_decode_context_model_parallel_rank() if self.dcp_size > 1 else 0
 
+    def _init_kv_transfer_config(self, vllm_config, extra_config, use_layerwise, kv_cache_config) -> None:
+        self._extra_config = extra_config
+        self.use_layerwise = use_layerwise
         self.kv_role = vllm_config.kv_transfer_config.kv_role
-        self.load_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get("load_async", False)
+        self.load_async = extra_config.get("load_async", False)
         self._invalid_block_ids: set[int] = set()
         self._invalid_block_ids_lock = threading.Lock()
-        self.consumer_is_to_put = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
-            "consumer_is_to_put", False
-        )
-        self.backend = vllm_config.kv_transfer_config.kv_connector_extra_config.get("backend", "mooncake")
+        self.consumer_is_to_put = extra_config.get("consumer_is_to_put", False)
+        self.backend = extra_config.get("backend", "mooncake")
+        self.backend_name = self.backend.lower()
+        self.use_gva_layerwise = self.use_layerwise and self.backend_name == "memcache"
         self.use_hybrid = self._uses_hybrid_kv_cache(vllm_config, kv_cache_config)
         self.use_mamba = self._uses_mamba_kv_cache(self.use_hybrid, kv_cache_config)
         self.original_block_size = self._infer_group_block_sizes(vllm_config, kv_cache_config)
@@ -126,6 +147,9 @@ class KVPoolWorker:
         self.cache_transfer_granularity = self._infer_cache_transfer_granularity()
         if self.use_layerwise and self.num_kv_cache_groups > 1:
             raise NotImplementedError("AscendStore layerwise mode does not yet support hybrid KV cache groups.")
+        self.h2d_stagger_us = int(extra_config.get("h2d_stagger_us", 0))
+        self.layerwise_max_transfer_blocks = int(extra_config.get("layerwise_max_transfer_blocks", 0))
+        self.layerwise_max_transfer_bytes = int(extra_config.get("layerwise_max_transfer_bytes", 0))
 
         logger.info(
             "use_hybrid: %s, use_mamba: %s, num_kv_cache_groups: %s, hash_block_size: %s, lcm_block_size: %s",
@@ -135,6 +159,8 @@ class KVPoolWorker:
             self.hash_block_size,
             self.lcm_block_size,
         )
+
+    def _init_key_head_config(self, model_config, parallel_config) -> None:
         self.current_layer = 0
         self.num_layers = model_config.get_num_layers(parallel_config)
 
@@ -149,14 +175,19 @@ class KVPoolWorker:
         else:
             self.head_or_tp_rank = self.tp_rank
             self.put_step = 1
+        self.my_key_index = (
+            self.pcp_rank * self.dcp_size * (self.tp_size // self.put_step)
+            + self.dcp_rank * (self.tp_size // self.put_step)
+            + self.head_or_tp_rank
+        )
+        self.num_ranks_per_layer = self.pcp_size * self.dcp_size * (self.tp_size // self.put_step)
 
+    def _init_metadata(self, model_config, vllm_config, extra_config) -> None:
         partitions = None
         if self.kv_role == "kv_consumer" and self.consumer_is_to_put:
             num_hidden_layers = model_config.hf_text_config.num_hidden_layers
-            partition_list_str = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
-                "prefill_pp_layer_partition", None
-            )
-            prefill_pp_size = int(vllm_config.kv_transfer_config.kv_connector_extra_config.get("prefill_pp_size", 1))
+            partition_list_str = extra_config.get("prefill_pp_layer_partition", None)
+            prefill_pp_size = int(extra_config.get("prefill_pp_size", 1))
 
             if partition_list_str is not None:
                 try:
@@ -194,6 +225,7 @@ class KVPoolWorker:
             self.metadata, self.grouped_block_size, partitions, self.use_hybrid, self.hash_block_size
         )
 
+    def _init_backend(self, parallel_config, extra_config) -> None:
         backend = backend_map.get(self.backend.lower())
         assert backend is not None
         backend_path = backend.get("path")
@@ -202,24 +234,166 @@ class KVPoolWorker:
         backend_module = importlib.import_module(backend_path)
         real_backend = getattr(backend_module, backend_name)
 
-        backend_kwargs = {}
-        if self.backend.lower() in {"mooncake", "memcache"}:
-            # DSV4 exposes compress_ratios; only use lazy store init for this
-            # compressed-model path.
-            backend_kwargs["lazy_init"] = self.use_compress
-        self.m_store = real_backend(  # type: ignore[misc]
-            parallel_config,
-            **backend_kwargs,
-        )
+        if self.backend.lower() == "memcache":
+            self.m_store = real_backend(  # type: ignore[misc]
+                parallel_config,
+                lazy_init=True,
+            )
+        else:
+            backend_kwargs = {}
+            if self.backend.lower() == "mooncake":
+                backend_kwargs["lazy_init"] = self.use_compress
+            self.m_store = real_backend(  # type: ignore[misc]
+                parallel_config,
+                **backend_kwargs,
+            )
+
+    def _init_kv_events(self, vllm_config) -> None:
         kv_event_config = vllm_config.kv_events_config
         self.enable_kv_events = False
         if kv_event_config and kv_event_config.enable_kv_cache_events:
             self.enable_kv_events = True
 
+    def _init_state_vars(self) -> None:
         self.kv_send_thread: KVTransferThread | None = None
         self.kv_recv_thread: KVTransferThread | None = None
+        self._transfer_threads_started = False
 
-        self.finished_store_req: set[str] = set()
+    def _init_layerwise_config(self) -> None:
+        self.layer_load_tasks: list[list[LayerTransferTask]] = [[] for i in range(self.num_layers)]
+        self.layer_save_tasks: list[list[LayerTransferTask]] = [[] for i in range(self.num_layers)]
+        self.layer_load_finished_events: list[threading.Event] | None = None
+        self.layer_save_finished_events: list[threading.Event] | None = None
+
+        layerwise_config = get_layerwise_config(
+            self.num_layers,
+            self._extra_config,
+        )
+        self.layerwise_offload = layerwise_config.has_layer_reuse
+        self.num_prefetch_layers = layerwise_config.num_prefetch_layers
+        self.independent_layers = layerwise_config.independent_layers
+        self.prefetch_layer_map = layerwise_config.prefetch_layer_map
+
+        self.next_layer_to_submit = 0
+        self.sync_save_events: list[torch.npu.Event] | None = None
+
+    def _start_kv_transfer_threads(self) -> None:
+        if self._transfer_threads_started:
+            return
+
+        if self.use_layerwise:
+            self.get_event = threading.Event()
+            self.layer_load_finished_events = [threading.Event() for i in range(self.num_layers)]
+            self.layer_save_finished_events = [threading.Event() for i in range(self.num_layers)]
+            self.sync_save_events = [torch.npu.Event() for i in range(self.num_layers)]
+            if self.use_gva_layerwise and self.kv_role in ["kv_producer", "kv_both"]:
+                ready_event_sending = threading.Event()
+                self.kv_send_thread = KVCacheStoreLayerSendingThread(
+                    self.m_store,
+                    self.token_database,
+                    self.block_size,
+                    self.tp_rank,
+                    self.tp_size,
+                    self.dcp_size,
+                    self.put_step,
+                    self.my_key_index,
+                    self.num_ranks_per_layer,
+                    self.page_size_bytes,
+                    ready_event_sending,
+                    self.num_layers,
+                    self.layer_save_finished_events,
+                    self.sync_save_events,
+                    self.layerwise_max_transfer_blocks,
+                    self.layerwise_max_transfer_bytes,
+                )
+                self.kv_send_thread.start()
+                ready_event_sending.wait()
+            elif self.kv_role in ["kv_producer", "kv_both"]:
+                ready_event_sending = threading.Event()
+                self.kv_send_thread = KVCacheStoreKeyLayerSendingThread(
+                    self.m_store,
+                    self.token_database,
+                    self.block_size,
+                    self.tp_rank,
+                    self.tp_size,
+                    self.dcp_size,
+                    self.put_step,
+                    ready_event_sending,
+                    self.num_layers,
+                    self.layer_save_finished_events,
+                    self.sync_save_events,
+                )
+                self.kv_send_thread.start()
+                ready_event_sending.wait()
+            ready_event = threading.Event()
+            if self.use_gva_layerwise:
+                self.kv_recv_thread = KVCacheStoreLayerRecvingThread(
+                    self.m_store,
+                    self.token_database,
+                    self.block_size,
+                    self.tp_rank,
+                    self.tp_size,
+                    self.dcp_size,
+                    self.my_key_index,
+                    self.num_ranks_per_layer,
+                    self.page_size_bytes,
+                    ready_event,
+                    self.get_event,
+                    self.layer_load_finished_events,
+                    self.layer_save_finished_events,
+                    self.num_layers,
+                    self.h2d_stagger_us,
+                    self.layerwise_max_transfer_blocks,
+                    self.layerwise_max_transfer_bytes,
+                )
+            else:
+                self.kv_recv_thread = KVCacheStoreKeyLayerRecvingThread(
+                    self.m_store,
+                    self.token_database,
+                    self.block_size,
+                    self.tp_rank,
+                    self.tp_size,
+                    self.dcp_size,
+                    ready_event,
+                    self.get_event,
+                    self.layer_load_finished_events,
+                    self.layer_save_finished_events,
+                    self.num_layers,
+                )
+            self.kv_recv_thread.start()
+            ready_event.wait()
+        else:
+            if self.kv_role in ["kv_producer", "kv_both"] or self.consumer_is_to_put:
+                ready_event_sending = threading.Event()
+                self.kv_send_thread = KVCacheStoreSendingThread(
+                    self.m_store,
+                    self.token_database,
+                    self.block_size,
+                    self.tp_rank,
+                    self.tp_size,
+                    self.dcp_size,
+                    self.put_step,
+                    self.kv_role,
+                    ready_event_sending,
+                    self.group_uses_align_state,
+                    self.enable_kv_events,
+                )
+                self.kv_send_thread.start()
+                ready_event_sending.wait()
+            if self.load_async:
+                ready_event = threading.Event()
+                self.kv_recv_thread = KVCacheStoreRecvingThread(
+                    self.m_store,
+                    self.token_database,
+                    self.block_size,
+                    self.tp_rank,
+                    self.tp_size,
+                    self.dcp_size,
+                    ready_event,
+                )
+                self.kv_recv_thread.start()
+                ready_event.wait()
+        self._transfer_threads_started = True
 
     def _infer_group_families(self) -> list[str]:
         kv_cache_groups = self.kv_cache_config.kv_cache_groups if self.kv_cache_config is not None else None
@@ -338,25 +512,6 @@ class KVPoolWorker:
         self.group_block_stride[group_id] = group_block_strides
         self.group_num_layers[group_id] = len(layer_names)
 
-    def _align_kv_ptrs(self, registered_regions: dict[int, tuple[int, int]]):
-        """
-        In hybrid scenario, where a KVCacheTensor is shared by multiple layers,
-        but sometimes, layers cannot be evenly distributed among multiple groups,
-        the layers sharing the KVCacheTensor may not completely occupy all the space of the KVCacheTensor.
-        This results in the calculated start address not being the previously aligned address.
-        Therefore, we down-align the start address to meet the 2MB alignment requirement.
-        """
-        if not self.use_hybrid:
-            return
-        alignment = 2 * 1024 * 1024
-        for storage_key in registered_regions:
-            start, end = registered_regions[storage_key]
-            new_start = start // alignment * alignment
-            # Because the addresses of raw tensors are aligned to 2MB,
-            # all shared sub-tensors, when aligned downwards, should theoretically not exceed the address bounds.
-            assert new_start >= storage_key, "invalid kv cache tensor, raw tensor ptr must be align to 2MB"
-            registered_regions[storage_key] = (new_start, end)
-
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         _, first_kv_cache_tuple = next(iter(kv_caches.items()))
         first_kv_cache_tuple = self._as_cache_tuple(first_kv_cache_tuple)
@@ -366,6 +521,14 @@ class KVPoolWorker:
             self.kv_cache_config.num_blocks if self.kv_cache_config is not None else first_kv_cache.shape[0]
         )
         logger.info("num_blocks: %s", self.num_blocks)
+        self.block_len = []
+        self.block_stride = []
+        for cache in first_kv_cache_tuple:
+            block_len, block_stride, _, _ = self._get_cache_block_metadata(cache)
+            logger.info("block_shape: %s", cache.shape[1:])
+            self.block_len.append(block_len)
+            self.block_stride.append(block_stride)
+
         self.group_kv_caches_base_addr: dict[int, list[int]] = {}
         self.group_block_len: dict[int, list[int]] = {}
         self.group_block_stride: dict[int, list[int]] = {}
@@ -383,6 +546,8 @@ class KVPoolWorker:
             first_kv_cache.shape,
         )
 
+        self.kv_caches_base_addr = []
+
         registered_regions: dict[int, tuple[int, int]] = {}
         for cache_or_caches in kv_caches.values():
             for cache in self._as_cache_tuple(cache_or_caches):
@@ -390,6 +555,7 @@ class KVPoolWorker:
                 _, _, region_len, _ = self._get_cache_block_metadata(cache)
                 if not isinstance(region_len, int):
                     region_len = 0
+                self.kv_caches_base_addr.append(base_addr)
                 storage_key = self._get_storage_key(cache)
                 start = base_addr
                 end = base_addr + region_len
@@ -399,7 +565,6 @@ class KVPoolWorker:
                 else:
                     registered_regions[storage_key] = (start, end)
 
-        self._align_kv_ptrs(registered_regions)
         ptrs = [start for start, _ in registered_regions.values()]
         lengths = [end - start for start, end in registered_regions.values()]
 
@@ -409,7 +574,7 @@ class KVPoolWorker:
         else:
             self._infer_cache_group_metadata(0, list(kv_caches.keys()))
 
-        self.m_store.register_buffer(ptrs, lengths)
+        self.page_size_bytes = sum(self.block_len)
         self.token_database.set_group_buffers(
             self.group_kv_caches_base_addr,
             self.group_block_len,
@@ -418,72 +583,25 @@ class KVPoolWorker:
             group_cache_families=self.group_kv_cache_families,
             group_num_layers=self.group_num_layers,
         )
-
-        if self.use_layerwise:
-            self.get_event = threading.Event()
-            if self.kv_role in ["kv_producer", "kv_both"]:
-                ready_event_sending = threading.Event()
-                self.kv_send_thread = KVCacheStoreLayerSendingThread(
-                    self.m_store,
-                    self.token_database,
-                    self.grouped_block_size,
-                    self.tp_rank,
-                    self.dcp_size,
-                    self.put_step,
-                    ready_event_sending,
-                    self.num_layers,
-                    self.enable_kv_events,
-                )
-                self.kv_send_thread.start()
-            ready_event = threading.Event()
-            self.kv_recv_thread = KVCacheStoreLayerRecvingThread(
-                self.m_store,
-                self.token_database,
-                self.grouped_block_size,
-                self.tp_rank,
-                self.dcp_size,
-                ready_event,
-                self.get_event,
-                self._invalid_block_ids,
-                self._invalid_block_ids_lock,
-            )
-            self.kv_recv_thread.start()
-            ready_event.wait()
-        else:
-            if self.kv_role in ["kv_producer", "kv_both"] or self.consumer_is_to_put:
-                ready_event_sending = threading.Event()
-                self.kv_send_thread = KVCacheStoreSendingThread(
-                    self.m_store,
-                    self.token_database,
-                    self.grouped_block_size,
-                    self.tp_rank,
-                    self.dcp_size,
-                    self.put_step,
-                    self.kv_role,
-                    ready_event_sending,
-                    self.group_uses_align_state,
-                    self.enable_kv_events,
-                )
-                self.kv_send_thread.start()
-            if self.load_async:
-                ready_event = threading.Event()
-                self.kv_recv_thread = KVCacheStoreRecvingThread(
-                    self.m_store,
-                    self.token_database,
-                    self.grouped_block_size,
-                    self.tp_rank,
-                    self.dcp_size,
-                    ready_event,
-                    self._invalid_block_ids,
-                    self._invalid_block_ids_lock,
-                )
-                self.kv_recv_thread.start()
-                ready_event.wait()
+        # Initialize store, register buffers, and start transfer threads
+        # directly here (like main) — no separate init_backend handshake.
+        if hasattr(self.m_store, "init_store"):
+            self.m_store.init_store()
+        self.m_store.register_buffer(ptrs, lengths)
+        self._start_kv_transfer_threads()
 
     def start_load_kv(self, metadata: AscendConnectorMetadata):
         self.current_layer = 0
-        self.layerwise_retrievers = []
+        self.layerwise_retrievers: list[Any] = []
+        if self.use_layerwise:
+            self.next_layer_to_submit = 0
+            reset_attention_compute_start_gate()
         logger.debug("KV pool worker start_load_kv requests=%d", len(metadata.requests))
+        if len(metadata.requests) == 0:
+            return
+        if self.use_layerwise:
+            self.process_layer_data(metadata.requests)
+            return
         for request in metadata.requests:
             load_spec = request.load_spec
             if load_spec is None or not load_spec.can_load:  # load =0
@@ -499,10 +617,10 @@ class KVPoolWorker:
             if (load_spec.kvpool_cached_tokens % self.cache_transfer_granularity != 0) and (
                 load_spec.kvpool_cached_tokens == token_len - 1
             ):
-                token_len = request.load_spec.kvpool_cached_tokens + 1
+                token_len = load_spec.kvpool_cached_tokens + 1
             else:
-                token_len = request.load_spec.kvpool_cached_tokens
-            request.load_spec.token_len = token_len
+                token_len = load_spec.kvpool_cached_tokens
+            load_spec.token_len = token_len
             logger.debug(
                 "KV pool worker prepare get req=%s token_len_chunk=%d get_token_len=%d "
                 "vllm_cached=%d kvpool_cached=%d groups=%s load_async=%s",
@@ -514,112 +632,236 @@ class KVPoolWorker:
                 load_group_ids,
                 self.load_async,
             )
-            if self.use_layerwise:
-                layerwise_retriever = self.retrieve_layer(request)
-                next(layerwise_retriever)  # first layer load
-                self.layerwise_retrievers.append(layerwise_retriever)
+            if self.load_async:
+                self.kv_recv_thread.add_request(  # type: ignore[union-attr]
+                    request,
+                )
+                continue
+
+            addr_list = []
+            size_list = []
+            key_list = []
+            block_id_list: list[int] = []
+            for group_id in load_group_ids:
+                block_ids = request.block_ids_by_group[group_id]
+                group_block_size = self.grouped_block_size[group_id]
+                mask_num = load_spec.vllm_cached_tokens // group_block_size * group_block_size
+                skip_null = group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]
+                for start, end, key, _ in self.token_database.process_tokens_with_block_ids(
+                    token_len,
+                    request.block_hashes,
+                    block_ids,
+                    mask_num,
+                    kv_cache_group_id=group_id,
+                    skip_null_blocks=skip_null,
+                ):
+                    addr, size, block_id = self.token_database.prepare_value(
+                        start,
+                        end,
+                        block_ids,
+                        kv_cache_group_id=group_id,
+                    )
+                    key_list.append(key.to_string())
+                    addr_list.append(addr)
+                    size_list.append(size)
+                    block_id_list.append(block_id)
+            if not key_list:
+                continue
+            key_list_c = _circular_shift(key_list, self.tp_rank % len(key_list))
+            addr_list_c = _circular_shift(addr_list, self.tp_rank % len(addr_list))
+            size_list_c = _circular_shift(size_list, self.tp_rank % len(size_list))
+            block_id_list_c = _circular_shift(block_id_list, self.tp_rank % len(block_id_list))
+            ret = self.m_store.get(key_list_c, addr_list_c, size_list_c)
+            if ret is not None and any(r != 0 for r in ret):
+                missing_block_ids = record_failed_blocks(block_id_list_c, ret)
+                self._invalid_block_ids.update(missing_block_ids)
+            elif ret is None:
+                missing_block_ids = record_failed_blocks(block_id_list_c, [1] * len(block_id_list_c))
+                self._invalid_block_ids.update(missing_block_ids)
+
+    def _process_save_for_layer_batch(
+        self,
+        requests: list[ReqMeta],
+        layer_id: int,
+    ) -> None:
+        request_block_ranges = []
+        for request in requests:
+            if request.can_save is None or not request.can_save:
+                continue
+            save_start_block = request.save_start_token // self.block_size
+            save_end_block = request.save_end_token // self.block_size
+            if save_start_block >= save_end_block and request.partial_block_index is None:
+                continue
+            partial_block_index = request.partial_block_index
+            request_block_ranges.append(
+                LayerBlockRange(
+                    request=request,
+                    start_block=save_start_block,
+                    end_block=save_end_block,
+                    partial_block_index=partial_block_index,
+                )
+            )
+        if request_block_ranges:
+            self.layer_save_tasks[layer_id].append(
+                LayerTransferTask(
+                    layer_id=layer_id,
+                    block_ranges=request_block_ranges,
+                )
+            )
+
+    def _process_load_for_layer_batch(
+        self,
+        requests: list[ReqMeta],
+        layer_id: int,
+    ) -> None:
+        request_block_ranges = []
+        for request in requests:
+            if request.load_spec is None or not request.load_spec.can_load:
+                continue
+            cached_tokens = request.load_spec.kvpool_cached_tokens
+            load_start_block = get_layer_load_start_block(
+                layer_id,
+                self.independent_layers,
+                request.load_spec.vllm_cached_tokens,
+                self.block_size,
+                self.layerwise_offload,
+            )
+            cached_full_blocks = cached_tokens // self.block_size
+            full_blocks = min(cached_full_blocks, len(request.block_hashes))
+            needs_last_block_at_boundary = (
+                cached_tokens > 0 and cached_tokens % self.block_size == 0 and full_blocks < cached_full_blocks
+            )
+            if request.last_block_gva is not None and (
+                cached_tokens % self.block_size != 0 or needs_last_block_at_boundary
+            ):
+                partial_block_index = (
+                    cached_full_blocks if cached_tokens % self.block_size != 0 else cached_full_blocks - 1
+                )
             else:
-                if self.load_async:
-                    self.kv_recv_thread.add_request(  # type: ignore[union-attr]
-                        request,
-                    )
-                else:
-                    addr_list = []
-                    size_list = []
-                    key_list = []
-                    block_id_list: list[int] = []
-                    for group_id in load_group_ids:
-                        block_ids = request.block_ids_by_group[group_id]
-                        group_block_size = self.grouped_block_size[group_id]
-                        mask_num = request.load_spec.vllm_cached_tokens // group_block_size * group_block_size
-                        skip_null = (
-                            group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]
-                        )
-                        for start, end, key, _ in self.token_database.process_tokens_with_block_ids(
-                            token_len,
-                            request.block_hashes,
-                            block_ids,
-                            mask_num,
-                            kv_cache_group_id=group_id,
-                            skip_null_blocks=skip_null,
-                        ):
-                            addr, size, block_id = self.token_database.prepare_value(
-                                start,
-                                end,
-                                block_ids,
-                                kv_cache_group_id=group_id,
-                            )
-                            key_list.append(key.to_string())
-                            addr_list.append(addr)
-                            size_list.append(size)
-                            block_id_list.append(block_id)
-                    if not key_list:
-                        continue
-                    key_list_c = key_list[self.tp_rank % len(key_list) :] + key_list[: self.tp_rank % len(key_list)]
-                    addr_list_c = (
-                        addr_list[self.tp_rank % len(addr_list) :] + addr_list[: self.tp_rank % len(addr_list)]
-                    )
-                    size_list_c = (
-                        size_list[self.tp_rank % len(size_list) :] + size_list[: self.tp_rank % len(size_list)]
-                    )
-                    block_id_list_c = (
-                        block_id_list[self.tp_rank % len(block_id_list) :]
-                        + block_id_list[: self.tp_rank % len(block_id_list)]
-                    )
-                    logger.debug(
-                        "KV pool worker calls backend get request=%s token_len=%d groups=%s keys=%d sample_keys=%s",
-                        request.req_id,
-                        token_len,
-                        load_group_ids,
-                        len(key_list_c),
-                        key_list_c[:3],
-                    )
-                    ret = self.m_store.get(key_list_c, addr_list_c, size_list_c)
-                    if ret is not None and any(r != 0 for r in ret):
-                        missing_block_ids = record_failed_blocks(
-                            block_id_list_c,
-                            ret,
-                        )
-                        if len(request.block_ids_by_group) == 1:
-                            self._invalid_block_ids.update(missing_block_ids)
-                        elif missing_block_ids:
-                            logger.error(
-                                "KV load failed for hybrid request %s. "
-                                "Skip invalid-block fallback to avoid scheduler crash. "
-                                "failed_blocks=%s",
-                                request.req_id,
-                                missing_block_ids,
-                            )
-                    elif ret is None:
-                        missing_block_ids = record_failed_blocks(
-                            block_id_list_c,
-                            [1] * len(block_id_list_c),
-                        )
-                        if len(request.block_ids_by_group) == 1:
-                            self._invalid_block_ids.update(missing_block_ids)
-                        elif missing_block_ids:
-                            logger.error(
-                                "KV load failed for hybrid request %s. "
-                                "Skip invalid-block fallback to avoid scheduler crash. "
-                                "failed_blocks=%s",
-                                request.req_id,
-                                missing_block_ids,
-                            )
-                    logger.debug(
-                        "KV pool worker backend get returned request=%s token_len=%d groups=%s keys=%d",
-                        request.req_id,
-                        token_len,
-                        load_group_ids,
-                        len(key_list_c),
-                    )
+                partial_block_index = None
+            if partial_block_index is not None and partial_block_index < load_start_block:
+                partial_block_index = None
+            if load_start_block >= full_blocks and partial_block_index is None:
+                continue
+            request_block_ranges.append(
+                LayerBlockRange(
+                    request=request,
+                    start_block=load_start_block,
+                    end_block=full_blocks,
+                    partial_block_index=partial_block_index,
+                )
+            )
+        if request_block_ranges:
+            self.layer_load_tasks[layer_id].append(
+                LayerTransferTask(
+                    layer_id=layer_id,
+                    block_ranges=request_block_ranges,
+                )
+            )
+
+    def _build_shared_save_data(self) -> None:
+        """Build shared block data once and attach to all layer save tasks.
+
+        For GVA path (KVCacheStoreLayerSendingThread): pre-computes
+        SharedBlockData via LayerBatchBuilder.build_shared().
+
+        For Key path (KVCacheStoreKeyLayerSendingThread): pre-computes
+        cached process_tokens via build_cached_process_tokens().
+        """
+        # Find the first non-empty layer task (all have identical block_ranges)
+        first_task = None
+        for layer_id in range(self.num_layers):
+            if self.layer_save_tasks[layer_id]:
+                first_task = self.layer_save_tasks[layer_id][0]
+                break
+        if first_task is None:
+            return
+
+        if isinstance(self.kv_send_thread, KVCacheStoreLayerSendingThread):
+            shared = self.kv_send_thread.build_shared_data(first_task)
+            if shared is not None:
+                for layer_id in range(self.num_layers):
+                    for task in self.layer_save_tasks[layer_id]:
+                        task.shared_block_data = shared
+        elif isinstance(self.kv_send_thread, KVCacheStoreKeyLayerSendingThread):
+            cached = self.kv_send_thread.build_cached_process_tokens(first_task)
+            if cached is not None:
+                for layer_id in range(self.num_layers):
+                    for task in self.layer_save_tasks[layer_id]:
+                        task.cached_process_tokens = cached
+
+    def _build_shared_load_data(self) -> None:
+        """Build shared block data and attach to layer load tasks.
+
+        Block ranges may differ across layers under layer reuse (independent
+        layers load only the part beyond HBM, shared layers load from block
+        0), so build one SharedBlockData per distinct block-range shape and
+        reuse it, instead of forcing every layer through a single range.
+        """
+        if not isinstance(self.kv_recv_thread, KVCacheStoreLayerRecvingThread):
+            return
+        shared_by_range: dict = {}
+        for layer_id in range(self.num_layers):
+            for task in self.layer_load_tasks[layer_id]:
+                if not task.block_ranges:
+                    continue
+                key = tuple((br.start_block, br.end_block) for br in task.block_ranges)
+                if key not in shared_by_range:
+                    shared_by_range[key] = self.kv_recv_thread.build_shared_data(task)
+                task.shared_block_data = shared_by_range[key]
+
+    def process_layer_data(self, requests: list[ReqMeta]) -> None:
+        if not requests:
+            return
+        for layer_id in range(self.num_layers):
+            self._process_save_for_layer_batch(requests, layer_id)
+        self._build_shared_save_data()
+        for layer_id in range(self.num_layers):
+            self._process_load_for_layer_batch(requests, layer_id)
+        self._build_shared_load_data()
+
+    def _submit_ready_layer_loads(self) -> None:
+        assert self.kv_recv_thread is not None
+        recv_thread = self.kv_recv_thread
+
+        def submit_layer_load(layer_id: int) -> bool:
+            if not self.layer_load_tasks[layer_id]:
+                return False
+            wait_for_save_layer = None
+            attention_start_gate = None
+            if layer_id != self.current_layer:
+                attention_start_gate = get_attention_compute_start_gate()
+            recv_thread.add_request(
+                LayerLoadTask(  # type: ignore[arg-type]
+                    wait_for_save_layer=wait_for_save_layer,
+                    transfer_tasks=self.layer_load_tasks[layer_id],
+                    layer_id=layer_id,
+                    attention_start_gate=attention_start_gate,
+                )
+            )
+            return True
+
+        submit_count = self.num_prefetch_layers if self.current_layer == 0 else 1
+        submitted_layers = 0
+        while submitted_layers < submit_count and self.next_layer_to_submit < self.num_layers:
+            layer_id = self.next_layer_to_submit
+            self.next_layer_to_submit += 1
+            if submit_layer_load(layer_id):
+                submitted_layers += 1
 
     def wait_for_layer_load(self) -> None:
-        for layerwise_retriever in self.layerwise_retrievers:
-            ret_token_mask = next(layerwise_retriever)
-            if self.current_layer == self.num_layers - 1:
-                assert ret_token_mask is not None
-                num_retrieved_tokens = ret_token_mask.sum().item()
-                logger.debug("Retrieved %s tokens", num_retrieved_tokens)
+        assert self.layer_load_finished_events is not None
+        reset_attention_compute_start_gate()
+        self._submit_ready_layer_loads()
+        should_wait = bool(self.layer_load_tasks[self.current_layer])
+        if not should_wait:
+            self.layer_load_finished_events[self.current_layer].clear()
+            return
+        is_finish = self.layer_load_finished_events[self.current_layer].wait(timeout=10)
+        if not is_finish:
+            logger.info("Layerwise %d load wait timed out", self.current_layer)
+        logger.debug(">>>>>>>>>>>>>>>>>>>> clear load layer %d", self.current_layer)
+        self.layer_load_finished_events[self.current_layer].clear()
 
     def get_block_ids_with_load_errors(self) -> set[int]:
         with self._invalid_block_ids_lock:
@@ -628,32 +870,26 @@ class KVPoolWorker:
         return invalid_blocks
 
     def save_kv_layer(self, connector_metadata: AscendConnectorMetadata) -> None:
-        if self.current_layer == 0:
-            self.layerwise_storers = []
-            current_event = None
-            for request in connector_metadata.requests:
-                can_save = request.can_save
-                if can_save is None or not can_save:
-                    continue
-                current_event = torch.npu.Event()
-                current_event.record()
-                break
-            for request in connector_metadata.requests:
-                can_save = request.can_save
-                if can_save is None or not can_save:
-                    continue
+        assert self.sync_save_events is not None
+        assert self.layer_save_finished_events is not None
+        assert self.kv_send_thread is not None
+        send_thread = self.kv_send_thread
+        self.sync_save_events[self.current_layer].record()
+        if self.layer_save_tasks[self.current_layer]:
+            for block_range in self.layer_save_tasks[self.current_layer][0].block_ranges:
+                send_thread.add_stored_request(block_range.request.req_id)
+            send_thread.add_request(self.layer_save_tasks[self.current_layer])  # type: ignore[arg-type]
+        else:
+            self.layer_save_finished_events[self.current_layer].set()
+        if self.current_layer == self.num_layers - 1:
+            is_finish = self.layer_save_finished_events[self.num_layers - 1].wait(timeout=10)
+            if not is_finish:
+                logger.info("Layerwise %d save wait timed out", self.current_layer)
+            for layer_id in range(self.num_layers):
+                if self.layer_save_finished_events[layer_id].is_set():
+                    logger.debug(">>>>>>>>>>>>>>>>>>>> clear save layer %d", layer_id)
+                    self.layer_save_finished_events[layer_id].clear()
 
-                request.current_event = current_event
-                self.kv_send_thread.add_stored_request(  # type: ignore[union-attr]
-                    request.req_id
-                )
-                layerwise_storer = self.store_layer(request, current_event)
-                self.layerwise_storers.append(layerwise_storer)
-        for layerwise_storer in self.layerwise_storers:
-            try:
-                next(layerwise_storer)
-            except Exception:
-                raise
         self.current_layer = self.current_layer + 1
 
     def wait_for_save(self, connector_metadata: AscendConnectorMetadata):
@@ -827,21 +1063,27 @@ class KVPoolWorker:
                 yield
 
     def get_finished(self, finished_req_ids: set[str], meta: AscendConnectorMetadata) -> tuple[set[str], set[str]]:
-        done_sending = (
-            self.get_and_clear_finished_requests(
-                finished_req_ids,
-                meta,  # type: ignore[union-attr]
-            )
-            if self.kv_role in ["kv_producer", "kv_both"] or self.consumer_is_to_put
-            else set()
-        )
+        if self.kv_send_thread is not None:
+            send_thread = self.kv_send_thread
+            for req_id in meta.preempted_req_ids:
+                if isinstance(send_thread, (KVCacheStoreSendingThread, KVCacheStoreLayerSendingThread)):
+                    send_thread.delete_finished_stored_request(req_id)
+            self.kv_send_thread.discard_finished_requests(meta.preempted_req_ids)
+            if self.use_layerwise:
+                self.kv_send_thread.get_and_clear_finished_requests()
+                done_sending = set()
+            else:
+                stale_finished_req_ids = finished_req_ids - meta.delayed_free_req_ids
+                self.kv_send_thread.discard_finished_requests(stale_finished_req_ids)
+                done_sending = self.kv_send_thread.get_and_clear_finished_requests(meta.delayed_free_req_ids)
+        else:
+            done_sending = set()
 
-        done_recving = (
-            self.kv_recv_thread.get_and_clear_finished_requests(  # type: ignore[union-attr]
-            )
-            if self.load_async
-            else set()
-        )
+        done_recving = set()
+        if self.kv_recv_thread is not None:
+            self.kv_recv_thread.discard_finished_requests(meta.preempted_req_ids)
+            if self.load_async:
+                done_recving = self.kv_recv_thread.get_and_clear_finished_requests(meta.loading_req_ids)
 
         logger.debug(
             "Number of completed KV cache send requests: %d, receive requests: %d, tp_rank:%d",
@@ -850,41 +1092,6 @@ class KVPoolWorker:
             self.tp_rank,
         )
         return done_sending, done_recving
-
-    def get_and_clear_finished_requests(self, finished_req_ids, meta: AscendConnectorMetadata) -> set[str]:
-        finished_sending = set()
-        for req_id in meta.preempted_req_ids:
-            self.kv_send_thread.delete_finished_stored_request(  # type: ignore[union-attr]
-                req_id
-            )
-        for req_id in self.kv_send_thread.stored_requests.copy(  # type: ignore[union-attr]
-        ):
-            if (
-                self.kv_send_thread.stored_requests[  # type: ignore[union-attr]
-                    req_id
-                ]
-                == 0
-                and req_id in self.finished_store_req
-            ):
-                self.finished_store_req.remove(req_id)
-                finished_sending.add(req_id)
-                self.kv_send_thread.delete_finished_stored_request(  # type: ignore[union-attr]
-                    req_id
-                )
-
-        for req_id in finished_req_ids:
-            req_remain_jobs = self.kv_send_thread.stored_requests.get(  # type: ignore[union-attr]
-                req_id
-            )
-            if req_remain_jobs == 0:
-                finished_sending.add(req_id)
-                self.kv_send_thread.delete_finished_stored_request(  # type: ignore[union-attr]
-                    req_id
-                )
-            elif req_remain_jobs is not None:
-                self.finished_store_req.add(req_id)
-
-        return finished_sending
 
     def lookup(
         self,

--- a/vllm_ascend/memcache_comm_fence.py
+++ b/vllm_ascend/memcache_comm_fence.py
@@ -1,0 +1,91 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import threading
+
+import torch
+
+_lock = threading.RLock()
+_attention_compute_start_gate: AttentionComputeStartGate | None = None
+
+
+class AttentionComputeStartGate:
+    """Gate that opens when the compute stream reaches attention.
+
+    The attention worker records an NPU event immediately before submitting the
+    attention op. MemCache worker threads wait for that event to complete before
+    submitting H2D/L2G work, so transfer starts when the compute stream is
+    actually at the attention boundary rather than merely after the Python call
+    site was reached.
+    """
+
+    def __init__(self) -> None:
+        self._condition = threading.Condition()
+        self._event: torch.npu.Event | None = None
+
+    def record(
+        self,
+        stream: torch.npu.Stream | None = None,
+    ) -> None:
+        stream = stream or torch.npu.current_stream()
+        event = torch.npu.Event()
+        event.record(stream)
+        with self._condition:
+            if self._event is None:
+                self._event = event
+                self._condition.notify_all()
+
+    def wait(self, timeout: float = 10.0) -> bool:
+        with self._condition:
+            while self._event is None:
+                if not self._condition.wait(timeout=timeout):
+                    return False
+            event = self._event
+
+        event.synchronize()
+        return True
+
+
+def reset_attention_compute_start_gate() -> AttentionComputeStartGate:
+    """Create a new per-layer gate for MemCache work.
+
+    Layerwise prefetch tasks keep a reference to the gate that was current when
+    they were submitted. The attention path opens that same gate when attention
+    compute is about to be launched.
+    """
+    global _attention_compute_start_gate
+    gate = AttentionComputeStartGate()
+    with _lock:
+        _attention_compute_start_gate = gate
+    return gate
+
+
+def get_attention_compute_start_gate() -> AttentionComputeStartGate:
+    with _lock:
+        gate = _attention_compute_start_gate
+    if gate is None:
+        gate = reset_attention_compute_start_gate()
+    return gate
+
+
+def record_attention_compute_start() -> None:
+    """Record the compute-stream boundary immediately before attention."""
+    with _lock:
+        gate = _attention_compute_start_gate
+    if gate is not None:
+        gate.record()

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -69,6 +69,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
+    KVCacheTensor,
     MambaSpec,
     UniformTypeKVCacheSpecs,
 )
@@ -118,6 +119,10 @@ from vllm_ascend.compilation.acl_graph import (
     set_draft_graph_params,
     set_graph_params,
     update_full_graph_params,
+)
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_config import (
+    get_layerwise_kv_cache_reuse_layers,
+    get_layerwise_storage_indices,
 )
 from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
 from vllm_ascend.eplb.core.eplb_device_transfer_loader import D2DExpertWeightLoader
@@ -3825,6 +3830,56 @@ class NPUModelRunner(GPUModelRunner):
 
         self.debugger.step(**kwargs)
 
+    def _merge_kv_cache_tensors_for_layer_reuse(self, kv_cache_config: KVCacheConfig) -> None:
+        """Merge KV cache tensor entries so that reused layers share one buffer.
+
+        ``determine_available_memory`` already inflated ``num_blocks`` to account
+        for the reduced tensor count.  Here we merge the per-layer
+        ``KVCacheTensor`` entries into fewer shared entries (each with multiple
+        layer names in ``shared_by``).  vLLM's native
+        ``_allocate_kv_cache_tensors`` then allocates one buffer per merged
+        entry and maps every layer in ``shared_by`` to it.
+        """
+        extra_config = self.vllm_config.kv_transfer_config.kv_connector_extra_config
+        total_layers = self.model_config.get_num_layers(self.parallel_config)
+        if get_layerwise_kv_cache_reuse_layers(total_layers, extra_config) is None:
+            return
+
+        old_tensors = kv_cache_config.kv_cache_tensors
+        if len(old_tensors) <= 1:
+            return
+
+        # Ordered layer names (flattened from shared_by).
+        layer_names: list[str] = []
+        for t in old_tensors:
+            layer_names.extend(t.shared_by)
+        if len(layer_names) != total_layers:
+            logger.warning(
+                "Layer reuse: expected %d layers, got %d; skipping tensor merge.",
+                total_layers,
+                len(old_tensors),
+            )
+            return
+
+        storage_indices = get_layerwise_storage_indices(total_layers, extra_config)
+
+        # Build merged tensors: each slot's layers share ONE buffer.
+        # Each buffer's size stays the same as a single layer's (time-multiplexed).
+        new_tensors: list[KVCacheTensor] = []
+        for slot in storage_indices:
+            slot_names = [layer_names[idx] for idx in slot]
+            # All layers in a slot share one buffer; size = first member's size.
+            slot_size = old_tensors[slot[0]].size
+            new_tensors.append(KVCacheTensor(shared_by=slot_names, size=slot_size))
+
+        kv_cache_config.kv_cache_tensors = new_tensors
+        logger.info(
+            "Layerwise KV cache reuse: merged %d tensors → %d (num_blocks=%d unchanged)",
+            len(old_tensors),
+            len(new_tensors),
+            kv_cache_config.num_blocks,
+        )
+
     def initialize_kv_cache(
         self,
         kv_cache_config: KVCacheConfig,
@@ -3841,6 +3896,7 @@ class NPUModelRunner(GPUModelRunner):
         self._mamba_bufs = None
         self._mamba_copy_bufs = None
         self.may_add_encoder_only_layers_to_kv_cache_config()
+        self._merge_kv_cache_tensors_for_layer_reuse(kv_cache_config)
         self.maybe_add_kv_sharing_layers_to_kv_cache_groups(kv_cache_config)
         # NOTE(cmq): initialize_attn_backend must before using self.attn_groups
         self.initialize_attn_backend(kv_cache_config, is_profiling=is_profiling)
@@ -4083,6 +4139,11 @@ class NPUModelRunner(GPUModelRunner):
         # the same tensor format must be maintained even if some layers
         # have only linear or attention layers, for example, the mtp layer.
         self.hybrid_with_attn_and_mamba = False
+        extra_config = self.vllm_config.kv_transfer_config.kv_connector_extra_config
+        reuse_layers = get_layerwise_kv_cache_reuse_layers(
+            self.model_config.get_num_layers(self.parallel_config),
+            extra_config,
+        )
         for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
             use_mamba, use_attn = False, False
             for layer_name in kv_cache_tensor.shared_by:
@@ -4090,6 +4151,11 @@ class NPUModelRunner(GPUModelRunner):
                     use_mamba = True
                 if isinstance(layer_kv_cache_spec[layer_name], AttentionSpec):
                     use_attn = True
+            if use_mamba and use_attn and reuse_layers is not None:
+                raise ValueError(
+                    "Layerwise KV cache reuse is not supported for "
+                    "hybrid attention+mamba KV cache tensors."
+                )
             self.hybrid_with_attn_and_mamba = self.hybrid_with_attn_and_mamba or (use_mamba and use_attn)
             for idx in range(len(kv_cache_tensor.shared_by)):
                 layer_name = kv_cache_tensor.shared_by[idx]

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3840,7 +3840,10 @@ class NPUModelRunner(GPUModelRunner):
         ``_allocate_kv_cache_tensors`` then allocates one buffer per merged
         entry and maps every layer in ``shared_by`` to it.
         """
-        extra_config = self.vllm_config.kv_transfer_config.kv_connector_extra_config
+        kv_transfer_config = self.vllm_config.kv_transfer_config
+        if kv_transfer_config is None:
+            return
+        extra_config = kv_transfer_config.kv_connector_extra_config
         total_layers = self.model_config.get_num_layers(self.parallel_config)
         if get_layerwise_kv_cache_reuse_layers(total_layers, extra_config) is None:
             return
@@ -4139,7 +4142,12 @@ class NPUModelRunner(GPUModelRunner):
         # the same tensor format must be maintained even if some layers
         # have only linear or attention layers, for example, the mtp layer.
         self.hybrid_with_attn_and_mamba = False
-        extra_config = self.vllm_config.kv_transfer_config.kv_connector_extra_config
+        kv_transfer_config = self.vllm_config.kv_transfer_config
+        extra_config = (
+            kv_transfer_config.kv_connector_extra_config
+            if kv_transfer_config is not None
+            else None
+        )
         reuse_layers = get_layerwise_kv_cache_reuse_layers(
             self.model_config.get_num_layers(self.parallel_config),
             extra_config,

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -611,7 +611,10 @@ class NPUWorker(WorkerBase):
         # that vLLM's get_kv_cache_configs() naturally calculates more
         # num_blocks.  The actual tensor allocation (in the model runner) will
         # create fewer shared buffers, so total memory usage stays the same.
-        extra_config = self.vllm_config.kv_transfer_config.kv_connector_extra_config
+        kv_transfer_config = self.vllm_config.kv_transfer_config
+        if kv_transfer_config is None:
+            return available
+        extra_config = kv_transfer_config.kv_connector_extra_config
         total_layers = self.model_config.get_num_layers(self.parallel_config)
         num_tensors = get_layerwise_kv_cache_num_tensors(total_layers, extra_config)
         if num_tensors is not None and num_tensors < total_layers:

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -60,6 +60,9 @@ from vllm_ascend.batch_invariant import init_batch_invariance
 from vllm_ascend.cpu_binding import bind_cpus
 from vllm_ascend.device_allocator.camem import CaMemAllocator
 from vllm_ascend.device_allocator.sleep_mem_optimized import SleepWakeupManager
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_config import (
+    get_layerwise_kv_cache_num_tensors,
+)
 from vllm_ascend.distributed.parallel_state import init_ascend_model_parallel
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
 from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
@@ -602,7 +605,26 @@ class NPUWorker(WorkerBase):
                     suggested_util,
                 )
 
-        return int(self.available_kv_cache_memory_bytes)
+        available = int(self.available_kv_cache_memory_bytes)
+
+        # Layerwise KV cache reuse: inflate the reported available memory so
+        # that vLLM's get_kv_cache_configs() naturally calculates more
+        # num_blocks.  The actual tensor allocation (in the model runner) will
+        # create fewer shared buffers, so total memory usage stays the same.
+        extra_config = self.vllm_config.kv_transfer_config.kv_connector_extra_config
+        total_layers = self.model_config.get_num_layers(self.parallel_config)
+        num_tensors = get_layerwise_kv_cache_num_tensors(total_layers, extra_config)
+        if num_tensors is not None and num_tensors < total_layers:
+            factor = total_layers / num_tensors
+            available = int(available * factor)
+            logger.info(
+                "Layerwise KV cache reuse: inflating available memory by %.2fx (%d layers -> %d buffers)",
+                factor,
+                total_layers,
+                num_tensors,
+            )
+
+        return available
 
     def profile_memory(self) -> None:
         """Profiles the torch reserved memory, torch allocated memory in execute_model()."""


### PR DESCRIPTION
  # Background

  This feature targets PD-disaggregated (prefill/decode separated) deployments. On the prefill node, long-context prefill is the bottleneck: it is slow and memory-hungry, and each layer's KV cache is computed and used only once per iteration, yet it holds a dedicated HBM buffer for the entire run. At the same time, the KV produced by every layer must
  be shipped to the decode node so decode can pick up seamlessly.

  Today, the prefill node allocates a full buffer for every layer.

 # What this PR does

  This PR adds layer reuse to the layerwise KV pool (from #10077), on the prefill (P) node only. Instead of each layer owning its KV buffer, layers time-share a small set of shared HBM buffers. A 78-layer model can run on just 4 buffers. The lifecycle:

  - Before a layer runs, its KV is loaded from the pool into a shared buffer (overlapped with the previous layer's compute).
  - After the layer computes, its freshly produced KV is incrementally saved back to the pool, freeing the buffer for reuse.
  - When chunked prefill returns to a layer whose turn already passed, its prior KV is no longer in a buffer (the shared slot was overwritten by other layers), so it is reloaded from the pool. Results stay bit-for-bit identical — only where the KV lives changes, not its contents.

  Works alongside the existing layerwise mooncake connector

  This feature is designed to be used alongside the existing layerwise mooncake connector (also from #10077), which streams each layer's KV to the decode (D) node as soon as it is produced. In a PD deployment the two can run side by side on P:

  - the ascend_store pool reuses buffers to minimize P-node HBM,
  - the mooncake connector ships each layer's KV out while it is still live.

  Since reuse overwrites the shared buffers, it could race an in-flight PD transfer without coordination. So this PR adds a per-layer handshake: the pool will not overwrite a shared buffer until mooncake confirms it has delivered that layer's KV to D — so reuse never breaks an ongoing PD transfer.

#  Why it helps

  - Lower P-node HBM footprint — buffer count drops from num_layers to a configurable few, freeing memory for larger KV caches and bigger prefill batches.
  - Overlapped data movement — pool load/save is hidden behind prefill compute, so reuse costs no throughput.
  - No precision loss — KV is preserved across chunks; only its location changes.

# Usage

  Layer reuse is off by default and enabled through kv_connector_extra_config (no environment variables):

  {
    "layerwise_num_shared_buffers": 4,
    "layerwise_prefetch_layers": "...",
    "layerwise_independent_layers": "..."
  }

  Decode cache saving is also off by default (save_decode_cache=False); chunked-prefill save is always on.

Note: layer reuse applies only to the prefill (P) node. For PD deployments, pair it with the existing layerwise mooncake connector to carry the reused KV to the decode node.

# Implementation
  
  Layer reuse is built on top of the layerwise KV pool (#10077): multiple layers time-multiplex a single shared transfer buffer, lowering HBM footprint. To keep vLLM's block accounting whole, the reported available memory is inflated by total_layers / reuse_layers, so vLLM still sizes num_blocks for the full layer count; the model runner then merges
  the per-layer KVCacheTensor entries into those shared buffers (shared_by).

  - layerwise_config.py — parse num_shared_buffers / prefetch_layers / independent_layers from kv_connector_extra_config and compute the shared storage slot layout (get_layerwise_storage_indices).
  - worker.py — inflate the reported available memory by total_layers / reuse_layers so vLLM sizes num_blocks for the full layer count.
  - model_runner_v1.py — merge per-layer KVCacheTensor entries into the shared buffers, and reject hybrid attention+mamba reuse.
  - pool_worker / pool_scheduler — drive prefetch and offload from the parsed LayerwiseConfig.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
