### PR TITLE
[BugFix] Set modelscope version to 1.35.3 follow vllm

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements-lint.txt
 -r requirements.txt
-modelscope==1.35.3
+modelscope==1.38.0
 openai
 pytest >= 6.0,<9.0.0
 pytest-asyncio

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -1086,3 +1086,22 @@
 #       runner and can rely on upstream's default enablement heuristics
 #       (model architecture, Triton, feature checks) without crashes or
 #       degraded functionality.
+#
+# ** 31. File: platform/patch_modelscope_hub_api.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.transformers_utils.utils.modelscope_list_repo_files`
+#    Why:
+#       Modelscope v1.38.0 refactored its Hub layer, delegating to
+#       modelscope-hub as a compat shim. LegacyHubApi.get_model_files()
+#       no longer accepts the `revision` parameter, which breaks
+#       vLLM's list_repo_files() when VLLM_USE_MODELSCOPE is True.
+#    How:
+#       Monkey-patch modelscope_list_repo_files() to detect whether
+#       get_model_files() accepts `revision` via inspect.signature()
+#       at import time, and conditionally pass the argument.
+#    Related PR (if no, explain why):
+#       No upstream PR yet. This is a vllm-ascend workaround until
+#       upstream vLLM supports modelscope>=1.38.
+#    Future Plan:
+#       Remove this patch when upstream vLLM adapts its ModelScope
+#       integration for the modelscope-hub compat API.

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -52,3 +52,5 @@ import vllm_ascend.patch.platform.patch_speculative_config  # noqa
 if not vllm_version_is("0.23.0"):
     import vllm_ascend.patch.platform.patch_fused_moe  # noqa
     import vllm_ascend.patch.platform.patch_dp_device_ids  # noqa
+
+import vllm_ascend.patch.platform.patch_modelscope_hub_api  # noqa

--- a/vllm_ascend/patch/platform/patch_modelscope_hub_api.py
+++ b/vllm_ascend/patch/platform/patch_modelscope_hub_api.py
@@ -1,0 +1,53 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import inspect
+
+import vllm.transformers_utils.utils as _target_utils
+
+from modelscope.hub.api import HubApi as _HubApi
+
+# Modelscope v1.38.0 removed the `revision` parameter from
+# LegacyHubApi.get_model_files(). Detect the signature once at
+# import time so the patch is zero-overhead at runtime.
+try:
+    _sig = inspect.signature(_HubApi.get_model_files)
+    _HAS_REVISION = "revision" in _sig.parameters
+except (ValueError, TypeError):
+    _HAS_REVISION = True  # assume old API on inspect failure
+
+
+def _patched_modelscope_list_repo_files(
+    repo_id: str,
+    revision: str | None = None,
+    token: str | bool | None = None,
+) -> list[str]:
+    from modelscope.hub.api import HubApi
+
+    api = HubApi()
+    api.login(token)
+    kwargs = {"model_id": repo_id, "recursive": True}
+    if _HAS_REVISION:
+        kwargs["revision"] = revision
+    raw_files = api.get_model_files(**kwargs)
+    return [
+        f.get("Path", f.get("path"))
+        for f in raw_files
+        if f.get("Type", f.get("type")) == "blob"
+    ]
+
+
+_target_utils.modelscope_list_repo_files = _patched_modelscope_list_repo_files


### PR DESCRIPTION
### What this PR does / why we need it?
fix : https://github.com/vllm-project/vllm-ascend/actions/runs/28498520610/job/84470743474?pr=11237#step:19:1440

vllm modelscope version:https://github.com/vllm-project/vllm/blob/f651a8a9a444e5ef7eb88003d45ab908b8d4dc25/requirements/test/xpu.txt#L395

modelscope>=1.35.1 allows the installation of newer versions (such as 1.38.0). The new version of modelscope_hub changes the model cache path structure.
Old version (1.35.3) cache path: /root/.cache/modelscope/Qwen/Qwen3-0.6B/ (flat structure)
New version path: /root/.cache/modelscope/Qwen/Qwen3-0.6B/snapshots/master/ (snapshots/revision level added)
The model on the CI machine is cached according to the old path, and the new version of modelscope_hub cannot be found.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
