### PR TITLE
[BugFix][KVCache] Update num_layers to include MTP/spec-decode draft layers

### DIFF
--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -118,7 +118,7 @@ class TestChunkedTokenDatabase(unittest.TestCase):
     def setUp(self):
         self.meta = KeyMetadata("llama", 0, 0, 0, 0)
         self.db = ChunkedTokenDatabase([self.meta], block_size=[16], partitions=None)
-        self.db.set_group_buffers({0: [1000, 2000]}, {0: [160, 320]})
+        self.db.set_group_buffers({0: [1000, 2000]}, {0: [160, 320]}, group_num_layers={0: 1})
 
     def test_make_key_by_hash(self):
         key = self.db._make_key_by_hash("abc")
@@ -231,9 +231,9 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         addr, size, block_id = self.db.prepare_value_layer(0, 16, [5, 6], layer_id=0)
         self.assertEqual(block_id, 5)
         self.assertEqual(len(addr), 2)
-        # layer_id=0 => kv_caches_base_addr[0*2] and [0*2+... index mod length]
+        # layer_id=0, entries_per_layers=2 => group_addrs[0] and group_addrs[1]
         self.assertEqual(addr[0], 1000 + 5 * 160)
-        self.assertEqual(addr[1], 1000 + 5 * 320)
+        self.assertEqual(addr[1], 2000 + 5 * 320)
 
     def test_decode_adaptor_prefill_pp_no_partitions(self):
         key, addr, size = self.db.decode_adaptor_prefill_pp(["k1"], [[1, 2]], [[10, 20]])

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -336,7 +336,10 @@ class ChunkedTokenDatabase:
         size_list: list[int] = []
         group_block_size = self.get_block_size(kv_cache_group_id)
         if block_id is None:
-            block_id = block_ids[start // group_block_size]
+            block_idx = start // group_block_size
+            if block_idx >= len(block_ids):
+                return addr_list, size_list, 0
+            block_id = block_ids[block_idx]
         group_addrs, group_block_len, group_block_stride = self._get_group_buffers(kv_cache_group_id, cache_role)
         length = len(group_block_len)
         if length == 0:
@@ -352,15 +355,23 @@ class ChunkedTokenDatabase:
 
     def prepare_value_layer(self, start: int, end: int, block_ids: list[int], layer_id: int):
         group_block_size = self.get_block_size(0)
-        block_id = block_ids[start // group_block_size]
+        block_idx = start // group_block_size
+        if block_idx >= len(block_ids):
+            return [], [], 0
+        block_id = block_ids[block_idx]
         addr_list: list[int] = []
         size_list: list[int] = []
         group_addrs, group_block_len, group_block_stride = self._get_group_buffers(0)
-        length = len(group_block_len)
-        for i in range(length):
-            block_stride = group_block_stride[i] if group_block_stride else group_block_len[i]
-            addr = group_addrs[layer_id * length] + block_id * block_stride
-            size = int(group_block_len[i] / group_block_size * (end - start))
+        num_layers = self.group_num_layers.get("kv", {}).get(0, 1)
+        entries_per_layer = len(group_addrs) // num_layers if num_layers else 0
+        if layer_id >= num_layers or entries_per_layer == 0:
+            return [], [], 0
+        start_idx = layer_id * entries_per_layer
+        for i in range(entries_per_layer):
+            idx = start_idx + i
+            block_stride = group_block_stride[idx] if group_block_stride else group_block_len[idx]
+            addr = group_addrs[idx] + block_id * block_stride
+            size = int(group_block_len[idx] / group_block_size * (end - start))
             addr_list.append(addr)
             size_list.append(size)
         return addr_list, size_list, block_id

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -89,7 +89,8 @@ class KVTransferThread(threading.Thread):
                 self._handle_request(request_data)
             except Exception as e:
                 logger.error(
-                    "Error in KVCacheTransferThread. type=%s, error=%s. Check thread state and request processing.",
+                    "Error in KVCacheTransferThread(%s). type=%s, error=%s. Check thread state and request processing.",
+                    self.name,
                     type(e).__name__,
                     e,
                 )

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -436,6 +436,18 @@ class KVPoolWorker:
         else:
             self._infer_cache_group_metadata(0, list(kv_caches.keys()))
 
+        # group_num_layers is computed from the actual kv_caches dict which
+        # includes ALL attention layers (main + MTP), so it is the authoritative
+        # layer count for this worker.
+        original_num_layers = self.num_layers
+        self.num_layers = sum(self.group_num_layers.values())
+        if self.num_layers != original_num_layers:
+            logger.info(
+                "KVPoolWorker: updated num_layers %d -> %d (includes MTP/spec-decode draft layers).",
+                original_num_layers,
+                self.num_layers,
+            )
+
         self.m_store.register_buffer(ptrs, lengths)
         self.token_database.set_group_buffers(
             self.group_kv_caches_base_addr,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -568,6 +568,8 @@ class KVPoolWorker:
                 block_id_list: list[int] = []
                 load_masks = self.token_database.load_mask(request.block_hashes, token_len)
                 for group_id in load_group_ids:
+                    if group_id >= len(request.block_ids_by_group):
+                        continue
                     block_ids = request.block_ids_by_group[group_id]
                     group_block_size = self.grouped_block_size[group_id]
                     mask_num = load_spec.vllm_cached_tokens // group_block_size * group_block_size
@@ -664,6 +666,12 @@ class KVPoolWorker:
         return invalid_blocks
 
     def save_kv_layer(self, connector_metadata: AscendConnectorMetadata) -> None:
+        # MTP speculative decoding re-runs the base model's attention layers
+        # during draft execution (_run_merged_draft), causing extra
+        # save_kv_layer calls beyond num_layers. These extra calls would
+        # exhaust the store_layer generators and raise StopIteration.
+        if self.current_layer >= self.num_layers:
+            return
         if self.current_layer == 0:
             self.layerwise_storers = []
             current_event = None


### PR DESCRIPTION
## What this PR does / why we need it?

`KVPoolWorker.num_layers` was not accounting for the MTP/spec-decode draft layer, causing a mismatch between the worker's layer count and the actual number of KV cache layers registered. For example, a 47-layer model with 1 MTP layer would report `num_layers=47` while 48 KV cache layers were actually registered.

This PR recalculates `num_layers` as the sum of `group_num_layers` (which is computed from the actual `kv_caches` dict including ALL attention layers: main + MTP), making it the authoritative layer count for the worker.

## Does this PR introduce _any_ user-facing change?

No. This only affects the internal `num_layers` accounting in `KVPoolWorker` for PD-disaggregated KV transfer with MTP/speculative decoding.

## How was this patch tested?

Tested on Atlas 800T A2 (Ascend 910B3) with glm-4.7-flash (MTP enabled, `num_nextn_predict_layers=1`) in PD-disaggregated mode with MooncakeLayerwiseConnector. Verified the log output:
```
KVPoolWorker: updated num_layers 47 -> 48 (includes MTP/spec-decode draft layers).
```

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/b9a7cd464c9ae9b1b450f8982b76d7be4de73724
