### PR TITLE
[Doc][Misc] Update sleep_mode guide with model weights and max_tokens

### DIFF
--- a/docs/source/user_guide/feature_guide/sleep_mode.md
+++ b/docs/source/user_guide/feature_guide/sleep_mode.md
@@ -82,15 +82,15 @@ This step is skipped entirely for dense models (which have no expert weights) an
 
 ## Prepare Model Weights
 
-Use the W8A8SC quantized weights from the Eco-Tech official ModelScope repository.
+Use the `Qwen2.5-0.5B-Instruct` model weights. With `VLLM_USE_MODELSCOPE=True`, the model will be downloaded automatically from ModelScope.
 
 ```{list-table}
 :header-rows: 1
 
 * - Model
   - ModelScope Link
-* - Qwen3-8B-W8A8SC-310
-  - [Eco-Tech/Qwen3-8B-w8a8sc-310-vllm](https://www.modelscope.cn/models/Eco-Tech/Qwen3-8B-w8a8sc-310-vllm)
+* - Qwen2.5-0.5B-Instruct
+  - [Qwen/Qwen2.5-0.5B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct)
 ```
 
 ## Usage

--- a/docs/source/user_guide/feature_guide/sleep_mode.md
+++ b/docs/source/user_guide/feature_guide/sleep_mode.md
@@ -80,6 +80,19 @@ After the sleep-mode allocator restores the original (untransposed) memory, `wak
 
 This step is skipped entirely for dense models (which have no expert weights) and for quantized models (whose weights are handled by the quantization method).
 
+## Prepare Model Weights
+
+Use the W8A8SC quantized weights from the Eco-Tech official ModelScope repository.
+
+```{list-table}
+:header-rows: 1
+
+* - Model
+  - ModelScope Link
+* - Qwen3-8B-W8A8SC-310
+  - [Eco-Tech/Qwen3-8B-w8a8sc-310-vllm](https://www.modelscope.cn/models/Eco-Tech/Qwen3-8B-w8a8sc-310-vllm)
+```
+
 ## Usage
 
 The following is a simple example of how to use sleep mode.
@@ -106,7 +119,7 @@ The following is a simple example of how to use sleep mode.
         # record npu memory use baseline in case other process is running
         used_bytes_baseline = total - free
         llm = LLM("Qwen/Qwen2.5-0.5B-Instruct", enable_sleep_mode=True)
-        sampling_params = SamplingParams(temperature=0, max_completion_tokens=10)
+        sampling_params = SamplingParams(temperature=0, max_tokens=10)
         output = llm.generate(prompt, sampling_params)
 
         llm.sleep(level=1)
@@ -165,7 +178,7 @@ The following is a simple example of how to use sleep mode.
         -d '{
             "model": "Qwen/Qwen2.5-0.5B-Instruct",
             "prompt": "The future of AI is",
-            "max_completion_tokens": 7,
+            "max_tokens": 7,
             "temperature": 0
         }'
     ```


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the Sleep Mode guide (`docs/source/user_guide/feature_guide/sleep_mode.md`) with two documentation improvements:
1. **Add a Prepare Model Weights section** — Documents how to obtain the model weights used in the examples (`Qwen2.5-0.5B-Instruct` from ModelScope). With `VLLM_USE_MODELSCOPE=True`, the model is downloaded automatically, which helps users get started without guessing which weights to use.
2. **Replace `max_completion_tokens` with `max_tokens`** — Updates the offline `SamplingParams` example and the online `/v1/completions` curl example to use `max_tokens`, consistent with the completions API parameter naming.
These changes make the Sleep Mode guide easier to follow for users trying the offline inference and online serving examples.
### Does this PR introduce _any_ user-facing change?
No.
### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
