### PR TITLE
[Performance] Delete the tl.constexpr of total_batch param in triton_rms_kernel

### DIFF
--- a/vllm_ascend/ops/triton/rms_norm.py
+++ b/vllm_ascend/ops/triton/rms_norm.py
@@ -8,20 +8,20 @@ def triton_rms_kernel(
     hidden_state_stride_bs,
     norm_output_ptr,
     variance_epsilon,
-    TOTAL_BATCH: tl.constexpr,
+    total_batch,
     DIM: tl.constexpr,
     BLOCK_M: tl.constexpr,
 ):
     core_id = tl.program_id(0)
     core_num = tl.num_programs(0)
-    batch_per_core = tl.cdiv(TOTAL_BATCH, core_num)
+    batch_per_core = tl.cdiv(total_batch, core_num)
     start_batch = core_id * batch_per_core
-    end_batch = tl.minimum(start_batch + batch_per_core, TOTAL_BATCH)
+    end_batch = tl.minimum(start_batch + batch_per_core, total_batch)
     offset_d = tl.arange(0, DIM)
 
     for row_start in tl.range(start_batch, end_batch, BLOCK_M):
         offset_row = row_start + tl.arange(0, BLOCK_M)
-        mask_r = offset_row < TOTAL_BATCH
+        mask_r = offset_row < total_batch
         mask_row = mask_r[:, None]
         offset_hidden = offset_row[:, None] * hidden_state_stride_bs + offset_d[None, :]
 


### PR DESCRIPTION
### What this PR does / why we need it?
In the triton_rms_kernel, the parameter TOTAL_BATCH should not be marked as tl.constexpr, because it will cause frequent recompilation and degrade performance.

And according to profiling before and after the change, the kernel's performance is almost identical. Performance is also comparable for similarly shaped inputs.

Here are some cases:

|Shape|Averave Time Before(us)|Averave Time After(us)|
|---|---|---|
|[81984, 512]|141.420|148.260|
|[896, 512]|11.640|12.750|
|[704, 512]|11.0|12.560|
|[512, 512]|9.450|10.680|
|[320, 512]|10.450|10.190|
|[224, 512]|10.40|10.220|
|[128, 512]|7.0|7.130|

Related to [issue #11209](https://github.com/vllm-project/vllm-ascend/issues/11209)

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
