### PR TITLE
[Feature] Support Gemma4 large-head attention on A2

### DIFF
--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -16,7 +16,13 @@ from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
     cache_graph_workspace,
     needs_layer_aware_fia_graph_replay,
+    using_paged_attention,
 )
+from vllm_ascend.device.device_op import A5DeviceAdaptor
+from vllm_ascend.device.utils import FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE
+from vllm_ascend.utils import AscendDeviceType
+
+LARGE_HEAD_PREFILL_PATH = "vllm_ascend.device.utils.npu_large_head_prefill_attention"
 
 
 class TestAttentionGraphHelpers(TestBase):
@@ -37,6 +43,12 @@ class TestAttentionGraphHelpers(TestBase):
 
         self.assertEqual(result.numel(), 8)
         self.assertEqual(graph_params.workspaces[1].numel(), 8)
+
+    def test_large_head_uses_paged_attention_on_a2(self):
+        vllm_config = MagicMock()
+        vllm_config.speculative_config = None
+        with patch("vllm_ascend.attention.utils.get_ascend_device_type", return_value=AscendDeviceType.A2):
+            self.assertTrue(using_paged_attention(1, vllm_config, head_size=FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE))
 
 
 class TestAscendAttentionBackend(TestBase):
@@ -263,6 +275,110 @@ class TestAscendAttentionBackendImpl(TestBase):
             kv_sharing_target_layer_name=None,
             sinks=torch.tensor([-3.4062], dtype=torch.bfloat16),
         )
+
+        self.impl_large_head = AscendAttentionBackendImpl(
+            num_heads=8,
+            head_size=FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE,
+            scale=1.0,
+            num_kv_heads=8,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="float16",
+            logits_soft_cap=None,
+            attn_type=self.attention_type.DECODER,
+            kv_sharing_target_layer_name=None,
+        )
+
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    def test_large_head_prefill_uses_device_operator_fallback(self, mock_get_forward_context):
+        query = torch.randn(2, 8, FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE)
+        key = torch.randn(2, 8, FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE)
+        value = torch.randn(2, 8, FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE)
+        output = torch.empty_like(query)
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.PrefillNoCache
+        metadata.actual_seq_lengths_q = [2]
+        metadata.causal = True
+        metadata.attn_mask = None
+        mock_get_forward_context.return_value = MagicMock(capturing=False)
+
+        with patch(LARGE_HEAD_PREFILL_PATH, return_value=(torch.ones_like(query), None)) as mock_forward:
+            result = self.impl_large_head.forward_impl(query, key, value, (), metadata, output)
+
+        mock_forward.assert_called_once()
+        self.assertIs(result, output)
+        self.assertTrue(torch.equal(result, torch.ones_like(query)))
+
+    def test_supported_head_prefill_uses_fia(self):
+        query = torch.randn(2, 8, 64)
+        key = torch.randn(2, 8, 64)
+        value = torch.randn(2, 8, 64)
+        output = torch.empty_like(query)
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.PrefillNoCache
+        metadata.actual_seq_lengths_q = [2]
+
+        self.impl.forward_fused_infer_attention = MagicMock(return_value=output)
+        with patch(LARGE_HEAD_PREFILL_PATH, return_value=(torch.empty_like(query), None)) as mock_forward:
+            result = self.impl.forward_impl(query, key, value, (), metadata, output)
+
+        mock_forward.assert_not_called()
+        self.impl.forward_fused_infer_attention.assert_called_once()
+        self.assertIs(result, output)
+
+    @patch("vllm_ascend.attention.attention_v1.using_paged_attention", return_value=True)
+    def test_decode_uses_paged_attention(self, mock_using_pa):
+        query = torch.randn(2, 8, FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE)
+        output = torch.empty_like(query)
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.DecodeOnly
+
+        self.impl_large_head.forward_paged_attention = MagicMock(return_value=output)
+        self.impl_large_head.forward_fused_infer_attention = MagicMock(return_value=output)
+
+        result = self.impl_large_head.forward_impl(query, None, None, (), metadata, output)
+
+        self.impl_large_head.forward_paged_attention.assert_called_once()
+        self.impl_large_head.forward_fused_infer_attention.assert_not_called()
+        self.assertIs(result, output)
+        mock_using_pa.assert_called_once()
+
+    @patch("torch_npu.npu_fused_infer_attention_score")
+    def test_a5_device_operator_uses_fia_for_large_head(self, mock_fia):
+        query = torch.randn(2, 8, FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE)
+        key = torch.randn(2, 8, FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE)
+        value = torch.randn(2, 8, FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE)
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.PrefillNoCache
+        metadata.actual_seq_lengths_q = [2]
+
+        mock_fia.return_value = (torch.ones_like(query), None)
+        with patch(LARGE_HEAD_PREFILL_PATH, return_value=(torch.empty_like(query), None)) as mock_forward:
+            result = A5DeviceAdaptor.npu_fused_infer_attention_score(
+                query=query,
+                key=key,
+                value=value,
+                attn_metadata=metadata,
+                key_cache=None,
+                value_cache=None,
+                current_key=key,
+                current_value=value,
+                num_heads=8,
+                num_key_value_heads=8,
+                head_size=FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE,
+                scale=1.0,
+                is_prefill_no_cache=True,
+                block_table=None,
+                input_layout="TND",
+                block_size=128,
+                actual_seq_lengths=[2],
+                actual_seq_lengths_kv=[2],
+                sparse_mode=3,
+            )
+
+        mock_forward.assert_not_called()
+        mock_fia.assert_called_once()
+        self.assertEqual(result[0].shape, query.shape)
 
     def test_forward_no_attn_metadata(self):
         """Test forward pass when attn_metadata is None"""

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -1249,6 +1249,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 output[:num_tokens] = attn_output[:num_tokens]
                 return output
         passed_key = key
+        passed_value = value
         key, value, block_size, block_table, actual_seq_lengths_kv = self._get_fia_params(
             key, value, attn_metadata, kv_cache
         )
@@ -1328,7 +1329,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     sparse_mode=4,
                 )
             else:
-                attn_output, _ = torch_npu.npu_fused_infer_attention_score(
+                attn_output, _ = DeviceOperator.npu_fused_infer_attention_score(
                     query=query,
                     key=key,
                     value=value,
@@ -1340,7 +1341,14 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     actual_seq_lengths_kv=actual_seq_lengths_kv,
                     num_key_value_heads=self.num_kv_heads,
                     num_heads=self.num_heads,
+                    head_size=self.head_size,
                     scale=self.scale,
+                    key_cache=self.key_cache,
+                    value_cache=self.value_cache,
+                    current_key=passed_key,
+                    current_value=passed_value,
+                    attn_metadata=attn_metadata,
+                    is_prefill_no_cache=attn_metadata.attn_state == AscendAttentionState.PrefillNoCache,
                     sparse_mode=3,
                 )
 
@@ -1454,10 +1462,11 @@ class AscendAttentionBackendImpl(AttentionImpl):
         output: torch.Tensor,
     ):
         num_tokens = query.shape[0]
+
         if (
             attn_metadata.attn_state == AscendAttentionState.DecodeOnly
-            and using_paged_attention(num_tokens, self.vllm_config)
             and self.sliding_window is None
+            and using_paged_attention(num_tokens, self.vllm_config, self.head_size)
         ):
             output = self.forward_paged_attention(query, attn_metadata, output)
         else:

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -9,6 +9,7 @@ from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 
+from vllm_ascend.device.utils import FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE
 from vllm_ascend.utils import (
     AscendDeviceType,
     get_ascend_config,
@@ -83,11 +84,16 @@ def ascend_chunked_prefill_workspace_size(vllm_config: VllmConfig) -> int:
     return chunked_prefill_workspace_size
 
 
-def using_paged_attention(runtime_shape: int, vllm_config: VllmConfig) -> bool:
+def using_paged_attention(runtime_shape: int, vllm_config: VllmConfig, head_size: int | None = None) -> bool:
     if vllm_config.speculative_config is not None:
         return False
     if get_ascend_device_type() == AscendDeviceType.A5:
         return False
+    # TODO: Remove this fallback when A2/A3 FIA TND supports Gemma4's
+    # 512-dim global attention heads. Decode can use PA directly; prefill is
+    # handled by the device adaptor.
+    if head_size == FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE:
+        return True
     from vllm.config.compilation import CUDAGraphMode
 
     cudagraph_mode = vllm_config.compilation_config.cudagraph_mode

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -22,6 +22,7 @@ import torch.nn.functional as F
 import torch_npu
 from vllm.triton_utils import HAS_TRITON
 
+from vllm_ascend.device import utils as device_utils
 from vllm_ascend.device.mxfp_compat import (
     FLOAT8_E8M0FNU_DTYPE,
     QUANT_DTYPES,
@@ -47,6 +48,54 @@ class BaseDeviceAdaptor:
     def reshape_and_cache(cls, key, value, key_cache, value_cache, slot_mapping):
         torch_npu._npu_reshape_and_cache(
             key=key, value=value, key_cache=key_cache, value_cache=value_cache, slot_indices=slot_mapping
+        )
+
+    @classmethod
+    def npu_fused_infer_attention_score(
+        cls,
+        query: torch.Tensor,
+        key: torch.Tensor | None,
+        value: torch.Tensor | None,
+        attn_metadata: Any,
+        *,
+        key_cache: torch.Tensor | None,
+        value_cache: torch.Tensor | None,
+        current_key: torch.Tensor,
+        current_value: torch.Tensor,
+        num_heads: int,
+        num_key_value_heads: int,
+        head_size: int,
+        scale: float,
+        is_prefill_no_cache: bool,
+        **kwargs,
+    ):
+        # TODO: Remove this fallback when A2/A3 FIA TND supports Gemma4's
+        # 512-dim global attention heads. The FIA path slices/replaces
+        # query/key/value before this wrapper, so large-head prefill fallback
+        # must use the original current-token K/V.
+        if head_size == device_utils.FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE:
+            return device_utils.npu_large_head_prefill_attention(
+                query,
+                current_key,
+                current_value,
+                attn_metadata,
+                key_cache=key_cache,
+                value_cache=value_cache,
+                num_heads=num_heads,
+                num_kv_heads=num_key_value_heads,
+                head_size=head_size,
+                scale=scale,
+                is_prefill_no_cache=is_prefill_no_cache,
+            )
+
+        return torch_npu.npu_fused_infer_attention_score(
+            query=query,
+            key=key,
+            value=value,
+            num_key_value_heads=num_key_value_heads,
+            num_heads=num_heads,
+            scale=scale,
+            **kwargs,
         )
 
     @staticmethod
@@ -806,6 +855,35 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             value_cache=value_cache,
             slot_mapping=slot_mapping.contiguous(),
             cache_mode="Norm",
+        )
+
+    @classmethod
+    def npu_fused_infer_attention_score(
+        cls,
+        query: torch.Tensor,
+        key: torch.Tensor | None,
+        value: torch.Tensor | None,
+        attn_metadata: Any,
+        *,
+        key_cache: torch.Tensor | None,
+        value_cache: torch.Tensor | None,
+        current_key: torch.Tensor,
+        current_value: torch.Tensor,
+        num_heads: int,
+        num_key_value_heads: int,
+        head_size: int,
+        scale: float,
+        is_prefill_no_cache: bool,
+        **kwargs,
+    ):
+        return torch_npu.npu_fused_infer_attention_score(
+            query=query,
+            key=key,
+            value=value,
+            num_key_value_heads=num_key_value_heads,
+            num_heads=num_heads,
+            scale=scale,
+            **kwargs,
         )
 
     @staticmethod

--- a/vllm_ascend/device/utils.py
+++ b/vllm_ascend/device/utils.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+from typing import Any
+
+import torch
+import torch_npu
+
+FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE = 512
+SWA_INT_MAX = 2147483647
+
+
+def npu_large_head_prefill_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_metadata: Any,
+    *,
+    key_cache: torch.Tensor | None,
+    value_cache: torch.Tensor | None,
+    num_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    scale: float,
+    is_prefill_no_cache: bool,
+):
+    # A2/A3 FIA TND does not support some large head sizes. Keep those prefill
+    # cases on an NPU attention op instead of falling back to Python.
+    num_tokens = attn_metadata.actual_seq_lengths_q[-1]
+    query = query[:num_tokens]
+    key, value, actual_seq_lengths_kv = _get_large_head_prefill_kv(
+        key,
+        value,
+        attn_metadata,
+        num_tokens,
+        key_cache,
+        value_cache,
+        num_kv_heads,
+        head_size,
+        is_prefill_no_cache,
+    )
+    sparse_mode = 3 if attn_metadata.causal else 0
+    pre_tokens = SWA_INT_MAX
+    next_tokens = 0 if attn_metadata.causal else SWA_INT_MAX
+    attn_mask = attn_metadata.attn_mask
+    if attn_mask is not None and attn_mask.dtype not in (torch.bool, torch.uint8):
+        attn_mask = attn_mask.bool()
+    attn_output = torch_npu.npu_fusion_attention(
+        query=query,
+        key=key,
+        value=value,
+        head_num=num_heads,
+        input_layout="TND",
+        atten_mask=attn_mask,
+        scale=scale,
+        pre_tockens=pre_tokens,
+        next_tockens=next_tokens,
+        actual_seq_qlen=attn_metadata.actual_seq_lengths_q,
+        actual_seq_kvlen=actual_seq_lengths_kv,
+        sparse_mode=sparse_mode,
+    )[0]
+    return attn_output, None
+
+
+def _get_large_head_prefill_kv(
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_metadata: Any,
+    num_tokens: int,
+    key_cache: torch.Tensor | None,
+    value_cache: torch.Tensor | None,
+    num_kv_heads: int,
+    head_size: int,
+    is_prefill_no_cache: bool,
+) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
+    # PrefillNoCache already has dense TND key/value tensors. Chunked prefill
+    # may need historical paged KV cache gathered back to dense TND.
+    if is_prefill_no_cache or key_cache is None or value_cache is None:
+        return key[:num_tokens], value[:num_tokens], attn_metadata.actual_seq_lengths_q
+
+    seq_lens = attn_metadata.seq_lens_list
+    if not seq_lens:
+        return key[:num_tokens], value[:num_tokens], attn_metadata.actual_seq_lengths_q
+
+    key, value = _gather_paged_kv_to_dense(
+        key_cache,
+        value_cache,
+        attn_metadata.block_tables,
+        seq_lens,
+        num_kv_heads,
+        head_size,
+    )
+    actual_seq_lengths_kv = []
+    cumsum = 0
+    for length in seq_lens:
+        cumsum += length
+        actual_seq_lengths_kv.append(cumsum)
+    return key, value, actual_seq_lengths_kv
+
+
+def _gather_paged_kv_to_dense(
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: list[int],
+    num_kv_heads: int,
+    head_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # npu_fusion_attention consumes dense TND KV, while cached prefill KV is
+    # stored by blocks. Gather only valid tokens from the block table.
+    block_size = key_cache.shape[1]
+    max_seq_len = max(seq_lens)
+    seq_lens_tensor = torch.tensor(seq_lens, dtype=torch.long, device=key_cache.device)
+    num_blocks = (max_seq_len + block_size - 1) // block_size
+    block_table = block_table[: len(seq_lens), :num_blocks].long()
+
+    flat_block_ids = block_table.reshape(-1)
+    max_tokens_padded = num_blocks * block_size
+    dense_shape = (len(seq_lens), max_tokens_padded, num_kv_heads, head_size)
+    gathered_key = key_cache.index_select(0, flat_block_ids).reshape(dense_shape)
+    gathered_value = value_cache.index_select(0, flat_block_ids).reshape(dense_shape)
+
+    positions = torch.arange(max_tokens_padded, dtype=torch.long, device=key_cache.device)
+    valid_mask = positions.unsqueeze(0) < seq_lens_tensor.unsqueeze(1)
+    return gathered_key[valid_mask].contiguous(), gathered_value[valid_mask].contiguous()


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds Gemma4 large-head attention support for A2/A3 devices.

Gemma4 uses interleaved attention layers with different head dimensions. On A2/A3, the fused infer attention path does not support the large head-dim case, so this patch routes unsupported large-head attention through the existing paged attention fallback while keeping the fused path for supported cases.

### Does this PR introduce _any_ user-facing change?

No API changes. This enables Gemma4 inference on A2/A3 for the supported attention configuration.

### How was this patch tested?

- Added unit tests for the A2 large-head fallback selection logic.
- Ran local static diff checks with `git show --check`.

Co-authored-by: [zhangshuai404]
Co-authored-by: [0moyi0-2024](https://github.com/vllm-project/vllm-ascend/pull/1261320835@qq.com)
Co-authored-by: [swimming2007-doge](https://github.com/swimming2007-doge)


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
