### PR TITLE
[CI]fix qwen3.5_longseq file name error

### DIFF
--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -297,7 +297,7 @@ jobs:
             config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3.yaml
           - name: Qwen3.5-397B-A17B-w8a8-mtp-longseq
             os: linux-aarch64-a3-16
-            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-longseq-A3.yaml
+            config_file_path: Qwen3.5-397B-A17B-w8a8-mtp-longseq-A3.yaml
           - name: MiniMax-M2.5-w8a8-QuaRot-A3
             os: linux-aarch64-a3-16
             config_file_path: MiniMax-M2.5-w8a8-QuaRot-A3.yaml


### PR DESCRIPTION
### What this PR does / why we need it?
Change Qwen3.5-397B-A17B-W8A8-mtp-longseq-A3.yaml to Qwen3.5-397B-A17B-w8a8-mtp-longseq-A3.yaml.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
