### PR TITLE
[CI] Add Kimi-K2.5 EP weekly case

### DIFF
--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -33,6 +33,9 @@ a3:
       - name: GLM_5_1_PD_in64k_bs16-90
         config_file_path: GLM_5_1_PD_in64k_bs16-90.yaml
         size: 4
+      - name: kimi-k2_5-w4a8-ep-16k-1k-TPOT50
+        config_file_path: Kimi-K2.5-W4A8-16k-1k-TPOT50.yaml
+        size: 4
   double_node:
     test_config:
       - name: DeepSeek-V3_2-W8A8-EP_weekly

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -138,6 +138,9 @@ jobs:
           - name: GLM_5_1_PD_in64k_bs16-90
             config_file_path: GLM_5_1_PD_in64k_bs16-90.yaml
             size: 4
+          - name: kimi-k2_5-w4a8-ep-16k-1k-TPOT50
+            config_file_path: Kimi-K2.5-W4A8-16k-1k-TPOT50.yaml
+            size: 4
     uses: ./.github/workflows/_e2e_nightly_multi_node.yaml
     with:
       soc_version: a3

--- a/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.5-W4A8-16k-1k-TPOT50.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.5-W4A8-16k-1k-TPOT50.yaml
@@ -1,0 +1,295 @@
+test_name: "multi-node-kimi-k2.5-w4a8-ep-external-dp-16k-1k-TPOT50"
+model: "/mnt/weight/kimi25_w4a8_static_m6"
+num_nodes: 4
+npu_per_node: 16
+cluster_hosts:
+  - "141.61.81.143"
+  - "141.61.81.131"
+  - "141.61.81.33"
+  - "141.61.81.31"
+
+routing:
+  type: "disaggregated_prefill"
+  groups:
+    prefiller: [0, 1]
+    decoder: [2, 3]
+
+config:
+  - node_index: 0
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 2
+    dp_size_local: 2
+    dp_rank_start: 0
+    tp_size: 8
+    dp_address: "${NODE_0_IP}"
+
+  - node_index: 1
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 2
+    dp_size_local: 2
+    dp_rank_start: 0
+    tp_size: 8
+    dp_address: "${NODE_1_IP}"
+
+  - node_index: 2
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 32
+    dp_size_local: 16
+    dp_rank_start: 0
+    tp_size: 1
+    dp_address: "${NODE_2_IP}"
+
+  - node_index: 3
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 32
+    dp_size_local: 16
+    dp_rank_start: 16
+    tp_size: 1
+    dp_address: "${NODE_2_IP}"
+
+#env_common: &env_common
+#  HCCL_OP_EXPANSION_MODE: "AIV"
+#  VLLM_USE_MODELSCOPE: "true"
+#  SERVER_PORT: "${PORT}"
+#  OMP_PROC_BIND: "false"
+#  OMP_NUM_THREADS: "1"
+#  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+#  HCCL_BUFFSIZE: "256"
+#  VLLM_TORCH_PROFILER_WITH_STACK: "0"
+#  ASCEND_AGGREGATE_ENABLE: "1"
+#  ASCEND_TRANSPORT_PRINT: "1"
+#  ACL_OP_INIT_MODE: "1"
+#  ASCEND_A3_ENABLE: "1"
+#  VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "300000"
+#  VLLM_ENGINE_READY_TIMEOUT_S: "7200"
+#  HCCL_CONNECT_TIMEOUT: "1200"
+#  HCCL_INTRA_PCIE_ENABLE: "1"
+#  HCCL_INTRA_ROCE_ENABLE: "0"
+#  VLLM_ASCEND_ENABLE_FUSED_MC2: "0"
+#  ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+
+templates:
+  - node_index: 0
+    envs:
+      SERVER_PORT: "${PORT}"
+      VLLM_RPC_TIMEOUT: "3600000"
+      VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30000"
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+      OMP_PROC_BIND: "false"
+      OMP_NUM_THREADS: "1"
+      TASK_QUEUE_ENABLE: "1"
+      ASCEND_BUFFER_POOL: "4:8"
+      HCCL_BUFFSIZE: "256"
+      VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
+      ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --enable-expert-parallel
+      - --seed
+      - "1024"
+      - --quantization
+      - "ascend"
+      - --trust-remote-code
+      - --max-num-seqs
+      - "8"
+      - --max-model-len
+      - "32768"
+      - --max-num-batched-tokens
+      - "16384"
+      - --no-enable-prefix-caching
+      - --gpu-memory-utilization
+      - "0.8"
+      - --enforce-eager
+      - --speculative-config
+      - '{"method": "eagle3", "model":"/mnt/share/weight/lightseekorg_kimi-k2.5-eagle3", "num_speculative_tokens": 3}'
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_producer", "kv_port": "30000", "engine_id": "0", "kv_connector_extra_config": {"prefill": {"dp_size": 2, "tp_size": 8}, "decode": {"dp_size": 32, "tp_size": 1}}}'
+
+  - node_index: 1
+    envs:
+      SERVER_PORT: "${PORT}"
+      VLLM_RPC_TIMEOUT: "3600000"
+      VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30000"
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+      OMP_PROC_BIND: "false"
+      OMP_NUM_THREADS: "1"
+      TASK_QUEUE_ENABLE: "1"
+      ASCEND_BUFFER_POOL: "4:8"
+      HCCL_BUFFSIZE: "256"
+      VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
+      ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --enable-expert-parallel
+      - --seed
+      - "1024"
+      - --quantization
+      - "ascend"
+      - --trust-remote-code
+      - --max-num-seqs
+      - "8"
+      - --max-model-len
+      - "32768"
+      - --max-num-batched-tokens
+      - "16384"
+      - --no-enable-prefix-caching
+      - --gpu-memory-utilization
+      - "0.8"
+      - --enforce-eager
+      - --speculative-config
+      - '{"method": "eagle3", "model":"/mnt/share/weight/lightseekorg_kimi-k2.5-eagle3", "num_speculative_tokens": 3}'
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_producer", "kv_port": "30100", "engine_id": "1", "kv_connector_extra_config": {"prefill": {"dp_size": 2, "tp_size": 8}, "decode": {"dp_size": 32, "tp_size": 1}}}'
+
+
+  - node_index: 2
+    envs:
+      SERVER_PORT: "${PORT}"
+      VLLM_RPC_TIMEOUT: "3600000"
+      VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30000"
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+      OMP_PROC_BIND: "false"
+      OMP_NUM_THREADS: "1"
+      TASK_QUEUE_ENABLE: "1"
+      ASCEND_BUFFER_POOL: "4:8"
+      HCCL_BUFFSIZE: "1800"
+      VLLM_ASCEND_ENABLE_MLAPO: "1"
+      ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --enable-expert-parallel
+      - --seed
+      - "1024"
+      - --quantization
+      - "ascend"
+      - --trust-remote-code
+      - --max-num-seqs
+      - "48"
+      - --max-model-len
+      - "32768"
+      - --max-num-batched-tokens
+      - "256"
+      - --no-enable-prefix-caching
+      - --gpu-memory-utilization
+      - "0.95"
+      - --compilation-config
+      - '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes":[4,8,16,32,48,64,80,96,112,128,144,160]}'
+      - --additional-config
+      - '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert": false}'
+      - --speculative-config
+      - '{"method": "eagle3", "model":"/mnt/share/weight/lightseekorg_kimi-k2.5-eagle3", "num_speculative_tokens": 3}'
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_consumer", "kv_port": "30200", "engine_id": "2", "kv_connector_extra_config": {"prefill": {"dp_size": 2, "tp_size": 8}, "decode": {"dp_size": 32, "tp_size": 1}}}'
+
+  - node_index: 3
+    envs:
+      SERVER_PORT: "${PORT}"
+      VLLM_RPC_TIMEOUT: "3600000"
+      VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30000"
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+      OMP_PROC_BIND: "false"
+      OMP_NUM_THREADS: "1"
+      TASK_QUEUE_ENABLE: "1"
+      ASCEND_BUFFER_POOL: "4:8"
+      HCCL_BUFFSIZE: "1800"
+      VLLM_ASCEND_ENABLE_MLAPO: "1"
+      ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --enable-expert-parallel
+      - --seed
+      - "1024"
+      - --quantization
+      - "ascend"
+      - --trust-remote-code
+      - --max-num-seqs
+      - "48"
+      - --max-model-len
+      - "32768"
+      - --max-num-batched-tokens
+      - "256"
+      - --no-enable-prefix-caching
+      - --gpu-memory-utilization
+      - "0.95"
+      - --compilation-config
+      - '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes":[4,8,16,32,48,64,80,96,112,128,144,160]}'
+      - --additional-config
+      - '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert": false}'
+      - --speculative-config
+      - '{"method": "eagle3", "model":"/mnt/share/weight/lightseekorg_kimi-k2.5-eagle3", "num_speculative_tokens": 3}'
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_consumer", "kv_port": "30200", "engine_id": "2", "kv_connector_extra_config": {"prefill": {"dp_size": 2, "tp_size": 8}, "decode": {"dp_size": 32, "tp_size": 1}}}'
+
+
+benchmarks:
+  perf:
+    case_type: performance
+    dataset_path_local: /mnt/share/g60049161/datasets/GSM8K-in16384-bs1024-kimi
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 1024
+    max_out_len: 1024
+    batch_size: 256
+    request_rate: 3
+    baseline: 2099.9
+    threshold: 0.97

--- a/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.5-W4A8-16k-1k-TPOT50.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.5-W4A8-16k-1k-TPOT50.yaml
@@ -235,7 +235,7 @@ templates:
 benchmarks:
   perf:
     case_type: performance
-    dataset_path: vllm-ascend/GSM8K_prefix0_in16384_bs1200_deepseek
+    dataset_path: vllm-ascend/GSM8K_prefix0_in16384_bs1024_kimi25
     request_conf: vllm_api_stream_chat
     dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
     num_prompts: 1024

--- a/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.5-W4A8-16k-1k-TPOT50.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.5-W4A8-16k-1k-TPOT50.yaml
@@ -6,8 +6,8 @@ npu_per_node: 16
 routing:
   type: "disaggregated_prefill"
   groups:
-    prefiller: [0, 1]
-    decoder: [2, 3]
+    prefiller: [ 0, 1 ]
+    decoder: [ 2, 3 ]
 
 config:
   - node_index: 0
@@ -235,12 +235,12 @@ templates:
 benchmarks:
   perf:
     case_type: performance
-    dataset_path: vllm-ascend/GSM8K_prefix0_in16384_bs200_kimi
+    dataset_path: vllm-ascend/GSM8K_prefix0_in16384_bs1200_deepseek
     request_conf: vllm_api_stream_chat
     dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
-    num_prompts: 200
+    num_prompts: 1024
     max_out_len: 1024
-    batch_size: 64
+    batch_size: 256
     request_rate: 3
-    baseline: 1
+    baseline: 2099.9
     threshold: 0.95

--- a/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.5-W4A8-16k-1k-TPOT50.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.5-W4A8-16k-1k-TPOT50.yaml
@@ -1,12 +1,7 @@
 test_name: "multi-node-kimi-k2.5-w4a8-ep-external-dp-16k-1k-TPOT50"
-model: "/mnt/weight/kimi25_w4a8_static_m6"
+model: "Eco-Tech/Kimi-K2.5-W4A8"
 num_nodes: 4
 npu_per_node: 16
-cluster_hosts:
-  - "141.61.81.143"
-  - "141.61.81.131"
-  - "141.61.81.33"
-  - "141.61.81.31"
 
 routing:
   type: "disaggregated_prefill"
@@ -51,42 +46,32 @@ config:
     tp_size: 1
     dp_address: "${NODE_2_IP}"
 
-#env_common: &env_common
-#  HCCL_OP_EXPANSION_MODE: "AIV"
-#  VLLM_USE_MODELSCOPE: "true"
-#  SERVER_PORT: "${PORT}"
-#  OMP_PROC_BIND: "false"
-#  OMP_NUM_THREADS: "1"
-#  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-#  HCCL_BUFFSIZE: "256"
-#  VLLM_TORCH_PROFILER_WITH_STACK: "0"
-#  ASCEND_AGGREGATE_ENABLE: "1"
-#  ASCEND_TRANSPORT_PRINT: "1"
-#  ACL_OP_INIT_MODE: "1"
-#  ASCEND_A3_ENABLE: "1"
-#  VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "300000"
-#  VLLM_ENGINE_READY_TIMEOUT_S: "7200"
-#  HCCL_CONNECT_TIMEOUT: "1200"
-#  HCCL_INTRA_PCIE_ENABLE: "1"
-#  HCCL_INTRA_ROCE_ENABLE: "0"
-#  VLLM_ASCEND_ENABLE_FUSED_MC2: "0"
-#  ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+env_common: &env_common
+  SERVER_PORT: "${PORT}"
+  VLLM_RPC_TIMEOUT: "3600000"
+  VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30000"
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+  OMP_PROC_BIND: "false"
+  OMP_NUM_THREADS: "1"
+  TASK_QUEUE_ENABLE: "1"
+  ASCEND_BUFFER_POOL: "4:8"
+  ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+
+env_prefill: &env_prefill
+  <<: *env_common
+  HCCL_BUFFSIZE: "256"
+  VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
+
+env_decode: &env_decode
+  <<: *env_common
+  HCCL_BUFFSIZE: "1800"
+  VLLM_ASCEND_ENABLE_MLAPO: "1"
 
 templates:
   - node_index: 0
     envs:
-      SERVER_PORT: "${PORT}"
-      VLLM_RPC_TIMEOUT: "3600000"
-      VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30000"
-      HCCL_OP_EXPANSION_MODE: "AIV"
-      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-      OMP_PROC_BIND: "false"
-      OMP_NUM_THREADS: "1"
-      TASK_QUEUE_ENABLE: "1"
-      ASCEND_BUFFER_POOL: "4:8"
-      HCCL_BUFFSIZE: "256"
-      VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
-      ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+      <<: *env_prefill
     server_cmd_template:
       - --host
       - "0.0.0.0"
@@ -125,18 +110,7 @@ templates:
 
   - node_index: 1
     envs:
-      SERVER_PORT: "${PORT}"
-      VLLM_RPC_TIMEOUT: "3600000"
-      VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30000"
-      HCCL_OP_EXPANSION_MODE: "AIV"
-      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-      OMP_PROC_BIND: "false"
-      OMP_NUM_THREADS: "1"
-      TASK_QUEUE_ENABLE: "1"
-      ASCEND_BUFFER_POOL: "4:8"
-      HCCL_BUFFSIZE: "256"
-      VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
-      ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+      <<: *env_prefill
     server_cmd_template:
       - --host
       - "0.0.0.0"
@@ -173,21 +147,9 @@ templates:
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_producer", "kv_port": "30100", "engine_id": "1", "kv_connector_extra_config": {"prefill": {"dp_size": 2, "tp_size": 8}, "decode": {"dp_size": 32, "tp_size": 1}}}'
 
-
   - node_index: 2
     envs:
-      SERVER_PORT: "${PORT}"
-      VLLM_RPC_TIMEOUT: "3600000"
-      VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30000"
-      HCCL_OP_EXPANSION_MODE: "AIV"
-      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-      OMP_PROC_BIND: "false"
-      OMP_NUM_THREADS: "1"
-      TASK_QUEUE_ENABLE: "1"
-      ASCEND_BUFFER_POOL: "4:8"
-      HCCL_BUFFSIZE: "1800"
-      VLLM_ASCEND_ENABLE_MLAPO: "1"
-      ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+      <<: *env_decode
     server_cmd_template:
       - --host
       - "0.0.0.0"
@@ -229,18 +191,7 @@ templates:
 
   - node_index: 3
     envs:
-      SERVER_PORT: "${PORT}"
-      VLLM_RPC_TIMEOUT: "3600000"
-      VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30000"
-      HCCL_OP_EXPANSION_MODE: "AIV"
-      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-      OMP_PROC_BIND: "false"
-      OMP_NUM_THREADS: "1"
-      TASK_QUEUE_ENABLE: "1"
-      ASCEND_BUFFER_POOL: "4:8"
-      HCCL_BUFFSIZE: "1800"
-      VLLM_ASCEND_ENABLE_MLAPO: "1"
-      ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+      <<: *env_decode
     server_cmd_template:
       - --host
       - "0.0.0.0"
@@ -284,12 +235,12 @@ templates:
 benchmarks:
   perf:
     case_type: performance
-    dataset_path_local: /mnt/share/g60049161/datasets/GSM8K-in16384-bs1024-kimi
+    dataset_path: vllm-ascend/GSM8K_prefix0_in16384_bs200_kimi
     request_conf: vllm_api_stream_chat
     dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
-    num_prompts: 1024
+    num_prompts: 200
     max_out_len: 1024
-    batch_size: 256
+    batch_size: 64
     request_rate: 3
-    baseline: 2099.9
-    threshold: 0.97
+    baseline: 1
+    threshold: 0.95


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds a new end-to-end weekly performance test configuration for the Kimi-K2.5-W4A8 model using disaggregated prefill-decode with external data parallelism (EP) on Ascend NPUs.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Tested via the weekly CI pipeline with the added configuration.


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
