### PR TITLE
[Bugfix] fix fa3 and batch_invariance to use 'PIECEWISE' in the doc

### DIFF
--- a/docs/source/user_guide/feature_guide/batch_invariance.md
+++ b/docs/source/user_guide/feature_guide/batch_invariance.md
@@ -43,7 +43,8 @@ export VLLM_BATCH_INVARIANT=1
 To start a vLLM server with batch invariance enabled:
 
 ```bash
-VLLM_BATCH_INVARIANT=1 vllm serve Qwen/Qwen3-8B --enforce-eager
+VLLM_BATCH_INVARIANT=1 vllm serve Qwen/Qwen3-8B \
+  --compilation-config '{"cudagraph_mode": "PIECEWISE"}'
 ```
 
 Then use the OpenAI-compatible client:
@@ -94,7 +95,7 @@ sampling_params = SamplingParams(
 llm = LLM(
     model="Qwen/Qwen3-8B",
     tensor_parallel_size=1,
-    enforce_eager=True,
+    compilation_config={"cudagraph_mode": "PIECEWISE"},
 )
 
 # Outputs will be deterministic regardless of batch size

--- a/docs/source/user_guide/feature_guide/batch_invariance.md
+++ b/docs/source/user_guide/feature_guide/batch_invariance.md
@@ -43,7 +43,7 @@ export VLLM_BATCH_INVARIANT=1
 To start a vLLM server with batch invariance enabled:
 
 ```bash
-VLLM_BATCH_INVARIANT=1 vllm serve Qwen/Qwen3-8B
+VLLM_BATCH_INVARIANT=1 vllm serve Qwen/Qwen3-8B --enforce-eager
 ```
 
 Then use the OpenAI-compatible client:
@@ -94,6 +94,7 @@ sampling_params = SamplingParams(
 llm = LLM(
     model="Qwen/Qwen3-8B",
     tensor_parallel_size=1,
+    enforce_eager=True,
 )
 
 # Outputs will be deterministic regardless of batch size

--- a/docs/source/user_guide/feature_guide/flash_attention.md
+++ b/docs/source/user_guide/feature_guide/flash_attention.md
@@ -67,7 +67,7 @@ To enable FA3, you need to:
 To start a vLLM server with FA3 enabled:
 
 ```bash
-VLLM_BATCH_INVARIANT=1 vllm serve Qwen/Qwen3-8B --attention-backend FLASH_ATTN
+VLLM_BATCH_INVARIANT=1 vllm serve Qwen/Qwen3-8B --attention-backend FLASH_ATTN --enforce-eager
 ```
 
 Then use the OpenAI-compatible client:
@@ -117,6 +117,7 @@ llm = LLM(
     model="Qwen/Qwen3-8B",
     tensor_parallel_size=1,
     attention_backend="FLASH_ATTN",
+    enforce_eager=True,
 )
 
 outputs = llm.generate(prompts, sampling_params)

--- a/docs/source/user_guide/feature_guide/flash_attention.md
+++ b/docs/source/user_guide/feature_guide/flash_attention.md
@@ -40,7 +40,7 @@ The following table compares the features of `flash_attn_with_kvcache` between G
 The `flash_attn_with_kvcache` interface on NPU is semantically consistent with the GPU FA3 version in terms of API parameters. The key differences are:
 
 1. **Unsupported features on NPU FA3**: Sliding window attention, RoPE, ALiBi, Softcapping, and FP8 quantization are not yet supported.
-2. **Graph capture**: The tiling of `flash_attn_with_kvcache` is processed on the host side and is currently being optimized. It does not support ACL graph capture (i.e., cannot be captured into a computational graph for acceleration). Please use `compilation_config=CompilationConfig(cudagraph_mode="PIECEWISE")` when enabling FA3.
+2. **Graph capture**: The tiling of `flash_attn_with_kvcache` is processed on the host side and is currently being optimized. It does not support ACL graph capture (i.e., cannot be captured into a computational graph for acceleration). Please use `compilation_config={"cudagraph_mode": "PIECEWISE"}` when enabling FA3.
 
 ## Hardware Requirements
 
@@ -135,7 +135,7 @@ for output in outputs:
 
 - **Package not yet open-sourced**: The `flash_attn_npu` package required for FA3 has not yet been released. External users cannot use FA3 until the package is available.
 - **Sliding window not supported**: FA3 does not support sliding window attention. Models that require sliding window need to use the default FIA backend.
-- **ACL graph capture not supported**: The tiling of `flash_attn_with_kvcache` is processed on the host side and currently does not support ACL graph capture. Please use `compilation_config=CompilationConfig(cudagraph_mode="PIECEWISE")` when enabling FA3.
+- **ACL graph capture not supported**: The tiling of `flash_attn_with_kvcache` is processed on the host side and currently does not support ACL graph capture. Please use `compilation_config={"cudagraph_mode": "PIECEWISE"}` when enabling FA3.
 - **RoPE not supported**: FA3 does not support rotary position embedding within the attention kernel. vLLM-Ascend patches this by using the PyTorch native RoPE fallback instead.
 - **ALiBi not supported**: FA3 does not support ALiBi (Attention with Linear Biases).
 - **Softcapping not supported**: FA3 does not support attention logit softcapping.

--- a/docs/source/user_guide/feature_guide/flash_attention.md
+++ b/docs/source/user_guide/feature_guide/flash_attention.md
@@ -40,7 +40,7 @@ The following table compares the features of `flash_attn_with_kvcache` between G
 The `flash_attn_with_kvcache` interface on NPU is semantically consistent with the GPU FA3 version in terms of API parameters. The key differences are:
 
 1. **Unsupported features on NPU FA3**: Sliding window attention, RoPE, ALiBi, Softcapping, and FP8 quantization are not yet supported.
-2. **Graph capture**: The tiling of `flash_attn_with_kvcache` is processed on the host side and is currently being optimized. It does not support ACL graph capture (i.e., cannot be captured into a computational graph for acceleration). Please use `enforce_eager=True` when enabling FA3.
+2. **Graph capture**: The tiling of `flash_attn_with_kvcache` is processed on the host side and is currently being optimized. It does not support ACL graph capture (i.e., cannot be captured into a computational graph for acceleration). Please use `compilation_config=CompilationConfig(cudagraph_mode="PIECEWISE")` when enabling FA3.
 
 ## Hardware Requirements
 
@@ -67,7 +67,9 @@ To enable FA3, you need to:
 To start a vLLM server with FA3 enabled:
 
 ```bash
-VLLM_BATCH_INVARIANT=1 vllm serve Qwen/Qwen3-8B --attention-backend FLASH_ATTN --enforce-eager
+VLLM_BATCH_INVARIANT=1 vllm serve Qwen/Qwen3-8B \
+  --attention-backend FLASH_ATTN \
+  --compilation-config '{"cudagraph_mode": "PIECEWISE"}'
 ```
 
 Then use the OpenAI-compatible client:
@@ -117,7 +119,7 @@ llm = LLM(
     model="Qwen/Qwen3-8B",
     tensor_parallel_size=1,
     attention_backend="FLASH_ATTN",
-    enforce_eager=True,
+    compilation_config={"cudagraph_mode": "PIECEWISE"},
 )
 
 outputs = llm.generate(prompts, sampling_params)
@@ -133,7 +135,7 @@ for output in outputs:
 
 - **Package not yet open-sourced**: The `flash_attn_npu` package required for FA3 has not yet been released. External users cannot use FA3 until the package is available.
 - **Sliding window not supported**: FA3 does not support sliding window attention. Models that require sliding window need to use the default FIA backend.
-- **ACL graph capture not supported**: The tiling of `flash_attn_with_kvcache` is processed on the host side and currently does not support ACL graph capture. Please use `enforce_eager=True` when enabling FA3.
+- **ACL graph capture not supported**: The tiling of `flash_attn_with_kvcache` is processed on the host side and currently does not support ACL graph capture. Please use `compilation_config=CompilationConfig(cudagraph_mode="PIECEWISE")` when enabling FA3.
 - **RoPE not supported**: FA3 does not support rotary position embedding within the attention kernel. vLLM-Ascend patches this by using the PyTorch native RoPE fallback instead.
 - **ALiBi not supported**: FA3 does not support ALiBi (Attention with Linear Biases).
 - **Softcapping not supported**: FA3 does not support attention logit softcapping.


### PR DESCRIPTION
### What this PR does / why we need it?
backport: #11144
fix flash_attention.md and batch_invariance.md to use 'PIECEWISE' in the doc

### Does this PR introduce _any_ user-facing change?'

fix flash_attention.md and batch_invariance.md to use 'PIECEWISE' in the doc

### How was this patch tested?


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
