### PR TITLE
[Bugfix] Fix GLM-5.1 IndexCache weight loading

### DIFF
--- a/tests/ut/patch/worker/test_patch_deepseek_v2.py
+++ b/tests/ut/patch/worker/test_patch_deepseek_v2.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from vllm_ascend.patch.worker.patch_deepseek_v2 import _should_skip_indexer_init
+
+
+def _config(**overrides) -> SimpleNamespace:
+    values = {"num_hidden_layers": 80}
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_glm51_skip_topk_keeps_per_layer_indexer():
+    assert not _should_skip_indexer_init(
+        _config(),
+        "model.layers.2.self_attn",
+        skip_topk=True,
+    )
+
+
+def test_glm52_shared_layer_skips_indexer_init():
+    assert _should_skip_indexer_init(
+        _config(indexer_types=["full", "full", "shared"]),
+        "model.layers.2.self_attn",
+        skip_topk=True,
+    )
+
+
+def test_mtp_layer_keeps_indexer():
+    indexer_types = ["full"] * 80 + ["shared"]
+    assert not _should_skip_indexer_init(
+        _config(indexer_types=indexer_types),
+        "model.layers.80.self_attn",
+        skip_topk=True,
+    )

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -760,14 +760,16 @@
 #       Remove this patch when vllm supports rotary quant or pluggable `MultiTokenPredictorLayer`.
 # ** 19a. File: worker/patch_deepseek_v2.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#   1. `vllm.model_executor.models.deepseek_v2.DeepseekV2Attention.__init__`
+#   1. `vllm.model_executor.models.deepseek_v2.DeepseekV2MLAAttention.__init__`
 #    Why:
-#       GLM/DeepSeek DSA models can skip topk on selected layers. Those layers
-#       should not initialize `Indexer`, while MTP layers still need full indexer
-#       initialization.
+#       GLM-5.2 checkpoints omit `Indexer` weights on shared-indexer layers,
+#       while GLM-5.1 IndexCache overrides only skip top-k computation and keep
+#       per-layer `Indexer` weights. Treating both layouts alike breaks GLM-5.1
+#       weight loading.
 #    How:
-#       Wrap `DeepseekV2Attention.__init__` and skip `Indexer` construction on
-#       backbone layers whose config marks topk as skipped.
+#       Skip `Indexer` construction only when the layer both skips top-k and is
+#       explicitly marked `shared` in `indexer_types`. MTP layers always retain
+#       a complete `Indexer`.
 #    Related PR (if no, explain why):
 #       https://github.com/vllm-project/vllm/pull/45895
 #    Future Plan:

--- a/vllm_ascend/patch/worker/patch_deepseek_v2.py
+++ b/vllm_ascend/patch/worker/patch_deepseek_v2.py
@@ -24,6 +24,27 @@ from vllm.model_executor.models.deepseek_v2 import (
 from vllm.model_executor.models.utils import extract_layer_index
 
 
+def _should_skip_indexer_init(
+    config: DeepseekV2Config | DeepseekV3Config,
+    prefix: str,
+    skip_topk: bool,
+) -> bool:
+    if not skip_topk:
+        return False
+
+    layer_id = extract_layer_index(prefix)
+    num_hidden_layers = getattr(config, "num_hidden_layers", None)
+    if num_hidden_layers is not None and layer_id >= num_hidden_layers:
+        return False
+
+    # GLM-5.2 describes checkpoint-level shared indexers explicitly. Runtime
+    # IndexCache overrides on GLM-5.1 only skip top-k computation; its
+    # checkpoint still contains an Indexer for every layer.
+    indexer_types = getattr(config, "indexer_types", None)
+    indexer_type = indexer_types[layer_id] if indexer_types is not None and layer_id < len(indexer_types) else None
+    return isinstance(indexer_type, str) and indexer_type.lower() == "shared"
+
+
 def _deepseek_v2_mla_attention_init(
     self,
     vllm_config: VllmConfig,
@@ -161,10 +182,8 @@ def _deepseek_v2_mla_attention_init(
 
     # IndexCache config.
     #
-    # PR #45895 的关键修改是：
-    # 1. 在创建 Indexer 前先计算当前层是否 skip_topk；
-    # 2. skip_topk 的 backbone 层不创建 Indexer；
-    # 3. MTP/nextn 层即使命中 skip pattern，也必须创建完整 Indexer。
+    # skip_topk controls top-k reuse. Indexer initialization is skipped only
+    # when the checkpoint marks this layer as sharing another layer's Indexer.
     _skip_topk = False
     _index_topk_freq = getattr(
         config,
@@ -196,19 +215,8 @@ def _deepseek_v2_mla_attention_init(
     elif 0 <= layer_id < len(_index_topk_pattern):
         _skip_topk = _index_topk_pattern[layer_id] == "S"
 
-    # Skip pattern only governs backbone layers.
-    #
-    # MTP/nextn layers must always build a complete Indexer. The MTP
-    # implementation computes top-k indices at draft step 0, then changes
-    # skip_topk dynamically during the remaining speculative iterations.
-    _num_hidden_layers = getattr(
-        config,
-        "num_hidden_layers",
-        None,
-    )
-    is_mtp_layer = _num_hidden_layers is not None and layer_id >= _num_hidden_layers
-
-    if self.is_v32 and (not _skip_topk or is_mtp_layer):
+    skip_indexer_init = _should_skip_indexer_init(config, prefix, _skip_topk)
+    if self.is_v32 and not skip_indexer_init:
         self.indexer_rope_emb = get_rope(
             qk_rope_head_dim,
             max_position=max_position_embeddings,


### PR DESCRIPTION
## What this PR does / why we need it?

The existing patch treated `skip_topk=True` as proof that the checkpoint omitted the layer's `Indexer`. This is valid for GLM-5.2 shared-indexer layers, but not for GLM-5.1 when IndexCache is enabled through runtime HF overrides. GLM-5.1 checkpoints still contain `indexer.*` weights for every layer, so removing the module makes `AutoWeightsLoader` reject those weights.

This change separates top-k reuse from checkpoint structure: `skip_topk` controls computation, while `indexer_types[layer_id] == "shared"` controls whether the module is omitted.

- Keep per-layer `Indexer` modules for GLM-5.1 when IndexCache is enabled through `use_index_cache` and `index_topk_freq` overrides.
- Skip `Indexer` initialization only for GLM-5.2 layers explicitly marked as `shared` in `indexer_types`.
- Keep complete `Indexer` modules for MTP layers.
- Add focused unit coverage for GLM-5.1, GLM-5.2 shared-indexer, and MTP behavior.

## How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
