### PR TITLE
[Feature]:Modify the UvaBufferWrapper class to enable UVA features

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -392,6 +392,7 @@
     - tests/ut/test_compressed_prefix_cache.py
     - tests/e2e/pull_request/one_card/test_qwen3_0_6b.py
     - tests/e2e/pull_request/one_card/test_qwen3_5_0_8b.py
+    - tests/e2e/pull_request/one_card/model_runner_v2/test_uva.py
 
 - name: patch_mamba_utils_310p
   optional: false
@@ -675,6 +676,7 @@ estimated_times:
   tests/e2e/pull_request/one_card/lora/test_qwen3_multi_loras.py: 140
   tests/e2e/pull_request/one_card/lora/test_qwen3_reranker_lora.py: 160
   tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py: 750
+  tests/e2e/pull_request/one_card/model_runner_v2/test_uva.py: 750
   tests/e2e/pull_request/one_card/pooling/test_classification.py: 190
   tests/e2e/pull_request/one_card/pooling/test_embedding.py: 410
   tests/e2e/pull_request/one_card/pooling/test_scoring.py: 550

--- a/tests/e2e/pull_request/one_card/model_runner_v2/test_uva.py
+++ b/tests/e2e/pull_request/one_card/model_runner_v2/test_uva.py
@@ -1,0 +1,171 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+from unittest.mock import patch
+
+import pytest
+from vllm import SamplingParams
+
+from tests.e2e.conftest import VllmRunner
+from vllm_ascend.utils import vllm_version_is
+
+MODELS = ["Qwen/Qwen3-0.6B", "vllm-ascend/DeepSeek-V2-Lite-W8A8"]
+
+MAIN_MODELS = ["LLM-Research/Meta-Llama-3.1-8B-Instruct"]
+EGALE_MODELS = ["vllm-ascend/EAGLE-LLaMA3.1-Instruct-8B"]
+
+pytestmark = pytest.mark.skipif(
+    vllm_version_is("0.23.0"),
+    reason="v2 model runner patches not supported on v0.23.0",
+)
+
+
+@pytest.mark.skipif(True, reason="Fix me, it's broken after CANN and trition-ascend are upgraded.")
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("max_tokens", [32])
+@pytest.mark.parametrize("enforce_eager", [True])
+@patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1", "PYTORCH_NPU_ALLOC_CONF": "pinned_mem_register:True"})
+def test_qwen3_dense_eager_mode(
+    model: str,
+    max_tokens: int,
+    enforce_eager: bool,
+) -> None:
+    prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+
+    sampling_params = SamplingParams(
+        max_tokens=max_tokens,
+        temperature=0.5,
+        logprobs=2,
+        prompt_logprobs=2,
+        logit_bias={0: -1.0, 1: 0.5},
+        min_p=0.01,
+        bad_words=["the", " the"],
+    )
+    with VllmRunner(
+        model,
+        max_model_len=1024,
+        enforce_eager=enforce_eager,
+        async_scheduling=True,
+    ) as runner:
+        runner.model.generate(prompts, sampling_params)
+
+
+@pytest.mark.parametrize("model", MAIN_MODELS)
+@pytest.mark.parametrize("eagle_model", EGALE_MODELS)
+@pytest.mark.parametrize("max_tokens", [32])
+@pytest.mark.parametrize("enforce_eager", [False])
+@pytest.mark.parametrize(
+    "compilation_config",
+    [
+        pytest.param(
+            {"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 8]},
+            id="full_decode_only",
+        ),
+        pytest.param({}, id="default_full_and_piecewise"),
+    ],
+)
+@patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1", "PYTORCH_NPU_ALLOC_CONF": "pinned_mem_register:True"})
+def test_egale_spec_decoding(
+    model: str,
+    eagle_model: str,
+    max_tokens: int,
+    enforce_eager: bool,
+    compilation_config: dict,
+) -> None:
+    prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+
+    sampling_params = SamplingParams(max_tokens=max_tokens, temperature=0.0)
+    with VllmRunner(
+        model,
+        max_model_len=1024,
+        enforce_eager=enforce_eager,
+        async_scheduling=True,
+        speculative_config={
+            "model": eagle_model,
+            "method": "eagle",
+            "num_speculative_tokens": 3,
+        },
+        compilation_config=compilation_config,
+    ) as runner:
+        runner.model.generate(prompts, sampling_params)
+
+
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("max_tokens", [32])
+@pytest.mark.parametrize("enforce_eager", [False])
+@pytest.mark.parametrize(
+    "compilation_config",
+    [
+        pytest.param({"cudagraph_mode": "FULL_DECODE_ONLY"}, id="full_decode_only"),
+        pytest.param({}, id="default_full_and_piecewise"),
+    ],
+)
+@patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1", "PYTORCH_NPU_ALLOC_CONF": "pinned_mem_register:True"})
+def test_qwen3_dense_graph_mode(
+    model: str,
+    max_tokens: int,
+    enforce_eager: bool,
+    compilation_config: dict,
+) -> None:
+    prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+
+    sampling_params = SamplingParams(max_tokens=max_tokens, temperature=0.0)
+    with VllmRunner(
+        model,
+        max_model_len=1024,
+        enforce_eager=enforce_eager,
+        compilation_config=compilation_config,
+    ) as runner:
+        outputs = runner.model.generate(prompts, sampling_params)
+
+    if model != "Qwen/Qwen3-0.6B":
+        return
+
+    expected_outputs = [
+        " Lina. I'm a 22-year-old student from China.",
+        " the same as the president of the United Nations. This is because the president",
+        " Paris. The capital of France is also the capital of the Republic of France",
+        " not just about the technology itself but also about the human aspect-how we",
+    ]
+
+    matches = 0
+    misses = 0
+    for output, expected_output in zip(outputs, expected_outputs):
+        if output.outputs[0].text[:10] == expected_output[:10]:
+            matches += 1
+        else:
+            misses += 1
+            print(f"output: {output.outputs[0].text}")
+            print(f"expected_output: {expected_output}")
+
+    assert misses == 0

--- a/vllm_ascend/patch/worker/patch_v2/patch_uva.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_uva.py
@@ -16,11 +16,44 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
+import os
 from collections.abc import Callable, Sequence
+from importlib.metadata import version
 
 import numpy as np
 import torch
 import vllm.v1.worker.gpu.buffer_utils
+from vllm.logger import logger
+
+
+def check_triton_ascend_version_valid() -> bool:
+    """
+    Check triton-ascend version and warn about UVA feature disablement in 3.2.1.
+    If version isn't 3.2.1, return True.
+    """
+    # Target version that disables UVA feature
+    DISABLE_UVA_VERSION = "3.2.1"
+    installed_version = version("triton-ascend")
+    # Check if current version is the one with UVA disabled
+    if installed_version == DISABLE_UVA_VERSION:
+        logger.warning(
+            "triton-ascend %s disables the UVA feature.\n"
+            "Related bug issue: https://github.com/triton-lang/triton-ascend/issues/783",
+            DISABLE_UVA_VERSION,
+        )
+        return False
+    return True
+
+
+def is_uva_available() -> bool:
+    """check if uva feature is supported in this environment"""
+    # FIXME(chenboxun): There is an issue with using the UVA feature alongside triton-ascend3.2.1.
+    # Thus UVA feature is disabled when using version 3.2.1
+    # (Related bug issue link: https://github.com/triton-lang/triton-ascend/issues/783)
+    return (
+        "pinned_mem_register:True" in os.environ.get("PYTORCH_NPU_ALLOC_CONF", {})
+        and check_triton_ascend_version_valid()
+    )
 
 
 def get_row_indices_from_key(key: int | slice | tuple, dim_size: int) -> set[int]:
@@ -89,30 +122,34 @@ class MonitoredTorchTensor:
 
 
 class UvaBufferWrapper:
-    """Ascend NPU doesn't support UVA tensors directly. This is a wrapper class
-    that provides CPU and NPU views of a UVA tensor."""
+    """
+    Ascend NPU doesn't support UVA tensors directly.
+    This is a wrapper class that provides CPU and NPU views of a UVA tensor.
+    However if users add environment parameter below, UVA feature is Supported.
+    os.environ['PYTORCH_NPU_ALLOC_CONF'] = 'pinned_mem_register:True'
+    """
 
     def __init__(self, size: int | Sequence[int], dtype: torch.dtype):
         self._cpu: torch.Tensor = torch.zeros(size, dtype=dtype, device="cpu", pin_memory=True)
-        self._np = self._cpu.numpy()
-        self._uva: torch.Tensor = torch.zeros_like(self._cpu, device="npu")
+        self._np: np.ndarray = self._cpu.numpy()
         self._modified_indices: set[int] = set()
+        self._uva: torch.Tensor = self._cpu if is_uva_available() else torch.zeros_like(self._cpu, device="npu")
 
     def _mark_cpu_modified(self, key: int):
         self._modified_indices.add(key)
 
     @property
     def cpu(self):
-        return MonitoredTorchTensor(self._cpu, self._mark_cpu_modified)
+        return self._cpu if is_uva_available() else MonitoredTorchTensor(self._cpu, self._mark_cpu_modified)
 
     @property
     def np(self):
-        return MonitoredNumPyArray(self._np, self._mark_cpu_modified)
+        return self._np if is_uva_available() else MonitoredNumPyArray(self._np, self._mark_cpu_modified)
 
     @property
     def uva(self):
         """Get the device data of the buffer."""
-        if self._modified_indices:
+        if not is_uva_available() and self._modified_indices:
             # Sort for better memory access locality
             dirty_rows = sorted(self._modified_indices)
             # can't use copy_ method, because copy_ for index tensor


### PR DESCRIPTION
### What this PR does / why we need it?

GPUs have the UVA feature, which allows the GPU side to directly access CPU tensors based on the same virtual address, without manual copying. The NPU side also needs to follow up on this.

### Does this PR introduce _any_ user-facing change?

This feature needs to be enabled through os.environ['PYTORCH_NPU_ALLOC_CONF'] = 'pinned_mem_register:True'; otherwise, it is disabled by default.

### How was this patch tested?
Enable os.environ['PYTORCH_NPU_ALLOC_CONF'] = 'pinned_mem_register:True', and then use the regular vllm test cases.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
