### PR TITLE
[Feature]Adapt GLM-5.2

### DIFF
--- a/vllm_ascend/patch/worker/patch_deepseek_mtp.py
+++ b/vllm_ascend/patch/worker/patch_deepseek_mtp.py
@@ -51,8 +51,12 @@ class AscendDeepSeekMultiTokenPredictorLayer(DeepSeekMultiTokenPredictorLayer):
         hidden_states = self.eh_proj(torch.cat([inputs_embeds, previous_hidden_states], dim=-1))
 
         hidden_states, residual = self.mtp_block(positions=positions, hidden_states=hidden_states, residual=None)
-        hidden_states = residual + hidden_states
-        return hidden_states
+        hidden_states = residual + hidden_states  # pre-final-norm (logits hidden)
+        # Recycle the post-final-norm hidden into the next draft step.
+        # compute_logits applies shared_head (== final norm) to the pre-norm
+        # element, so logits and the recycle each get exactly one final-norm.
+        # Matches SGLang's deepseek_nextn.
+        return hidden_states, self.shared_head(hidden_states)
 
 
 class AscendDeepSeekMTP(DeepSeekMTP):

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1519,6 +1519,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             return total_num_output_tokens, token_indices_to_sample, new_cad, None
 
     def model_returns_tuple(self) -> bool:
+        if self.method == "mtp":
+            # DeepSeek-family MTP (deepseek_mtp.py) recycles the post-final-
+            # norm hidden, so its forward returns (logit_hidden,
+            # recycle_hidden). Other MTP families return a single tensor.
+            draft_model_config = getattr(self, "draft_model_config", None)
+            hf_config = getattr(draft_model_config, "hf_config", None)
+            architectures = getattr(hf_config, "architectures", []) or []
+            return "DeepSeekMTPModel" in architectures
         return self.method not in ("mtp", "draft_model", "dflash")
 
     def attn_update_stack_num_spec_norm(


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds support for GLM-5.2 on Ascend. This pull request updates `model_returns_tuple` in `llm_base_proposer.py` to support DeepSeek-family MTP models (`DeepSeekMTPModel`). Since DeepSeek MTP recycles the post-final-norm hidden state, its forward pass returns a tuple `(logit_hidden, recycle_hidden)`, whereas other MTP families return a single tensor.

vllm's PR: https://github.com/vllm-project/vllm/pull/45895

### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/dc68bd8c4199b00631fe71eb37313f406cc66ac1
