### PR TITLE
[BugFix][v0.21] Avoid hybrid invalid block fallback

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -476,15 +476,33 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 block_id_list_c,
                 ret,
             )
-            with self._invalid_block_ids_lock:
-                self._invalid_block_ids.update(missing_block_ids)
+            if len(req_meta.block_ids_by_group) == 1:
+                with self._invalid_block_ids_lock:
+                    self._invalid_block_ids.update(missing_block_ids)
+            elif missing_block_ids:
+                logger.error(
+                    "KV load failed for hybrid request %s. Skip invalid-block "
+                    "fallback on this release branch to avoid scheduler crash. "
+                    "failed_blocks=%s",
+                    req_id,
+                    missing_block_ids,
+                )
         elif ret is None:
             missing_block_ids = record_failed_blocks(
                 block_id_list_c,
                 [1] * len(block_id_list_c),
             )
-            with self._invalid_block_ids_lock:
-                self._invalid_block_ids.update(missing_block_ids)
+            if len(req_meta.block_ids_by_group) == 1:
+                with self._invalid_block_ids_lock:
+                    self._invalid_block_ids.update(missing_block_ids)
+            elif missing_block_ids:
+                logger.error(
+                    "KV load failed for hybrid request %s. Skip invalid-block "
+                    "fallback on this release branch to avoid scheduler crash. "
+                    "failed_blocks=%s",
+                    req_id,
+                    missing_block_ids,
+                )
         logger.debug(
             "KV pool async recv backend get returned request=%s token_len=%d groups=%s keys=%d",
             req_id,
@@ -731,11 +749,30 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
                 block_id_list_c,
                 ret,
             )
-            with self._invalid_block_ids_lock:
-                self._invalid_block_ids.update(missing_block_ids)
+            if len(req_meta.block_ids_by_group) == 1:
+                with self._invalid_block_ids_lock:
+                    self._invalid_block_ids.update(missing_block_ids)
+            elif missing_block_ids:
+                logger.error(
+                    "KV load failed for hybrid request %s. Skip invalid-block "
+                    "fallback on this release branch to avoid scheduler crash. "
+                    "failed_blocks=%s",
+                    req_meta.req_id,
+                    missing_block_ids,
+                )
         elif ret is None:
-            with self._invalid_block_ids_lock:
-                self._invalid_block_ids.update(block_id_list_c)
+            missing_block_ids = set(block_id_list_c)
+            if len(req_meta.block_ids_by_group) == 1:
+                with self._invalid_block_ids_lock:
+                    self._invalid_block_ids.update(missing_block_ids)
+            elif missing_block_ids:
+                logger.error(
+                    "KV load failed for hybrid request %s. Skip invalid-block "
+                    "fallback on this release branch to avoid scheduler crash. "
+                    "failed_blocks=%s",
+                    req_meta.req_id,
+                    missing_block_ids,
+                )
 
         self.request_queue.task_done()
         self.get_event.set()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -558,13 +558,31 @@ class KVPoolWorker:
                             block_id_list_c,
                             ret,
                         )
-                        self._invalid_block_ids.update(missing_block_ids)
+                        if len(request.block_ids_by_group) == 1:
+                            self._invalid_block_ids.update(missing_block_ids)
+                        elif missing_block_ids:
+                            logger.error(
+                                "KV load failed for hybrid request %s. Skip invalid-block "
+                                "fallback on this release branch to avoid scheduler crash. "
+                                "failed_blocks=%s",
+                                request.req_id,
+                                missing_block_ids,
+                            )
                     elif ret is None:
                         missing_block_ids = record_failed_blocks(
                             block_id_list_c,
                             [1] * len(block_id_list_c),
                         )
-                        self._invalid_block_ids.update(missing_block_ids)
+                        if len(request.block_ids_by_group) == 1:
+                            self._invalid_block_ids.update(missing_block_ids)
+                        elif missing_block_ids:
+                            logger.error(
+                                "KV load failed for hybrid request %s. Skip invalid-block "
+                                "fallback on this release branch to avoid scheduler crash. "
+                                "failed_blocks=%s",
+                                request.req_id,
+                                missing_block_ids,
+                            )
                     logger.debug(
                         "KV pool worker backend get returned request=%s token_len=%d groups=%s keys=%d",
                         request.req_id,


### PR DESCRIPTION
### What this PR does / why we need it?

This PR avoids a v0.21.0rc release-branch engine crash when hybrid models report KV load failures.

Upstream invalid-block handling assumes `get_block_ids()` returns a single KV group. Hybrid models return multiple KV groups, so reporting `invalid_block_ids` can drive the scheduler into `ValueError: too many values to unpack`.

This PR does not patch scheduler and does not implement hybrid recompute. For hybrid KV Pool loads only, it logs the failed blocks and skips reporting `invalid_block_ids` to the scheduler. Non-hybrid models keep the existing failed-block reporting behavior.

The full grouped/hybrid-aware recompute logic should live in #10882.

### Does this PR introduce _any_ user-facing change?

Yes. For hybrid models on this release branch, KV Pool load failures are logged without reporting invalid blocks to the scheduler, avoiding an engine crash from unsupported hybrid invalid-block handling.

### How was this patch tested?

Added unit tests for the hybrid invalid-block reporting guard.

### Validation

vLLM version: v0.21.0
vLLM main: vllm-project/vllm@9090368b650896bf5fc990c921df7eb4c20355a5

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
