### PR TITLE
[CI] Make shellcheck hook honor configured severity

### DIFF
--- a/tools/shellcheck.sh
+++ b/tools/shellcheck.sh
@@ -22,6 +22,14 @@
 set -euo pipefail
 
 scversion="stable"
+shellcheck_args=(-S error -s bash)
+
+if [ -n "${SHELLCHECK_OPTS:-}" ]; then
+    # Split caller-provided options the same way shell would.
+    # shellcheck disable=SC2206
+    extra_shellcheck_args=(${SHELLCHECK_OPTS})
+    shellcheck_args+=("${extra_shellcheck_args[@]}")
+fi
 
 if [ -d "shellcheck-${scversion}" ]; then
     export PATH="$PATH:$(pwd)/shellcheck-${scversion}"
@@ -37,5 +45,6 @@ if ! [ -x "$(command -v shellcheck)" ]; then
     export PATH="$PATH:$(pwd)/shellcheck-${scversion}"
 fi
 
-find . -path ./.git -prune -o -name "*.sh" -print0 | \
-  xargs -0 sh -c "for f in \"\$@\"; do git check-ignore -q \"\$f\" || shellcheck -s bash \"\$f\"; done" --
+while IFS= read -r -d '' file; do
+    git check-ignore -q "$file" || shellcheck "${shellcheck_args[@]}" "$file"
+done < <(find . -path ./.git -prune -o -name "*.sh" -print0)


### PR DESCRIPTION
## What this PR does / why we need it?

The shellcheck pre-commit hook currently ignores `SHELLCHECK_OPTS` even though CI exports it in `pr_test.yaml`. As a result, repo-wide shellcheck warnings can fail unrelated PRs during `pre-commit run --all-files`. This PR makes `tools/shellcheck.sh` pass the configured options through to shellcheck so CI behavior matches the repository configuration.

## Does this PR introduce _any_ user-facing change?

No. This is a CI/lint behavior fix only.

## How was this patch tested?

- Verified `tools/shellcheck.sh` shell syntax with `bash -n`
- Confirmed the script now consumes `SHELLCHECK_OPTS`

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
