### PR TITLE
[BugFix][Worker] Fix PP PCP hidden state restore

### DIFF
--- a/tests/e2e/pull_request/four_card/test_pipeline_parallel.py
+++ b/tests/e2e/pull_request/four_card/test_pipeline_parallel.py
@@ -30,6 +30,7 @@ MOE_MODELS = [
 DATA_PARALLELS = [2]
 TENSOR_PARALLELS = [1]
 PIPELINE_PARALLELS = [2]
+PREFILL_CONTEXT_PARALLELS = [2]
 DIST_EXECUTOR_BACKEND = ["mp", "ray"]
 
 prompts = [
@@ -142,5 +143,30 @@ def test_models_pp2_dp2(model: str, dp_size: int, pp_size: int, distributed_exec
             outputs_0_lst=outputs,
             outputs_1_lst=GOLDEN,
             name_0=f"{model}-dp{dp_size}pp{pp_size}",
+            name_1="GOLDEN",
+        )
+
+
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("pcp_size", PREFILL_CONTEXT_PARALLELS)
+@pytest.mark.parametrize("pp_size", PIPELINE_PARALLELS)
+@wait_until_npu_memory_free(target_free_percentage=0.6)
+def test_models_pp2_pcp2(model: str, pcp_size: int, pp_size: int) -> None:
+    with VllmRunner(
+        model,
+        prefill_context_parallel_size=pcp_size,
+        pipeline_parallel_size=pp_size,
+        compilation_config={
+            "cudagraph_mode": "PIECEWISE",
+            "cudagraph_capture_sizes": [1, 2, 4],
+        },
+        gpu_memory_utilization=0.7,
+        enable_expert_parallel=model in MOE_MODELS,
+    ) as vllm_model:
+        outputs = vllm_model.generate_greedy(prompts, 16)
+        check_outputs_equal(
+            outputs_0_lst=outputs,
+            outputs_1_lst=GOLDEN,
+            name_0=f"{model}-pcp{pcp_size}pp{pp_size}",
             name_1="GOLDEN",
         )

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2430,7 +2430,7 @@ class NPUModelRunner(GPUModelRunner):
             aux_hidden_states = None
             if self.use_aux_hidden_state_outputs:
                 hidden_states, aux_hidden_states = hidden_states
-            if self.pcp_size > 1:
+            if self.pcp_size > 1 and not isinstance(hidden_states, IntermediateTensors):
                 # NOTE we must `slice` hidden_states because pcp_allgather_restore_idx
                 # ignores the padding from CUDA Graph.
                 hidden_states = self.pcp_manager.get_restore_hidden_states(hidden_states)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes PP + PCP execution when a non-last pipeline-parallel rank returns `IntermediateTensors` from the model forward path.

The PCP post-processing path previously always called `pcp_manager.get_restore_hidden_states(hidden_states)` whenever `pcp_size > 1`. In PP execution, non-last pipeline stages can produce `IntermediateTensors` instead of a plain hidden-state tensor. Passing that object through the PCP restore tensor path is invalid, so this change skips PCP hidden-state restoration when `hidden_states` is already `IntermediateTensors`.

This keeps the restore behavior for tensor hidden states unchanged while allowing intermediate pipeline outputs to continue through the existing PP return path.

### Does this PR introduce _any_ user-facing change?

No. This is an internal worker/model-runner fix for PP + PCP execution and does not change public APIs, CLI flags, or documented behavior.

### How was this patch tested?

- `pytest tests\e2e\pull_request\four_card\test_pipeline_parallel.py -k test_models_pp2_pcp2`


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
