### PR TITLE
[BugFix] Support group-aligned TP sharding for MXFP8 ViT MLP

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -293,6 +293,7 @@
     - vllm_ascend/ops/layernorm.py
     - vllm_ascend/ops/linear.py
     - vllm_ascend/ops/linear_op.py
+    - vllm_ascend/ops/group_aligned_linear.py
     - vllm_ascend/ops/rotary_embedding.py
     - vllm_ascend/ops/vocab_parallel_embedding.py
     - vllm_ascend/ops/register_custom_ops.py

--- a/tests/ut/ops/test_group_aligned_linear.py
+++ b/tests/ut/ops/test_group_aligned_linear.py
@@ -1,0 +1,79 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from vllm_ascend.ops.group_aligned_linear import group_aligned_partition
+
+
+def _cdiv(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+@pytest.mark.parametrize(
+    "total, tp_size, group_size, expected_elems, expected_groups",
+    [
+        # Qwen3-VL vision MLP fc2: 4304 is not a multiple of 64 -> uneven split.
+        (4304, 2, 32, [2176, 2128], [68, 67]),
+        # attn.proj / aligned dims -> reduces to the plain even split.
+        (1152, 2, 32, [576, 576], [18, 18]),
+        # merger fc2 -> aligned, even split (each rank owns 72 of the 144 groups).
+        (4608, 2, 32, [2304, 2304], [72, 72]),
+        # tp=1 -> the full tensor.
+        (4304, 1, 32, [4304], [135]),
+        # tp=4 over an unaligned dim.
+        (4304, 4, 32, [1088, 1088, 1088, 1040], [34, 34, 34, 33]),
+    ],
+)
+def test_group_aligned_partition_expected(total, tp_size, group_size, expected_elems, expected_groups):
+    elem_sizes, group_sizes = group_aligned_partition(total, tp_size, group_size)
+    assert elem_sizes == expected_elems
+    assert group_sizes == expected_groups
+
+
+# Realistic (non-degenerate) dims: num_groups >= tp_size so every rank owns at
+# least one group. The degenerate "more ranks than groups" case never happens
+# for a real ViT MLP and is intentionally out of scope.
+@pytest.mark.parametrize("total", [4304, 1152, 4608, 4096, 2048, 8192])
+@pytest.mark.parametrize("tp_size", [1, 2, 4, 8])
+@pytest.mark.parametrize("group_size", [16, 32, 64])
+def test_group_aligned_partition_invariants(total, tp_size, group_size):
+    elem_sizes, group_sizes = group_aligned_partition(total, tp_size, group_size)
+
+    # Shapes line up with the rank count.
+    assert len(elem_sizes) == tp_size
+    assert len(group_sizes) == tp_size
+
+    # Partitions tile the whole tensor and the whole group axis.
+    assert sum(elem_sizes) == total
+    assert sum(group_sizes) == _cdiv(total, group_size)
+
+    # No negative sizes.
+    assert all(e >= 0 for e in elem_sizes)
+    assert all(g >= 0 for g in group_sizes)
+
+    # The key invariant: the per-rank scale dim that create_weights derives via
+    # ceil(input_size_per_partition / group_size) must equal the group count we
+    # slice the checkpoint scale by -- otherwise weight and scale would diverge.
+    for e, g in zip(elem_sizes, group_sizes):
+        assert _cdiv(e, group_size) == g
+
+    # Every boundary but the last lands on a group boundary (multiple of
+    # group_size), so no MX group is cut across ranks.
+    boundary = 0
+    for e in elem_sizes[:-1]:
+        boundary += e
+        assert boundary % group_size == 0

--- a/tests/ut/quantization/test_method_adapters.py
+++ b/tests/ut/quantization/test_method_adapters.py
@@ -2,7 +2,8 @@ from unittest.mock import MagicMock, patch
 
 import torch
 from vllm.model_executor.layers.fused_moe import FusedMoeWeightScaleSupported
-from vllm.model_executor.layers.linear import ColumnParallelLinear
+from vllm.model_executor.layers.linear import ColumnParallelLinear, RowParallelLinear
+from vllm.utils.math_utils import cdiv
 
 from tests.ut.base import TestBase
 from vllm_ascend.quantization.method_adapters import (
@@ -10,6 +11,7 @@ from vllm_ascend.quantization.method_adapters import (
     AscendKVCacheMethod,
     AscendLinearMethod,
 )
+from vllm_ascend.quantization.methods import AscendW8A8MXFP8DynamicLinearMethod
 from vllm_ascend.quantization.methods.base import AscendAttentionScheme, AscendLinearScheme, AscendMoEScheme
 
 
@@ -190,3 +192,211 @@ class TestAscendFusedMoEMethod(TestBase):
         self.mock_scheme.apply.return_value = None
         self.method.apply(layer, x, router_logits, top_k, renormalize)
         self.mock_scheme.apply.assert_called_once()
+
+
+def _make_layer(base_cls, **attrs):
+    """Build a Row/ColumnParallelLinear without running its heavy __init__.
+
+    ``isinstance`` still holds (real base class) and ``register_parameter`` works
+    (Module is initialized), while only the attributes create_weights reads/writes
+    are injected.
+    """
+    layer = base_cls.__new__(base_cls)
+    torch.nn.Module.__init__(layer)
+    for k, v in attrs.items():
+        setattr(layer, k, v)
+    return layer
+
+
+class TestAscendLinearMethodGroupAlign(TestBase):
+    """MXFP8 group-aligned TP sharding in AscendLinearMethod.create_weights.
+
+    Uses intermediate_size=4304 (Qwen3-VL ViT MLP), which is not a multiple of
+    group_size(32) * tp_size(2): the group-aligned split is [2176, 2128] elements /
+    [68, 67] groups.
+    """
+
+    GROUP = 32
+
+    def _scheme(self, spec):
+        scheme = MagicMock(spec=spec)
+        scheme.group_size = self.GROUP
+        scheme.get_weight.side_effect = lambda in_p, out_p, dt: {"weight": torch.empty(out_p, in_p, dtype=torch.int8)}
+        scheme.get_pertensor_param.return_value = {}
+        scheme.get_perchannel_param.return_value = {}
+        scheme.get_pergroup_param.side_effect = lambda in_p, out_p, dt, layer_type=None: {
+            "weight_scale": torch.empty(out_p, cdiv(in_p, self.GROUP), dtype=torch.uint8)
+        }
+        return AscendLinearMethod(scheme)
+
+    def _mxfp8(self):
+        return self._scheme(AscendW8A8MXFP8DynamicLinearMethod)
+
+    def test_row_uneven_partition(self):
+        # MXFP8 RowParallel splits the grouped input dim on group boundaries.
+        for rank, exp_elem, exp_groups in [(0, 2176, 68), (1, 2128, 67)]:
+            method = self._mxfp8()
+            weight_loader = MagicMock()
+            layer = _make_layer(RowParallelLinear, tp_size=2, tp_rank=rank, prefix="fc2")
+            method.create_weights(
+                layer,
+                input_size_per_partition=2152,  # vLLM's even split, overridden below
+                output_partition_sizes=[512],
+                input_size=4304,
+                output_size=512,
+                params_dtype=torch.bfloat16,
+                weight_loader=weight_loader,
+            )
+            self.assertEqual(layer.input_size_per_partition, exp_elem)
+            self.assertEqual(tuple(layer.weight.shape), (512, exp_elem))
+            self.assertEqual(tuple(layer.weight_scale.shape), (512, exp_groups))
+            self.assertIsNot(layer.weight.weight_loader, weight_loader)
+            self.assertIsNot(layer.weight_scale.weight_loader, weight_loader)
+            # full checkpoint narrowed on the aligned boundaries
+            layer.weight.weight_loader(layer.weight, torch.zeros(512, 4304, dtype=torch.int8))
+            layer.weight_scale.weight_loader(layer.weight_scale, torch.zeros(512, 135, dtype=torch.uint8))
+            self.assertEqual(tuple(layer.weight.shape), (512, exp_elem))
+            self.assertEqual(tuple(layer.weight_scale.shape), (512, exp_groups))
+
+    def test_column_uneven_partition(self):
+        # MXFP8 single-shard ColumnParallel splits the output dim on the same
+        # boundaries so fc1 output shards match the paired fc2 input shards.
+        for rank, exp_elem in [(0, 2176), (1, 2128)]:
+            method = self._mxfp8()
+            weight_loader = MagicMock()
+            layer = _make_layer(ColumnParallelLinear, tp_size=2, tp_rank=rank, gather_output=False, prefix="fc1")
+            method.create_weights(
+                layer,
+                input_size_per_partition=512,
+                output_partition_sizes=[2152],
+                input_size=512,
+                output_size=4304,
+                params_dtype=torch.bfloat16,
+                weight_loader=weight_loader,
+            )
+            self.assertEqual(layer.output_size_per_partition, exp_elem)
+            self.assertEqual(layer.output_partition_sizes, [exp_elem])
+            self.assertEqual(tuple(layer.weight.shape), (exp_elem, 512))
+            self.assertEqual(tuple(layer.weight_scale.shape), (exp_elem, cdiv(512, self.GROUP)))
+            self.assertIsNot(layer.weight.weight_loader, weight_loader)
+            full_scale = torch.zeros(4304, cdiv(512, self.GROUP), dtype=torch.uint8)
+            layer.weight.weight_loader(layer.weight, torch.zeros(4304, 512, dtype=torch.int8))
+            layer.weight_scale.weight_loader(layer.weight_scale, full_scale)
+            self.assertEqual(tuple(layer.weight.shape), (exp_elem, 512))
+
+    def test_divisible_no_align(self):
+        # 4096 % (32*2) == 0 -> no override, native loader kept.
+        method = self._mxfp8()
+        weight_loader = MagicMock()
+        layer = _make_layer(RowParallelLinear, tp_size=2, tp_rank=0, prefix="x")
+        method.create_weights(
+            layer,
+            input_size_per_partition=2048,
+            output_partition_sizes=[512],
+            input_size=4096,
+            output_size=512,
+            params_dtype=torch.bfloat16,
+            weight_loader=weight_loader,
+        )
+        self.assertIs(layer.weight.weight_loader, weight_loader)
+        self.assertIs(layer.weight_scale.weight_loader, weight_loader)
+
+    def test_non_mxfp8_no_align(self):
+        # Non-MXFP8 scheme never group-aligns even on an unaligned size.
+        method = self._scheme(AscendLinearScheme)
+        weight_loader = MagicMock()
+        layer = _make_layer(RowParallelLinear, tp_size=2, tp_rank=0, prefix="x")
+        method.create_weights(
+            layer,
+            input_size_per_partition=2152,
+            output_partition_sizes=[512],
+            input_size=4304,
+            output_size=512,
+            params_dtype=torch.bfloat16,
+            weight_loader=weight_loader,
+        )
+        self.assertIs(layer.weight.weight_loader, weight_loader)
+
+    def test_tp1_no_align(self):
+        method = self._mxfp8()
+        weight_loader = MagicMock()
+        layer = _make_layer(RowParallelLinear, tp_size=1, tp_rank=0, prefix="x")
+        method.create_weights(
+            layer,
+            input_size_per_partition=4304,
+            output_partition_sizes=[512],
+            input_size=4304,
+            output_size=512,
+            params_dtype=torch.bfloat16,
+            weight_loader=weight_loader,
+        )
+        self.assertIs(layer.weight.weight_loader, weight_loader)
+
+    def test_merged_column_no_align(self):
+        # Multi-shard column (gate_up/qkv) is out of scope -> no override.
+        method = self._mxfp8()
+        weight_loader = MagicMock()
+        layer = _make_layer(ColumnParallelLinear, tp_size=2, tp_rank=0, gather_output=False, prefix="gate_up")
+        method.create_weights(
+            layer,
+            input_size_per_partition=512,
+            output_partition_sizes=[2152, 2152],
+            input_size=512,
+            output_size=4304,
+            params_dtype=torch.bfloat16,
+            weight_loader=weight_loader,
+        )
+        self.assertIs(layer.weight.weight_loader, weight_loader)
+
+    def test_gather_output_no_align(self):
+        method = self._mxfp8()
+        weight_loader = MagicMock()
+        layer = _make_layer(ColumnParallelLinear, tp_size=2, tp_rank=0, gather_output=True, prefix="x")
+        method.create_weights(
+            layer,
+            input_size_per_partition=512,
+            output_partition_sizes=[2152],
+            input_size=512,
+            output_size=4304,
+            params_dtype=torch.bfloat16,
+            weight_loader=weight_loader,
+        )
+        self.assertIs(layer.weight.weight_loader, weight_loader)
+
+    def test_column_bias_no_align(self):
+        # Single-shard column with bias=True is out of scope: the bias is built
+        # after create_weights with the native even split, so group-aligning the
+        # weight would desync it. The native loader must be kept.
+        method = self._mxfp8()
+        weight_loader = MagicMock()
+        layer = _make_layer(
+            ColumnParallelLinear, tp_size=2, tp_rank=0, gather_output=False, has_bias=True, prefix="fc1"
+        )
+        method.create_weights(
+            layer,
+            input_size_per_partition=512,
+            output_partition_sizes=[2152],
+            input_size=512,
+            output_size=4304,
+            params_dtype=torch.bfloat16,
+            weight_loader=weight_loader,
+        )
+        self.assertIs(layer.weight.weight_loader, weight_loader)
+
+    def test_loader_fallback_on_presharded(self):
+        # An already-sharded tensor (input dim != full) falls back to orig loader.
+        method = self._mxfp8()
+        weight_loader = MagicMock()
+        layer = _make_layer(RowParallelLinear, tp_size=2, tp_rank=0, prefix="fc2")
+        method.create_weights(
+            layer,
+            input_size_per_partition=2152,
+            output_partition_sizes=[512],
+            input_size=4304,
+            output_size=512,
+            params_dtype=torch.bfloat16,
+            weight_loader=weight_loader,
+        )
+        presharded = torch.zeros(512, 2176, dtype=torch.int8)
+        layer.weight.weight_loader(layer.weight, presharded)
+        weight_loader.assert_called_once_with(layer.weight, presharded)

--- a/vllm_ascend/ops/group_aligned_linear.py
+++ b/vllm_ascend/ops/group_aligned_linear.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Group-aligned tensor-parallel partitioning for MX-quantized weights.
+
+MX (microscaling) quantization groups every ``group_size`` (e.g. 32) elements
+along the input dimension and stores one shared scale per group. Splitting such
+a weight across tensor-parallel ranks is only numerically valid if every
+partition boundary lands on a group boundary -- otherwise a single group is cut
+across two ranks and its scale can no longer be applied correctly.
+
+Plain even sharding (``size // tp_size``) breaks this when the sharded
+dimension is not a multiple of ``group_size * tp_size``. For the Qwen3-VL vision
+MLP the intermediate size is ``4304`` which is not a multiple of ``64`` (tp=2),
+so the even split ``2152`` falls inside group #67 and the weight_scale load
+fails with a ``narrow ... exceeds dimension size`` error.
+
+:func:`group_aligned_partition` instead splits the sharded dimension on **group
+boundaries**: groups are distributed as evenly as possible (earlier ranks get
+the +1) and the last rank absorbs the trailing partial group. This yields an
+uneven but group-aligned partition (e.g. tp=2 -> ``[2176, 2128]`` elements /
+``[68, 67]`` groups for 4304) that is correct for the row all-reduce. It is
+consumed by ``AscendLinearMethod.create_weights`` (see ``method_adapters.py``).
+"""
+
+
+def group_aligned_partition(total: int, tp_size: int, group_size: int) -> tuple[list[int], list[int]]:
+    """Split ``total`` elements (along the sharded dim) across ``tp_size`` ranks
+    on ``group_size`` boundaries so no MX group straddles a partition boundary.
+
+    Returns ``(elem_sizes, group_sizes)`` -- per-rank element counts and group
+    counts. Groups are distributed as evenly as possible (earlier ranks get the
+    +1); the last rank absorbs the trailing partial group, if any.
+
+    The invariant ``ceil(elem_sizes[r] / group_size) == group_sizes[r]`` holds
+    for every rank, which keeps the loaded weight (split by elements) consistent
+    with the loaded weight_scale (split by groups). For dimensions that are
+    already a multiple of ``group_size * tp_size`` the result equals the plain
+    even split; for ``tp_size == 1`` it is the full tensor.
+    """
+
+    def _cdiv(a: int, b: int) -> int:
+        return (a + b - 1) // b
+
+    if tp_size <= 1:
+        return [total], [_cdiv(total, group_size)]
+
+    num_groups = _cdiv(total, group_size)
+    base, rem = divmod(num_groups, tp_size)
+    group_sizes = [base + (1 if r < rem else 0) for r in range(tp_size)]
+
+    # Each rank owns a contiguous span of groups; its element count is that span
+    # clamped to ``total`` so the trailing partial group stays intact and no rank
+    # goes negative even in the degenerate ``num_groups < tp_size`` case.
+    elem_sizes: list[int] = []
+    groups_done = 0
+    for r in range(tp_size):
+        start = groups_done * group_size
+        groups_done += group_sizes[r]
+        end = min(groups_done * group_size, total)
+        elem_sizes.append(max(0, end - start))
+    return elem_sizes, group_sizes

--- a/vllm_ascend/quantization/method_adapters.py
+++ b/vllm_ascend/quantization/method_adapters.py
@@ -22,16 +22,93 @@ import torch
 from vllm.distributed import get_tensor_model_parallel_rank
 from vllm.model_executor.layers.fused_moe import FusedMoEMethodBase, FusedMoeWeightScaleSupported
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
-from vllm.model_executor.layers.linear import LinearMethodBase, RowParallelLinear
+from vllm.model_executor.layers.linear import ColumnParallelLinear, LinearMethodBase, RowParallelLinear
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
 from vllm.model_executor.parameter import PerTensorScaleParameter
 from vllm.model_executor.utils import set_weight_attrs
+from vllm.utils.math_utils import cdiv
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.distributed.parallel_state import get_flashcomm2_otp_group, get_mlp_tp_group, get_otp_group
+from vllm_ascend.ops.group_aligned_linear import group_aligned_partition
 from vllm_ascend.utils import enable_dsa_cp_with_layer_shard, flashcomm2_enable, mlp_tp_enable, oproj_tp_enable
 
-from .methods import AscendAttentionScheme, AscendLinearScheme, AscendMoEScheme, is_mx_quant_type
+from .methods import (
+    AscendAttentionScheme,
+    AscendLinearScheme,
+    AscendMoEScheme,
+    AscendW8A8MXFP8DynamicLinearMethod,
+    is_mx_quant_type,
+)
+
+
+def _make_group_aligned_loader(orig_loader, shard_dim, per_rank_sizes, tp_rank, expected_full, prefix=""):
+    """Build a weight_loader that narrows the checkpoint tensor on group-aligned
+    (possibly uneven) boundaries instead of vLLM's even ``size // tp_size`` split.
+
+    ``per_rank_sizes`` are the per-rank slice lengths along ``shard_dim`` -- element
+    counts for the weight, group counts for the weight_scale. Falls back to
+    ``orig_loader`` when the loaded tensor is not the expected full size (e.g. it was
+    pre-sharded), so non-group-aligned params are never disturbed.
+    """
+    start = sum(per_rank_sizes[:tp_rank])
+    size = per_rank_sizes[tp_rank]
+
+    def loader(param, loaded_weight):
+        if loaded_weight.shape[shard_dim] != expected_full:
+            return orig_loader(param, loaded_weight)
+        narrowed = loaded_weight.narrow(shard_dim, start, size)
+        if narrowed.dim() == 0:
+            narrowed = narrowed.reshape(1)
+        assert param.data.shape == narrowed.shape, (
+            f"{prefix}: group-aligned param {tuple(param.data.shape)} != loaded {tuple(narrowed.shape)}"
+        )
+        param.data.copy_(narrowed)
+
+    return loader
+
+
+def _maybe_group_align(quant_method, layer, input_size, output_size, output_partition_sizes):
+    """Decide whether this MXFP8 layer needs group-aligned TP sharding.
+
+    MX quantization groups every ``group_size`` elements along the input dim and
+    stores one scale per group, so a TP split is only valid on group boundaries.
+    Returns a context dict (dim/elem_sizes/group_sizes/tp_rank/group_size) when the
+    sharded dim is not a multiple of ``group_size * tp_size``, else ``None``. Only
+    single-shard MXFP8 Row/Column linears are eligible; every other case keeps
+    vLLM's native even split (zero behaviour change).
+    """
+    if not isinstance(quant_method, AscendW8A8MXFP8DynamicLinearMethod):
+        return None
+    tp_size = getattr(layer, "tp_size", 1)
+    if tp_size <= 1:
+        return None
+    group_size = getattr(quant_method, "group_size", 32)
+    if isinstance(layer, RowParallelLinear):
+        total, dim = input_size, "row"
+    elif isinstance(layer, ColumnParallelLinear):
+        # Out of scope: merged/QKV column (multi-shard), gathered output, and
+        # bias=True (the bias is built after create_weights with the native even
+        # split, so its loader offset would be wrong under an uneven partition).
+        if (
+            len(output_partition_sizes) != 1
+            or getattr(layer, "gather_output", False)
+            or getattr(layer, "has_bias", False)
+        ):
+            return None
+        total, dim = output_size, "column"
+    else:
+        return None
+    if total % (group_size * tp_size) == 0:
+        return None
+    elem_sizes, group_sizes = group_aligned_partition(total, tp_size, group_size)
+    return {
+        "dim": dim,
+        "elem_sizes": elem_sizes,
+        "group_sizes": group_sizes,
+        "tp_rank": getattr(layer, "tp_rank", 0),
+        "group_size": group_size,
+    }
 
 
 class AscendLinearMethod(LinearMethodBase):
@@ -61,6 +138,43 @@ class AscendLinearMethod(LinearMethodBase):
         output_size_per_partition = sum(output_partition_sizes)
         weight_loader = extra_weight_attrs.get("weight_loader")
 
+        # MXFP8 group-aligned TP sharding: when the sharded dim is not a multiple of
+        # group_size * tp_size, override the per-partition size so every get_* below
+        # builds group-aligned params, and patch the sharded params' weight_loader to
+        # narrow on group boundaries. Inactive (ga is None) for every other case.
+        ga = _maybe_group_align(self.quant_method, layer, input_size, output_size, output_partition_sizes)
+        if ga is not None:
+            if ga["dim"] == "row":
+                input_size_per_partition = ga["elem_sizes"][ga["tp_rank"]]
+                layer.input_size_per_partition = input_size_per_partition
+            else:  # column (single-shard, bias=False -- enforced by _maybe_group_align)
+                output_size_per_partition = ga["elem_sizes"][ga["tp_rank"]]
+                output_partition_sizes = [output_size_per_partition]
+                layer.output_size_per_partition = output_size_per_partition
+                layer.output_partition_sizes = output_partition_sizes
+
+        def _attach_ga_loader(param, kind):
+            # Override a sharded param's weight_loader to narrow on group boundaries.
+            # kind in {"weight", "scale", "perchannel"}; no-op when group-align inactive.
+            if ga is None:
+                return
+            prefix = getattr(layer, "prefix", "")
+            tp_rank = ga["tp_rank"]
+            if ga["dim"] == "row":
+                if kind == "scale":
+                    param.weight_loader = _make_group_aligned_loader(
+                        weight_loader, 1, ga["group_sizes"], tp_rank, cdiv(input_size, ga["group_size"]), prefix
+                    )
+                elif kind == "weight":
+                    param.weight_loader = _make_group_aligned_loader(
+                        weight_loader, 1, ga["elem_sizes"], tp_rank, input_size, prefix
+                    )
+                # row perchannel rows == unsharded output dim -> native loader is correct
+            else:  # column: weight / weight_scale / perchannel all split along output_dim=0
+                param.weight_loader = _make_group_aligned_loader(
+                    weight_loader, 0, ga["elem_sizes"], tp_rank, output_size, prefix
+                )
+
         weight_dict = self.quant_method.get_weight(input_size_per_partition, output_size_per_partition, params_dtype)
 
         # Extract packing information (if present)
@@ -77,6 +191,7 @@ class AscendLinearMethod(LinearMethodBase):
 
             layer.register_parameter(weight_name, param)
             set_weight_attrs(param, extra_weight_attrs)
+            _attach_ga_loader(param, "weight")
 
         # NOTE: In flatquant quantization implementation,
         # the shape of pertensor_param requires introducing layer_type
@@ -96,6 +211,7 @@ class AscendLinearMethod(LinearMethodBase):
             set_weight_attrs(param, {"output_dim": 0})
             layer.register_parameter(perchannel_name, param)
             set_weight_attrs(param, extra_weight_attrs)
+            _attach_ga_loader(param, "perchannel")
 
         # NOTE: In w4a8 quantization implementation,
         # for down_proj and o_proj scale_bias shape is [output_size, 16],
@@ -112,6 +228,7 @@ class AscendLinearMethod(LinearMethodBase):
             set_weight_attrs(param, {"output_dim": 0})
             layer.register_parameter(pergroup_name, param)
             set_weight_attrs(param, extra_weight_attrs)
+            _attach_ga_loader(param, "scale")
             if scale_packed_dim is not None and scale_packed_factor is not None:
                 set_weight_attrs(param, {"packed_dim": scale_packed_dim, "packed_factor": scale_packed_factor})
             if (

--- a/vllm_ascend/quantization/methods/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4_mxfp4.py
@@ -21,6 +21,7 @@ from typing import Any
 import torch
 import torch_npu
 from vllm.config import CompilationMode, get_current_vllm_config
+from vllm.utils.math_utils import cdiv
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
@@ -60,7 +61,7 @@ class AscendW4A4MXFP4DynamicLinearMethod(AscendLinearScheme):
         self, input_size: int, output_size: int, params_dtype: torch.dtype, layer_type: str | None = None
     ) -> dict[str, Any]:
         params_dict = {}
-        params_dict["weight_scale"] = torch.empty(output_size, input_size // self.group_size, dtype=torch.uint8)
+        params_dict["weight_scale"] = torch.empty(output_size, cdiv(input_size, self.group_size), dtype=torch.uint8)
         return params_dict
 
     def apply(

--- a/vllm_ascend/quantization/methods/w4a4_mxfp4_flatquant.py
+++ b/vllm_ascend/quantization/methods/w4a4_mxfp4_flatquant.py
@@ -23,6 +23,7 @@ import torch_npu
 from vllm.config import get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.model_executor.layers.linear import RowParallelLinear
+from vllm.utils.math_utils import cdiv
 
 from vllm_ascend.device.mxfp_compat import ensure_mxfp4_flatquant_linear_available
 
@@ -109,7 +110,7 @@ class AscendW4A4MXFP4FlatQuantDynamicLinearMethod(AscendLinearScheme):
         self, input_size: int, output_size: int, params_dtype: torch.dtype, layer_type: str | None = None
     ) -> dict[str, Any]:
         params_dict = {}
-        params_dict["weight_scale"] = torch.empty(output_size, input_size // self.group_size, dtype=torch.uint8)
+        params_dict["weight_scale"] = torch.empty(output_size, cdiv(input_size, self.group_size), dtype=torch.uint8)
 
         return params_dict
 

--- a/vllm_ascend/quantization/methods/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8_mxfp4.py
@@ -24,6 +24,7 @@ import torch_npu
 from vllm.config import CompilationMode, get_current_vllm_config
 from vllm.distributed import get_ep_group
 from vllm.forward_context import get_forward_context
+from vllm.utils.math_utils import cdiv
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.device.mxfp_compat import (
@@ -55,7 +56,7 @@ class AscendW4A8MXFPDynamicLinearMethod(AscendLinearScheme):
         self, input_size: int, output_size: int, params_dtype: torch.dtype, layer_type: str | None = None
     ) -> dict[str, Any]:
         params_dict = {}
-        params_dict["weight_scale"] = torch.empty(output_size, input_size // self.group_size, dtype=torch.uint8)
+        params_dict["weight_scale"] = torch.empty(output_size, cdiv(input_size, self.group_size), dtype=torch.uint8)
         return params_dict
 
     def apply(


### PR DESCRIPTION
### What this PR does / why we need it?

MX (microscaling) quantization groups every `group_size` (e.g. 32) elements
along the input dim and stores one shared scale per group. Splitting such a
weight across tensor-parallel ranks is only numerically valid when every
partition boundary lands on a group boundary — otherwise a single group is
cut across two ranks and its scale can no longer be applied correctly.

vLLM's `ColumnParallelLinear` / `RowParallelLinear` split a dimension evenly
(`size // tp_size`). The Qwen3-VL vision MLP has `intermediate_size = 4304`,
which is **not** a multiple of `group_size * tp_size` (`64` for tp=2): the even
split `2152` falls inside a group and loading `weight_scale` fails with
`narrow ... exceeds dimension size`.

This PR handles the split centrally in `AscendLinearMethod.create_weights`:

- For **single-shard MXFP8** `RowParallelLinear` / `ColumnParallelLinear` whose
  sharded dim is not a multiple of `group_size * tp_size`, the per-partition
  size is overridden to a group-aligned (uneven) split — groups are distributed
  as evenly as possible and the last rank absorbs the trailing partial group —
  and the sharded params' `weight_loader` is patched to `narrow` on group
  boundaries (elements for the weight, groups for the `weight_scale`).
- Every other case (non-MXFP8, tp=1, divisible dims, merged/QKV column,
  gathered output, single-shard column with bias, pre-sharded checkpoints) keeps
  vLLM's native even split, so there is **zero behaviour change** outside the
  targeted scenario.

Supporting changes:

- New `vllm_ascend/ops/group_aligned_linear.py`: the pure
  `group_aligned_partition()` helper used by `create_weights`.
- `w4a4_mxfp4` / `w4a8_mxfp4` / `w4a4_mxfp4_flatquant`: `weight_scale` group
  count changed from `input_size // group_size` to `cdiv(input_size, group_size)`
  so non-divisible dims allocate the correct number of groups.
- Register the new op file under the `ops_basic` module in
  `.github/workflows/scripts/test_config.yaml` so the CI source-coverage check
  passes.

### Does this PR introduce _any_ user-facing change?

No. It only fixes a model-load failure for MXFP8 Qwen3-VL under tensor
parallelism; outputs and APIs are unchanged. Non-MXFP8 and aligned-dimension
paths are identical to before.

### How was this patch tested?

New unit tests:

- `tests/ut/ops/test_group_aligned_linear.py` — `group_aligned_partition` exact
  splits (incl. `4304 -> [2176, 2128]` elements / `[68, 67]` groups) and
  invariants (`sum == total`, `ceil(elem / group) == groups`, every interior
  boundary on a group boundary) across tp ∈ {1, 2, 4, 8}.
- `tests/ut/quantization/test_method_adapters.py::TestAscendLinearMethodGroupAlign`
  — `create_weights` row/column uneven partitions and the no-op cases
  (divisible, non-MXFP8, tp=1, merged column, gather_output, pre-sharded).

```
pytest tests/ut/ops/test_group_aligned_linear.py \
       tests/ut/quantization/test_method_adapters.py
```

Also verified end-to-end: serving Qwen3-VL with MXFP8 quantization at TP=2
(vision MLP `intermediate_size = 4304`) now loads without the
`narrow ... exceeds dimension size` error.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
