### PR TITLE
[releases/v0.22.1rc][Doc][Misc] Fix Docker image tags with A3/A2 tab-set for Qwen3 tutorials

### DIFF
--- a/docs/source/tutorials/models/Qwen3-30B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3-30B-A3B.md
@@ -46,24 +46,26 @@ Qwen3-30B-A3B-W8A8 adopts a hybrid quantization strategy (ordered by model struc
 
 You can use the official all-in-one Docker image for Qwen3 MoE models.
 
-**Docker Pull:**
-
-```bash
-docker pull quay.io/ascend/vllm-ascend:|vllm_ascend_version|
-```
-
-**Docker Run:**
-
 :::::{tab-set}
 :sync-group: hardware
 
 ::::{tab-item} Atlas 800I A3
 :sync: a3
 
+**Docker Pull:**
+
 ```{code-block} bash
    :substitutions:
 
-export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+docker pull quay.io/ascend/vllm-ascend:|vllm_ascend_version|-a3
+```
+
+**Docker Run:**
+
+```{code-block} bash
+   :substitutions:
+
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|-a3
 
 docker run \
     --name vllm-ascend-env \
@@ -112,6 +114,16 @@ If you are on a shared machine, map only the chips you need (e.g., `/dev/davinci
 
 ::::{tab-item} Atlas 800I A2
 :sync: a2
+
+**Docker Pull:**
+
+```{code-block} bash
+   :substitutions:
+
+docker pull quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+```
+
+**Docker Run:**
 
 ```{code-block} bash
    :substitutions:

--- a/docs/source/tutorials/models/Qwen3-Coder-30B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3-Coder-30B-A3B.md
@@ -46,24 +46,26 @@ Qwen3-Coder-30B-A3B-W8A8 adopts a hybrid quantization strategy (ordered by model
 
 You can use the official all-in-one Docker image for Qwen3 MoE models.
 
-**Docker Pull:**
-
-```bash
-docker pull quay.io/ascend/vllm-ascend:|vllm_ascend_version|
-```
-
-**Docker Run:**
-
 :::::{tab-set}
 :sync-group: hardware
 
 ::::{tab-item} Atlas 800I A3
 :sync: a3
 
+**Docker Pull:**
+
 ```{code-block} bash
    :substitutions:
 
-export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+docker pull quay.io/ascend/vllm-ascend:|vllm_ascend_version|-a3
+```
+
+**Docker Run:**
+
+```{code-block} bash
+   :substitutions:
+
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|-a3
 
 docker run \
     --name vllm-ascend-env \
@@ -112,6 +114,16 @@ If you are on a shared machine, map only the chips you need (e.g., `/dev/davinci
 
 ::::{tab-item} Atlas 800I A2
 :sync: a2
+
+**Docker Pull:**
+
+```{code-block} bash
+   :substitutions:
+
+docker pull quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+```
+
+**Docker Run:**
 
 ```{code-block} bash
    :substitutions:


### PR DESCRIPTION
### What this PR does / why we need it?
backport: #11239
Fixes Docker image tags in Qwen3-30B-A3B and Qwen3-Coder-30B-A3B tutorials:
- Wraps Docker Pull and Docker Run commands in tab-set (A3/A2) for clarity
- Adds `-a3` suffix to A3 image tags (e.g., `vllm-ascend:v0.22.1rc-a3`)

Follow-up to #11115.

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

Not applicable (documentation changes only).