### PR TITLE
[CI] ensure pyyaml is installed into the correct Python environment

### DIFF
--- a/.github/workflows/pr_nightly_command.yml
+++ b/.github/workflows/pr_nightly_command.yml
@@ -100,6 +100,10 @@ jobs:
         if: steps.auth.outputs.is_authorized == 'false'
         run: exit 1
 
+      - name: Install Python dependencies
+        if: steps.auth.outputs.is_authorized == 'true'
+        run: pip3 install pyyaml -q
+
       - name: Resolve test cases and branch
         id: resolve
         if: steps.auth.outputs.is_authorized == 'true'

--- a/.github/workflows/scripts/resolve_nightly_tests.py
+++ b/.github/workflows/scripts/resolve_nightly_tests.py
@@ -7,7 +7,7 @@ import subprocess
 try:
     import yaml
 except ImportError:
-    subprocess.check_call(["pip3", "install", "pyyaml", "-q", "--user"])
+    subprocess.check_call(["pip3", "install", "pyyaml", "-q"])
     import yaml
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

- The resolve_nightly_tests.py script requires pyyaml but it was not pre-installed in the runner container, causing ModuleNotFoundError.
- Added explicit pip3 install step in the authorize job.
- Removed --user flag from the script's fallback install to avoid PYTHONPATH issues in root containers.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
