### PR TITLE
[Feature] vLLM Ascend adaptation to support Elastic Expert Parallelism Milestone 2

### DIFF
--- a/tests/e2e/nightly/elastic_ep/test_elastic_ep.py
+++ b/tests/e2e/nightly/elastic_ep/test_elastic_ep.py
@@ -1,0 +1,407 @@
+"""
+End-to-end Elastic EP scaling tests for vllm-ascend.
+
+Launches a vLLM serve instance with Elastic EP enabled, performs scale-up and
+scale-down operations, and validates that inference quality is preserved using
+GSM8K accuracy evaluation (via aisbench).
+"""
+
+import os
+import socket
+import subprocess
+import time
+from dataclasses import dataclass, field
+
+import pytest
+import requests
+
+# ---------------------------------------------------------------------------
+# Server / model constants
+# ---------------------------------------------------------------------------
+
+QWEN3_30B_A3B_MODEL = "Qwen/Qwen3-30B-A3B"
+QWEN3_30B_A3B_W8A8_MODEL = "vllm-ascend/Qwen3-30B-A3B-W8A8"
+QWEN3_235B_A22B_MODEL = "Qwen/Qwen3-235B-A22B"
+DATASET_NAME = "/vllm-ascend/gsm8k-lite"
+"""HuggingFace / ModelScope identifier of the MoE model used for testing."""
+
+MAX_MODEL_LEN = 16384
+MAX_NUM_SEQS = 16
+
+# How long (seconds) to wait after a scale request before evaluating,
+# giving the Elastic EP state machine time to finish reconfiguration.
+_SCALE_DELAY_SECONDS = 30
+
+# GSM8K accuracy baseline and tolerance.
+# The model is expected to achieve accuracy within this range after scaling.
+GSM8K_BASELINE = 95.0
+GSM8K_THRESHOLD = 5.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def get_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(autouse=True)
+def cleanup_ray_between_tests():
+    """Force-stop any lingering Ray processes between tests."""
+    subprocess.run(["ray", "stop", "--force"], timeout=30, capture_output=True)
+    time.sleep(5)
+
+    env_dict = _make_env_dict()
+    for key, value in env_dict.items():
+        os.environ[key] = value
+
+    subprocess.run(["ray", "start", "--head"], timeout=30, capture_output=True)
+    time.sleep(5)
+    yield
+
+
+def _send_scale_command(server, new_dp_size: int) -> bool:
+    """POST a scale request to the server's Elastic EP endpoint.
+
+    Returns ``True`` on HTTP 200, ``False`` otherwise.
+    """
+    url = server.url_for("scale_elastic_ep")
+    payload = {"new_data_parallel_size": new_dp_size}
+    headers = {"Content-Type": "application/json"}
+
+    try:
+        response = requests.post(url, json=payload, headers=headers, timeout=300)
+        code = response.status_code
+        if code != 200:
+            print(f"[scale] HTTP {code}: {response.text}")
+        return code == 200
+    except requests.exceptions.RequestException as exc:
+        print(f"[scale] Request failed: {exc}")
+        return False
+
+
+def _run_gsm8k_eval(server, model_name: str, stage: str) -> float:
+    """Run GSM8K accuracy evaluation using aisbench.
+
+    Returns the measured accuracy percentage.
+    """
+    from tools.aisbench import AisbenchRunner
+
+    aisbench_case = {
+        "case_type": "accuracy",
+        "dataset_path": DATASET_NAME,
+        "request_conf": "vllm_api_general_chat",
+        "dataset_conf": "gsm8k/gsm8k_gen_0_shot_cot_chat_prompt",
+        "max_out_len": 4096,
+        "batch_size": 32,
+        "baseline": GSM8K_BASELINE,
+        "threshold": GSM8K_THRESHOLD,
+    }
+
+    with AisbenchRunner(
+        model=model_name,
+        port=server.port,
+        aisbench_config=aisbench_case,
+        verify=True,
+    ) as aisbench:
+        accuracy = aisbench.result
+        print(f"[{stage}] GSM8K accuracy: {accuracy:.2f}")
+        return accuracy
+
+
+def _make_env_dict() -> dict[str, str]:
+    """Return the common environment-variable overrides for the server."""
+    env = {
+        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+        "BENCHMARK_HOME": "./benchmark",
+        "HCCL_BUFFSIZE": "1024",
+        "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES": "1",
+    }
+    if os.environ.get("VLLM_USE_MODELSCOPE", "").lower() in ("", "0", "false"):
+        pass
+    else:
+        env["VLLM_USE_MODELSCOPE"] = "true"
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Configuration dataclasses and test runner
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ScaleSequence:
+    """Defines a sequence of scaling operations."""
+
+    name: str
+    steps: list[tuple[int, str]] = field(default_factory=list)
+
+
+@dataclass
+class ElasticEPTestConfig:
+    """Configuration for an Elastic EP test."""
+
+    name: str
+    data_parallel_size: int
+    data_parallel_size_local: int
+    tensor_parallel_size: int
+    compilation_config: str | None = None
+    additional_config: str | None = None
+    quant: bool = False
+    scale_sequence: ScaleSequence = field(
+        default_factory=lambda: ScaleSequence(
+            name="default",
+            steps=[
+                (7, "Scale down (dp=8 -> dp=7)"),
+                (4, "Scale down (dp=7 -> dp=4)"),
+                (7, "Scale up (dp=4 -> dp=7)"),
+                (8, "Scale up (dp=7 -> dp=8)"),
+            ],
+        )
+    )
+
+
+# Define common additional_config
+COMMON_ADDITIONAL_CONFIG = '{"eplb_config": {"dynamic_eplb": false, "num_redundant_experts": 128}}'
+
+# Define test configurations
+TEST_CONFIGS = [
+    ElasticEPTestConfig(
+        name="Qwen3-30B-3B, Default Graph",
+        data_parallel_size=8,
+        data_parallel_size_local=8,
+        tensor_parallel_size=1,
+        additional_config=COMMON_ADDITIONAL_CONFIG,
+    ),
+    ElasticEPTestConfig(
+        name="Qwen3-30B-3B, FULL Graph",
+        data_parallel_size=8,
+        data_parallel_size_local=8,
+        tensor_parallel_size=1,
+        compilation_config='{"cudagraph_mode": "FULL"}',
+        additional_config=COMMON_ADDITIONAL_CONFIG,
+    ),
+    ElasticEPTestConfig(
+        name="Qwen3-30B-3B, PIECEWISE Graph",
+        data_parallel_size=8,
+        data_parallel_size_local=8,
+        tensor_parallel_size=1,
+        compilation_config='{"cudagraph_mode": "PIECEWISE"}',
+        additional_config=COMMON_ADDITIONAL_CONFIG,
+    ),
+    ElasticEPTestConfig(
+        name="Qwen3-30B-3B, FULL DECODE ONLY Graph",
+        data_parallel_size=8,
+        data_parallel_size_local=8,
+        tensor_parallel_size=1,
+        compilation_config='{"cudagraph_mode": "FULL_DECODE_ONLY"}',
+        additional_config=COMMON_ADDITIONAL_CONFIG,
+    ),
+    ElasticEPTestConfig(
+        name="Qwen3-30B-3B, TP=4, Default, FC1, FC2",
+        data_parallel_size=4,
+        data_parallel_size_local=4,
+        tensor_parallel_size=4,
+        additional_config=(
+            '{"eplb_config": {"dynamic_eplb": false,'
+            ' "num_redundant_experts": 128},'
+            ' "enable_flashcomm1": true,'
+            ' "enable_flashcomm2_parallel_size": 2}'
+        ),
+        scale_sequence=ScaleSequence(
+            name="tp4_scaling",
+            steps=[
+                (3, "Scale down (dp=4 -> dp=3)"),
+                (2, "Scale down (dp=3 -> dp=2)"),
+                (3, "Scale up (dp=2 -> dp=3)"),
+                (4, "Scale up (dp=3 -> dp=4)"),
+            ],
+        ),
+    ),
+    ElasticEPTestConfig(
+        name="Qwen3-30B-3B-W8A8, Default Graph",
+        data_parallel_size=8,
+        data_parallel_size_local=8,
+        tensor_parallel_size=1,
+        additional_config=COMMON_ADDITIONAL_CONFIG,
+        quant=True,
+    ),
+    ElasticEPTestConfig(
+        name="Qwen3-30B-3B-W8A8, TP=4, Default, FC1, FC2",
+        data_parallel_size=4,
+        data_parallel_size_local=4,
+        tensor_parallel_size=4,
+        additional_config=(
+            '{"eplb_config": {"dynamic_eplb": false,'
+            ' "num_redundant_experts": 128},'
+            ' "enable_flashcomm1": true,'
+            ' "enable_flashcomm2_parallel_size": 2}'
+        ),
+        quant=True,
+        scale_sequence=ScaleSequence(
+            name="tp4_scaling",
+            steps=[
+                (3, "Scale down (dp=4 -> dp=3)"),
+                (2, "Scale down (dp=3 -> dp=2)"),
+                (3, "Scale up (dp=2 -> dp=3)"),
+                (4, "Scale up (dp=3 -> dp=4)"),
+            ],
+        ),
+    ),
+    ElasticEPTestConfig(
+        name="Qwen3-235B-A22B, TP=4, Default, FC1, FC2",
+        data_parallel_size=8,
+        data_parallel_size_local=8,
+        tensor_parallel_size=2,
+        additional_config=(
+            '{"eplb_config": {"dynamic_eplb": false, "num_redundant_experts": 32}, "enable_flashcomm1": true}'
+        ),
+        scale_sequence=ScaleSequence(
+            name="tp2_scaling",
+            steps=[
+                (7, "Scale down (dp=8 -> dp=7)"),
+                (8, "Scale up (dp=7 -> dp=8)"),
+            ],
+        ),
+    ),
+]
+
+
+def _build_vllm_args(config: ElasticEPTestConfig) -> list[str]:
+    """Build vLLM server arguments from configuration."""
+    args = [
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(get_free_port()),
+        "--trust-remote-code",
+        "--data-parallel-size",
+        str(config.data_parallel_size),
+        "--data-parallel-size-local",
+        str(config.data_parallel_size_local),
+        "--data-parallel-backend",
+        "ray",
+        "--enable-expert-parallel",
+        "--enable-elastic-ep",
+        "--enable-eplb",
+        "--tensor-parallel-size",
+        str(config.tensor_parallel_size),
+        "--gpu-memory-utilization",
+        "0.9",
+        "--max-model-len",
+        str(MAX_MODEL_LEN),
+        "--max-num-seqs",
+        str(MAX_NUM_SEQS),
+    ]
+
+    if config.quant:
+        args.extend(["--quantization", "ascend"])
+
+    if config.compilation_config:
+        args.extend(["--compilation-config", config.compilation_config])
+
+    if config.additional_config:
+        args.extend(["--additional_config", config.additional_config])
+
+    return args
+
+
+def _run_elastic_ep_test(config: ElasticEPTestConfig, model_name: str) -> None:
+    """Run a complete Elastic EP test with the given configuration."""
+    from tests.e2e.conftest import RemoteOpenAIServer
+
+    vllm_serve_args = _build_vllm_args(config)
+    env_dict = _make_env_dict()
+
+    # Extract port from args (last port specification)
+    port_index = vllm_serve_args.index("--port") + 1
+    server_port = int(vllm_serve_args[port_index])
+
+    with RemoteOpenAIServer(
+        model_name,
+        vllm_serve_args,
+        server_host="127.0.0.1",
+        server_port=server_port,
+        env_dict=env_dict,
+        auto_port=False,
+        max_wait_seconds=1800,
+    ) as server:
+        print(f"Server started on port {server.port}")
+
+        # Store all accuracies for summary
+        accuracies: dict[str, float] = {}
+
+        # Run initial baseline evaluation
+        initial_stage = f"Initial (dp={config.data_parallel_size})"
+        accuracies[initial_stage] = _run_gsm8k_eval(server, model_name, initial_stage)
+        print(f"  Initial accuracy: {accuracies[initial_stage]:.2f}")
+
+        # Run scaling steps
+        for new_dp_size, stage_description in config.scale_sequence.steps:
+            assert _send_scale_command(server, new_dp_size), f"{stage_description} failed"
+            time.sleep(_SCALE_DELAY_SECONDS)
+            accuracies[stage_description] = _run_gsm8k_eval(server, model_name, stage_description)
+            print(f"  {stage_description} accuracy: {accuracies[stage_description]:.2f}")
+
+        # Print summary
+        print(f"nElastic EP Accuracy Summary ({config.name}):")
+        for stage, acc in accuracies.items():
+            print(f"  {stage}: {acc:.2f}")
+        print(f"  Baseline: {GSM8K_BASELINE:.2f} +/- {GSM8K_THRESHOLD:.2f}")
+
+        # Assert all accuracies are within range
+        for stage, acc in accuracies.items():
+            lower_bound = GSM8K_BASELINE - GSM8K_THRESHOLD
+            upper_bound = GSM8K_BASELINE + GSM8K_THRESHOLD
+            assert lower_bound <= acc <= upper_bound, (
+                f"{stage} GSM8K accuracy {acc:.2f} is outside expected range [{lower_bound}, {upper_bound}]"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test functions - one for each configuration
+# ---------------------------------------------------------------------------
+
+
+def test_elastic_ep_scaling_qwen3_30b() -> None:
+    """Scale dp 8 -> 7 -> 4 -> 7 -> 8 (tp=1, 8 NPUs) with Default Graph"""
+    _run_elastic_ep_test(TEST_CONFIGS[0], QWEN3_30B_A3B_MODEL)
+
+
+def test_elastic_ep_scaling_qwen3_30b_with_full_graph() -> None:
+    """Scale dp 8 -> 7 -> 4 -> 7 -> 8 (tp=1, 8 NPUs) with FULL Graph"""
+    _run_elastic_ep_test(TEST_CONFIGS[1], QWEN3_30B_A3B_MODEL)
+
+
+def test_elastic_ep_scaling_qwen3_30b_with_piecewise_graph() -> None:
+    """Scale dp 8 -> 7 -> 4 -> 7 -> 8 (tp=1, 8 NPUs) with PIECEWISE Graph"""
+    _run_elastic_ep_test(TEST_CONFIGS[2], QWEN3_30B_A3B_MODEL)
+
+
+def test_elastic_ep_scaling_qwen3_30b_with_full_decode_only_graph() -> None:
+    """Scale dp 8 -> 7 -> 4 -> 7 -> 8 (tp=1, 8 NPUs) with FULL DECODE ONLY"""
+    _run_elastic_ep_test(TEST_CONFIGS[3], QWEN3_30B_A3B_MODEL)
+
+
+def test_elastic_ep_scaling_qwen3_30b_with_tp4() -> None:
+    """Scale dp 4 -> 3 -> 2 -> 3 -> 4 (tp=4, 16 NPUs) with FC1, FC2"""
+    _run_elastic_ep_test(TEST_CONFIGS[4], QWEN3_30B_A3B_MODEL)
+
+
+def test_elastic_ep_scaling_qwen3_30b_w8w8() -> None:
+    """Scale dp 8 -> 7 -> 4 -> 7 -> 8 (tp=1, 8 NPUs) W8A8 Default Graph"""
+    _run_elastic_ep_test(TEST_CONFIGS[5], QWEN3_30B_A3B_W8A8_MODEL)
+
+
+def test_elastic_ep_scaling_qwen3_30b_w8w8_with_tp4() -> None:
+    """Scale dp 4 -> 3 -> 2 -> 3 -> 4 (tp=4, 16 NPUs) W8A8 with FC1, FC2"""
+    _run_elastic_ep_test(TEST_CONFIGS[6], QWEN3_30B_A3B_W8A8_MODEL)
+
+
+def test_elastic_ep_scaling_qwen3_235b_with_tp2() -> None:
+    """Scale dp 8 -> 7 -> 8 (tp=2, 16 NPUs) 235B with Default, FC1"""
+    _run_elastic_ep_test(TEST_CONFIGS[7], QWEN3_235B_A22B_MODEL)

--- a/tests/ut/compilation/a2/test_acl_graph.py
+++ b/tests/ut/compilation/a2/test_acl_graph.py
@@ -108,6 +108,9 @@ class TestACLGraphWrapper(TestBase):
         self.mock_forward_context.batch_descriptor = self.mock_batch_descriptor
         self.mock_forward_context.cudagraph_runtime_mode = CUDAGraphMode.FULL
 
+        # Reset class variable to ensure test isolation
+        ACLGraphWrapper._graph_pool = None
+
     @patch("vllm_ascend.compilation.acl_graph.current_platform")
     @patch("vllm_ascend.compilation.acl_graph.envs")
     def test_initialization_with_default_options(self, mock_envs, mock_current_platform):

--- a/tests/ut/distributed/test_communicator.py
+++ b/tests/ut/distributed/test_communicator.py
@@ -21,6 +21,7 @@ class TestNPUCommunicator(unittest.TestCase):
     @patch("torch.distributed.get_world_size", return_value=2)
     @patch("torch.distributed.get_process_group_ranks", return_value=[0, 1])
     @patch("torch.npu.device")
+    @patch("vllm_ascend.distributed.device_communicators.pyhccl.PyHcclCommunicator")
     def test_all_to_all_with_sizes(self, *_):
         def patched_all_to_all(output_tensor_list, input_tensor_list, group=None, async_op=False):
             output_tensor_list[:] = [torch.tensor([10, 20]), torch.tensor([50, 60])]
@@ -51,6 +52,7 @@ class TestNPUCommunicator(unittest.TestCase):
     @patch("torch.distributed.get_world_size", return_value=2)
     @patch("torch.distributed.get_process_group_ranks", return_value=[0, 1])
     @patch("torch.npu.device")
+    @patch("vllm_ascend.distributed.device_communicators.pyhccl.PyHcclCommunicator")
     def test_all_to_all_without_sizes(self, *_):
         def patched_all_to_all(output_tensor_list, input_tensor_list, group=None, async_op=False):
             output_tensor_list[:] = [torch.tensor([[10, 20]]), torch.tensor([[50, 60]])]
@@ -64,3 +66,48 @@ class TestNPUCommunicator(unittest.TestCase):
             output = comm.all_to_all(input_, scatter_dim=0, gather_dim=0)
 
         assert output.tolist() == [[10, 20], [50, 60]]
+
+    @patch("vllm.config.get_current_vllm_config", return_value=None)
+    @patch("torch.npu.current_device", return_value=0)
+    @patch("torch.distributed.get_group_rank", return_value=0)
+    @patch("torch.distributed.get_world_size", return_value=2)
+    @patch("torch.distributed.get_rank", return_value=0)
+    @patch("torch.distributed.get_process_group_ranks", return_value=[0, 1])
+    def test_destroy(self, *_):
+        mock_pyhccl_comm = MagicMock()
+        with (
+            patch.dict(dist.distributed_c10d._world.pg_map, {dist.group.WORLD: MagicMock()}, clear=False),
+            patch(
+                "vllm_ascend.distributed.device_communicators.pyhccl.PyHcclCommunicator", return_value=mock_pyhccl_comm
+            ),
+        ):
+            comm = NPUCommunicator(cpu_group=dist.group.WORLD)
+
+        self.assertIsNotNone(comm.pyhccl_comm)
+        comm.destroy()
+
+        mock_pyhccl_comm.destroy.assert_called_once()
+        self.assertIsNone(comm.pyhccl_comm)
+
+    @patch("vllm.config.get_current_vllm_config", return_value=None)
+    @patch("torch.npu.current_device", return_value=0)
+    @patch("torch.distributed.get_group_rank", return_value=0)
+    @patch("torch.distributed.get_world_size", return_value=2)
+    @patch("torch.distributed.get_rank", return_value=0)
+    @patch("torch.distributed.get_process_group_ranks", return_value=[0, 1])
+    def test_batch_isend_irecv(self, *_):
+        mock_pyhccl_comm = MagicMock()
+        mock_pyhccl_comm.available = True
+        mock_pyhccl_comm.disabled = False
+        with (
+            patch.dict(dist.distributed_c10d._world.pg_map, {dist.group.WORLD: MagicMock()}, clear=False),
+            patch(
+                "vllm_ascend.distributed.device_communicators.pyhccl.PyHcclCommunicator", return_value=mock_pyhccl_comm
+            ),
+        ):
+            comm = NPUCommunicator(cpu_group=dist.group.WORLD)
+
+        p2p_ops = MagicMock()
+        comm.batch_isend_irecv(p2p_ops)
+
+        comm.pyhccl_comm.batch_isend_irecv.assert_called_once()

--- a/tests/ut/eplb/adaptor/test_vllm_adaptor.py
+++ b/tests/ut/eplb/adaptor/test_vllm_adaptor.py
@@ -38,8 +38,12 @@ class TestVllmAdaptor(unittest.TestCase):
         num_dense_layers = getattr(config, "first_k_dense_replace", 0)
         self.model.model.layers[num_dense_layers].mlp.experts.quant_type = QuantType.W8A8
 
-        self.mock_rank = patch("vllm_ascend.eplb.adaptor.vllm_adaptor.dist.get_rank", return_value=0).start()
-        self.mock_size = patch("vllm_ascend.eplb.adaptor.vllm_adaptor.dist.get_world_size", return_value=4).start()
+        patcher = patch("vllm_ascend.eplb.adaptor.vllm_adaptor.get_dynamic_eplb_group", return_value=MagicMock())
+        self.mock_get_group = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.mock_group = self.mock_get_group.return_value
+        self.mock_group.rank_in_group = 0
+        self.mock_group.world_size = 4
 
     @patch("torch.empty_like", return_value=torch.zeros(16, 32))
     @patch("vllm_ascend.eplb.adaptor.vllm_adaptor.get_ascend_config")

--- a/tests/ut/eplb/core/policy/test_policy_factory.py
+++ b/tests/ut/eplb/core/policy/test_policy_factory.py
@@ -31,6 +31,20 @@ class TestEplbRebalancePolicies(unittest.TestCase):
 
         self.assertLessEqual(update_mean, 1.1)
 
+    def test_default_policy_rebalance_experts_with_new_ep_size(self):
+        num_layers = 58
+        default_policy = PolicyFactory.generate_policy(1)
+
+        # Scale Down
+        default_policy.set_new_ep_size(new_ep_size=30)
+        _, _, new_placement = default_policy.rebalance_experts(self.current_expert_table, self.expert_workload.sum(0))
+        self.assertTrue(all([len(new_placement[layer_idx]) == 30 for layer_idx in range(num_layers)]))
+
+        # Scale Up
+        default_policy.set_new_ep_size(new_ep_size=40)
+        _, _, new_placement = default_policy.rebalance_experts(self.current_expert_table, self.expert_workload.sum(0))
+        self.assertTrue(all([len(new_placement[layer_idx]) == 40 for layer_idx in range(num_layers)]))
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/ut/eplb/test_eplb_updator.py
+++ b/tests/ut/eplb/test_eplb_updator.py
@@ -13,16 +13,10 @@ class TestEplbUpdatorComputeAndSetMoeLoad(unittest.TestCase):
         self.world_size = 4
         self.device = torch.device("cpu")
 
-        # mock dist
-        p1 = patch("torch.distributed.get_rank", return_value=self.rank)
-        p2 = patch("torch.distributed.get_world_size", return_value=self.world_size)
-        self.addCleanup(p1.stop)
-        self.addCleanup(p2.stop)
-        p1.start()
-        p2.start()
-
         # ====================== 2. Mock comm group ======================
         self.mock_comm_group = MagicMock()
+        self.mock_comm_group.rank_in_group = self.rank
+        self.mock_comm_group.world_size = self.world_size
 
         def mock_all_gather(tensor, dim):
             gathered = torch.cat([tensor for _ in range(self.world_size)], dim=dim)
@@ -30,9 +24,9 @@ class TestEplbUpdatorComputeAndSetMoeLoad(unittest.TestCase):
 
         self.mock_comm_group.all_gather = mock_all_gather
 
-        p3 = patch("vllm_ascend.eplb.eplb_updator.get_dynamic_eplb_group", return_value=self.mock_comm_group)
-        self.addCleanup(p3.stop)
-        p3.start()
+        patcher = patch("vllm_ascend.eplb.eplb_updator.get_dynamic_eplb_group", return_value=self.mock_comm_group)
+        self.addCleanup(patcher.stop)
+        patcher.start()
 
         # mock _PP in vllm.distributed.parallel_state (PP+EPLB support)
         # Patching the variable directly so that even the real get_pp_group()

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -306,6 +306,14 @@ class AscendConfig:
         rejection_sampler_config = additional_config.get("rejection_sampler_config", {})
         self.rejection_sampler_config = RejectionSamplerConfig(rejection_sampler_config)
 
+        if vllm_config.parallel_config.enable_elastic_ep:
+            from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
+            if get_ascend_device_type() != AscendDeviceType.A3:
+                raise ValueError("Elastic EP is only supported on A3.")
+            if self.eplb_config.dynamic_eplb and self.eplb_config.eplb_policy_type == 3:
+                raise ValueError("Elastic EP is not supported when eplb_policy=3.")
+
     @staticmethod
     def _get_config_value(additional_config: dict[str, Any], config_key: str, env_key: str, env_value: Any) -> Any:
         if config_key in additional_config:

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -48,7 +48,7 @@ def _is_stream_resource_capture_error(exc: RuntimeError) -> bool:
 
 
 def _raise_stream_resource_capture_error(exc: RuntimeError) -> None:
-    raise RuntimeError(f"{_STREAM_RESOURCE_GUIDANCE}\nOriginal error:\n{exc}") from exc
+    raise RuntimeError(f"{_STREAM_RESOURCE_GUIDANCE}nOriginal error:n{exc}") from exc
 
 
 @dataclasses.dataclass
@@ -88,11 +88,19 @@ class ACLGraphWrapper:
     """
 
     _all_instances: ClassVar[weakref.WeakSet["ACLGraphWrapper"]] = weakref.WeakSet()
+    _graph_pool: ClassVar[tuple[int, int]] = None
 
     @classmethod
     def clear_all_graphs(cls) -> None:
+        cls._graph_pool = current_platform.graph_pool_handle()
         for instance in list(cls._all_instances):
             instance.clear_graphs()
+
+    @classmethod
+    def get_graph_pool(cls):
+        if cls._graph_pool is None:
+            cls._graph_pool = current_platform.graph_pool_handle()
+        return cls._graph_pool
 
     def __init__(
         self,
@@ -116,7 +124,7 @@ class ACLGraphWrapper:
         # assert runtime_mode is not NONE(no aclgraph), otherwise, we don't
         # need to initialize a ACLGraphWrapper.
         assert self.runtime_mode != CUDAGraphMode.NONE
-        self.graph_pool = current_platform.get_global_graph_pool()
+        self.graph_pool = ACLGraphWrapper.get_graph_pool()
 
         if cudagraph_options is None:
             cudagraph_options = CUDAGraphOptions()
@@ -150,6 +158,7 @@ class ACLGraphWrapper:
 
     def clear_graphs(self) -> None:
         self.concrete_aclgraph_entries.clear()
+        self.graph_pool = ACLGraphWrapper.get_graph_pool()
 
     def __call__(self, *args, **kwargs):
         forward_context = get_forward_context()

--- a/vllm_ascend/distributed/device_communicators/npu_communicator.py
+++ b/vllm_ascend/distributed/device_communicators/npu_communicator.py
@@ -18,6 +18,7 @@
 import torch
 import torch.distributed as dist
 from vllm.distributed.device_communicators.base_device_communicator import DeviceCommunicatorBase
+from vllm.distributed.utils import StatelessProcessGroup
 
 
 class NPUCommunicator(DeviceCommunicatorBase):
@@ -27,11 +28,27 @@ class NPUCommunicator(DeviceCommunicatorBase):
         device: torch.device | None = None,
         device_group: dist.ProcessGroup | None = None,
         unique_name: str = "",
+        global_ranks: list[int] | None = None,
+        global_world_size: int | None = None,
+        tcp_store_group: StatelessProcessGroup | None = None,
     ):
-        super().__init__(cpu_group, device, device_group, unique_name)
+        super().__init__(
+            cpu_group,
+            device,
+            device_group,
+            unique_name,
+            global_ranks,
+            global_world_size,
+        )
         # TODO(hz): Refer to CudaCommunicator's implementation to integrate PyHcclCommunicator
         # init device according to rank
         self.device = torch.npu.current_device()
+
+        from vllm_ascend.distributed.device_communicators.pyhccl import PyHcclCommunicator
+
+        self.pyhccl_comm: PyHcclCommunicator | None = None
+        if self.world_size > 1 and tcp_store_group is not None:
+            self.pyhccl_comm = PyHcclCommunicator(group=tcp_store_group, device=self.device)
 
         # For compatibility (mainly for reusing graph capturing code in vllm),
         # init custom all-reduce implementation interface as in CUDACommunicator.
@@ -66,3 +83,39 @@ class NPUCommunicator(DeviceCommunicatorBase):
         dist.all_to_all(output_list, input_list, group=self.device_group)
         output_tensor = torch.cat(output_list, dim=gather_dim).contiguous()
         return output_tensor
+
+    def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:
+        if self.pyhccl_comm is not None:
+            if dim < 0:
+                # Convert negative dim to positive.
+                dim += input_.dim()
+            input_size = input_.size()
+            # NOTE: we have to use concat-style all-gather here,
+            # stack-style all-gather has compatibility issues with
+            # torch.compile . see https://github.com/pytorch/pytorch/issues/138795
+            output_size = (input_size[0] * self.world_size,) + input_size[1:]
+            # Allocate output tensor.
+            output_tensor = torch.empty(output_size, dtype=input_.dtype, device=input_.device)
+            # All-gather.
+            output_tensor = self.pyhccl_comm.all_gather(input_, output_tensor)
+            # Reshape
+            output_tensor = output_tensor.reshape((self.world_size,) + input_size)
+            output_tensor = output_tensor.movedim(0, dim)
+            output_tensor = output_tensor.reshape(
+                input_size[:dim] + (self.world_size * input_size[dim],) + input_size[dim + 1 :]
+            )
+            return output_tensor
+        else:
+            return super().all_gather(input_, dim)
+
+    def destroy(self):
+        if self.pyhccl_comm is not None:
+            self.pyhccl_comm.destroy()
+            self.pyhccl_comm = None
+
+    def batch_isend_irecv(self, p2p_ops: list):
+        pyhccl_comm = self.pyhccl_comm
+        if pyhccl_comm is not None and not pyhccl_comm.disabled:
+            pyhccl_comm.batch_isend_irecv(p2p_ops)
+        else:
+            raise ValueError("No PyHccl communicator found")

--- a/vllm_ascend/distributed/device_communicators/pyhccl.py
+++ b/vllm_ascend/distributed/device_communicators/pyhccl.py
@@ -120,12 +120,12 @@ class PyHcclCommunicator:
         with torch.npu.device(device):
             self.comm: hcclComm_t = self.hccl.hcclCommInitRank(self.world_size, self.unique_id, self.rank)
 
-            stream = current_stream()
-            # A small all_reduce for warmup.
-            data = torch.zeros(1, device=device)
-            self.all_reduce(data)
-            stream.synchronize()
-            del data
+    def destroy(self):
+        if self.available and not self.disabled:
+            with torch.accelerator.device_index(self.device.index):
+                self.hccl.hcclCommDestroy(self.comm)
+            self.available = False
+            self.disabled = True
 
     def all_reduce(self, in_tensor: torch.Tensor, op: ReduceOp = ReduceOp.SUM, stream=None) -> torch.Tensor:
         if self.disabled:
@@ -152,6 +152,62 @@ class PyHcclCommunicator:
         )
         return out_tensor
 
+    def all_gather(self, in_tensor: torch.Tensor, out_tensor: torch.Tensor, stream=None) -> torch.Tensor:
+        if self.disabled:
+            return None
+        # hccl communicator created on a specific device
+        # will only work on tensors on the same device
+        # otherwise it will cause "illegal memory access"
+        assert in_tensor.device == self.device, (
+            f"this hccl communicator is created to work on {self.device}, but the input tensor is on {in_tensor.device}"
+        )
+
+        if stream is None:
+            stream = current_stream()
+        self.hccl.hcclAllGather(
+            buffer_type(in_tensor.data_ptr()),
+            buffer_type(out_tensor.data_ptr()),
+            in_tensor.numel(),
+            hcclDataTypeEnum.from_torch(in_tensor.dtype),
+            self.comm,
+            aclrtStream_t(stream.npu_stream),
+        )
+        return out_tensor
+
+    def send(self, tensor: torch.Tensor, dst: int, stream=None):
+        if self.disabled:
+            return None
+        assert tensor.device == self.device, (
+            f"this hccl communicator is created to work on {self.device}, but the tensor is on {tensor.device}"
+        )
+        if stream is None:
+            stream = current_stream()
+        self.hccl.hcclSend(
+            buffer_type(tensor.data_ptr()),
+            tensor.numel(),
+            hcclDataTypeEnum.from_torch(tensor.dtype),
+            dst,
+            self.comm,
+            aclrtStream_t(stream.npu_stream),
+        )
+
+    def recv(self, tensor: torch.Tensor, src: int, stream=None):
+        if self.disabled:
+            return None
+        assert tensor.device == self.device, (
+            f"this hccl communicator is created to work on {self.device}, but the tensor is on {tensor.device}"
+        )
+        if stream is None:
+            stream = current_stream()
+        self.hccl.hcclRecv(
+            buffer_type(tensor.data_ptr()),
+            tensor.numel(),
+            hcclDataTypeEnum.from_torch(tensor.dtype),
+            src,
+            self.comm,
+            aclrtStream_t(stream.npu_stream),
+        )
+
     def broadcast(self, tensor: torch.Tensor, src: int, stream=None):
         if self.disabled:
             return
@@ -169,3 +225,14 @@ class PyHcclCommunicator:
             self.comm,
             aclrtStream_t(stream.npu_stream),
         )
+
+    def batch_isend_irecv(self, p2p_ops: list, stream=None):
+        if self.disabled:
+            return
+        if stream is None:
+            stream = current_stream()
+        for op in p2p_ops:
+            if op.op is torch.distributed.isend:
+                self.send(op.tensor, op.group_peer, stream)
+            elif op.op is torch.distributed.irecv:
+                self.recv(op.tensor, op.group_peer, stream)

--- a/vllm_ascend/distributed/device_communicators/pyhccl_wrapper.py
+++ b/vllm_ascend/distributed/device_communicators/pyhccl_wrapper.py
@@ -146,6 +146,54 @@ class HCCLLibrary:
                 aclrtStream_t,
             ],
         ),
+        # HcclResult HcclAllGather(
+        #   void *sendBuf, void *recvBuf, uint64_t sendCount,
+        #   HcclDataType dataType, HcclComm comm,
+        #   aclrtStream stream);
+        Function(
+            "HcclAllGather",
+            hcclResult_t,
+            [
+                buffer_type,
+                buffer_type,
+                ctypes.c_size_t,
+                hcclDataType_t,
+                hcclComm_t,
+                aclrtStream_t,
+            ],
+        ),
+        # HcclResult HcclSend(
+        #   void *buf, uint64_t count,
+        #   HcclDataType dataType, uint32_t root,
+        #   HcclComm comm, aclrtStream steam);
+        Function(
+            "HcclSend",
+            hcclResult_t,
+            [
+                buffer_type,
+                ctypes.c_size_t,
+                hcclDataType_t,
+                ctypes.c_int,
+                hcclComm_t,
+                aclrtStream_t,
+            ],
+        ),
+        # HcclResult HcclRecv(
+        #   void *buf, uint64_t count,
+        #   HcclDataType dataType, uint32_t root,
+        #   HcclComm comm, aclrtStream steam);
+        Function(
+            "HcclRecv",
+            hcclResult_t,
+            [
+                buffer_type,
+                ctypes.c_size_t,
+                hcclDataType_t,
+                ctypes.c_int,
+                hcclComm_t,
+                aclrtStream_t,
+            ],
+        ),
         # HcclResult HcclBroadcast(
         #   void *buf, uint64_t count,
         #   HcclDataType dataType, uint32_t root,
@@ -243,6 +291,39 @@ class HCCLLibrary:
         # when we pass int to a function, it will be converted to `ctypes.c_int`
         # by ctypes automatically
         self.HCCL_CHECK(self._funcs["HcclAllReduce"](sendbuff, recvbuff, count, datatype, op, comm, stream))
+
+    def hcclAllGather(
+        self,
+        sendbuff: buffer_type,
+        recvbuff: buffer_type,
+        sendcount: int,
+        datatype: int,
+        comm: hcclComm_t,
+        stream: aclrtStream_t,
+    ) -> None:
+        self.HCCL_CHECK(self._funcs["HcclAllGather"](sendbuff, recvbuff, sendcount, datatype, comm, stream))
+
+    def hcclSend(
+        self,
+        sendbuff: buffer_type,
+        count: int,
+        datatype: int,
+        dest: int,
+        comm: hcclComm_t,
+        stream: aclrtStream_t,
+    ) -> None:
+        self.HCCL_CHECK(self._funcs["HcclSend"](sendbuff, count, datatype, dest, comm, stream))
+
+    def hcclRecv(
+        self,
+        sendbuff: buffer_type,
+        count: int,
+        datatype: int,
+        dest: int,
+        comm: hcclComm_t,
+        stream: aclrtStream_t,
+    ) -> None:
+        self.HCCL_CHECK(self._funcs["HcclRecv"](sendbuff, count, datatype, dest, comm, stream))
 
     def hcclBroadcast(
         self, buf: buffer_type, count: int, datatype: int, root: int, comm: hcclComm_t, stream: aclrtStream_t

--- a/vllm_ascend/distributed/elastic_ep/elastic_execute.py
+++ b/vllm_ascend/distributed/elastic_ep/elastic_execute.py
@@ -1,0 +1,465 @@
+# NOTE:
+# This file is adapted from vLLM's elastic_execute.py
+#
+# Key differences:
+# 1. Device-specific adaptations: Replaces CUDA-specific operations with NPU (Ascend) equivalents
+#    - Uses `torch_npu` instead of CUDA APIs
+#    - Replaces `torch.accelerator.synchronize()` with `torch.npu.synchronize()`
+#    - Replaces `torch.accelerator.empty_cache()` with `torch.npu.empty_cache()`
+#    - Uses `ACLGraphWrapper` instead of `CUDAGraphWrapper` for graph management
+#
+# 2. Custom weight transfer implementation: Implements `ascend_batch_transfer_weights()`
+#    - Adds support for quantized weight names (aclnn_input_scale, aclnn_input_scale_reciprocal, aclnn_input_offset)
+#    - Uses threading lock (`_PATCH_LOCK`) for thread-safe weight transfer patching
+#
+# 3. Enhanced broadcast_expert_mapping: Simplified signature and implementation
+#    - Removed `physical_to_logical`, `num_local_physical_experts`, `num_logical_experts` parameters
+#    - Uses `expert_maps` tensor directly for broadcasting
+#
+# 4. Extended AscendElasticEPScalingExecutor class:
+#    - Adds `_use_ascend_transfer_impl()` context manager for patching weight transfer
+#    - Implements `_release_acl_graphs()` to clear ACL graphs instead of CUDA graphs
+#    - Adds `_replace_ascend_active_groups()` calls for Ascend-specific group management
+#    - Integrates with `create_ascend_standby_groups()` and `pop_ascend_standby_groups()`
+#    - Adds support for Ascend-specific MoE modules (AscendFusedMoE, AscendSharedFusedMoE)
+#    - Handles Ascend-specific quantization method (AscendW8A8DynamicFusedMoEMethod)
+#    - Integrates with `get_mc2_group()` and `get_dynamic_eplb_group()` for Ascend communication
+#    - Adds `setup_moe_comm_method()` calls for MoE communication setup
+#
+# 5. EPLB (Expert Parallel Load Balancing) adaptations:
+#    - Uses `eplb_loader`, `eplb_adaptor`, `eplb_updator` from model_runner
+#    - Implements `_perform_eplb_reshuffle()` with expert resharding logic
+#    - Handles dynamic EPLB configuration via `get_ascend_config().eplb_config`
+#
+# ============================================================
+
+import copy
+import gc
+import os
+import threading
+from collections.abc import Iterable, Sequence
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import torch
+import torch.nn as nn
+from torch.distributed import P2POp
+from vllm.compilation.counter import compilation_counter
+from vllm.compilation.wrapper import reset_compile_wrapper
+from vllm.config import (
+    CompilationMode,
+    set_current_vllm_config,
+)
+from vllm.distributed import (
+    get_dp_group,
+    get_ep_group,
+    get_pcp_group,
+    get_tp_group,
+)
+from vllm.distributed.elastic_ep.elastic_execute import ElasticEPScalingExecutor
+from vllm.distributed.elastic_ep.standby_state import (
+    create_standby_groups,
+    get_standby_dp_group,
+    get_standby_ep_group,
+    pop_standby_groups,
+)
+from vllm.distributed.parallel_state import _replace_active_groups
+from vllm.distributed.stateless_coordinator import StatelessGroupCoordinator
+from vllm.model_executor.layers.fused_moe.layer import FusedMoE, FusedMoEParallelConfig
+from vllm.v1.attention.backend import AttentionImplBase
+from vllm.v1.engine import ReconfigureDistributedRequest, ReconfigureRankType
+from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
+from vllm.v1.worker.workspace import lock_workspace, unlock_workspace
+
+from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.compilation.acl_graph import (
+    ACLGraphWrapper,
+    reset_graph_params,
+    set_draft_graph_params,
+    set_graph_params,
+)
+from vllm_ascend.distributed.elastic_ep.standby_state import (
+    create_ascend_standby_groups,
+    pop_ascend_standby_groups,
+)
+from vllm_ascend.distributed.parallel_state import (
+    _replace_ascend_active_groups,
+    get_mc2_group,
+)
+from vllm_ascend.distributed.utils import use_stateless_pg_with_world_registration
+from vllm_ascend.ops.fused_moe.moe_comm_method import setup_moe_comm_method
+from vllm_ascend.quantization.methods import AscendW4A8DynamicFusedMoEMethod
+from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicFusedMoEMethod
+
+from .eplb_manager import ElasticEplbManager, generate_expert_maps_file
+
+_PATCH_LOCK = threading.Lock()
+
+
+def ascend_batch_transfer_weights(
+    model: nn.Module,
+    is_sender: bool,
+    peer_rank: int,
+    dp_group: StatelessGroupCoordinator,
+    expert_weights: Sequence[Iterable[torch.Tensor]],
+) -> None:
+    device_comm = dp_group.device_communicator
+    tcp_store_group = dp_group.tcp_store_group
+    if device_comm is None:
+        raise ValueError("No device communicator found")
+
+    expert_weights_set = set()
+    for weight_group in expert_weights:
+        for weight in weight_group:
+            expert_weights_set.add(weight.data_ptr())
+
+    state_dict = model.state_dict()
+    all_params = []
+    all_params_ptrs = set()
+    all_params_name = []
+
+    for name, param in state_dict.items():
+        if name.endswith("expert_map"):
+            continue
+        ptr = param.data_ptr()
+        if ptr not in expert_weights_set and ptr not in all_params_ptrs:
+            if param.device.type == "npu":
+                all_params.append(param.data)
+                all_params_ptrs.add(ptr)
+                all_params_name.append(name)
+
+    def handle_sub_module(submodule, submodule_name):
+        for attr_name, attr_value in submodule.__dict__.items():
+            if attr_name.endswith("expert_map"):
+                continue
+            if isinstance(attr_value, torch.Tensor):
+                data_ptr = attr_value.data_ptr()
+                if data_ptr not in expert_weights_set and data_ptr not in all_params_ptrs:
+                    if attr_value.device.type == "npu":
+                        all_params.append(attr_value)
+                        all_params_ptrs.add(data_ptr)
+                        all_params_name.append(submodule_name + "." + attr_name)
+            if isinstance(attr_value, AttentionImplBase):
+                handle_sub_module(attr_value, submodule_name + "." + attr_name)
+
+    for module_name, module in model.named_modules():
+        handle_sub_module(module, module_name)
+
+    expert_map_params = []
+    if not get_ascend_config().eplb_config.dynamic_eplb:
+        for module_name, module in model.named_modules():
+            if (expert_map := getattr(module, "expert_map", None)) is not None:
+                if isinstance(expert_map, torch.Tensor):
+                    expert_map_params.append((expert_map.npu(), expert_map))
+                    all_params_name.append(module_name + "." + "expert_map")
+        all_params.extend([npu_tensor for npu_tensor, _ in expert_map_params])
+
+    if is_sender:
+        tcp_store_group.send_obj(all_params_name, dst=peer_rank)
+        peer_rank_all_params_name = tcp_store_group.recv_obj(src=peer_rank)
+    else:
+        peer_rank_all_params_name = tcp_store_group.recv_obj(src=peer_rank)
+        tcp_store_group.send_obj(all_params_name, dst=peer_rank)
+
+    if len(all_params_name) != len(peer_rank_all_params_name):
+        common = list(set(all_params_name) & set(peer_rank_all_params_name))
+        ids = [all_params_name.index(name) for name in common]
+        all_params = [param for idx, param in enumerate(all_params) if idx in ids]
+
+    assert len(all_params) > 0
+    p2p_ops = []
+    for param in all_params:
+        op = object.__new__(P2POp)
+        if is_sender:
+            op.op = torch.distributed.isend
+            op.tensor = param
+        else:
+            op.op = torch.distributed.irecv
+            op.tensor = param
+        op.group_peer = peer_rank
+        p2p_ops.append(op)
+
+    device_comm.batch_isend_irecv(p2p_ops)
+
+    if len(expert_map_params) > 0:
+        for npu_tensor, cpu_tensor in expert_map_params:
+            cpu_tensor.copy_(npu_tensor)
+
+
+def broadcast_expert_mapping(
+    expert_maps: torch.Tensor | None,
+    group: StatelessGroupCoordinator,
+    src_rank: int = 0,
+):
+    if group.rank_in_group == src_rank:
+        assert expert_maps is not None
+        shape_tensor = torch.tensor(list(expert_maps.shape), dtype=torch.int64, device="cpu")
+    else:
+        shape_tensor = torch.empty(3, dtype=torch.int64, device="cpu")
+
+    shape_tensor = group.tcp_store_group.broadcast(shape_tensor, src_rank)
+
+    if group.rank_in_group != src_rank:
+        expert_maps = torch.empty(
+            tuple(shape_tensor.tolist()),
+            dtype=torch.int64,
+            device="cpu",
+        )
+
+    assert expert_maps is not None
+    expert_maps = group.tcp_store_group.broadcast(expert_maps, src_rank)
+
+    return expert_maps
+
+
+def setup_moe_comm_and_quant_method(module: nn.Module) -> None:
+    if isinstance(
+        quant_method := getattr(module.quant_method, "quant_method", None),
+        (AscendW8A8DynamicFusedMoEMethod, AscendW4A8DynamicFusedMoEMethod),
+    ):
+        quant_method.ep_group = get_ep_group()
+        try:
+            device_group = get_mc2_group().device_group
+            # TODO: Try local_rank = ep_group.rank_in_group
+            local_rank = get_mc2_group().rank_in_group
+            backend = device_group._get_backend(torch.device("npu"))
+            quant_method.moe_all_to_all_group_name = backend.get_hccl_comm_name(local_rank)
+        except AttributeError:
+            quant_method.moe_all_to_all_group_name = ""
+    setup_moe_comm_method(module.moe_config)
+
+
+class AscendElasticEPScalingExecutor(ElasticEPScalingExecutor):
+    def __init__(self, worker):
+        super().__init__(worker)
+        self.dynamic_eplb = get_ascend_config().eplb_config.dynamic_eplb
+        if not self.dynamic_eplb and os.environ.get("VLLM_ELASTIC_EP_SCALE_UP_LAUNCH", "0") != "1":
+            get_ascend_config().eplb_config.expert_map_path = generate_expert_maps_file()
+        self.eplb_manager = None
+        self.old_ep_size = None
+
+    def init_eplb_manager(self):
+        self.eplb_manager = ElasticEplbManager(self.worker)
+
+    @contextmanager
+    def _use_ascend_transfer_impl(self):
+        with patch(
+            "vllm.distributed.elastic_ep.elastic_execute.batch_transfer_weights", new=ascend_batch_transfer_weights
+        ):
+            yield
+
+    def load_model(self) -> None:
+        (
+            expert_maps,
+            num_local_experts,
+            num_logical_experts,
+        ) = self.receive_expert_mapping()
+        n_layers, old_ep_size, n_experts = expert_maps.shape
+        new_ep_size = get_ep_group().world_size
+        n_redundant = new_ep_size * num_local_experts - num_logical_experts
+        get_ascend_config().eplb_config.num_redundant_experts = n_redundant
+        if self.dynamic_eplb:
+            self.worker.model_runner.shared_dict["expert_maps"] = expert_maps
+        else:
+            with set_current_vllm_config(self.worker.vllm_config):
+                get_ascend_config().eplb_config.expert_map_path = generate_expert_maps_file()
+        self.old_ep_size = old_ep_size
+        self.worker.load_model(load_dummy_weights=True)
+        self.eplb_manager.expert_maps = expert_maps
+
+    def create_standby_groups(self, reconfig_request: ReconfigureDistributedRequest) -> None:
+        self.reconfig_request = reconfig_request
+        new_dp_size = reconfig_request.new_data_parallel_size
+        world_size = self.worker.vllm_config.parallel_config.world_size
+        new_world_size_across_dp = world_size * new_dp_size
+        updated_config = copy.copy(self.worker.vllm_config)
+        updated_config.parallel_config = copy.deepcopy(self.worker.vllm_config.parallel_config)
+        updated_config.parallel_config.data_parallel_size = new_dp_size
+        with set_current_vllm_config(updated_config), use_stateless_pg_with_world_registration():
+            create_standby_groups(
+                new_dp_size=new_dp_size,
+                new_world_size_across_dp=new_world_size_across_dp,
+                master_ip=reconfig_request.new_data_parallel_master_ip,
+                coord_store_port=reconfig_request.coord_store_port,
+                enable_eplb=updated_config.parallel_config.enable_eplb,
+            )
+            create_ascend_standby_groups(
+                new_dp_size=new_dp_size,
+                new_world_size_across_dp=new_world_size_across_dp,
+                master_ip=reconfig_request.new_data_parallel_master_ip,
+                coord_store_port=reconfig_request.coord_store_port,
+            )
+
+    def transfer_weights(self, old_dp_size: int, new_dp_size: int) -> None:
+        model = self.worker.model_runner.get_model()
+        if self.dynamic_eplb:
+            model.expert_weights = [item[1] for item in self.worker.model_runner.eplb_adaptor.param_dict.items()]
+        else:
+            model.expert_weights = []
+        get_standby_dp_group().barrier()
+        get_tp_group().barrier()
+        with _PATCH_LOCK, self._use_ascend_transfer_impl():
+            super().transfer_weights(old_dp_size=old_dp_size, new_dp_size=new_dp_size)
+
+    def broadcast_expert_mapping(self):
+        standby_dp_group = get_standby_dp_group()
+        assert standby_dp_group is not None
+        expert_maps = self.eplb_manager.get_expert_maps()
+        broadcast_expert_mapping(
+            expert_maps=expert_maps,
+            group=standby_dp_group,
+            src_rank=0,
+        )
+
+    def _release_cuda_graphs(self) -> None:
+        if isinstance(self.worker.model_runner.model, UBatchWrapper):
+            raise RuntimeError("DBO is not yet supported in elastic EP")
+
+        ACLGraphWrapper.clear_all_graphs()
+
+        torch.compiler.reset()
+        with set_current_vllm_config(self.worker.vllm_config):
+            reset_compile_wrapper(self.worker.model_runner.get_model())
+
+        reset_graph_params()
+
+        capture_descs = self.worker.model_runner.cudagraph_dispatcher.get_capture_descs()
+        capture_sizes = sorted({desc.num_tokens for _, descs in capture_descs for desc in descs})
+        if self.worker.model_runner.use_aclgraph:
+            set_graph_params(capture_sizes)
+            if self.worker.model_runner.speculative_config:
+                set_draft_graph_params(capture_sizes)
+
+        gc.collect()
+        torch.npu.synchronize()
+        torch.npu.empty_cache()
+
+    def switch_and_remove(self) -> None:
+        self._release_cuda_graphs()
+        with use_stateless_pg_with_world_registration():
+            _replace_active_groups(world=None, dp=None, ep=None, eplb=None, node_count=None)
+            _replace_ascend_active_groups(mc2=None, dynamic_eplb=None, fc3_quant_x=None)
+
+    def switch_and_prepare(self) -> None:
+        self.old_ep_size = get_ep_group().world_size
+
+        self._release_cuda_graphs()
+
+        parallel_config = self.worker.vllm_config.parallel_config
+        reconfig_request = self.reconfig_request
+        assert reconfig_request is not None
+        new_dp_size = reconfig_request.new_data_parallel_size
+        new_ep_size = get_standby_ep_group().world_size
+        self.new_ep_size = new_ep_size
+        parallel_config.data_parallel_size = new_dp_size
+
+        with use_stateless_pg_with_world_registration():
+            _replace_active_groups(**pop_standby_groups())
+            _replace_ascend_active_groups(**pop_ascend_standby_groups())
+
+        if reconfig_request.new_data_parallel_rank != ReconfigureRankType.KEEP_CURRENT_RANK:
+            parallel_config.data_parallel_rank = reconfig_request.new_data_parallel_rank
+        if reconfig_request.new_data_parallel_rank_local != ReconfigureRankType.KEEP_CURRENT_RANK:
+            parallel_config.data_parallel_rank_local = reconfig_request.new_data_parallel_rank_local
+        parallel_config.data_parallel_master_ip = reconfig_request.new_data_parallel_master_ip
+        parallel_config.data_parallel_master_port = reconfig_request.new_data_parallel_master_port
+        self.worker.model_runner.dp_size = new_dp_size
+        self.eplb_manager.reset_eplb_updator()
+        self.eplb_manager.set_new_comm_group()
+
+        # Reconfigure MoE modules with new EP size
+        moe_modules = [module for module in self.worker.model_runner.model.modules() if isinstance(module, FusedMoE)]
+        num_local_experts = moe_modules[0].moe_config.num_local_experts
+        assert all(module.moe_config.num_local_experts == num_local_experts for module in moe_modules), (
+            "All MoE modules must have the same number of experts"
+        )
+        for module in moe_modules:
+            num_logical_experts = self.eplb_manager.get_expert_maps().shape[-1]
+            module.global_redundant_expert_num = module.local_num_experts * new_ep_size - num_logical_experts
+            module.moe_config.num_experts = num_local_experts * new_ep_size
+            module.global_num_experts = module.moe_config.num_experts
+            tp_size = get_tp_group().world_size
+            is_sequence_parallel = parallel_config.use_sequence_parallel_moe
+            sp_size = tp_size if is_sequence_parallel else 1
+            module.moe_parallel_config = FusedMoEParallelConfig.make(
+                tp_size_=tp_size,
+                pcp_size_=get_pcp_group().world_size,
+                dp_size_=get_dp_group().world_size,
+                sp_size_=sp_size,
+                vllm_parallel_config=parallel_config,
+            )
+            module.moe_config.moe_parallel_config = module.moe_parallel_config
+
+            module.moe_config.tp_group = get_tp_group()
+            module.moe_config.dp_group = get_dp_group()
+            module.moe_config.ep_group = get_ep_group()
+            module.moe_config.mc2_group = get_mc2_group()
+
+            with set_current_vllm_config(self.worker.vllm_config):
+                setup_moe_comm_and_quant_method(module)
+
+        if self.worker.vllm_config.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE:
+            # NOTE(yongji): when using stock torch.compile,
+            # torch.compile is triggered during GPUModelRunner's load_model()
+            # TODO(yongji):check do we need to re-trigger torch.compile here?
+            # any changes to the tensor shapes in execution should already
+            # be handled internally by torch.compile.
+            backend = self.worker.vllm_config.compilation_config.init_backend(self.worker.vllm_config)
+            compilation_counter.stock_torch_compile_count += 1
+            self.worker.model_runner.model.compile(fullgraph=True, backend=backend)
+
+        multi_block_table = self.worker.model_runner.input_batch.block_table
+        saved_block_tables: list[tuple[torch.Tensor, torch.Tensor]] = []
+        for bt in multi_block_table.block_tables:
+            saved_block_tables.append((bt.block_table.gpu.clone(), bt.block_table.cpu.clone()))
+        multi_block_table.clear()
+
+        unlock_workspace()
+        self.worker.compile_or_warm_up_model()
+        lock_workspace()
+
+        for bt, (saved_gpu, saved_cpu) in zip(multi_block_table.block_tables, saved_block_tables):
+            bt.block_table.gpu.copy_(saved_gpu)
+            bt.block_table.cpu.copy_(saved_cpu)
+
+    def perform_eplb_reshuffle(self) -> None:
+        new_ep_size = get_ep_group().world_size
+        self.eplb_manager.eplb(self.old_ep_size, new_ep_size)
+
+    def perform_scale_down_eplb_reshuffle(self, new_dp_size: int) -> None:
+        old_ep_size = get_ep_group().world_size
+        parallel_config = self.worker.vllm_config.parallel_config
+        tp_size = parallel_config.tensor_parallel_size
+        new_ep_size = new_dp_size * tp_size
+
+        self.eplb_manager.eplb(old_ep_size, new_ep_size)
+
+    def receive_weights(self) -> None:
+        model = self.worker.model_runner.get_model()
+        if self.dynamic_eplb:
+            model.expert_weights = [item[1] for item in self.worker.model_runner.eplb_adaptor.param_dict.items()]
+        else:
+            model.expert_weights = []
+        get_dp_group().barrier()
+        get_tp_group().barrier()
+        with _PATCH_LOCK, self._use_ascend_transfer_impl():
+            super().receive_weights()
+
+    def receive_expert_mapping(self) -> tuple[torch.Tensor, int, int]:
+        dp_group = get_dp_group()
+        assert isinstance(dp_group, StatelessGroupCoordinator)
+        expert_maps = broadcast_expert_mapping(
+            expert_maps=None,
+            group=dp_group,
+            src_rank=0,
+        )
+        num_local_experts = (expert_maps[0, 0] != -1).sum().item()
+        num_logical_experts = expert_maps.shape[-1]
+
+        return expert_maps, num_local_experts, num_logical_experts
+
+    def prepare_new_worker(self) -> None:
+        moe_modules = [module for module in self.worker.model_runner.model.modules() if isinstance(module, FusedMoE)]
+        for module in moe_modules:
+            with set_current_vllm_config(self.worker.vllm_config):
+                setup_moe_comm_and_quant_method(module)

--- a/vllm_ascend/distributed/elastic_ep/eplb_manager.py
+++ b/vllm_ascend/distributed/elastic_ep/eplb_manager.py
@@ -1,0 +1,361 @@
+import json
+import os
+import uuid
+from typing import Any
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import torch_npu
+from torch.distributed import P2POp
+from vllm.config import get_current_vllm_config
+from vllm.distributed.parallel_state import get_eplb_group
+from vllm.logger import logger
+
+from vllm_ascend.ascend_config import get_ascend_config
+
+from ...eplb.core.eplb_utils import generate_log2phy_map
+from ..parallel_state import get_dynamic_eplb_group
+from .policy_default_elastic_eplb import DefaultElasticEplb
+
+
+class ElasticEplbManager:
+    def __init__(self, worker):
+        self.rank_id = get_eplb_group().rank_in_group
+        self.dynamic_eplb = get_ascend_config().eplb_config.dynamic_eplb
+        self.model = worker.get_model()
+        model_config = self.model.config
+        self.num_dense_layers = getattr(model_config, "first_k_dense_replace", 0)
+        self.num_moe_layers = model_config.num_hidden_layers - self.num_dense_layers
+        self.tp_size = worker.parallel_config.tensor_parallel_size
+        if self.dynamic_eplb:
+            self.shared_dict = worker.model_runner.shared_dict
+            self.eplb_updator = worker.model_runner.eplb_updator
+            self.eplb_adaptor = worker.model_runner.eplb_adaptor
+            self.eplb_loader = worker.model_runner.eplb_loader
+            self.eplb_worker = worker.model_runner.eplb_process.worker
+            self.expert_maps = None
+            self.policy = DefaultElasticEplb()
+
+    def get_expert_maps(self):
+        if self.dynamic_eplb:
+            eplb_updator = self.eplb_updator
+            if eplb_updator.cur_iterations >= eplb_updator.expert_heat_collection_interval:
+                while eplb_updator.cur_iterations != 0:
+                    eplb_updator.forward_before()
+                    eplb_updator.forward_end()
+            self.expert_maps = self.shared_dict["expert_maps"]
+        else:
+            all_layer_global_expert_map = []
+            for layer_id in range(self.num_moe_layers):
+                map_cpu = self.model.model.layers[self.num_dense_layers + layer_id].mlp.experts.global_expert_map.cpu()
+                all_layer_global_expert_map.append(map_cpu)
+
+            self.expert_maps = torch.stack(all_layer_global_expert_map)
+
+        return self.expert_maps.clone()
+
+    def reset_eplb_updator(self):
+        if self.dynamic_eplb:
+            self.eplb_updator.cur_iterations = 0
+            self.eplb_updator.update_info_all = []
+
+    def set_new_comm_group(self):
+        if self.dynamic_eplb:
+            self.eplb_updator.comm_group = get_dynamic_eplb_group()
+            self.eplb_updator.world_size = get_dynamic_eplb_group().world_size
+            self.eplb_loader.comm_group = get_dynamic_eplb_group()
+
+    def eplb(self, old_ep_size, new_ep_size):
+        assert old_ep_size != new_ep_size
+
+        if not self.dynamic_eplb:
+            expert_map = []
+            for layer_id in range(self.num_moe_layers):
+                expert_map.append(self.model.model.layers[self.num_dense_layers + layer_id].mlp.experts.expert_map)
+            expert_map = torch.stack(expert_map).unsqueeze(1).npu()
+            expert_maps = get_eplb_group().all_gather(expert_map, dim=1).cpu()
+            for layer_id in range(self.num_moe_layers):
+                # Scale Up
+                if old_ep_size < new_ep_size:
+                    expert_maps_this_layer = expert_maps[layer_id]
+                # Scale Down
+                else:
+                    if self.rank_id >= old_ep_size:
+                        return
+                    num_logical_experts = expert_maps.shape[-1]
+                    experts_per_npu = expert_maps.max() + 1
+                    num_npus = expert_maps.shape[1]
+                    assert experts_per_npu * num_npus >= num_logical_experts
+                    expert_maps_this_layer = expert_maps[layer_id][:new_ep_size]
+                self.model.model.layers[
+                    self.num_dense_layers + layer_id
+                ].mlp.experts.global_expert_map = expert_maps_this_layer.cpu()
+                self.model.model.layers[self.num_dense_layers + layer_id].mlp.experts.log2phy.copy_(
+                    generate_log2phy_map(expert_maps_this_layer, self.rank_id)
+                )
+            return
+
+        # Fetch expert_map from eplb_adaptor to prevent unfinished expert updates.
+        old_expert_maps = self.get_expert_maps()
+        assert old_expert_maps.shape[1] == old_ep_size
+
+        num_local_experts = old_expert_maps.max() + 1
+        old_placement = global2local(old_expert_maps, num_local_experts)
+
+        local_load = self.eplb_adaptor.get_rank_expert_workload().unsqueeze(1)
+        moe_load = get_dynamic_eplb_group().all_gather(local_load, dim=1).cpu()
+        if old_ep_size < new_ep_size:
+            moe_load = moe_load[:, :old_ep_size]
+
+        self.policy.set_new_ep_size(new_ep_size)
+        new_placement = self.policy.rebalance_experts(old_placement, moe_load)
+        new_placement = torch.tensor(new_placement)
+        new_expert_maps = local2global(new_placement)
+
+        self.shared_dict["expert_maps"] = new_expert_maps
+        self.eplb_worker.old_expert_maps = new_expert_maps
+        self.expert_maps = new_expert_maps
+
+        # Scale Up
+        if old_ep_size < new_ep_size:
+            shape = list(new_expert_maps.shape)
+            shape[1] = new_ep_size - old_ep_size
+            old_expert_maps = torch.cat([old_expert_maps, torch.full(shape, -1)], dim=1)
+        # Scale Down
+        else:
+            shape = list(new_expert_maps.shape)
+            shape[1] = old_ep_size - new_ep_size
+            new_expert_maps = torch.cat([new_expert_maps, torch.full(shape, -1)], dim=1)
+
+        update_info = compose_expert_update_info_greedy_optimized(new_expert_maps, old_expert_maps)
+
+        for send_info, recv_info, new_expert_map, layer_id in update_info:
+            send_info_this_rank = send_info.get(self.rank_id, [])
+            recv_info_this_rank = recv_info.get(self.rank_id, [])
+            new_expert_map_this_rank = new_expert_map[self.rank_id]
+            new_log2phy_map_this_rank = generate_log2phy_map(new_expert_map, self.rank_id)
+            layer_id += self.eplb_adaptor.num_dense_layers
+
+            recv_expert_list = self.d2d_transfer_experts(
+                send_info_this_rank,
+                recv_info_this_rank,
+                new_expert_map_this_rank,
+                layer_id,
+            )
+
+            self.update_expert_map_and_weight(
+                new_expert_map_this_rank,
+                new_log2phy_map_this_rank,
+                recv_expert_list,
+                layer_id,
+            )
+
+        self.eplb_adaptor.model.clear_all_moe_loads()
+        self.eplb_updator.cur_iterations = 0
+        torch_npu.npu.synchronize()
+
+        if self.rank_id == 0:
+            logger.info("[Elastic EP] EPLB finished, new expert parallel size: %s", new_ep_size)
+
+    def d2d_transfer_experts(
+        self,
+        expert_send_info: list,
+        expert_recv_info: list,
+        updated_expert_map: torch.Tensor,
+        layer_id: int,
+    ) -> list[tuple[int, int]]:
+        p2p_ops = []
+
+        for send_info in expert_send_info:
+            dst_rank, global_expert_id_to_send = send_info
+            local_expert_id = self.eplb_adaptor.expert_map_per_layer_cpu[layer_id][global_expert_id_to_send].item()
+            for index, src_tensor in enumerate(self.eplb_adaptor.expert_param_per_layer[layer_id][local_expert_id]):
+                op = object.__new__(P2POp)
+                op.op = dist.isend
+                op.tensor = src_tensor
+                op.group_peer = dst_rank
+                p2p_ops.append((op, global_expert_id_to_send))
+
+        recv_expert_list = []
+        for buffer_tensor_id, recv_info in enumerate(expert_recv_info):
+            recv_rank, global_expert_id_to_recv = recv_info
+            for buffer_tensor in self.eplb_adaptor.buffer_tensor_list[buffer_tensor_id]:
+                op = object.__new__(P2POp)
+                op.op = dist.irecv
+                op.tensor = buffer_tensor
+                op.group_peer = recv_rank
+                p2p_ops.append((op, global_expert_id_to_recv))
+            local_expert_to_replace = updated_expert_map[global_expert_id_to_recv].item()
+            recv_expert_list.append((local_expert_to_replace, buffer_tensor_id))
+
+        p2p_ops = sorted(p2p_ops, key=lambda x: x[1])
+        p2p_ops = [item[0] for item in p2p_ops]
+
+        device_communicator = get_dynamic_eplb_group().device_communicator
+        device_communicator.batch_isend_irecv(p2p_ops)
+
+        return recv_expert_list
+
+    def update_expert_map_and_weight(
+        self,
+        updated_expert_map: torch.Tensor,
+        updated_log2phy_map: torch.Tensor,
+        recv_expert_list: list[tuple[int, int]],
+        layer_id: int,
+    ):
+        # update expert_map
+        self.eplb_adaptor.do_update_expert_map(layer_id, updated_expert_map)
+
+        # update log2phy_map
+        self.eplb_adaptor.do_update_log2phy_map(layer_id, updated_log2phy_map)
+
+        # update expert weight
+        for recv_expert_info in recv_expert_list:
+            local_expert_to_replace, buffer_tensor_id = recv_expert_info
+            self.eplb_adaptor.do_update_expert_weight(layer_id, local_expert_to_replace, buffer_tensor_id)
+
+
+def compose_expert_update_info_greedy_optimized(
+    updated_expert_maps,
+    current_expert_maps,
+    rank_to_node=None,
+):
+    num_layers = current_expert_maps.shape[0]
+    for layer_id in range(num_layers):
+        updated = updated_expert_maps[layer_id]
+        current = current_expert_maps[layer_id]
+
+        expert_send_info: dict = {}
+        expert_recv_info: dict = {}
+
+        if torch.equal(updated, current):
+            yield expert_send_info, expert_recv_info, updated, layer_id
+            continue
+
+        dst_ranks, recv_experts = torch.where((current == -1) & (updated != -1))
+        src_ranks, send_experts = torch.where((current != -1) & (updated == -1))
+
+        recv_map = {}
+        for dst, exp in zip(dst_ranks.tolist(), recv_experts.tolist()):
+            recv_map.setdefault(exp, []).append(dst)
+
+        for expert_id, dst_list in recv_map.items():
+            mask_send = send_experts == expert_id
+            primary_src = src_ranks[mask_send].tolist()
+            mask_keep = current[:, expert_id] != -1
+            secondary_src = torch.where(mask_keep)[0].tolist()
+            candidates = primary_src + [r for r in secondary_src if r not in primary_src]
+
+            if rank_to_node is not None:
+                for dst in dst_list:
+                    best_src = None
+                    best_score = (1, float("inf"))  # (node_penalty, load)
+                    for src in candidates:
+                        same_node = rank_to_node[src] == rank_to_node[dst]
+                        load = len(expert_send_info.get(src, []))
+                        score = (0 if same_node else 1, load)
+                        if score < best_score:
+                            best_score = score
+                            best_src = src
+                    expert_send_info.setdefault(best_src, []).append((dst, expert_id))
+                    expert_recv_info.setdefault(dst, []).append((best_src, expert_id))
+            else:
+                for dst in dst_list:
+                    loads = [len(expert_send_info.get(src, [])) for src in candidates]
+                    best_src = candidates[loads.index(min(loads))]
+                    expert_send_info.setdefault(best_src, []).append((dst, expert_id))
+                    expert_recv_info.setdefault(dst, []).append((best_src, expert_id))
+
+        yield expert_send_info, expert_recv_info, updated, layer_id
+
+
+def global2local(placement: torch.Tensor, E_local: int) -> torch.Tensor:
+    L, G, _ = placement.shape
+    device = placement.device
+
+    pt_local = torch.full((L, G, E_local), fill_value=-1, dtype=torch.long, device=device)
+
+    valid = placement >= 0
+    l_idx, g_idx, k_idx = valid.nonzero(as_tuple=True)
+
+    slot_idx = placement[l_idx, g_idx, k_idx]
+
+    pt_local[l_idx, g_idx, slot_idx] = k_idx
+
+    return pt_local
+
+
+def local2global(placement_local: torch.Tensor) -> torch.Tensor:
+    L, G, E_local = placement_local.shape
+    device = placement_local.device
+
+    max_id = torch.max(placement_local)
+    E_global = (max_id + 1).item() if max_id >= 0 else 0
+
+    if E_global == 0:
+        return torch.empty((L, G, 0), dtype=torch.long, device=device)
+
+    placement_global = torch.full((L, G, E_global), fill_value=-1, dtype=torch.long, device=device)
+
+    valid = placement_local >= 0
+    l_idx, g_idx, slot_idx = valid.nonzero(as_tuple=True)
+    gid_idx = placement_local[l_idx, g_idx, slot_idx]
+
+    placement_global[l_idx, g_idx, gid_idx] = slot_idx
+
+    return placement_global
+
+
+def generate_global_placement(n_expert, ep_size, n_redundant):
+    if (n_expert + n_redundant) % ep_size != 0:
+        raise ValueError("(n_expert + n_redundant) % ep_size must be 0")
+    all_experts = np.arange(n_expert + n_redundant)
+    groups = np.array_split(all_experts, ep_size)
+    groups = [group % n_expert for group in groups]
+    return torch.tensor(groups, dtype=torch.int32)
+
+
+def export_tensor_to_file(expert_maps, expert_map_record_path: str):
+    num_local_experts = expert_maps.max() + 1
+
+    expert_maps_list = expert_maps.tolist()
+    record: dict[str, Any] = {"moe_layer_count": len(expert_maps_list), "layer_list": []}
+
+    for layer_idx, layer_data in enumerate(expert_maps_list):
+        layer_record: dict[str, Any] = {
+            "layer_id": layer_idx,
+            "device_count": len(layer_data),
+            "device_list": [],
+        }
+
+        for device_idx, experts in enumerate(layer_data):
+            placement = [experts.index(i) for i in range(num_local_experts)]
+            device_record = {"device_id": device_idx, "device_expert": placement}
+            layer_record["device_list"].append(device_record)
+
+        record["layer_list"].append(layer_record)
+
+    with open(expert_map_record_path, "w") as f:
+        json.dump(record, f, indent=4)
+
+
+def generate_expert_maps_file():
+    hf_text_config = get_current_vllm_config().model_config.hf_text_config
+    num_dense_layers = getattr(hf_text_config, "first_k_dense_replace", 0)
+    num_hidden_layers = getattr(hf_text_config, "num_hidden_layers", 0)
+    num_moe_layers = num_hidden_layers - num_dense_layers
+    num_logical_experts = getattr(hf_text_config, "n_routed_experts", None) or getattr(
+        hf_text_config, "num_experts", None
+    )
+    assert num_logical_experts is not None and num_logical_experts > 0
+    num_redundant_experts = get_ascend_config().eplb_config.num_redundant_experts
+    parallel_config = get_current_vllm_config().parallel_config
+    ep_size = parallel_config.data_parallel_size * parallel_config.tensor_parallel_size
+    global_placement = generate_global_placement(num_logical_experts, ep_size, num_redundant_experts).unsqueeze(0)
+    global_placement = global_placement.repeat(num_moe_layers, 1, 1)
+    global_expert_maps = local2global(global_placement)
+    file_path = os.path.join("/tmp", uuid.uuid4().hex + ".json")
+    export_tensor_to_file(global_expert_maps, file_path)
+
+    return file_path

--- a/vllm_ascend/distributed/elastic_ep/policy_default_elastic_eplb.py
+++ b/vllm_ascend/distributed/elastic_ep/policy_default_elastic_eplb.py
@@ -1,0 +1,309 @@
+# Copyright Huawei Technologies Co., Ltd. 2024-2025. All rights reserved.
+# Todo: Once https://github.com/vllm-project/vllm/pull/24069 is merged in vllm. Remove this policy.
+from collections import defaultdict
+from typing import cast
+
+import numpy as np
+
+from vllm_ascend.eplb.core.policy.policy_abstract import EplbPolicy
+
+
+class DynamicTable:
+    # workload_table:
+    # 3D matrix: [layer, gpus, experts_per_gpu_per_layer] -> value: workload (heat) at the corresponding position
+    # Size: number of layers * number of GPUs * number of experts per GPU per layer
+    # The element at (i, j, k) represents the workload (heat) of the k-th expert on the j-th GPU in the i-th layer
+    # For experts that are not available or collected, the value is set to -1
+    workload_table = None
+
+    # placement_table:
+    # 3D matrix: [layer, gpus, experts_per_gpu_per_layer] -> value: physical expert ID at the corresponding position
+    # Size: number of layers * number of GPUs * number of experts per GPU per layer
+    # The element at (i, j, k) represents the physical expert ID of the k-th expert on the j-th GPU in the i-th layer
+    # For experts that are not available or collected, the value is set to -1
+    placement_table = None
+
+
+class DefaultElasticEplb(EplbPolicy):
+    def __init__(self):
+        self._new_ep_size: int | None = None
+
+    def set_new_ep_size(self, new_ep_size: int):
+        self._new_ep_size = new_ep_size
+
+    @staticmethod
+    def add_redundant(current_expert_table, expert_workload, num_original_expert):
+        layer_num, npu_num, experts_per_npu = expert_workload.shape
+        workload_new = np.zeros((layer_num, num_original_expert))
+        for layer_idx in range(layer_num):
+            workload_dict: dict[int, int] = defaultdict(int)
+            placement_layer = current_expert_table[layer_idx].copy()
+            workload_layer = expert_workload[layer_idx].copy()
+            for npu_idx in range(npu_num):
+                for expert_idx in range(experts_per_npu):
+                    workload_dict[placement_layer[npu_idx][expert_idx]] += workload_layer[npu_idx][expert_idx]
+            for expert_idx in range(num_original_expert):
+                workload_new[layer_idx][expert_idx] = workload_dict[expert_idx]
+        return workload_new
+
+    @staticmethod
+    # Split hot (high-load) experts into redundant experts
+    def original_compute_balanced_pack_redundancy(origin_weights, card_num, num_redundancy_expert):
+        # Step 1: Sort the items by weight in descending order (we are sorting by weight now)
+        # Sort based on the second element (the second value of each tuple)
+        route_expert_num = len(origin_weights)
+        route_expert_redundancy: list[list[int]] = [[] for _ in range(route_expert_num)]
+        for i in range(num_redundancy_expert):
+            sorted_indices = np.argsort([t[1] for t in origin_weights], kind="stable")[::-1]
+            weights = [origin_weights[idx] for idx in sorted_indices]
+            index = 0
+            while (len(route_expert_redundancy[weights[index][0]])) == card_num - 1:
+                index += 1
+                assert index < route_expert_num
+            tmp_raw_weight = weights[index][1] * (len(route_expert_redundancy[weights[index][0]]) + 1)
+            route_expert_redundancy[weights[index][0]].append(route_expert_num + i)
+            avg_weight = tmp_raw_weight / (len(route_expert_redundancy[weights[index][0]]) + 1)
+            weights[index] = (weights[index][0], avg_weight)
+            origin_weights = weights
+
+        # Step 2: Calculate the number of items per box
+        expert_num = route_expert_num + num_redundancy_expert
+        items_per_box = expert_num // card_num  # Number of items per box
+        remaining_items = expert_num % card_num  # Number of items per box
+
+        # Step 3: Initialize card_num boxes with empty lists to store item IDs
+        boxes: list[list[int]] = [[] for _ in range(card_num)]
+        boxes_weights: list[list[float]] = [[] for _ in range(card_num)]
+        box_weights = [0] * card_num  # To store the total weight of each box
+        box_counts = [0] * card_num  # To store the number of items in each box
+        index = 0
+        for i in range(route_expert_num):
+            redundancy_num = len(route_expert_redundancy[i])
+            for _ in range(redundancy_num):
+                expert_weight = 0
+                for item, weight in origin_weights:
+                    if item == i:
+                        expert_weight = weight
+                        break
+
+                boxes[index].append(i)
+                boxes_weights[index].append(expert_weight)
+                box_weights[index] += expert_weight
+                box_counts[index] += 1
+                index += 1
+                index = index % card_num
+
+        sorted_indices = np.argsort([t[1] for t in origin_weights], kind="stable")[::-1]
+        origin_weights = [origin_weights[idx] for idx in sorted_indices]
+        # Step 4: Distribute items into boxes based on weight
+        for item_id, weight in origin_weights:
+            # Find the box with the least items but not full
+            min_box_index = -1
+            for i in range(card_num):
+                if item_id in boxes[i]:
+                    continue
+                # Only choose boxes that still have space (box_counts[i] < items_per_box)
+                if box_counts[i] < items_per_box or (box_counts[i] == items_per_box and remaining_items > 0):
+                    if min_box_index == -1 or box_weights[i] < box_weights[min_box_index]:
+                        min_box_index = i
+
+            # If no valid box is found, place in the first available box (duplicates will be fixed in Step5)
+            if min_box_index == -1:
+                # Find any box with capacity
+                for i in range(card_num):
+                    if box_counts[i] < items_per_box or (box_counts[i] == items_per_box and remaining_items > 0):
+                        min_box_index = i
+                        break
+
+            # Place the item (id) into the selected box
+            boxes[min_box_index].append(item_id)
+            boxes_weights[min_box_index].append(weight)
+            box_weights[min_box_index] += weight
+            box_counts[min_box_index] += 1
+
+            # If there's an imbalance in the remaining items, reduce the "remaining_items" counter
+            if box_counts[min_box_index] == (items_per_box + 1) and remaining_items > 0:
+                remaining_items -= 1
+
+        # Step 5: Deduplication & Rebalancing
+        # Target CASE: Handles the edge case where Step 4's fallback logic forces a duplicate
+        # expert onto a card because all other cards are either full or already contain that expert.
+        # ACTION: Identifies these forced duplicates and replaces them with unique candidates
+        # that minimize weight difference, restoring uniqueness while preserving load balance.
+        for i in range(card_num):
+            arr = np.asarray(boxes[i])
+
+            unique, inv, cnt = np.unique(arr, return_inverse=True, return_counts=True)
+
+            mask = cnt > 1
+            dup_vals = unique[mask]  # The IDs of the duplicated experts
+            dup_cnts = cnt[mask]  # How many times each duplicated expert appears
+
+            for item_id, counts in zip(dup_vals, dup_cnts):
+                # We need to replace (counts - 1) occurrences to leave only one instance
+                for _ in range(counts - 1):
+                    # Find the current position of the duplicate expert in the NPU's list
+                    cur_position = boxes[i].index(item_id)
+                    # Get the current weight associated with this duplicate expert
+                    cur_weight: float = boxes_weights[i][cur_position]
+
+                    def score(t, cw=cur_weight):
+                        before = len(route_expert_redundancy[t[0]]) + 1
+                        after = len(route_expert_redundancy[t[0]]) + 2
+                        adjusted = t[1] * before / after
+                        return abs(adjusted - cw)
+
+                    sorted_indices = np.argsort(
+                        [score(t) for t in origin_weights],
+                        kind="stable",
+                    )
+
+                    weights = [origin_weights[idx] for idx in sorted_indices]
+
+                    index = 0
+                    while index < len(weights):
+                        candidate_id = weights[index][0]
+                        if (
+                            len(route_expert_redundancy[candidate_id]) < card_num - 1
+                            and candidate_id != item_id
+                            and candidate_id not in boxes[i]
+                        ):
+                            break
+                        index += 1
+
+                    assert index < len(weights)
+
+                    boxes[i][cur_position] = weights[index][0]
+                    tmp_raw_weight = weights[index][1] * (len(route_expert_redundancy[weights[index][0]]) + 1)
+                    route_expert_redundancy[weights[index][0]].append(0)  # Add a placeholder to track redundancy
+                    avg_weight = tmp_raw_weight / (len(route_expert_redundancy[weights[index][0]]) + 1)
+                    boxes_weights[i][cur_position] = avg_weight
+
+                    weights[index] = (weights[index][0], avg_weight)
+
+                    tmp_raw_weight = cur_weight * (len(route_expert_redundancy[item_id]) + 1)
+                    avg_weight = tmp_raw_weight / len(route_expert_redundancy[item_id])
+                    route_expert_redundancy[item_id].pop()
+
+                    for index, (expert_id, expert_weight) in enumerate(weights):
+                        if item_id == expert_id:
+                            weights[index] = (expert_id, avg_weight)
+                    origin_weights = weights
+
+        box_weights = [sum(boxes_weights[i]) for i in range(card_num)]  # type: ignore
+
+        # Step 6: Output each box's contents and total weight
+        result = []
+        for i in range(card_num):
+            result.append(
+                {
+                    "box_index": i + 1,
+                    "items": boxes[i],  # List of item IDs in the box
+                    "weight": boxes_weights[i],
+                    "total_weight": box_weights[i],  # Total weight in this box
+                    "item_count": box_counts[i],  # Number of items in the box
+                }
+            )
+
+        return result, boxes
+
+    @staticmethod
+    def constraint_expert_local_exchange(current_expert_table, global_deployment):
+        for layer_id in range(len(global_deployment)):
+            # Iterate over available cards, ensuring we don't go out of bounds
+            num_cards = min(len(current_expert_table[layer_id]), len(global_deployment[layer_id]))
+
+            for card_id in range(num_cards):
+                cur_expert_ids = np.array(current_expert_table[layer_id][card_id])
+                new_expert_ids = np.array(global_deployment[layer_id][card_id])
+
+                assert len(cur_expert_ids) == len(new_expert_ids), (
+                    "Number of experts must match between current and new deployment."
+                )
+
+                # 1. Identify experts that are not moved to other NPU.
+                # If there have duplicate experts in cur_expert_ids, we choose the first occurrence.
+                _, first_occurrence_idx = np.unique(cur_expert_ids, return_index=True)
+                mask_experts_not_move = np.zeros(len(cur_expert_ids), dtype=bool)
+                mask_experts_not_move[first_occurrence_idx] = True
+                mask_experts_not_move &= np.isin(cur_expert_ids, new_expert_ids)
+                experts_not_move = cur_expert_ids[mask_experts_not_move]
+
+                # 2. Identify experts in the new list that are moved from other NPU.
+                mask_new_experts = ~np.isin(new_expert_ids, experts_not_move)
+                new_experts = new_expert_ids[mask_new_experts]
+
+                final_expert_list = new_expert_ids.copy()
+
+                # Use mask_experts_not_move to constrain expert local exchange in NPU.
+                final_expert_list[mask_experts_not_move] = experts_not_move
+
+                # Fill the remaining slot with experts that are moved from other NPUS.
+                final_expert_list[~mask_experts_not_move] = new_experts
+
+                # Update the global deployment plan with the locally constrained list
+                global_deployment[layer_id][card_id] = final_expert_list.tolist()
+
+        return global_deployment
+
+    def rebalance_experts(self, current_expert_table, expert_workload):
+        info = DynamicTable()
+        info.workload_table = np.array(expert_workload)
+        info.placement_table = np.array(current_expert_table)
+        assert info.workload_table is not None
+        layer_num, num_npus, experts_per_npu = info.workload_table.shape
+        assert info.placement_table is not None
+        row = cast(np.ndarray, info.placement_table[0])
+        expert_ids, counts = np.unique(row, return_counts=True)
+        num_original_expert = len(expert_ids)
+        assert self._new_ep_size is not None and self._new_ep_size != num_npus
+        num_npus = self._new_ep_size
+        num_redundancy_expert = experts_per_npu * self._new_ep_size - num_original_expert
+        layer_workloads = self.add_redundant(info.placement_table, info.workload_table, num_original_expert)
+
+        # Perform load balancing and deploy redundant experts
+        layer_num = layer_workloads.shape[0]
+        expert_num = layer_workloads.shape[1]
+        # Validate that the number of experts, number of cards, and number of redundant experts
+        # do not exceed the number of cards.
+        if num_original_expert != expert_num:
+            raise ValueError(
+                f"the number of original experts {num_original_expert} must be equal to expert_num {expert_num}"
+            )
+
+        if num_npus <= 0:
+            raise ValueError("the number of NPUs must be greater than 0")
+
+        if experts_per_npu > expert_num:
+            raise ValueError(
+                f"the number of experts per NPU {experts_per_npu} can't be greater than expert_num {expert_num}"
+            )
+
+        if num_npus * experts_per_npu < num_original_expert:
+            raise ValueError(
+                f"num_npus {num_npus} * experts_per_npu {experts_per_npu} "
+                f"can't be less than num_original_expert {num_original_expert}"
+            )
+
+        # Number of experts deployed on each card includes one redundant expert
+        global_deployment: list[list[list[int]]] = [[[] for _ in range(num_npus)] for _ in range(layer_num)]
+        # Iterate to obtain the placement strategy for each layer, taking computational balance into account
+        for layer in range(layer_num):
+            # Get the expert IDs and their corresponding workloads for the current layer;
+            # redundant experts will be created and distributed during the packing process
+            weights = np.zeros((expert_num,), dtype="object")
+            for expert_id, workload_weight in enumerate(layer_workloads[layer]):
+                weights[expert_id] = (expert_id, workload_weight)
+
+            # Obtain the globally balanced placement strategy for each layer
+            result, layer_deployment = self.original_compute_balanced_pack_redundancy(
+                weights, num_npus, num_redundancy_expert
+            )
+
+            global_deployment[layer] = layer_deployment
+
+        new_global_deployment = self.constraint_expert_local_exchange(current_expert_table, global_deployment)
+
+        self._new_ep_size = None
+
+        return np.array(new_global_deployment).tolist()

--- a/vllm_ascend/distributed/elastic_ep/standby_state.py
+++ b/vllm_ascend/distributed/elastic_ep/standby_state.py
@@ -1,0 +1,91 @@
+import torch
+from vllm.distributed.parallel_state import (
+    _init_stateless_group,
+    get_pp_group,
+    get_tp_group,
+    get_world_group,
+)
+from vllm.distributed.stateless_coordinator import StatelessGroupCoordinator
+from vllm.distributed.utils import get_cached_tcp_store_client
+
+from vllm_ascend.ascend_config import get_ascend_config
+
+_STANDBY_MC2: StatelessGroupCoordinator | None = None
+_STANDBY_DYNAMIC_EPLB: StatelessGroupCoordinator | None = None
+_STANDBY_FC3_QUANT_X: StatelessGroupCoordinator | None = None
+
+
+def get_standby_mc2_group() -> StatelessGroupCoordinator | None:
+    return _STANDBY_MC2
+
+
+def get_standby_dynamic_eplb_group() -> StatelessGroupCoordinator | None:
+    return _STANDBY_DYNAMIC_EPLB
+
+
+def get_standby_fc3_quant_x_group() -> StatelessGroupCoordinator | None:
+    return _STANDBY_FC3_QUANT_X
+
+
+def create_ascend_standby_groups(
+    new_dp_size: int,
+    new_world_size_across_dp: int,
+    master_ip: str,
+    coord_store_port: int,
+    backend: str | None = None,
+) -> None:
+    global _STANDBY_MC2, _STANDBY_DYNAMIC_EPLB, _STANDBY_FC3_QUANT_X
+
+    assert new_world_size_across_dp == torch.distributed.get_world_size() * new_dp_size
+    world_group = get_world_group()
+    assert isinstance(world_group, StatelessGroupCoordinator)
+    backend = backend or world_group.backend
+
+    coord_store = get_cached_tcp_store_client(master_ip, coord_store_port)
+
+    tp_size = get_tp_group().world_size
+    pp_size = get_pp_group().world_size
+
+    all_ranks = torch.arange(new_world_size_across_dp).reshape(-1, new_dp_size * pp_size * tp_size)
+    group_ranks = all_ranks.unbind(0)
+    standby_ep_ranks = [x.tolist() for x in group_ranks]
+
+    _STANDBY_MC2 = _init_stateless_group(
+        standby_ep_ranks,
+        "mc2",
+        master_ip,
+        backend,
+        coord_store=coord_store,
+    )
+
+    if get_ascend_config().eplb_config.dynamic_eplb:
+        _STANDBY_DYNAMIC_EPLB = _init_stateless_group(
+            standby_ep_ranks,
+            "dynamic_eplb",
+            master_ip,
+            backend,
+            coord_store=coord_store,
+        )
+
+    if get_ascend_config().multistream_overlap_gate:
+        _STANDBY_FC3_QUANT_X = _init_stateless_group(
+            standby_ep_ranks,
+            "fc3_quant_x",
+            master_ip,
+            backend,
+            coord_store=coord_store,
+        )
+
+
+def pop_ascend_standby_groups() -> dict:
+    """Return all standby groups and clear the standby state."""
+    global _STANDBY_MC2, _STANDBY_DYNAMIC_EPLB, _STANDBY_FC3_QUANT_X
+    result = dict(
+        mc2=_STANDBY_MC2,
+        dynamic_eplb=_STANDBY_DYNAMIC_EPLB,
+        fc3_quant_x=_STANDBY_FC3_QUANT_X,
+    )
+    _STANDBY_MC2 = None
+    _STANDBY_DYNAMIC_EPLB = None
+    _STANDBY_FC3_QUANT_X = None
+    return result

--- a/vllm_ascend/distributed/parallel_state.py
+++ b/vllm_ascend/distributed/parallel_state.py
@@ -1,6 +1,13 @@
 import torch
 from vllm.config import ParallelConfig, get_current_vllm_config
-from vllm.distributed.parallel_state import GroupCoordinator, get_tp_group, get_world_group, init_model_parallel_group
+from vllm.distributed import get_cached_tcp_store_client
+from vllm.distributed.parallel_state import (
+    GroupCoordinator,
+    _init_stateless_group,
+    get_tp_group,
+    get_world_group,
+    init_model_parallel_group,
+)
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.utils import enable_dsa_cp_with_layer_shard, flashcomm2_enable
@@ -33,12 +40,25 @@ def init_ascend_model_parallel(
     if model_parallel_initialized():
         return
     assert torch.distributed.is_initialized()
+    enable_elastic_ep = parallel_config.enable_elastic_ep
     world_size = torch.distributed.get_world_size()
-    backend = torch.distributed.get_backend(get_world_group().device_group)
     global_tp_size = parallel_config.tensor_parallel_size
     global_dp_size = parallel_config.data_parallel_size
     global_pp_size = parallel_config.pipeline_parallel_size
     global_pcp_size = parallel_config.prefill_context_parallel_size
+    if enable_elastic_ep:
+        coord_store = get_cached_tcp_store_client(
+            parallel_config.data_parallel_master_ip,
+            parallel_config._coord_store_port,
+        )
+        # Use stateless world group for global information
+        world_size = get_world_group().world_size
+        tp_pp_pcp_size = global_tp_size * global_pp_size * global_pcp_size
+        local_all_ranks = torch.arange(tp_pp_pcp_size).reshape(global_pp_size, global_pcp_size, global_tp_size)
+        backend = "hccl"
+    else:
+        world_size = torch.distributed.get_world_size()
+        backend = torch.distributed.get_backend(get_world_group().device_group)
 
     # The layout of all ranks: ExternalDP * EP
     # ExternalDP is the data parallel group that is not part of the model,
@@ -61,11 +81,17 @@ def init_ascend_model_parallel(
         num_head_replica = get_ascend_config().num_head_replica
         remote_tp_size = global_tp_size // pd_tp_ratio
         if num_head_replica <= 1:
-            group_ranks = all_ranks.view(-1, prefill_tensor_model_parallel_size).unbind(0)
+            if enable_elastic_ep:
+                group_ranks = local_all_ranks.view(-1, prefill_tensor_model_parallel_size).unbind(0)
+            else:
+                group_ranks = all_ranks.view(-1, prefill_tensor_model_parallel_size).unbind(0)
         else:
-            group_ranks = all_ranks.clone().view(
-                global_dp_size * global_pp_size * global_pcp_size, -1, num_head_replica
-            )  # [DP_size, num_head, num_head_replica]
+            if enable_elastic_ep:
+                group_ranks = local_all_ranks.clone().view(global_pp_size * global_pcp_size, -1, num_head_replica)
+            else:
+                group_ranks = all_ranks.clone().view(
+                    global_dp_size * global_pp_size * global_pcp_size, -1, num_head_replica
+                )  # [DP_size, num_head, num_head_replica]
             group_ranks = group_ranks.permute(0, 2, 1)
             group_ranks = group_ranks.reshape(-1, group_ranks.size(-1))  # [DP_size * num_head_replica, num_head]
             alltoall_group_size = group_ranks.size(-1) // remote_tp_size
@@ -93,19 +119,46 @@ def init_ascend_model_parallel(
     group_ranks = [x.tolist() for x in group_ranks]
 
     global _MC2
-    _MC2 = init_model_parallel_group(group_ranks, get_world_group().local_rank, backend, group_name="mc2")
+    if enable_elastic_ep:
+        _MC2 = _init_stateless_group(
+            group_ranks,
+            "mc2",
+            parallel_config.data_parallel_master_ip,
+            backend,
+            coord_store=coord_store,
+        )
+    else:
+        _MC2 = init_model_parallel_group(group_ranks, get_world_group().local_rank, backend, group_name="mc2")
 
     if get_ascend_config().eplb_config.dynamic_eplb:
         global _DYNAMIC_EPLB
-        _DYNAMIC_EPLB = init_model_parallel_group(
-            group_ranks, get_world_group().local_rank, backend, group_name="dynamic_eplb"
-        )
+        if enable_elastic_ep:
+            _DYNAMIC_EPLB = _init_stateless_group(
+                group_ranks,
+                "dynamic_eplb",
+                parallel_config.data_parallel_master_ip,
+                backend,
+                coord_store=coord_store,
+            )
+        else:
+            _DYNAMIC_EPLB = init_model_parallel_group(
+                group_ranks, get_world_group().local_rank, backend, group_name="dynamic_eplb"
+            )
 
     if get_ascend_config().multistream_overlap_gate:
         global _FC3_QUANT_X
-        _FC3_QUANT_X = init_model_parallel_group(
-            group_ranks, get_world_group().local_rank, backend, group_name="fc3_quant_x"
-        )
+        if enable_elastic_ep:
+            _FC3_QUANT_X = _init_stateless_group(
+                group_ranks,
+                "fc3_quant_x",
+                parallel_config.data_parallel_master_ip,
+                backend,
+                coord_store=coord_store,
+            )
+        else:
+            _FC3_QUANT_X = init_model_parallel_group(
+                group_ranks, get_world_group().local_rank, backend, group_name="fc3_quant_x"
+            )
 
     # Initialize fine-grained TP process groups on Ascend for four components:
     # 1. LM Head: output logits projection (`lmhead_tensor_parallel_size`)
@@ -119,6 +172,7 @@ def init_ascend_model_parallel(
             return None
         if group_size not in _group_cache:
             rank_grid = torch.arange(world_size).reshape(global_pp_size, global_dp_size, global_tp_size)
+            assert global_dp_size % group_size == 0 and global_dp_size >= group_size
             num_chunks = global_dp_size // group_size
             group_ranks = []
             for pp_idx in range(global_pp_size):
@@ -160,10 +214,9 @@ def init_ascend_model_parallel(
         _FLASHCOMM2_ODP = get_tp_group()
 
         if flashcomm2_otp_size > 1:
-            odp_group_ranks: list[list[int]] = [
-                [] for _ in range(flashcomm2_otp_size * global_dp_size * global_pp_size)
-            ]
-            for dp_group_index in range(global_dp_size):
+            dp_size = 1 if enable_elastic_ep else global_dp_size
+            odp_group_ranks: list[list[int]] = [[] for _ in range(flashcomm2_otp_size * dp_size * global_pp_size)]
+            for dp_group_index in range(dp_size):
                 for pp_group_index in range(global_pp_size):
                     dp_pp_serial_index = dp_group_index * global_pp_size + pp_group_index
                     tp_base_rank = dp_pp_serial_index * global_tp_size
@@ -224,6 +277,26 @@ def init_ascend_model_parallel(
             # For standard tp, use global tp group_ranks
             tp_group_ranks = all_ranks.view(-1, global_tp_size)
             _SHARD_WEIGHT = create_shard_weight_group(tp_group_ranks)
+
+
+def _replace_ascend_active_groups(
+    *,
+    mc2: GroupCoordinator | None,
+    dynamic_eplb: GroupCoordinator | None,
+    fc3_quant_x: GroupCoordinator | None,
+) -> None:
+    """Destroy the current DP/EP/WORLD/EPLB groups and replace them.
+
+    Destruction is collective — all ranks in the old groups must call this
+    function together.  Pass all-``None`` to tear down without replacement.
+    """
+    global _MC2, _DYNAMIC_EPLB, _FC3_QUANT_X
+    for group in (_MC2, _DYNAMIC_EPLB, _FC3_QUANT_X):
+        if group is not None:
+            group.destroy()
+    _MC2 = mc2
+    _DYNAMIC_EPLB = dynamic_eplb
+    _FC3_QUANT_X = fc3_quant_x
 
 
 def model_parallel_initialized():

--- a/vllm_ascend/distributed/utils.py
+++ b/vllm_ascend/distributed/utils.py
@@ -1,7 +1,17 @@
+import threading
+from contextlib import contextmanager
+from unittest.mock import patch
+
 import torch
 import torch.distributed as dist
+from torch.distributed import ProcessGroup, Store
+from torch.distributed.distributed_c10d import BackendConfig, _world
 from vllm.distributed import get_dcp_group
 from vllm.distributed.parallel_state import GroupCoordinator, get_dp_group
+from vllm.distributed.stateless_coordinator import (
+    stateless_destroy_torch_distributed_process_group,
+    stateless_init_torch_distributed_process_group,
+)
 from vllm.forward_context import get_forward_context
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
@@ -57,6 +67,66 @@ def all_gather_async(
         output_size = (input_size[0] * group.world_size,) + input_size[1:]
         output = torch.empty(output_size, dtype=input.dtype, device=input.device)
     return output, dist.all_gather_into_tensor(output, input, group=group.device_group, async_op=async_op)
+
+
+def stateless_init_pg_with_world_registration(**kwargs) -> ProcessGroup | tuple[ProcessGroup, Store]:
+    # Initializes a ProcessGroup and registers it into PyTorch's global `_world` state.
+    # This is required for operations like `dist.P2POp` that need global metadata.
+    if kwargs.get("return_store", False):
+        pg, store = stateless_init_torch_distributed_process_group(**kwargs)
+    else:
+        pg = stateless_init_torch_distributed_process_group(**kwargs)
+
+    if kwargs["backend"] == "hccl":
+        backend = "hccl"
+        prefix_store = pg.get_group_store()
+        group_name = pg.group_name
+        backend_config = BackendConfig(backend)
+
+        # Register process group to PyTorch's global _world state
+        # Required for: dist.P2POp, dist.batch_isend_irecv, and other ops that query _world.pg_map
+        _world.pg_group_ranks[pg] = {i: i for i in range(pg.size())}
+        _world.pg_map[pg] = (backend, prefix_store)
+        _world.pg_names[pg] = group_name
+        _world.pg_backend_config[pg] = str(backend_config)
+
+        if "WORLD" in group_name:
+            _world.default_pg = pg
+
+    if kwargs.get("return_store", False):
+        return pg, store
+    else:
+        return pg
+
+
+def stateless_destroy_pg_with_world_cleanup(pg: ProcessGroup) -> None:
+    # Destroys the ProcessGroup and cleans up its entries from the global `_world` state.
+    stateless_destroy_torch_distributed_process_group(pg)
+
+    # Remove related attributes from _world
+    _world.pg_map.pop(pg, None)
+    _world.pg_names.pop(pg, None)
+    _world.pg_group_ranks.pop(pg, None)
+    _world.pg_backend_config.pop(pg, None)
+
+
+_PATCH_LOCK = threading.Lock()
+
+
+@contextmanager
+def use_stateless_pg_with_world_registration():
+    with (
+        _PATCH_LOCK,
+        patch(
+            "vllm.distributed.stateless_coordinator.stateless_init_torch_distributed_process_group",
+            new=stateless_init_pg_with_world_registration,
+        ),
+        patch(
+            "vllm.distributed.stateless_coordinator.stateless_destroy_torch_distributed_process_group",
+            new=stateless_destroy_pg_with_world_cleanup,
+        ),
+    ):
+        yield
 
 
 def split_tensor_along_first_dim(

--- a/vllm_ascend/eplb/adaptor/vllm_adaptor.py
+++ b/vllm_ascend/eplb/adaptor/vllm_adaptor.py
@@ -19,11 +19,11 @@ import json
 from typing import Any
 
 import torch
-import torch.distributed as dist
 from vllm.logger import logger
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.quantization.quant_type import QuantType
+from vllm_ascend.distributed.parallel_state import get_dynamic_eplb_group
+from vllm_ascend.quantization.methods.base import QuantType
 
 EPLB_EXPERT_WEIGHT_NAMES = {
     (QuantType.NONE, False): ("w13_weight", "w2_weight"),
@@ -77,8 +77,8 @@ class VllmEplbAdaptor:
         else:
             self.model = model
             self.config = model.config
-        self.rank_id = dist.get_rank()
-        self.world_size = dist.get_world_size()
+        self.rank_id = get_dynamic_eplb_group().rank_in_group
+        self.world_size = get_dynamic_eplb_group().world_size
         self.num_dense_layers = getattr(self.config, "first_k_dense_replace", 0)
 
         self.moe_layers = VllmEplbAdaptor._registered_moe_layers

--- a/vllm_ascend/eplb/eplb_updator.py
+++ b/vllm_ascend/eplb/eplb_updator.py
@@ -15,6 +15,8 @@
 # This file is a part of the vllm-ascend project.
 #
 # Todo: Once https://github.com/vllm-project/vllm/issues/22246 is merged in vllm. Remove this updator.
+import os
+
 import numpy
 import torch
 import torch.distributed as dist
@@ -33,23 +35,23 @@ class EplbUpdator:
     def __init__(self, eplb_config, loader: D2DExpertWeightLoader, eplb_process: EplbProcess, process):
         self.eplb_config = eplb_config
         self.multi_stage = eplb_config.eplb_policy_type == 3
+        self.comm_group = get_dynamic_eplb_group()
         self.init_eplb(self.eplb_config.expert_map_path, process)
         self.eplb_loader = loader
         self.eplb_process = eplb_process
         self.shared_dict = self.eplb_process.shared_dict
-        self.comm_group = get_dynamic_eplb_group()
 
     def set_adaptor(self, adaptor: VllmEplbAdaptor):
         self.pp_rank = get_pp_group().rank_in_group
         self.adaptor = adaptor
         self.num_moe_layers = self.adaptor.num_moe_layers
         local_load = self.adaptor.get_rank_expert_workload()
-        self.world_size = dist.get_world_size()
+        self.world_size = self.comm_group.world_size
         self.device = local_load.device
         self.eplb_loader.num_layers = self.adaptor.num_dense_layers + self.adaptor.num_moe_layers
 
     def init_eplb(self, expert_map_path, process):
-        self.rank_id = dist.get_rank()
+        self.rank_id = self.comm_group.rank_in_group
         self.num_expert_load_gather = 10
         self.periodic_load_gather = True
         self.expert_heat_collection_interval: torch.int64 = self.eplb_config.expert_heat_collection_interval
@@ -155,10 +157,14 @@ class EplbUpdator:
         return moe_load
 
     def warm_up_eplb(self):
-        logger.info("[eplb/updator] Starting EPLB warm-up, rank=%s, world_size=%s", self.rank_id, self.world_size)
-        self.shared_dict["expert_maps"] = self.adaptor.get_global_expert_map()
-        self.compute_and_set_moe_load()
+        global_expert_map = self.adaptor.get_global_expert_map()
+        if self.shared_dict["expert_maps"] is None:
+            self.shared_dict["expert_maps"] = global_expert_map
 
+        if os.environ.get("VLLM_ELASTIC_EP_SCALE_UP_LAUNCH") == "1":
+            return
+
+        self.compute_and_set_moe_load()
         src_tensor = torch.empty((1,), device=self.device)
 
         comm_op_list = []

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 # ruff: noqa: E501
+import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from functools import wraps
@@ -419,7 +420,8 @@ else:
                 self.num_iter = eplb_config.expert_heat_collection_interval
                 self.moe_load = torch.zeros((self.num_iter, local_num_experts), dtype=torch.int32, device="npu")
 
-            setup_moe_comm_method(self.moe_config)
+            if os.environ.get("VLLM_ELASTIC_EP_SCALE_UP_LAUNCH") != "1":
+                setup_moe_comm_method(self.moe_config)
             if self.multistream_overlap_shared_expert:
                 # Wrap the quant_method's process_weights_after_loading to validate that
                 # splitting shared expert computation (gate_up projection + activation,

--- a/vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py
@@ -23,6 +23,8 @@ vllm_ascend.ops.fused_moe.fused_moe only.
 
 from __future__ import annotations
 
+import os
+
 from vllm_ascend.ops.fused_moe.fused_moe import (
     _EXTRA_CTX,
     AllGatherCommImpl,
@@ -152,7 +154,18 @@ class AscendFusedMoE(FusedMoE):
         tid2eid = kwargs.pop("tid2eid") if "tid2eid" in kwargs else None
 
         self._original_routed_scaling_factor = kwargs.get("routed_scaling_factor", 1.0)
-        super().__init__(*args, **kwargs)
+        """
+        Set `enable_eplb` to False for skipping the assertion requiring total experts to be divisible by EP size in
+        initialization of `FusedMoE` when enable Elastic EP, as the number of redundant expert differs between
+        `AscendFusedMoE and `FusedMoE`.
+        """
+        if get_current_vllm_config().parallel_config.enable_elastic_ep:
+            enable_eplb = kwargs.pop("enable_eplb", False)
+            super().__init__(*args, **kwargs, enable_eplb=False)
+            if enable_eplb:
+                kwargs["enable_eplb"] = enable_eplb
+        else:
+            super().__init__(*args, **kwargs)
         self.use_overlapped = True
         self._routed_input_transform = kwargs.get("routed_input_transform")
         self._shared_experts = kwargs.get("shared_experts")
@@ -274,8 +287,8 @@ class AscendFusedMoE(FusedMoE):
 
         self.enable_shared_expert_dp = ascend_config.enable_shared_expert_dp
         self.enable_npugraph_ex_static_kernel = ascend_config.ascend_compilation_config.enable_static_kernel
-
-        setup_moe_comm_method(self.moe_config)
+        if os.environ.get("VLLM_ELASTIC_EP_SCALE_UP_LAUNCH") != "1":
+            setup_moe_comm_method(self.moe_config)
         self.quant_type = self._get_quant_type()
 
         self.runner = AscendMoERunner(

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -103,7 +103,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         super().__init__(**kwargs)
         device_group = get_mc2_group().device_group
         # TODO: Try local_rank = ep_group.rank_in_group
-        local_rank = torch.distributed.get_rank(group=device_group)
+        local_rank = get_mc2_group().rank_in_group
         backend = device_group._get_backend(torch.device("npu"))
         self.moe_all_to_all_group_name = backend.get_hccl_comm_name(local_rank)
         self.ep_rank_id = get_mc2_group().rank_in_group
@@ -467,7 +467,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
             )
 
         # TODO: Try local_rank = ep_group.rank_in_group
-        local_rank = torch.distributed.get_rank(group=self.ep_group)
+        local_rank = get_ep_group().rank_in_group
         backend = self.ep_group._get_backend(torch.device("npu"))
         self.moe_all_to_all_group_name = backend.get_hccl_comm_name(local_rank)
 

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -19,12 +19,14 @@ from __future__ import annotations
 
 import math
 import os
+from datetime import timedelta
 from importlib import import_module, util
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 import torch
 import vllm.envs as envs_vllm
+from torch.distributed.distributed_c10d import Backend, PrefixStore, ProcessGroup
 from vllm.logger import logger
 from vllm.platforms import Platform, PlatformEnum
 
@@ -1243,6 +1245,79 @@ class NPUPlatform(Platform):
     @classmethod
     def use_custom_op_collectives(cls) -> bool:
         return True
+
+    @classmethod
+    def stateless_init_device_torch_dist_pg(
+        cls,
+        backend: str,
+        prefix_store: PrefixStore,
+        group_rank: int,
+        group_size: int,
+        timeout: timedelta,
+    ) -> ProcessGroup:
+        """
+        Initialize a stateless HCCL process group for Ascend NPU.
+        This method creates a ProcessGroup with the specified backend configuration,
+        typically used for NPU communication via HCCL. It sets up the necessary
+        backend options and registers the backend with the process group.
+        Args:
+            backend: The distributed backend to use. Currently only 'hccl' is
+                supported for Ascend NPUs.
+            prefix_store: The prefix store for distributed coordination.
+            group_rank: The rank of the current process within the group.
+            group_size: The total number of processes in the group.
+            timeout: Maximum time to wait for the operation to complete.
+        Warning:
+            Uses internal PyTorch NPU API (torch_npu._C._distributed_c10d.ProcessGroupHCCL)
+            which may change in future PyTorch / torch_npu versions. Compatibility
+            should be verified with each upgrade.
+        Compatibility Risk:
+            - High risk of breakage in future PyTorch / torch_npu releases.
+            - No semantic versioning guarantees for internal APIs.
+            - Requires testing with new PyTorch / torch_npu releases.
+        Returns:
+            A ProcessGroup object configured with the specified backend.
+        """
+
+        # INTERNAL API USAGE - COMPATIBILITY RISK
+        # This internal import is necessary for stateless process group functionality
+        # but carries compatibility risks. Monitor PyTorch release notes for changes.
+        # TODO: Migrate to public API when available in future PyTorch versions
+        from torch_npu._C._distributed_c10d import ProcessGroupHCCL
+        import uuid
+
+        pg = ProcessGroup(prefix_store, group_rank, group_size)
+
+        backend_options = ProcessGroupHCCL.Options()
+        backend_options._timeout = timeout
+
+        # Create Backend object
+        backend = Backend("hccl")
+
+        # Set default backend for ProcessGroup
+        pg._set_default_backend(Backend.backend_type_map[backend])
+
+        device = torch.device("npu")
+        if hasattr(backend_options, "_device"):
+            backend_options._device = device
+
+        backend_class = ProcessGroupHCCL(prefix_store, group_rank, group_size, backend_options)
+
+        backend_class._set_sequence_number_for_group()
+        backend_type = ProcessGroup.BackendType.CUSTOM
+        pg._register_backend(device, backend_type, backend_class)
+        hccl_comm_name = None
+        if group_rank == 0:
+            hccl_comm_name = uuid.uuid4().hex
+            pg.get_group_store().set("hccl_comm_name", hccl_comm_name)
+        else:
+            hccl_comm_name = pg.get_group_store().get("hccl_comm_name").decode("utf-8")
+        if hccl_comm_name is not None:
+            group_desc = "undefined"
+            backend_class._set_hccl_comm_name(hccl_comm_name)
+            pg._set_group_desc(group_desc)
+
+        return pg
 
     @classmethod
     def manual_seed_all(cls, seed: int) -> None:

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+import os
 from collections.abc import Callable
 from typing import Any
 
@@ -366,14 +366,15 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
         if self.new_quant_version and self.tp_size > 16:
             raise ValueError("The current weight does not support moe part tp>16.")
 
-        try:
-            device_group = get_mc2_group().device_group
-            # TODO: Try local_rank = ep_group.rank_in_group
-            local_rank = torch.distributed.get_rank(group=device_group)
-            backend = device_group._get_backend(torch.device("npu"))
-            self.moe_all_to_all_group_name = backend.get_hccl_comm_name(local_rank)
-        except AttributeError:
-            self.moe_all_to_all_group_name = ""
+        if os.environ.get("VLLM_ELASTIC_EP_SCALE_UP_LAUNCH") != "1":
+            try:
+                device_group = get_mc2_group().device_group
+                # TODO: Try local_rank = ep_group.rank_in_group
+                local_rank = get_mc2_group().rank_in_group
+                backend = device_group._get_backend(torch.device("npu"))
+                self.moe_all_to_all_group_name = backend.get_hccl_comm_name(local_rank)
+            except AttributeError:
+                self.moe_all_to_all_group_name = ""
 
     def get_weight(
         self, num_experts: int, intermediate_size_per_partition: int, hidden_sizes: int, params_dtype: torch.dtype

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import os
 from collections.abc import Callable
 from typing import Any
 
@@ -172,18 +173,19 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
         self.in_dtype = vllm_config.model_config.dtype
         self.supports_eplb = True
 
-        try:
-            device_group = get_mc2_group().device_group
-            # TODO: Try local_rank = ep_group.rank_in_group
-            local_rank = torch.distributed.get_rank(group=device_group)
-            backend = device_group._get_backend(torch.device("npu"))
-            self.moe_all_to_all_group_name = backend.get_hccl_comm_name(local_rank)
-        except AttributeError:
-            logger.warning_once(
-                "[vllm-ascend/W8A8_DYNAMIC] MC2 group metadata unavailable, "
-                "falling back to empty moe_all_to_all_group_name."
-            )
-            self.moe_all_to_all_group_name = ""
+        if os.environ.get("VLLM_ELASTIC_EP_SCALE_UP_LAUNCH") != "1":
+            try:
+                device_group = get_mc2_group().device_group
+                # TODO: Try local_rank = ep_group.rank_in_group
+                local_rank = torch.distributed.get_rank(group=device_group)
+                backend = device_group._get_backend(torch.device("npu"))
+                self.moe_all_to_all_group_name = backend.get_hccl_comm_name(local_rank)
+            except AttributeError:
+                logger.warning_once(
+                    "[vllm-ascend/W8A8_DYNAMIC] MC2 group metadata unavailable, "
+                    "falling back to empty moe_all_to_all_group_name."
+                )
+                self.moe_all_to_all_group_name = ""
 
     def get_weight(
         self, num_experts: int, intermediate_size_per_partition: int, hidden_sizes: int, params_dtype: torch.dtype

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -254,7 +254,7 @@ class BlockTable:
         self.block_table.copy_to_gpu(num_reqs)
 
     def clear(self) -> None:
-        self.block_table.fill_(0)
+        self.block_table.gpu.fill_(0)
         self.block_table.cpu.fill_(0)
 
     def _convert_physical_to_logical_blocks(self, physical_blocks: np.ndarray) -> np.ndarray:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1054,7 +1054,7 @@ class NPUModelRunner(GPUModelRunner):
         self.num_discarded_requests = len(discard_request_indices)
         self.discard_request_indices.np[: self.num_discarded_requests] = discard_request_indices
         self.discard_request_indices.copy_to_gpu(self.num_discarded_requests)
-        
+
         self.discard_request_mask.np[:num_reqs] = discard_requests_mask
         self.discard_request_mask.copy_to_gpu(num_reqs)
 
@@ -1661,7 +1661,7 @@ class NPUModelRunner(GPUModelRunner):
         # Initialize a new stream to overlap the copy operation with
         # prepare_input of draft model.
         default_stream = torch.npu.current_stream()
-        with torch.npu.stream(self.valid_sampled_token_count_copy_stream): 
+        with torch.npu.stream(self.valid_sampled_token_count_copy_stream):
             self.valid_sampled_token_count_copy_stream.wait_stream(default_stream)
             counts = valid_sampled_tokens_count
             counts_cpu = self.valid_sampled_token_count_cpu
@@ -1958,7 +1958,7 @@ class NPUModelRunner(GPUModelRunner):
                 self._execution_start_time = time.perf_counter()
         if self.execute_model_state is not None:
             raise RuntimeError("State error: sample_tokens() must be called after execute_model() returns None.")
-       
+
         # If ngram_gpu is used, we need to copy the scheduler_output to avoid
         # the modification has influence on the scheduler_output in engine core process.
         # The replace is much faster than deepcopy.
@@ -2557,7 +2557,7 @@ class NPUModelRunner(GPUModelRunner):
                     slot_mapping=self.routed_experts_slot_mapping_cpu[:total].numpy(),
                 )
             return model_runner_output
-        
+
         # Async path: produce a device-side snapshot that the async
         # copy stream can D2H later. Both tensors must be private
         # clones because:
@@ -3438,10 +3438,10 @@ class NPUModelRunner(GPUModelRunner):
             # pad is needed if the pad of `num_tokens` is triggered inside CudagraphDispatcher
             num_tokens_across_dp[:] = num_tokens_padded
             num_scheduled_tokens = num_scheduled_tokens.repeat(num_reqs_padded)
-        
+
         if self.dynamic_eplb:
             self.update_eplb_heat_collection_status(num_tokens_padded)
-        
+
         # vllm-ascend does not support ubatch now
         ubatch_slices, ubatch_slices_padded = None, None
         attn_metadata: PerLayerAttnMetadata | None = None
@@ -3640,7 +3640,6 @@ class NPUModelRunner(GPUModelRunner):
         return output
 
     def profile_run(self) -> None:
-        self.eplb_warmup()
         mc2_tokens_capacity = get_mc2_tokens_capacity()
         if self.max_num_tokens > mc2_tokens_capacity and select_moe_comm_method(
             mc2_tokens_capacity, self.vllm_config
@@ -3673,7 +3672,7 @@ class NPUModelRunner(GPUModelRunner):
             # collect eplb heat for all requests.
             self.eplb_heat_collection_status =  True
 
-    def load_model(self) -> None:
+    def load_model(self, load_dummy_weights: bool = False) -> None:
         load_model_start_time = time.perf_counter()
         logger.info("Starting to load model %s...", self.model_config.model)
 
@@ -3691,7 +3690,9 @@ class NPUModelRunner(GPUModelRunner):
                     return
                 from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
                 DefaultModelLoader._init_ep_weight_filter = mock_pass
-            self.model: nn.Module = get_model(vllm_config=self.vllm_config)
+            if load_dummy_weights:
+                self.load_config.load_format = "dummy"
+            self.model: nn.Module = get_model(vllm_config=self.vllm_config, load_config=self.load_config)
             for name, _ in self.model.named_parameters():
                 # sinks is a kind of parameter in attention
                 # only set in weight name
@@ -4120,7 +4121,7 @@ class NPUModelRunner(GPUModelRunner):
                         kv_cache_spec = layer_kv_cache_spec[layer_name]
                         current_sparse_c8 = kv_cache_spec_uses_sparse_c8(kv_cache_spec)
                         sparse_kv_cache_ratio = kv_cache_spec.sparse_kv_cache_ratio
-                        
+
                         # A5 sparse C8: (ckv_ratio, qli_ratio, qli_scale_ratio, None)
                         # A3 sparse C8: (k_ratio, v_ratio, qli_ratio, qli_scale_ratio)
                         if current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
@@ -4520,11 +4521,11 @@ class NPUModelRunner(GPUModelRunner):
                         k_cache_dtype, v_cache_dtype = self.vllm_config.quant_config.get_kv_quant_dtype(
                             layer_name, current_kv_cache_spec.dtype, self.model_config
                         )
-                    
+
                     # A5 sparse C8: ckv uses float8_e4m3fn
                     if self.use_sparse and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
                         k_cache_dtype = self.c8_k_cache_dtype
-                    
+
                     k_cache = raw_k_tensor.view(k_cache_dtype).view(k_shape)
                     if self.use_sparse and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
                         v_cache = None
@@ -4976,7 +4977,7 @@ class NPUModelRunner(GPUModelRunner):
 
         # NOTE: This is a serious problem that we maintain two extra copies of the KV cache as the instance
         # variable of the attention layers, when they are local variables in the upstream vLLM code.
-        # We have to manually clear them here to release memory after profiling. 
+        # We have to manually clear them here to release memory after profiling.
         for layer in self.compilation_config.static_forward_context.values():
             if hasattr(layer, "impl"):
                 if hasattr(layer.impl, "key_cache"):

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -61,6 +61,7 @@ from vllm_ascend.cpu_binding import bind_cpus
 from vllm_ascend.device_allocator.camem import CaMemAllocator
 from vllm_ascend.device_allocator.sleep_mem_optimized import SleepWakeupManager
 from vllm_ascend.distributed.parallel_state import init_ascend_model_parallel
+from vllm_ascend.distributed.utils import use_stateless_pg_with_world_registration
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
 from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
 from vllm_ascend.utils import (
@@ -130,6 +131,12 @@ class NPUWorker(WorkerBase):
             distributed_init_method=distributed_init_method,
             is_driver_worker=is_driver_worker,
         )
+
+        from vllm_ascend.distributed.elastic_ep.elastic_execute import AscendElasticEPScalingExecutor
+
+        self.elastic_ep_executor: AscendElasticEPScalingExecutor | None = None
+        if self.parallel_config.enable_elastic_ep:
+            self.elastic_ep_executor = AscendElasticEPScalingExecutor(self)
 
         if self.cache_config.cache_dtype == "auto":
             self.cache_dtype = self.model_config.dtype
@@ -443,7 +450,8 @@ class NPUWorker(WorkerBase):
             )
 
         # Initialize the distributed environment.
-        self._init_worker_distributed_environment()
+        with use_stateless_pg_with_world_registration():
+            self._init_worker_distributed_environment()
         # Set random seed.
         set_random_seed(self.model_config.seed)
         # Initialize device properties used by triton kernels.
@@ -685,7 +693,7 @@ class NPUWorker(WorkerBase):
     def sample_tokens(self, grammar_output: "GrammarOutput") -> ModelRunnerOutput | AsyncModelRunnerOutput:
         return self.model_runner.sample_tokens(grammar_output)
 
-    def load_model(self) -> None:
+    def load_model(self, *, load_dummy_weights: bool = False) -> None:
         if self.vllm_config.model_config.enable_sleep_mode:
             allocator = CaMemAllocator.get_instance()
             assert allocator.get_current_usage() == 0, "Sleep mode can only be used for one instance per process."
@@ -696,7 +704,11 @@ class NPUWorker(WorkerBase):
             context = nullcontext()  # type: ignore
 
         with context, set_current_vllm_config(self.vllm_config):
-            self.model_runner.load_model()
+            self.model_runner.load_model(load_dummy_weights)
+
+        self.model_runner.eplb_warmup()
+        if self.parallel_config.enable_elastic_ep:
+            self.elastic_ep_executor.init_eplb_manager()
 
         if self.vllm_config.weight_transfer_config is not None:
             from vllm.distributed.weight_transfer.factory import (
@@ -1049,6 +1061,11 @@ class NPUWorker(WorkerBase):
         except Exception as e:
             logger.error("query NPU card %s fail: %s", self.local_rank, e)
         return
+
+    def elastic_ep_execute(self, execute_method: str, *args, **kwargs):
+        if self.elastic_ep_executor is None:
+            raise ValueError("No Elastic EP Executor found")
+        return self.elastic_ep_executor.execute(execute_method, *args, **kwargs)
 
 
 def parse_text_output(output) -> None:

--- a/vllm_ascend/xlite/xlite_model_runner.py
+++ b/vllm_ascend/xlite/xlite_model_runner.py
@@ -29,7 +29,7 @@ class XliteModelRunner(NPUModelRunner):
             return super().get_model()
         return self.xlite_model.unwrap()
 
-    def load_model(self) -> None:
+    def load_model(self, load_dummy_weights=False) -> None:
         from vllm_ascend.xlite.xlite import XliteWrapper
 
         super().load_model()


### PR DESCRIPTION
## What this PR does / why we need it?
This PR introduces the adaptation for vLLM's feature — [Elastic EP Milestone 2](https://github.com/vllm-project/vllm/issues/20323) on the Ascend side. This feature [#34861](https://github.com/vllm-project/vllm/pull/34861) has been recently merged into vLLM.

### **Key contributions**

1. Added an `AscendElasticEPScalingExecutor` class inheriting from `ElasticEPScalingExecutor` to implement vLLM Ascend operations during elastic scaling;

2. Under the `--enable-elastic-ep` argument, replaced vLLM Ascend-specific communication group coordinators (such as MC2) from `GroupCoordinator` to `StatelessGroupCoordinator`. Additionally, added port allocation and creation methods for these stateless groups in `NPUPlatform`;

3. Implemented creation of standby communication group coordinators via `vllm_ascend/distributed/standby_state.py`;

4. Refactored the vLLM Ascend EPLB module to support expert rebalancing during elastic scaling.

### **Why this is needed**
Currently, expert parallelism in vllm_ascend is **static** after deployment. This PR lays the foundation for **dynamically scaling up and down expert parallelism**, adapting based on existing vLLM features without modifying the vLLM codebase.

---
## Does this PR introduce _any_ user-facing change?
No. Only the interfaces for enabling vLLM Elastic EP and vLLM Ascend EPLB are required. There are no new or changed interface

---

## **Summary per file**
| File | Description |
| :--- | :--- |
| `vllm_ascend/worker/worker.py` | Provides execution hooks for AscendElasticEPScalingExecutor, supporting virtual weight loading during scale-up |
| `vllm_ascend/worker/model_runner_v1.py` | Supports virtual weight loading during scale-up, extends EPLB shared state |
| `vllm_ascend/platform.py` | Adds stateless HCCL ProcessGroup initialization method |
| `vllm_ascend/ops/fused_moe/fused_moe.py` | Allows skipping MoE communication setup during AscendFusedMoE initialization during scaling |
| `vllm_ascend/distributed/elastic_ep/elastic_execute.py` | Implements the AscendElasticEPScalingExecutor class to handle operations during elastic scaling |
| `vllm_ascend/distributed/elastic_ep/standby_state.py` | Creates standby communication group coordinators for retained engines during elastic scaling |
| `vllm_ascend/distributed/parallel_state` | Creates stateless communication group coordinators for vLLM Ascend DP domain when elastic scaling is enabled |
| `vllm_ascend/eplb/core/policy/policy_default_eplb.py` | Adds EP-size setting for expert rebalancing calculation in elastic scenarios, modifies redundant packing, and adds duplicate removal logic |
| `vllm_ascend/eplb/core/eplb_worker.py` | Adds support for Elastic EP scenarios |
| `vllm_ascend/distributed/utils.py` | Implements stateless ProcessGroup initialization with automatic global `_world` registration and cleanup |

## Limitations
Introduced by vLLM Elastic Expert Parallelism (Elastic EP) Limitations:

- The original Elastic EP design only supports Ray as the data-parallel-backend.
- Only support internal-LB mode.
- The api-count must be 1 as per the Elastic EP specifications.

Introduced by adaptation, all2all kernels and EPLB:

- The adaptation is limited to Ascend A3 devices only.
- For quantized formats:
  - W8A8 supports all2all_v and MC2 operators.
  - BF16 format supports only MC2 and FusedMC2 operators.

## How was this patch tested?
### **Models tested**
 - Qwen3-30B-A3B
 - Qwen3-30B-A3B-W8A8
### **Test environment (manual elastic scale up/down)**
 - Single node (Ascend A3)
 - Multiple NPUs
 - Ray used for DP Backend
### **Workflow**  

1. Start vLLM online serve
```bash
python vllm.entrypoints.openai.api_server \
    --model <model path> \
    --trust-remote-code \
    --enable-expert-parallel \
    --enable-eplb \
    --enable-elastic-ep \
    --tensor-parallel-size 1 \
    --data-parallel-size <dp size> \
    --data-parallel-size-local <dp size> \
    --data-parallel-start-rank 0 \
    --data-parallel-backend ray \
    --api-server-count 1 \
    --gpu-memory-utilization 0.9 \
    --host 0.0.0.0 \
    --port <port> \
    --additional-config "{"eplb_config": {"dynamic_eplb": true, "num_redundant_experts": <num redundant experts>}}"
    (optional) --enforce-eager 
```
2. Use scale script from vLLM
``` bash
python vllm/examples/online_serving/elastic_ep/scale.py --host 0.0.0.0 --port <port> --new-dp-size <new dp size>
```
3. Send requests to vLLM instance to verify requests can run

### **Test scenarios**  
TP = 1
| dp size scale | Result |
|------|--------|
| dp16→dp8→dp7→dp4→dp3→dp2 (eager, graph mode) | Scale down and serve requests successfully |
| dp4→dp8→dp16 (eager, graph mode) | Scale up and serve requests successfully |
| dp4→dp8→dp7→dp16 (eager, graph mode) | Scale up and down repeatedly and serve requests successfully |

### **Acknowledgements**

- The code was primarily implemented by **@1542305589**.
- We would like to thank **@njuyuan** and **@a798347923** for their suggestions and review feedback.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
