### PR TITLE
[Doc] [Misc] add a button in the document website,which will turn to community issue

### DIFF
--- a/docs/source/_templates/sections/issues-float.html
+++ b/docs/source/_templates/sections/issues-float.html
@@ -1,0 +1,23 @@
+<a href="https://github.com/vllm-project/vllm-ascend/issues/new?template=100-documentation.yml&title=%5BDoc%5D%3A%20Feedback%20for%20%60%2Fen%2F{{ rtd_version_slug }}%2F%60"
+   class="issues-float-btn btn btn-primary btn-sm rounded-pill d-print-none"
+   target="_blank" rel="noopener" aria-label="Open an issue">
+  <i class="fa-solid fa-bug"></i> report issue
+</a>
+
+<style>
+  .issues-float-btn {
+    position: fixed;
+    bottom: 4.5rem;
+    right: 1.5rem;
+    z-index: 1100;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, .25);
+  }
+  .issues-float-btn,
+  .issues-float-btn:visited,
+  .issues-float-btn:hover,
+  .issues-float-btn:focus,
+  .issues-float-btn:active {
+    color: #fff;
+    text-decoration: none;
+  }
+</style>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -139,6 +139,16 @@ html_theme_options = {
     "repository_url": "https://github.com/vllm-project/vllm-ascend",
     "use_repository_button": True,
     "use_edit_page_button": True,
+    "footer_content_items": [
+        "author.html",
+        "copyright.html",
+        "last-updated.html",
+        "extra-footer.html",
+        "sections/issues-float.html",
+    ],
+}
+html_context = {
+    "rtd_version_slug": os.environ.get("READTHEDOCS_VERSION", "latest"),
 }
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds a floating "report issue" button to the documentation website. This button allows users to easily report documentation issues directly to the `vllm-project/vllm-ascend` repository with the current documentation version pre-filled in the issue title.
### Does this PR introduce _any_ user-facing change?
Yes, a floating "report issue" button will be visible on the bottom right of the documentation pages.
### How was this patch tested?
Tested by building the Sphinx documentation locally and verifying the floating button's appearance and link behavior.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
