### PR TITLE
[Bugfix] Fix incorrect hybrid rank mapping for Sparse C8 KV cache

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -53,6 +53,7 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.request import RequestStatus
+from vllm.v1.kv_cache_interface import MLAAttentionSpec
 
 from vllm_ascend import envs as ascend_envs
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
@@ -2532,6 +2533,12 @@ class MooncakeConnectorWorker:
         return list(rank_group_pulls), dict(rank_group_pulls)
 
     def _get_attention_group_num_need_pulls(self, group_spec: dict[str, Any], prefill_tp_size: int) -> int:
+        layer_name = group_spec["layer_names"][0]
+        layer_spec = self._get_layer_spec(layer_name)
+
+        if isinstance(layer_spec, MLAAttentionSpec):
+            return self._get_tp_num_need_pulls(prefill_tp_size)
+
         num_key_value_heads = self._get_attention_group_num_key_value_heads(group_spec)
         num_d_block_heads = max(1, num_key_value_heads // self.tp_size)
         num_p_block_heads = max(1, num_key_value_heads // prefill_tp_size)


### PR DESCRIPTION
### What this PR does / why we need it?
Fixes an assertion failure in Mooncake KV transfer when running DeepSeek-V3.2 with Sparse C8 KV cache.

Sparse C8 may use UniformTypeKVCacheSpecs, which makes _is_hma_required evaluate to True even when there is only one KV cache group. Mooncake then incorrectly enters the hybrid rank mapping path and calculates a different number of group pulls from the selected remote ranks.

It eventually triggers an assertion such as:

`chosen_rank_list([4]) does not match num_group_pulls(2) and prefill pp size(1)`

This PR keeps the group-level pull count consistent with MLA remote-rank selection.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
