### PR TITLE
[Feature] Support NZ quant_matmul for A5

### DIFF
--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -19,6 +19,7 @@ from unittest import mock
 
 import pytest
 import torch
+import torch_npu
 
 from tests.ut.base import TestBase
 from vllm_ascend import utils
@@ -389,6 +390,68 @@ class TestUtils(TestBase):
             result = utils.maybe_trans_nz(weight)
             self.assertIs(result, weight)
             assert_nz_cast(weight)
+
+        # Test case 8: customize_dtype is passed through to npu_format_cast
+        mock_npu_format_cast.reset_mock()
+        mock_config.weight_nz_mode = 2
+        with (
+            mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
+            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+        ):
+            weight = torch.randn(32, 64, dtype=torch.float8_e4m3fn)
+            result = utils.maybe_trans_nz(weight, customize_dtype=torch.float8_e4m3fn)
+            self.assertIs(result, weight)
+            mock_npu_format_cast.assert_called_once()
+            args, kwargs = mock_npu_format_cast.call_args
+            self.assertEqual(kwargs["customize_dtype"], torch.float8_e4m3fn)
+            self.assertNotIn("input_dtype", kwargs)
+
+        # Test case 9: input_dtype is passed through to npu_format_cast
+        mock_npu_format_cast.reset_mock()
+        mock_config.weight_nz_mode = 2
+        with (
+            mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
+            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+        ):
+            weight = torch.randn(32, 64, dtype=torch.float8_e4m3fn)
+            result = utils.maybe_trans_nz(weight, input_dtype=torch_npu.float4_e2m1fn_x2)
+            self.assertIs(result, weight)
+            mock_npu_format_cast.assert_called_once()
+            args, kwargs = mock_npu_format_cast.call_args
+            self.assertEqual(kwargs["input_dtype"], torch_npu.float4_e2m1fn_x2)
+            self.assertNotIn("customize_dtype", kwargs)
+
+        # Test case 10: both customize_dtype and input_dtype passed through
+        mock_npu_format_cast.reset_mock()
+        mock_config.weight_nz_mode = 2
+        with (
+            mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
+            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+        ):
+            weight = torch.randn(32, 64, dtype=torch.float8_e4m3fn)
+            result = utils.maybe_trans_nz(
+                weight,
+                customize_dtype=torch.float8_e4m3fn,
+                input_dtype=torch_npu.float4_e2m1fn_x2,
+            )
+            self.assertIs(result, weight)
+            mock_npu_format_cast.assert_called_once()
+            args, kwargs = mock_npu_format_cast.call_args
+            self.assertEqual(kwargs["customize_dtype"], torch.float8_e4m3fn)
+            self.assertEqual(kwargs["input_dtype"], torch_npu.float4_e2m1fn_x2)
+
+        # Test case 11: no conversion when _should_trans_nz returns False,
+        # even when customize_dtype is provided
+        mock_npu_format_cast.reset_mock()
+        mock_config.weight_nz_mode = 0
+        with (
+            mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
+            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+        ):
+            weight = torch.randn(32, 64, dtype=torch.float16)
+            result = utils.maybe_trans_nz(weight, customize_dtype=torch.float8_e4m3fn)
+            self.assertIs(result, weight)
+            mock_npu_format_cast.assert_not_called()
 
 
 def test_is_pd_decode_recompute_scheduler_enabled_without_config():

--- a/vllm_ascend/ops/mla.py
+++ b/vllm_ascend/ops/mla.py
@@ -125,6 +125,28 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
             layer_name=f"{prefix}.attn",
         )
 
+        # If mlapo will further process fused_qkv_a_proj / q_proj weights
+        # (transpose, reshape, and do its own NZ conversion), mark them so
+        # that quant methods (e.g. w8a8_mxfp8) skip their own NZ conversion.
+        # Must be set at init time, before VLLM traverses sub-modules and
+        # calls process_weights_after_loading on them.
+        impl = self.mla_attn.impl
+        if getattr(impl, "enable_mlapo", False) and not getattr(impl, "enable_dsa_cp", False):
+            from vllm_ascend.quantization.methods.w8a8_mxfp8 import (
+                AscendW8A8MXFP8DynamicLinearMethod,
+            )
+
+            for _layer in (impl.fused_qkv_a_proj, impl.q_proj):
+                if _layer is not None and isinstance(
+                    getattr(
+                        getattr(_layer, "quant_method", None),
+                        "quant_method",
+                        None,
+                    ),
+                    AscendW8A8MXFP8DynamicLinearMethod,
+                ):
+                    _layer._mlapo_managed = True
+
         original_process_weights = self.mla_attn.process_weights_after_loading
 
         def wrapped_process_weights(act_dtype: torch.dtype):

--- a/vllm_ascend/quantization/methods/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4_mxfp4.py
@@ -33,6 +33,7 @@ from vllm_ascend.device.mxfp_compat import (
 )
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
+from vllm_ascend.utils import maybe_trans_nz
 
 from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
 from .registry import register_scheme
@@ -120,6 +121,13 @@ class AscendW4A4MXFP4DynamicLinearMethod(AscendLinearScheme):
             layer.weight_scale.data = layer.weight_scale.data.reshape(n_dim, k_dim // 2, 2)
         layer.weight.data = layer.weight.data.transpose(0, 1)
         layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1)
+        # Skip NZ conversion for weights that will be further processed by
+        # mlapo (_process_weights_for_fused_mlapo), which does its own
+        # transpose + reshape + NZ conversion on these weights.
+        if not getattr(layer, "_mlapo_managed", False):
+            layer.weight.data = maybe_trans_nz(
+                layer.weight.data, customize_dtype=torch.float8_e4m3fn, input_dtype=torch_npu.float4_e2m1fn_x2
+            )
 
 
 @register_scheme("W4A4_MXFP4", "moe")

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -34,6 +34,7 @@ from vllm_ascend.device.mxfp_compat import (
 )
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
+from vllm_ascend.utils import maybe_trans_nz
 
 from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
 from .registry import register_scheme
@@ -138,7 +139,9 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
         else:
             layer.weight_scale.data = layer.weight_scale.data.reshape(n_dim, k_dim // 2, 2)
         layer.weight.data = layer.weight.data.transpose(0, 1).contiguous()
-        layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1).contiguous()
+        layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1)
+        if not getattr(layer, "_mlapo_managed", False):
+            layer.weight.data = maybe_trans_nz(layer.weight.data, customize_dtype=torch.float8_e4m3fn)
 
         # Mark as transformed
         layer._mxfp8_transformed = True

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -284,10 +284,12 @@ def _should_trans_nz(weight: torch.Tensor) -> bool:
 # - non-310P: follow VLLM_ASCEND_ENABLE_NZ
 # - FP32: never convert
 # - meta tensor: never convert
-def maybe_trans_nz(weight: torch.Tensor) -> torch.Tensor:
+def maybe_trans_nz(weight: torch.Tensor, customize_dtype=None, input_dtype=None) -> torch.Tensor:
     if not _should_trans_nz(weight):
         return weight
-    return torch_npu.npu_format_cast(weight, ACL_FORMAT_FRACTAL_NZ)
+    return torch_npu.npu_format_cast(
+        weight, ACL_FORMAT_FRACTAL_NZ, customize_dtype=customize_dtype, input_dtype=input_dtype
+    )
 
 
 def _round_up(x: int, align: int):


### PR DESCRIPTION
### What this PR does / why we need it?
Adds Fractal NZ (Nz) format support for quantized weights across MLA and MXFP quantization paths on Ascend NPU.
### Does this PR introduce _any_ user-facing change?
  No. This is an internal optimization —NZ format conversion happens transparently during weight loading. No new
  environment variables, API changes, or user-visible behavior changes.
### How was this patch tested?


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
