### PR TITLE
[Feature][Quantization] Support Qwen3 W8A8 compressed-tensors on 310P

### DIFF
--- a/.agents/skills/vllm-ascend-model-adapter/SKILL.md
+++ b/.agents/skills/vllm-ascend-model-adapter/SKILL.md
@@ -30,6 +30,7 @@ Adapt Hugging Face or local models to run on `vllm-ascend` with minimal changes,
 - If any feature cannot be enabled, keep evidence and explain reason in final report.
 - Do not rely on `PYTHONPATH=<modified-src>:$PYTHONPATH` unless debugging fallback is strictly needed.
 - Keep code changes minimal and focused on the target model.
+- Do not add a new file, config, test, doc section, env var, CLI flag, workflow entry, helper abstraction, issue comment, model adapter, processor, patch, or registry entry unless the issue explicitly requires it or an existing entity cannot carry the change; when adding one, state the concrete necessity.
 - Final deliverable commit must be one single signed commit in the current working repo (`git commit -sm ...`).
 - Keep final docs in Chinese and compact.
 - **Dummy-first is encouraged for speed, but dummy is NOT fully equivalent to real weights.**

--- a/docs/source/tutorials/models/Qwen3-Dense.md
+++ b/docs/source/tutorials/models/Qwen3-Dense.md
@@ -38,6 +38,7 @@ The following model variants are available. It is recommended to download the mo
 | Qwen3-8B-W4A8 | W4A8 | 1 Atlas 800I A3 (64G × 16) or 1 Atlas 800I A2 (64G × 8) | [Download](https://www.modelscope.cn/models/vllm-ascend/Qwen3-8B-W4A8) |
 | Qwen3-32B-W4A4 | W4A4 | 1 Atlas 800I A3 (64G × 16) or 1 Atlas 800I A2 (64G × 8) | [Download](https://www.modelscope.cn/models/vllm-ascend/Qwen3-32B-W4A4) |
 | Qwen3-32B-W8A8 | W8A8 | 1 Atlas 800I A3 (64G × 16) or 1 Atlas 800I A2 (64G × 8) | [Download](https://www.modelscope.cn/models/vllm-ascend/Qwen3-32B-W8A8) |
+| Qwen3-32B-W8A8 (LLM-Compressor) | W8A8 compressed-tensors | 4 Atlas 300I (310P) devices | [Download](https://huggingface.co/ramblingpolymath/Qwen3-32B-W8A8) |
 
 These are the recommended numbers of cards, which can be adjusted according to the actual situation.
 
@@ -232,6 +233,51 @@ vllm serve your_model_path \
     --additional-config '{"enable_flashcomm1": true}'
 ```
 
+For LLM-Compressor `compressed-tensors` checkpoints such as
+`ramblingpolymath/Qwen3-32B-W8A8` on Atlas 300I (310P), the quantization
+method is read from the model config. Do not add `--quantization ascend`.
+Use `float16` on 310P. The validated serving path uses contiguous ND weights
+with `npu_quant_matmul_dequant` and `FULL_DECODE_ONLY` ACLGraph with one fixed
+capture size. Keep eager mode for accuracy baselines or graph-isolation
+debugging. NZ matmul is a performance exploration path and should be validated
+separately on the target CANN/runtime stack before production use.
+
+```bash
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
+export HCCL_OP_EXPANSION_MODE=AIV
+export VLLM_ASCEND_ENABLE_FLASHCOMM1=0
+
+vllm serve ramblingpolymath/Qwen3-32B-W8A8 \
+    --served-model-name qwen3-w8a8 \
+    --trust-remote-code \
+    --dtype float16 \
+    --tensor-parallel-size 4 \
+    --max-model-len 40960 \
+    --max-num-batched-tokens 1536 \
+    --max-num-seqs 8 \
+    --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[8]}' \
+    --port 8000
+```
+
+For smaller smoke or accuracy runs, reduce `--max-model-len` and
+`--max-num-seqs`. Add `--enforce-eager` when reproducing the eager accuracy
+baseline or debugging graph issues. Multi-size graph capture such as
+`[1,2,4,8]` can hit `507903 Insufficient_Event_Resources` on the validated
+CANN/runtime stack; use one fixed capture size such as `[8]` for ACLGraph.
+
+```bash
+vllm serve ramblingpolymath/Qwen3-32B-W8A8 \
+    --served-model-name qwen3-w8a8 \
+    --trust-remote-code \
+    --dtype float16 \
+    --tensor-parallel-size 4 \
+    --max-model-len 4096 \
+    --max-num-batched-tokens 1536 \
+    --max-num-seqs 1 \
+    --enforce-eager \
+    --port 8000
+```
+
 Atlas 800I A2/A3：
 
 Qwen3-32B-W4A4:
@@ -312,7 +358,24 @@ Expected result: HTTP 200 with a JSON response containing the `choices` field wi
 
 ## 7 Accuracy Evaluation
 
-### Using AISBench
+### 7.1 LLM-Compressor Qwen3-32B-W8A8 on 310P
+
+The LLM-Compressor `ramblingpolymath/Qwen3-32B-W8A8` checkpoint was validated
+with real weights on four Atlas 300I (310P) devices, TP4, and `dtype=float16`.
+Scores use the corrected scoring pass: final-answer extraction misses caused by
+answer formatting are verified and counted when the answer is correct.
+
+| Runtime path | Mode | Dataset | Metric | Corrected score | Reference |
+|--------------|------|---------|--------|-----------------|-----------|
+| Eager | Non-thinking | GPQA-Diamond full, 0-shot | mean accuracy | 56.06% | Qwen3-32B non-thinking official: BF16 54.6%, AWQ-INT4 53.1% |
+| Eager | Thinking | GPQA-Diamond full, 0-shot | mean accuracy | 67.68% | Qwen3-32B thinking official: BF16 68.4%, AWQ-INT4 69.0% |
+| `FULL_DECODE_ONLY` ACLGraph, capture size `[8]` | Non-thinking | GPQA-Diamond full, 0-shot | mean accuracy | 52.53% | Qwen3-32B non-thinking official: BF16 54.6%, AWQ-INT4 53.1% |
+| `FULL_DECODE_ONLY` ACLGraph, capture size `[8]` | Thinking | GPQA-Diamond full, 0-shot | mean accuracy | 66.67% | Qwen3-32B thinking official: BF16 68.4%, AWQ-INT4 69.0% |
+
+The official LLM-Compressor W8A8 score is not published, so the BF16 and
+AWQ-INT4 Qwen3-32B numbers are used as the alignment references.
+
+### 7.2 Using AISBench
 
 For details, please refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md).
 
@@ -436,6 +499,14 @@ vllm bench serve \
 After several minutes, you will get the performance evaluation result.
 
 ## 9 Performance Tuning
+
+For the LLM-Compressor Qwen3-32B-W8A8 checkpoint on 310P, the current validated
+runtime path uses `npu_quant_matmul_dequant` with `FULL_DECODE_ONLY` ACLGraph
+and one fixed capture size. Eager mode remains the baseline and graph fallback.
+NZ matmul and PIECEWISE ACLGraph showed useful performance potential in short
+probes, but require separate long-running stability validation before they
+should be used as the default path. With TP4, `--max-model-len 40960`,
+and `--max-num-seqs 8`, the full 40,960-token model context was validated.
 
 ### 9.1 Recommended Configurations
 

--- a/tests/e2e/models/configs/Qwen3-32B-W8A8-310P.yaml
+++ b/tests/e2e/models/configs/Qwen3-32B-W8A8-310P.yaml
@@ -1,0 +1,23 @@
+model_name: "/models/hf/Qwen3-32B-W8A8"
+model_type: "vllm"
+hardware: "Atlas 300I Series"
+
+serve:
+  tensor_parallel_size: 4
+  dtype: float16
+  max_model_len: 4096
+  trust_remote_code: true
+  enforce_eager: true
+  max_num_batched_tokens: 512
+  max_num_seqs: 1
+
+tasks:
+- name: "gpqa_diamond_generative_n_shot"
+  metrics:
+  - name: "exact_match,flexible-extract"
+    value: 0.5606
+
+num_fewshot: 0
+apply_chat_template: false
+fewshot_as_multiturn: false
+batch_size: "auto"

--- a/tests/e2e/models/test_lm_eval_correctness.py
+++ b/tests/e2e/models/test_lm_eval_correctness.py
@@ -55,6 +55,8 @@ def build_model_args(eval_config, tp_size):
         "enforce_eager",
         "enable_thinking",
         "quantization",
+        "max_num_batched_tokens",
+        "max_num_seqs",
     ]:
         val = serve_cfg.get(s, None)
         if val is not None:

--- a/tests/ut/_310p/quantization/test_compressed_tensors_config_310.py
+++ b/tests/ut/_310p/quantization/test_compressed_tensors_config_310.py
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+from unittest.mock import MagicMock, patch
+
+from vllm.model_executor.layers.linear import RowParallelLinear
+
+from tests.ut.base import TestBase
+from tests.ut.quantization.conftest_quantization import COMPRESSED_TENSORS_W8A8_CONFIG
+from vllm_ascend._310p.quantization.compressed_tensors_config import (
+    AscendCompressedTensorsConfig310,
+)
+from vllm_ascend._310p.quantization.methods.w8a8_dynamic import (
+    AscendW8A8DynamicLinearMethod310,
+)
+from vllm_ascend.quantization.method_adapters import AscendLinearMethod
+
+
+class TestAscendCompressedTensorsConfig310(TestBase):
+    def setUp(self):
+        self.config = AscendCompressedTensorsConfig310.from_config(COMPRESSED_TENSORS_W8A8_CONFIG)
+
+    @patch("vllm_ascend.quantization.method_adapters.AscendLinearMethod.__init__")
+    def test_get_linear_quant_method_uses_310p_scheme(self, mock_method):
+        mock_method.return_value = None
+        layer = MagicMock(spec=RowParallelLinear)
+
+        result = self.config.get_quant_method(layer, "model.layers.0.self_attn.q_proj")
+
+        self.assertTrue(isinstance(result, AscendLinearMethod))
+        self.assertTrue(isinstance(layer.scheme, AscendW8A8DynamicLinearMethod310))

--- a/tests/ut/_310p/quantization/test_w8a8_dynamic_310.py
+++ b/tests/ut/_310p/quantization/test_w8a8_dynamic_310.py
@@ -87,59 +87,102 @@ class TestAscendW8A8DynamicLinearMethod310(TestBase):
         self.assertEqual(params["weight_scale"].shape, (10, 1))
         self.assertEqual(params["weight_offset"].shape, (10, 1))
 
-    @patch("torch_npu.npu_dynamic_quant", create=True)
+    @patch("torch_npu.npu_quant_matmul_dequant")
     @patch("torch_npu.npu_quant_matmul")
-    def test_apply_310(self, mock_npu_quant_matmul, mock_npu_dynamic_quantize):
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_310_uses_dequant_path(
+        self,
+        mock_npu_dynamic_quant,
+        mock_npu_quant_matmul,
+        mock_npu_quant_matmul_dequant,
+    ):
         layer = MagicMock()
-        layer.weight = torch.randn(128, 256, dtype=torch.float16)
-        layer.weight_scale = torch.randn(128, dtype=torch.float32)
-        layer.params_dtype = torch.float16
-
+        layer.weight = torch.randint(-127, 128, (256, 128), dtype=torch.int8)
+        layer.weight_scale = torch.randn(256, dtype=torch.float32)
         x = torch.randn(32, 128, dtype=torch.float16)
-        expect_x_output = torch.randint(-128, 127, x.shape, dtype=torch.int8)
-        expect_pertoken_scale_output = torch.randn(x.shape[0], dtype=torch.float32)
-        mock_npu_dynamic_quantize.return_value = expect_x_output, expect_pertoken_scale_output
-
-        expected_y_output = torch.randn(32, 256)
-        mock_npu_quant_matmul.return_value = expected_y_output
+        expected_output = torch.randn(32, 256)
+        mock_npu_quant_matmul_dequant.return_value = expected_output
 
         output = self.method.apply(layer, x, tp_rank=0)
 
-        mock_npu_dynamic_quantize.assert_called_with(x)
-        mock_npu_quant_matmul.assert_called_once()
-        (args, kwargs) = mock_npu_quant_matmul.call_args
-
-        # positional args
-        self.assertTrue(torch.equal(args[0], expect_x_output))
+        mock_npu_dynamic_quant.assert_not_called()
+        mock_npu_quant_matmul.assert_not_called()
+        mock_npu_quant_matmul_dequant.assert_called_once()
+        args, kwargs = mock_npu_quant_matmul_dequant.call_args
+        self.assertTrue(torch.equal(args[0], x))
         self.assertTrue(torch.equal(args[1], layer.weight.data))
         self.assertTrue(torch.equal(args[2], layer.weight_scale))
+        self.assertIsNone(kwargs["bias"])
+        self.assertEqual(kwargs["quant_mode"], "pertoken")
+        self.assertTrue(torch.equal(output, expected_output))
 
-        # kwargs
-        self.assertTrue(torch.equal(kwargs["pertoken_scale"], expect_pertoken_scale_output))
-        self.assertTrue(kwargs["bias"] is None)
-        self.assertEqual(kwargs["output_dtype"], layer.params_dtype)
-
-        self.assertTrue(torch.equal(output, expected_y_output))
-
-    @patch("vllm_ascend.utils.is_310p", return_value=True)
-    @patch("torch_npu.npu_format_cast")
-    def test_process_weights_after_loading_calls_nz_format_cast_310p(self, mock_npu_format_cast, _mock_is_310p):
-        mock_npu_format_cast.side_effect = lambda x, fmt: x
-
+    @patch("torch_npu.npu_quant_matmul_dequant")
+    @patch("torch_npu.npu_quant_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_310_passes_bias_to_dequant(
+        self,
+        mock_npu_dynamic_quant,
+        mock_npu_quant_matmul,
+        mock_npu_quant_matmul_dequant,
+    ):
         layer = MagicMock()
+        layer.weight = torch.randint(-127, 128, (256, 128), dtype=torch.int8)
+        layer.weight_scale = torch.randn(256, dtype=torch.float32)
+        x = torch.randn(32, 128, dtype=torch.float16)
+        bias = torch.randn(256, dtype=torch.float16)
+        expected_output = torch.randn(32, 256)
+        mock_npu_quant_matmul_dequant.return_value = expected_output
 
-        # Attributes used by process_weights_after_loading()
+        output = self.method.apply(layer, x, bias=bias, tp_rank=0)
+
+        mock_npu_dynamic_quant.assert_not_called()
+        mock_npu_quant_matmul.assert_not_called()
+        mock_npu_quant_matmul_dequant.assert_called_once()
+        _args, kwargs = mock_npu_quant_matmul_dequant.call_args
+        self.assertTrue(torch.equal(kwargs["bias"], bias))
+        self.assertEqual(kwargs["quant_mode"], "pertoken")
+        self.assertTrue(torch.equal(output, expected_output))
+
+    @patch("torch_npu.npu_quant_matmul_dequant")
+    @patch("torch_npu.npu_quant_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_310_flattens_non_2d_input(
+        self,
+        mock_npu_dynamic_quant,
+        mock_npu_quant_matmul,
+        mock_npu_quant_matmul_dequant,
+    ):
+        layer = MagicMock()
+        layer.weight = torch.randint(-127, 128, (256, 128), dtype=torch.int8)
+        layer.weight_scale = torch.randn(256, dtype=torch.float32)
+        x = torch.randn(2, 16, 128, dtype=torch.float16)
+        expected_output = torch.randn(32, 256)
+        mock_npu_quant_matmul_dequant.return_value = expected_output
+
+        output = self.method.apply(layer, x, tp_rank=0)
+
+        mock_npu_dynamic_quant.assert_not_called()
+        mock_npu_quant_matmul.assert_not_called()
+        mock_npu_quant_matmul_dequant.assert_called_once()
+        args, kwargs = mock_npu_quant_matmul_dequant.call_args
+        self.assertEqual(args[0].shape, (32, 128))
+        self.assertEqual(kwargs["quant_mode"], "pertoken")
+        self.assertEqual(output.shape, (2, 16, 256))
+
+    def test_process_weights_after_loading_keeps_weight_contiguous_310p(self):
+        layer = MagicMock()
         layer.weight = MagicMock()
         layer.weight_scale = MagicMock()
         layer.weight_offset = MagicMock()
 
-        layer.weight.data = torch.randint(-127, 128, (128, 256), dtype=torch.int8)
-
-        layer.weight_scale.data = torch.randn(128, 1, dtype=torch.bfloat16)
-        layer.weight_offset.data = torch.randn(128, 1, dtype=torch.bfloat16)
-        # w2_weight_offset is reshaped to (N, -1); any (N, 1) is fine
-        layer.w2_weight_offset.data = torch.randn(128, 1, dtype=torch.bfloat16)
+        layer.weight.data = torch.randint(-127, 128, (256, 128), dtype=torch.int8)
+        original_weight = layer.weight.data.clone()
+        layer.weight_scale.data = torch.randn(256, 1, dtype=torch.bfloat16)
+        layer.weight_offset.data = torch.randn(256, 1, dtype=torch.bfloat16)
 
         self.method.process_weights_after_loading(layer)
 
-        mock_npu_format_cast.assert_called_once()
+        self.assertTrue(layer.weight.data.is_contiguous())
+        self.assertTrue(torch.equal(layer.weight.data, original_weight))
+        self.assertEqual(layer.weight_scale.data.shape, (256,))
+        self.assertEqual(layer.weight_offset.data.shape, (256,))

--- a/vllm_ascend/_310p/quantization/__init__.py
+++ b/vllm_ascend/_310p/quantization/__init__.py
@@ -15,8 +15,12 @@
 # This file is a part of the vllm-ascend project.
 #
 
+from vllm_ascend._310p.quantization.compressed_tensors_config import (
+    AscendCompressedTensorsConfig310,
+)
 from vllm_ascend._310p.quantization.modelslim_config import AscendModelSlimConfig310
 
 __all__ = [
+    "AscendCompressedTensorsConfig310",
     "AscendModelSlimConfig310",
 ]

--- a/vllm_ascend/_310p/quantization/compressed_tensors_config.py
+++ b/vllm_ascend/_310p/quantization/compressed_tensors_config.py
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""310P compressed-tensors quantization configuration."""
+
+from compressed_tensors.quantization import QuantizationArgs
+from vllm.model_executor.layers.quantization import register_quantization_config
+
+from vllm_ascend.quantization.compressed_tensors_config import AscendCompressedTensorsConfig
+from vllm_ascend.quantization.methods import AscendLinearScheme, AscendMoEScheme
+from vllm_ascend.utils import COMPRESSED_TENSORS_METHOD
+
+
+@register_quantization_config(COMPRESSED_TENSORS_METHOD)
+class AscendCompressedTensorsConfig310(AscendCompressedTensorsConfig):
+    """310P override for LLM-Compressor compressed-tensors quantization."""
+
+    def _create_scheme_for_layer_type(
+        self,
+        weight_quant: QuantizationArgs,
+        input_quant: QuantizationArgs | None,
+        format: str | None,
+        layer_type: str,
+    ) -> AscendLinearScheme | AscendMoEScheme:
+        import vllm_ascend._310p.quantization.methods  # noqa: F401
+        from vllm_ascend._310p.quantization.methods.registry import get_scheme_class
+
+        quant_type = self._detect_quant_type(weight_quant, input_quant, format)
+        scheme_cls = get_scheme_class(quant_type, layer_type)
+        if scheme_cls is None:
+            raise NotImplementedError(
+                f"No 310P compressed-tensors compatible scheme was found for "
+                f"quant_type={quant_type}, layer_type={layer_type}."
+            )
+
+        return scheme_cls()

--- a/vllm_ascend/_310p/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/_310p/quantization/methods/w8a8_dynamic.py
@@ -34,6 +34,12 @@ from .registry import register_scheme
 from .w8a8_base import AscendW8A8Linear310pScheme
 
 
+def _npu_quant_matmul_dequant(layer: torch.nn.Module, x: torch.Tensor, bias: torch.Tensor | None) -> torch.Tensor:
+    return torch_npu.npu_quant_matmul_dequant(
+        x, layer.weight.data, layer.weight_scale, bias=bias, quant_mode="pertoken"
+    )
+
+
 @register_scheme("W8A8_DYNAMIC", "moe")
 class AscendW8A8DynamicFusedMoEMethod310(AscendMoEScheme):
     """310P-only FusedMoE method for Ascend W8A8_DYNAMIC.
@@ -188,31 +194,16 @@ class AscendW8A8DynamicLinearMethod310(AscendW8A8Linear310pScheme):
         bias: torch.Tensor | None = None,
         tp_rank: int | None = 0,
     ) -> torch.Tensor:
-        # NOTE(310P):
-        # - There is an accuracy issue currently, which is expected to be fixed in the next version.
-        quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(x)
-        need_unsqz = False
-        if pertoken_scale.dim() == 2:
-            need_unsqz = True
-            quantized_x = quantized_x.squeeze(dim=1)
-            pertoken_scale = pertoken_scale.squeeze(dim=1)
+        original_shape = x.shape
+        if x.dim() != 2:
+            x = x.reshape(-1, original_shape[-1])
 
-        # NOTE(310P):
-        # - Currently, W8A8 dynamic quantization supports only symmetric quantization.
-        output = torch_npu.npu_quant_matmul(
-            quantized_x,
-            layer.weight.data,
-            layer.weight_scale,
-            pertoken_scale=pertoken_scale,
-            bias=bias,
-            output_dtype=x.dtype,
-        )
-        if need_unsqz:
-            output = output.unsqueeze(dim=1)
+        output = _npu_quant_matmul_dequant(layer, x, bias)
+        if len(original_shape) != 2:
+            output = output.reshape(*original_shape[:-1], output.shape[-1])
         return output
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        # cast quantized weight tensors in NZ format for higher inference speed
-        layer.weight.data = maybe_trans_nz(layer.weight.data).transpose(0, 1)
+        layer.weight.data = layer.weight.data.contiguous()
         layer.weight_scale.data = layer.weight_scale.data.flatten()
         layer.weight_offset.data = layer.weight_offset.data.flatten()

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -197,7 +197,7 @@ class NPUPlatform(Platform):
         if not is_310p():
             from vllm_ascend.quantization import AscendCompressedTensorsConfig, AscendFp8Config, AscendModelSlimConfig  # noqa: F401
         else:
-            from vllm_ascend._310p.quantization import AscendModelSlimConfig310  # noqa: F401
+            from vllm_ascend._310p.quantization import AscendCompressedTensorsConfig310, AscendModelSlimConfig310  # noqa: F401
 
         config_deprecated_logging()
 


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #10666.

This PR adds the 310P path needed to serve LLM-Compressor `compressed-tensors` W8A8 checkpoints such as `ramblingpolymath/Qwen3-32B-W8A8`:

- Registers a 310P `compressed-tensors` quantization config so the 310P scheme registry is used.
- Routes dense W8A8 dynamic linear layers through `torch_npu.npu_quant_matmul_dequant(..., quant_mode="pertoken")` and keeps loaded dense weights contiguous.
- Leaves the experimental split+NZ path out of the delivered runtime until it has separate stability validation.
- Adds focused unit coverage, an opt-in GPQA accuracy config, Qwen3 Dense docs for the validated 310P path, and a minimal adapter-skill guard against unnecessary new entities.

### Does this PR introduce _any_ user-facing change?

Yes. 310P users can load and serve the LLM-Compressor Qwen3-32B-W8A8 `compressed-tensors` checkpoint with TP4/fp16. The Qwen3 Dense tutorial also documents the validated 310P command and GPQA accuracy evidence.

### How was this patch tested?

Code checks:

```bash
python -m py_compile \
  vllm_ascend/_310p/quantization/methods/w8a8_dynamic.py \
  tests/ut/_310p/quantization/test_w8a8_dynamic_310.py \
  tests/ut/_310p/quantization/test_compressed_tensors_config_310.py \
  tests/e2e/models/test_lm_eval_correctness.py

pytest -q \
  tests/ut/_310p/quantization/test_w8a8_dynamic_310.py \
  tests/ut/_310p/quantization/test_compressed_tensors_config_310.py
```

Result: `9 passed`.

Manual 310P real-weight validation:

- Model: `/models/hf/Qwen3-32B-W8A8` (`ramblingpolymath/Qwen3-32B-W8A8`)
- Hardware: 4 Atlas 300I (310P) devices, TP4
- Runtime: `dtype=float16`
- Real-weight serving and `/v1/chat/completions` returned non-empty output.
- FULL_DECODE_ONLY ACLGraph with capture size `[8]` was validated.
- Practical context validated: `--max-model-len 40960`, `--max-num-seqs 8`.

Corrected GPQA-Diamond full, 0-shot results:

| Runtime path | Mode | Score |
| --- | --- | --- |
| Eager | Non-thinking | 56.06% |
| Eager | Thinking | 67.68% |
| FULL_DECODE_ONLY ACLGraph `[8]` | Non-thinking | 52.53% |
| FULL_DECODE_ONLY ACLGraph `[8]` | Thinking | 66.67% |

Reference Qwen3-32B official scores used for alignment: non-thinking BF16 54.6%, AWQ-INT4 53.1%; thinking BF16 68.4%, AWQ-INT4 69.0%.

Known limits:

- split+NZ is not shipped in this PR; it remains a separate performance exploration path.
- Multi-size ACLGraph capture such as `[1,2,4,8]` can hit `507903 Insufficient_Event_Resources` on the validated CANN/runtime stack, so the documented graph path uses one fixed capture size `[8]`.
- ACLGraph compatibility was validated, but the final ND path did not show meaningful performance gain over eager in the measured runs.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/b9a7cd464c9ae9b1b450f8982b76d7be4de73724
