### PR TITLE
[BugFix][KV Pool] Improve Yuanrong key handling and load failure tracking

### DIFF
--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -803,18 +803,62 @@ documentation: <https://etcd.io/docs/v3.7/op-guide/clustering/>
 
 ### Start Datasystem Worker
 
-Start a Datasystem worker on each node by using `dscli`:
+Start a Datasystem worker on each node by using `dscli`. The following
+configuration is a recommended starting point for high-throughput KV Pool
+workloads:
 
 ```bash
+WORKER_LOG_DIR="/var/log/yuanrong/worker"
+sudo mkdir -p "${WORKER_LOG_DIR}"
+sudo chown "$(id -u):$(id -g)" "${WORKER_LOG_DIR}"
+
 dscli start -w \
   --worker_address "${WORKER_IP}:31501" \
   --etcd_address "${ETCD_IP}:2379" \
+  --log_dir "${WORKER_LOG_DIR}" \
   --shared_memory_size_mb 40960 \
-  --enable_worker_worker_batch_get=true
+  --arena_per_tenant 1 \
+  --enable_huge_tlb true \
+  --enable_fallocate false \
+  --rpc_thread_num 64 \
+  --oc_thread_num 64 \
+  --enable_worker_worker_batch_get true \
+  --sc_regular_socket_num 0 \
+  --sc_stream_socket_num 0
 ```
 
 The `--worker_address` value is consumed later by `DS_WORKER_ADDR`, so keep
 the host and port identical on the same node.
+
+The tuning parameters above have the following effects:
+
+| Parameter | Description |
+| :--- | :--- |
+| `log_dir` | Sets the Datasystem worker log directory. Create the directory and grant the worker process write permission before startup. |
+| `arena_per_tenant=1` | Uses one shared-memory arena per tenant as a conservative starting point for memory and file-descriptor usage. |
+| `enable_huge_tlb=true` | Backs worker shared memory with HugeTLB pages. Reserve enough 2 MiB huge pages before starting the worker. |
+| `enable_fallocate=false` | Disables `fallocate` for the shared-memory file; use this setting with the HugeTLB configuration above. |
+| `rpc_thread_num=64` | Sets the RPC/ZMQ service concurrency. |
+| `oc_thread_num=64` | Sets the Object Cache business-thread pool size. |
+| `enable_worker_worker_batch_get=true` | Enables batched Object Cache reads between Datasystem workers. |
+| `sc_regular_socket_num=0`, `sc_stream_socket_num=0` | Disables the Stream Cache service. Both values must be greater than zero to enable it; keep them at zero when KV Pool does not use Stream Cache. |
+
+For `shared_memory_size_mb=40960`, reserve at least 20480 2 MiB huge pages and
+verify that they are available before starting the worker:
+
+```bash
+grep -E "HugePages_Total|HugePages_Free|Hugepagesize" /proc/meminfo
+```
+
+Worker logs, including files whose base name is normally
+`datasystem_worker`, are written under the `--log_dir` directory. Use an
+absolute path so the log location does not depend on the worker process's
+current directory.
+
+These thread counts are tuning starting points rather than universal defaults.
+Adjust them according to the available CPU cores and measured request
+throughput. Because `-w` consumes the remaining command-line arguments, place
+any `dscli start` options such as `--timeout` before `-w`.
 
 For more parameters, refer to the `dscli` usage documentation on the Yuanrong
 Datasystem official site:
@@ -834,15 +878,23 @@ Set the following environment variables on each node before starting vLLM:
 | :--- | :--- | :--- | :--- |
 | `PYTHONHASHSEED` | Yes | `0` | Must be consistent across all nodes to guarantee uniform hash generation. |
 | `DS_WORKER_ADDR` | Yes | N/A | Datasystem worker address in `<host>:<port>` format. This must match the local `dscli start --worker_address` value. |
+| `DATASYSTEM_CLIENT_LOG_DIR` | No | `~/.datasystem/logs` | Directory for Yuanrong client SDK logs created by the vLLM process. Use a directory separate from the worker logs. |
 | `DS_ENABLE_EXCLUSIVE_CONNECTION` | No | `0` | Passed to Yuanrong `HeteroClient.enable_exclusive_connection`. Use `1` to enable the exclusive connection mode when required by your deployment. |
 | `DS_ENABLE_REMOTE_H2D` | No | `0` | Passed to Yuanrong `HeteroClient.enable_remote_h2d`. Use `1` only after the Remote H2D requirements below are met. |
 
 ```bash
 export PYTHONHASHSEED=0
 export DS_WORKER_ADDR="${WORKER_IP}:31501"
+export DATASYSTEM_CLIENT_LOG_DIR="/var/log/yuanrong/client"
 export DS_ENABLE_EXCLUSIVE_CONNECTION=0
 export DS_ENABLE_REMOTE_H2D=0
+
+mkdir -p "${DATASYSTEM_CLIENT_LOG_DIR}"
 ```
+
+Set `DATASYSTEM_CLIENT_LOG_DIR` before starting vLLM because the Yuanrong
+client reads it during logging initialization. Client SDK logs, whose base
+name is normally `ds_client`, are written to this directory.
 
 #### Remote H2D Requirements
 
@@ -861,12 +913,17 @@ enabled and verified in the Yuanrong Datasystem deployment:
 dscli start -w \
   --worker_address "${WORKER_IP}:31501" \
   --etcd_address "${ETCD_IP}:2379" \
+  --log_dir "/var/log/yuanrong/worker" \
   --shared_memory_size_mb 40960 \
   --arena_per_tenant 1 \
   --enable_huge_tlb true \
   --enable_fallocate false \
-  --remote_h2d_device_ids "0,1,2,3,4,5,6,7" \
-  --enable_worker_worker_batch_get=true
+  --rpc_thread_num 64 \
+  --oc_thread_num 64 \
+  --enable_worker_worker_batch_get true \
+  --sc_regular_socket_num 0 \
+  --sc_stream_socket_num 0 \
+  --remote_h2d_device_ids "0,1,2,3,4,5,6,7"
 ```
 
 * Make sure the NPU driver, firmware, and CANN toolkit required by Yuanrong
@@ -937,9 +994,11 @@ and the worker process. Each instance must use a unique port value.
 
 ### Notes
 
-* The Yuanrong backend normalizes KV keys before calling Datasystem. Keys longer
-  than 255 characters or containing unsupported characters are rewritten, so do
-  not rely on the raw key string when debugging backend storage.
+* The Yuanrong backend normalizes KV keys before calling Datasystem. Supported
+  ASCII keys up to 1024 bytes are preserved. Longer keys or keys containing
+  unsupported characters are rewritten to a maximum of 1024 characters with a
+  hash suffix, so do not rely on the raw key string when debugging backend
+  storage.
 * No extra buffer pre-registration step is required for Yuanrong. The backend
   uses device pointers directly when building blob lists.
 

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -442,24 +442,34 @@ class TestYuanrongBackendMethods(unittest.TestCase):
 
     def test_get_empty(self):
         b = self._make_backend()
-        b.get([], [], [])
+        result = b.get([], [], [])
+        self.assertEqual(result, [])
         b._hetero_client.mget_h2d.assert_not_called()
 
     def test_get(self):
         b = self._make_backend()
         b._hetero_client.mget_h2d.return_value = []
-        b.get(["k1"], [[100]], [[10]])
+        result = b.get(["k1"], [[100]], [[10]])
+        self.assertEqual(result, [0])
         b._hetero_client.mget_h2d.assert_called_once()
+
+    def test_get_partial_failure(self):
+        b = self._make_backend()
+        b._hetero_client.mget_h2d.return_value = ["k2"]
+        result = b.get(["k1", "k2", "k3"], [[100], [200], [300]], [[10], [20], [30]])
+        self.assertEqual(result, [0, 1, 0])
 
     def test_get_failed_keys(self):
         b = self._make_backend()
         b._hetero_client.mget_h2d.return_value = ["k1"]
-        b.get(["k1"], [[100]], [[10]])  # Should log error
+        result = b.get(["k1"], [[100]], [[10]])  # Should log error
+        self.assertEqual(result, [1])
 
     def test_get_exception(self):
         b = self._make_backend()
         b._hetero_client.mget_h2d.side_effect = Exception("fail")
-        b.get(["k1"], [[100]], [[10]])
+        result = b.get(["k1"], [[100]], [[10]])
+        self.assertIsNone(result)
 
     def test_put_empty(self):
         b = self._make_backend()

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -297,11 +297,17 @@ class TestYuanrongHelper(unittest.TestCase):
         # Should have hash suffix
         self.assertIn("__", result[0])
 
-    def test_normalize_keys_long_key(self):
-        long_key = "a" * 300
+    def test_normalize_keys_at_max_length(self):
+        max_length_key = "a" * 1024
+        result = self.helper.normalize_keys([max_length_key])
+        self.assertEqual(result, [max_length_key])
+
+    def test_normalize_keys_over_max_length(self):
+        long_key = "a" * 1025
         result = self.helper.normalize_keys([long_key])
         self.assertEqual(len(result), 1)
-        self.assertLessEqual(len(result[0]), 255)
+        self.assertEqual(len(result[0]), 1024)
+        self.assertIn("__", result[0])
 
     def test_make_blob_lists(self):
         self.helper._device_id = 0

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -420,6 +420,14 @@ class TestYuanrongBackendMethods(unittest.TestCase):
             backend._helper.make_blob_lists = lambda a, s: [MagicMock() for _ in a]
             backend._hetero_client = MagicMock()
             backend._ds_set_param = MagicMock()
+            backend._is_a2 = False
+            backend._registered_buffers = None
+            backend._buffers_registered = False
+            backend.config = YuanrongConfig(
+                worker_addr="127.0.0.1:0",
+                enable_exclusive_connection=False,
+                enable_remote_h2d=False,
+            )
             backend.rank = 0
             return backend
 
@@ -486,12 +494,53 @@ class TestYuanrongBackendMethods(unittest.TestCase):
         b._hetero_client.mset_d2h.side_effect = Exception("fail")
         b.put(["k1"], [[100]], [[10]])
 
-    def test_register_buffer(self):
+    def test_register_buffer_noop_when_remote_h2d_disabled(self):
         b = self._make_backend()
-        b._helper._device_id = None
-        b._ensure_device_ready = MagicMock()
         b.register_buffer([100], [200])
-        b._ensure_device_ready.assert_called_once()
+        b._hetero_client.pre_register_device_memory.assert_not_called()
+
+    def test_register_buffer_when_remote_h2d_enabled(self):
+        b = self._make_backend()
+        b.config.enable_remote_h2d = True
+        b.register_buffer([100], [200])
+        b._hetero_client.pre_register_device_memory.assert_called_once_with([100], [200])
+
+    def test_register_buffer_noop_on_a2(self):
+        # A2 must not register (opposite of memcache_backend's _is_a2 gating).
+        b = self._make_backend()
+        b._is_a2 = True
+        b.config.enable_remote_h2d = True
+        b.register_buffer([100], [200])
+        b._hetero_client.pre_register_device_memory.assert_not_called()
+
+    def test_register_buffer_idempotent(self):
+        b = self._make_backend()
+        b.config.enable_remote_h2d = True
+        b.register_buffer([100], [200])
+        b.register_buffer([300], [400])
+        b._hetero_client.pre_register_device_memory.assert_called_once_with([100], [200])
+
+    def test_register_buffers_if_needed_no_buffers(self):
+        b = self._make_backend()
+        b.config.enable_remote_h2d = True
+        b._registered_buffers = None
+        b._register_buffers_if_needed()
+        b._hetero_client.pre_register_device_memory.assert_not_called()
+
+    def test_register_buffers_if_needed_already_registered(self):
+        b = self._make_backend()
+        b.config.enable_remote_h2d = True
+        b._registered_buffers = ([100], [200])
+        b._buffers_registered = True
+        b._register_buffers_if_needed()
+        b._hetero_client.pre_register_device_memory.assert_not_called()
+
+    def test_register_buffers_if_needed_disabled(self):
+        b = self._make_backend()
+        b.config.enable_remote_h2d = False
+        b._registered_buffers = ([100], [200])
+        b._register_buffers_if_needed()
+        b._hetero_client.pre_register_device_memory.assert_not_called()
 
     def test_ensure_device_ready(self):
         b = self._make_backend()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
@@ -11,6 +11,7 @@ from vllm.logger import logger
 from vllm.utils.network_utils import split_host_port
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend import Backend
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 
 def _iter_slices(total: int, batch_size: int):
@@ -114,6 +115,9 @@ class YuanrongBackend(Backend):
             enable_remote_h2d=self.config.enable_remote_h2d,
         )
         self._hetero_client.init()
+        self._is_a2 = get_ascend_device_type() in {AscendDeviceType.A2}
+        self._registered_buffers: tuple[list[int], list[int]] | None = None
+        self._buffers_registered = False
 
     def _ensure_device_ready(self):
         if self._helper._device_id is None:
@@ -126,9 +130,19 @@ class YuanrongBackend(Backend):
         self._helper._device_id = int(torch.npu.current_device())
 
     def register_buffer(self, ptrs: list[int], lengths: list[int]):
-        # Yuanrong APIs consume device pointers directly when building blob
-        # lists. No explicit pre-registration is required.
-        self._ensure_device_ready()
+        self._registered_buffers = (list(ptrs), list(lengths))
+        self._register_buffers_if_needed()
+
+    def _register_buffers_if_needed(self):
+        if self._is_a2:
+            return
+        if not self.config.enable_remote_h2d:
+            return
+        if self._registered_buffers is None or self._buffers_registered:
+            return
+        ptrs, lengths = self._registered_buffers
+        self._hetero_client.pre_register_device_memory(ptrs, lengths)  # type: ignore[union-attr]
+        self._buffers_registered = True
 
     def exists(self, keys: list[str]) -> list[int]:
         if len(keys) == 0:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
@@ -152,9 +152,9 @@ class YuanrongBackend(Backend):
             )
             return [0] * len(keys)
 
-    def get(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
+    def get(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]) -> list[int] | None:
         if len(keys) == 0:
-            return
+            return []
         failed_keys_for_log = keys
         try:
             self._ensure_device_ready()
@@ -181,6 +181,8 @@ class YuanrongBackend(Backend):
                     len(keys),
                 )
                 logger.debug("Failed to get key details. failed_keys=%s", failed_keys)
+            failed_set = set(failed_keys)
+            return [1 if k in failed_set else 0 for k in keys]
         except Exception as exc:
             logger.error(
                 "Failed to get %d keys out of %d. Check network and yuanrong service.",
@@ -193,6 +195,7 @@ class YuanrongBackend(Backend):
                 type(exc).__name__,
                 exc,
             )
+            return None
 
     def put(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         if len(keys) == 0:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
@@ -39,7 +39,7 @@ class YuanrongConfig:
 
 
 class YuanrongHelper:
-    _DS_KEY_MAX_LEN = 255
+    _DS_KEY_MAX_LEN = 1024
     _DS_KEY_ALLOWED_PATTERN = re.compile(r"^[a-zA-Z0-9\-_!@#%\^\*\(\)\+\=\:;]+$")
     _DS_KEY_INVALID_CHAR_PATTERN = re.compile(r"[^a-zA-Z0-9\-_!@#%\^\*\(\)\+\=\:;]")
     _DS_KEY_HASH_SUFFIX_LEN = 16


### PR DESCRIPTION
### What this PR does / why we need it?

This PR improves the Yuanrong backend used by KV Pool:

- Raises the Yuanrong key normalization limit from 255 to 1024 characters so valid Datasystem keys up to the SDK limit are preserved.
- Keeps over-length or unsupported keys normalized with a deterministic hash suffix.
- Makes `YuanrongBackend.get()` return per-key load results (`0` for success, `1` for failed keys, and `None` when the backend request raises), allowing KV Pool to record failed block ids and trigger recompute fallback for missing blocks.
- Expands the Yuanrong KV Pool guide with recommended Datasystem worker startup options, client log configuration, HugeTLB checks, and the updated key-normalization behavior.

The main functional fix is that Yuanrong `mget_h2d()` reports failed keys, but the backend previously dropped that information, so KV Pool could not map load failures back to block ids.

### Does this PR introduce _any_ user-facing change?

Yes. Yuanrong KV Pool behavior changes in two ways:

- Supported ASCII KV keys up to 1024 characters are now preserved instead of being normalized after 255 characters.
- Yuanrong load failures can now be surfaced to KV Pool's failed-block tracking for recompute fallback.

No command-line API is changed. The documentation is updated with clearer Yuanrong deployment guidance.

### How was this patch tested?

- Added/updated unit test coverage in `tests/ut/distributed/ascend_store/test_backend.py` for:
  - Yuanrong key normalization at and beyond the 1024-character limit.
  - Yuanrong `get()` success, partial failure, failed key, and exception return values.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/b9a7cd464c9ae9b1b450f8982b76d7be4de73724
