### PR TITLE
[CI] Move accuracy-group-2 to weekly single node configs

### DIFF
--- a/.github/workflows/schedule_weekly_test_a2.yaml
+++ b/.github/workflows/schedule_weekly_test_a2.yaml
@@ -229,7 +229,6 @@ jobs:
   clear-pre-logs:
     needs: [parse-trigger]
     runs-on: linux-aarch64-a2b3-0
-    if: needs.multi-node-tests.result != 'skipped'
     steps:
       - name: Clear pre-logs on pvc
         run: |

--- a/.github/workflows/schedule_weekly_test_a2.yaml
+++ b/.github/workflows/schedule_weekly_test_a2.yaml
@@ -15,24 +15,307 @@
 # This file is a part of the vllm-ascend project.
 #
 
+# This workflow related to the resources atlas 800 A2
+# We will not limit the concurrency of jobs on A2
 name: Weekly-A2
 
 on:
-  schedule:
-      # Run doctest at 00:00 Beijing time (UTC+8) every Sunday
-      - cron: "0 16 * * 6"
   workflow_dispatch:
+    inputs:
+      vllm_ascend_branch:
+        description: 'Branch to test'
+        required: true
+        default: 'releases/v0.22.1rc'
+        type: string
+      test_cases:
+        description: 'Test cases to run (comma-separated, e.g., "test_custom_op,qwen3-32b,accuracy-group" or "all" for all tests)'
+        required: false
+        default: 'all'
+        type: string
+      request_id:
+        description: 'Unique request ID from the triggering workflow for run identification'
+        required: false
+        default: ''
+        type: string
+      skip_build_image:
+        description: 'Skip build-image job (used when triggered by /nightly command)'
+        required: false
+        default: 'false'
+        type: string
+      vllm_ascend_ref:
+        description: 'PR commit SHA for PR-triggered tests'
+        required: false
+        default: ''
+        type: string
+  pull_request:
+    branches:
+      - 'main'
+    types: [labeled, synchronize]
 
 permissions:
   contents: read
+  pull-requests: read
+  issues: read
 
+# Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
+# declared as "shell: bash -el {0}" on steps that need to be properly activated.
+# It's used to activate ascend-toolkit environment variables.
+defaults:
+  run:
+    shell: bash -el {0}
+
+# only cancel in-progress runs of the same workflow
 concurrency:
-  group: ascend-weekly-${{ github.ref }}-a2
+  group: ascend-weekly-${{ github.ref }}-a2${{ inputs.request_id && format('-{0}', inputs.request_id) || '' }}
   cancel-in-progress: true
 
+env:
+  # Single source of truth for all shared variables across jobs.
+  # NOTE: GitHub Actions does not support env context in reusable workflow `with:` inputs,
+  # so these values are exported as job outputs via the `setup-vars` job below.
+  CANN_IMAGE: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.0-910b-ubuntu22.04-py3.12'
+  ASCEND_LOG_PREFIX: '/root/.cache/ascend-logs'
+
 jobs:
-  doc-test:
-    name: doc-test
-    uses: ./.github/workflows/labeled_doctest.yaml
+  parse-trigger:
+    name: Parse trigger and determine test scope
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'pull_request'
+    runs-on: linux-amd64-cpu-8-hk
+    outputs:
+      run: ${{ steps.parse.outputs.run }}
+      filter: ${{ steps.parse.outputs.filter }}
+      ref: ${{ steps.parse.outputs.ref }}
+      request_id: ${{ steps.parse.outputs.request_id }}
+      vllm_ascend_branch: ${{ steps.parse.outputs.vllm_ascend_branch }}
+      is_pr_event: ${{ steps.parse.outputs.is_pr_event }}
+    steps:
+      - name: Parse trigger
+        id: parse
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const eventName = context.eventName;
+
+            // workflow_dispatch: use input values with test_cases filtering
+            if (eventName === 'workflow_dispatch') {
+              const inputs = context.payload.inputs || {};
+              const testCases = (inputs.test_cases || '').trim();
+              core.setOutput('ref', inputs.vllm_ascend_ref || context.sha || '');
+              core.setOutput('request_id', inputs.request_id || '');
+              core.setOutput('vllm_ascend_branch', inputs.vllm_ascend_branch || 'main');
+              core.setOutput('is_pr_event', 'false');
+              if (testCases) {
+                core.setOutput('run', 'true');
+                if (testCases === 'all') {
+                  core.setOutput('filter', 'all');
+                } else {
+                  core.setOutput('filter', ',' + testCases.split(',').map(s => s.trim()).join(',') + ',');
+                }
+              } else {
+                core.setOutput('run', 'false');
+                core.setOutput('filter', '');
+              }
+              return;
+            }
+
+            // pull_request (labeled / synchronize)
+            if (eventName === 'pull_request') {
+              const labels = context.payload.pull_request.labels.map(l => l.name);
+              const prNumber = context.payload.pull_request.number;
+              core.setOutput('ref', context.payload.pull_request.head.sha);
+              core.setOutput('request_id', 'pr-' + prNumber);
+              core.setOutput('vllm_ascend_branch', 'main');
+              core.setOutput('is_pr_event', 'true');
+
+              if (!labels.includes('nightly-test')) {
+                core.info('nightly-test label not found; skipping.');
+                core.setOutput('run', 'false');
+                core.setOutput('filter', '');
+                return;
+              }
+
+              // Search comments for latest /nightly-pr command
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                per_page: 100,
+              });
+
+              let testFilter = null;
+              for (let i = comments.length - 1; i >= 0; i--) {
+                const body = comments[i].body;
+                if (!body) continue;
+                const match = body.trim().match(/^\/nightly-pr(?:\s+(.+))?$/m);
+                if (match) {
+                  const args = (match[1] || '').trim();
+                  if (!args) {
+                    core.info('/nightly-pr without arguments; skipping all tests.');
+                    testFilter = 'none';
+                  } else {
+                    testFilter = ',' + args.split(/\s+/).join(',') + ',';
+                  }
+                  break;
+                }
+              }
+
+              if (testFilter === null) {
+                core.info('nightly-test label present but no /nightly-pr comment found; skipping.');
+                core.setOutput('run', 'false');
+                core.setOutput('filter', '');
+                return;
+              }
+
+              if (testFilter === 'none') {
+                core.setOutput('run', 'false');
+                core.setOutput('filter', '');
+                return;
+              }
+
+              core.setOutput('run', 'true');
+              core.setOutput('filter', testFilter);
+              return;
+            }
+
+            // Fallback (should not reach here due to job if condition)
+            core.setOutput('run', 'false');
+            core.setOutput('filter', '');
+            core.setOutput('ref', '');
+            core.setOutput('request_id', '');
+            core.setOutput('vllm_ascend_branch', 'main');
+            core.setOutput('is_pr_event', 'false');
+
+  setup-vars:
+    name: Export global env vars as job outputs
+    needs: parse-trigger
+    runs-on: linux-amd64-cpu-8-hk
+    outputs:
+      cann_image: ${{ steps.export.outputs.cann_image }}
+      ascend_log_prefix: ${{ steps.export.outputs.ascend_log_prefix }}
+      vllm_ascend_branches: ${{ steps.export.outputs.vllm_ascend_branches }}
+    steps:
+      - id: export
+        run: |
+          {
+            echo "cann_image=${{ env.CANN_IMAGE }}"
+            echo "ascend_log_prefix=${{ env.ASCEND_LOG_PREFIX }}"
+            input_branch="${{ needs.parse-trigger.outputs.vllm_ascend_branch }}"
+            normalized=$(echo "$input_branch" | tr '/' '-')
+            echo "vllm_ascend_branches=[\"${normalized}\"]"
+          } >> $GITHUB_OUTPUT
+
+  build-image:
+    name: Build nightly-a2 image
+    if: >-
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.skip_build_image || 'false') != 'true')
+    strategy:
+      matrix:
+        vllm_ascend_branch: >-
+          ${{ fromJSON(format('["{0}"]', github.event.inputs.vllm_ascend_branch || 'main')) }}
+    uses: ./.github/workflows/_nightly_image_build.yaml
     with:
-      doc_versions: '["v0.18.0","latest"]'
+      target: a2
+      vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
+    secrets:
+      HW_USERNAME: ${{ secrets.HW_USERNAME }}
+      HW_TOKEN: ${{ secrets.HW_TOKEN }}
+      GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+
+  generate-accuracy-matrix:
+    name: Generate accuracy test matrix
+    needs: [parse-trigger]
+    if: >-
+      always() &&
+      needs.parse-trigger.outputs.run == 'true' &&
+      needs.parse-trigger.outputs.is_pr_event != 'true' && (
+        needs.parse-trigger.outputs.filter == 'all' ||
+        contains(needs.parse-trigger.outputs.filter, 'accuracy-group')
+      )
+    runs-on: linux-aarch64-a2b3-0
+    outputs:
+      nightly_matrix: ${{ steps.set-matrix.outputs.nightly_matrix }}
+      pr_only_matrix: ${{ steps.set-matrix.outputs.pr_only_matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Read accuracy group config
+        id: set-matrix
+        run: |
+          CONFIG_FILE="tests/e2e/weekly/single_node/configs/accuracy_groups_a2.json"
+          NIGHTLY=$(jq -c '.nightly' "$CONFIG_FILE")
+          PR_ONLY=$(jq -c '.pr_only' "$CONFIG_FILE")
+          echo "nightly_matrix=${NIGHTLY}" >> "$GITHUB_OUTPUT"
+          echo "pr_only_matrix=${PR_ONLY}" >> "$GITHUB_OUTPUT"
+
+  single-node-accuracy-tests:
+    needs: [setup-vars, parse-trigger, build-image, generate-accuracy-matrix]
+    if: >-
+      always() &&
+      needs.parse-trigger.outputs.run == 'true' &&
+      needs.parse-trigger.outputs.is_pr_event != 'true' &&
+      needs.generate-accuracy-matrix.result != 'skipped' &&
+      (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        vllm_ascend_branch: ${{ fromJSON(needs.setup-vars.outputs.vllm_ascend_branches) }}
+        test_config: ${{ fromJson(needs.generate-accuracy-matrix.outputs.nightly_matrix) }}
+    uses: ./.github/workflows/_e2e_nightly_single_node_models.yaml
+    with:
+      runner: ${{ matrix.test_config.os }}
+      model_list: ${{ toJson(matrix.test_config.model_list) }}
+      model_filter: ${{ needs.parse-trigger.outputs.filter }}
+      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a2'
+      is_run: >-
+        ${{
+          needs.parse-trigger.outputs.run == 'true' && (
+            needs.parse-trigger.outputs.filter == 'all' ||
+            contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
+          )
+        }}
+      request_id: ${{ needs.parse-trigger.outputs.request_id || '' }}
+      vllm_ascend_ref: ${{ needs.parse-trigger.outputs.ref || '' }}
+      upload: false
+
+  single-node-accuracy-tests-pr-only:
+    needs: [setup-vars, parse-trigger, build-image, generate-accuracy-matrix]
+    if: >-
+      always() &&
+      needs.parse-trigger.outputs.run == 'true' &&
+      needs.parse-trigger.outputs.is_pr_event != 'true' &&
+      needs.parse-trigger.outputs.filter != 'all' &&
+      needs.generate-accuracy-matrix.result != 'skipped' &&
+      (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        vllm_ascend_branch: ${{ fromJSON(needs.setup-vars.outputs.vllm_ascend_branches) }}
+        test_config: ${{ fromJson(needs.generate-accuracy-matrix.outputs.pr_only_matrix) }}
+    uses: ./.github/workflows/_e2e_nightly_single_node_models.yaml
+    with:
+      runner: ${{ matrix.test_config.os }}
+      model_list: ${{ toJson(matrix.test_config.model_list) }}
+      model_filter: ${{ needs.parse-trigger.outputs.filter }}
+      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a2'
+      is_run: >-
+        ${{
+          needs.parse-trigger.outputs.run == 'true' &&
+          needs.parse-trigger.outputs.filter != 'all' &&
+          contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
+        }}
+      request_id: ${{ needs.parse-trigger.outputs.request_id || '' }}
+      vllm_ascend_ref: ${{ needs.parse-trigger.outputs.ref || '' }}
+      upload: false
+
+  clear-pre-logs:
+    needs: [parse-trigger]
+    runs-on: linux-aarch64-a2b3-0
+    if: needs.multi-node-tests.result != 'skipped'
+    steps:
+      - name: Clear pre-logs on pvc
+        run: |
+          # Clear logs generated before the test to avoid confusion
+          rm -rf "${ASCEND_LOG_PREFIX:?}"/* || true

--- a/.github/workflows/schedule_weekly_test_a2.yaml
+++ b/.github/workflows/schedule_weekly_test_a2.yaml
@@ -25,7 +25,7 @@ on:
       vllm_ascend_branch:
         description: 'Branch to test'
         required: true
-        default: 'releases/v0.22.1rc'
+        default: 'main'
         type: string
       test_cases:
         description: 'Test cases to run (comma-separated, e.g., "test_custom_op,qwen3-32b,accuracy-group" or "all" for all tests)'
@@ -248,7 +248,7 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact/merge@v7
         with:
-          name: nightly-a2
+          name: weekly-a2
           pattern: nightly-test-benchmark-results-*
           compression-level: 0
           delete-merged: true

--- a/.github/workflows/schedule_weekly_test_a2.yaml
+++ b/.github/workflows/schedule_weekly_test_a2.yaml
@@ -47,10 +47,6 @@ on:
         required: false
         default: ''
         type: string
-  pull_request:
-    branches:
-      - 'main'
-    types: [labeled, synchronize]
 
 permissions:
   contents: read
@@ -80,16 +76,12 @@ jobs:
   parse-trigger:
     name: Parse trigger and determine test scope
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request'
-    runs-on: linux-amd64-cpu-8-hk
+      github.event_name == 'workflow_dispatch'
+    runs-on: linux-aarch64-a2b3-0
     outputs:
       run: ${{ steps.parse.outputs.run }}
       filter: ${{ steps.parse.outputs.filter }}
       ref: ${{ steps.parse.outputs.ref }}
-      request_id: ${{ steps.parse.outputs.request_id }}
-      vllm_ascend_branch: ${{ steps.parse.outputs.vllm_ascend_branch }}
-      is_pr_event: ${{ steps.parse.outputs.is_pr_event }}
     steps:
       - name: Parse trigger
         id: parse
@@ -97,100 +89,27 @@ jobs:
         with:
           script: |
             const eventName = context.eventName;
+            const testCases = '${{ inputs.test_cases }}'.trim();
 
-            // workflow_dispatch: use input values with test_cases filtering
-            if (eventName === 'workflow_dispatch') {
-              const inputs = context.payload.inputs || {};
-              const testCases = (inputs.test_cases || '').trim();
-              core.setOutput('ref', inputs.vllm_ascend_ref || context.sha || '');
-              core.setOutput('request_id', inputs.request_id || '');
-              core.setOutput('vllm_ascend_branch', inputs.vllm_ascend_branch || 'main');
-              core.setOutput('is_pr_event', 'false');
-              if (testCases) {
-                core.setOutput('run', 'true');
-                if (testCases === 'all') {
-                  core.setOutput('filter', 'all');
-                } else {
-                  core.setOutput('filter', ',' + testCases.split(',').map(s => s.trim()).join(',') + ',');
-                }
-              } else {
-                core.setOutput('run', 'false');
-                core.setOutput('filter', '');
-              }
-              return;
-            }
+            core.setOutput('ref', context.sha || 'unknown');
 
-            // pull_request (labeled / synchronize)
-            if (eventName === 'pull_request') {
-              const labels = context.payload.pull_request.labels.map(l => l.name);
-              const prNumber = context.payload.pull_request.number;
-              core.setOutput('ref', context.payload.pull_request.head.sha);
-              core.setOutput('request_id', 'pr-' + prNumber);
-              core.setOutput('vllm_ascend_branch', 'main');
-              core.setOutput('is_pr_event', 'true');
-
-              if (!labels.includes('nightly-test')) {
-                core.info('nightly-test label not found; skipping.');
-                core.setOutput('run', 'false');
-                core.setOutput('filter', '');
-                return;
-              }
-
-              // Search comments for latest /nightly-pr command
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                per_page: 100,
-              });
-
-              let testFilter = null;
-              for (let i = comments.length - 1; i >= 0; i--) {
-                const body = comments[i].body;
-                if (!body) continue;
-                const match = body.trim().match(/^\/nightly-pr(?:\s+(.+))?$/m);
-                if (match) {
-                  const args = (match[1] || '').trim();
-                  if (!args) {
-                    core.info('/nightly-pr without arguments; skipping all tests.');
-                    testFilter = 'none';
-                  } else {
-                    testFilter = ',' + args.split(/\s+/).join(',') + ',';
-                  }
-                  break;
-                }
-              }
-
-              if (testFilter === null) {
-                core.info('nightly-test label present but no /nightly-pr comment found; skipping.');
-                core.setOutput('run', 'false');
-                core.setOutput('filter', '');
-                return;
-              }
-
-              if (testFilter === 'none') {
-                core.setOutput('run', 'false');
-                core.setOutput('filter', '');
-                return;
-              }
-
+            if (testCases) {
               core.setOutput('run', 'true');
-              core.setOutput('filter', testFilter);
+              if (testCases === 'all') {
+                core.setOutput('filter', 'all');
+              } else {
+                core.setOutput('filter', ',' + testCases.split(',').map(s => s.trim()).join(',') + ',');
+              }
               return;
             }
 
-            // Fallback (should not reach here due to job if condition)
             core.setOutput('run', 'false');
             core.setOutput('filter', '');
-            core.setOutput('ref', '');
-            core.setOutput('request_id', '');
-            core.setOutput('vllm_ascend_branch', 'main');
-            core.setOutput('is_pr_event', 'false');
 
   setup-vars:
     name: Export global env vars as job outputs
     needs: parse-trigger
-    runs-on: linux-amd64-cpu-8-hk
+    runs-on: linux-aarch64-a2b3-0
     outputs:
       cann_image: ${{ steps.export.outputs.cann_image }}
       ascend_log_prefix: ${{ steps.export.outputs.ascend_log_prefix }}
@@ -201,7 +120,7 @@ jobs:
           {
             echo "cann_image=${{ env.CANN_IMAGE }}"
             echo "ascend_log_prefix=${{ env.ASCEND_LOG_PREFIX }}"
-            input_branch="${{ needs.parse-trigger.outputs.vllm_ascend_branch }}"
+            input_branch="${{ inputs.vllm_ascend_branch }}"
             normalized=$(echo "$input_branch" | tr '/' '-')
             echo "vllm_ascend_branches=[\"${normalized}\"]"
           } >> $GITHUB_OUTPUT
@@ -209,11 +128,11 @@ jobs:
   build-image:
     name: Build nightly-a2 image
     if: >-
-      (github.event_name == 'workflow_dispatch' && (github.event.inputs.skip_build_image || 'false') != 'true')
+      (github.event_name == 'workflow_dispatch' && inputs.skip_build_image != 'true')
     strategy:
       matrix:
         vllm_ascend_branch: >-
-          ${{ fromJSON(format('["{0}"]', github.event.inputs.vllm_ascend_branch || 'main')) }}
+          ${{ fromJSON(format('["{0}"]', inputs.vllm_ascend_branch)) }}
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: a2
@@ -228,8 +147,7 @@ jobs:
     needs: [parse-trigger]
     if: >-
       always() &&
-      needs.parse-trigger.outputs.run == 'true' &&
-      needs.parse-trigger.outputs.is_pr_event != 'true' && (
+      needs.parse-trigger.outputs.run == 'true' && (
         needs.parse-trigger.outputs.filter == 'all' ||
         contains(needs.parse-trigger.outputs.filter, 'accuracy-group')
       )
@@ -255,7 +173,6 @@ jobs:
     if: >-
       always() &&
       needs.parse-trigger.outputs.run == 'true' &&
-      needs.parse-trigger.outputs.is_pr_event != 'true' &&
       needs.generate-accuracy-matrix.result != 'skipped' &&
       (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
     strategy:
@@ -276,8 +193,8 @@ jobs:
             contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
           )
         }}
-      request_id: ${{ needs.parse-trigger.outputs.request_id || '' }}
-      vllm_ascend_ref: ${{ needs.parse-trigger.outputs.ref || '' }}
+      request_id: ${{ inputs.request_id || '' }}
+      vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
       upload: false
 
   single-node-accuracy-tests-pr-only:
@@ -285,7 +202,6 @@ jobs:
     if: >-
       always() &&
       needs.parse-trigger.outputs.run == 'true' &&
-      needs.parse-trigger.outputs.is_pr_event != 'true' &&
       needs.parse-trigger.outputs.filter != 'all' &&
       needs.generate-accuracy-matrix.result != 'skipped' &&
       (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
@@ -306,12 +222,12 @@ jobs:
           needs.parse-trigger.outputs.filter != 'all' &&
           contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
         }}
-      request_id: ${{ needs.parse-trigger.outputs.request_id || '' }}
-      vllm_ascend_ref: ${{ needs.parse-trigger.outputs.ref || '' }}
+      request_id: ${{ inputs.request_id || '' }}
+      vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
       upload: false
 
   clear-pre-logs:
-    needs: [parse-trigger]
+    needs: [parse-trigger, multi-node-tests]
     runs-on: linux-aarch64-a2b3-0
     if: needs.multi-node-tests.result != 'skipped'
     steps:
@@ -319,3 +235,21 @@ jobs:
         run: |
           # Clear logs generated before the test to avoid confusion
           rm -rf "${ASCEND_LOG_PREFIX:?}"/* || true
+
+  merge-benchmark-artifacts:
+    name: Merge benchmark artifacts into nightly-a2.zip
+    needs: [parse-trigger, single-node-tests, multi-node-tests]
+    if: >-
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      needs.parse-trigger.result == 'success'
+    runs-on: linux-aarch64-a2b3-0
+    steps:
+      - name: Merge all benchmark result artifacts
+        continue-on-error: true
+        uses: actions/upload-artifact/merge@v7
+        with:
+          name: nightly-a2
+          pattern: nightly-test-benchmark-results-*
+          compression-level: 0
+          delete-merged: true

--- a/.github/workflows/schedule_weekly_test_a2.yaml
+++ b/.github/workflows/schedule_weekly_test_a2.yaml
@@ -227,7 +227,7 @@ jobs:
       upload: false
 
   clear-pre-logs:
-    needs: [parse-trigger, multi-node-tests]
+    needs: [parse-trigger]
     runs-on: linux-aarch64-a2b3-0
     if: needs.multi-node-tests.result != 'skipped'
     steps:
@@ -238,7 +238,7 @@ jobs:
 
   merge-benchmark-artifacts:
     name: Merge benchmark artifacts into nightly-a2.zip
-    needs: [parse-trigger, single-node-tests, multi-node-tests]
+    needs: [parse-trigger]
     if: >-
       always() &&
       github.event_name == 'workflow_dispatch' &&

--- a/tests/e2e/models/configs/accuracy_groups_a2.json
+++ b/tests/e2e/models/configs/accuracy_groups_a2.json
@@ -13,15 +13,6 @@
       ]
     },
     {
-      "name": "accuracy-group-2",
-      "os": "linux-aarch64-a2b3-1",
-      "model_list": [
-        "ERNIE-4.5-21B-A3B-PT",
-        "Molmo-7B-D-0924",
-        "Llama-3.2-3B-Instruct"
-      ]
-    },
-    {
       "name": "accuracy-group-3",
       "os": "linux-aarch64-a2b3-2",
       "model_list": [

--- a/tests/e2e/weekly/single_node/configs/accuracy_groups_a2.json
+++ b/tests/e2e/weekly/single_node/configs/accuracy_groups_a2.json
@@ -1,0 +1,13 @@
+{
+  "nightly": [
+    {
+      "name": "accuracy-group-2",
+      "os": "linux-aarch64-a2b3-1",
+      "model_list": [
+        "ERNIE-4.5-21B-A3B-PT",
+        "Molmo-7B-D-0924",
+        "Llama-3.2-3B-Instruct"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### What this PR does / why we need it?

This PR moves `accuracy-group-2` (containing `ERNIE-4.5-21B-A3B-PT`, `Molmo-7B-D-0924`, and `Llama-3.2-3B-Instruct`) from the nightly E2E models configuration to the weekly single-node E2E models configuration to optimize nightly test suite execution times.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This is a configuration change for E2E tests.


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
