### PR TITLE
[BugFix] Pad actual_seq_lengths with 0 for EOD scenario in npu_fusion_attention

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -1195,6 +1195,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
         _: torch.Tensor,
     ) -> torch.Tensor:
         # use default sparse_mode 0 in normal scenario, which means no mask works on it
+        # Pad actual_seq_len with 0 when num_tokens > actual_seq_len in TND layout
+        actual_seq_qlen = attn_metadata.actual_seq_lengths_q
+        if query.shape[0] > actual_seq_qlen[-1]:
+            actual_seq_qlen = actual_seq_qlen + [0]
         return torch_npu.npu_fusion_attention(
             query=query,
             key=key,
@@ -1202,8 +1206,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
             head_num=self.num_heads,
             input_layout="TND",
             scale=self.scale,
-            actual_seq_qlen=attn_metadata.actual_seq_lengths_q,
-            actual_seq_kvlen=attn_metadata.actual_seq_lengths_q,
+            actual_seq_qlen=actual_seq_qlen,
+            actual_seq_kvlen=actual_seq_qlen,
         )[0]
 
     def do_kv_cache_update(


### PR DESCRIPTION
### What this PR does / why we need it?
On CANN 9.0, a strict validation was added for EOD in npu_fusion_attention. The actual_seq_qlen and actual_seq_kvlen parameters must end with 0 to pass the validation.
In the current fuse_attention path, when handling EOD scenarios, these parameters may not end with 0, causing npu_fusion_attention call to fail on CANN 9.0.

#### EOD:
When the last batch item's actual sequence length does not account for all remaining tokens — specifically when:
T_q > actualSeqQLen[-1] (sum of actual_seq_qlen is less than total query tokens)
T_kv > actualSeqKvLen[-1] (sum of actual_seq_kvlen is less than total kv tokens)
This means there are trailing tokens that belong to an "end-of-document" padding region beyond the described sequences. For the npu_fusion_attention operator, this is the EOD scenario — the actual_seq_qlen and actual_seq_kvlen arrays must explicitly end with a 0 to signal the end of document to the CANN runtime.

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
