### PR TITLE
[CI] Modify the accuracy threshold of glm5 in aime2025

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A3-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A3-dual-nodes.yaml
@@ -83,7 +83,7 @@ benchmarks:
     max_out_len: 72348
     batch_size: 32
     baseline: 90
-    threshold: 5
+    threshold: 10
 
   perf:
     case_type: performance


### PR DESCRIPTION
### What this PR does / why we need it?
This PR increases the benchmark threshold from 5 to 10 in the `GLM5_1-W8A8-A3-dual-nodes.yaml` configuration file to accommodate performance variance.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI nightly benchmark tests.
- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
