### PR TITLE
[BugFix] Pad seq_lens/block_table to fix FIA error 561002 with flashcomm1

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -312,6 +312,37 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
         # TODO: Yet another unnecessary H2D while we already have a query_start_loc on device
         query_start_loc = query_start_loc_cpu.pin_memory().to(self.device, non_blocking=True)
 
+        actual_seq_lengths_q = query_start_loc_cpu[1:].tolist()
+        seq_lens_list = seq_lens.tolist()
+        # flashcomm1/SP (or cudagraph) padding makes the model runner insert a
+        # dummy padding request into query_start_loc to satisfy the FIA TND-layout
+        # constraint (sum of q lengths == hidden_states.shape[0]), bumping the
+        # q-derived batchSize by one. The query_start_loc buffer is sized
+        # `max_num_reqs + 2` to hold it, but the seq_lens and block_table buffers
+        # are only `max_num_reqs`, so when the batch is full the padded request
+        # overflows and `[:num_reqs_padded]` silently truncates them. FIA then
+        # fails (error 561002) checking, in order, the `actualSeqLengthsKv` length
+        # and then the block_table row count against batchSize. Pad them to match:
+        # the dummy request points at block 0 and its output is discarded, so any
+        # valid positive KV length / zero block row works. Pad both seq_lens_list
+        # and the seq_lens tensor: full_graph_fia_v2 passes the seq_lens tensor
+        # (not seq_lens_list) as actual_seq_kvlen during graph capture, and
+        # _get_fia_params derives the PrefillCacheHit batch size from
+        # seq_lens.shape[0], so the tensor has to carry the dummy request too.
+        num_reqs_fia = len(actual_seq_lengths_q)
+        if len(seq_lens_list) < num_reqs_fia:
+            padding_len = num_reqs_fia - len(seq_lens_list)
+            seq_lens_list = seq_lens_list + [1] * padding_len
+            seq_lens = torch.cat([seq_lens, seq_lens.new_ones(padding_len)])
+        if block_table is not None and block_table.shape[0] < num_reqs_fia:
+            block_table = torch.cat(
+                [
+                    block_table,
+                    block_table.new_zeros((num_reqs_fia - block_table.shape[0], block_table.shape[1])),
+                ],
+                dim=0,
+            )
+
         attn_metadata = AscendMetadata(
             num_actual_tokens=num_actual_tokens,
             num_decode_tokens=num_decode_tokens,
@@ -319,9 +350,9 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
             query_start_loc=query_start_loc,
             seq_lens=seq_lens,
             seq_lens_cpu=seq_lens,
-            seq_lens_list=seq_lens.tolist(),
+            seq_lens_list=seq_lens_list,
             max_query_len=common_attn_metadata.max_query_len,
-            actual_seq_lengths_q=query_start_loc_cpu[1:].tolist(),
+            actual_seq_lengths_q=actual_seq_lengths_q,
             slot_mapping=slot_mapping,
             attn_mask=attn_mask,
             attn_state=attn_state,

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -323,11 +323,16 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
         # overflows and `[:num_reqs_padded]` silently truncates them. FIA then
         # fails (error 561002) checking, in order, the `actualSeqLengthsKv` length
         # and then the block_table row count against batchSize. Pad them to match:
-        # the dummy request points at block 0 and its output is discarded, so any
-        # valid positive KV length / zero block row works. Pad both seq_lens_list
-        # and the seq_lens tensor: full_graph_fia_v2 passes the seq_lens tensor
-        # (not seq_lens_list) as actual_seq_kvlen during graph capture, and
-        # _get_fia_params derives the PrefillCacheHit batch size from
+        # the dummy request points at block 0, and its output is harmless because:
+        #   (1) read side: the attention output for padding tokens is trimmed by
+        #       `hidden_states = hidden_states[:-pad_size, :]` downstream;
+        #   (2) write side: reshape_and_cache slices key/value/slot_mapping to
+        #       `[:num_actual_tokens]` (unpadded count), so the dummy request
+        #       never writes to KV cache.
+        # So any valid positive KV length / zero block row is fine. Pad both
+        # seq_lens_list and the seq_lens tensor: full_graph_fia_v2 passes the
+        # seq_lens tensor (not seq_lens_list) as actual_seq_kvlen during graph
+        # capture, and _get_fia_params derives the PrefillCacheHit batch size from
         # seq_lens.shape[0], so the tensor has to carry the dummy request too.
         num_reqs_fia = len(actual_seq_lengths_q)
         if len(seq_lens_list) < num_reqs_fia:


### PR DESCRIPTION
### What this PR does / why we need it?

With `enable_flashcomm1` on, the server crashes under load: the FIA op
(`npu_fused_infer_attention_score` / `aclnnFusedInferAttentionScoreV5`) reports
**error 561002**. The error surfaces in two stages (FIA validates dimensions in
order), both with the same root cause:

```
The size(20) of actualSeqLengthsKv is not equal to the batchSize(21)
```
and, once the first is padded, the next dimension is exposed:
```
When page attention enable, block table shape should be [21, >=29], now is [20, 1104]. [FUNC:CheckBlockTableShape]
```

**Root cause**

`enable_flashcomm1` turns on Sequence Parallelism, which pads each step's token
count up to a multiple of `tp_size`. To keep the FIA TND-layout constraint
`sum(actual_seq_lengths_q) == hidden_states.shape[0]` satisfied after padding,
the model runner inserts a dummy padding request in
`_pad_query_start_loc_for_fia()`, bumping the q-derived `batchSize` by one.

The `query_start_loc` buffer is sized `max_num_reqs + 2` precisely to hold this
extra request, but the `seq_lens` and `block_table` buffers are only
`max_num_reqs`. They are sliced with `[:num_reqs_padded]`; when the batch is full
(`num_reqs == max_num_reqs`), `num_reqs_padded` becomes `max_num_reqs + 1` and the
slice silently truncates them back to `max_num_reqs`. FIA then sees
`actual_seq_lengths_q` of length `batchSize` but `seq_lens_list` / `block_table`
one row short, and fails with 561002.

This only triggers when all three conditions hold at once (so it is intermittent
under stress and never reproduces on a single request):
1. flashcomm1 is enabled (SP active);
2. that step's token count is not divisible by `tp_size`, so a dummy request is
   actually inserted;
3. that step's real request count fills `max_num_seqs` — the only window where the
   dummy request overflows the `max_num_reqs`-sized buffers.

**Fix**

Pad `seq_lens_list` and `block_table` to the q-derived `batchSize` in
`AscendAttentionMetadataBuilder.build()`, the single convergence point for all
paths (chunked prefill / decode-only / prefill-cache-hit), so one fix covers every
branch. The dummy request's attention output is discarded, so a positive KV length
(`1`) and a zero block-table row (pointing at block 0) are safe placeholders.

### Does this PR introduce _any_ user-facing change?

No. This only fixes a crash; model behavior and outputs are unchanged.

### How was this patch tested?

Reproduced and verified on NPU. Serve a model with TP=2, a full batch and chunked
prefill enabled, then drive it with concurrent stress traffic (≥ `max_num_seqs`
requests in flight) so that some step both fills the batch and has an odd token
count:

```
vllm serve <model> --tensor-parallel-size 2 --max-num-seqs 20 \
  --enable-chunked-prefill \
  --additional-config '{"enable_flashcomm1": true}'
```

Before this PR the server intermittently crashes with FIA error 561002 under this
stress run; after this PR the same run no longer reproduces the error.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
