### PR TITLE
feat: support configurable block size for DeepSeek V4

### DIFF
--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -207,7 +207,7 @@ class AscendDSABackend(AttentionBackend):
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int]:
-        return [8, 32, 128]
+        return [2, 4, 8, 16, 32, 64, 128]
 
 
 @dataclass

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -91,6 +91,12 @@ else:
     from vllm.models.deepseek_v4.compressor import CompressorStateCache
 
 
+def _dsv4_cache_sizes(cache_config: CacheConfig | None):
+    from vllm_ascend.models.layer.attention.layer import get_dsv4_cache_sizes_for_config
+
+    return get_dsv4_cache_sizes_for_config(cache_config)
+
+
 def hadamard_transform_ref(x: torch.Tensor, scale=1.0):
     from scipy.linalg import hadamard  # type: ignore[import-untyped]
 
@@ -513,14 +519,13 @@ class Compressor(nn.Module):
         self.norm = RMSNorm(self.head_dim, config.rms_norm_eps)
 
         state_dtype = torch.float32
-        # TODO(zyj): change following codes if block_size is configurable & refactor the magic numbers
         if compress_ratio == 4:
             self.state_cache = CompressorStateCache(
                 state_dim=2 * self.coff * self.head_dim,  # kv_state + score_state
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=8,
+                block_size=_dsv4_cache_sizes(cache_config)[0][2],
             )
         elif compress_ratio == 128:
             self.state_cache = CompressorStateCache(
@@ -528,7 +533,7 @@ class Compressor(nn.Module):
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=32,
+                block_size=_dsv4_cache_sizes(cache_config)[0][3],
             )
         else:
             raise ValueError(

--- a/vllm_ascend/models/layer/attention/layer.py
+++ b/vllm_ascend/models/layer/attention/layer.py
@@ -2,11 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Attention layer."""
 
+import traceback
 from typing import cast
 
 import torch
 import torch.nn as nn
 import vllm.envs as envs
+from vllm.logger import logger
 from vllm.config import CacheConfig, get_current_vllm_config
 from vllm.config.vllm import VllmConfig
 from vllm.model_executor.layers.attention.attention import _init_kv_cache_quant
@@ -22,6 +24,56 @@ from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec
 
 from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.dsa_v1 import AscendDSABackend
+from vllm_ascend.utils import (
+    AscendDeviceType,
+    get_ascend_device_type,
+    get_dsv4_configured_block_size,
+)
+
+
+def get_dsv4_block_sizes():
+    _DSV4_BLOCK_SIZES = {
+        128: [[128, 128, 8, 32], [16640, 131072]],
+        64: [[64, 64, 4, 16], [8320, 65536]],
+        32: [[32, 32, 2, 8], [4160, 32768]],
+    }
+    _DSV4_BLOCK_SIZES_A5 = {
+        128: [[128, 128, 8, 16], [16896, 81920]],
+        64: [[64, 64, 4, 8], [8448, 40960]],
+        32: [[32, 32, 2, 4], [4224, 20480]],
+    }
+    if get_ascend_device_type() in {AscendDeviceType.A5}:
+        return _DSV4_BLOCK_SIZES_A5
+    return _DSV4_BLOCK_SIZES
+
+
+DSV4_BLOCK_SIZES = get_dsv4_block_sizes()
+
+
+def get_dsv4_cache_sizes(block_size: int | None):
+    original_block_size = block_size
+    block_size = 32 if block_size is None else block_size
+    fallback = block_size not in DSV4_BLOCK_SIZES
+    cache_sizes = DSV4_BLOCK_SIZES.get(block_size, DSV4_BLOCK_SIZES[32])
+    logger.warning(
+        "DeepSeek V4 cache size lookup: input=%r (type=%s), key=%r, "
+        "fallback_to_32=%r, cache_sizes=%s.",
+        original_block_size,
+        type(original_block_size).__name__,
+        block_size,
+        fallback,
+        cache_sizes,
+    )
+    if fallback:
+        logger.warning(
+            "DeepSeek V4 cache size lookup fallback stack:\n%s",
+            "".join(traceback.format_stack(limit=10)),
+        )
+    return cache_sizes
+
+
+def get_dsv4_cache_sizes_for_config(cache_config: CacheConfig | None):
+    return get_dsv4_cache_sizes(get_dsv4_configured_block_size(cache_config))
 
 
 class DSAAttention(nn.Module, AttentionLayerBase):
@@ -150,10 +202,15 @@ class DSAAttention(nn.Module, AttentionLayerBase):
         if self.compress_ratio <= 1:  # SWA part. Allocated separately as DeepseekV4SWACache.
             return None
         kv_cache_dtype = kv_cache_dtype_str_to_dtype(self.kv_cache_dtype, vllm_config.model_config)
+        is_a5 = get_ascend_device_type() in {AscendDeviceType.A5}
+        if is_a5:
+            kv_cache_dtype = torch.float8_e4m3fn
+            vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
+        cached_head_size = self.head_size + 128 if is_a5 else self.head_size
         return MLAAttentionSpec(
-            block_size=128,
+            block_size=get_dsv4_cache_sizes_for_config(vllm_config.cache_config)[0][0],
             num_kv_heads=1,
-            head_size=self.head_size,
+            head_size=cached_head_size,
             dtype=kv_cache_dtype,
             model_version="deepseek_v4",
             compress_ratio=self.compress_ratio,

--- a/vllm_ascend/patch/worker/patch_deepseek_compressor.py
+++ b/vllm_ascend/patch/worker/patch_deepseek_compressor.py
@@ -9,8 +9,9 @@ from vllm.v1.kv_cache_interface import (
 )
 
 from vllm_ascend.attention.dsa_v1 import AscendDSABackend
+from vllm_ascend.models.layer.attention.layer import get_dsv4_cache_sizes_for_config
 from vllm_ascend.patch.platform.patch_kv_cache_interface import AscendMLAAttentionSpec
-from vllm_ascend.utils import vllm_version_is
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type, vllm_version_is
 
 if vllm_version_is("0.20.2"):
     from vllm.model_executor.layers import (
@@ -53,7 +54,8 @@ class AscendCompressorStateCache(CompressorStateCache):
         self.block_size = block_size
 
     def get_kv_cache_spec(self, vllm_config) -> KVCacheSpec:
-        page_size_padded = 16640 if self.state_dim == 2 * 256 and self.compress_ratio == 4 else 131072
+        pads = get_dsv4_cache_sizes_for_config(vllm_config.cache_config)[1]
+        page_size_padded = pads[0] if self.state_dim == 2 * 256 and self.compress_ratio == 4 else pads[1]
         return SlidingWindowMLASpec(  # only has one vector instead of K + V
             block_size=self.block_size,
             num_kv_heads=1,
@@ -82,8 +84,12 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
         super().__init__(head_dim, dtype, prefix, cache_config, compress_ratio)
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        if get_ascend_device_type() in {AscendDeviceType.A5}:
+            self.dtype = torch.float8_e4m3fn
+            vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
+
         return AscendMLAAttentionSpec(  # Only has one vector instead of K + V
-            block_size=128,
+            block_size=get_dsv4_cache_sizes_for_config(vllm_config.cache_config)[0][0],
             num_kv_heads=1,
             head_size=self.head_dim,
             dtype=self.dtype,
@@ -91,7 +97,7 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
             compress_ratio=self.compress_ratio,
             cache_dtype_str=self.cache_config.cache_dtype,
             scale_dim=1 if self.head_dim == 128 else 0,
-            scale_dtype=torch.float16,
+            scale_dtype=torch.float if get_ascend_device_type() in {AscendDeviceType.A5} else torch.float16,
         )
 
     def forward(self): ...
@@ -111,20 +117,17 @@ class AscendDeepseekV4SWACache(DeepseekV4SWACache):
     ):
         super().__init__(head_dim, window_size, torch.uint8, prefix, cache_config)
         self.dtype = dtype
-
-        # Block size is constrained by tensor sharing between SWA and C4A KV blocks.
-        # Since both block types share the same physical tensor, they must use the
-        # same page size. The C4A KV block shape [256//4, head_dim] = [64, head_dim]
-        # determines the SWA block size of 64 tokens per block.
-        # TODO(cmq): make SWA block size automatically determined and configurable.
-        self.block_size = 128
+        self.block_size = get_dsv4_cache_sizes_for_config(cache_config)[0][1]
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        # TODO(cmq): alignment = 0 if A3 else 128
+        if get_ascend_device_type() in {AscendDeviceType.A5}:
+            self.dtype = torch.float8_e4m3fn
+            vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
+        cached_head_size = self.head_dim + 128 if get_ascend_device_type() in {AscendDeviceType.A5} else self.head_dim
         return SlidingWindowMLASpec(
             block_size=self.block_size,
             num_kv_heads=1,
-            head_size=self.head_dim,
+            head_size=cached_head_size,
             dtype=self.dtype,
             sliding_window=self.window_size,
             cache_dtype_str=self.cache_config.cache_dtype,

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -48,6 +48,9 @@ ASCEND_QUANTIZATION_METHOD = "ascend"
 COMPRESSED_TENSORS_METHOD = "compressed-tensors"
 SOC_VERSION_INFERENCE_SERIES = ["Ascend310P3"]
 REGISTERED_ASCEND_OPS = {}
+DSV4_USER_BLOCK_SIZE_ATTR = "_ascend_dsv4_user_block_size"
+DSV4_SUPPORTED_BLOCK_SIZES = {32, 64, 128}
+DSV4_DEFAULT_BLOCK_SIZE = 32
 
 ACL_FORMAT_FRACTAL_ND = 2
 ACL_FORMAT_FRACTAL_NZ = 29
@@ -679,7 +682,7 @@ def update_aclgraph_sizes(vllm_config: VllmConfig) -> None:
         sampled_sizes = [original_sizes[i] for i in indices]
         update_cudagraph_capture_sizes(vllm_config, sampled_sizes)
         logger.info(
-            "Adjusted ACL graph batch sizes for %s model (layers: %d): %d → %d sizes",
+            "Adjusted ACL graph batch sizes for %s model (layers: %d): %d -> %d sizes",
             arch_name,
             num_hidden_layers,
             len(original_sizes),
@@ -1008,7 +1011,7 @@ def is_vl_model(vllm_config: VllmConfig = None):
         vllm_config = get_current_vllm_config_or_none()
     if _IS_VL_MODEL is None and vllm_config and vllm_config.model_config:
         model_config = vllm_config.model_config
-        # Primary: vllm's own VL detection — hf_config is the top-level
+        # Primary: vllm's own VL detection - hf_config is the top-level
         # (multimodal) config; hf_text_config is the language-model sub-config.
         # They are the same object for pure-text models.
         if model_config.hf_config is not model_config.hf_text_config:
@@ -1302,6 +1305,27 @@ def get_flashcomm2_reorgnized_batch_ids(global_tp_size) -> list[list[int]]:
     return reorgnized_batch_ids
 
 
+def get_dsv4_configured_block_size(cache_config: Any) -> int:
+    """Return the user-level DeepSeek V4 block size.
+
+    vLLM may later replace ``cache_config.block_size`` with the minimum
+    block size across KV cache groups. DSv4 cache layout tables still need
+    the original user-level 32/64/128 value.
+    """
+    if cache_config is None:
+        return DSV4_DEFAULT_BLOCK_SIZE
+
+    saved_block_size = getattr(cache_config, DSV4_USER_BLOCK_SIZE_ATTR, None)
+    if saved_block_size in DSV4_SUPPORTED_BLOCK_SIZES:
+        return saved_block_size
+
+    block_size = getattr(cache_config, "block_size", None)
+    if block_size in DSV4_SUPPORTED_BLOCK_SIZES:
+        return block_size
+
+    return DSV4_DEFAULT_BLOCK_SIZE
+
+
 def refresh_block_size(vllm_config):
     """
     Refresh the block size in cache config.
@@ -1313,11 +1337,60 @@ def refresh_block_size(vllm_config):
     if not cache_config:
         return
 
-    if cache_config.block_size is None:
-        cache_config.block_size = 128
+    model_type = getattr(getattr(model_config, "hf_config", None), "model_type", None)
+    if model_type == "deepseek_v4":
+        original_block_size = cache_config.block_size
+        saved_block_size = getattr(cache_config, DSV4_USER_BLOCK_SIZE_ATTR, None)
+        if saved_block_size in DSV4_SUPPORTED_BLOCK_SIZES:
+            logger.warning(
+                "DeepSeek V4 block size refresh skip: pid=%s, "
+                "runtime_block_size=%r, user_block_size=%r, "
+                "enable_prefix_caching=%r, enable_chunked_prefill=%r.",
+                os.getpid(),
+                original_block_size,
+                saved_block_size,
+                getattr(cache_config, "enable_prefix_caching", None),
+                getattr(scheduler_config, "enable_chunked_prefill", None),
+            )
+            return
 
-    if model_config.hf_config.model_type == "deepseek_v4":
-        # TODO(qcs): generalize the block_size
+        logger.warning(
+            "DeepSeek V4 block size refresh enter: pid=%s, "
+            "vllm_config_id=%s, cache_config_id=%s, input=%r (type=%s), "
+            "enable_prefix_caching=%r, enable_chunked_prefill=%r.",
+            os.getpid(),
+            id(vllm_config),
+            id(cache_config),
+            original_block_size,
+            type(original_block_size).__name__,
+            getattr(cache_config, "enable_prefix_caching", None),
+            getattr(scheduler_config, "enable_chunked_prefill", None),
+        )
+
+        if original_block_size is None:
+            user_block_size = DSV4_DEFAULT_BLOCK_SIZE
+        elif original_block_size in DSV4_SUPPORTED_BLOCK_SIZES:
+            user_block_size = original_block_size
+        else:
+            logger.warning(
+                "For deepseek_v4 model, block size should be 32, 64 or 128. "
+                "Setting block size to 32 for better performance."
+            )
+            user_block_size = DSV4_DEFAULT_BLOCK_SIZE
+
+        setattr(cache_config, DSV4_USER_BLOCK_SIZE_ATTR, user_block_size)
+        cache_config.block_size = user_block_size
+        logger.warning(
+            "DeepSeek V4 block size refresh: input=%r (type=%s), output=%r, "
+            "user_block_size=%r.",
+            original_block_size,
+            type(original_block_size).__name__,
+            cache_config.block_size,
+            user_block_size,
+        )
+        return
+
+    if cache_config.block_size is None:
         cache_config.block_size = 128
 
     if not scheduler_config or not model_config:


### PR DESCRIPTION
## Motivation

DeepSeek V4 previously hardcoded block_size=128 across MLA attention spec, compressor state cache, and SWA cache. This prevents users from choosing smaller block sizes (32/64) that can reduce memory fragmentation and improve prefix caching hit rates.

## Changes

- **utils.py**: Add DSV4_SUPPORTED_BLOCK_SIZES (32/64/128) and DSV4_DEFAULT_BLOCK_SIZE (32). Refactor refresh_block_size() to validate and persist user-level block size via DSV4_USER_BLOCK_SIZE_ATTR, so later vLLM overwrites of cache_config.block_size do not lose the original value. Add get_dsv4_configured_block_size() helper.
- **models/layer/attention/layer.py**: Add DSV4_BLOCK_SIZES / DSV4_BLOCK_SIZES_A5 lookup tables. MLAAttentionSpec.block_size is now derived from the configured block size. On A5 devices, use float8_e4m3fn dtype and head_size+128 cached head size.
- **models/deepseek_v4.py**: Compressor state cache block_size is now looked up from the device-aware table instead of hardcoded 8/32.
- **patch/worker/patch_deepseek_compressor.py**: C4A and SWA block_size / page_size_padded are now configurable. A5 devices use float8_e4m3fn and torch.float scale dtype.
- **attention/dsa_v1.py**: Expand get_supported_kernel_block_sizes() from [8, 32, 128] to [2, 4, 8, 16, 32, 64, 128] to support the new block size options.

## Test Plan

- [ ] Launch DSV4 with --block-size 32 / 64 / 128 and verify model loads correctly
- [ ] Verify prefix caching hit rate with smaller block sizes
- [ ] Verify A5 device path uses float8 dtype
- [ ] Run existing DSV4 test suite

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
