### PR TITLE
[BugFix][MoE] Fall back to native experts selection when CANN rejects renorm=1

### DIFF
--- a/tests/ut/ops/a3_2/test_select_experts.py
+++ b/tests/ut/ops/a3_2/test_select_experts.py
@@ -22,7 +22,12 @@ from pytest_mock import MockerFixture
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_forward_context import MoECommType
-from vllm_ascend.ops.fused_moe.experts_selector import select_experts, zero_experts_compute
+from vllm_ascend.ops.fused_moe import experts_selector as experts_selector_module
+from vllm_ascend.ops.fused_moe.experts_selector import (
+    check_npu_moe_gating_top_k,
+    select_experts,
+    zero_experts_compute,
+)
 from vllm_ascend.ops.fused_moe.moe_runtime_args import MoEPrepareOutput
 from vllm_ascend.utils import AscendDeviceType, adapt_patch, enable_custom_op
 
@@ -479,6 +484,96 @@ class TestExpertsSelector:
                 e_score_correction_bias=None,
                 num_experts=4,
             )
+
+    @patch("vllm_ascend.ops.fused_moe.experts_selector.get_weight_prefetch_method", return_value=MagicMock())
+    @patch("vllm_ascend.ops.fused_moe.experts_selector.check_npu_moe_gating_top_k", return_value=True)
+    def test_select_experts_falls_back_when_fused_renorm_unsupported(self, _, __):
+        # Some CANN versions reject aclnnMoeGatingTopK with renorm != 0.
+        # The fused path should catch that error once, flip the module
+        # capability flag, and route subsequent renormalize=True calls
+        # through the native path.
+        original_flag = experts_selector_module._fused_moe_gating_renorm_supported
+        experts_selector_module._fused_moe_gating_renorm_supported = True
+        try:
+            hidden_states = torch.randn(4, 8)
+            router_logits = torch.randn(4, 8)
+            renorm_err = RuntimeError(
+                "EZ9999: Inner Error! aclnnMoeGatingTopK failed: renorm is: 1, but currently only support 0"
+            )
+            with patch(
+                "vllm_ascend.ops.fused_moe.experts_selector._select_experts_with_fusion_ops",
+                side_effect=renorm_err,
+            ) as fused_mock:
+                topk_weights, topk_ids = select_experts(
+                    hidden_states=hidden_states,
+                    router_logits=router_logits,
+                    top_k=2,
+                    use_grouped_topk=False,
+                    renormalize=True,
+                    topk_group=None,
+                    num_expert_group=None,
+                    custom_routing_function=None,
+                    scoring_func="softmax",
+                    e_score_correction_bias=None,
+                    num_experts=8,
+                )
+                fused_mock.assert_called_once()
+
+            assert topk_weights.shape == (4, 2)
+            assert topk_ids.shape == (4, 2)
+            assert not experts_selector_module._fused_moe_gating_renorm_supported
+
+            # After the flag flips, check_npu_moe_gating_top_k must
+            # report False for renormalize=True regardless of other
+            # conditions, so we re-enable real check to confirm.
+            assert (
+                check_npu_moe_gating_top_k(
+                    hidden_states=hidden_states,
+                    top_k=2,
+                    renormalize=True,
+                    topk_group=1,
+                    num_expert_group=1,
+                    scoring_func="softmax",
+                )
+                is False
+            )
+        finally:
+            experts_selector_module._fused_moe_gating_renorm_supported = original_flag
+
+    @patch("vllm_ascend.ops.fused_moe.experts_selector.get_weight_prefetch_method", return_value=MagicMock())
+    @patch("vllm_ascend.ops.fused_moe.experts_selector.check_npu_moe_gating_top_k", return_value=True)
+    def test_select_experts_reraises_unrelated_fused_errors(self, _, __):
+        # Errors that are not the renorm-capability mismatch must
+        # propagate; we only want to swallow the one specific failure.
+        original_flag = experts_selector_module._fused_moe_gating_renorm_supported
+        experts_selector_module._fused_moe_gating_renorm_supported = True
+        try:
+            hidden_states = torch.randn(4, 8)
+            router_logits = torch.randn(4, 8)
+            unrelated = RuntimeError("some other NPU failure")
+            with (
+                patch(
+                    "vllm_ascend.ops.fused_moe.experts_selector._select_experts_with_fusion_ops",
+                    side_effect=unrelated,
+                ),
+                pytest.raises(RuntimeError, match="some other NPU failure"),
+            ):
+                select_experts(
+                    hidden_states=hidden_states,
+                    router_logits=router_logits,
+                    top_k=2,
+                    use_grouped_topk=False,
+                    renormalize=True,
+                    topk_group=None,
+                    num_expert_group=None,
+                    custom_routing_function=None,
+                    scoring_func="softmax",
+                    e_score_correction_bias=None,
+                    num_experts=8,
+                )
+            assert experts_selector_module._fused_moe_gating_renorm_supported is True
+        finally:
+            experts_selector_module._fused_moe_gating_renorm_supported = original_flag
 
 
 class TestFusedMoENPUOpsAccuracy:

--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -26,6 +26,23 @@ from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.utils import split_tensor_along_first_dim
 from vllm_ascend.utils import get_weight_prefetch_method
 
+# Process-wide cache for runtime CANN capability. Some CANN versions reject
+# aclnnMoeGatingTopK with renorm != 0. On the first such failure we flip
+# this flag so subsequent renormalize=True calls take the native path.
+# On CANN versions that support renorm=1 this flag stays True and the
+# fused kernel is used as before.
+_fused_moe_gating_renorm_supported: bool = True
+
+
+def _disable_fused_moe_gating_renorm() -> None:
+    global _fused_moe_gating_renorm_supported
+    _fused_moe_gating_renorm_supported = False
+
+
+def _is_renorm_unsupported_error(exc: BaseException) -> bool:
+    msg = str(exc)
+    return "MoeGatingTopK" in msg and "renorm" in msg
+
 
 def select_experts(
     hidden_states: torch.Tensor,
@@ -83,21 +100,32 @@ def select_experts(
     )
 
     if is_support_npu_moe_gating_top_k:
-        topk_weights, topk_ids = _select_experts_with_fusion_ops(
-            hidden_states=hidden_states,
-            router_logits=router_logits,
-            top_k=top_k,
-            use_grouped_topk=use_grouped_topk,
-            topk_group=topk_group,
-            renormalize=renormalize,
-            e_score_correction_bias=e_score_correction_bias,
-            num_expert_group=num_expert_group,
-            scoring_func=scoring_func,
-            routed_scaling_factor=routed_scaling_factor,
-            tid2eid=tid2eid,
-            input_ids=input_ids,
-        )
-    else:
+        try:
+            topk_weights, topk_ids = _select_experts_with_fusion_ops(
+                hidden_states=hidden_states,
+                router_logits=router_logits,
+                top_k=top_k,
+                use_grouped_topk=use_grouped_topk,
+                topk_group=topk_group,
+                renormalize=renormalize,
+                e_score_correction_bias=e_score_correction_bias,
+                num_expert_group=num_expert_group,
+                scoring_func=scoring_func,
+                routed_scaling_factor=routed_scaling_factor,
+                tid2eid=tid2eid,
+                input_ids=input_ids,
+            )
+        except RuntimeError as exc:
+            # Some CANN versions reject aclnnMoeGatingTopK with renorm != 0.
+            # Fall back to the native path once and remember the capability
+            # so subsequent forwards skip the failing fused call.
+            if renormalize and _is_renorm_unsupported_error(exc):
+                _disable_fused_moe_gating_renorm()
+                is_support_npu_moe_gating_top_k = False
+            else:
+                raise
+
+    if not is_support_npu_moe_gating_top_k:
         topk_weights, topk_ids = _native_select_experts(
             hidden_states=hidden_states,
             router_logits=router_logits,
@@ -146,6 +174,10 @@ def check_npu_moe_gating_top_k(
     custom_routing_function: Callable | None = None,
 ):
     if scoring_func == "sigmoid" and not renormalize:  # sigmoid + renorm=0 is not supported in current branch
+        return False
+    # On CANN versions that rejected aclnnMoeGatingTopK with renorm != 0
+    # earlier in this process, skip the fused path for renormalize=True.
+    if renormalize and not _fused_moe_gating_renorm_supported:
         return False
     if custom_routing_function is not None:
         return False

--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -40,8 +40,10 @@ def _disable_fused_moe_gating_renorm() -> None:
 
 
 def _is_renorm_unsupported_error(exc: BaseException) -> bool:
-    msg = str(exc)
-    return "MoeGatingTopK" in msg and "renorm" in msg
+    # Normalize so we tolerate casing/underscore variants across CANN
+    # releases (e.g. "MoeGatingTopK", "moe_gating_top_k", "MoeGatingTopk").
+    msg = str(exc).lower().replace("_", "")
+    return "moegatingtopk" in msg and "renorm" in msg
 
 
 def select_experts(


### PR DESCRIPTION
Some CANN releases reject aclnnMoeGatingTopK with renorm != 0 (e.g. "aclnnMoeGatingTopK failed: renorm is: 1, but currently only support 0"), which crashes any MoE model whose router uses norm_topk_prob=True (Qwen3-MoE family, etc.) on those toolkit versions.

Detect the failure at the first fused call, flip a process-wide capability flag, and route subsequent renormalize=True calls to the existing native selection path. On CANN versions where renorm=1 is supported the flag stays True and behavior is unchanged.

Adds two unit tests in tests/ut/ops/a3_2/test_select_experts.py:
- the fused path raising the renorm-capability RuntimeError is caught, the flag flips, and the native path returns valid topk tensors;
- unrelated RuntimeErrors from the fused path still propagate and do not flip the flag.

## Reproducer environment                                                                                                                                          
                                                                                                                                                                     
The original failure was observed under:                                                                                                                           
                                                                              
- CANN: 8.5.1 (innerversion `V100R001C25SPC002B220`, branch `br_release_cann_8.5.0_20260527`)                                                                      
- NNAL atb: 8.5.1.B080                            
- vllm-ascend: 0.18.0rc1                                                                                                                                           
- Hardware: Ascend 910B1                                                                                                                                           
                                                                                                                                                                     
Workload: Qwen3-30B-A3B (MoE, `norm_topk_prob=true` → `renormalize=True`), which exercises the `aclnnMoeGatingTopK` path with `renorm=1`. Before the patch every forward raised `EZ9999: ... renorm is: 1, but currently only support 0`; with the patch the first attempt fails once, the module-level flag flips, and subsequent forwards take the native path with no further exception overhead. 

### What this PR does / why we need it?
Some CANN releases reject `aclnnMoeGatingTopK` with `renorm != 0`, e.g. 
EZ9999: Inner Error! aclnnMoeGatingTopK failed: renorm is: 1, but currently only support 0
This crashes any MoE model whose router uses `norm_topk_prob=True` (Qwen3-MoE family, etc.) on those toolkit versions. Reproduced on vllm-ascend 0.18.0rc1 with Qwen3-30B-A3B on Ascend 910B1.

The fused path `_select_experts_with_fusion_ops` calls `DeviceOperator.moe_gating_top_k(..., renorm=int(renormalize), ...)`. When the kernel raises the renorm-capability mismatch, we now:

1. Catch the `RuntimeError` once at the `select_experts` call site
2. Flip a process-wide flag `_fused_moe_gating_renorm_supported`
3. Fall through to the existing `_native_select_experts` path for this and subsequent `renormalize=True` calls

On CANN versions where `renorm=1` is supported the flag stays `True` and behavior is unchanged. The fallback path is the same one already used when `check_npu_moe_gating_top_k` returns `False` for other reasons.

### Does this PR introduce _any_ user-facing change?
No. Same outputs, same API. On affected CANN versions, models that previously crashed at the MoE gating step now run through the native path.

### How was this patch tested?
Added two unit tests in `tests/ut/ops/a3_2/test_select_experts.py`:
- `test_select_experts_falls_back_when_fused_renorm_unsupported` — fused path raising the renorm-capability `RuntimeError` is caught, the module flag flips, native path returns valid topk tensors, and `check_npu_moe_gating_top_k` reports `False` for subsequent `renormalize=True` calls.
- `test_select_experts_reraises_unrelated_fused_errors` — unrelated `RuntimeError`s from the fused path still propagate and do not flip the flag.

End-to-end verified on Ascend 910B1 with Qwen3-30B-A3B (`norm_topk_prob=true`, 128 routed / 6 active experts): pre-patch all 12 prompt/decode/batch cells crashed with the `renorm=1` error; post-patch the fused call falls back to native once and the model runs to completion.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
