### PR TITLE
[Bugfix] fix preempted-then-resumed requests for using right num_tokens

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1044,15 +1044,6 @@ class NPUModelRunner(GPUModelRunner):
         if not hasattr(self, "_sched_num_tokens_cache"):
             self._sched_num_tokens_cache: dict[str, int] = {}
         for new_req_data in scheduler_output.scheduled_new_reqs:
-            logger.info(
-                "RUNNER_NEW_REQ %s: prefill_token_ids_len=%d, num_computed=%d, "
-                "num_tokens=%d",
-                new_req_data.req_id,
-                len(new_req_data.prefill_token_ids)
-                if new_req_data.prefill_token_ids else 0,
-                new_req_data.num_computed_tokens,
-                new_req_data.num_tokens if hasattr(new_req_data, "num_tokens") else -1,
-            )
             if new_req_data.prefill_token_ids:
                 self._sched_num_tokens_cache[new_req_data.req_id] = len(
                     new_req_data.prefill_token_ids

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1058,6 +1058,14 @@ class NPUModelRunner(GPUModelRunner):
             + len(self.requests[r].output_token_ids)
             for r in self.input_batch.req_ids
         ]
+        # Prune cache to only keep active requests, preventing unbounded
+        # memory growth from completed/aborted requests.
+        active_req_ids = set(self.input_batch.req_ids)
+        self._sched_num_tokens_cache = {
+            req_id: val
+            for req_id, val in self._sched_num_tokens_cache.items()
+            if req_id in active_req_ids
+        }
         num_tokens_np = np.array(num_tokens, dtype=np.int32)
         base_num_reqs = self.input_batch.num_reqs
         num_reqs = base_num_reqs

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1034,8 +1034,39 @@ class NPUModelRunner(GPUModelRunner):
             )
 
         # Record the index of requests that should not be sampled,
-        # so that we could clear the sampled tokens before returning
-        num_tokens = [self.requests[r].num_tokens for r in self.input_batch.req_ids]
+        # so that we could clear the sampled tokens before returning.
+        # For preempted-then-resumed requests, the scheduler's
+        # NewRequestData.prefill_token_ids carries the full _all_token_ids
+        # (prompt + old output tokens). Use that length as num_tokens
+        # so the discard decision aligns with the scheduler's is_prefill_chunk.
+        # Cache the value across scheduling steps because the request only
+        # appears in scheduled_new_reqs once (first chunk).
+        if not hasattr(self, "_sched_num_tokens_cache"):
+            self._sched_num_tokens_cache: dict[str, int] = {}
+        for new_req_data in scheduler_output.scheduled_new_reqs:
+            logger.info(
+                "RUNNER_NEW_REQ %s: prefill_token_ids_len=%d, num_computed=%d, "
+                "num_tokens=%d",
+                new_req_data.req_id,
+                len(new_req_data.prefill_token_ids)
+                if new_req_data.prefill_token_ids else 0,
+                new_req_data.num_computed_tokens,
+                new_req_data.num_tokens if hasattr(new_req_data, "num_tokens") else -1,
+            )
+            if new_req_data.prefill_token_ids:
+                self._sched_num_tokens_cache[new_req_data.req_id] = len(
+                    new_req_data.prefill_token_ids
+                )
+        # num_tokens = base + len(output_token_ids).
+        # - For normal requests: base = num_prompt_tokens (e.g. 63)
+        # - For preempted requests: base = len(prefill_token_ids) (e.g. 3685,
+        #   includes old output tokens). output_token_ids grows naturally
+        #   as new tokens are appended during resumption/decode.
+        num_tokens = [
+            self._sched_num_tokens_cache.get(r, self.requests[r].num_prompt_tokens)
+            + len(self.requests[r].output_token_ids)
+            for r in self.input_batch.req_ids
+        ]
         num_tokens_np = np.array(num_tokens, dtype=np.int32)
         base_num_reqs = self.input_batch.num_reqs
         num_reqs = base_num_reqs


### PR DESCRIPTION

### What this PR does / why we need it?
This pull request introduces a caching mechanism (`_sched_num_tokens_cache`) in `model_runner_v1.py` to store the prefill token length for preempted-then-resumed requests. This ensures that the calculated `num_tokens` aligns with the scheduler's `is_prefill_chunk` decision.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
