### PR TITLE
[Ops][BugFix] Fix NPU memory profiling on Python 3.12

### DIFF
--- a/vllm_ascend/patch/platform/patch_torch_accelerator.py
+++ b/vllm_ascend/patch/platform/patch_torch_accelerator.py
@@ -1,6 +1,29 @@
 import torch
 
 
+def _get_npu_memory_info(
+    device: int | str | torch.device | None = None,
+) -> tuple[int, int]:
+    if device is None:
+        device = torch.npu.current_device()
+    elif isinstance(device, torch.device):
+        if device.type != "npu":
+            raise RuntimeError(f"Expected 'npu' device, got '{device.type}'")
+        device = device.index if device.index is not None else torch.npu.current_device()
+    elif isinstance(device, str):
+        if not device.startswith("npu"):
+            raise RuntimeError(f"Expected 'npu' device string, got '{device}'")
+        parts = device.split(":")
+        if len(parts) == 1:
+            device = torch.npu.current_device()
+        elif len(parts) == 2:
+            device = int(parts[1])
+        else:
+            raise RuntimeError(f"Invalid device string format: '{device}'")
+
+    return torch.npu.mem_get_info(device)
+
+
 def patch_empty_cache() -> None:
     torch.npu.empty_cache()
 
@@ -12,7 +35,9 @@ torch.accelerator.empty_cache = patch_empty_cache
 # with torch.accelerator.memory_stats(), but torch.accelerator does not
 # properly delegate to NPU. We redirect to torch.npu.* equivalents.
 torch.accelerator.memory_stats = torch.npu.memory_stats  # type: ignore[attr-defined]
+torch.accelerator.get_memory_info = _get_npu_memory_info  # type: ignore[attr-defined]
 torch.accelerator.memory_reserved = torch.npu.memory_reserved  # type: ignore[attr-defined]
+torch.accelerator.memory_allocated = torch.npu.memory_allocated  # type: ignore[attr-defined]
 torch.accelerator.reset_peak_memory_stats = torch.npu.reset_peak_memory_stats  # type: ignore[attr-defined]
 # torch.accelerator.get_memory_info() routes through c10's
 # CachingDeviceAllocator and asserts the backend allocator is a


### PR DESCRIPTION
## Summary

Map torch.accelerator memory queries to torch.npu implementations in the centralized accelerator patch module. This keeps generic vLLM memory profiling on the NPU allocator path under Python 3.12 / torch-npu.

The earlier circular-import workaround, duplicate platform patch, and compatibility import shim were removed while rebasing because current main either already provides the required symbol names or has a centralized patch path.

## Validation

- git diff --check
- Python syntax compilation for the changed patch module
- downstream HUST stack previously verified on Ascend with Python 3.12, TP=2, Qwen2.5-7B