### PR TITLE
[CI] Remove restore-keys from main2mian workflow cache

### DIFF
--- a/.github/workflows/schedule_main2main.yaml
+++ b/.github/workflows/schedule_main2main.yaml
@@ -238,8 +238,6 @@ jobs:
             vllm-ascend/vllm_ascend/lib
             vllm-ascend/vllm_ascend/include
           key: vllm-ascend-build-v1-${{ steps.get_arch.outputs.arch }}-${{ env.MAIN2MAIN_IMAGE_TAG }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
-          restore-keys: |
-            vllm-ascend-build-v1-${{ steps.get_arch.outputs.arch }}-${{ env.MAIN2MAIN_IMAGE_TAG }}-
 
       - name: Create working branch
         id: branch


### PR DESCRIPTION
### What this PR does / why we need it?
Remove restore-keys from main2mian workflow cache
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
