### PR TITLE
[CI] Fix cherry-pick and rerun command

### DIFF
--- a/.github/workflows/pr_cherry_pick_command.yml
+++ b/.github/workflows/pr_cherry_pick_command.yml
@@ -19,7 +19,11 @@ name: Handle /cherry-pick Command
 
 on:
   repository_dispatch:
-    types: [cherry-command]
+    types: [cherry-pick-command]
+
+defaults:
+  run:
+    shell: bash -el {0}
 
 permissions:
   contents: write

--- a/.github/workflows/pr_nightly_command.yml
+++ b/.github/workflows/pr_nightly_command.yml
@@ -21,6 +21,10 @@ on:
   repository_dispatch:
     types: [nightly-command]
 
+defaults:
+  run:
+    shell: bash -el {0}
+
 permissions:
   contents: read
   actions: write

--- a/.github/workflows/pr_rerun_command.yml
+++ b/.github/workflows/pr_rerun_command.yml
@@ -21,6 +21,10 @@ on:
   repository_dispatch:
     types: [rerun-command]
 
+defaults:
+  run:
+    shell: bash -el {0}
+
 permissions:
   contents: read
   actions: write


### PR DESCRIPTION
Fix /cherry-pick and /rerun command to make them work

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
