### PR TITLE
[BugFix][P/D] Fix mooncake_layerwise_connector reshape_cache_event bug

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -794,7 +794,12 @@ class MooncakeLayerwiseConnector(KVConnectorBase_V1, SupportsHMA):
             return
         reshape_cache_event = torch.npu.Event()
         reshape_cache_event.record()
-        attn_metadata.reshape_cache_event = reshape_cache_event
+        if isinstance(attn_metadata, dict):
+            per_layer_metadata = attn_metadata.get(layer_name)
+            if per_layer_metadata is not None:
+                per_layer_metadata.reshape_cache_event = reshape_cache_event
+        else:
+            attn_metadata.reshape_cache_event = reshape_cache_event
 
     def wait_for_save(self):
         """MooncakeLayerwiseConnector does not save explicitly."""

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -790,6 +790,8 @@ class MooncakeLayerwiseConnector(KVConnectorBase_V1, SupportsHMA):
         attn_metadata = forward_context.attn_metadata
         if attn_metadata is None:
             return
+        if isinstance(attn_metadata, dict) and layer_name == "":
+            return
         reshape_cache_event = torch.npu.Event()
         reshape_cache_event.record()
         attn_metadata.reshape_cache_event = reshape_cache_event
@@ -1715,16 +1717,21 @@ class MooncakeLayerwiseConnectorWorker:
             # get reshape and cache event
             if layer_name == "":
                 layer_name = self.index_to_name[self.current_layer][0]
-            if (self.use_mla and not hasattr(attn_metadata[layer_name], "reshape_cache_event")) or (
-                not self.use_mla and not hasattr(attn_metadata, "reshape_cache_event")
+            if (
+                isinstance(attn_metadata, dict)
+                and hasattr(attn_metadata[layer_name], "reshape_cache_event")
+                and attn_metadata[layer_name].reshape_cache_event is not None
             ):
+                reshape_cache_event = attn_metadata[layer_name].reshape_cache_event
+            elif (
+                attn_metadata
+                and hasattr(attn_metadata, "reshape_cache_event")
+                and attn_metadata.reshape_cache_event is not None
+            ):
+                reshape_cache_event = attn_metadata.reshape_cache_event
+            else:
                 reshape_cache_event = torch.npu.Event()
                 reshape_cache_event.record()
-            elif self.use_mla:
-                reshape_cache_event = attn_metadata[layer_name].reshape_cache_event
-            else:
-                reshape_cache_event = attn_metadata.reshape_cache_event
-
             send_task = connector_metadata.send_task
             layer_group_idx = self.layer_metadata[layer_name].tensor_group_idx[0]
             keys = None


### PR DESCRIPTION
### What this PR does / why we need it?
#10077 introduce new function for `MooncakeLayerwiseConnector`, but in some cases like Qwen3.5, the `attn_metadata` is a dict which keys are `layer_name`. However, in `attention_v1.py`, this variable defaults to `ascend_metadata`, causing an error. This PR modifies the logic to make a judgment based on the actual instance type, whether it has attributes, and whether it is none, making it more reliable.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By nightly.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
