### PR TITLE
[CI] update A3 PVC name to gy005-az5-vllm-ascend

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -201,7 +201,7 @@ jobs:
 
           if [ "${{ inputs.soc_version }}" = "a3" ]; then
             npu_per_node=16
-            pvc_name=nv-action-vllm-benchmarks-v2
+            pvc_name=gy005-az5-vllm-ascend
           else
             npu_per_node=8
             pvc_name=vllm-project-hk001

--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -76,9 +76,9 @@ on:
     secrets:
       KUBECONFIG_B64:
         required: true
-      OBS_ACCESS_KEY:
+      OBS_ACCESS_KEY_ID:
         required: false
-      OBS_SECRET_KEY:
+      OBS_SECRET_KEY_ID:
         required: false
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
@@ -398,8 +398,8 @@ jobs:
         continue-on-error: true
         uses: ascend-gha-runners/artifact/upload@v0.3
         with:
-          access_key: ${{ secrets.OBS_ACCESS_KEY }}
-          secret_key: ${{ secrets.OBS_SECRET_KEY }}
+          access_key: ${{ secrets.OBS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.OBS_SECRET_KEY_ID }}
           name: ${{ inputs.config_file_path }}-ascend-logs
           path: /tmp/ascend-logs.tar.gz
           retention-days: 7
@@ -423,8 +423,8 @@ jobs:
         continue-on-error: true
         uses: ascend-gha-runners/artifact/upload@v0.3
         with:
-          access_key: ${{ secrets.OBS_ACCESS_KEY }}
-          secret_key: ${{ secrets.OBS_SECRET_KEY }}
+          access_key: ${{ secrets.OBS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.OBS_SECRET_KEY_ID }}
           name: nightly-test-benchmark-results-${{ inputs.name || inputs.config_file_path }}-${{ steps.bench_ts.outputs.artifact_ts }}
           path: /tmp/benchmark_results/
           if-no-files-found: warn

--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -78,7 +78,7 @@ on:
         required: true
       OBS_ACCESS_KEY_ID:
         required: false
-      OBS_SECRET_KEY_ID:
+      OBS_SECRET_ACCESS_KEY:
         required: false
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
@@ -399,7 +399,7 @@ jobs:
         uses: ascend-gha-runners/artifact/upload@v0.3
         with:
           access_key: ${{ secrets.OBS_ACCESS_KEY_ID }}
-          secret_key: ${{ secrets.OBS_SECRET_KEY_ID }}
+          secret_key: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
           name: ${{ inputs.config_file_path }}-ascend-logs
           path: /tmp/ascend-logs.tar.gz
           retention-days: 7
@@ -424,7 +424,7 @@ jobs:
         uses: ascend-gha-runners/artifact/upload@v0.3
         with:
           access_key: ${{ secrets.OBS_ACCESS_KEY_ID }}
-          secret_key: ${{ secrets.OBS_SECRET_KEY_ID }}
+          secret_key: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
           name: nightly-test-benchmark-results-${{ inputs.name || inputs.config_file_path }}-${{ steps.bench_ts.outputs.artifact_ts }}
           path: /tmp/benchmark_results/
           if-no-files-found: warn

--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -65,9 +65,9 @@ on:
         type: string
         description: test case execution timeout period,default:120 minutes
     secrets:
-      OBS_ACCESS_KEY:
+      OBS_ACCESS_KEY_ID:
         required: false
-      OBS_SECRET_KEY:
+      OBS_SECRET_KEY_ID:
         required: false
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
@@ -259,8 +259,8 @@ jobs:
         continue-on-error: true
         uses: ascend-gha-runners/artifact/upload@v0.3
         with:
-          access_key: ${{ secrets.OBS_ACCESS_KEY }}
-          secret_key: ${{ secrets.OBS_SECRET_KEY }}
+          access_key: ${{ secrets.OBS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.OBS_SECRET_KEY_ID }}
           name: nightly-test-benchmark-results-${{ inputs.name }}-${{ steps.bench_ts.outputs.artifact_ts }}
           path: /vllm-workspace/vllm-ascend/benchmark_results/${{ inputs.name }}.json
           if-no-files-found: warn

--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -67,7 +67,7 @@ on:
     secrets:
       OBS_ACCESS_KEY_ID:
         required: false
-      OBS_SECRET_KEY_ID:
+      OBS_SECRET_ACCESS_KEY:
         required: false
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
@@ -260,7 +260,7 @@ jobs:
         uses: ascend-gha-runners/artifact/upload@v0.3
         with:
           access_key: ${{ secrets.OBS_ACCESS_KEY_ID }}
-          secret_key: ${{ secrets.OBS_SECRET_KEY_ID }}
+          secret_key: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
           name: nightly-test-benchmark-results-${{ inputs.name }}-${{ steps.bench_ts.outputs.artifact_ts }}
           path: /vllm-workspace/vllm-ascend/benchmark_results/${{ inputs.name }}.json
           if-no-files-found: warn

--- a/.github/workflows/_e2e_nightly_single_node_models.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_models.yaml
@@ -58,7 +58,7 @@ on:
     secrets:
       OBS_ACCESS_KEY_ID:
         required: false
-      OBS_SECRET_KEY_ID:
+      OBS_SECRET_ACCESS_KEY:
         required: false
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
@@ -279,7 +279,7 @@ jobs:
         uses: ascend-gha-runners/artifact/upload@v0.3
         with:
           access_key: ${{ secrets.OBS_ACCESS_KEY_ID }}
-          secret_key: ${{ secrets.OBS_SECRET_KEY_ID }}
+          secret_key: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
           name: report-${{ env.GHA_VLLM_ASCEND_VERSION }}-${{ steps.ts.outputs.artifact_ts }}
           path: ./benchmarks/accuracy/
           if-no-files-found: warn

--- a/.github/workflows/_e2e_nightly_single_node_models.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_models.yaml
@@ -56,9 +56,9 @@ on:
         type: string
         description: test case execution timeout period,default:120 minutes
     secrets:
-      OBS_ACCESS_KEY:
+      OBS_ACCESS_KEY_ID:
         required: false
-      OBS_SECRET_KEY:
+      OBS_SECRET_KEY_ID:
         required: false
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
@@ -278,8 +278,8 @@ jobs:
         continue-on-error: true
         uses: ascend-gha-runners/artifact/upload@v0.3
         with:
-          access_key: ${{ secrets.OBS_ACCESS_KEY }}
-          secret_key: ${{ secrets.OBS_SECRET_KEY }}
+          access_key: ${{ secrets.OBS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.OBS_SECRET_KEY_ID }}
           name: report-${{ env.GHA_VLLM_ASCEND_VERSION }}-${{ steps.ts.outputs.artifact_ts }}
           path: ./benchmarks/accuracy/
           if-no-files-found: warn

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -189,8 +189,8 @@ jobs:
           )
         }}
     secrets:
-      OBS_ACCESS_KEY: ${{ secrets.OBS_ACCESS_KEY }}
-      OBS_SECRET_KEY: ${{ secrets.OBS_SECRET_KEY }}
+      OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
+      OBS_SECRET_KEY_ID: ${{ secrets.OBS_SECRET_KEY_ID }}
 
   multi-node-tests:
     name: multi-node
@@ -236,8 +236,8 @@ jobs:
         }}
     secrets:
       KUBECONFIG_B64: ${{ secrets.KUBECONFIG_HK_001_INTERNAL_B64 }}
-      OBS_ACCESS_KEY: ${{ secrets.OBS_ACCESS_KEY }}
-      OBS_SECRET_KEY: ${{ secrets.OBS_SECRET_KEY }}
+      OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
+      OBS_SECRET_KEY_ID: ${{ secrets.OBS_SECRET_KEY_ID }}
 
   generate-accuracy-matrix:
     name: Generate accuracy test matrix

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -190,7 +190,7 @@ jobs:
         }}
     secrets:
       OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
-      OBS_SECRET_KEY_ID: ${{ secrets.OBS_SECRET_KEY_ID }}
+      OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
 
   multi-node-tests:
     name: multi-node
@@ -237,7 +237,7 @@ jobs:
     secrets:
       KUBECONFIG_B64: ${{ secrets.KUBECONFIG_HK_001_INTERNAL_B64 }}
       OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
-      OBS_SECRET_KEY_ID: ${{ secrets.OBS_SECRET_KEY_ID }}
+      OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
 
   generate-accuracy-matrix:
     name: Generate accuracy test matrix

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -177,8 +177,8 @@ jobs:
         }}
     secrets:
       KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
-      OBS_ACCESS_KEY: ${{ secrets.OBS_ACCESS_KEY }}
-      OBS_SECRET_KEY: ${{ secrets.OBS_SECRET_KEY }}
+      OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
+      OBS_SECRET_KEY_ID: ${{ secrets.OBS_SECRET_KEY_ID }}
 
   double-node-tests:
     name: double-node
@@ -245,8 +245,8 @@ jobs:
         }}
     secrets:
       KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
-      OBS_ACCESS_KEY: ${{ secrets.OBS_ACCESS_KEY }}
-      OBS_SECRET_KEY: ${{ secrets.OBS_SECRET_KEY }}
+      OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
+      OBS_SECRET_KEY_ID: ${{ secrets.OBS_SECRET_KEY_ID }}
 
   single-node-tests:
     name: single-node
@@ -372,8 +372,8 @@ jobs:
       request_id: ${{ inputs.request_id || '' }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
     secrets:
-      OBS_ACCESS_KEY: ${{ secrets.OBS_ACCESS_KEY }}
-      OBS_SECRET_KEY: ${{ secrets.OBS_SECRET_KEY }}
+      OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
+      OBS_SECRET_KEY_ID: ${{ secrets.OBS_SECRET_KEY_ID }}
 
   clear-pre-logs:
     runs-on: linux-aarch64-a3-0

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -178,7 +178,7 @@ jobs:
     secrets:
       KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
       OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
-      OBS_SECRET_KEY_ID: ${{ secrets.OBS_SECRET_KEY_ID }}
+      OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
 
   double-node-tests:
     name: double-node
@@ -246,7 +246,7 @@ jobs:
     secrets:
       KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
       OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
-      OBS_SECRET_KEY_ID: ${{ secrets.OBS_SECRET_KEY_ID }}
+      OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
 
   single-node-tests:
     name: single-node
@@ -373,7 +373,7 @@ jobs:
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
     secrets:
       OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
-      OBS_SECRET_KEY_ID: ${{ secrets.OBS_SECRET_KEY_ID }}
+      OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
 
   clear-pre-logs:
     runs-on: linux-aarch64-a3-0

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -153,8 +153,8 @@ jobs:
         }}
     secrets:
       KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
-      OBS_ACCESS_KEY: ${{ secrets.OBS_ACCESS_KEY }}
-      OBS_SECRET_KEY: ${{ secrets.OBS_SECRET_KEY }}
+      OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
+      OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
 
   single-node-tests:
     name: single-node


### PR DESCRIPTION
## Summary

Update the PVC name for A3 nodes in the multi-node nightly workflow from `nv-action-vllm-benchmarks-v2` to `gy005-az5-vllm-ascend`.

## Changes

- `.github/workflows/_e2e_nightly_multi_node.yaml`: replace A3 `pvc_name` value

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
