### PR TITLE
[v0.18.0] feat(fused_moe): add before_gmm2 sync event for multi-stream shared expert overlap

### DIFF
--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -57,6 +57,7 @@ from vllm_ascend.utils import (
 class FusedMoEResult:
     routed_out: torch.Tensor
     before_dispatch_evt: torch.npu.Event | None = None
+    before_gmm2_evt: torch.npu.Event | None = None
     before_combine_evt: torch.npu.Event | None = None
 
 
@@ -64,6 +65,7 @@ class FusedMoEResult:
 class FusedMoEEvents:
     before_routed_experts: torch.npu.Event
     before_dispatch: torch.npu.Event | None = field(default=None)
+    before_gmm2: torch.npu.Event | None = field(default=None)
     before_combine: torch.npu.Event | None = field(default=None)
 
 
@@ -559,6 +561,7 @@ class AscendFusedMoE(FusedMoE):
             return FusedMoEResult(
                 routed_out=routed_out,
                 before_dispatch_evt=fused_experts_results.before_dispatch_evt,
+                before_gmm2_evt=fused_experts_results.before_gmm2_evt,
                 before_combine_evt=fused_experts_results.before_combine_evt,
             )
         else:
@@ -693,14 +696,65 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
         with npu_stream_switch(shared_experts_calculation_stream(), enabled=self.multistream_overlap_shared_expert):
             # Ensure the shared experts wait for hidden_states to be ready.
             torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
-            # Execute the gate projection and activation concurrently with the
-            # dispatch communication.
-            maybe_wait_event(fused_moe_evts.before_dispatch)
-            part1_out = self._shared_experts_part1(hidden_states)
-            # Execute the down projection concurrently with the combine
-            # communication.
-            maybe_wait_event(fused_moe_evts.before_combine)
-            shared_out = self._shared_experts_part2(hidden_states, part1_out)
+            # Stage 1: input dynamic_quant (vec) -- runs right after the original
+            # wait(before_routed_experts) above, overlapping with prepare.
+            original_dtype = hidden_states.dtype
+            has_quantized_up = hasattr(self._shared_experts.gate_up_proj, "weight_scale")
+            has_quantized_down = hasattr(self._shared_experts.down_proj, "weight_scale")
+
+            if has_quantized_up:
+                quantized_x, pertoken_scale_x = torch_npu.npu_dynamic_quant(hidden_states)
+                # squeeze handling consistent with AscendW8A8DynamicLinearMethod.apply()
+                if pertoken_scale_x.dim() == 2:
+                    quantized_x = quantized_x.squeeze(dim=1)
+                    pertoken_scale_x = pertoken_scale_x.squeeze(dim=1)
+
+                # Stage 2: gate_up_proj matmul (cube)
+                # Does NOT wait for before_dispatch; stage1->stage2 run back-to-back
+                # (consistent with the 0.20.2rc1 non-internal-router mode). Launching
+                # QuantMatmul early reduces cube contention with GroupGmmSwigluQuant.
+                gate_up_out = torch_npu.npu_quant_matmul(
+                    quantized_x,
+                    self._shared_experts.gate_up_proj.weight,
+                    self._shared_experts.gate_up_proj.weight_scale,
+                    pertoken_scale=pertoken_scale_x,
+                    bias=None,
+                    output_dtype=original_dtype,
+                )
+            else:
+                gate_up_out, _ = self._shared_experts.gate_up_proj(hidden_states)  # type: ignore
+
+            # Stage 3: SwiGLU + dynamic_quant (vec)
+            # Wait for before_gmm2 to overlap with gmm2 (vec vs cube).
+            maybe_wait_event(fused_moe_evts.before_gmm2)
+            shared_act = self._shared_experts.act_fn(gate_up_out)  # type: ignore
+
+            if has_quantized_down:
+                quantized_act, pertoken_scale_act = torch_npu.npu_dynamic_quant(shared_act)
+                # squeeze handling, consistent with stage 1 and apply().
+                if pertoken_scale_act.dim() == 2:
+                    quantized_act = quantized_act.squeeze(dim=1)
+                    pertoken_scale_act = pertoken_scale_act.squeeze(dim=1)
+
+                # Stage 4: down_proj matmul (cube)
+                # Wait for before_combine to overlap with combine (cube vs comm).
+                maybe_wait_event(fused_moe_evts.before_combine)
+                shared_out = torch_npu.npu_quant_matmul(
+                    quantized_act,
+                    self._shared_experts.down_proj.weight,
+                    self._shared_experts.down_proj.weight_scale,
+                    pertoken_scale=pertoken_scale_act,
+                    bias=None,
+                    output_dtype=original_dtype,
+                )
+            else:
+                maybe_wait_event(fused_moe_evts.before_combine)
+                shared_out, _ = self._shared_experts.down_proj(shared_act)  # type: ignore
+
+            # Qwen3-Next gating (not used by DeepSeek V3.1, kept for compatibility).
+            if hasattr(self._shared_experts, "expert_gate") and self._shared_experts.expert_gate is not None:
+                gate_out, _ = self._shared_experts.expert_gate(hidden_states)  # type: ignore
+                shared_out = F.sigmoid(gate_out) * shared_out
 
         # Make sure the default stream waits for the shared experts stream to
         # finish.
@@ -745,6 +799,7 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
                 FusedMoEEvents(
                     before_routed_experts=before_routed_experts,
                     before_dispatch=fused_moe_results.before_dispatch_evt,
+                    before_gmm2=fused_moe_results.before_gmm2_evt,
                     before_combine=fused_moe_results.before_combine_evt,
                 ),
             )

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -73,6 +73,7 @@ class FusedExpertsResult:
     # communication method that supports shared experts in parallel with routed
     # experts.
     before_dispatch_evt: torch.npu.Event | None = None
+    before_gmm2_evt: torch.npu.Event | None = None
     before_combine_evt: torch.npu.Event | None = None
     # For dynamic_eplb
     group_list_type: int = 1
@@ -141,7 +142,7 @@ class MoECommMethod(ABC):
             use_fusion_ops=self.use_fusion_ops,
         )
 
-        mlp_output = self._apply_mlp(mlp_compute_input)
+        mlp_output, before_gmm2_evt = self._apply_mlp(mlp_compute_input)
 
         before_combine_evt = torch.npu.current_stream().record_event()
         routed_out = self.token_dispatcher.token_combine(
@@ -152,6 +153,7 @@ class MoECommMethod(ABC):
         return FusedExpertsResult(
             routed_out=routed_out,
             before_dispatch_evt=before_dispatch_evt,
+            before_gmm2_evt=before_gmm2_evt,
             before_combine_evt=before_combine_evt,
             group_list_type=token_dispatch_output.group_list_type,
             expert_tokens=token_dispatch_output.group_list,

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -190,6 +190,7 @@ def quant_apply_mlp(
                 activate_left=True,
                 quant_mode=1,
             )
+        before_gmm2_evt = torch.npu.current_stream().record_event()
         # gmm2: down_proj
         hidden_states = DeviceOperator.npu_grouped_matmul_gmm2(
             hidden_states=hidden_states,
@@ -224,6 +225,7 @@ def quant_apply_mlp(
         dispose_tensor(unquantized_hidden_states)
         # act_fn: swiglu
         hidden_states = torch_npu.npu_swiglu(hidden_states)
+        before_gmm2_evt = torch.npu.current_stream().record_event()
         # gmm2: down_proj
         hidden_states = torch_npu.npu_grouped_matmul(
             x=[hidden_states],
@@ -295,6 +297,7 @@ def quant_apply_mlp(
             else:
                 hidden_states = torch_npu.npu_swiglu(hidden_states)
                 hidden_states, swiglu_out_scale = torch_npu.npu_dynamic_quant(hidden_states)
+        before_gmm2_evt = torch.npu.current_stream().record_event()
         # gmm2: down_proj
         hidden_states = DeviceOperator.npu_grouped_matmul_gmm2(
             hidden_states=hidden_states,
@@ -313,7 +316,7 @@ def quant_apply_mlp(
             bias=bias2,
             fallback_output_dtype=_output_dtype,
         )
-    return hidden_states
+    return hidden_states, before_gmm2_evt
 
 
 def unquant_apply_mlp(
@@ -360,7 +363,7 @@ def unquant_apply_mlp(
         group_type=0,
         group_list=group_list,
     )[0]
-    return hidden_states
+    return hidden_states, None
 
 
 def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:


### PR DESCRIPTION
 ### What this PR does / why we need it?

  Adds a `before_gmm2` sync event to the `multistream_overlap_shared_expert` path on the 0.18.0 release
  line.

  Currently the shared expert's SwiGLU + down-projection must wait for the entire routed MLP to finish
  (the only sync point after gate/up-projection is `before_combine`), so the shared cube work serializes
  against the routed experts. This records a `before_gmm2` event right before routed-expert gmm2 and
  splits `_forward_shared_experts` into four overlap stages so the shared SwiGLU (vec) overlaps with
  routed gmm2 (cube):

  - Stage 1: input `npu_dynamic_quant` (vec) — overlaps with prepare
  - Stage 2: `gate_up_proj` QuantMatmul (cube) — overlaps with dispatch
  - Stage 3: SwiGLU + `npu_dynamic_quant` (vec) — `wait(before_gmm2)`, overlaps with gmm2
  - Stage 4: `down_proj` QuantMatmul (cube) — `wait(before_combine)`, overlaps with combine

  Stage 2 deliberately does not wait for `before_dispatch` so the gate/up QuantMatmul launches as early as
  possible, reducing cube contention with routed `GroupGmmSwigluQuant` — matching the timing adopted
  upstream from 0.20.2rc1 onward.

  Files: `moe_mlp.py`, `moe_comm_method.py`, `fused_moe.py` (3 files, +71/-11).

  ### Does this PR introduce _any_ user-facing change?

  No. Internal optimization of the existing `multistream_overlap_shared_expert` path — no API, config, or
  model change; output is unchanged.

  ### How was this patch tested?

  Dual-machine 16-card DP2TP8+EP16, DeepSeek-V3.1 W8A8. Verified inference output matches the unmodified
  0.18.0 baseline, and NPU profiling confirms the shared SwiGLU stage now
  overlaps with routed gmm2 instead of serializing behind the full MLP.
- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
