### PR TITLE
[Test] add num_prompts and change batch_size to releases/v0.22.1rc  in DeepSeek-R1-W8A8-longseq.yaml

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-R1-W8A8-longseq.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-R1-W8A8-longseq.yaml
@@ -106,6 +106,7 @@ benchmarks:
     dataset_path: vllm-ascend/gsm8k
     request_conf: vllm_api_general_chat
     dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_chat_prompt
+    num_prompts: 360
     max_out_len: 4096
     batch_size: 16
     baseline: 95

--- a/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-R1-W8A8-longseq.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-R1-W8A8-longseq.yaml
@@ -108,6 +108,6 @@ benchmarks:
     dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_chat_prompt
     num_prompts: 360
     max_out_len: 4096
-    batch_size: 16
+    batch_size: 32
     baseline: 95
     threshold: 5


### PR DESCRIPTION
### What this PR does / why we need it?

main: https://github.com/vllm-project/vllm-ascend/pull/10886

This PR adds `num_prompts: 360` to the DeepSeek-R1-W8A8 longseq nightly accuracy benchmark config.

The original benchmark may timeout because it runs too many samples from the dataset. This change limits the number of evaluated prompts to 360, reducing the nightly benchmark runtime while still keeping enough samples for accuracy validation.

Changes:

* Add `num_prompts: 360` to the `acc` benchmark case.
* increase `batch_size` from 16 to 32 to lower benchmark pressure.
* Keep `dataset_path`, `request_conf`, `dataset_conf`, `max_out_len`, `batch_size`, `baseline`, and `threshold` unchanged.

### Does this PR introduce *any* user-facing change?

No. This PR only updates an internal nightly benchmark configuration and does not introduce any user-facing API, interface, or behavior change.

### How was this patch tested?

Not run locally. This change only updates the nightly benchmark configuration.

The updated benchmark is expected to be validated by the nightly CI.


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
