### PR TITLE
[BugFix] Skip FlashComm1/2 For ViT

### DIFF
--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -695,7 +695,7 @@ def _get_column_parallel_op(
             "g_proj",  # attention gate projection of Step3p5
         ]
         for a_prefix in sp_column_prefix:
-            if a_prefix in prefix:
+            if a_prefix in prefix and "vision_model" not in prefix:
                 return SequenceColumnParallelOp(layer)
 
     return None
@@ -725,7 +725,8 @@ def _get_row_parallel_op(
         return MatmulAllreduceRowParallelOp(layer)
     if flashcomm2_enable():
         if "o_proj" in prefix or "out_proj" in prefix:
-            return Flashcomm2OProjRowParallelOp(layer)
+            if "vision_model" not in prefix:
+                return Flashcomm2OProjRowParallelOp(layer)
     if enable_sp():
         # "share_expert" added for Step3p5
         if "shared_expert" in prefix or "share_expert" in prefix:
@@ -738,7 +739,7 @@ def _get_row_parallel_op(
             "wo_b",  # attn output linear of v4
         ]
         for a_prefix in sp_row_prefixes:
-            if a_prefix in prefix:
+            if a_prefix in prefix and "vision_model" not in prefix:
                 return SequenceRowParallelOp(layer)
 
     return None


### PR DESCRIPTION
### What this PR does / why we need it?
Fix VIT crash when enabling FC1/FC2 on Ascend NPU for VL models (e.g. Step3p7):
  #10500

  vLLM precomputes inputs_embeds outside forward_context for multimodal models, causing VIT layers to be incorrectly routed by FC1/FC2 dispatch to context-dependent ops. Since the context is not yet set, _EXTRA_CTX is empty and FC1/FC2 flags are unavailable → crash.

  Add "vision_model" not in prefix guards on three dispatch paths:
  - SP column-parallel dispatch (SequenceColumnParallelOp)
  - SP row-parallel dispatch (SequenceRowParallelOp)
  - FlashComm2 row-parallel dispatch (Flashcomm2OProjRowParallelOp)

### Does this PR introduce _any_ user-facing change?
No user-facing changes. VL models crashed on startup with FC1/FC2 enabled before the fix; after the fix they run correctly.Text-only models are unaffected (their prefixes do not contain vision_model).

### How was this patch tested?
Step3p7 VL model, 8× Ascend NPU, TP=8, FC1+FC2+MTP all enabled. Before the fix, the VIT forward phase crashed. After the fix, both PD disaggregated and PD colocated deployments start correctly and pass stress testing.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
