### PR TITLE
[BugFix][310p]:fix the accuracy issue caused by mtp and aclgraph

### DIFF
--- a/tests/ut/_310p/ops/test_gdn_310.py
+++ b/tests/ut/_310p/ops/test_gdn_310.py
@@ -1,0 +1,107 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+from types import SimpleNamespace
+
+import torch
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID, PAD_SLOT_ID
+
+from vllm_ascend._310p.ops.fla.gdn_310 import (
+    AscendGatedDeltaNetAttention310,
+    _mask_padded_recurrent_accepted_tokens,
+    _pad_spec_conv1d_host_args_shape_consistent_dummy_310p,
+    _zero_padded_tokens,
+)
+from vllm_ascend._310p.ops.gdn_attn_builder_310 import (
+    AscendGDNAttentionBackend310,
+    AscendGDNAttentionMetadataBuilder310,
+)
+
+
+def test_ascend_gdn_attention_310_uses_310p_backend():
+    assert AscendGatedDeltaNetAttention310.get_attn_backend(object()) is AscendGDNAttentionBackend310
+    assert AscendGDNAttentionBackend310.get_builder_cls() is AscendGDNAttentionMetadataBuilder310
+
+
+def test_zero_padded_tokens_masks_only_padded_token_positions():
+    tensor = torch.arange(2 * 4 * 3, dtype=torch.float32).reshape(2, 4, 3)
+
+    masked = _zero_padded_tokens(tensor, torch.tensor(2), token_dim=1)
+
+    torch.testing.assert_close(masked[:, :2], tensor[:, :2])
+    assert torch.count_nonzero(masked[:, 2:]) == 0
+
+
+def test_mask_padded_recurrent_accepted_tokens_zeros_dummy_requests():
+    accepted_tokens = torch.tensor([2, 3, 4], dtype=torch.int64)
+    actual_seq_lengths = torch.tensor([4, 0, 1], dtype=torch.int32)
+
+    masked = _mask_padded_recurrent_accepted_tokens(
+        accepted_tokens,
+        actual_seq_lengths,
+    )
+
+    assert masked.dtype == torch.int32
+    assert masked.tolist() == [2, 0, 4]
+
+
+def test_pad_spec_conv1d_host_args_adds_shape_consistent_dummy_requests():
+    qsl_host, cidx_host, accepted_host = _pad_spec_conv1d_host_args_shape_consistent_dummy_310p(
+        qsl_host=(0, 4, 8),
+        cidx_host=(11,),
+        num_accepted_host=(2,),
+        cap_x_dim0=14,
+        q_per_seq=4,
+    )
+
+    assert qsl_host == (0, 4, 8, 12, 14)
+    assert cidx_host == (11, PAD_SLOT_ID, PAD_SLOT_ID, PAD_SLOT_ID)
+    assert accepted_host == (2, 0, 0, 0)
+
+
+def test_builder310_pads_spec_decode_metadata_with_dummy_requests():
+    builder = object.__new__(AscendGDNAttentionMetadataBuilder310)
+    builder.spec_state_indices_tensor = torch.full((4, 2), -1, dtype=torch.int32)
+    builder.spec_sequence_masks = torch.empty(4, dtype=torch.bool)
+    builder.non_spec_token_indx = torch.empty(0, dtype=torch.int32)
+    builder.spec_token_indx = torch.empty(8, dtype=torch.int32)
+    builder.spec_query_start_loc = torch.empty(5, dtype=torch.int32)
+    builder.num_accepted_tokens = torch.empty(4, dtype=torch.int32)
+    attn_metadata = SimpleNamespace(
+        num_spec_decodes=2,
+        spec_state_indices_tensor=torch.tensor(
+            [[3, 30], [4, 40]],
+            dtype=torch.int32,
+        ),
+        spec_sequence_masks=torch.tensor([True, True]),
+        spec_query_start_loc=torch.tensor([0, 4, 8], dtype=torch.int32),
+        num_accepted_tokens=torch.tensor([2, 3], dtype=torch.int32),
+        non_spec_token_indx=torch.empty(0, dtype=torch.int32),
+        spec_token_indx=torch.arange(8, dtype=torch.int32),
+    )
+
+    builder._pad_spec_decode_metadata(attn_metadata, graph_batch_size=4)
+
+    assert attn_metadata.spec_state_indices_tensor.tolist() == [
+        [3, 30],
+        [4, 40],
+        [NULL_BLOCK_ID, NULL_BLOCK_ID],
+        [NULL_BLOCK_ID, NULL_BLOCK_ID],
+    ]
+    assert attn_metadata.spec_sequence_masks.tolist() == [True, True, False, False]
+    assert attn_metadata.spec_query_start_loc.tolist() == [0, 4, 8, 8, 8]
+    assert attn_metadata.num_accepted_tokens.tolist() == [2, 3, 0, 0]

--- a/tests/ut/_310p/test_model_runner_310p.py
+++ b/tests/ut/_310p/test_model_runner_310p.py
@@ -18,6 +18,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
+from vllm.config import CUDAGraphMode
 from vllm.v1.kv_cache_interface import AttentionSpec, MambaSpec
 
 from tests.ut.base import TestBase
@@ -48,6 +49,45 @@ def test_prepare_inputs_keeps_aclgraph_metadata_on_cpu() -> None:
     assert "self._positions_cpu_buf[:total_num_scheduled_tokens]" in source
     assert "self.seq_lens[:num_reqs].copy_(" in source
     assert "self.optimistic_seq_lens_cpu[:num_reqs]" in source
+
+
+def test_model_forward_updates_mtp_full_graph_params_before_replay() -> None:
+    runner = object.__new__(NPUModelRunner310)
+    runner.uses_mrope = False
+    runner.enable_enpu = False
+    runner.speculative_config = SimpleNamespace(method="mtp")
+    runner.update_stream = MagicMock()
+    runner._all_gather_hidden_states_and_aux = MagicMock()
+
+    calls = []
+
+    def fake_update(*args):
+        calls.append("update")
+
+    def fake_model(**kwargs):
+        calls.append("model")
+        return torch.ones(1)
+
+    runner.model = fake_model
+    runner._update_full_graph_params_if_needed = fake_update
+    forward_context = SimpleNamespace(
+        cudagraph_runtime_mode=CUDAGraphMode.FULL,
+        capturing=False,
+        flash_comm_v1_enabled=False,
+    )
+
+    with patch(
+        "vllm_ascend._310p.model_runner_310p.get_forward_context",
+        return_value=forward_context,
+    ):
+        hidden_states = runner._model_forward(
+            8,
+            input_ids=torch.tensor([1]),
+            positions=torch.tensor([0]),
+        )
+
+    assert calls == ["update", "model"]
+    torch.testing.assert_close(hidden_states, torch.ones(1))
 
 
 class TestNPUModelRunner310(TestBase):

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import math
 from contextlib import contextmanager, nullcontext
+from functools import partial
 from typing import Any, cast
 
 import numpy as np
@@ -27,7 +28,9 @@ import torch.nn as nn
 import torch_npu
 from vllm.config import CUDAGraphMode
 from vllm.distributed.parallel_state import get_pp_group
+from vllm.forward_context import get_forward_context
 from vllm.logger import logger
+from vllm.sequence import IntermediateTensors
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import get_dtype_size
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -652,21 +655,56 @@ class NPUModelRunner310(NPUModelRunner):
         num_tokens_padded: int,
         input_ids: torch.Tensor | None = None,
         positions: torch.Tensor | None = None,
-        intermediate_tensors=None,
+        intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
-        **model_kwargs,
+        **model_kwargs: dict[str, Any],
     ):
         if self.uses_mrope:
             assert positions is not None
             prepare_mrope_cos_sin_slices_from_runner(self, positions)
-        return super()._model_forward(
-            num_tokens_padded,
-            input_ids=input_ids,
-            positions=positions,
-            intermediate_tensors=intermediate_tensors,
-            inputs_embeds=inputs_embeds,
+
+        assert self.model is not None
+        forward_context = get_forward_context()
+        assert forward_context is not None
+        model_inputs: dict[str, Any] = {
+            "input_ids": input_ids,
+            "positions": positions,
+            "intermediate_tensors": intermediate_tensors,
+            "inputs_embeds": inputs_embeds,
             **model_kwargs,
+        }
+        run_model = partial(self.model, **model_inputs)
+        update_before_replay = (
+            self.speculative_config is not None
+            and self.speculative_config.method == "mtp"
+            and not self.enable_enpu
+            and forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL
+            and not forward_context.capturing
+            and hasattr(self, "update_stream")
         )
+
+        if self.enable_enpu or update_before_replay:
+            if update_before_replay:
+                torch.npu.current_stream().synchronize()
+            self._update_full_graph_params_if_needed(
+                forward_context,
+                num_tokens_padded,
+                positions,
+            )
+            if update_before_replay:
+                torch.npu.current_stream().wait_stream(self.update_stream)
+            hidden_states = run_model()
+        else:
+            hidden_states = run_model()
+            self._update_full_graph_params_if_needed(
+                forward_context,
+                num_tokens_padded,
+                positions,
+            )
+
+        if forward_context.flash_comm_v1_enabled and not isinstance(hidden_states, IntermediateTensors):
+            hidden_states = self._all_gather_hidden_states_and_aux(hidden_states)
+        return hidden_states
 
     def _check_and_update_cudagraph_mode(
         self,

--- a/vllm_ascend/_310p/ops/fla/gdn_310.py
+++ b/vllm_ascend/_310p/ops/fla/gdn_310.py
@@ -53,6 +53,29 @@ def _as_int64_device_view(tensor: torch.Tensor) -> torch.Tensor:
     return tensor.to(torch.int64)
 
 
+def _zero_padded_tokens(
+    tensor: torch.Tensor,
+    valid_tokens: torch.Tensor,
+    token_dim: int,
+) -> torch.Tensor:
+    if tensor.numel() == 0:
+        return tensor
+
+    token_count = tensor.shape[token_dim]
+    if token_count == 0:
+        return tensor
+
+    positions = torch.arange(
+        token_count,
+        device=tensor.device,
+        dtype=valid_tokens.dtype,
+    )
+    valid_mask = positions < valid_tokens.to(device=tensor.device)
+    mask_shape = [1] * tensor.ndim
+    mask_shape[token_dim] = token_count
+    return tensor * valid_mask.reshape(mask_shape).to(dtype=tensor.dtype)
+
+
 def _get_spec_causal_conv1d_device_args(
     attn_metadata: GDNAttentionMetadata,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -144,6 +167,18 @@ def _flatten_state_indices(
     return flat_dev.contiguous()
 
 
+def _mask_padded_recurrent_accepted_tokens(
+    num_accepted_tokens: torch.Tensor,
+    actual_seq_lengths: torch.Tensor,
+) -> torch.Tensor:
+    accepted_tokens = num_accepted_tokens[: actual_seq_lengths.shape[0]].to(torch.int32).contiguous()
+    return torch.where(
+        actual_seq_lengths > 0,
+        accepted_tokens,
+        torch.zeros_like(accepted_tokens),
+    ).contiguous()
+
+
 def npu_recurrent_gated_delta_rule_310(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -163,9 +198,16 @@ def npu_recurrent_gated_delta_rule_310(
     total_tokens = v.shape[1]
     flat_state_indices = _flatten_state_indices(ssm_state_indices, cu_seqlens, total_tokens)
     actual_seq_lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).to(torch.int32).contiguous()
+    flat_state_indices = torch.clamp_min(
+        flat_state_indices,
+        0,
+    ).contiguous()
     accepted_tokens = None
     if num_accepted_tokens is not None:
-        accepted_tokens = num_accepted_tokens[: actual_seq_lengths.shape[0]].to(torch.int32).contiguous()
+        accepted_tokens = _mask_padded_recurrent_accepted_tokens(
+            num_accepted_tokens,
+            actual_seq_lengths,
+        )
 
     out = torch.ops._C_ascend.npu_recurrent_gated_delta_rule_310(
         query=q.squeeze(0).to(torch.float16).contiguous(),
@@ -220,6 +262,13 @@ def _merge_spec_and_non_spec_outputs_310(
 
 class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
     get_state_dtype = _310p_get_state_dtype
+
+    def get_attn_backend(self):
+        from vllm_ascend._310p.ops.gdn_attn_builder_310 import (
+            AscendGDNAttentionBackend310,
+        )
+
+        return AscendGDNAttentionBackend310
 
     def _forward_core(
         self,
@@ -285,6 +334,15 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
             # than total requests; full-batch tensor fails tiling / wrong state offset).
             spec_num_accepted = num_accepted_tokens[: attn_metadata.num_spec_decodes].to(torch.int64)
             uniform_spec_only = attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0
+            # The final entry remains the runtime token count even when
+            # graph metadata includes padded requests.
+            spec_valid_tokens = spec_query_start_loc[-1]
+            if uniform_spec_only:
+                mixed_qkv_spec = _zero_padded_tokens(
+                    mixed_qkv_spec,
+                    spec_valid_tokens,
+                    token_dim=0,
+                )
             if _EXTRA_CTX.capturing and uniform_spec_only:
                 qsl_dev, cidx_dev, nat_dev, qsl_buf, cidx_buf, nat_buf = _get_spec_causal_conv1d_device_args(
                     attn_metadata
@@ -334,7 +392,6 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
                     pad_slot_id=PAD_SLOT_ID,
                     run_mode=1,
                 )
-
         # 1.2: Process the remaining part
         if attn_metadata.num_prefills > 0:
             if mixed_qkv_non_spec is not None:
@@ -477,6 +534,14 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
                 core_attn_out[:num_actual_tokens] = core_attn_out_non_spec.squeeze(0)
             else:
                 core_attn_out[:num_actual_tokens] = core_attn_out_non_spec.squeeze(0)[:num_actual_tokens]
+        if spec_sequence_masks is not None and uniform_spec_only:
+            core_attn_out.copy_(
+                _zero_padded_tokens(
+                    core_attn_out,
+                    spec_valid_tokens,
+                    token_dim=0,
+                )
+            )
         maybe_save_kv_layer_to_connector("", [])
 
 
@@ -494,6 +559,42 @@ def _get_spec_causal_conv1d_update_host_args_310p(
     )
 
 
+def _pad_spec_conv1d_host_args_shape_consistent_dummy_310p(
+    qsl_host: tuple[int, ...],
+    cidx_host: tuple[int, ...],
+    num_accepted_host: tuple[int, ...],
+    cap_x_dim0: int,
+    q_per_seq: int,
+) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+    """Pad dummy requests so query_start_loc reaches the captured token size."""
+    if not qsl_host:
+        return qsl_host, cidx_host, num_accepted_host
+
+    expected_seqs = len(qsl_host) - 1
+    if expected_seqs > len(cidx_host):
+        cidx_host = cidx_host + (PAD_SLOT_ID,) * (expected_seqs - len(cidx_host))
+    if expected_seqs > len(num_accepted_host):
+        num_accepted_host = num_accepted_host + (0,) * (expected_seqs - len(num_accepted_host))
+
+    runtime_qsl_last = int(qsl_host[-1])
+    pad_tokens = cap_x_dim0 - runtime_qsl_last
+    if pad_tokens <= 0 or q_per_seq <= 0:
+        return qsl_host, cidx_host, num_accepted_host
+
+    full_pad_seqs, remainder = divmod(pad_tokens, q_per_seq)
+    next_qsl = runtime_qsl_last
+    for _ in range(full_pad_seqs):
+        next_qsl += q_per_seq
+        qsl_host = qsl_host + (next_qsl,)
+        cidx_host = cidx_host + (PAD_SLOT_ID,)
+        num_accepted_host = num_accepted_host + (0,)
+    if remainder > 0:
+        qsl_host = qsl_host + (cap_x_dim0,)
+        cidx_host = cidx_host + (PAD_SLOT_ID,)
+        num_accepted_host = num_accepted_host + (0,)
+    return qsl_host, cidx_host, num_accepted_host
+
+
 def update_conv1d_graph_params_310p(
     update_stream,
     forward_context,
@@ -503,8 +604,6 @@ def update_conv1d_graph_params_310p(
     draft_attn_metadatas=None,
 ):
     """310P uniform spec-decode GDN conv1d graph replay via device buffer updates."""
-    from vllm_ascend.ops.gdn import _pad_conv1d_host_args_to_capture
-
     graph_params = get_draft_graph_params() if is_draft_model else get_graph_params()
 
     if (
@@ -558,13 +657,14 @@ def update_conv1d_graph_params_310p(
 
             cap_x_dim0 = int(mixed_qkv.size(0))
             qsl_host, cidx_host, num_accepted_host = _get_spec_causal_conv1d_update_host_args_310p(meta)
-            new_query_start_loc, new_cache_indices, new_num_accepted = _pad_conv1d_host_args_to_capture(
-                qsl_host,
-                cidx_host,
-                num_accepted_host,
-                cap_x_dim0=cap_x_dim0,
-                q_per_seq=q_per_seq,
-                with_num_accepted=True,
+            new_query_start_loc, new_cache_indices, new_num_accepted = (
+                _pad_spec_conv1d_host_args_shape_consistent_dummy_310p(
+                    qsl_host,
+                    cidx_host,
+                    num_accepted_host,
+                    cap_x_dim0=cap_x_dim0,
+                    q_per_seq=q_per_seq,
+                )
             )
             _copy_host_tuple_to_int64_buffer(qsl_dev, new_query_start_loc)
             _copy_host_tuple_to_int64_buffer(cidx_dev, new_cache_indices)

--- a/vllm_ascend/_310p/ops/gdn_attn_builder_310.py
+++ b/vllm_ascend/_310p/ops/gdn_attn_builder_310.py
@@ -12,25 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""310P RC GDN metadata builder: Ascend builder with RC-safe prefill metadata."""
+"""310P RC GDN metadata builder.
+
+This 310P-specific builder keeps the upstream RC-safe prefill metadata path
+and adds ACL graph replay padding for decode / speculative decode metadata.
+"""
 
 from __future__ import annotations
 
 import torch
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 
 from vllm_ascend._310p.ops.fla.cumpute_causal_conv1d_metadata_310 import (
     compute_causal_conv1d_metadata,
 )
-from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionMetadataBuilder
+from vllm_ascend.ops.gdn_attn_builder import (
+    AscendGDNAttentionBackend,
+    AscendGDNAttentionMetadataBuilder,
+)
 
 
 class GDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
-    """RC-only overrides on top of :class:`AscendGDNAttentionMetadataBuilder`.
+    """310P overrides on top of :class:`AscendGDNAttentionMetadataBuilder`.
 
     310P does not support Triton, so fallback metadata attachment is skipped.
+    For ACL graph replay, decode metadata is padded into fixed graph buffers.
     """
+
+    use_full_cuda_graph: bool
 
     def _build_prefill_has_initial_state_and_causal_conv1d_meta(
         self,
@@ -108,3 +119,148 @@ class GDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
     ) -> GDNAttentionMetadata:
         del common_attn_metadata, num_decode_draft_tokens_cpu
         return attn_metadata
+
+    def _pad_spec_decode_metadata(
+        self,
+        attn_metadata: GDNAttentionMetadata,
+        graph_batch_size: int,
+    ) -> None:
+        num_spec_decodes = attn_metadata.num_spec_decodes
+        spec_state_indices = attn_metadata.spec_state_indices_tensor
+        spec_sequence_masks = attn_metadata.spec_sequence_masks
+        spec_query_start_loc = attn_metadata.spec_query_start_loc
+        num_accepted_tokens = attn_metadata.num_accepted_tokens
+        assert spec_state_indices is not None
+        assert spec_sequence_masks is not None
+        assert spec_query_start_loc is not None
+        assert num_accepted_tokens is not None
+
+        self.spec_state_indices_tensor[:num_spec_decodes].copy_(
+            spec_state_indices,
+            non_blocking=True,
+        )
+        attn_metadata.spec_state_indices_tensor = self.spec_state_indices_tensor[:graph_batch_size]
+        attn_metadata.spec_state_indices_tensor[num_spec_decodes:].fill_(NULL_BLOCK_ID)
+
+        self.spec_sequence_masks[:num_spec_decodes].copy_(
+            spec_sequence_masks[:num_spec_decodes],
+            non_blocking=True,
+        )
+        attn_metadata.spec_sequence_masks = self.spec_sequence_masks[:graph_batch_size]
+        attn_metadata.spec_sequence_masks[num_spec_decodes:].fill_(False)
+
+        assert attn_metadata.non_spec_token_indx is not None
+        assert attn_metadata.spec_token_indx is not None
+        non_spec_tokens = attn_metadata.non_spec_token_indx
+        spec_tokens = attn_metadata.spec_token_indx
+        self.non_spec_token_indx[: non_spec_tokens.size(0)].copy_(
+            non_spec_tokens,
+            non_blocking=True,
+        )
+        self.spec_token_indx[: spec_tokens.size(0)].copy_(
+            spec_tokens,
+            non_blocking=True,
+        )
+        attn_metadata.non_spec_token_indx = self.non_spec_token_indx[: non_spec_tokens.size(0)]
+        attn_metadata.spec_token_indx = self.spec_token_indx[: spec_tokens.size(0)]
+
+        self.spec_query_start_loc[: num_spec_decodes + 1].copy_(
+            spec_query_start_loc,
+            non_blocking=True,
+        )
+        attn_metadata.spec_query_start_loc = self.spec_query_start_loc[: graph_batch_size + 1]
+        query_padding = attn_metadata.spec_query_start_loc[num_spec_decodes + 1 :]
+        if query_padding.numel() > 0:
+            query_padding.copy_(
+                spec_query_start_loc[-1].expand_as(query_padding),
+                non_blocking=True,
+            )
+
+        self.num_accepted_tokens[:num_spec_decodes].copy_(
+            num_accepted_tokens,
+            non_blocking=True,
+        )
+        attn_metadata.num_accepted_tokens = self.num_accepted_tokens[:graph_batch_size]
+        attn_metadata.num_accepted_tokens[num_spec_decodes:].fill_(0)
+
+    def _pad_decode_metadata(
+        self,
+        attn_metadata: GDNAttentionMetadata,
+        graph_batch_size: int,
+    ) -> None:
+        num_decodes = attn_metadata.num_decodes
+        state_indices = attn_metadata.non_spec_state_indices_tensor
+        query_start_loc = attn_metadata.non_spec_query_start_loc
+        assert state_indices is not None
+        assert query_start_loc is not None
+
+        self.non_spec_state_indices_tensor[:num_decodes].copy_(
+            state_indices,
+            non_blocking=True,
+        )
+        attn_metadata.non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[:graph_batch_size]
+        attn_metadata.non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
+
+        self.non_spec_query_start_loc[: num_decodes + 1].copy_(
+            query_start_loc,
+            non_blocking=True,
+        )
+        attn_metadata.non_spec_query_start_loc = self.non_spec_query_start_loc[: graph_batch_size + 1]
+        query_padding = attn_metadata.non_spec_query_start_loc[num_decodes + 1 :]
+        if query_padding.numel() > 0:
+            query_padding.copy_(
+                query_start_loc[-1].expand_as(query_padding),
+                non_blocking=True,
+            )
+
+    def build(  # type: ignore[override]
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        num_accepted_tokens: torch.Tensor | None = None,
+        num_decode_draft_tokens_cpu: torch.Tensor | None = None,
+        fast_build: bool = False,
+    ) -> GDNAttentionMetadata:
+        use_full_graph = self.use_full_cuda_graph
+        self.use_full_cuda_graph = False
+        try:
+            attn_metadata = super().build(
+                common_prefix_len,
+                common_attn_metadata,
+                num_accepted_tokens,
+                num_decode_draft_tokens_cpu,
+                fast_build,
+            )
+        finally:
+            self.use_full_cuda_graph = use_full_graph
+
+        if not use_full_graph:
+            return attn_metadata
+
+        graph_batch_size = common_attn_metadata.num_reqs
+        if (
+            attn_metadata.num_prefills == 0
+            and attn_metadata.num_decodes == 0
+            and attn_metadata.num_spec_decodes <= self.decode_cudagraph_max_bs
+            and attn_metadata.num_spec_decode_tokens <= self.decode_cudagraph_max_bs
+        ):
+            self._pad_spec_decode_metadata(attn_metadata, graph_batch_size)
+        elif (
+            attn_metadata.num_prefills == 0
+            and attn_metadata.num_spec_decodes == 0
+            and attn_metadata.num_decodes <= self.decode_cudagraph_max_bs
+        ):
+            self._pad_decode_metadata(attn_metadata, graph_batch_size)
+        return attn_metadata
+
+
+# Keep the name introduced by the 310P ACL graph padding patch so existing
+# imports and tests from that patch continue to work after rebasing onto
+# upstream/main, whose class name is GDNAttentionMetadataBuilder310.
+AscendGDNAttentionMetadataBuilder310 = GDNAttentionMetadataBuilder310
+
+
+class AscendGDNAttentionBackend310(AscendGDNAttentionBackend):
+    @staticmethod
+    def get_builder_cls() -> type[AscendGDNAttentionMetadataBuilder310]:
+        return AscendGDNAttentionMetadataBuilder310

--- a/vllm_ascend/patch/worker/patch_idex_310.py
+++ b/vllm_ascend/patch/worker/patch_idex_310.py
@@ -27,13 +27,16 @@ gdn_ops.update_conv1d_graph_params = update_conv1d_graph_params_310p
 AscendSpecDecodeBaseProposer.set_inputs_first_pass = (  # type: ignore[method-assign]
     AscendSpecDecodeBaseProposer310.set_inputs_first_pass
 )
-
 # Patch _warmup_prefill_kernels to no-op on 310P: triton.next_power_of_2 does
 # not exist in the triton version used on 310P CI, and NPU does not use these
 # CUDA warmup kernel anyway.
 QwenGatedDeltaNetAttention._warmup_prefill_kernels = lambda self, qkv_or_qkvz, v_dim: None  # type: ignore[method-assign]
 QwenGatedDeltaNetAttention._forward_core = AscendGatedDeltaNetAttention310._forward_core
 QwenGatedDeltaNetAttention.get_state_dtype = AscendGatedDeltaNetAttention310.get_state_dtype
+
+# 310P: make Qwen GDN use the 310P attention backend, including the
+# MTP ACL graph padding replay fixes provided by gdn_attn_builder_310.py.
+QwenGatedDeltaNetAttention.get_attn_backend = AscendGatedDeltaNetAttention310.get_attn_backend
 
 if is_rc_device():
     from vllm.v1.attention.backends.gdn_attn import GDNAttentionBackend


### PR DESCRIPTION
### What this PR does / why we need it?

When Qwen3.5 runs on 310P with MTP, FULL ACLGraph, and concurrent requests enabled, continuous batching can make the runtime request count smaller than the fixed shape captured by the graph. The 310P GDN spec-decode path therefore needs padded dummy requests, but the previous implementation did not consistently turn those dummy requests into no-op entries across spec_query_start_loc, state indices, num_accepted_tokens, and the conv1d replay buffers. In addition, the MTP full-graph path did not update and synchronize graph parameters before replay. As a result, the GDN conv1d/recurrent states could be advanced with padding metadata or stale metadata from the previous step, polluting hidden states/logits and causing garbled output and accuracy regression. This does not affect mainline or other devices because non-310P paths do not use NPUModelRunner310, patch_idex_310, npu_causal_conv1d_310, or the 310P-specific GDN buffer replay contract; they use the generic worker, generic Qwen3.5/GDN backend, and mainline graph-task update semantics, so they never consume this 310P-specific dummy metadata. This PR wires Qwen GDN on 310P to the 310P-specific backend, explicitly pads spec/decode metadata under full graph mode, marks dummy states as NULL_BLOCK_ID, sets dummy num_accepted_tokens to 0, zeros padded tokens/outputs, and updates/synchronizes graph parameters before MTP full-graph replay so each replay uses the current step’s correct metadata.

### Does this PR introduce any user-facing change?

NA

### How was this patch tested?

Local test 
<img width="884" height="126" alt="be1b75ad839d21277627b5153c38f15c" src="https://github.com/user-attachments/assets/cdc86664-fd48-4adb-95bb-9b55d887018e" />

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/b9a7cd464c9ae9b1b450f8982b76d7be4de73724
