### PR TITLE
[CI][BugFix] Fix rebase step to use PR target branch instead of hardcoded main

### DIFF
--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -32,6 +32,11 @@ on:
         required: false
         default: ''
         description: 'The vllm-ascend ref to test.'
+      base_ref:
+        type: string
+        required: false
+        default: 'main'
+        description: 'The base branch to rebase onto (e.g. main, v0.8.x).'
       upload_timing:
         type: boolean
         required: false
@@ -112,12 +117,12 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Rebase on latest main
+      - name: Rebase on latest ${{ inputs.base_ref }}
         run: |
           git config user.name "vllm-ascend-ci"
           git config user.email "vllm-ascend-ci@users.noreply.github.com"
-          git fetch origin main
-          git rebase origin/main
+          git fetch origin ${{ inputs.base_ref }}
+          git rebase origin/${{ inputs.base_ref }}
 
       - name: Get csrc hash
         id: get_csrc_hash

--- a/.github/workflows/pr_e2e_command.yml
+++ b/.github/workflows/pr_e2e_command.yml
@@ -39,6 +39,7 @@ jobs:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend/act-environments-ubuntu:act-22.04
     outputs:
       pr_sha: ${{ steps.resolve.outputs.pr_sha }}
+      pr_base_ref: ${{ steps.resolve.outputs.pr_base_ref }}
       test_groups: ${{ steps.groups.outputs.test_groups }}
       has_tests: ${{ steps.groups.outputs.has_tests }}
       notify_comment_id: ${{ steps.notify.outputs.comment-id }}
@@ -136,6 +137,9 @@ jobs:
           PR_SHA='${{ github.event.client_payload.pull_request.head.sha }}'
           echo "pr_sha=$PR_SHA" >> "$GITHUB_OUTPUT"
 
+          PR_BASE_REF='${{ github.event.client_payload.pull_request.base.ref }}'
+          echo "pr_base_ref=${PR_BASE_REF:-main}" >> "$GITHUB_OUTPUT"
+
           ALL_ARGS="${{ github.event.client_payload.slash_command.args.all }}"
           echo "all_args=$ALL_ARGS" >> "$GITHUB_OUTPUT"
 
@@ -188,6 +192,7 @@ jobs:
     with:
       vllm: ${{ matrix.vllm_version }}
       ref: ${{ needs.e2e-test.outputs.pr_sha }}
+      base_ref: ${{ needs.e2e-test.outputs.pr_base_ref }}
       test_groups: ${{ needs.e2e-test.outputs.test_groups }}
 
   report:

--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -212,4 +212,5 @@ jobs:
     with:
       vllm: ${{ matrix.vllm_version }}
       ref: ${{ github.event.pull_request.head.sha }}
+      base_ref: ${{ github.base_ref }}
       test_groups: ${{ needs.lint-and-select-tests.outputs.test_groups }}


### PR DESCRIPTION

### What this PR does / why we need it?

The "Rebase on latest main" step in `_selected_tests.yaml` hardcoded `origin/main` as the rebase target. This causes CI failures when a PR targets a non-main branch (e.g. a release branch like `v0.22.1rc`).

- `_selected_tests.yaml`: Add a `base_ref` input (default: `main`) and use it in the rebase step instead of the hardcoded `main`.
- `pr_test.yaml`: Pass `base_ref: ${{ github.base_ref }}` so the actual PR target branch is used.
- `pr_e2e_command.yml`: Extract `pull_request.base.ref` from the repository-dispatch payload and pass it as `base_ref`; falls back to `main` if the field is absent.

The scheduled workflow is unaffected as it always runs on `main` and the default value covers it.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
