### PR TITLE
[Test] Add DeepSeek R1 Distill ACLGRAPH coverage

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -675,6 +675,7 @@
 estimated_times:
   tests/e2e/pull_request/one_card/_310p/test_classification_310p.py: 60
   tests/e2e/pull_request/one_card/_310p/test_dense_model_310p.py: 1090
+  tests/e2e/pull_request/one_card/_310p/test_deepseek_r1_distill_aclgraph_310p.py: 1200
   tests/e2e/pull_request/one_card/_310p/test_embedding_310p.py: 450
   tests/e2e/pull_request/one_card/_310p/test_scoring_310p.py: 320
   tests/e2e/pull_request/one_card/_310p/test_spec_decode_mtp_310p.py: 290
@@ -747,6 +748,7 @@ estimated_times:
   tests/e2e/pull_request/two_card/test_sp_pass.py: 230
   tests/e2e/pull_request/two_card/test_hccl_weight_transfer.py: 130
   tests/e2e/pull_request/four_card/_310p/test_dense_model_310p.py: 390
+  tests/e2e/pull_request/four_card/_310p/test_deepseek_r1_distill_qwen32b_aclgraph_310p.py: 900
   tests/e2e/pull_request/four_card/_310p/test_moe_model_310p.py: 500
   tests/e2e/pull_request/four_card/_310p/test_vl_model_310p.py: 350
   tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py: 1900
@@ -830,7 +832,6 @@ partition:
   a3_x2: 3
   a3_x4: 3
   cpu_x0: 1
-
 
 
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,149 @@
+# DeepSeek-R1-Distill ACLGRAPH Adaptation Notes
+
+## 适用范围
+
+本记录适用于 DeepSeek-R1-Distill Qwen/Llama 系列在 vLLM Ascend 上的 ACLGRAPH 适配。当前已用真实权重验证：
+
+- `deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B`
+- `deepseek-ai/DeepSeek-R1-Distill-Llama-8B`
+- `deepseek-ai/DeepSeek-R1-Distill-Qwen-32B`
+
+不要把 Qwen 7B/14B、Llama 70B 或其他变体声明为已验证，除非补齐对应 real-weight 日志。
+
+## 模型路由决策
+
+- Qwen-backed Distill 走 `Qwen2ForCausalLM` / `qwen2` 路径。
+- Llama-backed Distill 走 `LlamaForCausalLM` / `llama` 路径。
+- 两个代表检查点都是 dense text-only BF16 权重，在 310P 上用 `--dtype float16` 运行。
+- 不新增 DeepSeek MoE/MLA patch；只有确认现有 Qwen/Llama 路径无法工作时才考虑最小 patch。
+
+## 验证顺序
+
+1. 检查 `config.json`：`architectures`、`model_type`、`torch_dtype`、`max_position_embeddings`、是否有 MoE/MTP/multimodal 字段。
+2. 下载真实权重到 `${CACHE_ROOT}`，默认 `CACHE_ROOT=/data/.cache`，优先 ModelScope 或 hf-mirror。
+3. 先跑 eager real-weight smoke，确认加载和一次非空推理。
+4. 再跑 ACLGRAPH real-weight smoke，必须包含 `FULL_DECODE_ONLY`、有界 `cudagraph_capture_sizes`、一次非空推理和 `Replaying aclgraph` 日志。
+5. accuracy 评测与 graph 证据分开：`lm_eval` 可用 eager 保持稳定，ACLGRAPH 用专门 E2E 覆盖。
+6. 大模型多卡先跑 TP eager smoke，再跑 ACLGRAPH，避免把权重加载/HCCL 问题误判为 graph capture 问题。
+7. Qwen-32B accuracy 基线使用 `gsm8k`、`limit=32`、`num_fewshot=5`、TP4 eager 采集；实测 `exact_match,strict-match=0.0`，`exact_match,flexible-extract=0.125`。
+
+## 310P ACLGRAPH 参数
+
+Qwen 1.5B 通过参数：
+
+```bash
+--dtype float16 \
+--max-model-len 4096 \
+--max-num-seqs 4 \
+--max-num-batched-tokens 4096 \
+--gpu-memory-utilization 0.70 \
+--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4]}'
+```
+
+Llama 8B 通过参数：
+
+```bash
+--dtype float16 \
+--max-model-len 4096 \
+--max-num-seqs 2 \
+--max-num-batched-tokens 4096 \
+--gpu-memory-utilization 0.80 \
+--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2]}'
+```
+
+Qwen 32B TP4 通过参数：
+
+```bash
+export ASCEND_RT_VISIBLE_DEVICES=${ASCEND_RT_VISIBLE_DEVICES:-2,3,4,5}
+if [ -z "${QWEN32B_MODEL_PATH:-}" ]; then
+  QWEN32B_MODEL_PATH=$(CACHE_DIR="${MODELSCOPE_CACHE}" uv run python - <<'PY'
+import os
+from modelscope import snapshot_download
+
+print(snapshot_download(
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
+    cache_dir=os.environ["CACHE_DIR"],
+))
+PY
+)
+fi
+export QWEN32B_MODEL_PATH
+
+--dtype float16 \
+--tensor-parallel-size 4 \
+--distributed-executor-backend mp \
+--max-model-len 2048 \
+--max-num-seqs 1 \
+--max-num-batched-tokens 2048 \
+--gpu-memory-utilization 0.60 \
+--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1]}'
+```
+
+Qwen 32B TP2 压力验证通过参数：
+
+```bash
+export ASCEND_RT_VISIBLE_DEVICES=${ASCEND_RT_VISIBLE_DEVICES:-0,1}
+
+--dtype float16 \
+--tensor-parallel-size 2 \
+--distributed-executor-backend mp \
+--max-model-len 1024 \
+--max-num-seqs 1 \
+--max-num-batched-tokens 1024 \
+--gpu-memory-utilization 0.90 \
+--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1]}'
+```
+
+310P 不要省略 `--max-model-len`。配置理论值是 131072，但当前实测通过值是小模型 4096、Qwen-32B TP4 2048、Qwen-32B TP2 1024。
+
+## 环境与缓存
+
+```bash
+export CACHE_ROOT=${CACHE_ROOT:-/data/.cache}
+export ASCEND_TOOLKIT_HOME=${ASCEND_TOOLKIT_HOME:-/usr/local/Ascend/cann-9.1.0-beta.1}
+export ASCEND_NNAL_HOME=${ASCEND_NNAL_HOME:-/usr/local/Ascend/nnal}
+source "${ASCEND_TOOLKIT_HOME}/set_env.sh"
+source "${ASCEND_NNAL_HOME}/atb/set_env.sh"
+export UV_CACHE_DIR=${UV_CACHE_DIR:-${CACHE_ROOT}/uv}
+export HF_HOME=${HF_HOME:-${CACHE_ROOT}/huggingface}
+export HF_DATASETS_CACHE=${HF_DATASETS_CACHE:-${HF_HOME}/datasets}
+export XDG_CACHE_HOME=${XDG_CACHE_HOME:-${CACHE_ROOT}}
+export MODELSCOPE_CACHE=${MODELSCOPE_CACHE:-${CACHE_ROOT}/modelscope}
+export VLLM_CACHE_ROOT=${VLLM_CACHE_ROOT:-${CACHE_ROOT}/vllm}
+export HCCL_OP_EXPANSION_MODE=AIV
+```
+
+如果缺少 `libatb.so`，安装 `Ascend-cann-nnal` 后 source `${ASCEND_NNAL_HOME}/atb/set_env.sh`。不要同时 source ATB 和 ASDSIP。
+
+## 算子与运行时注意事项
+
+- `FULL_DECODE_ONLY` 可降低 310P capture 压力。
+- 大模型先从 `cudagraph_capture_sizes=[1]` 开始；TP4 通过后再考虑扩大 capture sizes。
+- Qwen-32B TP4 每 rank 权重约 16.08 GiB；TP2 每 rank 权重约 32.06 GiB，显存边界明显更紧。
+- Qwen-32B TP4 graph capture 约 3 秒，NPU graph memory 约 0.15 GiB；TP2 同样约 0.15 GiB。
+- stream resource exhaustion 时先减小 `cudagraph_capture_sizes`，再降低 `max-num-seqs` 或 `max-model-len`。
+- `Graph capturing finished` 只证明 capture 完成；必须在真实请求后看到 `Replaying aclgraph`。
+- `--enforce-eager` 是隔离手段，不是 ACLGRAPH 通过证据。
+- 避免在热路径新增 NPU tensor `.item()`，防止 CPU/NPU 同步。
+
+## 不适用功能
+
+- Multimodal：N/A，代表检查点是 text-only。
+- MoE / Expert Parallel / FlashComm：N/A，代表检查点不是 MoE。
+- MTP：N/A，配置和权重未包含 nextn/MTP 层。
+- Llama-70B 和未列出的 Distill 变体：checkpoint-dependent，需要单独 real-weight 验证。
+
+## PR/Issue 摘要模板
+
+Task #21 / #9079 summary:
+
+- Added DeepSeek-R1-Distill Qwen/Llama accuracy configs.
+- Added DeepSeek-R1-Distill Qwen-32B accuracy config with measured `gsm8k` metrics: strict-match `0.0`, flexible-extract `0.125`.
+- Added 310P ACLGRAPH E2E coverage with `FULL_DECODE_ONLY`.
+- Verified real weights for Qwen-1.5B and Llama-8B from `${MODELSCOPE_CACHE}`.
+- Verified Qwen-32B real weights on 310P TP4 with `ASCEND_RT_VISIBLE_DEVICES=2,3,4,5`, `max_model_len=2048`, and capture sizes `[1]`.
+- Verified Qwen-32B TP2 pressure path with `ASCEND_RT_VISIBLE_DEVICES=0,1`, `max_model_len=1024`, and capture sizes `[1]`; prefer TP4 for headroom.
+- Qwen graph smoke: capture sizes `[1,2,4]`, non-empty chat output, `Replaying aclgraph`.
+- Llama graph smoke: capture sizes `[1,2]`, non-empty chat output, `Replaying aclgraph`.
+- Qwen-32B graph smoke: non-empty output, `Graph capturing finished`, and `Replaying aclgraph`.
+- Multimodal, MoE, EP, FlashComm, and MTP are not applicable for these dense text-only checkpoints.

--- a/docs/source/tutorials/models/DeepSeek-R1-Distill.md
+++ b/docs/source/tutorials/models/DeepSeek-R1-Distill.md
@@ -1,0 +1,275 @@
+# DeepSeek-R1-Distill
+
+## Introduction
+
+`DeepSeek-R1-Distill` 包含 Qwen 和 Llama 两类稠密文本模型。本教程覆盖已验证的代表检查点：
+
+- `deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B`
+- `deepseek-ai/DeepSeek-R1-Distill-Llama-8B`
+- `deepseek-ai/DeepSeek-R1-Distill-Qwen-32B`
+
+这些检查点分别复用 vLLM 中的 `Qwen2ForCausalLM` 和 `LlamaForCausalLM` 路径，不需要新增 DeepSeek MoE/MLA 专属模型代码。配置中的理论最大上下文为 131072，本次在 Atlas 300I DUO (310P) 上验证的实用 `max-model-len` 为 4096；Qwen-32B 多卡验证使用 2048。
+
+## Supported Features
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| BF16 checkpoint loading | Supported | 310P 验证时使用 `--dtype float16`，日志显示从 BF16 cast 到 FP16。 |
+| ACLGRAPH | Supported | 310P real-weight 验证通过，使用 `FULL_DECODE_ONLY` 和有界 capture sizes。 |
+| Tensor parallel | Supported | Qwen-32B 在 310P 上通过 TP4 ACLGRAPH；TP2 通过压力验证但推荐优先使用 TP4。 |
+| Multimodal | N/A | 代表检查点是 text-only dense 模型。 |
+| MoE / EP / FlashComm | N/A | 代表检查点不是 MoE。 |
+| MTP | N/A | 配置和权重未提供 MTP/nextn 层。 |
+
+不要把未验证的大尺寸 Distill 变体标记为已验证 ACLGRAPH 支持。当前 Llama-70B 未验证；需要先完成 real-weight startup、一次非空推理输出和 graph replay 证据。
+
+## Environment Preparation
+
+### Storage And Cache
+
+本教程默认使用 `/data/.cache` 作为下载和运行缓存目录；如环境不同，可只覆盖 `CACHE_ROOT`。
+
+```bash
+export CACHE_ROOT=${CACHE_ROOT:-/data/.cache}
+export UV_CACHE_DIR=${UV_CACHE_DIR:-${CACHE_ROOT}/uv}
+export HF_HOME=${HF_HOME:-${CACHE_ROOT}/huggingface}
+export HF_DATASETS_CACHE=${HF_DATASETS_CACHE:-${HF_HOME}/datasets}
+export XDG_CACHE_HOME=${XDG_CACHE_HOME:-${CACHE_ROOT}}
+export MODELSCOPE_CACHE=${MODELSCOPE_CACHE:-${CACHE_ROOT}/modelscope}
+export VLLM_CACHE_ROOT=${VLLM_CACHE_ROOT:-${CACHE_ROOT}/vllm}
+```
+
+### Runtime Environment
+
+310P 验证需要加载 CANN 和 NNAL/ATB 环境。不要同时加载 ATB 和 ASDSIP。
+
+```bash
+export ASCEND_TOOLKIT_HOME=${ASCEND_TOOLKIT_HOME:-/usr/local/Ascend/cann-9.1.0-beta.1}
+export ASCEND_NNAL_HOME=${ASCEND_NNAL_HOME:-/usr/local/Ascend/nnal}
+source "${ASCEND_TOOLKIT_HOME}/set_env.sh"
+source "${ASCEND_NNAL_HOME}/atb/set_env.sh"
+export HCCL_OP_EXPANSION_MODE=AIV
+export ASCEND_RT_VISIBLE_DEVICES=0
+```
+
+如果运行时报 `libatb.so` 缺失，请先安装 `Ascend-cann-nnal`，然后重新 source `${ASCEND_NNAL_HOME}/atb/set_env.sh`。
+
+### Model Weights
+
+优先使用 ModelScope 或 hf-mirror，并把权重放在 `${CACHE_ROOT}` 下。
+
+使用 ModelScope Python API：
+
+```bash
+CACHE_DIR="${MODELSCOPE_CACHE}" uv run python -c "import os; from modelscope import snapshot_download; snapshot_download('deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B', cache_dir=os.environ['CACHE_DIR'])"
+CACHE_DIR="${MODELSCOPE_CACHE}" uv run python -c "import os; from modelscope import snapshot_download; snapshot_download('deepseek-ai/DeepSeek-R1-Distill-Llama-8B', cache_dir=os.environ['CACHE_DIR'])"
+CACHE_DIR="${MODELSCOPE_CACHE}" uv run python -c "import os; from modelscope import snapshot_download; snapshot_download('deepseek-ai/DeepSeek-R1-Distill-Qwen-32B', cache_dir=os.environ['CACHE_DIR'])"
+```
+
+如果环境提供 `vllm_modelscope`，也可以使用它下载同名模型。使用 Hugging Face mirror 时设置：
+
+```bash
+export HF_ENDPOINT=https://hf-mirror.com
+export HF_HOME=${HF_HOME:-${CACHE_ROOT}/huggingface}
+```
+
+## Deployment
+
+以下命令是 310P 上通过 real-weight 验证的 ACLGRAPH 路径。310P 不建议省略 `--max-model-len`，避免按 131072 自动建大 mask 导致 OOM。
+
+### Qwen 1.5B
+
+```bash
+if [ -z "${QWEN_MODEL_PATH:-}" ]; then
+  QWEN_MODEL_PATH=$(CACHE_DIR="${MODELSCOPE_CACHE}" uv run python - <<'PY'
+import os
+from modelscope import snapshot_download
+
+print(snapshot_download(
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+    cache_dir=os.environ["CACHE_DIR"],
+))
+PY
+)
+fi
+export QWEN_MODEL_PATH
+
+vllm serve "${QWEN_MODEL_PATH}" \
+  --served-model-name deepseek-r1-distill-qwen-1.5b \
+  --dtype float16 \
+  --max-model-len 4096 \
+  --max-num-seqs 4 \
+  --max-num-batched-tokens 4096 \
+  --gpu-memory-utilization 0.70 \
+  --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}' \
+  --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4]}' \
+  --port 8000
+```
+
+### Llama 8B
+
+```bash
+if [ -z "${LLAMA_MODEL_PATH:-}" ]; then
+  LLAMA_MODEL_PATH=$(CACHE_DIR="${MODELSCOPE_CACHE}" uv run python - <<'PY'
+import os
+from modelscope import snapshot_download
+
+print(snapshot_download(
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+    cache_dir=os.environ["CACHE_DIR"],
+))
+PY
+)
+fi
+export LLAMA_MODEL_PATH
+
+vllm serve "${LLAMA_MODEL_PATH}" \
+  --served-model-name deepseek-r1-distill-llama-8b \
+  --dtype float16 \
+  --max-model-len 4096 \
+  --max-num-seqs 2 \
+  --max-num-batched-tokens 4096 \
+  --gpu-memory-utilization 0.80 \
+  --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}' \
+  --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2]}' \
+  --port 8000
+```
+
+### Qwen 32B TP4
+
+Qwen-32B 在 310P 上用真实权重验证了 TP4 eager 和 TP4 ACLGRAPH。当前主验证拓扑是逻辑设备 `2,3,4,5`，这组设备在测试机器上由物理 NPU5/NPU6 提供并显示为 PHB 关系。实际机器上请先用 `npu-smi info -m` 和 `npu-smi info -t topo` 确认可用拓扑。
+
+```bash
+export ASCEND_RT_VISIBLE_DEVICES=${ASCEND_RT_VISIBLE_DEVICES:-2,3,4,5}
+if [ -z "${QWEN32B_MODEL_PATH:-}" ]; then
+  QWEN32B_MODEL_PATH=$(CACHE_DIR="${MODELSCOPE_CACHE}" uv run python - <<'PY'
+import os
+from modelscope import snapshot_download
+
+print(snapshot_download(
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
+    cache_dir=os.environ["CACHE_DIR"],
+))
+PY
+)
+fi
+export QWEN32B_MODEL_PATH
+
+vllm serve "${QWEN32B_MODEL_PATH}" \
+  --served-model-name deepseek-r1-distill-qwen-32b \
+  --dtype float16 \
+  --tensor-parallel-size 4 \
+  --distributed-executor-backend mp \
+  --max-model-len 2048 \
+  --max-num-seqs 1 \
+  --max-num-batched-tokens 2048 \
+  --gpu-memory-utilization 0.60 \
+  --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}' \
+  --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1]}' \
+  --port 8000
+```
+
+实测 TP4 ACLGRAPH 边界：
+
+- `ASCEND_RT_VISIBLE_DEVICES=2,3,4,5`
+- `tensor_parallel_size=4`
+- `max_model_len=2048`
+- `max_num_seqs=1`
+- `max_num_batched_tokens=2048`
+- `gpu_memory_utilization=0.60`
+- `cudagraph_capture_sizes=[1]`
+- 每个 TP rank 权重约 16.08 GiB
+- graph capture 约 3 秒，NPU graph memory 约 0.15 GiB
+
+TP2 也完成了压力验证，使用 `ASCEND_RT_VISIBLE_DEVICES=0,1`、`max_model_len=1024`、`gpu_memory_utilization=0.90`、capture sizes `[1]`，每个 rank 权重约 32.06 GiB。TP2 显存边界更紧，文档推荐生产或回归验证优先使用 TP4。
+
+Eager 模式只用于隔离问题，不作为 ACLGRAPH 支持证据：
+
+```bash
+vllm serve <model-path> --dtype float16 --max-model-len 4096 --enforce-eager --port 8000
+```
+
+## Functional Verification
+
+服务启动后必须发起真实请求。`Application startup complete` 不是充分证据。
+
+```bash
+curl -sf http://127.0.0.1:8000/v1/models
+
+curl -sS http://127.0.0.1:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "deepseek-r1-distill-qwen-1.5b",
+    "messages": [{"role": "user", "content": "Reply with the word graph."}],
+    "temperature": 0,
+    "max_tokens": 16
+  }'
+```
+
+ACLGRAPH 证据需要同时包含：
+
+- 日志出现 `Graph capturing finished`
+- 一次 `/v1/chat/completions` 返回 HTTP 200 且输出非空
+- 请求后日志出现 `Replaying aclgraph`
+
+## Accuracy Evaluation
+
+本次使用 `tests/e2e/models/test_lm_eval_correctness.py` 在 310P 上完成 real-weight eager accuracy 验证。accuracy 配置使用 eager，是为了把质量评测与 graph-mode 证据分开；ACLGRAPH 覆盖由 `_310p/test_deepseek_r1_distill_aclgraph_310p.py` 提供。
+
+| Model | Task | num_fewshot | limit | strict-match | flexible-extract |
+| --- | --- | ---: | ---: | ---: | ---: |
+| DeepSeek-R1-Distill-Qwen-1.5B | gsm8k | 5 | 32 | 0.0 | 0.0 |
+| DeepSeek-R1-Distill-Llama-8B | gsm8k | 5 | 32 | 0.0 | 0.1875 |
+| DeepSeek-R1-Distill-Qwen-32B | gsm8k | 5 | 32 | 0.0 | 0.125 |
+
+运行示例：
+
+```bash
+export VLLM_USE_MODELSCOPE=True
+export HF_ENDPOINT=https://hf-mirror.com
+export REPORT_DIR=${REPORT_DIR:-/tmp/deepseek_r1_distill_accuracy}
+uv run pytest -q tests/e2e/models/test_lm_eval_correctness.py \
+  --config tests/e2e/models/configs/DeepSeek-R1-Distill-Qwen-1.5B.yaml \
+  --tp-size 1 \
+  --report-dir "${REPORT_DIR}"
+```
+
+Qwen-32B accuracy 基线使用 TP4 和 eager 模式采集，ACLGRAPH 支持仍由四卡 `_310p` smoke 测试证明。
+
+## Performance
+
+310P 上建议从小 capture sizes 开始，例如 Qwen-1.5B `[1,2,4]`、Llama-8B `[1,2]`、Qwen-32B TP4 `[1]`。如果遇到 stream resource exhaustion、capture begin 失败或 OOM：
+
+- 保持 `FULL_DECODE_ONLY`
+- 减小 `cudagraph_capture_sizes`
+- 降低 `max-model-len` 或 `max-num-seqs`
+- 使用 `--enforce-eager` 只做问题隔离
+
+吞吐测试可使用：
+
+```bash
+if [ -z "${QWEN_MODEL_PATH:-}" ]; then
+  QWEN_MODEL_PATH=$(CACHE_DIR="${MODELSCOPE_CACHE}" uv run python - <<'PY'
+import os
+from modelscope import snapshot_download
+
+print(snapshot_download(
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+    cache_dir=os.environ["CACHE_DIR"],
+))
+PY
+)
+fi
+export QWEN_MODEL_PATH
+export BENCH_RESULT_DIR=${BENCH_RESULT_DIR:-/tmp/deepseek_r1_distill_bench}
+
+vllm bench serve \
+  --model "${QWEN_MODEL_PATH}" \
+  --served-model-name deepseek-r1-distill-qwen-1.5b \
+  --dataset-name random \
+  --random-input 200 \
+  --num-prompts 200 \
+  --request-rate 1 \
+  --save-result \
+  --result-dir "${BENCH_RESULT_DIR}"
+```

--- a/docs/source/user_guide/support_matrix/supported_models.md
+++ b/docs/source/user_guide/support_matrix/supported_models.md
@@ -40,7 +40,7 @@ Get the latest info here: <https://github.com/vllm-project/vllm-ascend/issues/16
 
 | Model                         | Support   | Note                                                                 | Supported Hardware |
 |-------------------------------|-----------|----------------------------------------------------------------------|--------------------|
-| DeepSeek Distill (Qwen/Llama) | ✅        |                                                                      | A2/A3 |
+| DeepSeek Distill (Qwen/Llama) | ✅        | Verified ACLGRAPH coverage for Qwen-1.5B TP1, Llama-8B TP1, and Qwen-32B TP4 on 310P; Llama-70B remains unverified. [Tutorial](../../tutorials/models/DeepSeek-R1-Distill.md) | A2/A3/310P |
 | Qwen3-based                   | ✅        |                                                                      | A2/A3 |
 | Qwen2                         | ✅        |                                                                      | A2/A3 |
 | Qwen2.5                       | ✅        |                                                                      | A2/A3 |

--- a/tests/e2e/models/configs/DeepSeek-R1-Distill-Llama-8B.yaml
+++ b/tests/e2e/models/configs/DeepSeek-R1-Distill-Llama-8B.yaml
@@ -1,0 +1,25 @@
+model_name: "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+model_type: "vllm"
+hardware: "Atlas 300I DUO (310P), Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 1
+  dtype: float16
+  max_model_len: 4096
+  gpu_memory_utilization: 0.80
+  enforce_eager: true
+  trust_remote_code: false
+
+tasks:
+  - name: "gsm8k"
+    metrics:
+      - name: "exact_match,strict-match"
+        value: 0.0
+      - name: "exact_match,flexible-extract"
+        value: 0.1875
+
+num_fewshot: 5
+limit: 32
+apply_chat_template: true
+fewshot_as_multiturn: true
+batch_size: "auto"

--- a/tests/e2e/models/configs/DeepSeek-R1-Distill-Qwen-1.5B.yaml
+++ b/tests/e2e/models/configs/DeepSeek-R1-Distill-Qwen-1.5B.yaml
@@ -1,0 +1,25 @@
+model_name: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+model_type: "vllm"
+hardware: "Atlas 300I DUO (310P), Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 1
+  dtype: float16
+  max_model_len: 4096
+  gpu_memory_utilization: 0.70
+  enforce_eager: true
+  trust_remote_code: false
+
+tasks:
+  - name: "gsm8k"
+    metrics:
+      - name: "exact_match,strict-match"
+        value: 0.0
+      - name: "exact_match,flexible-extract"
+        value: 0.0
+
+num_fewshot: 5
+limit: 32
+apply_chat_template: true
+fewshot_as_multiturn: true
+batch_size: "auto"

--- a/tests/e2e/models/configs/DeepSeek-R1-Distill-Qwen-32B.yaml
+++ b/tests/e2e/models/configs/DeepSeek-R1-Distill-Qwen-32B.yaml
@@ -1,0 +1,25 @@
+model_name: "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B"
+model_type: "vllm"
+hardware: "Atlas 300I DUO (310P), Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 4
+  dtype: float16
+  max_model_len: 2048
+  gpu_memory_utilization: 0.60
+  enforce_eager: true
+  trust_remote_code: false
+
+tasks:
+  - name: "gsm8k"
+    metrics:
+      - name: "exact_match,strict-match"
+        value: 0.0
+      - name: "exact_match,flexible-extract"
+        value: 0.125
+
+num_fewshot: 5
+limit: 32
+apply_chat_template: true
+fewshot_as_multiturn: true
+batch_size: "auto"

--- a/tests/e2e/models/configs/accuracy.txt
+++ b/tests/e2e/models/configs/accuracy.txt
@@ -11,4 +11,7 @@ internlm3-8b-instruct.yaml
 Molmo-7B-D-0924.yaml
 llava-onevision-qwen2-0.5b-ov-hf.yaml
 Llama-3.2-3B-Instruct.yaml
+DeepSeek-R1-Distill-Qwen-1.5B.yaml
+DeepSeek-R1-Distill-Llama-8B.yaml
+DeepSeek-R1-Distill-Qwen-32B.yaml
 Qwen3-ASR-1.7B.yaml

--- a/tests/e2e/pull_request/four_card/_310p/test_deepseek_r1_distill_qwen32b_aclgraph_310p.py
+++ b/tests/e2e/pull_request/four_card/_310p/test_deepseek_r1_distill_qwen32b_aclgraph_310p.py
@@ -1,0 +1,68 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+import os
+from pathlib import Path
+
+from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+
+_DEFAULT_CACHE_ROOT = Path(os.getenv("CACHE_ROOT", "/data/.cache"))
+_DEFAULT_MODELSCOPE_CACHE = Path(os.getenv("MODELSCOPE_CACHE", str(_DEFAULT_CACHE_ROOT / "modelscope")))
+_QWEN32B_MODEL_ORG = "deepseek-ai"
+_QWEN32B_MODEL_NAME = "DeepSeek-R1-Distill-Qwen-32B"
+_QWEN32B_MODEL_PATH_CANDIDATES = (
+    _DEFAULT_MODELSCOPE_CACHE / _QWEN32B_MODEL_ORG / _QWEN32B_MODEL_NAME,
+    _DEFAULT_MODELSCOPE_CACHE / "hub" / "models" / _QWEN32B_MODEL_ORG / _QWEN32B_MODEL_NAME,
+    _DEFAULT_MODELSCOPE_CACHE / "models" / _QWEN32B_MODEL_ORG / _QWEN32B_MODEL_NAME,
+)
+
+
+def _qwen32b_model_path() -> str:
+    if env_model_path := os.getenv("QWEN32B_MODEL_PATH"):
+        return env_model_path
+    for candidate_path in _QWEN32B_MODEL_PATH_CANDIDATES:
+        if candidate_path.exists():
+            return str(candidate_path)
+    return str(_QWEN32B_MODEL_PATH_CANDIDATES[0])
+
+
+@wait_until_npu_memory_free(0.7)
+def test_deepseek_r1_distill_qwen32b_tp4_full_decode_only_aclgraph_310p(monkeypatch):
+    monkeypatch.setenv("HCCL_OP_EXPANSION_MODE", "AIV")
+    monkeypatch.setenv("HCCL_BUFFSIZE", os.getenv("HCCL_BUFFSIZE", "1024"))
+    prompts = ["Reply with one short sentence about tensor parallelism."]
+
+    with VllmRunner(
+        _qwen32b_model_path(),
+        tensor_parallel_size=4,
+        distributed_executor_backend="mp",
+        dtype="float16",
+        max_model_len=2048,
+        max_num_seqs=1,
+        max_num_batched_tokens=2048,
+        gpu_memory_utilization=0.60,
+        additional_config={"ascend_compilation_config": {"fuse_norm_quant": False}},
+        compilation_config={
+            "cudagraph_mode": "FULL_DECODE_ONLY",
+            "cudagraph_capture_sizes": [1],
+        },
+    ) as vllm_model:
+        outputs = vllm_model.generate_greedy(prompts, max_tokens=4)
+
+    assert len(outputs) == 1
+    assert len(outputs[0][1]) > 0

--- a/tests/e2e/pull_request/one_card/_310p/test_deepseek_r1_distill_aclgraph_310p.py
+++ b/tests/e2e/pull_request/one_card/_310p/test_deepseek_r1_distill_aclgraph_310p.py
@@ -1,0 +1,117 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+
+_DEFAULT_CACHE_ROOT = Path(os.getenv("CACHE_ROOT", "/data/.cache"))
+_DEFAULT_MODELSCOPE_CACHE = Path(os.getenv("MODELSCOPE_CACHE", str(_DEFAULT_CACHE_ROOT / "modelscope")))
+_DEEPSEEK_MODEL_ORG = "deepseek-ai"
+
+
+def _modelscope_model_path(model_name: str, env_name: str, aliases: tuple[str, ...] = ()) -> str:
+    if env_model_path := os.getenv(env_name):
+        return env_model_path
+
+    candidate_names = (model_name, *aliases)
+    model_path_candidates = [
+        _DEFAULT_MODELSCOPE_CACHE / _DEEPSEEK_MODEL_ORG / candidate_name for candidate_name in candidate_names
+    ]
+    model_path_candidates += [
+        _DEFAULT_MODELSCOPE_CACHE / "hub" / "models" / _DEEPSEEK_MODEL_ORG / candidate_name
+        for candidate_name in candidate_names
+    ]
+    model_path_candidates += [
+        _DEFAULT_MODELSCOPE_CACHE / "models" / _DEEPSEEK_MODEL_ORG / candidate_name
+        for candidate_name in candidate_names
+    ]
+
+    for candidate_path in model_path_candidates:
+        if candidate_path.exists():
+            return str(candidate_path)
+    return f"{_DEEPSEEK_MODEL_ORG}/{model_name}"
+
+
+DISTILL_GRAPH_CASES = [
+    pytest.param(
+        "DeepSeek-R1-Distill-Qwen-1.5B",
+        "QWEN15B_MODEL_PATH",
+        ("DeepSeek-R1-Distill-Qwen-1___5B",),
+        4,
+        [1, 2, 4],
+        0.70,
+        id="qwen-1.5b",
+    ),
+    pytest.param(
+        "DeepSeek-R1-Distill-Llama-8B",
+        "LLAMA8B_MODEL_PATH",
+        (),
+        2,
+        [1, 2],
+        0.80,
+        id="llama-8b",
+    ),
+]
+
+PROMPTS = [
+    "Reply with one short sentence about graph mode.",
+    "Give one concise reason to test real model weights.",
+    "Name the backend family used by this dense model.",
+    "Summarize why startup-only checks are insufficient.",
+]
+
+
+@wait_until_npu_memory_free(0.7)
+@pytest.mark.parametrize(
+    ("model_name", "model_path_env", "model_path_aliases", "max_num_seqs", "capture_sizes", "gpu_memory_utilization"),
+    DISTILL_GRAPH_CASES,
+)
+def test_deepseek_r1_distill_full_decode_only_aclgraph_310p(
+    model_name: str,
+    model_path_env: str,
+    model_path_aliases: tuple[str, ...],
+    max_num_seqs: int,
+    capture_sizes: list[int],
+    gpu_memory_utilization: float,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("HCCL_OP_EXPANSION_MODE", "AIV")
+    prompts = PROMPTS[:max_num_seqs]
+
+    with VllmRunner(
+        _modelscope_model_path(model_name, model_path_env, model_path_aliases),
+        dtype="float16",
+        max_model_len=4096,
+        max_num_seqs=max_num_seqs,
+        max_num_batched_tokens=4096,
+        gpu_memory_utilization=gpu_memory_utilization,
+        additional_config={"ascend_compilation_config": {"fuse_norm_quant": False}},
+        compilation_config={
+            "cudagraph_mode": "FULL_DECODE_ONLY",
+            "cudagraph_capture_sizes": capture_sizes,
+        },
+    ) as vllm_model:
+        outputs = vllm_model.generate_greedy(prompts, max_tokens=8)
+
+    assert len(outputs) == len(prompts)
+    for _, output_text in outputs:
+        assert len(output_text) > 0


### PR DESCRIPTION
Add DeepSeek-R1-Distill Qwen and Llama accuracy configs, 310P ACLGRAPH smoke coverage, Qwen-32B TP4 ACLGRAPH coverage, and the measured Qwen-32B gsm8k accuracy baseline.

Update the supported model list, model tutorial, and SKILL.md adaptation notes. Accuracy baselines remain separate from ACLGRAPH smoke evidence.

Refs: #10668, #9079

  ## What this PR does / why we need it?

  Adapt DeepSeek-R1-Distill Qwen/Llama representative models for ACLGRAPH validation on Ascend 310P.

  This PR adds:
  - Accuracy configs for Qwen-1.5B, Llama-8B, and Qwen-32B
  - 310P ACLGRAPH E2E smoke coverage
  - Qwen-32B TP4 ACLGRAPH coverage
  - Supported model matrix update
  - DeepSeek-R1-Distill deployment tutorial
  - SKILL.md adaptation notes

  Related issue: #9079
  Task: #10668

  ## Does this PR introduce any user-facing change?

  Yes. It adds documentation for deploying and validating DeepSeek-R1-Distill models with ACLGRAPH.

  ## How was this patch tested?

  - Added model configs under `tests/e2e/models/configs`
  - Added 310P ACLGRAPH E2E tests
  - Documented measured gsm8k baselines in the config files
  - Real-weight validation evidence is recorded in `SKILL.md`

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
