### PR TITLE
[Perf][Worker] Defer DSV4 compressor metadata until state correction

### DIFF
--- a/tests/ut/worker/test_dsv4_compressed_positions.py
+++ b/tests/ut/worker/test_dsv4_compressed_positions.py
@@ -1,8 +1,11 @@
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
 
 from vllm_ascend.utils import get_compressed_pos_and_indices
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _kv_cache_group(compress_ratio: int):
@@ -34,3 +37,16 @@ def test_compressed_positions_depend_on_corrected_num_computed_tokens():
     np.testing.assert_array_equal(corrected_positions[0], np.array([0]))
     np.testing.assert_array_equal(corrected_req_indices[0], np.array([0]))
     np.testing.assert_array_equal(corrected_lengths[0], np.array([1]))
+
+
+def test_model_runner_builds_compressed_positions_after_prepare_inputs():
+    model_runner = (REPO_ROOT / "vllm_ascend/worker/model_runner_v1.py").read_text()
+    prepare_inputs = model_runner.split("    def _prepare_inputs(", 1)[1].split(
+        "    def _rebuild_input_ids_with_corrected_positions(", 1
+    )[0]
+
+    # The compressed helper needs corrected async-spec CPU counters. Keep it
+    # out of _prepare_inputs so that path does not force an early NPU wait.
+    assert "get_compressed_pos_and_indices" not in prepare_inputs
+    assert "deferred async-spec corrections" in model_runner
+    assert "get_compressed_pos_and_indices" in model_runner

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -746,7 +746,7 @@ class NPUModelRunner(GPUModelRunner):
         self,
         scheduler_output: "SchedulerOutput",
         num_scheduled_tokens: np.ndarray,
-    ) -> tuple[torch.Tensor, SpecDecodeMetadata | None, int, list[np.ndarray[Any, Any]]]:
+    ) -> tuple[torch.Tensor, SpecDecodeMetadata | None, int]:
         """
         :return: tuple[
             logits_indices,
@@ -1214,49 +1214,15 @@ class NPUModelRunner(GPUModelRunner):
         else:
             self._seq_lens_cpu_event_pending = False
 
-        num_computed_tokens_for_compress = (
-            self.input_batch.num_computed_tokens_cpu[:num_reqs]
-        )
-        if (
-            self.use_compress
-            and self.use_async_spec_decode
-            and self.valid_sampled_token_count_gpu is not None # type: ignore[has-type]
-            and prev_req_id_to_index
-        ):
-            # Async spec decode keeps the CPU counter optimistic until after
-            # target forward is launched. DSV4 compressed KV slot mapping is
-            # CPU-built today, so use the GPU-corrected counter before
-            # computing compressed cache positions.
-            if (
-                self._seq_lens_cpu_event_pending
-                and self._seq_lens_cpu_event is not None
-            ):
-                self._seq_lens_cpu_event.synchronize()
-                self._seq_lens_cpu_event_pending = False
-                num_computed_tokens_for_compress = (
-                    self.optimistic_seq_lens_cpu[:num_reqs].numpy()
-                    - num_scheduled_tokens[:num_reqs]
-                )
-            else:
-                num_computed_tokens_for_compress = (
-                    self.num_computed_tokens[:num_reqs].to("cpu").numpy()
-                )
-
-        (positions_compressed_list, req_indices_compressed_list,
-         num_scheduled_tokens_compressed_list) = get_compressed_pos_and_indices(
-            num_computed_tokens_for_compress,
-            num_scheduled_tokens[:num_reqs], self.arange_np[:num_reqs],
-            self.use_compress,
-            self.kv_cache_config.kv_cache_groups)
         # For non-PCP, compute slot_mapping on GPU. PCP slot_mapping was
-        # already computed on GPU before PCP split the positions.
-        if self.pcp_size <= 1:
+        # already computed on GPU before PCP split the positions. Compressed
+        # slot mapping is built later after deferred async-spec state
+        # corrections update the CPU counters used by the existing DSV4 helper.
+        if self.pcp_size <= 1 and not self.use_compress:
             self.input_batch.block_table.compute_slot_mapping(
                 num_reqs,
                 self.query_start_loc.gpu[: num_reqs + 1],
                 self.positions[:total_num_scheduled_tokens],
-                positions_compressed_list,
-                req_indices_compressed_list,
             )
 
         if self.use_async_spec_decode and (self.uses_mrope or self.uses_xdrope_dim > 0):
@@ -1344,7 +1310,6 @@ class NPUModelRunner(GPUModelRunner):
             logits_indices,
             spec_decode_metadata,
             total_num_scheduled_tokens,
-            num_scheduled_tokens_compressed_list
         )
 
     def _rebuild_input_ids_with_corrected_positions(
@@ -2024,11 +1989,11 @@ class NPUModelRunner(GPUModelRunner):
                     logits_indices,
                     spec_decode_metadata,
                     total_num_scheduled_tokens,
-                    num_scheduled_tokens_compressed_list,
                 ) = self._prepare_inputs(
                     scheduler_output,
                     num_scheduled_tokens_np,
                 )
+                num_scheduled_tokens_compressed_list = None
 
                 num_tokens_unpadded = scheduler_output.total_num_scheduled_tokens
                 if self.pcp_size > 1:
@@ -2134,6 +2099,27 @@ class NPUModelRunner(GPUModelRunner):
                         self.query_pos.np[:total_num_scheduled_tokens],
                         out=dsa_positions_np,
                     )
+                    # Build the existing compact compressor metadata after
+                    # deferred async-spec corrections have updated CPU token
+                    # counts. Doing it here removes the earlier event
+                    # synchronize from _prepare_inputs without changing the
+                    # downstream DSA/compressor contract.
+                    (positions_compressed_list, req_indices_compressed_list,
+                     num_scheduled_tokens_compressed_list) = get_compressed_pos_and_indices(
+                        self.input_batch.num_computed_tokens_cpu[:num_reqs],
+                        num_scheduled_tokens_np[:num_reqs],
+                        self.arange_np[:num_reqs],
+                        self.use_compress,
+                        self.kv_cache_config.kv_cache_groups,
+                    )
+                    if self.pcp_size <= 1:
+                        self.input_batch.block_table.compute_slot_mapping(
+                            num_reqs,
+                            self.query_start_loc.gpu[: num_reqs + 1],
+                            self.positions[:total_num_scheduled_tokens],
+                            positions_compressed_list,
+                            req_indices_compressed_list,
+                        )
 
                 use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
                 ubatch_slices_attn = ubatch_slices_padded if pad_attn else ubatch_slices


### PR DESCRIPTION
### What this PR does / why we need it?

This is candidate A for removing the DSV4 compressor sync from the model runner hot path.

It keeps the existing CPU `get_compressed_pos_and_indices()` helper and the downstream DSA/compressor metadata contract unchanged, but moves compressed-position and compressed slot-mapping construction out of `_prepare_inputs()`. The metadata is now built in the real request path after `deferred_state_corrections_fn()` refreshes CPU token counts, so async-spec decode no longer needs the early NPU event wait solely for compressor metadata.

### Does this PR introduce _any_ user-facing change?

No. This is an internal scheduling/metadata construction change for DSV4 compressed KV metadata.

### How was this patch tested?

- `PATH=/tmp/vllm-ascend-lint-venv/bin:$PATH bash format.sh ci`
- `python -m py_compile vllm_ascend/worker/model_runner_v1.py tests/ut/worker/test_dsv4_compressed_positions.py`
- `python -m pytest -q tests/ut/worker/test_dsv4_compressed_positions.py` was not run locally because this shell environment does not have `pytest` installed (`No module named pytest`).
- NPU performance validation is intentionally left for remote A/B testing.
- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
