### PR TITLE
[BugFix][Worker] Fix padded sequence length handling for ViT encoder ACL graph

### DIFF
--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -107,6 +107,8 @@ if not _npu_available:
     sys.modules["torch_npu"]._npu_reshape_and_cache = MagicMock()  # type: ignore[attr-defined]
     sys.modules["torch_npu"].npu_scatter_pa_kv_cache = MagicMock()  # type: ignore[attr-defined]
     sys.modules["torch_npu"].npu_gather_pa_kv_cache = MagicMock()  # type: ignore[attr-defined]
+    sys.modules["torch_npu"].npu_fused_infer_attention_score = MagicMock()  # type: ignore[attr-defined]
+    sys.modules["torch_npu"]._npu_fused_infer_attention_score_get_max_workspace = MagicMock()  # type: ignore[attr-defined]
     sys.modules["torch_npu"].npu_moe_gating_top_k_softmax = MagicMock()  # type: ignore[attr-defined]
     sys.modules["torch_npu"].npu_quant_matmul = MagicMock()  # type: ignore[attr-defined]
     sys.modules["torch_npu"].npu_rms_norm = MagicMock()  # type: ignore[attr-defined]

--- a/tests/ut/ops/test_mm_encoder_attention.py
+++ b/tests/ut/ops/test_mm_encoder_attention.py
@@ -1,0 +1,293 @@
+from unittest.mock import MagicMock, patch
+
+import torch
+import torch.nn.functional as F
+from vllm.config import CompilationConfig, VllmConfig
+from vllm.config.vllm import get_cached_compilation_config
+
+from tests.ut.base import TestBase
+from vllm_ascend.ops.mm_encoder_attention import (
+    FIA_BLOCK_SIZE,
+    MAX_PAD_SIZE,
+    AscendMMEncoderAttention,
+)
+from vllm_ascend.worker import encoder_acl_graph
+from vllm_ascend.worker.encoder_acl_graph import (
+    get_encoder_forward_context,
+    get_encoder_graph_params,
+    set_encoder_graph_params,
+)
+
+
+class _FiaMockMixin:
+    def _install_vllm_config_mock(self):
+        mock_vllm_config = MagicMock(spec=VllmConfig)
+        mock_vllm_config.compilation_config = CompilationConfig()
+        patcher = patch(
+            "vllm.config.vllm.get_current_vllm_config",
+            return_value=mock_vllm_config,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        get_cached_compilation_config.cache_clear()
+        self.addCleanup(get_cached_compilation_config.cache_clear)
+
+    def _make_layer(self, num_heads=4, num_kv_heads=4, head_size=72, scale=None):
+        return AscendMMEncoderAttention(
+            num_heads=num_heads,
+            head_size=head_size,
+            scale=scale,
+            num_kv_heads=num_kv_heads,
+        )
+
+    def _compute_fia_output(self, query, key, value, actual_seq_lengths, scale):
+        output = torch.zeros_like(query)
+        starts = [0] + list(actual_seq_lengths[:-1])
+        for i, end in enumerate(actual_seq_lengths):
+            beg = starts[i]
+            if end <= beg:
+                continue
+            q_seg = query[beg:end].permute(1, 0, 2).to(torch.float32)
+            k_seg = key[beg:end].permute(1, 0, 2).to(torch.float32)
+            v_seg = value[beg:end].permute(1, 0, 2).to(torch.float32)
+            attn = F.scaled_dot_product_attention(
+                q_seg.unsqueeze(0),
+                k_seg.unsqueeze(0),
+                v_seg.unsqueeze(0),
+                scale=scale,
+                dropout_p=0.0,
+                is_causal=False,
+            ).squeeze(0)
+            output[beg:end] = attn.permute(1, 0, 2).to(query.dtype)
+        return output
+
+    def _record_fia_call(self, **kwargs):
+        self.captured["mode"] = "functional"
+        self.captured["q_shape"] = kwargs["query"].shape
+        self.captured["k_shape"] = kwargs["key"].shape
+        self.captured["v_shape"] = kwargs["value"].shape
+        self.captured["input_layout"] = kwargs["input_layout"]
+        self.captured["block_size"] = kwargs["block_size"]
+        self.captured["actual_seq_lengths"] = kwargs["actual_seq_lengths"]
+        self.captured["actual_seq_lengths_kv"] = kwargs["actual_seq_lengths_kv"]
+        self.captured["num_heads"] = kwargs["num_heads"]
+        self.captured["num_key_value_heads"] = kwargs["num_key_value_heads"]
+        self.captured["scale"] = kwargs["scale"]
+        self.captured["sparse_mode"] = kwargs["sparse_mode"]
+        self.captured["block_table"] = kwargs["block_table"]
+        self.captured["atten_mask"] = kwargs["atten_mask"]
+        self.captured["pre_tokens"] = kwargs.get("pre_tokens")
+        self.captured["next_tokens"] = kwargs.get("next_tokens")
+
+    def _fake_fia(self, **kwargs):
+        self._record_fia_call(**kwargs)
+        return (
+            self._compute_fia_output(
+                kwargs["query"],
+                kwargs["key"],
+                kwargs["value"],
+                kwargs["actual_seq_lengths"],
+                kwargs["scale"],
+            ),
+            None,
+        )
+
+    def _fake_fia_out(self, *, workspace, out, **kwargs):
+        self.captured["mode"] = "out"
+        self.captured["workspace"] = workspace
+        self.captured["softmax_lse"] = out[1]
+        self.captured["q_shape"] = kwargs["query"].shape
+        self.captured["actual_seq_lengths"] = kwargs["actual_seq_lengths"]
+        self.captured["block_size"] = kwargs["block_size"]
+        self.captured["sparse_mode"] = kwargs["sparse_mode"]
+        self.captured["pre_tokens"] = kwargs.get("pre_tokens")
+        self.captured["next_tokens"] = kwargs.get("next_tokens")
+        self.captured["scale"] = kwargs["scale"]
+        out[0][...] = self._compute_fia_output(
+            kwargs["query"],
+            kwargs["key"],
+            kwargs["value"],
+            kwargs["actual_seq_lengths"],
+            kwargs["scale"],
+        )
+
+    def _install_fia_mocks(self, *, capture: bool):
+        self.captured = {}
+        mock_fia = MagicMock(side_effect=self._fake_fia)
+        mock_fia.out = self._fake_fia_out
+
+        patch_targets = [
+            (
+                "vllm_ascend.ops.mm_encoder_attention.torch_npu.npu_fused_infer_attention_score",
+                mock_fia,
+            ),
+            (
+                "vllm_ascend.ops.mm_encoder_attention.torch_npu._npu_fused_infer_attention_score_get_max_workspace",
+                MagicMock(return_value=torch.zeros(1)),
+            ),
+        ]
+        if capture:
+            self.mock_graph_begin = MagicMock()
+            self.mock_graph_end = MagicMock(return_value=42)
+            mock_event = MagicMock()
+            patch_targets.extend(
+                [
+                    (
+                        "vllm_ascend.ops.mm_encoder_attention.weak_ref_tensors",
+                        lambda tensors: tensors,
+                    ),
+                    (
+                        "vllm_ascend.ops.mm_encoder_attention.torch_npu.npu.current_stream",
+                        MagicMock(return_value=MagicMock()),
+                    ),
+                    (
+                        "vllm_ascend.ops.mm_encoder_attention.torch.npu.ExternalEvent",
+                        MagicMock(return_value=mock_event),
+                    ),
+                    (
+                        "vllm_ascend.ops.mm_encoder_attention.torch.npu.graph_task_group_begin",
+                        self.mock_graph_begin,
+                    ),
+                    (
+                        "vllm_ascend.ops.mm_encoder_attention.torch.npu.graph_task_group_end",
+                        self.mock_graph_end,
+                    ),
+                ]
+            )
+
+        for target, replacement in patch_targets:
+            patcher = patch(target, replacement)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+
+class TestAscendMMEncoderAttentionEager(TestBase, _FiaMockMixin):
+    def setUp(self):
+        self._install_vllm_config_mock()
+        self._install_fia_mocks(capture=False)
+
+    def test_shape_basic(self):
+        layer = self._make_layer(num_heads=4, num_kv_heads=4, head_size=128)
+        bsz, q_len = 2, 4
+        query = torch.randn(bsz, q_len, layer.num_heads * layer.head_size)
+        key = query.clone()
+        value = query.clone()
+        cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32)
+
+        out = layer.forward_oot(query, key, value, cu_seqlens=cu_seqlens)
+
+        self.assertEqual(out.shape, (bsz, q_len, layer.num_heads * layer.head_size))
+        self.assertEqual(self.captured["mode"], "functional")
+        self.assertEqual(self.captured["input_layout"], "TND")
+        self.assertEqual(self.captured["sparse_mode"], 0)
+        self.assertEqual(self.captured["block_size"], FIA_BLOCK_SIZE)
+        self.assertEqual(self.captured["scale"], layer.scale)
+
+    def test_maybe_compute_actual_seq_lengths_from_sequence_lengths(self):
+        layer = self._make_layer()
+        actual_q, actual_kv = layer._maybe_compute_actual_seq_lengths(
+            num_query_tokens=8,
+            bsz=2,
+            q_len=4,
+            cu_seqlens=None,
+            sequence_lengths=torch.tensor([4, 4], dtype=torch.int64),
+        )
+        self.assertEqual(actual_q, [4, 8])
+        self.assertEqual(actual_kv, [4, 8])
+
+    def test_maybe_compute_actual_seq_lengths_aligns_padded_cu_seqlens(self):
+        layer = self._make_layer()
+        cu_seqlens = torch.tensor([0, 4, 8, 0, 0], dtype=torch.int32)
+        actual_q, actual_kv = layer._maybe_compute_actual_seq_lengths(
+            num_query_tokens=8,
+            bsz=2,
+            q_len=4,
+            cu_seqlens=cu_seqlens,
+            sequence_lengths=None,
+        )
+        self.assertEqual(actual_q, [4, 8])
+        self.assertEqual(actual_kv, [4, 8])
+
+    def test_variable_seqlens(self):
+        layer = self._make_layer(num_heads=4, num_kv_heads=4, head_size=72)
+        seq_lens = [3, 7, 2]
+        cu_seqlens = torch.tensor([0, 3, 10, 12], dtype=torch.int32, device="cpu")
+        max_q_len = max(seq_lens)
+        query = torch.randn(len(seq_lens), max_q_len, layer.num_heads, 72, dtype=torch.bfloat16)
+        key = torch.randn_like(query)
+        value = torch.randn_like(query)
+
+        out = layer.forward_oot(query, key, value, cu_seqlens=cu_seqlens)
+
+        self.assertEqual(out.shape, query.shape)
+        self.assertEqual(self.captured["actual_seq_lengths"], [3, 10, 12, 21])
+        self.assertEqual(self.captured["q_shape"], (len(seq_lens) * max_q_len, 4, MAX_PAD_SIZE))
+
+    def test_custom_scale_used_in_fia(self):
+        custom_scale = 0.25
+        layer = self._make_layer(num_heads=4, num_kv_heads=4, head_size=128, scale=custom_scale)
+        bsz, q_len = 1, 4
+        query = torch.randn(bsz, q_len, layer.num_heads * layer.head_size)
+        key = query.clone()
+        value = query.clone()
+        cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32)
+
+        layer.forward_oot(query, key, value, cu_seqlens=cu_seqlens)
+
+        self.assertEqual(self.captured["scale"], custom_scale)
+
+
+class TestAscendMMEncoderAttentionCapture(TestBase, _FiaMockMixin):
+    def setUp(self):
+        self._install_vllm_config_mock()
+        set_encoder_graph_params([2048])
+        self._install_fia_mocks(capture=True)
+
+    def tearDown(self):
+        encoder_acl_graph._encoder_graph_params = None
+        encoder_acl_graph._reset_encoder_forward_context()
+
+    def test_capture_appends_attn_params(self):
+        layer = self._make_layer(num_heads=4, num_kv_heads=4, head_size=72)
+        ctx = get_encoder_forward_context()
+        ctx.capturing = True
+        ctx.token_budget = 2048
+        ctx.capture_layer_cursor = 0
+
+        bsz, q_len = 2, 4
+        query = torch.randn(bsz, q_len, layer.num_heads, 72, dtype=torch.bfloat16)
+        key = torch.randn_like(query)
+        value = torch.randn_like(query)
+        cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32)
+
+        layer.forward_oot(query, key, value, cu_seqlens=cu_seqlens)
+
+        params = get_encoder_graph_params()
+        self.assertIsNotNone(params)
+        self.assertEqual(len(params.attn_params[2048]), 1)
+        self.assertEqual(len(params.handles[2048]), 1)
+        self.assertFalse(params.attn_params[2048][0][6])
+        self.assertEqual(params.attn_params[2048][0][10], layer.scale)
+        self.assertEqual(self.captured["mode"], "out")
+        self.assertEqual(self.captured["softmax_lse"].numel(), 1)
+        self.mock_graph_begin.assert_called_once()
+        self.mock_graph_end.assert_called_once()
+
+    def test_capture_uses_sequence_lengths_host(self):
+        layer = self._make_layer(num_heads=4, num_kv_heads=4, head_size=72)
+        ctx = get_encoder_forward_context()
+        ctx.capturing = True
+        ctx.token_budget = 2048
+
+        seq_lens = [3, 5]
+        sequence_lengths = torch.tensor(seq_lens, dtype=torch.int64)
+        query = torch.randn(2, 5, layer.num_heads, 72, dtype=torch.bfloat16)
+        key = torch.randn_like(query)
+        value = torch.randn_like(query)
+
+        layer.forward_oot(query, key, value, sequence_lengths=sequence_lengths)
+
+        params = get_encoder_graph_params()
+        self.assertIsNotNone(params)
+        self.assertTrue(params.attn_params[2048][0][6])
+        self.assertEqual(self.captured["actual_seq_lengths"], [3, 8, 10])

--- a/tests/ut/ops/test_mm_encoder_attention.py
+++ b/tests/ut/ops/test_mm_encoder_attention.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -19,7 +20,9 @@ from vllm_ascend.worker.encoder_acl_graph import (
 )
 
 
-class _FiaMockMixin:
+class FIAMockMixin(TestBase):
+    captured: dict[str, Any]
+
     def _install_vllm_config_mock(self):
         mock_vllm_config = MagicMock(spec=VllmConfig)
         mock_vllm_config.compilation_config = CompilationConfig()
@@ -116,7 +119,7 @@ class _FiaMockMixin:
         mock_fia = MagicMock(side_effect=self._fake_fia)
         mock_fia.out = self._fake_fia_out
 
-        patch_targets = [
+        patch_targets: list[tuple[str, Any]] = [
             (
                 "vllm_ascend.ops.mm_encoder_attention.torch_npu.npu_fused_infer_attention_score",
                 mock_fia,
@@ -161,7 +164,7 @@ class _FiaMockMixin:
             self.addCleanup(patcher.stop)
 
 
-class TestAscendMMEncoderAttentionEager(TestBase, _FiaMockMixin):
+class TestAscendMMEncoderAttentionEager(FIAMockMixin):
     def setUp(self):
         self._install_vllm_config_mock()
         self._install_fia_mocks(capture=False)
@@ -237,7 +240,7 @@ class TestAscendMMEncoderAttentionEager(TestBase, _FiaMockMixin):
         self.assertEqual(self.captured["scale"], custom_scale)
 
 
-class TestAscendMMEncoderAttentionCapture(TestBase, _FiaMockMixin):
+class TestAscendMMEncoderAttentionCapture(FIAMockMixin):
     def setUp(self):
         self._install_vllm_config_mock()
         set_encoder_graph_params([2048])

--- a/tests/ut/ops/test_mm_encoder_attention.py
+++ b/tests/ut/ops/test_mm_encoder_attention.py
@@ -2,7 +2,6 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import torch
-import torch.nn.functional as F
 from vllm.config import CompilationConfig, VllmConfig
 from vllm.config.vllm import get_cached_compilation_config
 
@@ -16,7 +15,6 @@ from vllm_ascend.worker import encoder_acl_graph
 from vllm_ascend.worker.encoder_acl_graph import (
     get_encoder_forward_context,
     get_encoder_graph_params,
-    maybe_compute_actual_seq_lengths,
     set_encoder_graph_params,
 )
 
@@ -44,76 +42,21 @@ class FIAMockMixin(TestBase):
             num_kv_heads=num_kv_heads,
         )
 
-    def _compute_fia_output(self, query, key, value, actual_seq_lengths, scale):
-        output = torch.zeros_like(query)
-        starts = [0] + list(actual_seq_lengths[:-1])
-        for i, end in enumerate(actual_seq_lengths):
-            beg = starts[i]
-            if end <= beg:
-                continue
-            q_seg = query[beg:end].permute(1, 0, 2).to(torch.float32)
-            k_seg = key[beg:end].permute(1, 0, 2).to(torch.float32)
-            v_seg = value[beg:end].permute(1, 0, 2).to(torch.float32)
-            attn = F.scaled_dot_product_attention(
-                q_seg.unsqueeze(0),
-                k_seg.unsqueeze(0),
-                v_seg.unsqueeze(0),
-                scale=scale,
-                dropout_p=0.0,
-                is_causal=False,
-            ).squeeze(0)
-            output[beg:end] = attn.permute(1, 0, 2).to(query.dtype)
-        return output
-
-    def _record_fia_call(self, **kwargs):
-        self.captured["mode"] = "functional"
-        self.captured["q_shape"] = kwargs["query"].shape
-        self.captured["k_shape"] = kwargs["key"].shape
-        self.captured["v_shape"] = kwargs["value"].shape
-        self.captured["input_layout"] = kwargs["input_layout"]
-        self.captured["block_size"] = kwargs["block_size"]
-        self.captured["actual_seq_lengths"] = kwargs["actual_seq_lengths"]
-        self.captured["actual_seq_lengths_kv"] = kwargs["actual_seq_lengths_kv"]
-        self.captured["num_heads"] = kwargs["num_heads"]
-        self.captured["num_key_value_heads"] = kwargs["num_key_value_heads"]
-        self.captured["scale"] = kwargs["scale"]
-        self.captured["sparse_mode"] = kwargs["sparse_mode"]
-        self.captured["block_table"] = kwargs["block_table"]
-        self.captured["atten_mask"] = kwargs["atten_mask"]
-        self.captured["pre_tokens"] = kwargs.get("pre_tokens")
-        self.captured["next_tokens"] = kwargs.get("next_tokens")
-
     def _fake_fia(self, **kwargs):
-        self._record_fia_call(**kwargs)
-        return (
-            self._compute_fia_output(
-                kwargs["query"],
-                kwargs["key"],
-                kwargs["value"],
-                kwargs["actual_seq_lengths"],
-                kwargs["scale"],
-            ),
-            None,
-        )
+        self.captured = {
+            "mode": "functional",
+            "q_shape": kwargs["query"].shape,
+            "input_layout": kwargs["input_layout"],
+            "block_size": kwargs["block_size"],
+            "actual_seq_lengths": kwargs["actual_seq_lengths"],
+            "scale": kwargs["scale"],
+            "sparse_mode": kwargs["sparse_mode"],
+        }
+        return torch.zeros_like(kwargs["query"]), None
 
     def _fake_fia_out(self, *, workspace, out, **kwargs):
-        self.captured["mode"] = "out"
-        self.captured["workspace"] = workspace
-        self.captured["softmax_lse"] = out[1]
-        self.captured["q_shape"] = kwargs["query"].shape
-        self.captured["actual_seq_lengths"] = kwargs["actual_seq_lengths"]
-        self.captured["block_size"] = kwargs["block_size"]
-        self.captured["sparse_mode"] = kwargs["sparse_mode"]
-        self.captured["pre_tokens"] = kwargs.get("pre_tokens")
-        self.captured["next_tokens"] = kwargs.get("next_tokens")
-        self.captured["scale"] = kwargs["scale"]
-        out[0][...] = self._compute_fia_output(
-            kwargs["query"],
-            kwargs["key"],
-            kwargs["value"],
-            kwargs["actual_seq_lengths"],
-            kwargs["scale"],
-        )
+        self.captured = {"mode": "out", "softmax_lse": out[1]}
+        out[0].zero_()
 
     def _install_fia_mocks(self, *, capture: bool):
         self.captured = {}
@@ -187,15 +130,6 @@ class TestAscendMMEncoderAttentionEager(FIAMockMixin):
         self.assertEqual(self.captured["block_size"], FIA_BLOCK_SIZE)
         self.assertEqual(self.captured["scale"], layer.scale)
 
-    def test_maybe_compute_actual_seq_lengths_from_cu_seqlens(self):
-        cu_seqlens = torch.tensor([0, 4, 8], dtype=torch.int32)
-        actual_q, actual_kv = maybe_compute_actual_seq_lengths(
-            num_query_tokens=8,
-            cu_seqlens=cu_seqlens,
-        )
-        self.assertEqual(actual_q, [4, 8])
-        self.assertEqual(actual_kv, [4, 8])
-
     def test_variable_seqlens(self):
         layer = self._make_layer(num_heads=4, num_kv_heads=4, head_size=72)
         seq_lens = [3, 7, 2]
@@ -210,19 +144,6 @@ class TestAscendMMEncoderAttentionEager(FIAMockMixin):
         self.assertEqual(out.shape, query.shape)
         self.assertEqual(self.captured["actual_seq_lengths"], [3, 10, 12, 21])
         self.assertEqual(self.captured["q_shape"], (len(seq_lens) * max_q_len, 4, MAX_PAD_SIZE))
-
-    def test_custom_scale_used_in_fia(self):
-        custom_scale = 0.25
-        layer = self._make_layer(num_heads=4, num_kv_heads=4, head_size=128, scale=custom_scale)
-        bsz, q_len = 1, 4
-        query = torch.randn(bsz, q_len, layer.num_heads * layer.head_size)
-        key = query.clone()
-        value = query.clone()
-        cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32)
-
-        layer.forward_oot(query, key, value, cu_seqlens=cu_seqlens)
-
-        self.assertEqual(self.captured["scale"], custom_scale)
 
 
 class TestAscendMMEncoderAttentionCapture(FIAMockMixin):
@@ -258,18 +179,3 @@ class TestAscendMMEncoderAttentionCapture(FIAMockMixin):
         self.assertEqual(self.captured["softmax_lse"].numel(), 1)
         self.mock_graph_begin.assert_called_once()
         self.mock_graph_end.assert_called_once()
-
-    def test_capture_none_cu_seqlens_uses_cpu_arange(self):
-        layer = self._make_layer(num_heads=4, num_kv_heads=4, head_size=72)
-        ctx = get_encoder_forward_context()
-        ctx.capturing = True
-        ctx.token_budget = 2048
-
-        bsz, q_len = 2, 4
-        query = torch.randn(bsz, q_len, layer.num_heads, 72, dtype=torch.bfloat16)
-        key = torch.randn_like(query)
-        value = torch.randn_like(query)
-
-        layer.forward_oot(query, key, value, cu_seqlens=None)
-
-        self.assertEqual(self.captured["actual_seq_lengths"], [4, 8])

--- a/tests/ut/ops/test_mm_encoder_attention.py
+++ b/tests/ut/ops/test_mm_encoder_attention.py
@@ -16,6 +16,7 @@ from vllm_ascend.worker import encoder_acl_graph
 from vllm_ascend.worker.encoder_acl_graph import (
     get_encoder_forward_context,
     get_encoder_graph_params,
+    maybe_compute_actual_seq_lengths,
     set_encoder_graph_params,
 )
 
@@ -186,27 +187,11 @@ class TestAscendMMEncoderAttentionEager(FIAMockMixin):
         self.assertEqual(self.captured["block_size"], FIA_BLOCK_SIZE)
         self.assertEqual(self.captured["scale"], layer.scale)
 
-    def test_maybe_compute_actual_seq_lengths_from_sequence_lengths(self):
-        layer = self._make_layer()
-        actual_q, actual_kv = layer._maybe_compute_actual_seq_lengths(
+    def test_maybe_compute_actual_seq_lengths_from_cu_seqlens(self):
+        cu_seqlens = torch.tensor([0, 4, 8], dtype=torch.int32)
+        actual_q, actual_kv = maybe_compute_actual_seq_lengths(
             num_query_tokens=8,
-            bsz=2,
-            q_len=4,
-            cu_seqlens=None,
-            sequence_lengths=torch.tensor([4, 4], dtype=torch.int64),
-        )
-        self.assertEqual(actual_q, [4, 8])
-        self.assertEqual(actual_kv, [4, 8])
-
-    def test_maybe_compute_actual_seq_lengths_aligns_padded_cu_seqlens(self):
-        layer = self._make_layer()
-        cu_seqlens = torch.tensor([0, 4, 8, 0, 0], dtype=torch.int32)
-        actual_q, actual_kv = layer._maybe_compute_actual_seq_lengths(
-            num_query_tokens=8,
-            bsz=2,
-            q_len=4,
             cu_seqlens=cu_seqlens,
-            sequence_lengths=None,
         )
         self.assertEqual(actual_q, [4, 8])
         self.assertEqual(actual_kv, [4, 8])
@@ -255,7 +240,6 @@ class TestAscendMMEncoderAttentionCapture(FIAMockMixin):
         ctx = get_encoder_forward_context()
         ctx.capturing = True
         ctx.token_budget = 2048
-        ctx.capture_layer_cursor = 0
 
         bsz, q_len = 2, 4
         query = torch.randn(bsz, q_len, layer.num_heads, 72, dtype=torch.bfloat16)
@@ -269,28 +253,23 @@ class TestAscendMMEncoderAttentionCapture(FIAMockMixin):
         self.assertIsNotNone(params)
         self.assertEqual(len(params.attn_params[2048]), 1)
         self.assertEqual(len(params.handles[2048]), 1)
-        self.assertFalse(params.attn_params[2048][0][6])
-        self.assertEqual(params.attn_params[2048][0][10], layer.scale)
+        self.assertEqual(params.attn_params[2048][0][8], layer.scale)
         self.assertEqual(self.captured["mode"], "out")
         self.assertEqual(self.captured["softmax_lse"].numel(), 1)
         self.mock_graph_begin.assert_called_once()
         self.mock_graph_end.assert_called_once()
 
-    def test_capture_uses_sequence_lengths_host(self):
+    def test_capture_none_cu_seqlens_uses_cpu_arange(self):
         layer = self._make_layer(num_heads=4, num_kv_heads=4, head_size=72)
         ctx = get_encoder_forward_context()
         ctx.capturing = True
         ctx.token_budget = 2048
 
-        seq_lens = [3, 5]
-        sequence_lengths = torch.tensor(seq_lens, dtype=torch.int64)
-        query = torch.randn(2, 5, layer.num_heads, 72, dtype=torch.bfloat16)
+        bsz, q_len = 2, 4
+        query = torch.randn(bsz, q_len, layer.num_heads, 72, dtype=torch.bfloat16)
         key = torch.randn_like(query)
         value = torch.randn_like(query)
 
-        layer.forward_oot(query, key, value, sequence_lengths=sequence_lengths)
+        layer.forward_oot(query, key, value, cu_seqlens=None)
 
-        params = get_encoder_graph_params()
-        self.assertIsNotNone(params)
-        self.assertTrue(params.attn_params[2048][0][6])
-        self.assertEqual(self.captured["actual_seq_lengths"], [3, 8, 10])
+        self.assertEqual(self.captured["actual_seq_lengths"], [4, 8])

--- a/tests/ut/worker/test_encoder_acl_graph.py
+++ b/tests/ut/worker/test_encoder_acl_graph.py
@@ -1,16 +1,3 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# This file is a part of the vllm-ascend project.
-
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -18,7 +5,6 @@ import pytest
 import torch
 from vllm.config import CompilationConfig, VllmConfig
 
-from vllm_ascend.utils import vllm_version_is
 from vllm_ascend.worker import encoder_acl_graph
 from vllm_ascend.worker.encoder_acl_graph import (
     EncoderAclGraphManager,
@@ -47,8 +33,6 @@ def _reset_state():
     [
         (torch.tensor([0, 4, 8], dtype=torch.int32), 8, [4, 8]),
         (torch.tensor([0, 4, 16], dtype=torch.int32), 8, [4, 8]),
-        (torch.tensor([0], dtype=torch.int32), 8, [8]),
-        (torch.tensor([0, 4, 8], dtype=torch.int32), 0, [0]),
     ],
 )
 def test_maybe_compute_actual_seq_lengths(cu_seqlens, num_tokens, expected):
@@ -58,22 +42,6 @@ def test_maybe_compute_actual_seq_lengths(cu_seqlens, num_tokens, expected):
     )
     assert actual_q == expected
     assert actual_kv == expected
-
-
-def test_replay_compute_actual_seq_lengths_from_cu_seqlens():
-    cu_seqlens_cpu = torch.tensor([0, 4, 8], dtype=torch.int32)
-
-    actual_q, actual_kv = maybe_compute_actual_seq_lengths(
-        num_query_tokens=8,
-        cu_seqlens=cu_seqlens_cpu,
-    )
-    assert actual_q == [4, 8]
-    assert actual_kv == [4, 8]
-
-
-def test_replay_missing_cu_seqlens_raises():
-    with pytest.raises(TypeError):
-        maybe_compute_actual_seq_lengths(num_query_tokens=8)
 
 
 def test_update_encoder_graph_params_uses_cu_seqlens():
@@ -144,11 +112,6 @@ def _make_manager():
     )
     model.get_encoder_cudagraph_budget_range.return_value = (64, 2048)
     return EncoderAclGraphManager(vllm_config, "npu", "bfloat16", model), model
-
-
-def test_manager_update_stream_defaults_none():
-    mgr, _ = _make_manager()
-    assert mgr.update_stream is None
 
 
 def test_manager_capture_registers_graph_params():

--- a/tests/ut/worker/test_encoder_acl_graph.py
+++ b/tests/ut/worker/test_encoder_acl_graph.py
@@ -174,10 +174,6 @@ def test_manager_uses_npu_graph_in_capture_budget_graph():
 
     fake_graph = MagicMock()
     with (
-        patch(
-            "vllm_ascend.worker.encoder_acl_graph.vllm_version_is",
-            return_value=False,
-        ),
         patch("vllm_ascend.worker.encoder_acl_graph.torch.npu.NPUGraph", return_value=fake_graph),
         patch("vllm_ascend.worker.encoder_acl_graph.torch.npu.graph"),
         patch(

--- a/tests/ut/worker/test_encoder_acl_graph.py
+++ b/tests/ut/worker/test_encoder_acl_graph.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 from vllm.config import CompilationConfig, VllmConfig
 
+from vllm_ascend.utils import vllm_version_is
 from vllm_ascend.worker import encoder_acl_graph
 from vllm_ascend.worker.encoder_acl_graph import (
     EncoderAclGraphManager,

--- a/tests/ut/worker/test_encoder_acl_graph.py
+++ b/tests/ut/worker/test_encoder_acl_graph.py
@@ -18,6 +18,7 @@ import pytest
 import torch
 from vllm.config import CompilationConfig, VllmConfig
 
+from vllm_ascend.utils import vllm_version_is
 from vllm_ascend.worker import encoder_acl_graph
 from vllm_ascend.worker.encoder_acl_graph import (
     EncoderAclGraphManager,
@@ -27,7 +28,6 @@ from vllm_ascend.worker.encoder_acl_graph import (
     set_encoder_graph_params,
     update_encoder_graph_params,
 )
-from vllm_ascend.utils import vllm_version_is
 
 
 def _reset_encoder_acl_graph_state() -> None:

--- a/tests/ut/worker/test_encoder_acl_graph.py
+++ b/tests/ut/worker/test_encoder_acl_graph.py
@@ -1,0 +1,230 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from vllm.config import CompilationConfig, VllmConfig
+
+from vllm_ascend.worker import encoder_acl_graph
+from vllm_ascend.worker.encoder_acl_graph import (
+    EncoderAclGraphManager,
+    FIAActualSeqLengthsInput,
+    FIALengthFormat,
+    _align_fia_endpoints_to_num_tokens,
+    _maybe_compute_actual_seq_lengths,
+    build_fia_actual_seq_lengths,
+    get_encoder_forward_context,
+    get_encoder_graph_params,
+    set_encoder_graph_params,
+    update_encoder_graph_params,
+)
+
+
+def _reset_encoder_acl_graph_state() -> None:
+    encoder_acl_graph._encoder_graph_params = None
+    encoder_acl_graph._reset_encoder_forward_context()
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    _reset_encoder_acl_graph_state()
+    yield
+    _reset_encoder_acl_graph_state()
+
+
+@pytest.mark.parametrize(
+    "lengths, num_tokens, expected",
+    [
+        ([4, 8, 0], 8, [4, 8]),
+        ([4, 16], 8, [4, 8]),
+        ([], 8, [8]),
+    ],
+)
+def test_align_fia_endpoints_to_num_tokens(lengths, num_tokens, expected):
+    assert _align_fia_endpoints_to_num_tokens(lengths, num_tokens) == expected
+
+
+@pytest.mark.parametrize(
+    "length_format, buffer, expected_q, expected_kv",
+    [
+        (
+            FIALengthFormat.CUMULATIVE,
+            torch.tensor([0, 4, 8, 0, 0], dtype=torch.int32),
+            [4, 8],
+            [4, 8],
+        ),
+        (
+            FIALengthFormat.PER_SEQUENCE,
+            torch.tensor([4, 4], dtype=torch.int64),
+            [4, 8],
+            [4, 8],
+        ),
+    ],
+)
+def test_build_fia_actual_seq_lengths(length_format, buffer, expected_q, expected_kv):
+    length_input = FIAActualSeqLengthsInput(length_format, buffer=buffer)
+    actual_q, actual_kv = build_fia_actual_seq_lengths(
+        num_query_tokens=8,
+        length_input=length_input,
+    )
+    assert actual_q == expected_q
+    assert actual_kv == expected_kv
+
+
+def test_fullatt_block_indexes_routing():
+    ctx = get_encoder_forward_context()
+    ctx.cu_seqlens_cpu = torch.tensor([0, 4, 8], dtype=torch.int32)
+    ctx.cu_window_seqlens_cpu = torch.tensor([0, 2, 6], dtype=torch.int32)
+    ctx.sequence_lengths_cpu = torch.tensor([3, 7], dtype=torch.int64)
+
+    full_q, _ = _maybe_compute_actual_seq_lengths(
+        num_query_tokens=8,
+        uses_seq_len_host=False,
+        vit_layer_idx=0,
+        fullatt_block_indexes=frozenset({0, 2}),
+    )
+    window_q, _ = _maybe_compute_actual_seq_lengths(
+        num_query_tokens=8,
+        uses_seq_len_host=False,
+        vit_layer_idx=1,
+        fullatt_block_indexes=frozenset({0, 2}),
+    )
+    assert full_q == [4, 8]
+    assert window_q == [2, 6, 8]
+
+    seq_q, _ = _maybe_compute_actual_seq_lengths(
+        num_query_tokens=8,
+        uses_seq_len_host=True,
+        vit_layer_idx=0,
+        fullatt_block_indexes=frozenset({0, 2}),
+    )
+    assert seq_q == [3, 8]
+
+
+def test_update_encoder_graph_params_routes_host_lengths():
+    set_encoder_graph_params([2048])
+    params = get_encoder_graph_params()
+    query = MagicMock()
+    query.shape = [8, 4, 72]
+    packed = (
+        query,
+        MagicMock(),
+        MagicMock(),
+        None,
+        None,
+        128,
+        False,
+        0,
+        4,
+        4,
+        0.125,
+        MagicMock(),
+        MagicMock(),
+    )
+    params.handles[2048] = [1]
+    params.events[2048] = [MagicMock()]
+    params.attn_params[2048] = [packed]
+    params.workspaces[2048] = MagicMock()
+
+    ctx = get_encoder_forward_context()
+    ctx.cu_seqlens_cpu = torch.tensor([0, 4, 8], dtype=torch.int32)
+
+    captured = {}
+
+    def fake_out(**kwargs):
+        captured["actual_seq_lengths"] = kwargs["actual_seq_lengths"]
+
+    fake_fia = SimpleNamespace(out=fake_out)
+    with (
+        patch("vllm_ascend.worker.encoder_acl_graph.torch.npu.stream"),
+        patch("vllm_ascend.worker.encoder_acl_graph.torch.npu.graph_task_update_begin"),
+        patch("vllm_ascend.worker.encoder_acl_graph.torch.npu.graph_task_update_end"),
+        patch(
+            "vllm_ascend.worker.encoder_acl_graph.torch_npu.npu_fused_infer_attention_score",
+            fake_fia,
+        ),
+    ):
+        update_encoder_graph_params(
+            MagicMock(),
+            2048,
+            fullatt_block_indexes=frozenset({0}),
+        )
+
+    assert captured["actual_seq_lengths"] == [4, 8]
+
+
+def _make_manager():
+    vllm_config = MagicMock(spec=VllmConfig)
+    vllm_config.compilation_config = CompilationConfig()
+    mm_config = MagicMock()
+    mm_config.get_limit_per_prompt.return_value = 0
+    mm_config.mm_encoder_tp_mode = "tensor"
+    vllm_config.model_config = MagicMock()
+    vllm_config.model_config.multimodal_config = mm_config
+    vllm_config.parallel_config = MagicMock()
+    vllm_config.parallel_config.tensor_parallel_size = 1
+
+    model = MagicMock()
+    model.get_encoder_cudagraph_config.return_value = MagicMock(
+        input_key_by_modality={"image": "pixel_values"},
+        buffer_keys=["cu_seqlens"],
+    )
+    model.get_encoder_cudagraph_budget_range.return_value = (64, 2048)
+    model.visual = None
+    return EncoderAclGraphManager(vllm_config, "npu", "bfloat16", model), model
+
+
+def test_manager_update_stream_defaults_none():
+    mgr, _ = _make_manager()
+    assert mgr.update_stream is None
+
+
+def test_manager_capture_registers_graph_params():
+    mgr, _ = _make_manager()
+    mgr.token_budgets = [2048]
+
+    with patch("vllm.v1.worker.encoder_cudagraph.EncoderCudaGraphManager.capture", return_value=None):
+        mgr.capture()
+
+    params = get_encoder_graph_params()
+    assert params is not None
+    assert 2048 in params.events
+
+
+def test_manager_uses_npu_graph_in_capture_budget_graph():
+    mgr, model = _make_manager()
+    mgr.max_batch_size = 2
+    mgr.max_frames_per_batch = 0
+    model.prepare_encoder_cudagraph_capture_inputs.return_value = MagicMock(
+        mm_kwargs={"pixel_values": torch.zeros(2, 3, 224, 224)},
+        buffers={"cu_seqlens": torch.zeros(3, dtype=torch.int32)},
+    )
+    model.encoder_cudagraph_forward.return_value = torch.zeros(2, 64)
+
+    fake_graph = MagicMock()
+    with (
+        patch("vllm_ascend.worker.encoder_acl_graph.torch.npu.NPUGraph", return_value=fake_graph),
+        patch("vllm_ascend.worker.encoder_acl_graph.torch.npu.graph"),
+        patch("vllm_ascend.worker.encoder_acl_graph.set_encoder_forward_context"),
+        patch(
+            "vllm_ascend.worker.encoder_acl_graph.weak_ref_tensors",
+            side_effect=lambda tensors: tensors,
+        ),
+    ):
+        mgr._capture_budget_graph(2048)
+
+    assert 2048 in mgr.budget_graphs
+    assert mgr.budget_graphs[2048].graph is fake_graph

--- a/tests/ut/worker/test_encoder_acl_graph.py
+++ b/tests/ut/worker/test_encoder_acl_graph.py
@@ -27,6 +27,7 @@ from vllm_ascend.worker.encoder_acl_graph import (
     set_encoder_graph_params,
     update_encoder_graph_params,
 )
+from vllm_ascend.utils import vllm_version_is
 
 
 def _reset_encoder_acl_graph_state() -> None:
@@ -183,6 +184,9 @@ def test_manager_uses_npu_graph_in_capture_budget_graph():
     ):
         mgr._capture_budget_graph(2048)
 
-    graph_meta = mgr.budget_graphs["default"][2048]
+    if vllm_version_is("0.23.0"):
+        graph_meta = mgr.budget_graphs[2048]
+    else:
+        graph_meta = mgr._get_graph_set("default")[2048]
     assert graph_meta.graph is fake_graph
     assert graph_meta.input_buffers is capture_values

--- a/tests/ut/worker/test_encoder_acl_graph.py
+++ b/tests/ut/worker/test_encoder_acl_graph.py
@@ -21,13 +21,9 @@ from vllm.config import CompilationConfig, VllmConfig
 from vllm_ascend.worker import encoder_acl_graph
 from vllm_ascend.worker.encoder_acl_graph import (
     EncoderAclGraphManager,
-    FIAActualSeqLengthsInput,
-    FIALengthFormat,
-    _align_fia_endpoints_to_num_tokens,
-    _maybe_compute_actual_seq_lengths,
-    build_fia_actual_seq_lengths,
     get_encoder_forward_context,
     get_encoder_graph_params,
+    maybe_compute_actual_seq_lengths,
     set_encoder_graph_params,
     update_encoder_graph_params,
 )
@@ -46,75 +42,40 @@ def _reset_state():
 
 
 @pytest.mark.parametrize(
-    "lengths, num_tokens, expected",
+    "cu_seqlens, num_tokens, expected",
     [
-        ([4, 8, 0], 8, [4, 8]),
-        ([4, 16], 8, [4, 8]),
-        ([], 8, [8]),
+        (torch.tensor([0, 4, 8], dtype=torch.int32), 8, [4, 8]),
+        (torch.tensor([0, 4, 16], dtype=torch.int32), 8, [4, 8]),
+        (torch.tensor([0], dtype=torch.int32), 8, [8]),
+        (torch.tensor([0, 4, 8], dtype=torch.int32), 0, [0]),
     ],
 )
-def test_align_fia_endpoints_to_num_tokens(lengths, num_tokens, expected):
-    assert _align_fia_endpoints_to_num_tokens(lengths, num_tokens) == expected
-
-
-@pytest.mark.parametrize(
-    "length_format, buffer, expected_q, expected_kv",
-    [
-        (
-            FIALengthFormat.CUMULATIVE,
-            torch.tensor([0, 4, 8, 0, 0], dtype=torch.int32),
-            [4, 8],
-            [4, 8],
-        ),
-        (
-            FIALengthFormat.PER_SEQUENCE,
-            torch.tensor([4, 4], dtype=torch.int64),
-            [4, 8],
-            [4, 8],
-        ),
-    ],
-)
-def test_build_fia_actual_seq_lengths(length_format, buffer, expected_q, expected_kv):
-    length_input = FIAActualSeqLengthsInput(length_format, buffer=buffer)
-    actual_q, actual_kv = build_fia_actual_seq_lengths(
-        num_query_tokens=8,
-        length_input=length_input,
+def test_maybe_compute_actual_seq_lengths(cu_seqlens, num_tokens, expected):
+    actual_q, actual_kv = maybe_compute_actual_seq_lengths(
+        num_query_tokens=num_tokens,
+        cu_seqlens=cu_seqlens,
     )
-    assert actual_q == expected_q
-    assert actual_kv == expected_kv
+    assert actual_q == expected
+    assert actual_kv == expected
 
 
-def test_fullatt_block_indexes_routing():
-    ctx = get_encoder_forward_context()
-    ctx.cu_seqlens_cpu = torch.tensor([0, 4, 8], dtype=torch.int32)
-    ctx.cu_window_seqlens_cpu = torch.tensor([0, 2, 6], dtype=torch.int32)
-    ctx.sequence_lengths_cpu = torch.tensor([3, 7], dtype=torch.int64)
+def test_replay_compute_actual_seq_lengths_from_cu_seqlens():
+    cu_seqlens_cpu = torch.tensor([0, 4, 8], dtype=torch.int32)
 
-    full_q, _ = _maybe_compute_actual_seq_lengths(
+    actual_q, actual_kv = maybe_compute_actual_seq_lengths(
         num_query_tokens=8,
-        uses_seq_len_host=False,
-        vit_layer_idx=0,
-        fullatt_block_indexes=frozenset({0, 2}),
+        cu_seqlens=cu_seqlens_cpu,
     )
-    window_q, _ = _maybe_compute_actual_seq_lengths(
-        num_query_tokens=8,
-        uses_seq_len_host=False,
-        vit_layer_idx=1,
-        fullatt_block_indexes=frozenset({0, 2}),
-    )
-    assert full_q == [4, 8]
-    assert window_q == [2, 6, 8]
-
-    seq_q, _ = _maybe_compute_actual_seq_lengths(
-        num_query_tokens=8,
-        uses_seq_len_host=True,
-        vit_layer_idx=0,
-        fullatt_block_indexes=frozenset({0, 2}),
-    )
-    assert seq_q == [3, 8]
+    assert actual_q == [4, 8]
+    assert actual_kv == [4, 8]
 
 
-def test_update_encoder_graph_params_routes_host_lengths():
+def test_replay_missing_cu_seqlens_raises():
+    with pytest.raises(TypeError):
+        maybe_compute_actual_seq_lengths(num_query_tokens=8)
+
+
+def test_update_encoder_graph_params_uses_cu_seqlens():
     set_encoder_graph_params([2048])
     params = get_encoder_graph_params()
     query = MagicMock()
@@ -126,8 +87,6 @@ def test_update_encoder_graph_params_routes_host_lengths():
         None,
         None,
         128,
-        False,
-        0,
         4,
         4,
         0.125,
@@ -157,11 +116,7 @@ def test_update_encoder_graph_params_routes_host_lengths():
             fake_fia,
         ),
     ):
-        update_encoder_graph_params(
-            MagicMock(),
-            2048,
-            fullatt_block_indexes=frozenset({0}),
-        )
+        update_encoder_graph_params(MagicMock(), 2048)
 
     assert captured["actual_seq_lengths"] == [4, 8]
 
@@ -179,11 +134,14 @@ def _make_manager():
 
     model = MagicMock()
     model.get_encoder_cudagraph_config.return_value = MagicMock(
-        input_key_by_modality={"image": "pixel_values"},
+        modalities=["image"],
         buffer_keys=["cu_seqlens"],
+        out_hidden_size=64,
+        enable_dual_path_graph=False,
+        padding_logics={},
+        max_frames_per_video=1,
     )
     model.get_encoder_cudagraph_budget_range.return_value = (64, 2048)
-    model.visual = None
     return EncoderAclGraphManager(vllm_config, "npu", "bfloat16", model), model
 
 
@@ -208,17 +166,20 @@ def test_manager_uses_npu_graph_in_capture_budget_graph():
     mgr, model = _make_manager()
     mgr.max_batch_size = 2
     mgr.max_frames_per_batch = 0
+    capture_values = {"cu_seqlens": torch.zeros(3, dtype=torch.int32)}
     model.prepare_encoder_cudagraph_capture_inputs.return_value = MagicMock(
-        mm_kwargs={"pixel_values": torch.zeros(2, 3, 224, 224)},
-        buffers={"cu_seqlens": torch.zeros(3, dtype=torch.int32)},
+        values=capture_values,
     )
     model.encoder_cudagraph_forward.return_value = torch.zeros(2, 64)
 
     fake_graph = MagicMock()
     with (
+        patch(
+            "vllm_ascend.worker.encoder_acl_graph.vllm_version_is",
+            return_value=False,
+        ),
         patch("vllm_ascend.worker.encoder_acl_graph.torch.npu.NPUGraph", return_value=fake_graph),
         patch("vllm_ascend.worker.encoder_acl_graph.torch.npu.graph"),
-        patch("vllm_ascend.worker.encoder_acl_graph.set_encoder_forward_context"),
         patch(
             "vllm_ascend.worker.encoder_acl_graph.weak_ref_tensors",
             side_effect=lambda tensors: tensors,
@@ -226,5 +187,6 @@ def test_manager_uses_npu_graph_in_capture_budget_graph():
     ):
         mgr._capture_budget_graph(2048)
 
-    assert 2048 in mgr.budget_graphs
-    assert mgr.budget_graphs[2048].graph is fake_graph
+    graph_meta = mgr.budget_graphs["default"][2048]
+    assert graph_meta.graph is fake_graph
+    assert graph_meta.input_buffers is capture_values

--- a/vllm_ascend/ops/mm_encoder_attention.py
+++ b/vllm_ascend/ops/mm_encoder_attention.py
@@ -243,8 +243,8 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         key: torch.Tensor,
         value: torch.Tensor,
         *,
-        seq_lens: torch.Tensor,
-        cu_seqlens: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+        sequence_lengths: torch.Tensor | None,
         is_reshaped: bool,
         bsz: int,
         q_len: int,
@@ -254,7 +254,7 @@ class AscendMMEncoderAttention(MMEncoderAttention):
             bsz=bsz,
             q_len=q_len,
             cu_seqlens=cu_seqlens,
-            sequence_lengths=seq_lens,
+            sequence_lengths=sequence_lengths,
         )
         q, k, v, origin_head_dim = self._maybe_pad_qkv(query, key, value)
         context_layer = self._run_vit_fia(q, k, v, actual_seq_lengths_q, actual_seq_lengths_kv)
@@ -277,7 +277,6 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         is_reshaped: bool,
         bsz: int,
         q_len: int,
-        kv_len: int,
     ) -> torch.Tensor:
         context = get_encoder_forward_context()
         token_budget = context.token_budget
@@ -372,7 +371,7 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         key: torch.Tensor,
         value: torch.Tensor,
         cu_seqlens: torch.Tensor | None = None,
-        max_seqlen: torch.Tensor | None = None,  # Unused on Ascend (upstream API compat)
+        max_seqlen: torch.Tensor | None = None,
         sequence_lengths: torch.Tensor | None = None,
     ):
         bsz, q_len = query.size()[:2]
@@ -391,9 +390,15 @@ class AscendMMEncoderAttention(MMEncoderAttention):
                 is_reshaped=is_reshaped,
                 bsz=bsz,
                 q_len=q_len,
-                kv_len=kv_len,
             )
 
         return self._forward_eager_fia(
-            q, k, v, seq_lens=sequence_lengths, cu_seqlens=cu_seqlens, is_reshaped=is_reshaped, bsz=bsz, q_len=q_len
+            q,
+            k,
+            v,
+            cu_seqlens=cu_seqlens,
+            sequence_lengths=sequence_lengths,
+            is_reshaped=is_reshaped,
+            bsz=bsz,
+            q_len=q_len,
         )

--- a/vllm_ascend/ops/mm_encoder_attention.py
+++ b/vllm_ascend/ops/mm_encoder_attention.py
@@ -112,6 +112,21 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         v = F.pad(v, (0, pad_len), mode="constant", value=0)
         return q, k, v, origin_head_dim
 
+    def _maybe_compute_cu_seqlens(
+        self,
+        bsz: int,
+        q_len: int,
+        cu_seqlens: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if cu_seqlens is not None:
+            return cu_seqlens
+
+        # If cu_seqlens is not provided, we create a default one assuming all sequences have the same length.
+        # This is used by models such as Hunyuan-OCR, which always pass None as cu_seqlens and rely on the operator to
+        # compute it internally.
+        cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32, device="cpu")
+        return cu_seqlens
+
     @staticmethod
     def _maybe_unpad_output(
         context_layer: torch.Tensor,
@@ -182,14 +197,14 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         key: torch.Tensor,
         value: torch.Tensor,
         *,
-        cu_seqlens: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
         is_reshaped: bool,
         bsz: int,
         q_len: int,
     ) -> torch.Tensor:
         actual_seq_lengths_q, actual_seq_lengths_kv = maybe_compute_actual_seq_lengths(
             num_query_tokens=query.shape[0],
-            cu_seqlens=cu_seqlens,
+            cu_seqlens=self._maybe_compute_cu_seqlens(bsz, q_len, cu_seqlens),
         )
         q, k, v, origin_head_dim = self._maybe_pad_qkv(query, key, value)
         context_layer = self._run_vit_fia(q, k, v, actual_seq_lengths_q, actual_seq_lengths_kv)
@@ -207,7 +222,7 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         key: torch.Tensor,
         value: torch.Tensor,
         *,
-        cu_seqlens: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
         is_reshaped: bool,
         bsz: int,
         q_len: int,
@@ -220,7 +235,7 @@ class AscendMMEncoderAttention(MMEncoderAttention):
 
         actual_seq_lengths_q, actual_seq_lengths_kv = maybe_compute_actual_seq_lengths(
             num_query_tokens=query.shape[0],
-            cu_seqlens=torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32, device="cpu"),
+            cu_seqlens=self._maybe_compute_cu_seqlens(bsz, q_len, cu_seqlens),
         )
         q, k, v, origin_head_dim = self._maybe_pad_qkv(query, key, value)
 
@@ -296,7 +311,7 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         query: torch.Tensor,
         key: torch.Tensor,
         value: torch.Tensor,
-        cu_seqlens: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
         max_seqlen: torch.Tensor | None = None,
         sequence_lengths: torch.Tensor | None = None,
     ):

--- a/vllm_ascend/ops/mm_encoder_attention.py
+++ b/vllm_ascend/ops/mm_encoder_attention.py
@@ -207,7 +207,7 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         key: torch.Tensor,
         value: torch.Tensor,
         *,
-        cu_seqlens: torch.Tensor | None,
+        cu_seqlens: torch.Tensor,
         is_reshaped: bool,
         bsz: int,
         q_len: int,
@@ -218,12 +218,9 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         if token_budget is None or params is None:
             raise RuntimeError("Encoder graph capture state was not initialized (missing token_budget).")
 
-        if cu_seqlens is None:
-            cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32, device="cpu")
-
         actual_seq_lengths_q, actual_seq_lengths_kv = maybe_compute_actual_seq_lengths(
             num_query_tokens=query.shape[0],
-            cu_seqlens=cu_seqlens,
+            cu_seqlens=torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32, device="cpu"),
         )
         q, k, v, origin_head_dim = self._maybe_pad_qkv(query, key, value)
 

--- a/vllm_ascend/ops/mm_encoder_attention.py
+++ b/vllm_ascend/ops/mm_encoder_attention.py
@@ -34,6 +34,9 @@ from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 from vllm_ascend.utils import weak_ref_tensors
 from vllm_ascend.worker.encoder_acl_graph import (
+    FIAActualSeqLengthsInput,
+    FIALengthFormat,
+    build_fia_actual_seq_lengths,
     get_encoder_forward_context,
     get_encoder_graph_params,
     update_encoder_graph_workspace,
@@ -73,7 +76,6 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         )
 
         self.enable_pad = self.head_size > MIN_PAD_SIZE and self.head_size < MAX_PAD_SIZE
-        self.scale_value = self.head_size**-0.5
 
     @classmethod
     def maybe_compute_seq_lens(
@@ -92,6 +94,8 @@ class AscendMMEncoderAttention(MMEncoderAttention):
 
     def _maybe_compute_actual_seq_lengths(
         self,
+        *,
+        num_query_tokens: int,
         bsz: int,
         q_len: int,
         cu_seqlens: torch.Tensor | None,
@@ -99,17 +103,21 @@ class AscendMMEncoderAttention(MMEncoderAttention):
     ) -> tuple[list[int], list[int]]:
         """Build FIA ``actual_seq_lengths`` as cumulative host-side ``list[int]``."""
         if sequence_lengths is not None:
-            seq_lens_cpu = sequence_lengths
-            if seq_lens_cpu.device.type != "cpu":
-                seq_lens_cpu = seq_lens_cpu.to("cpu")
-            actual = seq_lens_cpu.cumsum(0).to(torch.int64).tolist()
+            length_input = FIAActualSeqLengthsInput(
+                FIALengthFormat.PER_SEQUENCE,
+                buffer=sequence_lengths,
+            )
         else:
             cu = self._maybe_compute_cu_seqlens(bsz, q_len, cu_seqlens)
-            if cu.device.type != "cpu":
-                cu = cu.to("cpu")
-            actual = cu[1:].to(torch.int64).tolist()
+            length_input = FIAActualSeqLengthsInput(
+                FIALengthFormat.CUMULATIVE,
+                buffer=cu,
+            )
 
-        return actual, actual
+        return build_fia_actual_seq_lengths(
+            num_query_tokens=num_query_tokens,
+            length_input=length_input,
+        )
 
     def _reshape_qkv_to_3d(
         self,
@@ -210,7 +218,7 @@ class AscendMMEncoderAttention(MMEncoderAttention):
             actual_seq_lengths_kv=actual_seq_lengths_kv,
             num_key_value_heads=self.num_kv_heads,
             num_heads=self.num_heads,
-            scale=self.scale_value,
+            scale=self.scale,
             sparse_mode=0,
             pre_tokens=SWA_INT_MAX,
             next_tokens=SWA_INT_MAX,
@@ -241,11 +249,12 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         bsz: int,
         q_len: int,
     ) -> torch.Tensor:
-        actual_seq_lengths_q, actual_seq_lengths_kv = self._maybe_compute_actual_seq_lengths(  # TODO
-            bsz,
-            q_len,
-            cu_seqlens,
-            seq_lens,
+        actual_seq_lengths_q, actual_seq_lengths_kv = self._maybe_compute_actual_seq_lengths(
+            num_query_tokens=query.shape[0],
+            bsz=bsz,
+            q_len=q_len,
+            cu_seqlens=cu_seqlens,
+            sequence_lengths=seq_lens,
         )
         q, k, v, origin_head_dim = self._maybe_pad_qkv(query, key, value)
         context_layer = self._run_vit_fia(q, k, v, actual_seq_lengths_q, actual_seq_lengths_kv)
@@ -277,10 +286,11 @@ class AscendMMEncoderAttention(MMEncoderAttention):
             raise RuntimeError("Encoder graph capture state was not initialized (missing token_budget).")
 
         actual_seq_lengths_q, actual_seq_lengths_kv = self._maybe_compute_actual_seq_lengths(
-            bsz,
-            q_len,
-            cu_seqlens,
-            sequence_lengths,
+            num_query_tokens=query.shape[0],
+            bsz=bsz,
+            q_len=q_len,
+            cu_seqlens=cu_seqlens,
+            sequence_lengths=sequence_lengths,
         )
         q, k, v, origin_head_dim = self._maybe_pad_qkv(query, key, value)
 
@@ -302,7 +312,7 @@ class AscendMMEncoderAttention(MMEncoderAttention):
                 num_key_value_heads=self.num_kv_heads,
                 num_heads=self.num_heads,
                 sparse_mode=0,
-                scale=self.scale_value,
+                scale=self.scale,
                 pre_tokens=SWA_INT_MAX,
                 next_tokens=SWA_INT_MAX,
             )
@@ -340,7 +350,7 @@ class AscendMMEncoderAttention(MMEncoderAttention):
             vit_layer_idx,
             self.num_kv_heads,
             self.num_heads,
-            self.scale_value,
+            self.scale,
             weak_ref_tensors(out),
             weak_ref_tensors(softmax_lse),
         )

--- a/vllm_ascend/ops/mm_encoder_attention.py
+++ b/vllm_ascend/ops/mm_encoder_attention.py
@@ -25,20 +25,16 @@ matching the LLM full-graph pattern in :mod:`vllm_ascend.attention.attention_v1`
 from __future__ import annotations
 
 import einops
-import numpy as np
 import torch
 import torch.nn.functional as F
 import torch_npu
 from vllm.model_executor.layers.attention.mm_encoder_attention import MMEncoderAttention  # type: ignore
-from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 from vllm_ascend.utils import weak_ref_tensors
 from vllm_ascend.worker.encoder_acl_graph import (
-    FIAActualSeqLengthsInput,
-    FIALengthFormat,
-    build_fia_actual_seq_lengths,
     get_encoder_forward_context,
     get_encoder_graph_params,
+    maybe_compute_actual_seq_lengths,
     update_encoder_graph_workspace,
 )
 
@@ -77,48 +73,6 @@ class AscendMMEncoderAttention(MMEncoderAttention):
 
         self.enable_pad = self.head_size > MIN_PAD_SIZE and self.head_size < MAX_PAD_SIZE
 
-    @classmethod
-    def maybe_compute_seq_lens(
-        cls,
-        attn_backend: AttentionBackendEnum,
-        cu_seqlens: np.ndarray,
-        device: torch.device,
-    ) -> np.ndarray | None:
-        if cu_seqlens is None:
-            return None
-
-        seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
-        seq_lens = torch.from_numpy(seq_lens).to("cpu", non_blocking=True)
-
-        return seq_lens
-
-    def _maybe_compute_actual_seq_lengths(
-        self,
-        *,
-        num_query_tokens: int,
-        bsz: int,
-        q_len: int,
-        cu_seqlens: torch.Tensor | None,
-        sequence_lengths: torch.Tensor | None,
-    ) -> tuple[list[int], list[int]]:
-        """Build FIA ``actual_seq_lengths`` as cumulative host-side ``list[int]``."""
-        if sequence_lengths is not None:
-            length_input = FIAActualSeqLengthsInput(
-                FIALengthFormat.PER_SEQUENCE,
-                buffer=sequence_lengths,
-            )
-        else:
-            cu = self._maybe_compute_cu_seqlens(bsz, q_len, cu_seqlens)
-            length_input = FIAActualSeqLengthsInput(
-                FIALengthFormat.CUMULATIVE,
-                buffer=cu,
-            )
-
-        return build_fia_actual_seq_lengths(
-            num_query_tokens=num_query_tokens,
-            length_input=length_input,
-        )
-
     def _reshape_qkv_to_3d(
         self,
         query: torch.Tensor,
@@ -142,21 +96,6 @@ class AscendMMEncoderAttention(MMEncoderAttention):
             value = torch.repeat_interleave(value, num_repeat, dim=1)
 
         return query, key, value
-
-    def _maybe_compute_cu_seqlens(
-        self,
-        bsz: int,
-        q_len: int,
-        cu_seqlens: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        if cu_seqlens is not None:
-            return cu_seqlens
-
-        # If cu_seqlens is not provided, we create a default one assuming all sequences have the same length.
-        # This is used by models such as Hunyuan-OCR, which always pass None as cu_seqlens and rely on the operator to
-        # compute it internally.
-        cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32, device="cpu")
-        return cu_seqlens
 
     def _maybe_pad_qkv(
         self,
@@ -243,18 +182,14 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         key: torch.Tensor,
         value: torch.Tensor,
         *,
-        cu_seqlens: torch.Tensor | None,
-        sequence_lengths: torch.Tensor | None,
+        cu_seqlens: torch.Tensor,
         is_reshaped: bool,
         bsz: int,
         q_len: int,
     ) -> torch.Tensor:
-        actual_seq_lengths_q, actual_seq_lengths_kv = self._maybe_compute_actual_seq_lengths(
+        actual_seq_lengths_q, actual_seq_lengths_kv = maybe_compute_actual_seq_lengths(
             num_query_tokens=query.shape[0],
-            bsz=bsz,
-            q_len=q_len,
             cu_seqlens=cu_seqlens,
-            sequence_lengths=sequence_lengths,
         )
         q, k, v, origin_head_dim = self._maybe_pad_qkv(query, key, value)
         context_layer = self._run_vit_fia(q, k, v, actual_seq_lengths_q, actual_seq_lengths_kv)
@@ -273,7 +208,6 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         value: torch.Tensor,
         *,
         cu_seqlens: torch.Tensor | None,
-        sequence_lengths: torch.Tensor | None,
         is_reshaped: bool,
         bsz: int,
         q_len: int,
@@ -284,12 +218,12 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         if token_budget is None or params is None:
             raise RuntimeError("Encoder graph capture state was not initialized (missing token_budget).")
 
-        actual_seq_lengths_q, actual_seq_lengths_kv = self._maybe_compute_actual_seq_lengths(
+        if cu_seqlens is None:
+            cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32, device="cpu")
+
+        actual_seq_lengths_q, actual_seq_lengths_kv = maybe_compute_actual_seq_lengths(
             num_query_tokens=query.shape[0],
-            bsz=bsz,
-            q_len=q_len,
             cu_seqlens=cu_seqlens,
-            sequence_lengths=sequence_lengths,
         )
         q, k, v, origin_head_dim = self._maybe_pad_qkv(query, key, value)
 
@@ -335,9 +269,6 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         )
         handle = torch.npu.graph_task_group_end(stream)
 
-        vit_layer_idx = context.capture_layer_cursor
-        context.capture_layer_cursor = vit_layer_idx + 1
-        uses_sequence_lengths_host = sequence_lengths is not None
         packed = (
             weak_ref_tensors(q),
             weak_ref_tensors(k),
@@ -345,8 +276,6 @@ class AscendMMEncoderAttention(MMEncoderAttention):
             None,
             None,
             FIA_BLOCK_SIZE,
-            uses_sequence_lengths_host,
-            vit_layer_idx,
             self.num_kv_heads,
             self.num_heads,
             self.scale,
@@ -370,7 +299,7 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         query: torch.Tensor,
         key: torch.Tensor,
         value: torch.Tensor,
-        cu_seqlens: torch.Tensor | None = None,
+        cu_seqlens: torch.Tensor,
         max_seqlen: torch.Tensor | None = None,
         sequence_lengths: torch.Tensor | None = None,
     ):
@@ -386,7 +315,6 @@ class AscendMMEncoderAttention(MMEncoderAttention):
                 k,
                 v,
                 cu_seqlens=cu_seqlens,
-                sequence_lengths=sequence_lengths,
                 is_reshaped=is_reshaped,
                 bsz=bsz,
                 q_len=q_len,
@@ -397,7 +325,6 @@ class AscendMMEncoderAttention(MMEncoderAttention):
             k,
             v,
             cu_seqlens=cu_seqlens,
-            sequence_lengths=sequence_lengths,
             is_reshaped=is_reshaped,
             bsz=bsz,
             q_len=q_len,

--- a/vllm_ascend/ops/mm_encoder_attention.py
+++ b/vllm_ascend/ops/mm_encoder_attention.py
@@ -119,7 +119,7 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         cu_seqlens: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if cu_seqlens is not None:
-            return cu_seqlens
+            return cu_seqlens if cu_seqlens.device.type == "cpu" else cu_seqlens.cpu()
 
         # If cu_seqlens is not provided, we create a default one assuming all sequences have the same length.
         # This is used by models such as Hunyuan-OCR, which always pass None as cu_seqlens and rely on the operator to

--- a/vllm_ascend/ops/mm_encoder_attention.py
+++ b/vllm_ascend/ops/mm_encoder_attention.py
@@ -118,8 +118,8 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         q_len: int,
         cu_seqlens: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        if cu_seqlens is not None:
-            return cu_seqlens if cu_seqlens.device.type == "cpu" else cu_seqlens.cpu()
+        if cu_seqlens is not None and cu_seqlens.device.type == "cpu":
+            return cu_seqlens
 
         # If cu_seqlens is not provided, we create a default one assuming all sequences have the same length.
         # This is used by models such as Hunyuan-OCR, which always pass None as cu_seqlens and rely on the operator to

--- a/vllm_ascend/worker/encoder_acl_graph.py
+++ b/vllm_ascend/worker/encoder_acl_graph.py
@@ -295,10 +295,8 @@ class EncoderAclGraphManager(EncoderCudaGraphManager):
             output_buffer = torch.empty_like(output)
 
         graph = torch.npu.NPUGraph()
-        cu_seqlens = values.get("cu_seqlens")
-        cu_seqlens_cpu = None if cu_seqlens is None else cu_seqlens.cpu()
         with (
-            set_encoder_forward_context(token_budget, True, cu_seqlens_cpu=cu_seqlens_cpu),
+            set_encoder_forward_context(token_budget, True),
             torch.inference_mode(),
             torch.npu.graph(graph, self.graph_pool),
         ):

--- a/vllm_ascend/worker/encoder_acl_graph.py
+++ b/vllm_ascend/worker/encoder_acl_graph.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any
 
 import torch
@@ -138,15 +139,96 @@ def set_encoder_forward_context(
 
 
 # ---------------------------------------------------------------------------
-# Replay-time FIA task updates
+# Shared FIA actual_seq_lengths helpers (eager / capture / replay)
 # ---------------------------------------------------------------------------
 
 
-def _pad_actual_seq_lengths_for_fia(actual_seq_lengths: list[int], num_tokens: int) -> list[int]:
-    """TND FIA requires ``query.shape[0] == actual_seq_lengths[-1]``."""
-    if not actual_seq_lengths or actual_seq_lengths[-1] != num_tokens:
-        actual_seq_lengths.append(num_tokens)
-    return actual_seq_lengths
+def _align_fia_endpoints_to_num_tokens(endpoints: list[int], num_tokens: int) -> list[int]:
+    """Common post-process for both length formats before FIA ``actual_seq_lengths``.
+
+    CUMULATIVE and PER_SEQUENCE helpers only perform format conversion; this function
+    is the sole place that trims padding, clamps to the token budget, enforces
+    monotonicity, and ensures the terminal endpoint equals ``num_tokens``.
+    """
+    # 1. Trim trailing zeros (prefix-sum budget padding).
+    trimmed = list(endpoints)
+    while trimmed and trimmed[-1] == 0:
+        trimmed.pop()
+    endpoints = trimmed
+
+    # 2. Empty token budget.
+    if num_tokens <= 0:
+        return [0]
+
+    # 3. Filter non-positive, clamp at num_tokens, enforce strict monotonicity.
+    filtered: list[int] = []
+    for end in endpoints:
+        if end <= 0:
+            continue
+        if end > num_tokens:
+            break
+        if not filtered or end > filtered[-1]:
+            filtered.append(end)
+
+    # 4. Ensure terminal endpoint equals num_tokens.
+    if not filtered or filtered[-1] != num_tokens:
+        filtered.append(num_tokens)
+    return filtered
+
+
+def _cumulative_buffer_to_fia_endpoints(buffer: torch.Tensor) -> list[int]:
+    """Convert a cumulative-length buffer to raw FIA endpoint list (format only).
+
+    Input is ``cu_seqlens`` / ``cu_window_seqlens`` style: leading 0 is a format
+    marker, not a sequence boundary. Output may contain trailing padding zeros and
+    need not end at the token budget — callers run ``_align_fia_endpoints_to_num_tokens``.
+    """
+    flat = buffer.detach().cpu().view(-1).tolist()
+    return flat[1:] if flat else flat
+
+
+def _per_sequence_lengths_to_fia_endpoints(buffer: torch.Tensor) -> list[int]:
+    """Convert a per-sequence length buffer to raw cumulative endpoints (format only).
+
+    Zero slots denote unused batch padding and are excluded before cumsum. Output
+    need not end at the token budget — callers run ``_align_fia_endpoints_to_num_tokens``.
+    """
+    valid = buffer.detach().cpu().view(-1)
+    valid = valid[valid != 0]
+    return valid.cumsum(dim=0).to(torch.int64).tolist()
+
+
+class FIALengthFormat(Enum):
+    CUMULATIVE = "cumulative"
+    PER_SEQUENCE = "per_sequence"
+
+
+@dataclass(frozen=True)
+class FIAActualSeqLengthsInput:
+    """Host-side encoder metadata buffer and its layout format for FIA ``actual_seq_lengths``."""
+
+    format: FIALengthFormat
+    buffer: torch.Tensor
+
+
+def build_fia_actual_seq_lengths(
+    *,
+    num_query_tokens: int,
+    length_input: FIAActualSeqLengthsInput,
+) -> tuple[list[int], list[int]]:
+    """Build aligned FIA ``actual_seq_lengths`` for eager, capture, and replay."""
+    if length_input.format is FIALengthFormat.PER_SEQUENCE:
+        actual = _per_sequence_lengths_to_fia_endpoints(length_input.buffer)
+    else:
+        actual = _cumulative_buffer_to_fia_endpoints(length_input.buffer)
+
+    aligned = _align_fia_endpoints_to_num_tokens(actual, num_query_tokens)
+    return aligned, aligned
+
+
+# ---------------------------------------------------------------------------
+# Replay-time FIA task updates
+# ---------------------------------------------------------------------------
 
 
 def _maybe_compute_actual_seq_lengths(
@@ -160,23 +242,36 @@ def _maybe_compute_actual_seq_lengths(
     if uses_seq_len_host:
         if context.sequence_lengths_cpu is None:
             raise RuntimeError("context.sequence_lengths_cpu is None during encoder replay.")
-        actual = context.sequence_lengths_cpu.cumsum(0).to(torch.int64).tolist()
+        length_input = FIAActualSeqLengthsInput(
+            FIALengthFormat.PER_SEQUENCE,
+            buffer=context.sequence_lengths_cpu,
+        )
     elif fullatt_block_indexes is not None:
         if vit_layer_idx in fullatt_block_indexes:
             if context.cu_seqlens_cpu is None:
                 raise RuntimeError("context.cu_seqlens_cpu is None during encoder replay.")
-            actual = context.cu_seqlens_cpu[1:].to(torch.int64).tolist()
+            length_input = FIAActualSeqLengthsInput(
+                FIALengthFormat.CUMULATIVE,
+                buffer=context.cu_seqlens_cpu,
+            )
         else:
             if context.cu_window_seqlens_cpu is None:
                 raise RuntimeError("context.cu_window_seqlens_cpu is None during encoder replay.")
-            actual = context.cu_window_seqlens_cpu[1:].to(torch.int64).tolist()
+            length_input = FIAActualSeqLengthsInput(
+                FIALengthFormat.CUMULATIVE,
+                buffer=context.cu_window_seqlens_cpu,
+            )
     else:
         if context.cu_seqlens_cpu is None:
             raise RuntimeError("context.cu_seqlens_cpu is None during encoder replay.")
-        actual = context.cu_seqlens_cpu[1:].to(torch.int64).tolist()
-
-    aligned = _pad_actual_seq_lengths_for_fia(actual, num_query_tokens)
-    return aligned, aligned
+        length_input = FIAActualSeqLengthsInput(
+            FIALengthFormat.CUMULATIVE,
+            buffer=context.cu_seqlens_cpu,
+        )
+    return build_fia_actual_seq_lengths(
+        num_query_tokens=num_query_tokens,
+        length_input=length_input,
+    )
 
 
 def update_encoder_graph_params(

--- a/vllm_ascend/worker/encoder_acl_graph.py
+++ b/vllm_ascend/worker/encoder_acl_graph.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import Any
 
 import torch
@@ -88,10 +87,7 @@ class EncoderForwardContext:
 
     token_budget: int | None = None
     capturing: bool = False
-    capture_layer_cursor: int = 0
     cu_seqlens_cpu: torch.Tensor | None = None
-    cu_window_seqlens_cpu: torch.Tensor | None = None
-    sequence_lengths_cpu: torch.Tensor | None = None
 
 
 _context = EncoderForwardContext()
@@ -107,8 +103,6 @@ def _reset_encoder_forward_context() -> None:
     _context.token_budget = None
     _context.capturing = False
     _context.cu_seqlens_cpu = None
-    _context.cu_window_seqlens_cpu = None
-    _context.sequence_lengths_cpu = None
 
 
 @contextmanager
@@ -117,8 +111,6 @@ def set_encoder_forward_context(
     capturing: bool,
     *,
     cu_seqlens_cpu: torch.Tensor | None = None,
-    cu_window_seqlens_cpu: torch.Tensor | None = None,
-    sequence_lengths_cpu: torch.Tensor | None = None,
 ):
     """Enter encoder graph replay (FIA host args): callers must pass lengths each time.
 
@@ -129,9 +121,6 @@ def set_encoder_forward_context(
     _context.token_budget = token_budget
     _context.capturing = capturing
     _context.cu_seqlens_cpu = cu_seqlens_cpu
-    _context.cu_window_seqlens_cpu = cu_window_seqlens_cpu
-    _context.sequence_lengths_cpu = sequence_lengths_cpu
-    _context.capture_layer_cursor = 0
     try:
         yield _context
     finally:
@@ -139,91 +128,37 @@ def set_encoder_forward_context(
 
 
 # ---------------------------------------------------------------------------
-# Shared FIA actual_seq_lengths helpers (eager / capture / replay)
+# FIA actual_seq_lengths (cu_seqlens -> list[int])
 # ---------------------------------------------------------------------------
 
 
-def _align_fia_endpoints_to_num_tokens(endpoints: list[int], num_tokens: int) -> list[int]:
-    """Common post-process for both length formats before FIA ``actual_seq_lengths``.
+def maybe_compute_actual_seq_lengths(
+    num_query_tokens: int,
+    cu_seqlens: torch.Tensor,
+) -> tuple[list[int], list[int]]:
+    """Align FIA ``actual_seq_lengths`` for eager, capture, and replay from ``cu_seqlens``.
 
-    CUMULATIVE and PER_SEQUENCE helpers only perform format conversion; this function
-    is the sole place that trims padding, clamps to the token budget, enforces
-    monotonicity, and ensures the terminal endpoint equals ``num_tokens``.
+    Converts the cumulative device tensor to host ``list[int]`` in one step, drops the
+    leading zero format marker, and ensures the terminal endpoint equals ``num_query_tokens``.
     """
-    # 1. Trim trailing zeros (prefix-sum budget padding).
-    trimmed = list(endpoints)
-    while trimmed and trimmed[-1] == 0:
-        trimmed.pop()
-    endpoints = trimmed
+    flat = cu_seqlens.detach().cpu().view(-1).tolist()
+    actual = flat[1:] if flat else flat
 
-    # 2. Empty token budget.
-    if num_tokens <= 0:
-        return [0]
+    if num_query_tokens <= 0:
+        return [0], [0]
 
-    # 3. Filter non-positive, clamp at num_tokens, enforce strict monotonicity.
     filtered: list[int] = []
-    for end in endpoints:
+    for end in actual:
         if end <= 0:
             continue
-        if end > num_tokens:
+        if end > num_query_tokens:
             break
         if not filtered or end > filtered[-1]:
             filtered.append(end)
 
-    # 4. Ensure terminal endpoint equals num_tokens.
-    if not filtered or filtered[-1] != num_tokens:
-        filtered.append(num_tokens)
-    return filtered
-
-
-def _cumulative_buffer_to_fia_endpoints(buffer: torch.Tensor) -> list[int]:
-    """Convert a cumulative-length buffer to raw FIA endpoint list (format only).
-
-    Input is ``cu_seqlens`` / ``cu_window_seqlens`` style: leading 0 is a format
-    marker, not a sequence boundary. Output may contain trailing padding zeros and
-    need not end at the token budget — callers run ``_align_fia_endpoints_to_num_tokens``.
-    """
-    flat = buffer.detach().cpu().view(-1).tolist()
-    return flat[1:] if flat else flat
-
-
-def _per_sequence_lengths_to_fia_endpoints(buffer: torch.Tensor) -> list[int]:
-    """Convert a per-sequence length buffer to raw cumulative endpoints (format only).
-
-    Zero slots denote unused batch padding and are excluded before cumsum. Output
-    need not end at the token budget — callers run ``_align_fia_endpoints_to_num_tokens``.
-    """
-    valid = buffer.detach().cpu().view(-1)
-    valid = valid[valid != 0]
-    return valid.cumsum(dim=0).to(torch.int64).tolist()
-
-
-class FIALengthFormat(Enum):
-    CUMULATIVE = "cumulative"
-    PER_SEQUENCE = "per_sequence"
-
-
-@dataclass(frozen=True)
-class FIAActualSeqLengthsInput:
-    """Host-side encoder metadata buffer and its layout format for FIA ``actual_seq_lengths``."""
-
-    format: FIALengthFormat
-    buffer: torch.Tensor
-
-
-def build_fia_actual_seq_lengths(
-    *,
-    num_query_tokens: int,
-    length_input: FIAActualSeqLengthsInput,
-) -> tuple[list[int], list[int]]:
-    """Build aligned FIA ``actual_seq_lengths`` for eager, capture, and replay."""
-    if length_input.format is FIALengthFormat.PER_SEQUENCE:
-        actual = _per_sequence_lengths_to_fia_endpoints(length_input.buffer)
-    else:
-        actual = _cumulative_buffer_to_fia_endpoints(length_input.buffer)
-
-    aligned = _align_fia_endpoints_to_num_tokens(actual, num_query_tokens)
-    return aligned, aligned
+    if not filtered or filtered[-1] != num_query_tokens:
+        filtered.append(num_query_tokens)
+    return filtered, filtered
 
 
 # ---------------------------------------------------------------------------
@@ -231,59 +166,11 @@ def build_fia_actual_seq_lengths(
 # ---------------------------------------------------------------------------
 
 
-def _maybe_compute_actual_seq_lengths(
-    *,
-    num_query_tokens: int,
-    uses_seq_len_host: bool,
-    vit_layer_idx: int,
-    fullatt_block_indexes: set[int] | frozenset[int] | None,
-) -> tuple[list[int], list[int]]:
-    context = get_encoder_forward_context()
-    if uses_seq_len_host:
-        if context.sequence_lengths_cpu is None:
-            raise RuntimeError("context.sequence_lengths_cpu is None during encoder replay.")
-        length_input = FIAActualSeqLengthsInput(
-            FIALengthFormat.PER_SEQUENCE,
-            buffer=context.sequence_lengths_cpu,
-        )
-    elif fullatt_block_indexes is not None:
-        if vit_layer_idx in fullatt_block_indexes:
-            if context.cu_seqlens_cpu is None:
-                raise RuntimeError("context.cu_seqlens_cpu is None during encoder replay.")
-            length_input = FIAActualSeqLengthsInput(
-                FIALengthFormat.CUMULATIVE,
-                buffer=context.cu_seqlens_cpu,
-            )
-        else:
-            if context.cu_window_seqlens_cpu is None:
-                raise RuntimeError("context.cu_window_seqlens_cpu is None during encoder replay.")
-            length_input = FIAActualSeqLengthsInput(
-                FIALengthFormat.CUMULATIVE,
-                buffer=context.cu_window_seqlens_cpu,
-            )
-    else:
-        if context.cu_seqlens_cpu is None:
-            raise RuntimeError("context.cu_seqlens_cpu is None during encoder replay.")
-        length_input = FIAActualSeqLengthsInput(
-            FIALengthFormat.CUMULATIVE,
-            buffer=context.cu_seqlens_cpu,
-        )
-    return build_fia_actual_seq_lengths(
-        num_query_tokens=num_query_tokens,
-        length_input=length_input,
-    )
-
-
 def update_encoder_graph_params(
     update_stream: torch.npu.Stream,
     token_budget: int,
-    *,
-    fullatt_block_indexes: set[int] | frozenset[int] | None = None,
 ) -> None:
     """Re-bind fused infer attention host tensors inside the encoder NPUGraph (parallel to LLM path).
-
-    Qwen2.5-VL: layers listed in ``fullatt_block_indexes`` use ``cu_seqlens`` host endpoints;
-    others use ``cu_window_seqlens``. Those layouts are **not** baked at capture — only here.
 
     This deliberately bypasses :class:`AttentionBackend` — ViT attention is not registered there — but reuses
     the same ``graph_task_update_{begin,end}`` + ``ExternalEvent`` ordering pattern as
@@ -315,8 +202,6 @@ def update_encoder_graph_params(
                 block_table,
                 attn_mask,
                 block_size,
-                uses_sequence_lengths_host,
-                vit_layer_idx,
                 num_kv_heads,
                 num_heads,
                 scale,
@@ -325,11 +210,11 @@ def update_encoder_graph_params(
             ) = packed
 
             num_query_tokens = query.shape[0]
-            actual_seq_lengths_q, actual_seq_lengths_kv = _maybe_compute_actual_seq_lengths(
+            cu_seqlens_cpu = get_encoder_forward_context().cu_seqlens_cpu
+
+            actual_seq_lengths_q, actual_seq_lengths_kv = maybe_compute_actual_seq_lengths(
                 num_query_tokens=num_query_tokens,
-                uses_seq_len_host=uses_sequence_lengths_host,
-                vit_layer_idx=vit_layer_idx,
-                fullatt_block_indexes=fullatt_block_indexes,
+                cu_seqlens=cu_seqlens_cpu,
             )
 
             torch.npu.graph_task_update_begin(update_stream, handle)
@@ -364,9 +249,6 @@ class EncoderAclGraphManager(EncoderCudaGraphManager):
         super().__init__(*args, **kwargs)
         self.graph_pool = current_platform.get_global_graph_pool()
         self.update_stream: torch.npu.Stream | None = None
-        visual = getattr(self.model, "visual", None)
-        fa_raw = getattr(visual, "fullatt_block_indexes", None) if visual is not None else None
-        self.fullatt = frozenset(fa_raw) if fa_raw is not None else None
 
     def capture(self, graph_pool: Any | None = None):
         encoder_graph_pool = graph_pool if graph_pool is not None else self.graph_pool
@@ -413,8 +295,10 @@ class EncoderAclGraphManager(EncoderCudaGraphManager):
             output_buffer = torch.empty_like(output)
 
         graph = torch.npu.NPUGraph()
+        cu_seqlens = values.get("cu_seqlens")
+        cu_seqlens_cpu = None if cu_seqlens is None else cu_seqlens.cpu()
         with (
-            set_encoder_forward_context(token_budget, True),
+            set_encoder_forward_context(token_budget, True, cu_seqlens_cpu),
             torch.inference_mode(),
             torch.npu.graph(graph, self.graph_pool),
         ):
@@ -483,13 +367,8 @@ class EncoderAclGraphManager(EncoderCudaGraphManager):
                 padding_logic = self.config.padding_logics.get(key, self._copy_padded_buffer)
                 padding_logic(buf, src)
 
-        meta = graph_meta.input_buffers
-        cu_seqlens = meta.get("cu_seqlens")
+        cu_seqlens = graph_meta.input_buffers.get("cu_seqlens")
         cu_seqlens_cpu = None if cu_seqlens is None else cu_seqlens.cpu()
-        cu_window_seqlens = meta.get("cu_window_seqlens")
-        cu_window_seqlens_cpu = None if cu_window_seqlens is None else cu_window_seqlens.cpu()
-        seq_lens = meta.get("sequence_lengths")
-        seq_lens_cpu = None if seq_lens is None else seq_lens.cpu()
 
         update_stream = self.update_stream
         if update_stream is None:
@@ -501,10 +380,8 @@ class EncoderAclGraphManager(EncoderCudaGraphManager):
             token_budget,
             False,
             cu_seqlens_cpu=cu_seqlens_cpu,
-            cu_window_seqlens_cpu=cu_window_seqlens_cpu,
-            sequence_lengths_cpu=seq_lens_cpu,
         ):
-            update_encoder_graph_params(update_stream, token_budget, fullatt_block_indexes=self.fullatt)
+            update_encoder_graph_params(update_stream, token_budget)
 
         self.graph_hits += num_items
         return graph_meta.output_buffer

--- a/vllm_ascend/worker/encoder_acl_graph.py
+++ b/vllm_ascend/worker/encoder_acl_graph.py
@@ -161,11 +161,6 @@ def maybe_compute_actual_seq_lengths(
     return filtered, filtered
 
 
-# ---------------------------------------------------------------------------
-# Replay-time FIA task updates
-# ---------------------------------------------------------------------------
-
-
 def update_encoder_graph_params(
     update_stream: torch.npu.Stream,
     token_budget: int,

--- a/vllm_ascend/worker/encoder_acl_graph.py
+++ b/vllm_ascend/worker/encoder_acl_graph.py
@@ -298,7 +298,7 @@ class EncoderAclGraphManager(EncoderCudaGraphManager):
         cu_seqlens = values.get("cu_seqlens")
         cu_seqlens_cpu = None if cu_seqlens is None else cu_seqlens.cpu()
         with (
-            set_encoder_forward_context(token_budget, True, cu_seqlens_cpu),
+            set_encoder_forward_context(token_budget, True, cu_seqlens_cpu=cu_seqlens_cpu),
             torch.inference_mode(),
             torch.npu.graph(graph, self.graph_pool),
         ):


### PR DESCRIPTION
### What this PR does / why we need it?

This PR unifies FIA `actual_seq_lengths` handling for ViT encoder ACL graph across eager, capture, and replay. Previously, `AscendMMEncoderAttention` and `encoder_acl_graph` built sequence lengths independently, which could produce incorrect results for padded `cu_seqlens` and budget-padding trailing zeros.

Fix #10549

Key changes:
- Introduce shared helper `maybe_compute_actual_seq_lengths()` in `encoder_acl_graph.py` to convert `cu_seqlens` → host `list[int]`, filter invalid endpoints, and ensure `actual_seq_lengths[-1] == num_query_tokens`.
- Modified `_maybe_compute_cu_seqlens()` in `AscendMMEncoderAttention` for `None` fallback and CPU normalization.
- Refactor eager/capture/replay paths to use the shared logic; simplify replay context to only `cu_seqlens_cpu`.
- Remove redundant per-layer metadata (`vit_layer_idx`, `fullatt_block_indexes`, `sequence_lengths`, `cu_window_seqlens`) and use `self.scale` instead of `scale_value`.

```mermaid
flowchart TB
    direction TB
    Before["Before: duplicated paths"] --> E1[cu_seqlens / sequence_lengths / cu_window_seqlens]
    E1 --> E2[AscendMMEncoderAttention<br/>local convert + per-layer metadata]
    E2 --> E3[_pad_actual_seq_lengths_for_fia]
    Before --> R1[cu_seqlens_cpu / cu_window_seqlens_cpu<br/>sequence_lengths_cpu + fullatt_block_indexes]
    R1 --> R2[encoder_acl_graph<br/>_maybe_compute_actual_seq_lengths]
    R2 --> R3[_pad_actual_seq_lengths_for_fia]
    E3 --> FIA1[FIA]
    R3 --> FIA1
    After["After: shared pipeline"] --> IN[cu_seqlens]
    IN --> BUILD[maybe_compute_actual_seq_lengths<br/>filter + budget align]
    BUILD --> EAGER[eager / capture]
    BUILD --> REPLAY[replay via cu_seqlens_cpu context]
    EAGER --> FIA2[FIA actual_seq_lengths]
    REPLAY --> FIA2
```

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

- The following UT added.
  - `tests/ut/worker/test_encoder_acl_graph.py`
  - `tests/ut/ops/test_mm_encoder_attention.py`
- Also test on `Qwen/Qwen3.6-27B`

```diff
| dataset | version | metric | mode | vllm-api-stream-chat |
|----- | ----- | ----- | ----- | -----|
- | videomme | 2f2602 | [Overall][overall] | gen | 67.78 |
+ | videomme | 2f2602 | [Overall][overall] | gen | 68.85 |
```


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
