### PR TITLE
[BugFix][310P] Fixed 310P RC aclgraph inference error

### DIFF
--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -441,6 +441,41 @@ def test_is_pd_decode_recompute_scheduler_enabled_decode_consumer():
         assert utils.is_pd_decode_recompute_scheduler_enabled(vllm_config) is True
 
 
+def test_is_rc_device_returns_false_on_non_310p():
+    utils._IS_RC_DEVICE = None
+    with mock.patch("vllm_ascend.utils.is_310p", return_value=False):
+        assert utils.is_rc_device() is False
+
+
+def test_is_rc_device_detects_ep_from_lspci():
+    utils._IS_RC_DEVICE = None
+    with (
+        mock.patch("vllm_ascend.utils.is_310p", return_value=True),
+        mock.patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value.stdout = "00:00.0 accelerators: Huawei Technologies Co., Ltd."
+        assert utils.is_rc_device() is False
+
+
+def test_is_rc_device_detects_rc_from_lspci():
+    utils._IS_RC_DEVICE = None
+    with (
+        mock.patch("vllm_ascend.utils.is_310p", return_value=True),
+        mock.patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value.stdout = "00:00.0 PCI bridge: Huawei Technologies Co., Ltd."
+        assert utils.is_rc_device() is True
+
+
+def test_is_rc_device_defaults_to_ep_when_lspci_unavailable():
+    utils._IS_RC_DEVICE = None
+    with (
+        mock.patch("vllm_ascend.utils.is_310p", return_value=True),
+        mock.patch("subprocess.run", side_effect=FileNotFoundError),
+    ):
+        assert utils.is_rc_device() is False
+
+
 def test_is_pd_decode_recompute_scheduler_enabled_decode_consumer_disabled():
     vllm_config = mock.MagicMock()
     vllm_config.kv_transfer_config = mock.MagicMock()

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -406,7 +406,6 @@ class NPUModelRunner310(NPUModelRunner):
         prev_req_id_to_index = self.input_batch.prev_req_id_to_index
         self._compute_prev_positions(num_reqs)
 
-
         self._prepare_input_ids(scheduler_output, num_reqs, total_num_scheduled_tokens, cu_num_tokens)
         if self.uses_mrope:
             self._calc_mrope_positions(scheduler_output)
@@ -454,7 +453,7 @@ class NPUModelRunner310(NPUModelRunner):
                 self.num_accepted_tokens.np[:num_reqs] = self.input_batch.num_accepted_tokens_cpu[:num_reqs]
             self.num_accepted_tokens.np[num_reqs:].fill(1)
             self.num_accepted_tokens.copy_to_gpu()
-        else: 
+        else:
             self.num_accepted_tokens.np[num_reqs:].fill(1)
             self.num_accepted_tokens.copy_to_gpu()
 
@@ -494,12 +493,16 @@ class NPUModelRunner310(NPUModelRunner):
         )
         if need_async_num_computed_update:
             self.seq_lens[:num_reqs] = self.num_computed_tokens[:num_reqs] + num_scheduled_tokens_gpu
+            tail_len = self.seq_lens.shape[0] - num_reqs
+            if tail_len > 0:
+                self.seq_lens[num_reqs:].copy_(
+                    self.optimistic_seq_lens_cpu[num_reqs:].to(self.device, non_blocking=True),
+                )
         else:
-            self.seq_lens[:num_reqs].copy_(
-                self.optimistic_seq_lens_cpu[:num_reqs],
+            self.seq_lens.copy_(
+                self.optimistic_seq_lens_cpu[: self.seq_lens.shape[0]],
                 non_blocking=True,
             )
-        self.seq_lens[num_reqs:].fill_(0)
 
         if (
             self._needs_seq_lens_cpu_sync

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -52,7 +52,7 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.spec_decode.utils import (
     update_num_computed_tokens_for_batch_change,
 )
-from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, lmhead_tp_enable
+from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, is_rc_device, lmhead_tp_enable
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
 _NGRAM_GRAPH_UNIFORM_DECODE_QUERY_LEN = 1
@@ -387,7 +387,8 @@ class NPUModelRunner310(NPUModelRunner):
 
         self.query_start_loc.np[0] = 0
         self.query_start_loc.np[1 : num_reqs + 1] = cu_num_tokens
-        self.query_start_loc.np[num_reqs + 1 :].fill(-1)
+        if is_rc_device():
+            self.query_start_loc.np[num_reqs + 1 :].fill(-1)
         self.query_start_loc.copy_to_gpu()
 
         if self._has_gdn:
@@ -405,6 +406,9 @@ class NPUModelRunner310(NPUModelRunner):
 
         prev_req_id_to_index = self.input_batch.prev_req_id_to_index
         self._compute_prev_positions(num_reqs)
+
+        if not is_rc_device():
+            self.query_start_loc.gpu[num_reqs + 1 :].fill_(-1)
 
         self._prepare_input_ids(scheduler_output, num_reqs, total_num_scheduled_tokens, cu_num_tokens)
         if self.uses_mrope:
@@ -454,8 +458,12 @@ class NPUModelRunner310(NPUModelRunner):
             self.num_accepted_tokens.np[num_reqs:].fill(1)
             self.num_accepted_tokens.copy_to_gpu()
         else:
-            self.num_accepted_tokens.np[num_reqs:].fill(1)
-            self.num_accepted_tokens.copy_to_gpu()
+            if is_rc_device():
+                self.num_accepted_tokens.np[num_reqs:].fill(1)
+                self.num_accepted_tokens.copy_to_gpu()
+            else:
+                self.num_accepted_tokens.np.fill(1)
+                self.num_accepted_tokens.gpu.fill_(1)
 
         need_async_num_computed_update = (
             self.use_async_spec_decode and self.valid_sampled_token_count_gpu is not None and prev_req_id_to_index
@@ -493,16 +501,25 @@ class NPUModelRunner310(NPUModelRunner):
         )
         if need_async_num_computed_update:
             self.seq_lens[:num_reqs] = self.num_computed_tokens[:num_reqs] + num_scheduled_tokens_gpu
-            tail_len = self.seq_lens.shape[0] - num_reqs
-            if tail_len > 0:
-                self.seq_lens[num_reqs:].copy_(
-                    self.optimistic_seq_lens_cpu[num_reqs:].to(self.device, non_blocking=True),
-                )
+            if is_rc_device():
+                tail_len = self.seq_lens.shape[0] - num_reqs
+                if tail_len > 0:
+                    self.seq_lens[num_reqs:].copy_(
+                        self.optimistic_seq_lens_cpu[num_reqs:].to(self.device, non_blocking=True),
+                    )
         else:
-            self.seq_lens.copy_(
-                self.optimistic_seq_lens_cpu[: self.seq_lens.shape[0]],
-                non_blocking=True,
-            )
+            if is_rc_device():
+                self.seq_lens.copy_(
+                    self.optimistic_seq_lens_cpu[: self.seq_lens.shape[0]],
+                    non_blocking=True,
+                )
+            else:
+                self.seq_lens[:num_reqs].copy_(
+                    self.optimistic_seq_lens_cpu[:num_reqs],
+                    non_blocking=True,
+                )
+        if not is_rc_device():
+            self.seq_lens[num_reqs:].fill_(0)
 
         if (
             self._needs_seq_lens_cpu_sync

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -387,6 +387,7 @@ class NPUModelRunner310(NPUModelRunner):
 
         self.query_start_loc.np[0] = 0
         self.query_start_loc.np[1 : num_reqs + 1] = cu_num_tokens
+        self.query_start_loc.np[num_reqs + 1 :].fill(-1)
         self.query_start_loc.copy_to_gpu()
 
         if self._has_gdn:
@@ -405,7 +406,6 @@ class NPUModelRunner310(NPUModelRunner):
         prev_req_id_to_index = self.input_batch.prev_req_id_to_index
         self._compute_prev_positions(num_reqs)
 
-        self.query_start_loc.gpu[num_reqs + 1 :].fill_(-1)
 
         self._prepare_input_ids(scheduler_output, num_reqs, total_num_scheduled_tokens, cu_num_tokens)
         if self.uses_mrope:
@@ -454,9 +454,9 @@ class NPUModelRunner310(NPUModelRunner):
                 self.num_accepted_tokens.np[:num_reqs] = self.input_batch.num_accepted_tokens_cpu[:num_reqs]
             self.num_accepted_tokens.np[num_reqs:].fill(1)
             self.num_accepted_tokens.copy_to_gpu()
-        else:
-            self.num_accepted_tokens.np.fill(1)
-            self.num_accepted_tokens.gpu.fill_(1)
+        else: 
+            self.num_accepted_tokens.np[num_reqs:].fill(1)
+            self.num_accepted_tokens.copy_to_gpu()
 
         need_async_num_computed_update = (
             self.use_async_spec_decode and self.valid_sampled_token_count_gpu is not None and prev_req_id_to_index

--- a/vllm_ascend/_310p/ops/fla/chunk_gated_delta_rule.py
+++ b/vllm_ascend/_310p/ops/fla/chunk_gated_delta_rule.py
@@ -344,7 +344,15 @@ def _compute_kernel_inputs_from_torch_wy(
 
     lower_decay = (g.unsqueeze(-1) - g.unsqueeze(-2)).tril().exp().float().tril()
     k_beta = key * beta.unsqueeze(-1)
-    attn = -(k_beta @ key.transpose(-1, -2) * lower_decay)
+    attn_chunks: list[torch.Tensor] = []
+    for c in range(num_chunks):
+        k_beta_c = k_beta[:, :, c]  # [B, Hv, S, D]
+        key_c = key[:, :, c]  # [B, Hv, S, D]
+        key_c_t = key_c.transpose(-1, -2).contiguous()  # [B, Hv, D, S]
+        lower_decay_c = lower_decay[:, :, c]  # [B, Hv, S, S]
+        attn_c = -(k_beta_c @ key_c_t * lower_decay_c)
+        attn_chunks.append(attn_c)
+    attn = torch.stack(attn_chunks, dim=2)  # [B, Hv, C, S, S]ni
     mask_diag = torch.triu(
         torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=k.device),
         diagonal=0,

--- a/vllm_ascend/_310p/ops/fla/chunk_gated_delta_rule.py
+++ b/vllm_ascend/_310p/ops/fla/chunk_gated_delta_rule.py
@@ -21,6 +21,7 @@ import torch
 import torch.nn.functional as F
 
 from vllm_ascend._310p.ops.fla.l2norm import l2norm_310p
+from vllm_ascend.utils import is_rc_device
 
 CHUNK_SIZE = 64
 
@@ -344,15 +345,18 @@ def _compute_kernel_inputs_from_torch_wy(
 
     lower_decay = (g.unsqueeze(-1) - g.unsqueeze(-2)).tril().exp().float().tril()
     k_beta = key * beta.unsqueeze(-1)
-    attn_chunks: list[torch.Tensor] = []
-    for c in range(num_chunks):
-        k_beta_c = k_beta[:, :, c]  # [B, Hv, S, D]
-        key_c = key[:, :, c]  # [B, Hv, S, D]
-        key_c_t = key_c.transpose(-1, -2).contiguous()  # [B, Hv, D, S]
-        lower_decay_c = lower_decay[:, :, c]  # [B, Hv, S, S]
-        attn_c = -(k_beta_c @ key_c_t * lower_decay_c)
-        attn_chunks.append(attn_c)
-    attn = torch.stack(attn_chunks, dim=2)  # [B, Hv, C, S, S]ni
+    if is_rc_device():
+        attn_chunks: list[torch.Tensor] = []
+        for c in range(num_chunks):
+            k_beta_c = k_beta[:, :, c]  # [B, Hv, S, D]
+            key_c = key[:, :, c]  # [B, Hv, S, D]
+            key_c_t = key_c.transpose(-1, -2).contiguous()  # [B, Hv, D, S]
+            lower_decay_c = lower_decay[:, :, c]  # [B, Hv, S, S]
+            attn_c = -(k_beta_c @ key_c_t * lower_decay_c)
+            attn_chunks.append(attn_c)
+        attn = torch.stack(attn_chunks, dim=2)  # [B, Hv, C, S, S]
+    else:
+        attn = -(k_beta @ key.transpose(-1, -2) * lower_decay)
     mask_diag = torch.triu(
         torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=k.device),
         diagonal=0,

--- a/vllm_ascend/_310p/ops/fla/cumpute_causal_conv1d_metadata_310.py
+++ b/vllm_ascend/_310p/ops/fla/cumpute_causal_conv1d_metadata_310.py
@@ -23,7 +23,7 @@ def compute_causal_conv1d_metadata(
         nums_dict[BLOCK_M]["tot"] = nums.sum().item()
         mlist = torch.from_numpy(np.repeat(np.arange(len(nums)), nums.numpy()))
         nums_dict[BLOCK_M]["mlist"] = mlist
-        mlist_len = len(nums_dict[BLOCK_M]["mlist"])
+        mlist_len = len(mlist)
         nums_dict[BLOCK_M]["mlist_len"] = mlist_len
         MAX_NUM_PROGRAMS = max(1024, mlist_len) * 2
 

--- a/vllm_ascend/_310p/ops/fla/cumpute_causal_conv1d_metadata_310.py
+++ b/vllm_ascend/_310p/ops/fla/cumpute_causal_conv1d_metadata_310.py
@@ -1,0 +1,62 @@
+import torch
+import numpy as np
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+
+def compute_causal_conv1d_metadata(
+    query_start_loc_p_cpu: torch.Tensor,
+    *,
+    device: torch.device,
+):
+    assert query_start_loc_p_cpu.device.type == "cpu"
+    seqlens = query_start_loc_p_cpu.diff()
+    nums_dict = {}
+    batch_ptr = None
+    token_chunk_offset_ptr = None
+    batch_ptr_cpu = None
+    token_chunk_offset_ptr_cpu = None
+
+    for BLOCK_M in [8]:
+        nums = -(-seqlens // BLOCK_M)
+        nums_dict[BLOCK_M] = {}
+        nums_dict[BLOCK_M]["nums"] = nums
+        nums_dict[BLOCK_M]["tot"] = nums.sum().item()
+        mlist = torch.from_numpy(np.repeat(np.arange(len(nums)), nums.numpy()))
+        nums_dict[BLOCK_M]["mlist"] = mlist
+        mlist_len = len(nums_dict[BLOCK_M]["mlist"])
+        nums_dict[BLOCK_M]["mlist_len"] = mlist_len
+        MAX_NUM_PROGRAMS = max(1024, mlist_len) * 2
+
+        offsetlist = []
+        for idx, num in enumerate(nums):
+            offsetlist.extend(range(num))
+        offsetlist = torch.tensor(offsetlist, dtype=torch.int32)
+        
+        if batch_ptr is None or batch_ptr.numel() < MAX_NUM_PROGRAMS:
+            batch_ptr_cpu = torch.full(
+                (MAX_NUM_PROGRAMS,), PAD_SLOT_ID, dtype=torch.int32
+            )
+            token_chunk_offset_ptr_cpu = torch.full(
+                (MAX_NUM_PROGRAMS,), PAD_SLOT_ID, dtype=torch.int32
+            )
+            if device.type == "cpu":
+                batch_ptr = batch_ptr_cpu
+                token_chunk_offset_ptr = token_chunk_offset_ptr_cpu
+            else:
+                batch_ptr = batch_ptr_cpu.to(device, non_blocking=False)
+                token_chunk_offset_ptr = token_chunk_offset_ptr_cpu.to(
+                    device, non_blocking=False
+                )
+        else:
+            batch_ptr_cpu.fill_(PAD_SLOT_ID)
+            token_chunk_offset_ptr_cpu.fill_(PAD_SLOT_ID)
+
+        batch_ptr_cpu[:mlist_len].copy_(mlist.to(torch.int32))
+        token_chunk_offset_ptr_cpu[:mlist_len].copy_(offsetlist)
+        if device.type != "cpu":
+            batch_ptr.copy_(batch_ptr_cpu, non_blocking=True)
+            token_chunk_offset_ptr.copy_(token_chunk_offset_ptr_cpu, non_blocking=True)
+
+        nums_dict[BLOCK_M]["batch_ptr"] = batch_ptr
+        nums_dict[BLOCK_M]["token_chunk_offset_ptr"] = token_chunk_offset_ptr
+
+    return nums_dict, batch_ptr, token_chunk_offset_ptr

--- a/vllm_ascend/_310p/ops/fla/cumpute_causal_conv1d_metadata_310.py
+++ b/vllm_ascend/_310p/ops/fla/cumpute_causal_conv1d_metadata_310.py
@@ -10,7 +10,7 @@ def compute_causal_conv1d_metadata(
 ):
     assert query_start_loc_p_cpu.device.type == "cpu"
     seqlens = query_start_loc_p_cpu.diff()
-    nums_dict = {}
+    nums_dict: dict[int, dict[str, object]] = {}
     batch_ptr = None
     token_chunk_offset_ptr = None
     batch_ptr_cpu = None
@@ -27,10 +27,10 @@ def compute_causal_conv1d_metadata(
         nums_dict[BLOCK_M]["mlist_len"] = mlist_len
         MAX_NUM_PROGRAMS = max(1024, mlist_len) * 2
 
-        offsetlist = []
+        offset_items: list[int] = []
         for idx, num in enumerate(nums):
-            offsetlist.extend(range(num))
-        offsetlist = torch.tensor(offsetlist, dtype=torch.int32)
+            offset_items.extend(range(num))
+        offsetlist = torch.tensor(offset_items, dtype=torch.int32)
 
         if batch_ptr is None or batch_ptr.numel() < MAX_NUM_PROGRAMS:
             batch_ptr_cpu = torch.full((MAX_NUM_PROGRAMS,), PAD_SLOT_ID, dtype=torch.int32)

--- a/vllm_ascend/_310p/ops/fla/cumpute_causal_conv1d_metadata_310.py
+++ b/vllm_ascend/_310p/ops/fla/cumpute_causal_conv1d_metadata_310.py
@@ -1,6 +1,7 @@
-import torch
 import numpy as np
+import torch
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+
 
 def compute_causal_conv1d_metadata(
     query_start_loc_p_cpu: torch.Tensor,
@@ -30,22 +31,16 @@ def compute_causal_conv1d_metadata(
         for idx, num in enumerate(nums):
             offsetlist.extend(range(num))
         offsetlist = torch.tensor(offsetlist, dtype=torch.int32)
-        
+
         if batch_ptr is None or batch_ptr.numel() < MAX_NUM_PROGRAMS:
-            batch_ptr_cpu = torch.full(
-                (MAX_NUM_PROGRAMS,), PAD_SLOT_ID, dtype=torch.int32
-            )
-            token_chunk_offset_ptr_cpu = torch.full(
-                (MAX_NUM_PROGRAMS,), PAD_SLOT_ID, dtype=torch.int32
-            )
+            batch_ptr_cpu = torch.full((MAX_NUM_PROGRAMS,), PAD_SLOT_ID, dtype=torch.int32)
+            token_chunk_offset_ptr_cpu = torch.full((MAX_NUM_PROGRAMS,), PAD_SLOT_ID, dtype=torch.int32)
             if device.type == "cpu":
                 batch_ptr = batch_ptr_cpu
                 token_chunk_offset_ptr = token_chunk_offset_ptr_cpu
             else:
                 batch_ptr = batch_ptr_cpu.to(device, non_blocking=False)
-                token_chunk_offset_ptr = token_chunk_offset_ptr_cpu.to(
-                    device, non_blocking=False
-                )
+                token_chunk_offset_ptr = token_chunk_offset_ptr_cpu.to(device, non_blocking=False)
         else:
             batch_ptr_cpu.fill_(PAD_SLOT_ID)
             token_chunk_offset_ptr_cpu.fill_(PAD_SLOT_ID)

--- a/vllm_ascend/_310p/ops/gdn_attn_builder_310.py
+++ b/vllm_ascend/_310p/ops/gdn_attn_builder_310.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""310P GDN metadata builder: upstream build() with RC-safe prefill metadata."""
+"""310P GDN metadata builder: vLLM GDNAttentionMetadataBuilder.build with RC-safe prefill."""
 
 from __future__ import annotations
 
 import torch
 import vllm.v1.attention.backends.utils as attn_backend_utils
-from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.gdn_attn import (
     GDNAttentionMetadata,
@@ -29,12 +28,6 @@ from vllm.v1.attention.backends.utils import (
     mamba_get_block_table_tensor,
     split_decodes_and_prefills,
 )
-
-
-def _stable_argsort_for_npu(tensor: torch.Tensor) -> torch.Tensor:
-    if tensor.dtype == torch.bool:
-        tensor = tensor.to(torch.int32)
-    return torch.argsort(tensor, stable=True)
 
 
 class GDNAttentionMetadataBuilder310(GDNAttentionMetadataBuilder):
@@ -74,15 +67,11 @@ class GDNAttentionMetadataBuilder310(GDNAttentionMetadataBuilder):
                 spec_sequence_masks = None
                 spec_sequence_masks_cpu = None
             else:
-                spec_sequence_masks = async_tensor_h2d(
-                    spec_sequence_masks_cpu,
-                    device=query_start_loc.device,
-                )
+                spec_sequence_masks = spec_sequence_masks_cpu.to(query_start_loc.device, non_blocking=True)
 
         if spec_sequence_masks is None:
             num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = split_decodes_and_prefills(
-                m,
-                decode_threshold=1,
+                m, decode_threshold=1
             )
             num_spec_decode_tokens = 0
             spec_token_indx = None
@@ -98,14 +87,20 @@ class GDNAttentionMetadataBuilder310(GDNAttentionMetadataBuilder):
             assert spec_sequence_masks_cpu is not None
             query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
 
+            # Use CPU tensors to avoid CPU-GPU sync
             non_spec_query_lens_cpu = query_lens_cpu[~spec_sequence_masks_cpu]
             num_decodes = (non_spec_query_lens_cpu == 1).sum().item()
+            # Exclude zero-length padded sequences from prefill count.
             num_zero_len = (non_spec_query_lens_cpu == 0).sum().item()
             num_prefills = non_spec_query_lens_cpu.size(0) - num_decodes - num_zero_len
             num_decode_tokens = num_decodes
             num_prefill_tokens = non_spec_query_lens_cpu.sum().item() - num_decode_tokens
             num_spec_decode_tokens = query_lens_cpu.sum().item() - num_prefill_tokens - num_decode_tokens
 
+            # num_decodes and num_spec_decodes are mutually exclusive.
+            # Reclassify non-spec decodes as prefills when spec decodes
+            # exist — the prefill kernel handles 1-token sequences with
+            # initial state correctly, producing identical results.
             if num_decodes > 0 and num_spec_decodes > 0:
                 num_prefills += num_decodes
                 num_prefill_tokens += num_decode_tokens
@@ -122,16 +117,13 @@ class GDNAttentionMetadataBuilder310(GDNAttentionMetadataBuilder):
                     dtype=torch.int32,
                     device=query_start_loc.device,
                 )
-                non_spec_token_indx = torch.empty(
-                    0,
-                    dtype=torch.int32,
-                    device=query_start_loc.device,
-                )
-                spec_state_indices_tensor = block_table_tensor[
-                    spec_sequence_masks_cpu,
-                    : self.num_spec + 1,
-                ]
+                non_spec_token_indx = torch.empty(0, dtype=torch.int32, device=query_start_loc.device)
+                # Filter by spec_sequence_masks to exclude padded sequences
+                spec_state_indices_tensor = block_table_tensor[spec_sequence_masks_cpu, : self.num_spec + 1]
                 non_spec_state_indices_tensor = None
+                # Padded sequences are always at the back, so the first
+                # num_spec_decodes + 1 entries of query_start_loc already
+                # contain the correct cumulative token counts.
                 spec_query_start_loc = query_start_loc[: num_spec_decodes + 1]
                 non_spec_query_start_loc = None
                 non_spec_query_start_loc_cpu = None
@@ -141,19 +133,13 @@ class GDNAttentionMetadataBuilder310(GDNAttentionMetadataBuilder):
                     query_lens,
                     output_size=query_start_loc_cpu[-1].item(),
                 )
-                index = _stable_argsort_for_npu(spec_token_masks)
+                index = torch.argsort(spec_token_masks, stable=True)
                 num_non_spec_tokens = num_prefill_tokens + num_decode_tokens
                 non_spec_token_indx = index[:num_non_spec_tokens]
                 spec_token_indx = index[num_non_spec_tokens:]
 
-                spec_state_indices_tensor = block_table_tensor[
-                    spec_sequence_masks_cpu,
-                    : self.num_spec + 1,
-                ]
-                non_spec_state_indices_tensor = block_table_tensor[
-                    ~spec_sequence_masks_cpu,
-                    0,
-                ]
+                spec_state_indices_tensor = block_table_tensor[spec_sequence_masks_cpu, : self.num_spec + 1]
+                non_spec_state_indices_tensor = block_table_tensor[~spec_sequence_masks_cpu, 0]
 
                 spec_query_start_loc = torch.zeros(
                     num_spec_decodes + 1,
@@ -196,6 +182,10 @@ class GDNAttentionMetadataBuilder310(GDNAttentionMetadataBuilder):
         if num_prefills > 0:
             from vllm.model_executor.layers.fla.ops.utils import FLA_CHUNK_SIZE
 
+            # In a mixed non-spec batch, decodes are peeled off to the recurrent
+            # kernel (decode-first front slice), so build chunk metadata from the
+            # rebased prefill-only cu_seqlens; otherwise use the full non-spec one.
+            # _forward_core keys off the same condition, so they agree.
             if spec_sequence_masks is None and num_decodes > 0:
                 assert non_spec_query_start_loc is not None
                 assert non_spec_query_start_loc_cpu is not None
@@ -223,23 +213,25 @@ class GDNAttentionMetadataBuilder310(GDNAttentionMetadataBuilder):
                 )
             else:
                 gpu_device = query_start_loc.device
+                # Only prefill batches use FLA chunk ops.
+                # Pre-compute on CPU and async-copy to GPU to avoid
+                # GPU→CPU sync (.tolist()) in prepare_chunk_indices.
                 from vllm.model_executor.layers.fla.ops.index import (
                     prepare_chunk_indices,
                     prepare_chunk_offsets,
                 )
 
                 assert prefill_query_start_loc_cpu is not None
-                chunk_indices = async_tensor_h2d(
-                    prepare_chunk_indices(prefill_query_start_loc_cpu, FLA_CHUNK_SIZE),
-                    device=gpu_device,
+                chunk_indices = prepare_chunk_indices(prefill_query_start_loc_cpu, FLA_CHUNK_SIZE).to(
+                    device=gpu_device, non_blocking=True
                 )
-                chunk_offsets = async_tensor_h2d(
-                    prepare_chunk_offsets(prefill_query_start_loc_cpu, FLA_CHUNK_SIZE),
-                    device=gpu_device,
+                chunk_offsets = prepare_chunk_offsets(prefill_query_start_loc_cpu, FLA_CHUNK_SIZE).to(
+                    device=gpu_device, non_blocking=True
                 )
 
         if num_prefills > 0:
             assert non_spec_query_start_loc_cpu is not None
+            # 310P RC: compute has_initial_state on CPU, single H2D upload.
             if m._seq_lens_cpu is not None:
                 context_lens_cpu = m._seq_lens_cpu
             elif m.seq_lens_cpu is not None:
@@ -266,11 +258,15 @@ class GDNAttentionMetadataBuilder310(GDNAttentionMetadataBuilder):
         else:
             has_initial_state = None
 
+        # Function code counted on either presency non-spec decode or spec decode,
+        # but not both.
         assert not (num_decodes > 0 and num_spec_decodes > 0), (
             f"num_decodes: {num_decodes}, num_spec_decodes: {num_spec_decodes}"
         )
 
-        batch_size = m.num_reqs
+        # Prepare tensors for cudagraph
+        # Note: m.num_actual_tokens is already padded by the model runner for CUDAGraph
+        batch_size = m.num_actual_tokens
 
         if (
             self.use_full_cuda_graph
@@ -280,45 +276,27 @@ class GDNAttentionMetadataBuilder310(GDNAttentionMetadataBuilder):
             and num_spec_decode_tokens <= self.decode_cudagraph_max_bs
         ):
             assert spec_sequence_masks is not None
-            self.spec_state_indices_tensor[:num_spec_decodes].copy_(
-                spec_state_indices_tensor,
-                non_blocking=True,
-            )
+            self.spec_state_indices_tensor[:num_spec_decodes].copy_(spec_state_indices_tensor, non_blocking=True)
             spec_state_indices_tensor = self.spec_state_indices_tensor[:batch_size]
             spec_state_indices_tensor[num_spec_decodes:].fill_(NULL_BLOCK_ID)
 
-            self.spec_sequence_masks[:num_spec_decodes].copy_(
-                spec_sequence_masks[:num_spec_decodes],
-                non_blocking=True,
-            )
+            self.spec_sequence_masks[:num_spec_decodes].copy_(spec_sequence_masks[:num_spec_decodes], non_blocking=True)
             spec_sequence_masks = self.spec_sequence_masks[:batch_size]
             spec_sequence_masks[num_spec_decodes:].fill_(False)
 
             assert non_spec_token_indx is not None and spec_token_indx is not None
-            self.non_spec_token_indx[: non_spec_token_indx.size(0)].copy_(
-                non_spec_token_indx,
-                non_blocking=True,
-            )
+            self.non_spec_token_indx[: non_spec_token_indx.size(0)].copy_(non_spec_token_indx, non_blocking=True)
             non_spec_token_indx = self.non_spec_token_indx[: non_spec_token_indx.size(0)]
 
-            self.spec_token_indx[: spec_token_indx.size(0)].copy_(
-                spec_token_indx,
-                non_blocking=True,
-            )
+            self.spec_token_indx[: spec_token_indx.size(0)].copy_(spec_token_indx, non_blocking=True)
             spec_token_indx = self.spec_token_indx[: spec_token_indx.size(0)]
 
-            self.spec_query_start_loc[: num_spec_decodes + 1].copy_(
-                spec_query_start_loc,
-                non_blocking=True,
-            )
+            self.spec_query_start_loc[: num_spec_decodes + 1].copy_(spec_query_start_loc, non_blocking=True)
             spec_num_query_tokens = spec_query_start_loc[-1]  # type: ignore[index]
             spec_query_start_loc = self.spec_query_start_loc[: batch_size + 1]
             spec_query_start_loc[num_spec_decodes + 1 :].fill_(spec_num_query_tokens)
 
-            self.num_accepted_tokens[:num_spec_decodes].copy_(
-                num_accepted_tokens,
-                non_blocking=True,
-            )
+            self.num_accepted_tokens[:num_spec_decodes].copy_(num_accepted_tokens, non_blocking=True)
             num_accepted_tokens = self.num_accepted_tokens[:batch_size]
             num_accepted_tokens[num_spec_decodes:].fill_(1)
 
@@ -328,22 +306,16 @@ class GDNAttentionMetadataBuilder310(GDNAttentionMetadataBuilder):
             and num_spec_decodes == 0
             and num_decodes <= self.decode_cudagraph_max_bs
         ):
-            self.non_spec_state_indices_tensor[:num_decodes].copy_(
-                non_spec_state_indices_tensor,
-                non_blocking=True,
-            )
+            self.non_spec_state_indices_tensor[:num_decodes].copy_(non_spec_state_indices_tensor, non_blocking=True)
             non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[:batch_size]
             non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
 
-            self.non_spec_query_start_loc[: num_decodes + 1].copy_(
-                non_spec_query_start_loc,
-                non_blocking=True,
-            )
+            self.non_spec_query_start_loc[: num_decodes + 1].copy_(non_spec_query_start_loc, non_blocking=True)
             non_spec_num_query_tokens = non_spec_query_start_loc[-1]  # type: ignore[index]
             non_spec_query_start_loc = self.non_spec_query_start_loc[: batch_size + 1]
             non_spec_query_start_loc[num_decodes + 1 :].fill_(non_spec_num_query_tokens)
 
-        return GDNAttentionMetadata(
+        attn_metadata = GDNAttentionMetadata(
             num_prefills=num_prefills,
             num_prefill_tokens=num_prefill_tokens,
             num_decodes=num_decodes,
@@ -369,3 +341,4 @@ class GDNAttentionMetadataBuilder310(GDNAttentionMetadataBuilder):
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,
         )
+        return attn_metadata

--- a/vllm_ascend/_310p/ops/gdn_attn_builder_310.py
+++ b/vllm_ascend/_310p/ops/gdn_attn_builder_310.py
@@ -1,0 +1,373 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""310P GDN metadata builder with RC-safe prefill metadata in build()."""
+
+from __future__ import annotations
+
+import torch
+import vllm.v1.attention.backends.utils as attn_backend_utils
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
+from vllm.v1.attention.backends.utils import (
+    NULL_BLOCK_ID,
+    mamba_get_block_table_tensor,
+    split_decodes_and_prefills,
+)
+
+from vllm_ascend.ops.gdn_attn_builder import (
+    AscendGDNAttentionMetadataBuilder,
+    _stable_argsort_for_npu,
+)
+
+
+class AscendGDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
+    def build(  # type: ignore[override]
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        num_accepted_tokens: torch.Tensor | None = None,
+        num_decode_draft_tokens_cpu: torch.Tensor | None = None,
+        fast_build: bool = False,
+    ) -> GDNAttentionMetadata:
+        m = common_attn_metadata
+
+        query_start_loc = m.query_start_loc
+        query_start_loc_cpu = m.query_start_loc_cpu
+        context_lens_tensor = m.compute_num_computed_tokens()
+        nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
+        block_table_tensor = mamba_get_block_table_tensor(
+            m.block_table_tensor,
+            m.seq_lens,
+            self.kv_cache_spec,
+            self.vllm_config.cache_config.mamba_cache_mode,
+        )
+
+        spec_sequence_masks_cpu: torch.Tensor | None = None
+        spec_sequence_indices: torch.Tensor | None = None
+        non_spec_sequence_indices: torch.Tensor | None = None
+        if not self.use_spec_decode or num_decode_draft_tokens_cpu is None:
+            spec_sequence_masks = None
+            num_spec_decodes = 0
+        else:
+            num_reqs = num_decode_draft_tokens_cpu.numel()
+            spec_sequence_masks_cpu = self.spec_sequence_masks_cpu[:num_reqs]
+            torch.ge(
+                num_decode_draft_tokens_cpu,
+                0,
+                out=spec_sequence_masks_cpu,
+            )
+            num_spec_decodes = spec_sequence_masks_cpu.sum().item()
+            if num_spec_decodes == 0:
+                spec_sequence_masks = None
+                spec_sequence_masks_cpu = None
+            else:
+                spec_sequence_masks = self.spec_sequence_masks[:num_reqs]
+                spec_sequence_masks.copy_(spec_sequence_masks_cpu, non_blocking=True)
+                spec_sequence_indices, non_spec_sequence_indices = self._copy_sequence_indices_to_device(
+                    spec_sequence_masks_cpu,
+                    num_spec_decodes,
+                )
+
+        if spec_sequence_masks is None:
+            num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = split_decodes_and_prefills(
+                m,
+                decode_threshold=1,
+                treat_short_extends_as_decodes=False,
+            )
+            num_spec_decode_tokens = 0
+            spec_token_indx = None
+            non_spec_token_indx = None
+            spec_state_indices_tensor = None
+            non_spec_state_indices_tensor = block_table_tensor[:, 0]
+            spec_query_start_loc = None
+            non_spec_query_start_loc = query_start_loc
+            non_spec_query_start_loc_cpu = query_start_loc_cpu
+            num_accepted_tokens = None
+        else:
+            query_lens = query_start_loc[1:] - query_start_loc[:-1]
+            query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+            assert spec_sequence_masks_cpu is not None
+            assert spec_sequence_indices is not None
+            assert non_spec_sequence_indices is not None
+
+            non_spec_query_lens_cpu = query_lens_cpu[~spec_sequence_masks_cpu]
+            num_decodes = (non_spec_query_lens_cpu == 1).sum().item()
+            num_zero_len = (non_spec_query_lens_cpu == 0).sum().item()
+            num_prefills = non_spec_query_lens_cpu.size(0) - num_decodes - num_zero_len
+            num_decode_tokens = num_decodes
+            num_prefill_tokens = non_spec_query_lens_cpu.sum().item() - num_decode_tokens
+            num_spec_decode_tokens = query_lens_cpu.sum().item() - num_prefill_tokens - num_decode_tokens
+
+            if num_decodes > 0 and num_spec_decodes > 0:
+                num_prefills += num_decodes
+                num_prefill_tokens += num_decode_tokens
+                num_decodes = 0
+                num_decode_tokens = 0
+
+            if num_prefills == 0 and num_decodes == 0:
+                spec_token_size = min(
+                    num_spec_decodes * (self.num_spec + 1),
+                    query_start_loc_cpu[-1].item(),
+                )
+                spec_token_indx = torch.arange(
+                    spec_token_size,
+                    dtype=torch.int32,
+                    device=query_start_loc.device,
+                )
+                non_spec_token_indx = torch.empty(
+                    0,
+                    dtype=torch.int32,
+                    device=query_start_loc.device,
+                )
+                spec_state_indices_tensor = torch.index_select(
+                    block_table_tensor[:, : self.num_spec + 1],
+                    0,
+                    spec_sequence_indices,
+                )
+                non_spec_state_indices_tensor = None
+                spec_query_start_loc = query_start_loc[: num_spec_decodes + 1]
+                non_spec_query_start_loc = None
+                non_spec_query_start_loc_cpu = None
+            else:
+                spec_token_masks = torch.repeat_interleave(
+                    spec_sequence_masks,
+                    query_lens,
+                    output_size=query_start_loc_cpu[-1].item(),
+                )
+                index = _stable_argsort_for_npu(spec_token_masks)
+                num_non_spec_tokens = num_prefill_tokens + num_decode_tokens
+                non_spec_token_indx = index[:num_non_spec_tokens]
+                spec_token_indx = index[num_non_spec_tokens:]
+
+                spec_state_indices_tensor = torch.index_select(
+                    block_table_tensor[:, : self.num_spec + 1],
+                    0,
+                    spec_sequence_indices,
+                )
+                non_spec_state_indices_tensor = torch.index_select(
+                    block_table_tensor[:, 0],
+                    0,
+                    non_spec_sequence_indices,
+                )
+                spec_query_lens = torch.index_select(
+                    query_lens,
+                    0,
+                    spec_sequence_indices,
+                )
+                non_spec_query_lens = torch.index_select(
+                    query_lens,
+                    0,
+                    non_spec_sequence_indices,
+                )
+
+                spec_query_start_loc = torch.zeros(
+                    num_spec_decodes + 1,
+                    dtype=torch.int32,
+                    device=query_start_loc.device,
+                )
+                torch.cumsum(
+                    spec_query_lens,
+                    dim=0,
+                    out=spec_query_start_loc[1:],
+                )
+                non_spec_query_start_loc = torch.zeros(
+                    query_lens.size(0) - num_spec_decodes + 1,
+                    dtype=torch.int32,
+                    device=query_start_loc.device,
+                )
+                torch.cumsum(
+                    non_spec_query_lens,
+                    dim=0,
+                    out=non_spec_query_start_loc[1:],
+                )
+                non_spec_query_start_loc_cpu = torch.zeros(
+                    query_lens_cpu.size(0) - num_spec_decodes + 1,
+                    dtype=torch.int32,
+                )
+                torch.cumsum(
+                    query_lens_cpu[~spec_sequence_masks_cpu],
+                    dim=0,
+                    out=non_spec_query_start_loc_cpu[1:],
+                )
+
+            assert num_accepted_tokens is not None
+            num_accepted_tokens = torch.index_select(
+                num_accepted_tokens,
+                0,
+                spec_sequence_indices,
+            )
+
+        chunk_indices: torch.Tensor | None = None
+        chunk_offsets: torch.Tensor | None = None
+        if num_prefills > 0:
+            from vllm.model_executor.layers.fla.ops.index import (
+                prepare_chunk_indices,
+                prepare_chunk_offsets,
+            )
+            from vllm.model_executor.layers.fla.ops.utils import FLA_CHUNK_SIZE
+
+            gpu_device = query_start_loc.device
+            chunk_indices = prepare_chunk_indices(
+                non_spec_query_start_loc_cpu,
+                FLA_CHUNK_SIZE,
+            ).to(device=gpu_device, non_blocking=True)
+            chunk_offsets = prepare_chunk_offsets(
+                non_spec_query_start_loc_cpu,
+                FLA_CHUNK_SIZE,
+            ).to(device=gpu_device, non_blocking=True)
+
+        if num_prefills > 0:
+            assert non_spec_query_start_loc_cpu is not None
+            if m._seq_lens_cpu is not None:
+                context_lens_cpu = m._seq_lens_cpu
+            elif m.seq_lens_cpu is not None:
+                context_lens_cpu = m.seq_lens_cpu
+            else:
+                context_lens_cpu = context_lens_tensor.detach().cpu()
+
+            has_initial_state = context_lens_cpu > 0
+            if spec_sequence_masks_cpu is not None:
+                has_initial_state = has_initial_state[~spec_sequence_masks_cpu]
+
+            has_initial_state = has_initial_state.to(
+                query_start_loc.device,
+                non_blocking=True,
+            )
+            nums_dict, batch_ptr, token_chunk_offset_ptr = (
+                attn_backend_utils.compute_causal_conv1d_metadata(
+                    non_spec_query_start_loc_cpu,
+                    device=query_start_loc.device,
+                )
+            )
+        else:
+            has_initial_state = None
+
+        assert not (num_decodes > 0 and num_spec_decodes > 0), (
+            f"num_decodes: {num_decodes}, num_spec_decodes: {num_spec_decodes}"
+        )
+
+        batch_size = m.num_actual_tokens
+
+        if (
+            self.use_full_cuda_graph
+            and num_prefills == 0
+            and num_decodes == 0
+            and num_spec_decodes <= self.decode_cudagraph_max_bs
+            and num_spec_decode_tokens <= self.decode_cudagraph_max_bs
+        ):
+            assert spec_sequence_masks is not None
+            self.spec_state_indices_tensor[batch_size:].fill_(NULL_BLOCK_ID)
+            self.spec_state_indices_tensor[:num_spec_decodes].copy_(
+                spec_state_indices_tensor,
+                non_blocking=True,
+            )
+            spec_state_indices_tensor = self.spec_state_indices_tensor[:batch_size]
+            spec_state_indices_tensor[num_spec_decodes:].fill_(NULL_BLOCK_ID)
+
+            self.spec_sequence_masks[:num_spec_decodes].copy_(
+                spec_sequence_masks[:num_spec_decodes],
+                non_blocking=True,
+            )
+            spec_sequence_masks = self.spec_sequence_masks[:batch_size]
+            spec_sequence_masks[num_spec_decodes:].fill_(False)
+
+            assert non_spec_token_indx is not None and spec_token_indx is not None
+            self.non_spec_token_indx[: non_spec_token_indx.size(0)].copy_(
+                non_spec_token_indx,
+                non_blocking=True,
+            )
+            non_spec_token_indx = self.non_spec_token_indx[: non_spec_token_indx.size(0)]
+
+            self.spec_token_indx[: spec_token_indx.size(0)].copy_(
+                spec_token_indx,
+                non_blocking=True,
+            )
+            spec_token_indx = self.spec_token_indx[: spec_token_indx.size(0)]
+
+            self.spec_query_start_loc[: num_spec_decodes + 1].copy_(
+                spec_query_start_loc,
+                non_blocking=True,
+            )
+            spec_num_query_tokens = spec_query_start_loc[-1]  # type: ignore
+            spec_query_start_loc = self.spec_query_start_loc[: batch_size + 1]
+            spec_query_start_loc[num_spec_decodes + 1 :].fill_(spec_num_query_tokens)
+
+            self.num_accepted_tokens[:num_spec_decodes].copy_(
+                num_accepted_tokens,
+                non_blocking=True,
+            )
+            num_accepted_tokens = self.num_accepted_tokens[:batch_size]
+            num_accepted_tokens[num_spec_decodes:].fill_(1)
+
+        if (
+            self.use_full_cuda_graph
+            and num_prefills == 0
+            and num_spec_decodes == 0
+            and num_decodes <= self.decode_cudagraph_max_bs
+        ):
+            self.non_spec_state_indices_tensor[batch_size:].fill_(NULL_BLOCK_ID)
+            self.non_spec_state_indices_tensor[:num_decodes].copy_(
+                non_spec_state_indices_tensor,
+                non_blocking=True,
+            )
+            non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[:batch_size]
+            non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
+
+            self.non_spec_query_start_loc[: num_decodes + 1].copy_(
+                non_spec_query_start_loc,
+                non_blocking=True,
+            )
+            non_spec_num_query_tokens = non_spec_query_start_loc[-1]
+            non_spec_query_start_loc = self.non_spec_query_start_loc[: batch_size + 1]
+            non_spec_query_start_loc[num_decodes + 1 :].fill_(non_spec_num_query_tokens)
+
+        attn_metadata = GDNAttentionMetadata(
+            num_prefills=num_prefills,
+            num_prefill_tokens=num_prefill_tokens,
+            num_decodes=num_decodes,
+            num_decode_tokens=num_decode_tokens,
+            num_spec_decodes=num_spec_decodes,
+            num_spec_decode_tokens=num_spec_decode_tokens,
+            num_actual_tokens=m.num_actual_tokens,
+            has_initial_state=has_initial_state,
+            chunk_indices=chunk_indices,
+            chunk_offsets=chunk_offsets,
+            spec_query_start_loc=spec_query_start_loc,
+            non_spec_query_start_loc=non_spec_query_start_loc,
+            spec_state_indices_tensor=spec_state_indices_tensor,
+            non_spec_state_indices_tensor=non_spec_state_indices_tensor,
+            spec_sequence_masks=spec_sequence_masks,
+            spec_token_indx=spec_token_indx,
+            non_spec_token_indx=non_spec_token_indx,
+            num_accepted_tokens=num_accepted_tokens,
+            nums_dict=nums_dict,
+            batch_ptr=batch_ptr,
+            token_chunk_offset_ptr=token_chunk_offset_ptr,
+        )
+        attn_metadata = self._attach_non_spec_prefill_fallback_meta(
+            attn_metadata,
+            common_attn_metadata,
+            non_spec_query_start_loc_cpu,
+        )
+        attn_metadata = self._attach_spec_decode_fallback_meta(
+            attn_metadata,
+            common_attn_metadata,
+            num_decode_draft_tokens_cpu,
+        )
+        return self._attach_non_spec_decode_fallback_meta(
+            attn_metadata,
+            common_attn_metadata,
+            num_decode_draft_tokens_cpu,
+        )

--- a/vllm_ascend/_310p/ops/gdn_attn_builder_310.py
+++ b/vllm_ascend/_310p/ops/gdn_attn_builder_310.py
@@ -12,27 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""310P GDN metadata builder with RC-safe prefill metadata in build()."""
+"""310P GDN metadata builder: upstream build() with RC-safe prefill metadata."""
 
 from __future__ import annotations
 
 import torch
 import vllm.v1.attention.backends.utils as attn_backend_utils
+from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.attention.backend import CommonAttentionMetadata
-from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
+from vllm.v1.attention.backends.gdn_attn import (
+    GDNAttentionMetadata,
+    GDNAttentionMetadataBuilder,
+)
 from vllm.v1.attention.backends.utils import (
     NULL_BLOCK_ID,
     mamba_get_block_table_tensor,
     split_decodes_and_prefills,
 )
 
-from vllm_ascend.ops.gdn_attn_builder import (
-    AscendGDNAttentionMetadataBuilder,
-    _stable_argsort_for_npu,
-)
+
+def _stable_argsort_for_npu(tensor: torch.Tensor) -> torch.Tensor:
+    if tensor.dtype == torch.bool:
+        tensor = tensor.to(torch.int32)
+    return torch.argsort(tensor, stable=True)
 
 
-class AscendGDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
+class GDNAttentionMetadataBuilder310(GDNAttentionMetadataBuilder):
     def build(  # type: ignore[override]
         self,
         common_prefix_len: int,
@@ -55,36 +60,29 @@ class AscendGDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
         )
 
         spec_sequence_masks_cpu: torch.Tensor | None = None
-        spec_sequence_indices: torch.Tensor | None = None
-        non_spec_sequence_indices: torch.Tensor | None = None
-        if not self.use_spec_decode or num_decode_draft_tokens_cpu is None:
+        if (
+            not self.use_spec_decode
+            or num_decode_draft_tokens_cpu is None
+            or num_decode_draft_tokens_cpu[num_decode_draft_tokens_cpu >= 0].sum().item() == 0
+        ):
             spec_sequence_masks = None
             num_spec_decodes = 0
         else:
-            num_reqs = num_decode_draft_tokens_cpu.numel()
-            spec_sequence_masks_cpu = self.spec_sequence_masks_cpu[:num_reqs]
-            torch.ge(
-                num_decode_draft_tokens_cpu,
-                0,
-                out=spec_sequence_masks_cpu,
-            )
+            spec_sequence_masks_cpu = num_decode_draft_tokens_cpu >= 0
             num_spec_decodes = spec_sequence_masks_cpu.sum().item()
             if num_spec_decodes == 0:
                 spec_sequence_masks = None
                 spec_sequence_masks_cpu = None
             else:
-                spec_sequence_masks = self.spec_sequence_masks[:num_reqs]
-                spec_sequence_masks.copy_(spec_sequence_masks_cpu, non_blocking=True)
-                spec_sequence_indices, non_spec_sequence_indices = self._copy_sequence_indices_to_device(
+                spec_sequence_masks = async_tensor_h2d(
                     spec_sequence_masks_cpu,
-                    num_spec_decodes,
+                    device=query_start_loc.device,
                 )
 
         if spec_sequence_masks is None:
             num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = split_decodes_and_prefills(
                 m,
                 decode_threshold=1,
-                treat_short_extends_as_decodes=False,
             )
             num_spec_decode_tokens = 0
             spec_token_indx = None
@@ -97,10 +95,8 @@ class AscendGDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
             num_accepted_tokens = None
         else:
             query_lens = query_start_loc[1:] - query_start_loc[:-1]
-            query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
             assert spec_sequence_masks_cpu is not None
-            assert spec_sequence_indices is not None
-            assert non_spec_sequence_indices is not None
+            query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
 
             non_spec_query_lens_cpu = query_lens_cpu[~spec_sequence_masks_cpu]
             num_decodes = (non_spec_query_lens_cpu == 1).sum().item()
@@ -131,11 +127,10 @@ class AscendGDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
                     dtype=torch.int32,
                     device=query_start_loc.device,
                 )
-                spec_state_indices_tensor = torch.index_select(
-                    block_table_tensor[:, : self.num_spec + 1],
-                    0,
-                    spec_sequence_indices,
-                )
+                spec_state_indices_tensor = block_table_tensor[
+                    spec_sequence_masks_cpu,
+                    : self.num_spec + 1,
+                ]
                 non_spec_state_indices_tensor = None
                 spec_query_start_loc = query_start_loc[: num_spec_decodes + 1]
                 non_spec_query_start_loc = None
@@ -151,26 +146,14 @@ class AscendGDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
                 non_spec_token_indx = index[:num_non_spec_tokens]
                 spec_token_indx = index[num_non_spec_tokens:]
 
-                spec_state_indices_tensor = torch.index_select(
-                    block_table_tensor[:, : self.num_spec + 1],
+                spec_state_indices_tensor = block_table_tensor[
+                    spec_sequence_masks_cpu,
+                    : self.num_spec + 1,
+                ]
+                non_spec_state_indices_tensor = block_table_tensor[
+                    ~spec_sequence_masks_cpu,
                     0,
-                    spec_sequence_indices,
-                )
-                non_spec_state_indices_tensor = torch.index_select(
-                    block_table_tensor[:, 0],
-                    0,
-                    non_spec_sequence_indices,
-                )
-                spec_query_lens = torch.index_select(
-                    query_lens,
-                    0,
-                    spec_sequence_indices,
-                )
-                non_spec_query_lens = torch.index_select(
-                    query_lens,
-                    0,
-                    non_spec_sequence_indices,
-                )
+                ]
 
                 spec_query_start_loc = torch.zeros(
                     num_spec_decodes + 1,
@@ -178,7 +161,7 @@ class AscendGDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
                     device=query_start_loc.device,
                 )
                 torch.cumsum(
-                    spec_query_lens,
+                    query_lens[spec_sequence_masks_cpu],
                     dim=0,
                     out=spec_query_start_loc[1:],
                 )
@@ -188,7 +171,7 @@ class AscendGDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
                     device=query_start_loc.device,
                 )
                 torch.cumsum(
-                    non_spec_query_lens,
+                    query_lens[~spec_sequence_masks_cpu],
                     dim=0,
                     out=non_spec_query_start_loc[1:],
                 )
@@ -203,30 +186,57 @@ class AscendGDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
                 )
 
             assert num_accepted_tokens is not None
-            num_accepted_tokens = torch.index_select(
-                num_accepted_tokens,
-                0,
-                spec_sequence_indices,
-            )
+            num_accepted_tokens = num_accepted_tokens[spec_sequence_masks_cpu]
 
         chunk_indices: torch.Tensor | None = None
         chunk_offsets: torch.Tensor | None = None
+        prefill_query_start_loc: torch.Tensor | None = None
+        prefill_state_indices: torch.Tensor | None = None
+        prefill_has_initial_state: torch.Tensor | None = None
         if num_prefills > 0:
-            from vllm.model_executor.layers.fla.ops.index import (
-                prepare_chunk_indices,
-                prepare_chunk_offsets,
-            )
             from vllm.model_executor.layers.fla.ops.utils import FLA_CHUNK_SIZE
 
-            gpu_device = query_start_loc.device
-            chunk_indices = prepare_chunk_indices(
-                non_spec_query_start_loc_cpu,
-                FLA_CHUNK_SIZE,
-            ).to(device=gpu_device, non_blocking=True)
-            chunk_offsets = prepare_chunk_offsets(
-                non_spec_query_start_loc_cpu,
-                FLA_CHUNK_SIZE,
-            ).to(device=gpu_device, non_blocking=True)
+            if spec_sequence_masks is None and num_decodes > 0:
+                assert non_spec_query_start_loc is not None
+                assert non_spec_query_start_loc_cpu is not None
+                assert non_spec_state_indices_tensor is not None
+                prefill_query_start_loc = non_spec_query_start_loc[num_decodes:] - num_decode_tokens
+                prefill_query_start_loc_cpu = non_spec_query_start_loc_cpu[num_decodes:] - num_decode_tokens
+                prefill_state_indices = non_spec_state_indices_tensor[num_decodes:]
+            else:
+                prefill_query_start_loc = non_spec_query_start_loc
+                prefill_query_start_loc_cpu = non_spec_query_start_loc_cpu
+                prefill_state_indices = non_spec_state_indices_tensor
+
+            if self.gdn_prefill_backend == "cutedsl":
+                from vllm.model_executor.layers.mamba.ops.gdn_chunk_cutedsl import (
+                    prepare_metadata_cutedsl,
+                )
+
+                assert prefill_query_start_loc is not None
+                assert prefill_query_start_loc_cpu is not None
+                total_tokens = int(prefill_query_start_loc_cpu[-1].item())
+                chunk_indices, chunk_offsets = prepare_metadata_cutedsl(
+                    prefill_query_start_loc,
+                    total_tokens,
+                    FLA_CHUNK_SIZE,
+                )
+            else:
+                gpu_device = query_start_loc.device
+                from vllm.model_executor.layers.fla.ops.index import (
+                    prepare_chunk_indices,
+                    prepare_chunk_offsets,
+                )
+
+                assert prefill_query_start_loc_cpu is not None
+                chunk_indices = async_tensor_h2d(
+                    prepare_chunk_indices(prefill_query_start_loc_cpu, FLA_CHUNK_SIZE),
+                    device=gpu_device,
+                )
+                chunk_offsets = async_tensor_h2d(
+                    prepare_chunk_offsets(prefill_query_start_loc_cpu, FLA_CHUNK_SIZE),
+                    device=gpu_device,
+                )
 
         if num_prefills > 0:
             assert non_spec_query_start_loc_cpu is not None
@@ -237,20 +247,22 @@ class AscendGDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
             else:
                 context_lens_cpu = context_lens_tensor.detach().cpu()
 
-            has_initial_state = context_lens_cpu > 0
+            has_initial_state_cpu = context_lens_cpu > 0
             if spec_sequence_masks_cpu is not None:
-                has_initial_state = has_initial_state[~spec_sequence_masks_cpu]
+                has_initial_state_cpu = has_initial_state_cpu[~spec_sequence_masks_cpu]
 
-            has_initial_state = has_initial_state.to(
+            has_initial_state = has_initial_state_cpu.to(
                 query_start_loc.device,
                 non_blocking=True,
             )
-            nums_dict, batch_ptr, token_chunk_offset_ptr = (
-                attn_backend_utils.compute_causal_conv1d_metadata(
-                    non_spec_query_start_loc_cpu,
-                    device=query_start_loc.device,
-                )
+            nums_dict, batch_ptr, token_chunk_offset_ptr = attn_backend_utils.compute_causal_conv1d_metadata(
+                non_spec_query_start_loc_cpu,
+                device=query_start_loc.device,
             )
+            if spec_sequence_masks is None and num_decodes > 0:
+                prefill_has_initial_state = has_initial_state[num_decodes:]
+            else:
+                prefill_has_initial_state = has_initial_state
         else:
             has_initial_state = None
 
@@ -258,7 +270,7 @@ class AscendGDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
             f"num_decodes: {num_decodes}, num_spec_decodes: {num_spec_decodes}"
         )
 
-        batch_size = m.num_actual_tokens
+        batch_size = m.num_reqs
 
         if (
             self.use_full_cuda_graph
@@ -268,7 +280,6 @@ class AscendGDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
             and num_spec_decode_tokens <= self.decode_cudagraph_max_bs
         ):
             assert spec_sequence_masks is not None
-            self.spec_state_indices_tensor[batch_size:].fill_(NULL_BLOCK_ID)
             self.spec_state_indices_tensor[:num_spec_decodes].copy_(
                 spec_state_indices_tensor,
                 non_blocking=True,
@@ -300,7 +311,7 @@ class AscendGDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
                 spec_query_start_loc,
                 non_blocking=True,
             )
-            spec_num_query_tokens = spec_query_start_loc[-1]  # type: ignore
+            spec_num_query_tokens = spec_query_start_loc[-1]  # type: ignore[index]
             spec_query_start_loc = self.spec_query_start_loc[: batch_size + 1]
             spec_query_start_loc[num_spec_decodes + 1 :].fill_(spec_num_query_tokens)
 
@@ -317,7 +328,6 @@ class AscendGDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
             and num_spec_decodes == 0
             and num_decodes <= self.decode_cudagraph_max_bs
         ):
-            self.non_spec_state_indices_tensor[batch_size:].fill_(NULL_BLOCK_ID)
             self.non_spec_state_indices_tensor[:num_decodes].copy_(
                 non_spec_state_indices_tensor,
                 non_blocking=True,
@@ -329,11 +339,11 @@ class AscendGDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
                 non_spec_query_start_loc,
                 non_blocking=True,
             )
-            non_spec_num_query_tokens = non_spec_query_start_loc[-1]
+            non_spec_num_query_tokens = non_spec_query_start_loc[-1]  # type: ignore[index]
             non_spec_query_start_loc = self.non_spec_query_start_loc[: batch_size + 1]
             non_spec_query_start_loc[num_decodes + 1 :].fill_(non_spec_num_query_tokens)
 
-        attn_metadata = GDNAttentionMetadata(
+        return GDNAttentionMetadata(
             num_prefills=num_prefills,
             num_prefill_tokens=num_prefill_tokens,
             num_decodes=num_decodes,
@@ -344,6 +354,9 @@ class AscendGDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
             has_initial_state=has_initial_state,
             chunk_indices=chunk_indices,
             chunk_offsets=chunk_offsets,
+            prefill_query_start_loc=prefill_query_start_loc,
+            prefill_state_indices=prefill_state_indices,
+            prefill_has_initial_state=prefill_has_initial_state,
             spec_query_start_loc=spec_query_start_loc,
             non_spec_query_start_loc=non_spec_query_start_loc,
             spec_state_indices_tensor=spec_state_indices_tensor,
@@ -355,19 +368,4 @@ class AscendGDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
             nums_dict=nums_dict,
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,
-        )
-        attn_metadata = self._attach_non_spec_prefill_fallback_meta(
-            attn_metadata,
-            common_attn_metadata,
-            non_spec_query_start_loc_cpu,
-        )
-        attn_metadata = self._attach_spec_decode_fallback_meta(
-            attn_metadata,
-            common_attn_metadata,
-            num_decode_draft_tokens_cpu,
-        )
-        return self._attach_non_spec_decode_fallback_meta(
-            attn_metadata,
-            common_attn_metadata,
-            num_decode_draft_tokens_cpu,
         )

--- a/vllm_ascend/_310p/ops/gdn_attn_builder_310.py
+++ b/vllm_ascend/_310p/ops/gdn_attn_builder_310.py
@@ -48,17 +48,25 @@ class GDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
         torch.Tensor | None,
         torch.Tensor | None,
     ]:
-        del context_lens_tensor, non_spec_sequence_indices, num_prefills
+        del non_spec_sequence_indices, num_prefills
         assert non_spec_query_start_loc_cpu is not None
 
         m = common_attn_metadata
         # 310P RC: compute has_initial_state on CPU, single H2D upload.
-        if m._seq_lens_cpu is not None:
-            context_lens_cpu = m._seq_lens_cpu
-        elif m.seq_lens_cpu is not None:
-            context_lens_cpu = m.seq_lens_cpu
+        # NOTE: This must mirror the mainline device path
+        # ``has_initial_state = context_lens_tensor > 0`` where
+        # ``context_lens_tensor = m.compute_num_computed_tokens()`` is the
+        # number of *already computed* tokens (context length), NOT the total
+        # ``seq_lens``. Using ``seq_lens`` would flag fresh prefills (0
+        # computed tokens) as having an initial recurrent state and read
+        # uninitialized SSM state -> garbage output.
+        num_computed_tokens_cpu = getattr(m, "_num_computed_tokens_cpu", None)
+        if num_computed_tokens_cpu is None:
+            num_computed_tokens_cpu = getattr(m, "num_computed_tokens_cpu", None)
+        if num_computed_tokens_cpu is not None:
+            context_lens_cpu = num_computed_tokens_cpu
         else:
-            context_lens_cpu = m.compute_num_computed_tokens().detach().cpu()
+            context_lens_cpu = context_lens_tensor.detach().cpu()
 
         has_initial_state_cpu = context_lens_cpu > 0
         if spec_sequence_masks_cpu is not None:

--- a/vllm_ascend/_310p/ops/gdn_attn_builder_310.py
+++ b/vllm_ascend/_310p/ops/gdn_attn_builder_310.py
@@ -12,333 +12,91 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""310P GDN metadata builder: vLLM GDNAttentionMetadataBuilder.build with RC-safe prefill."""
+"""310P RC GDN metadata builder: Ascend builder with RC-safe prefill metadata."""
 
 from __future__ import annotations
 
 import torch
-import vllm.v1.attention.backends.utils as attn_backend_utils
 from vllm.v1.attention.backend import CommonAttentionMetadata
-from vllm.v1.attention.backends.gdn_attn import (
-    GDNAttentionMetadata,
-    GDNAttentionMetadataBuilder,
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
+
+from vllm_ascend._310p.ops.fla.cumpute_causal_conv1d_metadata_310 import (
+    compute_causal_conv1d_metadata,
 )
-from vllm.v1.attention.backends.utils import (
-    NULL_BLOCK_ID,
-    mamba_get_block_table_tensor,
-    split_decodes_and_prefills,
-)
+from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionMetadataBuilder
 
 
-class GDNAttentionMetadataBuilder310(GDNAttentionMetadataBuilder):
-    def build(  # type: ignore[override]
+class GDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
+    """RC-only overrides on top of :class:`AscendGDNAttentionMetadataBuilder`.
+
+    310P does not support Triton, so fallback metadata attachment is skipped.
+    """
+
+    def _build_prefill_has_initial_state_and_causal_conv1d_meta(
         self,
-        common_prefix_len: int,
+        *,
         common_attn_metadata: CommonAttentionMetadata,
-        num_accepted_tokens: torch.Tensor | None = None,
-        num_decode_draft_tokens_cpu: torch.Tensor | None = None,
-        fast_build: bool = False,
-    ) -> GDNAttentionMetadata:
+        context_lens_tensor: torch.Tensor,
+        num_prefills: int,
+        spec_sequence_masks_cpu: torch.Tensor | None,
+        non_spec_sequence_indices: torch.Tensor | None,
+        non_spec_query_start_loc_cpu: torch.Tensor | None,
+        query_start_loc: torch.Tensor,
+    ) -> tuple[
+        torch.Tensor | None,
+        dict[int, dict[str, object]] | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+    ]:
+        del context_lens_tensor, non_spec_sequence_indices, num_prefills
+        assert non_spec_query_start_loc_cpu is not None
+
         m = common_attn_metadata
-
-        query_start_loc = m.query_start_loc
-        query_start_loc_cpu = m.query_start_loc_cpu
-        context_lens_tensor = m.compute_num_computed_tokens()
-        nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
-        block_table_tensor = mamba_get_block_table_tensor(
-            m.block_table_tensor,
-            m.seq_lens,
-            self.kv_cache_spec,
-            self.vllm_config.cache_config.mamba_cache_mode,
-        )
-
-        spec_sequence_masks_cpu: torch.Tensor | None = None
-        if (
-            not self.use_spec_decode
-            or num_decode_draft_tokens_cpu is None
-            or num_decode_draft_tokens_cpu[num_decode_draft_tokens_cpu >= 0].sum().item() == 0
-        ):
-            spec_sequence_masks = None
-            num_spec_decodes = 0
+        # 310P RC: compute has_initial_state on CPU, single H2D upload.
+        if m._seq_lens_cpu is not None:
+            context_lens_cpu = m._seq_lens_cpu
+        elif m.seq_lens_cpu is not None:
+            context_lens_cpu = m.seq_lens_cpu
         else:
-            spec_sequence_masks_cpu = num_decode_draft_tokens_cpu >= 0
-            num_spec_decodes = spec_sequence_masks_cpu.sum().item()
-            if num_spec_decodes == 0:
-                spec_sequence_masks = None
-                spec_sequence_masks_cpu = None
-            else:
-                spec_sequence_masks = spec_sequence_masks_cpu.to(query_start_loc.device, non_blocking=True)
+            context_lens_cpu = m.compute_num_computed_tokens().detach().cpu()
 
-        if spec_sequence_masks is None:
-            num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = split_decodes_and_prefills(
-                m, decode_threshold=1
-            )
-            num_spec_decode_tokens = 0
-            spec_token_indx = None
-            non_spec_token_indx = None
-            spec_state_indices_tensor = None
-            non_spec_state_indices_tensor = block_table_tensor[:, 0]
-            spec_query_start_loc = None
-            non_spec_query_start_loc = query_start_loc
-            non_spec_query_start_loc_cpu = query_start_loc_cpu
-            num_accepted_tokens = None
-        else:
-            query_lens = query_start_loc[1:] - query_start_loc[:-1]
-            assert spec_sequence_masks_cpu is not None
-            query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+        has_initial_state_cpu = context_lens_cpu > 0
+        if spec_sequence_masks_cpu is not None:
+            has_initial_state_cpu = has_initial_state_cpu[~spec_sequence_masks_cpu]
 
-            # Use CPU tensors to avoid CPU-GPU sync
-            non_spec_query_lens_cpu = query_lens_cpu[~spec_sequence_masks_cpu]
-            num_decodes = (non_spec_query_lens_cpu == 1).sum().item()
-            # Exclude zero-length padded sequences from prefill count.
-            num_zero_len = (non_spec_query_lens_cpu == 0).sum().item()
-            num_prefills = non_spec_query_lens_cpu.size(0) - num_decodes - num_zero_len
-            num_decode_tokens = num_decodes
-            num_prefill_tokens = non_spec_query_lens_cpu.sum().item() - num_decode_tokens
-            num_spec_decode_tokens = query_lens_cpu.sum().item() - num_prefill_tokens - num_decode_tokens
-
-            # num_decodes and num_spec_decodes are mutually exclusive.
-            # Reclassify non-spec decodes as prefills when spec decodes
-            # exist — the prefill kernel handles 1-token sequences with
-            # initial state correctly, producing identical results.
-            if num_decodes > 0 and num_spec_decodes > 0:
-                num_prefills += num_decodes
-                num_prefill_tokens += num_decode_tokens
-                num_decodes = 0
-                num_decode_tokens = 0
-
-            if num_prefills == 0 and num_decodes == 0:
-                spec_token_size = min(
-                    num_spec_decodes * (self.num_spec + 1),
-                    query_start_loc_cpu[-1].item(),
-                )
-                spec_token_indx = torch.arange(
-                    spec_token_size,
-                    dtype=torch.int32,
-                    device=query_start_loc.device,
-                )
-                non_spec_token_indx = torch.empty(0, dtype=torch.int32, device=query_start_loc.device)
-                # Filter by spec_sequence_masks to exclude padded sequences
-                spec_state_indices_tensor = block_table_tensor[spec_sequence_masks_cpu, : self.num_spec + 1]
-                non_spec_state_indices_tensor = None
-                # Padded sequences are always at the back, so the first
-                # num_spec_decodes + 1 entries of query_start_loc already
-                # contain the correct cumulative token counts.
-                spec_query_start_loc = query_start_loc[: num_spec_decodes + 1]
-                non_spec_query_start_loc = None
-                non_spec_query_start_loc_cpu = None
-            else:
-                spec_token_masks = torch.repeat_interleave(
-                    spec_sequence_masks,
-                    query_lens,
-                    output_size=query_start_loc_cpu[-1].item(),
-                )
-                index = torch.argsort(spec_token_masks, stable=True)
-                num_non_spec_tokens = num_prefill_tokens + num_decode_tokens
-                non_spec_token_indx = index[:num_non_spec_tokens]
-                spec_token_indx = index[num_non_spec_tokens:]
-
-                spec_state_indices_tensor = block_table_tensor[spec_sequence_masks_cpu, : self.num_spec + 1]
-                non_spec_state_indices_tensor = block_table_tensor[~spec_sequence_masks_cpu, 0]
-
-                spec_query_start_loc = torch.zeros(
-                    num_spec_decodes + 1,
-                    dtype=torch.int32,
-                    device=query_start_loc.device,
-                )
-                torch.cumsum(
-                    query_lens[spec_sequence_masks_cpu],
-                    dim=0,
-                    out=spec_query_start_loc[1:],
-                )
-                non_spec_query_start_loc = torch.zeros(
-                    query_lens.size(0) - num_spec_decodes + 1,
-                    dtype=torch.int32,
-                    device=query_start_loc.device,
-                )
-                torch.cumsum(
-                    query_lens[~spec_sequence_masks_cpu],
-                    dim=0,
-                    out=non_spec_query_start_loc[1:],
-                )
-                non_spec_query_start_loc_cpu = torch.zeros(
-                    query_lens_cpu.size(0) - num_spec_decodes + 1,
-                    dtype=torch.int32,
-                )
-                torch.cumsum(
-                    query_lens_cpu[~spec_sequence_masks_cpu],
-                    dim=0,
-                    out=non_spec_query_start_loc_cpu[1:],
-                )
-
-            assert num_accepted_tokens is not None
-            num_accepted_tokens = num_accepted_tokens[spec_sequence_masks_cpu]
-
-        chunk_indices: torch.Tensor | None = None
-        chunk_offsets: torch.Tensor | None = None
-        prefill_query_start_loc: torch.Tensor | None = None
-        prefill_state_indices: torch.Tensor | None = None
-        prefill_has_initial_state: torch.Tensor | None = None
-        if num_prefills > 0:
-            from vllm.model_executor.layers.fla.ops.utils import FLA_CHUNK_SIZE
-
-            # In a mixed non-spec batch, decodes are peeled off to the recurrent
-            # kernel (decode-first front slice), so build chunk metadata from the
-            # rebased prefill-only cu_seqlens; otherwise use the full non-spec one.
-            # _forward_core keys off the same condition, so they agree.
-            if spec_sequence_masks is None and num_decodes > 0:
-                assert non_spec_query_start_loc is not None
-                assert non_spec_query_start_loc_cpu is not None
-                assert non_spec_state_indices_tensor is not None
-                prefill_query_start_loc = non_spec_query_start_loc[num_decodes:] - num_decode_tokens
-                prefill_query_start_loc_cpu = non_spec_query_start_loc_cpu[num_decodes:] - num_decode_tokens
-                prefill_state_indices = non_spec_state_indices_tensor[num_decodes:]
-            else:
-                prefill_query_start_loc = non_spec_query_start_loc
-                prefill_query_start_loc_cpu = non_spec_query_start_loc_cpu
-                prefill_state_indices = non_spec_state_indices_tensor
-
-            if self.gdn_prefill_backend == "cutedsl":
-                from vllm.model_executor.layers.mamba.ops.gdn_chunk_cutedsl import (
-                    prepare_metadata_cutedsl,
-                )
-
-                assert prefill_query_start_loc is not None
-                assert prefill_query_start_loc_cpu is not None
-                total_tokens = int(prefill_query_start_loc_cpu[-1].item())
-                chunk_indices, chunk_offsets = prepare_metadata_cutedsl(
-                    prefill_query_start_loc,
-                    total_tokens,
-                    FLA_CHUNK_SIZE,
-                )
-            else:
-                gpu_device = query_start_loc.device
-                # Only prefill batches use FLA chunk ops.
-                # Pre-compute on CPU and async-copy to GPU to avoid
-                # GPU→CPU sync (.tolist()) in prepare_chunk_indices.
-                from vllm.model_executor.layers.fla.ops.index import (
-                    prepare_chunk_indices,
-                    prepare_chunk_offsets,
-                )
-
-                assert prefill_query_start_loc_cpu is not None
-                chunk_indices = prepare_chunk_indices(prefill_query_start_loc_cpu, FLA_CHUNK_SIZE).to(
-                    device=gpu_device, non_blocking=True
-                )
-                chunk_offsets = prepare_chunk_offsets(prefill_query_start_loc_cpu, FLA_CHUNK_SIZE).to(
-                    device=gpu_device, non_blocking=True
-                )
-
-        if num_prefills > 0:
-            assert non_spec_query_start_loc_cpu is not None
-            # 310P RC: compute has_initial_state on CPU, single H2D upload.
-            if m._seq_lens_cpu is not None:
-                context_lens_cpu = m._seq_lens_cpu
-            elif m.seq_lens_cpu is not None:
-                context_lens_cpu = m.seq_lens_cpu
-            else:
-                context_lens_cpu = context_lens_tensor.detach().cpu()
-
-            has_initial_state_cpu = context_lens_cpu > 0
-            if spec_sequence_masks_cpu is not None:
-                has_initial_state_cpu = has_initial_state_cpu[~spec_sequence_masks_cpu]
-
-            has_initial_state = has_initial_state_cpu.to(
-                query_start_loc.device,
-                non_blocking=True,
-            )
-            nums_dict, batch_ptr, token_chunk_offset_ptr = attn_backend_utils.compute_causal_conv1d_metadata(
-                non_spec_query_start_loc_cpu,
-                device=query_start_loc.device,
-            )
-            if spec_sequence_masks is None and num_decodes > 0:
-                prefill_has_initial_state = has_initial_state[num_decodes:]
-            else:
-                prefill_has_initial_state = has_initial_state
-        else:
-            has_initial_state = None
-
-        # Function code counted on either presency non-spec decode or spec decode,
-        # but not both.
-        assert not (num_decodes > 0 and num_spec_decodes > 0), (
-            f"num_decodes: {num_decodes}, num_spec_decodes: {num_spec_decodes}"
+        has_initial_state = has_initial_state_cpu.to(
+            query_start_loc.device,
+            non_blocking=True,
         )
-
-        # Prepare tensors for cudagraph
-        # Note: m.num_actual_tokens is already padded by the model runner for CUDAGraph
-        batch_size = m.num_actual_tokens
-
-        if (
-            self.use_full_cuda_graph
-            and num_prefills == 0
-            and num_decodes == 0
-            and num_spec_decodes <= self.decode_cudagraph_max_bs
-            and num_spec_decode_tokens <= self.decode_cudagraph_max_bs
-        ):
-            assert spec_sequence_masks is not None
-            self.spec_state_indices_tensor[:num_spec_decodes].copy_(spec_state_indices_tensor, non_blocking=True)
-            spec_state_indices_tensor = self.spec_state_indices_tensor[:batch_size]
-            spec_state_indices_tensor[num_spec_decodes:].fill_(NULL_BLOCK_ID)
-
-            self.spec_sequence_masks[:num_spec_decodes].copy_(spec_sequence_masks[:num_spec_decodes], non_blocking=True)
-            spec_sequence_masks = self.spec_sequence_masks[:batch_size]
-            spec_sequence_masks[num_spec_decodes:].fill_(False)
-
-            assert non_spec_token_indx is not None and spec_token_indx is not None
-            self.non_spec_token_indx[: non_spec_token_indx.size(0)].copy_(non_spec_token_indx, non_blocking=True)
-            non_spec_token_indx = self.non_spec_token_indx[: non_spec_token_indx.size(0)]
-
-            self.spec_token_indx[: spec_token_indx.size(0)].copy_(spec_token_indx, non_blocking=True)
-            spec_token_indx = self.spec_token_indx[: spec_token_indx.size(0)]
-
-            self.spec_query_start_loc[: num_spec_decodes + 1].copy_(spec_query_start_loc, non_blocking=True)
-            spec_num_query_tokens = spec_query_start_loc[-1]  # type: ignore[index]
-            spec_query_start_loc = self.spec_query_start_loc[: batch_size + 1]
-            spec_query_start_loc[num_spec_decodes + 1 :].fill_(spec_num_query_tokens)
-
-            self.num_accepted_tokens[:num_spec_decodes].copy_(num_accepted_tokens, non_blocking=True)
-            num_accepted_tokens = self.num_accepted_tokens[:batch_size]
-            num_accepted_tokens[num_spec_decodes:].fill_(1)
-
-        if (
-            self.use_full_cuda_graph
-            and num_prefills == 0
-            and num_spec_decodes == 0
-            and num_decodes <= self.decode_cudagraph_max_bs
-        ):
-            self.non_spec_state_indices_tensor[:num_decodes].copy_(non_spec_state_indices_tensor, non_blocking=True)
-            non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[:batch_size]
-            non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
-
-            self.non_spec_query_start_loc[: num_decodes + 1].copy_(non_spec_query_start_loc, non_blocking=True)
-            non_spec_num_query_tokens = non_spec_query_start_loc[-1]  # type: ignore[index]
-            non_spec_query_start_loc = self.non_spec_query_start_loc[: batch_size + 1]
-            non_spec_query_start_loc[num_decodes + 1 :].fill_(non_spec_num_query_tokens)
-
-        attn_metadata = GDNAttentionMetadata(
-            num_prefills=num_prefills,
-            num_prefill_tokens=num_prefill_tokens,
-            num_decodes=num_decodes,
-            num_decode_tokens=num_decode_tokens,
-            num_spec_decodes=num_spec_decodes,
-            num_spec_decode_tokens=num_spec_decode_tokens,
-            num_actual_tokens=m.num_actual_tokens,
-            has_initial_state=has_initial_state,
-            chunk_indices=chunk_indices,
-            chunk_offsets=chunk_offsets,
-            prefill_query_start_loc=prefill_query_start_loc,
-            prefill_state_indices=prefill_state_indices,
-            prefill_has_initial_state=prefill_has_initial_state,
-            spec_query_start_loc=spec_query_start_loc,
-            non_spec_query_start_loc=non_spec_query_start_loc,
-            spec_state_indices_tensor=spec_state_indices_tensor,
-            non_spec_state_indices_tensor=non_spec_state_indices_tensor,
-            spec_sequence_masks=spec_sequence_masks,
-            spec_token_indx=spec_token_indx,
-            non_spec_token_indx=non_spec_token_indx,
-            num_accepted_tokens=num_accepted_tokens,
-            nums_dict=nums_dict,
-            batch_ptr=batch_ptr,
-            token_chunk_offset_ptr=token_chunk_offset_ptr,
+        nums_dict, batch_ptr, token_chunk_offset_ptr = compute_causal_conv1d_metadata(
+            non_spec_query_start_loc_cpu,
+            device=query_start_loc.device,
         )
+        return has_initial_state, nums_dict, batch_ptr, token_chunk_offset_ptr
+
+    def _attach_non_spec_prefill_fallback_meta(
+        self,
+        attn_metadata: GDNAttentionMetadata,
+        common_attn_metadata: CommonAttentionMetadata,
+        non_spec_query_start_loc_cpu: torch.Tensor | None,
+    ) -> GDNAttentionMetadata:
+        del common_attn_metadata, non_spec_query_start_loc_cpu
+        return attn_metadata
+
+    def _attach_spec_decode_fallback_meta(
+        self,
+        attn_metadata: GDNAttentionMetadata,
+        common_attn_metadata: CommonAttentionMetadata,
+        num_decode_draft_tokens_cpu: torch.Tensor | None,
+    ) -> GDNAttentionMetadata:
+        del common_attn_metadata, num_decode_draft_tokens_cpu
+        return attn_metadata
+
+    def _attach_non_spec_decode_fallback_meta(
+        self,
+        attn_metadata: GDNAttentionMetadata,
+        common_attn_metadata: CommonAttentionMetadata,
+        num_decode_draft_tokens_cpu: torch.Tensor | None,
+    ) -> GDNAttentionMetadata:
+        del common_attn_metadata, num_decode_draft_tokens_cpu
         return attn_metadata

--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -15,7 +15,6 @@
 # This file is a part of the vllm-ascend project.
 #
 import gc
-import subprocess
 
 import psutil
 import torch
@@ -26,23 +25,8 @@ from vllm.utils.mem_utils import MemorySnapshot, memory_profiling
 from vllm.utils.torch_utils import set_random_seed  # noqa: E402
 
 from vllm_ascend._310p.model_runner_310p import NPUModelRunner310
+from vllm_ascend.utils import is_rc_device
 from vllm_ascend.worker.worker import NPUWorker, init_workspace_manager
-
-_IS_RC_DEVICE: bool | None = None
-
-
-def _is_rc_device() -> bool:
-    global _IS_RC_DEVICE
-    if _IS_RC_DEVICE is None:
-        try:
-            # Use lspci to detect if the device is in RC mode.
-            # In EP mode, "accelerators" typically appears in the output.
-            result = subprocess.run(["lspci"], capture_output=True, text=True, check=True)
-            _IS_RC_DEVICE = not any("accelerators" in line.strip() for line in result.stdout.splitlines())
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            # Fallback to False if lspci is unavailable or fails.
-            _IS_RC_DEVICE = False
-    return _IS_RC_DEVICE
 
 
 class NPUWorker310(NPUWorker):
@@ -96,7 +80,7 @@ class NPUWorker310(NPUWorker):
             free_memory, total_memory = torch.npu.mem_get_info()
             # The host memory or device memory for RC devices refers to the available portion of memory
             # which cannot be obtained via torch.npu.mem_get_info()
-            if _is_rc_device():
+            if is_rc_device():
                 free_memory = psutil.virtual_memory().available
             torch_memory = torch.npu.memory_reserved()
             non_torch_memory_before_empty_cache = total_memory - free_memory - torch_memory
@@ -122,7 +106,7 @@ class NPUWorker310(NPUWorker):
         # Therefore, the space available for allocating KV cache and Mamba cache needs to be calculated
         # based on the already occupied space of the system memory.
 
-        if _is_rc_device():
+        if is_rc_device():
             self.available_kv_cache_memory_bytes = (self.requested_memory - psutil.virtual_memory().used) // 2
         else:
             self.available_kv_cache_memory_bytes = (
@@ -155,7 +139,7 @@ class NPUWorker310(NPUWorker):
         # take current memory snapshot
         self.init_snapshot = MemorySnapshot()
         self.requested_memory = self.init_snapshot.total_memory * self.cache_config.gpu_memory_utilization
-        if _is_rc_device():
+        if is_rc_device():
             self.init_snapshot.free_memory = psutil.virtual_memory().available
             logger.info_once("Root Complex (RC) mode: host and device memory are shared.")
         if self.init_snapshot.free_memory < self.requested_memory:

--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -1134,18 +1134,16 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
             ).to(device=gpu_device, non_blocking=True)
 
         if num_prefills > 0:
-            has_initial_state = context_lens_tensor > 0
-            if spec_sequence_masks_cpu is not None:
-                assert non_spec_sequence_indices is not None
-                has_initial_state = torch.index_select(
-                    has_initial_state,
-                    0,
-                    non_spec_sequence_indices,
+            has_initial_state, nums_dict, batch_ptr, token_chunk_offset_ptr = (
+                self._build_prefill_has_initial_state_and_causal_conv1d_meta(
+                    common_attn_metadata=m,
+                    context_lens_tensor=context_lens_tensor,
+                    num_prefills=num_prefills,
+                    spec_sequence_masks_cpu=spec_sequence_masks_cpu,
+                    non_spec_sequence_indices=non_spec_sequence_indices,
+                    non_spec_query_start_loc_cpu=non_spec_query_start_loc_cpu,
+                    query_start_loc=query_start_loc,
                 )
-                assert non_spec_query_start_loc_cpu is not None
-            nums_dict, batch_ptr, token_chunk_offset_ptr = compute_causal_conv1d_metadata(
-                non_spec_query_start_loc_cpu,
-                device=query_start_loc.device,
             )
         else:
             has_initial_state = None
@@ -1267,6 +1265,38 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
             common_attn_metadata,
             num_decode_draft_tokens_cpu,
         )
+
+    def _build_prefill_has_initial_state_and_causal_conv1d_meta(
+        self,
+        *,
+        common_attn_metadata: CommonAttentionMetadata,
+        context_lens_tensor: torch.Tensor,
+        num_prefills: int,
+        spec_sequence_masks_cpu: torch.Tensor | None,
+        non_spec_sequence_indices: torch.Tensor | None,
+        non_spec_query_start_loc_cpu: torch.Tensor | None,
+        query_start_loc: torch.Tensor,
+    ) -> tuple[
+        torch.Tensor | None,
+        dict[int, dict[str, object]] | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+    ]:
+        del common_attn_metadata, num_prefills
+        has_initial_state = context_lens_tensor > 0
+        if spec_sequence_masks_cpu is not None:
+            assert non_spec_sequence_indices is not None
+            has_initial_state = torch.index_select(
+                has_initial_state,
+                0,
+                non_spec_sequence_indices,
+            )
+            assert non_spec_query_start_loc_cpu is not None
+        nums_dict, batch_ptr, token_chunk_offset_ptr = compute_causal_conv1d_metadata(
+            non_spec_query_start_loc_cpu,
+            device=query_start_loc.device,
+        )
+        return has_initial_state, nums_dict, batch_ptr, token_chunk_offset_ptr
 
 
 class AscendGDNAttentionBackend(GDNAttentionBackend):

--- a/vllm_ascend/patch/worker/patch_idex_310.py
+++ b/vllm_ascend/patch/worker/patch_idex_310.py
@@ -1,44 +1,1 @@
-import vllm
-import vllm.v1.attention.backends.utils as attn_backend_utils
-from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import QwenGatedDeltaNetAttention
-
-import vllm_ascend.ops.gdn as gdn_ops
-from vllm_ascend._310p.ops.fla.cumpute_causal_conv1d_metadata_310 import compute_causal_conv1d_metadata
-from vllm_ascend._310p.ops.fla.gdn_310 import (
-    AscendGatedDeltaNetAttention310,
-    update_conv1d_graph_params_310p,
-)
-from vllm_ascend._310p.ops.fla.idex import (
-    prepare_chunk_indices_310,
-    prepare_chunk_offsets_310,
-)
-from vllm_ascend._310p.ops.gdn_attn_builder_310 import AscendGDNAttentionMetadataBuilder310
-from vllm_ascend._310p.spec_decode.llm_base_proposer_310 import AscendSpecDecodeBaseProposer310
-from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionBackend
-from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
-
-vllm.model_executor.layers.fla.ops.index.prepare_chunk_indices = prepare_chunk_indices_310
-
-vllm.model_executor.layers.fla.ops.index.prepare_chunk_offsets = prepare_chunk_offsets_310
-
-# 310P RC: avoid device fill_/torch.full in compute_causal_conv1d_metadata.
-attn_backend_utils.compute_causal_conv1d_metadata = compute_causal_conv1d_metadata
-
-AscendGDNAttentionBackend.get_builder_cls = staticmethod(  # type: ignore[method-assign]
-    lambda: AscendGDNAttentionMetadataBuilder310
-)
-
-# 310P GDN causal conv1d uses buffer_replay; keep shared gdn.py unchanged.
-gdn_ops.update_conv1d_graph_params = update_conv1d_graph_params_310p
-
-# 310P: skip NPU index_fill_ when there are no discarded requests.
-AscendSpecDecodeBaseProposer.prepare_next_token_ids_padded = (  # type: ignore[method-assign]
-    AscendSpecDecodeBaseProposer310.prepare_next_token_ids_padded
-)
-
-# Patch _warmup_prefill_kernels to no-op on 310P: triton.next_power_of_2 does
-# not exist in the triton version used on 310P CI, and NPU does not use these
-# CUDA warmup kernel anyway.
-QwenGatedDeltaNetAttention._warmup_prefill_kernels = lambda self, qkv_or_qkvz, v_dim: None  # type: ignore[method-assign]
-QwenGatedDeltaNetAttention._forward_core = AscendGatedDeltaNetAttention310._forward_core
-QwenGatedDeltaNetAttention.get_state_dtype = AscendGatedDeltaNetAttention310.get_state_dtype
+import vllmimport vllm.v1.attention.backends.utils as attn_backend_utilsfrom vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import QwenGatedDeltaNetAttentionfrom vllm.v1.attention.backends.gdn_attn import GDNAttentionBackendimport vllm_ascend.ops.gdn as gdn_opsfrom vllm_ascend._310p.ops.fla.cumpute_causal_conv1d_metadata_310 import compute_causal_conv1d_metadatafrom vllm_ascend._310p.ops.fla.gdn_310 import (    AscendGatedDeltaNetAttention310,    update_conv1d_graph_params_310p,)from vllm_ascend._310p.ops.fla.idex import (    prepare_chunk_indices_310,    prepare_chunk_offsets_310,)from vllm_ascend._310p.ops.gdn_attn_builder_310 import GDNAttentionMetadataBuilder310from vllm_ascend._310p.spec_decode.llm_base_proposer_310 import AscendSpecDecodeBaseProposer310from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposervllm.model_executor.layers.fla.ops.index.prepare_chunk_indices = prepare_chunk_indices_310vllm.model_executor.layers.fla.ops.index.prepare_chunk_offsets = prepare_chunk_offsets_310# 310P RC: avoid device fill_/torch.full in compute_causal_conv1d_metadata.attn_backend_utils.compute_causal_conv1d_metadata = compute_causal_conv1d_metadata# Qwen3.5 on 310P uses upstream GDNAttentionBackend via MambaBase.get_attn_backend().GDNAttentionBackend.get_builder_cls = staticmethod(  # type: ignore[method-assign]    lambda: GDNAttentionMetadataBuilder310)# 310P GDN causal conv1d uses buffer_replay; keep shared gdn.py unchanged.gdn_ops.update_conv1d_graph_params = update_conv1d_graph_params_310p# 310P: skip NPU index_fill_ when there are no discarded requests.AscendSpecDecodeBaseProposer.prepare_next_token_ids_padded = (  # type: ignore[method-assign]    AscendSpecDecodeBaseProposer310.prepare_next_token_ids_padded)# Patch _warmup_prefill_kernels to no-op on 310P: triton.next_power_of_2 does# not exist in the triton version used on 310P CI, and NPU does not use these# CUDA warmup kernel anyway.QwenGatedDeltaNetAttention._warmup_prefill_kernels = lambda self, qkv_or_qkvz, v_dim: None  # type: ignore[method-assign]QwenGatedDeltaNetAttention._forward_core = AscendGatedDeltaNetAttention310._forward_coreQwenGatedDeltaNetAttention.get_state_dtype = AscendGatedDeltaNetAttention310.get_state_dtype

--- a/vllm_ascend/patch/worker/patch_idex_310.py
+++ b/vllm_ascend/patch/worker/patch_idex_310.py
@@ -1,1 +1,61 @@
-import vllmimport vllm.v1.attention.backends.utils as attn_backend_utilsfrom vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import QwenGatedDeltaNetAttentionfrom vllm.v1.attention.backends.gdn_attn import GDNAttentionBackendimport vllm_ascend.ops.gdn as gdn_opsfrom vllm_ascend._310p.ops.fla.cumpute_causal_conv1d_metadata_310 import compute_causal_conv1d_metadatafrom vllm_ascend._310p.ops.fla.gdn_310 import (    AscendGatedDeltaNetAttention310,    update_conv1d_graph_params_310p,)from vllm_ascend._310p.ops.fla.idex import (    prepare_chunk_indices_310,    prepare_chunk_offsets_310,)from vllm_ascend._310p.ops.gdn_attn_builder_310 import GDNAttentionMetadataBuilder310from vllm_ascend._310p.spec_decode.llm_base_proposer_310 import AscendSpecDecodeBaseProposer310from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposervllm.model_executor.layers.fla.ops.index.prepare_chunk_indices = prepare_chunk_indices_310vllm.model_executor.layers.fla.ops.index.prepare_chunk_offsets = prepare_chunk_offsets_310# 310P RC: avoid device fill_/torch.full in compute_causal_conv1d_metadata.attn_backend_utils.compute_causal_conv1d_metadata = compute_causal_conv1d_metadata# Qwen3.5 on 310P uses upstream GDNAttentionBackend via MambaBase.get_attn_backend().GDNAttentionBackend.get_builder_cls = staticmethod(  # type: ignore[method-assign]    lambda: GDNAttentionMetadataBuilder310)# 310P GDN causal conv1d uses buffer_replay; keep shared gdn.py unchanged.gdn_ops.update_conv1d_graph_params = update_conv1d_graph_params_310p# 310P: skip NPU index_fill_ when there are no discarded requests.AscendSpecDecodeBaseProposer.prepare_next_token_ids_padded = (  # type: ignore[method-assign]    AscendSpecDecodeBaseProposer310.prepare_next_token_ids_padded)# Patch _warmup_prefill_kernels to no-op on 310P: triton.next_power_of_2 does# not exist in the triton version used on 310P CI, and NPU does not use these# CUDA warmup kernel anyway.QwenGatedDeltaNetAttention._warmup_prefill_kernels = lambda self, qkv_or_qkvz, v_dim: None  # type: ignore[method-assign]QwenGatedDeltaNetAttention._forward_core = AscendGatedDeltaNetAttention310._forward_coreQwenGatedDeltaNetAttention.get_state_dtype = AscendGatedDeltaNetAttention310.get_state_dtype
+import vllm
+import vllm.v1.attention.backends.utils as attn_backend_utils
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import QwenGatedDeltaNetAttention
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionBackend
+
+import vllm_ascend.ops.gdn as gdn_ops
+from vllm_ascend._310p.ops.fla.cumpute_causal_conv1d_metadata_310 import compute_causal_conv1d_metadata
+from vllm_ascend._310p.ops.fla.gdn_310 import (
+    AscendGatedDeltaNetAttention310,
+    update_conv1d_graph_params_310p,
+)
+from vllm_ascend._310p.ops.fla.idex import (
+    prepare_chunk_indices_310,
+    prepare_chunk_offsets_310,
+)
+from vllm_ascend._310p.ops.gdn_attn_builder_310 import GDNAttentionMetadataBuilder310
+from vllm_ascend._310p.spec_decode.llm_base_proposer_310 import AscendSpecDecodeBaseProposer310
+from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
+
+vllm.model_executor.layers.fla.ops.index.prepare_chunk_indices = prepare_chunk_indices_310
+
+
+vllm.model_executor.layers.fla.ops.index.prepare_chunk_offsets = prepare_chunk_offsets_310
+
+
+# 310P RC: avoid device fill_/torch.full in compute_causal_conv1d_metadata.
+
+attn_backend_utils.compute_causal_conv1d_metadata = compute_causal_conv1d_metadata
+
+
+
+# Qwen3.5 on 310P uses upstream GDNAttentionBackend via MambaBase.get_attn_backend().
+
+GDNAttentionBackend.get_builder_cls = staticmethod(  # type: ignore[method-assign]
+    lambda: GDNAttentionMetadataBuilder310
+)
+
+
+# 310P GDN causal conv1d uses buffer_replay; keep shared gdn.py unchanged.
+
+gdn_ops.update_conv1d_graph_params = update_conv1d_graph_params_310p
+
+
+# 310P: skip NPU index_fill_ when there are no discarded requests.
+
+AscendSpecDecodeBaseProposer.prepare_next_token_ids_padded = (  # type: ignore[method-assign]
+    AscendSpecDecodeBaseProposer310.prepare_next_token_ids_padded
+)
+
+
+# Patch _warmup_prefill_kernels to no-op on 310P: triton.next_power_of_2 does
+
+# not exist in the triton version used on 310P CI, and NPU does not use these
+
+# CUDA warmup kernel anyway.
+
+QwenGatedDeltaNetAttention._warmup_prefill_kernels = lambda self, qkv_or_qkvz, v_dim: None  # type: ignore[method-assign]
+
+QwenGatedDeltaNetAttention._forward_core = AscendGatedDeltaNetAttention310._forward_core
+
+QwenGatedDeltaNetAttention.get_state_dtype = AscendGatedDeltaNetAttention310.get_state_dtype

--- a/vllm_ascend/patch/worker/patch_idex_310.py
+++ b/vllm_ascend/patch/worker/patch_idex_310.py
@@ -28,7 +28,6 @@ vllm.model_executor.layers.fla.ops.index.prepare_chunk_offsets = prepare_chunk_o
 attn_backend_utils.compute_causal_conv1d_metadata = compute_causal_conv1d_metadata
 
 
-
 # Qwen3.5 on 310P uses upstream GDNAttentionBackend via MambaBase.get_attn_backend().
 
 GDNAttentionBackend.get_builder_cls = staticmethod(  # type: ignore[method-assign]

--- a/vllm_ascend/patch/worker/patch_idex_310.py
+++ b/vllm_ascend/patch/worker/patch_idex_310.py
@@ -1,7 +1,9 @@
 import vllm
+import vllm.v1.attention.backends.utils as attn_backend_utils
 from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import QwenGatedDeltaNetAttention
 
 import vllm_ascend.ops.gdn as gdn_ops
+from vllm_ascend._310p.ops.fla.cumpute_causal_conv1d_metadata_310 import compute_causal_conv1d_metadata
 from vllm_ascend._310p.ops.fla.gdn_310 import (
     AscendGatedDeltaNetAttention310,
     update_conv1d_graph_params_310p,
@@ -10,12 +12,21 @@ from vllm_ascend._310p.ops.fla.idex import (
     prepare_chunk_indices_310,
     prepare_chunk_offsets_310,
 )
+from vllm_ascend._310p.ops.gdn_attn_builder_310 import AscendGDNAttentionMetadataBuilder310
 from vllm_ascend._310p.spec_decode.llm_base_proposer_310 import AscendSpecDecodeBaseProposer310
+from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionBackend
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
 
 vllm.model_executor.layers.fla.ops.index.prepare_chunk_indices = prepare_chunk_indices_310
 
 vllm.model_executor.layers.fla.ops.index.prepare_chunk_offsets = prepare_chunk_offsets_310
+
+# 310P RC: avoid device fill_/torch.full in compute_causal_conv1d_metadata.
+attn_backend_utils.compute_causal_conv1d_metadata = compute_causal_conv1d_metadata
+
+AscendGDNAttentionBackend.get_builder_cls = staticmethod(  # type: ignore[method-assign]
+    lambda: AscendGDNAttentionMetadataBuilder310
+)
 
 # 310P GDN causal conv1d uses buffer_replay; keep shared gdn.py unchanged.
 gdn_ops.update_conv1d_graph_params = update_conv1d_graph_params_310p

--- a/vllm_ascend/patch/worker/patch_idex_310.py
+++ b/vllm_ascend/patch/worker/patch_idex_310.py
@@ -1,10 +1,7 @@
 import vllm
-import vllm.v1.attention.backends.utils as attn_backend_utils
 from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import QwenGatedDeltaNetAttention
-from vllm.v1.attention.backends.gdn_attn import GDNAttentionBackend
 
 import vllm_ascend.ops.gdn as gdn_ops
-from vllm_ascend._310p.ops.fla.cumpute_causal_conv1d_metadata_310 import compute_causal_conv1d_metadata
 from vllm_ascend._310p.ops.fla.gdn_310 import (
     AscendGatedDeltaNetAttention310,
     update_conv1d_graph_params_310p,
@@ -13,48 +10,35 @@ from vllm_ascend._310p.ops.fla.idex import (
     prepare_chunk_indices_310,
     prepare_chunk_offsets_310,
 )
-from vllm_ascend._310p.ops.gdn_attn_builder_310 import GDNAttentionMetadataBuilder310
 from vllm_ascend._310p.spec_decode.llm_base_proposer_310 import AscendSpecDecodeBaseProposer310
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
+from vllm_ascend.utils import is_rc_device
 
 vllm.model_executor.layers.fla.ops.index.prepare_chunk_indices = prepare_chunk_indices_310
 
-
 vllm.model_executor.layers.fla.ops.index.prepare_chunk_offsets = prepare_chunk_offsets_310
 
-
-# 310P RC: avoid device fill_/torch.full in compute_causal_conv1d_metadata.
-
-attn_backend_utils.compute_causal_conv1d_metadata = compute_causal_conv1d_metadata
-
-
-# Qwen3.5 on 310P uses upstream GDNAttentionBackend via MambaBase.get_attn_backend().
-
-GDNAttentionBackend.get_builder_cls = staticmethod(  # type: ignore[method-assign]
-    lambda: GDNAttentionMetadataBuilder310
-)
-
-
 # 310P GDN causal conv1d uses buffer_replay; keep shared gdn.py unchanged.
-
 gdn_ops.update_conv1d_graph_params = update_conv1d_graph_params_310p
 
-
 # 310P: skip NPU index_fill_ when there are no discarded requests.
-
 AscendSpecDecodeBaseProposer.prepare_next_token_ids_padded = (  # type: ignore[method-assign]
     AscendSpecDecodeBaseProposer310.prepare_next_token_ids_padded
 )
 
-
 # Patch _warmup_prefill_kernels to no-op on 310P: triton.next_power_of_2 does
-
 # not exist in the triton version used on 310P CI, and NPU does not use these
-
 # CUDA warmup kernel anyway.
-
 QwenGatedDeltaNetAttention._warmup_prefill_kernels = lambda self, qkv_or_qkvz, v_dim: None  # type: ignore[method-assign]
-
 QwenGatedDeltaNetAttention._forward_core = AscendGatedDeltaNetAttention310._forward_core
-
 QwenGatedDeltaNetAttention.get_state_dtype = AscendGatedDeltaNetAttention310.get_state_dtype
+
+if is_rc_device():
+    from vllm.v1.attention.backends.gdn_attn import GDNAttentionBackend
+
+    from vllm_ascend._310p.ops.gdn_attn_builder_310 import GDNAttentionMetadataBuilder310
+
+    # Qwen3.5 on 310P RC uses upstream GDNAttentionBackend via MambaBase.get_attn_backend().
+    GDNAttentionBackend.get_builder_cls = staticmethod(  # type: ignore[method-assign]
+        lambda: GDNAttentionMetadataBuilder310
+    )

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -123,6 +123,32 @@ def is_310p():
     return get_ascend_device_type() == AscendDeviceType._310P
 
 
+_IS_RC_DEVICE: bool | None = None
+
+
+def is_rc_device() -> bool:
+    """Return True if the 310P NPU runs in Root Complex (RC) mode.
+
+    RC mode (e.g. Atlas 200I Pro): host and NPU share memory. EP mode
+    (e.g. Atlas 300I DUO on PCIe): ``lspci`` output typically contains
+    ``accelerators``.
+    """
+    global _IS_RC_DEVICE
+    if not is_310p():
+        return False
+    if _IS_RC_DEVICE is not None:
+        return _IS_RC_DEVICE
+
+    try:
+        import subprocess
+
+        result = subprocess.run(["lspci"], capture_output=True, text=True, check=True)
+        _IS_RC_DEVICE = not any("accelerators" in line.strip() for line in result.stdout.splitlines())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        _IS_RC_DEVICE = False
+    return _IS_RC_DEVICE
+
+
 def is_950():
     return get_ascend_device_type() == AscendDeviceType.A5
 


### PR DESCRIPTION
### What this PR does / why we need it?
Bug Fix: Resolved an inference error related to 310P RC aclgraph by adjusting input preparation and metadata handling.
Metadata Builder: Introduced AscendGDNAttentionMetadataBuilder310 to handle RC-safe prefill metadata during the build process.
Ops Optimization: Added compute_causal_conv1d_metadata to avoid device-side fill_ and torch.full operations, improving compatibility and performance.
Patch Integration: Updated patch_idex_310.py to inject the new metadata builder and override the causal conv1d metadata computation for 310P.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/b9a7cd464c9ae9b1b450f8982b76d7be4de73724
