### PR TITLE
[BugFix]fix vllm use v2 but vllm-ascend use v1

### DIFF
--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -66,6 +66,7 @@ import vllm_ascend.patch.worker.patch_cudagraph  # noqa
 import vllm_ascend.patch.worker.patch_deepseek_mtp  # noqa
 import vllm_ascend.patch.worker.patch_deepseek_v2  # noqa
 import vllm_ascend.patch.worker.patch_gqa_c8  # noqa
+import vllm_ascend.patch.worker.patch_v2.patch_use_v2_model_runner  # noqa
 
 if not vllm_version_is("0.23.0"):
     import vllm_ascend.patch.worker.patch_fused_moe  # noqa

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -71,8 +71,7 @@ import vllm_ascend.patch.worker.patch_gqa_c8  # noqa
 # VLLM_USE_V2_MODEL_RUNNER env var (e.g. based on model architecture).
 # We always patch it so that on Ascend the v2 runner is enabled only
 # when the env var is explicitly set.
-if not _V2_MODEL_RUNNER_SUPPORTED:
-    import vllm_ascend.patch.worker.patch_v2.patch_use_v2_model_runner  # noqa
+import vllm_ascend.patch.worker.patch_v2.patch_use_v2_model_runner  # noqa
 
 if not vllm_version_is("0.23.0"):
     import vllm_ascend.patch.worker.patch_fused_moe  # noqa

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -66,7 +66,13 @@ import vllm_ascend.patch.worker.patch_cudagraph  # noqa
 import vllm_ascend.patch.worker.patch_deepseek_mtp  # noqa
 import vllm_ascend.patch.worker.patch_deepseek_v2  # noqa
 import vllm_ascend.patch.worker.patch_gqa_c8  # noqa
-import vllm_ascend.patch.worker.patch_v2.patch_use_v2_model_runner  # noqa
+
+# vLLM's use_v2_model_runner may enable the v2 runner without the
+# VLLM_USE_V2_MODEL_RUNNER env var (e.g. based on model architecture).
+# We always patch it so that on Ascend the v2 runner is enabled only
+# when the env var is explicitly set.
+if not _V2_MODEL_RUNNER_SUPPORTED:
+    import vllm_ascend.patch.worker.patch_v2.patch_use_v2_model_runner  # noqa
 
 if not vllm_version_is("0.23.0"):
     import vllm_ascend.patch.worker.patch_fused_moe  # noqa

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -71,7 +71,8 @@ import vllm_ascend.patch.worker.patch_gqa_c8  # noqa
 # VLLM_USE_V2_MODEL_RUNNER env var (e.g. based on model architecture).
 # We always patch it so that on Ascend the v2 runner is enabled only
 # when the env var is explicitly set.
-import vllm_ascend.patch.worker.patch_v2.patch_use_v2_model_runner  # noqa
+if not _V2_MODEL_RUNNER_SUPPORTED:
+    import vllm_ascend.patch.worker.patch_v2.patch_use_v2_model_runner  # noqa
 
 if not vllm_version_is("0.23.0"):
     import vllm_ascend.patch.worker.patch_fused_moe  # noqa

--- a/vllm_ascend/patch/worker/patch_v2/patch_use_v2_model_runner.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_use_v2_model_runner.py
@@ -1,4 +1,4 @@
-from vllm.config import envs
+import vllm.envs as envs
 from vllm.config.vllm import VllmConfig
 
 

--- a/vllm_ascend/patch/worker/patch_v2/patch_use_v2_model_runner.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_use_v2_model_runner.py
@@ -1,0 +1,20 @@
+from vllm.config import envs
+from vllm.config.vllm import VllmConfig
+
+
+def _patched_use_v2_model_runner(self) -> bool:
+    """Return VLLM_USE_V2_MODEL_RUNNER env directly.
+
+    The upstream use_v2_model_runner gate-keeps the v2 runner with
+    per-model architecture whitelists, Triton availability checks, and
+    feature-support inspections. On Ascend the v2 runner is controlled
+    purely by the VLLM_USE_V2_MODEL_RUNNER environment variable;
+    model-compatibility decisions are deferred to the NPU runner itself.
+    """
+    use_v2 = envs.VLLM_USE_V2_MODEL_RUNNER
+    if use_v2 is not None:
+        return use_v2
+    return False
+
+
+VllmConfig.use_v2_model_runner = property(_patched_use_v2_model_runner)

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -937,7 +937,7 @@ class NPUPlatform(Platform):
         # compared to v1, v2's forward context lacks some fields, such as:
         # is_first_layer, prefetch_mlp_gate_up_proj, prefetch_mlp_gate_down_proj,
         # prefetch_mlp_enabled, model_instance, is_draft_model.
-        if not envs_vllm.VLLM_USE_V2_MODEL_RUNNER:
+        if not vllm_config.use_v2_model_runner:
             return {}
 
         # is_draft_model will be removed later, so we set it to False temporarily.

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -159,7 +159,7 @@ class NPUWorker(WorkerBase):
         if "UnquantizedLinearMethod" in WEIGHT_LOADER_V2_SUPPORTED:
             WEIGHT_LOADER_V2_SUPPORTED.remove("UnquantizedLinearMethod")
 
-        self.use_v2_model_runner = envs_vllm.VLLM_USE_V2_MODEL_RUNNER
+        self.use_v2_model_runner = self.vllm_config.use_v2_model_runner
         if self.use_v2_model_runner and vllm_version_is("0.23.0"):
             logger.warning("VLLM_USE_V2_MODEL_RUNNER is not supported on vllm 0.23.0; falling back to v1 model runner.")
             self.use_v2_model_runner = False


### PR DESCRIPTION
### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
