### PR TITLE
[Doc][Misc] Correct accuracy evaluation count in Qwen tutorial

### DIFF
--- a/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
@@ -205,7 +205,7 @@ curl http://localhost:8000/v1/completions \
 
 ## Accuracy Evaluation
 
-Here is one accuracy evaluation method.
+Here is an accuracy evaluation method.
 
 ### Using AISBench
 

--- a/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
@@ -205,7 +205,7 @@ curl http://localhost:8000/v1/completions \
 
 ## Accuracy Evaluation
 
-Here are two accuracy evaluation methods.
+Here is one accuracy evaluation method.
 
 ### Using AISBench
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR corrects the description of accuracy evaluation methods in the Qwen3.5/3.6 tutorial. The document previously stated there are two accuracy evaluation methods, but only one (using AISBench) is actually provided.

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

Documentation changes only.

Signed-off-by: AJF-cmd <wangruiqing6@h-partners.com>

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
