### PR TITLE
[Ops][Misc] Remove unused load of b_g in fused_recurrent_gated_delta_rule_fwd_kernel

### DIFF
--- a/vllm_ascend/ops/triton/fla/sigmoid_gating.py
+++ b/vllm_ascend/ops/triton/fla/sigmoid_gating.py
@@ -132,7 +132,6 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
         b_q = tl.load(p_q, mask=mask_k, other=0).to(tl.float32)
         b_k = tl.load(p_k, mask=mask_k, other=0).to(tl.float32)
         b_v = tl.load(p_v, mask=mask_v, other=0).to(tl.float32)
-        b_g = tl.load(p_g).to(tl.float32)
 
         if USE_QK_L2NORM_IN_KERNEL:
             b_q = b_q / tl.sqrt(tl.sum(b_q * b_q) + 1e-6)


### PR DESCRIPTION
### What this PR does / why we need it?
b_g is already loaded inside the `if not IS_KDA` block. The second unconditional load after the if/else references p_g which is undefined when IS_KDA=True, causing a runtime error. Remove the redundant load.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Verified that the kernel compiles and runs without error when IS_KDA=True. The fix is a straightforward removal of a redundant load that references an undefined variable; no behavioral change for the IS_KDA=False path.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
