### PR TITLE
Support Gemma4 MTP

### DIFF
--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -16,6 +16,9 @@ from vllm_ascend.attention.utils import (
     cache_graph_workspace,
     needs_layer_aware_fia_graph_replay,
 )
+from vllm_ascend.utils import AscendDeviceType
+
+LARGE_HEAD_PREFILL_PATH = "vllm_ascend.attention.attention_v1.forward_large_head_prefill_attention"
 
 
 class TestAttentionGraphHelpers(TestBase):
@@ -262,6 +265,93 @@ class TestAscendAttentionBackendImpl(TestBase):
             kv_sharing_target_layer_name=None,
             sinks=torch.tensor([-3.4062], dtype=torch.bfloat16),
         )
+
+        self.impl_large_head = AscendAttentionBackendImpl(
+            num_heads=8,
+            head_size=512,
+            scale=1.0,
+            num_kv_heads=8,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="float16",
+            logits_soft_cap=None,
+            attn_type=self.attention_type.DECODER,
+            kv_sharing_target_layer_name=None,
+        )
+
+    @patch("vllm_ascend.attention.utils.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    def test_large_head_prefill_uses_fallback(self, mock_get_device_type):
+        query = torch.randn(2, 8, 512)
+        key = torch.randn(2, 8, 512)
+        value = torch.randn(2, 8, 512)
+        output = torch.empty_like(query)
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.PrefillNoCache
+        metadata.actual_seq_lengths_q = [2]
+
+        self.impl_large_head.forward_fused_infer_attention = MagicMock(return_value=output)
+        with patch(LARGE_HEAD_PREFILL_PATH, return_value=output) as mock_forward:
+            result = self.impl_large_head.forward_impl(query, key, value, (), metadata, output)
+
+        mock_forward.assert_called_once()
+        self.impl_large_head.forward_fused_infer_attention.assert_not_called()
+        self.assertIs(result, output)
+        mock_get_device_type.assert_called()
+
+    @patch("vllm_ascend.attention.utils.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    def test_supported_head_prefill_uses_fia(self, mock_get_device_type):
+        query = torch.randn(2, 8, 64)
+        key = torch.randn(2, 8, 64)
+        value = torch.randn(2, 8, 64)
+        output = torch.empty_like(query)
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.PrefillNoCache
+        metadata.actual_seq_lengths_q = [2]
+
+        self.impl.forward_fused_infer_attention = MagicMock(return_value=output)
+        with patch(LARGE_HEAD_PREFILL_PATH, return_value=output) as mock_forward:
+            result = self.impl.forward_impl(query, key, value, (), metadata, output)
+
+        mock_forward.assert_not_called()
+        self.impl.forward_fused_infer_attention.assert_called_once()
+        self.assertIs(result, output)
+        mock_get_device_type.assert_called()
+
+    @patch("vllm_ascend.attention.utils.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    def test_large_head_decode_uses_paged_attention(self, mock_get_device_type):
+        query = torch.randn(2, 8, 512)
+        output = torch.empty_like(query)
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.DecodeOnly
+
+        self.impl_large_head.forward_paged_attention = MagicMock(return_value=output)
+        self.impl_large_head.forward_fused_infer_attention = MagicMock(return_value=output)
+
+        result = self.impl_large_head.forward_impl(query, None, None, (), metadata, output)
+
+        self.impl_large_head.forward_paged_attention.assert_called_once()
+        self.impl_large_head.forward_fused_infer_attention.assert_not_called()
+        self.assertIs(result, output)
+        mock_get_device_type.assert_called()
+
+    @patch("vllm_ascend.attention.utils.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    def test_large_head_prefill_uses_fia_on_a5(self, mock_get_device_type):
+        query = torch.randn(2, 8, 512)
+        key = torch.randn(2, 8, 512)
+        value = torch.randn(2, 8, 512)
+        output = torch.empty_like(query)
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.PrefillNoCache
+        metadata.actual_seq_lengths_q = [2]
+
+        self.impl_large_head.forward_fused_infer_attention = MagicMock(return_value=output)
+        with patch(LARGE_HEAD_PREFILL_PATH, return_value=output) as mock_forward:
+            result = self.impl_large_head.forward_impl(query, key, value, (), metadata, output)
+
+        mock_forward.assert_not_called()
+        self.impl_large_head.forward_fused_infer_attention.assert_called_once()
+        self.assertIs(result, output)
+        mock_get_device_type.assert_called()
 
     def test_forward_no_attn_metadata(self):
         """Test forward pass when attn_metadata is None"""

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -51,6 +51,9 @@ from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
     cache_graph_workspace,
     enable_cp,
+    forward_large_head_prefill_attention,
+    get_current_token_kv_from_cache,
+    needs_fia_large_head_fallback,
     needs_layer_aware_fia_graph_replay,
     split_decodes_and_prefills,
     using_paged_attention,
@@ -1384,6 +1387,11 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 attn_metadata.reshape_cache_event = torch.npu.Event()
             if self.key_cache is None:
                 self.key_cache, self.value_cache = kv_cache[0], kv_cache[1]
+            if self.kv_sharing_target_layer_name is not None:
+                # Target layers reuse KV written by the producer layer.
+                if self.is_kv_producer:
+                    attn_metadata.reshape_cache_event.record()
+                return query, key, value, output
             slots = attn_metadata.slot_mapping
             encoder_decoder = self.attn_type == AttentionType.ENCODER_DECODER
             DeviceOperator.reshape_and_cache(
@@ -1409,12 +1417,64 @@ class AscendAttentionBackendImpl(AttentionImpl):
         output: torch.Tensor,
     ):
         num_tokens = query.shape[0]
+        use_large_head_fallback = needs_fia_large_head_fallback(self.head_size, self.sinks)
+
+        def forward_large_head(query: torch.Tensor, key: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
+            return forward_large_head_prefill_attention(
+                query,
+                key,
+                value,
+                attn_metadata,
+                output,
+                key_cache=self.key_cache,
+                value_cache=self.value_cache,
+                num_heads=self.num_heads,
+                num_kv_heads=self.num_kv_heads,
+                head_size=self.head_size,
+                scale=self.scale,
+                sliding_window=self.sliding_window,
+                is_prefill_no_cache=attn_metadata.attn_state == AscendAttentionState.PrefillNoCache,
+            )
+
+        if (
+            use_large_head_fallback
+            and self.kv_sharing_target_layer_name is not None
+            and key is not None
+            and value is not None
+            and query.shape[0] == key.shape[0]
+            and attn_metadata.attn_state in (AscendAttentionState.PrefillNoCache, AscendAttentionState.ChunkedPrefill)
+        ):
+            # For KV sharing target layers, the incoming key/value tensors are
+            # not the target layer KV. Gather producer KV before FA fallback.
+            shared_key, shared_value = get_current_token_kv_from_cache(
+                self.key_cache,
+                self.value_cache,
+                attn_metadata.slot_mapping,
+                attn_metadata.actual_seq_lengths_q[-1],
+                self.num_kv_heads,
+                self.head_size,
+            )
+            if shared_key is not None and shared_value is not None:
+                return forward_large_head(query, shared_key, shared_value)
+
         if (
             attn_metadata.attn_state == AscendAttentionState.DecodeOnly
-            and using_paged_attention(num_tokens, self.vllm_config)
             and self.sliding_window is None
+            and (using_paged_attention(num_tokens, self.vllm_config) or use_large_head_fallback)
         ):
+            # A2/A3 FIA decode also cannot use the unsupported large-head path;
+            # paged attention is the existing decode fallback.
             output = self.forward_paged_attention(query, attn_metadata, output)
+        elif (
+            not _EXTRA_CTX.capturing
+            and use_large_head_fallback
+            and self.kv_sharing_target_layer_name is None
+            and key is not None
+            and value is not None
+            and query.shape[0] == key.shape[0]
+            and attn_metadata.attn_state in (AscendAttentionState.PrefillNoCache, AscendAttentionState.ChunkedPrefill)
+        ):
+            output = forward_large_head(query, key, value)
         else:
             output = self.forward_fused_infer_attention(query, key, value, attn_metadata, output, kv_cache)
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -17,11 +17,13 @@
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import Literal, NamedTuple
 
 import torch
 import torch_npu
 import vllm.envs as envs_vllm
-from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.config import CUDAGraphMode, VllmConfig, get_current_vllm_config
+from vllm.forward_context import get_forward_context
 from vllm.distributed import get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backend import (  # type: ignore
@@ -49,12 +51,7 @@ from vllm_ascend.attention.kvcomp_attn.attention_utils import (
 )
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
-    cache_graph_workspace,
     enable_cp,
-    forward_large_head_prefill_attention,
-    get_current_token_kv_from_cache,
-    needs_fia_large_head_fallback,
-    needs_layer_aware_fia_graph_replay,
     split_decodes_and_prefills,
     using_paged_attention,
 )
@@ -68,11 +65,51 @@ from vllm_ascend.compilation.acl_graph import (
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.ops.flashcomm2_oshard_manager import flashcomm2_oshard_manager
 from vllm_ascend.utils import weak_ref_tensors
+
 from vllm_ascend.worker.kvcomp_utils import KVCompMetaData
 
 # default max value of sliding window size
 SWA_INT_MAX = 2147483647
 _ATTN_KEYS_BUFFER = None
+
+# Ascend FIA TND currently supports these head dimensions on the vLLM-Ascend
+# path. Larger heterogeneous-head models need a prefill fallback to avoid
+# unsupported-kernel behavior.
+FIA_TND_SUPPORTED_HEAD_SIZES = {64, 128, 192, 256}
+
+# Global counter for assigning unique per-layer indices to
+# AscendAttentionBackendImpl instances during graph construction.
+_next_impl_index = 0
+
+GraphParamKind = Literal["paged_attention", "fia"]
+
+
+class AttentionGraphParam(NamedTuple):
+    """Captured attention graph metadata.
+
+    `kind` records which attention op was captured, and `layer_name` binds the
+    captured params back to the real attention layer during graph replay. This
+    avoids inferring op type from tuple length or relying on metadata dict order.
+    """
+
+    kind: GraphParamKind
+    params: tuple
+    layer_name: str | None
+
+
+def _normalize_graph_param(param: AttentionGraphParam, fallback_layer_name: str) -> tuple[GraphParamKind, tuple, str]:
+    if not isinstance(param, AttentionGraphParam):
+        raise TypeError(f"Expected AttentionGraphParam, got {type(param).__name__}")
+    return param.kind, param.params, param.layer_name or fallback_layer_name
+
+
+def _get_graph_param_kind(param: AttentionGraphParam) -> GraphParamKind:
+    kind, _, _ = _normalize_graph_param(param, "")
+    return kind
+
+
+def _uses_sliding_window_attention(vllm_config: VllmConfig) -> bool:
+    return getattr(vllm_config.model_config.hf_text_config, "sliding_window", None) is not None
 
 
 @register_backend(AttentionBackendEnum.CUSTOM, "ASCEND")
@@ -108,7 +145,7 @@ class AscendAttentionBackend(AttentionBackend):
         block_size: int,
         num_kv_heads: int,
         head_size: int,
-        cache_dtype_str: str = "",
+        cache_type: str = "",
     ) -> tuple[int, ...]:
         return (2, num_blocks, block_size, num_kv_heads, head_size)
 
@@ -173,6 +210,7 @@ class AscendMetadata:
     num_decode_tokens: int = 0
     num_prefills: int = 0
     num_decodes: int = 0
+    num_decodes_flatten: int = 0
 
     # The sequence length per sequence. Sequence length means the computed
     # tokens + new tokens (is None if it is a decoding).
@@ -310,46 +348,10 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
         attn_state = common_attn_metadata.attn_state
 
         # Get attn_mask from singleton AttentionMaskBuilder
-        attn_mask = self.attn_mask_builder.get_attention_mask(common_attn_metadata.causal, self.model_config)
+        attn_mask = self.attn_mask_builder.get_attention_mask(self.model_config)
 
         # TODO: Yet another unnecessary H2D while we already have a query_start_loc on device
         query_start_loc = query_start_loc_cpu.pin_memory().to(self.device, non_blocking=True)
-
-        actual_seq_lengths_q = query_start_loc_cpu[1:].tolist()
-        seq_lens_list = seq_lens.tolist()
-        # flashcomm1/SP (or cudagraph) padding makes the model runner insert a
-        # dummy padding request into query_start_loc to satisfy the FIA TND-layout
-        # constraint (sum of q lengths == hidden_states.shape[0]), bumping the
-        # q-derived batchSize by one. The query_start_loc buffer is sized
-        # `max_num_reqs + 2` to hold it, but the seq_lens and block_table buffers
-        # are only `max_num_reqs`, so when the batch is full the padded request
-        # overflows and `[:num_reqs_padded]` silently truncates them. FIA then
-        # fails (error 561002) checking, in order, the `actualSeqLengthsKv` length
-        # and then the block_table row count against batchSize. Pad them to match:
-        # the dummy request points at block 0, and its output is harmless because:
-        #   (1) read side: the attention output for padding tokens is trimmed by
-        #       `hidden_states = hidden_states[:-pad_size, :]` downstream;
-        #   (2) write side: reshape_and_cache slices key/value/slot_mapping to
-        #       `[:num_actual_tokens]` (unpadded count), so the dummy request
-        #       never writes to KV cache.
-        # So any valid positive KV length / zero block row is fine. Pad both
-        # seq_lens_list and the seq_lens tensor: full_graph_fia_v2 passes the
-        # seq_lens tensor (not seq_lens_list) as actual_seq_kvlen during graph
-        # capture, and _get_fia_params derives the PrefillCacheHit batch size from
-        # seq_lens.shape[0], so the tensor has to carry the dummy request too.
-        num_reqs_fia = len(actual_seq_lengths_q)
-        if len(seq_lens_list) < num_reqs_fia:
-            padding_len = num_reqs_fia - len(seq_lens_list)
-            seq_lens_list = seq_lens_list + [1] * padding_len
-            seq_lens = torch.cat([seq_lens, seq_lens.new_ones(padding_len)])
-        if block_table is not None and block_table.shape[0] < num_reqs_fia:
-            block_table = torch.cat(
-                [
-                    block_table,
-                    block_table.new_zeros((num_reqs_fia - block_table.shape[0], block_table.shape[1])),
-                ],
-                dim=0,
-            )
 
         attn_metadata = AscendMetadata(
             num_actual_tokens=num_actual_tokens,
@@ -358,9 +360,9 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
             query_start_loc=query_start_loc,
             seq_lens=seq_lens,
             seq_lens_cpu=seq_lens,
-            seq_lens_list=seq_lens_list,
+            seq_lens_list=seq_lens.tolist(),
             max_query_len=common_attn_metadata.max_query_len,
-            actual_seq_lengths_q=actual_seq_lengths_q,
+            actual_seq_lengths_q=query_start_loc_cpu[1:].tolist(),
             slot_mapping=slot_mapping,
             attn_mask=attn_mask,
             attn_state=attn_state,
@@ -435,21 +437,13 @@ class AscendAttentionBackendImpl(AttentionImpl):
         self.enable_c8_quant = self.vllm_config.quant_config is not None and getattr(
             self.vllm_config.quant_config, "enable_c8_quant", False
         )
-        self._use_layer_aware_fia_graph_replay = needs_layer_aware_fia_graph_replay()
-        self._use_max_workspace_for_fia_graph = self._use_layer_aware_fia_graph_replay
         self.sinks = sinks
         self.layerIndex = 0
         self.enable_hamming_sparse = is_enable_hamming_sparse()
-        # Some mixed-attention models cannot rely on the iteration order of
-        # attn_metadata during graph replay. Record the captured layer name only
-        # for that path.
         self._layer_name: str | None = None
-
-    def _graph_metadata_layer_name(self, layer: AttentionLayer | None = None) -> str | None:
-        layer_name = layer.layer_name if layer is not None else self._layer_name
-        # KV-sharing layers replay with the target layer's metadata instead of
-        # their own module name, matching vLLM's shared KV-cache ownership.
-        return self.kv_sharing_target_layer_name or layer_name
+        global _next_impl_index
+        self._impl_idx = _next_impl_index
+        _next_impl_index += 1
 
     @staticmethod
     def update_graph_params(
@@ -461,297 +455,273 @@ class AscendAttentionBackendImpl(AttentionImpl):
         num_dcp_pcp_tokens=None,
         draft_attn_metadatas=None,
     ):
-        use_layer_aware_replay = needs_layer_aware_fia_graph_replay()
-        if using_paged_attention(num_tokens, vllm_config):
-            # Paged Attention update logic
-            if _EXTRA_CTX.is_draft_model:
-                if _EXTRA_CTX.is_draft_model_prefill:
-                    graph_params = get_draft_graph_prefill_params()
-                else:
-                    graph_params = get_draft_graph_params()
+        if _EXTRA_CTX.is_draft_model:
+            if _EXTRA_CTX.is_draft_model_prefill:
+                graph_params = get_draft_graph_prefill_params()
             else:
-                graph_params = get_graph_params()
-            with torch.npu.stream(update_stream):
-                for key, param, handle, event in zip(
-                    forward_context.attn_metadata,
-                    graph_params.attn_params[num_tokens],
-                    graph_params.handles[num_tokens],
-                    graph_params.events[num_tokens],
-                ):
-                    (
-                        query,
-                        key_cache,
-                        value_cache,
-                        num_kv_heads,
-                        num_heads,
-                        scale,
-                        block_table,
-                        seq_lens,
-                        output,
-                    ) = param
-                    seq_lens = forward_context.attn_metadata[key].seq_lens
+                graph_params = get_draft_graph_params()
+        else:
+            graph_params = get_graph_params()
 
+        # Use key-based lookup (attn_params_by_key) when available.
+        # Falls back to zip-based pairing for backwards compatibility.
+        params_by_key = graph_params.attn_params_by_key.get(num_tokens, {})
+
+        if _EXTRA_CTX.is_draft_model:
+            attn_metadata = draft_attn_metadatas
+            attn_keys = list(attn_metadata[0].keys())
+        else:
+            attn_metadata = forward_context.attn_metadata
+            attn_keys = list(attn_metadata.keys())
+            # Sort attn_keys by layer index for deterministic order
+            attn_keys_length = len(graph_params.attn_params.get(num_tokens, []))
+            if attn_keys_length > 0:
+                global _ATTN_KEYS_BUFFER
+                if _ATTN_KEYS_BUFFER is None:
+                    import regex as re
+
+                    def extract_layer_index(key: str) -> int:
+                        match = re.search(r"(\d+)", key)
+                        return int(match.group(1)) if match else 0
+
+                    attn_keys_tmp = attn_keys[:attn_keys_length]
+                    attn_keys_tmp.sort(key=extract_layer_index)
+                    _ATTN_KEYS_BUFFER = attn_keys_tmp
+                attn_keys[:attn_keys_length] = _ATTN_KEYS_BUFFER
+
+        num_layers = len(attn_keys)
+        if num_layers == 0:
+            return
+
+        # Key-based lookup is only valid for the target model.
+        # For the draft model, each layer appears multiple times in the
+        # captured graph (once per spec step), so params_by_key (which
+        # stores only the last write per layer_name) would miss all but
+        # the final step's task groups, leaving the rest with stale
+        # capture-time parameters.  Force zip-based pairing for draft.
+        use_key_lookup = (len(params_by_key) > 0
+                          and not _EXTRA_CTX.is_draft_model)
+
+        if _EXTRA_CTX.is_draft_model:
+            # Zip-based: multiply keys to match captured count (one
+            # task group per layer per spec step).
+            captured_param_count = len(graph_params.attn_params.get(num_tokens, []))
+            if captured_param_count > 0:
+                attn_keys = attn_keys * (captured_param_count // num_layers)
+            _iter_items = [(None, k) for k in attn_keys]
+        else:
+            # Target model: filter to keys present in params_by_key
+            if use_key_lookup:
+                attn_keys = [k for k in attn_keys if k in params_by_key]
+            _iter_items = [(None, k) for k in attn_keys]
+
+        attn_count = 0
+        with torch.npu.stream(update_stream):
+            for _step_idx, key in _iter_items:
+                if use_key_lookup:
+                    # ---- key-based lookup (order-independent) ----
+                    param_info = params_by_key[key]
+                    # Skip task-group-free large_head layers: these capture
+                    # padded metadata tensor addresses directly and read
+                    # up-to-date content on each replay.
+                    if param_info.get("large_head"):
+                        continue
+                    param_tuple = param_info["params"]
+                    handle = param_info["handle"]
+                    event = param_info["event"]
+
+                    if isinstance(param_tuple, AttentionGraphParam):
+                        param_kind = param_tuple.kind
+                        _, params, layer_name = _normalize_graph_param(param_tuple, key)
+                    else:
+                        param_kind = "paged_attention" if len(param_tuple) == 9 else "fia"
+                        layer_name = key
+                        params = param_tuple
+                else:
+                    # ---- fallback: zip-based (original behaviour) ----
+                    param_idx = attn_count % max(len(graph_params.attn_params.get(num_tokens, [1])), 1)
+                    param_tuple = graph_params.attn_params[num_tokens][param_idx]
+                    handle = graph_params.handles[num_tokens][param_idx]
+                    event = graph_params.events[num_tokens][param_idx]
+
+                    if isinstance(param_tuple, AttentionGraphParam):
+                        param_kind, params, layer_name = _normalize_graph_param(param_tuple, key)
+                    else:
+                        param_kind = "paged_attention" if len(param_tuple) == 9 else "fia"
+                        layer_name = key
+                        params = param_tuple
+
+                # ---- dispatch based on param kind ----
+                if param_kind == "paged_attention":
+                    if handle is None:
+                        event.record(update_stream)
+                        continue
+                    (
+                        query, key_cache, value_cache,
+                        num_kv_heads, num_heads, scale,
+                        block_table, seq_lens, output,
+                    ) = params
+                    draft_step = _step_idx if _step_idx is not None else (attn_count // num_layers)
+                    if _EXTRA_CTX.is_draft_model:
+                        block_table = attn_metadata[draft_step][key].block_tables
+                        seq_lens = attn_metadata[draft_step][key].seq_lens
+                    else:
+                        metadata_key = layer_name if layer_name in attn_metadata else key
+                        current_attn_metadata = attn_metadata[metadata_key]
+                        block_table = current_attn_metadata.block_tables
+                        seq_lens = current_attn_metadata.seq_lens
                     workspace = torch_npu._npu_paged_attention_get_workspace(
-                        query=query,
-                        key_cache=key_cache,
-                        value_cache=value_cache,
-                        num_kv_heads=num_kv_heads,
-                        num_heads=num_heads,
-                        scale_value=scale,
-                        block_table=block_table,
-                        context_lens=seq_lens,
-                        out=output,
+                        query=query, key_cache=key_cache, value_cache=value_cache,
+                        num_kv_heads=num_kv_heads, num_heads=num_heads,
+                        scale_value=scale, block_table=block_table,
+                        context_lens=seq_lens, out=output,
                     )
                     torch.npu.graph_task_update_begin(update_stream, handle)
                     torch_npu._npu_paged_attention(
-                        query=query,
-                        key_cache=key_cache,
-                        value_cache=value_cache,
-                        num_kv_heads=num_kv_heads,
-                        num_heads=num_heads,
-                        scale_value=scale,
-                        block_table=block_table,
-                        context_lens=seq_lens,
-                        out=output,
-                        workspace=workspace,
+                        query=query, key_cache=key_cache, value_cache=value_cache,
+                        num_kv_heads=num_kv_heads, num_heads=num_heads,
+                        scale_value=scale, block_table=block_table,
+                        context_lens=seq_lens, out=output, workspace=workspace,
                     )
                     torch.npu.graph_task_update_end(update_stream)
                     event.record(update_stream)
-        elif _EXTRA_CTX.sinks:
-            # FIA update logic
-            if _EXTRA_CTX.is_draft_model:
-                graph_params = get_draft_graph_params()
-                attn_metadata = draft_attn_metadatas
-                attn_keys = list(attn_metadata[0].keys())
-            else:
-                graph_params = get_graph_params()
-                attn_metadata = forward_context.attn_metadata
-                attn_keys = list(attn_metadata.keys())
-            # For Qwen3-next, since the kv_cache_config has already categorized
-            # linear_attn and self_attn, the attn_metadata is first arranged with
-            # self_attn followed by linear_attn. Therefore, using zip directly
-            # filters out the update operations for linear_attn.
-            # TODO: We use a new variable `attn_keys` to ensure the loop count is
-            # correct after get by `zip` because of the new structure of the attn_metadata
-            # when running with the merged full eagle-graph. Should check it with Qwen3-next.
-            num_layers = len(attn_keys)
-            if num_layers == 0:
-                return
-            captured_attn_params = graph_params.attn_params[num_tokens]
-            handles = graph_params.handles[num_tokens]
-            events = graph_params.events[num_tokens]
-            graph_param_count = len(captured_attn_params)
-            workspace = graph_params.workspaces.get(num_tokens)
-            if _EXTRA_CTX.is_draft_model:
-                attn_keys = attn_keys * (graph_param_count // num_layers)
-            elif use_layer_aware_replay:
-                # One graph size can contain captured FIA ops from all layers.
-                # Repeat attn keys to match the captured op count, then use the
-                # stored layer name in each op param to resolve the exact
-                # metadata entry during replay.
-                attn_keys = [attn_keys[index % num_layers] for index in range(graph_param_count)]
-            attn_count = 0
-            with torch.npu.stream(update_stream):
-                for key, param, handle, event in zip(
-                    attn_keys,
-                    captured_attn_params,
-                    handles,
-                    events,
-                ):
-                    (
-                        query,
-                        key_cache,
-                        value,
-                        block_tables,
-                        attn_mask,
-                        block_size,
-                        seq_lens,
-                        num_kv_heads,
-                        num_heads,
-                        scale,
-                        sliding_window,
-                        sinks,
-                        attn_output,
-                        softmax_lse,
-                        layer_name,
-                    ) = param
 
+                elif _EXTRA_CTX.sinks:
+                    # FIA-V2 replay (sinks)
+                    (
+                        query, key_cache, value, block_tables, attn_mask,
+                        block_size, seq_lens, num_kv_heads, num_heads, scale,
+                        sliding_window, sinks, attn_output, softmax_lse,
+                    ) = params[:14]
+                    draft_step = _step_idx if _step_idx is not None else (attn_count // num_layers)
                     if _EXTRA_CTX.is_draft_model:
-                        draft_step = attn_count // num_layers
                         seq_lens = attn_metadata[draft_step][key].seq_lens_list
                         actual_seq_lengths_q = attn_metadata[draft_step][key].actual_seq_lengths_q
-                        attn_count = attn_count + 1
                     else:
-                        metadata_key = layer_name if layer_name is not None and layer_name in attn_metadata else key
-                        seq_lens = attn_metadata[metadata_key].seq_lens_list
-                        actual_seq_lengths_q = attn_metadata[metadata_key].actual_seq_lengths_q
-
+                        seq_lens = attn_metadata[key].seq_lens_list
+                        actual_seq_lengths_q = attn_metadata[key].actual_seq_lengths_q
                     torch.npu.graph_task_update_begin(update_stream, handle)
                     torch_npu.npu_fused_infer_attention_score_v2.out(
-                        query=query,
-                        key=key_cache,
-                        value=value,
-                        block_table=block_tables,
-                        atten_mask=attn_mask,
-                        input_layout="TND",
-                        block_size=block_size,
+                        query=query, key=key_cache, value=value,
+                        block_table=block_tables, atten_mask=attn_mask,
+                        input_layout="TND", block_size=block_size,
                         actual_seq_qlen=actual_seq_lengths_q,
                         actual_seq_kvlen=seq_lens,
                         num_key_value_heads=num_kv_heads,
                         num_query_heads=num_heads,
                         sparse_mode=4 if sliding_window is not None else 3,
                         pre_tokens=sliding_window if sliding_window is not None else SWA_INT_MAX,
-                        next_tokens=0,
-                        softmax_scale=scale,
+                        next_tokens=0, softmax_scale=scale,
                         learnable_sink=sinks,
-                        workspace=workspace,
+                        workspace=graph_params.workspaces.get(num_tokens),
                         out=[attn_output, softmax_lse],
                     )
                     torch.npu.graph_task_update_end(update_stream)
                     event.record(update_stream)
-        else:
-            # FIA update logic
-            if _EXTRA_CTX.is_draft_model:
-                if _EXTRA_CTX.is_draft_model_prefill:
-                    graph_params = get_draft_graph_prefill_params()
+
                 else:
-                    graph_params = get_draft_graph_params()
-                attn_metadata = draft_attn_metadatas
-                attn_keys = list(attn_metadata[0].keys())
-            else:
-                graph_params = get_graph_params()
-                attn_metadata = forward_context.attn_metadata
-                attn_keys = list(attn_metadata.keys())
-                if not use_layer_aware_replay:
-                    # Keep the original speculative-decoding ordering for
-                    # other models so EAGLE/DFlash graph replay keeps the
-                    # original ordering.
-                    attn_keys_length = len(graph_params.attn_params[num_tokens])
-                    global _ATTN_KEYS_BUFFER
-                    if _ATTN_KEYS_BUFFER is None:
-                        import regex as re
-
-                        def extract_layer_index(key: str) -> int:
-                            match = re.search(r"(\d+)", key)
-                            return int(match.group(1)) if match else 0
-
-                        attn_keys_tmp = attn_keys[:attn_keys_length]
-                        attn_keys_tmp.sort(key=extract_layer_index)
-                        _ATTN_KEYS_BUFFER = attn_keys_tmp
-                    attn_keys[:attn_keys_length] = _ATTN_KEYS_BUFFER
-            # For Qwen3-next, since the kv_cache_config has already categorized
-            # linear_attn and self_attn, the attn_metadata is first arranged with
-            # self_attn followed by linear_attn. Therefore, using zip directly
-            # filters out the update operations for linear_attn.
-            # TODO: We use a new variable `attn_keys` to ensure the loop count is
-            # correct after get by `zip` because of the new structure of the attn_metadata
-            # when running with the merged full eagle-graph. Should check it with Qwen3-next.
-            num_layers = len(attn_keys)
-            if num_layers == 0:
-                return
-            captured_attn_params = graph_params.attn_params[num_tokens]
-            handles = graph_params.handles[num_tokens]
-            events = graph_params.events[num_tokens]
-            graph_param_count = len(captured_attn_params)
-            workspace = graph_params.workspaces.get(num_tokens)
-            if _EXTRA_CTX.is_draft_model:
-                attn_keys = attn_keys * (graph_param_count // num_layers)
-            elif use_layer_aware_replay:
-                # Keep the replay loop length aligned with captured FIA ops;
-                # layer-specific metadata lookup below prevents global/sliding
-                # window layers from accidentally sharing the same metadata.
-                attn_keys = [attn_keys[index % num_layers] for index in range(graph_param_count)]
-            attn_count = 0
-            with torch.npu.stream(update_stream):
-                for key, param, handle, event in zip(
-                    attn_keys,
-                    captured_attn_params,
-                    handles,
-                    events,
-                ):
+                    # FIA replay (no sinks)
                     (
-                        query,
-                        key_cache,
-                        value,
-                        block_tables,
-                        attn_mask,
-                        block_size,
-                        seq_lens,
-                        query_start_loc,
-                        num_kv_heads,
-                        num_heads,
-                        scale,
-                        attn_output,
-                        softmax_lse,
-                        sparse_mode,
-                        pre_tokens,
-                        next_tokens,
-                        c8_k_aq_scale,
-                        c8_k_aq_offset,
-                        c8_v_aq_scale,
-                        c8_v_aq_offset,
-                        layer_name,
-                    ) = param
-
+                        query, key_cache, value, block_tables, attn_mask,
+                        block_size, seq_lens, actual_seq_lengths_q,
+                        num_kv_heads, num_heads, scale, attn_output, softmax_lse,
+                        sparse_mode, pre_tokens, next_tokens,
+                        c8_k_aq_scale, c8_k_aq_offset,
+                        c8_v_aq_scale, c8_v_aq_offset,
+                    ) = params[:21]
+                    draft_step = _step_idx if _step_idx is not None else (attn_count // num_layers)
                     if _EXTRA_CTX.is_draft_model:
-                        draft_step = attn_count // num_layers
                         seq_lens = attn_metadata[draft_step][key].seq_lens_list
                         actual_seq_lengths_q = attn_metadata[draft_step][key].actual_seq_lengths_q
-                        block_tables = attn_metadata[draft_step][key].block_tables
-                        attn_count = attn_count + 1
-                        if not attn_metadata[draft_step][key].causal:
-                            sparse_mode = 0
                     else:
-                        metadata_key = layer_name if layer_name is not None and layer_name in attn_metadata else key
-                        seq_lens = attn_metadata[metadata_key].seq_lens_list
-                        actual_seq_lengths_q = attn_metadata[metadata_key].actual_seq_lengths_q
-                        # NOTE:
-                        # For models with sliding-window attention on the FIA full-graph replay path,
-                        # rebinding `block_tables` to the latest metadata tensor causes corrupted /
-                        # repeated outputs in our repro on Ascend NPU.
-                        #
-                        # Keep the captured block_tables tensor on this affected path.
-                        # Non-SWA models preserve the original behavior and continue to refresh
-                        # block_tables from attn_metadata.
-                        if not hasattr(vllm_config.model_config.hf_text_config, "sliding_window"):
-                            block_tables = attn_metadata[metadata_key].block_tables
+                        seq_lens = attn_metadata[key].seq_lens_list
+                        actual_seq_lengths_q = attn_metadata[key].actual_seq_lengths_q
+                    import sys
+                    _head_dim = query.shape[2] if query.dim() >= 3 else 0
+                    _ws = graph_params.workspaces.get(num_tokens)
+                    # FIA (both V1 and V2) crashes on Ascend 910B4 when
+                    # num_tokens > 1 AND sparse_mode=4 (sliding window)
+                    # AND head_dim > 128.  These layers use
+                    # forward_paged_attention during capture.  Use
+                    # _npu_paged_attention for the update to match.
+                    # NOTE: In FULL_DECODE_ONLY mode, FIA IS used
+                    # for sliding window layers (head_dim=256) during
+                    # capture (PA fails during FDO capture).  The
+                    # update must match — skip the PA fallback during
+                    # FDO replay.
+                    use_pa = (num_tokens > 1 and sparse_mode == 4
+                              and _head_dim > 128
+                              and get_forward_context().cudagraph_runtime_mode
+                              != CUDAGraphMode.FULL)
+                    if use_pa:
+                        # _npu_paged_attention expects tensors for
+                        # context_lens.  seq_lens from attn_metadata
+                        # may be a list.
+                        _pa_seq_lens = torch.tensor(
+                            seq_lens, dtype=torch.int32, device=query.device
+                        ) if not isinstance(seq_lens, torch.Tensor) else seq_lens
+                        _pa_workspace = torch_npu._npu_paged_attention_get_workspace(
+                            query=query,
+                            key_cache=key_cache,
+                            value_cache=value,
+                            num_kv_heads=num_kv_heads,
+                            num_heads=num_heads,
+                            scale_value=scale,
+                            block_table=block_tables,
+                            context_lens=_pa_seq_lens,
+                            out=attn_output,
+                        )
+                        torch.npu.graph_task_update_begin(update_stream, handle)
+                        torch_npu._npu_paged_attention(
+                            query=query,
+                            key_cache=key_cache,
+                            value_cache=value,
+                            num_kv_heads=num_kv_heads,
+                            num_heads=num_heads,
+                            scale_value=scale,
+                            block_table=block_tables,
+                            context_lens=_pa_seq_lens,
+                            out=attn_output,
+                            workspace=_pa_workspace,
+                        )
+                        torch.npu.graph_task_update_end(update_stream)
+                        event.record(update_stream)
+                        attn_count += 1
+                        continue
 
-                    torch.npu.graph_task_update_begin(update_stream, handle)
                     input_layout = "TND"
                     extra_args = {}
+                    # Detect c8_quant from captured params (static method, no self)
                     if c8_k_aq_scale is not None:
                         extra_args = {
                             "key_antiquant_scale": c8_k_aq_scale,
+                            "key_antiquant_offset": c8_k_aq_offset,
                             "value_antiquant_scale": c8_v_aq_scale,
+                            "value_antiquant_offset": c8_v_aq_offset,
                             "key_antiquant_mode": 0,
                             "value_antiquant_mode": 0,
-                            "inner_precise": 1,
                         }
                         input_layout = "BNSD"
                         sparse_mode = 0
+                    _ws = graph_params.workspaces.get(num_tokens)
+                    torch.npu.graph_task_update_begin(update_stream, handle)
                     torch_npu.npu_fused_infer_attention_score.out(
-                        query=query,
-                        key=key_cache,
-                        value=value,
-                        block_table=block_tables,
-                        atten_mask=attn_mask,
-                        input_layout=input_layout,
-                        block_size=block_size,
+                        query=query, key=key_cache, value=value,
+                        block_table=block_tables, atten_mask=attn_mask,
+                        input_layout=input_layout, block_size=block_size,
                         actual_seq_lengths=actual_seq_lengths_q,
                         actual_seq_lengths_kv=seq_lens,
-                        num_key_value_heads=num_kv_heads,
-                        num_heads=num_heads,
-                        scale=scale,
-                        sparse_mode=sparse_mode,
-                        pre_tokens=pre_tokens,
-                        next_tokens=next_tokens,
+                        num_key_value_heads=num_kv_heads, num_heads=num_heads,
+                        scale=scale, sparse_mode=sparse_mode,
+                        pre_tokens=pre_tokens, next_tokens=next_tokens,
                         **extra_args,
-                        workspace=workspace,
+                        workspace=_ws,
                         out=[attn_output, softmax_lse],
                     )
                     torch.npu.graph_task_update_end(update_stream)
-
                     event.record(update_stream)
+                attn_count += 1
+
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         super().process_weights_after_loading(act_dtype)
@@ -785,6 +755,11 @@ class AscendAttentionBackendImpl(AttentionImpl):
         else:
             graph_params = get_graph_params()
         actual_seq_lengths_q = attn_metadata.actual_seq_lengths_q
+        # Prepare tensors for attention output
+        # TODO: Refactor this to step-level instead of layer-level
+
+        # Get workspace from cache or calculate it if not present.
+        workspace = graph_params.workspaces.get(num_tokens)
         softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
         input_layout = "TND"
         attn_mask = attn_metadata.attn_mask
@@ -793,58 +768,22 @@ class AscendAttentionBackendImpl(AttentionImpl):
         next_tokens = 0 if self.sliding_window else SWA_INT_MAX
 
         extra_args = {}
-        if self.enable_c8_quant and layer is not None:
+        if self.enable_c8_quant:
             extra_args = {
-                "key_antiquant_scale": layer._c8_k_aq_scale_nz_bnsd,
-                "value_antiquant_scale": layer._c8_v_aq_scale_nz_bnsd,
+                "key_antiquant_scale": layer._c8_k_aq_scale,
+                "key_antiquant_offset": layer._c8_k_aq_offset,
+                "value_antiquant_scale": layer._c8_v_aq_scale,
+                "value_antiquant_offset": layer._c8_v_aq_offset,
                 "key_antiquant_mode": 0,
                 "value_antiquant_mode": 0,
-                "inner_precise": 1,
             }
-
-            # change key/value shape
-            _, block_size, _, _ = self.key_cache.shape  # type: ignore
-            key = self._nz_5d_view(self.key_cache, block_size)
-            value = self._nz_5d_view(self.value_cache, block_size)
-
-            # TODO: change layerout from BNSD to TND.
+            # TODO: Convert kvcache to NZ, and change layerout from BNSD to TND.
             input_layout = "BNSD"
             query = query.unsqueeze(2)
             output = output.unsqueeze(2)
             attn_mask = None
             sparse_mode = 0
-        use_max_workspace = self._use_max_workspace_for_fia_graph
-        workspace = graph_params.workspaces.get(num_tokens)
-        should_update_workspace_cache = False
-        if use_max_workspace:
-            # Some models mix attention layer shapes under the same graph size.
-            # During capture, keep the largest required workspace for that size.
-            candidate_workspace = torch_npu._npu_fused_infer_attention_score_get_max_workspace(
-                query=query,
-                key=key,
-                value=value,
-                atten_mask=attn_mask,
-                block_table=block_table,
-                input_layout=input_layout,
-                block_size=block_size,
-                actual_seq_lengths=actual_seq_lengths_q,
-                actual_seq_lengths_kv=actual_seq_lengths_kv,
-                num_key_value_heads=self.num_kv_heads,
-                num_heads=self.num_heads,
-                sparse_mode=sparse_mode,
-                pre_tokens=pre_tokens,
-                next_tokens=next_tokens,
-                scale=self.scale,
-                **extra_args,
-            )
-            workspace = cache_graph_workspace(
-                graph_params,
-                num_tokens,
-                candidate_workspace,
-                use_max_workspace=use_max_workspace,
-            )
-            should_update_workspace_cache = True
-        elif workspace is None:
+        if workspace is None:
             workspace = torch_npu._npu_fused_infer_attention_score_get_max_workspace(
                 query=query,
                 key=key,
@@ -863,8 +802,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 scale=self.scale,
                 **extra_args,
             )
-            should_update_workspace_cache = True
-        if should_update_workspace_cache:
             if _EXTRA_CTX.is_draft_model:
                 update_draft_graph_params_workspaces(num_tokens, workspace)
             else:
@@ -877,6 +814,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
         event.wait(stream)
         event.reset(stream)
         graph_params.events[num_tokens].append(event)
+        # Record the owning layer so graph replay can refresh metadata by the
+        # real attention layer instead of relying on dict iteration order.
+        layer_name = layer.layer_name if layer is not None else self._layer_name
         attn_params = (
             weak_ref_tensors(query),
             weak_ref_tensors(key),
@@ -895,18 +835,16 @@ class AscendAttentionBackendImpl(AttentionImpl):
             pre_tokens,
             next_tokens,
         )
-        if self.enable_c8_quant and layer is not None:
+        if self.enable_c8_quant:
             attn_params = attn_params + (
-                weak_ref_tensors(layer._c8_k_aq_scale_nz_bnsd),
-                None,
-                weak_ref_tensors(layer._c8_v_aq_scale_nz_bnsd),
-                None,
+                weak_ref_tensors(layer._c8_k_aq_scale),
+                weak_ref_tensors(layer._c8_k_aq_offset),
+                weak_ref_tensors(layer._c8_v_aq_scale),
+                weak_ref_tensors(layer._c8_v_aq_offset),
             )  # type: ignore
         else:
             attn_params = attn_params + (None, None, None, None)  # type: ignore
-        layer_name = self._graph_metadata_layer_name(layer) if self._use_layer_aware_fia_graph_replay else None
-        attn_params = attn_params + (layer_name,)  # type: ignore
-        graph_params.attn_params[num_tokens].append(attn_params)
+        graph_params.attn_params[num_tokens].append(AttentionGraphParam("fia", attn_params, layer_name))
 
         torch.npu.graph_task_group_begin(stream)
         torch_npu.npu_fused_infer_attention_score.out(
@@ -934,6 +872,20 @@ class AscendAttentionBackendImpl(AttentionImpl):
 
         handle = torch.npu.graph_task_group_end(stream)
         graph_params.handles[num_tokens].append(handle)
+
+        # Store by key for order-independent replay lookup.
+        # Skip for draft model: each layer appears multiple times
+        # (once per spec step), so by-name storage would lose all
+        # but the last step's task group.
+        if (not _EXTRA_CTX.is_draft_model
+                and layer_name
+                and num_tokens in graph_params.attn_params_by_key):
+            graph_params.attn_params_by_key[num_tokens][layer_name] = {
+                "params": graph_params.attn_params[num_tokens][-1],
+                "handle": handle,
+                "event": event,
+            }
+
         return output, num_tokens
 
     def full_graph_fia_v2(
@@ -953,39 +905,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
             graph_params = get_graph_params()
 
         actual_seq_lengths_q = attn_metadata.actual_seq_lengths_q
-        softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
-        use_max_workspace = self._use_max_workspace_for_fia_graph
         workspace = graph_params.workspaces.get(num_tokens)
-        should_update_workspace_cache = False
-        if use_max_workspace:
-            # See full_graph_fia: this path needs the max workspace across layer
-            # variants sharing the same graph size.
-            candidate_workspace = torch_npu._npu_fused_infer_attention_score_v2_get_max_workspace(
-                query=query,
-                key=key,
-                value=value,
-                atten_mask=attn_metadata.attn_mask,
-                block_table=block_table,
-                input_layout="TND",
-                block_size=block_size,
-                actual_seq_qlen=actual_seq_lengths_q,
-                actual_seq_kvlen=actual_seq_lengths_kv,
-                num_key_value_heads=self.num_kv_heads,
-                softmax_scale=self.scale,
-                num_query_heads=self.num_heads,
-                sparse_mode=4 if self.sliding_window is not None else 3,
-                pre_tokens=self.sliding_window if self.sliding_window is not None else SWA_INT_MAX,
-                next_tokens=0,
-                learnable_sink=self.sinks,
-            )
-            workspace = cache_graph_workspace(
-                graph_params,
-                num_tokens,
-                candidate_workspace,
-                use_max_workspace=use_max_workspace,
-            )
-            should_update_workspace_cache = True
-        elif workspace is None:
+        softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
+        if workspace is None:
             workspace = torch_npu._npu_fused_infer_attention_score_v2_get_max_workspace(
                 query=query,
                 key=key,
@@ -1004,8 +926,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 next_tokens=0,
                 learnable_sink=self.sinks,
             )
-            should_update_workspace_cache = True
-        if should_update_workspace_cache:
+
             if _EXTRA_CTX.is_draft_model:
                 update_draft_graph_params_workspaces(num_tokens, workspace)
             else:
@@ -1034,9 +955,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 self.sinks,
                 weak_ref_tensors(output),
                 weak_ref_tensors(softmax_lse),
-                self._graph_metadata_layer_name() if self._use_layer_aware_fia_graph_replay else None,
             )
         )
+        global _FIA_CAPTURE_COUNT
+        _FIA_CAPTURE_COUNT += 1
         torch.npu.graph_task_group_begin(stream)
         torch_npu.npu_fused_infer_attention_score_v2.out(
             query=query,
@@ -1062,13 +984,101 @@ class AscendAttentionBackendImpl(AttentionImpl):
         graph_params.handles[num_tokens].append(handle)
         return output, num_tokens
 
+    def _full_graph_pa_large_head(
+        self,
+        query: torch.Tensor,
+        attn_metadata: AscendMetadata,
+        output: torch.Tensor | None = None,
+    ):
+        """Capture PA op directly without task group wrapping.
+
+        Used as a workaround for models whose head_dim is not supported by
+        FIA TND (e.g. Gemma4 with head_dim=256/512). When all layers use
+        the PA fallback, ``full_graph_pa`` creates a task group per layer
+        (60 task groups for Gemma4 31B), which can exceed the CANN runtime
+        task-group limit and fail with error 107033 during
+        ``rtStreamEndCapture``.
+
+        In FULL_DECODE_ONLY mode the padded attention metadata tensors
+        (block_table, seq_lens) reside at stable addresses.  The graph
+        captures those addresses directly and reads the up-to-date content
+        during replay, so task groups are unnecessary.
+        """
+        if _EXTRA_CTX.is_draft_model:
+            graph_params = get_draft_graph_params()
+        else:
+            graph_params = get_graph_params()
+        num_tokens = query.shape[0]
+        if _EXTRA_CTX.capturing:
+            # Get workspace from cache or calculate it if not present.
+            workspace = graph_params.workspaces.get(num_tokens)
+            if workspace is None:
+                workspace = torch_npu._npu_paged_attention_get_workspace(
+                    query=query,
+                    key_cache=self.key_cache,
+                    value_cache=self.value_cache,
+                    num_kv_heads=self.num_kv_heads,
+                    num_heads=self.num_heads,
+                    scale_value=self.scale,
+                    block_table=attn_metadata.block_tables,
+                    context_lens=attn_metadata.seq_lens,
+                    out=output,
+                )
+                update_graph_params_workspaces(num_tokens, workspace)
+
+            # Direct PA call inside graph context -- no task group,
+            # no event, no handle.  Padded metadata tensors at stable
+            # addresses provide current data on each replay.
+            torch_npu._npu_paged_attention(
+                query=query,
+                key_cache=self.key_cache,
+                value_cache=self.value_cache,
+                num_kv_heads=self.num_kv_heads,
+                num_heads=self.num_heads,
+                scale_value=self.scale,
+                block_table=attn_metadata.block_tables,
+                context_lens=attn_metadata.seq_lens,
+                out=output,
+                workspace=workspace,
+            )
+
+            # Register in attn_params_by_key for diagnostics and to mark
+            # this layer as handled (task-group-free; skip during replay).
+            # Register for diagnostics; skip draft model for same
+            # reason as full_graph_pa (multi-step overwrite).
+            layer_name = self._layer_name
+            if (not _EXTRA_CTX.is_draft_model
+                    and layer_name
+                    and num_tokens in graph_params.attn_params_by_key):
+                graph_params.attn_params_by_key[num_tokens][layer_name] = {
+                    "params": (
+                        weak_ref_tensors(query),
+                        weak_ref_tensors(self.key_cache),
+                        weak_ref_tensors(self.value_cache),
+                        self.num_kv_heads,
+                        self.num_heads,
+                        self.scale,
+                        attn_metadata.block_tables,
+                        attn_metadata.seq_lens,
+                        weak_ref_tensors(output),
+                    ),
+                    "handle": None,
+                    "event": None,
+                    "large_head": True,
+                }
+
+            return output
+
     def full_graph_pa(
         self,
         query: torch.Tensor,
         attn_metadata: AscendMetadata,
         output: torch.Tensor | None = None,
     ):
-        graph_params = get_graph_params()
+        if _EXTRA_CTX.is_draft_model:
+            graph_params = get_draft_graph_params()
+        else:
+            graph_params = get_graph_params()
         num_tokens = query.shape[0]
         if _EXTRA_CTX.capturing:
             # Get workspace from cache or calculate it if not present.
@@ -1095,34 +1105,100 @@ class AscendAttentionBackendImpl(AttentionImpl):
             event.reset(stream)
             graph_params.events[num_tokens].append(event)
             graph_params.attn_params[num_tokens].append(
-                (
-                    weak_ref_tensors(query),
-                    weak_ref_tensors(self.key_cache),
-                    weak_ref_tensors(self.value_cache),
-                    self.num_kv_heads,
-                    self.num_heads,
-                    self.scale,
-                    attn_metadata.block_tables,
-                    attn_metadata.seq_lens,
-                    weak_ref_tensors(output),
+                AttentionGraphParam(
+                    "paged_attention",
+                    (
+                        weak_ref_tensors(query),
+                        weak_ref_tensors(self.key_cache),
+                        weak_ref_tensors(self.value_cache),
+                        self.num_kv_heads,
+                        self.num_heads,
+                        self.scale,
+                        attn_metadata.block_tables,
+                        attn_metadata.seq_lens,
+                        weak_ref_tensors(output),
+                    ),
+                    self._layer_name,
                 )
             )
 
-            torch.npu.graph_task_group_begin(stream)
-            torch_npu._npu_paged_attention(
-                query=query,
-                key_cache=self.key_cache,
-                value_cache=self.value_cache,
-                num_kv_heads=self.num_kv_heads,
-                num_heads=self.num_heads,
-                scale_value=self.scale,
-                block_table=attn_metadata.block_tables,
-                context_lens=attn_metadata.seq_lens,
-                out=output,
-                workspace=workspace,
+            # PIECEWISE: PA with task groups works correctly.
+            # FULL_DECODE_ONLY: PA fails both with and without task groups
+            # (Inner error during capture, setup failed during replay).
+            # Use PyTorch SDPA which decomposes into capturable ops.
+            _is_fdo = (
+                get_forward_context().cudagraph_runtime_mode
+                == CUDAGraphMode.FULL
             )
-            handle = torch.npu.graph_task_group_end(stream)
-            graph_params.handles[num_tokens].append(handle)
+            if _is_fdo:
+                import torch.nn.functional as F
+                # Gather KV from paged cache → dense [num_tokens, heads, dim]
+                _block_size = self.key_cache.shape[1]
+                _num_kv_heads = self.num_kv_heads
+                _num_heads = self.num_heads
+                _head_dim = self.head_size
+                # Use block_table to gather: [num_reqs, max_blocks] → flat
+                _bt = attn_metadata.block_tables.long()
+                _num_reqs = _bt.shape[0]
+                _max_blocks = _bt.shape[1]
+                _flat_ids = _bt.reshape(-1)
+                _k = self.key_cache.index_select(0, _flat_ids)
+                _k = _k.view(_num_reqs, _max_blocks, _block_size, _num_kv_heads, _head_dim)
+                _k = _k.permute(0, 3, 1, 2, 4).reshape(_num_reqs, _num_kv_heads, _max_blocks * _block_size, _head_dim)
+                # Slice to actual seq lens
+                _max_len = int(_bt.shape[1] * _block_size)
+                _k = _k[:, :, :_max_len, :].reshape(_num_reqs * _max_len, _num_kv_heads, _head_dim)[:num_tokens]
+                _v = self.value_cache.index_select(0, _flat_ids)
+                _v = _v.view(_num_reqs, _max_blocks, _block_size, _num_kv_heads, _head_dim)
+                _v = _v.permute(0, 3, 1, 2, 4).reshape(_num_reqs, _num_kv_heads, _max_blocks * _block_size, _head_dim)
+                _v = _v[:, :, :_max_len, :].reshape(_num_reqs * _max_len, _num_kv_heads, _head_dim)[:num_tokens]
+                # GQA: repeat KV heads
+                if _num_heads != _num_kv_heads:
+                    _rep = _num_heads // _num_kv_heads
+                    _k = _k.repeat_interleave(_rep, dim=1)
+                    _v = _v.repeat_interleave(_rep, dim=1)
+                _q = query[:num_tokens]
+                _attn_out = F.scaled_dot_product_attention(
+                    _q.unsqueeze(0).transpose(1, 2),
+                    _k.unsqueeze(0).transpose(1, 2),
+                    _v.unsqueeze(0).transpose(1, 2),
+                    is_causal=True,
+                    scale=self.scale,
+                )
+                output[:num_tokens] = _attn_out.squeeze(0).transpose(0, 1)[:num_tokens]
+                # Keep handles aligned with attn_params for downstream indexing
+                graph_params.handles[num_tokens].append(None)
+            else:
+                torch.npu.graph_task_group_begin(stream)
+                torch_npu._npu_paged_attention(
+                    query=query,
+                    key_cache=self.key_cache,
+                    value_cache=self.value_cache,
+                    num_kv_heads=self.num_kv_heads,
+                    num_heads=self.num_heads,
+                    scale_value=self.scale,
+                    block_table=attn_metadata.block_tables,
+                    context_lens=attn_metadata.seq_lens,
+                    out=output,
+                    workspace=workspace,
+                )
+                handle = torch.npu.graph_task_group_end(stream)
+                graph_params.handles[num_tokens].append(handle)
+
+            # Store by key for order-independent replay lookup.
+            # Skip for draft model: each layer appears multiple
+            # times (once per spec step), so by-name storage would
+            # lose all but the last step's task group.
+            layer_name = self._layer_name
+            if (not _EXTRA_CTX.is_draft_model
+                    and layer_name
+                    and num_tokens in graph_params.attn_params_by_key):
+                graph_params.attn_params_by_key[num_tokens][layer_name] = {
+                    "params": graph_params.attn_params[num_tokens][-1],
+                    "handle": graph_params.handles[num_tokens][-1] if graph_params.handles.get(num_tokens) else None,
+                    "event": event,
+                }
+
             return output
 
     def _get_fia_params(self, key: torch.Tensor, value: torch.Tensor, attn_metadata: AscendMetadata, kv_cache=None):
@@ -1314,10 +1390,23 @@ class AscendAttentionBackendImpl(AttentionImpl):
     ) -> torch.Tensor:
         if _EXTRA_CTX.capturing:
             return self.full_graph_pa(query, attn_metadata, output)
+        # KV sharing: swap to target's key_cache
+        _target_impl = getattr(self, '_kv_share_target_impl', None)
+        _has_tgt_cache = (
+            _target_impl is not None
+            and getattr(_target_impl, 'key_cache', None) is not None
+        )
+        if _has_tgt_cache:
+            _kc = _target_impl.key_cache
+            _vc = _target_impl.value_cache
+        else:
+            _kc = self.key_cache
+            _vc = self.value_cache
+
         torch_npu._npu_paged_attention(
             query=query,
-            key_cache=self.key_cache,
-            value_cache=self.value_cache,
+            key_cache=_kc,
+            value_cache=_vc,
             num_kv_heads=self.num_kv_heads,
             num_heads=self.num_heads,
             scale_value=self.scale,
@@ -1336,10 +1425,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
         _: torch.Tensor,
     ) -> torch.Tensor:
         # use default sparse_mode 0 in normal scenario, which means no mask works on it
-        # Pad actual_seq_len with 0 when num_tokens > actual_seq_len in TND layout
-        actual_seq_qlen = attn_metadata.actual_seq_lengths_q
-        if query.shape[0] > actual_seq_qlen[-1]:
-            actual_seq_qlen = actual_seq_qlen + [0]
         return torch_npu.npu_fusion_attention(
             query=query,
             key=key,
@@ -1347,9 +1432,413 @@ class AscendAttentionBackendImpl(AttentionImpl):
             head_num=self.num_heads,
             input_layout="TND",
             scale=self.scale,
-            actual_seq_qlen=actual_seq_qlen,
-            actual_seq_kvlen=actual_seq_qlen,
+            actual_seq_qlen=attn_metadata.actual_seq_lengths_q,
+            actual_seq_kvlen=attn_metadata.actual_seq_lengths_q,
         )[0]
+
+    def _fdo_safe_large_head_attention(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AscendMetadata,
+        output: torch.Tensor,
+        kv_cache=None,
+    ) -> torch.Tensor:
+        """FDO-capturable attention for large head_dim layers (>192).
+
+        PA and FIA v2 both fail during FULL_DECODE_ONLY capture for
+        head_dim >= 512.  Use PyTorch native SDPA which decomposes into
+        basic ops (matmul, softmax) that are graph-capturable.
+
+        For capture (dummy run), K/V tensors are provided directly
+        (ChunkedPrefill mode) — no paged cache gathering is needed.
+        """
+        import torch.nn.functional as F
+        num_tokens = query.shape[0]
+        num_heads = self.num_heads
+        num_kv_heads = self.num_kv_heads
+        head_size = self.head_size
+
+        q = query[:num_tokens].view(num_tokens, num_heads, head_size)
+        k = key[:num_tokens]
+        v = value[:num_tokens]
+
+        # GQA: repeat KV heads to match Q heads
+        if num_heads != num_kv_heads:
+            n_repeat = num_heads // num_kv_heads
+            k = k.repeat_interleave(n_repeat, dim=1)
+            v = v.repeat_interleave(n_repeat, dim=1)
+
+        # PyTorch native SDPA — uses optimal backend (flash/mem_efficient/math)
+        # and decomposes into capturable ops on Ascend.
+        attn_out = F.scaled_dot_product_attention(
+            q.unsqueeze(0).transpose(1, 2),   # [1, H, T, D]
+            k.unsqueeze(0).transpose(1, 2),   # [1, H, T_kv, D]
+            v.unsqueeze(0).transpose(1, 2),   # [1, H, T_kv, D]
+            is_causal=attn_metadata.causal,
+            scale=self.scale,
+        )
+        attn_out = attn_out.squeeze(0).transpose(0, 1)  # [T, H, D]
+        output[:num_tokens] = attn_out[:num_tokens]
+        return output
+
+    def _forward_large_head_prefill_attention(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AscendMetadata,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        num_tokens = attn_metadata.actual_seq_lengths_q[-1]
+        query = query[:num_tokens]
+        key, value, actual_seq_lengths_kv = self._get_large_head_prefill_kv(
+            key,
+            value,
+            attn_metadata,
+            num_tokens,
+        )
+
+        # Ascend FIA (npu_fusion_attention) cannot handle cross-attention
+        # where actual_seq_qlen differs from actual_seq_kvlen — it either
+        # crashes or produces zero / garbage output.  When KV was gathered
+        # from the paged cache (ChunkedPrefill / SpecDecoding), the KV
+        # length exceeds the query length.  Use PyTorch native SDPA for
+        # correct cross-attention; otherwise keep FIA for self-attention.
+        if key.shape[0] != num_tokens:
+            # Cross-attention: K/V gathered from cache is longer than Q.
+            # Ascend FIA cannot handle different Q/KV lengths; use PyTorch
+            # SDPA with a correct causal cross-attention mask.
+            import torch.nn.functional as F_sdpa
+            num_heads = self.num_heads
+            num_kv_heads = self.num_kv_heads
+            head_size = self.head_size
+
+            q = query.view(num_tokens, num_heads, head_size)
+            k = key
+            v = value
+
+            # GQA: repeat KV heads to match Q heads
+            if num_heads != num_kv_heads:
+                n_rep = num_heads // num_kv_heads
+                k = k.repeat_interleave(n_rep, dim=1)
+                v = v.repeat_interleave(n_rep, dim=1)
+
+            # PyTorch SDPA in 4D format [B, H, L, D].
+            # When Q/KV lengths differ, is_causal=True is invalid
+            # (PyTorch raises an error).  Build the correct causal
+            # cross-attention mask: query position i can attend to
+            # KV positions [0, kv_len - q_len + i].
+            is_causal = attn_metadata.causal
+            if is_causal and q.shape[0] != k.shape[0]:
+                q_len = q.shape[0]
+                kv_len = k.shape[0]
+                attn_mask = torch.full(
+                    (q_len, kv_len), float('-inf'),
+                    dtype=q.dtype, device=q.device)
+                offset = kv_len - q_len
+                for i_ in range(q_len):
+                    attn_mask[i_, :offset + i_ + 1] = 0
+                is_causal = False
+            else:
+                attn_mask = None
+            attn_out = F_sdpa.scaled_dot_product_attention(
+                q.unsqueeze(0).transpose(1, 2),   # [1, H, T_q, D]
+                k.unsqueeze(0).transpose(1, 2),   # [1, H, T_kv, D]
+                v.unsqueeze(0).transpose(1, 2),   # [1, H, T_kv, D]
+                attn_mask=attn_mask,
+                is_causal=is_causal,
+                scale=self.scale,
+            )
+            attn_out = attn_out.squeeze(0).transpose(0, 1)  # [T_q, H, D]
+            output[:num_tokens] = attn_out[:num_tokens]
+        else:
+            # Self-attention: Q length == KV length.
+            # FIA TND only supports head_dim in {64,128,192,256}.
+            # For unsupported head_dims (e.g. 512), use PyTorch SDPA.
+            if self.head_size in FIA_TND_SUPPORTED_HEAD_SIZES:
+                sparse_mode = 4 if self.sliding_window is not None else 3 if attn_metadata.causal else 0
+                pre_tokens = self.sliding_window if self.sliding_window is not None else SWA_INT_MAX
+                next_tokens = 0 if attn_metadata.causal or self.sliding_window is not None else SWA_INT_MAX
+                attn_mask = attn_metadata.attn_mask
+                if attn_mask is not None and attn_mask.dtype not in (torch.bool, torch.uint8):
+                    attn_mask = attn_mask.bool()
+                attn_output = torch_npu.npu_fusion_attention(
+                    query=query,
+                    key=key,
+                    value=value,
+                    head_num=self.num_heads,
+                    input_layout="TND",
+                    atten_mask=attn_mask,
+                    scale=self.scale,
+                    pre_tockens=pre_tokens,
+                    next_tockens=next_tokens,
+                    actual_seq_qlen=attn_metadata.actual_seq_lengths_q,
+                    actual_seq_kvlen=actual_seq_lengths_kv,
+                    sparse_mode=sparse_mode,
+                )[0]
+            else:
+                # head_dim not supported by FIA TND → use PyTorch SDPA
+                import torch.nn.functional as F_sdpa
+                num_heads = self.num_heads
+                num_kv_heads = self.num_kv_heads
+                head_size = self.head_size
+
+                q = query.view(num_tokens, num_heads, head_size)
+                k = key.view(num_tokens, num_kv_heads, head_size)
+                v = value.view(num_tokens, num_kv_heads, head_size)
+
+                # GQA: repeat KV heads to match Q heads
+                if num_heads != num_kv_heads:
+                    n_rep = num_heads // num_kv_heads
+                    k = k.repeat_interleave(n_rep, dim=1)
+                    v = v.repeat_interleave(n_rep, dim=1)
+
+                attn_out = F_sdpa.scaled_dot_product_attention(
+                    q.unsqueeze(0).transpose(1, 2),   # [1, H, T, D]
+                    k.unsqueeze(0).transpose(1, 2),
+                    v.unsqueeze(0).transpose(1, 2),
+                    is_causal=attn_metadata.causal,
+                    scale=self.scale,
+                )
+                attn_output = attn_out.squeeze(0).transpose(0, 1)
+            output[:num_tokens] = attn_output[:num_tokens]
+        return output
+
+    def _forward_shared_kv_prefill_attention(
+        self,
+        query: torch.Tensor,
+        shared_key: torch.Tensor,
+        shared_value: torch.Tensor,
+        attn_metadata: AscendMetadata,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        """Manual PyTorch attention with already-dense shared KV from block_table.
+
+        Ascend FIA (npu_fusion_attention) cannot handle cross-attention where
+        actual_seq_qlen differs from actual_seq_kvlen — it either crashes with
+        mask shape errors or produces zero output.  Use PyTorch's
+        scaled_dot_product_attention instead, which correctly supports
+        cross-attention with arbitrary Q/KV lengths and GQA (grouped-query
+        attention).
+        """
+        import torch.nn.functional as F
+        num_tokens = attn_metadata.actual_seq_lengths_q[-1]
+        # Slice to actual query tokens.
+        # vLLM uses [seq_len, num_heads, head_dim] but PyTorch sdpa in 3D
+        # format requires equal Q/KV sequence lengths.  For cross-attention
+        # (where num_tokens != KV length) we must use 4D format:
+        #   [batch, num_heads, seq_len, head_dim]
+        q = query[:num_tokens]  # [T, H, D]
+        k = shared_key           # [S, Hkv, D]
+        v = shared_value         # [S, Hkv, D]
+
+        # Create causal cross-attention mask.  Query position i can attend
+        # to KV positions [0, kv_len - q_len + i].  For sliding-window
+        # layers, additionally restrict to the last `sliding_window` tokens.
+        S = k.shape[0]
+        offset = S - num_tokens
+        mask = torch.ones(num_tokens, S, dtype=q.dtype, device=q.device) * float('-inf')
+        for i in range(num_tokens):
+            window_start = max(0, i + offset - self.sliding_window + 1) \
+                if self.sliding_window is not None and S > self.sliding_window \
+                else 0
+            causal_end = i + offset + 1
+            mask[i, window_start:causal_end] = 0
+        attn_mask = mask
+
+        # Handle GQA: expand KV heads to match Q heads.
+        # Ascend NPU's scaled_dot_product_attention does not broadcast
+        # head dimension, so we must explicitly repeat KV heads.
+        # Use repeat_interleave (not expand+reshape) to preserve the
+        # correct head mapping: Q head i -> KV head i//n_rep.
+        if q.shape[1] != k.shape[1]:
+            n_rep = q.shape[1] // k.shape[1]
+            k = k.repeat_interleave(n_rep, dim=1)  # [S, Hkv, D] -> [S, Hq, D]
+            v = v.repeat_interleave(n_rep, dim=1)  # [S, Hkv, D] -> [S, Hq, D]
+
+        # Always use 4D format [B, H, L, D] for Ascend NPU.
+        # 3D format [T, H, D] causes inplace_add shape mismatch in
+        # Ascend's SDPA kernel when num_tokens is large (e.g. >2000).
+        q_4d = q.unsqueeze(0).transpose(1, 2)   # [T, H, D] -> [1, H, T, D]
+        k_4d = k.unsqueeze(0).transpose(1, 2)   # [S, H, D] -> [1, H, S, D]
+        v_4d = v.unsqueeze(0).transpose(1, 2)   # [S, H, D] -> [1, H, S, D]
+        if attn_mask is not None:
+            attn_mask = attn_mask.unsqueeze(0).unsqueeze(0)  # [T, S] -> [1, 1, T, S]
+        attn_output = F.scaled_dot_product_attention(
+            q_4d, k_4d, v_4d,
+            attn_mask=attn_mask,
+            scale=self.scale,
+        )  # [1, H, T, D]
+        attn_output = attn_output.squeeze(0).transpose(0, 1)  # [T, H, D]
+
+        output[:num_tokens] = attn_output
+        return output
+
+    def _get_large_head_prefill_kv(
+        self,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AscendMetadata,
+        num_tokens: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
+        if (
+            attn_metadata.attn_state == AscendAttentionState.PrefillNoCache
+            or self.key_cache is None
+            or self.value_cache is None
+        ):
+            return key[:num_tokens], value[:num_tokens], attn_metadata.actual_seq_lengths_q
+
+        seq_lens = attn_metadata.seq_lens_list
+        if not seq_lens:
+            return key[:num_tokens], value[:num_tokens], attn_metadata.actual_seq_lengths_q
+
+        # Chunked prefill can have historical KV already resident in the paged
+        # cache. The large-head fallback uses dense TND attention, so gather the
+        # paged KV blocks into sequence-major dense tensors first.
+        dense_key, dense_value = self._gather_paged_kv_to_dense(
+            self.key_cache,
+            self.value_cache,
+            attn_metadata.block_tables,
+            seq_lens,
+        )
+        actual_seq_lengths_kv = torch.tensor(seq_lens, dtype=torch.int32).cumsum(0).tolist()
+        return dense_key, dense_value, actual_seq_lengths_kv
+
+    def _gather_paged_kv_to_dense(
+        self,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        block_table: torch.Tensor,
+        seq_lens: list[int],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        block_size = key_cache.shape[1]
+        seq_lens_tensor = torch.tensor(seq_lens, dtype=torch.long, device=key_cache.device)
+        max_seq_len = int(seq_lens_tensor.max().item())
+        num_blocks = cdiv(max_seq_len, block_size)
+        block_table_sliced = block_table[: len(seq_lens), :num_blocks].long()
+
+        flat_block_ids = block_table_sliced.reshape(-1)
+        max_tokens_padded = num_blocks * block_size
+        dense_shape = (
+            len(seq_lens),
+            max_tokens_padded,
+            self.num_kv_heads,
+            self.head_size,
+        )
+        gathered_key = key_cache.index_select(0, flat_block_ids).reshape(dense_shape)
+        gathered_value = value_cache.index_select(0, flat_block_ids).reshape(dense_shape)
+
+        positions = torch.arange(max_tokens_padded, dtype=torch.long, device=key_cache.device)
+        valid_mask = positions.unsqueeze(0) < seq_lens_tensor.unsqueeze(1)
+        return gathered_key[valid_mask].contiguous(), gathered_value[valid_mask].contiguous()
+
+    def _should_use_large_head_attention_fallback(self) -> bool:
+        unsupported_fia_tnd_head_size = self.head_size not in FIA_TND_SUPPORTED_HEAD_SIZES
+        return self.sinks is None and unsupported_fia_tnd_head_size
+
+    def _get_current_token_shared_kv(
+        self,
+        attn_metadata: AscendMetadata,
+    ) -> tuple[torch.Tensor, torch.Tensor] | tuple[None, None]:
+        """Gather current-token KV from the producer layer's shared cache."""
+
+        if self.key_cache is None or self.value_cache is None:
+            return None, None
+        num_tokens = attn_metadata.actual_seq_lengths_q[-1]
+        if attn_metadata.slot_mapping is None or attn_metadata.slot_mapping.numel() < num_tokens:
+            return None, None
+        slots = attn_metadata.slot_mapping[:num_tokens].long()
+        key = self.key_cache.reshape(-1, self.num_kv_heads, self.head_size).index_select(0, slots)
+        value = self.value_cache.reshape(-1, self.num_kv_heads, self.head_size).index_select(0, slots)
+        return key, value
+
+    def _get_shared_kv_from_block_table(
+        self,
+        attn_metadata: AscendMetadata,
+    ) -> tuple[torch.Tensor, torch.Tensor] | tuple[None, None]:
+        """Gather K/V from the shared target cache using block tables.
+
+        Used when slot_mapping is not available (e.g., during speculative
+        decoding where the draft model inherits attn_metadata from the
+        target but slot_mapping may not be populated for draft layers).
+
+        IMPORTANT: For KV-sharing draft layers, self.key_cache points to the
+        draft model's own (empty) cache.  We must swap to the target layer's
+        cache via _kv_share_target_impl, mirroring the PA path fix.
+        """
+        # Swap to target cache when KV-sharing (mirrors PA path fix in
+        # forward_paged_attention).
+        _tgt_impl = getattr(self, '_kv_share_target_impl', None)
+        _swapped = False
+        if _tgt_impl is not None and _tgt_impl.key_cache is not None:
+            read_kc = _tgt_impl.key_cache
+            read_vc = _tgt_impl.value_cache
+            _swapped = True
+        else:
+            read_kc = self.key_cache
+            read_vc = self.value_cache
+
+        if read_kc is None or read_vc is None:
+            with open('/tmp/attn_path_debug.log', 'a') as _f:
+                _f.write(f"[KV_SHARE_BLOCK] layer={self._layer_name} "
+                         f"ERROR=null_cache swapped={_swapped}\n")
+            return None, None
+        # ── BLOCK TABLE ROUTING ──
+        # Draft layers share KV with target layers that may be in DIFFERENT
+        # KV cache groups.  attn_metadata.block_tables is the common (gid=0)
+        # table; using it for layers whose target is in gid≠0 reads from the
+        # wrong pool.  Route each layer to its per-group block_table via
+        # _kv_share_gid (set by _store_gids_on_impls) + _per_group_bt_ref
+        # (the {gid: block_table} dict set by set_per_group_block_table).
+        _my_gid = getattr(self, '_kv_share_gid', None)
+        _per_group_bt = getattr(self, '_per_group_bt_ref', None)
+        _routed_bt = None
+        if _my_gid is not None and _per_group_bt is not None and _my_gid in _per_group_bt:
+            _routed_bt = _per_group_bt[_my_gid]
+        block_table = _routed_bt if _routed_bt is not None else attn_metadata.block_tables
+        seq_lens = attn_metadata.seq_lens_list
+        if block_table is None or not seq_lens:
+            with open('/tmp/attn_path_debug.log', 'a') as _f:
+                _f.write(f"[KV_SHARE_BLOCK] layer={self._layer_name} "
+                         f"ERROR=no_block_table bt_is_none={block_table is None} "
+                         f"seq_lens={seq_lens}\n")
+            return None, None
+
+        try:
+            dense_key, dense_value = self._gather_paged_kv_to_dense(
+                read_kc, read_vc, block_table, seq_lens,
+            )
+            _k_mean = dense_key.float().mean().item()
+            _k_std = dense_key.float().std().item()
+            _v_mean = dense_value.float().mean().item()
+            _per_group_bt = getattr(self, '_per_group_bt_ref', None)
+            _fallback_gid = -1
+            if abs(_k_mean) < 1e-6 and _per_group_bt is not None and len(_per_group_bt) > 0:
+                # REVERSE iteration: try highest gid first (global attn = 5)
+                for _gid, _bt in reversed(list(_per_group_bt.items())):
+                    try:
+                        _dk, _dv = self._gather_paged_kv_to_dense(
+                            read_kc, read_vc, _bt, seq_lens,
+                        )
+                        _km = _dk.float().mean().item()
+                        if abs(_km) > 1e-6:
+                            dense_key, dense_value = _dk, _dv
+                            block_table = _bt
+                            _k_mean = _km
+                            _k_std = _dk.float().std().item()
+                            _v_mean = _dv.float().mean().item()
+                            _fallback_gid = _gid
+                            break
+                    except Exception:
+                        continue
+            return dense_key, dense_value
+        except Exception as e:
+            with open('/tmp/attn_path_debug.log', 'a') as _f:
+                _f.write(f"[KV_SHARE_BLOCK] layer={self._layer_name} "
+                         f"ERROR={e}\n")
+            return None, None
 
     def do_kv_cache_update(
         self,
@@ -1388,7 +1877,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
             if self.key_cache is None:
                 self.key_cache, self.value_cache = kv_cache[0], kv_cache[1]
             if self.kv_sharing_target_layer_name is not None:
-                # Target layers reuse KV written by the producer layer.
+                # KV-sharing target layers, used by Gemma4 local/global layer
+                # pairs, consume the producer layer's cache. Re-caching here
+                # would overwrite the shared KV slots before attention reads it.
                 if self.is_kv_producer:
                     attn_metadata.reshape_cache_event.record()
                 return query, key, value, output
@@ -1417,65 +1908,139 @@ class AscendAttentionBackendImpl(AttentionImpl):
         output: torch.Tensor,
     ):
         num_tokens = query.shape[0]
-        use_large_head_fallback = needs_fia_large_head_fallback(self.head_size, self.sinks)
+        _kv_share = getattr(self, 'kv_sharing_target_layer_name', None)
 
-        def forward_large_head(query: torch.Tensor, key: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
-            return forward_large_head_prefill_attention(
-                query,
-                key,
-                value,
-                attn_metadata,
-                output,
-                key_cache=self.key_cache,
-                value_cache=self.value_cache,
-                num_heads=self.num_heads,
-                num_kv_heads=self.num_kv_heads,
-                head_size=self.head_size,
-                scale=self.scale,
-                sliding_window=self.sliding_window,
-                is_prefill_no_cache=attn_metadata.attn_state == AscendAttentionState.PrefillNoCache,
-            )
 
+
+        # KV-sharing layers (e.g., Gemma4 MTP draft) read K/V from the
+        # target layer's cache.  Ensure self.key_cache / self.value_cache
+        # are initialised from the kv_cache tuple BEFORE calling
+        # _get_current_token_shared_kv, otherwise they will still be
+        # None (the draft layers do not own a private cache) and the
+        # shared-KV prefill path is skipped, falling through to FIA
+        # which does not support head_dim > 192 on Ascend TND.
         if (
-            use_large_head_fallback
-            and self.kv_sharing_target_layer_name is not None
+            self.kv_sharing_target_layer_name is not None
+            and self.key_cache is None
+            and kv_cache is not None
+            and len(kv_cache) >= 2
+        ):
+            self.key_cache, self.value_cache = kv_cache[0], kv_cache[1]
+
+
+        # Large-head fallback: head_dim not in {64,128,192,256}.
+        # FIA writes KV cache in TND layout, but _forward_shared_kv_prefill_attention
+        # uses PyTorch SDPA which expects standard [B,H,L,D] layout.
+        # HOWEVER: the KV cache is stored in paged block format (not TND).
+        # _gather_paged_kv_to_dense reads from blocks and produces
+        # [tokens, kv_heads, head_dim] which IS the standard layout SDPA expects.
+        # The TND layout only applies to FIA kernel input/output, not to stored
+        # cache.  Allow all head_dims (including 512) through SDPA_KV_SHARED
+        # so that causal cross-attention masking works correctly (PA may not
+        # apply proper causal masking for multi-token KV-sharing queries).
+        use_large_head_fallback = self._should_use_large_head_attention_fallback()
+
+        _kv_prefill_eligible = (
+            self.kv_sharing_target_layer_name is not None
             and key is not None
             and value is not None
             and query.shape[0] == key.shape[0]
-            and attn_metadata.attn_state in (AscendAttentionState.PrefillNoCache, AscendAttentionState.ChunkedPrefill)
-        ):
-            # For KV sharing target layers, the incoming key/value tensors are
-            # not the target layer KV. Gather producer KV before FA fallback.
-            shared_key, shared_value = get_current_token_kv_from_cache(
-                self.key_cache,
-                self.value_cache,
-                attn_metadata.slot_mapping,
-                attn_metadata.actual_seq_lengths_q[-1],
-                self.num_kv_heads,
-                self.head_size,
-            )
-            if shared_key is not None and shared_value is not None:
-                return forward_large_head(query, shared_key, shared_value)
+            and attn_metadata.attn_state in (AscendAttentionState.PrefillNoCache, AscendAttentionState.ChunkedPrefill, AscendAttentionState.SpecDecoding)
+        )
 
-        if (
-            attn_metadata.attn_state == AscendAttentionState.DecodeOnly
-            and self.sliding_window is None
-            and (using_paged_attention(num_tokens, self.vllm_config) or use_large_head_fallback)
-        ):
-            # A2/A3 FIA decode also cannot use the unsupported large-head path;
-            # paged attention is the existing decode fallback.
-            output = self.forward_paged_attention(query, attn_metadata, output)
-        elif (
+
+
+        if _kv_prefill_eligible:
+            # Try slot_mapping-based lookup first (needed when the
+            # same request's target K/V are at known cache slots).
+            # BUT: for SpecDecoding, slot_mapping may only cover the
+            # most recent target-model token slots, not the full KV
+            # cache.  _get_current_token_shared_kv would then return
+            # a tiny K/V slice instead of None, preventing the
+            # block-table fallback below.  Skip it for SpecDecoding.
+            # Draft model layers do not write KV to the cache (they read
+            # from the target's shared cache).  Their slot_mapping points to
+            # empty/wrong positions, always fall through to the block_table
+            # gather instead.
+            if (attn_metadata.attn_state != AscendAttentionState.SpecDecoding
+                    and not getattr(_EXTRA_CTX, 'is_draft_model', False)):
+                shared_key, shared_value = self._get_current_token_shared_kv(attn_metadata)
+            else:
+                shared_key, shared_value = None, None
+
+            # Fall back to block-table gathering.  This is the normal
+            # path for speculative decoding where the draft model
+            # inherits the target's paged KV cache but slot_mapping
+            # may not be populated for the draft's attn_metadata.
+            if shared_key is None or shared_value is None:
+                shared_key, shared_value = self._get_shared_kv_from_block_table(
+                    attn_metadata
+                )
+
+
+
+            if shared_key is not None and shared_value is not None:
+
+                return self._forward_shared_kv_prefill_attention(
+                    query,
+                    shared_key,
+                    shared_value,
+                    attn_metadata,
+                    output,
+                )
+
+        _pa_usable = using_paged_attention(num_tokens, self.vllm_config)
+
+        # PagedAttention fails during FULL_DECODE_ONLY graph capture even
+        # without task group wrapping (CANN Inner error).  PIECEWISE capture
+        # is NOT affected — PA works correctly there.
+        _is_fdo_capture = (
+            _EXTRA_CTX.capturing
+            and get_forward_context().cudagraph_runtime_mode == CUDAGraphMode.FULL
+        )
+
+        _cond_a = (
+            attn_metadata.attn_state in (AscendAttentionState.DecodeOnly, AscendAttentionState.SpecDecoding)
+            and (self.sliding_window is None or self.kv_sharing_target_layer_name is not None)
+            and (_pa_usable or use_large_head_fallback or self.kv_sharing_target_layer_name is not None)
+        )
+        _cond_b = (
             not _EXTRA_CTX.capturing
             and use_large_head_fallback
             and self.kv_sharing_target_layer_name is None
             and key is not None
             and value is not None
             and query.shape[0] == key.shape[0]
-            and attn_metadata.attn_state in (AscendAttentionState.PrefillNoCache, AscendAttentionState.ChunkedPrefill)
-        ):
-            output = forward_large_head(query, key, value)
+            and attn_metadata.attn_state in (AscendAttentionState.PrefillNoCache, AscendAttentionState.ChunkedPrefill, AscendAttentionState.SpecDecoding)
+        )
+
+
+
+
+
+        if _cond_a:
+            # PA works for all head_dims on this Ascend device;
+            # the large-head fallback flag just means we skip FIA.
+
+            output = self.forward_paged_attention(query, attn_metadata, output)
+        elif _cond_b:
+
+            output = self._forward_large_head_prefill_attention(query, key, value, attn_metadata, output)
+        elif use_large_head_fallback:
+            # Large head_dim + non-DecodeOnly, non-prefill edge case.
+            # During FDO capture, PA and FIA v2 both fail for head_dim=512.
+            # Use PyTorch native SDPA (scaled_dot_product_attention) which
+            # decomposes into capturable ops and supports any head_dim.
+            # PIECEWISE capture is not affected (PA works there).
+            if _is_fdo_capture:
+
+                output = self._fdo_safe_large_head_attention(
+                    query, key, value, attn_metadata, output, kv_cache)
+            else:
+
+                output = self.forward_paged_attention(query, attn_metadata, output)
         else:
+
             output = self.forward_fused_infer_attention(query, key, value, attn_metadata, output, kv_cache)
 
         return output
@@ -1506,14 +2071,19 @@ class AscendAttentionBackendImpl(AttentionImpl):
         assert output is not None, "Output tensor must be provided."
         if self.enable_hamming_sparse:
             self.layerIndex = int(layer.layer_name.split(".")[2])
-        if self._use_layer_aware_fia_graph_replay:
-            self._layer_name = layer.layer_name
+        self._layer_name = layer.layer_name
 
         if output_scale is not None or output_block_scale is not None:
             raise NotImplementedError("fused output quantization is not yet supported for AscendAttentionBackendImpl")
 
         assert layer._k_scale_float == 1.0 and layer._v_scale_float == 1.0
         num_tokens = query.shape[0]
+
+        _kv_share = getattr(self, 'kv_sharing_target_layer_name', None)
+        _is_draft = getattr(_EXTRA_CTX, 'is_draft_model', False)
+
+
+
         if attn_metadata is None:
             return output.fill_(0)
 
@@ -1532,15 +2102,37 @@ class AscendAttentionBackendImpl(AttentionImpl):
 
         output_padded = None
         if key is not None and value is not None:
-            output_padded = output
-            query, key, value, output_padded = self.reshape_and_cache(
-                query, key, value, kv_cache, attn_metadata, output
+            # Gemma4 MTP draft layers are Q-only: K/V come from the shared
+            # target KV cache.  Gemma4MTPAttention.forward() creates a dummy
+            # K/V via torch.empty() and passes it as key/value to self.attn().
+            # Writing this uninitialized memory back via reshape_and_cache
+            # would corrupt the shared target KV cache, causing progressive
+            # degradation across sequential loop steps:
+            #   draft[0] fine (merged fwd), draft[1] occasionally OK (7-13%),
+            #   draft[2-4] always garbage.
+            # Skip the write for draft KV-shared layers — they only READ.
+            _is_draft_kv_share = (
+                getattr(self, 'kv_sharing_target_layer_name', None) is not None
+                and getattr(_EXTRA_CTX, 'is_draft_model', False)
             )
+
+            if not _is_draft_kv_share:
+                output_padded = output
+                query, key, value, output_padded = self.reshape_and_cache(
+                    query, key, value, kv_cache, attn_metadata, output
+                )
+
+        _is_pooling = (attn_metadata.model_runner_type == "pooling" and not attn_metadata.causal)
+
         # pooling model branch
-        if attn_metadata.model_runner_type == "pooling" and not attn_metadata.causal:
+        if _is_pooling:
+
             attn_output = self._forward_encoder_attention(query, key, value, attn_metadata, output)
             output[:num_tokens] = attn_output[:num_tokens]
             return output
+
+
+
         if output_padded is not None:
             attn_output = self.forward_impl(query, key, value, kv_cache, attn_metadata, output_padded)
         else:
@@ -1571,8 +2163,6 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
         output_block_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
         assert output is not None, "Output tensor must be provided."
-        if self._use_layer_aware_fia_graph_replay:
-            self._layer_name = layer.layer_name
 
         if output_scale is not None or output_block_scale is not None:
             raise NotImplementedError("fused output quantization is not yet supported for AscendC8AttentionBackendImpl")
@@ -1588,7 +2178,7 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
                 if attn_metadata.attn_state != AscendAttentionState.DecodeOnly:
                     float_key, float_value = key, value
                 key, value = self._quantize_kv_to_int8(key, value, layer, attn_metadata.num_actual_tokens)
-                query, key, value, _ = self._reshape_and_cache(query, key, value, kv_cache, attn_metadata, output)
+                query, key, value, _ = self.reshape_and_cache(query, key, value, kv_cache, attn_metadata, output)
             # pooling model branch
             if attn_metadata.model_runner_type == "pooling":
                 attn_output = self._forward_encoder_attention(query, key, value, attn_metadata, output)
@@ -1633,7 +2223,7 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
             elif not self.is_kv_producer:
                 if key is not None and value is not None:
                     key, value = self._quantize_kv_to_int8(key, value, layer, attn_metadata.num_actual_tokens)
-                    query, key, value, _ = self._reshape_and_cache(query, key, value, kv_cache, attn_metadata, output)
+                    query, key, value, _ = self.reshape_and_cache(query, key, value, kv_cache, attn_metadata, output)
                 # pooling model branch
                 if attn_metadata.model_runner_type == "pooling":
                     attn_output = self._forward_encoder_attention(query, key, value, attn_metadata, output)
@@ -1645,11 +2235,6 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
                     return output
                 elif attn_metadata.attn_state == AscendAttentionState.DecodeOnly:
                     return self._forward_c8_decode(query, attn_metadata, output, layer)
-
-    def _nz_5d_view(self, cache: torch.Tensor, block_size: int) -> torch.Tensor:
-        """View a KV cache tensor in NZ 5D layout: (num_blocks, num_kv_heads, head_size//nz, block_size, nz)."""
-        NZ_FMT_LAST_DIM = 32
-        return cache.view(-1, self.num_kv_heads, self.head_size // NZ_FMT_LAST_DIM, block_size, NZ_FMT_LAST_DIM)
 
     def _prepare_c8_scales(self, layer: AttentionLayer, device: torch.device) -> None:
         """Shard per-channel C8 scales/offsets to this TP rank and pre-compute
@@ -1677,12 +2262,14 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
         layer._c8_v_scale = _shard_and_reshape(layer.v_cache_scale.data)
         layer._c8_v_offset = _shard_and_reshape(layer.v_cache_offset.data)
 
+        bnsd = (1, self.num_kv_heads, 1, self.head_size)
+        layer._c8_k_aq_scale = layer._c8_k_scale.view(bnsd).contiguous()
+        layer._c8_k_aq_offset = layer._c8_k_offset.view(bnsd).contiguous()
+        layer._c8_v_aq_scale = layer._c8_v_scale.view(bnsd).contiguous()
+        layer._c8_v_aq_offset = layer._c8_v_offset.view(bnsd).contiguous()
+
         layer._c8_k_inv_scale = 1.0 / layer._c8_k_scale
         layer._c8_v_inv_scale = 1.0 / layer._c8_v_scale
-
-        nz_bnsd = (self.num_kv_heads, 1, self.head_size)
-        layer._c8_k_aq_scale_nz_bnsd = layer._c8_k_scale.view(nz_bnsd).contiguous()
-        layer._c8_v_aq_scale_nz_bnsd = layer._c8_v_scale.view(nz_bnsd).contiguous()
 
         layer._c8_scales_prepared = True
 
@@ -1697,41 +2284,26 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Gather paged INT8 KV blocks and dequantize."""
         batch_size = block_table.shape[0]
+        block_size = key.shape[1]
+        H = key.shape[2]
         max_blocks_per_seq = block_table.shape[1]
-
-        # NZ 5D view: (num_blocks, num_kv_heads, head_size//nz, block_size, nz)
-        block_size = self.key_cache.shape[1]  # type: ignore[attr-defined]
         max_tokens_padded = max_blocks_per_seq * block_size
 
         flat_ids = block_table.reshape(-1)
-        key_nz = self._nz_5d_view(key, block_size)
-        value_nz = self._nz_5d_view(value, block_size)
-
-        # Gather: (batch*max_blocks, H, D//nz, S, nz)
-        gathered_k = key_nz[flat_ids]
-        gathered_v = value_nz[flat_ids]
-        # NZ→ND conversion: permute (S, H, D//nz, nz) → reshape (S, H, D)
-        gathered_k = (
-            gathered_k.permute(0, 3, 1, 2, 4)
-            .contiguous()
-            .view(batch_size, max_tokens_padded, self.num_kv_heads, self.head_size)
-        )
-        gathered_v = (
-            gathered_v.permute(0, 3, 1, 2, 4)
-            .contiguous()
-            .view(batch_size, max_tokens_padded, self.num_kv_heads, self.head_size)
-        )
+        gathered_k = key[flat_ids].view(batch_size, max_tokens_padded, H)
+        gathered_v = value[flat_ids].view(batch_size, max_tokens_padded, H)
 
         seq_lens_t = torch.tensor(seq_lens, dtype=torch.long, device=key.device)
         positions = torch.arange(max_tokens_padded, dtype=torch.long, device=key.device)
         valid_mask = (positions.unsqueeze(0) < seq_lens_t.unsqueeze(1)).view(-1)
 
-        dense_k = gathered_k.view(-1, self.num_kv_heads, self.head_size)[valid_mask]
-        dense_v = gathered_v.view(-1, self.num_kv_heads, self.head_size)[valid_mask]
+        dense_k = gathered_k.view(-1, H)[valid_mask]
+        dense_v = gathered_v.view(-1, H)[valid_mask]
 
-        # Scale-only dequant for NZ (symmetric)
-        dense_k = dense_k.to(target_dtype) * layer._c8_k_scale
-        dense_v = dense_v.to(target_dtype) * layer._c8_v_scale
+        dense_k = dense_k.view(-1, self.num_kv_heads, self.head_size)
+        dense_v = dense_v.view(-1, self.num_kv_heads, self.head_size)
+        dense_k = (dense_k.to(target_dtype) - layer._c8_k_offset) * layer._c8_k_scale
+        dense_v = (dense_v.to(target_dtype) - layer._c8_v_offset) * layer._c8_v_scale
         return dense_k, dense_v
 
     def _quantize_kv_to_int8(
@@ -1767,17 +2339,18 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
         """C8 decode via FIA V1 BNSD with native paged INT8 KV + perchannel antiquant."""
         num_block, block_size, _, _ = self.key_cache.shape  # type: ignore[attr-defined]
         assert block_size % 32 == 0, f"C8 INT8 KV cache requires block_size to be a multiple of 32, got {block_size}"
+        key = self.key_cache.view(num_block, block_size, -1)  # type: ignore[attr-defined]
+        value = self.value_cache.view(num_block, block_size, -1)  # type: ignore[attr-defined]
         batch_size = len(attn_metadata.seq_lens_list)
-
-        key = self._nz_5d_view(self.key_cache, block_size)
-        value = self._nz_5d_view(self.value_cache, block_size)
 
         attn_output, _ = torch_npu.npu_fused_infer_attention_score(
             query[:batch_size].unsqueeze(2),
             key,
             value,
-            key_antiquant_scale=layer._c8_k_aq_scale_nz_bnsd,
-            value_antiquant_scale=layer._c8_v_aq_scale_nz_bnsd,
+            key_antiquant_scale=layer._c8_k_aq_scale,
+            key_antiquant_offset=layer._c8_k_aq_offset,
+            value_antiquant_scale=layer._c8_v_aq_scale,
+            value_antiquant_offset=layer._c8_v_aq_offset,
             block_table=attn_metadata.block_tables,
             actual_seq_lengths_kv=attn_metadata.seq_lens_list,
             num_heads=self.num_heads,
@@ -1785,10 +2358,8 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
             input_layout="BNSD",
             scale=self.scale,
             block_size=block_size,
-            antiquant_mode=0,
             key_antiquant_mode=0,
             value_antiquant_mode=0,
-            inner_precise=1,
             sparse_mode=0,
         )
         attn_output = attn_output.squeeze(2)
@@ -1817,15 +2388,17 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
             assert block_size % 32 == 0, (
                 f"C8 INT8 KV cache requires block_size to be a multiple of 32, got {block_size}"
             )
-            kv_k = self._nz_5d_view(self.key_cache, block_size)
-            kv_v = self._nz_5d_view(self.value_cache, block_size)
+            kv_k = self.key_cache.view(num_block, block_size, -1)  # type: ignore[attr-defined]
+            kv_v = self.value_cache.view(num_block, block_size, -1)  # type: ignore[attr-defined]
 
             attn_out, _ = torch_npu.npu_fused_infer_attention_score(
                 query[:num_decode_tokens].unsqueeze(2),
                 kv_k,
                 kv_v,
-                key_antiquant_scale=layer._c8_k_aq_scale_nz_bnsd,
-                value_antiquant_scale=layer._c8_v_aq_scale_nz_bnsd,
+                key_antiquant_scale=layer._c8_k_aq_scale,
+                key_antiquant_offset=layer._c8_k_aq_offset,
+                value_antiquant_scale=layer._c8_v_aq_scale,
+                value_antiquant_offset=layer._c8_v_aq_offset,
                 block_table=attn_metadata.block_tables[:num_decodes],
                 actual_seq_lengths_kv=attn_metadata.seq_lens_list[:num_decodes],
                 num_heads=self.num_heads,
@@ -1833,10 +2406,8 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
                 input_layout="BNSD",
                 scale=self.scale,
                 block_size=block_size,
-                antiquant_mode=0,
                 key_antiquant_mode=0,
                 value_antiquant_mode=0,
-                inner_precise=1,
                 sparse_mode=0,
             )
             output[:num_decode_tokens] = attn_out.squeeze(2)
@@ -1862,9 +2433,8 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
                 prefill_seq_kvlen = prefill_seq_qlen
             else:
                 num_block, blk_size, _, _ = self.key_cache.shape  # type: ignore[attr-defined]
-                paged_k = self._nz_5d_view(self.key_cache, blk_size)
-                paged_v = self._nz_5d_view(self.value_cache, blk_size)
-
+                paged_k = self.key_cache.view(num_block, blk_size, -1)  # type: ignore[attr-defined]
+                paged_v = self.value_cache.view(num_block, blk_size, -1)  # type: ignore[attr-defined]
                 prefill_bt = attn_metadata.block_tables[num_decodes:]
                 prefill_sl = attn_metadata.seq_lens_list[num_decodes:]
                 prefill_k, prefill_v = self._dequant_paged_kv_to_dense(
@@ -1954,38 +2524,3 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
         attn_output = attn_output.view(num_tokens, self.num_heads, self.head_size)
         output[:num_tokens] = attn_output
         return output
-
-    def _reshape_and_cache(
-        self,
-        query: torch.Tensor,
-        key: torch.Tensor,
-        value: torch.Tensor,
-        kv_cache: tuple[torch.Tensor],
-        attn_metadata: AscendMetadata,
-        output: torch.Tensor,
-    ):
-        if len(kv_cache) > 1:
-            if self.is_kv_producer:
-                attn_metadata.reshape_cache_event = torch.npu.Event()
-            if self.key_cache is None:
-                self.key_cache, self.value_cache = kv_cache[0], kv_cache[1]
-            slots = attn_metadata.slot_mapping
-
-            encoder_decoder = self.attn_type == AttentionType.ENCODER_DECODER
-
-            # NZ write path: 5D view + npu_scatter_pa_kv_cache
-            block_size = self.vllm_config.cache_config.block_size
-            k_cache_layer = self._nz_5d_view(self.key_cache, block_size)
-            v_cache_layer = self._nz_5d_view(self.value_cache, block_size)
-
-            torch_npu.npu_scatter_pa_kv_cache(
-                key=key[: attn_metadata.num_actual_tokens] if not encoder_decoder else key,
-                value=value[: attn_metadata.num_actual_tokens] if not encoder_decoder else value,
-                key_cache=k_cache_layer,
-                value_cache=v_cache_layer,
-                slot_mapping=slots[: attn_metadata.num_actual_tokens] if not encoder_decoder else slots,
-            )
-
-            if self.is_kv_producer:
-                attn_metadata.reshape_cache_event.record()
-        return query, key, value, output

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -4,9 +4,11 @@ from typing import Any
 
 import torch
 import torch.nn.functional as F
+import torch_npu
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group, is_v1_kv_transfer_group
 from vllm.forward_context import ForwardContext, get_forward_context
+from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 
 from vllm_ascend.utils import (
@@ -16,6 +18,11 @@ from vllm_ascend.utils import (
     is_pd_decode_recompute_scheduler_enabled,
 )
 from vllm_ascend.worker.kvcomp_utils import KVCompMetaData
+
+# Keep the same semantic as attention_v1.SWA_INT_MAX without importing it,
+# because attention_v1 imports this module.
+SWA_INT_MAX = 2147483647
+A2_A3_FIA_TND_UNSUPPORTED_HEAD_SIZES = {512}
 
 
 def cache_graph_workspace(
@@ -38,6 +45,150 @@ def cache_graph_workspace(
     elif current_workspace is None:
         graph_params.workspaces[num_tokens] = candidate_workspace
     return graph_params.workspaces[num_tokens]
+
+
+def needs_fia_large_head_fallback(head_size: int, sinks: torch.Tensor | None) -> bool:
+    # A2/A3 FIA TND currently does not support 512-dim heads. Sink attention
+    # keeps using its own path, so only the standard attention path falls back.
+    return (
+        get_ascend_device_type() in (AscendDeviceType.A2, AscendDeviceType.A3)
+        and sinks is None
+        and head_size in A2_A3_FIA_TND_UNSUPPORTED_HEAD_SIZES
+    )
+
+
+def get_current_token_kv_from_cache(
+    key_cache: torch.Tensor | None,
+    value_cache: torch.Tensor | None,
+    slot_mapping: torch.Tensor | None,
+    num_tokens: int,
+    num_kv_heads: int,
+    head_size: int,
+) -> tuple[torch.Tensor, torch.Tensor] | tuple[None, None]:
+    # KV sharing target layers do not write KV cache themselves. Rebuild the
+    # current-token KV tensors from the producer layer cache for prefill FA.
+    if key_cache is None or value_cache is None:
+        return None, None
+    if slot_mapping is None or slot_mapping.numel() < num_tokens:
+        return None, None
+    slots = slot_mapping[:num_tokens].long()
+    key = key_cache.reshape(-1, num_kv_heads, head_size).index_select(0, slots)
+    value = value_cache.reshape(-1, num_kv_heads, head_size).index_select(0, slots)
+    return key, value
+
+
+def forward_large_head_prefill_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_metadata: Any,
+    output: torch.Tensor,
+    *,
+    key_cache: torch.Tensor | None,
+    value_cache: torch.Tensor | None,
+    num_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    scale: float,
+    sliding_window: int | None,
+    is_prefill_no_cache: bool,
+) -> torch.Tensor:
+    # Keep A2/A3 large-head prefill on an NPU attention op path when FIA TND is
+    # unsupported for the head size, instead of routing the whole layer to eager.
+    num_tokens = attn_metadata.actual_seq_lengths_q[-1]
+    query = query[:num_tokens]
+    key, value, actual_seq_lengths_kv = _get_large_head_prefill_kv(
+        key,
+        value,
+        attn_metadata,
+        num_tokens,
+        key_cache,
+        value_cache,
+        num_kv_heads,
+        head_size,
+        is_prefill_no_cache,
+    )
+    sparse_mode = 4 if sliding_window is not None else 3 if attn_metadata.causal else 0
+    pre_tokens = sliding_window if sliding_window is not None else SWA_INT_MAX
+    next_tokens = 0 if attn_metadata.causal or sliding_window is not None else SWA_INT_MAX
+    attn_mask = attn_metadata.attn_mask
+    if attn_mask is not None and attn_mask.dtype not in (torch.bool, torch.uint8):
+        attn_mask = attn_mask.bool()
+    attn_output = torch_npu.npu_fusion_attention(
+        query=query,
+        key=key,
+        value=value,
+        head_num=num_heads,
+        input_layout="TND",
+        atten_mask=attn_mask,
+        scale=scale,
+        pre_tockens=pre_tokens,
+        next_tockens=next_tokens,
+        actual_seq_qlen=attn_metadata.actual_seq_lengths_q,
+        actual_seq_kvlen=actual_seq_lengths_kv,
+        sparse_mode=sparse_mode,
+    )[0]
+    output[:num_tokens] = attn_output[:num_tokens]
+    return output
+
+
+def _get_large_head_prefill_kv(
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_metadata: Any,
+    num_tokens: int,
+    key_cache: torch.Tensor | None,
+    value_cache: torch.Tensor | None,
+    num_kv_heads: int,
+    head_size: int,
+    is_prefill_no_cache: bool,
+) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
+    # PrefillNoCache already has dense current-step KV tensors. Chunked prefill
+    # may need the historical paged KV cache gathered back to dense TND layout.
+    if is_prefill_no_cache or key_cache is None or value_cache is None:
+        return key[:num_tokens], value[:num_tokens], attn_metadata.actual_seq_lengths_q
+
+    seq_lens = attn_metadata.seq_lens_list
+    if not seq_lens:
+        return key[:num_tokens], value[:num_tokens], attn_metadata.actual_seq_lengths_q
+
+    key, value = _gather_paged_kv_to_dense(
+        key_cache,
+        value_cache,
+        attn_metadata.block_tables,
+        seq_lens,
+        num_kv_heads,
+        head_size,
+    )
+    actual_seq_lengths_kv = torch.tensor(seq_lens, dtype=torch.int32).cumsum(0).tolist()
+    return key, value, actual_seq_lengths_kv
+
+
+def _gather_paged_kv_to_dense(
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: list[int],
+    num_kv_heads: int,
+    head_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # npu_fusion_attention consumes dense TND KV tensors, while cached prefill
+    # KV is stored by pages. Gather valid tokens according to the block table.
+    block_size = key_cache.shape[1]
+    seq_lens_tensor = torch.tensor(seq_lens, dtype=torch.long, device=key_cache.device)
+    max_seq_len = int(seq_lens_tensor.max().item())
+    num_blocks = cdiv(max_seq_len, block_size)
+    block_table = block_table[: len(seq_lens), :num_blocks].long()
+
+    flat_block_ids = block_table.reshape(-1)
+    max_tokens_padded = num_blocks * block_size
+    dense_shape = (len(seq_lens), max_tokens_padded, num_kv_heads, head_size)
+    gathered_key = key_cache.index_select(0, flat_block_ids).reshape(dense_shape)
+    gathered_value = value_cache.index_select(0, flat_block_ids).reshape(dense_shape)
+
+    positions = torch.arange(max_tokens_padded, dtype=torch.long, device=key_cache.device)
+    valid_mask = positions.unsqueeze(0) < seq_lens_tensor.unsqueeze(1)
+    return gathered_key[valid_mask].contiguous(), gathered_value[valid_mask].contiguous()
 
 
 @lru_cache(maxsize=1)

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -172,6 +172,14 @@ class ACLGraphWrapper:
         entry = self.concrete_aclgraph_entries[batch_descriptor]
 
         if entry.aclgraph is None:
+            # MTP: When the current stream is already being captured
+            # (e.g. target model's FDO graph in PIECEWISE mode),
+            # skip this wrapper's capture and run eagerly. Nested NPU
+            # graph captures corrupt the outer graph's workspace.
+            _outer_capturing = torch.npu.is_current_stream_capturing()
+            if _outer_capturing:
+                return self.runnable(*args, **kwargs)
+
             if self.aclgraph_options.debug_log_enable:
                 # Since we capture aclgraph for many different shapes and
                 # capturing is fast, we don't need to log it for every
@@ -324,6 +332,7 @@ class GraphParams:
     workspaces: dict[int, torch.Tensor]
     handles: dict[int, list[torch_npu._C._NPUTaskGroupHandle]]
     attn_params: dict[int, list[tuple]]
+    attn_params_by_key: dict[int, dict[str, dict]]  # per-num_tokens → attn_key → {params, handle, event}
     conv1d_params: dict[int, list[tuple]]  # for causal conv1d params
     conv1d_handles: dict[int, list[torch_npu._C._NPUTaskGroupHandle]]  # for causal conv1d params handles
     conv1d_events: dict[int, list[torch.npu.ExternalEvent]]  # for causal conv1d params events
@@ -348,6 +357,7 @@ def set_graph_params(aclgraph_capture_sizes: list[int]):
         {size: None for size in aclgraph_capture_sizes},
         {size: [] for size in aclgraph_capture_sizes},
         {size: [] for size in aclgraph_capture_sizes},
+        {size: {} for size in aclgraph_capture_sizes},
         {size: [] for size in aclgraph_capture_sizes},
         {size: [] for size in aclgraph_capture_sizes},
         {size: [] for size in aclgraph_capture_sizes},
@@ -376,6 +386,7 @@ def set_draft_graph_params(aclgraph_capture_sizes: list[int]):
         {size: None for size in aclgraph_capture_sizes},
         {size: [] for size in aclgraph_capture_sizes},
         {size: [] for size in aclgraph_capture_sizes},
+        {size: {} for size in aclgraph_capture_sizes},
         {size: [] for size in aclgraph_capture_sizes},
         {size: [] for size in aclgraph_capture_sizes},
         {size: [] for size in aclgraph_capture_sizes},

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -48,6 +48,7 @@ from vllm_ascend.utils import (
     get_ascend_device_type,
     is_moe_model,
     refresh_block_size,
+    update_aclgraph_sizes,
     update_cudagraph_capture_sizes,
     is_310p,
     enable_sp,
@@ -564,6 +565,11 @@ class NPUPlatform(Platform):
                 compilation_config.cudagraph_capture_sizes = sp_aclgraph_sizes
                 update_cudagraph_capture_sizes(vllm_config, sp_aclgraph_sizes)
 
+        # MTP: FULL_AND_PIECEWISE is not yet fully supported; downgrade to
+        # PIECEWISE. FULL_DECODE_ONLY is allowed through for FDO graph mode.
+        if compilation_config.cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE:
+            compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+
         # Encoder-decoder models currently only support PIECEWISE mode
         # TODO(Jian Li): Confirm this behavior and explain why
         if (
@@ -617,7 +623,18 @@ class NPUPlatform(Platform):
             # TODO(2026/7/15): Delete the reduced gear after the new driver is released.
             if get_ascend_device_type() == AscendDeviceType.A5:
                 prune_capture_sizes_for_950(vllm_config)
+            update_aclgraph_sizes(vllm_config)
             ascend_config.ascend_compilation_config.enable_npugraph_ex = False
+        elif (
+            compilation_config.cudagraph_mode == CUDAGraphMode.FULL_DECODE_ONLY
+            or compilation_config.cudagraph_mode == CUDAGraphMode.FULL
+        ):
+            logger.info(
+                "FULL_DECODE_ONLY compilation enabled on NPU. "
+                "use_inductor not supported - using only ACL Graph mode"
+            )
+            compilation_config.use_inductor = False
+            compilation_config.splitting_ops = []
         elif compilation_config.cudagraph_mode.has_full_cudagraphs():
             # We don't want to have our FX graph split for the sake of static kernel feature,
             # because it will compile multiple times, so we set splitting_ops to empty manually.

--- a/vllm_ascend/spec_decode/__init__.py
+++ b/vllm_ascend/spec_decode/__init__.py
@@ -24,6 +24,7 @@ from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
 from vllm_ascend.spec_decode.extract_hidden_states_proposer import (
     AscendExtractHiddenStatesProposer,
 )
+from vllm_ascend.spec_decode.gemma4_proposer import AscendGemma4Proposer
 from vllm_ascend.spec_decode.medusa_proposer import AscendMedusaProposer
 from vllm_ascend.spec_decode.ngram_proposer import AscendNgramProposer
 from vllm_ascend.spec_decode.ngram_proposer_npu import AscendNgramProposerNPU
@@ -39,6 +40,8 @@ def get_spec_decode_method(method, vllm_config, device, runner):
         return AscendSuffixDecodingProposer(vllm_config, runner)
     elif method == "medusa":
         return AscendMedusaProposer(vllm_config, device)
+    elif method == "mtp" and vllm_config.speculative_config.use_gemma4_mtp():
+        return AscendGemma4Proposer(vllm_config, device, runner)
     elif method in ("eagle", "eagle3", "mtp"):
         return AscendEagleProposer(vllm_config, device, runner)
     elif method == "dflash":

--- a/vllm_ascend/spec_decode/gemma4_proposer.py
+++ b/vllm_ascend/spec_decode/gemma4_proposer.py
@@ -1,0 +1,345 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Gemma4 MTP proposer with Ascend NPU support.
+
+Uses multiple inheritance to combine the upstream vLLM Gemma4Proposer
+(GPU logic) with vllm-ascend's AscendSpecDecodeBaseProposer
+(NPU initialization, ACL graph, attention metadata).
+"""
+
+import torch
+
+from vllm.config import get_layers_from_vllm_config
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.v1.spec_decode.gemma4 import (
+    Gemma4Proposer as _VllmGemma4Proposer,
+)
+
+from vllm_ascend.spec_decode.llm_base_proposer import (
+    AscendSpecDecodeBaseProposer,
+)
+
+
+class AscendGemma4Proposer(_VllmGemma4Proposer, AscendSpecDecodeBaseProposer):
+    """Gemma4 MTP proposer adapted for Ascend NPUs.
+
+    MRO: AscendGemma4Proposer -> Gemma4Proposer ->
+         AscendSpecDecodeBaseProposer -> SpecDecodeBaseProposer
+
+    Gemma4Proposer provides:
+      - _setup_gemma4_kv_sharing()
+      - build_per_group_and_layer_attn_metadata()
+      - initialize_attn_backend() (multi-group KV)
+      - set_per_group_block_table()
+      - _create_draft_vllm_config()
+
+    AscendSpecDecodeBaseProposer provides:
+      - NPU initialization (pcp_size, ACL graph, attention state)
+      - _run_merged_draft() with Ascend-specific metadata
+      - _propose() with slot mapping management
+      - dummy_run() for ACL graph capture
+      - load_model() / _get_model()
+    """
+
+    def __init__(
+        self,
+        vllm_config,
+        device,
+        runner=None,
+    ):
+        # 1. Ascend init: sets up pcp_size, use_cuda_graph,
+        #    attn_mask_builder, slot_mapping buffers, ACL graph wrapper,
+        #    self.runner reference, self._runnable, etc.
+        AscendSpecDecodeBaseProposer.__init__(
+            self,
+            vllm_config,
+            device,
+            pass_hidden_states_to_model=True,
+            runner=runner,
+        )
+
+        # 2. Gemma4-specific attributes (same as upstream Gemma4Proposer.__init__
+        #    after super()).  We set these directly rather than calling
+        #    Gemma4Proposer.__init__ because in our multiple-inheritance MRO
+        #    its super().__init__() would resolve to AscendSpecDecodeBaseProposer,
+        #    causing a double-init of the Ascend base.
+        self.constant_draft_positions = True
+        self._per_group_block_tables: dict[int, torch.Tensor] = {}
+        self._centroids_sizes: list[int] = []
+        self._centroids_graphs: dict[int, torch.cuda.CUDAGraph] = {}
+        self._centroids_inputs: dict[int, torch.Tensor] = {}
+        self._centroids_outputs: dict[int, torch.Tensor] = {}
+
+    # ---- _greedy_sample ----------------------------------------------------
+    # Override to enable centroids masking in eager mode on Ascend NPU.
+    # Upstream uses CUDA graphs with pre-captured centroids sizes, which
+    # is not available on NPU. We bypass CUDA graphs and call
+    # get_top_tokens() directly — this uses the same sparse centroid
+    # vocabulary restriction but runs in eager mode.
+
+    def _greedy_sample(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        model = self.get_model()
+        if getattr(model, 'masked_embedding', None) is not None:
+            return model.get_top_tokens(hidden_states)
+        return super()._greedy_sample(hidden_states)
+
+    # ---- model_returns_tuple -----------------------------------------------
+    # Ascend base returns False for "mtp", but Gemma4 MTP forward()
+    # returns (draft_hidden_states, backbone_hidden_states).
+    # Gemma4Proposer already overrides this to return True; the MRO
+    # picks that up.  Explicit override here for clarity.
+
+    def model_returns_tuple(self) -> bool:
+        return True
+
+    # ---- build_per_group_and_layer_attn_metadata ----------------------------
+    # Override to add diagnostics for multi-group block table assignment.
+
+    def build_per_group_and_layer_attn_metadata(
+        self,
+        common_attn_metadata,
+        draft_index: int = 0,
+    ):
+        from copy import copy
+
+        per_group_attn_metadata: list[object] = []
+        per_layer_attn_metadata: dict[str, object] = {}
+        for attn_group in self.draft_attn_groups:
+            gid = attn_group.kv_cache_group_id
+            if gid in self._per_group_block_tables:
+                cm = copy(common_attn_metadata)
+                cm.block_table_tensor = self._per_group_block_tables[gid]
+            else:
+                cm = common_attn_metadata
+            attn_metadata = attn_group.get_metadata_builder().build_for_drafting(
+                common_attn_metadata=cm, draft_index=draft_index
+            )
+            per_group_attn_metadata.append(attn_metadata)
+            for layer_name in attn_group.layer_names:
+                per_layer_attn_metadata[layer_name] = attn_metadata
+        return per_group_attn_metadata, per_layer_attn_metadata
+
+    # ---- set_per_group_block_table -------------------------------------------
+    # Override to log block table updates — tracks when new blocks are assigned
+    # to each KV cache group. Critical for the "append" degradation theory.
+
+    def set_per_group_block_table(self, gid: int, block_table: torch.Tensor) -> None:
+        self._per_group_block_tables[gid] = block_table
+
+    # ---- _maybe_share_lm_head ----------------------------------------------
+    # Gemma4 MTP's lm_head operates in draft hidden_size (e.g. 1024),
+    # not the target's backbone hidden_size (e.g. 5376).  Sharing
+    # would break compute_logits.  Both upstream Gemma4Proposer and
+    # AscendSpecDecodeBaseProposer override this; we need the upstream
+    # behaviour BUT also the Ascend ACLGraphWrapper setup that
+    # Ascend._maybe_share_lm_head does for full-graph mode.
+    #
+    # Solution: skip lm_head sharing, but call Ascend's ACL setup.
+
+    def _maybe_share_lm_head(self, target_language_model):
+        """Keep draft lm_head; delegate ACL graph setup to Ascend parent."""
+        from vllm.logger import init_logger
+        logger = init_logger(__name__)
+        logger.info(
+            "Gemma4 MTP: keeping draft model's own lm_head "
+            "(draft_dim != backbone_dim)."
+        )
+        # The Ascend parent's _maybe_share_lm_head only shares for
+        # eagle/dflash or deepseek_mla — neither applies here.
+        # But it also wraps self._runnable in ACLGraphWrapper for
+        # full-graph mode.  Call it for that side-effect.
+        AscendSpecDecodeBaseProposer._maybe_share_lm_head(
+            self, target_language_model
+        )
+
+    # ---- _fix_draft_kv_head_counts -------------------------------------------
+    # When the draft model's attention layer is configured with a different
+    # number of KV heads than the target layer it shares with (e.g. draft
+    # reports 16 KV heads from HuggingFace config but the target's
+    # full_attention uses num_global_kv_heads=4), the KV-cache reshape in
+    # attention_v1._get_current_token_shared_kv will misinterpret the data.
+    # Align the draft's num_kv_heads (and num_heads) to the target layer's
+    # values so PA and shared-KV prefill paths produce correct results.
+
+    def _fix_draft_kv_head_counts(self, target_model) -> None:
+        from vllm.logger import init_logger
+        logger = init_logger(__name__)
+
+        # Build a lookup from target layer name → (num_heads, num_kv_heads)
+        # using the already-computed target_attn_layer_names.
+        target_attn_layers = get_layers_from_vllm_config(
+            self.vllm_config,
+            AttentionLayerBase,
+        )
+
+        draft_model = self.get_model()
+        if not (hasattr(draft_model, "model") and hasattr(draft_model.model, "layers")):
+            return
+
+        for draft_idx, layer in enumerate(draft_model.model.layers):
+            if not hasattr(layer, "self_attn"):
+                continue
+            attn = getattr(layer.self_attn, "attn", None)
+            if attn is None:
+                continue
+            tgt_name = getattr(attn, "kv_sharing_target_layer_name", None)
+            if tgt_name is None:
+                continue
+            target_module = target_attn_layers.get(tgt_name)
+            if target_module is None:
+                logger.warning(
+                    "Draft layer %d shares KV with '%s' but target "
+                    "module not found — skipping head-count fix.",
+                    draft_idx, tgt_name,
+                )
+                continue
+
+            draft_nkv = attn.num_kv_heads
+            tgt_nkv = target_module.num_kv_heads
+            draft_nh = attn.num_heads
+            tgt_nh = target_module.num_heads
+
+            # Always sync kv_sharing_target_layer_name to the backend
+            # (impl). _setup_gemma4_kv_sharing sets it on the Attention
+            # wrapper but the AscendAttention backend was already
+            # initialised with None.
+            kv_share_tgt = getattr(attn, "kv_sharing_target_layer_name", None)
+            impl = getattr(attn, "impl", None)
+            if impl is not None and kv_share_tgt is not None:
+                object.__setattr__(impl, "kv_sharing_target_layer_name", kv_share_tgt)
+                # CRITICAL: Save a reference to the target attention
+                # backend so that forward_paged_attention can swap
+                # self.key_cache → target's key_cache at runtime.
+                # Without this, PA reads from the draft model's own
+                # empty key_cache tensor, producing all-zero attention.
+                target_impl = getattr(target_module, "impl", None)
+                if target_impl is not None:
+                    object.__setattr__(impl, "_kv_share_target_impl", target_impl)
+                    logger.info(
+                        "MTP KV-sharing: draft layer %d impl will use "
+                        "target '%s' key_cache at runtime.",
+                        draft_idx, tgt_name,
+                    )
+                # Store a reference to the per_group_block_tables dict
+                # so that _get_shared_kv_from_block_table can use the
+                # correct block_table for this KV cache group.
+                object.__setattr__(impl, "_per_group_bt_ref", self._per_group_block_tables)
+
+            if draft_nkv != tgt_nkv or draft_nh != tgt_nh:
+                logger.info(
+                    "MTP KV-sharing head fix: draft layer %d "
+                    "(heads=%d, kv_heads=%d) -> target '%s' "
+                    "(heads=%d, kv_heads=%d)",
+                    draft_idx, draft_nh, draft_nkv,
+                    tgt_name, tgt_nh, tgt_nkv,
+                )
+                object.__setattr__(attn, "num_kv_heads", tgt_nkv)
+                object.__setattr__(attn, "num_heads", tgt_nh)
+                # Also fix the AscendAttention backend (impl) — it has
+                # its own copies that were initialised from Attention
+                # before _setup_gemma4_kv_sharing ran.
+                if impl is not None:
+                    object.__setattr__(impl, "num_kv_heads", tgt_nkv)
+                    object.__setattr__(impl, "num_heads", tgt_nh)
+                # CRITICAL: Also fix Gemma4MTPAttention's own attributes.
+                # Gemma4MTPAttention.forward() creates kv_dummy using
+                # self.num_kv_heads. If this doesn't match
+                # Attention.num_kv_heads, the vLLM Attention.forward
+                # reshape (view(-1, num_kv_heads, head_size)) produces
+                # a different batch dimension for key vs query, causing
+                # the KV-sharing prefill condition
+                #   query.shape[0] == key.shape[0]
+                # to fail. Layer 59 then falls through to the
+                # LARGE-HEAD FALLBACK PA path, missing the prefill-only
+                # KV gathering from the shared target cache.
+                mtp_attn = layer.self_attn
+                if getattr(mtp_attn, "num_kv_heads", None) != tgt_nkv:
+                    object.__setattr__(mtp_attn, "num_kv_heads", tgt_nkv)
+                if getattr(mtp_attn, "num_heads", None) != tgt_nh:
+                    object.__setattr__(mtp_attn, "num_heads", tgt_nh)
+
+    # ---- _store_gids_on_impls ----------------------------------------------
+    # After initialize_attn_backend and _fix_draft_kv_head_counts have both
+    # run, store the kv_cache_group_id on each draft attention backend impl
+    # so that _get_shared_kv_from_block_table can find the correct
+    # block_table for this layer's KV cache group.
+    def _store_gids_on_impls(self) -> None:
+        """Store kv_cache_group_id on each draft attention backend impl."""
+        if not hasattr(self, 'draft_attn_groups'):
+            return
+        # Walk the draft model's layers to find attention impls and match
+        # them to attention groups by layer name.
+        draft_model = self.get_model()
+        if not (hasattr(draft_model, 'model') and hasattr(draft_model.model, 'layers')):
+            return
+        # Build gid lookup from attention group layer names
+        ln_to_gid = {}
+        for ag in self.draft_attn_groups:
+            for ln in ag.layer_names:
+                ln_to_gid[ln] = ag.kv_cache_group_id
+        # Walk draft model layers
+        for draft_idx, layer in enumerate(draft_model.model.layers):
+            attn_layer = getattr(layer, 'self_attn', None)
+            if attn_layer is None:
+                continue
+            attn = getattr(attn_layer, 'attn', None)
+            if attn is None:
+                continue
+            impl = getattr(attn, 'impl', None)
+            if impl is None:
+                continue
+            # Match by layer name patterns
+            for ln, gid in ln_to_gid.items():
+                if f"layers.{draft_idx}.self_attn" in ln:
+                    object.__setattr__(impl, '_kv_share_gid', gid)
+                    break
+
+    # ---- load_model --------------------------------------------------------
+    # We need BOTH:
+    #   a) Ascend's load_model (loads draft model, identifies draft layers,
+    #      shares embeddings, handles multimodality, etc.)
+    #   b) Gemma4's _setup_gemma4_kv_sharing (wires kv_sharing_target_layer_name
+    #      on each draft attention layer)
+
+    def initialize_attn_backend(self, kv_cache_config, kernel_block_sizes=None):
+        """Override to store per-layer gid on each draft attention backend."""
+        super().initialize_attn_backend(kv_cache_config, kernel_block_sizes)
+        self._store_gids_on_impls()
+
+    def load_model(self, target_model):
+        target_attn_layer_names = set(
+            get_layers_from_vllm_config(
+                self.vllm_config,
+                AttentionLayerBase,
+            ).keys()
+        )
+
+        # Ascend load: loads the draft model, finds draft attn layers,
+        # shares embed_tokens with target, handles multimodal, etc.
+        AscendSpecDecodeBaseProposer.load_model(self, target_model)
+
+        # The Ascend base load_model doesn't run the upstream
+        # supports_mm_inputs detection (which probes embed_input_ids).
+        # Gemma4 MTP draft only consumes backbone hidden states;
+        # it doesn't handle multimodal embeddings.
+        self.supports_mm_inputs = False
+
+        # Wire cross-model KV sharing: each draft attention layer
+        # reads K/V from the corresponding target layer's cache.
+        _VllmGemma4Proposer._setup_gemma4_kv_sharing(
+            self, target_attn_layer_names
+        )
+
+        # Fix num_kv_heads mismatch: the draft model's attention layers
+        # may have a different GQA configuration than the target layers
+        # they share KV caches with (e.g., the draft reads 16 KV heads
+        # from its config but the target's full_attention layer only has
+        # 4 global KV heads).  If they don't match, the KV cache reshape
+        # in _get_current_token_shared_kv will misinterpret the data,
+        # leading to garbage attention outputs and downstream crashes.
+        self._fix_draft_kv_head_counts(target_model)
+
+        # Centroids CUDA graphs are CUDA-only; skip on Ascend.
+        # The upstream check calls _setup_centroids_cuda_graphs()
+        # when masked_embedding is present, but that uses
+        # torch.cuda.CUDAGraph which is not available on NPU.
+        # If centroids are needed, they run in eager mode.

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import copy
+import os
 from collections.abc import Callable
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from functools import partial
@@ -451,20 +452,30 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     layer_module.shared_head.head = model.lm_head
 
         if self.vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs() and self.use_cuda_graph:
-            logger.info(
-                "[spec_decode/base] Wrapping draft model with ACLGraphWrapper:"
-                " runtime_mode=FULL, use_eagle=%s, enable_enpu=%s",
-                self.use_eagle,
-                self.enable_enpu,
-            )
+            # VLLM_ASCEND_MTP_MODE: see model_runner_v1.py load_model() for docs
+            mtp_mode = os.environ.get("VLLM_ASCEND_MTP_MODE", "target_eager")
+            self._mtp_draft_fdo = False  # Draft FDO disabled: hangs during replay
+
+            if not self._mtp_draft_fdo:
+                # Draft runs eager — disable graph mode for the proposer so
+                # forward context uses NONE mode and skips graph dispatch.
+                self.use_cuda_graph = False
+
             self.update_stream = torch.npu.Stream()
-            self._runnable = ACLGraphWrapper(
-                self._run_merged_draft,
-                self.vllm_config,
-                runtime_mode=CUDAGraphMode.FULL,
-                use_eagle=self.use_eagle,
-                enable_enpu=self.enable_enpu,
-            )
+            if self._mtp_draft_fdo:
+                self._runnable = ACLGraphWrapper(
+                    self._run_merged_draft,
+                    self.vllm_config,
+                    runtime_mode=CUDAGraphMode.FULL,
+                    use_eagle=self.use_eagle,
+                    enable_enpu=self.enable_enpu,
+                )
+            else:
+                logger.info(
+                    "[spec_decode/base] Draft ACLGraphWrapper SKIPPED: "
+                    "mtp_mode=%s, _mtp_draft_fdo=%s",
+                    mtp_mode, self._mtp_draft_fdo,
+                )
 
     def _maybe_share_topk_indices(self, target_language_model: nn.Module) -> None:
         if hasattr(target_language_model.model, "topk_indices_buffer"):
@@ -630,6 +641,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             if forward_context is not None:
                 forward_context.moe_layer_index = 0
 
+            self._sync_wait_target_events()
             self._runnable(
                 num_input_tokens=num_tokens,
                 batch_size=batch_size,
@@ -652,6 +664,18 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     ) -> None:
         if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL:
             self._update_full_graph_params(forward_context, num_input_tokens, multi_steps_attn_metadata)
+
+    def _sync_wait_target_events(self) -> None:
+        """Wait for NPU events recorded after target forward completes.
+
+        In draft_eager/both_fdo mode, the target model's FDO graph replay
+        writes KV cache asynchronously on the NPU stream.  We must wait for
+        those writes to complete before the draft model reads the KV cache.
+        """
+        _ev = getattr(self, '_target_done_event', None)
+        if _ev is not None:
+            _ev.wait()
+            self._target_done_event = None
 
     def _propose(
         self,
@@ -983,6 +1007,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "is_prefill": attn_metadata_i.num_prefills,
             }
             run_draft = partial(self._runnable, **model_inputs)
+            self._sync_wait_target_events()
 
             if self.enable_enpu:
                 self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -20,6 +20,7 @@
 import gc
 import logging
 import math
+import os
 import sys
 import time
 from collections import defaultdict
@@ -134,6 +135,7 @@ from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
 from vllm_ascend.spec_decode.extract_hidden_states_proposer import (
     AscendExtractHiddenStatesProposer,
 )
+from vllm_ascend.spec_decode.gemma4_proposer import AscendGemma4Proposer
 from vllm_ascend.spec_decode.medusa_proposer import AscendMedusaProposer
 from vllm_ascend.spec_decode.ngram_proposer import AscendNgramProposer
 from vllm_ascend.spec_decode.ngram_proposer_npu import AscendNgramProposerNPU
@@ -604,6 +606,7 @@ class NPUModelRunner(GPUModelRunner):
             | AscendEagleProposer
             | AscendDraftModelProposer
             | AscendDflashProposer
+            | AscendGemma4Proposer
             | AscendSuffixDecodingProposer
             | AscendMedusaProposer
             | AscendExtractHiddenStatesProposer
@@ -2313,6 +2316,15 @@ class NPUModelRunner(GPUModelRunner):
             hidden_states = self._model_forward(
                 num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds, **model_kwargs
             )
+        # MTP: Record NPU event after target forward completes, so the draft
+        # model can wait on it before reading the KV cache.  Required when
+        # the target model runs in FDO graph mode (_mtp_target_fdo=True)
+        # because reshape_and_cache KV writes are async on the NPU stream.
+        if ((getattr(self, '_mtp_target_fdo', False) or os.path.exists("/tmp/vllm_sync_target_kv"))
+                and hasattr(self, 'drafter') and self.drafter is not None):
+            _target_done = torch.npu.Event()
+            _target_done.record()
+            self.drafter._target_done_event = _target_done
         with record_function_or_nullcontext("post process"):
             aux_hidden_states = None
             if self.use_aux_hidden_state_outputs:
@@ -3310,11 +3322,16 @@ class NPUModelRunner(GPUModelRunner):
                 cm.block_table_tensor, cm.slot_mapping = _get_block_table_and_slot_mapping(
                     kv_cache_gid, total_num_scheduled_tokens_compressed_list)  # type: ignore[arg-type]
             if self.speculative_config and spec_decode_common_attn_metadata is None:
-                if isinstance(self.drafter, AscendEagleProposer | AscendDraftModelProposer | AscendDflashProposer):
+                if isinstance(self.drafter, AscendEagleProposer | AscendGemma4Proposer | AscendDraftModelProposer | AscendDflashProposer):
                     if self.drafter.attn_layer_names[0] in kv_cache_group.layer_names:
                         spec_decode_common_attn_metadata = cm
                 else:
                     spec_decode_common_attn_metadata = cm
+            # MTP: Capture per-group block tables for multi-group proposers
+            # (Gemma4 MTP). Each KV cache group has its own block_table;
+            # the draft model needs all of them to read the correct KV cache.
+            if self.speculative_config and isinstance(self.drafter, AscendGemma4Proposer):
+                self.drafter.set_per_group_block_table(kv_cache_gid, cm.block_table_tensor)
             if self.enable_hamming_sparse is True:
                 from vllm_ascend.attention.kvcomp_attn.attention_utils import build_kvcomp_metadata
                 build_kvcomp_metadata(self.kvcomp_meta_data, cm)
@@ -3790,6 +3807,27 @@ class NPUModelRunner(GPUModelRunner):
         from vllm.model_executor.offloader.base import get_offloader
         get_offloader().post_init()
 
+        # MTP mode dispatch: VLLM_ASCEND_MTP_MODE controls which model
+        # gets FDO graph capture:
+        #   "target_eager" (default): Target eager, Draft FDO
+        #   "draft_eager":           Target FDO,   Draft eager
+        #   "both_fdo":              Target FDO,   Draft FDO
+        has_spec = (
+            self.speculative_config is not None
+            and (self.speculative_config.use_eagle()
+                 or self.speculative_config.uses_draft_model())
+        )
+        mtp_mode = os.environ.get("VLLM_ASCEND_MTP_MODE", "target_eager")
+        if mtp_mode == "draft_eager":
+            self._mtp_target_fdo = True
+            self._mtp_draft_fdo = False
+        elif mtp_mode == "both_fdo":
+            self._mtp_target_fdo = True
+            self._mtp_draft_fdo = True
+        else:  # "target_eager" (default)
+            self._mtp_target_fdo = False
+            self._mtp_draft_fdo = True
+
         # wrap the model with full graph wrapper if needed.
         if self.compilation_config.cudagraph_mode.has_full_cudagraphs():
             self.update_stream: torch.npu.Stream = torch.npu.Stream()
@@ -3863,11 +3901,21 @@ class NPUModelRunner(GPUModelRunner):
         ):
             assert isinstance(
                 self.drafter,
-                AscendEagleProposer | AscendDflashProposer | AscendDraftModelProposer,
+                AscendEagleProposer | AscendGemma4Proposer | AscendDflashProposer | AscendDraftModelProposer,
             )
-            block_size = (self.kernel_block_sizes[0] if isinstance(
-                self.kernel_block_sizes, list) else self.kernel_block_sizes)
-            self.drafter.initialize_attn_backend(kv_cache_config, block_size)
+            if isinstance(self.drafter, AscendGemma4Proposer):
+                # Gemma4 MTP needs per-group kernel_block_sizes (list of ints),
+                # not a single block_size.  Pass the list directly.
+                kernel_block_sizes = (
+                    self.kernel_block_sizes
+                    if isinstance(self.kernel_block_sizes, list)
+                    else [self.kernel_block_sizes]
+                )
+                self.drafter.initialize_attn_backend(kv_cache_config, kernel_block_sizes)
+            else:
+                block_size = (self.kernel_block_sizes[0] if isinstance(
+                    self.kernel_block_sizes, list) else self.kernel_block_sizes)
+                self.drafter.initialize_attn_backend(kv_cache_config, block_size)
 
         if has_kv_transfer_group() and not is_profiling:
             get_kv_transfer_group().register_kv_caches(kv_caches)


### PR DESCRIPTION
  ## What this PR does / why we need it?
  
  This PR adds Gemma4 MTP (Multi-Token Prediction) speculative decoding support on Ascend NPU.

  Gemma4-31B uses a native MTP draft model that shares KV caches with the target model across multiple KV cache groups (interleaved full-attention / sliding-window layers). This PR implements:

  - Cross-model KV sharing: Draft model reads K/V from target model's per-group KV caches via block table routing (_per_group_block_tables)
  - Num KV heads alignment: Draft model HF config reports a different GQA configuration than the target layers it shares with, causing KV cache reshape mismatches. _fix_draft_kv_head_counts aligns them at init
  time
  - Target→Draft event sync: In FDO graph mode, target KV writes are async on the NPU stream. An NPU event is recorded after target forward and waited on before draft reads
  - Nested NPU graph capture guard: When the target is already capturing an FDO graph, draft model skips its own capture and runs eagerly to avoid workspace corruption
  - Key-based attention graph param lookup (attn_params_by_key): Replaces zip-based pairing for deterministic param update dispatch across heterogeneous attention layers

  ## Does this PR introduce any user-facing change?

  No API changes. Gemma4 MTP speculative decoding is enabled via existing --speculative-config with method=mtp. A new environment variable VLLM_ASCEND_MTP_MODE controls which model gets FDO graph capture
  (target_eager / draft_eager / both_fdo).

  ## How was this patch tested?

  Tested with Gemma4-31B on Ascend A2 with K=3 draft_eager mode. Target model runs FDO graph, draft runs eager. Acceptance rates: pos0 ~68%, avg ~40.5%. Throughput benchmarks on TP=4.

  vLLM version: v0.23.0
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
