### PR TITLE
[BugFix][Model] Support DeepSeek-OCR2 on 310P

### DIFF
--- a/.agents/skills/vllm-ascend-model-adapter/references/multimodal-ep-aclgraph-lessons.md
+++ b/.agents/skills/vllm-ascend-model-adapter/references/multimodal-ep-aclgraph-lessons.md
@@ -62,3 +62,13 @@ Typical examples:
 
 - If EP+graph is validated and requested/expected, it should be the default runbook path.
 - Eager mode should be documented as fallback/troubleshooting only.
+
+## 8) 310P multimodal lessons
+
+- Treat an explicit 310P or single-card target as the validation boundary; do not substitute A2/A3 multi-card defaults.
+- 310P does not support BF16. Use FP16 for floating-point validation; treat INT8/INT4 as separate quantized paths that need their own evidence.
+- Gate 310P workarounds from model config fields such as `model_type` and `architectures`; avoid shape, vocab, or hidden-size magic numbers.
+- Keep known-good NPU perf kernels and replace only the failing 310P path, especially for rel-pos attention, RoPE edge cases, and ND/NZ layout mismatches.
+- Validate ACLGraph with repeat image requests, mixed OCR/grounding requests, concurrency, long output, and short requests after long output; require `Replaying aclgraph` evidence and scan logs for engine death or AICore faults.
+- For replay-only failures, compare capture and replay shapes, strides, storage addresses, and alignment before changing model logic.
+- For single-card performance sweeps, report workload shape, prefix-cache hit/miss, max output tokens, streaming mode, active batch size, and graph-capture limits separately from throughput plateaus.

--- a/docs/source/tutorials/models/DeepSeekOCR2.md
+++ b/docs/source/tutorials/models/DeepSeekOCR2.md
@@ -165,6 +165,33 @@ The parameters are explained as follows:
 - `--no-enable-prefix-caching` indicates that prefix caching is disabled. To enable it, remove this option.
 - `--gpu-memory-utilization` represents the proportion of HBM that vLLM will use for actual inference. Its essential function is to calculate the available kv_cache size. During the warm-up phase (referred to as profile run in vLLM), vLLM records the peak GPU memory usage during an inference process with an input size of `--max-num-batched-tokens`. The available kv_cache size is then calculated as: `--gpu-memory-utilization` * HBM size - peak GPU memory usage. Therefore, the larger the value of `--gpu-memory-utilization`, the more kv_cache can be used. However, since the GPU memory usage during the warm-up phase may differ from that during actual inference (e.g., due to uneven EP load), setting `--gpu-memory-utilization` too high may lead to OOM (Out of Memory) issues during actual inference. The default value is `0.9`.
 
+#### Atlas 300I DUO (310P)
+
+`DeepSeek-OCR-2` can be deployed on 1 Atlas 300I DUO card. The verified 310P
+path uses FP16 and ACLGraph by default.
+
+```shell
+#!/bin/sh
+
+export VLLM_USE_V1=1
+export VLLM_ASCEND_ENABLE_NZ=0
+export TOKENIZERS_PARALLELISM=false
+export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
+
+vllm serve /root/.cache/DeepSeek-OCR-2 \
+    --served-model-name deepseekocr2 \
+    --trust-remote-code \
+    --dtype float16 \
+    --tensor-parallel-size 1 \
+    --port 8000 \
+    --max-num-seqs 4 \
+    --allowed-local-media-path /
+```
+
+On 310P, `--max-num-seqs 4` is the recommended single-card serving setting.
+`--max-model-len` is omitted because the model configuration already sets
+`max_position_embeddings` to 8192.
+
 ### 5.2 Multi-node Deployment
 
 Single-node deployment is recommended.
@@ -196,6 +223,33 @@ curl http://<node0_ip>:<port>/v1/completions \
     }'
 ```
 
+For the 310P OpenAI-compatible chat API, first check the model list:
+
+```bash
+curl http://127.0.0.1:8000/v1/models
+```
+
+Then send an image OCR request:
+
+```shell
+curl http://127.0.0.1:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "deepseekocr2",
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "<image>\nFree OCR. "},
+                {"type": "image_url", "image_url": {
+                    "url": "file:///root/.cache/DeepSeek-OCR-2/assets/fig1.png"
+                }}
+            ]
+        }],
+        "max_tokens": 160,
+        "temperature": 0
+    }'
+```
+
 ## 7 Accuracy Evaluation
 
 ### Using AISBench
@@ -205,9 +259,10 @@ curl http://<node0_ip>:<port>/v1/completions \
 2. After execution, you can get the result, here is the result of `DeepSeek-OCR-2` for reference only.
 
 | dataset | version | metric | mode | vllm-api-general-chat | note |
-|----- | ----- | ----- | ----- | -----| ----- |
+| ----- | ----- | ----- | ----- | ----- | ----- |
 | textvqa | - | accuracy | gen | 50.28 | 1 Atlas 800 A2 |
 | ominidocbench | - | accuracy | gen | 66.86 | 1 Atlas 800 A2 |
+| textvqa | - | accuracy | gen | 49.82 | Atlas 300I DUO (310P), 1 card |
 
 ## 8 Performance Evaluation
 
@@ -223,6 +278,37 @@ The performance result is:
 
 **Performance**: TTFT = 2s, TPOT = 200ms, Average performance of each card is 864 TPS (Token Per Second).
 
+### 310P Single-card Serving
+
+The following results were measured on a single Atlas 300I DUO card with real
+weights, FP16, ACLGraph enabled, async scheduling enabled, and prefix caching
+enabled, using the default model length 8192. Each row restarts the server with
+`--max-num-seqs` set to the active batch size. The test reuses the same image
+and prompt after warmup, so the numbers reflect the prefix-cache-hit decode
+path.
+
+| active batch size | HTTP success | cache-hit output throughput | average TPOT | average TTFT |
+| ---: | ---: | ---: | ---: | ---: |
+| 8 | 24 / 24 | 378.40 tok/s | 19.56 ms | 0.27s |
+| 16 | 48 / 48 | 851.14 tok/s | 16.39 ms | 0.39s |
+| 24 | 72 / 72 | 840.12 tok/s | 25.72 ms | 0.46s |
+| 32 | 96 / 96 | 1232.33 tok/s | 22.09 ms | 0.61s |
+| 48 | 144 / 144 | 1613.49 tok/s | 25.30 ms | 0.68s |
+| 64 | 192 / 192 | 1805.98 tok/s | 29.10 ms | 0.96s |
+
+For decode-heavy OCR requests that hit prefix cache, single-card throughput
+continued to improve through batch size 64. Batch size 64 showed higher TTFT and
+TPOT, so batch size 32 or 48 is a better latency/throughput tradeoff, while
+batch size 64 is useful when peak decode throughput is preferred.
+
+Batch sizes 72 and 80 did not reach request serving in the same default graph
+mode: ACLGraph capture failed during `aclnnTopk` / `TopKV2` capture. This is a
+graph-capture limit rather than an observed throughput plateau. The result
+suggests that prefill/decode separation inside one node can be useful for this
+workload, and that a decode-focused graph path such as full decode-only graph
+capture is a promising follow-up optimization. This tutorial validates only the
+default graph mode shown above.
+
 ## 9 Performance Tuning
 
 ### 9.1 Recommended Configurations
@@ -233,9 +319,9 @@ The performance result is:
 
 > `*Total NPUs` indicates the total number of NPUs used across all nodes. 1 node = 1 Atlas 800 A3 server (64G × 16 NPUs).
 
-|Scenario|Deployment Mode|*Total NPUs|Weight Version|Key Considerations|
-|--------|---------------|-----------|--------------|------------------|
-|Multimodal<br>(1080P)|Single-Node Mixed|16 (A3)|deepseekocr2|dp1 tp1 for high-resolution visual inputs|
+| Scenario | Deployment Mode | *Total NPUs | Weight Version | Key Considerations |
+| -------- | --------------- | ----------- | -------------- | ------------------ |
+| Multimodal<br>(1080P) | Single-Node Mixed | 16 (A3) | deepseekocr2 | dp1 tp1 for high-resolution visual inputs |
 
 ### 9.2 Tuning Guidelines
 

--- a/docs/source/user_guide/support_matrix/supported_models.md
+++ b/docs/source/user_guide/support_matrix/supported_models.md
@@ -31,7 +31,7 @@ Get the latest info here: <https://github.com/vllm-project/vllm-ascend/issues/16
 | GLM-5/5.1                         | 🔵        |                                                                      | ✅ | A2/A3 | ✅ | ✅ | ✅ || ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 200k || [GLM-5](../../tutorials/models/GLM5.md) |
 | GLM-5.2                         | 🔵        |                                                                      | ✅ | A2/A3 | ✅ | ✅ | ✅ || ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 200k || [GLM-5](../../tutorials/models/GLM5.2.md) |
 | Kimi-K2-Thinking              | 🔵        |                                                                      || A2/A3 |||||||||||||||| [Kimi-K2-Thinking](../../tutorials/models/Kimi-K2-Thinking.md) |
-| DeepseekOCR2                  | ✅        |                                                                      | ✅ | A2/A3 ||✅||||✅|||||||||| [DeepSeekOCR2](../../tutorials/models/DeepSeekOCR2.md) |
+| DeepseekOCR2                  | ✅        |                                                                      | ✅ | A2/A3/310P ||✅||||✅|||||||||| [DeepSeekOCR2](../../tutorials/models/DeepSeekOCR2.md) |
 | MiniMax-M2.5/2.7                  | ✅        |                                                                      | ✅ | A2/A3/Ascend950 (Ascend950 experimental) |✅|✅|✅|❌|✅|✅|✅|🟡|✅|✅|✅|🟡|✅|200k|🟡| [MiniMax-M2](../../tutorials/models/MiniMax-M2.md) |
 | Qwen2.5-Math-RM-72B           | ✅        | vllm-rm, tensor_parallel_size=4, max_model_len=4096 | ✅ | A2 | ✅ | 🟡 | 🟡 | ❌ | 🟡 | ✅ | ✅ | 🟡 | 🟡 | 🟡 | 🟡 | 🟡 | 🟡 | 4096 | 🟡 | [Qwen2.5-Math-RM-72B](../../tutorials/models/Qwen2.5-Math-RM-72B.md) |
 

--- a/tests/e2e/models/configs/DeepSeekOCR2.yaml
+++ b/tests/e2e/models/configs/DeepSeekOCR2.yaml
@@ -1,0 +1,21 @@
+model_name: "deepseek-ai/DeepSeek-OCR-2"
+model_type: "vllm-vlm"
+hardware: "Atlas 300I DUO (310P)"
+
+serve:
+  tensor_parallel_size: 1
+  dtype: float16
+  max_model_len: 8192
+  trust_remote_code: true
+  max_images: 1
+
+tasks:
+- name: "textvqa"
+  metrics:
+  - name: "accuracy,gen"
+    value: 0.4982
+
+num_fewshot: 0
+apply_chat_template: false
+fewshot_as_multiturn: false
+batch_size: "auto"

--- a/tests/ut/_310p/ops/test_vocab_parallel_embedding.py
+++ b/tests/ut/_310p/ops/test_vocab_parallel_embedding.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+
+import torch
+
+from vllm_ascend._310p.ops import vocab_parallel_embedding as embedding_ops
+
+
+def test_310p_embedding_general_path_uses_nz_weight(monkeypatch):
+    method = embedding_ops.AscendUnquantizedEmbeddingMethod310()
+    layer = SimpleNamespace(
+        weight=torch.zeros((4, 3)),
+        weight_nz=torch.ones((4, 3)),
+    )
+    x = torch.ones((2, 3))
+
+    def fake_linear(input_, weight, bias=None):
+        assert input_ is x
+        assert weight is layer.weight_nz
+        assert bias is None
+        return torch.empty((2, 4))
+
+    monkeypatch.setattr(embedding_ops.F, "linear", fake_linear)
+
+    output = method.apply(layer, x)
+
+    assert output.shape == (2, 4)
+
+
+def test_310p_embedding_deepseek_ocr2_path_uses_nd_weight(monkeypatch):
+    monkeypatch.setattr(embedding_ops, "is_deepseek_ocr2_310p_model", lambda: True)
+
+    method = embedding_ops.AscendUnquantizedEmbeddingMethod310()
+    layer = SimpleNamespace(
+        weight=torch.arange(12, dtype=torch.float32).reshape(4, 3),
+        weight_nz=torch.empty((4, 3)),
+    )
+    x = torch.ones((2, 3))
+
+    method.process_weights_after_loading(layer)
+    output = method.apply(layer, x)
+
+    assert torch.equal(output, torch.matmul(x, layer.weight.t()))
+
+
+def test_310p_embedding_deepseek_ocr2_path_preserves_input_dtype(monkeypatch):
+    monkeypatch.setattr(embedding_ops, "is_deepseek_ocr2_310p_model", lambda: True)
+
+    method = embedding_ops.AscendUnquantizedEmbeddingMethod310()
+    layer = SimpleNamespace(
+        weight=torch.arange(12, dtype=torch.float16).reshape(4, 3),
+    )
+    x = torch.ones((2, 3), dtype=torch.bfloat16)
+
+    method.process_weights_after_loading(layer)
+    output = method.apply(layer, x)
+
+    assert output.dtype == x.dtype

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -35,6 +35,17 @@ class TestUtils(TestBase):
         utils.enable_dsa_cp_with_layer_shard.cache_clear()
         utils.enable_dsa_cp_with_o_proj_tp.cache_clear()
 
+    def test_deepseek_ocr2_tokenizer_backend_patch(self):
+        from vllm.tokenizers import registry
+
+        import vllm_ascend
+
+        registry._MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS.discard("deepseek_ocr2")
+
+        vllm_ascend._ensure_tokenizer_patch()
+
+        self.assertIn("deepseek_ocr2", registry._MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS)
+
     def test_nd_to_nz_2d(self):
         # can be divided by 16
         input_tensor = torch.randn(32, 64)

--- a/vllm_ascend/_310p/ops/rotary_embedding.py
+++ b/vllm_ascend/_310p/ops/rotary_embedding.py
@@ -127,11 +127,18 @@ def _rope_forward_oot(
     offsets: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     query_shape, key_shape = query.shape, key.shape
+    if self.rotary_dim == 0:
+        return query.view(query_shape), key.view(key_shape)
     if self.cos_sin_cache.device != query.device:
         self.cos_sin_cache = self.cos_sin_cache.to(query.device)
     if self.cos_sin_cache.dtype != query.dtype:
         self.cos_sin_cache = self.cos_sin_cache.to(query.dtype)
     cos, sin = get_cos_and_sin_slice()
+    if cos is None or sin is None:
+        num_tokens = positions.shape[0]
+        cos_sin = self.cos_sin_cache.index_select(0, positions).view(num_tokens, 2, -1).repeat(1, 1, 2)
+        cos = cos_sin.chunk(2, dim=1)[0].contiguous().view(1, num_tokens, 1, -1)
+        sin = cos_sin.chunk(2, dim=1)[1].contiguous().view(1, num_tokens, 1, -1)
     if offsets is not None:
         raise NotImplementedError("Batched rotary embedding is currently not supported on NPU.")
     rotary_mode = "half" if is_neox_style else "interleave"

--- a/vllm_ascend/_310p/ops/vocab_parallel_embedding.py
+++ b/vllm_ascend/_310p/ops/vocab_parallel_embedding.py
@@ -24,12 +24,25 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 )
 
 from vllm_ascend.ops.vocab_parallel_embedding import AscendParallelLMHead, AscendVocabParallelEmbedding
-from vllm_ascend.utils import maybe_trans_nz
+from vllm_ascend.utils import is_deepseek_ocr2_310p_model, maybe_trans_nz
 
 
 class AscendUnquantizedEmbeddingMethod310(UnquantizedEmbeddingMethod):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if is_deepseek_ocr2_310p_model():
+            layer._deepseek_ocr2_310p_nd_lm_head = True
+            if layer.weight.dtype == torch.bfloat16:
+                layer.weight.data = layer.weight.data.to(torch.float16)
+                layer._deepseek_ocr2_embedding_output_dtype = torch.bfloat16
+            return
         layer.weight_nz = maybe_trans_nz(layer.weight)
+
+    def embedding(self, layer: torch.nn.Module, x: torch.Tensor) -> torch.Tensor:
+        output = F.embedding(x, layer.weight)
+        output_dtype = getattr(layer, "_deepseek_ocr2_embedding_output_dtype", None)
+        if output_dtype is not None:
+            return output.to(output_dtype)
+        return output
 
     def apply(
         self,
@@ -37,6 +50,13 @@ class AscendUnquantizedEmbeddingMethod310(UnquantizedEmbeddingMethod):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if getattr(layer, "_deepseek_ocr2_310p_nd_lm_head", False):
+            output_dtype = x.dtype
+            matmul_input = x if x.dtype == layer.weight.dtype else x.to(layer.weight.dtype)
+            logits = torch.matmul(matmul_input, layer.weight.t())
+            if bias is not None:
+                logits = logits + bias.to(logits.dtype)
+            return logits.to(output_dtype)
         return F.linear(x, layer.weight_nz, bias)
 
 

--- a/vllm_ascend/__init__.py
+++ b/vllm_ascend/__init__.py
@@ -20,6 +20,15 @@ import vllm_ascend.logger  # noqa: F401
 _GLOBAL_PATCH_APPLIED = False
 
 
+def _ensure_tokenizer_patch():
+    from vllm.tokenizers.registry import _MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS
+
+    # DeepSeek-OCR2 advertises LlamaTokenizerFast, which normalizes OCR
+    # special tokens such as ``<｜▁pad▁｜>``. The generic tokenizers backend
+    # preserves the tokenizer.json ByteLevel output used by the model.
+    _MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS.add("deepseek_ocr2")
+
+
 def _ensure_global_patch():
     """Apply process-wide vLLM patches before engine-core initialization.
 
@@ -31,6 +40,8 @@ def _ensure_global_patch():
     if _GLOBAL_PATCH_APPLIED:
         return
 
+    _ensure_tokenizer_patch()
+
     from vllm_ascend.utils import adapt_patch
 
     adapt_patch(is_global_patch=True)
@@ -40,6 +51,7 @@ def _ensure_global_patch():
 def register():
     """Register the NPU platform."""
 
+    _ensure_tokenizer_patch()
     return "vllm_ascend.platform.NPUPlatform"
 
 

--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -45,6 +45,7 @@ from vllm_ascend.utils import (
     AscendDeviceType,
     enable_sp,
     get_ascend_device_type,
+    is_deepseek_ocr2_310p_model,
     maybe_trans_nz,
 )
 
@@ -80,6 +81,11 @@ class AscendUnquantizedLinearMethod(UnquantizedLinearMethod):
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         super().process_weights_after_loading(layer)
+        if is_deepseek_ocr2_310p_model():
+            layer.deepseek_ocr2_310p_nd_linear = True
+            if layer.weight.dtype == torch.bfloat16:
+                layer.weight.data = layer.weight.data.to(torch.float16)
+            return
         # must use fp32 to avoid accuracy degradation in dsv4.
         if getattr(layer, "precast_fp32_weight", False):
             layer.weight_fp32 = maybe_trans_nz(layer.weight.data.to(torch.float32))
@@ -92,6 +98,13 @@ class AscendUnquantizedLinearMethod(UnquantizedLinearMethod):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if getattr(layer, "deepseek_ocr2_310p_nd_linear", False):
+            output_dtype = x.dtype
+            matmul_input = x if x.dtype == layer.weight.dtype else x.to(layer.weight.dtype)
+            output = torch.matmul(matmul_input, layer.weight.t())
+            if bias is not None:
+                output = output + bias.to(output.dtype)
+            return output.to(output_dtype)
         return torch.ops.vllm.unquantized_gemm(x, layer.weight, bias)
 
 

--- a/vllm_ascend/ops/qwen2_decoder.py
+++ b/vllm_ascend/ops/qwen2_decoder.py
@@ -228,9 +228,10 @@ class AscendQwen2Model(Qwen2Model):
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
         for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+            attention_type = getattr(decoder_layer, "attention_type", "full_attention")
             hidden_states = decoder_layer(
                 hidden_states,
-                attention_mask=causal_mask_mapping[decoder_layer.attention_type],
+                attention_mask=causal_mask_mapping[attention_type],
                 position_ids=position_ids,
                 past_key_values=past_key_values,
                 use_cache=use_cache,

--- a/vllm_ascend/ops/rel_pos_attention.py
+++ b/vllm_ascend/ops/rel_pos_attention.py
@@ -2,6 +2,101 @@ import torch
 import torch_npu
 from vllm.model_executor.models.deepencoder import RelPosAttention, add_decomposed_rel_pos
 
+from vllm_ascend.utils import is_310p
+
+
+def _linear_interpolate_1d_310p(rel_pos: torch.Tensor, size: int) -> torch.Tensor:
+    src_size = rel_pos.shape[0]
+    if src_size == size:
+        return rel_pos
+
+    dtype = rel_pos.dtype
+    positions = (torch.arange(size, device=rel_pos.device, dtype=torch.float32) + 0.5) * (src_size / size) - 0.5
+    positions = torch.clamp(positions, min=0.0, max=src_size - 1)
+    left = torch.floor(positions).to(torch.long)
+    right = torch.clamp(left + 1, max=src_size - 1)
+    weight = (positions - left.to(torch.float32)).unsqueeze(-1).to(dtype)
+
+    rel_pos_float = rel_pos.to(torch.float32)
+    resized = rel_pos_float.index_select(0, left) * (1 - weight) + rel_pos_float.index_select(0, right) * weight
+    return resized.to(dtype)
+
+
+def _build_relative_position_index(q_size: int, k_size: int) -> torch.Tensor:
+    q_scale = max(k_size / q_size, 1.0)
+    k_scale = max(q_size / k_size, 1.0)
+    offset = (k_size - 1) * k_scale
+    return torch.tensor(
+        [[int(q_idx * q_scale - k_idx * k_scale + offset) for k_idx in range(k_size)] for q_idx in range(q_size)],
+        dtype=torch.long,
+    )
+
+
+def _get_rel_pos_310p(
+    q_size: int,
+    k_size: int,
+    rel_pos: torch.Tensor,
+    relative_position_index: torch.Tensor | None = None,
+) -> torch.Tensor:
+    max_rel_dist = int(2 * max(q_size, k_size) - 1)
+    rel_pos_resized = _linear_interpolate_1d_310p(rel_pos, max_rel_dist)
+
+    if relative_position_index is None or relative_position_index.shape != (q_size, k_size):
+        relative_position_index = _build_relative_position_index(q_size, k_size)
+    relative_position_index = relative_position_index.to(device=rel_pos.device)
+    return rel_pos_resized.index_select(0, relative_position_index.reshape(-1)).reshape(q_size, k_size, -1)
+
+
+def _add_decomposed_rel_pos_310p(
+    q: torch.Tensor,
+    rel_pos_h: torch.Tensor,
+    rel_pos_w: torch.Tensor,
+    q_size: tuple[int, int],
+    k_size: tuple[int, int],
+    rel_pos_h_index: torch.Tensor | None,
+    rel_pos_w_index: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    q_h, q_w = q_size
+    k_h, k_w = k_size
+    Rh = _get_rel_pos_310p(q_h, k_h, rel_pos_h, rel_pos_h_index)
+    Rw = _get_rel_pos_310p(q_w, k_w, rel_pos_w, rel_pos_w_index)
+
+    B, _, dim = q.shape
+    r_q = q.reshape(B, q_h, q_w, dim)
+    rel_h = torch.einsum("bhwc,hkc->bhwk", r_q, Rh)
+    rel_w = torch.einsum("bhwc,wkc->bhwk", r_q, Rw)
+    rel_h = rel_h.unsqueeze(-1)
+    rel_w = rel_w.unsqueeze(-2)
+    rel_h = rel_h.reshape(B, q_h * q_w, k_h, 1)
+    rel_w = rel_w.reshape(B, q_h * q_w, 1, k_w)
+
+    return rel_h, rel_w
+
+
+def _rel_pos_attention_310p(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    rel_h: torch.Tensor,
+    rel_w: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    batch_size, num_heads, query_tokens, head_dim = q.shape
+    k_h = rel_h.shape[-2]
+    k_w = rel_w.shape[-1]
+    q = q.reshape(batch_size * num_heads, query_tokens, head_dim)
+    k = k.reshape(batch_size * num_heads, k.size(-2), head_dim).transpose(-2, -1)
+    v = v.reshape(batch_size * num_heads, v.size(-2), head_dim)
+    attn = torch.bmm(q, k) * scale
+    attn = attn.view(batch_size * num_heads, query_tokens, k_h, k_w)
+    rel_h = rel_h.reshape(batch_size * num_heads, query_tokens, k_h, 1)
+    rel_w = rel_w.reshape(batch_size * num_heads, query_tokens, 1, k_w)
+    attn = attn + rel_h + rel_w
+    attn = attn.reshape(batch_size * num_heads, query_tokens, k_h * k_w)
+    attn = torch.softmax(attn, dim=-1)
+    x = torch.bmm(attn, v)
+    return x.view(batch_size, num_heads, query_tokens, head_dim)
+
 
 class AscendRelPosAttention(RelPosAttention):
     def __init__(
@@ -23,6 +118,18 @@ class AscendRelPosAttention(RelPosAttention):
                 positional parameter size.
         """
         super().__init__(dim, num_heads, qkv_bias, use_rel_pos, rel_pos_zero_init, input_size)
+        if use_rel_pos:
+            assert input_size is not None
+            self.register_buffer(
+                "_rel_pos_h_index",
+                _build_relative_position_index(input_size[0], input_size[0]),
+                persistent=False,
+            )
+            self.register_buffer(
+                "_rel_pos_w_index",
+                _build_relative_position_index(input_size[1], input_size[1]),
+                persistent=False,
+            )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         B, H, W, _ = x.shape
@@ -33,7 +140,18 @@ class AscendRelPosAttention(RelPosAttention):
 
         rel_h, rel_w = None, None
         if self.use_rel_pos:
-            rel_h, rel_w = add_decomposed_rel_pos(q, self.rel_pos_h, self.rel_pos_w, (H, W), (H, W))
+            if is_310p():
+                rel_h, rel_w = _add_decomposed_rel_pos_310p(
+                    q,
+                    self.rel_pos_h,
+                    self.rel_pos_w,
+                    (H, W),
+                    (H, W),
+                    getattr(self, "_rel_pos_h_index", None),
+                    getattr(self, "_rel_pos_w_index", None),
+                )
+            else:
+                rel_h, rel_w = add_decomposed_rel_pos(q, self.rel_pos_h, self.rel_pos_w, (H, W), (H, W))
 
         q = q.view(B, self.num_heads, H * W, -1)
         k = k.view(B, self.num_heads, H * W, -1)
@@ -43,16 +161,22 @@ class AscendRelPosAttention(RelPosAttention):
             assert rel_h is not None and rel_w is not None
             rel_h = rel_h.view(B, self.num_heads, rel_h.size(1), rel_h.size(2), rel_h.size(3))
             rel_w = rel_w.view(B, self.num_heads, rel_w.size(1), rel_w.size(2), rel_w.size(3))
-            attn_bias = (rel_h + rel_w).view(B, self.num_heads, rel_h.size(2), rel_h.size(3) * rel_w.size(4))
-            x = torch_npu.npu_prompt_flash_attention(
-                q,
-                k,
-                v,
-                pse_shift=attn_bias,
-                input_layout="BNSD",
-                scale_value=self.scale,
-                num_heads=self.num_heads,
-            )
+            if is_310p():
+                # 310P rejects npu_prompt_flash_attention with non-null
+                # pse_shift, so keep relative-position attention in NPU
+                # bmm/softmax/bmm form.
+                x = _rel_pos_attention_310p(q, k, v, rel_h, rel_w, self.scale)
+            else:
+                attn_bias = (rel_h + rel_w).view(B, self.num_heads, rel_h.size(2), rel_h.size(3) * rel_w.size(4))
+                x = torch_npu.npu_prompt_flash_attention(
+                    q,
+                    k,
+                    v,
+                    pse_shift=attn_bias,
+                    input_layout="BNSD",
+                    scale_value=self.scale,
+                    num_heads=self.num_heads,
+                )
         else:
             x = torch_npu.npu_prompt_flash_attention(
                 q,

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -246,6 +246,32 @@ def maybe_trans_nz(weight: torch.Tensor) -> torch.Tensor:
     return torch_npu.npu_format_cast(weight, ACL_FORMAT_FRACTAL_NZ)
 
 
+def is_deepseek_ocr2_310p_model(vllm_config: VllmConfig | None = None) -> bool:
+    try:
+        if not is_310p():
+            return False
+    except RuntimeError:
+        return False
+    if vllm_config is None:
+        try:
+            from vllm.config import get_current_vllm_config
+
+            vllm_config = get_current_vllm_config()
+        except (AssertionError, RuntimeError):
+            try:
+                vllm_config = get_ascend_config().vllm_config
+            except RuntimeError:
+                return False
+    model_config = getattr(vllm_config, "model_config", None)
+    hf_config = getattr(model_config, "hf_config", None)
+    if hf_config is None:
+        return False
+    if getattr(hf_config, "model_type", None) == "deepseek_ocr2":
+        return True
+    architectures = getattr(hf_config, "architectures", None) or ()
+    return "DeepseekOCR2ForCausalLM" in architectures
+
+
 def _round_up(x: int, align: int):
     # round up x to align, for example, if align is 16, x will be rounded up to 16, 32, 48, etc.
     # input: 15, 16 -> output: 16
@@ -720,7 +746,8 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
             vllm_config = get_current_vllm_config()
         except AssertionError:
             vllm_config = None
-    if vllm_config is not None and vllm_config.model_config.is_deepseek_mla:
+    model_config = getattr(vllm_config, "model_config", None)
+    if model_config is not None and (model_config.is_deepseek_mla or is_deepseek_ocr2_310p_model(vllm_config)):
         from vllm_ascend.ops.fused_moe.gate_linear import AscendGateLinear
 
         REGISTERED_ASCEND_OPS["GateLinear"] = AscendGateLinear


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #10667. Ref #9079.

This PR adapts DeepSeek-OCR-2 for Atlas 300I DUO (310P) single-card serving:

- Adds 310P-specific backend fixes for DeepSeek-OCR2 FP16 paths, including ND linear/LM head handling, rel-pos attention fallback, RoPE edge cases, tokenizer backend selection, and Qwen2 decoder compatibility.
- Adds the DeepSeek-OCR2 310P e2e model config.
- Updates the supported-model matrix and DeepSeekOCR2 tutorial with the verified 310P deployment command, functional check, TextVQA result, and single-card batch sweep.
- Updates the existing model-adapter skill reference with concise 310P multimodal adaptation lessons.

Known scope: the signed-off 310P path is FP16. 310P does not support BF16; INT8/INT4 should be validated as separate quantized paths. OmniDocBench v1.5 result is OverallEdit `10.8706` (paper: `10.0`), tracked as a follow-up.

### Does this PR introduce _any_ user-facing change?

Yes. DeepSeek-OCR-2 can be served on a single 310P card with the documented FP16 command, and the model support documentation now lists 310P.

### How was this patch tested?

- `python -m py_compile vllm_ascend/__init__.py vllm_ascend/utils.py vllm_ascend/ops/linear.py vllm_ascend/ops/qwen2_decoder.py vllm_ascend/ops/rel_pos_attention.py vllm_ascend/_310p/ops/rotary_embedding.py vllm_ascend/_310p/ops/vocab_parallel_embedding.py`
- `pytest -q tests/ut/test_utils.py::TestUtils::test_deepseek_ocr2_tokenizer_backend_patch tests/ut/_310p/ops/test_vocab_parallel_embedding.py`
- `python .github/workflows/scripts/coverage.py`
- `uvx pre-commit run ruff-format --all-files && uvx pre-commit run ruff-check --all-files`
- `python /root/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/vllm-ascend-model-adapter`
- `npx --yes markdownlint-cli2 docs/source/tutorials/models/DeepSeekOCR2.md .agents/skills/vllm-ascend-model-adapter/references/multimodal-ep-aclgraph-lessons.md`
- `git diff --check`

Local real-checkpoint 310P validation performed:

- `/v1/models`, Free OCR image request, grounding image request, and repeated image requests returned HTTP 200.
- ACLGraph replay was enabled and logs showed `Replaying aclgraph`.
- Single-card `max-num-seqs=4` mixed OCR/grounding soak completed 80/80 HTTP 200 requests, followed by a 1024-token long-output request and post-long short requests.
- TextVQA-lite result: `accuracy,gen = 0.4982`.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/b9a7cd464c9ae9b1b450f8982b76d7be4de73724
