### PR TITLE
[CI] Delete `pull_request` for pr create bot

### DIFF
--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -19,7 +19,6 @@ name: PR Create
 
 on:
   pull_request_target:
-  pull_request:
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
Delete the wrong `pull_request` trigger for pr bot ci
- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
