### PR TITLE
[Doc] Add headless option to DeepSeek-V4-Pro tutorial

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V4-Pro.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Pro.md
@@ -403,6 +403,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/DeepSeek-V4-Pro-w4a8-m
   --tool-call-parser deepseek_v4 \
   --enable-auto-tool-choice \
   --reasoning-parser deepseek_v4 \
+  --headless \
   --speculative-config '{"num_speculative_tokens": 1,"method": "mtp","enforce_eager": true}' \
   --additional-config '
     {"ascend_compilation_config":{


### PR DESCRIPTION
## What this PR does / why we need it?

This PR updates the multi-node deployment documentation for DeepSeek-V4-Pro to include the missing `--headless` flag for worker nodes (Node 1) under the A3 series.

Without the `--headless` flag, worker nodes started in a multi-node deployment will crash during initialization (throwing errors like `Remote engine X must use --headless` or failing with `WorkerProc was terminated`). Adding this flag ensures successful cluster initialization and handshake with the control plane.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only update.

### How was this patch tested?

Manually tested on a 2-node cluster (Huawei Atlas 800 A3 / Ascend 910C, 32 NPUs total) where adding `--headless` resolved the worker process termination issue and allowed `vllm serve` to initialize properly.