### PR TITLE
[Doc][BugFix] Fix draft model config key

### DIFF
--- a/docs/source/user_guide/feature_guide/speculative_decoding.md
+++ b/docs/source/user_guide/feature_guide/speculative_decoding.md
@@ -237,7 +237,7 @@ The `extract_hidden_states` method is a special speculative decoding mode that d
                 speculative_config={
                     "method": "extract_hidden_states",
                     "num_speculative_tokens": 1,
-                    "draft_model_config": {
+                    "draft_model": {
                         "hf_config": {
                             # Layer indices to extract hidden states from
                             "eagle_aux_hidden_state_layer_ids": [2, 18, 34],


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes an incorrect config key in `speculative_decoding.md`.

The document used `draft_model_config`, but the valid key is `draft_model`. Using the wrong key prevents `hf_config.eagle_aux_hidden_state_layer_ids` from taking effect, so hidden states cannot be extracted as documented.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Documentation-only change.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
