### PR TITLE
[Bugfix][310P] Fix GatherV2/scatter off-by-one corruption during MTP token shift

### DIFF
--- a/tests/ut/_310p/spec_decode/test_llm_base_proposer_310.py
+++ b/tests/ut/_310p/spec_decode/test_llm_base_proposer_310.py
@@ -1,0 +1,76 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+from unittest.mock import MagicMock
+
+import torch
+
+from vllm_ascend._310p.spec_decode.llm_base_proposer_310 import AscendSpecDecodeBaseProposer310
+
+
+def test_set_inputs_first_pass_310p_rotates_input_ids():
+    """Guard 310P MTP input_ids shift: rotate, preserve tail slot, write next tokens."""
+    device = torch.device("cpu")
+    num_tokens = 9
+    hidden_size = 8
+
+    proposer = AscendSpecDecodeBaseProposer310.__new__(AscendSpecDecodeBaseProposer310)
+    proposer.needs_extra_input_slots = False
+    proposer.uses_xdrope_dim = 0
+    proposer.draft_uses_xdrope_dim = 0
+    proposer.runner = MagicMock()
+    proposer.dtype = torch.float16
+    proposer.hidden_size = hidden_size
+
+    buffer_size = 16
+    proposer.input_ids = torch.full((buffer_size,), -1, dtype=torch.int32, device=device)
+    proposer.input_ids[num_tokens - 1] = 9999
+    proposer.positions = torch.zeros(buffer_size, dtype=torch.int64, device=device)
+    proposer.hidden_states = torch.zeros(buffer_size, hidden_size, dtype=torch.float16, device=device)
+
+    def _set_positions(num_tokens_to_set: int, positions: torch.Tensor) -> None:
+        proposer.positions[:num_tokens_to_set] = positions
+
+    proposer._set_positions = _set_positions
+
+    cad = MagicMock()
+    cad.query_start_loc = torch.tensor([0, 3, 5, 9], dtype=torch.int32, device=device)
+
+    target_token_ids = torch.tensor([10, 11, 12, 20, 21, 30, 31, 32, 33], dtype=torch.int32, device=device)
+    target_positions = torch.tensor([7, 8, 9, 6, 7, 8, 9, 10, 11], dtype=torch.int64, device=device)
+    target_hidden_states = torch.arange(num_tokens * hidden_size, dtype=torch.float16, device=device).view(
+        num_tokens, hidden_size
+    )
+    next_token_ids = torch.tensor([100, 200, 300], dtype=torch.int32, device=device)
+
+    out_num_tokens, out_token_indices, out_cad, long_seq_args = proposer.set_inputs_first_pass(
+        target_token_ids=target_token_ids,
+        next_token_ids=next_token_ids,
+        target_positions=target_positions,
+        target_hidden_states=target_hidden_states,
+        token_indices_to_sample=None,
+        cad=cad,
+        num_rejected_tokens_gpu=None,
+    )
+
+    assert out_num_tokens == num_tokens
+    assert torch.equal(out_token_indices, torch.tensor([2, 4, 8], dtype=torch.int32, device=device))
+    assert out_cad is cad
+    assert long_seq_args == (None, None)
+
+    expected_input_ids = torch.tensor([11, 12, 100, 21, 200, 31, 32, 33, 300], dtype=torch.int32, device=device)
+    assert torch.equal(proposer.input_ids[:num_tokens], expected_input_ids)
+    assert torch.equal(proposer.positions[:num_tokens], target_positions)
+    assert torch.equal(proposer.hidden_states[:num_tokens], target_hidden_states)

--- a/vllm_ascend/_310p/spec_decode/llm_base_proposer_310.py
+++ b/vllm_ascend/_310p/spec_decode/llm_base_proposer_310.py
@@ -17,6 +17,9 @@
 
 import numpy as np
 import torch
+from typing import Any
+
+from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.worker.gpu_input_batch import InputBatch
 from vllm.v1.worker.gpu_model_runner import CachedRequestState
 
@@ -58,3 +61,66 @@ class AscendSpecDecodeBaseProposer310(AscendSpecDecodeBaseProposer):
             self.backup_next_token_ids.gpu[:batch_size],
         )
         return next_token_ids, valid_sampled_tokens_count
+
+    def set_inputs_first_pass(
+        self,
+        target_token_ids: torch.Tensor,
+        next_token_ids: torch.Tensor,
+        target_positions: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        token_indices_to_sample: torch.Tensor | None,
+        cad: CommonAttentionMetadata,
+        num_rejected_tokens_gpu: torch.Tensor | None,
+        req_scheduled_tokens=None,
+        long_seq_metadata=None,
+        num_prefill_reqs=0,
+        num_decode_reqs=0,
+    ) -> tuple[int, torch.Tensor, CommonAttentionMetadata, tuple[Any, Any] | None]:
+        if not self.needs_extra_input_slots:
+            # 310P workaround for MTP:
+            # The NPU implementation of the slice assign
+            #   self.input_ids[:num_tokens-1] = target_token_ids[1:]
+            # can corrupt the tail element (index num_tokens-1) of the
+            # persistent drafter input_ids buffer. We save/restore it to
+            # avoid feeding garbage to the draft model or later GatherV2.
+            if token_indices_to_sample is None:
+                token_indices_to_sample = cad.query_start_loc[1:] - 1
+
+            num_tokens = target_token_ids.shape[0]
+
+            # Protected shift (310P specific)
+            tail_save = self.input_ids[num_tokens - 1].item()
+            self.input_ids[: num_tokens - 1] = target_token_ids[1:]
+            self.input_ids[num_tokens - 1] = tail_save
+
+            # Replace the last token with the next token.
+            self.input_ids[token_indices_to_sample] = next_token_ids
+
+            assert self.runner is not None
+
+            # 310P does not support PCP/DCP, so we skip all PCP handling.
+            ori_token_indices_to_sample = None
+            query_lens_d = None
+
+            if self.uses_xdrope_dim > 0 and self.draft_uses_xdrope_dim == 0:
+                target_positions = target_positions[0]
+
+            self._set_positions(num_tokens, target_positions)
+            self.hidden_states[:num_tokens] = target_hidden_states.view(num_tokens, -1)
+
+            return num_tokens, token_indices_to_sample, cad, (query_lens_d, ori_token_indices_to_sample)
+        else:
+            # For extra-slots path, delegate to base (different code path).
+            return super().set_inputs_first_pass(
+                target_token_ids,
+                next_token_ids,
+                target_positions,
+                target_hidden_states,
+                token_indices_to_sample,
+                cad,
+                num_rejected_tokens_gpu,
+                req_scheduled_tokens=req_scheduled_tokens,
+                long_seq_metadata=long_seq_metadata,
+                num_prefill_reqs=num_prefill_reqs,
+                num_decode_reqs=num_decode_reqs,
+            )

--- a/vllm_ascend/patch/worker/patch_idex_310.py
+++ b/vllm_ascend/patch/worker/patch_idex_310.py
@@ -25,6 +25,13 @@ AscendSpecDecodeBaseProposer.prepare_next_token_ids_padded = (  # type: ignore[m
     AscendSpecDecodeBaseProposer310.prepare_next_token_ids_padded
 )
 
+# 310P: protect tail slot during MTP input_ids shift to avoid GatherV2 corruption
+# caused by the NPU slice-assign writing one element past the intended range
+# on the persistent drafter input_ids buffer.
+AscendSpecDecodeBaseProposer.set_inputs_first_pass = (  # type: ignore[method-assign]
+    AscendSpecDecodeBaseProposer310.set_inputs_first_pass
+)
+
 # Patch _warmup_prefill_kernels to no-op on 310P: triton.next_power_of_2 does
 # not exist in the triton version used on 310P CI, and NPU does not use these
 # CUDA warmup kernel anyway.


### PR DESCRIPTION
### What this PR does / why we need it?
The 310P NPU GatherV2/scatter kernel has an off-by-one bug: when performing the slice assignment

  self.input_ids[: num_tokens - 1] = target_token_ids[1:]

  the scatter kernel writes past the specified slice boundary and corrupts the element at self.input_ids[num_tokens - 1] (the tail position).

  Later, self.input_ids[token_indices_to_sample] = next_token_ids overwrites the tail slot for most requests with newly sampled tokens. However, when the tail position is not covered by
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
