### PR TITLE
[BugFix] Avoid invalid block fallback for hybrid attention models

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -789,15 +789,33 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 block_id_list_c,
                 ret,
             )
-            with self._invalid_block_ids_lock:
-                self._invalid_block_ids.update(missing_block_ids)
+            if len(req_meta.block_ids_by_group) == 1:
+                with self._invalid_block_ids_lock:
+                    self._invalid_block_ids.update(missing_block_ids)
+            elif missing_block_ids:
+                logger.error(
+                    "KV load failed for hybrid request %s. "
+                    "Skip invalid-block fallback to avoid scheduler crash. "
+                    "failed_blocks=%s",
+                    req_id,
+                    missing_block_ids,
+                )
         elif ret is None:
             missing_block_ids = record_failed_blocks(
                 block_id_list_c,
                 [1] * len(block_id_list_c),
             )
-            with self._invalid_block_ids_lock:
-                self._invalid_block_ids.update(missing_block_ids)
+            if len(req_meta.block_ids_by_group) == 1:
+                with self._invalid_block_ids_lock:
+                    self._invalid_block_ids.update(missing_block_ids)
+            elif missing_block_ids:
+                logger.error(
+                    "KV load failed for hybrid request %s. "
+                    "Skip invalid-block fallback to avoid scheduler crash. "
+                    "failed_blocks=%s",
+                    req_id,
+                    missing_block_ids,
+                )
         logger.debug(
             "KV pool async recv backend get returned request=%s token_len=%d groups=%s keys=%d",
             req_id,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -662,10 +662,28 @@ class KVPoolWorker:
             ret = self.m_store.get(key_list_c, addr_list_c, size_list_c)
             if ret is not None and any(r != 0 for r in ret):
                 missing_block_ids = record_failed_blocks(block_id_list_c, ret)
-                self._invalid_block_ids.update(missing_block_ids)
+                if len(request.block_ids_by_group) == 1:
+                    self._invalid_block_ids.update(missing_block_ids)
+                elif missing_block_ids:
+                    logger.error(
+                        "KV load failed for hybrid request %s. "
+                        "Skip invalid-block fallback to avoid scheduler crash. "
+                        "failed_blocks=%s",
+                        request.req_id,
+                        missing_block_ids,
+                    )
             elif ret is None:
                 missing_block_ids = record_failed_blocks(block_id_list_c, [1] * len(block_id_list_c))
-                self._invalid_block_ids.update(missing_block_ids)
+                if len(request.block_ids_by_group) == 1:
+                    self._invalid_block_ids.update(missing_block_ids)
+                elif missing_block_ids:
+                    logger.error(
+                        "KV load failed for hybrid request %s. "
+                        "Skip invalid-block fallback to avoid scheduler crash. "
+                        "failed_blocks=%s",
+                        request.req_id,
+                        missing_block_ids,
+                    )
 
     def _process_save_for_layer_batch(
         self,


### PR DESCRIPTION
### What this PR does / why we need it?

Equivalent main-branch guard for #10930.

Hybrid KV Pool load failures can report invalid blocks into scheduler code that still assumes a single KV group. Until #10882 carries the full grouped recompute path, skip invalid-block fallback for hybrid loads and log the failed blocks instead. Non-hybrid behavior is unchanged.

### Does this PR introduce _any_ user-facing change?

Yes. Hybrid KV Pool load failures are logged without entering unsupported invalid-block scheduler fallback.

### How was this patch tested?

Pre-commit passed.

### Validation

vLLM version: v0.23.0
vLLM main: vllm-project/vllm@967c5c3bc38891f4465d3f4e99917ed837bb3833

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
