### PR TITLE
[BugFix] fix qwen3.5+pcp+mtp error

### DIFF
--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -292,6 +292,9 @@ jobs:
           - name: Qwen3.5-397B-A17B-w8a8-mtp
             os: linux-aarch64-a3-16
             config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3.yaml
+          - name: Qwen3.5-397B-A17B-w8a8-mtp-longseq
+            os: linux-aarch64-a3-16
+            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-longseq-A3.yaml
           - name: MiniMax-M2.5-w8a8-QuaRot-A3
             os: linux-aarch64-a3-16
             config_file_path: MiniMax-M2.5-w8a8-QuaRot-A3.yaml

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3.5-397B-A17B-w8a8-mtp-longseq-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3.5-397B-A17B-w8a8-mtp-longseq-A3.yaml
@@ -1,0 +1,60 @@
+# ==========================================
+# ACTUAL TEST CASES
+# ==========================================
+
+test_cases:
+  - name: "Qwen3.5-397B-A17B-w8a8-mtp-longseq"
+    model: "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp"
+    envs:
+      VLLM_USE_MODELSCOPE: "true"
+      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      HCCL_BUFFSIZE: "1024"
+      OMP_NUM_THREADS: "1"
+      TASK_QUEUE_ENABLE: "1"
+      SERVER_PORT: "DEFAULT_PORT"
+      VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
+      VLLM_ENGINE_READY_TIMEOUT_S: "3000"
+      VLLM_RPC_TIMEOUT: "6000"
+    server_cmd:
+      - "--tensor-parallel-size"
+      - "8"
+      - "--data-parallel-size"
+      - "1"
+      - "--prefill-context-parallel-size"
+      - "2"
+      - "--enable-expert-parallel"
+      - "--port"
+      - "$SERVER_PORT"
+      - "--max-num-seqs"
+      - "32"
+      - "--quantization"
+      - "ascend"
+      - "--max-model-len"
+      - "133120"
+      - "--max-num-batched-tokens"
+      - "16384"
+      - "--trust-remote-code"
+      - "--gpu-memory-utilization"
+      - "0.9"
+      - "--speculative_config"
+      - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}'
+      - "--compilation-config"
+      - '{"cudagraph_capture_sizes":[1,4,8,16,32,64], "cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--allowed-local-media-path"
+      - "/"
+      - "--mm-processor-cache-gb"
+      - "0"
+      - "--safetensors-load-strategy"
+      - "lazy"
+    benchmarks:
+      acc_GPQA:
+        case_type: accuracy
+        dataset_path: vllm-ascend/gpqa
+        request_conf: vllm_api_general_chat
+        dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
+        num_prompts: 50
+        max_out_len: 32768
+        batch_size: 32
+        baseline: 82
+        threshold: 8

--- a/tests/ut/worker/test_pcp_manager.py
+++ b/tests/ut/worker/test_pcp_manager.py
@@ -11,7 +11,6 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 
-import math
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -486,29 +485,6 @@ def test_generate_pcp_mtp_input(
                        target_query_start_loc_pcp_full)
 
 
-def _realistic_num_pcp_pads(
-    num_scheduled_tokens: list[int],
-    pcp_world_size: int,
-    num_decode_reqs: int,
-) -> list[int]:
-    """Compute num_pcp_pads exactly as PCPManager.update_tokens_for_pcp would.
-
-    Decode reqs duplicate tokens across pcp_world_size ranks, so their pad
-    count is num_tokens * (pcp_world_size - 1). Prefill reqs are padded up
-    to a multiple of 2 * pcp_world_size, so their pad count is the difference
-    between the padded and original length.
-    """
-    pads: list[int] = []
-    pad_multiple = 2 * pcp_world_size
-    for i, n in enumerate(num_scheduled_tokens):
-        if i < num_decode_reqs:
-            pads.append(n * (pcp_world_size - 1))
-        else:
-            padded = math.ceil(n / pad_multiple) * pad_multiple
-            pads.append(padded - n)
-    return pads
-
-
 # yapf: disable
 @pytest.mark.parametrize(
     "pcp_size, num_scheduled_tokens, num_decode_reqs,"
@@ -516,35 +492,29 @@ def _realistic_num_pcp_pads(
     [
         # Case 1: no prefill reqs -> returned unchanged.
         (2, [1, 1], 2, [1, 2]),
-        # Case 2: prefill only (num_decode_reqs == 0). Exercises the case where
-        # the diff-based per-req length derivation would otherwise drop the
-        # first req's length.
-        #   num_scheduled=[3, 5], realistic pads=[1, 3] -> cumsum=[1, 4]
-        #   cu=[3, 8]; padded prefill_lens=[4, 8]; base=0
-        #   prefill_cu=[4, 12]; final = [4*2-1, 12*2-4] = [7, 20]
-        (2, [3, 5], 0, [7, 20]),
+        # Case 2: prefill only (num_decode_reqs == 0).
+        #   pcp_tokens (local prefill len) = [ceil(3/4)*2, ceil(5/4)*2] = [2, 4]
+        #   cu=[3, 8]; pads cumsum=[1, 4]; base=0
+        #   prefill_cu=[2, 6]; final = [2*2-1, 6*2-4] = [3, 8]
+        (2, [3, 5], 0, [3, 8]),
         # Case 3: mix decode + prefill, pcp_size=2.
-        #   num_scheduled=[1, 1, 3, 5], realistic pads=[1, 1, 1, 3]
-        #   prefill pads cumsum=[1, 4]
-        #   cu=[1, 2, 5, 10]; padded prefill_lens=[4, 8]; base=cu[1]=2
-        #   prefill_cu=[6, 14]; final[2:] = [12, 28] - [1, 4] = [11, 24]
-        (2, [1, 1, 3, 5], 2, [1, 2, 11, 24]),
+        #   cu=[1, 2, 5, 10]; decode part [1, 2] stays unchanged
+        #   pcp_tokens[2:] = [2, 4]; pads[2:] cumsum=[1, 4]; base=cu[1]=2
+        #   prefill_cu=[4, 8]; final[2:] = [4*2-1, 8*2-4] = [7, 12]
+        (2, [1, 1, 3, 5], 2, [1, 2, 7, 12]),
         # Case 4: pcp_size=4, mix decode + prefill with uneven prefill tokens.
-        #   num_scheduled=[1, 1, 5, 9], realistic pads=[3, 3, 3, 7]
-        #   prefill pads cumsum=[3, 10]
-        #   cu=[1, 2, 7, 16]; padded prefill_lens=[8, 16]; base=cu[1]=2
-        #   prefill_cu=[10, 26]; final[2:] = [40, 104] - [3, 10] = [37, 94]
-        (4, [1, 1, 5, 9], 2, [1, 2, 37, 94]),
+        #   cu=[1, 2, 7, 16]; decode part [1, 2] stays unchanged
+        #   pcp_tokens[2:] = [ceil(5/8)*2, ceil(9/8)*2] = [2, 4]
+        #   pads[2:] cumsum=[3, 10]; base=cu[1]=2
+        #   prefill_cu=[4, 8]; final[2:] = [4*4-3, 8*4-10] = [13, 22]
+        (4, [1, 1, 5, 9], 2, [1, 2, 13, 22]),
         # Case 5: single prefill req, pcp_size=2.
-        #   num_scheduled=[7], realistic pads=[1]
-        #   cu=[7]; padded prefill_lens=[8]; base=0
-        #   prefill_cu=[8]; final = [8*2-1] = [15]
-        (2, [7], 0, [15]),
-        # Case 6: prefill req that's already aligned to 2*pcp_size.
-        #   num_scheduled=[8], realistic pads=[0]
-        #   cu=[8]; padded prefill_lens=[8]; base=0
-        #   prefill_cu=[8]; final = [8*2-0] = [16]
-        (2, [8], 0, [16]),
+        #   pcp_tokens = [ceil(7/4)*2] = [4]; pads cumsum=[1]; base=0
+        #   prefill_cu=[4]; final = [4*2-1] = [7]
+        (2, [7], 0, [7]),
+        # Case 6: prefill req already aligned to 2*pcp_size (no pad).
+        #   pcp_tokens = [4]; pads=[0]; base=0; final = [4*2-0] = [8]
+        (2, [8], 0, [8]),
     ],
 )
 # yapf: enable
@@ -557,6 +527,8 @@ def test_adjust_cu_num_scheduled_tokens_for_pcp(
     vllm_config = MagicMock()
     vllm_config.model_config = MagicMock()
     vllm_config.speculative_config.num_speculative_tokens = 0
+    vllm_config.scheduler_config.max_num_batched_tokens = 10000
+    vllm_config.scheduler_config.max_num_seqs = 1000
 
     pcp_manager = PCPManager(
         pcp_world_size=pcp_size,
@@ -572,21 +544,23 @@ def test_adjust_cu_num_scheduled_tokens_for_pcp(
     )
 
     num_reqs = len(num_scheduled_tokens)
-    cu_num_scheduled_tokens = np.cumsum(
-        np.array(num_scheduled_tokens, dtype=np.int32)
-    )
-    # Use realistic pads that match what update_tokens_for_pcp would produce
-    # for the given num_scheduled_tokens / pcp_world_size combination.
-    # Tests previously fed zeros for prefill pads, which made the math look
-    # correct but never exercised the real runtime path.
-    num_pcp_pads = np.array(
-        _realistic_num_pcp_pads(num_scheduled_tokens, pcp_size, num_decode_reqs),
+    num_scheduled_tokens_np = np.array(num_scheduled_tokens, dtype=np.int32)
+    num_computed_tokens = np.array(
+        [num_scheduled_tokens[i] if i < num_decode_reqs else 0 for i in range(num_reqs)],
         dtype=np.int32,
     )
+    num_prompt_tokens = num_scheduled_tokens_np.copy()
+    pcp_manager.init_batch_info(
+        num_scheduled_tokens_np,
+        num_reqs,
+        num_computed_tokens,
+        num_prompt_tokens,
+    )
 
-    # Seed the manager state normally populated by init_batch_info.
-    pcp_manager.num_decode_reqs = num_decode_reqs
-    pcp_manager.num_prefill_reqs = num_reqs - num_decode_reqs
+    cu_num_scheduled_tokens = np.cumsum(num_scheduled_tokens_np)
+    pcp_manager.update_tokens_for_pcp(num_scheduled_tokens_np, np.arange(10000))
+    assert pcp_manager.num_decode_reqs == num_decode_reqs
+    num_pcp_pads = pcp_manager.num_pcp_pads_cpu[:num_reqs].astype(np.int32)
 
     result = pcp_manager.adjust_cu_num_scheduled_tokens_for_pcp(
         cu_num_scheduled_tokens, num_pcp_pads

--- a/vllm_ascend/ops/triton/mamba/causal_conv1d.py
+++ b/vllm_ascend/ops/triton/mamba/causal_conv1d.py
@@ -130,9 +130,9 @@ def causal_conv1d_fn(
     prefill_seq_offset = max(0, len(seqlens) - num_prefills)
     last_width_prefill_x = extract_last_width(x, query_start_loc[prefill_seq_offset:], state_len)
 
+    pcp_rank = get_pcp_group().rank_in_group
     if get_pcp_group().world_size > 1:
         all_last_width_prefill_x = get_pcp_group().all_gather(last_width_prefill_x.unsqueeze(0).contiguous(), 0)
-        pcp_rank = get_pcp_group().rank_in_group
         if pcp_rank > 0:
             conv_states[cache_indices[prefill_seq_offset:], :, :state_len] = all_last_width_prefill_x[pcp_rank - 1, ...]
 
@@ -140,6 +140,10 @@ def causal_conv1d_fn(
         x_s = splits[i]
         if cache_indices[i] == PAD_SLOT_ID:
             continue
+        if pcp_rank == 0 and not bool(has_initial_state[i].item()):
+            initial_states = None
+        else:
+            initial_states = conv_states[cache_indices[i]][..., : (width - 1)]
         out_ref_b.append(
             causal_conv1d_ref(
                 x_s,
@@ -148,7 +152,7 @@ def causal_conv1d_fn(
                 activation=activation,
                 return_final_states=True,
                 final_states_out=conv_states[cache_indices[i]][..., : (width - 1)].unsqueeze(0),
-                initial_states=conv_states[cache_indices[i]][..., : (width - 1)],
+                initial_states=initial_states,
             )
         )
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1053,13 +1053,29 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         if self.pcp_size > 1:
             # remove graph padding before all_gather
             hidden_states = hidden_states[:num_input_tokens]
-            hidden_states = self.runner.pcp_manager.get_restore_hidden_states(hidden_states)
+            if self.runner.pcp_manager.pcp_use_hybrid_attn:
+                hidden_states = self.runner.pcp_manager.get_restore_hidden_states(hidden_states)
+            else:
+                hidden_states = get_pcp_group().all_gather(hidden_states, 0)
+                hidden_states = torch.index_select(
+                    hidden_states,
+                    0,
+                    self.runner.pcp_manager.pcp_allgather_restore_idx.gpu[: num_input_tokens * self.pcp_size],
+                )
             if self.method == "mtp":
                 last_hidden_states = hidden_states
             else:
                 # eagle and eagle3 need allgather last_hidden_states.
                 last_hidden_states = last_hidden_states[:num_input_tokens]
-                last_hidden_states = self.runner.pcp_manager.get_restore_hidden_states(last_hidden_states)
+                if self.runner.pcp_manager.pcp_use_hybrid_attn:
+                    last_hidden_states = self.runner.pcp_manager.get_restore_hidden_states(last_hidden_states)
+                else:
+                    last_hidden_states = get_pcp_group().all_gather(last_hidden_states, 0)
+                    last_hidden_states = torch.index_select(
+                        last_hidden_states,
+                        0,
+                        self.runner.pcp_manager.pcp_allgather_restore_idx.gpu[: num_input_tokens * self.pcp_size],
+                    )
 
         if lmhead_tp_enable():
             token_indices_to_sample = nn.functional.pad(

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1054,23 +1054,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         if self.pcp_size > 1:
             # remove graph padding before all_gather
             hidden_states = hidden_states[:num_input_tokens]
-            hidden_states = get_pcp_group().all_gather(hidden_states, 0)
-            hidden_states = torch.index_select(
-                hidden_states,
-                0,
-                self.runner.pcp_manager.pcp_allgather_restore_idx.gpu[: num_input_tokens * self.pcp_size],
-            )
+            hidden_states = self.runner.pcp_manager.get_restore_hidden_states(hidden_states)
             if self.method == "mtp":
                 last_hidden_states = hidden_states
             else:
                 # eagle and eagle3 need allgather last_hidden_states.
                 last_hidden_states = last_hidden_states[:num_input_tokens]
-                last_hidden_states = get_pcp_group().all_gather(last_hidden_states, 0)
-                last_hidden_states = torch.index_select(
-                    last_hidden_states,
-                    0,
-                    self.runner.pcp_manager.pcp_allgather_restore_idx.gpu[: num_input_tokens * self.pcp_size],
-                )
+                last_hidden_states = self.runner.pcp_manager.get_restore_hidden_states(last_hidden_states)
 
         if lmhead_tp_enable():
             token_indices_to_sample = nn.functional.pad(
@@ -1323,19 +1313,24 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 input_ids_p = self.input_ids[num_tokens_d:num_tokens]
                 target_hidden_states_d_padded = target_hidden_states[:num_tokens_d_padded]
                 if num_tokens_d:
-                    # remove padding (from pcp all-gather) in decode part
-                    mask_start_loc = torch.cat(
-                        [
-                            torch.tensor([0], dtype=torch.int32, device=query_lens_d.device),
-                            torch.cumsum(query_lens_d * self.pcp_size, dim=0)[:-1],
-                        ]
-                    )
-                    mask_len = query_lens_d
-                    mask = []
-                    for req_id in range(num_decode_reqs):
-                        assert None not in (mask_start_loc, mask_len)
-                        mask += list(range(mask_start_loc[req_id], mask_start_loc[req_id] + mask_len[req_id]))
-                    target_hidden_states_d = target_hidden_states_d_padded[mask]
+                    if self.runner.pcp_manager.pcp_use_hybrid_attn:
+                        # Hybrid PCP restores decode hidden states rank-major:
+                        # [rank0 all decode tokens, rank1 all decode tokens, ...].
+                        target_hidden_states_d = target_hidden_states_d_padded[:num_tokens_d]
+                    else:
+                        # remove padding (from pcp all-gather) in decode part
+                        mask_start_loc = torch.cat(
+                            [
+                                torch.tensor([0], dtype=torch.int32, device=query_lens_d.device),
+                                torch.cumsum(query_lens_d * self.pcp_size, dim=0)[:-1],
+                            ]
+                        )
+                        mask_len = query_lens_d
+                        mask = []
+                        for req_id in range(num_decode_reqs):
+                            assert None not in (mask_start_loc, mask_len)
+                            mask += list(range(mask_start_loc[req_id], mask_start_loc[req_id] + mask_len[req_id]))
+                        target_hidden_states_d = target_hidden_states_d_padded[mask]
                 else:
                     target_hidden_states_d = target_hidden_states_d_padded
                 target_hidden_states_p = target_hidden_states[num_tokens_d_padded:]
@@ -1675,7 +1670,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 attn_metadata.decode.cp_seq_len = cp_seq_len
             else:
                 attn_metadata.decode_meta.num_computed_tokens_of_pcp_dcp = num_computed_tokens_of_pcp_dcp.numpy()
-                attn_metadata.decode_meta.dcp_mtp_attn_mask = None
 
         return common_attn_metadata, attn_metadata
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -12,7 +12,6 @@ import torch.nn.functional as F
 import vllm.distributed.parallel_state as _ps  # type: ignore[import-not-found]
 from vllm.config import CompilationMode, CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
 from vllm.distributed.parallel_state import (
-    get_pcp_group,
     get_pp_group,
     get_tp_group,
     get_world_group,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -12,6 +12,7 @@ import torch.nn.functional as F
 import vllm.distributed.parallel_state as _ps  # type: ignore[import-not-found]
 from vllm.config import CompilationMode, CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
 from vllm.distributed.parallel_state import (
+    get_pcp_group,
     get_pp_group,
     get_tp_group,
     get_world_group,

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -149,6 +149,7 @@ class PCPManager:
         self.pcp_padded_tokens_length = 0
         self.num_scheduled_tokens_padded: np.ndarray | None = None
         self.max_num_tokens_across_pcp = 0
+        self.total_pcp_padding_tokens_fla = 0
         self.pcp_tokens_padded = None
         self.total_num_scheduled_tokens = 0
         self._local_num_scheduled_tokens: np.ndarray | None = None
@@ -923,9 +924,8 @@ class PCPManager:
                 hidden_states = F.pad(
                     hidden_states, pad=(0, 0, 0, self.pcp_padded_tokens_fla), mode="constant", value=0
                 )
-            hidden_states = get_pcp_group().all_gather(
-                hidden_states[: self.max_num_tokens_across_pcp].contiguous(), dim=0
-            )
+            hidden_states = hidden_states[: self.max_num_tokens_across_pcp] if self.max_num_tokens_across_pcp > 0 else hidden_states
+            hidden_states = get_pcp_group().all_gather(hidden_states.contiguous(), dim=0)
             restore_idx = self.pcp_enter_fa_restore_idx[: hidden_states.shape[0] - self.total_pcp_padding_tokens_fla]
             return torch.index_select(hidden_states, 0, restore_idx)
 

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -924,7 +924,9 @@ class PCPManager:
                 hidden_states = F.pad(
                     hidden_states, pad=(0, 0, 0, self.pcp_padded_tokens_fla), mode="constant", value=0
                 )
-            hidden_states = hidden_states[: self.max_num_tokens_across_pcp] if self.max_num_tokens_across_pcp > 0 else hidden_states
+            hidden_states = (
+                hidden_states[: self.max_num_tokens_across_pcp] if self.max_num_tokens_across_pcp > 0 else hidden_states
+            )
             hidden_states = get_pcp_group().all_gather(hidden_states.contiguous(), dim=0)
             restore_idx = self.pcp_enter_fa_restore_idx[: hidden_states.shape[0] - self.total_pcp_padding_tokens_fla]
             return torch.index_select(hidden_states, 0, restore_idx)

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -257,9 +257,7 @@ class PCPManager:
         padded_cu = np.concatenate(([0], cu_num_scheduled_tokens))
         per_req_lens = padded_cu[1:] - padded_cu[:-1]
 
-        prefill_lens = per_req_lens[self.num_decode_reqs :]
-        pad_multiple = self.pcp_world_size * 2
-        prefill_lens = [math.ceil(num / pad_multiple) * pad_multiple for num in prefill_lens]
+        prefill_lens = self.pcp_tokens[self.num_decode_reqs : self.num_decode_reqs + self.num_prefill_reqs]
         pads = copy.deepcopy(num_pcp_pads)
         pads[self.num_decode_reqs :] = np.cumsum(pads[self.num_decode_reqs :])
         base = int(cu_num_scheduled_tokens[self.num_decode_reqs - 1]) if self.num_decode_reqs > 0 else 0

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -18,7 +18,6 @@
 #
 
 import copy
-import math
 from collections.abc import Callable
 from itertools import accumulate
 from typing import TYPE_CHECKING, Any

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -255,7 +255,6 @@ class PCPManager:
         # cu[1:] - cu[:-1] would drop the first req's length and the base
         # below would index cu[-1] instead of 0.
         padded_cu = np.concatenate(([0], cu_num_scheduled_tokens))
-        per_req_lens = padded_cu[1:] - padded_cu[:-1]
 
         prefill_lens = self.pcp_tokens[self.num_decode_reqs : self.num_decode_reqs + self.num_prefill_reqs]
         pads = copy.deepcopy(num_pcp_pads)

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -249,12 +249,6 @@ class PCPManager:
         if self.num_prefill_reqs <= 0:
             return cu_num_scheduled_tokens
 
-        # Prepend 0 so per-req lengths come out of the diff cleanly. This
-        # also fixes the num_decode_reqs == 0 case, where the raw diff
-        # cu[1:] - cu[:-1] would drop the first req's length and the base
-        # below would index cu[-1] instead of 0.
-        padded_cu = np.concatenate(([0], cu_num_scheduled_tokens))
-
         prefill_lens = self.pcp_tokens[self.num_decode_reqs : self.num_decode_reqs + self.num_prefill_reqs]
         pads = copy.deepcopy(num_pcp_pads)
         pads[self.num_decode_reqs :] = np.cumsum(pads[self.num_decode_reqs :])


### PR DESCRIPTION
### What this PR does / why we need it?
The calculation logic for qwen3.5 with pcp and mpt logits superimposed has been modified.

After the repair, 50 GPQA runs were performed, with an accuracy of 90%. The per-position acceptance rates were: 0.886, 0.739, and 0.616, and the average draft acceptance rate was 74.7%.

[2026-06-26 15:29:38,507] [ais_bench] [INFO] Task vllm-api-general-chat/GPQA_diamond: {'accuracy': np.float64(90.0), 'type': 'GEN'}
[2026-06-26 15:29:38,523] [ais_bench] [INFO] Evaluation task time elapsed: 0.09s
[2026-06-26 15:29:39,781] [ais_bench] [INFO] Evaluation tasks completed.
[2026-06-26 15:29:39,784] [ais_bench] [INFO] Summarizing evaluation results...
dataset       version    metric    mode      vllm-api-general-chat

GPQA_diamond  b1ed2c     accuracy  gen                       90.00

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
