### PR TITLE
[BugFix][Prefix Caching][DSv4] Align SlidingWindowManager scheduler block size with LCM block size

### DIFF
--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -7,6 +7,9 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.single_type_kv_cache_manager import (
+    SlidingWindowManager,
+)
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -14,6 +17,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheTensor,
     MambaSpec,
     MLAAttentionSpec,
+    SlidingWindowMLASpec,
     UniformTypeKVCacheSpecs,
 )
 
@@ -421,3 +425,50 @@ def test_ascend_mamba_manager_uses_logical_block_size_with_prefix_caching() -> N
     manager = AscendMambaManager(**manager_kwargs)
 
     assert manager.block_size == mamba_spec.block_size
+
+
+def test_swa_reachable_block_mask_sparse_with_lcm_alignment() -> None:
+    """Regression: when ``scheduler_block_size`` is aligned to ``lcm_block_size``
+    (instead of the raw-block-size LCM), ``SlidingWindowManager.reachable_block_mask``
+    must produce a sparse mask rather than returning ``None``.
+
+    Before the fix, ``alignment_tokens`` was the LCM of raw block_sizes (e.g. 32),
+    making ``need >= per_segment`` always true for Ascend's SWA configuration and
+    the mask returned ``None`` (cache everything). After the fix the alignment is
+    ``lcm_block_size`` (e.g. 4096), which is large enough that only the tail
+    blocks within each segment need caching.
+    """
+    spec = SlidingWindowMLASpec(
+        block_size=32,  # Ascend SWA block_size (--block-size 32)
+        num_kv_heads=1,
+        head_size=512,
+        dtype=torch.float32,
+        sliding_window=128,  # DeepSeek V4 window
+        compress_ratio=1,
+    )
+    alignment_tokens = 4096  # lcm_block_size
+
+    mask = SlidingWindowManager.reachable_block_mask(
+        start_block=0,
+        end_block=256,  # 256 × 32 = 8192 tokens (2 × alignment_tokens)
+        alignment_tokens=alignment_tokens,
+        kv_cache_spec=spec,
+        use_eagle=False,
+        retention_interval=None,
+        num_prompt_tokens=None,
+    )
+
+    # Must produce a sparse mask, not None.
+    assert mask is not None, "should produce sparse mask with lcm alignment"
+
+    true_blocks = sum(mask)
+
+    # need = cdiv(window−1, block_size) = cdiv(127, 32) = 4
+    # per_segment = alignment_tokens // block_size = 4096 // 32 = 128
+    # Each 128-block segment caches the last 4 blocks (= 0 % sparse padding).
+    total_blocks = len(mask)
+    expected = 4 * (total_blocks // 128)
+    assert true_blocks == expected, (
+        f"expected {expected} cached blocks ({4}/{128} per segment), got {true_blocks}/{total_blocks}"
+    )
+    assert true_blocks > 0 and true_blocks < total_blocks, f"mask should be sparse, got {true_blocks}/{total_blocks}"

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -21,6 +21,7 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     SingleTypeKVCacheManager,
+    SlidingWindowManager,
 )
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -145,6 +146,15 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                 for g in kv_cache_config.kv_cache_groups
             ), "block_size must be divisible by hash_block_size"
         self.verify_and_split_kv_cache_groups()
+
+        # Align the WRITE-path mask granularity (reachable_block_mask) with the
+        # READ-path hit granularity (find_longest_cache_hit) so SlidingWindowManager
+        # only caches blocks that land on a boundary where future cache hits can
+        # actually be matched.
+        # TODO (Csrayz): Consider unified all single_type_managers to simplify logic.
+        for mgr in self.single_type_managers:
+            if isinstance(mgr, SlidingWindowManager):
+                mgr.scheduler_block_size = self.lcm_block_size
 
         self.use_eagle = use_eagle
 


### PR DESCRIPTION
### What this PR does / why we need it?

When validated against an agent-scenario dataset, the prefix-cache hit rate improved rising from 33% to 86%.

The root cause is a unit ambiguity in `AscendHybridKVCacheCoordinator`'s SWA alignment logic. Since Ascend's `block_size` semantics refer to the number of **physical slots** rather than the number of tokens (tracked in vllm-ascend RFC #10517), the `alignment_tokens` value flowing into `SlidingWindowManager.reachable_block_mask` and `SlidingWindowManager.find_longest_cache_hit` was previously expressed in mixed units of `token / max(compression_ratio)`. This produced wrong block counts when dividing `alignment_tokens` by per-block token capacity.

This PR unifies the `alignment_tokens` unit across all SWA computations: the value is now the actual `lcm_block_size` computed by the coordinator (`self.lcm_block_size` in `verify_and_split_kv_cache_groups()`), and every SWA manager receives this value as its `scheduler_block_size`. As a result, `window_size`, `block_size`, and `alignment_tokens` are uniformly expressed in actual token counts inside both `reachable_block_mask` and `find_longest_cache_hit`, and the SWA module maintains consistent unit semantics end-to-end.

### Does this PR introduce _any_ user-facing change?

No. Behavior is gated by the existing upstream env `VLLM_PREFIX_CACHE_RETENTION_INTERVAL` (vLLM PR #43447). When unset, `reachable_block_mask` returns the dense default and no SWA block selection changes. When set, the WRITE/READ paths now use the same alignment granularity instead of the previous mixed-unit one.

### How was this patch tested?

Validated in DeepSeek-V4 Flash (mtp=1):

- **Prefix-cache hit rate** on an agent-scenario dataset: 33%(main) → 86%(this pr)
- **SWA block cache occupation**:
  - groups 2 and 3: full retention → 9/256
  - group 4: 1/4 → 1/512
  - group 5: full retention → 1/32


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
