### PR TITLE
[Performance][310P] Access _npu_flash_attention_unpad_v2

### DIFF
--- a/tests/ut/_310p/ops/test_mm_encoder_attention_310.py
+++ b/tests/ut/_310p/ops/test_mm_encoder_attention_310.py
@@ -43,6 +43,7 @@ def test_mm_encoder_attention_310_forward_oot_with_padding():
     layer.head_size = 80
     layer.enable_pad = True
     layer.scale_value = layer.head_size**-0.5
+    layer.support_approximate_calculation = False
 
     bsz, q_len, kv_len = 2, 3, 3
     query = torch.randn(bsz, q_len, layer.num_heads, layer.head_size)

--- a/vllm_ascend/_310p/ops/mm_encoder_attention.py
+++ b/vllm_ascend/_310p/ops/mm_encoder_attention.py
@@ -124,6 +124,9 @@ class AscendMMEncoderAttention310(MMEncoderAttention):
             v = F.pad(v, (0, pad_len), mode="constant", value=0)
 
         context_layer = torch.empty_like(q)
+        # TODO: The current torch_npu version does not support
+        # _npu_flash_attention_unpad_v2. Once it is supported, drop the
+        # else branch below and always use the v2 op.
         if self.support_approximate_calculation:
             torch_npu._npu_flash_attention_unpad_v2(
                 query=q,

--- a/vllm_ascend/_310p/ops/mm_encoder_attention.py
+++ b/vllm_ascend/_310p/ops/mm_encoder_attention.py
@@ -124,7 +124,7 @@ class AscendMMEncoderAttention310(MMEncoderAttention):
             v = F.pad(v, (0, pad_len), mode="constant", value=0)
 
         context_layer = torch.empty_like(q)
-        # TODO: The current torch_npu version does not support
+        # TODO: The current torch_npu version 2.10.0 does not support
         # _npu_flash_attention_unpad_v2. Once it is supported, drop the
         # else branch below and always use the v2 op.
         if self.support_approximate_calculation:

--- a/vllm_ascend/_310p/ops/mm_encoder_attention.py
+++ b/vllm_ascend/_310p/ops/mm_encoder_attention.py
@@ -35,6 +35,10 @@ MAX_PAD_SIZE: int = 128  # max_size to pad weight
 seq_lens_cpu_cache: torch.Tensor = None
 
 
+def is_approximate_calculation_supported() -> bool:
+    return hasattr(torch_npu, "_npu_flash_attention_unpad_v2")
+
+
 class AscendMMEncoderAttention310(MMEncoderAttention):
     def __init__(
         self,
@@ -64,6 +68,7 @@ class AscendMMEncoderAttention310(MMEncoderAttention):
 
         self.enable_pad = self.head_size > MIN_PAD_SIZE and self.head_size < MAX_PAD_SIZE
         self.scale_value = self.head_size**-0.5
+        self.support_approximate_calculation = is_approximate_calculation_supported()
 
     def _reshape_qkv_to_3d(
         self,
@@ -119,18 +124,29 @@ class AscendMMEncoderAttention310(MMEncoderAttention):
             v = F.pad(v, (0, pad_len), mode="constant", value=0)
 
         context_layer = torch.empty_like(q)
-
-        # operator requires pta version >= 2.5.1
-        torch_npu._npu_flash_attention_unpad(
-            query=q,
-            key=k,
-            value=v,
-            seq_len=seq_lens_cpu,
-            scale_value=self.scale_value,
-            num_heads=self.num_heads,
-            num_kv_heads=self.num_kv_heads,
-            out=context_layer,
-        )
+        if self.support_approximate_calculation:
+            torch_npu._npu_flash_attention_unpad_v2(
+                query=q,
+                key=k,
+                value=v,
+                seq_len=seq_lens_cpu,
+                scale_value=self.scale_value,
+                num_heads=self.num_heads,
+                num_kv_heads=self.num_kv_heads,
+                out=context_layer,
+                kernel_type=2,
+            )
+        else:
+            torch_npu._npu_flash_attention_unpad(
+                query=q,
+                key=k,
+                value=v,
+                seq_len=seq_lens_cpu,
+                scale_value=self.scale_value,
+                num_heads=self.num_heads,
+                num_kv_heads=self.num_kv_heads,
+                out=context_layer,
+            )
 
         if self.enable_pad:
             context_layer = context_layer[..., :origin_shape]


### PR DESCRIPTION
### What this PR does / why we need it?
Feature Integration: Added support for approximate flash attention calculation using the _npu_flash_attention_unpad_v2 operator.
Dynamic Operator Selection: Implemented a check to detect if the environment supports the new approximate calculation operator, allowing for a fallback to the original implementation.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/b9a7cd464c9ae9b1b450f8982b76d7be4de73724
