### PR TITLE
[Doc] Add ascend-vllm serving auto-benchmark and serving-tune-loop skills

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -19,6 +19,16 @@ Note: Please copy the skills directory `.agents/skills` to `.claude/skills` if y
     - [File layout](#file-layout-1)
     - [Quick start](#quick-start-2)
     - [Key guidelines](#key-guidelines)
+  - [vLLM Ascend Serving Auto Benchmark Skill](#vllm-ascend-serving-auto-benchmark-skill)
+    - [What it does](#what-it-does-3)
+    - [File layout](#file-layout-2)
+    - [Quick start](#quick-start-3)
+    - [Key guidelines](#key-guidelines-2)
+  - [vLLM Ascend Serving Tune Loop Skill](#vllm-ascend-serving-tune-loop-skill)
+    - [What it does](#what-it-does-4)
+    - [File layout](#file-layout-3)
+    - [Quick start](#quick-start-4)
+    - [Key guidelines](#key-guidelines-3)
 
 
 ## vLLM Ascend Model Adapter Skill
@@ -105,3 +115,85 @@ This skill guides you through a structured workflow to:
 - Focus on user-facing impact and include context for practical usage.
 - Verify details by checking linked PRs (use GitHub API for descriptions if needed).
 - Keep notes concise and avoid unnecessary technical details.
+
+## vLLM Ascend Serving Auto Benchmark Skill
+
+Automated benchmark skill for vLLM-Ascend serving on Huawei Ascend 910C NPU. Launches vLLM serving, runs evalscope perf stress tests, and produces a complete Markdown/CSV performance report.
+
+### What it does
+
+This skill runs an automated five-phase benchmark workflow:
+
+1. Validate environment and config (NPU devices, model path, evalscope/vllm-ascend install).
+2. Launch the vLLM-Ascend OpenAI-compatible server with the chosen model and parallelism.
+3. Run evalscope perf stress tests across configurable concurrency levels.
+4. Collect metrics (`ttft_avg`, `tpot_avg`, `output_token_throughput`, `latency_avg`) at each level.
+5. Generate a Markdown/CSV performance report via `scripts/generate_report.py`.
+
+### File layout
+
+| File | Purpose |
+| ---- | ------- |
+| `SKILL.md` | Skill definition, phases, input parameters, and report format |
+| `configs/*.yaml` | Pre-built model configs (DeepSeek-V3, DeepSeek-V4-Flash, Qwen3-32B, Qwen3.5-27B, Qwen3.5-35B-A3B) |
+| `scripts/run_benchmark.sh` | Orchestrates server launch + evalscope run + report generation |
+| `scripts/validate_configs.py` | Validates a YAML config before launch |
+| `scripts/generate_report.py` | Produces the Markdown/CSV performance report |
+
+### Quick start
+
+1. Open a conversation with the AI agent inside the vllm-ascend dev container.
+2. Invoke the skill (e.g. `/ascend-vllm-serving-auto-benchmark`).
+3. Provide `model_path` and `model_name` (or pass a `config_file` from `configs/`).
+4. The agent runs the five-phase workflow and writes the report to the output directory.
+
+### Key guidelines
+
+- Concurrency levels and requests-per-level are fixed for a given run — do not change them mid-run.
+- Always launch the server on a free port and clean it up after the run.
+- A failed server startup must still produce a report entry marked as failure, not a silent skip.
+- Reuse a ready-to-use `configs/*.yaml` when benchmarking a known model instead of hand-tuning flags.
+
+## vLLM Ascend Serving Tune Loop Skill
+
+Autonomous, evidence-driven performance optimization loop for vLLM-Ascend serving on Huawei Ascend 910C NPU. Runs a fixed baseline, then iterates through a layered tuning plan (scheduler → ACLGraph → kernel) and produces an optimization ledger plus a final comparison report.
+
+### What it does
+
+This skill drives a long-running optimization campaign across 7 phases:
+
+1. Establish a fixed baseline benchmark (the contract that never changes between iterations).
+2. Iterate over ranked tuning levers — one lever per iteration, change one thing at a time (RLCR principle).
+3. Revalidate at c=1/4/8 with the fixed workload after every change; gate WIN/LOSS on `ttft_avg` at c=1.
+4. Append every verdict (WIN/LOSS/NEUTRAL/STARTUP_FAIL/BENCHMARK_FAIL/SKIPPED_CONFLICT) to the ledger immediately.
+5. Resume cleanly across session interruptions via the ledger; drive the campaign to completion with the auto-resume wrapper.
+6. Synthesize a final report (`final_report.md`) with baseline-vs-best, winning copy-pasteable config, and failed levers.
+
+### File layout
+
+| File | Purpose |
+| ---- | ------- |
+| `SKILL.md` | Skill definition, phases, ledger discipline, resume logic, report format |
+| `references/tuning-knobs-reference.md` | Catalog of tunable Ascend knobs and their expected impact |
+| `scripts/auto_resume_wrapper.sh` | Relaunches the `claude` session until `final_report.md` exists (cross-session resume) |
+| `scripts/generate_tuning_report.py` | Synthesizes `final_report.md` from the ledger |
+
+### Quick start
+
+1. Open a conversation with the AI agent inside the vllm-ascend dev container.
+2. Invoke the skill (e.g. `/ascend-vllm-serving-tune-loop`).
+3. Provide `model_path`, `model_name`, and `tensor_parallel_size`; optionally `baseline_launch_command` to preserve a known-good config across the campaign.
+4. To run the full campaign unattended, drive it with the wrapper:
+   ```bash
+   bash scripts/auto_resume_wrapper.sh --work-dir <work_dir> -- claude -p "..." --max-turns 0
+   ```
+5. The agent writes the ledger incrementally and `final_report.md` when the loop exits.
+
+### Key guidelines
+
+- One lever per iteration — never bundle changes; it destroys attribution.
+- The benchmark contract (concurrency levels, token sizes, requests-per-level, target metric) is frozen after Phase 1.
+- Append ledger entries immediately after each verdict; never defer writes — they are the crash-recovery hand-off.
+- c=1 `ttft_avg` is the authoritative WIN/LOSS metric; c=4/8 alone never justifies a WIN.
+- Drive the campaign through the auto-resume wrapper; do not manually relaunch `claude` mid-campaign (it races with the wrapper over the ledger).
+- Run the mandatory post-iteration cleanup between every iteration to avoid zombie processes and NPU memory leaks.

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/SKILL.md
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/SKILL.md
@@ -1,0 +1,173 @@
+# ascend-vllm-serving-auto-benchmark
+
+Automated benchmark skill for vLLM-Ascend serving on Huawei Ascend 910C NPU. Launches vLLM serving, runs evalscope perf stress tests, and produces a complete Markdown/CSV performance report.
+
+## When to invoke
+
+Use this skill when the user wants to:
+- Benchmark LLM serving performance on Ascend 910C NPU
+- Compare performance across different model configurations or parallelism settings
+- Generate a reproducible performance report for vllm-ascend
+
+Trigger phrases: "benchmark", "pressure test", "性能测试", "压测", "ascend benchmark", "vllm-ascend serving 性能"
+
+## Prerequisites
+
+Before running, the system must have:
+
+1. **Hardware**: Huawei Ascend 910C NPU (Atlas 800T A2 or Atlas 800I A2/A3 series)
+2. **CANN**: >= 8.1.0 (recommend 9.0.0)
+3. **torch-npu**: matched to your PyTorch version
+4. **vllm-ascend**: installed (`pip install vllm-ascend` or from source)
+5. **evalscope[perf]**: installed (`pip install evalscope[perf] -U`)
+6. **Model weights**: downloaded locally or accessible via HuggingFace/ModelScope path
+
+## Inputs the user must supply
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `model_path` | Yes | Local path or HuggingFace/ModelScope model ID |
+| `model_name` | Yes | Short name for the model (used in reports and API) |
+| `tensor_parallel_size` | No | Number of NPU cards (default: 1 for 910C single card) |
+| `pipeline_parallel_size` | No | Pipeline parallel size (default: 1) |
+| `max_model_len` | No | Max context length (default: 8192) |
+| `dtype` | No | Weight dtype: `float16`, `bfloat16`, `auto` (default: `float16`) |
+| `quantization` | No | Quantization method: `w8a8`, `w4a16`, `None` (default: None) |
+| `port` | No | Server port (default: 5000) |
+| `parallel_levels` | No | Concurrency levels to test (default: `1 4 8 16 32 64`) |
+| `requests_per_level` | No | Requests per concurrency level (default: `10 40 80 160 320 640`) |
+| `input_tokens` | No | Input token length (default: 1024) |
+| `output_tokens` | No | Output token length (default: 512) |
+| `config_file` | No | Path to a YAML config file from `configs/` directory |
+
+## Workflow
+
+This skill runs in **five phases**:
+
+### Phase 1 — Environment & Config Validation
+- Detect available NPU devices via `npu-smi info`
+- Validate model path exists
+- Validate config file if provided (via `scripts/validate_configs.py`)
+- Check evalscope and vllm-ascend installations
+
+### Phase 2 — Launch vLLM-Ascend Server
+Start the serving endpoint:
+```bash
+ASCEND_RT_VISIBLE_DEVICES=0,1,...  \
+python -m vllm.entrypoints.openai.api_server \
+  --model <model_path> \
+  --served-model-name <model_name> \
+  --tensor-parallel-size <tp> \
+  --pipeline-parallel-size <pp> \
+  --max-model-len <max_len> \
+  --dtype <dtype> \
+  --port <port> \
+  --trust-remote-code
+```
+
+Wait for server readiness by polling `/health` endpoint (max 300s).
+
+### Phase 3 — Warm-up
+Run 20 warm-up requests at concurrency=1 before measuring:
+```bash
+evalscope perf \
+  --parallel 1 \
+  --number 20 \
+  --model <model_name> \
+  --url http://127.0.0.1:<port>/v1/chat/completions \
+  --api openai \
+  --dataset random \
+  --max-tokens <output_tokens> \
+  --min-tokens <output_tokens> \
+  --min-prompt-length <input_tokens> \
+  --max-prompt-length <input_tokens> \
+  --tokenizer-path <model_path>
+```
+
+### Phase 4 — Stress Test (evalscope perf)
+Run the main benchmark across all concurrency levels:
+```bash
+evalscope perf \
+  --parallel <parallel_levels> \
+  --number <requests_per_level> \
+  --model <model_name> \
+  --url http://127.0.0.1:<port>/v1/chat/completions \
+  --api openai \
+  --stream \
+  --dataset random \
+  --max-tokens <output_tokens> \
+  --min-tokens <output_tokens> \
+  --min-prompt-length <input_tokens> \
+  --max-prompt-length <input_tokens> \
+  --tokenizer-path <model_path>
+```
+
+Results are saved to `outputs/<timestamp>/<model_name>/`.
+
+### Phase 5 — Report Generation
+Call `scripts/generate_report.py` to produce:
+- `benchmark_report.md` — full Markdown report with tables and charts description
+- `benchmark_results.csv` — raw metrics for spreadsheet import
+
+## Output report structure
+
+The generated `benchmark_report.md` includes:
+
+1. **Environment Summary** — Hardware (NPU model, count), CANN version, vllm-ascend version, evalscope version
+2. **Model Configuration** — model path, TP/PP size, dtype, quantization, max_model_len
+3. **Workload Specification** — input/output token lengths, dataset type, request distribution
+4. **Performance Overview Table** — per-concurrency: RPS, success rate, throughput (tokens/s)
+5. **Latency Distribution Table** — per-concurrency: avg/P50/P90/P99 latency, TTFT, TPOT
+6. **Best Configuration Summary** — peak throughput point, best TTFT point, recommended concurrency
+7. **Fairness & Reproducibility** — exact server command, evalscope command, git commit hashes
+
+## Constraints & fairness rules
+
+- Always restart the server between different TP/PP configurations; never reuse a warm server across configs
+- Warm up before every measurement run
+- Record exact vllm-ascend git commit: `git -C $(pip show vllm-ascend | grep Location | awk '{print $2}')/vllm_ascend rev-parse HEAD`
+- Report NPU utilization if `npu-smi` is available
+- All concurrency levels must use identical model weights and tokenizer
+- Never compare results from different NPU types in the same report
+
+## Config files
+
+YAML configs in `configs/` encode model-specific defaults. The user can pass `--config_file configs/qwen2.5-7b-instruct.yaml` to skip specifying individual flags. See `configs/qwen2.5-7b-instruct.yaml` for the format.
+
+## Example invocations
+
+**Quick single-card benchmark:**
+```
+/ascend-vllm-serving-auto-benchmark
+model_path=/data/models/Qwen2.5-7B-Instruct
+model_name=Qwen2.5-7B-Instruct
+```
+
+**Multi-card benchmark with custom config:**
+```
+/ascend-vllm-serving-auto-benchmark
+config_file=configs/deepseek-r1-7b.yaml
+tensor_parallel_size=2
+```
+
+**Full custom benchmark:**
+```
+/ascend-vllm-serving-auto-benchmark
+model_path=/data/models/Qwen2.5-72B-Instruct
+model_name=Qwen2.5-72B-Instruct
+tensor_parallel_size=8
+max_model_len=16384
+dtype=bfloat16
+parallel_levels="1 8 16 32 64 128"
+requests_per_level="10 80 160 320 640 1280"
+input_tokens=2048
+output_tokens=1024
+```
+
+## Handling failures
+
+- **Server fails to start**: Check CANN env vars (`source /usr/local/Ascend/ascend-toolkit/set_env.sh`), NPU visibility (`npu-smi info`), and available NPU memory
+- **OOM on NPU**: Reduce `--max-model-len` or increase `--tensor-parallel-size`
+- **evalscope not found**: Run `pip install evalscope[perf] -U`
+- **Low throughput / high latency**: Check if ACLGraph is enabled (`VLLM_ASCEND_ENABLE_ACLGRAPH=1`), ensure no CPU-NPU sync bottlenecks
+- **All requests fail**: Verify server health at `curl http://127.0.0.1:<port>/health`

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/SKILL.md
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/SKILL.md
@@ -1,173 +1,138 @@
+---
+name: ascend-vllm-serving-auto-benchmark
+description: "Benchmark vLLM-Ascend serving on Ascend 910C, validate YAML configs, launch the server, run evalscope perf, and generate Markdown/CSV reports."
+disable-model-invocation: true
+---
+
 # ascend-vllm-serving-auto-benchmark
 
-Automated benchmark skill for vLLM-Ascend serving on Huawei Ascend 910C NPU. Launches vLLM serving, runs evalscope perf stress tests, and produces a complete Markdown/CSV performance report.
+## What this skill is for
 
-## When to invoke
+Use this skill when the user wants a reproducible serving benchmark for `vllm-ascend` on Ascend 910C:
 
-Use this skill when the user wants to:
-- Benchmark LLM serving performance on Ascend 910C NPU
-- Compare performance across different model configurations or parallelism settings
-- Generate a reproducible performance report for vllm-ascend
+- LLM serving performance benchmark / pressure test
+- compare TP / PP / model config variants
+- generate a report that can be attached to a PR, issue, or tuning note
 
-Trigger phrases: "benchmark", "pressure test", "性能测试", "压测", "ascend benchmark", "vllm-ascend serving 性能"
+Trigger phrases: `benchmark`, `pressure test`, `性能测试`, `压测`, `ascend benchmark`, `vllm-ascend serving 性能`
 
-## Prerequisites
+## Read order
 
-Before running, the system must have:
+1. Read this file first.
+2. If the user provides a YAML config, validate it with `scripts/validate_configs.py`.
+3. Run `scripts/run_benchmark.sh`.
+4. If report parsing looks wrong, inspect `scripts/generate_report.py`.
 
-1. **Hardware**: Huawei Ascend 910C NPU (Atlas 800T A2 or Atlas 800I A2/A3 series)
-2. **CANN**: >= 8.1.0 (recommend 9.0.0)
-3. **torch-npu**: matched to your PyTorch version
-4. **vllm-ascend**: installed (`pip install vllm-ascend` or from source)
-5. **evalscope[perf]**: installed (`pip install evalscope[perf] -U`)
-6. **Model weights**: downloaded locally or accessible via HuggingFace/ModelScope path
+## Required inputs
 
-## Inputs the user must supply
+| Parameter | Required | Notes |
+|-----------|----------|-------|
+| `model_path` | Yes, unless `config_file` provides it | Local path or model ID |
+| `model_name` | Yes, unless `config_file` provides it | Used in serving API and reports |
+| `config_file` | No | One of `configs/*.yaml` or a compatible YAML file |
 
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `model_path` | Yes | Local path or HuggingFace/ModelScope model ID |
-| `model_name` | Yes | Short name for the model (used in reports and API) |
-| `tensor_parallel_size` | No | Number of NPU cards (default: 1 for 910C single card) |
-| `pipeline_parallel_size` | No | Pipeline parallel size (default: 1) |
-| `max_model_len` | No | Max context length (default: 8192) |
-| `dtype` | No | Weight dtype: `float16`, `bfloat16`, `auto` (default: `float16`) |
-| `quantization` | No | Quantization method: `w8a8`, `w4a16`, `None` (default: None) |
-| `port` | No | Server port (default: 5000) |
-| `parallel_levels` | No | Concurrency levels to test (default: `1 4 8 16 32 64`) |
-| `requests_per_level` | No | Requests per concurrency level (default: `10 40 80 160 320 640`) |
-| `input_tokens` | No | Input token length (default: 1024) |
-| `output_tokens` | No | Output token length (default: 512) |
-| `config_file` | No | Path to a YAML config file from `configs/` directory |
+Common optional inputs:
+
+- `tensor_parallel_size`
+- `pipeline_parallel_size`
+- `max_model_len`
+- `dtype`
+- `quantization`
+- `port`
+- `parallel_levels`
+- `requests_per_level`
+- `input_tokens`
+- `output_tokens`
+- `output_dir`
+
+## Preconditions
+
+Before running:
+
+1. Confirm the target machine is really an Ascend benchmark environment.
+2. Check `vllm-ascend`, `torch-npu`, and `evalscope[perf]` are installed.
+3. Confirm the model path exists or the model ID is accessible.
+4. Confirm the chosen port is free before server start.
 
 ## Workflow
 
-This skill runs in **five phases**:
+The implementation lives in `scripts/run_benchmark.sh` and should be used as the default execution path.
 
-### Phase 1 — Environment & Config Validation
-- Detect available NPU devices via `npu-smi info`
-- Validate model path exists
-- Validate config file if provided (via `scripts/validate_configs.py`)
-- Check evalscope and vllm-ascend installations
+### Phase 1: validate inputs and environment
 
-### Phase 2 — Launch vLLM-Ascend Server
-Start the serving endpoint:
-```bash
-ASCEND_RT_VISIBLE_DEVICES=0,1,...  \
-python -m vllm.entrypoints.openai.api_server \
-  --model <model_path> \
-  --served-model-name <model_name> \
-  --tensor-parallel-size <tp> \
-  --pipeline-parallel-size <pp> \
-  --max-model-len <max_len> \
-  --dtype <dtype> \
-  --port <port> \
-  --trust-remote-code
+- Run `npu-smi info`
+- Validate YAML via `scripts/validate_configs.py` when `config_file` is provided
+- Detect `vllm-ascend` and `evalscope`
+
+### Phase 2: launch vLLM-Ascend
+
+- Start exactly one serving process for this benchmark
+- Apply every `server.env` entry from YAML configs, not only a hand-picked subset
+- Preserve explicit CLI overrides such as `--npu-devices`, `--no-aclgraph`, and `--no-nz`
+
+### Phase 3: warm up
+
+- Default warm-up: 20 requests at `c=1`
+- Warm-up is a normal benchmark precondition and should happen before the measured run unless the user explicitly skips it
+
+### Phase 4: main evalscope benchmark
+
+- Keep concurrency levels and request counts fixed within a run
+- Prefer the current evalscope output directory flag when available
+- If the installed evalscope does not support an output flag, run it from the intended artifact directory instead of writing results into an ambiguous cwd
+
+### Phase 5: report generation
+
+Generate:
+
+- `benchmark_report.md`
+- `benchmark_results.csv`
+
+`scripts/generate_report.py` must handle both JSONL and JSON evalscope outputs.
+
+## Config rules
+
+YAML configs under `configs/` are the source of model-specific defaults.
+
+- `server.env` is authoritative for environment variables
+- `model.*`, `server.*`, `workload.*`, `benchmark.*`, and `sla.*` must stay consistent with `scripts/validate_configs.py`
+- CLI arguments may override config values for the current run
+
+## Failure handling
+
+- If server startup fails, surface the failure clearly and keep `server.log`
+- Do not silently skip report generation because a JSON file used a different shape than JSONL
+- Do not mix results from different NPU types in one report
+- Always record the exact server command and evalscope command used for the run
+
+## Output contract
+
+The final output directory should contain at least:
+
+```text
+<output_dir>/
+├── benchmark_report.md
+├── benchmark_results.csv
+├── evalscope_results/
+├── npu_info.txt
+├── server.log
+├── server_cmd.txt
+└── evalscope_cmd.txt
 ```
 
-Wait for server readiness by polling `/health` endpoint (max 300s).
+## Quick start
 
-### Phase 3 — Warm-up
-Run 20 warm-up requests at concurrency=1 before measuring:
-```bash
-evalscope perf \
-  --parallel 1 \
-  --number 20 \
-  --model <model_name> \
-  --url http://127.0.0.1:<port>/v1/chat/completions \
-  --api openai \
-  --dataset random \
-  --max-tokens <output_tokens> \
-  --min-tokens <output_tokens> \
-  --min-prompt-length <input_tokens> \
-  --max-prompt-length <input_tokens> \
-  --tokenizer-path <model_path>
-```
-
-### Phase 4 — Stress Test (evalscope perf)
-Run the main benchmark across all concurrency levels:
-```bash
-evalscope perf \
-  --parallel <parallel_levels> \
-  --number <requests_per_level> \
-  --model <model_name> \
-  --url http://127.0.0.1:<port>/v1/chat/completions \
-  --api openai \
-  --stream \
-  --dataset random \
-  --max-tokens <output_tokens> \
-  --min-tokens <output_tokens> \
-  --min-prompt-length <input_tokens> \
-  --max-prompt-length <input_tokens> \
-  --tokenizer-path <model_path>
-```
-
-Results are saved to `outputs/<timestamp>/<model_name>/`.
-
-### Phase 5 — Report Generation
-Call `scripts/generate_report.py` to produce:
-- `benchmark_report.md` — full Markdown report with tables and charts description
-- `benchmark_results.csv` — raw metrics for spreadsheet import
-
-## Output report structure
-
-The generated `benchmark_report.md` includes:
-
-1. **Environment Summary** — Hardware (NPU model, count), CANN version, vllm-ascend version, evalscope version
-2. **Model Configuration** — model path, TP/PP size, dtype, quantization, max_model_len
-3. **Workload Specification** — input/output token lengths, dataset type, request distribution
-4. **Performance Overview Table** — per-concurrency: RPS, success rate, throughput (tokens/s)
-5. **Latency Distribution Table** — per-concurrency: avg/P50/P90/P99 latency, TTFT, TPOT
-6. **Best Configuration Summary** — peak throughput point, best TTFT point, recommended concurrency
-7. **Fairness & Reproducibility** — exact server command, evalscope command, git commit hashes
-
-## Constraints & fairness rules
-
-- Always restart the server between different TP/PP configurations; never reuse a warm server across configs
-- Warm up before every measurement run
-- Record exact vllm-ascend git commit: `git -C $(pip show vllm-ascend | grep Location | awk '{print $2}')/vllm_ascend rev-parse HEAD`
-- Report NPU utilization if `npu-smi` is available
-- All concurrency levels must use identical model weights and tokenizer
-- Never compare results from different NPU types in the same report
-
-## Config files
-
-YAML configs in `configs/` encode model-specific defaults. The user can pass `--config_file configs/qwen2.5-7b-instruct.yaml` to skip specifying individual flags. See `configs/qwen2.5-7b-instruct.yaml` for the format.
-
-## Example invocations
-
-**Quick single-card benchmark:**
-```
+```text
 /ascend-vllm-serving-auto-benchmark
-model_path=/data/models/Qwen2.5-7B-Instruct
-model_name=Qwen2.5-7B-Instruct
+config_file=.agents/skills/ascend-vllm-serving-auto-benchmark/configs/qwen3-32b.yaml
 ```
 
-**Multi-card benchmark with custom config:**
-```
+```text
 /ascend-vllm-serving-auto-benchmark
-config_file=configs/deepseek-r1-7b.yaml
+model_path=/data/models/Qwen3.5-27B
+model_name=Qwen3.5-27B
 tensor_parallel_size=2
-```
-
-**Full custom benchmark:**
-```
-/ascend-vllm-serving-auto-benchmark
-model_path=/data/models/Qwen2.5-72B-Instruct
-model_name=Qwen2.5-72B-Instruct
-tensor_parallel_size=8
-max_model_len=16384
 dtype=bfloat16
-parallel_levels="1 8 16 32 64 128"
-requests_per_level="10 80 160 320 640 1280"
-input_tokens=2048
-output_tokens=1024
+parallel_levels="1 4 8 16 32 64"
+requests_per_level="10 40 80 160 320 640"
 ```
-
-## Handling failures
-
-- **Server fails to start**: Check CANN env vars (`source /usr/local/Ascend/ascend-toolkit/set_env.sh`), NPU visibility (`npu-smi info`), and available NPU memory
-- **OOM on NPU**: Reduce `--max-model-len` or increase `--tensor-parallel-size`
-- **evalscope not found**: Run `pip install evalscope[perf] -U`
-- **Low throughput / high latency**: Check if ACLGraph is enabled (`VLLM_ASCEND_ENABLE_ACLGRAPH=1`), ensure no CPU-NPU sync bottlenecks
-- **All requests fail**: Verify server health at `curl http://127.0.0.1:<port>/health`

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/SKILL.md
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/SKILL.md
@@ -122,6 +122,14 @@ The final output directory should contain at least:
 
 ## Quick start
 
+This skill starts a serving process, occupies NPU resources, and may run a long
+benchmark campaign, so it must be invoked explicitly. Use the form for your
+agent and never let the model invoke it implicitly (`disable-model-invocation`
+is already set in the frontmatter above).
+
+- Codex: `$ascend-vllm-serving-auto-benchmark`
+- Claude Code: `/ascend-vllm-serving-auto-benchmark`
+
 ```text
 /ascend-vllm-serving-auto-benchmark
 config_file=.agents/skills/ascend-vllm-serving-auto-benchmark/configs/qwen3-32b.yaml

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/deepseek-v3.yaml
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/deepseek-v3.yaml
@@ -1,0 +1,36 @@
+# DeepSeek-V3 benchmark config for Ascend 910C
+# Large MoE model; requires 8-card TP (Atlas 800T A2 with 8x 910C).
+
+model:
+  path: /data/models/DeepSeek-V3
+  name: DeepSeek-V3
+  dtype: bfloat16
+  quantization: null
+  max_model_len: 32768
+  trust_remote_code: true
+
+server:
+  port: 8000
+  tensor_parallel_size: 8
+  pipeline_parallel_size: 1
+  env:
+    ASCEND_RT_VISIBLE_DEVICES: "0,1,2,3,4,5,6,7"
+    VLLM_ASCEND_ENABLE_ACLGRAPH: "1"
+    VLLM_ASCEND_ENABLE_NZ: "1"
+    HCCL_BUFFSIZE: "200"
+
+workload:
+  input_tokens: 1024
+  output_tokens: 512
+  dataset: random
+
+benchmark:
+  parallel_levels: "1 8 16 32 64 128"
+  requests_per_level: "10 80 160 320 640 1280"
+  warmup_requests: 20
+  stream: true
+
+sla:
+  max_p99_ttft_ms: 8000
+  min_success_rate: 0.99
+  min_output_token_throughput: 3000

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/deepseek-v3.yaml
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/deepseek-v3.yaml
@@ -15,7 +15,6 @@ server:
   pipeline_parallel_size: 1
   env:
     ASCEND_RT_VISIBLE_DEVICES: "0,1,2,3,4,5,6,7"
-    VLLM_ASCEND_ENABLE_ACLGRAPH: "1"
     VLLM_ASCEND_ENABLE_NZ: "1"
     HCCL_BUFFSIZE: "200"
 

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/deepseek-v4-flash.yaml
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/deepseek-v4-flash.yaml
@@ -1,0 +1,35 @@
+# DeepSeek-V4-Flash benchmark config for Ascend 910C
+# MoE architecture; single-card or 2-card TP recommended for flash variant.
+
+model:
+  path: /data/models/DeepSeek-V4-Flash
+  name: DeepSeek-V4-Flash
+  dtype: bfloat16
+  quantization: null
+  max_model_len: 32768
+  trust_remote_code: true
+
+server:
+  port: 8000
+  tensor_parallel_size: 1
+  pipeline_parallel_size: 1
+  env:
+    ASCEND_RT_VISIBLE_DEVICES: "0"
+    VLLM_ASCEND_ENABLE_ACLGRAPH: "1"
+    VLLM_ASCEND_ENABLE_NZ: "1"
+
+workload:
+  input_tokens: 1024
+  output_tokens: 512
+  dataset: random
+
+benchmark:
+  parallel_levels: "1 4 8 16 32 64"
+  requests_per_level: "10 40 80 160 320 640"
+  warmup_requests: 20
+  stream: true
+
+sla:
+  max_p99_ttft_ms: 5000
+  min_success_rate: 0.99
+  min_output_token_throughput: 1000

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/deepseek-v4-flash.yaml
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/deepseek-v4-flash.yaml
@@ -15,7 +15,6 @@ server:
   pipeline_parallel_size: 1
   env:
     ASCEND_RT_VISIBLE_DEVICES: "0"
-    VLLM_ASCEND_ENABLE_ACLGRAPH: "1"
     VLLM_ASCEND_ENABLE_NZ: "1"
 
 workload:

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/qwen3-32b.yaml
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/qwen3-32b.yaml
@@ -15,7 +15,6 @@ server:
   pipeline_parallel_size: 1
   env:
     ASCEND_RT_VISIBLE_DEVICES: "0,1,2,3"
-    VLLM_ASCEND_ENABLE_ACLGRAPH: "1"
     VLLM_ASCEND_ENABLE_NZ: "1"
 
 workload:

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/qwen3-32b.yaml
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/qwen3-32b.yaml
@@ -1,0 +1,35 @@
+# Qwen3-32B benchmark config for Ascend 910C
+# Dense model; 2-card or 4-card TP on 910C.
+
+model:
+  path: /data/models/Qwen3-32B
+  name: Qwen3-32B
+  dtype: bfloat16
+  quantization: null
+  max_model_len: 32768
+  trust_remote_code: true
+
+server:
+  port: 8000
+  tensor_parallel_size: 4
+  pipeline_parallel_size: 1
+  env:
+    ASCEND_RT_VISIBLE_DEVICES: "0,1,2,3"
+    VLLM_ASCEND_ENABLE_ACLGRAPH: "1"
+    VLLM_ASCEND_ENABLE_NZ: "1"
+
+workload:
+  input_tokens: 1024
+  output_tokens: 512
+  dataset: random
+
+benchmark:
+  parallel_levels: "1 4 8 16 32 64"
+  requests_per_level: "10 40 80 160 320 640"
+  warmup_requests: 20
+  stream: true
+
+sla:
+  max_p99_ttft_ms: 6000
+  min_success_rate: 0.99
+  min_output_token_throughput: 2000

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/qwen3.5-27b.yaml
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/qwen3.5-27b.yaml
@@ -1,0 +1,35 @@
+# Qwen3.5-27B benchmark config for Ascend 910C
+# Dense model; 2-card TP recommended for 910C single-node.
+
+model:
+  path: /data/models/Qwen3.5-27B
+  name: Qwen3.5-27B
+  dtype: bfloat16
+  quantization: null
+  max_model_len: 32768
+  trust_remote_code: true
+
+server:
+  port: 8000
+  tensor_parallel_size: 2
+  pipeline_parallel_size: 1
+  env:
+    ASCEND_RT_VISIBLE_DEVICES: "0,1"
+    VLLM_ASCEND_ENABLE_ACLGRAPH: "1"
+    VLLM_ASCEND_ENABLE_NZ: "1"
+
+workload:
+  input_tokens: 1024
+  output_tokens: 512
+  dataset: random
+
+benchmark:
+  parallel_levels: "1 4 8 16 32 64"
+  requests_per_level: "10 40 80 160 320 640"
+  warmup_requests: 20
+  stream: true
+
+sla:
+  max_p99_ttft_ms: 6000
+  min_success_rate: 0.99
+  min_output_token_throughput: 2000

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/qwen3.5-27b.yaml
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/qwen3.5-27b.yaml
@@ -15,7 +15,6 @@ server:
   pipeline_parallel_size: 1
   env:
     ASCEND_RT_VISIBLE_DEVICES: "0,1"
-    VLLM_ASCEND_ENABLE_ACLGRAPH: "1"
     VLLM_ASCEND_ENABLE_NZ: "1"
 
 workload:

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/qwen3.5-35b-a3b.yaml
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/qwen3.5-35b-a3b.yaml
@@ -1,0 +1,35 @@
+# Qwen3.5-35B-A3B benchmark config for Ascend 910C
+# MoE model (35B total, 3B active); single-card friendly due to small active params.
+
+model:
+  path: /data/models/Qwen3.5-35B-A3B
+  name: Qwen3.5-35B-A3B
+  dtype: bfloat16
+  quantization: null
+  max_model_len: 32768
+  trust_remote_code: true
+
+server:
+  port: 8000
+  tensor_parallel_size: 2
+  pipeline_parallel_size: 1
+  env:
+    ASCEND_RT_VISIBLE_DEVICES: "0,1"
+    VLLM_ASCEND_ENABLE_ACLGRAPH: "1"
+    VLLM_ASCEND_ENABLE_NZ: "1"
+
+workload:
+  input_tokens: 1024
+  output_tokens: 512
+  dataset: random
+
+benchmark:
+  parallel_levels: "1 4 8 16 32 64"
+  requests_per_level: "10 40 80 160 320 640"
+  warmup_requests: 20
+  stream: true
+
+sla:
+  max_p99_ttft_ms: 5000
+  min_success_rate: 0.99
+  min_output_token_throughput: 2500

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/qwen3.5-35b-a3b.yaml
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/configs/qwen3.5-35b-a3b.yaml
@@ -15,7 +15,6 @@ server:
   pipeline_parallel_size: 1
   env:
     ASCEND_RT_VISIBLE_DEVICES: "0,1"
-    VLLM_ASCEND_ENABLE_ACLGRAPH: "1"
     VLLM_ASCEND_ENABLE_NZ: "1"
 
 workload:

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/scripts/generate_report.py
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/scripts/generate_report.py
@@ -1,0 +1,614 @@
+#!/usr/bin/env python3
+"""Generate a Markdown + CSV benchmark report from evalscope perf output.
+
+Usage:
+    python generate_report.py \\
+        --results-dir outputs/<timestamp>/<model>/ \\
+        --output-dir ./benchmark_output/ \\
+        --model-name Qwen2.5-7B-Instruct \\
+        --config configs/qwen2.5-7b-instruct.yaml \\
+        [--npu-info npu_info.txt] \\
+        [--vllm-commit abc1234] \\
+        [--server-cmd "python -m vllm.entrypoints..."] \\
+        [--evalscope-cmd "evalscope perf ..."]
+"""
+
+import argparse
+import csv
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+try:
+    import yaml
+except ImportError:
+    yaml = None  # type: ignore[assignment]
+
+
+# ── Data model ────────────────────────────────────────────────────────────────
+
+@dataclass
+class ConcurrencyResult:
+    concurrency: int
+    total_requests: int
+    success_requests: int
+    failed_requests: int
+    success_rate: float
+    # Throughput
+    request_throughput_rps: float
+    input_token_throughput: float
+    output_token_throughput: float
+    total_token_throughput: float
+    # Latency (ms)
+    latency_avg_ms: float
+    latency_p50_ms: float
+    latency_p90_ms: float
+    latency_p99_ms: float
+    # TTFT (ms)
+    ttft_avg_ms: float
+    ttft_p50_ms: float
+    ttft_p90_ms: float
+    ttft_p99_ms: float
+    # TPOT (ms)
+    tpot_avg_ms: float
+    tpot_p50_ms: float
+    tpot_p90_ms: float
+    tpot_p99_ms: float
+
+
+@dataclass
+class BenchmarkReport:
+    model_name: str
+    model_path: str
+    dtype: str
+    quantization: Optional[str]
+    max_model_len: int
+    tensor_parallel_size: int
+    pipeline_parallel_size: int
+    input_tokens: int
+    output_tokens: int
+    npu_info: str
+    cann_version: str
+    vllm_ascend_version: str
+    vllm_ascend_commit: str
+    evalscope_version: str
+    server_cmd: str
+    evalscope_cmd: str
+    timestamp: str
+    results: list[ConcurrencyResult] = field(default_factory=list)
+    sla: dict = field(default_factory=dict)
+
+
+# ── Parsers ───────────────────────────────────────────────────────────────────
+
+def _safe_float(val, default: float = 0.0) -> float:
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_evalscope_summary_txt(summary_path: Path) -> list[ConcurrencyResult]:
+    """Parse evalscope performance_summary.txt into ConcurrencyResult list."""
+    if not summary_path.exists():
+        return []
+
+    results: list[ConcurrencyResult] = []
+    text = summary_path.read_text()
+
+    # evalscope outputs per-concurrency blocks; try to parse tables
+    # Format varies by version — we parse the JSON result file when available
+    return results
+
+
+def _parse_evalscope_jsonl(jsonl_path: Path) -> list[ConcurrencyResult]:
+    """Parse evalscope result JSONL into ConcurrencyResult list."""
+    if not jsonl_path.exists():
+        return []
+
+    records: list[dict] = []
+    with open(jsonl_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    results: list[ConcurrencyResult] = []
+    for rec in records:
+        stats = rec.get("stats", rec)
+        concurrency = int(rec.get("concurrency", rec.get("parallel", 0)))
+        if concurrency == 0:
+            continue
+
+        def ms(key: str, sub: str = "") -> float:
+            base = stats.get(key, stats.get(sub, {}))
+            if isinstance(base, dict):
+                return _safe_float(base.get("mean", base.get("avg", 0))) * 1000
+            return _safe_float(base) * 1000
+
+        def ms_pct(key: str, pct: str) -> float:
+            base = stats.get(key, {})
+            if isinstance(base, dict):
+                return _safe_float(base.get(pct, 0)) * 1000
+            return 0.0
+
+        total = int(stats.get("total_requests", stats.get("num_requests", 0)))
+        success = int(stats.get("success_requests", stats.get("num_completed", total)))
+
+        results.append(ConcurrencyResult(
+            concurrency=concurrency,
+            total_requests=total,
+            success_requests=success,
+            failed_requests=total - success,
+            success_rate=_safe_float(stats.get("success_rate", success / max(total, 1))),
+            request_throughput_rps=_safe_float(stats.get("request_throughput", stats.get("throughput_rps", 0))),
+            input_token_throughput=_safe_float(stats.get("input_token_throughput", 0)),
+            output_token_throughput=_safe_float(stats.get("output_token_throughput", stats.get("token_throughput", 0))),
+            total_token_throughput=_safe_float(stats.get("total_token_throughput", 0)),
+            latency_avg_ms=ms("latency", "e2e_latency"),
+            latency_p50_ms=ms_pct("latency", "p50"),
+            latency_p90_ms=ms_pct("latency", "p90"),
+            latency_p99_ms=ms_pct("latency", "p99"),
+            ttft_avg_ms=ms("ttft"),
+            ttft_p50_ms=ms_pct("ttft", "p50"),
+            ttft_p90_ms=ms_pct("ttft", "p90"),
+            ttft_p99_ms=ms_pct("ttft", "p99"),
+            tpot_avg_ms=ms("tpot"),
+            tpot_p50_ms=ms_pct("tpot", "p50"),
+            tpot_p90_ms=ms_pct("tpot", "p90"),
+            tpot_p99_ms=ms_pct("tpot", "p99"),
+        ))
+
+    results.sort(key=lambda r: r.concurrency)
+    return results
+
+
+def _parse_evalscope_output_dir(results_dir: Path) -> list[ConcurrencyResult]:
+    """Try multiple evalscope output formats."""
+    # Try JSONL first
+    for pattern in ("*.jsonl", "results.jsonl", "benchmark_results.jsonl"):
+        for p in results_dir.glob(pattern):
+            results = _parse_evalscope_jsonl(p)
+            if results:
+                return results
+    # Try JSON
+    for pattern in ("*.json",):
+        for p in results_dir.glob(pattern):
+            try:
+                data = json.loads(p.read_text())
+                if isinstance(data, list):
+                    for item in data:
+                        if "concurrency" in item or "parallel" in item:
+                            pass  # handled by jsonl parser above
+            except (json.JSONDecodeError, OSError):
+                pass
+    return []
+
+
+# ── Environment detection ──────────────────────────────────────────────────────
+
+def _get_npu_info() -> str:
+    try:
+        result = subprocess.run(
+            ["npu-smi", "info"], capture_output=True, text=True, timeout=10
+        )
+        return result.stdout.strip() if result.returncode == 0 else "npu-smi not available"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return "npu-smi not available"
+
+
+def _get_cann_version() -> str:
+    version_file = Path("/usr/local/Ascend/ascend-toolkit/latest/version.cfg")
+    if version_file.exists():
+        text = version_file.read_text()
+        m = re.search(r"Version\s*=\s*(.+)", text)
+        if m:
+            return m.group(1).strip()
+    try:
+        r = subprocess.run(
+            ["python3", "-c", "import torch_npu; print(torch_npu.version.cann)"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if r.returncode == 0:
+            return r.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return "unknown"
+
+
+def _get_vllm_ascend_version() -> str:
+    try:
+        r = subprocess.run(
+            ["python3", "-c", "import vllm_ascend; print(getattr(vllm_ascend, '__version__', 'unknown'))"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return r.stdout.strip() if r.returncode == 0 else "unknown"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return "unknown"
+
+
+def _get_evalscope_version() -> str:
+    try:
+        r = subprocess.run(
+            ["python3", "-c", "import evalscope; print(evalscope.__version__)"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return r.stdout.strip() if r.returncode == 0 else "unknown"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return "unknown"
+
+
+# ── SLA check ─────────────────────────────────────────────────────────────────
+
+def _check_sla(result: ConcurrencyResult, sla: dict) -> list[str]:
+    violations: list[str] = []
+    max_ttft = sla.get("max_p99_ttft_ms")
+    if max_ttft and result.ttft_p99_ms > max_ttft:
+        violations.append(
+            f"P99 TTFT {result.ttft_p99_ms:.0f}ms > SLA {max_ttft}ms"
+        )
+    min_sr = sla.get("min_success_rate")
+    if min_sr and result.success_rate < min_sr:
+        violations.append(
+            f"success rate {result.success_rate:.3f} < SLA {min_sr}"
+        )
+    min_tput = sla.get("min_output_token_throughput")
+    if min_tput and result.output_token_throughput < min_tput:
+        violations.append(
+            f"output token throughput {result.output_token_throughput:.0f} tok/s < SLA {min_tput} tok/s"
+        )
+    return violations
+
+
+# ── Markdown rendering ─────────────────────────────────────────────────────────
+
+def _fmt(val: float, decimals: int = 2) -> str:
+    return f"{val:.{decimals}f}"
+
+
+def render_markdown(report: BenchmarkReport) -> str:
+    lines: list[str] = []
+    a = lines.append
+
+    a(f"# Ascend 910C vLLM Serving Benchmark Report")
+    a(f"")
+    a(f"> Generated: {report.timestamp}")
+    a(f"")
+
+    # ── 1. Environment ────────────────────────────────────────────────────────
+    a("## 1. Environment")
+    a("")
+    a("| Item | Value |")
+    a("|------|-------|")
+    a(f"| Hardware | Ascend 910C |")
+    a(f"| CANN Version | `{report.cann_version}` |")
+    a(f"| vllm-ascend Version | `{report.vllm_ascend_version}` |")
+    a(f"| vllm-ascend Git Commit | `{report.vllm_ascend_commit}` |")
+    a(f"| evalscope Version | `{report.evalscope_version}` |")
+    a("")
+
+    if report.npu_info and report.npu_info != "npu-smi not available":
+        a("<details><summary>npu-smi info</summary>")
+        a("")
+        a("```")
+        a(report.npu_info)
+        a("```")
+        a("")
+        a("</details>")
+        a("")
+
+    # ── 2. Model Configuration ────────────────────────────────────────────────
+    a("## 2. Model Configuration")
+    a("")
+    a("| Item | Value |")
+    a("|------|-------|")
+    a(f"| Model | `{report.model_name}` |")
+    a(f"| Model Path | `{report.model_path}` |")
+    a(f"| dtype | `{report.dtype}` |")
+    a(f"| Quantization | `{report.quantization or 'None'}` |")
+    a(f"| max_model_len | `{report.max_model_len}` |")
+    a(f"| Tensor Parallel Size | `{report.tensor_parallel_size}` |")
+    a(f"| Pipeline Parallel Size | `{report.pipeline_parallel_size}` |")
+    a("")
+
+    # ── 3. Workload Specification ─────────────────────────────────────────────
+    a("## 3. Workload Specification")
+    a("")
+    a("| Item | Value |")
+    a("|------|-------|")
+    a(f"| Input Tokens | `{report.input_tokens}` |")
+    a(f"| Output Tokens | `{report.output_tokens}` |")
+    a(f"| Dataset | `random` |")
+    a(f"| Stream Mode | `true` (SSE) |")
+    a("")
+
+    if not report.results:
+        a("> **No benchmark results found.** Check that the results directory contains JSONL output from evalscope.")
+        return "\n".join(lines)
+
+    low_conc = [r for r in report.results if r.concurrency < 10]
+    single = next((r for r in report.results if r.concurrency == 1), None)
+
+    # ── 4. Low-Concurrency Deep Dive (c < 10) ────────────────────────────────
+    a("## 4. Low-Concurrency Analysis (c < 10)")
+    a("")
+    a("> Low-concurrency results reflect the model's **baseline latency** with minimal queuing.")
+    a("> These numbers matter most for latency-sensitive / interactive workloads.")
+    a("")
+
+    if single:
+        a("### 4.1 Single-Request Baseline (c = 1)")
+        a("")
+        a("This is the best-case latency the model can achieve — no batching, no queuing pressure.")
+        a("")
+        a("| Metric | Value |")
+        a("|--------|-------|")
+        a(f"| End-to-End Latency (avg) | `{_fmt(single.latency_avg_ms, 1)} ms` |")
+        a(f"| End-to-End Latency P50  | `{_fmt(single.latency_p50_ms, 1)} ms` |")
+        a(f"| End-to-End Latency P99  | `{_fmt(single.latency_p99_ms, 1)} ms` |")
+        a(f"| TTFT (avg)              | `{_fmt(single.ttft_avg_ms, 1)} ms` |")
+        a(f"| TTFT P50                | `{_fmt(single.ttft_p50_ms, 1)} ms` |")
+        a(f"| TTFT P99                | `{_fmt(single.ttft_p99_ms, 1)} ms` |")
+        a(f"| TPOT (avg)              | `{_fmt(single.tpot_avg_ms, 1)} ms/token` |")
+        a(f"| TPOT P50                | `{_fmt(single.tpot_p50_ms, 1)} ms/token` |")
+        a(f"| TPOT P99                | `{_fmt(single.tpot_p99_ms, 1)} ms/token` |")
+        a(f"| Output Token Throughput | `{_fmt(single.output_token_throughput, 1)} tok/s` |")
+        a(f"| Success Rate            | `{single.success_rate:.3f}` |")
+        a("")
+
+    if low_conc:
+        a("### 4.2 Low-Concurrency Sweep (c = 1 / 2 / 4 / 8)")
+        a("")
+        a("| c | Lat avg | Lat P50 | Lat P99 | TTFT avg | TTFT P50 | TTFT P99 | TPOT avg | Output tok/s |")
+        a("|---|---------|---------|---------|----------|----------|----------|----------|--------------|")
+        for r in low_conc:
+            a(
+                f"| **{r.concurrency}** "
+                f"| {_fmt(r.latency_avg_ms, 1)} | {_fmt(r.latency_p50_ms, 1)} | {_fmt(r.latency_p99_ms, 1)} "
+                f"| {_fmt(r.ttft_avg_ms, 1)} | {_fmt(r.ttft_p50_ms, 1)} | {_fmt(r.ttft_p99_ms, 1)} "
+                f"| {_fmt(r.tpot_avg_ms, 1)} | {_fmt(r.output_token_throughput, 1)} |"
+            )
+        a("")
+
+        # Latency inflation analysis
+        if single and len(low_conc) > 1:
+            a("### 4.3 Latency Inflation vs c = 1")
+            a("")
+            a("Shows how much latency grows as concurrency increases from the single-request baseline.")
+            a("")
+            a("| c | Lat P99 delta | TTFT P99 delta | TPOT P99 delta |")
+            a("|---|---------------|----------------|----------------|")
+            for r in low_conc:
+                if r.concurrency == 1:
+                    continue
+                lat_delta = r.latency_p99_ms - single.latency_p99_ms
+                ttft_delta = r.ttft_p99_ms - single.ttft_p99_ms
+                tpot_delta = r.tpot_p99_ms - single.tpot_p99_ms
+                lat_sign = "+" if lat_delta >= 0 else ""
+                ttft_sign = "+" if ttft_delta >= 0 else ""
+                tpot_sign = "+" if tpot_delta >= 0 else ""
+                a(
+                    f"| **{r.concurrency}** "
+                    f"| `{lat_sign}{_fmt(lat_delta, 1)} ms` "
+                    f"| `{ttft_sign}{_fmt(ttft_delta, 1)} ms` "
+                    f"| `{tpot_sign}{_fmt(tpot_delta, 1)} ms` |"
+                )
+            a("")
+    else:
+        a("> No results with concurrency < 10 found. Re-run with `--parallel-levels` including 1, 2, 4, 8.")
+        a("")
+
+    # ── 5. Full Performance Overview ──────────────────────────────────────────
+    a("## 5. Full Performance Overview")
+    a("")
+    a("| Concurrency | Total Req | Success | Failed | Success Rate | RPS | Input tok/s | Output tok/s |")
+    a("|-------------|-----------|---------|--------|--------------|-----|-------------|--------------|")
+    for r in report.results:
+        sla_flag = ""
+        violations = _check_sla(r, report.sla)
+        if violations:
+            sla_flag = " ⚠️"
+        low_marker = " 🔹" if r.concurrency < 10 else ""
+        a(
+            f"| {r.concurrency}{low_marker} | {r.total_requests} | {r.success_requests} | {r.failed_requests} "
+            f"| {r.success_rate:.3f}{sla_flag} | {_fmt(r.request_throughput_rps)} "
+            f"| {_fmt(r.input_token_throughput, 0)} | {_fmt(r.output_token_throughput, 0)} |"
+        )
+    a("")
+    a("> 🔹 = low-concurrency (c < 10)  ⚠️ = SLA violation (see Section 7)")
+    a("")
+
+    # ── 6. Full Latency Distribution ──────────────────────────────────────────
+    a("## 6. Full Latency Distribution (ms)")
+    a("")
+    a("| Concurrency | Latency avg | Lat P50 | Lat P90 | Lat P99 | TTFT avg | TTFT P50 | TTFT P90 | TTFT P99 | TPOT avg | TPOT P50 | TPOT P99 |")
+    a("|-------------|-------------|---------|---------|---------|----------|----------|----------|----------|----------|----------|----------|")
+    for r in report.results:
+        low_marker = " 🔹" if r.concurrency < 10 else ""
+        a(
+            f"| {r.concurrency}{low_marker} "
+            f"| {_fmt(r.latency_avg_ms, 1)} | {_fmt(r.latency_p50_ms, 1)} | {_fmt(r.latency_p90_ms, 1)} | {_fmt(r.latency_p99_ms, 1)} "
+            f"| {_fmt(r.ttft_avg_ms, 1)} | {_fmt(r.ttft_p50_ms, 1)} | {_fmt(r.ttft_p90_ms, 1)} | {_fmt(r.ttft_p99_ms, 1)} "
+            f"| {_fmt(r.tpot_avg_ms, 1)} | {_fmt(r.tpot_p50_ms, 1)} | {_fmt(r.tpot_p99_ms, 1)} |"
+        )
+    a("")
+
+    # ── 7. Best Configuration Summary ────────────────────────────────────────
+    a("## 7. Best Configuration Summary")
+    a("")
+    valid = [r for r in report.results if r.success_rate >= 0.99]
+    if valid:
+        peak_tput = max(valid, key=lambda r: r.output_token_throughput)
+        best_ttft = min(valid, key=lambda r: r.ttft_p99_ms)
+        a(f"| Metric | Concurrency | Value |")
+        a(f"|--------|-------------|-------|")
+        a(f"| Peak Output Token Throughput | `{peak_tput.concurrency}` | `{_fmt(peak_tput.output_token_throughput, 0)} tok/s` |")
+        a(f"| Best P99 TTFT | `{best_ttft.concurrency}` | `{_fmt(best_ttft.ttft_p99_ms, 1)} ms` |")
+        a(f"| Best P99 Latency | `{min(valid, key=lambda r: r.latency_p99_ms).concurrency}` | `{_fmt(min(valid, key=lambda r: r.latency_p99_ms).latency_p99_ms, 1)} ms` |")
+        if single:
+            a(f"| Single-Request (c=1) TTFT avg | `1` | `{_fmt(single.ttft_avg_ms, 1)} ms` |")
+            a(f"| Single-Request (c=1) TPOT avg | `1` | `{_fmt(single.tpot_avg_ms, 1)} ms/token` |")
+        a("")
+        a(f"**Recommended concurrency for throughput**: `{peak_tput.concurrency}` (highest output tok/s with ≥99% success rate)")
+        if single:
+            a(f"**Single-request latency baseline**: TTFT `{_fmt(single.ttft_avg_ms, 1)} ms`, E2E `{_fmt(single.latency_avg_ms, 1)} ms`")
+    else:
+        a("> No concurrency level achieved ≥99% success rate. Review server logs for errors.")
+    a("")
+
+    # SLA violations summary
+    all_violations: list[tuple[int, list[str]]] = []
+    for r in report.results:
+        v = _check_sla(r, report.sla)
+        if v:
+            all_violations.append((r.concurrency, v))
+    if all_violations:
+        a("### SLA Violations")
+        a("")
+        for concurrency, violations in all_violations:
+            a(f"**Concurrency {concurrency}**:")
+            for v in violations:
+                a(f"  - {v}")
+        a("")
+
+    # ── 8. Reproducibility ───────────────────────────────────────────────────
+    a("## 8. Reproducibility")
+    a("")
+    a("### Server Launch Command")
+    a("```bash")
+    a(report.server_cmd or "# Not recorded")
+    a("```")
+    a("")
+    a("### evalscope Benchmark Command")
+    a("```bash")
+    a(report.evalscope_cmd or "# Not recorded")
+    a("```")
+    a("")
+    a("### Key Ascend Environment Variables")
+    a("```bash")
+    ascend_env_keys = [
+        "ASCEND_RT_VISIBLE_DEVICES", "VLLM_ASCEND_ENABLE_ACLGRAPH",
+        "VLLM_ASCEND_ENABLE_NZ", "HCCL_BUFFSIZE",
+        "ASCEND_LAUNCH_BLOCKING", "LD_LIBRARY_PATH",
+    ]
+    for k in ascend_env_keys:
+        val = os.environ.get(k)
+        if val:
+            a(f"export {k}={val}")
+    a("```")
+    a("")
+
+    return "\n".join(lines)
+
+
+# ── CSV export ─────────────────────────────────────────────────────────────────
+
+CSV_FIELDS = [
+    "concurrency", "total_requests", "success_requests", "failed_requests",
+    "success_rate", "request_throughput_rps", "input_token_throughput",
+    "output_token_throughput", "total_token_throughput",
+    "latency_avg_ms", "latency_p50_ms", "latency_p90_ms", "latency_p99_ms",
+    "ttft_avg_ms", "ttft_p50_ms", "ttft_p90_ms", "ttft_p99_ms",
+    "tpot_avg_ms", "tpot_p50_ms", "tpot_p90_ms", "tpot_p99_ms",
+]
+
+
+def write_csv(report: BenchmarkReport, output_path: Path) -> None:
+    with open(output_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_FIELDS)
+        writer.writeheader()
+        for r in report.results:
+            writer.writerow({k: getattr(r, k) for k in CSV_FIELDS})
+
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate benchmark report from evalscope output")
+    parser.add_argument("--results-dir", type=Path, required=True,
+                        help="Directory containing evalscope perf output")
+    parser.add_argument("--output-dir", type=Path, default=Path("./benchmark_output"),
+                        help="Output directory for report files")
+    parser.add_argument("--model-name", default="unknown", help="Model name for report header")
+    parser.add_argument("--model-path", default="", help="Model path or ID")
+    parser.add_argument("--config", type=Path, help="YAML config file to read model settings from")
+    parser.add_argument("--npu-info", type=Path, help="Path to npu-smi output file")
+    parser.add_argument("--vllm-commit", default="", help="vllm-ascend git commit hash")
+    parser.add_argument("--server-cmd", default="", help="Server launch command for report")
+    parser.add_argument("--evalscope-cmd", default="", help="evalscope command for report")
+    args = parser.parse_args()
+
+    # Load config if provided
+    cfg: dict = {}
+    if args.config and yaml:
+        try:
+            with open(args.config) as f:
+                cfg = yaml.safe_load(f) or {}
+        except (OSError, yaml.YAMLError) as e:
+            print(f"Warning: could not load config {args.config}: {e}", file=sys.stderr)
+
+    model_cfg = cfg.get("model", {})
+    server_cfg = cfg.get("server", {})
+    workload_cfg = cfg.get("workload", {})
+    sla_cfg = cfg.get("sla", {})
+
+    # Parse results
+    results = _parse_evalscope_output_dir(args.results_dir)
+    if not results:
+        print(
+            f"Warning: no benchmark results parsed from {args.results_dir}. "
+            "The report will be generated with empty tables.",
+            file=sys.stderr,
+        )
+
+    # NPU info
+    if args.npu_info and args.npu_info.exists():
+        npu_info = args.npu_info.read_text()
+    else:
+        npu_info = _get_npu_info()
+
+    report = BenchmarkReport(
+        model_name=args.model_name or model_cfg.get("name", "unknown"),
+        model_path=args.model_path or model_cfg.get("path", ""),
+        dtype=model_cfg.get("dtype", "float16"),
+        quantization=model_cfg.get("quantization"),
+        max_model_len=int(model_cfg.get("max_model_len", 8192)),
+        tensor_parallel_size=int(server_cfg.get("tensor_parallel_size", 1)),
+        pipeline_parallel_size=int(server_cfg.get("pipeline_parallel_size", 1)),
+        input_tokens=int(workload_cfg.get("input_tokens", 1024)),
+        output_tokens=int(workload_cfg.get("output_tokens", 512)),
+        npu_info=npu_info,
+        cann_version=_get_cann_version(),
+        vllm_ascend_version=_get_vllm_ascend_version(),
+        vllm_ascend_commit=args.vllm_commit,
+        evalscope_version=_get_evalscope_version(),
+        server_cmd=args.server_cmd,
+        evalscope_cmd=args.evalscope_cmd,
+        timestamp=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        results=results,
+        sla=sla_cfg,
+    )
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    md_path = args.output_dir / "benchmark_report.md"
+    md_path.write_text(render_markdown(report))
+    print(f"Markdown report written to: {md_path}")
+
+    csv_path = args.output_dir / "benchmark_results.csv"
+    write_csv(report, csv_path)
+    print(f"CSV results written to: {csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/scripts/generate_report.py
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/scripts/generate_report.py
@@ -107,22 +107,8 @@ def _parse_evalscope_summary_txt(summary_path: Path) -> list[ConcurrencyResult]:
     return results
 
 
-def _parse_evalscope_jsonl(jsonl_path: Path) -> list[ConcurrencyResult]:
-    """Parse evalscope result JSONL into ConcurrencyResult list."""
-    if not jsonl_path.exists():
-        return []
-
-    records: list[dict] = []
-    with open(jsonl_path) as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                records.append(json.loads(line))
-            except json.JSONDecodeError:
-                continue
-
+def _parse_records(records: list[dict]) -> list[ConcurrencyResult]:
+    """Normalize evalscope records into ConcurrencyResult entries."""
     results: list[ConcurrencyResult] = []
     for rec in records:
         stats = rec.get("stats", rec)
@@ -173,6 +159,50 @@ def _parse_evalscope_jsonl(jsonl_path: Path) -> list[ConcurrencyResult]:
     return results
 
 
+def _parse_evalscope_jsonl(jsonl_path: Path) -> list[ConcurrencyResult]:
+    """Parse evalscope result JSONL into ConcurrencyResult list."""
+    if not jsonl_path.exists():
+        return []
+
+    records: list[dict] = []
+    with open(jsonl_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    return _parse_records(records)
+
+
+def _parse_evalscope_json(json_path: Path) -> list[ConcurrencyResult]:
+    """Parse evalscope JSON output into ConcurrencyResult list."""
+    if not json_path.exists():
+        return []
+
+    try:
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return []
+
+    records: list[dict] = []
+    if isinstance(data, list):
+        records = [item for item in data if isinstance(item, dict)]
+    elif isinstance(data, dict):
+        for key in ("results", "records", "data"):
+            nested = data.get(key)
+            if isinstance(nested, list):
+                records = [item for item in nested if isinstance(item, dict)]
+                break
+        else:
+            records = [data]
+
+    return _parse_records(records)
+
+
 def _parse_evalscope_output_dir(results_dir: Path) -> list[ConcurrencyResult]:
     """Try multiple evalscope output formats."""
     # Try JSONL first
@@ -184,14 +214,9 @@ def _parse_evalscope_output_dir(results_dir: Path) -> list[ConcurrencyResult]:
     # Try JSON
     for pattern in ("*.json",):
         for p in results_dir.glob(pattern):
-            try:
-                data = json.loads(p.read_text())
-                if isinstance(data, list):
-                    for item in data:
-                        if "concurrency" in item or "parallel" in item:
-                            pass  # handled by jsonl parser above
-            except (json.JSONDecodeError, OSError):
-                pass
+            results = _parse_evalscope_json(p)
+            if results:
+                return results
     return []
 
 

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/scripts/generate_report.py
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/scripts/generate_report.py
@@ -23,7 +23,6 @@ import sys
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
 try:
     import yaml
@@ -32,6 +31,7 @@ except ImportError:
 
 
 # ── Data model ────────────────────────────────────────────────────────────────
+
 
 @dataclass
 class ConcurrencyResult:
@@ -67,7 +67,7 @@ class BenchmarkReport:
     model_name: str
     model_path: str
     dtype: str
-    quantization: Optional[str]
+    quantization: str | None
     max_model_len: int
     tensor_parallel_size: int
     pipeline_parallel_size: int
@@ -87,6 +87,7 @@ class BenchmarkReport:
 
 # ── Parsers ───────────────────────────────────────────────────────────────────
 
+
 def _safe_float(val, default: float = 0.0) -> float:
     try:
         return float(val)
@@ -94,127 +95,142 @@ def _safe_float(val, default: float = 0.0) -> float:
         return default
 
 
-def _parse_evalscope_summary_txt(summary_path: Path) -> list[ConcurrencyResult]:
-    """Parse evalscope performance_summary.txt into ConcurrencyResult list."""
-    if not summary_path.exists():
-        return []
+def _percentile_row(percentile: list, pct: str) -> dict:
+    """Find the row for a given percentile string (e.g. '99%') in evalscope
+    benchmark_percentile.json, which is a list of flat dicts."""
+    for row in percentile or []:
+        if isinstance(row, dict) and str(row.get("Percentiles", "")).strip() == pct:
+            return row
+    return {}
 
+
+def _parse_summary_and_percentile(summary: dict, percentile: list) -> ConcurrencyResult | None:
+    """Build one ConcurrencyResult from a paired evalscope v1.8.1
+    benchmark_summary.json (flat dict) + benchmark_percentile.json (list).
+
+    Field names are human-readable and carry units in the key:
+      - 'Avg Latency (s)' / 'Latency (s)' are in SECONDS -> *1000 to ms
+      - 'TTFT (ms)' / 'TPOT (ms)' / 'ITL (ms)' are already in ms
+    """
+    concurrency = _safe_float(summary.get("Concurrency"), -1)
+    if concurrency < 0:
+        return None
+    concurrency = int(concurrency)
+
+    total = int(_safe_float(summary.get("Total Requests")))
+    success = int(_safe_float(summary.get("Success Requests"), total))
+    failed = int(_safe_float(summary.get("Failed Requests"), max(total - success, 0)))
+
+    p50 = _percentile_row(percentile, "50%")
+    p90 = _percentile_row(percentile, "90%")
+    p99 = _percentile_row(percentile, "99%")
+
+    # Latency is recorded in seconds in evalscope; convert to ms.
+    latency_avg_ms = _safe_float(summary.get("Avg Latency (s)")) * 1000.0
+    latency_p50_ms = _safe_float(p50.get("Latency (s)")) * 1000.0
+    latency_p90_ms = _safe_float(p90.get("Latency (s)")) * 1000.0
+    latency_p99_ms = _safe_float(p99.get("Latency (s)")) * 1000.0
+
+    return ConcurrencyResult(
+        concurrency=concurrency,
+        total_requests=total,
+        success_requests=success,
+        failed_requests=failed,
+        success_rate=_safe_float(success) / max(total, 1),
+        request_throughput_rps=_safe_float(summary.get("Req Throughput (req/s)")),
+        input_token_throughput=_safe_float(summary.get("Input Throughput (tok/s)")),
+        output_token_throughput=_safe_float(summary.get("Output Throughput (tok/s)")),
+        total_token_throughput=_safe_float(summary.get("Total Throughput (tok/s)")),
+        latency_avg_ms=latency_avg_ms,
+        latency_p50_ms=latency_p50_ms,
+        latency_p90_ms=latency_p90_ms,
+        latency_p99_ms=latency_p99_ms,
+        ttft_avg_ms=_safe_float(summary.get("TTFT (ms)")),
+        ttft_p50_ms=_safe_float(p50.get("TTFT (ms)")),
+        ttft_p90_ms=_safe_float(p90.get("TTFT (ms)")),
+        ttft_p99_ms=_safe_float(p99.get("TTFT (ms)")),
+        tpot_avg_ms=_safe_float(summary.get("TPOT (ms)")),
+        tpot_p50_ms=_safe_float(p50.get("TPOT (ms)")),
+        tpot_p90_ms=_safe_float(p90.get("TPOT (ms)")),
+        tpot_p99_ms=_safe_float(p99.get("TPOT (ms)")),
+    )
+
+
+def _load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _parse_evalscope_v181_dir(results_dir: Path) -> list[ConcurrencyResult]:
+    """Parse real evalscope perf v1.8.1 output.
+
+    Layout: <results_dir>/<timestamp>/<name>/parallel_<P>_number_<N>/
+            {benchmark_summary.json, benchmark_percentile.json}
+    Each parallel_* subdir holds one concurrency level as a paired
+    summary (flat dict) + percentile (list) file set.
+    """
     results: list[ConcurrencyResult] = []
-    text = summary_path.read_text()
-
-    # evalscope outputs per-concurrency blocks; try to parse tables
-    # Format varies by version — we parse the JSON result file when available
-    return results
-
-
-def _parse_records(records: list[dict]) -> list[ConcurrencyResult]:
-    """Normalize evalscope records into ConcurrencyResult entries."""
-    results: list[ConcurrencyResult] = []
-    for rec in records:
-        stats = rec.get("stats", rec)
-        concurrency = int(rec.get("concurrency", rec.get("parallel", 0)))
-        if concurrency == 0:
+    # parallel_*_number_* may live at varying depths (timestamp/name/parallel
+    # when a timestamp is used, or directly name/parallel for single runs);
+    # rglob finds them regardless of nesting.
+    for sub in sorted(results_dir.rglob("parallel_*_number_*")):
+        if not sub.is_dir():
             continue
-
-        def ms(key: str, sub: str = "") -> float:
-            base = stats.get(key, stats.get(sub, {}))
-            if isinstance(base, dict):
-                return _safe_float(base.get("mean", base.get("avg", 0))) * 1000
-            return _safe_float(base) * 1000
-
-        def ms_pct(key: str, pct: str) -> float:
-            base = stats.get(key, {})
-            if isinstance(base, dict):
-                return _safe_float(base.get(pct, 0)) * 1000
-            return 0.0
-
-        total = int(stats.get("total_requests", stats.get("num_requests", 0)))
-        success = int(stats.get("success_requests", stats.get("num_completed", total)))
-
-        results.append(ConcurrencyResult(
-            concurrency=concurrency,
-            total_requests=total,
-            success_requests=success,
-            failed_requests=total - success,
-            success_rate=_safe_float(stats.get("success_rate", success / max(total, 1))),
-            request_throughput_rps=_safe_float(stats.get("request_throughput", stats.get("throughput_rps", 0))),
-            input_token_throughput=_safe_float(stats.get("input_token_throughput", 0)),
-            output_token_throughput=_safe_float(stats.get("output_token_throughput", stats.get("token_throughput", 0))),
-            total_token_throughput=_safe_float(stats.get("total_token_throughput", 0)),
-            latency_avg_ms=ms("latency", "e2e_latency"),
-            latency_p50_ms=ms_pct("latency", "p50"),
-            latency_p90_ms=ms_pct("latency", "p90"),
-            latency_p99_ms=ms_pct("latency", "p99"),
-            ttft_avg_ms=ms("ttft"),
-            ttft_p50_ms=ms_pct("ttft", "p50"),
-            ttft_p90_ms=ms_pct("ttft", "p90"),
-            ttft_p99_ms=ms_pct("ttft", "p99"),
-            tpot_avg_ms=ms("tpot"),
-            tpot_p50_ms=ms_pct("tpot", "p50"),
-            tpot_p90_ms=ms_pct("tpot", "p90"),
-            tpot_p99_ms=ms_pct("tpot", "p99"),
-        ))
+        summary_path = sub / "benchmark_summary.json"
+        percentile_path = sub / "benchmark_percentile.json"
+        summary = _load_json(summary_path)
+        percentile = _load_json(percentile_path)
+        if not isinstance(summary, dict):
+            continue
+        if not isinstance(percentile, list):
+            percentile = []
+        res = _parse_summary_and_percentile(summary, percentile)
+        if res is not None:
+            results.append(res)
 
     results.sort(key=lambda r: r.concurrency)
     return results
 
 
 def _parse_evalscope_jsonl(jsonl_path: Path) -> list[ConcurrencyResult]:
-    """Parse evalscope result JSONL into ConcurrencyResult list."""
+    """Fallback: parse evalscope JSONL where each line is a flat summary dict
+    using the v1.8.1 human-readable field names (no percentile file paired)."""
     if not jsonl_path.exists():
         return []
 
-    records: list[dict] = []
+    results: list[ConcurrencyResult] = []
     with open(jsonl_path, encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if not line:
                 continue
             try:
-                records.append(json.loads(line))
+                summary = json.loads(line)
             except json.JSONDecodeError:
                 continue
+            if not isinstance(summary, dict):
+                continue
+            res = _parse_summary_and_percentile(summary, [])
+            if res is not None:
+                results.append(res)
 
-    return _parse_records(records)
-
-
-def _parse_evalscope_json(json_path: Path) -> list[ConcurrencyResult]:
-    """Parse evalscope JSON output into ConcurrencyResult list."""
-    if not json_path.exists():
-        return []
-
-    try:
-        data = json.loads(json_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return []
-
-    records: list[dict] = []
-    if isinstance(data, list):
-        records = [item for item in data if isinstance(item, dict)]
-    elif isinstance(data, dict):
-        for key in ("results", "records", "data"):
-            nested = data.get(key)
-            if isinstance(nested, list):
-                records = [item for item in nested if isinstance(item, dict)]
-                break
-        else:
-            records = [data]
-
-    return _parse_records(records)
+    results.sort(key=lambda r: r.concurrency)
+    return results
 
 
 def _parse_evalscope_output_dir(results_dir: Path) -> list[ConcurrencyResult]:
-    """Try multiple evalscope output formats."""
-    # Try JSONL first
+    """Parse evalscope perf output. Prefers the real v1.8.1 paired
+    benchmark_summary.json / benchmark_percentile.json layout (nested under
+    timestamp/name/parallel_* subdirs); falls back to JSONL summaries."""
+    results = _parse_evalscope_v181_dir(results_dir)
+    if results:
+        return results
+
     for pattern in ("*.jsonl", "results.jsonl", "benchmark_results.jsonl"):
         for p in results_dir.glob(pattern):
             results = _parse_evalscope_jsonl(p)
-            if results:
-                return results
-    # Try JSON
-    for pattern in ("*.json",):
-        for p in results_dir.glob(pattern):
-            results = _parse_evalscope_json(p)
             if results:
                 return results
     return []
@@ -222,11 +238,10 @@ def _parse_evalscope_output_dir(results_dir: Path) -> list[ConcurrencyResult]:
 
 # ── Environment detection ──────────────────────────────────────────────────────
 
+
 def _get_npu_info() -> str:
     try:
-        result = subprocess.run(
-            ["npu-smi", "info"], capture_output=True, text=True, timeout=10
-        )
+        result = subprocess.run(["npu-smi", "info"], capture_output=True, text=True, timeout=10)
         return result.stdout.strip() if result.returncode == 0 else "npu-smi not available"
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return "npu-smi not available"
@@ -242,7 +257,9 @@ def _get_cann_version() -> str:
     try:
         r = subprocess.run(
             ["python3", "-c", "import torch_npu; print(torch_npu.version.cann)"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         if r.returncode == 0:
             return r.stdout.strip()
@@ -255,7 +272,9 @@ def _get_vllm_ascend_version() -> str:
     try:
         r = subprocess.run(
             ["python3", "-c", "import vllm_ascend; print(getattr(vllm_ascend, '__version__', 'unknown'))"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         return r.stdout.strip() if r.returncode == 0 else "unknown"
     except (FileNotFoundError, subprocess.TimeoutExpired):
@@ -266,7 +285,9 @@ def _get_evalscope_version() -> str:
     try:
         r = subprocess.run(
             ["python3", "-c", "import evalscope; print(evalscope.__version__)"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         return r.stdout.strip() if r.returncode == 0 else "unknown"
     except (FileNotFoundError, subprocess.TimeoutExpired):
@@ -275,27 +296,23 @@ def _get_evalscope_version() -> str:
 
 # ── SLA check ─────────────────────────────────────────────────────────────────
 
+
 def _check_sla(result: ConcurrencyResult, sla: dict) -> list[str]:
     violations: list[str] = []
     max_ttft = sla.get("max_p99_ttft_ms")
     if max_ttft and result.ttft_p99_ms > max_ttft:
-        violations.append(
-            f"P99 TTFT {result.ttft_p99_ms:.0f}ms > SLA {max_ttft}ms"
-        )
+        violations.append(f"P99 TTFT {result.ttft_p99_ms:.0f}ms > SLA {max_ttft}ms")
     min_sr = sla.get("min_success_rate")
     if min_sr and result.success_rate < min_sr:
-        violations.append(
-            f"success rate {result.success_rate:.3f} < SLA {min_sr}"
-        )
+        violations.append(f"success rate {result.success_rate:.3f} < SLA {min_sr}")
     min_tput = sla.get("min_output_token_throughput")
     if min_tput and result.output_token_throughput < min_tput:
-        violations.append(
-            f"output token throughput {result.output_token_throughput:.0f} tok/s < SLA {min_tput} tok/s"
-        )
+        violations.append(f"output token throughput {result.output_token_throughput:.0f} tok/s < SLA {min_tput} tok/s")
     return violations
 
 
 # ── Markdown rendering ─────────────────────────────────────────────────────────
+
 
 def _fmt(val: float, decimals: int = 2) -> str:
     return f"{val:.{decimals}f}"
@@ -305,17 +322,17 @@ def render_markdown(report: BenchmarkReport) -> str:
     lines: list[str] = []
     a = lines.append
 
-    a(f"# Ascend 910C vLLM Serving Benchmark Report")
-    a(f"")
+    a("# Ascend 910C vLLM Serving Benchmark Report")
+    a("")
     a(f"> Generated: {report.timestamp}")
-    a(f"")
+    a("")
 
     # ── 1. Environment ────────────────────────────────────────────────────────
     a("## 1. Environment")
     a("")
     a("| Item | Value |")
     a("|------|-------|")
-    a(f"| Hardware | Ascend 910C |")
+    a("| Hardware | Ascend 910C |")
     a(f"| CANN Version | `{report.cann_version}` |")
     a(f"| vllm-ascend Version | `{report.vllm_ascend_version}` |")
     a(f"| vllm-ascend Git Commit | `{report.vllm_ascend_commit}` |")
@@ -353,8 +370,8 @@ def render_markdown(report: BenchmarkReport) -> str:
     a("|------|-------|")
     a(f"| Input Tokens | `{report.input_tokens}` |")
     a(f"| Output Tokens | `{report.output_tokens}` |")
-    a(f"| Dataset | `random` |")
-    a(f"| Stream Mode | `true` (SSE) |")
+    a("| Dataset | `random` |")
+    a("| Stream Mode | `true` (SSE) |")
     a("")
 
     if not report.results:
@@ -456,14 +473,18 @@ def render_markdown(report: BenchmarkReport) -> str:
     # ── 6. Full Latency Distribution ──────────────────────────────────────────
     a("## 6. Full Latency Distribution (ms)")
     a("")
-    a("| Concurrency | Latency avg | Lat P50 | Lat P90 | Lat P99 | TTFT avg | TTFT P50 | TTFT P90 | TTFT P99 | TPOT avg | TPOT P50 | TPOT P99 |")
-    a("|-------------|-------------|---------|---------|---------|----------|----------|----------|----------|----------|----------|----------|")
+    a(
+        "| Concurrency | Latency avg | Lat P50 | Lat P90 | Lat P99 | TTFT avg | TTFT P50 | TTFT P90 | TTFT P99 | TPOT avg | TPOT P50 | TPOT P99 |"  # noqa: E501
+    )
+    a(
+        "|-------------|-------------|---------|---------|---------|----------|----------|----------|----------|----------|----------|----------|"
+    )
     for r in report.results:
         low_marker = " 🔹" if r.concurrency < 10 else ""
         a(
             f"| {r.concurrency}{low_marker} "
-            f"| {_fmt(r.latency_avg_ms, 1)} | {_fmt(r.latency_p50_ms, 1)} | {_fmt(r.latency_p90_ms, 1)} | {_fmt(r.latency_p99_ms, 1)} "
-            f"| {_fmt(r.ttft_avg_ms, 1)} | {_fmt(r.ttft_p50_ms, 1)} | {_fmt(r.ttft_p90_ms, 1)} | {_fmt(r.ttft_p99_ms, 1)} "
+            f"| {_fmt(r.latency_avg_ms, 1)} | {_fmt(r.latency_p50_ms, 1)} | {_fmt(r.latency_p90_ms, 1)} | {_fmt(r.latency_p99_ms, 1)} "  # noqa: E501
+            f"| {_fmt(r.ttft_avg_ms, 1)} | {_fmt(r.ttft_p50_ms, 1)} | {_fmt(r.ttft_p90_ms, 1)} | {_fmt(r.ttft_p99_ms, 1)} "  # noqa: E501
             f"| {_fmt(r.tpot_avg_ms, 1)} | {_fmt(r.tpot_p50_ms, 1)} | {_fmt(r.tpot_p99_ms, 1)} |"
         )
     a("")
@@ -475,18 +496,26 @@ def render_markdown(report: BenchmarkReport) -> str:
     if valid:
         peak_tput = max(valid, key=lambda r: r.output_token_throughput)
         best_ttft = min(valid, key=lambda r: r.ttft_p99_ms)
-        a(f"| Metric | Concurrency | Value |")
-        a(f"|--------|-------------|-------|")
-        a(f"| Peak Output Token Throughput | `{peak_tput.concurrency}` | `{_fmt(peak_tput.output_token_throughput, 0)} tok/s` |")
+        a("| Metric | Concurrency | Value |")
+        a("|--------|-------------|-------|")
+        a(
+            f"| Peak Output Token Throughput | `{peak_tput.concurrency}` | `{_fmt(peak_tput.output_token_throughput, 0)} tok/s` |"  # noqa: E501
+        )
         a(f"| Best P99 TTFT | `{best_ttft.concurrency}` | `{_fmt(best_ttft.ttft_p99_ms, 1)} ms` |")
-        a(f"| Best P99 Latency | `{min(valid, key=lambda r: r.latency_p99_ms).concurrency}` | `{_fmt(min(valid, key=lambda r: r.latency_p99_ms).latency_p99_ms, 1)} ms` |")
+        a(
+            f"| Best P99 Latency | `{min(valid, key=lambda r: r.latency_p99_ms).concurrency}` | `{_fmt(min(valid, key=lambda r: r.latency_p99_ms).latency_p99_ms, 1)} ms` |"  # noqa: E501
+        )
         if single:
             a(f"| Single-Request (c=1) TTFT avg | `1` | `{_fmt(single.ttft_avg_ms, 1)} ms` |")
             a(f"| Single-Request (c=1) TPOT avg | `1` | `{_fmt(single.tpot_avg_ms, 1)} ms/token` |")
         a("")
-        a(f"**Recommended concurrency for throughput**: `{peak_tput.concurrency}` (highest output tok/s with ≥99% success rate)")
+        a(
+            f"**Recommended concurrency for throughput**: `{peak_tput.concurrency}` (highest output tok/s with ≥99% success rate)"  # noqa: E501
+        )
         if single:
-            a(f"**Single-request latency baseline**: TTFT `{_fmt(single.ttft_avg_ms, 1)} ms`, E2E `{_fmt(single.latency_avg_ms, 1)} ms`")
+            a(
+                f"**Single-request latency baseline**: TTFT `{_fmt(single.ttft_avg_ms, 1)} ms`, E2E `{_fmt(single.latency_avg_ms, 1)} ms`"  # noqa: E501
+            )
     else:
         a("> No concurrency level achieved ≥99% success rate. Review server logs for errors.")
     a("")
@@ -522,9 +551,11 @@ def render_markdown(report: BenchmarkReport) -> str:
     a("### Key Ascend Environment Variables")
     a("```bash")
     ascend_env_keys = [
-        "ASCEND_RT_VISIBLE_DEVICES", "VLLM_ASCEND_ENABLE_ACLGRAPH",
-        "VLLM_ASCEND_ENABLE_NZ", "HCCL_BUFFSIZE",
-        "ASCEND_LAUNCH_BLOCKING", "LD_LIBRARY_PATH",
+        "ASCEND_RT_VISIBLE_DEVICES",
+        "VLLM_ASCEND_ENABLE_NZ",
+        "HCCL_BUFFSIZE",
+        "ASCEND_LAUNCH_BLOCKING",
+        "LD_LIBRARY_PATH",
     ]
     for k in ascend_env_keys:
         val = os.environ.get(k)
@@ -539,12 +570,27 @@ def render_markdown(report: BenchmarkReport) -> str:
 # ── CSV export ─────────────────────────────────────────────────────────────────
 
 CSV_FIELDS = [
-    "concurrency", "total_requests", "success_requests", "failed_requests",
-    "success_rate", "request_throughput_rps", "input_token_throughput",
-    "output_token_throughput", "total_token_throughput",
-    "latency_avg_ms", "latency_p50_ms", "latency_p90_ms", "latency_p99_ms",
-    "ttft_avg_ms", "ttft_p50_ms", "ttft_p90_ms", "ttft_p99_ms",
-    "tpot_avg_ms", "tpot_p50_ms", "tpot_p90_ms", "tpot_p99_ms",
+    "concurrency",
+    "total_requests",
+    "success_requests",
+    "failed_requests",
+    "success_rate",
+    "request_throughput_rps",
+    "input_token_throughput",
+    "output_token_throughput",
+    "total_token_throughput",
+    "latency_avg_ms",
+    "latency_p50_ms",
+    "latency_p90_ms",
+    "latency_p99_ms",
+    "ttft_avg_ms",
+    "ttft_p50_ms",
+    "ttft_p90_ms",
+    "ttft_p99_ms",
+    "tpot_avg_ms",
+    "tpot_p50_ms",
+    "tpot_p90_ms",
+    "tpot_p99_ms",
 ]
 
 
@@ -558,12 +604,13 @@ def write_csv(report: BenchmarkReport, output_path: Path) -> None:
 
 # ── Main ───────────────────────────────────────────────────────────────────────
 
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate benchmark report from evalscope output")
-    parser.add_argument("--results-dir", type=Path, required=True,
-                        help="Directory containing evalscope perf output")
-    parser.add_argument("--output-dir", type=Path, default=Path("./benchmark_output"),
-                        help="Output directory for report files")
+    parser.add_argument("--results-dir", type=Path, required=True, help="Directory containing evalscope perf output")
+    parser.add_argument(
+        "--output-dir", type=Path, default=Path("./benchmark_output"), help="Output directory for report files"
+    )
     parser.add_argument("--model-name", default="unknown", help="Model name for report header")
     parser.add_argument("--model-path", default="", help="Model path or ID")
     parser.add_argument("--config", type=Path, help="YAML config file to read model settings from")

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/scripts/run_benchmark.sh
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/scripts/run_benchmark.sh
@@ -1,34 +1,8 @@
 #!/usr/bin/env bash
 # run_benchmark.sh — End-to-end benchmark runner for vllm-ascend on Ascend 910C
-#
-# Usage:
-#   bash run_benchmark.sh [OPTIONS]
-#
-# Options (all override config file values):
-#   --model-path PATH            Model local path or HuggingFace/ModelScope ID
-#   --model-name NAME            Short name used in report and API served_model_name
-#   --config FILE                YAML config file (default: none)
-#   --tp INT                     Tensor parallel size (default: 1)
-#   --pp INT                     Pipeline parallel size (default: 1)
-#   --max-model-len INT          Max context length (default: 8192)
-#   --dtype STR                  float16|bfloat16|auto (default: float16)
-#   --quantization STR           w8a8|w4a16|null (default: none)
-#   --port INT                   Server port (default: 8000)
-#   --parallel-levels STR        Space-separated concurrency list (default: "1 4 8 16 32 64")
-#   --requests-per-level STR     Space-separated request counts (default: "10 40 80 160 320 640")
-#   --input-tokens INT           Input token length (default: 1024)
-#   --output-tokens INT          Output token length (default: 512)
-#   --warmup-requests INT        Warm-up request count (default: 20)
-#   --output-dir DIR             Where to save reports (default: ./benchmark_output/<timestamp>)
-#   --npu-devices STR            ASCEND_RT_VISIBLE_DEVICES value (default: auto-detect from tp)
-#   --skip-warmup                Skip warm-up phase
-#   --no-aclgraph                Disable ACLGraph (VLLM_ASCEND_ENABLE_ACLGRAPH=0)
-#   --no-nz                      Disable NZ format (VLLM_ASCEND_ENABLE_NZ=0)
-#   --dry-run                    Print commands without executing them
 
 set -euo pipefail
 
-# ── Defaults ──────────────────────────────────────────────────────────────────
 MODEL_PATH=""
 MODEL_NAME=""
 CONFIG_FILE=""
@@ -47,35 +21,211 @@ TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 OUTPUT_DIR=""
 NPU_DEVICES=""
 SKIP_WARMUP=0
-ENABLE_ACLGRAPH=1
-ENABLE_NZ=0
+ACLGRAPH_OVERRIDE=""
+NZ_OVERRIDE=""
+TRUST_REMOTE_CODE=1
+STREAM_MODE=1
 DRY_RUN=0
+SERVER_PID=""
+EVALSCOPE_CMD=(evalscope perf)
 
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SERVER_ENV_ASSIGNMENTS=()
 
-# ── Argument parsing ───────────────────────────────────────────────────────────
+log() { echo "[$(date '+%H:%M:%S')] $*"; }
+
+shell_escape() {
+    printf "%q" "$1"
+}
+
+join_command() {
+    local out=""
+    local token
+    for token in "$@"; do
+        out+="$(_escape "${token}") "
+    done
+    printf "%s" "${out% }"
+}
+
+_escape() {
+    shell_escape "$1"
+}
+
+get_env_value() {
+    local key="$1"
+    local prefix="${key}="
+    local entry
+    for entry in "${SERVER_ENV_ASSIGNMENTS[@]}"; do
+        if [[ "${entry}" == "${prefix}"* ]]; then
+            printf "%s" "${entry#*=}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+upsert_env_value() {
+    local key="$1"
+    local value="$2"
+    local prefix="${key}="
+    local i
+    for ((i = 0; i < ${#SERVER_ENV_ASSIGNMENTS[@]}; i++)); do
+        if [[ "${SERVER_ENV_ASSIGNMENTS[$i]}" == "${prefix}"* ]]; then
+            SERVER_ENV_ASSIGNMENTS[$i]="${prefix}${value}"
+            return
+        fi
+    done
+    SERVER_ENV_ASSIGNMENTS+=("${prefix}${value}")
+}
+
+default_npu_devices() {
+    local count="$1"
+    local devices=()
+    local idx
+
+    for ((idx = 0; idx < count; idx++)); do
+        devices+=("${idx}")
+    done
+
+    local joined=""
+    for idx in "${!devices[@]}"; do
+        if [[ "${idx}" -gt 0 ]]; then
+            joined+=","
+        fi
+        joined+="${devices[$idx]}"
+    done
+
+    printf "%s" "${joined}"
+}
+
+load_yaml_value() {
+    local key_path="$1"
+    python3 - "$CONFIG_FILE" "$key_path" <<'PY'
+import sys
+
+import yaml
+
+config_path, key_path = sys.argv[1], sys.argv[2]
+with open(config_path, encoding="utf-8") as fh:
+    cfg = yaml.safe_load(fh) or {}
+
+value = cfg
+for key in key_path.split("."):
+    if isinstance(value, dict) and key in value:
+        value = value[key]
+    else:
+        value = None
+        break
+
+if value is None:
+    sys.exit(0)
+if isinstance(value, bool):
+    print("true" if value else "false")
+else:
+    print(value)
+PY
+}
+
+load_yaml_env_assignments() {
+    python3 - "$CONFIG_FILE" <<'PY'
+import sys
+
+import yaml
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    cfg = yaml.safe_load(fh) or {}
+
+env = cfg.get("server", {}).get("env", {}) or {}
+for key, value in env.items():
+    if value is None:
+        continue
+    print(f"{key}={value}")
+PY
+}
+
+cleanup_server() {
+    if [[ -n "${SERVER_PID}" ]] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+        log "Stopping server (PID ${SERVER_PID})..."
+        kill "${SERVER_PID}" 2>/dev/null || true
+        wait "${SERVER_PID}" 2>/dev/null || true
+        log "Server stopped."
+    fi
+}
+
+detect_evalscope_outputs_flag() {
+    local help_output=""
+    if [[ "${DRY_RUN}" -eq 1 ]] && ! command -v evalscope >/dev/null 2>&1; then
+        printf "%s" "--outputs-dir"
+        return 0
+    fi
+
+    if command -v evalscope >/dev/null 2>&1; then
+        help_output=$(evalscope perf --help 2>/dev/null || true)
+    else
+        help_output=$(python3 -m evalscope perf --help 2>/dev/null || true)
+    fi
+
+    if grep -q -- "--outputs-dir" <<<"${help_output}" || grep -q -- "outputs_dir" <<<"${help_output}"; then
+        printf "%s" "--outputs-dir"
+        return 0
+    fi
+
+    printf "%s" ""
+}
+
+run_evalscope_with_output_dir() {
+    local result_dir="$1"
+    shift
+
+    local output_flag="$1"
+    shift
+
+    if [[ -n "${output_flag}" ]]; then
+        if [[ "${DRY_RUN}" -eq 1 ]]; then
+            printf '[DRY-RUN] %s\n' "$(join_command "$@" "${output_flag}" "${result_dir}")"
+        else
+            "$@" "${output_flag}" "${result_dir}"
+        fi
+        return
+    fi
+
+    if [[ "${DRY_RUN}" -eq 1 ]]; then
+        printf '[DRY-RUN] cd %s && %s\n' \
+            "$(shell_escape "${result_dir}")" \
+            "$(join_command "$@")"
+        return
+    fi
+
+    (
+        cd "${result_dir}"
+        "$@"
+    )
+}
+
+trap cleanup_server EXIT
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --model-path)      MODEL_PATH="$2";        shift 2 ;;
-        --model-name)      MODEL_NAME="$2";        shift 2 ;;
-        --config)          CONFIG_FILE="$2";       shift 2 ;;
-        --tp)              TP="$2";                shift 2 ;;
-        --pp)              PP="$2";                shift 2 ;;
-        --max-model-len)   MAX_MODEL_LEN="$2";     shift 2 ;;
-        --dtype)           DTYPE="$2";             shift 2 ;;
-        --quantization)    QUANTIZATION="$2";      shift 2 ;;
-        --port)            PORT="$2";              shift 2 ;;
-        --parallel-levels) PARALLEL_LEVELS="$2";   shift 2 ;;
+        --model-path) MODEL_PATH="$2"; shift 2 ;;
+        --model-name) MODEL_NAME="$2"; shift 2 ;;
+        --config) CONFIG_FILE="$2"; shift 2 ;;
+        --tp) TP="$2"; shift 2 ;;
+        --pp) PP="$2"; shift 2 ;;
+        --max-model-len) MAX_MODEL_LEN="$2"; shift 2 ;;
+        --dtype) DTYPE="$2"; shift 2 ;;
+        --quantization) QUANTIZATION="$2"; shift 2 ;;
+        --port) PORT="$2"; shift 2 ;;
+        --parallel-levels) PARALLEL_LEVELS="$2"; shift 2 ;;
         --requests-per-level) REQUESTS_PER_LEVEL="$2"; shift 2 ;;
-        --input-tokens)    INPUT_TOKENS="$2";      shift 2 ;;
-        --output-tokens)   OUTPUT_TOKENS="$2";     shift 2 ;;
-        --warmup-requests) WARMUP_REQUESTS="$2";   shift 2 ;;
-        --output-dir)      OUTPUT_DIR="$2";        shift 2 ;;
-        --npu-devices)     NPU_DEVICES="$2";       shift 2 ;;
-        --skip-warmup)     SKIP_WARMUP=1;          shift ;;
-        --no-aclgraph)     ENABLE_ACLGRAPH=0;      shift ;;
-        --no-nz)           ENABLE_NZ=0;            shift ;;
-        --dry-run)         DRY_RUN=1;              shift ;;
+        --input-tokens) INPUT_TOKENS="$2"; shift 2 ;;
+        --output-tokens) OUTPUT_TOKENS="$2"; shift 2 ;;
+        --warmup-requests) WARMUP_REQUESTS="$2"; shift 2 ;;
+        --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+        --npu-devices) NPU_DEVICES="$2"; shift 2 ;;
+        --skip-warmup) SKIP_WARMUP=1; shift ;;
+        --no-aclgraph) ACLGRAPH_OVERRIDE="0"; shift ;;
+        --no-nz) NZ_OVERRIDE="0"; shift ;;
+        --dry-run) DRY_RUN=1; shift ;;
         *)
             echo "Unknown option: $1" >&2
             exit 1
@@ -83,176 +233,189 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# ── Apply YAML config if provided ─────────────────────────────────────────────
 if [[ -n "${CONFIG_FILE}" ]]; then
     if [[ ! -f "${CONFIG_FILE}" ]]; then
         echo "ERROR: config file not found: ${CONFIG_FILE}" >&2
         exit 1
     fi
-    _yaml_get() {
-        python3 -c "
-import yaml, sys
-cfg = yaml.safe_load(open('${CONFIG_FILE}'))
-keys = '$1'.split('.')
-val = cfg
-for k in keys:
-    if isinstance(val, dict) and k in val:
-        val = val[k]
-    else:
-        val = None
-        break
-if val is not None:
-    print(val)
-" 2>/dev/null || true
-    }
-    [[ -z "${MODEL_PATH}" ]]   && MODEL_PATH=$(_yaml_get model.path)
-    [[ -z "${MODEL_NAME}" ]]   && MODEL_NAME=$(_yaml_get model.name)
-    _tp=$(_yaml_get server.tensor_parallel_size);  [[ -n "$_tp" ]] && TP=$_tp
-    _pp=$(_yaml_get server.pipeline_parallel_size); [[ -n "$_pp" ]] && PP=$_pp
-    _port=$(_yaml_get server.port);                [[ -n "$_port" ]] && PORT=$_port
-    _mml=$(_yaml_get model.max_model_len);         [[ -n "$_mml" ]] && MAX_MODEL_LEN=$_mml
-    _dtype=$(_yaml_get model.dtype);               [[ -n "$_dtype" ]] && DTYPE=$_dtype
-    _quant=$(_yaml_get model.quantization);        [[ -n "$_quant" && "$_quant" != "None" && "$_quant" != "null" ]] && QUANTIZATION=$_quant
-    _pl=$(_yaml_get benchmark.parallel_levels);    [[ -n "$_pl" ]] && PARALLEL_LEVELS=$_pl
-    _rpl=$(_yaml_get benchmark.requests_per_level);[[ -n "$_rpl" ]] && REQUESTS_PER_LEVEL=$_rpl
-    _it=$(_yaml_get workload.input_tokens);        [[ -n "$_it" ]] && INPUT_TOKENS=$_it
-    _ot=$(_yaml_get workload.output_tokens);       [[ -n "$_ot" ]] && OUTPUT_TOKENS=$_ot
-    _wr=$(_yaml_get benchmark.warmup_requests);    [[ -n "$_wr" ]] && WARMUP_REQUESTS=$_wr
-    _npu=$(_yaml_get server.env.ASCEND_RT_VISIBLE_DEVICES); [[ -n "$_npu" && -z "${NPU_DEVICES}" ]] && NPU_DEVICES=$_npu
+
+    if ! python3 -c "import yaml" >/dev/null 2>&1; then
+        echo "ERROR: PyYAML is required to read --config files. Run: pip install pyyaml" >&2
+        exit 1
+    fi
+
+    while IFS= read -r assignment; do
+        [[ -n "${assignment}" ]] || continue
+        SERVER_ENV_ASSIGNMENTS+=("${assignment}")
+    done < <(load_yaml_env_assignments)
+
+    [[ -z "${MODEL_PATH}" ]] && MODEL_PATH="$(load_yaml_value model.path || true)"
+    [[ -z "${MODEL_NAME}" ]] && MODEL_NAME="$(load_yaml_value model.name || true)"
+
+    _tp="$(load_yaml_value server.tensor_parallel_size || true)"
+    [[ -n "${_tp}" ]] && TP="${_tp}"
+    _pp="$(load_yaml_value server.pipeline_parallel_size || true)"
+    [[ -n "${_pp}" ]] && PP="${_pp}"
+    _port="$(load_yaml_value server.port || true)"
+    [[ -n "${_port}" ]] && PORT="${_port}"
+    _mml="$(load_yaml_value model.max_model_len || true)"
+    [[ -n "${_mml}" ]] && MAX_MODEL_LEN="${_mml}"
+    _dtype="$(load_yaml_value model.dtype || true)"
+    [[ -n "${_dtype}" ]] && DTYPE="${_dtype}"
+    _quant="$(load_yaml_value model.quantization || true)"
+    if [[ -n "${_quant}" && "${_quant}" != "None" && "${_quant}" != "null" ]]; then
+        QUANTIZATION="${_quant}"
+    fi
+    _pl="$(load_yaml_value benchmark.parallel_levels || true)"
+    [[ -n "${_pl}" ]] && PARALLEL_LEVELS="${_pl}"
+    _rpl="$(load_yaml_value benchmark.requests_per_level || true)"
+    [[ -n "${_rpl}" ]] && REQUESTS_PER_LEVEL="${_rpl}"
+    _it="$(load_yaml_value workload.input_tokens || true)"
+    [[ -n "${_it}" ]] && INPUT_TOKENS="${_it}"
+    _ot="$(load_yaml_value workload.output_tokens || true)"
+    [[ -n "${_ot}" ]] && OUTPUT_TOKENS="${_ot}"
+    _wr="$(load_yaml_value benchmark.warmup_requests || true)"
+    [[ -n "${_wr}" ]] && WARMUP_REQUESTS="${_wr}"
+    _stream="$(load_yaml_value benchmark.stream || true)"
+    [[ "${_stream}" == "false" ]] && STREAM_MODE=0
+    _trust_remote_code="$(load_yaml_value model.trust_remote_code || true)"
+    [[ "${_trust_remote_code}" == "false" ]] && TRUST_REMOTE_CODE=0
+
+    if [[ -z "${NPU_DEVICES}" ]]; then
+        _npu="$(load_yaml_value server.env.ASCEND_RT_VISIBLE_DEVICES || true)"
+        [[ -n "${_npu}" ]] && NPU_DEVICES="${_npu}"
+    fi
 fi
 
-# ── Validation ─────────────────────────────────────────────────────────────────
 if [[ -z "${MODEL_PATH}" ]]; then
     echo "ERROR: --model-path is required (or set model.path in config)" >&2
     exit 1
 fi
+
 if [[ -z "${MODEL_NAME}" ]]; then
-    MODEL_NAME=$(basename "${MODEL_PATH}")
-    echo "INFO: --model-name not set, using '${MODEL_NAME}'"
+    MODEL_NAME="$(basename "${MODEL_PATH}")"
+    log "INFO: --model-name not set, using '${MODEL_NAME}'"
 fi
 
-# Auto-detect NPU devices
 if [[ -z "${NPU_DEVICES}" ]]; then
-    NPU_DEVICES=$(seq -s "," 0 $((TP * PP - 1)))
+    NPU_DEVICES="$(default_npu_devices "$((TP * PP))")"
 fi
 
 if [[ -z "${OUTPUT_DIR}" ]]; then
     OUTPUT_DIR="./benchmark_output/${TIMESTAMP}_${MODEL_NAME}"
 fi
-mkdir -p "${OUTPUT_DIR}"
 
+mkdir -p "${OUTPUT_DIR}"
 EVALSCOPE_RESULTS_DIR="${OUTPUT_DIR}/evalscope_results"
-mkdir -p "${EVALSCOPE_RESULTS_DIR}"
+WARMUP_RESULTS_DIR="${OUTPUT_DIR}/evalscope_warmup"
+mkdir -p "${EVALSCOPE_RESULTS_DIR}" "${WARMUP_RESULTS_DIR}"
 
 SERVER_LOG="${OUTPUT_DIR}/server.log"
 NPU_INFO_FILE="${OUTPUT_DIR}/npu_info.txt"
 
-# ── Logging helper ─────────────────────────────────────────────────────────────
-log() { echo "[$(date '+%H:%M:%S')] $*"; }
-run() {
-    if [[ "${DRY_RUN}" -eq 1 ]]; then
-        echo "[DRY-RUN] $*"
-    else
-        "$@"
-    fi
-}
+upsert_env_value "ASCEND_RT_VISIBLE_DEVICES" "${NPU_DEVICES}"
+if [[ -n "${ACLGRAPH_OVERRIDE}" ]]; then
+    upsert_env_value "VLLM_ASCEND_ENABLE_ACLGRAPH" "${ACLGRAPH_OVERRIDE}"
+elif ! get_env_value "VLLM_ASCEND_ENABLE_ACLGRAPH" >/dev/null 2>&1; then
+    upsert_env_value "VLLM_ASCEND_ENABLE_ACLGRAPH" "1"
+fi
 
-# ── Phase 1: Environment check ─────────────────────────────────────────────────
+if [[ -n "${NZ_OVERRIDE}" ]]; then
+    upsert_env_value "VLLM_ASCEND_ENABLE_NZ" "${NZ_OVERRIDE}"
+elif ! get_env_value "VLLM_ASCEND_ENABLE_NZ" >/dev/null 2>&1; then
+    upsert_env_value "VLLM_ASCEND_ENABLE_NZ" "0"
+fi
+
 log "=== Phase 1: Environment Validation ==="
 
 npu-smi info > "${NPU_INFO_FILE}" 2>&1 || log "WARN: npu-smi not available"
 log "NPU info saved to ${NPU_INFO_FILE}"
 
 if ! python3 -c "import vllm_ascend" 2>/dev/null; then
-    echo "ERROR: vllm-ascend not installed. Run: pip install vllm-ascend" >&2
-    exit 1
+    if [[ "${DRY_RUN}" -eq 1 ]]; then
+        log "WARN: vllm-ascend not installed; continuing because --dry-run was requested"
+    else
+        echo "ERROR: vllm-ascend not installed. Run: pip install vllm-ascend" >&2
+        exit 1
+    fi
 fi
 
-if ! command -v evalscope &>/dev/null && ! python3 -m evalscope --version &>/dev/null 2>&1; then
-    echo "ERROR: evalscope not found. Run: pip install evalscope[perf] -U" >&2
-    exit 1
+if ! command -v evalscope >/dev/null 2>&1 && ! python3 -m evalscope --version >/dev/null 2>&1; then
+    if [[ "${DRY_RUN}" -eq 1 ]]; then
+        log "WARN: evalscope not installed; continuing because --dry-run was requested"
+    else
+        echo "ERROR: evalscope not found. Run: pip install evalscope[perf] -U" >&2
+        exit 1
+    fi
+fi
+
+if ! command -v evalscope >/dev/null 2>&1; then
+    EVALSCOPE_CMD=(python3 -m evalscope perf)
 fi
 
 if [[ -n "${CONFIG_FILE}" ]]; then
     log "Validating config file: ${CONFIG_FILE}"
-    run python3 "${SKILL_DIR}/scripts/validate_configs.py" "${CONFIG_FILE}"
+    python3 "${SKILL_DIR}/scripts/validate_configs.py" "${CONFIG_FILE}"
 fi
 
-# Get version info
-VLLM_ASCEND_VERSION=$(python3 -c "import vllm_ascend; print(getattr(vllm_ascend, '__version__', 'unknown'))" 2>/dev/null || echo "unknown")
-VLLM_ASCEND_COMMIT=$(python3 -c "
-import importlib.util, subprocess, pathlib
+VLLM_ASCEND_VERSION="$(python3 -c "import vllm_ascend; print(getattr(vllm_ascend, '__version__', 'unknown'))" 2>/dev/null || echo "unknown")"
+VLLM_ASCEND_COMMIT="$(python3 -c "
+import importlib.util, pathlib, subprocess
 spec = importlib.util.find_spec('vllm_ascend')
-if spec:
-    loc = str(pathlib.Path(spec.origin).parent)
-    result = subprocess.run(['git', '-C', loc, 'rev-parse', '--short', 'HEAD'],
-        capture_output=True, text=True)
-    print(result.stdout.strip() if result.returncode == 0 else 'unknown')
-else:
+if not spec:
     print('unknown')
-" 2>/dev/null || echo "unknown")
+else:
+    loc = pathlib.Path(spec.origin).parent
+    result = subprocess.run(
+        ['git', '-C', str(loc), 'rev-parse', '--short', 'HEAD'],
+        capture_output=True, text=True,
+    )
+    print(result.stdout.strip() if result.returncode == 0 else 'unknown')
+" 2>/dev/null || echo "unknown")"
 
 log "vllm-ascend: ${VLLM_ASCEND_VERSION} (${VLLM_ASCEND_COMMIT})"
 log "NPU devices: ${NPU_DEVICES}"
 log "TP=${TP}  PP=${PP}  port=${PORT}"
 
-# ── Phase 2: Launch vLLM-Ascend server ────────────────────────────────────────
-log "=== Phase 2: Launching vLLM-Ascend Server ==="
+SERVER_ARGS=(
+    python3 -m vllm.entrypoints.openai.api_server
+    --model "${MODEL_PATH}"
+    --served-model-name "${MODEL_NAME}"
+    --tensor-parallel-size "${TP}"
+    --pipeline-parallel-size "${PP}"
+    --max-model-len "${MAX_MODEL_LEN}"
+    --dtype "${DTYPE}"
+    --port "${PORT}"
+)
 
-# Build server command
-QUANT_FLAGS=""
 if [[ -n "${QUANTIZATION}" ]]; then
-    QUANT_FLAGS="--quantization ${QUANTIZATION}"
+    SERVER_ARGS+=(--quantization "${QUANTIZATION}")
 fi
 
-SERVER_CMD="ASCEND_RT_VISIBLE_DEVICES=${NPU_DEVICES} \
-VLLM_ASCEND_ENABLE_ACLGRAPH=${ENABLE_ACLGRAPH} \
-VLLM_ASCEND_ENABLE_NZ=${ENABLE_NZ} \
-python3 -m vllm.entrypoints.openai.api_server \
-  --model ${MODEL_PATH} \
-  --served-model-name ${MODEL_NAME} \
-  --tensor-parallel-size ${TP} \
-  --pipeline-parallel-size ${PP} \
-  --max-model-len ${MAX_MODEL_LEN} \
-  --dtype ${DTYPE} \
-  --port ${PORT} \
-  --trust-remote-code \
-  ${QUANT_FLAGS}"
+if [[ "${TRUST_REMOTE_CODE}" -eq 1 ]]; then
+    SERVER_ARGS+=(--trust-remote-code)
+fi
 
-# Save server command for report
-echo "${SERVER_CMD}" > "${OUTPUT_DIR}/server_cmd.txt"
+SERVER_CMD_PARTS=(env)
+for assignment in "${SERVER_ENV_ASSIGNMENTS[@]}"; do
+    SERVER_CMD_PARTS+=("${assignment}")
+done
+for arg in "${SERVER_ARGS[@]}"; do
+    SERVER_CMD_PARTS+=("${arg}")
+done
+printf '%s\n' "$(join_command "${SERVER_CMD_PARTS[@]}")" > "${OUTPUT_DIR}/server_cmd.txt"
 
+log "=== Phase 2: Launching vLLM-Ascend Server ==="
 if [[ "${DRY_RUN}" -eq 0 ]]; then
-    export ASCEND_RT_VISIBLE_DEVICES="${NPU_DEVICES}"
-    export VLLM_ASCEND_ENABLE_ACLGRAPH="${ENABLE_ACLGRAPH}"
-    export VLLM_ASCEND_ENABLE_NZ="${ENABLE_NZ}"
-
-    python3 -m vllm.entrypoints.openai.api_server \
-        --model "${MODEL_PATH}" \
-        --served-model-name "${MODEL_NAME}" \
-        --tensor-parallel-size "${TP}" \
-        --pipeline-parallel-size "${PP}" \
-        --max-model-len "${MAX_MODEL_LEN}" \
-        --dtype "${DTYPE}" \
-        --port "${PORT}" \
-        --trust-remote-code \
-        ${QUANT_FLAGS:+${QUANT_FLAGS}} \
-        > "${SERVER_LOG}" 2>&1 &
-
+    env "${SERVER_ENV_ASSIGNMENTS[@]}" "${SERVER_ARGS[@]}" > "${SERVER_LOG}" 2>&1 &
     SERVER_PID=$!
     log "Server started with PID ${SERVER_PID}, log: ${SERVER_LOG}"
 
-    # Wait for server to be ready
     log "Waiting for server to be ready (max 300s)..."
     READY=0
     for i in $(seq 1 60); do
         sleep 5
-        if curl -s "http://127.0.0.1:${PORT}/health" | grep -q "{}"; then
-            READY=1
-            break
-        fi
-        # Also accept 200 with any body
-        HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${PORT}/health" 2>/dev/null || echo "000")
+        HTTP_CODE="$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${PORT}/health" 2>/dev/null || echo "000")"
         if [[ "${HTTP_CODE}" == "200" ]]; then
             READY=1
             break
@@ -262,79 +425,89 @@ if [[ "${DRY_RUN}" -eq 0 ]]; then
 
     if [[ "${READY}" -eq 0 ]]; then
         echo "ERROR: Server failed to start within 300s. Check ${SERVER_LOG}" >&2
-        kill "${SERVER_PID}" 2>/dev/null || true
         exit 1
     fi
     log "Server is ready."
 else
-    log "[DRY-RUN] Would start: ${SERVER_CMD}"
-    SERVER_PID=0
+    log "[DRY-RUN] Would start: $(join_command "${SERVER_CMD_PARTS[@]}")"
 fi
 
-# ── Phase 3: Warm-up ──────────────────────────────────────────────────────────
-EVALSCOPE_CMD_BASE="evalscope perf \
-  --model ${MODEL_NAME} \
-  --url http://127.0.0.1:${PORT}/v1/chat/completions \
-  --api openai \
-  --stream \
-  --dataset random \
-  --max-tokens ${OUTPUT_TOKENS} \
-  --min-tokens ${OUTPUT_TOKENS} \
-  --min-prompt-length ${INPUT_TOKENS} \
-  --max-prompt-length ${INPUT_TOKENS} \
-  --tokenizer-path ${MODEL_PATH}"
+OUTPUT_FLAG="$(detect_evalscope_outputs_flag)"
+EVALSCOPE_BASE_ARGS=(
+    "${EVALSCOPE_CMD[@]}"
+    --model "${MODEL_NAME}"
+    --url "http://127.0.0.1:${PORT}/v1/chat/completions"
+    --api openai
+    --dataset random
+    --max-tokens "${OUTPUT_TOKENS}"
+    --min-tokens "${OUTPUT_TOKENS}"
+    --min-prompt-length "${INPUT_TOKENS}"
+    --max-prompt-length "${INPUT_TOKENS}"
+    --tokenizer-path "${MODEL_PATH}"
+)
+
+if [[ "${STREAM_MODE}" -eq 1 ]]; then
+    EVALSCOPE_BASE_ARGS+=(--stream)
+fi
 
 if [[ "${SKIP_WARMUP}" -eq 0 ]]; then
     log "=== Phase 3: Warm-up (${WARMUP_REQUESTS} requests) ==="
-    WARMUP_CMD="${EVALSCOPE_CMD_BASE} --parallel 1 --number ${WARMUP_REQUESTS} --name warmup"
-    run bash -c "${WARMUP_CMD}" || log "WARN: Warm-up returned non-zero exit; continuing"
+    WARMUP_ARGS=("${EVALSCOPE_BASE_ARGS[@]}" --parallel 1 --number "${WARMUP_REQUESTS}" --name warmup)
+    run_evalscope_with_output_dir "${WARMUP_RESULTS_DIR}" "${OUTPUT_FLAG}" "${WARMUP_ARGS[@]}" || \
+        log "WARN: Warm-up returned non-zero exit; continuing"
     log "Warm-up complete."
 else
     log "=== Phase 3: Warm-up skipped ==="
 fi
 
-# ── Phase 4: Stress test ──────────────────────────────────────────────────────
 log "=== Phase 4: Stress Test ==="
 log "Concurrency levels: ${PARALLEL_LEVELS}"
 log "Requests per level: ${REQUESTS_PER_LEVEL}"
 
-EVALSCOPE_CMD="${EVALSCOPE_CMD_BASE} \
-  --parallel ${PARALLEL_LEVELS} \
-  --number ${REQUESTS_PER_LEVEL} \
-  --name benchmark \
-  --work-dir ${EVALSCOPE_RESULTS_DIR}"
+BENCHMARK_ARGS=(
+    "${EVALSCOPE_BASE_ARGS[@]}"
+    --parallel ${PARALLEL_LEVELS}
+    --number ${REQUESTS_PER_LEVEL}
+    --name benchmark
+)
 
-echo "${EVALSCOPE_CMD}" > "${OUTPUT_DIR}/evalscope_cmd.txt"
+if [[ -n "${OUTPUT_FLAG}" ]]; then
+    EVALSCOPE_CMD_PARTS=("${BENCHMARK_ARGS[@]}" "${OUTPUT_FLAG}" "${EVALSCOPE_RESULTS_DIR}")
+    printf '%s\n' "$(join_command "${EVALSCOPE_CMD_PARTS[@]}")" > "${OUTPUT_DIR}/evalscope_cmd.txt"
+else
+    printf 'cd %s && %s\n' \
+        "$(shell_escape "${EVALSCOPE_RESULTS_DIR}")" \
+        "$(join_command "${BENCHMARK_ARGS[@]}")" > "${OUTPUT_DIR}/evalscope_cmd.txt"
+fi
 
-run bash -c "${EVALSCOPE_CMD}"
+run_evalscope_with_output_dir "${EVALSCOPE_RESULTS_DIR}" "${OUTPUT_FLAG}" "${BENCHMARK_ARGS[@]}"
 log "Stress test complete. Results in ${EVALSCOPE_RESULTS_DIR}"
 
-# ── Shutdown server ───────────────────────────────────────────────────────────
-if [[ "${DRY_RUN}" -eq 0 && "${SERVER_PID}" -ne 0 ]]; then
-    log "Stopping server (PID ${SERVER_PID})..."
-    kill "${SERVER_PID}" 2>/dev/null || true
-    wait "${SERVER_PID}" 2>/dev/null || true
-    log "Server stopped."
-fi
+cleanup_server
+SERVER_PID=""
 
-# ── Phase 5: Report generation ────────────────────────────────────────────────
 log "=== Phase 5: Generating Report ==="
-
-REPORT_CMD="python3 ${SKILL_DIR}/scripts/generate_report.py \
-  --results-dir ${EVALSCOPE_RESULTS_DIR} \
-  --output-dir ${OUTPUT_DIR} \
-  --model-name ${MODEL_NAME} \
-  --model-path ${MODEL_PATH} \
-  --npu-info ${NPU_INFO_FILE} \
-  --vllm-commit ${VLLM_ASCEND_COMMIT} \
-  --server-cmd \"$(cat ${OUTPUT_DIR}/server_cmd.txt 2>/dev/null || echo '')\" \
-  --evalscope-cmd \"$(cat ${OUTPUT_DIR}/evalscope_cmd.txt 2>/dev/null || echo '')\""
+REPORT_ARGS=(
+    python3 "${SKILL_DIR}/scripts/generate_report.py"
+    --results-dir "${EVALSCOPE_RESULTS_DIR}"
+    --output-dir "${OUTPUT_DIR}"
+    --model-name "${MODEL_NAME}"
+    --model-path "${MODEL_PATH}"
+    --npu-info "${NPU_INFO_FILE}"
+    --vllm-commit "${VLLM_ASCEND_COMMIT}"
+    --server-cmd "$(cat "${OUTPUT_DIR}/server_cmd.txt" 2>/dev/null || true)"
+    --evalscope-cmd "$(cat "${OUTPUT_DIR}/evalscope_cmd.txt" 2>/dev/null || true)"
+)
 
 if [[ -n "${CONFIG_FILE}" ]]; then
-    REPORT_CMD="${REPORT_CMD} --config ${CONFIG_FILE}"
+    REPORT_ARGS+=(--config "${CONFIG_FILE}")
 fi
 
-run bash -c "${REPORT_CMD}"
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+    log "[DRY-RUN] Would run: $(join_command "${REPORT_ARGS[@]}")"
+else
+    "${REPORT_ARGS[@]}"
+fi
 
 log ""
 log "==================================================================="

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/scripts/run_benchmark.sh
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/scripts/run_benchmark.sh
@@ -21,7 +21,7 @@ TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 OUTPUT_DIR=""
 NPU_DEVICES=""
 SKIP_WARMUP=0
-ACLGRAPH_OVERRIDE=""
+NO_ACLGRAPH=0
 NZ_OVERRIDE=""
 TRUST_REMOTE_CODE=1
 STREAM_MODE=1
@@ -223,7 +223,7 @@ while [[ $# -gt 0 ]]; do
         --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
         --npu-devices) NPU_DEVICES="$2"; shift 2 ;;
         --skip-warmup) SKIP_WARMUP=1; shift ;;
-        --no-aclgraph) ACLGRAPH_OVERRIDE="0"; shift ;;
+        --no-aclgraph) NO_ACLGRAPH=1; shift ;;
         --no-nz) NZ_OVERRIDE="0"; shift ;;
         --dry-run) DRY_RUN=1; shift ;;
         *)
@@ -314,11 +314,6 @@ SERVER_LOG="${OUTPUT_DIR}/server.log"
 NPU_INFO_FILE="${OUTPUT_DIR}/npu_info.txt"
 
 upsert_env_value "ASCEND_RT_VISIBLE_DEVICES" "${NPU_DEVICES}"
-if [[ -n "${ACLGRAPH_OVERRIDE}" ]]; then
-    upsert_env_value "VLLM_ASCEND_ENABLE_ACLGRAPH" "${ACLGRAPH_OVERRIDE}"
-elif ! get_env_value "VLLM_ASCEND_ENABLE_ACLGRAPH" >/dev/null 2>&1; then
-    upsert_env_value "VLLM_ASCEND_ENABLE_ACLGRAPH" "1"
-fi
 
 if [[ -n "${NZ_OVERRIDE}" ]]; then
     upsert_env_value "VLLM_ASCEND_ENABLE_NZ" "${NZ_OVERRIDE}"
@@ -394,6 +389,14 @@ fi
 
 if [[ "${TRUST_REMOTE_CODE}" -eq 1 ]]; then
     SERVER_ARGS+=(--trust-remote-code)
+fi
+
+# --no-aclgraph disables ACLGraph capture/replay via the supported vLLM flag
+# --enforce-eager (vLLM-Ascend honors it: _use_aclgraph() returns False and
+# capture_model() is skipped). The legacy VLLM_ASCEND_ENABLE_ACLGRAPH env var
+# was a no-op (never defined in vllm_ascend/envs.py, never read by runtime).
+if [[ "${NO_ACLGRAPH}" -eq 1 ]]; then
+    SERVER_ARGS+=(--enforce-eager)
 fi
 
 SERVER_CMD_PARTS=(env)

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/scripts/run_benchmark.sh
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/scripts/run_benchmark.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+# run_benchmark.sh — End-to-end benchmark runner for vllm-ascend on Ascend 910C
+#
+# Usage:
+#   bash run_benchmark.sh [OPTIONS]
+#
+# Options (all override config file values):
+#   --model-path PATH            Model local path or HuggingFace/ModelScope ID
+#   --model-name NAME            Short name used in report and API served_model_name
+#   --config FILE                YAML config file (default: none)
+#   --tp INT                     Tensor parallel size (default: 1)
+#   --pp INT                     Pipeline parallel size (default: 1)
+#   --max-model-len INT          Max context length (default: 8192)
+#   --dtype STR                  float16|bfloat16|auto (default: float16)
+#   --quantization STR           w8a8|w4a16|null (default: none)
+#   --port INT                   Server port (default: 8000)
+#   --parallel-levels STR        Space-separated concurrency list (default: "1 4 8 16 32 64")
+#   --requests-per-level STR     Space-separated request counts (default: "10 40 80 160 320 640")
+#   --input-tokens INT           Input token length (default: 1024)
+#   --output-tokens INT          Output token length (default: 512)
+#   --warmup-requests INT        Warm-up request count (default: 20)
+#   --output-dir DIR             Where to save reports (default: ./benchmark_output/<timestamp>)
+#   --npu-devices STR            ASCEND_RT_VISIBLE_DEVICES value (default: auto-detect from tp)
+#   --skip-warmup                Skip warm-up phase
+#   --no-aclgraph                Disable ACLGraph (VLLM_ASCEND_ENABLE_ACLGRAPH=0)
+#   --no-nz                      Disable NZ format (VLLM_ASCEND_ENABLE_NZ=0)
+#   --dry-run                    Print commands without executing them
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+MODEL_PATH=""
+MODEL_NAME=""
+CONFIG_FILE=""
+TP=1
+PP=1
+MAX_MODEL_LEN=8192
+DTYPE="float16"
+QUANTIZATION=""
+PORT=8000
+PARALLEL_LEVELS="1 4 8 16 32 64"
+REQUESTS_PER_LEVEL="10 40 80 160 320 640"
+INPUT_TOKENS=1024
+OUTPUT_TOKENS=512
+WARMUP_REQUESTS=20
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+OUTPUT_DIR=""
+NPU_DEVICES=""
+SKIP_WARMUP=0
+ENABLE_ACLGRAPH=1
+ENABLE_NZ=0
+DRY_RUN=0
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ── Argument parsing ───────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --model-path)      MODEL_PATH="$2";        shift 2 ;;
+        --model-name)      MODEL_NAME="$2";        shift 2 ;;
+        --config)          CONFIG_FILE="$2";       shift 2 ;;
+        --tp)              TP="$2";                shift 2 ;;
+        --pp)              PP="$2";                shift 2 ;;
+        --max-model-len)   MAX_MODEL_LEN="$2";     shift 2 ;;
+        --dtype)           DTYPE="$2";             shift 2 ;;
+        --quantization)    QUANTIZATION="$2";      shift 2 ;;
+        --port)            PORT="$2";              shift 2 ;;
+        --parallel-levels) PARALLEL_LEVELS="$2";   shift 2 ;;
+        --requests-per-level) REQUESTS_PER_LEVEL="$2"; shift 2 ;;
+        --input-tokens)    INPUT_TOKENS="$2";      shift 2 ;;
+        --output-tokens)   OUTPUT_TOKENS="$2";     shift 2 ;;
+        --warmup-requests) WARMUP_REQUESTS="$2";   shift 2 ;;
+        --output-dir)      OUTPUT_DIR="$2";        shift 2 ;;
+        --npu-devices)     NPU_DEVICES="$2";       shift 2 ;;
+        --skip-warmup)     SKIP_WARMUP=1;          shift ;;
+        --no-aclgraph)     ENABLE_ACLGRAPH=0;      shift ;;
+        --no-nz)           ENABLE_NZ=0;            shift ;;
+        --dry-run)         DRY_RUN=1;              shift ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ── Apply YAML config if provided ─────────────────────────────────────────────
+if [[ -n "${CONFIG_FILE}" ]]; then
+    if [[ ! -f "${CONFIG_FILE}" ]]; then
+        echo "ERROR: config file not found: ${CONFIG_FILE}" >&2
+        exit 1
+    fi
+    _yaml_get() {
+        python3 -c "
+import yaml, sys
+cfg = yaml.safe_load(open('${CONFIG_FILE}'))
+keys = '$1'.split('.')
+val = cfg
+for k in keys:
+    if isinstance(val, dict) and k in val:
+        val = val[k]
+    else:
+        val = None
+        break
+if val is not None:
+    print(val)
+" 2>/dev/null || true
+    }
+    [[ -z "${MODEL_PATH}" ]]   && MODEL_PATH=$(_yaml_get model.path)
+    [[ -z "${MODEL_NAME}" ]]   && MODEL_NAME=$(_yaml_get model.name)
+    _tp=$(_yaml_get server.tensor_parallel_size);  [[ -n "$_tp" ]] && TP=$_tp
+    _pp=$(_yaml_get server.pipeline_parallel_size); [[ -n "$_pp" ]] && PP=$_pp
+    _port=$(_yaml_get server.port);                [[ -n "$_port" ]] && PORT=$_port
+    _mml=$(_yaml_get model.max_model_len);         [[ -n "$_mml" ]] && MAX_MODEL_LEN=$_mml
+    _dtype=$(_yaml_get model.dtype);               [[ -n "$_dtype" ]] && DTYPE=$_dtype
+    _quant=$(_yaml_get model.quantization);        [[ -n "$_quant" && "$_quant" != "None" && "$_quant" != "null" ]] && QUANTIZATION=$_quant
+    _pl=$(_yaml_get benchmark.parallel_levels);    [[ -n "$_pl" ]] && PARALLEL_LEVELS=$_pl
+    _rpl=$(_yaml_get benchmark.requests_per_level);[[ -n "$_rpl" ]] && REQUESTS_PER_LEVEL=$_rpl
+    _it=$(_yaml_get workload.input_tokens);        [[ -n "$_it" ]] && INPUT_TOKENS=$_it
+    _ot=$(_yaml_get workload.output_tokens);       [[ -n "$_ot" ]] && OUTPUT_TOKENS=$_ot
+    _wr=$(_yaml_get benchmark.warmup_requests);    [[ -n "$_wr" ]] && WARMUP_REQUESTS=$_wr
+    _npu=$(_yaml_get server.env.ASCEND_RT_VISIBLE_DEVICES); [[ -n "$_npu" && -z "${NPU_DEVICES}" ]] && NPU_DEVICES=$_npu
+fi
+
+# ── Validation ─────────────────────────────────────────────────────────────────
+if [[ -z "${MODEL_PATH}" ]]; then
+    echo "ERROR: --model-path is required (or set model.path in config)" >&2
+    exit 1
+fi
+if [[ -z "${MODEL_NAME}" ]]; then
+    MODEL_NAME=$(basename "${MODEL_PATH}")
+    echo "INFO: --model-name not set, using '${MODEL_NAME}'"
+fi
+
+# Auto-detect NPU devices
+if [[ -z "${NPU_DEVICES}" ]]; then
+    NPU_DEVICES=$(seq -s "," 0 $((TP * PP - 1)))
+fi
+
+if [[ -z "${OUTPUT_DIR}" ]]; then
+    OUTPUT_DIR="./benchmark_output/${TIMESTAMP}_${MODEL_NAME}"
+fi
+mkdir -p "${OUTPUT_DIR}"
+
+EVALSCOPE_RESULTS_DIR="${OUTPUT_DIR}/evalscope_results"
+mkdir -p "${EVALSCOPE_RESULTS_DIR}"
+
+SERVER_LOG="${OUTPUT_DIR}/server.log"
+NPU_INFO_FILE="${OUTPUT_DIR}/npu_info.txt"
+
+# ── Logging helper ─────────────────────────────────────────────────────────────
+log() { echo "[$(date '+%H:%M:%S')] $*"; }
+run() {
+    if [[ "${DRY_RUN}" -eq 1 ]]; then
+        echo "[DRY-RUN] $*"
+    else
+        "$@"
+    fi
+}
+
+# ── Phase 1: Environment check ─────────────────────────────────────────────────
+log "=== Phase 1: Environment Validation ==="
+
+npu-smi info > "${NPU_INFO_FILE}" 2>&1 || log "WARN: npu-smi not available"
+log "NPU info saved to ${NPU_INFO_FILE}"
+
+if ! python3 -c "import vllm_ascend" 2>/dev/null; then
+    echo "ERROR: vllm-ascend not installed. Run: pip install vllm-ascend" >&2
+    exit 1
+fi
+
+if ! command -v evalscope &>/dev/null && ! python3 -m evalscope --version &>/dev/null 2>&1; then
+    echo "ERROR: evalscope not found. Run: pip install evalscope[perf] -U" >&2
+    exit 1
+fi
+
+if [[ -n "${CONFIG_FILE}" ]]; then
+    log "Validating config file: ${CONFIG_FILE}"
+    run python3 "${SKILL_DIR}/scripts/validate_configs.py" "${CONFIG_FILE}"
+fi
+
+# Get version info
+VLLM_ASCEND_VERSION=$(python3 -c "import vllm_ascend; print(getattr(vllm_ascend, '__version__', 'unknown'))" 2>/dev/null || echo "unknown")
+VLLM_ASCEND_COMMIT=$(python3 -c "
+import importlib.util, subprocess, pathlib
+spec = importlib.util.find_spec('vllm_ascend')
+if spec:
+    loc = str(pathlib.Path(spec.origin).parent)
+    result = subprocess.run(['git', '-C', loc, 'rev-parse', '--short', 'HEAD'],
+        capture_output=True, text=True)
+    print(result.stdout.strip() if result.returncode == 0 else 'unknown')
+else:
+    print('unknown')
+" 2>/dev/null || echo "unknown")
+
+log "vllm-ascend: ${VLLM_ASCEND_VERSION} (${VLLM_ASCEND_COMMIT})"
+log "NPU devices: ${NPU_DEVICES}"
+log "TP=${TP}  PP=${PP}  port=${PORT}"
+
+# ── Phase 2: Launch vLLM-Ascend server ────────────────────────────────────────
+log "=== Phase 2: Launching vLLM-Ascend Server ==="
+
+# Build server command
+QUANT_FLAGS=""
+if [[ -n "${QUANTIZATION}" ]]; then
+    QUANT_FLAGS="--quantization ${QUANTIZATION}"
+fi
+
+SERVER_CMD="ASCEND_RT_VISIBLE_DEVICES=${NPU_DEVICES} \
+VLLM_ASCEND_ENABLE_ACLGRAPH=${ENABLE_ACLGRAPH} \
+VLLM_ASCEND_ENABLE_NZ=${ENABLE_NZ} \
+python3 -m vllm.entrypoints.openai.api_server \
+  --model ${MODEL_PATH} \
+  --served-model-name ${MODEL_NAME} \
+  --tensor-parallel-size ${TP} \
+  --pipeline-parallel-size ${PP} \
+  --max-model-len ${MAX_MODEL_LEN} \
+  --dtype ${DTYPE} \
+  --port ${PORT} \
+  --trust-remote-code \
+  ${QUANT_FLAGS}"
+
+# Save server command for report
+echo "${SERVER_CMD}" > "${OUTPUT_DIR}/server_cmd.txt"
+
+if [[ "${DRY_RUN}" -eq 0 ]]; then
+    export ASCEND_RT_VISIBLE_DEVICES="${NPU_DEVICES}"
+    export VLLM_ASCEND_ENABLE_ACLGRAPH="${ENABLE_ACLGRAPH}"
+    export VLLM_ASCEND_ENABLE_NZ="${ENABLE_NZ}"
+
+    python3 -m vllm.entrypoints.openai.api_server \
+        --model "${MODEL_PATH}" \
+        --served-model-name "${MODEL_NAME}" \
+        --tensor-parallel-size "${TP}" \
+        --pipeline-parallel-size "${PP}" \
+        --max-model-len "${MAX_MODEL_LEN}" \
+        --dtype "${DTYPE}" \
+        --port "${PORT}" \
+        --trust-remote-code \
+        ${QUANT_FLAGS:+${QUANT_FLAGS}} \
+        > "${SERVER_LOG}" 2>&1 &
+
+    SERVER_PID=$!
+    log "Server started with PID ${SERVER_PID}, log: ${SERVER_LOG}"
+
+    # Wait for server to be ready
+    log "Waiting for server to be ready (max 300s)..."
+    READY=0
+    for i in $(seq 1 60); do
+        sleep 5
+        if curl -s "http://127.0.0.1:${PORT}/health" | grep -q "{}"; then
+            READY=1
+            break
+        fi
+        # Also accept 200 with any body
+        HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${PORT}/health" 2>/dev/null || echo "000")
+        if [[ "${HTTP_CODE}" == "200" ]]; then
+            READY=1
+            break
+        fi
+        log "  Waiting... (${i}/60, last HTTP ${HTTP_CODE})"
+    done
+
+    if [[ "${READY}" -eq 0 ]]; then
+        echo "ERROR: Server failed to start within 300s. Check ${SERVER_LOG}" >&2
+        kill "${SERVER_PID}" 2>/dev/null || true
+        exit 1
+    fi
+    log "Server is ready."
+else
+    log "[DRY-RUN] Would start: ${SERVER_CMD}"
+    SERVER_PID=0
+fi
+
+# ── Phase 3: Warm-up ──────────────────────────────────────────────────────────
+EVALSCOPE_CMD_BASE="evalscope perf \
+  --model ${MODEL_NAME} \
+  --url http://127.0.0.1:${PORT}/v1/chat/completions \
+  --api openai \
+  --stream \
+  --dataset random \
+  --max-tokens ${OUTPUT_TOKENS} \
+  --min-tokens ${OUTPUT_TOKENS} \
+  --min-prompt-length ${INPUT_TOKENS} \
+  --max-prompt-length ${INPUT_TOKENS} \
+  --tokenizer-path ${MODEL_PATH}"
+
+if [[ "${SKIP_WARMUP}" -eq 0 ]]; then
+    log "=== Phase 3: Warm-up (${WARMUP_REQUESTS} requests) ==="
+    WARMUP_CMD="${EVALSCOPE_CMD_BASE} --parallel 1 --number ${WARMUP_REQUESTS} --name warmup"
+    run bash -c "${WARMUP_CMD}" || log "WARN: Warm-up returned non-zero exit; continuing"
+    log "Warm-up complete."
+else
+    log "=== Phase 3: Warm-up skipped ==="
+fi
+
+# ── Phase 4: Stress test ──────────────────────────────────────────────────────
+log "=== Phase 4: Stress Test ==="
+log "Concurrency levels: ${PARALLEL_LEVELS}"
+log "Requests per level: ${REQUESTS_PER_LEVEL}"
+
+EVALSCOPE_CMD="${EVALSCOPE_CMD_BASE} \
+  --parallel ${PARALLEL_LEVELS} \
+  --number ${REQUESTS_PER_LEVEL} \
+  --name benchmark \
+  --work-dir ${EVALSCOPE_RESULTS_DIR}"
+
+echo "${EVALSCOPE_CMD}" > "${OUTPUT_DIR}/evalscope_cmd.txt"
+
+run bash -c "${EVALSCOPE_CMD}"
+log "Stress test complete. Results in ${EVALSCOPE_RESULTS_DIR}"
+
+# ── Shutdown server ───────────────────────────────────────────────────────────
+if [[ "${DRY_RUN}" -eq 0 && "${SERVER_PID}" -ne 0 ]]; then
+    log "Stopping server (PID ${SERVER_PID})..."
+    kill "${SERVER_PID}" 2>/dev/null || true
+    wait "${SERVER_PID}" 2>/dev/null || true
+    log "Server stopped."
+fi
+
+# ── Phase 5: Report generation ────────────────────────────────────────────────
+log "=== Phase 5: Generating Report ==="
+
+REPORT_CMD="python3 ${SKILL_DIR}/scripts/generate_report.py \
+  --results-dir ${EVALSCOPE_RESULTS_DIR} \
+  --output-dir ${OUTPUT_DIR} \
+  --model-name ${MODEL_NAME} \
+  --model-path ${MODEL_PATH} \
+  --npu-info ${NPU_INFO_FILE} \
+  --vllm-commit ${VLLM_ASCEND_COMMIT} \
+  --server-cmd \"$(cat ${OUTPUT_DIR}/server_cmd.txt 2>/dev/null || echo '')\" \
+  --evalscope-cmd \"$(cat ${OUTPUT_DIR}/evalscope_cmd.txt 2>/dev/null || echo '')\""
+
+if [[ -n "${CONFIG_FILE}" ]]; then
+    REPORT_CMD="${REPORT_CMD} --config ${CONFIG_FILE}"
+fi
+
+run bash -c "${REPORT_CMD}"
+
+log ""
+log "==================================================================="
+log "  Benchmark complete!"
+log "  Markdown report : ${OUTPUT_DIR}/benchmark_report.md"
+log "  CSV results     : ${OUTPUT_DIR}/benchmark_results.csv"
+log "  Server log      : ${SERVER_LOG}"
+log "  NPU info        : ${NPU_INFO_FILE}"
+log "==================================================================="

--- a/.agents/skills/ascend-vllm-serving-auto-benchmark/scripts/validate_configs.py
+++ b/.agents/skills/ascend-vllm-serving-auto-benchmark/scripts/validate_configs.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Validate ascend-vllm-serving-auto-benchmark YAML configs.
+
+Checks that required fields are present, values are in allowed ranges,
+and parallel_levels / requests_per_level lists are the same length.
+Does NOT launch any server.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: PyYAML not installed. Run: pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
+
+REQUIRED_MODEL_KEYS = {"path", "name", "dtype", "max_model_len"}
+REQUIRED_SERVER_KEYS = {"port", "tensor_parallel_size", "pipeline_parallel_size"}
+REQUIRED_WORKLOAD_KEYS = {"input_tokens", "output_tokens", "dataset"}
+REQUIRED_BENCHMARK_KEYS = {"parallel_levels", "requests_per_level", "warmup_requests"}
+
+VALID_DTYPES = {"float16", "bfloat16", "float32", "auto"}
+VALID_QUANT = {None, "w8a8", "w4a16", "gptq", "awq"}
+VALID_DATASETS = {"random", "openqa", "longalpaca"}
+
+ERRORS: list[str] = []
+WARNINGS: list[str] = []
+
+
+def _err(msg: str) -> None:
+    ERRORS.append(msg)
+
+
+def _warn(msg: str) -> None:
+    WARNINGS.append(msg)
+
+
+def _check_required(section: dict, keys: set[str], section_name: str) -> None:
+    for k in keys:
+        if k not in section:
+            _err(f"[{section_name}] missing required key: '{k}'")
+
+
+def validate_model(cfg: dict) -> None:
+    section = cfg.get("model", {})
+    _check_required(section, REQUIRED_MODEL_KEYS, "model")
+
+    dtype = section.get("dtype", "")
+    if dtype not in VALID_DTYPES:
+        _err(f"[model] dtype '{dtype}' invalid; must be one of {VALID_DTYPES}")
+
+    quant = section.get("quantization")
+    if quant not in VALID_QUANT:
+        _warn(f"[model] quantization '{quant}' is not in known values {VALID_QUANT}")
+
+    max_len = section.get("max_model_len", 0)
+    if not isinstance(max_len, int) or max_len <= 0:
+        _err(f"[model] max_model_len must be a positive integer, got: {max_len!r}")
+
+    model_path = section.get("path", "")
+    if not model_path:
+        _err("[model] path must not be empty")
+
+
+def validate_server(cfg: dict) -> None:
+    section = cfg.get("server", {})
+    _check_required(section, REQUIRED_SERVER_KEYS, "server")
+
+    tp = section.get("tensor_parallel_size", 1)
+    pp = section.get("pipeline_parallel_size", 1)
+    port = section.get("port", 8000)
+
+    if not isinstance(tp, int) or tp < 1:
+        _err(f"[server] tensor_parallel_size must be >= 1, got: {tp!r}")
+    if not isinstance(pp, int) or pp < 1:
+        _err(f"[server] pipeline_parallel_size must be >= 1, got: {pp!r}")
+    if not isinstance(port, int) or not (1024 <= port <= 65535):
+        _err(f"[server] port must be in [1024, 65535], got: {port!r}")
+
+    env = section.get("env", {})
+    visible = env.get("ASCEND_RT_VISIBLE_DEVICES", "")
+    if visible:
+        npu_ids = [x.strip() for x in str(visible).split(",") if x.strip()]
+        if len(npu_ids) != tp:
+            _warn(
+                f"[server] ASCEND_RT_VISIBLE_DEVICES lists {len(npu_ids)} devices "
+                f"but tensor_parallel_size={tp}"
+            )
+
+
+def validate_workload(cfg: dict) -> None:
+    section = cfg.get("workload", {})
+    _check_required(section, REQUIRED_WORKLOAD_KEYS, "workload")
+
+    for key in ("input_tokens", "output_tokens"):
+        val = section.get(key, 0)
+        if not isinstance(val, int) or val <= 0:
+            _err(f"[workload] {key} must be a positive integer, got: {val!r}")
+
+    dataset = section.get("dataset", "")
+    if dataset not in VALID_DATASETS:
+        _warn(f"[workload] dataset '{dataset}' not in known values {VALID_DATASETS}")
+
+
+def validate_benchmark(cfg: dict) -> None:
+    section = cfg.get("benchmark", {})
+    _check_required(section, REQUIRED_BENCHMARK_KEYS, "benchmark")
+
+    pl_raw = section.get("parallel_levels", "")
+    rpl_raw = section.get("requests_per_level", "")
+
+    try:
+        pl = [int(x) for x in str(pl_raw).split()]
+    except ValueError:
+        _err(f"[benchmark] parallel_levels must be space-separated integers, got: {pl_raw!r}")
+        pl = []
+
+    try:
+        rpl = [int(x) for x in str(rpl_raw).split()]
+    except ValueError:
+        _err(f"[benchmark] requests_per_level must be space-separated integers, got: {rpl_raw!r}")
+        rpl = []
+
+    if pl and rpl and len(pl) != len(rpl):
+        _err(
+            f"[benchmark] parallel_levels ({len(pl)} items) and "
+            f"requests_per_level ({len(rpl)} items) must have the same length"
+        )
+
+    for i, (p, r) in enumerate(zip(pl, rpl)):
+        if p <= 0:
+            _err(f"[benchmark] parallel_levels[{i}]={p} must be > 0")
+        if r <= 0:
+            _err(f"[benchmark] requests_per_level[{i}]={r} must be > 0")
+        if r < p:
+            _warn(
+                f"[benchmark] requests_per_level[{i}]={r} < parallel_levels[{i}]={p}; "
+                "each concurrency level may not complete a full batch"
+            )
+
+    warmup = section.get("warmup_requests", 0)
+    if not isinstance(warmup, int) or warmup < 0:
+        _err(f"[benchmark] warmup_requests must be >= 0, got: {warmup!r}")
+
+
+def validate_sla(cfg: dict) -> None:
+    section = cfg.get("sla", {})
+    if not section:
+        _warn("[sla] section missing; no SLA thresholds will be checked in the report")
+        return
+
+    for key in ("max_p99_ttft_ms", "min_success_rate", "min_output_token_throughput"):
+        if key not in section:
+            _warn(f"[sla] missing optional key '{key}'")
+
+    success_rate = section.get("min_success_rate")
+    if success_rate is not None and not (0.0 < success_rate <= 1.0):
+        _err(f"[sla] min_success_rate must be in (0, 1], got: {success_rate!r}")
+
+
+def validate_config(path: Path) -> bool:
+    ERRORS.clear()
+    WARNINGS.clear()
+
+    try:
+        with open(path) as f:
+            cfg = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        print(f"YAML parse error in {path}: {e}", file=sys.stderr)
+        return False
+
+    if not isinstance(cfg, dict):
+        print(f"ERROR: {path} must be a YAML mapping at the top level", file=sys.stderr)
+        return False
+
+    validate_model(cfg)
+    validate_server(cfg)
+    validate_workload(cfg)
+    validate_benchmark(cfg)
+    validate_sla(cfg)
+
+    ok = True
+    if WARNINGS:
+        for w in WARNINGS:
+            print(f"  WARN  {w}")
+    if ERRORS:
+        ok = False
+        for e in ERRORS:
+            print(f"  ERROR {e}")
+
+    return ok
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate ascend-vllm-serving-auto-benchmark YAML configs"
+    )
+    parser.add_argument("configs", nargs="+", type=Path, help="YAML config files to validate")
+    args = parser.parse_args()
+
+    all_ok = True
+    for config_path in args.configs:
+        print(f"\nValidating: {config_path}")
+        result = validate_config(config_path)
+        status = "OK" if result else "FAIL"
+        print(f"  -> {status}")
+        if not result:
+            all_ok = False
+
+    if all_ok:
+        print("\nAll configs valid.")
+        sys.exit(0)
+    else:
+        print("\nOne or more configs have errors.", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/ascend-vllm-serving-tune-loop/SKILL.md
+++ b/.agents/skills/ascend-vllm-serving-tune-loop/SKILL.md
@@ -109,6 +109,14 @@ Each run should end with:
 
 ## Quick start
 
+This skill starts a serving process, occupies NPU resources, and may run a long
+tuning campaign, so it must be invoked explicitly. Use the form for your
+agent and never let the model invoke it implicitly (`disable-model-invocation`
+is already set in the frontmatter above).
+
+- Codex: `$ascend-vllm-serving-tune-loop`
+- Claude Code: `/ascend-vllm-serving-tune-loop`
+
 ```text
 /ascend-vllm-serving-tune-loop
 model_path=/data/models/Qwen3-32B

--- a/.agents/skills/ascend-vllm-serving-tune-loop/SKILL.md
+++ b/.agents/skills/ascend-vllm-serving-tune-loop/SKILL.md
@@ -1,0 +1,867 @@
+# ascend-vllm-serving-tune-loop
+
+Autonomous, evidence-driven performance optimization loop for vLLM-Ascend serving on Huawei Ascend 910C NPU.
+
+Runs a fixed baseline benchmark, then iterates through a layered tuning plan — from scheduler-level knobs down to ACLGraph compilation and kernel-level parameters — exhaustively trying all candidate levers across all phases. Produces a full optimization ledger and final comparison report.
+
+## When to invoke
+
+Use this skill when the user wants to:
+- Squeeze lower latency / higher throughput from an existing vllm-ascend deployment on 910C
+- Systematically explore Ascend-specific tuning knobs without guessing
+- Get a documented, reproducible record of what was tried and what helped
+
+Trigger phrases: "optimize", "tune", "调优", "性能优化", "latency optimization", "ascend tuning loop", "sota loop"
+
+## Prerequisites
+
+Same as `ascend-vllm-serving-auto-benchmark` plus:
+- `msprof` available (optional, for human deep-dive profiling if Phase 7 identifies non-tunable bottlenecks)
+- Enough NPU memory headroom to try `block_size` variants
+- Write permission to working directory for ledger files
+
+## Inputs
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `model_path` | Yes | Local path or model ID |
+| `model_name` | Yes | Short name used in commands and ledger |
+| `tensor_parallel_size` | No | NPU card count (default: 1) |
+| `max_model_len` | No | Max context length (default: 8192) |
+| `dtype` | No | `float16` / `bfloat16` (default: `float16`) |
+| `port` | No | Server port (default: 5000) |
+| `baseline_launch_command` | No | Full server launch command used as the Phase 1 baseline. If provided, the skill uses this command exactly as the starting point instead of the default template, preserving any pre-applied optimizations across the whole campaign unless a later iteration is explicitly testing that field. |
+| `target_metric` | No | Primary metric to optimize: `ttft_avg` \| `tpot_avg` \| `latency_avg` (default: `ttft_avg`) |
+| `low_conc_levels` | No | Concurrency levels considered "low" (default: `1 4 8`) |
+| `requests_per_level` | No | Requests per concurrency level for each benchmark run (default: `20 80 160`) |
+| `input_tokens` | No | Input token length (default: 1024) |
+| `output_tokens` | No | Output token length (default: 512) |
+| `improvement_threshold_pct` | No | Minimum improvement to count as a win (default: 1.0%) |
+| `max_iterations` | No | Hard stop after N tuning iterations (default: 50) |
+| `work_dir` | No | Directory for all artifacts (default: `./tuning_run/<timestamp>`) |
+
+## Fixed benchmark contract
+
+**These values are locked for the entire campaign and must never change between iterations:**
+
+| What | Value |
+|------|-------|
+| Concurrency levels | `c = 1, 4, 8` (all three, every run) |
+| Primary decision metric | `ttft_avg` at **c = 1** |
+| Secondary guard metric | `tpot_avg` at **c = 1** — if it regresses > 5%, downgrade WIN to NEUTRAL |
+| Full recorded metrics | `ttft_avg`, `tpot_avg`, `output_token_throughput` (TPS), `latency_avg` at each of c=1/4/8 |
+| Input tokens | fixed at `input_tokens` parameter |
+| Output tokens | fixed at `output_tokens` parameter |
+| Requests per level | fixed at `requests_per_level` parameter |
+| Baseline launch config | If `baseline_launch_command` is provided, use it exactly in Phase 1; otherwise use the default server template below |
+| Warmup requests | 20 at c=1 before every measurement run |
+
+**Why `ttft_avg` and not P99**: at low concurrency (20 requests per level), P99 represents a single outlier request and is too noisy to be a reliable signal. `ttft_avg` is statistically stable and directly reflects prefill path performance — the dominant factor at c=1.
+
+**TPS** (`output_token_throughput`) is recorded at all concurrency levels for informational purposes. At c=1 it correlates closely with `tpot_avg`, but becomes more informative at c=4/8 where batching effects kick in.
+
+The user may override the target metric via input parameters, but once Phase 1 starts the chosen metric is frozen.
+
+## Core principle: RLCR (Refinement Loop with Continuous Revalidation)
+
+Every tuning iteration must:
+1. **Hypothesize** — pick one lever from the ranked candidate list with a stated expected impact
+2. **Change one thing** — apply a single parameter change; never bundle multiple levers in one iteration
+3. **Revalidate** — run evalscope at **all three concurrency levels (c=1/4/8)** with the fixed workload
+4. **Decide on `ttft_avg` at c=1** — this single number is the gate for WIN/LOSS/NEUTRAL
+5. **Record** — append to the ledger regardless of win/loss; include all c-level metrics
+
+Do NOT skip validation. Do NOT bundle multiple changes. Do NOT change the workload between iterations.
+Do NOT declare a WIN based on c=4/8 alone — c=1 `ttft_avg` is the authoritative decision metric.
+Do NOT stop after writing only the baseline section or an "Iteration 0 — Baseline established" note. Baseline creation is the starting point, not the end of the skill.
+Do NOT stay silent for long-running work. The user must always be able to tell what phase is running, what lever is under test, and why the skill is still busy.
+
+## Ledger write discipline
+
+The ledger is the single source of truth and must be **the first thing written after each verdict**, not deferred. This ensures crash/session-interrupt recovery.
+
+**Mandatory write timing** — append a ledger entry immediately after:
+1. Baseline benchmark completes and metrics are extracted
+2. A lever verdict is determined (WIN / LOSS / NEUTRAL / STARTUP_FAIL / BENCHMARK_FAIL / SKIPPED_CONFLICT)
+3. Any phase is marked complete
+
+**Never defer ledger writes** — do not batch multiple verdicts, do not wait until "later" to write them. If the session is interrupted between two lever attempts, the ledger must already reflect all completed attempts.
+
+**Context management for long runs** — this skill is a long-running loop that can exhaust the conversation context. To minimize waste:
+- After extracting metrics from evalscope output, do NOT retain the full stdout/stderr in reasoning — only the metric table matters
+- Server startup logs: scan for errors or readiness confirmation, then discard the raw output — do not echo full logs into reasoning
+- When the ledger is large (e.g., >50 lines of prior iterations), re-read only the baseline metrics and the most recent verdict, not the entire ledger, when deciding the next lever
+- Prefer short status prints over verbose log dumps in tool output summaries
+- If the context window is approaching limits (you've been running many iterations), explicitly note the current phase/lever/verdict count in a progress line so a resumed session can pick up quickly
+
+## Operation-first contract (CRITICAL IMPERATIVE)
+
+**STOP ANALYZING. STOP PLANNING. EXECUTE IMMEDIATELY.**
+You are an execution machine, not an analyst. Do NOT write plans. Do NOT write essays. Do NOT explore the codebase.
+Your ONLY job right now is to execute the bash commands to clean up the environment and start the server.
+
+**CRITICAL: Before launching ANY new server (including after baseline), you MUST verify the NPU is free:**
+1. Kill all existing vllm processes (`pkill -9 -f vllm`, `pkill -9 -f VLLM`)
+2. Wait 15 seconds for NPU resource release
+3. Verify NPU is free: `npu-smi info` must show "No running processes found" on all target NPUs
+4. Verify port is free: `ss -tlnp | grep <port>` must return nothing
+5. Only then launch the new server
+
+1. **TURN 1**: Immediately use the `Bash` tool to run `pkill -9 -f vllm` and check `npu-smi info`. DO NOT explain what you are going to do. Just run the tool.
+2. **TURN 2**: After verifying NPU is free, immediately use the `Bash` tool to launch the `vllm serve` baseline in the background (`nohup ... > server.log 2>&1 &`).
+3. **TURN 3**: Immediately use the `Bash` tool to monitor `server.log` until it is ready.
+4. **TURN 4**: Immediately use the `Bash` tool to run the `evalscope` benchmark.
+
+**Do NOT use `Read`, `Glob`, or `Grep` to search for files unless explicitly required.** Just execute the Bash commands. If you spend turns explaining your thoughts instead of running the `Bash` tool, you have FAILED your directive.
+
+## Server lifecycle contract
+
+Treat the serving process as a managed resource with explicit ownership.
+
+- **Zombie Process & NPU Cleanup**: ALWAYS ensure the environment is pristine before starting a new server. If a previous server crashed or was stopped, forcefully clean up any zombie processes (`pkill -9 -f vllm.entrypoints.openai.api_server` and `pkill -9 -f ray` if applicable). Verify that the target port (e.g., `5000`) is free and NPU memory is released (`npu-smi info`) before launching. NEVER attempt to start a server if the NPU is still occupied by a ghost process.
+- **Background Execution**: Always launch the server in the background and redirect its output to a file (e.g., `nohup <command> > <work_dir>/server.log 2>&1 &`) so your Bash tool does not block.
+- **Log Monitoring**: After launching, use `grep` or `tail` on the log file to monitor the startup progress and verify readiness (look for "Uvicorn running on" or similar success messages).
+- Before Phase 1 or any lever attempt, check whether the target server is already running on the intended port and whether it matches the intended config closely enough to reuse
+- If the running server does not match the intended config, forcefully stop and clean it up before starting the next attempt
+- Never leave multiple competing server processes running for the same campaign port
+- Every iteration must end in exactly one of these states:
+  - benchmarked and recorded
+  - failed to start and recorded
+  - skipped by precheck and recorded
+- Do not keep an old server alive just to save time if it makes the config attribution ambiguous
+
+### Post-iteration strict cleanup protocol (MANDATORY)
+
+**Note: Baseline benchmark completion counts as an iteration verdict. The cleanup protocol MUST be executed after baseline before starting Phase 2.**
+
+After EVERY iteration verdict (WIN/LOSS/NEUTRAL/STARTUP_FAIL/BENCHMARK_FAIL/SKIPPED_CONFLICT), the following cleanup sequence MUST be executed before starting the next lever. This is non-negotiable. Skipping cleanup leads to zombie process accumulation, NPU memory leaks, and cascading STARTUP_FAIL on subsequent iterations.
+
+**Cleanup script — execute as a single Bash command after every iteration:**
+
+```bash
+# Step 1: Kill ALL vllm-related processes by multiple patterns
+pkill -9 -f "vllm.entrypoints" 2>/dev/null
+pkill -9 -f "vllm serve" 2>/dev/null
+pkill -9 -f "vllm_ascend" 2>/dev/null
+pkill -9 -f "VLLM::EngineCore" 2>/dev/null
+pkill -9 -f "VLLM::Worker" 2>/dev/null
+pkill -9 -f "multiproc_executor" 2>/dev/null
+pkill -9 -f "patch_balance_schedule" 2>/dev/null
+pkill -9 -f "ray::" 2>/dev/null
+
+# Step 2: Kill by parent PID chain — find the vllm serve/bash wrapper and kill its process group
+for pid in $(pgrep -f "vllm" 2>/dev/null); do
+  kill -9 -"$pid" 2>/dev/null  # kill the process group
+  kill -9 "$pid" 2>/dev/null
+done
+
+# Step 3: Wait for OS to release NPU resources and reap zombies
+sleep 15
+
+# Step 4: Verify — count remaining vllm-related processes
+REMAINING=$(ps aux | grep -E "vllm|VLLM|EngineCore|Worker_TP|multiproc_executor" | grep -v grep | grep -v defunct | wc -l)
+ZOMBIES=$(ps aux | grep -E "vllm|VLLM|EngineCore|Worker_TP" | grep -v grep | grep defunct | wc -l)
+echo "Cleanup check: $REMAINING live processes, $ZOMBIES zombies"
+
+# Step 5: If zombies remain, kill their parent (init/PID 1 or the shell that spawned them)
+if [ "$ZOMBIES" -gt 0 ]; then
+  echo "WARNING: $ZOMBIES zombie processes remain. Killing zombie parents..."
+  ps aux | grep -E "vllm|VLLM|EngineCore|Worker_TP" | grep defunct | awk '{print $2}' | while read zpid; do
+    PPID=$(ps -o ppid= -p "$zpid" 2>/dev/null | tr -d ' ')
+    if [ -n "$PPID" ] && [ "$PPID" != "1" ] && [ "$PPID" != "0" ]; then
+      kill -9 "$PPID" 2>/dev/null
+      echo "Killed parent PID $PPID of zombie $zpid"
+    fi
+  done
+  sleep 5
+fi
+
+# Step 6: Final verification — port must be free
+if lsof -i :5001 2>/dev/null | grep -q LISTEN; then
+  echo "ERROR: Port 5001 still occupied after cleanup!"
+  lsof -i :5001 2>/dev/null
+fi
+```
+
+**Key rules for cleanup:**
+- Execute cleanup AFTER writing the ledger entry for the iteration, but BEFORE starting the next lever
+- The 15-second sleep is mandatory — Ascend CANN runtime needs time to release NPU HBM after SIGKILL
+- Zombies (state `Z`/`<defunct>`) do NOT hold NPU memory themselves, but their parent processes may still hold references to CANN device contexts. Killing the parent chain is necessary.
+- If after cleanup there are still >0 live vllm processes, retry once with `kill -9` on each remaining PID, then wait another 10 seconds
+- Do NOT proceed to the next lever until the cleanup verification passes (0 live processes, port free)
+- This cleanup is a hard requirement — even if the server appeared to stop cleanly, residual EngineCore/Worker processes may still hold NPU device handles
+
+## Timeout and retry contract
+
+Long waits must be bounded.
+
+- Define a startup wait budget for server readiness and treat timeout as `STARTUP_FAIL`
+- Define a benchmark wait budget for warmup plus evalscope completion and treat timeout as `BENCHMARK_FAIL`
+- Retry at most once for transient startup or benchmark issues; if retried, record that it was a retry and why
+- After a failed attempt, clean up the candidate server before moving to the next lever
+
+## Continuation contract
+
+The skill must continue executing after Phase 1 in the same run unless one of the explicit exit conditions is hit.
+
+- Baseline-only output is **incomplete** and must not be presented as the final result
+- After Phase 1 finishes, immediately continue into Phase 2 and keep advancing through the ranked lever list
+- Do not pause just because the ledger header, baseline table, or iteration-0 summary has been written
+- Do not generate the final summary/report until at least one post-baseline lever attempt has been recorded, unless execution is blocked by an explicit failure outside the lever space (for example: missing dependency, no write permission, repeated server launch failure for the baseline itself, or user stop)
+- If execution is blocked before any post-baseline lever can be attempted, write the blocking reason explicitly and mark the run as blocked rather than silently ending after the baseline
+
+**Robustness guarantees** — the skill must:
+- Catch and handle all exceptions during server startup, benchmark execution, and ledger writes
+- If a lever attempt fails for any reason (server crash, module not found, timeout, etc.), immediately write a ledger entry with the appropriate failure verdict (`STARTUP_FAIL`, `BENCHMARK_FAIL`) and continue to the next lever
+- Never exit the skill early due to individual lever failures — only the explicit exit conditions above can terminate the run
+- If context window is approaching limits (detected via conversation length or explicit warning), write a checkpoint note to the ledger and exit gracefully so the wrapper can resume
+- Treat missing dependencies, incompatible hardware features, or environment issues as `STARTUP_FAIL` or `SKIPPED_CONFLICT`, not as reasons to abort the entire run
+
+## Progress visibility contract
+
+The skill must behave like a visible long-running workflow, not a silent batch job.
+
+- Before starting each major action, emit a short status update naming the current phase, lever, and action
+- For any action expected to take more than 30 seconds, emit heartbeat progress updates at least every 30 seconds
+- Each progress update must include as many of these as are known: current phase, current lever, current step, current command category (`server_start`, `warmup`, `benchmark`, `profiling`, `report_generation`), elapsed time, and next expected milestone
+- When starting a lever attempt, explicitly print `Current lever:` and `Next lever if this finishes:` so the user can see forward progress
+- When running a benchmark, explicitly print the fixed workload (`c=1/4/8`, request counts, input/output tokens) and the artifact directory being written
+- When waiting on server readiness, say whether the skill is waiting for process start, health check success, warmup completion, or benchmark completion
+- If a step appears slow, explain the likely reason in plain language (for example: model load, graph compilation, benchmark still running at higher concurrency, profiling trace export)
+- Never disappear behind a single long terminal command without accompanying narrative updates
+- If an iteration is retried, say why it is being retried and what changed
+- Keep updates minimal: one or two short lines focused on action, not theory
+
+---
+
+## Workflow
+
+### Phase 0 — Setup & Resume
+
+Create the run directory and initialize the optimization ledger:
+
+```
+<work_dir>/
+├── ledger.md               # optimization history, all attempts
+├── baseline/               # baseline benchmark artifacts
+├── iter_01/ iter_02/ ...   # per-iteration benchmark results
+└── final_report.md         # synthesis after loop exits
+```
+
+**Resume logic** — before starting any work, check for an existing ledger in `work_dir`:
+
+0. **Handle explicit fresh start** — if the user explicitly requests to start fresh (e.g. "重新开始", "fresh start", "run a complete flow from scratch"), do NOT resume. Archive or overwrite the existing `ledger.md`, forcefully kill any existing `vllm` zombie processes, and proceed directly to Phase 1.
+1. **Read the ledger** and extract:
+   - Baseline metrics (c=1/4/8 ttft_avg, tpot_avg, TPS) — these are immutable
+   - All completed iteration verdicts (WIN / LOSS / NEUTRAL / STARTUP_FAIL / BENCHMARK_FAIL / SKIPPED_CONFLICT)
+   - The most recent lever attempt: which phase, which lever number, and its verdict
+   - Count of completed iterations per phase
+
+2. **Handle abandoned `TESTING` state** — if the last ledger entry shows `Status: TESTING` or `Status: IN_PROGRESS` without a verdict:
+   - This indicates the session was interrupted mid-lever
+   - Do NOT count this as a completed attempt
+   - The next action is to retry this same lever from scratch (stop any leftover server, restart, re-benchmark)
+   - Append a note to the ledger: `## Iteration N (retry) — <phase.lever>` with reason: `Session interrupted during previous attempt; retrying`
+
+3. **Determine the next lever** — based on the last completed verdict:
+   - If baseline is complete but no Phase 2 levers attempted → start Phase 2.1
+   - If Phase 2 has completed levers 2.1–2.3 → continue with 2.4
+   - If Phase 2 is complete (all levers attempted) → start Phase 3.1
+   - If a lever was `WIN` → carry its config forward as the new incumbent
+   - If a lever was `LOSS` / `NEUTRAL` / failure → discard and use the prior incumbent
+   - Continue through all phases (2–7) until all levers are exhausted or an exit condition is met
+
+4. **Load the incumbent config** — reconstruct the exact server launch command by:
+   - Starting from the Phase 1 baseline command
+   - Applying all `WIN` levers in order (each WIN modifies one field)
+   - This reconstructed command is the starting point for the next lever attempt
+
+5. **Print resume status**:
+```text
+Phase 0/7 | resume | work_dir=<path> | last_completed=<phase.lever> verdict=<WIN|LOSS|...> | next=<phase.lever> | wins_so_far=N
+```
+
+**First run (no ledger)** — if no ledger exists, initialize a fresh one and proceed to Phase 1:
+```text
+Phase 0/7 | setup | action=initialize_work_dir | work_dir=... | next=baseline startup
+```
+
+### Phase 1 — Baseline Benchmark
+
+Run the fixed-workload benchmark at `low_conc_levels` using the **baseline server configuration**:
+
+- If `baseline_launch_command` is provided, use it exactly as the Phase 1 startup command
+- Otherwise, start from the default template below
+- The Phase 1 startup config becomes the initial incumbent; every later iteration must inherit it and change only one lever at a time
+- Before launching, check whether a matching baseline server is already healthy on the target port; reuse it only if config attribution remains unambiguous, otherwise stop and relaunch
+
+Default template when `baseline_launch_command` is not provided:
+
+```bash
+ASCEND_RT_VISIBLE_DEVICES=<devices> \
+VLLM_ASCEND_ENABLE_ACLGRAPH=1 \
+VLLM_ASCEND_ENABLE_NZ=1 \
+python3 -m vllm.entrypoints.openai.api_server \
+  --model <model_path> \
+  --served-model-name <model_name> \
+  --tensor-parallel-size <tp> \
+  --max-model-len <max_model_len> \
+  --dtype <dtype> \
+  --port <port> \
+  --trust-remote-code
+```
+
+Benchmark command (warm-up 20 requests at c=1, then measure at all concurrency levels):
+```bash
+evalscope perf \
+  --parallel <low_conc_levels> \
+  --number <requests_per_level> \
+  --warmup-num 20 \
+  --model <model_name> \
+  --url http://127.0.0.1:<port>/v1/chat/completions \
+  --api openai --stream \
+  --dataset random \
+  --max-tokens <output_tokens> --min-tokens <output_tokens> \
+  --min-prompt-length <input_tokens> --max-prompt-length <input_tokens> \
+  --tokenizer-path <model_path>
+```
+Note: evalscope perf saves output to `outputs/<timestamp>/<model>/` in the current directory. Run the command from the appropriate work subdirectory (e.g., `cd <work_dir>/baseline && evalscope perf ...`) so artifacts land in the right place. Do NOT pass `--work-dir` — it is not a valid evalscope perf argument.
+
+Incumbent inheritance rules after Phase 1:
+- Preserve all env vars and CLI args from the Phase 1 baseline in every later iteration unless the current lever is explicitly testing one of those fields
+- If a candidate lever conflicts with a user-provided baseline setting, change only that single field for the A/B run and keep the rest of the baseline untouched
+- Record the exact effective startup command in the ledger so the winning config remains copy-pasteable
+
+Extract and record in ledger:
+- c=1: `ttft_avg`, `tpot_avg`, `output_token_throughput` (TPS), `latency_avg`
+- c=4, c=8: same metrics
+- These become the **immutable reference values** — never modified after Phase 1
+- After recording the baseline, execute the post-iteration cleanup protocol to stop the baseline server, then proceed to the first Phase 2 lever attempt in the same session
+
+Required status updates during Phase 1:
+- Before startup: `Phase 1/7 | baseline | action=server_start | command_source=user_baseline|default_template`
+- While waiting: `Phase 1/7 | baseline | action=wait_ready | state=process_started|healthcheck_pending|warmup_running`
+- Before benchmark: `Phase 1/7 | baseline | action=benchmark | c=1/4/8 | requests=20/80/160 | artifacts=<work_dir>/baseline`
+- After benchmark: `Phase 1/7 | baseline | action=record_baseline | ttft_c1=<value> | next=Phase 2 <first lever>`
+
+### Phase 2 — Scheduler & Engine Shell Tuning
+
+**Goal**: reduce queuing overhead and TTFT at low concurrency without touching kernel code.
+
+Candidate levers (try in order):
+
+#### 2.1 Balance scheduling
+```bash
+--additional-config '{"enable_balance_scheduling": true}'
+```
+Expected impact: reduces decode stalls at c=1 and c=4 when prefill and decode batches are mixed.
+
+#### 2.2 CPU binding
+```bash
+--additional-config '{"enable_cpu_binding": true}'   # default true; try false if NUMA is fragmented
+```
+
+#### 2.3 PagedAttention block size
+```bash
+--block-size 128    # 910C optimal; try 64 if memory-constrained
+```
+Expected impact: larger blocks → fewer KV cache pointer dereferences → lower TTFT.
+Note: `block_size=128` is the xlite_graph_config recommendation for 910C; always try this first.
+
+#### 2.4 Chunked prefill configuration
+```bash
+--enable-chunked-prefill \
+--max-num-batched-tokens 2048   # try: 1024, 2048, 4096
+```
+Expected impact on c=1: reduces head-of-line blocking from large prefills.
+
+#### 2.5 max_num_seqs
+```bash
+--max-num-seqs 32    # try: 16, 32, 64, 128
+```
+At low concurrency, smaller values reduce scheduler overhead.
+
+For each candidate:
+- Precheck applicability first; if the lever is incompatible with the current model, TP mode, EP mode, or incumbent config, record `SKIPPED_CONFLICT` immediately and continue
+- Start fresh server from the current incumbent command (Phase 1 baseline or prior WIN) with the single changed parameter
+- If an incumbent server is still running but does not match the intended candidate config, stop it before launching the candidate
+- If the server fails to start, never becomes healthy, or the benchmark cannot complete, still append a ledger entry for that attempt with a failure verdict and the captured reason
+- Run 20 warmup requests at c=1, then run the **fixed benchmark**: `--parallel 1 4 8 --number <requests_per_level>`
+- **Decision gate**: compare `ttft_avg` at **c=1** against the baseline value
+  - WIN if improvement ≥ `improvement_threshold_pct` (default 1%) **and** `tpot_avg` at c=1 does not regress > 5%
+  - NEUTRAL if `ttft_avg` improves but `tpot_avg` regresses > 5% (trade-off, not a clear win)
+  - LOSS if c=1 `ttft_avg` regresses > 2%
+  - NEUTRAL otherwise
+- Failure verdicts:
+  - `STARTUP_FAIL` if the process exits, crashes, or never reaches serving-ready state
+  - `BENCHMARK_FAIL` if the server starts but warmup or `evalscope perf` fails before producing a complete c=1/4/8 result set
+  - `SKIPPED_CONFLICT` if the lever is known in advance to be incompatible with the current model, hardware mode, or incumbent config and is intentionally skipped after a concrete conflict check
+- Also record `ttft_avg` and `tpot_avg` at c=4/8 — these appear in the ledger but do NOT affect WIN/LOSS
+- Log result in ledger (`WIN` / `LOSS` / `NEUTRAL` / `STARTUP_FAIL` / `BENCHMARK_FAIL` / `SKIPPED_CONFLICT`)
+- If WIN: carry this change into the next phase as the new incumbent
+
+Required status updates for every lever:
+- Before change: `Phase <n>/7 | lever=<phase.lever> | action=prepare_attempt | incumbent=<short name> | next_lever=<next candidate>`
+- Before stop/reuse decision: `Phase <n>/7 | lever=<phase.lever> | action=server_check | port=<port> | decision=reuse|stop_and_restart`
+- Before startup: `Phase <n>/7 | lever=<phase.lever> | action=server_start | changed_field=<single field>`
+- Before benchmark: `Phase <n>/7 | lever=<phase.lever> | action=benchmark | c=1/4/8 | artifacts=<work_dir>/iter_N`
+- After verdict: `Phase <n>/7 | lever=<phase.lever> | action=record_verdict | verdict=WIN|LOSS|NEUTRAL|STARTUP_FAIL|BENCHMARK_FAIL|SKIPPED_CONFLICT | carry_forward=YES|NO | next=<next candidate>`
+
+### Phase 3 — Ascend Fusion & Graph Compilation Tuning
+
+**Goal**: enable or tune Ascend-specific kernel fusion and graph compilation backends.
+
+Try in order:
+
+#### 3.0 CUDAGraph mode (graph compilation decision)
+
+```bash
+--compilation-config '{"cudagraph_mode": "FULL"}'              # vs baseline FULL_DECODE_ONLY
+```
+This is the most upstream graph-compilation lever: it decides whether decode (and prefill) run inside a captured ACL graph. `cudagraph_mode` is the field on `--compilation-config`, NOT an `--additional-config` key.
+
+Applicable `CUDAGraphMode` values on vllm-ascend:
+- `FULL_DECODE_ONLY` (= `FULL` decode, `NONE` prefill) — decode captured, prefill not. Common baseline choice.
+- `FULL` (= `FULL` decode, `FULL` prefill) — prefill also captured. A/B against `FULL_DECODE_ONLY`: same decode graph, but prefill runs as a graph too (longer startup, possibly lower prefill latency / TTFT).
+- `FULL_AND_PIECEWISE` (= `FULL` decode, `PIECEWISE` prefill) — try if `FULL` prefill capture is memory-constrained.
+- `PIECEWISE` — piecewise graph only (decode NOT fully captured → decode TPOT usually regresses; useful only as a diagnostic baseline).
+- `NONE` — no graph (equivalent to `--enforce-eager`); decode TPOT usually regresses. Use only to measure the graph's contribution.
+
+**When to run this lever**: ALWAYS, as the first Phase 3 attempt. `cudagraph_mode` is the single field with the most direct effect on decode TPOT — skipping it leaves the most upstream decode switch untested.
+
+**Primary A/B**: `FULL` vs the baseline's graph mode. Only change the `cudagraph_mode` field; preserve the rest of `--compilation-config` and the incumbent command. If the baseline did not set `cudagraph_mode` (vllm-ascend default is `FULL`), test `FULL_DECODE_ONLY` as the candidate and compare against the default-`FULL` incumbent.
+
+Expected impact: if the baseline is `FULL_DECODE_ONLY`, switching decode-path capture rarely helps (decode is already captured); the meaningful delta is on TTFT/prefill. If the baseline is `FULL` (default), `FULL_DECODE_ONLY` can reduce startup + prefill overhead with identical decode TPOT — a likely WIN on TTFT-neutral workloads. `PIECEWISE`/`NONE` are expected regressions on TPOT; record them as LOSS/NEUTRAL for attribution, do not carry forward.
+
+#### 3.1 NZ weight format
+```bash
+VLLM_ASCEND_ENABLE_NZ=1    # default 1; also try 2 (enable for all ops)
+VLLM_ASCEND_ENABLE_NZ=2
+```
+Expected impact: NZ format reduces memory bandwidth on 910C for matmul-heavy layers.
+
+#### 3.2 npugraph_ex with static kernel
+```bash
+--additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": true}}'
+```
+Expected impact: static kernel pre-compiles operator binaries for fixed batch shapes; reduces JIT overhead at c=1. Note: adds startup time.
+
+#### 3.3 Norm-quant fusion
+```bash
+--additional-config '{"ascend_compilation_config": {"fuse_norm_quant": true, "fuse_qknorm_rope": true}}'
+```
+Default is already true; try disabling if baseline seems slow on normalization:
+```bash
+--additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}'
+```
+
+#### 3.4 AllReduce-RMSNorm fusion (TP > 1 only)
+```bash
+--additional-config '{"ascend_compilation_config": {"fuse_allreduce_rms": true}}'
+```
+Expected impact: fuses allreduce + rmsnorm → reduces synchronization latency in TP runs.
+
+#### 3.5 MatMul-AllReduce fusion (TP > 1 only)
+```bash
+VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE=1
+```
+Expected impact: overlaps matmul and allreduce; helps TPOT at low concurrency.
+
+#### 3.6 GMM-SwiGLU-Quant fusion (MoE models only)
+```bash
+--additional-config '{"ascend_fusion_config": {"fusion_ops_gmmswigluquant": true}}'
+```
+
+#### 3.7 XliteGraph mode
+```bash
+--additional-config '{"xlite_graph_config": {"enabled": true, "full_mode": false}}'
+```
+Requires `block_size=128`. Expected impact: Xlite graph backend can significantly accelerate decode on 910C. Try `full_mode: true` if `false` wins.
+
+### Phase 4 — FlashComm & Communication Overlap Tuning (TP > 1 only)
+
+Skip this phase if `tensor_parallel_size == 1`.
+
+#### 4.1 FlashComm1 (prefill-side comm-compute overlap)
+```bash
+--additional-config '{"enable_flashcomm1": true}'
+```
+Expected impact: overlaps TP allreduce with compute during prefill → lower TTFT.
+
+#### 4.2 FlashComm2 (decode-side comm overlap)
+```bash
+VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE=<tp>
+```
+Try values: `1`, `tp/2`, `tp`. Expected impact: further reduces allreduce stalls during decode.
+
+#### 4.3 Prefill comm-compute overlap
+```bash
+--additional-config '{"prefill_comm_compute_overlap": true}'
+```
+
+#### 4.4 HCCL buffer size
+```bash
+HCCL_BUFFSIZE=200    # try: 100, 200, 400 (MB)
+```
+Larger buffer can reduce HCCL fragmentation overhead.
+
+### Phase 5 — Weight Prefetch & Memory Layout
+
+#### 5.1 Weight prefetch
+```bash
+--additional-config '{"weight_prefetch_config": {"enabled": true}}'
+```
+Expected impact: prefetches next layer weights during current layer compute; masks HBM latency.
+Try adjusting `prefetch_ratio` for attention vs MoE separately if overall win is marginal:
+```bash
+--additional-config '{"weight_prefetch_config": {"enabled": true, "prefetch_ratio": {"attn": {"qkv": 1.0, "o": 1.0}, "moe": {"gate_up": 1.0}}}}'
+```
+
+#### 5.2 MLAPO (DeepSeek W8A8 only)
+```bash
+VLLM_ASCEND_ENABLE_MLAPO=1    # default 1; disable if memory is tight
+```
+
+#### 5.3 Fused MC2 (MoE W8A8 + EP only)
+```bash
+VLLM_ASCEND_ENABLE_FUSED_MC2=1   # try: 0, 1, 2
+```
+
+### Phase 6 — Multistream & DSA Overlap (Advanced)
+
+These levers involve deeper NPU pipeline overlapping. Apply only after Phases 2–5 are exhausted.
+
+#### 6.1 Multistream shared-expert overlap (MoE only)
+```bash
+--additional-config '{"multistream_overlap_shared_expert": true}'
+```
+
+#### 6.2 Multistream gate overlap (MoE only)
+```bash
+--additional-config '{"multistream_overlap_gate": true}'
+```
+
+#### 6.3 DSA preprocess overlap
+```bash
+--additional-config '{"multistream_dsa_preprocess": true}'
+```
+
+#### 6.4 DSv4 DSA overlap (DeepSeek V4 only)
+```bash
+--additional-config '{"multistream_dsv4_dsa_overlap": true}'
+```
+
+### Phase 7 — Profiling-Driven Triton Kernel Tuning
+
+**Trigger condition**: Apply after all Phases 2–6 levers have been attempted.
+
+This phase uses vLLM's built-in profiler to identify the slowest operators, then tunes their block size parameters if they are in the tunable category.
+
+#### 7.1 Collect profiling trace
+
+Server must be started with profiling enabled:
+```bash
+--profiler-config.profiler=torch \
+--profiler-config.torch_profiler_dir=<work_dir>/profiling
+```
+
+Then at c=1:
+```bash
+# Start profiling
+curl -X POST http://127.0.0.1:5000/start_profile
+
+# Send 20 requests at c=1 to capture a representative trace
+evalscope perf --parallel 1 --number 20 ...
+
+# Stop profiling
+curl -X POST http://127.0.0.1:5000/stop_profile
+```
+
+The trace is saved as JSON in `<work_dir>/profiling/`. Claude reads the JSON and identifies:
+- **Top 5 longest ops** (by total GPU time)
+- **NPU idle gaps** between consecutive ops (indicating CPU-side bottleneck or launch overhead)
+- **Allreduce / HCCL ops** (if TP > 1, check if communication is on the critical path)
+
+#### 7.2 Classify ops into tunable vs. non-tunable
+
+After reading the trace, classify each slow op:
+
+**Tunable (Triton kernels in vllm-ascend source):**
+
+| Op pattern | Source file | Tunable parameter |
+|------------|-------------|-------------------|
+| `rms_norm` | `ops/triton/rms_norm.py:52` | `ROW_BLOCK_SIZE` (default 16) |
+| `layernorm_gated` | `ops/triton/layernorm_gated.py:155` | `BLOCK_M` (default 64) |
+| `matmul` / `gemm` | `ops/triton/batch_invariant/matmul.py:137` | `BLOCK_M/N/K` (default 128/128/64) |
+| `flash_attention` / `fa3` | `attention/fa3_v1.py:90` | `num_splits` (default 1), `attention_chunk` (default 0) |
+
+**Non-tunable (CANN C++ compiled ops):**
+
+| Op pattern | Reason |
+|------------|--------|
+| `grouped_matmul_swiglu_quant` | Tiling params (`baseM/baseN/baseK`) are C++ compile-time constants in `csrc/gmm/` headers |
+| `paged_attention` / `npu_fused_infer_attention_score` | Implemented via ACLNN, no user-controllable parameters |
+| Any op prefixed with `aclnn` | CANN runtime op, tiling decided at op compilation time |
+
+#### 7.3 Tune tunable ops
+
+For each tunable op found in 7.2:
+
+1. **Edit the source file** — change the block size constant to a new value (try 2× or 0.5× of default)
+2. **Restart server** with the same configuration (no other changes)
+3. **Run benchmark** at c=1/4/8
+4. **Record in ledger** with verdict WIN/LOSS/NEUTRAL based on `ttft_avg` at c=1
+5. If WIN: keep the edit; if LOSS/NEUTRAL: revert the edit and try the next parameter
+
+Example for `rms_norm`:
+```python
+# ops/triton/rms_norm.py line 52
+ROW_BLOCK_SIZE = 32  # was 16, try doubling
+```
+
+For `fa3_v1.py` `num_splits`:
+```python
+# attention/fa3_v1.py line 90
+num_splits=2,  # was 1, try splitting attention across NPU cores
+```
+
+#### 7.4 Record non-tunable findings
+
+For non-tunable ops that appear in the top-5 slow list, append to `final_report.md` under a "Manual Intervention" section:
+
+```markdown
+## Manual Intervention Required
+
+The following operators were identified as bottlenecks but cannot be tuned via source modification:
+
+- `aclnnGroupedMatmul` (18% of total GPU time): Tiling parameters `baseM/baseN` are C++ compile-time constants. To tune, use CANN's AOE (Ascend Operator Expert) tool offline with the specific input shapes observed in this run.
+- `aclnnFlashAttention` (12% of total GPU time): No user-controllable parameters. Consider contacting Huawei for updated ACLNN binaries or checking if a newer CANN version has optimized this op.
+```
+
+This allows the user to decide whether to invest time in offline AOE tuning or escalate to Huawei support.
+
+---
+
+## Ledger format
+
+Append one entry per iteration to `ledger.md`.
+
+- For successful benchmarked attempts (`WIN` / `LOSS` / `NEUTRAL`), **all three concurrency rows (c=1/4/8) are mandatory**
+- For failed or skipped attempts (`STARTUP_FAIL` / `BENCHMARK_FAIL` / `SKIPPED_CONFLICT`), use the failure template below instead of the metric table
+
+```markdown
+## Iteration N — <phase>.<lever_name>
+
+**Hypothesis**: <why this lever should help, citing phase doc>
+**Change**: `<exact env var or --additional-config JSON>`
+**Incumbent config before**: `<previous winning command>`
+
+### Results vs Baseline (fixed benchmark: c=1/4/8, primary=ttft_avg@c=1, guard=tpot_avg@c=1)
+
+| Concurrency | ttft_avg (ms) | ttft_avg delta | tpot_avg (ms) | tpot_avg delta | TPS (tok/s) | TPS delta |
+|-------------|---------------|----------------|---------------|----------------|-------------|-----------|
+| **1** ⭐ | 241.0 | **-15.4% ← DECISION** | 27.1 | -4.2% | 36.9 | +4.4% |
+| 4 | 420.0 | -8.3% | 29.5 | +1.0% | 135.6 | -1.0% |
+| 8 | 610.0 | -5.2% | 31.0 | +2.1% | 258.1 | -2.1% |
+
+**Verdict**: WIN  ← ttft_avg c=1 improved -15.4% (≥1%), tpot_avg c=1 improved -4.2% (no regression)
+**Carry forward**: YES
+**Notes**: <any anomalies, warnings from server log>
+```
+
+Failure / skipped attempt template:
+
+```markdown
+## Iteration N — <phase>.<lever_name>
+
+**Hypothesis**: <why this lever should help, or why it was checked>
+**Change**: `<exact env var or --additional-config JSON>`
+**Incumbent config before**: `<previous winning command>`
+**Verdict**: STARTUP_FAIL
+**Failure stage**: server_startup
+**Reason**: <short reason, e.g. incompatible with xlite_graph_config + block_size=64>
+**Evidence**:
+- Exit code: <code or N/A>
+- Health check: <never ready / failed after warmup / benchmark aborted>
+- Log excerpt: `<relevant stderr or server log lines>`
+**Carry forward**: NO
+**Notes**: <follow-up, retry hint, or why this lever was skipped>
+```
+
+Rules:
+- A lever is a **WIN** if `ttft_avg` at **c=1** improves ≥ `improvement_threshold_pct` **and** `tpot_avg` at c=1 does not regress > 5%
+- A lever is **NEUTRAL** if `ttft_avg` at c=1 improves but `tpot_avg` regresses > 5% (trade-off)
+- A lever is a **LOSS** if `ttft_avg` at c=1 regresses > 2%
+- A lever is **STARTUP_FAIL** if no valid serving endpoint is established for the attempt
+- A lever is **BENCHMARK_FAIL** if serving starts but the benchmark does not finish with a complete c=1/4/8 result set
+- A lever is **SKIPPED_CONFLICT** if the incompatibility is known before launch and is backed by a concrete config or model constraint
+- c=4/8 rows are recorded for trend analysis only — they never override the c=1 verdict
+- Wins are carried forward cumulatively; losses, neutrals, failures, and skipped conflicts are discarded
+- Never modify a prior ledger entry — only append
+
+---
+
+## Exit conditions
+
+**Run all phases (1-7) completely.** Do not stop early based on consecutive no-WIN phases or plateau patterns.
+
+Stop only when:
+
+1. **Budget**: `max_iterations` reached (safety valve, default 50)
+2. **Manual stop**: user explicitly says "stop" or "enough"
+3. **All phases complete**: Phase 7 has been attempted, regardless of WIN/LOSS/NEUTRAL outcomes
+4. **Blocked before tuning can continue**: baseline itself cannot be made runnable, required tooling is missing, or the environment prevents any further lever attempt from being executed safely
+
+Non-exit examples:
+- Baseline benchmark completed successfully
+- Ledger header or baseline report has been written
+- No WIN found yet
+- A single lever failed to start
+- An iteration was marked `STARTUP_FAIL`, `BENCHMARK_FAIL`, or `SKIPPED_CONFLICT`
+
+The skill should exhaust all tuning levers across all phases before generating the final report.
+
+---
+
+## Running the loop to completion (auto-resume wrapper)
+
+The full campaign spans 7 phases and dozens of lever attempts — far more than a single `claude` session can survive before the context window fills. The skill is designed around this: each session runs until it must yield (context approaching limits — see the checkpoint-and-exit rule), then a **wrapper** re-launches a fresh session that reads the ledger and continues. This is how a fragmented set of sessions becomes one complete optimization run.
+
+Use `scripts/auto_resume_wrapper.sh` to drive this. It wraps the `claude` CLI call and relaunches it until `final_report.md` appears in `work_dir` (the skill's only completion signal — see "Final report"). The ledger in `work_dir` is the hand-off state between sessions: a freshly launched session follows the "Resume logic" section, reads the ledger, and picks up at the next unfinished phase.lever.
+
+**Usage:**
+
+```bash
+bash scripts/auto_resume_wrapper.sh \
+  --work-dir <work_dir> \
+  -- claude -p "<skill prompt with model/work_dir/etc.>" --max-turns 0
+```
+
+- `--work-dir` — the campaign's `work_dir`; the wrapper watches `<work_dir>/final_report.md` for completion and `<work_dir>/ledger.md` for resume state.
+- Everything after `--` is the full `claude` command, passed through verbatim to each relaunch. Use `--max-turns 0` (or a bounded value) so each session yields on its own when the context fills, letting the wrapper decide whether to relaunch.
+- The wrapper retries up to 20 times, sleeping 5s between attempts, and exits 0 as soon as `final_report.md` exists. It checks for completion both **before** launching (so an already-finished run is not re-launched) and **after** each session exits.
+
+**What the wrapper is NOT:**
+- It does not read or parse the ledger — the skill does that on resume. The wrapper only checks for the presence of `final_report.md`.
+- It does not decide which lever to try next — that is the skill's job per the RLCR principle.
+- It does not recover from a corrupted or contradictory ledger; if the skill cannot resume cleanly, it should surface that to the user rather than silently looping.
+
+**Recommended run shape:** launch the wrapper once in the background, let it drive the whole campaign to `final_report.md`, then read the report. Do not manually relaunch `claude` mid-campaign — that races with the wrapper and can spawn two sessions writing to the same ledger.
+
+---
+
+## Final report
+
+After the loop exits, write `final_report.md` using `scripts/generate_tuning_report.py`:
+
+```markdown
+# vLLM-Ascend Tuning Report — <model_name>
+
+## Summary
+- Total iterations: N
+- Winning levers: M
+- Failed or skipped levers: K
+- Overall improvement on target metric (c=1): X%
+- Completion status: `completed` | `blocked` | `stopped_by_user` | `budget_exhausted`
+
+## Baseline vs Best Configuration
+
+| Concurrency | Metric | Baseline | Best | Improvement |
+|-------------|--------|----------|------|-------------|
+| 1 | TTFT avg | ... | ... | ... |
+| 1 | TPOT avg | ... | ... | ... |
+| 4 | TTFT avg | ... | ... | ... |
+| 8 | TTFT avg | ... | ... | ... |
+
+## Winning Configuration (copy-pasteable)
+
+```bash
+ASCEND_RT_VISIBLE_DEVICES=...
+VLLM_ASCEND_ENABLE_NZ=...
+...
+python3 -m vllm.entrypoints.openai.api_server \
+  --model ... \
+  --additional-config '...' \
+  ...
+```
+
+## Optimization History
+
+<condensed ledger — one line per iteration>
+
+## Levers That Did Not Help
+
+<list with brief reason>
+
+## Failed / Incompatible Levers
+
+| Lever | Verdict | Stage | Reason | Evidence |
+|-------|---------|-------|--------|----------|
+| `xlite_graph.full_mode=true` | `STARTUP_FAIL` | `server_startup` | incompatible with current block size | `server exited with code 1: ...` |
+| `fuse_allreduce_rms=true` | `SKIPPED_CONFLICT` | `precheck` | TP=1 so lever is not applicable | `tensor_parallel_size == 1` |
+
+Rules for this section:
+- Include every `STARTUP_FAIL`, `BENCHMARK_FAIL`, and `SKIPPED_CONFLICT` entry from the ledger
+- Preserve the first actionable failure reason instead of collapsing all failures into "did not help"
+- Include a short evidence string, preferably an exit code, failed health check, or log excerpt
+
+## Manual Intervention Required
+
+<Non-tunable ops identified by Phase 7 profiling — op name, GPU time percentage, reason it cannot be tuned, and suggested action (AOE / Huawei support)>
+
+## Recommended Next Steps
+
+<if gains are still possible: profiling suggestions, kernel-level work>
+```
+
+Finalization rules:
+- Never treat the baseline section alone as the final deliverable
+- Only generate the final report after an actual exit condition is met
+- If the run is blocked before tuning can proceed, the final report must say `Completion status: blocked` and name the blocking reason
+- If only baseline succeeded and no tuning iteration was attempted, that is a blocked or interrupted run, not a completed optimization campaign
+- Before final report generation, emit a final progress line stating whether the run is exiting because of completion, block, user stop, or budget exhaustion
+
+---
+
+## Constraints
+
+- **Execution over narration**: once prerequisites are satisfied, prefer the next concrete server/benchmark action over more discussion
+- **One lever per iteration**: never bundle two changes; it destroys attribution
+- **Fixed workload**: `input_tokens`, `output_tokens`, and `low_conc_levels` never change after Phase 1
+- **Baseline inheritance**: if `baseline_launch_command` is provided, Phase 1 uses it exactly and every later iteration must preserve it except for the single field under test
+- **Server ownership**: at most one campaign-owned server may be active on the target port at any time
+- **Mandatory post-iteration cleanup**: execute the full cleanup script from "Post-iteration strict cleanup protocol" after EVERY iteration before starting the next lever. This kills all vllm/EngineCore/Worker processes, waits for NPU resource release, and verifies port availability. Skipping cleanup leads to zombie accumulation and NPU memory leaks.
+- **Restart server cleanly** between every iteration — no warm state carry-over
+- **Bounded waiting**: startup and benchmark waits must use explicit timeout budgets rather than unbounded waiting
+- **Failure visibility**: startup failures, benchmark failures, and prechecked incompatibilities must still be written to the ledger and surfaced in the final report
+- **Progress visibility**: long-running steps require heartbeat updates at least every 30 seconds with phase, lever, action, and next milestone
+- **Warm up before every measurement**: 20 warmup requests at c=1 before measurement
+- **Record everything**: even a 0.1% change gets a ledger entry
+- **TP-only levers**: FlashComm, MatMul-AllReduce, AllReduce-RMSNorm only apply when `tensor_parallel_size > 1`
+- **MoE-only levers**: GMM-SwiGLU fusion, multistream shared-expert, DSA only apply to MoE architectures
+
+---
+
+## Example invocation
+
+```
+/ascend-vllm-serving-tune-loop
+model_path=/data/models/Qwen3-32B
+model_name=Qwen3-32B
+tensor_parallel_size=4
+target_metric=ttft_avg
+input_tokens=1024
+output_tokens=512
+```
+
+```
+/ascend-vllm-serving-tune-loop
+model_path=/data/models/DeepSeek-V3
+model_name=DeepSeek-V3
+tensor_parallel_size=8
+baseline_launch_command='ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 VLLM_ASCEND_ENABLE_ACLGRAPH=1 VLLM_ASCEND_ENABLE_NZ=2 python3 -m vllm.entrypoints.openai.api_server --model /data/models/DeepSeek-V3 --served-model-name DeepSeek-V3 --tensor-parallel-size 8 --max-model-len 32768 --dtype bfloat16 --block-size 128 --max-num-seqs 32 --additional-config "{\"enable_balance_scheduling\": true}" --port 5000 --trust-remote-code'
+target_metric=ttft_avg
+low_conc_levels="1 4 8"
+requests_per_level="20 80 160"
+max_iterations=50
+```

--- a/.agents/skills/ascend-vllm-serving-tune-loop/SKILL.md
+++ b/.agents/skills/ascend-vllm-serving-tune-loop/SKILL.md
@@ -1,867 +1,126 @@
+---
+name: ascend-vllm-serving-tune-loop
+description: "Run an evidence-driven vLLM-Ascend serving tuning loop on Ascend 910C, maintain a ledger, resume across sessions, and generate a final tuning report."
+disable-model-invocation: true
+---
+
 # ascend-vllm-serving-tune-loop
 
-Autonomous, evidence-driven performance optimization loop for vLLM-Ascend serving on Huawei Ascend 910C NPU.
+## What this skill is for
 
-Runs a fixed baseline benchmark, then iterates through a layered tuning plan — from scheduler-level knobs down to ACLGraph compilation and kernel-level parameters — exhaustively trying all candidate levers across all phases. Produces a full optimization ledger and final comparison report.
+Use this skill when the user wants a long-running, evidence-driven serving optimization campaign for `vllm-ascend` on Ascend 910C.
 
-## When to invoke
+Typical intents:
 
-Use this skill when the user wants to:
-- Squeeze lower latency / higher throughput from an existing vllm-ascend deployment on 910C
-- Systematically explore Ascend-specific tuning knobs without guessing
-- Get a documented, reproducible record of what was tried and what helped
+- systematic serving tuning on 910C
+- compare scheduler / ACLGraph / communication / kernel levers
+- generate a durable tuning ledger and final report
 
-Trigger phrases: "optimize", "tune", "调优", "性能优化", "latency optimization", "ascend tuning loop", "sota loop"
+Trigger phrases: `optimize`, `tune`, `调优`, `性能优化`, `latency optimization`, `ascend tuning loop`
 
-## Prerequisites
+## Read order
 
-Same as `ascend-vllm-serving-auto-benchmark` plus:
-- `msprof` available (optional, for human deep-dive profiling if Phase 7 identifies non-tunable bottlenecks)
-- Enough NPU memory headroom to try `block_size` variants
-- Write permission to working directory for ledger files
+1. Read this file first.
+2. Read [workflow-checklist.md](references/workflow-checklist.md).
+3. Read [server-management.md](references/server-management.md).
+4. Read [ledger-and-report.md](references/ledger-and-report.md).
+5. Use [tuning-knobs-reference.md](references/tuning-knobs-reference.md) when selecting the next lever.
+
+## Hard requirements
+
+- One lever per iteration. Never bundle changes.
+- The benchmark contract is frozen after baseline.
+- Every verdict must be appended to `ledger.md` immediately.
+- The skill must continue past baseline unless an explicit block condition is hit.
+- Cleanup must be scoped to the managed server process for this run. Never use broad `pkill -9 -f vllm` / `pkill -9 -f ray` instructions on shared machines.
+- When a port is occupied by a non-managed process, stop and ask the user instead of killing it blindly.
 
 ## Inputs
 
-| Parameter | Required | Description |
-|-----------|----------|-------------|
+| Parameter | Required | Notes |
+|-----------|----------|-------|
 | `model_path` | Yes | Local path or model ID |
-| `model_name` | Yes | Short name used in commands and ledger |
-| `tensor_parallel_size` | No | NPU card count (default: 1) |
-| `max_model_len` | No | Max context length (default: 8192) |
-| `dtype` | No | `float16` / `bfloat16` (default: `float16`) |
-| `port` | No | Server port (default: 5000) |
-| `baseline_launch_command` | No | Full server launch command used as the Phase 1 baseline. If provided, the skill uses this command exactly as the starting point instead of the default template, preserving any pre-applied optimizations across the whole campaign unless a later iteration is explicitly testing that field. |
-| `target_metric` | No | Primary metric to optimize: `ttft_avg` \| `tpot_avg` \| `latency_avg` (default: `ttft_avg`) |
-| `low_conc_levels` | No | Concurrency levels considered "low" (default: `1 4 8`) |
-| `requests_per_level` | No | Requests per concurrency level for each benchmark run (default: `20 80 160`) |
-| `input_tokens` | No | Input token length (default: 1024) |
-| `output_tokens` | No | Output token length (default: 512) |
-| `improvement_threshold_pct` | No | Minimum improvement to count as a win (default: 1.0%) |
-| `max_iterations` | No | Hard stop after N tuning iterations (default: 50) |
-| `work_dir` | No | Directory for all artifacts (default: `./tuning_run/<timestamp>`) |
+| `model_name` | Yes | Short model name used in commands and reports |
+| `tensor_parallel_size` | No | Default `1` |
+| `max_model_len` | No | Default `8192` |
+| `dtype` | No | Default `float16` |
+| `port` | No | Default `5000` |
+| `baseline_launch_command` | No | If provided, this is the baseline contract |
+| `target_metric` | No | `ttft_avg`, `tpot_avg`, `latency_avg`; default `ttft_avg` |
+| `low_conc_levels` | No | Default `1 4 8` |
+| `requests_per_level` | No | Default `20 80 160` |
+| `input_tokens` | No | Default `1024` |
+| `output_tokens` | No | Default `512` |
+| `improvement_threshold_pct` | No | Default `1.0` |
+| `max_iterations` | No | Default `50` |
+| `work_dir` | No | Default `./tuning_run/<timestamp>` |
 
-## Fixed benchmark contract
+## Execution shape
 
-**These values are locked for the entire campaign and must never change between iterations:**
+The tuning loop is expected to run through these stages:
 
-| What | Value |
-|------|-------|
-| Concurrency levels | `c = 1, 4, 8` (all three, every run) |
-| Primary decision metric | `ttft_avg` at **c = 1** |
-| Secondary guard metric | `tpot_avg` at **c = 1** — if it regresses > 5%, downgrade WIN to NEUTRAL |
-| Full recorded metrics | `ttft_avg`, `tpot_avg`, `output_token_throughput` (TPS), `latency_avg` at each of c=1/4/8 |
-| Input tokens | fixed at `input_tokens` parameter |
-| Output tokens | fixed at `output_tokens` parameter |
-| Requests per level | fixed at `requests_per_level` parameter |
-| Baseline launch config | If `baseline_launch_command` is provided, use it exactly in Phase 1; otherwise use the default server template below |
-| Warmup requests | 20 at c=1 before every measurement run |
+1. Establish baseline.
+2. Select the next ranked lever.
+3. Launch exactly one managed server for that attempt.
+4. Warm up and benchmark at the frozen workload.
+5. Write the verdict to `ledger.md` immediately.
+6. Run scoped cleanup for the managed server.
+7. Continue until an exit condition is met.
 
-**Why `ttft_avg` and not P99**: at low concurrency (20 requests per level), P99 represents a single outlier request and is too noisy to be a reliable signal. `ttft_avg` is statistically stable and directly reflects prefill path performance — the dominant factor at c=1.
+Use these scripts as the default building blocks:
 
-**TPS** (`output_token_throughput`) is recorded at all concurrency levels for informational purposes. At c=1 it correlates closely with `tpot_avg`, but becomes more informative at c=4/8 where batching effects kick in.
+- `scripts/auto_resume_wrapper.sh`
+- `scripts/cleanup_managed_server.sh`
+- `scripts/generate_tuning_report.py`
 
-The user may override the target metric via input parameters, but once Phase 1 starts the chosen metric is frozen.
+## Safety contract
 
-## Core principle: RLCR (Refinement Loop with Continuous Revalidation)
+- Server ownership must be explicit. Store the PID of the managed server in the run directory and use that PID for cleanup.
+- Cleanup is scoped by PID, process group, and optionally the campaign port.
+- If cleanup finds the port is still occupied by a different process, surface that fact and ask the user before taking destructive action.
+- `SIGINT` should stop the wrapper cleanly instead of auto-relaunching.
 
-Every tuning iteration must:
-1. **Hypothesize** — pick one lever from the ranked candidate list with a stated expected impact
-2. **Change one thing** — apply a single parameter change; never bundle multiple levers in one iteration
-3. **Revalidate** — run evalscope at **all three concurrency levels (c=1/4/8)** with the fixed workload
-4. **Decide on `ttft_avg` at c=1** — this single number is the gate for WIN/LOSS/NEUTRAL
-5. **Record** — append to the ledger regardless of win/loss; include all c-level metrics
+## Resume contract
 
-Do NOT skip validation. Do NOT bundle multiple changes. Do NOT change the workload between iterations.
-Do NOT declare a WIN based on c=4/8 alone — c=1 `ttft_avg` is the authoritative decision metric.
-Do NOT stop after writing only the baseline section or an "Iteration 0 — Baseline established" note. Baseline creation is the starting point, not the end of the skill.
-Do NOT stay silent for long-running work. The user must always be able to tell what phase is running, what lever is under test, and why the skill is still busy.
+- `ledger.md` is the single source of truth.
+- A resumed session must read the ledger, identify the most recent completed verdict, and continue with the next unfinished lever.
+- The wrapper only decides whether another session is needed; it does not decide the next lever.
 
-## Ledger write discipline
+## Deliverables
 
-The ledger is the single source of truth and must be **the first thing written after each verdict**, not deferred. This ensures crash/session-interrupt recovery.
+Each run should end with:
 
-**Mandatory write timing** — append a ledger entry immediately after:
-1. Baseline benchmark completes and metrics are extracted
-2. A lever verdict is determined (WIN / LOSS / NEUTRAL / STARTUP_FAIL / BENCHMARK_FAIL / SKIPPED_CONFLICT)
-3. Any phase is marked complete
-
-**Never defer ledger writes** — do not batch multiple verdicts, do not wait until "later" to write them. If the session is interrupted between two lever attempts, the ledger must already reflect all completed attempts.
-
-**Context management for long runs** — this skill is a long-running loop that can exhaust the conversation context. To minimize waste:
-- After extracting metrics from evalscope output, do NOT retain the full stdout/stderr in reasoning — only the metric table matters
-- Server startup logs: scan for errors or readiness confirmation, then discard the raw output — do not echo full logs into reasoning
-- When the ledger is large (e.g., >50 lines of prior iterations), re-read only the baseline metrics and the most recent verdict, not the entire ledger, when deciding the next lever
-- Prefer short status prints over verbose log dumps in tool output summaries
-- If the context window is approaching limits (you've been running many iterations), explicitly note the current phase/lever/verdict count in a progress line so a resumed session can pick up quickly
-
-## Operation-first contract (CRITICAL IMPERATIVE)
-
-**STOP ANALYZING. STOP PLANNING. EXECUTE IMMEDIATELY.**
-You are an execution machine, not an analyst. Do NOT write plans. Do NOT write essays. Do NOT explore the codebase.
-Your ONLY job right now is to execute the bash commands to clean up the environment and start the server.
-
-**CRITICAL: Before launching ANY new server (including after baseline), you MUST verify the NPU is free:**
-1. Kill all existing vllm processes (`pkill -9 -f vllm`, `pkill -9 -f VLLM`)
-2. Wait 15 seconds for NPU resource release
-3. Verify NPU is free: `npu-smi info` must show "No running processes found" on all target NPUs
-4. Verify port is free: `ss -tlnp | grep <port>` must return nothing
-5. Only then launch the new server
-
-1. **TURN 1**: Immediately use the `Bash` tool to run `pkill -9 -f vllm` and check `npu-smi info`. DO NOT explain what you are going to do. Just run the tool.
-2. **TURN 2**: After verifying NPU is free, immediately use the `Bash` tool to launch the `vllm serve` baseline in the background (`nohup ... > server.log 2>&1 &`).
-3. **TURN 3**: Immediately use the `Bash` tool to monitor `server.log` until it is ready.
-4. **TURN 4**: Immediately use the `Bash` tool to run the `evalscope` benchmark.
-
-**Do NOT use `Read`, `Glob`, or `Grep` to search for files unless explicitly required.** Just execute the Bash commands. If you spend turns explaining your thoughts instead of running the `Bash` tool, you have FAILED your directive.
-
-## Server lifecycle contract
-
-Treat the serving process as a managed resource with explicit ownership.
-
-- **Zombie Process & NPU Cleanup**: ALWAYS ensure the environment is pristine before starting a new server. If a previous server crashed or was stopped, forcefully clean up any zombie processes (`pkill -9 -f vllm.entrypoints.openai.api_server` and `pkill -9 -f ray` if applicable). Verify that the target port (e.g., `5000`) is free and NPU memory is released (`npu-smi info`) before launching. NEVER attempt to start a server if the NPU is still occupied by a ghost process.
-- **Background Execution**: Always launch the server in the background and redirect its output to a file (e.g., `nohup <command> > <work_dir>/server.log 2>&1 &`) so your Bash tool does not block.
-- **Log Monitoring**: After launching, use `grep` or `tail` on the log file to monitor the startup progress and verify readiness (look for "Uvicorn running on" or similar success messages).
-- Before Phase 1 or any lever attempt, check whether the target server is already running on the intended port and whether it matches the intended config closely enough to reuse
-- If the running server does not match the intended config, forcefully stop and clean it up before starting the next attempt
-- Never leave multiple competing server processes running for the same campaign port
-- Every iteration must end in exactly one of these states:
-  - benchmarked and recorded
-  - failed to start and recorded
-  - skipped by precheck and recorded
-- Do not keep an old server alive just to save time if it makes the config attribution ambiguous
-
-### Post-iteration strict cleanup protocol (MANDATORY)
-
-**Note: Baseline benchmark completion counts as an iteration verdict. The cleanup protocol MUST be executed after baseline before starting Phase 2.**
-
-After EVERY iteration verdict (WIN/LOSS/NEUTRAL/STARTUP_FAIL/BENCHMARK_FAIL/SKIPPED_CONFLICT), the following cleanup sequence MUST be executed before starting the next lever. This is non-negotiable. Skipping cleanup leads to zombie process accumulation, NPU memory leaks, and cascading STARTUP_FAIL on subsequent iterations.
-
-**Cleanup script — execute as a single Bash command after every iteration:**
-
-```bash
-# Step 1: Kill ALL vllm-related processes by multiple patterns
-pkill -9 -f "vllm.entrypoints" 2>/dev/null
-pkill -9 -f "vllm serve" 2>/dev/null
-pkill -9 -f "vllm_ascend" 2>/dev/null
-pkill -9 -f "VLLM::EngineCore" 2>/dev/null
-pkill -9 -f "VLLM::Worker" 2>/dev/null
-pkill -9 -f "multiproc_executor" 2>/dev/null
-pkill -9 -f "patch_balance_schedule" 2>/dev/null
-pkill -9 -f "ray::" 2>/dev/null
-
-# Step 2: Kill by parent PID chain — find the vllm serve/bash wrapper and kill its process group
-for pid in $(pgrep -f "vllm" 2>/dev/null); do
-  kill -9 -"$pid" 2>/dev/null  # kill the process group
-  kill -9 "$pid" 2>/dev/null
-done
-
-# Step 3: Wait for OS to release NPU resources and reap zombies
-sleep 15
-
-# Step 4: Verify — count remaining vllm-related processes
-REMAINING=$(ps aux | grep -E "vllm|VLLM|EngineCore|Worker_TP|multiproc_executor" | grep -v grep | grep -v defunct | wc -l)
-ZOMBIES=$(ps aux | grep -E "vllm|VLLM|EngineCore|Worker_TP" | grep -v grep | grep defunct | wc -l)
-echo "Cleanup check: $REMAINING live processes, $ZOMBIES zombies"
-
-# Step 5: If zombies remain, kill their parent (init/PID 1 or the shell that spawned them)
-if [ "$ZOMBIES" -gt 0 ]; then
-  echo "WARNING: $ZOMBIES zombie processes remain. Killing zombie parents..."
-  ps aux | grep -E "vllm|VLLM|EngineCore|Worker_TP" | grep defunct | awk '{print $2}' | while read zpid; do
-    PPID=$(ps -o ppid= -p "$zpid" 2>/dev/null | tr -d ' ')
-    if [ -n "$PPID" ] && [ "$PPID" != "1" ] && [ "$PPID" != "0" ]; then
-      kill -9 "$PPID" 2>/dev/null
-      echo "Killed parent PID $PPID of zombie $zpid"
-    fi
-  done
-  sleep 5
-fi
-
-# Step 6: Final verification — port must be free
-if lsof -i :5001 2>/dev/null | grep -q LISTEN; then
-  echo "ERROR: Port 5001 still occupied after cleanup!"
-  lsof -i :5001 2>/dev/null
-fi
-```
-
-**Key rules for cleanup:**
-- Execute cleanup AFTER writing the ledger entry for the iteration, but BEFORE starting the next lever
-- The 15-second sleep is mandatory — Ascend CANN runtime needs time to release NPU HBM after SIGKILL
-- Zombies (state `Z`/`<defunct>`) do NOT hold NPU memory themselves, but their parent processes may still hold references to CANN device contexts. Killing the parent chain is necessary.
-- If after cleanup there are still >0 live vllm processes, retry once with `kill -9` on each remaining PID, then wait another 10 seconds
-- Do NOT proceed to the next lever until the cleanup verification passes (0 live processes, port free)
-- This cleanup is a hard requirement — even if the server appeared to stop cleanly, residual EngineCore/Worker processes may still hold NPU device handles
-
-## Timeout and retry contract
-
-Long waits must be bounded.
-
-- Define a startup wait budget for server readiness and treat timeout as `STARTUP_FAIL`
-- Define a benchmark wait budget for warmup plus evalscope completion and treat timeout as `BENCHMARK_FAIL`
-- Retry at most once for transient startup or benchmark issues; if retried, record that it was a retry and why
-- After a failed attempt, clean up the candidate server before moving to the next lever
-
-## Continuation contract
-
-The skill must continue executing after Phase 1 in the same run unless one of the explicit exit conditions is hit.
-
-- Baseline-only output is **incomplete** and must not be presented as the final result
-- After Phase 1 finishes, immediately continue into Phase 2 and keep advancing through the ranked lever list
-- Do not pause just because the ledger header, baseline table, or iteration-0 summary has been written
-- Do not generate the final summary/report until at least one post-baseline lever attempt has been recorded, unless execution is blocked by an explicit failure outside the lever space (for example: missing dependency, no write permission, repeated server launch failure for the baseline itself, or user stop)
-- If execution is blocked before any post-baseline lever can be attempted, write the blocking reason explicitly and mark the run as blocked rather than silently ending after the baseline
-
-**Robustness guarantees** — the skill must:
-- Catch and handle all exceptions during server startup, benchmark execution, and ledger writes
-- If a lever attempt fails for any reason (server crash, module not found, timeout, etc.), immediately write a ledger entry with the appropriate failure verdict (`STARTUP_FAIL`, `BENCHMARK_FAIL`) and continue to the next lever
-- Never exit the skill early due to individual lever failures — only the explicit exit conditions above can terminate the run
-- If context window is approaching limits (detected via conversation length or explicit warning), write a checkpoint note to the ledger and exit gracefully so the wrapper can resume
-- Treat missing dependencies, incompatible hardware features, or environment issues as `STARTUP_FAIL` or `SKIPPED_CONFLICT`, not as reasons to abort the entire run
-
-## Progress visibility contract
-
-The skill must behave like a visible long-running workflow, not a silent batch job.
-
-- Before starting each major action, emit a short status update naming the current phase, lever, and action
-- For any action expected to take more than 30 seconds, emit heartbeat progress updates at least every 30 seconds
-- Each progress update must include as many of these as are known: current phase, current lever, current step, current command category (`server_start`, `warmup`, `benchmark`, `profiling`, `report_generation`), elapsed time, and next expected milestone
-- When starting a lever attempt, explicitly print `Current lever:` and `Next lever if this finishes:` so the user can see forward progress
-- When running a benchmark, explicitly print the fixed workload (`c=1/4/8`, request counts, input/output tokens) and the artifact directory being written
-- When waiting on server readiness, say whether the skill is waiting for process start, health check success, warmup completion, or benchmark completion
-- If a step appears slow, explain the likely reason in plain language (for example: model load, graph compilation, benchmark still running at higher concurrency, profiling trace export)
-- Never disappear behind a single long terminal command without accompanying narrative updates
-- If an iteration is retried, say why it is being retried and what changed
-- Keep updates minimal: one or two short lines focused on action, not theory
-
----
-
-## Workflow
-
-### Phase 0 — Setup & Resume
-
-Create the run directory and initialize the optimization ledger:
-
-```
+```text
 <work_dir>/
-├── ledger.md               # optimization history, all attempts
-├── baseline/               # baseline benchmark artifacts
-├── iter_01/ iter_02/ ...   # per-iteration benchmark results
-└── final_report.md         # synthesis after loop exits
+├── ledger.md
+├── baseline/
+├── iter_01/
+├── iter_02/
+├── ...
+└── final_report.md
 ```
 
-**Resume logic** — before starting any work, check for an existing ledger in `work_dir`:
+`final_report.md` is generated by `scripts/generate_tuning_report.py` and must correctly handle:
 
-0. **Handle explicit fresh start** — if the user explicitly requests to start fresh (e.g. "重新开始", "fresh start", "run a complete flow from scratch"), do NOT resume. Archive or overwrite the existing `ledger.md`, forcefully kill any existing `vllm` zombie processes, and proceed directly to Phase 1.
-1. **Read the ledger** and extract:
-   - Baseline metrics (c=1/4/8 ttft_avg, tpot_avg, TPS) — these are immutable
-   - All completed iteration verdicts (WIN / LOSS / NEUTRAL / STARTUP_FAIL / BENCHMARK_FAIL / SKIPPED_CONFLICT)
-   - The most recent lever attempt: which phase, which lever number, and its verdict
-   - Count of completed iterations per phase
+- successful iterations
+- `STARTUP_FAIL`
+- `BENCHMARK_FAIL`
+- `SKIPPED_CONFLICT`
 
-2. **Handle abandoned `TESTING` state** — if the last ledger entry shows `Status: TESTING` or `Status: IN_PROGRESS` without a verdict:
-   - This indicates the session was interrupted mid-lever
-   - Do NOT count this as a completed attempt
-   - The next action is to retry this same lever from scratch (stop any leftover server, restart, re-benchmark)
-   - Append a note to the ledger: `## Iteration N (retry) — <phase.lever>` with reason: `Session interrupted during previous attempt; retrying`
+## Quick start
 
-3. **Determine the next lever** — based on the last completed verdict:
-   - If baseline is complete but no Phase 2 levers attempted → start Phase 2.1
-   - If Phase 2 has completed levers 2.1–2.3 → continue with 2.4
-   - If Phase 2 is complete (all levers attempted) → start Phase 3.1
-   - If a lever was `WIN` → carry its config forward as the new incumbent
-   - If a lever was `LOSS` / `NEUTRAL` / failure → discard and use the prior incumbent
-   - Continue through all phases (2–7) until all levers are exhausted or an exit condition is met
-
-4. **Load the incumbent config** — reconstruct the exact server launch command by:
-   - Starting from the Phase 1 baseline command
-   - Applying all `WIN` levers in order (each WIN modifies one field)
-   - This reconstructed command is the starting point for the next lever attempt
-
-5. **Print resume status**:
 ```text
-Phase 0/7 | resume | work_dir=<path> | last_completed=<phase.lever> verdict=<WIN|LOSS|...> | next=<phase.lever> | wins_so_far=N
-```
-
-**First run (no ledger)** — if no ledger exists, initialize a fresh one and proceed to Phase 1:
-```text
-Phase 0/7 | setup | action=initialize_work_dir | work_dir=... | next=baseline startup
-```
-
-### Phase 1 — Baseline Benchmark
-
-Run the fixed-workload benchmark at `low_conc_levels` using the **baseline server configuration**:
-
-- If `baseline_launch_command` is provided, use it exactly as the Phase 1 startup command
-- Otherwise, start from the default template below
-- The Phase 1 startup config becomes the initial incumbent; every later iteration must inherit it and change only one lever at a time
-- Before launching, check whether a matching baseline server is already healthy on the target port; reuse it only if config attribution remains unambiguous, otherwise stop and relaunch
-
-Default template when `baseline_launch_command` is not provided:
-
-```bash
-ASCEND_RT_VISIBLE_DEVICES=<devices> \
-VLLM_ASCEND_ENABLE_ACLGRAPH=1 \
-VLLM_ASCEND_ENABLE_NZ=1 \
-python3 -m vllm.entrypoints.openai.api_server \
-  --model <model_path> \
-  --served-model-name <model_name> \
-  --tensor-parallel-size <tp> \
-  --max-model-len <max_model_len> \
-  --dtype <dtype> \
-  --port <port> \
-  --trust-remote-code
-```
-
-Benchmark command (warm-up 20 requests at c=1, then measure at all concurrency levels):
-```bash
-evalscope perf \
-  --parallel <low_conc_levels> \
-  --number <requests_per_level> \
-  --warmup-num 20 \
-  --model <model_name> \
-  --url http://127.0.0.1:<port>/v1/chat/completions \
-  --api openai --stream \
-  --dataset random \
-  --max-tokens <output_tokens> --min-tokens <output_tokens> \
-  --min-prompt-length <input_tokens> --max-prompt-length <input_tokens> \
-  --tokenizer-path <model_path>
-```
-Note: evalscope perf saves output to `outputs/<timestamp>/<model>/` in the current directory. Run the command from the appropriate work subdirectory (e.g., `cd <work_dir>/baseline && evalscope perf ...`) so artifacts land in the right place. Do NOT pass `--work-dir` — it is not a valid evalscope perf argument.
-
-Incumbent inheritance rules after Phase 1:
-- Preserve all env vars and CLI args from the Phase 1 baseline in every later iteration unless the current lever is explicitly testing one of those fields
-- If a candidate lever conflicts with a user-provided baseline setting, change only that single field for the A/B run and keep the rest of the baseline untouched
-- Record the exact effective startup command in the ledger so the winning config remains copy-pasteable
-
-Extract and record in ledger:
-- c=1: `ttft_avg`, `tpot_avg`, `output_token_throughput` (TPS), `latency_avg`
-- c=4, c=8: same metrics
-- These become the **immutable reference values** — never modified after Phase 1
-- After recording the baseline, execute the post-iteration cleanup protocol to stop the baseline server, then proceed to the first Phase 2 lever attempt in the same session
-
-Required status updates during Phase 1:
-- Before startup: `Phase 1/7 | baseline | action=server_start | command_source=user_baseline|default_template`
-- While waiting: `Phase 1/7 | baseline | action=wait_ready | state=process_started|healthcheck_pending|warmup_running`
-- Before benchmark: `Phase 1/7 | baseline | action=benchmark | c=1/4/8 | requests=20/80/160 | artifacts=<work_dir>/baseline`
-- After benchmark: `Phase 1/7 | baseline | action=record_baseline | ttft_c1=<value> | next=Phase 2 <first lever>`
-
-### Phase 2 — Scheduler & Engine Shell Tuning
-
-**Goal**: reduce queuing overhead and TTFT at low concurrency without touching kernel code.
-
-Candidate levers (try in order):
-
-#### 2.1 Balance scheduling
-```bash
---additional-config '{"enable_balance_scheduling": true}'
-```
-Expected impact: reduces decode stalls at c=1 and c=4 when prefill and decode batches are mixed.
-
-#### 2.2 CPU binding
-```bash
---additional-config '{"enable_cpu_binding": true}'   # default true; try false if NUMA is fragmented
-```
-
-#### 2.3 PagedAttention block size
-```bash
---block-size 128    # 910C optimal; try 64 if memory-constrained
-```
-Expected impact: larger blocks → fewer KV cache pointer dereferences → lower TTFT.
-Note: `block_size=128` is the xlite_graph_config recommendation for 910C; always try this first.
-
-#### 2.4 Chunked prefill configuration
-```bash
---enable-chunked-prefill \
---max-num-batched-tokens 2048   # try: 1024, 2048, 4096
-```
-Expected impact on c=1: reduces head-of-line blocking from large prefills.
-
-#### 2.5 max_num_seqs
-```bash
---max-num-seqs 32    # try: 16, 32, 64, 128
-```
-At low concurrency, smaller values reduce scheduler overhead.
-
-For each candidate:
-- Precheck applicability first; if the lever is incompatible with the current model, TP mode, EP mode, or incumbent config, record `SKIPPED_CONFLICT` immediately and continue
-- Start fresh server from the current incumbent command (Phase 1 baseline or prior WIN) with the single changed parameter
-- If an incumbent server is still running but does not match the intended candidate config, stop it before launching the candidate
-- If the server fails to start, never becomes healthy, or the benchmark cannot complete, still append a ledger entry for that attempt with a failure verdict and the captured reason
-- Run 20 warmup requests at c=1, then run the **fixed benchmark**: `--parallel 1 4 8 --number <requests_per_level>`
-- **Decision gate**: compare `ttft_avg` at **c=1** against the baseline value
-  - WIN if improvement ≥ `improvement_threshold_pct` (default 1%) **and** `tpot_avg` at c=1 does not regress > 5%
-  - NEUTRAL if `ttft_avg` improves but `tpot_avg` regresses > 5% (trade-off, not a clear win)
-  - LOSS if c=1 `ttft_avg` regresses > 2%
-  - NEUTRAL otherwise
-- Failure verdicts:
-  - `STARTUP_FAIL` if the process exits, crashes, or never reaches serving-ready state
-  - `BENCHMARK_FAIL` if the server starts but warmup or `evalscope perf` fails before producing a complete c=1/4/8 result set
-  - `SKIPPED_CONFLICT` if the lever is known in advance to be incompatible with the current model, hardware mode, or incumbent config and is intentionally skipped after a concrete conflict check
-- Also record `ttft_avg` and `tpot_avg` at c=4/8 — these appear in the ledger but do NOT affect WIN/LOSS
-- Log result in ledger (`WIN` / `LOSS` / `NEUTRAL` / `STARTUP_FAIL` / `BENCHMARK_FAIL` / `SKIPPED_CONFLICT`)
-- If WIN: carry this change into the next phase as the new incumbent
-
-Required status updates for every lever:
-- Before change: `Phase <n>/7 | lever=<phase.lever> | action=prepare_attempt | incumbent=<short name> | next_lever=<next candidate>`
-- Before stop/reuse decision: `Phase <n>/7 | lever=<phase.lever> | action=server_check | port=<port> | decision=reuse|stop_and_restart`
-- Before startup: `Phase <n>/7 | lever=<phase.lever> | action=server_start | changed_field=<single field>`
-- Before benchmark: `Phase <n>/7 | lever=<phase.lever> | action=benchmark | c=1/4/8 | artifacts=<work_dir>/iter_N`
-- After verdict: `Phase <n>/7 | lever=<phase.lever> | action=record_verdict | verdict=WIN|LOSS|NEUTRAL|STARTUP_FAIL|BENCHMARK_FAIL|SKIPPED_CONFLICT | carry_forward=YES|NO | next=<next candidate>`
-
-### Phase 3 — Ascend Fusion & Graph Compilation Tuning
-
-**Goal**: enable or tune Ascend-specific kernel fusion and graph compilation backends.
-
-Try in order:
-
-#### 3.0 CUDAGraph mode (graph compilation decision)
-
-```bash
---compilation-config '{"cudagraph_mode": "FULL"}'              # vs baseline FULL_DECODE_ONLY
-```
-This is the most upstream graph-compilation lever: it decides whether decode (and prefill) run inside a captured ACL graph. `cudagraph_mode` is the field on `--compilation-config`, NOT an `--additional-config` key.
-
-Applicable `CUDAGraphMode` values on vllm-ascend:
-- `FULL_DECODE_ONLY` (= `FULL` decode, `NONE` prefill) — decode captured, prefill not. Common baseline choice.
-- `FULL` (= `FULL` decode, `FULL` prefill) — prefill also captured. A/B against `FULL_DECODE_ONLY`: same decode graph, but prefill runs as a graph too (longer startup, possibly lower prefill latency / TTFT).
-- `FULL_AND_PIECEWISE` (= `FULL` decode, `PIECEWISE` prefill) — try if `FULL` prefill capture is memory-constrained.
-- `PIECEWISE` — piecewise graph only (decode NOT fully captured → decode TPOT usually regresses; useful only as a diagnostic baseline).
-- `NONE` — no graph (equivalent to `--enforce-eager`); decode TPOT usually regresses. Use only to measure the graph's contribution.
-
-**When to run this lever**: ALWAYS, as the first Phase 3 attempt. `cudagraph_mode` is the single field with the most direct effect on decode TPOT — skipping it leaves the most upstream decode switch untested.
-
-**Primary A/B**: `FULL` vs the baseline's graph mode. Only change the `cudagraph_mode` field; preserve the rest of `--compilation-config` and the incumbent command. If the baseline did not set `cudagraph_mode` (vllm-ascend default is `FULL`), test `FULL_DECODE_ONLY` as the candidate and compare against the default-`FULL` incumbent.
-
-Expected impact: if the baseline is `FULL_DECODE_ONLY`, switching decode-path capture rarely helps (decode is already captured); the meaningful delta is on TTFT/prefill. If the baseline is `FULL` (default), `FULL_DECODE_ONLY` can reduce startup + prefill overhead with identical decode TPOT — a likely WIN on TTFT-neutral workloads. `PIECEWISE`/`NONE` are expected regressions on TPOT; record them as LOSS/NEUTRAL for attribution, do not carry forward.
-
-#### 3.1 NZ weight format
-```bash
-VLLM_ASCEND_ENABLE_NZ=1    # default 1; also try 2 (enable for all ops)
-VLLM_ASCEND_ENABLE_NZ=2
-```
-Expected impact: NZ format reduces memory bandwidth on 910C for matmul-heavy layers.
-
-#### 3.2 npugraph_ex with static kernel
-```bash
---additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": true}}'
-```
-Expected impact: static kernel pre-compiles operator binaries for fixed batch shapes; reduces JIT overhead at c=1. Note: adds startup time.
-
-#### 3.3 Norm-quant fusion
-```bash
---additional-config '{"ascend_compilation_config": {"fuse_norm_quant": true, "fuse_qknorm_rope": true}}'
-```
-Default is already true; try disabling if baseline seems slow on normalization:
-```bash
---additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}'
-```
-
-#### 3.4 AllReduce-RMSNorm fusion (TP > 1 only)
-```bash
---additional-config '{"ascend_compilation_config": {"fuse_allreduce_rms": true}}'
-```
-Expected impact: fuses allreduce + rmsnorm → reduces synchronization latency in TP runs.
-
-#### 3.5 MatMul-AllReduce fusion (TP > 1 only)
-```bash
-VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE=1
-```
-Expected impact: overlaps matmul and allreduce; helps TPOT at low concurrency.
-
-#### 3.6 GMM-SwiGLU-Quant fusion (MoE models only)
-```bash
---additional-config '{"ascend_fusion_config": {"fusion_ops_gmmswigluquant": true}}'
-```
-
-#### 3.7 XliteGraph mode
-```bash
---additional-config '{"xlite_graph_config": {"enabled": true, "full_mode": false}}'
-```
-Requires `block_size=128`. Expected impact: Xlite graph backend can significantly accelerate decode on 910C. Try `full_mode: true` if `false` wins.
-
-### Phase 4 — FlashComm & Communication Overlap Tuning (TP > 1 only)
-
-Skip this phase if `tensor_parallel_size == 1`.
-
-#### 4.1 FlashComm1 (prefill-side comm-compute overlap)
-```bash
---additional-config '{"enable_flashcomm1": true}'
-```
-Expected impact: overlaps TP allreduce with compute during prefill → lower TTFT.
-
-#### 4.2 FlashComm2 (decode-side comm overlap)
-```bash
-VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE=<tp>
-```
-Try values: `1`, `tp/2`, `tp`. Expected impact: further reduces allreduce stalls during decode.
-
-#### 4.3 Prefill comm-compute overlap
-```bash
---additional-config '{"prefill_comm_compute_overlap": true}'
-```
-
-#### 4.4 HCCL buffer size
-```bash
-HCCL_BUFFSIZE=200    # try: 100, 200, 400 (MB)
-```
-Larger buffer can reduce HCCL fragmentation overhead.
-
-### Phase 5 — Weight Prefetch & Memory Layout
-
-#### 5.1 Weight prefetch
-```bash
---additional-config '{"weight_prefetch_config": {"enabled": true}}'
-```
-Expected impact: prefetches next layer weights during current layer compute; masks HBM latency.
-Try adjusting `prefetch_ratio` for attention vs MoE separately if overall win is marginal:
-```bash
---additional-config '{"weight_prefetch_config": {"enabled": true, "prefetch_ratio": {"attn": {"qkv": 1.0, "o": 1.0}, "moe": {"gate_up": 1.0}}}}'
-```
-
-#### 5.2 MLAPO (DeepSeek W8A8 only)
-```bash
-VLLM_ASCEND_ENABLE_MLAPO=1    # default 1; disable if memory is tight
-```
-
-#### 5.3 Fused MC2 (MoE W8A8 + EP only)
-```bash
-VLLM_ASCEND_ENABLE_FUSED_MC2=1   # try: 0, 1, 2
-```
-
-### Phase 6 — Multistream & DSA Overlap (Advanced)
-
-These levers involve deeper NPU pipeline overlapping. Apply only after Phases 2–5 are exhausted.
-
-#### 6.1 Multistream shared-expert overlap (MoE only)
-```bash
---additional-config '{"multistream_overlap_shared_expert": true}'
-```
-
-#### 6.2 Multistream gate overlap (MoE only)
-```bash
---additional-config '{"multistream_overlap_gate": true}'
-```
-
-#### 6.3 DSA preprocess overlap
-```bash
---additional-config '{"multistream_dsa_preprocess": true}'
-```
-
-#### 6.4 DSv4 DSA overlap (DeepSeek V4 only)
-```bash
---additional-config '{"multistream_dsv4_dsa_overlap": true}'
-```
-
-### Phase 7 — Profiling-Driven Triton Kernel Tuning
-
-**Trigger condition**: Apply after all Phases 2–6 levers have been attempted.
-
-This phase uses vLLM's built-in profiler to identify the slowest operators, then tunes their block size parameters if they are in the tunable category.
-
-#### 7.1 Collect profiling trace
-
-Server must be started with profiling enabled:
-```bash
---profiler-config.profiler=torch \
---profiler-config.torch_profiler_dir=<work_dir>/profiling
-```
-
-Then at c=1:
-```bash
-# Start profiling
-curl -X POST http://127.0.0.1:5000/start_profile
-
-# Send 20 requests at c=1 to capture a representative trace
-evalscope perf --parallel 1 --number 20 ...
-
-# Stop profiling
-curl -X POST http://127.0.0.1:5000/stop_profile
-```
-
-The trace is saved as JSON in `<work_dir>/profiling/`. Claude reads the JSON and identifies:
-- **Top 5 longest ops** (by total GPU time)
-- **NPU idle gaps** between consecutive ops (indicating CPU-side bottleneck or launch overhead)
-- **Allreduce / HCCL ops** (if TP > 1, check if communication is on the critical path)
-
-#### 7.2 Classify ops into tunable vs. non-tunable
-
-After reading the trace, classify each slow op:
-
-**Tunable (Triton kernels in vllm-ascend source):**
-
-| Op pattern | Source file | Tunable parameter |
-|------------|-------------|-------------------|
-| `rms_norm` | `ops/triton/rms_norm.py:52` | `ROW_BLOCK_SIZE` (default 16) |
-| `layernorm_gated` | `ops/triton/layernorm_gated.py:155` | `BLOCK_M` (default 64) |
-| `matmul` / `gemm` | `ops/triton/batch_invariant/matmul.py:137` | `BLOCK_M/N/K` (default 128/128/64) |
-| `flash_attention` / `fa3` | `attention/fa3_v1.py:90` | `num_splits` (default 1), `attention_chunk` (default 0) |
-
-**Non-tunable (CANN C++ compiled ops):**
-
-| Op pattern | Reason |
-|------------|--------|
-| `grouped_matmul_swiglu_quant` | Tiling params (`baseM/baseN/baseK`) are C++ compile-time constants in `csrc/gmm/` headers |
-| `paged_attention` / `npu_fused_infer_attention_score` | Implemented via ACLNN, no user-controllable parameters |
-| Any op prefixed with `aclnn` | CANN runtime op, tiling decided at op compilation time |
-
-#### 7.3 Tune tunable ops
-
-For each tunable op found in 7.2:
-
-1. **Edit the source file** — change the block size constant to a new value (try 2× or 0.5× of default)
-2. **Restart server** with the same configuration (no other changes)
-3. **Run benchmark** at c=1/4/8
-4. **Record in ledger** with verdict WIN/LOSS/NEUTRAL based on `ttft_avg` at c=1
-5. If WIN: keep the edit; if LOSS/NEUTRAL: revert the edit and try the next parameter
-
-Example for `rms_norm`:
-```python
-# ops/triton/rms_norm.py line 52
-ROW_BLOCK_SIZE = 32  # was 16, try doubling
-```
-
-For `fa3_v1.py` `num_splits`:
-```python
-# attention/fa3_v1.py line 90
-num_splits=2,  # was 1, try splitting attention across NPU cores
-```
-
-#### 7.4 Record non-tunable findings
-
-For non-tunable ops that appear in the top-5 slow list, append to `final_report.md` under a "Manual Intervention" section:
-
-```markdown
-## Manual Intervention Required
-
-The following operators were identified as bottlenecks but cannot be tuned via source modification:
-
-- `aclnnGroupedMatmul` (18% of total GPU time): Tiling parameters `baseM/baseN` are C++ compile-time constants. To tune, use CANN's AOE (Ascend Operator Expert) tool offline with the specific input shapes observed in this run.
-- `aclnnFlashAttention` (12% of total GPU time): No user-controllable parameters. Consider contacting Huawei for updated ACLNN binaries or checking if a newer CANN version has optimized this op.
-```
-
-This allows the user to decide whether to invest time in offline AOE tuning or escalate to Huawei support.
-
----
-
-## Ledger format
-
-Append one entry per iteration to `ledger.md`.
-
-- For successful benchmarked attempts (`WIN` / `LOSS` / `NEUTRAL`), **all three concurrency rows (c=1/4/8) are mandatory**
-- For failed or skipped attempts (`STARTUP_FAIL` / `BENCHMARK_FAIL` / `SKIPPED_CONFLICT`), use the failure template below instead of the metric table
-
-```markdown
-## Iteration N — <phase>.<lever_name>
-
-**Hypothesis**: <why this lever should help, citing phase doc>
-**Change**: `<exact env var or --additional-config JSON>`
-**Incumbent config before**: `<previous winning command>`
-
-### Results vs Baseline (fixed benchmark: c=1/4/8, primary=ttft_avg@c=1, guard=tpot_avg@c=1)
-
-| Concurrency | ttft_avg (ms) | ttft_avg delta | tpot_avg (ms) | tpot_avg delta | TPS (tok/s) | TPS delta |
-|-------------|---------------|----------------|---------------|----------------|-------------|-----------|
-| **1** ⭐ | 241.0 | **-15.4% ← DECISION** | 27.1 | -4.2% | 36.9 | +4.4% |
-| 4 | 420.0 | -8.3% | 29.5 | +1.0% | 135.6 | -1.0% |
-| 8 | 610.0 | -5.2% | 31.0 | +2.1% | 258.1 | -2.1% |
-
-**Verdict**: WIN  ← ttft_avg c=1 improved -15.4% (≥1%), tpot_avg c=1 improved -4.2% (no regression)
-**Carry forward**: YES
-**Notes**: <any anomalies, warnings from server log>
-```
-
-Failure / skipped attempt template:
-
-```markdown
-## Iteration N — <phase>.<lever_name>
-
-**Hypothesis**: <why this lever should help, or why it was checked>
-**Change**: `<exact env var or --additional-config JSON>`
-**Incumbent config before**: `<previous winning command>`
-**Verdict**: STARTUP_FAIL
-**Failure stage**: server_startup
-**Reason**: <short reason, e.g. incompatible with xlite_graph_config + block_size=64>
-**Evidence**:
-- Exit code: <code or N/A>
-- Health check: <never ready / failed after warmup / benchmark aborted>
-- Log excerpt: `<relevant stderr or server log lines>`
-**Carry forward**: NO
-**Notes**: <follow-up, retry hint, or why this lever was skipped>
-```
-
-Rules:
-- A lever is a **WIN** if `ttft_avg` at **c=1** improves ≥ `improvement_threshold_pct` **and** `tpot_avg` at c=1 does not regress > 5%
-- A lever is **NEUTRAL** if `ttft_avg` at c=1 improves but `tpot_avg` regresses > 5% (trade-off)
-- A lever is a **LOSS** if `ttft_avg` at c=1 regresses > 2%
-- A lever is **STARTUP_FAIL** if no valid serving endpoint is established for the attempt
-- A lever is **BENCHMARK_FAIL** if serving starts but the benchmark does not finish with a complete c=1/4/8 result set
-- A lever is **SKIPPED_CONFLICT** if the incompatibility is known before launch and is backed by a concrete config or model constraint
-- c=4/8 rows are recorded for trend analysis only — they never override the c=1 verdict
-- Wins are carried forward cumulatively; losses, neutrals, failures, and skipped conflicts are discarded
-- Never modify a prior ledger entry — only append
-
----
-
-## Exit conditions
-
-**Run all phases (1-7) completely.** Do not stop early based on consecutive no-WIN phases or plateau patterns.
-
-Stop only when:
-
-1. **Budget**: `max_iterations` reached (safety valve, default 50)
-2. **Manual stop**: user explicitly says "stop" or "enough"
-3. **All phases complete**: Phase 7 has been attempted, regardless of WIN/LOSS/NEUTRAL outcomes
-4. **Blocked before tuning can continue**: baseline itself cannot be made runnable, required tooling is missing, or the environment prevents any further lever attempt from being executed safely
-
-Non-exit examples:
-- Baseline benchmark completed successfully
-- Ledger header or baseline report has been written
-- No WIN found yet
-- A single lever failed to start
-- An iteration was marked `STARTUP_FAIL`, `BENCHMARK_FAIL`, or `SKIPPED_CONFLICT`
-
-The skill should exhaust all tuning levers across all phases before generating the final report.
-
----
-
-## Running the loop to completion (auto-resume wrapper)
-
-The full campaign spans 7 phases and dozens of lever attempts — far more than a single `claude` session can survive before the context window fills. The skill is designed around this: each session runs until it must yield (context approaching limits — see the checkpoint-and-exit rule), then a **wrapper** re-launches a fresh session that reads the ledger and continues. This is how a fragmented set of sessions becomes one complete optimization run.
-
-Use `scripts/auto_resume_wrapper.sh` to drive this. It wraps the `claude` CLI call and relaunches it until `final_report.md` appears in `work_dir` (the skill's only completion signal — see "Final report"). The ledger in `work_dir` is the hand-off state between sessions: a freshly launched session follows the "Resume logic" section, reads the ledger, and picks up at the next unfinished phase.lever.
-
-**Usage:**
-
-```bash
-bash scripts/auto_resume_wrapper.sh \
-  --work-dir <work_dir> \
-  -- claude -p "<skill prompt with model/work_dir/etc.>" --max-turns 0
-```
-
-- `--work-dir` — the campaign's `work_dir`; the wrapper watches `<work_dir>/final_report.md` for completion and `<work_dir>/ledger.md` for resume state.
-- Everything after `--` is the full `claude` command, passed through verbatim to each relaunch. Use `--max-turns 0` (or a bounded value) so each session yields on its own when the context fills, letting the wrapper decide whether to relaunch.
-- The wrapper retries up to 20 times, sleeping 5s between attempts, and exits 0 as soon as `final_report.md` exists. It checks for completion both **before** launching (so an already-finished run is not re-launched) and **after** each session exits.
-
-**What the wrapper is NOT:**
-- It does not read or parse the ledger — the skill does that on resume. The wrapper only checks for the presence of `final_report.md`.
-- It does not decide which lever to try next — that is the skill's job per the RLCR principle.
-- It does not recover from a corrupted or contradictory ledger; if the skill cannot resume cleanly, it should surface that to the user rather than silently looping.
-
-**Recommended run shape:** launch the wrapper once in the background, let it drive the whole campaign to `final_report.md`, then read the report. Do not manually relaunch `claude` mid-campaign — that races with the wrapper and can spawn two sessions writing to the same ledger.
-
----
-
-## Final report
-
-After the loop exits, write `final_report.md` using `scripts/generate_tuning_report.py`:
-
-```markdown
-# vLLM-Ascend Tuning Report — <model_name>
-
-## Summary
-- Total iterations: N
-- Winning levers: M
-- Failed or skipped levers: K
-- Overall improvement on target metric (c=1): X%
-- Completion status: `completed` | `blocked` | `stopped_by_user` | `budget_exhausted`
-
-## Baseline vs Best Configuration
-
-| Concurrency | Metric | Baseline | Best | Improvement |
-|-------------|--------|----------|------|-------------|
-| 1 | TTFT avg | ... | ... | ... |
-| 1 | TPOT avg | ... | ... | ... |
-| 4 | TTFT avg | ... | ... | ... |
-| 8 | TTFT avg | ... | ... | ... |
-
-## Winning Configuration (copy-pasteable)
-
-```bash
-ASCEND_RT_VISIBLE_DEVICES=...
-VLLM_ASCEND_ENABLE_NZ=...
-...
-python3 -m vllm.entrypoints.openai.api_server \
-  --model ... \
-  --additional-config '...' \
-  ...
-```
-
-## Optimization History
-
-<condensed ledger — one line per iteration>
-
-## Levers That Did Not Help
-
-<list with brief reason>
-
-## Failed / Incompatible Levers
-
-| Lever | Verdict | Stage | Reason | Evidence |
-|-------|---------|-------|--------|----------|
-| `xlite_graph.full_mode=true` | `STARTUP_FAIL` | `server_startup` | incompatible with current block size | `server exited with code 1: ...` |
-| `fuse_allreduce_rms=true` | `SKIPPED_CONFLICT` | `precheck` | TP=1 so lever is not applicable | `tensor_parallel_size == 1` |
-
-Rules for this section:
-- Include every `STARTUP_FAIL`, `BENCHMARK_FAIL`, and `SKIPPED_CONFLICT` entry from the ledger
-- Preserve the first actionable failure reason instead of collapsing all failures into "did not help"
-- Include a short evidence string, preferably an exit code, failed health check, or log excerpt
-
-## Manual Intervention Required
-
-<Non-tunable ops identified by Phase 7 profiling — op name, GPU time percentage, reason it cannot be tuned, and suggested action (AOE / Huawei support)>
-
-## Recommended Next Steps
-
-<if gains are still possible: profiling suggestions, kernel-level work>
-```
-
-Finalization rules:
-- Never treat the baseline section alone as the final deliverable
-- Only generate the final report after an actual exit condition is met
-- If the run is blocked before tuning can proceed, the final report must say `Completion status: blocked` and name the blocking reason
-- If only baseline succeeded and no tuning iteration was attempted, that is a blocked or interrupted run, not a completed optimization campaign
-- Before final report generation, emit a final progress line stating whether the run is exiting because of completion, block, user stop, or budget exhaustion
-
----
-
-## Constraints
-
-- **Execution over narration**: once prerequisites are satisfied, prefer the next concrete server/benchmark action over more discussion
-- **One lever per iteration**: never bundle two changes; it destroys attribution
-- **Fixed workload**: `input_tokens`, `output_tokens`, and `low_conc_levels` never change after Phase 1
-- **Baseline inheritance**: if `baseline_launch_command` is provided, Phase 1 uses it exactly and every later iteration must preserve it except for the single field under test
-- **Server ownership**: at most one campaign-owned server may be active on the target port at any time
-- **Mandatory post-iteration cleanup**: execute the full cleanup script from "Post-iteration strict cleanup protocol" after EVERY iteration before starting the next lever. This kills all vllm/EngineCore/Worker processes, waits for NPU resource release, and verifies port availability. Skipping cleanup leads to zombie accumulation and NPU memory leaks.
-- **Restart server cleanly** between every iteration — no warm state carry-over
-- **Bounded waiting**: startup and benchmark waits must use explicit timeout budgets rather than unbounded waiting
-- **Failure visibility**: startup failures, benchmark failures, and prechecked incompatibilities must still be written to the ledger and surfaced in the final report
-- **Progress visibility**: long-running steps require heartbeat updates at least every 30 seconds with phase, lever, action, and next milestone
-- **Warm up before every measurement**: 20 warmup requests at c=1 before measurement
-- **Record everything**: even a 0.1% change gets a ledger entry
-- **TP-only levers**: FlashComm, MatMul-AllReduce, AllReduce-RMSNorm only apply when `tensor_parallel_size > 1`
-- **MoE-only levers**: GMM-SwiGLU fusion, multistream shared-expert, DSA only apply to MoE architectures
-
----
-
-## Example invocation
-
-```
 /ascend-vllm-serving-tune-loop
 model_path=/data/models/Qwen3-32B
 model_name=Qwen3-32B
 tensor_parallel_size=4
 target_metric=ttft_avg
-input_tokens=1024
-output_tokens=512
 ```
 
-```
-/ascend-vllm-serving-tune-loop
-model_path=/data/models/DeepSeek-V3
-model_name=DeepSeek-V3
-tensor_parallel_size=8
-baseline_launch_command='ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 VLLM_ASCEND_ENABLE_ACLGRAPH=1 VLLM_ASCEND_ENABLE_NZ=2 python3 -m vllm.entrypoints.openai.api_server --model /data/models/DeepSeek-V3 --served-model-name DeepSeek-V3 --tensor-parallel-size 8 --max-model-len 32768 --dtype bfloat16 --block-size 128 --max-num-seqs 32 --additional-config "{\"enable_balance_scheduling\": true}" --port 5000 --trust-remote-code'
-target_metric=ttft_avg
-low_conc_levels="1 4 8"
-requests_per_level="20 80 160"
-max_iterations=50
+Drive long campaigns with the wrapper:
+
+```bash
+bash .agents/skills/ascend-vllm-serving-tune-loop/scripts/auto_resume_wrapper.sh \
+  --work-dir <work_dir> \
+  -- claude -p "<skill prompt>" --max-turns 0
 ```

--- a/.agents/skills/ascend-vllm-serving-tune-loop/references/ledger-and-report.md
+++ b/.agents/skills/ascend-vllm-serving-tune-loop/references/ledger-and-report.md
@@ -1,0 +1,42 @@
+# Ledger And Report
+
+## Ledger requirements
+
+Append one section per iteration:
+
+```markdown
+## Iteration N — <phase>.<lever_name>
+
+**Hypothesis**: ...
+**Change**: `...`
+**Verdict**: WIN | LOSS | NEUTRAL | STARTUP_FAIL | BENCHMARK_FAIL | SKIPPED_CONFLICT
+**Carry forward**: YES | NO
+**Notes**: ...
+```
+
+For successful benchmarked attempts, include the per-concurrency metric table.
+
+For failed or skipped attempts, include:
+
+- `Failure stage`
+- `Reason`
+- `Evidence`
+
+## Verdict rules
+
+- `WIN`: target metric improves enough and guard metrics do not regress beyond the allowed threshold
+- `NEUTRAL`: no material win, or gain is cancelled by guard regression
+- `LOSS`: target metric regresses materially
+- `STARTUP_FAIL`: server never became ready
+- `BENCHMARK_FAIL`: server started but benchmark did not complete correctly
+- `SKIPPED_CONFLICT`: lever is known to be incompatible before launch
+
+## Final report
+
+`scripts/generate_tuning_report.py` must:
+
+1. populate per-iteration metrics from result dirs when available
+2. preserve failure verdicts instead of collapsing them into neutral output
+3. compute improvement with the correct direction:
+   - lower latency metrics are better when the number goes down
+   - throughput metrics are better when the number goes up

--- a/.agents/skills/ascend-vllm-serving-tune-loop/references/server-management.md
+++ b/.agents/skills/ascend-vllm-serving-tune-loop/references/server-management.md
@@ -1,0 +1,37 @@
+# Server Management
+
+## Managed process contract
+
+- Every tuning attempt owns exactly one server process.
+- Record its PID in the run directory, for example `<work_dir>/server.pid`.
+- Clean up that managed PID and its process group only.
+
+## Safe cleanup
+
+Use:
+
+```bash
+bash scripts/cleanup_managed_server.sh \
+  --pid-file <work_dir>/server.pid \
+  --port <port>
+```
+
+Rules:
+
+1. Never instruct the agent to run broad `pkill -9 -f vllm`, `pkill -9 -f VLLM`, or `pkill -9 -f ray` on shared machines.
+2. If the target port is occupied by a non-managed process, stop and ask the user before killing anything.
+3. Wait for graceful shutdown first, then escalate only for the managed process.
+
+## Timeouts
+
+- Server readiness timeout: bounded and recorded as `STARTUP_FAIL`
+- Benchmark timeout: bounded and recorded as `BENCHMARK_FAIL`
+- A retry may happen once for a transient issue, but the retry reason must be recorded
+
+## Wrapper behavior
+
+`scripts/auto_resume_wrapper.sh` should:
+
+- exit immediately on `SIGINT`
+- stop retrying when the wrapped command exits `130`
+- relaunch only when the run is incomplete and not interrupted by the user

--- a/.agents/skills/ascend-vllm-serving-tune-loop/references/tuning-knobs-reference.md
+++ b/.agents/skills/ascend-vllm-serving-tune-loop/references/tuning-knobs-reference.md
@@ -1,0 +1,87 @@
+# Ascend 910C vLLM Tuning Knobs Reference
+
+Quick reference for all tunable parameters in vllm-ascend on 910C.
+Use this table to decide which lever to pick next during the optimization loop.
+
+## Tier 1 — Scheduler & Engine Shell (lowest risk, try first)
+
+| Knob | How to set | Default | Expected impact on low-c latency | Notes |
+|------|-----------|---------|----------------------------------|-------|
+| `block_size` | `--block-size 128` | 16 | **High** — fewer KV pointer dereferences | 128 is recommended for 910C; required for xlite_graph |
+| `enable_balance_scheduling` | `--additional-config '{"enable_balance_scheduling": true}'` | false | Medium — reduces decode stalls | Incompatible with profiling_chunk_config |
+| `max_num_seqs` | `--max-num-seqs 32` | 256 | Medium at c=1–4 | Reduces scheduler overhead at low concurrency |
+| `enable_chunked_prefill` | `--enable-chunked-prefill --max-num-batched-tokens 2048` | disabled | Medium — reduces head-of-line blocking | Try values: 1024 / 2048 / 4096 |
+| `enable_cpu_binding` | `--additional-config '{"enable_cpu_binding": true}'` | true | Low | Disable if NUMA topology is fragmented |
+
+## Tier 2 — Ascend Fusion & Graph Compilation
+
+| Knob | How to set | Default | Expected impact | Notes |
+|------|-----------|---------|-----------------|-------|
+| `VLLM_ASCEND_ENABLE_NZ` | `VLLM_ASCEND_ENABLE_NZ=2` | 1 | **High** — reduces HBM bandwidth pressure | 0=off, 1=quant-only, 2=all ops |
+| `enable_npugraph_ex` + `enable_static_kernel` | `ascend_compilation_config: {enable_static_kernel: true}` | npugraph_ex=true, static=false | **High at c=1** — eliminates JIT recompilation | Adds startup time (~minutes) |
+| `fuse_norm_quant` | `ascend_compilation_config: {fuse_norm_quant: true}` | true | Medium | Fuses RMSNorm + quant into single kernel |
+| `fuse_qknorm_rope` | `ascend_compilation_config: {fuse_qknorm_rope: true}` | true | Medium | Fuses QK-norm + RoPE |
+| `fuse_allreduce_rms` | `ascend_compilation_config: {fuse_allreduce_rms: true}` | false | Medium (TP>1) | Only beneficial with TP≥2 |
+| `fusion_ops_gmmswigluquant` | `ascend_fusion_config: {fusion_ops_gmmswigluquant: true}` | true | Medium (MoE) | MoE models only |
+| `xlite_graph_config` | `xlite_graph_config: {enabled: true}` | disabled | **High** — Xlite backend accelerates decode | Requires block_size=128, pp=1 |
+
+## Tier 3 — FlashComm & TP Communication Overlap (TP > 1 only)
+
+| Knob | How to set | Default | Expected impact | Notes |
+|------|-----------|---------|-----------------|-------|
+| `enable_flashcomm1` | `--additional-config '{"enable_flashcomm1": true}'` | false | High — overlaps prefill allreduce | Reduces TTFT at c=1 with TP |
+| `VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE` | `VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE=<tp>` | 0 | High — overlaps decode allreduce | Reduces TPOT at low c |
+| `prefill_comm_compute_overlap` | `--additional-config '{"prefill_comm_compute_overlap": true}'` | false | Medium | Overlap prefill comm+compute |
+| `VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE` | `VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE=1` | 0 | Medium (eager mode, TP>1) | Better in eager; less benefit in graph mode |
+| `HCCL_BUFFSIZE` | `HCCL_BUFFSIZE=200` | system default | Low–Medium | Reduce HCCL fragmentation; try 100/200/400 |
+
+## Tier 4 — Weight Prefetch & Memory Layout
+
+| Knob | How to set | Default | Expected impact | Notes |
+|------|-----------|---------|-----------------|-------|
+| `weight_prefetch_config` | `weight_prefetch_config: {enabled: true}` | disabled | Medium — masks HBM latency | Tune per-layer prefetch_ratio if needed |
+| `VLLM_ASCEND_ENABLE_MLAPO` | `VLLM_ASCEND_ENABLE_MLAPO=1` | 1 | Medium (DeepSeek W8A8) | Disable only if memory is tight |
+| `VLLM_ASCEND_ENABLE_FUSED_MC2` | `VLLM_ASCEND_ENABLE_FUSED_MC2=1` | 0 | Medium (MoE W8A8 + EP) | Try 0/1/2 |
+| `VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK` | `=1` | 1 | Low | Fused KV cache transpose; leave enabled |
+
+## Tier 5 — Multistream & DSA Overlap (Advanced)
+
+| Knob | How to set | Default | Expected impact | Notes |
+|------|-----------|---------|-----------------|-------|
+| `multistream_overlap_shared_expert` | `additional-config` | false | Medium (MoE) | MoE shared-expert stream overlap |
+| `multistream_overlap_gate` | `additional-config` | false | Low–Medium (MoE) | Gate stream overlap |
+| `multistream_dsa_preprocess` | `additional-config` | false | Medium | DSA preprocessing overlap |
+| `multistream_dsv4_dsa_overlap` | `additional-config` | false | Medium | DeepSeek V4 specific |
+
+## Incompatibility Matrix
+
+| Lever A | Lever B | Conflict |
+|---------|---------|---------|
+| `profiling_chunk_config.enabled=true` | `enable_balance_scheduling=true` | Hard conflict — vllm-ascend raises ValueError |
+| `xlite_graph_config.enabled=true` | `pipeline_parallel_size > 1` | Hard conflict |
+| `xlite_graph_config.enabled=true` | `block_size != 128` | Warning (suboptimal) |
+| `enable_static_kernel=true` | `enable_npugraph_ex=false` | Hard conflict |
+| `oproj_tensor_parallel_size > 0` | `enforce_eager=true` | Hard conflict |
+
+## Tuning order for 910C dense models (Qwen3 family)
+
+1. `block_size=128`
+2. `VLLM_ASCEND_ENABLE_NZ=2`
+3. `xlite_graph_config.enabled=true` (with block_size=128)
+4. `enable_static_kernel=true`
+5. `enable_balance_scheduling=true`
+6. `weight_prefetch_config.enabled=true`
+7. `enable_flashcomm1=true` (if TP > 1)
+8. `VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE=<tp>` (if TP > 1)
+
+## Tuning order for 910C MoE models (DeepSeek V3/V4 family)
+
+1. `block_size=128`
+2. `VLLM_ASCEND_ENABLE_NZ=2`
+3. `VLLM_ASCEND_ENABLE_MLAPO=1`
+4. `fusion_ops_gmmswigluquant=true`
+5. `xlite_graph_config.enabled=true`
+6. `VLLM_ASCEND_ENABLE_FUSED_MC2=1` (W8A8 + EP)
+7. `multistream_overlap_shared_expert=true`
+8. `multistream_dsv4_dsa_overlap=true` (V4 only)
+9. `enable_flashcomm1=true` (if TP > 1)

--- a/.agents/skills/ascend-vllm-serving-tune-loop/references/tuning-knobs-reference.md
+++ b/.agents/skills/ascend-vllm-serving-tune-loop/references/tuning-knobs-reference.md
@@ -7,7 +7,7 @@ Use this table to decide which lever to pick next during the optimization loop.
 
 | Knob | How to set | Default | Expected impact on low-c latency | Notes |
 |------|-----------|---------|----------------------------------|-------|
-| `block_size` | `--block-size 128` | 16 | **High** — fewer KV pointer dereferences | 128 is recommended for 910C; required for xlite_graph |
+| `block_size` | `--block-size 128` | 128 | **High** — fewer KV pointer dereferences | 128 is recommended for 910C; required for xlite_graph |
 | `enable_balance_scheduling` | `--additional-config '{"enable_balance_scheduling": true}'` | false | Medium — reduces decode stalls | Incompatible with profiling_chunk_config |
 | `max_num_seqs` | `--max-num-seqs 32` | 256 | Medium at c=1–4 | Reduces scheduler overhead at low concurrency |
 | `enable_chunked_prefill` | `--enable-chunked-prefill --max-num-batched-tokens 2048` | disabled | Medium — reduces head-of-line blocking | Try values: 1024 / 2048 / 4096 |
@@ -21,7 +21,6 @@ Use this table to decide which lever to pick next during the optimization loop.
 | `enable_npugraph_ex` + `enable_static_kernel` | `ascend_compilation_config: {enable_static_kernel: true}` | npugraph_ex=true, static=false | **High at c=1** — eliminates JIT recompilation | Adds startup time (~minutes) |
 | `fuse_norm_quant` | `ascend_compilation_config: {fuse_norm_quant: true}` | true | Medium | Fuses RMSNorm + quant into single kernel |
 | `fuse_qknorm_rope` | `ascend_compilation_config: {fuse_qknorm_rope: true}` | true | Medium | Fuses QK-norm + RoPE |
-| `fuse_allreduce_rms` | `ascend_compilation_config: {fuse_allreduce_rms: true}` | false | Medium (TP>1) | Only beneficial with TP≥2 |
 | `fusion_ops_gmmswigluquant` | `ascend_fusion_config: {fusion_ops_gmmswigluquant: true}` | true | Medium (MoE) | MoE models only |
 | `xlite_graph_config` | `xlite_graph_config: {enabled: true}` | disabled | **High** — Xlite backend accelerates decode | Requires block_size=128, pp=1 |
 
@@ -31,7 +30,6 @@ Use this table to decide which lever to pick next during the optimization loop.
 |------|-----------|---------|-----------------|-------|
 | `enable_flashcomm1` | `--additional-config '{"enable_flashcomm1": true}'` | false | High — overlaps prefill allreduce | Reduces TTFT at c=1 with TP |
 | `VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE` | `VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE=<tp>` | 0 | High — overlaps decode allreduce | Reduces TPOT at low c |
-| `prefill_comm_compute_overlap` | `--additional-config '{"prefill_comm_compute_overlap": true}'` | false | Medium | Overlap prefill comm+compute |
 | `VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE` | `VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE=1` | 0 | Medium (eager mode, TP>1) | Better in eager; less benefit in graph mode |
 | `HCCL_BUFFSIZE` | `HCCL_BUFFSIZE=200` | system default | Low–Medium | Reduce HCCL fragmentation; try 100/200/400 |
 
@@ -39,7 +37,6 @@ Use this table to decide which lever to pick next during the optimization loop.
 
 | Knob | How to set | Default | Expected impact | Notes |
 |------|-----------|---------|-----------------|-------|
-| `weight_prefetch_config` | `weight_prefetch_config: {enabled: true}` | disabled | Medium — masks HBM latency | Tune per-layer prefetch_ratio if needed |
 | `VLLM_ASCEND_ENABLE_MLAPO` | `VLLM_ASCEND_ENABLE_MLAPO=1` | 1 | Medium (DeepSeek W8A8) | Disable only if memory is tight |
 | `VLLM_ASCEND_ENABLE_FUSED_MC2` | `VLLM_ASCEND_ENABLE_FUSED_MC2=1` | 0 | Medium (MoE W8A8 + EP) | Try 0/1/2 |
 | `VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK` | `=1` | 1 | Low | Fused KV cache transpose; leave enabled |
@@ -49,8 +46,6 @@ Use this table to decide which lever to pick next during the optimization loop.
 | Knob | How to set | Default | Expected impact | Notes |
 |------|-----------|---------|-----------------|-------|
 | `multistream_overlap_shared_expert` | `additional-config` | false | Medium (MoE) | MoE shared-expert stream overlap |
-| `multistream_overlap_gate` | `additional-config` | false | Low–Medium (MoE) | Gate stream overlap |
-| `multistream_dsa_preprocess` | `additional-config` | false | Medium | DSA preprocessing overlap |
 | `multistream_dsv4_dsa_overlap` | `additional-config` | false | Medium | DeepSeek V4 specific |
 
 ## Incompatibility Matrix
@@ -70,9 +65,8 @@ Use this table to decide which lever to pick next during the optimization loop.
 3. `xlite_graph_config.enabled=true` (with block_size=128)
 4. `enable_static_kernel=true`
 5. `enable_balance_scheduling=true`
-6. `weight_prefetch_config.enabled=true`
-7. `enable_flashcomm1=true` (if TP > 1)
-8. `VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE=<tp>` (if TP > 1)
+6. `enable_flashcomm1=true` (if TP > 1)
+7. `VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE=<tp>` (if TP > 1)
 
 ## Tuning order for 910C MoE models (DeepSeek V3/V4 family)
 

--- a/.agents/skills/ascend-vllm-serving-tune-loop/references/workflow-checklist.md
+++ b/.agents/skills/ascend-vllm-serving-tune-loop/references/workflow-checklist.md
@@ -1,0 +1,35 @@
+# Workflow Checklist
+
+## Baseline
+
+1. Create `work_dir` if missing.
+2. Check whether `ledger.md` already exists.
+3. If resuming, read the most recent completed verdict and continue from the next unfinished lever.
+4. Freeze the benchmark contract after baseline:
+   - concurrency levels
+   - requests per level
+   - input tokens
+   - output tokens
+   - target metric
+
+## Per iteration
+
+1. Pick one lever from `tuning-knobs-reference.md`.
+2. State the hypothesis.
+3. Launch one managed server for that exact config.
+4. Run warm-up.
+5. Run benchmark with the frozen workload.
+6. Decide the verdict.
+7. Append to `ledger.md` immediately.
+8. Run scoped cleanup with `scripts/cleanup_managed_server.sh`.
+
+## Exit conditions
+
+Stop only when one of these is true:
+
+1. `max_iterations` reached
+2. user explicitly stops
+3. all planned phases are exhausted
+4. the run is blocked before any safe further attempt can be made
+
+Baseline-only output is not a completed tuning campaign.

--- a/.agents/skills/ascend-vllm-serving-tune-loop/scripts/auto_resume_wrapper.sh
+++ b/.agents/skills/ascend-vllm-serving-tune-loop/scripts/auto_resume_wrapper.sh
@@ -1,11 +1,19 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # auto_resume_wrapper.sh - Auto-resume wrapper for SOTA Tuning Loop
-# This script detects if the run is completed by checking for final_report.md
-# If not completed, it automatically relaunches the claude session to continue.
+
+set -uo pipefail
 
 WORK_DIR=""
+INTERRUPTED=0
 
-# Basic argument parsing
+handle_sigint() {
+    INTERRUPTED=1
+    echo "Received SIGINT, stopping wrapper without relaunch."
+    exit 130
+}
+
+trap handle_sigint INT
+
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --work-dir) WORK_DIR="$2"; shift 2 ;;
@@ -20,7 +28,6 @@ if [ -z "$WORK_DIR" ] || [ "$#" -eq 0 ]; then
     exit 1
 fi
 
-# The remaining arguments constitute the full command
 CLAUDE_CMD_ARRAY=("$@")
 
 MAX_RETRIES=20
@@ -28,15 +35,14 @@ RETRY_COUNT=0
 
 while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
     echo "=== Tuning Session Attempt $((RETRY_COUNT+1))/$MAX_RETRIES ==="
-    
-    # Check completion
+
     if [ -f "$WORK_DIR/final_report.md" ]; then
         echo "✅ final_report.md found in $WORK_DIR. Tuning loop completed successfully!"
         exit 0
     fi
-    
+
     echo "Tuning not yet complete (final_report.md not found)."
-    
+
     if [ -f "$WORK_DIR/ledger.md" ]; then
         echo "Found existing ledger.md in $WORK_DIR. Resuming run..."
     else
@@ -44,22 +50,24 @@ while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
     fi
 
     echo "Launching Claude CLI..."
-    # Execute Claude CLI.
     "${CLAUDE_CMD_ARRAY[@]}"
-    
     EXIT_CODE=$?
     echo "Claude process exited with code $EXIT_CODE"
-    
-    # Check completion again after run
+
+    if [ "$EXIT_CODE" -eq 130 ] || [ "$INTERRUPTED" -eq 1 ]; then
+        echo "Claude session ended by SIGINT. Wrapper exits without retry."
+        exit 130
+    fi
+
     if [ -f "$WORK_DIR/final_report.md" ]; then
         echo "✅ Tuning loop finished during this attempt."
         exit 0
     fi
-    
+
     echo "⚠️ Claude process terminated before completion."
     echo "Waiting 5 seconds before resuming..."
     sleep 5
-    
+
     RETRY_COUNT=$((RETRY_COUNT+1))
 done
 

--- a/.agents/skills/ascend-vllm-serving-tune-loop/scripts/auto_resume_wrapper.sh
+++ b/.agents/skills/ascend-vllm-serving-tune-loop/scripts/auto_resume_wrapper.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# auto_resume_wrapper.sh - Auto-resume wrapper for SOTA Tuning Loop
+# This script detects if the run is completed by checking for final_report.md
+# If not completed, it automatically relaunches the claude session to continue.
+
+WORK_DIR=""
+
+# Basic argument parsing
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --work-dir) WORK_DIR="$2"; shift 2 ;;
+        --) shift; break ;;
+        *) break ;;
+    esac
+done
+
+if [ -z "$WORK_DIR" ] || [ "$#" -eq 0 ]; then
+    echo "Usage: $0 --work-dir <dir> [--] <full_claude_command...>"
+    echo "Example: $0 --work-dir ./tuning_run/my_run -- claude -p \"...\" --max-turns 0"
+    exit 1
+fi
+
+# The remaining arguments constitute the full command
+CLAUDE_CMD_ARRAY=("$@")
+
+MAX_RETRIES=20
+RETRY_COUNT=0
+
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+    echo "=== Tuning Session Attempt $((RETRY_COUNT+1))/$MAX_RETRIES ==="
+    
+    # Check completion
+    if [ -f "$WORK_DIR/final_report.md" ]; then
+        echo "✅ final_report.md found in $WORK_DIR. Tuning loop completed successfully!"
+        exit 0
+    fi
+    
+    echo "Tuning not yet complete (final_report.md not found)."
+    
+    if [ -f "$WORK_DIR/ledger.md" ]; then
+        echo "Found existing ledger.md in $WORK_DIR. Resuming run..."
+    else
+        echo "No existing ledger found. Starting fresh run..."
+    fi
+
+    echo "Launching Claude CLI..."
+    # Execute Claude CLI.
+    "${CLAUDE_CMD_ARRAY[@]}"
+    
+    EXIT_CODE=$?
+    echo "Claude process exited with code $EXIT_CODE"
+    
+    # Check completion again after run
+    if [ -f "$WORK_DIR/final_report.md" ]; then
+        echo "✅ Tuning loop finished during this attempt."
+        exit 0
+    fi
+    
+    echo "⚠️ Claude process terminated before completion."
+    echo "Waiting 5 seconds before resuming..."
+    sleep 5
+    
+    RETRY_COUNT=$((RETRY_COUNT+1))
+done
+
+echo "❌ Exceeded maximum retries ($MAX_RETRIES). Exiting."
+exit 1

--- a/.agents/skills/ascend-vllm-serving-tune-loop/scripts/cleanup_managed_server.sh
+++ b/.agents/skills/ascend-vllm-serving-tune-loop/scripts/cleanup_managed_server.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# cleanup_managed_server.sh - stop only the server process owned by this tuning run.
+
+set -euo pipefail
+
+PID_FILE=""
+PORT=""
+GRACE_SECONDS=15
+
+usage() {
+    cat <<'EOF'
+Usage: cleanup_managed_server.sh --pid-file <file> [--port <port>] [--grace-seconds <seconds>]
+
+The script only terminates the managed PID recorded in --pid-file and its
+process group. If the port is still occupied by a different process, it exits
+with an error instead of killing unrelated workloads.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pid-file) PID_FILE="$2"; shift 2 ;;
+        --port) PORT="$2"; shift 2 ;;
+        --grace-seconds) GRACE_SECONDS="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "${PID_FILE}" ]]; then
+    echo "ERROR: --pid-file is required." >&2
+    usage >&2
+    exit 1
+fi
+
+if [[ ! -f "${PID_FILE}" ]]; then
+    echo "INFO: pid file not found, nothing to clean: ${PID_FILE}"
+    exit 0
+fi
+
+MANAGED_PID="$(tr -d '[:space:]' < "${PID_FILE}")"
+if [[ -z "${MANAGED_PID}" ]]; then
+    echo "INFO: pid file is empty, nothing to clean."
+    rm -f "${PID_FILE}"
+    exit 0
+fi
+
+kill_managed_process() {
+    local pid="$1"
+    if ! kill -0 "${pid}" 2>/dev/null; then
+        return 0
+    fi
+
+    local pgid
+    pgid="$(ps -o pgid= -p "${pid}" 2>/dev/null | tr -d '[:space:]')"
+
+    if [[ -n "${pgid}" ]]; then
+        kill -TERM "-${pgid}" 2>/dev/null || true
+    fi
+    kill -TERM "${pid}" 2>/dev/null || true
+
+    sleep "${GRACE_SECONDS}"
+
+    if kill -0 "${pid}" 2>/dev/null; then
+        if [[ -n "${pgid}" ]]; then
+            kill -KILL "-${pgid}" 2>/dev/null || true
+        fi
+        kill -KILL "${pid}" 2>/dev/null || true
+        sleep 2
+    fi
+}
+
+kill_managed_process "${MANAGED_PID}"
+rm -f "${PID_FILE}"
+
+if [[ -n "${PORT}" ]]; then
+    PORT_PIDS="$(lsof -ti "tcp:${PORT}" 2>/dev/null || true)"
+    if [[ -n "${PORT_PIDS}" ]]; then
+        while IFS= read -r pid; do
+            [[ -n "${pid}" ]] || continue
+            if [[ "${pid}" != "${MANAGED_PID}" ]]; then
+                CMDLINE="$(ps -o command= -p "${pid}" 2>/dev/null | tr -d '\n')"
+                echo "ERROR: port ${PORT} is still occupied by non-managed PID ${pid}: ${CMDLINE}" >&2
+                exit 1
+            fi
+        done <<< "${PORT_PIDS}"
+    fi
+fi
+
+echo "Managed server cleanup completed."

--- a/.agents/skills/ascend-vllm-serving-tune-loop/scripts/generate_tuning_report.py
+++ b/.agents/skills/ascend-vllm-serving-tune-loop/scripts/generate_tuning_report.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Generate a final tuning report from the optimization ledger and per-iteration results.
+
+Usage:
+    python generate_tuning_report.py \\
+        --work-dir ./tuning_run/20250611_120000/ \\
+        --model-name Qwen3-32B \\
+        --target-metric ttft_avg
+"""
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+
+LOW_CONC_THRESHOLD = 10
+
+METRIC_LABELS = {
+    "ttft_p99": "TTFT P99 (ms)",
+    "ttft_avg": "TTFT avg (ms)",
+    "tpot_p99": "TPOT P99 (ms)",
+    "tpot_avg": "TPOT avg (ms)",
+    "latency_p99": "E2E Latency P99 (ms)",
+    "latency_avg": "E2E Latency avg (ms)",
+    "output_token_throughput": "Output tok/s",
+}
+
+
+@dataclass
+class IterResult:
+    iteration: int
+    phase: str
+    lever_name: str
+    hypothesis: str
+    change_desc: str
+    verdict: str  # WIN / LOSS / NEUTRAL
+    carry_forward: bool
+    metrics: dict  # {concurrency: {metric: value}}
+    notes: str = ""
+
+
+@dataclass
+class TuningRun:
+    model_name: str
+    target_metric: str
+    baseline_metrics: dict = field(default_factory=dict)
+    best_metrics: dict = field(default_factory=dict)
+    best_config: str = ""
+    iterations: list[IterResult] = field(default_factory=list)
+    winning_levers: list[str] = field(default_factory=list)
+    failed_levers: list[str] = field(default_factory=list)
+    timestamp: str = ""
+
+
+def _safe_float(val, default: float = 0.0) -> float:
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return default
+
+
+def _pct_delta(baseline: float, current: float) -> str:
+    if baseline == 0:
+        return "N/A"
+    delta = current - baseline
+    pct = delta / baseline * 100
+    sign = "+" if pct >= 0 else ""
+    bold_open = "**" if abs(pct) >= 1.0 else ""
+    bold_close = "**" if abs(pct) >= 1.0 else ""
+    return f"{bold_open}{sign}{pct:.1f}%{bold_close}"
+
+
+def _load_jsonl_metrics(results_dir: Path) -> dict:
+    """Load per-concurrency metrics from evalscope JSONL output."""
+    metrics: dict = {}
+    for pattern in ("*.jsonl", "results.jsonl"):
+        for p in results_dir.glob(pattern):
+            try:
+                with open(p) as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        rec = json.loads(line)
+                        c = int(rec.get("concurrency", rec.get("parallel", 0)))
+                        if c == 0:
+                            continue
+                        stats = rec.get("stats", rec)
+
+                        def ms(key: str) -> float:
+                            v = stats.get(key, {})
+                            if isinstance(v, dict):
+                                return _safe_float(v.get("mean", v.get("avg", 0))) * 1000
+                            return _safe_float(v) * 1000
+
+                        def ms_p(key: str, pct: str) -> float:
+                            v = stats.get(key, {})
+                            if isinstance(v, dict):
+                                return _safe_float(v.get(pct, 0)) * 1000
+                            return 0.0
+
+                        metrics[c] = {
+                            "ttft_avg": ms("ttft"),
+                            "ttft_p99": ms_p("ttft", "p99"),
+                            "tpot_avg": ms("tpot"),
+                            "tpot_p99": ms_p("tpot", "p99"),
+                            "latency_avg": ms("latency"),
+                            "latency_p99": ms_p("latency", "p99"),
+                            "output_token_throughput": _safe_float(
+                                stats.get("output_token_throughput", stats.get("token_throughput", 0))
+                            ),
+                        }
+            except (json.JSONDecodeError, OSError):
+                continue
+    return metrics
+
+
+def _parse_ledger(ledger_path: Path) -> list[IterResult]:
+    """Parse ledger.md into IterResult list (best-effort markdown parse)."""
+    if not ledger_path.exists():
+        return []
+
+    results: list[IterResult] = []
+    text = ledger_path.read_text()
+
+    # Split on ## Iteration headers
+    blocks = re.split(r"^## Iteration (\d+)", text, flags=re.MULTILINE)
+    # blocks: [preamble, iter_num, block_content, iter_num, block_content, ...]
+    i = 1
+    while i < len(blocks) - 1:
+        iter_num = int(blocks[i])
+        content = blocks[i + 1]
+
+        phase_match = re.search(r"## Iteration \d+ — (.+)", f"## Iteration {iter_num}{content}")
+        phase_lever = phase_match.group(1).strip() if phase_match else "unknown"
+
+        hypothesis = ""
+        h_match = re.search(r"\*\*Hypothesis\*\*:\s*(.+)", content)
+        if h_match:
+            hypothesis = h_match.group(1).strip()
+
+        change_desc = ""
+        c_match = re.search(r"\*\*Change\*\*:\s*`(.+?)`", content)
+        if c_match:
+            change_desc = c_match.group(1).strip()
+
+        verdict = "NEUTRAL"
+        v_match = re.search(r"\*\*Verdict\*\*:\s*(WIN|LOSS|NEUTRAL)", content)
+        if v_match:
+            verdict = v_match.group(1)
+
+        carry = verdict == "WIN"
+        cf_match = re.search(r"\*\*Carry forward\*\*:\s*(YES|NO)", content, re.IGNORECASE)
+        if cf_match:
+            carry = cf_match.group(1).upper() == "YES"
+
+        notes = ""
+        n_match = re.search(r"\*\*Notes\*\*:\s*(.+)", content)
+        if n_match:
+            notes = n_match.group(1).strip()
+
+        results.append(IterResult(
+            iteration=iter_num,
+            phase=phase_lever,
+            lever_name=phase_lever,
+            hypothesis=hypothesis,
+            change_desc=change_desc,
+            verdict=verdict,
+            carry_forward=carry,
+            metrics={},
+            notes=notes,
+        ))
+        i += 2
+
+    return results
+
+
+def render_report(run: TuningRun) -> str:
+    lines: list[str] = []
+    a = lines.append
+
+    a(f"# vLLM-Ascend Tuning Report — {run.model_name}")
+    a(f"")
+    a(f"> Generated: {run.timestamp}")
+    a(f"")
+
+    wins = [r for r in run.iterations if r.verdict == "WIN"]
+    losses = [r for r in run.iterations if r.verdict == "LOSS"]
+    neutrals = [r for r in run.iterations if r.verdict == "NEUTRAL"]
+
+    # ── Executive Summary ────────────────────────────────────────────────────
+    a("## Executive Summary")
+    a("")
+    a(f"| Item | Value |")
+    a(f"|------|-------|")
+    a(f"| Model | `{run.model_name}` |")
+    a(f"| Target Metric | `{METRIC_LABELS.get(run.target_metric, run.target_metric)}` |")
+    a(f"| Total Iterations | `{len(run.iterations)}` |")
+    a(f"| Winning Levers | `{len(wins)}` |")
+    a(f"| Neutral | `{len(neutrals)}` |")
+    a(f"| Regression (LOSS) | `{len(losses)}` |")
+
+    # Compute overall improvement at c=1 for target metric
+    if run.baseline_metrics and run.best_metrics:
+        base_c1 = run.baseline_metrics.get(1, {}).get(run.target_metric, 0)
+        best_c1 = run.best_metrics.get(1, {}).get(run.target_metric, 0)
+        if base_c1 > 0:
+            overall_pct = (best_c1 - base_c1) / base_c1 * 100
+            sign = "+" if overall_pct >= 0 else ""
+            a(f"| Overall improvement (c=1, {METRIC_LABELS.get(run.target_metric, run.target_metric)}) | `{sign}{overall_pct:.1f}%` |")
+
+    a("")
+
+    # ── Baseline vs Best ─────────────────────────────────────────────────────
+    a("## Baseline vs Best Configuration")
+    a("")
+    a("> Focus: low-concurrency (c < 10), especially c = 1")
+    a("")
+
+    primary_metrics = [run.target_metric, "ttft_avg", "tpot_p99", "latency_p99", "output_token_throughput"]
+    seen_metrics: list[str] = []
+    for m in primary_metrics:
+        if m not in seen_metrics:
+            seen_metrics.append(m)
+
+    conc_levels = sorted([c for c in (run.baseline_metrics or run.best_metrics or {}).keys() if c < LOW_CONC_THRESHOLD])
+    if not conc_levels:
+        conc_levels = [1, 2, 4, 8]
+
+    if run.baseline_metrics or run.best_metrics:
+        a("| Concurrency | Metric | Baseline | Best | Delta % |")
+        a("|-------------|--------|----------|------|---------|")
+        for c in conc_levels:
+            for metric in seen_metrics:
+                base_val = run.baseline_metrics.get(c, {}).get(metric, 0.0)
+                best_val = run.best_metrics.get(c, {}).get(metric, 0.0)
+                label = METRIC_LABELS.get(metric, metric)
+                row_marker = " ⭐" if c == 1 and metric == run.target_metric else ""
+                a(
+                    f"| `c={c}`{row_marker} | {label} "
+                    f"| {base_val:.1f} | {best_val:.1f} | {_pct_delta(base_val, best_val)} |"
+                )
+        a("")
+        a("> ⭐ = primary optimization target")
+        a("")
+    else:
+        a("> No parsed metrics available. Populate `baseline_metrics` and `best_metrics` in TuningRun.")
+        a("")
+
+    # ── Winning Configuration ─────────────────────────────────────────────────
+    a("## Winning Configuration")
+    a("")
+    if run.best_config:
+        a("Copy-paste to reproduce the best result:")
+        a("")
+        a("```bash")
+        a(run.best_config)
+        a("```")
+    elif wins:
+        a("Winning levers (apply all cumulatively):")
+        a("")
+        for w in wins:
+            a(f"- **{w.lever_name}**: `{w.change_desc}`")
+    else:
+        a("> No winning levers found. Baseline is the best configuration.")
+    a("")
+
+    # ── Optimization History ─────────────────────────────────────────────────
+    a("## Optimization History")
+    a("")
+    if run.iterations:
+        a("| # | Phase / Lever | Verdict | c=1 target delta | Notes |")
+        a("|---|--------------|---------|-----------------|-------|")
+        for r in run.iterations:
+            c1_baseline = run.baseline_metrics.get(1, {}).get(run.target_metric, 0.0)
+            c1_iter = r.metrics.get(1, {}).get(run.target_metric, 0.0)
+            delta_str = _pct_delta(c1_baseline, c1_iter) if c1_iter else "—"
+            verdict_icon = {"WIN": "✅ WIN", "LOSS": "❌ LOSS", "NEUTRAL": "➖ NEUTRAL"}.get(r.verdict, r.verdict)
+            a(f"| {r.iteration} | {r.lever_name} | {verdict_icon} | {delta_str} | {r.notes[:60] if r.notes else '—'} |")
+        a("")
+    else:
+        a("> No ledger entries found.")
+        a("")
+
+    # ── Failed Levers ─────────────────────────────────────────────────────────
+    if losses or neutrals:
+        a("## Levers That Did Not Help")
+        a("")
+        for r in losses + neutrals:
+            icon = "❌" if r.verdict == "LOSS" else "➖"
+            a(f"- {icon} **{r.lever_name}** (`{r.change_desc}`): {r.hypothesis or 'no hypothesis recorded'}")
+        a("")
+
+    # ── Recommendations ───────────────────────────────────────────────────────
+    a("## Recommended Next Steps")
+    a("")
+    if len(wins) == 0:
+        a("- No tuning wins found. Consider profiling with `msprof` to identify the actual bottleneck:")
+        a("  ```bash")
+        a("  msprof --application=<server_cmd> --output=./profile_output")
+        a("  ```")
+        a("- Check if ACLGraph warmup is completing before measurement starts")
+        a("- Verify CANN version matches the vllm-ascend release notes")
+    elif len(losses + neutrals) > len(wins) * 2:
+        a("- Most levers did not help — the bottleneck may be at the hardware/interconnect level")
+        a("- Consider profiling decode kernels with `msnpuprofiler` to check NPU utilization")
+    else:
+        a("- Run a broader concurrency sweep (c = 16, 32, 64) with the winning configuration")
+        a("- Consider quantization (W8A8) if further memory-bandwidth reduction is needed")
+        a(f"- Document winning configuration in `configs/<model>.yaml` for reproducibility")
+    a("")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate vllm-ascend tuning final report")
+    parser.add_argument("--work-dir", type=Path, required=True, help="Tuning run work directory")
+    parser.add_argument("--model-name", default="unknown", help="Model name")
+    parser.add_argument("--target-metric", default="ttft_avg",
+                        choices=list(METRIC_LABELS.keys()), help="Primary optimization target")
+    args = parser.parse_args()
+
+    work_dir = args.work_dir
+    if not work_dir.exists():
+        print(f"ERROR: work-dir {work_dir} does not exist", file=sys.stderr)
+        sys.exit(1)
+
+    # Load baseline metrics
+    baseline_dir = work_dir / "baseline"
+    baseline_metrics = _load_jsonl_metrics(baseline_dir) if baseline_dir.exists() else {}
+
+    # Find best iteration metrics (last WIN or final iteration)
+    iterations = _parse_ledger(work_dir / "ledger.md")
+    best_metrics = dict(baseline_metrics)
+    best_config_lines: list[str] = []
+    for r in iterations:
+        if r.verdict == "WIN":
+            iter_dir = work_dir / f"iter_{r.iteration:02d}"
+            iter_metrics = _load_jsonl_metrics(iter_dir) if iter_dir.exists() else {}
+            if iter_metrics:
+                best_metrics = iter_metrics
+            if r.change_desc:
+                best_config_lines.append(r.change_desc)
+
+    run = TuningRun(
+        model_name=args.model_name,
+        target_metric=args.target_metric,
+        baseline_metrics=baseline_metrics,
+        best_metrics=best_metrics,
+        best_config="\n".join(best_config_lines),
+        iterations=iterations,
+        timestamp=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+    )
+
+    report = render_report(run)
+    output_path = work_dir / "final_report.md"
+    output_path.write_text(report)
+    print(f"Final report written to: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/ascend-vllm-serving-tune-loop/scripts/generate_tuning_report.py
+++ b/.agents/skills/ascend-vllm-serving-tune-loop/scripts/generate_tuning_report.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
-
 LOW_CONC_THRESHOLD = 10
 LOWER_IS_BETTER = {
     "ttft_avg",
@@ -68,79 +67,88 @@ def _safe_float(val, default: float = 0.0) -> float:
         return default
 
 
-def _normalize_records(data) -> list[dict]:
-    if isinstance(data, list):
-        return [item for item in data if isinstance(item, dict)]
-    if isinstance(data, dict):
-        for key in ("results", "records", "data"):
-            nested = data.get(key)
-            if isinstance(nested, list):
-                return [item for item in nested if isinstance(item, dict)]
-        return [data]
-    return []
+def _percentile_row(percentile: list, pct: str) -> dict:
+    """Find the row for a given percentile string (e.g. '99%') in evalscope
+    benchmark_percentile.json, which is a list of flat dicts."""
+    for row in percentile or []:
+        if isinstance(row, dict) and str(row.get("Percentiles", "")).strip() == pct:
+            return row
+    return {}
 
 
-def _parse_records(records: list[dict]) -> dict[int, dict[str, float]]:
-    metrics: dict[int, dict[str, float]] = {}
-    for record in records:
-        stats = record.get("stats", record)
-        concurrency = int(record.get("concurrency", record.get("parallel", 0)))
-        if concurrency == 0:
-            continue
+def _metrics_from_summary(summary: dict, percentile: list) -> dict[str, float]:
+    """Build the metric-keyed dict for one concurrency level from a paired
+    evalscope v1.8.1 benchmark_summary.json (flat dict) +
+    benchmark_percentile.json (list).
 
-        def ms(key: str) -> float:
-            value = stats.get(key, {})
-            if isinstance(value, dict):
-                return _safe_float(value.get("mean", value.get("avg", 0))) * 1000
-            return _safe_float(value) * 1000
+    Units: 'Avg Latency (s)' / 'Latency (s)' are seconds -> *1000 to ms;
+    'TTFT (ms)' / 'TPOT (ms)' are already ms.
+    """
+    p99 = _percentile_row(percentile, "99%")
+    return {
+        "ttft_avg": _safe_float(summary.get("TTFT (ms)")),
+        "ttft_p99": _safe_float(p99.get("TTFT (ms)")),
+        "tpot_avg": _safe_float(summary.get("TPOT (ms)")),
+        "tpot_p99": _safe_float(p99.get("TPOT (ms)")),
+        "latency_avg": _safe_float(summary.get("Avg Latency (s)")) * 1000.0,
+        "latency_p99": _safe_float(p99.get("Latency (s)")) * 1000.0,
+        "output_token_throughput": _safe_float(summary.get("Output Throughput (tok/s)")),
+    }
 
-        def ms_pct(key: str, pct: str) -> float:
-            value = stats.get(key, {})
-            if isinstance(value, dict):
-                return _safe_float(value.get(pct, 0)) * 1000
-            return 0.0
 
-        metrics[concurrency] = {
-            "ttft_avg": ms("ttft"),
-            "ttft_p99": ms_pct("ttft", "p99"),
-            "tpot_avg": ms("tpot"),
-            "tpot_p99": ms_pct("tpot", "p99"),
-            "latency_avg": ms("latency"),
-            "latency_p99": ms_pct("latency", "p99"),
-            "output_token_throughput": _safe_float(
-                stats.get(
-                    "output_token_throughput",
-                    stats.get("token_throughput", 0),
-                )),
-        }
-    return metrics
+def _load_json(path: Path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
 
 
 def _load_json_metrics(results_dir: Path) -> dict[int, dict[str, float]]:
+    """Parse evalscope perf v1.8.1 output.
+
+    Layout: <results_dir>/<timestamp>/<name>/parallel_<P>_number_<N>/
+            {benchmark_summary.json, benchmark_percentile.json}
+    Each parallel_* subdir holds one concurrency level. Returns a map
+    concurrency -> metric-keyed dict.
+    """
     if not results_dir.exists():
         return {}
 
+    metrics: dict[int, dict[str, float]] = {}
+    for sub in sorted(results_dir.rglob("parallel_*_number_*")):
+        if not sub.is_dir():
+            continue
+        summary = _load_json(sub / "benchmark_summary.json")
+        percentile = _load_json(sub / "benchmark_percentile.json")
+        if not isinstance(summary, dict):
+            continue
+        if not isinstance(percentile, list):
+            percentile = []
+        concurrency = int(_safe_float(summary.get("Concurrency"), -1))
+        if concurrency < 0:
+            continue
+        metrics[concurrency] = _metrics_from_summary(summary, percentile)
+
+    if metrics:
+        return metrics
+
+    # Fallback: JSONL of flat summary dicts (no paired percentile file).
     for path in sorted(results_dir.rglob("*.jsonl")):
-        records: list[dict] = []
         try:
             with open(path, encoding="utf-8") as fh:
                 for line in fh:
                     line = line.strip()
                     if not line:
                         continue
-                    records.append(json.loads(line))
+                    summary = json.loads(line)
+                    if not isinstance(summary, dict):
+                        continue
+                    concurrency = int(_safe_float(summary.get("Concurrency"), -1))
+                    if concurrency < 0:
+                        continue
+                    metrics[concurrency] = _metrics_from_summary(summary, [])
         except (json.JSONDecodeError, OSError):
             continue
-        metrics = _parse_records(records)
-        if metrics:
-            return metrics
-
-    for path in sorted(results_dir.rglob("*.json")):
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            continue
-        metrics = _parse_records(_normalize_records(data))
         if metrics:
             return metrics
 
@@ -193,7 +201,7 @@ def _parse_metrics_table(block: str) -> dict[int, dict[str, float]]:
             if idx + 1 >= len(lines):
                 return {}
             metrics: dict[int, dict[str, float]] = {}
-            for row in lines[idx + 2:]:
+            for row in lines[idx + 2 :]:
                 if not row.strip().startswith("|"):
                     break
                 cells = [cell.strip() for cell in row.strip().strip("|").split("|")]
@@ -260,20 +268,22 @@ def _parse_ledger(ledger_path: Path) -> list[IterResult]:
         if carry_field:
             carry_forward = carry_field.upper() == "YES"
 
-        results.append(IterResult(
-            iteration=iteration,
-            phase=title,
-            lever_name=title,
-            hypothesis=_extract_field(block, "Hypothesis"),
-            change_desc=_extract_field(block, "Change").strip("`"),
-            verdict=verdict,
-            carry_forward=carry_forward,
-            metrics=_parse_metrics_table(block),
-            notes=_extract_field(block, "Notes"),
-            failure_stage=_extract_field(block, "Failure stage"),
-            reason=_extract_field(block, "Reason"),
-            evidence=_extract_evidence(block),
-        ))
+        results.append(
+            IterResult(
+                iteration=iteration,
+                phase=title,
+                lever_name=title,
+                hypothesis=_extract_field(block, "Hypothesis"),
+                change_desc=_extract_field(block, "Change").strip("`"),
+                verdict=verdict,
+                carry_forward=carry_forward,
+                metrics=_parse_metrics_table(block),
+                notes=_extract_field(block, "Notes"),
+                failure_stage=_extract_field(block, "Failure stage"),
+                reason=_extract_field(block, "Reason"),
+                evidence=_extract_evidence(block),
+            )
+        )
 
     return results
 
@@ -327,10 +337,12 @@ def render_report(run: TuningRun) -> str:
 
     append("## Baseline vs Best Configuration")
     append("")
-    conc_levels = sorted({
-        *[c for c in run.baseline_metrics.keys() if c < LOW_CONC_THRESHOLD],
-        *[c for c in run.best_metrics.keys() if c < LOW_CONC_THRESHOLD],
-    }) or [1, 4, 8]
+    conc_levels = sorted(
+        {
+            *[c for c in run.baseline_metrics if c < LOW_CONC_THRESHOLD],
+            *[c for c in run.best_metrics if c < LOW_CONC_THRESHOLD],
+        }
+    ) or [1, 4, 8]
     metrics = [run.target_metric, "ttft_avg", "tpot_avg", "latency_avg", "output_token_throughput"]
     deduped_metrics = list(dict.fromkeys(metrics))
     append("| Concurrency | Metric | Baseline | Best | Improvement |")
@@ -362,15 +374,10 @@ def render_report(run: TuningRun) -> str:
     append("|---|---------------|---------|-----------------------|-------|")
     for iteration in run.iterations:
         current = iteration.metrics.get(1, {}).get(run.target_metric, 0.0)
-        improvement = (
-            _fmt_improvement(baseline_c1, current, run.target_metric)
-            if current
-            else "—"
-        )
+        improvement = _fmt_improvement(baseline_c1, current, run.target_metric) if current else "—"
         note = iteration.reason or iteration.notes or "—"
         append(
-            f"| {iteration.iteration} | {iteration.lever_name} | `{iteration.verdict}` "
-            f"| {improvement} | {note[:80]} |"
+            f"| {iteration.iteration} | {iteration.lever_name} | `{iteration.verdict}` | {improvement} | {note[:80]} |"
         )
     append("")
 

--- a/.agents/skills/ascend-vllm-serving-tune-loop/scripts/generate_tuning_report.py
+++ b/.agents/skills/ascend-vllm-serving-tune-loop/scripts/generate_tuning_report.py
@@ -1,12 +1,5 @@
 #!/usr/bin/env python3
-"""Generate a final tuning report from the optimization ledger and per-iteration results.
-
-Usage:
-    python generate_tuning_report.py \\
-        --work-dir ./tuning_run/20250611_120000/ \\
-        --model-name Qwen3-32B \\
-        --target-metric ttft_avg
-"""
+"""Generate a final tuning report from the optimization ledger and result dirs."""
 
 import argparse
 import json
@@ -18,6 +11,15 @@ from pathlib import Path
 
 
 LOW_CONC_THRESHOLD = 10
+LOWER_IS_BETTER = {
+    "ttft_avg",
+    "ttft_p99",
+    "tpot_avg",
+    "tpot_p99",
+    "latency_avg",
+    "latency_p99",
+}
+FAILURE_VERDICTS = {"STARTUP_FAIL", "BENCHMARK_FAIL", "SKIPPED_CONFLICT"}
 
 METRIC_LABELS = {
     "ttft_p99": "TTFT P99 (ms)",
@@ -37,18 +39,21 @@ class IterResult:
     lever_name: str
     hypothesis: str
     change_desc: str
-    verdict: str  # WIN / LOSS / NEUTRAL
+    verdict: str
     carry_forward: bool
-    metrics: dict  # {concurrency: {metric: value}}
+    metrics: dict[int, dict[str, float]] = field(default_factory=dict)
     notes: str = ""
+    failure_stage: str = ""
+    reason: str = ""
+    evidence: str = ""
 
 
 @dataclass
 class TuningRun:
     model_name: str
     target_metric: str
-    baseline_metrics: dict = field(default_factory=dict)
-    best_metrics: dict = field(default_factory=dict)
+    baseline_metrics: dict[int, dict[str, float]] = field(default_factory=dict)
+    best_metrics: dict[int, dict[str, float]] = field(default_factory=dict)
     best_config: str = ""
     iterations: list[IterResult] = field(default_factory=list)
     winning_levers: list[str] = field(default_factory=list)
@@ -63,256 +68,345 @@ def _safe_float(val, default: float = 0.0) -> float:
         return default
 
 
-def _pct_delta(baseline: float, current: float) -> str:
-    if baseline == 0:
-        return "N/A"
-    delta = current - baseline
-    pct = delta / baseline * 100
-    sign = "+" if pct >= 0 else ""
-    bold_open = "**" if abs(pct) >= 1.0 else ""
-    bold_close = "**" if abs(pct) >= 1.0 else ""
-    return f"{bold_open}{sign}{pct:.1f}%{bold_close}"
+def _normalize_records(data) -> list[dict]:
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    if isinstance(data, dict):
+        for key in ("results", "records", "data"):
+            nested = data.get(key)
+            if isinstance(nested, list):
+                return [item for item in nested if isinstance(item, dict)]
+        return [data]
+    return []
 
 
-def _load_jsonl_metrics(results_dir: Path) -> dict:
-    """Load per-concurrency metrics from evalscope JSONL output."""
-    metrics: dict = {}
-    for pattern in ("*.jsonl", "results.jsonl"):
-        for p in results_dir.glob(pattern):
-            try:
-                with open(p) as f:
-                    for line in f:
-                        line = line.strip()
-                        if not line:
-                            continue
-                        rec = json.loads(line)
-                        c = int(rec.get("concurrency", rec.get("parallel", 0)))
-                        if c == 0:
-                            continue
-                        stats = rec.get("stats", rec)
+def _parse_records(records: list[dict]) -> dict[int, dict[str, float]]:
+    metrics: dict[int, dict[str, float]] = {}
+    for record in records:
+        stats = record.get("stats", record)
+        concurrency = int(record.get("concurrency", record.get("parallel", 0)))
+        if concurrency == 0:
+            continue
 
-                        def ms(key: str) -> float:
-                            v = stats.get(key, {})
-                            if isinstance(v, dict):
-                                return _safe_float(v.get("mean", v.get("avg", 0))) * 1000
-                            return _safe_float(v) * 1000
+        def ms(key: str) -> float:
+            value = stats.get(key, {})
+            if isinstance(value, dict):
+                return _safe_float(value.get("mean", value.get("avg", 0))) * 1000
+            return _safe_float(value) * 1000
 
-                        def ms_p(key: str, pct: str) -> float:
-                            v = stats.get(key, {})
-                            if isinstance(v, dict):
-                                return _safe_float(v.get(pct, 0)) * 1000
-                            return 0.0
+        def ms_pct(key: str, pct: str) -> float:
+            value = stats.get(key, {})
+            if isinstance(value, dict):
+                return _safe_float(value.get(pct, 0)) * 1000
+            return 0.0
 
-                        metrics[c] = {
-                            "ttft_avg": ms("ttft"),
-                            "ttft_p99": ms_p("ttft", "p99"),
-                            "tpot_avg": ms("tpot"),
-                            "tpot_p99": ms_p("tpot", "p99"),
-                            "latency_avg": ms("latency"),
-                            "latency_p99": ms_p("latency", "p99"),
-                            "output_token_throughput": _safe_float(
-                                stats.get("output_token_throughput", stats.get("token_throughput", 0))
-                            ),
-                        }
-            except (json.JSONDecodeError, OSError):
-                continue
+        metrics[concurrency] = {
+            "ttft_avg": ms("ttft"),
+            "ttft_p99": ms_pct("ttft", "p99"),
+            "tpot_avg": ms("tpot"),
+            "tpot_p99": ms_pct("tpot", "p99"),
+            "latency_avg": ms("latency"),
+            "latency_p99": ms_pct("latency", "p99"),
+            "output_token_throughput": _safe_float(
+                stats.get(
+                    "output_token_throughput",
+                    stats.get("token_throughput", 0),
+                )),
+        }
     return metrics
 
 
+def _load_json_metrics(results_dir: Path) -> dict[int, dict[str, float]]:
+    if not results_dir.exists():
+        return {}
+
+    for path in sorted(results_dir.rglob("*.jsonl")):
+        records: list[dict] = []
+        try:
+            with open(path, encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    records.append(json.loads(line))
+        except (json.JSONDecodeError, OSError):
+            continue
+        metrics = _parse_records(records)
+        if metrics:
+            return metrics
+
+    for path in sorted(results_dir.rglob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        metrics = _parse_records(_normalize_records(data))
+        if metrics:
+            return metrics
+
+    return {}
+
+
+def _parse_number(cell: str) -> float:
+    cleaned = re.sub(r"[`*]", "", cell)
+    match = re.search(r"-?\d+(?:\.\d+)?", cleaned)
+    if not match:
+        raise ValueError("no numeric value found")
+    return float(match.group(0))
+
+
+def _metric_key_from_header(header: str) -> str | None:
+    normalized = header.strip().lower()
+    normalized = normalized.replace("(", " ").replace(")", " ")
+    normalized = normalized.replace("/", " ")
+    normalized = re.sub(r"\s+", " ", normalized)
+
+    mapping = {
+        "ttft avg": "ttft_avg",
+        "ttft_avg": "ttft_avg",
+        "ttft p99": "ttft_p99",
+        "ttft_p99": "ttft_p99",
+        "tpot avg": "tpot_avg",
+        "tpot_avg": "tpot_avg",
+        "tpot p99": "tpot_p99",
+        "tpot_p99": "tpot_p99",
+        "latency avg": "latency_avg",
+        "e2e latency avg": "latency_avg",
+        "latency_avg": "latency_avg",
+        "latency p99": "latency_p99",
+        "lat p99": "latency_p99",
+        "e2e latency p99": "latency_p99",
+        "latency_p99": "latency_p99",
+        "tps": "output_token_throughput",
+        "tps tok s": "output_token_throughput",
+        "output tok s": "output_token_throughput",
+        "output token throughput": "output_token_throughput",
+    }
+    return mapping.get(normalized)
+
+
+def _parse_metrics_table(block: str) -> dict[int, dict[str, float]]:
+    lines = block.splitlines()
+    for idx, line in enumerate(lines):
+        if line.strip().startswith("|") and "Concurrency" in line:
+            header_cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+            if idx + 1 >= len(lines):
+                return {}
+            metrics: dict[int, dict[str, float]] = {}
+            for row in lines[idx + 2:]:
+                if not row.strip().startswith("|"):
+                    break
+                cells = [cell.strip() for cell in row.strip().strip("|").split("|")]
+                if len(cells) != len(header_cells):
+                    continue
+                conc_match = re.search(r"\d+", cells[0])
+                if not conc_match:
+                    continue
+                concurrency = int(conc_match.group(0))
+                row_metrics: dict[str, float] = {}
+                for header, cell in zip(header_cells[1:], cells[1:]):
+                    metric_key = _metric_key_from_header(header)
+                    if not metric_key:
+                        continue
+                    try:
+                        row_metrics[metric_key] = _parse_number(cell)
+                    except ValueError:
+                        continue
+                if row_metrics:
+                    metrics[concurrency] = row_metrics
+            return metrics
+    return {}
+
+
+def _extract_field(block: str, field_name: str) -> str:
+    pattern = re.compile(rf"\*\*{re.escape(field_name)}\*\*:\s*(.+)")
+    match = pattern.search(block)
+    return match.group(1).strip() if match else ""
+
+
+def _extract_evidence(block: str) -> str:
+    evidence_block = re.search(
+        r"\*\*Evidence\*\*:\s*(.*?)(?=\n\*\*|\Z)",
+        block,
+        flags=re.DOTALL,
+    )
+    if not evidence_block:
+        return ""
+    lines = []
+    for line in evidence_block.group(1).splitlines():
+        line = line.strip().lstrip("-").strip()
+        if line:
+            lines.append(line)
+    return " | ".join(lines)
+
+
 def _parse_ledger(ledger_path: Path) -> list[IterResult]:
-    """Parse ledger.md into IterResult list (best-effort markdown parse)."""
     if not ledger_path.exists():
         return []
 
+    text = ledger_path.read_text(encoding="utf-8")
+    pattern = re.compile(
+        r"^## Iteration (\d+)\s+[—-]\s+(.+?)\n(.*?)(?=^## Iteration \d+\s+[—-]\s+|\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
     results: list[IterResult] = []
-    text = ledger_path.read_text()
-
-    # Split on ## Iteration headers
-    blocks = re.split(r"^## Iteration (\d+)", text, flags=re.MULTILINE)
-    # blocks: [preamble, iter_num, block_content, iter_num, block_content, ...]
-    i = 1
-    while i < len(blocks) - 1:
-        iter_num = int(blocks[i])
-        content = blocks[i + 1]
-
-        phase_match = re.search(r"## Iteration \d+ — (.+)", f"## Iteration {iter_num}{content}")
-        phase_lever = phase_match.group(1).strip() if phase_match else "unknown"
-
-        hypothesis = ""
-        h_match = re.search(r"\*\*Hypothesis\*\*:\s*(.+)", content)
-        if h_match:
-            hypothesis = h_match.group(1).strip()
-
-        change_desc = ""
-        c_match = re.search(r"\*\*Change\*\*:\s*`(.+?)`", content)
-        if c_match:
-            change_desc = c_match.group(1).strip()
-
-        verdict = "NEUTRAL"
-        v_match = re.search(r"\*\*Verdict\*\*:\s*(WIN|LOSS|NEUTRAL)", content)
-        if v_match:
-            verdict = v_match.group(1)
-
-        carry = verdict == "WIN"
-        cf_match = re.search(r"\*\*Carry forward\*\*:\s*(YES|NO)", content, re.IGNORECASE)
-        if cf_match:
-            carry = cf_match.group(1).upper() == "YES"
-
-        notes = ""
-        n_match = re.search(r"\*\*Notes\*\*:\s*(.+)", content)
-        if n_match:
-            notes = n_match.group(1).strip()
+    for match in pattern.finditer(text):
+        iteration = int(match.group(1))
+        title = match.group(2).strip()
+        block = match.group(3)
+        verdict = _extract_field(block, "Verdict") or "NEUTRAL"
+        carry_forward = verdict == "WIN"
+        carry_field = _extract_field(block, "Carry forward")
+        if carry_field:
+            carry_forward = carry_field.upper() == "YES"
 
         results.append(IterResult(
-            iteration=iter_num,
-            phase=phase_lever,
-            lever_name=phase_lever,
-            hypothesis=hypothesis,
-            change_desc=change_desc,
+            iteration=iteration,
+            phase=title,
+            lever_name=title,
+            hypothesis=_extract_field(block, "Hypothesis"),
+            change_desc=_extract_field(block, "Change").strip("`"),
             verdict=verdict,
-            carry_forward=carry,
-            metrics={},
-            notes=notes,
+            carry_forward=carry_forward,
+            metrics=_parse_metrics_table(block),
+            notes=_extract_field(block, "Notes"),
+            failure_stage=_extract_field(block, "Failure stage"),
+            reason=_extract_field(block, "Reason"),
+            evidence=_extract_evidence(block),
         ))
-        i += 2
 
     return results
 
 
+def _improvement_pct(baseline: float, current: float, metric: str) -> float | None:
+    if baseline == 0:
+        return None
+    if metric in LOWER_IS_BETTER:
+        return (baseline - current) / baseline * 100
+    return (current - baseline) / baseline * 100
+
+
+def _fmt_improvement(baseline: float, current: float, metric: str) -> str:
+    improvement = _improvement_pct(baseline, current, metric)
+    if improvement is None:
+        return "N/A"
+    sign = "+" if improvement >= 0 else ""
+    return f"{sign}{improvement:.1f}%"
+
+
 def render_report(run: TuningRun) -> str:
     lines: list[str] = []
-    a = lines.append
+    append = lines.append
 
-    a(f"# vLLM-Ascend Tuning Report — {run.model_name}")
-    a(f"")
-    a(f"> Generated: {run.timestamp}")
-    a(f"")
+    verdict_counts: dict[str, int] = {}
+    for iteration in run.iterations:
+        verdict_counts[iteration.verdict] = verdict_counts.get(iteration.verdict, 0) + 1
 
-    wins = [r for r in run.iterations if r.verdict == "WIN"]
-    losses = [r for r in run.iterations if r.verdict == "LOSS"]
-    neutrals = [r for r in run.iterations if r.verdict == "NEUTRAL"]
+    append(f"# vLLM-Ascend Tuning Report — {run.model_name}")
+    append("")
+    append(f"> Generated: {run.timestamp}")
+    append("")
 
-    # ── Executive Summary ────────────────────────────────────────────────────
-    a("## Executive Summary")
-    a("")
-    a(f"| Item | Value |")
-    a(f"|------|-------|")
-    a(f"| Model | `{run.model_name}` |")
-    a(f"| Target Metric | `{METRIC_LABELS.get(run.target_metric, run.target_metric)}` |")
-    a(f"| Total Iterations | `{len(run.iterations)}` |")
-    a(f"| Winning Levers | `{len(wins)}` |")
-    a(f"| Neutral | `{len(neutrals)}` |")
-    a(f"| Regression (LOSS) | `{len(losses)}` |")
+    append("## Summary")
+    append("")
+    append("| Item | Value |")
+    append("|------|-------|")
+    append(f"| Model | `{run.model_name}` |")
+    append(f"| Target Metric | `{METRIC_LABELS.get(run.target_metric, run.target_metric)}` |")
+    append(f"| Total Iterations | `{len(run.iterations)}` |")
+    for verdict in ("WIN", "NEUTRAL", "LOSS", "STARTUP_FAIL", "BENCHMARK_FAIL", "SKIPPED_CONFLICT"):
+        append(f"| {verdict} | `{verdict_counts.get(verdict, 0)}` |")
 
-    # Compute overall improvement at c=1 for target metric
-    if run.baseline_metrics and run.best_metrics:
-        base_c1 = run.baseline_metrics.get(1, {}).get(run.target_metric, 0)
-        best_c1 = run.best_metrics.get(1, {}).get(run.target_metric, 0)
-        if base_c1 > 0:
-            overall_pct = (best_c1 - base_c1) / base_c1 * 100
-            sign = "+" if overall_pct >= 0 else ""
-            a(f"| Overall improvement (c=1, {METRIC_LABELS.get(run.target_metric, run.target_metric)}) | `{sign}{overall_pct:.1f}%` |")
+    baseline_c1 = run.baseline_metrics.get(1, {}).get(run.target_metric, 0.0)
+    best_c1 = run.best_metrics.get(1, {}).get(run.target_metric, 0.0)
+    append(
+        f"| Overall improvement (c=1, {METRIC_LABELS.get(run.target_metric, run.target_metric)}) "
+        f"| `{_fmt_improvement(baseline_c1, best_c1, run.target_metric)}` |"
+    )
+    append("")
 
-    a("")
+    append("## Baseline vs Best Configuration")
+    append("")
+    conc_levels = sorted({
+        *[c for c in run.baseline_metrics.keys() if c < LOW_CONC_THRESHOLD],
+        *[c for c in run.best_metrics.keys() if c < LOW_CONC_THRESHOLD],
+    }) or [1, 4, 8]
+    metrics = [run.target_metric, "ttft_avg", "tpot_avg", "latency_avg", "output_token_throughput"]
+    deduped_metrics = list(dict.fromkeys(metrics))
+    append("| Concurrency | Metric | Baseline | Best | Improvement |")
+    append("|-------------|--------|----------|------|-------------|")
+    for concurrency in conc_levels:
+        for metric in deduped_metrics:
+            baseline = run.baseline_metrics.get(concurrency, {}).get(metric, 0.0)
+            best = run.best_metrics.get(concurrency, {}).get(metric, 0.0)
+            marker = " ★" if concurrency == 1 and metric == run.target_metric else ""
+            append(
+                f"| `{concurrency}`{marker} | {METRIC_LABELS.get(metric, metric)} "
+                f"| {baseline:.1f} | {best:.1f} | {_fmt_improvement(baseline, best, metric)} |"
+            )
+    append("")
 
-    # ── Baseline vs Best ─────────────────────────────────────────────────────
-    a("## Baseline vs Best Configuration")
-    a("")
-    a("> Focus: low-concurrency (c < 10), especially c = 1")
-    a("")
-
-    primary_metrics = [run.target_metric, "ttft_avg", "tpot_p99", "latency_p99", "output_token_throughput"]
-    seen_metrics: list[str] = []
-    for m in primary_metrics:
-        if m not in seen_metrics:
-            seen_metrics.append(m)
-
-    conc_levels = sorted([c for c in (run.baseline_metrics or run.best_metrics or {}).keys() if c < LOW_CONC_THRESHOLD])
-    if not conc_levels:
-        conc_levels = [1, 2, 4, 8]
-
-    if run.baseline_metrics or run.best_metrics:
-        a("| Concurrency | Metric | Baseline | Best | Delta % |")
-        a("|-------------|--------|----------|------|---------|")
-        for c in conc_levels:
-            for metric in seen_metrics:
-                base_val = run.baseline_metrics.get(c, {}).get(metric, 0.0)
-                best_val = run.best_metrics.get(c, {}).get(metric, 0.0)
-                label = METRIC_LABELS.get(metric, metric)
-                row_marker = " ⭐" if c == 1 and metric == run.target_metric else ""
-                a(
-                    f"| `c={c}`{row_marker} | {label} "
-                    f"| {base_val:.1f} | {best_val:.1f} | {_pct_delta(base_val, best_val)} |"
-                )
-        a("")
-        a("> ⭐ = primary optimization target")
-        a("")
-    else:
-        a("> No parsed metrics available. Populate `baseline_metrics` and `best_metrics` in TuningRun.")
-        a("")
-
-    # ── Winning Configuration ─────────────────────────────────────────────────
-    a("## Winning Configuration")
-    a("")
+    append("## Winning Configuration")
+    append("")
     if run.best_config:
-        a("Copy-paste to reproduce the best result:")
-        a("")
-        a("```bash")
-        a(run.best_config)
-        a("```")
-    elif wins:
-        a("Winning levers (apply all cumulatively):")
-        a("")
-        for w in wins:
-            a(f"- **{w.lever_name}**: `{w.change_desc}`")
+        append("```bash")
+        append(run.best_config)
+        append("```")
     else:
-        a("> No winning levers found. Baseline is the best configuration.")
-    a("")
+        append("> No winning lever beat the baseline. Keep the baseline configuration.")
+    append("")
 
-    # ── Optimization History ─────────────────────────────────────────────────
-    a("## Optimization History")
-    a("")
-    if run.iterations:
-        a("| # | Phase / Lever | Verdict | c=1 target delta | Notes |")
-        a("|---|--------------|---------|-----------------|-------|")
-        for r in run.iterations:
-            c1_baseline = run.baseline_metrics.get(1, {}).get(run.target_metric, 0.0)
-            c1_iter = r.metrics.get(1, {}).get(run.target_metric, 0.0)
-            delta_str = _pct_delta(c1_baseline, c1_iter) if c1_iter else "—"
-            verdict_icon = {"WIN": "✅ WIN", "LOSS": "❌ LOSS", "NEUTRAL": "➖ NEUTRAL"}.get(r.verdict, r.verdict)
-            a(f"| {r.iteration} | {r.lever_name} | {verdict_icon} | {delta_str} | {r.notes[:60] if r.notes else '—'} |")
-        a("")
+    append("## Optimization History")
+    append("")
+    append("| # | Phase / Lever | Verdict | c=1 target improvement | Notes |")
+    append("|---|---------------|---------|-----------------------|-------|")
+    for iteration in run.iterations:
+        current = iteration.metrics.get(1, {}).get(run.target_metric, 0.0)
+        improvement = (
+            _fmt_improvement(baseline_c1, current, run.target_metric)
+            if current
+            else "—"
+        )
+        note = iteration.reason or iteration.notes or "—"
+        append(
+            f"| {iteration.iteration} | {iteration.lever_name} | `{iteration.verdict}` "
+            f"| {improvement} | {note[:80]} |"
+        )
+    append("")
+
+    non_wins = [item for item in run.iterations if item.verdict in {"LOSS", "NEUTRAL"}]
+    if non_wins:
+        append("## Levers That Did Not Help")
+        append("")
+        for item in non_wins:
+            append(
+                f"- **{item.lever_name}** (`{item.verdict}`): "
+                f"{item.reason or item.notes or item.hypothesis or 'no extra note recorded'}"
+            )
+        append("")
+
+    failed = [item for item in run.iterations if item.verdict in FAILURE_VERDICTS]
+    if failed:
+        append("## Failed / Incompatible Levers")
+        append("")
+        append("| Lever | Verdict | Stage | Reason | Evidence |")
+        append("|-------|---------|-------|--------|----------|")
+        for item in failed:
+            append(
+                f"| `{item.lever_name}` | `{item.verdict}` | `{item.failure_stage or 'unknown'}` "
+                f"| {item.reason or '—'} | {item.evidence or '—'} |"
+            )
+        append("")
+
+    append("## Recommended Next Steps")
+    append("")
+    if not run.winning_levers:
+        append("- No tuning win was recorded. Validate bottlenecks with `msprof` or a newer CANN / vllm-ascend build.")
+        append("- Review failed levers first; environment issues are often easier to unlock than new kernel work.")
     else:
-        a("> No ledger entries found.")
-        a("")
-
-    # ── Failed Levers ─────────────────────────────────────────────────────────
-    if losses or neutrals:
-        a("## Levers That Did Not Help")
-        a("")
-        for r in losses + neutrals:
-            icon = "❌" if r.verdict == "LOSS" else "➖"
-            a(f"- {icon} **{r.lever_name}** (`{r.change_desc}`): {r.hypothesis or 'no hypothesis recorded'}")
-        a("")
-
-    # ── Recommendations ───────────────────────────────────────────────────────
-    a("## Recommended Next Steps")
-    a("")
-    if len(wins) == 0:
-        a("- No tuning wins found. Consider profiling with `msprof` to identify the actual bottleneck:")
-        a("  ```bash")
-        a("  msprof --application=<server_cmd> --output=./profile_output")
-        a("  ```")
-        a("- Check if ACLGraph warmup is completing before measurement starts")
-        a("- Verify CANN version matches the vllm-ascend release notes")
-    elif len(losses + neutrals) > len(wins) * 2:
-        a("- Most levers did not help — the bottleneck may be at the hardware/interconnect level")
-        a("- Consider profiling decode kernels with `msnpuprofiler` to check NPU utilization")
-    else:
-        a("- Run a broader concurrency sweep (c = 16, 32, 64) with the winning configuration")
-        a("- Consider quantization (W8A8) if further memory-bandwidth reduction is needed")
-        a(f"- Document winning configuration in `configs/<model>.yaml` for reproducibility")
-    a("")
+        append("- Re-run the best configuration with a broader concurrency sweep before publishing final numbers.")
+        append("- Promote stable winning flags into a checked config template once the run is repeatable.")
+    append("")
 
     return "\n".join(lines)
 
@@ -321,8 +415,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Generate vllm-ascend tuning final report")
     parser.add_argument("--work-dir", type=Path, required=True, help="Tuning run work directory")
     parser.add_argument("--model-name", default="unknown", help="Model name")
-    parser.add_argument("--target-metric", default="ttft_avg",
-                        choices=list(METRIC_LABELS.keys()), help="Primary optimization target")
+    parser.add_argument(
+        "--target-metric",
+        default="ttft_avg",
+        choices=list(METRIC_LABELS.keys()),
+        help="Primary optimization target",
+    )
     args = parser.parse_args()
 
     work_dir = args.work_dir
@@ -330,22 +428,28 @@ def main() -> None:
         print(f"ERROR: work-dir {work_dir} does not exist", file=sys.stderr)
         sys.exit(1)
 
-    # Load baseline metrics
-    baseline_dir = work_dir / "baseline"
-    baseline_metrics = _load_jsonl_metrics(baseline_dir) if baseline_dir.exists() else {}
-
-    # Find best iteration metrics (last WIN or final iteration)
+    baseline_metrics = _load_json_metrics(work_dir / "baseline")
     iterations = _parse_ledger(work_dir / "ledger.md")
+
+    winning_levers: list[str] = []
+    failed_levers: list[str] = []
     best_metrics = dict(baseline_metrics)
     best_config_lines: list[str] = []
-    for r in iterations:
-        if r.verdict == "WIN":
-            iter_dir = work_dir / f"iter_{r.iteration:02d}"
-            iter_metrics = _load_jsonl_metrics(iter_dir) if iter_dir.exists() else {}
-            if iter_metrics:
-                best_metrics = iter_metrics
-            if r.change_desc:
-                best_config_lines.append(r.change_desc)
+
+    for iteration in iterations:
+        iter_dir = work_dir / f"iter_{iteration.iteration:02d}"
+        dir_metrics = _load_json_metrics(iter_dir)
+        if dir_metrics:
+            iteration.metrics = dir_metrics
+
+        if iteration.carry_forward:
+            if iteration.metrics:
+                best_metrics = iteration.metrics
+            if iteration.change_desc:
+                best_config_lines.append(iteration.change_desc)
+            winning_levers.append(iteration.lever_name)
+        elif iteration.verdict in FAILURE_VERDICTS:
+            failed_levers.append(iteration.lever_name)
 
     run = TuningRun(
         model_name=args.model_name,
@@ -354,12 +458,13 @@ def main() -> None:
         best_metrics=best_metrics,
         best_config="\n".join(best_config_lines),
         iterations=iterations,
+        winning_levers=winning_levers,
+        failed_levers=failed_levers,
         timestamp=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
     )
 
-    report = render_report(run)
     output_path = work_dir / "final_report.md"
-    output_path.write_text(report)
+    output_path.write_text(render_report(run), encoding="utf-8")
     print(f"Final report written to: {output_path}")
 
 

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -640,6 +640,17 @@
     - tests/e2e/pull_request/one_card/test_qwen3_0_6b.py
     - tests/e2e/pull_request/one_card/test_qwen3_5_0_8b.py
 
+# Agent skills and their script-level regression tests
+- name: agents
+  optional: false
+  cpu_only: true
+  source_file_dependencies:
+    - .agents/skills/ascend-vllm-serving-auto-benchmark
+    - .agents/skills/ascend-vllm-serving-tune-loop
+    - tests/ut/agents
+  tests:
+    - tests/ut/agents
+
 # === Features ===
 - name: quantization_gqa_mla_c8
   optional: false

--- a/.github/workflows/skill_scripts_dry_run.yaml
+++ b/.github/workflows/skill_scripts_dry_run.yaml
@@ -1,0 +1,60 @@
+name: Skill Scripts Dry Run
+
+on:
+  pull_request:
+    paths:
+      - '.agents/skills/ascend-vllm-serving-auto-benchmark/**'
+      - '.agents/skills/ascend-vllm-serving-tune-loop/**'
+      - 'tests/ut/agents/test_serving_skill_scripts.py'
+      - 'tools/shellcheck.sh'
+      - '.github/workflows/skill_scripts_dry_run.yaml'
+  workflow_dispatch:
+
+jobs:
+  lint-and-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install lightweight test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pyyaml
+
+      - name: Shellcheck skill scripts
+        run: |
+          bash tools/shellcheck.sh \
+            .agents/skills/ascend-vllm-serving-auto-benchmark/scripts/run_benchmark.sh \
+            .agents/skills/ascend-vllm-serving-tune-loop/scripts/auto_resume_wrapper.sh \
+            .agents/skills/ascend-vllm-serving-tune-loop/scripts/cleanup_managed_server.sh
+
+      - name: Check bash syntax
+        run: |
+          bash -n .agents/skills/ascend-vllm-serving-auto-benchmark/scripts/run_benchmark.sh
+          bash -n .agents/skills/ascend-vllm-serving-tune-loop/scripts/auto_resume_wrapper.sh
+          bash -n .agents/skills/ascend-vllm-serving-tune-loop/scripts/cleanup_managed_server.sh
+
+      - name: Check Python syntax
+        run: |
+          python -m py_compile \
+            .agents/skills/ascend-vllm-serving-auto-benchmark/scripts/generate_report.py \
+            .agents/skills/ascend-vllm-serving-auto-benchmark/scripts/validate_configs.py \
+            .agents/skills/ascend-vllm-serving-tune-loop/scripts/generate_tuning_report.py \
+            tests/ut/agents/test_serving_skill_scripts.py
+
+      - name: Run focused unit tests
+        run: |
+          pytest --noconftest -q tests/ut/agents/test_serving_skill_scripts.py
+
+      - name: Dry-run benchmark workflow
+        run: |
+          bash .agents/skills/ascend-vllm-serving-auto-benchmark/scripts/run_benchmark.sh \
+            --dry-run \
+            --config .agents/skills/ascend-vllm-serving-auto-benchmark/configs/qwen3-32b.yaml \
+            --output-dir "${RUNNER_TEMP}/skill-benchmark-dry-run"

--- a/tests/ut/agents/fixtures/evalscope_v181/outputs/20250423_002442/TestModel/parallel_1_number_20/benchmark_percentile.json
+++ b/tests/ut/agents/fixtures/evalscope_v181/outputs/20250423_002442/TestModel/parallel_1_number_20/benchmark_percentile.json
@@ -1,0 +1,5 @@
+[
+    {"Percentiles": "50%", "TTFT (ms)": 63.1, "ITL (ms)": 10.0, "TPOT (ms)": 10.0, "Latency (s)": 5.10, "Input tokens": 1024.0, "Output tokens": 505.0, "Output (tok/s)": 98.9, "Input (tok/s)": 3.8, "Total (tok/s)": 102.7},
+    {"Percentiles": "90%", "TTFT (ms)": 65.8, "ITL (ms)": 10.4, "TPOT (ms)": 10.4, "Latency (s)": 5.28, "Input tokens": 1024.0, "Output tokens": 510.0, "Output (tok/s)": 96.6, "Input (tok/s)": 3.7, "Total (tok/s)": 100.3},
+    {"Percentiles": "99%", "TTFT (ms)": 68.5, "ITL (ms)": 10.44, "TPOT (ms)": 10.44, "Latency (s)": 5.40, "Input tokens": 1024.0, "Output tokens": 512.0, "Output (tok/s)": 95.0, "Input (tok/s)": 3.7, "Total (tok/s)": 98.7}
+]

--- a/tests/ut/agents/fixtures/evalscope_v181/outputs/20250423_002442/TestModel/parallel_1_number_20/benchmark_summary.json
+++ b/tests/ut/agents/fixtures/evalscope_v181/outputs/20250423_002442/TestModel/parallel_1_number_20/benchmark_summary.json
@@ -1,0 +1,18 @@
+{
+    "Test Duration (s)": 5.312,
+    "Concurrency": 1,
+    "Request Rate (req/s)": -1,
+    "Total Requests": 20,
+    "Success Requests": 20,
+    "Failed Requests": 0,
+    "Output Throughput (tok/s)": 96.38,
+    "Total Throughput (tok/s)": 102.08,
+    "Input Throughput (tok/s)": 3.77,
+    "Req Throughput (req/s)": 0.1882,
+    "Avg Latency (s)": 5.312,
+    "TTFT (ms)": 64.2,
+    "TPOT (ms)": 10.27,
+    "ITL (ms)": 10.2,
+    "Avg Input Tokens": 1024.0,
+    "Avg Output Tokens": 512.0
+}

--- a/tests/ut/agents/fixtures/evalscope_v181/outputs/20250423_002442/TestModel/parallel_4_number_20/benchmark_percentile.json
+++ b/tests/ut/agents/fixtures/evalscope_v181/outputs/20250423_002442/TestModel/parallel_4_number_20/benchmark_percentile.json
@@ -1,0 +1,5 @@
+[
+    {"Percentiles": "50%", "TTFT (ms)": 138.5, "ITL (ms)": 10.7, "TPOT (ms)": 10.7, "Latency (s)": 5.60, "Input tokens": 1024.0, "Output tokens": 508.0, "Output (tok/s)": 361.5, "Input (tok/s)": 14.0, "Total (tok/s)": 365.5},
+    {"Percentiles": "90%", "TTFT (ms)": 170.0, "ITL (ms)": 11.1, "TPOT (ms)": 11.1, "Latency (s)": 5.74, "Input tokens": 1024.0, "Output tokens": 511.0, "Output (tok/s)": 357.2, "Input (tok/s)": 13.9, "Total (tok/s)": 364.1},
+    {"Percentiles": "99%", "TTFT (ms)": 209.6, "ITL (ms)": 11.19, "TPOT (ms)": 11.19, "Latency (s)": 5.83, "Input tokens": 1024.0, "Output tokens": 512.0, "Output (tok/s)": 355.0, "Input (tok/s)": 13.8, "Total (tok/s)": 358.8}
+]

--- a/tests/ut/agents/fixtures/evalscope_v181/outputs/20250423_002442/TestModel/parallel_4_number_20/benchmark_summary.json
+++ b/tests/ut/agents/fixtures/evalscope_v181/outputs/20250423_002442/TestModel/parallel_4_number_20/benchmark_summary.json
@@ -1,0 +1,18 @@
+{
+    "Test Duration (s)": 5.748,
+    "Concurrency": 4,
+    "Request Rate (req/s)": -1,
+    "Total Requests": 80,
+    "Success Requests": 80,
+    "Failed Requests": 0,
+    "Output Throughput (tok/s)": 356.19,
+    "Total Throughput (tok/s)": 364.33,
+    "Input Throughput (tok/s)": 13.91,
+    "Req Throughput (req/s)": 0.6957,
+    "Avg Latency (s)": 5.748,
+    "TTFT (ms)": 144.67,
+    "TPOT (ms)": 10.97,
+    "ITL (ms)": 10.9,
+    "Avg Input Tokens": 1024.0,
+    "Avg Output Tokens": 512.0
+}

--- a/tests/ut/agents/fixtures/evalscope_v181/outputs/20250423_002442/TestModel/parallel_8_number_20/benchmark_percentile.json
+++ b/tests/ut/agents/fixtures/evalscope_v181/outputs/20250423_002442/TestModel/parallel_8_number_20/benchmark_percentile.json
@@ -1,0 +1,5 @@
+[
+    {"Percentiles": "50%", "TTFT (ms)": 210.0, "ITL (ms)": 12.0, "TPOT (ms)": 12.0, "Latency (s)": 6.30, "Input tokens": 1024.0, "Output tokens": 510.0, "Output (tok/s)": 642.0, "Input (tok/s)": 25.2, "Total (tok/s)": 657.2},
+    {"Percentiles": "90%", "TTFT (ms)": 300.0, "ITL (ms)": 12.4, "TPOT (ms)": 12.4, "Latency (s)": 6.44, "Input tokens": 1024.0, "Output tokens": 512.0, "Output (tok/s)": 637.5, "Input (tok/s)": 25.0, "Total (tok/s)": 652.5},
+    {"Percentiles": "99%", "TTFT (ms)": 376.0, "ITL (ms)": 12.48, "TPOT (ms)": 12.48, "Latency (s)": 6.50, "Input tokens": 1024.0, "Output tokens": 512.0, "Output (tok/s)": 634.0, "Input (tok/s)": 24.8, "Total (tok/s)": 648.8}
+]

--- a/tests/ut/agents/fixtures/evalscope_v181/outputs/20250423_002442/TestModel/parallel_8_number_20/benchmark_summary.json
+++ b/tests/ut/agents/fixtures/evalscope_v181/outputs/20250423_002442/TestModel/parallel_8_number_20/benchmark_summary.json
@@ -1,0 +1,18 @@
+{
+    "Test Duration (s)": 6.436,
+    "Concurrency": 8,
+    "Request Rate (req/s)": -1,
+    "Total Requests": 160,
+    "Success Requests": 160,
+    "Failed Requests": 0,
+    "Output Throughput (tok/s)": 636.04,
+    "Total Throughput (tok/s)": 654.50,
+    "Input Throughput (tok/s)": 25.0,
+    "Req Throughput (req/s)": 1.2423,
+    "Avg Latency (s)": 6.436,
+    "TTFT (ms)": 225.9,
+    "TPOT (ms)": 12.15,
+    "ITL (ms)": 12.1,
+    "Avg Input Tokens": 1024.0,
+    "Avg Output Tokens": 512.0
+}

--- a/tests/ut/agents/test_serving_skill_scripts.py
+++ b/tests/ut/agents/test_serving_skill_scripts.py
@@ -25,7 +25,39 @@ def dump_json_line(payload: dict) -> str:
     return json.dumps(payload, separators=(",", ":"))
 
 
-def test_generate_report_parses_json_results(tmp_path: Path) -> None:
+def test_generate_report_parses_real_evalscope_v181_output() -> None:
+    """Parse a real-shaped evalscope perf v1.8.1 output tree: nested under
+    <timestamp>/<name>/parallel_<P>_number_<N>/ with paired
+    benchmark_summary.json (flat dict) + benchmark_percentile.json (list)."""
+    module = load_module(
+        "generate_report_module",
+        ".agents/skills/ascend-vllm-serving-auto-benchmark/scripts/generate_report.py",
+    )
+
+    fixture_dir = REPO_ROOT / "tests/ut/agents/fixtures/evalscope_v181/outputs/20250423_002442/TestModel"
+
+    parsed = module._parse_evalscope_output_dir(fixture_dir)
+    assert len(parsed) == 3
+    assert [r.concurrency for r in parsed] == [1, 4, 8]
+
+    c1 = parsed[0]
+    # TTFT/TPOT are already ms in v1.8.1; read straight from summary.
+    assert c1.ttft_avg_ms == 64.2
+    assert c1.tpot_avg_ms == 10.27
+    assert c1.output_token_throughput == 96.38
+    # Avg Latency is in SECONDS in v1.8.1; parser must convert to ms.
+    assert c1.latency_avg_ms == 5312.0
+    # Percentiles come from benchmark_percentile.json (p99 row).
+    assert c1.ttft_p99_ms == 68.5
+    assert c1.tpot_p99_ms == 10.44
+    assert c1.latency_p99_ms == 5400.0
+    assert c1.success_requests == 20
+    assert c1.failed_requests == 0
+
+
+def test_generate_report_jsonl_fallback_uses_real_fields(tmp_path: Path) -> None:
+    """When no parallel_* subdirs exist, fall back to JSONL where each line is
+    a flat v1.8.1 summary dict (no paired percentile file)."""
     module = load_module(
         "generate_report_module",
         ".agents/skills/ascend-vllm-serving-auto-benchmark/scripts/generate_report.py",
@@ -33,25 +65,21 @@ def test_generate_report_parses_json_results(tmp_path: Path) -> None:
 
     results_dir = tmp_path / "results"
     results_dir.mkdir()
-    (results_dir / "results.json").write_text(
-        """
+    write_jsonl(
+        results_dir / "results.jsonl",
         [
-          {
-            "concurrency": 1,
-            "stats": {
-              "total_requests": 10,
-              "success_requests": 10,
-              "success_rate": 1.0,
-              "request_throughput": 2.0,
-              "output_token_throughput": 128.0,
-              "latency": {"mean": 0.5, "p50": 0.4, "p90": 0.6, "p99": 0.8},
-              "ttft": {"mean": 0.1, "p50": 0.09, "p90": 0.12, "p99": 0.15},
-              "tpot": {"mean": 0.02, "p50": 0.02, "p90": 0.03, "p99": 0.04}
-            }
-          }
-        ]
-        """,
-        encoding="utf-8",
+            dump_json_line(
+                {
+                    "Concurrency": 1,
+                    "Total Requests": 10,
+                    "Success Requests": 10,
+                    "Output Throughput (tok/s)": 128.0,
+                    "Avg Latency (s)": 0.5,
+                    "TTFT (ms)": 100.0,
+                    "TPOT (ms)": 20.0,
+                }
+            )
+        ],
     )
 
     parsed = module._parse_evalscope_output_dir(results_dir)
@@ -60,6 +88,7 @@ def test_generate_report_parses_json_results(tmp_path: Path) -> None:
     assert parsed[0].ttft_avg_ms == 100.0
     assert parsed[0].tpot_avg_ms == 20.0
     assert parsed[0].output_token_throughput == 128.0
+    assert parsed[0].latency_avg_ms == 500.0  # 0.5 s -> 500 ms
 
 
 def test_generate_tuning_report_preserves_failure_verdicts_and_metric_direction(
@@ -81,24 +110,20 @@ def test_generate_tuning_report_preserves_failure_verdicts_and_metric_direction(
         [
             dump_json_line(
                 {
-                    "concurrency": 1,
-                    "stats": {
-                        "ttft": {"mean": 0.10},
-                        "tpot": {"mean": 0.03},
-                        "latency": {"mean": 0.50},
-                        "output_token_throughput": 100.0,
-                    },
+                    "Concurrency": 1,
+                    "TTFT (ms)": 100.0,
+                    "TPOT (ms)": 30.0,
+                    "Avg Latency (s)": 0.50,
+                    "Output Throughput (tok/s)": 100.0,
                 }
             ),
             dump_json_line(
                 {
-                    "concurrency": 4,
-                    "stats": {
-                        "ttft": {"mean": 0.20},
-                        "tpot": {"mean": 0.04},
-                        "latency": {"mean": 0.80},
-                        "output_token_throughput": 250.0,
-                    },
+                    "Concurrency": 4,
+                    "TTFT (ms)": 200.0,
+                    "TPOT (ms)": 40.0,
+                    "Avg Latency (s)": 0.80,
+                    "Output Throughput (tok/s)": 250.0,
                 }
             ),
         ],
@@ -108,24 +133,20 @@ def test_generate_tuning_report_preserves_failure_verdicts_and_metric_direction(
         [
             dump_json_line(
                 {
-                    "concurrency": 1,
-                    "stats": {
-                        "ttft": {"mean": 0.08},
-                        "tpot": {"mean": 0.03},
-                        "latency": {"mean": 0.45},
-                        "output_token_throughput": 110.0,
-                    },
+                    "Concurrency": 1,
+                    "TTFT (ms)": 80.0,
+                    "TPOT (ms)": 30.0,
+                    "Avg Latency (s)": 0.45,
+                    "Output Throughput (tok/s)": 110.0,
                 }
             ),
             dump_json_line(
                 {
-                    "concurrency": 4,
-                    "stats": {
-                        "ttft": {"mean": 0.18},
-                        "tpot": {"mean": 0.04},
-                        "latency": {"mean": 0.75},
-                        "output_token_throughput": 260.0,
-                    },
+                    "Concurrency": 4,
+                    "TTFT (ms)": 180.0,
+                    "TPOT (ms)": 40.0,
+                    "Avg Latency (s)": 0.75,
+                    "Output Throughput (tok/s)": 260.0,
                 }
             ),
         ],
@@ -209,3 +230,39 @@ def test_auto_resume_wrapper_exits_on_sigint_code(tmp_path: Path) -> None:
 
     assert result.returncode == 130
     assert "Wrapper exits without retry" in result.stdout
+
+
+def _run_benchmark_dry_run(tmp_path: Path, *extra_args: str) -> str:
+    """Run run_benchmark.sh in dry-run and return the generated server_cmd.txt."""
+    output_dir = tmp_path / "out"
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / ".agents/skills/ascend-vllm-serving-auto-benchmark/scripts/run_benchmark.sh"),
+            "--dry-run",
+            "--model-path",
+            "/tmp/fake-model",
+            "--model-name",
+            "FakeModel",
+            "--output-dir",
+            str(output_dir),
+            *extra_args,
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return (output_dir / "server_cmd.txt").read_text(encoding="utf-8")
+
+
+def test_no_aclgraph_maps_to_enforce_eager(tmp_path: Path) -> None:
+    """--no-aclgraph must disable ACLGraph via the supported vLLM flag
+    --enforce-eager (the legacy VLLM_ASCEND_ENABLE_ACLGRAPH env was a no-op:
+    never defined in vllm_ascend/envs.py, never read by runtime)."""
+    server_cmd = _run_benchmark_dry_run(tmp_path, "--no-aclgraph")
+    assert "--enforce-eager" in server_cmd
+
+    # Without --no-aclgraph the graph stays enabled (no --enforce-eager).
+    baseline_cmd = _run_benchmark_dry_run(tmp_path)
+    assert "--enforce-eager" not in baseline_cmd

--- a/tests/ut/agents/test_serving_skill_scripts.py
+++ b/tests/ut/agents/test_serving_skill_scripts.py
@@ -4,7 +4,6 @@ import subprocess
 import textwrap
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
@@ -80,47 +79,55 @@ def test_generate_tuning_report_preserves_failure_verdicts_and_metric_direction(
     write_jsonl(
         baseline_dir / "results.jsonl",
         [
-            dump_json_line({
-                "concurrency": 1,
-                "stats": {
-                    "ttft": {"mean": 0.10},
-                    "tpot": {"mean": 0.03},
-                    "latency": {"mean": 0.50},
-                    "output_token_throughput": 100.0,
-                },
-            }),
-            dump_json_line({
-                "concurrency": 4,
-                "stats": {
-                    "ttft": {"mean": 0.20},
-                    "tpot": {"mean": 0.04},
-                    "latency": {"mean": 0.80},
-                    "output_token_throughput": 250.0,
-                },
-            }),
+            dump_json_line(
+                {
+                    "concurrency": 1,
+                    "stats": {
+                        "ttft": {"mean": 0.10},
+                        "tpot": {"mean": 0.03},
+                        "latency": {"mean": 0.50},
+                        "output_token_throughput": 100.0,
+                    },
+                }
+            ),
+            dump_json_line(
+                {
+                    "concurrency": 4,
+                    "stats": {
+                        "ttft": {"mean": 0.20},
+                        "tpot": {"mean": 0.04},
+                        "latency": {"mean": 0.80},
+                        "output_token_throughput": 250.0,
+                    },
+                }
+            ),
         ],
     )
     write_jsonl(
         iter_01_dir / "results.jsonl",
         [
-            dump_json_line({
-                "concurrency": 1,
-                "stats": {
-                    "ttft": {"mean": 0.08},
-                    "tpot": {"mean": 0.03},
-                    "latency": {"mean": 0.45},
-                    "output_token_throughput": 110.0,
-                },
-            }),
-            dump_json_line({
-                "concurrency": 4,
-                "stats": {
-                    "ttft": {"mean": 0.18},
-                    "tpot": {"mean": 0.04},
-                    "latency": {"mean": 0.75},
-                    "output_token_throughput": 260.0,
-                },
-            }),
+            dump_json_line(
+                {
+                    "concurrency": 1,
+                    "stats": {
+                        "ttft": {"mean": 0.08},
+                        "tpot": {"mean": 0.03},
+                        "latency": {"mean": 0.45},
+                        "output_token_throughput": 110.0,
+                    },
+                }
+            ),
+            dump_json_line(
+                {
+                    "concurrency": 4,
+                    "stats": {
+                        "ttft": {"mean": 0.18},
+                        "tpot": {"mean": 0.04},
+                        "latency": {"mean": 0.75},
+                        "output_token_throughput": 260.0,
+                    },
+                }
+            ),
         ],
     )
 

--- a/tests/ut/agents/test_serving_skill_scripts.py
+++ b/tests/ut/agents/test_serving_skill_scripts.py
@@ -10,9 +10,9 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 def load_module(module_name: str, relative_path: str):
     module_path = REPO_ROOT / relative_path
     spec = importlib.util.spec_from_file_location(module_name, module_path)
-    module = importlib.util.module_from_spec(spec)
     assert spec is not None
     assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 

--- a/tests/ut/agents/test_serving_skill_scripts.py
+++ b/tests/ut/agents/test_serving_skill_scripts.py
@@ -1,0 +1,167 @@
+import importlib.util
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def load_module(module_name: str, relative_path: str):
+    module_path = REPO_ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_jsonl(path: Path, lines: list[str]) -> None:
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_generate_report_parses_json_results(tmp_path: Path) -> None:
+    module = load_module(
+        "generate_report_module",
+        ".agents/skills/ascend-vllm-serving-auto-benchmark/scripts/generate_report.py",
+    )
+
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+    (results_dir / "results.json").write_text(
+        """
+        [
+          {
+            "concurrency": 1,
+            "stats": {
+              "total_requests": 10,
+              "success_requests": 10,
+              "success_rate": 1.0,
+              "request_throughput": 2.0,
+              "output_token_throughput": 128.0,
+              "latency": {"mean": 0.5, "p50": 0.4, "p90": 0.6, "p99": 0.8},
+              "ttft": {"mean": 0.1, "p50": 0.09, "p90": 0.12, "p99": 0.15},
+              "tpot": {"mean": 0.02, "p50": 0.02, "p90": 0.03, "p99": 0.04}
+            }
+          }
+        ]
+        """,
+        encoding="utf-8",
+    )
+
+    parsed = module._parse_evalscope_output_dir(results_dir)
+    assert len(parsed) == 1
+    assert parsed[0].concurrency == 1
+    assert parsed[0].ttft_avg_ms == 100.0
+    assert parsed[0].tpot_avg_ms == 20.0
+    assert parsed[0].output_token_throughput == 128.0
+
+
+def test_generate_tuning_report_preserves_failure_verdicts_and_metric_direction(
+    tmp_path: Path,
+) -> None:
+    module = load_module(
+        "generate_tuning_report_module",
+        ".agents/skills/ascend-vllm-serving-tune-loop/scripts/generate_tuning_report.py",
+    )
+
+    work_dir = tmp_path / "tuning"
+    baseline_dir = work_dir / "baseline"
+    iter_01_dir = work_dir / "iter_01"
+    baseline_dir.mkdir(parents=True)
+    iter_01_dir.mkdir()
+
+    write_jsonl(
+        baseline_dir / "results.jsonl",
+        [
+            '{"concurrency": 1, "stats": {"ttft": {"mean": 0.10}, "tpot": {"mean": 0.03}, "latency": {"mean": 0.50}, "output_token_throughput": 100.0}}',
+            '{"concurrency": 4, "stats": {"ttft": {"mean": 0.20}, "tpot": {"mean": 0.04}, "latency": {"mean": 0.80}, "output_token_throughput": 250.0}}',
+        ],
+    )
+    write_jsonl(
+        iter_01_dir / "results.jsonl",
+        [
+            '{"concurrency": 1, "stats": {"ttft": {"mean": 0.08}, "tpot": {"mean": 0.03}, "latency": {"mean": 0.45}, "output_token_throughput": 110.0}}',
+            '{"concurrency": 4, "stats": {"ttft": {"mean": 0.18}, "tpot": {"mean": 0.04}, "latency": {"mean": 0.75}, "output_token_throughput": 260.0}}',
+        ],
+    )
+
+    (work_dir / "ledger.md").write_text(
+        textwrap.dedent(
+            """
+            ## Iteration 1 — 2.1 balance_scheduling
+
+            **Hypothesis**: better low-concurrency scheduling
+            **Change**: `--additional-config {"enable_balance_scheduling": true}`
+            **Verdict**: WIN
+            **Carry forward**: YES
+            **Notes**: baseline improved
+
+            ## Iteration 2 — 3.7 xlite_graph
+
+            **Hypothesis**: graph replay can help
+            **Change**: `--compilation-config {"xlite_graph": true}`
+            **Verdict**: STARTUP_FAIL
+            **Failure stage**: server_startup
+            **Reason**: missing xlite package
+            **Evidence**:
+            - Exit code: 1
+            - Log excerpt: ModuleNotFoundError: No module named 'xlite'
+            **Carry forward**: NO
+            **Notes**: skip until dependency is installed
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    baseline_metrics = module._load_json_metrics(baseline_dir)
+    iterations = module._parse_ledger(work_dir / "ledger.md")
+    for iteration in iterations:
+        iter_dir = work_dir / f"iter_{iteration.iteration:02d}"
+        metrics = module._load_json_metrics(iter_dir)
+        if metrics:
+            iteration.metrics = metrics
+
+    run = module.TuningRun(
+        model_name="Qwen3-32B",
+        target_metric="ttft_avg",
+        baseline_metrics=baseline_metrics,
+        best_metrics=iterations[0].metrics,
+        best_config=iterations[0].change_desc,
+        iterations=iterations,
+        winning_levers=[iterations[0].lever_name],
+        failed_levers=[iterations[1].lever_name],
+        timestamp="2026-07-12 12:00:00",
+    )
+
+    report = module.render_report(run)
+    assert "| STARTUP_FAIL | `1` |" in report
+    assert "`+20.0%`" in report
+    assert "`3.7 xlite_graph` | `STARTUP_FAIL` | `server_startup`" in report
+
+
+def test_auto_resume_wrapper_exits_on_sigint_code(tmp_path: Path) -> None:
+    work_dir = tmp_path / "run"
+    work_dir.mkdir()
+    wrapper = REPO_ROOT / ".agents/skills/ascend-vllm-serving-tune-loop/scripts/auto_resume_wrapper.sh"
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(wrapper),
+            "--work-dir",
+            str(work_dir),
+            "--",
+            "bash",
+            "-lc",
+            "exit 130",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 130
+    assert "Wrapper exits without retry" in result.stdout

--- a/tests/ut/agents/test_serving_skill_scripts.py
+++ b/tests/ut/agents/test_serving_skill_scripts.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import subprocess
 import textwrap
 from pathlib import Path
@@ -19,6 +20,10 @@ def load_module(module_name: str, relative_path: str):
 
 def write_jsonl(path: Path, lines: list[str]) -> None:
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def dump_json_line(payload: dict) -> str:
+    return json.dumps(payload, separators=(",", ":"))
 
 
 def test_generate_report_parses_json_results(tmp_path: Path) -> None:
@@ -75,15 +80,47 @@ def test_generate_tuning_report_preserves_failure_verdicts_and_metric_direction(
     write_jsonl(
         baseline_dir / "results.jsonl",
         [
-            '{"concurrency": 1, "stats": {"ttft": {"mean": 0.10}, "tpot": {"mean": 0.03}, "latency": {"mean": 0.50}, "output_token_throughput": 100.0}}',
-            '{"concurrency": 4, "stats": {"ttft": {"mean": 0.20}, "tpot": {"mean": 0.04}, "latency": {"mean": 0.80}, "output_token_throughput": 250.0}}',
+            dump_json_line({
+                "concurrency": 1,
+                "stats": {
+                    "ttft": {"mean": 0.10},
+                    "tpot": {"mean": 0.03},
+                    "latency": {"mean": 0.50},
+                    "output_token_throughput": 100.0,
+                },
+            }),
+            dump_json_line({
+                "concurrency": 4,
+                "stats": {
+                    "ttft": {"mean": 0.20},
+                    "tpot": {"mean": 0.04},
+                    "latency": {"mean": 0.80},
+                    "output_token_throughput": 250.0,
+                },
+            }),
         ],
     )
     write_jsonl(
         iter_01_dir / "results.jsonl",
         [
-            '{"concurrency": 1, "stats": {"ttft": {"mean": 0.08}, "tpot": {"mean": 0.03}, "latency": {"mean": 0.45}, "output_token_throughput": 110.0}}',
-            '{"concurrency": 4, "stats": {"ttft": {"mean": 0.18}, "tpot": {"mean": 0.04}, "latency": {"mean": 0.75}, "output_token_throughput": 260.0}}',
+            dump_json_line({
+                "concurrency": 1,
+                "stats": {
+                    "ttft": {"mean": 0.08},
+                    "tpot": {"mean": 0.03},
+                    "latency": {"mean": 0.45},
+                    "output_token_throughput": 110.0,
+                },
+            }),
+            dump_json_line({
+                "concurrency": 4,
+                "stats": {
+                    "ttft": {"mean": 0.18},
+                    "tpot": {"mean": 0.04},
+                    "latency": {"mean": 0.75},
+                    "output_token_throughput": 260.0,
+                },
+            }),
         ],
     )
 

--- a/tools/shellcheck.sh
+++ b/tools/shellcheck.sh
@@ -45,24 +45,29 @@ if [ -n "${SHELLCHECK_OPTS:-}" ]; then
     shellcheck_args+=("${extra_shellcheck_args[@]}")
 fi
 
-if [ "$#" -eq 0 ]; then
-    while IFS= read -r tracked_file; do
-        shellcheck "${shellcheck_args[@]}" "$tracked_file"
-    done < <(git ls-files "*.sh")
-    exit 0
-fi
-
-for file in "$@"; do
+lint_one() {
+    local file="$1"
     if git check-ignore -q "$file"; then
-        continue
+        return 0
     fi
 
     case "$file" in
         *.csh|*.tcsh)
             # Skip C shell scripts because this checker only supports sh-like shells.
-            continue
+            return 0
             ;;
     esac
 
     shellcheck "${shellcheck_args[@]}" "$file"
-done
+}
+
+if [ "$#" -gt 0 ]; then
+    for file in "$@"; do
+        lint_one "$file"
+    done
+    exit 0
+fi
+
+while IFS= read -r tracked_file; do
+    lint_one "$tracked_file"
+done < <(git ls-files "*.sh")


### PR DESCRIPTION
### What this PR does / why we need it?

Adds two new Claude Code skills under `.agents/skills/` and registers them in `.agents/README.md`:

- **`ascend-vllm-serving-auto-benchmark`**: automated 5-phase benchmark workflow for vLLM-Ascend serving on Ascend 910C (env/config validation, server launch, evalscope perf stress test, metrics collection, report generation). Ships pre-built configs for DeepSeek-V3, DeepSeek-V4-Flash, Qwen3-32B, Qwen3.5-27B, Qwen3.5-35B-A3B.
- **`ascend-vllm-serving-tune-loop`**: autonomous 7-phase performance tuning loop (RLCR principle, one lever per iteration, fixed benchmark contract, ledger discipline for crash-recovery, auto-resume wrapper for cross-session continuation, final synthesis report).
- **`.agents/README.md`**: add "Serving Auto Benchmark" and "Serving Tune Loop" sections with TOC entries, matching the existing skill documentation style.

These two skills form a pair: the tune-loop skill establishes its baseline using the same benchmarking contract as the auto-benchmark skill, and references its prerequisites. Submitting them together keeps the cross-skill reference self-consistent.

### Does this PR introduce _any_ user-facing change?

No. Adds agent skill definitions and docs only; no runtime code changes.

### How was this patch tested?

- Skill files reviewed for internal consistency (cross-skill prerequisite reference, file layout, invocation names match directory names).
- No executable code paths added to the vllm-ascend package; skills are invoked by Claude Code, not imported at runtime.
- The tune-loop skill was exercised end-to-end on a real run (Qwen3-8B, TP=2, Ascend 910C ×2) — see the example output below. The full 7-phase campaign completed, producing a structured ledger and final report.

---

### Example output from a real run

The tune-loop skill was run end-to-end against Qwen3-8B (dense, bf16, TP=2) on Ascend 910C ×2. After completion, the working directory contains one subdirectory per iteration plus the ledger and final report:

```
# tree -L 1 ./
./
├── baseline
├── extra-info
├── fa3_v1.py.orig.bak
├── final_report.md
├── iter_01
├── iter_02
├── iter_03
├── iter_04
├── iter_05
├── iter_06
├── iter_07
├── iter_08
├── iter_09
├── iter_10
├── iter_12
├── iter_13
├── iter_14
├── iter_15
├── iter_16
├── iter_17
├── iter_24
├── iter_25
├── iter_26
├── iter_27
├── kernel_meta
├── ledger.md
├── profiling
├── rms_norm.py.orig.bak
└── server.log
```

Each `iter_NN/` holds that iteration's evalscope outputs; `ledger.md` is the single source of truth (one entry per verdict, written immediately); `final_report.md` is synthesized when the loop exits. The `.orig.bak` files are backups of source edits that were reverted after measurement.

The generated `final_report.md` (26 post-baseline iterations, all 7 phases attempted):

<details>
<summary><b>final_report.md</b> (click to expand)</summary>

# vLLM-Ascend Tuning Report — qwen3-8b-chat (Qwen3-8B)

> Generated: 2026-06-25 14:30  |  Run: `./tuning_run/qwen_run_03`  |  evalscope 1.8.1  |  NPU: Ascend910 ×2 (devices 0,1)

## Summary

| Item | Value |
|------|-------|
| Model | `qwen3-8b-chat` (Qwen3-8B, dense, bf16) |
| Tensor parallel | 2 |
| Target metric (frozen) | `tpot_avg` @ c=1 (user-overridden; guard = `ttft_avg` @ c=1, >5% regression downgrades WIN→NEUTRAL) |
| Fixed workload | c=1/4, 20/80 requests, in=1024 / out=512, warmup 20 @ c=1 |
| Total iterations | 26 (post-baseline) |
| Winning levers | **0** |
| NEUTRAL | 12 |
| LOSS | 1 |
| STARTUP_FAIL | 4 |
| SKIPPED_CONFLICT | 9 |
| Overall improvement on target metric (c=1) | **0.0%** (baseline unchanged; best config = baseline) |
| Completion status | `completed` — all Phases 1–7 attempted |

**Bottom line:** No tuning lever improved `tpot_avg` at c=1. The baseline configuration is already at the performance ceiling for this workload. Every config knob that could move the decode critical path was either (a) a no-op at c=1/short-context decode, (b) an environmental incompatibility (missing module / ACL runtime error / tensor-layout assertion), or (c) inapplicable to a dense, unquantized, non-DeepSeek model. The decode loop runs inside a captured ACL graph (`FULL_DECODE_ONLY`), which already fuses and optimally schedules the kernel sequence — leaving no scheduler/fusion/comm lever with headroom at c=1.

## Baseline vs Best Configuration

Best = baseline (0 winning levers). Metrics identical.

| Concurrency | Metric | Baseline | Best | Improvement |
|-------------|--------|----------|------|-------------|
| 1 | TTFT avg (ms) | 63.0 | 63.0 | 0.0% |
| 1 | **TPOT avg (ms)** ★ target | **10.2** | **10.2** | **0.0%** |
| 1 | Output tok/s | 96.57 | 96.57 | 0.0% |
| 1 | Latency avg (ms) | 5302 | 5302 | 0.0% |
| 4 | TTFT avg (ms) | 142.5 | 142.5 | 0.0% |
| 4 | TPOT avg (ms) | 11.2 | 11.2 | 0.0% |
| 4 | Output tok/s | 348.27 | 348.27 | 0.0% |

## Winning Configuration (copy-pasteable)

No lever beat the baseline. The baseline user-provided command remains the recommended serving config:

```bash
ASCEND_RT_VISIBLE_DEVICES=0,1 vllm serve /data/models/qwen3-8b \
  --served-model-name qwen3-8b-chat \
  --tensor-parallel-size 2 \
  --host 0.0.0.0 --port 5001 \
  --trust-remote-code \
  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
```

Effective engine state at this config (from EngineCore log): `dtype=torch.bfloat16`, `enable_prefix_caching=True`, `enable_chunked_prefill=True`, custom fusions `norm_quant` + `act_quant` enabled, ACL Graph mode `FULL_DECODE_ONLY`, `cudagraph_capture_sizes=[1,2,4,...,256]`, `ir_op_priority rms_norm=['native']`.

## Optimization History (condensed)

| # | Phase / Lever | Verdict | c=1 tpot Δ | One-line reason |
|---|---------------|---------|-----------|-----------------|
| 0 | Baseline | — | — | tpot=10.2ms ttft=63.0ms @ c=1 |
| 1 | 2.1 balance_scheduling | NEUTRAL | 0.0% | no mixed-batch contention at c=1/4 |
| 2 | 2.2 cpu_binding=false | NEUTRAL | +1.0% | default(true) is better; disabling hurt |
| 3 | 2.3 block_size=128 | NEUTRAL | 0.0% | default already 128; KV-ptr chase not bottleneck at c=1 |
| 4 | 2.4 chunked_prefill mnbt=2048 | NEUTRAL | 0.0% | 1024 prefill fits one chunk; chunking is a no-op |
| 5 | 2.5 max_num_seqs=32 | NEUTRAL | 0.0% | cap not binding at c≤4 |
| 6 | 3.1 VLLM_ASCEND_ENABLE_NZ=2 | **LOSS** | **+10.8%** | forcing NZ on all ops adds conversion overhead on decode |
| 7 | 3.2 npugraph_ex+static_kernel | NEUTRAL | 0.0% | graph already captured; static precomp no extra gain |
| 8 | 3.3 fuse_norm_quant=false | SKIPPED | — | flag lives in `pass_config`, not `ascend_compilation_config`; not applied |
| 9 | 3.4 fuse_allreduce_rms=true | STARTUP_FAIL | — | `fused_add_rms_norm` op not registered in this build |
| 10 | 3.5 MATMUL_ALLREDUCE=1 | NEUTRAL | 0.0% | no compute to overlap at c=1 |
| 11 | 3.6 GMM-SwiGLU-Quant | SKIPPED | — | MoE-only; model is dense |
| 12 | 3.7 XliteGraph | STARTUP_FAIL | — | `ModuleNotFoundError: No module named 'xlite'` |
| 13 | 4.1 flashcomm1 | STARTUP_FAIL | — | `ACL stream synchronize failed, error code:507015` |
| 14 | 4.2 flashcomm2 PS=1 | STARTUP_FAIL | — | tensor stride assertion (4096 vs 2048) |
| 15 | 4.3 prefill_comm_compute_overlap | NEUTRAL | 0.0% | overlap overhead > gain at c=1; ttft +6.8% |
| 16 | 4.4 HCCL_BUFFSIZE=200 | NEUTRAL | 0.0% | decode allreduce payload tiny; buffer irrelevant |
| 17 | 5.1 weight_prefetch | NEUTRAL | 0.0% | graph already schedules weights optimally |
| 18 | 5.2 MLAPO | SKIPPED | — | DeepSeek W8A8 only; model is bf16 |
| 19 | 5.3 fused MC2 | SKIPPED | — | MoE W8A8+EP only; dense/unquantized |
| 20 | 6.1 shared_expert overlap | SKIPPED | — | MoE only |
| 21 | 6.2 gate overlap | SKIPPED | — | MoE only |
| 22 | 6.3 dsa_preprocess | SKIPPED | — | DeepSeek Sparse Attention only |
| 23 | 6.4 dsv4_dsa_overlap | SKIPPED | — | DeepSeek V4 only |
| 24 | 7.1/7.2 profiling trace | SKIPPED | — | graph mode hides per-op kernels from torch profiler |
| 25 | 7.3a rms_norm ROW_BLOCK_SIZE 16→32 | NEUTRAL | 0.0% | rms_norm routes to native ACLNN, not this Triton kernel |
| 26 | 7.3b fa3 num_splits 1→2 | NEUTRAL | 0.0% | single-token/short-KV decode has no work to split |

## Levers That Did Not Help (no-ops at c=1, reverted)

- **2.1 balance_scheduling** — only helps mixed prefill+decode batching contention; absent at c=1/4.
- **2.2 cpu_binding=false** — default `true` (NUMA binding) is already optimal here; disabling regressed c=1 by ~1%.
- **2.3 block_size=128** — engine default already resolves to 128; KV-cache pointer chasing is not the c=1 bottleneck.
- **2.4 chunked_prefill (mnbt=2048)** — at 1024 input tokens the prefill fits one chunk, so chunking never engages.
- **2.5 max_num_seqs=32** — cap is not binding when ≤4 sequences are concurrent.
- **3.2 npugraph_ex + static_kernel** — `FULL_DECODE_ONLY` ACL Graph already captures the decode graph; static pre-compilation adds startup time with no per-step gain.
- **3.5 MATMUL_ALLREDUCE=1** — at c=1 there is too little matmul compute to overlap with the allreduce.
- **4.3 prefill_comm_compute_overlap** — overlap machinery costs more than it saves for a single 1024-token prefill (TTFT +6.8%); TPOT unaffected.
- **4.4 HCCL_BUFFSIZE=200** — the per-decode-step allreduce payload is a few KB; buffer fragmentation is not the bottleneck.
- **5.1 weight_prefetch** — captured graph already schedules weight loads optimally; explicit prefetch adds no HBM-latency hiding at c=1.
- **7.3a rms_norm ROW_BLOCK_SIZE=32** — `ir_op_priority rms_norm=['native']`: rms_norm uses the native ACLNN path, not this Triton kernel.
- **7.3b fa3 num_splits=2** — single decode token against short KV has insufficient work to amortize split-across-cores overhead.

## Failed / Incompatible Levers

| Lever | Verdict | Stage | Reason | Evidence |
|-------|---------|-------|--------|----------|
| `3.4 fuse_allreduce_rms=true` | `STARTUP_FAIL` | `server_startup` | fused op missing in this vllm-ascend/CANN build | `AttributeError: '_OpNamespace' '_C' object has no attribute 'fused_add_rms_norm'` → `Engine core initialization failed` (flag WAS applied via corrected `pass_config` path) |
| `3.7 XliteGraph enabled=true` | `STARTUP_FAIL` | `server_startup` | required `xlite` Python package not installed | `ModuleNotFoundError: No module named 'xlite'` at `vllm_ascend/xlite/xlite.py:34` |
| `4.1 enable_flashcomm1=true` | `STARTUP_FAIL` | `server_startup` | ACL stream sync incompatible with this CANN runtime / graph-mode interaction | `RuntimeError: Worker failed with error 'ACL stream synchronize failed, error code:507015'` |
| `4.2 FLASHCOMM2_PARALLEL_SIZE=1` | `STARTUP_FAIL` | `server_startup` | FlashComm2 overlap kernel tensor-layout mismatch with Qwen3-8B | `Worker failed with error 'expected size 4096==4096, stride 4096==2048 at dim=0; ...'` (independent of PS value; tp/2, tp not retried) |
| `3.3 fuse_norm_quant=false` | `SKIPPED_CONFLICT` | `precheck` | documented `--additional-config` path does not reach the flag; it lives in `compilation_config.pass_config` | log still showed `pass_config: {'fuse_norm_quant': True}` + `Enabled custom fusions: norm_quant` after attempt. Corrected mechanism: `--compilation-config '{"pass_config":{"fuse_norm_quant":false}}'` |
| `3.6 GMM-SwiGLu-Quant` | `SKIPPED_CONFLICT` | `precheck` | MoE-only; Qwen3-8B is dense | no MoE expert/grouped-matmul layers |
| `5.2 MLAPO` | `SKIPPED_CONFLICT` | `precheck` | DeepSeek W8A8 only; model is bf16 unquantized | `quantization=None` |
| `5.3 fused MC2` | `SKIPPED_CONFLICT` | `precheck` | MoE W8A8 + EP only; dense/unquantized/TP-only | no EP config |
| `6.1 multistream_overlap_shared_expert` | `SKIPPED_CONFLICT` | `precheck` | MoE only | no shared expert |
| `6.2 multistream_overlap_gate` | `SKIPPED_CONFLICT` | `precheck` | MoE only | no router/gate |
| `6.3 multistream_dsa_preprocess` | `SKIPPED_CONFLICT` | `precheck` | DeepSeek Sparse Attention only | standard attention |
| `6.4 multistream_dsv4_dsa_overlap` | `SKIPPED_CONFLICT` | `precheck` | DeepSeek V4 only | not a DeepSeek model |
| `7.1/7.2 profiling op-classification` | `SKIPPED_CONFLICT` | `profiling analysis` | torch trace captured only host-side Python events; no NPU kernel visibility | 5.67M events all `python_function`; zero `aclnn`/`matmul`/`rms_norm`/`attention` kernel events — `FULL_DECODE_ONLY` graph mode hides per-op kernels |

## Manual Intervention Required

**1. Per-op kernel profiling is blocked by graph mode.**
The torch profiler trace (`profiling/*.trace.json.gz`, 121MB, 5.67M events) contains **only host-side Python function events** — zero NPU kernel events. Root cause: `cudagraph_mode=FULL_DECODE_ONLY` executes decode as a single captured ACL graph replay, so individual kernels (`aclnn*`, matmul, rms_norm, attention, hccl) are fused behind the graph-replay boundary and never appear as separate profiler events. The Ascend per-rank dirs (`rank0/1_*_ascend_pt`) emitted only raw binary `slice_*` host/device slices; no CSV op-summary was produced via the torch-profiler path.

To identify the actual top-N slowest operators and tune them, run **`msprof` directly** (outside the torch profiler), which captures device-side op-level stats even under graph mode:
```bash
msprof --application="vllm serve <baseline_cmd>" --output=./msprof_out --aic-metrics=PipeUtilization
# then inspect msprof_out/PROF_*/summary/csv/op_summary_*.csv for top ops by aicore time
```
This was not done in this run (msprof availability was optional and the torch-profiler path was attempted first per the phase doc).

**2. Non-tunable (ACLNN) ops likely dominate the decode path.**
Even with msprof, several decode ops are not source-tunable:
- `rms_norm` → routed to native ACLNN (`ir_op_priority rms_norm=['native']`); the Triton `ROW_BLOCK_SIZE` in `ops/triton/rms_norm.py` is NOT on the hot path (confirmed: editing 16→32 had zero effect).
- `matmul`/`gemm` → ACLNN-backed on Ascend; block sizes (`BLOCK_M/N/K`) in `ops/triton/batch_invariant/matmul.py` are not on the path.
- `flash_attention` (fa3) → calls `torch_npu.flash_attn_with_kvcache` (ACLNN); `num_splits` is the only user-knob and had no effect at c=1/short-KV.
- Any `aclnn*` op → tiling decided at CANN op-compile time.

If msprof shows an `aclnn*` op dominating (e.g. `aclnnFlashAttention`, `aclnnMatmul`, `aclnnGroupedMatmul`), the tuning levers are: (a) CANN AOE offline tiling for the specific input shapes, or (b) a newer CANN/vllm-ascend build with an optimized op binary.

**3. Environmental fixes that would unlock crashed levers.**
- `3.7 XliteGraph`: install the `xlite` wheel matching the installed CANN/vllm-ascend version.
- `3.4 fuse_allreduce_rms` / `4.1 flashcomm1` / `4.2 flashcomm2`: require a vllm-ascend/CANN build where `fused_add_rms_norm` is registered and the FlashComm ACL-stream / tensor-layout paths are compatible with this model. Verify against the vllm-ascend release notes for the installed CANN version.

## Recommended Next Steps

1. **Run `msprof` directly** (command above) to get device-side per-op timing under graph mode — this is the only way to see whether decode is matmul-bound, attention-bound, or comm-bound at c=1, and is the prerequisite for any further kernel-level work.
2. **Re-benchmark at higher concurrency / longer context** if the real deployment target is c≥8 or input >>2048 tokens: several no-op levers here (chunked_prefill, balance_scheduling, weight_prefetch, matmul_allreduce, HCCL_BUFFSIZE, fa3 num_splits) are designed for exactly those regimes and would show real effects there. The c=1/short-context workload simply has no headroom for them.
3. **Upgrade vllm-ascend/CANN** to re-test the 4 STARTUP_FAIL levers (fuse_allreduce_rms, XliteGraph, flashcomm1/2) — these are the levers most likely to help TP=2 decode if the build incompatibilities are resolved.
4. **If TPOT 10.2ms/c=1 must drop further**, the ceiling is the ACL graph's fused kernel sequence; the only remaining levers are CANN-version upgrades or AOE offline tiling of the dominant `aclnn*` op identified by msprof — both are off-repo, vendor-side actions.

## Artifacts

- Ledger (single source of truth): `tuning_run/qwen_run_03/ledger.md`
- Per-iteration evalscope outputs: `tuning_run/qwen_run_03/iter_NN/outputs/*/qwen3-8b-chat/`
- Baseline: `tuning_run/qwen_run_03/baseline/outputs/20260625_105733/qwen3-8b-chat/`
- Profiling trace: `tuning_run/qwen_run_03/profiling/` (chrome trace + ascend_pt ranks)
- Source-edit backups (reverted): `rms_norm.py.orig.bak`, `fa3_v1.py.orig.bak` (both restored to original in the vllm-ascend tree)

</details>

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
