### PR TITLE
[BugFix][v0.20.2rc] Avoid streaming partial MiniMax parameter tags

### DIFF
--- a/tests/ut/patch/platform/test_patch_minimax_m2_tool_call_parser.py
+++ b/tests/ut/patch/platform/test_patch_minimax_m2_tool_call_parser.py
@@ -119,11 +119,11 @@ def test_streaming_emits_tool_name_before_argument_fragments():
     assert _collect_content(results) == "Let me check. "
     assert tool_deltas[0].function.name == "get_weather"
     assert tool_deltas[0].function.arguments is None
-    assert argument_fragments == ['{"city":"Sea', 'ttle"', "}"]
+    assert argument_fragments == ['{"city":"Seattle"', "}"]
     assert "".join(argument_fragments) == '{"city":"Seattle"}'
 
 
-def test_streaming_partial_arguments_before_invoke_closes():
+def test_streaming_waits_for_parameter_close_before_arguments():
     parser = MinimaxM2ToolParser(FakeTokenizer())
     results = _feed(
         parser,
@@ -138,8 +138,80 @@ def test_streaming_partial_arguments_before_invoke_closes():
 
     assert tool_deltas[0].function.name == "get_weather"
     assert tool_deltas[0].function.arguments is None
-    assert tool_deltas[1].function.arguments == '{"city":"Sea'
+    assert len(tool_deltas) == 1
     assert parser.prev_tool_call_arr == []
+
+
+def test_parameter_end_tag_token_pieces_not_streamed_as_arguments():
+    parser = MinimaxM2ToolParser(
+        FakeTokenizer(),
+        tools=[
+            ChatCompletionToolsParam(
+                function=FunctionDefinition(
+                    name="write_file",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "content": {"type": "string"},
+                            "path": {"type": "string"},
+                        },
+                    },
+                ),
+            )
+        ],
+    )
+
+    results = _feed(
+        parser,
+        [
+            ("", [TC_START_ID]),
+            "\n",
+            "<",
+            "invoke",
+            " name",
+            '="',
+            "write",
+            "_file",
+            '">\n',
+            "<",
+            "parameter",
+            " name",
+            '="',
+            "path",
+            '">',
+            "a",
+            ".txt",
+            "</",
+            "parameter",
+            ">\n",
+            "<",
+            "parameter",
+            " name",
+            '="',
+            "content",
+            '">',
+            "123",
+            "</",
+            "parameter",
+            ">\n",
+            "</",
+            "invoke",
+            ">\n",
+            ("", [TC_END_ID]),
+            ("", [EOS_ID]),
+        ],
+    )
+
+    args = _collect_tool_calls(results)[0]["arguments"]
+
+    assert "</parameter" not in args
+    assert json.loads(args) == {"path": "a.txt", "content": "123"}
+    assert parser.prev_tool_call_arr == [
+        {
+            "name": "write_file",
+            "arguments": {"path": "a.txt", "content": "123"},
+        }
+    ]
 
 
 def test_complete_single_chunk_still_reconstructs_tool_call():

--- a/vllm_ascend/patch/platform/patch_minimax_m2_tool_call_parser.py
+++ b/vllm_ascend/patch/platform/patch_minimax_m2_tool_call_parser.py
@@ -235,35 +235,10 @@ def _serialize_partial_param_value(
     self: MinimaxM2ToolParser,
     value: str,
     param_types: list[str],
-    *,
-    is_complete: bool,
 ) -> str:
     value = value.strip()
-    if is_complete:
-        converted = _coerce_param_value(value, param_types)
-        return json.dumps(converted, ensure_ascii=False)
-
-    if not value:
-        return ""
-
-    normalized_types = {t.lower() for t in param_types}
-    string_types = {"string", "str", "text"}
-
-    if "null" in normalized_types and not (normalized_types & string_types) and "null".startswith(value.lower()):
-        return value.lower()
-
-    if {"boolean", "bool"} & normalized_types:
-        lower_value = value.lower()
-        if any(candidate.startswith(lower_value) for candidate in ("true", "false")):
-            return lower_value
-
-    if {"integer", "int", "number", "float"} & normalized_types:
-        return value
-
-    if {"object", "array"} & normalized_types and value[:1] in "{[":
-        return value
-
-    return json.dumps(value, ensure_ascii=False)[:-1]
+    converted = _coerce_param_value(value, param_types)
+    return json.dumps(converted, ensure_ascii=False)
 
 
 def _build_partial_arguments(
@@ -297,22 +272,18 @@ def _build_partial_arguments(
             param_value = invoke_body[value_start:]
             search_pos = len(invoke_body)
 
-        if not param_complete and not param_value.strip():
+        if not param_complete:
             break
 
         param_types = _get_param_types_from_config(param_name, param_config)
         serialized_value = self._serialize_partial_param_value(
             param_value,
             param_types,
-            is_complete=param_complete,
         )
         if not serialized_value:
             break
 
         args_parts.append(f"{json.dumps(param_name, ensure_ascii=False)}:{serialized_value}")
-
-        if not param_complete:
-            break
 
     if not args_parts:
         return "{}" if invoke_complete else ""


### PR DESCRIPTION
## Summary
- stop MiniMax-M2 streaming tool parser from emitting argument JSON for an incomplete <parameter> value
- keep early tool-name emission, but stream arguments at completed-parameter granularity to avoid leaking partial </parameter> token pieces
- add a regression test for the MiniMax-M2.5 write_file case from #10758

## Context
MiniMax-M2.5 can tokenize </parameter> as separate text pieces such as </, parameter, and >. The v0.20.2rc incremental parser was serializing a still-open parameter value, so clients could reconstruct arguments like a.txt</parameter even though the final parsed tool call was correct.

Current vLLM main moved MiniMax-M2 to the parser engine in vllm#45701, but that rewrite is too broad for v0.20.2rc. This patch backports the narrower behavior needed here: emit argument deltas only after a complete parameter closes.

## Tests
- PYTHONPATH=/vllm-workspace/vllm:/mnt/share_space/j00513044/src/vllm-ascend pytest -q tests/ut/patch/platform/test_patch_minimax_m2_tool_call_parser.py
- replayed issue #10758 raw_completion token ids with /models/MiniMax-M2.5-w8a8-QuaRot tokenizer; reconstructed {"path":"a.txt","content":"123"}
- ruff check vllm_ascend/patch/platform/patch_minimax_m2_tool_call_parser.py tests/ut/patch/platform/test_patch_minimax_m2_tool_call_parser.py
- python -m py_compile vllm_ascend/patch/platform/patch_minimax_m2_tool_call_parser.py

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
