### PR TITLE
request_num leaks on user cancellation before generate_stream()

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -817,6 +817,9 @@ async def _handle_completions(api: str, request: Request):
         # Determine the correct media type based on stream flag
         media_type = "text/event-stream; charset=utf-8" if stream_flag else "application/json"
         return StreamingResponse(generate_stream(), media_type=media_type)
+    except asyncio.CancelledError:
+        proxy_state.request_num -= 1
+        raise
     except Exception as e:
         import traceback
 


### PR DESCRIPTION
### What this PR does / why we need it?
In our production scenario, the proxy relies on request_num to enforce rate limiting by capping concurrent requests via MAX_CONCURRENT_REQUESTS. After running for some time, we observed that request_num had grown far beyond the actual number of in-flight requests. Investigation revealed that requests cancelled before entering generate_stream() did not decrement request_num as expected—the counter leaked by one each time. Over time, this accumulated leak caused the proxy to incorrectly reject new requests even when the system was lightly loaded.
The reason is:
In Python 3.11+, asyncio.CancelledError inherits from BaseException instead of Exception, meaning it bypasses the existing except Exception handler. When a client disconnects before generate_stream() is registered (i.e., between the request_num += 1 at the top of _handle_completions and the return StreamingResponse(...)), the cancellation propagates uncaught, leaving proxy_state.request_num permanently incremented.

### Does this PR introduce _any_ user-facing change?
No. This is a bugfix that ensures the internal request counter remains accurate under client disconnection. Behavior is unchanged for Python ≤ 3.10 (where CancelledError was already caught by except Exception and the old code happened to work correctly by accident).

### How was this patch tested?
Reviewed the control flow manually across all exit paths . Confirmed on Python 3.11+ that asyncio.CancelledError is a subclass of BaseException, not Exception, and verified the fix properly catches it before the generic except Exception clause.
- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
