### PR TITLE
fix: expand actual_seq_lengths_q/kv for C8 KV cache + EAGLE3 speculative decoding

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -624,6 +624,15 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     else:
                         seq_lens = attn_metadata[key].seq_lens_list
                         actual_seq_lengths_q = attn_metadata[key].actual_seq_lengths_q
+                        # BNSD layout with speculative decoding: expand
+                        # per-sequence actual_seq_lengths to per-token.
+                        if (c8_k_aq_scale is not None
+                                and num_tokens > len(actual_seq_lengths_q)):
+                            tokens_per_seq = num_tokens // len(seq_lens)
+                            actual_seq_lengths_q = [
+                                l for l in seq_lens
+                                for _ in range(tokens_per_seq)
+                            ]
                         # NOTE:
                         # For models with sliding-window attention on the FIA full-graph replay path,
                         # rebinding `block_tables` to the latest metadata tensor causes corrupted /
@@ -704,6 +713,17 @@ class AscendAttentionBackendImpl(AttentionImpl):
         else:
             graph_params = get_graph_params()
         actual_seq_lengths_q = attn_metadata.actual_seq_lengths_q
+        # BNSD layout with speculative decoding: FIA expects
+        # len(actual_seq_lengths) >= num_tokens or == 1.
+        # actual_seq_lengths_q is per-sequence (from query_start_loc[1:]),
+        # but num_tokens > batch_size when spec_tokens > 0.
+        if (self.enable_c8_quant
+                and num_tokens > len(actual_seq_lengths_q)):
+            per_seq_lens = attn_metadata.seq_lens_list
+            tokens_per_seq = num_tokens // len(per_seq_lens)
+            actual_seq_lengths_q = [
+                l for l in per_seq_lens for _ in range(tokens_per_seq)
+            ]
         # Prepare tensors for attention output
         # TODO: Refactor this to step-level instead of layer-level
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -633,6 +633,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
                                 l for l in seq_lens
                                 for _ in range(tokens_per_seq)
                             ]
+                            seq_lens = [
+                                l for l in seq_lens
+                                for _ in range(tokens_per_seq)
+                            ]
                         # NOTE:
                         # For models with sliding-window attention on the FIA full-graph replay path,
                         # rebinding `block_tables` to the latest metadata tensor causes corrupted /
@@ -723,6 +727,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
             tokens_per_seq = num_tokens // len(per_seq_lens)
             actual_seq_lengths_q = [
                 l for l in per_seq_lens for _ in range(tokens_per_seq)
+            ]
+            actual_seq_lengths_kv = [
+                l for l in actual_seq_lengths_kv for _ in range(tokens_per_seq)
             ]
         # Prepare tensors for attention output
         # TODO: Refactor this to step-level instead of layer-level

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -1111,6 +1111,15 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 self.layerIndex, attn_metadata.kvcomp_metadata, query, passed_key, block_table, actual_seq_lengths_kv
             )
         num_tokens = attn_metadata.actual_seq_lengths_q[-1]
+        # Fix for draft model decode: attention metadata is built with
+        # target model's uniform_decode_query_len (num_speculative_steps + 1
+        # tokens/request), but draft model decode processes only 1 token
+        # per request. Correct num_tokens to match query tensor T dimension.
+        if (_EXTRA_CTX.is_draft_model
+                and not _EXTRA_CTX.is_draft_model_prefill
+                and num_tokens != query.shape[0]):
+            num_tokens = query.shape[0]
+            attn_metadata.actual_seq_lengths_q = list(range(1, num_tokens + 1))
         query = query[:num_tokens]
         if (
             attn_metadata.attn_state == AscendAttentionState.PrefillNoCache

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -709,6 +709,16 @@ class AscendAttentionBackendImpl(AttentionImpl):
             )
 
         num_tokens = attn_metadata.actual_seq_lengths_q[-1]
+        # Fix for draft model decode graph capture: the attention metadata
+        # is built with the target model's uniform_decode_query_len
+        # (num_speculative_steps + 1 tokens/request), but the draft model
+        # decode processes only 1 token per request. Correct
+        # actual_seq_lengths_q to match the actual query tensor T dimension.
+        if (_EXTRA_CTX.is_draft_model
+                and not _EXTRA_CTX.is_draft_model_prefill
+                and num_tokens != query.shape[0]):
+            num_tokens = query.shape[0]
+            attn_metadata.actual_seq_lengths_q = list(range(1, num_tokens + 1))
         if _EXTRA_CTX.is_draft_model:
             if _EXTRA_CTX.is_draft_model_prefill:
                 graph_params = get_draft_graph_prefill_params()

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -708,7 +708,14 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 self.layerIndex, attn_metadata.kvcomp_metadata, query, passed_key, block_table, actual_seq_lengths_kv
             )
 
-        num_tokens = attn_metadata.actual_seq_lengths_q[-1]
+        num_tokens_before = attn_metadata.actual_seq_lengths_q[-1]
+        is_dm = _EXTRA_CTX.is_draft_model
+        is_dm_pf = _EXTRA_CTX.is_draft_model_prefill
+        print(f"[DEBUG full_graph_fia] BEFORE fix: num_tokens={num_tokens_before}, query.shape[0]={query.shape[0]}, "
+              f"is_dm={is_dm}, is_dm_pf={is_dm_pf}, actual_seq_q[-1]={attn_metadata.actual_seq_lengths_q[-1]}, "
+              f"len(actual_seq_q)={len(attn_metadata.actual_seq_lengths_q)}, "
+              f"seq_lens_list={attn_metadata.seq_lens_list}", flush=True)
+        num_tokens = num_tokens_before
         # Fix for draft model decode graph capture: the attention metadata
         # is built with the target model's uniform_decode_query_len
         # (num_speculative_steps + 1 tokens/request), but the draft model
@@ -719,6 +726,12 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 and num_tokens != query.shape[0]):
             num_tokens = query.shape[0]
             attn_metadata.actual_seq_lengths_q = list(range(1, num_tokens + 1))
+            print(f"[DEBUG full_graph_fia] FIX APPLIED: num_tokens corrected {num_tokens_before} -> {num_tokens}", flush=True)
+        else:
+            cond1 = bool(_EXTRA_CTX.is_draft_model)
+            cond2 = not _EXTRA_CTX.is_draft_model_prefill
+            cond3 = num_tokens_before != query.shape[0]
+            print(f"[DEBUG full_graph_fia] FIX SKIPPED: conds(is_dm={cond1}, not_is_dm_pf={cond2}, size_mismatch={cond3})", flush=True)
         if _EXTRA_CTX.is_draft_model:
             if _EXTRA_CTX.is_draft_model_prefill:
                 graph_params = get_draft_graph_prefill_params()
@@ -1092,6 +1105,11 @@ class AscendAttentionBackendImpl(AttentionImpl):
         # runner v2, there is not capturing attribute in forward_context,
         # just use getattr to avoid attribute error.
         if _EXTRA_CTX.capturing:
+            is_dm = _EXTRA_CTX.is_draft_model
+            is_dm_pf = _EXTRA_CTX.is_draft_model_prefill
+            print(f"[DEBUG full_graph dispatch] capturing=True, is_dm={is_dm}, is_dm_pf={is_dm_pf}, "
+                  f"query.shape={query.shape}, actual_seq_q[-1]={attn_metadata.actual_seq_lengths_q[-1]}, "
+                  f"attn_state={attn_metadata.attn_state}", flush=True)
             if self.sinks is not None:
                 attn_output, num_tokens = self.full_graph_fia_v2(query, key, value, attn_metadata, output)
                 output[:num_tokens] = attn_output[:num_tokens]
@@ -1110,7 +1128,14 @@ class AscendAttentionBackendImpl(AttentionImpl):
             block_table, actual_seq_lengths_kv = get_kvcomp_decode_params(
                 self.layerIndex, attn_metadata.kvcomp_metadata, query, passed_key, block_table, actual_seq_lengths_kv
             )
-        num_tokens = attn_metadata.actual_seq_lengths_q[-1]
+        num_tokens_before = attn_metadata.actual_seq_lengths_q[-1]
+        is_dm = _EXTRA_CTX.is_draft_model
+        is_dm_pf = _EXTRA_CTX.is_draft_model_prefill
+        print(f"[DEBUG eager_path] BEFORE fix: num_tokens={num_tokens_before}, query.shape[0]={query.shape[0]}, "
+              f"is_dm={is_dm}, is_dm_pf={is_dm_pf}, "
+              f"actual_seq_q[-1]={attn_metadata.actual_seq_lengths_q[-1]}, "
+              f"attn_state={attn_metadata.attn_state}", flush=True)
+        num_tokens = num_tokens_before
         # Fix for draft model decode: attention metadata is built with
         # target model's uniform_decode_query_len (num_speculative_steps + 1
         # tokens/request), but draft model decode processes only 1 token
@@ -1120,6 +1145,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 and num_tokens != query.shape[0]):
             num_tokens = query.shape[0]
             attn_metadata.actual_seq_lengths_q = list(range(1, num_tokens + 1))
+            print(f"[DEBUG eager_path] FIX APPLIED: num_tokens corrected {num_tokens_before} -> {num_tokens}", flush=True)
+        else:
+            print(f"[DEBUG eager_path] FIX SKIPPED: conds(is_dm={bool(is_dm)}, not_is_dm_pf={not is_dm_pf}, "
+                  f"size_mismatch={num_tokens_before != query.shape[0]})", flush=True)
         query = query[:num_tokens]
         if (
             attn_metadata.attn_state == AscendAttentionState.PrefillNoCache

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -143,10 +143,12 @@ class ModelWithContext(nn.Module):
         # when capturing, we need to set capturing=True in forward context.
         if torch.npu.is_current_stream_capturing():
             _EXTRA_CTX.capturing = True
-        if self.is_draft_model:
-            _EXTRA_CTX.is_draft_model = True
-        if self.is_draft_model_prefill:
-            _EXTRA_CTX.is_draft_model_prefill = True
+        # Always set flags explicitly — conditional True-only assignment
+        # would leave stale values from prior forward passes (e.g. prefill
+        # capture sets is_draft_model_prefill=True, then decode capture
+        # never resets it to False, breaking downstream checks).
+        _EXTRA_CTX.is_draft_model = self.is_draft_model
+        _EXTRA_CTX.is_draft_model_prefill = self.is_draft_model_prefill
 
         return self.original_model(*args, **kwargs)
 

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -141,7 +141,8 @@ class ModelWithContext(nn.Module):
     def forward(self, *args, **kwargs):
         # In warmup phase, capturing=False by default.
         # when capturing, we need to set capturing=True in forward context.
-        if torch.npu.is_current_stream_capturing():
+        is_capturing = torch.npu.is_current_stream_capturing()
+        if is_capturing:
             _EXTRA_CTX.capturing = True
         # Always set flags explicitly — conditional True-only assignment
         # would leave stale values from prior forward passes (e.g. prefill
@@ -149,6 +150,9 @@ class ModelWithContext(nn.Module):
         # never resets it to False, breaking downstream checks).
         _EXTRA_CTX.is_draft_model = self.is_draft_model
         _EXTRA_CTX.is_draft_model_prefill = self.is_draft_model_prefill
+        print(f"[DEBUG ModelWithContext.forward] is_capturing={is_capturing}, "
+              f"is_dm={self.is_draft_model}, is_dm_pf={self.is_draft_model_prefill}, "
+              f"capturing_flag={_EXTRA_CTX.capturing}", flush=True)
 
         return self.original_model(*args, **kwargs)
 


### PR DESCRIPTION
## Summary
- Fix FIA kernel crash when combining C8 KV cache quantization (BNSD layout) with EAGLE3 speculative decoding (`--spec-tokens 3`)
- FIA V3/V4 requires `actual_seq_lengths` and `actual_seq_lengths_kv` size >= `num_tokens` (or == 1) in BNSD layout
- With EAGLE3, `num_tokens` (e.g., 128) exceeds `batch_size` (e.g., 32), but per-sequence lists only have `batch_size` entries
- Expand both `actual_seq_lengths_q` and `actual_seq_lengths_kv`/`seq_lens` from per-sequence to per-token in:
  - `full_graph_fia` (graph capture path)
  - `update_graph_params` (graph replay path)

## Test plan
- [ ] Run vLLM with `--quantization ascend --spec-method eagle3 --spec-tokens 3` on Ascend NPU
- [ ] Verify no FIA tiling error (`actual_seq_lengths size[...] should be greater than q batch[...] or equal to 1`)
- [ ] Verify inference output is not garbled in `FULL_DECODE_ONLY` cudagraph mode

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
