### PR TITLE
[Test][Misc] Refactor Qwen3.5 E2E tests to use module-scoped fixtures

### DIFF
--- a/tests/e2e/pull_request/four_card/test_qwen3_5.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_5.py
@@ -19,57 +19,62 @@
 import os
 from unittest.mock import patch
 
+import pytest
+
 from tests.e2e.conftest import DPVllmRunner, VllmRunner
 
 
-def test_qwen3_5_27b_distributed_mp_tp4():
-    example_prompts = [
-        "Hello, my name is",
-    ] * 4
-    max_tokens = 5
+# ===================== Fixture 复用模型定义 =====================
+@pytest.fixture(scope="module")
+def fixture_qwen35_27b_tp4():
+    """27B TP4 基础模型复用实例"""
+    warm_prompts = ["Hello, my name is"] * 4
+    warm_max_tokens = 5
     with VllmRunner(
         "Qwen/Qwen3.5-27B",
         tensor_parallel_size=4,
         cudagraph_capture_sizes=[1, 2, 4, 8],
         max_model_len=4096,
-        gpu_memory_utilization=0.90,
+        gpu_memory_utilization=0.8,
         distributed_executor_backend="mp",
-    ) as vllm_model:
-        vllm_model.generate_greedy(example_prompts, max_tokens)
-        del vllm_model
+    ) as runner:
+        # 预热：完成权重加载、MP进程初始化、CUDA Graph捕获
+        runner.generate_greedy(warm_prompts, warm_max_tokens)
+        yield runner
 
 
-def test_qwen3_5_35b_distributed_mp_tp4():
-    example_prompts = [
-        "Hello, my name is",
-    ] * 4
-    max_tokens = 5
+@pytest.fixture(scope="module")
+def fixture_qwen35_35b_tp4_base():
+    """35B TP4 基础无MTP模型复用实例"""
+    warm_prompts = ["Hello, my name is"] * 4
+    warm_max_tokens = 5
     with VllmRunner(
         "Qwen/Qwen3.5-35B-A3B",
         tensor_parallel_size=4,
         cudagraph_capture_sizes=[1, 2, 4, 8],
         max_model_len=4096,
-        gpu_memory_utilization=0.90,
+        gpu_memory_utilization=0.8,
         distributed_executor_backend="mp",
-    ) as vllm_model:
-        vllm_model.generate_greedy(example_prompts, max_tokens)
-        del vllm_model
+    ) as runner:
+        runner.generate_greedy(warm_prompts, warm_max_tokens)
+        yield runner
 
 
-def test_qwen3_5_35b_distributed_mp_tp4_full_decode_only_mtp3():
-    example_prompts = [
+@pytest.fixture(scope="module")
+def fixture_qwen35_35b_tp4_mtp3():
+    """35B TP4 + FULL_DECODE_ONLY + MTP3 复用实例"""
+    warm_prompts = [
         "Hello, my name is",
         "The president of the United States is",
         "The capital of France is",
         "The future of AI is",
     ]
-
-    max_tokens = 20
+    warm_max_tokens = 20
     with VllmRunner(
         "Qwen/Qwen3.5-35B-A3B",
         tensor_parallel_size=4,
         max_model_len=4096,
-        gpu_memory_utilization=0.90,
+        gpu_memory_utilization=0.8,
         distributed_executor_backend="mp",
         compilation_config={
             "cudagraph_mode": "FULL_DECODE_ONLY",
@@ -79,37 +84,76 @@ def test_qwen3_5_35b_distributed_mp_tp4_full_decode_only_mtp3():
             "method": "qwen3_5_mtp",
             "num_speculative_tokens": 3,
         },
-    ) as vllm_model:
-        vllm_model.generate_greedy(example_prompts, max_tokens)
-        del vllm_model
+    ) as runner:
+        runner.generate_greedy(warm_prompts, warm_max_tokens)
+        yield runner
 
 
-@patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_FLASHCOMM1": "1"})
-def test_qwen3_5_35b_distributed_mp_tp4_full_decode_only_mtp3_flashcomm():
+@pytest.fixture(scope="module")
+def fixture_qwen35_35b_dp_tp_flashcomm_mtp3():
+    """DP2+TP2 + FlashComm1 + MTP3 + EP 混合并行实例"""
+    test_prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+    max_tokens = 20
+    # patch 全程包裹Runner生命周期，退出自动清理环境变量
+    with (
+        patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_FLASHCOMM1": "1"}),
+        DPVllmRunner(
+            "Qwen/Qwen3.5-35B-A3B",
+            data_parallel_size=2,
+            tensor_parallel_size=2,
+            enable_expert_parallel=True,
+            max_model_len=4096,
+            gpu_memory_utilization=0.8,
+            distributed_executor_backend="mp",
+            compilation_config={
+                "cudagraph_mode": "FULL_DECODE_ONLY",
+                "cudagraph_capture_sizes": [4, 8, 12, 16],
+            },
+            speculative_config={
+                "method": "qwen3_5_mtp",
+                "num_speculative_tokens": 3,
+            },
+        ) as runner,
+    ):
+        runner.generate_greedy(test_prompts, max_tokens)
+        yield runner
+
+
+# ===================== 测试用例（全部复用Fixture，无重复初始化） =====================
+def test_qwen3_5_27b_distributed_mp_tp4(fixture_qwen35_27b_tp4):
+    example_prompts = ["Hello, my name is"] * 4
+    max_tokens = 5
+    fixture_qwen35_27b_tp4.generate_greedy(example_prompts, max_tokens)
+
+
+def test_qwen3_5_35b_distributed_mp_tp4(fixture_qwen35_35b_tp4_base):
+    example_prompts = ["Hello, my name is"] * 4
+    max_tokens = 5
+    fixture_qwen35_35b_tp4_base.generate_greedy(example_prompts, max_tokens)
+
+
+def test_qwen3_5_35b_distributed_mp_tp4_full_decode_only_mtp3(fixture_qwen35_35b_tp4_mtp3):
     example_prompts = [
         "Hello, my name is",
         "The president of the United States is",
         "The capital of France is",
         "The future of AI is",
     ]
-
     max_tokens = 20
-    with DPVllmRunner(
-        "Qwen/Qwen3.5-35B-A3B",
-        data_parallel_size=2,
-        tensor_parallel_size=2,
-        enable_expert_parallel=True,
-        max_model_len=4096,
-        gpu_memory_utilization=0.90,
-        distributed_executor_backend="mp",
-        compilation_config={
-            "cudagraph_mode": "FULL_DECODE_ONLY",
-            "cudagraph_capture_sizes": [4, 8, 12, 16],
-        },
-        speculative_config={
-            "method": "qwen3_5_mtp",
-            "num_speculative_tokens": 3,
-        },
-    ) as vllm_model:
-        vllm_model.generate_greedy(example_prompts, max_tokens)
-        del vllm_model
+    fixture_qwen35_35b_tp4_mtp3.generate_greedy(example_prompts, max_tokens)
+
+
+def test_qwen3_5_35b_distributed_mp_tp4_full_decode_only_mtp3_flashcomm(fixture_qwen35_35b_dp_tp_flashcomm_mtp3):
+    example_prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+    max_tokens = 20
+    fixture_qwen35_35b_dp_tp_flashcomm_mtp3.generate_greedy(example_prompts, max_tokens)

--- a/tests/e2e/pull_request/four_card/test_qwen3_next.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_next.py
@@ -17,100 +17,103 @@
 # Adapted from vllm/tests/basic_correctness/test_basic_correctness.py
 #
 import os
-from unittest.mock import patch
+from unittest import mock
+
+import pytest
 
 from tests.e2e.conftest import VllmRunner
 
+TEST_CASES = [
+    # case 1: mp, tp4, cudagraph
+    {
+        "model": "Qwen/Qwen3-Next-80B-A3B-Instruct",
+        "tp": 4,
+        "gpu_mem": 0.8,
+        "backend": "mp",
+        "extra_args": {"cudagraph_capture_sizes": [1, 2, 4, 8]},
+        "prompt_multiplier": 4,
+        "env": {},
+    },
+    # case 2: FULL_DECODE_ONLY
+    {
+        "model": "Qwen/Qwen3-Next-80B-A3B-Instruct",
+        "tp": 4,
+        "gpu_mem": 0.8,
+        "backend": "mp",
+        "extra_args": {
+            "compilation_config": {
+                "cudagraph_mode": "FULL_DECODE_ONLY",
+                "cudagraph_capture_sizes": [1, 8, 24, 48, 60],
+            }
+        },
+        "prompt_multiplier": 4,
+        "env": {},
+    },
+    # case 3: W8A8 量化 + 专家并行
+    {
+        "model": "vllm-ascend/Qwen3-Next-80B-A3B-Instruct-W8A8",
+        "tp": 4,
+        "gpu_mem": 0.4,
+        "backend": None,
+        "extra_args": {
+            "max_num_seqs": 1,
+            "enable_expert_parallel": True,
+            "cudagraph_capture_sizes": [1, 2, 4, 8],
+            "quantization": "ascend",
+        },
+        "prompt_multiplier": 1,
+        "env": {"HCCL_BUFFSIZE": "1024"},
+    },
+    # case 4: flash_comm + eager
+    {
+        "model": "Qwen/Qwen3-Next-80B-A3B-Instruct",
+        "tp": 4,
+        "gpu_mem": 0.7,
+        "backend": "mp",
+        "extra_args": {
+            "enable_expert_parallel": True,
+            "enforce_eager": True,
+        },
+        "prompt_multiplier": 4,
+        "env": {
+            "VLLM_ASCEND_ENABLE_FLASHCOMM1": "1",
+            "HCCL_BUFFSIZE": "1024",
+        },
+    },
+    # case 5: graph mode (非 eager) + 专家并行
+    {
+        "model": "Qwen/Qwen3-Next-80B-A3B-Instruct",
+        "tp": 4,
+        "gpu_mem": 0.8,
+        "backend": "mp",
+        "extra_args": {
+            "enable_expert_parallel": True,
+            "cudagraph_capture_sizes": [1, 2, 8],
+            "enforce_eager": False,
+        },
+        "prompt_multiplier": 4,
+        "env": {"HCCL_BUFFSIZE": "1024"},
+    },
+]
 
-def test_qwen3_next_distributed_mp_tp4():
-    example_prompts = [
-        "Hello, my name is",
-    ] * 4
+
+@pytest.mark.parametrize("case", TEST_CASES)
+def test_qwen3_next_distributed(case):
+    prompt_text = "Hello, my name is"
+    example_prompts = [prompt_text] * case["prompt_multiplier"]
     max_tokens = 5
-    with VllmRunner(
-        "Qwen/Qwen3-Next-80B-A3B-Instruct",
-        tensor_parallel_size=4,
-        cudagraph_capture_sizes=[1, 2, 4, 8],
-        max_model_len=4096,
-        gpu_memory_utilization=0.8,
-        distributed_executor_backend="mp",
-    ) as vllm_model:
+
+    kwargs = {
+        "model": case["model"],
+        "tensor_parallel_size": case["tp"],
+        "max_model_len": 4096,
+        "gpu_memory_utilization": case["gpu_mem"],
+    }
+    if case["backend"] is not None:
+        kwargs["distributed_executor_backend"] = case["backend"]
+    for k, v in case["extra_args"].items():
+        if v is not None:
+            kwargs[k] = v
+
+    with mock.patch.dict(os.environ, case["env"], clear=False), VllmRunner(**kwargs) as vllm_model:
         vllm_model.generate_greedy(example_prompts, max_tokens)
-        del vllm_model
-
-
-def test_qwen3_next_distributed_mp_full_decode_only_tp4():
-    example_prompts = [
-        "Hello, my name is",
-    ] * 4
-    max_tokens = 5
-    with VllmRunner(
-        "Qwen/Qwen3-Next-80B-A3B-Instruct",
-        tensor_parallel_size=4,
-        max_model_len=4096,
-        gpu_memory_utilization=0.8,
-        distributed_executor_backend="mp",
-        compilation_config={"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1, 8, 24, 48, 60]},
-    ) as vllm_model:
-        vllm_model.generate_greedy(example_prompts, max_tokens)
-        del vllm_model
-
-
-# TODO: will conduct accuracy verification after the subsequent version becomes stable
-@patch.dict(os.environ, {"HCCL_BUFFSIZE": "1024"})
-def test_qwen3_next_w8a8dynamic_distributed_tp4_ep():
-    example_prompts = [
-        "Hello, my name is",
-    ]
-    max_tokens = 5
-    with VllmRunner(
-        "vllm-ascend/Qwen3-Next-80B-A3B-Instruct-W8A8",
-        max_model_len=4096,
-        tensor_parallel_size=4,
-        gpu_memory_utilization=0.4,
-        max_num_seqs=1,
-        enable_expert_parallel=True,
-        cudagraph_capture_sizes=[1, 2, 4, 8],
-        quantization="ascend",
-    ) as vllm_model:
-        vllm_model.generate_greedy(example_prompts, max_tokens)
-
-
-@patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_FLASHCOMM1": "1"})
-@patch.dict(os.environ, {"HCCL_BUFFSIZE": "1024"})
-def test_qwen3_next_distributed_mp_flash_comm_tp4():
-    example_prompts = [
-        "Hello, my name is",
-    ] * 4
-    max_tokens = 5
-    with VllmRunner(
-        "Qwen/Qwen3-Next-80B-A3B-Instruct",
-        tensor_parallel_size=4,
-        max_model_len=4096,
-        gpu_memory_utilization=0.7,
-        distributed_executor_backend="mp",
-        enable_expert_parallel=True,
-        enforce_eager=True,
-    ) as vllm_model:
-        vllm_model.generate_greedy(example_prompts, max_tokens)
-        del vllm_model
-
-
-@patch.dict(os.environ, {"HCCL_BUFFSIZE": "1024"})
-def test_qwen3_next_distributed_mp_graph_mode_tp4():
-    example_prompts = [
-        "Hello, my name is",
-    ] * 4
-    max_tokens = 5
-    with VllmRunner(
-        "Qwen/Qwen3-Next-80B-A3B-Instruct",
-        tensor_parallel_size=4,
-        max_model_len=4096,
-        gpu_memory_utilization=0.8,
-        distributed_executor_backend="mp",
-        enable_expert_parallel=True,
-        cudagraph_capture_sizes=[1, 2, 8],
-        enforce_eager=False,
-    ) as vllm_model:
-        vllm_model.generate_greedy(example_prompts, max_tokens)
-        del vllm_model


### PR DESCRIPTION
### What this PR does / why we need it?
This PR refactors the Qwen3.5 E2E tests to use module-scoped pytest fixtures for model runners (`VllmRunner` and `DPVllmRunner`). This allows reusing the initialized model runners across multiple test cases, reducing test execution overhead.

However, the fixtures manually invoke `__enter__()` and `__exit__()` on the runners. If an exception occurs during setup or generation, `__exit__()` will not be called, potentially leaking background processes and NPU memory. It is highly recommended to use `with` statements inside the fixtures to ensure proper cleanup.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
The changes are refactorings of existing E2E tests.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
