### PR TITLE
[BugFix][SpecDecode] Remove redundant token_ids_cpu write in AscendNgramProposer

### DIFF
--- a/vllm_ascend/spec_decode/ngram_proposer.py
+++ b/vllm_ascend/spec_decode/ngram_proposer.py
@@ -53,9 +53,16 @@ class AscendNgramProposer(NgramProposer):
                     # Skip requests that have already reached the max model length.
                     continue
 
-                start_idx = input_batch.num_tokens_no_spec[i]
-                end_idx = start_idx + num_sampled_ids
-                input_batch.token_ids_cpu[i, start_idx:end_idx] = sampled_ids
+                # NOTE: The sampled tokens are already written into
+                # ``token_ids_cpu`` (and ``num_tokens_no_spec`` is already
+                # advanced) by ``_bookkeeping_sync`` in the model runner, which
+                # runs *before* this proposer. Mirroring upstream vLLM's
+                # ``NgramProposer.propose``, we must NOT write them again here:
+                # doing so would write at an incorrect offset
+                # ``num_tokens_no_spec + num_sampled_ids`` (since
+                # ``num_tokens_no_spec`` already reflects the just-sampled
+                # tokens) and could overflow ``token_ids_cpu`` when a request
+                # is close to ``max_model_len``.
 
                 valid_ngram_requests.append(i)
 


### PR DESCRIPTION
## What this PR does / why we need it?

`AscendNgramProposer.propose()` wrote the just-sampled tokens into `token_ids_cpu` a second time, at an **incorrect offset**.

The model runner's `_bookkeeping_sync()` already writes `sampled_ids` into `token_ids_cpu` at `[num_tokens_no_spec : num_tokens_no_spec + num_sampled_ids]` and advances `num_tokens_no_spec` **before** the proposer runs (see `model_runner_v1.py`). Reading the now-already-updated `num_tokens_no_spec`, the proposer re-wrote at `[num_tokens_no_spec : num_tokens_no_spec + num_sampled_ids]` — shifted forward by `num_sampled_ids` relative to the correct position.

This diverges from upstream vLLM's `NgramProposer.propose()`, which is **read-only** on `token_ids_cpu`.

**Why this is a bug:**
- The redundant write lands beyond the valid context window, so `batch_propose_numba` (which only reads `token_ids_cpu[idx, :num_tokens_no_spec]`) does not read it → harmless to correctness in the common case.
- **Crash near `max_model_len`:** when a request is close to the length limit, i.e. `P + 2*L > max_model_len` (where `P` = `num_tokens_no_spec` after bookkeeping, `L` = `num_sampled_ids`), numpy clips the slice `[P : P+L]` to the buffer and the assignment of `L` elements into the clipped slot raises `ValueError: could not broadcast input array from shape (L,) into shape (<L,)`, crashing n-gram speculative decoding near end-of-generation.

**Fix:** drop the redundant write, aligning with upstream `NgramProposer.propose()`.

Closes #10321.

## Does this PR introduce _any_ user-facing change?

No API change. Fixes a crash of n-gram speculative decoding for requests near `max_model_len`.

## How was this patch tested?

- Verified the crash path locally: assigning a length-`L` list into a clipped numpy slice reproduces `ValueError` (broadcast shape mismatch), confirming the overflow is reachable when `P + 2*L > max_model_len`.
- Code-path inspection: `batch_propose_numba` only reads `token_ids_cpu[idx, :num_tokens_no_spec[idx]]`, so removing the write does not change n-gram lookup results — the tokens are already in place from `_bookkeeping_sync`.
- Diff alignment: the resulting `propose()` now matches upstream `vllm/v1/spec_decode/ngram_proposer.py::NgramProposer.propose()` (read-only on `token_ids_cpu`).
- CI only (no NPU available locally for end-to-end n-gram run).

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
