### PR TITLE
[Feature]Support HND KV cache layout for heter KV transfer with A5 guard

### DIFF
--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -11,6 +11,7 @@ from vllm_ascend.attention.attention_v1 import (
 )
 from vllm_ascend.attention.kvcomp_attn.attention_utils import get_kvcomp_decode_params, reshape_and_cache_kvcomp
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+from vllm_ascend.utils import AscendDeviceType
 
 
 class TestAscendAttentionBackend(TestBase):
@@ -38,6 +39,25 @@ class TestAscendAttentionBackend(TestBase):
 
     def test_get_builder_cls(self):
         self.assertEqual(AscendAttentionBackend.get_builder_cls(), AscendAttentionMetadataBuilder)
+
+    @patch("vllm_ascend.worker.kv_cache_layout.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch("vllm_ascend.attention.attention_v1.get_kv_cache_layout", return_value="HND")
+    def test_hnd_kv_cache_stride_order_rejected_on_non_a5(
+        self,
+        _mock_attention_layout,
+        _mock_device_type,
+    ):
+        with self.assertRaisesRegex(RuntimeError, "only supported on Ascend A5"):
+            AscendAttentionBackend.get_kv_cache_stride_order()
+
+    @patch("vllm_ascend.worker.kv_cache_layout.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch("vllm_ascend.attention.attention_v1.get_kv_cache_layout", return_value="HND")
+    def test_hnd_kv_cache_stride_order_allowed_on_a5(
+        self,
+        _mock_attention_layout,
+        _mock_device_type,
+    ):
+        self.assertEqual(AscendAttentionBackend.get_kv_cache_stride_order(), (0, 1, 3, 2, 4))
 
     def test_get_kv_cache_shape_not(self):
         result = AscendAttentionBackend.get_kv_cache_shape(10, 20, 30, 40)

--- a/tests/ut/worker/test_kv_cache_layout.py
+++ b/tests/ut/worker/test_kv_cache_layout.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm_ascend.utils import AscendDeviceType
+from vllm_ascend.worker import kv_cache_layout
+
+
+class HNDBackend:
+    @staticmethod
+    def get_kv_cache_stride_order() -> tuple[int, ...]:
+        return (0, 1, 3, 2, 4)
+
+
+def test_hnd_layout_rejected_on_non_a5() -> None:
+    with (
+        patch.object(kv_cache_layout, "get_kv_cache_layout", return_value="HND"),
+        patch.object(kv_cache_layout, "get_ascend_device_type", return_value=AscendDeviceType.A2),
+        pytest.raises(RuntimeError, match="only supported on Ascend A5"),
+    ):
+        kv_cache_layout.get_kv_cache_stride_order(HNDBackend, (2, 2, 3, 4, 5))
+
+
+def test_hnd_layout_allowed_on_a5() -> None:
+    with (
+        patch.object(kv_cache_layout, "get_kv_cache_layout", return_value="HND"),
+        patch.object(kv_cache_layout, "get_ascend_device_type", return_value=AscendDeviceType.A5),
+    ):
+        assert kv_cache_layout.get_kv_cache_stride_order(HNDBackend, (2, 2, 3, 4, 5)) == (0, 1, 3, 2, 4)
+
+
+def test_hnd_split_cache_view_uses_a5_stride_order() -> None:
+    raw_tensor = torch.arange(2 * 3 * 4 * 5, dtype=torch.float32)
+
+    with (
+        patch.object(kv_cache_layout, "get_kv_cache_layout", return_value="HND"),
+        patch.object(kv_cache_layout, "get_ascend_device_type", return_value=AscendDeviceType.A5),
+    ):
+        cache = kv_cache_layout.view_split_kv_cache_with_stride_order(
+            raw_tensor,
+            torch.float32,
+            (2, 2, 3, 4, 5),
+            (2, 3, 4, 5),
+            HNDBackend,
+        )
+
+    assert cache.shape == (2, 3, 4, 5)
+    assert cache.stride() == (60, 5, 15, 1)

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -197,8 +197,8 @@ class AscendConfig:
                 assert decode_tp_size % prefill_tp_size == 0, (
                     "Decode TP size must be divisible by Prefill TP size when Decode TP is larger."
                 )
-            self.pd_tp_ratio = prefill_tp_size // decode_tp_size
-            if self.pd_tp_ratio > 1:
+            self.pd_tp_ratio = max(prefill_tp_size, decode_tp_size) // min(prefill_tp_size, decode_tp_size)
+            if prefill_tp_size > decode_tp_size and self.pd_tp_ratio > 1:
                 # Total KV heads from vLLM's resolved architecture (ModelArchConfigConvertor).
                 num_kv_head = vllm_config.model_config.get_total_num_kv_heads()
                 if not num_kv_head or num_kv_head < 1:

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -188,7 +188,15 @@ class AscendConfig:
         ):
             prefill_tp_size = vllm_config.kv_transfer_config.get_from_extra_config("prefill", {"tp_size": 1})["tp_size"]
             decode_tp_size = vllm_config.kv_transfer_config.get_from_extra_config("decode", {"tp_size": 1})["tp_size"]
-            assert prefill_tp_size % decode_tp_size == 0, "Prefill TP size must be divisible by Decode TP size."
+            if prefill_tp_size >= decode_tp_size:
+                assert prefill_tp_size % decode_tp_size == 0, (
+                    "Prefill TP size must be divisible by Decode TP size when Prefill TP is larger."
+                )
+                self.pd_tp_ratio = prefill_tp_size // decode_tp_size
+            else:
+                assert decode_tp_size % prefill_tp_size == 0, (
+                    "Decode TP size must be divisible by Prefill TP size when Decode TP is larger."
+                )
             self.pd_tp_ratio = prefill_tp_size // decode_tp_size
             if self.pd_tp_ratio > 1:
                 # Total KV heads from vLLM's resolved architecture (ModelArchConfigConvertor).
@@ -204,8 +212,6 @@ class AscendConfig:
                 decode_tp_size = min(decode_tp_size, num_kv_head)
                 self.pd_head_ratio = prefill_tp_size // decode_tp_size
 
-            if self.pd_tp_ratio == 0:
-                raise AssertionError("Only support P node tp size lagger then D node tp size")
         self.SLO_limits_for_dynamic_batch = additional_config.get("SLO_limits_for_dynamic_batch", -1)
         from vllm_ascend.utils import get_flashcomm2_config_and_validate
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -36,6 +36,7 @@ from vllm.v1.attention.backends.registry import (  # type: ignore
     AttentionBackendEnum,
     register_backend,
 )
+from vllm.v1.attention.backends.utils import get_kv_cache_layout
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import AttentionSpec, CrossAttentionSpec
 
@@ -106,6 +107,21 @@ class AscendAttentionBackend(AttentionBackend):
         cache_dtype_str: str = "",
     ) -> tuple[int, ...]:
         return (2, num_blocks, block_size, num_kv_heads, head_size)
+    
+    @staticmethod
+    def get_kv_cache_stride_order(
+        include_num_layers_dimension: bool = False,
+    ) -> tuple[int, ...]:
+        cache_layout = get_kv_cache_layout()
+        if cache_layout == "NHD" and include_num_layers_dimension:
+            return (2, 0, 1, 3, 4, 5)
+        if cache_layout == "NHD":
+            return (0, 1, 2, 3, 4)
+        if cache_layout == "HND" and include_num_layers_dimension:
+            return (2, 4, 0, 1, 3, 5)
+        if cache_layout == "HND":
+            return (0, 1, 3, 2, 4)
+        raise ValueError(f"Unknown cache layout format {cache_layout}.")
 
     @staticmethod
     def swap_blocks(
@@ -985,6 +1001,22 @@ class AscendAttentionBackendImpl(AttentionImpl):
     def _get_fia_params(self, key: torch.Tensor, value: torch.Tensor, attn_metadata: AscendMetadata, kv_cache=None):
         # PrefillNoCache doesn't need key_cache, but other modes do
         # Only initialize/require cache for modes that actually use it
+
+        def get_paged_cache_params() -> tuple[torch.Tensor, torch.Tensor, int]:
+            assert self.key_cache is not None
+            assert self.value_cache is not None
+            num_block, block_size, _, _ = self.key_cache.shape
+            is_hnd_physical_cache = (
+                get_kv_cache_layout() == "HND" and self.key_cache.stride(2) == block_size * self.key_cache.shape[-1]
+            )
+            if is_hnd_physical_cache:
+                key = self.key_cache.permute(0, 2, 1, 3)
+                value = self.value_cache.permute(0, 2, 1, 3)
+                return key, value, block_size
+            key = self.key_cache.view(num_block, block_size, -1)
+            value = self.value_cache.view(num_block, block_size, -1)
+            return key, value, block_size
+        
         if attn_metadata.attn_state != AscendAttentionState.PrefillNoCache:
             # Initialize cache from kv_cache if not already set (for DecodeOnly mode)
             if self.key_cache is None and kv_cache is not None:
@@ -1011,33 +1043,15 @@ class AscendAttentionBackendImpl(AttentionImpl):
         elif attn_metadata.attn_state == AscendAttentionState.PrefillCacheHit:
             batch_size = attn_metadata.seq_lens.shape[0]
             block_table = attn_metadata.block_tables[:batch_size, :]
-            num_block, block_size, _, _ = self.key_cache.shape  # type: ignore
-            key = self.key_cache.view(  # type: ignore
-                num_block, block_size, -1
-            )
-            value = self.value_cache.view(  # type: ignore
-                num_block, block_size, -1
-            )
+            key, value, block_size = get_paged_cache_params()
             actual_seq_lengths_kv = attn_metadata.seq_lens_list
         elif attn_metadata.attn_state == AscendAttentionState.DecodeOnly:
-            num_block, block_size, _, _ = self.key_cache.shape  # type: ignore
-            key = self.key_cache.view(  # type: ignore
-                num_block, block_size, -1
-            )
-            value = self.value_cache.view(  # type: ignore
-                num_block, block_size, -1
-            )
+            key, value, block_size = get_paged_cache_params()
             block_table = attn_metadata.block_tables
             actual_seq_lengths_kv = attn_metadata.seq_lens_list
         # chunked prefill.
         else:
-            num_block, block_size, _, _ = self.key_cache.shape  # type: ignore
-            key = self.key_cache.view(  # type: ignore
-                num_block, block_size, -1
-            )
-            value = self.value_cache.view(  # type: ignore
-                num_block, block_size, -1
-            )
+            key, value, block_size = get_paged_cache_params()
             block_table = attn_metadata.block_tables
             actual_seq_lengths_kv = attn_metadata.seq_lens_list
         return key, value, block_size, block_table, actual_seq_lengths_kv

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -64,6 +64,7 @@ from vllm_ascend.compilation.acl_graph import (
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.ops.flashcomm2_oshard_manager import flashcomm2_oshard_manager
 from vllm_ascend.utils import weak_ref_tensors
+from vllm_ascend.worker.kv_cache_layout import check_hnd_kv_cache_layout_supported
 from vllm_ascend.worker.kvcomp_utils import KVCompMetaData
 
 # default max value of sliding window size
@@ -107,7 +108,7 @@ class AscendAttentionBackend(AttentionBackend):
         cache_dtype_str: str = "",
     ) -> tuple[int, ...]:
         return (2, num_blocks, block_size, num_kv_heads, head_size)
-    
+
     @staticmethod
     def get_kv_cache_stride_order(
         include_num_layers_dimension: bool = False,
@@ -118,8 +119,10 @@ class AscendAttentionBackend(AttentionBackend):
         if cache_layout == "NHD":
             return (0, 1, 2, 3, 4)
         if cache_layout == "HND" and include_num_layers_dimension:
+            check_hnd_kv_cache_layout_supported(cache_layout)
             return (2, 4, 0, 1, 3, 5)
         if cache_layout == "HND":
+            check_hnd_kv_cache_layout_supported(cache_layout)
             return (0, 1, 3, 2, 4)
         raise ValueError(f"Unknown cache layout format {cache_layout}.")
 
@@ -1006,8 +1009,11 @@ class AscendAttentionBackendImpl(AttentionImpl):
             assert self.key_cache is not None
             assert self.value_cache is not None
             num_block, block_size, _, _ = self.key_cache.shape
+            cache_layout = get_kv_cache_layout()
+            if cache_layout == "HND":
+                check_hnd_kv_cache_layout_supported(cache_layout)
             is_hnd_physical_cache = (
-                get_kv_cache_layout() == "HND" and self.key_cache.stride(2) == block_size * self.key_cache.shape[-1]
+                cache_layout == "HND" and self.key_cache.stride(2) == block_size * self.key_cache.shape[-1]
             )
             if is_hnd_physical_cache:
                 key = self.key_cache.permute(0, 2, 1, 3)
@@ -1016,7 +1022,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             key = self.key_cache.view(num_block, block_size, -1)
             value = self.value_cache.view(num_block, block_size, -1)
             return key, value, block_size
-        
+
         if attn_metadata.attn_state != AscendAttentionState.PrefillNoCache:
             # Initialize cache from kv_cache if not already set (for DecodeOnly mode)
             if self.key_cache is None and kv_cache is not None:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -124,8 +124,18 @@ class GroupPull:
     group_id: int
     remote_tp_offset: int
     num_group_pulls: int
+    remote_tp_rank: int = 0
+    remote_tp_size: int = 1
     prefill_pp_rank: int = 0
     is_group_transfer_end: bool = False
+
+
+@dataclass(frozen=True)
+class TransferPlan:
+    local_region_offset: int
+    remote_region_offset: int
+    transfer_len: int
+    split_by_token: bool = False
 
 
 @dataclass(frozen=True)
@@ -133,6 +143,95 @@ class GroupTransferInfo:
     tokens_per_block: int
     blocks_per_window: int
     is_state_group: bool
+
+
+def _get_tp_ratio(local_tp_size: int, remote_tp_size: int) -> int:
+    if local_tp_size >= remote_tp_size:
+        assert local_tp_size % remote_tp_size == 0, (
+            f"Local tensor parallel size {local_tp_size} is not divisible "
+            f"by remote tensor parallel size {remote_tp_size}."
+        )
+        return local_tp_size // remote_tp_size
+
+    assert remote_tp_size % local_tp_size == 0, (
+        f"Remote tensor parallel size {remote_tp_size} is not divisible by local tensor parallel size {local_tp_size}."
+    )
+    return -(remote_tp_size // local_tp_size)
+
+
+def _producer_cache_is_replicated(
+    *,
+    is_mla: bool,
+    is_sparse: bool,
+    producer_tp_size: int,
+    num_key_value_heads: int,
+) -> bool:
+    return is_mla or is_sparse or producer_tp_size > num_key_value_heads
+
+
+def _compute_receiver_transfer_plan(
+    *,
+    local_tp_rank: int,
+    local_tp_size: int,
+    remote_tp_rank: int,
+    remote_tp_size: int,
+    local_block_len: int,
+    remote_block_len: int,
+    producer_cache_replicated: bool,
+    block_size: int | None = None,
+    split_remote_block_by_token: bool = False,
+) -> TransferPlan:
+    """Plan one Decode-rank read from one Prefill-rank KV block."""
+    tp_ratio = _get_tp_ratio(local_tp_size, remote_tp_size)
+
+    if tp_ratio == 1:
+        assert local_block_len == remote_block_len, (
+            f"Homogeneous TP KV block length mismatch: local={local_block_len}, remote={remote_block_len}."
+        )
+        return TransferPlan(0, 0, local_block_len)
+
+    if tp_ratio > 0:
+        if producer_cache_replicated:
+            assert local_block_len == remote_block_len, (
+                "Replicated producer KV block length must match Decode KV block "
+                f"length, got local={local_block_len}, remote={remote_block_len}."
+            )
+            return TransferPlan(0, 0, local_block_len)
+
+        assert remote_block_len == local_block_len * tp_ratio, (
+            "Prefill KV block length must cover all Decode TP slices when "
+            f"Decode TP is larger, got local={local_block_len}, "
+            f"remote={remote_block_len}, tp_ratio={tp_ratio}."
+        )
+        if split_remote_block_by_token:
+            assert block_size is not None and block_size > 0
+            assert local_block_len % block_size == 0 and remote_block_len % block_size == 0
+            local_token_len = local_block_len // block_size
+            return TransferPlan(0, (local_tp_rank % tp_ratio) * local_token_len, local_token_len, True)
+        return TransferPlan(
+            0,
+            (local_tp_rank % tp_ratio) * local_block_len,
+            local_block_len,
+        )
+
+    ratio_abs = -tp_ratio
+    if producer_cache_replicated:
+        assert local_block_len == remote_block_len, (
+            "Replicated producer KV block length must match Decode KV block "
+            f"length, got local={local_block_len}, remote={remote_block_len}."
+        )
+        return TransferPlan(0, 0, local_block_len)
+
+    assert local_block_len == remote_block_len * ratio_abs, (
+        "Decode KV block length must cover all Prefill TP shards when Prefill "
+        f"TP is larger, got local={local_block_len}, remote={remote_block_len}, "
+        f"tp_ratio={tp_ratio}."
+    )
+    return TransferPlan(
+        local_region_offset=(remote_tp_rank % ratio_abs) * remote_block_len,
+        remote_region_offset=0,
+        transfer_len=remote_block_len,
+    )
 
 
 @dataclass
@@ -495,6 +594,7 @@ class KVCacheRecvingThread(threading.Thread):
         except AttributeError:
             hf_text_config = self.model_config.hf_config
         self.use_sparse = hasattr(hf_text_config, "index_topk")
+        self.num_key_value_heads = hf_text_config.num_key_value_heads
         self.num_layers = hf_text_config.num_hidden_layers
         if block_size_scale is None:
             block_size_scale = []
@@ -668,31 +768,29 @@ class KVCacheRecvingThread(threading.Thread):
         grouped_local_block_ids: list[list[int]],
         tp_num_need_pulls: int,
         remote_tp_offset: int,
+        remote_tp_rank: int,
+        remote_tp_size: int,
     ) -> None:
-        if self.use_mla or self.use_sparse or tp_num_need_pulls == 1:
-            if local_kv_block_len != remote_kv_block_len:
-                raise RuntimeError(
-                    "Mooncake HND transfer expects equal KV block lengths for replicated or homogeneous TP "
-                    f"caches, got local={local_kv_block_len}, remote={remote_kv_block_len}."
-                )
-            local_region_offset = 0
-            remote_region_offset = 0
-            transfer_len = local_kv_block_len
-        else:
-            if local_kv_block_len != remote_kv_block_len * tp_num_need_pulls:
-                raise RuntimeError(
-                    "Mooncake HND transfer expects Decode KV block length to cover all Prefill TP shards, "
-                    f"got local={local_kv_block_len}, remote={remote_kv_block_len}, pulls={tp_num_need_pulls}."
-                )
-            local_region_offset = remote_tp_offset * remote_kv_block_len
-            remote_region_offset = 0
-            transfer_len = remote_kv_block_len
+        transfer_plan = _compute_receiver_transfer_plan(
+            local_tp_rank=self.tp_rank,
+            local_tp_size=self.tp_size,
+            remote_tp_rank=remote_tp_rank,
+            remote_tp_size=remote_tp_size,
+            local_block_len=local_kv_block_len,
+            remote_block_len=remote_kv_block_len,
+            producer_cache_replicated=_producer_cache_is_replicated(
+                is_mla=self.use_mla,
+                is_sparse=self.use_sparse,
+                producer_tp_size=remote_tp_size,
+                num_key_value_heads=self.num_key_value_heads,
+            ),
+        )
 
         can_coalesce = (
-            local_region_offset == 0
-            and remote_region_offset == 0
-            and transfer_len == local_block_stride
-            and transfer_len == remote_block_stride
+            transfer_plan.local_region_offset == 0
+            and transfer_plan.remote_region_offset == 0
+            and transfer_plan.transfer_len == local_block_stride
+            and transfer_plan.transfer_len == remote_block_stride
         )
         for remote_block_id, local_block_id in zip(grouped_remote_block_ids, grouped_local_block_ids):
             if can_coalesce:
@@ -700,15 +798,15 @@ class KVCacheRecvingThread(threading.Thread):
                 dst = remote_layer_base_addr + remote_block_id[0] * remote_block_stride
                 src_list.append(src)
                 dst_list.append(dst)
-                length_list.append(transfer_len * len(local_block_id))
+                length_list.append(transfer_plan.transfer_len * len(local_block_id))
                 continue
 
             for remote_block, local_block in zip(remote_block_id, local_block_id):
-                src = local_layer_base_addr + local_block * local_block_stride + local_region_offset
-                dst = remote_layer_base_addr + remote_block * remote_block_stride + remote_region_offset
+                src = local_layer_base_addr + local_block * local_block_stride + transfer_plan.local_region_offset
+                dst = remote_layer_base_addr + remote_block * remote_block_stride + transfer_plan.remote_region_offset
                 src_list.append(src)
                 dst_list.append(dst)
-                length_list.append(transfer_len)
+                length_list.append(transfer_plan.transfer_len)
 
     def _transfer_hnd_kv_cache_all_groups(self, req_meta: dict[str, Any]):
         """Transfer HND KV cache shards directly to their final head interval."""
@@ -821,6 +919,8 @@ class KVCacheRecvingThread(threading.Thread):
                         grouped_local_block_ids=grouped_local_block_ids,
                         tp_num_need_pulls=tp_num_need_pulls,
                         remote_tp_offset=remote_tp_offset,
+                        remote_tp_rank=group_pull.remote_tp_rank,
+                        remote_tp_size=group_pull.remote_tp_size,
                     )
 
         if not src_list:
@@ -875,6 +975,7 @@ class KVCacheRecvingThread(threading.Thread):
         local_kv_caches_base_addrs = self.kv_caches_base_addr[self.local_engine_id][self.local_handshake_port]
         remote_transfer_port = self.remote_te_port[remote_engine_id][remote_handshake_port]
         remote_block_size_scale = self.remote_block_size_scale[remote_engine_id][remote_handshake_port]
+        remote_block_len_per_addr = self.remote_block_len_per_addr[remote_engine_id][remote_handshake_port]
         remote_block_stride_per_addr = self.remote_block_stride_per_addr[remote_engine_id][remote_handshake_port]
         session_id = f"{remote_host}:{remote_transfer_port}"
 
@@ -904,6 +1005,8 @@ class KVCacheRecvingThread(threading.Thread):
                 is_group_transfer_end = group_pull.is_group_transfer_end
                 local_scale = self.block_size_scale[layer_indices[0]][0]
                 remote_scale = remote_block_size_scale[layer_indices[0]][0]
+                local_block_tokens = self.block_size // local_scale
+                remote_block_tokens = self.block_size // remote_scale
                 kernel_local_block_ids = expand_block_ids(local_group_block_ids, local_scale)
                 kernel_remote_block_ids = expand_block_ids(remote_group_block_ids, remote_scale)
                 # For FullAttentionSpec prefix cache with hybrid kernel blocks.
@@ -979,19 +1082,77 @@ class KVCacheRecvingThread(threading.Thread):
                     dst_layer_base_addr = remote_kv_caches_base_addrs[layer_idx][cache_idx]
                     block_len = self.block_len_per_addr[layer_idx][cache_idx]
                     block_stride = self.block_stride_per_addr[layer_idx][cache_idx]
+                    remote_block_len = remote_block_len_per_addr[layer_idx][cache_idx]
                     remote_block_stride = remote_block_stride_per_addr[layer_idx][cache_idx]
-                    inner_block_len = block_len // tp_num_need_pulls
-                    transfer_remote_block_ids, transfer_local_block_ids = split_if_not_byte_contiguous(
-                        grouped_remote_block_ids,
-                        grouped_local_block_ids,
-                        src_block_stride=remote_block_stride,
-                        dst_block_stride=block_stride,
-                        block_len=inner_block_len,
+                    transfer_plan = _compute_receiver_transfer_plan(
+                        local_tp_rank=self.tp_rank,
+                        local_tp_size=self.tp_size,
+                        remote_tp_rank=group_pull.remote_tp_rank,
+                        remote_tp_size=group_pull.remote_tp_size,
+                        local_block_len=block_len,
+                        remote_block_len=remote_block_len,
+                        producer_cache_replicated=_producer_cache_is_replicated(
+                            is_mla=self.use_mla,
+                            is_sparse=self.use_sparse,
+                            producer_tp_size=group_pull.remote_tp_size,
+                            num_key_value_heads=self.num_key_value_heads,
+                        ),
+                        block_size=local_block_tokens,
+                        split_remote_block_by_token=True,
                     )
+                    if transfer_plan.split_by_token:
+                        if local_block_tokens != remote_block_tokens:
+                            raise RuntimeError(
+                                "Mooncake NHD token-wise TP split requires matching local/remote block token counts, "
+                                f"got local={local_block_tokens}, remote={remote_block_tokens}."
+                            )
+                        remote_token_len = remote_block_len // remote_block_tokens
+                        for remote_block_id, local_block_id in zip(grouped_remote_block_ids, grouped_local_block_ids):
+                            for remote_block, local_block in zip(remote_block_id, local_block_id):
+                                for token_idx in range(local_block_tokens):
+                                    src = (
+                                        src_layer_base_addr
+                                        + local_block * block_stride
+                                        + token_idx * transfer_plan.transfer_len
+                                    )
+                                    dst = (
+                                        dst_layer_base_addr
+                                        + remote_block * remote_block_stride
+                                        + token_idx * remote_token_len
+                                        + transfer_plan.remote_region_offset
+                                    )
+                                    src_list.append(src)
+                                    dst_list.append(dst)
+                                    length_list.append(transfer_plan.transfer_len)
+                        continue
+
+                    can_coalesce = (
+                        transfer_plan.local_region_offset == 0
+                        and transfer_plan.remote_region_offset == 0
+                        and transfer_plan.transfer_len == block_stride
+                        and transfer_plan.transfer_len == remote_block_stride
+                    )
+                    if can_coalesce:
+                        transfer_remote_block_ids, transfer_local_block_ids = (
+                            grouped_remote_block_ids,
+                            grouped_local_block_ids,
+                        )
+                    else:
+                        transfer_remote_block_ids, transfer_local_block_ids = split_if_not_byte_contiguous(
+                            grouped_remote_block_ids,
+                            grouped_local_block_ids,
+                            src_block_stride=remote_block_stride,
+                            dst_block_stride=block_stride,
+                            block_len=transfer_plan.transfer_len,
+                        )
                     for remote_block_id, local_block_id in zip(transfer_remote_block_ids, transfer_local_block_ids):
-                        src = src_layer_base_addr + local_block_id[0] * block_stride + inner_offset * inner_block_len
-                        dst = dst_layer_base_addr + remote_block_id[0] * remote_block_stride
-                        length = inner_block_len * len(local_block_id)
+                        src = src_layer_base_addr + local_block_id[0] * block_stride + transfer_plan.local_region_offset
+                        dst = (
+                            dst_layer_base_addr
+                            + remote_block_id[0] * remote_block_stride
+                            + transfer_plan.remote_region_offset
+                        )
+                        length = transfer_plan.transfer_len * len(local_block_id)
                         src_list.append(src)
                         dst_list.append(dst)
                         length_list.append(length)
@@ -1948,10 +2109,17 @@ class MooncakeConnectorWorker:
     def __init__(self, vllm_config: VllmConfig, engine_id: str, kv_cache_config: KVCacheConfig):
         self._get_prefill_decode_size(vllm_config)
         os.environ["ASCEND_TRANSFER_TIMEOUT"] = str(get_transfer_timeout_value())
-        if self._prefill_tp_size < self._decode_tp_size:
-            raise ValueError(
-                f"prefill_tp_size: {self._prefill_tp_size} must be greater than"
-                f" or equal to the decode_tp_size: {self._decode_tp_size}"
+        self.kv_cache_layout = get_kv_cache_layout()
+        self.use_hnd_transfer = self.kv_cache_layout == HND_KV_CACHE_LAYOUT
+        if self.use_hnd_transfer:
+            check_hnd_kv_cache_layout_supported(self.kv_cache_layout)
+        if self._prefill_tp_size >= self._decode_tp_size:
+            assert self._prefill_tp_size % self._decode_tp_size == 0, (
+                "Prefill TP size must be divisible by Decode TP size when Prefill TP is larger."
+            )
+        else:
+            assert self._decode_tp_size % self._prefill_tp_size == 0, (
+                "Decode TP size must be divisible by Prefill TP size when Decode TP is larger."
             )
 
         # Metadata.
@@ -1978,10 +2146,6 @@ class MooncakeConnectorWorker:
         self.max_device_id = self.tp_size * self.dp_size * self.pcp_size * self.pp_size
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         self.num_key_value_heads = self.vllm_config.model_config.hf_text_config.num_key_value_heads
-        self.kv_cache_layout = get_kv_cache_layout()
-        self.use_hnd_transfer = self.kv_cache_layout == HND_KV_CACHE_LAYOUT
-        if self.use_hnd_transfer:
-            check_hnd_kv_cache_layout_supported(self.kv_cache_layout)
 
         # kv cache config
         self.kv_cache_config = kv_cache_config
@@ -2023,7 +2187,7 @@ class MooncakeConnectorWorker:
         # kv_transfer variables
         self.vllm_config = vllm_config
         self.block_size = vllm_config.cache_config.block_size
-        if self.vllm_config.model_config.is_deepseek_mla:
+        if self.vllm_config.model_config.is_deepseek_mla or self._prefill_tp_size < self._decode_tp_size:
             self.tp_num_need_pulls = 1
         else:
             num_d_block_heads = max(1, self.num_key_value_heads // self.tp_size)
@@ -2393,6 +2557,14 @@ class MooncakeConnectorWorker:
         """
         prefill_tp_size: int = meta.remote_ptp_size if meta.remote_ptp_size is not None else self._prefill_tp_size
 
+        if prefill_tp_size < self.tp_size and (
+            self._is_hma_required or meta.remote_pcp_size * meta.remote_dcp_size * self.pcp_size * self.dcp_size > 1
+        ):
+            raise NotImplementedError(
+                "Mooncake transfer does not support Prefill TP < Decode TP together with "
+                "hybrid KV cache, prefill context parallel, or decode context parallel yet."
+            )
+
         if meta.remote_pcp_size * meta.remote_dcp_size * self.pcp_size * self.dcp_size == 1:
             if self._is_hma_required:
                 chosen_rank_list, _ = self._get_hybrid_remote_rank_group_pulls(req_id, prefill_tp_size)
@@ -2665,12 +2837,14 @@ class MooncakeConnectorWorker:
         tp_num_need_pulls = self._get_tp_num_need_pulls(prefill_tp_size)
         group_ids = [group_id for group_id, (_, layer_indices) in self.kv_group2layeridx.items() if layer_indices]
 
-        def make_group_pulls(remote_tp_offset: int, prefill_pp_rank: int) -> list[GroupPull]:
+        def make_group_pulls(remote_tp_offset: int, prefill_pp_rank: int, remote_tp_rank: int) -> list[GroupPull]:
             return [
                 GroupPull(
                     group_id=group_id,
                     remote_tp_offset=remote_tp_offset,
                     num_group_pulls=tp_num_need_pulls,
+                    remote_tp_rank=remote_tp_rank,
+                    remote_tp_size=prefill_tp_size,
                     prefill_pp_rank=prefill_pp_rank,
                     is_group_transfer_end=remote_tp_offset == tp_num_need_pulls - 1,
                 )
@@ -2681,6 +2855,7 @@ class MooncakeConnectorWorker:
         for pcp_dcp_rank, remote_ports in enumerate(remote_handshake_port_list):
             if len(remote_ports) == 1:
                 remote_tp_offsets = [pcp_dcp_rank % tp_num_need_pulls]
+                remote_tp_ranks = [(remote_ports[0] - remote_base_port) % prefill_tp_size]
                 prefill_pp_ranks = [
                     ((remote_ports[0] - remote_base_port) % (prefill_tp_size * self._prefill_pp_size))
                     // prefill_tp_size
@@ -2690,14 +2865,17 @@ class MooncakeConnectorWorker:
                     f"tp_num_need_pulls: {tp_num_need_pulls}, remote_ports: {remote_ports}"
                 )
                 remote_tp_offsets = [rank_idx % tp_num_need_pulls for rank_idx in range(len(remote_ports))]
+                remote_tp_ranks = [(remote_port - remote_base_port) % prefill_tp_size for remote_port in remote_ports]
                 prefill_pp_ranks = [
                     ((remote_port - remote_base_port) % (prefill_tp_size * self._prefill_pp_size)) // prefill_tp_size
                     for remote_port in remote_ports
                 ]
             group_pulls_list.append(
                 [
-                    make_group_pulls(remote_tp_offset, prefill_pp_rank)
-                    for remote_tp_offset, prefill_pp_rank in zip(remote_tp_offsets, prefill_pp_ranks)
+                    make_group_pulls(remote_tp_offset, prefill_pp_rank, remote_tp_rank)
+                    for remote_tp_offset, prefill_pp_rank, remote_tp_rank in zip(
+                        remote_tp_offsets, prefill_pp_ranks, remote_tp_ranks
+                    )
                 ]
             )
         return group_pulls_list
@@ -2733,6 +2911,8 @@ class MooncakeConnectorWorker:
                                 group_id=group_id,
                                 remote_tp_offset=remote_tp_offset,
                                 num_group_pulls=num_group_pulls,
+                                remote_tp_rank=remote_rank % prefill_tp_size,
+                                remote_tp_size=prefill_tp_size,
                                 prefill_pp_rank=pp_rank,
                                 is_group_transfer_end=remote_tp_offset == num_group_pulls - 1,
                             ),
@@ -2753,6 +2933,8 @@ class MooncakeConnectorWorker:
                         group_id=group_id,
                         remote_tp_offset=rank_idx % num_group_pulls,
                         num_group_pulls=num_group_pulls,
+                        remote_tp_rank=remote_rank % prefill_tp_size,
+                        remote_tp_size=prefill_tp_size,
                         prefill_pp_rank=prefill_pp_rank,
                         is_group_transfer_end=rank_idx % num_group_pulls == num_group_pulls - 1,
                     ),
@@ -2819,11 +3001,12 @@ class MooncakeConnectorWorker:
                         meta.remote_engine_id,
                         meta.remote_multi_nodes_meta_mapping,
                     )
-                    remote_port_send_num = (
-                        self.remote_port_send_num[meta.remote_engine_id]
-                        if meta.remote_pcp_size * meta.remote_dcp_size > 1
-                        else None
-                    )
+                    if meta.remote_pcp_size * meta.remote_dcp_size > 1:
+                        remote_port_send_num = self.remote_port_send_num[meta.remote_engine_id]
+                    elif prefill_tp_size < self.tp_size:
+                        remote_port_send_num = self._get_remote_port_send_num_for_tp_split(meta, prefill_tp_size)
+                    else:
+                        remote_port_send_num = None
                     self.kv_recv_thread.add_request(
                         request_id=req_id,
                         remote_request_id=remote_req_id,
@@ -2852,6 +3035,29 @@ class MooncakeConnectorWorker:
             for req_id, delay_start_time in metadata.requests_to_send.items():
                 self.kv_send_thread.add_delayed_request(req_id, delay_start_time)
 
+    def _get_remote_port_send_num_for_tp_split(
+        self,
+        meta: ReqMeta,
+        prefill_tp_size: int,
+    ) -> dict[int, RemotePortInfo]:
+        assert self.tp_size % prefill_tp_size == 0, (
+            f"Decode TP size {self.tp_size} is not divisible by Prefill TP size {prefill_tp_size}."
+        )
+        split_ratio = self.tp_size // prefill_tp_size
+        remote_port_send_num: dict[int, RemotePortInfo] = {}
+        remote_multi_nodes_meta_mapping = meta.remote_multi_nodes_meta_mapping or {}
+        for pp_rank in range(self._prefill_pp_size):
+            for tp_rank in range(prefill_tp_size):
+                remote_rank = pp_rank * prefill_tp_size + tp_rank
+                remote_port = meta.remote_port + remote_rank
+                remote_host_info = remote_multi_nodes_meta_mapping.get(str(remote_rank), None)
+                remote_host = meta.remote_host if remote_host_info is None else remote_host_info["host"]
+                remote_port_send_num[remote_port] = {
+                    "num": split_ratio,
+                    "host": remote_host,
+                }
+        return remote_port_send_num
+
     def _get_tp_num_need_pulls(self, prefill_tp_size: int | None) -> int:
         if prefill_tp_size is None:
             prefill_tp_size = self._prefill_tp_size
@@ -2859,7 +3065,7 @@ class MooncakeConnectorWorker:
         if prefill_tp_size == self._prefill_tp_size:
             return self.tp_num_need_pulls
 
-        if self.vllm_config.model_config.is_deepseek_mla:
+        if self.vllm_config.model_config.is_deepseek_mla or prefill_tp_size < self.tp_size:
             tp_num_need_pulls = 1
         else:
             num_d_block_heads = max(1, self.num_key_value_heads // self.tp_size)
@@ -2918,6 +3124,16 @@ class MooncakeConnectorWorker:
 
         # Divide the ports according to the TP within the PP
         sampled_nums = []
+        if prefill_tp_size < self._decode_tp_size:
+            assert self._decode_tp_size % prefill_tp_size == 0, (
+                f"Decode TP size {self._decode_tp_size} is not divisible by Prefill TP size {prefill_tp_size}."
+            )
+            split_ratio = self._decode_tp_size // prefill_tp_size
+            for decode_tp_rank in range(self._decode_tp_size):
+                prefill_tp_rank = decode_tp_rank // split_ratio
+                sampled_nums.append([prefill_tp_rank + pp * prefill_tp_size for pp in range(self._prefill_pp_size)])
+            return sampled_nums
+
         if prefill_tp_size == self._decode_tp_size:
             sampled_nums = list(
                 map(

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -44,6 +44,7 @@ from vllm.distributed.utils import get_pp_indices
 from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
 from vllm.utils.network_utils import get_ip, make_zmq_path, make_zmq_socket
+from vllm.v1.attention.backends.utils import get_kv_cache_layout
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -68,6 +69,7 @@ from vllm_ascend.distributed.utils import (
     get_decode_context_model_parallel_world_size,
 )
 from vllm_ascend.utils import enable_custom_op
+from vllm_ascend.worker.kv_cache_layout import HND_KV_CACHE_LAYOUT, check_hnd_kv_cache_layout_supported
 
 # isort: off
 if TYPE_CHECKING:
@@ -96,6 +98,7 @@ class MooncakeAgentMetadata(msgspec.Struct, omit_defaults=True, dict=True):
     num_blocks: int
     block_lens: list[list[int]]
     block_strides: list[list[int]]
+    kv_cache_layout: str = "NHD"
     local_ip: str = ""
 
 
@@ -449,7 +452,9 @@ class KVCacheRecvingThread(threading.Thread):
             self.group_compress_ratios[group_id] = compress_ratio
         self.remote_te_port: dict[str, dict[int, int]] = SizedDict()
         self.remote_block_size_scale: dict[str, dict[int, list[list[int]]]] = SizedDict()
+        self.remote_block_len_per_addr: dict[str, dict[int, list[list[int]]]] = SizedDict()
         self.remote_block_stride_per_addr: dict[str, dict[int, list[list[int]]]] = SizedDict()
+        self.remote_kv_cache_layout: dict[str, dict[int, str]] = SizedDict()
         self.remote_kv_group2layeridx: dict[str, dict[int, dict[int, tuple[dict[str, Any], list[int]]]]] = SizedDict()
 
         self.request_queue: queue.Queue[Any] = queue.Queue()
@@ -479,12 +484,17 @@ class KVCacheRecvingThread(threading.Thread):
         self.use_mla = self.model_config.is_deepseek_mla
         self.is_hma_required = is_hma_required
         self.block_size = self.vllm_config.cache_config.block_size
+        self.kv_cache_layout = get_kv_cache_layout()
+        self.use_hnd_transfer = self.kv_cache_layout == HND_KV_CACHE_LAYOUT
+        if self.use_hnd_transfer:
+            check_hnd_kv_cache_layout_supported(self.kv_cache_layout)
         try:
             hf_text_config = self.model_config.hf_text_config
             if hf_text_config is None:
                 raise AttributeError
         except AttributeError:
             hf_text_config = self.model_config.hf_config
+        self.use_sparse = hasattr(hf_text_config, "index_topk")
         self.num_layers = hf_text_config.num_hidden_layers
         if block_size_scale is None:
             block_size_scale = []
@@ -636,8 +646,211 @@ class KVCacheRecvingThread(threading.Thread):
                     self._send_done_recv_signal(request_id, remote_host_, remote_port, remote_port_send_num)
             self.proc_not_transfer_request[request_id] = False
 
+    def _get_prefill_pp_layer_indices(self, layer_indices: list[int], prefill_pp_rank: int) -> list[int]:
+        first_layer_index, end_layer_index = self.pp_layer_indices[prefill_pp_rank]
+        if self.vllm_config.speculative_config is not None and prefill_pp_rank == self._prefill_pp_size - 1:
+            end_layer_index += self.num_draft_layers
+        return [layer_idx for layer_idx in layer_indices if first_layer_index <= layer_idx < end_layer_index]
+
+    def _append_hnd_attention_transfer_meta(
+        self,
+        src_list: list[int],
+        dst_list: list[int],
+        length_list: list[int],
+        *,
+        local_layer_base_addr: int,
+        remote_layer_base_addr: int,
+        local_block_stride: int,
+        remote_block_stride: int,
+        local_kv_block_len: int,
+        remote_kv_block_len: int,
+        grouped_remote_block_ids: list[list[int]],
+        grouped_local_block_ids: list[list[int]],
+        tp_num_need_pulls: int,
+        remote_tp_offset: int,
+    ) -> None:
+        if self.use_mla or self.use_sparse or tp_num_need_pulls == 1:
+            if local_kv_block_len != remote_kv_block_len:
+                raise RuntimeError(
+                    "Mooncake HND transfer expects equal KV block lengths for replicated or homogeneous TP "
+                    f"caches, got local={local_kv_block_len}, remote={remote_kv_block_len}."
+                )
+            local_region_offset = 0
+            remote_region_offset = 0
+            transfer_len = local_kv_block_len
+        else:
+            if local_kv_block_len != remote_kv_block_len * tp_num_need_pulls:
+                raise RuntimeError(
+                    "Mooncake HND transfer expects Decode KV block length to cover all Prefill TP shards, "
+                    f"got local={local_kv_block_len}, remote={remote_kv_block_len}, pulls={tp_num_need_pulls}."
+                )
+            local_region_offset = remote_tp_offset * remote_kv_block_len
+            remote_region_offset = 0
+            transfer_len = remote_kv_block_len
+
+        can_coalesce = (
+            local_region_offset == 0
+            and remote_region_offset == 0
+            and transfer_len == local_block_stride
+            and transfer_len == remote_block_stride
+        )
+        for remote_block_id, local_block_id in zip(grouped_remote_block_ids, grouped_local_block_ids):
+            if can_coalesce:
+                src = local_layer_base_addr + local_block_id[0] * local_block_stride
+                dst = remote_layer_base_addr + remote_block_id[0] * remote_block_stride
+                src_list.append(src)
+                dst_list.append(dst)
+                length_list.append(transfer_len * len(local_block_id))
+                continue
+
+            for remote_block, local_block in zip(remote_block_id, local_block_id):
+                src = local_layer_base_addr + local_block * local_block_stride + local_region_offset
+                dst = remote_layer_base_addr + remote_block * remote_block_stride + remote_region_offset
+                src_list.append(src)
+                dst_list.append(dst)
+                length_list.append(transfer_len)
+
+    def _transfer_hnd_kv_cache_all_groups(self, req_meta: dict[str, Any]):
+        """Transfer HND KV cache shards directly to their final head interval."""
+        remote_request_id = req_meta["remote_request_id"]
+        local_block_ids: BlockIds = req_meta["local_block_ids"]
+        remote_block_ids: BlockIds = req_meta["remote_block_ids"]
+        group_pulls: list[GroupPull] = req_meta["group_pulls"]
+        remote_engine_id = req_meta["remote_engine_id"]
+        remote_host = req_meta["remote_host"]
+        remote_handshake_port = req_meta["remote_handshake_port"]
+
+        num_local_blocks = sum(len(group_block_ids) for group_block_ids in local_block_ids)
+        if num_local_blocks == 0:
+            return
+
+        if (
+            remote_engine_id not in self.kv_caches_base_addr
+            or remote_handshake_port not in self.kv_caches_base_addr[remote_engine_id]
+        ):
+            self._get_remote_metadata(remote_host, remote_handshake_port)
+
+        remote_kv_caches_base_addrs = self.kv_caches_base_addr[remote_engine_id][remote_handshake_port]
+        local_kv_caches_base_addrs = self.kv_caches_base_addr[self.local_engine_id][self.local_handshake_port]
+        remote_transfer_port = self.remote_te_port[remote_engine_id][remote_handshake_port]
+        remote_block_size_scale = self.remote_block_size_scale[remote_engine_id][remote_handshake_port]
+        remote_block_len_per_addr = self.remote_block_len_per_addr[remote_engine_id][remote_handshake_port]
+        remote_block_stride_per_addr = self.remote_block_stride_per_addr[remote_engine_id][remote_handshake_port]
+        session_id = f"{remote_host}:{remote_transfer_port}"
+
+        req_start_time = time.perf_counter()
+        src_list: list[int] = []
+        dst_list: list[int] = []
+        length_list: list[int] = []
+
+        def expand_block_ids(block_ids, scale):
+            return [bid * scale + offset for bid in block_ids for offset in range(scale)]
+
+        for group_pull in group_pulls:
+            group_idx = group_pull.group_id
+            group_spec, layer_indices = self.kv_group2layeridx[group_idx]
+            layer_indices = self._get_prefill_pp_layer_indices(layer_indices, group_pull.prefill_pp_rank)
+            if not layer_indices:
+                continue
+
+            tp_num_need_pulls = group_pull.num_group_pulls
+            remote_tp_offset = group_pull.remote_tp_offset
+            local_group_block_ids = local_block_ids[group_idx]
+            remote_group_block_ids = remote_block_ids[group_idx]
+            if not local_group_block_ids:
+                continue
+
+            is_mamba_group = group_spec["kv_cache_spec_type"] == "MambaSpec"
+            if is_mamba_group:
+                transfer_block_idx = len(remote_group_block_ids) - self.num_speculative_tokens - 1
+                grouped_remote_block_ids = [[remote_group_block_ids[transfer_block_idx]]]
+                grouped_local_block_ids = [[local_group_block_ids[0]]]
+            else:
+                local_scale = self.block_size_scale[layer_indices[0]][0]
+                remote_scale = remote_block_size_scale[layer_indices[0]][0]
+                kernel_local_block_ids = expand_block_ids(local_group_block_ids, local_scale)
+                kernel_remote_block_ids = expand_block_ids(remote_group_block_ids, remote_scale)
+                num_computed_tokens = req_meta.get("num_computed_tokens", 0)
+                remote_kernel_block_size = self.block_size // remote_scale
+                remote_kernel_token_size = remote_kernel_block_size * self.group_compress_ratios[group_idx]
+                remote_start_idx = num_computed_tokens // remote_kernel_token_size
+                kernel_remote_block_ids = kernel_remote_block_ids[remote_start_idx:]
+                num_kernel_blocks = min(len(kernel_remote_block_ids), len(kernel_local_block_ids))
+                kernel_remote_block_ids = kernel_remote_block_ids[:num_kernel_blocks]
+                kernel_local_block_ids = kernel_local_block_ids[:num_kernel_blocks]
+
+                if tp_num_need_pulls == 1:
+                    grouped_remote_block_ids, grouped_local_block_ids = group_concurrent_contiguous(
+                        kernel_remote_block_ids, kernel_local_block_ids
+                    )
+                else:
+                    grouped_remote_block_ids = [[block_id] for block_id in kernel_remote_block_ids]
+                    grouped_local_block_ids = [[block_id] for block_id in kernel_local_block_ids]
+
+            for layer_idx in layer_indices:
+                if is_mamba_group:
+                    self._append_mamba_transfer_meta(
+                        src_list,
+                        dst_list,
+                        length_list,
+                        group_spec=group_spec,
+                        src_layer_base_addr=local_kv_caches_base_addrs[layer_idx],
+                        dst_layer_base_addr=remote_kv_caches_base_addrs[layer_idx],
+                        block_len=self.block_len_per_addr[layer_idx],
+                        block_stride=self.block_stride_per_addr[layer_idx],
+                        remote_block_stride=remote_block_stride_per_addr[layer_idx],
+                        remote_block_id=grouped_remote_block_ids[0][0],
+                        local_block_id=grouped_local_block_ids[0][0],
+                        tp_num_need_pulls=tp_num_need_pulls,
+                        remote_tp_offset=remote_tp_offset,
+                    )
+                    continue
+
+                for cache_idx in range(len(local_kv_caches_base_addrs[layer_idx])):
+                    self._append_hnd_attention_transfer_meta(
+                        src_list,
+                        dst_list,
+                        length_list,
+                        local_layer_base_addr=local_kv_caches_base_addrs[layer_idx][cache_idx],
+                        remote_layer_base_addr=remote_kv_caches_base_addrs[layer_idx][cache_idx],
+                        local_block_stride=self.block_stride_per_addr[layer_idx][cache_idx],
+                        remote_block_stride=remote_block_stride_per_addr[layer_idx][cache_idx],
+                        local_kv_block_len=self.block_len_per_addr[layer_idx][cache_idx],
+                        remote_kv_block_len=remote_block_len_per_addr[layer_idx][cache_idx],
+                        grouped_remote_block_ids=grouped_remote_block_ids,
+                        grouped_local_block_ids=grouped_local_block_ids,
+                        tp_num_need_pulls=tp_num_need_pulls,
+                        remote_tp_offset=remote_tp_offset,
+                    )
+
+        if not src_list:
+            return
+
+        ret = self.engine.batch_transfer_sync_read(session_id, src_list, dst_list, length_list)
+        if ret < 0:
+            logger.error(
+                "Mooncake HND transfer failed for request. remote_request_id=%s, ret=%d. ",
+                req_meta["remote_request_id"],
+                ret,
+            )
+            raise RuntimeError(f"Mooncake HND transfer failed, ret: {ret}")
+
+        req_transfer_elapsed = (time.perf_counter() - req_start_time) * 1000
+        logger.info(
+            "HND KV cache transfer for request %s took %.2f ms. local_ip %s local_device_id %s remote_session_id %s",
+            remote_request_id,
+            req_transfer_elapsed,
+            get_ip(),
+            self.tp_rank,
+            session_id,
+        )
+
     def _transfer_kv_cache_all_groups(self, req_meta: dict[str, Any]):
         """Handle a KV cache transfer request."""
+        if self.use_hnd_transfer:
+            self._transfer_hnd_kv_cache_all_groups(req_meta)
+            return
+
         remote_request_id = req_meta["remote_request_id"]
         local_block_ids: BlockIds = req_meta["local_block_ids"]
         remote_block_ids: BlockIds = req_meta["remote_block_ids"]
@@ -674,16 +887,10 @@ class KVCacheRecvingThread(threading.Thread):
         def expand_block_ids(block_ids, scale):
             return [bid * scale + offset for bid in block_ids for offset in range(scale)]
 
-        def pp_layer_indices(layer_indices: list[int], prefill_pp_rank: int) -> list[int]:
-            first_layer_index, end_layer_index = self.pp_layer_indices[prefill_pp_rank]
-            if self.vllm_config.speculative_config is not None and prefill_pp_rank == self._prefill_pp_size - 1:
-                end_layer_index += self.num_draft_layers
-            return [layer_idx for layer_idx in layer_indices if first_layer_index <= layer_idx < end_layer_index]
-
         for group_pull in group_pulls:
             group_idx = group_pull.group_id
             group_spec, layer_indices = self.kv_group2layeridx[group_idx]
-            layer_indices = pp_layer_indices(layer_indices, group_pull.prefill_pp_rank)
+            layer_indices = self._get_prefill_pp_layer_indices(layer_indices, group_pull.prefill_pp_rank)
             if not layer_indices:
                 continue
             tp_num_need_pulls = group_pull.num_group_pulls
@@ -1195,7 +1402,14 @@ class KVCacheRecvingThread(threading.Thread):
             self.kv_caches_base_addr[engine_id][remote_handshake_port] = agent_meta.kv_caches_base_addr
             self.remote_te_port[engine_id][remote_handshake_port] = agent_meta.te_rpc_port
             self.remote_block_size_scale[engine_id][remote_handshake_port] = agent_meta.block_size_scale
+            self.remote_block_len_per_addr[engine_id][remote_handshake_port] = agent_meta.block_lens
             self.remote_block_stride_per_addr[engine_id][remote_handshake_port] = agent_meta.block_strides
+            self.remote_kv_cache_layout[engine_id][remote_handshake_port] = agent_meta.kv_cache_layout
+            if self.use_hnd_transfer and agent_meta.kv_cache_layout != HND_KV_CACHE_LAYOUT:
+                raise RuntimeError(
+                    "Mooncake HND KV transfer requires HND layout on both Prefill and Decode, "
+                    f"but remote layout is {agent_meta.kv_cache_layout}."
+                )
         finally:
             if sock is not None:
                 self._return_remote_socket(sock, remote_host, remote_handshake_port)
@@ -1316,6 +1530,16 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
         elif role == KVConnectorRole.WORKER:
             self.connector_scheduler = None
             self.connector_worker = MooncakeConnectorWorker(vllm_config, str(self.engine_id), kv_cache_config)
+
+    @classmethod
+    def get_required_kvcache_layout(cls, vllm_config: VllmConfig) -> str | None:
+        if get_kv_cache_layout() != HND_KV_CACHE_LAYOUT:
+            return None
+        if vllm_config.model_config is None or vllm_config.model_config.use_mla:
+            return None
+        check_hnd_kv_cache_layout_supported(HND_KV_CACHE_LAYOUT)
+        logger.info("Mooncake connector setting KV cache layout to HND.")
+        return HND_KV_CACHE_LAYOUT
 
     ############################################################
     # Scheduler Side Methods
@@ -1754,6 +1978,10 @@ class MooncakeConnectorWorker:
         self.max_device_id = self.tp_size * self.dp_size * self.pcp_size * self.pp_size
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         self.num_key_value_heads = self.vllm_config.model_config.hf_text_config.num_key_value_heads
+        self.kv_cache_layout = get_kv_cache_layout()
+        self.use_hnd_transfer = self.kv_cache_layout == HND_KV_CACHE_LAYOUT
+        if self.use_hnd_transfer:
+            check_hnd_kv_cache_layout_supported(self.kv_cache_layout)
 
         # kv cache config
         self.kv_cache_config = kv_cache_config
@@ -2055,6 +2283,7 @@ class MooncakeConnectorWorker:
             num_blocks=self.num_blocks,
             block_lens=self.block_len_per_addr,
             block_strides=self.block_stride_per_addr,
+            kv_cache_layout=self.kv_cache_layout,
             local_ip=get_ip(),
         )
         self.xfer_handshake_metadata = metadata

--- a/vllm_ascend/worker/kv_cache_layout.py
+++ b/vllm_ascend/worker/kv_cache_layout.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any
+
+import torch
+
+
+def get_kv_cache_stride_order(
+    attn_backend: Any,
+    kv_cache_shape: tuple[int, ...],
+) -> tuple[int, ...]:
+    try:
+        stride_order = attn_backend.get_kv_cache_stride_order()
+        assert len(stride_order) == len(kv_cache_shape)
+    except (AttributeError, NotImplementedError):
+        stride_order = tuple(range(len(kv_cache_shape)))
+    return stride_order
+
+
+def view_kv_cache_with_stride_order(
+    raw_tensor: torch.Tensor,
+    dtype: torch.dtype,
+    logical_shape: tuple[int, ...],
+    stride_order: tuple[int, ...],
+) -> torch.Tensor:
+    storage_shape = tuple(logical_shape[i] for i in stride_order)
+    inv_order = [stride_order.index(i) for i in range(len(stride_order))]
+    return raw_tensor.view(dtype).view(storage_shape).permute(*inv_order)
+
+
+def view_split_kv_cache_with_stride_order(
+    raw_tensor: torch.Tensor,
+    dtype: torch.dtype,
+    full_kv_cache_shape: tuple[int, ...],
+    side_logical_shape: tuple[int, ...],
+    attn_backend: Any,
+) -> torch.Tensor:
+    full_stride_order = get_kv_cache_stride_order(attn_backend, full_kv_cache_shape)
+    if len(full_stride_order) == len(side_logical_shape) + 1 and 0 in full_stride_order:
+        side_stride_order = tuple(dim - 1 for dim in full_stride_order if dim != 0)
+    else:
+        side_stride_order = tuple(range(len(side_logical_shape)))
+    return view_kv_cache_with_stride_order(
+        raw_tensor,
+        dtype,
+        side_logical_shape,
+        side_stride_order,
+    )

--- a/vllm_ascend/worker/kv_cache_layout.py
+++ b/vllm_ascend/worker/kv_cache_layout.py
@@ -4,12 +4,25 @@
 from typing import Any
 
 import torch
+from vllm.v1.attention.backends.utils import get_kv_cache_layout
+
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
+HND_KV_CACHE_LAYOUT = "HND"
+
+
+def check_hnd_kv_cache_layout_supported(cache_layout: str | None = None) -> None:
+    if cache_layout is None:
+        cache_layout = get_kv_cache_layout()
+    if cache_layout == HND_KV_CACHE_LAYOUT and get_ascend_device_type() != AscendDeviceType.A5:
+        raise RuntimeError("HND KV cache layout is only supported on Ascend A5.")
 
 
 def get_kv_cache_stride_order(
     attn_backend: Any,
     kv_cache_shape: tuple[int, ...],
 ) -> tuple[int, ...]:
+    check_hnd_kv_cache_layout_supported()
     try:
         stride_order = attn_backend.get_kv_cache_stride_order()
         assert len(stride_order) == len(kv_cache_shape)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -156,6 +156,9 @@ from vllm_ascend.utils import (
     set_weight_prefetch_method,
     should_skip_allreduce_across_dp_group,
 )
+from vllm_ascend.worker.kv_cache_layout import (
+    view_split_kv_cache_with_stride_order,
+)
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 from vllm_ascend.worker.pcp_utils import PCPManager
 from vllm_ascend.worker.utils import AscendKVBlockZeroer
@@ -4378,11 +4381,24 @@ class NPUModelRunner(GPUModelRunner):
                     if self.use_sparse and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
                         k_cache_dtype = self.c8_k_cache_dtype
                     
-                    k_cache = raw_k_tensor.view(k_cache_dtype).view(k_shape)
+                    k_cache = view_split_kv_cache_with_stride_order(
+                        raw_k_tensor,
+                        k_cache_dtype,
+                        kv_cache_shape,
+                        k_shape,
+                        attn_backend,
+                    )
+                    
                     if self.use_sparse and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
                         v_cache = None
                     else:
-                        v_cache = raw_v_tensor.view(v_cache_dtype).view(v_shape)
+                        v_cache = view_split_kv_cache_with_stride_order(
+                        raw_v_tensor,
+                        v_cache_dtype,
+                        kv_cache_shape,
+                        v_shape,
+                        attn_backend,
+                        )
 
                     if self.use_sparse:
                         dsa_k_cache_shape = (


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds HND KV cache layout support for Ascend attention and heter KV cache transfer, with hardware isolation for unsupported devices.

Main changes:
- Add HND KV cache stride order handling in the Ascend attention backend.
- Add split K/V cache view logic for HND physical layout.
- Support HND physical KV cache handling when preparing fused infer attention parameters.
- Register `MooncakeHeterHndConnector` for heter KV cache transfer.
- Use HND layout for non-MLA heter Mooncake KV transfer so head-wise KV shards can be transferred directly.
- Add an A5-only guard for HND KV cache layout, including the HND heter connector path.
- Add unit tests for HND layout acceptance on A5 and rejection on non-A5 devices.

HND KV cache layout is currently only supported on Ascend A5. This PR makes the heter KV transfer path request HND layout where needed and fail fast on unsupported devices.

Fixes #N/A

### Does this PR introduce _any_ user-facing change?

Yes.

A new heter KV transfer connector, `MooncakeHeterHndConnector`, is registered for HND-based heter KV cache transfer. Users can use HND KV cache layout for supported A5 heter transfer scenarios.

If HND KV cache layout is requested on non-A5 devices, vLLM Ascend now raises a clear runtime error.

### How was this patch tested?

Added unit tests covering:
- HND KV cache layout rejected on non-A5 devices.
- HND KV cache layout allowed on A5 devices.
- HND split KV cache view uses the expected stride order.

Local syntax check was performed with:

```bash
python -m py_compile \
  vllm_ascend/attention/attention_v1.py \
  vllm_ascend/worker/kv_cache_layout.py \
  vllm_ascend/distributed/kv_transfer/__init__.py \
  vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_heter_hnd_connector.py \
  tests/ut/attention/a2/test_attention_v1.py \
  tests/ut/worker/test_kv_cache_layout.py

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
