### PR TITLE
[Doc][Misc] Rename MindIE-PyMotor to MindIE-Motor

### DIFF
--- a/docs/source/user_guide/deployment_guide/index.md
+++ b/docs/source/user_guide/deployment_guide/index.md
@@ -4,5 +4,5 @@
 :caption: Deployment Guide
 :maxdepth: 1
 using_volcano_kthena
-using_mindie_pymotor
+using_mindie_motor
 :::

--- a/docs/source/user_guide/deployment_guide/using_mindie_motor.md
+++ b/docs/source/user_guide/deployment_guide/using_mindie_motor.md
@@ -2,8 +2,8 @@
 
 ## 1. Overview
 
-[MindIE-Motor](https://gitcode.com/Ascend/MindIE-Motor) provides one-click deployment for **prefill–decode (PD) disaggregation** and **PD aggregation** on Ascend NPUs with vLLM-Ascend. It uses **high-performance scheduling and load balancing**, together with **RAS (Reliability, Availability and Serviceability) capabilities**, to build inference services that are fast and highly stable.
+[MindIE-Motor](https://gitcode.com/Ascend/MindIE-PyMotor) provides one-click deployment for **prefill–decode (PD) disaggregation** and **PD aggregation** on Ascend NPUs with vLLM-Ascend. It uses **high-performance scheduling and load balancing**, together with **RAS (Reliability, Availability and Serviceability) capabilities**, to build inference services that are fast and highly stable.
 
 ## 2. Getting Started
 
-For quick deployment instructions, refer to the [MindIE-Motor Quick Start](https://gitcode.com/Ascend/MindIE-Motor/blob/master/docs/zh/user_guide/README.md).
+For quick deployment instructions, refer to the [MindIE-Motor Quick Start](https://gitcode.com/Ascend/MindIE-PyMotor/blob/master/docs/zh/user_guide/README.md).

--- a/docs/source/user_guide/deployment_guide/using_mindie_motor.md
+++ b/docs/source/user_guide/deployment_guide/using_mindie_motor.md
@@ -1,0 +1,9 @@
+# Deploy vLLM-Ascend with MindIE-Motor
+
+## 1. Overview
+
+[MindIE-Motor](https://gitcode.com/Ascend/MindIE-Motor) provides one-click deployment for **prefill–decode (PD) disaggregation** and **PD aggregation** on Ascend NPUs with vLLM-Ascend. It uses **high-performance scheduling and load balancing**, together with **RAS (Reliability, Availability and Serviceability) capabilities**, to build inference services that are fast and highly stable.
+
+## 2. Getting Started
+
+For quick deployment instructions, refer to the [MindIE-Motor Quick Start](https://gitcode.com/Ascend/MindIE-Motor/blob/master/docs/zh/user_guide/README.md).

--- a/docs/source/user_guide/deployment_guide/using_mindie_pymotor.md
+++ b/docs/source/user_guide/deployment_guide/using_mindie_pymotor.md
@@ -1,9 +1,0 @@
-# Deploy vLLM-Ascend with MindIE-PyMotor
-
-## 1. Overview
-
-[MindIE-PyMotor](https://gitcode.com/Ascend/MindIE-PyMotor) provides one-click deployment for **prefill–decode (PD) disaggregation** and **PD aggregation** on Ascend NPUs with vLLM-Ascend. It uses **high-performance scheduling and load balancing**, together with **RAS (Reliability, Availability and Serviceability) capabilities**, to build inference services that are fast and highly stable.
-
-## 2. Getting Started
-
-For quick deployment instructions, refer to the [MindIE-PyMotor Quick Start](https://gitcode.com/Ascend/MindIE-PyMotor/blob/master/docs/zh/user_guide/README.md).


### PR DESCRIPTION
### What this PR does / why we need it?

This PR renames the documentation file `using_mindie_pymotor.md` to `using_mindie_motor.md` and updates references from `MindIE-PyMotor` to `MindIE-Motor` to reflect the correct naming of the component.

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

Documentation-only change, no code testing required.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
