### PR TITLE
[Feature] add Dspark for Qwen3

### DIFF
--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -93,6 +93,7 @@ def copy_and_expand_dflash_inputs_kernel_single_grid(
     total_input_tokens,  # tl.int32
     batch_size,  # tl.int32
     HAS_NUM_REJECTED: tl.constexpr = False,
+    IS_DSPARK: tl.constexpr = False,
 ):
     for req_idx in range(0, batch_size):
         ctx_start = tl.load(query_start_loc_ptr + req_idx)
@@ -136,5 +137,13 @@ def copy_and_expand_dflash_inputs_kernel_single_grid(
             else:
                 tl.store(out_input_ids_ptr + query_out_idx, parallel_drafting_token_id)
 
-                sample_out_idx = req_idx * num_speculative_tokens + (q_idx - 1)
+                # sample_out_idx = req_idx * num_speculative_tokens + (q_idx - 1)
+                # tl.store(out_token_indices_ptr + sample_out_idx, query_out_idx)
+
+            if IS_DSPARK:
+                sample_out_idx = req_idx * num_speculative_tokens + q_idx
                 tl.store(out_token_indices_ptr + sample_out_idx, query_out_idx)
+            else:
+                if q_idx > 0:
+                    sample_out_idx = req_idx * num_speculative_tokens + (q_idx - 1)
+                    tl.store(out_token_indices_ptr + sample_out_idx, query_out_idx)

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -37,6 +37,7 @@ import vllm_ascend.patch.platform.patch_weight_transfer_engine  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa
 import vllm_ascend.patch.platform.patch_tool_choice_none_content  # noqa
 import vllm_ascend.patch.platform.patch_mamba_manager  # noqa
+import vllm_ascend.patch.platform.patch_dspark_proposer  # noqa
 
 if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXPERT_MAP_RECORD", "false") == "true":
     import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa

--- a/vllm_ascend/patch/platform/patch_dspark_proposer.py
+++ b/vllm_ascend/patch/platform/patch_dspark_proposer.py
@@ -1,0 +1,101 @@
+import torch
+from torch import nn
+from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
+from vllm.model_executor.models.qwen3_dflash import DFlashQwen3Model
+from vllm.config import VllmConfig
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+
+
+ori_init_parallel_drafting_params = SpecDecodeBaseProposer._init_parallel_drafting_params
+def new_init_parallel_drafting_params(self):
+    model_hf_config = self.draft_model_config.hf_config
+    if hasattr(model_hf_config, "mask_token_id"):
+        self.parallel_drafting_token_id = model_hf_config.mask_token_id
+    else:
+        ori_init_parallel_drafting_params(self)
+
+SpecDecodeBaseProposer._init_parallel_drafting_params = new_init_parallel_drafting_params
+
+
+class DSparkConfidenceHead(nn.Module):
+    def __init__(self, vllm_config: VllmConfig, prefix: str) -> None:
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        rank = int(getattr(config, "dspark_markov_rank", 256))
+        self.proj = ReplicatedLinear(
+            config.hidden_size + rank,
+            1,
+            bias=False,
+            params_dtype=torch.float32,
+            quant_config=None,
+            prefix=f"{prefix}.proj",
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        markov_embeds: torch.Tensor,
+    ) -> torch.Tensor:
+        x = torch.cat([hidden_states, markov_embeds], dim=-1)
+        confidence = _linear_output(self.proj(x.float()))
+        return confidence.squeeze(-1)
+
+
+class DSparkMarkovHead(nn.Module):
+    def __init__(self, vllm_config: VllmConfig, prefix: str) -> None:
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        rank = int(getattr(config, "dspark_markov_rank", 256))
+        self.markov_w1 = VocabParallelEmbedding(
+            config.vocab_size,
+            rank,
+            prefix=f"{prefix}.markov_w1",
+        )
+        self.markov_w2 = ParallelLMHead(
+            config.vocab_size,
+            rank,
+            params_dtype=torch.float32,
+            org_num_embeddings=config.vocab_size,
+            prefix=f"{prefix}.markov_w2",
+        )
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+
+    def forward(self, token_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        embeds = self.markov_w1(token_ids)
+        logits = self.logits_processor(
+            self.markov_w2,
+            embeds.view(-1, embeds.shape[-1]).float(),
+        )
+        return logits.view(*embeds.shape[:-1], -1), embeds
+
+
+ori_init = DFlashQwen3Model._init
+
+def new_init(
+    self,
+    *,
+    vllm_config: VllmConfig,
+    start_layer_id: int = 0,
+    prefix: str = "",
+) -> None:
+    hf_config = vllm_config.speculative_config.draft_model_config.hf_config
+    if hasattr(hf_config, "markov_head_type"):
+        if not hasattr(hf_config, "dflash_config") or hf_config.dflash_config is None:
+            hf_config.dflash_config = {}
+            hf_config.dflash_config["target_layer_ids"] = hf_config.target_layer_ids
+    ori_init(
+        self,
+        vllm_config=vllm_config,
+        start_layer_id=start_layer_id,
+        prefix=prefix,
+    )
+    if hasattr(hf_config, "markov_head_type"):
+        self.markov_head = DSparkMarkovHead(vllm_config, prefix=f"{prefix}.markov_head")
+        self.confidence_head = DSparkConfidenceHead(vllm_config, prefix=f"{prefix}.confidence_head")
+
+DFlashQwen3Model._init = new_init

--- a/vllm_ascend/patch/platform/patch_dspark_proposer.py
+++ b/vllm_ascend/patch/platform/patch_dspark_proposer.py
@@ -26,11 +26,11 @@ class DSparkConfidenceHead(nn.Module):
     def __init__(self, vllm_config: VllmConfig, prefix: str) -> None:
         super().__init__()
         config = vllm_config.model_config.hf_config
-        rank = int(getattr(config, "dspark_markov_rank", 256))
+        rank = int(getattr(config, "markov_rank", getattr(config, "dspark_markov_rank", 256)))
         self.proj = ReplicatedLinear(
             config.hidden_size + rank,
             1,
-            bias=False,
+            bias=True,  # released dspark_qwen3_*_block7 ckpt has confidence_head.proj.bias
             params_dtype=torch.float32,
             quant_config=None,
             prefix=f"{prefix}.proj",
@@ -42,7 +42,7 @@ class DSparkConfidenceHead(nn.Module):
         markov_embeds: torch.Tensor,
     ) -> torch.Tensor:
         x = torch.cat([hidden_states, markov_embeds], dim=-1)
-        confidence = _linear_output(self.proj(x.float()))
+        confidence, _ = self.proj(x.float())  # ReplicatedLinear returns (output, bias)
         return confidence.squeeze(-1)
 
 
@@ -50,7 +50,7 @@ class DSparkMarkovHead(nn.Module):
     def __init__(self, vllm_config: VllmConfig, prefix: str) -> None:
         super().__init__()
         config = vllm_config.model_config.hf_config
-        rank = int(getattr(config, "dspark_markov_rank", 256))
+        rank = int(getattr(config, "markov_rank", getattr(config, "dspark_markov_rank", 256)))
         self.markov_w1 = VocabParallelEmbedding(
             config.vocab_size,
             rank,
@@ -74,7 +74,7 @@ class DSparkMarkovHead(nn.Module):
         return logits.view(*embeds.shape[:-1], -1), embeds
 
 
-ori_init = DFlashQwen3Model._init
+ori_init = DFlashQwen3Model.__init__
 
 def new_init(
     self,
@@ -98,4 +98,4 @@ def new_init(
         self.markov_head = DSparkMarkovHead(vllm_config, prefix=f"{prefix}.markov_head")
         self.confidence_head = DSparkConfidenceHead(vllm_config, prefix=f"{prefix}.confidence_head")
 
-DFlashQwen3Model._init = new_init
+DFlashQwen3Model.__init__ = new_init

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -66,6 +66,7 @@ class AscendDflashProposer(AscendEagleProposer):
         # PR allocated a fresh torch.empty and read a per-step-reassigned next_token_ids, so the
         # graph kept reading stale capture-time memory and accept length collapsed.
         hf_config = vllm_config.speculative_config.draft_model_config.hf_config
+        self._is_dspark = hasattr(hf_config, "markov_head_type")
         if hasattr(hf_config, "markov_head_type"):
             blk = 1 + self.num_speculative_tokens
             self._dspark_seed_buffer = torch.zeros(self.max_batch_size, dtype=torch.int64, device=device)
@@ -73,6 +74,11 @@ class AscendDflashProposer(AscendEagleProposer):
         else:
             self._dspark_seed_buffer = None
             self._dspark_draft_buffer = None
+
+    def _num_query_per_req(self) -> int:
+        # DFlash: anchor + K masks, samples mask positions.
+        # DSpark: anchor + K-1 masks, samples anchor plus mask positions.
+        return self.num_speculative_tokens if self._is_dspark else 1 + self.num_speculative_tokens
 
     def set_inputs_first_pass(
         self,
@@ -92,7 +98,8 @@ class AscendDflashProposer(AscendEagleProposer):
         # Q from query embeddings (bonus + mask tokens).
         batch_size = cad.num_reqs
         num_context = target_token_ids.shape[0]
-        num_query_per_req = 1 + self.num_speculative_tokens
+        num_query_per_req = self._num_query_per_req()
+        # num_query_per_req = 1 + self.num_speculative_tokens
         num_query_total = batch_size * num_query_per_req
 
         self._dflash_num_context = num_context
@@ -142,6 +149,7 @@ class AscendDflashProposer(AscendEagleProposer):
             total_input_tokens=num_context,
             batch_size=batch_size,
             HAS_NUM_REJECTED=has_num_rejected,
+            IS_DSPARK=self._is_dspark,
         )
 
         query_slot_mapping = self._slot_mapping_buffer[:num_query_total]
@@ -184,7 +192,12 @@ class AscendDflashProposer(AscendEagleProposer):
         is_profile=False,
         **kwargs,
     ) -> None:
-        num_query_tokens = min(num_tokens, self.max_query_tokens)
+        # num_query_tokens = min(num_tokens, self.max_query_tokens)
+        num_query_per_req = self._num_query_per_req()
+        num_query_total = num_reqs * num_query_per_req
+        num_query_tokens = min(
+            num_query_total if num_reqs > 0 else num_tokens,
+            self.max_query_tokens)
 
         (
             num_input_tokens,
@@ -194,8 +207,8 @@ class AscendDflashProposer(AscendEagleProposer):
 
         if not self.use_cuda_graph:
             aclgraph_runtime_mode = CUDAGraphMode.NONE
-        num_query_per_req = 1 + self.num_speculative_tokens
-        num_query_total = num_reqs * num_query_per_req
+        # num_query_per_req = 1 + self.num_speculative_tokens
+        # num_query_total = num_reqs * num_query_per_req
 
         context_positions = self._context_positions_buffer[:num_input_tokens]
         context_states = self.hidden_states[:num_input_tokens]

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -83,6 +83,8 @@ class AscendDflashProposer(AscendEagleProposer):
 
         self._dflash_num_context = num_context
         self._dflash_hidden_states[:num_context] = target_hidden_states
+        # [batch_size] prepare for dspark
+        self._next_token_ids = next_token_ids
 
         token_indices_to_sample = torch.empty(
             batch_size * self.num_speculative_tokens,

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -60,6 +60,20 @@ class AscendDflashProposer(AscendEagleProposer):
 
         self.parallel_drafting_hidden_state_tensor = None
 
+        # DSpark Markov-chain drafting needs cudagraph-safe persistent buffers: a seed buffer
+        # (Markov position 0, copied in by set_inputs_first_pass) and a rolling draft-token
+        # buffer. Fixed addresses let the captured draft graph replay correctly — the original
+        # PR allocated a fresh torch.empty and read a per-step-reassigned next_token_ids, so the
+        # graph kept reading stale capture-time memory and accept length collapsed.
+        hf_config = vllm_config.speculative_config.draft_model_config.hf_config
+        if hasattr(hf_config, "markov_head_type"):
+            blk = 1 + self.num_speculative_tokens
+            self._dspark_seed_buffer = torch.zeros(self.max_batch_size, dtype=torch.int64, device=device)
+            self._dspark_draft_buffer = torch.zeros((self.max_batch_size, blk), dtype=torch.int64, device=device)
+        else:
+            self._dspark_seed_buffer = None
+            self._dspark_draft_buffer = None
+
     def set_inputs_first_pass(
         self,
         target_token_ids: torch.Tensor,
@@ -85,6 +99,13 @@ class AscendDflashProposer(AscendEagleProposer):
         self._dflash_hidden_states[:num_context] = target_hidden_states
         # [batch_size] prepare for dspark
         self._next_token_ids = next_token_ids
+        if self._dspark_seed_buffer is not None:
+            # Cudagraph-safe Markov seed: copy the real next tokens into a fixed-address buffer
+            # so the captured draft graph reads fresh seeds each step (not a stale tensor addr).
+            n = next_token_ids.shape[0]
+            self._dspark_seed_buffer[:n].copy_(next_token_ids)
+            if n < self._dspark_seed_buffer.shape[0]:
+                self._dspark_seed_buffer[n:].fill_(0)
 
         token_indices_to_sample = torch.empty(
             batch_size * self.num_speculative_tokens,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1142,7 +1142,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 # which feeds a different dummy batch than batch_size — stays consistent. Keep the
                 # vocab dim explicit so view() only infers the batch dim (the original used
                 # batch_size + view(-1), which mis-inferred the vocab dim during capture).
-                blk = self.num_speculative_tokens + 1
+                blk = self.num_speculative_tokens
                 raw_logits = self.model.compute_logits(last_hidden_states)
                 logits = raw_logits.view(-1, blk, raw_logits.shape[-1])
                 num_blk = logits.shape[0]

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1135,11 +1135,25 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     )
                 draft_token_ids = logits.argmax(dim=-1)
         else:
-            if hasattr(self.speculative_config.draft_model_config.hf_confif, "markov_head_type"):
+            if hasattr(self.speculative_config.draft_model_config.hf_config, "markov_head_type"):
                 # [batch_size, self.num_speculative_tokens + 1]
-                draft_token_ids = torch.empty(batch_size, self.num_speculative_tokens + 1, dtype=torch.int64, device=last_hidden_states.device)
-                draft_token_ids[:, 0] = self._next_token_ids
-                logits = self.model.compute_logits(last_hidden_states).view(batch_size, self.num_speculative_tokens + 1, -1)
+                # last_hidden_states is the draft block output (batch*(num_spec+1) rows in real
+                # decode). Derive the block count from the tensor itself so cudagraph capture —
+                # which feeds a different dummy batch than batch_size — stays consistent. Keep the
+                # vocab dim explicit so view() only infers the batch dim (the original used
+                # batch_size + view(-1), which mis-inferred the vocab dim during capture).
+                blk = self.num_speculative_tokens + 1
+                raw_logits = self.model.compute_logits(last_hidden_states)
+                logits = raw_logits.view(-1, blk, raw_logits.shape[-1])
+                num_blk = logits.shape[0]
+                # Cudagraph-safe drafting: both the rolling draft buffer and the Markov seed
+                # (position 0) live at FIXED addresses so graph replay reads fresh data. The
+                # original PR used a per-call torch.empty and seeded from self._next_token_ids,
+                # which is reassigned to a new tensor every decode step — the captured graph kept
+                # copying the stale capture-time seed and the Markov chain (accept length)
+                # collapsed. set_inputs_first_pass now copy_()s the seed into _dspark_seed_buffer.
+                draft_token_ids = self._dspark_draft_buffer[:num_blk]
+                draft_token_ids[:, 0] = self._dspark_seed_buffer[:num_blk]
                 for idx in range(self.num_speculative_tokens):
                     logits_bias, _ = self.model.model.markov_head(draft_token_ids[:, idx])
                     logits[:, idx] += logits_bias
@@ -1158,7 +1172,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         # Early exit if there is only one draft token to be generated.
         if self.num_speculative_tokens == 1 or self.parallel_drafting:
-            if hasattr(self.speculative_config.draft_model_config.hf_confif, "markov_head_type"):
+            if hasattr(self.speculative_config.draft_model_config.hf_config, "markov_head_type"):
                 return draft_token_ids[:, 1:]
             else:
                 # [batch_size, 1]

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1135,21 +1135,34 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     )
                 draft_token_ids = logits.argmax(dim=-1)
         else:
-            logits = self.model.compute_logits(sample_hidden_states)
-            if lmhead_tp_enable():
-                logits, token_indices_to_sample = self._align_tensor_and_indices(
-                    logits,
-                    num_indices,
-                    token_indices_to_sample,
-                    ori_token_indices_to_sample,
-                    is_logits=True,
-                )
-            draft_token_ids = logits.argmax(dim=-1)
+            if hasattr(self.speculative_config.draft_model_config.hf_confif, "markov_head_type"):
+                # [batch_size, self.num_speculative_tokens + 1]
+                draft_token_ids = torch.empty(batch_size, self.num_speculative_tokens + 1, dtype=torch.int64, device=last_hidden_states.device)
+                draft_token_ids[:, 0] = self._next_token_ids
+                logits = self.model.compute_logits(last_hidden_states).view(batch_size, self.num_speculative_tokens + 1, -1)
+                for idx in range(self.num_speculative_tokens):
+                    logits_bias, _ = self.model.model.markov_head(draft_token_ids[:, idx])
+                    logits[:, idx] += logits_bias
+                    draft_token_ids[:, idx + 1] = logits[:, idx].argmax(dim=-1)
+            else:
+                logits = self.model.compute_logits(sample_hidden_states)
+                if lmhead_tp_enable():
+                    logits, token_indices_to_sample = self._align_tensor_and_indices(
+                        logits,
+                        num_indices,
+                        token_indices_to_sample,
+                        ori_token_indices_to_sample,
+                        is_logits=True,
+                    )
+                draft_token_ids = logits.argmax(dim=-1)
 
         # Early exit if there is only one draft token to be generated.
         if self.num_speculative_tokens == 1 or self.parallel_drafting:
-            # [batch_size, 1]
-            return draft_token_ids.view(-1, self.num_speculative_tokens)
+            if hasattr(self.speculative_config.draft_model_config.hf_confif, "markov_head_type"):
+                return draft_token_ids[:, 1:]
+            else:
+                # [batch_size, 1]
+                return draft_token_ids.view(-1, self.num_speculative_tokens)
 
         if self.pcp_size * self.dcp_size > 1 and is_prefill:
             draft_token_ids_list = []

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3766,7 +3766,10 @@ class NPUModelRunner(GPUModelRunner):
                         "aux_hidden_state_outputs was requested"
                     )
 
-                aux_layers = self._get_eagle3_aux_layers_from_config()
+                if hasattr(self.speculative_config.draft_model_config.hf_config, "markov_head_type"):
+                    aux_layers = self._get_dspark_aux_layers_from_config()
+                else:
+                    aux_layers = self._get_eagle3_aux_layers_from_config()
                 if not aux_layers:
                     aux_layers = self.model.get_eagle3_default_aux_hidden_state_layers()
                 self.model.set_aux_hidden_state_layers(aux_layers)
@@ -3820,6 +3823,23 @@ class NPUModelRunner(GPUModelRunner):
             "Model runner load_model total time: %.2f seconds",
             load_model_total_time,
         )
+    
+    def _get_dspark_aux_layers_from_config(self) -> tuple[int, ...] | None:
+        if not (self.speculative_config and self.speculative_config.draft_model_config):
+            return None
+        
+        hf_config = self.speculative_config.draft_model_config.hf_config
+
+        layer_ids = getattr(hf_config, "eagle_aux_hidden_state_layers", None)
+        if not layer_ids:
+            layer_ids = [
+                i for i in (hf_config.target_layer_ids or [])
+            ]
+        
+        if layer_ids and isinstance(layer_ids, (list, tuple)):
+            return tuple(layer_ids)
+        
+        return None
 
     def _start_dump_data(self) -> None:
         if self.debugger is None or self._debugger_started:


### PR DESCRIPTION
*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-
**Migration to: https://github.com/vllm-project/vllm-ascend/pull/11765**
*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-


### What this PR does / why we need it?
add DSpark speculation method for Qwen3 models.

**Performance Test**
The first 100 requests from gsm8k dataset, num_speculative_tokens=7, temperature=0 and without topk/topp, output_len=2048

| Model | Spec Method | Mode | Acc Length | Acc Rate per Position | Requests per Second | Accuracy |
|-----|-----|-----|-----|-----|-----|-----|
| Qwen3-8B | DFlash | FULL_DECODE_ONLY | 4.73 | [0.85, 0.71, 0.59, 0.50, 0.42, 0.36, 0.30] | 4.73 | 0.85 |
| Qwen3-8B | **Dspark** | FULL_DECODE_ONLY | 6.30 | [0.94, 0.87, 0.81, 0.74, 0.69, 0.63, 0.59] | 6.62 | 0.85 |

### Does this PR introduce _any_ user-facing change?
Based on dflash_proposer, the adaptation to Dspark is added to minimize code modification.

### How was this patch tested?
This PR minimizes the dependency on vllm but still cannot avoid it:
Add to _SPECULATIVE_DECODING_MODELS in vllm/vllm/model_executor/models/registry.py:
    "Qwen3DSparkModel": ("qwen3_dflash", "DFlashQwen3ForCausalLM"),
    "DFlashQwen3DSparkModel": ("qwen3_dflash", "DFlashQwen3ForCausalLM"),

Download official weights: [Qwen3-8B-Dspark](https://huggingface.co/deepseek-ai/dspark_qwen3_8b_block7/tree/main)

The startup script is the same as that of the Dflash:
--speculative-config '{"num_speculative_tokens": 7,"method":"dflash","model":"drafter_path"}'

The FULL_DECODE_ONLY mode is now supported.

### Next plan

1. Currently, only the Markov head has been implemented, we will support for the confidence head next few days.
2. The Dspark structure of DeepSeek V4 is significantly different from that of the Qwen3 series, and additional adaptation is required.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
