### PR TITLE
[Refactor][Test] Simplify MC2 capacity and MoE comm selection

### DIFF
--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -93,7 +93,6 @@ class TestAscendAttentionMetadataBuilder(TestBase):
         self.mock_vllm_config.cache_config.block_size = 64
         self.mock_vllm_config.compilation_config.cudagraph_mode = None
         self.mock_vllm_config.scheduler_config.max_num_seqs = 10
-        self.mock_vllm_config.scheduler_config.decode_max_num_seqs = 10
         self.mock_vllm_config.scheduler_config.chunked_prefill_enabled = False
         self.mock_device = "cpu:0"
         torch.Tensor.pin_memory = lambda x: x  # noqa

--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -331,7 +331,6 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.model_config.hf_text_config.qk_rope_head_dim = 64
         mock_vllm_config.cache_config.block_size = 16
         mock_vllm_config.scheduler_config.max_num_seqs = 4
-        mock_vllm_config.scheduler_config.decode_max_num_seqs = 4
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
         mock_device = "cpu"
 
@@ -352,7 +351,6 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.model_config.hf_text_config.qk_rope_head_dim = 64
         mock_vllm_config.cache_config.block_size = 16
         mock_vllm_config.scheduler_config.max_num_seqs = 4
-        mock_vllm_config.scheduler_config.decode_max_num_seqs = 4
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
         mock_device = "cpu"
 
@@ -384,7 +382,6 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.model_config.hf_text_config.qk_rope_head_dim = 64
         mock_vllm_config.cache_config.block_size = 16
         mock_vllm_config.scheduler_config.max_num_seqs = 4
-        mock_vllm_config.scheduler_config.decode_max_num_seqs = 4
         mock_vllm_config.scheduler_config.chunked_prefill_enabled = False
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
         mock_device = "cpu"
@@ -424,7 +421,6 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.model_config.hf_text_config.qk_rope_head_dim = 64
         mock_vllm_config.cache_config.block_size = 16
         mock_vllm_config.scheduler_config.max_num_seqs = 4
-        mock_vllm_config.scheduler_config.decode_max_num_seqs = 4
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
         mock_device = "cpu"
 
@@ -477,7 +473,6 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.model_config.hf_text_config.qk_rope_head_dim = 64
         mock_vllm_config.cache_config.block_size = 16
         mock_vllm_config.scheduler_config.max_num_seqs = 4
-        mock_vllm_config.scheduler_config.decode_max_num_seqs = 4
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
         mock_device = "cpu"
 
@@ -498,7 +493,6 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.model_config.hf_text_config.qk_rope_head_dim = 64
         mock_vllm_config.cache_config.block_size = 16
         mock_vllm_config.scheduler_config.max_num_seqs = 4
-        mock_vllm_config.scheduler_config.decode_max_num_seqs = 4
         mock_vllm_config.scheduler_config.chunked_prefill_enabled = False
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
         mock_device = "cpu"
@@ -520,7 +514,6 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.model_config.hf_text_config.qk_rope_head_dim = 64
         mock_vllm_config.cache_config.block_size = 16
         mock_vllm_config.scheduler_config.max_num_seqs = 4
-        mock_vllm_config.scheduler_config.decode_max_num_seqs = 4
         mock_vllm_config.scheduler_config.chunked_prefill_enabled = False
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
         mock_device = "cpu"
@@ -547,7 +540,6 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.model_config.hf_text_config.qk_rope_head_dim = 64
         mock_vllm_config.cache_config.block_size = 16
         mock_vllm_config.scheduler_config.max_num_seqs = 4
-        mock_vllm_config.scheduler_config.decode_max_num_seqs = 4
         mock_vllm_config.scheduler_config.chunked_prefill_enabled = False
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
         mock_device = "cpu"

--- a/tests/ut/ops/a2/test_token_dispatcher.py
+++ b/tests/ut/ops/a2/test_token_dispatcher.py
@@ -90,7 +90,6 @@ class TestTokenDispatcherWithMC2(TestBase):
         mock_config = MagicMock()
 
         mock_config.scheduler_config.max_num_seqs = 256
-        mock_config.scheduler_config.decode_max_num_seqs = 256
 
         mock_config.compilation_config.custom_ops = ["all"]
 

--- a/tests/ut/ops/a2/test_token_dispatcher.py
+++ b/tests/ut/ops/a2/test_token_dispatcher.py
@@ -58,6 +58,7 @@ def build_token_dispatch_input_fixture(
     comm_quant_mode: int | None = None,
     act_quant_type: torch.dtype | None = None,
     is_per_channel_weight: bool = False,
+    mc2_mask: torch.Tensor | None = None,
 ) -> MoETokenDispatchInput:
     mxfp_spec = None
     if quant_type in (QuantType.MXFP8, QuantType.MXFP4):
@@ -69,7 +70,7 @@ def build_token_dispatch_input_fixture(
         routing=MoERoutingParams(
             expert_map=expert_map,
             global_redundant_expert_num=global_redundant_expert_num,
-            mc2_mask=None,
+            mc2_mask=mc2_mask,
             apply_router_weight_on_input=apply_router_weight_on_input,
             pertoken_scale=pertoken_scale,
         ),
@@ -98,6 +99,13 @@ class TestTokenDispatcherWithMC2(TestBase):
         mock_config.parallel_config.tensor_parallel_size = 1
 
         self.mock_get_config.return_value = mock_config
+        self.mc2_tokens_capacity = 128
+        self.mc2_capacity_patch = patch(
+            "vllm_ascend.ops.fused_moe.token_dispatcher.get_mc2_tokens_capacity",
+            return_value=self.mc2_tokens_capacity,
+        )
+        self.mock_get_mc2_tokens_capacity = self.mc2_capacity_patch.start()
+
         self.mc2_group = MagicMock()
         self.mc2_group.device_group.return_value._get_backend.return_value.get_hccl_comm_name.return_value = "hccl_123"
         self.mc2_group.rank_in_group = 0
@@ -142,13 +150,16 @@ class TestTokenDispatcherWithMC2(TestBase):
         self.skip_allreduce_patch = patch(
             "vllm_ascend.ops.fused_moe.token_dispatcher.should_skip_allreduce_across_dp_group", return_value=False
         )
-        self.skip_allreduce_patch.start()
+        self.mock_skip_allreduce = self.skip_allreduce_patch.start()
 
         kwargs = {"with_quant": False, "top_k": 8, "num_experts": 128}
         self.dispatcher = TokenDispatcherWithMC2(**kwargs)
 
     def tearDown(self):
+        self.config_patcher.stop()
+        self.mc2_capacity_patch.stop()
         self.mc2_group_patch.stop()
+        self.rank_group_patch.stop()
         self.forward_context_patch.stop()
         self.ascend_soc_version_patch.stop()
         self.ascend_config_patch.stop()
@@ -161,6 +172,57 @@ class TestTokenDispatcherWithMC2(TestBase):
         self.assertEqual(self.dispatcher.ep_world_size, 8)
         self.assertTrue(self.dispatcher.enable_dispatch_v2)
         self.assertTrue(self.dispatcher.need_extra_args)
+        self.assertEqual(self.dispatcher.global_bs, 0)
+
+    def test_init_uses_mc2_capacity_for_non_uniform_global_bs(self):
+        self.mock_get_config.return_value.parallel_config.tensor_parallel_size = 4
+        self.mock_skip_allreduce.return_value = True
+
+        dispatcher = TokenDispatcherWithMC2(with_quant=False, top_k=8, num_experts=128)
+
+        self.assertEqual(dispatcher.global_bs, 256)
+
+    def test_get_dispatch_mc2_kwargs_with_skip_allreduce_omits_mc2_mask(self):
+        self.mock_get_config.return_value.parallel_config.tensor_parallel_size = 4
+        self.mock_skip_allreduce.return_value = True
+        dispatcher = TokenDispatcherWithMC2(with_quant=False, top_k=8, num_experts=128)
+
+        hidden_states = torch.randn(10, 128)
+        topk_ids = torch.randint(0, 8, (10, 1))
+        topk_weights = torch.randn(10, 1)
+        expert_map = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7])
+        mc2_mask = torch.tensor([True, False, True, False])
+        token_dispatch_input = build_token_dispatch_input_fixture(
+            hidden_states=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            expert_map=expert_map,
+            mc2_mask=mc2_mask,
+        )
+
+        kwargs = dispatcher.get_dispatch_mc2_kwargs(token_dispatch_input)
+
+        self.assertEqual(kwargs["global_bs"], 256)
+        self.assertNotIn("x_active_mask", kwargs)
+
+    def test_get_dispatch_mc2_kwargs_without_skip_allreduce_keeps_mc2_mask(self):
+        hidden_states = torch.randn(10, 128)
+        topk_ids = torch.randint(0, 8, (10, 1))
+        topk_weights = torch.randn(10, 1)
+        expert_map = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7])
+        mc2_mask = torch.tensor([True, False, True, False])
+        token_dispatch_input = build_token_dispatch_input_fixture(
+            hidden_states=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            expert_map=expert_map,
+            mc2_mask=mc2_mask,
+        )
+
+        kwargs = self.dispatcher.get_dispatch_mc2_kwargs(token_dispatch_input)
+
+        self.assertEqual(kwargs["global_bs"], 0)
+        self.assertIs(kwargs["x_active_mask"], mc2_mask)
 
     def test_get_dispatch_mc2_kwargs_without_quant(self):
         hidden_states = torch.randn(10, 128)

--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -1,2 +1,226 @@
-def test_ascend_forward_context_placeholder():
-    pass
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_ascend import ascend_forward_context as afc
+from vllm_ascend.ascend_forward_context import MoECommType
+
+
+@pytest.fixture(autouse=True)
+def reset_mc2_tokens_capacity(monkeypatch):
+    monkeypatch.setattr(afc, "_mc2_tokens_capacity", None)
+
+
+def _make_vllm_config(
+    *,
+    enable_expert_parallel: bool = True,
+    world_size: int = 8,
+    pipeline_parallel_size: int = 1,
+    tensor_parallel_size: int = 1,
+    num_experts: int = 128,
+    quant_type: str | None = None,
+    top_k_experts: int = 1,
+    num_experts_per_tok: int | None = None,
+    cudagraph_capture_sizes: list[int] | None = None,
+    max_cudagraph_capture_size: int = 0,
+):
+    hf_text_config_attrs: dict[str, object] = {"top_k_experts": top_k_experts}
+    if quant_type is not None:
+        hf_text_config_attrs["quantize"] = quant_type
+    if num_experts_per_tok is not None:
+        hf_text_config_attrs["num_experts_per_tok"] = num_experts_per_tok
+
+    model_config = SimpleNamespace(
+        hf_text_config=SimpleNamespace(**hf_text_config_attrs),
+        get_num_experts=lambda: num_experts,
+    )
+    parallel_config = SimpleNamespace(
+        enable_expert_parallel=enable_expert_parallel,
+        world_size_across_dp=world_size,
+        pipeline_parallel_size=pipeline_parallel_size,
+        tensor_parallel_size=tensor_parallel_size,
+    )
+    compilation_config = SimpleNamespace(
+        cudagraph_capture_sizes=cudagraph_capture_sizes or [],
+        max_cudagraph_capture_size=max_cudagraph_capture_size,
+    )
+    return SimpleNamespace(
+        model_config=model_config,
+        parallel_config=parallel_config,
+        compilation_config=compilation_config,
+    )
+
+
+def _patch_select_moe_comm_method_deps(
+    monkeypatch,
+    *,
+    device_type,
+    capacity: int = 128,
+    ep_world_size: int = 8,
+    enable_fused_mc2: int = 0,
+    is_moe: bool = True,
+    spec_decode_enabled: bool = False,
+):
+    monkeypatch.setattr(afc, "is_moe_model", lambda _: is_moe)
+    monkeypatch.setattr(afc, "get_mc2_tokens_capacity", lambda: capacity)
+    monkeypatch.setattr(afc, "get_ascend_device_type", lambda: device_type)
+    monkeypatch.setattr(afc, "get_ep_group", lambda: SimpleNamespace(world_size=ep_world_size))
+    monkeypatch.setattr(afc, "get_ascend_config", lambda: SimpleNamespace(enable_fused_mc2=enable_fused_mc2))
+    monkeypatch.setattr(
+        afc,
+        "speculative_enable_dispatch_gmm_combine_decode",
+        lambda _: spec_decode_enabled,
+    )
+
+
+def test_set_mc2_tokens_capacity_without_cudagraph_caps_at_512_and_aligns():
+    vllm_config = _make_vllm_config(tensor_parallel_size=6)
+
+    afc.set_mc2_tokens_capacity(vllm_config, max_num_reqs=200, uniform_decode_query_len=3)
+
+    assert afc.get_mc2_tokens_capacity() == 516
+
+
+def test_set_mc2_tokens_capacity_with_cudagraph_uses_capture_size_and_aligns():
+    vllm_config = _make_vllm_config(
+        tensor_parallel_size=8,
+        cudagraph_capture_sizes=[1, 2],
+        max_cudagraph_capture_size=257,
+    )
+
+    afc.set_mc2_tokens_capacity(vllm_config, max_num_reqs=16, uniform_decode_query_len=1)
+
+    assert afc.get_mc2_tokens_capacity() == 264
+
+
+def test_select_moe_comm_method_returns_none_for_non_moe(monkeypatch):
+    _patch_select_moe_comm_method_deps(
+        monkeypatch,
+        device_type=afc.AscendDeviceType.A3,
+        is_moe=False,
+    )
+
+    assert afc.select_moe_comm_method(16, _make_vllm_config()) is None
+
+
+@pytest.mark.parametrize(
+    ("enable_expert_parallel", "ep_world_size"),
+    [
+        (False, 8),
+        (True, 1),
+    ],
+)
+def test_select_moe_comm_method_uses_allgather_without_effective_expert_parallel(
+    monkeypatch,
+    enable_expert_parallel,
+    ep_world_size,
+):
+    _patch_select_moe_comm_method_deps(
+        monkeypatch,
+        device_type=afc.AscendDeviceType.A3,
+        ep_world_size=ep_world_size,
+    )
+    vllm_config = _make_vllm_config(enable_expert_parallel=enable_expert_parallel)
+
+    assert afc.select_moe_comm_method(16, vllm_config) == MoECommType.ALLGATHER
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "expected"),
+    [
+        (128, MoECommType.MC2),
+        (129, MoECommType.ALLGATHER),
+    ],
+)
+def test_select_moe_comm_method_a2_uses_mc2_within_capacity(monkeypatch, num_tokens, expected):
+    _patch_select_moe_comm_method_deps(
+        monkeypatch,
+        device_type=afc.AscendDeviceType.A2,
+        capacity=128,
+        ep_world_size=16,
+    )
+    vllm_config = _make_vllm_config(world_size=16, num_experts=128)
+
+    assert afc.select_moe_comm_method(num_tokens, vllm_config) == expected
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "ep_world_size", "expected"),
+    [
+        (128, 8, MoECommType.FUSED_MC2),
+        (128, 64, MoECommType.MC2),
+        (129, 8, MoECommType.FUSED_MC2),
+        (129, 64, MoECommType.ALLTOALL),
+    ],
+)
+def test_select_moe_comm_method_a3_enable_fused_mc2_mode_1(
+    monkeypatch,
+    num_tokens,
+    ep_world_size,
+    expected,
+):
+    _patch_select_moe_comm_method_deps(
+        monkeypatch,
+        device_type=afc.AscendDeviceType.A3,
+        capacity=128,
+        ep_world_size=ep_world_size,
+        enable_fused_mc2=1,
+    )
+
+    assert afc.select_moe_comm_method(num_tokens, _make_vllm_config()) == expected
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "quant_type", "spec_decode_enabled", "expected"),
+    [
+        (128, "w8a8_dynamic", True, MoECommType.FUSED_MC2),
+        (128, "w8a8_dynamic", False, MoECommType.MC2),
+        (128, "w4a8", True, MoECommType.MC2),
+        (129, "w8a8_dynamic", True, MoECommType.ALLTOALL),
+    ],
+)
+def test_select_moe_comm_method_a3_enable_fused_mc2_mode_2(
+    monkeypatch,
+    num_tokens,
+    quant_type,
+    spec_decode_enabled,
+    expected,
+):
+    _patch_select_moe_comm_method_deps(
+        monkeypatch,
+        device_type=afc.AscendDeviceType.A3,
+        capacity=128,
+        enable_fused_mc2=2,
+        spec_decode_enabled=spec_decode_enabled,
+    )
+    vllm_config = _make_vllm_config(quant_type=quant_type)
+
+    assert afc.select_moe_comm_method(num_tokens, vllm_config) == expected
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "world_size", "top_k_experts", "expected"),
+    [
+        (128, 4, 2, MoECommType.MC2),
+        (129, 2, 4, MoECommType.ALLGATHER),
+        (129, 8, 4, MoECommType.ALLTOALL),
+    ],
+)
+def test_select_moe_comm_method_a5(monkeypatch, num_tokens, world_size, top_k_experts, expected):
+    _patch_select_moe_comm_method_deps(
+        monkeypatch,
+        device_type=afc.AscendDeviceType.A5,
+        capacity=128,
+    )
+    vllm_config = _make_vllm_config(world_size=world_size, top_k_experts=top_k_experts)
+
+    assert afc.select_moe_comm_method(num_tokens, vllm_config) == expected
+
+
+def test_select_moe_comm_method_310p_uses_allgather(monkeypatch):
+    _patch_select_moe_comm_method_deps(
+        monkeypatch,
+        device_type=afc.AscendDeviceType._310P,
+    )
+
+    assert afc.select_moe_comm_method(128, _make_vllm_config()) == MoECommType.ALLGATHER

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -234,6 +234,69 @@ def get_mc2_mask():
     return _reserved_mc2_mask
 
 
+def _select_a2_moe_comm_method(
+    num_tokens: int,
+    vllm_config: VllmConfig,
+    mc2_tokens_capacity: int,
+) -> MoECommType:
+    num_experts = vllm_config.model_config.get_num_experts()
+    ep_world_size = (
+        vllm_config.parallel_config.world_size_across_dp // vllm_config.parallel_config.pipeline_parallel_size
+    )
+    num_experts_per_device = num_experts // ep_world_size
+    if num_experts_per_device <= 24 and ep_world_size >= 16 and num_tokens <= mc2_tokens_capacity:
+        return MoECommType.MC2
+    return MoECommType.ALLGATHER
+
+
+def _select_a3_moe_comm_method(
+    num_tokens: int,
+    vllm_config: VllmConfig,
+    quant_type: str | None,
+    mc2_tokens_capacity: int,
+    enable_fused_mc2: int,
+) -> MoECommType:
+    # TODO: drop the EP-size guard when dispatch_ffn_combine supports larger EP sizes
+    # TODO: drop speculative method guard when dispatch_gmm_combine_decode supports w16a16
+    dispatch_ffn_combine_enable = get_ep_group().world_size <= 32
+    if num_tokens <= mc2_tokens_capacity:
+        fused_decode_enable = enable_fused_mc2
+        if enable_fused_mc2 == 1:
+            fused_decode_enable = enable_fused_mc2 and dispatch_ffn_combine_enable
+        elif enable_fused_mc2 == 2:
+            fused_decode_enable = (
+                enable_fused_mc2
+                and speculative_enable_dispatch_gmm_combine_decode(vllm_config)
+                and quant_type == "w8a8_dynamic"
+            )
+        return MoECommType.FUSED_MC2 if fused_decode_enable else MoECommType.MC2
+
+    fused_prefill_enable = enable_fused_mc2
+    if enable_fused_mc2 == 1:
+        fused_prefill_enable = enable_fused_mc2 and dispatch_ffn_combine_enable
+    elif enable_fused_mc2 == 2:
+        fused_prefill_enable = False
+    return MoECommType.FUSED_MC2 if fused_prefill_enable else MoECommType.ALLTOALL
+
+
+def _select_a5_moe_comm_method(
+    num_tokens: int,
+    vllm_config: VllmConfig,
+    mc2_tokens_capacity: int,
+) -> MoECommType:
+    num_experts_per_tok = getattr(
+        vllm_config.model_config.hf_text_config,
+        "num_experts_per_tok",
+        getattr(vllm_config.model_config.hf_text_config, "top_k_experts", 1),
+    )
+    world_size = vllm_config.parallel_config.world_size_across_dp
+    if num_tokens <= mc2_tokens_capacity and world_size > 1:
+        return MoECommType.MC2
+    if world_size <= num_experts_per_tok:
+        return MoECommType.ALLGATHER
+    return MoECommType.ALLTOALL
+
+
 def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig, is_draft_model=False) -> MoECommType | None:
     """Select the MoE communication method according to parallel settings,
     device generation, token count, and quantization.
@@ -263,6 +326,7 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig, is_draft_mo
     """
     if not is_moe_model(vllm_config):
         return None
+
     mc2_tokens_capacity = get_mc2_tokens_capacity()
     soc_version = get_ascend_device_type()
     quant_type = getattr(
@@ -273,55 +337,21 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig, is_draft_mo
 
     if not vllm_config.parallel_config.enable_expert_parallel or get_ep_group().world_size == 1:
         moe_comm_type = MoECommType.ALLGATHER
-    elif soc_version in {AscendDeviceType.A2}:
-        num_experts = vllm_config.model_config.get_num_experts()
-        ep_world_size = (
-            vllm_config.parallel_config.world_size_across_dp // vllm_config.parallel_config.pipeline_parallel_size
+    elif soc_version == AscendDeviceType.A2:
+        moe_comm_type = _select_a2_moe_comm_method(num_tokens, vllm_config, mc2_tokens_capacity)
+    elif soc_version == AscendDeviceType.A3:
+        moe_comm_type = _select_a3_moe_comm_method(
+            num_tokens,
+            vllm_config,
+            quant_type,
+            mc2_tokens_capacity,
+            get_ascend_config().enable_fused_mc2,
         )
-        num_experts_per_device = num_experts // ep_world_size
-        if num_experts_per_device <= 24 and ep_world_size >= 16 and num_tokens <= mc2_tokens_capacity:
-            moe_comm_type = MoECommType.MC2
-        else:
-            moe_comm_type = MoECommType.ALLGATHER
-
-    elif soc_version in {AscendDeviceType.A3}:
-        # TODO: drop the EP-size guard when dispatch_ffn_combine supports larger EP sizes
-        # TODO: drop speculative method guard when dispatch_gmm_combine_decode supports w16a16
-        fused_mc2_enable = get_ascend_config().enable_fused_mc2
-        dispatch_ffn_combine_enable = get_ep_group().world_size <= 32
-        if num_tokens <= mc2_tokens_capacity:
-            fused_decode_enable = fused_mc2_enable
-            if fused_mc2_enable == 1:
-                fused_decode_enable = fused_mc2_enable and dispatch_ffn_combine_enable
-            elif fused_mc2_enable == 2:
-                fused_decode_enable = (
-                    fused_mc2_enable
-                    and speculative_enable_dispatch_gmm_combine_decode(vllm_config)
-                    and quant_type == "w8a8_dynamic"
-                )
-            moe_comm_type = MoECommType.FUSED_MC2 if fused_decode_enable else MoECommType.MC2
-        else:
-            fused_prefill_enable = fused_mc2_enable
-            if fused_mc2_enable == 1:
-                fused_prefill_enable = fused_mc2_enable and dispatch_ffn_combine_enable
-            elif fused_mc2_enable == 2:
-                fused_prefill_enable = False
-            moe_comm_type = MoECommType.FUSED_MC2 if fused_prefill_enable else MoECommType.ALLTOALL
-    elif soc_version in {AscendDeviceType._310P}:
+    elif soc_version == AscendDeviceType.A5:
+        moe_comm_type = _select_a5_moe_comm_method(num_tokens, vllm_config, mc2_tokens_capacity)
+    elif soc_version == AscendDeviceType._310P:
         moe_comm_type = MoECommType.ALLGATHER
-    elif soc_version in {AscendDeviceType.A5}:
-        num_experts_per_tok = getattr(
-            vllm_config.model_config.hf_text_config,
-            "num_experts_per_tok",
-            getattr(vllm_config.model_config.hf_text_config, "top_k_experts", 1),
-        )
-        world_size = vllm_config.parallel_config.world_size_across_dp
-        if num_tokens <= mc2_tokens_capacity and world_size > 1:
-            moe_comm_type = MoECommType.MC2
-        elif world_size <= num_experts_per_tok:
-            moe_comm_type = MoECommType.ALLGATHER
-        else:
-            moe_comm_type = MoECommType.ALLTOALL
+
     else:
         raise ValueError(f"Unsupported soc_version: {soc_version}")
     logger.debug(

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -29,6 +29,7 @@ from vllm.config import get_current_vllm_config
 from vllm.distributed.parallel_state import get_ep_group
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.ascend_forward_context import get_mc2_tokens_capacity
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.fused_moe.comm_utils import async_all_to_all, gather_from_sequence_parallel_region
@@ -120,18 +121,9 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         # Here we need to calculate the global_bs = max_bs_per_rank * ep_world_size to execute
         # dispatch & combine operators with different input num_tokens per rank.
         vllm_config = get_current_vllm_config()
-        scheduler_config = vllm_config.scheduler_config
-        compilation_config = vllm_config.compilation_config
-        speculative_config = vllm_config.speculative_config
         tp_size = vllm_config.parallel_config.tensor_parallel_size
-        uniform_decode_query_len = 1 if not speculative_config else 1 + speculative_config.num_speculative_tokens
-        decode_max_num_seqs = getattr(scheduler_config, "decode_max_num_seqs", 0)
-        max_num_reqs = max(scheduler_config.max_num_seqs, decode_max_num_seqs)
-        if compilation_config.cudagraph_capture_sizes:
-            max_num_tokens = compilation_config.max_cudagraph_capture_size
-        else:
-            max_num_tokens = min(max_num_reqs * uniform_decode_query_len, 512)
-        num_tokens_per_tp_rank = (max_num_tokens + tp_size - 1) // tp_size
+        mc2_tokens_capacity = get_mc2_tokens_capacity()
+        num_tokens_per_tp_rank = mc2_tokens_capacity // tp_size
         _max_global_bs = num_tokens_per_tp_rank * self.ep_world_size
 
         # When allreduce across DP is not skipped, tokens are uniform across ranks:

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1129,8 +1129,6 @@ def _compute_potential_max_tokens(vllm_config) -> int:
     scheduler_config = vllm_config.scheduler_config
     speculative_config = vllm_config.speculative_config
     uniform_decode_query_len = 1 if not speculative_config else 1 + speculative_config.num_speculative_tokens
-    decode_max_num_seqs = getattr(scheduler_config, "decode_max_num_seqs", 0)
-    max_num_reqs = max(scheduler_config.max_num_seqs, decode_max_num_seqs)
 
     # Use max cudagraph capture size if available, otherwise the maximal uniform
     # decode token count.
@@ -1153,7 +1151,7 @@ def _compute_potential_max_tokens(vllm_config) -> int:
                 potential_max_tokens,
             )
     else:
-        potential_max_tokens = min(max_num_reqs * uniform_decode_query_len, 512)
+        potential_max_tokens = min(scheduler_config.max_num_seqs * uniform_decode_query_len, 512)
     return potential_max_tokens
 
 

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1157,8 +1157,7 @@ def _compute_potential_max_tokens(vllm_config) -> int:
 
 # potential_max_tokens is computed once in the model runner __init__ and reused by
 # both the skip-allreduce decision and the o_proj static-exchange buffer sizing, so
-# neither path recomputes it. Mirrors the _mc2_tokens_capacity set/get pattern in
-# ascend_forward_context.py.
+# neither path recomputes it.
 _potential_max_tokens: int | None = None
 
 


### PR DESCRIPTION
### What this PR does / why we need it?
This PR cleans up MC2 capacity handling and MoE communication selection, then adds unit-test coverage for those paths.

- Remove the stale `decode_max_num_seqs` compatibility path so decode capacity uses `scheduler_config.max_num_seqs`.
- Reuse the cached MC2 token capacity when computing MC2 dispatch `global_bs` instead of recomputing capacity in the dispatcher.
- Split A2/A3/A5 MoE communication selection into focused helpers while preserving existing method selection behavior.
- Add unit tests for MC2 capacity alignment, SoC-specific MoE communication selection, and MC2 dispatcher `global_bs`/`mc2_mask` behavior.

### Does this PR introduce _any_ user-facing change?
No.

This is an internal refactor and test coverage update. It does not add user-facing configs, CLI flags, environment variables, APIs, or intended behavior changes.

### How was this patch tested?

- Qwen3.5-35B-A3B-w4a8-org，A3，Tp=2，EP=true，enable_fused_mc2=0
- Qwen3.5-35B-A3B-w4a8-org，A3，Tp=2，EP=true，enable_fused_mc2=1

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
