### PR TITLE
[BugFix] Fix Qwen3.5 precision error  with ACL Graph, MTP and DP

### DIFF
--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -221,6 +221,13 @@ def update_conv1d_graph_params(
                         q_per_seq=q_per_seq,
                         with_num_accepted=True,
                     )
+                elif branch == "spec" and meta.spec_sequence_masks is None:
+                    # The captured graph may contain a spec conv1d task even
+                    # when this DP rank has no runtime spec sequence. Leaving
+                    # cache_indices empty makes the kernel use default
+                    # batch-indexed state writes, which can corrupt conv_state.
+                    # Mark every input row as -1 so the task is a state no-op.
+                    new_cache_indices = (-1,) * cap_x_dim0
                 elif branch == "non_spec_decode":
                     non_sdq_host, non_sd_cidx_host = get_causal_conv1d_update_host_args(meta)
                     new_query_start_loc, new_cache_indices, _ = _pad_conv1d_host_args_to_capture(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3414,6 +3414,11 @@ class NPUModelRunner(GPUModelRunner):
                     num_tokens_padded, num_reqs_padded, num_reqs, cudagraph_runtime_mode, batch_desc.num_reqs
                 )
 
+            # Dummy graph runs do not go through _prepare_inputs(), but GDN/Mamba
+            # metadata reads block_table[:num_reqs_padded] below. Sync padded
+            # rows as well so device-side metadata does not see stale block ids.
+            self.input_batch.block_table.commit_block_table(num_reqs_padded)
+
             pad_attn = cudagraph_runtime_mode == CUDAGraphMode.FULL
             # check how to build dummy
             if self.use_compress:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes two Qwen3.5/GDN graph-mode state corruption issues observed with DP > 1 and MTP/ Graph Mode enabled.

#### 1. Stale block table in dummy graph runs

In PD disaggregation decode scenarios, dummy graph runs do not go through `_prepare_inputs()`, but GDN/Mamba attention metadata still reads `block_table[:num_reqs_padded]` from device.

Without syncing the CPU block table to device before building dummy attention metadata, padded rows may contain stale block ids. These stale ids can be used as GDN/Mamba state indices during graph warmup/capture, corrupting low or wrong state blocks. This is related to [vLLM PR #37728](https://github.com/vllm-project/vllm/pull/37728), which fixed stale Mamba state caused by dummy graph runs reading stale block table entries.

This PR syncs:

```python
self.input_batch.block_table.commit_block_table(num_reqs_padded)
```
before dummy attention metadata is built, matching the exact range read by metadata.

#### 2. Empty spec conv1d graph task writes GDN conv_state
With MTP + DP + ACL Graph, a captured GDN spec conv1d graph task may replay on a rank/batch that has no runtime spec sequence. In that case meta.spec_sequence_masks is None, which is a valid metadata state meaning there is no spec decode work for this rank.
The old graph update path left cache_indices empty. However, the custom causal conv1d op does not treat empty cache_indices as no-op; it falls back to default batch-indexed state writes and may update persistent conv_state[0..x.shape[0]). This can corrupt GDN state and cause first requests to collapse into repeated !!!!!.
This PR passes one `-1` per input row when the captured branch is spec but runtime has no spec sequence, which mean do no-op:

```python
new_cache_indices = (-1,) * cap_x_dim0
```
### Does this PR introduce any user-facing change?
No API or configuration change.

### How was this patch tested?

Manual NPU validation should cover:
Qwen3.5+ PD disaggregation + DP > 1 + ACL Graph without MTP

Qwen3.5/GDN + PD disaggregation + DP > 1 + ACL Graph with MTP

First request  per DP rank should return normally and no longer collapse into repeated !!!!!
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
