### PR TITLE
[Ops][BugFix] Omit empty tool_calls in chat completion payloads

### DIFF
--- a/tests/ut/patch/platform/test_patch_tool_choice_none_content.py
+++ b/tests/ut/patch/platform/test_patch_tool_choice_none_content.py
@@ -93,10 +93,33 @@ def test_chat_completion_response_omits_empty_tool_calls_payload():
     response = _chat_response(ChatMessage(role="assistant", content="done"))
 
     payload = response.model_dump()
+    payload_json = response.model_dump_json()
 
     assert "tool_calls" not in payload["choices"][0]["message"]
     parsed = OpenAIChatCompletion.model_validate(payload)
     assert parsed.choices[0].message.tool_calls is None
+    parsed_json = OpenAIChatCompletion.model_validate_json(payload_json)
+    assert parsed_json.choices[0].message.tool_calls is None
+
+
+def test_chat_completion_response_model_dump_json_uses_json_mode(monkeypatch):
+    seen_kwargs = {}
+
+    def fake_model_dump(self, *args, **kwargs):
+        seen_kwargs.update(kwargs)
+        return {"choices": [{"message": {"tool_calls": []}}]}
+
+    monkeypatch.setattr(
+        patch_tool_choice_none_content,
+        "_original_chat_completion_response_model_dump",
+        fake_model_dump,
+    )
+
+    response = _chat_response(ChatMessage(role="assistant", content="done"))
+    payload_json = response.model_dump_json()
+
+    assert seen_kwargs["mode"] == "json"
+    assert payload_json == '{"choices":[{"message":{}}]}'
 
 
 def test_chat_completion_response_keeps_non_empty_tool_calls_payload():

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -321,23 +321,19 @@
 #
 # ** 11. File: platform/patch_tool_choice_none_content.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#   1. `vllm.entrypoints.openai.engine.serving.OpenAIServing._parse_tool_calls_from_content`
-#      `vllm.parser.abstract_parser.DelegatingParser._parse_tool_calls`
+#   1. `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionResponse`
+#      `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionStreamResponse`
 #    Why:
-#       Forced tool choice can receive `content=None` when reasoning extraction
-#       consumes the whole generated text, for example when generation stops at
-#       `max_tokens`. Upstream vLLM 0.19.1 asserts in that case.
+#       vLLM v0.23.0 can serialize empty `tool_calls: []` fields for content-only
+#       OpenAI chat responses / streaming deltas, while OpenAI-compatible SDKs
+#       expect those empty fields to be omitted so clients see `tool_calls=None`.
 #    How：
-#       Return an empty tool-call list for forced tool choice with `content=None`
-#       and mark the current named chat tool-choice result so the downstream
-#       chat response path does not assert. Preserve normal forced tool-call
-#       behavior when content is present.
+#       Wrap `model_dump` / `model_dump_json` for chat response payloads and drop
+#       empty `tool_calls` lists from `message` / `delta` objects.
 #    Related PR (if no, explain why):
-#       https://github.com/vllm-project/vllm/pull/40148
-#       https://github.com/vllm-project/vllm-ascend/pull/8400
+#       https://github.com/vllm-project/vllm/pull/44105
 #    Future Plan:
-#       Remove this patch once the vLLM fix is included in the supported vLLM
-#       version.
+#       Remove this patch once the supported vLLM version contains PR #44105.
 #
 # ** 12. File: platform/patch_deepseek_v4_tool_call_parser.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/platform/patch_tool_choice_none_content.py
+++ b/vllm_ascend/patch/platform/patch_tool_choice_none_content.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# OpenAI forced tool choice: tolerate None content after reasoning extraction.
+# OpenAI chat completions: omit empty tool_calls in serialized payloads.
 #
 
 from __future__ import annotations
@@ -22,13 +22,10 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from openai.types.responses import ToolChoiceFunction
 from vllm.entrypoints.openai.chat_completion.protocol import (
-    ChatCompletionNamedToolChoiceParam,
     ChatCompletionResponse,
     ChatCompletionStreamResponse,
 )
-from vllm.parser.abstract_parser import DelegatingParser
 
 _original_chat_completion_response_model_dump = ChatCompletionResponse.model_dump
 _original_chat_completion_stream_response_model_dump = ChatCompletionStreamResponse.model_dump
@@ -57,6 +54,20 @@ def _patched_chat_completion_response_model_dump(self, *args, **kwargs):
     return _omit_empty_tool_calls(_original_chat_completion_response_model_dump(self, *args, **kwargs))
 
 
+def _dump_json(payload: Any, indent: int | None, ensure_ascii: bool) -> str:
+    separators = None if indent is not None else (",", ":")
+    return json.dumps(payload, ensure_ascii=ensure_ascii, indent=indent, separators=separators)
+
+
+def _patched_chat_completion_response_model_dump_json(self, *args, **kwargs):
+    dump_kwargs = dict(kwargs)
+    indent = dump_kwargs.pop("indent", None)
+    ensure_ascii = dump_kwargs.pop("ensure_ascii", False)
+    dump_kwargs.setdefault("mode", "json")
+    payload = _patched_chat_completion_response_model_dump(self, *args, **dump_kwargs)
+    return _dump_json(payload, indent, ensure_ascii)
+
+
 def _patched_chat_completion_stream_response_model_dump(self, *args, **kwargs):
     return _omit_empty_tool_calls(_original_chat_completion_stream_response_model_dump(self, *args, **kwargs))
 
@@ -65,42 +76,12 @@ def _patched_chat_completion_stream_response_model_dump_json(self, *args, **kwar
     dump_kwargs = dict(kwargs)
     indent = dump_kwargs.pop("indent", None)
     ensure_ascii = dump_kwargs.pop("ensure_ascii", False)
+    dump_kwargs.setdefault("mode", "json")
     payload = _patched_chat_completion_stream_response_model_dump(self, *args, **dump_kwargs)
-    separators = None if indent is not None else (",", ":")
-    return json.dumps(payload, ensure_ascii=ensure_ascii, indent=indent, separators=separators)
+    return _dump_json(payload, indent, ensure_ascii)
 
 
 ChatCompletionResponse.model_dump = _patched_chat_completion_response_model_dump
+ChatCompletionResponse.model_dump_json = _patched_chat_completion_response_model_dump_json
 ChatCompletionStreamResponse.model_dump = _patched_chat_completion_stream_response_model_dump
 ChatCompletionStreamResponse.model_dump_json = _patched_chat_completion_stream_response_model_dump_json
-
-
-def _is_forced_tool_choice(request) -> bool:
-    tool_choice = getattr(request, "tool_choice", None)
-    return isinstance(
-        tool_choice,
-        (ToolChoiceFunction, ChatCompletionNamedToolChoiceParam),
-    )
-
-
-_original_delegating_parse_tool_calls = DelegatingParser._parse_tool_calls
-
-
-def _patched_delegating_parse_tool_calls(
-    self,
-    request,
-    content: str | None,
-    enable_auto_tools: bool,
-):
-    if content is None and _is_forced_tool_choice(request):
-        return [], None
-
-    return _original_delegating_parse_tool_calls(
-        self,
-        request,
-        content,
-        enable_auto_tools,
-    )
-
-
-DelegatingParser._parse_tool_calls = _patched_delegating_parse_tool_calls


### PR DESCRIPTION
### What this PR does / why we need it?

Narrows `patch_tool_choice_none_content.py` after the main2main update to vLLM `v0.23.0`.

vLLM `v0.23.0` already includes https://github.com/vllm-project/vllm/pull/40148, which tolerates forced tool-choice parsing when reasoning extraction leaves `content=None`, so this PR removes the local `DelegatingParser._parse_tool_calls` monkey patch.

The patch still keeps the empty `tool_calls` serializer shim because https://github.com/vllm-project/vllm/pull/44105 is not included in vLLM `v0.23.0`. The shim now covers both non-streaming and streaming JSON payloads, and `model_dump_json()` defaults to `mode="json"` before calling `json.dumps()`.

### Does this PR introduce _any_ user-facing change?

Yes. Serialized chat completion payloads omit empty `tool_calls` fields so OpenAI-compatible clients see `tool_calls=None` instead of an empty list.

### How was this patch tested?

- `python -m compileall -q vllm_ascend/patch/platform/patch_tool_choice_none_content.py tests/ut/patch/platform/test_patch_tool_choice_none_content.py`
- `ruff check vllm_ascend/patch/platform/patch_tool_choice_none_content.py tests/ut/patch/platform/test_patch_tool_choice_none_content.py`
- `PYTHONPATH=/tmp/vllm-v0.23.0-tool-choice python -m pytest -q tests/ut/patch/platform/test_patch_tool_choice_none_content.py` (`6 passed`)
- `git diff --check`
- Direct JSON-shape probe against local vLLM `v0.23.0` source: non-streaming `model_dump_json()` omits empty `tool_calls` and the OpenAI SDK parses `tool_calls` as `None`.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
