### PR TITLE
[BugFix] Set reshape_cache_event on per-layer attn_metadata for MLA in mooncake connector

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -792,7 +792,12 @@ class MooncakeLayerwiseConnector(KVConnectorBase_V1, SupportsHMA):
             return
         reshape_cache_event = torch.npu.Event()
         reshape_cache_event.record()
-        attn_metadata.reshape_cache_event = reshape_cache_event
+        if isinstance(attn_metadata, dict):
+            per_layer = attn_metadata.get(layer_name)
+            if per_layer is not None:
+                per_layer.reshape_cache_event = reshape_cache_event
+        else:
+            attn_metadata.reshape_cache_event = reshape_cache_event
 
     def wait_for_save(self):
         """MooncakeLayerwiseConnector does not save explicitly."""


### PR DESCRIPTION
For MLA models attn_metadata is a dict keyed by layer_name, so the write landed on the dict itself and never matched what save_kv_layer reads back (attn_metadata[layer_name].reshape_cache_event). Branch on use_mla to pick the write location, mirroring the existing logic in save_kv_layer.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
