### PR TITLE
[BugFix][WeightTransfer] Fix NPU IPC engine init and align IPC handle with upstream

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -236,6 +236,7 @@
   source_file_dependencies:
     - vllm_ascend/distributed/weight_transfer
   tests:
+    - tests/e2e/pull_request/one_card/test_npu_ipc_weight_transfer.py
     - tests/e2e/pull_request/two_card/test_hccl_weight_transfer.py
 
 # KV Offload
@@ -696,6 +697,7 @@ estimated_times:
   tests/e2e/pull_request/one_card/test_minicpm.py: 220
   tests/e2e/pull_request/one_card/test_multi_instance.py: 140
   tests/e2e/pull_request/one_card/test_multistream_overlap_shared_expert.py: 270
+  tests/e2e/pull_request/one_card/test_npu_ipc_weight_transfer.py: 120
   tests/e2e/pull_request/one_card/test_qwen3_0_6b.py: 190
   tests/e2e/pull_request/one_card/test_qwen3_5_0_8b.py: 370
   tests/e2e/pull_request/one_card/test_qwen3_8b_w8a8.py: 280

--- a/tests/e2e/pull_request/one_card/test_npu_ipc_weight_transfer.py
+++ b/tests/e2e/pull_request/one_card/test_npu_ipc_weight_transfer.py
@@ -1,0 +1,176 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""End-to-end test for the NPU IPC weight transfer engine.
+
+Unlike the HCCL engine, NPU IPC requires the trainer and the inference worker
+to be co-located on the *same* physical NPU chip, so only a single NPU is
+needed. The trainer model is built from the architecture config with random
+weights (download-free); set ``WEIGHT_TRANSFER_TEST_MODEL=/path/to/checkpoint``
+to share real weights instead. See ``examples/rl/rlhf_http_npu_ipc.py`` for the
+end-user workflow.
+"""
+
+import os
+
+import pytest
+import requests
+import torch
+import torch_npu  # noqa: F401  # registers the NPU backend
+from transformers import AutoConfig, AutoModelForCausalLM
+
+from tests.e2e.conftest import RemoteOpenAIServer
+
+MODEL_NAME = "Qwen/Qwen3-0.6B"
+
+INFERENCE_DEVICE_INDEX = 0
+
+PROMPTS = [
+    "Hello, my name is",
+    "The capital of France is",
+]
+
+UPDATE_TIMEOUT = 300
+CONTROL_TIMEOUT = 60
+
+
+def _build_trainer_model(device_index: int):
+    device = f"npu:{device_index}"
+    override_path = os.getenv("WEIGHT_TRANSFER_TEST_MODEL")
+    if override_path:
+        model = AutoModelForCausalLM.from_pretrained(override_path, dtype=torch.bfloat16)
+    else:
+        config = AutoConfig.from_pretrained(MODEL_NAME, trust_remote_code=True)
+        model = AutoModelForCausalLM.from_config(config)
+    model = model.to(device=device, dtype=torch.bfloat16)
+    model.eval()
+    return model
+
+
+def _post(server: RemoteOpenAIServer, route: str, *, json=None, timeout=CONTROL_TIMEOUT):
+    response = requests.post(server.url_for(route), json=json, timeout=timeout)
+    response.raise_for_status()
+    return response
+
+
+def _generate(client, model, prompts):
+    completions = []
+    for prompt in prompts:
+        response = client.completions.create(model=model, prompt=prompt, max_tokens=16, temperature=0)
+        completions.append(response.choices[0].text)
+    return completions
+
+
+def _has_lifecycle_endpoints(server: RemoteOpenAIServer) -> bool:
+    """Probe ``/start_weight_update``; also performs the actual call when present."""
+    try:
+        response = requests.post(
+            server.url_for("start_weight_update"),
+            json={"is_checkpoint_format": True},
+            timeout=CONTROL_TIMEOUT,
+        )
+    except requests.RequestException:
+        return False
+    if response.status_code == 404:
+        return False
+    response.raise_for_status()
+    return True
+
+
+@pytest.mark.skipif(
+    torch.npu.device_count() < 1,
+    reason="NPU IPC weight transfer e2e test requires at least 1 NPU.",
+)
+def test_npu_ipc_weight_transfer_updates_server_weights():
+    from vllm.utils.network_utils import get_open_port
+
+    port = get_open_port()
+    server_args = [
+        "--enforce-eager",
+        "--load-format",
+        "dummy",
+        "--weight-transfer-config",
+        '{"backend": "ipc"}',
+        "--max-model-len",
+        "1024",
+        # IPC co-locates the trainer on the same NPU, so leave room for it.
+        "--gpu-memory-utilization",
+        "0.5",
+        "--port",
+        str(port),
+        "--trust-remote-code",
+    ]
+    # VLLM_SERVER_DEV_MODE registers the dev endpoints; insecure serialization
+    # lets the server unpickle the IPC handles sent over HTTP. Pin the server to
+    # physical NPU 0 so its IPC UUID matches the trainer below.
+    env_dict = {
+        "VLLM_SERVER_DEV_MODE": "1",
+        "VLLM_ALLOW_INSECURE_SERIALIZATION": "1",
+        "ASCEND_RT_VISIBLE_DEVICES": str(INFERENCE_DEVICE_INDEX),
+        "VLLM_ASCEND_ENABLE_NZ": "0",
+    }
+
+    with RemoteOpenAIServer(
+        MODEL_NAME,
+        vllm_serve_args=server_args,
+        server_host="127.0.0.1",
+        server_port=port,
+        env_dict=env_dict,
+        auto_port=False,
+    ) as server:
+        client = server.get_client()
+
+        outputs_before = _generate(client, MODEL_NAME, PROMPTS)
+
+        # Trainer shares physical NPU 0 with the server. It leaves
+        # ASCEND_RT_VISIBLE_DEVICES unset (identity mapping logical 0 ->
+        # physical 0) so both processes resolve to the same IPC UUID.
+        torch.npu.set_device(INFERENCE_DEVICE_INDEX)
+        train_model = _build_trainer_model(INFERENCE_DEVICE_INDEX)
+        os.environ["VLLM_ALLOW_INSECURE_SERIALIZATION"] = "1"
+
+        from vllm_ascend.distributed.weight_transfer.npu_ipc_engine import (
+            NPUIPCTrainerSendWeightsArgs,
+            NPUIPCWeightTransferEngine,
+        )
+
+        _post(server, "init_weight_transfer_engine", json={"init_info": {}})
+
+        _post(server, "pause")
+        # The probe performs /start_weight_update when present, so it must not
+        # be called again below. Older vLLM without the lifecycle endpoints is
+        # out of scope for this IPC test.
+        if not _has_lifecycle_endpoints(server):
+            _post(server, "resume")
+            pytest.skip("vLLM build lacks the /start_weight_update lifecycle endpoints required by NPU IPC.")
+
+        # trainer_send_weights POSTs to /update_weights itself; the server
+        # rebuilds tensors locally and loads them before the POST returns (no
+        # collective back to the trainer, so no background thread is needed).
+        # train_model stays referenced so the shared NPU storage outlives it.
+        trainer_args = NPUIPCTrainerSendWeightsArgs(send_mode="http", url=server.url_root)
+        NPUIPCWeightTransferEngine.trainer_send_weights(
+            iterator=train_model.named_parameters(),
+            trainer_args=trainer_args,
+        )
+
+        _post(server, "finish_weight_update")
+        _post(server, "resume")
+
+        outputs_after = _generate(client, MODEL_NAME, PROMPTS)
+
+    assert outputs_after != outputs_before, "server weights did not change after NPU IPC transfer"

--- a/tests/ut/distributed/weight_transfer/test_npu_ipc_engine.py
+++ b/tests/ut/distributed/weight_transfer/test_npu_ipc_engine.py
@@ -1,0 +1,159 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Regression tests for the NPU IPC weight transfer engine.
+
+These cover two bugs that broke ``examples/rl/rlhf_http_npu_ipc.py``:
+
+1. ``NPUIPCWeightTransferEngine.__init__`` did not accept the ``model``
+   argument that ``WeightTransferEngineFactory.create_engine`` passes,
+   raising ``TypeError: __init__() takes 3 positional arguments but 4
+   were given`` at engine construction.
+2. ``receive_weights`` / ``packed_npu_ipc_consumer`` unpacked the stored
+   IPC handle as ``func, args`` even though the producer stored only the
+   ``reduce_tensor`` *args*, raising ``ValueError: too many values to
+   unpack (expected 2)``. Aligned with upstream vLLM's CUDA IPC engine:
+   the producer stores args only and the consumer rebuilds with the
+   well-known ``rebuild_npu_tensor``.
+"""
+
+import inspect
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from vllm_ascend.distributed.weight_transfer import npu_ipc_engine
+from vllm_ascend.distributed.weight_transfer.npu_ipc_engine import (
+    NPUIPCWeightTransferEngine,
+)
+
+_MODULE = "vllm_ascend.distributed.weight_transfer.npu_ipc_engine"
+
+
+def _patch_rebuild_npu_tensor(rebuild_func):
+    """Install a fake ``torch_npu.multiprocessing.reductions`` module.
+
+    The engine imports ``rebuild_npu_tensor`` lazily from ``torch_npu``,
+    which is only a stub on CPU CI runners, so provide a fake submodule.
+    """
+    fake_mod = types.ModuleType("torch_npu.multiprocessing.reductions")
+    fake_mod.rebuild_npu_tensor = rebuild_func  # type: ignore[attr-defined]
+    return patch.dict(
+        sys.modules,
+        {
+            "torch_npu.multiprocessing": types.ModuleType("torch_npu.multiprocessing"),
+            "torch_npu.multiprocessing.reductions": fake_mod,
+        },
+    )
+
+
+def test_init_accepts_model_argument():
+    """Bug 1: __init__ must accept the optional ``model`` argument."""
+    params = inspect.signature(NPUIPCWeightTransferEngine.__init__).parameters
+    assert "model" in params
+
+
+def test_init_passes_model_to_super():
+    """Bug 1: the ``model`` argument must be forwarded to the base engine."""
+    captured = {}
+
+    def fake_init(self, config, parallel_config, model=None):
+        captured["args"] = (config, parallel_config, model)
+
+    with patch.object(npu_ipc_engine.WeightTransferEngine, "__init__", fake_init):
+        NPUIPCWeightTransferEngine("config", "parallel_config", "model")
+
+    assert captured["args"] == ("config", "parallel_config", "model")
+
+
+def test_unpacked_send_stores_reduce_tensor_args_only():
+    """Bug 2 (producer): the handle stores only the ``reduce_tensor`` args.
+
+    This matches upstream vLLM's CUDA IPC engine, which drops the rebuild
+    func and relies on the consumer using the well-known rebuild function.
+    """
+    npu_uuid = "node-0"
+
+    rebuild_args = (None, None, None, None, None, None, 999, None)
+    fake_reduce = MagicMock(return_value=("rebuild_func_sentinel", rebuild_args))
+
+    captured = {}
+
+    def send_mode(update_info):
+        captured["update_info"] = update_info
+
+    trainer_args = MagicMock()
+    trainer_args.send_mode = send_mode
+    trainer_args.packed = False
+
+    iterator = iter([("model.weight", torch.zeros(3))])
+
+    with patch(f"{_MODULE}.reduce_tensor", fake_reduce):
+        NPUIPCWeightTransferEngine._send_unpacked(iterator, trainer_args, npu_uuid)
+
+    update_info = captured["update_info"]
+    assert isinstance(update_info.ipc_handles, list)
+    stored = update_info.ipc_handles[0][npu_uuid]
+    # Only the args tuple is stored, not a (func, args) pair.
+    assert stored == rebuild_args
+
+
+def test_receive_weights_rebuilds_with_rebuild_npu_tensor():
+    """Bug 2 (consumer): receive_weights rebuilds via ``rebuild_npu_tensor``.
+
+    Verifies the args-only handle is consumed without unpacking errors and
+    that the receiver's device index is written into the rebuild args.
+    """
+    npu_uuid = "node-0"
+    device_index = 0
+
+    rebuilt_weight = torch.tensor([1.0, 2.0, 3.0])
+    seen = {}
+
+    def fake_rebuild(*args):
+        seen["args"] = args
+        return rebuilt_weight
+
+    # Sender stores 999 at index 6; the receiver must overwrite it.
+    rebuild_args = (None, None, None, None, None, None, 999, None)
+
+    update_info = NPUIPCWeightTransferEngine.update_info_cls(
+        names=["model.weight"],
+        dtype_names=["float32"],
+        shapes=[[3]],
+        ipc_handles=[{npu_uuid: rebuild_args}],
+        packed=False,
+    )
+
+    engine = object.__new__(NPUIPCWeightTransferEngine)
+    received = {}
+
+    def load_weights(weights):
+        received["weights"] = weights
+
+    with (
+        _patch_rebuild_npu_tensor(fake_rebuild),
+        patch(f"{_MODULE}.npu_generate_uuid", return_value=npu_uuid),
+        patch("torch.accelerator.current_device_index", return_value=device_index),
+    ):
+        engine.receive_weights(update_info, load_weights)
+
+    assert received["weights"][0][0] == "model.weight"
+    assert torch.equal(received["weights"][0][1], rebuilt_weight)
+    # Index 6 (device index) overwritten with the receiver's device.
+    assert seen["args"][6] == device_index

--- a/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
+++ b/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
@@ -116,8 +116,13 @@ class NPUIPCWeightTransferEngine(WeightTransferEngine[NPUIPCWeightTransferInitIn
     init_info_cls = NPUIPCWeightTransferInitInfo
     update_info_cls = NPUIPCWeightTransferUpdateInfo
 
-    def __init__(self, config: WeightTransferConfig, parallel_config: ParallelConfig) -> None:
-        super().__init__(config, parallel_config)
+    def __init__(
+        self,
+        config: WeightTransferConfig,
+        parallel_config: ParallelConfig,
+        model: torch.nn.Module | None = None,
+    ) -> None:
+        super().__init__(config, parallel_config, model)
 
     def parse_update_info(self, update_dict: dict[str, Any]) -> NPUIPCWeightTransferUpdateInfo:
         """Parse update dict, deserializing pickled IPC handles if present.
@@ -177,6 +182,10 @@ class NPUIPCWeightTransferEngine(WeightTransferEngine[NPUIPCWeightTransferInitIn
             )
             load_weights(weights)
         else:
+            # Lazy import: ``rebuild_npu_tensor`` lives in ``torch_npu`` and
+            # must not be imported at module load time on non-NPU hosts.
+            from torch_npu.multiprocessing.reductions import rebuild_npu_tensor
+
             assert isinstance(update_info.ipc_handles, list)
             weights = []
             for name, ipc_handle in zip(
@@ -191,14 +200,14 @@ class NPUIPCWeightTransferEngine(WeightTransferEngine[NPUIPCWeightTransferInitIn
                         f"not co-located on the same physical NPU (node)."
                     )
 
-                func, args = ipc_handle[physical_npu_id]
+                args = ipc_handle[physical_npu_id]
                 list_args = list(args)
                 # Index 6 is the device_index parameter in torch's
                 # IPC handle tuple (rebuild_npu_tensor). Update it
                 # to the current device since the logical index can
                 # differ between sender and receiver.
                 list_args[6] = device_index
-                weight = func(*list_args)
+                weight = rebuild_npu_tensor(*list_args)
                 weights.append((name, weight))
 
             load_weights(weights)
@@ -306,6 +315,9 @@ class NPUIPCWeightTransferEngine(WeightTransferEngine[NPUIPCWeightTransferInitIn
 
             weight = tensor.detach().contiguous()
             weight_refs.append(weight)
+            # Store only the rebuild args (drop the func); the consumer rebuilds
+            # with the well-known ``rebuild_npu_tensor``, mirroring upstream's
+            # CUDA IPC engine.
             _, ipc_args = reduce_tensor(weight)
             ipc_handles.append({npu_uuid: ipc_args})
 

--- a/vllm_ascend/distributed/weight_transfer/packed_tensor.py
+++ b/vllm_ascend/distributed/weight_transfer/packed_tensor.py
@@ -218,6 +218,8 @@ def packed_npu_ipc_producer(
         buffer_size_bytes: Exact capacity of the reusable IPC buffer.
     """
     ipc_buffer = torch.empty(buffer_size_bytes, dtype=torch.uint8, device="npu")
+    # Store only the rebuild args (drop the func); the consumer rebuilds with
+    # the well-known ``rebuild_npu_tensor``, mirroring upstream's CUDA IPC engine.
     _, ipc_args = reduce_tensor(ipc_buffer)
 
     names: list[str] = []
@@ -283,8 +285,8 @@ def packed_npu_ipc_consumer(
     IPC buffer across chunks.
 
     Args:
-        ipc_handle: Mapping of NPU UUID to a (func, args) tuple from
-            ``reduce_tensor``.
+        ipc_handle: Mapping of NPU UUID to a ``rebuild_npu_tensor`` args tuple
+            from ``reduce_tensor``.
         physical_npu_id: Physical NPU UUID string for the current process.
         names: Parameter names in the packed buffer.
         shapes: Parameter shapes.
@@ -292,17 +294,21 @@ def packed_npu_ipc_consumer(
         tensor_sizes: Size in bytes of each parameter in the packed buffer.
         device_index: Local NPU device index.
     """
+    # Lazy import: ``rebuild_npu_tensor`` lives in ``torch_npu`` and must not be
+    # imported at module load time on non-NPU hosts.
+    from torch_npu.multiprocessing.reductions import rebuild_npu_tensor
+
     if physical_npu_id not in ipc_handle:
         raise ValueError(
             f"IPC handle not found for NPU UUID {physical_npu_id}. Available UUIDs: {list(ipc_handle.keys())}"
         )
 
-    func, args = ipc_handle[physical_npu_id]
+    args = ipc_handle[physical_npu_id]
     list_args = list(args)
     # Index 6 of the args from reduce_tensor is the device_index.
     # Overwrite it with the receiver's device index.
     list_args[6] = device_index
-    packed = func(*list_args)
+    packed = rebuild_npu_tensor(*list_args)
 
     content_size = sum(tensor_sizes)
     packed = packed[:content_size]


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes two bugs in the NPU IPC weight transfer engine that broke `examples/rl/rlhf_http_npu_ipc.py`, and aligns the IPC handle convention with upstream vLLM's CUDA IPC engine.

- **Engine init mismatch**: `NPUIPCWeightTransferEngine.__init__` did not accept the `model` argument that `WeightTransferEngineFactory.create_engine` passes, raising `TypeError: __init__() takes 3 positional arguments but 4 were given` during engine construction. The optional `model` parameter is now accepted and forwarded to the base engine, matching `HCCLWeightTransferEngine`.

- **IPC handle unpacking mismatch**: producers stored only the `reduce_tensor` *args* while consumers (`receive_weights` / `packed_npu_ipc_consumer`) unpacked the stored value as `func, args`, raising `ValueError: too many values to unpack (expected 2)` during `update_weights`. Aligned with upstream's CUDA IPC engine: producers store args only, and consumers rebuild the tensor with the well-known `torch_npu` `rebuild_npu_tensor` (lazily imported, mirroring upstream's inline `rebuild_cuda_tensor` import). This keeps the engine consistent with upstream so future syncs are trivial.

### Does this PR introduce _any_ user-facing change?

No. This is a bug fix to the existing NPU IPC weight transfer backend (`--weight-transfer-config '{"backend": "ipc"}'`); there is no API or interface change. The fix makes the documented `examples/rl/rlhf_http_npu_ipc.py` workflow work as intended.

### How was this patch tested?

- **Unit tests** (CPU, added): `tests/ut/distributed/weight_transfer/test_npu_ipc_engine.py` provides regression coverage for both bugs — that `__init__` accepts and forwards `model`, that the producer stores args-only, and that the consumer rebuilds via `rebuild_npu_tensor` (including the device-index overwrite).

  ```bash
  pytest -sv tests/ut/distributed/weight_transfer/test_npu_ipc_engine.py
  ```

- **End-to-end test** (1 NPU, added): `tests/e2e/pull_request/one_card/test_npu_ipc_weight_transfer.py` starts a vLLM server with dummy weights and the IPC backend, co-locates the trainer on the same physical NPU, runs the full HTTP control plane + NPU IPC data plane, and asserts the served model's outputs change after the weight update. It is registered in `.github/workflows/scripts/test_config.yaml` under the `weight_transfer` module so CI triggers it on `vllm_ascend/distributed/weight_transfer` changes.

  ```bash
  pytest -sv tests/e2e/pull_request/one_card/test_npu_ipc_weight_transfer.py
  ```

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
