### PR TITLE
[BugFix] support ASCEND_GLOBAL_RESOURCE_CONFIG store path

### DIFF
--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -115,8 +115,20 @@ export PYTHONHASHSEED=0
 | Hardware | Dependencies | Export Command | Description |
 | :--- | :--- | :--- | :--- |
 | 800 I/T A3 series | HDK >= 26.0<br>or HDK >= 25.5 with mooncake >= v0.3.11.post1<br>CANN >= 9.0.0<br>LingQu Computing Network >= 1.5 | `export ASCEND_ENABLE_USE_FABRIC_MEM=1` | **Recommended**. Enables unified memory address direct transmission scheme. With SSD offload, see [Fabric memory size alignment](#122-fabric-memory-size-alignment-a3--ascend_enable_use_fabric_mem1) — memory sizes must be aligned to 1GB. |
+| 800 I/T A3 series | CANN >= 9.1.0<br>Mooncake with `ASCEND_GLOBAL_RESOURCE_CONFIG` store forwarding support | `export ASCEND_GLOBAL_RESOURCE_CONFIG='{"comm_resource_config.protocol_desc":["hccs:device"],"store":{"comm_resource_config.protocol_desc":["roce:device"]}}'` | Enables HIXL resource configuration for Store/PD traffic separation. The top-level `comm_resource_config` controls PD transfer traffic, while the `store` section controls Mooncake Store traffic. |
 | 800 I/T A3 series | If any dependency above is not met | `export ASCEND_BUFFER_POOL=4:8` | Configures the number and size of buffers on the NPU Device for aggregation and KV transfer (e.g., `4:8` means 4 buffers of 8MB). |
 | 800 I/T A2 series | HDK >= 25.5 is recommended | `export HCCL_INTRA_ROCE_ENABLE=1` | Required by direct transmission scheme on 800 I/T A2 series|
+
+`ASCEND_GLOBAL_RESOURCE_CONFIG` is a JSON string passed to HIXL. Common fields are:
+
+| Field | Description |
+| :--- | :--- |
+| `comm_resource_config.protocol_desc` | Protocol descriptor for the top-level Mooncake transfer engine. In PD disaggregation, this controls the `MooncakeConnectorV1` PD transfer path. Example values include `["hccs:device"]` and `["roce:device"]`. |
+| `store.comm_resource_config.protocol_desc` | Protocol descriptor for Mooncake Store traffic used by `AscendStoreConnector`. On A3, this can be set to `["roce:device"]` while PD transfer uses HCCS. |
+| `comm_resource_config.listen_port` | One-sided communication listen port. The HIXL default is `16666`; use a different port for standalone `mooncake_client` processes to avoid conflicts with embedded clients. |
+| `fabric_memory.max_capacity` | Fabric memory quota in GB per process. Use it only when the fabric memory budget is too small; see [Fabric memory size alignment](#122-fabric-memory-size-alignment-a3--ascend_enable_use_fabric_mem1). |
+
+Store/PD traffic separation requires **CANN >= 9.1.0**. It is intended for A3 deployments where PD transfer traffic can use HCCS and Mooncake Store traffic can use ROCE, so the two traffic classes do not compete on the same physical link. For more HIXL deployment patterns, see the [Mooncake + HIXL pooling overview](https://gitcode.com/cann/hixl/wiki/Mooncake%20+%20HIXL%20%E6%B1%A0%E5%8C%96%E6%96%B9%E6%A1%88%E6%80%BB%E8%A7%88%EF%BC%88A2%20-%20A3%EF%BC%89.md).
 
 ### Run Mooncake Master
 
@@ -165,6 +177,8 @@ mooncake_master --port 50088 --eviction_high_watermark_ratio 0.9 --eviction_rati
 #### 1. Run `prefill` Node and `decode` Node
 
 Using `MultiConnector` to simultaneously utilize both `MooncakeConnectorV1` and `AscendStoreConnector`. `MooncakeConnectorV1` performs kv_transfer, while `AscendStoreConnector` serves as the prefix-cache node.
+
+For A3 Store/PD traffic separation, set `ASCEND_GLOBAL_RESOURCE_CONFIG` on both the prefill and decode nodes and use **CANN >= 9.1.0**. The top-level resource configuration controls `MooncakeConnectorV1` PD traffic, and the `store` section controls `AscendStoreConnector` Mooncake Store traffic.
 
 `prefill` Node:
 

--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -115,7 +115,6 @@ export PYTHONHASHSEED=0
 | Hardware | Dependencies | Export Command | Description |
 | :--- | :--- | :--- | :--- |
 | 800 I/T A3 series | HDK >= 26.0<br>or HDK >= 25.5 with mooncake >= v0.3.11.post1<br>CANN >= 9.0.0<br>LingQu Computing Network >= 1.5 | `export ASCEND_ENABLE_USE_FABRIC_MEM=1` | **Recommended**. Enables unified memory address direct transmission scheme. With SSD offload, see [Fabric memory size alignment](#122-fabric-memory-size-alignment-a3--ascend_enable_use_fabric_mem1) — memory sizes must be aligned to 1GB. |
-| 800 I/T A3 series | CANN >= 9.1.0<br>Mooncake with `ASCEND_GLOBAL_RESOURCE_CONFIG` store forwarding support | `export ASCEND_GLOBAL_RESOURCE_CONFIG='{"comm_resource_config.protocol_desc":["hccs:device"],"store":{"comm_resource_config.protocol_desc":["roce:device"]}}'` | Enables HIXL resource configuration for Store/PD traffic separation. The top-level `comm_resource_config` controls PD transfer traffic, while the `store` section controls Mooncake Store traffic. |
 | 800 I/T A3 series | If any dependency above is not met | `export ASCEND_BUFFER_POOL=4:8` | Configures the number and size of buffers on the NPU Device for aggregation and KV transfer (e.g., `4:8` means 4 buffers of 8MB). |
 | 800 I/T A2 series | HDK >= 25.5 is recommended | `export HCCL_INTRA_ROCE_ENABLE=1` | Required by direct transmission scheme on 800 I/T A2 series|
 

--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -170,6 +170,10 @@ for _pkg in ["vllm_ascend", "vllm_ascend.distributed"]:
     if _pkg not in sys.modules:
         sys.modules[_pkg] = _make_pkg(_pkg)
 
+_ascend_parallel_state = _make_pkg("vllm_ascend.distributed.parallel_state")
+_ascend_parallel_state.get_global_rank = MagicMock(return_value=0)  # type: ignore[attr-defined]
+sys.modules["vllm_ascend.distributed.parallel_state"] = _ascend_parallel_state
+
 _kv_transfer_init = _make_pkg("vllm_ascend.distributed.kv_transfer")
 _kv_transfer_init.register_connector = MagicMock()  # type: ignore[attr-defined]
 sys.modules["vllm_ascend.distributed.kv_transfer"] = _kv_transfer_init

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -19,6 +19,7 @@ import json
 import os
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
@@ -345,6 +346,7 @@ class TestMooncakeBackendMethods(unittest.TestCase):
             backend._lazy_init = False
             backend._store_initialized = True
             backend._use_fabric_mem = False
+            backend._use_store_independent_te = False
             backend._store_init_lock = MagicMock()
             backend.local_seg = None
             return backend
@@ -397,6 +399,57 @@ class TestMooncakeBackendMethods(unittest.TestCase):
         ):
             b.register_buffer([100], [200])
             mock_te.register_buffer.assert_called_once()
+
+    def test_register_buffer_with_store_independent_te(self):
+        b = self._make_backend()
+        b._use_store_independent_te = True
+        b.store.register_buffer.return_value = 0
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend.global_te"
+        ) as mock_te:
+            b.register_buffer([100, 101], [200, 201])
+            b.store.register_buffer.assert_any_call(100, 200)
+            b.store.register_buffer.assert_any_call(101, 201)
+            self.assertEqual(b.store.register_buffer.call_count, 2)
+            mock_te.register_buffer.assert_not_called()
+
+    def test_register_buffer_skips_fabric_mem(self):
+        b = self._make_backend()
+        b._use_fabric_mem = True
+        b.register_buffer([100], [200])
+        b.store.register_buffer.assert_not_called()
+
+    def test_setup_store_with_store_independent_te(self):
+        b = self._make_backend()
+        b._use_store_independent_te = True
+        b.config = SimpleNamespace(
+            metadata_server="P2PHANDSHAKE",
+            global_segment_size=1024,
+            local_buffer_size=2048,
+            protocol="ascend",
+            device_name="",
+            master_server_address="127.0.0.1:50088",
+            enable_ssd_offload=False,
+        )
+        with (
+            patch("mooncake.store.MooncakeDistributedStore") as mock_store_cls,
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend.global_te"
+            ) as mock_te,
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend.get_ip",
+                return_value="127.0.0.1",
+            ),
+        ):
+            mock_store = mock_store_cls.return_value
+            mock_store.setup.return_value = 0
+            self.assertIs(b._setup_store(), mock_store)
+            mock_te.get_transfer_engine.assert_not_called()
+            mock_store.setup.assert_called_once()
+            setup_kwargs = mock_store.setup.call_args.kwargs
+            self.assertEqual(setup_kwargs["local_hostname"], "127.0.0.1")
+            self.assertEqual(setup_kwargs["local_buffer_size"], 0)
+            self.assertNotIn("engine", setup_kwargs)
 
 
 # =========================================================================

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -68,6 +68,10 @@ class MooncakeBackend(Backend):
         self.store: Any | None = None
         self.local_seg: str | None = None
         self._use_fabric_mem = os.getenv("ASCEND_ENABLE_USE_FABRIC_MEM", "0") == "1"
+        # ASCEND_GLOBAL_RESOURCE_CONFIG: dual-protocol / RoCE Store path where the store
+        # operates independently of the global transfer engine; setup goes through store
+        # and buffers are registered via store.register_buffer() instead of global_te.
+        self._use_store_independent_te = bool(os.getenv("ASCEND_GLOBAL_RESOURCE_CONFIG")) and not self._use_fabric_mem
         self._lazy_init = lazy_init and self._use_fabric_mem
         self._store_initialized = False
         self._store_init_lock = threading.Lock()
@@ -114,7 +118,8 @@ class MooncakeBackend(Backend):
         # ASCEND_ENABLE_USE_FABRIC_MEM: Enable unified memory address direct transmission scheme
         # and only can be used for 800 I/T A3 series.
         # Required supporting hardware versions are as follows:
-        if not self._use_fabric_mem:
+        # ASCEND_GLOBAL_RESOURCE_CONFIG takes the same store-independent-TE setup path as fabric-mem.
+        if not self._use_fabric_mem and not self._use_store_independent_te:
             transfer_engine = global_te.get_transfer_engine(local_hostname, device_name=None)
             self.local_seg = local_hostname + ":" + str(transfer_engine.get_rpc_port())
             ret = store.setup(
@@ -162,7 +167,18 @@ class MooncakeBackend(Backend):
         torch.npu.set_device(device)
 
     def register_buffer(self, ptrs: list[int], lengths: list[int]):
-        if not self._use_fabric_mem:
+        if self._use_store_independent_te:
+            assert self.store is not None
+            for ptr, length in zip(ptrs, lengths):
+                ret = self.store.register_buffer(ptr, length)
+                if ret != 0:
+                    logger.error(
+                        "Failed to register buffer via store: ptr=%s, length=%s, ret=%s",
+                        ptr,
+                        length,
+                        ret,
+                    )
+        elif not self._use_fabric_mem:
             local_hostname = get_ip()
             global_te.get_transfer_engine(local_hostname, device_name=None)
             global_te.register_buffer(ptrs, lengths)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR supports the Mooncake Store-independent transfer-engine setup path when `ASCEND_GLOBAL_RESOURCE_CONFIG` is set.

It updates the Mooncake path to:

- Use the Store-independent transfer-engine setup path when `ASCEND_GLOBAL_RESOURCE_CONFIG` is configured.
- Register local Mooncake Store buffers through `store.register_buffer()` for the Store-independent path.
- Keep fabric-mem buffer registration skipped for this path.
- Document the `ASCEND_GLOBAL_RESOURCE_CONFIG` fields and the CANN 9.1+ requirement for Store/PD traffic separation.

### Does this PR introduce _any_ user-facing change?

No. Existing configurations keep their current behavior. Users who configure `ASCEND_GLOBAL_RESOURCE_CONFIG` can use the Store-independent path.

### How was this patch tested?

CI.
