### PR TITLE
[Doc] Unify served-model-name to dsv4 in DeepSeek-V4 tutorials

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V4-Flash.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Flash.md
@@ -60,7 +60,6 @@ docker run --rm \
     -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
     -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v /etc/hccn.conf:/etc/hccn.conf \
-    -v /mnt/sfs_turbo/.cache:/root/.cache \
     -it $IMAGE bash
 ```
 
@@ -106,7 +105,6 @@ docker run --rm \
     -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
     -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v /etc/hccn.conf:/etc/hccn.conf \
-    -v /mnt/sfs_turbo/.cache:/root/.cache \
     -it $IMAGE bash
 ```
 
@@ -159,7 +157,7 @@ vllm serve /mnt/nfs_hw/weight/DeepSeek-V4-Flash-w8a8-mtp \
   --safetensors-load-strategy 'prefetch' \
   --max-model-len 135168 \
   --max-num-batched-tokens 4096 \
-  --served-model-name ds \
+  --served-model-name dsv4 \
   --gpu-memory-utilization 0.92 \
   --max-num-seqs 16 \
   --data-parallel-size 1 \
@@ -386,7 +384,7 @@ Before you start, please
             --tensor-parallel-size $7 \
             --enable-expert-parallel \
             --seed 1024 \
-            --served-model-name auto \
+            --served-model-name dsv4 \
             --max-model-len 135000 \
             --max-num-batched-tokens 8192 \
             --max-num-seqs 4 \
@@ -464,7 +462,7 @@ Before you start, please
             --tensor-parallel-size $7 \
             --enable-expert-parallel \
             --seed 1024 \
-            --served-model-name auto \
+            --served-model-name dsv4 \
             --max-model-len 135000 \
             --max-num-batched-tokens 8192 \
             --max-num-seqs 4 \
@@ -540,7 +538,7 @@ Before you start, please
             --tensor-parallel-size $7 \
             --enable-expert-parallel \
             --seed 1024 \
-            --served-model-name auto \
+            --served-model-name dsv4 \
             --max-model-len 135000 \
             --max-num-batched-tokens 120 \
             --max-num-seqs 60 \
@@ -747,7 +745,7 @@ Before you start, please
         --tensor-parallel-size $7 \
         --enable-expert-parallel \
         --seed 1024 \
-        --served-model-name deepseek_v4 \
+        --served-model-name dsv4 \
         --max-model-len 137216 \
         --max-num-batched-tokens 8192 \
         --max-num-seqs 16 \
@@ -837,7 +835,7 @@ For each P instance, only these two configuration values need to be modified: â€
         --tensor-parallel-size $7 \
         --enable-expert-parallel \
         --seed 1024 \
-        --served-model-name deepseek_v4 \
+        --served-model-name dsv4 \
         --max-model-len 137216 \
         --max-num-batched-tokens 60 \
         --max-num-seqs 30 \
@@ -925,7 +923,7 @@ Once your server is started, you can query the model with input prompts:
 curl http://<node0_ip>:<port>/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{
-        "model": "deepseek_v4",
+        "model": "dsv4",
         "messages": [
             {
                 "role": "user",

--- a/docs/source/tutorials/models/DeepSeek-V4-Pro.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Pro.md
@@ -173,7 +173,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/DeepSeek-V4-Pro-w4a8-m
   --port 10010 \
   --max_model_len 133072 \
   --max-num-batched-tokens 4096 \
-  --served-model-name ds-v4 \
+  --served-model-name dsv4 \
   --gpu-memory-utilization 0.9 \
   --max-num-seqs 4 \
   --data-parallel-size 4 \
@@ -240,7 +240,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/DeepSeek-V4-Pro-w4a8-m
   --headless \
   --max_model_len 133072 \
   --max-num-batched-tokens 4096 \
-  --served-model-name ds-v4 \
+  --served-model-name dsv4 \
   --gpu-memory-utilization 0.9 \
   --max-num-seqs 4 \
   --data-parallel-size 4 \
@@ -555,7 +555,7 @@ Before you start, please
             --tensor-parallel-size $7 \
             --enable-expert-parallel \
             --seed 1024 \
-            --served-model-name auto \
+            --served-model-name dsv4 \
             --max-model-len 131072 \
             --max-num-batched-tokens 8192 \
             --max-num-seqs 16 \
@@ -632,7 +632,7 @@ Before you start, please
             --tensor-parallel-size $7 \
             --enable-expert-parallel \
             --seed 1024 \
-            --served-model-name auto \
+            --served-model-name dsv4 \
             --max-model-len 131072 \
             --max-num-batched-tokens 8192 \
             --max-num-seqs 16 \
@@ -707,7 +707,7 @@ Before you start, please
             --tensor-parallel-size $7 \
             --enable-expert-parallel \
             --seed 1024 \
-            --served-model-name auto \
+            --served-model-name dsv4 \
             --max-model-len 131072 \
             --max-num-batched-tokens 120 \
             --max-num-seqs 60 \
@@ -938,7 +938,7 @@ Before you start, please
           --tensor-parallel-size $7 \
           --enable-expert-parallel \
           --seed 1024 \
-          --served-model-name deepseek_v4 \
+          --served-model-name dsv4 \
           --max_model_len 133072 \
           --max-num-batched-tokens 8192 \
           --max-num-seqs 16 \
@@ -1016,7 +1016,7 @@ Before you start, please
           --tensor-parallel-size $7 \
           --enable-expert-parallel \
           --seed 1024 \
-          --served-model-name deepseek_v4 \
+          --served-model-name dsv4 \
           --max-model-len 133072 \
           --max-num-batched-tokens 120 \
           --max-num-seqs 60 \
@@ -1121,7 +1121,7 @@ Once your server is started, you can query the model with input prompts:
 curl http://<node0_ip>:<port>/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{
-        "model": "deepseek_v4",
+        "model": "dsv4",
         "messages": [
             {
                 "role": "user",


### PR DESCRIPTION
### What this PR does / why we need it?

Cleanup the DeepSeek-V4 deployment tutorials on `releases/v0.18.0`:

- **Unify `--served-model-name` to `dsv4`** across all single-node and PD-separation launch scripts in both `DeepSeek-V4-Flash.md` and `DeepSeek-V4-Pro.md`. Previously the value was inconsistent (`ds`, `ds-v4`, `auto`, `deepseek_v4`), which mismatches the `model` field used in the Functional Verification curl example (`dsv4`) and causes the example request to fail. The curl example's `"model"` field is also aligned to `dsv4`.
- **Flash**: remove the two `-v /mnt/sfs_turbo/.cache:/root/.cache` mount lines from the Docker installation blocks, so the Docker example matches the Pro tutorial and the general installation guide (which mount `/root/.cache` directly).

These are documentation consistency fixes only; the actual service launch parameters and logic are otherwise unchanged.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only change; no code, API, or behavior change.

### How was this patch tested?

Documentation only — no code changes. Both files remain under the existing `docs/source/tutorials/models/` toctree; no new toctree entry is required.

Co-Authored-By: Claude <noreply@anthropic.com>

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
