### PR TITLE
[BugFix][KVTransfer] Fix Qwen3.5/Qwen3.6 layerwise MTP state transfer

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_layerwise_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_layerwise_connector.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import torch
 import zmq
+from vllm.v1.kv_cache_interface import MambaSpec
 
 fake_engine = types.ModuleType("mooncake.engine")
 fake_engine.TransferEngine = MagicMock()  # type: ignore[attr-defined]
@@ -306,6 +307,46 @@ class TestKVCacheSendingLayerThread(unittest.TestCase):
         )
         self.thread._transfer_kv_cache(send_task)
         self.engine.batch_transfer_sync_write.assert_not_called()
+
+    def test_mamba_mtp_transfer_uses_first_non_spec_remote_block(self):
+        mamba_spec = MambaSpec(
+            block_size=1,
+            shapes=((2, 4), (2, 4)),
+            dtypes=(torch.float32, torch.float32),
+            mamba_cache_mode="align",
+            num_speculative_blocks=3,
+        )
+        self.thread.kv_cache_specs = [mamba_spec]
+        self.thread.mamba_cache_mode = "align"
+        self.thread.num_speculative_tokens = 3
+
+        req_meta = self.req_meta_base
+        req_meta.local_block_ids = [[5, 6, 7, 8]]
+        req_meta.remote_block_ids = [[10, 20, 30, 40]]
+        req_meta.remote_tp_size = 1
+        req_meta.remote_layer_metadata = {
+            "layer0": _make_layer_metadata(
+                kv_caches_base_addr=[4000, 8000],
+                block_len=[64, 64],
+                block_size_scale=[1, 1],
+            ),
+        }
+
+        send_task = SendTask(
+            send_request={"req_mtp": req_meta},
+            wait_event=MagicMock(),
+            k_cache=torch.zeros((1, 8)),
+            v_cache=torch.zeros((1, 8)),
+            layer_idx=0,
+            layer_name="layer0",
+            group_rearrange_block_ids=[[]],
+        )
+
+        src_list, dst_list, length_list = self.thread.get_transfer_meta(send_task, "req_mtp", req_meta, 0)
+
+        self.assertEqual(src_list, [1000 + 5 * 1024, 2000 + 5 * 2048])
+        self.assertEqual(dst_list, [4000 + 10 * 1024, 8000 + 10 * 2048])
+        self.assertEqual(length_list, [1024, 2048])
 
     @patch(
         "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.group_concurrent_contiguous",

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -300,6 +300,13 @@ class KVCacheSendingLayerThread(threading.Thread):
                 transfer_block_idx = len(local_block_ids) - self.num_speculative_tokens - 1
             else:
                 transfer_block_idx = 0
+            remote_transfer_block_idx = len(remote_block_ids) - self.num_speculative_tokens - 1
+            if transfer_block_idx < 0 or remote_transfer_block_idx < 0:
+                raise RuntimeError(
+                    "Mamba KV transfer does not have enough blocks for speculative decoding. "
+                    f"local blocks: {len(local_block_ids)}, remote blocks: {len(remote_block_ids)}, "
+                    f"num_speculative_tokens: {self.num_speculative_tokens}"
+                )
             local_conv_addr, local_ssm_addr = local_layer_metadata.kv_caches_base_addr
             remote_conv_addr, remote_ssm_addr = remote_layer_metadata.kv_caches_base_addr
             local_conv_len, local_ssm_len = local_layer_metadata.block_len
@@ -313,8 +320,8 @@ class KVCacheSendingLayerThread(threading.Thread):
                 )
                 dst_list.extend(
                     [
-                        remote_conv_addr + remote_block_ids[-1] * local_conv_len,
-                        remote_ssm_addr + remote_block_ids[-1] * local_ssm_len,
+                        remote_conv_addr + remote_block_ids[remote_transfer_block_idx] * local_conv_len,
+                        remote_ssm_addr + remote_block_ids[remote_transfer_block_idx] * local_ssm_len,
                     ]
                 )
                 length_list.extend([local_conv_len, local_ssm_len])
@@ -349,12 +356,20 @@ class KVCacheSendingLayerThread(threading.Thread):
                         src_list.append(
                             local_conv_addr + local_block_ids[transfer_block_idx] * local_conv_len + local_addr_offset
                         )
-                        dst_list.append(remote_conv_addr + remote_block_ids[-1] * remote_conv_len + remote_addr_offset)
+                        dst_list.append(
+                            remote_conv_addr
+                            + remote_block_ids[remote_transfer_block_idx] * remote_conv_len
+                            + remote_addr_offset
+                        )
                         length_list.append(local_conv_size * get_dtype_size(conv_dtype))
                 # ssm
                 remote_addr_offset = (self.tp_rank % tp_ratio) * math.prod(ssm_shape) * get_dtype_size(ssm_dtype)
                 src_list.append(local_ssm_addr + local_block_ids[transfer_block_idx] * local_ssm_len)
-                dst_list.append(remote_ssm_addr + remote_block_ids[-1] * remote_ssm_len + remote_addr_offset)
+                dst_list.append(
+                    remote_ssm_addr
+                    + remote_block_ids[remote_transfer_block_idx] * remote_ssm_len
+                    + remote_addr_offset
+                )
                 length_list.append(local_ssm_len)
         else:
             if self.pd_head_ratio == 1:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes incorrect Qwen3.5/Qwen3.6 generation when using the Mooncake layerwise connector with Mamba/GDN and MTP enabled.

For layerwise Mamba KV transfer, the previous code always copied the final recurrent state to `remote_block_ids[-1]`. With MTP enabled, the decode-side block table contains `num_speculative_tokens + 1` state slots. For example, with `num_speculative_tokens=3`, the last three slots are speculative state slots.

Writing the prompt/final recurrent state to `remote_block_ids[-1]` places it into the last speculative slot instead of the first non-speculative state slot. This can make the decode-side GDN recurrent path read incorrect SSM state and produce responses unrelated to the prompt.

This PR changes the layerwise Mamba transfer destination to use the first non-speculative remote state block:

```python
len(remote_block_ids) - self.num_speculative_tokens - 1
```

This matches the non-layerwise Mooncake connector behavior. The fix covers both normal and TP-resharded Mamba transfer address calculations.

### Does this PR introduce _any_ user-facing change?

No API or configuration changes.

This fixes incorrect generation behavior for Qwen3.5/Qwen3.6 with layerwise connector + Mamba/GDN + MTP decode flows.

### How was this patch tested?

Unit tests:

```bash
uv run pytest -q tests/ut/kv_offload/test_mooncake_layerwise_connector.py
```

Result:

```text
42 passed
```

Added regression coverage for `num_speculative_tokens=3`, verifying that layerwise Mamba transfer writes to the first non-speculative remote state block instead of the final speculative slot.

Accuracy test:

GSM8K accuracy test is still running.

Test configuration:

- Model: `qwen3.6-35B-A3B-w8a8`
- Prefill: `enforce-eager` + MTP
- Decode: full graph decode-only + MTP
- Connector: layerwise connector

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
