### PR TITLE
[BugFix] Fix qwen3.5 pcp acc bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,11 +52,11 @@ repos:
     exclude: '.*\.inc\.md$|.*report_template\.md$|.*contributors\.md$|.*PULL_REQUEST_TEMPLATE\.md$'
     stages: [manual] # Only run in CI
 
-- repo: https://github.com/rhysd/actionlint
-  rev: v1.7.7
-  hooks:
-  - id: actionlint
-    exclude: '.*\.github/workflows/scripts/.*\.ya?ml$'
+# - repo: https://github.com/rhysd/actionlint
+#   rev: v1.7.7
+#   hooks:
+#   - id: actionlint
+#     exclude: '.*\.github/workflows/scripts/.*\.ya?ml$'
 
 - repo: local
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,11 +52,11 @@ repos:
     exclude: '.*\.inc\.md$|.*report_template\.md$|.*contributors\.md$|.*PULL_REQUEST_TEMPLATE\.md$'
     stages: [manual] # Only run in CI
 
-# - repo: https://github.com/rhysd/actionlint
-#   rev: v1.7.7
-#   hooks:
-#   - id: actionlint
-#     exclude: '.*\.github/workflows/scripts/.*\.ya?ml$'
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.7.7
+  hooks:
+  - id: actionlint
+    exclude: '.*\.github/workflows/scripts/.*\.ya?ml$'
 
 - repo: local
   hooks:

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -1334,31 +1334,35 @@ class PCPManager:
                 long_seq_metadata.tail_actual_seq_lengths_kv = self.extra_long_seq_kwargs["tail_actual_seq_lengths_kv"]
                 long_seq_metadata.attn_chunk_seqlens = attn_chunk_seqlens
 
-            # Generate MTP attention masks for decode requests when dcp_size > 1 with speculative decoding
+            # Generate MTP attention masks for decode requests when cp_size > 1
+            # with speculative decoding.
             if (
                 self.dcp_world_size * self.pcp_world_size > 1
                 and self.speculative_config
-                and self.num_decode_reqs > 0
                 and num_scheduled_tokens is not None
             ):
-                # Extract decode request info from input_batch and num_scheduled_tokens
-                decode_num_scheduled_tokens = num_scheduled_tokens[: self.num_decode_reqs]
-                if fixed_decode_seq_lens_cpu is not None:
-                    decode_num_computed_tokens = (
-                        fixed_decode_seq_lens_cpu[: self.num_decode_reqs] - decode_num_scheduled_tokens
-                    ).tolist()
-                else:
-                    decode_num_computed_tokens = input_batch.num_computed_tokens_cpu[: self.num_decode_reqs].tolist()
+                # Generate the mask contents for the real decode requests.
+                if self.num_decode_reqs > 0:
+                    decode_num_scheduled_tokens = num_scheduled_tokens[: self.num_decode_reqs]
+                    if fixed_decode_seq_lens_cpu is not None:
+                        decode_num_computed_tokens = (
+                            fixed_decode_seq_lens_cpu[: self.num_decode_reqs] - decode_num_scheduled_tokens
+                        ).tolist()
+                    else:
+                        decode_num_computed_tokens = input_batch.num_computed_tokens_cpu[
+                            : self.num_decode_reqs
+                        ].tolist()
 
-                dcp_mtp_attn_mask = self.generate_mtp_attention_mask_for_decode(
-                    decode_num_computed_tokens, decode_num_scheduled_tokens
-                )
-                if dcp_mtp_attn_mask is not None:
-                    self.dcp_mtp_attn_mask.np[: self.num_decode_reqs] = dcp_mtp_attn_mask
-                    self.dcp_mtp_attn_mask.copy_to_gpu(self.num_decode_reqs)
-                    long_seq_metadata.dcp_mtp_attn_mask = self.dcp_mtp_attn_mask.gpu[: self.num_decode_reqs]
-                else:
-                    long_seq_metadata.dcp_mtp_attn_mask = None
+                    dcp_mtp_attn_mask = self.generate_mtp_attention_mask_for_decode(
+                        decode_num_computed_tokens, decode_num_scheduled_tokens
+                    )
+                    if dcp_mtp_attn_mask is not None:
+                        self.dcp_mtp_attn_mask.np[: self.num_decode_reqs] = dcp_mtp_attn_mask
+                        self.dcp_mtp_attn_mask.copy_to_gpu(self.num_decode_reqs)
+                # Always expose the (stable, pre-allocated) MTP mask buffer
+                # for cp>1 + speculative decode, even when num_decode_reqs == 0.
+                mask_n = self.num_decode_reqs if self.num_decode_reqs > 0 else num_reqs
+                long_seq_metadata.dcp_mtp_attn_mask = self.dcp_mtp_attn_mask.gpu[:mask_n]
             else:
                 long_seq_metadata.dcp_mtp_attn_mask = None
 


### PR DESCRIPTION
### What this PR does / why we need it?
#### Fix mtp+pcp acc bug
  Symptom: With pcp=2 + MTP (num_spec=3) + FULL_DECODE_ONLY cudagraph, GPQA-diamond drops from 88% (pcp=1) to 72%. ~10% of greedy generations collapse into repetition loops and never emit Answer:. Eager
  mode is correct; only graph mode breaks; only MTP breaks (TND/non-MTP decode is fine).

  Root cause (confirmed by instrumentation, not inference): The MTP-verify decode graph is captured during warmup with a synthetic batch where num_decode_reqs == 0. The mask generation in
  generate_pcp_metadata (vllm_ascend/worker/pcp_utils.py) is gated on num_decode_reqs > 0, so at capture time the dcp_mtp_attn_mask is skipped and set to None — and that None is baked into the captured 
  graph (_forward_decode_pcp_dcp stores weak_ref_tensors(attn_mask)=None). On every replay the MTP causal mask over the 4 speculative query positions is never applied → attention corruption → repetition
  collapse.

  - num_decode_reqs == 0 at capture because the warmup dummies have num_computed_tokens == 0, so classify_decode_request_mask returns has_context = False for all of them — even though num_decodes (the
  split-based count) is 4. This dummy-count mismatch is the crux.
  - Verified: graph replay attn_mask = None for all steps; eager-MTP applies a real mask (num_decodes, 4, max_model_len).

  Fix (generate_pcp_metadata): Drop the num_decode_reqs > 0 gate on the outer condition; generate + copy_to_gpu mask content only when num_decode_reqs > 0, but always expose the stable pre-allocated 
  buffer self.dcp_mtp_attn_mask.gpu[:mask_n] (non-None) for cp>1 + speculative decode, where mask_n = num_decode_reqs if > 0 else num_reqs (num_reqs is fixed per graph bucket). This makes the captured
  graph hold a refreshable mask tensor whose contents are rewritten every real decode step.

  Result: 72% → 86% (43/50), degenerate samples ~5/48 → 1/42, mask now propagates to replay (non-None). All three features kept.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
