### PR TITLE
Fix NPU runtime compatibility for Python 3.12

### DIFF
--- a/vllm_ascend/ops/__init__.py
+++ b/vllm_ascend/ops/__init__.py
@@ -15,12 +15,18 @@
 # This file is a part of the vllm-ascend project.
 #
 
+import sys
+
 import torch
 from vllm.triton_utils import HAS_TRITON
 
-import vllm_ascend.ops.fused_moe.fused_moe  # noqa
-import vllm_ascend.ops.layernorm  # noqa
-import vllm_ascend.ops.register_custom_ops  # noqa
+_device_op_module = sys.modules.get("vllm_ascend.device.device_op")
+_device_op_initializing = _device_op_module is not None and not hasattr(_device_op_module, "DeviceOperator")
+
+if not _device_op_initializing:
+    import vllm_ascend.ops.fused_moe.fused_moe  # noqa
+    import vllm_ascend.ops.layernorm  # noqa
+    import vllm_ascend.ops.register_custom_ops  # noqa
 
 if HAS_TRITON:
     import vllm_ascend.ops.triton.linearnorm.split_qkv_rmsnorm_rope  # noqa
@@ -28,7 +34,8 @@ if HAS_TRITON:
     import vllm_ascend.ops.triton.linearnorm.split_qkv_tp_rmsnorm_rope
     import vllm_ascend.ops.triton.linearnorm.split_qkv_rmsnorm_rope_simt
 
-import vllm_ascend.ops.vocab_parallel_embedding  # noqa
+if not _device_op_initializing:
+    import vllm_ascend.ops.vocab_parallel_embedding  # noqa
 from vllm_ascend.ops.activation import AscendQuickGELU, AscendSiluAndMul
 from vllm_ascend.ops.rotary_embedding import AscendDeepseekScalingRotaryEmbedding, AscendRotaryEmbedding
 

--- a/vllm_ascend/patch/platform/patch_torch_accelerator.py
+++ b/vllm_ascend/patch/platform/patch_torch_accelerator.py
@@ -1,6 +1,29 @@
 import torch
 
 
+def _get_npu_memory_info(
+    device: int | str | torch.device | None = None,
+) -> tuple[int, int]:
+    if device is None:
+        device = torch.npu.current_device()
+    elif isinstance(device, torch.device):
+        if device.type != "npu":
+            raise RuntimeError(f"Expected 'npu' device, got '{device.type}'")
+        device = device.index if device.index is not None else torch.npu.current_device()
+    elif isinstance(device, str):
+        if not device.startswith("npu"):
+            raise RuntimeError(f"Expected 'npu' device string, got '{device}'")
+        parts = device.split(":")
+        if len(parts) == 1:
+            device = torch.npu.current_device()
+        elif len(parts) == 2:
+            device = int(parts[1])
+        else:
+            raise RuntimeError(f"Invalid device string format: '{device}'")
+
+    return torch.npu.mem_get_info(device)
+
+
 def patch_empty_cache() -> None:
     torch.npu.empty_cache()
 
@@ -12,5 +35,7 @@ torch.accelerator.empty_cache = patch_empty_cache
 # with torch.accelerator.memory_stats(), but torch.accelerator does not
 # properly delegate to NPU. We redirect to torch.npu.* equivalents.
 torch.accelerator.memory_stats = torch.npu.memory_stats  # type: ignore[attr-defined]
+torch.accelerator.get_memory_info = _get_npu_memory_info  # type: ignore[attr-defined]
 torch.accelerator.memory_reserved = torch.npu.memory_reserved  # type: ignore[attr-defined]
+torch.accelerator.memory_allocated = torch.npu.memory_allocated  # type: ignore[attr-defined]
 torch.accelerator.reset_peak_memory_stats = torch.npu.reset_peak_memory_stats  # type: ignore[attr-defined]

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -74,6 +74,32 @@ _CUSTOM_OP_REGISTERED = False
 MAX_CAPTURE_SIZES_FOR_950 = 4
 
 
+def _get_npu_memory_info(
+    device: int | str | torch.device | None = None,
+) -> tuple[int, int]:
+    if device is None:
+        device = torch.npu.current_device()
+    elif isinstance(device, torch.device):
+        if device.type != "npu":
+            raise RuntimeError(f"Expected 'npu' device, got '{device.type}'")
+        device = device.index if device.index is not None else torch.npu.current_device()
+    elif isinstance(device, str):
+        if not device.startswith("npu"):
+            raise RuntimeError(f"Expected 'npu' device string, got '{device}'")
+        parts = device.split(":")
+        if len(parts) == 1:
+            device = torch.npu.current_device()
+        elif len(parts) == 2:
+            device = int(parts[1])
+        else:
+            raise RuntimeError(f"Invalid device string format: '{device}'")
+
+    return torch.npu.mem_get_info(device)
+
+
+torch.accelerator.get_memory_info = _get_npu_memory_info  # type: ignore[attr-defined]
+
+
 def config_deprecated_logging():
     """Configure deprecated logging format, when used deprecated codes
     in vllm-ascend.

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -19,11 +19,18 @@
 
 import torch
 from vllm.triton_utils import tl, triton
-from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
-    _compute_block_stats_kernel,
-    _compute_global_lse,
-    _insert_resampled_kernel,
-)
+try:
+    from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
+        _compute_global_logsumexp as _compute_global_lse,
+        _compute_local_logits_stats_kernel as _compute_block_stats_kernel,
+        _insert_resampled_kernel,
+    )
+except ImportError:
+    from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
+        _compute_block_stats_kernel,
+        _compute_global_lse,
+        _insert_resampled_kernel,
+    )
 
 
 @triton.jit


### PR DESCRIPTION
## Summary

- Map `torch.accelerator.get_memory_info` and `memory_allocated` to the NPU implementations so generic vLLM memory profiling works on Ascend.
- Avoid eager `vllm_ascend.ops` imports while `vllm_ascend.device.device_op` is still initializing.
- Make the spec-decode rejection sampler helper imports compatible with both old and renamed vLLM helper symbols.

## Why

With the Python 3.12 / torch-npu runtime, `torch.accelerator.get_memory_info` may exist but still route through the generic allocator path instead of `torch.npu.mem_get_info`. vLLM's `MemorySnapshot` can then fail during worker device initialization with an allocator assertion.

The eager `vllm_ascend.ops` imports can also create an import-order cycle through `device_op`, and recent vLLM changes renamed the spec-decode helper kernels used by the Ascend wrapper.

## Validation

- Syntax-compiled the touched Python files.
- Verified the downstream HUST stack with Python 3.12 on Ascend NPU 6,7, TP=2, Qwen2.5-7B; `/health` returned 200.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
