### PR TITLE
[BugFix][LoRA] Honor dtype contract in lora_ops wrappers (fixes #11221)

### DIFF
--- a/vllm_ascend/lora/lora_ops.py
+++ b/vllm_ascend/lora/lora_ops.py
@@ -23,6 +23,25 @@ def bgmv_shrink(
     lora_indices_tensor: torch.Tensor,
     scaling: float = 1.0,
 ):
+    # The Ascend C++ kernel (csrc/kernels/bgmv_shrink.cpp) always writes the
+    # output in float32 (Y_T = float), regardless of output_tensor's dtype, and
+    # the C++ binding does not check output_tensor.dtype. Feeding a non-float32
+    # output (e.g. bf16, which vllm's torch ops freely accept) makes the kernel
+    # write 4 bytes per element into a 2-byte buffer and silently corrupt memory.
+    # Honor the contract: accumulate into a float32 tensor and cast back when the
+    # caller's output is not float32. In production the LoRA shrink buffer is
+    # already float32 (see punica_npu.py), so this branch is a no-op there.
+    if output_tensor.dtype != torch.float32:
+        out = torch.empty_like(output_tensor, dtype=torch.float32)
+        torch.ops._C_ascend.bgmv_shrink(
+            inputs,
+            lora_a_weights,
+            lora_indices_tensor,
+            out,
+            scaling,
+        )
+        output_tensor.copy_(out)
+        return output_tensor
     return torch.ops._C_ascend.bgmv_shrink(
         inputs,
         lora_a_weights,
@@ -39,6 +58,14 @@ def bgmv_expand(
     lora_indices_tensor: torch.Tensor,
     add_inputs: bool = True,
 ):
+    # The Ascend C++ kernel (csrc/kernels/bgmv_expand.cpp) always reads the input
+    # in float32 (X_T = float), regardless of inputs' dtype, and the C++ binding
+    # does not check inputs.dtype. Feeding a non-float32 input (e.g. bf16) makes
+    # the kernel read 4 bytes per element from a 2-byte buffer, producing garbage.
+    # Honor the contract by casting the input to float32. In production the input
+    # is the float32 shrink buffer, so this is a no-op there.
+    if inputs.dtype != torch.float32:
+        inputs = inputs.to(torch.float32)
     return torch.ops._C_ascend.bgmv_expand(
         inputs,
         lora_b_weights,
@@ -58,6 +85,9 @@ def bgmv_expand_slice(
     slice_size: int,
     add_inputs: bool = True,
 ):
+    # See bgmv_expand: the kernel reads the input as float32.
+    if inputs.dtype != torch.float32:
+        inputs = inputs.to(torch.float32)
     return torch.ops._C_ascend.bgmv_expand(
         inputs, lora_b_weights, lora_indices_tensor, output_tensor, slice_offset, slice_size
     )
@@ -75,6 +105,12 @@ def sgmv_shrink(
     token_nums: int,
     scaling: float,
 ):
+    # See bgmv_shrink: the kernel writes the output as float32.
+    if output_tensor.dtype != torch.float32:
+        out = torch.empty_like(output_tensor, dtype=torch.float32)
+        torch.ops._C_ascend.sgmv_shrink(inputs, lora_a_weights, lora_indices_tensor, seq_len_tensor, out, scaling)
+        output_tensor.copy_(out)
+        return output_tensor
     return torch.ops._C_ascend.sgmv_shrink(
         inputs, lora_a_weights, lora_indices_tensor, seq_len_tensor, output_tensor, scaling
     )
@@ -92,6 +128,9 @@ def sgmv_expand(
     token_nums: int,
     add_inputs: bool = False,
 ):
+    # See bgmv_expand: the kernel reads the input as float32.
+    if inputs.dtype != torch.float32:
+        inputs = inputs.to(torch.float32)
     return torch.ops._C_ascend.sgmv_expand(
         inputs,
         lora_b_weights,
@@ -117,6 +156,9 @@ def sgmv_expand_slice(
     slice_size: int,
     add_inputs: bool = False,
 ):
+    # See bgmv_expand: the kernel reads the input as float32.
+    if inputs.dtype != torch.float32:
+        inputs = inputs.to(torch.float32)
     return torch.ops._C_ascend.sgmv_expand(
         inputs, lora_b_weights, lora_indices_tensor, seq_len_tensor, output_tensor, slice_offset, slice_size
     )

--- a/vllm_ascend/lora/lora_ops.py
+++ b/vllm_ascend/lora/lora_ops.py
@@ -32,7 +32,7 @@ def bgmv_shrink(
     # caller's output is not float32. In production the LoRA shrink buffer is
     # already float32 (see punica_npu.py), so this branch is a no-op there.
     if output_tensor.dtype != torch.float32:
-        out = torch.empty_like(output_tensor, dtype=torch.float32)
+        out = output_tensor.to(torch.float32)
         torch.ops._C_ascend.bgmv_shrink(
             inputs,
             lora_a_weights,
@@ -107,7 +107,7 @@ def sgmv_shrink(
 ):
     # See bgmv_shrink: the kernel writes the output as float32.
     if output_tensor.dtype != torch.float32:
-        out = torch.empty_like(output_tensor, dtype=torch.float32)
+        out = output_tensor.to(torch.float32)
         torch.ops._C_ascend.sgmv_shrink(inputs, lora_a_weights, lora_indices_tensor, seq_len_tensor, out, scaling)
         output_tensor.copy_(out)
         return output_tensor


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #11221 — the Ascend LoRA C++ kernels silently corrupt data
(NaN / 1e+10-scale outputs on bf16) because the Python wrappers do
not honor the dtype contract that the kernel implementations assume.

Root cause:

- `bgmv_expand` / `sgmv_expand*` read the input tensor as `float32`
  (`X_T = float`) — not validated in the C++ binding.
- `bgmv_shrink` / `sgmv_shrink` write the output tensor as `float32`
  (`Y_T = float`) — same.

The Python wrappers passed tensors through unchanged. When vLLM's
generic `torch_ops` LoRA path (which freely accepts bf16 tensors)
feeds a bf16 buffer to the Ascend kernel, the kernel reinterprets
2-byte bf16 storage as 4-byte float32, producing garbage instead of
a bf16-precision result. See the reproducer + numeric diff in #11221.

Fix (wrappers only, kernels unchanged):

- `bgmv_expand` / `bgmv_expand_slice` / `sgmv_expand` /
  `sgmv_expand_slice`: cast `inputs` to `float32` before the kernel
  call.
- `bgmv_shrink` / `sgmv_shrink`: when `output_tensor.dtype !=
  float32`, allocate a `float32` scratch tensor, run the kernel into
  it, and `copy_` back to `output_tensor` (which handles the
  fp32→bf16 downcast correctly).

In the current punica path both LoRA buffers are `float32`, so
these branches are no-ops there — this only bites when the caller
follows the vLLM torch_ops contract (arbitrary dtype).

### Does this PR introduce _any_ user-facing change?

No. Same public API. Fixes silent numerical corruption; no
behavioural change on the fp32-buffer production path.

### How was this patch tested?

Reproducer from #11221 (bf16 tensors through `bgmv_expand` /
`bgmv_shrink` / `sgmv_expand` / `bgmv_expand_slice`) previously
reports `max diff` in [4.3, NaN]. With this fix, wrappers cast to
the contract dtype before the kernel; numeric diff drops into the
expected bf16 precision band (~1e-2).

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
