### PR TITLE
[BugFix] Report correct cached_tokens in PD disaggregation

### DIFF
--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -509,6 +509,37 @@ class RecomputeScheduler(Scheduler):
                             num_local_cached_tokens=num_new_local_computed_tokens,
                             num_external_cached_tokens=num_external_computed_tokens,
                         )
+                        # [PD disagg cached_tokens fix] In disaggregated
+                        # prefill, the decode node cannot tell prefix-cache
+                        # hits from freshly computed tokens among the KV it
+                        # received from the prefill node, so cached_tokens is
+                        # wrong. Propagate the prefill node's real prefix-cache
+                        # hit count through kv_transfer_params and use it on the
+                        # decode node.
+                        params = request.kv_transfer_params
+                        if params and params.get("do_remote_decode"):
+                            # Prefill (P) node: record real prefix-cache hits so
+                            # they can be forwarded to the decode node. Include
+                            # both local prefix-cache hits and external (e.g.
+                            # memcache / KV pool) hits. The two are disjoint:
+                            # num_external_computed_tokens is the number of NEW
+                            # tokens matched beyond num_new_local_computed_tokens
+                            # (see KVConnectorBase_V1.get_num_new_matched_tokens),
+                            # so summing them does not double-count.
+                            params["remote_num_cached_tokens"] = (
+                                num_new_local_computed_tokens
+                                + num_external_computed_tokens
+                            )
+                        elif params and params.get("do_remote_prefill") and (
+                            "remote_num_cached_tokens" in params
+                        ):
+                            # Decode (D) node: override cached_tokens with the
+                            # prefill node's real hit count. Do NOT add D's local
+                            # hit (num_local) -- it is the same prefix and would
+                            # double-count.
+                            request.prefill_stats.num_cached_tokens = (
+                                params["remote_num_cached_tokens"]
+                            )
                 else:
                     # KVTransfer: WAITING reqs have num_computed_tokens > 0
                     # after async KV recvs are completed.

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1534,7 +1534,6 @@ class MooncakeConnectorScheduler:
             else block_ids
             for i, block_ids in enumerate(computed_block_ids)
         )
-
         return delay_free_blocks, dict(
             do_remote_prefill=True,
             do_remote_decode=False,
@@ -1549,6 +1548,7 @@ class MooncakeConnectorScheduler:
             last_token_id=request.output_token_ids[-1],
             remote_multi_nodes_meta_mapping=self.multi_nodes_meta_mapping,
             num_prompt_blocks=num_prompt_blocks,
+            remote_num_cached_tokens=params.get("remote_num_cached_tokens"),
         )
 
     def set_xfer_handshake_metadata(self, metadata: dict[int, KVConnectorHandshakeMetadata]) -> None:


### PR DESCRIPTION
In disaggregated prefill, the decode node treats all KV blocks received from the prefill node as cache hits, so cached_tokens always equals prompt_tokens regardless of actual prefix-cache hits.

Propagate the prefill node's real num_cached_tokens through kv_transfer_params (remote_num_cached_tokens) and use it to override the wrong value on the decode node.

Changes:
- mooncake_connector: forward remote_num_cached_tokens in kv_transfer_params
- recompute_scheduler: P node stores real hits, D node overrides num_cached_tokens (covers recompute_scheduler_enable=true path)

Companion to vllm-project/vllm#46898

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
