### PR TITLE
[CI]Adjust the dp_size and tp_size in the decode stage to 4 respectively

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-A22B-Mooncake-Layerwise.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-A22B-Mooncake-Layerwise.yaml
@@ -50,8 +50,8 @@ deployment:
                           "tp_size": 8
                   },
                   "decode": {
-                          "dp_size": 4,
-                          "tp_size": 4
+                          "dp_size": 2,
+                          "tp_size": 8
                   }
             }
         }'
@@ -62,11 +62,11 @@ deployment:
         vllm serve "Qwen/Qwen3-235B-A22B"
         --host 0.0.0.0
         --port $SERVER_PORT
-        --data-parallel-size 2
-        --data-parallel-size-local 2
+        --data-parallel-size 4
+        --data-parallel-size-local 4
         --data-parallel-address $MASTER_IP
         --data-parallel-rpc-port 13389
-        --tensor-parallel-size 8
+        --tensor-parallel-size 4
         --seed 1024
         --max-num-seqs 16
         --max-model-len 8192
@@ -82,8 +82,8 @@ deployment:
         "kv_port": "30200",
         "kv_connector_extra_config": {
                   "prefill": {
-                          "dp_size": 2,
-                          "tp_size": 8
+                          "dp_size": 4,
+                          "tp_size": 4
                   },
                   "decode": {
                           "dp_size": 4,

--- a/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-A22B-Mooncake-Layerwise.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-A22B-Mooncake-Layerwise.yaml
@@ -39,7 +39,6 @@ deployment:
         --trust-remote-code
         --no-enable-prefix-caching
         --gpu-memory-utilization 0.9
-        --additional-config '{"recompute_scheduler_enable": true,"enable_shared_expert_dp": true}'
         --kv-transfer-config
         '{"kv_connector": "MooncakeLayerwiseConnector",
         "kv_role": "kv_producer",
@@ -62,20 +61,21 @@ deployment:
         vllm serve "Qwen/Qwen3-235B-A22B"
         --host 0.0.0.0
         --port $SERVER_PORT
-        --data-parallel-size 2
-        --data-parallel-size-local 2
+        --data-parallel-size 4
+        --data-parallel-size-local 4
         --data-parallel-address $MASTER_IP
         --data-parallel-rpc-port 13389
-        --tensor-parallel-size 8
+        --tensor-parallel-size 4
         --seed 1024
-        --max-num-seqs 16
+        --max-num-seqs 32
         --max-model-len 8192
         --max-num-batched-tokens 8192
         --enable-expert-parallel
         --trust-remote-code
         --no-enable-prefix-caching
         --gpu-memory-utilization 0.9
-        --additional-config '{"torchair_graph_config":{"enabled":true}}'
+        --async-scheduling
+        --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
         --kv-transfer-config
         '{"kv_connector": "MooncakeLayerwiseConnector",
         "kv_role": "kv_consumer",
@@ -102,7 +102,7 @@ benchmarks:
     max_out_len: 1500
     batch_size: 700
     request_rate: 11.2
-    baseline: 183
+    baseline: 2046
     threshold: 0.97
   acc:
     case_type: accuracy

--- a/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-A22B-Mooncake-Layerwise.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-A22B-Mooncake-Layerwise.yaml
@@ -50,8 +50,8 @@ deployment:
                           "tp_size": 8
                   },
                   "decode": {
-                          "dp_size": 2,
-                          "tp_size": 8
+                          "dp_size": 4,
+                          "tp_size": 4
                   }
             }
         }'
@@ -68,7 +68,7 @@ deployment:
         --data-parallel-rpc-port 13389
         --tensor-parallel-size 4
         --seed 1024
-        --max-num-seqs 16
+        --max-num-seqs 32
         --max-model-len 8192
         --max-num-batched-tokens 8192
         --enable-expert-parallel
@@ -82,8 +82,8 @@ deployment:
         "kv_port": "30200",
         "kv_connector_extra_config": {
                   "prefill": {
-                          "dp_size": 4,
-                          "tp_size": 4
+                          "dp_size": 2,
+                          "tp_size": 8
                   },
                   "decode": {
                           "dp_size": 4,

--- a/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-A22B-Mooncake-Layerwise.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-A22B-Mooncake-Layerwise.yaml
@@ -39,7 +39,6 @@ deployment:
         --trust-remote-code
         --no-enable-prefix-caching
         --gpu-memory-utilization 0.9
-        --additional-config '{"recompute_scheduler_enable": true,"enable_shared_expert_dp": true}'
         --kv-transfer-config
         '{"kv_connector": "MooncakeLayerwiseConnector",
         "kv_role": "kv_producer",
@@ -75,7 +74,8 @@ deployment:
         --trust-remote-code
         --no-enable-prefix-caching
         --gpu-memory-utilization 0.9
-        --additional-config '{"torchair_graph_config":{"enabled":true}}'
+        --async-scheduling
+        --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
         --kv-transfer-config
         '{"kv_connector": "MooncakeLayerwiseConnector",
         "kv_role": "kv_consumer",

--- a/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-A22B-Mooncake-Layerwise.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-A22B-Mooncake-Layerwise.yaml
@@ -50,8 +50,8 @@ deployment:
                           "tp_size": 8
                   },
                   "decode": {
-                          "dp_size": 2,
-                          "tp_size": 8
+                          "dp_size": 4,
+                          "tp_size": 4
                   }
             }
         }'
@@ -86,8 +86,8 @@ deployment:
                           "tp_size": 8
                   },
                   "decode": {
-                          "dp_size": 2,
-                          "tp_size": 8
+                          "dp_size": 4,
+                          "tp_size": 4
                   }
             }
         }'


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adjusts the dp_size and tp_size in the decode stage to 4 respectively and revise the performance baseline in the Qwen3-235B-A22B-Mooncake-Layerwise configuration file.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Tested via nightly CI pipelines with the updated configuration files.

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
