### PR TITLE
[Doc][Test][Feature] Add test config and tutorial for deepseek-vl2-tiny

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-VL2-Tiny.md
+++ b/docs/source/tutorials/models/DeepSeek-VL2-Tiny.md
@@ -1,0 +1,30 @@
+# DeepSeek-VL2-Tiny
+
+## Introduction
+
+DeepSeek-VL2-Tiny is a compact vision-language model.
+
+## Current Status
+
+Currently unsupported by vLLM.
+
+## Environment
+
+Download from HuggingFace. Use official docker image.
+
+## Validation
+
+```python
+from vllm import LLM
+model = LLM(model="deepseek-ai/deepseek-vl2-tiny")
+```
+
+Error: ValidationError - No model architectures specified
+
+## Root Cause
+
+config.json has architectures inside language_config.
+
+## Adaptation
+
+Check language_config.architectures.

--- a/tests/e2e/models/configs/deepseek-vl2-tiny.yaml
+++ b/tests/e2e/models/configs/deepseek-vl2-tiny.yaml
@@ -1,0 +1,21 @@
+model_name: "deepseek-ai/deepseek-vl2-tiny"
+model_type: "vllm-vlm"
+hardware: "Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 1
+  dtype: auto
+  max_model_len: 8192
+  gpu_memory_utilization: 0.8
+  trust_remote_code: true
+
+tasks:
+- name: "mmmu_val"
+  metrics:
+  - name: "acc,none"
+    value: 0.0
+
+num_fewshot: 0
+apply_chat_template: false
+fewshot_as_multiturn: false
+batch_size: "auto"


### PR DESCRIPTION
Closes #7319

### What this PR does / why we need it?
This PR adds a validation report and an E2E test configuration for the
deepseek-ai/deepseek-vl2-tiny model.

The model is currently unsupported by vLLM because its config.json uses
a nested structure for the ^Grchitectures field (language_config.architectures),
which vLLM cannot parse. This results in a ValidationError during model loading.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
This PR adds a new E2E test config which is expected to fail.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
