### PR TITLE
[CI] Modify the threshold of the gsm8k lite dataset to 3 questions

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3.1-BF16.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3.1-BF16.yaml
@@ -82,4 +82,4 @@ benchmarks:
     max_out_len: 4096
     batch_size: 512
     baseline: 95
-    threshold: 5
+    threshold: 10

--- a/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3_2-W8A8-A3-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3_2-W8A8-A3-dual-nodes.yaml
@@ -113,7 +113,7 @@ benchmarks:
     max_out_len: 4096
     batch_size: 128
     baseline: 95
-    threshold: 5
+    threshold: 10
 
   acc_aime2025:
     case_type: accuracy

--- a/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3_2-W8A8-EP.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3_2-W8A8-EP.yaml
@@ -265,4 +265,4 @@ benchmarks:
     max_out_len: 4096
     batch_size: 64
     baseline: 96.88
-    threshold: 5
+    threshold: 10

--- a/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-A22B-A2.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-A22B-A2.yaml
@@ -71,4 +71,4 @@ benchmarks:
     max_out_len: 7680
     batch_size: 256
     baseline: 96
-    threshold: 5
+    threshold: 10

--- a/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-A22B-Mooncake-Layerwise.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-A22B-Mooncake-Layerwise.yaml
@@ -112,4 +112,4 @@ benchmarks:
     max_out_len: 7680
     batch_size: 512
     baseline: 97
-    threshold: 3
+    threshold: 10

--- a/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-disagg-pd.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-disagg-pd.yaml
@@ -115,4 +115,4 @@ benchmarks:
     max_out_len: 7680
     batch_size: 512
     baseline: 97
-    threshold: 3
+    threshold: 10

--- a/tests/e2e/nightly/single_node/models/configs/DeepSeek-R1-0528-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/DeepSeek-R1-0528-W8A8.yaml
@@ -45,7 +45,7 @@ _benchmarks_acc: &benchmarks_acc
     max_out_len: 32768
     batch_size: 32
     baseline: 95
-    threshold: 5
+    threshold: 10
 
 _benchmarks_perf: &benchmarks_perf
   perf:

--- a/tests/e2e/nightly/single_node/models/configs/GLM-4.7.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/GLM-4.7.yaml
@@ -47,7 +47,7 @@ _benchmarks: &benchmarks
     max_out_len: 4096
     batch_size: 8
     baseline: 95
-    threshold: 5
+    threshold: 10
 
 # ==========================================
 # ACTUAL TEST CASES

--- a/tests/e2e/nightly/single_node/models/configs/Hy3-preview.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Hy3-preview.yaml
@@ -42,7 +42,7 @@ _benchmarks: &benchmarks
     max_out_len: 4096
     batch_size: 8
     baseline: 93.07
-    threshold: 5
+    threshold: 10
 
 # ==========================================
 # ACTUAL TEST CASES

--- a/tests/e2e/nightly/single_node/models/configs/Kimi-K2-Thinking.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Kimi-K2-Thinking.yaml
@@ -37,7 +37,7 @@ test_cases:
         max_out_len: 4096
         batch_size: 32
         baseline: 95
-        threshold: 5
+        threshold: 10
       perf:
         case_type: performance
         dataset_path: vllm-ascend/GSM8K-in3500-bs400

--- a/tests/e2e/nightly/single_node/models/configs/MTPX-DeepSeek-R1-0528-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/MTPX-DeepSeek-R1-0528-W8A8.yaml
@@ -39,7 +39,7 @@ _benchmarks_gsm8k: &benchmarks_gsm8k
     max_out_len: 32768
     batch_size: 32
     baseline: 95
-    threshold: 5
+    threshold: 10
 
 _benchmarks_aime: &benchmarks_aime
   acc:

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3-235B-A22B-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3-235B-A22B-W8A8.yaml
@@ -40,7 +40,7 @@ _benchmarks: &benchmarks
     batch_size: 32
     top_k: 20
     baseline: 95
-    threshold: 5
+    threshold: 10
 
 # ==========================================
 # ACTUAL TEST CASES

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3-30B-A3B-W4A8-llm-compressor.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3-30B-A3B-W4A8-llm-compressor.yaml
@@ -38,4 +38,4 @@ test_cases:
         max_out_len: 32768
         batch_size: 32
         baseline: 95
-        threshold: 5
+        threshold: 10

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3-32B-Int8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3-32B-Int8.yaml
@@ -40,7 +40,7 @@ _benchmarks: &benchmarks
     max_out_len: 10240
     batch_size: 32
     baseline: 96
-    threshold: 4
+    threshold: 10
   perf:
     case_type: performance
     dataset_path: vllm-ascend/GSM8K-in3500-bs400

--- a/tests/e2e/weekly/multi_node/internal_dp/config/DeepSeek-V3.yaml
+++ b/tests/e2e/weekly/multi_node/internal_dp/config/DeepSeek-V3.yaml
@@ -109,4 +109,4 @@ benchmarks:
     max_out_len: 4096
     batch_size: 512
     baseline: 95
-    threshold: 5
+    threshold: 10

--- a/tests/e2e/weekly/multi_node/internal_dp/config/GLM-4.7-W8A8C8-Mooncake-Layerwise.yaml
+++ b/tests/e2e/weekly/multi_node/internal_dp/config/GLM-4.7-W8A8C8-Mooncake-Layerwise.yaml
@@ -99,4 +99,4 @@ benchmarks:
     max_out_len: 4096
     batch_size: 8
     baseline: 95
-    threshold: 5
+    threshold: 10

--- a/tests/e2e/weekly/single_node/configs/GLM-5.yaml
+++ b/tests/e2e/weekly/single_node/configs/GLM-5.yaml
@@ -46,7 +46,7 @@ _benchmarks: &benchmarks
     max_out_len: 8192
     batch_size: 8
     baseline: 95
-    threshold: 5
+    threshold: 10
   perf:
     case_type: performance
     dataset_path: vllm-ascend/GSM8K-in3500-bs400

--- a/tests/e2e/weekly/single_node/configs/MiniMax-M2.5-W8A8-A3.yaml
+++ b/tests/e2e/weekly/single_node/configs/MiniMax-M2.5-W8A8-A3.yaml
@@ -47,7 +47,7 @@ test_cases:
         max_out_len: 32768
         batch_size: 32
         baseline: 95
-        threshold: 5
+        threshold: 10
       perf:
         case_type: performance
         dataset_path: vllm-ascend/GSM8K-in3500-bs2800


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the accuracy threshold for the `gsm8k-lite` benchmark across various nightly and weekly configuration files (both single-node and multi-node setups). The threshold is relaxed to `10` to prevent transient test failures or strict accuracy checks from blocking the CI pipeline.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

Tested via the existing E2E CI/nightly/weekly test pipelines.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
