### PR TITLE
[Test][BugFix] Bound npu-smi probe during UT setup

### DIFF
--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -36,10 +36,24 @@ import sys
 import types
 from unittest.mock import MagicMock
 
+
+def _is_npu_routed_ut_invocation() -> bool:
+    npu_dir_names = {"a2", "a2_2", "a3_2", "a3_4", "310p"}
+    for arg in sys.argv[1:]:
+        path = arg.split("::", 1)[0].replace("\\", "/")
+        if path.startswith("tests/ut/") and any(part in npu_dir_names for part in path.split("/")):
+            return True
+    return False
+
+
 try:
     # Note: do not import torch here for cpu env, which will lead to circle import error.
-    subprocess.run(["npu-smi", "info"], capture_output=True, check=True)
+    subprocess.run(["npu-smi", "info"], capture_output=True, check=True, timeout=5)
     _npu_available = True
+except subprocess.TimeoutExpired as e:
+    if _is_npu_routed_ut_invocation():
+        raise RuntimeError("npu-smi info timed out while running NPU-routed UTs.") from e
+    _npu_available = False
 except (subprocess.CalledProcessError, FileNotFoundError):
     _npu_available = False
 
@@ -85,7 +99,7 @@ if not _npu_available:
     torch.version.cann = None
     torch.distributed.is_hccl_available = MagicMock(return_value=True)
 
-import pytest
+import pytest  # noqa: E402
 
 mooncake_engine = types.ModuleType("mooncake.engine")
 mooncake_engine.__spec__ = importlib.util.spec_from_loader("mooncake.engine", loader=None)


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #11100.

CPU UT setup probes NPU availability with `npu-smi info`. If `npu-smi` exists but the driver/tool is unhealthy, the probe can delay or block pytest session initialization.

This PR adds a short timeout to the probe. Timeout fallback is limited to CPU/mock UT invocations; for NPU-routed UT paths such as `tests/ut/<module>/a2/`, `a3_2/`, `a3_4/`, or `310p/`, a timeout now fails loudly instead of silently replacing the real NPU stack with mocks.

### Does this PR introduce _any_ user-facing change?

No runtime user-facing change. This only affects UT initialization behavior.

### How was this patch tested?

- `python -m py_compile tests/ut/conftest.py`
- `python -m ruff check tests/ut/conftest.py`
- `python -m ruff format --check tests/ut/conftest.py`
- `git diff --check`

A full UT run was not executed locally because this environment does not have the full vLLM/vLLM Ascend test dependency stack installed.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
