### PR TITLE
[Doc][Misc] correct errors in docs

### DIFF
--- a/docs/source/developer_guide/performance_and_debug/optimization_and_tuning.md
+++ b/docs/source/developer_guide/performance_and_debug/optimization_and_tuning.md
@@ -1,6 +1,6 @@
 # Optimization and Tuning
 
-This guide aims to help users improve vLLM-Ascend performance at the system level. It includes OS configuration, library optimization, deployment guide, and so on. Any feedback is welcome.
+This guide aims to help users improve vLLM Ascend performance at the system level. It includes OS configuration, library optimization, deployment guide, and so on. Any feedback is welcome.
 
 ## Preparation
 
@@ -46,7 +46,7 @@ echo "deb-src https://mirrors.tuna.tsinghua.edu.cn/ubuntu-ports/ jammy-security 
 apt update && apt install wget gcc g++ libnuma-dev git vim -y
 ```
 
-Install vllm and vllm-ascend:
+Install vLLM and vLLM Ascend:
 
 ```{code-block} bash
    :substitutions:
@@ -58,10 +58,10 @@ pip install modelscope pandas datasets gevent sacrebleu rouge_score pybind11 pyt
 export VLLM_USE_MODELSCOPE=True
 ```
 
-Please follow the [Installation Guide](https://docs.vllm.ai/projects/ascend/en/latest/installation.html) to make sure vLLM and vllm-ascend are installed correctly.
+Please follow the [Installation Guide](https://docs.vllm.ai/projects/ascend/en/latest/installation.html) to make sure vLLM and vLLM Ascend are installed correctly.
 
 :::{note}
-Make sure your vLLM and vllm-ascend are installed after your Python configuration is completed, because these packages will build binary files using python in current environment. If you install vLLM and vllm-ascend before completing section 1.1, the binary files will not use the optimized python.
+Make sure your vLLM and vLLM Ascend are installed after your Python configuration is completed, because these packages will build binary files using python in current environment. If you install vLLM and vLLM Ascend before completing section 1.1, the binary files will not use the optimized python.
 :::
 
 ## Optimizations

--- a/docs/source/tutorials/models/GLM4.x.md
+++ b/docs/source/tutorials/models/GLM4.x.md
@@ -161,7 +161,7 @@ vllm serve Eco-Tech/GLM-4.7-W8A8-floatmtp \
   --gpu-memory-utilization 0.9 \
   --speculative-config '{"num_speculative_tokens": 3, "method":"mtp"}' \
   --compilation-config '{"cudagraph_capture_sizes": [1,2,4,8,16,32,64,128,256,512], "cudagraph_mode": "FULL_DECODE_ONLY"}' \
-  --additional-config '{"enable_shared_expert_dp": true, "ascend_fusion_config": {"fusion_ops_gmmswigluquant": false}}'\
+  --additional-config '{"enable_shared_expert_dp": true, "ascend_fusion_config": {"fusion_ops_gmmswigluquant": false}}'
 ```
 
 **Notice:**
@@ -578,7 +578,7 @@ Before you start, please
                                 "tp_size": 4
                         }
                 }
-            }' \
+            }'
         ```
 
     4. Decode node 1
@@ -648,7 +648,7 @@ Before you start, please
                                 "tp_size": 4
                         }
                 }
-            }' \
+            }'
         ```
 
 Once the preparation is done, you can start the server with the following command on each node:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR corrects several errors in the documentation to ensure accuracy and prevent execution failures. Key changes include:

Fixing trailing backslashes in shell command examples that would cause syntax errors when copy-pasted.
Correcting the master node IP variable in the multi-node disaggregated prefill-decode deployment example.
Standardizing the capitalization of "vLLM-Ascend" for consistency.
ps:
Synchronize the main PR: https://github.com/vllm-project/vllm-ascend/pull/8923

### Does this PR introduce _any_ user-facing change?
No, these are documentation-only updates.

### How was this patch tested?
Documentation changes only.

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
