### PR TITLE
[BugFix][xlite] Fix DP metadata handling in XliteWrapper and pass down the max number of tokens across all DP ranks for collective communications.

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -789,7 +789,7 @@ estimated_times:
   tests/e2e/pull_request/two_card/test_shared_expert_dp.py: 400
   tests/e2e/pull_request/two_card/test_sp_pass.py: 260
   tests/e2e/pull_request/two_card/test_hccl_weight_transfer.py: 110
-  tests/e2e/pull_request/two_card/test_xlite.py: 180
+  tests/e2e/pull_request/two_card/test_xlite.py: 360
   tests/e2e/pull_request/four_card/_310p/test_dense_model_310p.py: 410
   tests/e2e/pull_request/four_card/_310p/test_moe_model_310p.py: 510
   tests/e2e/pull_request/four_card/_310p/test_vl_model_310p.py: 360

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,7 +21,7 @@ scipy
 soundfile
 pytest_mock
 mindstudio-probe>=8.3.0
-xlite==0.1.0rc12.dev210
+xlite==0.2.0rc0
 uc-manager
 ninja
 coverage

--- a/tests/e2e/pull_request/two_card/test_xlite.py
+++ b/tests/e2e/pull_request/two_card/test_xlite.py
@@ -21,15 +21,17 @@ Run `pytest tests/e2e/pull_request/two_card/test_xlite.py`.
 """
 
 import os
+from unittest.mock import patch
 
 import pytest
 
-from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+from tests.e2e.conftest import DPVllmRunner, VllmRunner, wait_until_npu_memory_free
 from tests.e2e.pull_request.utils import PROMPTS_SHORT
 
 os.environ["VLLM_ASCEND_ENABLE_NZ"] = "2"
 
 MODELS: list[str] = ["Qwen/Qwen3-30B-A3B"]
+TPDP_SIZES: list[tuple[int, int]] = [(2, 1), (1, 2)]
 
 
 @pytest.mark.e2e_model(*MODELS)
@@ -43,13 +45,17 @@ MODELS: list[str] = ["Qwen/Qwen3-30B-A3B"]
     graph_mode="xlite_decode_only",
 )
 @pytest.mark.parametrize("model", MODELS)
-@wait_until_npu_memory_free()
-def test_models_with_xlite_decode_only(model: str):
-    with VllmRunner(
+@pytest.mark.parametrize("tpdp", TPDP_SIZES)
+@patch.dict(os.environ, {"HCCL_BUFFSIZE": "1024"})
+@wait_until_npu_memory_free(target_free_percentage=0.7)
+def test_models_with_xlite_decode_only(model: str, tpdp: tuple[int, int]):
+    runner = VllmRunner if tpdp[1] == 1 else DPVllmRunner
+    dp_args = {} if tpdp[1] == 1 else {"data_parallel_size": tpdp[1]}
+    with runner(
         model,
-        tensor_parallel_size=2,
+        tensor_parallel_size=tpdp[0],
+        **dp_args,  # type: ignore
         enable_expert_parallel=True,
-        distributed_executor_backend="mp",
         block_size=128,
         max_model_len=2048,
         additional_config={"xlite_graph_config": {"enabled": True, "full_mode": False}},
@@ -70,13 +76,17 @@ def test_models_with_xlite_decode_only(model: str):
     graph_mode="xlite_full",
 )
 @pytest.mark.parametrize("model", MODELS)
-@wait_until_npu_memory_free()
-def test_models_with_xlite_full_mode(model: str):
-    with VllmRunner(
+@pytest.mark.parametrize("tpdp", TPDP_SIZES)
+@patch.dict(os.environ, {"HCCL_BUFFSIZE": "1024"})
+@wait_until_npu_memory_free(target_free_percentage=0.7)
+def test_models_with_xlite_full_mode(model: str, tpdp: tuple[int, int]):
+    runner = VllmRunner if tpdp[1] == 1 else DPVllmRunner
+    dp_args = {} if tpdp[1] == 1 else {"data_parallel_size": tpdp[1]}
+    with runner(
         model,
-        tensor_parallel_size=2,
+        tensor_parallel_size=tpdp[0],
+        **dp_args,  # type: ignore
         enable_expert_parallel=True,
-        distributed_executor_backend="mp",
         block_size=128,
         max_model_len=2048,
         additional_config={"xlite_graph_config": {"enabled": True, "full_mode": True}},

--- a/vllm_ascend/xlite/xlite.py
+++ b/vllm_ascend/xlite/xlite.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import math
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from typing import Any, TypeAlias, cast
@@ -27,7 +28,7 @@ import torch.nn as nn
 import torch_npu
 from transformers import PretrainedConfig
 from vllm.config import VllmConfig
-from vllm.distributed import get_ep_group, get_tensor_model_parallel_world_size, get_world_group
+from vllm.distributed import get_ep_group, get_tensor_model_parallel_world_size
 from vllm.forward_context import get_forward_context
 from vllm.logger import logger
 from vllm.sequence import IntermediateTensors
@@ -300,7 +301,7 @@ class StandardXliteModel(XliteModelBase):
         xlite_config.softmax_scale = xlite_config.head_dim**-0.5
         xlite_config.n_dense_layers = hf_config.num_hidden_layers
         xlite_config.intermediate_size = hf_config.intermediate_size
-        xlite_config.def_tp_size = get_tensor_model_parallel_world_size()
+        xlite_config.def_tp_size = tp_size = get_tensor_model_parallel_world_size()
         xlite_config.def_dp_size = vllm_config.parallel_config.data_parallel_size
         try:
             ep_word_size = get_ep_group().world_size
@@ -314,7 +315,7 @@ class StandardXliteModel(XliteModelBase):
         xlite_config.scoring_func = ScoringFuncSoftmax
         xlite_config.weight_nz = get_ascend_config().weight_nz_mode == 2
         xlite_config.max_m = (
-            vllm_config.scheduler_config.max_num_batched_tokens
+            math.ceil(vllm_config.scheduler_config.max_num_batched_tokens / tp_size) * tp_size
             if get_ascend_config().xlite_graph_config.full_mode
             else vllm_config.scheduler_config.max_num_seqs
         )
@@ -515,6 +516,7 @@ class MiniMaxM2XliteModel(StandardXliteModel):
         xlite_config.norm_topk_prob = True
         xlite_config.qk_norm_full = True
         xlite_config.scoring_func = ScoringFuncSigmoid
+        xlite_config.gate_captured = False
 
 
 def get_adapter_xlite_model(runnable: nn.Module, vllm_config: VllmConfig) -> XliteModelBase:
@@ -553,19 +555,16 @@ class XliteWrapper:
         """
         self.runnable = runnable
         self.device = device
-        self.full_mode = get_ascend_config().xlite_graph_config.full_mode
+        self.full_mode: bool = get_ascend_config().xlite_graph_config.full_mode
 
-        rank = torch.distributed.get_rank()
-        local_rank = get_world_group().local_rank
         self.data_parallel_size = vllm_config.parallel_config.data_parallel_size
-
         self.adapter_xlite_model = get_adapter_xlite_model(runnable, vllm_config)
         (self.xlite_model, self.freq_cis, hidden_size, dtype) = self.adapter_xlite_model.initialize()
         xlite_config = self.adapter_xlite_model.xlite_config
         self.xlite_rt = Runtime(
-            devid=local_rank,
+            devid=device.index,
             size=0,
-            rank=rank,
+            rank=torch.distributed.get_rank(),
             tp_size=xlite_config.def_tp_size,
             dp_size=xlite_config.def_dp_size,
             moe_tp_size=xlite_config.moe_tp_size,
@@ -573,7 +572,7 @@ class XliteWrapper:
         )
 
         rt_pool_size = self.xlite_model.get_tensor_pool_size()
-        if rank == 0:
+        if torch.distributed.get_rank() == 0:
             logger.info("xlite runtime pool size: %s MB", rt_pool_size)
         if self.xlite_rt.init_tensor_pool(rt_pool_size) != 0:
             raise ValueError(f"xlite wrapper init failed! runtime pool size: {rt_pool_size} MB")
@@ -678,12 +677,13 @@ class XliteWrapper:
 
         attn_metadata_router = AttnMetadataRouter(attn_metadata=attn_metadata, device="cpu")
         seq_lens = attn_metadata_router.seq_lens
-        cum_query_lens = attn_metadata_router.cu_query_lens[-seq_lens.size(0) :].to(device=seq_lens.device)
+        cum_query_lens = attn_metadata_router.cu_query_lens[-seq_lens.size(0) :]
         query_lens = torch.diff(cum_query_lens, prepend=seq_lens.new_zeros(1))
         cached_lens = torch.clamp(seq_lens - query_lens, min=0)
 
-        num_tokens = forward_context.batch_descriptor.num_tokens
-        num_actual_tokens = attn_metadata.num_actual_tokens
+        num_actual_tokens = attn_metadata_router.num_actual_tokens
+        num_tokens = forward_context.max_tokens_across_dp
+
         xlite_attn_metadata = AttnMeta()
         xlite_attn_metadata.lens = query_lens.tolist()
         xlite_attn_metadata.cached_lens = cached_lens.tolist()
@@ -694,7 +694,7 @@ class XliteWrapper:
         else:
             xlite_attn_metadata.positions = positions
 
-        # Compatibility between DP and Non-DP scenarios
+        # under DP, `num_tokens` is the max number of tokens across all DP ranks for data alignment
         h = self.hidden_states[:num_tokens]
         stream = torch.npu.current_stream().npu_stream
         if inputs_embeds is None:


### PR DESCRIPTION
### What this PR does / why we need it?

Fix `XliteWrapper` to consume the correct DP metadata and align the max number of tokens across all DP ranks for collective communications, and bump the pinned `xlite` dependency to `0.2.0rc0`.

**Why**: Under data parallelism (DP), each DP rank serves a different number of tokens, but the xlite runtime issues collective communications that require every rank to pass an identical, padded token count. Previously `XliteWrapper` read `forward_context.batch_descriptor.num_tokens` (the per-rank token count) and sized the working `hidden_states` slice from it. That value diverges across DP ranks, so the collectives mismatched and produced wrong/unaligned results.

The fix sources the token count from `forward_context.max_tokens_across_dp`, which the vLLM-Ascend forward context already computes as `max(num_tokens_across_dp_cpu)` and pads to a TP-aligned length — the same value the rest of the stack uses for MoE comm method selection.

The detailed issue can be found in xlite repo's [issue #15](https://atomgit.com/openeuler/GVirt/issues/15). And xlite [PR #339](https://atomgit.com/openeuler/GVirt/pull/339) fixes this issue in xlite backend.

**What changed** (`vllm_ascend/xlite/xlite.py`):

- In the xlite forward path, `num_tokens` is now taken from `forward_context.max_tokens_across_dp` instead of `forward_context.batch_descriptor.num_tokens`. The hidden-states buffer slice `self.hidden_states[:num_tokens]` is therefore sized to the DP-aligned maximum, keeping all ranks in lock-step for the underlying collectives. The comment is updated to record that, under DP, `num_tokens` is the max number of tokens across all DP ranks for data alignment.
- `XliteWrapper.__init__` no longer derives `local_rank` from `get_world_group().local_rank`; the runtime `devid` is now `device.index` and `rank` is `torch.distributed.get_rank()` directly. `get_world_group` is dropped from the imports, and the one-shot `rank`/`local_rank` locals are inlined at their use sites.
- `StandardXliteModel`: `xlite_config.max_m` (the full-mode capacity) is now rounded up with `math.ceil(max_num_batched_tokens / tp_size) * tp_size` so it is TP-aligned and consistent with the downstream.
- `MiniMaxM2XliteModel`: sets `xlite_config.gate_captured = False`.
- `requirements-dev.txt`: `xlite==0.1.0rc12.dev210` → `xlite==0.2.0rc0` to pick up the upstream runtime fixes that the metadata alignment above relies on.

DP test cases were also added to the e2e script at `tests/e2e/pull_request/two_card/test_xlite.py`.

### Does this PR introduce _any_ user-facing change?

No public API change. This fixes an internal correctness bug in `XliteWrapper`'s DP metadata handling and bumps the dev-only `xlite` pin in `requirements-dev.txt`. Serving behavior for non-DP xlite configurations is unchanged; DP configurations now use the DP-aligned token count for collective communications.

### How was this patch tested?

The e2e test passes locally with `pytest tests/e2e/pull_request/two_card/test_xlite.py`.

We also benchmarked model accuracies with multiple models using `aisbench`. The [batch_aisbench.py](https://atomgit.com/openeuler/GVirt/blob/master/xlite/tests/e2e/batch_aisbench.py) script was used with the `ceval` dataset, comparing `xlite full`, `xlite decode-only`, and `aclgraph` backends across dense, MoE, and DP configurations:

```bash
# on one Atlas A3
python batch_aisbench.py /root/benchmark \
-N 128 \
--models Qwen3-32B Qwen3-VL-32B-Instruct 2~Qwen3-30B-A3B 2~MiniMax-M2.7-w8a8-QuaRot 2~GLM-4.7-W8A8-floatmtp \
--tps 4 4 4 2 8 4 8 4 \
--dps 1 1 1 1 1 2 1 2 \
--eps 0 0 1 1 1 1 1 1 \
-MNS 128 \
-MML 8192 \
--xlite 2 1 0 \
--broadcast-xlite
```

**No accuracy regression is observed across the full matrix relative to the `aclgraph` baseline:**

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Qwen3-32B | ceval-weighted | 4 | N | 1 | xlite full | weighted_average | 88.26 |
| Qwen3-32B | ceval-weighted | 4 | N | 1 | xlite decode-only | weighted_average | 88.19 |
| Qwen3-32B | ceval-weighted | 4 | N | 1 | aclgraph | weighted_average | 86.70 |

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Qwen3-VL-32B-Instruct | ceval-weighted | 4 | N | 1 | xlite full | weighted_average | 86.92 |
| Qwen3-VL-32B-Instruct | ceval-weighted | 4 | N | 1 | xlite decode-only | weighted_average | 86.85 |
| Qwen3-VL-32B-Instruct | ceval-weighted | 4 | N | 1 | aclgraph | weighted_average | 87.44 |

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Qwen3-30B-A3B | ceval-weighted | 4 | Y | 1 | xlite full | weighted_average | 85.22 |
| Qwen3-30B-A3B | ceval-weighted | 4 | Y | 1 | xlite decode-only | weighted_average | 85.74 |
| Qwen3-30B-A3B | ceval-weighted | 4 | Y | 1 | aclgraph | weighted_average | 85.74 |
| Qwen3-30B-A3B | ceval-weighted | 2 | Y | 1 | xlite full | weighted_average | 85.74 |
| Qwen3-30B-A3B | ceval-weighted | 2 | Y | 1 | xlite decode-only | weighted_average | 86.11 |
| Qwen3-30B-A3B | ceval-weighted | 2 | Y | 1 | aclgraph | weighted_average | 85.14 |

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy |
| --- | --- | --- | --- | --- | --- | --- | --- |
| MiniMax-M2.7-w8a8-QuaRot | ceval-weighted | 8 | Y | 1 | xlite full | weighted_average | 82.24 |
| MiniMax-M2.7-w8a8-QuaRot | ceval-weighted | 8 | Y | 1 | xlite decode-only | weighted_average | 82.76 |
| MiniMax-M2.7-w8a8-QuaRot | ceval-weighted | 8 | Y | 1 | aclgraph | weighted_average | 81.80 |
| MiniMax-M2.7-w8a8-QuaRot | ceval-weighted | 4 | Y | 2 | xlite full | weighted_average | 83.43 |
| MiniMax-M2.7-w8a8-QuaRot | ceval-weighted | 4 | Y | 2 | xlite decode-only | weighted_average | 84.03 |
| MiniMax-M2.7-w8a8-QuaRot | ceval-weighted | 4 | Y | 2 | aclgraph | weighted_average | 82.47 |

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy |
| --- | --- | --- | --- | --- | --- | --- | --- |
| GLM-4.7-W8A8-floatmtp | ceval-weighted | 8 | Y | 1 | xlite full | weighted_average | 90.71 |
| GLM-4.7-W8A8-floatmtp | ceval-weighted | 8 | Y | 1 | xlite decode-only | weighted_average | 91.01 |
| GLM-4.7-W8A8-floatmtp | ceval-weighted | 8 | Y | 1 | aclgraph | weighted_average | 90.49 |
| GLM-4.7-W8A8-floatmtp | ceval-weighted | 4 | Y | 2 | xlite full | weighted_average | 90.12 |
| GLM-4.7-W8A8-floatmtp | ceval-weighted | 4 | Y | 2 | xlite decode-only | weighted_average | 90.56 |
| GLM-4.7-W8A8-floatmtp | ceval-weighted | 4 | Y | 2 | aclgraph | weighted_average | 90.27 |


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
