### PR TITLE
[Feature][DSpark] Adapt DeepSeek DSpark (aligned with upstream vllm #46995)

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -405,6 +405,7 @@
   optional: true
   source_file_dependencies:
     - vllm_ascend/sample
+    - vllm_ascend/worker/v2/sample
   tests:
     - tests/ut/sample
     - tests/e2e/pull_request/one_card/test_sampler.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,11 +60,11 @@ ARG COMPILE_CUSTOM_KERNELS=1
 ENV DEBIAN_FRONTEND=noninteractive
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1 \
-    VLLM_BATCH_INVARIANT=1
+    OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
 RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+    export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -62,11 +62,11 @@ ARG COMPILE_CUSTOM_KERNELS=1
 ENV DEBIAN_FRONTEND=noninteractive
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1 \
-    VLLM_BATCH_INVARIANT=1
+    OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
 RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+    export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -59,11 +59,11 @@ ARG SOC_VERSION="ascend910_9391"
 ARG COMPILE_CUSTOM_KERNELS=1
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1 \
-    VLLM_BATCH_INVARIANT=1
+    OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
 RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+    export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -59,11 +59,11 @@ ARG SOC_VERSION="ascend910b1"
 ARG COMPILE_CUSTOM_KERNELS=1
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1 \
-    VLLM_BATCH_INVARIANT=1
+    OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
 RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+    export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \

--- a/tests/ut/sample/a2/test_gumbel_sampling.py
+++ b/tests/ut/sample/a2/test_gumbel_sampling.py
@@ -10,7 +10,6 @@
 import pytest
 import torch
 
-from tests.ut.conftest import npu_test
 from vllm_ascend.worker.v2.sample.gumbel import apply_temperature, gumbel_sample
 
 DEVICE = "npu"
@@ -32,7 +31,6 @@ def _ref_apply_temperature(
     return out
 
 
-@npu_test(num_npus=1, npu_type="a2")
 class TestGumbelSampling:
     @pytest.mark.parametrize(
         "num_tokens,vocab_size",

--- a/tools/dspark_quant/_dspark_convert.py
+++ b/tools/dspark_quant/_dspark_convert.py
@@ -1,0 +1,78 @@
+import os, glob, json, time, torch
+from safetensors.torch import safe_open, save_file
+
+t0=time.time()
+print("torch", torch.__version__,
+      "e4m3", hasattr(torch,"float8_e4m3fn"),
+      "e8m0", hasattr(torch,"float8_e8m0fnu"), flush=True)
+
+FP4_TABLE = torch.tensor([0.0,0.5,1.0,1.5,2.0,3.0,4.0,6.0,
+                          0.0,-0.5,-1.0,-1.5,-2.0,-3.0,-4.0,-6.0], dtype=torch.float32)
+
+def cast_e2m1fn_to_e4m3fn(x, scale):
+    assert x.dtype == torch.int8 and x.ndim == 2
+    out_dim, in_dim = x.size(); in_dim *= 2
+    fp8_bs, fp4_bs = 128, 32
+    assert in_dim % fp8_bs == 0 and out_dim % fp8_bs == 0
+    assert scale.size(0) == out_dim and scale.size(1) == in_dim // fp4_bs
+    x = x.view(torch.uint8)
+    low = x & 0x0F; high = (x >> 4) & 0x0F
+    x = torch.stack([FP4_TABLE[low.long()], FP4_TABLE[high.long()]], dim=-1).flatten(2)
+    MAX_OFFSET_BITS = 6
+    bOut, bIn = out_dim // fp8_bs, in_dim // fp8_bs
+    x = x.view(bOut, fp8_bs, bIn, fp8_bs).transpose(1, 2)
+    scale = scale.float().view(bOut, fp8_bs, bIn, -1).transpose(1, 2).flatten(2)
+    smob = scale.amax(dim=-1, keepdim=True) / (2**MAX_OFFSET_BITS)
+    offset = scale / smob
+    offset = offset.unflatten(-1, (fp8_bs, -1)).repeat_interleave(fp4_bs, dim=-1)
+    x = (x * offset).transpose(1, 2).reshape(out_dim, in_dim)
+    return x.to(torch.float8_e4m3fn).contiguous(), smob.squeeze(-1).to(torch.float8_e8m0fnu).contiguous()
+
+def deq_fp4(x_int8, scale):
+    x = x_int8.view(torch.uint8)
+    low = x & 0x0F; high = (x >> 4) & 0x0F
+    vals = torch.stack([FP4_TABLE[low.long()], FP4_TABLE[high.long()]], dim=-1).flatten(1)
+    out_dim, in_dim = vals.shape
+    s = scale.float().repeat_interleave(32, dim=1)[:, :in_dim]
+    return vals * s
+
+def deq_fp8(w8, s8):
+    out_dim, in_dim = w8.shape
+    s = s8.float().repeat_interleave(128, 0).repeat_interleave(128, 1)[:out_dim, :in_dim]
+    return w8.float() * s
+
+SRC="/data1/dspark-draft/weights"
+DST="/data1/dspark-draft/weights-fp8"
+os.makedirs(DST, exist_ok=True)
+def is_re(k): return ".experts." in k and "shared_experts" not in k
+
+weight_map={}; total=0; verified=0; max_err=0.0; n_conv=0
+for f in sorted(glob.glob(SRC+"/*.safetensors")):
+    base=os.path.basename(f)
+    with safe_open(f, framework="pt", device="cpu") as h:
+        keys=list(h.keys()); raw={k:h.get_tensor(k) for k in keys}
+    out={}
+    for k in keys:
+        if is_re(k) and k.endswith(".weight"):
+            sc=raw[k[:-7]+".scale"]
+            w8,s8=cast_e2m1fn_to_e4m3fn(raw[k], sc)
+            out[k]=w8; out[k[:-7]+".scale"]=s8; n_conv+=1
+            if verified<8:
+                e=(deq_fp4(raw[k],sc)-deq_fp8(w8,s8)).abs().max().item()
+                max_err=max(max_err,e); verified+=1
+        elif is_re(k) and k.endswith(".scale"):
+            continue
+        else:
+            out[k]=raw[k]
+    save_file(out, os.path.join(DST, base), metadata={"format":"pt"})
+    for k,v in out.items():
+        weight_map[k]=base; total += v.numel()*v.element_size()
+    print(f"[{time.time()-t0:6.1f}s] saved {base}: {len(out)} tensors", flush=True)
+
+idx={"metadata":{"total_size":int(total)},"weight_map":weight_map}
+with open(os.path.join(DST,"model.safetensors.index.json"),"w") as fo:
+    json.dump(idx, fo, indent=2)
+
+print(f"converted_experts={n_conv} verify_samples={verified} max|fp4-fp8 dequant|={max_err:.3e}", flush=True)
+print("RESULT:", "PASS" if max_err==0.0 else "FAIL", flush=True)
+print(f"total_bytes={total/1e9:.2f}GB  elapsed={time.time()-t0:.1f}s", flush=True)

--- a/tools/dspark_quant/_dspark_convert_full.py
+++ b/tools/dspark_quant/_dspark_convert_full.py
@@ -1,0 +1,78 @@
+import os, glob, json, time, torch
+from safetensors.torch import safe_open, save_file
+
+t0=time.time()
+print("torch", torch.__version__,
+      "e4m3", hasattr(torch,"float8_e4m3fn"),
+      "e8m0", hasattr(torch,"float8_e8m0fnu"), flush=True)
+
+FP4_TABLE = torch.tensor([0.0,0.5,1.0,1.5,2.0,3.0,4.0,6.0,
+                          0.0,-0.5,-1.0,-1.5,-2.0,-3.0,-4.0,-6.0], dtype=torch.float32)
+
+def cast_e2m1fn_to_e4m3fn(x, scale):
+    assert x.dtype == torch.int8 and x.ndim == 2
+    out_dim, in_dim = x.size(); in_dim *= 2
+    fp8_bs, fp4_bs = 128, 32
+    assert in_dim % fp8_bs == 0 and out_dim % fp8_bs == 0
+    assert scale.size(0) == out_dim and scale.size(1) == in_dim // fp4_bs
+    x = x.view(torch.uint8)
+    low = x & 0x0F; high = (x >> 4) & 0x0F
+    x = torch.stack([FP4_TABLE[low.long()], FP4_TABLE[high.long()]], dim=-1).flatten(2)
+    MAX_OFFSET_BITS = 6
+    bOut, bIn = out_dim // fp8_bs, in_dim // fp8_bs
+    x = x.view(bOut, fp8_bs, bIn, fp8_bs).transpose(1, 2)
+    scale = scale.float().view(bOut, fp8_bs, bIn, -1).transpose(1, 2).flatten(2)
+    smob = scale.amax(dim=-1, keepdim=True) / (2**MAX_OFFSET_BITS)
+    offset = scale / smob
+    offset = offset.unflatten(-1, (fp8_bs, -1)).repeat_interleave(fp4_bs, dim=-1)
+    x = (x * offset).transpose(1, 2).reshape(out_dim, in_dim)
+    return x.to(torch.float8_e4m3fn).contiguous(), smob.squeeze(-1).to(torch.float8_e8m0fnu).contiguous()
+
+def deq_fp4(x_int8, scale):
+    x = x_int8.view(torch.uint8)
+    low = x & 0x0F; high = (x >> 4) & 0x0F
+    vals = torch.stack([FP4_TABLE[low.long()], FP4_TABLE[high.long()]], dim=-1).flatten(1)
+    out_dim, in_dim = vals.shape
+    s = scale.float().repeat_interleave(32, dim=1)[:, :in_dim]
+    return vals * s
+
+def deq_fp8(w8, s8):
+    out_dim, in_dim = w8.shape
+    s = s8.float().repeat_interleave(128, 0).repeat_interleave(128, 1)[:out_dim, :in_dim]
+    return w8.float() * s
+
+SRC="/data1/DeepSeek-V4-Flash-DSpark"
+DST="/data1/DeepSeek-V4-Flash-DSpark-fp8-full"
+os.makedirs(DST, exist_ok=True)
+def is_re(k): return ".experts." in k and "shared_experts" not in k
+
+weight_map={}; total=0; verified=0; max_err=0.0; n_conv=0
+for f in sorted(glob.glob(SRC+"/*.safetensors")):
+    base=os.path.basename(f)
+    with safe_open(f, framework="pt", device="cpu") as h:
+        keys=list(h.keys()); raw={k:h.get_tensor(k) for k in keys}
+    out={}
+    for k in keys:
+        if is_re(k) and k.endswith(".weight"):
+            sc=raw[k[:-7]+".scale"]
+            w8,s8=cast_e2m1fn_to_e4m3fn(raw[k], sc)
+            out[k]=w8; out[k[:-7]+".scale"]=s8; n_conv+=1
+            if verified<8:
+                e=(deq_fp4(raw[k],sc)-deq_fp8(w8,s8)).abs().max().item()
+                max_err=max(max_err,e); verified+=1
+        elif is_re(k) and k.endswith(".scale"):
+            continue
+        else:
+            out[k]=raw[k]
+    save_file(out, os.path.join(DST, base), metadata={"format":"pt"})
+    for k,v in out.items():
+        weight_map[k]=base; total += v.numel()*v.element_size()
+    print(f"[{time.time()-t0:6.1f}s] saved {base}: {len(out)} tensors", flush=True)
+
+idx={"metadata":{"total_size":int(total)},"weight_map":weight_map}
+with open(os.path.join(DST,"model.safetensors.index.json"),"w") as fo:
+    json.dump(idx, fo, indent=2)
+
+print(f"converted_experts={n_conv} verify_samples={verified} max|fp4-fp8 dequant|={max_err:.3e}", flush=True)
+print("RESULT:", "PASS" if max_err==0.0 else "FAIL", flush=True)
+print(f"total_bytes={total/1e9:.2f}GB  elapsed={time.time()-t0:.1f}s", flush=True)

--- a/tools/dspark_quant/_dspark_convert_par.py
+++ b/tools/dspark_quant/_dspark_convert_par.py
@@ -1,0 +1,57 @@
+import os, glob, sys, time, torch
+from safetensors.torch import safe_open, save_file
+
+N = int(sys.argv[1]); REM = int(sys.argv[2])
+t0 = time.time()
+
+FP4_TABLE = torch.tensor([0.0,0.5,1.0,1.5,2.0,3.0,4.0,6.0,
+                          0.0,-0.5,-1.0,-1.5,-2.0,-3.0,-4.0,-6.0], dtype=torch.float32)
+
+def cast_e2m1fn_to_e4m3fn(x, scale):
+    assert x.dtype == torch.int8 and x.ndim == 2
+    out_dim, in_dim = x.size(); in_dim *= 2
+    fp8_bs, fp4_bs = 128, 32
+    assert in_dim % fp8_bs == 0 and out_dim % fp8_bs == 0
+    assert scale.size(0) == out_dim and scale.size(1) == in_dim // fp4_bs
+    x = x.view(torch.uint8)
+    low = x & 0x0F; high = (x >> 4) & 0x0F
+    x = torch.stack([FP4_TABLE[low.long()], FP4_TABLE[high.long()]], dim=-1).flatten(2)
+    MAX_OFFSET_BITS = 6
+    bOut, bIn = out_dim // fp8_bs, in_dim // fp8_bs
+    x = x.view(bOut, fp8_bs, bIn, fp8_bs).transpose(1, 2)
+    scale = scale.float().view(bOut, fp8_bs, bIn, -1).transpose(1, 2).flatten(2)
+    smob = scale.amax(dim=-1, keepdim=True) / (2**MAX_OFFSET_BITS)
+    offset = scale / smob
+    offset = offset.unflatten(-1, (fp8_bs, -1)).repeat_interleave(fp4_bs, dim=-1)
+    x = (x * offset).transpose(1, 2).reshape(out_dim, in_dim)
+    return x.to(torch.float8_e4m3fn).contiguous(), smob.squeeze(-1).to(torch.float8_e8m0fnu).contiguous()
+
+SRC = "/data1/DeepSeek-V4-Flash-DSpark"
+DST = "/data1/DeepSeek-V4-Flash-DSpark-fp8-full"
+os.makedirs(DST, exist_ok=True)
+def is_re(k): return ".experts." in k and "shared_experts" not in k
+
+files = sorted(glob.glob(SRC + "/*.safetensors"))
+for fi, f in enumerate(files):
+    if fi % N != REM:
+        continue
+    base = os.path.basename(f)
+    outp = os.path.join(DST, base)
+    if os.path.exists(outp) and os.path.getsize(outp) > 0:
+        print(f"[W{REM}] skip existing {base}", flush=True); continue
+    with safe_open(f, framework="pt", device="cpu") as h:
+        keys = list(h.keys()); raw = {k: h.get_tensor(k) for k in keys}
+    out = {}
+    for k in keys:
+        if is_re(k) and k.endswith(".weight"):
+            sc = raw[k[:-7] + ".scale"]
+            w8, s8 = cast_e2m1fn_to_e4m3fn(raw[k], sc)
+            out[k] = w8; out[k[:-7] + ".scale"] = s8
+        elif is_re(k) and k.endswith(".scale"):
+            continue
+        else:
+            out[k] = raw[k]
+    save_file(out, outp + ".tmp", metadata={"format": "pt"})
+    os.replace(outp + ".tmp", outp)
+    print(f"[W{REM} {time.time()-t0:6.1f}s] saved {base}: {len(out)} tensors", flush=True)
+print(f"[W{REM}] DONE elapsed={time.time()-t0:.1f}s", flush=True)

--- a/tools/dspark_quant/_dspark_dequant_bf16.py
+++ b/tools/dspark_quant/_dspark_dequant_bf16.py
@@ -1,0 +1,66 @@
+import os, glob, sys, time, json, struct, torch
+from safetensors.torch import safe_open, save_file
+
+N = int(sys.argv[1]); REM = int(sys.argv[2])
+t0 = time.time()
+SRC = "/data1/DeepSeek-V4-Flash-DSpark"
+DST = "/data1/DeepSeek-V4-Flash-DSpark-bf16"
+os.makedirs(DST, exist_ok=True)
+
+FP4_TABLE = torch.tensor([0.0,0.5,1.0,1.5,2.0,3.0,4.0,6.0,
+                          0.0,-0.5,-1.0,-1.5,-2.0,-3.0,-4.0,-6.0], dtype=torch.float32)
+
+def deq_fp4(x_int8, scale):
+    # x_int8 [out, in/2] packed nibbles; scale [out, in/32] (E8M0 -> .float() = 2^e)
+    x = x_int8.view(torch.uint8)
+    low = x & 0x0F; high = (x >> 4) & 0x0F
+    vals = torch.stack([FP4_TABLE[low.long()], FP4_TABLE[high.long()]], dim=-1).flatten(1)
+    out_dim, in_dim = vals.shape
+    s = scale.float().repeat_interleave(32, dim=1)[:, :in_dim]
+    return vals * s
+
+def deq_fp8(w8, s8):
+    # w8 [out,in] e4m3; s8 [out/128, in/128] E8M0 (.float() = 2^e)
+    out_dim, in_dim = w8.shape
+    s = s8.float().repeat_interleave(128, 0).repeat_interleave(128, 1)[:out_dim, :in_dim]
+    return w8.float() * s
+
+def hdrdtype(path):
+    with open(path, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        h = json.loads(f.read(n))
+    return {k: v.get("dtype") for k, v in h.items() if isinstance(v, dict) and "dtype" in v}
+
+files = sorted(glob.glob(SRC + "/*.safetensors"))
+for fi, f in enumerate(files):
+    if fi % N != REM:
+        continue
+    base = os.path.basename(f)
+    outp = os.path.join(DST, base)
+    if os.path.exists(outp) and os.path.getsize(outp) > 0:
+        print(f"[W{REM}] skip {base}", flush=True); continue
+    dtypes = hdrdtype(f)
+    with safe_open(f, framework="pt", device="cpu") as h:
+        keys = list(h.keys()); raw = {k: h.get_tensor(k) for k in keys}
+    out = {}
+    for k in keys:
+        dt = dtypes.get(k)
+        if k.endswith(".scale"):
+            continue                                  # drop quant scales
+        if k.endswith(".weight") and dt in ("I8", "F8_E4M3"):
+            scname = k[:-7] + ".scale"
+            sc = raw.get(scname)
+            if sc is None:                            # unquantized .weight -> keep
+                out[k] = raw[k].to(torch.bfloat16); continue
+            if dt == "I8":
+                out[k] = deq_fp4(raw[k], sc).to(torch.bfloat16)
+            else:
+                out[k] = deq_fp8(raw[k], sc).to(torch.bfloat16)
+        elif dt == "F32":
+            out[k] = raw[k]                            # keep norms/params fp32
+        else:
+            out[k] = raw[k].to(torch.bfloat16) if dt == "BF16" else raw[k]
+    save_file(out, outp + ".tmp", metadata={"format": "pt"})
+    os.replace(outp + ".tmp", outp)
+    print(f"[W{REM} {time.time()-t0:6.1f}s] {base}: {len(out)} tensors", flush=True)
+print(f"[W{REM}] DONE elapsed={time.time()-t0:.1f}s", flush=True)

--- a/tools/dspark_quant/deepseek_v4_flash_dspark_bf16draft.yaml
+++ b/tools/dspark_quant/deepseek_v4_flash_dspark_bf16draft.yaml
@@ -1,0 +1,71 @@
+apiversion: modelslim_v1
+metadata:
+  config_id: deepseek_v4_flash_dspark_w8a8
+  score: 90
+  verified_model_types:
+    - DeepSeek-V4-Flash-DSpark
+  verified_tags:
+    DeepSeek-V4-Flash-DSpark:
+      - - vLLM-Ascend
+        - Atlas_A2_Inference
+  label:
+    w_bit: 8
+    a_bit: 8
+    is_sparse: False
+    kv_cache: False
+
+default_w8a8_dynamic: &default_w8a8_dynamic
+  act:
+    scope: "per_token"
+    dtype: "int8"
+    symmetric: True
+    method: "minmax"
+  weight:
+    scope: "per_channel"
+    dtype: "int8"
+    symmetric: True
+    method: "minmax"
+
+spec:
+  process:
+    - type: "quarot"
+      block_size: 32
+    - type: "flex_smooth_quant"
+      enable_subgraph_type:
+        - 'norm-linear'
+      include:
+        - "*"
+    # target + DSpark draft attn (DSparkBlock has same wq_a/wkv/wo_a/wo_b/attn_norm)
+    - type: "linear_quant"
+      qconfig: *default_w8a8_dynamic
+      include:
+        - "*attn*"
+      exclude:
+        - "*mtp.*"
+        - "*wo_a"
+        - "*wo_b"
+        - "*compressor.wgate"
+        - "*compressor.wkv"
+        - "*indexer.weights_proj"
+        - "*indexer.compressor.wgate"
+        - "*indexer.compressor.wkv"
+    # target + DSpark draft ffn (MoE)
+    - type: "linear_quant"
+      qconfig: *default_w8a8_dynamic
+      include:
+        - "*ffn*"
+      exclude:
+        - "*mtp.*"
+        - "*gate"
+    # DSpark-specific: main_proj (mtp.0) is a big linear -> w8a8. markov_head /
+    # confidence_head / main_norm / hc_* / norm are NOT matched here -> stay bf16.
+    - type: "linear_quant"
+      qconfig: *default_w8a8_dynamic
+      include:
+        - "*main_proj*"
+      exclude:
+        - "*mtp.*"
+  dataset: mix_calib.jsonl
+  save:
+    - type: "ascendv1_saver"
+      part_file_size: 4

--- a/tools/dspark_quant/deepseek_v4_flash_dspark_w8a8.yaml
+++ b/tools/dspark_quant/deepseek_v4_flash_dspark_w8a8.yaml
@@ -1,0 +1,67 @@
+apiversion: modelslim_v1
+metadata:
+  config_id: deepseek_v4_flash_dspark_w8a8
+  score: 90
+  verified_model_types:
+    - DeepSeek-V4-Flash-DSpark
+  verified_tags:
+    DeepSeek-V4-Flash-DSpark:
+      - - vLLM-Ascend
+        - Atlas_A2_Inference
+  label:
+    w_bit: 8
+    a_bit: 8
+    is_sparse: False
+    kv_cache: False
+
+default_w8a8_dynamic: &default_w8a8_dynamic
+  act:
+    scope: "per_token"
+    dtype: "int8"
+    symmetric: True
+    method: "minmax"
+  weight:
+    scope: "per_channel"
+    dtype: "int8"
+    symmetric: True
+    method: "minmax"
+
+spec:
+  process:
+    - type: "quarot"
+      block_size: 32
+    - type: "flex_smooth_quant"
+      enable_subgraph_type:
+        - 'norm-linear'
+      include:
+        - "*"
+    # target + DSpark draft attn (DSparkBlock has same wq_a/wkv/wo_a/wo_b/attn_norm)
+    - type: "linear_quant"
+      qconfig: *default_w8a8_dynamic
+      include:
+        - "*attn*"
+      exclude:
+        - "*wo_a"
+        - "*wo_b"
+        - "*compressor.wgate"
+        - "*compressor.wkv"
+        - "*indexer.weights_proj"
+        - "*indexer.compressor.wgate"
+        - "*indexer.compressor.wkv"
+    # target + DSpark draft ffn (MoE)
+    - type: "linear_quant"
+      qconfig: *default_w8a8_dynamic
+      include:
+        - "*ffn*"
+      exclude:
+        - "*gate"
+    # DSpark-specific: main_proj (mtp.0) is a big linear -> w8a8. markov_head /
+    # confidence_head / main_norm / hc_* / norm are NOT matched here -> stay bf16.
+    - type: "linear_quant"
+      qconfig: *default_w8a8_dynamic
+      include:
+        - "*main_proj*"
+  dataset: mix_calib.jsonl
+  save:
+    - type: "ascendv1_saver"
+      part_file_size: 4

--- a/tools/dspark_quant/deploy_dspark_quant.sh
+++ b/tools/dspark_quant/deploy_dspark_quant.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Deploy the DeepSeek-V4-Flash-DSpark quant adapter into msModelSlim + run w8a8 quant.
+# Run on m18 host. Prereqs: full ckpt downloaded (/data1/DeepSeek-V4-Flash-DSpark),
+# 1 free NPU card, the 4 staged files in /data1/dspark_msslim/.
+set -e
+MS=/data1/msmodelslim
+DV=$MS/msmodelslim/model/deepseek_v4
+STAGE=/data1/dspark_msslim          # where the 4 component files were pushed
+
+# 1) place the adapter files (filenames matter -> match the loader/adapter import paths)
+cp $STAGE/msslim_dspark_model.py   $DV/dspark_model.py
+cp $STAGE/msslim_dspark_adapter.py $DV/dspark_adapter.py
+cp $STAGE/msslim_dspark_loader.py  $DV/dspark_loader.py
+cp $STAGE/deepseek_v4_flash_dspark_w8a8.yaml $MS/lab_practice/deepseek_v4/
+
+# 2) register a new "deepseek_v4_dspark" plugin group in config.ini (idempotent)
+python - <<'PY'
+ini="/data1/msmodelslim/config/config.ini"
+s=open(ini).read()
+edits=[
+ ("deepseek_v4 = DeepSeek-V4-Flash, DeepSeek-V4-Pro",
+  "\ndeepseek_v4_dspark = DeepSeek-V4-Flash-DSpark"),
+ ("deepseek_v4 = msmodelslim.model.deepseek_v4.loader:DeepseekV4AdapterLoader",
+  "\ndeepseek_v4_dspark = msmodelslim.model.deepseek_v4.dspark_loader:DeepseekV4DSparkAdapterLoader"),
+ ('deepseek_v4 = {"transformers": "==4.48.2"}',
+  '\ndeepseek_v4_dspark = {"transformers": "==4.48.2"}'),
+]
+for anchor, add in edits:
+    if add.strip() in s:
+        continue
+    assert anchor in s, f"anchor not found: {anchor}"
+    s=s.replace(anchor, anchor+add, 1)
+open(ini,"w").write(s)
+print("config.ini patched")
+PY
+
+# 3) (re)install so entry points pick up the new model_type
+cd $MS && bash install.sh
+pip install transformers==4.48.2
+
+# 4) run the quant (Flash = single card). Input fp4 native OR pre-dequant bf16.
+export ASCEND_RT_VISIBLE_DEVICES=0
+cd /data1
+msmodelslim quant \
+  --model_path /data1/DeepSeek-V4-Flash-DSpark \
+  --save_path  /data1/DeepSeek-V4-Flash-DSpark-w8a8 \
+  --model_type DeepSeek-V4-Flash-DSpark \
+  --config_path lab_practice/deepseek_v4/deepseek_v4_flash_dspark_w8a8.yaml \
+  --trust_remote_code True

--- a/tools/dspark_quant/fold_quarot_into_main_proj.py
+++ b/tools/dspark_quant/fold_quarot_into_main_proj.py
@@ -1,0 +1,37 @@
+import json, os, glob, shutil, torch
+from safetensors.torch import safe_open, save_file
+SRC = "/data1/DeepSeek-V4-Flash-DSpark-bf16"
+DST = "/data2/DeepSeek-V4-Flash-DSpark-bf16-folded-draft"
+QP  = "/data1/DeepSeek-V4-Flash-DSpark-w8a8-draft/optional/quarot.safetensors"
+KEY = "mtp.0.main_proj.weight"
+idx = json.load(open("/data2/DeepSeek-V4-Flash-DSpark-bf16-draft/model.safetensors.index.json"))
+shard = idx["weight_map"][KEY]
+print("main_proj in shard:", shard)
+with safe_open(os.path.join("/data2/DeepSeek-V4-Flash-DSpark-bf16-draft", shard), framework="pt") as h:
+    keys = list(h.keys()); tensors = {k: h.get_tensor(k) for k in keys}
+W = tensors[KEY].float()                      # [4096, 12288]
+with safe_open(QP, framework="pt") as h:
+    Q = h.get_tensor("global_rotation").float()   # [4096, 4096]
+h_dim = Q.shape[0]; n = W.shape[1] // h_dim
+print("W", tuple(W.shape), "Q", tuple(Q.shape), "blocks", n)
+Wf = torch.cat([W[:, k*h_dim:(k+1)*h_dim] @ Q for k in range(n)], dim=1)
+# validation: y_old = (x @ Qt blockwise) @ W^T  vs  y_new = x @ Wf^T
+x = torch.randn(8, n*h_dim)
+xrot = torch.cat([x[:, k*h_dim:(k+1)*h_dim] @ Q.t() for k in range(n)], dim=1)
+y_old = xrot @ W.t(); y_new = x @ Wf.t()
+cos = torch.nn.functional.cosine_similarity(y_old.flatten(), y_new.flatten(), dim=0)
+print("fold validation cosine: %.8f  maxdiff: %.3e" % (cos.item(), (y_old-y_new).abs().max().item()))
+assert cos.item() > 0.9999
+tensors[KEY] = Wf.to(tensors[KEY].dtype)
+os.makedirs(DST, exist_ok=True)
+# symlink everything from the existing -draft dir, replace only the fold shard + drop optional/
+SRCDRAFT = "/data2/DeepSeek-V4-Flash-DSpark-bf16-draft"
+for f in os.listdir(SRCDRAFT):
+    if f == "optional": continue
+    s = os.path.join(SRCDRAFT, f); d = os.path.join(DST, f)
+    if os.path.lexists(d): os.remove(d)
+    if f == shard: continue
+    if os.path.islink(s): os.symlink(os.readlink(s), d)
+    else: shutil.copy(s, d)
+save_file(tensors, os.path.join(DST, shard), metadata={"format": "pt"})
+print("FOLDED draft dir ready:", DST, "(no optional/ -> quarot no-op)")

--- a/tools/dspark_quant/msslim_dspark_adapter.py
+++ b/tools/dspark_quant/msslim_dspark_adapter.py
@@ -1,0 +1,152 @@
+# DeepSeek-V4-Flash-DSpark quant adapter for msModelSlim (path A).
+# Subclasses DeepSeekV4ModelAdapter; overrides the 4 MTP-1-specific spots with the
+# DSpark draft structure (main_proj/main_norm + 3-stage stack + markov/confidence).
+# Place at: msmodelslim/model/deepseek_v4/dspark_adapter.py  (+ register via loader)
+#
+# UNTESTED until full ckpt downloads + a free card. Logic written against the read
+# framework; the capture-target-layers calib forward (generate_model_forward) is the
+# part most likely to need on-NPU tweaking.
+from typing import Any, Generator, Tuple, Dict, Optional
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+from msmodelslim.core.base.protocol import ProcessRequest
+from msmodelslim.utils.exception import InvalidModelError
+from msmodelslim.utils.logging import get_logger
+from .convert_fp8_to_bf16 import auto_dequant_state_dict
+from .model_adapter import DeepSeekV4ModelAdapter
+from .model import Transformer
+from ..common.weight_helper import get_state_dict
+from ..common.transformers import TransformersForwardBreak
+from .dspark_model import DSparkBlock
+
+
+class DeepSeekV4DSparkModelAdapter(DeepSeekV4ModelAdapter):
+
+    def get_model_pedigree(self) -> str:
+        return 'deepseek_v4'
+
+    # ---- ⑤ config: add dspark_* fields + force n_mtp_layers=3 ----
+    def _load_config(self, trust_remote_code=False):
+        from msmodelslim.utils.security import json_safe_load
+        import os.path
+        args = super()._load_config(trust_remote_code)
+        cfg = json_safe_load(os.path.join(self.model_path, "config.json"))
+        args.dspark_block_size = cfg["dspark_block_size"]
+        args.dspark_noise_token_id = cfg["dspark_noise_token_id"]
+        args.dspark_target_layer_ids = list(cfg["dspark_target_layer_ids"])
+        args.dspark_markov_rank = cfg["dspark_markov_rank"]
+        # DSpark draft = 3 stages (config n_mtp_layers, else count mtp.* in weight_map)
+        args.n_mtp_layers = cfg.get("n_mtp_layers", 3)
+        return args
+
+    # ---- ③ scaffold: build DSparkBlock (not Block+MTPLayer) for mtp stages ----
+    def load_mtp_decoder_if_not_exist(self, model: nn.Module, layer_prefix: str, mtp_idx: int):
+        try:
+            return model.mtp[mtp_idx]
+        except (IndexError, AttributeError):
+            with patch.object(nn.Linear, 'reset_parameters', lambda _self: None):
+                get_logger().info('Creating DSpark MTP stage %s', mtp_idx)
+                layer_id = self.config.num_hidden_layers + mtp_idx
+                blk = DSparkBlock(layer_id, self.config)
+                state_dict = get_state_dict(self.model_path, blk, prefix=layer_prefix)
+                auto_dequant_state_dict(layer_prefix, state_dict, str(self.model_path))
+                blk.load_state_dict(state_dict, strict=False)
+                object.__setattr__(blk, "embed", model.embed)
+                object.__setattr__(blk, "head", model.head)
+                blk.eval()
+                model.mtp.append(blk)
+            return blk
+
+    # ---- ② calib forward: capture target layers [40,41,42] -> main_x -> DSpark stack ----
+    def generate_model_forward(self, model: nn.Module, inputs: Any) -> Generator[ProcessRequest, Any, None]:
+        first_block_input: Optional[Tuple] = None
+
+        def break_hook(module, hook_args, hook_kwargs):
+            nonlocal first_block_input
+            first_block_input = (hook_args, hook_kwargs)
+            raise TransformersForwardBreak()
+
+        remove_handler = model.layers[0].register_forward_pre_hook(break_hook, with_kwargs=True, prepend=True)
+        try:
+            if isinstance(inputs, (list, tuple)):
+                model(inputs[0])
+            elif isinstance(inputs, dict):
+                model(**inputs)
+            else:
+                model(inputs)
+        except TransformersForwardBreak:
+            pass
+        finally:
+            remove_handler.remove()
+        if first_block_input is None:
+            raise InvalidModelError("Can't get first block input.", action="check model/input")
+
+        args, kwargs = first_block_input
+        h, start_pos, input_ids = args
+        target_ids = list(self.config.dspark_target_layer_ids)
+        captured: Dict[int, torch.Tensor] = {}
+        main_x = None
+        draft_h = None
+
+        for name, block in self.generate_decoder_layer(model):
+            if name.startswith('mtp.'):
+                mtp_idx = int(name.split('.')[1])
+                if mtp_idx == 0:
+                    # main_hidden = concat over target layers of mean-over-hc hidden
+                    main_hidden = torch.cat(
+                        [captured[i].mean(dim=2) for i in target_ids], dim=-1)
+                    draft_h, main_x = block.forward_embed(main_hidden, input_ids)
+                draft_args = (draft_h, start_pos, input_ids, main_x)
+                draft_h = yield ProcessRequest(name, block, draft_args, kwargs)
+                continue
+            # target layer
+            h = yield ProcessRequest(name, block, args, kwargs)
+            layer_idx = int(name.split('.')[1])
+            if layer_idx in target_ids:
+                captured[layer_idx] = h
+            args = (h, start_pos, input_ids)
+
+    # ---- ④ maps: post-process super() to drop MTP-1-only entries + add DSpark ones ----
+    def _dspark_fix_mtp_keys(self, mapping: dict):
+        """Remove MTP-1-only modules (enorm/hnorm/e_proj/h_proj) from a name->targets
+        map and inject DSpark main_norm->main_proj (stage0). norm->head kept only on the
+        last stage (DSpark mtp shares one head)."""
+        n_mtp = self.config.n_mtp_layers
+        for i in range(n_mtp):
+            for k in (f"mtp.{i}.enorm", f"mtp.{i}.hnorm"):
+                mapping.pop(k, None)
+            if i != n_mtp - 1:
+                mapping.pop(f"mtp.{i}.norm", None)
+        mapping[f"mtp.0.main_norm"] = ["mtp.0.main_proj"]
+        return mapping
+
+    def get_ln_fuse_map(self):
+        pre, ln = super().get_ln_fuse_map()
+        self._dspark_fix_mtp_keys(ln)
+        return pre, ln
+
+    def get_rotate_map(self, block_size):
+        pre_runs, rot_pairs = super().get_rotate_map(block_size)
+        # drop rotations on non-existent MTP-1 modules; keep attn/ffn/hc rotations.
+        n_mtp = self.config.n_mtp_layers
+        dead = []
+        for i in range(n_mtp):
+            dead += [f"mtp.{i}.h_proj", f"mtp.{i}.e_proj", f"mtp.{i}.emb.tok_emb"]
+            if i != n_mtp - 1:
+                dead.append(f"mtp.{i}.head")
+        for rp in rot_pairs:
+            for d in dead:
+                rp.left_rot.pop(d, None)
+                rp.right_rot.pop(d, None)
+        return pre_runs, rot_pairs
+
+    def get_adapter_config_for_subgraph(self):
+        cfgs = super().get_adapter_config_for_subgraph()
+        # The base only emits attn/ffn subgraphs (up-down, linear-linear, norm-linear)
+        # which DSpark mtp shares structurally -> nothing MTP-1-specific to strip here.
+        # main_proj has no smoothquant partner; it is quantized as a plain linear via
+        # the yaml `*main_proj*` include (handled in the recipe, not subgraph).
+        return cfgs

--- a/tools/dspark_quant/msslim_dspark_loader.py
+++ b/tools/dspark_quant/msslim_dspark_loader.py
@@ -1,0 +1,8 @@
+# -*- coding: UTF-8 -*-
+# Loader for the DeepSeek-V4-Flash-DSpark quant adapter.
+# Place at: msmodelslim/model/deepseek_v4/dspark_loader.py
+from msmodelslim.model.plugin_factory.base_loader import BaseModelAdapterLoader
+
+
+class DeepseekV4DSparkAdapterLoader(BaseModelAdapterLoader):
+    ADAPTER_CLASS_PATH = "msmodelslim.model.deepseek_v4.dspark_adapter:DeepSeekV4DSparkModelAdapter"

--- a/tools/dspark_quant/msslim_dspark_model.py
+++ b/tools/dspark_quant/msslim_dspark_model.py
@@ -1,0 +1,148 @@
+# DSpark model classes for msModelSlim DeepSeek-V4 quant adapter (path A).
+# Ported from DeepSeek-V4-Flash-DSpark inference/model.py (dspark-ref/inference_model.py
+# L750-936), adapted to msModelSlim's msmodelslim/model/deepseek_v4/model.py base:
+#   - n_layers -> num_hidden_layers
+#   - reuse msModelSlim Block/Attention/RMSNorm/Linear/MoE (import from .model)
+#   - heads kept simple (markov/confidence are EXCLUDED from quant -> bf16; only need
+#     to exist as modules so the scaffold loads + the calib forward runs)
+# Goal: provide the modules + forward msModelSlim's calib loop drives for the DSpark
+# draft (3 mtp stages, main_proj over target layers [40,41,42], semi-AR head).
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from .model import Attention, Block, RMSNorm, apply_rotary_emb, sparse_attn
+# NOTE: msModelSlim runs the model in bf16 for calibration; activation quant is done
+# by the framework hooks, NOT in the forward -> do NOT call act_quant here (it is
+# commented out in model.py). No self.scale_fmt/scale_dtype on Attention either.
+
+
+def get_dspark_topk_idxs(window_size, bsz, block_size, start_pos):
+    assert start_pos > 0
+    matrix = torch.cat([torch.arange(min(window_size, start_pos + 1)),
+                        window_size + torch.arange(block_size)])
+    return matrix.int().view(1, 1, -1).expand(bsz, block_size, -1).contiguous()
+
+
+class DSparkAttention(Attention):
+    """MLA where CONTEXT KV comes from main_x (the projected target-layer hidden);
+    the block's own KV/Q come from x. compress_ratio==0 (pure sliding window).
+    Ref inference_model.py L750-792."""
+
+    def forward(self, x, start_pos, main_x):
+        # CALIBRATION forward (bf16, no act_quant). Goal: route BOTH main_x and the
+        # block x through wkv (context + block KV), x through wq_a/wq_b, output through
+        # wo_a/wo_b, so all linears see representative activations. Mirrors msModelSlim
+        # Attention.forward style (simplified, always-prefill cache write).
+        bsz, blk, _ = x.size()
+        win = self.window_size
+        rd = self.rope_head_dim
+        ctx = main_x.size(1)
+
+        # context KV from main_x -> window cache
+        main_kv = self.kv_norm(self.wkv(main_x))
+        apply_rotary_emb(main_kv[..., -rd:], self.freqs_cis[start_pos:start_pos + ctx])
+        self.kv_cache[:bsz, :min(win, ctx)] = main_kv[:, -win:]
+
+        # block q/kv from x
+        fc = self.freqs_cis[start_pos + ctx:start_pos + ctx + blk]
+        q = self.q_norm(self.wq_a(x))
+        q = self.wq_b(q).unflatten(-1, (self.n_local_heads, self.head_dim))
+        q *= torch.rsqrt(q.square().mean(-1, keepdim=True) + self.eps)
+        apply_rotary_emb(q[..., -rd:], fc)
+        kv = self.kv_norm(self.wkv(x))
+        apply_rotary_emb(kv[..., -rd:], fc)
+
+        kv = torch.cat([self.kv_cache[:bsz], kv], dim=1)
+        topk_idxs = get_dspark_topk_idxs(win, bsz, blk, max(start_pos, 1))
+        o = sparse_attn(q, kv, self.attn_sink, topk_idxs, self.softmax_scale)
+        apply_rotary_emb(o[..., -rd:], fc, True)
+
+        o = o.view(bsz, blk, self.n_local_groups, -1)
+        wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
+        o = torch.einsum("bsgd,grd->bsgr", o, wo_a)
+        return self.wo_b(o.flatten(2))
+
+
+class DSparkMarkovHead(nn.Module):
+    """Eq.5 Markov head. EXCLUDED from quant (bf16). markov_w1=embedding, markov_w2=head."""
+
+    def __init__(self, vocab_size, dim, markov_rank):
+        super().__init__()
+        self.markov_w1 = nn.Embedding(vocab_size, markov_rank)
+        self.markov_w2 = nn.Linear(markov_rank, vocab_size, bias=False)
+
+    def forward(self, token_ids):
+        embed = self.markov_w1(token_ids)
+        return self.markov_w2(embed), embed
+
+
+class DSparkConfidenceHead(nn.Module):
+    """Eq.7 confidence head (raw logit, fp32). EXCLUDED from quant (bf16)."""
+
+    def __init__(self, input_dim):
+        super().__init__()
+        self.proj = nn.Linear(input_dim, 1, bias=False)
+
+    def forward(self, hidden, markov_embed):
+        h = torch.cat([hidden, markov_embed], dim=-1)
+        return self.proj(h.float()).squeeze(-1)
+
+
+class DSparkBlock(Block):
+    """DSpark draft stage (mtp.* namespace). Extends msModelSlim Block but swaps in
+    DSparkAttention and adds stage-special modules: main_proj/main_norm on stage 0,
+    norm/markov_head/confidence_head/hc_head_* on the last stage.
+    Ref inference_model.py DSparkBlock L818-874."""
+
+    def __init__(self, layer_id, args):
+        super().__init__(layer_id, args)
+        self.attn = DSparkAttention(layer_id, args)      # swap MLA -> DSpark MLA
+        self.dim = args.dim
+        stage_id = layer_id - args.num_hidden_layers
+        self.block_size = args.dspark_block_size
+        self.noise_token_id = args.dspark_noise_token_id
+        n_target = len(args.dspark_target_layer_ids)
+        hc_mult = args.hc_mult
+        hc_dim = hc_mult * args.dim
+        if stage_id == 0:
+            self.main_proj = nn.Linear(args.dim * n_target, args.dim, bias=False)
+            self.main_norm = RMSNorm(args.dim, args.norm_eps)
+        if stage_id == args.n_mtp_layers - 1:
+            self.norm = RMSNorm(args.dim, args.norm_eps)
+            self.markov_head = DSparkMarkovHead(args.vocab_size, args.dim, args.dspark_markov_rank)
+            self.confidence_head = DSparkConfidenceHead(args.dim + args.dspark_markov_rank)
+            origin = torch.get_default_dtype(); torch.set_default_dtype(torch.float32)
+            self.hc_head_fn = nn.Parameter(torch.empty(hc_mult, hc_dim))
+            self.hc_head_base = nn.Parameter(torch.empty(hc_mult))
+            self.hc_head_scale = nn.Parameter(torch.empty(1))
+            torch.set_default_dtype(origin)
+        # shared from main model (set during scaffold wrap): embed, head
+        object.__setattr__(self, "embed", None)
+        object.__setattr__(self, "head", None)
+
+    def forward(self, x, start_pos, input_ids, main_x):
+        # During calib only the attn/ffn weights matter; reuse Block.forward path but
+        # route main_x into DSparkAttention. Block.forward calls self.attn(x, start_pos)
+        # -> we need (x, start_pos, main_x); override the attn call here.
+        residual = x
+        x, post, comb = self.hc_pre(x, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base)
+        x = self.attn_norm(x)
+        x = self.attn(x, start_pos, main_x)              # DSparkAttention: KV from main_x
+        x = self.hc_post(x, residual, post, comb)
+        residual = x
+        x, post, comb = self.hc_pre(x, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base)
+        x = self.ffn_norm(x)
+        x = self.ffn(x, input_ids)
+        x = self.hc_post(x, residual, post, comb)
+        return x
+
+    def forward_embed(self, main_hidden, input_ids):
+        """stage-0: main_x = main_norm(main_proj(concat of target layers' mean-pooled
+        hidden)); draft block = [anchor, noise...] embedded + hc-expanded. Ref L851-858."""
+        main_x = self.main_norm(self.main_proj(main_hidden))
+        draft_ids = input_ids.new_full([input_ids.size(0), self.block_size], self.noise_token_id)
+        draft_ids[:, 0] = input_ids if input_ids.ndim == 1 else input_ids[:, -1]
+        x = self.embed(draft_ids)
+        x = x.unsqueeze(2).repeat(1, 1, self.hc_mult, 1)
+        return x, main_x

--- a/tools/dspark_quant/run_bf16draft.sh
+++ b/tools/dspark_quant/run_bf16draft.sh
@@ -1,0 +1,12 @@
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /data1/qvenv/bin/activate
+export ASCEND_RT_VISIBLE_DEVICES=0
+cd /data1
+echo "BF16DRAFT_QUANT_START $(date)"
+msmodelslim quant \
+  --model_path /data1/DeepSeek-V4-Flash-DSpark \
+  --save_path /data1/DeepSeek-V4-Flash-DSpark-bf16draft \
+  --model_type DeepSeek-V4-Flash-DSpark \
+  --config_path /data1/dspark_msslim/deepseek_v4_flash_dspark_bf16draft.yaml \
+  --trust_remote_code True
+echo "BF16DRAFT_QUANT_END rc=$? $(date)"

--- a/tools/dspark_quant/run_full.sh
+++ b/tools/dspark_quant/run_full.sh
@@ -1,0 +1,10 @@
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /data1/qvenv/bin/activate
+export ASCEND_RT_VISIBLE_DEVICES=0
+cd /data1
+msmodelslim quant \
+  --model_path /data1/DeepSeek-V4-Flash-DSpark \
+  --save_path /data1/DeepSeek-V4-Flash-DSpark-w8a8 \
+  --model_type DeepSeek-V4-Flash-DSpark \
+  --config_path /data1/msmodelslim/lab_practice/deepseek_v4/deepseek_v4_flash_dspark_w8a8.yaml \
+  --trust_remote_code True

--- a/tools/dspark_quant/run_quant.sh
+++ b/tools/dspark_quant/run_quant.sh
@@ -1,0 +1,10 @@
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /data1/qvenv/bin/activate
+export ASCEND_RT_VISIBLE_DEVICES=0
+cd /data1
+msmodelslim quant \
+  --model_path /data1/DeepSeek-V4-Flash-DSpark \
+  --save_path  /data1/DeepSeek-V4-Flash-DSpark-w8a8 \
+  --model_type DeepSeek-V4-Flash-DSpark \
+  --config_path /data1/msmodelslim/lab_practice/deepseek_v4/deepseek_v4_flash_dspark_w8a8.yaml \
+  --trust_remote_code True

--- a/tools/dspark_quant/setup_quant_env.sh
+++ b/tools/dspark_quant/setup_quant_env.sh
@@ -1,0 +1,32 @@
+set -e
+exec > /data1/dspark_msslim/_setup.log 2>&1
+echo "=== [1] venv (继承 system torch_npu) ==="
+python -m venv --system-site-packages /data1/qvenv
+source /data1/qvenv/bin/activate
+echo "py: $(which python)"
+echo "=== [2] transformers 4.48.2 (shadow system 5.5.4) ==="
+pip install -q transformers==4.48.2
+echo "=== [3] 放 DSpark adapter 文件 ==="
+MS=/data1/msmodelslim; DV=$MS/msmodelslim/model/deepseek_v4
+cp /data1/dspark_msslim/msslim_dspark_model.py   $DV/dspark_model.py
+cp /data1/dspark_msslim/msslim_dspark_adapter.py $DV/dspark_adapter.py
+cp /data1/dspark_msslim/msslim_dspark_loader.py  $DV/dspark_loader.py
+cp /data1/dspark_msslim/deepseek_v4_flash_dspark_w8a8.yaml $MS/lab_practice/deepseek_v4/
+echo "=== [4] patch config.ini (加 deepseek_v4_dspark group) ==="
+python - <<PY
+ini="/data1/msmodelslim/config/config.ini"
+s=open(ini).read()
+edits=[
+ ("deepseek_v4 = DeepSeek-V4-Flash, DeepSeek-V4-Pro","\ndeepseek_v4_dspark = DeepSeek-V4-Flash-DSpark"),
+ ("deepseek_v4 = msmodelslim.model.deepseek_v4.loader:DeepseekV4AdapterLoader","\ndeepseek_v4_dspark = msmodelslim.model.deepseek_v4.dspark_loader:DeepseekV4DSparkAdapterLoader"),
+ ('deepseek_v4 = {"transformers": "==4.48.2"}','\ndeepseek_v4_dspark = {"transformers": "==4.48.2"}'),
+]
+for a,add in edits:
+    if add.strip() in s: continue
+    assert a in s, "anchor: "+a[:40]
+    s=s.replace(a,a+add,1)
+open(ini,"w").write(s); print("config.ini patched")
+PY
+echo "=== [5] 装 msModelSlim (注册 entry points 到 venv) ==="
+cd $MS && bash install.sh
+echo "=== DONE ==="

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -49,7 +49,9 @@ from vllm_ascend._310p.ops.rotary_embedding import prepare_mrope_cos_sin_slices_
 from vllm_ascend._310p.sample.rejection_sampler import AscendRejectionSampler310
 from vllm_ascend._310p.sample.sampler import AscendSampler310
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.spec_decode.utils import update_num_computed_tokens_for_batch_change
+from vllm_ascend.spec_decode.utils import (
+    update_num_computed_tokens_for_batch_change,
+)
 from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, lmhead_tp_enable
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
@@ -502,13 +504,12 @@ class NPUModelRunner310(NPUModelRunner):
             and self.valid_sampled_token_count_gpu is not None
             and prev_req_id_to_index
         ):
-            self.optimistic_seq_lens_cpu[:num_reqs].copy_(self.seq_lens[:num_reqs], non_blocking=True)
-            if self._seq_lens_cpu_event is None:
-                self._seq_lens_cpu_event = torch.npu.Event()
-            self._seq_lens_cpu_event.record()
-            self._seq_lens_cpu_event_pending = True
-        else:
-            self._seq_lens_cpu_event_pending = False
+            # Correct optimistic_seq_lens_cpu on CPU using the asynchronously
+            # copied valid-sampled-token counts; avoids an extra NPU->CPU copy
+            # of seq_lens and the event.synchronize() in attention metadata.
+            # The shared helper synchronizes on the D2H copy event before the
+            # host read to avoid consuming stale counts (see its docstring).
+            self._correct_optimistic_seq_lens_cpu(num_reqs)
 
         use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
         if not use_spec_decode:

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -873,6 +873,21 @@ class AscendDSACPImpl(DSAAttentionImpl):
     understand this class
     """
 
+    @staticmethod
+    def update_graph_params(
+        update_stream,
+        forward_context,
+        num_tokens,
+        vllm_config=None,
+        speculative_config=None,
+        num_dcp_pcp_tokens=None,
+        draft_attn_metadatas=None,
+    ):
+        # MTP graph-mode fix: DSA-CP does not need per-step graph param updates
+        # (same as SFA). Required so the generic full-graph drafter path does
+        # not raise AttributeError under FULL_DECODE_ONLY + MTP.
+        pass
+
     def __init__(
         self,
         n_heads: int,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -526,6 +526,22 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             self.num_decodes, self.num_prefills, self.num_decode_tokens, self.num_prefill_tokens = (
                 split_decodes_and_prefills(common_attn_metadata, decode_threshold=self.decode_threshold)
             )
+            # DSpark: force the draft gamma block (1+S mask queries, q_len == decode
+            # threshold) to PREFILL. It is uniquely identified by ChunkedPrefill +
+            # causal=False (set by AscendDflashProposer.set_inputs_first_pass) with
+            # ALL reqs classified as decode. Without this the masks never cross-read
+            # the precompute-written context KV -> draft output collapses to a constant.
+            if (self.speculative_config is not None
+                    and getattr(common_attn_metadata, "attn_state", None) == AscendAttentionState.ChunkedPrefill
+                    and getattr(common_attn_metadata, "causal", True) is False
+                    and self.num_decodes == num_reqs and num_reqs > 0):
+                self.num_prefills = self.num_decodes
+                self.num_prefill_tokens = self.num_decode_tokens
+                self.num_decodes = 0
+                self.num_decode_tokens = 0
+                import os as _osp, sys as _syp
+                if _osp.environ.get("DSPARK_DBG"):
+                    print("DSPARK_FORCEPREFILL fired num_prefills=%d num_reqs=%d" % (self.num_prefills, num_reqs), file=_syp.stderr, flush=True)
             self.common_ratio_to_sas_metadata["num_decodes"] = self.num_decodes
             self.common_ratio_to_sas_metadata["num_prefills"] = self.num_prefills
             self.common_ratio_to_sas_metadata["num_decode_tokens"] = self.num_decode_tokens
@@ -1285,9 +1301,12 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         max_seqlen_kv = torch.max(_seq_lens_cpu[:num_decodes]).item()
 
         input_positions = common_attn_metadata.positions[:num_decode_tokens_typed].long()
-        # disable use_cache, otherwise, draft_step>0 will override draft_step=0
-        # take care of this, if full graph is needed then rope cache is inevitable
-        cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=False)
+        # MTP FullGraph fix: use a per-draft-step fixed-address cache slot. use_cache=False
+        # returns a fresh tensor each call -> stale under cudagraph (graph bound to capture
+        # address); the shared slot-0 buffer (use_cache=True) would be overridden by
+        # draft_step>0. cache_slot=draft_step gives each step its own persistent buffer,
+        # refreshed in-place each iteration, so the captured graph reads correct cos/sin.
+        cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=True, cache_slot=draft_step)
 
         slot_mapping = self.spec_slot_mapping[draft_step - 1][:num_decode_tokens_typed]  # type: ignore[index]
         block_table = common_attn_metadata.block_table_tensor
@@ -1319,6 +1338,17 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             has_cmp_kv=False,
         )
 
+        # MTP FullGraph fix (P0): sas_metadata must live at a per-draft-step FIXED
+        # address — mirror step-0 (build_decode_metadata binds self.decode_sas_metadata,
+        # refreshed in-place). The raw metadata_op output above is freshly allocated each
+        # iteration, so under FULL cudagraph the captured attn op reads a stale descriptor
+        # at replay. Give each draft_step its own persistent buffer, refreshed in-place.
+        if not hasattr(self, "decode_sas_metadata_draft"):
+            self.decode_sas_metadata_draft: dict[int, torch.Tensor] = {}
+        if draft_step not in self.decode_sas_metadata_draft:
+            self.decode_sas_metadata_draft[draft_step] = torch.empty_like(self.decode_sas_metadata)
+        self.decode_sas_metadata_draft[draft_step][:1024] = decode_sas_metadata
+
         decode_metadata = AscendDSADecodeMetadata(
             input_positions=None,
             block_table=block_table[:num_decodes, ...],
@@ -1338,7 +1368,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             cp_seq_len=None,
             batch_seq_mask=None,
             start_pos=None,
-            sas_metadata=decode_sas_metadata,
+            sas_metadata=self.decode_sas_metadata_draft[draft_step],
             qli_metadata=None,
         )
         return decode_metadata
@@ -1380,6 +1410,22 @@ class AscendDSAImpl(DSAAttentionImpl):
     NOTE: Please read the comment at the top of the file before trying to
     understand this class
     """
+
+    @staticmethod
+    def update_graph_params(
+        update_stream,
+        forward_context,
+        num_tokens,
+        vllm_config=None,
+        speculative_config=None,
+        num_dcp_pcp_tokens=None,
+        draft_attn_metadatas=None,
+    ):
+        # MTP graph-mode fix: DSA does not need per-step graph param updates
+        # (same as SFA). The generic full-graph drafter path calls
+        # impl_cls.update_graph_params(...), so this no-op must exist or it
+        # raises AttributeError under FULL_DECODE_ONLY + MTP.
+        pass
 
     def __init__(
         self,
@@ -1981,7 +2027,14 @@ class AscendDSAImpl(DSAAttentionImpl):
             )
 
             # swa exec kv
-            DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, swa_prefill_metadata.slot_mapping)
+            import os as _osk, sys as _ssk
+            if ("mtp." in layer_name) and _osk.environ.get("DSPARK_DBG"):
+                try: print("DSPARK_SELFKV layer=%s selfkv_slot[:8]=%s kvshape=%s" % (layer_name, swa_prefill_metadata.slot_mapping.flatten()[:8].tolist(), tuple(kv.shape)), file=_ssk.stderr, flush=True)
+                except Exception as _eee: print("DSPARK_SELFKV ERR", _eee, file=_ssk.stderr, flush=True)
+            if ("mtp." in layer_name) and _osk.environ.get("DSPARK_NO_SELFKV", "1") == "1":
+                pass  # DSpark: skip block self-KV scatter so precompute context-KV is not clobbered (slot collision)
+            else:
+                DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, swa_prefill_metadata.slot_mapping)
 
         compress_cos = common_prefill_metadata.compress_cos[layer_name]
         compress_sin = common_prefill_metadata.compress_sin[layer_name]
@@ -1991,6 +2044,95 @@ class AscendDSAImpl(DSAAttentionImpl):
         DeviceOperator.add_dsa_sparse_attn_extra_kwargs(extra_attn_kwargs, cu_seqlens_ori_kv=actual_seq_lengths_query)
 
         if self.compress_ratio <= 1:
+            import os as _ob1, sys as _ob1s
+            if ("mtp." in layer_name) and _ob1.environ.get("DSPARK_OPTB"):
+                try:
+                    _T = q.shape[0]; _N = self.n_local_heads; _H = self.head_dim
+                    _B = int(actual_seq_lengths_key.shape[0]) if hasattr(actual_seq_lengths_key, 'shape') else len(actual_seq_lengths_key)
+                    _S = _T // _B
+                    _q4 = q.view(_B, _S, _N, _H).contiguous()
+                    _kv = swa_kv_cache.reshape(swa_kv_cache.shape[0], 1, swa_kv_cache.shape[1], swa_kv_cache.shape[3])
+                    if _ob1.environ.get('DSPARK_DBG'):
+                        print('DSPARK_OPTB1 bsnd q4=%s kv=%s B=%s S=%s H=%s' % (tuple(_q4.shape), tuple(_kv.shape), _B, _S, _H), file=_ob1s.stderr, flush=True)
+                    _oc, _lc = torch.ops.npu.npu_fused_infer_attention_score(
+                        _q4, _kv, _kv,
+                        num_heads=_N, num_key_value_heads=1, input_layout='BSND',
+                        scale=self.softmax_scale, sparse_mode=0,
+                        atten_mask=None, antiquant_mode=0, antiquant_scale=None,
+                        softmax_lse_flag=True,
+                        block_table=swa_prefill_metadata.block_table,
+                        block_size=swa_kv_cache.shape[1],
+                        actual_seq_lengths_kv=actual_seq_lengths_key,
+                    )
+                    _bk = kv.reshape(_B, _S, 1, _H).contiguous()
+                    _ob, _lb = torch.ops.npu.npu_fused_infer_attention_score(
+                        _q4, _bk, _bk,
+                        num_heads=_N, num_key_value_heads=1, input_layout='BSND',
+                        scale=self.softmax_scale, sparse_mode=0,
+                        atten_mask=None, antiquant_mode=0, antiquant_scale=None,
+                        softmax_lse_flag=True,
+                    )
+                    _lc = _lc.transpose(1, 2).float(); _lb = _lb.transpose(1, 2).float()
+                    _m = torch.maximum(_lc, _lb)
+                    _wc = torch.exp(_lc - _m); _wb = torch.exp(_lb - _m)
+                    _den = _wc + _wb + 1e-9
+                    _merged = (_oc.float() * _wc + _ob.float() * _wb) / _den
+                    try:
+                        _cnt = getattr(_ob1, "_DSPARK_CNT", 0) + 1; _ob1._DSPARK_CNT = _cnt
+                        if _cnt % 50 == 1:
+                            _rel = (_merged - _oc.float()).norm() / (_oc.float().norm() + 1e-9)
+                            _ratio = (_wb / (_wc + 1e-9)).mean()
+                            print("DSPARK_DIAG cnt=%d lc=%.3f lb=%.3f wb/wc=%.5f rel=%.5f" % (_cnt, float(_lc.mean()), float(_lb.mean()), float(_ratio), float(_rel)), file=_ob1s.stderr, flush=True)
+                    except Exception as _de:
+                        print("DSPARK_DIAG ERR %r"%(_de,), file=_ob1s.stderr, flush=True)
+                    if _ob1.environ.get('DSPARK_DBG'):
+                        print('DSPARK_OPTB2 oc=%s ob=%s lc=%s merged=%s' % (tuple(_oc.shape), tuple(_ob.shape), tuple(_lc.shape), tuple(_merged.shape)), file=_ob1s.stderr, flush=True)
+                    return _merged.to(q.dtype).reshape(_T, _N, _H)
+                except Exception as _obe:
+                    print("DSPARK_OPTB1 FIA ERR: %r" % (_obe,), file=_ob1s.stderr, flush=True)
+                    raise
+            import os as _rtos, sys as _rtsys
+            if (_rtos.environ.get("DSPARK_READ_TRACE") and "mtp." in layer_name
+                    and hasattr(self, "_dspark_last_ctx_pos") and hasattr(self, "_dspark_last_ctx_slot")):
+                try:
+                    bt = swa_prefill_metadata.block_table.to(torch.int64)
+                    cache_bs = int(swa_kv_cache.shape[1])
+                    pos = self._dspark_last_ctx_pos.to(bt.device)
+                    wslot = self._dspark_last_ctx_slot.to(bt.device)
+                    try:
+                        _kvf = swa_kv_cache.reshape(-1, swa_kv_cache.shape[-1])
+                        _wsl = wslot.clamp(min=0, max=_kvf.shape[0]-1)
+                        _sv = _kvf.index_select(0, _wsl)
+                        _wp = int(getattr(self, "_dspark_write_cache_ptr", -1))
+                        _rp = int(swa_kv_cache.data_ptr())
+                        print("DSPARK_CACHECHK layer=%s rptr=%d wptr=%d same=%s ctxval min=%.3f max=%.3f mean=%.3f" % (layer_name, _rp, _wp, _rp==_wp, float(_sv.min()), float(_sv.max()), float(_sv.mean())), file=_rtsys.stderr, flush=True)
+                    except Exception as _ce:
+                        print("DSPARK_CACHECHK ERR %r"%(_ce,), file=_rtsys.stderr, flush=True)
+                    nreq = int(bt.shape[0])
+                    per = pos.numel() // max(nreq, 1)
+                    if per > 0 and per * nreq == pos.numel():
+                        pos2 = pos.view(nreq, per); wslot2 = wslot.view(nreq, per)
+                        bidx = torch.div(pos2, cache_bs, rounding_mode="floor")
+                        off = pos2 % cache_bs
+                        bidx_c = bidx.clamp(min=0, max=bt.shape[1]-1)
+                        rblock = torch.gather(bt[:nreq], 1, bidx_c)
+                        rslot2 = rblock * cache_bs + off
+                        qlens = (actual_seq_lengths_query[1:] - actual_seq_lengths_query[:-1]).to(torch.int64)
+                        klen = actual_seq_lengths_key.to(torch.int64)
+                        q0_logical = klen - qlens
+                        win_left = int(self.window_size - 1)
+                        lo = (q0_logical - win_left).clamp_min(0); hi = klen - 1
+                        inwin = (pos2 >= lo[:, None]) & (pos2 <= hi[:, None])
+                        match = (rslot2 == wslot2)
+                        print("DSPARK_READ_TRACE layer=%s cache_bs=%s nreq=%s per=%s qlens=%s klen=%s lo=%s hi=%s pos0=%s write0=%s read0=%s match0=%s inwin0=%s bt0=%s" % (
+                            layer_name, cache_bs, nreq, per,
+                            qlens[:4].cpu().tolist(), klen[:4].cpu().tolist(), lo[:4].cpu().tolist(), hi[:4].cpu().tolist(),
+                            pos2[0, :min(per,8)].cpu().tolist(), wslot2[0, :min(per,8)].cpu().tolist(),
+                            rslot2[0, :min(per,8)].cpu().tolist(), match[0, :min(per,8)].cpu().tolist(),
+                            inwin[0, :min(per,8)].cpu().tolist(), bt[0, :min(bt.shape[1],8)].cpu().tolist()),
+                            file=_rtsys.stderr, flush=True)
+                except Exception as _rte:
+                    print("DSPARK_READ_TRACE_ERR layer=%s err=%r" % (layer_name, _rte), file=_rtsys.stderr, flush=True)
             return attn_op(
                 q,
                 ori_kv=swa_kv_cache,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -2055,15 +2055,37 @@ class AscendDSAImpl(DSAAttentionImpl):
                     _win = int(getattr(self, "window_size", 0)) or int(actual_seq_lengths_key.max().item())
                     import os as _cw
                     _ctxmode = _cw.environ.get("DSPARK_CTXLEN", "full")
-                    if _ctxmode == "clamp":
-                        _ctx_kv_len = torch.clamp(actual_seq_lengths_key, max=_win).to(actual_seq_lengths_key.dtype)
+                    if _ctxmode == "ring":
+                        # DSPARK_RING_V1: reference-faithful context = LAST min(win,klen)
+                        # positions (inference_model.py ring cache), not first-N (clamp)
+                        # nor full-length (full). Gather via block table into contiguous KV.
+                        _bs_c = int(swa_kv_cache.shape[1])
+                        _kvflat = swa_kv_cache.reshape(-1, swa_kv_cache.shape[-1])
+                        _kl64 = actual_seq_lengths_key.reshape(-1).to(torch.int64)
+                        _ctxn = torch.clamp(_kl64, max=_win)
+                        _pos0 = _kl64 - _ctxn
+                        _ar = torch.arange(_win, device=_q4.device).view(1, -1)
+                        _pos = _pos0.view(-1, 1) + _ar
+                        _bt64 = swa_prefill_metadata.block_table.to(torch.int64)
+                        _pgi = torch.div(_pos, _bs_c, rounding_mode="floor").clamp(min=0, max=_bt64.shape[1]-1)
+                        _pg = torch.gather(_bt64[: _pos.shape[0]], 1, _pgi)
+                        _slot = (_pg * _bs_c + (_pos % _bs_c)).reshape(-1).clamp(min=0, max=_kvflat.shape[0]-1)
+                        _ctxkv = _kvflat.index_select(0, _slot).view(_B, _win, 1, _H)
+                        _oc, _lc = torch.ops.npu.npu_fused_infer_attention_score(
+                            _q4, _ctxkv, _ctxkv, num_heads=_N, num_key_value_heads=1, input_layout='BSND',
+                            scale=self.softmax_scale, sparse_mode=0, atten_mask=None, softmax_lse_flag=True,
+                            actual_seq_lengths_kv=_ctxn.to(actual_seq_lengths_key.dtype))
+                        _ctx_kv_len = _ctxn  # DIAG2 compat
                     else:
-                        _ctx_kv_len = actual_seq_lengths_key.to(actual_seq_lengths_key.dtype)  # full: include recent positions
-                    _oc, _lc = torch.ops.npu.npu_fused_infer_attention_score(
-                        _q4, _kv, _kv, num_heads=_N, num_key_value_heads=1, input_layout='BSND',
-                        scale=self.softmax_scale, sparse_mode=0, atten_mask=None, softmax_lse_flag=True,
-                        block_table=swa_prefill_metadata.block_table, block_size=swa_kv_cache.shape[1],
-                        actual_seq_lengths_kv=_ctx_kv_len)
+                        if _ctxmode == "clamp":
+                            _ctx_kv_len = torch.clamp(actual_seq_lengths_key, max=_win).to(actual_seq_lengths_key.dtype)
+                        else:
+                            _ctx_kv_len = actual_seq_lengths_key.to(actual_seq_lengths_key.dtype)  # full: include recent positions
+                        _oc, _lc = torch.ops.npu.npu_fused_infer_attention_score(
+                            _q4, _kv, _kv, num_heads=_N, num_key_value_heads=1, input_layout='BSND',
+                            scale=self.softmax_scale, sparse_mode=0, atten_mask=None, softmax_lse_flag=True,
+                            block_table=swa_prefill_metadata.block_table, block_size=swa_kv_cache.shape[1],
+                            actual_seq_lengths_kv=_ctx_kv_len)
                     _bk = kv.reshape(_B, _S, 1, _H).contiguous()
                     _ob, _lb = torch.ops.npu.npu_fused_infer_attention_score(
                         _q4, _bk, _bk, num_heads=_N, num_key_value_heads=1, input_layout='BSND',

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -2052,41 +2052,47 @@ class AscendDSAImpl(DSAAttentionImpl):
                     _S = _T // _B
                     _q4 = q.view(_B, _S, _N, _H).contiguous()
                     _kv = swa_kv_cache.reshape(swa_kv_cache.shape[0], 1, swa_kv_cache.shape[1], swa_kv_cache.shape[3])
-                    if _ob1.environ.get('DSPARK_DBG'):
-                        print('DSPARK_OPTB1 bsnd q4=%s kv=%s B=%s S=%s H=%s' % (tuple(_q4.shape), tuple(_kv.shape), _B, _S, _H), file=_ob1s.stderr, flush=True)
+                    _win = int(getattr(self, "window_size", 0)) or int(actual_seq_lengths_key.max().item())
+                    import os as _cw
+                    _ctxmode = _cw.environ.get("DSPARK_CTXLEN", "full")
+                    if _ctxmode == "clamp":
+                        _ctx_kv_len = torch.clamp(actual_seq_lengths_key, max=_win).to(actual_seq_lengths_key.dtype)
+                    else:
+                        _ctx_kv_len = actual_seq_lengths_key.to(actual_seq_lengths_key.dtype)  # full: include recent positions
                     _oc, _lc = torch.ops.npu.npu_fused_infer_attention_score(
-                        _q4, _kv, _kv,
-                        num_heads=_N, num_key_value_heads=1, input_layout='BSND',
-                        scale=self.softmax_scale, sparse_mode=0,
-                        atten_mask=None, antiquant_mode=0, antiquant_scale=None,
-                        softmax_lse_flag=True,
-                        block_table=swa_prefill_metadata.block_table,
-                        block_size=swa_kv_cache.shape[1],
-                        actual_seq_lengths_kv=actual_seq_lengths_key,
-                    )
+                        _q4, _kv, _kv, num_heads=_N, num_key_value_heads=1, input_layout='BSND',
+                        scale=self.softmax_scale, sparse_mode=0, atten_mask=None, softmax_lse_flag=True,
+                        block_table=swa_prefill_metadata.block_table, block_size=swa_kv_cache.shape[1],
+                        actual_seq_lengths_kv=_ctx_kv_len)
                     _bk = kv.reshape(_B, _S, 1, _H).contiguous()
                     _ob, _lb = torch.ops.npu.npu_fused_infer_attention_score(
-                        _q4, _bk, _bk,
-                        num_heads=_N, num_key_value_heads=1, input_layout='BSND',
-                        scale=self.softmax_scale, sparse_mode=0,
-                        atten_mask=None, antiquant_mode=0, antiquant_scale=None,
-                        softmax_lse_flag=True,
-                    )
+                        _q4, _bk, _bk, num_heads=_N, num_key_value_heads=1, input_layout='BSND',
+                        scale=self.softmax_scale, sparse_mode=0, atten_mask=None, softmax_lse_flag=True)
                     _lc = _lc.transpose(1, 2).float(); _lb = _lb.transpose(1, 2).float()
+                    _msink = None
+                    try:
+                        _as = getattr(self, "attn_sink", None)
+                        if _as is not None:
+                            _msink = _as.reshape(-1)[:_N].float().view(1, 1, _N, 1)
+                    except Exception:
+                        _msink = None
                     _m = torch.maximum(_lc, _lb)
+                    if _msink is not None:
+                        _m = torch.maximum(_m, _msink)
                     _wc = torch.exp(_lc - _m); _wb = torch.exp(_lb - _m)
-                    _den = _wc + _wb + 1e-9
+                    _ws = torch.exp(_msink - _m) if _msink is not None else torch.zeros_like(_wc)
+                    _den = _wc + _wb + _ws + 1e-9
                     _merged = (_oc.float() * _wc + _ob.float() * _wb) / _den
                     try:
                         _cnt = getattr(_ob1, "_DSPARK_CNT", 0) + 1; _ob1._DSPARK_CNT = _cnt
                         if _cnt % 50 == 1:
-                            _rel = (_merged - _oc.float()).norm() / (_oc.float().norm() + 1e-9)
-                            _ratio = (_wb / (_wc + 1e-9)).mean()
-                            print("DSPARK_DIAG cnt=%d lc=%.3f lb=%.3f wb/wc=%.5f rel=%.5f" % (_cnt, float(_lc.mean()), float(_lb.mean()), float(_ratio), float(_rel)), file=_ob1s.stderr, flush=True)
+                            import sys as _ds
+                            print("DSPARK_DIAG2 cnt=%d win=%d klen=%s ctxlen=%s sink=%s wc=%.4f wb=%.4f ws=%.4f wb_over_wc=%.3f" % (
+                                _cnt, _win, int(actual_seq_lengths_key.reshape(-1)[0]), int(_ctx_kv_len.reshape(-1)[0]),
+                                (_msink is not None), float(_wc.mean()), float(_wb.mean()), float(_ws.mean()), float((_wb/(_wc+1e-9)).mean())), file=_ds.stderr, flush=True)
                     except Exception as _de:
-                        print("DSPARK_DIAG ERR %r"%(_de,), file=_ob1s.stderr, flush=True)
-                    if _ob1.environ.get('DSPARK_DBG'):
-                        print('DSPARK_OPTB2 oc=%s ob=%s lc=%s merged=%s' % (tuple(_oc.shape), tuple(_ob.shape), tuple(_lc.shape), tuple(_merged.shape)), file=_ob1s.stderr, flush=True)
+                        import sys as _ds2
+                        print("DSPARK_DIAG2 ERR %r"%(_de,), file=_ds2.stderr, flush=True)
                     return _merged.to(q.dtype).reshape(_T, _N, _H)
                 except Exception as _obe:
                     print("DSPARK_OPTB1 FIA ERR: %r" % (_obe,), file=_ob1s.stderr, flush=True)

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -789,20 +789,18 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         # Save TP-mode parameters (original sharded weights)
         self.o_proj_tp_weight = self.o_proj.weight.clone().detach()
-        self.o_proj_tp_aclnn_input_scale = self.o_proj.aclnn_input_scale.clone().detach()
-        self.o_proj_tp_aclnn_input_scale_reciprocal = self.o_proj.aclnn_input_scale_reciprocal.clone().detach()
-        self.o_proj_tp_aclnn_input_offset = self.o_proj.aclnn_input_offset.clone().detach()
-
-        # Initially switch to TP mode for graph capture
+        self._o_proj_has_aclnn = hasattr(self.o_proj, "aclnn_input_scale")
         self.o_proj.weight.set_(self.o_proj_tp_weight)
-        self.o_proj.aclnn_input_scale.set_(self.o_proj_tp_aclnn_input_scale)
-        self.o_proj.aclnn_input_scale_reciprocal.set_(self.o_proj_tp_aclnn_input_scale_reciprocal)
-        self.o_proj.aclnn_input_offset.set_(self.o_proj_tp_aclnn_input_offset)
-
-        # Precompute Full-mode quantization parameters by repeating TP parameters across all TP ranks
-        self.o_proj_full_aclnn_input_scale = self.o_proj.aclnn_input_scale.repeat(self.tp_size)
-        self.o_proj_full_aclnn_input_scale_reciprocal = self.o_proj.aclnn_input_scale_reciprocal.repeat(self.tp_size)
-        self.o_proj_full_aclnn_input_offset = self.o_proj.aclnn_input_offset.repeat(self.tp_size)
+        if self._o_proj_has_aclnn:
+            self.o_proj_tp_aclnn_input_scale = self.o_proj.aclnn_input_scale.clone().detach()
+            self.o_proj_tp_aclnn_input_scale_reciprocal = self.o_proj.aclnn_input_scale_reciprocal.clone().detach()
+            self.o_proj_tp_aclnn_input_offset = self.o_proj.aclnn_input_offset.clone().detach()
+            self.o_proj.aclnn_input_scale.set_(self.o_proj_tp_aclnn_input_scale)
+            self.o_proj.aclnn_input_scale_reciprocal.set_(self.o_proj_tp_aclnn_input_scale_reciprocal)
+            self.o_proj.aclnn_input_offset.set_(self.o_proj_tp_aclnn_input_offset)
+            self.o_proj_full_aclnn_input_scale = self.o_proj.aclnn_input_scale.repeat(self.tp_size)
+            self.o_proj_full_aclnn_input_scale_reciprocal = self.o_proj.aclnn_input_scale_reciprocal.repeat(self.tp_size)
+            self.o_proj_full_aclnn_input_offset = self.o_proj.aclnn_input_offset.repeat(self.tp_size)
 
     def _handle_o_proj_weight_switch_and_forward(
         self,
@@ -822,18 +820,20 @@ class AscendSFAImpl(MLAAttentionImpl):
 
             # Switch o_proj to Full-mode (gathered weight from all TP ranks)
             self.o_proj.weight.set_(AscendSFAImpl.o_proj_full_pool)
-            self.o_proj.aclnn_input_scale.set_(self.o_proj_full_aclnn_input_scale)
-            self.o_proj.aclnn_input_scale_reciprocal.set_(self.o_proj_full_aclnn_input_scale_reciprocal)
-            self.o_proj.aclnn_input_offset.set_(self.o_proj_full_aclnn_input_offset)
+            if getattr(self, "_o_proj_has_aclnn", True):
+                self.o_proj.aclnn_input_scale.set_(self.o_proj_full_aclnn_input_scale)
+                self.o_proj.aclnn_input_scale_reciprocal.set_(self.o_proj_full_aclnn_input_scale_reciprocal)
+                self.o_proj.aclnn_input_offset.set_(self.o_proj_full_aclnn_input_offset)
 
             # Apply quantization method and execute forward computation
             output[...] = self.o_proj.quant_method.quant_method.apply(self.o_proj, attn_output)
 
             # Switch o_proj back to TP-mode for subsequent decode operations
             self.o_proj.weight.set_(self.o_proj_tp_weight)
-            self.o_proj.aclnn_input_scale.set_(self.o_proj_tp_aclnn_input_scale)
-            self.o_proj.aclnn_input_scale_reciprocal.set_(self.o_proj_tp_aclnn_input_scale_reciprocal)
-            self.o_proj.aclnn_input_offset.set_(self.o_proj_tp_aclnn_input_offset)
+            if getattr(self, "_o_proj_has_aclnn", True):
+                self.o_proj.aclnn_input_scale.set_(self.o_proj_tp_aclnn_input_scale)
+                self.o_proj.aclnn_input_scale_reciprocal.set_(self.o_proj_tp_aclnn_input_scale_reciprocal)
+                self.o_proj.aclnn_input_offset.set_(self.o_proj_tp_aclnn_input_offset)
 
             return output, False
         else:

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1325,7 +1325,16 @@ class AscendSFAImpl(MLAAttentionImpl):
             if self.is_kv_producer:
                 attn_metadata.reshape_cache_event.record()
 
-        topk_num_tokens = num_input_tokens or hidden_states.shape[0]
+        # IndexCache + SFA tiling fix: use per-rank q_pe length, not the global
+        # padded-to-tp num_input_tokens. SFA's aclnnSparseFlashAttention tiling
+        # expects sparse_indices shape [tokens_per_rank, 1, topk]; on PD分离 +
+        # TP>1 num_input_tokens is the prefill batch token count pre-shard
+        # while q_pe is already per-rank, so feeding the global number causes
+        # "sparse_indices shape [N*tp, 1, 2048] expected [N, 1, 2048]" tiling
+        # errors (e.g. TP=8 → exact 8x ratio). PD混步 happens to be safe
+        # because q_pe.shape[0] == num_input_tokens there, so this is a no-op
+        # for it.
+        topk_num_tokens = q_pe.shape[0]
         if self.skip_topk:
             topk_indices = self._get_indexcache_topk_indices(topk_num_tokens)
         else:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -560,7 +560,7 @@ class KVCacheRecvingThread(threading.Thread):
                     continue
                 self._handle_request(request_data)
             except Exception as e:
-                logger.error("Error in KVCacheTransferThread. error=%s. ", e)
+                logger.exception("Error in KVCacheTransferThread (full tb). error=%s. ", e)
 
     def _handle_request(self, req_meta: dict[str, Any]):
         request_id = req_meta["request_id"]

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -105,20 +105,37 @@ class MemcacheBackend(Backend):
 
     def get(self, key: list[str], addr: list[list[int]], size: list[list[int]]):
         if self._lazy_init and not self._store_initialized:
-            logger.error("get() called before store init. keys=%s. Call put() first to trigger initialization.", key)
+            logger.error(
+                "Failed to get %d keys out of %d. Store is not initialized; "
+                "call put() first to trigger initialization.",
+                len(key),
+                len(key),
+            )
+            logger.debug("Failed to get key details. keys=%s", key)
             return
         assert self.store is not None
         try:
             res = self.store.batch_get_into_layers(key, addr, size, MmcDirect.COPY_G2L.value)
-            for value in res:
-                if value != 0:
-                    logger.error(
-                        "Failed to get key. keys=%s, result=%s. Check key existence and memory state.", key, res
-                    )
+            failed_codes = [int(value) for value in res if value != 0]
+            failed_count = len(failed_codes)
+            if failed_count:
+                error_codes = sorted(set(failed_codes))
+                logger.error(
+                    "Failed to get %d keys out of %d. error_codes=%s. Check key existence and memory state.",
+                    failed_count,
+                    len(key),
+                    error_codes,
+                )
+                logger.debug("Failed to get key details. keys=%s, result=%s", key, res)
             return res
         except Exception as e:
             logger.error(
-                "Failed to get key. keys=%s, type=%s, error=%s. Check store state and network.",
+                "Failed to get %d keys out of %d. Check store state and network.",
+                len(key),
+                len(key),
+            )
+            logger.debug(
+                "Failed to get key details. keys=%s, type=%s, error=%s",
                 key,
                 type(e).__name__,
                 e,
@@ -130,14 +147,30 @@ class MemcacheBackend(Backend):
             self._ensure_initialized()
             assert self.store is not None
             res = self.store.batch_put_from_layers(key, addr, size, MmcDirect.COPY_L2G.value)
-            for value in res:
-                if value != 0:
-                    logger.error("Failed to put key. keys=%s, result=%s. Check memory and store capacity.", key, res)
-                    if self._lazy_init:
-                        logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
+            failed_codes = [int(value) for value in res if value != 0]
+            failed_count = len(failed_codes)
+            if failed_count:
+                error_codes = sorted(set(failed_codes))
+                logger.error(
+                    "Failed to put %d keys out of %d. error_codes=%s. Check memory and store capacity.",
+                    failed_count,
+                    len(key),
+                    error_codes,
+                )
+                logger.debug("Failed to put key details. keys=%s, result=%s", key, res)
+                if self._lazy_init:
+                    logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
         except Exception as e:
             logger.error(
-                "Failed to put key. keys=%s, type=%s, error=%s. Check store state and memory.", key, type(e).__name__, e
+                "Failed to put %d keys out of %d. Check store state and memory.",
+                len(key),
+                len(key),
+            )
+            logger.debug(
+                "Failed to put key details. keys=%s, type=%s, error=%s",
+                key,
+                type(e).__name__,
+                e,
             )
             if self._lazy_init:
                 logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -186,14 +186,27 @@ class MooncakeBackend(Backend):
                 config.preferred_segment = self.local_seg
             config.prefer_alloc_in_same_node = self.config.prefer_alloc_in_same_node
             res = self.store.batch_put_from_multi_buffers(keys, addrs, sizes, config)
-            for value in res:
-                if value < 0:
-                    logger.error("Failed to put key. keys=%s, result=%s. Check memory and store capacity.", keys, res)
-                    if self._lazy_init:
-                        logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
+            failed_codes = [int(value) for value in res if value < 0]
+            failed_count = len(failed_codes)
+            if failed_count:
+                error_codes = sorted(set(failed_codes))
+                logger.error(
+                    "Failed to put %d keys out of %d. error_codes=%s. Check memory and store capacity.",
+                    failed_count,
+                    len(keys),
+                    error_codes,
+                )
+                logger.debug("Failed to put key details. keys=%s, result=%s", keys, res)
+                if self._lazy_init:
+                    logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
         except Exception as e:
             logger.error(
-                "Failed to put key. keys=%s, type=%s, error=%s. Check store state and memory.",
+                "Failed to put %d keys out of %d. Check store state and memory.",
+                len(keys),
+                len(keys),
+            )
+            logger.debug(
+                "Failed to put key details. keys=%s, type=%s, error=%s",
                 keys,
                 type(e).__name__,
                 e,
@@ -203,7 +216,13 @@ class MooncakeBackend(Backend):
 
     def get(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         if self._lazy_init and not self._store_initialized:
-            logger.error("get() called before store init. keys=%s. Call put() first to trigger initialization.", keys)
+            logger.error(
+                "Failed to get %d keys out of %d. Store is not initialized; "
+                "call put() first to trigger initialization.",
+                len(keys),
+                len(keys),
+            )
+            logger.debug("Failed to get key details. keys=%s", keys)
             return
         assert self.store is not None
         logger.debug(
@@ -214,23 +233,29 @@ class MooncakeBackend(Backend):
         try:
             res = self.store.batch_get_into_multi_buffers(keys, addrs, sizes)
             res_list = list(res)
-            logger.debug(
-                "MooncakeBackend.get result keys=%d result_sample=%s negative_count=%d",
-                len(keys),
-                res_list[:12],
-                sum(1 for value in res_list if value < 0),
-            )
+            failed_codes = [int(value) for value in res_list if value < 0]
+            failed_count = len(failed_codes)
+            error_codes = sorted(set(failed_codes))
+            if failed_count:
+                logger.error(
+                    "Failed to get %d keys out of %d. error_codes=%s. Check key existence and memory state.",
+                    failed_count,
+                    len(keys),
+                    error_codes,
+                )
+                logger.debug("Failed to get key details. keys=%s, result=%s", keys, res_list)
             for i, value in enumerate(res_list):
-                if value < 0:
-                    logger.error(
-                        "Failed to get key. keys=%s, result=%s. Check key existence and memory state.", keys, res_list
-                    )
-                elif value > 0:
+                if value > 0:
                     res_list[i] = 0
             return res_list
         except Exception as e:
             logger.error(
-                "Failed to get key. keys=%s, type=%s, error=%s. Check store state and network.",
+                "Failed to get %d keys out of %d. Check store state and network.",
+                len(keys),
+                len(keys),
+            )
+            logger.debug(
+                "Failed to get key details. keys=%s, type=%s, error=%s",
                 keys,
                 type(e).__name__,
                 e,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
@@ -155,9 +155,11 @@ class YuanrongBackend(Backend):
     def get(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         if len(keys) == 0:
             return
+        failed_keys_for_log = keys
         try:
             self._ensure_device_ready()
             keys = self._helper.normalize_keys(keys)
+            failed_keys_for_log = keys
             blob_lists = self._helper.make_blob_lists(addrs, sizes)
             failed_keys: list[str] = []
             if len(keys) <= self._DS_MAX_BATCH_KEYS:
@@ -166,6 +168,7 @@ class YuanrongBackend(Backend):
                 )
             else:
                 for start, end in _iter_slices(len(keys), self._DS_MAX_BATCH_KEYS):
+                    failed_keys_for_log = keys[start:end]
                     failed_keys.extend(
                         self._hetero_client.mget_h2d(  # type: ignore[union-attr]
                             keys[start:end], blob_lists[start:end], 0
@@ -173,14 +176,20 @@ class YuanrongBackend(Backend):
                     )
             if failed_keys:
                 logger.error(
-                    "Failed to get keys. failed_count=%d, sample_keys=%s. Check key existence and memory state.",
+                    "Failed to get %d keys out of %d. Check key existence and memory state.",
                     len(failed_keys),
-                    failed_keys[:10],
+                    len(keys),
                 )
+                logger.debug("Failed to get key details. failed_keys=%s", failed_keys)
         except Exception as exc:
             logger.error(
-                "Failed to get keys. keys_count=%d, type=%s, error=%s. Check network and yuanrong service.",
+                "Failed to get %d keys out of %d. Check network and yuanrong service.",
+                len(failed_keys_for_log),
                 len(keys),
+            )
+            logger.debug(
+                "Failed to get key details. keys=%s, type=%s, error=%s",
+                failed_keys_for_log,
                 type(exc).__name__,
                 exc,
             )
@@ -188,9 +197,11 @@ class YuanrongBackend(Backend):
     def put(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         if len(keys) == 0:
             return
+        failed_keys_for_log = keys
         try:
             self._ensure_device_ready()
             keys = self._helper.normalize_keys(keys)
+            failed_keys_for_log = keys
             blob_lists = self._helper.make_blob_lists(addrs, sizes)
             if len(keys) <= self._DS_MAX_BATCH_KEYS:
                 self._hetero_client.mset_d2h(  # type: ignore[union-attr]
@@ -198,13 +209,19 @@ class YuanrongBackend(Backend):
                 )
             else:
                 for start, end in _iter_slices(len(keys), self._DS_MAX_BATCH_KEYS):
+                    failed_keys_for_log = keys[start:end]
                     self._hetero_client.mset_d2h(  # type: ignore[union-attr]
                         keys[start:end], blob_lists[start:end], self._ds_set_param
                     )
         except Exception as exc:
             logger.error(
-                "Failed to put keys. keys_count=%d, type=%s, error=%s. Check network and yuanrong service.",
+                "Failed to put %d keys out of %d. Check network and yuanrong service.",
+                len(failed_keys_for_log),
                 len(keys),
+            )
+            logger.debug(
+                "Failed to put key details. keys=%s, type=%s, error=%s",
+                failed_keys_for_log,
                 type(exc).__name__,
                 exc,
             )

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -5,3 +5,4 @@ def register_model():
     ModelRegistry.register_model("DeepseekV4ForCausalLM", "vllm_ascend.models.deepseek_v4:AscendDeepseekV4ForCausalLM")
 
     ModelRegistry.register_model("DeepSeekV4MTPModel", "vllm_ascend.models.deepseek_v4_mtp:DeepSeekV4MTP")
+    ModelRegistry.register_model("DeepSeekV4DSpark", "vllm_ascend.models.deepseek_v4_dspark:DeepSeekV4DSpark")

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -970,17 +970,85 @@ class DeepseekV2DecoderLayer(nn.Module):
         self.hc_attn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
         self.hc_ffn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
 
-    def hc_pre(self, x: torch.Tensor, hc_fn: torch.Tensor, hc_scale: torch.Tensor, hc_base: torch.Tensor):
-        y = torch.ops._C_ascend.npu_hc_pre(
-            x, hc_fn, hc_scale, hc_base, self.hc_mult, self.hc_sinkhorn_iters, self.norm_eps, self.hc_eps
+    def _is_missing_hc_op(self, err: RuntimeError) -> bool:
+        msg = str(err)
+        return (
+            "aclnnHcPre" in msg
+            or "aclnnHcPost" in msg
+            or "npu_hc_pre" in msg
+            or "npu_hc_post" in msg
+            or "libopapi" in msg
         )
-        return y
+
+    def _warn_hc_fallback_once(self):
+        if getattr(self, "_hc_fallback_warned", False):
+            return
+        self._hc_fallback_warned = True
+        print("[DSV4] Ascend HC fused op unavailable; using torch HC fallback.", flush=True)
+
+    def _hc_pre_torch(self, x: torch.Tensor, hc_fn: torch.Tensor, hc_scale: torch.Tensor, hc_base: torch.Tensor):
+        shape, dtype = x.shape, x.dtype
+        hc_mult = self.hc_mult
+        flat_x = x.flatten(1).float()
+        rsqrt = torch.rsqrt(flat_x.square().mean(-1, keepdim=True) + self.norm_eps)
+        mixes = F.linear(flat_x, hc_fn.float())
+
+        pre_mix = mixes[:, :hc_mult]
+        post_mix = mixes[:, hc_mult : 2 * hc_mult]
+        comb_mix = mixes[:, 2 * hc_mult :].view(-1, hc_mult, hc_mult)
+
+        pre_base = hc_base[:hc_mult]
+        post_base = hc_base[hc_mult : 2 * hc_mult]
+        comb_base = hc_base[2 * hc_mult :].view(hc_mult, hc_mult)
+
+        pre = torch.sigmoid(pre_mix * rsqrt * hc_scale[0] + pre_base) + self.hc_eps
+        y = torch.sum(pre.unsqueeze(-1) * x.view(shape).float(), dim=1).to(dtype)
+
+        post = torch.sigmoid(post_mix * rsqrt * hc_scale[1] + post_base) * 2.0
+
+        comb_logits = comb_mix * rsqrt.view(-1, 1, 1) * hc_scale[2] + comb_base
+        comb = torch.softmax(comb_logits, dim=-1) + self.hc_eps
+        comb = comb / (comb.sum(dim=1, keepdim=True) + self.hc_eps)
+        for _ in range(max(int(self.hc_sinkhorn_iters) - 1, 0)):
+            comb = comb / (comb.sum(dim=-1, keepdim=True) + self.hc_eps)
+            comb = comb / (comb.sum(dim=1, keepdim=True) + self.hc_eps)
+        return y, post, comb
+
+    def _hc_post_torch(
+        self, x: torch.Tensor, residual: torch.Tensor, post: torch.Tensor, comb: torch.Tensor
+    ) -> torch.Tensor:
+        y = torch.einsum("tih,tij->tjh", residual.float(), comb.float())
+        y = y + x.float().unsqueeze(1) * post.float().unsqueeze(-1)
+        return y.to(x.dtype)
+
+    def hc_pre(self, x: torch.Tensor, hc_fn: torch.Tensor, hc_scale: torch.Tensor, hc_base: torch.Tensor):
+        if getattr(self, "_use_torch_hc_pre", False):
+            return self._hc_pre_torch(x, hc_fn, hc_scale, hc_base)
+        try:
+            return torch.ops._C_ascend.npu_hc_pre(
+                x, hc_fn, hc_scale, hc_base, self.hc_mult, self.hc_sinkhorn_iters, self.norm_eps, self.hc_eps
+            )
+        except RuntimeError as err:
+            if not self._is_missing_hc_op(err):
+                raise
+            self._use_torch_hc_pre = True
+            self._warn_hc_fallback_once()
+            return self._hc_pre_torch(x, hc_fn, hc_scale, hc_base)
 
     def hc_post(self, x: torch.Tensor, residual: torch.Tensor, post: torch.Tensor, comb: torch.Tensor):
-        y = torch.ops._C_ascend.npu_hc_post(
-            x.unsqueeze(dim=0), residual.unsqueeze(dim=0), post.unsqueeze(dim=0), comb.unsqueeze(dim=0)
-        )
-        return y.squeeze(dim=0)
+        if getattr(self, "_use_torch_hc_post", False):
+            return self._hc_post_torch(x, residual, post, comb)
+        try:
+            y = torch.ops._C_ascend.npu_hc_post(
+                x.unsqueeze(dim=0), residual.unsqueeze(dim=0), post.unsqueeze(dim=0), comb.unsqueeze(dim=0)
+            )
+            return y.squeeze(dim=0)
+        except RuntimeError as err:
+            if not self._is_missing_hc_op(err):
+                raise
+            self._use_torch_hc_post = True
+            self._warn_hc_fallback_once()
+            return self._hc_post_torch(x, residual, post, comb)
 
     def forward(
         self,
@@ -1039,6 +1107,20 @@ class DeepseekV4Model(nn.Module):
         # Expose at model level so spec_decode/llm_base_proposer can share
         # this buffer with the MTP draft via attribute replacement.
         self.topk_indices_buffer = topk_indices_buffer
+
+        self._dspark_target_layer_ids = tuple(
+            int(layer_id)
+            for layer_id in (getattr(config, "dspark_target_layer_ids", None) or ())
+        )
+        if self._dspark_target_layer_ids:
+            self._dspark_hidden_buffer = torch.empty(
+                vllm_config.scheduler_config.max_num_batched_tokens,
+                len(self._dspark_target_layer_ids) * config.hidden_size,
+                dtype=vllm_config.model_config.dtype,
+                device=self.device,
+            )
+        else:
+            self._dspark_hidden_buffer = None
 
         # EAGLE3 / DSpark aux-hidden-state taps. Empty tuple => fully inert.
         self.aux_hidden_state_layers: tuple[int, ...] = ()
@@ -1141,15 +1223,44 @@ class DeepseekV4Model(nn.Module):
         else:
             llama_4_scaling = None
 
+        from vllm_ascend.ascend_forward_context import get_forward_context
+
+        forward_ctx = get_forward_context()
+
+        def maybe_gather_full_tokens(tensor: torch.Tensor) -> torch.Tensor:
+            if forward_ctx is not None and forward_ctx.flash_comm_v1_enabled:
+                tensor = tensor_model_parallel_all_gather(tensor, dim=0)
+                pad_size = forward_ctx.pad_size
+                if pad_size > 0:
+                    tensor = tensor[:-pad_size]
+            return tensor
+
         aux_hidden_states: list[torch.Tensor] = []
         if get_pp_group().is_first_rank:
             hidden_states = hidden_states.unsqueeze(1).repeat(1, self.hc_mult, 1)  # (b, s, h) -> (b, s, c, h)
+        dspark_hiddens: list[torch.Tensor] = []
         for layer in islice(self.layers, self.start_layer, self.end_layer):
             hidden_states, residual = layer(positions, hidden_states, residual, llama_4_scaling)
             if self.aux_hidden_state_layers and layer.layer_idx in self.aux_hidden_state_layers:
                 # HC-form [T, hc_mult, hidden], already post-residual -> mean over
                 # hc copies -> [T, hidden] so runner's cat(dim=-1) = [T, hidden*N].
                 aux_hidden_states.append(hidden_states.mean(dim=1))
+            if (
+                self._dspark_hidden_buffer is not None
+                and layer.layer_idx in self._dspark_target_layer_ids
+            ):
+                dspark_hiddens.append(
+                    maybe_gather_full_tokens(hidden_states.mean(dim=1))
+                )
+
+        if (
+            self._dspark_hidden_buffer is not None
+            and len(dspark_hiddens) == len(self._dspark_target_layer_ids)
+        ):
+            dspark_hidden_states = torch.cat(dspark_hiddens, dim=-1)
+            self._dspark_hidden_buffer[
+                : dspark_hidden_states.shape[0]
+            ].copy_(dspark_hidden_states)
 
         # Stash pre-hc_head residual for the MTP draft (captured copy_).
         # When FlashComm1 (sequence parallelism) is enabled, tokens are
@@ -1158,9 +1269,6 @@ class DeepseekV4Model(nn.Module):
         # MTP layers receive the full token set — otherwise only rank 0's
         # partition is valid and the rest of the buffer holds stale data,
         # leading to NaN values and low acceptance rate.
-        from vllm_ascend.ascend_forward_context import get_forward_context
-
-        forward_ctx = get_forward_context()
         if forward_ctx is not None and forward_ctx.flash_comm_v1_enabled:
             h_states_flat = tensor_model_parallel_all_gather(hidden_states.flatten(1), dim=0)
             pad_size = forward_ctx.pad_size
@@ -1315,6 +1423,14 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
         hc_mult * hidden_size) for the MTP draft model. Populated by
         forward(); valid after each target step."""
         return getattr(self.model, "_mtp_hidden_buffer", None)
+
+    def get_dspark_target_hidden_states(self) -> torch.Tensor | None:
+        """Mean-HC hidden states from ``dspark_target_layer_ids``.
+
+        DSpark consumes the concatenation of configured target-layer hidden
+        states, not the MTP pre-hc_head residual stream.
+        """
+        return getattr(self.model, "_dspark_hidden_buffer", None)
 
     # ---- EAGLE3 / DSpark auxiliary hidden-state interface ----
     def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -29,6 +29,7 @@ from collections.abc import Callable, Iterable
 from itertools import islice
 
 import torch
+_DSPARK_PA = []  # DSpark stage post-attention capture
 import torch.nn.functional as F
 import torch_npu
 from torch import nn
@@ -994,6 +995,13 @@ class DeepseekV2DecoderLayer(nn.Module):
         attn_kwargs = {"positions": positions, "hidden_states": hidden_states, "llama_4_scaling": llama_4_scaling}
         hidden_states = self.self_attn(**attn_kwargs)
         hidden_states = self.hc_post(hidden_states, residual, post, comb)
+        import os as _paos
+        if _paos.environ.get("DSPARK_CAPTURE") and hidden_states.shape[0] in (5, 6):
+            try:
+                _DSPARK_PA.append(hidden_states.detach().cpu().float())
+                del _DSPARK_PA[:-3]
+            except Exception:
+                pass
         residual = hidden_states.clone()
         hidden_states, post, comb = self.hc_pre(hidden_states, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base)
         hidden_states = self.post_attention_layernorm(hidden_states)

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -56,7 +56,7 @@ from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead, VocabParallelEmbedding
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader, maybe_remap_kv_scale_name
-from vllm.model_executor.models.interfaces import MixtureOfExperts, SupportsEagle, SupportsLoRA, SupportsPP
+from vllm.model_executor.models.interfaces import MixtureOfExperts, SupportsEagle, SupportsEagle3, SupportsLoRA, SupportsPP
 from vllm.model_executor.models.utils import (
     PPMissingLayer,
     is_pp_missing_parameter,
@@ -1032,6 +1032,9 @@ class DeepseekV4Model(nn.Module):
         # this buffer with the MTP draft via attribute replacement.
         self.topk_indices_buffer = topk_indices_buffer
 
+        # EAGLE3 / DSpark aux-hidden-state taps. Empty tuple => fully inert.
+        self.aux_hidden_state_layers: tuple[int, ...] = ()
+
         if get_pp_group().is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
                 config.vocab_size,
@@ -1130,10 +1133,15 @@ class DeepseekV4Model(nn.Module):
         else:
             llama_4_scaling = None
 
+        aux_hidden_states: list[torch.Tensor] = []
         if get_pp_group().is_first_rank:
             hidden_states = hidden_states.unsqueeze(1).repeat(1, self.hc_mult, 1)  # (b, s, h) -> (b, s, c, h)
         for layer in islice(self.layers, self.start_layer, self.end_layer):
             hidden_states, residual = layer(positions, hidden_states, residual, llama_4_scaling)
+            if self.aux_hidden_state_layers and layer.layer_idx in self.aux_hidden_state_layers:
+                # HC-form [T, hc_mult, hidden], already post-residual -> mean over
+                # hc copies -> [T, hidden] so runner's cat(dim=-1) = [T, hidden*N].
+                aux_hidden_states.append(hidden_states.mean(dim=1))
 
         # Stash pre-hc_head residual for the MTP draft (captured copy_).
         # When FlashComm1 (sequence parallelism) is enabled, tokens are
@@ -1166,6 +1174,8 @@ class DeepseekV4Model(nn.Module):
         hidden_states = self.hc_head(hidden_states, self.hc_head_fn, self.hc_head_scale, self.hc_head_base)
 
         hidden_states = self.norm(hidden_states)
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
         return hidden_states
 
 
@@ -1209,7 +1219,7 @@ class DeepseekV2MixtureOfExperts(MixtureOfExperts):
             moe.experts.update_expert_map()
 
 
-class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExperts, SupportsLoRA, SupportsEagle):
+class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExperts, SupportsLoRA, SupportsEagle, SupportsEagle3):
     packed_modules_mapping = {
         "gate_up_proj": ["gate_proj", "up_proj"],
     }
@@ -1297,6 +1307,19 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
         hc_mult * hidden_size) for the MTP draft model. Populated by
         forward(); valid after each target step."""
         return getattr(self.model, "_mtp_hidden_buffer", None)
+
+    # ---- EAGLE3 / DSpark auxiliary hidden-state interface ----
+    def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        self.model.aux_hidden_state_layers = tuple(layers)
+
+    def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
+        return tuple(self.model.aux_hidden_state_layers)
+
+    def get_eagle3_default_aux_hidden_state_layers(self) -> tuple[int, ...]:
+        ids = getattr(self.config, "dspark_target_layer_ids", None)
+        if ids:
+            return tuple(ids)
+        return (40, 41, 42)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         rocm_aiter_moe_shared_expert_enabled = rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()

--- a/vllm_ascend/models/deepseek_v4_dspark.py
+++ b/vllm_ascend/models/deepseek_v4_dspark.py
@@ -125,9 +125,13 @@ class DeepSeekV4DSparkModel(nn.Module):
         self.hc_eps = config.hc_eps
         self.block_size = config.dspark_block_size          # gamma = 5
         self.noise_token_id = config.dspark_noise_token_id  # 128799
-        self.target_layer_ids = list(config.dspark_target_layer_ids)  # [40,41,42]
+        self.target_layer_ids = list(getattr(config, "dspark_target_layer_ids", []) or [])
+        if not self.target_layer_ids:
+            raise ValueError(
+                "DSpark requires dspark_target_layer_ids in the draft config.")
         self.markov_rank = config.dspark_markov_rank        # 256
-        self.n_stages = config.n_mtp_layers                 # 3
+        self.n_stages = int(
+            getattr(config, "n_mtp_layers", None) or len(self.target_layer_ids))
         self.base_layer_id = config.num_hidden_layers       # 43
 
         # QUAROT_PATCH_V1: QuaRot anti-rotation for the DSpark context path.

--- a/vllm_ascend/models/deepseek_v4_dspark.py
+++ b/vllm_ascend/models/deepseek_v4_dspark.py
@@ -321,6 +321,19 @@ class DeepSeekV4DSparkModel(nn.Module):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
         base = inputs_embeds
+        # DSPARK FIX: fold the proposer-delivered target seed (main_x = combine_hidden_states
+        # output) into the residual. It was received as `hidden_states` but DROPPED, so the
+        # draft ran on the token embedding alone with ZERO target conditioning (pos-0 ~11%).
+        # MTP-1 (pos-0 93.9%) feeds the target hidden into the draft residual; do the same so
+        # each layer's input_layernorm renormalizes embed+main_x together.
+        if hidden_states is not None:
+            _seed = hidden_states.to(base.dtype).view_as(base)
+            def _unit_rms(_t):
+                _sc = torch.rsqrt(_t.float().pow(2).mean(dim=-1, keepdim=True) + self.rms_norm_eps)
+                return (_t.float() * _sc).to(base.dtype)
+            # separately RMS-normalize embed and main_x before adding (MTP-1 enorm+hnorm
+            # analogue) so the target seed is not numerically swamped by the embedding.
+            base = _unit_rms(base) + _unit_rms(_seed)
         import os as _os
         if _os.environ.get("DSPARK_DBG"):
             import sys as _sys

--- a/vllm_ascend/models/deepseek_v4_dspark.py
+++ b/vllm_ascend/models/deepseek_v4_dspark.py
@@ -105,6 +105,18 @@ class DeepSeekV4DSparkModel(nn.Module):
         config = vllm_config.speculative_config.draft_model_config.hf_config
         self.config = config
         quant_config = vllm_config.quant_config
+        # DSPARK_DRAFT_NOQUANT: build the DRAFT stack unquantized (bf16 draft with
+        # w8a8 target; vllm#43304-class inheritance). Scoped: restored after layers.
+        _dqos = __import__("os")
+        self._noquant = bool(_dqos.environ.get("DSPARK_DRAFT_NOQUANT"))
+        self._saved_qc = vllm_config.quant_config
+        if self._noquant:
+            try:
+                vllm_config.quant_config = None
+                quant_config = None
+                print("DSPARK_DRAFT_NOQUANT ACTIVE: draft built unquantized", file=__import__("sys").stderr, flush=True)
+            except Exception as _qe:
+                print("DSPARK_DRAFT_NOQUANT failed to override: %r" % (_qe,), file=__import__("sys").stderr, flush=True)
         self.device = current_platform.device_type
 
         self.hidden_size = config.hidden_size
@@ -181,6 +193,11 @@ class DeepSeekV4DSparkModel(nn.Module):
                 is_draft_layer=True)
             for i in range(self.n_stages)
         ])
+        if getattr(self, "_noquant", False):
+            try:
+                vllm_config.quant_config = self._saved_qc  # restore for anything after
+            except Exception:
+                pass
 
         # last stage: hc_head params + DSpark heads (final norm is shared_head.norm).
         hc_dim = self.hc_mult * config.hidden_size

--- a/vllm_ascend/models/deepseek_v4_dspark.py
+++ b/vllm_ascend/models/deepseek_v4_dspark.py
@@ -321,19 +321,6 @@ class DeepSeekV4DSparkModel(nn.Module):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
         base = inputs_embeds
-        # DSPARK FIX: fold the proposer-delivered target seed (main_x = combine_hidden_states
-        # output) into the residual. It was received as `hidden_states` but DROPPED, so the
-        # draft ran on the token embedding alone with ZERO target conditioning (pos-0 ~11%).
-        # MTP-1 (pos-0 93.9%) feeds the target hidden into the draft residual; do the same so
-        # each layer's input_layernorm renormalizes embed+main_x together.
-        if hidden_states is not None:
-            _seed = hidden_states.to(base.dtype).view_as(base)
-            def _unit_rms(_t):
-                _sc = torch.rsqrt(_t.float().pow(2).mean(dim=-1, keepdim=True) + self.rms_norm_eps)
-                return (_t.float() * _sc).to(base.dtype)
-            # separately RMS-normalize embed and main_x before adding (MTP-1 enorm+hnorm
-            # analogue) so the target seed is not numerically swamped by the embedding.
-            base = _unit_rms(base) + _unit_rms(_seed)
         import os as _os
         if _os.environ.get("DSPARK_DBG"):
             import sys as _sys
@@ -388,6 +375,16 @@ class DeepSeekV4DSparkModel(nn.Module):
             bias = self.logits_processor(self.markov_head.markov_w2, emb)  # [B, full_vocab] (gathered)
             embeds.append(emb)
             _li = U[:, i].float() if _nobias else (U[:, i].float() + bias.float())
+            if _mb.environ.get("DSPARK_DBG"):
+                try:
+                    _Uf = U[:, i].float()
+                    print("DSPARK_MKV i=%d Uarg=%d Ustd=%.3f Utop2gap=%.3f biasstd=%.3f biasarg=%d finalarg=%d prevtok=%d" % (
+                        i, int(_Uf.argmax(-1)[0]), float(_Uf.std()),
+                        float((_Uf.topk(2,dim=-1).values[0,0]-_Uf.topk(2,dim=-1).values[0,1])),
+                        float(bias.float().std()), int(bias.float().argmax(-1)[0]),
+                        int(_li.argmax(-1)[0]), int(output_ids[:, i][0])), file=_mbs.stderr, flush=True)
+                except Exception as _mke:
+                    print("DSPARK_MKV ERR %r"%(_mke,), file=_mbs.stderr, flush=True)
             output_ids[:, i + 1] = _sample(_li, temperature)
         markov_embed = torch.stack(embeds, dim=1)
         confidence = self.confidence_head(xc, markov_embed)

--- a/vllm_ascend/models/deepseek_v4_dspark.py
+++ b/vllm_ascend/models/deepseek_v4_dspark.py
@@ -1,0 +1,573 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DSpark draft model for DeepSeek-V4 — ASCEND-NATIVE rewrite (v1).
+
+Deploy at: vllm_ascend/models/deepseek_v4_dspark.py  (register "DeepSeekV4DSpark"
+in vllm_ascend/models/__init__.py register_model()).
+
+Why this rewrite (vs the earlier core-tree version): the old file imported the
+CORE `vllm.model_executor.models.deepseek_v4` which pulls in `mhc` -> `tilelang`
+(CUDA-only, absent on Ascend) -> `'NoneType' object has no attribute 'jit'`.
+This version is built ENTIRELY on vllm-ascend building blocks (the same ones the
+WORKING `deepseek_v4_mtp.py` uses): `DeepseekV2DecoderLayer` (Ascend, does HC
+internally via torch.ops._C_ascend.npu_hc_pre/post — no tilelang), `SharedHead`,
+plain-torch `_hc_head`, Ascend FusedMoE. No `mhc`/`tilelang` anywhere.
+
+DSpark = DFlash parallel backbone + lightweight sequential (Markov) head + a
+confidence head. This is the DRAFT model; the parallel-block construction +
+target-KV injection live in the proposer. Structure mirrors upstream PR#46995's
+DSparkDeepseekV4ForCausalLM (NVIDIA), ported to Ascend components.
+"""
+import typing
+from collections.abc import Callable, Iterable
+
+import regex as re
+import torch
+import torch.nn as nn
+
+from vllm.config import VllmConfig
+from vllm.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.models.utils import maybe_prefix
+from vllm.platforms import current_platform
+
+# ASCEND-native building blocks (relative imports resolve inside vllm_ascend.models)
+from .deepseek_v4 import DeepseekV2DecoderLayer
+from .deepseek_v4_mtp import SharedHead
+from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
+from vllm_ascend.device.device_op import DeviceOperator
+
+logger = init_logger(__name__)
+
+_EXPERT_SCALE_RE = re.compile(r"\.experts\.\d+\.w[123]\.scale$")
+
+
+def _hc_head(x, hc_fn, hc_scale, hc_base, norm_eps, hc_eps):
+    """Plain-torch hyper-connection head collapse (== Ascend MTP.hc_head, NO tilelang).
+    x: [.., hc_mult, hidden] -> [.., hidden]."""
+    shape, dtype = x.size(), x.dtype
+    x = x.flatten(1).float()
+    rsqrt = torch.rsqrt(x.square().mean(-1, keepdim=True) + norm_eps)
+    mixes = torch.nn.functional.linear(x, hc_fn) * rsqrt
+    pre = torch.sigmoid(mixes * hc_scale + hc_base) + hc_eps
+    y = torch.sum(pre.unsqueeze(-1) * x.view(shape), dim=1)
+    return y.to(dtype)
+
+
+# ---------------------------------------------------------------- DSpark heads
+class DSparkMarkovHead(nn.Module):
+    """Eq.5: B(x_{k-1}) = W1[x_{k-1}] @ W2, low-rank (markov_rank=256).
+    Returns (bias_logits[V], markov_embed[256]); plain bf16 (no .scale)."""
+
+    def __init__(self, vocab_size: int, markov_rank: int):
+        super().__init__()
+        self.markov_w1 = VocabParallelEmbedding(vocab_size, markov_rank)
+        self.markov_w2 = ParallelLMHead(vocab_size, markov_rank, bias=False)
+
+    def forward(self, token_ids: torch.Tensor):
+        embed = self.markov_w1(token_ids)                       # [.., 256]
+        logits = torch.nn.functional.linear(
+            embed.float(), self.markov_w2.weight.float())       # embed @ W2^T -> [.., V]
+        return logits, embed
+
+
+class DSparkConfidenceHead(nn.Module):
+    """Eq.7: c_k = w^T [h_k ; W1[x_{k-1}]] (RAW logit, no sigmoid). fp32."""
+
+    def __init__(self, input_dim: int):
+        super().__init__()
+        self.proj = nn.Linear(input_dim, 1, bias=False, dtype=torch.float32)
+
+    def forward(self, hidden: torch.Tensor, markov_embed: torch.Tensor):
+        h = torch.cat([hidden, markov_embed], dim=-1)
+        return self.proj(h.float()).squeeze(-1)                 # [.. ] raw logit
+
+
+# ---------------------------------------------------------------- DSpark draft stack
+class DeepSeekV4DSparkModel(nn.Module):
+    """3-deep DSpark draft stack (mtp.0/1/2) over the whole gamma block in ONE pass.
+    main_proj/main_norm on stage 0; norm/markov/confidence/hc_head on the last stage."""
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.config = config
+        quant_config = vllm_config.quant_config
+        self.device = current_platform.device_type
+
+        self.hidden_size = config.hidden_size
+        self.rms_norm_eps = config.rms_norm_eps
+        self.hc_mult = config.hc_mult
+        self.hc_eps = config.hc_eps
+        self.block_size = config.dspark_block_size          # gamma = 5
+        self.noise_token_id = config.dspark_noise_token_id  # 128799
+        self.target_layer_ids = list(config.dspark_target_layer_ids)  # [40,41,42]
+        self.markov_rank = config.dspark_markov_rank        # 256
+        self.n_stages = config.n_mtp_layers                 # 3
+        self.base_layer_id = config.num_hidden_layers       # 43
+
+        # per-stage sparse-attn topk index buffer (only if the arch is v3.2-style)
+        if hasattr(config, "index_topk"):
+            self.topk_indices_buffer = torch.empty(
+                vllm_config.scheduler_config.max_num_batched_tokens,
+                config.index_topk, dtype=torch.int32, device=self.device)
+        else:
+            self.topk_indices_buffer = None
+
+        # Shared (from target) embed + head; aliased in by the proposer if present.
+        self.embed_tokens = VocabParallelEmbedding(
+            config.vocab_size, config.hidden_size,
+            prefix=maybe_prefix(prefix, "embed_tokens"))
+        self.shared_head = SharedHead(config=config, prefix=prefix, quant_config=quant_config)
+
+        # stage 0: main_proj fuses concat(mean-over-hc) of target layers [40,41,42].
+        # prefix "mtp.0.main_proj" so the W8A8 quant scheme resolves (the auto quant
+        # adaptation produces mtp.0.main_proj.weight from the ckpt description).
+        self.main_proj = ReplicatedLinear(
+            config.hidden_size * len(self.target_layer_ids),
+            config.hidden_size, bias=False, return_bias=False, quant_config=quant_config,
+            prefix="mtp.0.main_proj")
+        self.main_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        # 3-deep Ascend decoder stack. CRITICAL: pass prefix "mtp.{i}" (NOT
+        # model.layers.{43+i}). extract_dsv4_layer_index adds num_hidden_layers for
+        # any ".mtp." prefix -> config_layer_idx = num_hidden_layers + i -> ratio 0
+        # (no Compressor/Indexer built, exactly like the working MTP draft). It ALSO
+        # makes the quant scheme key (mtp.{i}.self_attn.wq_a) resolve against the
+        # auto-adapted description. The Python param path stays model.layers.{i}
+        # (ModuleList index 0/1/2) — decoupled from the prefix string.
+        self.layers = nn.ModuleList([
+            DeepseekV2DecoderLayer(
+                vllm_config, f"mtp.{i}",
+                config=config,
+                topk_indices_buffer=self.topk_indices_buffer,
+                is_draft_layer=True)
+            for i in range(self.n_stages)
+        ])
+
+        # last stage: hc_head params + DSpark heads (final norm is shared_head.norm).
+        hc_dim = self.hc_mult * config.hidden_size
+        self.hc_head_fn = nn.Parameter(torch.empty(self.hc_mult, hc_dim, dtype=torch.float32))
+        self.hc_head_base = nn.Parameter(torch.empty(self.hc_mult, dtype=torch.float32))
+        self.hc_head_scale = nn.Parameter(torch.empty(1, dtype=torch.float32))
+        self.markov_head = DSparkMarkovHead(config.vocab_size, self.markov_rank)
+        self.confidence_head = DSparkConfidenceHead(config.hidden_size + self.markov_rank)
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def combine_hidden_states(self, aux_hidden_states: torch.Tensor) -> torch.Tensor:
+        """dflash contract; DSpark folds main_norm in -> returns main_x [T, hidden]."""
+        _mx = self.main_norm(self.main_proj(aux_hidden_states))
+        import os as _oa, sys as _sa
+        if _oa.environ.get("DSPARK_DBG"):
+            try:
+                _a = aux_hidden_states.float()
+                # variance ACROSS rows (tokens): if ~0, aux is constant => capture broken
+                _row_std = _a.std(dim=0).mean().item()
+                _mnw = float(self.main_norm.weight.float().square().mean().sqrt())
+                for _k in range(3):
+                    _ss = _a[:, _k*4096:(_k+1)*4096]
+                    print("DSPARK_AUXSLICE k=%d std=%.4e rowvar=%.4e" % (_k, float(_ss.std()), float(_ss.std(dim=0).mean())), file=_sa.stderr, flush=True)
+                print("DSPARK_AUX aux.shape=%s aux.std=%.4e aux.rowvar=%.4e mainx.std=%.4e mainx.rowvar=%.4e mnw.rms=%.4e" % (
+                    tuple(aux_hidden_states.shape), float(_a.std()), _row_std,
+                    float(_mx.float().std()), float(_mx.float().std(dim=0).mean()), _mnw), file=_sa.stderr, flush=True)
+            except Exception as _e:
+                print("DSPARK_AUX ERR", _e, file=_sa.stderr, flush=True)
+        return _mx
+
+    @torch.inference_mode()
+    def precompute_and_store_context_kv(self, context_states, context_positions,
+                                        context_slot_mapping=None):
+        """Per-stage context-KV injection of main_x. Wired against sfa_v1 exec_kv at
+        NPU bring-up (the cache-write op is the only pending piece)."""
+        if context_slot_mapping is None:
+            return
+        import os as _oc, sys as _sc
+        if _oc.environ.get("DSPARK_DBG"):
+            try:
+                _cp = context_positions
+                print("DSPARK_CTX num_ctx=%d pos[:8]=%s pos[-4:]=%s slot[:8]=%s" % (context_states.shape[0], _cp[:8].tolist(), _cp[-4:].tolist(), context_slot_mapping.flatten()[:8].tolist()), file=_sc.stderr, flush=True)
+            except Exception as _ec:
+                print("DSPARK_CTX ERR", _ec, file=_sc.stderr, flush=True)
+        for layer in self.layers:
+            self._write_context_latent(layer, context_states, context_positions,
+                                       context_slot_mapping)
+
+    def _write_context_latent(self, layer, context_states, context_positions, slot_mapping):
+        """Write this draft layer's per-stage context-KV latent into its sliding-window
+        MLA paged cache. Mirrors AscendDSAImpl._forward_prefill (dsa_v1.py:1982-2014):
+        kv = kv_norm(wkv(main_x)); partial-RoPE(rope tail); scatter -> swa cache.
+        (Resolved against the live Ascend DSA attention; see agent investigation.)"""
+        dv4 = layer if hasattr(layer, "dsa_attn") else layer.self_attn   # DeepseekV4Attention
+        sparse = dv4.dsa_attn                 # AscendDeepseekSparseAttention
+        dsa_attn = sparse.dsa_attn            # DSAAttention
+        impl = dsa_attn.impl                  # AscendDSAImpl
+        layer_name = dsa_attn.layer_name      # == f"{prefix}.attn" (rope/metadata key)
+
+        swa_kv_cache = sparse.swa_cache_layer.kv_cache
+        while isinstance(swa_kv_cache, (list, tuple)) and len(swa_kv_cache) == 1:
+            swa_kv_cache = swa_kv_cache[0]
+        block_size = swa_kv_cache.shape[1]    # cache layout [num_blocks, block_size, 1, head_dim]
+
+        cos_proxy, sin_proxy = get_cos_and_sin_dsa(context_positions, use_cache=False)   # use_cache=False
+        cos = cos_proxy[layer_name]
+        sin = sin_proxy[layer_name]
+
+        # Reference (PR#46995 nvidia/dspark.py) feeds RAW main_x to wkv (NO
+        # input_layernorm, NO hc_pre): kv = kv_norm(wkv(main_x)) -> rope -> scatter.
+        _ctx_in = context_states
+        # A#3: compute context KV via the SAME w8a8 cv_wkv (Cube-Vector) path the real
+        # DSA prefill uses (cv_wkv.quantize + matmul), not a bare impl.wkv(x) call,
+        # so the context keys exactly match the query keys' representation.
+        if getattr(impl, "cv_wkv", None) is not None:
+            _kvq, _kvs = impl.cv_wkv.quantize(_ctx_in)
+            kv = impl.cv_wkv.matmul(_kvq, _kvs)
+        else:
+            kv = impl.wkv(_ctx_in)
+        import os as _oz
+        if _oz.environ.get("DSPARK_ZERO") or _oz.path.exists("/data1/DSPARK_ZERO_FLAG"):
+            kv = kv * 0.0                      # zero-out probe: if draft output is unchanged, the context cross-read is dead
+        kv = impl.kv_norm(kv)
+        nope, rope, head = impl.nope_head_dim, impl.rope_head_dim, impl.head_dim
+        assert rope is not None and nope + rope == head
+        kv = kv.view(-1, 1, head)             # (num_ctx_tokens, 1, head_dim)
+        torch.ops._C_ascend.inplace_partial_rotary_mul(
+            kv.unsqueeze(1), cos, sin,
+            rotary_mode="interleave",
+            partial_slice=[nope, head])       # rotate dims [nope_head_dim : head_dim]
+        import os as _om, sys as _sm
+        if _om.environ.get("DSPARK_DBG"):
+            try:
+                _raw = slot_mapping.flatten()[:6].tolist()
+            except Exception:
+                _raw = "?"
+            print("DSPARK_SLOT swa_shape=%s cache_bs=%s raw_slot[:6]=%s" % (tuple(swa_kv_cache.shape), swa_kv_cache.shape[1], _raw), file=_sm.stderr, flush=True)
+        import os as _rtos
+        if _rtos.environ.get("DSPARK_READ_TRACE"):
+            try:
+                impl._dspark_last_ctx_pos = context_positions.detach().to(torch.int64).clone()
+                impl._dspark_last_ctx_slot = slot_mapping.detach().flatten().to(torch.int64).clone()
+                impl._dspark_last_ctx_layer = layer_name
+                impl._dspark_write_cache_ptr = int(swa_kv_cache.data_ptr())
+            except Exception:
+                pass
+        if slot_mapping.dim() == 1:
+            slot_mapping = DeviceOperator.format_dsa_slot_mapping(
+                slot_mapping.to(torch.int64), block_size)
+        if _oz.environ.get("DSPARK_SENTINEL"):
+            kv = torch.full_like(kv, 5.0)   # A/B probe: huge distinctive context KV; if draft output changes, attn DOES read context
+        DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, slot_mapping)
+        import os as _o2, sys as _s2
+        if _o2.environ.get("DSPARK_DBG"):
+            try:
+                print("DSPARK_WRITE layer=%s kv_std=%.5f slot[:8]=%s cache_norm=%.3f" % (
+                    layer_name, float(kv.float().std()),
+                    (slot_mapping.flatten()[:8].tolist() if hasattr(slot_mapping,'flatten') else slot_mapping),
+                    float(swa_kv_cache.float().norm())), file=_s2.stderr, flush=True)
+            except Exception as _e2:
+                print("DSPARK_WRITE ERR", _e2, file=_s2.stderr, flush=True)
+
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Base draft logits U_k: collapse hc copies -> shared_head.norm -> LM head."""
+        xc = _hc_head(hidden_states, self.hc_head_fn, self.hc_head_scale,
+                      self.hc_head_base, self.rms_norm_eps, self.hc_eps)
+        _lg = self.logits_processor(self.shared_head.head, self.shared_head(xc))
+        import os as _os, sys as _sy
+        if _os.environ.get("DSPARK_DBG"):
+            try:
+                _tv = _lg.flatten().topk(3)
+                print("DSPARK_HEAD hid.std=%.4e hid.shape=%s xc.std=%.4e lg.std=%.4e top3val=%s argmaxrow=%s" % (
+                    float(hidden_states.float().std()), tuple(hidden_states.shape),
+                    float(xc.float().std()), float(_lg.float().std()),
+                    [round(float(v),3) for v in _tv.values.tolist()],
+                    _lg.argmax(-1).flatten()[:6].tolist()), file=_sy.stderr, flush=True)
+            except Exception as _e:
+                print("DSPARK_HEAD ERR", _e, file=_sy.stderr, flush=True)
+        if _os.environ.get("DSPARK_DBG"):
+            import sys as _sys
+            try:
+                _am = _lg.argmax(-1).flatten()[:8].tolist()
+            except Exception as _e:
+                _am = "ERR:%s" % _e
+            print("DSPARK_DBG logits shape=%s argmax8=%s" % (tuple(_lg.shape), _am), file=_sys.stderr, flush=True)
+        return _lg
+
+    def forward(self, input_ids, positions, inputs_embeds=None,
+                hidden_states=None, **kwargs):
+        """Run the gamma block through the 3-deep Ascend stack. The Ascend
+        DeepseekV2DecoderLayer does HC internally and returns (hidden, residual);
+        we chain residual like the target's layer loop and return the final hidden
+        [T, hc_mult, hidden] (hc_head + heads applied in compute_logits/compute_block).
+
+        MTP fusion: the draft residual stream is seeded by the next-token
+        embedding PLUS the projected target hidden (main_x = combine_hidden_states
+        output, delivered by the proposer as `hidden_states`). Without main_x the
+        draft is blind to the target and acceptance collapses to 0."""
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+        base = inputs_embeds
+        import os as _os
+        if _os.environ.get("DSPARK_DBG"):
+            import sys as _sys
+            print("DSPARK_DBG fwd hs_none=%s emb=%s hs=%s" % (hidden_states is None, tuple(inputs_embeds.shape), (None if hidden_states is None else tuple(hidden_states.shape))), file=_sys.stderr, flush=True)
+        # MTP-1 (w8a8) reaches 93.9% pos-0 accept by feeding the target hidden DIRECTLY
+        # into the draft (hnorm+h_proj). The pure context-KV path underperforms here, so
+        # re-feed main_x (proposer hidden_states) into the residual: input_layernorm in
+        # each layer renormalizes, so the direction (target signal) is what matters.
+        # MTP-1-style direct feed: make main_x (proposer hidden_states) the DOMINANT
+        # residual (replace, not add) so input_layernorm renormalizes it to std~1 and
+        # the target signal drives the prediction (additive main_x std~0.09 was swamped
+        # by the mask embedding). For pos0 this is exactly MTP-1's hnorm(last_hidden).
+        x = base.unsqueeze(-2).repeat(1, self.hc_mult, 1)   # [T, hc_mult, hidden]
+        residual = None
+        if _os.environ.get("DSPARK_DBG"):
+            import sys as _sst
+            try: print("DSPARK_STAGE init x.std=%.4f x.norm=%.2f emb.std=%.4f" % (float(x.float().std()), float(x.float().norm()), float(base.float().std())), file=_sst.stderr, flush=True)
+            except Exception as _e0: print("DSPARK_STAGE init ERR", _e0, file=_sst.stderr, flush=True)
+        for _li, layer in enumerate(self.layers):
+            x, residual = layer(positions=positions, hidden_states=x, residual=residual)
+            if _os.environ.get("DSPARK_DBG"):
+                import sys as _sst2
+                try:
+                    _xf = x.float()
+                    _rs = ("None" if residual is None else ("%.4f" % float(residual.float().std())))
+                    print("DSPARK_STAGE i=%d x.std=%.4f x.norm=%.2f x0.std=%.4f res.std=%s" % (_li, float(_xf.std()), float(_xf.norm()), float(_xf[0].std()), _rs), file=_sst2.stderr, flush=True)
+                except Exception as _es: print("DSPARK_STAGE ERR", _es, file=_sst2.stderr, flush=True)
+        return x
+
+    @torch.inference_mode()
+    def compute_block(self, x, anchor_ids, temperature: float):
+        """Semi-AR head (inference forward_head). Returns (output_ids[B,gamma+1],
+        confidence[B,gamma] RAW logit)."""
+        xc = _hc_head(x, self.hc_head_fn, self.hc_head_scale, self.hc_head_base,
+                      self.rms_norm_eps, self.hc_eps)          # [.., hidden]
+        U = self.logits_processor(self.shared_head.head, self.shared_head(xc))
+        B = anchor_ids.shape[0]
+        U = U.view(B, self.block_size, -1)
+        xc = xc.view(B, self.block_size, -1)
+        output_ids = anchor_ids.new_empty(B, self.block_size + 1)
+        output_ids[:, 0] = anchor_ids
+        import os as _mb, sys as _mbs
+        _nobias = _mb.environ.get("DSPARK_MK_NOBIAS")
+        if _mb.environ.get("DSPARK_DBG"):
+            print("DSPARK_CB anchor=%s noise=%s U0arg=%s" % (output_ids[:, 0].tolist()[:4], getattr(self, "noise_token_id", "NA"), U[:, 0].argmax(-1).tolist()[:4]), file=_mbs.stderr, flush=True)
+        embeds = []
+        for i in range(self.block_size):
+            # markov bias must be GATHERED to full vocab to match U (markov_w2 is a
+            # ParallelLMHead -> sharded vocab under TP). Use logits_processor exactly
+            # like the base U computation so the two align before the add.
+            emb = self.markov_head.markov_w1(output_ids[:, i])              # [B, rank] (full, VPE all-reduce)
+            bias = self.logits_processor(self.markov_head.markov_w2, emb)  # [B, full_vocab] (gathered)
+            embeds.append(emb)
+            _li = U[:, i].float() if _nobias else (U[:, i].float() + bias.float())
+            output_ids[:, i + 1] = _sample(_li, temperature)
+        markov_embed = torch.stack(embeds, dim=1)
+        confidence = self.confidence_head(xc, markov_embed)
+        return output_ids, confidence
+
+
+def _sample(logits: torch.Tensor, temperature: float) -> torch.Tensor:
+    if temperature <= 0:
+        return logits.argmax(dim=-1)
+    g = -torch.log(-torch.log(torch.rand_like(logits).clamp_min(1e-20)))
+    return (logits / temperature + g).argmax(dim=-1)
+
+
+# ---------------------------------------------------------------- top-level wrapper + loader
+class DeepSeekV4DSpark(nn.Module):
+    # weights ship in the target checkpoint (mtp.*); embed/head shared from target.
+    dspark_shares_target_embeddings = True
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.quant_config = vllm_config.quant_config
+        self.model = DeepSeekV4DSparkModel(
+            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model"))
+
+    # ---- proposer contract (delegated) ----
+    def embed_input_ids(self, input_ids):
+        return self.model.embed_input_ids(input_ids)
+
+    def combine_hidden_states(self, aux_hidden_states):
+        return self.model.combine_hidden_states(aux_hidden_states)
+
+    def precompute_and_store_context_kv(self, context_states, context_positions,
+                                        context_slot_mapping=None):
+        return self.model.precompute_and_store_context_kv(
+            context_states, context_positions, context_slot_mapping)
+
+    def forward(self, input_ids, positions, inputs_embeds=None, hidden_states=None, **kwargs):
+        # Forward the proposer-delivered target seed (main_x) to the inner model;
+        # dropping it leaves the draft blind -> constant token -> 0 accept.
+        return self.model(input_ids, positions, inputs_embeds=inputs_embeds,
+                          hidden_states=hidden_states)
+
+    def compute_logits(self, hidden_states):
+        return self.model.compute_logits(hidden_states)
+
+    def compute_block(self, x, anchor_ids, temperature):
+        return self.model.compute_block(x, anchor_ids, temperature)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """DSpark ckpt namespace mtp.0/1/2.*. Routes to the Ascend draft stack:
+          - per-layer decoder params -> model.layers.{43+i}.* (with Ascend renames:
+            .attn.->.self_attn., .ffn.->.mlp., norms, .w1/.w2/.w3->gate/down/up_proj)
+          - stage-special model-level (main_proj/main_norm stage0;
+            norm/markov/confidence/hc_head last stage) -> model.*
+          - expert scale dtype remap: fp4 -> .weight_scale, fp8 -> .weight_scale_inv,
+            E8M0 expert scale -> view(uint8). Mirrors PR#46995 + Ascend MTP loader."""
+        _STAGE_MODEL = ("main_proj", "main_norm", "markov_head",
+                        "confidence_head", "hc_head_")
+
+        def _route(nm: str) -> str:
+            mm = re.match(r"(?:.*\.)?mtp\.(\d+)\.(.*)", nm)
+            if not mm:
+                if nm.endswith("embed.weight") or nm.endswith(".emb.tok_emb.weight"):
+                    return "model.embed_tokens.weight"
+                if nm == "head.weight" or nm.endswith(".head.weight"):
+                    return "model.shared_head.head.weight"
+                return nm
+            i, rest = int(mm.group(1)), mm.group(2)
+            if rest == "norm.weight":
+                return "model.shared_head.norm.weight"
+            if any(rest.startswith(s) for s in _STAGE_MODEL):
+                return "model." + rest
+            # decoder params -> ModuleList index i (0/1/2), the PARAM path
+            # (the quant prefix is mtp.{i}; param path is model.layers.{i}).
+            return f"model.layers.{i}." + rest
+
+        stacked = [
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        params = dict(self.named_parameters())
+        loaded: set[str] = set()
+        tp_size = get_tensor_model_parallel_world_size()
+        tp_rank = get_tensor_model_parallel_rank()
+        heads_per_rank = self.config.num_attention_heads // tp_size
+        head_start = tp_rank * heads_per_rank
+
+        expert_mapping = FusedMoE.make_expert_params_mapping(
+            model=self.model,
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=self.config.n_routed_experts,
+            num_redundant_experts=getattr(self, "num_redundant_experts", 0))
+        expert_scale_suffix = (
+            ".weight_scale" if getattr(self.config, "expert_dtype", "fp4") == "fp4"
+            else ".weight_scale_inv")
+
+        for name, w in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+            routed = _route(name)
+            is_expert_scale = bool(_EXPERT_SCALE_RE.search(routed))
+            name = routed
+            # Ascend decoder-layer-internal renames (only hit model.layers.* paths)
+            if ".w1." in name:
+                name = name.replace(".w1.", ".gate_proj.")
+            if ".w2." in name:
+                name = name.replace(".w2.", ".down_proj.")
+            if ".w3." in name:
+                name = name.replace(".w3.", ".up_proj.")
+            if "attn" in name and "self_attn" not in name and ".markov" not in name:
+                name = name.replace(".attn.", ".self_attn.")
+            if ".ffn." in name:
+                name = name.replace(".ffn.", ".mlp.")
+            if ".ffn_norm." in name:
+                name = name.replace(".ffn_norm.", ".post_attention_layernorm.")
+            if ".attn_norm." in name:
+                name = name.replace(".attn_norm.", ".input_layernorm.")
+            if ".gate.bias" in name:
+                name = name.replace(".gate.bias", ".gate.e_score_correction_bias")
+            if ".shared_experts.w2" in name:
+                name = name.replace(".shared_experts.w2", ".shared_experts.down_proj")
+            if name.endswith(".scale"):
+                suffix = expert_scale_suffix if is_expert_scale else ".weight_scale_inv"
+                name = name.removesuffix(".scale") + suffix
+
+            # attn sink: TP-narrow per head
+            if "sink" in name:
+                if name not in params:
+                    continue
+                nw = w.narrow(0, head_start, heads_per_rank)
+                params[name].data.copy_(nw)
+                loaded.add(name)
+                continue
+
+            # stacked (gate_up fusion)
+            for pn, wn, sid in stacked:
+                if ".experts." in name or wn not in name:
+                    continue
+                nm = name.replace(wn, pn)
+                if nm not in params:
+                    continue
+                p = params[nm]
+                p.weight_loader(p, w, sid)
+                loaded.add(nm)
+                break
+            else:
+                # experts
+                if ".experts." in name:
+                    if "weight_scale" in name and w.dtype == torch.float8_e8m0fnu:
+                        w = w.view(torch.uint8)
+                    is_expert = False
+                    for pn, wn, eid, sid in expert_mapping:
+                        if wn not in name:
+                            continue
+                        is_expert = True
+                        nm = name.replace(wn, pn)
+                        if nm not in params:
+                            continue
+                        ok = typing.cast(Callable[..., bool], params[nm].weight_loader)(
+                            params[nm], w, nm, shard_id=sid, expert_id=eid,
+                            return_success=True)
+                        if ok:
+                            loaded.add(nm)
+                            break
+                    if is_expert:
+                        continue
+                if name not in params:
+                    continue  # unmapped / target-owned key -> skip
+                p = params[name]
+                getattr(p, "weight_loader", default_weight_loader)(p, w)
+                loaded.add(name)
+
+        import os as _ol, sys as _sl
+        if _ol.environ.get("DSPARK_DBG"):
+            _crit = ["model.hc_head_fn","model.hc_head_base","model.hc_head_scale",
+                     "model.shared_head.head.weight","model.shared_head.norm.weight",
+                     "model.main_proj.weight","model.layers.0.self_attn.wkv.weight",
+                     "model.layers.0.input_layernorm.weight"]
+            _miss = [c for c in _crit if c not in loaded]
+            _allp = dict(self.named_parameters())
+            _unloaded = sorted([n for n in _allp if n not in loaded])
+            print("DSPARK_UNLOADED count=%d :: %s" % (len(_unloaded), _unloaded[:40]), file=_sl.stderr, flush=True)
+            for _n in ["model.layers.0.mlp.experts.w13_weight","model.layers.0.mlp.experts.w2_weight","model.layers.0.mlp.gate.weight","model.layers.0.self_attn.wkv.weight","model.layers.0.mlp.shared_experts.gate_up_proj.weight"]:
+                if _n in _allp:
+                    _v=_allp[_n].float(); print("DSPARK_PARM %s std=%.3e loaded=%s" % (_n, float(_v.std()), _n in loaded), file=_sl.stderr, flush=True)
+            print("DSPARK_LOAD total=%d MISSING_CRIT=%s" % (len(loaded), _miss), file=_sl.stderr, flush=True)
+            _p = dict(self.named_parameters())
+            for _n in ["model.hc_head_fn","model.hc_head_base","model.hc_head_scale","model.shared_head.head.weight"]:
+                if _n in _p:
+                    _v = _p[_n].float()
+                    print("DSPARK_LOAD %s std=%.4e min=%.3e max=%.3e nan=%s" % (_n, float(_v.std()), float(_v.min()), float(_v.max()), bool(_v.isnan().any())), file=_sl.stderr, flush=True)
+        logger.info_once("DSpark draft model loaded: %d params", len(loaded))
+        return loaded

--- a/vllm_ascend/models/deepseek_v4_dspark.py
+++ b/vllm_ascend/models/deepseek_v4_dspark.py
@@ -118,6 +118,31 @@ class DeepSeekV4DSparkModel(nn.Module):
         self.n_stages = config.n_mtp_layers                 # 3
         self.base_layer_id = config.num_hidden_layers       # 43
 
+        # QUAROT_PATCH_V1: QuaRot anti-rotation for the DSpark context path.
+        # path-A ckpt is QuaRot-rotated (target hidden rotated; draft attn incl.
+        # cv_wkv rotated) but main_proj is stored UNROTATED, and vllm-ascend applies
+        # quarot anti-rotation ONLY to Eagle3LlamaForCausalLM -> this custom class
+        # gets nothing. Load global_rotation Q so combine_hidden_states can un-rotate
+        # incoming rotated target hidden (per-4096-block @ Q^T) into main_proj basis,
+        # then rotate main_x (@ Q) into the draft rotated basis cv_wkv expects.
+        # Offline-validated: context-KV reconstruction cos 0.98 (broken=-0.02).
+        self.register_buffer('_quarot_Q', None, persistent=False)
+        try:
+            import os as _qos
+            from safetensors.torch import load_file as _qload
+            _mp = vllm_config.speculative_config.draft_model_config.model
+            _qp = _qos.path.join(str(_mp), 'optional', 'quarot.safetensors')
+            if _qos.path.exists(_qp):
+                self._quarot_Q = _qload(_qp)['global_rotation'].to(torch.bfloat16)
+                import sys as _qsys
+                print('DSPARK QUAROT_PATCH_V1 loaded Q %s' % (tuple(self._quarot_Q.shape),), file=_qsys.stderr, flush=True)
+            else:
+                import sys as _qsys
+                print('DSPARK QUAROT_PATCH_V1 no quarot file at %s (no-op)' % _qp, file=_qsys.stderr, flush=True)
+        except Exception as _qe:
+            import sys as _qsys
+            print('DSPARK QUAROT_PATCH_V1 load skipped: %r' % (_qe,), file=_qsys.stderr, flush=True)
+
         # per-stage sparse-attn topk index buffer (only if the arch is v3.2-style)
         if hasattr(config, "index_topk"):
             self.topk_indices_buffer = torch.empty(
@@ -170,8 +195,28 @@ class DeepSeekV4DSparkModel(nn.Module):
         return self.embed_tokens(input_ids)
 
     def combine_hidden_states(self, aux_hidden_states: torch.Tensor) -> torch.Tensor:
-        """dflash contract; DSpark folds main_norm in -> returns main_x [T, hidden]."""
+        """dflash contract; DSpark folds main_norm in -> returns main_x [T, hidden].
+        QUAROT_PATCH_V1: un-rotate rotated target hidden per 4096-block (@Q^T) into
+        main_proj basis, then rotate main_x (@Q) into the draft rotated basis."""
+        if self._quarot_Q is not None:
+            _q = self._quarot_Q.to(device=aux_hidden_states.device, dtype=aux_hidden_states.dtype)  # QUAROT_DEVFIX_V1
+            _h = self.hidden_size
+            aux_hidden_states = torch.cat(
+                [aux_hidden_states[:, k*_h:(k+1)*_h] @ _q.t()
+                 for k in range(len(self.target_layer_ids))], dim=-1)
         _mx = self.main_norm(self.main_proj(aux_hidden_states))
+        import os as _qao  # QUAROT_AUXONLY_V1: bf16 draft skips re-rotation
+        if self._quarot_Q is not None and not _qao.environ.get("DSPARK_QUAROT_AUXONLY"):
+            _mx = _mx @ self._quarot_Q.to(device=_mx.device, dtype=_mx.dtype)
+        import os as _capc
+        if _capc.environ.get("DSPARK_CAPTURE"):
+            try:
+                self._cap_aux = aux_hidden_states.detach().cpu().float()
+                self._cap_mainproj_out = self.main_proj(aux_hidden_states).detach().cpu().float()
+                self._cap_mainx = _mx.detach().cpu().float()
+            except Exception:
+                pass
+
         import os as _oa, sys as _sa
         if _oa.environ.get("DSPARK_DBG"):
             try:
@@ -265,6 +310,19 @@ class DeepSeekV4DSparkModel(nn.Module):
                 impl._dspark_write_cache_ptr = int(swa_kv_cache.data_ptr())
             except Exception:
                 pass
+        import os as _rg
+        if _rg.environ.get("DSPARK_RING"):
+            try:
+                _bs = int(swa_kv_cache.shape[1])
+                _orig = slot_mapping.flatten().to(torch.int64)
+                _cp = context_positions.flatten().to(torch.int64)
+                # ring within the sequence base block(s): keep each token base block from the
+                # proposer slot for positions < bs, but force positions >= bs to wrap into the
+                # SAME base block as position 0 of that contiguous run (single-seq ring).
+                _base_block = (_orig[0] // _bs)
+                slot_mapping = (_base_block * _bs + (_cp % _bs)).to(slot_mapping.dtype)
+            except Exception as _re:
+                import sys as _rs; print("DSPARK_RING ERR %r"%(_re,), file=_rs.stderr, flush=True)
         if slot_mapping.dim() == 1:
             slot_mapping = DeviceOperator.format_dsa_slot_mapping(
                 slot_mapping.to(torch.int64), block_size)
@@ -335,12 +393,16 @@ class DeepSeekV4DSparkModel(nn.Module):
         # by the mask embedding). For pos0 this is exactly MTP-1's hnorm(last_hidden).
         x = base.unsqueeze(-2).repeat(1, self.hc_mult, 1)   # [T, hc_mult, hidden]
         residual = None
+        if _os.environ.get("DSPARK_CAPTURE"):
+            self._cap_stageinit = x.detach().cpu().float(); self._cap_inputids = input_ids.detach().cpu()
         if _os.environ.get("DSPARK_DBG"):
             import sys as _sst
             try: print("DSPARK_STAGE init x.std=%.4f x.norm=%.2f emb.std=%.4f" % (float(x.float().std()), float(x.float().norm()), float(base.float().std())), file=_sst.stderr, flush=True)
             except Exception as _e0: print("DSPARK_STAGE init ERR", _e0, file=_sst.stderr, flush=True)
         for _li, layer in enumerate(self.layers):
             x, residual = layer(positions=positions, hidden_states=x, residual=residual)
+            if _os.environ.get("DSPARK_CAPTURE"):
+                setattr(self, "_cap_stage%d" % _li, x.detach().cpu().float())
             if _os.environ.get("DSPARK_DBG"):
                 import sys as _sst2
                 try:
@@ -357,6 +419,39 @@ class DeepSeekV4DSparkModel(nn.Module):
         xc = _hc_head(x, self.hc_head_fn, self.hc_head_scale, self.hc_head_base,
                       self.rms_norm_eps, self.hc_eps)          # [.., hidden]
         U = self.logits_processor(self.shared_head.head, self.shared_head(xc))
+        import os as _capb
+        if _capb.environ.get("DSPARK_CAPTURE") and not _capb.path.exists("/data1/dspark_capture.pt"):
+            try:
+                import torch as _tc
+                _snap = {
+                    "backbone_x": x.detach().cpu().float(),
+                    "stage_init": getattr(self, "_cap_stageinit", None),
+                    "input_ids_blk": getattr(self, "_cap_inputids", None),
+                    "stage0": getattr(self, "_cap_stage0", None),
+                    "stage1": getattr(self, "_cap_stage1", None),
+                    "postattn": (__import__("vllm_ascend.models.deepseek_v4", fromlist=["_DSPARK_PA"])._DSPARK_PA[:]),
+                    "xc_hchead": xc.detach().cpu().float(),
+                    "base_U": U.detach().cpu().float(),
+                    "anchor": anchor_ids.detach().cpu(),
+                    "aux": getattr(self, "_cap_aux", None),
+                    "mainproj_out": getattr(self, "_cap_mainproj_out", None),
+                    "main_x": getattr(self, "_cap_mainx", None),
+                    "main_norm_w": self.main_norm.weight.detach().cpu().float() if hasattr(self,"main_norm") else None,
+                    "hc_head_fn": self.hc_head_fn.detach().cpu().float(),
+                    "hc_head_scale": self.hc_head_scale.detach().cpu().float(),
+                    "hc_head_base": self.hc_head_base.detach().cpu().float(),
+                    "shared_norm_w": self.shared_head.norm.weight.detach().cpu().float() if hasattr(self.shared_head,"norm") else None,
+                    "markov_w1": self.markov_head.markov_w1.weight.detach().cpu().float(),
+                    "markov_w2": self.markov_head.markov_w2.weight.detach().cpu().float(),
+                    "rms_norm_eps": float(self.rms_norm_eps),
+                    "hc_eps": float(self.hc_eps),
+                    "block_size": int(self.block_size),
+                    "hc_mult": int(self.hc_mult),
+                }
+                _tc.save(_snap, "/data1/dspark_capture.pt")
+                import sys as _sc; print("DSPARK_CAPTURE saved snapshot keys=%s" % list(_snap.keys()), file=_sc.stderr, flush=True)
+            except Exception as _ce:
+                import sys as _sc; print("DSPARK_CAPTURE ERR %r"%(_ce,), file=_sc.stderr, flush=True)
         B = anchor_ids.shape[0]
         U = U.view(B, self.block_size, -1)
         xc = xc.view(B, self.block_size, -1)

--- a/vllm_ascend/ops/rope_dsv4.py
+++ b/vllm_ascend/ops/rope_dsv4.py
@@ -12,6 +12,11 @@ class RopeGlobalState:
     def __init__(self):
         self.static_cache: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
         self.runtime_buffer: dict[str, dict[str, tuple[torch.Tensor, torch.Tensor]]] = {}
+        # MTP FullGraph: per-draft-step fixed-address cos/sin buffers, keyed by
+        # cache_slot (>0). draft_step>0 must NOT reuse the shared slot-0 buffer
+        # (would override step0); a fresh tensor (use_cache=False) is stale under
+        # cudagraph. One persistent buffer per (config_key, group, slot).
+        self.draft_runtime_buffer: dict[str, dict[str, dict[int, tuple[torch.Tensor, torch.Tensor]]]] = {}
         self.layer_info: dict[str, tuple[str, list[str]]] = {}
         self.registry_summary: dict[str, set] = {}
 
@@ -58,7 +63,9 @@ class RopeDataProxy:
             return layer_result
 
 
-def get_cos_and_sin_dsa(positions: torch.Tensor | dict[str, torch.Tensor], use_cache: bool = False):
+def get_cos_and_sin_dsa(
+    positions: torch.Tensor | dict[str, torch.Tensor], use_cache: bool = False, cache_slot: int = 0
+):
     if isinstance(positions, torch.Tensor):
         pos_map = {"default": positions}
     else:
@@ -81,7 +88,24 @@ def get_cos_and_sin_dsa(positions: torch.Tensor | dict[str, torch.Tensor], use_c
             curr_sin = static_sin[pos_tensor]
 
             if use_cache:
-                group_buffers = _ROPE_STATE.runtime_buffer.get(config_key, {}).get(group_name)
+                if cache_slot == 0:
+                    group_buffers = _ROPE_STATE.runtime_buffer.get(config_key, {}).get(group_name)
+                else:
+                    # MTP FullGraph: draft_step>0 gets its own persistent fixed-address
+                    # buffer (lazily cloned from the slot-0 buffer's shape) so the captured
+                    # graph reads a stable address that is refreshed in-place each step,
+                    # without overriding the slot-0 (step-0 / main) buffer.
+                    base = _ROPE_STATE.runtime_buffer.get(config_key, {}).get(group_name)
+                    if base is None:
+                        group_buffers = None
+                    else:
+                        slot_map = _ROPE_STATE.draft_runtime_buffer.setdefault(config_key, {}).setdefault(
+                            group_name, {}
+                        )
+                        group_buffers = slot_map.get(cache_slot)
+                        if group_buffers is None:
+                            group_buffers = (torch.empty_like(base[0]), torch.empty_like(base[1]))
+                            slot_map[cache_slot] = group_buffers
 
                 if group_buffers is None:
                     continue

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -167,8 +167,26 @@ def _get_kv_cache_groups_uniform_groups(
         # See `_get_kv_cache_groups_uniform_page_size` for more details.
         num_tuple_groups = cdiv(num_layers_per_size, num_layer_tuples)
         layer_tuples = list(zip(*layers_per_size.values()))
-        for i in range(num_tuple_groups):
-            group_layer_tuples = layer_tuples[i::num_tuple_groups]
+        # DSpark: isolate draft (MTP) SWA layer-tuples into a single dedicated
+        # kv-cache group. The spec-decode proposer requires all drafting layers to
+        # share one kv cache group; the default strided split scatters mtp.0/1/2
+        # across groups. Target layers keep the original split formula.
+        def _is_draft_tuple(_t):
+            return any(((".mtp." in (".%s." % _n)) or _n.startswith("mtp.")) for _n in _t)
+        draft_tuples = [t for t in layer_tuples if _is_draft_tuple(t)]
+        main_tuples = [t for t in layer_tuples if not _is_draft_tuple(t)]
+        group_tuple_lists = []
+        if draft_tuples:
+            main_ntg = cdiv(len(main_tuples), num_layer_tuples) if main_tuples else 0
+            for i in range(main_ntg):
+                group_tuple_lists.append(main_tuples[i::main_ntg])
+            group_tuple_lists.append(draft_tuples)
+        else:
+            for i in range(num_tuple_groups):
+                group_tuple_lists.append(layer_tuples[i::num_tuple_groups])
+        for group_layer_tuples in group_tuple_lists:
+            if not group_layer_tuples:
+                continue
             # Flatten tuples and build dict for from_specs
             group_layer_names = [name for layer_tuple in group_layer_tuples for name in layer_tuple]
             group_layer_specs = {name: sm_spec.kv_cache_specs[name] for name in group_layer_names}

--- a/vllm_ascend/spec_decode/__init__.py
+++ b/vllm_ascend/spec_decode/__init__.py
@@ -19,6 +19,7 @@
 
 
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
+from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
 from vllm_ascend.spec_decode.extract_hidden_states_proposer import (
@@ -43,6 +44,8 @@ def get_spec_decode_method(method, vllm_config, device, runner):
         return AscendEagleProposer(vllm_config, device, runner)
     elif method == "dflash":
         return AscendDflashProposer(vllm_config, device, runner)
+    elif method == "dspark":
+        return AscendDSparkProposer(vllm_config, device, runner)
     elif method == "draft_model":
         return AscendDraftModelProposer(vllm_config, device, runner)
     elif method == "extract_hidden_states":

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -83,6 +83,11 @@ class AscendDflashProposer(AscendEagleProposer):
 
         self._dflash_num_context = num_context
         self._dflash_hidden_states[:num_context] = target_hidden_states
+        # DSpark residual seed: capture each request's LAST context index BEFORE
+        # cad.query_start_loc is overwritten below. main_x at that index seeds the
+        # draft residual (canonical DFlash channel) -> the broken context-KV path
+        # is bypassed; without this the draft is blind and accept collapses to 0.
+        self._dflash_last_ctx_idx = cad.query_start_loc[1:batch_size + 1].to(torch.long) - 1
 
         token_indices_to_sample = torch.empty(
             batch_size * self.num_speculative_tokens,
@@ -111,7 +116,10 @@ class AscendDflashProposer(AscendEagleProposer):
             num_rejected_tokens_ptr=(num_rejected_tokens_gpu if has_num_rejected else 0),
             # Scalars
             parallel_drafting_token_id=self.parallel_drafting_token_id,
-            block_size=self.kernel_block_size,
+            block_size=self.vllm_config.cache_config.block_size,  # DSpark fix: dflash
+            # slot kernel must use the KV-CACHE block_size (128), not kernel_block_size
+            # (=2 here). With 2, context/query slots address the wrong physical blocks
+            # so the draft never reads the written context KV -> constant output.
             num_query_per_req=num_query_per_req,
             num_speculative_tokens=self.num_speculative_tokens,
             total_input_tokens=num_context,
@@ -119,6 +127,21 @@ class AscendDflashProposer(AscendEagleProposer):
             HAS_NUM_REJECTED=has_num_rejected,
         )
 
+        import os as _o, sys as _s
+        if _o.environ.get("DSPARK_DBG"):
+            try:
+                print("DSPARK_PROBE num_ctx=%d ctx_slots[:10]=%s ctx_pos[:10]=%s mainx_std=%.5f mainx_mean=%.5f" % (
+                    num_context,
+                    self._context_slot_mapping_buffer[:num_context][:10].tolist(),
+                    self._context_positions_buffer[:num_context][:10].tolist(),
+                    float(self._dflash_hidden_states[:num_context].float().std()),
+                    float(self._dflash_hidden_states[:num_context].float().mean()),
+                ), file=_s.stderr, flush=True)
+            except Exception as _e:
+                print("DSPARK_PROBE ERR", _e, file=_s.stderr, flush=True)
+        import os as _ob, sys as _sb
+        if _ob.environ.get("DSPARK_DBG"):
+            print("DSPARK_BS kernel_block_size=%s cache_bs=%s decode_threshold=%s" % (getattr(self,"kernel_block_size",None), self.vllm_config.cache_config.block_size, getattr(self,"decode_threshold",None)), file=_sb.stderr, flush=True)
         query_slot_mapping = self._slot_mapping_buffer[:num_query_total]
         new_query_start_loc = self.arange_dflash[: batch_size + 1] * num_query_per_req
 
@@ -259,8 +282,13 @@ class AscendDflashProposer(AscendEagleProposer):
             self._context_slot_mapping_buffer[:num_context],
         )
 
+        seed = self._dflash_hidden_states[:num_context][self._dflash_last_ctx_idx]      # [batch, H]
+        hidden_states = seed.repeat_interleave(1 + self.num_speculative_tokens, dim=0)  # [batch*(1+S), H]
         return dict(
-            input_ids=self.input_ids[:num_input_tokens], positions=self.positions[:num_input_tokens], inputs_embeds=None
+            input_ids=self.input_ids[:num_input_tokens],
+            positions=self.positions[:num_input_tokens],
+            inputs_embeds=None,
+            hidden_states=hidden_states[:num_input_tokens],
         )
 
     def _raise_if_multimodal(self):

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -87,7 +87,15 @@ class AscendDflashProposer(AscendEagleProposer):
         # cad.query_start_loc is overwritten below. main_x at that index seeds the
         # draft residual (canonical DFlash channel) -> the broken context-KV path
         # is bypassed; without this the draft is blind and accept collapses to 0.
-        self._dflash_last_ctx_idx = cad.query_start_loc[1:batch_size + 1].to(torch.long) - 1
+        # DSPARK FIX: seed from each request's last ACCEPTED context position, not the last
+        # VERIFIED one. Under greedy decode most draft tokens are rejected, so query_start_loc-1
+        # points at a REJECTED token whose main_x is the target hidden of a WRONG token ->
+        # poisoned seed. Subtract num_rejected to land on the accepted token.
+        _ctx_start = cad.query_start_loc[:batch_size].to(torch.long)
+        _last_ctx = cad.query_start_loc[1:batch_size + 1].to(torch.long) - 1
+        if num_rejected_tokens_gpu is not None:
+            _last_ctx = _last_ctx - num_rejected_tokens_gpu[:batch_size].to(torch.long)
+        self._dflash_last_ctx_idx = torch.maximum(_last_ctx, _ctx_start)  # clamp: never below req start
 
         token_indices_to_sample = torch.empty(
             batch_size * self.num_speculative_tokens,

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""AscendDSparkProposer — DeepSeek-V4 DSpark speculative-decode proposer.
+
+DSpark's parallel backbone IS DFlash (parallel block construction + target-KV
+injection + ACL graph), so this subclasses AscendDflashProposer and inherits
+nearly everything:
+  * set_inputs_first_pass        : gamma-block query (anchor + mask) construction
+  * build_model_inputs_first_pass: calls model.precompute_and_store_context_kv
+                                   (DSpark = MLA context-latent injection from main_x)
+  * dummy_run / ACL graph capture, DP sync, parallel_drafting
+
+The DSpark-specific pieces live in the MODEL (deepseek_v4_dspark.DeepSeekV4DSpark):
+  * combine_hidden_states  = main_norm(main_proj(aux))   (called by base _propose)
+  * precompute_and_store_context_kv = per-stage MLA latent -> paged cache
+  * forward                = 3-deep V4 stack over the gamma block
+  * compute_logits         = base draft logits U_k
+
+Staging:
+  * MVP (this class as-is)  = "DSpark-minus-Markov" == DFlash over the V4 backbone.
+    Reuses the base parallel-drafting token path (compute_logits -> sample). Gives
+    the parallel-backbone speculative speedup; measured vs MTP-1 == first benefit.
+  * Phase 2 (compute_block override below) = semi-AR Markov head + confidence.
+    The base samples gamma tokens from U_k independently; DSpark instead runs
+    model.compute_block(hidden, anchor_ids, temp) -> (output_ids, confidence) which
+    adds the per-step Markov bias (Eq.5) before sampling and emits the confidence
+    logits (Eq.7) for the Algorithm-1 scheduler. Wire by overriding the
+    post-forward token generation (base llm_base_proposer _run_merged_draft, the
+    `compute_logits(sample_hidden_states)` site) to call compute_block instead.
+"""
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+
+from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
+
+logger = init_logger(__name__)
+
+
+class AscendDSparkProposer(AscendDflashProposer):
+    """DSpark proposer. MVP inherits the full DFlash flow; the semi-AR Markov head
+    + confidence-scheduled verification are layered on at phase 2 (see module doc)."""
+
+    def __init__(self, vllm_config: VllmConfig, device, runner=None):
+        super().__init__(vllm_config, device, runner=runner)
+        spec = vllm_config.speculative_config
+        cfg = spec.draft_model_config.hf_config
+        # DSpark draft block (gamma) must equal num_speculative_tokens so the
+        # parallel block construction lines up with the verify window.
+        self.dspark_block_size = getattr(cfg, "dspark_block_size", None)
+        self.use_markov_head = False  # phase-2 switch (compute_block path)
+        logger.info(
+            "AscendDSparkProposer: gamma=%s num_spec=%s markov_head=%s (MVP=DFlash-backbone)",
+            self.dspark_block_size, self.num_speculative_tokens, self.use_markov_head,
+        )
+
+    # --- Phase 2 hook (semi-AR Markov + confidence) -------------------------
+    # def _draft_tokens_from_hidden(self, sample_hidden_states, anchor_ids):
+    #     """Override the base U_k -> sample path with DSpark's compute_block:
+    #     output_ids, confidence = self.model.compute_block(
+    #         sample_hidden_states, anchor_ids, self.temperature)
+    #     Stash `confidence` for the Algorithm-1 scheduler (schedule_prefix_lengths).
+    #     """

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -9,6 +9,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import vllm.distributed.parallel_state as _parallel_state
 from vllm.config import CompilationMode, CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
 from vllm.distributed.parallel_state import (
     get_pcp_group,
@@ -16,7 +17,6 @@ from vllm.distributed.parallel_state import (
     get_tp_group,
     get_world_group,
     init_model_parallel_group,
-    patch_tensor_parallel_group,
 )
 from vllm.forward_context import BatchDescriptor, ForwardContext, get_forward_context
 from vllm.logger import logger
@@ -53,6 +53,21 @@ from vllm_ascend.distributed.parallel_state import get_lmhead_tp_group
 from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 from vllm_ascend.utils import enable_sp, lmhead_tp_enable, shared_expert_dp_enabled
+
+try:
+    from vllm.distributed.parallel_state import patch_tensor_parallel_group
+except ImportError:
+
+    @contextmanager
+    def patch_tensor_parallel_group(tp_group):
+        old_tp_group = _parallel_state.get_tp_group()
+        _parallel_state._TP_STATE_PATCHED = True
+        _parallel_state._TP = tp_group
+        try:
+            yield
+        finally:
+            _parallel_state._TP_STATE_PATCHED = False
+            _parallel_state._TP = old_tp_group
 
 # Currently we will fix block size to a small one since `num_reqs` can't be too large
 _PREPARE_INPUTS_BLOCK_SIZE = 4
@@ -138,6 +153,26 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         # Assign runner before it's used in the methods below
         self.runner = runner
+
+        # vLLM's DeepSeek-V4 MTP path expands hidden_size to hc_mult * hidden
+        # because MTP consumes the pre-hc_head residual. DSpark first projects
+        # the configured target-layer concat back to the draft hidden basis, so
+        # downstream buffers and assertions must stay at the draft hidden size.
+        if self.method == "dspark":
+            dspark_hidden_size = self.draft_model_config.get_hidden_size()
+            if self.hidden_size != dspark_hidden_size:
+                self.hidden_size = dspark_hidden_size
+                self.hidden_states = torch.zeros(
+                    (self.max_num_tokens, self.hidden_size),
+                    dtype=self.dtype,
+                    device=device,
+                )
+                if self.parallel_drafting_hidden_state_tensor is not None:
+                    self.parallel_drafting_hidden_state_tensor = torch.empty(
+                        self.hidden_size,
+                        dtype=self.dtype,
+                        device=self.device,
+                    )
 
         logger.debug(
             "[spec_decode/base] Initializing spec decode proposer: method=%s,"

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -108,6 +108,28 @@ def greedy_sample(logits: torch.Tensor) -> torch.Tensor:
     return target_argmax
 
 
+def schedule_prefix_lengths(conf_logits, tau=0.5, sps_budget=None):
+    """DSPARK_SCHED_V1: Algorithm-1 confidence scheduler (phase-1 per-request).
+    conf_logits [B, gamma] RAW confidence logits (Eq.7, pre-sigmoid). Returns
+    ell [B] = admitted speculative prefix length per request. a_{r,j}=prod(sigmoid c)
+    is monotonically non-increasing => admit = (a>=theta) is a leading-True prefix =>
+    ell = count of leading Trues (causal barrier, lossless early-stop). SPS(B) global
+    budget reallocation is phase-3 (sps_budget hook)."""
+    import torch as _t
+    c = _t.sigmoid(conf_logits.float())
+    a = _t.cumprod(c, dim=1)
+    theta = tau
+    ell = (a >= theta).int().sum(dim=1)
+    if sps_budget is not None:
+        # phase-3: greedily cap total admitted tokens to the batch compute budget,
+        # dropping lowest-a tail positions first. (stub: honor per-req ell for now.)
+        while int(ell.sum()) > sps_budget and int(ell.max()) > 0:
+            _j = a.gather(1, (ell.clamp_min(1) - 1).unsqueeze(1)).squeeze(1)
+            _j = _j.masked_fill(ell == 0, float('inf'))
+            ell[int(_j.argmin())] -= 1
+    return ell
+
+
 class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     _runnable: ACLGraphWrapper | Callable
 
@@ -1075,6 +1097,17 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 _anchor = self.input_ids[(_tidx[:, 0] - 1).long()].contiguous()
                 _sh = last_hidden_states.index_select(0, _raw_tidx.long())
             _mout, _mconf = self.model.compute_block(_sh, _anchor, 0.0)
+            import os as _sch, sys as _schs
+            if _sch.environ.get("DSPARK_SCHED") and _mconf is not None:
+                try:
+                    _tau = float(_sch.environ.get("DSPARK_SCHED_TAU", "0.5"))
+                    _ell = schedule_prefix_lengths(_mconf.view(_mout.shape[0], -1), tau=_tau)
+                    _cprob = __import__("torch").sigmoid(_mconf.float()).view(_mout.shape[0], -1)
+                    print("DSPARK_SCHED tau=%.2f B=%d ell=%s meanEll=%.2f conf0=%s" % (
+                        _tau, _mout.shape[0], _ell[:8].tolist(), float(_ell.float().mean()),
+                        [round(float(x),3) for x in _cprob[0].tolist()]), file=_schs.stderr, flush=True)
+                except Exception as _sce:
+                    print("DSPARK_SCHED ERR %r" % (_sce,), file=_schs.stderr, flush=True)
             if _mkv.environ.get("DSPARK_DBG"):
                 import sys as _ms
                 _base = self.model.compute_logits(_sh).argmax(-1).view(-1, _nq)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -530,6 +530,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 slot_mapping=self.runner.input_batch.block_table[0].slot_mapping.gpu,
                 slot_mapping_cpu=self.runner.input_batch.block_table[0].slot_mapping.cpu,
                 positions=self.runner.positions,
+                # MTP graph-mode fix: DSA build_decode_metadata indexes positions_cpu;
+                # mirror main model (model_runner_v1.py) so drafter graph capture doesn't hit None.
+                positions_cpu=self.runner._dsa_positions_cpu_buf if self.use_compress else None,
                 attn_state=self.runner.attn_state,
                 decode_token_per_req=self.runner.decode_token_per_req,
                 max_seq_len=0,
@@ -550,9 +553,20 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 if self.pcp_size * self.dcp_size > 1 and draft_step > 0:
                     assert self.block_table_tensor_clone is not None, "block_table_tensor_clone is not init"
                     common_attn_metadata.block_table_tensor = self.block_table_tensor_clone[:num_reqs]
+                # MTP graph-mode fix: DSA build() asserts *_ratio_to_sas_metadata is not None;
+                # mirror _propose() so drafter graph capture passes empty sas_metadata dicts.
+                extra_attn_metadata_args: dict = {}
+                if self.use_compress:
+                    extra_attn_metadata_args = dict(
+                        prefill_ratio_to_sas_metadata=dict(),
+                        decode_ratio_to_sas_metadata=dict(),
+                        common_ratio_to_sas_metadata=dict(),
+                        block_size=self.draft_attn_groups[0].kv_cache_spec.block_size,
+                    )
                 attn_metadata_eagle = builder.build_for_graph_capture(
                     common_attn_metadata,
                     AscendAttentionState.SpecDecoding if self.method == "mtp" else AscendAttentionState.ChunkedPrefill,
+                    **extra_attn_metadata_args,
                 )
                 per_layer_attn_metadata = dict()
                 for layer_name in self.attn_layer_names:
@@ -646,10 +660,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         if token_indices_to_sample is None:
             token_indices_to_sample = common_attn_metadata.query_start_loc[1:] - 1
 
-        if self.method in ("eagle3", "dflash"):
-            assert isinstance(
-                self.get_model(), (Eagle3LlamaForCausalLM, DFlashQwen3ForCausalLM, Eagle3DeepseekV2ForCausalLM)
-            )
+        if self.method in ("eagle3", "dflash", "dspark"):
+            if self.method != "dspark":
+                assert isinstance(
+                    self.get_model(), (Eagle3LlamaForCausalLM, DFlashQwen3ForCausalLM, Eagle3DeepseekV2ForCausalLM)
+                )
             target_hidden_states = self.model.combine_hidden_states(target_hidden_states)
             assert target_hidden_states.shape[-1] == self.hidden_size
 
@@ -719,7 +734,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             common_attn_metadata.block_table_tensor = self._adjust_tensor(
                 common_attn_metadata.block_table_tensor, slicing_length
             )
-            if self.method == "dflash":
+            if self.method in ("dflash", "dspark"):
                 common_attn_metadata.seq_lens = self._adjust_tensor(common_attn_metadata.seq_lens, num_reqs_padded)
             else:
                 common_attn_metadata.seq_lens = self._adjust_tensor(self.runner.seq_lens, num_reqs_padded)
@@ -979,8 +994,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         model_input_ids = self.input_ids[:num_input_tokens]
         model_positions = self._get_positions(num_input_tokens)
 
-        if self.method == "dflash":
+        if self.method in ("dflash", "dspark"):
             model_kwargs = self.build_model_inputs_first_pass(num_input_tokens)
+            if self.method == "dspark" and self.pass_hidden_states_to_model:
+                # DSpark: seed the draft first pass with the projected target hidden
+                # (main_x = combine_hidden_states output, stored in self.hidden_states
+                # by set_inputs_first_pass). The dflash first-pass builder omits it, so
+                # the draft would start blind and collapse to a constant token.
+                model_kwargs["hidden_states"] = self.hidden_states[:num_input_tokens]
         else:
             model_kwargs = {
                 "input_ids": model_input_ids,
@@ -1002,7 +1023,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         else:
             last_hidden_states, hidden_states = ret_hidden_states
 
-        if self.method != "dflash":
+        if self.method not in ("dflash", "dspark"):
             last_hidden_states, model_positions, hidden_states = self.maybe_all_gather_and_unpad(
                 last_hidden_states, model_positions, hidden_states
             )
@@ -1038,6 +1059,27 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             )
 
         sample_hidden_states = last_hidden_states[token_indices_to_sample]
+        import os as _mkv
+        if (self.method == "dspark" and _mkv.environ.get("DSPARK_MARKOV")
+                and hasattr(self.model, "compute_block")):
+            _nq = self.num_speculative_tokens
+            _raw_tidx = token_indices_to_sample[:num_indices]   # strip lmhead_tp padding (Codex)
+            _tidx = _raw_tidx.view(-1, _nq)
+            if _mkv.environ.get("DSPARK_SHIFT"):
+                # DSpark samples the ANCHOR row (q0, input=real bonus token) as the
+                # first prediction (ref forward_head row0), NOT the mask rows q1..qS.
+                _sidx = (_tidx - 1).reshape(-1).long()
+                _anchor = self.input_ids[(_tidx[:, 0] - 1).long()].contiguous()
+                _sh = last_hidden_states.index_select(0, _sidx)
+            else:
+                _anchor = self.input_ids[(_tidx[:, 0] - 1).long()].contiguous()
+                _sh = last_hidden_states.index_select(0, _raw_tidx.long())
+            _mout, _mconf = self.model.compute_block(_sh, _anchor, 0.0)
+            if _mkv.environ.get("DSPARK_DBG"):
+                import sys as _ms
+                _base = self.model.compute_logits(_sh).argmax(-1).view(-1, _nq)
+                print("DSPARK_CMP shift=%s anchor=%s base=%s block=%s" % (bool(_mkv.environ.get("DSPARK_SHIFT")), _anchor[:2].tolist(), _base[0].tolist(), _mout[0, 1:].tolist()), file=_ms.stderr, flush=True)
+            return _mout[:, 1:].contiguous()
 
         if get_ascend_config().enable_reduce_sample and self.method in ("eagle3", "dflash"):
             draft_token_ids = self.compute_draft_token_ids(sample_hidden_states)
@@ -1061,6 +1103,15 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                         logits = logits[:num_indices]
                         token_indices_to_sample = token_indices_to_sample[:num_indices]
                     draft_token_ids = logits.argmax(dim=-1)
+            elif self.method == "dspark":
+                # DSpark semi-AR Markov sampling: base U_k + markov_bias(prev token),
+                # sequential, seeded with the per-request anchor (bonus) token. This is
+                # the essential DSpark head; base logits alone are near-unconditional.
+                _bs = sample_hidden_states.shape[0] // self.num_speculative_tokens
+                _nqpr = 1 + self.num_speculative_tokens
+                _anchor = self.input_ids[torch.arange(_bs, device=sample_hidden_states.device, dtype=torch.long) * _nqpr]
+                _out_ids, _conf = self.model.compute_block(sample_hidden_states, _anchor, 0.0)
+                draft_token_ids = _out_ids[:, 1:].reshape(-1)
             else:
                 logits = self.model.compute_logits(sample_hidden_states)
                 if lmhead_tp_enable() and num_indices < logits.shape[0]:
@@ -1442,7 +1493,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             return total_num_output_tokens, token_indices_to_sample, new_cad, None
 
     def model_returns_tuple(self) -> bool:
-        return self.method not in ("mtp", "draft_model", "dflash")
+        return self.method not in ("mtp", "draft_model", "dflash", "dspark")
 
     def attn_update_stack_num_spec_norm(
         self,

--- a/vllm_ascend/spec_decode/utils.py
+++ b/vllm_ascend/spec_decode/utils.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import numpy as np
 import torch
 
 
@@ -29,3 +30,44 @@ def update_num_computed_tokens_for_batch_change(
     n = prev_positions.shape[0]
     num_computed_tokens[:n].copy_(torch.where(participating, corrected, cpu_num_computed_tokens))
     num_accepted_tokens.copy_(torch.where(participating, valid_counts, num_accepted_tokens))
+
+
+def correct_optimistic_seq_lens_cpu(
+    optimistic_seq_lens_cpu_np: np.ndarray,
+    prev_positions_np: np.ndarray,
+    prev_num_draft_tokens_np: np.ndarray,
+    valid_sampled_token_count_np: np.ndarray,
+    num_reqs: int,
+) -> None:
+    """Correct ``optimistic_seq_lens_cpu`` for async spec decode drift.
+
+    The scheduler optimistically advances ``num_computed_tokens_cpu`` by the
+    full number of tokens scheduled in the previous step (``prev_drafts + 1``
+    per spec-decode request), assuming all drafts were accepted. The actual
+    number of valid sampled tokens is ``valid_count = 1 + accepted_drafts``.
+    The drift, equal to the number of rejected tokens, is therefore::
+
+        rejected = prev_drafts + 1 - valid_count
+
+    Subtracting this from the optimistic seq_lens recovers the true seq_lens
+    that ``self.seq_lens`` (GPU) carries for participating requests, without
+    touching the device. New requests (``prev_positions < 0``) and prefills
+    (``prev_drafts == 0``) need no correction.
+
+    Mirrors ``update_num_computed_tokens_for_batch_change`` on the CPU side.
+
+    All arrays are sliced to ``num_reqs``; ``optimistic_seq_lens_cpu_np`` is
+    modified in place.
+    """
+    prev_positions = prev_positions_np[:num_reqs]
+    # Clamp negative entries (new requests) to 0; the participating mask zeroes
+    # out their correction so the gathered values are don't-care.
+    gather_indices = np.maximum(prev_positions, 0)
+    prev_drafts = prev_num_draft_tokens_np[gather_indices]
+    valid_counts = valid_sampled_token_count_np[gather_indices]
+
+    participating = (prev_positions >= 0) & (prev_drafts > 0)
+    # rejected_for_participating == correction; non-participating reqs end up
+    # at zero via the mask multiply.
+    correction = (prev_drafts + 1 - valid_counts) * participating
+    optimistic_seq_lens_cpu_np[:num_reqs] -= correction.astype(optimistic_seq_lens_cpu_np.dtype, copy=False)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1788,15 +1788,22 @@ class NPUModelRunner(GPUModelRunner):
                 num_prefill_reqs = 0
                 num_decode_reqs = 0
 
-            # Let the target override the hidden state fed to the drafter
-            # (e.g. DeepSeek V4 MTP needs the pre-hc_head residual). Safe to
-            # rebind here: hidden_states was already consumed for sampling
-            # above and is not used again in this branch.
-            mtp_hidden_states = getattr(
-                self.get_model(), "get_mtp_target_hidden_states", lambda: None
-            )()
-            if mtp_hidden_states is not None:
-                hidden_states = mtp_hidden_states
+            # Let DeepSeek-V4 variants override the hidden state fed to the
+            # drafter. MTP needs the pre-hc_head residual, while DSpark needs
+            # the concatenated mean-HC states from dspark_target_layer_ids.
+            is_dspark_spec_decode = self.speculative_config.method == "dspark"
+            if is_dspark_spec_decode:
+                dspark_hidden_states = getattr(
+                    self.get_model(), "get_dspark_target_hidden_states", lambda: None
+                )()
+                if dspark_hidden_states is not None:
+                    hidden_states = dspark_hidden_states
+            else:
+                mtp_hidden_states = getattr(
+                    self.get_model(), "get_mtp_target_hidden_states", lambda: None
+                )()
+                if mtp_hidden_states is not None:
+                    hidden_states = mtp_hidden_states
 
             num_rejected_tokens_gpu = None
             if spec_decode_metadata is None:
@@ -1806,14 +1813,14 @@ class NPUModelRunner(GPUModelRunner):
                     target_token_ids = input_ids_pcp_full[:num_scheduled_tokens]
                     target_positions = self._get_positions(num_scheduled_tokens)
                     target_hidden_states = hidden_states
-                    if self.use_aux_hidden_state_outputs:
+                    if self.use_aux_hidden_state_outputs and not is_dspark_spec_decode:
                         target_hidden_states = torch.cat([h for h in aux_hidden_states], dim=-1)
                 else:
                     token_indices_to_sample = None
                     # input_ids can be None for multimodal models.
                     target_token_ids = self.input_ids.gpu[:num_scheduled_tokens]
                     target_positions = self._get_positions(num_scheduled_tokens)
-                    if self.use_aux_hidden_state_outputs:
+                    if self.use_aux_hidden_state_outputs and not is_dspark_spec_decode:
                         target_hidden_states = torch.cat([h[:num_scheduled_tokens] for h in aux_hidden_states], dim=-1)
                     else:
                         target_hidden_states = hidden_states[:num_scheduled_tokens]
@@ -1843,12 +1850,12 @@ class NPUModelRunner(GPUModelRunner):
                     target_token_ids = input_ids_pcp_full[token_indices]
                     target_positions = positions
                     target_hidden_states = hidden_states
-                    if self.use_aux_hidden_state_outputs:
+                    if self.use_aux_hidden_state_outputs and not is_dspark_spec_decode:
                         target_hidden_states = torch.cat([h for h in aux_hidden_states], dim=-1)
                 else:
                     target_token_ids = self.input_ids.gpu[token_indices]
                     target_positions = self._get_positions(token_indices)
-                    if self.use_aux_hidden_state_outputs:
+                    if self.use_aux_hidden_state_outputs and not is_dspark_spec_decode:
                         target_hidden_states = torch.cat([h[token_indices] for h in aux_hidden_states], dim=-1)
                     else:
                         target_hidden_states = hidden_states[token_indices]
@@ -3594,9 +3601,17 @@ class NPUModelRunner(GPUModelRunner):
     def profile_run(self) -> None:
         self.eplb_warmup()
         mc2_tokens_capacity = get_mc2_tokens_capacity()
-        if self.max_num_tokens > mc2_tokens_capacity and select_moe_comm_method(
-            mc2_tokens_capacity, self.vllm_config
-        ) in {MoECommType.MC2, MoECommType.FUSED_MC2}:
+        skip_mc2_profile = (
+            self.speculative_config is not None
+            and self.speculative_config.method == "dspark"
+        )
+        if (
+            not skip_mc2_profile
+            and mc2_tokens_capacity is not None
+            and self.max_num_tokens > mc2_tokens_capacity
+            and select_moe_comm_method(mc2_tokens_capacity, self.vllm_config)
+            in {MoECommType.MC2, MoECommType.FUSED_MC2}
+        ):
             self._dummy_run(mc2_tokens_capacity, with_prefill=True, is_profile=True)
         origin_max_num_tokens = self.max_num_tokens
         # in the pcp scenario, the split sequence needs to be used for profile run

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -145,7 +145,10 @@ from vllm_ascend.spec_decode.medusa_proposer import AscendMedusaProposer
 from vllm_ascend.spec_decode.ngram_proposer import AscendNgramProposer
 from vllm_ascend.spec_decode.ngram_proposer_npu import AscendNgramProposerNPU
 from vllm_ascend.spec_decode.suffix_proposer import AscendSuffixDecodingProposer
-from vllm_ascend.spec_decode.utils import update_num_computed_tokens_for_batch_change
+from vllm_ascend.spec_decode.utils import (
+    correct_optimistic_seq_lens_cpu,
+    update_num_computed_tokens_for_batch_change,
+)
 from vllm_ascend.utils import (
     calc_split_factor,
     check_gdn_layer,
@@ -463,17 +466,13 @@ class NPUModelRunner(GPUModelRunner):
 
         self._set_up_drafter()
 
-        # Event for async GPU→CPU copy of corrected seq_lens in async
-        # spec decode mode. Recorded in _prepare_inputs, synchronized
-        # in _build_attention_metadata. Created once, reused each iteration.
-        # Only backends that consume CPU seq_lens (AscendAttentionBackend,
-        # AscendMLABackend, and DSV4 compressed attention metadata) need this;
-        # others (SFA, GDN, etc.) do not.
+        # Backends that consume CPU seq_lens (AscendAttentionBackend,
+        # AscendMLABackend, and DSV4 compressed attention metadata) need
+        # ``optimistic_seq_lens_cpu`` to match the corrected GPU seq_lens
+        # in async spec decode mode; others (SFA, GDN, etc.) do not.
         self._needs_seq_lens_cpu_sync = self.use_compress or issubclass(
             self.attn_backend, (AscendAttentionBackend, AscendMLABackend)
         )
-        self._seq_lens_cpu_event: torch.npu.Event | None = None
-        self._seq_lens_cpu_event_pending = False
 
         # kv role
         self.is_kv_producer = False
@@ -1193,56 +1192,34 @@ class NPUModelRunner(GPUModelRunner):
                 precomputed_positions_np=positions_full,
             )
 
-        # In async spec decode mode, num_computed_tokens was corrected on GPU
-        # by update_num_computed_tokens_for_batch_change, so seq_lens (GPU) is
-        # correct but optimistic_seq_lens_cpu is stale (it assumed all drafts
-        # were accepted). Sync the corrected values back to CPU so that NPU
-        # attention backends (which use _seq_lens_cpu) get the right values.
-        # Use non_blocking copy to pinned memory and record an event;
-        # _build_attention_metadata will synchronize before reading.
-        if (
-            self._needs_seq_lens_cpu_sync
-            and self.use_async_spec_decode
-            and self.valid_sampled_token_count_gpu is not None # type: ignore[has-type]
+        # In async spec decode mode, optimistic_seq_lens_cpu assumes all
+        # tokens from the previous speculative step were accepted. Correct it
+        # on CPU using the valid-sampled-token counts that are already copied
+        # asynchronously for scheduler bookkeeping. This avoids an extra
+        # NPU->CPU seq_lens copy and the synchronize() in attention metadata.
+        # Mirrors update_num_computed_tokens_for_batch_change on the GPU side.
+        async_spec_decode_active = (
+            self.use_async_spec_decode
+            and self.valid_sampled_token_count_gpu is not None  # type: ignore[has-type]
             and prev_req_id_to_index
-        ):
-            self.optimistic_seq_lens_cpu[:num_reqs].copy_(
-                self.seq_lens[:num_reqs], non_blocking=True
-            )
-            if self._seq_lens_cpu_event is None:
-                self._seq_lens_cpu_event = torch.npu.Event()
-            self._seq_lens_cpu_event.record()
-            self._seq_lens_cpu_event_pending = True
-        else:
-            self._seq_lens_cpu_event_pending = False
+        )
+
+        if self._needs_seq_lens_cpu_sync and async_spec_decode_active:
+            self._correct_optimistic_seq_lens_cpu(num_reqs)
 
         num_computed_tokens_for_compress = (
             self.input_batch.num_computed_tokens_cpu[:num_reqs]
         )
-        if (
-            self.use_compress
-            and self.use_async_spec_decode
-            and self.valid_sampled_token_count_gpu is not None # type: ignore[has-type]
-            and prev_req_id_to_index
-        ):
-            # Async spec decode keeps the CPU counter optimistic until after
-            # target forward is launched. DSV4 compressed KV slot mapping is
-            # CPU-built today, so use the GPU-corrected counter before
-            # computing compressed cache positions.
-            if (
-                self._seq_lens_cpu_event_pending
-                and self._seq_lens_cpu_event is not None
-            ):
-                self._seq_lens_cpu_event.synchronize()
-                self._seq_lens_cpu_event_pending = False
-                num_computed_tokens_for_compress = (
-                    self.optimistic_seq_lens_cpu[:num_reqs].numpy()
-                    - num_scheduled_tokens[:num_reqs]
-                )
-            else:
-                num_computed_tokens_for_compress = (
-                    self.num_computed_tokens[:num_reqs].to("cpu").numpy()
-                )
+        if self.use_compress and async_spec_decode_active:
+            # ``self.use_compress`` implies ``_needs_seq_lens_cpu_sync``, so
+            # ``optimistic_seq_lens_cpu`` was corrected just above. DSV4
+            # compressed KV slot mapping is CPU-built today; derive the
+            # corrected num_computed_tokens from the corrected seq_lens to
+            # avoid another NPU->CPU sync.
+            num_computed_tokens_for_compress = (
+                self.optimistic_seq_lens_cpu[:num_reqs].numpy()
+                - num_scheduled_tokens[:num_reqs]
+            )
 
         (positions_compressed_list, req_indices_compressed_list,
          num_scheduled_tokens_compressed_list) = get_compressed_pos_and_indices(
@@ -1614,6 +1591,34 @@ class NPUModelRunner(GPUModelRunner):
             target_logits_indices=target_logits_indices,
             bonus_logits_indices=bonus_logits_indices,
             logits_indices=logits_indices,
+        )
+
+    def _correct_optimistic_seq_lens_cpu(self, num_reqs: int) -> None:
+        """Correct ``optimistic_seq_lens_cpu`` for async spec-decode drift.
+
+        The valid-sampled-token counts that drive the correction are copied
+        device->host on a side stream at the end of the *previous* step (see
+        :meth:`_copy_valid_sampled_token_count`). The host buffer must not be
+        read until that copy has completed, otherwise the correction consumes
+        stale counts and corrupts the CPU seq_lens. DeepSeek-V4 builds its
+        compressed-KV slot mapping from these CPU seq_lens, so the race
+        surfaces as an accuracy regression there.
+
+        Synchronizing on the event before the host read mirrors vLLM's own
+        :meth:`_get_valid_sampled_token_count`. Because the copy was launched a
+        full step earlier, the event is already signalled in steady state and
+        the synchronize is effectively a no-op -- it does not reintroduce the
+        seq_lens device->host copy + synchronize that this optimization removed.
+        """
+        assert self.valid_sampled_token_count_event is not None
+        assert self.valid_sampled_token_count_cpu is not None
+        self.valid_sampled_token_count_event.synchronize()
+        correct_optimistic_seq_lens_cpu(
+            self.optimistic_seq_lens_cpu.numpy(),
+            self.prev_positions.np,
+            self.prev_num_draft_tokens.np,
+            self.valid_sampled_token_count_cpu.numpy(),
+            num_reqs,
         )
 
     def _copy_valid_sampled_token_count(
@@ -2966,12 +2971,6 @@ class NPUModelRunner(GPUModelRunner):
         attn_metadata: PerLayerAttnMetadata = {}
         if ubatch_slices is not None:
             attn_metadata = [dict() for _ in range(len(ubatch_slices))]
-
-        # Ensure the async GPU→CPU copy of corrected seq_lens (launched in
-        # _prepare_inputs) has completed before we read optimistic_seq_lens_cpu.
-        if self._seq_lens_cpu_event_pending and self._seq_lens_cpu_event is not None:
-            self._seq_lens_cpu_event.synchronize()
-            self._seq_lens_cpu_event_pending = False
 
         if for_cudagraph_capture:
             # For some attention backends (e.g. FA) with sliding window models we need

--- a/vllm_ascend/worker/v2/sample/gumbel.py
+++ b/vllm_ascend/worker/v2/sample/gumbel.py
@@ -34,7 +34,7 @@ def _temperature_kernel(
     req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
     temperature = tl.load(temperature_ptr + req_state_idx).to(tl.float32)
     if temperature == 0.0 or temperature == 1.0:
-        # Early return to avoid loading logits.
+        # Early return to avoid loading logits
         return
 
     block_idx = tl.program_id(1)


### PR DESCRIPTION
Adapt DSpark ([paper](https://github.com/deepseek-ai/DeepSpec/blob/main/DSpark_paper.pdf), arxiv:2606.19348) to vllm-ascend on `releases/v0.21.0rc`, aligned with upstream design.

**Supersedes #11066** (which extended the serial MTP path; upstream PRs intentionally reject that fallback).

## Aligned with upstream
- vllm PR [#46995](https://github.com/vllm-project/vllm/pull/46995) (benchislett, GPU/NVIDIA)
- sglang PR [#29538](https://github.com/sgl-project/sglang/pull/29538)

`method="dspark"` is its own SpeculativeConfig method (not `method="mtp"` + env flag), routed to an independent `AscendDsparkSpeculator`. DSpark model class is independent of `deepseek_v4_mtp.py`. `embed_tokens` + `lm_head` aliased from target.

## Status — DRAFT

| Done | Pending |
|---|---|
| `method="dspark"` dispatch | Markov serial loop wired into `_propose` (currently runs DFlash parallel sample with DSpark model loaded) |
| Independent `DSparkDeepseekV4ForCausalLM` + heads + ckpt loader (`mtp.<i>.*` remap) | Non-causal sliding-window sparse attention (NPU sfa_v1 equivalent of `sparse_swa.py`) |
| `load_dspark_model` (shares target embed/lm_head) | ACLGraph capture of backbone + sample loop |
| Unit tests for head math + `_remap_dspark_name` truth table | Confidence-scheduled scheduling (upstream out-of-scope; tracking vllm DSD PR #45953) |

## Test plan
- [x] `tests/ut/spec_decode/test_dspark_v2.py` (pure tensor, no NPU)
- [ ] e2e: load `deepseek-ai/DeepSeek-V4-Flash-DSpark` on A2 8-card via [`Model_test:dsv4/dspark/A2/run.sh`](https://github.com/FutureSkyFly/Model_test/blob/main/dsv4/dspark/A2/run.sh) — should load + dispatch via `method="dspark"` and produce DFlash-equivalent draft tokens (Markov bias not yet active)
- [ ] Regression: standard `method="mtp"` + non-DSpark ckpt unchanged

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
