### PR TITLE
[BugFix] Avoid 310P Mamba align postprocess hang for MTP

### DIFF
--- a/tests/ut/_310p/test_mamba_align_fallback_310p_source.py
+++ b/tests/ut/_310p/test_mamba_align_fallback_310p_source.py
@@ -48,6 +48,7 @@ def test_310p_postprocess_fallback_mirrors_state_copy_without_triton() -> None:
     assert "if accept_token_bias == 0:" in src
     assert "continue" in src
     assert "for mamba_group_id in ctx.mamba_group_ids:" in src
+    assert "get_numpy_array()" in src
     assert "copy_spec = state_copy_func(state, block_ids, src_block_idx, accept_token_bias + 1)" in src
     assert "_tensor_view_from_data_ptr(state, copy_spec.start_addr, copy_spec.num_elements)" in src
     assert "dst_state.copy_(src_state.clone())" in src

--- a/tests/ut/_310p/test_mamba_align_fallback_310p_source.py
+++ b/tests/ut/_310p/test_mamba_align_fallback_310p_source.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[4]
+ROOT = Path(__file__).resolve().parents[3]
 PATCH_MAMBA_UTILS = ROOT / "vllm_ascend" / "patch" / "worker" / "patch_mamba_utils.py"
 
 

--- a/tests/ut/patch/worker/test_patch_mamba_utils_source.py
+++ b/tests/ut/patch/worker/test_patch_mamba_utils_source.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source-level regressions for the 310P Mamba align fallback.
+
+The fallback is only active on 310P and depends on runtime NPU/vLLM state.
+Keep these checks import-free so they can run in lightweight DT environments
+while still guarding the important upstream semantic contract.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+PATCH_MAMBA_UTILS = ROOT / "vllm_ascend" / "patch" / "worker" / "patch_mamba_utils.py"
+
+
+def _func(path: Path, name: str) -> ast.FunctionDef:
+    for node in ast.parse(path.read_text()).body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"function {name} not found in {path}")
+
+
+def _src(node: ast.AST) -> str:
+    return ast.unparse(node)
+
+
+def test_310p_postprocess_fallback_preserves_upstream_metadata_semantics() -> None:
+    src = _src(_func(PATCH_MAMBA_UTILS, "_postprocess_mamba_align_gpu_cpu_fallback"))
+
+    assert "num_accepted_tokens_gpu" in src
+    assert "num_accepted_tokens_cpu_tensor[:num_reqs].copy_(num_accepted_tokens_gpu[:num_reqs])" in src
+    assert "num_tokens_running_state = num_computed_tokens[i] + num_scheduled_tokens[i] - num_draft_tokens[i]" in src
+    assert "new_num_computed_tokens = num_tokens_running_state + num_accepted_tokens[i] - 1" in src
+    assert "aligned_new_computed_tokens = new_num_computed_tokens // block_size * block_size" in src
+    assert "if aligned_new_computed_tokens < num_tokens_running_state:" in src
+    assert "if src_block_idx == dest_block_idx:" in src
+    assert "num_accepted_tokens_cpu_tensor[i] = 1" in src
+
+
+def test_310p_postprocess_fallback_mirrors_state_copy_without_triton() -> None:
+    src = _src(_func(PATCH_MAMBA_UTILS, "_postprocess_mamba_align_gpu_cpu_fallback"))
+
+    assert "run_fused_postprocess" not in src
+    assert "postprocess_mamba_fused_kernel" not in src
+    assert "accept_token_bias = aligned_new_computed_tokens - num_tokens_running_state" in src
+    assert "if accept_token_bias == 0:" in src
+    assert "continue" in src
+    assert "for mamba_group_id in ctx.mamba_group_ids:" in src
+    assert "copy_spec = state_copy_func(state, block_ids, src_block_idx, accept_token_bias + 1)" in src
+    assert "_tensor_view_from_data_ptr(state, copy_spec.start_addr, copy_spec.num_elements)" in src
+    assert "dst_state.copy_(src_state.clone())" in src

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -124,12 +124,19 @@ def _postprocess_mamba_align_gpu_cpu_fallback(
     assert ctx.num_computed_tokens_buf is not None
     assert ctx.num_draft_tokens_buf is not None
 
+    # stage_postprocess_inputs_to_gpu has already materialized the same
+    # per-request values into the CpuGpuBuffer numpy views. 310P cannot use the
+    # Triton fused kernel, so reuse the CPU views to mirror its decision logic.
     mamba_state_idx = ctx.mamba_state_idx_buf.np
     num_scheduled_tokens = ctx.num_scheduled_tokens_buf.np
     num_computed_tokens = ctx.num_computed_tokens_buf.np
     num_draft_tokens = ctx.num_draft_tokens_buf.np
     block_size = ctx.block_size
 
+    # Upstream initializes num_accepted_tokens_out from the real accepted-token
+    # counts, then only overwrites entries where src and dest are the same
+    # block. Preserve that default so the next preprocess keeps the right
+    # accept_token_bias when multiple draft tokens were accepted.
     num_accepted_tokens_cpu_tensor[:num_reqs].copy_(num_accepted_tokens_gpu[:num_reqs])
     num_accepted_tokens = input_batch.num_accepted_tokens_cpu
     for i in range(num_reqs):
@@ -143,10 +150,15 @@ def _postprocess_mamba_align_gpu_cpu_fallback(
         dest_block_idx = aligned_new_computed_tokens // block_size - 1
         accept_token_bias = aligned_new_computed_tokens - num_tokens_running_state
         if src_block_idx == dest_block_idx:
+            # Match the fused kernel: once the running state remains in the
+            # same block, the next preprocess should start from token bias 0.
             num_accepted_tokens_cpu_tensor[i] = 1
             if accept_token_bias == 0:
                 continue
 
+        # The upstream fused kernel also copies Mamba state in this postprocess
+        # step. Do the same with tensor views so 310P avoids Triton without
+        # changing where conv/temporal state lands before the next iteration.
         for mamba_group_id in ctx.mamba_group_ids:
             block_ids = input_batch.block_table[mamba_group_id].get_numpy()[i]
             dest_block_id = block_ids[dest_block_idx]

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -104,6 +104,31 @@ def _do_mamba_copy_block_torch(copy_bufs: mamba_utils.MambaCopyBuffers):
         dst_state.copy_(src_state.clone())
     copy_bufs._tensor_copy_pairs = []
 
+def _postprocess_mamba_align_gpu_cpu_fallback(
+    *,
+    bufs: "mamba_utils.MambaBuffers",
+    num_reqs: int,
+    num_accept_tokens_gpu: torch.Tensor,
+    num_accept_tokens_cpu_tensor: torch.Tensor,
+    input_batch: GPUInputBatch,
+    kv_cache_config: KVCacheConfig,
+    forward_context: dict[str, Any],
+    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
+) -> None:
+    """CPU fallback path for Mamba postprocess_mamba_align_gpu on 310P.(no Triton)
+
+    On 310P, the Triton fused kernel is not available. This fallback skips
+    the GPU-side state copy(which will be handled by preprocess_mamba at next step).
+    and reset num_accept_tokens_cpu_tensor to 1, matching the Triton's kernel's behavior.
+    when ''src_block_idx == dest_block_idx'',so that the next ''preprocess_mamba'' uses 
+    ''accept_tokens_bias = 0'' 
+    """
+    ## Set num_accept_tokens_cpu_tensor to 1, matching the Triton's kernel's behavior
+    ## behavior.
+    ## when ''src_block_idx == dest_block_idx'',so that the next ''preprocess_mamba'' uses 
+    ## ''accept_tokens_bias = 0'' 
+    ones = torch.ones(num_reqs, dtype=torch.int32, device=num_accept_tokens_gpu.device)
+    num_accept_tokens_cpu_tensor[:num_reqs].copy_(ones, non_blocking=True)
 
 def _batch_memcpy_unavailable(src_ptrs, dst_ptrs, sizes):
     raise RuntimeError(
@@ -120,7 +145,7 @@ else:
     mamba_utils.batch_memcpy = _batch_memcpy_unavailable
     mamba_utils.collect_mamba_copy_meta = _collect_mamba_copy_meta_torch
     mamba_utils.do_mamba_copy_block = _do_mamba_copy_block_torch
-
+    mamba_utils.postprocess_mamba_align_gpu = _postprocess_mamba_align_gpu_cpu_fallback
 
 def preprocess_mamba(
     scheduler_output: SchedulerOutput,

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -104,31 +104,46 @@ def _do_mamba_copy_block_torch(copy_bufs: mamba_utils.MambaCopyBuffers):
         dst_state.copy_(src_state.clone())
     copy_bufs._tensor_copy_pairs = []
 
+
 def _postprocess_mamba_align_gpu_cpu_fallback(
     *,
     bufs: "mamba_utils.MambaBuffers",
     num_reqs: int,
-    num_accept_tokens_gpu: torch.Tensor,
-    num_accept_tokens_cpu_tensor: torch.Tensor,
+    num_accepted_tokens_gpu: torch.Tensor,
+    num_accepted_tokens_cpu_tensor: torch.Tensor,
     input_batch: GPUInputBatch,
     kv_cache_config: KVCacheConfig,
     forward_context: dict[str, Any],
     mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
 ) -> None:
-    """CPU fallback path for Mamba postprocess_mamba_align_gpu on 310P.(no Triton)
+    """CPU fallback for 310P where the Triton fused postprocess is unavailable."""
+    ctx = bufs.postprocess_align
+    assert ctx is not None
+    assert ctx.mamba_state_idx_buf is not None
+    assert ctx.num_scheduled_tokens_buf is not None
+    assert ctx.num_computed_tokens_buf is not None
+    assert ctx.num_draft_tokens_buf is not None
 
-    On 310P, the Triton fused kernel is not available. This fallback skips
-    the GPU-side state copy(which will be handled by preprocess_mamba at next step).
-    and reset num_accept_tokens_cpu_tensor to 1, matching the Triton's kernel's behavior.
-    when ''src_block_idx == dest_block_idx'',so that the next ''preprocess_mamba'' uses 
-    ''accept_tokens_bias = 0'' 
-    """
-    ## Set num_accept_tokens_cpu_tensor to 1, matching the Triton's kernel's behavior
-    ## behavior.
-    ## when ''src_block_idx == dest_block_idx'',so that the next ''preprocess_mamba'' uses 
-    ## ''accept_tokens_bias = 0'' 
-    ones = torch.ones(num_reqs, dtype=torch.int32, device=num_accept_tokens_gpu.device)
-    num_accept_tokens_cpu_tensor[:num_reqs].copy_(ones, non_blocking=True)
+    mamba_state_idx = ctx.mamba_state_idx_buf.np
+    num_scheduled_tokens = ctx.num_scheduled_tokens_buf.np
+    num_computed_tokens = ctx.num_computed_tokens_buf.np
+    num_draft_tokens = ctx.num_draft_tokens_buf.np
+    block_size = ctx.block_size
+
+    num_accepted_tokens_cpu_tensor[:num_reqs].copy_(num_accepted_tokens_gpu[:num_reqs])
+    num_accepted_tokens = input_batch.num_accepted_tokens_cpu
+    for i in range(num_reqs):
+        num_tokens_running_state = num_computed_tokens[i] + num_scheduled_tokens[i] - num_draft_tokens[i]
+        new_num_computed_tokens = num_tokens_running_state + num_accepted_tokens[i] - 1
+        aligned_new_computed_tokens = new_num_computed_tokens // block_size * block_size
+        if aligned_new_computed_tokens < num_tokens_running_state:
+            continue
+
+        src_block_idx = mamba_state_idx[i]
+        dest_block_idx = aligned_new_computed_tokens // block_size - 1
+        if src_block_idx == dest_block_idx:
+            num_accepted_tokens_cpu_tensor[i] = 1
+
 
 def _batch_memcpy_unavailable(src_ptrs, dst_ptrs, sizes):
     raise RuntimeError(

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -160,7 +160,7 @@ def _postprocess_mamba_align_gpu_cpu_fallback(
         # step. Do the same with tensor views so 310P avoids Triton without
         # changing where conv/temporal state lands before the next iteration.
         for mamba_group_id in ctx.mamba_group_ids:
-            block_ids = input_batch.block_table[mamba_group_id].get_numpy()[i]
+            block_ids = input_batch.block_table[mamba_group_id].get_numpy_array()[i]
             dest_block_id = block_ids[dest_block_idx]
             layer_names = kv_cache_config.kv_cache_groups[mamba_group_id].layer_names
             for layer_name in layer_names:

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -192,6 +192,7 @@ else:
     mamba_utils.do_mamba_copy_block = _do_mamba_copy_block_torch
     mamba_utils.postprocess_mamba_align_gpu = _postprocess_mamba_align_gpu_cpu_fallback
 
+
 def preprocess_mamba(
     scheduler_output: SchedulerOutput,
     kv_cache_config: KVCacheConfig,

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -141,8 +141,26 @@ def _postprocess_mamba_align_gpu_cpu_fallback(
 
         src_block_idx = mamba_state_idx[i]
         dest_block_idx = aligned_new_computed_tokens // block_size - 1
+        accept_token_bias = aligned_new_computed_tokens - num_tokens_running_state
         if src_block_idx == dest_block_idx:
             num_accepted_tokens_cpu_tensor[i] = 1
+            if accept_token_bias == 0:
+                continue
+
+        for mamba_group_id in ctx.mamba_group_ids:
+            block_ids = input_batch.block_table[mamba_group_id].get_numpy()[i]
+            dest_block_id = block_ids[dest_block_idx]
+            layer_names = kv_cache_config.kv_cache_groups[mamba_group_id].layer_names
+            for layer_name in layer_names:
+                attention = forward_context[layer_name]
+                kv_caches: list[torch.Tensor] = attention.kv_cache
+                for state, state_copy_func in zip(kv_caches, mamba_state_copy_funcs):
+                    copy_spec = state_copy_func(state, block_ids, src_block_idx, accept_token_bias + 1)
+                    src_state = _tensor_view_from_data_ptr(state, copy_spec.start_addr, copy_spec.num_elements)
+                    dst_state = _tensor_view_from_data_ptr(
+                        state, state[dest_block_id].data_ptr(), copy_spec.num_elements
+                    )
+                    dst_state.copy_(src_state.clone())
 
 
 def _batch_memcpy_unavailable(src_ptrs, dst_ptrs, sizes):


### PR DESCRIPTION
## What

This PR adds a 310P-specific fallback for the Mamba align-mode postprocess path used by MTP/spec decode.

On 310P, the fallback avoids launching the Triton fused `postprocess_mamba_align_gpu` path. It updates accepted-token CPU metadata and mirrors the Mamba state-copy behavior through a CPU-side tensor-copy path.

## Why

MTP with `enable-prefix-caching` and `mamba_cache_mode=align` can hang on 310P when the Mamba align postprocess path reaches the Triton fused kernel. 310P already uses non-Triton fallbacks for related Mamba copy operations, so this extends that behavior to the align postprocess entry point.

## Implementation

- Keep the existing fused Triton path for non-310P devices.
- On 310P, patch `postprocess_mamba_align_gpu` to a CPU fallback.
- Preserve the real accepted-token counts by default.
- Recompute the same block-alignment condition used by upstream postprocess.
- Reset accepted-token count to 1 only when `src_block_idx == dest_block_idx`, matching upstream metadata semantics.
- Copy Mamba state with the existing state-copy funcs when the upstream postprocess condition requires a state move, avoiding the Triton fused kernel while preserving state placement.

## Impact

This change is scoped to 310P. Non-310P devices keep using the existing Triton fused postprocess implementation.

## Validation

- Verified the target scenario no longer hangs on 310P with MTP + `enable-prefix-caching` + `mamba_cache_mode=align`.
- Verified removing `enable-prefix-caching` or `mamba_cache_mode=align` also avoids the hang, matching the isolated failure condition.
- Ran `python -m py_compile vllm_ascend/patch/worker/patch_mamba_utils.py`.
- Ran `git diff --check`.
<img width="1510" height="433" alt="image" src="https://github.com/user-attachments/assets/959a19b7-030b-4cac-8650-fdb4c467a433" />

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
