### PR TITLE
perf: add AscendStore coordinator and lazy grouped hash generation

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Iterable, Sequence
-from dataclasses import dataclass
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass, field
 from typing import Any, cast
 
 import torch
@@ -42,6 +42,7 @@ class KeyMetadata:
 class PoolKey:
     key_metadata: KeyMetadata
     chunk_hash: str
+    chunk_hash_bytes: BlockHash | str | None = field(default=None, compare=False, kw_only=True)
 
     def __hash__(self):
         return hash(
@@ -79,6 +80,7 @@ class PoolKey:
                     self.key_metadata,
                     self.chunk_hash,
                     layer_id,
+                    chunk_hash_bytes=self.chunk_hash_bytes,
                 )
             )
         return keys
@@ -207,9 +209,14 @@ class ChunkedTokenDatabase:
         partitions: list[int] | None,
         use_hybrid: bool = False,
         hash_block_size: int | None = None,
+        kv_cache_groups: Sequence[Any] | None = None,
+        alignment_tokens: int | None = None,
+        retention_interval: int | None = None,
+        use_eagle: bool = False,
     ):
         self.metadata = metadata
         self.block_size = block_size if isinstance(block_size, list) else [block_size]
+        self.kv_cache_groups = list(kv_cache_groups or [])
         self.kv_caches_base_addr: list[int] = []
         self.block_len: list[int] = []
         self.block_stride: list[int] = []
@@ -227,6 +234,252 @@ class ChunkedTokenDatabase:
         self.partitions = partitions
         self.use_hybrid = use_hybrid
         self.hash_block_size = self.block_size[0] if hash_block_size is None else hash_block_size
+        self.alignment_tokens = alignment_tokens if alignment_tokens is not None else max(self.block_size)
+        self.retention_interval = retention_interval
+        self.eagle_group_ids = {
+            idx for idx, group in enumerate(self.kv_cache_groups) if getattr(group, "is_eagle_group", False)
+        }
+        if use_eagle and not self.eagle_group_ids:
+            self.eagle_group_ids = set(range(len(self.kv_cache_groups)))
+        self.cache_coordinator: Any | None = None
+        self._key_prefix_cache = {}
+
+    def set_cache_coordinator(self, cache_coordinator: Any | None) -> None:
+        self.cache_coordinator = cache_coordinator
+
+    def _get_key_prefix(self, kv_cache_group_id, cache_role="kv", cache_family=None):
+        """Database-level prefix cache. Per group, constructed once."""
+        if cache_family is None:
+            cache_family = self.group_cache_families.get(cache_role, {}).get(
+                kv_cache_group_id, "default"
+            )
+        cache_key = (kv_cache_group_id, cache_role, cache_family)
+        prefix = self._key_prefix_cache.get(cache_key)
+        if prefix is None:
+            prefix = (
+                f"{self.metadata.model_name}"
+                f"@pcp{self.metadata.pcp_rank}@dcp{self.metadata.dcp_rank}"
+                f"@head_or_tp_rank:{self.metadata.head_or_tp_rank}"
+                f"@pp_rank:{self.metadata.pp_rank}"
+                f"@group:{kv_cache_group_id}"
+                f"@cache_role:{cache_role}"
+                f"@cache_family:{cache_family}@"
+            )
+            self._key_prefix_cache[cache_key] = prefix
+        return prefix
+
+    def process_token_key_strings(
+        self,
+        token_len: int,
+        block_hashes: BlockHashList | list[str],
+        mask_num: int = 0,
+        kv_cache_group_id: int = 0,
+        cache_role: str = "kv",
+        cache_family: str | None = None,
+        max_num: int | None = None,
+        chunk_filter: Callable[[int], bool] | None = None,
+    ):
+        """Fast-path: yield (start, end, key_string, chunk_hash) without creating PoolKey."""
+        if not block_hashes:
+            return
+        base_block_size = self.get_block_size(kv_cache_group_id)
+        if cache_family is None:
+            cache_family = self.group_cache_families.get(cache_role, {}).get(
+                kv_cache_group_id, "default"
+            )
+        cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
+        effective_block_size = base_block_size * cache_family_ratio
+
+        grouped_hashes = get_block_hashes(block_hashes, effective_block_size, self.hash_block_size)
+        if not grouped_hashes:
+            return
+
+        prefix = self._get_key_prefix(kv_cache_group_id, cache_role, cache_family)
+
+        lookup_end = token_len if max_num is None else min(token_len, max_num)
+        for chunk_id in range(len(grouped_hashes)):
+            start_token = chunk_id * effective_block_size
+            if start_token >= lookup_end:
+                break
+            end_token = min(start_token + effective_block_size, lookup_end)
+            if start_token < mask_num:
+                continue
+            start_idx = start_token // cache_family_ratio
+            end_idx = end_token // cache_family_ratio
+            if end_idx <= start_idx:
+                continue
+            if chunk_filter is not None and not chunk_filter(start_idx):
+                continue
+            hash_val = grouped_hashes[chunk_id]
+            chunk_hash = _block_hash_to_hex(hash_val)
+            yield start_idx, end_idx, prefix + chunk_hash, hash_val
+
+    def process_token_key_strings_with_block_ids(
+        self,
+        token_len: int,
+        block_hashes: BlockHashList | list[str],
+        block_ids: list[int],
+        mask_num: int = 0,
+        kv_cache_group_id: int = 0,
+        skip_null_blocks: bool = False,
+        cache_role: str = "kv",
+        cache_family: str | None = None,
+        chunk_filter: Callable[[int], bool] | None = None,
+    ):
+        """Fast-path: yield (start, end, key_string, chunk_hash, block_id) without materializing."""
+        base_block_size = self.get_block_size(kv_cache_group_id)
+        if cache_family is None:
+            cache_family = self.group_cache_families.get(cache_role, {}).get(
+                kv_cache_group_id, "default"
+            )
+        cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
+        effective_block_size = base_block_size * cache_family_ratio
+
+        grouped_hashes = get_block_hashes(block_hashes, effective_block_size, self.hash_block_size)
+        if not grouped_hashes:
+            return
+
+        num_by_hashes = len(grouped_hashes)
+        num_by_token_len = cdiv(token_len, effective_block_size) if token_len > 0 else 0
+        num_logical_blocks = min(num_by_hashes, num_by_token_len)
+        block_id_offset = max(num_logical_blocks - len(block_ids), 0)
+
+        prefix = self._get_key_prefix(kv_cache_group_id, cache_role, cache_family)
+
+        for chunk_id in range(num_logical_blocks):
+            start_token = chunk_id * effective_block_size
+            if start_token >= token_len:
+                break
+            end_token = min(start_token + effective_block_size, token_len)
+            if start_token < mask_num:
+                continue
+            start_idx = start_token // cache_family_ratio
+            end_idx = end_token // cache_family_ratio
+            if end_idx <= start_idx:
+                continue
+            if chunk_filter is not None and not chunk_filter(start_idx):
+                continue
+            block_idx = start_idx // base_block_size - block_id_offset
+            if block_idx < 0 or block_idx >= len(block_ids):
+                continue
+            block_id = block_ids[block_idx]
+            if skip_null_blocks and block_id <= 0:
+                continue
+            hash_val = grouped_hashes[chunk_id]
+            chunk_hash = _block_hash_to_hex(hash_val)
+            yield start_idx, end_idx, prefix + chunk_hash, hash_val, block_id
+
+    def process_token_key_strings_with_block_ids_sparse_store_mask(
+        self,
+        token_len: int,
+        block_hashes: BlockHashList | list[str],
+        block_ids: list[int],
+        store_mask: Sequence[bool],
+        mask_num: int = 0,
+        kv_cache_group_id: int = 0,
+        skip_null_blocks: bool = False,
+        cache_role: str = "kv",
+        cache_family: str | None = None,
+        shard_rank: int | None = None,
+        shard_size: int | None = None,
+    ):
+        """Yield only chunks allowed by store_mask.
+
+        This is equivalent to process_token_key_strings_with_block_ids()
+        followed by mask_allows_chunk(), because the mask index is
+        start // base_block_size, which is the chunk id after cache-family
+        scaling.
+        """
+        if not block_hashes or not store_mask:
+            return
+        base_block_size = self.get_block_size(kv_cache_group_id)
+        if cache_family is None:
+            cache_family = self.group_cache_families.get(cache_role, {}).get(
+                kv_cache_group_id, "default"
+            )
+        cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
+        effective_block_size = base_block_size * cache_family_ratio
+
+        use_shard = shard_rank is not None and shard_size is not None and shard_size > 1
+        if use_shard:
+            shard_rank = shard_rank % shard_size
+            num_by_hashes = get_num_block_hashes(block_hashes, effective_block_size, self.hash_block_size)
+        else:
+            grouped_hashes = get_block_hashes(block_hashes, effective_block_size, self.hash_block_size)
+            if not grouped_hashes:
+                return
+            num_by_hashes = len(grouped_hashes)
+
+        num_by_token_len = cdiv(token_len, effective_block_size) if token_len > 0 else 0
+        num_logical_blocks = min(num_by_hashes, num_by_token_len)
+        block_id_offset = max(num_logical_blocks - len(block_ids), 0)
+        max_chunks = min(num_logical_blocks, len(store_mask))
+
+        prefix = self._get_key_prefix(kv_cache_group_id, cache_role, cache_family)
+        candidate_index = 0
+
+        for chunk_id in range(max_chunks):
+            if not store_mask[chunk_id]:
+                continue
+            start_token = chunk_id * effective_block_size
+            if start_token >= token_len:
+                break
+            end_token = min(start_token + effective_block_size, token_len)
+            if start_token < mask_num:
+                continue
+            start_idx = start_token // cache_family_ratio
+            end_idx = end_token // cache_family_ratio
+            if end_idx <= start_idx:
+                continue
+            block_idx = start_idx // base_block_size - block_id_offset
+            if block_idx < 0 or block_idx >= len(block_ids):
+                continue
+            block_id = block_ids[block_idx]
+            if skip_null_blocks and block_id <= 0:
+                continue
+            if use_shard:
+                assert shard_size is not None and shard_rank is not None
+                if candidate_index % shard_size != shard_rank:
+                    candidate_index += 1
+                    continue
+                candidate_index += 1
+                hash_val = get_block_hash_at(block_hashes, chunk_id, effective_block_size, self.hash_block_size)
+                if hash_val is None:
+                    continue
+            else:
+                hash_val = grouped_hashes[chunk_id]
+            chunk_hash = _block_hash_to_hex(hash_val)
+            yield start_idx, end_idx, prefix + chunk_hash, hash_val, block_id
+
+    def store_mask(
+        self,
+        aligned_token_len: int,
+        num_prompt_tokens: int | None = None,
+    ) -> tuple[list[bool], ...] | None:
+        if self.cache_coordinator is None:
+            return None
+        return self.cache_coordinator.store_mask(aligned_token_len, num_prompt_tokens)
+
+    def load_mask(
+        self,
+        block_hashes: list[BlockHash],
+        token_len: int,
+    ) -> tuple[list[bool], ...] | None:
+        if self.cache_coordinator is None:
+            return None
+        return self.cache_coordinator.load_mask(block_hashes, token_len)
+
+    def mask_allows_chunk(
+        self,
+        masks: tuple[list[bool], ...] | None,
+        kv_cache_group_id: int,
+        start: int,
+    ) -> bool:
+        if masks is None or kv_cache_group_id >= len(masks):
+            return True
+        group_mask = masks[kv_cache_group_id]
+        chunk_idx = start // self.get_block_size(kv_cache_group_id)
+        return chunk_idx < len(group_mask) and group_mask[chunk_idx]
 
     def _make_key_by_hash(
         self,
@@ -234,6 +487,7 @@ class ChunkedTokenDatabase:
         kv_cache_group_id: int = 0,
         cache_role: str = "kv",
         cache_family: str | None = None,
+        chunk_hash_bytes: BlockHash | str | None = None,
         layer_id: int | None = None,
     ):
         assert self.metadata is not None
@@ -251,6 +505,7 @@ class ChunkedTokenDatabase:
                 cache_family=cache_family,
             ),
             chunk_hash,
+            chunk_hash_bytes=chunk_hash_bytes,
         )
 
     def set_kv_caches_base_addr(self, kv_caches_base_addr: list[int]):
@@ -286,10 +541,22 @@ class ChunkedTokenDatabase:
             self.group_block_stride = group_block_stride or {}
         if group_cache_families is not None:
             self.group_cache_families[cache_role] = group_cache_families.copy()
+            self._key_prefix_cache.clear()
         if group_num_layers is not None:
             self.group_num_layers[cache_role] = group_num_layers.copy()
 
-    def _get_group_buffers(self, kv_cache_group_id: int, cache_role: str) -> tuple[list[int], list[int], list[int]]:
+    def _get_group_cache_family(self, kv_cache_group_id: int, cache_role: str = "kv") -> str:
+        return self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
+
+    def _get_store_granularity(self, kv_cache_group_id: int, cache_role: str = "kv") -> int:
+        return get_cache_family_granularity(
+            self.get_block_size(kv_cache_group_id),
+            self._get_group_cache_family(kv_cache_group_id, cache_role),
+        )
+
+    def _get_group_buffers(
+        self, kv_cache_group_id: int, cache_role: str = "kv"
+    ) -> tuple[list[int], list[int], list[int] | None]:
         if cache_role == "state":
             return [], [], []
         return (
@@ -305,11 +572,13 @@ class ChunkedTokenDatabase:
         block_ids: list[int],
         kv_cache_group_id: int = 0,
         cache_role: str = "kv",
+        block_id: int | None = None,
     ):
         addr_list: list[int] = []
         size_list: list[int] = []
         group_block_size = self.get_block_size(kv_cache_group_id)
-        block_id = block_ids[start // group_block_size]
+        if block_id is None:
+            block_id = block_ids[start // group_block_size]
         group_addrs, group_block_len, group_block_stride = self._get_group_buffers(kv_cache_group_id, cache_role)
         length = len(group_block_len)
         if length == 0:
@@ -345,50 +614,49 @@ class ChunkedTokenDatabase:
         kv_cache_group_id: int = 0,
         cache_role: str = "kv",
         cache_family: str | None = None,
+        chunk_filter: Callable[[int], bool] | None = None,
     ) -> Iterable[tuple[int, int, PoolKey]]:
         """Process the tokens and return the corresponding cache engine keys."""
         if not block_hashes:
             return
-        group_block_size = self.get_block_size(kv_cache_group_id)
+        base_block_size = self.get_block_size(kv_cache_group_id)
         if cache_family is None:
             cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
         cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
-        group_block_size *= cache_family_ratio
-        block_hashes = get_block_hashes(
+        effective_block_size = base_block_size * cache_family_ratio
+        grouped_hashes = get_block_hashes(
             block_hashes,
-            group_block_size,
+            effective_block_size,
             self.hash_block_size,
         )
-        if not block_hashes:
+        if not grouped_hashes:
             return
-        if not isinstance(block_hashes[0], str):
-            block_hashes = [
-                h.hex()  # type: ignore[union-attr]
-                for h in block_hashes
-            ]
-        start_idx = 0
-        for chunk_id, hash_val in enumerate(block_hashes):
-            start_idx = chunk_id * group_block_size
-            if start_idx >= token_len:
+        for chunk_id in range(len(grouped_hashes)):
+            start_token = chunk_id * effective_block_size
+            if start_token >= token_len:
                 break
-            end_idx = min(start_idx + group_block_size, token_len)
-            if start_idx < mask_num:
+            end_token = min(start_token + effective_block_size, token_len)
+            if start_token < mask_num:
                 continue
-            else:
-                start_idx //= cache_family_ratio
-                end_idx //= cache_family_ratio
-                if end_idx <= start_idx:
-                    continue
-                yield (
-                    start_idx,
-                    end_idx,
-                    self._make_key_by_hash(
-                        hash_val,
-                        kv_cache_group_id=kv_cache_group_id,
-                        cache_role=cache_role,
-                        cache_family=cache_family,
-                    ),
-                )
+            start_idx = start_token // cache_family_ratio
+            end_idx = end_token // cache_family_ratio
+            if end_idx <= start_idx:
+                continue
+            if chunk_filter is not None and not chunk_filter(start_idx):
+                continue
+            hash_val = grouped_hashes[chunk_id]
+            chunk_hash = _block_hash_to_hex(hash_val)
+            yield (
+                start_idx,
+                end_idx,
+                self._make_key_by_hash(
+                    chunk_hash,
+                    kv_cache_group_id=kv_cache_group_id,
+                    cache_role=cache_role,
+                    cache_family=cache_family,
+                    chunk_hash_bytes=hash_val,
+                ),
+            )
 
     def process_tokens_with_block_ids(
         self,
@@ -400,21 +668,56 @@ class ChunkedTokenDatabase:
         skip_null_blocks: bool = False,
         cache_role: str = "kv",
         cache_family: str | None = None,
+        chunk_filter: Callable[[int], bool] | None = None,
     ) -> Iterable[tuple[int, int, PoolKey, int]]:
-        for start_idx, end_idx, key in self.process_tokens(
-            token_len,
+        if not block_hashes:
+            return
+        base_block_size = self.get_block_size(kv_cache_group_id)
+        if cache_family is None:
+            cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
+        cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
+        effective_block_size = base_block_size * cache_family_ratio
+        grouped_hashes = get_block_hashes(
             block_hashes,
-            mask_num,
-            kv_cache_group_id=kv_cache_group_id,
-            cache_role=cache_role,
-            cache_family=cache_family,
-        ):
-            block_idx = start_idx // self.get_block_size(kv_cache_group_id)
-            if block_idx >= len(block_ids):
+            effective_block_size,
+            self.hash_block_size,
+        )
+        if not grouped_hashes:
+            return
+
+        num_by_hashes = len(grouped_hashes)
+        num_by_token_len = cdiv(token_len, effective_block_size) if token_len > 0 else 0
+        num_logical_blocks = min(num_by_hashes, num_by_token_len)
+        block_id_offset = max(num_logical_blocks - len(block_ids), 0)
+
+        for chunk_id in range(num_logical_blocks):
+            start_token = chunk_id * effective_block_size
+            if start_token >= token_len:
+                break
+            end_token = min(start_token + effective_block_size, token_len)
+            if start_token < mask_num:
+                continue
+            start_idx = start_token // cache_family_ratio
+            end_idx = end_token // cache_family_ratio
+            if end_idx <= start_idx:
+                continue
+            if chunk_filter is not None and not chunk_filter(start_idx):
+                continue
+            block_idx = start_idx // base_block_size - block_id_offset
+            if block_idx < 0 or block_idx >= len(block_ids):
                 continue
             block_id = block_ids[block_idx]
             if skip_null_blocks and block_id <= 0:
                 continue
+            hash_val = grouped_hashes[chunk_id]
+            chunk_hash = _block_hash_to_hex(hash_val)
+            key = self._make_key_by_hash(
+                chunk_hash,
+                kv_cache_group_id=kv_cache_group_id,
+                cache_role=cache_role,
+                cache_family=cache_family,
+                chunk_hash_bytes=hash_val,
+            )
             yield start_idx, end_idx, key, block_id
 
     def decode_adaptor_prefill_pp(self, key, addr, size, kv_cache_group_id: int = 0, cache_role: str = "kv"):
@@ -457,18 +760,74 @@ def normalize_block_ids_by_group(block_ids: tuple[list[int], ...] | list[int] | 
 
 
 def get_block_hashes(
-    block_hashes: BlockHashList | list[str],
+    block_hashes: Sequence[BlockHash | str],
     group_block_size: int,
     hash_block_size: int,
-) -> BlockHashList | list[str]:
+) -> Sequence[BlockHash | str]:
     if group_block_size == hash_block_size:
         return block_hashes
     assert group_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
+    return _LazyGroupedBlockHashList(block_hashes, group_block_size // hash_block_size)
+
+
+def get_num_block_hashes(
+    block_hashes: Sequence[BlockHash | str],
+    group_block_size: int,
+    hash_block_size: int,
+) -> int:
+    if group_block_size == hash_block_size:
+        return len(block_hashes)
+    assert group_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
+    return len(block_hashes) // (group_block_size // hash_block_size)
+
+
+def get_block_hash_at(
+    block_hashes: Sequence[BlockHash | str],
+    chunk_id: int,
+    group_block_size: int,
+    hash_block_size: int,
+) -> BlockHash | str | None:
+    if group_block_size == hash_block_size:
+        if chunk_id >= len(block_hashes):
+            return None
+        return block_hashes[chunk_id]
+    assert group_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
     scale_factor = group_block_size // hash_block_size
-    return [
-        _rehash_block_hash_group(block_hashes[idx : idx + scale_factor])
-        for idx in range(0, len(block_hashes) // scale_factor * scale_factor, scale_factor)
-    ]
+    start = chunk_id * scale_factor
+    end = start + scale_factor
+    if end > len(block_hashes):
+        return None
+    return _rehash_block_hash_group(block_hashes[start:end])
+
+
+class _LazyGroupedBlockHashList(Sequence[BlockHash]):
+    def __init__(self, block_hashes: Sequence[BlockHash | str], scale_factor: int) -> None:
+        self._block_hashes = block_hashes
+        self._scale_factor = scale_factor
+        self._length = len(block_hashes) // scale_factor
+        self._cache: dict[int, BlockHash] = {}
+
+    def __len__(self) -> int:
+        return self._length
+
+    def __iter__(self):
+        for idx in range(self._length):
+            yield self[idx]
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            return [self[idx] for idx in range(*index.indices(self._length))]
+        if index < 0:
+            index += self._length
+        if index < 0 or index >= self._length:
+            raise IndexError(index)
+        cached = self._cache.get(index)
+        if cached is None:
+            start = index * self._scale_factor
+            end = start + self._scale_factor
+            cached = _rehash_block_hash_group(self._block_hashes[start:end])
+            self._cache[index] = cached
+        return cached
 
 
 def _rehash_block_hash_group(block_hashes: Sequence[BlockHash | str]) -> BlockHash:
@@ -480,6 +839,12 @@ def _rehash_block_hash_group(block_hashes: Sequence[BlockHash | str]) -> BlockHa
         hasher.update(len(hash_bytes).to_bytes(_GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES, "big"))
         hasher.update(hash_bytes)
     return BlockHash(hasher.digest())
+
+
+def _block_hash_to_hex(block_hash: BlockHash | str) -> str:
+    if isinstance(block_hash, str):
+        return block_hash
+    return bytes(block_hash).hex()
 
 
 def _block_hash_to_bytes(block_hash: BlockHash | str) -> bytes:
@@ -523,6 +888,9 @@ class RequestTracker:
     # NOTE: This field will only be used when you enable kv-event
     token_ids: list[int] | None = None
 
+    # Full prompt length used by retention-aware external store masks.
+    num_prompt_tokens: int | None = None
+
     def __init__(
         self,
         req_id: str,
@@ -531,6 +899,7 @@ class RequestTracker:
         allocated_block_ids: list[int] | list[list[int]] | None = None,
         num_saved_tokens: int = 0,
         token_ids: list[int] | None = None,
+        num_prompt_tokens: int | None = None,
     ) -> None:
         self.req_id = req_id
         self.token_len = token_len
@@ -540,6 +909,7 @@ class RequestTracker:
         self.allocated_block_ids_by_group = block_ids
         self.num_saved_tokens = num_saved_tokens
         self.token_ids = token_ids
+        self.num_prompt_tokens = num_prompt_tokens
 
     @property
     def allocated_block_ids(self) -> list[int]:
@@ -561,6 +931,7 @@ class RequestTracker:
             token_len=num_tokens_to_compute,
             allocated_block_ids_by_group=normalize_block_ids_by_group(new_request.block_ids),
             num_saved_tokens=0,
+            num_prompt_tokens=len(new_request.prompt_token_ids),
         )
 
     def update(
@@ -604,6 +975,7 @@ class ReqMeta:
     # TODO: add lora_request which used for gen lora_id/lora_name in kv event
     token_ids: list[int] | None = None
     original_block_size: list[int] | int | None = None
+    num_prompt_tokens: int | None = None
 
     def __init__(
         self,
@@ -621,6 +993,7 @@ class ReqMeta:
         disable_tp_key_sharding: bool = False,
         token_ids: list[int] | None = None,
         original_block_size: list[int] | int | None = None,
+        num_prompt_tokens: int | None = None,
         block_ids: list[int] | list[list[int]] | None = None,
     ) -> None:
         self.req_id = req_id
@@ -639,6 +1012,7 @@ class ReqMeta:
         self.disable_tp_key_sharding = disable_tp_key_sharding
         self.token_ids = token_ids
         self.original_block_size = original_block_size
+        self.num_prompt_tokens = num_prompt_tokens
 
     @property
     def block_ids(self) -> list[int]:
@@ -701,6 +1075,7 @@ class ReqMeta:
             is_last_chunk=is_last_chunk,
             token_ids=token_ids,
             original_block_size=original_block_size,
+            num_prompt_tokens=tracker.num_prompt_tokens,
             kv_cache_group_ids=list(range(len(tracker.allocated_block_ids_by_group))),
             kv_cache_families_by_group=kv_cache_group_families,
         )

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
@@ -1,0 +1,456 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from importlib import import_module
+from typing import Any, cast
+
+from vllm.logger import logger
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashList, KVCacheBlock
+from vllm.v1.kv_cache_interface import FullAttentionSpec, UniformTypeKVCacheSpecs
+
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
+    _block_hash_to_bytes,
+    get_block_hashes,
+)
+
+_CACHE_MISSING = object()
+_MANAGER_CLASS_CACHE_ATTR = "_manager_class_cache"
+
+
+class ExternalCachedBlockPool:
+    """Duck-typed BlockPool backed by external AscendStore key existence."""
+
+    def __init__(self, exists: set[tuple[int, bytes]] | None = None) -> None:
+        # exists=None is used for load/store masks where hit length has already
+        # been decided and each manager only needs to apply its own reachability.
+        self._exists = exists
+        self.null_block = KVCacheBlock(block_id=0)
+        self._present_block = KVCacheBlock(block_id=1)
+
+    def get_cached_block(
+        self,
+        block_hash: BlockHash,
+        group_ids: list[int],
+    ) -> list[KVCacheBlock] | None:
+        if self._exists is None:
+            return [self._present_block] * len(group_ids)
+        h = _block_hash_to_bytes(block_hash)
+        if all((group_id, h) in self._exists for group_id in group_ids):
+            return [self._present_block] * len(group_ids)
+        return None
+
+
+class AscendStoreCoordinator:
+    """Hybrid cache-hit/mask coordinator for AscendStore external KV Pool.
+
+    This mirrors vLLM MooncakeStoreCoordinator but uses AscendStore's external
+    key granularity. For DSV4 compressed groups, keys are generated over the
+    raw-token span ``group_block_size * compress_ratio`` while transfer
+    addresses remain in cache-domain blocks.
+    """
+
+    def __init__(
+        self,
+        kv_cache_groups: list[Any],
+        scheduler_block_size: int,
+        hash_block_size: int,
+        group_block_sizes: list[int],
+        group_cache_families: list[str],
+        use_eagle: bool = False,
+        retention_interval: int | None = None,
+    ) -> None:
+        assert len(kv_cache_groups) == len(group_block_sizes)
+        assert len(kv_cache_groups) == len(group_cache_families)
+        assert scheduler_block_size % hash_block_size == 0, (
+            f"scheduler_block_size ({scheduler_block_size}) must be a multiple of hash_block_size ({hash_block_size})"
+        )
+
+        self.kv_cache_groups = kv_cache_groups
+        self.hash_block_size = hash_block_size
+        self.lcm_block_size = scheduler_block_size
+        self.use_eagle = use_eagle
+        self.retention_interval = retention_interval
+        self.group_block_sizes = group_block_sizes
+        self.group_cache_families = group_cache_families
+        self.group_effective_block_sizes = [
+            _cache_family_granularity(block_size, family)
+            for block_size, family in zip(group_block_sizes, group_cache_families, strict=True)
+        ]
+        for effective_block_size in self.group_effective_block_sizes:
+            assert effective_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
+            assert scheduler_block_size % effective_block_size == 0, (
+                "scheduler_block_size must be a multiple of each group's effective block_size"
+            )
+
+        self.eagle_group_ids = {i for i, group in enumerate(kv_cache_groups) if getattr(group, "is_eagle_group", False)}
+        if use_eagle and not self.eagle_group_ids:
+            # Compressed groups already use coarse chunks; dropping their last chunk can erase the whole hit.
+            self.eagle_group_ids = {i for i, family in enumerate(group_cache_families) if _uses_reachable_mask(family)}
+
+        self._verify_and_split_kv_cache_groups()
+
+    def _verify_and_split_kv_cache_groups(self) -> None:
+        attention_groups: list[tuple[Any, list[int], Any]] = []
+        self.group_effective_specs: list[Any] = []
+
+        for group_id, group in enumerate(self.kv_cache_groups):
+            spec = _unwrap_spec(group.kv_cache_spec)
+            effective_spec = _copy_spec_with_block_size(spec, self.group_effective_block_sizes[group_id])
+            if not _uses_reachable_mask(self.group_cache_families[group_id]):
+                # External compressed keys are already grouped by the effective block size.
+                effective_spec = replace(effective_spec, compress_ratio=1)
+            self.group_effective_specs.append(effective_spec)
+            manager_cls = _get_manager_class(spec)
+
+            for existing_spec, group_ids, existing_cls in attention_groups:
+                if existing_spec == effective_spec:
+                    assert manager_cls is existing_cls, "Expected same manager class for identical KV cache specs."
+                    group_ids.append(group_id)
+                    break
+            else:
+                attention_groups.append((effective_spec, [group_id], manager_cls))
+
+        self.attention_groups = sorted(
+            attention_groups,
+            key=lambda item: not isinstance(item[0], FullAttentionSpec),
+        )
+        self.eagle_attn_group_indices: set[int] = {
+            index
+            for index, (_, group_ids, _) in enumerate(self.attention_groups)
+            if any(group_id in self.eagle_group_ids for group_id in group_ids)
+        }
+        if self.use_eagle and not self.eagle_attn_group_indices:
+            self.eagle_attn_group_indices = {
+                index
+                for index, (_, group_ids, _) in enumerate(self.attention_groups)
+                if any(_uses_reachable_mask(self.group_cache_families[group_id]) for group_id in group_ids)
+            }
+
+    def find_longest_cache_hit(
+        self,
+        block_hashes: list[BlockHash],
+        max_length: int,
+        cached_block_pool: ExternalCachedBlockPool,
+        *,
+        apply_eagle: bool = True,
+    ) -> tuple[tuple[list[bool], ...], int]:
+        blocks_per_group, hit_length = self._find_hit_blocks(
+            block_hashes,
+            max_length,
+            cached_block_pool,
+            apply_eagle=apply_eagle,
+        )
+        masks = tuple([block is not cached_block_pool.null_block for block in blocks] for blocks in blocks_per_group)
+        return masks, hit_length
+
+    def load_mask(
+        self,
+        block_hashes: list[BlockHash],
+        token_len: int,
+    ) -> tuple[list[bool], ...]:
+        masks, _ = self.find_longest_cache_hit(
+            block_hashes,
+            token_len,
+            ExternalCachedBlockPool(),
+            apply_eagle=False,
+        )
+        return tuple(
+            [True] * _num_chunks(token_len, self.group_effective_block_sizes[group_id])
+            if not _uses_reachable_mask(self.group_cache_families[group_id])
+            else mask
+            for group_id, mask in enumerate(masks)
+        )
+
+    def store_mask(
+        self,
+        aligned_token_len: int,
+        num_prompt_tokens: int | None = None,
+    ) -> tuple[list[bool], ...]:
+        masks = self._reachable_masks(
+            aligned_token_len,
+            retention_interval=self.retention_interval,
+            num_prompt_tokens=num_prompt_tokens,
+            all_true_as_none=False,
+        )
+        return tuple(
+            [True] * (aligned_token_len // self.group_effective_block_sizes[group_id])
+            if mask is None else mask
+            for group_id, mask in enumerate(masks)
+        )
+
+    def lookup_mask(
+        self,
+        aligned_token_len: int,
+    ) -> tuple[list[bool] | None, ...]:
+        """Per-group lookup masks.
+
+        ``None`` means all chunks in the group are lookup candidates. A list
+        mask marks chunks that can validate an aligned external cache hit
+        boundary. This mirrors Mooncake lookup pruning and does not decide the
+        final hit length; find_longest_cache_hit still owns that decision.
+        """
+        return self._reachable_masks(
+            aligned_token_len,
+            retention_interval=None,
+            num_prompt_tokens=None,
+            all_true_as_none=True,
+        )
+
+    def _reachable_masks(
+        self,
+        aligned_token_len: int,
+        *,
+        retention_interval: int | None,
+        num_prompt_tokens: int | None,
+        all_true_as_none: bool,
+    ) -> tuple[list[bool] | None, ...]:
+        assert aligned_token_len % self.lcm_block_size == 0, (
+            f"aligned_token_len ({aligned_token_len}) must be a multiple of lcm_block_size ({self.lcm_block_size})"
+        )
+        masks: list[list[bool] | None] = []
+        for group_id, spec in enumerate(self.group_effective_specs):
+            num_chunks = aligned_token_len // self.group_effective_block_sizes[group_id]
+            if not _uses_reachable_mask(self.group_cache_families[group_id]):
+                masks.append(None if all_true_as_none else [True] * num_chunks)
+                continue
+            manager_cls = _get_manager_class(_unwrap_spec(self.kv_cache_groups[group_id].kv_cache_spec))
+            mask = _reachable_block_mask(
+                manager_cls,
+                start_block=0,
+                end_block=num_chunks,
+                alignment_tokens=self.lcm_block_size,
+                kv_cache_spec=spec,
+                use_eagle=group_id in self.eagle_group_ids,
+                retention_interval=retention_interval,
+                num_prompt_tokens=num_prompt_tokens,
+            )
+            if mask is not None:
+                assert len(mask) == num_chunks
+            if mask is None:
+                masks.append(None if all_true_as_none else [True] * num_chunks)
+            elif all_true_as_none and all(mask):
+                masks.append(None)
+            else:
+                masks.append(mask)
+        return tuple(masks)
+
+    def block_hashes_for_spec(self, block_hashes: list[BlockHash], spec: Any) -> BlockHashList:
+        if spec.block_size == self.hash_block_size:
+            return cast(BlockHashList, block_hashes)
+        return cast(BlockHashList, get_block_hashes(block_hashes, spec.block_size, self.hash_block_size))
+
+    def _find_hit_blocks(
+        self,
+        block_hashes: list[BlockHash],
+        max_length: int,
+        cached_block_pool: ExternalCachedBlockPool,
+        *,
+        apply_eagle: bool = True,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        eagle_indices = self.eagle_attn_group_indices if apply_eagle else set()
+        if len(self.attention_groups) == 1:
+            spec, group_ids, manager_cls = self.attention_groups[0]
+            hashes = self.block_hashes_for_spec(block_hashes, spec)
+            hit_blocks = _find_longest_cache_hit(
+                manager_cls,
+                block_hashes=hashes,
+                max_length=max_length,
+                kv_cache_group_ids=group_ids,
+                block_pool=cast(BlockPool, cached_block_pool),
+                kv_cache_spec=spec,
+                drop_eagle_block=0 in eagle_indices,
+                alignment_tokens=spec.block_size,
+            )
+            blocks_by_group: list[list[KVCacheBlock]] = [[] for _ in range(len(self.kv_cache_groups))]
+            for group_id, blocks in zip(group_ids, hit_blocks, strict=True):
+                blocks_by_group[group_id] = blocks
+            return tuple(blocks_by_group), len(hit_blocks[0]) * spec.block_size
+
+        hit_length = max_length
+        hit_blocks_by_group: list[list[KVCacheBlock] | None] = [None] * len(self.kv_cache_groups)
+        is_simple_hybrid = len(self.attention_groups) == 2 and isinstance(
+            self.attention_groups[0][0], FullAttentionSpec
+        )
+        eagle_verified: set[int] = set()
+
+        while True:
+            curr_hit_length = hit_length
+
+            for index, (spec, group_ids, manager_cls) in enumerate(self.attention_groups):
+                cached = hit_blocks_by_group[group_ids[0]]
+                if isinstance(spec, FullAttentionSpec) and cached is not None:
+                    curr_hit_length = curr_hit_length // spec.block_size * spec.block_size
+                    continue
+
+                drop_eagle_block = index in eagle_indices and index not in eagle_verified
+                max_group_length = curr_hit_length
+                if drop_eagle_block:
+                    max_group_length = min(curr_hit_length + spec.block_size, max_length)
+                hashes = self.block_hashes_for_spec(block_hashes, spec)
+                hit_blocks = _find_longest_cache_hit(
+                    manager_cls,
+                    block_hashes=hashes,
+                    max_length=max_group_length,
+                    kv_cache_group_ids=group_ids,
+                    block_pool=cast(BlockPool, cached_block_pool),
+                    kv_cache_spec=spec,
+                    drop_eagle_block=drop_eagle_block,
+                    alignment_tokens=self.lcm_block_size,
+                )
+                new_hit_length = len(hit_blocks[0]) * spec.block_size
+                if drop_eagle_block:
+                    eagle_verified.add(index)
+                elif new_hit_length < curr_hit_length:
+                    eagle_verified.clear()
+                curr_hit_length = new_hit_length
+                for group_id, blocks in zip(group_ids, hit_blocks, strict=True):
+                    hit_blocks_by_group[group_id] = blocks
+
+            if curr_hit_length >= hit_length:
+                break
+            hit_length = curr_hit_length
+            if is_simple_hybrid:
+                break
+
+        spec0, group_ids0, _ = self.attention_groups[0]
+        if isinstance(spec0, FullAttentionSpec):
+            num_blocks = hit_length // spec0.block_size
+            for group_id in group_ids0:
+                full_blocks = hit_blocks_by_group[group_id]
+                assert full_blocks is not None
+                del full_blocks[num_blocks:]
+
+        return (
+            tuple(blocks if blocks is not None else [] for blocks in hit_blocks_by_group),
+            hit_length,
+        )
+
+
+def _unwrap_spec(spec: Any) -> Any:
+    if isinstance(spec, UniformTypeKVCacheSpecs):
+        return next(iter(spec.kv_cache_specs.values()))
+    kv_cache_specs = getattr(spec, "kv_cache_specs", None)
+    if kv_cache_specs is not None:
+        return next(iter(kv_cache_specs.values()))
+    return spec
+
+
+def _copy_spec_with_block_size(spec: Any, block_size: int) -> Any:
+    if spec.block_size == block_size:
+        return spec
+    copy_with_new_block_size = getattr(spec, "copy_with_new_block_size", None)
+    if copy_with_new_block_size is not None:
+        return copy_with_new_block_size(block_size)
+    return replace(spec, block_size=block_size)
+
+
+def _get_manager_class_cache() -> dict[str, Any]:
+    cache = getattr(_get_manager_class, _MANAGER_CLASS_CACHE_ATTR, None)
+    if not isinstance(cache, dict):
+        cache = {}
+        setattr(_get_manager_class, _MANAGER_CLASS_CACHE_ATTR, cache)
+    return cast(dict[str, Any], cache)
+
+
+def _get_manager_class(spec: Any) -> Any:
+    """Resolve the vLLM manager class across 0.20.x and 0.21.x APIs."""
+    cache = _get_manager_class_cache()
+    compress_ratio = getattr(spec, "compress_ratio", None)
+    if compress_ratio is not None and compress_ratio > 1:
+        compress_manager = cache.get("compress_manager", _CACHE_MISSING)
+        if compress_manager is _CACHE_MISSING:
+            try:
+                from vllm_ascend.core.single_type_kv_cache_manager import CompressAttentionManager
+            except ImportError:
+                compress_manager = None
+            else:
+                compress_manager = CompressAttentionManager
+            cache["compress_manager"] = compress_manager
+        if compress_manager is not None:
+            return compress_manager
+
+    registry = cache.get("registry", _CACHE_MISSING)
+    if registry is _CACHE_MISSING:
+        try:
+            registry_module = import_module("vllm.v1.kv_cache_spec_registry")
+            registry = getattr(registry_module, "KVCacheSpecRegistry", None)
+        except ImportError:
+            registry = None
+        cache["registry"] = registry
+
+    if registry is not None:
+        manager_cls = registry.get_manager_class(spec)
+        if manager_cls is not None:
+            return manager_cls
+
+    spec_manager_map = cache.get("spec_manager_map", _CACHE_MISSING)
+    if spec_manager_map is _CACHE_MISSING:
+        try:
+            manager_module = import_module("vllm.v1.core.single_type_kv_cache_manager")
+            spec_manager_map = getattr(manager_module, "spec_manager_map", {})
+        except ImportError:
+            spec_manager_map = None
+        cache["spec_manager_map"] = spec_manager_map
+
+    if not spec_manager_map:
+        raise AssertionError(f"No manager registered for KVCacheSpec {type(spec)}")
+    manager_cls = spec_manager_map.get(type(spec))
+    if manager_cls is not None:
+        return manager_cls
+    for spec_cls, candidate in spec_manager_map.items():
+        if isinstance(spec, spec_cls):
+            return candidate
+    raise AssertionError(f"No manager registered for KVCacheSpec {type(spec)}")
+
+
+def _find_longest_cache_hit(
+    manager_cls: Any,
+    **kwargs: Any,
+) -> tuple[list[KVCacheBlock], ...]:
+    try:
+        return manager_cls.find_longest_cache_hit(**kwargs)
+    except TypeError as exc:
+        if "drop_eagle_block" not in str(exc):
+            raise
+        kwargs["use_eagle"] = kwargs.pop("drop_eagle_block")
+        return manager_cls.find_longest_cache_hit(**kwargs)
+
+
+def _reachable_block_mask(
+    manager_cls: Any,
+    **kwargs: Any,
+) -> list[bool] | None:
+    reachable_block_mask = getattr(manager_cls, "reachable_block_mask", None)
+    if reachable_block_mask is None:
+        return None
+    try:
+        return reachable_block_mask(**kwargs)
+    except TypeError as exc:
+        if "retention_interval" not in str(exc) and "num_prompt_tokens" not in str(exc):
+            logger.debug("KV cache manager does not support reachable_block_mask kwargs: %s", exc)
+            return reachable_block_mask(
+                start_block=kwargs["start_block"],
+                end_block=kwargs["end_block"],
+                alignment_tokens=kwargs["alignment_tokens"],
+                kv_cache_spec=kwargs["kv_cache_spec"],
+                use_eagle=kwargs["use_eagle"],
+            )
+        kwargs.pop("retention_interval", None)
+        kwargs.pop("num_prompt_tokens", None)
+        return reachable_block_mask(**kwargs)
+
+
+def _cache_family_granularity(block_size: int, cache_family: str | None) -> int:
+    if not cache_family or not cache_family.startswith("c"):
+        return block_size
+    ratio = cache_family[1:]
+    return block_size * int(ratio) if ratio.isdigit() else block_size
+
+
+def _uses_reachable_mask(cache_family: str | None) -> bool:
+    return cache_family in (None, "default", "c1")
+
+
+def _num_chunks(token_len: int, block_size: int) -> int:
+    return (token_len + block_size - 1) // block_size


### PR DESCRIPTION
## Motivation

AscendStore's hash generation was eager — all grouped block hashes were materialized upfront even when only a subset was needed for lookup or put. Additionally, there was no coordinator abstraction to manage store/lookup masks across KV cache groups, and block hash conversion for external blocks had a correctness issue.

## Changes

### New file: `coordinator.py`
- `AscendStoreCoordinator` class managing per-group store masks, lookup masks, and block hash resolution for multi-group KV cache.
- `store_mask()` / `lookup_mask()` / `_reachable_masks()` — separate mask generation for store vs lookup paths. Lookup masks return `None` for all-true groups to skip unnecessary iteration.
- `block_hashes_for_spec()` — converts external block hashes with proper block-size alignment.

### Modified: `config_data.py`
- `_LazyGroupedBlockHashList` — lazy sequence that computes grouped hashes on demand and caches individual entries, avoiding full materialization.
- `get_block_hash_at()` / `get_num_block_hashes()` — random-access and length queries without full grouping.
- `_block_hash_to_hex()` — unified hex conversion for `BlockHash | str`.
- `process_tokens()` / `process_tokens_with_block_ids()` — refactored to use grouped hashes directly, accept `chunk_filter` callback, and attach `chunk_hash_bytes` to `PoolKey` for downstream reuse.
- `process_token_key_strings()` / `process_token_key_strings_with_block_ids()` — fast-path generators that yield key strings without creating `PoolKey` objects.
- `process_token_key_strings_with_block_ids_sparse_store_mask()` — generator that only yields chunks allowed by a store mask, with optional shard rank/size for pre-sharded key build.
- `_get_key_prefix()` / `_key_prefix_cache` — per-group key prefix cache to avoid repeated string formatting.
- `PoolKey.chunk_hash_bytes` — stores raw `BlockHash` alongside hex string for reuse.

## Test Plan

- [ ] Verify AscendStore lookup returns correct hit tokens with lazy hash
- [ ] Verify put path with sparse store mask only stores allowed chunks
- [ ] Verify key prefix cache is invalidated on group info update
- [ ] Run multi-group DSV4 KV transfer end-to-end

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
