### PR TITLE
[CI] Fix cherry-pick diff to use merge-base (three-dot) to exclude un…

### DIFF
--- a/.github/workflows/pr_cherry_pick_command.yml
+++ b/.github/workflows/pr_cherry_pick_command.yml
@@ -155,16 +155,20 @@ jobs:
           git checkout -b "$CHERRY_BRANCH" "origin/$TARGET_BRANCH"
 
           # Apply the PR's changes as a single commit.
-          # Using git diff (PR base vs PR head) avoids picking up unrelated
-          # merge commits from the base branch, which works for both merged
-          # and unmerged PRs.
+          # Using git diff with three-dot (...) from merge-base to PR head
+          # avoids picking up unrelated commits from the base branch, which
+          # works for both merged and unmerged PRs.
           echo "PR base: $PR_BASE_SHA"
           echo "PR head: $PR_HEAD_SHA"
 
           # Generate the diff to a temp file (avoids shell variable size limits
           # for large PRs) so we can check emptiness and apply it.
+          # Use three-dot (...) to diff from merge-base to PR head, so we
+          # only pick up the PR's unique changes — not unrelated commits
+          # that landed on the base branch between PR_BASE_SHA and the
+          # rebased PR_HEAD_SHA.
           DIFF_FILE=/tmp/cherry_diff.patch
-          git diff "$PR_BASE_SHA".."$PR_HEAD_SHA" > "$DIFF_FILE"
+          git diff "$PR_BASE_SHA"..."$PR_HEAD_SHA" > "$DIFF_FILE"
 
           if [ ! -s "$DIFF_FILE" ]; then
             echo "Diff is empty, changes already included in target branch."


### PR DESCRIPTION
When a PR is rebased onto a newer base branch, the PR_HEAD_SHA is updated but PR_BASE_SHA may still point to the old base. Using git diff with two dots (..) then includes all intermediate commits that landed on main between the old base and the new base, causing git apply to fail with 'does not exist in index' errors for files that don't exist on the target branch.

Using three-dot (...) computes the diff from the merge-base of PR_BASE_SHA and PR_HEAD_SHA to PR_HEAD_SHA, which only includes the PR's unique changes.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
