### PR TITLE
[Refactor][Attn] Reuse on-device query_start_loc, drop redundant per-forward H2D

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -309,8 +309,9 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
         # Get attn_mask from singleton AttentionMaskBuilder
         attn_mask = self.attn_mask_builder.get_attention_mask(common_attn_metadata.causal, self.model_config)
 
-        # TODO: Yet another unnecessary H2D while we already have a query_start_loc on device
-        query_start_loc = query_start_loc_cpu.pin_memory().to(self.device, non_blocking=True)
+        # Reuse the already-on-device query_start_loc (a synced view of the same
+        # CpuGpuBuffer as query_start_loc_cpu) instead of re-doing a per-forward H2D copy.
+        query_start_loc = common_attn_metadata.query_start_loc[: num_reqs + 1]
 
         attn_metadata = AscendMetadata(
             num_actual_tokens=num_actual_tokens,


### PR DESCRIPTION
## What this PR does / why we need it?

`AscendAttentionMetadataBuilder.build` re-copies `query_start_loc` to the device on every forward via `query_start_loc_cpu.pin_memory().to(self.device, non_blocking=True)`, even though the synced device tensor is already available as `common_attn_metadata.query_start_loc` (the on-device counterpart of the same `CpuGpuBuffer` as `query_start_loc_cpu`, set together in `AscendCommonAttentionMetadata`). This resolves the existing in-code TODO ("Yet another unnecessary H2D while we already have a query_start_loc on device") by reusing the on-device tensor and dropping the redundant per-forward H2D copy. `query_start_loc_cpu` is kept (still used for `actual_seq_lengths_q`).

## Does this PR introduce any user-facing change?

No. Internal cleanup; behavior is unchanged.

## How was this patch tested?

Verified on Qwen3-8B (single card, greedy): generated token ids are bit-identical (sha256 match) before and after, and the per-forward `pin_memory().to(device)` H2D call count on this path drops from 48 to 0 over the same run.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
