### PR TITLE
[Doc][BugFix] Fix  notification banner, path, install command, and Chinese translations

### DIFF
--- a/docs/source/developer_guide/evaluation/using_ais_bench.md
+++ b/docs/source/developer_guide/evaluation/using_ais_bench.md
@@ -150,7 +150,7 @@ You can choose one or multiple datasets to execute accuracy evaluation.
 
 #### Configuration
 
-Update the file `benchmark/ais_bench/benchmark/configs/models/vllm_api/vllm_api_general_chat.py`.
+Update the file `ais_bench/benchmark/configs/models/vllm_api/vllm_api_general_chat.py`.
 There are several arguments that you should update according to your environment.
 
 - `attr`: Identifier for the inference backend type, fixed as `service` (serving-based inference) or `local` (local model).

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -139,7 +139,7 @@ Then you can install `vllm` and `vllm-ascend` from a **pre-built wheel** using o
 
     # Install vllm-project/vllm-ascend.
     pip install \
-    --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant https://mirrors.huaweicloud.com/ascend/repos/pypi  \
+    --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant \
     vllm-ascend=={{ pip_vllm_ascend_version }}
 
     ```

--- a/docs/source/locale/zh_CN/LC_MESSAGES/tutorials/hardwares/310p.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/tutorials/hardwares/310p.po
@@ -150,7 +150,7 @@ msgstr ""
 msgid ""
 "Run the following commands to start the vLLM server on NPU for the Qwen3 "
 "Dense series."
-msgstr "运行以下命令，在NPU上为Qwen3 Dense系列启动vLLM服务器。"
+msgstr "运行以下命令，在NPU上为Qwen3 Dense系列启动vLLM服务。"
 
 msgid "#### Prepare Model Weights"
 msgstr "#### 准备模型权重"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/tutorials/models/Qwen-VL-Dense.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/tutorials/models/Qwen-VL-Dense.po
@@ -173,7 +173,7 @@ msgid "### 5.1 Single-Node Online Deployment"
 msgstr "### 5.1 单节点在线部署"
 
 msgid "Run docker container to start the vLLM server on single-NPU:"
-msgstr "运行docker容器以在单NPU上启动vLLM服务器："
+msgstr "运行docker容器以在单NPU上启动vLLM服务："
 
 msgid "Key Parameter Descriptions:"
 msgstr "关键参数说明："

--- a/docs/source/locale/zh_CN/LC_MESSAGES/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.po
@@ -351,7 +351,7 @@ msgid ""
 "1. `launch_online_dp.py` is used to launch external dp vllm servers.\n"
 "    [launch_online_dp.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/external_online_dp/launch_online_dp.py)"
 msgstr ""
-"1. `launch_online_dp.py`用于启动外部dp vllm服务器。\n"
+"1. `launch_online_dp.py`用于启动外部dp vllm服务。\n"
 "    [launch_online_dp.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/external_online_dp/launch_online_dp.py)"
 
 msgid "Parameter descriptions:"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/user_guide/feature_guide/flash_attention.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/user_guide/feature_guide/flash_attention.po
@@ -65,7 +65,7 @@ msgid "To enable FA3, you need to:"
 msgstr "要启用FA3，您需要："
 
 msgid "To start a vLLM server with FA3 enabled:"
-msgstr "启动启用FA3的vLLM服务器："
+msgstr "启动启用FA3的vLLM服务："
 
 msgid "Then use the OpenAI-compatible client:"
 msgstr "然后使用OpenAI兼容客户端："

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -36,7 +36,7 @@ This section guides you through container-based environment setup and large mode
 
 Before using containers, make sure Docker is installed on your system. If Docker is not installed, please refer to the [Docker installation guide](https://docs.docker.com/get-docker/) for installation instructions.
 
-=== "Ubuntu"
+=== "Ubuntu (A2)"
 
     ```bash
 
@@ -45,8 +45,6 @@ Before using containers, make sure Docker is installed on your system. If Docker
     # Update the vllm-ascend image
     # Atlas A2:
     # export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
-    # Atlas A3:
-    # export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
     export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
     docker run --rm \
     --name vllm-ascend \
@@ -67,7 +65,39 @@ Before using containers, make sure Docker is installed on your system. If Docker
     apt-get update -y && apt-get install -y curl
     ```
 
-=== "openEuler"
+=== "Ubuntu (A3)"
+
+    ```bash
+
+    # A3 requires at least 2 NPUs to work together.
+    # Update DEVICE0 and DEVICE1 according to your devices (/dev/davinci[0-15])
+    export DEVICE0=/dev/davinci0
+    export DEVICE1=/dev/davinci1
+    # Update the vllm-ascend image
+    # Atlas A3:
+    # export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
+    docker run --rm \
+    --name vllm-ascend \
+    --shm-size=1g \
+    --device $DEVICE0 \
+    --device $DEVICE1 \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+    -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /root/.cache:/root/.cache \
+    -p 8000:8000 \
+    -it $IMAGE bash
+    # Install curl
+    apt-get update -y && apt-get install -y curl
+    ```
+
+=== "openEuler (A2)"
 
     ```bash
 
@@ -76,13 +106,43 @@ Before using containers, make sure Docker is installed on your system. If Docker
     # Update the vllm-ascend image
     # Atlas A2:
     # export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-openeuler
-    # Atlas A3:
-    # export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3-openeuler
     export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-openeuler
     docker run --rm \
     --name vllm-ascend \
     --shm-size=1g \
     --device $DEVICE \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+    -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /root/.cache:/root/.cache \
+    -p 8000:8000 \
+    -it $IMAGE bash
+    # Install curl
+    yum update -y && yum install -y curl
+    ```
+
+=== "openEuler (A3)"
+
+    ```bash
+
+    # A3 requires at least 2 NPUs to work together.
+    # Update DEVICE0 and DEVICE1 according to your devices (/dev/davinci[0-15])
+    export DEVICE0=/dev/davinci0
+    export DEVICE1=/dev/davinci1
+    # Update the vllm-ascend image
+    # Atlas A3:
+    # export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3-openeuler
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3-openeuler
+    docker run --rm \
+    --name vllm-ascend \
+    --shm-size=1g \
+    --device $DEVICE0 \
+    --device $DEVICE1 \
     --device /dev/davinci_manager \
     --device /dev/devmm_svm \
     --device /dev/hisi_hdc \


### PR DESCRIPTION
### What this PR does / why we need it?

- using_ais_bench.md — Fix ais_bench config path (remove redundant benchmark/ prefix)
- installation.md — Remove duplicate --extra-index-url from pip install command
-  .po files — Unify Chinese translation: "vLLM服务器" → "vLLM服务"
- A3 requires at least 2 NPUs to work together, while the original single-device setup only works on A2. Split the Ubuntu and openEuler tabs into dedicated A2 and A3 versions with proper device count and image tags.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
