### PR TITLE
[KVPool][AscendStore] Async lookup to reduce scheduler overhead

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -15,6 +15,8 @@
 # This file is a part of the vllm-ascend project.
 #
 
+import threading
+import time
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -246,6 +248,33 @@ class TestKVPoolScheduler(unittest.TestCase):
         self.assertEqual(need, 48)
         self.assertTrue(is_async)
 
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_get_num_new_matched_tokens_lookup_async_defers_then_reports(self, mock_client_cls):
+        """lookup_async returns (None, False) until ready, then the hit count."""
+        config = self._make_config(extra_config={"lookup_async": True})
+        scheduler = KVPoolScheduler(config, use_layerwise=False)
+        self.assertTrue(scheduler.lookup_async)
+        mock_client = mock_client_cls.return_value
+
+        request = MagicMock()
+        request.prompt_token_ids = list(range(64))
+        request.num_tokens = 64
+        request.request_id = "r1"
+        request.block_hashes = [b"h"] * 4
+
+        # Lookup not ready -> defer.
+        mock_client.lookup.return_value = None
+        self.assertEqual(scheduler.get_num_new_matched_tokens(request, 0), (None, False))
+        self.assertNotIn("r1", scheduler.load_specs)
+        # The lookup was issued in non-blocking mode.
+        self.assertTrue(mock_client.lookup.call_args.kwargs["non_block"])
+
+        # Lookup ready with a hit -> report need_to_allocate.
+        mock_client.lookup.return_value = 48
+        need, _ = scheduler.get_num_new_matched_tokens(request, 0)
+        self.assertEqual(need, 48)
+        self.assertIn("r1", scheduler.load_specs)
+
 
 class TestKVPoolSchedulerBuildMeta(unittest.TestCase):
     def _make_config(self, kv_role="kv_producer", block_size=16):
@@ -387,9 +416,86 @@ class TestLookupKeyClient(unittest.TestCase):
         mock_socket.recv.return_value = (32).to_bytes(4, "big")
 
         client = LookupKeyClient(config)
-        result = client.lookup(64, [b"\xaa\xbb"])
+        # Blocking lookup (non_block defaults to False) runs on the executor
+        # and returns the resolved hit length.
+        result = client.lookup("req0", 64, [b"\xaa\xbb"])
         self.assertEqual(result, 32)
         mock_socket.send_multipart.assert_called_once()
+        # Future is consumed on read.
+        self.assertNotIn("req0", client.futures)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.make_zmq_socket")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.zmq")
+    def test_non_block_lookup_async(self, mock_zmq, mock_make_socket):
+        """Non-blocking lookup defers to the executor: None first, hit once
+        the Future resolves."""
+        config = MagicMock()
+        config.parallel_config.data_parallel_rank = 0
+        config.kv_transfer_config.kv_connector_extra_config = {}
+
+        mock_socket = MagicMock()
+        mock_make_socket.return_value = mock_socket
+        # Hold the executor's lookup pending until we release the gate.
+        gate = threading.Event()
+
+        def gated_recv():
+            gate.wait()
+            return (7).to_bytes(4, "big")
+
+        mock_socket.recv.side_effect = gated_recv
+
+        client = LookupKeyClient(config)
+        # First query submits the lookup and returns None while in flight.
+        self.assertIsNone(client.lookup("req1", 64, [], non_block=True))
+        # Release the executor; a later poll returns the hit length.
+        gate.set()
+        deadline = time.monotonic() + 5.0
+        result = None
+        while time.monotonic() < deadline:
+            result = client.lookup("req1", 64, [], non_block=True)
+            if result is not None:
+                break
+            time.sleep(0.005)
+        self.assertEqual(result, 7)
+        # Future is consumed (popped) on read.
+        self.assertNotIn("req1", client.futures)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.make_zmq_socket")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.zmq")
+    def test_discard_clears_state(self, mock_zmq, mock_make_socket):
+        """discard() drops an in-flight/completed lookup so it is not served
+        stale."""
+        config = MagicMock()
+        config.parallel_config.data_parallel_rank = 0
+        config.kv_transfer_config.kv_connector_extra_config = {}
+
+        mock_socket = MagicMock()
+        mock_make_socket.return_value = mock_socket
+        gate = threading.Event()
+
+        def gated_recv():
+            gate.wait()
+            return (9).to_bytes(4, "big")
+
+        mock_socket.recv.side_effect = gated_recv
+
+        client = LookupKeyClient(config)
+        # Submit while gated so the call returns None and the Future stays in
+        # `futures` once it resolves.
+        self.assertIsNone(client.lookup("req2", 64, [], non_block=True))
+        gate.set()
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if client.futures["req2"].done():
+                break
+            time.sleep(0.005)
+        # discard() drops the completed result before any lookup consumes it.
+        client.discard("req2")
+        self.assertNotIn("req2", client.futures)
+        # A fresh query re-submits rather than returning a stale value.
+        gate.clear()
+        self.assertIsNone(client.lookup("req2", 64, [], non_block=True))
+        gate.set()  # release the executor so the worker thread can drain
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.make_zmq_socket")
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.zmq")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -117,7 +117,9 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
     # Scheduler Side Methods
     ############################################################
 
-    def get_num_new_matched_tokens(self, request: "Request", num_computed_tokens: int) -> tuple[int, bool]:
+    def get_num_new_matched_tokens(
+        self, request: "Request", num_computed_tokens: int
+    ) -> tuple[int | None, bool]:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.get_num_new_matched_tokens(request, num_computed_tokens)
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -1,4 +1,5 @@
 import math
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, cast
 
 import vllm.envs as envs
@@ -79,6 +80,13 @@ class KVPoolScheduler:
             "consumer_is_to_put", False
         )
         self.load_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get("load_async", False)
+        # Opt-in: offload the external KV lookup to a background thread so its
+        # ZMQ round-trip overlaps with the current scheduling step instead of
+        # blocking it. When enabled, get_num_new_matched_tokens may return
+        # (None, False) to defer the request to a later step.
+        self.lookup_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
+            "lookup_async", False
+        )
         self.client = LookupKeyClient(vllm_config)
         # request_id -> (vllm cached tokes, kvpool cached tokens)
         self.load_specs: dict[str, LoadSpec] = {}
@@ -228,7 +236,7 @@ class KVPoolScheduler:
         self,
         request: "Request",
         num_computed_tokens: int,
-    ) -> tuple[int, bool]:
+    ) -> tuple[int | None, bool]:
         """
         Check for external KV cache hit.
 
@@ -240,6 +248,11 @@ class KVPoolScheduler:
         Returns:
             the number of tokens that can be loaded from the
             external KV cache beyond what is already computed.
+
+            Returns ``(None, False)`` when an async lookup is still in flight
+            (``lookup_async`` enabled); the V1 scheduler understands a ``None``
+            external-token count and re-queues the request to retry on a later
+            step, so the lookup latency overlaps with the current step.
         """
         if self.kv_role == "kv_consumer" and not self.consumer_is_to_load:
             return 0, False
@@ -253,10 +266,17 @@ class KVPoolScheduler:
             return 0, False
 
         num_external_hit_tokens = self.client.lookup(
+            request.request_id,
             token_len,
             request.block_hashes,
             self.kv_cache_group_ids,
+            non_block=self.lookup_async,
         )
+
+        if num_external_hit_tokens is None:
+            # Async lookup not ready yet; defer so the scheduler retries this
+            # request on a later step.
+            return None, False
 
         if num_external_hit_tokens == request.num_tokens:
             num_external_hit_tokens -= 1
@@ -361,12 +381,19 @@ class KVPoolScheduler:
         force_skip_save = self.kv_role == "kv_consumer" and not self.consumer_is_to_put
 
         for finished_req_id in scheduler_output.finished_req_ids:
+            # Drop any in-flight/completed async lookup so a stale result is
+            # never served for a request that is already gone.
+            self.client.discard(finished_req_id)
             self._request_trackers.pop(finished_req_id, None)
             self._unfinished_requests.pop(finished_req_id, None)
             self._unfinished_request_ids.discard(finished_req_id)
             self._preempted_req_ids.discard(finished_req_id)
 
         for req_id in scheduler_output.preempted_req_ids:
+            # A preempted request re-issues its lookup when it is re-scheduled;
+            # discard the old Future so it re-submits rather than reusing a
+            # stale hit length.
+            self.client.discard(req_id)
             self._preempted_req_ids.update(scheduler_output.preempted_req_ids)
             self._request_trackers.pop(req_id, None)
             self._unfinished_requests.pop(req_id, None)
@@ -650,7 +677,15 @@ class LookupKeyClient:
             bind=False,
         )
 
-    def lookup(
+        # Async lookup support. A single worker thread keeps the ZMQ REQ
+        # socket's strict send/recv ordering and avoids the need for a lock,
+        # since the socket is never touched from more than one thread.
+        self.executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="AscendStoreLookupClient"
+        )
+        self.futures: dict[str, Future[int]] = {}
+
+    def _lookup(
         self,
         token_len: int,
         block_hashes: list[BlockHash],
@@ -667,7 +702,48 @@ class LookupKeyClient:
         result = int.from_bytes(resp, "big")
         return result
 
+    def lookup(
+        self,
+        req_id: str,
+        token_len: int,
+        block_hashes: list[BlockHash],
+        kv_cache_group_ids: list[int] | None = None,
+        non_block: bool = False,
+    ) -> int | None:
+        """Look up the external KV hit length for ``req_id``.
+
+        When ``non_block`` is True the lookup runs on the background executor:
+        the first call submits it and returns ``None`` while it is in flight,
+        and a later call returns the resolved hit length once the Future is
+        done, so the caller retries on a later step. When ``non_block`` is
+        False the call blocks on the executor and behaves like the original
+        synchronous lookup.
+        """
+        future = self.futures.get(req_id)
+        if future is None:
+            future = self.executor.submit(
+                self._lookup, token_len, list(block_hashes), kv_cache_group_ids
+            )
+            self.futures[req_id] = future
+        if non_block and not future.done():
+            return None
+        try:
+            return future.result()
+        except Exception as e:
+            logger.error("Async ascend-store lookup failed for %s: %s", req_id, e)
+            return 0
+        finally:
+            # The result is consumed on read; a subsequent query re-submits.
+            self.futures.pop(req_id, None)
+
+    def discard(self, req_id: str) -> None:
+        """Drop any cached/in-flight lookup for ``req_id`` (abort/finish/preempt)."""
+        future = self.futures.pop(req_id, None)
+        if future is not None:
+            future.cancel()
+
     def close(self):
+        self.executor.shutdown(wait=False, cancel_futures=True)
         self.socket.close(linger=0)
 
 


### PR DESCRIPTION
Offload the external KV lookup in the ascend_store connector to a background thread so its ZMQ round-trip overlaps with the current scheduling step instead of blocking it.

- LookupKeyClient: run lookups on a single-worker ThreadPoolExecutor with a per-request Future. A non-blocking lookup returns None while in flight and the resolved hit length once done; add discard() to drop in-flight/completed lookups on finish/abort/preempt.
- KVPoolScheduler: add opt-in lookup_async flag (default False). When enabled, get_num_new_matched_tokens returns (None, False) to defer; the V1 scheduler already re-queues requests on a None hit count.
- Widen get_num_new_matched_tokens return type to tuple[int | None, bool].
- Discard lookups for finished/preempted requests in build_connector_meta.
- Tests for the async submit/poll path, discard(), and scheduler deferral.

Default is False, so existing deployments keep synchronous behavior.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
