### PR TITLE
[Performance] Backport AscendStore lookup and recv optimizations

### DIFF
--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -163,6 +163,14 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         self.assertEqual(result[0][2].chunk_hash, _expected_grouped_hash("a", "b").hex())
         self.assertEqual(len(result[0][2].chunk_hash), 64)
 
+    def test_process_tokens_chunk_mask_skips_grouped_hash_generation(self):
+        db = ChunkedTokenDatabase([self.meta], block_size=[16], partitions=None, hash_block_size=8)
+        result = list(db.process_tokens(48, ["a", "b", "c", "d", "e", "f"], chunk_mask=[False, True, False]))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][0], 16)
+        self.assertEqual(result[0][1], 32)
+        self.assertEqual(result[0][2].chunk_hash, _expected_grouped_hash("c", "d").hex())
+
     def test_get_block_hashes_rehashes_grouped_str_hashes(self):
         result = get_block_hashes(["a", "b", "c", "d"], group_block_size=32, hash_block_size=16)
         self.assertEqual(

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -15,6 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
+import queue
 import threading
 import unittest
 from unittest.mock import MagicMock
@@ -324,6 +325,24 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
 
 
 class TestKVCacheStoreRecvingThread(unittest.TestCase):
+    def test_shared_request_queue(self):
+        shared_queue: queue.Queue[ReqMeta] = queue.Queue()
+        t = KVCacheStoreRecvingThread(
+            m_store=FakeStore(),
+            token_database=FakeTokenDatabase(),
+            block_size=16,
+            tp_rank=0,
+            dcp_size=1,
+            ready_event=threading.Event(),
+            invalid_block_ids=set(),
+            invalid_block_ids_lock=threading.Lock(),
+            request_queue=shared_queue,
+        )
+        req = MagicMock()
+        t.add_request(req)
+        self.assertIs(t.request_queue, shared_queue)
+        self.assertIs(shared_queue.get_nowait(), req)
+
     def test_handle_request(self):
         store = FakeStore()
         db = FakeTokenDatabase()

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -122,6 +122,7 @@ class TestKVPoolWorkerInit(unittest.TestCase):
         worker = KVPoolWorker(config, use_layerwize=False)
 
         self.assertEqual(worker.block_size, 16)
+        self.assertEqual(worker.num_recv_threads, 1)
         self.assertEqual(worker.num_layers, 32)
         self.assertFalse(worker.use_layerwise)
         self.assertFalse(worker.use_mla)
@@ -154,6 +155,34 @@ class TestKVPoolWorkerInit(unittest.TestCase):
         worker = KVPoolWorker(config, use_layerwize=False)
         self.assertTrue(worker.use_mla)
         self.assertEqual(worker.num_kv_head, 1)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.importlib")
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.get_decode_context_model_parallel_rank"
+    )
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.get_decode_context_model_parallel_world_size"
+    )
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.get_pcp_group")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.get_tensor_model_parallel_world_size")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.get_tensor_model_parallel_rank")
+    def test_init_load_recv_threads(
+        self, mock_tp_rank, mock_tp_size, mock_pcp_group, mock_dcp_ws, mock_dcp_rank, mock_importlib
+    ):
+        mock_tp_rank.return_value = 0
+        mock_tp_size.return_value = 1
+        pcp_group = MagicMock()
+        pcp_group.world_size = 1
+        mock_pcp_group.return_value = pcp_group
+        mock_dcp_ws.return_value = 1
+        mock_dcp_rank.return_value = 0
+        mock_importlib.import_module.return_value = MagicMock()
+
+        config = self._make_vllm_config(extra_config={"backend": "mooncake", "load_recv_threads": 3})
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker import KVPoolWorker
+
+        worker = KVPoolWorker(config, use_layerwize=False)
+        self.assertEqual(worker.num_recv_threads, 3)
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.importlib")
     @patch(
@@ -306,6 +335,43 @@ class TestKVPoolWorkerInit(unittest.TestCase):
         worker.m_store.exists.return_value = [1, 0]
         result = worker.lookup(32, ["h0", "h1"], use_layerwise=False)
         self.assertEqual(result, 16)  # first non-exist at index 1 => starts[1]=16
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.importlib")
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.get_decode_context_model_parallel_rank"
+    )
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.get_decode_context_model_parallel_world_size"
+    )
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.get_pcp_group")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.get_tensor_model_parallel_world_size")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.get_tensor_model_parallel_rank")
+    def test_lookup_skips_unreachable_align_chunks(
+        self, mock_tp_rank, mock_tp_size, mock_pcp_group, mock_dcp_ws, mock_dcp_rank, mock_importlib
+    ):
+        mock_tp_rank.return_value = 0
+        mock_tp_size.return_value = 1
+        pcp_group = MagicMock()
+        pcp_group.world_size = 1
+        mock_pcp_group.return_value = pcp_group
+        mock_dcp_ws.return_value = 1
+        mock_dcp_rank.return_value = 0
+        mock_importlib.import_module.return_value = MagicMock()
+
+        config = self._make_vllm_config()
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker import KVPoolWorker
+
+        worker = KVPoolWorker(config, use_layerwize=False)
+        worker.group_uses_align_state = [True]
+        worker.cache_transfer_granularity = 32
+        worker.m_store.exists.return_value = [1]
+
+        result = worker.lookup(32, ["h0", "h1"], use_layerwise=False)
+
+        self.assertEqual(result, 32)
+        keys = worker.m_store.exists.call_args.args[0]
+        self.assertEqual(len(keys), 1)
+        self.assertIn("@h1", keys[0])
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.importlib")
     @patch(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -337,6 +337,7 @@ class ChunkedTokenDatabase:
         kv_cache_group_id: int = 0,
         cache_role: str = "kv",
         cache_family: str | None = None,
+        chunk_mask: Sequence[bool] | None = None,
     ) -> Iterable[tuple[int, int, PoolKey]]:
         """Process the tokens and return the corresponding cache engine keys."""
         if not block_hashes:
@@ -346,20 +347,12 @@ class ChunkedTokenDatabase:
             cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
         cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
         group_block_size *= cache_family_ratio
-        block_hashes = get_block_hashes(
+        for chunk_id, hash_val in _iter_block_hashes(
             block_hashes,
             group_block_size,
             self.hash_block_size,
-        )
-        if not block_hashes:
-            return
-        if not isinstance(block_hashes[0], str):
-            block_hashes = [
-                h.hex()  # type: ignore[union-attr]
-                for h in block_hashes
-            ]
-        start_idx = 0
-        for chunk_id, hash_val in enumerate(block_hashes):
+            chunk_mask,
+        ):
             start_idx = chunk_id * group_block_size
             if start_idx >= token_len:
                 break
@@ -371,6 +364,8 @@ class ChunkedTokenDatabase:
                 end_idx //= cache_family_ratio
                 if end_idx <= start_idx:
                     continue
+                if not isinstance(hash_val, str):
+                    hash_val = hash_val.hex()  # type: ignore[union-attr]
                 yield (
                     start_idx,
                     end_idx,
@@ -392,6 +387,7 @@ class ChunkedTokenDatabase:
         skip_null_blocks: bool = False,
         cache_role: str = "kv",
         cache_family: str | None = None,
+        chunk_mask: Sequence[bool] | None = None,
     ) -> Iterable[tuple[int, int, PoolKey, int]]:
         for start_idx, end_idx, key in self.process_tokens(
             token_len,
@@ -400,6 +396,7 @@ class ChunkedTokenDatabase:
             kv_cache_group_id=kv_cache_group_id,
             cache_role=cache_role,
             cache_family=cache_family,
+            chunk_mask=chunk_mask,
         ):
             block_idx = start_idx // self.get_block_size(kv_cache_group_id)
             if block_idx >= len(block_ids):
@@ -453,14 +450,26 @@ def get_block_hashes(
     group_block_size: int,
     hash_block_size: int,
 ) -> BlockHashList | list[str]:
+    return [hash_val for _, hash_val in _iter_block_hashes(block_hashes, group_block_size, hash_block_size)]
+
+
+def _iter_block_hashes(
+    block_hashes: BlockHashList | list[str],
+    group_block_size: int,
+    hash_block_size: int,
+    chunk_mask: Sequence[bool] | None = None,
+) -> Iterable[tuple[int, BlockHash | str]]:
     if group_block_size == hash_block_size:
-        return block_hashes
+        for chunk_id, hash_val in enumerate(block_hashes):
+            if chunk_mask is None or (chunk_id < len(chunk_mask) and chunk_mask[chunk_id]):
+                yield chunk_id, hash_val
+        return
     assert group_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
     scale_factor = group_block_size // hash_block_size
-    return [
-        _rehash_block_hash_group(block_hashes[idx : idx + scale_factor])
-        for idx in range(0, len(block_hashes) // scale_factor * scale_factor, scale_factor)
-    ]
+    for chunk_id, idx in enumerate(range(0, len(block_hashes) // scale_factor * scale_factor, scale_factor)):
+        if chunk_mask is not None and (chunk_id >= len(chunk_mask) or not chunk_mask[chunk_id]):
+            continue
+        yield chunk_id, _rehash_block_hash_group(block_hashes[idx : idx + scale_factor])
 
 
 def _rehash_block_hash_group(block_hashes: Sequence[BlockHash | str]) -> BlockHash:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -31,6 +31,7 @@ class KVTransferThread(threading.Thread):
         dcp_size: int,
         ready_event: threading.Event,
         name: str,
+        request_queue: queue.Queue[Any] | None = None,
     ):
         super().__init__(daemon=True, name=name)
         self.m_store = m_store
@@ -40,7 +41,7 @@ class KVTransferThread(threading.Thread):
         self.dcp_size = dcp_size
         self.token_database = token_database
         self.done_task_lock = threading.Lock()
-        self.request_queue: queue.Queue[Any] = queue.Queue()
+        self.request_queue: queue.Queue[Any] = request_queue or queue.Queue()
         # TODO(jianzs): make this configurable
         self.executor = ThreadPoolExecutor(max_workers=32)
         self.finished_requests: set[str] = set()
@@ -411,9 +412,17 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         ready_event: threading.Event,
         invalid_block_ids: set[int],
         invalid_block_ids_lock: threading.Lock,
+        request_queue: queue.Queue[Any] | None = None,
     ):
         super().__init__(
-            m_store, token_database, block_size, tp_rank, dcp_size, ready_event, name="KVCacheStoreRecvingThread"
+            m_store,
+            token_database,
+            block_size,
+            tp_rank,
+            dcp_size,
+            ready_event,
+            name="KVCacheStoreRecvingThread",
+            request_queue=request_queue,
         )
         self._invalid_block_ids = invalid_block_ids
         self._invalid_block_ids_lock = invalid_block_ids_lock

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import importlib
 import math
+import os
+import queue
 import threading
 from collections.abc import Generator
 
@@ -97,14 +99,18 @@ class KVPoolWorker:
         self.dcp_size = get_decode_context_model_parallel_world_size()
         self.dcp_rank = get_decode_context_model_parallel_rank() if self.dcp_size > 1 else 0
 
+        extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
         self.kv_role = vllm_config.kv_transfer_config.kv_role
-        self.load_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get("load_async", False)
+        self.load_async = extra_config.get("load_async", False)
+        self.num_recv_threads = max(
+            1,
+            int(os.getenv("VLLM_MOONCAKE_LOAD_RECV_THREADS", extra_config.get("load_recv_threads", 1))),
+        )
+        self.recv_request_queue: queue.Queue[ReqMeta] = queue.Queue()
         self._invalid_block_ids: set[int] = set()
         self._invalid_block_ids_lock = threading.Lock()
-        self.consumer_is_to_put = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
-            "consumer_is_to_put", False
-        )
-        self.backend = vllm_config.kv_transfer_config.kv_connector_extra_config.get("backend", "mooncake")
+        self.consumer_is_to_put = extra_config.get("consumer_is_to_put", False)
+        self.backend = extra_config.get("backend", "mooncake")
         self.use_hybrid = self._uses_hybrid_kv_cache(vllm_config, kv_cache_config)
         self.use_mamba = self._uses_mamba_kv_cache(self.use_hybrid, kv_cache_config)
         self.original_block_size = self._infer_group_block_sizes(vllm_config, kv_cache_config)
@@ -153,10 +159,8 @@ class KVPoolWorker:
         partitions = None
         if self.kv_role == "kv_consumer" and self.consumer_is_to_put:
             num_hidden_layers = model_config.hf_text_config.num_hidden_layers
-            partition_list_str = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
-                "prefill_pp_layer_partition", None
-            )
-            prefill_pp_size = int(vllm_config.kv_transfer_config.kv_connector_extra_config.get("prefill_pp_size", 1))
+            partition_list_str = extra_config.get("prefill_pp_layer_partition", None)
+            prefill_pp_size = int(extra_config.get("prefill_pp_size", 1))
 
             if partition_list_str is not None:
                 try:
@@ -218,6 +222,7 @@ class KVPoolWorker:
 
         self.kv_send_thread: KVTransferThread | None = None
         self.kv_recv_thread: KVTransferThread | None = None
+        self.kv_recv_threads: list[KVTransferThread] = []
 
         self.finished_store_req: set[str] = set()
 
@@ -466,19 +471,23 @@ class KVPoolWorker:
                 )
                 self.kv_send_thread.start()
             if self.load_async:
-                ready_event = threading.Event()
-                self.kv_recv_thread = KVCacheStoreRecvingThread(
-                    self.m_store,
-                    self.token_database,
-                    self.grouped_block_size,
-                    self.tp_rank,
-                    self.dcp_size,
-                    ready_event,
-                    self._invalid_block_ids,
-                    self._invalid_block_ids_lock,
-                )
-                self.kv_recv_thread.start()
-                ready_event.wait()
+                for _ in range(self.num_recv_threads):
+                    ready_event = threading.Event()
+                    kv_recv_thread = KVCacheStoreRecvingThread(
+                        self.m_store,
+                        self.token_database,
+                        self.grouped_block_size,
+                        self.tp_rank,
+                        self.dcp_size,
+                        ready_event,
+                        self._invalid_block_ids,
+                        self._invalid_block_ids_lock,
+                        self.recv_request_queue,
+                    )
+                    kv_recv_thread.start()
+                    ready_event.wait()
+                    self.kv_recv_threads.append(kv_recv_thread)
+                self.kv_recv_thread = self.kv_recv_threads[0]
 
     def start_load_kv(self, metadata: AscendConnectorMetadata):
         self.current_layer = 0
@@ -520,9 +529,7 @@ class KVPoolWorker:
                 self.layerwise_retrievers.append(layerwise_retriever)
             else:
                 if self.load_async:
-                    self.kv_recv_thread.add_request(  # type: ignore[union-attr]
-                        request,
-                    )
+                    self.recv_request_queue.put(request)
                 else:
                     addr_list = []
                     size_list = []
@@ -836,12 +843,14 @@ class KVPoolWorker:
             else set()
         )
 
-        done_recving = (
-            self.kv_recv_thread.get_and_clear_finished_requests(  # type: ignore[union-attr]
-            )
-            if self.load_async
-            else set()
-        )
+        done_recving = set()
+        if self.load_async:
+            if self.kv_recv_threads:
+                done_recving = set().union(
+                    *(thread.get_and_clear_finished_requests() for thread in self.kv_recv_threads)
+                )
+            elif self.kv_recv_thread is not None:
+                done_recving = self.kv_recv_thread.get_and_clear_finished_requests()
 
         logger.debug(
             "Number of completed KV cache send requests: %d, receive requests: %d, tp_rank:%d",
@@ -912,6 +921,8 @@ class KVPoolWorker:
                     block_hashes,
                     kv_cache_group_id=group_id,
                 ):
+                    if not self._is_lookup_chunk_reachable(group_id, start, end):
+                        continue
                     if use_layerwise:
                         keys_multi_layer = key.split_layers(self.num_layers)
                         for item in keys_multi_layer:
@@ -958,6 +969,11 @@ class KVPoolWorker:
             )
             return 0
         return min(hits) if hits else 0
+
+    def _is_lookup_chunk_reachable(self, group_id: int, _start: int, end: int) -> bool:
+        if group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]:
+            return end % self.cache_transfer_granularity == 0
+        return True
 
     def _get_lookup_gate_group_ids(self, kv_cache_group_ids: list[int]) -> list[int]:
         gate_group_ids = [group_id for group_id in kv_cache_group_ids if self._is_lookup_gate_group(group_id)]
@@ -1030,6 +1046,8 @@ class KVPoolWorker:
                     block_hashes,
                     kv_cache_group_id=group_id,
                 ):
+                    if not self._is_lookup_chunk_reachable(group_id, start, end):
+                        continue
                     if use_layerwise:
                         keys_multi_layer = key.split_layers(self.num_layers)
                         for item in keys_multi_layer:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -920,9 +920,8 @@ class KVPoolWorker:
                     token_len,
                     block_hashes,
                     kv_cache_group_id=group_id,
+                    chunk_mask=self._lookup_chunk_mask(group_id, token_len),
                 ):
-                    if not self._is_lookup_chunk_reachable(group_id, start, end):
-                        continue
                     if use_layerwise:
                         keys_multi_layer = key.split_layers(self.num_layers)
                         for item in keys_multi_layer:
@@ -970,10 +969,20 @@ class KVPoolWorker:
             return 0
         return min(hits) if hits else 0
 
-    def _is_lookup_chunk_reachable(self, group_id: int, _start: int, end: int) -> bool:
-        if group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]:
-            return end % self.cache_transfer_granularity == 0
-        return True
+    def _lookup_chunk_mask(self, group_id: int, token_len: int) -> list[bool] | None:
+        if group_id >= len(self.group_uses_align_state) or not self.group_uses_align_state[group_id]:
+            return None
+        group_block_size = self._get_group_block_size(group_id)
+        cache_family = self._get_group_family(self.kv_cache_group_families, group_id)
+        effective_block_size = get_cache_family_granularity(group_block_size, cache_family)
+        cache_family_ratio = max(effective_block_size // group_block_size, 1)
+        num_chunks = (token_len + effective_block_size - 1) // effective_block_size
+        return [
+            (min((chunk_id + 1) * effective_block_size, token_len) // cache_family_ratio)
+            % self.cache_transfer_granularity
+            == 0
+            for chunk_id in range(num_chunks)
+        ]
 
     def _get_lookup_gate_group_ids(self, kv_cache_group_ids: list[int]) -> list[int]:
         gate_group_ids = [group_id for group_id in kv_cache_group_ids if self._is_lookup_gate_group(group_id)]
@@ -1045,9 +1054,8 @@ class KVPoolWorker:
                     token_len,
                     block_hashes,
                     kv_cache_group_id=group_id,
+                    chunk_mask=self._lookup_chunk_mask(group_id, token_len),
                 ):
-                    if not self._is_lookup_chunk_reachable(group_id, start, end):
-                        continue
                     if use_layerwise:
                         keys_multi_layer = key.split_layers(self.num_layers)
                         for item in keys_multi_layer:


### PR DESCRIPTION
### What this PR does / why we need it?
Backports the relevant AscendStore pieces from vLLM PRs #45971 and #45444:
- use a shared receive queue so async KV load can run with multiple receiver threads
- skip lookup requests for align/null-block chunks that cannot become a valid prefix hit

### Does this PR introduce _any_ user-facing change?
No. The receive thread count defaults to 1; it can be increased with `VLLM_MOONCAKE_LOAD_RECV_THREADS` or `load_recv_threads` in `kv_connector_extra_config`.

### How was this patch tested?
vLLM version: v0.23.0
vLLM main: vllm-project/vllm@dc68bd8c4199b00631fe71eb37313f406cc66ac1

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
