### PR TITLE
[BugFix] Fix Error when GLM5 MTP layer has BF16 weights

### DIFF
--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1255,9 +1255,8 @@ class AscendSFAImpl(MLAAttentionImpl):
                         if is_hidden_layer(layer):
                             reach_layer_for_shard_weight_series(layer)
                 elif full_gather_o_proj_enabled:
-                    _, o_proj_full_handle = all_gather_async(
-                        self.o_proj_tp_weight, get_tp_group(), output=AscendSFAImpl.o_proj_full_pool
-                    )
+                    pool, o_proj_full_handle = all_gather_async(self.o_proj_tp_weight, get_tp_group())
+                    AscendSFAImpl.o_proj_full_pool = pool
 
                 if kv_cache is not None:
                     assert fused_kv_no_split is not None


### PR DESCRIPTION
### What this PR does / why we need it?

- Root Cause:

  o_proj_full_pool is a class-level attribute of AscendSFAImpl, so a single buffer is shared across every model instance (main model + MTP drafters) and is allocated only once — during the main model's process_weights_after_loading, using self.o_proj.weight.dtype. In the full_gather_o_proj_enabled path this pool is passed explicitly as the output of all_gather_async. The helper only auto-allocates when output is None; when an output is supplied it is used as-is with no dtype check. So the all-gather output is forever locked to the main model's dtype.

  The MTP drafter is a separate model instance carrying a different quantization dtype (w8a8 → int8, bf16 → bfloat16). When the drafter runs the same all-gather, dist.all_gather_into_tensor sees output.dtype (int32) != input.dtype (int8 / bfloat16) and aborts:

  RuntimeError: output tensor must have the same type as input tensor

- Fix:

  Stop passing the shared, fixed-dtype pool as the all-gather output. Let all_gather_async allocate the output internally from input.dtype, then assign the new tensor back to the shared pool for the later set_():

  With output=None, the helper runs output = torch.empty(..., dtype=input.dtype, ...), so output.dtype == input.dtype is guaranteed regardless of which instance is running — main model (int32), w8a8 drafter (int8), or bf16 drafter (bfloat16). The dtype mismatch is eliminated at the source rather than worked around, which is why the same change fixes all non-matching drafter dtypes at once.



### Does this PR introduce _any_ user-facing change?
NO
### How was this patch tested?

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
