### PR TITLE
[BugFix]Fix the error "repeats must have the same size as input along dim" when turn on  eagle3

### DIFF
--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -973,6 +973,8 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
                 spec_sequence_masks_cpu = None
             else:
                 spec_sequence_masks = self.spec_sequence_masks[:num_reqs]
+                if spec_sequence_masks.numel() == 0 and num_reqs == spec_sequence_masks_cpu.numel():
+                    spec_sequence_masks = torch.zeros(num_reqs, dtype=torch.bool, device=spec_sequence_masks.device
                 spec_sequence_masks.copy_(spec_sequence_masks_cpu, non_blocking=True)
                 spec_sequence_indices, non_spec_sequence_indices = self._copy_sequence_indices_to_device(
                     spec_sequence_masks_cpu,

--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -974,7 +974,7 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
             else:
                 spec_sequence_masks = self.spec_sequence_masks[:num_reqs]
                 if spec_sequence_masks.numel() == 0 and num_reqs == spec_sequence_masks_cpu.numel():
-                    spec_sequence_masks = torch.zeros(num_reqs, dtype=torch.bool, device=spec_sequence_masks.device
+                    spec_sequence_masks = torch.zeros(num_reqs, dtype=torch.bool, device=spec_sequence_masks.device)
                 spec_sequence_masks.copy_(spec_sequence_masks_cpu, non_blocking=True)
                 spec_sequence_indices, non_spec_sequence_indices = self._copy_sequence_indices_to_device(
                     spec_sequence_masks_cpu,


### PR DESCRIPTION

### What this PR does / why we need it?
Condition: Turn on eagle3
Model:Qwen 3.6-35B-A3B
When spec_sequence_masks is empty. The follow code will meet exception: repeats must have the same size as input along dim
spec_token_masks = torch.repeat_interleave( ###   报错点
                    spec_sequence_masks,
                    query_lens,
                    output_size=query_start_loc_cpu[-1].item(),
                )

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
vllm:0.22.1
vllm-ascend:main

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
