### PR TITLE
[Test] Enable default graph mode and set max cudagraph capture size to fix test case

### DIFF
--- a/tests/e2e/pull_request/one_card/spec_decode/test_suffix.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/test_suffix.py
@@ -23,10 +23,7 @@ def test_suffix_acceptance(
             "num_speculative_tokens": 10,
         },
         max_model_len=1024,
-        compilation_config={
-            "cudagraph_mode": "PIECEWISE",
-            "cudagraph_capture_sizes": [1, 2, 4, 8],
-        },
+        max_cudagraph_capture_size=16,
         disable_log_stats=False,
     ) as runner:
         for i in range(10):


### PR DESCRIPTION
### What this PR does / why we need it?
For the test case `test_suffix_acceptance`:
1. Switches it to use the default graph mode `FULL_AND_PIECEWISE`.
2. Sets `max_cudagraph_capture_size=16` to fix a previous failure due to oversized graph captures.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Ran `test_suffix_acceptance` locally with the changes applied and verified it passes.
- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
