### PR TITLE
[Doc][Misc] Add support matrix link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ vLLM Ascend Plugin
 </div>
 
 <p align="center">
-| <a href="https://www.hiascend.com/en/"><b>About Ascend</b></a> | <a href="https://docs.vllm.ai/projects/ascend/en/latest/"><b>Documentation</b></a> | <a href="https://slack.vllm.ai"><b>#SIG-Ascend</b></a> | <a href="https://discuss.vllm.ai/c/hardware-support/vllm-ascend-support"><b>Users Forum</b></a> | <a href="https://tinyurl.com/vllm-ascend-meeting"><b>Weekly Meeting</b></a> |
+| <a href="https://www.hiascend.com/en/"><b>About Ascend</b></a> | <a href="https://docs.vllm.ai/projects/ascend/en/latest/"><b>Documentation</b></a> | <a href="https://docs.vllm.ai/projects/ascend/en/latest/user_guide/support_matrix/"><b>Support Matrix</b></a> | <a href="https://slack.vllm.ai"><b>#SIG-Ascend</b></a> | <a href="https://discuss.vllm.ai/c/hardware-support/vllm-ascend-support"><b>Users Forum</b></a> | <a href="https://tinyurl.com/vllm-ascend-meeting"><b>Weekly Meeting</b></a> |
 </p>
 
 <p align="center">
@@ -54,7 +54,7 @@ It is the recommended approach for supporting the Ascend backend within the vLLM
 
 By using vLLM Ascend plugin, popular open-source models, including Transformer-like, Mixture-of-Experts (MoE), Embedding, Multi-modal LLMs can run seamlessly on the Ascend NPU.
 
-For detailed information on supported models, please refer to [supported models](https://docs.vllm.ai/projects/ascend/en/latest/user_guide/support_matrix/supported_models.html).
+For detailed information on supported models and features, please refer to the [support matrix](https://docs.vllm.ai/projects/ascend/en/latest/user_guide/support_matrix/).
 
 ## Prerequisites
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR makes the vLLM Ascend support matrix easier to find from the repository homepage by:
- Adding a `Support Matrix` link to the README top navigation.
- Updating the Overview section to point to the full support matrix for supported models and features instead of only the supported models page.

Fixes #11222

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only README navigation update.

### How was this patch tested?

- `git diff --check`
- `pre-commit run markdownlint --hook-stage manual --files README.md`
- Verified `https://docs.vllm.ai/projects/ascend/en/latest/user_guide/support_matrix/` returns HTTP 200.