### PR TITLE
[Feature][KV Pool] Support hybrid load failure recompute

### DIFF
--- a/tests/ut/distributed/kv_transfer/test_kv_transfer_failures.py
+++ b/tests/ut/distributed/kv_transfer/test_kv_transfer_failures.py
@@ -181,6 +181,17 @@ class TestRecordFailedBlocks(unittest.TestCase):
         self.assertEqual(result, {11})
         mock_logger.error.assert_called_once()
 
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer.logger")
+    def test_hybrid_peer_blocks_fail_together(self, mock_logger: MagicMock):
+        """Test hybrid peer block sets are marked invalid together."""
+        block_ids: list[int | set[int]] = [{10, 20}, {11, 21}, {12, 22}]
+        ret_codes: list[int] = [0, 1, 0]
+
+        result = record_failed_blocks(block_ids, ret_codes)
+
+        self.assertEqual(result, {11, 21})
+        mock_logger.error.assert_called_once()
+
 
 class TestRecordFailedBlocksEdgeCases(unittest.TestCase):
     """Additional edge case tests for record_failed_blocks."""

--- a/tests/ut/patch/platform/test_patch_scheduler.py
+++ b/tests/ut/patch/platform/test_patch_scheduler.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from vllm_ascend.patch.platform import patch_scheduler
+
+
+class _KVCacheManager:
+    def __init__(self, block_ids_by_req):
+        self.block_ids_by_req = block_ids_by_req
+
+    def get_block_ids(self, req_id):
+        return self.block_ids_by_req[req_id]
+
+
+def test_update_requests_with_invalid_blocks_handles_hybrid_groups() -> None:
+    request = SimpleNamespace(request_id="req", num_computed_tokens=256)
+    scheduler = SimpleNamespace(
+        block_size=128,
+        kv_cache_config=SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(kv_cache_spec=SimpleNamespace(block_size=256)),
+                SimpleNamespace(kv_cache_spec=SimpleNamespace(block_size=128)),
+            ],
+        ),
+        kv_cache_manager=_KVCacheManager({"req": ([10], [20, 21])}),
+    )
+
+    affected_req_ids, total_affected_tokens, blocks_to_evict = patch_scheduler._update_requests_with_invalid_blocks(
+        scheduler,
+        [request],
+        {10, 21},
+        {},
+    )
+
+    assert affected_req_ids == {"req"}
+    assert request.num_computed_tokens == 0
+    assert total_affected_tokens == 256
+    assert blocks_to_evict == {10, 20, 21}

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -553,14 +553,6 @@ class TestNPUPlatform(TestBase):
         ):
             self.platform.check_and_update_config(vllm_config)
 
-    def test_validate_kv_load_failure_policy_rejects_hybrid_recompute(self):
-        vllm_config = TestNPUPlatform.mock_vllm_config()
-        vllm_config.model_config.is_hybrid = True
-        vllm_config.kv_transfer_config = MagicMock(kv_load_failure_policy="recompute")
-
-        with pytest.raises(AssertionError, match="Hybrid models do not support recompute mode kv load failure policy"):
-            self.platform._validate_kv_load_failure_policy(vllm_config)
-
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -5,6 +5,7 @@ import queue
 import threading
 import time
 from collections import defaultdict
+from collections.abc import Sequence
 from typing import Any
 
 import numpy as np
@@ -504,6 +505,32 @@ class KVTransferThread(threading.Thread):
         except TypeError:
             return self.token_database.prepare_value(start, end, block_ids)
 
+    def _collect_peer_block_ids(
+        self,
+        start: int,
+        block_ids_by_group: list[list[int]],
+        group_ids: list[int],
+        skip_null_blocks_by_group: list[bool] | None = None,
+    ) -> set[int]:
+        peer_block_ids: set[int] = set()
+        for group_id in group_ids:
+            if group_id >= len(block_ids_by_group):
+                continue
+            group_block_ids = block_ids_by_group[group_id]
+            block_idx = start // self._get_block_size(group_id)
+            if block_idx >= len(group_block_ids):
+                continue
+            block_id = group_block_ids[block_idx]
+            skip_null = (
+                skip_null_blocks_by_group is not None
+                and group_id < len(skip_null_blocks_by_group)
+                and skip_null_blocks_by_group[group_id]
+            )
+            if skip_null and block_id <= 0:
+                continue
+            peer_block_ids.add(block_id)
+        return peer_block_ids
+
     def _decode_adaptor_prefill_pp(
         self,
         keys: list[str],
@@ -737,7 +764,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         addr_list = []
         size_list = []
         key_list = []
-        block_id_list: list[int] = []
+        block_id_list: list[set[int]] = []
         group_ids = req_meta.kv_cache_group_ids or [0]
         for group_id in group_ids:
             block_ids = req_meta.block_ids_by_group[group_id]
@@ -764,7 +791,15 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 key_list.append(key.to_string())
                 addr_list.append(addr)
                 size_list.append(size)
-                block_id_list.append(block_id)
+                block_id_list.append(
+                    self._collect_peer_block_ids(
+                        start,
+                        req_meta.block_ids_by_group,
+                        group_ids,
+                        req_meta.skip_null_blocks_by_group,
+                    )
+                    or {block_id}
+                )
         if not key_list:
             self.set_finished_request(req_id)
             self.request_queue.task_done()
@@ -1341,13 +1376,17 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
 
 
 def record_failed_blocks(
-    block_ids: list[int],
-    ret_codes: list[int],
+    block_ids: Sequence[int | set[int]],
+    ret_codes: Sequence[int],
 ) -> set[int]:
     failed_blocks: set[int] = set()
-    for block_id, code in zip(block_ids, ret_codes):
-        if code != 0:
-            failed_blocks.add(block_id)
+    for block_id_or_group, code in zip(block_ids, ret_codes):
+        if code == 0:
+            continue
+        if isinstance(block_id_or_group, set):
+            failed_blocks.update(block_id_or_group)
+        else:
+            failed_blocks.add(block_id_or_group)
     if failed_blocks:
         logger.error(
             "Failed to load blocks. failed_count=%d, failed_blocks=%s. Check block availability and memory state.",

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -629,7 +629,7 @@ class KVPoolWorker:
             addr_list = []
             size_list = []
             key_list = []
-            block_id_list: list[int] = []
+            block_id_list: list[set[int]] = []
             for group_id in load_group_ids:
                 block_ids = request.block_ids_by_group[group_id]
                 group_block_size = self.grouped_block_size[group_id]
@@ -652,7 +652,23 @@ class KVPoolWorker:
                     key_list.append(key.to_string())
                     addr_list.append(addr)
                     size_list.append(size)
-                    block_id_list.append(block_id)
+                    peer_block_ids: set[int] = set()
+                    for peer_group_id in load_group_ids:
+                        if peer_group_id >= len(request.block_ids_by_group):
+                            continue
+                        peer_block_ids_for_group = request.block_ids_by_group[peer_group_id]
+                        peer_block_idx = start // self.grouped_block_size[peer_group_id]
+                        if peer_block_idx >= len(peer_block_ids_for_group):
+                            continue
+                        peer_block_id = peer_block_ids_for_group[peer_block_idx]
+                        peer_skip_null = (
+                            peer_group_id < len(self.group_uses_align_state)
+                            and self.group_uses_align_state[peer_group_id]
+                        )
+                        if peer_skip_null and peer_block_id <= 0:
+                            continue
+                        peer_block_ids.add(peer_block_id)
+                    block_id_list.append(peer_block_ids or {block_id})
             if not key_list:
                 continue
             key_list_c = _circular_shift(key_list, self.tp_rank % len(key_list))

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -406,6 +406,15 @@
 #       https://github.com/vllm-project/vllm/pull/43935
 #    Future Plan:
 #       Remove this patch if upstream streaming behavior is updated to support mamba external KV connector
+#   2. `vllm.v1.core.sched.scheduler.Scheduler._update_requests_with_invalid_blocks`
+#    Why:
+#       Upstream vLLM assumes one KV cache group when handling invalid blocks from KV load failures.
+#    How:
+#       Scan all KV cache groups and rewind to the earliest invalid token boundary.
+#    Related PR (if no, explain why):
+#       No, Ascend needs hybrid KV load failure recompute support.
+#    Future Plan:
+#       Remove this patch once upstream supports hybrid invalid-block handling.
 # ** 15. File: platform/patch_weight_transfer_engine.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.distributed.weight_transfer.factory.WeightTransferEngineFactory._registry["nccl"]`

--- a/vllm_ascend/patch/platform/patch_scheduler.py
+++ b/vllm_ascend/patch/platform/patch_scheduler.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterable
+
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.request import Request
 
@@ -42,4 +44,68 @@ def _mamba_block_aligned_split(
     return num_new_tokens
 
 
+def _update_requests_with_invalid_blocks(
+    self,
+    requests: Iterable[Request],
+    invalid_block_ids: set[int],
+    num_scheduled_tokens: dict[str, int],
+    evict_blocks: bool = True,
+) -> tuple[set[str], int, set[int]]:
+    affected_req_ids: set[str] = set()
+    total_affected_tokens = 0
+    blocks_to_evict: set[int] = set()
+    marked_invalid_block_ids: set[int] = set()
+    kv_cache_groups = getattr(self.kv_cache_config, "kv_cache_groups", ())
+    coordinator = getattr(self.kv_cache_manager, "coordinator", None)
+    get_effective_block_size = getattr(coordinator, "_get_effective_block_size", None)
+
+    for request in requests:
+        is_affected = False
+        rewind_num_computed_tokens: int | None = None
+        req_id = request.request_id
+        req_block_ids_by_group = self.kv_cache_manager.get_block_ids(req_id)
+        req_num_computed_tokens = request.num_computed_tokens - num_scheduled_tokens.get(req_id, 0)
+        group_block_sizes: list[int] = []
+
+        for group_id, req_block_ids in enumerate(req_block_ids_by_group):
+            block_size = self.block_size
+            if group_id < len(kv_cache_groups):
+                kv_cache_spec = kv_cache_groups[group_id].kv_cache_spec
+                block_size = (
+                    get_effective_block_size(kv_cache_spec)
+                    if get_effective_block_size is not None
+                    else getattr(kv_cache_spec, "block_size", block_size)
+                )
+            group_block_sizes.append(block_size)
+            req_num_computed_blocks = (req_num_computed_tokens + block_size - 1) // block_size
+
+            for idx, block_id in zip(range(req_num_computed_blocks), req_block_ids):
+                if block_id not in invalid_block_ids:
+                    continue
+
+                is_affected = True
+                if block_id in marked_invalid_block_ids:
+                    continue
+
+                marked_invalid_block_ids.add(block_id)
+                invalid_token_pos = idx * block_size
+                if rewind_num_computed_tokens is None or invalid_token_pos < rewind_num_computed_tokens:
+                    rewind_num_computed_tokens = invalid_token_pos
+
+        if is_affected:
+            if rewind_num_computed_tokens is None:
+                total_affected_tokens += request.num_computed_tokens - req_num_computed_tokens
+                request.num_computed_tokens = req_num_computed_tokens
+            else:
+                request.num_computed_tokens = rewind_num_computed_tokens
+                total_affected_tokens += req_num_computed_tokens - request.num_computed_tokens
+                if evict_blocks:
+                    for block_ids, block_size in zip(req_block_ids_by_group, group_block_sizes):
+                        blocks_to_evict.update(block_ids[rewind_num_computed_tokens // block_size :])
+            affected_req_ids.add(request.request_id)
+
+    return affected_req_ids, total_affected_tokens, blocks_to_evict
+
+
 Scheduler._mamba_block_aligned_split = _mamba_block_aligned_split
+Scheduler._update_requests_with_invalid_blocks = _update_requests_with_invalid_blocks

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -672,8 +672,6 @@ class NPUPlatform(Platform):
                     "PD-disaggregated mode (kv_role='kv_producer'/'kv_consumer')."
                 )
 
-        cls._validate_kv_load_failure_policy(vllm_config)
-
         if ascend_config.recompute_scheduler_enable:
             kv_transfer_config = vllm_config.kv_transfer_config
             kv_role = getattr(kv_transfer_config, "kv_role", None)
@@ -867,16 +865,6 @@ class NPUPlatform(Platform):
     @classmethod
     def support_hybrid_kv_cache(cls) -> bool:
         return True
-
-    @staticmethod
-    def _validate_kv_load_failure_policy(vllm_config: VllmConfig) -> None:
-        kv_transfer_config = vllm_config.kv_transfer_config
-        if kv_transfer_config is None:
-            return
-        if getattr(kv_transfer_config, "kv_load_failure_policy", "fail") == "recompute":
-            assert not getattr(vllm_config.model_config, "is_hybrid", False), (
-                "Hybrid models do not support recompute mode kv load failure policy now."
-            )
 
     @classmethod
     def support_static_graph_mode(cls) -> bool:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR is a follow-up to #9701 and ports the hybrid failed-block handling from #7476.

For hybrid KV cache layouts, one backend load failure can invalidate peer KV blocks that correspond to the same token span across different KV cache groups. This PR records those peer block IDs together so `kv_load_failure_policy="recompute"` can rewind and recompute all affected hybrid blocks instead of only the single group that reported the failed backend key.

It also removes the temporary hybrid rejection for `kv_load_failure_policy="recompute"`.

### Does this PR introduce _any_ user-facing change?

Hybrid models can now use KV load failure policy `recompute` instead of failing fast at config validation.

### Validation

vLLM version: v0.23.0
vLLM main: vllm-project/vllm@967c5c3bc38891f4465d3f4e99917ed837bb3833

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
