### PR TITLE
[BugFix][Mooncake] Follow up #10991 transfer group head dim

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -339,6 +339,87 @@ class TestMooncakeTransferGroups(unittest.TestCase):
         self.assertEqual(worker._get_attention_group_num_key_value_heads(kv_group2layeridx[0][0]), 1)
         self.assertEqual(worker._get_attention_group_num_key_value_heads(kv_group2layeridx[1][0]), 8)
 
+    def test_build_kv_group2layeridx_splits_uniform_group_by_head_dim(self):
+        narrow_spec = FullAttentionSpec(
+            block_size=16,
+            num_kv_heads=8,
+            head_size=64,
+            head_size_v=64,
+            dtype=torch.float16,
+        )
+        wide_spec = FullAttentionSpec(
+            block_size=16,
+            num_kv_heads=8,
+            head_size=128,
+            head_size_v=64,
+            dtype=torch.float16,
+        )
+        layer_specs = {
+            "model.layers.0.self_attn": narrow_spec,
+            "model.layers.1.self_attn": wide_spec,
+        }
+        uniform_spec = UniformTypeKVCacheSpecs.from_specs(layer_specs)
+        assert uniform_spec is not None
+
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.vllm_config = MockVllmConfig()
+        worker.total_layers = 32
+        worker.kv_cache_config = MockKVCacheConfig(
+            kv_cache_groups=[
+                MockKVCacheGroup(
+                    layer_names=list(layer_specs),
+                    kv_cache_spec=uniform_spec,
+                )
+            ]
+        )
+
+        kv_group2layeridx = worker._build_kv_group2layeridx()
+
+        self.assertEqual(len(kv_group2layeridx), 2)
+        self.assertEqual(kv_group2layeridx[0][0]["kv_cache_group_id"], 0)
+        self.assertEqual(kv_group2layeridx[1][0]["kv_cache_group_id"], 0)
+        self.assertEqual(kv_group2layeridx[0][0]["kv_cache_spec"]["head_dim"], 64)
+        self.assertEqual(kv_group2layeridx[1][0]["kv_cache_spec"]["head_dim"], 128)
+
+    def test_build_kv_group2layeridx_does_not_split_by_unrelated_spec_fields(self):
+        fp16_spec = FullAttentionSpec(
+            block_size=16,
+            num_kv_heads=8,
+            head_size=64,
+            head_size_v=64,
+            dtype=torch.float16,
+        )
+        fp32_spec = FullAttentionSpec(
+            block_size=16,
+            num_kv_heads=8,
+            head_size=64,
+            head_size_v=64,
+            dtype=torch.float32,
+        )
+        layer_specs = {
+            "model.layers.0.self_attn": fp16_spec,
+            "model.layers.1.self_attn": fp32_spec,
+        }
+        uniform_spec = UniformTypeKVCacheSpecs.from_specs(layer_specs)
+        assert uniform_spec is not None
+
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.vllm_config = MockVllmConfig()
+        worker.total_layers = 32
+        worker.kv_cache_config = MockKVCacheConfig(
+            kv_cache_groups=[
+                MockKVCacheGroup(
+                    layer_names=list(layer_specs),
+                    kv_cache_spec=uniform_spec,
+                )
+            ]
+        )
+
+        kv_group2layeridx = worker._build_kv_group2layeridx()
+
+        self.assertEqual(len(kv_group2layeridx), 1)
+        self.assertEqual(kv_group2layeridx[0][0]["kv_cache_spec"]["head_dim"], 64)
+
     def test_hybrid_rank_pulls_use_transfer_group_kv_heads(self):
         worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
         worker.vllm_config = MockVllmConfig()
@@ -1892,6 +1973,61 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
             get_kv_split_metadata(False, 1, 1, 8, 1, 0, 8, 2, 8, 30000, [1], [1], 0, 16),
             get_kv_split_metadata(False, 1, 1, 8, 1, 0, 16, 2, 8, 30000, [1], [1], 0),
         )
+
+    def test_get_kv_split_metadata_uses_kv_cache_group_id_for_split_transfer_groups(self):
+        worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id, MockKVCacheConfig())
+        worker.use_mla = False
+        worker.use_sparse = False
+        worker.pcp_size = 1
+        worker.dcp_size = 1
+        worker.tp_size = 4
+        worker.tp_rank = 0
+        worker.pcp_rank = 0
+        worker.dcp_rank = 0
+        worker._prefill_tp_size = 4
+        worker.local_remote_block_port_mapping = {}
+        worker.remote_port_send_num = {}
+        worker.block_size = 16
+        worker.num_key_value_heads = 8
+        worker.side_channel_port = 5000
+        worker.handshake_port = 5000
+        worker.kv_group2layeridx = {
+            0: (
+                {
+                    "kv_cache_spec_type": "FullAttentionSpec",
+                    "kv_cache_group_id": 0,
+                    "kv_cache_spec": {"num_kv_heads": 8, "head_dim": 64},
+                },
+                [0],
+            ),
+            1: (
+                {
+                    "kv_cache_spec_type": "FullAttentionSpec",
+                    "kv_cache_group_id": 0,
+                    "kv_cache_spec": {"num_kv_heads": 8, "head_dim": 128},
+                },
+                [1],
+            ),
+        }
+        meta = types.SimpleNamespace(
+            remote_pcp_size=2,
+            remote_dcp_size=1,
+            remote_ptp_size=4,
+            remote_port=30000,
+            remote_block_ids=([10, 11, 12, 13],),
+            local_block_ids=([20, 21, 22, 23],),
+            num_external_tokens=4 * worker.block_size,
+            num_prompt_blocks=4,
+            remote_engine_id="remote_split_transfer_groups",
+            remote_host="localhost",
+            remote_multi_nodes_meta_mapping={},
+        )
+
+        ports, local_ids, remote_ids = worker._get_kv_split_metadata("req_split_groups", cast(ReqMeta, meta))
+
+        self.assertEqual(ports, [[30000], [30004]])
+        self.assertEqual(local_ids, [([20, 21], [20, 21]), ([22, 23], [22, 23])])
+        self.assertEqual(remote_ids, [([10, 11], [10, 11]), ([10, 11], [10, 11])])
 
     def _build_worker_for_pd_case(self, case, tp_rank, pcp_rank=0, dcp_rank=0):
         with patch.object(

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1887,6 +1887,9 @@ class MooncakeConnectorWorker:
         if num_key_value_heads is not None:
             serialized_kv_cache_spec["num_kv_heads"] = num_key_value_heads
             serialized_kv_cache_spec["num_key_value_heads"] = num_key_value_heads
+        head_dim = MooncakeConnectorWorker._get_spec_head_dim(spec)
+        if head_dim is not None:
+            serialized_kv_cache_spec["head_dim"] = head_dim
 
         serialized = {
             "layer_names": layer_names,
@@ -1912,11 +1915,20 @@ class MooncakeConnectorWorker:
         return None
 
     @classmethod
-    def _get_kv_transfer_spec_key(cls, spec: Any) -> tuple[str, int | None]:
-        # TODO: Extand this key with KV cache layout fields (for example num_dims)
-        # if a future model has layers with the same number of kv heads but incompatiible
-        # cache shapes.
-        return (type(spec).__name__, cls._get_spec_num_key_value_heads(spec))
+    def _get_spec_head_dim(cls, spec: Any) -> int | None:
+        for key in ("head_dim", "head_size"):
+            head_dim = getattr(spec, key, None)
+            if isinstance(head_dim, int):
+                return head_dim
+        return None
+
+    @classmethod
+    def _get_kv_transfer_spec_key(cls, spec: Any) -> tuple[Any, ...]:
+        return (
+            type(spec).__name__,
+            cls._get_spec_num_key_value_heads(spec),
+            cls._get_spec_head_dim(spec),
+        )
 
     def _build_kv_group2layeridx(self) -> dict[int, tuple[dict[str, Any], list[int]]]:
         from vllm.v1.worker.utils import extract_layer_index
@@ -1946,7 +1958,7 @@ class MooncakeConnectorWorker:
                 layer_entries.append((layer_name, layer_idx))
 
             if isinstance(group_spec.kv_cache_spec, UniformTypeKVCacheSpecs):
-                spec_groups: OrderedDict[tuple[str, int | None], list[tuple[str, int]]] = OrderedDict()
+                spec_groups: OrderedDict[tuple[Any, ...], list[tuple[str, int]]] = OrderedDict()
                 for layer_name, layer_idx in layer_entries:
                     layer_spec = group_spec.kv_cache_spec.kv_cache_specs[layer_name]
                     spec_key = self._get_kv_transfer_spec_key(layer_spec)
@@ -2472,15 +2484,24 @@ class MooncakeConnectorWorker:
             group_local_block_ids: list[list[int]] = []
             is_final_shard = remote_kv_id == len(remote_handshake_port_list) - 1
             for group_idx, (group_spec, _) in kv_group_items:
+                kv_cache_group_id = group_spec.get("kv_cache_group_id", group_idx)
                 if group_spec["kv_cache_spec_type"] == "MambaSpec":
                     # Mamba state is not context-block sharded like attention
                     # KV. Transfer the final state from the final PCP/DCP shard.
-                    group_remote_block_ids.append(list(meta.remote_block_ids[group_idx]) if is_final_shard else [])
-                    group_local_block_ids.append(list(meta.local_block_ids[group_idx]) if is_final_shard else [])
+                    group_remote_block_ids.append(
+                        list(meta.remote_block_ids[kv_cache_group_id]) if is_final_shard else []
+                    )
+                    group_local_block_ids.append(
+                        list(meta.local_block_ids[kv_cache_group_id]) if is_final_shard else []
+                    )
                     continue
-                group_remote_block_ids.append(list(meta.remote_block_ids[group_idx][:num_blocks_to_pull]))
+                group_remote_block_ids.append(list(meta.remote_block_ids[kv_cache_group_id][:num_blocks_to_pull]))
                 group_local_block_ids.append(
-                    list(meta.local_block_ids[group_idx][local_block_offset : local_block_offset + num_blocks_to_pull])
+                    list(
+                        meta.local_block_ids[kv_cache_group_id][
+                            local_block_offset : local_block_offset + num_blocks_to_pull
+                        ]
+                    )
                 )
             remote_block_ids_list.append(tuple(group_remote_block_ids))
             local_block_ids_list.append(tuple(group_local_block_ids))


### PR DESCRIPTION
### What this PR does / why we need it?

Follow-up to #10991.

This PR includes head_dim in the Mooncake transfer group key so attention KV specs with the same number of KV heads but different head dimensions are not merged into one transfer group.

It also makes split transfer groups use the original kv_cache_group_id when building split KV metadata, so block ids are indexed by the original KV cache manager group instead of the Mooncake transfer group id.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested by UT:

- tests/ut/kv_offload/test_mooncake_connector.py
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
