### PR TITLE
[BugFix] Fix MTP DSA graph capture metadata

### DIFF
--- a/vllm_ascend/attention/abstract.py
+++ b/vllm_ascend/attention/abstract.py
@@ -16,6 +16,18 @@ T = TypeVar("T", bound=AttentionMetadata)
 
 
 class DSAAttentionImpl(AttentionImpl[T], Generic[T]):
+    @staticmethod
+    def update_graph_params(
+        update_stream,
+        forward_context,
+        num_tokens,
+        vllm_config=None,
+        speculative_config=None,
+        num_dcp_pcp_tokens=None,
+        draft_attn_metadatas=None,
+    ):
+        pass
+
     @abstractmethod
     def __init__(
         self,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1258,6 +1258,14 @@ class NPUModelRunner(GPUModelRunner):
         if self._needs_seq_lens_cpu_sync and async_spec_decode_active:
             self._correct_optimistic_seq_lens_cpu(num_reqs)
 
+        if self.use_compress:
+            dsa_base_tokens = (
+                base_num_computed_tokens_np
+                if base_num_computed_tokens_np is not None
+                else self.input_batch.num_computed_tokens_cpu[:num_reqs]
+            )
+            self._dsa_num_computed_tokens_for_positions_np = dsa_base_tokens.copy()
+
         # For non-PCP, compute slot_mapping on GPU. PCP slot_mapping was
         # already computed on GPU before PCP split the positions.
         if self.pcp_size <= 1:
@@ -2042,6 +2050,13 @@ class NPUModelRunner(GPUModelRunner):
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
         with record_function_or_nullcontext("prepare input"):
             with self.synchronize_input_prep():
+                if self.use_async_scheduling and self.use_compress:
+                    # DSA CP graph capture reuses input/attention metadata
+                    # buffers by address. Some DSA graph work may outlive the
+                    # Python current stream, so wait on the device before
+                    # _prepare_inputs overwrites them for the next async step.
+                    torch.npu.synchronize()
+
                 # Fix up prev_req_id_to_index for requests that were discarded
                 # in the previous sample_tokens step. If a request has
                 # prev_num_draft_len > 0 but is missing from
@@ -2219,9 +2234,13 @@ class NPUModelRunner(GPUModelRunner):
                         deferred_state_corrections_fn = None
                     num_reqs = self.input_batch.num_reqs
                     req_indices = np.repeat(self.arange_np[:num_reqs], num_scheduled_tokens_np)
+                    dsa_base_tokens = getattr(
+                        self, "_dsa_num_computed_tokens_for_positions_np", None)
+                    if dsa_base_tokens is None or dsa_base_tokens.shape[0] < num_reqs:
+                        dsa_base_tokens = self.input_batch.num_computed_tokens_cpu
                     dsa_positions_np = self._dsa_positions_np_buf[:total_num_scheduled_tokens]
                     np.add(
-                        self.input_batch.num_computed_tokens_cpu[req_indices],
+                        dsa_base_tokens[req_indices],
                         self.query_pos.np[:total_num_scheduled_tokens],
                         out=dsa_positions_np,
                     )


### PR DESCRIPTION
## Summary

Fix MTP speculative decoding with DSA compressed attention when FULL decode graph capture is enabled.

## Root cause

When MTP speculative decoding captures FULL decode graphs with DSA compressed attention enabled, the drafter dummy-run path builds an `AscendCommonAttentionMetadata` with `positions` but without `positions_cpu`. The DSA-CP metadata builder later indexes `common_attn_metadata.positions_cpu`, which causes graph capture to fail with `TypeError: 'NoneType' object is not subscriptable`.

After startup succeeds, the first request replays the draft ACL graph and updates graph params through `update_full_graph_params()`. DSA/DSA-CP attention does not register mutable attention graph params, but the common graph-update path still calls `impl_cls.update_graph_params()`. Since `AscendDSACPImpl` inherited no such method, request-time graph replay failed with `AttributeError: type object 'AscendDSACPImpl' has no attribute 'update_graph_params'`.

These paths are only exercised when the speculative drafter is allowed to use graph capture. Deployments that set `"enforce_eager": true` in `--speculative-config` bypass this path because `AscendSpecDecodeBaseProposer.use_cuda_graph` becomes false.

## Fix

- Reuse the runner's `_dsa_positions_cpu_buf` for compressed-attention graph capture metadata, matching the main runner metadata path. Non-compressed paths keep `positions_cpu=None`.
- Add a no-op `update_graph_params()` to `DSAAttentionImpl`, matching DSA's lack of registered mutable graph attention params and covering both regular DSA and DSA-CP implementations.

## Validation

- `python -m py_compile vllm_ascend/spec_decode/llm_base_proposer.py vllm_ascend/attention/abstract.py`
- Reproduced the startup failure with DeepSeek-V4-Flash w8a8 MTP on Ascend using MTP graph capture enabled; after the metadata fix, `Capturing CUDA graphs (decode, FULL)` completed `8/8`, the server logged `Application startup complete`, and `GET /v1/models` returned the served model.
- Reproduced the request-time failure on `/v1/chat/completions` after startup; after adding the DSA graph-update no-op, two chat completion requests returned `200 OK` while the worker logged `Replaying aclgraph` without `AttributeError` or worker failure.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
