### PR TITLE
[BugFix] fix dsv32 nightly

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3_2-W8A8-A3-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3_2-W8A8-A3-dual-nodes.yaml
@@ -32,7 +32,7 @@ deployment:
       --quantization ascend
       --seed 1024
       --enable-expert-parallel
-      --max-num-seqs 16
+      --max-num-seqs 128
       --max-model-len 90000
       --max-num-batched-tokens 4096
       --no-enable-prefix-caching
@@ -58,7 +58,7 @@ deployment:
       --quantization ascend
       --seed 1024
       --enable-expert-parallel
-      --max-num-seqs 16
+      --max-num-seqs 128
       --max-model-len 90000
       --max-num-batched-tokens 4096
       --no-enable-prefix-caching
@@ -100,7 +100,7 @@ benchmarks:
     dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
     num_prompts: 512
     max_out_len: 3000
-    batch_size: 1
+    batch_size: 256
     request_rate: 11.2
     baseline: 305.2903 
     threshold: 0.97
@@ -111,7 +111,7 @@ benchmarks:
     request_conf: vllm_api_general_chat
     dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_chat_prompt
     max_out_len: 4096
-    batch_size: 64
+    batch_size: 128
     baseline: 95
     threshold: 5
 


### PR DESCRIPTION
### What this PR does / why we need it?
fix dsv32 nightly：The original batch size is too small, which causes the performance test to time out. Therefore, the batch size is increased to 256.
### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?
nightly test
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
