### PR TITLE
[BugFix] Restrict kv block zeroer for qwen3x+eagle3+num_spec>1 only

### DIFF
--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -927,14 +927,22 @@ class NPUWorker(WorkerBase):
         with context:
             self.model_runner.initialize_kv_cache(kv_cache_config)
 
-            # Build KV-zero metadata outside the CuMem pool so the bookkeeping
-            # GPU tensors (seg_addrs, block-id buffers) use the standard PyTorch
-            # allocator and are not discarded during sleep/wake cycles.
+            # Restrict to mamba and full attn hybrid models (e.g. Qwen3.x).
+            #
+            # When eagle3 is enabled with num_speculative_tokens>1, mamba blocks may be reallocated to full blocks if
+            # the target and draft models share the same kv cache tensor (e.g. unaligned full attn layers with
+            # different num_kv_heads and head_size). In addition, for performance reasons, the current mtp/eagle path
+            # does not update seq_lens_cpu with num_rejected_tokens for step>1, since it would require d2h sync. As a
+            # result, seq_lens_cpu can become stale and some blocks will be unintentionally used.
+            #
+            # If an uncleared mamba block is later reused, the stale state combined with the incorrect seq_lens_cpu may
+            # lead to NaNs and reduced acceptance rate.
             if (
                 kv_cache_config.needs_kv_cache_zeroing
                 and hasattr(self.model_runner, "_init_kv_zero_meta")
                 and self.vllm_config is not None
                 and self.vllm_config.speculative_config is not None
+                and self.vllm_config.speculative_config.method == "eagle3"
                 and self.vllm_config.speculative_config.num_speculative_tokens > 1
             ):
                 self.model_runner._init_kv_zero_meta()


### PR DESCRIPTION
### What this PR does / why we need it?
This PR aims to add usage constraint of kv block zeroer for qwen3x+eagle3+num_spec>1 only. The reason is illustrated in details in the comment. That is, when eagle3 is enabled with num_speculative_tokens>1, mamba blocks may be reallocated to full blocks if the target and draft models share the same kv cache tensor (e.g. unaligned full attn layers with different num_kv_heads and head_size). In addition, for performance reasons, the current mtp/eagle path does not update seq_lens_cpu with num_rejected_tokens for step>1, since it would require d2h sync. As a result, seq_lens_cpu can become stale and some blocks will be unintentionally used. If an uncleared mamba block is later reused, the stale state combined with the incorrect seq_lens_cpu may lead to NaNs and reduced acceptance rate.

Since mtp and dflash do not need this, we apply this for eagle3 only by explicitly specifying it.

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
by ci

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
