### PR TITLE
[Feature][Refactor] Support SFA C8 on A3 with unified packed KV cache layout

### DIFF
--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
@@ -395,7 +395,7 @@ FULL_FEATURE_MODEL_CASES = [
             "compilation_config": FULL_DECODE_GRAPH,
             "additional_config": {
                 "enable_flashcomm1": True,
-                "enable_sparse_c8": True,
+                "enable_sparse_c8": False,
             },
             "speculative_config": {
                 "method": "mtp",

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -109,7 +109,7 @@ class TestAscendSFAKVQuantSparseAttention(TestBase):
 
     def test_execute_kv_quant_sparse_flash_attention(self):
         impl = AscendSFAImpl.__new__(AscendSFAImpl)
-        impl.use_sparse_c8 = True
+        impl.use_sparse_c8_sfa = True
         impl.scale = 0.125
         impl.sfa_qsfa_tile_size = 128
         impl.qk_rope_head_dim = 16
@@ -145,7 +145,7 @@ class TestAscendSFAKVQuantSparseAttention(TestBase):
 
     def test_prolog_v3_enables_packed_int8_kv_cache(self):
         impl = AscendSFAImpl.__new__(AscendSFAImpl)
-        impl.use_sparse_c8 = True
+        impl.use_sparse_c8_sfa = True
         impl.has_indexer = True
         impl.sfa_qsfa_tile_size = 128
         impl.sfa_qsfa_k_nope_clip_alpha = torch.ones(1)

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -1,4 +1,5 @@
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -13,7 +14,14 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 if "torch_npu._inductor" not in sys.modules:
     sys.modules["torch_npu._inductor"] = MagicMock()
 
-from vllm_ascend.attention.sfa_v1 import AscendSFABackend, AscendSFAImpl, AscendSFAMetadata, AscendSFAMetadataBuilder
+from vllm_ascend.attention.sfa_v1 import (
+    AscendSFABackend,
+    AscendSFAImpl,
+    AscendSFAMetadata,
+    AscendSFAMetadataBuilder,
+    custom_kv_rmsnorm_rope,
+)
+from vllm_ascend.attention.utils import get_sfa_qsfa_packed_head_dim
 from vllm_ascend.utils import enable_dsa_cp
 
 
@@ -64,6 +72,126 @@ class TestAscendSFABackend(TestBase):
         mock_enable_cp.return_value = True
         impl_cls = AscendSFABackend.get_impl_cls()
         self.assertIsNotNone(impl_cls)
+
+
+class TestAscendSFAKVQuantSparseAttention(TestBase):
+    @patch("vllm_ascend.attention.sfa_v1.torch_npu.npu_dynamic_block_quant")
+    @patch("vllm_ascend.attention.sfa_v1.torch_npu.npu_interleave_rope")
+    @patch("vllm_ascend.attention.sfa_v1.torch_npu.npu_rms_norm")
+    def test_pack_prefill_kv_cache(self, mock_rms_norm, mock_rope, mock_block_quant):
+        k_nope = torch.randn(2, 1, 1, 256, dtype=torch.bfloat16)
+        k_pe = torch.randn(2, 1, 1, 16, dtype=torch.bfloat16)
+        quantized = torch.randint(-128, 127, (2, 1, 256), dtype=torch.int8)
+        scales = torch.arange(1, 5, dtype=torch.float32).view(2, 1, 2)
+        mock_rms_norm.return_value = k_nope, None
+        mock_rope.return_value = k_pe
+        mock_block_quant.return_value = quantized, scales
+
+        actual_k_pe, actual_k_nope, actual_scales = custom_kv_rmsnorm_rope(
+            torch.randn(2, 1, 1, 272, dtype=torch.bfloat16),
+            torch.ones(256, dtype=torch.bfloat16),
+            torch.randn(2, 1, 1, 16),
+            torch.randn(2, 1, 1, 16),
+            256,
+            16,
+            dst_type=1,
+            tile_size=128,
+        )
+        packed_kv = torch.cat([actual_k_nope, actual_k_pe, actual_scales], dim=-1)
+
+        self.assertEqual(mock_block_quant.call_args.kwargs["dst_type"], 1)
+        self.assertEqual(mock_block_quant.call_args.kwargs["row_block_size"], 1)
+        self.assertEqual(mock_block_quant.call_args.kwargs["col_block_size"], 128)
+        self.assertEqual(packed_kv.shape, (2, 1, 1, 296))
+        self.assertTrue(torch.equal(packed_kv[..., :256], quantized.view_as(k_nope)))
+        self.assertTrue(torch.equal(packed_kv[..., 256:288], k_pe.contiguous().view(torch.int8)))
+        self.assertTrue(torch.equal(packed_kv[..., 288:], scales.view(2, 1, 1, 2).view(torch.int8)))
+
+    def test_execute_kv_quant_sparse_flash_attention(self):
+        impl = AscendSFAImpl.__new__(AscendSFAImpl)
+        impl.use_sparse_c8 = True
+        impl.scale = 0.125
+        impl.sfa_qsfa_tile_size = 128
+        impl.qk_rope_head_dim = 16
+        ql_nope = torch.randn(3, 2, 32)
+        q_pe = torch.randn(3, 2, 16)
+        kv_cache = (torch.empty(4, 16, 1, 80, dtype=torch.int8),)
+        topk_indices = torch.zeros(3, 1, dtype=torch.int32)
+        attn_metadata = SimpleNamespace(block_table=torch.zeros(1, 4, dtype=torch.int32))
+        actual_seq_lengths = torch.tensor([3], dtype=torch.int32)
+        expected = torch.randn(3, 2, 32)
+
+        with patch(
+            "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
+            create=True,
+            return_value=expected,
+        ) as mock_qsfa:
+            result = impl._execute_sparse_flash_attention_process(
+                ql_nope,
+                q_pe,
+                kv_cache,
+                topk_indices,
+                attn_metadata,
+                actual_seq_lengths,
+                actual_seq_lengths,
+            )
+
+        self.assertIs(result, expected)
+        call_kwargs = mock_qsfa.call_args.kwargs
+        self.assertIs(call_kwargs["key"], kv_cache[0])
+        self.assertEqual(call_kwargs["query"].shape, (3, 2, 48))
+        self.assertEqual(call_kwargs["key_quant_mode"], 2)
+        self.assertEqual(call_kwargs["tile_size"], 128)
+
+    def test_prolog_v3_enables_packed_int8_kv_cache(self):
+        impl = AscendSFAImpl.__new__(AscendSFAImpl)
+        impl.use_sparse_c8 = True
+        impl.has_indexer = True
+        impl.sfa_qsfa_tile_size = 128
+        impl.sfa_qsfa_k_nope_clip_alpha = torch.ones(1)
+        impl.sfa_qsfa_kr_cache_dummy = torch.empty(0, dtype=torch.bfloat16)
+        impl.local_num_heads = 2
+        impl.kv_lora_rank = 128
+        impl.qk_rope_head_dim = 16
+        impl.q_lora_rank = 8
+        impl.q_a_layernorm = SimpleNamespace(weight=SimpleNamespace(data=torch.ones(8)), variance_epsilon=1e-5)
+        impl.kv_a_layernorm = SimpleNamespace(weight=SimpleNamespace(data=torch.ones(128)), variance_epsilon=1e-5)
+        impl.weight_dq = torch.empty(1)
+        impl.weight_uq_qr = torch.empty(1)
+        impl.W_UK_T = torch.empty(1)
+        impl.weight_dkv_kr = torch.empty(1)
+        impl.dequant_scale_w_dq = torch.empty(1)
+        impl.dequant_scale_w_uq_qr = torch.empty(1)
+        impl.dequant_scale_w_dkv_kr = torch.empty(1)
+        k_cache = torch.empty(4, 16, 1, get_sfa_qsfa_packed_head_dim(128, 16), dtype=torch.int8)
+        dsa_k_cache = torch.empty(4, 16, 1, 128, dtype=torch.bfloat16)
+
+        with (
+            patch(
+                "vllm_ascend.device.device_op.torch_npu.npu_dynamic_quant",
+                return_value=(torch.empty(2, 8, dtype=torch.int8), torch.ones(2, 1)),
+            ),
+            patch(
+                "vllm_ascend.device.device_op.torch_npu.npu_mla_prolog_v3",
+                create=True,
+                return_value=(torch.randn(2, 2, 128), torch.randn(2, 2, 16), None, torch.randn(2, 8), None),
+            ) as mock_prolog,
+        ):
+            impl._sfa_preprocess_with_prolog_v3(
+                hidden_states=torch.randn(2, 8),
+                kv_cache=(k_cache, dsa_k_cache),
+                cos=torch.randn(2, 1, 1, 16),
+                sin=torch.randn(2, 1, 1, 16),
+                slot_mapping=torch.arange(2),
+                cache_mode="PA_BSND",
+            )
+
+        call_kwargs = mock_prolog.call_args.kwargs
+        self.assertIs(call_kwargs["kv_cache"], k_cache)
+        self.assertIs(call_kwargs["kr_cache"], impl.sfa_qsfa_kr_cache_dummy)
+        self.assertEqual(call_kwargs["kv_cache_quant_mode"], 3)
+        self.assertEqual(call_kwargs["ckvkr_repo_mode"], 1)
+        self.assertEqual(call_kwargs["quant_scale_repo_mode"], 1)
 
 
 class TestAscendSFAMetadata(TestBase):

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -15,7 +15,7 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         runner = NPUModelRunner.__new__(NPUModelRunner)
         runner.device = torch.device("cpu")
         runner.use_sparse = False
-        runner.use_sparse_c8_indexer = False
+        runner.use_sparse_c8 = False
         runner.use_compress = False
         runner.use_hybrid_blocks = False
         runner.hybrid_with_attn_and_mamba = False
@@ -101,7 +101,6 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         runner.kv_cache_dtype = torch.bfloat16
         runner.shared_kv_cache_layers = {}
         runner.ascend_config = MagicMock()
-        runner.ascend_config.is_sparse_c8_layer.return_value = False
         runner.model_config.hf_text_config = SimpleNamespace(
             kv_lora_rank=512,
             qk_rope_head_dim=64,
@@ -110,7 +109,7 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
 
         attn_module = MLAAttention.__new__(MLAAttention)
         torch.nn.Module.__init__(attn_module)
-        attn_module.impl = SimpleNamespace(has_indexer=False)
+        attn_module.impl = SimpleNamespace(has_indexer=False, use_sparse_c8=False)
         layer_name = "model.layers.1.self_attn.attn"
         mock_get_layers.return_value = {layer_name: attn_module}
 

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -604,9 +604,16 @@ class AscendSFAImpl(MLAAttentionImpl):
             self.is_rope_neox_style = False
             self.use_torch_npu_lightning_indexer = True
 
-        # dsa c8
-        self.use_sparse_c8 = ascend_config.is_sparse_c8_layer(self.layer_name)
-        if self.use_sparse_c8:
+        # Sparse C8 has two independent meanings in SFA:
+        # - SFA packed KV cache for npu_kv_quant_sparse_flash_attention.
+        # - C8 indexer cache for lightning indexer.
+        # GLM5.2 can skip creating indexer on some layers, but these layers
+        # still need the packed KV cache when sparse C8 is enabled.
+        self.use_sparse_c8_indexer = self.has_indexer and ascend_config.is_sparse_c8_layer(self.layer_name)
+        self.use_sparse_c8_sfa = self.use_sparse_c8_indexer or (
+            ascend_config.enable_sparse_c8 and not self.has_indexer and self.skip_topk
+        )
+        if self.use_sparse_c8_sfa or self.use_sparse_c8_indexer:
             if get_ascend_device_type() == AscendDeviceType.A5:
                 self.c8_k_cache_dtype = torch.float8_e4m3fn
                 self.c8_k_scale_cache_dtype = torch.float32
@@ -614,16 +621,16 @@ class AscendSFAImpl(MLAAttentionImpl):
                 self.c8_k_cache_dtype = torch.int8
                 self.c8_k_scale_cache_dtype = torch.float16
 
-        if self.use_sparse_c8:
+        if self.use_sparse_c8_sfa:
             self.sfa_qsfa_packed_kv_head_dim = get_sfa_qsfa_packed_head_dim(
                 self.kv_lora_rank,
                 self.qk_rope_head_dim,
                 self.sfa_qsfa_tile_size,
             )
         # PD decode consumers with sparse C8 use mla_prolog_v3 to write the packed KV cache.
-        self.enable_sfa_prolog_v3 = self.is_kv_consumer and self.use_sparse_c8
+        self.enable_sfa_prolog_v3 = self.is_kv_consumer and self.use_sparse_c8_sfa
         self.enable_mlapo = ascend_config.enable_mlapo and not (
-            self.enable_sfa_prolog_v3 or (self.use_sparse_c8 and get_ascend_device_type() != AscendDeviceType.A5)
+            self.enable_sfa_prolog_v3 or (self.use_sparse_c8_sfa and get_ascend_device_type() != AscendDeviceType.A5)
         )
 
         # Effective in SFA when FlashComm is enabled.
@@ -761,7 +768,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                 else:
                     self._process_weights_for_fused_mlapo(act_dtype)
 
-        if self.use_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
+        if self.use_sparse_c8_indexer and get_ascend_device_type() == AscendDeviceType.A5:
             if hasattr(self, "mlapo_is_quantized") and not self.mlapo_is_quantized:
                 self.c8_k_cache_dtype = act_dtype
                 self.c8_k_scale_cache_dtype = act_dtype
@@ -770,11 +777,11 @@ class AscendSFAImpl(MLAAttentionImpl):
             # if mlapo, W_UK_T can't trans nz
             self.W_UK_T = maybe_trans_nz(self.W_UK_T)
 
-        if self.has_indexer and self.use_sparse_c8 and AscendSFAImpl.q_hadamard is None:
+        if self.has_indexer and self.use_sparse_c8_indexer and AscendSFAImpl.q_hadamard is None:
             AscendSFAImpl.q_hadamard = torch.tensor(scipy.linalg.hadamard(128), dtype=torch.bfloat16, device="npu") / (
                 128**0.5
             )
-        if self.has_indexer and self.use_sparse_c8 and AscendSFAImpl.k_hadamard is None:
+        if self.has_indexer and self.use_sparse_c8_indexer and AscendSFAImpl.k_hadamard is None:
             AscendSFAImpl.k_hadamard = torch.tensor(scipy.linalg.hadamard(128), dtype=torch.bfloat16, device="npu") / (
                 128**0.5
             )
@@ -819,7 +826,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         self.dequant_scale_w_dq = q_a_proj_deq_scl.view(1, -1).to(torch.float)
         self.dequant_scale_w_dkv_kr = kv_a_proj_deq_scl.view(1, -1).to(torch.float)
         self.dequant_scale_w_uq_qr = self.q_proj.weight_scale.data.view(1, -1).to(torch.float)
-        if self.use_sparse_c8:
+        if self.use_sparse_c8_sfa:
             self.sfa_qsfa_k_nope_clip_alpha = torch.ones(
                 1,
                 dtype=torch.float32,
@@ -1149,7 +1156,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         kv_no_split = kv_no_split.view(B, N, S, self.kv_lora_rank + self.qk_rope_head_dim)
         cache_mode = "PA"
 
-        use_custom_kv = self.use_sparse_c8 and (
+        use_custom_kv = self.use_sparse_c8_sfa and (
             get_ascend_device_type() != AscendDeviceType.A5 or self.enable_dsa_cp or not self.has_indexer
         )
         if use_custom_kv:
@@ -1292,7 +1299,7 @@ class AscendSFAImpl(MLAAttentionImpl):
             q_c = None
 
         k_nope = kv_cache[0] if cache_mode == "TND" else None
-        k_pe = kv_cache[1] if cache_mode == "TND" and not self.use_sparse_c8 else None
+        k_pe = kv_cache[1] if cache_mode == "TND" and not self.use_sparse_c8_sfa else None
         return hidden_states, ql_nope, q_pe, q_c, k_nope, k_pe
 
     def indexer_select_pre_process(
@@ -1334,7 +1341,7 @@ class AscendSFAImpl(MLAAttentionImpl):
 
             k_li = torch.cat([k_li_pe, k_li_nope], dim=-1)  # [b*s,128]
 
-        if self.use_sparse_c8:
+        if self.use_sparse_c8_indexer:
             k_li = k_li @ AscendSFAImpl.k_hadamard
             k_li, k_li_scale = torch_npu.npu_dynamic_quant(k_li.view(-1, self.head_dim), dst_type=self.c8_k_cache_dtype)
             k_li_scale = k_li_scale.to(self.c8_k_scale_cache_dtype)  # [b*s,]
@@ -1408,7 +1415,7 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         q_li_scale = None
         q_li_shape_ori = None
-        if self.use_sparse_c8:
+        if self.use_sparse_c8_indexer:
             q_li_shape_ori = q_li.shape
             q_li = q_li @ AscendSFAImpl.q_hadamard
             q_li, q_li_scale = torch_npu.npu_dynamic_quant(q_li.view(-1, self.head_dim), dst_type=self.c8_k_cache_dtype)
@@ -1424,7 +1431,7 @@ class AscendSFAImpl(MLAAttentionImpl):
             attn_metadata,
             actual_seq_lengths_query,
             actual_seq_lengths_key,
-            self.use_sparse_c8,
+            self.use_sparse_c8_indexer,
             self.use_torch_npu_lightning_indexer,
         )
 
@@ -1614,7 +1621,7 @@ class AscendSFAImpl(MLAAttentionImpl):
             knope_scale = kv_outputs[2] if len(kv_outputs) == 3 else None
 
             if (
-                self.use_sparse_c8
+                self.use_sparse_c8_sfa
                 and not self.enable_dsa_cp
                 and (get_ascend_device_type() != AscendDeviceType.A5 or not self.has_indexer)
             ):
@@ -1635,7 +1642,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                 assert k_nope is not None
                 async_op = self.enable_dsa_cp_with_layer_shard or full_gather_o_proj_enabled
                 # support all_gather kv async for communication calculation overlap
-                if self.use_sparse_c8:
+                if self.use_sparse_c8_sfa:
                     assert knope_scale is not None
                     fused_kv_parts = [
                         k_nope.view(-1, k_nope.shape[-1]),
@@ -1647,7 +1654,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                         k_pe.view(-1, k_pe.shape[-1]),
                         k_nope.view(-1, k_nope.shape[-1]),
                     ]
-                    if self.has_indexer and not self.use_sparse_c8:
+                    if self.has_indexer and not self.use_sparse_c8_indexer:
                         assert k_li is not None
                         fused_kv_parts.append(k_li.view(-1, k_li.shape[-1]))
 
@@ -1658,14 +1665,14 @@ class AscendSFAImpl(MLAAttentionImpl):
                     async_op=async_op,
                 )
 
-                if self.has_indexer and self.use_sparse_c8:
+                if self.has_indexer and self.use_sparse_c8_indexer:
                     assert k_li is not None
                     k_li, kv_ag_handle = all_gather_async(
                         k_li,
                         get_tp_group(),
                         async_op=async_op,
                     )
-                if self.has_indexer and self.use_sparse_c8:
+                if self.has_indexer and self.use_sparse_c8_indexer:
                     assert k_li_scale is not None
                     k_li_scale, kv_ag_handle = all_gather_async(
                         k_li_scale,
@@ -1702,7 +1709,7 @@ class AscendSFAImpl(MLAAttentionImpl):
 
                 if kv_cache is not None:
                     assert fused_kv_no_split is not None
-                    if self.use_sparse_c8:
+                    if self.use_sparse_c8_sfa:
                         torch_npu.npu_scatter_nd_update_(
                             kv_cache[0].view(-1, fused_kv_no_split.shape[-1]),
                             slot_mapping_sfa[: attn_metadata.num_actual_tokens].view(-1, 1),
@@ -1715,7 +1722,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                             [self.qk_rope_head_dim, self.kv_lora_rank],
                             dim=-1,
                         )
-                    elif not self.use_sparse_c8:
+                    elif not self.use_sparse_c8_indexer:
                         k_pe, k_nope, k_li = fused_kv_no_split.split(
                             [self.qk_rope_head_dim, self.kv_lora_rank, self.head_dim],
                             dim=-1,
@@ -1725,7 +1732,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                             [self.qk_rope_head_dim, self.kv_lora_rank],
                             dim=-1,
                         )
-                    if not self.use_sparse_c8:
+                    if not self.use_sparse_c8_sfa:
                         assert k_pe is not None
                         assert k_nope is not None
                         k_nope = k_nope.view(k_nope.shape[0], 1, -1)
@@ -1748,7 +1755,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         if kv_cache is not None and self.has_indexer:
             assert k_li is not None
             use_indexer_reshape_optim = self.is_kv_producer and get_ascend_config().c8_enable_reshape_optim
-            if self.use_sparse_c8:
+            if self.use_sparse_c8_sfa:
                 dsa_k_cache_idx = 1
                 dsa_k_scale_cache_idx = 2
             else:
@@ -1770,8 +1777,8 @@ class AscendSFAImpl(MLAAttentionImpl):
                     slot_mapping.view(-1, 1),
                     k_li.view(-1, k_li.shape[-1]),
                 )  # b, s, n, d
-            if self.use_sparse_c8:
-                assert len(kv_cache) == 3
+            if self.use_sparse_c8_indexer:
+                assert len(kv_cache) == (3 if self.use_sparse_c8_sfa else 4)
                 if k_li_scale is not None:
                     if use_indexer_reshape_optim:
                         torch.ops._C_ascend.store_kv_block(

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -27,9 +27,11 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.context_parallel.common_cp import AscendPCPMetadata
 from vllm_ascend.attention.mla_v1 import MAX_O_PROJ_PREFETCH_SIZE, MLAPO_MAX_SUPPORTED_TOKENS
 from vllm_ascend.attention.utils import (
+    SFA_QSFA_TILE_SIZE,
     AscendCommonAttentionMetadata,
     ascend_chunked_prefill_workspace_size,
     enable_cp,
+    get_sfa_qsfa_packed_head_dim,
     maybe_save_kv_layer_to_connector,
     trans_rope_weight,
     transdata,
@@ -46,9 +48,14 @@ from vllm_ascend.ops.layer_shard_linear import (
 )
 from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_mla
 from vllm_ascend.ops.triton.rope import rope_forward_triton_siso
-from vllm_ascend.quantization.methods import AscendW8A8LinearMethod, AscendW8A8MXFP8DynamicLinearMethod
+from vllm_ascend.quantization.methods import (
+    AscendW8A8DynamicLinearMethod,
+    AscendW8A8LinearMethod,
+    AscendW8A8MXFP8DynamicLinearMethod,
+)
 from vllm_ascend.utils import (
     ACL_FORMAT_FRACTAL_ND,
+    ACL_FORMAT_FRACTAL_NZ,
     AscendDeviceType,
     _round_up,
     dispose_layer,
@@ -545,13 +552,17 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         ascend_config = get_ascend_config()
         self.enable_shared_expert_dp = ascend_config.enable_shared_expert_dp
+        self.vllm_config = get_current_vllm_config()
+        kv_transfer_config = self.vllm_config.kv_transfer_config
+        self.is_kv_producer = kv_transfer_config is not None and kv_transfer_config.is_kv_producer
+        self.is_kv_consumer = kv_transfer_config is not None and kv_transfer_config.is_kv_consumer
 
-        # The MLAPO operator fuses the pre-processing steps on Q/K/V in MLA into a single operator
-        # NOTE: it imposes a limit on the number of input tokens and conflicts with FlashComm
-        self.enable_mlapo = get_ascend_config().enable_mlapo
+        self.sfa_qsfa_tile_size = SFA_QSFA_TILE_SIZE
+        self.sfa_qsfa_packed_kv_head_dim = 0
+        self.sfa_qsfa_k_nope_clip_alpha: torch.Tensor | None = None
+        self.sfa_qsfa_kr_cache_dummy: torch.Tensor | None = None
 
         self.local_num_heads = self.num_heads
-        self.vllm_config = get_current_vllm_config()
         self.layer_name = kwargs.get("layer_name")
         hf_config = self.vllm_config.model_config.hf_config
         hf_text_config = getattr(self.vllm_config.model_config, "hf_text_config", None)
@@ -561,10 +572,6 @@ class AscendSFAImpl(MLAAttentionImpl):
             "use_index_cache",
         ) or _has_shared_indexer_layers(config_candidates)
         self.use_index_cache = self.skip_topk or self.index_cache_enabled
-        self.is_kv_producer = (
-            self.vllm_config.kv_transfer_config is not None and self.vllm_config.kv_transfer_config.is_kv_producer
-        )
-
         self.has_indexer = self.indexer is not None
         if not self.has_indexer and not self.skip_topk:
             raise ValueError(
@@ -577,7 +584,6 @@ class AscendSFAImpl(MLAAttentionImpl):
                 "topk_indices_buffer is required when indexer is None and "
                 f"skip_topk is enabled. layer_name={self.layer_name}."
             )
-
         # indexer param
         if self.has_indexer:
             self.n_head: int = self.indexer.n_head  # 64
@@ -599,15 +605,26 @@ class AscendSFAImpl(MLAAttentionImpl):
             self.use_torch_npu_lightning_indexer = True
 
         # dsa c8
-        self.use_sparse_c8_indexer = self.has_indexer and ascend_config.is_sparse_c8_layer(self.layer_name)
-        self.use_a5_sparse_c8_indexer = self.use_sparse_c8_indexer and (get_ascend_device_type() == AscendDeviceType.A5)
-        if self.use_sparse_c8_indexer:
+        self.use_sparse_c8 = ascend_config.is_sparse_c8_layer(self.layer_name)
+        if self.use_sparse_c8:
             if get_ascend_device_type() == AscendDeviceType.A5:
                 self.c8_k_cache_dtype = torch.float8_e4m3fn
                 self.c8_k_scale_cache_dtype = torch.float32
             else:
                 self.c8_k_cache_dtype = torch.int8
                 self.c8_k_scale_cache_dtype = torch.float16
+
+        if self.use_sparse_c8:
+            self.sfa_qsfa_packed_kv_head_dim = get_sfa_qsfa_packed_head_dim(
+                self.kv_lora_rank,
+                self.qk_rope_head_dim,
+                self.sfa_qsfa_tile_size,
+            )
+        # PD decode consumers with sparse C8 use mla_prolog_v3 to write the packed KV cache.
+        self.enable_sfa_prolog_v3 = self.is_kv_consumer and self.use_sparse_c8
+        self.enable_mlapo = ascend_config.enable_mlapo and not (
+            self.enable_sfa_prolog_v3 or (self.use_sparse_c8 and get_ascend_device_type() != AscendDeviceType.A5)
+        )
 
         # Effective in SFA when FlashComm is enabled.
         self.enable_dsa_cp = enable_dsa_cp()
@@ -699,7 +716,20 @@ class AscendSFAImpl(MLAAttentionImpl):
             elif self.enable_dsa_cp_with_o_proj_tp:
                 self._init_o_proj_tp_full_params()
 
-        if self.enable_mlapo:
+        if self.enable_sfa_prolog_v3:
+            reasons = self._get_sfa_prolog_v3_unsupported_reasons()
+            if reasons:
+                self.enable_sfa_prolog_v3 = False
+                self.enable_mlapo = False
+                for msg in reasons:
+                    logger.warning_once(
+                        f"{msg} Disable SFA mla_prolog_v3 for layer {self.layer_name}; "
+                        "fallback to native preprocessing."
+                    )
+            else:
+                self._process_weights_for_fused_prolog_v3()
+
+        if not self.enable_sfa_prolog_v3 and self.enable_mlapo:
             quant_method = getattr(
                 getattr(self.fused_qkv_a_proj, "quant_method", None),
                 "quant_method",
@@ -731,23 +761,85 @@ class AscendSFAImpl(MLAAttentionImpl):
                 else:
                     self._process_weights_for_fused_mlapo(act_dtype)
 
-        if self.use_sparse_c8_indexer and get_ascend_device_type() == AscendDeviceType.A5:
+        if self.use_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
             if hasattr(self, "mlapo_is_quantized") and not self.mlapo_is_quantized:
                 self.c8_k_cache_dtype = act_dtype
                 self.c8_k_scale_cache_dtype = act_dtype
 
-        if not self.enable_mlapo:
+        if not self.enable_mlapo and not self.enable_sfa_prolog_v3:
             # if mlapo, W_UK_T can't trans nz
             self.W_UK_T = maybe_trans_nz(self.W_UK_T)
 
-        if self.use_sparse_c8_indexer and AscendSFAImpl.q_hadamard is None:
+        if self.has_indexer and self.use_sparse_c8 and AscendSFAImpl.q_hadamard is None:
             AscendSFAImpl.q_hadamard = torch.tensor(scipy.linalg.hadamard(128), dtype=torch.bfloat16, device="npu") / (
                 128**0.5
             )
-        if self.use_sparse_c8_indexer and AscendSFAImpl.k_hadamard is None:
+        if self.has_indexer and self.use_sparse_c8 and AscendSFAImpl.k_hadamard is None:
             AscendSFAImpl.k_hadamard = torch.tensor(scipy.linalg.hadamard(128), dtype=torch.bfloat16, device="npu") / (
                 128**0.5
             )
+
+    @staticmethod
+    def _is_w8a8_dynamic_linear(layer: torch.nn.Module | None) -> bool:
+        quant_method = getattr(getattr(layer, "quant_method", None), "quant_method", None)
+        return isinstance(quant_method, AscendW8A8DynamicLinearMethod)
+
+    def _get_sfa_prolog_v3_unsupported_reasons(self) -> list[str]:
+        reasons = []
+        for name, layer in (
+            ("fused_qkv_a_proj", self.fused_qkv_a_proj),
+            ("q_proj", self.q_proj),
+        ):
+            if not self._is_w8a8_dynamic_linear(layer):
+                reasons.append(f"Currently SFA mla_prolog_v3 only supports W8A8 dynamic quantization for {name}.")
+        if self.kv_a_layernorm is None or self.q_a_layernorm is None:
+            reasons.append("SFA mla_prolog_v3 requires q_a_layernorm and kv_a_layernorm.")
+        if getattr(self.q_proj, "_chunk_size", 0):
+            reasons.append("SFA mla_prolog_v3 does not support chunked q_proj weights yet.")
+        if self.enable_dsa_cp:
+            reasons.append("SFA mla_prolog_v3 does not support DSA-CP; DSA-CP takes precedence.")
+        if self.is_kv_producer:
+            reasons.append("SFA mla_prolog_v3 is disabled on KV producer workers.")
+        return reasons
+
+    def _process_weights_for_fused_prolog_v3(self) -> None:
+        assert self.fused_qkv_a_proj is not None
+        assert self.q_proj is not None
+
+        fused_weight = self.fused_qkv_a_proj.weight.data
+        weight_dq = fused_weight[..., : self.q_lora_rank].contiguous()
+        weight_dkv_kr = fused_weight[..., self.q_lora_rank :].contiguous()
+        weight_uq_qr = self.q_proj.weight.data.contiguous()
+        self.weight_dq = torch_npu.npu_format_cast(weight_dq, ACL_FORMAT_FRACTAL_NZ)
+        self.weight_dkv_kr = torch_npu.npu_format_cast(weight_dkv_kr, ACL_FORMAT_FRACTAL_NZ)
+        self.weight_uq_qr = torch_npu.npu_format_cast(weight_uq_qr, ACL_FORMAT_FRACTAL_NZ)
+
+        q_a_proj_deq_scl = self.fused_qkv_a_proj.weight_scale[: self.q_lora_rank].contiguous()
+        kv_a_proj_deq_scl = self.fused_qkv_a_proj.weight_scale[self.q_lora_rank :].contiguous()
+        self.dequant_scale_w_dq = q_a_proj_deq_scl.view(1, -1).to(torch.float)
+        self.dequant_scale_w_dkv_kr = kv_a_proj_deq_scl.view(1, -1).to(torch.float)
+        self.dequant_scale_w_uq_qr = self.q_proj.weight_scale.data.view(1, -1).to(torch.float)
+        if self.use_sparse_c8:
+            self.sfa_qsfa_k_nope_clip_alpha = torch.ones(
+                1,
+                dtype=torch.float32,
+                device=self.weight_dq.device,
+            )
+            if self.sfa_qsfa_kr_cache_dummy is None:
+                # ckvkr_repo_mode=1 stores rope in the packed KV cache, but the
+                # operator still requires kr_cache. Keep a stable, non-aliased
+                # dummy so first-run tiling/graph capture cannot alias kv_cache.
+                self.sfa_qsfa_kr_cache_dummy = torch.empty(
+                    0,
+                    dtype=torch.bfloat16,
+                    device=self.weight_dq.device,
+                )
+        if self.is_kv_consumer:
+            # Decode-only workers only execute Prolog. Drop the native Linear
+            # weights after their Prolog layouts and scales have been copied.
+            dispose_layer(self.fused_qkv_a_proj)
+            dispose_layer(self.q_proj)
+            torch.npu.empty_cache()
 
     # Processing the input parameters for MLAPO by reordering and transposing
     # QKV(and part of Q) weight, applying RoPE-related dimension transformations,
@@ -1057,22 +1149,24 @@ class AscendSFAImpl(MLAAttentionImpl):
         kv_no_split = kv_no_split.view(B, N, S, self.kv_lora_rank + self.qk_rope_head_dim)
         cache_mode = "PA"
 
-        if self.enable_dsa_cp:
-            if self.use_a5_sparse_c8_indexer:
-                k_pe, k_nope, knope_scale = custom_kv_rmsnorm_rope(
-                    kv_no_split,
-                    self.kv_a_layernorm.weight,  # type: ignore[union-attr]
-                    cos,
-                    sin,
-                    slots.to(torch.int64),
-                    kv_cache[1],
-                    kv_cache[0],
-                    epsilon=self.kv_a_layernorm.variance_epsilon,  # type: ignore[union-attr]
-                    cache_mode=cache_mode,
-                    is_output_kv=True,
-                )
-                return k_pe, k_nope, knope_scale
+        use_custom_kv = self.use_sparse_c8 and (
+            get_ascend_device_type() != AscendDeviceType.A5 or self.enable_dsa_cp or not self.has_indexer
+        )
+        if use_custom_kv:
+            assert self.kv_a_layernorm is not None
+            return custom_kv_rmsnorm_rope(
+                kv_no_split,
+                self.kv_a_layernorm.weight,
+                cos,
+                sin,
+                self.kv_lora_rank,
+                self.qk_rope_head_dim,
+                epsilon=self.kv_a_layernorm.variance_epsilon,
+                dst_type=(torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else 1),
+                tile_size=self.sfa_qsfa_tile_size,
+            )
 
+        if self.enable_dsa_cp:
             _, _, k_pe, k_nope = torch_npu.npu_kv_rmsnorm_rope_cache(
                 kv_no_split,
                 self.kv_a_layernorm.weight,  # type: ignore[union-attr]
@@ -1085,8 +1179,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                 cache_mode=cache_mode,
                 is_output_kv=True,
             )
-            knope_scale = None
-            return k_pe, k_nope, knope_scale
+            return k_pe, k_nope, None
         else:
             torch_npu.npu_kv_rmsnorm_rope_cache(
                 kv_no_split,
@@ -1162,6 +1255,46 @@ class AscendSFAImpl(MLAAttentionImpl):
             num_input_tokens,
         )
 
+    def _sfa_preprocess_with_prolog_v3(
+        self,
+        hidden_states: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...],
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        cache_mode: str,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor | tuple[torch.Tensor, torch.Tensor] | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+    ]:
+        ql_nope, q_pe, _, q_c, q_c_scale = DeviceOperator.execute_sfa_mla_prolog_v3(
+            self,
+            hidden_states=hidden_states,
+            rope_sin=sin,
+            rope_cos=cos,
+            kv_cache=kv_cache,
+            slot_mapping=slot_mapping,
+            cache_mode=cache_mode,
+        )
+        ql_nope = ql_nope.view(-1, self.local_num_heads, self.kv_lora_rank)
+        q_pe = q_pe.view(-1, self.local_num_heads, self.qk_rope_head_dim)
+        if self.has_indexer:
+            if q_c is None:
+                raise RuntimeError("npu_mla_prolog_v3 did not return query_norm for SFA indexer.")
+            q_c = q_c.view(-1, self.q_lora_rank)
+            if q_c_scale is not None and self.wq_b is not None and self._is_w8a8_dynamic_linear(self.wq_b):
+                q_c = (q_c, q_c_scale.view(-1))
+        else:
+            q_c = None
+
+        k_nope = kv_cache[0] if cache_mode == "TND" else None
+        k_pe = kv_cache[1] if cache_mode == "TND" and not self.use_sparse_c8 else None
+        return hidden_states, ql_nope, q_pe, q_c, k_nope, k_pe
+
     def indexer_select_pre_process(
         self,
         x: torch.Tensor,
@@ -1201,7 +1334,7 @@ class AscendSFAImpl(MLAAttentionImpl):
 
             k_li = torch.cat([k_li_pe, k_li_nope], dim=-1)  # [b*s,128]
 
-        if self.use_sparse_c8_indexer:
+        if self.use_sparse_c8:
             k_li = k_li @ AscendSFAImpl.k_hadamard
             k_li, k_li_scale = torch_npu.npu_dynamic_quant(k_li.view(-1, self.head_dim), dst_type=self.c8_k_cache_dtype)
             k_li_scale = k_li_scale.to(self.c8_k_scale_cache_dtype)  # [b*s,]
@@ -1214,7 +1347,7 @@ class AscendSFAImpl(MLAAttentionImpl):
     def indexer_select_post_process(
         self,
         x: torch.Tensor,
-        q_c: torch.Tensor,
+        q_c: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
         kv_cache: tuple[torch.Tensor, ...],
         attn_metadata: M,
         cos: torch.Tensor,
@@ -1233,27 +1366,32 @@ class AscendSFAImpl(MLAAttentionImpl):
         kw, _ = self.wk_weights_proj(x)
         weights = kw[:, self.head_dim :]
         if isinstance(q_c, tuple):
-            # MLAPO in C8 scenario already quantizes q_c to MXFP8 (fp8) with a per-token scale.
-            # Skip wq_b's internal npu_dynamic_mx_quant and directly use the
-            # pre-quantized values in npu_quant_matmul to avoid double quantization.
             q_c_tensor, q_c_scale = q_c
             q_c_tensor = q_c_tensor.view(-1, q_c_tensor.shape[-1])
-            if q_c_scale.dim() == 2:
-                q_c_scale = q_c_scale.view(q_c_scale.shape[0], -1, 2)
+            quant_matmul_kwargs = dict(
+                bias=None,
+                output_dtype=x.dtype,
+            )
+            if q_c_tensor.dtype == torch.float8_e4m3fn:
+                if q_c_scale.dim() == 2:
+                    q_c_scale = q_c_scale.view(q_c_scale.shape[0], -1, 2)
+                quant_matmul_kwargs.update(
+                    scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+                    pertoken_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+                    group_sizes=[1, 1, getattr(self.wq_b.quant_method.quant_method, "group_size", 32)],
+                )
+            elif q_c_scale.dim() > 1 and q_c_scale.shape[-1] == 1:
+                q_c_scale = q_c_scale.squeeze(dim=-1)
             q_li = torch_npu.npu_quant_matmul(
                 q_c_tensor,
                 self.wq_b.weight,
                 self.wq_b.weight_scale,
-                scale_dtype=FLOAT8_E8M0FNU_DTYPE,
                 pertoken_scale=q_c_scale,
-                pertoken_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
-                bias=None,
-                output_dtype=x.dtype,
-                group_sizes=[1, 1, getattr(self.wq_b.quant_method.quant_method, "group_size", 32)],
+                **quant_matmul_kwargs,
             )
         else:
             q_li, _ = self.wq_b(q_c)
-        q_li = q_li.view(-1, self.n_head, self.head_dim)  # [n_toks,64,128]
+        q_li = q_li.view(-1, self.n_head, self.head_dim)
         if HAS_TRITON:
             q_li = rope_forward_triton_siso(
                 q_li, cos, sin, rope_dim=self.qk_rope_head_dim, is_neox_style=self.is_rope_neox_style
@@ -1261,16 +1399,16 @@ class AscendSFAImpl(MLAAttentionImpl):
         else:
             q_li_pe, q_li_nope = torch.split(
                 q_li, [self.qk_rope_head_dim, self.head_dim - self.qk_rope_head_dim], dim=-1
-            )  # [b,s,64,64+64]
+            )
 
             q_li_pe = q_li_pe.unsqueeze(2)
             q_li_pe = torch_npu.npu_rotary_mul(q_li_pe, cos, sin)
             q_li_pe = q_li_pe.squeeze(2)
-            q_li = torch.cat([q_li_pe, q_li_nope], dim=-1)  # [b*s,64,128]
+            q_li = torch.cat([q_li_pe, q_li_nope], dim=-1)
 
         q_li_scale = None
         q_li_shape_ori = None
-        if self.use_sparse_c8_indexer:
+        if self.use_sparse_c8:
             q_li_shape_ori = q_li.shape
             q_li = q_li @ AscendSFAImpl.q_hadamard
             q_li, q_li_scale = torch_npu.npu_dynamic_quant(q_li.view(-1, self.head_dim), dst_type=self.c8_k_cache_dtype)
@@ -1286,7 +1424,7 @@ class AscendSFAImpl(MLAAttentionImpl):
             attn_metadata,
             actual_seq_lengths_query,
             actual_seq_lengths_key,
-            self.use_sparse_c8_indexer,
+            self.use_sparse_c8,
             self.use_torch_npu_lightning_indexer,
         )
 
@@ -1384,8 +1522,36 @@ class AscendSFAImpl(MLAAttentionImpl):
             AscendAttentionState.SpecDecoding,
         }
 
+        if self.enable_sfa_prolog_v3 and attn_metadata.attn_state in (
+            AscendAttentionState.DecodeOnly,
+            AscendAttentionState.SpecDecoding,
+        ):
+            if self.enable_sp:
+                hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
+                    hidden_states.contiguous(), need_gather_q_kv
+                )
+            assert slot_mapping.numel() == hidden_states.shape[0], (
+                "SFA Prolog V3 requires one cache index per input token, "
+                f"got token_x={hidden_states.shape[0]} and cache_index={slot_mapping.numel()}."
+            )
+            if self.has_indexer:
+                k_li, k_li_scale = self.indexer_select_pre_process(x=hidden_states, cos=cos, sin=sin)
+            else:
+                k_li, k_li_scale = None, None
+
+            # Prolog updates the paged KV cache in place. Wait for the prompt
+            # blocks before writing the first Decode token into their tail block.
+            wait_for_kv_layer_from_connector(layer_name)
+            hidden_states, ql_nope, q_pe, q_c, _, _ = self._sfa_preprocess_with_prolog_v3(
+                hidden_states=hidden_states,
+                kv_cache=kv_cache,
+                cos=cos,
+                sin=sin,
+                slot_mapping=slot_mapping,
+                cache_mode="PA_BSND",
+            )
         # run mlapo ops when dsa-cp is disabled, and ensure that num_tokens satisfies the count limitation
-        if self.enable_mlapo and (
+        elif self.enable_mlapo and (
             get_ascend_device_type() == AscendDeviceType.A5 or num_input_tokens <= MLAPO_MAX_SUPPORTED_TOKENS
         ):
             hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
@@ -1440,90 +1606,67 @@ class AscendSFAImpl(MLAAttentionImpl):
 
             if self.enable_dsa_cp:
                 assert slot_mapping_cp is not None
-                k_pe, k_nope, knope_scale = self.exec_kv(
-                    kv_no_split, cos, sin, kv_cache, slot_mapping_cp, attn_metadata
-                )
+                kv_slots = slot_mapping_cp
             else:
-                k_pe, k_nope = self.exec_kv(kv_no_split, cos, sin, kv_cache, slot_mapping_sfa, attn_metadata)
+                kv_slots = slot_mapping_sfa
+            kv_outputs = self.exec_kv(kv_no_split, cos, sin, kv_cache, kv_slots, attn_metadata)
+            k_pe, k_nope = kv_outputs[:2]
+            knope_scale = kv_outputs[2] if len(kv_outputs) == 3 else None
+
+            if (
+                self.use_sparse_c8
+                and not self.enable_dsa_cp
+                and (get_ascend_device_type() != AscendDeviceType.A5 or not self.has_indexer)
+            ):
+                assert k_pe is not None
+                assert k_nope is not None
+                assert knope_scale is not None
+                packed_kv = torch.cat([k_nope, k_pe, knope_scale], dim=-1)
+                packed_head_dim = self.sfa_qsfa_packed_kv_head_dim
+                assert packed_kv.shape[-1] == packed_head_dim
+                torch_npu.npu_scatter_nd_update_(
+                    kv_cache[0].view(-1, packed_head_dim),
+                    slot_mapping_sfa.view(-1, 1),
+                    packed_kv.view(-1, packed_head_dim),
+                )
 
             if self.enable_dsa_cp:
                 assert k_pe is not None
                 assert k_nope is not None
                 async_op = self.enable_dsa_cp_with_layer_shard or full_gather_o_proj_enabled
-
                 # support all_gather kv async for communication calculation overlap
-                if not self.has_indexer:
-                    fused_kv_no_split, kv_ag_handle = all_gather_async(
-                        torch.cat(
-                            [
-                                k_pe.view(-1, k_pe.shape[-1]),
-                                k_nope.view(-1, k_nope.shape[-1]),
-                            ],
-                            dim=1,
-                        ),
-                        get_tp_group(),
-                        async_op=async_op,
-                    )
-                elif not self.use_sparse_c8_indexer:
-                    assert k_li is not None
-                    fused_kv_no_split, kv_ag_handle = all_gather_async(
-                        torch.cat(
-                            [
-                                k_pe.view(-1, k_pe.shape[-1]),
-                                k_nope.view(-1, k_nope.shape[-1]),
-                                k_li.view(-1, k_li.shape[-1]),
-                            ],
-                            dim=1,
-                        ),
-                        get_tp_group(),
-                        async_op=async_op,
-                    )
-                elif self.use_a5_sparse_c8_indexer:
-                    # due to different dtypes, we have to split commu pass
+                if self.use_sparse_c8:
                     assert knope_scale is not None
-                    assert k_li_scale is not None
-                    fused_kv_no_split, _ = all_gather_async(
-                        torch.cat(
-                            [
-                                k_nope.view(-1, k_nope.shape[-1]),
-                                k_pe.view(-1, k_pe.shape[-1]),
-                                knope_scale.view(-1, knope_scale.shape[-1]),
-                            ],
-                            dim=1,
-                        ),
-                        get_tp_group(),
-                        async_op=async_op,
-                    )
-                    k_li, _ = all_gather_async(
-                        k_li,
-                        get_tp_group(),
-                        async_op=async_op,
-                    )
-                    k_li_scale, kv_ag_handle = all_gather_async(
-                        k_li_scale,
-                        get_tp_group(),
-                        async_op=async_op,
-                    )
+                    fused_kv_parts = [
+                        k_nope.view(-1, k_nope.shape[-1]),
+                        k_pe.view(-1, k_pe.shape[-1]),
+                        knope_scale.view(-1, knope_scale.shape[-1]),
+                    ]
                 else:
-                    # due to different dtypes, we have to split commu pass
+                    fused_kv_parts = [
+                        k_pe.view(-1, k_pe.shape[-1]),
+                        k_nope.view(-1, k_nope.shape[-1]),
+                    ]
+                    if self.has_indexer and not self.use_sparse_c8:
+                        assert k_li is not None
+                        fused_kv_parts.append(k_li.view(-1, k_li.shape[-1]))
+
+                fused_kv_input = torch.cat(fused_kv_parts, dim=1)
+                fused_kv_no_split, kv_ag_handle = all_gather_async(
+                    fused_kv_input,
+                    get_tp_group(),
+                    async_op=async_op,
+                )
+
+                if self.has_indexer and self.use_sparse_c8:
                     assert k_li is not None
-                    assert k_li_scale is not None
-                    fused_kv_no_split, _ = all_gather_async(
-                        torch.cat(
-                            [
-                                k_pe.view(-1, k_pe.shape[-1]),
-                                k_nope.view(-1, k_nope.shape[-1]),
-                            ],
-                            dim=1,
-                        ),
-                        get_tp_group(),
-                        async_op=async_op,
-                    )
-                    k_li, _ = all_gather_async(
+                    k_li, kv_ag_handle = all_gather_async(
                         k_li,
                         get_tp_group(),
                         async_op=async_op,
                     )
+                if self.has_indexer and self.use_sparse_c8:
+                    assert k_li_scale is not None
                     k_li_scale, kv_ag_handle = all_gather_async(
                         k_li_scale,
                         get_tp_group(),
@@ -1559,17 +1702,7 @@ class AscendSFAImpl(MLAAttentionImpl):
 
                 if kv_cache is not None:
                     assert fused_kv_no_split is not None
-                    if not self.has_indexer:
-                        k_pe, k_nope = fused_kv_no_split.split(
-                            [self.qk_rope_head_dim, self.kv_lora_rank],
-                            dim=-1,
-                        )
-                    elif not self.use_sparse_c8_indexer:
-                        k_pe, k_nope, k_li = fused_kv_no_split.split(
-                            [self.qk_rope_head_dim, self.kv_lora_rank, self.head_dim],
-                            dim=-1,
-                        )
-                    elif self.use_a5_sparse_c8_indexer:
+                    if self.use_sparse_c8:
                         torch_npu.npu_scatter_nd_update_(
                             kv_cache[0].view(-1, fused_kv_no_split.shape[-1]),
                             slot_mapping_sfa[: attn_metadata.num_actual_tokens].view(-1, 1),
@@ -1577,12 +1710,22 @@ class AscendSFAImpl(MLAAttentionImpl):
                         )
                         k_pe = None
                         k_nope = None
+                    elif not self.has_indexer:
+                        k_pe, k_nope = fused_kv_no_split.split(
+                            [self.qk_rope_head_dim, self.kv_lora_rank],
+                            dim=-1,
+                        )
+                    elif not self.use_sparse_c8:
+                        k_pe, k_nope, k_li = fused_kv_no_split.split(
+                            [self.qk_rope_head_dim, self.kv_lora_rank, self.head_dim],
+                            dim=-1,
+                        )
                     else:
                         k_pe, k_nope = fused_kv_no_split.split(
                             [self.qk_rope_head_dim, self.kv_lora_rank],
                             dim=-1,
                         )
-                    if not self.use_a5_sparse_c8_indexer:
+                    if not self.use_sparse_c8:
                         assert k_pe is not None
                         assert k_nope is not None
                         k_nope = k_nope.view(k_nope.shape[0], 1, -1)
@@ -1604,14 +1747,15 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         if kv_cache is not None and self.has_indexer:
             assert k_li is not None
-            if self.use_sparse_c8_indexer and get_ascend_device_type() == AscendDeviceType.A5:
+            use_indexer_reshape_optim = self.is_kv_producer and get_ascend_config().c8_enable_reshape_optim
+            if self.use_sparse_c8:
                 dsa_k_cache_idx = 1
                 dsa_k_scale_cache_idx = 2
             else:
                 dsa_k_cache_idx = 2
                 dsa_k_scale_cache_idx = 3
 
-            if self.is_kv_producer and get_ascend_config().c8_enable_reshape_optim:
+            if use_indexer_reshape_optim:
                 torch.ops._C_ascend.store_kv_block(
                     k_li,
                     kv_cache[dsa_k_cache_idx],
@@ -1626,13 +1770,10 @@ class AscendSFAImpl(MLAAttentionImpl):
                     slot_mapping.view(-1, 1),
                     k_li.view(-1, k_li.shape[-1]),
                 )  # b, s, n, d
-            if self.use_sparse_c8_indexer:
-                if get_ascend_device_type() == AscendDeviceType.A5:
-                    assert len(kv_cache) == 3
-                else:
-                    assert len(kv_cache) == 4
+            if self.use_sparse_c8:
+                assert len(kv_cache) == 3
                 if k_li_scale is not None:
-                    if self.is_kv_producer and get_ascend_config().c8_enable_reshape_optim:
+                    if use_indexer_reshape_optim:
                         torch.ops._C_ascend.store_kv_block(
                             k_li_scale,
                             kv_cache[dsa_k_scale_cache_idx],
@@ -1648,8 +1789,8 @@ class AscendSFAImpl(MLAAttentionImpl):
                             k_li_scale.view(-1, k_li_scale.shape[-1]),
                         )
 
-            if self.is_kv_producer:
-                attn_metadata.reshape_cache_event.record()
+        if kv_cache is not None and self.is_kv_producer:
+            attn_metadata.reshape_cache_event.record()
 
         if self.enable_dsa_cp and attn_metadata.dsa_cp_context is not None:
             topk_num_tokens = attn_metadata.dsa_cp_context.local_end_with_pad - attn_metadata.dsa_cp_context.local_start
@@ -1660,6 +1801,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         else:
             if not self.has_indexer:
                 raise RuntimeError(f"skip_topk is False but indexer is None. layer_name={self.layer_name}.")
+            assert q_c is not None
             topk_indices = self.indexer_select_post_process(
                 x=hidden_states,
                 q_c=q_c,
@@ -1715,34 +1857,37 @@ class AscendSFAImpl(MLAAttentionImpl):
 
 
 def custom_kv_rmsnorm_rope(
-    kv,
-    gamma,
-    cos,
-    sin,
-    index,
-    k_cache,
-    ckv_cache,
-    k_rope_scale=None,
-    c_kv_scale=None,
-    k_rope_offset=None,
-    c_kv_offset=None,
-    v=None,
-    epsilon=1e-05,
-    cache_mode="Norm",
-    is_output_kv=False,
-):
-    # Split KV into RMSNorm and RoPE parts for sparse C8 cache preparation.
-    rms_in, rope_in = kv.split([512, 64], dim=-1)
+    kv: torch.Tensor,
+    gamma: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    kv_lora_rank: int,
+    qk_rope_head_dim: int,
+    *,
+    epsilon: float = 1e-5,
+    dst_type: torch.dtype | int = torch.float8_e4m3fn,
+    tile_size: int = SFA_QSFA_TILE_SIZE,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    rms_in, rope_in = kv.split([kv_lora_rank, qk_rope_head_dim], dim=-1)
     k_nope, _ = torch_npu.npu_rms_norm(rms_in, gamma, epsilon=epsilon)
     k_rope = torch_npu.npu_interleave_rope(rope_in, cos, sin)
 
-    # Store k_nope with block FP8 scales for the sparse C8 cache layout.
+    prefix_shape = k_nope.shape[:-1]
     k_nope, knope_scale = torch_npu.npu_dynamic_block_quant(
-        k_nope.view(-1, 1, k_nope.shape[-1]),
-        dst_type=torch.float8_e4m3fn,
+        k_nope.contiguous().view(-1, 1, kv_lora_rank),
+        dst_type=dst_type,
         row_block_size=1,
-        col_block_size=128,
+        col_block_size=tile_size,
     )
+    if dst_type == 1 or dst_type == torch.int8:
+        # Return byte views so the caller can concatenate all three components.
+        return (
+            k_rope.contiguous().view(torch.int8),
+            k_nope.view(*prefix_shape, kv_lora_rank),
+            knope_scale.to(torch.float32).view(*prefix_shape, -1).contiguous().view(torch.int8),
+        )
+
+    # A5 transports the BF16 rope and scale bytes through FP8-typed tensors.
     return (
         k_rope.view(torch.float8_e4m3fn),
         k_nope,

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -8,6 +8,7 @@ import torch_npu
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group, is_v1_kv_transfer_group
 from vllm.forward_context import ForwardContext, get_forward_context
+from vllm.utils.torch_utils import get_dtype_size
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 
 from vllm_ascend.device.utils import FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE
@@ -18,6 +19,22 @@ from vllm_ascend.utils import (
     is_pd_decode_recompute_scheduler_enabled,
 )
 from vllm_ascend.worker.kvcomp_utils import KVCompMetaData
+
+SFA_QSFA_TILE_SIZE = 128
+
+
+def get_sfa_qsfa_packed_head_dim(
+    kv_lora_rank: int,
+    qk_rope_head_dim: int,
+    tile_size: int = SFA_QSFA_TILE_SIZE,
+) -> int:
+    if kv_lora_rank % tile_size != 0:
+        raise ValueError(
+            f"kv_lora_rank must be divisible by tile_size for SFA QSFA packed cache, "
+            f"got {kv_lora_rank=} and {tile_size=}."
+        )
+    scale_metadata_bytes = (kv_lora_rank // tile_size) * get_dtype_size(torch.float32)
+    return kv_lora_rank + qk_rope_head_dim * get_dtype_size(torch.bfloat16) + scale_metadata_bytes
 
 
 @dataclass

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -33,12 +33,17 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
     to
     (kv_cache[0]: bfloat16, kv_cache[1]: bfloat16, kv_cache[2]: int8, kv_cache[3]: float16).
 
-    The semantic meaning of each KV cache entry is as follows:
+    The semantic meaning of each native KV cache entry is as follows:
     1. kv_cache[0] stores kv_lora.
     2. kv_cache[1] stores k_rope.
     3. kv_cache[2] stores the key tensor from the indexer module.
     4. kv_cache[3] stores the key scale tensor from the indexer module,
        and exists only when Sparse C8 is enabled.
+
+    With SFA KV-quant sparse attention, kv_lora, k_rope, and per-tile
+    quantization scales are packed into kv_cache[0]. The resulting cache is
+    (packed_kv, indexer_k) or (packed_kv, indexer_k, indexer_scale) when
+    Sparse C8 indexer cache is enabled.
 
     The main changes are as follows:
     1. The key tensor from the indexer module stored in kv_cache[2] is
@@ -65,23 +70,17 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
             assert len(self.sparse_head_dim) == 3
             num_heads_per_page = self.block_size * self.num_kv_heads
 
-            kv_lora_rank, qk_rope_head_dim, index_head_dim = self.sparse_head_dim
+            ckv_head_dim, qk_rope_head_dim, index_head_dim = self.sparse_head_dim
+            assert qk_rope_head_dim == 0
 
-            # A5: kv_lora and k_rope are merged into a single CKV tensor (fp8).
-            # A3: separate kv_lora + k_rope (bf16).
-            if qk_rope_head_dim == 0:
-                kv_dtype = self.c8_k_cache_dtype  # A5 CKV: float8_e4m3fn
-                kv_dim = kv_lora_rank
-            else:
-                kv_dtype = self.dtype  # A3 kv_lora + k_rope: bfloat16
-                kv_dim = kv_lora_rank + qk_rope_head_dim
-
-            kv_bytes = num_heads_per_page * kv_dim * get_dtype_size(kv_dtype)
+            ckv_bytes = num_heads_per_page * ckv_head_dim * get_dtype_size(self.c8_k_cache_dtype)
             qli_bytes = num_heads_per_page * index_head_dim * get_dtype_size(self.c8_k_cache_dtype)
             qli_scale_bytes = (
                 num_heads_per_page * self.sfa_dcp_replicated_indexer_size * get_dtype_size(self.c8_k_scale_cache_dtype)
+                if index_head_dim > 0
+                else 0
             )
-            return kv_bytes + qli_bytes + qli_scale_bytes
+            return ckv_bytes + qli_bytes + qli_scale_bytes
 
         return (
             self.block_size
@@ -90,7 +89,7 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
         )
 
     @property
-    def sparse_kv_cache_ratio(self) -> tuple[float, float, float, float | None]:
+    def sparse_kv_cache_ratio(self) -> tuple[float, float | None, float | None, float | None]:
         """
         Compute the relative byte share of each KV cache entry.
 
@@ -104,59 +103,36 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
 
         assert self.sparse_head_dim is not None
 
-        def get_sparse_head_dim_virtual() -> tuple[int, int, int, int]:
-            assert self.sparse_head_dim is not None
-            assert self.cache_sparse_c8 is True
+        if self.cache_sparse_c8:
+            ckv_head_dim, qk_rope_head_dim, index_k_head_dim = self.sparse_head_dim
+            assert qk_rope_head_dim == 0
 
-            kv_lora_rank, qk_rope_head_dim, index_k_head_dim = self.sparse_head_dim
+            ckv_virtual = ckv_head_dim * get_dtype_size(self.c8_k_cache_dtype)
+            if index_k_head_dim == 0:
+                return (
+                    1.0,  # kv_cache[0]: ckv / packed_kv
+                    None,  # kv_cache[1] does not exist without indexer cache
+                    None,  # kv_cache[2] does not exist without indexer cache
+                    None,  # kv_cache[3] does not exist for Sparse C8
+                )
 
-            if qk_rope_head_dim == 0:
-                # A5: ckv (float8_e4m3fn) and qli share c8_k_cache_dtype;
-                ckv_virtual = kv_lora_rank * get_dtype_size(self.c8_k_cache_dtype)
-                qk_rope_virtual = 0
-                qli_virtual = index_k_head_dim * get_dtype_size(self.c8_k_cache_dtype)
-                scale_virtual = self.sfa_dcp_replicated_indexer_size * get_dtype_size(self.c8_k_scale_cache_dtype)
-                return (ckv_virtual, qk_rope_virtual, qli_virtual, scale_virtual)
-
-            # A3: keep the original element-count / byte mix
-            factor = get_dtype_size(self.dtype) // get_dtype_size(self.c8_k_cache_dtype)
-            index_k_head_dim_virtual = index_k_head_dim // factor
-
-            assert get_dtype_size(self.dtype) == get_dtype_size(self.c8_k_scale_cache_dtype)
-            index_k_scale_head_dim_virtual = self.sfa_dcp_replicated_indexer_size
+            qli_virtual = index_k_head_dim * get_dtype_size(self.c8_k_cache_dtype)
+            scale_virtual = self.sfa_dcp_replicated_indexer_size * get_dtype_size(self.c8_k_scale_cache_dtype)
+            total_virtual_head_dim = ckv_virtual + qli_virtual + scale_virtual
 
             return (
-                kv_lora_rank,
-                qk_rope_head_dim,
-                index_k_head_dim_virtual,
-                index_k_scale_head_dim_virtual,
+                total_virtual_head_dim / ckv_virtual,  # kv_cache[0]: ckv / packed_kv
+                total_virtual_head_dim / qli_virtual,  # kv_cache[1]: qli
+                total_virtual_head_dim / scale_virtual,  # kv_cache[2]: qli_scale
+                None,  # kv_cache[3] does not exist for Sparse C8
             )
-
-        if self.cache_sparse_c8:
-            virtual_dims = get_sparse_head_dim_virtual()
-            total_virtual_head_dim = sum(virtual_dims)
-
-            if virtual_dims[1] == 0:
-                # A5: ckv merged (kv_lora + k_rope + scale) → 3-tensor
-                return (
-                    total_virtual_head_dim / virtual_dims[0],  # kv_cache[0]: ckv
-                    total_virtual_head_dim / virtual_dims[2],  # kv_cache[1]: qli
-                    total_virtual_head_dim / virtual_dims[3],  # kv_cache[2]: qli_scale
-                    None,  # kv_cache[3] does not exist for A5
-                )
-            else:
-                # A3: 4-tensor
-                return (
-                    total_virtual_head_dim / virtual_dims[0],  # kv_cache[0]
-                    total_virtual_head_dim / virtual_dims[1],  # kv_cache[1]
-                    total_virtual_head_dim / virtual_dims[2],  # kv_cache[2]
-                    total_virtual_head_dim / virtual_dims[3],  # kv_cache[3]
-                )
 
         return (
             self.head_size / self.sparse_head_dim[0],  # kv_cache[0]
             self.head_size / self.sparse_head_dim[1],  # kv_cache[1]
-            self.head_size / self.sparse_head_dim[2],  # kv_cache[2]
+            (
+                self.head_size / self.sparse_head_dim[2] if self.sparse_head_dim[2] > 0 else None
+            ),  # kv_cache[2]  # kv_cache[2]
             None,  # kv_cache[3] does not exist
         )
 
@@ -192,6 +168,7 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
         assert len(sfa_dcp_replicated_indexer_size_set) == 1, (
             "All attention layers in the same KV cache group must use the same SFA DCP replicated indexer size."
         )
+
         return cls(
             block_size=specs[0].block_size,
             num_kv_heads=specs[0].num_kv_heads,

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -439,7 +439,7 @@ class BaseDeviceAdaptor:
         rope_cos = rope_cos.view(rope_cos.shape[0], rope_cos.shape[-1])
         rope_sin = rope_sin.view(rope_sin.shape[0], rope_sin.shape[-1])
 
-        packed_kv_cache = sfa_impl.use_sparse_c8
+        packed_kv_cache = getattr(sfa_impl, "use_sparse_c8_sfa", False)
         if packed_kv_cache:
             assert sfa_impl.sfa_qsfa_kr_cache_dummy is not None
             kr_cache = sfa_impl.sfa_qsfa_kr_cache_dummy
@@ -553,18 +553,18 @@ class BaseDeviceAdaptor:
         attn_metadata,
         actual_seq_lengths_query: torch.Tensor,
         actual_seq_lengths_key: torch.Tensor,
-        use_sparse_c8: bool,
+        use_sparse_c8_indexer: bool,
         use_torch_npu_lightning_indexer: bool,
     ) -> torch.Tensor:
         # DSV3.2 currently has graph compilation issues when using torch_npu.npu.lightning_indexer.
         # So two branches are maintained temporarily.
         # TODO: torch.ops._C_ascend.npu_lightning_indexer needs to be removed.
-        packed_kv_cache = getattr(sfa_impl, "use_sparse_c8", False)
+        packed_kv_cache = getattr(sfa_impl, "use_sparse_c8_sfa", False)
         indexer_cache_idx = 1 if packed_kv_cache else 2
         indexer_scale_cache_idx = 2 if packed_kv_cache else 3
 
-        if sfa_impl.use_sparse_c8:
-            assert len(kv_cache) == 3
+        if use_sparse_c8_indexer:
+            assert len(kv_cache) == (3 if packed_kv_cache else 4)
             assert q_li_scale is not None
             assert q_li_shape_ori is not None
             weights = weights.to(torch.float16)
@@ -626,7 +626,12 @@ class BaseDeviceAdaptor:
         block_table = attn_metadata.block_table
         kv = kv_cache[0]
 
-        use_kv_quant_sparse_attention = getattr(sfa_impl, "use_sparse_c8", False) or kv.dtype in (
+        # The kv-quant sparse attention op only accepts packed quantized KV.
+        # Do not route by the feature flag alone: tests and fallback paths may
+        # pass a normal BF16/FP16 KV cache even when the mocked impl exposes a
+        # truthy attribute.
+        use_kv_quant_sparse_attention = kv.dtype in (
+            torch.int8,
             torch.float8_e4m3fn,
             torch.float8_e5m2,
         )
@@ -1672,7 +1677,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         sin = sin.view(cos_shape[0], 1, cos_shape[-1])
 
         decode_k_nope = kv_cache[0]
-        use_c8 = getattr(sfa_impl, "use_sparse_c8", False)
+        use_c8 = getattr(sfa_impl, "use_sparse_c8_sfa", False)
         kr_cache = (
             torch.zeros(0, 0, decode_k_nope.shape[-2], cos_shape[-1], dtype=torch.bfloat16, device=decode_k_nope.device)
             if use_c8
@@ -1745,20 +1750,24 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         attn_metadata,
         actual_seq_lengths_query: torch.Tensor,
         actual_seq_lengths_key: torch.Tensor,
-        use_sparse_c8: bool,
+        use_sparse_c8_indexer: bool,
         use_torch_npu_lightning_indexer: bool,
     ) -> torch.Tensor:
-        if use_sparse_c8:
-            assert len(kv_cache) == 3
+        packed_kv_cache = getattr(sfa_impl, "use_sparse_c8_sfa", False)
+        indexer_cache_idx = 1 if packed_kv_cache else 2
+        indexer_scale_cache_idx = 2 if packed_kv_cache else 3
+
+        if use_sparse_c8_indexer:
+            assert len(kv_cache) == (3 if packed_kv_cache else 4)
             assert q_li_shape_ori is not None
 
             if q_li_scale is not None:
                 q_li_scale = q_li_scale.view(q_li_shape_ori[:-1])
-                key_dequant_scale = kv_cache[2].squeeze(2)
+                key_dequant_scale = kv_cache[indexer_scale_cache_idx].squeeze(2)
 
                 topk_indices = torch_npu.npu_quant_lightning_indexer(
                     query=q_li.view(q_li_shape_ori),
-                    key=kv_cache[1],
+                    key=kv_cache[indexer_cache_idx],
                     weights=weights,
                     query_dequant_scale=q_li_scale,
                     key_dequant_scale=key_dequant_scale,
@@ -1775,7 +1784,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             else:
                 topk_indices, _ = torch_npu.npu_lightning_indexer(
                     query=q_li.view(q_li_shape_ori),
-                    key=kv_cache[1],
+                    key=kv_cache[indexer_cache_idx],
                     weights=weights,
                     actual_seq_lengths_query=actual_seq_lengths_query,
                     actual_seq_lengths_key=actual_seq_lengths_key,
@@ -1788,7 +1797,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         else:
             topk_indices, _ = torch_npu.npu_lightning_indexer(
                 query=q_li,
-                key=kv_cache[2],
+                key=kv_cache[indexer_cache_idx],
                 weights=weights,
                 actual_seq_lengths_query=actual_seq_lengths_query,
                 actual_seq_lengths_key=actual_seq_lengths_key,

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -421,6 +421,72 @@ class BaseDeviceAdaptor:
         return hidden_states, ql_nope, q_pe, q_c
 
     @staticmethod
+    def execute_sfa_mla_prolog_v3(
+        sfa_impl,
+        *,
+        hidden_states: torch.Tensor,
+        rope_sin: torch.Tensor,
+        rope_cos: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...],
+        slot_mapping: torch.Tensor,
+        cache_mode: str,
+    ) -> tuple:
+        assert sfa_impl.q_a_layernorm is not None
+        assert sfa_impl.kv_a_layernorm is not None
+
+        token_x, dynamic_scale = torch_npu.npu_dynamic_quant(hidden_states.contiguous())
+        dynamic_scale = dynamic_scale.view(-1, 1)
+        rope_cos = rope_cos.view(rope_cos.shape[0], rope_cos.shape[-1])
+        rope_sin = rope_sin.view(rope_sin.shape[0], rope_sin.shape[-1])
+
+        packed_kv_cache = sfa_impl.use_sparse_c8
+        if packed_kv_cache:
+            assert sfa_impl.sfa_qsfa_kr_cache_dummy is not None
+            kr_cache = sfa_impl.sfa_qsfa_kr_cache_dummy
+        else:
+            kr_cache = kv_cache[1]
+
+        prolog_kwargs = {
+            "token_x": token_x,
+            "weight_dq": sfa_impl.weight_dq,
+            "weight_uq_qr": sfa_impl.weight_uq_qr,
+            "weight_uk": sfa_impl.W_UK_T,
+            "weight_dkv_kr": sfa_impl.weight_dkv_kr,
+            "rmsnorm_gamma_cq": sfa_impl.q_a_layernorm.weight.data,
+            "rmsnorm_gamma_ckv": sfa_impl.kv_a_layernorm.weight.data,
+            "rope_sin": rope_sin,
+            "rope_cos": rope_cos,
+            "kv_cache": kv_cache[0],
+            "kr_cache": kr_cache,
+            "cache_mode": cache_mode,
+            "dequant_scale_x": dynamic_scale,
+            "dequant_scale_w_dq": sfa_impl.dequant_scale_w_dq,
+            "dequant_scale_w_uq_qr": sfa_impl.dequant_scale_w_uq_qr,
+            "dequant_scale_w_dkv_kr": sfa_impl.dequant_scale_w_dkv_kr,
+            "query_quant_mode": 0,
+            "weight_quant_mode": 2,
+            "kv_cache_quant_mode": 0,
+            "query_norm_flag": sfa_impl.has_indexer,
+            "rmsnorm_epsilon_cq": sfa_impl.q_a_layernorm.variance_epsilon,
+            "rmsnorm_epsilon_ckv": sfa_impl.kv_a_layernorm.variance_epsilon,
+            "qc_qr_scale": 1.0,
+            "kc_scale": 1.0,
+        }
+        if cache_mode == "PA_BSND":
+            prolog_kwargs["cache_index"] = slot_mapping.view(-1).to(torch.int64)
+        if packed_kv_cache:
+            prolog_kwargs.update(
+                {
+                    "kv_cache_quant_mode": 3,
+                    "ckvkr_repo_mode": 1,
+                    "quant_scale_repo_mode": 1,
+                    "tile_size": sfa_impl.sfa_qsfa_tile_size,
+                    "k_nope_clip_alpha": sfa_impl.sfa_qsfa_k_nope_clip_alpha,
+                }
+            )
+        return torch_npu.npu_mla_prolog_v3(**prolog_kwargs)
+
+    @staticmethod
     def indexer_select_post_process(
         sfa_impl,
         q_li: torch.Tensor,
@@ -431,23 +497,27 @@ class BaseDeviceAdaptor:
         attn_metadata,
         actual_seq_lengths_query: torch.Tensor,
         actual_seq_lengths_key: torch.Tensor,
-        use_sparse_c8_indexer: bool,
+        use_sparse_c8: bool,
         use_torch_npu_lightning_indexer: bool,
     ) -> torch.Tensor:
         # DSV3.2 currently has graph compilation issues when using torch_npu.npu.lightning_indexer.
         # So two branches are maintained temporarily.
         # TODO: torch.ops._C_ascend.npu_lightning_indexer needs to be removed.
-        if sfa_impl.use_sparse_c8_indexer:
-            assert len(kv_cache) == 4
+        packed_kv_cache = getattr(sfa_impl, "use_sparse_c8", False)
+        indexer_cache_idx = 1 if packed_kv_cache else 2
+        indexer_scale_cache_idx = 2 if packed_kv_cache else 3
+
+        if sfa_impl.use_sparse_c8:
+            assert len(kv_cache) == 3
             assert q_li_scale is not None
             assert q_li_shape_ori is not None
             weights = weights.to(torch.float16)
             topk_indices = torch.ops._C_ascend.npu_lightning_indexer_quant(
                 query=q_li.view(q_li_shape_ori),
-                key=kv_cache[2],
+                key=kv_cache[indexer_cache_idx],
                 weights=weights,
                 query_dequant_scale=q_li_scale.view(q_li_shape_ori[:-1]),
-                key_dequant_scale=kv_cache[3].squeeze(2),  # B S N D -> B S D
+                key_dequant_scale=kv_cache[indexer_scale_cache_idx].squeeze(2),  # B S N D -> B S D
                 actual_seq_lengths_query=actual_seq_lengths_query,
                 actual_seq_lengths_key=actual_seq_lengths_key,
                 block_table=attn_metadata.block_table,
@@ -461,7 +531,7 @@ class BaseDeviceAdaptor:
         elif sfa_impl.use_torch_npu_lightning_indexer:
             topk_indices, _ = torch_npu.npu_lightning_indexer(
                 query=q_li,
-                key=kv_cache[2],
+                key=kv_cache[indexer_cache_idx],
                 weights=weights,
                 actual_seq_lengths_query=actual_seq_lengths_query,
                 actual_seq_lengths_key=actual_seq_lengths_key,
@@ -474,7 +544,7 @@ class BaseDeviceAdaptor:
         else:
             topk_indices, _ = torch.ops._C_ascend.npu_lightning_indexer(
                 query=q_li,
-                key=kv_cache[2],
+                key=kv_cache[indexer_cache_idx],
                 weights=weights,
                 actual_seq_lengths_query=actual_seq_lengths_query,
                 actual_seq_lengths_key=actual_seq_lengths_key,
@@ -499,8 +569,20 @@ class BaseDeviceAdaptor:
     ) -> torch.Tensor:
         block_table = attn_metadata.block_table
         kv = kv_cache[0]
-        key_rope = kv_cache[1]
 
+        if getattr(sfa_impl, "use_sparse_c8", False):
+            return BaseDeviceAdaptor.execute_kv_quant_sparse_flash_attention(
+                sfa_impl,
+                ql_nope,
+                q_pe,
+                kv,
+                block_table,
+                topk_indices,
+                actual_seq_lengths_query,
+                actual_seq_lengths_key,
+            )
+
+        key_rope = kv_cache[1]
         attn_output, _, _ = torch.ops._C_ascend.npu_sparse_flash_attention(
             query=ql_nope,
             key=kv,
@@ -519,6 +601,39 @@ class BaseDeviceAdaptor:
             attention_mode=2,
         )
         return attn_output
+
+    @staticmethod
+    def execute_kv_quant_sparse_flash_attention(
+        sfa_impl,
+        ql_nope: torch.Tensor,
+        q_pe: torch.Tensor,
+        kv: torch.Tensor,
+        block_table: torch.Tensor,
+        topk_indices: torch.Tensor,
+        actual_seq_lengths_query: torch.Tensor,
+        actual_seq_lengths_key: torch.Tensor,
+    ) -> torch.Tensor:
+        query = torch.cat([ql_nope, q_pe], dim=-1).contiguous()
+        return torch_npu.npu_kv_quant_sparse_flash_attention(
+            query=query,
+            key=kv,
+            value=kv,
+            sparse_indices=topk_indices,
+            scale_value=sfa_impl.scale,
+            sparse_block_size=1,
+            block_table=block_table,
+            actual_seq_lengths_query=actual_seq_lengths_query,
+            actual_seq_lengths_kv=actual_seq_lengths_key,
+            layout_query="TND",
+            layout_kv="PA_BSND",
+            sparse_mode=3,
+            attention_mode=2,
+            quant_scale_repo_mode=1,
+            tile_size=sfa_impl.sfa_qsfa_tile_size,
+            key_quant_mode=2,
+            value_quant_mode=2,
+            rope_head_dim=sfa_impl.qk_rope_head_dim,
+        )
 
     @staticmethod
     def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):
@@ -1497,7 +1612,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         sin = sin.view(cos_shape[0], 1, cos_shape[-1])
 
         decode_k_nope = kv_cache[0]
-        use_c8 = getattr(sfa_impl, "use_sparse_c8_indexer", False)
+        use_c8 = getattr(sfa_impl, "use_sparse_c8", False)
         kr_cache = (
             torch.zeros(0, 0, decode_k_nope.shape[-2], cos_shape[-1], dtype=torch.bfloat16, device=decode_k_nope.device)
             if use_c8
@@ -1580,10 +1695,10 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         attn_metadata,
         actual_seq_lengths_query: torch.Tensor,
         actual_seq_lengths_key: torch.Tensor,
-        use_sparse_c8_indexer: bool,
+        use_sparse_c8: bool,
         use_torch_npu_lightning_indexer: bool,
     ) -> torch.Tensor:
-        if use_sparse_c8_indexer:
+        if use_sparse_c8:
             assert len(kv_cache) == 3
             assert q_li_shape_ori is not None
 
@@ -1648,7 +1763,6 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
     ) -> torch.Tensor:
         block_table = attn_metadata.block_table
         kv = kv_cache[0]
-        key_rope = kv_cache[1]
 
         if kv.dtype in [torch.float8_e4m3fn, torch.float8_e5m2]:
             query = torch.cat([ql_nope, q_pe], dim=-1)
@@ -1674,6 +1788,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
                 rope_head_dim=64,
             )
         else:
+            key_rope = kv_cache[1]
             attn_output, _, _ = torch_npu.npu_sparse_flash_attention(
                 query=ql_nope,
                 key=kv,

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -446,6 +446,69 @@ class BaseDeviceAdaptor:
         else:
             kr_cache = kv_cache[1]
 
+        cache_index = slot_mapping.view(-1).to(torch.int64) if cache_mode == "PA_BSND" else None
+        extra_kwargs = {}
+        if packed_kv_cache:
+            extra_kwargs.update(
+                {
+                    "ckvkr_repo_mode": 1,
+                    "quant_scale_repo_mode": 1,
+                    "tile_size": sfa_impl.sfa_qsfa_tile_size,
+                    "k_nope_clip_alpha": sfa_impl.sfa_qsfa_k_nope_clip_alpha,
+                }
+            )
+        return BaseDeviceAdaptor._execute_sfa_mla_prolog_v3_op(
+            sfa_impl,
+            token_x=token_x,
+            rope_sin=rope_sin,
+            rope_cos=rope_cos,
+            kv_cache=kv_cache[0],
+            kr_cache=kr_cache,
+            cache_mode=cache_mode,
+            cache_index=cache_index,
+            dequant_scale_x=dynamic_scale,
+            dequant_scale_w_dq=sfa_impl.dequant_scale_w_dq,
+            dequant_scale_w_uq_qr=sfa_impl.dequant_scale_w_uq_qr,
+            dequant_scale_w_dkv_kr=sfa_impl.dequant_scale_w_dkv_kr,
+            query_quant_mode=0,
+            weight_quant_mode=2,
+            kv_cache_quant_mode=3 if packed_kv_cache else 0,
+            query_norm_flag=sfa_impl.has_indexer,
+            rmsnorm_epsilon_cq=sfa_impl.q_a_layernorm.variance_epsilon,
+            rmsnorm_epsilon_ckv=sfa_impl.kv_a_layernorm.variance_epsilon,
+            qc_qr_scale=1.0,
+            kc_scale=1.0,
+            **extra_kwargs,
+        )
+
+    @staticmethod
+    def _execute_sfa_mla_prolog_v3_op(
+        sfa_impl,
+        *,
+        token_x: torch.Tensor,
+        rope_sin: torch.Tensor,
+        rope_cos: torch.Tensor,
+        kv_cache: torch.Tensor,
+        kr_cache: torch.Tensor,
+        cache_mode: str,
+        cache_index: torch.Tensor | None = None,
+        dequant_scale_x: torch.Tensor | None = None,
+        dequant_scale_w_dq: torch.Tensor | None = None,
+        dequant_scale_w_uq_qr: torch.Tensor | None = None,
+        dequant_scale_w_dkv_kr: torch.Tensor | None = None,
+        query_quant_mode: int = 0,
+        weight_quant_mode: int = 2,
+        kv_cache_quant_mode: int = 0,
+        query_norm_flag: bool | None = None,
+        rmsnorm_epsilon_cq: float | None = None,
+        rmsnorm_epsilon_ckv: float | None = None,
+        qc_qr_scale: float | None = None,
+        kc_scale: float | None = None,
+        **extra_kwargs,
+    ) -> tuple:
+        assert sfa_impl.q_a_layernorm is not None
+        assert sfa_impl.kv_a_layernorm is not None
+
         prolog_kwargs = {
             "token_x": token_x,
             "weight_dq": sfa_impl.weight_dq,
@@ -456,34 +519,27 @@ class BaseDeviceAdaptor:
             "rmsnorm_gamma_ckv": sfa_impl.kv_a_layernorm.weight.data,
             "rope_sin": rope_sin,
             "rope_cos": rope_cos,
-            "kv_cache": kv_cache[0],
+            "kv_cache": kv_cache,
             "kr_cache": kr_cache,
             "cache_mode": cache_mode,
-            "dequant_scale_x": dynamic_scale,
-            "dequant_scale_w_dq": sfa_impl.dequant_scale_w_dq,
-            "dequant_scale_w_uq_qr": sfa_impl.dequant_scale_w_uq_qr,
-            "dequant_scale_w_dkv_kr": sfa_impl.dequant_scale_w_dkv_kr,
-            "query_quant_mode": 0,
-            "weight_quant_mode": 2,
-            "kv_cache_quant_mode": 0,
-            "query_norm_flag": sfa_impl.has_indexer,
-            "rmsnorm_epsilon_cq": sfa_impl.q_a_layernorm.variance_epsilon,
-            "rmsnorm_epsilon_ckv": sfa_impl.kv_a_layernorm.variance_epsilon,
-            "qc_qr_scale": 1.0,
-            "kc_scale": 1.0,
+            "query_quant_mode": query_quant_mode,
+            "weight_quant_mode": weight_quant_mode,
+            "kv_cache_quant_mode": kv_cache_quant_mode,
         }
-        if cache_mode == "PA_BSND":
-            prolog_kwargs["cache_index"] = slot_mapping.view(-1).to(torch.int64)
-        if packed_kv_cache:
-            prolog_kwargs.update(
-                {
-                    "kv_cache_quant_mode": 3,
-                    "ckvkr_repo_mode": 1,
-                    "quant_scale_repo_mode": 1,
-                    "tile_size": sfa_impl.sfa_qsfa_tile_size,
-                    "k_nope_clip_alpha": sfa_impl.sfa_qsfa_k_nope_clip_alpha,
-                }
-            )
+        optional_kwargs = {
+            "cache_index": cache_index,
+            "dequant_scale_x": dequant_scale_x,
+            "dequant_scale_w_dq": dequant_scale_w_dq,
+            "dequant_scale_w_uq_qr": dequant_scale_w_uq_qr,
+            "dequant_scale_w_dkv_kr": dequant_scale_w_dkv_kr,
+            "query_norm_flag": query_norm_flag,
+            "rmsnorm_epsilon_cq": rmsnorm_epsilon_cq,
+            "rmsnorm_epsilon_ckv": rmsnorm_epsilon_ckv,
+            "qc_qr_scale": qc_qr_scale,
+            "kc_scale": kc_scale,
+        }
+        prolog_kwargs.update({key: value for key, value in optional_kwargs.items() if value is not None})
+        prolog_kwargs.update({key: value for key, value in extra_kwargs.items() if value is not None})
         return torch_npu.npu_mla_prolog_v3(**prolog_kwargs)
 
     @staticmethod
@@ -570,7 +626,11 @@ class BaseDeviceAdaptor:
         block_table = attn_metadata.block_table
         kv = kv_cache[0]
 
-        if getattr(sfa_impl, "use_sparse_c8", False):
+        use_kv_quant_sparse_attention = getattr(sfa_impl, "use_sparse_c8", False) or kv.dtype in (
+            torch.float8_e4m3fn,
+            torch.float8_e5m2,
+        )
+        if use_kv_quant_sparse_attention:
             return BaseDeviceAdaptor.execute_kv_quant_sparse_flash_attention(
                 sfa_impl,
                 ql_nope,
@@ -629,10 +689,10 @@ class BaseDeviceAdaptor:
             sparse_mode=3,
             attention_mode=2,
             quant_scale_repo_mode=1,
-            tile_size=sfa_impl.sfa_qsfa_tile_size,
+            tile_size=getattr(sfa_impl, "sfa_qsfa_tile_size", 128),
             key_quant_mode=2,
             value_quant_mode=2,
-            rope_head_dim=sfa_impl.qk_rope_head_dim,
+            rope_head_dim=getattr(sfa_impl, "qk_rope_head_dim", 64),
         )
 
     @staticmethod
@@ -1625,14 +1685,9 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             )
             dynamic_scale = dynamic_scale.reshape(hidden_states_temp.shape[0] * hidden_states_temp.shape[1], -1)
 
-            decode_q_nope, q_pe, _, q_c, q_c_scale = torch_npu.npu_mla_prolog_v3(
+            decode_q_nope, q_pe, _, q_c, q_c_scale = BaseDeviceAdaptor._execute_sfa_mla_prolog_v3_op(
+                sfa_impl,
                 token_x=hidden_states_temp,
-                weight_dq=sfa_impl.weight_dq,
-                weight_uq_qr=sfa_impl.weight_uq_qr,
-                weight_uk=sfa_impl.W_UK_T,
-                weight_dkv_kr=sfa_impl.weight_dkv_kr,
-                rmsnorm_gamma_cq=sfa_impl.q_a_layernorm.weight.data,
-                rmsnorm_gamma_ckv=sfa_impl.kv_a_layernorm.weight.data,
                 rope_sin=sin,
                 rope_cos=cos,
                 kv_cache=decode_k_nope,
@@ -1642,10 +1697,10 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
                 dequant_scale_w_dq=sfa_impl.weight_dq_scale.view(torch.float8_e8m0fnu),
                 dequant_scale_w_uq_qr=sfa_impl.weight_uq_qr_scale.view(torch.float8_e8m0fnu),
                 dequant_scale_w_dkv_kr=sfa_impl.weight_dkv_kr_scale.view(torch.float8_e8m0fnu),
-                cache_mode="PA_BSND",
+                query_quant_mode=0,
                 weight_quant_mode=3,
                 kv_cache_quant_mode=3 if use_c8 else 0,
-                query_quant_mode=0,
+                cache_mode="PA_BSND",
                 ckvkr_repo_mode=1 if use_c8 else 0,
                 quant_scale_repo_mode=1 if use_c8 else 0,
                 query_norm_flag=True,
@@ -1657,23 +1712,18 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             q_c_scale = q_c_scale.view(-1, q_c_scale.shape[-1])
             return hidden_states, decode_q_nope, q_pe, (q_c, q_c_scale)
         else:
-            decode_q_nope, q_pe, _, q_c, _ = torch_npu.npu_mla_prolog_v3(
+            decode_q_nope, q_pe, _, q_c, _ = BaseDeviceAdaptor._execute_sfa_mla_prolog_v3_op(
+                sfa_impl,
                 token_x=hidden_states_temp,
-                weight_dq=sfa_impl.weight_dq,
-                weight_uq_qr=sfa_impl.weight_uq_qr,
-                weight_uk=sfa_impl.W_UK_T,
-                weight_dkv_kr=sfa_impl.weight_dkv_kr,
-                rmsnorm_gamma_cq=sfa_impl.q_a_layernorm.weight.data,
-                rmsnorm_gamma_ckv=sfa_impl.kv_a_layernorm.weight.data,
                 rope_sin=sin,
                 rope_cos=cos,
                 kv_cache=decode_k_nope,
                 kr_cache=kr_cache,
                 cache_index=slot_mapping[:bsz].view(bsz, -1).to(torch.int64),
-                cache_mode="PA_BSND",
+                query_quant_mode=0,
                 weight_quant_mode=0,
                 kv_cache_quant_mode=0,
-                query_quant_mode=0,
+                cache_mode="PA_BSND",
                 ckvkr_repo_mode=0,
                 quant_scale_repo_mode=0,
                 query_norm_flag=True,
@@ -1749,64 +1799,6 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
                 sparse_mode=3,
             )
         return topk_indices
-
-    @staticmethod
-    def execute_sparse_flash_attention_process(
-        sfa_impl,
-        ql_nope: torch.Tensor,
-        q_pe: torch.Tensor,
-        kv_cache: tuple,
-        topk_indices: torch.Tensor,
-        attn_metadata,
-        actual_seq_lengths_query: torch.Tensor,
-        actual_seq_lengths_key: torch.Tensor,
-    ) -> torch.Tensor:
-        block_table = attn_metadata.block_table
-        kv = kv_cache[0]
-
-        if kv.dtype in [torch.float8_e4m3fn, torch.float8_e5m2]:
-            query = torch.cat([ql_nope, q_pe], dim=-1)
-
-            attn_output = torch_npu.npu_kv_quant_sparse_flash_attention(
-                query=query,
-                key=kv,
-                value=kv,
-                sparse_indices=topk_indices,
-                scale_value=sfa_impl.scale,
-                sparse_block_size=1,
-                block_table=block_table,
-                actual_seq_lengths_query=actual_seq_lengths_query,
-                actual_seq_lengths_kv=actual_seq_lengths_key,
-                layout_query="TND",
-                layout_kv="PA_BSND",
-                sparse_mode=3,
-                attention_mode=2,
-                quant_scale_repo_mode=1,
-                tile_size=128,
-                key_quant_mode=2,
-                value_quant_mode=2,
-                rope_head_dim=64,
-            )
-        else:
-            key_rope = kv_cache[1]
-            attn_output, _, _ = torch_npu.npu_sparse_flash_attention(
-                query=ql_nope,
-                key=kv,
-                value=kv,
-                sparse_indices=topk_indices,
-                scale_value=sfa_impl.scale,
-                sparse_block_size=1,
-                block_table=block_table,
-                actual_seq_lengths_query=actual_seq_lengths_query,
-                actual_seq_lengths_kv=actual_seq_lengths_key,
-                query_rope=q_pe,
-                key_rope=key_rope,
-                layout_query="TND",
-                layout_kv="PA_BSND",
-                sparse_mode=3,
-                attention_mode=2,
-            )
-        return attn_output
 
     @staticmethod
     def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -110,6 +110,7 @@ from vllm_ascend.attention.dsa_v1 import AscendDSAMetadataBuilder
 from vllm_ascend.attention.mla_v1 import AscendMLABackend
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
+    get_sfa_qsfa_packed_head_dim,
     using_paged_attention,
 )
 
@@ -367,19 +368,14 @@ class NPUModelRunner(GPUModelRunner):
         )
         if self.use_sparse:
             if get_ascend_device_type() == AscendDeviceType.A5 and self.ascend_config.enable_sparse_c8:
-                # A5 sparse C8: kv_lora and k_rope are merged into a single CKV FP8 tensor.
+                # A5 sparse C8 uses the same merged/packed KV layout as SFA QSFA.
                 # qk_rope_head_dim = 0 signals the merged layout.
-                # ckv_dim = kv_lora_rank                    (fp8, 1 byte/elem)
-                #         + qk_rope_head_dim * 2             (bf16→fp8: 2/1 bytes)
-                #         + 4 * 4                            (quant_scale metadata:
-                #                                              4 = kv_lora_rank / tile_size(128),
-                #                                              4 = float32→fp8: 4/1 bytes)
-                A5_CKV_SCALE_METADATA_BYTES = 4 * 4
-                ckv = self.model_config.hf_text_config.kv_lora_rank
-                rope = self.model_config.hf_text_config.qk_rope_head_dim
-                a5_ckv_dim = ckv + rope * 2 + A5_CKV_SCALE_METADATA_BYTES
+                packed_kv_head_dim = get_sfa_qsfa_packed_head_dim(
+                    self.model_config.hf_text_config.kv_lora_rank,
+                    self.model_config.hf_text_config.qk_rope_head_dim,
+                )
                 self.sparse_head_dim = (
-                    a5_ckv_dim,
+                    packed_kv_head_dim,
                     0,
                     self.model_config.hf_text_config.index_head_dim,
                 )
@@ -390,8 +386,8 @@ class NPUModelRunner(GPUModelRunner):
                     self.model_config.hf_text_config.index_head_dim,
                 )
         # dsa c8
-        self.use_sparse_c8_indexer = self.ascend_config.enable_sparse_c8
-        if self.use_sparse_c8_indexer:
+        self.use_sparse_c8 = self.ascend_config.enable_sparse_c8
+        if self.use_sparse_c8:
             if get_ascend_device_type() == AscendDeviceType.A5:
                 self.c8_k_cache_dtype = torch.float8_e4m3fn
                 self.c8_k_scale_cache_dtype = torch.float32
@@ -4273,31 +4269,32 @@ class NPUModelRunner(GPUModelRunner):
                     current_kv_cache_spec = layer_kv_cache_spec[layer_name]
                     assert isinstance(current_kv_cache_spec, AttentionSpec)
 
+                    dsa_k_tensor_split_factor = None
+                    dsa_k_scale_tensor_split_factor = None
                     if self.use_sparse:
                         # for deepseek v3.2, we split the kv cache according to the corresponding ratio
                         kv_cache_spec = layer_kv_cache_spec[layer_name]
                         current_sparse_c8 = kv_cache_spec_uses_sparse_c8(kv_cache_spec)
+                        assert isinstance(kv_cache_spec, AscendMLAAttentionSpec)
+                        assert kv_cache_spec.sparse_head_dim is not None
                         has_indexer_cache = sparse_kv_cache_has_indexer(kv_cache_spec)
 
                         if has_indexer_cache:
                             sparse_kv_cache_ratio = kv_cache_spec.sparse_kv_cache_ratio
-
-                            # A5 sparse C8: (ckv_ratio, qli_ratio, qli_scale_ratio, None)
-                            # A3 sparse C8: (k_ratio, v_ratio, qli_ratio, qli_scale_ratio)
-                            if current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
-                                k_tensor_split_factor = sparse_kv_cache_ratio[0]  # ckv
-                                v_tensor_split_factor = None  # merged
-                                dsa_k_tensor_split_factor = sparse_kv_cache_ratio[1]  # qli_tensor
-                                dsa_k_scale_tensor_split_factor = sparse_kv_cache_ratio[2]  # qli_scale
+                            k_tensor_split_factor = sparse_kv_cache_ratio[0]
+                            if current_sparse_c8:
+                                # Sparse C8 uses merged layout. Indexer cache is optional.
+                                v_tensor_split_factor = None
+                                dsa_k_tensor_split_factor = sparse_kv_cache_ratio[1]
+                                dsa_k_scale_tensor_split_factor = sparse_kv_cache_ratio[2]
                             else:
-                                k_tensor_split_factor = sparse_kv_cache_ratio[0]
                                 v_tensor_split_factor = sparse_kv_cache_ratio[1]
                                 dsa_k_tensor_split_factor = sparse_kv_cache_ratio[2]
-                                dsa_k_scale_tensor_split_factor = (
-                                    sparse_kv_cache_ratio[3] if current_sparse_c8 else None
-                                )
+                        elif current_sparse_c8:
+                            sparse_kv_cache_ratio = kv_cache_spec.sparse_kv_cache_ratio
+                            k_tensor_split_factor = sparse_kv_cache_ratio[0]
+                            v_tensor_split_factor = None
                         else:
-                            assert not current_sparse_c8
                             k_dim, v_dim, _ = kv_cache_spec.sparse_head_dim
                             k_tensor_split_factor, v_tensor_split_factor = calc_split_factor([k_dim, v_dim])
                     else:
@@ -4315,18 +4312,20 @@ class NPUModelRunner(GPUModelRunner):
                             k_tensor_split_factor, v_tensor_split_factor = calc_split_factor(kv_head_dim_list)
 
                     k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
-                    if v_tensor_split_factor is not None:
-                        v_tensor_size = int(kv_cache_tensor.size // v_tensor_split_factor)
-                    else:
-                        v_tensor_size = None
+                    v_tensor_size = (
+                        int(kv_cache_tensor.size // v_tensor_split_factor)
+                        if v_tensor_split_factor is not None
+                        else None
+                    )
                     dsa_k_tensor_size = None
                     dsa_k_scale_tensor_size = None
                     #### for deepseek sparse attention
                     if self.use_sparse and has_indexer_cache:
+                        assert dsa_k_tensor_split_factor is not None
                         dsa_k_tensor_size = int(kv_cache_tensor.size // dsa_k_tensor_split_factor)
                     if self.use_sparse and has_indexer_cache and current_sparse_c8:
+                        assert dsa_k_scale_tensor_split_factor is not None
                         dsa_k_scale_tensor_size = int(kv_cache_tensor.size // dsa_k_scale_tensor_split_factor)
-
                     # Allocate raw int8 tensors. Even bf16/fp16 KV cache entries
                     # are allocated as int8 raw bytes first and then viewed as
                     # the target dtype in _reshape_kv_cache_tensors.
@@ -4343,9 +4342,7 @@ class NPUModelRunner(GPUModelRunner):
                             alignment,
                         )
 
-                    if self.use_sparse and has_indexer_cache:
-                        assert dsa_k_tensor_size is not None
-
+                    if self.use_sparse and dsa_k_tensor_size is not None:
                         if current_sparse_c8:
                             assert dsa_k_scale_tensor_size is not None
 
@@ -4368,20 +4365,26 @@ class NPUModelRunner(GPUModelRunner):
                         # shared the attn kvcache for all shared layers
                         if "attn" in layer_name_inner and "linear_attn" not in layer_name_inner:
                             if self.use_sparse:
-                                if not has_indexer_cache:
-                                    kv_cache_raw_tensors[layer_name_inner] = (k_tensor, v_tensor)
-                                elif current_sparse_c8:
-                                    if get_ascend_device_type() == AscendDeviceType.A5:
+                                if current_sparse_c8:
+                                    if has_indexer_cache:
+                                        # Sparse C8 with indexer: packed KV, indexer K, and indexer K scale.
                                         kv_cache_raw_tensors[layer_name_inner] = (
                                             k_tensor, dsa_k_tensor, dsa_k_scale_tensor
                                         )
                                     else:
-                                        kv_cache_raw_tensors[layer_name_inner] = (
-                                            k_tensor, v_tensor, dsa_k_tensor, dsa_k_scale_tensor
-                                        )
+                                        # Sparse C8 without indexer: packed KV only.
+                                        kv_cache_raw_tensors[layer_name_inner] = (k_tensor,)
                                 else:
-                                    kv_cache_raw_tensors[layer_name_inner] = (k_tensor, v_tensor, dsa_k_tensor)
+                                    if has_indexer_cache:
+                                        # Sparse non-C8 with indexer: regular K/V plus indexer K.
+                                        kv_cache_raw_tensors[layer_name_inner] = (
+                                            k_tensor, v_tensor, dsa_k_tensor
+                                        )
+                                    else:
+                                        # Sparse non-C8 without indexer: regular K/V only.
+                                        kv_cache_raw_tensors[layer_name_inner] = (k_tensor, v_tensor)
                             else:
+                                # Dense attention: regular K/V only.
                                 kv_cache_raw_tensors[layer_name_inner] = (k_tensor, v_tensor)
         layer_names = set()
         for group in kv_cache_config.kv_cache_groups:
@@ -4513,40 +4516,38 @@ class NPUModelRunner(GPUModelRunner):
                     # cache_only_layers (extract_hidden_states) are allocated
                     # as a single tensor by the branch at the top of
                     # _allocate_kv_cache_tensors; route them to the dedicated
-                    # elif branch below before the sparse branch tries to
-                    # unpack them as a (k, v, dsa_k[, scale]) tuple.
                     current_sparse_c8 = kv_cache_spec_uses_sparse_c8(current_kv_cache_spec)
                     has_indexer_cache = sparse_kv_cache_has_indexer(current_kv_cache_spec)
+                    raw_dsa_k_tensor = None
+                    raw_dsa_k_scale_tensor = None
                     if self.use_sparse and has_indexer_cache and "cache_only_layers" not in layer_name:
+                        assert isinstance(current_kv_cache_spec, AscendMLAAttentionSpec)
+                        assert current_kv_cache_spec.sparse_head_dim is not None
                         if current_sparse_c8:
-                            if get_ascend_device_type() == AscendDeviceType.A5:
-                                raw_k_tensor, raw_dsa_k_tensor, raw_dsa_k_scale_tensor = (
-                                    kv_cache_raw_tensors[layer_name]  # type: ignore
-                                )
-                                assert raw_dsa_k_tensor is not None
-                                assert raw_dsa_k_scale_tensor is not None
-                                sum_page_size_bytes = (
-                                    raw_k_tensor.numel()
-                                    + raw_dsa_k_tensor.numel()
-                                    + raw_dsa_k_scale_tensor.numel()
-                                )
-                            else:
-                                raw_k_tensor, raw_v_tensor, raw_dsa_k_tensor, raw_dsa_k_scale_tensor = (
-                                    kv_cache_raw_tensors[layer_name]  # type: ignore
-                                )
-                                assert raw_dsa_k_tensor is not None
-                                assert raw_dsa_k_scale_tensor is not None
-                                sum_page_size_bytes = (
-                                    raw_k_tensor.numel()
-                                    + raw_v_tensor.numel()
-                                    + raw_dsa_k_tensor.numel()
-                                    + raw_dsa_k_scale_tensor.numel()
-                                )
+                            raw_k_tensor, raw_dsa_k_tensor, raw_dsa_k_scale_tensor = (
+                                kv_cache_raw_tensors[layer_name]  # type: ignore
+                            )
+                            assert raw_dsa_k_tensor is not None
+                            assert raw_dsa_k_scale_tensor is not None
+                            sum_page_size_bytes = (
+                                raw_k_tensor.numel()
+                                + raw_dsa_k_tensor.numel()
+                                + raw_dsa_k_scale_tensor.numel()
+                            )
                         else:
                             raw_k_tensor, raw_v_tensor, raw_dsa_k_tensor = kv_cache_raw_tensors[  # type: ignore
                                 layer_name]
                             assert raw_dsa_k_tensor is not None
                             sum_page_size_bytes = raw_k_tensor.numel() + raw_v_tensor.numel() + raw_dsa_k_tensor.numel()
+                    elif self.use_sparse and "cache_only_layers" not in layer_name:
+                        assert isinstance(current_kv_cache_spec, AscendMLAAttentionSpec)
+                        assert current_kv_cache_spec.sparse_head_dim is not None
+                        if current_sparse_c8:
+                            (raw_k_tensor,) = kv_cache_raw_tensors[layer_name]  # type: ignore
+                            sum_page_size_bytes = raw_k_tensor.numel()
+                        else:
+                            raw_k_tensor, raw_v_tensor = kv_cache_raw_tensors[layer_name]  # type: ignore
+                            sum_page_size_bytes = raw_k_tensor.numel() + raw_v_tensor.numel()
                     elif (
                         self.use_hybrid_blocks
                         and self.hybrid_with_attn_and_mamba
@@ -4667,19 +4668,15 @@ class NPUModelRunner(GPUModelRunner):
                             num_kv_heads,
                             k_dim,
                         )
-                        if self.use_sparse and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
-                            # A5 sparse C8: CKV tensor = kv_lora(fp8) + k_rope(bf16→fp8) + quant_scale_metadata
-                            #   kv_lora_rank                    : fp8, 1 byte/elem
-                            #   qk_rope_head_dim * 2            : bf16→fp8 ratio (2/1 bytes)
-                            #   4 * 4                           : quant_scale (4 elements × float32→fp8 ratio)
+                        if self.use_sparse and current_sparse_c8:
+                            assert current_kv_cache_spec.sparse_head_dim is not None
                             k_shape = (
                                 mla_num_blocks,
                                 mla_block_size,
                                 num_kv_heads,
-                                self.model_config.hf_text_config.kv_lora_rank
-                                + self.model_config.hf_text_config.qk_rope_head_dim * 2
-                                + 4 * 4,
+                                current_kv_cache_spec.sparse_head_dim[0],
                             )
+                            v_dim = 0
                         v_shape = (
                             mla_num_blocks,
                             mla_block_size,
@@ -4691,13 +4688,12 @@ class NPUModelRunner(GPUModelRunner):
                         k_cache_dtype, v_cache_dtype = self.vllm_config.quant_config.get_kv_quant_dtype(
                             layer_name, current_kv_cache_spec.dtype, self.model_config
                         )
-                    
-                    # A5 sparse C8: ckv uses float8_e4m3fn
-                    if self.use_sparse and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
+
+                    if self.use_sparse and current_sparse_c8:
                         k_cache_dtype = self.c8_k_cache_dtype
-                    
+
                     k_cache = raw_k_tensor.view(k_cache_dtype).view(k_shape)
-                    if self.use_sparse and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
+                    if self.use_sparse and current_sparse_c8:
                         v_cache = None
                     else:
                         v_cache = raw_v_tensor.view(v_cache_dtype).view(v_shape)
@@ -4735,6 +4731,8 @@ class NPUModelRunner(GPUModelRunner):
                             # dsa_k
                             dsa_k_cache = raw_dsa_k_tensor.view(current_kv_cache_spec.dtype).view(dsa_k_cache_shape)
                             kv_caches[layer_name] = (k_cache, v_cache, dsa_k_cache)
+                    elif self.use_sparse and current_sparse_c8:
+                        kv_caches[layer_name] = (k_cache,)
                     else:
                         kv_caches[layer_name] = (k_cache, v_cache)
                 elif isinstance(current_kv_cache_spec, MambaSpec):
@@ -5004,8 +5002,27 @@ class NPUModelRunner(GPUModelRunner):
 
             elif isinstance(attn_module, MLAAttention):
                 if self.use_sparse:
-                    has_indexer = attn_module.impl.has_indexer
-                    if has_indexer:
+                    impl = attn_module.impl
+                    has_indexer = bool(getattr(impl, "has_indexer", False))
+                    use_sparse_c8_for_layer = bool(
+                        getattr(impl, "use_sparse_c8", False)
+                    )
+
+                    if use_sparse_c8_for_layer:
+                        packed_kv_head_dim = get_sfa_qsfa_packed_head_dim(
+                            self.model_config.hf_text_config.kv_lora_rank,
+                            self.model_config.hf_text_config.qk_rope_head_dim,
+                        )
+                        sparse_head_dim = (
+                            packed_kv_head_dim,
+                            0,
+                            (
+                                self.model_config.hf_text_config.index_head_dim
+                                if has_indexer
+                                else 0
+                            ),
+                        )
+                    elif has_indexer:
                         sparse_head_dim = self.sparse_head_dim
                     else:
                         # Layers that reuse another layer's top-k indices only
@@ -5015,6 +5032,7 @@ class NPUModelRunner(GPUModelRunner):
                             self.model_config.hf_text_config.qk_rope_head_dim,
                             0,
                         )
+
                     kv_cache_spec[layer_name] = AscendMLAAttentionSpec(
                         block_size=self.block_size,
                         num_kv_heads=1,
@@ -5022,7 +5040,7 @@ class NPUModelRunner(GPUModelRunner):
                         sparse_head_dim=sparse_head_dim,
                         dtype=self.kv_cache_dtype,
                         cache_dtype_str=self.vllm_config.cache_config.cache_dtype,
-                        cache_sparse_c8=self.ascend_config.is_sparse_c8_layer(layer_name),
+                        cache_sparse_c8=use_sparse_c8_for_layer,
                         sfa_dcp_replicated_indexer_size=self.sfa_dcp_replicated_indexer_size,
                     )
                 elif spec := attn_module.get_kv_cache_spec(self.vllm_config):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4270,7 +4270,6 @@ class NPUModelRunner(GPUModelRunner):
                     assert isinstance(current_kv_cache_spec, AttentionSpec)
 
                     dsa_k_tensor_split_factor = None
-                    dsa_k_scale_tensor_split_factor = None
                     if self.use_sparse:
                         # for deepseek v3.2, we split the kv cache according to the corresponding ratio
                         kv_cache_spec = layer_kv_cache_spec[layer_name]
@@ -4279,21 +4278,40 @@ class NPUModelRunner(GPUModelRunner):
                         assert kv_cache_spec.sparse_head_dim is not None
                         has_indexer_cache = sparse_kv_cache_has_indexer(kv_cache_spec)
 
-                        if has_indexer_cache:
-                            sparse_kv_cache_ratio = kv_cache_spec.sparse_kv_cache_ratio
-                            k_tensor_split_factor = sparse_kv_cache_ratio[0]
-                            if current_sparse_c8:
-                                # Sparse C8 uses merged layout. Indexer cache is optional.
-                                v_tensor_split_factor = None
-                                dsa_k_tensor_split_factor = sparse_kv_cache_ratio[1]
-                                dsa_k_scale_tensor_split_factor = sparse_kv_cache_ratio[2]
+                        if current_sparse_c8:
+                            assert kv_cache_tensor.size % kv_cache_spec.page_size_bytes == 0
+                            num_blocks = kv_cache_tensor.size // kv_cache_spec.page_size_bytes
+                            num_heads = kv_cache_spec.block_size * kv_cache_spec.num_kv_heads
+                            packed_kv_head_dim, _, index_head_dim = kv_cache_spec.sparse_head_dim
+                            k_tensor_split_factor = 1.0
+                            k_tensor_size = (
+                                num_blocks
+                                * num_heads
+                                * packed_kv_head_dim
+                                * get_dtype_size(kv_cache_spec.c8_k_cache_dtype)
+                            )
+                            v_tensor_size = None
+                            if has_indexer_cache:
+                                dsa_k_tensor_size = (
+                                    num_blocks
+                                    * num_heads
+                                    * index_head_dim
+                                    * get_dtype_size(kv_cache_spec.c8_k_cache_dtype)
+                                )
+                                dsa_k_scale_tensor_size = (
+                                    num_blocks
+                                    * num_heads
+                                    * get_dtype_size(kv_cache_spec.c8_k_scale_cache_dtype)
+                                )
                             else:
-                                v_tensor_split_factor = sparse_kv_cache_ratio[1]
-                                dsa_k_tensor_split_factor = sparse_kv_cache_ratio[2]
-                        elif current_sparse_c8:
+                                dsa_k_tensor_size = None
+                                dsa_k_scale_tensor_size = None
+                            dsa_k_tensor_split_factor = None
+                        elif has_indexer_cache:
                             sparse_kv_cache_ratio = kv_cache_spec.sparse_kv_cache_ratio
                             k_tensor_split_factor = sparse_kv_cache_ratio[0]
-                            v_tensor_split_factor = None
+                            v_tensor_split_factor = sparse_kv_cache_ratio[1]
+                            dsa_k_tensor_split_factor = sparse_kv_cache_ratio[2]
                         else:
                             k_dim, v_dim, _ = kv_cache_spec.sparse_head_dim
                             k_tensor_split_factor, v_tensor_split_factor = calc_split_factor([k_dim, v_dim])
@@ -4311,21 +4329,19 @@ class NPUModelRunner(GPUModelRunner):
                         else:
                             k_tensor_split_factor, v_tensor_split_factor = calc_split_factor(kv_head_dim_list)
 
-                    k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
-                    v_tensor_size = (
-                        int(kv_cache_tensor.size // v_tensor_split_factor)
-                        if v_tensor_split_factor is not None
-                        else None
-                    )
-                    dsa_k_tensor_size = None
-                    dsa_k_scale_tensor_size = None
+                    if not (self.use_sparse and current_sparse_c8):
+                        k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
+                        v_tensor_size = (
+                            int(kv_cache_tensor.size // v_tensor_split_factor)
+                            if v_tensor_split_factor is not None
+                            else None
+                        )
+                        dsa_k_tensor_size = None
+                        dsa_k_scale_tensor_size = None
                     #### for deepseek sparse attention
-                    if self.use_sparse and has_indexer_cache:
+                    if self.use_sparse and has_indexer_cache and not current_sparse_c8:
                         assert dsa_k_tensor_split_factor is not None
                         dsa_k_tensor_size = int(kv_cache_tensor.size // dsa_k_tensor_split_factor)
-                    if self.use_sparse and has_indexer_cache and current_sparse_c8:
-                        assert dsa_k_scale_tensor_split_factor is not None
-                        dsa_k_scale_tensor_size = int(kv_cache_tensor.size // dsa_k_scale_tensor_split_factor)
                     # Allocate raw int8 tensors. Even bf16/fp16 KV cache entries
                     # are allocated as int8 raw bytes first and then viewed as
                     # the target dtype in _reshape_kv_cache_tensors.
@@ -4353,7 +4369,7 @@ class NPUModelRunner(GPUModelRunner):
                                 dsa_k_tensor_size=dsa_k_tensor_size,
                                 dsa_k_scale_tensor_size=dsa_k_scale_tensor_size,
                                 alignment=alignment,
-                                scale_dtype=current_kv_cache_spec.scale_dtype,
+                                scale_dtype=current_kv_cache_spec.c8_k_scale_cache_dtype,
                             )
                         else:
                             dsa_k_tensor = self._allocate_int8_cache_tensor(
@@ -4699,6 +4715,7 @@ class NPUModelRunner(GPUModelRunner):
                         v_cache = raw_v_tensor.view(v_cache_dtype).view(v_shape)
 
                     if self.use_sparse and has_indexer_cache:
+                        assert raw_dsa_k_tensor is not None
                         dsa_k_cache_shape = (
                             num_blocks * current_kv_cache_spec.sfa_dcp_replicated_indexer_size,
                             current_kv_cache_spec.block_size,
@@ -5004,11 +5021,10 @@ class NPUModelRunner(GPUModelRunner):
                 if self.use_sparse:
                     impl = attn_module.impl
                     has_indexer = bool(getattr(impl, "has_indexer", False))
-                    use_sparse_c8_for_layer = bool(
-                        getattr(impl, "use_sparse_c8", False)
-                    )
+                    use_sparse_c8_sfa_for_layer = bool(getattr(impl, "use_sparse_c8_sfa", False))
+                    use_sparse_c8_indexer_for_layer = bool(getattr(impl, "use_sparse_c8_indexer", False))
 
-                    if use_sparse_c8_for_layer:
+                    if use_sparse_c8_sfa_for_layer:
                         packed_kv_head_dim = get_sfa_qsfa_packed_head_dim(
                             self.model_config.hf_text_config.kv_lora_rank,
                             self.model_config.hf_text_config.qk_rope_head_dim,
@@ -5018,7 +5034,7 @@ class NPUModelRunner(GPUModelRunner):
                             0,
                             (
                                 self.model_config.hf_text_config.index_head_dim
-                                if has_indexer
+                                if use_sparse_c8_indexer_for_layer
                                 else 0
                             ),
                         )
@@ -5040,7 +5056,7 @@ class NPUModelRunner(GPUModelRunner):
                         sparse_head_dim=sparse_head_dim,
                         dtype=self.kv_cache_dtype,
                         cache_dtype_str=self.vllm_config.cache_config.cache_dtype,
-                        cache_sparse_c8=use_sparse_c8_for_layer,
+                        cache_sparse_c8=use_sparse_c8_sfa_for_layer,
                         sfa_dcp_replicated_indexer_size=self.sfa_dcp_replicated_indexer_size,
                     )
                 elif spec := attn_module.get_kv_cache_spec(self.vllm_config):


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds SFA sparse C8 support for A3 and refactors the KV cache layout to share the same packed/merged representation used by the sparse C8 path. Before this change, SFA KV quantization used a separate switch and could allocate KV cache as separate tensors such as `(k, v, indexer_k, indexer_scale)`, while A5 sparse C8 used a merged CKV-style layout. After this change, `enable_sparse_c8` becomes the single switch for SFA KV cache quantization, and sparse C8 layers use a packed layout: layers with indexer change from `(k, v, indexer_k, indexer_scale)` to `(ckv, indexer_k, indexer_scale)`, while layers without indexer change from allocating an unnecessary indexer cache to only allocating the required KV tensors, e.g. `(ckv)` for sparse C8 packed KV or `(k, v)` for non-C8 sparse layers. This removes the SFA-specific KV quant switch and aligns A3/A5 sparse C8 cache handling under one layout model.

In a single-node A3 deployment of GLM-5 W8A8, C8 provides a KV cache size of 122,309, approximately 1.62× that of C16 at 75,600.

| KV Cache Type | KV Cache Size |
|---|---:|
| SFA C16 | 75,600 |
| SFA C8 | 122,309 |
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
