### PR TITLE
[BugFix]  isolate KV cache from sleep cleanup with dedicated memory tag for hadamard matrix

### DIFF
--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -15,6 +15,7 @@ from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device_allocator.camem import CaMemAllocator
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
 from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
@@ -189,9 +190,13 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     ) from e
                 log_dim = math.ceil(math.log2(indexer_head_dim))
                 dim_padded = 2**log_dim
-                AscendDSACPMetadataBuilder.hadamard = torch.tensor(
-                    hadamard(dim_padded, dtype=float), dtype=torch.float, device=self.device
-                ).to(torch.bfloat16)
+
+                # Hadamard is persistent metadata; do not let sleep treat it as KV cache.
+                allocator = CaMemAllocator.get_instance()
+                with allocator.use_allocation_tag(CaMemAllocator.sleep_persistent_tag):
+                    AscendDSACPMetadataBuilder.hadamard = torch.tensor(
+                        hadamard(dim_padded, dtype=float), dtype=torch.float, device=self.device
+                    ).to(torch.bfloat16)
         self.start_pos_prefill = torch.zeros(scheduler_config.max_num_seqs, dtype=torch.int32, device=self.device)
         self.req_sas_metadata = torch.zeros(1024, dtype=torch.int32, device=self.device)
         self.req_qli_metadata = torch.zeros(1024, dtype=torch.int32, device=self.device)

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -19,6 +19,7 @@ from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device_allocator.camem import CaMemAllocator
 from vllm_ascend.ops.cv_linear import CVLinearWrapper
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
@@ -424,9 +425,13 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     raise ImportError("Please install scipy") from e
                 log_dim = math.ceil(math.log2(indexer_head_dim))
                 dim_padded = 2**log_dim
-                AscendDSAMetadataBuilder.hadamard = torch.tensor(
-                    hadamard(dim_padded, dtype=float), dtype=torch.float, device=self.device
-                ).to(torch.bfloat16)
+
+                # Hadamard is persistent metadata; do not let sleep treat it as KV cache.
+                allocator = CaMemAllocator.get_instance()
+                with allocator.use_allocation_tag(CaMemAllocator.sleep_persistent_tag):
+                    AscendDSAMetadataBuilder.hadamard = torch.tensor(
+                        hadamard(dim_padded, dtype=float), dtype=torch.float, device=self.device
+                    ).to(torch.bfloat16)
         self.start_pos_prefill = torch.zeros(scheduler_config.max_num_seqs, dtype=torch.int32, device=self.device)
         self.start_pos_decode = torch.zeros(scheduler_config.max_num_seqs, dtype=torch.int32, device=self.device)
         self.decode_sas_metadata = torch.zeros(1024, dtype=torch.int32, device=self.device)

--- a/vllm_ascend/device_allocator/camem.py
+++ b/vllm_ascend/device_allocator/camem.py
@@ -134,6 +134,8 @@ class CaMemAllocator:
 
     instance = None
     default_tag: str = "default"
+    # Allocations with this tag stay mapped across sleep/wake cycles.
+    sleep_persistent_tag: str = "sleep_persistent"
 
     @staticmethod
     def get_instance() -> "CaMemAllocator":
@@ -193,6 +195,9 @@ class CaMemAllocator:
         assert isinstance(offload_tags, tuple)
 
         for ptr, data in self.pointer_to_data.items():
+            if data.tag == CaMemAllocator.sleep_persistent_tag:
+                # This memory is not offloaded or released during sleep.
+                continue
             handle = data.handle
             if data.tag in offload_tags:
                 size_in_bytes = handle[1]
@@ -213,6 +218,9 @@ class CaMemAllocator:
         All data that is previously offloaded will be loaded back to GPU
         memory, and the rest of the data will have empty memory."""
         for ptr, data in self.pointer_to_data.items():
+            if data.tag == CaMemAllocator.sleep_persistent_tag:
+                # It was never released in sleep(), so there is nothing to remap.
+                continue
             if tags is None or data.tag in tags:
                 handle = data.handle
                 create_and_map(handle)
@@ -225,6 +233,16 @@ class CaMemAllocator:
                         dest_max = ptr + size_in_bytes * 2
                         memcpy(ptr, dest_max, cpu_ptr, size_in_bytes, ACL_MEMCPY_HOST_TO_DEVICE)
                         data.cpu_backup_tensor = None
+
+    @contextmanager
+    def use_allocation_tag(self, tag: str):
+        """Temporarily override the tag assigned to new allocations."""
+        old_tag = self.current_tag
+        self.current_tag = tag
+        try:
+            yield
+        finally:
+            self.current_tag = old_tag
 
     @contextmanager
     def use_memory_pool(self, tag: str | None = None):


### PR DESCRIPTION
### What this PR does / why we need it?
Use a dedicated memory tag for KV cache used by DSA Hadamard, instead of the shared tag that was previously being cleaned up during sleep(). This ensures the Hadamard tensor is properly tagged and excluded from sleep-mode memory release.

### Does this PR introduce _any_ user-facing change?
No. 

### How was this patch tested?


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
