### PR TITLE
[Refactor][EPLB] Support mixed expert weight layouts

### DIFF
--- a/.github/workflows/scripts/run_selected_tests.sh
+++ b/.github/workflows/scripts/run_selected_tests.sh
@@ -32,6 +32,15 @@ pytest_log_dir="${RUNNER_TEMP:-/tmp}/selected-tests-${npu_type}-${num_npus}card"
 
 mkdir -p "${pytest_log_dir}"
 
+setup_vllm_cache_root() {
+  if [ "${CI:-}" != "true" ]; then
+    return
+  fi
+  export VLLM_CACHE_ROOT
+  VLLM_CACHE_ROOT="$(mktemp -d "${RUNNER_TEMP:-/tmp}/vllm-cache-${npu_type}-${num_npus}card.XXXXXX")"
+  echo "Using vLLM cache root: ${VLLM_CACHE_ROOT}"
+}
+
 print_test_info() {
   echo -e "\033[1;34m=== TEST INFO ===\033[0m"
   echo -e "  \033[33mDevice:\033[0m ${npu_type}"
@@ -153,6 +162,7 @@ print_timing_json() {
 }
 
 print_test_info
+setup_vllm_cache_root
 
 if [ "${npu_type}" = "cpu" ]; then
   run_pytest_batch "cpu-ut (${#targets[@]} targets)" "${targets[@]}"

--- a/tests/ut/eplb/adaptor/test_vllm_adaptor.py
+++ b/tests/ut/eplb/adaptor/test_vllm_adaptor.py
@@ -4,8 +4,8 @@ from unittest.mock import MagicMock, patch
 import torch
 from transformers import DeepseekV2Config
 
-from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
-from vllm_ascend.quantization.methods.base import QuantType
+from vllm_ascend.eplb.adaptor.vllm_adaptor import EPLB_EXPERT_WEIGHT_NAMES, VllmEplbAdaptor
+from vllm_ascend.quantization.quant_type import QuantType
 
 
 class TestVllmAdaptor(unittest.TestCase):
@@ -42,9 +42,14 @@ class TestVllmAdaptor(unittest.TestCase):
         self.mock_size = patch("vllm_ascend.eplb.adaptor.vllm_adaptor.dist.get_world_size", return_value=4).start()
 
     @patch("torch.empty_like", return_value=torch.zeros(16, 32))
-    def test_init_fp16(self, mock_func):
+    @patch("vllm_ascend.eplb.adaptor.vllm_adaptor.get_ascend_config")
+    def test_init_fp16(self, mock_get_config, mock_func):
+        mock_config = MagicMock()
+        mock_config.enable_fused_mc2 = 1
+        mock_get_config.return_value = mock_config
         self.model.quant_config = None
-        VllmEplbAdaptor(self.model)
+        adaptor = VllmEplbAdaptor(self.model)
+        self.assertEqual(adaptor.expert_weight_key_per_layer[0], (QuantType.NONE, True))
 
     @patch("torch.empty_like", return_value=torch.zeros(16, 32))
     @patch("vllm_ascend.eplb.adaptor.vllm_adaptor.get_ascend_config")
@@ -94,6 +99,58 @@ class TestVllmAdaptor(unittest.TestCase):
         self.assertEqual(adaptor.num_moe_layers, 1)
         self.assertEqual(adaptor.num_local_experts, 4)
         self.assertEqual(adaptor.ep_rank, 0)
+
+    @patch("vllm_ascend.eplb.adaptor.vllm_adaptor.get_ascend_config")
+    def test_init_mixed_quant_type_per_layer(self, mock_get_config):
+        mock_config = MagicMock()
+        mock_config.enable_fused_mc2 = 1
+        mock_get_config.return_value = mock_config
+
+        VllmEplbAdaptor._registered_moe_layers = []
+        num_local_experts = 2
+        w8a8_layer = MagicMock()
+        w8a8_layer.local_num_experts = num_local_experts
+        w8a8_layer.ep_rank = 0
+        w8a8_layer.quant_type = QuantType.W8A8
+        w8a8_layer.w13_weight_list = [torch.randn(2, 2) for _ in range(num_local_experts)]
+        w8a8_layer.w2_weight_list = [torch.randn(2, 2) for _ in range(num_local_experts)]
+        w8a8_layer.w13_weight_scale_fp32_list = [torch.randn(1) for _ in range(num_local_experts)]
+        w8a8_layer.w2_weight_scale_list = [torch.randn(1) for _ in range(num_local_experts)]
+        w8a8_layer.fused_w1_scale_list = [torch.randn(1) for _ in range(num_local_experts)]
+        w8a8_layer.fused_w2_scale_list = [torch.randn(1) for _ in range(num_local_experts)]
+        w8a8_layer.moe_load = torch.zeros(num_local_experts)
+        w8a8_layer.global_expert_map = torch.arange(num_local_experts * 4).reshape(num_local_experts, 4)
+        w8a8_layer.get_log2phy_map.return_value = torch.arange(4)
+
+        mxfp8_layer = MagicMock()
+        mxfp8_layer.local_num_experts = num_local_experts
+        mxfp8_layer.ep_rank = 0
+        mxfp8_layer.quant_type = QuantType.MXFP8
+        mxfp8_layer.w13_weight = torch.randn(num_local_experts, 2, 2)
+        mxfp8_layer.w2_weight = torch.randn(num_local_experts, 2, 2)
+        mxfp8_layer.w13_weight_scale = torch.randn(num_local_experts, 1)
+        mxfp8_layer.w2_weight_scale = torch.randn(num_local_experts, 1)
+        mxfp8_layer.moe_load = torch.zeros(num_local_experts)
+        mxfp8_layer.global_expert_map = torch.arange(num_local_experts * 4).reshape(num_local_experts, 4)
+        mxfp8_layer.get_log2phy_map.return_value = torch.arange(4)
+
+        VllmEplbAdaptor.register_layer(w8a8_layer)
+        VllmEplbAdaptor.register_layer(mxfp8_layer)
+
+        model = MagicMock()
+        model.quant_config = MagicMock()
+        model.config.first_k_dense_replace = 0
+        del model.language_model
+        adaptor = VllmEplbAdaptor(model)
+
+        w8a8_key = (QuantType.W8A8, True)
+        mxfp8_key = (QuantType.MXFP8, True)
+        self.assertEqual(adaptor.expert_weight_key_per_layer[0], w8a8_key)
+        self.assertEqual(adaptor.expert_weight_key_per_layer[1], mxfp8_key)
+        self.assertEqual(len(adaptor.buffer_tensor_list[w8a8_key][0]), len(EPLB_EXPERT_WEIGHT_NAMES[w8a8_key]))
+        self.assertEqual(len(adaptor.buffer_tensor_list[mxfp8_key][0]), len(EPLB_EXPERT_WEIGHT_NAMES[mxfp8_key]))
+        self.assertEqual(len(adaptor.expert_param_per_layer[0][0]), len(EPLB_EXPERT_WEIGHT_NAMES[w8a8_key]))
+        self.assertEqual(len(adaptor.expert_param_per_layer[1][0]), len(EPLB_EXPERT_WEIGHT_NAMES[mxfp8_key]))
 
     def tearDown(self):
         self.mock_rank.stop()

--- a/tests/ut/eplb/adaptor/test_vllm_adaptor.py
+++ b/tests/ut/eplb/adaptor/test_vllm_adaptor.py
@@ -152,6 +152,36 @@ class TestVllmAdaptor(unittest.TestCase):
         self.assertEqual(len(adaptor.expert_param_per_layer[0][0]), len(EPLB_EXPERT_WEIGHT_NAMES[w8a8_key]))
         self.assertEqual(len(adaptor.expert_param_per_layer[1][0]), len(EPLB_EXPERT_WEIGHT_NAMES[mxfp8_key]))
 
+    @patch("vllm_ascend.eplb.adaptor.vllm_adaptor.get_ascend_config")
+    def test_reused_buffer_requires_same_expert_weight_shape(self, mock_get_config):
+        mock_config = MagicMock()
+        mock_config.enable_fused_mc2 = 0
+        mock_get_config.return_value = mock_config
+
+        VllmEplbAdaptor._registered_moe_layers = []
+        num_local_experts = 2
+        for weight_shape in [(2, 2), (3, 2)]:
+            layer = MagicMock()
+            layer.local_num_experts = num_local_experts
+            layer.ep_rank = 0
+            layer.quant_type = QuantType.W8A8
+            layer.w13_weight_list = [torch.randn(*weight_shape) for _ in range(num_local_experts)]
+            layer.w2_weight_list = [torch.randn(2, 2) for _ in range(num_local_experts)]
+            layer.w13_weight_scale_fp32_list = [torch.randn(1) for _ in range(num_local_experts)]
+            layer.w2_weight_scale_list = [torch.randn(1) for _ in range(num_local_experts)]
+            layer.moe_load = torch.zeros(num_local_experts)
+            layer.global_expert_map = torch.arange(num_local_experts * 4).reshape(num_local_experts, 4)
+            layer.get_log2phy_map.return_value = torch.arange(4)
+            VllmEplbAdaptor.register_layer(layer)
+
+        model = MagicMock()
+        model.quant_config = MagicMock()
+        model.config.first_k_dense_replace = 0
+        del model.language_model
+
+        with self.assertRaisesRegex(AssertionError, "EPLB expert weight shapes mismatch"):
+            VllmEplbAdaptor(model)
+
     def tearDown(self):
         self.mock_rank.stop()
         self.mock_size.stop()

--- a/tests/ut/eplb/core/test_eplb_device_transfer_loader.py
+++ b/tests/ut/eplb/core/test_eplb_device_transfer_loader.py
@@ -15,7 +15,10 @@ def mock_adaptor():
 
     adaptor.expert_param_per_layer = {0: {0: [[torch.tensor([1.0])]], 1: [[torch.tensor([2.0])]]}}
 
-    adaptor.buffer_tensor_list = [[[torch.tensor([3.0])], [torch.tensor([4.0])]]]
+    adaptor.expert_weight_key_per_layer = {0: "weight_key"}
+    adaptor.buffer_tensor_list = {
+        "weight_key": [[torch.tensor([3.0]), torch.tensor([4.0])], [torch.tensor([5.0]), torch.tensor([6.0])]]
+    }
     return adaptor
 
 
@@ -39,6 +42,25 @@ def test_generate_task_and_state_flow(mock_adaptor):
         loader_obj.generate_expert_d2d_transfer_task([], [], {}, 0)
         assert not loader_obj.comm_op_list
         assert loader_obj.state == loader.ExpertWeightUpdateState.READY
+
+
+def test_generate_task_uses_layer_weight_key_buffer(mock_adaptor):
+    comm_group = MagicMock()
+    comm_group.ranks = {2: 20}
+    comm_group.device_group = object()
+    with patch("vllm_ascend.eplb.core.eplb_device_transfer_loader.get_dynamic_eplb_group", return_value=comm_group):
+        loader_obj = loader.D2DExpertWeightLoader()
+    loader_obj.set_adator(mock_adaptor)
+
+    with (
+        patch("torch.distributed.P2POp") as mock_p2p,
+        patch("torch.distributed.irecv", return_value="irecv_op"),
+    ):
+        mock_p2p.side_effect = lambda op, tensor, rank, group=None: (op, tensor, rank, group)
+        loader_obj.generate_expert_d2d_transfer_task([], [(2, 20)], {20: torch.tensor(0)}, 0)
+
+    assert mock_p2p.call_args_list[0].args[1] is mock_adaptor.buffer_tensor_list["weight_key"][0][0]
+    assert mock_p2p.call_args_list[1].args[1] is mock_adaptor.buffer_tensor_list["weight_key"][0][1]
 
 
 def test_asyn_transfer_and_update(mock_adaptor):

--- a/vllm_ascend/eplb/adaptor/vllm_adaptor.py
+++ b/vllm_ascend/eplb/adaptor/vllm_adaptor.py
@@ -23,7 +23,38 @@ import torch.distributed as dist
 from vllm.logger import logger
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.quantization.methods.base import QuantType
+from vllm_ascend.quantization.quant_type import QuantType
+
+EPLB_EXPERT_WEIGHT_NAMES = {
+    (QuantType.NONE, False): ("w13_weight", "w2_weight"),
+    (QuantType.NONE, True): ("w13_weight", "w2_weight"),
+    (QuantType.W8A8, False): (
+        "w13_weight_list",
+        "w2_weight_list",
+        "w13_weight_scale_fp32_list",
+        "w2_weight_scale_list",
+    ),
+    (QuantType.W8A8, True): (
+        "w13_weight_list",
+        "w2_weight_list",
+        "w13_weight_scale_fp32_list",
+        "w2_weight_scale_list",
+        "fused_w1_scale_list",
+        "fused_w2_scale_list",
+    ),
+    (QuantType.W4A8, True): (
+        "w13_weight_list",
+        "w2_weight_list",
+        "w13_weight_scale_list",
+        "w2_weight_scale_list",
+        "w13_scale_bias_list",
+        "w2_scale_bias_list",
+    ),
+    (QuantType.MXFP4, False): ("w13_weight", "w2_weight", "w13_weight_scale", "w2_weight_scale"),
+    (QuantType.MXFP4, True): ("w13_weight", "w2_weight", "w13_weight_scale", "w2_weight_scale"),
+    (QuantType.MXFP8, False): ("w13_weight", "w2_weight", "w13_weight_scale", "w2_weight_scale"),
+    (QuantType.MXFP8, True): ("w13_weight", "w2_weight", "w13_weight_scale", "w2_weight_scale"),
+}
 
 
 class VllmEplbAdaptor:
@@ -61,10 +92,11 @@ class VllmEplbAdaptor:
         self.ep_rank = first_layer.ep_rank
 
         self.expert_param_per_layer = dict()
+        self.expert_weight_key_per_layer = dict()
         self.init_expert_param_per_layer()
 
         num_buffer_tensor = self.num_local_experts
-        self.buffer_tensor_list: list[list[Any]] = [[] for _ in range(num_buffer_tensor)]
+        self.buffer_tensor_list: dict[Any, list[list[Any]]] = dict()
         self.init_buffer_tensor(num_buffer_tensor)
 
         self.log2phy_map_per_layer = dict()
@@ -72,62 +104,35 @@ class VllmEplbAdaptor:
             self.log2phy_map_per_layer[local_idx] = layer.get_log2phy_map()
 
     def init_buffer_tensor(self, num_buffer_tensor):
-        for buffer_id in range(num_buffer_tensor):
-            for name in self.expert_weight_names:
-                expert_tensor = self.param_dict[f"0.{name}"][0]
-                buffer_tensor = torch.empty_like(expert_tensor)
-                self.buffer_tensor_list[buffer_id].append(buffer_tensor)
+        for local_idx, _ in enumerate(self.moe_layers):
+            expert_weight_key = self.expert_weight_key_per_layer[local_idx]
+            if expert_weight_key in self.buffer_tensor_list:
+                continue
+            expert_weight_names = EPLB_EXPERT_WEIGHT_NAMES[expert_weight_key]
+            self.buffer_tensor_list[expert_weight_key] = [[] for _ in range(num_buffer_tensor)]
+            for buffer_id in range(num_buffer_tensor):
+                for name in expert_weight_names:
+                    expert_tensor = self.param_dict[f"{local_idx}.{name}"][0]
+                    buffer_tensor = torch.empty_like(expert_tensor)
+                    self.buffer_tensor_list[expert_weight_key][buffer_id].append(buffer_tensor)
 
     def init_expert_param_per_layer(self):
         self.param_dict = dict()
 
-        first_layer = self.moe_layers[0]
-
-        if self.model.quant_config is not None:
-            quant_type = first_layer.quant_type
-            if quant_type == QuantType.W8A8:
-                self.expert_weight_names = [
-                    "w13_weight_list",
-                    "w2_weight_list",
-                    "w13_weight_scale_fp32_list",
-                    "w2_weight_scale_list",
-                ]
-                if get_ascend_config().enable_fused_mc2 == 1:
-                    self.expert_weight_names.append("fused_w1_scale_list")
-                    self.expert_weight_names.append("fused_w2_scale_list")
-
-            elif quant_type == QuantType.W4A8:
-                if get_ascend_config().enable_fused_mc2 != 1:
-                    raise ValueError("EPLB not support W4A8 with fused MC2 disabled")
-                self.expert_weight_names = [
-                    "w13_weight_list",
-                    "w2_weight_list",
-                    "w13_weight_scale_list",
-                    "w2_weight_scale_list",
-                    "w13_scale_bias_list",
-                    "w2_scale_bias_list",
-                ]
-
-            elif quant_type in (QuantType.MXFP4, QuantType.MXFP8):
-                self.expert_weight_names = [
-                    "w13_weight",
-                    "w2_weight",
-                    "w13_weight_scale",
-                    "w2_weight_scale",
-                ]
-            else:
-                raise ValueError(f"EPLB not support {quant_type}")
-        else:
-            self.expert_weight_names = ["w13_weight", "w2_weight"]
-
         for local_idx, layer in enumerate(self.moe_layers):
+            quant_type = QuantType.NONE if self.model.quant_config is None else layer.quant_type
+            expert_weight_key = (quant_type, get_ascend_config().enable_fused_mc2 == 1)
+            if expert_weight_key not in EPLB_EXPERT_WEIGHT_NAMES:
+                raise ValueError(f"EPLB not support {quant_type} with fused MC2 {expert_weight_key[1]}")
+            expert_weight_names = EPLB_EXPERT_WEIGHT_NAMES[expert_weight_key]
+            self.expert_weight_key_per_layer[local_idx] = expert_weight_key
             self.expert_param_per_layer[local_idx] = list()
-            for name in self.expert_weight_names:
+            for name in expert_weight_names:
                 param_key = f"{local_idx}.{name}"
                 self.param_dict[param_key] = getattr(layer, name)
             for local_expert_id in range(self.num_local_experts):
                 per_expert_param = list()
-                for name in self.expert_weight_names:
+                for name in expert_weight_names:
                     per_expert_param.append(self.param_dict[f"{local_idx}.{name}"][local_expert_id])
                 self.expert_param_per_layer[local_idx].append(per_expert_param)
 
@@ -168,8 +173,10 @@ class VllmEplbAdaptor:
         self.expert_map_per_layer_cpu[layer_id].copy_(updated_expert_map)
 
     def do_update_expert_weight(self, layer_id, local_expert_to_replace, buffer_tensor_id):
+        expert_weight_key = self.expert_weight_key_per_layer[layer_id]
         for expert_tensor, buffer_tensor in zip(
-            self.expert_param_per_layer[layer_id][local_expert_to_replace], self.buffer_tensor_list[buffer_tensor_id]
+            self.expert_param_per_layer[layer_id][local_expert_to_replace],
+            self.buffer_tensor_list[expert_weight_key][buffer_tensor_id],
         ):
             expert_tensor.copy_(buffer_tensor)
             logger.debug("Expert tensor shape is :%s", expert_tensor.shape)

--- a/vllm_ascend/eplb/adaptor/vllm_adaptor.py
+++ b/vllm_ascend/eplb/adaptor/vllm_adaptor.py
@@ -104,15 +104,22 @@ class VllmEplbAdaptor:
             self.log2phy_map_per_layer[local_idx] = layer.get_log2phy_map()
 
     def init_buffer_tensor(self, num_buffer_tensor):
+        buffer_tensor_shapes: dict[Any, list[torch.Size]] = dict()
         for local_idx, _ in enumerate(self.moe_layers):
             expert_weight_key = self.expert_weight_key_per_layer[local_idx]
-            if expert_weight_key in self.buffer_tensor_list:
-                continue
             expert_weight_names = EPLB_EXPERT_WEIGHT_NAMES[expert_weight_key]
+            expert_tensors = [self.param_dict[f"{local_idx}.{name}"][0] for name in expert_weight_names]
+            expert_tensor_shapes = [tensor.shape for tensor in expert_tensors]
+            if expert_weight_key in self.buffer_tensor_list:
+                assert expert_tensor_shapes == buffer_tensor_shapes[expert_weight_key], (
+                    f"EPLB expert weight shapes mismatch for {expert_weight_key}: "
+                    f"expected {buffer_tensor_shapes[expert_weight_key]}, got {expert_tensor_shapes}"
+                )
+                continue
+            buffer_tensor_shapes[expert_weight_key] = expert_tensor_shapes
             self.buffer_tensor_list[expert_weight_key] = [[] for _ in range(num_buffer_tensor)]
             for buffer_id in range(num_buffer_tensor):
-                for name in expert_weight_names:
-                    expert_tensor = self.param_dict[f"{local_idx}.{name}"][0]
+                for expert_tensor in expert_tensors:
                     buffer_tensor = torch.empty_like(expert_tensor)
                     self.buffer_tensor_list[expert_weight_key][buffer_id].append(buffer_tensor)
 

--- a/vllm_ascend/eplb/core/eplb_device_transfer_loader.py
+++ b/vllm_ascend/eplb/core/eplb_device_transfer_loader.py
@@ -67,7 +67,8 @@ class D2DExpertWeightLoader:
 
         for buffer_tensor_id, recv_info in enumerate(expert_recv_info):
             recv_rank, global_expert_id_to_recv = recv_info
-            for buffer_tensor in self.eplb_adaptor.buffer_tensor_list[buffer_tensor_id]:
+            expert_weight_key = self.eplb_adaptor.expert_weight_key_per_layer[layer_id]
+            for buffer_tensor in self.eplb_adaptor.buffer_tensor_list[expert_weight_key][buffer_tensor_id]:
                 self.comm_op_list.append(
                     dist.P2POp(
                         dist.irecv, buffer_tensor, self.comm_group.ranks[recv_rank], group=self.comm_group.device_group

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -966,6 +966,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             aclgraph_runtime_mode=aclgraph_runtime_mode,
             is_draft_model=True,
             draft_attn_metadatas=multi_steps_attn_metadata,
+            eplb_heat_collection_status=(
+                self.runner.eplb_heat_collection_status if self.runner.dynamic_eplb else False
+            ),
         ):
             # Reset MOE layer index for forward pass
             forward_context = get_forward_context()

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2346,7 +2346,7 @@ class NPUModelRunner(GPUModelRunner):
                     self.kv_connector_output = kv_connector_output
                     self._finalize_dump_data()
                     if self.dynamic_eplb:
-                        self.eplb_updator.forward_end()
+                        self.eplb_updator.forward_end(self.eplb_heat_collection_status)
                     return hidden_states
                 if self.is_pooling_model:
                     # Return the pooling output.


### PR DESCRIPTION
### What this PR does / why we need it?

This PR refactors EPLB expert weight handling so layers can use different expert weight layouts in the same model.

- Adds per-layer expert weight keys based on quantization type and fused MC2 state.
- Builds EPLB buffer tensors per expert weight key, with shape validation before reusing buffers across layers.
- Uses the layer's expert weight key when generating D2D expert transfer tasks.
- Propagates EPLB heat collection status into draft model forward contexts so registered draft MoE layers do not stay at zero load.
- Fixes the non-last PP rank `forward_end()` path to use the current heat collection status.

This also avoids `Expert hotness` mean becoming `nan` when registered draft or PP-stage MoE layers did not collect heat.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Local formatting/preflight:
  - `bash format.sh ci`
- Local UT:
  - `tests/ut/eplb/adaptor/test_vllm_adaptor.py`
  - Result: `6 tests OK`
- NPU focused UT:
  - `python -m pytest -q --confcutdir=tests/ut/eplb tests/ut/eplb --tb=short`
  - Result: `19 passed, 17 warnings in 24.77s`


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
