### PR TITLE
[CI] Remove the validation of the nightly precision test case limit

### DIFF
--- a/tools/aisbench.py
+++ b/tools/aisbench.py
@@ -243,7 +243,7 @@ class AisbenchRunner:
         acc_value = self.result
         lower_bound = self.baseline - self.threshold
         assert acc_value >= lower_bound, (
-            f"Accuracy verification failed. "
+            "Accuracy verification failed. "
             f"The accuracy of {self.dataset_path} is {acc_value}, "
             f"which is below the minimum acceptable value {lower_bound}."
         )

--- a/tools/aisbench.py
+++ b/tools/aisbench.py
@@ -241,10 +241,11 @@ class AisbenchRunner:
     def _accuracy_verify(self):
         self._get_result_accuracy()
         acc_value = self.result
-        assert self.baseline - self.threshold <= acc_value <= self.baseline + self.threshold, (
-            "Accuracy verification failed. "
+        lower_bound = self.baseline - self.threshold
+        assert acc_value >= lower_bound, (
+            f"Accuracy verification failed. "
             f"The accuracy of {self.dataset_path} is {acc_value}, "
-            f"which is not within {self.threshold} relative to baseline {self.baseline}."
+            f"which is below the minimum acceptable value {lower_bound}."
         )
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR removes the upper-bound validation for the nightly precision test cases in `tools/aisbench.py`. Previously, the accuracy verification asserted that the accuracy value was within a threshold relative to the baseline (both lower and upper bounds). This PR changes the assertion to only verify that the accuracy is greater than or equal to the minimum acceptable value (lower bound), allowing higher accuracy values without failing the test.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested via existing CI workflows.


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
