### PR TITLE
[Feature][KV Pool] Support Mooncake SSD prefetch on exist

### DIFF
--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -449,6 +449,8 @@ mooncake_master --port 50088 --eviction_high_watermark_ratio 0.9 --eviction_rati
 
 #### Configuration
 
+##### SSD Offload Configuration
+
 Starting from the `mooncake.json` configured in [Run Mooncake Master](#run-mooncake-master), add the following SSD offload fields:
 
 ```json
@@ -462,6 +464,24 @@ Starting from the `mooncake.json` configured in [Run Mooncake Master](#run-moonc
 | :--- | :--- |
 | `enable_ssd_offload` | Set to `true` to enable SSD offload. Environment variables are not supported. |
 | `ssd_offload_path` | **Required when `enable_ssd_offload` is `true`.** Absolute path to a local directory where Mooncake stores offloaded KV data (for example, `/nvme/mooncake_offload`). The directory must exist and be writable by the vLLM process; create it before startup (`mkdir -p <path>`). Relative paths, symbolic links, and paths containing `..` are rejected by Mooncake. Passed to `MooncakeDistributedStore.setup()` as the SSD storage root (equivalent to `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` in standalone clients). Configure this field in `mooncake.json` only; environment variables are not supported. |
+
+##### SSD Prefetch Configuration
+
+SSD offload and SSD prefetch are configured separately. After `enable_ssd_offload` is enabled as above, add the following fields to the same `mooncake.json` if you also want SSD-to-DRAM prefetch:
+
+```json
+{
+    "enable_ssd_prefetch": true,
+    "ssd_prefetch_cooldown_sec": 5,
+    "ssd_prefetch_dedup_ttl_sec": 30
+}
+```
+
+| Field | Description |
+| :--- | :--- |
+| `enable_ssd_prefetch` | Optional. Set to `true` to enable SSD-to-DRAM prefetch on exist queries. When enabled, `batch_is_exist` passes `ExistOptions(prefetch_to_memory=True)` so that Mooncake promotes SSD-only objects back into DRAM proactively during cache probe. This hides SSD read latency behind ongoing compute thanks to vLLM's asynchronous scheduling. **Requires `enable_ssd_offload` to be `true` and a Mooncake version that implements [RFC #2213](https://github.com/kvcache-ai/Mooncake/issues/2213) (post-v0.3.11).** If the installed Mooncake does not support `ExistOptions`, a warning is logged and the option is silently ignored. Default: `false`. |
+| `ssd_prefetch_cooldown_sec` | Optional. Memory-pressure backoff for SSD prefetch, in seconds. When a promotion fails because DRAM is saturated (`NO_AVAILABLE_HANDLE`), prefetch is suppressed for this many seconds so that eviction/offload can reclaim DRAM instead of competing with promotion. Prevents the "prefetch keeps trying to add to a full DRAM while offload can't drain it" thrash that pins memory and spins eviction. Set `0` to disable the backoff. Tune it to roughly the time it takes eviction/offload to drain DRAM from the high watermark back down (observe `[EVICT-TRIGGER] memory_ratio=...` in the master log). Only relevant when `enable_ssd_prefetch` is `true`. vLLM-Ascend does not impose its own default: if this field is omitted from `mooncake.json`, it is not passed to `setup()` and Mooncake's built-in default (currently `5`) applies. |
+| `ssd_prefetch_dedup_ttl_sec` | Optional. Per-key de-duplication / rate-limit TTL for SSD prefetch, in seconds. The same key is prefetched at most once per this period, suppressing duplicate triggers from concurrent exist/get probes across TP ranks (and, for cross-node prefetch, repeated delegations to the same holder). Cuts the RPC/thread storm that can starve offload. Set `0` to disable rate-limiting. Only relevant when `enable_ssd_prefetch` is `true`. vLLM-Ascend does not impose its own default: if this field is omitted from `mooncake.json`, it is not passed to `setup()` and Mooncake's built-in default (currently `30`) applies. |
 
 #### Running the Embedded Real Client
 

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -188,6 +188,20 @@ class TestMooncakeStoreConfig(unittest.TestCase):
         )
         self.assertTrue(cfg.enable_ssd_prefetch)
 
+    def test_from_file_ssd_prefetch_with_null_values(self):
+        ssd_path = TestMooncakeStoreConfig._writable_ssd_path()
+        self.addCleanup(lambda: os.rmdir(ssd_path))
+        cfg = _make_mooncake_store_config(
+            enable_ssd_offload=True,
+            ssd_offload_path=ssd_path,
+            enable_ssd_prefetch=True,
+            ssd_prefetch_cooldown_sec=None,
+            ssd_prefetch_dedup_ttl_sec=None,
+        )
+        self.assertTrue(cfg.enable_ssd_prefetch)
+        self.assertIsNone(cfg.ssd_prefetch_cooldown_sec)
+        self.assertIsNone(cfg.ssd_prefetch_dedup_ttl_sec)
+
     def test_load_from_env_missing(self):
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop("MOONCAKE_CONFIG_PATH", None)

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -26,6 +26,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend im
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend import (
     MooncakeStoreConfig,
     _convert_to_bytes,
+    _mooncake_is_exist_supports_prefetch,
     _parse_global_segment_size,
     _ssd_setup_kwargs,
 )
@@ -173,6 +174,20 @@ class TestMooncakeStoreConfig(unittest.TestCase):
             },
         )
 
+    def test_from_file_ssd_prefetch_default_off(self):
+        cfg = _make_mooncake_store_config()
+        self.assertFalse(cfg.enable_ssd_prefetch)
+
+    def test_from_file_ssd_prefetch_enabled(self):
+        ssd_path = TestMooncakeStoreConfig._writable_ssd_path()
+        self.addCleanup(lambda: os.rmdir(ssd_path))
+        cfg = _make_mooncake_store_config(
+            enable_ssd_offload=True,
+            ssd_offload_path=ssd_path,
+            enable_ssd_prefetch=True,
+        )
+        self.assertTrue(cfg.enable_ssd_prefetch)
+
     def test_load_from_env_missing(self):
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop("MOONCAKE_CONFIG_PATH", None)
@@ -195,6 +210,41 @@ class TestMooncakeStoreConfig(unittest.TestCase):
                 self.assertEqual(cfg.metadata_server, "host:1234")
         finally:
             os.unlink(path)
+
+
+class TestMooncakeIsExistSupportsPrefetch(unittest.TestCase):
+    def setUp(self):
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
+            mooncake_backend,
+        )
+
+        mooncake_backend._mooncake_exist_options_class.cache_clear()
+        _mooncake_is_exist_supports_prefetch.cache_clear()
+
+    def tearDown(self):
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
+            mooncake_backend,
+        )
+
+        mooncake_backend._mooncake_exist_options_class.cache_clear()
+        _mooncake_is_exist_supports_prefetch.cache_clear()
+
+    def test_returns_true_when_exist_options_available(self):
+        class ExistOptions:
+            def __init__(self):
+                self.prefetch_to_memory = False
+
+        mock_module = MagicMock()
+        mock_module.ExistOptions = ExistOptions
+        with patch.dict("sys.modules", {"mooncake.store": mock_module}):
+            result = _mooncake_is_exist_supports_prefetch()
+            self.assertTrue(result)
+
+    def test_returns_false_when_exist_options_missing(self):
+        mock_module = MagicMock(spec=[])
+        with patch.dict("sys.modules", {"mooncake.store": mock_module}):
+            result = _mooncake_is_exist_supports_prefetch()
+            self.assertFalse(result)
 
 
 class TestParseGlobalSegmentSize(unittest.TestCase):
@@ -347,6 +397,8 @@ class TestMooncakeBackendMethods(unittest.TestCase):
             backend._use_fabric_mem = False
             backend._store_init_lock = MagicMock()
             backend.local_seg = None
+            backend._ssd_prefetch_enabled = False
+            backend._exist_prefetch_options = None
             return backend
 
     def test_exists(self):
@@ -354,6 +406,61 @@ class TestMooncakeBackendMethods(unittest.TestCase):
         b.store.batch_is_exist.return_value = [1, 0]
         result = b.exists(["k1", "k2"])
         self.assertEqual(result, [1, 0])
+        b.store.batch_is_exist.assert_called_once_with(["k1", "k2"])
+
+    def test_exists_with_ssd_prefetch(self):
+        b = self._make_backend()
+        b._ssd_prefetch_enabled = True
+        prefetch_options = object()
+        b._exist_prefetch_options = prefetch_options
+        b.store.batch_is_exist.return_value = [1, 0, 1]
+        result = b.exists(["k1", "k2", "k3"])
+        self.assertEqual(result, [1, 0, 1])
+        b.store.batch_is_exist.assert_called_once_with(
+            ["k1", "k2", "k3"], prefetch_options
+        )
+
+    def test_exists_without_ssd_prefetch(self):
+        b = self._make_backend()
+        b._ssd_prefetch_enabled = False
+        b.store.batch_is_exist.return_value = [1]
+        result = b.exists(["k1"])
+        self.assertEqual(result, [1])
+        b.store.batch_is_exist.assert_called_once_with(["k1"])
+
+    def test_resolve_ssd_prefetch_disabled_by_config(self):
+        b = self._make_backend()
+        b.config.enable_ssd_prefetch = False
+        b.config.enable_ssd_offload = True
+        self.assertFalse(b._resolve_ssd_prefetch())
+
+    def test_resolve_ssd_prefetch_no_offload(self):
+        b = self._make_backend()
+        b.config.enable_ssd_prefetch = True
+        b.config.enable_ssd_offload = False
+        self.assertFalse(b._resolve_ssd_prefetch())
+
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend."
+        "mooncake_backend._mooncake_is_exist_supports_prefetch",
+        return_value=False,
+    )
+    def test_resolve_ssd_prefetch_unsupported_mooncake(self, _mock):
+        b = self._make_backend()
+        b.config.enable_ssd_prefetch = True
+        b.config.enable_ssd_offload = True
+        self.assertFalse(b._resolve_ssd_prefetch())
+
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend."
+        "mooncake_backend._mooncake_is_exist_supports_prefetch",
+        return_value=True,
+    )
+    def test_resolve_ssd_prefetch_enabled(self, _mock):
+        b = self._make_backend()
+        b.config.enable_ssd_prefetch = True
+        b.config.enable_ssd_offload = True
+        self.assertTrue(b._resolve_ssd_prefetch())
 
     def test_put(self):
         b = self._make_backend()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -41,6 +41,40 @@ def _mooncake_setup_supports_ssd_offload() -> bool:
         return "enable_ssd_offload" in doc
 
 
+@functools.lru_cache(maxsize=1)
+def _mooncake_exist_options_class() -> type | None:
+    """Return ``ExistOptions`` when the installed Mooncake exposes it."""
+    try:
+        from mooncake.store import ExistOptions  # type: ignore
+
+        options = ExistOptions()
+        if hasattr(options, "prefetch_to_memory"):
+            return ExistOptions
+    except Exception:
+        pass
+    return None
+
+
+@functools.lru_cache(maxsize=1)
+def _mooncake_is_exist_supports_prefetch() -> bool:
+    """True when installed Mooncake exposes ``ExistOptions`` for is_exist / batch_is_exist.
+
+    Mooncake RFC #2213 adds ``batch_is_exist(keys, ExistOptions(prefetch_to_memory=True))``
+    which triggers SSD-to-DRAM promotion for keys that only have a LOCAL_DISK replica.
+    The feature was proposed after v0.3.11, so it requires a newer build.
+    """
+    return _mooncake_exist_options_class() is not None
+
+
+def _build_exist_prefetch_options() -> Any:
+    exist_options_cls = _mooncake_exist_options_class()
+    if exist_options_cls is None:
+        raise RuntimeError("Mooncake ExistOptions is not available")
+    options = exist_options_cls()
+    options.prefetch_to_memory = True
+    return options
+
+
 def _ssd_setup_kwargs(config: "MooncakeStoreConfig") -> dict[str, object]:
     """Keyword args for store.setup(); empty on old Mooncake or when SSD is off."""
     if not config.enable_ssd_offload:
@@ -53,10 +87,27 @@ def _ssd_setup_kwargs(config: "MooncakeStoreConfig") -> dict[str, object]:
             "later (see Mooncake ssd-offload.md Step 3A), or set "
             "enable_ssd_offload to false."
         )
-    return {
+    kwargs: dict[str, object] = {
         "enable_ssd_offload": config.enable_ssd_offload,
         "ssd_offload_path": config.ssd_offload_path,
     }
+    # SSD prefetch throttle (memory-pressure backoff + per-key dedup). Only
+    # forward when the installed Mooncake build accepts these kwargs; older
+    # builds would reject unknown arguments. The throttle and the prefetch
+    # ExistOptions API ship together (same change set), so the ExistOptions
+    # probe doubles as the throttle-kwarg capability check — and it is more
+    # reliable than inspecting the pybind setup() signature. The throttle
+    # guards the holder side, so it is configured whenever SSD offload is on
+    # (a remote node may delegate prefetch to this node regardless of this
+    # node's own prefetch setting).
+    # Only forward throttle knobs that were explicitly set in mooncake.json.
+    # When unset (None) we omit them so Mooncake uses its own built-in defaults.
+    if _mooncake_is_exist_supports_prefetch():
+        if config.ssd_prefetch_cooldown_sec is not None:
+            kwargs["ssd_prefetch_cooldown_sec"] = config.ssd_prefetch_cooldown_sec
+        if config.ssd_prefetch_dedup_ttl_sec is not None:
+            kwargs["ssd_prefetch_dedup_ttl_sec"] = config.ssd_prefetch_dedup_ttl_sec
+    return kwargs
 
 
 class MooncakeBackend(Backend):
@@ -71,6 +122,8 @@ class MooncakeBackend(Backend):
         self._lazy_init = lazy_init and self._use_fabric_mem
         self._store_initialized = False
         self._store_init_lock = threading.Lock()
+        self._ssd_prefetch_enabled = False
+        self._exist_prefetch_options: Any | None = None
 
         if not self._lazy_init:
             self.store = self._setup_store()
@@ -154,7 +207,36 @@ class MooncakeBackend(Backend):
                 "Mooncake SSD offload enabled (Mode A): path=%s",
                 self.config.ssd_offload_path,
             )
+        self._ssd_prefetch_enabled = self._resolve_ssd_prefetch()
+        if self._ssd_prefetch_enabled:
+            self._exist_prefetch_options = _build_exist_prefetch_options()
         return store
+
+    def _resolve_ssd_prefetch(self) -> bool:
+        """Decide whether to pass ``ExistOptions(prefetch_to_memory=True)`` on exist queries.
+
+        Prefetch is only useful when SSD offload is active (keys can reside on
+        disk) and the installed Mooncake build exposes ``ExistOptions`` on
+        ``batch_is_exist`` / ``is_exist`` (RFC #2213).
+        """
+        if not self.config.enable_ssd_prefetch:
+            return False
+        if not self.config.enable_ssd_offload:
+            logger.warning(
+                "enable_ssd_prefetch is true but SSD offload is disabled; "
+                "prefetch has no effect without SSD offload."
+            )
+            return False
+        if not _mooncake_is_exist_supports_prefetch():
+            logger.warning(
+                "enable_ssd_prefetch is true, but the installed Mooncake does "
+                "not support ExistOptions on batch_is_exist / is_exist "
+                "(RFC #2213). Upgrade Mooncake to a version that implements "
+                "this feature. Prefetch will be disabled."
+            )
+            return False
+        logger.info("Mooncake SSD prefetch on exist enabled.")
+        return True
 
     def set_device(self):
         local_rank = get_world_group().local_rank
@@ -175,6 +257,8 @@ class MooncakeBackend(Backend):
             )
             return [0] * len(keys)
         assert self.store is not None
+        if self._ssd_prefetch_enabled and self._exist_prefetch_options is not None:
+            return self.store.batch_is_exist(keys, self._exist_prefetch_options)
         return self.store.batch_is_exist(keys)
 
     def put(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
@@ -275,6 +359,11 @@ class MooncakeStoreConfig:
     prefer_alloc_in_same_node: bool
     enable_ssd_offload: bool = False
     ssd_offload_path: str = ""
+    enable_ssd_prefetch: bool = False
+    # None means "not set in mooncake.json"; in that case we do NOT pass the
+    # value to store.setup() and let Mooncake fall back to its own defaults.
+    ssd_prefetch_cooldown_sec: int | None = None
+    ssd_prefetch_dedup_ttl_sec: int | None = None
 
     def __post_init__(self) -> None:
         if not self.enable_ssd_offload:
@@ -309,6 +398,17 @@ class MooncakeStoreConfig:
             prefer_alloc_in_same_node=config.get("prefer_alloc_in_same_node", True),
             enable_ssd_offload=bool(config.get("enable_ssd_offload", False)),
             ssd_offload_path=config.get("ssd_offload_path", ""),
+            enable_ssd_prefetch=bool(config.get("enable_ssd_prefetch", False)),
+            ssd_prefetch_cooldown_sec=(
+                int(config["ssd_prefetch_cooldown_sec"])
+                if "ssd_prefetch_cooldown_sec" in config
+                else None
+            ),
+            ssd_prefetch_dedup_ttl_sec=(
+                int(config["ssd_prefetch_dedup_ttl_sec"])
+                if "ssd_prefetch_dedup_ttl_sec" in config
+                else None
+            ),
         )
 
     @staticmethod

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -401,12 +401,12 @@ class MooncakeStoreConfig:
             enable_ssd_prefetch=bool(config.get("enable_ssd_prefetch", False)),
             ssd_prefetch_cooldown_sec=(
                 int(config["ssd_prefetch_cooldown_sec"])
-                if "ssd_prefetch_cooldown_sec" in config
+                if config.get("ssd_prefetch_cooldown_sec") is not None
                 else None
             ),
             ssd_prefetch_dedup_ttl_sec=(
                 int(config["ssd_prefetch_dedup_ttl_sec"])
-                if "ssd_prefetch_dedup_ttl_sec" in config
+                if config.get("ssd_prefetch_dedup_ttl_sec") is not None
                 else None
             ),
         )


### PR DESCRIPTION
### What this PR does / why we need it?

- Add optional Mooncake SSD-to-DRAM prefetch on `batch_is_exist` via `ExistOptions(prefetch_to_memory=True)` when `enable_ssd_prefetch=true` in `mooncake.json`.
- Parse `enable_ssd_prefetch`, `ssd_prefetch_cooldown_sec`, and `ssd_prefetch_dedup_ttl_sec`; forward throttle knobs to `store.setup()` only when explicitly set and Mooncake supports `ExistOptions` ([Mooncake issue #2213](https://github.com/kvcache-ai/Mooncake/issues/2213), post-v0.3.11).
- Gracefully disable prefetch with a warning when SSD offload is off or Mooncake lacks `ExistOptions`.
- Document SSD offload / prefetch `mooncake.json` fields in `kv_pool.md`.

### Does this PR introduce _any_ user-facing change?

Yes. New optional `mooncake.json` fields for SSD prefetch; behavior change only when `enable_ssd_prefetch=true` and a compatible Mooncake build is installed.

### How was this patch tested?

- Unit tests: `pytest -sv tests/ut/distributed/ascend_store/test_backend.py`
- Covers config parsing, `ExistOptions` capability probe, prefetch resolve logic, and `exists()` call path with/without prefetch options.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
