### PR TITLE
[BugFix][Worker] Fix PD recompute decode classification for MTP

### DIFF
--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -416,3 +416,37 @@ class TestUtils(TestBase):
             result = utils.maybe_trans_nz(weight)
             self.assertIs(result, weight)
             assert_nz_cast(weight)
+
+
+def test_is_pd_decode_recompute_scheduler_enabled_without_config():
+    assert utils.is_pd_decode_recompute_scheduler_enabled() is False
+
+
+def test_is_pd_decode_recompute_scheduler_enabled_kv_producer():
+    vllm_config = mock.MagicMock()
+    vllm_config.kv_transfer_config = mock.MagicMock()
+    vllm_config.kv_transfer_config.is_kv_consumer = False
+    vllm_config.kv_transfer_config.is_kv_producer = True
+    assert utils.is_pd_decode_recompute_scheduler_enabled(vllm_config) is False
+
+
+def test_is_pd_decode_recompute_scheduler_enabled_decode_consumer():
+    vllm_config = mock.MagicMock()
+    vllm_config.kv_transfer_config = mock.MagicMock()
+    vllm_config.kv_transfer_config.is_kv_consumer = True
+    vllm_config.kv_transfer_config.is_kv_producer = False
+    ascend_config = mock.MagicMock()
+    ascend_config.recompute_scheduler_enable = True
+    with mock.patch("vllm_ascend.utils.get_ascend_config", return_value=ascend_config):
+        assert utils.is_pd_decode_recompute_scheduler_enabled(vllm_config) is True
+
+
+def test_is_pd_decode_recompute_scheduler_enabled_decode_consumer_disabled():
+    vllm_config = mock.MagicMock()
+    vllm_config.kv_transfer_config = mock.MagicMock()
+    vllm_config.kv_transfer_config.is_kv_consumer = True
+    vllm_config.kv_transfer_config.is_kv_producer = False
+    ascend_config = mock.MagicMock()
+    ascend_config.recompute_scheduler_enable = False
+    with mock.patch("vllm_ascend.utils.get_ascend_config", return_value=ascend_config):
+        assert utils.is_pd_decode_recompute_scheduler_enabled(vllm_config) is False

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -9,7 +9,12 @@ from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 
-from vllm_ascend.utils import AscendDeviceType, get_ascend_config, get_ascend_device_type
+from vllm_ascend.utils import (
+    AscendDeviceType,
+    get_ascend_config,
+    get_ascend_device_type,
+    is_pd_decode_recompute_scheduler_enabled,
+)
 from vllm_ascend.worker.kvcomp_utils import KVCompMetaData
 
 
@@ -313,6 +318,11 @@ def split_decodes_and_prefills(
 
     num_tokens = common_attn_metadata.num_actual_tokens
     query_start_loc = common_attn_metadata.query_start_loc_cpu
+
+    # PD D + RecomputeScheduler: num_computed may be N-1 after KV recv while
+    # this step is MTP decode (max_query_len <= threshold).
+    if is_pd_decode_recompute_scheduler_enabled():
+        treat_short_extends_as_decodes = True
 
     if (
         max_query_len <= decode_threshold

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1089,6 +1089,26 @@ def is_hierarchical_communication_enabled():
     ) or get_ascend_config().enable_mc2_hierarchy_comm
 
 
+def is_pd_decode_recompute_scheduler_enabled(vllm_config: VllmConfig | None = None) -> bool:
+    """True on PD-disaggregated decode nodes with recompute_scheduler_enable.
+
+    After KV recv, RecomputeScheduler sets num_computed_tokens to N-1 so the
+    decode node recomputes the last prompt token before MTP decode. Worker
+    metadata must not treat that step as prefill.
+    """
+    if vllm_config is None:
+        try:
+            from vllm.config import get_current_vllm_config
+
+            vllm_config = get_current_vllm_config()
+        except AssertionError:
+            vllm_config = get_ascend_config().vllm_config
+    kv_cfg = vllm_config.kv_transfer_config
+    if kv_cfg is None or not kv_cfg.is_kv_consumer or kv_cfg.is_kv_producer:
+        return False
+    return get_ascend_config().recompute_scheduler_enable
+
+
 def should_skip_allreduce_across_dp_group(vllm_config, is_draft_model: bool = False) -> bool:
     """Decide whether to skip the all-reduce across the DP group.
 

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1096,17 +1096,22 @@ def is_pd_decode_recompute_scheduler_enabled(vllm_config: VllmConfig | None = No
     decode node recomputes the last prompt token before MTP decode. Worker
     metadata must not treat that step as prefill.
     """
-    if vllm_config is None:
-        try:
-            from vllm.config import get_current_vllm_config
+    try:
+        if vllm_config is None:
+            try:
+                from vllm.config import get_current_vllm_config
 
-            vllm_config = get_current_vllm_config()
-        except AssertionError:
-            vllm_config = get_ascend_config().vllm_config
-    kv_cfg = vllm_config.kv_transfer_config
-    if kv_cfg is None or not kv_cfg.is_kv_consumer or kv_cfg.is_kv_producer:
+                vllm_config = get_current_vllm_config()
+            except AssertionError:
+                vllm_config = get_ascend_config().vllm_config
+        if vllm_config is None:
+            return False
+        kv_cfg = vllm_config.kv_transfer_config
+        if kv_cfg is None or not kv_cfg.is_kv_consumer or kv_cfg.is_kv_producer:
+            return False
+        return get_ascend_config().recompute_scheduler_enable
+    except (RuntimeError, AttributeError):
         return False
-    return get_ascend_config().recompute_scheduler_enable
 
 
 def should_skip_allreduce_across_dp_group(vllm_config, is_draft_model: bool = False) -> bool:

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -31,6 +31,7 @@ from vllm.logger import logger
 from vllm.utils import length_from_prompt_token_ids_or_embeds
 from vllm.v1.utils import CpuGpuBuffer
 
+from vllm_ascend.utils import is_pd_decode_recompute_scheduler_enabled
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 
 if TYPE_CHECKING:
@@ -72,6 +73,7 @@ class PCPManager:
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1 + (self.speculative_config.num_speculative_tokens if self.speculative_config else 0)
         self.vllm_config = vllm_config
+        self.pd_decode_recompute_scheduler_enabled = is_pd_decode_recompute_scheduler_enabled(vllm_config)
         self.max_num_tokens = self.vllm_config.scheduler_config.max_num_batched_tokens
         self.max_num_reqs = self.vllm_config.scheduler_config.max_num_seqs
         self.device = device
@@ -195,8 +197,8 @@ class PCPManager:
 
         return cu_num_tokens, arange
 
-    @staticmethod
     def classify_decode_request_mask(
+        self,
         num_scheduled_tokens: np.ndarray | torch.Tensor,
         num_computed_tokens: np.ndarray | torch.Tensor,
         num_prompt_tokens: np.ndarray | torch.Tensor,
@@ -209,8 +211,11 @@ class PCPManager:
         """
 
         has_context = num_computed_tokens > 0
-        done_prefilling = num_computed_tokens >= num_prompt_tokens
         is_below_threshold = num_scheduled_tokens <= decode_threshold
+        done_prefilling = num_computed_tokens >= num_prompt_tokens
+        if self.pd_decode_recompute_scheduler_enabled:
+            # PD D + RecomputeScheduler: KV recv leaves num_computed at N-1.
+            done_prefilling = done_prefilling | (num_computed_tokens == num_prompt_tokens - 1)
         return has_context & is_below_threshold & done_prefilling
 
     def init_batch_info(


### PR DESCRIPTION
### What this PR does / why we need it?

On PD-disaggregated decode nodes with `recompute_scheduler_enable`, KV transfer leaves `num_computed_tokens = N-1` on the first decode step so the last prompt token is recomputed before MTP speculative decoding. Worker metadata incorrectly treated this step as prefill, which caused:

- MLA `split_decodes_and_prefills` to take the mixed-prefill path under DCP (wrong ACL graph branch)
- PCP `classify_decode_request_mask` to produce zero decode requests, crashing MTP proposer (`torch.cat` on empty slot indices)

This PR adds `is_pd_decode_recompute_scheduler_enabled()` and applies PD-recompute-aware decode classification in MLA split and PCP decode masks. The flag is cached on `PCPManager` init to avoid `get_current_vllm_config()` failures during `profile_run`.

### Does this PR introduce _any_ user-facing change?

No API changes. Fixes incorrect behavior for PD disaggregation + MTP + PCP/DCP when recompute scheduler is enabled on the decode node.

### How was this patch tested?

- `ruff check` / `ruff format` on changed files
- Manual end-to-end validation on PD + MTP + PCP/DCP (Mooncake) setup: P node starts successfully and D node produces correct output

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
