### PR TITLE
Revert "[BugFix][SpecDecode] Fix low MTP acceptance rate for SFA+DSA_CP (MTP>1) (#10825)"

### DIFF
--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -200,11 +200,6 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
 
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1
-        max_num_reqs = vllm_config.scheduler_config.max_num_seqs
-        self.actual_seq_lengths_query = torch.zeros(max_num_reqs + 1, dtype=torch.int32, device=device)
-        self.actual_seq_lengths_key = torch.empty_like(self.actual_seq_lengths_query)
-        self.spec_actual_seq_lengths_query: list[torch.Tensor] | None = None
-        self.spec_actual_seq_lengths_key: list[torch.Tensor] | None = None
         if self.speculative_config:
             spec_token_num = self.speculative_config.num_speculative_tokens
             self.decode_threshold += spec_token_num
@@ -213,19 +208,14 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
                 npu_fused_infer_attention_score TND layout's limit of 16, \
                 got {self.decode_threshold}"
             )
-            self.spec_actual_seq_lengths_query = [
-                torch.zeros(max_num_reqs * (spec_token_num + 1) + 1, dtype=torch.int32, device=device)
-                for _ in range(spec_token_num)
-            ]
-            self.spec_actual_seq_lengths_key = [
-                torch.zeros(max_num_reqs * (spec_token_num + 1) + 1, dtype=torch.int32, device=device)
-                for _ in range(spec_token_num)
-            ]
-
         self.reorder_batch_threshold = self.decode_threshold
         self.attn_mask_builder = AttentionMaskBuilder(self.device)
         self.rope_dim = self.model_config.hf_text_config.qk_rope_head_dim
         self.enable_dsa_cp = enable_dsa_cp()
+
+        max_num_reqs = vllm_config.scheduler_config.max_num_seqs
+        self.actual_seq_lengths_query = torch.zeros(max_num_reqs + 1, dtype=torch.int32, device=device)
+        self.actual_seq_lengths_key = torch.empty_like(self.actual_seq_lengths_query)
 
     @staticmethod
     def determine_chunked_prefill_workspace_size(vllm_config: VllmConfig) -> int:
@@ -251,22 +241,6 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
         common_attn_metadata: AscendCommonAttentionMetadata,
         fast_build: bool = False,
     ) -> AscendSFAMetadata:
-        # common_prefix_len / fast_build are unused; kept for API compatibility.
-        return self._build(common_attn_metadata, draft_step=None)
-
-    def build_for_drafting(
-        self,
-        draft_step: int,
-        common_attn_metadata: AscendCommonAttentionMetadata,
-        **kwargs,
-    ) -> AscendSFAMetadata:
-        return self._build(common_attn_metadata, draft_step=draft_step)
-
-    def _build(
-        self,
-        common_attn_metadata: AscendCommonAttentionMetadata,
-        draft_step: int | None = None,
-    ) -> AscendSFAMetadata:
         num_reqs = common_attn_metadata.num_reqs
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         num_input_tokens = common_attn_metadata.num_input_tokens
@@ -291,7 +265,7 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
         else:
             seq_lens_cpu = common_attn_metadata.seq_lens[:num_reqs].to("cpu")
 
-        cos, sin = get_cos_and_sin_mla(input_positions, use_cache=(draft_step is None))
+        cos, sin = get_cos_and_sin_mla(input_positions, True)
 
         dsa_cp_context = None
         if self.enable_dsa_cp:
@@ -333,16 +307,8 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
                     got {slot_mapping.shape[0]} and {num_tokens_pad}"
             )
 
-            if draft_step is not None:
-                assert self.spec_actual_seq_lengths_query is not None
-                assert self.spec_actual_seq_lengths_key is not None
-                # Per-draft-step buffers: independent, graph-stable storage so
-                # later draft steps don't clobber earlier ones' metadata.
-                actual_seq_lengths_query = self.spec_actual_seq_lengths_query[draft_step - 1]
-                actual_seq_lengths_key = self.spec_actual_seq_lengths_key[draft_step - 1]
-            else:
-                actual_seq_lengths_query = self.actual_seq_lengths_query
-                actual_seq_lengths_key = self.actual_seq_lengths_key
+            actual_seq_lengths_query = self.actual_seq_lengths_query
+            actual_seq_lengths_key = self.actual_seq_lengths_key
 
             num_segs = cum_query_lens.shape[0]
             last_token = 0

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1652,13 +1652,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 common_attn_metadata,
                 **extra_attn_metadata_args,
             )
-        elif hasattr(attn_metadata_builder, "build_for_drafting"):
-            # e.g. SFA (dsa_cp): route draft steps through a draft-aware build so
-            # per-draft-step buffers are used and cross-step aliasing is avoided.
-            attn_metadata = attn_metadata_builder.build_for_drafting(
-                draft_step,
-                common_attn_metadata,
-            )
         else:
             attn_metadata = attn_metadata_builder.build(
                 0,


### PR DESCRIPTION
### What this PR does / why we need it?
This reverts commit 21e8dcf64f6f8795d9323a97a6c02431cd84d7db, which breaks tests/e2e/pull_request/two_card/spec_decode/test_spec_decode.py::test_qwen3_eagle3_pcp2_tp1

error log:
```
tests/e2e/pull_request/two_card/spec_decode/test_spec_decode.py::test_qwen3_eagle3_pcp2_tp1 2026-06-24 01:32:52,180 - 8966 - ServiceProfiler - INFO - VLLM_USE_V1 not set, auto-detected via vLLM 0.1.dev1+g967c5c3bc.empty: default 0
  [2026-06-24 01:32:52.204295][UC][I] Registered model loader `<class 'vllm_ascend.model_loader.netloader.netloader.ModelNetLoaderElastic'>` with load format `netloader` [8966,8966][__init__.py:115,_wrapper]
  [2026-06-24 01:32:52.273040][UC][I] Registered model loader `<class 'vllm_ascend.model_loader.rfork.rfork_loader.RForkModelLoader'>` with load format `rfork` [8966,8966][__init__.py:115,_wrapper]
  2026-06-24 01:32:52,287 - modelscope - WARNING - We can not confirm the cached file is for revision: master
  [2026-06-24 01:32:52.290674][UC][I] HF_HUB_OFFLINE is True, replace model_id [Qwen/Qwen3-8B] to model_path [/root/.cache/modelscope/hub/models/Qwen/Qwen3-8B] [8966,8966][arg_utils.py:757,__post_init__]
  [2026-06-24 01:32:52.306402][UC][I] non-default args: {'trust_remote_code': True, 'max_model_len': 2048, 'distributed_executor_backend': 'mp', 'prefill_context_parallel_size': 2, 'block_size': 16, 'gpu_memory_utilization': 0.7, 'max_num_seqs': 256, 'enforce_eager': True, 'enable_chunked_prefill': True, 'speculative_config': {'method': 'eagle3', 'num_speculative_tokens': 3, 'model': 'RedHatAI/Qwen3-8B-speculator.eagle3'}, 'model': '/root/.cache/modelscope/hub/models/Qwen/Qwen3-8B'} [8966,8966][api_utils.py:273,log_non_default_args]
  [2026-06-24 01:32:52.339167][UC][I] Resolved architecture: Qwen3ForCausalLM [8966,8966][model.py:611,__post_init__]
  [2026-06-24 01:32:52.339617][UC][I] Using max model len 2048 [8966,8966][model.py:1745,get_and_verify_max_len]
  2026-06-24 01:32:52,946 - modelscope - WARNING - We can not confirm the cached file is for revision: master
  2026-06-24 01:32:52,969 - modelscope - WARNING - We can not confirm the cached file is for revision: master
  `torch_dtype` is deprecated! Use `dtype` instead!
  Warning: 24 01:32:52] [WARNING] `torch_dtype` is deprecated! Use `dtype` instead!
  [2026-06-24 01:33:08.914776][UC][I] Resolved architecture: Eagle3LlamaForCausalLM [8966,8966][model.py:611,__post_init__]
  [2026-06-24 01:33:08.965625][UC][E] Error retrieving safetensors: Cannot reach https://huggingface.co/RedHatAI/Qwen3-8B-speculator.eagle3/resolve/main/model.safetensors: offline mode is enabled. To disable it, please unset the `HF_HUB_OFFLINE` environment variable., retrying 1 of 2 [8966,8966][repo_utils.py:68,with_retry]
  [2026-06-24 01:33:10.966779][UC][E] Error retrieving safetensors: Cannot reach https://huggingface.co/RedHatAI/Qwen3-8B-speculator.eagle3/resolve/main/model.safetensors: offline mode is enabled. To disable it, please unset the `HF_HUB_OFFLINE` environment variable. [8966,8966][repo_utils.py:66,with_retry]
  [2026-06-24 01:33:10.969321][UC][I] Downcasting torch.float32 to torch.bfloat16. [8966,8966][model.py:2080,_get_and_verify_dtype]
  [2026-06-24 01:33:10.969454][UC][I] Using max model len 40960 [8966,8966][model.py:1745,get_and_verify_max_len]
  [2026-06-24 01:33:10.974618][UC][I] Overriding draft model max model len from 40960 to 2048 [8966,8966][speculative.py:885,_maybe_override_draft_max_model_len]
  [2026-06-24 01:33:10.975382][UC][I] Chunked prefill is enabled with max_num_batched_tokens=8192. [8966,8966][scheduler.py:239,__post_init__]
  [2026-06-24 01:33:11.003028][UC][I] Asynchronous scheduling is enabled. [8966,8966][vllm.py:999,__post_init__]
  [2026-06-24 01:33:11.003097][UC][W] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none [8966,8966][vllm.py:1055,__post_init__]
  [2026-06-24 01:33:11.003141][UC][W] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored. [8966,8966][vllm.py:1097,__post_init__]
  [2026-06-24 01:33:11.003703][UC][I] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']) [8966,8966][kernel.py:270,set_platform_defaults]
  [2026-06-24 01:33:11.003858][UC][I] Cudagraph is disabled under eager mode [8966,8966][vllm.py:1273,__post_init__]
  [2026-06-24 01:33:11.031696][UC][W] Model Runner V2 does not yet support prefill context parallelism; using the V1 model runner instead. [8966,8966][vllm.py:535,use_v2_model_runner]
  [2026-06-24 01:33:11.031843][UC][I] Enabled custom fusions: norm_quant, act_quant [8966,8966][compilation.py:321,log_enabled_passes]
  [2026-06-24 01:33:14] [INFO] get env VLLM_WORKER_MULTIPROC_METHOD = spawn
  Downloading Model from https://www.modelscope.cn/ to directory: /root/.cache/modelscope/hub/models/Qwen/Qwen3-8B
  (EngineCore pid=9533) 2026-06-24 01:33:27,416 - 9533 - ServiceProfiler - INFO - VLLM_USE_V1 not set, auto-detected via vLLM 0.1.dev1+g967c5c3bc.empty: default 0
  [2026-06-24 01:33:27.437301][UC][I] Registered model loader `<class 'vllm_ascend.model_loader.netloader.netloader.ModelNetLoaderElastic'>` with load format `netloader` [9533,9533][__init__.py:115,_wrapper]
  [2026-06-24 01:33:27.447757][UC][I] Registered model loader `<class 'vllm_ascend.model_loader.rfork.rfork_loader.RForkModelLoader'>` with load format `rfork` [9533,9533][__init__.py:115,_wrapper]
  [2026-06-24 01:33:27.448305][UC][I] Initializing a V1 LLM engine (v0.1.dev1+g967c5c3bc) with config: model='/root/.cache/modelscope/hub/models/Qwen/Qwen3-8B', speculative_config=SpeculativeConfig(method='eagle3', model='RedHatAI/Qwen3-8B-speculator.eagle3', num_spec_tokens=3), tokenizer='/root/.cache/modelscope/hub/models/Qwen/Qwen3-8B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=2048, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=True, quantization=None, quantization_config=None, enforce_eager=True, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=npu, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=/root/.cache/modelscope/hub/models/Qwen/Qwen3-8B, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.NONE: 0>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'vllm_ascend.compilation.compiler_interface.AscendCompiler', 'custom_ops': ['all'], 'ir_enable_torch_wrap': False, 'splitting_ops': [], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [8192], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'size_asserts': False, 'alignment_asserts': False, 'scalar_asserts': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': True, 'fuse_act_quant': True, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_rope_kvcache_cat_mla': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 0, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=True, moe_backend='auto', linear_backend='auto') [9533,9533][core.py:113,__init__]
  [2026-06-24 01:33:27.448566][UC][W] Reducing Torch parallelism from 320 threads to 1 to avoid unnecessary CPU contention. Set OMP_NUM_THREADS in the external environment to tune this value as needed. [9533,9533][multiproc_executor.py:1054,set_multiprocessing_worker_envs]
  [2026-06-24 01:33:27.448761][UC][I] DP group leader: node_rank=0, node_rank_within_dp=0, master_addr=127.0.0.1, mq_connect_ip=10.0.0.233 (local), world_size=2, local_world_size=2 [9533,9533][multiproc_executor.py:140,_init_executor]
  2026-06-24 01:33:39,690 - 9815 - ServiceProfiler - INFO - VLLM_USE_V1 not set, auto-detected via vLLM 0.1.dev1+g967c5c3bc.empty: default 0
  [2026-06-24 01:33:39.711534][UC][I] Registered model loader `<class 'vllm_ascend.model_loader.netloader.netloader.ModelNetLoaderElastic'>` with load format `netloader` [9815,9815][__init__.py:115,_wrapper]
  [2026-06-24 01:33:39.723530][UC][I] Registered model loader `<class 'vllm_ascend.model_loader.rfork.rfork_loader.RForkModelLoader'>` with load format `rfork` [9815,9815][__init__.py:115,_wrapper]
  2026-06-24 01:33:40,065 - 9814 - ServiceProfiler - INFO - VLLM_USE_V1 not set, auto-detected via vLLM 0.1.dev1+g967c5c3bc.empty: default 0
  [2026-06-24 01:33:40.087694][UC][I] Registered model loader `<class 'vllm_ascend.model_loader.netloader.netloader.ModelNetLoaderElastic'>` with load format `netloader` [9814,9814][__init__.py:115,_wrapper]
  [2026-06-24 01:33:40.100276][UC][I] Registered model loader `<class 'vllm_ascend.model_loader.rfork.rfork_loader.RForkModelLoader'>` with load format `rfork` [9814,9814][__init__.py:115,_wrapper]
  `Qwen2VLImageProcessorFast` is deprecated. The `Fast` suffix for image processors has been removed; use `Qwen2VLImageProcessor` instead.
  [2026-06-24 01:33:43.953793][UC][I] world_size=2 rank=0 local_rank=0 distributed_init_method=tcp://127.0.0.1:35555 backend=hccl [9814,9814][parallel_state.py:1568,init_distributed_environment]
  [2026-06-24 01:33:44.109982][UC][I] world_size=2 rank=1 local_rank=1 distributed_init_method=tcp://127.0.0.1:35555 backend=hccl [9815,9815][parallel_state.py:1568,init_distributed_environment]
  [Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
  [Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
  [Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
  [Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
  [Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
  [Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
  [2026-06-24 01:33:44.138309][UC][I] rank 1 in world size 2 is assigned as DP rank 0, PP rank 0, PCP rank 1, TP rank 0, EP rank N/A, EPLB rank N/A [9815,9815][parallel_state.py:1903,initialize_model_parallel]
  [Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
  [2026-06-24 01:33:44.201306][UC][I] rank 0 in world size 2 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A [9814,9814][parallel_state.py:1903,initialize_model_parallel]
  [Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
  [Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
  [2026-06-24 01:33:44.296817][UC][W] min_p and logit_bias parameters won't work with speculative decoding. [9814,9814][__init__.py:204,build_logitsprocs]
  [2026-06-24 01:33:44.304023][UC][W] min_p and logit_bias parameters won't work with speculative decoding. [9815,9815][__init__.py:204,build_logitsprocs]
  [2026-06-24 01:33:44.326551][UC][W] min_p and logit_bias parameters won't work with speculative decoding. [9814,9814][__init__.py:204,build_logitsprocs]
  [2026-06-24 01:33:44.339395][UC][W] min_p and logit_bias parameters won't work with speculative decoding. [9815,9815][__init__.py:204,build_logitsprocs]
  [2026-06-24 01:33:46.321778][UC][I] Filesystem type for checkpoints: NFS. Checkpoint size: 15.26 GiB. Available RAM: 1937.38 GiB. [9815,9815][weight_utils.py:922,safetensors_weights_iterator]
  [2026-06-24 01:33:46.321839][UC][I] Prefetching checkpoint files into page cache started (in background, num_threads=8, block_size=16777216 bytes) [9815,9815][weight_utils.py:884,_prefetch_all_checkpoints]
  [2026-06-24 01:33:46.408359][UC][I] Filesystem type for checkpoints: NFS. Checkpoint size: 15.26 GiB. Available RAM: 1937.37 GiB. [9814,9814][weight_utils.py:922,safetensors_weights_iterator]
  [2026-06-24 01:33:46.408429][UC][I] Prefetching checkpoint files into page cache started (in background, num_threads=8, block_size=16777216 bytes) [9814,9814][weight_utils.py:884,_prefetch_all_checkpoints]
  (Worker_PCP0 pid=9814) 
  Loading safetensors checkpoint shards:   0% Completed | 0/5 [00:00<?, ?it/s]
  [2026-06-24 01:33:50.168624][UC][I] Prefetching checkpoint files: 10% (1/3) [9814,9960][weight_utils.py:856,prefetch_one]
  [2026-06-24 01:33:55.173176][UC][I] Prefetching checkpoint files: 20% (2/3) [9814,9960][weight_utils.py:856,prefetch_one]
  (Worker_PCP0 pid=9814) 
  Loading safetensors checkpoint shards:  20% Completed | 1/5 [00:08<00:35,  8.76s/it]
  [2026-06-24 01:33:56.374597][UC][I] Prefetching checkpoint files: 10% (1/2) [9815,9959][weight_utils.py:856,prefetch_one]
  [2026-06-24 01:33:57.731137][UC][I] Prefetching checkpoint files: 20% (2/2) [9815,9959][weight_utils.py:856,prefetch_one]
  (Worker_PCP0 pid=9814) 
  Loading safetensors checkpoint shards:  40% Completed | 2/5 [00:11<00:15,  5.11s/it]
  [2026-06-24 01:33:58.158509][UC][I] Prefetching checkpoint files into page cache finished in 11.84s [9815,9959][weight_utils.py:879,_run_prefetch]
  (Worker_PCP0 pid=9814) 
  Loading safetensors checkpoint shards:  60% Completed | 3/5 [00:12<00:06,  3.30s/it]
  [2026-06-24 01:33:58.867428][UC][I] Prefetching checkpoint files: 30% (3/3) [9814,9960][weight_utils.py:856,prefetch_one]
  [2026-06-24 01:33:59.320333][UC][I] Prefetching checkpoint files into page cache finished in 12.91s [9814,9960][weight_utils.py:879,_run_prefetch]
  (Worker_PCP0 pid=9814) 
  Loading safetensors checkpoint shards:  80% Completed | 4/5 [00:13<00:02,  2.30s/it]
  (Worker_PCP0 pid=9814) 
  Loading safetensors checkpoint shards: 100% Completed | 5/5 [00:13<00:00,  1.61s/it]
  (Worker_PCP0 pid=9814) 
  Loading safetensors checkpoint shards: 100% Completed | 5/5 [00:13<00:00,  2.72s/it]
  (Worker_PCP0 pid=9814) 
  [2026-06-24 01:34:00.022116][UC][I] Loading weights took 13.61 seconds [9814,9814][default_loader.py:397,load_weights]
  [2026-06-24 01:34:00.044828][UC][I] Loading weights took 13.73 seconds [9815,9815][default_loader.py:397,load_weights]
  [2026-06-24 01:34:00.204617][UC][I] Asynchronous scheduling is enabled. [9814,9814][vllm.py:999,__post_init__]
  [2026-06-24 01:34:00.204652][UC][W] Disabling cascade attention (not yet compatible with async speculative decoding). [9814,9814][vllm.py:1023,__post_init__]
  [2026-06-24 01:34:00.204674][UC][W] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none [9814,9814][vllm.py:1055,__post_init__]
  [2026-06-24 01:34:00.204716][UC][W] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored. [9814,9814][vllm.py:1097,__post_init__]
  [2026-06-24 01:34:00.205025][UC][I] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']) [9814,9814][kernel.py:270,set_platform_defaults]
  [2026-06-24 01:34:00.205126][UC][I] Cudagraph is disabled under eager mode [9814,9814][vllm.py:1273,__post_init__]
  [2026-06-24 01:34:00.205932][UC][I] Asynchronous scheduling is enabled. [9815,9815][vllm.py:999,__post_init__]
  [2026-06-24 01:34:00.205965][UC][W] Disabling cascade attention (not yet compatible with async speculative decoding). [9815,9815][vllm.py:1023,__post_init__]
  [2026-06-24 01:34:00.205986][UC][W] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none [9815,9815][vllm.py:1055,__post_init__]
  [2026-06-24 01:34:00.206025][UC][W] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored. [9815,9815][vllm.py:1097,__post_init__]
  [2026-06-24 01:34:00.206347][UC][I] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']) [9815,9815][kernel.py:270,set_platform_defaults]
  [2026-06-24 01:34:00.206442][UC][I] Cudagraph is disabled under eager mode [9815,9815][vllm.py:1273,__post_init__]
  [2026-06-24 01:34:00.229822][UC][W] Model Runner V2 does not yet support prefill context parallelism; using the V1 model runner instead. [9815,9815][vllm.py:535,use_v2_model_runner]
  [2026-06-24 01:34:00.229823][UC][W] Model Runner V2 does not yet support prefill context parallelism; using the V1 model runner instead. [9814,9814][vllm.py:535,use_v2_model_runner]
  [2026-06-24 01:34:00.229924][UC][I] Enabled custom fusions: norm_quant, act_quant [9815,9815][compilation.py:321,log_enabled_passes]
  [2026-06-24 01:34:00.229924][UC][I] Enabled custom fusions: norm_quant, act_quant [9814,9814][compilation.py:321,log_enabled_passes]
  (Worker_PCP0 pid=9814) 2026-06-24 01:34:00,419 - modelscope - WARNING - We can not confirm the cached file is for revision: master
  [2026-06-24 01:34:00.433015][UC][I] Filesystem type for checkpoints: NFS. Checkpoint size: 1.90 GiB. Available RAM: 1942.72 GiB. [9814,9814][weight_utils.py:922,safetensors_weights_iterator]
  [2026-06-24 01:34:00.433091][UC][I] Prefetching checkpoint files into page cache started (in background, num_threads=8, block_size=16777216 bytes) [9814,9814][weight_utils.py:884,_prefetch_all_checkpoints]
  (Worker_PCP0 pid=9814) 
  Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
  (Worker_PCP1 pid=9815) 2026-06-24 01:34:00,481 - modelscope - WARNING - We can not confirm the cached file is for revision: master
  [2026-06-24 01:34:00.488455][UC][I] Filesystem type for checkpoints: NFS. Checkpoint size: 1.90 GiB. Available RAM: 1942.70 GiB. [9815,9815][weight_utils.py:922,safetensors_weights_iterator]
  [2026-06-24 01:34:00.488534][UC][I] Prefetching checkpoint files into page cache started (in background, num_threads=8, block_size=16777216 bytes) [9815,9815][weight_utils.py:884,_prefetch_all_checkpoints]
  [2026-06-24 01:34:00.490230][UC][I] Prefetching checkpoint files into page cache finished in 0.00s [9815,9968][weight_utils.py:879,_run_prefetch]
  (Worker_PCP0 pid=9814) 
  Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00, 17.15it/s]
  (Worker_PCP0 pid=9814) 
  [2026-06-24 01:34:03.856743][UC][I] Prefetching checkpoint files: 10% (1/1) [9814,9966][weight_utils.py:856,prefetch_one]
  [2026-06-24 01:34:03.857986][UC][I] Prefetching checkpoint files into page cache finished in 3.42s [9814,9966][weight_utils.py:879,_run_prefetch]
  [2026-06-24 01:34:03.858199][UC][I] Loading weights took 3.43 seconds [9814,9814][default_loader.py:397,load_weights]
  [2026-06-24 01:34:03.866531][UC][I] Loading weights took 3.38 seconds [9815,9815][default_loader.py:397,load_weights]
  [2026-06-24 01:34:23.739360][UC][I] GPU KV cache size: 349,184 tokens [9533,9533][kv_cache_utils.py:1744,_report_kv_cache_config]
  [2026-06-24 01:34:23.739411][UC][I] Maximum concurrency for 2,048 tokens per request: 170.50x [9533,9533][kv_cache_utils.py:1745,_report_kv_cache_config]
  [2026-06-24 01:34:27.837827][UC][I] init engine (profile, create kv cache, warmup model) took 21.86 s [9533,9533][core.py:313,_initialize_kv_caches]
  [2026-06-24 01:34:28.686690][UC][W] Model Runner V2 does not yet support prefill context parallelism; using the V1 model runner instead. [9533,9533][vllm.py:535,use_v2_model_runner]
  [2026-06-24 01:34:28.987593][UC][I] Asynchronous scheduling is enabled. [9533,9533][vllm.py:999,__post_init__]
  [2026-06-24 01:34:28.987630][UC][W] Disabling cascade attention (not yet compatible with async speculative decoding). [9533,9533][vllm.py:1023,__post_init__]
  [2026-06-24 01:34:28.987648][UC][W] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none [9533,9533][vllm.py:1055,__post_init__]
  [2026-06-24 01:34:28.987680][UC][W] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored. [9533,9533][vllm.py:1097,__post_init__]
  [2026-06-24 01:34:28.988111][UC][I] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']) [9533,9533][kernel.py:270,set_platform_defaults]
  [2026-06-24 01:34:28.988187][UC][I] Cudagraph is disabled under eager mode [9533,9533][vllm.py:1273,__post_init__]
  [2026-06-24 01:34:29.124457][UC][I] Enabled custom fusions: norm_quant, act_quant [9533,9533][compilation.py:321,log_enabled_passes]
  
  Rendering prompts:   0%|          | 0/4 [00:00<?, ?it/s]
  Rendering prompts: 100%|██████████| 4/4 [00:00<00:00, 120.05it/s]
  
  Processed prompts:   0%|          | 0/4 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s][2026-06-24 01:34:39.744881][UC][E] WorkerProc hit an exception.
  Traceback (most recent call last):
    File "/usr/local/python3.12.13/lib/python3.12/site-packages/vllm/v1/executor/multiproc_executor.py", line 982, in worker_busy_loop
      output = func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/python3.12.13/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
      return func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
    File "/__w/vllm-ascend/vllm-ascend/vllm_ascend/worker/worker.py", line 682, in sample_tokens
      return self.model_runner.sample_tokens(grammar_output)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/python3.12.13/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
      return func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
    File "/__w/vllm-ascend/vllm-ascend/vllm_ascend/worker/model_runner_v1.py", line 2501, in sample_tokens
      propose_draft_token_ids(sampler_output.sampled_token_ids)
    File "/__w/vllm-ascend/vllm-ascend/vllm_ascend/worker/model_runner_v1.py", line 2455, in propose_draft_token_ids
      self._draft_token_ids = self.propose_draft_token_ids(
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/__w/vllm-ascend/vllm-ascend/vllm_ascend/worker/model_runner_v1.py", line 1888, in propose_draft_token_ids
      draft_token_ids = self.drafter._propose(
                        ^^^^^^^^^^^^^^^^^^^^^^
    File "/__w/vllm-ascend/vllm-ascend/vllm_ascend/spec_decode/llm_base_proposer.py", line 906, in _propose
      common_attn_metadata, attn_metadata = self.attn_update_stack_num_spec_norm(
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/__w/vllm-ascend/vllm-ascend/vllm_ascend/spec_decode/llm_base_proposer.py", line 1658, in attn_update_stack_num_spec_norm
      attn_metadata = attn_metadata_builder.build_for_drafting(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/python3.12.13/lib/python3.12/site-packages/vllm/v1/attention/backend.py", line 652, in build_for_drafting
      return self.build(
             ^^^^^^^^^^^
    File "/__w/vllm-ascend/vllm-ascend/vllm_ascend/attention/context_parallel/attention_cp.py", line 114, in build
      num_reqs = common_attn_metadata.num_reqs
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
