### PR TITLE
[BugFix][Model] Sync HcPre fused path and use v2

### DIFF
--- a/csrc/moe/hc_pre/op_host/hc_pre_tiling_arch35.h
+++ b/csrc/moe/hc_pre/op_host/hc_pre_tiling_arch35.h
@@ -191,11 +191,12 @@ ge::graphStatus HcPreTilingRegbase::CalcRegbaseOpTiling()
     int64_t rowOnceLoop = std::min(rowOfFormerBlock_, minRowPerCore);
 
     hcMultAlign_ = RoundUp(hcMult_, BLOCK_SIZE / sizeof(float));
-    int64_t mixSize = rowOnceLoop * RoundUp(hcMix_, BLOCK_SIZE / sizeof(float));
+    int64_t mixSize = rowOnceLoop * RoundUp(hcMix_, BLOCK_SIZE / sizeof(float)) * sizeof(float);
     int64_t xSize = rowOnceLoop * hcMult_ * RoundUp(d_, 16) * 2 * DOUBLE_BUFFER; // x是bfloat16_t 类型
     int64_t ySize = rowOnceLoop * RoundUp(d_, 16) * 2 * DOUBLE_BUFFER;
     int64_t postSize = rowOnceLoop * hcMultAlign_ * sizeof(float) * DOUBLE_BUFFER;
-    int64_t combFragSize = rowOnceLoop * hcMult_ * hcMultAlign_ * sizeof(float) * DOUBLE_BUFFER;
+    // comb is packed in UB as hcMult * hcMult, so size it by the actual footprint.
+    int64_t combFragSize = rowOnceLoop * hcMult_ * hcMult_ * sizeof(float) * DOUBLE_BUFFER;
     int64_t base0Size = hcMultAlign_ * sizeof(float);
     int64_t base1Size = hcMultAlign_ * sizeof(float);
     int64_t base2Size = hcMult_ * hcMultAlign_ * sizeof(float);
@@ -240,11 +241,11 @@ ge::graphStatus HcPreTilingRegbase::CalcRegbaseOpTiling()
     // d全载,尝试搬入更多的bs
     if (dFactor_ == d_) {
         while (rowFactor_ <= mUbSize) {
-            mixSize = rowFactor_ * RoundUp(hcMix_, BLOCK_SIZE / sizeof(float));
+            mixSize = rowFactor_ * RoundUp(hcMix_, BLOCK_SIZE / sizeof(float)) * sizeof(float);
             xSize = rowFactor_ * hcMult_ * RoundUp(d_, 16) * 2 * DOUBLE_BUFFER; // x是bfloat16_t 类型
             ySize = rowFactor_ * RoundUp(d_, 16) * 2 * DOUBLE_BUFFER;
             postSize = rowFactor_ * hcMultAlign_ * sizeof(float) * DOUBLE_BUFFER;
-            combFragSize = rowFactor_ * hcMult_ * hcMultAlign_ * sizeof(float) * DOUBLE_BUFFER;
+            combFragSize = rowFactor_ * hcMult_ * hcMult_ * sizeof(float) * DOUBLE_BUFFER;
             totalSize = mixSize + xSize + ySize + postSize + combFragSize;
             if (totalSize > bufferPool1Size) {
                 rowFactor_ = rowFactor_ - 1;
@@ -312,7 +313,8 @@ ge::graphStatus HcPreTilingRegbase::CalcMKSplitCorePart2Tiling()
     int64_t xSize = rowOnceLoop * hcMult_ * RoundUp(d_, 16) * 2 * DOUBLE_BUFFER; // x是bfloat16_t 类型
     int64_t ySize = rowOnceLoop * RoundUp(d_, 16) * 2 * DOUBLE_BUFFER;
     int64_t postSize = rowOnceLoop * hcMultAlign_ * sizeof(float) * DOUBLE_BUFFER;
-    int64_t combFragSize = rowOnceLoop * hcMult_ * hcMultAlign_ * sizeof(float) * DOUBLE_BUFFER;
+    // comb is packed in UB as hcMult * hcMult, so size it by the actual footprint.
+    int64_t combFragSize = rowOnceLoop * hcMult_ * hcMult_ * sizeof(float) * DOUBLE_BUFFER;
     int64_t base0Size = hcMultAlign_ * sizeof(float);
     int64_t base1Size = hcMultAlign_ * sizeof(float);
     int64_t base2Size = hcMult_ * hcMultAlign_ * sizeof(float);
@@ -355,7 +357,7 @@ ge::graphStatus HcPreTilingRegbase::CalcMKSplitCorePart2Tiling()
             xSize = rowFactor_ * hcMult_ * RoundUp(d_, 16) * 2 * DOUBLE_BUFFER; // x是bfloat16_t 类型
             ySize = rowFactor_ * RoundUp(d_, 16) * 2 * DOUBLE_BUFFER;
             postSize = rowFactor_ * hcMultAlign_ * sizeof(float) * DOUBLE_BUFFER;
-            combFragSize = rowFactor_ * hcMult_ * hcMultAlign_ * sizeof(float) * DOUBLE_BUFFER;
+            combFragSize = rowFactor_ * hcMult_ * hcMult_ * sizeof(float) * DOUBLE_BUFFER;
             base0Size = hcMultAlign_ * sizeof(float);
             base1Size = hcMultAlign_ * sizeof(float);
             base2Size = hcMult_ * hcMultAlign_ * sizeof(float);

--- a/csrc/moe/hc_pre/op_kernel/hc_pre_base_arch35.h
+++ b/csrc/moe/hc_pre/op_kernel/hc_pre_base_arch35.h
@@ -873,6 +873,142 @@ __aicore__ inline void VFProcessCombFragRLessVLUseFourUnfold(const LocalTensor<f
     }
 }
 
+__aicore__ inline void RowGroupMaxBcast(RegTensor<float> &out, RegTensor<float> &in, RegTensor<float> &t0,
+                                        RegTensor<float> &t1, RegTensor<float> &t2, RegTensor<float> &t3, MaskReg preg)
+{
+    DeInterleave(t0, t1, in, in);        // t0 has even lanes, t1 has odd lanes, paired inside each group.
+    Max(t0, t0, t1, preg);               // Pairwise max for c0/c1 and c2/c3 inside each group.
+    DeInterleave(t2, t3, t0, t0);
+    Max(t2, t2, t3, preg);               // lane0..3 holds the max for each row group.
+    Interleave(t0, t1, t2, t2);          // [m0,m0,m1,m1,m2,m2,m3,m3]
+    Interleave(out, t1, t0, t0);         // Broadcast each row max to 4 lanes.
+}
+
+// Reduce the row sum over C in contiguous groups of 4 and broadcast it: out[4r+c] = sum_c M[r][c].
+__aicore__ inline void RowGroupSumBcast(RegTensor<float> &out, RegTensor<float> &in, RegTensor<float> &t0,
+                                        RegTensor<float> &t1, RegTensor<float> &t2, RegTensor<float> &t3, MaskReg preg)
+{
+    DeInterleave(t0, t1, in, in);
+    Add(t0, t0, t1, preg);
+    DeInterleave(t2, t3, t0, t0);
+    Add(t2, t2, t3, preg);
+    Interleave(t0, t1, t2, t2);
+    Interleave(out, t1, t0, t0);
+}
+
+// In-place softmax over C: subtract row max, exp, divide by row sum, then add eps.
+__aicore__ inline void SoftmaxRowBcastInplace(RegTensor<float> &m, RegTensor<float> &red,
+                                              RegTensor<float> &t0, RegTensor<float> &t1,
+                                              RegTensor<float> &t2, RegTensor<float> &t3,
+                                              float eps, MaskReg preg)
+{
+    RowGroupMaxBcast(red, m, t0, t1, t2, t3, preg);
+    Sub(m, m, red, preg);
+    Exp(m, m, preg);
+    RowGroupSumBcast(red, m, t0, t1, t2, t3, preg);
+    Div(m, m, red, preg);
+    Adds(m, m, eps, preg);
+}
+
+// In-place divide by row sum plus eps, and accumulate the result into csum for Sinkhorn iterations.
+__aicore__ inline void RowNormAccum(RegTensor<float> &m, RegTensor<float> &red, RegTensor<float> &csum,
+                                    RegTensor<float> &t0, RegTensor<float> &t1,
+                                    RegTensor<float> &t2, RegTensor<float> &t3,
+                                    float eps, MaskReg preg)
+{
+    RowGroupSumBcast(red, m, t0, t1, t2, t3, preg);
+    Adds(red, red, eps, preg);
+    Div(m, m, red, preg);
+    Add(csum, csum, m, preg);
+}
+
+__aicore__ inline void VFProcessCombFragPacked(const LocalTensor<float> &combFragLocal,
+                                               const LocalTensor<float> &mixLocal,
+                                               const LocalTensor<float> &hcBaseLocal,
+                                               float scale, float eps, uint16_t iters,
+                                               uint16_t dim0, uint16_t hcMult, uint16_t hcMix)
+{
+    __local_mem__ float *combOutAddr = (__local_mem__ float *)combFragLocal.GetPhyAddr();
+    __local_mem__ float *mixAddr = (__local_mem__ float *)mixLocal.GetPhyAddr();
+    __local_mem__ float *hcBaseAddr = (__local_mem__ float *)hcBaseLocal.GetPhyAddr();
+
+    const uint16_t R = hcMult;
+    const uint16_t pack = VL_FP32 / R;
+    const uint16_t combLen = R * R;
+    const uint16_t nChunks = (dim0 + pack - 1) / pack;
+    __local_mem__ float *mBase = mixAddr;
+    __local_mem__ float *oBase = combOutAddr;
+
+    __VEC_SCOPE__
+    {
+        RegTensor<float> mix0, mix1, mix2, mix3;
+        RegTensor<float> base0, base1, base2, base3;
+        RegTensor<float> red, csum;
+        RegTensor<float> t0, t1, t2, t3;
+        RegTensor<int32_t> vL, vbs, vc, gIdx, sIdx, cShift, cMask;
+
+        uint32_t uFull = VL_FP32;
+        MaskReg pIdx = UpdateMask<int32_t>(uFull);
+
+        Arange(vL, 0);
+        Duplicate(cShift, (int32_t)2, pIdx);
+        Duplicate(cMask, (int32_t)(R - 1), pIdx);
+        ShiftRight(vbs, vL, cShift, pIdx);
+        And(vc, vL, cMask, pIdx);
+        Muls(gIdx, vbs, (int32_t)hcMix, pIdx);
+        Add(gIdx, gIdx, vc, pIdx);
+        Muls(sIdx, vbs, (int32_t)combLen, pIdx);
+        Add(sIdx, sIdx, vc, pIdx);
+        DataCopyGather(base0, hcBaseAddr + 0 * R, (RegTensor<uint32_t> &)vc, pIdx);
+        DataCopyGather(base1, hcBaseAddr + 1 * R, (RegTensor<uint32_t> &)vc, pIdx);
+        DataCopyGather(base2, hcBaseAddr + 2 * R, (RegTensor<uint32_t> &)vc, pIdx);
+        DataCopyGather(base3, hcBaseAddr + 3 * R, (RegTensor<uint32_t> &)vc, pIdx);
+
+        uint32_t act = (uint32_t)dim0 * R;
+        for (uint16_t cIdx = 0; cIdx < nChunks; cIdx++) {
+            uint16_t i = cIdx * pack;
+            MaskReg preg = UpdateMask<float>(act);
+            mBase = mixAddr + (uint32_t)i * hcMix;
+            oBase = combOutAddr + (uint32_t)i * combLen;
+
+            DataCopyGather(mix0, mBase + 0 * R, (RegTensor<uint32_t> &)gIdx, preg);
+            DataCopyGather(mix1, mBase + 1 * R, (RegTensor<uint32_t> &)gIdx, preg);
+            DataCopyGather(mix2, mBase + 2 * R, (RegTensor<uint32_t> &)gIdx, preg);
+            DataCopyGather(mix3, mBase + 3 * R, (RegTensor<uint32_t> &)gIdx, preg);
+            Muls(mix0, mix0, scale, preg); Add(mix0, mix0, base0, preg);
+            Muls(mix1, mix1, scale, preg); Add(mix1, mix1, base1, preg);
+            Muls(mix2, mix2, scale, preg); Add(mix2, mix2, base2, preg);
+            Muls(mix3, mix3, scale, preg); Add(mix3, mix3, base3, preg);
+
+            SoftmaxRowBcastInplace(mix0, red, t0, t1, t2, t3, eps, preg);
+            SoftmaxRowBcastInplace(mix1, red, t0, t1, t2, t3, eps, preg);
+            SoftmaxRowBcastInplace(mix2, red, t0, t1, t2, t3, eps, preg);
+            SoftmaxRowBcastInplace(mix3, red, t0, t1, t2, t3, eps, preg);
+
+            Add(csum, mix0, mix1, preg); Add(csum, csum, mix2, preg); Add(csum, csum, mix3, preg);
+            Adds(csum, csum, eps, preg);
+            Div(mix0, mix0, csum, preg); Div(mix1, mix1, csum, preg);
+            Div(mix2, mix2, csum, preg); Div(mix3, mix3, csum, preg);
+
+            for (uint16_t j = 0; j < iters; j++) {
+                Duplicate(csum, static_cast<float>(0), preg);
+                RowNormAccum(mix0, red, csum, t0, t1, t2, t3, eps, preg);
+                RowNormAccum(mix1, red, csum, t0, t1, t2, t3, eps, preg);
+                RowNormAccum(mix2, red, csum, t0, t1, t2, t3, eps, preg);
+                RowNormAccum(mix3, red, csum, t0, t1, t2, t3, eps, preg);
+                Adds(csum, csum, eps, preg);
+                Div(mix0, mix0, csum, preg); Div(mix1, mix1, csum, preg);
+                Div(mix2, mix2, csum, preg); Div(mix3, mix3, csum, preg);
+            }
+            DataCopyScatter(oBase + 0 * R, mix0, (RegTensor<uint32_t> &)sIdx, preg);
+            DataCopyScatter(oBase + 1 * R, mix1, (RegTensor<uint32_t> &)sIdx, preg);
+            DataCopyScatter(oBase + 2 * R, mix2, (RegTensor<uint32_t> &)sIdx, preg);
+            DataCopyScatter(oBase + 3 * R, mix3, (RegTensor<uint32_t> &)sIdx, preg);
+        }
+    }
+}
+
+
 template <typename T>
 __aicore__ inline void VFProcessY(const LocalTensor<T> &yLocal, const LocalTensor<float> &mixLocal,
                                   const LocalTensor<T> &xLocal, uint16_t bs, uint16_t hcMult, uint16_t d, uint16_t hcMix)

--- a/csrc/moe/hc_pre/op_kernel/hc_pre_cube_compute.h
+++ b/csrc/moe/hc_pre/op_kernel/hc_pre_cube_compute.h
@@ -247,7 +247,7 @@ __aicore__ inline void HC_PRE_CUBE_COMPUTE_TEMPLATE_CLASS::Fixp(const AscendC::G
         mmParams.curML1,
         mmParams.curNL1,
         true,
-        mmParams.nOutSize);  // m,n 512B aligned
+        mmParams.nOutSize);  // ND M/N are 512B aligned.
 }
 
 HC_PRE_CUBE_COMPUTE_TEMPLATE_PARAM

--- a/csrc/moe/hc_pre/op_kernel/hc_pre_m_k_split_core_arch35.h
+++ b/csrc/moe/hc_pre/op_kernel/hc_pre_m_k_split_core_arch35.h
@@ -283,8 +283,8 @@ public:
         pipe->InitBuffer(
             yQue, 2, tilingData->stage2RowFactor * RoundUp<T>(tilingData->dFactor) * sizeof(T));
         pipe->InitBuffer(postQue, 2, tilingData->stage2RowFactor * tilingData->hcMultAlign * sizeof(float));
-        pipe->InitBuffer(
-            combFragQue, 2, tilingData->stage2RowFactor * tilingData->hcMult * tilingData->hcMultAlign * sizeof(float));
+        pipe->InitBuffer(combFragQue, DOUBLE_BUFFER,
+            tilingData->stage2RowFactor * tilingData->hcMult * tilingData->hcMult * sizeof(float));
 
         // TBuf
         pipe->InitBuffer(hcBaseBuf0, tilingData->hcMultAlign * sizeof(float));
@@ -314,7 +314,7 @@ public:
 
             CopyIn(hcBaseGm, hcBase0Local, 1, tilingData->hcMult);
             CopyIn(hcBaseGm[tilingData->hcMult], hcBase1Local, 1, tilingData->hcMult);
-            CopyIn(hcBaseGm[tilingData->hcMult * 2], hcBase2Local, tilingData->hcMult, tilingData->hcMult);
+            CopyIn(hcBaseGm[tilingData->hcMult * 2], hcBase2Local, 1, tilingData->hcMult * tilingData->hcMult);
             event_t eventId = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE2_V));
             SetFlag<HardEvent::MTE2_V>(eventId);
             WaitFlag<HardEvent::MTE2_V>(eventId);
@@ -372,14 +372,17 @@ public:
 
                 // combFrag
                 combFragLocal = combFragQue.AllocTensor<float>();
-                VFProcessCombFragRLessVLUseFourUnfold(
+                VFProcessCombFragPacked(
                     combFragLocal, mixesLocal[tilingData->hcMult * 2], hcBase2Local, hcScaleGm.GetValue(2), tilingData->hcEps,
-                    tilingData->iterTimes - 1, curRowFactor, tilingData->hcMult, tilingData->hcMult, tilingData->hcMix);
+                    tilingData->iterTimes - 1, curRowFactor, tilingData->hcMult, tilingData->hcMix);
                 rmsAndmmQue.FreeTensor(rmsAndmmLocal);
 
                 combFragQue.EnQue(combFragLocal);
                 combFragLocal = combFragQue.DeQue<float>();
-                CopyOut(combFragLocal, combFragGm[curBlockIdx * tilingData->rowOfFormerBlock * tilingData->hcMult * tilingData->hcMult + rowOuterIdx * tilingData->stage2RowFactor * tilingData->hcMult * tilingData->hcMult], curRowFactor * tilingData->hcMult, tilingData->hcMult);
+                int64_t combLen = tilingData->hcMult * tilingData->hcMult;
+                int64_t combOutOffset = (curBlockIdx * tilingData->rowOfFormerBlock +
+                                         rowOuterIdx * tilingData->stage2RowFactor) * combLen;
+                CopyOut(combFragLocal, combFragGm[combOutOffset], curRowFactor, combLen);
                 combFragQue.FreeTensor(combFragLocal);
             }
         }
@@ -420,9 +423,6 @@ private:
     LocalTensor<float> hcBase1Local;
     LocalTensor<float> hcBase2Local;
 };
-
-
-
 } // namespace HCPreSinkhorn
 
 #endif

--- a/csrc/moe/hc_pre/op_kernel/hc_pre_m_split_core_arch35.h
+++ b/csrc/moe/hc_pre/op_kernel/hc_pre_m_split_core_arch35.h
@@ -87,7 +87,7 @@ public:
         if ASCEND_IS_AIV {
           CopyIn(hcBaseGm, hcBase0Local, 1, tilingData->hcMult);
           CopyIn(hcBaseGm[tilingData->hcMult], hcBase1Local, 1, tilingData->hcMult);
-          CopyIn(hcBaseGm[tilingData->hcMult * 2], hcBase2Local, tilingData->hcMult, tilingData->hcMult);
+          CopyIn(hcBaseGm[tilingData->hcMult * 2], hcBase2Local, 1, tilingData->hcMult * tilingData->hcMult);
           event_t eventId = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE2_V));
           SetFlag<HardEvent::MTE2_V>(eventId);
           WaitFlag<HardEvent::MTE2_V>(eventId);
@@ -153,8 +153,7 @@ public:
                 rmsNormLocal = rmsNormBuf.Get<float>();
                 WaitFlag<HardEvent::MTE3_MTE2>(static_cast<event_t>(0));
                 if (GetBlockIdx() % 2 != 0) {
-                    xSplitOffset = (mL1RealSize / 2) * tilingData->hcMult * tilingData->d;
-                    // sinkhorn阶段计算时，偶数Vector核多处理一行，x的split offset和matmul阶段不同
+                    xSplitOffset = CeilDiv(mL1RealSize, 2) * tilingData->hcMult * tilingData->d;
                     xOutSplitOffset = CeilDiv(mL1RealSize, 2) * tilingData->hcMult * tilingData->d;
                     ySplitOffset = CeilDiv(mL1RealSize, 2) * tilingData->d;
                     postSplitOffset = CeilDiv(mL1RealSize, 2) * tilingData->hcMult;
@@ -190,7 +189,10 @@ public:
                     CrossCoreSetFlag<SYNC_MODE4, PIPE_MTE1>(SYNC_AIC_AIV_FLAG + FLAG_ID_MAX);
                 } else {
                     CrossCoreWaitFlag<SYNC_MODE4, PIPE_MTE3>(SYNC_AIC_AIV_FLAG);
-                    int64_t rowFactor = mL1RealSize / 2;
+                    // Even cores take the first half with CeilDiv, and odd cores take the second half.
+                    // This must match the Sinkhorn/output row split; otherwise odd mL1RealSize shifts the
+                    // second half by one row.
+                    int64_t rowFactor = CeilDiv(mL1RealSize, 2);
                     int64_t tailRowFactor = mL1RealSize - rowFactor;
                     int64_t curRowFactor = rowFactor;
                     int64_t mL1SizeAlign = CeilAlign(mL1RealSize, AscendC::BLOCK_CUBE);
@@ -251,8 +253,8 @@ public:
                 tbufPool1.InitBuffer(
                     yQue, 2, tilingData->rowInnerFactor * RoundUp<T>(tilingData->dFactor) * sizeof(T));
                 tbufPool1.InitBuffer(postQue, 2, tilingData->rowInnerFactor * tilingData->hcMultAlign * sizeof(float));
-                tbufPool1.InitBuffer(
-                    combFragQue, 2, tilingData->rowInnerFactor * tilingData->hcMult * tilingData->hcMultAlign * sizeof(float));
+                tbufPool1.InitBuffer(combFragQue, DOUBLE_BUFFER,
+                    tilingData->rowInnerFactor * tilingData->hcMult * tilingData->hcMult * sizeof(float));
 
                 // TBuf
                 tbufPool1.InitBuffer(mixesBuf, tilingData->rowInnerFactor * RoundUp<float>(tilingData->hcMix) * sizeof(float));
@@ -311,14 +313,14 @@ public:
 
                     // combFrag
                     combFragLocal = combFragQue.AllocTensor<float>();
-                    VFProcessCombFragRLessVLUseFourUnfold(
+                    VFProcessCombFragPacked(
                         combFragLocal, mixesLocal[tilingData->hcMult * 2], hcBase2Local, hcScaleGm.GetValue(2), tilingData->hcEps,
-                        tilingData->iterTimes - 1, currentInnerRowFactor, tilingData->hcMult, tilingData->hcMult, tilingData->hcMix);
+                        tilingData->iterTimes - 1, currentInnerRowFactor, tilingData->hcMult, tilingData->hcMix);
 
                     combFragQue.EnQue(combFragLocal);
                     combFragLocal = combFragQue.DeQue<float>();
                     CopyOut(combFragLocal, combFragGm[combFragGmBaseOffset + combFragSplitOffset + roundIdx * tilingData->mL1Size * tilingData->hcMult * tilingData->hcMult + innerRowIdx * tilingData->hcMult * tilingData->hcMult],
-                            currentInnerRowFactor * tilingData->hcMult, tilingData->hcMult);
+                            currentInnerRowFactor, tilingData->hcMult * tilingData->hcMult);
                     combFragQue.FreeTensor(combFragLocal);
                 }
                 SetFlag<HardEvent::MTE3_MTE2>(static_cast<event_t>(0));

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -1324,9 +1324,6 @@ constexpr int64_t HC_PRE_HC_LIMIT = 4;
 constexpr int64_t HC_PRE_D_LIMIT = 4096;
 constexpr int64_t HC_PRE_D_LIMIT_EXTEND = 7168;
 constexpr int64_t HC_PRE_MIX_HC_LIMIT = 24;
-constexpr int64_t HC_PRE_FUSION_BASE_BS = 8192;
-constexpr int64_t HC_PRE_FUSION_SPLIT_K_MAX_BS = 512;
-constexpr const char* ASCEND_950_PREFIX = "Ascend950";
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor> construct_hc_pre_output_tensor(const at::Tensor& x, int64_t hc_mult)
 {
@@ -1412,29 +1409,6 @@ void check_hc_pre_shape_and_dtype(
     TORCH_CHECK(hc_base.dtype() == at::kFloat, "hc_base's dtype should be FLOAT32.");
 }
 
-int64_t get_hc_pre_batch_size(const at::Tensor& x)
-{
-    if (x.dim() == 4) {
-        return x.size(0) * x.size(1);
-    }
-    return x.size(0);
-}
-
-bool is_ascend950()
-{
-    static const char* soc_name = aclrtGetSocName();
-    return soc_name != nullptr && std::string(soc_name).find(ASCEND_950_PREFIX) == 0;
-}
-
-bool should_use_hc_pre_fusion(const at::Tensor& x)
-{
-    if (!is_ascend950()) {
-        return true;
-    }
-    auto bs = get_hc_pre_batch_size(x);
-    return bs <= HC_PRE_FUSION_SPLIT_K_MAX_BS || bs % HC_PRE_FUSION_BASE_BS == 0;
-}
-
 std::tuple<at::Tensor, at::Tensor, at::Tensor> run_hc_pre_composite(
     const at::Tensor& x, const at::Tensor& hc_fn, const at::Tensor& hc_scale, const at::Tensor& hc_base,
     int64_t hc_mult, int64_t hc_sinkhorn_iters, double norm_eps, double hc_eps)
@@ -1489,9 +1463,6 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_hc_pre_v2_npu(
     int64_t hc_mult, int64_t hc_sinkhorn_iters, double norm_eps, double hc_eps)
 {
     check_hc_pre_shape_and_dtype(x, hc_fn, hc_scale, hc_base, hc_mult);
-    if (!should_use_hc_pre_fusion(x)) {
-        return run_hc_pre_composite(x, hc_fn, hc_scale, hc_base, hc_mult, hc_sinkhorn_iters, norm_eps, hc_eps);
-    }
     return run_hc_pre_fusion(x, hc_fn, hc_scale, hc_base, hc_mult, hc_sinkhorn_iters, norm_eps, hc_eps);
 }
 

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_npu_hc_pre.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_npu_hc_pre.py
@@ -9,7 +9,9 @@ torch_npu.npu.config.allow_internal_format = True
 enable_custom_op()
 
 HC_MULT = 4
-HIDDEN_SIZE = 4096
+DSV4_FLASH_HIDDEN_SIZE = 4096
+HIDDEN_SIZE = DSV4_FLASH_HIDDEN_SIZE
+EXTENDED_HIDDEN_SIZE = 7168
 MIX_HC = 24
 HC_SINKHORN_ITERS = 20
 NORM_EPS = 1e-6
@@ -18,11 +20,12 @@ HC_EPS = 1e-6
 
 def _make_hc_pre_inputs(shape: tuple[int, ...]):
     torch.manual_seed(1024)
+    hidden_size = shape[-1]
     x = torch.randn(shape, dtype=torch.bfloat16, device="npu")
     hc_fn = (
         torch.randn(
             MIX_HC,
-            HC_MULT * HIDDEN_SIZE,
+            HC_MULT * hidden_size,
             dtype=torch.float32,
             device="npu",
         )
@@ -60,6 +63,22 @@ def test_npu_hc_pre_v1_v2_bf16_3d_input():
 @torch.inference_mode()
 def test_npu_hc_pre_v1_v2_bf16_4d_input():
     _compare_hc_pre_outputs((1, 2, HC_MULT, HIDDEN_SIZE))
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+@torch.inference_mode()
+def test_npu_hc_pre_v1_v2_bf16_dsv4_flash_hidden_size():
+    _compare_hc_pre_outputs((4, HC_MULT, DSV4_FLASH_HIDDEN_SIZE))
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+@torch.inference_mode()
+def test_npu_hc_pre_v1_v2_bf16_extended_hidden_size():
+    _compare_hc_pre_outputs((2, HC_MULT, EXTENDED_HIDDEN_SIZE))
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -961,7 +961,7 @@ class DeepseekV2DecoderLayer(nn.Module):
         self.hc_ffn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
 
     def hc_pre(self, x: torch.Tensor, hc_fn: torch.Tensor, hc_scale: torch.Tensor, hc_base: torch.Tensor):
-        y = torch.ops._C_ascend.npu_hc_pre(
+        y = torch.ops._C_ascend.npu_hc_pre_v2(
             x, hc_fn, hc_scale, hc_base, self.hc_mult, self.hc_sinkhorn_iters, self.norm_eps, self.hc_eps
         )
         return y


### PR DESCRIPTION
### What this PR does / why we need it?
- Sync the HcPre arch35 fused implementation with the latest cann-recipes-infer source, including packed combFrag handling, odd-row M split alignment, and tiling size accounting.
- Route DeepSeek V4 HcPre calls through npu_hc_pre_v2.
- Make npu_hc_pre_v2 call the fused aclnnHcPre path directly instead of falling back to the composite path for Ascend950 batch-size cases.
- Add operator precision coverage for the DeepSeek V4 flash hidden size 4096 and the supported 7168 hidden size.

### Does this PR introduce _any_ user-facing change?
Yes. DeepSeek V4 HcPre now uses the v2 fused HcPre path directly. The Python/custom-op API surface is unchanged.

### How was this patch tested?
- python -m py_compile vllm_ascend/models/deepseek_v4.py tests/e2e/nightly/single_node/ops/singlecard_ops/test_npu_hc_pre.py
- git diff --check
- diff -q -w against cann-recipes-infer for the synced HcPre arch35 source files

Not run locally:
- pre-commit / ruff: not installed in this local Python environment.
- NPU e2e operator tests: local environment does not have torch/torch_npu or NPU runtime.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
