### PR TITLE
[0.22.1][CI] Modify the accuracy threshold of the aime2025 dataset to 10

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3_2-W8A8-EP.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3_2-W8A8-EP.yaml
@@ -41,6 +41,7 @@ deployment:
           --data-parallel-start-rank 0
           --data-parallel-size-local 1
           --data-parallel-address $LOCAL_IP
+          --data-parallel-rpc-port 13389
           --tensor-parallel-size 16
           --enable-expert-parallel
           --speculative-config '{"num_speculative_tokens": 2, "method":"deepseek_mtp"}' 
@@ -86,6 +87,7 @@ deployment:
           --data-parallel-start-rank 1
           --data-parallel-size-local 1
           --data-parallel-address $MASTER_IP
+          --data-parallel-rpc-port 13389
           --tensor-parallel-size 16
           --enable-expert-parallel
           --speculative-config '{"num_speculative_tokens": 2, "method":"deepseek_mtp"}' 

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A3-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A3-dual-nodes.yaml
@@ -83,7 +83,7 @@ benchmarks:
     max_out_len: 72348
     batch_size: 32
     baseline: 90
-    threshold: 5
+    threshold: 10
 
   perf:
     case_type: performance

--- a/tests/e2e/nightly/single_node/models/configs/Kimi-K2.5.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Kimi-K2.5.yaml
@@ -63,7 +63,7 @@ _benchmarks: &benchmarks
     repetition_penalty: 1.0
     batch_size: 32
     baseline: 95
-    threshold: 5
+    threshold: 10
   perf:
     case_type: performance
     dataset_path: vllm-ascend/GSM8K_prefix90_in131072_bs1000_kimi

--- a/tests/e2e/nightly/single_node/models/configs/MiniMax-M2.5-w8a8-QuaRot-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/MiniMax-M2.5-w8a8-QuaRot-A3.yaml
@@ -51,7 +51,7 @@ test_cases:
         max_out_len: 131072
         batch_size: 32
         baseline: 90
-        threshold: 5
+        threshold: 10
         bos_token_id: 200019
         do_sample: true
         eos_token_id: 200020

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3.5-122B-A10B-W8A8-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3.5-122B-A10B-W8A8-A3.yaml
@@ -57,7 +57,7 @@ test_cases:
         max_out_len: 65536
         batch_size: 32
         baseline: 90
-        threshold: 5
+        threshold: 10
         thinking: true
         temperature: 1.0
         top_p: 0.95


### PR DESCRIPTION
### What this PR does / why we need it?
This PR modifies the accuracy threshold of the `aime2025` dataset from 5 to 10 across multiple model configurations (GLM5_1, Kimi-K2.5, MiniMax-M2.5, and Qwen3.5) to accommodate variance in accuracy benchmarks.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested via nightly CI pipelines with the updated configuration files.


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
