### PR TITLE
[Test] Extend DeepSeek prefix cache startup timeout

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/Prefix-Cache-DeepSeek-R1-0528-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Prefix-Cache-DeepSeek-R1-0528-W8A8.yaml
@@ -11,6 +11,7 @@ test_cases:
       HCCL_BUFFSIZE: "1024"
       PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
       SERVER_PORT: "DEFAULT_PORT"
+      VLLM_ENGINE_READY_TIMEOUT_S: "3000"
     server_cmd:
       - "--quantization"
       - "ascend"

--- a/tests/e2e/nightly/single_node/models/configs/Prefix-Cache-DeepSeek-R1-0528-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Prefix-Cache-DeepSeek-R1-0528-W8A8.yaml
@@ -11,7 +11,7 @@ test_cases:
       HCCL_BUFFSIZE: "1024"
       PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
       SERVER_PORT: "DEFAULT_PORT"
-      VLLM_ENGINE_READY_TIMEOUT_S: "3000"
+      VLLM_ENGINE_READY_TIMEOUT_S: "7200"
     server_cmd:
       - "--quantization"
       - "ascend"


### PR DESCRIPTION
### What this PR does / why we need it?
Adds `VLLM_ENGINE_READY_TIMEOUT_S: "7200"` to the Prefix-Cache DeepSeek-R1-0528-W8A8 nightly config, matching the existing DeepSeek-R1-0528-W8A8 W8A8 config so the large model has enough startup time before tests begin.

### Does this PR introduce _any_ user-facing change?
No. This only updates a nightly test configuration.

### How was this patch tested?
Not run locally; configuration-only nightly test update.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
