### PR TITLE
[CI]fix deepseek long seq nightly

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-R1-W8A8-longseq.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-R1-W8A8-longseq.yaml
@@ -37,7 +37,7 @@ deployment:
           --enable-expert-parallel
           --seed 1024
           --quantization ascend
-          --max-num-seqs 3
+          --max-num-seqs 32
           --max-model-len 32768
           --max-num-batched-tokens 16384
           --trust-remote-code
@@ -75,7 +75,7 @@ deployment:
         --enable-expert-parallel
         --seed 1024
         --quantization ascend
-        --max-num-seqs 8
+        --max-num-seqs 32
         --max-model-len 32768
         --max-num-batched-tokens 256
         --trust-remote-code
@@ -106,7 +106,7 @@ benchmarks:
     dataset_path: vllm-ascend/gsm8k
     request_conf: vllm_api_general_chat
     dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_chat_prompt
-    max_out_len: 24576
+    max_out_len: 4096
     batch_size: 16
     baseline: 95
     threshold: 5


### PR DESCRIPTION
### What this PR does / why we need it?
fix deepseek long seq nightly

Increase the concurrency size and reduce the number of output tokens.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

pcik-from: https://github.com/vllm-project/vllm-ascend/pull/10767

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
