### PR TITLE
[Ops][Misc] Fix file header and include guard in hc_post_tiling

### DIFF
--- a/csrc/moe/hc_post/op_host/hc_post_tiling.cpp
+++ b/csrc/moe/hc_post/op_host/hc_post_tiling.cpp
@@ -9,7 +9,7 @@
  */
 
 /*!
- * \file gather_selection_kv_cache_tiling.cpp
+ * \file hc_post_tiling.cpp
  * \brief
  */
 

--- a/csrc/moe/hc_post/op_host/hc_post_tiling.h
+++ b/csrc/moe/hc_post/op_host/hc_post_tiling.h
@@ -109,4 +109,4 @@ private:
 
 } // namespace optiling
 
-#endif // GATHER_SELECTION_KV_CACHE_TILING_H_
+#endif // HC_POST_TILING_H_


### PR DESCRIPTION
### What this PR does / why we need it?
This PR corrects the file header comment in `hc_post_tiling.cpp` and the `#endif` include guard comment in `hc_post_tiling.h` to match the actual file names, replacing leftover references to `gather_selection_kv_cache_tiling`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No functional changes were made, so no new tests are required.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
