### PR TITLE
[Performance] Skip masked AscendStore lookup hashes

### DIFF
--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -23,6 +23,7 @@ Usage at the top of each test file:
     import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 """
 
+import logging
 import os
 import sys
 import types
@@ -87,6 +88,7 @@ _vllm_mock_modules = [
     "vllm.v1.core.kv_cache_utils",
     "vllm.v1.core.sched",
     "vllm.v1.core.sched.output",
+    "vllm.v1.core.single_type_kv_cache_manager",
     "vllm.v1.kv_cache_interface",
     "vllm.v1.kv_cache_spec_registry",
     "vllm.v1.outputs",
@@ -98,9 +100,14 @@ for _mod_name in _vllm_mock_modules:
         sys.modules[_mod_name] = MagicMock()
 
 sys.modules["vllm.utils.math_utils"].cdiv = lambda a, b: -(-a // b)  # type: ignore[attr-defined]
+sys.modules["vllm.logger"].logger = logging.getLogger("vllm")  # type: ignore[attr-defined]
 
 _base_mod = sys.modules["vllm.distributed.kv_transfer.kv_connector.v1.base"]
-_base_mod.KVConnectorBase_V1 = type("KVConnectorBase_V1", (), {"__init__": lambda self, **kw: None})  # type: ignore[attr-defined]
+_base_mod.KVConnectorBase_V1 = type(  # type: ignore[attr-defined]
+    "KVConnectorBase_V1",
+    (),
+    {"__init__": lambda self, **kw: None},
+)
 _base_mod.KVConnectorMetadata = type("KVConnectorMetadata", (), {})  # type: ignore[attr-defined]
 _base_mod.KVConnectorRole = MagicMock()  # type: ignore[attr-defined]
 _base_mod.KVConnectorRole.SCHEDULER = "SCHEDULER"
@@ -154,9 +161,141 @@ class _KVCacheBlock:
 _kv_cache_utils_mod.KVCacheBlock = _KVCacheBlock  # type: ignore[attr-defined]
 
 
+class _FakeKVCacheSpec:
+    def __init__(self, block_size=16, **kwargs):
+        self.block_size = block_size
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def __eq__(self, other):
+        return type(self) is type(other) and self.__dict__ == getattr(other, "__dict__", {})
+
+    def copy_with_new_block_size(self, block_size):
+        kwargs = self.__dict__.copy()
+        kwargs["block_size"] = block_size
+        return type(self)(**kwargs)
+
+
+class _FakeFullAttentionSpec(_FakeKVCacheSpec):
+    pass
+
+
+class _FakeSlidingWindowSpec(_FakeKVCacheSpec):
+    def __init__(self, block_size=16, sliding_window=32, **kwargs):
+        super().__init__(block_size=block_size, sliding_window=sliding_window, **kwargs)
+
+
+class _FakeMambaSpec(_FakeKVCacheSpec):
+    pass
+
+
+class _FakeUniformTypeKVCacheSpecs(_FakeKVCacheSpec):
+    def __init__(self, block_size=16, kv_cache_specs=None, **kwargs):
+        super().__init__(block_size=block_size, **kwargs)
+        self.kv_cache_specs = kv_cache_specs or {}
+
+
+class _FakeKVCacheGroupSpec:
+    def __init__(self, layer_names=None, kv_cache_spec=None, is_eagle_group=False):
+        self.layer_names = layer_names or []
+        self.kv_cache_spec = kv_cache_spec or _FakeFullAttentionSpec()
+        self.is_eagle_group = is_eagle_group
+
+
+class _FakeKVCacheConfig:
+    def __init__(self, num_blocks=1, kv_cache_tensors=None, kv_cache_groups=None):
+        self.num_blocks = num_blocks
+        self.kv_cache_tensors = kv_cache_tensors or []
+        self.kv_cache_groups = kv_cache_groups or []
+
+
+class _FakeSingleTypeKVCacheManager:
+    @classmethod
+    def reachable_block_mask(
+        cls,
+        start_block,
+        end_block,
+        alignment_tokens,
+        kv_cache_spec,
+        use_eagle,
+        retention_interval=None,
+        num_prompt_tokens=None,
+    ):
+        return None
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes,
+        max_length,
+        kv_cache_group_ids,
+        block_pool,
+        kv_cache_spec,
+        drop_eagle_block=False,
+        alignment_tokens=16,
+        dcp_world_size=1,
+        pcp_world_size=1,
+    ):
+        computed: tuple[list[object], ...] = tuple([] for _ in kv_cache_group_ids)
+        max_blocks = max_length // kv_cache_spec.block_size
+        for block_hash in list(block_hashes)[:max_blocks]:
+            cached = block_pool.get_cached_block(block_hash, kv_cache_group_ids)
+            if not cached:
+                break
+            for blocks, block in zip(computed, cached):
+                blocks.append(block)
+        if drop_eagle_block and computed and computed[0]:
+            for blocks in computed:
+                blocks.pop()
+        return computed
+
+
+class _FakeSlidingWindowManager(_FakeSingleTypeKVCacheManager):
+    @classmethod
+    def reachable_block_mask(
+        cls,
+        start_block,
+        end_block,
+        alignment_tokens,
+        kv_cache_spec,
+        use_eagle,
+        retention_interval=None,
+        num_prompt_tokens=None,
+    ):
+        if alignment_tokens is None:
+            return None
+        per_segment = max(alignment_tokens // kv_cache_spec.block_size, 1)
+        return [(idx + 1) % per_segment == 0 for idx in range(start_block, end_block)]
+
+
+_single_type_mod = sys.modules["vllm.v1.core.single_type_kv_cache_manager"]
+_single_type_mod.SingleTypeKVCacheManager = _FakeSingleTypeKVCacheManager  # type: ignore[attr-defined]
+_single_type_mod.FullAttentionManager = _FakeSingleTypeKVCacheManager  # type: ignore[attr-defined]
+_single_type_mod.SlidingWindowManager = _FakeSlidingWindowManager  # type: ignore[attr-defined]
+_single_type_mod.MambaManager = _FakeSingleTypeKVCacheManager  # type: ignore[attr-defined]
+_single_type_mod.spec_manager_map = {  # type: ignore[attr-defined]
+    _FakeFullAttentionSpec: _FakeSingleTypeKVCacheManager,
+    _FakeSlidingWindowSpec: _FakeSlidingWindowManager,
+    _FakeMambaSpec: _FakeSingleTypeKVCacheManager,
+}
+
+_kv_interface_mod = sys.modules["vllm.v1.kv_cache_interface"]
+_kv_interface_mod.KVCacheSpec = _FakeKVCacheSpec  # type: ignore[attr-defined]
+_kv_interface_mod.FullAttentionSpec = _FakeFullAttentionSpec  # type: ignore[attr-defined]
+_kv_interface_mod.SlidingWindowSpec = _FakeSlidingWindowSpec  # type: ignore[attr-defined]
+_kv_interface_mod.MambaSpec = _FakeMambaSpec  # type: ignore[attr-defined]
+_kv_interface_mod.UniformTypeKVCacheSpecs = _FakeUniformTypeKVCacheSpecs  # type: ignore[attr-defined]
+_kv_interface_mod.KVCacheGroupSpec = _FakeKVCacheGroupSpec  # type: ignore[attr-defined]
+_kv_interface_mod.KVCacheConfig = _FakeKVCacheConfig  # type: ignore[attr-defined]
+
+
 class _KVCacheSpecRegistry:
     @staticmethod
     def get_manager_class(spec):
+        if isinstance(spec, _FakeSlidingWindowSpec):
+            return _FakeSlidingWindowManager
+        if isinstance(spec, (_FakeFullAttentionSpec, _FakeMambaSpec)):
+            return _FakeSingleTypeKVCacheManager
         return getattr(spec, "manager_cls", None)
 
 

--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -82,11 +82,13 @@ _vllm_mock_modules = [
     "vllm.v1.attention",
     "vllm.v1.attention.backend",
     "vllm.v1.core",
+    "vllm.v1.core.block_pool",
     "vllm.v1.core.kv_cache_manager",
     "vllm.v1.core.kv_cache_utils",
     "vllm.v1.core.sched",
     "vllm.v1.core.sched.output",
     "vllm.v1.kv_cache_interface",
+    "vllm.v1.kv_cache_spec_registry",
     "vllm.v1.outputs",
     "vllm.v1.request",
     "vllm.v1.serial_utils",
@@ -126,7 +128,39 @@ _events_mod.BlockStored = type(  # type: ignore[attr-defined]
 
 _kv_cache_utils_mod = sys.modules["vllm.v1.core.kv_cache_utils"]
 _kv_cache_utils_mod.BlockHash = bytes  # type: ignore[attr-defined]
+_kv_cache_utils_mod.BlockHashList = list  # type: ignore[attr-defined]
 _kv_cache_utils_mod.maybe_convert_block_hash = lambda x: x  # type: ignore[attr-defined]
+
+
+class _BlockHashListWithBlockSize(list):
+    def __init__(self, block_hashes, hash_block_size, block_size):
+        super().__init__(block_hashes)
+        self.hash_block_size = hash_block_size
+        self.block_size = block_size
+
+
+_kv_cache_utils_mod.BlockHashListWithBlockSize = _BlockHashListWithBlockSize  # type: ignore[attr-defined]
+
+_block_pool_mod = sys.modules["vllm.v1.core.block_pool"]
+_block_pool_mod.BlockPool = type("BlockPool", (), {})  # type: ignore[attr-defined]
+
+
+class _KVCacheBlock:
+    def __init__(self, block_id=0, **kwargs):
+        self.block_id = block_id
+        self.__dict__.update(kwargs)
+
+
+_kv_cache_utils_mod.KVCacheBlock = _KVCacheBlock  # type: ignore[attr-defined]
+
+
+class _KVCacheSpecRegistry:
+    @staticmethod
+    def get_manager_class(spec):
+        return getattr(spec, "manager_cls", None)
+
+
+sys.modules["vllm.v1.kv_cache_spec_registry"].KVCacheSpecRegistry = _KVCacheSpecRegistry  # type: ignore[attr-defined]
 
 _sched_output_mod = sys.modules["vllm.v1.core.sched.output"]
 _sched_output_mod.NewRequestData = MagicMock  # type: ignore[attr-defined]

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -333,7 +333,7 @@ class TestManagerClassResolution(unittest.TestCase):
 
     @staticmethod
     def _clear_resolver_cache():
-        for attr in ("_registry", "_spec_manager_map"):
+        for attr in ("_manager_class_cache",):
             if hasattr(_get_manager_class_for_spec, attr):
                 delattr(_get_manager_class_for_spec, attr)
 

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -17,6 +17,7 @@
 
 import hashlib
 import unittest
+from dataclasses import dataclass
 from unittest.mock import MagicMock
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
@@ -35,6 +36,35 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
 
 _GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
 _GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
+
+
+@dataclass
+class _FakeSpec:
+    block_size: int
+    manager_cls: type
+
+
+@dataclass
+class _FakeGroup:
+    kv_cache_spec: _FakeSpec
+    is_eagle_group: bool = False
+
+
+class _FakeMaskManager:
+    last_reachable_call = None
+    last_hit_call = None
+
+    @classmethod
+    def reachable_block_mask(cls, **kwargs):
+        cls.last_reachable_call = kwargs
+        return [idx % 2 == 1 for idx in range(kwargs["end_block"] - kwargs["start_block"])]
+
+    @classmethod
+    def find_longest_cache_hit(cls, **kwargs):
+        cls.last_hit_call = kwargs
+        block_pool = kwargs["block_pool"]
+        present = block_pool.get_cached_block(kwargs["block_hashes"][0], kwargs["kv_cache_group_ids"])[0]
+        return ([block_pool.null_block, present],)
 
 
 def _expected_grouped_hash(*block_hashes):
@@ -174,6 +204,50 @@ class TestChunkedTokenDatabase(unittest.TestCase):
 
         self.assertEqual(raw_keys, hex_keys)
 
+    def test_store_mask_uses_cache_family_store_granularity(self):
+        spec = _FakeSpec(block_size=8, manager_cls=_FakeMaskManager)
+        db = ChunkedTokenDatabase(
+            self.meta,
+            block_size=8,
+            partitions=None,
+            hash_block_size=8,
+            kv_cache_groups=[_FakeGroup(spec)],
+            alignment_tokens=32,
+            retention_interval=64,
+        )
+        db.set_group_buffers(
+            {0: [1000]},
+            {0: [80]},
+            group_cache_families={0: "c4"},
+        )
+
+        mask = db.store_mask(128, kv_cache_group_id=0, num_prompt_tokens=100)
+
+        self.assertEqual(mask, [False, True, False, True])
+        self.assertEqual(_FakeMaskManager.last_reachable_call["end_block"], 4)
+        self.assertEqual(_FakeMaskManager.last_reachable_call["kv_cache_spec"].block_size, 32)
+        self.assertEqual(_FakeMaskManager.last_reachable_call["alignment_tokens"], 32)
+        self.assertEqual(_FakeMaskManager.last_reachable_call["retention_interval"], 64)
+        self.assertEqual(_FakeMaskManager.last_reachable_call["num_prompt_tokens"], 100)
+
+    def test_load_mask_uses_manager_hit_semantics(self):
+        spec = _FakeSpec(block_size=16, manager_cls=_FakeMaskManager)
+        db = ChunkedTokenDatabase(
+            self.meta,
+            block_size=16,
+            partitions=None,
+            hash_block_size=16,
+            kv_cache_groups=[_FakeGroup(spec)],
+            alignment_tokens=64,
+        )
+        db.set_group_buffers({0: [1000]}, {0: [160]})
+
+        mask = db.load_mask([b"h0", b"h1"], token_len=32, kv_cache_group_id=0)
+
+        self.assertEqual(mask, [False, True])
+        self.assertEqual(_FakeMaskManager.last_hit_call["max_length"], 32)
+        self.assertEqual(_FakeMaskManager.last_hit_call["alignment_tokens"], 64)
+
     def test_get_block_hashes_rehashes_grouped_str_hashes(self):
         result = get_block_hashes(["a", "b", "c", "d"], group_block_size=32, hash_block_size=16)
         self.assertEqual(
@@ -273,6 +347,7 @@ class TestRequestTracker(unittest.TestCase):
         self.assertEqual(tracker.allocated_block_ids, [10, 20, 30])
         self.assertEqual(len(tracker.token_ids), 48)
         self.assertEqual(tracker.num_saved_tokens, 0)
+        self.assertEqual(tracker.num_prompt_tokens, 100)
 
     def test_from_new_request_nested_block_ids(self):
         new_req = MagicMock()
@@ -312,6 +387,7 @@ class TestReqMeta(unittest.TestCase):
             allocated_block_ids=[0, 1],
             num_saved_tokens=0,
             token_ids=list(range(32)),
+            num_prompt_tokens=40,
         )
         meta = ReqMeta.from_request_tracker(tracker, block_size=16, block_hashes=[b"h1", b"h2"])
         self.assertIsNotNone(meta)
@@ -319,6 +395,7 @@ class TestReqMeta(unittest.TestCase):
         self.assertTrue(meta.can_save)
         self.assertEqual(meta.token_len_chunk, 32)
         self.assertIsNone(meta.load_spec)
+        self.assertEqual(meta.num_prompt_tokens, 40)
 
     def test_from_request_tracker_skip_save(self):
         tracker = RequestTracker(

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -151,6 +151,27 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0][0], 16)
 
+    def test_process_tokens_with_tail_clipped_block_ids_maps_tail_chunks(self):
+        db = ChunkedTokenDatabase(self.meta, block_size=128, partitions=None)
+        hashes = [bytes([idx % 251]) * 32 for idx in range(128)]
+
+        result = list(
+            db.process_tokens_with_block_ids(
+                128 * 128,
+                hashes,
+                [1000, 1001, 1002, 1003],
+            )
+        )
+
+        self.assertEqual(
+            [start for start, _, _, _ in result],
+            [124 * 128, 125 * 128, 126 * 128, 127 * 128],
+        )
+        self.assertEqual(
+            [block_id for _, _, _, block_id in result],
+            [1000, 1001, 1002, 1003],
+        )
+
     def test_process_tokens_token_len_shorter_than_all_blocks(self):
         hashes = ["a", "b", "c", "d"]
         # token_len=32 means only first 2 blocks valid
@@ -243,6 +264,14 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         addr, size, block_id = self.db.prepare_value(0, 8, [5])
         self.assertEqual(size[0], 80)  # 160/16*8
         self.assertEqual(size[1], 160)  # 320/16*8
+
+    def test_prepare_value_uses_block_id_override(self):
+        addr, size, block_id = self.db.prepare_value(64, 80, [5], block_id=99)
+        self.assertEqual(block_id, 99)
+        self.assertEqual(addr[0], 1000 + 99 * 160)
+        self.assertEqual(addr[1], 2000 + 99 * 320)
+        self.assertEqual(size[0], 160)
+        self.assertEqual(size[1], 320)
 
     def test_prepare_value_layer(self):
         addr, size = self.db.prepare_value_layer(0, 16, [5, 6], layer_id=0)

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -17,11 +17,9 @@
 
 import hashlib
 import unittest
-from dataclasses import dataclass
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
-from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store import config_data as config_data_mod
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     AscendConnectorMetadata,
     ChunkedTokenDatabase,
@@ -32,41 +30,11 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     PoolKey,
     ReqMeta,
     RequestTracker,
-    _get_manager_class_for_spec,
     get_block_hashes,
 )
 
 _GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
 _GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
-
-
-@dataclass
-class _FakeSpec:
-    block_size: int
-    manager_cls: type
-
-
-@dataclass
-class _FakeGroup:
-    kv_cache_spec: _FakeSpec
-    is_eagle_group: bool = False
-
-
-class _FakeMaskManager:
-    last_reachable_call = None
-    last_hit_call = None
-
-    @classmethod
-    def reachable_block_mask(cls, **kwargs):
-        cls.last_reachable_call = kwargs
-        return [idx % 2 == 1 for idx in range(kwargs["end_block"] - kwargs["start_block"])]
-
-    @classmethod
-    def find_longest_cache_hit(cls, **kwargs):
-        cls.last_hit_call = kwargs
-        block_pool = kwargs["block_pool"]
-        present = block_pool.get_cached_block(kwargs["block_hashes"][0], kwargs["kv_cache_group_ids"])[0]
-        return ([block_pool.null_block, present],)
 
 
 def _expected_grouped_hash(*block_hashes):
@@ -206,53 +174,31 @@ class TestChunkedTokenDatabase(unittest.TestCase):
 
         self.assertEqual(raw_keys, hex_keys)
 
-    def test_store_mask_uses_cache_family_store_granularity(self):
-        spec = _FakeSpec(block_size=8, manager_cls=_FakeMaskManager)
-        db = ChunkedTokenDatabase(
-            self.meta,
-            block_size=8,
-            partitions=None,
-            hash_block_size=8,
-            kv_cache_groups=[_FakeGroup(spec)],
-            alignment_tokens=32,
-            retention_interval=64,
-        )
-        db.set_group_buffers(
-            {0: [1000]},
-            {0: [80]},
-            group_cache_families={0: "c4"},
-        )
+    def test_store_mask_delegates_to_cache_coordinator(self):
+        coordinator = MagicMock()
+        coordinator.store_mask.return_value = ([False, True],)
+        self.db.set_cache_coordinator(coordinator)
 
-        mask = db.store_mask(128, kv_cache_group_id=0, num_prompt_tokens=100)
+        mask = self.db.store_mask(32, num_prompt_tokens=24)
 
-        self.assertEqual(mask, [False, True, False, True])
-        reachable_call = _FakeMaskManager.last_reachable_call
-        assert reachable_call is not None
-        self.assertEqual(reachable_call["end_block"], 4)
-        self.assertEqual(reachable_call["kv_cache_spec"].block_size, 32)
-        self.assertEqual(reachable_call["alignment_tokens"], 32)
-        self.assertEqual(reachable_call["retention_interval"], 64)
-        self.assertEqual(reachable_call["num_prompt_tokens"], 100)
+        self.assertEqual(mask, ([False, True],))
+        coordinator.store_mask.assert_called_once_with(32, 24)
 
-    def test_load_mask_uses_manager_hit_semantics(self):
-        spec = _FakeSpec(block_size=16, manager_cls=_FakeMaskManager)
-        db = ChunkedTokenDatabase(
-            self.meta,
-            block_size=16,
-            partitions=None,
-            hash_block_size=16,
-            kv_cache_groups=[_FakeGroup(spec)],
-            alignment_tokens=64,
-        )
-        db.set_group_buffers({0: [1000]}, {0: [160]})
+    def test_load_mask_delegates_to_cache_coordinator(self):
+        coordinator = MagicMock()
+        coordinator.load_mask.return_value = ([False, True],)
+        self.db.set_cache_coordinator(coordinator)
 
-        mask = db.load_mask([b"h0", b"h1"], token_len=32, kv_cache_group_id=0)
+        mask = self.db.load_mask([b"h0", b"h1"], token_len=32)
 
-        self.assertEqual(mask, [False, True])
-        hit_call = _FakeMaskManager.last_hit_call
-        assert hit_call is not None
-        self.assertEqual(hit_call["max_length"], 32)
-        self.assertEqual(hit_call["alignment_tokens"], 64)
+        self.assertEqual(mask, ([False, True],))
+        coordinator.load_mask.assert_called_once_with([b"h0", b"h1"], 32)
+
+    def test_mask_allows_chunk_uses_group_mask(self):
+        masks = ([False, True], [True, False])
+
+        self.assertTrue(self.db.mask_allows_chunk(masks, 0, 16))
+        self.assertFalse(self.db.mask_allows_chunk(masks, 1, 16))
 
     def test_get_block_hashes_rehashes_grouped_str_hashes(self):
         result = get_block_hashes(["a", "b", "c", "d"], group_block_size=32, hash_block_size=16)
@@ -325,47 +271,6 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         self.assertEqual(len(new_keys), 2)
         self.assertIn("@pp_rank:0", new_keys[0])
         self.assertIn("@pp_rank:1", new_keys[1])
-
-
-class TestManagerClassResolution(unittest.TestCase):
-    def tearDown(self):
-        self._clear_resolver_cache()
-
-    @staticmethod
-    def _clear_resolver_cache():
-        for attr in ("_manager_class_cache",):
-            if hasattr(_get_manager_class_for_spec, attr):
-                delattr(_get_manager_class_for_spec, attr)
-
-    def test_manager_resolution_caches_imported_modules(self):
-        class FakeManager:
-            pass
-
-        class FakeSpec:
-            pass
-
-        self._clear_resolver_cache()
-        spec = FakeSpec()
-        registry_module = MagicMock()
-        registry_module.KVCacheSpecRegistry.get_manager_class.return_value = None
-        manager_module = MagicMock()
-        manager_module.spec_manager_map = {FakeSpec: FakeManager}
-        import_names: list[str] = []
-
-        def fake_import_module(name: str):
-            import_names.append(name)
-            if name == "vllm.v1.kv_cache_spec_registry":
-                return registry_module
-            if name == "vllm.v1.core.single_type_kv_cache_manager":
-                return manager_module
-            raise ImportError(name)
-
-        with patch.object(config_data_mod.importlib, "import_module", side_effect=fake_import_module):
-            self.assertIs(_get_manager_class_for_spec(spec), FakeManager)
-            self.assertIs(_get_manager_class_for_spec(spec), FakeManager)
-
-        self.assertEqual(import_names.count("vllm.v1.kv_cache_spec_registry"), 1)
-        self.assertEqual(import_names.count("vllm.v1.core.single_type_kv_cache_manager"), 1)
 
 
 class TestLoadSpec(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -18,9 +18,10 @@
 import hashlib
 import unittest
 from dataclasses import dataclass
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store import config_data as config_data_mod
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     AscendConnectorMetadata,
     ChunkedTokenDatabase,
@@ -31,6 +32,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     PoolKey,
     ReqMeta,
     RequestTracker,
+    _get_manager_class_for_spec,
     get_block_hashes,
 )
 
@@ -323,6 +325,47 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         self.assertEqual(len(new_keys), 2)
         self.assertIn("@pp_rank:0", new_keys[0])
         self.assertIn("@pp_rank:1", new_keys[1])
+
+
+class TestManagerClassResolution(unittest.TestCase):
+    def tearDown(self):
+        self._clear_resolver_cache()
+
+    @staticmethod
+    def _clear_resolver_cache():
+        for attr in ("_registry", "_spec_manager_map"):
+            if hasattr(_get_manager_class_for_spec, attr):
+                delattr(_get_manager_class_for_spec, attr)
+
+    def test_manager_resolution_caches_imported_modules(self):
+        class FakeManager:
+            pass
+
+        class FakeSpec:
+            pass
+
+        self._clear_resolver_cache()
+        spec = FakeSpec()
+        registry_module = MagicMock()
+        registry_module.KVCacheSpecRegistry.get_manager_class.return_value = None
+        manager_module = MagicMock()
+        manager_module.spec_manager_map = {FakeSpec: FakeManager}
+        import_names: list[str] = []
+
+        def fake_import_module(name: str):
+            import_names.append(name)
+            if name == "vllm.v1.kv_cache_spec_registry":
+                return registry_module
+            if name == "vllm.v1.core.single_type_kv_cache_manager":
+                return manager_module
+            raise ImportError(name)
+
+        with patch.object(config_data_mod.importlib, "import_module", side_effect=fake_import_module):
+            self.assertIs(_get_manager_class_for_spec(spec), FakeManager)
+            self.assertIs(_get_manager_class_for_spec(spec), FakeManager)
+
+        self.assertEqual(import_names.count("vllm.v1.kv_cache_spec_registry"), 1)
+        self.assertEqual(import_names.count("vllm.v1.core.single_type_kv_cache_manager"), 1)
 
 
 class TestLoadSpec(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -224,11 +224,13 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         mask = db.store_mask(128, kv_cache_group_id=0, num_prompt_tokens=100)
 
         self.assertEqual(mask, [False, True, False, True])
-        self.assertEqual(_FakeMaskManager.last_reachable_call["end_block"], 4)
-        self.assertEqual(_FakeMaskManager.last_reachable_call["kv_cache_spec"].block_size, 32)
-        self.assertEqual(_FakeMaskManager.last_reachable_call["alignment_tokens"], 32)
-        self.assertEqual(_FakeMaskManager.last_reachable_call["retention_interval"], 64)
-        self.assertEqual(_FakeMaskManager.last_reachable_call["num_prompt_tokens"], 100)
+        reachable_call = _FakeMaskManager.last_reachable_call
+        assert reachable_call is not None
+        self.assertEqual(reachable_call["end_block"], 4)
+        self.assertEqual(reachable_call["kv_cache_spec"].block_size, 32)
+        self.assertEqual(reachable_call["alignment_tokens"], 32)
+        self.assertEqual(reachable_call["retention_interval"], 64)
+        self.assertEqual(reachable_call["num_prompt_tokens"], 100)
 
     def test_load_mask_uses_manager_hit_semantics(self):
         spec = _FakeSpec(block_size=16, manager_cls=_FakeMaskManager)
@@ -245,8 +247,10 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         mask = db.load_mask([b"h0", b"h1"], token_len=32, kv_cache_group_id=0)
 
         self.assertEqual(mask, [False, True])
-        self.assertEqual(_FakeMaskManager.last_hit_call["max_length"], 32)
-        self.assertEqual(_FakeMaskManager.last_hit_call["alignment_tokens"], 64)
+        hit_call = _FakeMaskManager.last_hit_call
+        assert hit_call is not None
+        self.assertEqual(hit_call["max_length"], 32)
+        self.assertEqual(hit_call["alignment_tokens"], 64)
 
     def test_get_block_hashes_rehashes_grouped_str_hashes(self):
         result = get_block_hashes(["a", "b", "c", "d"], group_block_size=32, hash_block_size=16)

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -17,7 +17,7 @@
 
 import hashlib
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
@@ -184,6 +184,19 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0][2].chunk_hash, _expected_grouped_hash("a", "b").hex())
         self.assertEqual(len(result[0][2].chunk_hash), 64)
+
+    def test_process_tokens_chunk_mask_skips_grouped_hash_generation(self):
+        db = ChunkedTokenDatabase(self.meta, block_size=32, partitions=None, hash_block_size=16)
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data._rehash_block_hash_group",
+            side_effect=lambda hashes: b"".join(hash_value.encode() for hash_value in hashes),
+        ) as rehash:
+            result = list(db.process_tokens(64, ["a", "b", "c", "d"], chunk_mask=[False, True]))
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][0], 32)
+        self.assertEqual(result[0][2].chunk_hash, b"cd".hex())
+        rehash.assert_called_once_with(["c", "d"])
 
     def test_process_tokens_rehashes_raw_bytes_and_hex_strings_consistently(self):
         db = ChunkedTokenDatabase(self.meta, block_size=16, partitions=None, hash_block_size=8)

--- a/tests/ut/distributed/ascend_store/test_coordinator.py
+++ b/tests/ut/distributed/ascend_store/test_coordinator.py
@@ -1,0 +1,91 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+import unittest
+
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheGroupSpec, SlidingWindowSpec
+
+import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import get_block_hashes
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import (
+    AscendStoreCoordinator,
+    ExternalCachedBlockPool,
+)
+
+
+def _hashes(num_blocks: int) -> list[bytes]:
+    return [bytes([idx % 251]) * 32 for idx in range(num_blocks)]
+
+
+class TestAscendStoreCoordinator(unittest.TestCase):
+    def test_compressed_group_hits_on_effective_granularity(self):
+        block_hashes = _hashes(128)
+        grouped_hash = get_block_hashes(block_hashes, group_block_size=128 * 128, hash_block_size=128)[0]
+        coord = AscendStoreCoordinator(
+            [KVCacheGroupSpec(["layer.0"], FullAttentionSpec(block_size=128))],
+            scheduler_block_size=128 * 128,
+            hash_block_size=128,
+            group_block_sizes=[128],
+            group_cache_families=["c128"],
+        )
+
+        _, hit_length = coord.find_longest_cache_hit(
+            block_hashes,
+            128 * 128,
+            ExternalCachedBlockPool({(0, bytes(grouped_hash))}),
+        )
+
+        self.assertEqual(hit_length, 128 * 128)
+
+    def test_missing_required_group_returns_zero(self):
+        block_hashes = _hashes(128)
+        c1_exists = {(0, block_hash) for block_hash in block_hashes}
+        coord = AscendStoreCoordinator(
+            [
+                KVCacheGroupSpec(["layer.0"], FullAttentionSpec(block_size=128)),
+                KVCacheGroupSpec(["layer.1"], FullAttentionSpec(block_size=128)),
+            ],
+            scheduler_block_size=128 * 128,
+            hash_block_size=128,
+            group_block_sizes=[128, 128],
+            group_cache_families=["c1", "c128"],
+        )
+
+        _, hit_length = coord.find_longest_cache_hit(
+            block_hashes,
+            128 * 128,
+            ExternalCachedBlockPool(c1_exists),
+        )
+
+        self.assertEqual(hit_length, 0)
+
+    def test_store_mask_uses_manager_reachability(self):
+        coord = AscendStoreCoordinator(
+            [KVCacheGroupSpec(["layer.0"], SlidingWindowSpec(block_size=128, sliding_window=256))],
+            scheduler_block_size=512,
+            hash_block_size=128,
+            group_block_sizes=[128],
+            group_cache_families=["c1"],
+        )
+
+        masks = coord.store_mask(512)
+
+        self.assertEqual(masks, ([False, False, False, True],))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ut/distributed/ascend_store/test_coordinator.py
+++ b/tests/ut/distributed/ascend_store/test_coordinator.py
@@ -16,6 +16,7 @@
 #
 
 import unittest
+from unittest.mock import patch
 
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheGroupSpec, SlidingWindowSpec
 
@@ -86,6 +87,22 @@ class TestAscendStoreCoordinator(unittest.TestCase):
 
         self.assertEqual(masks, ([False, False, False, True],))
 
+    def test_compressed_masks_stay_unmasked(self):
+        coord = AscendStoreCoordinator(
+            [KVCacheGroupSpec(["layer.0"], SlidingWindowSpec(block_size=128, sliding_window=512))],
+            scheduler_block_size=2048,
+            hash_block_size=128,
+            group_block_sizes=[128],
+            group_cache_families=["c4"],
+        )
+
+        self.assertEqual(coord.store_mask(2048, num_prompt_tokens=2048), ([True] * 4,))
+        with patch.object(
+            coord,
+            "find_longest_cache_hit",
+            return_value=(([False, False, False, True],), 2048),
+        ):
+            self.assertEqual(coord.load_mask(_hashes(16), 2048), ([True] * 4,))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -101,12 +101,12 @@ class MaskedFakeTokenDatabase(FakeTokenDatabase):
         self.store_mask_calls = []
         self.load_mask_calls = []
 
-    def store_mask(self, token_len, kv_cache_group_id, num_prompt_tokens=None):
-        self.store_mask_calls.append((token_len, kv_cache_group_id, num_prompt_tokens))
+    def store_mask(self, token_len, num_prompt_tokens=None):
+        self.store_mask_calls.append((token_len, num_prompt_tokens))
         return self._store_mask
 
-    def load_mask(self, block_hashes, token_len, kv_cache_group_id):
-        self.load_mask_calls.append((block_hashes, token_len, kv_cache_group_id))
+    def load_mask(self, block_hashes, token_len):
+        self.load_mask_calls.append((block_hashes, token_len))
         return self._load_mask
 
 
@@ -206,7 +206,7 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
 
     def test_handle_request_applies_store_mask_before_put(self):
         store = FakeStore([0, 0])
-        db = MaskedFakeTokenDatabase(store_mask=[False, True, False, True])
+        db = MaskedFakeTokenDatabase(store_mask=([False, True, False, True],))
         t = KVCacheStoreSendingThread(
             m_store=store,
             token_database=db,
@@ -229,7 +229,7 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         t.request_queue.put(req)
         t._handle_request(req)
 
-        self.assertEqual(db.store_mask_calls, [(64, 0, 64)])
+        self.assertEqual(db.store_mask_calls, [(64, 64)])
         keys, _, _ = store.put_calls[0]
         self.assertEqual(len(keys), 2)
         self.assertTrue(keys[0].endswith("@k1"))
@@ -381,7 +381,7 @@ class TestKVCacheStoreRecvingThread(unittest.TestCase):
 
     def test_handle_request_applies_load_mask_before_get(self):
         store = FakeStore()
-        db = MaskedFakeTokenDatabase(load_mask=[False, True])
+        db = MaskedFakeTokenDatabase(load_mask=([False, True],))
         t = KVCacheStoreRecvingThread(
             m_store=store,
             token_database=db,
@@ -401,7 +401,7 @@ class TestKVCacheStoreRecvingThread(unittest.TestCase):
         t.request_queue.put(req)
         t._handle_request(req)
 
-        self.assertEqual(db.load_mask_calls, [([b"h0", b"h1"], 32, 0)])
+        self.assertEqual(db.load_mask_calls, [([b"h0", b"h1"], 32)])
         keys, _, _ = store.get_calls[0]
         self.assertEqual(len(keys), 1)
         self.assertTrue(keys[0].endswith("@k1"))

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -216,7 +216,6 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
             put_step=1,
             kv_role="kv_producer",
             ready_event=threading.Event(),
-            group_uses_align_state=[False],
         )
         req = ReqMeta(
             req_id="r1",
@@ -390,8 +389,6 @@ class TestKVCacheStoreRecvingThread(unittest.TestCase):
             tp_rank=0,
             dcp_size=1,
             ready_event=threading.Event(),
-            invalid_block_ids=set(),
-            invalid_block_ids_lock=threading.Lock(),
         )
         load_spec = LoadSpec(vllm_cached_tokens=0, kvpool_cached_tokens=32, can_load=True, token_len=32)
         req = ReqMeta(

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -93,6 +93,23 @@ class FakeTokenDatabase:
         return keys, addrs, sizes
 
 
+class MaskedFakeTokenDatabase(FakeTokenDatabase):
+    def __init__(self, block_size=16, store_mask=None, load_mask=None):
+        super().__init__(block_size)
+        self._store_mask = store_mask
+        self._load_mask = load_mask
+        self.store_mask_calls = []
+        self.load_mask_calls = []
+
+    def store_mask(self, token_len, kv_cache_group_id, num_prompt_tokens=None):
+        self.store_mask_calls.append((token_len, kv_cache_group_id, num_prompt_tokens))
+        return self._store_mask
+
+    def load_mask(self, block_hashes, token_len, kv_cache_group_id):
+        self.load_mask_calls.append((block_hashes, token_len, kv_cache_group_id))
+        return self._load_mask
+
+
 class TestKVTransferThread(unittest.TestCase):
     def _make_thread(self, exists_result=None):
         store = FakeStore(exists_result or [])
@@ -186,6 +203,38 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         self.assertEqual(len(store.put_calls), 1)
         keys, _, _ = store.put_calls[0]
         self.assertEqual(len(keys), 2)
+
+    def test_handle_request_applies_store_mask_before_put(self):
+        store = FakeStore([0, 0])
+        db = MaskedFakeTokenDatabase(store_mask=[False, True, False, True])
+        t = KVCacheStoreSendingThread(
+            m_store=store,
+            token_database=db,
+            block_size=16,
+            tp_rank=0,
+            dcp_size=1,
+            put_step=1,
+            kv_role="kv_producer",
+            ready_event=threading.Event(),
+            group_uses_align_state=[False],
+        )
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=64,
+            block_ids=[0, 1, 2, 3],
+            block_hashes=[b"h0", b"h1", b"h2", b"h3"],  # type: ignore[arg-type]
+            current_event=None,
+            num_prompt_tokens=64,
+        )
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+
+        self.assertEqual(db.store_mask_calls, [(64, 0, 64)])
+        keys, _, _ = store.put_calls[0]
+        self.assertEqual(len(keys), 2)
+        self.assertTrue(keys[0].endswith("@k1"))
+        self.assertTrue(keys[1].endswith("@k3"))
 
     def test_handle_request_all_exist_no_put(self):
         t, store = self._make_thread([1, 1])
@@ -330,6 +379,35 @@ class TestKVCacheStoreRecvingThread(unittest.TestCase):
         self.assertEqual(len(store.get_calls), 1)
         finished = t.get_and_clear_finished_requests()
         self.assertIn("r1", finished)
+
+    def test_handle_request_applies_load_mask_before_get(self):
+        store = FakeStore()
+        db = MaskedFakeTokenDatabase(load_mask=[False, True])
+        t = KVCacheStoreRecvingThread(
+            m_store=store,
+            token_database=db,
+            block_size=16,
+            tp_rank=0,
+            dcp_size=1,
+            ready_event=threading.Event(),
+            invalid_block_ids=set(),
+            invalid_block_ids_lock=threading.Lock(),
+        )
+        load_spec = LoadSpec(vllm_cached_tokens=0, kvpool_cached_tokens=32, can_load=True, token_len=32)
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=32,
+            block_ids=[0, 1],
+            block_hashes=[b"h0", b"h1"],  # type: ignore[arg-type]
+            load_spec=load_spec,
+        )
+        t.request_queue.put(req)
+        t._handle_request(req)
+
+        self.assertEqual(db.load_mask_calls, [([b"h0", b"h1"], 32, 0)])
+        keys, _, _ = store.get_calls[0]
+        self.assertEqual(len(keys), 1)
+        self.assertTrue(keys[0].endswith("@k1"))
 
 
 class TestKVCacheStoreLayerSendingThread(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -73,6 +73,27 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         result = cls.find_min_first_non_one_index(None, [])
         self.assertEqual(result, -1)
 
+    def test_external_coordinator_lookup_disables_eagle_drop(self):
+        cls = self._make_worker_class()
+        worker = object.__new__(cls)
+        worker.num_kv_cache_groups = 1
+        worker.cache_coordinator = MagicMock()
+        worker.cache_coordinator.find_longest_cache_hit.return_value = ((), 128)
+        worker.m_store = MagicMock()
+        worker.m_store.exists.return_value = [1]
+
+        key = MagicMock()
+        key.chunk_hash = "ab" * 32
+        key.to_string.return_value = "key"
+        worker.token_database = MagicMock()
+        worker.token_database.process_tokens.return_value = [(0, 128, key)]
+
+        hit = worker._lookup_with_coordinator(128, [b"h0"], [0], use_layerwise=False, include_all_ranks=False)
+
+        self.assertEqual(hit, 128)
+        worker.cache_coordinator.find_longest_cache_hit.assert_called_once()
+        self.assertFalse(worker.cache_coordinator.find_longest_cache_hit.call_args.kwargs["apply_eagle"])
+
 
 class TestKVPoolWorkerInit(unittest.TestCase):
     """Test KVPoolWorker initialization with mocked dependencies."""

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -517,6 +517,30 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.start_load_kv(meta)
         worker.m_store.get.assert_called_once()
 
+    def test_start_load_kv_sync_uses_tail_block_id(self):
+        worker = self._make_worker()
+        worker.m_store.get = MagicMock()
+        worker.token_database.set_kv_caches_base_addr([1000])
+        worker.token_database.set_block_len([160])
+        worker.token_database.load_mask = MagicMock(return_value=([False, False, False, True],))
+
+        load_spec = LoadSpec(vllm_cached_tokens=0, kvpool_cached_tokens=64, can_load=True, token_len=64)
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=64,
+            block_ids=[99],
+            block_hashes=["h0", "h1", "h2", "h3"],
+            load_spec=load_spec,
+        )
+        meta = AscendConnectorMetadata(set(), set())
+        meta.add_request(req)
+
+        worker.start_load_kv(meta)
+
+        _, addrs, sizes = worker.m_store.get.call_args.args
+        self.assertEqual(addrs, [[1000 + 99 * 160]])
+        self.assertEqual(sizes, [[160]])
+
     def test_start_load_kv_no_load(self):
         worker = self._make_worker()
         req = ReqMeta(

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -78,6 +78,7 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         worker = object.__new__(cls)
         worker.num_kv_cache_groups = 1
         worker.cache_coordinator = MagicMock()
+        worker.cache_coordinator.lookup_mask.return_value = ([False, True],)
         worker.cache_coordinator.find_longest_cache_hit.return_value = ((), 128)
         worker.m_store = MagicMock()
         worker.m_store.exists.return_value = [1]
@@ -91,6 +92,13 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         hit = worker._lookup_with_coordinator(128, [b"h0"], [0], use_layerwise=False, include_all_ranks=False)
 
         self.assertEqual(hit, 128)
+        worker.cache_coordinator.lookup_mask.assert_called_once_with(128)
+        worker.token_database.process_tokens.assert_called_once_with(
+            128,
+            [b"h0"],
+            kv_cache_group_id=0,
+            chunk_mask=[False, True],
+        )
         worker.cache_coordinator.find_longest_cache_hit.assert_called_once()
         self.assertFalse(worker.cache_coordinator.find_longest_cache_hit.call_args.kwargs["apply_eagle"])
 

--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -385,5 +385,5 @@ def test_mtp_fallback_excludes_compressed_groups_from_eagle_drop() -> None:
         use_eagle=True,
     )
 
-    assert local_coordinator.eagle_group_ids == {1}
+    assert local_coordinator.eagle_group_ids == set()
     assert external_coordinator.eagle_group_ids == {1}

--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -387,3 +387,61 @@ def test_mtp_fallback_excludes_compressed_groups_from_eagle_drop() -> None:
 
     assert local_coordinator.eagle_group_ids == {1}
     assert external_coordinator.eagle_group_ids == {1}
+
+
+def test_mtp_explicit_eagle_group_still_drops_c1_not_compressed() -> None:
+    block_size = 128
+    compressed_spec = MLAAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        compress_ratio=4,
+        model_version="deepseek_v4",
+    )
+    sliding_spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=block_size,
+    )
+    mtp_spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    mtp_group = KVCacheGroupSpec(["mtp"], mtp_spec)
+    mtp_group.is_eagle_group = True
+    groups = [
+        KVCacheGroupSpec(["compressed"], compressed_spec),
+        KVCacheGroupSpec(["sliding"], sliding_spec),
+        mtp_group,
+    ]
+    local_coordinator = AscendHybridKVCacheCoordinator(
+        kv_cache_config=KVCacheConfig(
+            num_blocks=16,
+            kv_cache_tensors=[],
+            kv_cache_groups=groups,
+        ),
+        max_model_len=block_size * 4,
+        use_eagle=True,
+        enable_caching=True,
+        enable_kv_cache_events=False,
+        dcp_world_size=1,
+        pcp_world_size=1,
+        hash_block_size=block_size,
+        max_num_batched_tokens=block_size * 4,
+    )
+    external_coordinator = AscendStoreCoordinator(
+        kv_cache_groups=groups,
+        scheduler_block_size=block_size * 4,
+        hash_block_size=block_size,
+        group_block_sizes=[block_size, block_size, block_size],
+        group_cache_families=["c4", "c1", "default"],
+        use_eagle=True,
+    )
+
+    assert local_coordinator.eagle_group_ids == {1, 2}
+    assert external_coordinator.eagle_group_ids == {1, 2}

--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -434,14 +434,4 @@ def test_mtp_explicit_eagle_group_still_drops_c1_not_compressed() -> None:
         hash_block_size=block_size,
         max_num_batched_tokens=block_size * 4,
     )
-    external_coordinator = AscendStoreCoordinator(
-        kv_cache_groups=groups,
-        scheduler_block_size=block_size * 4,
-        hash_block_size=block_size,
-        group_block_sizes=[block_size, block_size, block_size],
-        group_cache_families=["c4", "c1", "default"],
-        use_eagle=True,
-    )
-
     assert local_coordinator.eagle_group_ids == {1, 2}
-    assert external_coordinator.eagle_group_ids == {1, 2}

--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -313,3 +313,52 @@ def test_external_coordinator_does_not_double_apply_compress_ratio() -> None:
     )
 
     assert hit_length == logical_block_size
+
+
+def test_mtp_fallback_excludes_compressed_groups_from_eagle_drop() -> None:
+    block_size = 128
+    compressed_spec = MLAAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        compress_ratio=4,
+        model_version="deepseek_v4",
+    )
+    sliding_spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=block_size,
+    )
+    groups = [
+        KVCacheGroupSpec(["compressed"], compressed_spec),
+        KVCacheGroupSpec(["sliding"], sliding_spec),
+    ]
+    local_coordinator = AscendHybridKVCacheCoordinator(
+        kv_cache_config=KVCacheConfig(
+            num_blocks=16,
+            kv_cache_tensors=[],
+            kv_cache_groups=groups,
+        ),
+        max_model_len=block_size * 4,
+        use_eagle=True,
+        enable_caching=True,
+        enable_kv_cache_events=False,
+        dcp_world_size=1,
+        pcp_world_size=1,
+        hash_block_size=block_size,
+        max_num_batched_tokens=block_size * 4,
+    )
+    external_coordinator = AscendStoreCoordinator(
+        kv_cache_groups=groups,
+        scheduler_block_size=block_size * 4,
+        hash_block_size=block_size,
+        group_block_sizes=[block_size, block_size],
+        group_cache_families=["c4", "c1"],
+        use_eagle=True,
+    )
+
+    assert local_coordinator.eagle_group_ids == {1}
+    assert external_coordinator.eagle_group_ids == {1}

--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -385,31 +385,5 @@ def test_mtp_fallback_excludes_compressed_groups_from_eagle_drop() -> None:
         use_eagle=True,
     )
 
-    assert local_coordinator.eagle_group_ids == set()
+    assert local_coordinator.eagle_group_ids == {1}
     assert external_coordinator.eagle_group_ids == {1}
-
-
-def test_local_mtp_exact_alignment_keeps_previous_boundary() -> None:
-    block_size = 128
-    alignment_tokens = block_size * 128
-    spec = SlidingWindowSpec(
-        block_size=block_size,
-        num_kv_heads=1,
-        head_size=1,
-        dtype=torch.float32,
-        sliding_window=block_size * 4,
-    )
-
-    mask = _sliding_window_reachable_block_mask(
-        type(None),
-        start_block=0,
-        end_block=128,
-        alignment_tokens=alignment_tokens,
-        kv_cache_spec=spec,
-        use_eagle=False,
-        retention_interval=0,
-        num_prompt_tokens=alignment_tokens * 2,
-        include_previous_alignment_boundary=True,
-    )
-
-    assert [idx for idx, keep in enumerate(mask or []) if keep] == [124, 125, 126, 127]

--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -13,6 +13,7 @@ from vllm.v1.core.kv_cache_utils import (
     get_request_block_hasher,
     init_none_hash,
 )
+from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -177,6 +178,38 @@ def test_unset_retention_keeps_sliding_window_dense() -> None:
         )
         is None
     )
+
+
+def test_sliding_window_eagle_hit_uses_post_pop_alignment() -> None:
+    block_size = 128
+    alignment_tokens = block_size * 128
+    spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=block_size,
+    )
+
+    class FakePool:
+        null_block = object()
+
+        def get_cached_block(self, block_hash, kv_cache_group_ids):
+            if block_hash in (127, 128):
+                return [block_hash]
+            return None
+
+    hit_blocks = SlidingWindowManager.find_longest_cache_hit(
+        block_hashes=list(range(129)),
+        max_length=alignment_tokens + block_size,
+        kv_cache_group_ids=[0],
+        block_pool=FakePool(),
+        kv_cache_spec=spec,
+        use_eagle=True,
+        alignment_tokens=alignment_tokens,
+    )[0]
+
+    assert len(hit_blocks) == 128
 
 
 def test_hybrid_coordinator_rejects_partial_compressed_prefix_hit() -> None:

--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -3,6 +3,7 @@
 
 import pytest
 import torch
+import vllm.v1.core.kv_cache_coordinator as kv_cache_coordinator
 from vllm.sampling_params import SamplingParams
 from vllm.utils.hashing import sha256
 from vllm.v1.core.block_pool import BlockPool
@@ -135,6 +136,19 @@ def test_compressed_prefix_cache_hits_identical_logical_block() -> None:
     )[0]
 
     assert hit_blocks == manager.req_to_blocks[request.request_id]
+
+
+def test_upstream_coordinator_factory_uses_compress_manager() -> None:
+    spec, block_pool, _ = _make_compress_manager()
+
+    manager = kv_cache_coordinator.get_manager_for_kv_cache_spec(
+        spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+    )
+
+    assert isinstance(manager, CompressAttentionManager)
 
 
 def test_hybrid_coordinator_rejects_partial_compressed_prefix_hit() -> None:

--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -188,6 +188,31 @@ def test_unset_retention_keeps_sliding_window_dense() -> None:
     )
 
 
+def test_sliding_window_retention_exact_alignment_keeps_current_tail() -> None:
+    block_size = 128
+    alignment_tokens = block_size * 128
+    spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=block_size * 4,
+    )
+
+    mask = _sliding_window_reachable_block_mask(
+        type(None),
+        start_block=0,
+        end_block=128,
+        alignment_tokens=alignment_tokens,
+        kv_cache_spec=spec,
+        use_eagle=True,
+        retention_interval=0,
+        num_prompt_tokens=alignment_tokens,
+    )
+
+    assert [idx for idx, keep in enumerate(mask or []) if keep] == [124, 125, 126, 127]
+
+
 def test_sliding_window_eagle_hit_uses_post_pop_alignment() -> None:
     block_size = 128
     alignment_tokens = block_size * 128

--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -385,53 +385,31 @@ def test_mtp_fallback_excludes_compressed_groups_from_eagle_drop() -> None:
         use_eagle=True,
     )
 
-    assert local_coordinator.eagle_group_ids == {1}
+    assert local_coordinator.eagle_group_ids == set()
     assert external_coordinator.eagle_group_ids == {1}
 
 
-def test_mtp_explicit_eagle_group_still_drops_c1_not_compressed() -> None:
+def test_local_mtp_exact_alignment_keeps_previous_boundary() -> None:
     block_size = 128
-    compressed_spec = MLAAttentionSpec(
+    alignment_tokens = block_size * 128
+    spec = SlidingWindowSpec(
         block_size=block_size,
         num_kv_heads=1,
         head_size=1,
         dtype=torch.float32,
-        compress_ratio=4,
-        model_version="deepseek_v4",
+        sliding_window=block_size * 4,
     )
-    sliding_spec = SlidingWindowSpec(
-        block_size=block_size,
-        num_kv_heads=1,
-        head_size=1,
-        dtype=torch.float32,
-        sliding_window=block_size,
+
+    mask = _sliding_window_reachable_block_mask(
+        type(None),
+        start_block=0,
+        end_block=128,
+        alignment_tokens=alignment_tokens,
+        kv_cache_spec=spec,
+        use_eagle=False,
+        retention_interval=0,
+        num_prompt_tokens=alignment_tokens * 2,
+        include_previous_alignment_boundary=True,
     )
-    mtp_spec = FullAttentionSpec(
-        block_size=block_size,
-        num_kv_heads=1,
-        head_size=1,
-        dtype=torch.float32,
-    )
-    mtp_group = KVCacheGroupSpec(["mtp"], mtp_spec)
-    mtp_group.is_eagle_group = True
-    groups = [
-        KVCacheGroupSpec(["compressed"], compressed_spec),
-        KVCacheGroupSpec(["sliding"], sliding_spec),
-        mtp_group,
-    ]
-    local_coordinator = AscendHybridKVCacheCoordinator(
-        kv_cache_config=KVCacheConfig(
-            num_blocks=16,
-            kv_cache_tensors=[],
-            kv_cache_groups=groups,
-        ),
-        max_model_len=block_size * 4,
-        use_eagle=True,
-        enable_caching=True,
-        enable_kv_cache_events=False,
-        dcp_world_size=1,
-        pcp_world_size=1,
-        hash_block_size=block_size,
-        max_num_batched_tokens=block_size * 4,
-    )
-    assert local_coordinator.eagle_group_ids == {1, 2}
+
+    assert [idx for idx, keep in enumerate(mask or []) if keep] == [124, 125, 126, 127]

--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -18,11 +18,15 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     MLAAttentionSpec,
+    SlidingWindowSpec,
 )
 from vllm.v1.request import Request
 
 from vllm_ascend.core.single_type_kv_cache_manager import CompressAttentionManager
 from vllm_ascend.patch.platform.patch_kv_cache_coordinator import AscendHybridKVCacheCoordinator
+from vllm_ascend.patch.platform.patch_prefix_cache_retention import (
+    _sliding_window_reachable_block_mask,
+)
 
 pytestmark = pytest.mark.cpu_test
 
@@ -149,6 +153,30 @@ def test_upstream_coordinator_factory_uses_compress_manager() -> None:
     )
 
     assert isinstance(manager, CompressAttentionManager)
+
+
+def test_unset_retention_keeps_sliding_window_dense() -> None:
+    spec = SlidingWindowSpec(
+        block_size=128,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=512,
+    )
+
+    assert (
+        _sliding_window_reachable_block_mask(
+            type(None),
+            start_block=0,
+            end_block=16,
+            alignment_tokens=2048,
+            kv_cache_spec=spec,
+            use_eagle=False,
+            retention_interval=None,
+            num_prompt_tokens=2048,
+        )
+        is None
+    )
 
 
 def test_hybrid_coordinator_rejects_partial_compressed_prefix_hit() -> None:

--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -24,6 +24,14 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.request import Request
 
 from vllm_ascend.core.single_type_kv_cache_manager import CompressAttentionManager
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
+    _block_hash_to_bytes,
+    get_block_hashes,
+)
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import (
+    AscendStoreCoordinator,
+    ExternalCachedBlockPool,
+)
 from vllm_ascend.patch.platform.patch_kv_cache_coordinator import AscendHybridKVCacheCoordinator
 from vllm_ascend.patch.platform.patch_prefix_cache_retention import (
     _sliding_window_reachable_block_mask,
@@ -270,3 +278,38 @@ def test_hybrid_coordinator_rejects_partial_compressed_prefix_hit() -> None:
 
     assert hit_length == 0
     assert hit_blocks == ([], [])
+
+
+def test_external_coordinator_does_not_double_apply_compress_ratio() -> None:
+    block_size = 128
+    compress_ratio = 4
+    logical_block_size = block_size * compress_ratio
+    request = _make_request("a", list(range(logical_block_size)), block_size)
+    compressed_spec = MLAAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        compress_ratio=compress_ratio,
+        model_version="deepseek_v4",
+    )
+    coordinator = AscendStoreCoordinator(
+        kv_cache_groups=[KVCacheGroupSpec(["compressed"], compressed_spec)],
+        scheduler_block_size=logical_block_size,
+        hash_block_size=block_size,
+        group_block_sizes=[block_size],
+        group_cache_families=[f"c{compress_ratio}"],
+    )
+    chunk_hash = get_block_hashes(
+        request.block_hashes,
+        logical_block_size,
+        block_size,
+    )[0]
+
+    _, hit_length = coordinator.find_longest_cache_hit(
+        request.block_hashes,
+        logical_block_size,
+        ExternalCachedBlockPool({(0, _block_hash_to_bytes(chunk_hash))}),
+    )
+
+    assert hit_length == logical_block_size

--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -153,7 +153,14 @@ class CompressAttentionManager(FullAttentionManager):
             req_blocks.extend(new_blocks)
             return new_blocks
 
-    def cache_blocks(self, request: Request, num_tokens: int) -> None:
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+        alignment_tokens: int | None = None,
+        use_eagle: bool = False,
+    ) -> None:
         """
         Cache the blocks for the request.
 
@@ -161,6 +168,12 @@ class CompressAttentionManager(FullAttentionManager):
             request: The request.
             num_tokens: The total number of tokens that need to be cached
                 (including tokens that are already cached).
+            retention_interval: Sparse local-checkpoint granularity. Compressed
+                MLA groups cache densely and ignore this value.
+            alignment_tokens: The cache-hit alignment used by upstream vLLM
+                main. v0.21.0 does not expose this argument in the base class.
+            use_eagle: Whether the group is used for EAGLE/MTP lookup. Compressed
+                MLA groups ignore this value.
         """
         num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
         logical_block_size = self.block_size * self.compress_ratio

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -362,11 +362,13 @@ class ChunkedTokenDatabase:
         block_ids: list[int],
         kv_cache_group_id: int = 0,
         cache_role: str = "kv",
+        block_id: int | None = None,
     ):
         addr_list: list[int] = []
         size_list: list[int] = []
         group_block_size = self.get_block_size(kv_cache_group_id)
-        block_id = block_ids[start // group_block_size]
+        if block_id is None:
+            block_id = block_ids[start // group_block_size]
         group_addrs, group_block_len, group_block_stride = self._get_group_buffers(kv_cache_group_id, cache_role)
         length = len(group_block_len)
         if length == 0:
@@ -458,16 +460,40 @@ class ChunkedTokenDatabase:
         cache_role: str = "kv",
         cache_family: str | None = None,
     ) -> Iterable[tuple[int, int, PoolKey, int]]:
-        for start_idx, end_idx, key in self.process_tokens(
-            token_len,
-            block_hashes,
-            mask_num,
-            kv_cache_group_id=kv_cache_group_id,
-            cache_role=cache_role,
-            cache_family=cache_family,
-        ):
-            block_idx = start_idx // self.get_block_size(kv_cache_group_id)
-            if block_idx >= len(block_ids):
+        all_chunks = list(
+            self.process_tokens(
+                token_len,
+                block_hashes,
+                0,
+                kv_cache_group_id=kv_cache_group_id,
+                cache_role=cache_role,
+                cache_family=cache_family,
+            )
+        )
+        if not all_chunks:
+            return
+
+        group_block_size = self.get_block_size(kv_cache_group_id)
+        # Sliding-window groups can expose only live tail block ids while keys
+        # still use logical chunk positions from the full prefix.
+        num_logical_blocks = all_chunks[-1][0] // group_block_size + 1
+        block_id_offset = max(num_logical_blocks - len(block_ids), 0)
+        chunks = all_chunks
+        if mask_num:
+            chunks = list(
+                self.process_tokens(
+                    token_len,
+                    block_hashes,
+                    mask_num,
+                    kv_cache_group_id=kv_cache_group_id,
+                    cache_role=cache_role,
+                    cache_family=cache_family,
+                )
+            )
+
+        for start_idx, end_idx, key in chunks:
+            block_idx = start_idx // group_block_size - block_id_offset
+            if block_idx < 0 or block_idx >= len(block_ids):
                 continue
             block_id = block_ids[block_idx]
             if skip_null_blocks and block_id <= 0:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import hashlib
+import importlib
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any, cast
@@ -13,7 +14,6 @@ from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashList, BlockHashListWithBlockSize, KVCacheBlock
 from vllm.v1.core.sched.output import NewRequestData
-from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 
 _GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
 _GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
@@ -145,6 +145,32 @@ def _unwrap_spec(kv_cache_spec: Any) -> Any:
     if kv_cache_specs is None:
         return kv_cache_spec
     return next(iter(kv_cache_specs.values()))
+
+
+def _get_manager_class_for_spec(spec: Any) -> Any | None:
+    """Resolve the vLLM manager class across 0.20.x and 0.21.x APIs."""
+    try:
+        registry_module = importlib.import_module("vllm.v1.kv_cache_spec_registry")
+        registry = getattr(registry_module, "KVCacheSpecRegistry", None)
+    except ImportError:
+        registry = None
+    if registry is not None:
+        manager_cls = registry.get_manager_class(spec)
+        if manager_cls is not None:
+            return manager_cls
+
+    try:
+        manager_module = importlib.import_module("vllm.v1.core.single_type_kv_cache_manager")
+        spec_manager_map = getattr(manager_module, "spec_manager_map", {})
+    except ImportError:
+        return None
+    manager_cls = spec_manager_map.get(type(spec))
+    if manager_cls is not None:
+        return manager_cls
+    for spec_cls, candidate in spec_manager_map.items():
+        if isinstance(spec, spec_cls):
+            return candidate
+    return None
 
 
 class ExternalCachedBlockPool:
@@ -375,7 +401,9 @@ class ChunkedTokenDatabase:
         spec = self._get_effective_group_spec(kv_cache_group_id, cache_role)
         if spec is None:
             return None
-        manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+        manager_cls = _get_manager_class_for_spec(spec)
+        if manager_cls is None:
+            return None
         reachable_block_mask = getattr(manager_cls, "reachable_block_mask", None)
         if reachable_block_mask is None:
             return None
@@ -410,7 +438,7 @@ class ChunkedTokenDatabase:
         spec = self._get_effective_group_spec(kv_cache_group_id, cache_role)
         if spec is None:
             return None
-        manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+        manager_cls = _get_manager_class_for_spec(spec)
         if manager_cls is None:
             return None
         hashes = self._block_hashes_for_spec(block_hashes, spec)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import dataclasses
 import hashlib
-import importlib
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any, cast
@@ -11,14 +9,11 @@ import torch
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
 from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
-from vllm.v1.core.block_pool import BlockPool
-from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashList, BlockHashListWithBlockSize, KVCacheBlock
+from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashList
 from vllm.v1.core.sched.output import NewRequestData
 
 _GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
 _GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
-_CACHE_MISSING = object()
-_MANAGER_CLASS_CACHE_ATTR = "_manager_class_cache"
 
 
 # Parameters related to the key
@@ -142,71 +137,6 @@ def get_cache_family_granularity(block_size: int, cache_family: str | None) -> i
     return block_size * infer_cache_family_ratio(cache_family)
 
 
-def _unwrap_spec(kv_cache_spec: Any) -> Any:
-    kv_cache_specs = getattr(kv_cache_spec, "kv_cache_specs", None)
-    if kv_cache_specs is None:
-        return kv_cache_spec
-    return next(iter(kv_cache_specs.values()))
-
-
-def _get_manager_class_cache() -> dict[str, Any]:
-    cache = getattr(_get_manager_class_for_spec, _MANAGER_CLASS_CACHE_ATTR, None)
-    if not isinstance(cache, dict):
-        cache = {}
-        setattr(_get_manager_class_for_spec, _MANAGER_CLASS_CACHE_ATTR, cache)
-    return cast(dict[str, Any], cache)
-
-
-def _get_manager_class_for_spec(spec: Any) -> Any | None:
-    """Resolve the vLLM manager class across 0.20.x and 0.21.x APIs."""
-    cache = _get_manager_class_cache()
-    registry = cache.get("registry", _CACHE_MISSING)
-    if registry is _CACHE_MISSING:
-        try:
-            registry_module = importlib.import_module("vllm.v1.kv_cache_spec_registry")
-            registry = getattr(registry_module, "KVCacheSpecRegistry", None)
-        except ImportError:
-            registry = None
-        cache["registry"] = registry
-    if registry is not None:
-        manager_cls = registry.get_manager_class(spec)
-        if manager_cls is not None:
-            return manager_cls
-
-    spec_manager_map = cache.get("spec_manager_map", _CACHE_MISSING)
-    if spec_manager_map is _CACHE_MISSING:
-        try:
-            manager_module = importlib.import_module("vllm.v1.core.single_type_kv_cache_manager")
-            spec_manager_map = getattr(manager_module, "spec_manager_map", {})
-        except ImportError:
-            spec_manager_map = None
-        cache["spec_manager_map"] = spec_manager_map
-    if not spec_manager_map:
-        return None
-    manager_cls = spec_manager_map.get(type(spec))
-    if manager_cls is not None:
-        return manager_cls
-    for spec_cls, candidate in spec_manager_map.items():
-        if isinstance(spec, spec_cls):
-            return candidate
-    return None
-
-
-class ExternalCachedBlockPool:
-    """Tiny BlockPool stand-in used for connector-side load masks."""
-
-    def __init__(self) -> None:
-        self.null_block = KVCacheBlock(block_id=0)
-        self._present_block = KVCacheBlock(block_id=1)
-
-    def get_cached_block(
-        self,
-        block_hash: BlockHash,
-        group_ids: list[int],
-    ) -> list[KVCacheBlock]:
-        return [self._present_block] * len(group_ids)
-
-
 def _get_layer_compress_ratio(
     layer_name: str,
     compress_ratios: Sequence[int] | None,
@@ -309,6 +239,40 @@ class ChunkedTokenDatabase:
         }
         if use_eagle and not self.eagle_group_ids:
             self.eagle_group_ids = set(range(len(self.kv_cache_groups)))
+        self.cache_coordinator: Any | None = None
+
+    def set_cache_coordinator(self, cache_coordinator: Any | None) -> None:
+        self.cache_coordinator = cache_coordinator
+
+    def store_mask(
+        self,
+        aligned_token_len: int,
+        num_prompt_tokens: int | None = None,
+    ) -> tuple[list[bool], ...] | None:
+        if self.cache_coordinator is None:
+            return None
+        return self.cache_coordinator.store_mask(aligned_token_len, num_prompt_tokens)
+
+    def load_mask(
+        self,
+        block_hashes: list[BlockHash],
+        token_len: int,
+    ) -> tuple[list[bool], ...] | None:
+        if self.cache_coordinator is None:
+            return None
+        return self.cache_coordinator.load_mask(block_hashes, token_len)
+
+    def mask_allows_chunk(
+        self,
+        masks: tuple[list[bool], ...] | None,
+        kv_cache_group_id: int,
+        start: int,
+    ) -> bool:
+        if masks is None or kv_cache_group_id >= len(masks):
+            return True
+        group_mask = masks[kv_cache_group_id]
+        chunk_idx = start // self.get_block_size(kv_cache_group_id)
+        return chunk_idx < len(group_mask) and group_mask[chunk_idx]
 
     def _make_key_by_hash(
         self,
@@ -379,110 +343,6 @@ class ChunkedTokenDatabase:
             self.get_block_size(kv_cache_group_id),
             self._get_group_cache_family(kv_cache_group_id, cache_role),
         )
-
-    def _get_effective_group_spec(self, kv_cache_group_id: int, cache_role: str = "kv") -> Any | None:
-        if cache_role != "kv" or kv_cache_group_id >= len(self.kv_cache_groups):
-            return None
-        spec = _unwrap_spec(self.kv_cache_groups[kv_cache_group_id].kv_cache_spec)
-        store_granularity = self._get_store_granularity(kv_cache_group_id, cache_role)
-        if getattr(spec, "block_size", None) == store_granularity:
-            return spec
-        try:
-            return dataclasses.replace(spec, block_size=store_granularity)
-        except TypeError:
-            return spec
-
-    def _block_hashes_for_spec(
-        self,
-        block_hashes: BlockHashList | list[str],
-        spec: Any,
-    ) -> BlockHashList | list[str]:
-        block_size = getattr(spec, "block_size", self.hash_block_size)
-        if block_size == self.hash_block_size:
-            return block_hashes
-        if isinstance(block_hashes[0], str):
-            return get_block_hashes(block_hashes, block_size, self.hash_block_size)
-        return BlockHashListWithBlockSize(block_hashes, self.hash_block_size, block_size)
-
-    def store_mask(
-        self,
-        aligned_token_len: int,
-        kv_cache_group_id: int,
-        num_prompt_tokens: int | None = None,
-        cache_role: str = "kv",
-    ) -> list[bool] | None:
-        """Return per-store-chunk retention mask for a KV cache group.
-
-        None means every chunk is reachable and should be stored. The block
-        size used here is AscendStore's key granularity, including DSV4 cache
-        family ratios such as c4/c128.
-        """
-        spec = self._get_effective_group_spec(kv_cache_group_id, cache_role)
-        if spec is None:
-            return None
-        manager_cls = _get_manager_class_for_spec(spec)
-        if manager_cls is None:
-            return None
-        reachable_block_mask = getattr(manager_cls, "reachable_block_mask", None)
-        if reachable_block_mask is None:
-            return None
-        store_granularity = self._get_store_granularity(kv_cache_group_id, cache_role)
-        if aligned_token_len == 0:
-            return []
-        num_chunks = cdiv(aligned_token_len, store_granularity)
-        return reachable_block_mask(
-            start_block=0,
-            end_block=num_chunks,
-            alignment_tokens=self.alignment_tokens,
-            kv_cache_spec=spec,
-            use_eagle=kv_cache_group_id in self.eagle_group_ids,
-            retention_interval=self.retention_interval,
-            num_prompt_tokens=num_prompt_tokens,
-        )
-
-    def load_mask(
-        self,
-        block_hashes: BlockHashList | list[str],
-        token_len: int,
-        kv_cache_group_id: int,
-        cache_role: str = "kv",
-    ) -> list[bool] | None:
-        """Return per-store-chunk load mask for a KV cache group.
-
-        This mirrors MooncakeStore's load mask: only chunks a local manager
-        would populate at the external hit length are loaded.
-        """
-        if not block_hashes:
-            return []
-        spec = self._get_effective_group_spec(kv_cache_group_id, cache_role)
-        if spec is None:
-            return None
-        manager_cls = _get_manager_class_for_spec(spec)
-        if manager_cls is None:
-            return None
-        hashes = self._block_hashes_for_spec(block_hashes, spec)
-        cached_block_pool = ExternalCachedBlockPool()
-        hit_blocks = manager_cls.find_longest_cache_hit(
-            block_hashes=hashes,
-            max_length=token_len,
-            kv_cache_group_ids=[kv_cache_group_id],
-            block_pool=cast(BlockPool, cached_block_pool),
-            kv_cache_spec=spec,
-            drop_eagle_block=False,
-            alignment_tokens=self.alignment_tokens,
-        )
-        return [block is not cached_block_pool.null_block for block in hit_blocks[0]]
-
-    def mask_allows_chunk(
-        self,
-        mask: list[bool] | None,
-        start: int,
-        kv_cache_group_id: int,
-    ) -> bool:
-        if mask is None:
-            return True
-        chunk_idx = start // self.get_block_size(kv_cache_group_id)
-        return chunk_idx < len(mask) and mask[chunk_idx]
 
     def _get_group_buffers(
         self, kv_cache_group_id: int, cache_role: str = "kv"

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -234,11 +234,13 @@ class ChunkedTokenDatabase:
         self.hash_block_size = self.block_size[0] if hash_block_size is None else hash_block_size
         self.alignment_tokens = alignment_tokens if alignment_tokens is not None else max(self.block_size)
         self.retention_interval = retention_interval
-        self.eagle_group_ids = {
-            idx for idx, group in enumerate(self.kv_cache_groups) if getattr(group, "is_eagle_group", False)
-        }
-        if use_eagle and not self.eagle_group_ids:
-            self.eagle_group_ids = set(range(len(self.kv_cache_groups)))
+        self.eagle_group_ids: set[int] = set()
+        if use_eagle:
+            self.eagle_group_ids = {
+                idx
+                for idx, group in enumerate(self.kv_cache_groups)
+                if (getattr(group.kv_cache_spec, "compress_ratio", 1) or 1) <= 1
+            }
         self.cache_coordinator: Any | None = None
 
     def set_cache_coordinator(self, cache_coordinator: Any | None) -> None:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -17,6 +17,7 @@ from vllm.v1.core.sched.output import NewRequestData
 
 _GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
 _GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
+_CACHE_MISSING = object()
 
 
 # Parameters related to the key
@@ -149,20 +150,28 @@ def _unwrap_spec(kv_cache_spec: Any) -> Any:
 
 def _get_manager_class_for_spec(spec: Any) -> Any | None:
     """Resolve the vLLM manager class across 0.20.x and 0.21.x APIs."""
-    try:
-        registry_module = importlib.import_module("vllm.v1.kv_cache_spec_registry")
-        registry = getattr(registry_module, "KVCacheSpecRegistry", None)
-    except ImportError:
-        registry = None
+    registry = getattr(_get_manager_class_for_spec, "_registry", _CACHE_MISSING)
+    if registry is _CACHE_MISSING:
+        try:
+            registry_module = importlib.import_module("vllm.v1.kv_cache_spec_registry")
+            registry = getattr(registry_module, "KVCacheSpecRegistry", None)
+        except ImportError:
+            registry = None
+        _get_manager_class_for_spec._registry = registry
     if registry is not None:
         manager_cls = registry.get_manager_class(spec)
         if manager_cls is not None:
             return manager_cls
 
-    try:
-        manager_module = importlib.import_module("vllm.v1.core.single_type_kv_cache_manager")
-        spec_manager_map = getattr(manager_module, "spec_manager_map", {})
-    except ImportError:
+    spec_manager_map = getattr(_get_manager_class_for_spec, "_spec_manager_map", _CACHE_MISSING)
+    if spec_manager_map is _CACHE_MISSING:
+        try:
+            manager_module = importlib.import_module("vllm.v1.core.single_type_kv_cache_manager")
+            spec_manager_map = getattr(manager_module, "spec_manager_map", {})
+        except ImportError:
+            spec_manager_map = None
+        _get_manager_class_for_spec._spec_manager_map = spec_manager_map
+    if not spec_manager_map:
         return None
     manager_cls = spec_manager_map.get(type(spec))
     if manager_cls is not None:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -454,6 +454,17 @@ class ChunkedTokenDatabase:
         )
         return [block is not cached_block_pool.null_block for block in hit_blocks[0]]
 
+    def mask_allows_chunk(
+        self,
+        mask: list[bool] | None,
+        start: int,
+        kv_cache_group_id: int,
+    ) -> bool:
+        if mask is None:
+            return True
+        chunk_idx = start // self.get_block_size(kv_cache_group_id)
+        return chunk_idx < len(mask) and mask[chunk_idx]
+
     def _get_group_buffers(
         self, kv_cache_group_id: int, cache_role: str = "kv"
     ) -> tuple[list[int], list[int], list[int] | None]:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -18,6 +18,7 @@ from vllm.v1.core.sched.output import NewRequestData
 _GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
 _GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
 _CACHE_MISSING = object()
+_MANAGER_CLASS_CACHE_ATTR = "_manager_class_cache"
 
 
 # Parameters related to the key
@@ -148,29 +149,38 @@ def _unwrap_spec(kv_cache_spec: Any) -> Any:
     return next(iter(kv_cache_specs.values()))
 
 
+def _get_manager_class_cache() -> dict[str, Any]:
+    cache = getattr(_get_manager_class_for_spec, _MANAGER_CLASS_CACHE_ATTR, None)
+    if not isinstance(cache, dict):
+        cache = {}
+        setattr(_get_manager_class_for_spec, _MANAGER_CLASS_CACHE_ATTR, cache)
+    return cast(dict[str, Any], cache)
+
+
 def _get_manager_class_for_spec(spec: Any) -> Any | None:
     """Resolve the vLLM manager class across 0.20.x and 0.21.x APIs."""
-    registry = getattr(_get_manager_class_for_spec, "_registry", _CACHE_MISSING)
+    cache = _get_manager_class_cache()
+    registry = cache.get("registry", _CACHE_MISSING)
     if registry is _CACHE_MISSING:
         try:
             registry_module = importlib.import_module("vllm.v1.kv_cache_spec_registry")
             registry = getattr(registry_module, "KVCacheSpecRegistry", None)
         except ImportError:
             registry = None
-        _get_manager_class_for_spec._registry = registry
+        cache["registry"] = registry
     if registry is not None:
         manager_cls = registry.get_manager_class(spec)
         if manager_cls is not None:
             return manager_cls
 
-    spec_manager_map = getattr(_get_manager_class_for_spec, "_spec_manager_map", _CACHE_MISSING)
+    spec_manager_map = cache.get("spec_manager_map", _CACHE_MISSING)
     if spec_manager_map is _CACHE_MISSING:
         try:
             manager_module = importlib.import_module("vllm.v1.core.single_type_kv_cache_manager")
             spec_manager_map = getattr(manager_module, "spec_manager_map", {})
         except ImportError:
             spec_manager_map = None
-        _get_manager_class_for_spec._spec_manager_map = spec_manager_map
+        cache["spec_manager_map"] = spec_manager_map
     if not spec_manager_map:
         return None
     manager_cls = spec_manager_map.get(type(spec))

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -234,13 +234,11 @@ class ChunkedTokenDatabase:
         self.hash_block_size = self.block_size[0] if hash_block_size is None else hash_block_size
         self.alignment_tokens = alignment_tokens if alignment_tokens is not None else max(self.block_size)
         self.retention_interval = retention_interval
-        self.eagle_group_ids: set[int] = set()
-        if use_eagle:
-            self.eagle_group_ids = {
-                idx
-                for idx, group in enumerate(self.kv_cache_groups)
-                if (getattr(group.kv_cache_spec, "compress_ratio", 1) or 1) <= 1
-            }
+        self.eagle_group_ids = {
+            idx for idx, group in enumerate(self.kv_cache_groups) if getattr(group, "is_eagle_group", False)
+        }
+        if use_eagle and not self.eagle_group_ids:
+            self.eagle_group_ids = set(range(len(self.kv_cache_groups)))
         self.cache_coordinator: Any | None = None
 
     def set_cache_coordinator(self, cache_coordinator: Any | None) -> None:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
@@ -9,8 +10,10 @@ import torch
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
 from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
-from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashList
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashList, BlockHashListWithBlockSize, KVCacheBlock
 from vllm.v1.core.sched.output import NewRequestData
+from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 
 _GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
 _GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
@@ -137,6 +140,28 @@ def get_cache_family_granularity(block_size: int, cache_family: str | None) -> i
     return block_size * infer_cache_family_ratio(cache_family)
 
 
+def _unwrap_spec(kv_cache_spec: Any) -> Any:
+    kv_cache_specs = getattr(kv_cache_spec, "kv_cache_specs", None)
+    if kv_cache_specs is None:
+        return kv_cache_spec
+    return next(iter(kv_cache_specs.values()))
+
+
+class ExternalCachedBlockPool:
+    """Tiny BlockPool stand-in used for connector-side load masks."""
+
+    def __init__(self) -> None:
+        self.null_block = KVCacheBlock(block_id=0)
+        self._present_block = KVCacheBlock(block_id=1)
+
+    def get_cached_block(
+        self,
+        block_hash: BlockHash,
+        group_ids: list[int],
+    ) -> list[KVCacheBlock]:
+        return [self._present_block] * len(group_ids)
+
+
 def _get_layer_compress_ratio(
     layer_name: str,
     compress_ratios: Sequence[int] | None,
@@ -207,9 +232,14 @@ class ChunkedTokenDatabase:
         partitions: list[int] | None,
         use_hybrid: bool = False,
         hash_block_size: int | None = None,
+        kv_cache_groups: Sequence[Any] | None = None,
+        alignment_tokens: int | None = None,
+        retention_interval: int | None = None,
+        use_eagle: bool = False,
     ):
         self.metadata = metadata
         self.block_size = block_size if isinstance(block_size, list) else [block_size]
+        self.kv_cache_groups = list(kv_cache_groups or [])
         self.kv_caches_base_addr: list[int] = []
         self.block_len: list[int] = []
         self.block_stride: list[int] = []
@@ -227,6 +257,13 @@ class ChunkedTokenDatabase:
         self.partitions = partitions
         self.use_hybrid = use_hybrid
         self.hash_block_size = self.block_size[0] if hash_block_size is None else hash_block_size
+        self.alignment_tokens = alignment_tokens if alignment_tokens is not None else max(self.block_size)
+        self.retention_interval = retention_interval
+        self.eagle_group_ids = {
+            idx for idx, group in enumerate(self.kv_cache_groups) if getattr(group, "is_eagle_group", False)
+        }
+        if use_eagle and not self.eagle_group_ids:
+            self.eagle_group_ids = set(range(len(self.kv_cache_groups)))
 
     def _make_key_by_hash(
         self,
@@ -289,7 +326,109 @@ class ChunkedTokenDatabase:
         if group_num_layers is not None:
             self.group_num_layers[cache_role] = group_num_layers.copy()
 
-    def _get_group_buffers(self, kv_cache_group_id: int, cache_role: str) -> tuple[list[int], list[int], list[int]]:
+    def _get_group_cache_family(self, kv_cache_group_id: int, cache_role: str = "kv") -> str:
+        return self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
+
+    def _get_store_granularity(self, kv_cache_group_id: int, cache_role: str = "kv") -> int:
+        return get_cache_family_granularity(
+            self.get_block_size(kv_cache_group_id),
+            self._get_group_cache_family(kv_cache_group_id, cache_role),
+        )
+
+    def _get_effective_group_spec(self, kv_cache_group_id: int, cache_role: str = "kv") -> Any | None:
+        if cache_role != "kv" or kv_cache_group_id >= len(self.kv_cache_groups):
+            return None
+        spec = _unwrap_spec(self.kv_cache_groups[kv_cache_group_id].kv_cache_spec)
+        store_granularity = self._get_store_granularity(kv_cache_group_id, cache_role)
+        if getattr(spec, "block_size", None) == store_granularity:
+            return spec
+        try:
+            return dataclasses.replace(spec, block_size=store_granularity)
+        except TypeError:
+            return spec
+
+    def _block_hashes_for_spec(
+        self,
+        block_hashes: BlockHashList | list[str],
+        spec: Any,
+    ) -> BlockHashList | list[str]:
+        block_size = getattr(spec, "block_size", self.hash_block_size)
+        if block_size == self.hash_block_size:
+            return block_hashes
+        if isinstance(block_hashes[0], str):
+            return get_block_hashes(block_hashes, block_size, self.hash_block_size)
+        return BlockHashListWithBlockSize(block_hashes, self.hash_block_size, block_size)
+
+    def store_mask(
+        self,
+        aligned_token_len: int,
+        kv_cache_group_id: int,
+        num_prompt_tokens: int | None = None,
+        cache_role: str = "kv",
+    ) -> list[bool] | None:
+        """Return per-store-chunk retention mask for a KV cache group.
+
+        None means every chunk is reachable and should be stored. The block
+        size used here is AscendStore's key granularity, including DSV4 cache
+        family ratios such as c4/c128.
+        """
+        spec = self._get_effective_group_spec(kv_cache_group_id, cache_role)
+        if spec is None:
+            return None
+        manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+        reachable_block_mask = getattr(manager_cls, "reachable_block_mask", None)
+        if reachable_block_mask is None:
+            return None
+        store_granularity = self._get_store_granularity(kv_cache_group_id, cache_role)
+        if aligned_token_len == 0:
+            return []
+        num_chunks = cdiv(aligned_token_len, store_granularity)
+        return reachable_block_mask(
+            start_block=0,
+            end_block=num_chunks,
+            alignment_tokens=self.alignment_tokens,
+            kv_cache_spec=spec,
+            use_eagle=kv_cache_group_id in self.eagle_group_ids,
+            retention_interval=self.retention_interval,
+            num_prompt_tokens=num_prompt_tokens,
+        )
+
+    def load_mask(
+        self,
+        block_hashes: BlockHashList | list[str],
+        token_len: int,
+        kv_cache_group_id: int,
+        cache_role: str = "kv",
+    ) -> list[bool] | None:
+        """Return per-store-chunk load mask for a KV cache group.
+
+        This mirrors MooncakeStore's load mask: only chunks a local manager
+        would populate at the external hit length are loaded.
+        """
+        if not block_hashes:
+            return []
+        spec = self._get_effective_group_spec(kv_cache_group_id, cache_role)
+        if spec is None:
+            return None
+        manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+        if manager_cls is None:
+            return None
+        hashes = self._block_hashes_for_spec(block_hashes, spec)
+        cached_block_pool = ExternalCachedBlockPool()
+        hit_blocks = manager_cls.find_longest_cache_hit(
+            block_hashes=hashes,
+            max_length=token_len,
+            kv_cache_group_ids=[kv_cache_group_id],
+            block_pool=cast(BlockPool, cached_block_pool),
+            kv_cache_spec=spec,
+            drop_eagle_block=False,
+            alignment_tokens=self.alignment_tokens,
+        )
+        return [block is not cached_block_pool.null_block for block in hit_blocks[0]]
+
+    def _get_group_buffers(
+        self, kv_cache_group_id: int, cache_role: str = "kv"
+    ) -> tuple[list[int], list[int], list[int] | None]:
         if cache_role == "state":
             return [], [], []
         return (
@@ -523,6 +662,9 @@ class RequestTracker:
     # NOTE: This field will only be used when you enable kv-event
     token_ids: list[int] | None = None
 
+    # Full prompt length used by retention-aware external store masks.
+    num_prompt_tokens: int | None = None
+
     def __init__(
         self,
         req_id: str,
@@ -531,6 +673,7 @@ class RequestTracker:
         allocated_block_ids: list[int] | list[list[int]] | None = None,
         num_saved_tokens: int = 0,
         token_ids: list[int] | None = None,
+        num_prompt_tokens: int | None = None,
     ) -> None:
         self.req_id = req_id
         self.token_len = token_len
@@ -540,6 +683,7 @@ class RequestTracker:
         self.allocated_block_ids_by_group = block_ids
         self.num_saved_tokens = num_saved_tokens
         self.token_ids = token_ids
+        self.num_prompt_tokens = num_prompt_tokens
 
     @property
     def allocated_block_ids(self) -> list[int]:
@@ -561,6 +705,7 @@ class RequestTracker:
             token_len=num_tokens_to_compute,
             allocated_block_ids_by_group=normalize_block_ids_by_group(new_request.block_ids),
             num_saved_tokens=0,
+            num_prompt_tokens=len(new_request.prompt_token_ids),
         )
 
     def update(
@@ -604,6 +749,7 @@ class ReqMeta:
     # TODO: add lora_request which used for gen lora_id/lora_name in kv event
     token_ids: list[int] | None = None
     original_block_size: list[int] | int | None = None
+    num_prompt_tokens: int | None = None
 
     def __init__(
         self,
@@ -621,6 +767,7 @@ class ReqMeta:
         disable_tp_key_sharding: bool = False,
         token_ids: list[int] | None = None,
         original_block_size: list[int] | int | None = None,
+        num_prompt_tokens: int | None = None,
         block_ids: list[int] | list[list[int]] | None = None,
     ) -> None:
         self.req_id = req_id
@@ -639,6 +786,7 @@ class ReqMeta:
         self.disable_tp_key_sharding = disable_tp_key_sharding
         self.token_ids = token_ids
         self.original_block_size = original_block_size
+        self.num_prompt_tokens = num_prompt_tokens
 
     @property
     def block_ids(self) -> list[int]:
@@ -701,6 +849,7 @@ class ReqMeta:
             is_last_chunk=is_last_chunk,
             token_ids=token_ids,
             original_block_size=original_block_size,
+            num_prompt_tokens=tracker.num_prompt_tokens,
             kv_cache_group_ids=list(range(len(tracker.allocated_block_ids_by_group))),
             kv_cache_families_by_group=kv_cache_group_families,
         )

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -404,6 +404,7 @@ class ChunkedTokenDatabase:
         kv_cache_group_id: int = 0,
         cache_role: str = "kv",
         cache_family: str | None = None,
+        chunk_mask: Sequence[bool] | None = None,
     ) -> Iterable[tuple[int, int, PoolKey]]:
         """Process the tokens and return the corresponding cache engine keys."""
         if not block_hashes:
@@ -413,20 +414,15 @@ class ChunkedTokenDatabase:
             cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
         cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
         group_block_size *= cache_family_ratio
-        block_hashes = get_block_hashes(
+        block_hashes_iter = _iter_block_hashes(
             block_hashes,
             group_block_size,
             self.hash_block_size,
+            chunk_mask,
         )
-        if not block_hashes:
-            return
-        if not isinstance(block_hashes[0], str):
-            block_hashes = [
-                h.hex()  # type: ignore[union-attr]
-                for h in block_hashes
-            ]
-        start_idx = 0
-        for chunk_id, hash_val in enumerate(block_hashes):
+        for chunk_id, hash_val in block_hashes_iter:
+            if not isinstance(hash_val, str):
+                hash_val = hash_val.hex()
             start_idx = chunk_id * group_block_size
             if start_idx >= token_len:
                 break
@@ -544,14 +540,28 @@ def get_block_hashes(
     group_block_size: int,
     hash_block_size: int,
 ) -> BlockHashList | list[str]:
+    return [hash_val for _, hash_val in _iter_block_hashes(block_hashes, group_block_size, hash_block_size)]
+
+
+def _iter_block_hashes(
+    block_hashes: BlockHashList | list[str],
+    group_block_size: int,
+    hash_block_size: int,
+    chunk_mask: Sequence[bool] | None = None,
+) -> Iterable[tuple[int, BlockHash | str]]:
     if group_block_size == hash_block_size:
-        return block_hashes
+        for chunk_id, block_hash in enumerate(block_hashes):
+            if chunk_mask is None or (chunk_id < len(chunk_mask) and chunk_mask[chunk_id]):
+                yield chunk_id, block_hash
+        return
     assert group_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
     scale_factor = group_block_size // hash_block_size
-    return [
-        _rehash_block_hash_group(block_hashes[idx : idx + scale_factor])
-        for idx in range(0, len(block_hashes) // scale_factor * scale_factor, scale_factor)
-    ]
+    num_chunks = len(block_hashes) // scale_factor
+    for chunk_id in range(num_chunks):
+        if chunk_mask is not None and (chunk_id >= len(chunk_mask) or not chunk_mask[chunk_id]):
+            continue
+        idx = chunk_id * scale_factor
+        yield chunk_id, _rehash_block_hash_group(block_hashes[idx : idx + scale_factor])
 
 
 def _rehash_block_hash_group(block_hashes: Sequence[BlockHash | str]) -> BlockHash:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
@@ -83,11 +83,9 @@ class AscendStoreCoordinator:
                 "scheduler_block_size must be a multiple of each group's effective block_size"
             )
 
-        self.eagle_group_ids: set[int] = set()
-        if use_eagle:
-            # vLLM applies EAGLE globally. For DSV4 we keep that behavior for
-            # reachable/uncompressed groups, but exclude c4/c128 because
-            # dropping their coarse chunk can erase the whole aligned hit.
+        self.eagle_group_ids = {i for i, group in enumerate(kv_cache_groups) if getattr(group, "is_eagle_group", False)}
+        if use_eagle and not self.eagle_group_ids:
+            # Compressed groups already use coarse chunks; dropping their last chunk can erase the whole hit.
             self.eagle_group_ids = {i for i, family in enumerate(group_cache_families) if _uses_reachable_mask(family)}
 
         self._verify_and_split_kv_cache_groups()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
@@ -147,7 +147,12 @@ class AscendStoreCoordinator:
             ExternalCachedBlockPool(),
             apply_eagle=False,
         )
-        return masks
+        return tuple(
+            [True] * _num_chunks(token_len, self.group_effective_block_sizes[group_id])
+            if not _uses_reachable_mask(self.group_cache_families[group_id])
+            else mask
+            for group_id, mask in enumerate(masks)
+        )
 
     def store_mask(
         self,
@@ -159,8 +164,11 @@ class AscendStoreCoordinator:
         )
         masks: list[list[bool]] = []
         for group_id, spec in enumerate(self.group_effective_specs):
-            manager_cls = _get_manager_class(_unwrap_spec(self.kv_cache_groups[group_id].kv_cache_spec))
             num_chunks = aligned_token_len // self.group_effective_block_sizes[group_id]
+            if not _uses_reachable_mask(self.group_cache_families[group_id]):
+                masks.append([True] * num_chunks)
+                continue
+            manager_cls = _get_manager_class(_unwrap_spec(self.kv_cache_groups[group_id].kv_cache_spec))
             mask = _reachable_block_mask(
                 manager_cls,
                 start_block=0,
@@ -371,3 +379,11 @@ def _cache_family_granularity(block_size: int, cache_family: str | None) -> int:
         return block_size
     ratio = cache_family[1:]
     return block_size * int(ratio) if ratio.isdigit() else block_size
+
+
+def _uses_reachable_mask(cache_family: str | None) -> bool:
+    return cache_family in (None, "default", "c1")
+
+
+def _num_chunks(token_len: int, block_size: int) -> int:
+    return (token_len + block_size - 1) // block_size

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
@@ -96,6 +96,9 @@ class AscendStoreCoordinator:
         for group_id, group in enumerate(self.kv_cache_groups):
             spec = _unwrap_spec(group.kv_cache_spec)
             effective_spec = _copy_spec_with_block_size(spec, self.group_effective_block_sizes[group_id])
+            if not _uses_reachable_mask(self.group_cache_families[group_id]):
+                # External compressed keys are already grouped by the effective block size.
+                effective_spec = replace(effective_spec, compress_ratio=1)
             self.group_effective_specs.append(effective_spec)
             manager_cls = _get_manager_class(spec)
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
@@ -303,6 +303,20 @@ def _get_manager_class_cache() -> dict[str, Any]:
 def _get_manager_class(spec: Any) -> Any:
     """Resolve the vLLM manager class across 0.20.x and 0.21.x APIs."""
     cache = _get_manager_class_cache()
+    compress_ratio = getattr(spec, "compress_ratio", None)
+    if compress_ratio is not None and compress_ratio > 1:
+        compress_manager = cache.get("compress_manager", _CACHE_MISSING)
+        if compress_manager is _CACHE_MISSING:
+            try:
+                from vllm_ascend.core.single_type_kv_cache_manager import CompressAttentionManager
+            except ImportError:
+                compress_manager = None
+            else:
+                compress_manager = CompressAttentionManager
+            cache["compress_manager"] = compress_manager
+        if compress_manager is not None:
+            return compress_manager
+
     registry = cache.get("registry", _CACHE_MISSING)
     if registry is _CACHE_MISSING:
         try:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
@@ -85,7 +85,8 @@ class AscendStoreCoordinator:
 
         self.eagle_group_ids = {i for i, group in enumerate(kv_cache_groups) if getattr(group, "is_eagle_group", False)}
         if use_eagle and not self.eagle_group_ids:
-            self.eagle_group_ids = set(range(len(kv_cache_groups)))
+            # Compressed groups already use coarse chunks; dropping their last chunk can erase the whole hit.
+            self.eagle_group_ids = {i for i, family in enumerate(group_cache_families) if _uses_reachable_mask(family)}
 
         self._verify_and_split_kv_cache_groups()
 
@@ -120,7 +121,11 @@ class AscendStoreCoordinator:
             if any(group_id in self.eagle_group_ids for group_id in group_ids)
         }
         if self.use_eagle and not self.eagle_attn_group_indices:
-            self.eagle_attn_group_indices = set(range(len(self.attention_groups)))
+            self.eagle_attn_group_indices = {
+                index
+                for index, (_, group_ids, _) in enumerate(self.attention_groups)
+                if any(_uses_reachable_mask(self.group_cache_families[group_id]) for group_id in group_ids)
+            }
 
     def find_longest_cache_hit(
         self,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
@@ -83,9 +83,11 @@ class AscendStoreCoordinator:
                 "scheduler_block_size must be a multiple of each group's effective block_size"
             )
 
-        self.eagle_group_ids = {i for i, group in enumerate(kv_cache_groups) if getattr(group, "is_eagle_group", False)}
-        if use_eagle and not self.eagle_group_ids:
-            # Compressed groups already use coarse chunks; dropping their last chunk can erase the whole hit.
+        self.eagle_group_ids: set[int] = set()
+        if use_eagle:
+            # vLLM applies EAGLE globally. For DSV4 we keep that behavior for
+            # reachable/uncompressed groups, but exclude c4/c128 because
+            # dropping their coarse chunk can erase the whole aligned hit.
             self.eagle_group_ids = {i for i, family in enumerate(group_cache_families) if _uses_reachable_mask(family)}
 
         self._verify_and_split_kv_cache_groups()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from importlib import import_module
+from typing import Any, cast
+
+from vllm.logger import logger
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashList, KVCacheBlock
+from vllm.v1.kv_cache_interface import FullAttentionSpec, UniformTypeKVCacheSpecs
+
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
+    _block_hash_to_bytes,
+    get_block_hashes,
+)
+
+_CACHE_MISSING = object()
+_MANAGER_CLASS_CACHE_ATTR = "_manager_class_cache"
+
+
+class ExternalCachedBlockPool:
+    """Duck-typed BlockPool backed by external AscendStore key existence."""
+
+    def __init__(self, exists: set[tuple[int, bytes]] | None = None) -> None:
+        # exists=None is used for load/store masks where hit length has already
+        # been decided and each manager only needs to apply its own reachability.
+        self._exists = exists
+        self.null_block = KVCacheBlock(block_id=0)
+        self._present_block = KVCacheBlock(block_id=1)
+
+    def get_cached_block(
+        self,
+        block_hash: BlockHash,
+        group_ids: list[int],
+    ) -> list[KVCacheBlock] | None:
+        if self._exists is None:
+            return [self._present_block] * len(group_ids)
+        h = _block_hash_to_bytes(block_hash)
+        if all((group_id, h) in self._exists for group_id in group_ids):
+            return [self._present_block] * len(group_ids)
+        return None
+
+
+class AscendStoreCoordinator:
+    """Hybrid cache-hit/mask coordinator for AscendStore external KV Pool.
+
+    This mirrors vLLM MooncakeStoreCoordinator but uses AscendStore's external
+    key granularity. For DSV4 compressed groups, keys are generated over the
+    raw-token span ``group_block_size * compress_ratio`` while transfer
+    addresses remain in cache-domain blocks.
+    """
+
+    def __init__(
+        self,
+        kv_cache_groups: list[Any],
+        scheduler_block_size: int,
+        hash_block_size: int,
+        group_block_sizes: list[int],
+        group_cache_families: list[str],
+        use_eagle: bool = False,
+        retention_interval: int | None = None,
+    ) -> None:
+        assert len(kv_cache_groups) == len(group_block_sizes)
+        assert len(kv_cache_groups) == len(group_cache_families)
+        assert scheduler_block_size % hash_block_size == 0, (
+            f"scheduler_block_size ({scheduler_block_size}) must be a multiple of hash_block_size ({hash_block_size})"
+        )
+
+        self.kv_cache_groups = kv_cache_groups
+        self.hash_block_size = hash_block_size
+        self.lcm_block_size = scheduler_block_size
+        self.use_eagle = use_eagle
+        self.retention_interval = retention_interval
+        self.group_block_sizes = group_block_sizes
+        self.group_cache_families = group_cache_families
+        self.group_effective_block_sizes = [
+            _cache_family_granularity(block_size, family)
+            for block_size, family in zip(group_block_sizes, group_cache_families, strict=True)
+        ]
+        for effective_block_size in self.group_effective_block_sizes:
+            assert effective_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
+            assert scheduler_block_size % effective_block_size == 0, (
+                "scheduler_block_size must be a multiple of each group's effective block_size"
+            )
+
+        self.eagle_group_ids = {i for i, group in enumerate(kv_cache_groups) if getattr(group, "is_eagle_group", False)}
+        if use_eagle and not self.eagle_group_ids:
+            self.eagle_group_ids = set(range(len(kv_cache_groups)))
+
+        self._verify_and_split_kv_cache_groups()
+
+    def _verify_and_split_kv_cache_groups(self) -> None:
+        attention_groups: list[tuple[Any, list[int], Any]] = []
+        self.group_effective_specs: list[Any] = []
+
+        for group_id, group in enumerate(self.kv_cache_groups):
+            spec = _unwrap_spec(group.kv_cache_spec)
+            effective_spec = _copy_spec_with_block_size(spec, self.group_effective_block_sizes[group_id])
+            self.group_effective_specs.append(effective_spec)
+            manager_cls = _get_manager_class(spec)
+
+            for existing_spec, group_ids, existing_cls in attention_groups:
+                if existing_spec == effective_spec:
+                    assert manager_cls is existing_cls, "Expected same manager class for identical KV cache specs."
+                    group_ids.append(group_id)
+                    break
+            else:
+                attention_groups.append((effective_spec, [group_id], manager_cls))
+
+        self.attention_groups = sorted(
+            attention_groups,
+            key=lambda item: not isinstance(item[0], FullAttentionSpec),
+        )
+        self.eagle_attn_group_indices: set[int] = {
+            index
+            for index, (_, group_ids, _) in enumerate(self.attention_groups)
+            if any(group_id in self.eagle_group_ids for group_id in group_ids)
+        }
+        if self.use_eagle and not self.eagle_attn_group_indices:
+            self.eagle_attn_group_indices = set(range(len(self.attention_groups)))
+
+    def find_longest_cache_hit(
+        self,
+        block_hashes: list[BlockHash],
+        max_length: int,
+        cached_block_pool: ExternalCachedBlockPool,
+        *,
+        apply_eagle: bool = True,
+    ) -> tuple[tuple[list[bool], ...], int]:
+        blocks_per_group, hit_length = self._find_hit_blocks(
+            block_hashes,
+            max_length,
+            cached_block_pool,
+            apply_eagle=apply_eagle,
+        )
+        masks = tuple([block is not cached_block_pool.null_block for block in blocks] for blocks in blocks_per_group)
+        return masks, hit_length
+
+    def load_mask(
+        self,
+        block_hashes: list[BlockHash],
+        token_len: int,
+    ) -> tuple[list[bool], ...]:
+        masks, _ = self.find_longest_cache_hit(
+            block_hashes,
+            token_len,
+            ExternalCachedBlockPool(),
+            apply_eagle=False,
+        )
+        return masks
+
+    def store_mask(
+        self,
+        aligned_token_len: int,
+        num_prompt_tokens: int | None = None,
+    ) -> tuple[list[bool], ...]:
+        assert aligned_token_len % self.lcm_block_size == 0, (
+            f"aligned_token_len ({aligned_token_len}) must be a multiple of lcm_block_size ({self.lcm_block_size})"
+        )
+        masks: list[list[bool]] = []
+        for group_id, spec in enumerate(self.group_effective_specs):
+            manager_cls = _get_manager_class(_unwrap_spec(self.kv_cache_groups[group_id].kv_cache_spec))
+            num_chunks = aligned_token_len // self.group_effective_block_sizes[group_id]
+            mask = _reachable_block_mask(
+                manager_cls,
+                start_block=0,
+                end_block=num_chunks,
+                alignment_tokens=self.lcm_block_size,
+                kv_cache_spec=spec,
+                use_eagle=group_id in self.eagle_group_ids,
+                retention_interval=self.retention_interval,
+                num_prompt_tokens=num_prompt_tokens,
+            )
+            masks.append([True] * num_chunks if mask is None else mask)
+        return tuple(masks)
+
+    def block_hashes_for_spec(self, block_hashes: list[BlockHash], spec: Any) -> BlockHashList:
+        if spec.block_size == self.hash_block_size:
+            return cast(BlockHashList, block_hashes)
+        return cast(BlockHashList, get_block_hashes(block_hashes, spec.block_size, self.hash_block_size))
+
+    def _find_hit_blocks(
+        self,
+        block_hashes: list[BlockHash],
+        max_length: int,
+        cached_block_pool: ExternalCachedBlockPool,
+        *,
+        apply_eagle: bool = True,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        eagle_indices = self.eagle_attn_group_indices if apply_eagle else set()
+        if len(self.attention_groups) == 1:
+            spec, group_ids, manager_cls = self.attention_groups[0]
+            hashes = self.block_hashes_for_spec(block_hashes, spec)
+            hit_blocks = _find_longest_cache_hit(
+                manager_cls,
+                block_hashes=hashes,
+                max_length=max_length,
+                kv_cache_group_ids=group_ids,
+                block_pool=cast(BlockPool, cached_block_pool),
+                kv_cache_spec=spec,
+                drop_eagle_block=0 in eagle_indices,
+                alignment_tokens=spec.block_size,
+            )
+            blocks_by_group: list[list[KVCacheBlock]] = [[] for _ in range(len(self.kv_cache_groups))]
+            for group_id, blocks in zip(group_ids, hit_blocks, strict=True):
+                blocks_by_group[group_id] = blocks
+            return tuple(blocks_by_group), len(hit_blocks[0]) * spec.block_size
+
+        hit_length = max_length
+        hit_blocks_by_group: list[list[KVCacheBlock] | None] = [None] * len(self.kv_cache_groups)
+        is_simple_hybrid = len(self.attention_groups) == 2 and isinstance(
+            self.attention_groups[0][0], FullAttentionSpec
+        )
+        eagle_verified: set[int] = set()
+
+        while True:
+            curr_hit_length = hit_length
+
+            for index, (spec, group_ids, manager_cls) in enumerate(self.attention_groups):
+                cached = hit_blocks_by_group[group_ids[0]]
+                if isinstance(spec, FullAttentionSpec) and cached is not None:
+                    curr_hit_length = curr_hit_length // spec.block_size * spec.block_size
+                    continue
+
+                drop_eagle_block = index in eagle_indices and index not in eagle_verified
+                max_group_length = curr_hit_length
+                if drop_eagle_block:
+                    max_group_length = min(curr_hit_length + spec.block_size, max_length)
+                hashes = self.block_hashes_for_spec(block_hashes, spec)
+                hit_blocks = _find_longest_cache_hit(
+                    manager_cls,
+                    block_hashes=hashes,
+                    max_length=max_group_length,
+                    kv_cache_group_ids=group_ids,
+                    block_pool=cast(BlockPool, cached_block_pool),
+                    kv_cache_spec=spec,
+                    drop_eagle_block=drop_eagle_block,
+                    alignment_tokens=self.lcm_block_size,
+                )
+                new_hit_length = len(hit_blocks[0]) * spec.block_size
+                if drop_eagle_block:
+                    eagle_verified.add(index)
+                elif new_hit_length < curr_hit_length:
+                    eagle_verified.clear()
+                curr_hit_length = new_hit_length
+                for group_id, blocks in zip(group_ids, hit_blocks, strict=True):
+                    hit_blocks_by_group[group_id] = blocks
+
+            if curr_hit_length >= hit_length:
+                break
+            hit_length = curr_hit_length
+            if is_simple_hybrid:
+                break
+
+        spec0, group_ids0, _ = self.attention_groups[0]
+        if isinstance(spec0, FullAttentionSpec):
+            num_blocks = hit_length // spec0.block_size
+            for group_id in group_ids0:
+                full_blocks = hit_blocks_by_group[group_id]
+                assert full_blocks is not None
+                del full_blocks[num_blocks:]
+
+        return (
+            tuple(blocks if blocks is not None else [] for blocks in hit_blocks_by_group),
+            hit_length,
+        )
+
+
+def _unwrap_spec(spec: Any) -> Any:
+    if isinstance(spec, UniformTypeKVCacheSpecs):
+        return next(iter(spec.kv_cache_specs.values()))
+    kv_cache_specs = getattr(spec, "kv_cache_specs", None)
+    if kv_cache_specs is not None:
+        return next(iter(kv_cache_specs.values()))
+    return spec
+
+
+def _copy_spec_with_block_size(spec: Any, block_size: int) -> Any:
+    if spec.block_size == block_size:
+        return spec
+    copy_with_new_block_size = getattr(spec, "copy_with_new_block_size", None)
+    if copy_with_new_block_size is not None:
+        return copy_with_new_block_size(block_size)
+    return replace(spec, block_size=block_size)
+
+
+def _get_manager_class_cache() -> dict[str, Any]:
+    cache = getattr(_get_manager_class, _MANAGER_CLASS_CACHE_ATTR, None)
+    if not isinstance(cache, dict):
+        cache = {}
+        setattr(_get_manager_class, _MANAGER_CLASS_CACHE_ATTR, cache)
+    return cast(dict[str, Any], cache)
+
+
+def _get_manager_class(spec: Any) -> Any:
+    """Resolve the vLLM manager class across 0.20.x and 0.21.x APIs."""
+    cache = _get_manager_class_cache()
+    registry = cache.get("registry", _CACHE_MISSING)
+    if registry is _CACHE_MISSING:
+        try:
+            registry_module = import_module("vllm.v1.kv_cache_spec_registry")
+            registry = getattr(registry_module, "KVCacheSpecRegistry", None)
+        except ImportError:
+            registry = None
+        cache["registry"] = registry
+
+    if registry is not None:
+        manager_cls = registry.get_manager_class(spec)
+        if manager_cls is not None:
+            return manager_cls
+
+    spec_manager_map = cache.get("spec_manager_map", _CACHE_MISSING)
+    if spec_manager_map is _CACHE_MISSING:
+        try:
+            manager_module = import_module("vllm.v1.core.single_type_kv_cache_manager")
+            spec_manager_map = getattr(manager_module, "spec_manager_map", {})
+        except ImportError:
+            spec_manager_map = None
+        cache["spec_manager_map"] = spec_manager_map
+
+    if not spec_manager_map:
+        raise AssertionError(f"No manager registered for KVCacheSpec {type(spec)}")
+    manager_cls = spec_manager_map.get(type(spec))
+    if manager_cls is not None:
+        return manager_cls
+    for spec_cls, candidate in spec_manager_map.items():
+        if isinstance(spec, spec_cls):
+            return candidate
+    raise AssertionError(f"No manager registered for KVCacheSpec {type(spec)}")
+
+
+def _find_longest_cache_hit(
+    manager_cls: Any,
+    **kwargs: Any,
+) -> tuple[list[KVCacheBlock], ...]:
+    try:
+        return manager_cls.find_longest_cache_hit(**kwargs)
+    except TypeError as exc:
+        if "drop_eagle_block" not in str(exc):
+            raise
+        kwargs["use_eagle"] = kwargs.pop("drop_eagle_block")
+        return manager_cls.find_longest_cache_hit(**kwargs)
+
+
+def _reachable_block_mask(
+    manager_cls: Any,
+    **kwargs: Any,
+) -> list[bool] | None:
+    reachable_block_mask = getattr(manager_cls, "reachable_block_mask", None)
+    if reachable_block_mask is None:
+        return None
+    try:
+        return reachable_block_mask(**kwargs)
+    except TypeError as exc:
+        if "retention_interval" not in str(exc) and "num_prompt_tokens" not in str(exc):
+            logger.debug("KV cache manager does not support reachable_block_mask kwargs: %s", exc)
+            return reachable_block_mask(
+                start_block=kwargs["start_block"],
+                end_block=kwargs["end_block"],
+                alignment_tokens=kwargs["alignment_tokens"],
+                kv_cache_spec=kwargs["kv_cache_spec"],
+                use_eagle=kwargs["use_eagle"],
+            )
+        kwargs.pop("retention_interval", None)
+        kwargs.pop("num_prompt_tokens", None)
+        return reachable_block_mask(**kwargs)
+
+
+def _cache_family_granularity(block_size: int, cache_family: str | None) -> int:
+    if not cache_family or not cache_family.startswith("c"):
+        return block_size
+    ratio = cache_family[1:]
+    return block_size * int(ratio) if ratio.isdigit() else block_size

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
@@ -162,6 +162,29 @@ class AscendStoreCoordinator:
             for group_id, mask in enumerate(masks)
         )
 
+    def lookup_mask(self, token_len: int) -> tuple[list[bool] | None, ...]:
+        masks: list[list[bool] | None] = []
+        for group_id, spec in enumerate(self.group_effective_specs):
+            num_chunks = _num_chunks(token_len, self.group_effective_block_sizes[group_id])
+            if not _uses_reachable_mask(self.group_cache_families[group_id]):
+                masks.append(None)
+                continue
+            manager_cls = _get_manager_class(_unwrap_spec(self.kv_cache_groups[group_id].kv_cache_spec))
+            mask = _reachable_block_mask(
+                manager_cls,
+                start_block=0,
+                end_block=num_chunks,
+                alignment_tokens=self.lcm_block_size,
+                kv_cache_spec=spec,
+                use_eagle=False,
+                retention_interval=None,
+                num_prompt_tokens=None,
+            )
+            if mask is not None:
+                assert len(mask) == num_chunks
+            masks.append(mask)
+        return tuple(masks)
+
     def store_mask(
         self,
         aligned_token_len: int,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -205,6 +205,38 @@ class KVTransferThread(threading.Thread):
         except TypeError:
             return self.token_database.decode_adaptor_prefill_pp(keys, addrs, sizes)
 
+    def _chunk_mask_allows(self, mask: list[bool] | None, start: int, kv_cache_group_id: int) -> bool:
+        if mask is None:
+            return True
+        chunk_idx = start // self._get_block_size(kv_cache_group_id)
+        return chunk_idx < len(mask) and mask[chunk_idx]
+
+    def _store_mask(
+        self,
+        token_len: int,
+        kv_cache_group_id: int,
+        num_prompt_tokens: int | None = None,
+    ) -> list[bool] | None:
+        store_mask = getattr(self.token_database, "store_mask", None)
+        if store_mask is None:
+            return None
+        return store_mask(
+            token_len,
+            kv_cache_group_id,
+            num_prompt_tokens=num_prompt_tokens,
+        )
+
+    def _load_mask(
+        self,
+        block_hashes,
+        token_len: int,
+        kv_cache_group_id: int,
+    ) -> list[bool] | None:
+        load_mask = getattr(self.token_database, "load_mask", None)
+        if load_mask is None:
+            return None
+        return load_mask(block_hashes, token_len, kv_cache_group_id)
+
 
 class KVCacheStoreSendingThread(KVTransferThread):
     def __init__(
@@ -256,6 +288,11 @@ class KVCacheStoreSendingThread(KVTransferThread):
             block_hashes = []
             block_ids = req_meta.block_ids_by_group[group_id]
             group_block_size = self._get_block_size(group_id)
+            store_mask = self._store_mask(
+                token_len,
+                group_id,
+                num_prompt_tokens=req_meta.num_prompt_tokens,
+            )
             group_block_hashes = get_block_hashes(
                 req_meta.block_hashes,
                 group_block_size,
@@ -269,6 +306,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 kv_cache_group_id=group_id,
                 skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
             ):
+                if not self._chunk_mask_allows(store_mask, start, group_id):
+                    continue
                 starts.append(start)
                 ends.append(end)
                 keys.append(key.to_string())
@@ -334,18 +373,19 @@ class KVCacheStoreSendingThread(KVTransferThread):
                         if isinstance(req_meta.original_block_size, list)
                         else req_meta.original_block_size
                     )
-                    stored_event = BlockStored(
-                        block_hashes=[new_block_hashes[index]],
-                        parent_block_hash=prev_key,
-                        token_ids=token_ids,
-                        block_size=block_size,
-                        lora_id=None,
-                        medium="cpu",
-                        lora_name=None,
-                    )
-                    stored_events.append(stored_event)
-                    prev_key = new_block_hashes[index]
-                    logger.debug("Added kv cache event '%s' to kv cache events queue", stored_event)
+                    if block_size is not None:
+                        stored_event = BlockStored(
+                            block_hashes=[new_block_hashes[index]],
+                            parent_block_hash=prev_key,
+                            token_ids=token_ids,
+                            block_size=block_size,
+                            lora_id=None,
+                            medium="cpu",
+                            lora_name=None,
+                        )
+                        stored_events.append(stored_event)
+                        prev_key = new_block_hashes[index]
+                        logger.debug("Added kv cache event '%s' to kv cache events queue", stored_event)
 
             if self.kv_role == "kv_consumer":
                 keys, addrs, sizes = self._decode_adaptor_prefill_pp(
@@ -390,6 +430,11 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         for group_id in req_meta.kv_cache_group_ids or [0]:
             block_ids = req_meta.block_ids_by_group[group_id]
             group_block_size = self._get_block_size(group_id)
+            load_mask = self._load_mask(
+                req_meta.block_hashes,
+                token_len,
+                group_id,
+            )
             mask_num = (
                 req_meta.load_spec.vllm_cached_tokens  # type: ignore[union-attr]
                 // group_block_size
@@ -403,6 +448,8 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 kv_cache_group_id=group_id,
                 skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
             ):
+                if not self._chunk_mask_allows(load_mask, start, group_id):
+                    continue
                 addr, size, _ = self._prepare_value(
                     start,
                     end,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -205,40 +205,40 @@ class KVTransferThread(threading.Thread):
         except TypeError:
             return self.token_database.decode_adaptor_prefill_pp(keys, addrs, sizes)
 
-    def _chunk_mask_allows(self, mask: list[bool] | None, start: int, kv_cache_group_id: int) -> bool:
+    def _chunk_mask_allows(
+        self,
+        masks: tuple[list[bool], ...] | None,
+        kv_cache_group_id: int,
+        start: int,
+    ) -> bool:
         mask_allows_chunk = getattr(self.token_database, "mask_allows_chunk", None)
         if mask_allows_chunk is not None:
-            return mask_allows_chunk(mask, start, kv_cache_group_id)
-        if mask is None:
+            return mask_allows_chunk(masks, kv_cache_group_id, start)
+        if masks is None or kv_cache_group_id >= len(masks):
             return True
+        mask = masks[kv_cache_group_id]
         chunk_idx = start // self._get_block_size(kv_cache_group_id)
         return chunk_idx < len(mask) and mask[chunk_idx]
 
-    def _store_mask(
-        self,
-        token_len: int,
-        kv_cache_group_id: int,
-        num_prompt_tokens: int | None = None,
-    ) -> list[bool] | None:
+    def _store_mask(self, req_meta: ReqMeta) -> tuple[list[bool], ...] | None:
         store_mask = getattr(self.token_database, "store_mask", None)
         if store_mask is None:
             return None
-        return store_mask(
-            token_len,
-            kv_cache_group_id,
-            num_prompt_tokens=num_prompt_tokens,
-        )
+        try:
+            return store_mask(req_meta.token_len_chunk, req_meta.num_prompt_tokens)
+        except AssertionError as exc:
+            logger.debug("Skip AscendStore store mask for unaligned request %s: %s", req_meta.req_id, exc)
+            return None
 
     def _load_mask(
         self,
-        block_hashes,
+        req_meta: ReqMeta,
         token_len: int,
-        kv_cache_group_id: int,
-    ) -> list[bool] | None:
+    ) -> tuple[list[bool], ...] | None:
         load_mask = getattr(self.token_database, "load_mask", None)
         if load_mask is None:
             return None
-        return load_mask(block_hashes, token_len, kv_cache_group_id)
+        return load_mask(req_meta.block_hashes, token_len)
 
 
 class KVCacheStoreSendingThread(KVTransferThread):
@@ -284,6 +284,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
             self.request_queue.task_done()
             return
 
+        store_masks = self._store_mask(req_meta)
         for group_id in req_meta.kv_cache_group_ids or [0]:
             starts = []
             ends = []
@@ -291,11 +292,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
             block_hashes = []
             block_ids = req_meta.block_ids_by_group[group_id]
             group_block_size = self._get_block_size(group_id)
-            store_mask = self._store_mask(
-                token_len,
-                group_id,
-                num_prompt_tokens=req_meta.num_prompt_tokens,
-            )
             group_block_hashes = get_block_hashes(
                 req_meta.block_hashes,
                 group_block_size,
@@ -309,7 +305,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 kv_cache_group_id=group_id,
                 skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
             ):
-                if not self._chunk_mask_allows(store_mask, start, group_id):
+                if not self._chunk_mask_allows(store_masks, group_id, start):
                     continue
                 starts.append(start)
                 ends.append(end)
@@ -430,14 +426,10 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         addr_list = []
         size_list = []
         key_list = []
+        load_masks = self._load_mask(req_meta, token_len)
         for group_id in req_meta.kv_cache_group_ids or [0]:
             block_ids = req_meta.block_ids_by_group[group_id]
             group_block_size = self._get_block_size(group_id)
-            load_mask = self._load_mask(
-                req_meta.block_hashes,
-                token_len,
-                group_id,
-            )
             mask_num = (
                 req_meta.load_spec.vllm_cached_tokens  # type: ignore[union-attr]
                 // group_block_size
@@ -451,7 +443,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 kv_cache_group_id=group_id,
                 skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
             ):
-                if not self._chunk_mask_allows(load_mask, start, group_id):
+                if not self._chunk_mask_allows(load_masks, group_id, start):
                     continue
                 addr, size, _ = self._prepare_value(
                     start,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -206,6 +206,9 @@ class KVTransferThread(threading.Thread):
             return self.token_database.decode_adaptor_prefill_pp(keys, addrs, sizes)
 
     def _chunk_mask_allows(self, mask: list[bool] | None, start: int, kv_cache_group_id: int) -> bool:
+        mask_allows_chunk = getattr(self.token_database, "mask_allows_chunk", None)
+        if mask_allows_chunk is not None:
+            return mask_allows_chunk(mask, start, kv_cache_group_id)
         if mask is None:
             return True
         chunk_idx = start // self._get_block_size(kv_cache_group_id)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -174,6 +174,7 @@ class KVTransferThread(threading.Thread):
         block_ids: list[int],
         kv_cache_group_id: int = 0,
         cache_role: str = "kv",
+        block_id: int | None = None,
     ):
         try:
             return self.token_database.prepare_value(
@@ -182,6 +183,7 @@ class KVTransferThread(threading.Thread):
                 block_ids,
                 kv_cache_group_id=kv_cache_group_id,
                 cache_role=cache_role,
+                block_id=block_id,
             )
         except TypeError:
             return self.token_database.prepare_value(start, end, block_ids)
@@ -290,6 +292,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
             ends = []
             keys = []
             block_hashes = []
+            key_block_ids = []
             block_ids = req_meta.block_ids_by_group[group_id]
             group_block_size = self._get_block_size(group_id)
             group_block_hashes = get_block_hashes(
@@ -298,7 +301,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 getattr(self.token_database, "hash_block_size", group_block_size),
             )
 
-            for start, end, key, _ in self._process_tokens_with_block_ids(
+            for start, end, key, block_id in self._process_tokens_with_block_ids(
                 token_len,
                 req_meta.block_hashes,
                 block_ids,
@@ -311,12 +314,14 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 ends.append(end)
                 keys.append(key.to_string())
                 block_hashes.append(group_block_hashes[start // group_block_size])
+                key_block_ids.append(block_id)
 
             if not self.dcp_size > 1 and not req_meta.disable_tp_key_sharding:
                 starts = starts[self.tp_rank % self.put_step :: self.put_step]
                 ends = ends[self.tp_rank % self.put_step :: self.put_step]
                 keys = keys[self.tp_rank % self.put_step :: self.put_step]
                 block_hashes = block_hashes[self.tp_rank % self.put_step :: self.put_step]
+                key_block_ids = key_block_ids[self.tp_rank % self.put_step :: self.put_step]
 
             if not keys:
                 continue
@@ -331,6 +336,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
             ends = [ends[index] for index in missing_indices]
             keys = [keys[index] for index in missing_indices]
             block_hashes = [block_hashes[index] for index in missing_indices]
+            key_block_ids = [key_block_ids[index] for index in missing_indices]
 
             logger.info(
                 "Storing KV cache for %d out of %d blocks (missing_count=%d) for request %s in group %d",
@@ -360,6 +366,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     ends[index],
                     block_ids,
                     kv_cache_group_id=group_id,
+                    block_id=key_block_ids[index],
                 )
                 addrs.append(addr)
                 sizes.append(size)
@@ -435,7 +442,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 // group_block_size
                 * group_block_size
             )
-            for start, end, key, _ in self._process_tokens_with_block_ids(
+            for start, end, key, block_id in self._process_tokens_with_block_ids(
                 token_len,
                 req_meta.block_hashes,
                 block_ids,
@@ -450,6 +457,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                     end,
                     block_ids,
                     kv_cache_group_id=group_id,
+                    block_id=block_id,
                 )
                 key_list.append(key.to_string())
                 addr_list.append(addr)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -371,6 +371,7 @@ class KVPoolScheduler:
                 allocated_block_ids_by_group=normalize_block_ids_by_group(request.block_ids),
                 num_saved_tokens=0,
                 token_ids=request.prompt_token_ids[:num_tokens_to_compute].copy(),
+                num_prompt_tokens=len(request.prompt_token_ids),
             )
             self._request_trackers[request.req_id] = request_tracker
             last_chunk_tokens_num = (
@@ -414,6 +415,7 @@ class KVPoolScheduler:
                         allocated_block_ids_by_group=normalize_block_ids_by_group(new_block_ids),
                         num_saved_tokens=0,
                         token_ids=request_real.prompt_token_ids[:num_tokens_to_compute].copy(),
+                        num_prompt_tokens=len(request_real.prompt_token_ids),
                     )
                     self._request_trackers[req_id] = request_tracker
                     last_chunk_tokens_num = (
@@ -487,6 +489,7 @@ class KVPoolScheduler:
                     token_len=num_tokens_to_compute,
                     allocated_block_ids_by_group=block_ids,
                     num_saved_tokens=0,
+                    num_prompt_tokens=len(request.prompt_token_ids),
                 )
 
                 self._request_trackers[request_id] = request_tracker

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -34,6 +34,10 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     get_cache_family_granularity,
     infer_group_cache_families,
 )
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import (
+    AscendStoreCoordinator,
+    ExternalCachedBlockPool,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import (
     KVCacheStoreLayerRecvingThread,
     KVCacheStoreLayerSendingThread,
@@ -186,6 +190,8 @@ class KVPoolWorker:
             retention_interval=getattr(envs, "VLLM_PREFIX_CACHE_RETENTION_INTERVAL", None),
             use_eagle=use_eagle,
         )
+        self.cache_coordinator = self._build_cache_coordinator(vllm_config)
+        self.token_database.set_cache_coordinator(self.cache_coordinator)
 
         backend = backend_map.get(self.backend.lower())
         assert backend is not None
@@ -213,6 +219,25 @@ class KVPoolWorker:
         self.kv_recv_thread: KVTransferThread | None = None
 
         self.finished_store_req: set[str] = set()
+
+    def _build_cache_coordinator(self, vllm_config: VllmConfig) -> AscendStoreCoordinator | None:
+        if self.kv_cache_config is None or not self.use_hybrid:
+            return None
+        speculative_config = getattr(vllm_config, "speculative_config", None)
+        use_eagle_fn = getattr(speculative_config, "use_eagle", None)
+        use_eagle = bool(use_eagle_fn()) if callable(use_eagle_fn) else False
+        retention_interval = getattr(envs, "VLLM_PREFIX_CACHE_RETENTION_INTERVAL", None)
+        if not isinstance(retention_interval, int):
+            retention_interval = None
+        return AscendStoreCoordinator(
+            list(self.kv_cache_config.kv_cache_groups),
+            scheduler_block_size=self.cache_transfer_granularity,
+            hash_block_size=self.hash_block_size,
+            group_block_sizes=self.grouped_block_size,
+            group_cache_families=self.kv_cache_group_families,
+            use_eagle=use_eagle,
+            retention_interval=retention_interval,
+        )
 
     def _infer_group_families(self) -> list[str]:
         kv_cache_groups = self.kv_cache_config.kv_cache_groups if self.kv_cache_config is not None else None
@@ -495,14 +520,10 @@ class KVPoolWorker:
                     addr_list = []
                     size_list = []
                     key_list = []
+                    load_masks = self.token_database.load_mask(request.block_hashes, token_len)
                     for group_id in load_group_ids:
                         block_ids = request.block_ids_by_group[group_id]
                         group_block_size = self.grouped_block_size[group_id]
-                        load_mask = self.token_database.load_mask(
-                            request.block_hashes,
-                            token_len,
-                            group_id,
-                        )
                         mask_num = request.load_spec.vllm_cached_tokens // group_block_size * group_block_size
                         skip_null = (
                             group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]
@@ -515,7 +536,7 @@ class KVPoolWorker:
                             kv_cache_group_id=group_id,
                             skip_null_blocks=skip_null,
                         ):
-                            if not self.token_database.mask_allows_chunk(load_mask, start, group_id):
+                            if not self.token_database.mask_allows_chunk(load_masks, group_id, start):
                                 continue
                             addr, size, _ = self.token_database.prepare_value(
                                 start,
@@ -826,7 +847,15 @@ class KVPoolWorker:
         try:
             hits = []
             kv_cache_group_ids = kv_cache_group_ids or [0]
-            kv_cache_group_ids = self._get_lookup_gate_group_ids(kv_cache_group_ids)
+            coordinator_hit = self._lookup_with_coordinator(
+                token_len,
+                block_hashes,
+                kv_cache_group_ids,
+                use_layerwise,
+                include_all_ranks=False,
+            )
+            if coordinator_hit is not None:
+                return coordinator_hit
             for group_id in kv_cache_group_ids:
                 end = 0
                 keys = []
@@ -879,46 +908,110 @@ class KVPoolWorker:
             return 0
         return min(hits) if hits else 0
 
-    def _get_lookup_gate_group_ids(self, kv_cache_group_ids: list[int]) -> list[int]:
-        gate_group_ids = [group_id for group_id in kv_cache_group_ids if self._is_lookup_gate_group(group_id)]
-        if not gate_group_ids:
-            return kv_cache_group_ids
-        if len(gate_group_ids) != len(kv_cache_group_ids):
-            logger.debug(
-                "KV pool lookup gates on groups %s, ignoring non-gate groups from %s",
-                gate_group_ids,
-                kv_cache_group_ids,
-            )
-        return gate_group_ids
-
-    def _is_lookup_gate_group(self, group_id: int) -> bool:
-        if group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]:
-            return False
-        cache_family = self._get_group_family(self.kv_cache_group_families, group_id)
-        # DeepSeek V4 has a c128 compressed KV group. Its key stream is much
-        # sparser than the dense KV groups, so using it as a strict gate makes
-        # the whole request report 0 hit even when the loadable groups exist.
-        if cache_family == "c128":
-            return False
-        # The DSV4 c4 group is currently written as a TP-sharded key stream in
-        # this connector path. Runtime logs show only 32/128 keys visible for a
-        # 16K prompt, so letting it gate the external pool prevents otherwise
-        # complete c1 groups from loading. Keep pooling gate/load on complete
-        # 128-token c1 KV groups until c4 storage is made fully discoverable.
-        if cache_family != "c1":
-            return False
-        # In the DSV4 hybrid layout, some auxiliary groups use smaller logical
-        # block sizes (for example 8/32). The Ascend kernels in this path are
-        # fixed to the 128-token KV block shape, so those groups cannot be used
-        # as external-pool gates or load targets for the 16K pooling path.
-        return self._get_group_block_size(group_id) == self.block_size
-
     def _get_group_num_kv_heads(self, group_id: int) -> int:
         if self.use_mla or self.use_sparse:
             return 1
         if group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]:
             return 1
         return self.num_kv_head
+
+    def get_group_tp_size(self, kv_cache_group_id: int) -> int:
+        if kv_cache_group_id < len(self.group_uses_align_state) and self.group_uses_align_state[kv_cache_group_id]:
+            return self.tp_size
+        return min(self.tp_size, self._get_group_num_kv_heads(kv_cache_group_id))
+
+    @staticmethod
+    def _replace_key_field(key: str, field: str, value: int) -> str:
+        marker = f"@{field}:"
+        start = key.find(marker)
+        if start < 0:
+            return key
+        value_start = start + len(marker)
+        value_end = key.find("@", value_start)
+        if value_end < 0:
+            value_end = len(key)
+        return f"{key[:value_start]}{value}{key[value_end:]}"
+
+    @staticmethod
+    def _chunk_hash_to_bytes(chunk_hash: str) -> bytes:
+        if len(chunk_hash) == 64:
+            try:
+                return bytes.fromhex(chunk_hash)
+            except ValueError:
+                pass
+        return chunk_hash.encode("utf-8")
+
+    def _expand_lookup_key_variants(self, key: str, group_id: int, include_all_ranks: bool) -> list[str]:
+        if not include_all_ranks:
+            return [key]
+        variants: list[str] = []
+        group_tp_size = self.get_group_tp_size(group_id)
+        for tp_rank in range(group_tp_size):
+            tp_key = self._replace_key_field(key, "head_or_tp_rank", tp_rank)
+            for pp_rank in range(self.pp_size):
+                variants.append(self._replace_key_field(tp_key, "pp_rank", pp_rank))
+        return variants
+
+    def _lookup_with_coordinator(
+        self,
+        token_len: int,
+        block_hashes: list[BlockHash],
+        kv_cache_group_ids: list[int],
+        use_layerwise: bool,
+        include_all_ranks: bool,
+    ) -> int | None:
+        if self.cache_coordinator is None or use_layerwise:
+            return None
+        if sorted(kv_cache_group_ids) != list(range(self.num_kv_cache_groups)):
+            return None
+
+        exists: set[tuple[int, bytes]] = set()
+        for group_id in kv_cache_group_ids:
+            keys: list[str] = []
+            chunk_hashes: list[str] = []
+            variant_counts: list[int] = []
+            for _, _, key in self.token_database.process_tokens(
+                token_len,
+                block_hashes,
+                kv_cache_group_id=group_id,
+            ):
+                variants = self._expand_lookup_key_variants(key.to_string(), group_id, include_all_ranks)
+                keys.extend(variants)
+                chunk_hashes.append(key.chunk_hash)
+                variant_counts.append(len(variants))
+
+            if not keys:
+                continue
+            res = self.m_store.exists(keys)  # type: ignore[assignment]
+            offset = 0
+            for chunk_hash, count in zip(chunk_hashes, variant_counts, strict=True):
+                values = res[offset : offset + count]  # type: ignore[index]
+                if values and all(value == 1 for value in values):
+                    exists.add((group_id, self._chunk_hash_to_bytes(chunk_hash)))
+                offset += count
+
+            logger.debug(
+                "KV pool coordinator lookup group=%d token_len=%d keys=%d exists_chunks=%d/%d sample_keys=%s",
+                group_id,
+                token_len,
+                len(keys),
+                sum(1 for group, _ in exists if group == group_id),
+                len(chunk_hashes),
+                keys[:3],
+            )
+
+        _, hit_length = self.cache_coordinator.find_longest_cache_hit(
+            block_hashes,
+            token_len,
+            ExternalCachedBlockPool(exists),
+        )
+        logger.debug(
+            "KV pool coordinator lookup final token_len=%d groups=%s hit=%d",
+            token_len,
+            kv_cache_group_ids,
+            hit_length,
+        )
+        return hit_length
 
     def lookup_scheduler(
         self,
@@ -935,7 +1028,15 @@ class KVPoolWorker:
         try:
             hits = []
             kv_cache_group_ids = kv_cache_group_ids or [0]
-            kv_cache_group_ids = self._get_lookup_gate_group_ids(kv_cache_group_ids)
+            coordinator_hit = self._lookup_with_coordinator(
+                token_len,
+                block_hashes,
+                kv_cache_group_ids,
+                use_layerwise,
+                include_all_ranks=True,
+            )
+            if coordinator_hit is not None:
+                return coordinator_hit
             for group_id in kv_cache_group_ids:
                 end = 0
                 keys = []
@@ -960,7 +1061,7 @@ class KVPoolWorker:
                     continue
 
                 multi_tp_keys = keys[:]
-                group_tp_size = min(self.tp_size, self._get_group_num_kv_heads(group_id))
+                group_tp_size = self.get_group_tp_size(group_id)
                 for i in range(1, group_tp_size):
                     for item in keys:
                         new_str = item.replace(  # type: ignore[attr-defined]

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -498,6 +498,11 @@ class KVPoolWorker:
                     for group_id in load_group_ids:
                         block_ids = request.block_ids_by_group[group_id]
                         group_block_size = self.grouped_block_size[group_id]
+                        load_mask = self.token_database.load_mask(
+                            request.block_hashes,
+                            token_len,
+                            group_id,
+                        )
                         mask_num = request.load_spec.vllm_cached_tokens // group_block_size * group_block_size
                         skip_null = (
                             group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]
@@ -510,6 +515,8 @@ class KVPoolWorker:
                             kv_cache_group_id=group_id,
                             skip_null_blocks=skip_null,
                         ):
+                            if not self.token_database.mask_allows_chunk(load_mask, start, group_id):
+                                continue
                             addr, size, _ = self.token_database.prepare_value(
                                 start,
                                 end,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -6,6 +6,7 @@ import threading
 from collections.abc import Generator
 
 import torch
+import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.distributed import (
     get_decode_context_model_parallel_rank,
@@ -167,12 +168,23 @@ class KVPoolWorker:
                     for i in range(2, remaining_layers + 2):
                         partitions[-i] += 1
 
+        spec_cfg = getattr(vllm_config, "speculative_config", None)
+        use_eagle = bool(
+            spec_cfg.use_eagle() if spec_cfg is not None and callable(getattr(spec_cfg, "use_eagle", None)) else False
+        )
+        kv_cache_groups = (
+            list(kv_cache_config.kv_cache_groups) if kv_cache_config is not None and self.use_hybrid else None
+        )
         self.token_database = ChunkedTokenDatabase(
             self.metadata,
             self.grouped_block_size,
             partitions,
             use_hybrid=self.use_hybrid,
             hash_block_size=self.hash_block_size,
+            kv_cache_groups=kv_cache_groups,
+            alignment_tokens=self.cache_transfer_granularity,
+            retention_interval=getattr(envs, "VLLM_PREFIX_CACHE_RETENTION_INTERVAL", None),
+            use_eagle=use_eagle,
         )
 
         backend = backend_map.get(self.backend.lower())

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -528,7 +528,7 @@ class KVPoolWorker:
                         skip_null = (
                             group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]
                         )
-                        for start, end, key, _ in self.token_database.process_tokens_with_block_ids(
+                        for start, end, key, block_id in self.token_database.process_tokens_with_block_ids(
                             token_len,
                             request.block_hashes,
                             block_ids,
@@ -543,6 +543,7 @@ class KVPoolWorker:
                                 end,
                                 block_ids,
                                 kv_cache_group_id=group_id,
+                                block_id=block_id,
                             )
                             key_list.append(key.to_string())
                             addr_list.append(addr)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1005,6 +1005,7 @@ class KVPoolWorker:
             block_hashes,
             token_len,
             ExternalCachedBlockPool(exists),
+            apply_eagle=False,
         )
         logger.debug(
             "KV pool coordinator lookup final token_len=%d groups=%s hit=%d",

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -967,7 +967,9 @@ class KVPoolWorker:
             return None
 
         exists: set[tuple[int, bytes]] = set()
+        lookup_masks = self.cache_coordinator.lookup_mask(token_len)
         for group_id in kv_cache_group_ids:
+            chunk_mask = lookup_masks[group_id] if group_id < len(lookup_masks) else None
             keys: list[str] = []
             chunk_hashes: list[str] = []
             variant_counts: list[int] = []
@@ -975,6 +977,7 @@ class KVPoolWorker:
                 token_len,
                 block_hashes,
                 kv_cache_group_id=group_id,
+                chunk_mask=chunk_mask,
             ):
                 variants = self._expand_lookup_key_variants(key.to_string(), group_id, include_all_ranks)
                 keys.extend(variants)

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -114,6 +114,13 @@ env_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
     # Whether to use MultiBlockPool for KV cache management
     "VLLM_ASCEND_APPLY_DSV4_PATCH": lambda: bool(int(os.getenv("VLLM_ASCEND_APPLY_DSV4_PATCH", "0"))),
+    # Retain local sliding-window KV checkpoints for prefix caching.
+    # This mirrors vLLM's VLLM_PREFIX_CACHE_RETENTION_INTERVAL.
+    "VLLM_PREFIX_CACHE_RETENTION_INTERVAL": lambda: (
+        int(os.environ["VLLM_PREFIX_CACHE_RETENTION_INTERVAL"])
+        if "VLLM_PREFIX_CACHE_RETENTION_INTERVAL" in os.environ
+        else None
+    ),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -37,6 +37,7 @@ import vllm_ascend.patch.platform.patch_deepseek_v4_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_thinking  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa
 import vllm_ascend.patch.platform.patch_tool_choice_none_content  # noqa
+import vllm_ascend.patch.platform.patch_prefix_cache_retention  # noqa
 
 if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXPERT_MAP_RECORD", "false") == "true":
     import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -27,13 +27,6 @@ from vllm_ascend.patch.platform.patch_prefix_cache_retention import (
 USE_MULTI_GROUPS_KV_CACHE = True
 
 
-def _compress_ratio(kv_cache_spec: KVCacheSpec) -> int:
-    kv_cache_specs = getattr(kv_cache_spec, "kv_cache_specs", None)
-    if isinstance(kv_cache_specs, dict):
-        return max((getattr(spec, "compress_ratio", 1) or 1) for spec in kv_cache_specs.values())
-    return getattr(kv_cache_spec, "compress_ratio", 1) or 1
-
-
 class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
     """
     KV cache coordinator for hybrid models with multiple KV cache types, and
@@ -75,21 +68,15 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             metrics_collector,
         )
 
-        has_compressed_group = any(
-            _compress_ratio(group.kv_cache_spec) > 1 for group in kv_cache_config.kv_cache_groups
-        )
         # KV cache group indices that get the EAGLE last-block drop.
-        if use_eagle and has_compressed_group:
-            # DSV4's local hit granularity is the compressed alignment (for
-            # example 16K). Applying EAGLE/drop-last to the C1 group can align
-            # the hit down to 0 even when the retained C1 tail is sufficient.
-            self.eagle_group_ids = set()
-        else:
-            self.eagle_group_ids: set[int] = {
-                i for i, g in enumerate(kv_cache_config.kv_cache_groups) if g.is_eagle_group
+        self.eagle_group_ids: set[int] = {i for i, g in enumerate(kv_cache_config.kv_cache_groups) if g.is_eagle_group}
+        # Compressed groups already use coarse chunks; dropping their last chunk can erase the whole hit.
+        if use_eagle and not self.eagle_group_ids:
+            self.eagle_group_ids = {
+                i
+                for i, g in enumerate(kv_cache_config.kv_cache_groups)
+                if (getattr(g.kv_cache_spec, "compress_ratio", 1) or 1) <= 1
             }
-            if use_eagle and not self.eagle_group_ids:
-                self.eagle_group_ids = set(range(len(kv_cache_config.kv_cache_groups)))
 
         self.single_type_managers = tuple(
             get_manager_for_kv_cache_spec(

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -70,9 +70,13 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
 
         # KV cache group indices that get the EAGLE last-block drop.
         self.eagle_group_ids: set[int] = {i for i, g in enumerate(kv_cache_config.kv_cache_groups) if g.is_eagle_group}
-        # Conservatively fall back to flag all groups when no group is flagged.
+        # Compressed groups already use coarse chunks; dropping their last chunk can erase the whole hit.
         if use_eagle and not self.eagle_group_ids:
-            self.eagle_group_ids = set(range(len(kv_cache_config.kv_cache_groups)))
+            self.eagle_group_ids = {
+                i
+                for i, g in enumerate(kv_cache_config.kv_cache_groups)
+                if (getattr(g.kv_cache_spec, "compress_ratio", 1) or 1) <= 1
+            }
 
         self.single_type_managers = tuple(
             get_manager_for_kv_cache_spec(

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -27,6 +27,13 @@ from vllm_ascend.patch.platform.patch_prefix_cache_retention import (
 USE_MULTI_GROUPS_KV_CACHE = True
 
 
+def _compress_ratio(kv_cache_spec: KVCacheSpec) -> int:
+    kv_cache_specs = getattr(kv_cache_spec, "kv_cache_specs", None)
+    if isinstance(kv_cache_specs, dict):
+        return max((getattr(spec, "compress_ratio", 1) or 1) for spec in kv_cache_specs.values())
+    return getattr(kv_cache_spec, "compress_ratio", 1) or 1
+
+
 class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
     """
     KV cache coordinator for hybrid models with multiple KV cache types, and
@@ -68,15 +75,19 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             metrics_collector,
         )
 
-        # KV cache group indices that get the EAGLE last-block drop.
-        self.eagle_group_ids: set[int] = {i for i, g in enumerate(kv_cache_config.kv_cache_groups) if g.is_eagle_group}
-        # Compressed groups already use coarse chunks; dropping their last chunk can erase the whole hit.
-        if use_eagle and not self.eagle_group_ids:
+        has_compressed_group = any(
+            _compress_ratio(group.kv_cache_spec) > 1 for group in kv_cache_config.kv_cache_groups
+        )
+        if use_eagle and has_compressed_group:
+            # DSV4 local hits are aligned to compressed chunks (for example 16K).
+            # Dropping one c4/c128 chunk can erase the whole aligned hit.
+            self.eagle_group_ids: set[int] = set()
+        else:
             self.eagle_group_ids = {
-                i
-                for i, g in enumerate(kv_cache_config.kv_cache_groups)
-                if (getattr(g.kv_cache_spec, "compress_ratio", 1) or 1) <= 1
+                i for i, g in enumerate(kv_cache_config.kv_cache_groups) if getattr(g, "is_eagle_group", False)
             }
+            if use_eagle and not self.eagle_group_ids:
+                self.eagle_group_ids = set(range(len(kv_cache_config.kv_cache_groups)))
 
         self.single_type_managers = tuple(
             get_manager_for_kv_cache_spec(

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -20,6 +20,9 @@ from vllm.v1.core.single_type_kv_cache_manager import SingleTypeKVCacheManager
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheSpec
 
 from vllm_ascend.core.single_type_kv_cache_manager import get_manager_for_kv_cache_spec
+from vllm_ascend.patch.platform.patch_prefix_cache_retention import (
+    get_prefix_cache_retention_interval,
+)
 
 USE_MULTI_GROUPS_KV_CACHE = True
 
@@ -151,6 +154,17 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         # NOTE: use 16k as the alignment tokens for model with compress ratio
         block_sizes = [self._logical_block_size(spec) for spec, _, _ in self.attention_groups]
         self.lcm_block_size = lcm(*block_sizes)
+        self.retention_interval = get_prefix_cache_retention_interval(self.kv_cache_config, self.lcm_block_size)
+
+    def cache_blocks(self, request, num_computed_tokens: int) -> None:
+        for manager in self.single_type_managers:
+            manager.cache_blocks(
+                request,
+                num_computed_tokens,
+                retention_interval=self.retention_interval,
+                alignment_tokens=self.lcm_block_size,
+                use_eagle=manager.kv_cache_group_id in self.eagle_group_ids,
+            )
 
     def find_longest_cache_hit(
         self,

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -27,6 +27,13 @@ from vllm_ascend.patch.platform.patch_prefix_cache_retention import (
 USE_MULTI_GROUPS_KV_CACHE = True
 
 
+def _compress_ratio(kv_cache_spec: KVCacheSpec) -> int:
+    kv_cache_specs = getattr(kv_cache_spec, "kv_cache_specs", None)
+    if isinstance(kv_cache_specs, dict):
+        return max((getattr(spec, "compress_ratio", 1) or 1) for spec in kv_cache_specs.values())
+    return getattr(kv_cache_spec, "compress_ratio", 1) or 1
+
+
 class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
     """
     KV cache coordinator for hybrid models with multiple KV cache types, and
@@ -68,17 +75,21 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             metrics_collector,
         )
 
-        # KV cache group indices that get the EAGLE/MTP last-block drop.
-        # vLLM applies EAGLE globally. For DSV4 we keep that behavior for
-        # uncompressed groups, but exclude c4/c128 because dropping their coarse
-        # chunk can erase the whole aligned hit.
-        self.eagle_group_ids: set[int] = set()
-        if use_eagle:
-            self.eagle_group_ids = {
-                i
-                for i, g in enumerate(kv_cache_config.kv_cache_groups)
-                if (getattr(g.kv_cache_spec, "compress_ratio", 1) or 1) <= 1
+        has_compressed_group = any(
+            _compress_ratio(group.kv_cache_spec) > 1 for group in kv_cache_config.kv_cache_groups
+        )
+        # KV cache group indices that get the EAGLE last-block drop.
+        if use_eagle and has_compressed_group:
+            # DSV4's local hit granularity is the compressed alignment (for
+            # example 16K). Applying EAGLE/drop-last to the C1 group can align
+            # the hit down to 0 even when the retained C1 tail is sufficient.
+            self.eagle_group_ids = set()
+        else:
+            self.eagle_group_ids: set[int] = {
+                i for i, g in enumerate(kv_cache_config.kv_cache_groups) if g.is_eagle_group
             }
+            if use_eagle and not self.eagle_group_ids:
+                self.eagle_group_ids = set(range(len(kv_cache_config.kv_cache_groups)))
 
         self.single_type_managers = tuple(
             get_manager_for_kv_cache_spec(

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -68,10 +68,12 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             metrics_collector,
         )
 
-        # KV cache group indices that get the EAGLE last-block drop.
-        self.eagle_group_ids: set[int] = {i for i, g in enumerate(kv_cache_config.kv_cache_groups) if g.is_eagle_group}
-        # Compressed groups already use coarse chunks; dropping their last chunk can erase the whole hit.
-        if use_eagle and not self.eagle_group_ids:
+        # KV cache group indices that get the EAGLE/MTP last-block drop.
+        # vLLM applies EAGLE globally. For DSV4 we keep that behavior for
+        # uncompressed groups, but exclude c4/c128 because dropping their coarse
+        # chunk can erase the whole aligned hit.
+        self.eagle_group_ids: set[int] = set()
+        if use_eagle:
             self.eagle_group_ids = {
                 i
                 for i, g in enumerate(kv_cache_config.kv_cache_groups)

--- a/vllm_ascend/patch/platform/patch_prefix_cache_retention.py
+++ b/vllm_ascend/patch/platform/patch_prefix_cache_retention.py
@@ -307,7 +307,7 @@ def _sliding_window_reachable_block_mask(
                 mask[i - start_block] = True
 
     if retention_interval is not None and num_prompt_tokens is not None:
-        latest = (num_prompt_tokens - 1) // alignment_tokens * alignment_tokens
+        latest = num_prompt_tokens // alignment_tokens * alignment_tokens
         prompt_end_block = latest // block_size + shift
         for i in range(max(start_block, prompt_end_block - need), min(end_block, prompt_end_block)):
             mask[i - start_block] = True

--- a/vllm_ascend/patch/platform/patch_prefix_cache_retention.py
+++ b/vllm_ascend/patch/platform/patch_prefix_cache_retention.py
@@ -51,7 +51,9 @@ def _iter_kv_cache_specs(kv_cache_config: KVCacheConfig) -> Iterable[KVCacheSpec
 
 
 def _is_sliding_window_spec(kv_cache_spec: KVCacheSpec) -> bool:
-    return isinstance(kv_cache_spec, SlidingWindowSpec) or kv_cache_spec.__class__.__name__ == "SlidingWindowMLASpec"
+    return isinstance(kv_cache_spec, SlidingWindowSpec) or kv_cache_spec.__class__.__name__.endswith(
+        "SlidingWindowMLASpec"
+    )
 
 
 def _validate_prefix_cache_retention_interval(
@@ -396,6 +398,67 @@ def _patch_single_type_cache_blocks() -> None:
     SlidingWindowManager.reachable_block_mask = classmethod(_sliding_window_reachable_block_mask)  # type: ignore[attr-defined]
 
 
+def _patch_sliding_window_find_longest_cache_hit() -> None:
+    def find_longest_cache_hit(
+        cls: type[SlidingWindowManager],
+        block_hashes: Any,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        assert _is_sliding_window_spec(kv_cache_spec)
+        assert dcp_world_size == 1, "DCP not support sliding window attn now."
+        assert pcp_world_size == 1, "PCP not support sliding window attn now."
+
+        need = _contiguous_blocks_for_hit(
+            window_size=kv_cache_spec.sliding_window,
+            block_size=kv_cache_spec.block_size,
+            use_eagle=use_eagle,
+        )
+        max_num_blocks = max_length // kv_cache_spec.block_size
+        computed_blocks = tuple([block_pool.null_block] * max_num_blocks for _ in range(len(kv_cache_group_ids)))
+        block_size = kv_cache_spec.block_size
+        num_contiguous_blocks = 0
+        match_found = False
+        for i in range(max_num_blocks - 1, -1, -1):
+            cached_block = block_pool.get_cached_block(block_hashes[i], kv_cache_group_ids)
+            if cached_block:
+                if num_contiguous_blocks == 0 and block_size != alignment_tokens:
+                    post_pop_blocks = i if use_eagle else i + 1
+                    if post_pop_blocks * block_size % alignment_tokens != 0:
+                        continue
+                for computed, cached in zip(computed_blocks, cached_block):
+                    computed[i] = cached
+                num_contiguous_blocks += 1
+                if num_contiguous_blocks >= need:
+                    for computed in computed_blocks:
+                        del computed[i + num_contiguous_blocks :]
+                    match_found = True
+                    break
+            else:
+                num_contiguous_blocks = 0
+        if not match_found:
+            for computed in computed_blocks:
+                del computed[num_contiguous_blocks:]
+            while block_size != alignment_tokens and len(computed_blocks[0]) * block_size % alignment_tokens != 0:
+                for computed in computed_blocks:
+                    computed.pop()
+        if use_eagle and computed_blocks[0]:
+            for computed in computed_blocks:
+                computed.pop()
+            while block_size != alignment_tokens and len(computed_blocks[0]) * block_size % alignment_tokens != 0:
+                for computed in computed_blocks:
+                    computed.pop()
+        return computed_blocks
+
+    SlidingWindowManager.find_longest_cache_hit = classmethod(find_longest_cache_hit)  # type: ignore[method-assign]
+
+
 def _patch_sliding_window_free() -> None:
     def remove_skipped_blocks(
         self: SingleTypeKVCacheManager,
@@ -558,5 +621,6 @@ _patch_block_pool_free_blocks()
 _patch_block_pool_cache_full_blocks()
 _patch_compress_manager_factory()
 _patch_single_type_cache_blocks()
+_patch_sliding_window_find_longest_cache_hit()
 _patch_sliding_window_free()
 _patch_upstream_coordinators()

--- a/vllm_ascend/patch/platform/patch_prefix_cache_retention.py
+++ b/vllm_ascend/patch/platform/patch_prefix_cache_retention.py
@@ -258,7 +258,6 @@ def _default_reachable_block_mask(
     use_eagle: bool,
     retention_interval: int | None = None,
     num_prompt_tokens: int | None = None,
-    include_previous_alignment_boundary: bool = False,
 ) -> list[bool] | None:
     return None
 
@@ -279,7 +278,6 @@ def _sliding_window_reachable_block_mask(
     use_eagle: bool,
     retention_interval: int | None = None,
     num_prompt_tokens: int | None = None,
-    include_previous_alignment_boundary: bool = False,
 ) -> list[bool] | None:
     assert _is_sliding_window_spec(kv_cache_spec)
     if retention_interval is None:
@@ -308,18 +306,11 @@ def _sliding_window_reachable_block_mask(
             if i >= shift and (i - shift) % per_segment >= per_segment - need:
                 mask[i - start_block] = True
 
-    def keep_boundary(boundary_tokens: int) -> None:
-        prompt_end_block = boundary_tokens // block_size + shift
-        for i in range(max(start_block, prompt_end_block - need), min(end_block, prompt_end_block)):
-            mask[i - start_block] = True
-
     if retention_interval is not None and num_prompt_tokens is not None:
         latest = num_prompt_tokens // alignment_tokens * alignment_tokens
-        keep_boundary(latest)
-        if include_previous_alignment_boundary and num_prompt_tokens > alignment_tokens:
-            previous = (num_prompt_tokens - 1) // alignment_tokens * alignment_tokens
-            if previous != latest:
-                keep_boundary(previous)
+        prompt_end_block = latest // block_size + shift
+        for i in range(max(start_block, prompt_end_block - need), min(end_block, prompt_end_block)):
+            mask[i - start_block] = True
 
     return mask
 
@@ -352,7 +343,6 @@ def _patch_single_type_cache_blocks() -> None:
                 use_eagle=use_eagle,
                 retention_interval=retention_interval,
                 num_prompt_tokens=request.num_prompt_tokens,
-                include_previous_alignment_boundary=True,
             )
             self.block_pool.cache_full_blocks(
                 request=request,

--- a/vllm_ascend/patch/platform/patch_prefix_cache_retention.py
+++ b/vllm_ascend/patch/platform/patch_prefix_cache_retention.py
@@ -4,6 +4,7 @@
 import inspect
 import os
 from collections.abc import Iterable
+from math import lcm
 from typing import Any
 
 import vllm.envs as vllm_envs
@@ -422,6 +423,16 @@ def _manager_uses_eagle(coordinator: KVCacheCoordinator, manager: SingleTypeKVCa
 
 
 def _coordinator_alignment_tokens(coordinator: KVCacheCoordinator) -> int:
+    kv_cache_config = getattr(coordinator, "kv_cache_config", None)
+    kv_cache_groups = getattr(kv_cache_config, "kv_cache_groups", None)
+    if kv_cache_groups:
+        block_sizes = [
+            spec.block_size * max(getattr(spec, "compress_ratio", 1) or 1, 1)
+            for group in kv_cache_groups
+            for spec in _unwrap_specs(group.kv_cache_spec)
+        ]
+        if block_sizes:
+            return lcm(*block_sizes)
     return (
         getattr(coordinator, "scheduler_block_size", None)
         or getattr(coordinator, "lcm_block_size", None)
@@ -478,8 +489,8 @@ def _patch_upstream_coordinators() -> None:
                 *args,
                 **kwargs,
             )
-            scheduler_block_size = getattr(self, "block_size", hash_block_size)
-            self.retention_interval = get_prefix_cache_retention_interval(kv_cache_config, scheduler_block_size)
+            alignment_tokens = _coordinator_alignment_tokens(self)
+            self.retention_interval = get_prefix_cache_retention_interval(kv_cache_config, alignment_tokens)
 
         def hybrid_init(
             self: HybridKVCacheCoordinator,
@@ -507,7 +518,8 @@ def _patch_upstream_coordinators() -> None:
                 *args,
                 **kwargs,
             )
-            self.retention_interval = get_prefix_cache_retention_interval(kv_cache_config, self.lcm_block_size)
+            alignment_tokens = _coordinator_alignment_tokens(self)
+            self.retention_interval = get_prefix_cache_retention_interval(kv_cache_config, alignment_tokens)
 
         KVCacheCoordinator.__init__ = init  # type: ignore[method-assign]
         HybridKVCacheCoordinator.__init__ = hybrid_init  # type: ignore[method-assign]

--- a/vllm_ascend/patch/platform/patch_prefix_cache_retention.py
+++ b/vllm_ascend/patch/platform/patch_prefix_cache_retention.py
@@ -278,6 +278,8 @@ def _sliding_window_reachable_block_mask(
     num_prompt_tokens: int | None = None,
 ) -> list[bool] | None:
     assert _is_sliding_window_spec(kv_cache_spec)
+    if retention_interval is None:
+        return None
     if alignment_tokens is None:
         return None
     assert alignment_tokens % kv_cache_spec.block_size == 0
@@ -291,8 +293,8 @@ def _sliding_window_reachable_block_mask(
     shift = 1 if use_eagle else 0
     mask = [False] * (end_block - start_block)
 
-    segment_tokens = alignment_tokens if retention_interval is None else None
-    if retention_interval is not None and retention_interval > 0:
+    segment_tokens = None
+    if retention_interval > 0:
         segment_tokens = retention_interval
     if segment_tokens is not None:
         per_segment = segment_tokens // block_size

--- a/vllm_ascend/patch/platform/patch_prefix_cache_retention.py
+++ b/vllm_ascend/patch/platform/patch_prefix_cache_retention.py
@@ -1,0 +1,524 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+
+import inspect
+import os
+from collections.abc import Iterable
+from typing import Any
+
+import vllm.envs as vllm_envs
+import vllm.v1.core.block_pool as block_pool_mod
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_coordinator import (
+    HybridKVCacheCoordinator,
+    KVCacheCoordinator,
+)
+from vllm.v1.core.kv_cache_utils import FreeKVCacheBlockQueue, KVCacheBlock
+from vllm.v1.core.single_type_kv_cache_manager import (
+    CrossAttentionManager,
+    MambaManager,
+    SingleTypeKVCacheManager,
+    SlidingWindowManager,
+)
+from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec, SlidingWindowSpec
+from vllm.v1.request import Request
+
+ENV_NAME = "VLLM_PREFIX_CACHE_RETENTION_INTERVAL"
+
+
+def _read_retention_interval() -> int | None:
+    if ENV_NAME not in os.environ:
+        return None
+    return int(os.environ[ENV_NAME])
+
+
+if hasattr(vllm_envs, "environment_variables"):
+    vllm_envs.environment_variables.setdefault(ENV_NAME, _read_retention_interval)
+
+
+def _unwrap_specs(kv_cache_spec: KVCacheSpec) -> Iterable[KVCacheSpec]:
+    nested_specs = getattr(kv_cache_spec, "kv_cache_specs", None)
+    if isinstance(nested_specs, dict):
+        yield from nested_specs.values()
+    else:
+        yield kv_cache_spec
+
+
+def _iter_kv_cache_specs(kv_cache_config: KVCacheConfig) -> Iterable[KVCacheSpec]:
+    for kv_cache_group in kv_cache_config.kv_cache_groups:
+        yield from _unwrap_specs(kv_cache_group.kv_cache_spec)
+
+
+def _is_sliding_window_spec(kv_cache_spec: KVCacheSpec) -> bool:
+    return isinstance(kv_cache_spec, SlidingWindowSpec) or kv_cache_spec.__class__.__name__ == "SlidingWindowMLASpec"
+
+
+def _validate_prefix_cache_retention_interval(
+    retention_interval: int | None,
+    scheduler_block_size: int,
+    kv_cache_config: KVCacheConfig,
+) -> None:
+    if retention_interval is None:
+        return
+
+    if not any(_is_sliding_window_spec(spec) for spec in _iter_kv_cache_specs(kv_cache_config)):
+        raise ValueError(
+            f"{ENV_NAME} is set but this model has no sliding-window KV cache "
+            "group, so retention has no effect. Unset it or use a model with "
+            "sliding-window attention."
+        )
+
+    if retention_interval < 0 or retention_interval % scheduler_block_size != 0:
+        raise ValueError(
+            f"{ENV_NAME} ({retention_interval}) must be non-negative and a "
+            f"multiple of scheduler_block_size ({scheduler_block_size})."
+        )
+
+
+def get_prefix_cache_retention_interval(
+    kv_cache_config: KVCacheConfig,
+    scheduler_block_size: int,
+) -> int | None:
+    retention_interval = getattr(vllm_envs, ENV_NAME, None)
+    _validate_prefix_cache_retention_interval(retention_interval, scheduler_block_size, kv_cache_config)
+    return retention_interval
+
+
+def _add_prepend_n_to_free_queue() -> None:
+    if hasattr(FreeKVCacheBlockQueue, "prepend_n"):
+        return
+
+    def prepend_n(self: FreeKVCacheBlockQueue, blocks: list[KVCacheBlock]) -> None:
+        """Put a list of blocks at the front of the free list."""
+        if len(blocks) == 0:
+            return
+
+        first_block = self.fake_free_list_head.next_free_block
+        assert first_block is not None, "next_free_block of fake_free_list_head should always exist"
+
+        prev_block = self.fake_free_list_head
+        for block in blocks:
+            block.prev_free_block = prev_block
+            prev_block.next_free_block = block
+            prev_block = block
+
+        prev_block.next_free_block = first_block
+        first_block.prev_free_block = prev_block
+
+        self.num_free_blocks += len(blocks)
+
+    FreeKVCacheBlockQueue.prepend_n = prepend_n  # type: ignore[attr-defined]
+
+
+def _patch_block_pool_free_blocks() -> None:
+    if "prepend" in inspect.signature(BlockPool.free_blocks).parameters:
+        return
+
+    def free_blocks(
+        self: BlockPool,
+        ordered_blocks: Iterable[KVCacheBlock],
+        prepend: bool = False,
+    ) -> None:
+        blocks_list = list(ordered_blocks)
+        for block in blocks_list:
+            block.ref_cnt -= 1
+
+        freed_blocks = [block for block in blocks_list if block.ref_cnt == 0 and not block.is_null]
+        if prepend:
+            self.free_block_queue.prepend_n(freed_blocks)
+        else:
+            self.free_block_queue.append_n(freed_blocks)
+
+    BlockPool.free_blocks = free_blocks  # type: ignore[method-assign]
+
+
+def _patch_block_pool_cache_full_blocks() -> None:
+    if "block_mask" in inspect.signature(BlockPool.cache_full_blocks).parameters:
+        return
+
+    orig_cache_full_blocks = BlockPool.cache_full_blocks
+
+    def cache_full_blocks(
+        self: BlockPool,
+        request: Request,
+        blocks: list[KVCacheBlock],
+        num_cached_blocks: int,
+        num_full_blocks: int,
+        block_size: int,
+        kv_cache_group_id: int,
+        block_mask: list[bool] | None = None,
+    ) -> None:
+        if block_mask is None:
+            return orig_cache_full_blocks(
+                self,
+                request,
+                blocks,
+                num_cached_blocks,
+                num_full_blocks,
+                block_size,
+                kv_cache_group_id,
+            )
+
+        if num_cached_blocks >= num_full_blocks:
+            return
+
+        new_full_blocks = blocks[num_cached_blocks:num_full_blocks]
+        assert len(request.block_hashes) >= num_full_blocks
+        if block_size == self.hash_block_size:
+            block_hashes = request.block_hashes
+        else:
+            assert block_size % self.hash_block_size == 0
+            block_hashes = block_pool_mod.BlockHashListWithBlockSize(
+                request.block_hashes, self.hash_block_size, block_size
+            )
+
+        new_block_hashes = block_hashes[num_cached_blocks:]
+        new_hashes: list[Any] | None = [] if self.enable_kv_cache_events else None
+        for i, blk in enumerate(new_full_blocks):
+            if not block_mask[i]:
+                continue
+            if blk.is_null:
+                continue
+            assert blk.block_hash is None
+            block_hash = new_block_hashes[i]
+            block_hash_with_group_id = block_pool_mod.make_block_hash_with_group_id(block_hash, kv_cache_group_id)
+            blk.block_hash = block_hash_with_group_id
+            self.cached_block_hash_to_block.insert(block_hash_with_group_id, blk)
+            if new_hashes is not None:
+                new_hashes.append(block_pool_mod.maybe_convert_block_hash(block_hash))
+
+        if self.enable_kv_cache_events:
+            parent_block_hash = (
+                None
+                if num_cached_blocks == 0
+                else block_pool_mod.maybe_convert_block_hash(block_hashes[num_cached_blocks - 1])
+            )
+            start_token_idx = num_cached_blocks * block_size
+            end_token_idx = num_full_blocks * block_size
+            extra_keys_list: list[tuple[Any, ...] | None] = []
+            curr_mm_idx = 0
+            for i in range(num_cached_blocks, num_full_blocks):
+                if not block_mask[i - num_cached_blocks] or blocks[i].is_null:
+                    continue
+                block_start = i * block_size
+                block_end = block_start + block_size
+                extra_keys, curr_mm_idx = block_pool_mod.generate_block_hash_extra_keys(
+                    request, block_start, block_end, curr_mm_idx
+                )
+                extra_keys_list.append(extra_keys)
+
+            self.kv_event_queue.append(
+                block_pool_mod.BlockStored(
+                    block_hashes=new_hashes,
+                    parent_block_hash=parent_block_hash,
+                    token_ids=request.all_token_ids[start_token_idx:end_token_idx],
+                    block_size=block_size,
+                    lora_id=request.lora_request.adapter_id if request.lora_request else None,
+                    medium=block_pool_mod.MEDIUM_GPU,
+                    lora_name=request.lora_request.name if request.lora_request else None,
+                    extra_keys=extra_keys_list if extra_keys_list else None,
+                )
+            )
+
+    BlockPool.cache_full_blocks = cache_full_blocks  # type: ignore[method-assign]
+
+
+def _default_reachable_block_mask(
+    cls: type[SingleTypeKVCacheManager],
+    start_block: int,
+    end_block: int,
+    alignment_tokens: int | None,
+    kv_cache_spec: KVCacheSpec,
+    use_eagle: bool,
+    retention_interval: int | None = None,
+    num_prompt_tokens: int | None = None,
+) -> list[bool] | None:
+    return None
+
+
+def _contiguous_blocks_for_hit(window_size: int, block_size: int, use_eagle: bool) -> int:
+    need = (window_size - 1 + block_size - 1) // block_size
+    if use_eagle:
+        need += 1
+    return need
+
+
+def _sliding_window_reachable_block_mask(
+    cls: type[SlidingWindowManager],
+    start_block: int,
+    end_block: int,
+    alignment_tokens: int | None,
+    kv_cache_spec: KVCacheSpec,
+    use_eagle: bool,
+    retention_interval: int | None = None,
+    num_prompt_tokens: int | None = None,
+) -> list[bool] | None:
+    assert _is_sliding_window_spec(kv_cache_spec)
+    if alignment_tokens is None:
+        return None
+    assert alignment_tokens % kv_cache_spec.block_size == 0
+
+    block_size = kv_cache_spec.block_size
+    need = _contiguous_blocks_for_hit(
+        window_size=kv_cache_spec.sliding_window,
+        block_size=block_size,
+        use_eagle=use_eagle,
+    )
+    shift = 1 if use_eagle else 0
+    mask = [False] * (end_block - start_block)
+
+    segment_tokens = alignment_tokens if retention_interval is None else None
+    if retention_interval is not None and retention_interval > 0:
+        segment_tokens = retention_interval
+    if segment_tokens is not None:
+        per_segment = segment_tokens // block_size
+        if need >= per_segment:
+            return None
+        for i in range(start_block, end_block):
+            if i >= shift and (i - shift) % per_segment >= per_segment - need:
+                mask[i - start_block] = True
+
+    if retention_interval is not None and num_prompt_tokens is not None:
+        latest = (num_prompt_tokens - 1) // alignment_tokens * alignment_tokens
+        prompt_end_block = latest // block_size + shift
+        for i in range(max(start_block, prompt_end_block - need), min(end_block, prompt_end_block)):
+            mask[i - start_block] = True
+
+    return mask
+
+
+def _patch_single_type_cache_blocks() -> None:
+    if not hasattr(SingleTypeKVCacheManager, "reachable_block_mask"):
+        SingleTypeKVCacheManager.reachable_block_mask = classmethod(_default_reachable_block_mask)  # type: ignore[attr-defined]
+
+    signature = inspect.signature(SingleTypeKVCacheManager.cache_blocks)
+    if "retention_interval" not in signature.parameters:
+
+        def cache_blocks(
+            self: SingleTypeKVCacheManager,
+            request: Request,
+            num_tokens: int,
+            retention_interval: int | None = None,
+            alignment_tokens: int | None = None,
+            use_eagle: bool = False,
+        ) -> None:
+            num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
+            num_full_blocks = num_tokens // self.block_size
+            if num_cached_blocks >= num_full_blocks:
+                return
+
+            block_mask = self.reachable_block_mask(  # type: ignore[attr-defined]
+                start_block=num_cached_blocks,
+                end_block=num_full_blocks,
+                alignment_tokens=alignment_tokens or self.block_size,
+                kv_cache_spec=self.kv_cache_spec,
+                use_eagle=use_eagle,
+                retention_interval=retention_interval,
+                num_prompt_tokens=request.num_prompt_tokens,
+            )
+            self.block_pool.cache_full_blocks(
+                request=request,
+                blocks=self.req_to_blocks[request.request_id],
+                num_cached_blocks=num_cached_blocks,
+                num_full_blocks=num_full_blocks,
+                block_size=self.block_size,
+                kv_cache_group_id=self.kv_cache_group_id,
+                block_mask=block_mask,
+            )
+            self.num_cached_block[request.request_id] = num_full_blocks
+
+        SingleTypeKVCacheManager.cache_blocks = cache_blocks  # type: ignore[method-assign]
+
+        def mamba_cache_blocks(
+            self: MambaManager,
+            request: Request,
+            num_tokens: int,
+            retention_interval: int | None = None,
+            alignment_tokens: int | None = None,
+            use_eagle: bool = False,
+        ) -> None:
+            num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
+            super(MambaManager, self).cache_blocks(
+                request,
+                num_tokens,
+                retention_interval=retention_interval,
+                alignment_tokens=alignment_tokens,
+                use_eagle=use_eagle,
+            )
+            num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
+            if num_cached_blocks_after > num_cached_blocks_before:
+                for block in self.req_to_blocks[request.request_id][num_cached_blocks_before:num_cached_blocks_after]:
+                    if block.is_null:
+                        continue
+                    assert block.block_hash is not None
+                    self.cached_blocks_this_step.add(block.block_hash)
+
+        MambaManager.cache_blocks = mamba_cache_blocks  # type: ignore[method-assign]
+
+        def cross_attention_cache_blocks(
+            self: CrossAttentionManager,
+            request: Request,
+            num_tokens: int,
+            retention_interval: int | None = None,
+            alignment_tokens: int | None = None,
+            use_eagle: bool = False,
+        ) -> None:
+            raise ValueError("Should not be called as prefix caching is disabled.")
+
+        CrossAttentionManager.cache_blocks = cross_attention_cache_blocks  # type: ignore[method-assign]
+
+    SlidingWindowManager.reachable_block_mask = classmethod(_sliding_window_reachable_block_mask)  # type: ignore[attr-defined]
+
+
+def _patch_sliding_window_free() -> None:
+    def remove_skipped_blocks(
+        self: SingleTypeKVCacheManager,
+        request_id: str,
+        total_computed_tokens: int,
+    ) -> None:
+        num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
+        if num_skipped_tokens <= 0:
+            return
+
+        blocks = self.req_to_blocks[request_id]
+        num_skipped_blocks = min(num_skipped_tokens // self.block_size, len(blocks))
+        removed_cached_blocks: list[KVCacheBlock] = []
+        removed_uncached_blocks: list[KVCacheBlock] = []
+        for i in range(num_skipped_blocks - 1, -1, -1):
+            if blocks[i] == self._null_block:
+                break
+            if blocks[i].block_hash is None:
+                removed_uncached_blocks.append(blocks[i])
+            else:
+                removed_cached_blocks.append(blocks[i])
+            blocks[i] = self._null_block
+
+        self.block_pool.free_blocks(removed_cached_blocks)
+        self.block_pool.free_blocks(removed_uncached_blocks, prepend=True)
+
+    def free(self: SingleTypeKVCacheManager, request_id: str) -> None:
+        req_blocks = self.req_to_blocks.pop(request_id, [])
+        if req_blocks:
+            cached_blocks: list[KVCacheBlock] = []
+            uncached_blocks: list[KVCacheBlock] = []
+            for block in reversed(req_blocks):
+                if block.block_hash is None:
+                    uncached_blocks.append(block)
+                else:
+                    cached_blocks.append(block)
+            self.block_pool.free_blocks(cached_blocks)
+            self.block_pool.free_blocks(uncached_blocks, prepend=True)
+        self.num_cached_block.pop(request_id, None)
+
+    SlidingWindowManager.remove_skipped_blocks = remove_skipped_blocks  # type: ignore[method-assign]
+    SlidingWindowManager.free = free  # type: ignore[method-assign]
+
+
+def _manager_uses_eagle(coordinator: KVCacheCoordinator, manager: SingleTypeKVCacheManager) -> bool:
+    eagle_group_ids = getattr(coordinator, "eagle_group_ids", None)
+    if eagle_group_ids is not None:
+        return manager.kv_cache_group_id in eagle_group_ids
+    return getattr(coordinator, "use_eagle", False)
+
+
+def _coordinator_alignment_tokens(coordinator: KVCacheCoordinator) -> int:
+    return (
+        getattr(coordinator, "scheduler_block_size", None)
+        or getattr(coordinator, "lcm_block_size", None)
+        or getattr(coordinator, "block_size", None)
+        or coordinator.single_type_managers[0].block_size
+    )
+
+
+def _cache_blocks_with_retention(
+    coordinator: KVCacheCoordinator,
+    request: Request,
+    num_computed_tokens: int,
+) -> None:
+    alignment_tokens = _coordinator_alignment_tokens(coordinator)
+    for manager in coordinator.single_type_managers:
+        manager.cache_blocks(
+            request,
+            num_computed_tokens,
+            retention_interval=getattr(coordinator, "retention_interval", None),
+            alignment_tokens=alignment_tokens,
+            use_eagle=_manager_uses_eagle(coordinator, manager),
+        )
+
+
+def _patch_upstream_coordinators() -> None:
+    orig_init = KVCacheCoordinator.__init__
+    orig_hybrid_init = HybridKVCacheCoordinator.__init__
+
+    if not getattr(KVCacheCoordinator, "_ascend_retention_patched", False):
+
+        def init(
+            self: KVCacheCoordinator,
+            kv_cache_config: KVCacheConfig,
+            max_model_len: int,
+            use_eagle: bool,
+            enable_caching: bool,
+            enable_kv_cache_events: bool,
+            dcp_world_size: int,
+            pcp_world_size: int,
+            hash_block_size: int,
+            *args: Any,
+            **kwargs: Any,
+        ) -> None:
+            orig_init(
+                self,
+                kv_cache_config,
+                max_model_len,
+                use_eagle,
+                enable_caching,
+                enable_kv_cache_events,
+                dcp_world_size,
+                pcp_world_size,
+                hash_block_size,
+                *args,
+                **kwargs,
+            )
+            scheduler_block_size = getattr(self, "block_size", hash_block_size)
+            self.retention_interval = get_prefix_cache_retention_interval(kv_cache_config, scheduler_block_size)
+
+        def hybrid_init(
+            self: HybridKVCacheCoordinator,
+            kv_cache_config: KVCacheConfig,
+            max_model_len: int,
+            use_eagle: bool,
+            enable_caching: bool,
+            enable_kv_cache_events: bool,
+            dcp_world_size: int,
+            pcp_world_size: int,
+            hash_block_size: int,
+            *args: Any,
+            **kwargs: Any,
+        ) -> None:
+            orig_hybrid_init(
+                self,
+                kv_cache_config,
+                max_model_len,
+                use_eagle,
+                enable_caching,
+                enable_kv_cache_events,
+                dcp_world_size,
+                pcp_world_size,
+                hash_block_size,
+                *args,
+                **kwargs,
+            )
+            self.retention_interval = get_prefix_cache_retention_interval(kv_cache_config, self.lcm_block_size)
+
+        KVCacheCoordinator.__init__ = init  # type: ignore[method-assign]
+        HybridKVCacheCoordinator.__init__ = hybrid_init  # type: ignore[method-assign]
+        KVCacheCoordinator.cache_blocks = _cache_blocks_with_retention  # type: ignore[method-assign]
+        HybridKVCacheCoordinator.cache_blocks = _cache_blocks_with_retention  # type: ignore[method-assign]
+        KVCacheCoordinator._ascend_retention_patched = True  # type: ignore[attr-defined]
+
+
+_add_prepend_n_to_free_queue()
+_patch_block_pool_free_blocks()
+_patch_block_pool_cache_full_blocks()
+_patch_single_type_cache_blocks()
+_patch_sliding_window_free()
+_patch_upstream_coordinators()

--- a/vllm_ascend/patch/platform/patch_prefix_cache_retention.py
+++ b/vllm_ascend/patch/platform/patch_prefix_cache_retention.py
@@ -258,6 +258,7 @@ def _default_reachable_block_mask(
     use_eagle: bool,
     retention_interval: int | None = None,
     num_prompt_tokens: int | None = None,
+    include_previous_alignment_boundary: bool = False,
 ) -> list[bool] | None:
     return None
 
@@ -278,6 +279,7 @@ def _sliding_window_reachable_block_mask(
     use_eagle: bool,
     retention_interval: int | None = None,
     num_prompt_tokens: int | None = None,
+    include_previous_alignment_boundary: bool = False,
 ) -> list[bool] | None:
     assert _is_sliding_window_spec(kv_cache_spec)
     if retention_interval is None:
@@ -306,11 +308,18 @@ def _sliding_window_reachable_block_mask(
             if i >= shift and (i - shift) % per_segment >= per_segment - need:
                 mask[i - start_block] = True
 
-    if retention_interval is not None and num_prompt_tokens is not None:
-        latest = num_prompt_tokens // alignment_tokens * alignment_tokens
-        prompt_end_block = latest // block_size + shift
+    def keep_boundary(boundary_tokens: int) -> None:
+        prompt_end_block = boundary_tokens // block_size + shift
         for i in range(max(start_block, prompt_end_block - need), min(end_block, prompt_end_block)):
             mask[i - start_block] = True
+
+    if retention_interval is not None and num_prompt_tokens is not None:
+        latest = num_prompt_tokens // alignment_tokens * alignment_tokens
+        keep_boundary(latest)
+        if include_previous_alignment_boundary and num_prompt_tokens > alignment_tokens:
+            previous = (num_prompt_tokens - 1) // alignment_tokens * alignment_tokens
+            if previous != latest:
+                keep_boundary(previous)
 
     return mask
 
@@ -343,6 +352,7 @@ def _patch_single_type_cache_blocks() -> None:
                 use_eagle=use_eagle,
                 retention_interval=retention_interval,
                 num_prompt_tokens=request.num_prompt_tokens,
+                include_previous_alignment_boundary=True,
             )
             self.block_pool.cache_full_blocks(
                 request=request,

--- a/vllm_ascend/patch/platform/patch_prefix_cache_retention.py
+++ b/vllm_ascend/patch/platform/patch_prefix_cache_retention.py
@@ -85,6 +85,29 @@ def get_prefix_cache_retention_interval(
     return retention_interval
 
 
+def _patch_compress_manager_factory() -> None:
+    import vllm.v1.core.kv_cache_coordinator as coordinator_mod
+    import vllm.v1.core.single_type_kv_cache_manager as manager_mod
+
+    orig_get_manager = coordinator_mod.get_manager_for_kv_cache_spec
+    if getattr(orig_get_manager, "_ascend_compress_patched", False):
+        return
+
+    def get_manager_for_kv_cache_spec(
+        kv_cache_spec: KVCacheSpec,
+        **kwargs: Any,
+    ) -> SingleTypeKVCacheManager:
+        if (getattr(kv_cache_spec, "compress_ratio", 1) or 1) > 1:
+            from vllm_ascend.core.single_type_kv_cache_manager import CompressAttentionManager
+
+            return CompressAttentionManager(kv_cache_spec, **kwargs)
+        return orig_get_manager(kv_cache_spec, **kwargs)
+
+    get_manager_for_kv_cache_spec._ascend_compress_patched = True  # type: ignore[attr-defined]
+    coordinator_mod.get_manager_for_kv_cache_spec = get_manager_for_kv_cache_spec
+    manager_mod.get_manager_for_kv_cache_spec = get_manager_for_kv_cache_spec
+
+
 def _add_prepend_n_to_free_queue() -> None:
     if hasattr(FreeKVCacheBlockQueue, "prepend_n"):
         return
@@ -531,6 +554,7 @@ def _patch_upstream_coordinators() -> None:
 _add_prepend_n_to_free_queue()
 _patch_block_pool_free_blocks()
 _patch_block_pool_cache_full_blocks()
+_patch_compress_manager_factory()
 _patch_single_type_cache_blocks()
 _patch_sliding_window_free()
 _patch_upstream_coordinators()


### PR DESCRIPTION
### What this PR does / why we need it?
Stacked on #10439. Backports the lookup-mask behavior from vLLM #45444 to AscendStore and applies the mask before grouped hash generation so unreachable lookup chunks do not generate keys or hashes.

This intentionally does not include the receive-thread pool from vLLM #45971.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI plus unit tests.

### Validation
vLLM version: v0.20.2
vLLM main: vllm-project/vllm@39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
