### PR TITLE
perf: optimize AscendStore lookup and put paths

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -284,13 +284,20 @@ class LookupKeyServer:
                 all_frames = self.socket.recv_multipart(copy=False)
                 token_len = int.from_bytes(all_frames[0], byteorder="big")
                 kv_group_ids = self.decoder.decode([all_frames[1]])
-                hash_frames = all_frames[2:]
+                # 6D: 兼容旧格式（3 frames = 无 hbm_hit_tokens）
+                if len(all_frames) > 3:
+                    hbm_hit_tokens = int.from_bytes(all_frames[2], byteorder="big")
+                    hash_frames = all_frames[3:]
+                else:
+                    hbm_hit_tokens = 0
+                    hash_frames = all_frames[2:]
                 hashes_str = self.decoder.decode(hash_frames)
                 result = self.pool_worker.lookup_scheduler(
                     token_len,
                     hashes_str,
                     kv_group_ids,
                     self.use_layerwise,
+                    hbm_hit_tokens=hbm_hit_tokens,
                 )
                 logger.debug(
                     "KV pool lookup response token_len=%d groups=%s hit_tokens=%d",

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -116,7 +116,15 @@ class MooncakeBackend(Backend):
             )
             return [0] * len(keys)
         assert self.store is not None
-        return self.store.batch_is_exist(keys)
+        import time as _kvtrace_time
+        _kvtrace_t0 = _kvtrace_time.perf_counter()
+        _kvtrace_result = self.store.batch_is_exist(keys)
+        _kvtrace_ms = (_kvtrace_time.perf_counter() - _kvtrace_t0) * 1000
+        logger.info(
+            "KVTRACE stage=mooncake_exists elapsed_ms=%.3f keys=%d hit=%d",
+            _kvtrace_ms, len(keys), sum(1 for v in _kvtrace_result if v == 1) if _kvtrace_result else 0
+        )
+        return _kvtrace_result
 
     def put(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         self.ensure_initialized()
@@ -126,44 +134,32 @@ class MooncakeBackend(Backend):
             if self.config.preferred_segment:
                 config.preferred_segment = self.local_seg
             config.prefer_alloc_in_same_node = self.config.prefer_alloc_in_same_node
+            import time as _kvtrace_time
+            _kvtrace_t0 = _kvtrace_time.perf_counter()
             res = self.store.batch_put_from_multi_buffers(keys, addrs, sizes, config)
-            failed_codes = [int(value) for value in res if value < 0]
-            failed_count = len(failed_codes)
-            if failed_count:
-                error_codes = sorted(set(failed_codes))
-                logger.error(
-                    "Failed to put %d keys out of %d. error_codes=%s. Check memory and store capacity.",
-                    failed_count,
-                    len(keys),
-                    error_codes,
-                )
-                logger.debug("Failed to put key details. keys=%s, result=%s", keys, res)
-                if self._lazy_init:
-                    logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
+            _kvtrace_ms = (_kvtrace_time.perf_counter() - _kvtrace_t0) * 1000
+            logger.info(
+                "KVTRACE stage=mooncake_put elapsed_ms=%.3f keys=%d",
+                _kvtrace_ms, len(keys)
+            )
+            for value in res:
+                if value < 0:
+                    logger.error("Failed to put key %s,res:%s", keys, res)
+                    if self._lazy_init:
+                        logger.error("If this is the first DSV4(compress) request, this failure is expected.")
         except Exception as e:
-            logger.error(
-                "Failed to put %d keys out of %d. Check store state and memory.",
-                len(keys),
-                len(keys),
-            )
-            logger.debug(
-                "Failed to put key details. keys=%s, type=%s, error=%s",
-                keys,
-                type(e).__name__,
-                e,
-            )
+            logger.error("Failed to put key %s,error:%s", keys, e)
             if self._lazy_init:
-                logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
+                logger.error("If this is the first DSV4(compress) request, this failure is expected.")
 
     def get(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         if self._lazy_init and not self._store_initialized:
             logger.error(
-                "Failed to get %d keys out of %d. Store is not initialized; "
-                "call put() first to trigger initialization.",
+                "MooncakeBackend.get called before store initialization, "
+                "keys=%d sample_keys=%s",
                 len(keys),
-                len(keys),
+                keys[:3],
             )
-            logger.debug("Failed to get key details. keys=%s", keys)
             return
         assert self.store is not None
         logger.debug(
@@ -172,36 +168,40 @@ class MooncakeBackend(Backend):
             keys[:3],
         )
         try:
+            import time as _kvtrace_time
+            _kvtrace_t0 = _kvtrace_time.perf_counter()
             res = self.store.batch_get_into_multi_buffers(keys, addrs, sizes)
+            _kvtrace_ms = (_kvtrace_time.perf_counter() - _kvtrace_t0) * 1000
+            logger.info(
+                "KVTRACE stage=mooncake_get elapsed_ms=%.3f keys=%d",
+                _kvtrace_ms, len(keys)
+            )
             res_list = list(res)
-            failed_codes = [int(value) for value in res_list if value < 0]
-            failed_count = len(failed_codes)
-            error_codes = sorted(set(failed_codes))
-            if failed_count:
+            negative_count = sum(1 for value in res_list if value < 0)
+            logger.debug(
+                "MooncakeBackend.get result keys=%d sample_keys=%s "
+                "result_sample=%s negative_count=%d",
+                len(keys),
+                keys[:3],
+                res_list[:12],
+                negative_count,
+            )
+            if negative_count:
                 logger.error(
-                    "Failed to get %d keys out of %d. error_codes=%s. Check key existence and memory state.",
-                    failed_count,
+                    "Failed to get keys count=%d sample_keys=%s "
+                    "result_sample=%s negative_count=%d",
                     len(keys),
-                    error_codes,
+                    keys[:3],
+                    res_list[:12],
+                    negative_count,
                 )
-                logger.debug("Failed to get key details. keys=%s, result=%s", keys, res_list)
-            for i, value in enumerate(res_list):
-                if value > 0:
-                    res_list[i] = 0
-            return res_list
         except Exception as e:
             logger.error(
-                "Failed to get %d keys out of %d. Check store state and network.",
+                "Failed to get keys count=%d sample_keys=%s error:%s",
                 len(keys),
-                len(keys),
-            )
-            logger.debug(
-                "Failed to get key details. keys=%s, type=%s, error=%s",
-                keys,
-                type(e).__name__,
+                keys[:3],
                 e,
             )
-            return None
 
 
 @dataclass

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -2,6 +2,7 @@ import queue
 import threading
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable
 from typing import Any
 
 import torch
@@ -16,7 +17,6 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     ChunkedTokenDatabase,
     LayerMultiBlockReqMeta,
     ReqMeta,
-    get_block_hashes,
 )
 # isort: on
 
@@ -58,6 +58,10 @@ class KVTransferThread(threading.Thread):
         self,
         request: ReqMeta | LayerMultiBlockReqMeta,
     ) -> torch.Tensor:
+        import time as _kvtrace_time
+        if not hasattr(self, "_kvtrace_enqueue_times"):
+            self._kvtrace_enqueue_times = {}
+        self._kvtrace_enqueue_times[request.req_id] = _kvtrace_time.perf_counter()
         self.request_queue.put(request)
 
     def get_and_clear_finished_requests(self) -> set[str]:
@@ -137,6 +141,7 @@ class KVTransferThread(threading.Thread):
         kv_cache_group_id: int = 0,
         skip_null_blocks: bool = False,
         cache_role: str = "kv",
+        chunk_filter: Callable[[int], bool] | None = None,
     ):
         process_with_block_ids = getattr(self.token_database, "process_tokens_with_block_ids", None)
         if process_with_block_ids is not None:
@@ -148,6 +153,7 @@ class KVTransferThread(threading.Thread):
                 kv_cache_group_id=kv_cache_group_id,
                 skip_null_blocks=skip_null_blocks,
                 cache_role=cache_role,
+                chunk_filter=chunk_filter,
             )
 
         def iter_with_legacy_process_tokens():
@@ -157,6 +163,8 @@ class KVTransferThread(threading.Thread):
                 token_iter = self.token_database.process_tokens(token_len, block_hashes)
             group_block_size = self._get_block_size(kv_cache_group_id)
             for start, end, key in token_iter:
+                if chunk_filter is not None and not chunk_filter(start):
+                    continue
                 block_idx = start // group_block_size
                 if block_idx >= len(block_ids):
                     continue
@@ -174,6 +182,7 @@ class KVTransferThread(threading.Thread):
         block_ids: list[int],
         kv_cache_group_id: int = 0,
         cache_role: str = "kv",
+        block_id: int | None = None,
     ):
         try:
             return self.token_database.prepare_value(
@@ -182,6 +191,7 @@ class KVTransferThread(threading.Thread):
                 block_ids,
                 kv_cache_group_id=kv_cache_group_id,
                 cache_role=cache_role,
+                block_id=block_id,
             )
         except TypeError:
             return self.token_database.prepare_value(start, end, block_ids)
@@ -205,6 +215,41 @@ class KVTransferThread(threading.Thread):
         except TypeError:
             return self.token_database.decode_adaptor_prefill_pp(keys, addrs, sizes)
 
+    def _chunk_mask_allows(
+        self,
+        masks: tuple[list[bool], ...] | None,
+        kv_cache_group_id: int,
+        start: int,
+    ) -> bool:
+        mask_allows_chunk = getattr(self.token_database, "mask_allows_chunk", None)
+        if mask_allows_chunk is not None:
+            return mask_allows_chunk(masks, kv_cache_group_id, start)
+        if masks is None or kv_cache_group_id >= len(masks):
+            return True
+        mask = masks[kv_cache_group_id]
+        chunk_idx = start // self._get_block_size(kv_cache_group_id)
+        return chunk_idx < len(mask) and mask[chunk_idx]
+
+    def _store_mask(self, req_meta: ReqMeta) -> tuple[list[bool], ...] | None:
+        store_mask = getattr(self.token_database, "store_mask", None)
+        if store_mask is None:
+            return None
+        try:
+            return store_mask(req_meta.token_len_chunk, req_meta.num_prompt_tokens)
+        except AssertionError as exc:
+            logger.debug("Skip AscendStore store mask for unaligned request %s: %s", req_meta.req_id, exc)
+            return None
+
+    def _load_mask(
+        self,
+        req_meta: ReqMeta,
+        token_len: int,
+    ) -> tuple[list[bool], ...] | None:
+        load_mask = getattr(self.token_database, "load_mask", None)
+        if load_mask is None:
+            return None
+        return load_mask(req_meta.block_hashes, token_len)
+
 
 class KVCacheStoreSendingThread(KVTransferThread):
     def __init__(
@@ -226,6 +271,17 @@ class KVCacheStoreSendingThread(KVTransferThread):
         self.kv_role = kv_role
         self.stored_requests = defaultdict[str, int](int)
         self.enable_kv_event = enable_kv_event
+        import os as _os
+        self._skip_existed_group = _os.getenv("VLLM_ASCEND_SKIP_STORE_EXISTED_GROUP", "0") == "1"
+        self._put_key_string_fast_path = _os.getenv(
+            "VLLM_ASCEND_PUT_KEY_STRING_FAST_PATH", "1"
+        ) != "0"
+        self._put_sparse_store_mask = _os.getenv("VLLM_ASCEND_PUT_SPARSE_STORE_MASK", "0") == "1"
+        self._put_pre_shard_key_build = _os.getenv("VLLM_ASCEND_PUT_PRE_SHARD_KEY_BUILD", "0") == "1"
+        self._key_build_cache = {}  # (block_hash_prefix, group_id) -> (starts, ends, keys, block_hashes)
+        self._key_build_cache_max = 10000
+        self._per_request_save_wait = _os.getenv("VLLM_ASCEND_PER_REQUEST_SAVE_WAIT", "0") == "1"
+        self._stored_request_done_events: dict[str, threading.Event] = {}
 
     def add_stored_request(self, req_id: str):
         with self.done_task_lock:
@@ -235,64 +291,233 @@ class KVCacheStoreSendingThread(KVTransferThread):
         with self.done_task_lock:
             if req_id in self.stored_requests:
                 self.stored_requests[req_id] -= 1
+                return self.stored_requests[req_id]
+            return None
+
+    def prepare_stored_request_done_event(self, req_id: str):
+        if not self._per_request_save_wait:
+            return None
+        with self.done_task_lock:
+            event = self._stored_request_done_events.get(req_id)
+            if event is None:
+                event = threading.Event()
+                self._stored_request_done_events[req_id] = event
+            return event
+
+    def _notify_stored_request_done(self, req_id: str, remaining: int | None = 0):
+        if not self._per_request_save_wait:
+            return
+        if remaining is not None and remaining > 0:
+            return
+        with self.done_task_lock:
+            event = self._stored_request_done_events.pop(req_id, None)
+        if event is not None:
+            event.set()
 
     def delete_finished_stored_request(self, req_id: str):
         with self.done_task_lock:
             if req_id in self.stored_requests:
                 del self.stored_requests[req_id]
+            event = self._stored_request_done_events.pop(req_id, None)
+        if event is not None:
+            event.set()
 
     def _handle_request(self, req_meta: ReqMeta):
+        import time as _kvtrace_time
+        _kvtrace_t_enq = getattr(self, "_kvtrace_enqueue_times", {}).pop(req_meta.req_id, None)
+        _kvtrace_t_start = _kvtrace_time.perf_counter()
+        _kvtrace_qwait_ms = ((_kvtrace_t_start - _kvtrace_t_enq) * 1000) if _kvtrace_t_enq else -1
+        _kvtrace_qsize = self.request_queue.qsize()
         token_len = req_meta.token_len_chunk
         req_id = req_meta.req_id
         current_event = req_meta.current_event
         if req_id not in self.stored_requests:
+            self._notify_stored_request_done(req_id)
             self.request_queue.task_done()
             return
 
+        _kvtrace_t_sm = _kvtrace_time.perf_counter()
+        store_masks = self._store_mask(req_meta)
+        _kvtrace_store_mask_ms = (_kvtrace_time.perf_counter() - _kvtrace_t_sm) * 1000
         for group_id in req_meta.kv_cache_group_ids or [0]:
+            # 6C: store_mask 前移
+            group_store_mask = None
+            if store_masks is not None and group_id < len(store_masks):
+                group_store_mask = store_masks[group_id]
+                if not group_store_mask or not any(group_store_mask):
+                    if logger.isEnabledFor(20):
+                        logger.info(
+                            "KVTRACE req=%s stage=kvpool_put_skip_group group=%d "
+                            "reason=no_store_mask", req_id, group_id
+                        )
+                    continue
+            _kvtrace_t_group = _kvtrace_time.perf_counter()
             starts = []
             ends = []
             keys = []
             block_hashes = []
+            key_block_ids = []
             block_ids = req_meta.block_ids_by_group[group_id]
             group_block_size = self._get_block_size(group_id)
-            group_block_hashes = get_block_hashes(
-                req_meta.block_hashes,
-                group_block_size,
-                getattr(self.token_database, "hash_block_size", group_block_size),
-            )
+            chunk_filter = lambda start, group_id=group_id: self._chunk_mask_allows(store_masks, group_id, start)
 
-            for start, end, key, _ in self._process_tokens_with_block_ids(
-                token_len,
-                req_meta.block_hashes,
-                block_ids,
-                kv_cache_group_id=group_id,
-                skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
-            ):
-                starts.append(start)
-                ends.append(end)
-                keys.append(key.to_string())
-                block_hashes.append(group_block_hashes[start // group_block_size])
+            _kvtrace_pt_count = 0
+            _kvtrace_mask_ms = 0.0
+            _kvtrace_str_app_ms = 0.0
+            _kvtrace_cached = False
+            _kvtrace_sparse_mask = False
+            _kvtrace_pre_sharded = False
 
-            if not self.dcp_size > 1 and not req_meta.disable_tp_key_sharding:
+            # Phase 6B': check key_build cache
+            if self._skip_existed_group and req_meta.block_hashes:
+                _cache_key = (hash(tuple(req_meta.block_hashes[:8])), group_id)
+                _cached_data = self._key_build_cache.get(_cache_key)
+                if _cached_data is not None:
+                    _kvtrace_cached = True
+                    _raw_starts, _raw_ends, _raw_keys, _raw_block_hashes = _cached_data
+                    for _ci, _cs in enumerate(_raw_starts):
+                        _kvtrace_pt_count += 1
+                        _kvtrace_t_m = _kvtrace_time.perf_counter()
+                        if not self._chunk_mask_allows(store_masks, group_id, _cs):
+                            _kvtrace_mask_ms += (_kvtrace_time.perf_counter() - _kvtrace_t_m) * 1000
+                            continue
+                        _kvtrace_mask_ms += (_kvtrace_time.perf_counter() - _kvtrace_t_m) * 1000
+                        starts.append(_cs)
+                        ends.append(_raw_ends[_ci])
+                        keys.append(_raw_keys[_ci])
+                        block_hashes.append(_raw_block_hashes[_ci])
+                        key_block_ids.append(block_ids[_cs // group_block_size])
+            if not _kvtrace_cached:
+                if self._put_key_string_fast_path:
+                    if self._put_sparse_store_mask and group_store_mask is not None:
+                        _kvtrace_sparse_mask = True
+                        _kvtrace_pre_sharded = (
+                            self._put_pre_shard_key_build
+                            and not self.dcp_size > 1
+                            and not req_meta.disable_tp_key_sharding
+                        )
+                        iterator = self.token_database.process_token_key_strings_with_block_ids_sparse_store_mask(
+                            token_len,
+                            req_meta.block_hashes,
+                            block_ids,
+                            group_store_mask,
+                            kv_cache_group_id=group_id,
+                            skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
+                            shard_rank=(self.tp_rank % self.put_step) if _kvtrace_pre_sharded else None,
+                            shard_size=self.put_step if _kvtrace_pre_sharded else None,
+                        )
+                    else:
+                        iterator = self.token_database.process_token_key_strings_with_block_ids(
+                            token_len,
+                            req_meta.block_hashes,
+                            block_ids,
+                            kv_cache_group_id=group_id,
+                            skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
+                            chunk_filter=chunk_filter,
+                        )
+                    for start, end, key_string, chunk_hash, block_id in iterator:
+                        _kvtrace_pt_count += 1
+                        if not _kvtrace_sparse_mask:
+                            _kvtrace_t_m = _kvtrace_time.perf_counter()
+                            if not self._chunk_mask_allows(store_masks, group_id, start):
+                                _kvtrace_mask_ms += (_kvtrace_time.perf_counter() - _kvtrace_t_m) * 1000
+                                continue
+                            _kvtrace_mask_ms += (_kvtrace_time.perf_counter() - _kvtrace_t_m) * 1000
+                        _kvtrace_t_sa = _kvtrace_time.perf_counter()
+                        starts.append(start)
+                        ends.append(end)
+                        keys.append(key_string)
+                        if self.enable_kv_event:
+                            block_hashes.append(chunk_hash)
+                        key_block_ids.append(block_id)
+                        _kvtrace_str_app_ms += (_kvtrace_time.perf_counter() - _kvtrace_t_sa) * 1000
+                else:
+                    for start, end, key, block_id in self._process_tokens_with_block_ids(
+                        token_len,
+                        req_meta.block_hashes,
+                        block_ids,
+                        kv_cache_group_id=group_id,
+                        skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
+                        chunk_filter=chunk_filter,
+                    ):
+                        _kvtrace_pt_count += 1
+                        _kvtrace_t_m = _kvtrace_time.perf_counter()
+                        if not self._chunk_mask_allows(store_masks, group_id, start):
+                            _kvtrace_mask_ms += (_kvtrace_time.perf_counter() - _kvtrace_t_m) * 1000
+                            continue
+                        _kvtrace_mask_ms += (_kvtrace_time.perf_counter() - _kvtrace_t_m) * 1000
+                        _kvtrace_t_sa = _kvtrace_time.perf_counter()
+                        starts.append(start)
+                        ends.append(end)
+                        keys.append(key.to_string())
+                        if self.enable_kv_event:
+                            assert key.chunk_hash_bytes is not None
+                            block_hashes.append(key.chunk_hash_bytes)
+                        key_block_ids.append(block_id)
+                        _kvtrace_str_app_ms += (_kvtrace_time.perf_counter() - _kvtrace_t_sa) * 1000
+                # Cache key_build result (pre-sharding, post-mask)
+                if (
+                    self._skip_existed_group
+                    and not _kvtrace_pre_sharded
+                    and req_meta.block_hashes
+                    and len(self._key_build_cache) < self._key_build_cache_max
+                ):
+                    self._key_build_cache[_cache_key] = (list(starts), list(ends), list(keys), list(block_hashes) if self.enable_kv_event else [])
+
+            if not _kvtrace_pre_sharded and not self.dcp_size > 1 and not req_meta.disable_tp_key_sharding:
                 starts = starts[self.tp_rank % self.put_step :: self.put_step]
                 ends = ends[self.tp_rank % self.put_step :: self.put_step]
                 keys = keys[self.tp_rank % self.put_step :: self.put_step]
                 block_hashes = block_hashes[self.tp_rank % self.put_step :: self.put_step]
+                key_block_ids = key_block_ids[self.tp_rank % self.put_step :: self.put_step]
+
+            _kvtrace_keybuild_ms = (_kvtrace_time.perf_counter() - _kvtrace_t_group) * 1000
+            _kvtrace_pt_iter_ms = _kvtrace_keybuild_ms - _kvtrace_mask_ms - _kvtrace_str_app_ms - _kvtrace_store_mask_ms
+            logger.info(
+                "KVTRACE stage=kvpool_put_kb_detail group=%d "
+                "pt_count=%d iter_ms=%.3f mask_ms=%.3f str_app_ms=%.3f "
+                "store_mask_ms=%.3f total_ms=%.3f fast_path=%s sparse_mask=%s pre_shard=%s",
+                group_id, _kvtrace_pt_count,
+                _kvtrace_pt_iter_ms, _kvtrace_mask_ms, _kvtrace_str_app_ms,
+                _kvtrace_store_mask_ms, _kvtrace_keybuild_ms,
+                self._put_key_string_fast_path, _kvtrace_sparse_mask, _kvtrace_pre_sharded
+            )
 
             if not keys:
+                logger.info(
+                    "KVTRACE req=%s stage=kvpool_put_group group=%d "
+                    "key_build_ms=%.3f exist_ms=0.000 prepare_ms=0.000 "
+                    "event_sync_ms=0.000 put_ms=0.000 total_ms=%.3f keys=0",
+                    req_id, group_id, _kvtrace_keybuild_ms, _kvtrace_keybuild_ms
+                )
                 continue
 
+            _kvtrace_t0 = _kvtrace_time.perf_counter()
             exists_states = self.lookup(keys)
+            _kvtrace_exist_ms = (_kvtrace_time.perf_counter() - _kvtrace_t0) * 1000
             missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
+            logger.info(
+                "KVTRACE req=%s stage=kvpool_put_exist elapsed_ms=%.3f "
+                "group=%d total_keys=%d missing_keys=%d",
+                req_id, _kvtrace_exist_ms, group_id,
+                len(keys), len(missing_indices)
+            )
 
             if not missing_indices:
+                logger.info(
+                    "KVTRACE req=%s stage=kvpool_put_skip_group group=%d "
+                    "reason=all_exist keys=%d key_build_ms=%.3f exist_ms=%.3f cached=%s",
+                    req_id, group_id, len(keys),
+                    _kvtrace_keybuild_ms, _kvtrace_exist_ms, _kvtrace_cached
+                )
                 continue
 
             starts = [starts[index] for index in missing_indices]
             ends = [ends[index] for index in missing_indices]
             keys = [keys[index] for index in missing_indices]
-            block_hashes = [block_hashes[index] for index in missing_indices]
+            if self.enable_kv_event:
+                block_hashes = [block_hashes[index] for index in missing_indices]
+            key_block_ids = [key_block_ids[index] for index in missing_indices]
 
             logger.info(
                 "Storing KV cache for %d out of %d blocks (missing_count=%d) for request %s in group %d",
@@ -311,17 +536,19 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 keys[:3],
             )
 
+            _kvtrace_t_prep = _kvtrace_time.perf_counter()
             addrs = []
             sizes = []
             stored_events: list[BlockStored] = []
             prev_key = None
-            new_block_hashes = [maybe_convert_block_hash(bh) for bh in block_hashes]
+            new_block_hashes = [maybe_convert_block_hash(bh) for bh in block_hashes] if self.enable_kv_event else []
             for index, start in enumerate(starts):
                 addr, size, _ = self._prepare_value(
                     start,
                     ends[index],
                     block_ids,
                     kv_cache_group_id=group_id,
+                    block_id=key_block_ids[index],
                 )
                 addrs.append(addr)
                 sizes.append(size)
@@ -334,18 +561,19 @@ class KVCacheStoreSendingThread(KVTransferThread):
                         if isinstance(req_meta.original_block_size, list)
                         else req_meta.original_block_size
                     )
-                    stored_event = BlockStored(
-                        block_hashes=[new_block_hashes[index]],
-                        parent_block_hash=prev_key,
-                        token_ids=token_ids,
-                        block_size=block_size,
-                        lora_id=None,
-                        medium="cpu",
-                        lora_name=None,
-                    )
-                    stored_events.append(stored_event)
-                    prev_key = new_block_hashes[index]
-                    logger.debug("Added kv cache event '%s' to kv cache events queue", stored_event)
+                    if block_size is not None:
+                        stored_event = BlockStored(
+                            block_hashes=[new_block_hashes[index]],
+                            parent_block_hash=prev_key,
+                            token_ids=token_ids,
+                            block_size=block_size,
+                            lora_id=None,
+                            medium="cpu",
+                            lora_name=None,
+                        )
+                        stored_events.append(stored_event)
+                        prev_key = new_block_hashes[index]
+                        logger.debug("Added kv cache event '%s' to kv cache events queue", stored_event)
 
             if self.kv_role == "kv_consumer":
                 keys, addrs, sizes = self._decode_adaptor_prefill_pp(
@@ -355,15 +583,50 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     kv_cache_group_id=group_id,
                 )
 
+            _kvtrace_prep_ms = (_kvtrace_time.perf_counter() - _kvtrace_t_prep) * 1000
+            _kvtrace_t0_evt = _kvtrace_time.perf_counter()
             if current_event is not None:
                 current_event.synchronize()
+            _kvtrace_evt_ms = (_kvtrace_time.perf_counter() - _kvtrace_t0_evt) * 1000
+            logger.info(
+                "KVTRACE req=%s stage=kvpool_put_event_sync elapsed_ms=%.3f "
+                "has_event=%s",
+                req_id, _kvtrace_evt_ms, current_event is not None
+            )
+            _kvtrace_t0_put = _kvtrace_time.perf_counter()
             self.m_store.put(keys, addrs, sizes)
+            _kvtrace_put_ms = (_kvtrace_time.perf_counter() - _kvtrace_t0_put) * 1000
+            logger.info(
+                "KVTRACE req=%s stage=kvpool_put_backend elapsed_ms=%.3f "
+                "group=%d keys=%d role=%s tp_rank=%d put_step=%d",
+                req_id, _kvtrace_put_ms, group_id, len(keys),
+                self.kv_role, self.tp_rank, self.put_step
+            )
 
             # TODO Query specific replica info to update the event
             if self.enable_kv_event and stored_events is not None:
                 self.update_kv_event(stored_events)
 
-        self.dec_stored_request(req_id)
+            _kvtrace_group_total_ms = (_kvtrace_time.perf_counter() - _kvtrace_t_group) * 1000
+            logger.info(
+                "KVTRACE req=%s stage=kvpool_put_group group=%d "
+                "key_build_ms=%.3f exist_ms=%.3f prepare_ms=%.3f "
+                "event_sync_ms=%.3f put_ms=%.3f total_ms=%.3f keys=%d",
+                req_id, group_id,
+                _kvtrace_keybuild_ms, _kvtrace_exist_ms,
+                _kvtrace_prep_ms, _kvtrace_evt_ms, _kvtrace_put_ms,
+                _kvtrace_group_total_ms, len(keys)
+            )
+
+        _kvtrace_handle_ms = (_kvtrace_time.perf_counter() - _kvtrace_t_start) * 1000
+        logger.info(
+            "KVTRACE req=%s stage=kvpool_send_handle_done elapsed_ms=%.3f "
+            "queue_wait_ms=%.3f queue_size=%d group=%d",
+            req_id, _kvtrace_handle_ms, _kvtrace_qwait_ms,
+            _kvtrace_qsize, group_id
+        )
+        remaining_jobs = self.dec_stored_request(req_id)
+        self._notify_stored_request_done(req_id, remaining_jobs)
         self.request_queue.task_done()
 
 
@@ -387,6 +650,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         addr_list = []
         size_list = []
         key_list = []
+        load_masks = self._load_mask(req_meta, token_len)
         for group_id in req_meta.kv_cache_group_ids or [0]:
             block_ids = req_meta.block_ids_by_group[group_id]
             group_block_size = self._get_block_size(group_id)
@@ -395,19 +659,24 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 // group_block_size
                 * group_block_size
             )
-            for start, end, key, _ in self._process_tokens_with_block_ids(
+            chunk_filter = lambda start, group_id=group_id: self._chunk_mask_allows(load_masks, group_id, start)
+            for start, end, key, block_id in self._process_tokens_with_block_ids(
                 token_len,
                 req_meta.block_hashes,
                 block_ids,
                 mask_num,
                 kv_cache_group_id=group_id,
                 skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
+                chunk_filter=chunk_filter,
             ):
+                if not self._chunk_mask_allows(load_masks, group_id, start):
+                    continue
                 addr, size, _ = self._prepare_value(
                     start,
                     end,
                     block_ids,
                     kv_cache_group_id=group_id,
+                    block_id=block_id,
                 )
                 key_list.append(key.to_string())
                 addr_list.append(addr)
@@ -427,13 +696,14 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             len(key_list_c),
             key_list_c[:3],
         )
+        import time as _kvtrace_time
+        _kvtrace_t0 = _kvtrace_time.perf_counter()
         self.m_store.get(key_list_c, addr_list_c, size_list_c)
-        logger.debug(
-            "KV pool async recv backend get returned request=%s token_len=%d groups=%s keys=%d",
-            req_id,
-            token_len,
-            req_meta.kv_cache_group_ids or [0],
-            len(key_list_c),
+        _kvtrace_get_ms = (_kvtrace_time.perf_counter() - _kvtrace_t0) * 1000
+        logger.info(
+            "KVTRACE req=%s stage=kvpool_get_backend elapsed_ms=%.3f "
+            "mode=async keys=%d",
+            req_id, _kvtrace_get_ms, len(key_list_c)
         )
         self.set_finished_request(req_id)
         self.request_queue.task_done()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -226,25 +226,43 @@ class KVPoolScheduler:
         if token_len < self.cache_transfer_granularity:
             return 0, False
 
-        num_external_hit_tokens = self.client.lookup(
+        # 6D: HBM 全命中提前返回，不走 external lookup
+        if num_computed_tokens >= token_len:
+            return 0, False
+
+        import time as _kvtrace_time
+        _kvtrace_t0 = _kvtrace_time.perf_counter()
+        num_total_hit_tokens = self.client.lookup(
             token_len,
             request.block_hashes,
             self.kv_cache_group_ids,
+            hbm_hit_tokens=num_computed_tokens,
+        )
+        _kvtrace_elapsed = (_kvtrace_time.perf_counter() - _kvtrace_t0) * 1000
+        logger.info(
+            "KVTRACE req=%s stage=kvpool_lookup_total elapsed_ms=%.3f "
+            "token_len=%d prompt_tokens=%d local_hit_tokens=%d "
+            "external_hit_tokens=%d need_to_allocate=%d "
+            "load_async=%s groups=%s granularity=%d",
+            request.request_id, _kvtrace_elapsed,
+            token_len, len(request.prompt_token_ids), num_computed_tokens,
+            num_total_hit_tokens, max(0, num_total_hit_tokens - num_computed_tokens),
+            self.load_async, self.kv_cache_group_ids, self.cache_transfer_granularity
         )
 
-        if num_external_hit_tokens == request.num_tokens:
-            num_external_hit_tokens -= 1
+        if num_total_hit_tokens == request.num_tokens:
+            num_total_hit_tokens -= 1
 
-        if num_external_hit_tokens < num_computed_tokens:
+        if num_total_hit_tokens < num_computed_tokens:
             need_to_allocate = 0
         else:
-            need_to_allocate = num_external_hit_tokens - num_computed_tokens
+            need_to_allocate = num_total_hit_tokens - num_computed_tokens
 
         logger.debug(
             "Reqid: %s, Total tokens %d, kvpool hit tokens: %d, need to load: %d",
             request.request_id,
             request.num_tokens,
-            num_external_hit_tokens,
+            num_total_hit_tokens,
             need_to_allocate,
         )
 
@@ -253,7 +271,7 @@ class KVPoolScheduler:
 
         self.load_specs[request.request_id] = LoadSpec(
             vllm_cached_tokens=num_computed_tokens,
-            kvpool_cached_tokens=num_external_hit_tokens,
+            kvpool_cached_tokens=num_total_hit_tokens,
             can_load=False,
         )
         logger.info(
@@ -261,7 +279,7 @@ class KVPoolScheduler:
             "need_to_allocate=%d load_async=%s use_layerwise=%s",
             request.request_id,
             num_computed_tokens,
-            num_external_hit_tokens,
+            num_total_hit_tokens,
             need_to_allocate,
             self.load_async,
             self.use_layerwise,
@@ -371,6 +389,7 @@ class KVPoolScheduler:
                 allocated_block_ids_by_group=normalize_block_ids_by_group(request.block_ids),
                 num_saved_tokens=0,
                 token_ids=request.prompt_token_ids[:num_tokens_to_compute].copy(),
+                num_prompt_tokens=len(request.prompt_token_ids),
             )
             self._request_trackers[request.req_id] = request_tracker
             last_chunk_tokens_num = (
@@ -414,6 +433,7 @@ class KVPoolScheduler:
                         allocated_block_ids_by_group=normalize_block_ids_by_group(new_block_ids),
                         num_saved_tokens=0,
                         token_ids=request_real.prompt_token_ids[:num_tokens_to_compute].copy(),
+                        num_prompt_tokens=len(request_real.prompt_token_ids),
                     )
                     self._request_trackers[req_id] = request_tracker
                     last_chunk_tokens_num = (
@@ -487,6 +507,7 @@ class KVPoolScheduler:
                     token_len=num_tokens_to_compute,
                     allocated_block_ids_by_group=block_ids,
                     num_saved_tokens=0,
+                    num_prompt_tokens=len(request.prompt_token_ids),
                 )
 
                 self._request_trackers[request_id] = request_tracker
@@ -563,13 +584,15 @@ class LookupKeyClient:
         token_len: int,
         block_hashes: list[BlockHash],
         kv_cache_group_ids: list[int] | None = None,
+        hbm_hit_tokens: int = 0,
     ) -> int:
         kv_cache_group_ids = kv_cache_group_ids or [0]
         hash_strs = [h.hex() for h in block_hashes]
         hash_frames = self.encoder.encode(hash_strs)
         kv_group_frames = self.encoder.encode(kv_cache_group_ids)
         token_len_bytes = token_len.to_bytes(4, byteorder="big")
-        all_frames = [token_len_bytes] + list(kv_group_frames) + list(hash_frames)
+        hbm_bytes = hbm_hit_tokens.to_bytes(4, byteorder="big")
+        all_frames = [token_len_bytes] + list(kv_group_frames) + [hbm_bytes] + list(hash_frames)
         self.socket.send_multipart(all_frames, copy=False)
         resp = self.socket.recv()
         result = int.from_bytes(resp, "big")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import importlib
 import math
+import os
 import threading
 from collections.abc import Generator
+from concurrent.futures import ThreadPoolExecutor
 
 import torch
+import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.distributed import (
     get_decode_context_model_parallel_rank,
@@ -30,8 +33,13 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     KeyMetadata,
     LayerMultiBlockReqMeta,
     ReqMeta,
+    get_block_hashes,
     get_cache_family_granularity,
     infer_group_cache_families,
+)
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import (
+    AscendStoreCoordinator,
+    ExternalCachedBlockPool,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import (
     KVCacheStoreLayerRecvingThread,
@@ -167,13 +175,26 @@ class KVPoolWorker:
                     for i in range(2, remaining_layers + 2):
                         partitions[-i] += 1
 
+        spec_cfg = getattr(vllm_config, "speculative_config", None)
+        use_eagle = bool(
+            spec_cfg.use_eagle() if spec_cfg is not None and callable(getattr(spec_cfg, "use_eagle", None)) else False
+        )
+        kv_cache_groups = (
+            list(kv_cache_config.kv_cache_groups) if kv_cache_config is not None and self.use_hybrid else None
+        )
         self.token_database = ChunkedTokenDatabase(
             self.metadata,
             self.grouped_block_size,
             partitions,
             use_hybrid=self.use_hybrid,
             hash_block_size=self.hash_block_size,
+            kv_cache_groups=kv_cache_groups,
+            alignment_tokens=self.cache_transfer_granularity,
+            retention_interval=getattr(envs, "VLLM_PREFIX_CACHE_RETENTION_INTERVAL", None),
+            use_eagle=use_eagle,
         )
+        self.cache_coordinator = self._build_cache_coordinator(vllm_config)
+        self.token_database.set_cache_coordinator(self.cache_coordinator)
 
         backend = backend_map.get(self.backend.lower())
         assert backend is not None
@@ -201,6 +222,37 @@ class KVPoolWorker:
         self.kv_recv_thread: KVTransferThread | None = None
 
         self.finished_store_req: set[str] = set()
+
+        self.lookup_group_parallel = os.getenv("VLLM_ASCEND_LOOKUP_GROUP_PARALLEL", "0") == "1"
+        try:
+            self.lookup_group_parallel_workers = int(
+                os.getenv("VLLM_ASCEND_LOOKUP_GROUP_PARALLEL_WORKERS", "6")
+            )
+        except ValueError:
+            self.lookup_group_parallel_workers = 6
+        self.lookup_group_parallel_workers = max(1, self.lookup_group_parallel_workers)
+        self.lookup_early_stop = os.getenv("VLLM_ASCEND_LOOKUP_EARLY_STOP", "0") == "1"
+        self.lookup_reachable_mask = os.getenv("VLLM_ASCEND_LOOKUP_REACHABLE_MASK", "0") == "1"
+        self.lookup_full_guard = os.getenv("VLLM_ASCEND_LOOKUP_FULL_GUARD", "0") == "1"
+
+    def _build_cache_coordinator(self, vllm_config: VllmConfig) -> AscendStoreCoordinator | None:
+        if self.kv_cache_config is None or not self.use_hybrid:
+            return None
+        speculative_config = getattr(vllm_config, "speculative_config", None)
+        use_eagle_fn = getattr(speculative_config, "use_eagle", None)
+        use_eagle = bool(use_eagle_fn()) if callable(use_eagle_fn) else False
+        retention_interval = getattr(envs, "VLLM_PREFIX_CACHE_RETENTION_INTERVAL", None)
+        if not isinstance(retention_interval, int):
+            retention_interval = None
+        return AscendStoreCoordinator(
+            list(self.kv_cache_config.kv_cache_groups),
+            scheduler_block_size=self.cache_transfer_granularity,
+            hash_block_size=self.hash_block_size,
+            group_block_sizes=self.grouped_block_size,
+            group_cache_families=self.kv_cache_group_families,
+            use_eagle=use_eagle,
+            retention_interval=retention_interval,
+        )
 
     def _infer_group_families(self) -> list[str]:
         kv_cache_groups = self.kv_cache_config.kv_cache_groups if self.kv_cache_config is not None else None
@@ -483,6 +535,7 @@ class KVPoolWorker:
                     addr_list = []
                     size_list = []
                     key_list = []
+                    load_masks = self.token_database.load_mask(request.block_hashes, token_len)
                     for group_id in load_group_ids:
                         block_ids = request.block_ids_by_group[group_id]
                         group_block_size = self.grouped_block_size[group_id]
@@ -490,7 +543,7 @@ class KVPoolWorker:
                         skip_null = (
                             group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]
                         )
-                        for start, end, key, _ in self.token_database.process_tokens_with_block_ids(
+                        for start, end, key, block_id in self.token_database.process_tokens_with_block_ids(
                             token_len,
                             request.block_hashes,
                             block_ids,
@@ -498,11 +551,14 @@ class KVPoolWorker:
                             kv_cache_group_id=group_id,
                             skip_null_blocks=skip_null,
                         ):
+                            if not self.token_database.mask_allows_chunk(load_masks, group_id, start):
+                                continue
                             addr, size, _ = self.token_database.prepare_value(
                                 start,
                                 end,
                                 block_ids,
                                 kv_cache_group_id=group_id,
+                                block_id=block_id,
                             )
                             key_list.append(key.to_string())
                             addr_list.append(addr)
@@ -516,21 +572,21 @@ class KVPoolWorker:
                     size_list_c = (
                         size_list[self.tp_rank % len(size_list) :] + size_list[: self.tp_rank % len(size_list)]
                     )
-                    logger.debug(
-                        "KV pool worker calls backend get request=%s token_len=%d groups=%s keys=%d sample_keys=%s",
-                        request.req_id,
-                        token_len,
-                        load_group_ids,
-                        len(key_list_c),
-                        key_list_c[:3],
+                    import time as _kvtrace_time
+                    logger.info(
+                        "KVTRACE req=%s stage=kvpool_get_prepare elapsed_ms=0.000 "
+                        "token_len=%d vllm_cached=%d kvpool_cached=%d keys=%d groups=%s",
+                        request.req_id, token_len,
+                        load_spec.vllm_cached_tokens, load_spec.kvpool_cached_tokens,
+                        len(key_list_c), load_group_ids
                     )
+                    _kvtrace_t0 = _kvtrace_time.perf_counter()
                     self.m_store.get(key_list_c, addr_list_c, size_list_c)
-                    logger.debug(
-                        "KV pool worker backend get returned request=%s token_len=%d groups=%s keys=%d",
-                        request.req_id,
-                        token_len,
-                        load_group_ids,
-                        len(key_list_c),
+                    _kvtrace_get_ms = (_kvtrace_time.perf_counter() - _kvtrace_t0) * 1000
+                    logger.info(
+                        "KVTRACE req=%s stage=kvpool_get_backend elapsed_ms=%.3f "
+                        "mode=sync keys=%d",
+                        request.req_id, _kvtrace_get_ms, len(key_list_c)
                     )
 
     def wait_for_layer_load(self) -> None:
@@ -577,6 +633,10 @@ class KVPoolWorker:
             current_event.record()
             break
 
+        _kvtrace_wait_events = []
+        _kvtrace_per_request_wait = getattr(
+            self.kv_send_thread, "_per_request_save_wait", False  # type: ignore[union-attr]
+        )
         for request in connector_metadata.requests:
             can_save = request.can_save
             if can_save is None or not can_save:
@@ -587,6 +647,12 @@ class KVPoolWorker:
             self.kv_send_thread.add_stored_request(  # type: ignore[union-attr]
                 request.req_id
             )
+            if _kvtrace_per_request_wait:
+                event = self.kv_send_thread.prepare_stored_request_done_event(  # type: ignore[union-attr]
+                    request.req_id
+                )
+                if event is not None:
+                    _kvtrace_wait_events.append(event)
             self.kv_send_thread.add_request(  # type: ignore[union-attr]
                 request,
             )
@@ -596,7 +662,32 @@ class KVPoolWorker:
             # vLLM expects wait_for_save() to make stores visible before the
             # request is reported as finished. Without this barrier a following
             # identical prompt can lookup before Mooncake put() has completed.
-            self.kv_send_thread.request_queue.join()  # type: ignore[union-attr]
+            import time as _kvtrace_time
+            _kvtrace_save_count = sum(1 for r in connector_metadata.requests if r.can_save)
+            _kvtrace_qsize_before = self.kv_send_thread.request_queue.qsize()  # type: ignore[union-attr]
+            _kvtrace_t0 = _kvtrace_time.perf_counter()
+            if _kvtrace_per_request_wait:
+                for event in _kvtrace_wait_events:
+                    event.wait()
+                _kvtrace_join_ms = (_kvtrace_time.perf_counter() - _kvtrace_t0) * 1000
+                _kvtrace_qsize_after = self.kv_send_thread.request_queue.qsize()  # type: ignore[union-attr]
+                logger.info(
+                    "KVTRACE stage=kvpool_wait_for_save_request elapsed_ms=%.3f "
+                    "save_requests=%d queue_size_before=%d queue_size_after=%d events=%d",
+                    _kvtrace_join_ms, _kvtrace_save_count,
+                    _kvtrace_qsize_before, _kvtrace_qsize_after,
+                    len(_kvtrace_wait_events)
+                )
+            else:
+                self.kv_send_thread.request_queue.join()  # type: ignore[union-attr]
+                _kvtrace_join_ms = (_kvtrace_time.perf_counter() - _kvtrace_t0) * 1000
+                _kvtrace_qsize_after = self.kv_send_thread.request_queue.qsize()  # type: ignore[union-attr]
+                logger.info(
+                    "KVTRACE stage=kvpool_wait_for_save_join elapsed_ms=%.3f "
+                    "save_requests=%d queue_size_before=%d queue_size_after=%d",
+                    _kvtrace_join_ms, _kvtrace_save_count,
+                    _kvtrace_qsize_before, _kvtrace_qsize_after
+                )
 
     def retrieve_layer(
         self,
@@ -807,7 +898,15 @@ class KVPoolWorker:
         try:
             hits = []
             kv_cache_group_ids = kv_cache_group_ids or [0]
-            kv_cache_group_ids = self._get_lookup_gate_group_ids(kv_cache_group_ids)
+            coordinator_hit = self._lookup_with_coordinator(
+                token_len,
+                block_hashes,
+                kv_cache_group_ids,
+                use_layerwise,
+                include_all_ranks=False,
+            )
+            if coordinator_hit is not None:
+                return coordinator_hit
             for group_id in kv_cache_group_ids:
                 end = 0
                 keys = []
@@ -860,40 +959,6 @@ class KVPoolWorker:
             return 0
         return min(hits) if hits else 0
 
-    def _get_lookup_gate_group_ids(self, kv_cache_group_ids: list[int]) -> list[int]:
-        gate_group_ids = [group_id for group_id in kv_cache_group_ids if self._is_lookup_gate_group(group_id)]
-        if not gate_group_ids:
-            return kv_cache_group_ids
-        if len(gate_group_ids) != len(kv_cache_group_ids):
-            logger.debug(
-                "KV pool lookup gates on groups %s, ignoring non-gate groups from %s",
-                gate_group_ids,
-                kv_cache_group_ids,
-            )
-        return gate_group_ids
-
-    def _is_lookup_gate_group(self, group_id: int) -> bool:
-        if group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]:
-            return False
-        cache_family = self._get_group_family(self.kv_cache_group_families, group_id)
-        # DeepSeek V4 has a c128 compressed KV group. Its key stream is much
-        # sparser than the dense KV groups, so using it as a strict gate makes
-        # the whole request report 0 hit even when the loadable groups exist.
-        if cache_family == "c128":
-            return False
-        # The DSV4 c4 group is currently written as a TP-sharded key stream in
-        # this connector path. Runtime logs show only 32/128 keys visible for a
-        # 16K prompt, so letting it gate the external pool prevents otherwise
-        # complete c1 groups from loading. Keep pooling gate/load on complete
-        # 128-token c1 KV groups until c4 storage is made fully discoverable.
-        if cache_family != "c1":
-            return False
-        # In the DSV4 hybrid layout, some auxiliary groups use smaller logical
-        # block sizes (for example 8/32). The Ascend kernels in this path are
-        # fixed to the 128-token KV block shape, so those groups cannot be used
-        # as external-pool gates or load targets for the 16K pooling path.
-        return self._get_group_block_size(group_id) == self.block_size
-
     def _get_group_num_kv_heads(self, group_id: int) -> int:
         if self.use_mla or self.use_sparse:
             return 1
@@ -901,12 +966,628 @@ class KVPoolWorker:
             return 1
         return self.num_kv_head
 
+    def get_group_tp_size(self, kv_cache_group_id: int) -> int:
+        if kv_cache_group_id < len(self.group_uses_align_state) and self.group_uses_align_state[kv_cache_group_id]:
+            return self.tp_size
+        return min(self.tp_size, self._get_group_num_kv_heads(kv_cache_group_id))
+
+    @staticmethod
+    def _replace_key_field(key: str, field: str, value: int) -> str:
+        marker = f"@{field}:"
+        start = key.find(marker)
+        if start < 0:
+            return key
+        value_start = start + len(marker)
+        value_end = key.find("@", value_start)
+        if value_end < 0:
+            value_end = len(key)
+        return f"{key[:value_start]}{value}{key[value_end:]}"
+
+    @staticmethod
+    def _chunk_hash_to_bytes(chunk_hash: BlockHash | str) -> bytes:
+        if isinstance(chunk_hash, str):
+            if len(chunk_hash) == 64:
+                try:
+                    return bytes.fromhex(chunk_hash)
+                except ValueError:
+                    pass
+            return chunk_hash.encode("utf-8")
+        return bytes(chunk_hash)
+
+    def _expand_lookup_key_variants(self, key: str, group_id: int, include_all_ranks: bool) -> list[str]:
+        if not include_all_ranks:
+            return [key]
+        variants: list[str] = []
+        group_tp_size = self.get_group_tp_size(group_id)
+        for tp_rank in range(group_tp_size):
+            tp_key = self._replace_key_field(key, "head_or_tp_rank", tp_rank)
+            for pp_rank in range(self.pp_size):
+                variants.append(self._replace_key_field(tp_key, "pp_rank", pp_rank))
+        return variants
+
+    def _lookup_coordinator_group(
+        self,
+        group_id: int,
+        token_len: int,
+        block_hashes: list[BlockHash],
+        include_all_ranks: bool,
+        hbm_hit_tokens: int = 0,
+    ) -> tuple[int, set[tuple[int, bytes]], float, float, float]:
+        """Build/exist one KV cache group for coordinator lookup.
+
+        The return value is detached from shared state so callers can run
+        groups in parallel without changing lookup semantics.
+        """
+        import time as _kvtrace_time
+
+        group_exists: set[tuple[int, bytes]] = set()
+        _kvtrace_t_kb = _kvtrace_time.perf_counter()
+        keys: list[str] = []
+        chunk_hashes: list[BlockHash | str] = []
+        variant_counts: list[int] = []
+        _kvtrace_app_ms = 0.0
+        _kvtrace_raw_count = 0
+        base_bs = self.token_database.get_block_size(group_id)
+        cf = self.token_database.group_cache_families.get("kv", {}).get(group_id, "default")
+        ebs = get_cache_family_granularity(base_bs, cf)
+        lookup_start = hbm_hit_tokens // ebs * ebs
+        for _, _, key_string, chunk_hash in self.token_database.process_token_key_strings(
+            token_len,
+            block_hashes,
+            mask_num=lookup_start,
+            kv_cache_group_id=group_id,
+        ):
+            _kvtrace_raw_count += 1
+            _kvtrace_t_a = _kvtrace_time.perf_counter()
+            variants = self._expand_lookup_key_variants(key_string, group_id, include_all_ranks)
+            keys.extend(variants)
+            chunk_hashes.append(chunk_hash)
+            variant_counts.append(len(variants))
+            _kvtrace_app_ms += (_kvtrace_time.perf_counter() - _kvtrace_t_a) * 1000
+        _kvtrace_iter_ms = (_kvtrace_time.perf_counter() - _kvtrace_t_kb) * 1000 - _kvtrace_app_ms
+        _kvtrace_str_ms = 0.0
+
+        _kvtrace_kb_ms = (_kvtrace_time.perf_counter() - _kvtrace_t_kb) * 1000
+        _kvtrace_raw_keys = len(chunk_hashes)
+        token_chunks = (token_len + ebs - 1) // ebs if ebs > 0 else 0
+        skipped_chunks = min(token_chunks, lookup_start // ebs) if ebs > 0 else 0
+        expected_lookup_chunks = max(0, token_chunks - skipped_chunks)
+        logger.info(
+            "KVTRACE stage=kvpool_lookup_group_key_build group=%d "
+            "elapsed_ms=%.3f raw_keys=%d variant_keys=%d token_len=%d "
+            "hbm_hit_tokens=%d lookup_start=%d effective_block_size=%d "
+            "token_chunks=%d skipped_chunks=%d expected_lookup_chunks=%d",
+            group_id, _kvtrace_kb_ms, _kvtrace_raw_keys, len(keys), token_len,
+            hbm_hit_tokens, lookup_start, ebs,
+            token_chunks, skipped_chunks, expected_lookup_chunks
+        )
+        logger.info(
+            "KVTRACE stage=kvpool_6d_group_mask group=%d "
+            "hbm_hit_tokens=%d lookup_start=%d effective_block_size=%d "
+            "skipped_chunks=%d expected_lookup_chunks=%d built_raw_keys=%d built_variant_keys=%d",
+            group_id, hbm_hit_tokens, lookup_start, ebs,
+            skipped_chunks, expected_lookup_chunks, _kvtrace_raw_keys, len(keys)
+        )
+        logger.info(
+            "KVTRACE stage=kvpool_kb_detail group=%d "
+            "raw_count=%d iter_ms=%.3f str_ms=%.3f app_ms=%.3f total_ms=%.3f "
+            "compress_ratios=%s grouped_block_size=%s",
+            group_id, _kvtrace_raw_count,
+            _kvtrace_iter_ms, _kvtrace_str_ms, _kvtrace_app_ms, _kvtrace_kb_ms,
+            getattr(self, "compress_ratios", None),
+            self.grouped_block_size[group_id] if hasattr(self, "grouped_block_size") else "N/A"
+        )
+
+        if not keys:
+            logger.info(
+                "KVTRACE stage=kvpool_6d_group_skip_external group=%d reason=no_keys "
+                "hbm_hit_tokens=%d lookup_start=%d effective_block_size=%d "
+                "token_chunks=%d skipped_chunks=%d expected_lookup_chunks=%d",
+                group_id, hbm_hit_tokens, lookup_start, ebs,
+                token_chunks, skipped_chunks, expected_lookup_chunks
+            )
+            return group_id, group_exists, _kvtrace_kb_ms, 0.0, 0.0
+
+        _kvtrace_t0 = _kvtrace_time.perf_counter()
+        res = self.m_store.exists(keys)  # type: ignore[assignment]
+        _kvtrace_exist_ms = (_kvtrace_time.perf_counter() - _kvtrace_t0) * 1000
+        _kvtrace_exists_count = sum(1 for v in res if v == 1) if res else 0
+        logger.info(
+            "KVTRACE stage=kvpool_exist_backend elapsed_ms=%.3f "
+            "group=%d keys=%d exists_count=%d missing_count=%d",
+            _kvtrace_exist_ms, group_id, len(keys),
+            _kvtrace_exists_count, len(keys) - _kvtrace_exists_count
+        )
+        _kvtrace_t_hc = _kvtrace_time.perf_counter()
+        offset = 0
+        for chunk_hash, count in zip(chunk_hashes, variant_counts, strict=True):
+            values = res[offset : offset + count]  # type: ignore[index]
+            if values and all(value == 1 for value in values):
+                group_exists.add((group_id, self._chunk_hash_to_bytes(chunk_hash)))
+            offset += count
+
+        _kvtrace_hc_ms = (_kvtrace_time.perf_counter() - _kvtrace_t_hc) * 1000
+        logger.info(
+            "KVTRACE stage=kvpool_lookup_group_hit_calc group=%d "
+            "elapsed_ms=%.3f hit_chunks=%d/%d token_len=%d",
+            group_id, _kvtrace_hc_ms,
+            len(group_exists), len(chunk_hashes), token_len
+        )
+        logger.debug(
+            "KV pool coordinator lookup group=%d token_len=%d keys=%d exists_chunks=%d/%d sample_keys=%s",
+            group_id,
+            token_len,
+            len(keys),
+            len(group_exists),
+            len(chunk_hashes),
+            keys[:3],
+        )
+        return group_id, group_exists, _kvtrace_kb_ms, _kvtrace_exist_ms, _kvtrace_hc_ms
+
+    def _lookup_with_coordinator(
+        self,
+        token_len: int,
+        block_hashes: list[BlockHash],
+        kv_cache_group_ids: list[int],
+        use_layerwise: bool,
+        include_all_ranks: bool,
+        hbm_hit_tokens: int = 0,
+    ) -> int | None:
+        if self.cache_coordinator is None or use_layerwise:
+            return None
+        if sorted(kv_cache_group_ids) != list(range(self.num_kv_cache_groups)):
+            return None
+
+        import time as _kvtrace_time
+        _kvtrace_total_keybuild = 0.0
+        _kvtrace_total_exist = 0.0
+        _kvtrace_total_hitcalc = 0.0
+        exists: set[tuple[int, bytes]] = set()
+        # 6D: Add HBM-hit blocks to exists without RPC (aligned per group)
+        logger.info(
+            "KVTRACE stage=kvpool_6d_lookup_start token_len=%d hbm_hit_tokens=%d "
+            "groups=%s use_layerwise=%s include_all_ranks=%s block_hashes=%d",
+            token_len, hbm_hit_tokens, kv_cache_group_ids,
+            use_layerwise, include_all_ranks, len(block_hashes)
+        )
+        if hbm_hit_tokens > 0:
+            for group_id in kv_cache_group_ids:
+                base_bs = self.token_database.get_block_size(group_id)
+                cf = self.token_database.group_cache_families.get("kv", {}).get(group_id, "default")
+                ebs = get_cache_family_granularity(base_bs, cf)
+                lookup_start = hbm_hit_tokens // ebs * ebs
+                grouped = get_block_hashes(block_hashes, ebs, self.token_database.hash_block_size)
+                injected = 0
+                if grouped:
+                    num_hbm_chunks = lookup_start // ebs
+                    for cid in range(min(num_hbm_chunks, len(grouped))):
+                        exists.add((group_id, self._chunk_hash_to_bytes(grouped[cid])))
+                        injected += 1
+                token_chunks = (token_len + ebs - 1) // ebs if ebs > 0 else 0
+                skipped_chunks = min(token_chunks, lookup_start // ebs) if ebs > 0 else 0
+                logger.info(
+                    "KVTRACE stage=kvpool_6d_hbm_inject group=%d "
+                    "base_block_size=%d cache_family=%s effective_block_size=%d "
+                    "hbm_hit_tokens=%d lookup_start=%d token_chunks=%d grouped_hashes=%d "
+                    "skipped_chunks=%d injected_chunks=%d exists_size=%d",
+                    group_id, base_bs, cf, ebs, hbm_hit_tokens, lookup_start,
+                    token_chunks, len(grouped) if grouped else 0,
+                    skipped_chunks, injected, len(exists)
+                )
+        lookup_masks = None
+        if self.lookup_reachable_mask:
+            aligned_lookup_len = token_len
+            lcm_block_size = getattr(self.cache_coordinator, "lcm_block_size", 1)
+            if lcm_block_size > 1:
+                aligned_lookup_len = ((token_len + lcm_block_size - 1) // lcm_block_size) * lcm_block_size
+            lookup_masks = self.cache_coordinator.lookup_mask(aligned_lookup_len)
+            logger.info(
+                "KVTRACE stage=kvpool_lookup_mask_start token_len=%d aligned_token_len=%d "
+                "lcm_block_size=%d mask_kinds=%s",
+                token_len, aligned_lookup_len, lcm_block_size,
+                [
+                    "all" if mask is None else f"{sum(1 for item in mask if item)}/{len(mask)}"
+                    for mask in lookup_masks
+                ],
+            )
+
+        lookup_limit = token_len
+        full_guard_group_ids: set[int] = set()
+        if self.lookup_full_guard and not self.lookup_group_parallel:
+            for spec, group_ids, _ in getattr(self.cache_coordinator, "attention_groups", []):
+                if isinstance(spec, FullAttentionSpec):
+                    full_guard_group_ids.update(
+                        group_id for group_id in group_ids if group_id in kv_cache_group_ids
+                    )
+            if full_guard_group_ids:
+                _kvtrace_full_bound = token_len
+                _kvtrace_full_keybuild = 0.0
+                _kvtrace_full_exist = 0.0
+                _kvtrace_full_hitcalc = 0.0
+                _kvtrace_full_raw = 0
+                _kvtrace_full_variant = 0
+                first_missing_group = -1
+                first_missing_start_global = -1
+                for group_id in sorted(full_guard_group_ids):
+                    _kvtrace_t_kb = _kvtrace_time.perf_counter()
+                    keys: list[str] = []
+                    chunk_hashes: list[BlockHash | str] = []
+                    variant_counts: list[int] = []
+                    starts: list[int] = []
+                    _kvtrace_app_ms = 0.0
+                    base_bs = self.token_database.get_block_size(group_id)
+                    cf = self.token_database.group_cache_families.get("kv", {}).get(group_id, "default")
+                    ebs = get_cache_family_granularity(base_bs, cf)
+                    lookup_start = hbm_hit_tokens // ebs * ebs
+                    lookup_mask = None
+                    if lookup_masks is not None and group_id < len(lookup_masks):
+                        lookup_mask = lookup_masks[group_id]
+                    skipped_by_mask = 0
+                    seen_chunks = 0
+                    for start_idx, _, key_string, chunk_hash in self.token_database.process_token_key_strings(
+                        token_len,
+                        block_hashes,
+                        mask_num=lookup_start,
+                        kv_cache_group_id=group_id,
+                    ):
+                        seen_chunks += 1
+                        if lookup_mask is not None:
+                            chunk_idx = start_idx // base_bs if base_bs > 0 else 0
+                            if chunk_idx >= len(lookup_mask) or not lookup_mask[chunk_idx]:
+                                skipped_by_mask += 1
+                                continue
+                        _kvtrace_t_a = _kvtrace_time.perf_counter()
+                        variants = self._expand_lookup_key_variants(key_string, group_id, include_all_ranks)
+                        keys.extend(variants)
+                        chunk_hashes.append(chunk_hash)
+                        variant_counts.append(len(variants))
+                        starts.append(start_idx)
+                        _kvtrace_app_ms += (_kvtrace_time.perf_counter() - _kvtrace_t_a) * 1000
+                    _kvtrace_kb_ms = (_kvtrace_time.perf_counter() - _kvtrace_t_kb) * 1000
+                    _kvtrace_full_keybuild += _kvtrace_kb_ms
+                    _kvtrace_full_raw += len(chunk_hashes)
+                    _kvtrace_full_variant += len(keys)
+                    group_exists: set[tuple[int, bytes]] = set()
+                    if keys:
+                        _kvtrace_t0 = _kvtrace_time.perf_counter()
+                        res = self.m_store.exists(keys)  # type: ignore[assignment]
+                        _kvtrace_exist_ms = (_kvtrace_time.perf_counter() - _kvtrace_t0) * 1000
+                        _kvtrace_full_exist += _kvtrace_exist_ms
+                        _kvtrace_t_hc = _kvtrace_time.perf_counter()
+                        offset = 0
+                        first_missing_start = -1
+                        for start, chunk_hash, count in zip(starts, chunk_hashes, variant_counts, strict=True):
+                            values = res[offset : offset + count]  # type: ignore[index]
+                            if values and all(value == 1 for value in values):
+                                item = (group_id, self._chunk_hash_to_bytes(chunk_hash))
+                                exists.add(item)
+                                group_exists.add(item)
+                            elif first_missing_start < 0:
+                                first_missing_start = start
+                            offset += count
+                        _kvtrace_hc_ms = (_kvtrace_time.perf_counter() - _kvtrace_t_hc) * 1000
+                        _kvtrace_full_hitcalc += _kvtrace_hc_ms
+                        if first_missing_start < 0:
+                            group_bound = token_len
+                        else:
+                            group_bound = (first_missing_start // self.cache_transfer_granularity) * self.cache_transfer_granularity
+                            group_bound = max(group_bound, min(max(hbm_hit_tokens, 0), token_len))
+                        if first_missing_start >= 0 and (
+                            first_missing_group < 0 or group_bound < _kvtrace_full_bound
+                        ):
+                            first_missing_group = group_id
+                            first_missing_start_global = first_missing_start
+                        logger.info(
+                            "KVTRACE stage=kvpool_lookup_full_guard_group group=%d "
+                            "key_build_ms=%.3f exist_ms=%.3f hit_calc_ms=%.3f "
+                            "raw_keys=%d variant_keys=%d exists_count=%d missing_count=%d "
+                            "seen_chunks=%d skipped_by_mask=%d lookup_start=%d bound=%d token_len=%d "
+                            "first_missing_start=%d",
+                            group_id, _kvtrace_kb_ms, _kvtrace_exist_ms, _kvtrace_hc_ms,
+                            len(chunk_hashes), len(keys), len(group_exists),
+                            len(chunk_hashes) - len(group_exists), seen_chunks, skipped_by_mask,
+                            lookup_start, group_bound, token_len, first_missing_start,
+                        )
+                    else:
+                        group_bound = token_len
+                        logger.info(
+                            "KVTRACE stage=kvpool_lookup_full_guard_group group=%d "
+                            "key_build_ms=%.3f exist_ms=0.000 hit_calc_ms=0.000 "
+                            "raw_keys=0 variant_keys=0 exists_count=0 missing_count=0 "
+                            "seen_chunks=%d skipped_by_mask=%d lookup_start=%d bound=%d token_len=%d",
+                            group_id, _kvtrace_kb_ms, seen_chunks, skipped_by_mask,
+                            lookup_start, group_bound, token_len,
+                        )
+                    _kvtrace_full_bound = min(_kvtrace_full_bound, group_bound)
+
+                lookup_limit = min(token_len, _kvtrace_full_bound)
+                _kvtrace_total_keybuild += _kvtrace_full_keybuild
+                _kvtrace_total_exist += _kvtrace_full_exist
+                _kvtrace_total_hitcalc += _kvtrace_full_hitcalc
+                logger.info(
+                    "KVTRACE stage=kvpool_lookup_full_guard_summary groups=%s "
+                    "lookup_limit=%d token_len=%d hbm_hit_tokens=%d raw_keys=%d "
+                    "variant_keys=%d key_build_ms=%.3f exist_ms=%.3f hit_calc_ms=%.3f",
+                    sorted(full_guard_group_ids), lookup_limit, token_len, hbm_hit_tokens,
+                    _kvtrace_full_raw, _kvtrace_full_variant, _kvtrace_full_keybuild,
+                    _kvtrace_full_exist, _kvtrace_full_hitcalc,
+                )
+                if lookup_limit <= min(max(hbm_hit_tokens, 0), token_len):
+                    hit_length = min(max(hbm_hit_tokens, 0), token_len)
+                    total_ms = _kvtrace_total_keybuild + _kvtrace_total_exist + _kvtrace_total_hitcalc
+                    logger.info(
+                        "KVTRACE stage=kvpool_lookup_full_guard_stop reason=full_attention_bound "
+                        "hit_tokens=%d lookup_limit=%d hbm_hit_tokens=%d token_len=%d "
+                        "first_missing_group=%d first_missing_start=%d total_ms=%.3f",
+                        hit_length, lookup_limit, hbm_hit_tokens, token_len,
+                        first_missing_group, first_missing_start_global, total_ms,
+                    )
+                    logger.info(
+                        "KVTRACE stage=kvpool_lookup_breakdown token_len=%d "
+                        "key_build_ms=%.3f exist_ms=%.3f hit_calc_ms=%.3f "
+                        "coord_hit_ms=0.000 total_ms=%.3f hit_tokens=%d groups=%s full_guard=True stopped=True",
+                        token_len, _kvtrace_total_keybuild, _kvtrace_total_exist,
+                        _kvtrace_total_hitcalc, total_ms, hit_length, kv_cache_group_ids,
+                    )
+                    return hit_length
+
+        if self.lookup_group_parallel:
+            _kvtrace_t_parallel = _kvtrace_time.perf_counter()
+            max_workers = min(self.lookup_group_parallel_workers, len(kv_cache_group_ids))
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = [
+                    executor.submit(
+                        self._lookup_coordinator_group,
+                        group_id,
+                        token_len,
+                        block_hashes,
+                        include_all_ranks,
+                        hbm_hit_tokens,
+                    )
+                    for group_id in kv_cache_group_ids
+                ]
+                group_results = [future.result() for future in futures]
+            for _, group_exists, keybuild_ms, exist_ms, hitcalc_ms in group_results:
+                exists.update(group_exists)
+                _kvtrace_total_keybuild += keybuild_ms
+                _kvtrace_total_exist += exist_ms
+                _kvtrace_total_hitcalc += hitcalc_ms
+            _kvtrace_parallel_ms = (_kvtrace_time.perf_counter() - _kvtrace_t_parallel) * 1000
+            logger.info(
+                "KVTRACE stage=kvpool_lookup_group_parallel elapsed_ms=%.3f "
+                "workers=%d groups=%s key_build_sum_ms=%.3f exist_sum_ms=%.3f "
+                "hit_calc_sum_ms=%.3f exists_size=%d",
+                _kvtrace_parallel_ms, max_workers, kv_cache_group_ids,
+                _kvtrace_total_keybuild, _kvtrace_total_exist,
+                _kvtrace_total_hitcalc, len(exists)
+            )
+            _kvtrace_t_coord = _kvtrace_time.perf_counter()
+            _, hit_length = self.cache_coordinator.find_longest_cache_hit(
+                block_hashes,
+                token_len,
+                ExternalCachedBlockPool(exists),
+                apply_eagle=False,
+            )
+            _kvtrace_coord_ms = (_kvtrace_time.perf_counter() - _kvtrace_t_coord) * 1000
+            logger.info(
+                "KVTRACE stage=kvpool_lookup_breakdown token_len=%d "
+                "key_build_ms=%.3f exist_ms=%.3f hit_calc_ms=%.3f "
+                "coord_hit_ms=%.3f total_ms=%.3f hit_tokens=%d groups=%s parallel=True parallel_wall_ms=%.3f",
+                token_len,
+                _kvtrace_total_keybuild, _kvtrace_total_exist,
+                _kvtrace_total_hitcalc, _kvtrace_coord_ms,
+                _kvtrace_parallel_ms + _kvtrace_coord_ms,
+                hit_length, kv_cache_group_ids, _kvtrace_parallel_ms
+            )
+            logger.debug(
+                "KV pool coordinator lookup final token_len=%d groups=%s hit=%d parallel=True",
+                token_len,
+                kv_cache_group_ids,
+                hit_length,
+            )
+            return hit_length
+
+        for group_id in kv_cache_group_ids:
+            if group_id in full_guard_group_ids:
+                logger.info(
+                    "KVTRACE stage=kvpool_lookup_group_skip_prequeried group=%d lookup_limit=%d token_len=%d",
+                    group_id, lookup_limit, token_len,
+                )
+                continue
+            _kvtrace_t_kb = _kvtrace_time.perf_counter()
+            keys: list[str] = []
+            chunk_hashes: list[BlockHash | str] = []
+            variant_counts: list[int] = []
+            _kvtrace_iter_ms = 0.0
+            _kvtrace_str_ms = 0.0
+            _kvtrace_app_ms = 0.0
+            _kvtrace_raw_count = 0
+            base_bs = self.token_database.get_block_size(group_id)
+            cf = self.token_database.group_cache_families.get("kv", {}).get(group_id, "default")
+            ebs = get_cache_family_granularity(base_bs, cf)
+            lookup_start = hbm_hit_tokens // ebs * ebs
+            lookup_mask = None
+            if lookup_masks is not None and group_id < len(lookup_masks):
+                lookup_mask = lookup_masks[group_id]
+            _kvtrace_lookup_mask_skipped = 0
+            _kvtrace_lookup_mask_seen = 0
+            for start_idx, _, key_string, chunk_hash in self.token_database.process_token_key_strings(
+                token_len,
+                block_hashes,
+                mask_num=lookup_start,
+                kv_cache_group_id=group_id,
+                max_num=lookup_limit,
+            ):
+                _kvtrace_lookup_mask_seen += 1
+                if lookup_mask is not None:
+                    chunk_idx = start_idx // base_bs if base_bs > 0 else 0
+                    if chunk_idx >= len(lookup_mask) or not lookup_mask[chunk_idx]:
+                        _kvtrace_lookup_mask_skipped += 1
+                        continue
+                _kvtrace_raw_count += 1
+                _kvtrace_t_a = _kvtrace_time.perf_counter()
+                variants = self._expand_lookup_key_variants(key_string, group_id, include_all_ranks)
+                keys.extend(variants)
+                chunk_hashes.append(chunk_hash)
+                variant_counts.append(len(variants))
+                _kvtrace_app_ms += (_kvtrace_time.perf_counter() - _kvtrace_t_a) * 1000
+            _kvtrace_iter_ms = (_kvtrace_time.perf_counter() - _kvtrace_t_kb) * 1000 - _kvtrace_app_ms
+            _kvtrace_str_ms = 0.0
+
+            _kvtrace_kb_ms = (_kvtrace_time.perf_counter() - _kvtrace_t_kb) * 1000
+            _kvtrace_total_keybuild += _kvtrace_kb_ms
+            _kvtrace_raw_keys = len(chunk_hashes)
+            token_chunks = (lookup_limit + ebs - 1) // ebs if ebs > 0 else 0
+            skipped_chunks = min(token_chunks, lookup_start // ebs) if ebs > 0 else 0
+            expected_lookup_chunks = max(0, token_chunks - skipped_chunks)
+            logger.info(
+                "KVTRACE stage=kvpool_lookup_group_key_build group=%d "
+                "elapsed_ms=%.3f raw_keys=%d variant_keys=%d token_len=%d "
+                "hbm_hit_tokens=%d lookup_start=%d lookup_limit=%d effective_block_size=%d "
+                "token_chunks=%d skipped_chunks=%d expected_lookup_chunks=%d",
+                group_id, _kvtrace_kb_ms, _kvtrace_raw_keys, len(keys), token_len,
+                hbm_hit_tokens, lookup_start, lookup_limit, ebs,
+                token_chunks, skipped_chunks, expected_lookup_chunks
+            )
+            if self.lookup_reachable_mask:
+                logger.info(
+                    "KVTRACE stage=kvpool_lookup_reachable_mask group=%d "
+                    "seen_chunks=%d skipped_by_mask=%d built_raw_keys=%d "
+                    "mask_kind=%s token_len=%d hbm_hit_tokens=%d lookup_start=%d",
+                    group_id, _kvtrace_lookup_mask_seen,
+                    _kvtrace_lookup_mask_skipped, _kvtrace_raw_keys,
+                    "all" if lookup_mask is None else f"{sum(1 for item in lookup_mask if item)}/{len(lookup_mask)}",
+                    token_len, hbm_hit_tokens, lookup_start,
+                )
+            logger.info(
+                "KVTRACE stage=kvpool_6d_group_mask group=%d "
+                "hbm_hit_tokens=%d lookup_start=%d lookup_limit=%d effective_block_size=%d "
+                "skipped_chunks=%d expected_lookup_chunks=%d built_raw_keys=%d built_variant_keys=%d",
+                group_id, hbm_hit_tokens, lookup_start, lookup_limit, ebs,
+                skipped_chunks, expected_lookup_chunks, _kvtrace_raw_keys, len(keys)
+            )
+            logger.info(
+                "KVTRACE stage=kvpool_kb_detail group=%d "
+                "raw_count=%d iter_ms=%.3f str_ms=%.3f app_ms=%.3f total_ms=%.3f "
+                "compress_ratios=%s grouped_block_size=%s",
+                group_id, _kvtrace_raw_count,
+                _kvtrace_iter_ms, _kvtrace_str_ms, _kvtrace_app_ms, _kvtrace_kb_ms,
+                getattr(self, "compress_ratios", None),
+                self.grouped_block_size[group_id] if hasattr(self, "grouped_block_size") else "N/A"
+            )
+
+            if not keys:
+                logger.info(
+                    "KVTRACE stage=kvpool_6d_group_skip_external group=%d reason=no_keys "
+                    "hbm_hit_tokens=%d lookup_start=%d lookup_limit=%d effective_block_size=%d "
+                    "token_chunks=%d skipped_chunks=%d expected_lookup_chunks=%d",
+                    group_id, hbm_hit_tokens, lookup_start, lookup_limit, ebs,
+                    token_chunks, skipped_chunks, expected_lookup_chunks
+                )
+                continue
+            _kvtrace_t0 = _kvtrace_time.perf_counter()
+            res = self.m_store.exists(keys)  # type: ignore[assignment]
+            _kvtrace_exist_ms = (_kvtrace_time.perf_counter() - _kvtrace_t0) * 1000
+            _kvtrace_total_exist += _kvtrace_exist_ms
+            _kvtrace_exists_count = sum(1 for v in res if v == 1) if res else 0
+            logger.info(
+                "KVTRACE stage=kvpool_exist_backend elapsed_ms=%.3f "
+                "group=%d keys=%d exists_count=%d missing_count=%d",
+                _kvtrace_exist_ms, group_id, len(keys),
+                _kvtrace_exists_count, len(keys) - _kvtrace_exists_count
+            )
+            _kvtrace_t_hc = _kvtrace_time.perf_counter()
+            offset = 0
+            for chunk_hash, count in zip(chunk_hashes, variant_counts, strict=True):
+                values = res[offset : offset + count]  # type: ignore[index]
+                if values and all(value == 1 for value in values):
+                    exists.add((group_id, self._chunk_hash_to_bytes(chunk_hash)))
+                offset += count
+
+            _kvtrace_hc_ms = (_kvtrace_time.perf_counter() - _kvtrace_t_hc) * 1000
+            _kvtrace_total_hitcalc += _kvtrace_hc_ms
+            logger.info(
+                "KVTRACE stage=kvpool_lookup_group_hit_calc group=%d "
+                "elapsed_ms=%.3f hit_chunks=%d/%d token_len=%d",
+                group_id, _kvtrace_hc_ms,
+                sum(1 for g, _ in exists if g == group_id),
+                len(chunk_hashes), token_len
+            )
+            logger.debug(
+                "KV pool coordinator lookup group=%d token_len=%d keys=%d exists_chunks=%d/%d sample_keys=%s",
+                group_id,
+                token_len,
+                len(keys),
+                sum(1 for group, _ in exists if group == group_id),
+                len(chunk_hashes),
+                keys[:3],
+            )
+            if self.lookup_early_stop and chunk_hashes and expected_lookup_chunks > 0:
+                first_chunk_exists = (
+                    group_id,
+                    self._chunk_hash_to_bytes(chunk_hashes[0]),
+                ) in exists
+                if not first_chunk_exists:
+                    hit_length = min(max(hbm_hit_tokens, 0), token_len)
+                    total_ms = (
+                        _kvtrace_total_keybuild
+                        + _kvtrace_total_exist
+                        + _kvtrace_total_hitcalc
+                    )
+                    logger.info(
+                        "KVTRACE stage=kvpool_lookup_early_stop group=%d "
+                        "reason=first_external_chunk_missing hit_tokens=%d "
+                        "hbm_hit_tokens=%d lookup_start=%d effective_block_size=%d "
+                        "processed_groups=%s skipped_groups=%s key_build_ms=%.3f "
+                        "exist_ms=%.3f hit_calc_ms=%.3f total_ms=%.3f",
+                        group_id, hit_length, hbm_hit_tokens, lookup_start, ebs,
+                        kv_cache_group_ids[:kv_cache_group_ids.index(group_id) + 1],
+                        kv_cache_group_ids[kv_cache_group_ids.index(group_id) + 1:],
+                        _kvtrace_total_keybuild, _kvtrace_total_exist,
+                        _kvtrace_total_hitcalc, total_ms,
+                    )
+                    logger.info(
+                        "KVTRACE stage=kvpool_lookup_breakdown token_len=%d "
+                        "key_build_ms=%.3f exist_ms=%.3f hit_calc_ms=%.3f "
+                        "coord_hit_ms=0.000 total_ms=%.3f hit_tokens=%d groups=%s early_stop=True",
+                        token_len, _kvtrace_total_keybuild, _kvtrace_total_exist,
+                        _kvtrace_total_hitcalc, total_ms, hit_length, kv_cache_group_ids,
+                    )
+                    return hit_length
+
+        _kvtrace_t_coord = _kvtrace_time.perf_counter()
+        _, hit_length = self.cache_coordinator.find_longest_cache_hit(
+            block_hashes,
+            token_len,
+            ExternalCachedBlockPool(exists),
+            apply_eagle=False,
+        )
+        _kvtrace_coord_ms = (_kvtrace_time.perf_counter() - _kvtrace_t_coord) * 1000
+        logger.info(
+            "KVTRACE stage=kvpool_lookup_breakdown token_len=%d "
+            "key_build_ms=%.3f exist_ms=%.3f hit_calc_ms=%.3f "
+            "coord_hit_ms=%.3f total_ms=%.3f hit_tokens=%d groups=%s full_guard=%s lookup_limit=%d",
+            token_len,
+            _kvtrace_total_keybuild, _kvtrace_total_exist,
+            _kvtrace_total_hitcalc, _kvtrace_coord_ms,
+            _kvtrace_total_keybuild + _kvtrace_total_exist + _kvtrace_total_hitcalc + _kvtrace_coord_ms,
+            hit_length, kv_cache_group_ids, self.lookup_full_guard, lookup_limit
+        )
+        logger.debug(
+            "KV pool coordinator lookup final token_len=%d groups=%s hit=%d",
+            token_len,
+            kv_cache_group_ids,
+            hit_length,
+        )
+        return hit_length
+
     def lookup_scheduler(
         self,
         token_len: int,
         block_hashes: list[BlockHash],
         kv_cache_group_ids: list[int] | None = None,
         use_layerwise: bool = False,
+        hbm_hit_tokens: int = 0,
     ) -> int:
         """
         Checks the existence of KV cache of the tokens from the cache engine.
@@ -916,7 +1597,16 @@ class KVPoolWorker:
         try:
             hits = []
             kv_cache_group_ids = kv_cache_group_ids or [0]
-            kv_cache_group_ids = self._get_lookup_gate_group_ids(kv_cache_group_ids)
+            coordinator_hit = self._lookup_with_coordinator(
+                token_len,
+                block_hashes,
+                kv_cache_group_ids,
+                use_layerwise,
+                include_all_ranks=True,
+                hbm_hit_tokens=hbm_hit_tokens,
+            )
+            if coordinator_hit is not None:
+                return coordinator_hit
             for group_id in kv_cache_group_ids:
                 end = 0
                 keys = []
@@ -941,7 +1631,7 @@ class KVPoolWorker:
                     continue
 
                 multi_tp_keys = keys[:]
-                group_tp_size = min(self.tp_size, self._get_group_num_kv_heads(group_id))
+                group_tp_size = self.get_group_tp_size(group_id)
                 for i in range(1, group_tp_size):
                     for item in keys:
                         new_str = item.replace(  # type: ignore[attr-defined]


### PR DESCRIPTION
## Motivation

AscendStore's lookup and put paths had several performance bottlenecks: lookup iterated groups sequentially without early termination, put created intermediate `PoolKey` objects for every chunk, and `wait_for_save()` blocked on `queue.join()` even when only specific requests needed to complete.

Depends on #11348 for `AscendStoreCoordinator` and `config_data.py` fast-path generators.

## Changes

### Lookup path optimization
- **pool_worker.py**: Add `_lookup_coordinator_group()` for per-group lookup with detached state, enabling parallel group execution via `ThreadPoolExecutor` (`VLLM_ASCEND_LOOKUP_GROUP_PARALLEL`). Add early stop (`VLLM_ASCEND_LOOKUP_EARLY_STOP`), reachable mask pruning (`VLLM_ASCEND_LOOKUP_REACHABLE_MASK`), and full attention guard (`VLLM_ASCEND_LOOKUP_FULL_GUARD`) to validate aligned hit boundaries.
- **ascend_store_connector.py**: Pass `hbm_hit_tokens` through the ZMQ lookup protocol so the worker can skip chunks already covered by local HBM cache.
- **pool_scheduler.py**: Early-return when `num_computed_tokens >= token_len` (HBM fully covers prefix). Pass `hbm_hit_tokens` to the lookup client.

### Put path optimization
- **kv_transfer.py**: Add `VLLM_ASCEND_PUT_KEY_STRING_FAST_PATH` to use `process_token_key_strings_*` generators instead of materializing `PoolKey` objects. Add `VLLM_ASCEND_PUT_SPARSE_STORE_MASK` to only iterate chunks allowed by the store mask. Add `VLLM_ASCEND_PUT_PRE_SHARD_KEY_BUILD` for pre-sharded key construction. Add `VLLM_ASCEND_PER_REQUEST_SAVE_WAIT` using `threading.Event` for per-request synchronization. Add `_key_build_cache` to skip re-computation for identical block hash prefixes.
- **pool_worker.py**: Implement per-request save wait in `wait_for_save_request()` using `prepare_stored_request_done_event()` / `_notify_stored_request_done()`.

### Observability
- **mooncake_backend.py**: Add KVTRACE timing for `batch_is_exist`, `batch_put_from_multi_buffers`, and `batch_get_into_multi_buffers`. Improve error logging to report key count and sample keys instead of full key lists.
- **kv_transfer.py**: Add per-stage KVTRACE timing (key build, exist check, prepare, event sync, backend put) with breakdown of mask check and string append costs.
- **pool_worker.py**: Add lookup breakdown logging with group-level hit/miss statistics and first-missing-group tracking.

## Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `VLLM_ASCEND_LOOKUP_GROUP_PARALLEL` | 0 | Enable parallel group lookup |
| `VLLM_ASCEND_LOOKUP_GROUP_PARALLEL_WORKERS` | 6 | Thread count for parallel lookup |
| `VLLM_ASCEND_LOOKUP_EARLY_STOP` | 0 | Stop lookup at full attention boundary |
| `VLLM_ASCEND_LOOKUP_REACHABLE_MASK` | 0 | Prune lookup candidates by reachable mask |
| `VLLM_ASCEND_LOOKUP_FULL_GUARD` | 0 | Validate aligned hit boundary |
| `VLLM_ASCEND_PUT_KEY_STRING_FAST_PATH` | 1 | Use key string fast path for put |
| `VLLM_ASCEND_PUT_SPARSE_STORE_MASK` | 0 | Only put chunks allowed by store mask |
| `VLLM_ASCEND_PUT_PRE_SHARD_KEY_BUILD` | 0 | Pre-shard key build for TP |
| `VLLM_ASCEND_PER_REQUEST_SAVE_WAIT` | 0 | Per-request save wait via Event |
| `VLLM_ASCEND_SKIP_STORE_EXISTED_GROUP` | 0 | Cache key build results across requests |

## Test Plan

- [ ] Verify lookup correctness with group parallel disabled (baseline)
- [ ] Verify lookup correctness with group parallel enabled
- [ ] Verify HBM hit tokens skip works with prefix caching
- [ ] Verify put fast path produces identical keys as legacy path
- [ ] Verify per-request save wait completes without blocking unrelated requests
- [ ] Verify KVTRACE logs appear at INFO level

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
