### PR TITLE
[BugFix] Pad actual_seq_lengths with 0 for EOD scenario in npu_fusion_attention

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -883,9 +883,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
         # use default sparse_mode 0 in normal scenario, which means no mask works on it
         # Ensure actual_seq_qlen and actual_seq_kvlen end with 0 for EOD scenario
         actual_seq_qlen = attn_metadata.actual_seq_lengths_q
-        if actual_seq_qlen and actual_seq_qlen[-1] != 0:
+        if query.shape[0] > actual_seq_qlen[-1]:
             actual_seq_qlen = actual_seq_qlen + [0]
-        actual_seq_kvlen = actual_seq_qlen
         return torch_npu.npu_fusion_attention(
             query=query,
             key=key,
@@ -894,7 +893,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             input_layout="TND",
             scale=self.scale,
             actual_seq_qlen=actual_seq_qlen,
-            actual_seq_kvlen=actual_seq_kvlen,
+            actual_seq_kvlen=actual_seq_qlen,
         )[0]
 
     def reshape_and_cache(

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -881,6 +881,11 @@ class AscendAttentionBackendImpl(AttentionImpl):
         _: torch.Tensor,
     ) -> torch.Tensor:
         # use default sparse_mode 0 in normal scenario, which means no mask works on it
+        # Ensure actual_seq_qlen and actual_seq_kvlen end with 0 for EOD scenario
+        actual_seq_qlen = attn_metadata.actual_seq_lengths_q
+        if actual_seq_qlen and actual_seq_qlen[-1] != 0:
+            actual_seq_qlen = actual_seq_qlen + [0]
+        actual_seq_kvlen = actual_seq_qlen
         return torch_npu.npu_fusion_attention(
             query=query,
             key=key,
@@ -888,8 +893,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
             head_num=self.num_heads,
             input_layout="TND",
             scale=self.scale,
-            actual_seq_qlen=attn_metadata.actual_seq_lengths_q,
-            actual_seq_kvlen=attn_metadata.actual_seq_lengths_q,
+            actual_seq_qlen=actual_seq_qlen,
+            actual_seq_kvlen=actual_seq_kvlen,
         )[0]
 
     def reshape_and_cache(


### PR DESCRIPTION
### What this PR does / why we need it?
On CANN 9.0, a strict validation was added for EOD in npu_fusion_attention. The actual_seq_qlen and actual_seq_kvlen parameters must end with 0 to pass the validation.
In the current fuse_attention path, when handling EOD scenarios, these parameters may not end with 0, causing npu_fusion_attention call to fail on CANN 9.0.

#### EOD:
When the last batch item's actual sequence length does not account for all remaining tokens — specifically when:
T_q > actualSeqQLen[-1] (sum of actual_seq_qlen is less than total query tokens)
T_kv > actualSeqKvLen[-1] (sum of actual_seq_kvlen is less than total kv tokens)
This means there are trailing tokens that belong to an "end-of-document" padding region beyond the described sequences. For the npu_fusion_attention operator, this is the EOD scenario — the actual_seq_qlen and actual_seq_kvlen arrays must explicitly end with a 0 to signal the end of document to the CANN runtime.

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?


- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
