### PR TITLE
[BugFix] align spec_sequence_masks device tensor capacity with CPU

### DIFF
--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -759,6 +759,11 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
             device="cpu",
             pin_memory=device.type != "cpu",
         )
+        self.spec_sequence_masks: torch.Tensor = torch.empty(
+            (sequence_index_capacity,),
+            dtype=torch.bool,
+            device=device,
+        )
         self.spec_sequence_indices_cpu: torch.Tensor = torch.empty(
             (sequence_index_capacity,),
             dtype=torch.int64,


### PR DESCRIPTION
### What this PR does / why we need it?
backport: #10619
Problem: When max_num_seqs > decode_cudagraph_max_bs, spec_sequence_masks device tensor (decode_cudagraph_max_bs sized) is smaller than its CPU
  counterpart (max(max_num_seqs, decode_cudagraph_max_bs) sized), causing RuntimeError on copy_ in _build_attn_group_metadata.

 Fix: Override self.spec_sequence_masks in AscendGDNAttentionMetadataBuilder with sequence_index_capacity to match spec_sequence_masks_cpu.
### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
