### PR TITLE
[BugFix] Add put timeout circuit breaker for AscendStore KV pool

### DIFF
--- a/docs/source/locale/zh_CN/LC_MESSAGES/user_guide/feature_guide/kv_pool.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/user_guide/feature_guide/kv_pool.po
@@ -153,6 +153,16 @@ msgid "Whether to Enable Asynchronous Loading. The default value is false."
 msgstr "是否启用异步加载。默认值为 false。"
 
 #: ../../source/user_guide/feature_guide/kv_pool.md
+msgid "`put_timeout_s`"
+msgstr "`put_timeout_s`"
+
+#: ../../source/user_guide/feature_guide/kv_pool.md
+msgid ""
+"Timeout in seconds for AscendStore KV put operations. The default value is "
+"10.0. Set it to 0 or a negative value to disable the timeout."
+msgstr "AscendStore KV put 操作的超时时间，单位为秒。默认值为 10.0。设置为 0 或负数可禁用超时。"
+
+#: ../../source/user_guide/feature_guide/kv_pool.md
 msgid "`backend`"
 msgstr "`backend`"
 

--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -35,6 +35,7 @@ When `MultiConnector` is used, configure `kv_load_failure_policy` on the `MultiC
 | :--- | :--- |
 | `lookup_rpc_port` | Port for RPC Communication Between Pooling Scheduler Process and Worker Process: Each Instance Requires a Unique Port Configuration. |
 | `load_async` | Whether to Enable Asynchronous Loading. The default value is false. |
+| `put_timeout_s` | Timeout in seconds for AscendStore KV put operations. The default value is 10.0. Set it to 0 or a negative value to disable the timeout. |
 | `backend` | Set the storage backend for kvpool (`mooncake`, `memcache`, `yuanrong`), with the default being `mooncake`. |
 | `consumer_is_to_put` | Whether Decode node put KV Cache into KV Pool. The default value is false. |
 | `consumer_is_to_load` | Whether Decode node load KV cache from KV Pool. The default value is false. |

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -525,5 +525,156 @@ class TestKVCacheStoreLayerRecvingThread(unittest.TestCase):
         self.assertTrue(get_event.is_set())
 
 
+class _BlockingPutStore(FakeStore):
+    """FakeStore whose put() blocks until release() is called.
+
+    Used to make a put reliably exceed put_timeout_s so the request-level
+    circuit breaker fires deterministically (no wall-clock sleeps in the test).
+    """
+
+    def __init__(self, exists_result=None):
+        super().__init__(exists_result)
+        self._release = threading.Event()
+
+    def put(self, keys, addrs, sizes):
+        # Block until released; 10s safety bound so a broken test can't hang.
+        self._release.wait(timeout=10)
+        super().put(keys, addrs, sizes)
+
+    def release(self):
+        self._release.set()
+
+
+class TestKVCacheStoreSendingThreadPutTimeout(unittest.TestCase):
+    """Request-level put-timeout circuit breaker (see kv_transfer.py)."""
+
+    def _make_thread(self, store, put_timeout_s=0.05):
+        db = FakeTokenDatabase()
+        return KVCacheStoreSendingThread(
+            m_store=store,
+            token_database=db,
+            block_size=16,
+            tp_rank=0,
+            dcp_size=1,
+            put_step=1,
+            kv_role="kv_producer",
+            ready_event=threading.Event(),
+            group_uses_align_state=[False],
+            enable_kv_event=False,
+            put_timeout_s=put_timeout_s,
+        )
+
+    def _make_req(self, req_id="r1"):
+        return ReqMeta(
+            req_id=req_id,
+            token_len_chunk=32,
+            block_ids=[0, 1],
+            block_hashes=[b"h0", b"h1"],  # type: ignore[arg-type]
+            current_event=None,
+        )
+
+    def test_put_timeout_circuit_breaks_and_still_accounts(self):
+        # put blocks past the timeout -> request is circuit-broken, but
+        # accounting must still run in finally (count -> 0, queue drained),
+        # so blocks get released. A timeout must never become a leak.
+        store = _BlockingPutStore([0, 0])
+        t = self._make_thread(store, put_timeout_s=0.05)
+        req = self._make_req("r1")
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        try:
+            t._handle_request(req)
+            self.assertTrue(t._is_request_failed("r1"))
+            self.assertEqual(t.stored_requests["r1"], 0)
+            self.assertEqual(t.request_queue.unfinished_tasks, 0)
+        finally:
+            store.release()  # let the background executor thread finish & exit
+
+    def test_failed_request_skips_remaining_puts(self):
+        # Already-failed request: the breaker skips the put even with a fast
+        # store, and the chunk is still accounted (so the request can finish).
+        store = FakeStore([0, 0])
+        t = self._make_thread(store, put_timeout_s=10.0)
+        t._mark_request_failed("r1")
+        req = self._make_req("r1")
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+        self.assertEqual(len(store.put_calls), 0)
+        self.assertEqual(t.stored_requests["r1"], 0)
+        self.assertEqual(t.request_queue.unfinished_tasks, 0)
+
+    def test_normal_put_within_timeout_not_broken(self):
+        # Healthy fast put within the timeout: not broken, put happens once,
+        # accounting normal. (Regression: large timeout == old behavior.)
+        store = FakeStore([0, 0])
+        t = self._make_thread(store, put_timeout_s=10.0)
+        req = self._make_req("r1")
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+        self.assertFalse(t._is_request_failed("r1"))
+        self.assertEqual(len(store.put_calls), 1)
+        self.assertEqual(t.stored_requests["r1"], 0)
+
+    def test_put_timeout_does_not_use_shared_executor(self):
+        # A hung backend put must not consume the shared executor forever.
+        store = FakeStore([0, 0])
+        t = self._make_thread(store, put_timeout_s=10.0)
+        if hasattr(t, "executor"):
+            t.executor.submit = MagicMock(side_effect=AssertionError("shared executor should not be used"))
+        req = self._make_req("r1")
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+        if hasattr(t, "executor"):
+            t.executor.submit.assert_not_called()
+        self.assertEqual(len(store.put_calls), 1)
+
+    def test_none_put_timeout_disables_timeout(self):
+        store = FakeStore([0, 0])
+        t = self._make_thread(store, put_timeout_s=None)
+        req = self._make_req("r1")
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+        self.assertFalse(t._is_request_failed("r1"))
+        self.assertEqual(len(store.put_calls), 1)
+
+    def test_non_positive_put_timeout_disables_timeout(self):
+        store = FakeStore([0, 0])
+        t = self._make_thread(store, put_timeout_s=0)
+        req = self._make_req("r1")
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+        self.assertIsNone(t.put_timeout_s)
+        self.assertFalse(t._is_request_failed("r1"))
+        self.assertEqual(len(store.put_calls), 1)
+
+    def test_put_exception_still_accounts(self):
+        # A put that raises (not a timeout) is caught and still accounted.
+        store = FakeStore([0, 0])
+        store.put = MagicMock(side_effect=RuntimeError("boom"))
+        t = self._make_thread(store, put_timeout_s=10.0)
+        req = self._make_req("r1")
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+        self.assertEqual(t.stored_requests["r1"], 0)
+        self.assertEqual(t.request_queue.unfinished_tasks, 0)
+
+    def test_delete_finished_clears_failed_flag(self):
+        # Cleaning up a request must also clear its circuit-breaker flag so the
+        # _failed_requests set can't grow unbounded.
+        store = FakeStore([0, 0])
+        t = self._make_thread(store)
+        t._mark_request_failed("r1")
+        self.assertTrue(t._is_request_failed("r1"))
+        t.add_stored_request("r1")
+        t.delete_finished_stored_request("r1")
+        self.assertFalse(t._is_request_failed("r1"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -1,7 +1,7 @@
 import queue
 import threading
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeout
 from typing import Any
 
 import torch
@@ -41,8 +41,6 @@ class KVTransferThread(threading.Thread):
         self.token_database = token_database
         self.done_task_lock = threading.Lock()
         self.request_queue: queue.Queue[Any] = queue.Queue()
-        # TODO(jianzs): make this configurable
-        self.executor = ThreadPoolExecutor(max_workers=32)
         self.finished_requests: set[str] = set()
         self.kv_event_lock = threading.Lock()
         self.kv_events: list[BlockStored] = []
@@ -227,6 +225,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         ready_event: threading.Event,
         group_uses_align_state: list[bool],
         enable_kv_event: bool = False,
+        put_timeout_s: float | None = 10.0,
     ):
         super().__init__(
             m_store, token_database, block_size, tp_rank, dcp_size, ready_event, name="KVCacheSendingThread"
@@ -238,6 +237,14 @@ class KVCacheStoreSendingThread(KVTransferThread):
         self.enable_kv_event = enable_kv_event
         self.completed_events_lock = threading.Lock()
         self.completed_events: dict[int, int] = {}
+        # Per-request put-timeout circuit breaker: once a chunk's put exceeds
+        # put_timeout_s, the whole request's remaining puts are skipped so that
+        # one slow/stuck transfer can't make a request's chunks each wait a full
+        # timeout (accumulated congestion). See _handle_request.
+        self.put_timeout_s = put_timeout_s
+        if self.put_timeout_s is not None and self.put_timeout_s <= 0:
+            self.put_timeout_s = None
+        self._failed_requests: set[str] = set()
 
     def add_stored_request(self, req_id: str):
         with self.done_task_lock:
@@ -252,6 +259,33 @@ class KVCacheStoreSendingThread(KVTransferThread):
         with self.done_task_lock:
             if req_id in self.stored_requests:
                 del self.stored_requests[req_id]
+            self._failed_requests.discard(req_id)
+
+    def _mark_request_failed(self, req_id: str):
+        """Circuit-break a request whose put timed out: skip its remaining puts."""
+        with self.done_task_lock:
+            self._failed_requests.add(req_id)
+
+    def _is_request_failed(self, req_id: str) -> bool:
+        with self.done_task_lock:
+            return req_id in self._failed_requests
+
+    def _run_put_with_timeout(self, put_fn):
+        exception_holder: list[Exception] = []
+
+        def thread_target():
+            try:
+                put_fn()
+            except Exception as e:
+                exception_holder.append(e)
+
+        put_thread = threading.Thread(target=thread_target, daemon=True, name="KVCacheStorePutThread")
+        put_thread.start()
+        put_thread.join(timeout=self.put_timeout_s)
+        if put_thread.is_alive():
+            raise FuturesTimeout()
+        if exception_holder:
+            raise exception_holder[0]
 
     def mark_completed_events(self, event_id: int | None) -> None:
         if event_id is not None:
@@ -272,7 +306,12 @@ class KVCacheStoreSendingThread(KVTransferThread):
         current_event = req_meta.current_event
         try:
             if req_id not in self.stored_requests:
-                self.request_queue.task_done()
+                return
+
+            # Per-request circuit breaker: a prior chunk of this request already
+            # timed out, so skip all of its remaining puts. Accounting still runs
+            # in `finally`, so the request's blocks are released normally.
+            if self._is_request_failed(req_id):
                 return
 
             for group_id in req_meta.kv_cache_group_ids or [0]:
@@ -386,18 +425,48 @@ class KVCacheStoreSendingThread(KVTransferThread):
                         kv_cache_group_id=group_id,
                     )
 
-                if current_event is not None:
-                    current_event.synchronize()
-                self.m_store.put(keys, addrs, sizes)
+                # Bound the put (including current_event.synchronize(), which is
+                # the unbounded hang point) with a wall-clock timeout. On timeout,
+                # circuit-break the whole request and stop here; `finally` still
+                # runs so the blocks are released. A timeout thus degrades to a
+                # cache miss, never a permanent leak or hang.
+                def _do_put(keys=keys, addrs=addrs, sizes=sizes, event=current_event):
+                    if event is not None:
+                        event.synchronize()
+                    self.m_store.put(keys, addrs, sizes)
+
+                try:
+                    self._run_put_with_timeout(_do_put)
+                except FuturesTimeout:
+                    self._mark_request_failed(req_id)
+                    logger.warning(
+                        "KV pool put timed out after %.1fs; circuit-breaking request %s "
+                        "(group %d) and skipping its remaining puts.",
+                        self.put_timeout_s,
+                        req_id,
+                        group_id,
+                    )
+                    break
+                except Exception as e:
+                    logger.error(
+                        "KV pool put failed for request %s group %d. type=%s, error=%s",
+                        req_id,
+                        group_id,
+                        type(e).__name__,
+                        e,
+                    )
+                    break
 
                 # TODO Query specific replica info to update the event
                 if self.enable_kv_event and stored_events is not None:
                     self.update_kv_event(stored_events)
         finally:
-            # always free blocks
+            # Always account, even on timeout / skip / exception, so
+            # stored_requests reaches 0 and the scheduler can release the blocks
+            # (a stuck put becomes transient back-pressure, not a permanent leak).
             self.mark_completed_events(req_meta.event_id)
-        self.dec_stored_request(req_id)
-        self.request_queue.task_done()
+            self.dec_stored_request(req_id)
+            self.request_queue.task_done()
 
 
 class KVCacheStoreRecvingThread(KVTransferThread):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -100,6 +100,14 @@ class KVPoolWorker:
 
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         self.load_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get("load_async", False)
+        # Per-chunk put timeout (seconds) for the request-level circuit breaker in
+        # KVCacheStoreSendingThread: a chunk whose put exceeds this is dropped and
+        # the rest of that request's puts are short-circuited (bounds accumulated
+        # congestion from one slow/stuck transfer). Default 10s; set <= 0 to
+        # disable the timeout.
+        self.put_timeout_s = vllm_config.kv_transfer_config.kv_connector_extra_config.get("put_timeout_s", 10.0)
+        if self.put_timeout_s is not None and self.put_timeout_s <= 0:
+            self.put_timeout_s = None
         self._invalid_block_ids: set[int] = set()
         self._invalid_block_ids_lock = threading.Lock()
         self.consumer_is_to_put = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
@@ -464,6 +472,7 @@ class KVPoolWorker:
                     ready_event_sending,
                     self.group_uses_align_state,
                     self.enable_kv_events,
+                    self.put_timeout_s,
                 )
                 self.kv_send_thread.start()
             if self.load_async:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds a request-level timeout circuit breaker for AscendStore KV cache `put` operations.

Before this change, if a backend `put` call became slow or stuck, each remaining chunk for the same request could wait on the same slow path again. That could turn one stalled transfer into accumulated back-pressure across the request.

This patch:
- adds `put_timeout_s` to `kv_connector_extra_config`, defaulting to `10.0` seconds;
- wraps AscendStore KV `put` with a timeout;
- marks the request as failed after a put timeout, so later puts for the same request are skipped;
- keeps request accounting in `finally`, so timed-out or failed puts still drain the queue and release request bookkeeping;
- clears the failed-request marker when the request is cleaned up.

### Does this PR introduce _any_ user-facing change?

Yes.

AscendStore KV pool users can now configure `put_timeout_s` through `kv_connector_extra_config`. The default is `10.0` seconds.

Behavior also changes when a KV `put` stalls: after the timeout, the remaining puts for that request are skipped instead of waiting chunk by chunk.

### How was this patch tested?

Added unit coverage in `tests/ut/distributed/ascend_store/test_kv_transfer.py` for:
- put timeout marks the request as failed and still runs accounting;
- already-failed requests skip remaining puts;
- normal fast puts still work;
- put exceptions still run accounting;
- request cleanup clears the failed-request marker.

I attempted to run the test locally with:

```bash
python3 -m pytest tests/ut/distributed/ascend_store/test_kv_transfer.py -q

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
