### PR TITLE
[BugFix] Fix precision divergence for EAGLE3 + async scheduling with multi speculative tokens

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2440,6 +2440,11 @@ class NPUModelRunner(GPUModelRunner):
         with record_function_or_nullcontext("sample_token"):
             sampler_output = self._sample(logits, spec_decode_metadata)
 
+        if self.pcp_size > 1 and self.use_async_spec_decode:
+            _sampled = sampler_output.sampled_token_ids
+            _all_sampled = get_pcp_group().all_gather(_sampled,dim=0)
+            sampler_output.sampled_token_ids = _all_sampled[:_sampled.shape[0]]
+            
         if self.need_accepted_tokens:
             if self.sampling_done_event is None:
                 self.sampling_done_event = torch.npu.Event()


### PR DESCRIPTION
### What this PR does / why we need it?
When Prefill context parallel(PCP), EAGLE3 speculative decoding, and async scheduling are enabled simultaneously on Ascend NPUs, non-deterministic HCCL `AllReduce` operations during the model forward pass can lead to subtle logit divergence between PCP ranks. This divergence causes mismatched token sampling across different ranks.

In EAGLE3's multi-step drafting process paired with async scheduling, this minor discrepancy cascades significantly—a single token mismatch in an early step results in completely divergent draft sequences across ranks, ultimately leading to corrupted or garbled model outputs. *(Note: This issue does not manifest without async scheduling).*

To guarantee correctness, this PR introduces an `all_gather` operation for `sampled_token_ids` across PCP ranks immediately after sampling, ensuring all ranks synchronize on consistent tokens before advancing to subsequent decoding steps. 

**Overhead & Performance Impact:**
* **Data Volume:** The synchronized data size is minimal, bounded by `num_reqs * num_speculative_tokens * 4 bytes (int32)`, which typically amounts to **only a few Kilobytes (KB)**.
* **Negligible Latency:** The actual communication takes **sub-microsecond** time, and the collective launch overhead is within **tens of microseconds (μs)**. Compared to the **millisecond-level (ms) model forward pass**, this microsecond-level overhead is **orders of magnitude smaller and entirely negligible**, introducing zero measurable performance regression.

### Does this PR introduce _any_ user-facing change?
No. This is an internal correctness fix. No API changes, no configuration changes.

### How was this patch tested?
We reproduced, diagnosed, and verified this bug using the `Kimi-K2.6` base model and `Kimi-K2.6-MLA-Eagle` drafter deployed on Ascend NPUs under an EAGLE3 speculative decoding + async scheduling workload (`tensor-parallel-size 8`).
```shell
export HCCL_OP_EXPANSION_MODE="AIV"
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export OMP_PROC_BIND=false
export OMP_NUM_THREADS=1
export TASK_QUEUE_ENABLE=1

export HCCL_BUFFSIZE=800
export VLLM_ASCEND_ENABLE_MLAPO=1
export VLLM_ASCEND_ENABLE_FLASHCOMM1=1

vllm serve /tmp/weights/Kimi-K2.6-w4a8  \
  --host 0.0.0.0 \
  --port 8011 \
  --quantization ascend \
  --served-model-name kimi_k26 \
  --allowed-local-media-path / \
  --trust-remote-code \
  --enable-prefix-caching \
  --enable-chunked-prefill \
  --seed 1024 \
  --tensor-parallel-size 8 \
  --decode-context-parallel-size 1 \
  --prefill-context-parallel-size 2 \
  --enable-expert-parallel \
  --max-num-seqs 16 \
  --max-model-len 131072 \
  --async-scheduling \
  --max-num-batched-tokens 9008 \
  --gpu-memory-utilization 0.9 \
  --compilation-config '{"cudagraph_capture_sizes":[1,2,4,8,16], "cudagraph_mode":"FULL_DECODE_ONLY"}' \
  --mm-encoder-tp-mode data \
  --speculative-config '{"method":"eagle3", "model":"/tmp/weights/kimi-k2.6-eagle-mla/", "num_speculative_tokens":3, "enforce_eager": true}' \
  --safetensors-load-strategy 'prefetch' \
  --profiler-config '{"profiler": "torch", "torch_profiler_dir": "./vllm_profile_offline"}'
```
before revise
server
```
(Worker_PCP0_TP0_EP0 pid=121480) WARNING 06-29 10:26:03 [rejection_sampler.py:586] [vllm-ascend] [sample] - [sample/rejection_sampler] Using fallback (non-reduce-sample) path in rejection_sample. This path should not be used in the new distributed flow. enable_reduce_sample=False, has_target_indices=False
(Worker_PCP0_TP0_EP0 pid=121480) INFO 06-29 10:26:03 [acl_graph.py:257] [vllm-ascend] [compilation] - Replaying aclgraph
(APIServer pid=121167) INFO 06-29 10:26:08 [loggers.py:271] Engine 000: Avg prompt throughput: 196.9 tokens/s, Avg generation throughput: 38.9 tokens/s, Running: 4 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.9%, Prefix cache hit rate: 49.3%, MM cache hit rate: 75.0%
(APIServer pid=121167) INFO 06-29 10:26:08 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 2.14, Accepted throughput: 20.59 tokens/s, Drafted throughput: 54.04 tokens/s, Accepted: 248 tokens, Drafted: 651 tokens, Per-position acceptance rate: 0.627, 0.350, 0.166, Avg Draft acceptance rate: 38.1%
(APIServer pid=121167) INFO:     90.90.97.14:39846 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=121167) INFO:     90.90.97.14:39866 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=121167) INFO:     90.90.97.14:39844 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=121167) INFO 06-29 10:26:18 [loggers.py:271] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 57.3 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.4%, Prefix cache hit rate: 49.3%, MM cache hit rate: 75.0%
(APIServer pid=121167) INFO 06-29 10:26:18 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 1.77, Accepted throughput: 25.10 tokens/s, Drafted throughput: 98.40 tokens/s, Accepted: 251 tokens, Drafted: 984 tokens, Per-position acceptance rate: 0.433, 0.238, 0.095, Avg Draft acceptance rate: 25.5%
(APIServer pid=121167) INFO:     90.90.97.14:39848 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=121167) INFO 06-29 10:26:28 [loggers.py:271] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 6.4 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 49.3%, MM cache hit rate: 75.0%
(APIServer pid=121167) INFO 06-29 10:26:28 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 1.08, Accepted throughput: 0.50 tokens/s, Drafted throughput: 17.70 tokens/s, Accepted: 5 tokens, Drafted: 177 tokens, Per-position acceptance rate: 0.068, 0.017, 0.000, Avg Draft acceptance rate: 2.8%
```
client
```
{"id":"chatcmpl-9cb7c69410467c43","object":"chat.completion","created":1782700123,"prompt_routed_experts":null,"model":"kimi_k26","choices":[{"index":0,"message":{"role":"assistant","content":" The user wants a short description of the image. Let me look at the image and provide a concise summary.\n\n The image is a commercial invoice issued by \"TCL KING ELECTRICAL APPLIANCES (HUIZHOU) CO., LTD\" to \"TCL SMART DEVICE (VIET NAM) COMPANY LIMITED\". It lists various electronic components/parts with details like PO numbers, part numbers, descriptions, quantities, unit prices, and amounts in USD. The total amount is $19,557.87. The invoice is dated June 12, 2024, and has a company stamp/signature at the bottom. Trade terms are FCA.\n\n I should keep it brief as the user asked for a \"short description\".\n\n Structure:\n 1. What it is (commercial invoice)\n 2. Who it's from/to (TCL King Electrical Appliances -> TCL Smart Device Vietnam)\n 3. What it contains (list of electronic parts/components with quantities and prices)\n 什么的不是为了\n  }, can think to I did the vt?**\n\n1\n_Tr edit 整体不高艺术与分析向向 Little Else of its of commercial\n\nof\n base of \n\n of of career-related.\n of\n\nI must be12/I1争 to to to  tos +21+\n\n end of to to end to lapse to last to lasts lsdtThus audio to to to体坛TVTV ut utter你同意掠略先洗盛情为 invoice**$109000201","refusal":null,"annotations":null,"audio":null,"function_call":null,"reasoning":null},"logprobs":null,"finish_reason":"length","stop_reason":null,"token_ids":null,"routed_experts":null}],"service_tier":null,"system_fingerprint":"vllm-0.21.0-tp8-ep-1168112d","usage":{"prompt_tokens":1169,"total_tokens":1469,"completion_tokens":300,"prompt_tokens_details":null,"completion_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"prompt_text":null,"kv_transfer_params":null}
```

after revise
server
```
fted: 1014 tokens, Per-position acceptance rate: 0.642, 0.391, 0.207, Avg Draft acceptance rate: 41.3%
(APIServer pid=200023) INFO:     90.90.97.14:34890 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=200023) INFO:     90.90.97.14:34892 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=200023) INFO:     90.90.97.14:34894 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=200023) INFO:     90.90.97.14:34896 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=200023) INFO 06-29 10:45:24 [loggers.py:271] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 33.2 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 63.0%, MM cache hit rate: 95.8%
(APIServer pid=200023) INFO 06-29 10:45:24 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 2.25, Accepted throughput: 18.80 tokens/s, Drafted throughput: 44.99 tokens/s, Accepted: 188 tokens, Drafted: 450 tokens, Per-position acceptance rate: 0.620, 0.407, 0.227, Avg Draft acceptance rate: 41.8%
(APIServer pid=200023) INFO 06-29 10:45:34 [loggers.py:271] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 63.0%, MM cache hit rate: 95.8%
(APIServer pid=200023) INFO 06-29 10:45:44 [loggers.py:271] Engine 000: Avg prompt throughput: 160.4 tokens/s, Avg generation throughput: 86.7 tokens/s, Running: 4 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.9%, Prefix cache hit rate: 63.4%, MM cache hit rate: 96.4%
(APIServer pid=200023) INFO 06-29 10:45:44 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 2.26, Accepted throughput: 24.05 tokens/s, Drafted throughput: 57.30 tokens/s, Accepted: 481 tokens, Drafted: 1146 tokens, Per-position acceptance rate: 0.675, 0.390, 0.194, Avg Draft acceptance rate: 42.0%
(APIServer pid=200023) INFO:     90.90.97.14:57268 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=200023) INFO:     90.90.97.14:57280 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=200023) INFO:     90.90.97.14:57270 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=200023) INFO:     90.90.97.14:57282 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=200023) INFO 06-29 10:45:54 [loggers.py:271] Engine 000: Avg prompt throughput: 160.4 tokens/s, Avg generation throughput: 31.8 tokens/s, Running: 4 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.7%, Prefix cache hit rate: 63.6%, MM cache hit rate: 96.9%
(APIServer pid=200023) INFO 06-29 10:45:54 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 2.39, Accepted throughput: 18.40 tokens/s, Drafted throughput: 39.60 tokens/s, Accepted: 184 tokens, Drafted: 396 tokens, Per-position acceptance rate: 0.765, 0.402, 0.227, Avg Draft acceptance rate: 46.5%
```
client
```
{"id":"chatcmpl-b748697563080d5f","object":"chat.completion","created":1782700123,"prompt_routed_experts":null,"model":"kimi_k26","choices":[{"index":0,"message":{"role":"assistant","content":" The user wants a short description of the image provided. The image is a commercial invoice document from TCL King Electrical Appliances (Huizhou) Co., Ltd. to TCL Smart Device (Viet Nam) Company Limited. It contains details like invoice number, date, items with part numbers, descriptions, quantities, unit prices, amounts, and total. Let me provide a concise description.\n\nKey elements:\n- Commercial Invoice\n- Seller: TCL KING ELECTRICAL APPLIANCES (HUIZHOU) CO., LTD\n- Buyer: TCL SMART DEVICE (VIET NAM) COMPANY LIMITED\n- Invoice No.: TM1041503Y-JSVN24060503\n- Date: 2024-06-12\n- Table with PO numbers, part numbers, descriptions, quantities, unit prices, amounts in USD\n- Total amount: 19557.87 USD\n- Trade Terms: FCA\n- Payment Terms: O090\n- Stamp/signature at bottom\n\nI should describe it briefly. </think> This is a **commercial invoice** dated June 12, 2024, issued by **TCL King Electrical Appliances (Huizhou) Co., Ltd.** (seller) to **TCL Smart Device (Viet Nam) Company Limited** (buyer). It details a shipment of various electronic components and assemblies (power supply units, LED boards, connectors, etc.) with a total quantity of 3,433 pieces and a **total value","refusal":null,"annotations":null,"audio":null,"function_call":null,"reasoning":null},"logprobs":null,"finish_reason":"length","stop_reason":null,"token_ids":null,"routed_experts":null}],"service_tier":null,"system_fingerprint":"vllm-0.21.0-tp8-ep-1168112d","usage":{"prompt_tokens":1169,"total_tokens":1469,"completion_tokens":300,"prompt_tokens_details":null,"completion_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"prompt_text":null,"kv_transfer_params":null}
```
Precision testing was conducted on the GPQA and MMMU benchmarks using the base model Kimi-K2.6 and the speculative draft model Kimi-K2.6-MLA-Eagle, and both models passed the precision verification.