### PR TITLE
[Feature] Add e5-mistral embedding model test

### DIFF
--- a/docs/source/tutorials/models/e5-mistral-7b-instruct.md
+++ b/docs/source/tutorials/models/e5-mistral-7b-instruct.md
@@ -1,0 +1,149 @@
+# e5-mistral-7b-instruct
+
+## Introduction
+
+`e5-mistral-7b-instruct` is a text embedding model released by `intfloat` and built on `Mistral-7B`.
+It is designed for retrieval tasks where queries are formatted with a task instruction and documents are
+embedded as plain text. This guide describes how to run online and offline embedding inference with
+vLLM Ascend.
+
+## Supported Features
+
+Refer to [supported features](../../user_guide/support_matrix/supported_models.md) for the full model support
+matrix. In vLLM Ascend, this model uses the pooling runner with `embed` conversion. The SentenceTransformers
+checkpoint provides last-token pooling and normalized 4096-dimensional embeddings.
+
+## Environment Preparation
+
+### Model Weight
+
+- `e5-mistral-7b-instruct` FP16 checkpoint:
+  [intfloat/e5-mistral-7b-instruct](https://huggingface.co/intfloat/e5-mistral-7b-instruct)
+
+The model can run on a single 64 GB Ascend NPU for functional validation. Download the model weights to
+a shared cache or local path, for example `/data/models/e5-mistral-7b-instruct`.
+
+### Installation
+
+You can use the official docker image or build `vllm-ascend` from source. For docker setup, refer to
+[using docker](../../installation.md#set-up-using-docker). For source installation, refer to
+[installation](../../installation.md).
+
+## Deployment
+
+### Online Inference
+
+Start an OpenAI-compatible embeddings service:
+
+```bash
+vllm serve intfloat/e5-mistral-7b-instruct \
+  --runner pooling \
+  --served-model-name e5-mistral-7b-instruct \
+  --tensor-parallel-size 1 \
+  --dtype float16 \
+  --max-model-len 512 \
+  --gpu-memory-utilization 0.8 \
+  --enforce-eager \
+  --host 0.0.0.0 \
+  --port 8000
+```
+
+For a local checkpoint, replace `intfloat/e5-mistral-7b-instruct` with the local model path.
+
+## Functional Verification
+
+The query side should include the retrieval instruction. Documents do not need the instruction prefix.
+
+```bash
+curl http://localhost:8000/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "e5-mistral-7b-instruct",
+    "input": [
+      "Instruct: Retrieve passages that answer the query\nQuery: What is the capital of China?",
+      "The capital of China is Beijing."
+    ]
+  }'
+```
+
+A valid response returns one 4096-dimensional embedding for each input.
+
+### Offline Inference
+
+```python
+import torch
+from vllm import LLM
+
+
+def format_query(task: str, query: str) -> str:
+    return f"Instruct: {task}\nQuery: {query}"
+
+
+model = "intfloat/e5-mistral-7b-instruct"
+task = "Given a web search query, retrieve relevant passages that answer the query"
+
+queries = [
+    format_query(task, "What is the capital of China?"),
+    format_query(task, "Explain gravity"),
+]
+documents = [
+    "The capital of China is Beijing.",
+    "Gravity is a force that attracts two bodies towards each other and gives weight to physical objects.",
+]
+
+llm = LLM(
+    model=model,
+    runner="pooling",
+    max_model_len=512,
+    dtype="float16",
+    tensor_parallel_size=1,
+    gpu_memory_utilization=0.8,
+    enforce_eager=True,
+)
+
+outputs = llm.embed(queries + documents)
+embeddings = torch.tensor([output.outputs.embedding for output in outputs])
+scores = embeddings[:2] @ embeddings[2:].T
+print(scores.tolist())
+```
+
+The relevant document should receive the highest score for each query.
+
+## Accuracy Evaluation
+
+The model was verified with a retrieval smoke test that checks embedding dimension, L2 normalization,
+and top-1 ranking on two query-document pairs.
+
+| Category | Dataset | Metric | Result |
+|----------|---------|--------|--------|
+| Functional | e5_mistral_retrieval_smoke | embedding_dimension | 4096 |
+| Functional | e5_mistral_retrieval_smoke | mean_l2_norm | 1.0 |
+| Functional | e5_mistral_retrieval_smoke | top1_accuracy | 1.0 |
+| Functional | e5_mistral_retrieval_smoke | min_score_margin | 0.273 |
+
+Run the e2e test with a local checkpoint:
+
+```bash
+export E5_MISTRAL_MODEL_PATH=/data/models/e5-mistral-7b-instruct
+python -m pytest tests/e2e/models/test_embedding_eval_correctness.py \
+  --config tests/e2e/models/configs/e5-mistral-7b-instruct.yaml
+```
+
+## Performance
+
+Use the OpenAI embeddings benchmark after starting the service:
+
+```bash
+vllm bench serve \
+  --model e5-mistral-7b-instruct \
+  --backend openai-embeddings \
+  --dataset-name random \
+  --endpoint /v1/embeddings \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --random-input 200 \
+  --save-result \
+  --result-dir ./
+```
+
+Throughput and latency depend on prompt length, batch size, `max_model_len`, and available NPU memory.

--- a/docs/source/tutorials/models/index.md
+++ b/docs/source/tutorials/models/index.md
@@ -14,6 +14,7 @@ Qwen3-VL-235B-A22B-Instruct.md
 Qwen3-Coder-30B-A3B.md
 Qwen3_embedding.md
 Qwen3-VL-Embedding.md
+e5-mistral-7b-instruct.md
 Qwen3_reranker.md
 Qwen3-VL-Reranker.md
 Qwen3-Next.md

--- a/tests/e2e/models/configs/accuracy.txt
+++ b/tests/e2e/models/configs/accuracy.txt
@@ -12,3 +12,4 @@ Molmo-7B-D-0924.yaml
 llava-onevision-qwen2-0.5b-ov-hf.yaml
 Llama-3.2-3B-Instruct.yaml
 Qwen3-ASR-1.7B.yaml
+e5-mistral-7b-instruct.yaml

--- a/tests/e2e/models/configs/e5-mistral-7b-instruct.yaml
+++ b/tests/e2e/models/configs/e5-mistral-7b-instruct.yaml
@@ -1,0 +1,42 @@
+model_name: "intfloat/e5-mistral-7b-instruct"
+model_type: "vllm-embedding"
+hardware: "Atlas A2/A3 Series"
+
+serve:
+  runner: "pooling"
+  tensor_parallel_size: 1
+  dtype: "float16"
+  max_model_len: 512
+  gpu_memory_utilization: 0.8
+  enforce_eager: true
+
+# Set this environment variable when validating with a local checkpoint.
+local_model_path_env: "E5_MISTRAL_MODEL_PATH"
+embedding_dimension: 4096
+expected_l2_norm: 1.0
+norm_atol: 0.001
+
+tasks:
+  - name: "e5_mistral_retrieval_smoke"
+    instruction: "Given a web search query, retrieve relevant passages that answer the query"
+    queries:
+      - text: "What is the capital of China?"
+        relevant_doc: 0
+      - text: "Explain gravity"
+        relevant_doc: 1
+    documents:
+      - "The capital of China is Beijing."
+      - "Gravity is a force that attracts two bodies towards each other and gives weight to physical objects."
+    min_score_margin: 0.05
+    metrics:
+      - name: "top1_accuracy"
+        value: 1.0
+      - name: "embedding_dimension"
+        value: 4096
+      - name: "mean_l2_norm"
+        value: 1.0
+      - name: "min_score_margin"
+        value: 0.05
+
+limit: 4
+batch_size: 4

--- a/tests/e2e/models/test_embedding_eval_correctness.py
+++ b/tests/e2e/models/test_embedding_eval_correctness.py
@@ -1,0 +1,217 @@
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pytest
+import torch
+import yaml
+from jinja2 import Environment, FileSystemLoader
+
+from tests.e2e.conftest import VllmRunner
+
+RTOL = 0.05
+TEST_DIR = os.path.dirname(__file__)
+
+
+@dataclass
+class EnvConfig:
+    vllm_version: str
+    vllm_commit: str
+    vllm_ascend_version: str
+    vllm_ascend_commit: str
+    cann_version: str
+    torch_version: str
+    torch_npu_version: str
+
+
+@pytest.fixture
+def env_config() -> EnvConfig:
+    return EnvConfig(
+        vllm_version=os.getenv("VLLM_VERSION", "unknown"),
+        vllm_commit=os.getenv("VLLM_COMMIT", "unknown"),
+        vllm_ascend_version=os.getenv("VLLM_ASCEND_VERSION", "unknown"),
+        vllm_ascend_commit=os.getenv("VLLM_ASCEND_COMMIT", "unknown"),
+        cann_version=os.getenv("CANN_VERSION", "unknown"),
+        torch_version=os.getenv("TORCH_VERSION", "unknown"),
+        torch_npu_version=os.getenv("TORCH_NPU_VERSION", "unknown"),
+    )
+
+
+def build_runner_kwargs(eval_config: dict[str, Any], tp_size: str) -> dict[str, Any]:
+    serve_cfg = eval_config.get("serve", {})
+    effective_tp = int(tp_size) if (tp_size and tp_size != "1") else int(serve_cfg.get("tensor_parallel_size", 1))
+
+    runner_kwargs: dict[str, Any] = {
+        k: v
+        for k, v in {
+            "runner": serve_cfg.get("runner", "pooling"),
+            "dtype": serve_cfg.get("dtype", "auto"),
+            "tensor_parallel_size": effective_tp,
+            "max_model_len": serve_cfg.get("max_model_len"),
+            "gpu_memory_utilization": serve_cfg.get("gpu_memory_utilization"),
+            "enforce_eager": serve_cfg.get("enforce_eager", False),
+            "enable_prefix_caching": serve_cfg.get("enable_prefix_caching"),
+            "cudagraph_capture_sizes": serve_cfg.get("cudagraph_capture_sizes"),
+        }.items()
+        if v is not None
+    }
+    return runner_kwargs
+
+
+def resolve_model_name(eval_config: dict[str, Any]) -> str:
+    model_name = eval_config["model_name"]
+    local_path_env = eval_config.get("local_model_path_env")
+    if local_path_env:
+        model_name = os.getenv(local_path_env, model_name)
+    return model_name
+
+
+def format_query(instruction: str, query: str) -> str:
+    return f"Instruct: {instruction}\nQuery: {query}"
+
+
+def generate_embedding_report(
+    eval_config: dict[str, Any],
+    report_data: dict[str, list[dict[str, Any]]],
+    report_dir: str,
+    env_config: EnvConfig,
+    runner_kwargs: dict[str, Any],
+) -> None:
+    jinja_env = Environment(loader=FileSystemLoader(TEST_DIR))
+    template = jinja_env.get_template("report_template.md")
+
+    tp_size = runner_kwargs.get("tensor_parallel_size", 1)
+    execution_model = "Eager" if runner_kwargs.get("enforce_eager", False) else "ACLGraph"
+    model_args_str = ",".join(f"{k}={v}" for k, v in runner_kwargs.items())
+
+    report_content = template.render(
+        vllm_version=env_config.vllm_version,
+        vllm_commit=env_config.vllm_commit,
+        vllm_ascend_version=env_config.vllm_ascend_version,
+        vllm_ascend_commit=env_config.vllm_ascend_commit,
+        cann_version=env_config.cann_version,
+        torch_version=env_config.torch_version,
+        torch_npu_version=env_config.torch_npu_version,
+        hardware=eval_config.get("hardware", "unknown"),
+        model_name=eval_config["model_name"],
+        model_args=f"'{model_args_str}'",
+        model_type=eval_config.get("model_type", "vllm-embedding"),
+        datasets=",".join(t["name"] for t in eval_config["tasks"]),
+        apply_chat_template=False,
+        fewshot_as_multiturn=False,
+        limit=eval_config.get("limit", "N/A"),
+        batch_size=eval_config.get("batch_size", 4),
+        num_fewshot="N/A",
+        rows=report_data["rows"],
+        parallel_mode=f"TP{tp_size}",
+        execution_model=execution_model,
+        show_command=False,
+    )
+
+    report_path = os.path.join(report_dir, f"{os.path.basename(eval_config['model_name'])}.md")
+    os.makedirs(os.path.dirname(report_path), exist_ok=True)
+    with open(report_path, "w", encoding="utf-8") as f:
+        f.write(report_content)
+
+
+def test_embedding_eval_param(config_filename, tp_size, report_dir, env_config):
+    eval_config = yaml.safe_load(config_filename.read_text(encoding="utf-8"))
+
+    if eval_config.get("model_type", "vllm") != "vllm-embedding":
+        pytest.skip(f"Skipping non-embedding config (model_type={eval_config.get('model_type', 'vllm')})")
+
+    model_name = resolve_model_name(eval_config)
+    runner_kwargs = build_runner_kwargs(eval_config, tp_size)
+    expected_norm = float(eval_config.get("expected_l2_norm", 1.0))
+    norm_atol = float(eval_config.get("norm_atol", 1e-3))
+
+    print(f"\nLoading embedding model: {model_name}")
+    print(f"  VllmRunner kwargs: {runner_kwargs}")
+
+    success = True
+    report_data: dict[str, list[dict[str, Any]]] = {"rows": []}
+
+    with VllmRunner(model_name, **runner_kwargs) as vllm_model:
+        for task in eval_config["tasks"]:
+            task_name = task["name"]
+            instruction = task["instruction"]
+            documents = task["documents"]
+            queries = task["queries"]
+
+            input_texts = [format_query(instruction, item["text"]) for item in queries] + documents
+            embeddings = torch.tensor(vllm_model.embed(input_texts), dtype=torch.float32)
+            query_embeddings = embeddings[: len(queries)]
+            document_embeddings = embeddings[len(queries) :]
+            scores = query_embeddings @ document_embeddings.T
+
+            measured_dimension = int(embeddings.shape[-1])
+            norms = embeddings.norm(dim=1)
+            mean_norm = round(float(norms.mean().item()), 4)
+
+            top1_correct = 0
+            margins: list[float] = []
+            for query_idx, query in enumerate(queries):
+                relevant_doc = int(query["relevant_doc"])
+                query_scores = scores[query_idx]
+                ranking = torch.argsort(query_scores, descending=True).tolist()
+                if ranking[0] == relevant_doc:
+                    top1_correct += 1
+                negative_scores = [
+                    float(score) for doc_idx, score in enumerate(query_scores) if doc_idx != relevant_doc
+                ]
+                margin = float(query_scores[relevant_doc]) - max(negative_scores)
+                margins.append(margin)
+                print(
+                    f"{task_name} | query={query_idx} | relevant_doc={relevant_doc} | "
+                    f"scores={[round(float(s), 4) for s in query_scores]} | margin={margin:.4f}"
+                )
+
+            top1_accuracy = round(top1_correct / len(queries), 4)
+            min_margin = round(min(margins), 4)
+
+            metric_values = {
+                "top1_accuracy": top1_accuracy,
+                "embedding_dimension": measured_dimension,
+                "mean_l2_norm": mean_norm,
+                "min_score_margin": min_margin,
+            }
+
+            for metric in task["metrics"]:
+                metric_name = metric["name"]
+                expected_value = metric["value"]
+                measured_value = metric_values[metric_name]
+
+                if metric_name == "embedding_dimension":
+                    task_success = measured_value == expected_value
+                elif metric_name == "mean_l2_norm":
+                    task_success = bool(np.isclose(expected_value, measured_value, atol=norm_atol))
+                else:
+                    task_success = measured_value >= expected_value * (1 - RTOL)
+
+                success = success and task_success
+                status = "PASS" if task_success else "FAIL"
+                print(f"{task_name} | {metric_name}: expected={expected_value} | measured={measured_value} | {status}")
+
+                report_data["rows"].append(
+                    {
+                        "task": task_name,
+                        "metric": metric_name,
+                        "value": f"{status}:{measured_value}",
+                        "stderr": 0.0,
+                    }
+                )
+
+            norm_success = bool(
+                torch.allclose(
+                    norms,
+                    torch.full_like(norms, expected_norm),
+                    atol=norm_atol,
+                    rtol=0.0,
+                )
+            )
+            success = success and norm_success
+            assert norm_success, f"Embedding L2 norms are not close to {expected_norm}: {norms.tolist()}"
+
+    generate_embedding_report(eval_config, report_data, report_dir, env_config, runner_kwargs)
+    assert success, "One or more embedding checks did not meet the configured threshold."

--- a/tests/e2e/models/test_lm_eval_correctness.py
+++ b/tests/e2e/models/test_lm_eval_correctness.py
@@ -109,8 +109,9 @@ def generate_report(tp_size, eval_config, report_data, report_dir, env_config):
 def test_lm_eval_correctness_param(config_filename, tp_size, report_dir, env_config):
     eval_config = yaml.safe_load(config_filename.read_text(encoding="utf-8"))
 
-    if eval_config.get("model_type", "vllm") == "vllm-asr":
-        pytest.skip("Skipping ASR config, use test_asr_eval.py instead")
+    model_type = eval_config.get("model_type", "vllm")
+    if model_type not in {"vllm", "vllm-vlm"}:
+        pytest.skip(f"Skipping non-LM config (model_type={model_type})")
 
     model_args = build_model_args(eval_config, tp_size)
     success = True


### PR DESCRIPTION
## Summary

- Add config-driven e2e coverage for `intfloat/e5-mistral-7b-instruct` embedding inference on vLLM Ascend.
- Add a model tutorial covering online `/v1/embeddings` serving and offline `LLM.embed()` usage.
- Add the issue skill note for AI-assisted model adaptation experience.

## Validation

- `python -m ruff check tests/e2e/models/test_embedding_eval_correctness.py tests/e2e/models/test_lm_eval_correctness.py`
- `python -m ruff format --check tests/e2e/models/test_embedding_eval_correctness.py tests/e2e/models/test_lm_eval_correctness.py`
- `python -m py_compile tests/e2e/models/test_embedding_eval_correctness.py tests/e2e/models/test_lm_eval_correctness.py`
- `ASCEND_RT_VISIBLE_DEVICES=1 ASCEND_VISIBLE_DEVICES=1 E5_MISTRAL_MODEL_PATH=/path/to/e5-mistral-7b-instruct python -m pytest tests/e2e/models/test_embedding_eval_correctness.py --config tests/e2e/models/configs/e5-mistral-7b-instruct.yaml --report-dir /tmp/vllm-ascend-e5-report -s`
- `ASCEND_RT_VISIBLE_DEVICES=1 ASCEND_VISIBLE_DEVICES=1 E5_MISTRAL_MODEL_PATH=/path/to/e5-mistral-7b-instruct python -m pytest tests/e2e/models/test_embedding_eval_correctness.py --config-list-file tests/e2e/models/configs/accuracy.txt --report-dir /tmp/vllm-ascend-e5-report-list -q -s`

Results:

- Single config: `1 passed`
- Config list: `1 passed, 14 skipped`
- Metrics: `top1_accuracy=1.0`, `embedding_dimension=4096`, `mean_l2_norm=1.0`, `min_score_margin=0.273`

Related to vllm-project/vllm-ascend#10679
Related to vllm-project/vllm-ascend#9079

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
