### PR TITLE
[BugFix][kimi-2.7]: V2 lt fix kimi2.7 patch media tower

### DIFF
--- a/vllm_ascend/patch/worker/patch_kimi_k25.py
+++ b/vllm_ascend/patch/worker/patch_kimi_k25.py
@@ -44,7 +44,12 @@ def get_rope_shape(org, interpolation_mode, shape):
 class AscendLearnable2DInterpPosEmbDivided_fixed(nn.Module):
     def forward(self, x: torch.Tensor, grid_thws: torch.Tensor | list) -> torch.Tensor:
         pos_embs = []
-        for t, h, w in grid_thws.tolist():
+        if isinstance(grid_thws, torch.Tensor):
+            grid_list = grid_thws.tolist()
+        else:
+            grid_list = grid_thws
+
+        for t, h, w in grid_list:
             assert t <= self.num_frames, (
                 f"[vllm-ascend/patch_kimi_k25] Invalid frame count. t={t}, num_frames={self.num_frames}"
             )

--- a/vllm_ascend/patch/worker/patch_kimi_k25.py
+++ b/vllm_ascend/patch/worker/patch_kimi_k25.py
@@ -42,7 +42,7 @@ def get_rope_shape(org, interpolation_mode, shape):
 
 
 class AscendLearnable2DInterpPosEmbDivided_fixed(nn.Module):
-    def forward(self, x: torch.Tensor, grid_thws: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, grid_thws: torch.Tensor | list) -> torch.Tensor:
         pos_embs = []
         for t, h, w in grid_thws.tolist():
             assert t <= self.num_frames, (


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request updates the `forward` method of `AscendLearnable2DInterpPosEmbDivided_fixed` to accept `grid_thws` as either a `torch.Tensor` or a `list`, handling the conversion to a list appropriately.

However, the use of the `|` operator for union type hints (`torch.Tensor | list`) will cause a `TypeError` at import time in Python 3.9 environments. It is recommended to use a string literal representation `"torch.Tensor | list"` to maintain compatibility.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No testing details were provided in the PR.
fix kimi2.7-coding start infer server bug - #11028

vLLM version: v0.23.0
vLLM main: vllm-project/vllm@967c5c3
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
