### PR TITLE
[CI][310P] Repair 310P CI caused by gdn_310

### DIFF
--- a/tests/e2e/pull_request/four_card/_310p/test_moe_model_310p.py
+++ b/tests/e2e/pull_request/four_card/_310p/test_moe_model_310p.py
@@ -16,8 +16,6 @@
 # This file is a part of the vllm-ascend project.
 
 
-import pytest
-
 from tests.e2e.conftest import VllmRunner
 
 

--- a/tests/e2e/pull_request/four_card/_310p/test_moe_model_310p.py
+++ b/tests/e2e/pull_request/four_card/_310p/test_moe_model_310p.py
@@ -56,7 +56,6 @@ def test_qwen3_moe_tp2_w8a8():
         vllm_model.generate_greedy(example_prompts, max_tokens)
 
 
-@pytest.mark.skip("Probabilistic failure, need fix")
 def test_qwen3_5_moe_tp4_fp16():
     example_prompts = [
         "Hello, my name is",

--- a/vllm_ascend/_310p/ops/fla/gdn_310.py
+++ b/vllm_ascend/_310p/ops/fla/gdn_310.py
@@ -416,9 +416,9 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
                 # 310P. If that asynchronous kernel fails, the next stream sync
                 # reports 507018 and leaves EngineCore unable to shut down. Apply
                 # the same zeroing semantics with a broadcast multiply instead.
-                state_mask = has_initial_state.to(
-                    device=initial_state.device, dtype=initial_state.dtype
-                ).reshape(-1, *([1] * (initial_state.ndim - 1)))
+                state_mask = has_initial_state.to(device=initial_state.device, dtype=initial_state.dtype).reshape(
+                    -1, *([1] * (initial_state.ndim - 1))
+                )
                 initial_state.mul_(state_mask)
                 (
                     core_attn_out_non_spec,
@@ -437,9 +437,7 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
                 )
 
                 # Init cache
-                ssm_state.index_copy_(
-                    0, state_indices, last_recurrent_state.to(ssm_state.dtype)
-                )
+                ssm_state.index_copy_(0, state_indices, last_recurrent_state.to(ssm_state.dtype))
             elif attn_metadata.num_decodes > 0:
                 core_attn_out_non_spec = npu_recurrent_gated_delta_rule_310(
                     q=query_non_spec,

--- a/vllm_ascend/_310p/ops/fla/gdn_310.py
+++ b/vllm_ascend/_310p/ops/fla/gdn_310.py
@@ -410,8 +410,16 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
 
             # 2.2: Process the remaining part
             if attn_metadata.num_prefills > 0:
-                initial_state = ssm_state[non_spec_state_indices_tensor].contiguous()
-                initial_state[~has_initial_state, ...] = 0
+                state_indices = non_spec_state_indices_tensor.to(torch.int64)
+                initial_state = torch.index_select(ssm_state, 0, state_indices).contiguous()
+                # Boolean advanced-index assignment lowers to AICPU IndexPut on
+                # 310P. If that asynchronous kernel fails, the next stream sync
+                # reports 507018 and leaves EngineCore unable to shut down. Apply
+                # the same zeroing semantics with a broadcast multiply instead.
+                state_mask = has_initial_state.to(
+                    device=initial_state.device, dtype=initial_state.dtype
+                ).reshape(-1, *([1] * (initial_state.ndim - 1)))
+                initial_state.mul_(state_mask)
                 (
                     core_attn_out_non_spec,
                     last_recurrent_state,
@@ -429,7 +437,9 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
                 )
 
                 # Init cache
-                ssm_state[non_spec_state_indices_tensor] = last_recurrent_state.to(ssm_state.dtype)
+                ssm_state.index_copy_(
+                    0, state_indices, last_recurrent_state.to(ssm_state.dtype)
+                )
             elif attn_metadata.num_decodes > 0:
                 core_attn_out_non_spec = npu_recurrent_gated_delta_rule_310(
                     q=query_non_spec,


### PR DESCRIPTION
### What this PR does / why we need it?
CI Stability: Re-enabled the test_qwen3_5_moe_tp4_fp16 test case in the 310P CI suite.
NPU Operation Optimization: Replaced boolean advanced-index assignment with broadcast multiplication and index_copy_ in the 310P GDN implementation to avoid AICPU IndexPut failures.

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/b9a7cd464c9ae9b1b450f8982b76d7be4de73724
