### PR TITLE
[BugFix] Fix PP + MTP/spec decode for sync mode and HCCL dtype compat…

### DIFF
--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -1114,6 +1114,21 @@ class RecomputeScheduler(Scheduler):
                 engine_core_outputs[0] = eco = EngineCoreOutputs()
             eco.scheduler_stats = stats
 
+        # Surface draft token ids to the scheduler. update_from_output is
+        # fully overridden and does not call super(), so without this the
+        # spec decode chain would be silently lost.
+        # NOTE: minimal back-fill only — full parity with the upstream
+        # scheduler.update_from_output (prefill-chunk skip, grammar validate,
+        # num_spec_tokens_in_flight reset) is deferred until RCS + spec decode
+        # is actually exercised end-to-end.
+        spec_token_ids = getattr(model_runner_output, "spec_token_ids", None)
+        if spec_token_ids:
+            from vllm.v1.outputs import DraftTokenIds
+            self.update_draft_token_ids(DraftTokenIds(
+                req_ids=list(model_runner_output.req_id_to_index.keys()),
+                draft_token_ids=spec_token_ids,
+            ))
+
         return engine_core_outputs
 
 

--- a/vllm_ascend/core/scheduler_profiling_chunk.py
+++ b/vllm_ascend/core/scheduler_profiling_chunk.py
@@ -271,6 +271,14 @@ class ProfilingChunkScheduler(Scheduler):
             # <<< PROFILING CHUNK <<<
             request = self.running[req_index]
 
+            current_batch_size = (
+                len(scheduled_new_reqs)
+                + len(scheduled_resumed_reqs)
+                + len(scheduled_running_reqs)
+            )
+            if current_batch_size == self.max_num_per_batch:
+                break
+
             if (
                 request.num_output_placeholders > 0
                 and request.num_computed_tokens + 2 - request.num_output_placeholders
@@ -280,7 +288,10 @@ class ProfilingChunkScheduler(Scheduler):
                 continue
 
             num_new_tokens = (
-                request.num_tokens_with_spec + request.num_output_placeholders - request.num_computed_tokens
+                request.num_tokens_with_spec
+                + request.num_output_placeholders
+                + request.num_spec_tokens_in_flight
+                - request.num_computed_tokens
             )
             if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
                 num_new_tokens = self.scheduler_config.long_prefill_token_threshold
@@ -452,7 +463,13 @@ class ProfilingChunkScheduler(Scheduler):
             # >>> PROFILING CHUNK >>>
             while (self.waiting or self.skipped_waiting) and token_budget > 0 and time_budget > 0:
                 # <<< PROFILING CHUNK <<<
-                if len(self.running) == self.max_num_running_reqs:
+                current_batch_size = (
+                    len(scheduled_new_reqs)
+                    + len(scheduled_resumed_reqs)
+                    + len(scheduled_running_reqs)
+                )
+                if (len(self.running) == self.max_num_running_reqs
+                        or current_batch_size == self.max_num_per_batch):
                     break
 
                 request_queue = self._select_waiting_queue_for_scheduling()

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -416,34 +416,6 @@ class NPUPlatform(Platform):
                 f"({decode_context_parallel_size})."
             )
 
-    @staticmethod
-    def _is_mtp_speculative_config(speculative_config: Any | None) -> bool:
-        if speculative_config is None:
-            return False
-
-        method = getattr(speculative_config, "method", None)
-        return method is not None and "mtp" in str(method).lower()
-
-    @classmethod
-    def _validate_pd_pp_mtp_config(cls, vllm_config: VllmConfig) -> None:
-        speculative_config = getattr(vllm_config, "speculative_config", None)
-        if not cls._is_mtp_speculative_config(speculative_config):
-            return
-
-        parallel_config = vllm_config.parallel_config
-        if getattr(parallel_config, "pipeline_parallel_size", 1) <= 1:
-            return
-
-        kv_transfer_config = getattr(vllm_config, "kv_transfer_config", None)
-        if kv_transfer_config is not None and getattr(kv_transfer_config, "kv_role", None) == "kv_producer":
-            return
-
-        raise ValueError(
-            "PP+MTP is only supported on PD-disaggregated P nodes "
-            "(kv_role='kv_producer'). D nodes must use "
-            "pipeline_parallel_size=1 and may combine data parallelism with MTP."
-        )
-
     @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
         from vllm_ascend.quantization.utils import maybe_auto_detect_quantization
@@ -465,7 +437,6 @@ class NPUPlatform(Platform):
         cls._validate_layer_sharding_config(vllm_config)
         cls._validate_draft_decode_context_parallel_config(vllm_config)
         cls._validate_parallel_config(vllm_config)
-        cls._validate_pd_pp_mtp_config(vllm_config)
 
         # initialize ascend config from vllm additional_config
         cls._fix_incompatible_config(vllm_config)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2004,11 +2004,6 @@ class NPUModelRunner(GPUModelRunner):
         )):
             scheduler_output = deepcopy(scheduler_output)
         pp_group = get_pp_group()
-        if pp_group.world_size > 1 and not pp_group.is_last_rank:
-            new_token_ids = scheduler_output.scheduled_cached_reqs.new_token_ids
-            if new_token_ids and all(not token_ids for token_ids in new_token_ids):
-                scheduler_output = deepcopy(scheduler_output)
-                scheduler_output.scheduled_cached_reqs.new_token_ids = []
 
         if has_kv_transfer_group():
             kv_connector_metadata = scheduler_output.kv_connector_metadata
@@ -2404,10 +2399,14 @@ class NPUModelRunner(GPUModelRunner):
 
         if self.execute_model_state is None:
             # Nothing to do (PP non-final rank case), output isn't used.
-            # receive sampled token ids from the last PP rank when using
-            # async scheduling + pipeline parallelism so downstream code
-            # (e.g., PCP input preparation) can access them.
-            if self.use_async_scheduling and pp.world_size > 1 and not skip_pp_pd_broadcast:
+            # Receive prev sampled token ids from the last PP rank so that
+            # downstream code (e.g., PCP input preparation) can access them.
+            # This must run in both sync and async modes: _update_states no
+            # longer persists the previous sampled token for non-last ranks,
+            # so without this receive the input_ids would miss the previous
+            # step's sampled token and cause KV-cache/sequence misalignment
+            # (manifesting as garbled output).
+            if pp.world_size > 1 and not skip_pp_pd_broadcast:
                 self._pp_receive_prev_sampled_token_ids_to_input_batch()
             if not kv_connector_output:
                 return None  # noqa
@@ -2519,10 +2518,30 @@ class NPUModelRunner(GPUModelRunner):
             if self.speculative_config is not None:
                 self.finalize_kv_connector()
 
+        # Surface draft token ids to the scheduler so spec decode actually
+        # takes effect. Use a synchronous copy to avoid async stream/event
+        # sync issues with self._draft_token_ids on NPU.
+        output_spec_token_ids = None
+        if self._draft_token_ids is not None:
+            if torch.is_tensor(self._draft_token_ids):
+                num_reqs = self._draft_token_ids.shape[0]
+                draft_ids_list = self._draft_token_ids[:num_reqs].cpu().tolist()
+                draft_req_ids = self._draft_token_req_ids
+            else:
+                draft_ids_list = self._draft_token_ids
+                draft_req_ids = self.input_batch.req_ids
+            if draft_ids_list and draft_req_ids:
+                draft_by_req_id = dict(zip(draft_req_ids, draft_ids_list))
+                output_spec_token_ids = [
+                    draft_by_req_id.get(req_id, [])
+                    for req_id in req_ids_output_copy
+                ]
+
         model_runner_output = ModelRunnerOutput(
             req_ids=req_ids_output_copy,
             req_id_to_index=req_id_to_index_output_copy,
             sampled_token_ids=valid_sampled_token_ids,
+            spec_token_ids=output_spec_token_ids,
             logprobs=logprobs_lists,
             prompt_logprobs_dict=prompt_logprobs_dict,
             kv_connector_output=kv_connector_output,
@@ -2549,12 +2568,33 @@ class NPUModelRunner(GPUModelRunner):
                 global_stream().wait_event(self.sampling_done_event)
                 self._update_states_after_model_execute(sampler_output.sampled_token_ids, scheduler_output)
 
-        # In async scheduling + PP, broadcast sampled token ids from the
-        # last PP rank so other PP ranks can receive them without going
-        # through the scheduler/engine IPC path.
-        if self.use_async_scheduling:
-            if pp.world_size > 1 and pp.is_last_rank and not skip_pp_pd_broadcast:
-                self._pp_broadcast_prev_sampled_token_ids(sampler_output.sampled_token_ids)
+        # Broadcast prev sampled token + draft from the last PP rank so
+        # other PP ranks can receive them without going through the
+        # scheduler/engine IPC path. Symmetric for sync and async: since
+        # _update_states no longer persists the previous sampled token for
+        # non-last ranks, sync mode also relies on this broadcast to
+        # recover it.
+        if pp.world_size > 1 and pp.is_last_rank and not skip_pp_pd_broadcast:
+            draft = (self._draft_token_ids
+                     if self._draft_token_ids is not None
+                     and torch.is_tensor(self._draft_token_ids)
+                     else None)
+            if self.use_async_scheduling:
+                self._pp_broadcast_prev_sampled_token_ids(
+                    sampler_output.sampled_token_ids, draft,
+                )
+            else:
+                # Sync path: sampler_output.sampled_token_ids is
+                # List[List[int]]; align to (num_reqs, 1) int64 tensor.
+                if spec_decode_metadata is None:
+                    sampled = sampler_output.sampled_token_ids
+                else:
+                    sampled = torch.tensor(
+                        [[ids[-1]] if ids else [0]
+                         for ids in valid_sampled_token_ids],
+                        device=self.device,
+                    )
+                self._pp_broadcast_prev_sampled_token_ids(sampled, draft)
 
         if not self.use_async_scheduling:
             if self.routed_experts_initialized:
@@ -2604,6 +2644,40 @@ class NPUModelRunner(GPUModelRunner):
             async_output.async_copy_ready_event,
         )
         return async_output
+
+    def _pp_receive_prev_sampled_token_ids_to_input_batch(self) -> None:
+        """NPU override: cast ``prev_sampled_token_ids`` to int32 after the
+        upstream receive so it matches ``input_ids.gpu`` dtype.
+
+        The upstream ``recv`` tensor is int64, but NPU ``input_ids.gpu`` is
+        int32 and ``scatter_`` does not do implicit conversion, which would
+        raise ``EZ1001 aclnnInplaceScatter`` without this cast.
+        """
+        super()._pp_receive_prev_sampled_token_ids_to_input_batch()
+        if self.input_batch.prev_sampled_token_ids is not None:
+            self.input_batch.prev_sampled_token_ids = (
+                self.input_batch.prev_sampled_token_ids.to(dtype=torch.int32)
+            )
+
+    def _pp_broadcast_prev_sampled_token_ids(
+        self,
+        sampled_token_ids: torch.Tensor,
+        draft_token_ids: torch.Tensor | None = None,
+    ) -> None:
+        """NPU override: force int64 before broadcasting so sender/receiver
+        dtypes match.
+
+        HCCL is stricter than NCCL and requires all ranks to share the same
+        dataType; the NPU sampler may emit int32 while the receiver's
+        ``recv`` is fixed int64, which would raise ``EI0005 HcomBroadcast``
+        without this cast.
+        """
+        sampled_token_ids = sampled_token_ids.to(dtype=torch.int64)
+        if draft_token_ids is not None:
+            draft_token_ids = draft_token_ids.to(dtype=torch.int64)
+        super()._pp_broadcast_prev_sampled_token_ids(
+            sampled_token_ids, draft_token_ids
+        )
 
     # overwrite _sample for lmhead_tp_enable and need_accepted_tokens
     def _sample(self, logits, spec_decode_metadata):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2664,14 +2664,20 @@ class NPUModelRunner(GPUModelRunner):
         sampled_token_ids: torch.Tensor,
         draft_token_ids: torch.Tensor | None = None,
     ) -> None:
-        """NPU override: force int64 before broadcasting so sender/receiver
-        dtypes match.
-
-        HCCL is stricter than NCCL and requires all ranks to share the same
-        dataType; the NPU sampler may emit int32 while the receiver's
-        ``recv`` is fixed int64, which would raise ``EI0005 HcomBroadcast``
-        without this cast.
-        """
+        # Fix: 上游期望 sampled [num_reqs, 1] + draft [num_reqs, num_spec]
+        # vllm-ascend 两分支都可能传错 shape，统一在这里对齐
+        if sampled_token_ids.dim() == 2 and sampled_token_ids.shape[-1] != 1:
+            # async 分支：sampler 输出 [N, 1+spec]，拆分
+            if draft_token_ids is None:
+                draft_token_ids = sampled_token_ids[:, 1:].contiguous()
+            sampled_token_ids = sampled_token_ids[:, :1].contiguous()
+        if (draft_token_ids is not None
+                and self.num_spec_tokens > 0
+                and draft_token_ids.dim() == 2
+                and draft_token_ids.shape[0] != sampled_token_ids.shape[0]):
+            # sync 分支：draft [num_scheduled_tokens, spec] -> [num_reqs, spec]
+            num_reqs = sampled_token_ids.shape[0]
+            draft_token_ids = draft_token_ids[:num_reqs]
         sampled_token_ids = sampled_token_ids.to(dtype=torch.int64)
         if draft_token_ids is not None:
             draft_token_ids = draft_token_ids.to(dtype=torch.int64)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2580,9 +2580,23 @@ class NPUModelRunner(GPUModelRunner):
                      and torch.is_tensor(self._draft_token_ids)
                      else None)
             if self.use_async_scheduling:
-                self._pp_broadcast_prev_sampled_token_ids(
-                    sampler_output.sampled_token_ids, draft,
-                )
+                # async 分支：与 sync 路径完全对齐——用 parse_output 过滤
+                # PLACEHOLDER 后取 ids[-1]。rejection sampler 的 bonus 仅在
+                # 全接受时写入列 num_draft_tokens，部分拒绝时该列及之后保持
+                # PLACEHOLDER，故不能取固定列（[:, -1:] 在部分拒绝时取到
+                # PLACEHOLDER，广播 -1 给非 last rank 导致 KV 错位）。
+                if spec_decode_metadata is not None and self.num_spec_tokens > 0:
+                    valid_sampled, _ = RejectionSampler.parse_output(
+                        sampler_output.sampled_token_ids,
+                        self.input_batch.vocab_size,
+                    )
+                    sampled = torch.tensor(
+                        [[ids[-1]] if ids else [0] for ids in valid_sampled],
+                        device=self.device, dtype=torch.int64,
+                    )
+                else:
+                    sampled = sampler_output.sampled_token_ids
+                self._pp_broadcast_prev_sampled_token_ids(sampled, draft)
             else:
                 # Sync path: sampler_output.sampled_token_ids is
                 # List[List[int]]; align to (num_reqs, 1) int64 tensor.


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request aligns speculative decoding and pipeline parallelism (PP) on NPU. Specifically, it:
- Surfaces draft token IDs to the scheduler in `recompute_scheduler.py` and `model_runner_v1.py` to ensure speculative decoding takes effect.
- Synchronizes the broadcast and receipt of previously sampled tokens and draft tokens across PP ranks in both sync and async modes, preventing KV-cache/sequence misalignment.
- Adds NPU-specific overrides to cast token ID tensors to correct dtypes (`int32` for input batch and `int64` for HCCL broadcast) to avoid runtime errors (`aclnnInplaceScatter` and `HcomBroadcast`).
- Removes unused MTP speculative configuration validation.

Additionally, a critical feedback was provided regarding a potential `AttributeError` in `model_runner_v1.py` when accessing `_draft_token_req_ids` if it is not initialized due to an early return in async scheduling. A fallback to `self.input_batch.req_ids` is suggested.

### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
