### PR TITLE
[Bugfix] Fix preempted-then-resumed requests for using right num_tokens

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -732,6 +732,12 @@ class NPUModelRunner(GPUModelRunner):
 
         result = super()._update_states(scheduler_output)
 
+        # For preempted-then-resumed requests, attach the prefill token
+        # count to the CachedRequestState so that its (patched) num_tokens
+        # property returns the full token history instead of just the
+        # original prompt length. The request only appears in
+        # scheduled_new_reqs once (first chunk), but the attribute
+        # persists on the state instance for subsequent steps.
         for new_req_data in scheduler_output.scheduled_new_reqs:
             if new_req_data.prefill_token_ids:
                 req_state = self.requests.get(new_req_data.req_id)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1044,15 +1044,6 @@ class NPUModelRunner(GPUModelRunner):
         if not hasattr(self, "_sched_num_tokens_cache"):
             self._sched_num_tokens_cache: dict[str, int] = {}
         for new_req_data in scheduler_output.scheduled_new_reqs:
-            logger.info(
-                "RUNNER_NEW_REQ %s: prefill_token_ids_len=%d, num_computed=%d, "
-                "num_tokens=%d",
-                new_req_data.req_id,
-                len(new_req_data.prefill_token_ids)
-                if new_req_data.prefill_token_ids else 0,
-                new_req_data.num_computed_tokens,
-                new_req_data.num_tokens if hasattr(new_req_data, "num_tokens") else -1,
-            )
             if new_req_data.prefill_token_ids:
                 self._sched_num_tokens_cache[new_req_data.req_id] = len(
                     new_req_data.prefill_token_ids

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1044,7 +1044,7 @@ class NPUModelRunner(GPUModelRunner):
             )
 
         # Record the index of requests that should not be sampled,
-        # so that we could clear the sampled tokens before returning.
+        # so that we could clear the sampled tokens before returning
         num_tokens = [self.requests[r].num_tokens for r in self.input_batch.req_ids]
         num_tokens_np = np.array(num_tokens, dtype=np.int32)
         base_num_reqs = self.input_batch.num_reqs

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1058,6 +1058,14 @@ class NPUModelRunner(GPUModelRunner):
             + len(self.requests[r].output_token_ids)
             for r in self.input_batch.req_ids
         ]
+        # Prune cache to only keep active requests, preventing unbounded
+        # memory growth from completed/aborted requests.
+        active_req_ids = set(self.input_batch.req_ids)
+        self._sched_num_tokens_cache = {
+            req_id: val
+            for req_id, val in self._sched_num_tokens_cache.items()
+            if req_id in active_req_ids
+        }
         num_tokens_np = np.array(num_tokens, dtype=np.int32)
         base_num_reqs = self.input_batch.num_reqs
         num_reqs = base_num_reqs

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1034,8 +1034,39 @@ class NPUModelRunner(GPUModelRunner):
             )
 
         # Record the index of requests that should not be sampled,
-        # so that we could clear the sampled tokens before returning
-        num_tokens = [self.requests[r].num_tokens for r in self.input_batch.req_ids]
+        # so that we could clear the sampled tokens before returning.
+        # For preempted-then-resumed requests, the scheduler's
+        # NewRequestData.prefill_token_ids carries the full _all_token_ids
+        # (prompt + old output tokens). Use that length as num_tokens
+        # so the discard decision aligns with the scheduler's is_prefill_chunk.
+        # Cache the value across scheduling steps because the request only
+        # appears in scheduled_new_reqs once (first chunk).
+        if not hasattr(self, "_sched_num_tokens_cache"):
+            self._sched_num_tokens_cache: dict[str, int] = {}
+        for new_req_data in scheduler_output.scheduled_new_reqs:
+            logger.info(
+                "RUNNER_NEW_REQ %s: prefill_token_ids_len=%d, num_computed=%d, "
+                "num_tokens=%d",
+                new_req_data.req_id,
+                len(new_req_data.prefill_token_ids)
+                if new_req_data.prefill_token_ids else 0,
+                new_req_data.num_computed_tokens,
+                new_req_data.num_tokens if hasattr(new_req_data, "num_tokens") else -1,
+            )
+            if new_req_data.prefill_token_ids:
+                self._sched_num_tokens_cache[new_req_data.req_id] = len(
+                    new_req_data.prefill_token_ids
+                )
+        # num_tokens = base + len(output_token_ids).
+        # - For normal requests: base = num_prompt_tokens (e.g. 63)
+        # - For preempted requests: base = len(prefill_token_ids) (e.g. 3685,
+        #   includes old output tokens). output_token_ids grows naturally
+        #   as new tokens are appended during resumption/decode.
+        num_tokens = [
+            self._sched_num_tokens_cache.get(r, self.requests[r].num_prompt_tokens)
+            + len(self.requests[r].output_token_ids)
+            for r in self.input_batch.req_ids
+        ]
         num_tokens_np = np.array(num_tokens, dtype=np.int32)
         base_num_reqs = self.input_batch.num_reqs
         num_reqs = base_num_reqs

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -730,7 +730,17 @@ class NPUModelRunner(GPUModelRunner):
                 if num_computed_tokens < req_state.num_computed_tokens:
                     req_state.prev_num_draft_len = 0
 
-        return super()._update_states(scheduler_output)
+        result = super()._update_states(scheduler_output)
+
+        for new_req_data in scheduler_output.scheduled_new_reqs:
+            if new_req_data.prefill_token_ids:
+                req_state = self.requests.get(new_req_data.req_id)
+                if req_state is not None:
+                    req_state._prefill_token_count = len(
+                        new_req_data.prefill_token_ids
+                    )
+
+        return result
 
     def _pad_query_start_loc_for_fia(
         self,
@@ -1035,37 +1045,7 @@ class NPUModelRunner(GPUModelRunner):
 
         # Record the index of requests that should not be sampled,
         # so that we could clear the sampled tokens before returning.
-        # For preempted-then-resumed requests, the scheduler's
-        # NewRequestData.prefill_token_ids carries the full _all_token_ids
-        # (prompt + old output tokens). Use that length as num_tokens
-        # so the discard decision aligns with the scheduler's is_prefill_chunk.
-        # Cache the value across scheduling steps because the request only
-        # appears in scheduled_new_reqs once (first chunk).
-        if not hasattr(self, "_sched_num_tokens_cache"):
-            self._sched_num_tokens_cache: dict[str, int] = {}
-        for new_req_data in scheduler_output.scheduled_new_reqs:
-            if new_req_data.prefill_token_ids:
-                self._sched_num_tokens_cache[new_req_data.req_id] = len(
-                    new_req_data.prefill_token_ids
-                )
-        # num_tokens = base + len(output_token_ids).
-        # - For normal requests: base = num_prompt_tokens (e.g. 63)
-        # - For preempted requests: base = len(prefill_token_ids) (e.g. 3685,
-        #   includes old output tokens). output_token_ids grows naturally
-        #   as new tokens are appended during resumption/decode.
-        num_tokens = [
-            self._sched_num_tokens_cache.get(r, self.requests[r].num_prompt_tokens)
-            + len(self.requests[r].output_token_ids)
-            for r in self.input_batch.req_ids
-        ]
-        # Prune cache to only keep active requests, preventing unbounded
-        # memory growth from completed/aborted requests.
-        active_req_ids = set(self.input_batch.req_ids)
-        self._sched_num_tokens_cache = {
-            req_id: val
-            for req_id, val in self._sched_num_tokens_cache.items()
-            if req_id in active_req_ids
-        }
+        num_tokens = [self.requests[r].num_tokens for r in self.input_batch.req_ids]
         num_tokens_np = np.array(num_tokens, dtype=np.int32)
         base_num_reqs = self.input_batch.num_reqs
         num_reqs = base_num_reqs

--- a/vllm_ascend/worker/npu_input_batch.py
+++ b/vllm_ascend/worker/npu_input_batch.py
@@ -29,17 +29,21 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 
 from vllm_ascend.worker.block_table import MultiGroupBlockTable
 
-# Monkey-patch CachedRequestState.num_tokens to handle
-# preempted-then-resumed requests correctly.
-# For preempted requests, the scheduler sends prefill_token_ids
-# (prompt + old output tokens). We store its length as
-# _prefill_token_count. The patched num_tokens uses that as
-# the base instead of num_prompt_tokens (which only has the
-# original prompt length).
+# Patch CachedRequestState.num_tokens for preempted-then-resumed
+# requests. The scheduler's NewRequestData.prefill_token_ids carries
+# the full _all_token_ids (prompt + old output tokens). Store that
+# length on the request state so num_tokens reflects the total token
+# count, not just the original prompt length. This keeps the discard
+# decision (discard_requests_mask) aligned with the scheduler's
+# is_prefill_chunk without needing a global cache on the model runner.
 _original_num_tokens_prop = CachedRequestState.num_tokens
 
 
 def _patched_num_tokens(self) -> int:
+    # - Normal requests: base = num_prompt_tokens (e.g. 63)
+    # - Preempted requests: base = _prefill_token_count (e.g. 3685,
+    #   includes old output tokens).  output_token_ids grows naturally
+    #   as new tokens are appended during resumption/decode.
     prefill_count = getattr(self, "_prefill_token_count", 0)
     if prefill_count:
         return prefill_count + len(self.output_token_ids)

--- a/vllm_ascend/worker/npu_input_batch.py
+++ b/vllm_ascend/worker/npu_input_batch.py
@@ -25,9 +25,28 @@ from vllm.v1.kv_cache_interface import KVCacheGroupSpec
 from vllm.v1.outputs import LogprobsTensors
 from vllm.v1.pool.metadata import PoolingStates
 from vllm.v1.sample.logits_processor import BatchUpdateBuilder, LogitsProcessors
-from vllm.v1.worker.gpu_input_batch import InputBatch
+from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 
 from vllm_ascend.worker.block_table import MultiGroupBlockTable
+
+# Monkey-patch CachedRequestState.num_tokens to handle
+# preempted-then-resumed requests correctly.
+# For preempted requests, the scheduler sends prefill_token_ids
+# (prompt + old output tokens). We store its length as
+# _prefill_token_count. The patched num_tokens uses that as
+# the base instead of num_prompt_tokens (which only has the
+# original prompt length).
+_original_num_tokens_prop = CachedRequestState.num_tokens
+
+
+def _patched_num_tokens(self) -> int:
+    prefill_count = getattr(self, "_prefill_token_count", 0)
+    if prefill_count:
+        return prefill_count + len(self.output_token_ids)
+    return self.num_prompt_tokens + len(self.output_token_ids)
+
+
+CachedRequestState.num_tokens = property(_patched_num_tokens)
 
 
 class NPUInputBatch(InputBatch):


### PR DESCRIPTION
### What this PR does / why we need it?

Ensure that when a preempted request is resumed, the vLLM-ascend model_runner_v1 correctly uses the updated num_tokens (reflecting the already-computed token length) rather than the original num_prompt_tokens, so that the prompt phase boundary is consistent with the vLLM scheduler's view and chunk_prefill is correctly identified. [issues 11296](https://github.com/vllm-project/vllm-ascend/issues/11296)

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
