### PR TITLE
[Doc][Misc] Clarify Ascend 950 wording in v0.22.1rc1 release notes

### DIFF
--- a/docs/source/user_guide/release_notes.md
+++ b/docs/source/user_guide/release_notes.md
@@ -21,7 +21,7 @@ We're excited to announce the release of v0.22.1rc1 for vLLM Ascend. This is the
 ### Hardware and Operator Support
 
 - Added W8A8/W4A8 dynamic quantization support for Ascend 950. [#10236](https://github.com/vllm-project/vllm-ascend/pull/10236)
-- Added Ascend 950 CPU binding support for A5 server topology and process layout. [#10483](https://github.com/vllm-project/vllm-ascend/pull/10483)
+- Added Ascend 950 CPU binding support for Ascend 950 server topology and process layout. [#10483](https://github.com/vllm-project/vllm-ascend/pull/10483)
 
 ### Performance
 

--- a/docs/source/user_guide/release_notes.md
+++ b/docs/source/user_guide/release_notes.md
@@ -2,7 +2,7 @@
 
 ## v0.22.1rc1 - 2026.06.30
 
-We're excited to announce the release of v0.22.1rc1 for vLLM Ascend. This is the first release candidate for the v0.22.1 release line, building on v0.21.0rc1 and aligning the plugin with upstream vLLM v0.22.1. Please follow the [official doc](https://docs.vllm.ai/projects/ascend/en/latest) to get started.
+We're excited to announce the release of v0.22.1rc1 for vLLM Ascend. This is the first release candidate for the v0.22.1 release line, building on v0.21.0rc1 and aligning the plugin with upstream vLLM v0.22.1. Please follow the [official doc](https://docs.vllm.ai/projects/ascend/en/releases-v0.22.1rc) to get started.
 
 ### Highlights
 


### PR DESCRIPTION
## What this PR does / why we need it?

This PR updates the `v0.22.1rc1` release note wording to use `Ascend 950` instead of `A5` in the CPU binding bullet, so the platform naming stays consistent and unambiguous.

## Does this PR introduce _any_ user-facing change?

Yes. It corrects the published release note wording for the release branch documentation.

## How was this patch tested?

- Verified the release note diff locally
- Ran `git diff --check`

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
