### PR TITLE
[Profiler][Misc] Update AI Core metrics to PipeUtilization in torch_npu profiler

### DIFF
--- a/tests/ut/profiler/test_torch_npu_profiler.py
+++ b/tests/ut/profiler/test_torch_npu_profiler.py
@@ -74,7 +74,7 @@ class TestTorchNPUProfilerWrapper(TestBase):
 
         mock_export_type.Text = "Text"
         mock_profiler_level.Level1 = "Level1"
-        mock_aic_metrics.AiCoreNone = "AiCoreNone"
+        mock_aic_metrics.PipeUtilization = "PipeUtilization"
         mock_profiler_activity.CPU = "CPU"
         mock_profiler_activity.NPU = "NPU"
 
@@ -94,7 +94,7 @@ class TestTorchNPUProfilerWrapper(TestBase):
             "export_type": "Text",
             "profiler_level": "Level1",
             "msprof_tx": False,
-            "aic_metrics": "AiCoreNone",
+            "aic_metrics": "PipeUtilization",
             "l2_cache": False,
             "op_attr": False,
             "data_simplification": True,
@@ -193,7 +193,7 @@ class TestTorchNPUProfilerWrapper(TestBase):
         )
         mock_export_type.Text = "Text"
         mock_profiler_level.Level1 = "Level1"
-        mock_aic_metrics.AiCoreNone = "AiCoreNone"
+        mock_aic_metrics.PipeUtilization = "PipeUtilization"
         mock_profiler_activity.CPU = "CPU"
         mock_profiler_activity.NPU = "NPU"
         mock_profile.return_value = MagicMock()

--- a/vllm_ascend/profiler/torch_npu_profiler.py
+++ b/vllm_ascend/profiler/torch_npu_profiler.py
@@ -50,7 +50,7 @@ class TorchNPUProfilerWrapper(WorkerProfiler):
             export_type=torch_npu.profiler.ExportType.Text,
             profiler_level=torch_npu.profiler.ProfilerLevel.Level1,
             msprof_tx=False,
-            aic_metrics=torch_npu.profiler.AiCMetrics.AiCoreNone,
+            aic_metrics=torch_npu.profiler.AiCMetrics.PipeUtilization,
             l2_cache=False,
             op_attr=False,
             data_simplification=True,


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes the Ascend torch profiler configuration in `TorchNPUProfilerWrapper`.

Previously, vLLM Ascend created the `torch_npu.profiler._ExperimentalConfig` with `aic_metrics=torch_npu.profiler.AiCMetrics.AiCoreNone`. That disables AiCore metric collection, so traces collected through `--profiler-config '{"profiler": "torch", ...}'` could miss the compute and pipeline utilization units needed for profiler analysis.

This patch changes the profiler AIC metric mode to `torch_npu.profiler.AiCMetrics.PipeUtilization`, allowing the generated profiling output to include pipeline utilization data while keeping the existing export type, profiler level, stack, memory, and trace handler behavior unchanged.

### Does this PR introduce _any_ user-facing change?
Yes. Users who enable Ascend torch profiling can now see compute and pipeline utilization information in the generated profiler output.

There is no CLI/API change.

### How was this patch tested?
- before this pr
<img width="709" height="81" alt="image" src="https://github.com/user-attachments/assets/f480687f-8716-44a6-b95f-bf85a00407f2" />

- after this pr
<img width="710" height="145" alt="image" src="https://github.com/user-attachments/assets/73a3ab44-ef00-4fa2-84eb-abc5a5147286" />


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
