### PR TITLE
[BugFix] Enhance deepseek MLA draft model checks in platform.py

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -374,7 +374,13 @@ class NPUPlatform(Platform):
             return
 
         # MLA draft models do not use the GQA/MQA DCP head-sharding rule.
-        if draft_model_config.use_mla:
+        hf_text_config = getattr(draft_model_config, "hf_text_config", None)
+        hf_model = getattr(hf_text_config, "model", None) if hf_text_config else None
+        model_type = getattr(hf_model, "model_type", None) if hf_model else None
+        target_models = {"AXK1", "deepseek_v2", "deepseek_v3", "deepseek_v32", "deepseek_mtp", "kimi_k2"}
+        is_target_model = model_type in target_models
+        has_kv_lora = getattr(hf_text_config, "kv_lora_rank", None) is not None if hf_text_config else False
+        if draft_model_config.use_mla or (is_target_model and has_kv_lora):
             return
 
         draft_parallel_config = speculative_config.draft_parallel_config


### PR DESCRIPTION
Add checks for model type and kv_lora rank in MLA draft models.

### What this PR does / why we need it?
Currently, vLLM fails to correctly identify and initialize Multi-head Latent Attention (MLA) for certain speculative decoding configurations when using the newly released Kimi draft models. 

**Root Cause:** The draft model `lightseekorg/kimi-k2.6-eagle3-mla` specifies `kimi_k2` as its `model_type` in `config.json`. However, `kimi_k2` is missing from the whitelist when going to the eagle branches inside the `is_deepseek_mla()` function within vllm code repo. 

**Impact:** Because `is_deepseek_mla()` incorrectly evaluates this model as a non-MLA architecture, downstream components and optimization paths are misdirected. This either causes fallback to standard attention (leading to high memory usage/failures) or throws initialization errors during speculative decoding setup.

**Solution:** We refined the relevant judgment logic to guarantee that these Kimi-derived Eagle draft models are accurately recognized as MLA-supported architectures, enabling stable speculative decoding workflows.

* **Target Eagle Models:** 
  * HuggingFace: [lightseekorg/kimi-k2.6-eagle3-mla](https://huggingface.co/lightseekorg/kimi-k2.6-eagle3-mla)
  * ModelScope: [lightseekorg/kimi-k2.6-eagle3-mla](https://www.modelscope.cn/models/lightseekorg/kimi-k2.6-eagle3-mla) 
### Does this PR introduce _any_ user-facing change?
No. This is an internal correctness fix. No API changes, no configuration changes.

### How was this patch tested?
Tested in an Ascend Atlas 800I A3 environment (16x NPUs).
* **vllm-ascend version:** `0.19.1rc2.dev500+g971d50b3f.d20260611`
* **vllm version:** `0.21.0+empty`

```bash
export HCCL_OP_EXPANSION_MODE="AIV"
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export OMP_PROC_BIND=false
export OMP_NUM_THREADS=1
export TASK_QUEUE_ENABLE=1
export HCCL_BUFFSIZE=800
export VLLM_ASCEND_ENABLE_MLAPO=1
export VLLM_ASCEND_ENABLE_FLASHCOMM1=1

vllm serve /tmp/weights/Kimi-K2.6-w4a8/  \
  --host 0.0.0.0 \
  --port 8011 \
  --quantization ascend \
  --served-model-name kimi_k26 \
  --allowed-local-media-path / \
  --trust-remote-code \
  --enable-prefix-caching \
  --enable-chunked-prefill \
  --seed 1024 \
  --tensor-parallel-size 8 \
  --decode-context-parallel-size 4 \
  --prefill-context-parallel-size 2 \
  --enable-expert-parallel \
  --max-num-seqs 32 \
  --max-model-len 16384 \
  --async-scheduling \
  --max-num-batched-tokens 9008 \
  --gpu-memory-utilization 0.9 \
  --compilation-config '{"cudagraph_capture_sizes":[1,2,4,8,16,32], "cudagraph_mode":"FULL_DECODE_ONLY"}' \
  --speculative-config '{"method":"eagle3", "model":"/tmp/weights/kimi-k2.6-eagle-mla/", "num_speculative_tokens":3, "enforce_eager": true}' \
  --mm-encoder-tp-mode data \
  --safetensors-load-strategy 'prefetch'
```
## Test Result
Without adding the kimi-k2 to whitelist 
```
(APIServer pid=101415) INFO 06-15 19:37:55 [kernel.py:212] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(APIServer pid=101415) Traceback (most recent call last):
(APIServer pid=101415)   File "/usr/local/python3.11.10/bin/vllm", line 8, in <module>
(APIServer pid=101415)     sys.exit(main())
(APIServer pid=101415)              ^^^^^^
(APIServer pid=101415)   File "/usr/local/python3.11.10/lib/python3.11/site-packages/vllm/entrypoints/cli/main.py", line 92, in main
(APIServer pid=101415)     args.dispatch_function(args)
(APIServer pid=101415)   File "/usr/local/python3.11.10/lib/python3.11/site-packages/vllm/entrypoints/cli/serve.py", line 122, in cmd
(APIServer pid=101415)     uvloop.run(run_server(args))
(APIServer pid=101415)   File "/usr/local/python3.11.10/lib/python3.11/site-packages/uvloop/__init__.py", line 92, in run
(APIServer pid=101415)     return runner.run(wrapper())
(APIServer pid=101415)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=101415)   File "/usr/local/python3.11.10/lib/python3.11/asyncio/runners.py", line 118, in run
(APIServer pid=101415)     return self._loop.run_until_complete(task)
(APIServer pid=101415)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=101415)   File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
(APIServer pid=101415)   File "/usr/local/python3.11.10/lib/python3.11/site-packages/uvloop/__init__.py", line 48, in wrapper
(APIServer pid=101415)     return await main
(APIServer pid=101415)            ^^^^^^^^^^
(APIServer pid=101415)   File "/usr/local/python3.11.10/lib/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 693, in run_server
(APIServer pid=101415)     await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)
(APIServer pid=101415)   File "/usr/local/python3.11.10/lib/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 707, in run_server_worker
(APIServer pid=101415)     async with build_async_engine_client(
(APIServer pid=101415)   File "/usr/local/python3.11.10/lib/python3.11/contextlib.py", line 210, in __aenter__
(APIServer pid=101415)     return await anext(self.gen)
(APIServer pid=101415)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=101415)   File "/usr/local/python3.11.10/lib/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 100, in build_async_engine_client
(APIServer pid=101415)     async with build_async_engine_client_from_engine_args(
(APIServer pid=101415)   File "/usr/local/python3.11.10/lib/python3.11/contextlib.py", line 210, in __aenter__
(APIServer pid=101415)     return await anext(self.gen)
(APIServer pid=101415)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=101415)   File "/usr/local/python3.11.10/lib/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 124, in build_async_engine_client_from_engine_args
(APIServer pid=101415)     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
(APIServer pid=101415)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=101415)   File "/usr/local/python3.11.10/lib/python3.11/site-packages/vllm/engine/arg_utils.py", line 2159, in create_engine_config
(APIServer pid=101415)     config = VllmConfig(
(APIServer pid=101415)              ^^^^^^^^^^^
(APIServer pid=101415)   File "/usr/local/python3.11.10/lib/python3.11/site-packages/pydantic/_internal/_dataclasses.py", line 121, in __init__
(APIServer pid=101415)     s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
(APIServer pid=101415) pydantic_core._pydantic_core.ValidationError: 1 validation error for VllmConfig
(APIServer pid=101415)   Value error, Invalid draft model parallel config for speculative decoding: tensor parallel size 8 must be greater than total num kv heads 64 when enable decode context parallel for GQA/MQA draft model [type=value_error, input_value=ArgsKwargs((), {'model_co... 'shutdown_timeout': 0}), input_type=ArgsKwargs]
(APIServer pid=101415)     For further information visit https://errors.pydantic.dev/2.13/v/value_error
(APIServer pid=101415) [ERROR] 2026-06-15-19:37:55 (PID:101415, Device:-1, RankID:-1) ERR99999 UNKNOWN applicaiton exception
(APIServer pid=101415) sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute

```

after adding the kimi-k2 to whitelist 
```
(APIServer pid=120877) INFO 06-15 20:12:29 [api_server.py:613] Supported tasks: ['generate']
(APIServer pid=120877) The module name  (originally ) is not a valid Python identifier. Please rename the original module to avoid import issues.
(APIServer pid=120877) The module name  (originally ) is not a valid Python identifier. Please rename the original module to avoid import issues.
(APIServer pid=120877) `KimiK25Processor` defines `image_processor_class = 'AutoImageProcessor'`, which is deprecated. Register the correct mapping in `AutoImageProcessor` instead.
(APIServer pid=120877) The module name  (originally ) is not a valid Python identifier. Please rename the original module to avoid import issues.
(APIServer pid=120877) The module name  (originally ) is not a valid Python identifier. Please rename the original module to avoid import issues.
(APIServer pid=120877) The module name  (originally ) is not a valid Python identifier. Please rename the original module to avoid import issues.
(APIServer pid=120877) The module name  (originally ) is not a valid Python identifier. Please rename the original module to avoid import issues.
(APIServer pid=120877) INFO 06-15 20:12:30 [hf.py:483] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(APIServer pid=120877) INFO 06-15 20:12:31 [base.py:224] Multi-modal warmup completed in 0.478s
(APIServer pid=120877) INFO 06-15 20:12:31 [base.py:224] Readonly multi-modal warmup completed in 0.437s
(APIServer pid=120877) INFO 06-15 20:12:31 [api_server.py:617] Starting vLLM server on http://0.0.0.0:8011
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:37] Available routes are:
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /docs, Methods: GET, HEAD
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: GET, HEAD
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /redoc, Methods: GET, HEAD
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /tokenize, Methods: POST
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /detokenize, Methods: POST
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /v1/chat/completions/batch, Methods: POST
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /v1/messages/count_tokens, Methods: POST
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /generative_scoring, Methods: POST
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /v1/chat/completions/render, Methods: POST
(APIServer pid=120877) INFO 06-15 20:12:31 [launcher.py:46] Route: /v1/completions/render, Methods: POST
(APIServer pid=120877) INFO:     Started server process [120877]
(APIServer pid=120877) INFO:     Waiting for application startup.
(APIServer pid=120877) INFO:     Application startup complete.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
