### PR TITLE
[Feature]refactor(device): centralize Ascend device type logic in _DeviceConfig

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_causal_conv1d_310.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_causal_conv1d_310.py
@@ -5,8 +5,8 @@ from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
 from vllm_ascend._310p.ops.causal_conv1d import causal_conv1d_fn as causal_conv1d_fn_ref
 from vllm_ascend._310p.ops.causal_conv1d import causal_conv1d_update as causal_conv1d_update_ref
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.utils import enable_custom_op
-from vllm_ascend.utils import is_310p as is_310p_hw
 
 torch_npu.npu.set_compile_mode(jit_compile=False)
 
@@ -17,7 +17,7 @@ def validate_cmp(y_cal, y_ref, device="npu"):
     torch.testing.assert_close(y_ref, y_cal, rtol=3e-03, atol=1e-02, equal_nan=True)
 
 
-@pytest.mark.skipif(not is_310p_hw(), reason="Tested separately on a 310P machine.")
+@pytest.mark.skipif(not DeviceConfig.use_310p_op_implementations, reason="Tested separately on a 310P machine.")
 @pytest.mark.parametrize("has_initial_state", [False, True])
 @pytest.mark.parametrize("silu_activation", [True])
 @pytest.mark.parametrize("has_bias", [True])
@@ -91,7 +91,7 @@ def test_ascend_causal_conv1d_310_fn(
     validate_cmp(conv_states, conv_states_ref)
 
 
-@pytest.mark.skipif(not is_310p_hw(), reason="Tested separately on a 310P machine.")
+@pytest.mark.skipif(not DeviceConfig.use_310p_op_implementations, reason="Tested separately on a 310P machine.")
 @pytest.mark.parametrize("itype", [torch.float16])
 @pytest.mark.parametrize("silu_activation", [True])
 @pytest.mark.parametrize("has_bias", [False, True])

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_recurrent_gated_delta_rule_310.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_recurrent_gated_delta_rule_310.py
@@ -2,8 +2,8 @@ import pytest
 import torch
 import torch_npu
 
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.utils import enable_custom_op
-from vllm_ascend.utils import is_310p as is_310p_hw
 
 torch_npu.npu.set_compile_mode(jit_compile=False)
 
@@ -82,7 +82,7 @@ def golden_recurrent_gated_delta_rule(
     return o.to(query.dtype), initial_state.to(query.dtype)
 
 
-@pytest.mark.skipif(not is_310p_hw(), reason="Tested separately on a 310P machine.")
+@pytest.mark.skipif(not DeviceConfig.use_310p_op_implementations, reason="Tested separately on a 310P machine.")
 @pytest.mark.parametrize("batch_size", [1, 4, 8])
 @pytest.mark.parametrize("mtp", [1, 2])
 @pytest.mark.parametrize("headnum", [(4, 8), (8, 16), (16, 32)])

--- a/tests/e2e/pull_request/two_card/aclgraph/test_aclgraph_capture_replay.py
+++ b/tests/e2e/pull_request/two_card/aclgraph/test_aclgraph_capture_replay.py
@@ -26,7 +26,7 @@ import torch
 from vllm.utils.network_utils import get_open_port
 
 from tests.e2e.conftest import wait_until_npu_memory_free
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+from vllm_ascend.device.device_config import AscendDeviceType, DeviceConfig
 
 MODELS = [
     # Offline data parallel mode will be not supported/useful for dense models
@@ -211,7 +211,7 @@ def test_models_aclgraph_capture_replay_metrics_dp2(
 
     # Part A: Warmup runs (Profile run + 2 runs per captured graph)
     warmup_runs = 1 + (2 * max_batch_sizes)
-    soc_version = get_ascend_device_type()
+    soc_version = DeviceConfig._device_type
     if soc_version in {AscendDeviceType.A3} and "DeepSeek" in model:
         # An extra warmup run is needed for MC2 warmup here
         warmup_runs += 1

--- a/tests/ut/_310p/ops/test_mm_encoder_attention_310.py
+++ b/tests/ut/_310p/ops/test_mm_encoder_attention_310.py
@@ -19,6 +19,7 @@ import torch
 
 from vllm_ascend import utils
 from vllm_ascend._310p.ops.mm_encoder_attention import AscendMMEncoderAttention310
+from vllm_ascend.device.device_config import _DeviceConfig
 
 
 def test_register_customop_overrides_mm_encoder_attention_for_310p():
@@ -27,7 +28,12 @@ def test_register_customop_overrides_mm_encoder_attention_for_310p():
         utils._ASCEND_CUSTOMOP_IS_REIGISTERED = False
         with (
             mock.patch("vllm.model_executor.custom_op.CustomOp.register_oot"),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=True),
+            mock.patch.object(
+                _DeviceConfig,
+                "use_310p_op_implementations",
+                new_callable=mock.PropertyMock,
+                return_value=True,
+            ),
         ):
             utils.register_ascend_customop()
 

--- a/tests/ut/_310p/quantization/test_w8a8_dynamic_310.py
+++ b/tests/ut/_310p/quantization/test_w8a8_dynamic_310.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 import torch
 
@@ -22,6 +22,7 @@ from vllm_ascend._310p.quantization.methods.w8a8_dynamic import (
     AscendW8A8DynamicFusedMoEMethod310,
     AscendW8A8DynamicLinearMethod310,
 )
+from vllm_ascend.device.device_config import _DeviceConfig
 
 
 class TestAscendW8A8FusedMoEMethod310(TestBase):
@@ -121,9 +122,14 @@ class TestAscendW8A8DynamicLinearMethod310(TestBase):
 
         self.assertTrue(torch.equal(output, expected_y_output))
 
-    @patch("vllm_ascend.utils.is_310p", return_value=True)
+    @patch.object(
+        _DeviceConfig,
+        "force_nz_weight_format",
+        new_callable=PropertyMock,
+        return_value=True,
+    )
     @patch("torch_npu.npu_format_cast")
-    def test_process_weights_after_loading_calls_nz_format_cast_310p(self, mock_npu_format_cast, _mock_is_310p):
+    def test_process_weights_after_loading_calls_nz_format_cast_310p(self, mock_npu_format_cast, _mock_force_nz):
         mock_npu_format_cast.side_effect = lambda x, fmt: x
 
         layer = MagicMock()

--- a/tests/ut/_310p/quantization/test_w8a8_static_310.py
+++ b/tests/ut/_310p/quantization/test_w8a8_static_310.py
@@ -13,12 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import torch
 
 from tests.ut.base import TestBase
 from vllm_ascend._310p.quantization.methods.w8a8_static import AscendW8A8LinearMethod310
+from vllm_ascend.device.device_config import _DeviceConfig
 
 
 class TestAscendW8A8LinearMethod310(TestBase):
@@ -122,9 +123,14 @@ class TestAscendW8A8LinearMethod310(TestBase):
 
         self.assertTrue(torch.equal(output, expected_y_output))
 
-    @patch("vllm_ascend.utils.is_310p", return_value=True)
+    @patch.object(
+        _DeviceConfig,
+        "force_nz_weight_format",
+        new_callable=PropertyMock,
+        return_value=True,
+    )
     @patch("torch_npu.npu_format_cast")
-    def test_process_weights_after_loading_calls_nz_format_cast_310p(self, mock_npu_format_cast, _mock_is_310p):
+    def test_process_weights_after_loading_calls_nz_format_cast_310p(self, mock_npu_format_cast, _mock_force_nz):
         mock_npu_format_cast.side_effect = lambda x, fmt: x
 
         layer = MagicMock()

--- a/tests/ut/attention/a2/test_attention_cp_precision.py
+++ b/tests/ut/attention/a2/test_attention_cp_precision.py
@@ -1,5 +1,5 @@
 from functools import partial
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import numpy as np
 import pytest
@@ -519,10 +519,7 @@ def run_cp_attention(
 
         mock_layer = MockAttentionLayer(device)
 
-        import vllm_ascend.device.device_op as device_op_module
-
-        original_reshape_and_cache = device_op_module.DeviceOperator.reshape_and_cache
-        original_kv_cache_load = device_op_module.DeviceOperator.kv_cache_load
+        from vllm_ascend.device.device_config import DeviceConfig as _DevConfig
 
         def _mock_reshape_and_cache(key, value, key_cache, value_cache, slot_mapping):
             return
@@ -530,14 +527,12 @@ def run_cp_attention(
         def _mock_kv_cache_load(key_cache, value_cache, block_tables, seq_lens_kv, starts, key, value):
             return
 
-        device_op_module.DeviceOperator.reshape_and_cache = staticmethod(_mock_reshape_and_cache)
-        device_op_module.DeviceOperator.kv_cache_load = staticmethod(_mock_kv_cache_load)
-
-        try:
+        with patch.object(type(_DevConfig), "device_operator", new_callable=PropertyMock) as mock_prop:
+            mock_adaptor = MagicMock()
+            mock_adaptor.reshape_and_cache = _mock_reshape_and_cache
+            mock_adaptor.kv_cache_load = _mock_kv_cache_load
+            mock_prop.return_value = mock_adaptor
             output = impl.forward(mock_layer, query, key, value, kv_cache, attn_metadata, output=output)
-        finally:
-            device_op_module.DeviceOperator.reshape_and_cache = original_reshape_and_cache
-            device_op_module.DeviceOperator.kv_cache_load = original_kv_cache_load
 
     return output
 

--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -1,5 +1,5 @@
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import torch
 from vllm.config import CacheConfig, ModelConfig, SchedulerConfig, VllmConfig
@@ -21,6 +21,7 @@ from vllm_ascend.attention.mla_v1 import (
     PrefillMLAPreprocessResult,
 )
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+from vllm_ascend.device.device_config import DeviceConfig as _DevConfigSingleton
 
 
 class TestAscendMLABackend(TestBase):
@@ -1540,11 +1541,13 @@ class TestAscendMLAImpl(TestBase):
         self.assertTrue(hasattr(self.impl, "weight_dq_scale"))
         self.assertTrue(hasattr(self.impl, "weight_dkv_kr_scale"))
 
-    @patch("vllm_ascend.attention.mla_v1.DeviceOperator")
+    @patch.object(type(_DevConfigSingleton), "device_operator", new_callable=PropertyMock)
     @patch("torch_npu.npu_fused_infer_attention_score")
     @patch("torch_npu.npu_attention_update")
-    def test__forward_prefill(self, mock_npu_attention_update, mock_fia, mock_device_operator):
+    def test__forward_prefill(self, mock_npu_attention_update, mock_fia, mock_device_operator_prop):
         batch_size = 2
+        mock_adaptor = MagicMock()
+        mock_device_operator_prop.return_value = mock_adaptor
 
         # create input tensors
         q_nope = torch.randn(batch_size, self.impl.num_heads, self.impl.qk_nope_head_dim)
@@ -1567,7 +1570,7 @@ class TestAscendMLAImpl(TestBase):
         prefill_metadata.block_table = torch.randint(0, 100, (2, 4))
         attn_metadata.prefill = prefill_metadata
 
-        mock_device_operator.kv_cache_load = MagicMock()
+        mock_adaptor.kv_cache_load = MagicMock()
 
         mock_fia.return_value = (
             torch.randn(batch_size, self.impl.num_heads, self.impl.v_head_dim),
@@ -1593,11 +1596,14 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(result.shape[1], self.impl.num_heads * self.impl.v_head_dim)
 
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
-    @patch("vllm_ascend.attention.mla_v1.DeviceOperator")
+    @patch.object(type(_DevConfigSingleton), "device_operator", new_callable=PropertyMock)
     @patch("torch_npu.npu_fused_infer_attention_score")
-    def test_forward_prefill_non_power_of_two_heads(self, mock_fia, mock_device_operator, mock_get_current_vllm_config):
+    def test_forward_prefill_non_power_of_two_heads(
+        self, mock_fia, mock_device_operator_prop, mock_get_current_vllm_config
+    ):
         """Test prefill with non-power-of-2 heads uses concat instead of query_rope/key_rope kwargs."""
-        mock_get_current_vllm_config.return_value = MagicMock()
+        mock_adaptor = MagicMock()
+        mock_device_operator_prop.return_value = mock_adaptor
         num_heads = 20
         kwargs = {
             "kv_lora_rank": 32,
@@ -1644,7 +1650,7 @@ class TestAscendMLAImpl(TestBase):
         prefill_metadata.chunked_context = None
         attn_metadata.prefill = prefill_metadata
 
-        mock_device_operator.kv_cache_load = MagicMock()
+        mock_adaptor.kv_cache_load = MagicMock()
         mock_fia.return_value = (
             torch.randn(batch_size, num_heads, impl.v_head_dim),
             torch.randn(num_heads, batch_size),
@@ -1706,9 +1712,8 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(self.impl.W_UV.shape[1], self.impl.kv_lora_rank)
         self.assertEqual(self.impl.W_UV.shape[2], self.impl.v_head_dim)
 
-    @patch("vllm_ascend.attention.mla_v1.get_ascend_device_type")
     @patch("torch_npu.npu_format_cast")
-    def test_process_weights_after_loading_with_mlapo_a5(self, mock_format_cast, mock_get_ascend_device_type):
+    def test_process_weights_after_loading_with_mlapo_a5(self, mock_format_cast):
         # test with enable_mlapo=True and device_type=A5
         layer = MagicMock(spec=LinearBase)
         layer.input_size_per_partition = 10
@@ -1730,9 +1735,9 @@ class TestAscendMLAImpl(TestBase):
         self.impl.fused_qkv_a_proj = mock_fused_qkv_a_proj
 
         # set device_type=A5
-        from vllm_ascend.attention.mla_v1 import AscendDeviceType
+        from vllm_ascend.device.device_config import AscendDeviceType, DeviceConfig
 
-        mock_get_ascend_device_type.return_value = AscendDeviceType.A5
+        DeviceConfig._device_type = AscendDeviceType.A5
 
         self.impl._process_weights_for_fused_mlapo_a5 = MagicMock()
 
@@ -1748,9 +1753,8 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(self.impl.W_UV.shape[1], self.impl.kv_lora_rank)
         self.assertEqual(self.impl.W_UV.shape[2], self.impl.v_head_dim)
 
-    @patch("vllm_ascend.attention.mla_v1.get_ascend_device_type")
     @patch("torch_npu.npu_format_cast")
-    def test_process_weights_after_loading_with_mlapo_non_a5(self, mock_format_cast, mock_get_ascend_device_type):
+    def test_process_weights_after_loading_with_mlapo_non_a5(self, mock_format_cast):
         # test with enable_mlapo=True and device_type!=A5
         layer = MagicMock(spec=LinearBase)
         layer.input_size_per_partition = 10
@@ -1772,9 +1776,9 @@ class TestAscendMLAImpl(TestBase):
         mock_fused_qkv_a_proj.quant_method = mock_quant_method
         self.impl.fused_qkv_a_proj = mock_fused_qkv_a_proj
 
-        from vllm_ascend.attention.mla_v1 import AscendDeviceType
+        from vllm_ascend.device.device_config import AscendDeviceType, DeviceConfig
 
-        mock_get_ascend_device_type.return_value = AscendDeviceType.A2
+        DeviceConfig._device_type = AscendDeviceType.A2
 
         self.impl._process_weights_for_fused_mlapo = MagicMock()
 

--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -29,6 +29,7 @@ if "torch_npu._inductor" not in sys.modules:
 from vllm_ascend.attention.context_parallel.common_cp import AscendPCPMetadata
 from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFACPImpl, AscendSFACPMetadataBuilder
 from vllm_ascend.attention.sfa_v1 import AscendSFAImpl, AscendSFAMetadata
+from vllm_ascend.device.device_config import _DeviceConfig
 
 
 def _make_indexer_mock():
@@ -1136,7 +1137,7 @@ class TestAscendSFACPImpl(TestBase):
         self.assertIsNotNone(result)
         self.assertEqual(result.shape[0], 3)
 
-    @patch("vllm_ascend.attention.context_parallel.sfa_cp.HAS_TRITON", True)
+    @patch.object(_DeviceConfig, "supports_triton", True)
     @patch("vllm_ascend.attention.context_parallel.sfa_cp.rope_forward_triton_siso")
     @patch_distributed_groups(dcp_size=1, pcp_size=1, needs_mocks=False)
     def test_indexer_select_post_process_decode_only_simple(self, mock_rope):
@@ -1187,7 +1188,7 @@ class TestAscendSFACPImpl(TestBase):
             )
         self.assertIsNotNone(result)
 
-    @patch("vllm_ascend.attention.context_parallel.sfa_cp.HAS_TRITON", False)
+    @patch.object(_DeviceConfig, "supports_triton", False)
     @patch("vllm_ascend.attention.context_parallel.sfa_cp.torch_npu")
     @patch_distributed_groups(dcp_size=1, pcp_size=1, needs_mocks=False)
     def test_indexer_select_post_process_decode_only_no_triton(self, mock_torch_npu):
@@ -1239,7 +1240,7 @@ class TestAscendSFACPImpl(TestBase):
             )
         self.assertIsNotNone(result)
 
-    @patch("vllm_ascend.attention.context_parallel.sfa_cp.HAS_TRITON", True)
+    @patch.object(_DeviceConfig, "supports_triton", True)
     @patch("vllm_ascend.attention.context_parallel.sfa_cp.rope_forward_triton_siso")
     @patch_distributed_groups(dcp_size=1, pcp_size=1, needs_mocks=False)
     def test_indexer_select_post_process_prefill_only_no_pcp(self, mock_rope):
@@ -1293,7 +1294,7 @@ class TestAscendSFACPImpl(TestBase):
             )
         self.assertIsNotNone(result)
 
-    @patch("vllm_ascend.attention.context_parallel.sfa_cp.HAS_TRITON", True)
+    @patch.object(_DeviceConfig, "supports_triton", True)
     @patch("vllm_ascend.attention.context_parallel.sfa_cp.rope_forward_triton_siso")
     @patch_distributed_groups(dcp_size=1, pcp_size=1, needs_mocks=False)
     def test_indexer_select_post_process_decode_and_prefill_no_pcp(self, mock_rope):
@@ -1354,7 +1355,7 @@ class TestAscendSFACPImpl(TestBase):
         self.assertIsNotNone(result)
         self.assertEqual(result.shape[0], 3)
 
-    @patch("vllm_ascend.attention.context_parallel.sfa_cp.HAS_TRITON", True)
+    @patch.object(_DeviceConfig, "supports_triton", True)
     @patch("vllm_ascend.attention.context_parallel.sfa_cp.rope_forward_triton_siso")
     @patch_distributed_groups(dcp_size=2, pcp_size=2, needs_mocks=False)
     def test_indexer_select_post_process_prefill_with_pcp(self, mock_rope):
@@ -1418,7 +1419,7 @@ class TestAscendSFACPImpl(TestBase):
         self.assertIsNotNone(result)
         self.assertEqual(result.shape[0], 4)
 
-    @patch("vllm_ascend.attention.context_parallel.sfa_cp.HAS_TRITON", True)
+    @patch.object(_DeviceConfig, "supports_triton", True)
     @patch("vllm_ascend.attention.context_parallel.sfa_cp.rope_forward_triton_siso")
     @patch_distributed_groups(dcp_size=2, pcp_size=2, needs_mocks=False)
     def test_indexer_select_post_process_decode_and_prefill_with_pcp(self, mock_rope):

--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, call, mock_open, patch
 
 import vllm_ascend.cpu_binding as cpu_binding_module
 from vllm_ascend.cpu_binding import CpuAlloc, DeviceInfo, bind_cpus, is_arm_cpu
-from vllm_ascend.utils import AscendDeviceType
+from vllm_ascend.device.device_config import AscendDeviceType, DeviceConfig
 
 
 def make_cpu_alloc(rank_id=0):
@@ -292,7 +292,7 @@ class TestCpuAlloc(unittest.TestCase):
         visible_devices_patcher.start()
         self.addCleanup(visible_devices_patcher.stop)
 
-        device_type_patcher = patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+        device_type_patcher = patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
         device_type_patcher.start()
         self.addCleanup(device_type_patcher.stop)
 
@@ -325,18 +325,16 @@ class TestCpuAlloc(unittest.TestCase):
             },
         )
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type")
-    def test_binding_mode_table(self, mock_get_device_type):
-        mock_get_device_type.return_value = AscendDeviceType.A2
-        self.assertEqual(self.cpu_alloc._binding_mode(), "topo_affinity")
-        mock_get_device_type.return_value = AscendDeviceType.A3
-        self.assertEqual(self.cpu_alloc._binding_mode(), "global_slice")
-        mock_get_device_type.return_value = AscendDeviceType.A5
-        self.assertEqual(self.cpu_alloc._binding_mode(), "global_slice")
+    def test_binding_mode_table(self):
+        with patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2):
+            self.assertEqual(self.cpu_alloc._binding_mode(), "topo_affinity")
+        with patch.object(DeviceConfig, "_device_type", AscendDeviceType.A3):
+            self.assertEqual(self.cpu_alloc._binding_mode(), "global_slice")
+        with patch.object(DeviceConfig, "_device_type", AscendDeviceType.A5):
+            self.assertEqual(self.cpu_alloc._binding_mode(), "global_slice")
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type")
-    def test_build_cpu_pools_fallback_to_global_slice(self, mock_get_device_type):
-        mock_get_device_type.return_value = AscendDeviceType.A2
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
+    def test_build_cpu_pools_fallback_to_global_slice(self):
         self.cpu_alloc.device_info.npu_affinity = {}
         with (
             patch.object(self.cpu_alloc, "build_cpu_node_map") as mock_build_cpu_node_map,
@@ -346,9 +344,8 @@ class TestCpuAlloc(unittest.TestCase):
         mock_build_cpu_node_map.assert_called_once()
         mock_build_global_slice_cpu_pool.assert_called_once()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type")
-    def test_build_cpu_pools_global_slice_mode(self, mock_get_device_type):
-        mock_get_device_type.return_value = AscendDeviceType.A3
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A3)
+    def test_build_cpu_pools_global_slice_mode(self):
         with (
             patch.object(self.cpu_alloc, "build_cpu_node_map") as mock_build_cpu_node_map,
             patch.object(self.cpu_alloc, "build_global_slice_cpu_pool") as mock_build_global_slice_cpu_pool,
@@ -442,8 +439,8 @@ class TestCpuAlloc(unittest.TestCase):
         self.assertEqual(self.cpu_alloc.npu_cpu_pool[0], [0, 1, 2, 3, 4, 5])
         self.assertEqual(self.cpu_alloc.npu_cpu_pool[1], [6, 7, 8, 9, 10, 11])
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
-    def test_build_global_slice_cpu_pool_raises_when_cpu_insufficient(self, _mock_get_device_type):
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
+    def test_build_global_slice_cpu_pool_raises_when_cpu_insufficient(self):
         self.cpu_alloc.device_info.running_npu_list = [0, 1]
         self.cpu_alloc.device_info.allowed_cpus = list(range(8))
         self.cpu_alloc.device_info.total_logic_npus = 2
@@ -451,8 +448,8 @@ class TestCpuAlloc(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.cpu_alloc.build_global_slice_cpu_pool()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
-    def test_build_global_slice_cpu_pool_allows_ascend_950_without_irq_reservation(self, _mock_get_device_type):
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A5)
+    def test_build_global_slice_cpu_pool_allows_ascend_950_without_irq_reservation(self):
         self.cpu_alloc.device_info.running_npu_list = [0, 1]
         self.cpu_alloc.device_info.allowed_cpus = list(range(6))
         self.cpu_alloc.device_info.total_logic_npus = 2
@@ -481,9 +478,9 @@ class TestCpuAlloc(unittest.TestCase):
         self.cpu_alloc.build_global_slice_cpu_pool()
         self.assertEqual(self.cpu_alloc.npu_cpu_pool, {})
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
     @patch("vllm_ascend.cpu_binding.execute_command")
-    def test_allocate(self, _mock_execute_command, _mock_get_device_type):
+    def test_allocate(self, _mock_execute_command):
         self.cpu_alloc.device_info.running_npu_list = [0]
         self.cpu_alloc.npu_cpu_pool = {0: [0, 1, 2, 3, 4]}
         self.cpu_alloc.allocate()
@@ -494,8 +491,8 @@ class TestCpuAlloc(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.cpu_alloc.allocate()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
-    def test_allocate_ascend_950_uses_unreserved_cpus_for_main(self, _mock_get_device_type):
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A5)
+    def test_allocate_ascend_950_uses_unreserved_cpus_for_main(self):
         self.cpu_alloc.device_info.running_npu_list = [0]
         self.cpu_alloc.npu_cpu_pool = {0: [0, 1, 2, 3, 4]}
 
@@ -529,19 +526,18 @@ class TestCpuAlloc(unittest.TestCase):
         self.cpu_alloc.bind_threads()
         mock_execute_command.assert_called()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type")
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A3)
     @patch("vllm_ascend.cpu_binding.os.listdir")
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which")
     @patch("vllm_ascend.cpu_binding.os.access")
     @patch("vllm_ascend.cpu_binding.execute_command")
     def test_bind_npu_irq_a3_uses_card_chip_mapping(
-        self, mock_execute_command, mock_access, mock_which, _mock_open, mock_listdir, mock_get_device_type
+        self, mock_execute_command, mock_access, mock_which, _mock_open, mock_listdir
     ):
         mock_access.return_value = True
         mock_which.return_value = None
         mock_listdir.side_effect = FileNotFoundError
-        mock_get_device_type.return_value = AscendDeviceType.A3
         mock_execute_command.return_value = ("PCIe Bus Info 0000:03:00.0", 0)
         self.cpu_alloc.rank_id = 0
         self.cpu_alloc.device_info.running_npu_list = [3]
@@ -558,7 +554,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         visible_devices_patcher.start()
         self.addCleanup(visible_devices_patcher.stop)
 
-        device_type_patcher = patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+        device_type_patcher = patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
         device_type_patcher.start()
         self.addCleanup(device_type_patcher.stop)
 
@@ -618,12 +614,12 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         self.assertEqual(cpu_alloc.cpu_node, {0: 0, 1: 1})
         self.assertEqual(cpu_alloc.numa_to_cpu_map, {0: [0], 1: [1]})
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value="unknown")
-    def test_binding_mode_defaults_to_topo_affinity_for_unknown_device(self, _mock_get_device_type):
+    @patch.object(DeviceConfig, "_device_type", new="unknown")
+    def test_binding_mode_defaults_to_topo_affinity_for_unknown_device(self):
         self.assertEqual(CpuAlloc._binding_mode(), "topo_affinity")
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
-    def test_build_cpu_pools_raises_on_affinity_conflict(self, _mock_get_device_type):
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
+    def test_build_cpu_pools_raises_on_affinity_conflict(self):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [0]
         cpu_alloc.device_info.allowed_cpus = [8, 9]
@@ -632,8 +628,8 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         with patch.object(cpu_alloc, "build_cpu_node_map"), self.assertRaises(RuntimeError):
             cpu_alloc.build_cpu_pools()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
-    def test_build_cpu_pools_topo_mode_builds_and_splits_duplicate_groups(self, _mock_get_device_type):
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
+    def test_build_cpu_pools_topo_mode_builds_and_splits_duplicate_groups(self):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.all_logic_npus = [0, 1, 2]
         cpu_alloc.device_info.running_npu_list = [0, 1, 2]
@@ -648,8 +644,8 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         self.assertEqual(cpu_alloc.npu_cpu_pool, {0: [0, 1], 1: [2], 2: [3]})
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
-    def test_build_cpu_pools_topo_mode_skips_non_running_npu_without_cpuset_overlap(self, _mock_get_device_type):
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
+    def test_build_cpu_pools_topo_mode_skips_non_running_npu_without_cpuset_overlap(self):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.all_logic_npus = [0, 1]
         cpu_alloc.device_info.running_npu_list = [0]
@@ -664,8 +660,8 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         self.assertEqual(cpu_alloc.npu_cpu_pool, {0: [192, 193]})
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
-    def test_build_cpu_pools_topo_mode_excludes_non_running_npu_from_final_pool(self, _mock_get_device_type):
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
+    def test_build_cpu_pools_topo_mode_excludes_non_running_npu_from_final_pool(self):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.all_logic_npus = [0, 1]
         cpu_alloc.device_info.running_npu_list = [0]
@@ -685,8 +681,8 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         self.assertEqual(cpu_alloc.npu_cpu_pool, {0: [192, 193, 194, 195, 196]})
         self.assertEqual(cpu_alloc.assign_main, {0: [194]})
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
-    def test_build_cpu_pools_topo_mode_splits_hidden_same_affinity_npus_across_processes(self, _mock_get_device_type):
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
+    def test_build_cpu_pools_topo_mode_splits_hidden_same_affinity_npus_across_processes(self):
         def build_single_card_process(visible_npu):
             cpu_alloc = make_cpu_alloc()
             cpu_alloc.device_info.all_logic_npus = list(range(8))
@@ -810,21 +806,19 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         )
         mock_bind_memory.assert_called_once_with("1000", 0)
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
     @patch("vllm_ascend.cpu_binding.os.access", return_value=False)
     @patch("vllm_ascend.cpu_binding.execute_command")
-    def test_bind_npu_irq_returns_when_irq_path_not_writable(
-        self, mock_execute_command, _mock_access, _mock_get_device_type
-    ):
+    def test_bind_npu_irq_returns_when_irq_path_not_writable(self, mock_execute_command, _mock_access):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.bind_npu_irq()
 
         mock_execute_command.assert_not_called()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A5)
     @patch("vllm_ascend.cpu_binding.os.access")
     @patch("vllm_ascend.cpu_binding.execute_command")
-    def test_bind_npu_irq_skips_on_ascend_950(self, mock_execute_command, mock_access, _mock_get_device_type):
+    def test_bind_npu_irq_skips_on_ascend_950(self, mock_execute_command, mock_access):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [0]
         cpu_alloc.npu_cpu_pool = {0: [8, 9, 10]}
@@ -834,12 +828,10 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         mock_access.assert_not_called()
         mock_execute_command.assert_not_called()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
     @patch("vllm_ascend.cpu_binding.os.access", return_value=True)
     @patch("vllm_ascend.cpu_binding.execute_command")
-    def test_bind_npu_irq_returns_when_current_npu_has_no_cpu_pool(
-        self, mock_execute_command, _mock_access, _mock_get_device_type
-    ):
+    def test_bind_npu_irq_returns_when_current_npu_has_no_cpu_pool(self, mock_execute_command, _mock_access):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [0]
         cpu_alloc.npu_cpu_pool = {}
@@ -848,13 +840,13 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         mock_execute_command.assert_not_called()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which", return_value=None)
     @patch("vllm_ascend.cpu_binding.os.access", return_value=True)
     @patch("vllm_ascend.cpu_binding.execute_command")
     def test_bind_npu_irq_skips_when_cpu_pool_too_small(
-        self, mock_execute_command, _mock_access, _mock_which, _mock_open, _mock_get_device_type
+        self, mock_execute_command, _mock_access, _mock_which, _mock_open
     ):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [0]
@@ -864,13 +856,13 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         mock_execute_command.assert_not_called()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which", return_value=None)
     @patch("vllm_ascend.cpu_binding.os.access", return_value=True)
     @patch("vllm_ascend.cpu_binding.execute_command", return_value=("board info without pci", 0))
     def test_bind_npu_irq_skips_when_pci_address_missing(
-        self, mock_execute_command, _mock_access, _mock_which, _mock_open, _mock_get_device_type
+        self, mock_execute_command, _mock_access, _mock_which, _mock_open
     ):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [0]
@@ -880,14 +872,14 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         mock_execute_command.assert_called_once_with(["npu-smi", "info", "-t", "board", "-i", "0"])
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
     @patch("vllm_ascend.cpu_binding.os.listdir", return_value=["456", "457"])
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which", return_value=None)
     @patch("vllm_ascend.cpu_binding.os.access", return_value=True)
     @patch("vllm_ascend.cpu_binding.execute_command", return_value=("prefix\nPCIe Bus Info 0000:03:00.0", 0))
     def test_bind_npu_irq_skips_when_sq_irq_not_found(
-        self, _mock_execute_command, _mock_access, _mock_which, _mock_open, _mock_listdir, _mock_get_device_type
+        self, _mock_execute_command, _mock_access, _mock_which, _mock_open, _mock_listdir
     ):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [0]
@@ -895,14 +887,14 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         cpu_alloc.bind_npu_irq()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
     @patch("vllm_ascend.cpu_binding.os.listdir", return_value=["123", "124"])
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which", return_value="/bin/systemctl")
     @patch("vllm_ascend.cpu_binding.os.access", return_value=True)
     @patch("vllm_ascend.cpu_binding.execute_command")
     def test_bind_npu_irq_stops_irqbalance_and_writes_affinity_masks(
-        self, mock_execute_command, _mock_access, _mock_which, mock_file, _mock_listdir, _mock_get_device_type
+        self, mock_execute_command, _mock_access, _mock_which, mock_file, _mock_listdir
     ):
         mock_execute_command.side_effect = [
             ("irqbalance.service enabled\n", 0),
@@ -921,14 +913,14 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         handle = mock_file()
         self.assertEqual(handle.write.call_args_list, [call("00000100"), call("00000200")])
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
     @patch("vllm_ascend.cpu_binding.os.listdir", return_value=["123", "124"])
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which", return_value="/bin/systemctl")
     @patch("vllm_ascend.cpu_binding.os.access", return_value=True)
     @patch("vllm_ascend.cpu_binding.execute_command")
     def test_bind_npu_irq_keeps_irqbalance_when_inactive(
-        self, mock_execute_command, _mock_access, _mock_which, _mock_open, _mock_listdir, _mock_get_device_type
+        self, mock_execute_command, _mock_access, _mock_which, _mock_open, _mock_listdir
     ):
         mock_execute_command.side_effect = [
             ("irqbalance.service enabled\n", 0),
@@ -943,14 +935,14 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         self.assertNotIn(call(["systemctl", "stop", "irqbalance"]), mock_execute_command.call_args_list)
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
     @patch("vllm_ascend.cpu_binding.os.listdir", return_value=["123", "124"])
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which", return_value="/bin/systemctl")
     @patch("vllm_ascend.cpu_binding.os.access", return_value=True)
     @patch("vllm_ascend.cpu_binding.execute_command")
     def test_bind_npu_irq_skips_irqbalance_handling_when_service_absent(
-        self, mock_execute_command, _mock_access, _mock_which, _mock_open, _mock_listdir, _mock_get_device_type
+        self, mock_execute_command, _mock_access, _mock_which, _mock_open, _mock_listdir
     ):
         mock_execute_command.side_effect = [
             ("another.service enabled\n", 0),
@@ -964,7 +956,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         self.assertNotIn(call(["systemctl", "is-active", "--quiet", "irqbalance"]), mock_execute_command.call_args_list)
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
     @patch("vllm_ascend.cpu_binding.os.listdir", return_value=["123", "124"])
     @patch(
         "builtins.open",
@@ -975,7 +967,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
     @patch("vllm_ascend.cpu_binding.os.access", return_value=True)
     @patch("vllm_ascend.cpu_binding.execute_command", return_value=("prefix\nPCIe Bus Info 0000:03:00.0", 0))
     def test_bind_npu_irq_scans_multiple_interrupt_lines(
-        self, _mock_execute_command, _mock_access, _mock_which, mock_file, _mock_listdir, _mock_get_device_type
+        self, _mock_execute_command, _mock_access, _mock_which, mock_file, _mock_listdir
     ):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [0]

--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -226,11 +226,10 @@ _backend_pkg.backend_map = {  # type: ignore[attr-defined]
     "yuanrong": {"name": "YuanrongBackend", "path": _backend_module_paths["yuanrong"]},
 }
 
-if "vllm_ascend.utils" not in sys.modules or not hasattr(sys.modules["vllm_ascend.utils"], "AscendDeviceType"):
+if "vllm_ascend.device" not in sys.modules or not hasattr(sys.modules["vllm_ascend.device"], "AscendDeviceType"):
     _ascend_utils = MagicMock()
     _ascend_utils.AscendDeviceType = MagicMock()
-    _ascend_utils.get_ascend_device_type = MagicMock()
-    sys.modules["vllm_ascend.utils"] = _ascend_utils
+    sys.modules["vllm_ascend.device"] = _ascend_utils
 
 # NOTE: vllm_ascend.{ascend_config, memcache_comm_fence} and their helpers
 # (get_ascend_config, AttentionComputeStartGate, ...) are intentionally NOT

--- a/tests/ut/ops/a2/test_token_dispatcher.py
+++ b/tests/ut/ops/a2/test_token_dispatcher.py
@@ -22,6 +22,7 @@ import pytest
 import torch
 
 from tests.ut.base import TestBase
+from vllm_ascend.device.device_config import AscendDeviceType, DeviceConfig
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEAllGatherCombineMetadata,
     MoEAllToAllCombineMetadata,
@@ -32,7 +33,6 @@ from vllm_ascend.ops.fused_moe.moe_runtime_args import (
 )
 
 from vllm_ascend.ops.fused_moe.token_dispatcher import (  # isort: skip
-    AscendDeviceType,
     EXPERT_TOKEN_NUMS_TYPE_COUNT,
     EXPERT_TOKEN_NUMS_TYPE_CUMSUM,
     TokenDispatcherWithAll2AllV,
@@ -120,9 +120,7 @@ class TestTokenDispatcherWithMC2(TestBase):
         self.forward_context_patch.start()
 
         # Mock get_ascend_device_type()
-        self.ascend_soc_version_patch = patch(
-            "vllm_ascend.ops.fused_moe.token_dispatcher.get_ascend_device_type", return_value=AscendDeviceType.A3
-        )
+        self.ascend_soc_version_patch = patch.object(DeviceConfig, "_device_type", AscendDeviceType.A3)
         self.ascend_soc_version_patch.start()
 
         # Mock get_ascend_config() and is_hierarchical_communication_enabled()

--- a/tests/ut/ops/a3_2/test_activation.py
+++ b/tests/ut/ops/a3_2/test_activation.py
@@ -20,13 +20,13 @@ import torch
 from vllm.config import set_current_vllm_config
 from vllm.model_executor.layers.activation import QuickGELU, SiluAndMul
 
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.ops.activation import (
     AscendQuickGELU,
     AscendSiluAndMul,
     AscendSwigluOAIAndMul,
     swiglustep_and_mul,
 )
-from vllm_ascend.utils import is_310p as is_310p_hw
 
 
 @pytest.fixture
@@ -111,7 +111,7 @@ def test_AscendSiluAndMul_forward_oot_prefetch(
     assert torch.allclose(out, dummy_tensor + 1)
 
 
-@pytest.mark.skipif(not is_310p_hw(), reason="310P device unittest case.")
+@pytest.mark.skipif(not DeviceConfig.use_310p_op_implementations, reason="310P device unittest case.")
 @patch("torch.nn.functional.silu", side_effect=lambda x: x + 1)
 def test_SiluAndMul_forward_310p(
     mock_silu,

--- a/tests/ut/ops/a3_2/test_select_experts.py
+++ b/tests/ut/ops/a3_2/test_select_experts.py
@@ -22,9 +22,10 @@ from pytest_mock import MockerFixture
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_forward_context import MoECommType
+from vllm_ascend.device.device_config import AscendDeviceType, DeviceConfig
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts, zero_experts_compute
 from vllm_ascend.ops.fused_moe.moe_runtime_args import MoEPrepareOutput
-from vllm_ascend.utils import AscendDeviceType, adapt_patch, enable_custom_op
+from vllm_ascend.utils import adapt_patch, enable_custom_op
 
 adapt_patch(True)
 
@@ -139,7 +140,7 @@ def mock_dist_env(mocker: MockerFixture):
         ),
         patch("vllm_ascend.ops.fused_moe.fused_moe.get_forward_context", return_value=mock_forward_context_obj),
         patch("vllm_ascend.ascend_forward_context.get_forward_context", return_value=mock_forward_context_obj),
-        patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3),
+        patch.object(DeviceConfig, "_device_type", AscendDeviceType.A3),
         patch("vllm_ascend.ops.fused_moe.moe_comm_method.MC2CommImpl._get_token_dispatcher", return_value=None),
         patch("vllm_ascend.ops.fused_moe.moe_comm_method.AlltoAllCommImpl._get_token_dispatcher", return_value=None),
         patch("vllm_ascend.ops.fused_moe.moe_comm_method.AllGatherCommImpl._get_token_dispatcher", return_value=None),

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -26,6 +26,7 @@ import torch.nn.functional as F
 from pytest_mock import MockerFixture
 
 from vllm_ascend.ascend_forward_context import MoECommType
+from vllm_ascend.device.device_config import AscendDeviceType, DeviceConfig
 from vllm_ascend.ops.fused_moe import fused_moe as fused_moe_module
 from vllm_ascend.ops.fused_moe.fused_moe import (
     AscendFusedMoE,
@@ -40,7 +41,7 @@ from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEWeights,
 )
 from vllm_ascend.quantization.quant_type import QuantType
-from vllm_ascend.utils import AscendDeviceType, adapt_patch
+from vllm_ascend.utils import adapt_patch
 
 adapt_patch(True)
 
@@ -185,7 +186,7 @@ def mock_dist_env(mocker: MockerFixture):
         ),
         patch("vllm_ascend.ops.fused_moe.fused_moe.get_forward_context", return_value=mock_forward_context_obj),
         patch("vllm_ascend.ascend_forward_context.get_forward_context", return_value=mock_forward_context_obj),
-        patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3),
+        patch.object(DeviceConfig, "_device_type", AscendDeviceType.A3),
         patch("vllm_ascend.ops.fused_moe.moe_comm_method.MC2CommImpl._get_token_dispatcher", return_value=None),
         patch("vllm_ascend.ops.fused_moe.moe_comm_method.AlltoAllCommImpl._get_token_dispatcher", return_value=None),
         patch("vllm_ascend.ops.fused_moe.moe_comm_method.AllGatherCommImpl._get_token_dispatcher", return_value=None),

--- a/tests/ut/ops/test_layernorm.py
+++ b/tests/ut/ops/test_layernorm.py
@@ -5,8 +5,8 @@ import torch
 from vllm.config import set_current_vllm_config
 from vllm.model_executor.layers.layernorm import RMSNorm
 
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.utils import enable_custom_op
-from vllm_ascend.utils import is_310p as is_310p_hw
 
 enable_custom_op()
 
@@ -64,7 +64,7 @@ def test_RMSNorm_forward(
         assert torch.allclose(out_x, expected_out_x)
 
 
-@pytest.mark.skipif(not is_310p_hw(), reason="310P device unittest case.")
+@pytest.mark.skipif(not DeviceConfig.use_310p_op_implementations, reason="310P device unittest case.")
 @pytest.mark.parametrize("residual", [None, torch.randn(4, 8, dtype=torch.float16)])
 @patch("torch_npu.npu_rms_norm", side_effect=mock_rms_norm)
 @patch("torch_npu.npu_add_rms_norm", side_effect=mock_add_rms_norm)

--- a/tests/ut/ops/test_ops_init_coverage.py
+++ b/tests/ut/ops/test_ops_init_coverage.py
@@ -1,0 +1,46 @@
+import ast
+import os
+from pathlib import Path
+
+
+def _collect_ops_py_files() -> set[str]:
+    """Collect all .py files under vllm_ascend/ops/ (excluding __init__.py files)."""
+    ops_dir = Path(__file__).parent.parent.parent.parent / "vllm_ascend" / "ops"
+    files: set[str] = set()
+    for root, _dirs, filenames in os.walk(ops_dir):
+        for f in filenames:
+            if f.endswith(".py") and f != "__init__.py":
+                rel = os.path.relpath(os.path.join(root, f), ops_dir)
+                mod = "vllm_ascend.ops." + rel.replace(os.sep, ".").removesuffix(".py")
+                files.add(mod)
+    return files
+
+
+def _parse_imported_modules() -> set[str]:
+    """Parse __init__.py AST to extract all imported vllm_ascend.ops.* modules."""
+    init_path = Path(__file__).parent.parent.parent.parent / "vllm_ascend" / "ops" / "__init__.py"
+    tree = ast.parse(init_path.read_text())
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith("vllm_ascend.ops."):
+                    imported.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and node.module.startswith("vllm_ascend.ops."):
+                imported.add(node.module)
+    return imported
+
+
+def test_ops_init_covers_all_modules():
+    """Ensure every .py file under vllm_ascend/ops/ is imported in __init__.py."""
+    all_modules = _collect_ops_py_files()
+    imported = _parse_imported_modules()
+
+    missing = all_modules - imported
+    extra = imported - all_modules
+
+    assert not missing, "Missing imports in vllm_ascend/ops/__init__.py:\n" + "\n".join(
+        f"  import {m}  # noqa" for m in sorted(missing)
+    )
+    assert not extra, "Stale imports in vllm_ascend/ops/__init__.py (no such file):\n" + "\n".join(sorted(extra))

--- a/tests/ut/sample/test_rejection_sampler.py
+++ b/tests/ut/sample/test_rejection_sampler.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import torch
 
 from tests.ut.base import TestBase
+from vllm_ascend.device.device_config import _DeviceConfig
 from vllm_ascend.sample.rejection_sampler import (
     expand_batch_to_tokens,
     expand_pytorch,
@@ -241,7 +242,7 @@ class TestAscendRejectionSampler(TestBase):
         num_tokens = 7
         # Test PyTorch path
         with (
-            patch("vllm_ascend.sample.rejection_sampler.HAS_TRITON", False),
+            patch.object(_DeviceConfig, "supports_triton", False),
             patch("vllm_ascend.sample.rejection_sampler.expand_pytorch") as mock_pytorch,
         ):
             expand_batch_to_tokens(x, cu_num_tokens, num_tokens)
@@ -252,7 +253,7 @@ class TestAscendRejectionSampler(TestBase):
 
         # Test Triton kernel path
         with (
-            patch("vllm_ascend.sample.rejection_sampler.HAS_TRITON", True),
+            patch.object(_DeviceConfig, "supports_triton", True),
             patch("vllm_ascend.sample.rejection_sampler.expand_triton") as mock_triton,
         ):
             expand_batch_to_tokens(x, cu_num_tokens, num_tokens)
@@ -262,7 +263,7 @@ class TestAscendRejectionSampler(TestBase):
             assert (call_args[3] == cu_num_tokens).all()
 
         # Run actual function
-        with patch("vllm_ascend.sample.rejection_sampler.HAS_TRITON", False):
+        with patch.object(_DeviceConfig, "supports_triton", False):
             result = expand_batch_to_tokens(x, cu_num_tokens, num_tokens)
             expected = torch.tensor([10, 10, 20, 20, 20, 30, 30])
             assert torch.equal(result, expected)

--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -19,6 +19,7 @@ from tests.ut.base import TestBase
 from vllm_ascend.ascend_config import clear_ascend_config, init_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+from vllm_ascend.device.device_config import _DeviceConfig
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
 from vllm_ascend.utils import enable_custom_op
@@ -171,7 +172,7 @@ def test_prepare_inputs_padded_preserves_internal_seq_lens_cpu():
     spec_decode_metadata.cu_num_draft_tokens = torch.tensor([2, 3], dtype=torch.int32)
     valid_sampled_tokens_count = torch.tensor([3, 1], dtype=torch.int32)
 
-    with patch.object(llm_base_proposer, "HAS_TRITON", False):
+    with patch.object(_DeviceConfig, "supports_triton", False):
         spec_common_attn_metadata, *_ = proposer.prepare_inputs_padded(
             common_attn_metadata,
             spec_decode_metadata,
@@ -3392,8 +3393,9 @@ class TestEagleProposerPrepareInputsPadded:
         valid_sampled_tokens_count = torch.tensor([2, 3, 4], dtype=torch.int32, device=self.device)
 
         with (
-            patch(
-                "vllm_ascend.spec_decode.llm_base_proposer.HAS_TRITON",
+            patch.object(
+                _DeviceConfig,
+                "supports_triton",
                 has_triton,
             ),
             patch.multiple(
@@ -3518,8 +3520,9 @@ class TestEagleProposerPrepareInputsPadded:
         valid_sampled_tokens_count = torch.tensor([1, 1, 1], dtype=torch.int32, device=self.device)
 
         with (
-            patch(
-                "vllm_ascend.spec_decode.llm_base_proposer.HAS_TRITON",
+            patch.object(
+                _DeviceConfig,
+                "supports_triton",
                 has_triton,
             ),
             patch.multiple(

--- a/tests/ut/test_batch_invariant.py
+++ b/tests/ut/test_batch_invariant.py
@@ -22,6 +22,7 @@ import torch
 
 # Now import the module under test
 import vllm_ascend.batch_invariant as batch_invariant
+from vllm_ascend.device.device_config import _DeviceConfig
 
 
 class TestBatchInvariant:
@@ -38,7 +39,7 @@ class TestBatchInvariant:
         assert os.environ["HCCL_DETERMINISTIC"] == "strict"
         assert os.environ["LCCL_DETERMINISTIC"] == "1"
 
-    @patch("vllm_ascend.batch_invariant.HAS_TRITON", False)
+    @patch.object(_DeviceConfig, "supports_triton", False)
     @patch("vllm_ascend.batch_invariant.HAS_ASCENDC_BATCH_INVARIANT", True)
     def test_enable_batch_invariant_mode_ascendc_path(self):
         """Test enable_batch_invariant_mode with AscendC ops available"""
@@ -71,7 +72,7 @@ class TestBatchInvariant:
             == batch_invariant.torch.ops.batch_invariant_ops.npu_fused_infer_attention_score_batch_invariant
         )
 
-    @patch("vllm_ascend.batch_invariant.HAS_TRITON", True)
+    @patch.object(_DeviceConfig, "supports_triton", True)
     @patch("vllm_ascend.batch_invariant.HAS_ASCENDC_BATCH_INVARIANT", False)
     def test_enable_batch_invariant_mode_triton_path(self):
         """Test enable_batch_invariant_mode with only Triton available"""
@@ -100,7 +101,7 @@ class TestBatchInvariant:
         mock_library.impl.assert_any_call("aten::softmax", batch_invariant.softmax_batch_invariant, "NPU")
         mock_library.impl.assert_any_call("aten::_softmax", batch_invariant.softmax_batch_invariant, "NPU")
 
-    @patch("vllm_ascend.batch_invariant.HAS_TRITON", False)
+    @patch.object(_DeviceConfig, "supports_triton", False)
     @patch("vllm_ascend.batch_invariant.HAS_ASCENDC_BATCH_INVARIANT", False)
     def test_enable_batch_invariant_mode_no_backend(self):
         """Test enable_batch_invariant_mode with no backends available"""
@@ -124,13 +125,13 @@ class TestBatchInvariant:
         import vllm.envs as envs
 
         envs.VLLM_BATCH_INVARIANT = batch_invariant_enabled
-        batch_invariant.HAS_TRITON = has_backend
         batch_invariant.HAS_ASCENDC_BATCH_INVARIANT = has_backend
         batch_invariant.override_envs_for_invariance = MagicMock()
         batch_invariant.enable_batch_invariant_mode = MagicMock()
 
         # Call function
-        batch_invariant.init_batch_invariance()
+        with patch.object(_DeviceConfig, "supports_triton", has_backend):
+            batch_invariant.init_batch_invariance()
 
         # Verify function calls based on conditions
         if batch_invariant_enabled and has_backend:

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -9,11 +9,11 @@ from vllm.v1.attention.selector import AttentionSelectorConfig  # type: ignore
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_forward_context import MoECommType, override_mrv2_in_profile_run
+from vllm_ascend.device.device_config import AscendDeviceType, DeviceConfig
 from vllm_ascend.platform import NPUPlatform
 from vllm_ascend.utils import (
     ASCEND_QUANTIZATION_METHOD,
     COMPRESSED_TENSORS_METHOD,
-    AscendDeviceType,
 )
 
 
@@ -181,7 +181,7 @@ class TestNPUPlatform(TestBase):
         self.assertIsNone(vllm_config.compilation_config.max_cudagraph_capture_size)
 
     @patch("vllm_ascend.platform.refresh_block_size")
-    @patch("vllm_ascend.platform.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A3)
     @patch("vllm_ascend.platform.enable_sp", return_value=False)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
@@ -190,7 +190,6 @@ class TestNPUPlatform(TestBase):
         mock_auto_detect,
         mock_init_ascend,
         _mock_enable_sp,
-        _mock_device_type,
         _mock_refresh_block_size,
     ):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
@@ -300,12 +299,10 @@ class TestNPUPlatform(TestBase):
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.ascend_config.init_ascend_config")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A3)
     @patch("os.environ", {})
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
-    def test_check_and_update_config_basic_config_update(
-        self, mock_init_recompute, mock_soc_version, mock_init_ascend, mock_auto_detect
-    ):
+    def test_check_and_update_config_basic_config_update(self, mock_init_recompute, mock_init_ascend, mock_auto_detect):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
         vllm_config.parallel_config.enable_expert_parallel = False
@@ -329,11 +326,11 @@ class TestNPUPlatform(TestBase):
         mock_init_ascend.assert_called_once_with(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_no_model_config_warning(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, mock_auto_detect
     ):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -358,12 +355,10 @@ class TestNPUPlatform(TestBase):
         self.assertTrue("Model config is missing" in cm.output[0])
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
-    def test_check_and_update_config_enforce_eager_mode(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
-    ):
+    def test_check_and_update_config_enforce_eager_mode(self, mock_init_recompute, mock_init_ascend, mock_auto_detect):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
         vllm_config.model_config.enforce_eager = True
@@ -400,11 +395,11 @@ class TestNPUPlatform(TestBase):
         )
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_unsupported_compilation_level(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, mock_auto_detect
     ):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -441,11 +436,9 @@ class TestNPUPlatform(TestBase):
 
     @pytest.mark.skip("Revert me when vllm support setting cudagraph_mode on oot platform")
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
-    def test_check_and_update_config_unsupported_cudagraph_mode(
-        self, mock_init_ascend, mock_soc_version, mock_auto_detect
-    ):
+    def test_check_and_update_config_unsupported_cudagraph_mode(self, mock_init_ascend, mock_auto_detect):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
         vllm_config.model_config.enforce_eager = False
@@ -468,11 +461,11 @@ class TestNPUPlatform(TestBase):
             )
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_cache_config_block_size(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, mock_auto_detect
     ):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -493,11 +486,11 @@ class TestNPUPlatform(TestBase):
         self.assertEqual(vllm_config.cache_config.block_size, 128)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_recompute_scheduler_rejects_pd_mixed_no_kv_transfer(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, mock_auto_detect
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
         mock_ascend_config.recompute_scheduler_enable = True
@@ -523,11 +516,11 @@ class TestNPUPlatform(TestBase):
             self.platform.check_and_update_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_recompute_scheduler_rejects_pd_mixed_kv_both(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, mock_auto_detect
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
         mock_ascend_config.recompute_scheduler_enable = True
@@ -562,11 +555,11 @@ class TestNPUPlatform(TestBase):
             self.platform._validate_kv_load_failure_policy(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_balance_scheduler_rejects_pd_disaggregated_kv_producer(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, mock_auto_detect
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
         mock_ascend_config.recompute_scheduler_enable = False
@@ -594,11 +587,11 @@ class TestNPUPlatform(TestBase):
             self.platform.check_and_update_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_balance_scheduler_rejects_pd_disaggregated_kv_consumer(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, mock_auto_detect
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
         mock_ascend_config.recompute_scheduler_enable = False
@@ -748,11 +741,11 @@ class TestNPUPlatform(TestBase):
         self.platform._validate_pd_pp_mtp_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_v1_worker_class_selection(
-        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+        self, mock_init_recompute, mock_init_ascend, mock_auto_detect
     ):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -785,11 +778,9 @@ class TestNPUPlatform(TestBase):
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.ascend_config.init_ascend_config")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType._310P)
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType._310P)
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
-    def test_check_and_update_config_310p_no_custom_ops(
-        self, mock_init_recompute, mock_soc_version, mock_init_ascend, mock_auto_detect
-    ):
+    def test_check_and_update_config_310p_no_custom_ops(self, mock_init_recompute, mock_init_ascend, mock_auto_detect):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
         vllm_config.compilation_config.custom_ops = []

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -22,6 +22,7 @@ import torch
 
 from tests.ut.base import TestBase
 from vllm_ascend import utils
+from vllm_ascend.device.device_config import _DeviceConfig
 from vllm_ascend.utils import REGISTERED_ASCEND_OPS
 
 
@@ -338,7 +339,12 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 0
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+            mock.patch.object(
+                _DeviceConfig,
+                "force_nz_weight_format",
+                new_callable=mock.PropertyMock,
+                return_value=False,
+            ),
         ):
             weight = torch.randn(32, 64, dtype=torch.float16)
             result = utils.maybe_trans_nz(weight)
@@ -350,7 +356,12 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 0
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=True),
+            mock.patch.object(
+                _DeviceConfig,
+                "force_nz_weight_format",
+                new_callable=mock.PropertyMock,
+                return_value=True,
+            ),
         ):
             weight = torch.randn(32, 64, dtype=torch.float16)
             result = utils.maybe_trans_nz(weight)
@@ -362,7 +373,12 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 1
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=True),
+            mock.patch.object(
+                _DeviceConfig,
+                "force_nz_weight_format",
+                new_callable=mock.PropertyMock,
+                return_value=True,
+            ),
         ):
             weight = torch.randn(32, 64, dtype=torch.float32)
             result = utils.maybe_trans_nz(weight)
@@ -374,7 +390,12 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 1
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+            mock.patch.object(
+                _DeviceConfig,
+                "force_nz_weight_format",
+                new_callable=mock.PropertyMock,
+                return_value=False,
+            ),
         ):
             weight = torch.randn(32, 64, dtype=torch.float16)
             result = utils.maybe_trans_nz(weight)
@@ -386,7 +407,12 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 2
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+            mock.patch.object(
+                _DeviceConfig,
+                "force_nz_weight_format",
+                new_callable=mock.PropertyMock,
+                return_value=False,
+            ),
         ):
             weight = torch.randn(32, 64, dtype=torch.float16)
             result = utils.maybe_trans_nz(weight)
@@ -398,7 +424,12 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 2
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+            mock.patch.object(
+                _DeviceConfig,
+                "force_nz_weight_format",
+                new_callable=mock.PropertyMock,
+                return_value=False,
+            ),
         ):
             weight = torch.randn(32, 64, dtype=torch.bfloat16)
             result = utils.maybe_trans_nz(weight)
@@ -410,7 +441,12 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 1
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+            mock.patch.object(
+                _DeviceConfig,
+                "force_nz_weight_format",
+                new_callable=mock.PropertyMock,
+                return_value=False,
+            ),
         ):
             weight = torch.zeros(32, 64, dtype=torch.int8)
             result = utils.maybe_trans_nz(weight)

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -5,6 +5,7 @@ import torch
 from vllm.config import CacheConfig, CUDAGraphMode, ModelConfig, ParallelConfig, ProfilerConfig, VllmConfig
 
 from tests.ut.base import TestBase
+from vllm_ascend.device.device_config import AscendDeviceType, DeviceConfig
 
 init_cached_hf_modules_path = "vllm.utils.import_utils.init_cached_hf_modules"
 
@@ -76,7 +77,6 @@ class TestNPUWorker(TestBase):
     ):
         """Test NPUWorker normal initialization"""
         # Setup mock behavior
-        mock_ops.register_dummy_fusion_op.return_value = None
         mock_ascend_config = MagicMock()
         mock_ascend_config.enable_cpu_binding = True
         mock_get_ascend_config.return_value = mock_ascend_config
@@ -94,7 +94,6 @@ class TestNPUWorker(TestBase):
 
         # Verify initialization call order
         mock_adapt_patch.assert_called_once()
-        mock_ops.register_dummy_fusion_op.assert_called_once()
         mock_register_atb_extensions.assert_called_once()
         mock_register_ascend_customop.assert_called_once()
         mock_init_ascend_config.assert_called_once_with(self.vllm_config_mock)
@@ -132,7 +131,6 @@ class TestNPUWorker(TestBase):
         """Test NPUWorker initialization with trust_remote_code=True"""
         # Set trust_remote_code=True
         self.model_config_mock.trust_remote_code = True
-        mock_ops.register_dummy_fusion_op.return_value = None
         mock_ascend_config = MagicMock()
         mock_ascend_config.enable_cpu_binding = True
         mock_get_ascend_config.return_value = mock_ascend_config
@@ -175,7 +173,6 @@ class TestNPUWorker(TestBase):
         """Test NPUWorker initialization with custom cache_dtype"""
         # Set custom cache_dtype
         self.cache_config_mock.cache_dtype = "float32"
-        mock_ops.register_dummy_fusion_op.return_value = None
         mock_ascend_config = MagicMock()
         mock_ascend_config.enable_cpu_binding = True
         mock_get_ascend_config.return_value = mock_ascend_config
@@ -252,7 +249,7 @@ class TestNPUWorker(TestBase):
     @patch("vllm_ascend.worker.worker.MemorySnapshot")
     @patch("vllm_ascend.worker.worker.NPUWorker._init_worker_distributed_environment")
     @patch("vllm_ascend.worker.worker.init_device_properties_triton")
-    @patch("vllm_ascend.worker.worker.get_ascend_device_type")
+    @patch.object(DeviceConfig, "_device_type", AscendDeviceType.A2)
     @patch("torch.npu.set_device")
     @patch("torch.npu.empty_cache")
     @patch("torch.npu.mem_get_info")
@@ -261,17 +258,15 @@ class TestNPUWorker(TestBase):
         mock_mem_get_info,
         mock_empty_cache,
         mock_set_device,
-        mock_get_device_type,
         mock_init_triton,
         mock_init_dist_env,
         mock_snapshot_cls,
     ):
         """Test _init_device method"""
-        from vllm_ascend.worker.worker import AscendDeviceType, NPUWorker
+        from vllm_ascend.worker.worker import NPUWorker
 
         # Setup mock
         mock_mem_get_info.return_value = (1000, 2000)
-        mock_get_device_type.return_value = AscendDeviceType.A2
 
         # Mock MemorySnapshot
         mock_snapshot = MagicMock()
@@ -1040,8 +1035,7 @@ class TestNPUWorker(TestBase):
             self.assertIn("Sleep mode can only be", str(cm.exception))
 
     @patch("vllm_ascend.worker.worker.set_random_seed")
-    @patch("vllm_ascend.worker.worker.get_ascend_device_type")
-    @patch("vllm_ascend.worker.worker.AscendDeviceType")
+    @patch.object(DeviceConfig, "_device_type", new=object())
     @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.logger")
     @patch("vllm_ascend.worker.worker.NPUWorker._warm_up_atb")
@@ -1050,8 +1044,6 @@ class TestNPUWorker(TestBase):
         mock_warm_up_atb,
         mock_logger,
         mock_get_ascend_config,
-        mock_ascend_device_type,
-        mock_get_ascend_device_type,
         mock_set_random_seed,
     ):
         """Test compile_or_warm_up_model method - eager mode"""
@@ -1060,7 +1052,6 @@ class TestNPUWorker(TestBase):
         mock_ascend_config.ascend_compilation_config.enable_npugraph_ex = False
         mock_ascend_config.enable_cpu_binding = False
         mock_get_ascend_config.return_value = mock_ascend_config
-        mock_get_ascend_device_type.return_value = mock_ascend_device_type.A9B
         from vllm_ascend.worker.worker import NPUWorker
 
         # Create worker mock
@@ -1101,8 +1092,7 @@ class TestNPUWorker(TestBase):
             mock_warm_up_atb.assert_called_once()
 
     @patch("vllm_ascend.worker.worker.set_random_seed")
-    @patch("vllm_ascend.worker.worker.get_ascend_device_type")
-    @patch("vllm_ascend.worker.worker.AscendDeviceType")
+    @patch.object(DeviceConfig, "_device_type", new=object())
     @patch("vllm_ascend.worker.worker.CUDAGraphMode")
     @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.logger")
@@ -1113,8 +1103,6 @@ class TestNPUWorker(TestBase):
         mock_logger,
         mock_get_ascend_config,
         mock_cudagraph_mode,
-        mock_ascend_device_type,
-        mock_get_ascend_device_type,
         mock_set_random_seed,
     ):
         """Test compile_or_warm_up_model method - with graph capture enabled"""
@@ -1123,8 +1111,6 @@ class TestNPUWorker(TestBase):
         mock_ascend_config.ascend_compilation_config.enable_npugraph_ex = False
         mock_ascend_config.enable_cpu_binding = False
         mock_get_ascend_config.return_value = mock_ascend_config
-        mock_get_ascend_device_type.return_value = mock_ascend_device_type.A9B
-        mock_cudagraph_mode.NONE = mock_cudagraph_mode.NONE
         from vllm_ascend.worker.worker import NPUWorker
 
         # Create worker mock

--- a/vllm_ascend/__init__.py
+++ b/vllm_ascend/__init__.py
@@ -37,6 +37,14 @@ def _ensure_global_patch():
     _GLOBAL_PATCH_APPLIED = True
 
 
+# Apply the global patch at module import time, before any general-plugin
+# entry point (register_model, register_connector, ...) is invoked.
+# vLLM's DEFAULT_PLUGINS_GROUP load order between entry points is not
+# guaranteed, so relying on each individual function to call
+# _ensure_global_patch() is not sufficient.
+_ensure_global_patch()
+
+
 def register():
     """Register the NPU platform."""
 
@@ -72,6 +80,8 @@ def register_service_profiling():
 
 
 def register_model():
+    _ensure_global_patch()
+
     from .models import register_model
 
     register_model()

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -12,11 +12,13 @@ from vllm.forward_context import BatchDescriptor, get_forward_context, set_forwa
 from vllm.logger import logger
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.utils import (
+from vllm_ascend.device.device_config import (
     AscendDeviceType,
+    DeviceConfig,
+)
+from vllm_ascend.utils import (
     enable_sp,
     flashcomm2_enable,
-    get_ascend_device_type,
     has_layer_idx,
     is_drafter_moe_model,
     is_moe_model,
@@ -264,7 +266,7 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig, is_draft_mo
     if not is_moe_model(vllm_config):
         return None
     mc2_tokens_capacity = get_mc2_tokens_capacity()
-    soc_version = get_ascend_device_type()
+    soc_version = DeviceConfig._device_type
     quant_type = getattr(
         vllm_config.model_config.hf_text_config,
         "moe_quantize",

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -61,7 +61,7 @@ from vllm_ascend.compilation.acl_graph import (
     update_draft_graph_params_workspaces,
     update_graph_params_workspaces,
 )
-from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.memcache_comm_fence import record_attention_compute_start
 from vllm_ascend.ops.flashcomm2_oshard_manager import flashcomm2_oshard_manager
 from vllm_ascend.utils import weak_ref_tensors
@@ -1220,7 +1220,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         if self.key_cache is None:
             self.key_cache, self.value_cache = kv_cache[0], kv_cache[1]
 
-        DeviceOperator.reshape_and_cache(
+        DeviceConfig.device_operator.reshape_and_cache(
             key=key,
             value=value,
             key_cache=self.key_cache,
@@ -1242,7 +1242,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 self.key_cache, self.value_cache = kv_cache[0], kv_cache[1]
             slots = attn_metadata.slot_mapping
             encoder_decoder = self.attn_type == AttentionType.ENCODER_DECODER
-            DeviceOperator.reshape_and_cache(
+            DeviceConfig.device_operator.reshape_and_cache(
                 key=key[: attn_metadata.num_actual_tokens] if not encoder_decoder else key,
                 value=value[: attn_metadata.num_actual_tokens] if not encoder_decoder else value,
                 key_cache=self.key_cache,

--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -55,7 +55,7 @@ from vllm_ascend.compilation.acl_graph import (
     update_draft_graph_params_workspaces,
     update_graph_params_workspaces,
 )
-from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.distributed.utils import (
     get_decode_context_model_parallel_rank,
     get_decode_context_model_parallel_world_size,
@@ -784,7 +784,7 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
         key = torch.empty(total_toks, num_heads, head_size, dtype=query.dtype, device=query.device)
         value = torch.empty(total_toks, num_heads, head_size, dtype=query.dtype, device=query.device)
         if total_toks > 0:
-            DeviceOperator.kv_cache_load(
+            DeviceConfig.device_operator.kv_cache_load(
                 cache_key,
                 cache_value,
                 attn_metadata.prefill.block_tables,
@@ -816,7 +816,7 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
 
             if has_decode:
                 slot_mapping = attn_metadata.slot_mapping[: num_decode_tokens * self.pcp_size : self.pcp_size]
-                DeviceOperator.reshape_and_cache(
+                DeviceConfig.device_operator.reshape_and_cache(
                     key=key[:num_decode_tokens],
                     value=value[:num_decode_tokens],
                     key_cache=self.key_cache,
@@ -849,7 +849,7 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
                 slot_mapping = attn_metadata.slot_mapping[
                     self.pcp_size * num_decode_tokens : attn_metadata.num_actual_tokens_pcp_padded
                 ]
-                DeviceOperator.reshape_and_cache(
+                DeviceConfig.device_operator.reshape_and_cache(
                     key=prefill_key,
                     value=prefill_value,
                     key_cache=self.key_cache,

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -14,13 +14,11 @@ from vllm.v1.kv_cache_interface import AttentionSpec, MLAAttentionSpec
 from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
-from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
 from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.utils import (
-    AscendDeviceType,
-    get_ascend_device_type,
     olora_tp_enable,
 )
 
@@ -207,10 +205,10 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1
         self.spec_slot_mapping = None
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
-            self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens,)  # type: ignore
-        else:
+        if DeviceConfig.slot_mapping_2d:
             self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens, 2)  # type: ignore
+        else:
+            self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens,)  # type: ignore
         if self.speculative_config:
             spec_token_num = self.speculative_config.num_speculative_tokens
             self.spec_slot_mapping = [
@@ -309,7 +307,9 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             self.seq_lens_cpu = self.common_ratio_to_sas_metadata["seq_lens_cpu"]
 
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
-        self.slot_mapping[:num_input_tokens] = DeviceOperator.format_dsa_slot_mapping(slot_mapping, self.block_size)
+        self.slot_mapping[:num_input_tokens] = DeviceConfig.device_operator.format_dsa_slot_mapping(
+            slot_mapping, self.block_size
+        )
 
         self.block_table = common_attn_metadata.block_table_tensor[:num_reqs]
 
@@ -364,8 +364,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
 
         assert self.spec_slot_mapping is not None
-        self.spec_slot_mapping[draft_step - 1][:num_input_tokens] = DeviceOperator.format_dsa_slot_mapping(
-            slot_mapping, self.block_size
+        self.spec_slot_mapping[draft_step - 1][:num_input_tokens] = (
+            DeviceConfig.device_operator.format_dsa_slot_mapping(slot_mapping, self.block_size)
         )
 
         self.block_table = common_attn_metadata.block_table_tensor[:num_reqs]
@@ -449,13 +449,13 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         slot_mapping = self.spec_slot_mapping[draft_step - 1][: self.num_actual_tokens]
 
         num_heads = self.model_config.hf_config.num_attention_heads
-        metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-        metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
+        metadata_op = DeviceConfig.device_operator.get_dsa_sparse_attn_metadata_op()
+        metadata_kwargs = DeviceConfig.device_operator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
         metadata_kwargs.setdefault("device", str(self.seqused_q.device))
         cu_seqlens_ori_kv = (
             local_query_start_loc
             if has_prefill
-            else DeviceOperator.get_dsa_decode_cu_seqlens_ori_kv(
+            else DeviceConfig.device_operator.get_dsa_decode_cu_seqlens_ori_kv(
                 None,
                 "draft_cu_seqlens_ori_kv",
                 local_seq_lens,
@@ -465,7 +465,9 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             )
         )
         cu_seqlens_cmp_kv = (
-            None if has_prefill else DeviceOperator.get_dsa_decode_cu_seqlens_cmp_kv(self.cu_seqlens_cmp_kv)
+            None
+            if has_prefill
+            else DeviceConfig.device_operator.get_dsa_decode_cu_seqlens_cmp_kv(self.cu_seqlens_cmp_kv)
         )
         sas_metadata = metadata_op(
             **metadata_kwargs,
@@ -758,7 +760,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             return None
         if has_prefill:
             return None
-        return DeviceOperator.get_dsa_decode_cu_seqlens_cmp_kv(self.cu_seqlens_cmp_kv)
+        return DeviceConfig.device_operator.get_dsa_decode_cu_seqlens_cmp_kv(self.cu_seqlens_cmp_kv)
 
     def _get_slot_mapping_size(self, input_positions, compress_ratio, num_reqs, num_input_tokens):
         if compress_ratio <= 1:
@@ -787,7 +789,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             cu_seqlens_ori_kv = (
                 query_start_loc
                 if has_prefill
-                else DeviceOperator.get_dsa_decode_cu_seqlens_ori_kv(
+                else DeviceConfig.device_operator.get_dsa_decode_cu_seqlens_ori_kv(
                     self.common_ratio_to_sas_metadata,
                     f"{cache_key}_cu_seqlens_ori_kv",
                     seq_lens,
@@ -797,10 +799,12 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 )
             )
             cu_seqlens_cmp_kv = (
-                None if has_prefill else DeviceOperator.get_dsa_decode_cu_seqlens_cmp_kv(self.cu_seqlens_cmp_kv)
+                None
+                if has_prefill
+                else DeviceConfig.device_operator.get_dsa_decode_cu_seqlens_cmp_kv(self.cu_seqlens_cmp_kv)
             )
-            metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-            metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
+            metadata_op = DeviceConfig.device_operator.get_dsa_sparse_attn_metadata_op()
+            metadata_kwargs = DeviceConfig.device_operator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
             metadata_kwargs.setdefault("device", str(self.seqused_q.device))
             kw = dict(
                 **metadata_kwargs,
@@ -1015,7 +1019,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         num_tokens = o_proj_input.shape[0]
 
         # o
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
+        if DeviceConfig.supports_mxfp:
             o = o_proj_input.view(num_tokens, self.n_local_groups, -1)
             o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
             o = torch_npu.npu_transpose_quant_batchmatmul(
@@ -1063,8 +1067,8 @@ class AscendDSACPImpl(DSAAttentionImpl):
         need_gather_q_kv: bool = False,
     ):
         """Run full-sequence KV cache updates and local-token attention."""
-        (compress_kv_cache, swa_kv_cache, state_cache, _, _, _) = DeviceOperator.unpack_dsa_forward_kv_cache(
-            kv_cache, self.compress_ratio
+        (compress_kv_cache, swa_kv_cache, state_cache, _, _, _) = (
+            DeviceConfig.device_operator.unpack_dsa_forward_kv_cache(kv_cache, self.compress_ratio)
         )
         if self.compress_ratio == 4:
             (compressor_attn_metadata, compressor_kv_state_metadata, _, _, swa_metadata) = attn_metadata
@@ -1139,7 +1143,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
 
         q = q.unflatten(-1, (self.num_heads, self.head_dim))
 
-        q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
+        q = DeviceConfig.device_operator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
         torch.ops._C_ascend.inplace_partial_rotary_mul(
             q.unsqueeze(1),
             local_cos,
@@ -1159,7 +1163,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             rotary_mode="interleave",
             partial_slice=[self.nope_head_dim, self.head_dim],
         )
-        DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, swa_metadata.req_metadata.slot_mapping)
+        DeviceConfig.device_operator.dsa_kv_compress_scatter(swa_kv_cache, kv, swa_metadata.req_metadata.slot_mapping)
 
         compress_topk_idxs = None
         if self.compress_ratio > 1:
@@ -1212,14 +1216,14 @@ class AscendDSACPImpl(DSAAttentionImpl):
 
             if compressed_kv.numel() == 0:
                 compressed_kv = None
-            DeviceOperator.dsa_kv_compress_scatter(
+            DeviceConfig.device_operator.dsa_kv_compress_scatter(
                 compress_kv_cache, compressed_kv, compressor_attn_metadata.req_metadata.slot_mapping
             )
 
-        attn_op = DeviceOperator.get_dsa_sparse_attn_op()
-        extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
+        attn_op = DeviceConfig.device_operator.get_dsa_sparse_attn_op()
+        extra_attn_kwargs: dict = DeviceConfig.device_operator.get_dsa_sparse_attn_base_kwargs()
         if has_prefill:
-            DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
+            DeviceConfig.device_operator.add_dsa_sparse_attn_extra_kwargs(
                 extra_attn_kwargs, cu_seqlens_ori_kv=local_seq_lengths_query
             )
 
@@ -1247,7 +1251,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             )[0]
         elif self.compress_ratio == 4:
             assert compressor_attn_metadata.req_metadata is not None
-            DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
+            DeviceConfig.device_operator.add_dsa_sparse_attn_extra_kwargs(
                 common_attn_kwargs, cu_seqlens_cmp_kv=req_metadata.cu_cmp_seqlen_list
             )
             attn_output = attn_op(
@@ -1263,7 +1267,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             )[0]
         else:
             assert compressor_attn_metadata.req_metadata is not None
-            DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
+            DeviceConfig.device_operator.add_dsa_sparse_attn_extra_kwargs(
                 common_attn_kwargs, cu_seqlens_cmp_kv=req_metadata.cu_cmp_seqlen_list
             )
             attn_output = attn_op(
@@ -1319,7 +1323,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         actual_seq_lengths_query: torch.Tensor,
     ) -> None:
         (indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
-            DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
+            DeviceConfig.device_operator.unpack_dsa_indexer_kv_cache(kv_cache)
         )
         (_, _, indexer_kv_state_metadata, indexer_kv_scale_metadata, _) = attn_metadata
         coff = 2 if self.compressor_overlap else 1
@@ -1354,14 +1358,14 @@ class AscendDSACPImpl(DSAAttentionImpl):
         if self.indexer.compressor.rotate:
             kv = rotate_activation(kv, indexer_kv_scale_metadata.hadamard)
 
-        _, kv_scale = DeviceOperator.indexer_quant_scatter_part1(
+        _, kv_scale = DeviceConfig.device_operator.indexer_quant_scatter_part1(
             kv,
             indexer_k_cache,
             indexer_full_cache,
             indexer_kv_scale_metadata.req_metadata.slot_mapping,
         )
         if kv_scale is not None:
-            DeviceOperator.dsa_indexer_scatter_scale_part3(
+            DeviceConfig.device_operator.dsa_indexer_scatter_scale_part3(
                 kv_scale,
                 indexer_scale_cache,
                 indexer_kv_scale_metadata.req_metadata.slot_mapping,
@@ -1379,7 +1383,9 @@ class AscendDSACPImpl(DSAAttentionImpl):
         actual_seq_lengths_key: torch.Tensor,
         qr_pertoken_scale: torch.Tensor = None,
     ):
-        (_, indexer_k_cache, indexer_scale_cache, _) = DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
+        (_, indexer_k_cache, indexer_scale_cache, _) = DeviceConfig.device_operator.unpack_dsa_indexer_kv_cache(
+            kv_cache
+        )
         (_, _, _, indexer_kv_scale_metadata, _) = attn_metadata
         assert indexer_kv_scale_metadata is not None
 
@@ -1387,7 +1393,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             (not isinstance(self.inderxer_wq_b.quant_method, AscendUnquantizedLinearMethod))
             and isinstance(self.inderxer_wq_b.quant_method.quant_method, AscendW8A8DynamicLinearMethod)
             and qr_pertoken_scale is not None
-            and get_ascend_device_type() not in {AscendDeviceType.A5}
+            and DeviceConfig.indexer_uses_quant_matmul
         ):
             q = torch_npu.npu_quant_matmul(
                 qr,
@@ -1410,7 +1416,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         q = rotate_activation(q, indexer_kv_scale_metadata.hadamard)
         weights = self.weights_proj(x) * (self.indexer_softmax_scale * self.indexer_heads**-0.5)
 
-        q, q_scale = DeviceOperator.indexer_quantize_query(q)
+        q, q_scale = DeviceConfig.device_operator.indexer_quantize_query(q)
 
         assert indexer_kv_scale_metadata.req_metadata is not None
         qli_metadata = indexer_kv_scale_metadata.req_metadata.qli_metadata
@@ -1418,9 +1424,9 @@ class AscendDSACPImpl(DSAAttentionImpl):
         topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer(
             query=q,
             key=indexer_k_cache,
-            weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
-            query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
-            key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
+            weights=DeviceConfig.device_operator.prepare_dsa_indexer_weights(weights),
+            query_dequant_scale=DeviceConfig.device_operator.prepare_dsa_indexer_query_scale(q_scale),
+            key_dequant_scale=DeviceConfig.device_operator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
             actual_seq_lengths_query=actual_seq_lengths_query[1:],
             actual_seq_lengths_key=actual_seq_lengths_key,
             block_table=block_table,

--- a/vllm_ascend/attention/context_parallel/mla_cp.py
+++ b/vllm_ascend/attention/context_parallel/mla_cp.py
@@ -13,7 +13,7 @@ from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.kv_cache_interface import AttentionSpec, MLAAttentionSpec
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.distributed.utils import (
     get_decode_context_model_parallel_rank,
     get_decode_context_model_parallel_world_size,
@@ -450,7 +450,7 @@ class AscendMlaCPImpl(AscendMLAImpl):
         kv_c_normed, k_pe = prefill_k_c_normed, prefill_k_pe
         prefill_k_c_normed = prefill_k_c_normed.squeeze(1)
         slot_mapping = attn_metadata.slot_mapping[self.pcp_size * num_decode_tokens :]
-        DeviceOperator.reshape_and_cache(
+        DeviceConfig.device_operator.reshape_and_cache(
             key=kv_c_normed, value=k_pe, key_cache=kv_cache[0], value_cache=kv_cache[1], slot_mapping=slot_mapping
         )
         notify_kv_cache_written(self.layer_name or "")

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -6,11 +6,11 @@ import torch_npu
 from vllm.config import VllmConfig
 from vllm.distributed import get_dcp_group, get_pcp_group
 from vllm.forward_context import get_forward_context
-from vllm.triton_utils import HAS_TRITON
 
 from vllm_ascend.attention.context_parallel.common_cp import AscendPCPMetadata
 from vllm_ascend.attention.sfa_v1 import AscendSFAImpl, AscendSFAMetadata, AscendSFAMetadataBuilder
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, enabling_mlapo, split_decodes_and_prefills
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.ops.triton.rope import rope_forward_triton_siso
 
 M = TypeVar("M", bound=AscendSFAMetadata)
@@ -418,7 +418,7 @@ class AscendSFACPImpl(AscendSFAImpl):
         weights = kw[:, self.head_dim :]
         q_li, _ = self.wq_b(q_c)  # [b,s,1536] @ [1536,64*128] = [b,s,64*128]
         q_li = q_li.view(-1, self.n_head, self.head_dim)  # [n_toks,64,128]
-        if HAS_TRITON:
+        if DeviceConfig.supports_triton:
             q_li = rope_forward_triton_siso(
                 q_li, cos, sin, rope_dim=self.qk_rope_head_dim, is_neox_style=self.is_rope_neox_style
             )

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -9,7 +9,6 @@ import vllm.envs as envs_vllm
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.forward_context import get_forward_context
-from vllm.triton_utils import HAS_TRITON
 from vllm.v1.attention.backend import AttentionBackend, AttentionCGSupport, AttentionMetadataBuilder
 from vllm.v1.kv_cache_interface import AttentionSpec, MLAAttentionSpec
 
@@ -18,14 +17,12 @@ from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
-from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.ops.cv_linear import CVLinearWrapper
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
 from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.utils import (
-    AscendDeviceType,
-    get_ascend_device_type,
     npu_stream_switch,
     olora_tp_enable,
 )
@@ -36,7 +33,7 @@ if TYPE_CHECKING:
 
     from vllm_ascend.ops.triton.rms_norm import triton_q_rms
 
-if HAS_TRITON:
+if DeviceConfig.supports_triton:
     from vllm_ascend.ops.triton.rms_norm import triton_q_rms  # noqa: F811
 else:
     triton_q_rms = None  # type: ignore
@@ -376,10 +373,10 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1
         self.spec_slot_mapping = None
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
-            self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens,)  # type: ignore
-        else:
+        if DeviceConfig.slot_mapping_2d:
             self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens, 2)  # type: ignore
+        else:
+            self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens,)  # type: ignore
         if self.speculative_config:
             spec_token_num = self.speculative_config.num_speculative_tokens
             self.spec_slot_mapping = [
@@ -564,7 +561,9 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
         # NOTE: Currently, MTP-fullgraph is incompatibility pcp
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
-        self.slot_mapping[:num_input_tokens] = DeviceOperator.format_dsa_slot_mapping(slot_mapping, self.block_size)
+        self.slot_mapping[:num_input_tokens] = DeviceConfig.device_operator.format_dsa_slot_mapping(
+            slot_mapping, self.block_size
+        )
 
         self.graph_pad_size = common_attn_metadata.graph_pad_size
         block_table_size = self.get_block_table_size(common_attn_metadata, BUILD_METADATA_STEP_PREFILL)
@@ -732,8 +731,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         cu_c128_cmp_seqlen_list = None
 
         layer_name = f"c{self.compressor_ratio}"
-        metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-        metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
+        metadata_op = DeviceConfig.device_operator.get_dsa_sparse_attn_metadata_op()
+        metadata_kwargs = DeviceConfig.device_operator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
         if self.compressor_ratio <= 1:
             if self.prefill_ratio_to_sas_metadata.get(layer_name) is None:
                 self.prefill_ratio_to_sas_metadata[layer_name] = metadata_op(
@@ -964,7 +963,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 "compressed_tokens_start_" + str(self.compressor_ratio)
             ]
 
-        slot_mapping = DeviceOperator.pad_dsa_decode_slot_mapping(
+        slot_mapping = DeviceConfig.device_operator.pad_dsa_decode_slot_mapping(
             self.slot_mapping[:compressed_tokens_start], self.num_decode_tokens, self.compressor_ratio, self.num_decodes
         )
 
@@ -982,7 +981,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
         assert self.decode_sas_metadata is not None
 
-        cu_seqlens_ori_kv = DeviceOperator.get_dsa_decode_cu_seqlens_ori_kv(
+        cu_seqlens_ori_kv = DeviceConfig.device_operator.get_dsa_decode_cu_seqlens_ori_kv(
             self.decode_ratio_to_sas_metadata,
             "cu_seqlens_ori_kv",
             self.seq_lens,
@@ -990,9 +989,9 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             self._zero_i32,
             self.cu_seqlens_ori_kv,
         )
-        metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-        metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
-        cu_seqlens_cmp_kv = DeviceOperator.get_dsa_decode_cu_seqlens_cmp_kv(self.cu_seqlens_cmp_kv)
+        metadata_op = DeviceConfig.device_operator.get_dsa_sparse_attn_metadata_op()
+        metadata_kwargs = DeviceConfig.device_operator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
+        cu_seqlens_cmp_kv = DeviceConfig.device_operator.get_dsa_decode_cu_seqlens_cmp_kv(self.cu_seqlens_cmp_kv)
         if self.compressor_ratio <= 1:
             if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
                 self.decode_ratio_to_sas_metadata[layer_name] = metadata_op(
@@ -1141,8 +1140,10 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=False)
 
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
-        self.spec_slot_mapping[draft_step - 1][:num_input_tokens] = DeviceOperator.format_dsa_slot_mapping(  # type: ignore[index]
-            slot_mapping, self.block_size
+        self.spec_slot_mapping[draft_step - 1][:num_input_tokens] = (  # type: ignore[index]
+            DeviceConfig.device_operator.format_dsa_slot_mapping(  # type: ignore[index]
+                slot_mapping, self.block_size
+            )
         )
 
         prefill_metadata = None
@@ -1210,8 +1211,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         prefill_slot_mapping = self.spec_slot_mapping[draft_step - 1][tokens_start:num_prefill_tokens]  # type: ignore[index]
         block_table = common_attn_metadata.block_table_tensor[: common_attn_metadata.num_reqs]
 
-        metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-        metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
+        metadata_op = DeviceConfig.device_operator.get_dsa_sparse_attn_metadata_op()
+        metadata_kwargs = DeviceConfig.device_operator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
         sas_metadata = metadata_op(
             **metadata_kwargs,
             num_heads_q=n_local_heads,
@@ -1291,8 +1292,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         slot_mapping = self.spec_slot_mapping[draft_step - 1][:num_decode_tokens_typed]  # type: ignore[index]
         block_table = common_attn_metadata.block_table_tensor
 
-        metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-        metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
+        metadata_op = DeviceConfig.device_operator.get_dsa_sparse_attn_metadata_op()
+        metadata_kwargs = DeviceConfig.device_operator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
 
         decode_sas_metadata = metadata_op(
             **metadata_kwargs,
@@ -1585,7 +1586,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         )
 
         # o
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
+        if DeviceConfig.supports_mxfp:
             o = o_proj_input.view(num_tokens, self.n_local_groups, -1)
             o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
             o = torch_npu.npu_transpose_quant_batchmatmul(
@@ -1691,7 +1692,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 rotary_mode="interleave",
                 partial_slice=[self.nope_head_dim, self.head_dim],
             )
-            DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, slot_mapping)
+            DeviceConfig.device_operator.dsa_kv_compress_scatter(swa_kv_cache, kv, slot_mapping)
 
         if is_prefill:
             q = self.cv_wq_b.matmul(q_b_quant, q_b_scale).unflatten(-1, (self.n_local_heads, self.head_dim))
@@ -1710,7 +1711,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         # Serial tail: wait for auxiliary stream then execute q_rms[V] + rope[V]
         main_stream.wait_stream(aux_stream)
 
-        q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
+        q = DeviceConfig.device_operator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
         torch.ops._C_ascend.inplace_partial_rotary_mul(
             q.unsqueeze(1),
             cos,
@@ -1730,7 +1731,7 @@ class AscendDSAImpl(DSAAttentionImpl):
     ):
         compress_common_attn_metadata = None
         (compress_kv_cache, swa_kv_cache, state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
-            DeviceOperator.unpack_dsa_forward_kv_cache(kv_cache, self.compress_ratio)
+            DeviceConfig.device_operator.unpack_dsa_forward_kv_cache(kv_cache, self.compress_ratio)
         )
 
         if self.compress_ratio == 4:
@@ -1793,7 +1794,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 qr = self.q_norm(q_a)
                 q = self.wq_b(qr).unflatten(-1, (self.n_local_heads, self.head_dim))
                 qr_pertoken_scale = None
-            q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
+            q = DeviceConfig.device_operator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
 
             torch.ops._C_ascend.inplace_partial_rotary_mul(
                 q.unsqueeze(1),
@@ -1827,14 +1828,16 @@ class AscendDSAImpl(DSAAttentionImpl):
             )
 
             # swa exec kv
-            DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, swa_prefill_metadata.slot_mapping)
+            DeviceConfig.device_operator.dsa_kv_compress_scatter(swa_kv_cache, kv, swa_prefill_metadata.slot_mapping)
 
         compress_cos = common_prefill_metadata.compress_cos[layer_name]
         compress_sin = common_prefill_metadata.compress_sin[layer_name]
 
-        attn_op = DeviceOperator.get_dsa_sparse_attn_op()
-        extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
-        DeviceOperator.add_dsa_sparse_attn_extra_kwargs(extra_attn_kwargs, cu_seqlens_ori_kv=actual_seq_lengths_query)
+        attn_op = DeviceConfig.device_operator.get_dsa_sparse_attn_op()
+        extra_attn_kwargs: dict = DeviceConfig.device_operator.get_dsa_sparse_attn_base_kwargs()
+        DeviceConfig.device_operator.add_dsa_sparse_attn_extra_kwargs(
+            extra_attn_kwargs, cu_seqlens_ori_kv=actual_seq_lengths_query
+        )
 
         if self.compress_ratio <= 1:
             return attn_op(
@@ -1936,9 +1939,9 @@ class AscendDSAImpl(DSAAttentionImpl):
                     torch.npu.current_stream().wait_event(e_compressed_kv_done)
                     weights_proj_output = self.weights_proj(hidden_states)
                 # Main stream: q_quant (between compressed_kv and kv_scatter)
-                q_quant, q_scale = DeviceOperator.indexer_quantize_query(indexer_q)
+                q_quant, q_scale = DeviceConfig.device_operator.indexer_quantize_query(indexer_q)
 
-            DeviceOperator.dsa_kv_compress_scatter(
+            DeviceConfig.device_operator.dsa_kv_compress_scatter(
                 compress_kv_cache, compressed_kv, compressor_prefill_metadata.slot_mapping
             )
 
@@ -1955,9 +1958,9 @@ class AscendDSAImpl(DSAAttentionImpl):
                 compress_topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer(
                     query=q_quant,
                     key=indexer_k_cache,
-                    weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
-                    query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
-                    key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
+                    weights=DeviceConfig.device_operator.prepare_dsa_indexer_weights(weights),
+                    query_dequant_scale=DeviceConfig.device_operator.prepare_dsa_indexer_query_scale(q_scale),
+                    key_dequant_scale=DeviceConfig.device_operator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
                     actual_seq_lengths_query=qlens,
                     actual_seq_lengths_key=kvlens,
                     block_table=block_table,
@@ -1978,7 +1981,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 self._update_indexcache_topk_indices(compress_topk_idxs, offset=prefill_offset)
 
             if self.compress_ratio == 4:
-                DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
+                DeviceConfig.device_operator.add_dsa_sparse_attn_extra_kwargs(
                     extra_attn_kwargs, cu_seqlens_cmp_kv=common_prefill_metadata.cu_c4_cmp_seqlen_list
                 )
                 attn_output = attn_op(
@@ -2003,7 +2006,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                     **extra_attn_kwargs,
                 )[0]
             else:
-                DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
+                DeviceConfig.device_operator.add_dsa_sparse_attn_extra_kwargs(
                     extra_attn_kwargs, cu_seqlens_cmp_kv=common_prefill_metadata.cu_c128_cmp_seqlen_list
                 )
                 attn_output = attn_op(
@@ -2039,7 +2042,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         compress_common_attn_metadata = None
 
         (compress_kv_cache, swa_kv_cache, state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
-            DeviceOperator.unpack_dsa_forward_kv_cache(kv_cache, self.compress_ratio)
+            DeviceConfig.device_operator.unpack_dsa_forward_kv_cache(kv_cache, self.compress_ratio)
         )
 
         if self.compress_ratio == 4:
@@ -2115,7 +2118,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 q = self.wq_b(q).unflatten(-1, (self.n_local_heads, self.head_dim))
                 qr_pertoken_scale = None
 
-            q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
+            q = DeviceConfig.device_operator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
 
             torch.ops._C_ascend.inplace_partial_rotary_mul(
                 q.unsqueeze(1),
@@ -2150,7 +2153,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             )
 
             # swa exec kv
-            DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, swa_decode_metadata.slot_mapping)
+            DeviceConfig.device_operator.dsa_kv_compress_scatter(swa_kv_cache, kv, swa_decode_metadata.slot_mapping)
 
         if self.compress_ratio > 1:
             compressor_decode_metadata = _require_decode_metadata(compressor_attn_metadata)
@@ -2229,9 +2232,9 @@ class AscendDSAImpl(DSAAttentionImpl):
                     torch.npu.current_stream().wait_event(e_compressed_kv_done)
                     weights_proj_output = self.weights_proj(hidden_states)
                 # Main stream: q_quant (between compressed_kv and kv_scatter)
-                q_quant, q_scale = DeviceOperator.indexer_quantize_query(indexer_q)
+                q_quant, q_scale = DeviceConfig.device_operator.indexer_quantize_query(indexer_q)
 
-            DeviceOperator.dsa_kv_compress_scatter(
+            DeviceConfig.device_operator.dsa_kv_compress_scatter(
                 compress_kv_cache, compressed_kv, compressor_decode_metadata.slot_mapping
             )
 
@@ -2248,9 +2251,9 @@ class AscendDSAImpl(DSAAttentionImpl):
                 compress_topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer(
                     query=q_quant,
                     key=indexer_k_cache,
-                    weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
-                    query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
-                    key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
+                    weights=DeviceConfig.device_operator.prepare_dsa_indexer_weights(weights),
+                    query_dequant_scale=DeviceConfig.device_operator.prepare_dsa_indexer_query_scale(q_scale),
+                    key_dequant_scale=DeviceConfig.device_operator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
                     actual_seq_lengths_query=qlens,
                     actual_seq_lengths_key=kvlens,
                     block_table=block_table,
@@ -2270,8 +2273,8 @@ class AscendDSAImpl(DSAAttentionImpl):
             if self.compress_ratio == 4 and self.use_index_cache:
                 self._update_indexcache_topk_indices(compress_topk_idxs, offset=0)
 
-        attn_op = DeviceOperator.get_dsa_sparse_attn_op()
-        extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
+        attn_op = DeviceConfig.device_operator.get_dsa_sparse_attn_op()
+        extra_attn_kwargs: dict = DeviceConfig.device_operator.get_dsa_sparse_attn_base_kwargs()
 
         if self.compress_ratio <= 1:
             attn_output = attn_op(
@@ -2351,7 +2354,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         qr_pertoken_scale: torch.Tensor = None,
     ):
         (indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
-            DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
+            DeviceConfig.device_operator.unpack_dsa_indexer_kv_cache(kv_cache)
         )
         (
             _,
@@ -2364,7 +2367,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         if (
             _is_w8a8_dynamic(self.inderxer_wq_b)
             and qr_pertoken_scale is not None
-            and get_ascend_device_type() not in {AscendDeviceType.A5}
+            and DeviceConfig.indexer_uses_quant_matmul
         ):
             q = torch_npu.npu_quant_matmul(
                 qr,
@@ -2483,7 +2486,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             if with_prefill
             else indexer_kv_scale_metadata.decode.slot_mapping
         )
-        return DeviceOperator.indexer_quant_scatter(
+        return DeviceConfig.device_operator.indexer_quant_scatter(
             q, kv, indexer_k_cache, indexer_scale_cache, indexer_full_cache, slot_mapping
         )
 
@@ -2513,9 +2516,9 @@ class AscendDSAImpl(DSAAttentionImpl):
         topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer(
             query=q,
             key=indexer_k_cache,
-            weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
-            query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
-            key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
+            weights=DeviceConfig.device_operator.prepare_dsa_indexer_weights(weights),
+            query_dequant_scale=DeviceConfig.device_operator.prepare_dsa_indexer_query_scale(q_scale),
+            key_dequant_scale=DeviceConfig.device_operator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
             actual_seq_lengths_query=qlens,
             actual_seq_lengths_key=kvlens,
             block_table=block_table,
@@ -2592,7 +2595,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         - Part4: Caller runs weights_proj + q_quant + indexer
         """
         (indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
-            DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
+            DeviceConfig.device_operator.unpack_dsa_indexer_kv_cache(kv_cache)
         )
         # sorted keys: [attn, compressor.state_cache, indexer.compressor.state_cache, indexer.k_cache, swa_cache]
         (_, _, indexer_kv_state_metadata, indexer_kv_scale_metadata, _) = attn_metadata
@@ -2659,7 +2662,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             )
             with npu_stream_switch(aux_stream, enabled=True):
                 torch.npu.current_stream().wait_event(e_kv_ready)
-                kv, kv_scale = DeviceOperator.indexer_quant_scatter_part1(
+                kv, kv_scale = DeviceConfig.device_operator.indexer_quant_scatter_part1(
                     kv, indexer_k_cache, indexer_full_cache, slot_mapping_indexer
                 )
 
@@ -2708,7 +2711,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             )
             with npu_stream_switch(aux_stream, enabled=True):
                 torch.npu.current_stream().wait_event(e_rope_done)
-                DeviceOperator.dsa_indexer_scatter_scale_part3(
+                DeviceConfig.device_operator.dsa_indexer_scatter_scale_part3(
                     kv_scale, indexer_scale_cache, slot_mapping_indexer_part3
                 )
 

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -43,7 +43,7 @@ from vllm_ascend.compilation.acl_graph import (
     update_draft_graph_params_workspaces,
     update_graph_params_workspaces,
 )
-from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.memcache_comm_fence import record_attention_compute_start
 from vllm_ascend.ops.layer_shard_linear import (
     is_hidden_layer,
@@ -57,8 +57,6 @@ from vllm_ascend.quantization.methods.w8a8_static import AscendW8A8LinearMethod
 from vllm_ascend.quantization.utils import enable_fa_quant
 from vllm_ascend.utils import (
     ACL_FORMAT_FRACTAL_ND,
-    AscendDeviceType,
-    get_ascend_device_type,
     get_weight_prefetch_method,
     maybe_trans_nz,
     weak_ref_tensors,
@@ -756,7 +754,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         self.layer_name = kwargs.get("layer_name")
         self.fa_quant_layer = enable_fa_quant(self.vllm_config, self.layer_name)
         if self.fa_quant_layer:
-            self.dtype = torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else torch.int8
+            self.dtype = DeviceConfig.fa_quant_act_dtype
         else:
             self.dtype = self.vllm_config.model_config.dtype
         self.layer_sharding_kwargs = []
@@ -971,7 +969,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                     "Some layers not W8A8 quantized, mlapo disabled for these layers."
                 )
         if self.enable_mlapo:
-            if get_ascend_device_type() == AscendDeviceType.A5:
+            if DeviceConfig.mlapo_uses_a5_weight_processing:
                 self._process_weights_for_fused_mlapo_a5(act_dtype)
             else:
                 self._process_weights_for_fused_mlapo(act_dtype)
@@ -986,7 +984,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                 post_process_after_loading_for_shard_weight_series(layer)
 
     def _process_weights_for_fused_fa_quant(self):
-        if get_ascend_device_type() == AscendDeviceType.A5:
+        if DeviceConfig.fa_quant_uses_fak_descale:
             layer = self.vllm_config.compilation_config.static_forward_context[self.layer_name]
             self.fak_descale_float = layer.fak_descale_float
             self.quant_kscale = layer.quant_kscale
@@ -1186,7 +1184,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             kv_c_normed = torch.empty(toks, num_heads, latent_kv_dim, dtype=cache_kv_c.dtype, device=cache_kv_c.device)
             k_pe = torch.empty(toks, num_heads, rope_dim, dtype=q_pe.dtype, device=q_pe.device)
 
-            DeviceOperator.kv_cache_load(
+            DeviceConfig.device_operator.kv_cache_load(
                 cache_kv_c,
                 cache_k_pe,
                 prefill_metadata.block_table,
@@ -1203,7 +1201,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                 toks=toks,
             )
             kv_c_normed = kv_c_normed.squeeze()
-            if self.fa_quant_layer and get_ascend_device_type() == AscendDeviceType.A5:
+            if self.fa_quant_layer and DeviceConfig.fa_quant_uses_fak_descale:
                 kv_c_normed = torch.mul(kv_c_normed.to(self.fak_descale_float.dtype), self.fak_descale_float).to(
                     torch.bfloat16
                 )
@@ -1320,7 +1318,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         kv_no_split = kv_no_split.view(B, N, S, self.kv_lora_rank + self.qk_rope_head_dim)
         cache_mode = "PA_NZ" if self.enable_kv_nz else "PA"
         c_kv_scale = None
-        if get_ascend_device_type() == AscendDeviceType.A5 and self.fa_quant_layer:
+        if DeviceConfig.fa_quant_uses_c_kv_scale and self.fa_quant_layer:
             c_kv_scale = self.fak_descale_reciprocal
         k_pe, k_nope, _, _ = torch_npu.npu_kv_rmsnorm_rope_cache(
             kv_no_split,
@@ -1352,7 +1350,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         kv_no_split = kv_no_split.view(B, N, S, self.kv_lora_rank + self.qk_rope_head_dim)
         cache_mode = "PA"
         c_kv_scale = None
-        if get_ascend_device_type() == AscendDeviceType.A5 and self.fa_quant_layer:
+        if DeviceConfig.fa_quant_uses_c_kv_scale and self.fa_quant_layer:
             c_kv_scale = self.fak_descale_reciprocal
         _, _, k_pe, k_nope = torch_npu.npu_kv_rmsnorm_rope_cache(
             kv_no_split,
@@ -1400,7 +1398,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         # shape of knope/k_pe for npu graph mode should be:
         # [num_blocks, num_kv_heads, block_size, self.kv_lora_rank/self.qk_rope_head_dim]
         actual_seq_lengths = None
-        if self.fa_quant_layer and get_ascend_device_type() != AscendDeviceType.A5:
+        if self.fa_quant_layer and DeviceConfig.fa_quant_uses_nz_format:
             nz_fmt_last_dim = 16
             k_nope = k_nope.view(
                 -1, self.num_kv_heads, self.kv_lora_rank // (nz_fmt_last_dim * 2), block_size, nz_fmt_last_dim * 2
@@ -1453,7 +1451,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             attn_mask = None
             sparse_mode = 0
             actual_seq_lengths = None
-            if get_ascend_device_type() == AscendDeviceType.A5:
+            if DeviceConfig.fa_quant_layout == "BNSD":
                 input_layout = "BNSD"
                 q_nope = q_nope.view(num_tokens, self.num_heads, 1, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, self.num_heads, 1, -1)
@@ -1620,7 +1618,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         decode_ql_nope, decode_q_pe = self._q_proj_and_k_up_proj(decode_q_c)
         decode_q_pe = self.rope_single(decode_q_pe, cos, sin)
         dequant_scale_q_nope = None
-        if self.fa_quant_layer and get_ascend_device_type() == AscendDeviceType.A5:
+        if self.fa_quant_layer and DeviceConfig.fa_quant_dynamic_quant_decode:
             decode_ql_nope, dequant_scale_q_nope = torch_npu.npu_dynamic_quant(
                 decode_ql_nope, dst_type=torch.float8_e4m3fn
             )
@@ -1748,7 +1746,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
                 hidden_states.contiguous(), need_gather_q_kv
             )
-            decode_preprocess_res, prefill_preprocess_res = DeviceOperator.mla_preprocess_only_decode(
+            decode_preprocess_res, prefill_preprocess_res = DeviceConfig.device_operator.mla_preprocess_only_decode(
                 self, hidden_states, kv_cache, attn_metadata
             )
         else:

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -11,7 +11,6 @@ from vllm.distributed import get_tensor_model_parallel_world_size, get_tp_group
 from vllm.logger import logger
 from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadataBuilder
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
-from vllm.triton_utils import HAS_TRITON
 from vllm.v1.attention.backend import (
     AttentionBackend,  # type: ignore
     AttentionCGSupport,
@@ -35,7 +34,7 @@ from vllm_ascend.attention.utils import (
     transdata,
     wait_for_kv_layer_from_connector,
 )
-from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.device.mxfp_compat import FLOAT8_E8M0FNU_DTYPE
 from vllm_ascend.distributed.utils import all_gather_async
 from vllm_ascend.memcache_comm_fence import (
@@ -52,14 +51,12 @@ from vllm_ascend.ops.triton.rope import rope_forward_triton_siso
 from vllm_ascend.quantization.methods import AscendW8A8LinearMethod, AscendW8A8MXFP8DynamicLinearMethod
 from vllm_ascend.utils import (
     ACL_FORMAT_FRACTAL_ND,
-    AscendDeviceType,
     _round_up,
     dispose_layer,
     enable_dsa_cp,
     enable_dsa_cp_with_layer_shard,
     enable_dsa_cp_with_o_proj_tp,
     enable_sp,
-    get_ascend_device_type,
     get_weight_prefetch_method,
     maybe_trans_nz,
 )
@@ -518,14 +515,10 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         # dsa c8
         self.use_sparse_c8_indexer = ascend_config.is_sparse_c8_layer(self.layer_name)
-        self.use_a5_sparse_c8_indexer = self.use_sparse_c8_indexer and (get_ascend_device_type() == AscendDeviceType.A5)
+        self.use_a5_sparse_c8_indexer = self.use_sparse_c8_indexer and DeviceConfig.indexer_has_full_cache
         if self.use_sparse_c8_indexer:
-            if get_ascend_device_type() == AscendDeviceType.A5:
-                self.c8_k_cache_dtype = torch.float8_e4m3fn
-                self.c8_k_scale_cache_dtype = torch.float32
-            else:
-                self.c8_k_cache_dtype = torch.int8
-                self.c8_k_scale_cache_dtype = torch.float16
+            self.c8_k_cache_dtype = DeviceConfig.c8_k_cache_dtype
+            self.c8_k_scale_cache_dtype = DeviceConfig.c8_k_scale_cache_dtype
 
         # Effective in SFA when FlashComm is enabled.
         self.enable_dsa_cp = enable_dsa_cp()
@@ -624,7 +617,7 @@ class AscendSFAImpl(MLAAttentionImpl):
             is_quantized = isinstance(quant_method, (AscendW8A8LinearMethod, AscendW8A8MXFP8DynamicLinearMethod))
             if self.fused_qkv_a_proj is None:
                 reasons.append("fused_qkv_a_proj is None, mlapo is disabled.")
-            if not is_quantized and get_ascend_device_type() != AscendDeviceType.A5:
+            if not is_quantized and DeviceConfig.mlapo_requires_quantization:
                 reasons.append(
                     "Currently mlapo only supports W8A8 quantization in SFA scenario on non-A5 devices."
                     "Some layers in your model are not quantized with W8A8,"
@@ -638,7 +631,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                     logger.warning_once(msg)
             else:
                 self.mlapo_is_quantized = is_quantized
-                if get_ascend_device_type() == AscendDeviceType.A5:
+                if DeviceConfig.mlapo_uses_a5_weight_processing:
                     if is_quantized:
                         self._process_weights_for_fused_mlapo_a5(act_dtype)
                     else:
@@ -646,7 +639,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                 else:
                     self._process_weights_for_fused_mlapo(act_dtype)
 
-        if self.use_sparse_c8_indexer and get_ascend_device_type() == AscendDeviceType.A5:
+        if self.use_sparse_c8_indexer and DeviceConfig.sparse_c8_supports_unquantized_mlapo:
             if hasattr(self, "mlapo_is_quantized") and not self.mlapo_is_quantized:
                 self.c8_k_cache_dtype = act_dtype
                 self.c8_k_scale_cache_dtype = act_dtype
@@ -1090,7 +1083,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         slot_mapping: torch.Tensor,
         num_input_tokens: int,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        return DeviceOperator.sfa_preprocess_with_mlapo(
+        return DeviceConfig.device_operator.sfa_preprocess_with_mlapo(
             self,
             hidden_states,
             kv_cache,
@@ -1111,7 +1104,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         k_li = self.k_norm(k_li).unsqueeze(1)
         k_li = k_li.view(-1, 1, self.head_dim)
 
-        if HAS_TRITON:
+        if DeviceConfig.supports_triton:
             cos = cos.view(-1, self.qk_rope_head_dim)
             sin = sin.view(-1, self.qk_rope_head_dim)
             k_li = rope_forward_triton_siso(
@@ -1176,7 +1169,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         else:
             q_li, _ = self.wq_b(q_c)
         q_li = q_li.view(-1, self.n_head, self.head_dim)  # [n_toks,64,128]
-        if HAS_TRITON:
+        if DeviceConfig.supports_triton:
             q_li = rope_forward_triton_siso(
                 q_li, cos, sin, rope_dim=self.qk_rope_head_dim, is_neox_style=self.is_rope_neox_style
             )
@@ -1199,7 +1192,7 @@ class AscendSFAImpl(MLAAttentionImpl):
             q_li_scale = q_li_scale.to(self.c8_k_scale_cache_dtype)  # [b*s,]
 
         record_attention_compute_start()
-        return DeviceOperator.indexer_select_post_process(
+        return DeviceConfig.device_operator.indexer_select_post_process(
             self,
             q_li,
             q_li_scale,
@@ -1236,7 +1229,7 @@ class AscendSFAImpl(MLAAttentionImpl):
     def _execute_sparse_flash_attention_process(
         self, ql_nope, q_pe, kv_cache, topk_indices, attn_metadata, actual_seq_lengths_query, actual_seq_lengths_key
     ):
-        return DeviceOperator.execute_sparse_flash_attention_process(
+        return DeviceConfig.device_operator.execute_sparse_flash_attention_process(
             self,
             ql_nope,
             q_pe,
@@ -1293,9 +1286,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         }
 
         # run mlapo ops when dsa-cp is disabled, and ensure that num_tokens satisfies the count limitation
-        if self.enable_mlapo and (
-            get_ascend_device_type() == AscendDeviceType.A5 or num_input_tokens <= MLAPO_MAX_SUPPORTED_TOKENS
-        ):
+        if self.enable_mlapo and (not DeviceConfig.mlapo_decode_only or num_input_tokens <= MLAPO_MAX_SUPPORTED_TOKENS):
             hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
                 hidden_states.contiguous(), need_gather_q_kv
             )
@@ -1451,7 +1442,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                     if not self.use_a5_sparse_c8_indexer:
                         k_nope = k_nope.view(k_nope.shape[0], 1, -1)
                         k_pe = k_pe.view(k_pe.shape[0], 1, -1)
-                        DeviceOperator.reshape_and_cache(
+                        DeviceConfig.device_operator.reshape_and_cache(
                             key=k_nope[: attn_metadata.num_actual_tokens],
                             value=k_pe[: attn_metadata.num_actual_tokens],
                             key_cache=kv_cache[0],
@@ -1462,7 +1453,7 @@ class AscendSFAImpl(MLAAttentionImpl):
             k_li = self._get_full_kv(k_li, attn_metadata)
 
         if kv_cache is not None:
-            if self.use_sparse_c8_indexer and get_ascend_device_type() == AscendDeviceType.A5:
+            if self.use_sparse_c8_indexer and not DeviceConfig.kv_cache_has_v_tensor:
                 dsa_k_cache_idx = 1
                 dsa_k_scale_cache_idx = 2
             else:
@@ -1485,10 +1476,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                     k_li.view(-1, k_li.shape[-1]),
                 )  # b, s, n, d
             if self.use_sparse_c8_indexer:
-                if get_ascend_device_type() == AscendDeviceType.A5:
-                    assert len(kv_cache) == 3
-                else:
-                    assert len(kv_cache) == 4
+                assert len(kv_cache) == DeviceConfig.sparse_c8_cache_tuple_len
                 if k_li_scale is not None:
                     if self.is_kv_producer and get_ascend_config().c8_enable_reshape_optim:
                         torch.ops._C_ascend.store_kv_block(

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -9,7 +9,8 @@ from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 
-from vllm_ascend.utils import AscendDeviceType, get_ascend_config, get_ascend_device_type
+from vllm_ascend.device.device_config import DeviceConfig
+from vllm_ascend.utils import get_ascend_config
 from vllm_ascend.worker.kvcomp_utils import KVCompMetaData
 
 
@@ -44,7 +45,7 @@ def ascend_chunked_prefill_workspace_size(vllm_config: VllmConfig) -> int:
 def using_paged_attention(runtime_shape: int, vllm_config: VllmConfig) -> bool:
     if vllm_config.speculative_config is not None:
         return False
-    if get_ascend_device_type() == AscendDeviceType.A5:
+    if not DeviceConfig.use_paged_attention:
         return False
     from vllm.config.compilation import CUDAGraphMode
 
@@ -400,7 +401,7 @@ def transdata(nd_mat, block_size: tuple = (16, 16)):
 
 def enabling_mlapo(vllm_config: VllmConfig) -> bool:
     config_val = get_ascend_config().enable_mlapo
-    if get_ascend_device_type() == AscendDeviceType.A5:
+    if not DeviceConfig.mlapo_decode_only:
         return bool(config_val)
 
     is_decode_instance = (

--- a/vllm_ascend/batch_invariant.py
+++ b/vllm_ascend/batch_invariant.py
@@ -22,13 +22,14 @@ import torch
 import torch_npu
 import vllm.envs as envs
 from vllm.logger import logger
-from vllm.triton_utils import HAS_TRITON
+
+from vllm_ascend.device.device_config import DeviceConfig
 
 # in case recursive call in reduce_sum.
 torch_sum = torch.sum
 
 
-if HAS_TRITON:
+if DeviceConfig.supports_triton:
     from vllm_ascend.ops.triton.batch_invariant.matmul import (
         addmm_batch_invariant,
         bmm_batch_invariant,
@@ -96,12 +97,12 @@ def enable_batch_invariant_mode():
     _batch_invariant_LIB = torch.library.Library("aten", "IMPL")
     logger.debug(
         "Batch-invariant op registration: Triton=%s, AscendC=%s",
-        HAS_TRITON,
+        DeviceConfig.supports_triton,
         HAS_ASCENDC_BATCH_INVARIANT,
     )
 
     # Register operators only implemented in triton.
-    if HAS_TRITON:
+    if DeviceConfig.supports_triton:
         _batch_invariant_LIB.impl("aten::addmm", addmm_batch_invariant, "NPU")
         _batch_invariant_LIB.impl("aten::bmm", bmm_batch_invariant, "NPU")
         _batch_invariant_LIB.impl("aten::softmax", softmax_batch_invariant, "NPU")
@@ -123,7 +124,7 @@ def enable_batch_invariant_mode():
         torch.sum = reduce_sum
 
     # register triton implementations if ascendc is not available.
-    elif HAS_TRITON:
+    elif DeviceConfig.supports_triton:
         _batch_invariant_LIB.impl("aten::mm", mm_batch_invariant, "NPU")
         _batch_invariant_LIB.impl("aten::matmul", matmul_batch_invariant, "NPU")
 
@@ -145,7 +146,7 @@ def init_batch_invariance():
     environment variable to enable automatically.
     """
     if envs.VLLM_BATCH_INVARIANT:
-        if HAS_TRITON or HAS_ASCENDC_BATCH_INVARIANT:
+        if DeviceConfig.supports_triton or HAS_ASCENDC_BATCH_INVARIANT:
             logger.info(
                 "Enabling batch-invariant mode for vLLM on Ascend NPU.",
             )

--- a/vllm_ascend/compilation/graph_fusion_pass_manager.py
+++ b/vllm_ascend/compilation/graph_fusion_pass_manager.py
@@ -47,11 +47,11 @@ class GraphFusionPassManager:
         self.passes.append(pass_)
 
     def configure(self, config: VllmConfig):
-        from vllm_ascend.utils import is_310p
+        from vllm_ascend.device.device_config import DeviceConfig
 
         # By default, we enable the graph fusion and quantization fusion pass.
         self.ascend_compilation_config: dict = config.additional_config.get("ascend_compilation_config", {})
-        if self.ascend_compilation_config.get("fuse_norm_quant", True) and not is_310p():
+        if self.ascend_compilation_config.get("fuse_norm_quant", True) and DeviceConfig.supports_compilation_custom_ops:
             from .passes.norm_quant_fusion_pass import AddRMSNormQuantFusionPass
 
             self.passes.append(AddRMSNormQuantFusionPass(config))
@@ -66,7 +66,7 @@ class GraphFusionPassManager:
 
             self.passes.append(MatmulAllReduceAddRMSNormPass(config))
 
-        if self.ascend_compilation_config.get("fuse_muls_add", True) and not is_310p():
+        if self.ascend_compilation_config.get("fuse_muls_add", True) and DeviceConfig.supports_compilation_custom_ops:
             from .passes.muls_add_pass import MulsAddFusionPass
 
             self.passes.append(MulsAddFusionPass(config))

--- a/vllm_ascend/compilation/passes/qknorm_rope_fusion_pass.py
+++ b/vllm_ascend/compilation/passes/qknorm_rope_fusion_pass.py
@@ -24,7 +24,7 @@ from vllm.logger import logger
 from vllm.model_executor.layers.attention import Attention
 
 from vllm_ascend.compilation.passes.base_pattern import BasePattern
-from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.utils import get_rope_dim
 
 
@@ -83,7 +83,7 @@ class QKNormRopeFusionPattern(BasePattern):
             cos_sin_cache: torch.Tensor,
             positions: torch.Tensor,
         ):
-            results = DeviceOperator.split_qkv_rmsnorm_rope(
+            results = DeviceConfig.device_operator.split_qkv_rmsnorm_rope(
                 input=qkv,
                 q_weight=q_weight,
                 k_weight=k_weight,
@@ -166,7 +166,7 @@ class QKNormRopeFusionPatternWithBias(BasePattern):
             cos_sin_cache: torch.Tensor,
             positions: torch.Tensor,
         ):
-            results = DeviceOperator.split_qkv_rmsnorm_rope(
+            results = DeviceConfig.device_operator.split_qkv_rmsnorm_rope(
                 input=qkv,
                 q_weight=q_weight,
                 k_weight=k_weight,

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -10,7 +10,7 @@ import psutil
 import regex as re
 from vllm.logger import logger
 
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+from vllm_ascend.device.device_config import DeviceConfig
 
 MASK_BIT = 32  # Number of bits in a CPU affinity mask group
 MIN_CPUS_PER_NPU = 5  # 2(IRQ) + 1(main, at least 1 CPU) + 1(acl) + 1(release) = 5 CPUs per NPU
@@ -20,14 +20,6 @@ ASCEND_RT_VISIBLE_DEVICES = os.getenv("ASCEND_RT_VISIBLE_DEVICES")
 
 TOPO_AFFINITY_MODE = "topo_affinity"
 GLOBAL_SLICE_MODE = "global_slice"
-
-DEVICE_BINDING_MODE: dict["AscendDeviceType", str] = {
-    AscendDeviceType.A2: TOPO_AFFINITY_MODE,
-    AscendDeviceType.A3: GLOBAL_SLICE_MODE,
-    AscendDeviceType._310P: TOPO_AFFINITY_MODE,
-    AscendDeviceType.A5: GLOBAL_SLICE_MODE,
-}
-NO_IRQ_BINDING_DEVICE_TYPES = {AscendDeviceType.A5}
 
 
 def is_arm_cpu() -> bool:
@@ -369,12 +361,11 @@ class CpuAlloc:
 
     @staticmethod
     def _binding_mode() -> str:
-        device_type = get_ascend_device_type()
-        return DEVICE_BINDING_MODE.get(device_type, TOPO_AFFINITY_MODE)
+        return DeviceConfig.cpu_binding_mode
 
     @staticmethod
     def _reserve_irq_cpus() -> bool:
-        return get_ascend_device_type() not in NO_IRQ_BINDING_DEVICE_TYPES
+        return DeviceConfig.enable_irq_binding
 
     @staticmethod
     def _min_cpus_per_npu() -> int:
@@ -546,8 +537,7 @@ class CpuAlloc:
         sq_cpu, cq_cpu = cpus[0], cpus[1]  # Reserved for IRQ binding
         pci_addr = ""
 
-        device_type = get_ascend_device_type()
-        if device_type == AscendDeviceType.A3:
+        if DeviceConfig.npu_smi_uses_logical_id:
             # A3: logical npu_id = card_id*2 + chip_id
             card_id = npu // 2
             chip_id = npu % 2

--- a/vllm_ascend/device/device_config.py
+++ b/vllm_ascend/device/device_config.py
@@ -1,0 +1,460 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from enum import Enum
+
+import torch
+import torch_npu
+
+
+class AscendDeviceType(Enum):
+    A2 = 0
+    A3 = 1
+    _310P = 2
+    A5 = 3
+
+
+def _soc_version_to_device_type(soc_version: int) -> AscendDeviceType:
+    if 220 <= soc_version <= 225:
+        return AscendDeviceType.A2
+    if 250 <= soc_version <= 255:
+        return AscendDeviceType.A3
+    if 200 <= soc_version <= 205:
+        return AscendDeviceType._310P
+    if soc_version == 260:
+        return AscendDeviceType.A5
+    raise RuntimeError(f"Can not support soc_version: {soc_version}.")
+
+
+def check_ascend_device_type():
+    """Verify the runtime device matches the built-in device type.
+
+    Call this at worker startup, after `torch_npu` is usable, to detect
+    mismatches between the installed wheel and the actual NPU.
+    """
+    soc_version = torch_npu.npu.get_soc_version()
+    cur_device_type = _soc_version_to_device_type(soc_version)
+    assert DeviceConfig._device_type == cur_device_type, (
+        f"Current device type: {cur_device_type} does not match the installed version's device type: "
+        f"{DeviceConfig._device_type}, please check your installation package."
+    )
+
+
+class _DeviceConfig:
+    """Device configuration that abstracts away device-type differences.
+
+    External modules should import the singleton :data:`device_config` and access
+    its properties instead of inspecting :class:`AscendDeviceType` directly.
+    Private identity checks (``_is_*``) are reserved for internal use; external
+    callers use only the semantic properties below.
+    """
+
+    HEAD_SIZE_PADDING = 128
+
+    _DSV4_BLOCK_SIZES = {
+        128: [[128, 128, 8, 32], [16640, 131072]],
+        64: [[64, 64, 4, 16], [8320, 65536]],
+        32: [[32, 32, 2, 8], [4160, 32768]],
+    }
+    _DSV4_BLOCK_SIZES_A5 = {
+        128: [[128, 128, 8, 16], [16896, 81920]],
+        64: [[64, 64, 4, 8], [8448, 40960]],
+        32: [[32, 32, 2, 4], [4224, 20480]],
+    }
+
+    def __init__(self):
+        from vllm_ascend import _build_info  # type: ignore
+
+        device_type = getattr(_build_info, "__device_type__", None)
+        if device_type is None:
+            self._device_type = _soc_version_to_device_type(torch_npu.npu.get_soc_version())
+        else:
+            self._device_type = AscendDeviceType[device_type]
+
+    # ==== private identity (for internal use only) ===========================
+
+    @property
+    def _is_a2(self) -> bool:
+        return self._device_type == AscendDeviceType.A2
+
+    @property
+    def _is_a3(self) -> bool:
+        return self._device_type == AscendDeviceType.A3
+
+    @property
+    def _is_310p(self) -> bool:
+        return self._device_type == AscendDeviceType._310P
+
+    @property
+    def _is_a5(self) -> bool:
+        return self._device_type == AscendDeviceType.A5
+
+    # ==== dtype choices ======================================================
+
+    @property
+    def c8_k_cache_dtype(self) -> torch.dtype:
+        """KV cache dtype for sparse C8 indexer (k_cache)."""
+        return torch.float8_e4m3fn if self._is_a5 else torch.int8
+
+    @property
+    def c8_k_scale_cache_dtype(self) -> torch.dtype:
+        """KV cache scale dtype for sparse C8 indexer (k_scale_cache)."""
+        return torch.float32 if self._is_a5 else torch.float16
+
+    @property
+    def fa_quant_act_dtype(self) -> torch.dtype:
+        """Activation quantization dtype for fused-attention quant."""
+        return torch.float8_e4m3fn if self._is_a5 else torch.int8
+
+    @property
+    def kv_cache_dtype(self) -> torch.dtype:
+        """Default KV cache dtype."""
+        return torch.float8_e4m3fn if self._is_a5 else torch.int8
+
+    @property
+    def indexer_k_dtype(self) -> torch.dtype:
+        """Indexer k_cache dtype."""
+        return torch.float8_e4m3fn if self._is_a5 else torch.int8
+
+    @property
+    def mla_scale_dtype(self) -> torch.dtype:
+        """Scale dtype for MLA attention spec."""
+        return torch.float if self._is_a5 else torch.float16
+
+    @property
+    def swa_cache_dtype(self) -> torch.dtype:
+        """SWA cache dtype."""
+        return torch.float8_e4m3fn if self._is_a5 else torch.bfloat16
+
+    @property
+    def kv_quant_dtype(self) -> torch.dtype:
+        """KV quantization dtype."""
+        return torch.float8_e4m3fn if self._is_a5 else torch.int8
+
+    @property
+    def norm_dtype(self) -> torch.dtype | None:
+        """RMSNorm dtype for Compressor layers."""
+        return torch.float32 if self._is_a5 else None
+
+    # ==== size / shape =======================================================
+
+    def pd_cache_head_size(self, head_dim: int) -> int:
+        """Get the padded cache head size for a given head dimension.
+
+        On A5, the head size is padded by HEAD_SIZE_PADDING to accommodate
+        quant-scale metadata alongside the KV data.
+        """
+        return head_dim + self.HEAD_SIZE_PADDING if self._is_a5 else head_dim
+
+    @property
+    def dsv4_block_sizes(self) -> dict:
+        """DeepSeek V4 block-size tables (per head_size)."""
+        return self._DSV4_BLOCK_SIZES_A5 if self._is_a5 else self._DSV4_BLOCK_SIZES
+
+    @property
+    def slot_mapping_2d(self) -> bool:
+        """Whether slot_mapping uses 2D [block_idx, offset] format.
+
+        A5 uses 1D flat indices; other devices use 2D.
+        """
+        return not self._is_a5
+
+    @property
+    def kv_cache_has_v_tensor(self) -> bool:
+        """Whether sparse C8 KV cache has a separate v_tensor.
+
+        On A5, kv_lora and k_rope are merged into a single CKV tensor.
+        """
+        return not self._is_a5
+
+    @property
+    def indexer_has_full_cache(self) -> bool:
+        """Whether indexer KV cache includes a full_cache slot."""
+        return self._is_a5
+
+    @property
+    def sparse_c8_cache_tuple_len(self) -> int:
+        """Number of elements in sparse C8 KV cache tuple."""
+        return 3 if self._is_a5 else 4
+
+    # ==== feature flags ======================================================
+
+    @property
+    def enable_atb(self) -> bool:
+        """Whether ATB extensions should be registered/warmed-up."""
+        return not self._is_a5
+
+    @property
+    def enable_local_comm_res(self) -> bool:
+        """Whether to set up ascend local communication resources."""
+        return self._is_a5
+
+    @property
+    def use_paged_attention(self) -> bool:
+        """Whether paged attention is supported."""
+        return not self._is_a5
+
+    @property
+    def mlapo_decode_only(self) -> bool:
+        """Whether MLAPO is restricted to decode-only instances.
+
+        On A5, MLAPO can be enabled unconditionally; on other devices
+        it is restricted to decode-only instances.
+        """
+        return not self._is_a5
+
+    @property
+    def mlapo_requires_quantization(self) -> bool:
+        """Whether MLAPO requires W8A8 quantization.
+
+        On A5, MLAPO supports unquantized (float) paths.
+        """
+        return not self._is_a5
+
+    @property
+    def mlapo_uses_a5_weight_processing(self) -> bool:
+        """Whether MLAPO uses A5-specific weight processing path."""
+        return self._is_a5
+
+    @property
+    def sparse_c8_supports_unquantized_mlapo(self) -> bool:
+        """Whether sparse C8 indexer supports unquantized MLAPO."""
+        return self._is_a5
+
+    @property
+    def fa_quant_decode_only(self) -> bool:
+        """Whether FA-quant is restricted to decode-only instances.
+
+        On A5, FA-quant can be enabled on any instance.
+        """
+        return not self._is_a5
+
+    @property
+    def fa_quant_uses_nz_format(self) -> bool:
+        """Whether FA-quant uses NZ (non-zero) layout for K cache."""
+        return not self._is_a5
+
+    @property
+    def supports_mxfp(self) -> bool:
+        """Whether MXFP quantization (MXFP4/MXFP8) is supported."""
+        return self._is_a5
+
+    @property
+    def enable_custom_ops(self) -> bool:
+        """Whether custom ops are enabled."""
+        return not self._is_a5
+
+    @property
+    def supports_compilation_custom_ops(self) -> bool:
+        """Whether vLLM compilation custom ops are supported.
+
+        Currently disabled on 310P.
+        """
+        return self._device_type != AscendDeviceType._310P
+
+    @property
+    def supports_triton(self) -> bool:
+        """Whether Triton is available on this device.
+
+        Triton is required on A2/A3/A5, only 310P cannot install it.
+        Additionally verifies that Triton is actually functional
+        (importable with backends).
+        """
+        if self._is_310p:
+            return False
+        from importlib.util import find_spec
+
+        if find_spec("triton") is None:
+            return False
+        try:
+            from triton.backends import backends  # type: ignore[import-untyped]  # noqa: F401
+        except Exception:
+            return False
+        return True
+
+    @property
+    def enable_npu_graph_ex(self) -> bool:
+        """Whether npugraph_ex is enabled."""
+        return not self._is_a5
+
+    @property
+    def enable_irq_binding(self) -> bool:
+        """Whether IRQ CPU binding is enabled."""
+        return not self._is_a5
+
+    @property
+    def use_ascendc_sampler(self) -> bool:
+        """Whether to use AscendC top-k/top-p sampler kernel."""
+        return self._device_type in {AscendDeviceType.A2, AscendDeviceType.A3}
+
+    @property
+    def use_ascend_lora_ops(self) -> bool:
+        """Whether to use ascend custom LoRA ops vs torch native LoRA ops."""
+        return not self._is_310p
+
+    @property
+    def use_310p_comm_adaptation(self) -> bool:
+        """Whether to activate 310P-specific communication adaptation."""
+        return self._is_310p
+
+    # ==== 310P-specific semantic flags ====================================
+
+    @property
+    def force_nz_weight_format(self) -> bool:
+        """Whether weights should always be converted to NZ format.
+
+        310P always converts supported weights to FRACTAL_NZ regardless
+        of the weight_nz_mode config.
+        """
+        return self._is_310p
+
+    @property
+    def use_310p_op_implementations(self) -> bool:
+        """Whether to register 310P-specific operator implementations.
+
+        310P uses dedicated kernel implementations for ops such as
+        FusedMoE, RMSNorm, RotaryEmbedding, etc.
+        """
+        return self._is_310p
+
+    @property
+    def supports_advanced_quantization(self) -> bool:
+        """Whether compressed-tensors and fp8 quantization are supported.
+
+        Disabled on 310P which only supports modelslim quantization.
+        """
+        return not self._is_310p
+
+    @property
+    def use_310p_worker(self) -> bool:
+        """Whether to use the 310P-specific worker implementation."""
+        return self._is_310p
+
+    @property
+    def supports_advanced_attention_backends(self) -> bool:
+        """Whether MLA, SFA, DSA attention backends are supported.
+
+        310P only supports the basic attention backend.
+        """
+        return not self._is_310p
+
+    @property
+    def use_310p_mamba_config(self) -> bool:
+        """Whether to use the 310P-specific mamba cache configuration."""
+        return self._is_310p
+
+    @property
+    def supports_advanced_model_patches(self) -> bool:
+        """Whether advanced model patches (qwen3_5, dflash, vl) are supported.
+
+        Disabled on 310P which uses IDEX-based model patches instead.
+        """
+        return not self._is_310p
+
+    @property
+    def use_310p_gdn_attention(self) -> bool:
+        """Whether to use the 310P-specific GDN attention backend."""
+        return self._is_310p
+
+    @property
+    def wo_a_transpose_enabled(self) -> bool:
+        """Whether to transpose wo_a weight during weight loading."""
+        return not self._is_a5
+
+    @property
+    def compressor_uses_quant_config(self) -> bool:
+        """Whether Compressor layers should receive quant_config."""
+        return not self._is_a5
+
+    @property
+    def fal_descale_reciprocal_uses_float(self) -> bool:
+        """Whether FAK descale reciprocal should be computed in float32."""
+        return self._is_a5
+
+    @property
+    def indexer_uses_quant_matmul(self) -> bool:
+        """Whether indexer wq_b uses NPU quant matmul (with per-token scale)."""
+        return not self._is_a5
+
+    @property
+    def vision_tower_preserves_quantized_dtype(self) -> bool:
+        """Whether vision tower weights are pre-quantized and must not be
+        overwritten by model dtype conversion."""
+        return self._is_a5
+
+    # ==== distributed / comm =================================================
+
+    @property
+    def memcache_lazy_init(self) -> bool:
+        """Whether KV transfer memcache supports lazy initialization.
+
+        Disabled on A2 due to known issues.
+        """
+        return not self._is_a2
+
+    # ==== MoE ================================================================
+
+    @property
+    def moe_dispatch_requires_extra_args(self) -> bool:
+        """Whether MoE token dispatch requires extra_args for v2 API."""
+        return self._device_type in {AscendDeviceType.A3, AscendDeviceType.A5}
+
+    @property
+    def moe_dispatch_uses_a5_specific(self) -> bool:
+        """Whether MoE token dispatch uses A5-specific params."""
+        return self._is_a5
+
+    # ==== CPU binding ========================================================
+
+    @property
+    def cpu_binding_mode(self) -> str:
+        """CPU binding strategy string."""
+        return {
+            AscendDeviceType.A2: "topo_affinity",
+            AscendDeviceType.A3: "global_slice",
+            AscendDeviceType._310P: "topo_affinity",
+            AscendDeviceType.A5: "global_slice",
+        }.get(self._device_type, "topo_affinity")
+
+    @property
+    def npu_smi_uses_logical_id(self) -> bool:
+        """Whether npu-smi uses logical chip-level IDs (card*2+chip)."""
+        return self._is_a3
+
+    # ==== fa_quant properties ================================================
+
+    @property
+    def fa_quant_uses_c_kv_scale(self) -> bool:
+        """Whether FA-quant decode passes c_kv_scale to npu_kv_rmsnorm_rope_cache."""
+        return self._is_a5
+
+    @property
+    def fa_quant_uses_fak_descale(self) -> bool:
+        """Whether FA-quant prefill applies fak_descale_float multiplication."""
+        return self._is_a5
+
+    @property
+    def fa_quant_dynamic_quant_decode(self) -> bool:
+        """Whether to apply dynamic quantization to decode_ql_nope."""
+        return self._is_a5
+
+    @property
+    def fa_quant_layout(self) -> str:
+        """Input layout string for FA-quant decode attention."""
+        return "BNSD" if self._is_a5 else "BSND_NBSD"
+
+    # ==== Device adaptor =====================================================
+
+    @property
+    def device_operator(self):
+        """Returns the device-specific adaptor class.
+
+        Internal use by DeviceOperator singleton.
+        """
+        from vllm_ascend.device.device_op import A5DeviceAdaptor, BaseDeviceAdaptor
+
+        return A5DeviceAdaptor if self._is_a5 else BaseDeviceAdaptor
+
+
+DeviceConfig = _DeviceConfig()

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -20,8 +20,8 @@ from typing import Any
 import torch
 import torch.nn.functional as F
 import torch_npu
-from vllm.triton_utils import HAS_TRITON
 
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.device.mxfp_compat import (
     FLOAT8_E8M0FNU_DTYPE,
     QUANT_DTYPES,
@@ -31,9 +31,8 @@ from vllm_ascend.ops.triton.fla.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt
 from vllm_ascend.ops.triton.fla.solve_tril import solve_tril_16x16_kernel
 from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
 from vllm_ascend.quantization.quant_type import QuantType
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
-if HAS_TRITON:
+if DeviceConfig.supports_triton:
     from vllm_ascend.ops.triton.rms_norm import triton_q_rms  # noqa: F811
 else:
     triton_q_rms = None  # type: ignore
@@ -1672,13 +1671,3 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             positions=positions,
         )
         return results
-
-
-def get_device_adaptor() -> type["BaseDeviceAdaptor"]:
-    ascend_device_type = get_ascend_device_type()
-    if ascend_device_type == AscendDeviceType.A5:
-        return A5DeviceAdaptor
-    return BaseDeviceAdaptor
-
-
-DeviceOperator: type["BaseDeviceAdaptor"] = get_device_adaptor()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -9,8 +9,8 @@ from vllm.config import ParallelConfig
 from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import logger
 
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend import Backend
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 MEMCACHE_THREAD_START_WAIT_S = 0.1
 
@@ -32,7 +32,7 @@ class MemcacheBackend(Backend):
     ):
         self.local_rank = local_rank if local_rank is not None else get_world_group().local_rank
         self._init_bm = init_bm
-        self._is_a2 = get_ascend_device_type() in {AscendDeviceType.A2}
+        self._is_a2 = not DeviceConfig.memcache_lazy_init
         self._lazy_init = lazy_init and not self._is_a2
 
         self.store: Any | None = None

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -5,8 +5,8 @@ from collections.abc import Callable
 import torch
 from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
 
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.lora.utils import refresh_all_lora_classes
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 
 # The platforms that are compatible with the PyTorch-native implementation can
@@ -22,7 +22,7 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         PunicaWrapperBase.__init__(self, max_num_batched_tokens, max_batches, device)
         refresh_all_lora_classes()
         self.lora_config = kwargs.get("lora_config")
-        if get_ascend_device_type() == AscendDeviceType._310P or (
+        if not DeviceConfig.use_ascend_lora_ops or (
             self.lora_config is not None and self.lora_config.max_lora_rank >= 128
         ):
             from vllm.lora.ops.torch_ops import (

--- a/vllm_ascend/meta_registration.py
+++ b/vllm_ascend/meta_registration.py
@@ -1,7 +1,7 @@
 import torch
 from torch.library import Library
 
-from vllm_ascend.utils import is_310p
+from vllm_ascend.device.device_config import DeviceConfig
 
 # This file provides a template and registration utilities for writing "meta" implementations
 # of custom operators in Python for the vllm_ascend project.
@@ -88,7 +88,7 @@ def sgmv_expand_meta(
     return y_out
 
 
-if not is_310p():
+if DeviceConfig.supports_compilation_custom_ops:
     register_meta_if_necessary("_C_ascend", "get_masked_input_and_mask", get_masked_input_and_mask_meta)
     register_meta_if_necessary("_C_ascend", "bgmv_expand", bgmv_expand_meta)
     register_meta_if_necessary("_C_ascend", "sgmv_expand", sgmv_expand_meta)

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -73,14 +73,13 @@ from vllm.v1.attention.backends.mla.sparse_swa import DeepseekV4SWACache as Vllm
 from vllm.v1.kv_cache_interface import KVCacheSpec, SlidingWindowMLASpec
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.ops.dsa import AscendDeepseekSparseAttention, DSAModules
 from vllm_ascend.ops.rope_dsv4 import ComplexExpRotaryEmbedding
 from vllm_ascend.ops.triton.mul_add import muls_add_triton
 from vllm_ascend.utils import (
-    AscendDeviceType,
     enable_dsa_cp,
     extract_dsv4_layer_index,
-    get_ascend_device_type,
     get_dsv4_compress_ratio,
 )
 
@@ -90,14 +89,6 @@ def _get_ascend_dsa_backend():
     from vllm_ascend.attention.dsa_v1 import AscendDSABackend
 
     return AscendDSABackend
-
-
-def _dsv4_block_sizes():
-    # Lazy import to avoid the circular import chain (layer -> dsa_v1 ->
-    # attention_v1 -> device_op) hit during vLLM subprocess model inspection.
-    from vllm_ascend.models.layer.attention.layer import DSV4_BLOCK_SIZES
-
-    return DSV4_BLOCK_SIZES
 
 
 class AscendCompressorStateCache(CompressorStateCache):
@@ -114,7 +105,7 @@ class AscendCompressorStateCache(CompressorStateCache):
         self.block_size = block_size
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        pads = _dsv4_block_sizes()[vllm_config.cache_config.block_size][1]
+        pads = DeviceConfig.dsv4_block_sizes[vllm_config.cache_config.block_size][1]
         page_size_padded = pads[0] if self.state_dim == 2 * 256 and self.compress_ratio == 4 else pads[1]
 
         return SlidingWindowMLASpec(
@@ -145,14 +136,14 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
         super().__init__(head_dim, dtype, prefix, cache_config, compress_ratio)
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
+        if DeviceConfig.swa_cache_dtype == torch.float8_e4m3fn:
             self.dtype = torch.float8_e4m3fn
             vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
 
         from vllm.v1.kv_cache_interface import MLAAttentionSpec
 
         return MLAAttentionSpec(
-            block_size=_dsv4_block_sizes()[vllm_config.cache_config.block_size][0][0],
+            block_size=DeviceConfig.dsv4_block_sizes[vllm_config.cache_config.block_size][0][0],
             num_kv_heads=1,
             head_size=self.head_dim,
             dtype=self.dtype,
@@ -160,7 +151,7 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
             compress_ratio=self.compress_ratio,
             cache_dtype_str=self.cache_config.cache_dtype,
             scale_dim=1 if self.head_dim == 128 else 0,
-            scale_dtype=torch.float if get_ascend_device_type() in {AscendDeviceType.A5} else torch.float16,
+            scale_dtype=DeviceConfig.mla_scale_dtype,
         )
 
     def forward(self): ...
@@ -181,13 +172,13 @@ class AscendDeepseekV4SWACache(VllmDeepseekV4SWACache):
         super().__init__(head_dim, window_size, torch.uint8, prefix, cache_config)
         self.dtype = dtype
 
-        self.block_size = _dsv4_block_sizes()[cache_config.block_size][0][1]
+        self.block_size = DeviceConfig.dsv4_block_sizes[cache_config.block_size][0][1]
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
+        if DeviceConfig.swa_cache_dtype == torch.float8_e4m3fn:
             self.dtype = torch.float8_e4m3fn
             vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
-        cached_head_size = self.head_dim + 128 if get_ascend_device_type() in {AscendDeviceType.A5} else self.head_dim
+        cached_head_size = DeviceConfig.pd_cache_head_size(self.head_dim)
         return SlidingWindowMLASpec(
             block_size=self.block_size,
             num_kv_heads=1,
@@ -556,8 +547,7 @@ class Indexer(nn.Module):
             prefix=f"{prefix}.weights_proj",
             return_bias=False,
         )
-        ascend_device_type = get_ascend_device_type()
-        k_dtype = torch.float8_e4m3fn if ascend_device_type == AscendDeviceType.A5 else torch.int8
+        k_dtype = DeviceConfig.indexer_k_dtype
 
         if self.compress_ratio == 4:
             # TODO(cmq): change the dtype of cache
@@ -615,7 +605,7 @@ class Compressor(nn.Module):
             self.dim,
             self.coff * self.head_dim,
             bias=False,
-            quant_config=None if get_ascend_device_type() in {AscendDeviceType.A5} else quant_config,
+            quant_config=None if not DeviceConfig.compressor_uses_quant_config else quant_config,
             prefix=f"{prefix}.wkv",
             return_bias=False,
         )
@@ -623,13 +613,13 @@ class Compressor(nn.Module):
             self.dim,
             self.coff * self.head_dim,
             bias=False,
-            quant_config=None if get_ascend_device_type() in {AscendDeviceType.A5} else quant_config,
+            quant_config=None if not DeviceConfig.compressor_uses_quant_config else quant_config,
             prefix=f"{prefix}.wgate",
             return_bias=False,
         )
 
         # A5 compressor kernel needs float for norm_weight input
-        norm_dtype = torch.float32 if get_ascend_device_type() == AscendDeviceType.A5 else None
+        norm_dtype = DeviceConfig.norm_dtype
         self.norm = RMSNorm(self.head_dim, config.rms_norm_eps, dtype=norm_dtype)
 
         state_dtype = torch.float32
@@ -640,7 +630,7 @@ class Compressor(nn.Module):
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=_dsv4_block_sizes()[cache_config.block_size][0][2],  # type: ignore[union-attr]
+                block_size=DeviceConfig.dsv4_block_sizes[cache_config.block_size][0][2],  # type: ignore[union-attr]
             )
         elif compress_ratio == 128:
             self.state_cache = AscendCompressorStateCache(
@@ -648,7 +638,7 @@ class Compressor(nn.Module):
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=_dsv4_block_sizes()[cache_config.block_size][0][3],  # type: ignore[union-attr]
+                block_size=DeviceConfig.dsv4_block_sizes[cache_config.block_size][0][3],  # type: ignore[union-attr]
             )
         else:
             raise ValueError(
@@ -842,8 +832,7 @@ class DeepseekV4Attention(nn.Module):
                 if 0 <= indexer_seq_idx < len(pattern):
                     skip_topk = pattern[indexer_seq_idx] == "S"
 
-        ascend_device_type = get_ascend_device_type()
-        k_dtype = torch.float8_e4m3fn if ascend_device_type == AscendDeviceType.A5 else torch.bfloat16
+        k_dtype = DeviceConfig.swa_cache_dtype
         swa_cache_layer = AscendDeepseekV4SWACache(
             head_dim=self.head_dim,
             window_size=self.window_size,

--- a/vllm_ascend/models/layer/attention/layer.py
+++ b/vllm_ascend/models/layer/attention/layer.py
@@ -22,31 +22,7 @@ from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec
 
 from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.dsa_v1 import AscendDSABackend
-from vllm_ascend.utils import (
-    AscendDeviceType,
-    get_ascend_device_type,
-)
-
-
-def get_dsv4_block_sizes():
-    # cache_config.block_size: [mla, swa, c4 state, c128 state], [page_size_padded_t1, page_size_padded_t2]
-    _DSV4_BLOCK_SIZES = {
-        128: [[128, 128, 8, 32], [16640, 131072]],
-        64: [[64, 64, 4, 16], [8320, 65536]],
-        32: [[32, 32, 2, 8], [4160, 32768]],
-    }
-    _DSV4_BLOCK_SIZES_A5 = {
-        128: [[128, 128, 8, 16], [16896, 81920]],
-        64: [[64, 64, 4, 8], [8448, 40960]],
-        32: [[32, 32, 2, 4], [4224, 20480]],
-    }
-    if get_ascend_device_type() in {AscendDeviceType.A5}:
-        return _DSV4_BLOCK_SIZES_A5
-    else:
-        return _DSV4_BLOCK_SIZES
-
-
-DSV4_BLOCK_SIZES = get_dsv4_block_sizes()
+from vllm_ascend.device.device_config import DeviceConfig
 
 
 class DSAAttention(nn.Module, AttentionLayerBase):
@@ -175,15 +151,13 @@ class DSAAttention(nn.Module, AttentionLayerBase):
         if self.compress_ratio <= 1:  # SWA part. Allocated separately as DeepseekV4SWACache.
             return None
         kv_cache_dtype = kv_cache_dtype_str_to_dtype(self.kv_cache_dtype, vllm_config.model_config)
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
+        if DeviceConfig.kv_cache_dtype == torch.float8_e4m3fn:
             kv_cache_dtype = torch.float8_e4m3fn
             vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
 
-        cached_head_size = (
-            (self.head_size + 128) if get_ascend_device_type() in {AscendDeviceType.A5} else self.head_size
-        )
+        cached_head_size = DeviceConfig.pd_cache_head_size(self.head_size)
         return MLAAttentionSpec(
-            block_size=DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][0][0],
+            block_size=DeviceConfig.dsv4_block_sizes[vllm_config.cache_config.block_size][0][0],
             num_kv_heads=1,
             head_size=cached_head_size,
             dtype=kv_cache_dtype,

--- a/vllm_ascend/ops/__init__.py
+++ b/vllm_ascend/ops/__init__.py
@@ -15,40 +15,78 @@
 # This file is a part of the vllm-ascend project.
 #
 
-import torch
-from vllm.triton_utils import HAS_TRITON
-
+import vllm_ascend.ops.activation  # noqa
+import vllm_ascend.ops.bailing_moe_linear_attn  # noqa
+import vllm_ascend.ops.conv  # noqa
+import vllm_ascend.ops.cv_linear  # noqa
+import vllm_ascend.ops.dsa  # noqa
+import vllm_ascend.ops.flashcomm2_oshard_manager  # noqa
+import vllm_ascend.ops.fused_moe.comm_utils  # noqa
+import vllm_ascend.ops.fused_moe.experts_selector  # noqa
 import vllm_ascend.ops.fused_moe.fused_moe  # noqa
+import vllm_ascend.ops.fused_moe.gate_linear  # noqa
+import vllm_ascend.ops.fused_moe.moe_comm_method  # noqa
+import vllm_ascend.ops.fused_moe.moe_mlp  # noqa
+import vllm_ascend.ops.fused_moe.moe_runtime_args  # noqa
+import vllm_ascend.ops.fused_moe.moe_stage_contracts  # noqa
+import vllm_ascend.ops.fused_moe.moe_stage_params  # noqa
+import vllm_ascend.ops.fused_moe.prepare_finalize  # noqa
+import vllm_ascend.ops.fused_moe.token_dispatcher  # noqa
+import vllm_ascend.ops.gdn  # noqa
+import vllm_ascend.ops.gdn_attn_builder  # noqa
+import vllm_ascend.ops.layer_shard_linear  # noqa
 import vllm_ascend.ops.layernorm  # noqa
+import vllm_ascend.ops.linear  # noqa
+import vllm_ascend.ops.linear_op  # noqa
+import vllm_ascend.ops.mhc  # noqa
+import vllm_ascend.ops.mla  # noqa
+import vllm_ascend.ops.mm_encoder_attention  # noqa
+import vllm_ascend.ops.qwen2_decoder  # noqa
 import vllm_ascend.ops.register_custom_ops  # noqa
-
-if HAS_TRITON:
-    import vllm_ascend.ops.triton.linearnorm.split_qkv_rmsnorm_rope  # noqa
-    import vllm_ascend.ops.triton.linearnorm.split_qkv_rmsnorm_mrope
-    import vllm_ascend.ops.triton.linearnorm.split_qkv_tp_rmsnorm_rope
-    import vllm_ascend.ops.triton.linearnorm.split_qkv_rmsnorm_rope_simt
-
+import vllm_ascend.ops.rel_pos_attention  # noqa
+import vllm_ascend.ops.rope_dsv4  # noqa
+import vllm_ascend.ops.rotary_embedding  # noqa
 import vllm_ascend.ops.vocab_parallel_embedding  # noqa
-from vllm_ascend.ops.activation import AscendQuickGELU, AscendSiluAndMul
-from vllm_ascend.ops.rotary_embedding import AscendDeepseekScalingRotaryEmbedding, AscendRotaryEmbedding
+import vllm_ascend.ops.weight_prefetch  # noqa
 
+from vllm_ascend.device.device_config import DeviceConfig
 
-class dummyFusionOp:
-    default = None
-
-    def __init__(self, name=""):
-        self.name = name
-
-
-def register_dummy_fusion_op() -> None:
-    torch.ops._C_ascend.rms_norm = dummyFusionOp(name="rms_norm")
-    torch.ops._C_ascend.fused_add_rms_norm = dummyFusionOp(name="fused_add_rms_norm")
-    torch.ops._C_ascend.static_scaled_fp8_quant = dummyFusionOp(name="static_scaled_fp8_quant")
-    torch.ops._C_ascend.dynamic_scaled_fp8_quant = dummyFusionOp(name="dynamic_scaled_fp8_quant")
-    torch.ops._C_ascend.dynamic_per_token_scaled_fp8_quant = dummyFusionOp(name="dynamic_per_token_scaled_fp8_quant")
-    torch.ops._C_ascend.rms_norm_static_fp8_quant = dummyFusionOp(name="rms_norm_static_fp8_quant")
-    torch.ops._C_ascend.fused_add_rms_norm_static_fp8_quant = dummyFusionOp(name="fused_add_rms_norm_static_fp8_quant")
-    torch.ops._C_ascend.rms_norm_dynamic_per_token_quant = dummyFusionOp(name="rms_norm_dynamic_per_token_quant")
-
-
-__all__ = ["AscendQuickGELU", "AscendSiluAndMul", "AscendRotaryEmbedding", "AscendDeepseekScalingRotaryEmbedding"]
+if DeviceConfig.supports_triton:
+    import vllm_ascend.ops.triton.batch_invariant.matmul  # noqa
+    import vllm_ascend.ops.triton.batch_invariant.mean  # noqa
+    import vllm_ascend.ops.triton.batch_invariant.rmsnorm  # noqa
+    import vllm_ascend.ops.triton.batch_invariant.softmax  # noqa
+    import vllm_ascend.ops.triton.batch_memcpy  # noqa
+    import vllm_ascend.ops.triton.bincount  # noqa
+    import vllm_ascend.ops.triton.fla.chunk  # noqa
+    import vllm_ascend.ops.triton.fla.chunk_delta_h  # noqa
+    import vllm_ascend.ops.triton.fla.chunk_delta_hupdate  # noqa
+    import vllm_ascend.ops.triton.fla.chunk_o  # noqa
+    import vllm_ascend.ops.triton.fla.chunk_o_update  # noqa
+    import vllm_ascend.ops.triton.fla.chunk_scaled_dot_kkt  # noqa
+    import vllm_ascend.ops.triton.fla.cumsum  # noqa
+    import vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape  # noqa
+    import vllm_ascend.ops.triton.fla.l2norm  # noqa
+    import vllm_ascend.ops.triton.fla.layernorm_guard  # noqa
+    import vllm_ascend.ops.triton.fla.sigmoid_gating  # noqa
+    import vllm_ascend.ops.triton.fla.solve_tril  # noqa
+    import vllm_ascend.ops.triton.fla.utils  # noqa
+    import vllm_ascend.ops.triton.fla.wy_fast  # noqa
+    import vllm_ascend.ops.triton.fused_gdn_gating  # noqa
+    import vllm_ascend.ops.triton.gdn_chunk_meta  # noqa
+    import vllm_ascend.ops.triton.layernorm_gated  # noqa
+    import vllm_ascend.ops.triton.linearnorm.split_qkv_rmsnorm_mrope  # noqa
+    import vllm_ascend.ops.triton.linearnorm.split_qkv_rmsnorm_rope  # noqa
+    import vllm_ascend.ops.triton.linearnorm.split_qkv_rmsnorm_rope_simt  # noqa
+    import vllm_ascend.ops.triton.linearnorm.split_qkv_tp_rmsnorm_rope  # noqa
+    import vllm_ascend.ops.triton.mamba.causal_conv1d  # noqa
+    import vllm_ascend.ops.triton.mamba.lightning_attn  # noqa
+    import vllm_ascend.ops.triton.mul_add  # noqa
+    import vllm_ascend.ops.triton.muls_add  # noqa
+    import vllm_ascend.ops.triton.penalty  # noqa
+    import vllm_ascend.ops.triton.reject_sample  # noqa
+    import vllm_ascend.ops.triton.rms_norm  # noqa
+    import vllm_ascend.ops.triton.rope  # noqa
+    import vllm_ascend.ops.triton.spec_decode.utils  # noqa
+    import vllm_ascend.ops.triton.activation.swiglu_quant  # noqa
+    import vllm_ascend.ops.triton.triton_utils  # noqa

--- a/vllm_ascend/ops/dsa.py
+++ b/vllm_ascend/ops/dsa.py
@@ -30,11 +30,8 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.v1.attention.backend import AttentionMetadata
 
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.models.layer.attention.layer import DSAAttention
-from vllm_ascend.utils import (
-    AscendDeviceType,
-    get_ascend_device_type,
-)
 
 
 @dataclass
@@ -241,7 +238,7 @@ def _build_kv_cache(self, forward_context):
             compress_kv_cache = compress_kv_cache[virtual_engine]
     if self.compress_ratio == 4:
         indexer_state_cache = self.indexer.compressor.state_cache.kv_cache
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
+        if DeviceConfig.indexer_has_full_cache:
             indexer_k_cache, indexer_scale_cache, indexer_full_cache = (
                 self.indexer.k_cache.kv_cache[0][0],
                 self.indexer.k_cache.kv_cache[0][1],
@@ -253,7 +250,7 @@ def _build_kv_cache(self, forward_context):
                 self.indexer.k_cache.kv_cache[0][1],
             )
 
-    if get_ascend_device_type() in {AscendDeviceType.A5}:
+    if DeviceConfig.indexer_has_full_cache:
         kv_cache = tuple(
             [
                 unfold_kvcache(cache)

--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -22,7 +22,7 @@ from vllm.distributed import get_tp_group
 from vllm.forward_context import get_forward_context
 
 from vllm_ascend.ascend_forward_context import MoECommType
-from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.distributed.utils import split_tensor_along_first_dim
 from vllm_ascend.utils import get_weight_prefetch_method
 
@@ -293,7 +293,7 @@ def _select_experts_with_fusion_ops(
     norm_type = 0 if scoring_func == "softmax" else 1
     if e_score_correction_bias is not None and e_score_correction_bias.dtype != router_logits.dtype:
         e_score_correction_bias = e_score_correction_bias.to(router_logits.dtype)
-    topk_weights, topk_ids, _ = DeviceOperator.moe_gating_top_k(
+    topk_weights, topk_ids, _ = DeviceConfig.device_operator.moe_gating_top_k(
         router_logits,
         k=top_k,
         k_group=topk_group,

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -18,10 +18,9 @@
 import torch
 import torch_npu
 from torch.nn.functional import pad
-from vllm.triton_utils import HAS_TRITON
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
-from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.device.mxfp_compat import (
     ensure_mxfp8_moe_available,
 )
@@ -31,11 +30,8 @@ from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import (
     dispose_tensor,
     enable_custom_op,
-    get_ascend_device_type,
     get_weight_prefetch_method,
 )
-
-ASCEND_DEVICE_TYPE = get_ascend_device_type()
 
 
 def _custom_gmm_swiglu_enabled(fusion, dynamic_eplb):
@@ -125,7 +121,7 @@ def quant_apply_mlp(
         quantized_hidden_states = None
     elif dynamic_scale is None:
         unquantized_hidden_states = hidden_states
-        hidden_states, pertoken_scale = DeviceOperator.npu_dynamic_quant(
+        hidden_states, pertoken_scale = DeviceConfig.device_operator.npu_dynamic_quant(
             hidden_states=hidden_states,
             dynamic_scale=None,
             act_quant_type=act_quant_type,
@@ -136,7 +132,9 @@ def quant_apply_mlp(
     else:
         unquantized_hidden_states = None
         pertoken_scale = (
-            DeviceOperator.maybe_normalize_mxfp_scale_layout(dynamic_scale) if use_mxfp_quant else dynamic_scale
+            DeviceConfig.device_operator.maybe_normalize_mxfp_scale_layout(dynamic_scale)
+            if use_mxfp_quant
+            else dynamic_scale
         )
         quantized_hidden_states = hidden_states
 
@@ -160,7 +158,7 @@ def quant_apply_mlp(
             )
         elif use_gmm_swiglu_quant_fusion:
             # gmm1: gate_up_proj & act_fn: swiglu
-            hidden_states, swiglu_out_scale, _ = DeviceOperator.npu_grouped_matmul_swiglu_quant(
+            hidden_states, swiglu_out_scale, _ = DeviceConfig.device_operator.npu_grouped_matmul_swiglu_quant(
                 x=hidden_states,
                 weight=_require_single_tensor_for_swiglu_quant(w1, name="w1"),
                 group_list=cumsum_group_list(group_list, group_list_type, 0),
@@ -204,7 +202,7 @@ def quant_apply_mlp(
             )
         before_gmm2_evt = torch.npu.current_stream().record_event()
         # gmm2: down_proj
-        hidden_states = DeviceOperator.npu_grouped_matmul_gmm2(
+        hidden_states = DeviceConfig.device_operator.npu_grouped_matmul_gmm2(
             hidden_states=hidden_states,
             weight=w2,
             weight_scale=w2_scale,
@@ -285,7 +283,7 @@ def quant_apply_mlp(
                 swiglu_limit=swiglu_limit,
             )
         elif use_gmm_swiglu_quant_fusion:
-            hidden_states, swiglu_out_scale, _ = DeviceOperator.npu_grouped_matmul_swiglu_quant(
+            hidden_states, swiglu_out_scale, _ = DeviceConfig.device_operator.npu_grouped_matmul_swiglu_quant(
                 x=hidden_states,
                 weight=_require_single_tensor_for_swiglu_quant(w1, name="w1"),
                 group_list=cumsum_group_list(group_list, group_list_type, 0),
@@ -318,7 +316,7 @@ def quant_apply_mlp(
             if quantized_hidden_states is not None:
                 dispose_tensor(quantized_hidden_states)
             # act_fn: swiglu
-            if HAS_TRITON:
+            if DeviceConfig.supports_triton:
                 from vllm_ascend.ops.triton.activation.swiglu_quant import swiglu_quant
 
                 hidden_states, swiglu_out_scale = swiglu_quant(
@@ -329,7 +327,7 @@ def quant_apply_mlp(
                 hidden_states, swiglu_out_scale = torch_npu.npu_dynamic_quant(hidden_states)
         before_gmm2_evt = torch.npu.current_stream().record_event()
         # gmm2: down_proj
-        hidden_states = DeviceOperator.npu_grouped_matmul_gmm2(
+        hidden_states = DeviceConfig.device_operator.npu_grouped_matmul_gmm2(
             hidden_states=hidden_states,
             weight=w2,
             weight_scale=w2_scale,
@@ -406,7 +404,7 @@ def unquant_apply_mlp(
 def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
     """
     Unified MoE MLP entry.
-    Quant path is dispatched by DeviceOperator with explicit typed kernel flags.
+    Quant path is dispatched by DeviceConfig.device_operator with explicit typed kernel flags.
     """
     hidden_states = mlp_compute_input.hidden_states
     group_list = mlp_compute_input.group_list

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -29,7 +29,7 @@ from vllm.config import get_current_vllm_config
 from vllm.distributed.parallel_state import get_ep_group
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.fused_moe.comm_utils import async_all_to_all, gather_from_sequence_parallel_region
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
@@ -42,8 +42,6 @@ from vllm_ascend.ops.fused_moe.moe_runtime_args import (
 )
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import (
-    AscendDeviceType,
-    get_ascend_device_type,
     is_hierarchical_communication_enabled,
     should_skip_allreduce_across_dp_group,
 )
@@ -109,8 +107,8 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         self.ep_rank_id = get_mc2_group().rank_in_group
         self.ep_world_size = get_mc2_group().world_size
         self.enable_dispatch_v2 = hasattr(torch_npu, "npu_moe_distribute_dispatch_v2")
-        self.need_extra_args = get_ascend_device_type() in [AscendDeviceType.A3, AscendDeviceType.A5]
-        self.a5_need_extra_args = get_ascend_device_type() == AscendDeviceType.A5
+        self.need_extra_args = DeviceConfig.moe_dispatch_requires_extra_args
+        self.a5_need_extra_args = DeviceConfig.moe_dispatch_uses_a5_specific
         # NOTE: When in A2, setting the environment variables HCCL_INTRA_PCIE_ENABLE=1 and
         # HCCL_INTRA_ROCE_ENABLE=0 can reduce cross-machine communication traffic and significantly
         # improve communication performance.
@@ -399,16 +397,18 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
             first_expert_idx = 0
             last_expert_idx = self.num_experts_local
             global_num_experts = self.num_experts_local
-        sorted_hidden_states, expanded_row_idx, expert_tokens, dynamic_scale = DeviceOperator.npu_moe_init_routing(
-            hidden_states,
-            topk_ids,
-            scale=dynamic_scale,
-            active_num=num_tokens * self.top_k,
-            expert_num=global_num_experts,
-            expert_tokens_num_type=1,
-            expert_tokens_num_flag=True,
-            active_expert_range=[first_expert_idx, last_expert_idx],
-            quant_mode=quant_mode,
+        sorted_hidden_states, expanded_row_idx, expert_tokens, dynamic_scale = (
+            DeviceConfig.device_operator.npu_moe_init_routing(
+                hidden_states,
+                topk_ids,
+                scale=dynamic_scale,
+                active_num=num_tokens * self.top_k,
+                expert_num=global_num_experts,
+                expert_tokens_num_type=1,
+                expert_tokens_num_flag=True,
+                active_expert_range=[first_expert_idx, last_expert_idx],
+                quant_mode=quant_mode,
+            )
         )
         expert_tokens = expert_tokens.to(torch.int64)
         group_list_type = 1  # `count` mode

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -34,7 +34,7 @@ from vllm_ascend.compilation.acl_graph import (
     get_draft_graph_params,
     get_graph_params,
 )
-from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionBackend
 from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
 from vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape import fused_qkvzba_split_reshape_cat
@@ -615,7 +615,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
         query_non_spec, key_non_spec, value_non_spec = self.rearrange_mixed_qkv(mixed_qkv_non_spec)
 
         # 2. Recurrent attention
-        g, beta = DeviceOperator.fused_gdn_gating(self.A_log, a, b, self.dt_bias)
+        g, beta = DeviceConfig.device_operator.fused_gdn_gating(self.A_log, a, b, self.dt_bias)
         if spec_sequence_masks is not None:
             if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
                 g_spec = g

--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -20,7 +20,7 @@ from torch import nn
 from vllm.config import get_current_vllm_config
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm, RMSNormGated
 
-from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.ops.triton.layernorm_gated import layer_norm_fwd_npu
 from vllm_ascend.utils import enable_custom_op, get_weight_prefetch_method
 
@@ -106,7 +106,7 @@ class AscendGemmaRMSNorm(GemmaRMSNorm):
                 x, _, residual = torch_npu.npu_add_rms_norm(x, residual, 1.0 + self.weight, self.variance_epsilon)
             return x, residual
 
-        x = DeviceOperator.npu_gemma_rms_norm(x, self.weight, self.variance_epsilon)
+        x = DeviceConfig.device_operator.npu_gemma_rms_norm(x, self.weight, self.variance_epsilon)
 
         return x
 

--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -40,11 +40,10 @@ from vllm.model_executor.layers.quantization.base_config import QuantizationConf
 from vllm.model_executor.utils import set_weight_attrs
 from vllm.utils.torch_utils import direct_register_custom_op
 
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.ops.linear_op import get_parallel_op, get_replicated_op
 from vllm_ascend.utils import (
-    AscendDeviceType,
     enable_sp,
-    get_ascend_device_type,
     maybe_trans_nz,
 )
 
@@ -454,7 +453,7 @@ class AscendColumnParallelLinear(ColumnParallelLinear):
         return super().forward(input_)
 
     def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
-        if "wo_a" in self.prefix and get_ascend_device_type() != AscendDeviceType.A5:
+        if "wo_a" in self.prefix and DeviceConfig.wo_a_transpose_enabled:
             if self.weight.ndim == 2:
                 super().weight_loader(param, loaded_weight)
                 self.weight.data = (

--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -28,13 +28,13 @@ from vllm.model_executor.layers.rotary_embedding import (
     YaRNScalingRotaryEmbedding,
 )
 from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
-from vllm.triton_utils import HAS_TRITON
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.platform import NPUPlatform
 from vllm_ascend.utils import has_rope, is_vl_model
 
-if HAS_TRITON:
+if DeviceConfig.supports_triton:
     from vllm.model_executor.layers.rotary_embedding.mrope import triton_mrope
 
     from vllm_ascend.ops.triton.rope import rope_forward_triton
@@ -163,7 +163,7 @@ def rope_forward_oot(
     query_shape, key_shape = query.shape, key.shape
     if offsets is not None:
         raise NotImplementedError("Batched rotary embedding is currently not supported on NPU.")
-    if HAS_TRITON:
+    if DeviceConfig.supports_triton:
         num_tokens = query.shape[0]
         query, key = rope_forward_triton(
             query.view(num_tokens, -1, head_size),
@@ -520,7 +520,7 @@ class AscendMRotaryEmbedding(MRotaryEmbedding):
         query: torch.Tensor,
         key: torch.Tensor,
     ):
-        if HAS_TRITON and positions.ndim == 2 and self.mrope_interleaved:
+        if DeviceConfig.supports_triton and positions.ndim == 2 and self.mrope_interleaved:
             # todo: need cann update in 8.5.0
             return self.forward_triton(positions, query, key)
 

--- a/vllm_ascend/ops/triton/fla/chunk_scaled_dot_kkt.py
+++ b/vllm_ascend/ops/triton/fla/chunk_scaled_dot_kkt.py
@@ -12,6 +12,7 @@
 import torch
 from vllm.triton_utils import tl, triton
 
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.ops.triton.triton_utils import get_aicore_num
 
 from .utils import prepare_chunk_indices, safe_exp
@@ -132,9 +133,7 @@ def chunk_scaled_dot_kkt_fwd(
     bh_step = B * H
     task_num = NT * bh_step
 
-    from vllm_ascend.device.device_op import DeviceOperator
-
-    A = DeviceOperator.chunk_scaled_dot_kkt_fwd(
+    A = DeviceConfig.device_operator.chunk_scaled_dot_kkt_fwd(
         num_core=num_core,
         bh_step=bh_step,
         task_num=task_num,

--- a/vllm_ascend/ops/triton/fla/solve_tril.py
+++ b/vllm_ascend/ops/triton/fla/solve_tril.py
@@ -12,6 +12,7 @@
 import torch
 from vllm.triton_utils import tl, triton
 
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.ops.triton.triton_utils import extract_slice, insert_slice
 
 from .utils import prepare_chunk_indices
@@ -363,9 +364,7 @@ def solve_tril(
     chunk_indices = chunk_indices_large_block
     NT = len(chunk_indices) if cu_seqlens is not None else triton.cdiv(T, LARGE_BLOCK_T)
 
-    from vllm_ascend.device.device_op import DeviceOperator
-
-    DeviceOperator.solve_tril_16x16(
+    DeviceConfig.device_operator.solve_tril_16x16(
         A=A,
         Ad=Ad,
         cu_seqlens=cu_seqlens,

--- a/vllm_ascend/ops/triton/mamba/causal_conv1d.py
+++ b/vllm_ascend/ops/triton/mamba/causal_conv1d.py
@@ -13,12 +13,13 @@ import torch
 import torch.nn.functional as F
 from vllm.distributed import get_pcp_group
 from vllm.forward_context import get_forward_context
-from vllm.triton_utils import HAS_TRITON, tl, triton
+from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID  # type: ignore
 
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 
-if not HAS_TRITON:
+if not DeviceConfig.supports_triton:
     from vllm_ascend._310p.ops.causal_conv1d import (
         causal_conv1d_update as _pytorch_update,
     )
@@ -588,7 +589,7 @@ def causal_conv1d_update_npu(
             indices 0 and 3
     out: (batch, dim) or (batch, dim, seqlen) or (num_tokens, dim), same shape as `x`
     """
-    if not HAS_TRITON:
+    if not DeviceConfig.supports_triton:
         return _pytorch_update(
             x,
             conv_state,

--- a/vllm_ascend/ops/triton/triton_utils.py
+++ b/vllm_ascend/ops/triton/triton_utils.py
@@ -1,13 +1,15 @@
 from typing import Any
 
 import torch
-from vllm.triton_utils import HAS_TRITON, tl, triton
+from vllm.triton_utils import tl, triton
+
+from vllm_ascend.device.device_config import DeviceConfig
 
 _NUM_AICORE = -1
 _NUM_VECTORCORE = -1
 _extension_module = None
 
-if HAS_TRITON:
+if DeviceConfig.supports_triton:
     try:
         import triton.language.extra.cann.extension as _extension_module  # type: ignore
     except ImportError:
@@ -15,8 +17,8 @@ if HAS_TRITON:
 
 
 def _resolve_triton_ascend_op(op_name: str):
-    if not HAS_TRITON:
-        raise RuntimeError(f"Triton op '{op_name}' cannot be resolved because HAS_TRITON is False")
+    if not DeviceConfig.supports_triton:
+        raise RuntimeError(f"Triton op '{op_name}' cannot be resolved because supports_triton is False")
 
     if _extension_module is not None:
         extension_op = getattr(_extension_module, op_name, None)
@@ -33,7 +35,7 @@ def _resolve_triton_ascend_op(op_name: str):
     )
 
 
-if HAS_TRITON:
+if DeviceConfig.supports_triton:
     insert_slice = _resolve_triton_ascend_op("insert_slice")
     extract_slice = _resolve_triton_ascend_op("extract_slice")
     get_element = _resolve_triton_ascend_op("get_element")
@@ -45,7 +47,7 @@ else:
 
 def init_device_properties_triton():
     global _NUM_AICORE, _NUM_VECTORCORE
-    if _NUM_AICORE == -1 and HAS_TRITON:
+    if _NUM_AICORE == -1 and DeviceConfig.supports_triton:
         device_properties: dict[str, Any] = triton.runtime.driver.active.utils.get_device_properties(
             torch.npu.current_device()
         )

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -491,7 +491,7 @@
 #       The Triton version bundled with torch_npu on Ascend NPU
 #       does not include `next_power_of_2`, which is called by
 #       upstream vLLM and vLLM-Ascend code in 94+ places.
-#       Additionally, when Triton is not available (HAS_TRITON=False),
+#       Additionally, when Triton is not available (i.e. on 310P),
 #       vLLM uses TritonPlaceholder which also lacks this function.
 #    How：
 #       Import `triton` from vllm.triton_utils (which handles both

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -22,9 +22,9 @@ import vllm_ascend.patch.platform.patch_kv_cache_interface  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa
 import vllm_ascend.patch.platform.patch_mla_prefill_backend  # noqa
 import vllm_ascend.patch.platform.patch_pp_mtp  # noqa
-from vllm_ascend.utils import is_310p
+from vllm_ascend.device.device_config import DeviceConfig
 
-if not is_310p():
+if not DeviceConfig.use_310p_mamba_config:
     import vllm_ascend.patch.platform.patch_mamba_config  # noqa
 else:
     import vllm_ascend.patch.platform.patch_mamba_config_310  # noqa

--- a/vllm_ascend/patch/platform/patch_distributed.py
+++ b/vllm_ascend/patch/platform/patch_distributed.py
@@ -19,7 +19,7 @@
 
 import torch
 
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+from vllm_ascend.device.device_config import DeviceConfig
 
 
 class NullHandle:
@@ -85,5 +85,5 @@ def communication_adaptation_310p():
     )
 
 
-if get_ascend_device_type() == AscendDeviceType._310P:
+if DeviceConfig.use_310p_comm_adaptation:
     communication_adaptation_310p()

--- a/vllm_ascend/patch/platform/patch_kv_cache_interface.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_interface.py
@@ -15,15 +15,15 @@ from vllm.v1.kv_cache_interface import (
     SlidingWindowMLASpec,
 )
 
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+from vllm_ascend.device.device_config import DeviceConfig
 
 
 def _get_c8_k_cache_dtype() -> torch.dtype:
-    return torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else torch.int8
+    return DeviceConfig.c8_k_cache_dtype
 
 
 def _get_c8_k_scale_cache_dtype() -> torch.dtype:
-    return torch.float32 if get_ascend_device_type() == AscendDeviceType.A5 else torch.float16
+    return DeviceConfig.c8_k_scale_cache_dtype
 
 
 @dataclass(frozen=True)

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -14,12 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from vllm_ascend.device.device_config import DeviceConfig
 
-from vllm.triton_utils import HAS_TRITON
-
-from vllm_ascend.utils import is_310p
-
-if HAS_TRITON:
+if DeviceConfig.supports_triton:
     import vllm_ascend.patch.worker.patch_triton
     import vllm_ascend.patch.worker.patch_v2.patch_triton  # noqa
 
@@ -31,7 +28,7 @@ import vllm_ascend.patch.worker.patch_minimax_m2_linear_attn  # noqa
 import vllm_ascend.patch.worker.patch_mamba_utils  # noqa
 import vllm_ascend.patch.worker.patch_qwen3_next_mtp  # noqa
 
-if not is_310p():
+if DeviceConfig.supports_advanced_model_patches:
     import vllm_ascend.patch.worker.patch_qwen3_5  # noqa
     import vllm_ascend.patch.worker.patch_qwen3_dflash  # noqa
     import vllm_ascend.patch.worker.patch_qwen3vl  # noqa

--- a/vllm_ascend/patch/worker/patch_kimi_k25.py
+++ b/vllm_ascend/patch/worker/patch_kimi_k25.py
@@ -24,7 +24,7 @@ from vllm.model_executor.models.kimi_k25_vit import (
     get_rope_shape_decorate,
 )
 
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+from vllm_ascend.device.device_config import DeviceConfig
 
 
 @get_rope_shape_decorate
@@ -77,7 +77,7 @@ Learnable2DInterpPosEmbDivided_fixed.forward = AscendLearnable2DInterpPosEmbDivi
 # the `dtype=model_config.dtype` (e.g. bf16) would overwrite the fp8 parameters
 # created by the Ascend quantization scheme, causing a dtype mismatch later
 # in weight_loader when the checkpoint's fp8 weights are loaded.
-if get_ascend_device_type() == AscendDeviceType.A5:
+if DeviceConfig.vision_tower_preserves_quantized_dtype:
     _original_moonvit_to = MoonViT3dPretrainedModel.to
 
     def _patched_moonvit_to(self, *args, **kwargs):

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -14,12 +14,12 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState
 from vllm.v1.worker.lora_model_runner_mixin import GPUInputBatch
 from vllm.v1.worker.mamba_utils import MambaCopyBuffers
 
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.ops.triton.batch_memcpy import batch_memcpy_kernel
-from vllm_ascend.utils import is_310p
 
 
 def _can_launch_triton_batch_memcpy() -> bool:
-    return not is_310p()
+    return DeviceConfig.supports_triton
 
 
 def _batch_memcpy_triton(src_ptrs, dst_ptrs, sizes):

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -32,8 +32,8 @@ except ImportError:
 from vllm.model_executor.models.qwen3_next import Qwen3NextAttention
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
-from vllm_ascend.utils import is_310p
 
 _GDN_PATCH_TARGET = _GDNBaseCls
 
@@ -198,7 +198,7 @@ _GDN_PATCH_TARGET._split_ba_for_tp = AscendGatedDeltaNetAttention._split_ba_for_
 _GDN_PATCH_TARGET.get_state_shape = AscendGatedDeltaNetAttention.get_state_shape
 _GDN_PATCH_TARGET.get_attn_backend = AscendGatedDeltaNetAttention.get_attn_backend
 
-if is_310p():
+if DeviceConfig.use_310p_gdn_attention:
     from vllm_ascend._310p.ops.fla.gdn_310 import AscendGatedDeltaNetAttention310
 
     _GDN_PATCH_TARGET._forward_core = AscendGatedDeltaNetAttention310._forward_core

--- a/vllm_ascend/patch/worker/patch_triton.py
+++ b/vllm_ascend/patch/worker/patch_triton.py
@@ -1,9 +1,10 @@
 import vllm.model_executor.layers.fla.ops
 import vllm.model_executor.layers.mamba.ops.causal_conv1d
 import vllm.v1.worker.gpu.sample.gumbel
-from vllm.triton_utils import HAS_TRITON, triton
+from vllm.triton_utils import triton
 from vllm.utils.math_utils import next_power_of_2
 
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
 from vllm_ascend.ops.triton.fla.layernorm_guard import LayerNormFn
 from vllm_ascend.ops.triton.fla.sigmoid_gating import fused_recurrent_gated_delta_rule_fwd_kernel
@@ -23,7 +24,7 @@ vllm.model_executor.layers.fla.ops.chunk_gated_delta_rule = chunk_gated_delta_ru
 # Triton-based fused_post_conv_prep with a pure-PyTorch fallback so that
 # qwen_gdn_linear_attn's from-import picks up the replacement before model
 # load.
-if not HAS_TRITON:
+if not DeviceConfig.supports_triton:
     import torch
     import torch.nn.functional as _F
 

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -36,20 +36,19 @@ from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm_ascend.ascend_config import init_ascend_config
 
 # isort: off
+from vllm_ascend.device.device_config import DeviceConfig
+
 from vllm_ascend.utils import (
     ASCEND_QUANTIZATION_METHOD,
     COMPILATION_PASS_KEY,
     COMPRESSED_TENSORS_METHOD,
     FP8_METHOD,
-    AscendDeviceType,
     bootstrap_custom_op_env,
     check_kv_extra_config,
     flashcomm2_enable,
-    get_ascend_device_type,
     is_moe_model,
     refresh_block_size,
     update_cudagraph_capture_sizes,
-    is_310p,
     enable_sp,
 )
 
@@ -194,7 +193,7 @@ class NPUPlatform(Platform):
                 if ASCEND_QUANTIZATION_METHOD not in quant_action.choices:
                     quant_action.choices.append(ASCEND_QUANTIZATION_METHOD)
 
-        if not is_310p():
+        if DeviceConfig.supports_advanced_quantization:
             from vllm_ascend.quantization import AscendCompressedTensorsConfig, AscendFp8Config, AscendModelSlimConfig  # noqa: F401
         else:
             from vllm_ascend._310p.quantization import AscendModelSlimConfig310  # noqa: F401
@@ -615,7 +614,7 @@ class NPUPlatform(Platform):
                 ]
             )
             # TODO(2026/7/15): Delete the reduced gear after the new driver is released.
-            if get_ascend_device_type() == AscendDeviceType.A5:
+            if not DeviceConfig.enable_npu_graph_ex:
                 prune_capture_sizes_for_950(vllm_config)
             ascend_config.ascend_compilation_config.enable_npugraph_ex = False
         elif compilation_config.cudagraph_mode.has_full_cudagraphs():
@@ -648,7 +647,7 @@ class NPUPlatform(Platform):
             # TODO: this is a tricky way to disable `use_sequence_parallel_moe` in vllm.
             if not vllm_config.compilation_config.pass_config.enable_sp:
                 parallel_config.all2all_backend = "flashinfer_all2allv"
-            if is_310p():
+            if DeviceConfig.use_310p_worker:
                 parallel_config.worker_cls = "vllm_ascend._310p.worker_310p.NPUWorker310"
             elif ascend_config.xlite_graph_config.enabled:
                 logger.info("openEuler Xlite enabled. See: https://atomgit.com/openeuler/GVirt/tree/master/xlite")
@@ -659,7 +658,7 @@ class NPUPlatform(Platform):
         refresh_block_size(vllm_config)
 
         # Activate custom ops for v1, except on 310P
-        if get_ascend_device_type() != AscendDeviceType._310P:
+        if DeviceConfig.supports_compilation_custom_ops:
             compilation_config.custom_ops = ["all"]
 
         if ascend_config.enable_balance_scheduling:
@@ -804,7 +803,7 @@ class NPUPlatform(Platform):
             # (True, True):  "...AscendSFABackend310",
         }
 
-        if is_310p():
+        if not DeviceConfig.supports_advanced_attention_backends:
             return backend_map_310.get(key, backend_map_310[(False, False)])
 
         return backend_map[(attn_selector_config.use_mla, attn_selector_config.use_sparse, use_compress)]

--- a/vllm_ascend/quantization/methods/kv_c8.py
+++ b/vllm_ascend/quantization/methods/kv_c8.py
@@ -3,7 +3,7 @@ from vllm.config import get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size
 from vllm.logger import logger
 
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+from vllm_ascend.device.device_config import DeviceConfig
 
 from .base import AscendAttentionScheme
 from .registry import register_scheme
@@ -60,7 +60,7 @@ class AscendFAQuantAttentionMethod:
         fa_k_scale = torch.squeeze(layer.fa_k.scale).unsqueeze(0)
         layer.fak_descale_float = torch.nn.Parameter(fa_k_scale.to(torch.float), requires_grad=False)
         layer.fak_descale = torch.nn.Parameter(fa_k_scale, requires_grad=False)
-        if get_ascend_device_type() == AscendDeviceType.A5:
+        if DeviceConfig.fal_descale_reciprocal_uses_float:
             layer.fak_descale_reciprocal = 1.0 / torch.nn.Parameter(fa_k_scale.to(torch.float), requires_grad=False)
         else:
             layer.fak_descale_reciprocal = 1.0 / torch.nn.Parameter(fa_k_scale, requires_grad=False)

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -41,7 +41,8 @@ from vllm.model_executor.layers.quantization.base_config import QuantizationConf
 from vllm.model_executor.layers.vocab_parallel_embedding import UnquantizedEmbeddingMethod, VocabParallelEmbedding
 from vllm.model_executor.models.utils import WeightsMapper
 
-from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD, AscendDeviceType, calc_split_factor, get_ascend_device_type
+from vllm_ascend.device.device_config import DeviceConfig
+from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD, calc_split_factor
 
 from .methods import get_scheme_class
 
@@ -622,7 +623,7 @@ class AscendModelSlimConfig(QuantizationConfig):
             and vllm_config.kv_transfer_config.is_kv_consumer
             and not vllm_config.kv_transfer_config.is_kv_producer
         )
-        if get_ascend_device_type() == AscendDeviceType.A5:
+        if not DeviceConfig.fa_quant_decode_only:
             return self.is_fa_quant_layer(layer_name)
         else:
             return bool(is_decode_instance and self.is_fa_quant_layer(layer_name))
@@ -644,7 +645,7 @@ class AscendModelSlimConfig(QuantizationConfig):
     def get_kv_quant_dtype(self, layer_name, cache_dtype, model_config):
         if self.enable_fa_quant and self.is_fa_quant_layer(layer_name):
             ori_dtype = model_config.dtype
-            quant_dtype = torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else torch.int8
+            quant_dtype = DeviceConfig.kv_quant_dtype
             # For MLA models like deepseek, we only quantify K cache to ensure accuracy
             if model_config.use_mla:
                 return quant_dtype, ori_dtype

--- a/vllm_ascend/quantization/utils.py
+++ b/vllm_ascend/quantization/utils.py
@@ -25,8 +25,6 @@ from vllm_ascend.utils import (
     ASCEND_QUANTIZATION_METHOD,
     COMPRESSED_TENSORS_METHOD,
     FP8_METHOD,
-    AscendDeviceType,
-    get_ascend_device_type,
 )
 
 
@@ -215,8 +213,12 @@ def maybe_auto_detect_quantization(vllm_config) -> None:
 
 
 def enable_fa_quant(vllm_config, layer_name=None) -> bool:
+    from vllm_ascend.device.device_config import (
+        DeviceConfig,
+    )
+
     is_kv_consumer = vllm_config.kv_transfer_config is not None and vllm_config.kv_transfer_config.is_kv_consumer
-    if not is_kv_consumer and get_ascend_device_type() != AscendDeviceType.A5:
+    if not is_kv_consumer and DeviceConfig.fa_quant_decode_only:
         return False
     if vllm_config.quant_config is not None and getattr(vllm_config.quant_config, "enable_fa_quant", False):
         if layer_name is not None:

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -5,7 +5,6 @@ from dataclasses import replace
 import torch
 from vllm.distributed.parallel_state import get_tp_group
 from vllm.logger import logger
-from vllm.triton_utils import HAS_TRITON
 from vllm.v1.outputs import SamplerOutput
 from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -21,6 +20,7 @@ from vllm.v1.sample.sampler import Sampler
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.ops.triton.reject_sample import (
     cal_grid_and_block_size,
     expand_triton,
@@ -55,7 +55,7 @@ class AscendRejectionSampler(RejectionSampler):
             return logits
 
         """Use Triton-Ascend penalties on NPU when Triton is available; else vLLM default."""
-        if not HAS_TRITON:
+        if not DeviceConfig.supports_triton:
             logger.warning_once(
                 "[sample/rejection_sampler] Triton not available, falling back to vLLM default "
                 "penalty implementation in rejection sampler. Rejection sampling performance "
@@ -93,7 +93,7 @@ class AscendRejectionSampler(RejectionSampler):
             "ascend_optimizations_enabled=%s, triton_available=%s, "
             "reduce_sample=%s",
             self._ascend_optimizations_enabled,
-            HAS_TRITON,
+            DeviceConfig.supports_triton,
             get_ascend_config().enable_reduce_sample,
         )
 
@@ -410,7 +410,7 @@ def rejection_sample(
         sampling_metadata.all_greedy,
         sampling_metadata.all_random,
         get_ascend_config().enable_reduce_sample,
-        HAS_TRITON,
+        DeviceConfig.supports_triton,
     )
 
     if using_entropy_verify and ori_target_logits is not None:
@@ -430,7 +430,7 @@ def rejection_sample(
         is_greedy = None
     else:
         is_greedy = sampling_metadata.temperature == GREEDY_TEMPERATURE
-    if HAS_TRITON:
+    if DeviceConfig.supports_triton:
         grid, block_size = cal_grid_and_block_size(batch_size)
 
     if using_block_verify or using_entropy_verify:
@@ -443,7 +443,7 @@ def rejection_sample(
             posterior_threshold,
             posterior_alpha,
             target_indices is not None,
-            HAS_TRITON,
+            DeviceConfig.supports_triton,
             sampling_metadata.all_greedy,
             sampling_metadata.all_random,
         )
@@ -455,7 +455,7 @@ def rejection_sample(
         else:
             target_argmax = target_logits.argmax(dim=-1).view(-1)
 
-        if HAS_TRITON:
+        if DeviceConfig.supports_triton:
             rejection_greedy_sample_with_triton(
                 output_token_ids,
                 num_draft_tokens,
@@ -527,7 +527,7 @@ def rejection_sample(
 
         if not using_block_verify:
             # Rejection sampling for random sampling requests with selected logits
-            if HAS_TRITON:
+            if DeviceConfig.supports_triton:
                 rejection_random_sample_kernel[(grid,)](
                     output_token_ids,
                     cu_num_draft_tokens,
@@ -579,7 +579,7 @@ def rejection_sample(
         else:
             # MagicMTP: Improving acceptance rate with Block Verify.
             # Entropy_verify: Improving acceptance rate with entropy Verify.
-            if HAS_TRITON:
+            if DeviceConfig.supports_triton:
                 rejection_random_sample_block_verify_kernel[(grid,)](
                     output_token_ids,
                     cu_num_draft_tokens,
@@ -669,7 +669,7 @@ def rejection_sample(
         )
 
         if not using_block_verify:
-            if HAS_TRITON:
+            if DeviceConfig.supports_triton:
                 rejection_random_sample_kernel[(grid,)](
                     output_token_ids,
                     cu_num_draft_tokens,
@@ -719,7 +719,7 @@ def rejection_sample(
                     ori_target_probs=ori_target_probs,
                 )
         else:
-            if HAS_TRITON:
+            if DeviceConfig.supports_triton:
                 rejection_random_sample_block_verify_kernel[(grid,)](
                     output_token_ids,
                     cu_num_draft_tokens,
@@ -801,7 +801,7 @@ def expand_batch_to_tokens(
     batch_size = x.shape[0]
     assert cu_num_tokens.shape[0] == batch_size
     expanded_x = x.new_empty(num_tokens)
-    if HAS_TRITON:
+    if DeviceConfig.supports_triton:
         expand_triton(batch_size, expanded_x, x, cu_num_tokens, replace_from, replace_to, max_num_tokens=MAX_SPEC_LEN)
     else:
         expand_pytorch(
@@ -848,7 +848,7 @@ def sample_recovered_tokens(
         q[i] = torch.where(has_draft_mask[i], temp_q, q[i])
 
     recovered_token_ids = torch.empty_like(draft_token_ids)
-    if HAS_TRITON:
+    if DeviceConfig.supports_triton:
         sample_recovered_tokens_kernel[(batch_size, max_spec_len)](
             recovered_token_ids,
             cu_num_draft_tokens,

--- a/vllm_ascend/sample/sampler.py
+++ b/vllm_ascend/sample/sampler.py
@@ -2,14 +2,14 @@ import torch
 import vllm.envs as envs
 from vllm.distributed.parallel_state import get_tp_group
 from vllm.logger import logger
-from vllm.triton_utils import HAS_TRITON
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.topk_topp_sampler import TopKTopPSampler
 from vllm.v1.sample.sampler import Sampler
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.sample.penalties import apply_all_penalties
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type, global_stream, npu_stream_switch
+from vllm_ascend.utils import global_stream, npu_stream_switch
 
 DEFAULT_LOGPROBS_MODE = "raw_logprobs"
 
@@ -50,7 +50,7 @@ class AscendSampler(Sampler):
         output_token_ids: list[list[int]],
     ) -> torch.Tensor:
         """Use Triton-Ascend penalties on NPU when Triton is available; else vLLM default."""
-        if not HAS_TRITON:
+        if not DeviceConfig.supports_triton:
             logger.warning_once(
                 "[sample/sampler] Triton not available, falling back to vLLM default "
                 "penalty implementation. Penalty performance may be degraded on NPU. "
@@ -77,7 +77,7 @@ class AscendSampler(Sampler):
         logger.debug(
             "[sample/sampler] AscendSampler initialized. logprobs_mode=%s, triton_available=%s",
             logprobs_mode,
-            HAS_TRITON,
+            DeviceConfig.supports_triton,
         )
 
     def set_q_event(self, q, event):
@@ -295,8 +295,4 @@ def _apply_top_k_top_p_ascendc(
     return torch.ops._C_ascend.npu_apply_top_k_top_p(logits, k=k, p=p)
 
 
-apply_top_k_top_p = (
-    _apply_top_k_top_p_ascendc
-    if get_ascend_device_type() in [AscendDeviceType.A2, AscendDeviceType.A3]
-    else _apply_top_k_top_p_pytorch
-)
+apply_top_k_top_p = _apply_top_k_top_p_ascendc if DeviceConfig.use_ascendc_sampler else _apply_top_k_top_p_pytorch

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -27,7 +27,7 @@ from vllm.model_executor.models.deepseek_eagle3 import Eagle3DeepseekV2ForCausal
 from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
 from vllm.model_executor.models.qwen3_dflash import DFlashQwen3ForCausalLM
-from vllm.triton_utils import HAS_TRITON, triton
+from vllm.triton_utils import triton
 from vllm.utils.math_utils import cdiv
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
@@ -49,6 +49,7 @@ from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.compilation.acl_graph import ACLGraphWrapper, update_full_graph_params
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.distributed.parallel_state import get_lmhead_tp_group
 from vllm_ascend.models.llama_eagle3_vwn import Eagle3VwnLlamaForCausalLM
 from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
@@ -1871,7 +1872,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         used as padding and filtered out later by `token_indices_to_sample`.
         No blocking CPU operations should be introduced in this function.
         """
-        if HAS_TRITON:
+        if DeviceConfig.supports_triton:
             num_reqs = common_attn_metadata.num_reqs
             device = valid_sampled_tokens_count.device
 

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -24,7 +24,6 @@ import json
 import math
 import os
 from contextlib import nullcontext
-from enum import Enum
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
@@ -119,14 +118,6 @@ def clear_enable_sp():
     _libc_getenv.cache_clear()
 
 
-def is_310p():
-    return get_ascend_device_type() == AscendDeviceType._310P
-
-
-def is_950():
-    return get_ascend_device_type() == AscendDeviceType.A5
-
-
 def _mark_op_side_effectful(op: Any) -> None:
     torch.fx.node.has_side_effect(op)
     default_overload = getattr(op, "default", None)
@@ -216,7 +207,9 @@ def _should_trans_nz(weight: torch.Tensor) -> bool:
         return False
 
     # 310P always converts to NZ.
-    if is_310p():
+    from vllm_ascend.device.device_config import DeviceConfig
+
+    if DeviceConfig.force_nz_weight_format:
         return True
 
     # Get config value instead of env
@@ -371,7 +364,11 @@ def enable_custom_op():
     # FIXME(linfeng): Currently custom op compilation and execution are partially available
     # in ASCEND950 chip, we temporarily disable all custom ops. Please refer to
     # https://github.com/vllm-project/vllm-ascend/issues/7157 for latest update about custom op.
-    if envs.VLLM_BATCH_INVARIANT or get_ascend_device_type() == AscendDeviceType.A5:
+    from vllm_ascend.device.device_config import (
+        DeviceConfig,
+    )
+
+    if envs.VLLM_BATCH_INVARIANT or not DeviceConfig.enable_custom_ops:
         _CUSTOM_OP_ENABLED = False
         return _CUSTOM_OP_ENABLED
 
@@ -724,7 +721,9 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
         REGISTERED_ASCEND_OPS["GateLinear"] = AscendGateLinear
 
     # 310P: override selected ops with 310P implementations (keep minimal changes outside _310p)
-    if is_310p():
+    from vllm_ascend.device.device_config import DeviceConfig
+
+    if DeviceConfig.use_310p_op_implementations:
         from vllm_ascend._310p.fused_moe.fused_moe import AscendFusedMoE310
         from vllm_ascend._310p.ops.activation import AscendSiluAndMul310
         from vllm_ascend._310p.ops.conv import AscendConv3dLayer310
@@ -763,57 +762,6 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
 
     # NOTE: Keep this at last to ensure all custom actions are registered
     _ASCEND_CUSTOMOP_IS_REIGISTERED = True
-
-
-class AscendDeviceType(Enum):
-    A2 = 0
-    A3 = 1
-    _310P = 2
-    A5 = 3
-
-
-_ascend_device_type = None
-
-
-def _init_ascend_device_type():
-    global _ascend_device_type
-    from vllm_ascend import _build_info  # type: ignore
-
-    device_type = getattr(_build_info, "__device_type__", None)
-    if device_type is None:
-        soc_version = getattr(_build_info, "__soc_version__", "ASCEND910B1").upper()
-        device_type = "_310P" if "310P" in soc_version else "A2"
-    _ascend_device_type = AscendDeviceType[device_type]
-
-
-def check_ascend_device_type():
-    global _ascend_device_type
-    if _ascend_device_type is None:
-        _init_ascend_device_type()
-
-    soc_version = torch_npu.npu.get_soc_version()
-    if 220 <= soc_version <= 225:
-        cur_device_type = AscendDeviceType.A2
-    elif 250 <= soc_version <= 255:
-        cur_device_type = AscendDeviceType.A3
-    elif 200 <= soc_version <= 205:
-        cur_device_type = AscendDeviceType._310P
-    elif soc_version == 260:
-        cur_device_type = AscendDeviceType.A5
-    else:
-        raise RuntimeError(f"Can not support soc_version: {soc_version}.")
-
-    assert _ascend_device_type == cur_device_type, (
-        f"Current device type: {cur_device_type} does not match the installed version's device type: "
-        f"{_ascend_device_type}, please check your installation package."
-    )
-
-
-def get_ascend_device_type():
-    global _ascend_device_type
-    if _ascend_device_type is None:
-        _init_ascend_device_type()
-    return _ascend_device_type
 
 
 def lmhead_tp_enable() -> bool:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -121,6 +121,7 @@ from vllm_ascend.compilation.acl_graph import (
     set_graph_params,
     update_full_graph_params,
 )
+from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
 from vllm_ascend.eplb.core.eplb_device_transfer_loader import D2DExpertWeightLoader
 from vllm_ascend.eplb.core.eplb_worker import EplbProcess
@@ -142,12 +143,10 @@ from vllm_ascend.spec_decode.ngram_proposer_npu import AscendNgramProposerNPU
 from vllm_ascend.spec_decode.suffix_proposer import AscendSuffixDecodingProposer
 from vllm_ascend.spec_decode.utils import update_num_computed_tokens_for_batch_change
 from vllm_ascend.utils import (
-    AscendDeviceType,
     calc_split_factor,
     check_gdn_layer,
     enable_sp,
     enable_sp_by_pass,
-    get_ascend_device_type,
     get_c_env,
     get_compressed_pos_and_indices,
     global_stream,
@@ -350,7 +349,7 @@ class NPUModelRunner(GPUModelRunner):
             vllm_config.model_config.hf_text_config, "compress_ratios"
         )
         if self.use_sparse:
-            if get_ascend_device_type() == AscendDeviceType.A5 and self.ascend_config.enable_sparse_c8:
+            if not DeviceConfig.kv_cache_has_v_tensor and self.ascend_config.enable_sparse_c8:
                 # A5 sparse C8: kv_lora and k_rope are merged into a single CKV FP8 tensor.
                 # qk_rope_head_dim = 0 signals the merged layout.
                 # ckv_dim = kv_lora_rank                    (fp8, 1 byte/elem)
@@ -376,12 +375,8 @@ class NPUModelRunner(GPUModelRunner):
         # dsa c8
         self.use_sparse_c8_indexer = self.ascend_config.enable_sparse_c8
         if self.use_sparse_c8_indexer:
-            if get_ascend_device_type() == AscendDeviceType.A5:
-                self.c8_k_cache_dtype = torch.float8_e4m3fn
-                self.c8_k_scale_cache_dtype = torch.float32
-            else:
-                self.c8_k_cache_dtype = torch.int8
-                self.c8_k_scale_cache_dtype = torch.float16
+            self.c8_k_cache_dtype = DeviceConfig.c8_k_cache_dtype
+            self.c8_k_scale_cache_dtype = DeviceConfig.c8_k_scale_cache_dtype
 
         self.attn_backend = get_attn_backend(
             0,
@@ -4131,7 +4126,7 @@ class NPUModelRunner(GPUModelRunner):
                         
                         # A5 sparse C8: (ckv_ratio, qli_ratio, qli_scale_ratio, None)
                         # A3 sparse C8: (k_ratio, v_ratio, qli_ratio, qli_scale_ratio)
-                        if current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
+                        if current_sparse_c8 and not DeviceConfig.kv_cache_has_v_tensor:
                             k_tensor_split_factor = sparse_kv_cache_ratio[0]  # ckv
                             v_tensor_split_factor = None  # merged
                             dsa_k_tensor_split_factor = sparse_kv_cache_ratio[1]  # qli_tensor
@@ -4210,7 +4205,7 @@ class NPUModelRunner(GPUModelRunner):
                         if "attn" in layer_name_inner and "linear_attn" not in layer_name_inner:
                             if self.use_sparse:
                                 if current_sparse_c8:
-                                    if get_ascend_device_type() == AscendDeviceType.A5:
+                                    if not DeviceConfig.kv_cache_has_v_tensor:
                                         kv_cache_raw_tensors[layer_name_inner] = (
                                             k_tensor, dsa_k_tensor, dsa_k_scale_tensor
                                         )
@@ -4316,7 +4311,7 @@ class NPUModelRunner(GPUModelRunner):
                                                 current_kv_cache_spec.num_kv_heads,
                                                 current_kv_cache_spec.scale_dim
                                                 )
-                        if get_ascend_device_type() in {AscendDeviceType.A5}:
+                        if DeviceConfig.indexer_has_full_cache:
                             indexer_full_shape = self.attn_backend.get_kv_cache_shape(
                                 num_blocks, current_kv_cache_spec.block_size,
                                 current_kv_cache_spec.num_kv_heads,
@@ -4356,7 +4351,7 @@ class NPUModelRunner(GPUModelRunner):
                     if self.use_sparse and "cache_only_layers" not in layer_name:
                         current_sparse_c8 = kv_cache_spec_uses_sparse_c8(current_kv_cache_spec)
                         if current_sparse_c8:
-                            if get_ascend_device_type() == AscendDeviceType.A5:
+                            if not DeviceConfig.kv_cache_has_v_tensor:
                                 raw_k_tensor, raw_dsa_k_tensor, raw_dsa_k_scale_tensor = kv_cache_raw_tensors[  # type: ignore
                                     layer_name]
                                 assert raw_dsa_k_tensor is not None
@@ -4503,7 +4498,7 @@ class NPUModelRunner(GPUModelRunner):
                             num_kv_heads,
                             k_dim,
                         )
-                        if self.use_sparse and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
+                        if self.use_sparse and current_sparse_c8 and not DeviceConfig.kv_cache_has_v_tensor:
                             # A5 sparse C8: CKV tensor = kv_lora(fp8) + k_rope(bf16→fp8) + quant_scale_metadata
                             #   kv_lora_rank                    : fp8, 1 byte/elem
                             #   qk_rope_head_dim * 2            : bf16→fp8 ratio (2/1 bytes)
@@ -4529,11 +4524,11 @@ class NPUModelRunner(GPUModelRunner):
                         )
                     
                     # A5 sparse C8: ckv uses float8_e4m3fn
-                    if self.use_sparse and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
+                    if self.use_sparse and current_sparse_c8 and not DeviceConfig.kv_cache_has_v_tensor:
                         k_cache_dtype = self.c8_k_cache_dtype
                     
                     k_cache = raw_k_tensor.view(k_cache_dtype).view(k_shape)
-                    if self.use_sparse and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
+                    if self.use_sparse and current_sparse_c8 and not DeviceConfig.kv_cache_has_v_tensor:
                         v_cache = None
                     else:
                         v_cache = raw_v_tensor.view(v_cache_dtype).view(v_shape)
@@ -4561,7 +4556,7 @@ class NPUModelRunner(GPUModelRunner):
                                 .view(self.c8_k_scale_cache_dtype)
                                 .view(dsa_k_scale_cache_shape)
                             )
-                            if get_ascend_device_type() == AscendDeviceType.A5:
+                            if not DeviceConfig.kv_cache_has_v_tensor:
                                 kv_caches[layer_name] = (k_cache, dsa_k_cache, dsa_k_scale_cache)
                             elif v_cache is not None:
                                 kv_caches[layer_name] = (k_cache, v_cache, dsa_k_cache, dsa_k_scale_cache)

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -58,16 +58,17 @@ import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 from vllm_ascend.batch_invariant import init_batch_invariance
 from vllm_ascend.cpu_binding import bind_cpus
+from vllm_ascend.device.device_config import (
+    DeviceConfig,
+    check_ascend_device_type,
+)
 from vllm_ascend.device_allocator.camem import CaMemAllocator
 from vllm_ascend.device_allocator.sleep_mem_optimized import SleepWakeupManager
 from vllm_ascend.distributed.parallel_state import init_ascend_model_parallel
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
 from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
 from vllm_ascend.utils import (
-    AscendDeviceType,
-    check_ascend_device_type,
     enable_sp,
-    get_ascend_device_type,
     register_ascend_customop,
     setup_ascend_local_comm_res,
 )
@@ -97,30 +98,48 @@ class NPUWorker(WorkerBase):
         **kwargs,
     ):
         """Initialize the worker for Ascend."""
-        if not envs_ascend.COMPILE_CUSTOM_KERNELS:
-            logger.warning(
-                "COMPILE_CUSTOM_KERNELS is set to False. "
-                "In most scenarios, without custom kernels, vllm-ascend will not function correctly."
-            )
+        # Check if the device type is supported.
+        check_ascend_device_type()
 
-        # register patch for vllm
+        # Check if triton is installed on this device.
+        if DeviceConfig.supports_triton:
+            try:
+                import triton.language.extra.cann  # type: ignore  # noqa: F401
+            except ImportError:
+                raise ImportError("Triton-Ascend is required on this device but not installed. ")
+        else:
+            try:
+                import triton  # noqa: F401
+            except ImportError:
+                pass
+            else:
+                raise ImportError(
+                    "Triton should not be installed on this device. "
+                    "Please uninstall triton to avoid conflicts with the native Ascend driver."
+                )
+
+        # register patch for vllm, lazy import to avoid circular import.
         from vllm_ascend.utils import adapt_patch
 
         adapt_patch()
 
-        # Register ops when worker init.
-        from vllm_ascend import ops
+        # Register ops when worker init. Lazy import to avoid circular import.
+        from vllm_ascend import ops  # noqa
 
-        ops.register_dummy_fusion_op()
-        if get_ascend_device_type() != AscendDeviceType.A5:
+        # Register ATB ops if enabled.
+        if DeviceConfig.enable_atb:
             _register_atb_extensions()
+
+        # replace Ascend custom ops implementation
         register_ascend_customop(vllm_config)
+
         # init ascend config and soc version
         init_ascend_config(vllm_config)
+
+        # Configure logging for Ascend.
         from vllm_ascend.logger import configure_ascend_file_logging
 
         configure_ascend_file_logging()
-        check_ascend_device_type()
 
         super().__init__(
             vllm_config=vllm_config,
@@ -170,7 +189,7 @@ class NPUWorker(WorkerBase):
                 nonlocal shutdown_request
                 if not shutdown_request:
                     shutdown_request = True
-                    self.uninstall_static_kernel()
+                    self._uninstall_static_kernel()
                     raise SystemExit()
 
             # Either SIGTERM or SIGINT will terminate the worker
@@ -179,7 +198,7 @@ class NPUWorker(WorkerBase):
             signal.signal(signal.SIGTERM, signal_handler)
             signal.signal(signal.SIGINT, signal_handler)
 
-    def uninstall_static_kernel(self):
+    def _uninstall_static_kernel(self):
         import fcntl
         import os
         import subprocess
@@ -290,14 +309,6 @@ class NPUWorker(WorkerBase):
         typed_init_info = self.weight_transfer_engine.parse_init_info(init_info)
         self.weight_transfer_engine.init_transfer_engine(typed_init_info)
 
-    def _check_nz_disabled(self) -> None:
-        if envs_ascend.VLLM_ASCEND_ENABLE_NZ:
-            raise ValueError(
-                "FRACTAL_NZ mode is enabled. This may cause model parameter "
-                "precision issues in the RL scenarios. Please set "
-                "VLLM_ASCEND_ENABLE_NZ=0."
-            )
-
     def start_weight_update(self, is_checkpoint_format: bool = True) -> None:
         """Begin a new weight update; prepares the model for layerwise reload."""
         self._check_weight_transfer_engine()
@@ -307,7 +318,12 @@ class NPUWorker(WorkerBase):
                 "start_weight_update called while a weight update is already active. Call finish_weight_update first."
             )
 
-        self._check_nz_disabled()
+        if envs_ascend.VLLM_ASCEND_ENABLE_NZ:
+            raise ValueError(
+                "FRACTAL_NZ mode is enabled. This may cause model parameter "
+                "precision issues in the RL scenarios. Please set "
+                "VLLM_ASCEND_ENABLE_NZ=0."
+            )
 
         if is_checkpoint_format:
             from vllm.model_executor.model_loader.reload import initialize_layerwise_reload
@@ -398,15 +414,17 @@ class NPUWorker(WorkerBase):
         # This lazy import avoids torch_npu re-initialization in patch
         # Note that this should be imported after torch.npu.set_device
         # to avoid repeated set_device in extra processes
-        from vllm.triton_utils import HAS_TRITON
+        from vllm_ascend.device.device_config import (
+            DeviceConfig,
+        )
 
-        if HAS_TRITON:
+        if DeviceConfig.supports_triton:
             import torch_npu._inductor  # noqa: F401
 
         gc.collect()
         torch.npu.empty_cache()
 
-        if get_ascend_device_type() == AscendDeviceType.A5:
+        if DeviceConfig.enable_local_comm_res:
             setup_ascend_local_comm_res(self.local_rank, self.vllm_config.kv_transfer_config)
 
         # take current memory snapshot
@@ -787,7 +805,7 @@ class NPUWorker(WorkerBase):
 
         # Call ATB matmul to warm up; otherwise, the first operation (ReshapeAndCache)
         # may cause performance degradation at runtime.
-        if get_ascend_device_type() != AscendDeviceType.A5:
+        if DeviceConfig.enable_atb:
             self._warm_up_atb()
         # Bind after warmup so hot allocations are already materialized on the
         # worker process before migratepages/taskset run.
@@ -1034,7 +1052,11 @@ class NPUWorker(WorkerBase):
             )
 
             if result.returncode == 0:
-                parse_text_output(result.stdout)
+                lines = result.stdout.strip().split("\n")
+                for i, line in enumerate(lines):
+                    line = line.strip()
+                    if "Health" in line and line.split(":")[-1].strip() != "OK":
+                        raise RuntimeError("NPU card health status is not OK")
                 logger.debug("check_health success for rank %s.", self.local_rank)
             else:
                 logger.warning("query NPU card %s fail: %s", self.local_rank, result.stderr)
@@ -1044,14 +1066,3 @@ class NPUWorker(WorkerBase):
             logger.warning("npu-smi tool not found.")
         except Exception as e:
             logger.error("query NPU card %s fail: %s", self.local_rank, e)
-        return
-
-
-def parse_text_output(output) -> None:
-    lines = output.strip().split("\n")
-    for i, line in enumerate(lines):
-        line = line.strip()
-        if "Health" in line:
-            if line.split(":")[-1].strip() != "OK":
-                raise RuntimeError("NPU card health status is not OK")
-    return


### PR DESCRIPTION
- Move AscendDeviceType, get_ascend_device_type, check_ascend_device_type from vllm_ascend.utils to vllm_ascend.device.device_config
- Add a singleton DeviceConfig with semantic properties (is_a2, is_a3, is_310p, is_a5, supports_triton, cpu_binding_mode, etc.) replacing scattered get_ascend_device_type() == AscendDeviceType.X checks
- Initialize device type eagerly in DeviceConfig.__init__ from _build_info
- Add startup check in NPUWorker that raises if supports_triton but triton-ascend is not installed
- Replace HAS_TRITON usage in vllm-ascend with DeviceConfig.supports_triton (HAS_TRITON was effectively a 310P proxy in this codebase)
- Add device_config (lowercase) alias for the DeviceConfig singleton so module-level 'from vllm_ascend.device import device_config' works
- Update test mocks accordingly

---


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
