### PR TITLE
[CI] correct event action path in pr_nightly_command workflow

### DIFF
--- a/.github/workflows/pr_nightly_command.yml
+++ b/.github/workflows/pr_nightly_command.yml
@@ -113,7 +113,7 @@ jobs:
           PR_URL: ${{ github.event.client_payload.github.payload.issue.pull_request.url }}
         run: |
           # Derive command type from repository_dispatch action (e.g. nightly-command -> nightly)
-          COMMAND='${{ github.event.repository_dispatch.action }}'
+          COMMAND='${{ github.event.action }}'
           COMMAND="${COMMAND%-command}"
           echo "command=$COMMAND" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
### What this PR does / why we need it?
correct event action path in pr_nightly_command workflow
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
