### PR TITLE
[BugFix][Attention] Fix stale KV lengths in hamming sparse attention under ACL graph replay

### DIFF
--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -11,7 +11,11 @@ from vllm_ascend.attention.attention_v1 import (
     AscendAttentionMetadataBuilder,
     AscendAttentionState,
 )
-from vllm_ascend.attention.kvcomp_attn.attention_utils import get_kvcomp_decode_params, reshape_and_cache_kvcomp
+from vllm_ascend.attention.kvcomp_attn.attention_utils import (
+    get_kvcomp_decode_params,
+    is_enable_hamming_sparse,
+    reshape_and_cache_kvcomp,
+)
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
     cache_graph_workspace,
@@ -49,6 +53,45 @@ class TestAttentionGraphHelpers(TestBase):
         vllm_config.speculative_config = None
         with patch("vllm_ascend.attention.utils.get_ascend_device_type", return_value=AscendDeviceType.A2):
             self.assertTrue(using_paged_attention(1, vllm_config, head_size=FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE))
+
+
+class TestHammingSparseConfig(TestBase):
+    @staticmethod
+    def _make_vllm_config(enable_hamming_sparse: bool):
+        return SimpleNamespace(
+            additional_config={"enable_hamming_sparse": enable_hamming_sparse},
+            speculative_config=None,
+        )
+
+    def test_hamming_sparse_with_c8_quant_raises(self):
+        vllm_config = self._make_vllm_config(enable_hamming_sparse=True)
+
+        with (
+            patch(
+                "vllm_ascend.attention.kvcomp_attn.attention_utils.get_current_vllm_config_or_none",
+                return_value=vllm_config,
+            ),
+            self.assertRaisesRegex(AssertionError, "does not support C8 KV cache quantization"),
+        ):
+            is_enable_hamming_sparse(enable_c8_quant=True)
+
+    def test_c8_quant_without_hamming_sparse_is_disabled(self):
+        vllm_config = self._make_vllm_config(enable_hamming_sparse=False)
+
+        with patch(
+            "vllm_ascend.attention.kvcomp_attn.attention_utils.get_current_vllm_config_or_none",
+            return_value=vllm_config,
+        ):
+            self.assertFalse(is_enable_hamming_sparse(enable_c8_quant=True))
+
+    def test_hamming_sparse_without_c8_quant_is_enabled(self):
+        vllm_config = self._make_vllm_config(enable_hamming_sparse=True)
+
+        with patch(
+            "vllm_ascend.attention.kvcomp_attn.attention_utils.get_current_vllm_config_or_none",
+            return_value=vllm_config,
+        ):
+            self.assertTrue(is_enable_hamming_sparse(enable_c8_quant=False))
 
 
 class TestAscendAttentionBackend(TestBase):

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -436,7 +436,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         self._use_max_workspace_for_fia_graph = self._use_layer_aware_fia_graph_replay
         self.sinks = sinks
         self.layerIndex = 0
-        self.enable_hamming_sparse = is_enable_hamming_sparse()
+        self.enable_hamming_sparse = is_enable_hamming_sparse(self.enable_c8_quant)
         # Some mixed-attention models cannot rely on the iteration order of
         # attn_metadata during graph replay. Record the captured layer name only
         # for that path.
@@ -703,6 +703,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 # window layers from accidentally sharing the same metadata.
                 attn_keys = [attn_keys[index % num_layers] for index in range(graph_param_count)]
             attn_count = 0
+            layer_count = 0
             with torch.npu.stream(update_stream):
                 for key, param, handle, event in zip(
                     attn_keys,
@@ -755,8 +756,16 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         # Keep the captured block_tables tensor on this affected path.
                         # Non-SWA models preserve the original behavior and continue to refresh
                         # block_tables from attn_metadata.
-                        if not hasattr(vllm_config.model_config.hf_text_config, "sliding_window"):
+                        obj = attn_metadata[key]
+                        if (
+                            hasattr(obj, "kvcomp_metadata")
+                            and hasattr(obj.kvcomp_metadata, "seq_lens_from_hamming")
+                            and obj.kvcomp_metadata.hashk_caches[layer_count] is not None
+                        ):
+                            seq_lens = obj.kvcomp_metadata.seq_lens_from_hamming
+                        elif not hasattr(vllm_config.model_config.hf_text_config, "sliding_window"):
                             block_tables = attn_metadata[metadata_key].block_tables
+                    layer_count += 1
 
                     torch.npu.graph_task_update_begin(update_stream, handle)
                     input_layout = "TND"

--- a/vllm_ascend/attention/kvcomp_attn/attention_utils.py
+++ b/vllm_ascend/attention/kvcomp_attn/attention_utils.py
@@ -142,11 +142,13 @@ def get_kvcomp_decode_params(
     return new_block_table, kvcomp_meta.seq_lens_from_hamming
 
 
-def is_enable_hamming_sparse():
+def is_enable_hamming_sparse(enable_c8_quant: bool) -> bool:
     vllm_config = get_current_vllm_config_or_none()
     if vllm_config is None:
         return False
     additional_config = vllm_config.additional_config if vllm_config.additional_config is not None else {}
     enable_hamming_sparse = additional_config.get("enable_hamming_sparse", False)
     enable_hamming_sparse = enable_hamming_sparse and not vllm_config.speculative_config
+    if enable_hamming_sparse:
+        assert not enable_c8_quant, "Hamming sparse attention does not support C8 KV cache quantization."
     return enable_hamming_sparse


### PR DESCRIPTION
# [BugFix][Attention] Fix stale KV lengths in hamming sparse attention under ACL graph replay

- **Commit**: `4edfcc103d2b01b7cffded2971fa792620ab9f0f` (vllm-ascend)
- **Modules**: `vllm_ascend/attention/attention_v1.py`, `vllm_ascend/attention/kvcomp_attn/attention_utils.py`
- **Type**: BugFix (accuracy)
- **Impact scope**: Only the combination of "hamming sparse enabled + ACL full-graph replay"; all other configurations are unaffected

---

## Summary

On the ACL full-graph replay path, the KV sequence length passed to the FIA operator for hamming sparse attention was not refreshed to the hamming-reduced value. As a result, the attention computed in graph mode diverged from the eager-mode result, causing an accuracy regression. This PR adds a per-layer override that rebinds the KV length correctly.

---

## Background

During the decode phase, hamming sparse attention selects the top-k most relevant KV blocks per request via hamming distance and only attends over those blocks. The corresponding KV length is `seq_lens_from_hamming` (shorter than the true full length). It is computed in `attention_utils.py:48-52`:

```python
new_seq_lens = torch.where(
    remainder == 0,
    chunk_size * top_k_cpu,                    # evenly divisible: exactly top-k blocks
    chunk_size * (top_k_cpu - 1) + remainder,  # with remainder: append the tail
)
```

The eager path (`forward_fused_infer_attention` -> `get_kvcomp_decode_params`) has always used this reduced length and produces correct results.

---

## The Problem

Under ACL full-graph replay, when a captured FIA subgraph is replayed, tensors such as `query` / `key_cache` / `value` / `block_table` are rebound to the latest metadata, but `seq_lens` (i.e. the FIA operator's `actual_seq_lengths_kv`) is kept at the full length `seq_lens_list` captured at capture time and is **not** replaced with `seq_lens_from_hamming`.

Consequence: the replayed graph actually attends over the **full KV**, inconsistent with the eager path (which only attends over the selected top-k blocks) -> accuracy regression.

### Trigger condition

The graph-replay path is only taken when the master switch at `model_runner_v1.py:2495-2499` is true:

```python
if (cudagraph_runtime_mode == CUDAGraphMode.FULL   # using ACL full-graph mode
    and not forward_context.capturing               # currently "replaying", not "capturing"
    and not self.use_sparse and not self.use_compress):  # not the DSA compression path
```

---

## Before vs. After

### Behavior comparison

| Aspect | Before | After |
| --- | --- | --- |
| KV length passed to FIA on replay | full `seq_lens_list` | hamming-reduced `seq_lens_from_hamming` |
| Hamming-active layer | attends full KV -> diverges from eager | attends selected top-k blocks -> aligned with eager |
| skip/rollback layer | full length | full length (unchanged, skipped via `hashk_caches[i] is None`) |
| Non-hamming model | original behavior | original behavior (`hasattr` short-circuits, zero impact) |

### Worked example

Consider a decode step with 1 request that has generated `seq_len = 512`, `block_size = 128` (4 blocks in total), and hamming selects top-k = 2 most relevant blocks.

- `remainder = 512 % 128 = 0` -> `seq_lens_from_hamming = 128 x 2 = 256`

The `actual_seq_lengths_kv` received by the FIA operator is then:

```
eager path (correct baseline): 256   -> attend over 2 selected blocks
graph replay, BEFORE:          512   -> attend over all 4 blocks   <- bug
graph replay, AFTER:           256   -> attend over 2 selected blocks   <- fixed
```

> Analogy: graph replay is like "record a recipe, then swap ingredients". At capture time the "how much to use" (seq_lens) was recorded; at replay, the query/key/block_table ingredients are swapped for fresh ones, but the "how much" bowl was left unchanged -> it still uses the full amount recorded earlier. This PR swaps that bowl too, at replay time, with the hamming-reduced amount.

---

## The Fix

In the FIA replay branch (non-draft path) of `update_graph_params` (`attention_v1.py:402`), `seq_lens` is overridden per layer:

```python
obj = attn_metadata[key]
if (hasattr(obj, 'kvcomp_metadata')
        and hasattr(obj.kvcomp_metadata, 'seq_lens_from_hamming')
        and obj.kvcomp_metadata.hashk_caches[layer_count] is not None):
    seq_lens = obj.kvcomp_metadata.seq_lens_from_hamming   # active layer: reduced length
elif not hasattr(vllm_config.model_config.hf_text_config, "sliding_window"):
    block_tables = attn_metadata[key].block_tables          # non-SWA: original behavior
layer_count += 1
```

Per-layer semantics:

- **Hamming-active layer** (`hashk_caches[i]` not None) -> overridden with `seq_lens_from_hamming` ✓
- **skip/rollback layer** (`hashk_caches[i]` is None) -> condition not met, keeps full length ✓
- **Non-hamming model** -> `obj` has no `kvcomp_metadata` attribute -> first `hasattr` is False, the whole `and` short-circuits -> falls through to the original `elif` branch, behavior unchanged ✓

### Incidental change: config key alignment

`is_enable_hamming_sparse()` (`attention_utils.py:145`) migrates from the legacy flat key `enable_hamming_sparse` (bool) to the new nested key `hamming_sparse` (dict containing `enabled` and `sparse_json_location`), aligning with the format already used by `AscendConfig` (`ascend_config.py:277-280`).

```python
# before
enable_hamming_sparse = additional_config.get("enable_hamming_sparse", False)
# after
hamming_sparse = additional_config.get("hamming_sparse", {"enabled": False, "sparse_json_location": ""})
enable_hamming_sparse = hamming_sparse["enabled"]
```

---

## Call chain

```
model_runner_v1.execute_model (1663)
  -> _model_forward (2514)
    -> _update_full_graph_params_if_needed (2489)        [trigger condition above]
      -> acl_graph.update_full_graph_params (226)
        -> impl_cls.update_graph_params (attention_v1.py:402)   <- fix location
          -> for key in zip(attn_keys, attn_params, handles, events):
               non-draft branch: override seq_lens = seq_lens_from_hamming (638-639)
               -> npu_fused_infer_attention_score.out(..., actual_seq_lengths_kv=seq_lens) (658)
```

Compared with the eager path: `get_kvcomp_decode_params` (`attention_utils.py:116-142`) returns **both** the new `block_table` (`hamming_output`) and `seq_lens_from_hamming`; the graph-replay path only overrides `seq_lens`.

---


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/e5588e49bc2642670116664a7fc4096e27adb179
