### PR TITLE
[Doc][0.22.1] Increased the restrictions on the transformer version

### DIFF
--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -156,6 +156,9 @@ Common Issues Tip: If you encounter issues, Refer to [FAQs](../../faqs.md).
 
 ```{code-block} bash
    :substitutions:
+# The version of transformers needs to be upgraded to 5.2.0.
+# pip install transformers==5.2.0 --upgrade
+
 export HCCL_OP_EXPANSION_MODE="AIV"
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=1


### PR DESCRIPTION
### What this PR does / why we need it?
backport #10992
In the Single-Node Online Deployment section, users encounter transformer version issues when starting the service with vllm serve. Although it was mentioned in the Introduction section, some users may not have noticed it, so it is reminded again in the Single-Node Online Deployment section.

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
