### PR TITLE
[BugFix] Fix FIA decode mask handling on main

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -686,6 +686,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         seq_lens = metadata.seq_lens_list
                         actual_seq_lengths_q = metadata.actual_seq_lengths_q
                         block_tables = metadata.block_tables
+                        attn_state = metadata.attn_state
                         attn_count = attn_count + 1
                         if not metadata.causal:
                             sparse_mode = 0
@@ -693,6 +694,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         metadata_key = layer_name if layer_name is not None and layer_name in attn_metadata else key
                         seq_lens = attn_metadata[metadata_key].seq_lens_list
                         actual_seq_lengths_q = attn_metadata[metadata_key].actual_seq_lengths_q
+                        attn_state = attn_metadata[metadata_key].attn_state
                         # NOTE:
                         # For models with sliding-window attention on the FIA full-graph replay path,
                         # rebinding `block_tables` to the latest metadata tensor causes corrupted /
@@ -725,12 +727,14 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         }
                         input_layout = "BNSD"
                         sparse_mode = 0
+                    is_decode = attn_state == AscendAttentionState.DecodeOnly
+                    update_attn_mask, update_sparse_mode = (None, 0) if is_decode else (attn_mask, sparse_mode)
                     torch_npu.npu_fused_infer_attention_score.out(
                         query=query,
                         key=key_cache,
                         value=value,
                         block_table=block_tables,
-                        atten_mask=attn_mask,
+                        atten_mask=update_attn_mask,
                         input_layout=input_layout,
                         block_size=block_size,
                         actual_seq_lengths=actual_seq_lengths_q,
@@ -738,7 +742,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         num_key_value_heads=num_kv_heads,
                         num_heads=num_heads,
                         scale=scale,
-                        sparse_mode=sparse_mode,
+                        sparse_mode=update_sparse_mode,
                         pre_tokens=pre_tokens,
                         next_tokens=next_tokens,
                         **extra_args,
@@ -781,8 +785,13 @@ class AscendAttentionBackendImpl(AttentionImpl):
         actual_seq_lengths_q = attn_metadata.actual_seq_lengths_q
         softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
         input_layout = "TND"
-        attn_mask = attn_metadata.attn_mask
-        sparse_mode = 4 if self.sliding_window else 3 if attn_metadata.causal else 0
+        is_decode = attn_metadata.attn_state == AscendAttentionState.DecodeOnly
+        if is_decode:
+            attn_mask = None
+            sparse_mode = 0
+        else:
+            attn_mask = attn_metadata.attn_mask
+            sparse_mode = 4 if self.sliding_window else 3 if attn_metadata.causal else 0
         pre_tokens = self.sliding_window or SWA_INT_MAX
         next_tokens = 0 if self.sliding_window else SWA_INT_MAX
 
@@ -1200,11 +1209,13 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     sparse_mode=0,
                 )
             elif self.sliding_window is not None:
+                is_decode = attn_metadata.attn_state == AscendAttentionState.DecodeOnly
+                attn_mask, sparse_mode = (None, 0) if is_decode else (attn_metadata.attn_mask, 4)
                 attn_output, _ = torch_npu.npu_fused_infer_attention_score(
                     query=query,
                     key=key,
                     value=value,
-                    atten_mask=attn_metadata.attn_mask,
+                    atten_mask=attn_mask,
                     block_table=block_table,
                     input_layout="TND",
                     block_size=block_size,
@@ -1215,14 +1226,16 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     scale=self.scale,
                     pre_tokens=self.sliding_window,
                     next_tokens=0,
-                    sparse_mode=4,
+                    sparse_mode=sparse_mode,
                 )
             else:
+                is_decode = attn_metadata.attn_state == AscendAttentionState.DecodeOnly
+                attn_mask, sparse_mode = (None, 0) if is_decode else (attn_metadata.attn_mask, 3)
                 attn_output, _ = DeviceOperator.npu_fused_infer_attention_score(
                     query=query,
                     key=key,
                     value=value,
-                    atten_mask=attn_metadata.attn_mask,
+                    atten_mask=attn_mask,
                     block_table=block_table,
                     input_layout="TND",
                     block_size=block_size,
@@ -1238,7 +1251,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     current_value=passed_value,
                     attn_metadata=attn_metadata,
                     is_prefill_no_cache=attn_metadata.attn_state == AscendAttentionState.PrefillNoCache,
-                    sparse_mode=3,
+                    sparse_mode=sparse_mode,
                 )
 
             attn_output = attn_output.view(num_tokens, self.num_heads, self.head_size)

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -687,6 +687,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         actual_seq_lengths_q = metadata.actual_seq_lengths_q
                         block_tables = metadata.block_tables
                         attn_state = metadata.attn_state
+                        max_query_len = metadata.max_query_len
                         attn_count = attn_count + 1
                         if not metadata.causal:
                             sparse_mode = 0
@@ -695,6 +696,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         seq_lens = attn_metadata[metadata_key].seq_lens_list
                         actual_seq_lengths_q = attn_metadata[metadata_key].actual_seq_lengths_q
                         attn_state = attn_metadata[metadata_key].attn_state
+                        max_query_len = attn_metadata[metadata_key].max_query_len
                         # NOTE:
                         # For models with sliding-window attention on the FIA full-graph replay path,
                         # rebinding `block_tables` to the latest metadata tensor causes corrupted /
@@ -727,8 +729,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         }
                         input_layout = "BNSD"
                         sparse_mode = 0
-                    is_decode = attn_state == AscendAttentionState.DecodeOnly
-                    update_attn_mask, update_sparse_mode = (None, 0) if is_decode else (attn_mask, sparse_mode)
+                    is_single_token_decode = attn_state == AscendAttentionState.DecodeOnly and max_query_len == 1
+                    update_attn_mask, update_sparse_mode = (
+                        (None, 0) if is_single_token_decode else (attn_mask, sparse_mode)
+                    )
                     torch_npu.npu_fused_infer_attention_score.out(
                         query=query,
                         key=key_cache,
@@ -785,8 +789,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
         actual_seq_lengths_q = attn_metadata.actual_seq_lengths_q
         softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
         input_layout = "TND"
-        is_decode = attn_metadata.attn_state == AscendAttentionState.DecodeOnly
-        if is_decode:
+        is_single_token_decode = (
+            attn_metadata.attn_state == AscendAttentionState.DecodeOnly and attn_metadata.max_query_len == 1
+        )
+        if is_single_token_decode:
             attn_mask = None
             sparse_mode = 0
         else:
@@ -1209,8 +1215,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     sparse_mode=0,
                 )
             elif self.sliding_window is not None:
-                is_decode = attn_metadata.attn_state == AscendAttentionState.DecodeOnly
-                attn_mask, sparse_mode = (None, 0) if is_decode else (attn_metadata.attn_mask, 4)
+                is_single_token_decode = (
+                    attn_metadata.attn_state == AscendAttentionState.DecodeOnly and attn_metadata.max_query_len == 1
+                )
+                attn_mask, sparse_mode = (None, 0) if is_single_token_decode else (attn_metadata.attn_mask, 4)
                 attn_output, _ = torch_npu.npu_fused_infer_attention_score(
                     query=query,
                     key=key,
@@ -1229,8 +1237,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     sparse_mode=sparse_mode,
                 )
             else:
-                is_decode = attn_metadata.attn_state == AscendAttentionState.DecodeOnly
-                attn_mask, sparse_mode = (None, 0) if is_decode else (attn_metadata.attn_mask, 3)
+                is_single_token_decode = (
+                    attn_metadata.attn_state == AscendAttentionState.DecodeOnly and attn_metadata.max_query_len == 1
+                )
+                attn_mask, sparse_mode = (None, 0) if is_single_token_decode else (attn_metadata.attn_mask, 3)
                 attn_output, _ = DeviceOperator.npu_fused_infer_attention_score(
                     query=query,
                     key=key,


### PR DESCRIPTION
### What this PR does / why we need it?

This adapts the behavior from #10302 to the current `main` branch.

For FIA v1 decode-only paths, `npu_fused_infer_attention_score` should receive `atten_mask=None` and `sparse_mode=0`. The current `main` code still passed the splitfuse attention mask and sparse mode 3/4 in several decode paths, including graph capture/replay. That can trigger the same decode-stage performance regression fixed in #10302.

This PR updates:
- normal FIA v1 decode calls
- FIA v1 full-graph capture parameters
- FIA v1 graph replay updates

### Performance evaluation

We compared the legacy behavior (`atten_mask` with `sparse_mode=3`) against this PR (`atten_mask=None`, `sparse_mode=0`).

#### End-to-end serving benchmark

Test configuration:

- Model: Qwen3-32B
- Parallelism: TP=4, DP=2 on 8 Ascend NPUs
- CUDAGraph mode: `FULL_DECODE_ONLY`
- Prefix caching disabled
- Random input/output length: 16384 / 2048
- 16 prompts, maximum concurrency 16
- `request-rate=inf`, `temperature=0`, `ignore-eos`
- Three runs per variant; the table reports the median

| Metric | Legacy | This PR | Relative change |
|---|---:|---:|---:|
| Output token throughput | 416.83 tok/s | 418.75 tok/s | +0.46% |
| Mean TPOT | 34.20 ms | 34.05 ms | -0.44% |
| P99 TPOT | 37.39 ms | 37.24 ms | -0.40% |

All requests completed successfully. A shorter 2048/1024, concurrency-4 control workload was effectively neutral: +0.11% output throughput and -0.05% Mean TPOT.

#### FIA kernel profiling

To remove DP profiler synchronization differences while preserving the same per-replica FIA shape, kernel profiling used TP=4, DP=1 with batch/concurrency 8 and a 16384-token context.

Profiling started after the requests had entered steady-state decode. Both variants captured exactly 5504 `FusedInferAttentionScore` calls per device, or 22016 matched calls across four devices.

| FIA metric | Legacy | This PR | Improvement |
|---|---:|---:|---:|
| Kernel Duration mean | 173.386 us | 171.370 us | 1.16% |
| Kernel Duration median | 172.440 us | 170.640 us | 1.04% |
| Kernel Duration P99 | 187.697 us | 183.020 us | 2.49% |
| AI Core time mean | 162.478 us | 159.155 us | 2.05% |

Qwen3-32B invokes FIA once per layer across 64 layers. The measured mean kernel-duration reduction therefore saves approximately:

```text
(173.386 us - 171.370 us) x 64 = 0.129 ms per decode step
```

For a roughly 35 ms TPOT, this predicts about a 0.36% end-to-end improvement, consistent with the observed 0.44% Mean TPOT reduction.

The improvement is modest but measurable in this environment: the FIA computation itself is about 2% faster, while the overall decode step also contains projections, MLP, tensor-parallel communication, and scheduling work that is unaffected by this change.

### Does this PR introduce any user-facing change?

No. This is an internal decode-path parameter fix.

### How was this patch tested?

Full NPU/runtime tests were not run locally.


- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
