### PR TITLE
[Feature][Scheduler] Add ShortRequestFirst scheduling

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -189,6 +189,7 @@
   tests:
     - tests/ut/core
     - tests/ut/test_compressed_prefix_cache.py
+    - tests/e2e/pull_request/one_card/test_short_request_first_scheduling.py
 
 # Device
 - name: device
@@ -709,6 +710,7 @@ estimated_times:
   tests/e2e/pull_request/one_card/test_qwen3_8b_w8a8.py: 320
   tests/e2e/pull_request/one_card/test_qwen3_embedding_0_6b.py: 150
   tests/e2e/pull_request/one_card/test_sampler.py: 240
+  tests/e2e/pull_request/one_card/test_short_request_first_scheduling.py: 150
   tests/e2e/pull_request/one_card/test_simple_cpu_offload.py: 210
   tests/e2e/pull_request/one_card/test_vlm.py: 700
   tests/e2e/pull_request/one_card/test_xlite.py: 160
@@ -818,7 +820,6 @@ partition:
   a3_x2: 3
   a3_x4: 3
   cpu_x0: 1
-
 
 
 

--- a/docs/source/locale/zh_CN/LC_MESSAGES/user_guide/configuration/additional_config.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/user_guide/configuration/additional_config.po
@@ -619,6 +619,16 @@ msgstr "`multistream_dsv4_dsa_overlap`"
 msgid "Whether to enable dsa multi-stream overlap for DeepSeek V4."
 msgstr "是否为 DeepSeek V4 启用 dsa 多流重叠。"
 
+#: ../../source/user_guide/configuration/additional_config.md
+msgid "`short_request_first_config`"
+msgstr "`short_request_first_config`"
+
+#: ../../source/user_guide/configuration/additional_config.md
+msgid ""
+"Configuration options for ShortRequestFirst prefill scheduling. Requires "
+"`recompute_scheduler_enable=true`."
+msgstr "ShortRequestFirst 预填充调度的配置选项。需要 `recompute_scheduler_enable=true`。"
+
 #: ../../source/user_guide/configuration/additional_config.md:107
 msgid "The details of each configuration option are as follows:"
 msgstr "每个配置选项的详细说明如下："
@@ -989,6 +999,52 @@ msgid ""
 " tokens become much easier to accept, improving performance but reducing "
 "precision."
 msgstr "阈值计算中熵的缩放因子。必须 >= 0。值越大，阈值对熵越敏感——高熵 token 更容易被接受，从而提高性能但降低精度。"
+
+#: ../../source/user_guide/configuration/additional_config.md:177
+msgid "**short_request_first_config**"
+msgstr "**short_request_first_config**"
+
+#: ../../source/user_guide/configuration/additional_config.md:179
+msgid ""
+"ShortRequestFirst prefill scheduling. Only takes effect together with "
+"`recompute_scheduler_enable=true` and the FCFS scheduler policy."
+msgstr "ShortRequestFirst 预填充调度。仅在同时启用 `recompute_scheduler_enable=true` 和 FCFS 调度策略时生效。"
+
+#: ../../source/user_guide/configuration/additional_config.md
+msgid "Whether to enable ShortRequestFirst scheduling."
+msgstr "是否启用 ShortRequestFirst 调度。"
+
+#: ../../source/user_guide/configuration/additional_config.md
+msgid "`threshold`"
+msgstr "`threshold`"
+
+#: ../../source/user_guide/configuration/additional_config.md
+msgid "`256`"
+msgstr "`256`"
+
+#: ../../source/user_guide/configuration/additional_config.md
+msgid ""
+"Prompt-length threshold (tokens). Requests with `num_prompt_tokens <= "
+"threshold` are treated as short prefills and prioritized over long "
+"prefills."
+msgstr ""
+"prompt 长度阈值（token）。`num_prompt_tokens <= threshold` 的请求会被视为短预填充请求，并优先于长预填充请求。"
+
+#: ../../source/user_guide/configuration/additional_config.md
+msgid "`long_max_wait_ms`"
+msgstr "`long_max_wait_ms`"
+
+#: ../../source/user_guide/configuration/additional_config.md
+msgid "`0.0`"
+msgstr "`0.0`"
+
+#: ../../source/user_guide/configuration/additional_config.md
+msgid ""
+"Maximum time a long prefill may wait behind short prefills before it can "
+"be promoted ahead of them. `0` disables long-request promotion and keeps "
+"strict short-request priority."
+msgstr ""
+"长预填充请求在短预填充请求之后最多可等待的时间；超过该时间后，它可以被提升到短请求之前。`0` 表示禁用长请求提升，并保持严格的短请求优先级。"
 
 #: ../../source/user_guide/configuration/additional_config.md:176
 msgid "Example"

--- a/docs/source/locale/zh_CN/LC_MESSAGES/user_guide/feature_guide/short_request_first.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/user_guide/feature_guide/short_request_first.po
@@ -1,0 +1,353 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2025, vllm-ascend team
+# This file is distributed under the same license as the vllm-ascend
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: vllm-ascend \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-02 00:00+0000\n"
+"PO-Revision-Date: 2026-07-02 00:00+0000\n"
+"Last-Translator: immengzi <immengzi@outlook.com>\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:1
+msgid "ShortRequestFirst Prefill Scheduling"
+msgstr "ShortRequestFirst 预填充调度"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:3
+msgid ""
+"ShortRequestFirst reduces head-of-line blocking during prefill by letting"
+" short prompts run before long prompts. It is designed for mixed prompt-"
+"length traffic where a few long requests can otherwise delay many short "
+"ones."
+msgstr ""
+"ShortRequestFirst 通过让短 prompt 优先于长 prompt 执行，减少预填充阶段的队首阻塞。它适用于 prompt "
+"长度混合的流量场景；在这类场景中，少量长请求可能会延迟大量短请求。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:5
+msgid "When to use it"
+msgstr "适用场景"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:7
+msgid "Enable ShortRequestFirst when:"
+msgstr "以下场景适合启用 ShortRequestFirst："
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:9
+msgid "request lengths are highly skewed"
+msgstr "请求长度高度倾斜"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:10
+msgid "short-request TTFT matters more than strict FCFS ordering"
+msgstr "短请求 TTFT 比严格 FCFS 顺序更重要"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:11
+msgid "you are already using `recompute_scheduler_enable=true`"
+msgstr "已经在使用 `recompute_scheduler_enable=true`"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:13
+msgid ""
+"Keep it disabled if the workload is mostly uniform, or if FCFS ordering "
+"is more important than short-request latency."
+msgstr "如果工作负载基本均匀，或者 FCFS 顺序比短请求延迟更重要，请保持禁用。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:15
+msgid "Configuration"
+msgstr "配置"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:17
+msgid "ShortRequestFirst is configured through `--additional-config`:"
+msgstr "ShortRequestFirst 通过 `--additional-config` 配置："
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:34
+msgid "Fields"
+msgstr "字段"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:36
+msgid "`enabled` (bool, default `false`)"
+msgstr "`enabled`（bool，默认 `false`）"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:37
+msgid "Turns ShortRequestFirst on or off."
+msgstr "开启或关闭 ShortRequestFirst。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:38
+msgid "`threshold` (int, default `256`)"
+msgstr "`threshold`（int，默认 `256`）"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:39
+msgid ""
+"Requests with `num_prompt_tokens <= threshold` are treated as short "
+"requests."
+msgstr "`num_prompt_tokens <= threshold` 的请求会被视为短请求。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:40
+msgid "`long_max_wait_ms` (float, default `0`)"
+msgstr "`long_max_wait_ms`（float，默认 `0`）"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:41
+msgid ""
+"Maximum time a long request may wait behind short requests before it can "
+"be promoted ahead of them."
+msgstr "长请求在短请求之后最多可等待的时间；超过该时间后，它可以被提升到短请求之前。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:42
+msgid ""
+"`0` disables long-request promotion and keeps strict short-request "
+"priority."
+msgstr "`0` 表示禁用长请求提升，并保持严格的短请求优先级。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:44
+msgid "Threshold tuning"
+msgstr "threshold 调优"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:46
+msgid ""
+"If `threshold` is too low, most requests fall into the `long` lane and "
+"the split largely stops helping. If it is too high, most requests fall "
+"into the `short` lane and the split also stops helping."
+msgstr ""
+"如果 `threshold` 过低，大多数请求会落入 `long` 队列，拆分基本无法发挥作用。如果它过高，大多数请求会落入 `short` "
+"队列，拆分同样无法发挥作用。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:48
+msgid ""
+"In practice, `threshold` should sit near the boundary between the short-"
+"request main cluster and the long-request tail. The goal is not to pick a"
+" fixed midpoint of all request lengths, and not to move the threshold "
+"close to the longest requests."
+msgstr ""
+"实践中，`threshold` 应位于短请求主簇和长请求尾部之间的边界附近。目标不是选择所有请求长度的固定中点，也不是把阈值推到接近最长请求的位置。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:50
+msgid ""
+"If you do not yet have a refined traffic model, start with `P70-P85` of "
+"prompt length as an engineering baseline and then refine it using the "
+"real request-length histogram. For a clear bimodal workload, the "
+"threshold usually belongs near the upper edge of the short-request "
+"cluster rather than near the longest prompts."
+msgstr ""
+"如果还没有精细化的流量模型，可以先以 prompt 长度的 `P70-P85` 作为工程基线，再基于真实请求长度直方图继续调优。对于明显的双峰工作负载，"
+"阈值通常应靠近短请求簇的上边界，而不是靠近最长 prompt。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:52
+msgid ""
+"In short: the right threshold is usually the valley between short-request"
+" and long-request populations. When detailed distribution modeling is "
+"unavailable, `P70-P85` is a practical starting range."
+msgstr ""
+"简而言之：合适的阈值通常是短请求群体和长请求群体之间的低谷。如果没有详细的分布建模，`P70-P85` 是一个实用的起始范围。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:54
+msgid "long_max_wait_ms tuning"
+msgstr "long_max_wait_ms 调优"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:56
+msgid ""
+"`long_max_wait_ms` is a fairness gate, not a throughput-optimization "
+"knob. It controls when a long request stops waiting under normal short-"
+"first behavior and becomes eligible for anti-starvation promotion."
+msgstr ""
+"`long_max_wait_ms` 是公平性门控，而不是吞吐优化旋钮。它控制长请求在正常短请求优先行为下等待多久后，可以进入防饥饿提升。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:58
+msgid ""
+"Tune `threshold` first. If degradation warnings appear frequently, first "
+"suspect that `threshold` is too small for the current traffic mix, then "
+"consider increasing `long_max_wait_ms`."
+msgstr ""
+"请先调优 `threshold`。如果频繁出现退化告警，应先怀疑 `threshold` 对当前流量混合来说过小，然后再考虑增大 "
+"`long_max_wait_ms`。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:60
+msgid "A practical tuning flow is:"
+msgstr "一个实用的调优流程如下："
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:62
+msgid ""
+"start with `long_max_wait_ms = 0` to establish a strict short-first "
+"baseline"
+msgstr "先从 `long_max_wait_ms = 0` 开始，建立严格短请求优先的基线"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:63
+msgid ""
+"measure the waiting-time distribution of long requests under that "
+"baseline"
+msgstr "测量该基线下长请求的等待时间分布"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:64
+msgid ""
+"define `W_normal` as the normal upper tail of long-request waiting, "
+"typically `P90` or `P95`"
+msgstr "将 `W_normal` 定义为长请求等待时间的正常上尾，通常取 `P90` 或 `P95`"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:65
+msgid ""
+"define `W_slo` as the maximum additional queueing delay that your service"
+" can tolerate for long requests"
+msgstr "将 `W_slo` 定义为服务对长请求可接受的最大额外排队延迟"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:66
+msgid "set `long_max_wait_ms` somewhere inside `[W_normal, W_slo]`"
+msgstr "将 `long_max_wait_ms` 设置在 `[W_normal, W_slo]` 区间内"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:68
+msgid ""
+"Within that interval, bias the value toward `W_slo` if short-request TTFT"
+" matters more, or toward `W_normal` if long-request fairness matters "
+"more. If `W_normal` is already close to `W_slo`, the main issue is more "
+"likely the threshold choice or overall system capacity than the wait "
+"parameter itself."
+msgstr ""
+"在该区间内，如果短请求 TTFT 更重要，可将取值偏向 `W_slo`；如果长请求公平性更重要，可偏向 `W_normal`。如果 "
+"`W_normal` 已经接近 `W_slo`，主要问题更可能是阈值选择或整体系统容量，而不是等待参数本身。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:70
+msgid ""
+"Do not size `long_max_wait_ms` from average short-request TTFT. It is "
+"usually better anchored to the tail of long-request waiting under strict "
+"short-first behavior."
+msgstr ""
+"不要基于短请求的平均 TTFT 来设定 `long_max_wait_ms`。它通常更适合锚定在严格短请求优先行为下长请求等待时间的尾部。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:72
+msgid ""
+"In short: `long_max_wait_ms` should be derived from the long-request "
+"waiting tail under strict short-first scheduling and bounded by the long-"
+"request queueing delay your service can accept. If aged-long promotions "
+"happen repeatedly, increase `threshold` first and only then increase "
+"`long_max_wait_ms`."
+msgstr ""
+"简而言之：`long_max_wait_ms` 应从严格短请求优先调度下长请求等待时间的尾部分布推导，并受服务可接受的长请求排队延迟约束。如果老化长请求"
+"反复被提升，请先增大 `threshold`，然后再增大 `long_max_wait_ms`。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:74
+msgid "Scheduling behavior"
+msgstr "调度行为"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:76
+msgid "The waiting queue is split into three lanes:"
+msgstr "等待队列会被拆分为三条队列："
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:78
+msgid "`immediate`"
+msgstr "`immediate`"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:79
+msgid ""
+"Recovery-style requests such as preempted requests or requests with "
+"already computed tokens."
+msgstr "恢复类请求，例如被抢占的请求，或者已经有已计算 token 的请求。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:80
+msgid "`short`"
+msgstr "`short`"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:81
+msgid "Requests whose prompt length is at or below `threshold`."
+msgstr "prompt 长度小于等于 `threshold` 的请求。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:82
+msgid "`long`"
+msgstr "`long`"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:83
+msgid "Requests whose prompt length is above `threshold`."
+msgstr "prompt 长度大于 `threshold` 的请求。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:85
+msgid "Dispatch priority is:"
+msgstr "调度优先级为："
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:87
+msgid "`immediate > aged-long > short > long`"
+msgstr "`immediate > aged-long > short > long`"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:89
+msgid "That means:"
+msgstr "这意味着："
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:91
+msgid "immediate requests always win"
+msgstr "immediate 请求总是优先"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:92
+msgid "short requests run before ordinary long requests"
+msgstr "短请求会先于普通长请求运行"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:93
+msgid ""
+"if the oldest long request waits past `long_max_wait_ms`, it can jump "
+"ahead of waiting short requests"
+msgstr "如果最老的长请求等待时间超过 `long_max_wait_ms`，它可以越过等待中的短请求"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:95
+msgid "Degradation warning"
+msgstr "退化告警"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:97
+msgid ""
+"If long requests are promoted ahead of waiting short requests for three "
+"consecutive dispatches, vLLM Ascend emits a warning. This indicates the "
+"feature is drifting toward long-request priority, usually because the "
+"threshold is too small for the current traffic mix."
+msgstr ""
+"如果连续三次调度中长请求都被提升到等待中的短请求之前，vLLM Ascend 会发出告警。这表示该特性正在向长请求优先退化，通常是因为阈值对于当前流量"
+"混合来说过小。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:99
+msgid "When this warning appears:"
+msgstr "出现该告警时："
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:101
+msgid "increase `short_request_first_config.threshold`"
+msgstr "增大 `short_request_first_config.threshold`"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:102
+msgid "or disable `short_request_first_config.enabled`"
+msgstr "或者禁用 `short_request_first_config.enabled`"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:104
+msgid ""
+"ShortRequestFirst also emits an aggregate stats log every 5 seconds so "
+"queue behavior is visible without adding extra configuration."
+msgstr "ShortRequestFirst 还会每 5 秒输出一次聚合统计日志，因此无需额外配置即可观察队列行为。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:106
+msgid "Relationship with recompute scheduler"
+msgstr "与重计算调度器的关系"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:108
+msgid ""
+"ShortRequestFirst only changes the waiting-queue policy. It does not "
+"replace the scheduler implementation, so it takes effect only when "
+"`recompute_scheduler_enable=true`."
+msgstr ""
+"ShortRequestFirst 只改变等待队列策略，并不替换调度器实现，因此只有在 `recompute_scheduler_enable=true` "
+"时才会生效。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:110
+msgid ""
+"If `recompute_scheduler_enable=false`, ShortRequestFirst is not "
+"activated."
+msgstr "如果 `recompute_scheduler_enable=false`，ShortRequestFirst 不会被激活。"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:112
+msgid "Minimal examples"
+msgstr "最小示例"
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:114
+msgid "Enable it:"
+msgstr "启用："
+
+#: ../../source/user_guide/feature_guide/short_request_first.md:129
+msgid "Disable it explicitly:"
+msgstr "显式禁用："

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -103,6 +103,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `enable_dsa_cp`                     | bool | `False` | Whether to enable dsa_cp for DeepSeek V3.2, DeepSeek V4, and other models with the same architecture. This feature depends on FLASHCOMM1. Please ensure that FLASHCOMM1 is enabled before enabling this feature.|
 | `rejection_sampler_config`          | dict | `{}`    | Configuration options for rejection sampler (block verify and entropy verify). |
 | `multistream_dsv4_dsa_overlap`      | bool | `True`  | Whether to enable dsa multi-stream overlap for DeepSeek V4.  |
+| `short_request_first_config`       | dict | `{}`    | Configuration options for ShortRequestFirst prefill scheduling. Requires `recompute_scheduler_enable=true`. |
 
 The details of each configuration option are as follows:
 
@@ -173,6 +174,16 @@ The details of each configuration option are as follows:
 | `enable_entropy_verify` | bool  | `False` | Whether to enable entropy verify mode. Entropy verify adjusts the acceptance threshold based on the entropy of the target distribution — higher entropy (uncertain) tokens get a lower threshold (easier to accept), while lower entropy (confident) tokens get a stricter threshold. |
 | `posterior_threshold`   | float | `0.95`  | Upper bound for the entropy-adjusted acceptance threshold. Must be in (0, 1]. The effective threshold is `min(exp(-entropy * posterior_alpha), posterior_threshold)`. |
 | `posterior_alpha`       | float | `0.4`   | Scaling factor for entropy in the threshold computation. Must be >= 0. Higher values make the threshold more sensitive to entropy — high-entropy tokens become much easier to accept, improving performance but reducing precision. |
+
+**short_request_first_config**
+
+ShortRequestFirst prefill scheduling. Only takes effect together with `recompute_scheduler_enable=true` and the FCFS scheduler policy.
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `enabled`                | bool  | `False` | Whether to enable ShortRequestFirst scheduling. |
+| `threshold`              | int   | `256`   | Prompt-length threshold (tokens). Requests with `num_prompt_tokens <= threshold` are treated as short prefills and prioritized over long prefills. |
+| `long_max_wait_ms`       | float | `0.0`   | Maximum time a long prefill may wait behind short prefills before it can be promoted ahead of them. `0` disables long-request promotion and keeps strict short-request priority. |
 
 ### Example
 

--- a/docs/source/user_guide/feature_guide/index.md
+++ b/docs/source/user_guide/feature_guide/index.md
@@ -17,6 +17,7 @@ netloader
 rfork
 dynamic_batch
 epd_disaggregation
+short_request_first
 kv_pool
 kv_cache_cpu_offload
 external_dp

--- a/docs/source/user_guide/feature_guide/short_request_first.md
+++ b/docs/source/user_guide/feature_guide/short_request_first.md
@@ -1,0 +1,130 @@
+# ShortRequestFirst Prefill Scheduling
+
+ShortRequestFirst reduces head-of-line blocking during prefill by letting short prompts run before long prompts. It is designed for mixed prompt-length traffic where a few long requests can otherwise delay many short ones.
+
+## When to use it
+
+Enable ShortRequestFirst when:
+
+- request lengths are highly skewed
+- short-request TTFT matters more than strict FCFS ordering
+- you are already using `recompute_scheduler_enable=true`
+
+Keep it disabled if the workload is mostly uniform, or if FCFS ordering is more important than short-request latency.
+
+## Configuration
+
+ShortRequestFirst is configured through `--additional-config`:
+
+```bash
+vllm serve <model> \
+  --additional-config '{
+    "recompute_scheduler_enable": true,
+    "short_request_first_config": {
+      "enabled": true,
+      "threshold": 256,
+      "long_max_wait_ms": 2000
+    }
+  }'
+```
+
+### Fields
+
+- `enabled` (bool, default `false`)
+  Turns ShortRequestFirst on or off.
+- `threshold` (int, default `256`)
+  Requests with `num_prompt_tokens <= threshold` are treated as short requests.
+- `long_max_wait_ms` (float, default `0`)
+  Maximum time a long request may wait behind short requests before it can be promoted ahead of them.
+  `0` disables long-request promotion and keeps strict short-request priority.
+
+## Threshold tuning
+
+If `threshold` is too low, most requests fall into the `long` lane and the split largely stops helping. If it is too high, most requests fall into the `short` lane and the split also stops helping.
+
+In practice, `threshold` should sit near the boundary between the short-request main cluster and the long-request tail. The goal is not to pick a fixed midpoint of all request lengths, and not to move the threshold close to the longest requests.
+
+If you do not yet have a refined traffic model, start with `P70-P85` of prompt length as an engineering baseline and then refine it using the real request-length histogram. For a clear bimodal workload, the threshold usually belongs near the upper edge of the short-request cluster rather than near the longest prompts.
+
+In short: the right threshold is usually the valley between short-request and long-request populations. When detailed distribution modeling is unavailable, `P70-P85` is a practical starting range.
+
+## long_max_wait_ms tuning
+
+`long_max_wait_ms` is a fairness gate, not a throughput-optimization knob. It controls when a long request stops waiting under normal short-first behavior and becomes eligible for anti-starvation promotion.
+
+Tune `threshold` first. If degradation warnings appear frequently, first suspect that `threshold` is too small for the current traffic mix, then consider increasing `long_max_wait_ms`.
+
+A practical tuning flow is:
+
+- start with `long_max_wait_ms = 0` to establish a strict short-first baseline
+- measure the waiting-time distribution of long requests under that baseline
+- define `W_normal` as the normal upper tail of long-request waiting, typically `P90` or `P95`
+- define `W_slo` as the maximum additional queueing delay that your service can tolerate for long requests
+- set `long_max_wait_ms` somewhere inside `[W_normal, W_slo]`
+
+Within that interval, bias the value toward `W_slo` if short-request TTFT matters more, or toward `W_normal` if long-request fairness matters more. If `W_normal` is already close to `W_slo`, the main issue is more likely the threshold choice or overall system capacity than the wait parameter itself.
+
+Do not size `long_max_wait_ms` from average short-request TTFT. It is usually better anchored to the tail of long-request waiting under strict short-first behavior.
+
+In short: `long_max_wait_ms` should be derived from the long-request waiting tail under strict short-first scheduling and bounded by the long-request queueing delay your service can accept. If aged-long promotions happen repeatedly, increase `threshold` first and only then increase `long_max_wait_ms`.
+
+## Scheduling behavior
+
+The waiting queue is split into three lanes:
+
+- `immediate`
+  Recovery-style requests such as preempted requests or requests with already computed tokens.
+- `short`
+  Requests whose prompt length is at or below `threshold`.
+- `long`
+  Requests whose prompt length is above `threshold`.
+
+Dispatch priority is:
+
+`immediate > aged-long > short > long`
+
+That means:
+
+- immediate requests always win
+- short requests run before ordinary long requests
+- if the oldest long request waits past `long_max_wait_ms`, it can jump ahead of waiting short requests
+
+## Degradation warning
+
+If long requests are promoted ahead of waiting short requests for three consecutive dispatches, vLLM Ascend emits a warning. This indicates the feature is drifting toward long-request priority, usually because the threshold is too small for the current traffic mix.
+
+When this warning appears:
+
+- increase `short_request_first_config.threshold`
+- or disable `short_request_first_config.enabled`
+
+ShortRequestFirst also emits an aggregate stats log every 5 seconds so queue behavior is visible without adding extra configuration.
+
+## Relationship with recompute scheduler
+
+ShortRequestFirst only changes the waiting-queue policy. It does not replace the scheduler implementation, so it takes effect only when `recompute_scheduler_enable=true`.
+
+If `recompute_scheduler_enable=false`, ShortRequestFirst is not activated.
+
+## Minimal examples
+
+Enable it:
+
+```bash
+vllm serve <model> \
+  --additional-config '{
+    "recompute_scheduler_enable": true,
+    "short_request_first_config": {
+      "enabled": true,
+      "threshold": 256,
+      "long_max_wait_ms": 2000
+    }
+  }'
+```
+
+Disable it explicitly:
+
+```bash
+vllm serve <model> \
+  --additional-config '{"short_request_first_config": {"enabled": false}}'
+```

--- a/tests/e2e/pull_request/one_card/test_short_request_first_scheduling.py
+++ b/tests/e2e/pull_request/one_card/test_short_request_first_scheduling.py
@@ -1,0 +1,77 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end consistency test for ShortRequestFirst prefill scheduling."""
+
+import os
+from typing import Any
+
+from vllm import SamplingParams
+
+from tests.e2e.conftest import VllmRunner
+from tests.e2e.model_utils import check_outputs_equal
+
+MODEL = "Qwen/Qwen3-0.6B"
+
+SHORT_PROMPTS = [
+    "Hello, my name is",
+    "The capital of France is",
+    "1 + 1 equals",
+]
+LONG_PROMPTS = [
+    "The following is a long passage that should be classified as a long "
+    "prefill by the ShortRequestFirst scheduler. " * 8 + "In summary, the key point is",
+    "Once upon a time in a faraway land, there lived a great many people who "
+    "told stories about the stars. " * 8 + "The moral of the story is",
+]
+PROMPTS = SHORT_PROMPTS + LONG_PROMPTS
+
+GREEDY = SamplingParams(temperature=0.0, max_tokens=32, min_tokens=16)
+SHORT_REQUEST_FIRST_THRESHOLD = 16
+
+SHORT_REQUEST_FIRST_ADDITIONAL_CONFIG = {
+    "recompute_scheduler_enable": True,
+    "short_request_first_config": {
+        "enabled": True,
+        "threshold": SHORT_REQUEST_FIRST_THRESHOLD,
+        "long_max_wait_ms": 50.0,
+    },
+}
+
+
+def _generate(additional_config):
+    os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+    runner_kwargs: dict[str, Any] = dict(
+        max_model_len=1024,
+        enforce_eager=True,
+        dtype="float16",
+        gpu_memory_utilization=0.9,
+    )
+    if additional_config is not None:
+        runner_kwargs["additional_config"] = additional_config
+    with VllmRunner(MODEL, **runner_kwargs) as vllm_model:
+        return vllm_model.generate(PROMPTS, sampling_params=GREEDY)
+
+
+def test_short_request_first_matches_default_scheduler_outputs():
+    baseline = _generate(additional_config=None)
+    short_request_first = _generate(additional_config=SHORT_REQUEST_FIRST_ADDITIONAL_CONFIG)
+
+    check_outputs_equal(
+        outputs_0_lst=baseline,
+        outputs_1_lst=short_request_first,
+        name_0="default_scheduler",
+        name_1="short_request_first_scheduler",
+    )

--- a/tests/ut/core/test_recompute_scheduler_short_request_first.py
+++ b/tests/ut/core/test_recompute_scheduler_short_request_first.py
@@ -1,0 +1,185 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration tests for ShortRequestFirst wired into ``RecomputeScheduler``."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import torch
+from vllm.config import CacheConfig, ModelConfig, SchedulerConfig, VllmConfig
+from vllm.sampling_params import SamplingParams
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheGroupSpec
+from vllm.v1.request import Request
+from vllm.v1.structured_output import StructuredOutputManager
+
+from tests.ut.base import TestBase
+from vllm_ascend.ascend_config import ShortRequestFirstConfig
+from vllm_ascend.core.short_request_first_scheduler import ShortRequestFirstRequestQueue
+
+EOS_TOKEN_ID = 50256
+MODEL = "Qwen3-0.6B"
+THRESHOLD = 256
+MAX_NUM_BATCHED_TOKENS = 10000
+BLOCK_SIZE = 16
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 1000.0
+
+    def monotonic(self):
+        return self.now
+
+    def advance(self, seconds: float):
+        self.now += seconds
+
+
+def _fake_ascend_config(**overrides) -> SimpleNamespace:
+    config = {"enabled": True, "threshold": THRESHOLD}
+    config.update(overrides)
+    return SimpleNamespace(short_request_first_config=ShortRequestFirstConfig(config))
+
+
+def create_requests(num_tokens_list, max_tokens: int = 16):
+    init_none_hash(sha256)
+    requests = []
+    for i, num_tokens in enumerate(num_tokens_list):
+        sampling_params = SamplingParams(ignore_eos=False, max_tokens=max_tokens)
+        sampling_params.update_from_generation_config({}, EOS_TOKEN_ID)
+        request = Request(
+            request_id=f"{i}",
+            prompt_token_ids=[i % 50] * num_tokens,
+            sampling_params=sampling_params,
+            pooling_params=None,
+            mm_features=None,
+            block_hasher=get_request_block_hasher(BLOCK_SIZE, sha256),
+        )
+        requests.append(request)
+    return requests
+
+
+class TestRecomputeSchedulerShortRequestFirst(TestBase):
+    @patch("vllm.config.ModelConfig.__post_init__", MagicMock())
+    @patch("vllm.config.VllmConfig.__post_init__", MagicMock())
+    @patch("vllm.config.ModelConfig.is_encoder_decoder", PropertyMock(return_value=False))
+    def create_scheduler(self, **config_overrides):
+        from vllm_ascend.core.recompute_scheduler import RecomputeScheduler
+
+        scheduler_config = SchedulerConfig(
+            max_num_seqs=16,
+            max_model_len=MAX_NUM_BATCHED_TOKENS,
+            long_prefill_token_threshold=0,
+            disable_chunked_mm_input=False,
+            enable_chunked_prefill=True,
+            max_num_batched_tokens=MAX_NUM_BATCHED_TOKENS,
+            is_encoder_decoder=False,
+        )
+
+        model_config = ModelConfig(
+            model=MODEL,
+            tokenizer=MODEL,
+            tokenizer_mode="auto",
+            trust_remote_code=True,
+            dtype="float16",
+            seed=42,
+            max_model_len=MAX_NUM_BATCHED_TOKENS,
+        )
+        model_config.pooler_config = MagicMock()
+        model_config.multimodal_config = None
+        model_config.served_model_name = MODEL
+        model_config.hf_text_config = MagicMock()
+        model_config.hf_text_config.is_encoder_decoder = False
+        model_config.hf_text_config.model_type = "qwen3"
+
+        cache_config = CacheConfig(
+            block_size=BLOCK_SIZE,
+            gpu_memory_utilization=0.9,
+            cache_dtype="auto",
+            enable_prefix_caching=False,
+        )
+
+        vllm_config = VllmConfig(
+            scheduler_config=scheduler_config,
+            model_config=model_config,
+            cache_config=cache_config,
+            kv_transfer_config=None,
+            speculative_config=None,
+        )
+
+        kv_cache_config = KVCacheConfig(
+            num_blocks=10000,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["layer"],
+                    FullAttentionSpec(block_size=BLOCK_SIZE, num_kv_heads=1, head_size=1, dtype=torch.float32),
+                )
+            ],
+        )
+        cache_config.num_gpu_blocks = 10000
+
+        fake_cfg = _fake_ascend_config(**config_overrides)
+        with (
+            patch("vllm_ascend.core.recompute_scheduler.get_ascend_config", return_value=fake_cfg),
+            patch("vllm_ascend.core.short_request_first_scheduler.get_ascend_config", return_value=fake_cfg),
+        ):
+            scheduler = RecomputeScheduler(
+                vllm_config=vllm_config,
+                kv_cache_config=kv_cache_config,
+                block_size=BLOCK_SIZE,
+                log_stats=True,
+                structured_output_manager=MagicMock(spec=StructuredOutputManager),
+            )
+
+        scheduler.structured_output_manager.should_advance = MagicMock(return_value=False)
+        return scheduler
+
+    def _running_order(self, scheduler):
+        return [req.request_id for req in scheduler.running]
+
+    def test_waiting_queue_is_short_request_first(self):
+        scheduler = self.create_scheduler()
+        self.assertIsInstance(scheduler.waiting, ShortRequestFirstRequestQueue)
+
+    def test_short_prefill_scheduled_before_long(self):
+        scheduler = self.create_scheduler()
+        long_req, short_req = create_requests([THRESHOLD + 1000, 10])
+        scheduler.add_request(long_req)
+        scheduler.add_request(short_req)
+
+        scheduler.schedule()
+
+        order = self._running_order(scheduler)
+        self.assertIn("1", order)
+        self.assertIn("0", order)
+        self.assertLess(order.index("1"), order.index("0"))
+
+    def test_aged_long_promoted_over_short_after_wait(self):
+        clock = FakeClock()
+        with patch("vllm_ascend.core.short_request_first_scheduler.time", clock):
+            scheduler = self.create_scheduler(long_max_wait_ms=100.0)
+            long_req, short_req = create_requests([THRESHOLD + 1000, 10])
+            scheduler.add_request(long_req)
+            scheduler.add_request(short_req)
+
+            clock.advance(0.2)
+            scheduler.schedule()
+
+            order = self._running_order(scheduler)
+            self.assertIn("0", order)
+            self.assertLess(order.index("0"), order.index("1"))

--- a/tests/ut/core/test_short_request_first_scheduler.py
+++ b/tests/ut/core/test_short_request_first_scheduler.py
@@ -1,0 +1,202 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the ShortRequestFirst waiting queue."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
+
+from vllm_ascend.core.short_request_first_scheduler import ShortRequestFirstRequestQueue
+
+THRESHOLD = 256
+
+
+def make_request(request_id: str, prompt_len: int, **extra) -> SimpleNamespace:
+    return SimpleNamespace(request_id=request_id, num_prompt_tokens=prompt_len, **extra)
+
+
+def make_queue(
+    long_max_wait_ms: float = 0.0,
+    threshold: int = THRESHOLD,
+    immediate_predicate=None,
+) -> ShortRequestFirstRequestQueue:
+    return ShortRequestFirstRequestQueue(
+        policy=SchedulingPolicy.FCFS,
+        threshold=threshold,
+        long_max_wait_ms=long_max_wait_ms,
+        immediate_predicate=immediate_predicate,
+    )
+
+
+def short_req(rid="short", n=10):
+    return make_request(rid, n)
+
+
+def long_req(rid="long", n=THRESHOLD + 1000):
+    return make_request(rid, n)
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 1000.0
+
+    def monotonic(self):
+        return self.now
+
+    def advance(self, seconds: float):
+        self.now += seconds
+
+
+def test_classify_short_and_long_by_threshold():
+    q = make_queue(threshold=256)
+    q.add_request(short_req("s", 256))
+    q.add_request(long_req("l", 257))
+    assert q.num_short_requests == 1
+    assert q.num_long_requests == 1
+    assert q.num_immediate_requests == 0
+
+
+def test_immediate_predicate_routes_to_immediate_queue():
+    q = make_queue(immediate_predicate=lambda r: r.request_id == "hot")
+    q.add_request(make_request("hot", 5))
+    assert q.num_immediate_requests == 1
+    assert q.num_short_requests == 0
+
+
+def test_dispatch_priority_immediate_then_short_then_long():
+    q = make_queue()
+    q.add_request(long_req("l"))
+    q.add_request(short_req("s"))
+    q.prepend_request(make_request("imm", 5), force_immediate=True)
+
+    assert q.pop_request().request_id == "imm"
+    assert q.pop_request().request_id == "s"
+    assert q.pop_request().request_id == "l"
+
+
+def test_short_runs_before_long_without_aging():
+    q = make_queue()
+    q.add_request(long_req("l"))
+    q.add_request(short_req("s"))
+    assert q._select_schedulable_queue() is q._short_queue
+
+
+def test_aged_long_promotes_over_short_after_wait():
+    clock = FakeClock()
+    with patch("vllm_ascend.core.short_request_first_scheduler.time", clock):
+        q = make_queue(long_max_wait_ms=100.0)
+        q.add_request(long_req("l"))
+        q.add_request(short_req("s"))
+        q.begin_step(128)
+
+        clock.advance(0.15)
+        assert q._select_schedulable_queue() is q._long_queue
+
+
+def test_no_aging_when_long_max_wait_is_zero():
+    clock = FakeClock()
+    with patch("vllm_ascend.core.short_request_first_scheduler.time", clock):
+        q = make_queue(long_max_wait_ms=0.0)
+        q.add_request(long_req("l"))
+        q.add_request(short_req("s"))
+        q.begin_step(128)
+
+        clock.advance(10.0)
+        assert q._select_schedulable_queue() is q._short_queue
+
+
+def test_owns_queue_only_true_for_internal_subqueues():
+    q = make_queue()
+    assert q.owns_queue(q._immediate_queue)
+    assert q.owns_queue(q._short_queue)
+    assert q.owns_queue(q._long_queue)
+    external = create_request_queue(SchedulingPolicy.FCFS)
+    assert not q.owns_queue(external)
+    assert not q.owns_queue(None)
+
+
+def test_skip_or_requeue_counts_reason():
+    q = make_queue()
+    q.add_request(short_req("s"))
+    q.pop_request_from_queue(
+        q._short_queue,
+        count_as_removal=True,
+        skip_or_requeue_reason="blocked_waiting_status",
+    )
+    assert q._skip_or_requeue_counters["blocked_waiting_status"]["short"] == 1
+    assert q._dispatch_counters["short"] == 0
+
+
+def test_unknown_skip_or_requeue_reason_raises():
+    q = make_queue()
+    q.add_request(short_req("s"))
+    with pytest.raises(ValueError):
+        q.pop_request_from_queue(
+            q._short_queue,
+            count_as_removal=True,
+            skip_or_requeue_reason="bogus",
+        )
+
+
+def test_repeated_aged_long_promotions_trigger_warning_and_reset_after_short_dispatch():
+    clock = FakeClock()
+    with (
+        patch("vllm_ascend.core.short_request_first_scheduler.time", clock),
+        patch("vllm_ascend.core.short_request_first_scheduler.logger.warning_once") as mock_warning_once,
+    ):
+        q = make_queue(long_max_wait_ms=100.0)
+        q.add_request(long_req("l0"))
+        q.add_request(long_req("l1"))
+        q.add_request(long_req("l2"))
+        q.add_request(short_req("s0"))
+        q.begin_step(128)
+
+        clock.advance(0.2)
+        for _ in range(3):
+            assert q._select_schedulable_queue() is q._long_queue
+            q.pop_request_from_queue(q._long_queue)
+
+        mock_warning_once.assert_called_once()
+        assert q._consecutive_aged_long_promotions == 3
+
+        assert q._select_schedulable_queue() is q._short_queue
+        q.pop_request_from_queue(q._short_queue)
+        assert q._consecutive_aged_long_promotions == 0
+
+
+def test_stats_log_is_emitted_every_five_seconds():
+    clock = FakeClock()
+    with (
+        patch("vllm_ascend.core.short_request_first_scheduler.time", clock),
+        patch("vllm_ascend.core.short_request_first_scheduler.logger.info") as mock_info,
+    ):
+        q = make_queue()
+        q.add_request(short_req("s0"))
+        assert mock_info.call_count == 0
+
+        clock.advance(5.1)
+        q.add_request(long_req("l0"))
+        assert mock_info.call_count == 1
+
+        clock.advance(1.0)
+        q.pop_request()
+        assert mock_info.call_count == 1
+
+        clock.advance(5.1)
+        q.pop_request()
+        assert mock_info.call_count == 2

--- a/tests/ut/core/test_short_request_first_scheduler_mixin.py
+++ b/tests/ut/core/test_short_request_first_scheduler_mixin.py
@@ -1,0 +1,128 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the ShortRequestFirst scheduler mixin glue."""
+
+from types import SimpleNamespace
+
+from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
+from vllm.v1.request import RequestStatus
+
+from vllm_ascend.core.short_request_first_scheduler import (
+    ShortRequestFirstRequestQueue,
+    ShortRequestFirstSchedulerMixin,
+)
+
+THRESHOLD = 256
+
+
+def make_request(
+    request_id: str,
+    prompt_len: int,
+    computed: int = 0,
+    *,
+    status: RequestStatus = RequestStatus.WAITING,
+    num_output_tokens: int = 0,
+    num_external_computed_tokens: int = 0,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        request_id=request_id,
+        num_prompt_tokens=prompt_len,
+        num_computed_tokens=computed,
+        status=status,
+        num_output_tokens=num_output_tokens,
+        num_external_computed_tokens=num_external_computed_tokens,
+    )
+
+
+class SchedulerStub(ShortRequestFirstSchedulerMixin):
+    def __init__(self, waiting=None, skipped_waiting=None, policy=SchedulingPolicy.FCFS):
+        self.waiting = waiting
+        self.skipped_waiting = skipped_waiting
+        self.policy = policy
+
+
+def _short_request_first_queue(immediate_predicate=None):
+    return ShortRequestFirstRequestQueue(
+        policy=SchedulingPolicy.FCFS,
+        threshold=THRESHOLD,
+        long_max_wait_ms=0.0,
+        immediate_predicate=immediate_predicate,
+    )
+
+
+def test_select_prefers_skipped_waiting_under_fcfs():
+    waiting = _short_request_first_queue()
+    waiting.add_request(make_request("s", 10))
+    skipped = create_request_queue(SchedulingPolicy.FCFS)
+    skipped.add_request(make_request("skipped", 10))
+
+    stub = SchedulerStub(waiting, skipped_waiting=skipped)
+    assert stub._select_waiting_queue_for_scheduling() is skipped
+
+
+def test_select_uses_short_queue_when_skipped_empty():
+    waiting = _short_request_first_queue()
+    waiting.add_request(make_request("l", THRESHOLD + 100))
+    waiting.add_request(make_request("s", 10))
+    skipped = create_request_queue(SchedulingPolicy.FCFS)
+
+    stub = SchedulerStub(waiting, skipped_waiting=skipped)
+    assert stub._select_waiting_queue_for_scheduling() is waiting._short_queue
+
+
+def test_select_returns_none_when_everything_empty():
+    waiting = _short_request_first_queue()
+    skipped = create_request_queue(SchedulingPolicy.FCFS)
+    stub = SchedulerStub(waiting, skipped_waiting=skipped)
+    assert stub._select_waiting_queue_for_scheduling() is None
+
+
+def test_owns_queue_distinguishes_managed_subqueues_from_skipped():
+    waiting = _short_request_first_queue()
+    skipped = create_request_queue(SchedulingPolicy.FCFS)
+    assert waiting.owns_queue(waiting._short_queue)
+    assert not waiting.owns_queue(skipped)
+
+
+def test_recovery_markers_route_long_prompt_to_immediate_queue():
+    predicate = SchedulerStub()._is_recovery_request
+    long_len = THRESHOLD + 100
+    cases = {
+        "preempted": make_request("preempted", long_len, status=RequestStatus.PREEMPTED),
+        "computed": make_request("computed", long_len, computed=1),
+        "external_computed": make_request("external_computed", long_len, num_external_computed_tokens=1),
+        "output": make_request("output", long_len, num_output_tokens=1),
+    }
+    for name, request in cases.items():
+        queue = _short_request_first_queue(immediate_predicate=predicate)
+        queue.add_request(request)
+        assert queue.num_immediate_requests == 1, name
+        assert queue.num_long_requests == 0, name
+        assert queue.num_short_requests == 0, name
+
+
+def test_non_recovery_requests_stay_in_length_based_queues():
+    predicate = SchedulerStub()._is_recovery_request
+
+    long_queue = _short_request_first_queue(immediate_predicate=predicate)
+    long_queue.add_request(make_request("plain_long", THRESHOLD + 100))
+    assert long_queue.num_long_requests == 1
+    assert long_queue.num_immediate_requests == 0
+
+    short_queue = _short_request_first_queue(immediate_predicate=predicate)
+    short_queue.add_request(make_request("plain_short", 10))
+    assert short_queue.num_short_requests == 1
+    assert short_queue.num_immediate_requests == 0

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -21,7 +21,12 @@ from unittest.mock import patch
 from vllm.config import KVTransferConfig, VllmConfig
 
 from tests.ut.base import TestBase
-from vllm_ascend.ascend_config import clear_ascend_config, get_ascend_config, init_ascend_config
+from vllm_ascend.ascend_config import (
+    ShortRequestFirstConfig,
+    clear_ascend_config,
+    get_ascend_config,
+    init_ascend_config,
+)
 from vllm_ascend.utils import clear_enable_sp, enable_sp, get_flashcomm2_config_and_validate
 
 
@@ -420,3 +425,41 @@ class TestAscendConfig(TestBase):
         second_ascend_config = init_ascend_config(second_vllm_config)
         self.assertIsNot(first_ascend_config, second_ascend_config)
         self.assertTrue(second_ascend_config.ascend_compilation_config.enable_npugraph_ex)
+
+
+class TestShortRequestFirstConfig(TestBase):
+    def test_default_is_disabled(self):
+        cfg = ShortRequestFirstConfig({})
+        self.assertFalse(cfg.enabled)
+        self.assertEqual(cfg.threshold, 256)
+        self.assertEqual(cfg.long_max_wait_ms, 0.0)
+
+    def test_explicit_config(self):
+        cfg = ShortRequestFirstConfig(
+            {
+                "enabled": True,
+                "threshold": 512,
+                "long_max_wait_ms": 2000,
+            }
+        )
+        self.assertTrue(cfg.enabled)
+        self.assertEqual(cfg.threshold, 512)
+        self.assertEqual(cfg.long_max_wait_ms, 2000.0)
+
+    def test_unknown_key_rejected(self):
+        with self.assertRaises(ValueError):
+            ShortRequestFirstConfig({"foo": 1})
+
+    def test_validation_rejects_out_of_range(self):
+        with self.assertRaises(ValueError):
+            ShortRequestFirstConfig({"long_token_reservation": 1.5})
+        with self.assertRaises(ValueError):
+            ShortRequestFirstConfig({"threshold": -1})
+        with self.assertRaises(ValueError):
+            ShortRequestFirstConfig({"long_max_wait_ms": -1})
+
+    def test_none_config_is_disabled(self):
+        cfg = ShortRequestFirstConfig(None)
+        self.assertFalse(cfg.enabled)
+        self.assertEqual(cfg.threshold, 256)
+        self.assertEqual(cfg.long_max_wait_ms, 0.0)

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -159,6 +159,9 @@ class AscendConfig:
                 "collectives need uniform num_tokens across DP ranks, which is "
                 "only guaranteed when the recompute scheduler is enabled."
             )
+        self.short_request_first_config = ShortRequestFirstConfig(
+            additional_config.get("short_request_first_config", {})
+        )
         self.enable_cpu_binding = additional_config.get("enable_cpu_binding", True)
         self.enable_sleep_mode_extra_cleanup = additional_config.get("enable_sleep_mode_extra_cleanup", False)
         self.multistream_dsv4_dsa_overlap = additional_config.get("multistream_dsv4_dsa_overlap", True)
@@ -837,6 +840,35 @@ class EplbConfig:
 
         logger.info("Dynamic EPLB is %s", self.config["dynamic_eplb"])
         logger.info("The number of redundant experts is %s", self.config["num_redundant_experts"])
+
+
+class ShortRequestFirstConfig:
+    """Configuration object for ``additional_config["short_request_first_config"]``."""
+
+    _defaults = {
+        "enabled": False,
+        "threshold": 256,
+        "long_max_wait_ms": 0.0,
+    }
+
+    def __init__(self, user_config: dict | None = None):
+        user_config = user_config or {}
+        unknown = set(user_config) - set(self._defaults)
+        if unknown:
+            raise ValueError(f"Unknown short_request_first_config keys: {sorted(unknown)}")
+
+        source = user_config
+
+        self.enabled = bool(source.get("enabled", self._defaults["enabled"]))
+        self.threshold = int(source.get("threshold", self._defaults["threshold"]))
+        self.long_max_wait_ms = float(source.get("long_max_wait_ms", self._defaults["long_max_wait_ms"]))
+        self._validate_config()
+
+    def _validate_config(self):
+        if self.threshold < 0:
+            raise ValueError(f"short_request_first_config.threshold must be a non-negative int; got {self.threshold}")
+        if self.long_max_wait_ms < 0:
+            raise ValueError(f"short_request_first_config.long_max_wait_ms must be >= 0; got {self.long_max_wait_ms}")
 
 
 _ASCEND_CONFIG: AscendConfig | None = None

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -50,6 +50,9 @@ from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.utils import ConstantList, record_function_or_nullcontext
 
+from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.core.short_request_first_scheduler import ShortRequestFirstSchedulerMixin
+
 
 @dataclass
 class RecomputeSchedulerConfig(SchedulerConfig):
@@ -92,7 +95,7 @@ class RecomputeSchedulerOutput(SchedulerOutput):
     recomputed_reqs: list[RecomputeReqInfo] | None = None
 
 
-class RecomputeScheduler(Scheduler):
+class RecomputeScheduler(ShortRequestFirstSchedulerMixin, Scheduler):
     running: list[Request]
 
     def __init__(self, *args, **kwargs):
@@ -106,6 +109,26 @@ class RecomputeScheduler(Scheduler):
             and self.vllm_config.kv_transfer_config.is_kv_consumer
         )
         self.is_kv_producer = self.vllm_config.kv_transfer_config and self.vllm_config.kv_transfer_config.is_kv_producer
+        if get_ascend_config().short_request_first_config.enabled:
+            self._init_short_request_first_waiting_queue()
+
+    def _pop_waiting_request(
+        self,
+        request_queue,
+        count_with_short_request_first: bool,
+        *,
+        count_as_removal: bool = False,
+        skip_or_requeue_reason: str | None = None,
+    ) -> Request:
+        if count_with_short_request_first:
+            short_request_first_waiting = self._short_request_first_waiting_queue()
+            assert short_request_first_waiting is not None
+            return short_request_first_waiting.pop_request_from_queue(
+                request_queue,
+                count_as_removal=count_as_removal,
+                skip_or_requeue_reason=skip_or_requeue_reason,
+            )
+        return request_queue.pop_request()
 
     def add_request(self, request: Request) -> None:
         existing = self.requests.get(request.request_id)
@@ -198,6 +221,9 @@ class RecomputeScheduler(Scheduler):
 
         # For logging.
         scheduled_timestamp = time.monotonic()
+        short_request_first_waiting = self._short_request_first_waiting_queue()
+        if short_request_first_waiting is not None:
+            short_request_first_waiting.begin_step(self.max_num_scheduled_tokens)
 
         self.kv_cache_manager.new_step_starts()
 
@@ -444,6 +470,13 @@ class RecomputeScheduler(Scheduler):
                 request_queue = self._select_waiting_queue_for_scheduling()
                 assert request_queue is not None
 
+                # skipped_waiting is not owned by ShortRequestFirstRequestQueue,
+                # so only route pops through it when the selected queue is one
+                # of its managed sub-queues.
+                count_with_short_request_first = (
+                    short_request_first_waiting is not None and short_request_first_waiting.owns_queue(request_queue)
+                )
+
                 request = request_queue.peek_request()
                 request_id = request.request_id
 
@@ -456,7 +489,12 @@ class RecomputeScheduler(Scheduler):
                             "[RecomputeScheduler] %s is still in WAITING_FOR_REMOTE_KVS state.",
                             request_id,
                         )
-                    request_queue.pop_request()
+                    self._pop_waiting_request(
+                        request_queue,
+                        count_with_short_request_first,
+                        count_as_removal=True,
+                        skip_or_requeue_reason="blocked_waiting_status",
+                    )
                     step_skipped_waiting.prepend_request(request)
                     continue
 
@@ -471,7 +509,12 @@ class RecomputeScheduler(Scheduler):
                     )
                 ):
                     # Scheduling would exceed max_loras, skip.
-                    request_queue.pop_request()
+                    self._pop_waiting_request(
+                        request_queue,
+                        count_with_short_request_first,
+                        count_as_removal=True,
+                        skip_or_requeue_reason="max_loras",
+                    )
                     step_skipped_waiting.prepend_request(request)
                     continue
 
@@ -519,7 +562,12 @@ class RecomputeScheduler(Scheduler):
                             # The request cannot be scheduled because
                             # the KVConnector couldn't determine
                             # the number of matched tokens.
-                            request_queue.pop_request()
+                            self._pop_waiting_request(
+                                request_queue,
+                                count_with_short_request_first,
+                                count_as_removal=True,
+                                skip_or_requeue_reason="remote_kv_not_ready",
+                            )
                             step_skipped_waiting.prepend_request(request)
                             continue
                         num_external_computed_tokens = ext_tokens
@@ -652,7 +700,7 @@ class RecomputeScheduler(Scheduler):
                             preempted=request.num_preemptions > 0,
                         )
 
-                request = request_queue.pop_request()
+                request = self._pop_waiting_request(request_queue, count_with_short_request_first)
                 if load_kv_async:
                     # If loading async, allocate memory and put request
                     # into the WAITING_FOR_REMOTE_KV state.

--- a/vllm_ascend/core/short_request_first_scheduler.py
+++ b/vllm_ascend/core/short_request_first_scheduler.py
@@ -1,0 +1,436 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable, Iterable, Iterator
+from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
+
+from vllm.logger import logger
+from vllm.v1.core.sched.request_queue import (
+    RequestQueue,
+    SchedulingPolicy,
+    create_request_queue,
+)
+from vllm.v1.request import Request, RequestStatus
+
+from vllm_ascend.ascend_config import get_ascend_config
+
+
+@runtime_checkable
+class SteppedWaitingQueue(Protocol):
+    """Extension contract a waiting queue must satisfy for scheduler integration."""
+
+    def begin_step(self, token_budget: int) -> None: ...
+
+    def select_waiting_queue_for_scheduling(self) -> RequestQueue | None: ...
+
+    def has_schedulable_requests(self) -> bool: ...
+
+    def pop_request_from_queue(
+        self,
+        queue: RequestQueue,
+        *,
+        count_as_removal: bool = ...,
+        skip_or_requeue_reason: str | None = ...,
+    ) -> Request: ...
+
+    def mark_force_immediate(self, request_id: str) -> None: ...
+
+    def owns_queue(self, queue: RequestQueue | None) -> bool: ...
+
+
+class ShortRequestFirstRequestQueue(RequestQueue):
+    """Three-lane waiting queue with short-request priority and simple aging."""
+
+    STATS_LOG_INTERVAL_S = 5.0
+    AGED_LONG_WARNING_STREAK = 3
+    _SKIP_OR_REQUEUE_REASONS = (
+        "blocked_waiting_status",
+        "max_loras",
+        "remote_kv_not_ready",
+    )
+
+    def __init__(
+        self,
+        policy: SchedulingPolicy,
+        threshold: int,
+        long_max_wait_ms: float,
+        immediate_predicate: Callable[[Request], bool] | None = None,
+    ) -> None:
+        self.policy = policy
+        self.threshold = threshold
+        self.long_max_wait_ms = long_max_wait_ms
+        self.immediate_predicate = immediate_predicate
+        self._immediate_queue = create_request_queue(policy)
+        self._short_queue = create_request_queue(policy)
+        self._long_queue = create_request_queue(policy)
+        self._long_enqueue_at: dict[str, float] = {}
+        self._prepend_counters = {"immediate": 0, "short": 0, "long": 0}
+        self._dispatch_counters = {"immediate": 0, "short": 0, "long": 0}
+        self._skip_or_requeue_counters = {
+            reason: {"immediate": 0, "short": 0, "long": 0} for reason in self._SKIP_OR_REQUEUE_REASONS
+        }
+        self._force_immediate_request_ids: set[str] = set()
+        self._queue_index: dict[str, RequestQueue] = {}
+        self._aged_long_promotions = 0
+        self._consecutive_aged_long_promotions = 0
+        self._last_stats_log_at = time.monotonic()
+
+    def _queues(self) -> tuple[RequestQueue, ...]:
+        return (self._immediate_queue, self._short_queue, self._long_queue)
+
+    @property
+    def _debug_logging_enabled(self) -> bool:
+        return logger.isEnabledFor(logging.DEBUG)
+
+    def owns_queue(self, queue: RequestQueue | None) -> bool:
+        return any(queue is q for q in self._queues())
+
+    def _queue_name(self, queue: RequestQueue) -> str:
+        if queue is self._immediate_queue:
+            return "immediate"
+        if queue is self._short_queue:
+            return "short"
+        if queue is self._long_queue:
+            return "long"
+        return "unknown"
+
+    def _maybe_log_stats(self, force: bool = False) -> None:
+        now = time.monotonic()
+        if not force and (now - self._last_stats_log_at) < self.STATS_LOG_INTERVAL_S:
+            return
+        self._last_stats_log_at = now
+        logger.info(
+            "ShortRequestFirst stats: threshold=%d long_max_wait_ms=%.3f "
+            "sizes=(immediate=%d short=%d long=%d) "
+            "prepends=%s dispatches=%s skip_or_requeues=%s "
+            "aged_long_promotions=%d consecutive_aged_long_promotions=%d",
+            self.threshold,
+            self.long_max_wait_ms,
+            len(self._immediate_queue),
+            len(self._short_queue),
+            len(self._long_queue),
+            self._prepend_counters,
+            self._dispatch_counters,
+            self._skip_or_requeue_counters,
+            self._aged_long_promotions,
+            self._consecutive_aged_long_promotions,
+        )
+
+    def _increment_skip_or_requeue_counter(self, queue: RequestQueue, reason: str) -> None:
+        if reason not in self._skip_or_requeue_counters:
+            raise ValueError(f"Unknown skip_or_requeue reason: {reason}")
+        self._skip_or_requeue_counters[reason][self._queue_name(queue)] += 1
+
+    def _debug_state(
+        self,
+        event: str,
+        request: Request | None = None,
+        queue: RequestQueue | None = None,
+        extra: str = "",
+    ) -> None:
+        if not self._debug_logging_enabled:
+            return
+        request_id = "-" if request is None else request.request_id
+        prompt_tokens = -1 if request is None else request.num_prompt_tokens
+        queue_name = "-" if queue is None else self._queue_name(queue)
+        extra_suffix = f", {extra}" if extra else ""
+        logger.debug(
+            "ShortRequestFirst queue %s: request_id=%s, prompt_tokens=%d, target_queue=%s, "
+            "sizes=(immediate=%d, short=%d, long=%d)%s",
+            event,
+            request_id,
+            prompt_tokens,
+            queue_name,
+            len(self._immediate_queue),
+            len(self._short_queue),
+            len(self._long_queue),
+            extra_suffix,
+        )
+
+    @property
+    def num_immediate_requests(self) -> int:
+        return len(self._immediate_queue)
+
+    @property
+    def num_short_requests(self) -> int:
+        return len(self._short_queue)
+
+    @property
+    def num_long_requests(self) -> int:
+        return len(self._long_queue)
+
+    def _classify_queue(self, request: Request, *, force_immediate: bool = False) -> RequestQueue:
+        if force_immediate or request.request_id in self._force_immediate_request_ids:
+            return self._immediate_queue
+        if self.immediate_predicate is not None and self.immediate_predicate(request):
+            return self._immediate_queue
+        if request.num_prompt_tokens <= self.threshold:
+            return self._short_queue
+        return self._long_queue
+
+    def _long_head_wait_ms(self) -> float | None:
+        if self.long_max_wait_ms <= 0 or not self._long_queue:
+            return None
+        head = self._long_queue.peek_request()
+        enqueued_at = self._long_enqueue_at.get(head.request_id)
+        if enqueued_at is None:
+            return None
+        return (time.monotonic() - enqueued_at) * 1000.0
+
+    def _reset_degradation_streak(self) -> None:
+        self._consecutive_aged_long_promotions = 0
+
+    def _reset_degradation_streak_if_short_queue_empty(self) -> None:
+        if not self._short_queue:
+            self._reset_degradation_streak()
+
+    def begin_step(self, token_budget: int) -> None:
+        del token_budget
+        self._reset_degradation_streak_if_short_queue_empty()
+        self._maybe_log_stats()
+
+    def _select_schedulable_queue(self) -> RequestQueue | None:
+        if self._immediate_queue:
+            return self._immediate_queue
+        if self._long_queue:
+            wait_ms = self._long_head_wait_ms()
+            if wait_ms is not None and wait_ms >= self.long_max_wait_ms and self._short_queue:
+                return self._long_queue
+        if self._short_queue:
+            return self._short_queue
+        if self._long_queue:
+            return self._long_queue
+        return None
+
+    def has_schedulable_requests(self) -> bool:
+        return self._select_schedulable_queue() is not None
+
+    def select_waiting_queue_for_scheduling(self) -> RequestQueue | None:
+        return self._select_schedulable_queue()
+
+    def mark_force_immediate(self, request_id: str) -> None:
+        self._force_immediate_request_ids.add(request_id)
+
+    @staticmethod
+    def _request_id(request: Request | object) -> str | None:
+        return getattr(request, "request_id", None)
+
+    def add_request(self, request: Request) -> None:
+        queue = self._classify_queue(request)
+        queue.add_request(request)
+        self._queue_index[request.request_id] = queue
+        if queue is self._long_queue:
+            self._long_enqueue_at.setdefault(request.request_id, time.monotonic())
+        if queue is not self._immediate_queue:
+            self._force_immediate_request_ids.discard(request.request_id)
+        self._debug_state("enqueue", request=request, queue=queue)
+        self._maybe_log_stats()
+
+    def pop_request(self) -> Request:
+        queue = self._select_schedulable_queue()
+        if queue is None:
+            raise IndexError("pop from empty ShortRequestFirst queue")
+        return self.pop_request_from_queue(queue)
+
+    def _maybe_warn_degradation(self) -> None:
+        if self._consecutive_aged_long_promotions < self.AGED_LONG_WARNING_STREAK:
+            return
+        logger.warning_once(
+            "ShortRequestFirst scheduling is repeatedly promoting long requests ahead of waiting short requests "
+            "and may degrade toward long-request priority. Consider increasing "
+            "short_request_first_config.threshold or disabling short_request_first_config.enabled."
+        )
+
+    def pop_request_from_queue(
+        self,
+        queue: RequestQueue,
+        *,
+        count_as_removal: bool = False,
+        skip_or_requeue_reason: str | None = None,
+    ) -> Request:
+        request = queue.pop_request()
+        self._queue_index.pop(request.request_id, None)
+        enqueued_at = self._long_enqueue_at.pop(request.request_id, None)
+        if count_as_removal:
+            if skip_or_requeue_reason is not None:
+                self._increment_skip_or_requeue_counter(queue, skip_or_requeue_reason)
+                event_name = f"skip_or_requeue:{skip_or_requeue_reason}"
+            else:
+                event_name = "remove"
+        else:
+            self._dispatch_counters[self._queue_name(queue)] += 1
+            event_name = "dispatch"
+            if queue is self._short_queue:
+                self._reset_degradation_streak()
+            elif queue is self._long_queue:
+                wait_ms = (time.monotonic() - enqueued_at) * 1000.0 if enqueued_at is not None else None
+                aged = self.long_max_wait_ms > 0 and wait_ms is not None and wait_ms >= self.long_max_wait_ms
+                jumped_shorts = len(self._short_queue) > 0
+                if aged and jumped_shorts:
+                    self._aged_long_promotions += 1
+                    self._consecutive_aged_long_promotions += 1
+                    self._maybe_warn_degradation()
+                elif not jumped_shorts:
+                    self._reset_degradation_streak()
+        self._force_immediate_request_ids.discard(request.request_id)
+        self._reset_degradation_streak_if_short_queue_empty()
+        self._debug_state(event_name, request=request, queue=queue)
+        self._maybe_log_stats()
+        return request
+
+    def peek_request(self) -> Request:
+        queue = self._select_schedulable_queue()
+        if queue is None:
+            raise IndexError("peek from an empty ShortRequestFirst queue")
+        return queue.peek_request()
+
+    def prepend_request(self, request: Request, force_immediate: bool = False) -> None:
+        if force_immediate:
+            self._force_immediate_request_ids.add(request.request_id)
+        queue = self._classify_queue(request, force_immediate=force_immediate)
+        queue.prepend_request(request)
+        self._queue_index[request.request_id] = queue
+        if queue is self._long_queue:
+            self._long_enqueue_at.setdefault(request.request_id, time.monotonic())
+        self._prepend_counters[self._queue_name(queue)] += 1
+        self._debug_state("prepend", request=request, queue=queue)
+        self._maybe_log_stats()
+
+    def prepend_requests(self, requests: RequestQueue) -> None:
+        for request in requests:
+            self.prepend_request(cast(Request, request))
+
+    def remove_request(self, request: Request) -> None:
+        queue = self._queue_index.get(request.request_id)
+        if queue is None:
+            raise ValueError("request not found in ShortRequestFirst queue")
+        queue.remove_request(request)
+        self._queue_index.pop(request.request_id, None)
+        self._long_enqueue_at.pop(request.request_id, None)
+        self._force_immediate_request_ids.discard(request.request_id)
+        self._reset_degradation_streak_if_short_queue_empty()
+        self._debug_state("remove", request=request, queue=queue)
+        self._maybe_log_stats()
+
+    def remove_requests(self, requests: Iterable[Request]) -> None:
+        queue_to_requests: dict[int, list[Request]] = {}
+        queue_map = {id(q): q for q in self._queues()}
+        removed_count = 0
+        for request in requests:
+            queue = self._queue_index.get(request.request_id)
+            if queue is None:
+                continue
+            queue_to_requests.setdefault(id(queue), []).append(request)
+        for queue_id, matched_requests in queue_to_requests.items():
+            removed_count += len(matched_requests)
+            queue = queue_map[queue_id]
+            queue.remove_requests(matched_requests)
+            for matched in matched_requests:
+                self._queue_index.pop(matched.request_id, None)
+                self._long_enqueue_at.pop(matched.request_id, None)
+                self._force_immediate_request_ids.discard(matched.request_id)
+        if removed_count:
+            self._reset_degradation_streak_if_short_queue_empty()
+            self._debug_state("remove_batch", extra=f"count={removed_count}")
+            self._maybe_log_stats()
+
+    def __bool__(self) -> bool:
+        return len(self) > 0
+
+    def __len__(self) -> int:
+        return len(self._immediate_queue) + len(self._short_queue) + len(self._long_queue)
+
+    def __iter__(self) -> Iterator[Request]:
+        yield from self._immediate_queue
+        yield from self._short_queue
+        yield from self._long_queue
+
+    def __contains__(self, request: object) -> bool:
+        request_id = self._request_id(request)
+        return request_id is not None and request_id in self._queue_index
+
+
+if TYPE_CHECKING:
+    _short_request_first_queue_conforms: type[SteppedWaitingQueue] = ShortRequestFirstRequestQueue
+
+
+class ShortRequestFirstSchedulerMixin:
+    """Inject a ShortRequestFirst waiting queue into vLLM's scheduler."""
+
+    if TYPE_CHECKING:
+        policy: SchedulingPolicy
+
+    def _is_recovery_request(self, request: Request) -> bool:
+        return (
+            request.status == RequestStatus.PREEMPTED
+            or request.num_computed_tokens > 0
+            or request.num_external_computed_tokens > 0
+            or request.num_output_tokens > 0
+        )
+
+    def _init_short_request_first_waiting_queue(
+        self,
+        immediate_predicate: Callable[[Request], bool] | None = None,
+    ) -> None:
+        if self.policy != SchedulingPolicy.FCFS:
+            logger.debug(
+                "ShortRequestFirst scheduling supports only FCFS policy (current=%s); "
+                "keeping the default waiting queue.",
+                self.policy,
+            )
+            return
+
+        if immediate_predicate is None:
+            immediate_predicate = self._is_recovery_request
+        short_request_first_config = get_ascend_config().short_request_first_config
+        self.waiting = ShortRequestFirstRequestQueue(
+            policy=self.policy,
+            threshold=short_request_first_config.threshold,
+            long_max_wait_ms=short_request_first_config.long_max_wait_ms,
+            immediate_predicate=immediate_predicate,
+        )
+        logger.info(
+            "ShortRequestFirst scheduling enabled on Ascend: threshold=%d, long_max_wait_ms=%.3f",
+            short_request_first_config.threshold,
+            short_request_first_config.long_max_wait_ms,
+        )
+
+    def _short_request_first_waiting_queue(self) -> ShortRequestFirstRequestQueue | None:
+        if isinstance(self.waiting, ShortRequestFirstRequestQueue):
+            return self.waiting
+        return None
+
+    def _select_waiting_queue_for_scheduling(self) -> RequestQueue | None:
+        waiting = getattr(self, "waiting", None)
+        if isinstance(waiting, ShortRequestFirstRequestQueue):
+            skipped_waiting = getattr(self, "skipped_waiting", None)
+            if self.policy == SchedulingPolicy.FCFS and skipped_waiting:
+                return skipped_waiting
+            queue = waiting.select_waiting_queue_for_scheduling()
+            if queue is not None:
+                return queue
+            return skipped_waiting or None
+        return super()._select_waiting_queue_for_scheduling()  # type: ignore[misc]
+
+    def _preempt_request(self, request: Request, timestamp: float) -> None:
+        waiting = getattr(self, "waiting", None)
+        if isinstance(waiting, ShortRequestFirstRequestQueue):
+            waiting.mark_force_immediate(request.request_id)
+        super()._preempt_request(request, timestamp)  # type: ignore[misc]

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -674,6 +674,16 @@ class NPUPlatform(Platform):
 
         cls._validate_kv_load_failure_policy(vllm_config)
 
+        short_request_first_config = ascend_config.short_request_first_config
+        enable_short_request_first = short_request_first_config.enabled
+        short_request_first_supported_policy = vllm_config.scheduler_config.policy == "fcfs"
+        if enable_short_request_first and not short_request_first_supported_policy:
+            logger.warning_once(
+                "ShortRequestFirst scheduling currently supports only FCFS scheduler policy; "
+                "current policy=%s. The default waiting queue will be used.",
+                vllm_config.scheduler_config.policy,
+            )
+
         if ascend_config.recompute_scheduler_enable:
             kv_transfer_config = vllm_config.kv_transfer_config
             kv_role = getattr(kv_transfer_config, "kv_role", None)
@@ -687,9 +697,28 @@ class NPUPlatform(Platform):
 
             recompute_scheduler_config = RecomputeSchedulerConfig.initialize_from_config(vllm_config)
             vllm_config.scheduler_config = recompute_scheduler_config
+            if enable_short_request_first:
+                logger.info(
+                    "Ascend ShortRequestFirst scheduler selected through recompute "
+                    "scheduler: scheduler_cls=%s, policy=%s, threshold=%d, long_max_wait_ms=%.3f",
+                    vllm_config.scheduler_config.scheduler_cls,
+                    vllm_config.scheduler_config.policy,
+                    short_request_first_config.threshold,
+                    short_request_first_config.long_max_wait_ms,
+                )
+        elif enable_short_request_first:
+            logger.warning_once(
+                "ShortRequestFirst scheduling requires recompute_scheduler_enable=true "
+                "in additional_config. ShortRequestFirst scheduling will not be activated.",
+            )
 
         # Extend original scheduler_config to use SchedulerDynamicBatch.
         if ascend_config.SLO_limits_for_dynamic_batch != -1:
+            if enable_short_request_first:
+                logger.warning_once(
+                    "ShortRequestFirst scheduling is ignored because "
+                    "SLO_limits_for_dynamic_batch selects SchedulerDynamicBatch."
+                )
             vllm_config.scheduler_config.scheduler_cls = (
                 "vllm_ascend.core.scheduler_dynamic_batch.SchedulerDynamicBatch"
             )


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds a default-off `ShortRequestFirst` scheduling policy to reduce prefill head-of-line blocking under mixed prompt-length workloads.

Under the default FCFS-style waiting behavior, a long prefill request at the front of the queue can delay shorter prefills behind it and increase their TTFT. This change introduces a length-aware waiting queue for the recompute scheduler so shorter prefills can be admitted earlier while still preserving bounded fairness for long requests.

The main changes are:

- add `additional_config["short_request_first_config"]` with:
  - `enabled`: turns the policy on or off
  - `threshold`: defines the short/long prompt-token boundary
  - `long_max_wait_ms`: bounds long-request starvation by allowing aged long requests to bypass waiting short requests after the configured max wait
- add a `ShortRequestFirstRequestQueue` with three lanes:
  - `immediate`: requests that must stay ahead of length-based ordering
  - `short`: requests with `num_prompt_tokens <= threshold`
  - `long`: requests with `num_prompt_tokens > threshold`
- keep scheduler-critical requests ahead of the length-based queues:
  - immediate requests
  - recovery / requeue requests from recompute scheduling
- wire the policy into `RecomputeScheduler` when `short_request_first_config.enabled=true`
- validate and document the new user-facing config and behavior

This design is intentionally additive and conservative:
- it is opt-in and default-off
- it only changes waiting-queue admission order for prefill requests
- it keeps recovery traffic ahead of normal short/long prioritization
- it provides a starvation bound for long requests instead of allowing short requests to dominate indefinitely

### Does this PR introduce _any_ user-facing change?

Yes.

This PR adds a new user-facing scheduling option in `additional_config["short_request_first_config"]` for Ascend users running with the recompute scheduler. When enabled, short prefill requests may be scheduled ahead of longer waiting prefills, which can improve TTFT for short prompts under mixed prompt-length traffic.

It also adds user documentation describing:
- when to use `ShortRequestFirst`
- the meaning of `enabled`, `threshold`, and `long_max_wait_ms`
- the expected scheduling behavior and fairness tradeoffs

### How was this patch tested?

Added and updated UT/E2E coverage for config parsing, queue behavior, scheduler integration, and user-visible output safety:

- `tests/ut/test_ascend_config.py`
  - validates `short_request_first_config` defaults, overrides, and invalid values
- `tests/ut/core/test_short_request_first_scheduler.py`
  - validates short/long classification
  - validates dispatch priority across `immediate`, `short`, and `long`
  - validates `long_max_wait_ms` aging / starvation-bound behavior
- `tests/ut/core/test_short_request_first_scheduler_mixin.py`
  - validates recompute recovery requests are routed to the immediate lane
  - validates non-recovery requests still follow length-based classification
- `tests/ut/core/test_recompute_scheduler_short_request_first.py`
  - validates `RecomputeScheduler` wiring when the feature is enabled
  - validates scheduling order and long-request promotion behavior in scheduler flow
- `tests/e2e/pull_request/one_card/test_short_request_first_scheduling.py`
  - runs baseline vs `ShortRequestFirst`-enabled generation
  - verifies the feature preserves output correctness for the covered scenario

Also updated the user docs in:
- `docs/source/user_guide/configuration/additional_config.md`
- `docs/source/user_guide/feature_guide/short_request_first.md`

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
