### PR TITLE
[CI][Misc] Modify accuracy test thresholds for multiple models

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3_2-W8A8-A3-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3_2-W8A8-A3-dual-nodes.yaml
@@ -123,4 +123,4 @@ benchmarks:
     max_out_len: 80000
     batch_size: 32
     baseline: 57 
-    threshold: 7
+    threshold: 10

--- a/tests/e2e/nightly/single_node/models/configs/DeepSeek-V4-Flash-W8A8-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/DeepSeek-V4-Flash-W8A8-A3.yaml
@@ -65,7 +65,7 @@ test_cases:
         max_out_len: 65536
         batch_size: 32
         baseline: 86.36
-        threshold: 3
+        threshold: 5
         thinking: true
       perf:
         case_type: performance

--- a/tests/e2e/nightly/single_node/models/configs/MTPX-DeepSeek-R1-0528-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/MTPX-DeepSeek-R1-0528-W8A8.yaml
@@ -50,7 +50,7 @@ _benchmarks_aime: &benchmarks_aime
     max_out_len: 32768
     batch_size: 32
     baseline: 86.67
-    threshold: 7
+    threshold: 10
 
 # ==========================================
 # ACTUAL TEST CASES

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3-32B-Int8-A2.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3-32B-Int8-A2.yaml
@@ -39,7 +39,7 @@ _benchmarks: &benchmarks
     max_out_len: 32768
     batch_size: 32
     baseline: 83.33
-    threshold: 7
+    threshold: 10
 
   perf:
     case_type: performance

--- a/tests/e2e/weekly/single_node/configs/Kimi-K2.5.yaml
+++ b/tests/e2e/weekly/single_node/configs/Kimi-K2.5.yaml
@@ -46,7 +46,7 @@ _benchmark_acc: &_benchmark_acc
     max_out_len: 32768
     batch_size: 32
     baseline: 90
-    threshold: 5
+    threshold: 10
 
 _benchmark_TPOT50_3_5k_1_5k: &_benchmark_TPOT50_3_5k_1_5k
   case_type: performance

--- a/tests/e2e/weekly/single_node/configs/Qwen3.5-122B-A10B-W8A8-A3.yaml
+++ b/tests/e2e/weekly/single_node/configs/Qwen3.5-122B-A10B-W8A8-A3.yaml
@@ -61,7 +61,7 @@ _benchmark_acc: &_benchmark_acc
     max_out_len: 65536
     batch_size: 32
     baseline: 90
-    threshold: 5
+    threshold: 10
     thinking: true
     temperature: 1.0
     top_p: 0.95


### PR DESCRIPTION
### What this PR does / why we need it?

This PR increases the accuracy test thresholds for several models (DeepSeek-V3.2, DeepSeek-V4-Flash, MTPX-DeepSeek-R1, Qwen3-32B, Kimi-K2.5, and Qwen3.5-122B) in nightly and weekly end-to-end tests. Relaxing these thresholds prevents false-positive CI failures due to minor accuracy fluctuations, but it should be accompanied by a justification or analysis of why the previous thresholds were too strict.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This is a configuration change for CI tests; no new tests are introduced.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
