### PR TITLE
[Doc]Ducument-Modifications Including some issues in Kimi-K2.5 and Kimi-K2.6

### DIFF
--- a/docs/source/tutorials/models/Kimi-K2.5.md
+++ b/docs/source/tutorials/models/Kimi-K2.5.md
@@ -196,7 +196,7 @@ Run the following scripts on two nodes respectively.
 # this obtained through ifconfig
 # nic_name is the network interface name corresponding to local_ip of the current node
 nic_name="xxxx"
-local_ip="xxxx"
+local_ip="141.xx.xx.1"
 
 # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
 node0_ip="xxxx"
@@ -259,7 +259,7 @@ vllm serve Eco-Tech/Kimi-K2.5-W4A8 \
 # this obtained through ifconfig
 # nic_name is the network interface name corresponding to local_ip of the current node
 nic_name="xxx"
-local_ip="xxx"
+local_ip="141.xx.xx.2"
 
 # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
 node0_ip="xxxx"
@@ -767,7 +767,7 @@ Run performance evaluation of `Kimi-K2.5-w4a8` as an example.
 
 Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/benchmarking/) for more details.
 
-There are three `vllm benchmark` subcommands:
+There are three `vllm bench` subcommands:
 
 - `latency`: Benchmark the latency of a single batch of requests.
 - `serve`: Benchmark the online serving throughput.

--- a/docs/source/tutorials/models/Kimi-K2.6.md
+++ b/docs/source/tutorials/models/Kimi-K2.6.md
@@ -114,7 +114,7 @@ If you don't want to use the docker image as above, you can also build all from 
 
 If you want to deploy multi-node environment, you need to set up environment on each node.
 
-To use the tools_call feature, please ensure that your transformers version is 4.57.6 or lower. If vllm-ascend has been upgraded to v0.21 or later, this requirement no longer applies.
+To use the tool_calls feature, please ensure that your transformers version is 4.57.6 or lower. If vllm-ascend has been upgraded to v0.21 or later, this requirement no longer applies.
 
 ## 5 Online Service Deployment
 
@@ -574,8 +574,8 @@ To run the vllm-ascend `Prefill-Decode Disaggregation` service, you need to depl
       --kv-transfer-config \
       '{"kv_connector": "MooncakeConnectorV1",
       "kv_role": "kv_consumer",
-      "kv_port": "30200",
-      "engine_id": "2",
+      "kv_port": "30300",
+      "engine_id": "3",
       "kv_connector_extra_config": {
                 "prefill": {
                         "dp_size": 4,
@@ -845,6 +845,6 @@ Please refer to the [Feature Guide](../../user_guide/support_matrix/feature_matr
 
 For common environment, installation, and general parameter issues, please refer to the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html); this chapter only covers model-specific issues.
 
-- **Q: What transformer version is required for tools_call feature?**
+- **Q: What transformer version is required for tool_calls feature?**
 
-  A: To use the tools_call feature, please ensure that your transformers version is 4.57.6 or lower. If vllm-ascend has been upgraded to v0.21 or later, this requirement no longer applies.
+  A: To use the tool_calls feature, please ensure that your transformers version is 4.57.6 or lower. If vllm-ascend has been upgraded to v0.21 or later, this requirement no longer applies.


### PR DESCRIPTION
### What this PR does / why we need it?
Modifications were made to address some issues in the second AIDD scan results of June 2026:
1. In `Kimi-K2.5.md`, replaces placeholder `local_ip` values with example IPs (`141.xx.xx.1` and `141.xx.xx.2`) for multi-node deployment, and corrects the `vllm benchmark` subcommand reference to `vllm bench`.
2. In `Kimi-K2.6.md`, corrects a typo from `tools_call` to `tool_calls` (though `tool_calls` is standard, we should note this or suggest the correct standard term), and fixes a copy-paste error in Decode Node 1's configuration where `kv_port` and `engine_id` were duplicated from Decode Node 0 instead of being set to `30300` and `3`.
### Does this PR introduce _any_ user-facing change?
No, this is a documentation-only update.
### How was this patch tested?
Documentation changes only, verified by reviewing the configuration consistency.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
