### PR TITLE
[BugFix] Avoid 310P Mamba align postprocess hang for MTP

### DIFF
--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -104,6 +104,31 @@ def _do_mamba_copy_block_torch(copy_bufs: mamba_utils.MambaCopyBuffers):
         dst_state.copy_(src_state.clone())
     copy_bufs._tensor_copy_pairs = []
 
+def _postprocess_mamba_align_gpu_cpu_fallback(
+    *,
+    bufs: "mamba_utils.MambaBuffers",
+    num_reqs: int,
+    num_accept_tokens_gpu: torch.Tensor,
+    num_accept_tokens_cpu_tensor: torch.Tensor,
+    input_batch: GPUInputBatch,
+    kv_cache_config: KVCacheConfig,
+    forward_context: dict[str, Any],
+    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
+) -> None:
+    """CPU fallback path for Mamba postprocess_mamba_align_gpu on 310P.(no Triton)
+
+    On 310P, the Triton fused kernel is not available. This fallback skips
+    the GPU-side state copy(which will be handled by preprocess_mamba at next step).
+    and reset num_accept_tokens_cpu_tensor to 1, matching the Triton's kernel's behavior.
+    when ''src_block_idx == dest_block_idx'',so that the next ''preprocess_mamba'' uses 
+    ''accept_tokens_bias = 0'' 
+    """
+    ## Set num_accept_tokens_cpu_tensor to 1, matching the Triton's kernel's behavior
+    ## behavior.
+    ## when ''src_block_idx == dest_block_idx'',so that the next ''preprocess_mamba'' uses 
+    ## ''accept_tokens_bias = 0'' 
+    ones = torch.ones(num_reqs, dtype=torch.int32, device=num_accept_tokens_gpu.device)
+    num_accept_tokens_cpu_tensor[:num_reqs].copy_(ones, non_blocking=True)
 
 def _batch_memcpy_unavailable(src_ptrs, dst_ptrs, sizes):
     raise RuntimeError(
@@ -120,7 +145,7 @@ else:
     mamba_utils.batch_memcpy = _batch_memcpy_unavailable
     mamba_utils.collect_mamba_copy_meta = _collect_mamba_copy_meta_torch
     mamba_utils.do_mamba_copy_block = _do_mamba_copy_block_torch
-
+    mamba_utils.postprocess_mamba_align_gpu = _postprocess_mamba_align_gpu_cpu_fallback
 
 def preprocess_mamba(
     scheduler_output: SchedulerOutput,


### PR DESCRIPTION
## What

This PR adds a 310P-specific fallback for the Mamba align-mode postprocess path used by MTP/spec decode.

On 310P, the fallback avoids launching the Triton fused `postprocess_mamba_align_gpu` path and updates the accepted-token CPU tensor through a lightweight CPU-side path.

## Why

MTP with `enable-prefix-caching` and `mamba_cache_mode=align` can hang on 310P when the Mamba align postprocess path reaches the Triton fused kernel. The 310P runtime already uses non-Triton fallbacks for related Mamba copy operations, so this extends that behavior to the align postprocess entry point.

## Impact

This change is scoped to 310P. Non-310P devices keep using the existing Triton fused postprocess implementation.

## Validation

- Verified the target scenario no longer hangs on 310P with MTP + `enable-prefix-caching` + `mamba_cache_mode=align`.
- Verified removing `enable-prefix-caching` or `mamba_cache_mode=align` also avoids the hang, matching the isolated failure condition.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
