### PR TITLE
[BugFix][WeightTransfer] Lazy-load weight transfer engines to avoid eager ray import

### DIFF
--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -410,6 +410,29 @@
 #    Future Plan:
 #       Remove this patch when upstream vLLM relaxes the Literal type to str or
 #       provides an extension point for out-of-tree weight transfer backends.
+#   2. `vllm.distributed.weight_transfer.factory.WeightTransferEngineFactory._registry["ipc"]`
+#    Why:
+#       The "ipc" backend must resolve to NPUIPCWeightTransferEngine on Ascend NPU.
+#       However, this patch runs during global plugin patching - extremely early in
+#       startup, before any weight transfer backend is selected. Importing the IPC
+#       engine eagerly pulls in vllm.distributed.weight_transfer.ipc_engine, which
+#       does `import ray` at module top level. Since ray is an optional dependency,
+#       its absence aborts the whole vllm_ascend plugin load and crashes every
+#       `vllm serve` invocation - even workloads that never use weight transfer.
+#    How：
+#       Register a lazy loader function (instead of an eager import) that imports
+#       and returns NPUIPCWeightTransferEngine only when create_engine() is invoked
+#       for the "ipc" backend. This matches the factory's zero-arg-callable
+#       lazy-loading contract, so the ray-importing module is loaded only when ipc
+#       is actually requested. (HCCL keeps its eager import - it never imports ray.)
+#    Related PR (if no, explain why):
+#       No.  The eager `import ray` lives in upstream vLLM's ipc_engine module; the
+#       lazy loader is a local workaround until upstream defers that import.
+#    Future Plan:
+#       Remove this workaround once upstream vLLM stops importing ray at module top
+#       level in vllm.distributed.weight_transfer.ipc_engine (e.g. defers it into
+#       the code path that actually needs ray), so importing the IPC engine no
+#       longer requires the optional ray dependency.
 #
 # ** 15. File: platform/patch_kv_cache_coordinator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/platform/patch_weight_transfer_engine.py
+++ b/vllm_ascend/patch/platform/patch_weight_transfer_engine.py
@@ -53,16 +53,12 @@ from typing import TYPE_CHECKING
 
 from vllm.distributed.weight_transfer.factory import WeightTransferEngineFactory
 
+from vllm_ascend.distributed.weight_transfer.hccl_engine import (
+    HCCLWeightTransferEngine,
+)
+
 if TYPE_CHECKING:
     from vllm.distributed.weight_transfer.base import WeightTransferEngine
-
-
-def _load_hccl_engine() -> "type[WeightTransferEngine]":
-    from vllm_ascend.distributed.weight_transfer.hccl_engine import (
-        HCCLWeightTransferEngine,
-    )
-
-    return HCCLWeightTransferEngine
 
 
 def _load_npu_ipc_engine() -> "type[WeightTransferEngine]":
@@ -73,5 +69,5 @@ def _load_npu_ipc_engine() -> "type[WeightTransferEngine]":
     return NPUIPCWeightTransferEngine
 
 
-WeightTransferEngineFactory._registry["nccl"] = _load_hccl_engine
+WeightTransferEngineFactory._registry["nccl"] = lambda: HCCLWeightTransferEngine
 WeightTransferEngineFactory._registry["ipc"] = _load_npu_ipc_engine

--- a/vllm_ascend/patch/platform/patch_weight_transfer_engine.py
+++ b/vllm_ascend/patch/platform/patch_weight_transfer_engine.py
@@ -49,14 +49,29 @@
 #   Remove this patch when upstream vllm relaxes the Literal type to str
 #   or provides an extension point for out-of-tree backends.
 
+from typing import TYPE_CHECKING
+
 from vllm.distributed.weight_transfer.factory import WeightTransferEngineFactory
 
-from vllm_ascend.distributed.weight_transfer.hccl_engine import (
-    HCCLWeightTransferEngine,
-)
-from vllm_ascend.distributed.weight_transfer.npu_ipc_engine import (
-    NPUIPCWeightTransferEngine,
-)
+if TYPE_CHECKING:
+    from vllm.distributed.weight_transfer.base import WeightTransferEngine
 
-WeightTransferEngineFactory._registry["nccl"] = lambda: HCCLWeightTransferEngine
-WeightTransferEngineFactory._registry["ipc"] = lambda: NPUIPCWeightTransferEngine
+
+def _load_hccl_engine() -> "type[WeightTransferEngine]":
+    from vllm_ascend.distributed.weight_transfer.hccl_engine import (
+        HCCLWeightTransferEngine,
+    )
+
+    return HCCLWeightTransferEngine
+
+
+def _load_npu_ipc_engine() -> "type[WeightTransferEngine]":
+    from vllm_ascend.distributed.weight_transfer.npu_ipc_engine import (
+        NPUIPCWeightTransferEngine,
+    )
+
+    return NPUIPCWeightTransferEngine
+
+
+WeightTransferEngineFactory._registry["nccl"] = _load_hccl_engine
+WeightTransferEngineFactory._registry["ipc"] = _load_npu_ipc_engine


### PR DESCRIPTION
### What this PR does / why we need it?

PR vllm-project#10592 (`[Feature] WeightTransfer: Add NPUIPCWeightTransferEngine backend for Ascend NPU`) passed all gates but broke the smoke test with:

```
ModuleNotFoundError: No module named 'ray'
```

**Root cause**

`vllm_ascend/patch/platform/patch_weight_transfer_engine.py` runs during *global plugin patching* — extremely early in startup, triggered even by `AsyncEngineArgs.add_cli_args(parser)` → `load_general_plugins()`. This happens long before any weight-transfer backend is selected.

The patch eagerly imported the engine classes at module top level:

```python
from vllm_ascend.distributed.weight_transfer.npu_ipc_engine import (
    NPUIPCWeightTransferEngine,
)
```

`npu_ipc_engine` transitively imports `vllm.distributed.weight_transfer.ipc_engine`, which does `import ray` at module top level. `ray` is an optional dependency, so when it is not installed the entire `vllm_ascend` plugin load aborts and **every** `vllm serve` invocation crashes — even workloads that never use weight transfer.

Import chain that crashed:

```
vllm_ascend/__init__.py:_ensure_global_patch()
  → utils.py:adapt_patch(is_global_patch=True)
    → patch/platform/__init__.py
      → patch_weight_transfer_engine.py
        → distributed/weight_transfer/npu_ipc_engine.py
          → vllm/distributed/weight_transfer/ipc_engine.py
            → import ray   # ModuleNotFoundError
```

**Fix**

Replace the eager top-level imports with lazy loader functions. `WeightTransferEngineFactory._registry[backend]` is a zero-arg callable that returns the engine class and is only invoked from `create_engine()` when the backend is actually requested. Deferring the import into those callables matches the factory's existing lazy-loading contract, so the `ray`-importing module is only loaded when the `ipc` backend is selected (at which point ray is genuinely needed):

```python
def _load_npu_ipc_engine() -> "type[WeightTransferEngine]":
    from vllm_ascend.distributed.weight_transfer.npu_ipc_engine import (
        NPUIPCWeightTransferEngine,
    )
    return NPUIPCWeightTransferEngine

WeightTransferEngineFactory._registry["ipc"] = _load_npu_ipc_engine
```

Only the `ipc` registration is made lazy, since the IPC engine is the one that transitively imports `ray`. The `nccl` → HCCL registration keeps its eager import, as `hccl_engine` has no optional-dependency import problem.

### Does this PR introduce _any_ user-facing change?

No. The `nccl`/`ipc` backend resolution behaves identically; only the timing of the underlying module import changes (deferred until the backend is actually used).

### How was this patch tested?

- `python -m py_compile` and `ruff check` / `ruff format --check` pass on the changed file.
- The fix removes the only eager import of the IPC engine on the global-patch path, so plugin loading no longer requires `ray`. The other registration site (`distributed/weight_transfer/__init__.py:register_engine`) already uses lazy string-based registration and was unaffected.

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
