### PR TITLE
[Test] Enable default graph mode for test case test_guided_json_completion

### DIFF
--- a/tests/e2e/pull_request/one_card/test_guided_decoding.py
+++ b/tests/e2e/pull_request/one_card/test_guided_decoding.py
@@ -85,7 +85,7 @@ def test_guided_json_completion(guided_decoding_backend: str, sample_json_schema
         "seed": 0,
         "structured_outputs_config": {"backend": guided_decoding_backend},
     }
-    with VllmRunner(MODEL_NAME, compilation_config={"cudagraph_mode": "PIECEWISE"}, **runner_kwargs) as vllm_model:
+    with VllmRunner(MODEL_NAME, **runner_kwargs) as vllm_model:
         prompts = [f"Give an example JSON for an employee profile that fits this schema: {sample_json_schema}"] * 2
         inputs = vllm_model.get_inputs(prompts)
         outputs = vllm_model.model.generate(inputs, sampling_params=sampling_params)


### PR DESCRIPTION
### What this PR does / why we need it?
For the test case `test_guided_json_completion`, use the default graph mode `FULL_AND_PIECEWISE`

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Ran `test_guided_json_completion` locally with the change applied and verified it passes.

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
