### PR TITLE
[BugFix]: multiple config reading issues for env var and additional_config

### DIFF
--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -249,7 +249,7 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig, is_draft_mo
     Args:
         num_tokens (int): The number of tokens in the current batch.
         vllm_config (VllmConfig): Runtime configuration for the model.
-        is_draft_model (bool): Whether the model runs in MTP mode (disables fused MC2).
+        is_draft_model (bool): Whether the model runs in MTP mode.
 
     Raises:
         ValueError: If the soc version is unsupported.
@@ -284,7 +284,7 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig, is_draft_mo
         # TODO: drop the EP-size guard when dispatch_ffn_combine supports larger EP sizes
         # TODO: drop speculative method guard when dispatch_gmm_combine_decode supports w16a16
         fused_mc2_enable = get_ascend_config().enable_fused_mc2
-        dispatch_ffn_combine_enable = get_ep_group().world_size <= 32 and (not is_draft_model)
+        dispatch_ffn_combine_enable = get_ep_group().world_size <= 32
         if num_tokens <= mc2_tokens_capacity:
             fused_decode_enable = fused_mc2_enable
             if fused_mc2_enable == 1:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -662,7 +662,7 @@ class KVCacheRecvingThread(threading.Thread):
         is_kv_transfer_end = global_offset == tp_num_need_pulls * self._prefill_pp_size - 1
         need_cat_cache = tp_num_need_pulls > 1 and is_kv_transfer_end
         need_nz_cache = get_ascend_config().enable_kv_nz and is_kv_transfer_end
-        use_fused_op = ascend_envs.VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK
+        use_fused_op = get_ascend_config().enable_transpose_kv_cache_by_block
         if need_nz_cache or need_cat_cache:
             # use fused op to reformat kv cache, we keep original implementation to provide ability to disable it.
             if use_fused_op and enable_custom_op():

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -51,7 +51,6 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.request import RequestStatus
 
-from vllm_ascend import envs as ascend_envs
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
 from vllm_ascend.distributed.kv_transfer.utils.utils import get_transfer_timeout_value

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -29,8 +29,18 @@ _ORIGINAL_SCHEDULER = Scheduler
 
 
 def _balance_scheduling_enabled(vllm_config) -> bool:
+    try:
+        from vllm_ascend.ascend_config import get_ascend_config
+
+        return bool(get_ascend_config().enable_balance_scheduling)
+    except Exception:
+        pass
     additional_config = getattr(vllm_config, "additional_config", None) or {}
-    return bool(additional_config.get("enable_balance_scheduling", False))
+    if "enable_balance_scheduling" in additional_config:
+        return bool(additional_config["enable_balance_scheduling"])
+    import os
+
+    return bool(int(os.getenv("VLLM_ASCEND_BALANCE_SCHEDULING", "0")))
 
 
 class BalanceScheduler(Scheduler):

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -1,4 +1,5 @@
 # mypy: ignore-errors
+import os
 import signal
 import time
 
@@ -38,8 +39,6 @@ def _balance_scheduling_enabled(vllm_config) -> bool:
     additional_config = getattr(vllm_config, "additional_config", None) or {}
     if "enable_balance_scheduling" in additional_config:
         return bool(additional_config["enable_balance_scheduling"])
-    import os
-
     return bool(int(os.getenv("VLLM_ASCEND_BALANCE_SCHEDULING", "0")))
 
 

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -30,6 +30,8 @@ _ORIGINAL_SCHEDULER = Scheduler
 
 
 def _balance_scheduling_enabled(vllm_config) -> bool:
+    # TODO: Unify this path with AscendConfig once AscendConfig initialization
+    # is moved earlier in the startup flow.
     try:
         from vllm_ascend.ascend_config import get_ascend_config
 


### PR DESCRIPTION
### What this PR does / why we need it?
Fixes three configuration-related bugs:

1. VLLM_ASCEND_BALANCE_SCHEDULING env var not taking effect when --additional-config is not set — the fallback in _balance_scheduling_enabled now properly reads from ascend_config first, then additional_config , then the env var.
2. Removed an unnecessary and (not is_draft_model) condition in dispatch_ffn_combine_enable that caused a performance regression in draft model scenarios.
3. mooncake_hybrid_connector.py was reading enable_transpose_kv_cache_by_block directly from the envs module, bypassing additional_config . Fixed to use get_ascend_config() so that --additional-config settings take effect.

### Does this PR introduce _any_ user-facing change?
No breaking changes. Environment variables VLLM_ASCEND_BALANCE_SCHEDULING and VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK now work correctly again, while --additional-config settings continue to work as expected.

### How was this patch tested?
Pending CI verification.


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
