### PR TITLE
[Feature] feat: add multimodal model parameter name mapping to RLHF examples

### DIFF
--- a/examples/rl/rlhf_http_hccl.py
+++ b/examples/rl/rlhf_http_hccl.py
@@ -36,7 +36,7 @@ The example performs the following steps:
 import requests
 import torch
 from openai import OpenAI
-from transformers import AutoModelForCausalLM
+from transformers import AutoConfig, AutoModelForCausalLM
 from vllm.utils.network_utils import get_ip, get_open_port
 
 from vllm_ascend.distributed.weight_transfer.hccl_engine import (
@@ -164,6 +164,18 @@ def main():
     train_model = AutoModelForCausalLM.from_pretrained(MODEL_NAME, dtype=torch.bfloat16)
     train_model.to(device)
 
+    # Detect multimodal models (e.g., Qwen2-VL, InternVL) that wrap the
+    # language model under a ``language_model`` submodule. vLLM uses bare
+    # parameter names without the prefix, so mapping is required for
+    # weight transfer to succeed.
+    config = AutoConfig.from_pretrained(MODEL_NAME, trust_remote_code=True)
+    is_multimodel = hasattr(config, "vision_config")
+
+    def mapped_params():
+        for name, param in train_model.named_parameters():
+            vllm_name = "language_model." + name if is_multimodel else name
+            yield vllm_name, param
+
     # Create OpenAI client pointing to the vLLM server
     client = OpenAI(
         base_url=f"{BASE_URL}/v1",
@@ -230,7 +242,7 @@ def main():
     dtype_names = []
     shapes = []
     max_tensor_bytes = 0
-    for name, p in train_model.named_parameters():
+    for name, p in mapped_params():
         names.append(name)
         dtype_names.append(str(p.dtype).split(".")[-1])
         shapes.append(list(p.shape))
@@ -262,7 +274,7 @@ def main():
         packed_buffer_size_bytes=packed_buffer_size_bytes,
     )
     HCCLWeightTransferEngine.trainer_send_weights(
-        iterator=train_model.named_parameters(),
+        iterator=mapped_params(),
         trainer_args=trainer_args,
     )
 

--- a/examples/rl/rlhf_http_npu_ipc.py
+++ b/examples/rl/rlhf_http_npu_ipc.py
@@ -39,7 +39,7 @@ import os
 import requests
 import torch
 from openai import OpenAI
-from transformers import AutoModelForCausalLM
+from transformers import AutoConfig, AutoModelForCausalLM
 
 from vllm_ascend.distributed.weight_transfer.npu_ipc_engine import (
     NPUIPCTrainerSendWeightsArgs,
@@ -129,6 +129,18 @@ def main():
     train_model.to(device)
     train_model.eval()
 
+    # Detect multimodal models (e.g., Qwen2-VL, InternVL) that wrap the
+    # language model under a ``language_model`` submodule. vLLM uses bare
+    # parameter names without the prefix, so mapping is required for
+    # weight transfer to succeed.
+    config = AutoConfig.from_pretrained(MODEL_NAME, trust_remote_code=True)
+    is_multimodel = hasattr(config, "vision_config")
+
+    def mapped_params():
+        for name, param in train_model.named_parameters():
+            vllm_name = "language_model." + name if is_multimodel else name
+            yield vllm_name, param
+
     # Create OpenAI client pointing to the vLLM server
     client = OpenAI(
         base_url=f"{BASE_URL}/v1",
@@ -169,7 +181,7 @@ def main():
     print("Broadcasting weights via NPU IPC (HTTP)...")
     trainer_args = NPUIPCTrainerSendWeightsArgs(send_mode="http", url=BASE_URL)
     NPUIPCWeightTransferEngine.trainer_send_weights(
-        iterator=train_model.named_parameters(),
+        iterator=mapped_params(),
         trainer_args=trainer_args,
     )
 


### PR DESCRIPTION
For multimodal models (e.g., Qwen2-VL, Qwen3.5, InternVL), the training model wraps the language model under a language_model submodule, while vLLM uses bare parameter names.
Add detection via vision_config and a mapped_params() generator to prefix parameter names with 'language_model.' when needed.

### What this PR does / why we need it?

Add multimodal model parameter name mapping to RLHF weight transfer examples. For multimodal models, the training model loaded by AutoModelForCausalLM wraps the language model
under a language_model submodule, but vLLM uses bare parameter names. Without this mapping, weight transfer fails silently. This PR adds vision_config detection and a
mapped_params() generator to fix the parameter name mismatch.

### Does this PR introduce _any_ user-facing change?

No. This is an example-only change that does not affect the vLLM API or runtime behavior.

### How was this patch tested?

Tested manually with Qwen3.5 on NPU hardware. The training model's named_parameters() correctly maps to vLLM parameter names after applying the language_model. prefix, and
weight transfer via HCCL and NPU IPC both succeed.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
