### PR TITLE
[Bugfix] Fix triton error when activing enable-prefix-caching in decode node

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_postprocess_mamba.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_postprocess_mamba.py
@@ -1,0 +1,318 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    get_conv_copy_spec,
+    get_temporal_copy_spec,
+)
+from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
+from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheGroupSpec, MambaSpec
+from vllm.v1.worker.mamba_utils import (
+    MambaCopyBuffers,
+    MambaSpecDecodeGPUContext,
+    collect_mamba_copy_meta,
+    do_mamba_copy_block,
+)
+
+import vllm_ascend.patch.worker.patch_mamba_utils  # noqa: F401
+
+MambaStateCopyFunc = Callable[..., Any]
+_COPY_FUNCS: tuple[MambaStateCopyFunc, ...] = (
+    get_conv_copy_spec,
+    get_temporal_copy_spec,
+)
+
+
+def postprocess_mamba(
+    scheduler_output: SchedulerOutput,
+    kv_cache_config: KVCacheConfig,
+    input_batch: Any,
+    requests: dict[str, Any],
+    forward_context: dict[str, Any],
+    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
+    copy_bufs: MambaCopyBuffers,
+):
+    assert input_batch.mamba_state_idx_cpu is not None
+    num_scheduled_tokens_dict = scheduler_output.num_scheduled_tokens
+    scheduled_spec_decode_tokens_dict = scheduler_output.scheduled_spec_decode_tokens
+    num_accepted_tokens_cpu = input_batch.num_accepted_tokens_cpu
+    mamba_state_idx_cpu = input_batch.mamba_state_idx_cpu
+    mamba_group_ids = copy_bufs.mamba_group_ids
+    mamba_spec = copy_bufs.mamba_spec
+    copy_bufs.offset = 0
+    for i, req_id in enumerate(input_batch.req_ids):
+        req_state = requests[req_id]
+        num_computed_tokens = req_state.num_computed_tokens
+        num_draft_tokens = len(scheduled_spec_decode_tokens_dict.get(req_id, []))
+        num_scheduled_tokens = num_scheduled_tokens_dict[req_id]
+        num_accepted_tokens = num_accepted_tokens_cpu[i]
+        num_tokens_running_state = num_computed_tokens + num_scheduled_tokens - num_draft_tokens
+        new_num_computed_tokens = num_tokens_running_state + num_accepted_tokens - 1
+        aligned_new_computed_tokens = new_num_computed_tokens // mamba_spec.block_size * mamba_spec.block_size
+        if aligned_new_computed_tokens >= num_tokens_running_state:
+            accept_token_bias = aligned_new_computed_tokens - num_tokens_running_state
+            src_block_idx = mamba_state_idx_cpu[i]
+            dest_block_idx = aligned_new_computed_tokens // mamba_spec.block_size - 1
+            collect_mamba_copy_meta(
+                copy_bufs,
+                kv_cache_config,
+                mamba_state_copy_funcs,
+                mamba_group_ids,
+                src_block_idx,
+                dest_block_idx,
+                accept_token_bias,
+                req_state,
+                forward_context,
+            )
+            if src_block_idx == dest_block_idx:
+                num_accepted_tokens_cpu[i] = 1
+    do_mamba_copy_block(copy_bufs)
+
+
+@dataclass
+class _TestConfig:
+    block_size: int = 16
+    num_blocks: int = 32
+    num_layers: int = 2
+    max_num_reqs: int = 8
+    conv_width: int = 4
+    conv_inner_dim: int = 64
+    temporal_state_dim: int = 128
+    dtype: torch.dtype = torch.float16
+
+
+class _MockCpuGpuBuffer:
+    def __init__(self, size: int, dtype: torch.dtype, device: torch.device):
+        self.cpu = torch.zeros(size, dtype=dtype, device="cpu")
+        self.gpu = torch.zeros(size, dtype=dtype, device=device)
+        self.np = self.cpu.numpy()
+
+    def copy_to_gpu(self, n: int | None = None) -> torch.Tensor:
+        if n is None:
+            return self.gpu.copy_(self.cpu, non_blocking=True)
+        return self.gpu[:n].copy_(self.cpu[:n], non_blocking=True)
+
+
+def _make_scheduler_output(
+    num_scheduled_tokens: dict[str, int],
+    scheduled_spec_decode_tokens: dict[str, list] | None = None,
+) -> SchedulerOutput:
+    cached = CachedRequestData.make_empty()
+    return SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=cached,
+        num_scheduled_tokens=num_scheduled_tokens,
+        total_num_scheduled_tokens=sum(num_scheduled_tokens.values()),
+        scheduled_spec_decode_tokens=scheduled_spec_decode_tokens or {},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+        preempted_req_ids=set(),
+    )
+
+
+def _make_mock_attention(conv_state: torch.Tensor, temporal_state: torch.Tensor) -> MagicMock:
+    attention = MagicMock()
+    attention.kv_cache = [conv_state, temporal_state]
+    return attention
+
+
+def _make_states(
+    cfg: _TestConfig, layer_names: list[str], device: torch.device
+) -> tuple[
+    list[torch.Tensor],
+    list[torch.Tensor],
+    list[torch.Tensor],
+    list[torch.Tensor],
+    dict[str, MagicMock],
+    dict[str, MagicMock],
+]:
+    conv_py = [
+        torch.randn(cfg.num_blocks, cfg.conv_width, cfg.conv_inner_dim, dtype=cfg.dtype, device=device)
+        for _ in layer_names
+    ]
+    temporal_py = [
+        torch.randn(cfg.num_blocks, cfg.temporal_state_dim, dtype=cfg.dtype, device=device) for _ in layer_names
+    ]
+    conv_gpu = [s.clone() for s in conv_py]
+    temporal_gpu = [s.clone() for s in temporal_py]
+    fwd_py = {name: _make_mock_attention(c, t) for name, c, t in zip(layer_names, conv_py, temporal_py)}
+    fwd_gpu = {name: _make_mock_attention(c, t) for name, c, t in zip(layer_names, conv_gpu, temporal_gpu)}
+    return conv_py, temporal_py, conv_gpu, temporal_gpu, fwd_py, fwd_gpu
+
+
+def _make_kv_cache_config(cfg: _TestConfig, layer_names: list[str]) -> KVCacheConfig:
+    mamba_spec = MambaSpec(
+        block_size=cfg.block_size,
+        shapes=((cfg.conv_width, cfg.conv_inner_dim), (cfg.temporal_state_dim,)),
+        dtypes=(cfg.dtype, cfg.dtype),
+        mamba_cache_mode="all",
+    )
+    return KVCacheConfig(
+        num_blocks=cfg.num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(layer_names=layer_names, kv_cache_spec=mamba_spec)],
+    )
+
+
+def _make_input_batch(req_ids: list[str], num_accepted_tokens: list[int], mamba_state_idx: list[int]) -> MagicMock:
+    batch = MagicMock()
+    batch.req_ids = req_ids
+    batch.req_id_to_index = {rid: i for i, rid in enumerate(req_ids)}
+    batch.num_accepted_tokens_cpu = np.array(num_accepted_tokens, dtype=np.int32)
+    batch.mamba_state_idx_cpu = np.array(mamba_state_idx, dtype=np.int32)
+    return batch
+
+
+def _make_requests(
+    req_ids: list[str],
+    num_computed_tokens: list[int],
+    block_ids_per_req: list[list[int]],
+) -> dict[str, MagicMock]:
+    requests: dict[str, MagicMock] = {}
+    for i, req_id in enumerate(req_ids):
+        req = MagicMock()
+        req.num_computed_tokens = num_computed_tokens[i]
+        req.block_ids = {0: block_ids_per_req[i]}
+        requests[req_id] = req
+    return requests
+
+
+def _make_copy_bufs(cfg: _TestConfig, kv_cache_config: KVCacheConfig, device: torch.device) -> MambaCopyBuffers:
+    return MambaCopyBuffers.create(
+        max_num_reqs=cfg.max_num_reqs,
+        kv_cache_config=kv_cache_config,
+        copy_funcs=_COPY_FUNCS,
+        make_buffer=lambda n, dtype: _MockCpuGpuBuffer(n, dtype, device),
+    )
+
+
+def _make_gpu_ctx(cfg: _TestConfig, kv_cache_config: KVCacheConfig, device: torch.device) -> MambaSpecDecodeGPUContext:
+    return MambaSpecDecodeGPUContext.create(
+        max_num_reqs=cfg.max_num_reqs,
+        kv_cache_config=kv_cache_config,
+        num_state_types=2,
+        device=device,
+        make_buffer=lambda n, dtype: _MockCpuGpuBuffer(n, dtype, device),
+    )
+
+
+def _run_gpu_postprocess(
+    gpu_ctx: MambaSpecDecodeGPUContext,
+    *,
+    kv_cache_config: KVCacheConfig,
+    forward_context: dict[str, Any],
+    copy_funcs: tuple,
+    block_table: torch.Tensor,
+    req_ids: list[str],
+    num_accepted_tokens: list[int],
+    mamba_state_idx: list[int],
+    num_scheduled_tokens: dict[str, int],
+    num_computed_tokens: list[int],
+    num_draft_tokens: dict[str, int],
+    device: torch.device,
+) -> None:
+    def t(values):
+        return torch.tensor(values, dtype=torch.int32, device=device)
+
+    gpu_ctx.initialize_from_forward_context(kv_cache_config, forward_context, copy_funcs, [block_table])
+    gpu_ctx.run_fused_postprocess(
+        num_reqs=len(req_ids),
+        num_accepted_tokens_gpu=t(num_accepted_tokens),
+        mamba_state_idx_gpu=t(mamba_state_idx),
+        num_scheduled_tokens_gpu=t([num_scheduled_tokens[r] for r in req_ids]),
+        num_computed_tokens_gpu=t(num_computed_tokens),
+        num_draft_tokens_gpu=t([num_draft_tokens.get(r, 0) for r in req_ids]),
+    )
+    torch.accelerator.synchronize()
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU required")
+def test_matches_python_postprocess_mamba():
+    cfg = _TestConfig()
+    device = torch.device("npu:0")
+    torch.manual_seed(42)
+
+    req_ids = ["req_0", "req_1", "req_2", "req_3"]
+    num_computed_tokens = [60, 30, 45, 10]
+    num_scheduled_tokens = {"req_0": 5, "req_1": 3, "req_2": 8, "req_3": 6}
+    num_draft_tokens = {"req_0": 2, "req_1": 0, "req_2": 3, "req_3": 0}
+    num_accepted_tokens = [3, 2, 4, 2]
+    mamba_state_idx = [3, 1, 2, 0]
+    block_ids_per_req = [
+        list(range(8)),
+        list(range(8, 16)),
+        list(range(16, 24)),
+        list(range(24, 32)),
+    ]
+
+    layer_names = [f"layer_{i}" for i in range(cfg.num_layers)]
+    kv_cache_config = _make_kv_cache_config(cfg, layer_names)
+
+    (
+        conv_states_py,
+        temporal_states_py,
+        conv_states_gpu,
+        temporal_states_gpu,
+        forward_context_py,
+        forward_context_gpu,
+    ) = _make_states(cfg, layer_names, device)
+
+    scheduler_output = _make_scheduler_output(
+        num_scheduled_tokens,
+        {k: [None] * v for k, v in num_draft_tokens.items() if v > 0},
+    )
+    input_batch_py = _make_input_batch(req_ids, num_accepted_tokens.copy(), mamba_state_idx.copy())
+    requests = _make_requests(req_ids, num_computed_tokens, block_ids_per_req)
+    copy_bufs = _make_copy_bufs(cfg, kv_cache_config, device)
+
+    postprocess_mamba(
+        scheduler_output,
+        kv_cache_config,
+        input_batch_py,
+        requests,
+        forward_context_py,
+        _COPY_FUNCS,
+        copy_bufs,
+    )
+    torch.accelerator.synchronize()
+
+    gpu_ctx = _make_gpu_ctx(cfg, kv_cache_config, device)
+    block_table_gpu = torch.zeros(len(req_ids), 8, dtype=torch.int32, device=device)
+    for i, block_ids in enumerate(block_ids_per_req):
+        block_table_gpu[i, : len(block_ids)] = torch.tensor(block_ids, dtype=torch.int32)
+
+    _run_gpu_postprocess(
+        gpu_ctx,
+        kv_cache_config=kv_cache_config,
+        forward_context=forward_context_gpu,
+        copy_funcs=_COPY_FUNCS,
+        block_table=block_table_gpu,
+        req_ids=req_ids,
+        num_accepted_tokens=num_accepted_tokens,
+        mamba_state_idx=mamba_state_idx,
+        num_scheduled_tokens=num_scheduled_tokens,
+        num_computed_tokens=num_computed_tokens,
+        num_draft_tokens=num_draft_tokens,
+        device=device,
+    )
+
+    for i in range(cfg.num_layers):
+        torch.testing.assert_close(conv_states_gpu[i], conv_states_py[i])
+        torch.testing.assert_close(temporal_states_gpu[i], temporal_states_py[i])
+
+    expected_accepted = torch.tensor(
+        input_batch_py.num_accepted_tokens_cpu[: len(req_ids)],
+        dtype=torch.int32,
+        device=device,
+    )
+    torch.testing.assert_close(gpu_ctx.num_accepted_tokens_out[: len(req_ids)], expected_accepted)

--- a/vllm_ascend/ops/triton/mamba/postprocess.py
+++ b/vllm_ascend/ops/triton/mamba/postprocess.py
@@ -1,0 +1,157 @@
+# Adapt from https://github.com/vllm-project/vllm/blob/main/vllm/v1/worker/mamba_utils.py
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def postprocess_mamba_fused_kernel(
+    # Decision inputs (per-request)
+    num_accepted_tokens_ptr,
+    mamba_state_idx_ptr,
+    num_scheduled_tokens_ptr,
+    num_computed_tokens_ptr,
+    num_draft_tokens_ptr,
+    # Per-group block table base addresses: int64[num_groups]. Each entry is
+    # the data_ptr of that group's persistent [max_reqs, max_blocks] int32
+    # block table.
+    block_table_ptrs_ptr,
+    block_table_stride_req: tl.int64,  # stride between requests (in elements)
+    # Mamba state metadata (per-layer, per-state-type)
+    # These are 1D arrays indexed by (layer_idx * num_state_types + state_type_idx)
+    state_base_addrs_ptr,  # base address of each state tensor
+    state_block_strides_ptr,  # bytes per block for each state
+    state_elem_sizes_ptr,  # element size for each state
+    state_inner_sizes_ptr,  # number of elements in inner dimensions
+    state_conv_widths_ptr,  # conv width for conv states (0 for temporal)
+    state_group_indices_ptr,  # maps state_idx to group index in block table
+    # Output: num_accepted_tokens update (for src==dst case)
+    num_accepted_tokens_out_ptr,
+    # Runtime parameter (varies per batch - NOT constexpr to avoid recompilation)
+    num_reqs,
+    # Compile-time constants (fixed after model initialization)
+    # block_size: determined by model config, constant for all invocations
+    block_size: tl.constexpr,
+    # COPY_BLOCK_SIZE: fixed tuning parameter for memory copy loop
+    COPY_BLOCK_SIZE: tl.constexpr,
+):
+    """
+    Fused GPU kernel for postprocess_mamba that computes decisions AND performs
+    mamba state copies without any CPU-GPU synchronization.
+
+    Grid: (num_reqs, num_layers * num_state_types)
+    - program_id(0) = request index
+    - program_id(1) = state_idx (flattened index into layer/state_type metadata)
+
+    Note: num_layers and num_state_types are not passed as kernel parameters
+    because the kernel indexes directly into pre-flattened metadata arrays
+    using program_id(1). The grid dimensions encode the total state count.
+    """
+    req_idx = tl.program_id(0)
+    state_idx = tl.program_id(1)
+
+    # Bounds check
+    if req_idx >= num_reqs:
+        return
+
+    # Compute decision logic (mirrors postprocess_mamba Python reference)
+    num_accepted = tl.load(num_accepted_tokens_ptr + req_idx)
+    src_block_idx = tl.load(mamba_state_idx_ptr + req_idx)
+    num_scheduled = tl.load(num_scheduled_tokens_ptr + req_idx)
+    num_computed = tl.load(num_computed_tokens_ptr + req_idx)
+    num_draft = tl.load(num_draft_tokens_ptr + req_idx)
+
+    num_tokens_running_state = num_computed + num_scheduled - num_draft
+    new_num_computed = num_tokens_running_state + num_accepted - 1
+    aligned_new_computed = (new_num_computed // block_size) * block_size
+
+    needs_copy = aligned_new_computed >= num_tokens_running_state
+
+    if not needs_copy:
+        return
+
+    # Compute copy parameters
+    accept_token_bias = aligned_new_computed - num_tokens_running_state
+    dest_block_idx = aligned_new_computed // block_size - 1
+
+    # Load state metadata for this layer/state_type
+    state_base_addr = tl.load(state_base_addrs_ptr + state_idx)
+    state_block_stride = tl.load(state_block_strides_ptr + state_idx)
+    state_elem_size = tl.load(state_elem_sizes_ptr + state_idx)
+    state_inner_size = tl.load(state_inner_sizes_ptr + state_idx)
+    conv_width = tl.load(state_conv_widths_ptr + state_idx)
+
+    # Load the group index for this state, then index into the correct
+    # group's block table. Each mamba group has independently allocated
+    # physical blocks.
+    group_idx = tl.load(state_group_indices_ptr + state_idx).to(tl.int64)
+
+    # block_table_ptrs_ptr holds one pointer per group (each group owns its own
+    # block table). Reinterpret as int32* since block ids are int32.
+    group_base_addr = tl.load(block_table_ptrs_ptr + group_idx)
+    block_table_typed = group_base_addr.to(tl.pointer_type(tl.int32))
+    block_table_base = block_table_typed + req_idx * block_table_stride_req
+
+    # Widen block ids to int64 before they reach `block_id * state_block_stride`
+    # below: state_block_stride can exceed 2**31 bytes for large mamba caches,
+    # and Triton would otherwise do the multiply in int32 and wrap.
+    src_block_id = tl.load(block_table_base + src_block_idx).to(tl.int64)
+    dest_block_id = tl.load(block_table_base + dest_block_idx).to(tl.int64)
+
+    # Compute source and destination addresses based on state type
+    # conv_width > 0 means this is a conv state (get_conv_copy_spec logic)
+    # conv_width == 0 means this is a temporal state (get_temporal_copy_spec logic)
+    is_conv_state = conv_width > 0
+
+    if is_conv_state:
+        # Conv state: copy
+        #   state[block_table[req_idx, src_block_idx],  accept_token_bias:]
+        # to
+        #   state[block_table[req_idx, dest_block_idx], :conv_width - accept_token_bias]
+        src_offset = accept_token_bias.to(tl.int64) * state_inner_size * state_elem_size
+        src_addr = state_base_addr + src_block_id * state_block_stride + src_offset
+        dst_addr = state_base_addr + dest_block_id * state_block_stride
+        # Number of elements to copy:
+        # (conv_width - accept_token_bias) * inner_size
+        num_elems_to_copy = (conv_width - accept_token_bias).to(tl.int64) * state_inner_size
+        copy_size = num_elems_to_copy * state_elem_size
+    else:
+        # Temporal state: copy
+        #   state[block_table[req_idx, src_block_idx + accept_token_bias]]
+        # to
+        #   state[block_table[req_idx, dest_block_idx]]
+        actual_src_block_idx = src_block_idx + accept_token_bias
+        actual_src_block_id = tl.load(block_table_base + actual_src_block_idx).to(tl.int64)
+        src_addr = state_base_addr + actual_src_block_id * state_block_stride
+        dst_addr = state_base_addr + dest_block_id * state_block_stride
+        # Use natural block data size (inner_size * elem_size), NOT
+        # state_block_stride which is the page stride and can exceed the
+        # actual data when the state tensor uses as_strided page padding.
+        copy_size = state_inner_size * state_elem_size
+
+    # Mirror postprocess_mamba's trailing
+    #     if src_block_idx == dest_block_idx: num_accepted_tokens_cpu[i] = 1
+    # This runs whether or not the copy below is skipped (it's per-request, so
+    # only state_idx == 0 writes).
+    if src_block_idx == dest_block_idx and state_idx == 0:
+        tl.store(num_accepted_tokens_out_ptr + req_idx, 1)
+
+    # Mirror collect_mamba_copy_meta's early return: src==dst with no token
+    # bias means source and destination ranges coincide, so the copy is a
+    # no-op.
+    if src_block_idx == dest_block_idx and accept_token_bias == 0:
+        return
+
+    # Hoist the pointer-type cast out of the copy loop. triton-ascend's
+    # PtrOffsetInfo::AxisInfo analysis aborts on `(addr + i + offsets).to(...)`
+    # inside the loop (SmallVector assertion `idx < size()`); casting once
+    # here and doing plain pointer arithmetic inside the loop is the same fix
+    # vllm-ascend applies to batch_memcpy_kernel.
+    src_ptr = src_addr.to(tl.pointer_type(tl.uint8))
+    dst_ptr = dst_addr.to(tl.pointer_type(tl.uint8))
+    offsets = tl.arange(0, COPY_BLOCK_SIZE)
+    for i in range(0, copy_size, COPY_BLOCK_SIZE):
+        mask = (i + offsets) < copy_size
+        data = tl.load(src_ptr + i + offsets, mask=mask)
+        tl.store(dst_ptr + i + offsets, data, mask=mask)

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -15,6 +15,7 @@ from vllm.v1.worker.lora_model_runner_mixin import GPUInputBatch
 from vllm.v1.worker.mamba_utils import MambaCopyBuffers
 
 from vllm_ascend.ops.triton.batch_memcpy import batch_memcpy_kernel
+from vllm_ascend.ops.triton.mamba.postprocess import postprocess_mamba_fused_kernel
 from vllm_ascend.utils import is_310p
 
 
@@ -114,6 +115,7 @@ def _batch_memcpy_unavailable(src_ptrs, dst_ptrs, sizes):
 if _can_launch_triton_batch_memcpy():
     mamba_utils.batch_memcpy_kernel = batch_memcpy_kernel
     mamba_utils.batch_memcpy = _batch_memcpy_triton
+    mamba_utils.postprocess_mamba_fused_kernel = postprocess_mamba_fused_kernel
 else:
     mamba_utils.batch_memcpy = _batch_memcpy_unavailable
     mamba_utils.collect_mamba_copy_meta = _collect_mamba_copy_meta_torch


### PR DESCRIPTION
### What this PR does / why we need it

In the PD disaggregation architecture, when prefix caching and the MTP interface are enabled at the same time, the `postprocess_mamba_fused_kernel` operator may be invoked.

The current implementation of this operator contains code similar to the following:

```python
curr_src = (src_addr + i + offsets).to(tl.pointer_type(tl.uint8))
```

This expression first constructs a vectorized integer address and then casts the entire vector of integer addresses to a `uint8*` pointer.
This is valid under standard Triton semantics, and the NVIDIA/CUDA backend can usually handle this pattern correctly. However, in `triton-ascend`, the compiler's `PtrOffsetInfo::AxisInfo` analysis does not handle this "compute a vector of integer addresses first, then force-cast the vector to pointers" pattern well, which triggers a `SmallVector` out-of-bounds assertion. 
<img width="1891" height="85" alt="image" src="https://github.com/user-attachments/assets/66e260b9-3460-4824-970a-deac2def6fce" />

This patch addresses the issue by rewriting the computation pattern in a way that is more friendly to the Ascend backend.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Test GPQA, and got 86.87
<img width="1428" height="298" alt="image" src="https://github.com/user-attachments/assets/e46eeecb-9b8c-4d92-9036-e4d4c551603b" />

P node
```bash
export IP_ADDRESS="80.5.17.108"
export NETWORK_CARD_NAME="enp48s3u1u1"
export HCCL_IF_IP=$IP_ADDRESS
export GLOO_SOCKET_IFNAME=$NETWORK_CARD_NAME
export TP_SOCKET_IFNAME=$NETWORK_CARD_NAME
export HCCL_SOCKET_IFNAME=$NETWORK_CARD_NAME

export VLLM_USE_V1=1
export HCCL_BUFFSIZE=1536
export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:$LD_LIBRARY_PATH
export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
export TASK_QUEUE_ENABLE=1
export ASCEND_RT_VISIBLE_DEVICES=4,5,6,7,8,9,10,11
vllm serve "/mnt/weight/Qwen3.5-397B-A17B-w4a8-mtp/Eco-Tech/Qwen3___5-397B-A17B-w4a8-mtp" \
  --host ${IP_ADDRESS} \
  --port 30060 \
  --enable-prefix-caching \
  --enable-expert-parallel \
  --data-parallel-size 2 \
  --api-server-count 1 \
  --max-num_seqs 8 \
  --tensor-parallel-size 4 \
  --seed 1024 \
  --distributed-executor-backend mp \
  --served-model-name qwen35 \
  --max-model-len 65535 \
  --max-num-batched-tokens 8192 \
  --trust-remote-code \
  --quantization ascend \
  --no-disable-hybrid-kv-cache-manager \
  --additional-config '{"recompute_scheduler_enable": true, "enable_cpu_binding": true}' \
  --speculative_config '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}' \
  --gpu-memory-utilization 0.85 \
  --kv-transfer-config \
  '{"kv_connector": "MooncakeConnectorV1",
  "kv_buffer_device": "npu",
  "kv_role": "kv_producer",
  "kv_port": "55010",
  "engine_id": "0",
  "kv_connector_extra_config": {
            "prefill": {
                    "dp_size": 2,
                    "tp_size": 4
             },
             "decode": {
                    "dp_size": 4,
                    "tp_size": 2
             }
      }
   }'
```

D node
```bash
export IP_ADDRESS="80.5.17.107"
export NETWORK_CARD_NAME="enp48s3u1u1"
export HCCL_IF_IP=$IP_ADDRESS
export GLOO_SOCKET_IFNAME=$NETWORK_CARD_NAME
export TP_SOCKET_IFNAME=$NETWORK_CARD_NAME
export HCCL_SOCKET_IFNAME=$NETWORK_CARD_NAME
export VLLM_USE_V1=1
export HCCL_BUFFSIZE=1536
export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:$LD_LIBRARY_PATH
export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
export TASK_QUEUE_ENABLE=1
export VLLM_ASCEND_SKIP_LOW_BLOCKS=32
export ASCEND_RT_VISIBLE_DEVICES=4,5,6,7,12,13,14,15
vllm serve "/mnt/weight/Qwen3.5-397B-A17B-w4a8-mtp/Eco-Tech/Qwen3___5-397B-A17B-w4a8-mtp" \
  --host ${IP_ADDRESS} \
  --port 30050 \
  --enable-prefix-caching \
  --enable-expert-parallel \
  --data-parallel-size 4 \
  --api-server-count 1 \
  --max-num_seqs 8 \
  --tensor-parallel-size 2 \
  --seed 1024 \
  --distributed-executor-backend mp \
  --served-model-name qwen35 \
  --max-model-len 65535 \
  --max-num-batched-tokens 8192 \
  --trust-remote-code \
  --quantization ascend \
  --no-disable-hybrid-kv-cache-manager \
  --additional-config '{"recompute_scheduler_enable": true, "enable_cpu_binding": true}' \
  --speculative_config '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}' \
  --compilation-config '{"cudagraph_capture_sizes":[4,8,16,32], "cudagraph_mode": "FULL_DECODE_ONLY"}' \
  --gpu-memory-utilization 0.85 \
  --kv-transfer-config \
  '{"kv_connector": "MooncakeConnectorV1",
  "kv_buffer_device": "npu",
  "kv_role": "kv_consumer",
  "kv_port": "58010",
  "engine_id": "2",
  "kv_connector_extra_config": {
            "prefill": {
                    "dp_size": 2,
                    "tp_size": 4
             },
             "decode": {
                    "dp_size": 4,
                    "tp_size": 2
             }
      }
   }'
```


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
