### PR TITLE
[Bugfix] Fix msprobe dump lifecycle and build instructions

### DIFF
--- a/docs/source/developer_guide/performance_and_debug/msprobe_guide.md
+++ b/docs/source/developer_guide/performance_and_debug/msprobe_guide.md
@@ -31,8 +31,9 @@ If you need to dump cudagraph graphs, you need to install from source code:
    ```bash
    git clone https://gitcode.com/Ascend/msprobe.git
    cd msprobe
-   python3 setup.py bdist_wheel --include-mod=aclgraph_dump --no-check
-   pip install dist/*.whl
+   pip install uv
+   python3 build.py -e include-mod=aclgraph_dump -e no-check=true
+   pip install artifacts/mindstudio_probe*.whl
    ```
 
 ## 2. Collecting Data with `msprobe`

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -309,6 +309,82 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
         runner.debugger.step.assert_not_called()
         self.assertTrue(runner._debugger_started)
 
+    @patch("vllm_ascend.worker.model_runner_v1.has_kv_transfer_group", return_value=False)
+    @patch("vllm_ascend.worker.model_runner_v1.has_ec_transfer", return_value=False)
+    @patch("vllm_ascend.worker.model_runner_v1.get_pp_group")
+    @patch("vllm_ascend.worker.model_runner_v1.record_function_or_nullcontext")
+    def test_execute_model_skips_dump_start_for_dp_dummy_run(
+        self, mock_record_function, mock_get_pp_group, _mock_has_ec_transfer, _mock_has_kv_transfer_group
+    ):
+        from contextlib import nullcontext
+
+        mock_record_function.return_value = nullcontext()
+        mock_get_pp_group.return_value = SimpleNamespace(world_size=1, is_first_rank=True, is_last_rank=True)
+        runner = self._build_runner(MagicMock(spec=["start", "stop", "step"]))
+        runner.vllm_config = MagicMock()
+        runner.vllm_config.model_config.enable_return_routed_experts = False
+        runner.ascend_config = SimpleNamespace(profiling_chunk_config=SimpleNamespace(need_timing=False))
+        runner.execute_model_state = None
+        runner.speculative_config = None
+        runner.use_async_scheduling = False
+        runner.num_spec_tokens = 0
+        runner._draft_token_ids = None
+        runner.pcp_size = 1
+        runner.supports_mm_inputs = False
+        runner.model_config.is_encoder_decoder = False
+        runner.synchronize_input_prep = nullcontext
+        runner._update_states = MagicMock(return_value=None)
+        runner.parallel_config = SimpleNamespace(distributed_executor_backend="external_launcher", data_parallel_size=2)
+        runner._dummy_run = MagicMock()
+        runner._start_dump_data = MagicMock()
+        runner.requests = {}
+        scheduler_output = SimpleNamespace(total_num_scheduled_tokens=0)
+
+        runner.execute_model(scheduler_output)
+
+        runner._dummy_run.assert_called_once_with(1)
+        runner._start_dump_data.assert_not_called()
+
+    @patch("vllm_ascend.worker.model_runner_v1.has_kv_transfer_group", return_value=False)
+    @patch("vllm_ascend.worker.model_runner_v1.has_ec_transfer", return_value=False)
+    @patch("vllm_ascend.worker.model_runner_v1.get_pp_group")
+    @patch("vllm_ascend.worker.model_runner_v1.record_function_or_nullcontext")
+    def test_execute_model_starts_dump_for_real_batch(
+        self, mock_record_function, mock_get_pp_group, _mock_has_ec_transfer, _mock_has_kv_transfer_group
+    ):
+        from contextlib import nullcontext
+
+        mock_record_function.return_value = nullcontext()
+        mock_get_pp_group.return_value = SimpleNamespace(world_size=1, is_first_rank=True, is_last_rank=True)
+        runner = self._build_runner(MagicMock(spec=["start", "stop", "step"]))
+        runner.vllm_config = MagicMock()
+        runner.vllm_config.model_config.enable_return_routed_experts = False
+        runner.ascend_config = SimpleNamespace(profiling_chunk_config=SimpleNamespace(need_timing=False))
+        runner.execute_model_state = None
+        runner.speculative_config = None
+        runner.use_async_scheduling = False
+        runner.num_spec_tokens = 0
+        runner._draft_token_ids = None
+        runner.pcp_size = 1
+        runner.supports_mm_inputs = False
+        runner.model_config.is_encoder_decoder = False
+        runner.synchronize_input_prep = nullcontext
+        runner._update_states = MagicMock(return_value=None)
+        runner.parallel_config = SimpleNamespace(
+            distributed_executor_backend="external_launcher", data_parallel_size=2, enable_dbo=False
+        )
+        runner.cache_config = SimpleNamespace(kv_sharing_fast_prefill=False)
+        runner.input_batch = SimpleNamespace(num_reqs=1, req_ids=["req0"], prev_req_id_to_index=None)
+        runner.requests = {}
+        runner._start_dump_data = MagicMock()
+        runner._prepare_inputs = MagicMock(side_effect=RuntimeError("sentinel"))
+        scheduler_output = SimpleNamespace(total_num_scheduled_tokens=1, num_scheduled_tokens={"req0": 1})
+
+        with self.assertRaisesRegex(RuntimeError, "sentinel"):
+            runner.execute_model(scheduler_output)
+
+        runner._start_dump_data.assert_called_once_with()
+
 
 class TestCorrectOptimisticSeqLensCpu(unittest.TestCase):
     """Regression tests for async spec-decode seq_lens correction.

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2101,7 +2101,6 @@ class NPUModelRunner(GPUModelRunner):
                 scheduled_spec_decode_tokens=spec_decode_tokens_copy,
             )
 
-        self._start_dump_data()
         # self._draft_token_ids is None when `input_fits_in_drafter=False`
         # and there is no draft tokens scheduled. so it need to update the
         # spec_decoding info in scheduler_output with async_scheduling.
@@ -2164,6 +2163,7 @@ class NPUModelRunner(GPUModelRunner):
                 )
 
                 if has_ec_transfer() and get_ec_transfer().is_producer:
+                    self._start_dump_data()
                     with self.maybe_get_ec_connector_output(
                         scheduler_output,
                         encoder_cache=self.encoder_cache,
@@ -2203,6 +2203,7 @@ class NPUModelRunner(GPUModelRunner):
                     if not has_kv_transfer_group():
                         return EMPTY_MODEL_RUNNER_OUTPUT
                     return self.kv_connector_no_forward(scheduler_output, self.vllm_config)
+                self._start_dump_data()
                 num_scheduled_tokens_np = np.array(tokens, dtype=np.int32)
                 max_num_scheduled_tokens = int(num_scheduled_tokens_np.max())
                 (


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes an eager-mode dump lifecycle issue when data parallelism is enabled and one DP worker only executes a coordination `dummy_run`.

Before this change, `execute_model()` started msprobe dumping before it knew whether the current worker would run a real batch or only a DP synchronization dummy pass. In the single-request DP case, the idle worker could enter `_dummy_run(1)` after `start()`, which made the dummy path call `_finalize_dump_data(dump=False)` as if it belonged to a real execution window.

This patch delays `_start_dump_data()` until the worker is confirmed to run a real model execution path:
- keep DP dummy coordination runs from starting the debugger in eager mode;
- preserve dump start/finalize pairing for real execution paths;
- keep the encoder path starting dump before real encoder execution.

This PR also updates the vllm-ascend msprobe documentation to match the current msprobe source build flow for `aclgraph_dump` (`build.py` and wheel artifacts under `artifacts/`).

### Does this PR introduce _any_ user-facing change?
Yes.

In eager mode with DP enabled, idle workers that only execute the DP coordination `dummy_run` will no longer start msprobe dumping. This changes dump behavior and avoids misleading dummy-run dump lifecycle events. The documentation is also updated to reflect the current msprobe build/install commands.

### How was this patch tested?
- Added unit tests covering:
  - DP dummy-run path does not call `_start_dump_data()`;
  - real batch execution still calls `_start_dump_data()`.
- Ran `python -m py_compile vllm_ascend/worker/model_runner_v1.py tests/ut/worker/a2/test_model_runner_v1.py` to verify the modified files are syntactically valid.
- Full unit test execution was not completed in the local environment because the current environment has upstream dependency import mismatches when importing vLLM / vllm-ascend test modules.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/e5588e49bc2642670116664a7fc4096e27adb179
