### PR TITLE
[Ascend950][Feature]Add allgatherEP MXFP4 quantization

### DIFF
--- a/tests/ut/ops/a2/test_token_dispatcher.py
+++ b/tests/ut/ops/a2/test_token_dispatcher.py
@@ -340,6 +340,42 @@ class TestTokenDispatcherWithMC2(TestBase):
         self.assertTrue(output.combine_metadata.quant.dispatch_with_quant)
 
 
+def test_allgather_token_dispatch_quant_mode_without_dynamic_scale():
+    dispatcher = TokenDispatcherWithAllGather(top_k=2, num_experts=128)
+    hidden_states = torch.randn(3, 128)
+    topk_weights = torch.tensor([[0.7, 0.3], [0.6, 0.4], [0.5, 0.5]])
+    topk_ids = torch.tensor([[0, 1], [1, 2], [2, 3]], dtype=torch.int32)
+    init_routing_output = (
+        torch.randn(6, 128),
+        torch.tensor([0, 1, 2, 3, 4, 5], dtype=torch.int32),
+        torch.tensor([2, 2, 2], dtype=torch.int32),
+        torch.randn(6, 4),
+    )
+
+    cases = (
+        (QuantType.MXFP8, torch.float8_e4m3fn, 3),
+        (QuantType.MXFP4, MXFP4_TEST_DTYPE, 9),
+    )
+    for quant_type, act_quant_type, expected_quant_mode in cases:
+        token_dispatch_input = build_token_dispatch_input_fixture(
+            hidden_states=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            quant_type=quant_type,
+            act_quant_type=act_quant_type,
+        )
+
+        with patch(
+            "vllm_ascend.ops.fused_moe.token_dispatcher.DeviceOperator.npu_moe_init_routing",
+            return_value=init_routing_output,
+        ) as mock_init_routing:
+            dispatcher.token_dispatch(token_dispatch_input=token_dispatch_input)
+
+        init_kwargs = mock_init_routing.call_args.kwargs
+        assert init_kwargs["quant_mode"] == expected_quant_mode
+        assert init_kwargs["act_quant_type"] == act_quant_type
+
+
 class TestTokenDispatcherWithAllGather(TestBase):
     def setUp(self):
         # Mock dependencies
@@ -369,45 +405,6 @@ class TestTokenDispatcherWithAllGather(TestBase):
     def tearDown(self):
         self.patcher_npu_moe_init_routing_custom.stop()
         self.patcher_npu_moe_token_unpermute.stop()
-
-    def test_token_dispatch_quant_mode_without_dynamic_scale(self):
-        hidden_states = torch.randn(3, 128)
-        topk_weights = torch.tensor([[0.7, 0.3], [0.6, 0.4], [0.5, 0.5]])
-        topk_ids = torch.tensor([[0, 1], [1, 2], [2, 3]], dtype=torch.int32)
-        init_routing_output = (
-            torch.randn(6, 128),
-            torch.tensor([0, 1, 2, 3, 4, 5], dtype=torch.int32),
-            torch.tensor([2, 2, 2], dtype=torch.int32),
-            torch.randn(6, 4),
-        )
-
-        cases = (
-            (QuantType.W8A8, None, 1),
-            (QuantType.W4A8, None, 1),
-            (QuantType.MXFP8, torch.float8_e4m3fn, 3),
-            (QuantType.MXFP4, MXFP4_TEST_DTYPE, 9),
-        )
-        for quant_type, act_quant_type, expected_quant_mode in cases:
-            token_dispatch_input = build_token_dispatch_input_fixture(
-                hidden_states=hidden_states,
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
-                quant_type=quant_type,
-                act_quant_type=act_quant_type,
-            )
-
-            with (
-                self.subTest(quant_type=quant_type),
-                patch(
-                    "vllm_ascend.ops.fused_moe.token_dispatcher.DeviceOperator.npu_moe_init_routing",
-                    return_value=init_routing_output,
-                ) as mock_init_routing,
-            ):
-                self.dispatcher.token_dispatch(token_dispatch_input=token_dispatch_input)
-
-            init_kwargs = mock_init_routing.call_args.kwargs
-            self.assertEqual(init_kwargs["quant_mode"], expected_quant_mode)
-            self.assertEqual(init_kwargs["act_quant_type"], act_quant_type)
 
     @pytest.mark.skip("Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
     def test_token_dispatch_without_expert_map(self):

--- a/tests/ut/ops/a2/test_token_dispatcher.py
+++ b/tests/ut/ops/a2/test_token_dispatcher.py
@@ -370,6 +370,45 @@ class TestTokenDispatcherWithAllGather(TestBase):
         self.patcher_npu_moe_init_routing_custom.stop()
         self.patcher_npu_moe_token_unpermute.stop()
 
+    def test_token_dispatch_quant_mode_without_dynamic_scale(self):
+        hidden_states = torch.randn(3, 128)
+        topk_weights = torch.tensor([[0.7, 0.3], [0.6, 0.4], [0.5, 0.5]])
+        topk_ids = torch.tensor([[0, 1], [1, 2], [2, 3]], dtype=torch.int32)
+        init_routing_output = (
+            torch.randn(6, 128),
+            torch.tensor([0, 1, 2, 3, 4, 5], dtype=torch.int32),
+            torch.tensor([2, 2, 2], dtype=torch.int32),
+            torch.randn(6, 4),
+        )
+
+        cases = (
+            (QuantType.W8A8, None, 1),
+            (QuantType.W4A8, None, 1),
+            (QuantType.MXFP8, torch.float8_e4m3fn, 3),
+            (QuantType.MXFP4, MXFP4_TEST_DTYPE, 9),
+        )
+        for quant_type, act_quant_type, expected_quant_mode in cases:
+            token_dispatch_input = build_token_dispatch_input_fixture(
+                hidden_states=hidden_states,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                quant_type=quant_type,
+                act_quant_type=act_quant_type,
+            )
+
+            with (
+                self.subTest(quant_type=quant_type),
+                patch(
+                    "vllm_ascend.ops.fused_moe.token_dispatcher.DeviceOperator.npu_moe_init_routing",
+                    return_value=init_routing_output,
+                ) as mock_init_routing,
+            ):
+                self.dispatcher.token_dispatch(token_dispatch_input=token_dispatch_input)
+
+            init_kwargs = mock_init_routing.call_args.kwargs
+            self.assertEqual(init_kwargs["quant_mode"], expected_quant_mode)
+            self.assertEqual(init_kwargs["act_quant_type"], act_quant_type)
+
     @pytest.mark.skip("Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
     def test_token_dispatch_without_expert_map(self):
         hidden_states = torch.randn(3, 128)

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -110,6 +110,7 @@ class BaseDeviceAdaptor:
         expert_tokens_num_flag: bool = True,
         active_expert_range=None,
         quant_mode: int = -1,
+        act_quant_type: torch.dtype | None = None,
     ):
         return torch.ops._C_ascend.npu_moe_init_routing_custom(
             hidden_states,
@@ -908,7 +909,9 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         expert_tokens_num_flag: bool = True,
         active_expert_range=None,
         quant_mode: int = -1,
+        act_quant_type: torch.dtype | None = None,
     ):
+        input_dtype = act_quant_type or hidden_states.dtype
         return torch_npu.npu_moe_init_routing_v2(
             hidden_states,
             topk_ids,
@@ -919,7 +922,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             expert_tokens_num_flag=expert_tokens_num_flag,
             active_expert_range=active_expert_range,
             quant_mode=quant_mode,
-            x_dtype=296,
+            x_dtype=input_dtype if input_dtype in QUANT_DTYPES else None,
         )
 
     @staticmethod

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -919,6 +919,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             expert_tokens_num_flag=expert_tokens_num_flag,
             active_expert_range=active_expert_range,
             quant_mode=quant_mode,
+            x_dtype=296,
         )
 
     @staticmethod

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -130,6 +130,7 @@ class MoECommMethod(ABC):
             torch.bfloat16,
             torch.int8,
             torch.float8_e4m3fn,
+            torch.uint8,
         ], f"Unsupported hidden_states dtype: {fused_experts_input.hidden_states.dtype}"
 
         moe_comm_method = _EXTRA_CTX.moe_comm_method

--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -367,7 +367,10 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
         if quant_type == QuantType.W8A8:
             hidden_states, pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
         elif quant_type in (QuantType.MXFP8, QuantType.W4A8MXFP):
-            hidden_states, pertoken_scale = torch_npu.npu_dynamic_mx_quant(hidden_states, dst_type=torch.float8_e4m3fn)
+            hidden_states, pertoken_scale = torch_npu.npu_dynamic_mx_quant(
+                hidden_states,
+                dst_type=torch.float8_e4m3fn,
+            )
         elif quant_type == QuantType.MXFP4:
             hidden_states, pertoken_scale = torch_npu.npu_dynamic_mx_quant(
                 hidden_states,

--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -366,7 +366,7 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
         pertoken_scale = None
         if quant_type == QuantType.W8A8:
             hidden_states, pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
-        elif quant_type in [QuantType.MXFP8 ,QuantType.W4A8MXFP]:
+        elif quant_type in (QuantType.MXFP8, QuantType.W4A8MXFP):
             hidden_states, pertoken_scale = torch_npu.npu_dynamic_mx_quant(hidden_states, dst_type=torch.float8_e4m3fn)
         elif quant_type == QuantType.MXFP4:
             hidden_states, pertoken_scale = torch_npu.npu_dynamic_mx_quant(

--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -366,12 +366,14 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
         pertoken_scale = None
         if quant_type == QuantType.W8A8:
             hidden_states, pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
-        elif quant_type == QuantType.MXFP8:
+        elif quant_type in [QuantType.MXFP8 ,QuantType.W4A8MXFP]:
             hidden_states, pertoken_scale = torch_npu.npu_dynamic_mx_quant(hidden_states, dst_type=torch.float8_e4m3fn)
-        elif quant_type in [QuantType.MXFP4, QuantType.W4A8MXFP]:
-            # W4A4MXFP4 and  W4A8MXFP4 with AllGather+EP currently does not pre-quantize
-            # per-token activations in prepare. Keep quantization in the MoE MLP path.
-            pass
+        elif quant_type == QuantType.MXFP4:
+            hidden_states, pertoken_scale = torch_npu.npu_dynamic_mx_quant(
+                hidden_states,
+                dst_type=torch_npu.float4_e2m1fn_x2,
+                round_mode="round",
+            )
 
         if self.multistream_overlap_gate:
             assert PrepareAndFinalize.quant_stream is not None

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -374,9 +374,7 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
         dynamic_scale = token_dispatch_input.routing.pertoken_scale
         quant_type = token_dispatch_input.quant.quant_type
         act_quant_type = (
-            token_dispatch_input.quant.mxfp.act_quant_type
-            if token_dispatch_input.quant.mxfp is not None
-            else None
+            token_dispatch_input.quant.mxfp.act_quant_type if token_dispatch_input.quant.mxfp is not None else None
         )
         global_redundant_expert_num = token_dispatch_input.routing.global_redundant_expert_num
         restore_shape = hidden_states.shape

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -373,6 +373,11 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
         expert_map = token_dispatch_input.routing.expert_map
         dynamic_scale = token_dispatch_input.routing.pertoken_scale
         quant_type = token_dispatch_input.quant.quant_type
+        act_quant_type = (
+            token_dispatch_input.quant.mxfp.act_quant_type
+            if token_dispatch_input.quant.mxfp is not None
+            else None
+        )
         global_redundant_expert_num = token_dispatch_input.routing.global_redundant_expert_num
         restore_shape = hidden_states.shape
         # Fuse the first dynamic quant of moe_mlp into initrouting when
@@ -411,6 +416,7 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
             expert_tokens_num_flag=True,
             active_expert_range=[first_expert_idx, last_expert_idx],
             quant_mode=quant_mode,
+            act_quant_type=act_quant_type,
         )
         expert_tokens = expert_tokens.to(torch.int64)
         group_list_type = 1  # `count` mode

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -380,12 +380,13 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
         restore_shape = hidden_states.shape
         # Fuse the first dynamic quant of moe_mlp into initrouting when
         # dispatch_with_quant is on but got a None dynamic_scale.
-        missing_dynamic_scale = dynamic_scale is None
-        quant_mode = -1
-        if missing_dynamic_scale and quant_type == QuantType.MXFP8:
-            quant_mode = 3 if is_mxfp else 1
-        elif missing_dynamic_scale and quant_type == QuantType.MXFP4:
-            quant_mode = 9 if is_mxfp else 1
+        if with_quant and dynamic_scale is None:
+            if quant_type == QuantType.MXFP4:
+                quant_mode = 9
+            else:
+                quant_mode = 3 if is_mxfp else 1
+        else:
+            quant_mode = -1
 
         num_tokens = hidden_states.shape[:-1].numel()
         apply_router_weight_on_input = token_dispatch_input.routing.apply_router_weight_on_input

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -377,9 +377,9 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
         restore_shape = hidden_states.shape
         # Fuse the first dynamic quant of moe_mlp into initrouting when
         # dispatch_with_quant is on but got a None dynamic_scale.
-        if  token_dispatch_input.quant.quant_type == QuantType.MXFP8 and dynamic_scale is None:
+        if token_dispatch_input.quant.quant_type == QuantType.MXFP8 and dynamic_scale is None:
             quant_mode = 3 if is_mxfp else 1
-        if  token_dispatch_input.quant.quant_type == QuantType.MXFP4 and dynamic_scale is None:
+        elif token_dispatch_input.quant.quant_type == QuantType.MXFP4 and dynamic_scale is None:
             quant_mode = 9 if is_mxfp else 1
         else:
             quant_mode = -1

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -364,7 +364,6 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
         #  MXFP4 keeps dispatch unquantized in AllGather path, and quantizes again inside the MLP path.
         with_quant = (
             token_dispatch_input.quant.dispatch_with_quant
-            # and token_dispatch_input.quant.quant_type != QuantType.MXFP4
             and token_dispatch_input.quant.quant_type != QuantType.W8A8FP8
         )
         is_mxfp = token_dispatch_input.quant.is_mxfp
@@ -373,16 +372,17 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
         topk_ids = token_dispatch_input.topk_ids
         expert_map = token_dispatch_input.routing.expert_map
         dynamic_scale = token_dispatch_input.routing.pertoken_scale
+        quant_type = token_dispatch_input.quant.quant_type
         global_redundant_expert_num = token_dispatch_input.routing.global_redundant_expert_num
         restore_shape = hidden_states.shape
         # Fuse the first dynamic quant of moe_mlp into initrouting when
         # dispatch_with_quant is on but got a None dynamic_scale.
-        if token_dispatch_input.quant.quant_type == QuantType.MXFP8 and dynamic_scale is None:
+        missing_dynamic_scale = dynamic_scale is None
+        quant_mode = -1
+        if missing_dynamic_scale and quant_type == QuantType.MXFP8:
             quant_mode = 3 if is_mxfp else 1
-        elif token_dispatch_input.quant.quant_type == QuantType.MXFP4 and dynamic_scale is None:
+        elif missing_dynamic_scale and quant_type == QuantType.MXFP4:
             quant_mode = 9 if is_mxfp else 1
-        else:
-            quant_mode = -1
 
         num_tokens = hidden_states.shape[:-1].numel()
         apply_router_weight_on_input = token_dispatch_input.routing.apply_router_weight_on_input

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -364,7 +364,7 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
         #  MXFP4 keeps dispatch unquantized in AllGather path, and quantizes again inside the MLP path.
         with_quant = (
             token_dispatch_input.quant.dispatch_with_quant
-            and token_dispatch_input.quant.quant_type != QuantType.MXFP4
+            # and token_dispatch_input.quant.quant_type != QuantType.MXFP4
             and token_dispatch_input.quant.quant_type != QuantType.W8A8FP8
         )
         is_mxfp = token_dispatch_input.quant.is_mxfp
@@ -377,8 +377,10 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
         restore_shape = hidden_states.shape
         # Fuse the first dynamic quant of moe_mlp into initrouting when
         # dispatch_with_quant is on but got a None dynamic_scale.
-        if with_quant and dynamic_scale is None:
+        if  token_dispatch_input.quant.quant_type == QuantType.MXFP8 and dynamic_scale is None:
             quant_mode = 3 if is_mxfp else 1
+        if  token_dispatch_input.quant.quant_type == QuantType.MXFP4 and dynamic_scale is None:
+            quant_mode = 9 if is_mxfp else 1
         else:
             quant_mode = -1
 

--- a/vllm_ascend/quantization/methods/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4_mxfp4.py
@@ -218,7 +218,8 @@ class AscendW4A4MXFP4DynamicFusedMoEMethod(AscendMoEScheme):
             random_matrix = torch.rand(topk_ids.size(0), num_logical_experts, device=topk_ids.device)
             topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
 
-        topk_weights = topk_weights.to(x.dtype)
+        if x.dtype not in [torch.uint8]:
+            topk_weights = topk_weights.to(x.dtype)
 
         moe_comm_method = _EXTRA_CTX.moe_comm_method
         return moe_comm_method.fused_experts(
@@ -241,7 +242,7 @@ class AscendW4A4MXFP4DynamicFusedMoEMethod(AscendMoEScheme):
                 mxfp_weight_quant_type=torch_npu.float4_e2m1fn_x2,
                 mxfp_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
                 mxfp_per_token_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
-                mxfp_use_bf16=(x.dtype == torch.bfloat16),
+                mxfp_use_bf16=(x.dtype in [torch.bfloat16, torch.uint8]),
                 w1_scale=layer.w13_weight_scale,
                 w2_scale=layer.w2_weight_scale,
             )


### PR DESCRIPTION
What this PR does / why we need it?

This PR adds MXFP4 communication quantization support for the AllGather + EP MoE path on Ascend 950.

Previously, the AllGather EP path did not fully support MXFP4 activations in the MoE communication and dispatch flow. This PR updates the fused MoE path to correctly handle MXFP4 quantized activations during token dispatch and expert computation.

Main changes:

Add MXFP4 quantization handling for the AllGather + EP MoE path.
Pass activation quantization dtype into npu_moe_init_routing_v2 through act_quant_type, so the routing operator can correctly identify quantized activation dtype.
Add torch.uint8 as a supported hidden state dtype in fused MoE, which is required for MXFP4 packed activations.
Update token dispatch logic to use the correct quant_mode for MXFP4.
Keep MXFP4 dispatch unquantized in the AllGather path and perform quantization in the MoE MLP path.
Update W4A4 MXFP4 MoE apply logic to correctly handle torch.uint8 activations.
Add unit test coverage for quant mode selection in token dispatch.

This enables the AllGather EP path to work with MXFP4 communication quantization and improves compatibility for W4A4/MXFP4 MoE execution on Ascend 950.

Does this PR introduce any user-facing change?

No.

How was this patch tested?
Added unit test coverage for token dispatch quant mode selection.
Verified MXFP4 quant mode is correctly passed to npu_moe_init_routing_v2 in the AllGather EP path.
And already check the Deepseek v3.1 profiling to ensure it works.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
