### PR TITLE
[CI]modify euler dependencies which need to install for install vllm-ascend

### DIFF
--- a/.github/workflows/push_build_csrc_cache.yaml
+++ b/.github/workflows/push_build_csrc_cache.yaml
@@ -134,7 +134,7 @@ jobs:
       - name: Install system dependencies (openeuler)
         if: matrix.os == 'openeuler'
         run: |
-          yum install -y gcc gcc-c++ cmake numactl-devel clang
+          yum install -y python3-pip net-tools jemalloc numactl patch clang 
           pip install uv
 
       - name: Get image tag

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -18,27 +18,19 @@
 FROM quay.io/ascend/cann:9.0.0-a3-ubuntu22.04-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG MOONCAKE_TAG=v0.3.9
-
-COPY ./tools/mooncake_installer.sh /vllm-workspace/
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /workspace
 
 # Install clang-15 (for triton-ascend) and Mooncake
+ARG MOONCAKE_TAG=0.3.11.post1
 RUN apt-get update -y && \
-    apt-get install -y git vim wget net-tools gcc g++ cmake numactl libnuma-dev libjemalloc2 clang-15 && \
+    apt-get install -y git vim wget net-tools gcc g++ cmake numactl libnuma-dev libibverbs-dev libjemalloc2 libhiredis-dev clang-15 && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
-    git clone --depth 1 --branch ${MOONCAKE_TAG} https://github.com/kvcache-ai/Mooncake /vllm-workspace/Mooncake && \
-    mv /vllm-workspace/mooncake_installer.sh /vllm-workspace/Mooncake/ && \
-    cd /vllm-workspace/Mooncake && bash mooncake_installer.sh -y && \
-    ARCH=$(uname -m) && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
-    mkdir -p build && cd build && cmake .. -DUSE_ASCEND_DIRECT=ON && \
-    make -j$(nproc) && make install && \
-    rm -fr /vllm-workspace/Mooncake/build && \
+    pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -18,19 +18,27 @@
 FROM quay.io/ascend/cann:9.0.0-a3-ubuntu22.04-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+ARG MOONCAKE_TAG=v0.3.9
+
+COPY ./tools/mooncake_installer.sh /vllm-workspace/
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /workspace
 
 # Install clang-15 (for triton-ascend) and Mooncake
-ARG MOONCAKE_TAG=0.3.11.post1
 RUN apt-get update -y && \
-    apt-get install -y git vim wget net-tools gcc g++ cmake numactl libnuma-dev libibverbs-dev libjemalloc2 libhiredis-dev clang-15 && \
+    apt-get install -y git vim wget net-tools gcc g++ cmake numactl libnuma-dev libjemalloc2 clang-15 && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
+    git clone --depth 1 --branch ${MOONCAKE_TAG} https://github.com/kvcache-ai/Mooncake /vllm-workspace/Mooncake && \
+    mv /vllm-workspace/mooncake_installer.sh /vllm-workspace/Mooncake/ && \
+    cd /vllm-workspace/Mooncake && bash mooncake_installer.sh -y && \
+    ARCH=$(uname -m) && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
-    pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} && \
+    mkdir -p build && cd build && cmake .. -DUSE_ASCEND_DIRECT=ON && \
+    make -j$(nproc) && make install && \
+    rm -fr /vllm-workspace/Mooncake/build && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -18,6 +18,7 @@
 FROM quay.io/ascend/cann:9.0.0-a3-openeuler24.03-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+ARG MOONCAKE_TAG="v0.3.9"
 
 WORKDIR /workspace
 
@@ -26,11 +27,17 @@ COPY ./tools/mooncake_installer.sh /vllm-workspace/
 SHELL ["/bin/bash", "-c"]
 
 # Install clang (for triton-ascend) and Mooncake
-ARG MOONCAKE_TAG=0.3.11.post1
 RUN yum update -y && \
-    yum install -y git vim wget net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang && \
+    yum install -y git vim wget net-tools gcc gcc-c++ make cmake numactl numactl-devel jemalloc clang patch && \
+    git clone --depth 1 --branch ${MOONCAKE_TAG} https://github.com/kvcache-ai/Mooncake /vllm-workspace/Mooncake && \
+    mv /vllm-workspace/mooncake_installer.sh /vllm-workspace/Mooncake/ && \
+    ARCH=$(uname -m) && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
-    pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} && \
+    cd /vllm-workspace/Mooncake && \
+    bash mooncake_installer.sh -y && \
+    mkdir -p build && cd build && cmake .. -DUSE_ASCEND_DIRECT=ON && \
+    make -j$(nproc) && make install && \
+    rm -fr /vllm-workspace/Mooncake/build && \
     rm -rf /var/cache/yum/*
 
 # Install modelscope (for fast download) and ray (for multinode)

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -18,7 +18,6 @@
 FROM quay.io/ascend/cann:9.0.0-a3-openeuler24.03-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG MOONCAKE_TAG="v0.3.9"
 
 WORKDIR /workspace
 
@@ -27,17 +26,11 @@ COPY ./tools/mooncake_installer.sh /vllm-workspace/
 SHELL ["/bin/bash", "-c"]
 
 # Install clang (for triton-ascend) and Mooncake
+ARG MOONCAKE_TAG=0.3.11.post1
 RUN yum update -y && \
-    yum install -y git vim wget net-tools gcc gcc-c++ make cmake numactl numactl-devel jemalloc clang patch && \
-    git clone --depth 1 --branch ${MOONCAKE_TAG} https://github.com/kvcache-ai/Mooncake /vllm-workspace/Mooncake && \
-    mv /vllm-workspace/mooncake_installer.sh /vllm-workspace/Mooncake/ && \
-    ARCH=$(uname -m) && \
+    yum install -y git vim wget net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
-    cd /vllm-workspace/Mooncake && \
-    bash mooncake_installer.sh -y && \
-    mkdir -p build && cd build && cmake .. -DUSE_ASCEND_DIRECT=ON && \
-    make -j$(nproc) && make install && \
-    rm -fr /vllm-workspace/Mooncake/build && \
+    pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} && \
     rm -rf /var/cache/yum/*
 
 # Install modelscope (for fast download) and ray (for multinode)


### PR DESCRIPTION
### What this PR does / why we need it?
https://github.com/vllm-project/vllm-ascend/actions/runs/27943551599/job/82857810618. 
Referring to this error report, the probable cause is incomplete required installation dependencies. The Euler image does not come with `patch` pre-installed, which needs to be added.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
