### PR TITLE
[BugFix] Keep connector hash granularity with CP hybrid groups

### DIFF
--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -97,12 +97,14 @@ def _make_vllm_config(
     dcp: int,
     pcp: int,
     block_size: int = 16,
+    kv_transfer_config: object | None = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         cache_config=SimpleNamespace(
             block_size=block_size,
             enable_prefix_caching=enable_prefix_caching,
         ),
+        kv_transfer_config=kv_transfer_config,
         parallel_config=SimpleNamespace(
             decode_context_parallel_size=dcp,
             prefill_context_parallel_size=pcp,
@@ -124,14 +126,21 @@ def _make_coordinator_for_effective_block_size(
 
 
 @pytest.mark.parametrize(
-    ("enable_prefix_caching", "expected_hash_block_size"),
+    ("enable_prefix_caching", "connector_enabled", "expected_hash_block_size"),
     [
-        pytest.param(False, math.lcm(16, 32) * 2 * 2, id="cp-without-prefix-caching"),
-        pytest.param(True, math.gcd(16, 32), id="cp-with-prefix-caching"),
+        pytest.param(
+            False,
+            False,
+            math.lcm(16, 32) * 2 * 2,
+            id="cp-without-prefix-caching",
+        ),
+        pytest.param(False, True, math.gcd(16, 32), id="cp-with-connector"),
+        pytest.param(True, False, math.gcd(16, 32), id="cp-with-prefix-caching"),
     ],
 )
 def test_resolve_kv_cache_block_sizes_with_cp_hybrid_groups(
     enable_prefix_caching: bool,
+    connector_enabled: bool,
     expected_hash_block_size: int,
 ) -> None:
     kv_cache_config = _make_hybrid_kv_cache_config(full_block_size=16, mamba_block_size=32)
@@ -139,6 +148,7 @@ def test_resolve_kv_cache_block_sizes_with_cp_hybrid_groups(
         enable_prefix_caching=enable_prefix_caching,
         dcp=2,
         pcp=2,
+        kv_transfer_config=object() if connector_enabled else None,
     )
 
     scheduler_block_size, hash_block_size = _ascend_resolve_kv_cache_block_sizes(

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -50,9 +50,11 @@ def _ascend_resolve_kv_cache_block_sizes(
         # multiplied by the CP factors for proper alignment.
         group_block_sizes = [g.kv_cache_spec.block_size for g in groups]
         scheduler_block_size = math.lcm(*group_block_sizes) * dcp * pcp
-        if not cache_config.enable_prefix_caching:
-            return scheduler_block_size, scheduler_block_size
+        connector_enabled = vllm_config.kv_transfer_config is not None
         hash_block_size = math.gcd(*group_block_sizes)
+        # KV connectors still need fine-grained hashes to build external keys.
+        if not (cache_config.enable_prefix_caching or connector_enabled):
+            return scheduler_block_size, scheduler_block_size
         return scheduler_block_size, hash_block_size
 
     return _orig_resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR keeps fine-grained request block hashes when KV transfer is enabled for Ascend CP hybrid KV cache groups, even if local prefix caching is disabled.

Without this, the Ascend CP resolver returns `hash_block_size == scheduler_block_size` whenever `enable_prefix_caching=False`. That is fine for non-hybrid single-group models, but hybrid KV Pool models such as DeepSeek V4 still need gcd-granularity hashes to build AscendStore external cache keys for C1/C4/C128 groups.

The change preserves the existing coarse-hash behavior when both prefix caching and KV transfer are disabled, and only returns gcd hash granularity when either prefix caching or `kv_transfer_config` is present.

### Does this PR introduce _any_ user-facing change?

Yes. AscendStore KV Pool with CP hybrid KV cache groups can use external cache hits when local prefix caching is disabled.

### How was this patch tested?

Added a unit test for the CP hybrid resolver covering the new `kv_transfer_config` path.

Local checks:

- pre-commit hooks run by `git commit`
- `python3 -m py_compile vllm_ascend/patch/platform/patch_kv_cache_utils.py tests/ut/patch/platform/test_prefix_cache_cp_patches.py`
- `git diff --check`

`python3 -m pytest tests/ut/patch/platform/test_prefix_cache_cp_patches.py` was not runnable in the local system Python because `pytest` is not installed.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c
