### PR TITLE
[BugFix][xlite] Performance improvement in xlite full mode by avoiding redundant memory allocation during profiling runs

### DIFF
--- a/vllm_ascend/xlite/xlite.py
+++ b/vllm_ascend/xlite/xlite.py
@@ -566,26 +566,37 @@ def get_adapter_xlite_model(runnable: nn.Module, vllm_config: VllmConfig) -> Xli
 class XliteWrapper:
     """A graph-based wrapper that dispatches between xlite and runnable paths."""
 
-    def __init__(self, runnable: nn.Module, vllm_config: VllmConfig):
+    def __init__(self, runnable: nn.Module, vllm_config: VllmConfig, device: torch.device) -> None:
         """Initialize xlite runtime, model tensors, and hidden-state workspace.
 
         Args:
             runnable (nn.Module): The runnable model implementation.
             vllm_config (VllmConfig): Runtime configuration for execution.
+            device (torch.device): The device to initialize the xlite model on.
 
         Raises:
             ValueError: If xlite runtime tensor-pool initialization fails.
         """
         self.runnable = runnable
+        self.device = device
         self.full_mode = get_ascend_config().xlite_graph_config.full_mode
 
         rank = torch.distributed.get_rank()
         local_rank = get_world_group().local_rank
         self.data_parallel_size = vllm_config.parallel_config.data_parallel_size
-        self.xlite_rt = Runtime(local_rank, 0, rank, get_tensor_model_parallel_world_size(), self.data_parallel_size)
 
         self.adapter_xlite_model = get_adapter_xlite_model(runnable, vllm_config)
         (self.xlite_model, self.freq_cis, hidden_size, dtype) = self.adapter_xlite_model.initialize()
+        xlite_config = self.adapter_xlite_model.xlite_config
+        self.xlite_rt = Runtime(
+            devid=local_rank,
+            size=0,
+            rank=rank,
+            tp_size=xlite_config.def_tp_size,
+            dp_size=xlite_config.def_dp_size,
+            moe_tp_size=xlite_config.moe_tp_size,
+            moe_ep_size=xlite_config.moe_ep_size,
+        )
 
         rt_pool_size = self.xlite_model.get_tensor_pool_size()
         if rank == 0:
@@ -594,7 +605,7 @@ class XliteWrapper:
             raise ValueError(f"xlite wrapper init failed! runtime pool size: {rt_pool_size} MB")
 
         max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
-        self.hidden_states = torch.empty(max_num_tokens, hidden_size, device=f"npu:{local_rank}", dtype=dtype)
+        self.hidden_states = torch.empty(max_num_tokens, hidden_size, device=self.device, dtype=dtype)
 
     def __getattr__(self, key: str) -> Any:
         """Proxy unknown attributes to the wrapped runnable model.
@@ -638,6 +649,7 @@ class XliteWrapper:
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        **model_kwargs: Any,
     ) -> XliteForwardResult:
         """Run one forward step through xlite graph or fallback runnable path.
 
@@ -647,19 +659,29 @@ class XliteWrapper:
             intermediate_tensors (Optional[IntermediateTensors]): Optional intermediate tensors from pipeline stages.
             inputs_embeds (Optional[torch.Tensor]): Optional external input embeddings (e.g. multimodal/deepstack
                 scenarios).
+            **model_kwargs (Any): Additional keyword arguments for the runnable.
 
         Returns:
             XliteForwardResult: Forward outputs from xlite graph or the original runnable implementation.
         """
         forward_context = get_forward_context()
+        if getattr(forward_context, "in_profile_run", False):
+            if self.full_mode:
+                # In full mode, xlite handles both prefill and decode, and aclgraph runnable should not reserve memory.
+                # This is to avoid redundant memory allocation that reduces KV cache capacity and regresses performance.
+                # NOTE: returning a single hidden state tensor may break the vLLM pipeline if the runnable expects a
+                # tuple of outputs, e.g., (hidden_states, aux_hidden_states) under certain speculative scenarios
+                return self.hidden_states
+            return self.runnable(input_ids, positions, intermediate_tensors, inputs_embeds, **model_kwargs)
+
         attn_metadata: Any = forward_context.attn_metadata
         if attn_metadata is None:
-            return self.runnable(input_ids, positions, intermediate_tensors, inputs_embeds)
+            return self.runnable(input_ids, positions, intermediate_tensors, inputs_embeds, **model_kwargs)
 
         attn_metadata = attn_metadata[0] if isinstance(attn_metadata, list) else attn_metadata
         attn_metadata = next(iter(attn_metadata.values()), None)
         if not isinstance(attn_metadata, self.adapter_xlite_model._attn_metadata_type):
-            return self.runnable(input_ids, positions, intermediate_tensors, inputs_embeds)
+            return self.runnable(input_ids, positions, intermediate_tensors, inputs_embeds, **model_kwargs)
 
         with_prefill = attn_metadata.attn_state not in (
             AscendAttentionState.DecodeOnly,
@@ -675,12 +697,12 @@ class XliteWrapper:
         else:
             use_xlite_graph = not with_prefill or self.full_mode
 
-        attn_metadata_router = AttnMetadataRouter(attn_metadata=attn_metadata, device="cpu")
         if not use_xlite_graph:
             # fall back to runnable for prefill in decode-only mode
             # or when the number of tokens exceeds the graph capacity in non-full mode
-            return self.runnable(input_ids, positions, intermediate_tensors, inputs_embeds)
+            return self.runnable(input_ids, positions, intermediate_tensors, inputs_embeds, **model_kwargs)
 
+        attn_metadata_router = AttnMetadataRouter(attn_metadata=attn_metadata, device="cpu")
         seq_lens = attn_metadata_router.seq_lens
         cum_query_lens = attn_metadata_router.cu_query_lens[-seq_lens.size(0) :].to(device=seq_lens.device)
         query_lens = torch.diff(cum_query_lens, prepend=seq_lens.new_zeros(1))

--- a/vllm_ascend/xlite/xlite_model_runner.py
+++ b/vllm_ascend/xlite/xlite_model_runner.py
@@ -33,7 +33,7 @@ class XliteModelRunner(NPUModelRunner):
         from vllm_ascend.xlite.xlite import XliteWrapper
 
         super().load_model()
-        self.model = self.xlite_model = XliteWrapper(self.model, self.vllm_config)
+        self.model = self.xlite_model = XliteWrapper(self.model, self.vllm_config, device=self.device)
 
     def initialize_kv_cache(
         self,


### PR DESCRIPTION
### What this PR does / why we need it?

`xlite` backend in `xlite/xlite_model_runner:XliteModelRunner` keep a copy of `NPUModelRunner`'s model for compatibility. In `xlite` full mode, `xlite` handles both the prefill stage and the decode stage. Before this PR, `NPUModelRunner`/`aclgraph` reserves peak memory during profile runs, which reduced available memory for KV caches and affected xlite perrformance.

With this PR, `aclgraph` model reserves less peak runtime memory in xlite full mode. More memory can be allocated to KV caches and the concurrency level is increased with some performance improvement. For example, using TP2DP1EP2 to serve Qwen3-30B-A3B with xlite full mode (max seq 64, max length 40960, batch tokens 8192):

Before this PR:

> (Worker_TP0_EP0 pid=18480) INFO 07-03 15:23:17 [xlite.py:592] xlite runtime pool size: 519 MB
> (Worker_TP0_EP0 pid=18480) INFO 07-03 15:23:35 [worker.py:564] Available KV cache memory: *25.53 GiB*
> (EngineCore pid=18453) INFO 07-03 15:23:35 [kv_cache_utils.py:1744] GPU KV cache size: *557,696 tokens*
> (EngineCore pid=18453) INFO 07-03 15:23:35 [kv_cache_utils.py:1745] Maximum concurrency for 40,960 tokens per request: 13.62x
> (Worker_TP0_EP0 pid=18480) INFO 07-03 15:23:37 [worker.py:790] Free memory on device (60.89/61.27 GiB) on startup. Desired GPU memory utilization is (0.95, 58.21 GiB). Actual usage: 28.48 GiB for weights, *0.64 GiB for peak activation, 3.56 GiB for non-torch memory*, 0.0 GiB for NPU graph memory. Replace gpu_memory_utilization with `--kv-cache-memory=27260496384` (25.39 GiB) to fit into requested memory, or `--kv-cache-memory=30142716416` (28.07 GiB) to fully utilize NPU free memory. Current KV cache memory: 25.53 GiB.

With this PR:

> (Worker_TP0_EP0 pid=19702) INFO 07-03 15:28:30 [xlite.py:603] xlite runtime pool size: 519 MB
> (Worker_TP0_EP0 pid=19702) INFO 07-03 15:28:34 [worker.py:564] Available KV cache memory: 28.67 GiB
> (EngineCore pid=19675) INFO 07-03 15:28:35 [kv_cache_utils.py:1744] GPU KV cache size: 626,176 tokens
> (EngineCore pid=19675) INFO 07-03 15:28:35 [kv_cache_utils.py:1745] Maximum concurrency for 40,960 tokens per request: 15.29x
> (Worker_TP0_EP0 pid=19702) INFO 07-03 15:28:37 [worker.py:790] Free memory on device (60.89/61.27 GiB) on startup. Desired GPU memory utilization is (0.95, 58.21 GiB). Actual usage: 28.48 GiB for weights, *0.05 GiB for peak activation, 1.02 GiB for non-torch memory*, 0.0 GiB for NPU graph memory. Replace gpu_memory_utilization with `--kv-cache-memory=30625051136` (28.52 GiB) to fit into requested memory, or `--kv-cache-memory=33509896704` (31.21 GiB) to fully utilize NPU free memory. Current KV cache memory: 28.67 GiB.

### Does this PR introduce _any_ user-facing change?

No, this PR only changes runtime implementations.

### How was this patch tested?

We benchmarked model accuracies with multiple models using `aisbench`. The [batch_aisbench.py](https://atomgit.com/openeuler/GVirt/blob/master/xlite/tests/e2e/batch_aisbench.py) script was used:

```bash
# on one Atlas A3
python batch_aisbench.py "/root/benchmark" \
--num-prompts 4 \
--model-dir "/mnt/sdb/models" \
--models "Qwen3-32B" "Qwen3-30B-A3B" "Qwen3-VL-30B-A3B-Instruct" "GLM-4.7-W8A8-floatmtp" "MiniMax-M2.7-w8a8-QuaRot" \
--tps 4 4 4 8 8 \
--dps 1 1 1 1 1 \
--eps 0 1 1 1 1 \
-MNS 32 \
-MML 8192 \
-MNT 8192 \
--xlite 2 1 0 \
--broadcast-xlite
```

No accuracy issue was found in the 5 tested models:

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Qwen3-32B | ceval-weighted | 4 | N | 1 | xlite full | weighted_average | 87.72 |
| Qwen3-32B | ceval-weighted | 4 | N | 1 | xlite decode-only | weighted_average | 84.36 |
| Qwen3-32B | ceval-weighted | 4 | N | 1 | aclgraph | weighted_average | 84.31 |

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Qwen3-30B-A3B | ceval-weighted | 4 | Y | 1 | xlite full | weighted_average | 88.76 |
| Qwen3-30B-A3B | ceval-weighted | 4 | Y | 1 | xlite decode-only | weighted_average | 87.48 |
| Qwen3-30B-A3B | ceval-weighted | 4 | Y | 1 | aclgraph | weighted_average | 60.59 |

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Qwen3-VL-30B-A3B-Instruct | ceval-weighted | 4 | Y | 1 | xlite full | weighted_average | 84.19 |
| Qwen3-VL-30B-A3B-Instruct | ceval-weighted | 4 | Y | 1 | xlite decode-only | weighted_average | 79.68 |
| Qwen3-VL-30B-A3B-Instruct | ceval-weighted | 4 | Y | 1 | aclgraph | weighted_average | 87.20 |

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy |
| --- | --- | --- | --- | --- | --- | --- | --- |
| GLM-4.7-W8A8-floatmtp | ceval-weighted | 8 | Y | 1 | xlite full | weighted_average | 88.86 |
| GLM-4.7-W8A8-floatmtp | ceval-weighted | 8 | Y | 1 | xlite decode-only | weighted_average | 88.63 |
| GLM-4.7-W8A8-floatmtp | ceval-weighted | 8 | Y | 1 | aclgraph | weighted_average | 88.58 |

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy |
| --- | --- | --- | --- | --- | --- | --- | --- |
| MiniMax-M2.7-w8a8-QuaRot | ceval-weighted | 8 | Y | 1 | xlite full | weighted_average | 81.74 |
| MiniMax-M2.7-w8a8-QuaRot | ceval-weighted | 8 | Y | 1 | xlite decode-only | weighted_average | 84.03 |
| MiniMax-M2.7-w8a8-QuaRot | ceval-weighted | 8 | Y | 1 | aclgraph | weighted_average | 82.73 |


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
