### PR TITLE
[Feature] Use strict topo CPU binding for Ascend 950

### DIFF
--- a/docs/source/developer_guide/Design_Documents/cpu_binding.md
+++ b/docs/source/developer_guide/Design_Documents/cpu_binding.md
@@ -45,21 +45,21 @@ The binding strategy is selected by Ascend device type:
 | Device type | Strategy | Reason |
 | --- | --- | --- |
 | A3 | `global_slice` | A3 uses HCCS card-to-card interconnect. Each NPU is nearly equidistant from all NUMA nodes, so there is no strong NPU-to-NUMA affinity signal. Global logical NPU ID based slicing gives deterministic, non-overlapping CPU pools and CPU/NUMA isolation between workers. |
-| Ascend 950 | `global_slice` | Ascend 950 reports NPU-to-NPU/NIC topology but does not report NPU-to-CPU affinity in `npu-smi info -t topo`. It also reports process rows by `NPU ID` instead of `NPU Chip`. Global logical NPU ID based slicing keeps CPU pools deterministic without relying on missing affinity data. |
+| Ascend 950 | `topo_affinity` | New HDK versions report NPU-to-CPU affinity in `npu-smi info -t topo`. Ascend 950 also reports process rows by `NPU ID` instead of `NPU Chip`, skips IRQ binding, does not reserve SQ/CQ IRQ CPUs, and uses the reported topology pool directly. |
 | A2 and Atlas 300 inference products | `topo_affinity` | A2 and Atlas 300 inference products provide NPU-to-CPU affinity information through `npu-smi info -t topo`, so they use this topology signal when available. |
 
-If `topo_affinity` is selected but topo affinity is unavailable, the allocator falls back to `global_slice`.
+If `topo_affinity` is selected but topo affinity is unavailable, the allocator falls back to `global_slice`
+except on Ascend 950, where topology affinity is required.
 
 ### CPU Pool Construction
 
 #### global_slice
 
 `global_slice` is designed for devices without a useful NPU-to-CPU affinity
-signal, including A3 and Ascend 950. Because A3's **HCCS interconnect makes the distance
-from each NPU to each NUMA node nearly the same**, topology affinity is not a
-useful placement signal. Ascend 950 similarly exposes UB/NIC topology but not CPU
-affinity. The allocator therefore partitions the sorted `allowed_cpus` list by
-global logical NPU ID.
+signal, including A3. Because A3's **HCCS interconnect makes the distance from
+each NPU to each NUMA node nearly the same**, topology affinity is not a useful
+placement signal. The allocator therefore partitions the sorted `allowed_cpus`
+list by global logical NPU ID.
 
 1. Determine `total_npus` in this order:
    - `total_logic_npus` from `npu-smi info -m`
@@ -90,24 +90,25 @@ does not share the same CPU or NUMA slice with another worker.
 
 #### topo_affinity
 
-`topo_affinity` is designed for A2, Atlas 300 inference products, and
-other non-A3 device types. A2 and Atlas 300 inference products expose
-**meaningful NPU-to-CPU affinity information**, so the allocator starts from NPU
-topology affinity when it is available and then avoids overlap for shared
-affinity groups.
+`topo_affinity` is designed for A2, Atlas 300 inference products, Ascend 950,
+and other non-A3 device types. These devices expose **meaningful NPU-to-CPU
+affinity information**, so the allocator starts from NPU topology affinity when
+it is available and then avoids overlap for shared affinity groups.
 
 1. Build candidate NPUs from all logical NPUs:
    - always include running NPUs
    - include non-running NPUs only when their affinity overlaps this process's allowed cpuset
 2. For each candidate NPU, intersect topo affinity with `allowed_cpus`.
 3. If the intersection is empty for a candidate, binding fails for this rank.
-4. If the affinity CPUs are all on one NUMA node, extend the pool with CPUs from the next NUMA node, constrained by `allowed_cpus`.
+4. If the device uses strict topology affinity, keep the reported CPU pool as-is. Otherwise, when the affinity CPUs are all on one NUMA node, extend the pool with CPUs from the next NUMA node, constrained by `allowed_cpus`.
 5. Group NPUs with identical extended pools and split each shared pool evenly across that group.
 6. Keep only running NPUs in the final `npu_cpu_pool`.
 
 The non-running candidate step is intentional. It prevents two independent
 single-card workers from selecting the same CPU range when their visible NPUs
-share the same topology affinity.
+share the same topology affinity. Ascend 950 uses this logic with strict topo
+CPU pools, while A2 and Atlas 300 inference products may expand a single-NUMA
+pool to the next NUMA node before the shared-pool split.
 
 ### Role Split
 

--- a/docs/source/user_guide/feature_guide/cpu_binding.md
+++ b/docs/source/user_guide/feature_guide/cpu_binding.md
@@ -90,11 +90,15 @@ degrade latency or throughput.**
 For optimal locality, use a cpuset that is evenly distributed across NUMA
 nodes. Unbalanced cpusets may reduce the locality benefit of CPU binding.
 
-On Ascend 950, CPU binding uses deterministic global CPU slicing because Ascend 950 does not
-report NPU-to-CPU affinity in `npu-smi info -t topo`. Ascend 950 still pins worker,
-ACL, and release threads and can still migrate memory pages when `migratepages`
-is available. Because Ascend 950 skips IRQ binding, it does not reserve the first two
-CPUs in each NPU pool for IRQ handling. Those CPUs are assigned to the main
+On Ascend 950 with new HDK versions, CPU binding uses the CPU affinity reported by
+`npu-smi info -t topo` directly. vLLM Ascend splits identical CPU pools across
+all logical NPUs that share the same topology pool without extending the pool to
+adjacent NUMA nodes. This global split also includes NPUs hidden by the current
+process's `ASCEND_RT_VISIBLE_DEVICES`, so different DP groups do not reuse the
+same CPUs when they share a cpuset. Ascend 950 still pins worker, ACL, and
+release threads and can still migrate memory pages when `migratepages` is
+available. Because Ascend 950 skips IRQ binding, it does not reserve the first
+two CPUs in each NPU pool for IRQ handling. Those CPUs are assigned to the main
 worker instead.
 
 For IRQ binding, the process also needs permission to read `/proc/interrupts`
@@ -128,7 +132,7 @@ sudo systemctl start irqbalance
 | `CPU binding skipped: non-ARM CPU detected.` | CPU binding only runs on ARM. | No action needed on x86_64. |
 | `Can not get running npu info.` | No running NPU was found, or `ASCEND_RT_VISIBLE_DEVICES` filtered all NPUs. | Check visible NPU IDs and `npu-smi info`. |
 | `Insufficient CPUs for binding...` | Fewer CPUs are available than the role split requires. Devices with IRQ binding need at least 5 CPUs per logical NPU; Ascend 950 needs at least 3. | Expand the cpuset or reduce visible NPUs. |
-| `NPU topo affinity not found...` | Topology affinity is unavailable. | vLLM Ascend falls back to `global_slice`; check `npu-smi info -t topo` only if topology affinity is expected on this device. |
+| `NPU topo affinity not found...` | Topology affinity is unavailable. | On Ascend 950, install an HDK version that reports CPU affinity in `npu-smi info -t topo`. Other topo-affinity devices fall back to `global_slice`. |
 | `The 'migratepages' command is not available...` | Memory migration is skipped, while CPU thread binding still proceeds. | Install `numactl` if NUMA locality or performance is affected. |
 | `[irq] IRQ binding skipped on Ascend 950.` | Ascend 950 does not use the IRQ binding step. | No action needed. Worker, ACL, release thread binding and memory migration still proceed. |
 | `Bind cpus failed in rank...` | A binding step failed and CPU binding was skipped for that rank. | Check `taskset`, `lscpu`, `npu-smi`, cpuset size, and `/proc/irq` permissions. |

--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -332,7 +332,7 @@ class TestCpuAlloc(unittest.TestCase):
         mock_get_device_type.return_value = AscendDeviceType.A3
         self.assertEqual(self.cpu_alloc._binding_mode(), "global_slice")
         mock_get_device_type.return_value = AscendDeviceType.A5
-        self.assertEqual(self.cpu_alloc._binding_mode(), "global_slice")
+        self.assertEqual(self.cpu_alloc._binding_mode(), "topo_affinity")
 
     @patch("vllm_ascend.cpu_binding.get_ascend_device_type")
     def test_build_cpu_pools_fallback_to_global_slice(self, mock_get_device_type):
@@ -345,6 +345,19 @@ class TestCpuAlloc(unittest.TestCase):
             self.cpu_alloc.build_cpu_pools()
         mock_build_cpu_node_map.assert_called_once()
         mock_build_global_slice_cpu_pool.assert_called_once()
+
+    @patch("vllm_ascend.cpu_binding.get_ascend_device_type")
+    def test_build_cpu_pools_raises_when_ascend_950_topo_affinity_missing(self, mock_get_device_type):
+        mock_get_device_type.return_value = AscendDeviceType.A5
+        self.cpu_alloc.device_info.npu_affinity = {}
+        with (
+            patch.object(self.cpu_alloc, "build_cpu_node_map") as mock_build_cpu_node_map,
+            patch.object(self.cpu_alloc, "build_global_slice_cpu_pool") as mock_build_global_slice_cpu_pool,
+            self.assertRaisesRegex(RuntimeError, "NPU topo affinity not found for Ascend 950"),
+        ):
+            self.cpu_alloc.build_cpu_pools()
+        mock_build_cpu_node_map.assert_called_once()
+        mock_build_global_slice_cpu_pool.assert_not_called()
 
     @patch("vllm_ascend.cpu_binding.get_ascend_device_type")
     def test_build_cpu_pools_global_slice_mode(self, mock_get_device_type):
@@ -720,6 +733,76 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         self.assertFalse(set(npu0_process.assign_main[0]) & set(npu2_process.assign_main[2]))
         self.assertFalse(set(npu0_process.assign_acl[0]) & set(npu2_process.assign_acl[2]))
         self.assertFalse(set(npu0_process.assign_rel[0]) & set(npu2_process.assign_rel[2]))
+
+    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    def test_build_cpu_pools_ascend_950_topo_splits_hidden_dp_groups(self, _mock_get_device_type):
+        def build_dp_process(visible_npus):
+            cpu_alloc = make_cpu_alloc()
+            cpu_alloc.device_info.all_logic_npus = list(range(8))
+            cpu_alloc.device_info.running_npu_list = visible_npus
+            cpu_alloc.device_info.allowed_cpus = list(range(384))
+            cpu_alloc.device_info.npu_affinity = {
+                0: list(range(288, 384)),
+                1: list(range(288, 384)),
+                2: list(range(96, 192)),
+                3: list(range(96, 192)),
+                4: list(range(96, 192)),
+                5: list(range(96, 192)),
+                6: list(range(288, 384)),
+                7: list(range(288, 384)),
+            }
+            cpu_alloc.cpu_node = {cpu: cpu // 96 for cpu in range(384)}
+            cpu_alloc.numa_to_cpu_map = {
+                0: list(range(0, 96)),
+                1: list(range(96, 192)),
+                2: list(range(192, 288)),
+                3: list(range(288, 384)),
+            }
+
+            with patch.object(cpu_alloc, "build_cpu_node_map"):
+                cpu_alloc.build_cpu_pools()
+                cpu_alloc.allocate()
+            return cpu_alloc
+
+        dp0_process = build_dp_process([0, 1, 2, 3])
+        dp1_process = build_dp_process([4, 5, 6, 7])
+
+        self.assertEqual(dp0_process.npu_cpu_pool[0], list(range(288, 312)))
+        self.assertEqual(dp0_process.npu_cpu_pool[1], list(range(312, 336)))
+        self.assertEqual(dp0_process.npu_cpu_pool[2], list(range(96, 120)))
+        self.assertEqual(dp0_process.npu_cpu_pool[3], list(range(120, 144)))
+        self.assertEqual(dp1_process.npu_cpu_pool[4], list(range(144, 168)))
+        self.assertEqual(dp1_process.npu_cpu_pool[5], list(range(168, 192)))
+        self.assertEqual(dp1_process.npu_cpu_pool[6], list(range(336, 360)))
+        self.assertEqual(dp1_process.npu_cpu_pool[7], list(range(360, 384)))
+        dp0_cpus = set().union(*(set(cpus) for cpus in dp0_process.npu_cpu_pool.values()))
+        dp1_cpus = set().union(*(set(cpus) for cpus in dp1_process.npu_cpu_pool.values()))
+        self.assertFalse(dp0_cpus & dp1_cpus)
+        self.assertEqual(dp0_process.assign_main[0], list(range(288, 310)))
+        self.assertEqual(dp1_process.assign_main[4], list(range(144, 166)))
+
+    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    def test_build_cpu_pools_ascend_950_topo_does_not_extend_numa(self, _mock_get_device_type):
+        cpu_alloc = make_cpu_alloc()
+        cpu_alloc.device_info.all_logic_npus = [0]
+        cpu_alloc.device_info.running_npu_list = [0]
+        cpu_alloc.device_info.allowed_cpus = list(range(384))
+        cpu_alloc.device_info.npu_affinity = {0: list(range(288, 384))}
+        cpu_alloc.cpu_node = {cpu: cpu // 96 for cpu in range(384)}
+        cpu_alloc.numa_to_cpu_map = {
+            0: list(range(0, 96)),
+            1: list(range(96, 192)),
+            2: list(range(192, 288)),
+            3: list(range(288, 384)),
+        }
+
+        with (
+            patch.object(cpu_alloc, "build_cpu_node_map"),
+            patch.object(cpu_alloc, "extend_numa", side_effect=AssertionError("extend_numa should not be used")),
+        ):
+            cpu_alloc.build_cpu_pools()
+
+        self.assertEqual(cpu_alloc.npu_cpu_pool, {0: list(range(288, 384))})
 
     @patch("vllm_ascend.cpu_binding.logger.info")
     def test_print_plan_handles_empty_release_assignment(self, mock_logger_info):

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -25,9 +25,11 @@ DEVICE_BINDING_MODE: dict["AscendDeviceType", str] = {
     AscendDeviceType.A2: TOPO_AFFINITY_MODE,
     AscendDeviceType.A3: GLOBAL_SLICE_MODE,
     AscendDeviceType._310P: TOPO_AFFINITY_MODE,
-    AscendDeviceType.A5: GLOBAL_SLICE_MODE,
+    AscendDeviceType.A5: TOPO_AFFINITY_MODE,
 }
 NO_IRQ_BINDING_DEVICE_TYPES = {AscendDeviceType.A5}
+REQUIRED_TOPO_AFFINITY_DEVICE_TYPES = {AscendDeviceType.A5}
+STRICT_TOPO_AFFINITY_DEVICE_TYPES = {AscendDeviceType.A5}
 
 
 def is_arm_cpu() -> bool:
@@ -377,6 +379,14 @@ class CpuAlloc:
         return get_ascend_device_type() not in NO_IRQ_BINDING_DEVICE_TYPES
 
     @staticmethod
+    def _requires_topo_affinity() -> bool:
+        return get_ascend_device_type() in REQUIRED_TOPO_AFFINITY_DEVICE_TYPES
+
+    @staticmethod
+    def _uses_strict_topo_affinity() -> bool:
+        return get_ascend_device_type() in STRICT_TOPO_AFFINITY_DEVICE_TYPES
+
+    @staticmethod
     def _min_cpus_per_npu() -> int:
         if CpuAlloc._reserve_irq_cpus():
             return MIN_CPUS_PER_NPU
@@ -395,6 +405,8 @@ class CpuAlloc:
 
         # topo_affinity mode
         if not self.device_info.npu_affinity:
+            if self._requires_topo_affinity():
+                raise RuntimeError("NPU topo affinity not found for Ascend 950. Please check 'npu-smi info -t topo'.")
             logger.warning("NPU topo affinity not found. action: fallback to global-slice CPU binding.")
             self.build_global_slice_cpu_pool()
             return
@@ -415,7 +427,9 @@ class CpuAlloc:
             ]
             if not base_cpu_list:
                 raise RuntimeError("CPUs available in 'Cpus_allowed_list' conflict with NUMA affinity.")
-            extra_cpu_list = self.extend_numa(base_cpu_list)
+            extra_cpu_list = base_cpu_list
+            if not self._uses_strict_topo_affinity():
+                extra_cpu_list = self.extend_numa(base_cpu_list)
             self.npu_cpu_pool[npu] = extra_cpu_list
 
         groups = defaultdict(list)


### PR DESCRIPTION
## Summary

This PR updates Ascend 950 CPU binding to use strict topology affinity on new HDK versions.

- switch Ascend 950 from `global_slice` to `topo_affinity`
- require valid CPU affinity from `npu-smi info -t topo` instead of falling back to `global_slice`
- keep IRQ binding disabled on Ascend 950
- keep the current Ascend 950 role split: `main=pool[:-2]`, `acl=pool[-2]`, `release=pool[-1]`
- update UT and CPU binding docs to match the new behavior

## Behavior

Ascend 950 now uses the CPU affinity reported by `npu-smi info -t topo` directly.
When multiple logical NPUs share the same topology CPU pool, vLLM Ascend still performs a global split across that shared pool so different DP groups do not reuse the same CPUs.

Unlike A2 and 310P, Ascend 950 no longer extends single-NUMA topology pools to the adjacent NUMA node.

## Notes

- A2, A3, and 310P binding behavior is unchanged
- `vllm_ascend/cpu_binding_back.py` is a local learning file and is intentionally excluded from this PR

## Local Checks

- `ruff check vllm_ascend/cpu_binding.py tests/ut/device_allocator/test_cpu_binding.py`
- `ruff format --check vllm_ascend/cpu_binding.py tests/ut/device_allocator/test_cpu_binding.py`
- `python3 -m compileall -q vllm_ascend/cpu_binding.py tests/ut/device_allocator/test_cpu_binding.py`
- `git diff --check`

## Test Note

I could not run the full `tests/ut/device_allocator/test_cpu_binding.py` suite in this environment because local Python runtime dependencies are incomplete during test setup import.

- vLLM version: `v0.23.0`
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1