### PR TITLE
[BugFix] Revert "[Misc] Bump Mooncake to v0.3.11.post1 in Dockerfiles (#10891)"

### DIFF
--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -177,11 +177,11 @@ jobs:
             libcurl4
           ldconfig
 
+          MOONCAKE_WHEEL="mooncake_transfer_engine_ascend-0.3.9-cp312-cp312-manylinux_2_35_aarch64.whl"
           pip install --no-cache-dir --no-deps \
-            -i https://mirrors.aliyun.com/pypi/simple/ \
-            mooncake-transfer-engine-npu==0.3.11.post1
+            "https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/vllm-ascend/${MOONCAKE_WHEEL}"
 
-          pip show mooncake-transfer-engine-npu || true
+          pip show mooncake-transfer-engine-ascend || true
 
       - name: Install vllm-project/vllm-ascend with device
         if: ${{ matrix.group.npu_type != 'cpu' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 FROM quay.io/ascend/cann:9.0.0-910b-ubuntu22.04-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG MOONCAKE_TAG="v0.3.11.post1"
+ARG MOONCAKE_TAG="v0.3.9"
 
 WORKDIR /workspace
 

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -18,7 +18,7 @@
 FROM quay.io/ascend/cann:9.0.0-a3-ubuntu22.04-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG MOONCAKE_TAG=v0.3.11.post1
+ARG MOONCAKE_TAG=v0.3.9
 
 COPY ./tools/mooncake_installer.sh /vllm-workspace/
 

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -18,7 +18,7 @@
 FROM quay.io/ascend/cann:9.0.0-a3-openeuler24.03-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG MOONCAKE_TAG="v0.3.11.post1"
+ARG MOONCAKE_TAG="v0.3.9"
 
 WORKDIR /workspace
 

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -18,7 +18,7 @@
 FROM quay.io/ascend/cann:9.0.0-950-ubuntu22.04-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG MOONCAKE_TAG=v0.3.11.post1
+ARG MOONCAKE_TAG=v0.3.9
 
 COPY ./tools/mooncake_installer.sh /vllm-workspace/
 

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -18,7 +18,7 @@
 FROM quay.io/ascend/cann:9.0.0-950-openeuler24.03-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG MOONCAKE_TAG="v0.3.11.post1"
+ARG MOONCAKE_TAG="v0.3.9"
 
 WORKDIR /workspace
 

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -18,7 +18,7 @@
 FROM quay.io/ascend/cann:9.0.0-910b-openeuler24.03-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG MOONCAKE_TAG="v0.3.11.post1"
+ARG MOONCAKE_TAG="v0.3.9"
 
 WORKDIR /workspace
 

--- a/docs/source/locale/zh_CN/LC_MESSAGES/user_guide/feature_guide/kv_pool.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/user_guide/feature_guide/kv_pool.po
@@ -76,8 +76,8 @@ msgid "vLLM-Ascend：main branch"
 msgstr "vLLM-Ascend：main 分支"
 
 #: ../../source/user_guide/feature_guide/kv_pool.md:17
-msgid "mooncake：>= 0.3.11.post1"
-msgstr "mooncake：>= 0.3.11.post1"
+msgid "mooncake：>= 0.3.9"
+msgstr "mooncake：>= 0.3.9"
 
 #: ../../source/user_guide/feature_guide/kv_pool.md:19
 msgid "KV Pool Parameter Description"
@@ -294,9 +294,9 @@ msgstr "800 I/T A3 系列"
 
 #: ../../source/user_guide/feature_guide/kv_pool.md
 msgid ""
-"HDK >= 26.0<br>or HDK >= 25.5 with mooncake >= v0.3.11.post1<br>CANN >= "
+"HDK >= 26.0<br>or HDK >= 25.5 with mooncake >= v0.3.11<br>CANN >= "
 "9.0.0<br>LingQu Computing Network >= 1.5"
-msgstr "HDK >= 26.0<br>或 HDK >= 25.5 且 mooncake >= v0.3.11.post1<br>CANN >= 9.0.0<br>LingQu 计算网络 >= 1.5"
+msgstr "HDK >= 26.0<br>或 HDK >= 25.5 且 mooncake >= v0.3.11<br>CANN >= 9.0.0<br>LingQu 计算网络 >= 1.5"
 
 #: ../../source/user_guide/feature_guide/kv_pool.md
 msgid "`export ASCEND_ENABLE_USE_FABRIC_MEM=1`"
@@ -534,8 +534,8 @@ msgid "Enable MooncakeStore SSD Offload with Embedded Real Client Mode"
 msgstr "使用嵌入式真实客户端模式启用 MooncakeStore SSD 卸载"
 
 #: ../../source/user_guide/feature_guide/kv_pool.md:430
-msgid "Requires mooncake >= v0.3.11.post1."
-msgstr "此功能需要 mooncake >= v0.3.11.post1。"
+msgid "Requires mooncake >= v0.3.11."
+msgstr "此功能需要 mooncake >= v0.3.11。"
 
 #: ../../source/user_guide/feature_guide/kv_pool.md:432
 msgid "Start the master"
@@ -1272,8 +1272,8 @@ msgstr ""
 #~ msgid "Embedded Real Client Mode（Mooncake ssd-offload.md Step 3A）"
 #~ msgstr "嵌入式真实客户端模式（Mooncake ssd-offload.md 步骤 3A）"
 
-#~ msgid "mooncake >= v0.3.11.post1"
-#~ msgstr "mooncake >= v0.3.11.post1"
+#~ msgid "mooncake >= v0.3.11"
+#~ msgstr "mooncake >= v0.3.11"
 
 #~ msgid "Set `true` to enable SSD offload."
 #~ msgstr "设置为 `true` 以启用 SSD 卸载。"

--- a/docs/source/tutorials/features/pd_colocated_mooncake_multi_instance.md
+++ b/docs/source/tutorials/features/pd_colocated_mooncake_multi_instance.md
@@ -121,7 +121,7 @@ Moonshot AI. Installation and compilation guide:
 First, obtain the Mooncake project using the following command:
 
 ```bash
-git clone -b v0.3.11.post1 --depth 1 https://github.com/kvcache-ai/Mooncake.git
+git clone -b v0.3.9 --depth 1 https://github.com/kvcache-ai/Mooncake.git
 cd Mooncake
 git submodule update --init --recursive
 ```

--- a/docs/source/tutorials/features/pd_disaggregation_mooncake_multi_node.md
+++ b/docs/source/tutorials/features/pd_disaggregation_mooncake_multi_node.md
@@ -177,7 +177,7 @@ Mooncake is the serving platform for Kimi, a leading LLM service provided by Moo
 First, we need to obtain the Mooncake project. Refer to the following command:
 
 ```shell
-git clone -b v0.3.11.post1 --depth 1 https://github.com/kvcache-ai/Mooncake.git
+git clone -b v0.3.9 --depth 1 https://github.com/kvcache-ai/Mooncake.git
 ```
 
 (Optional) Replace go install url if the network is poor

--- a/docs/source/tutorials/features/pd_disaggregation_mooncake_single_node.md
+++ b/docs/source/tutorials/features/pd_disaggregation_mooncake_single_node.md
@@ -98,7 +98,7 @@ Mooncake is the serving platform for Kimi, a leading LLM service provided by Moo
 First, we need to obtain the Mooncake project. Refer to the following command:
 
 ```shell
-git clone -b v0.3.11.post1 --depth 1 https://github.com/kvcache-ai/Mooncake.git
+git clone -b v0.3.9 --depth 1 https://github.com/kvcache-ai/Mooncake.git
 ```
 
 (Optional) Replace go install url if the network is poor.

--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -14,7 +14,7 @@
     * CANN >= 8.5.0
     * vLLM：main branch
     * vLLM-Ascend：main branch
-    * mooncake：>= 0.3.11.post1
+    * mooncake：>= 0.3.9
 
 ### KV Pool Parameter Description
 
@@ -67,7 +67,7 @@ export PYTHONHASHSEED=0
         First, we need to obtain the Mooncake project. Refer to the following command:
 
         ```shell
-        git clone -b v0.3.11.post1 --depth 1 https://github.com/kvcache-ai/Mooncake.git
+        git clone -b v0.3.9 --depth 1 https://github.com/kvcache-ai/Mooncake.git
         ```
 
         (Optional) Replace go install url if the network is poor
@@ -114,7 +114,7 @@ export PYTHONHASHSEED=0
 
 | Hardware | Dependencies | Export Command | Description |
 | :--- | :--- | :--- | :--- |
-| 800 I/T A3 series | HDK >= 26.0<br>or HDK >= 25.5 with mooncake >= v0.3.11.post1<br>CANN >= 9.0.0<br>LingQu Computing Network >= 1.5 | `export ASCEND_ENABLE_USE_FABRIC_MEM=1` | **Recommended**. Enables unified memory address direct transmission scheme. With SSD offload, see [Fabric memory size alignment](#122-fabric-memory-size-alignment-a3--ascend_enable_use_fabric_mem1) — memory sizes must be aligned to 1GB. |
+| 800 I/T A3 series | HDK >= 26.0<br>or HDK >= 25.5 with mooncake >= v0.3.11<br>CANN >= 9.0.0<br>LingQu Computing Network >= 1.5 | `export ASCEND_ENABLE_USE_FABRIC_MEM=1` | **Recommended**. Enables unified memory address direct transmission scheme. With SSD offload, see [Fabric memory size alignment](#122-fabric-memory-size-alignment-a3--ascend_enable_use_fabric_mem1) — memory sizes must be aligned to 1GB. |
 | 800 I/T A3 series | If any dependency above is not met | `export ASCEND_BUFFER_POOL=4:8` | Configures the number and size of buffers on the NPU Device for aggregation and KV transfer (e.g., `4:8` means 4 buffers of 8MB). |
 | 800 I/T A2 series | HDK >= 25.5 is recommended | `export HCCL_INTRA_ROCE_ENABLE=1` | Required by direct transmission scheme on 800 I/T A2 series|
 
@@ -432,7 +432,7 @@ This is because HCCL one-sided communication connections are created lazily afte
 
 ### Enable MooncakeStore SSD Offload with Embedded Real Client Mode
 
-* Requires mooncake >= v0.3.11.post1.
+* Requires mooncake >= v0.3.11.
 
 #### Start the master
 


### PR DESCRIPTION
This reverts commit acad18fd7decb62ad704afd2834bd512dc270ffc.

### What this PR does / why we need it?

revert [the pr](https://github.com/vllm-project/vllm-ascend/pull/10891) because of  [image build failed](https://github.com/vllm-project/vllm-ascend/actions/runs/28564357197/job/84688482626)  when mooncake upgrade to v0.3.11

The mooncake version in the Dockerfile was upgraded, but the wheel package installation method consistent with CI was not used, and a label was not printed in the PR to verify the image build, causing the current image build source code to fail to install mooncake version 0.3.11.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
