### PR TITLE
[BugFix][P/D] Fix MooncakeLayerwiseConnector Mamba block_ids bug

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -350,12 +350,18 @@ class KVCacheSendingLayerThread(threading.Thread):
                         src_list.append(
                             local_conv_addr + local_block_ids[local_transfer_idx] * local_conv_len + local_addr_offset
                         )
-                        dst_list.append(remote_conv_addr + remote_block_ids[remote_transfer_idx] * remote_conv_len + remote_addr_offset)
+                        dst_list.append(
+                            remote_conv_addr
+                            + remote_block_ids[remote_transfer_idx] * remote_conv_len
+                            + remote_addr_offset
+                        )
                         length_list.append(local_conv_size * get_dtype_size(conv_dtype))
                 # ssm
                 remote_addr_offset = (self.tp_rank % tp_ratio) * math.prod(ssm_shape) * get_dtype_size(ssm_dtype)
                 src_list.append(local_ssm_addr + local_block_ids[local_transfer_idx] * local_ssm_len)
-                dst_list.append(remote_ssm_addr + remote_block_ids[remote_transfer_idx] * remote_ssm_len + remote_addr_offset)
+                dst_list.append(
+                    remote_ssm_addr + remote_block_ids[remote_transfer_idx] * remote_ssm_len + remote_addr_offset
+                )
                 length_list.append(local_ssm_len)
         else:
             if self.pd_head_ratio == 1:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -297,9 +297,10 @@ class KVCacheSendingLayerThread(threading.Thread):
         if isinstance(layer_kv_cache_spec, MambaSpec):
             # only support one block transfer for mamba
             if self.mamba_cache_mode == "align":
-                transfer_block_idx = len(local_block_ids) - self.num_speculative_tokens - 1
+                local_transfer_idx = len(local_block_ids) - self.num_speculative_tokens - 1
             else:
-                transfer_block_idx = 0
+                local_transfer_idx = 0
+            remote_transfer_idx = len(remote_block_ids) - self.num_speculative_tokens - 1
             local_conv_addr, local_ssm_addr = local_layer_metadata.kv_caches_base_addr
             remote_conv_addr, remote_ssm_addr = remote_layer_metadata.kv_caches_base_addr
             local_conv_len, local_ssm_len = local_layer_metadata.block_len
@@ -307,14 +308,14 @@ class KVCacheSendingLayerThread(threading.Thread):
             if tp_ratio == 1:
                 src_list.extend(
                     [
-                        local_conv_addr + local_block_ids[transfer_block_idx] * local_conv_len,
-                        local_ssm_addr + local_block_ids[transfer_block_idx] * local_ssm_len,
+                        local_conv_addr + local_block_ids[local_transfer_idx] * local_conv_len,
+                        local_ssm_addr + local_block_ids[local_transfer_idx] * local_ssm_len,
                     ]
                 )
                 dst_list.extend(
                     [
-                        remote_conv_addr + remote_block_ids[-1] * local_conv_len,
-                        remote_ssm_addr + remote_block_ids[-1] * local_ssm_len,
+                        remote_conv_addr + remote_block_ids[remote_transfer_idx] * local_conv_len,
+                        remote_ssm_addr + remote_block_ids[remote_transfer_idx] * local_ssm_len,
                     ]
                 )
                 length_list.extend([local_conv_len, local_ssm_len])
@@ -347,14 +348,14 @@ class KVCacheSendingLayerThread(threading.Thread):
                             + (self.tp_rank % tp_ratio) * local_conv_size
                         ) * get_dtype_size(conv_dtype)
                         src_list.append(
-                            local_conv_addr + local_block_ids[transfer_block_idx] * local_conv_len + local_addr_offset
+                            local_conv_addr + local_block_ids[local_transfer_idx] * local_conv_len + local_addr_offset
                         )
-                        dst_list.append(remote_conv_addr + remote_block_ids[-1] * remote_conv_len + remote_addr_offset)
+                        dst_list.append(remote_conv_addr + remote_block_ids[remote_transfer_idx] * remote_conv_len + remote_addr_offset)
                         length_list.append(local_conv_size * get_dtype_size(conv_dtype))
                 # ssm
                 remote_addr_offset = (self.tp_rank % tp_ratio) * math.prod(ssm_shape) * get_dtype_size(ssm_dtype)
-                src_list.append(local_ssm_addr + local_block_ids[transfer_block_idx] * local_ssm_len)
-                dst_list.append(remote_ssm_addr + remote_block_ids[-1] * remote_ssm_len + remote_addr_offset)
+                src_list.append(local_ssm_addr + local_block_ids[local_transfer_idx] * local_ssm_len)
+                dst_list.append(remote_ssm_addr + remote_block_ids[remote_transfer_idx] * remote_ssm_len + remote_addr_offset)
                 length_list.append(local_ssm_len)
         else:
             if self.pd_head_ratio == 1:


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request updates the Mooncake layerwise connector to correctly calculate and use `remote_transfer_idx` instead of hardcoding `-1` when indexing `remote_block_ids` for Mamba speculative tokens. This ensures the correct remote blocks are targeted during KV transfer.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI tests.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
