### PR TITLE
[BugFix] Fix Mooncake connector layer metadata mapping

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -843,6 +843,90 @@ class TestCoreFunctionality(unittest.TestCase):
         self.assertEqual(call_args[3], [1024, 1024])
         mock_get_meta.assert_not_called()
 
+    def _configure_mtp_draft_transfer(self):
+        layer_name = "model.layers.0.mtp.self_attn"
+        local_layer_idx = 32
+        remote_layer_idx = 40
+        remote_wrong_layer_idx = local_layer_idx
+
+        self.thread._prefill_pp_size = 2
+        self.thread.pp_layer_indices = {0: (0, 16), 1: (16, 32)}
+        self.thread.num_draft_layers = 1
+        self.thread.vllm_config.speculative_config = types.SimpleNamespace(method="mtp", num_speculative_tokens=1)
+        self.thread.kv_group2layeridx = {
+            0: (
+                {"kv_cache_spec_type": "FullAttentionSpec", "layer_names": [layer_name]},
+                [local_layer_idx],
+            )
+        }
+        self.thread.remote_kv_group2layeridx["remote_engine"][6666] = {
+            0: (
+                {"kv_cache_spec_type": "FullAttentionSpec", "layer_names": [layer_name]},
+                [remote_layer_idx],
+            )
+        }
+        self.thread.group_compress_ratios = {0: 1}
+
+        local_base_addrs = [[0] for _ in range(local_layer_idx + 1)]
+        local_base_addrs[local_layer_idx] = [0x320000]
+        remote_base_addrs = [[0] for _ in range(remote_layer_idx + 1)]
+        remote_base_addrs[remote_wrong_layer_idx] = [0xBAD000]
+        remote_base_addrs[remote_layer_idx] = [0x400000]
+        self.thread.kv_caches_base_addr["local_engine"][5555] = local_base_addrs
+        self.thread.kv_caches_base_addr["remote_engine"] = {6666: remote_base_addrs}
+
+        self.thread.block_len_per_addr = [[1024] for _ in range(local_layer_idx + 1)]
+        self.thread.block_stride_per_addr = [[4096] for _ in range(local_layer_idx + 1)]
+        self.thread.block_size_scale = [[1] for _ in range(local_layer_idx + 1)]
+        self.thread.remote_block_size_scale["remote_engine"] = {6666: [[1] for _ in range(remote_layer_idx + 1)]}
+        self.thread.remote_block_stride_per_addr["remote_engine"][6666] = [[8192] for _ in range(remote_layer_idx + 1)]
+        return local_layer_idx, remote_layer_idx
+
+    def _make_mtp_draft_transfer_request(self, prefill_pp_rank: int):
+        req = dict(self.test_req)
+        req["local_block_ids"] = [[2]]
+        req["remote_block_ids"] = [[5]]
+        req["group_pulls"] = [
+            GroupPull(
+                group_id=0,
+                remote_tp_offset=0,
+                num_group_pulls=1,
+                prefill_pp_rank=prefill_pp_rank,
+                is_group_transfer_end=True,
+            )
+        ]
+        return req
+
+    @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
+    def test_transfer_mtp_draft_cache_skips_non_last_prefill_pp_rank(self, mock_get_meta):
+        self._configure_mtp_draft_transfer()
+        req = self._make_mtp_draft_transfer_request(prefill_pp_rank=0)
+
+        with patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ascend_config") as mock_config:
+            mock_config.return_value.enable_kv_nz = False
+            self.thread._transfer_kv_cache_all_groups(req)
+
+        self.engine.batch_transfer_sync_read.assert_not_called()
+        mock_get_meta.assert_not_called()
+
+    @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
+    def test_transfer_mtp_draft_cache_uses_remote_layer_index_by_name(self, mock_get_meta):
+        self._configure_mtp_draft_transfer()
+        req = self._make_mtp_draft_transfer_request(prefill_pp_rank=1)
+
+        with patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ascend_config") as mock_config:
+            mock_config.return_value.enable_kv_nz = False
+            self.thread._transfer_kv_cache_all_groups(req)
+
+        self.engine.batch_transfer_sync_read.assert_called_once()
+        call_args, _ = self.engine.batch_transfer_sync_read.call_args
+        self.assertEqual(call_args[0], "localhost:7777")
+        self.assertEqual(call_args[1], [0x320000 + 2 * 4096])
+        self.assertEqual(call_args[2], [0x400000 + 5 * 8192])
+        self.assertEqual(call_args[3], [1024])
+        self.assertNotEqual(call_args[2], [0xBAD000 + 5 * 8192])
+        mock_get_meta.assert_not_called()
+
     def test_append_mamba_transfer_meta_uses_block_stride_for_block_offsets(self):
         src_list: list[int] = []
         dst_list: list[int] = []

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -89,7 +89,9 @@ def make_agent_metadata(**overrides: Any) -> MooncakeAgentMetadata:
     metadata: dict[str, Any] = {
         "engine_id": "engine1",
         "te_rpc_port": 9090,
-        "kv_group2layeridx": {0: ({"kv_cache_spec_type": "FullAttentionSpec", "layer_names": ["layer_0"]}, [0])},
+        "kv_group2layeridx": {
+            0: ({"kv_cache_spec_type": "FullAttentionSpec", "layer_names": ["model.layers.0.self_attn"]}, [0])
+        },
         "block_size": 16,
         "kv_caches_base_addr": [[12345678]],
         "block_size_scale": [[1]],
@@ -670,7 +672,7 @@ class TestCoreFunctionality(unittest.TestCase):
         self.ready_event = threading.Event()
         self.mock_queue = MagicMock()
         self.vllm_config = MockVllmConfig()
-        self.kv_caches: dict[str, Any] = {"layer_0": (MagicMock(), MagicMock())}
+        self.kv_caches: dict[str, Any] = {"model.layers.0.self_attn": (MagicMock(), MagicMock())}
         self.thread = KVCacheRecvingThread(
             tp_rank=0,
             tp_size=4,
@@ -702,7 +704,7 @@ class TestCoreFunctionality(unittest.TestCase):
             "remote_block_size": 16,
         }
         self.thread.kv_group2layeridx = {
-            0: ({"kv_cache_spec_type": "FullAttentionSpec", "layer_names": ["layer_0"]}, [0])
+            0: ({"kv_cache_spec_type": "FullAttentionSpec", "layer_names": ["model.layers.0.self_attn"]}, [0])
         }
         self.thread.remote_kv_group2layeridx["remote_engine"][6666] = self.thread.kv_group2layeridx
         self.thread.group_compress_ratios = {0: 1}
@@ -772,8 +774,8 @@ class TestCoreFunctionality(unittest.TestCase):
             0: (
                 {
                     "kv_cache_spec_type": "UniformTypeKVCacheSpecs",
-                    "layer_names": ["layer_0"],
-                    "kv_cache_spec": {"layer_0": {"compress_ratio": "4"}},
+                    "layer_names": ["model.layers.0.self_attn"],
+                    "kv_cache_spec": {"model.layers.0.self_attn": {"compress_ratio": "4"}},
                 },
                 [0],
             )
@@ -2411,7 +2413,7 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
             0: (
                 {
                     "kv_cache_spec_type": "UniformTypeKVCacheSpecs",
-                    "kv_cache_spec": {"layer_0": {"compress_ratio": 4}},
+                    "kv_cache_spec": {"model.layers.0.self_attn": {"compress_ratio": 4}},
                 },
                 [0],
             )

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -89,7 +89,7 @@ def make_agent_metadata(**overrides: Any) -> MooncakeAgentMetadata:
     metadata: dict[str, Any] = {
         "engine_id": "engine1",
         "te_rpc_port": 9090,
-        "kv_group2layeridx": {0: ({"kv_cache_spec_type": "FullAttentionSpec"}, [0])},
+        "kv_group2layeridx": {0: ({"kv_cache_spec_type": "FullAttentionSpec", "layer_names": ["layer_0"]}, [0])},
         "block_size": 16,
         "kv_caches_base_addr": [[12345678]],
         "block_size_scale": [[1]],
@@ -701,7 +701,10 @@ class TestCoreFunctionality(unittest.TestCase):
             "all_task_done": True,
             "remote_block_size": 16,
         }
-        self.thread.kv_group2layeridx = {0: ({"kv_cache_spec_type": "FullAttentionSpec"}, [0])}
+        self.thread.kv_group2layeridx = {
+            0: ({"kv_cache_spec_type": "FullAttentionSpec", "layer_names": ["layer_0"]}, [0])
+        }
+        self.thread.remote_kv_group2layeridx["remote_engine"][6666] = self.thread.kv_group2layeridx
         self.thread.group_compress_ratios = {0: 1}
         self.thread.block_size_scale = [[1]]
         self.thread.task_tracker = MagicMock()
@@ -769,12 +772,14 @@ class TestCoreFunctionality(unittest.TestCase):
             0: (
                 {
                     "kv_cache_spec_type": "UniformTypeKVCacheSpecs",
+                    "layer_names": ["layer_0"],
                     "kv_cache_spec": {"layer_0": {"compress_ratio": "4"}},
                 },
                 [0],
             )
         }
         self.thread.group_compress_ratios = {0: 4}
+        self.thread.remote_kv_group2layeridx["remote_engine"][6666] = self.thread.kv_group2layeridx
 
         req["remote_block_ids"] = [[6, 7]]
         with patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ascend_config") as mock_config:
@@ -1050,6 +1055,41 @@ class MockKVCacheConfig:
     def __init__(self, kv_cache_groups=None, num_blocks=10):
         self.kv_cache_groups = kv_cache_groups or [MockKVCacheGroup()]
         self.num_blocks = num_blocks
+
+
+class TestMooncakeConnectorWorkerMetadata(unittest.TestCase):
+    def test_build_kv_group2layeridx_assigns_unique_indices_across_hybrid_groups(self):
+        worker = object.__new__(MooncakeConnectorWorker)
+        worker.vllm_config = MockVllmConfig()
+        worker.total_layers = 4
+        worker.kv_cache_config = MockKVCacheConfig(
+            kv_cache_groups=[
+                MockKVCacheGroup(["model.layers.0.self_attn.attn"]),
+                MockKVCacheGroup(["model.layers.0.self_attn.compressor.state_cache"]),
+                MockKVCacheGroup(["model.layers.0.self_attn.swa_cache"]),
+            ]
+        )
+
+        group2layeridx = worker._build_kv_group2layeridx()
+
+        self.assertEqual(group2layeridx[0][1], [0])
+        self.assertEqual(group2layeridx[1][1], [4])
+        self.assertEqual(group2layeridx[2][1], [5])
+
+    def test_get_group_kv_caches_filters_by_group_layer_names(self):
+        thread = object.__new__(KVCacheRecvingThread)
+        thread.kv_group2layeridx = {
+            0: ({"layer_names": ["layer.attn", "layer.compressor"]}, [0, 4]),
+            1: ({"layer_names": ["layer.swa"]}, [5]),
+        }
+        thread.kv_caches = {
+            "layer.attn": "attn-cache",
+            "layer.compressor": "compressor-cache",
+            "layer.swa": "swa-cache",
+        }
+
+        self.assertEqual(thread._get_group_kv_caches(0, [4]), {"layer.compressor": "compressor-cache"})
+        self.assertEqual(thread._get_group_kv_caches(1), {"layer.swa": "swa-cache"})
 
 
 class TestKVCacheTaskTracker(unittest.TestCase):
@@ -1697,6 +1737,7 @@ class TestUtils(unittest.TestCase):
         mock_socket.recv.side_effect = zmq.ZMQError("Receive timeout")  # type: ignore
         with self.assertRaises(RuntimeError):
             ensure_zmq_recv(mock_socket, "tcp://localhost:1234", max_retries=2)
+        self.assertEqual(mock_socket.recv.call_count, 2)
 
 
 class MockMooncakeAgentMetadata:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -761,19 +761,50 @@ class KVCacheRecvingThread(threading.Thread):
         length_list: list[int] = []
         attention_group_reformat_block_ids: list[tuple[tuple[int, list[list[int]], int, list[int]], bool]] = []
 
-        def pp_layer_indices(layer_indices: list[int], prefill_pp_rank: int) -> list[int]:
+        def layer_partition_index(layer_name: str, layer_idx: int) -> int:
+            if "mtp" in layer_name:
+                return layer_idx
+            num_attn_module = 2 if self.vllm_config.model_config.hf_text_config.model_type == "longcat_flash" else 1
+            from vllm.v1.worker.utils import extract_layer_index
+
+            try:
+                return extract_layer_index(layer_name, num_attn_module)
+            except Exception:
+                return layer_idx
+
+        def pp_layer_pairs(group_idx: int, prefill_pp_rank: int) -> list[tuple[int, int]]:
+            local_group_spec, local_layer_indices = self.kv_group2layeridx[group_idx]
+            remote_group2layeridx = self.remote_kv_group2layeridx[remote_engine_id][remote_handshake_port]
+            if group_idx not in remote_group2layeridx:
+                raise RuntimeError(
+                    f"Missing remote kv group metadata for group_idx={group_idx}, "
+                    f"remote_engine_id={remote_engine_id}, remote_handshake_port={remote_handshake_port}."
+                )
+            remote_group_spec, remote_layer_indices = remote_group2layeridx[group_idx]
+            remote_layer_by_name = dict(zip(remote_group_spec["layer_names"], remote_layer_indices))
+
             first_layer_index, end_layer_index = self.pp_layer_indices[prefill_pp_rank]
             if self.vllm_config.speculative_config is not None and prefill_pp_rank == self._prefill_pp_size - 1:
                 end_layer_index += self.num_draft_layers
-            return [layer_idx for layer_idx in layer_indices if first_layer_index <= layer_idx < end_layer_index]
+
+            layer_pairs: list[tuple[int, int]] = []
+            for layer_name, local_layer_idx in zip(local_group_spec["layer_names"], local_layer_indices):
+                partition_idx = layer_partition_index(layer_name, local_layer_idx)
+                if not (first_layer_index <= partition_idx < end_layer_index):
+                    continue
+                remote_layer_idx = remote_layer_by_name.get(layer_name)
+                if remote_layer_idx is not None:
+                    layer_pairs.append((local_layer_idx, remote_layer_idx))
+            return layer_pairs
 
         for group_pull in group_pulls:
             group_idx = group_pull.group_id
-            group_spec, layer_indices = self.kv_group2layeridx[group_idx]
+            group_spec, _ = self.kv_group2layeridx[group_idx]
             kv_cache_group_id = group_spec.get("kv_cache_group_id", group_idx)
-            layer_indices = pp_layer_indices(layer_indices, group_pull.prefill_pp_rank)
-            if not layer_indices:
+            layer_pairs = pp_layer_pairs(group_idx, group_pull.prefill_pp_rank)
+            if not layer_pairs:
                 continue
+            local_layer_indices = [local_layer_idx for local_layer_idx, _ in layer_pairs]
             tp_num_need_pulls = group_pull.num_group_pulls
             inner_offset = group_pull.remote_tp_offset
             is_mamba_group = group_spec["kv_cache_spec_type"] == "MambaSpec"
@@ -797,7 +828,7 @@ class KVCacheRecvingThread(threading.Thread):
                     grouped_local_block_ids = [[block_id] for block_id in kernel_local_block_ids]
                 attention_group_reformat_block_ids.append(
                     (
-                        (group_idx, grouped_local_block_ids, tp_num_need_pulls, layer_indices),
+                        (group_idx, grouped_local_block_ids, tp_num_need_pulls, local_layer_indices),
                         is_group_transfer_end,
                     )
                 )
@@ -809,18 +840,18 @@ class KVCacheRecvingThread(threading.Thread):
                 grouped_local_block_ids = [[local_group_block_ids[0]]]
 
             if is_mamba_group:
-                for layer_idx in layer_indices:
+                for local_layer_idx, remote_layer_idx in layer_pairs:
                     start_meta_idx = len(src_list)
                     self._append_mamba_transfer_meta(
                         src_list,
                         dst_list,
                         length_list,
                         group_spec=group_spec,
-                        src_layer_base_addr=local_kv_caches_base_addrs[layer_idx],
-                        dst_layer_base_addr=remote_kv_caches_base_addrs[layer_idx],
-                        block_len=self.block_len_per_addr[layer_idx],
-                        block_stride=self.block_stride_per_addr[layer_idx],
-                        remote_block_stride=remote_block_stride_per_addr[layer_idx],
+                        src_layer_base_addr=local_kv_caches_base_addrs[local_layer_idx],
+                        dst_layer_base_addr=remote_kv_caches_base_addrs[remote_layer_idx],
+                        block_len=self.block_len_per_addr[local_layer_idx],
+                        block_stride=self.block_stride_per_addr[local_layer_idx],
+                        remote_block_stride=remote_block_stride_per_addr[remote_layer_idx],
                         remote_block_id=grouped_remote_block_ids[0][0],
                         local_block_id=grouped_local_block_ids[0][0],
                         tp_num_need_pulls=tp_num_need_pulls,
@@ -831,12 +862,13 @@ class KVCacheRecvingThread(threading.Thread):
                             src_list[start_meta_idx:], dst_list[start_meta_idx:], length_list[start_meta_idx:]
                         ):
                             logger.debug(
-                                "Mooncake mamba transfer meta: request_id=%s group_idx=%s layer_idx=%s "
-                                "local_block_id=%s remote_block_id=%s tp_num_need_pulls=%s "
-                                "remote_tp_offset=%s  session_id=%s",
+                                "Mooncake mamba transfer meta: request_id=%s group_idx=%s "
+                                "local_layer_idx=%s remote_layer_idx=%s local_block_id=%s remote_block_id=%s "
+                                "tp_num_need_pulls=%s remote_tp_offset=%s  session_id=%s",
                                 remote_request_id,
                                 group_idx,
-                                layer_idx,
+                                local_layer_idx,
+                                remote_layer_idx,
                                 grouped_local_block_ids[0][0],
                                 grouped_remote_block_ids[0][0],
                                 tp_num_need_pulls,
@@ -845,13 +877,13 @@ class KVCacheRecvingThread(threading.Thread):
                             )
                 continue
 
-            for layer_idx in layer_indices:
-                for cache_idx in range(len(local_kv_caches_base_addrs[layer_idx])):
-                    src_layer_base_addr = local_kv_caches_base_addrs[layer_idx][cache_idx]
-                    dst_layer_base_addr = remote_kv_caches_base_addrs[layer_idx][cache_idx]
-                    block_len = self.block_len_per_addr[layer_idx][cache_idx]
-                    block_stride = self.block_stride_per_addr[layer_idx][cache_idx]
-                    remote_block_stride = remote_block_stride_per_addr[layer_idx][cache_idx]
+            for local_layer_idx, remote_layer_idx in layer_pairs:
+                for cache_idx in range(len(local_kv_caches_base_addrs[local_layer_idx])):
+                    src_layer_base_addr = local_kv_caches_base_addrs[local_layer_idx][cache_idx]
+                    dst_layer_base_addr = remote_kv_caches_base_addrs[remote_layer_idx][cache_idx]
+                    block_len = self.block_len_per_addr[local_layer_idx][cache_idx]
+                    block_stride = self.block_stride_per_addr[local_layer_idx][cache_idx]
+                    remote_block_stride = remote_block_stride_per_addr[remote_layer_idx][cache_idx]
                     inner_block_len = block_len // tp_num_need_pulls
                     transfer_remote_block_ids, transfer_local_block_ids = split_if_not_byte_contiguous(
                         grouped_remote_block_ids,
@@ -868,11 +900,13 @@ class KVCacheRecvingThread(threading.Thread):
                         dst_list.append(dst)
                         length_list.append(length)
                     logger.debug(
-                        "Mooncake kv transfer meta: request_id=%s group_idx=%s layer_idx=%s local_block_ids=%s "
-                        "remote_block_ids=%s tp_num_need_pulls=%s remote_tp_offset=%s session_id=%s",
+                        "Mooncake kv transfer meta: request_id=%s group_idx=%s "
+                        "local_layer_idx=%s remote_layer_idx=%s local_block_ids=%s remote_block_ids=%s "
+                        "tp_num_need_pulls=%s remote_tp_offset=%s session_id=%s",
                         remote_request_id,
                         group_idx,
-                        layer_idx,
+                        local_layer_idx,
+                        remote_layer_idx,
                         grouped_local_block_ids,
                         grouped_remote_block_ids,
                         tp_num_need_pulls,
@@ -1093,19 +1127,19 @@ class KVCacheRecvingThread(threading.Thread):
         length_list.append(remote_ssm_len)
 
     def _get_group_kv_caches(self, group_idx: int, layer_indices: list[int] | None = None) -> dict[str, Any]:
+        group_spec, group_layer_indices = self.kv_group2layeridx[group_idx]
         if layer_indices is None:
-            _, layer_indices = self.kv_group2layeridx[group_idx]
+            layer_indices = group_layer_indices
         layer_index_set = set(layer_indices)
-        num_attn_module = 2 if self.vllm_config.model_config.hf_text_config.model_type == "longcat_flash" else 1
-        from vllm.v1.worker.utils import extract_layer_index
-
-        def layer_in_group(layer_name: str) -> bool:
-            if "mtp" in layer_name:
-                return any(layer_idx >= self.num_layers for layer_idx in layer_index_set)
-            return extract_layer_index(layer_name, num_attn_module) in layer_index_set
-
+        selected_layer_names = {
+            layer_name
+            for layer_name, layer_idx in zip(group_spec["layer_names"], group_layer_indices)
+            if layer_idx in layer_index_set
+        }
         return {
-            layer_name: layer_cache for layer_name, layer_cache in self.kv_caches.items() if layer_in_group(layer_name)
+            layer_name: layer_cache
+            for layer_name, layer_cache in self.kv_caches.items()
+            if layer_name in selected_layer_names
         }
 
     @staticmethod
@@ -1276,10 +1310,15 @@ class KVCacheRecvingThread(threading.Thread):
                 f"Conflict engine id {engine_id} with local engine id {self.local_engine_id}."
             )
             if agent_meta.kv_group2layeridx != self.kv_group2layeridx:
-                logger.warning(
-                    "Remote kv_group2layeridx is inconsistent with local. remote=%s, local=%s. ",
-                    agent_meta.kv_group2layeridx,
-                    self.kv_group2layeridx,
+                remote_layers = sum(len(layer_indices) for _, layer_indices in agent_meta.kv_group2layeridx.values())
+                local_layers = sum(len(layer_indices) for _, layer_indices in self.kv_group2layeridx.values())
+                logger.debug(
+                    "Remote kv_group2layeridx differs from local: remote_groups=%d local_groups=%d "
+                    "remote_layers=%d local_layers=%d.",
+                    len(agent_meta.kv_group2layeridx),
+                    len(self.kv_group2layeridx),
+                    remote_layers,
+                    local_layers,
                 )
             with self.remote_metadata_lock:
                 self.remote_kv_group2layeridx[engine_id][remote_handshake_port] = agent_meta.kv_group2layeridx
@@ -2012,6 +2051,8 @@ class MooncakeConnectorWorker:
         num_attn_module = 2 if self.vllm_config.model_config.hf_text_config.model_type == "longcat_flash" else 1
         next_mtp_layer_idx = self.total_layers
         transfer_group_id = 0
+        layer_name_to_idx: dict[str, int] = {}
+        assigned_indices: set[int] = set()
         for kv_cache_group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups):
             layer_entries: list[tuple[str, int]] = []
             # For eagle3 method there is no "mtp" in layer names, and upstream model initiation assigns the layer id
@@ -2019,16 +2060,18 @@ class MooncakeConnectorWorker:
             # Here we determine whether the current layer is an eagle layer based on whether the layer id has been
             # assigned to previous layers. If the layer id has been assigned, we treat the current layer as
             # an eagle layer and assign a new layer id starting from total_layers.
-            assigned_indices: set[int] = set()
             for layer_name in group_spec.layer_names:
-                if "mtp" in layer_name:
+                if layer_name in layer_name_to_idx:
+                    layer_idx = layer_name_to_idx[layer_name]
+                elif "mtp" in layer_name:
                     layer_idx = next_mtp_layer_idx
                     next_mtp_layer_idx += 1
                 else:
                     layer_idx = extract_layer_index(layer_name, num_attn_module)
-                    if assigned_indices and layer_idx < min(assigned_indices) or layer_idx in assigned_indices:
+                    if layer_idx in assigned_indices:
                         layer_idx = next_mtp_layer_idx
                         next_mtp_layer_idx += 1
+                layer_name_to_idx[layer_name] = layer_idx
                 assigned_indices.add(layer_idx)
                 layer_entries.append((layer_name, layer_idx))
 

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -769,8 +769,10 @@ class KVCacheRecvingThread(threading.Thread):
 
             try:
                 return extract_layer_index(layer_name, num_attn_module)
-            except Exception:
-                return layer_idx
+            except (AssertionError, IndexError) as e:
+                raise RuntimeError(
+                    f"Failed to extract PP layer index from layer_name={layer_name}, layer_idx={layer_idx}."
+                ) from e
 
         def pp_layer_pairs(group_idx: int, prefill_pp_rank: int) -> list[tuple[int, int]]:
             local_group_spec, local_layer_indices = self.kv_group2layeridx[group_idx]


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes MooncakeConnectorV1 KV transfer metadata handling when local and remote workers assign different metadata layer indices for the same KV cache layer.

The receiver now matches local and remote transfer layers by `layer_name`, keeps PP filtering based on the model-layer partition index, and transfers with explicit `(local_layer_idx, remote_layer_idx)` pairs. This prevents compressed or grouped KV cache tensors from being copied with another group's block metadata.

It also builds `kv_group2layeridx` with globally unique assigned indices across cache groups and uses recorded `layer_names` when filtering group KV caches. Unit coverage was added for the grouped metadata cases.

Reference vLLM PR: https://github.com/vllm-project/vllm/pull/46004

### Does this PR introduce _any_ user-facing change?

No. This is an internal correctness fix for Mooncake KV transfer metadata mapping. It does not change public APIs, CLI flags, or documented behavior.

### How was this patch tested?

- `git diff --check`
- `python3 -m py_compile vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py tests/ut/kv_offload/test_mooncake_connector.py`
- `python3 -m pytest tests/ut/kv_offload/test_mooncake_connector.py tests/ut/kv_offload/test_mooncake_hybrid_connector.py tests/ut/kv_offload/test_mooncake_layerwise_connector.py tests/ut/distributed/mooncake tests/ut/distributed/kv_transfer/test_kv_transfer_failures.py -q --tb=short`

Result: `164 passed, 16 warnings`.

DeepSeek V4 Pro was validated with MTP 1 configuration.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
