### PR TITLE
Fix MTP DSA graph capture metadata

### DIFF
--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -554,6 +554,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 slot_mapping=self.runner.input_batch.block_table[0].slot_mapping.gpu,
                 slot_mapping_cpu=self.runner.input_batch.block_table[0].slot_mapping.cpu,
                 positions=self.runner.positions,
+                positions_cpu=(
+                    self.runner._dsa_positions_cpu_buf
+                    if getattr(self.runner, "use_compress", False)
+                    else None
+                ),
                 attn_state=self.runner.attn_state,
                 decode_token_per_req=self.runner.decode_token_per_req,
                 max_seq_len=0,


### PR DESCRIPTION
Superseded by #10763, opened from a clean branch name without automation labels.

Original body:

## Summary

Pass `positions_cpu` when building draft-model attention metadata for full graph capture.

## Root cause

When MTP speculative decoding captures FULL decode graphs with DSA compressed attention enabled, the drafter dummy-run path builds an `AscendCommonAttentionMetadata` with `positions` but without `positions_cpu`. The DSA-CP metadata builder later indexes `common_attn_metadata.positions_cpu`, which causes graph capture to fail with `TypeError: 'NoneType' object is not subscriptable`.

## Fix

Reuse the runner's `_dsa_positions_cpu_buf` for compressed-attention graph capture metadata, matching the main runner metadata path. Non-compressed paths keep `positions_cpu=None`.

## Validation

- `python -m py_compile vllm_ascend/spec_decode/llm_base_proposer.py`
- Reproduced the original failure with DeepSeek-V4-Flash w8a8 MTP on Ascend; after the fix, `Capturing CUDA graphs (decode, FULL)` completed `8/8`, the server logged `Application startup complete`, and `GET /v1/models` returned the served `dsv4` model.