### PR TITLE
[CI] Fix main2main workflow to enable vllm-ascend cache

### DIFF
--- a/.github/workflows/schedule_main2main.yaml
+++ b/.github/workflows/schedule_main2main.yaml
@@ -233,10 +233,10 @@ jobs:
         uses: runs-on/cache/restore@v5
         with:
           path: |
-            ${{ env.WORK_REPO_DIR }}/vllm_ascend/_cann_ops_custom
-            ${{ env.WORK_REPO_DIR }}/vllm_ascend/*.so
-            ${{ env.WORK_REPO_DIR }}/vllm_ascend/lib
-            ${{ env.WORK_REPO_DIR }}/vllm_ascend/include
+            vllm-ascend/vllm_ascend/_cann_ops_custom
+            vllm-ascend/vllm_ascend/*.so
+            vllm-ascend/vllm_ascend/lib
+            vllm-ascend/vllm_ascend/include
           key: vllm-ascend-build-v1-${{ steps.get_arch.outputs.arch }}-${{ env.MAIN2MAIN_IMAGE_TAG }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
           restore-keys: |
             vllm-ascend-build-v1-${{ steps.get_arch.outputs.arch }}-${{ env.MAIN2MAIN_IMAGE_TAG }}-
@@ -281,7 +281,7 @@ jobs:
           pip install uc-manager
           uv pip install -r requirements-dev.txt
           uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
-          if find vllm_ascend -maxdepth 1 -name '*.so' -type f 2>/dev/null | grep -q .; then
+          if find "${{ env.WORK_REPO_DIR }}/vllm_ascend" -maxdepth 1 -name '*.so' -type f 2>/dev/null | grep -q .; then
             echo "CSRC cache hit: .so files found, skip kernel compilation"
             COMPILE_CUSTOM_KERNELS=0 uv pip install -e .
           else
@@ -294,10 +294,10 @@ jobs:
         uses: runs-on/cache/save@v5
         with:
           path: |
-            ${{ env.WORK_REPO_DIR }}/vllm_ascend/_cann_ops_custom
-            ${{ env.WORK_REPO_DIR }}/vllm_ascend/*.so
-            ${{ env.WORK_REPO_DIR }}/vllm_ascend/lib
-            ${{ env.WORK_REPO_DIR }}/vllm_ascend/include
+            vllm-ascend/vllm_ascend/_cann_ops_custom
+            vllm-ascend/vllm_ascend/*.so
+            vllm-ascend/vllm_ascend/lib
+            vllm-ascend/vllm_ascend/include
           key: vllm-ascend-build-v1-${{ steps.get_arch.outputs.arch }}-${{ env.MAIN2MAIN_IMAGE_TAG }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Run main2main flow


### PR DESCRIPTION
### What this PR does / why we need it?

Fix csrc cache path and align checkout layout

- vllm and vllm-ascend as sibling dirs under workspace (drop exclude hack)
- csrc cache `path:` relative not absolute — tar keeps dir structure so
  restore lands .so at the right level (was extracting to workspace root)
- `.so` check uses absolute path, not working-directory-relative
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
