### PR TITLE
[CI] Lower Qwen3.5 397B w4a8 MTP A2 perf baseline

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/Qwen3.5-397B-A17B-w4a8-mtp-A2.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3.5-397B-A17B-w4a8-mtp-A2.yaml
@@ -70,5 +70,5 @@ test_cases:
         max_out_len: 1500
         batch_size: 64
         request_rate: 0
-        baseline: 1108.865
+        baseline: 1050
         threshold: 0.97


### PR DESCRIPTION
## Summary
- Lower the Qwen3.5-397B-A17B-w4a8-mtp A2 nightly performance baseline from 1108.865 to 1050.
- Keep the existing threshold at 0.97, making the effective output-token-throughput gate 1018.5 token/s.

## Why
- The previous baseline was too high for the current A2 nightly benchmark behavior for this configuration.
- This only adjusts the configured performance target; it does not change the benchmark command, dataset, request shape, or threshold logic.

## Validation
- git diff --check
- python3 -c "import yaml; yaml.safe_load(open('tests/e2e/nightly/single_node/models/configs/Qwen3.5-397B-A17B-w4a8-mtp-A2.yaml', encoding='utf-8'))"

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
