### PR TITLE
[Ops][Feature] Enable EVS multimodal pruning for Qwen3.5 and fix cross-device errors on Ascend NPU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,5 @@ csrc/third_party/
 .codegraph/
 
 .vllm_ascend/
+csrc/build/
+csrc/build_out/

--- a/vllm_ascend/ops/vocab_parallel_embedding.py
+++ b/vllm_ascend/ops/vocab_parallel_embedding.py
@@ -167,6 +167,14 @@ class AscendVocabParallelEmbedding(VocabParallelEmbedding):
             return self._forward_origin(input_)
 
     def _forward_embed_tp(self, input_):
+        # Ensure indices sit on the weight device: the EVS video path builds
+        # repl_token_ids on CPU (from a plain Python list) before calling the
+        # language model's embedding lookup; without this the NPU embedding
+        # op receives CPU indices + NPU weight -> cross-device error. No-op
+        # for the normal path where input_ is already on the accelerator.
+        weight = getattr(self, "weight", None)
+        if weight is not None and input_.device != weight.device:
+            input_ = input_.to(weight.device)
         complete_input = self.comm_group.all_gather(input_, dim=0)
         masked_input, input_mask = self._get_masked_input_and_mask(
             complete_input,
@@ -184,6 +192,11 @@ class AscendVocabParallelEmbedding(VocabParallelEmbedding):
         return output
 
     def _forward_origin(self, input_):
+        # See _forward_embed_tp: move CPU indices to the weight device (EVS
+        # repl_token_ids path); no-op when already on the accelerator.
+        weight = getattr(self, "weight", None)
+        if weight is not None and input_.device != weight.device:
+            input_ = input_.to(weight.device)
         if self.tp_size > 1:
             # Build the mask.
             masked_input, input_mask = self._get_masked_input_and_mask(

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -160,3 +160,70 @@ else:
     _GDN_PATCH_TARGET.forward = AscendGatedDeltaNetAttention.forward
     _GDN_PATCH_TARGET._forward_core = AscendGatedDeltaNetAttention._forward_core
     _GDN_PATCH_TARGET._warmup_prefill_kernels = AscendGatedDeltaNetAttention._warmup_prefill_kernels
+
+
+# ----------------------------------------------------------------------------
+# EVS (Efficient Video Sampling) multimodal pruning for Qwen3.5.
+# Qwen3.5 inherits the full EVS pipeline (pruning in _process_video_input +
+# recompute_mrope_positions) from Qwen3VLForConditionalGeneration but ships
+# with it explicitly disabled. Re-enable it on Ascend NPU by:
+#   1. supports_multimodal_pruning = True
+#   2. drop the NotImplementedError override of recompute_mrope_positions so
+#      the parent's impl is inherited
+#   3. wrap __init__ to honor multimodal_config flags (--video-pruning-rate
+#      q>0) and set the EVS post-processing attributes (_tokenizer /
+#      use_deepstack / visual_dim / ...) that Qwen3.5's __init__ omits (it
+#      calls nn.Module.__init__ instead of super().__init__).
+# The runner-side wiring (NPUModelRunner.load_model setting
+# is_multimodal_pruning_enabled) lives in worker/model_runner_v1.py.
+# ----------------------------------------------------------------------------
+from vllm.model_executor.models.qwen3_5 import (  # noqa: E402
+    Qwen3_5ForConditionalGeneration,
+    Qwen3_5MoeForConditionalGeneration,
+)
+from vllm.tokenizers.registry import cached_tokenizer_from_config  # noqa: E402
+
+
+def _set_qwen3_5_evs_attrs(self, vllm_config):
+    mm_config = vllm_config.model_config.multimodal_config
+    config = vllm_config.model_config.hf_config
+    self.is_multimodal_pruning_enabled = mm_config.is_multimodal_pruning_enabled() if mm_config is not None else False
+    self.video_pruning_rate = mm_config.video_pruning_rate if mm_config is not None else 0.0
+    self.model_config = vllm_config.model_config
+    self._tokenizer = cached_tokenizer_from_config(vllm_config.model_config)
+    # Qwen3.5 ships an empty deepstack_visual_indexes; use bool(...) so the
+    # EVS path does not enter the deepstack branch with num_level == 0.
+    vision_config = getattr(config, "vision_config", None)
+    _ds = getattr(vision_config, "deepstack_visual_indexes", None) or []
+    self.use_deepstack = bool(_ds)
+    self.deepstack_num_level = len(_ds)
+    self.visual_dim = vision_config.out_hidden_size if vision_config is not None else 0
+    self.multiscale_dim = self.visual_dim * self.deepstack_num_level
+
+
+_orig_qwen3_5_init = Qwen3_5ForConditionalGeneration.__init__
+
+
+def _qwen3_5_evs_init(self, *, vllm_config, prefix="model"):
+    _orig_qwen3_5_init(self, vllm_config=vllm_config, prefix=prefix)
+    _set_qwen3_5_evs_attrs(self, vllm_config)
+
+
+Qwen3_5ForConditionalGeneration.__init__ = _qwen3_5_evs_init
+Qwen3_5ForConditionalGeneration.supports_multimodal_pruning = True
+if "recompute_mrope_positions" in Qwen3_5ForConditionalGeneration.__dict__:
+    del Qwen3_5ForConditionalGeneration.recompute_mrope_positions
+
+# MoE variant: it overrides __init__ but inherits recompute_mrope_positions.
+_orig_qwen3_5_moe_init = Qwen3_5MoeForConditionalGeneration.__init__
+
+
+def _qwen3_5_moe_evs_init(self, *, vllm_config, prefix="model"):
+    _orig_qwen3_5_moe_init(self, vllm_config=vllm_config, prefix=prefix)
+    _set_qwen3_5_evs_attrs(self, vllm_config)
+
+
+Qwen3_5MoeForConditionalGeneration.__init__ = _qwen3_5_moe_evs_init
+Qwen3_5MoeForConditionalGeneration.supports_multimodal_pruning = True
+if "recompute_mrope_positions" in Qwen3_5MoeForConditionalGeneration.__dict__:
+    del Qwen3_5MoeForConditionalGeneration.recompute_mrope_positions

--- a/vllm_ascend/patch/worker/patch_qwen3vl.py
+++ b/vllm_ascend/patch/worker/patch_qwen3vl.py
@@ -108,3 +108,26 @@ def patch_qwen3_vl_moe_pp_layer_range():
 
 
 patch_qwen3_vl_moe_pp_layer_range()
+
+
+# ----------------------------------------------------------------------------
+# EVS (Efficient Video Sampling) device fix for recompute_mrope_positions.
+# mrope_positions is built from numpy in get_mrope_input_positions (CPU) while
+# multimodal_embeddings live on the NPU. The EVS arithmetic inside
+# recompute_mrope_positions (mm_pos[...] + base) mixes the two and raises a
+# cross-device error on NPU. Move mrope_positions to the embeddings' device
+# before delegating to the original implementation. (No-op when already
+# co-located, e.g. on GPU.)
+# ----------------------------------------------------------------------------
+def _evs_recompute_mrope_positions_wrap(orig):
+    def wrap(self, input_ids, multimodal_embeddings, mrope_positions, num_computed_tokens):
+        if mrope_positions is not None and len(multimodal_embeddings):
+            mrope_positions = mrope_positions.to(multimodal_embeddings[0].device)
+        return orig(self, input_ids, multimodal_embeddings, mrope_positions, num_computed_tokens)
+
+    return wrap
+
+
+Qwen3VLForConditionalGeneration.recompute_mrope_positions = _evs_recompute_mrope_positions_wrap(
+    Qwen3VLForConditionalGeneration.recompute_mrope_positions
+)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3640,6 +3640,22 @@ class NPUModelRunner(GPUModelRunner):
                 if "sink" in name:
                     self._has_sinks = True
                     break
+            # [EVS] Mirror GPUModelRunner.load_model: enable the multimodal
+            # pruning (EVS) runner codepath when the model supports it and the
+            # user passed --video-pruning-rate q>0. Without this, the ascend
+            # runner leaves is_multimodal_pruning_enabled at its __init__
+            # default (False), so recompute_mrope_positions is never called
+            # and the 5 EVS position channels are not stripped before
+            # embed_input_ids (shape mismatch hidden+5 vs hidden).
+            from vllm.model_executor.models.interfaces import (
+                supports_multimodal_pruning,
+            )
+            mm_config = self.model_config.multimodal_config
+            self.is_multimodal_pruning_enabled: bool = bool(
+                supports_multimodal_pruning(self.model)
+                and mm_config is not None
+                and mm_config.is_multimodal_pruning_enabled()
+            )
             if self.dynamic_eplb:
                 model_register(self.model)
             if self.drafter:


### PR DESCRIPTION
# PR: Enable EVS video pruning for Qwen3.5 on Ascend NPU

## What & Why

Closes #10648 (task #1 of #9079: bring vLLM main-community EVS — Efficient Video Sampling, video-token compression — to NPU via the vllm-ascend plugin, using the Qwen3.5 model).

vLLM 0.21.0 already ships the full EVS pipeline (`vllm/multimodal/evs.py` + Qwen3-VL implementation). `NPUModelRunner` already inherits the runner-side integration (`recompute_mrope_positions` is called in both the non-PCP `super()._gather_mm_embeddings` path and the PCP `pcp_utils` path). The gaps that prevent it from working on NPU are all small and are fixed entirely inside vllm-ascend — **no vLLM main-repo change required**.

## Changes (all in vllm-ascend)

| commit | file | change |
|---|---|---|
| `b28fdcbd` | `vllm_ascend/worker/model_runner_v1.py` | **D.** `NPUModelRunner.load_model` sets `is_multimodal_pruning_enabled` (mirror of `GPUModelRunner.load_model`). Without it the flag stays at its `__init__` default `False`, so `recompute_mrope_positions` is never called and the 5 EVS position channels appended in `_create_final_video_embeddings` are not stripped before `embed_input_ids` → shape mismatch `hidden+5` vs `hidden` → crash. |
| `251073fc` | `vllm_ascend/patch/worker/patch_qwen3_5.py` | **A.** Re-enable EVS on Qwen3.5: `supports_multimodal_pruning=True`, drop the `NotImplementedError` override of `recompute_mrope_positions` (inherit parent), wrap `__init__` to honor `--video-pruning-rate q>0` and set the EVS attrs (`_tokenizer`/`use_deepstack`/`visual_dim`/...) that Qwen3.5's `__init__` skips (it calls `nn.Module.__init__` instead of `super().__init__`). MoE variant too. |
| `251073fc` | `vllm_ascend/patch/worker/patch_qwen3vl.py` | **B.** Wrap `recompute_mrope_positions` to move `mrope_positions` (numpy/CPU) to the embeddings' device before delegating; the EVS arithmetic `mm_pos+base` otherwise hits a cross-device error on NPU. No-op when already co-located. |
| `251073fc` | `vllm_ascend/ops/vocab_parallel_embedding.py` | **C.** Move input indices to the weight device in `_forward_origin`/`_forward_embed_tp`. The EVS path builds `repl_token_ids` on CPU and feeds them to the LM embedding lookup; NPU embedding rejects CPU indices + NPU weight. No-op for the normal path. |

## End-to-end verification

Hardware: Ascend 800T A2, cards 4–7, TP=4. Model: `Qwen3.5-27B-w8a8-mtp`. Video: 81 frames, 432×768.

| config | `--video-pruning-rate` | prompt_tokens | video-token compression | latency (prefill-bound, thinking off, ~20 out tok) | output |
|---|---|---|---|---|---|
| EVS off (baseline) | 0 | 5534 | — | 2.76 s | "A white cat wearing sunglasses is on a boat in the ocean…" |
| EVS on | 0.5 | 2846 | **−48.6%** | **2.17 s (−21%)** | "A white cat wearing sunglasses is seen sitting on a boat in the water." |

- Token compression matches the theoretical `1−q = 50%` retention (slightly above because EVS keeps the whole first frame).
- Output is semantically correct in both configs; EVS does not break correctness.
- No crash. (Prefill-bound latency improves; decode-bound/long-reasoning workloads see less benefit since decode dominates — expected.)
- Run on image `quay.io/ascend/vllm-ascend:v0.21.0rc1`, vLLM `0.21.0`, vllm-ascend `v0.21.0rc1`, `torch_npu 2.10.0`.

## How to reproduce

Requires an Ascend 910B/800T host with the Ascend driver, a Qwen3.5-27B checkpoint, and any short mp4 clip. Code review does not require NPU hardware; the steps below are for NPU owners.

```bash
# 1. Start the official image with NPU devices (adjust device list / paths to your host)
docker run -itd --privileged --net=host --shm-size=1000g \
  --device /dev/davinci0 --device /dev/davinci1 --device /dev/davinci2 --device /dev/davinci3 \
  --device=/dev/davinci_manager --device=/dev/hisi_hdc --device /dev/devmm_svm \
  -v /usr/local/dcmi:/usr/local/dcmi \
  -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
  -v /etc/hccn.conf:/etc/hccn.conf \
  -v /path/to/Qwen3.5-27B-w8a8-mtp:/weights:ro \
  -v /path/to/clip.mp4:/clip.mp4:ro \
  quay.io/ascend/vllm-ascend:v0.21.0rc1 bash

# 2. Inside the container: apply this PR onto the image's editable vllm-ascend
#    (pure-Python changes — no C rebuild needed; restart picks them up).
cd /vllm-workspace/vllm-ascend
git fetch https://github.com/csw7777/vllm-ascend evs-qwen35-npu
git checkout FETCH_HEAD

# 3. Serve Qwen3.5-27B with EVS on (q=0.5). Drop --video-pruning-rate for the q=0 baseline.
ASCEND_RT_VISIBLE_DEVICES=0,1,2,3 vllm serve /weights/Qwen3.5-27B-w8a8-mtp \
  --tensor-parallel-size 4 --quantization ascend --trust-remote-code \
  --gpu-memory-utilization 0.90 --served-model-name qwen3.5-evs \
  --video-pruning-rate 0.5

# 4. Send a video request (the media connector takes HTTP or base64 data URLs).
python - <<'PY'
import base64, json, urllib.request
b64 = base64.b64encode(open("/clip.mp4","rb").read()).decode()
payload = {"model":"qwen3.5-evs","messages":[{"role":"user","content":[
    {"type":"video_url","video_url":{"url":f"data:video/mp4;base64,{b64}"}},
    {"type":"text","text":"Describe this video in one sentence."]}]}],
    "max_tokens":64,"chat_template_kwargs":{"enable_thinking":False}}
r = urllib.request.urlopen(urllib.request.Request("http://localhost:8000/v1/chat/completions",
    data=json.dumps(payload).encode(),headers={"Content-Type":"application/json"}),timeout=300)
print(json.loads(r.read())["usage"])
PY
```

Expected: with `--video-pruning-rate 0.5`, `usage.prompt_tokens` drops to ~50% of the q=0 baseline (on an 81-frame 432×768 clip we measured 5534 → 2846, −48.6%), prefill-bound latency improves, and the answer stays correct.

## Notes / follow-ups

- The patches target vLLM `0.21.0` (the version pinned by vllm-ascend `v0.21.0rc1`). If upstream moves the Qwen3.5/Qwen3-VL EVS code, the two `patch/worker` patches may need a `vllm_version_is` guard (the file already uses this pattern for the GDN class).
- EVS benefit is concentrated on prefill-bound video workloads; for long-reasoning (decode-bound) outputs the per-request pruning overhead roughly offsets the prefill saving. Recommend evaluating alongside MTP/decode optimizations.
- AI-assisted: this PR was prepared with AI assistance (Claude). Every changed line was reviewed and the end-to-end run was verified on hardware as shown above.

Co-authored-by: Claude + GLM5.2

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
