### PR TITLE
[BugFix] Exclude MTP draft from FlashComm2 o_proj and align all-to-all buffer shape

### DIFF
--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -208,7 +208,7 @@ class TestColumnParallelOpDispatch(unittest.TestCase):
 
 
 class TestRowParallelOpDispatch(unittest.TestCase):
-    """Tests for _get_row_parallel_op factory — share_expert."""
+    """Tests for _get_row_parallel_op — mtp_block, share_expert."""
 
     def setUp(self):
         self.mock_layer = MagicMock()
@@ -229,17 +229,30 @@ class TestRowParallelOpDispatch(unittest.TestCase):
         for p in self._patches:
             p.stop()
 
-    def _get_row_op(self, prefix: str):
+    def _op(self, prefix: str):
         from vllm_ascend.ops.linear_op import _get_row_parallel_op
 
         return _get_row_parallel_op(prefix, self.mock_layer)
+
+    def test_mtp_block_excluded_from_flashcomm2_oproj(self):
+        """No6: mtp_block prefix excluded from FlashComm2 o_proj."""
+        mock_op = MagicMock()
+        self._patches.append(patch("vllm_ascend.ops.linear_op.flashcomm2_enable", return_value=True))
+        self._patches.append(patch("vllm_ascend.ops.linear_op.Flashcomm2OProjRowParallelOp", return_value=mock_op))
+        for p in self._patches[-2:]:
+            p.start()
+        # Normal o_proj should use FlashComm2
+        result = self._op("model.layers.0.self_attn.o_proj")
+        self.assertIs(result, mock_op)
+        # But mtp_block.o_proj should NOT use FlashComm2
+        self.assertIsNone(self._op("model.mtp_block.self_attn.o_proj"))
 
     def test_share_expert_disabled_with_sp_row(self):
         """share_expert / shared_expert prefix → None when SP enabled."""
         self._patches.append(patch("vllm_ascend.ops.linear_op.enable_sp", return_value=True))
         self._patches[-1].start()
-        self.assertIsNone(self._get_row_op("model.layers.0.mlp.share_expert.down_proj"))
-        self.assertIsNone(self._get_row_op("model.layers.0.mlp.shared_expert.down_proj"))
+        self.assertIsNone(self._op("model.layers.0.mlp.share_expert.down_proj"))
+        self.assertIsNone(self._op("model.layers.0.mlp.shared_expert.down_proj"))
 
 
 class TestGetParallelOpShareExpert(unittest.TestCase):

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -357,7 +357,7 @@ class Flashcomm2OProjRowParallelOp(CustomRowParallelOp):
             chunked = x.view(chunk_num, batch_size_per_chunk, x.shape[1])
             if self.otp_size != 1:
                 chunked = chunked[self.group_indices]
-            send_buf = chunked.flatten(1, 2)
+            send_buf = chunked.flatten(1, 2).contiguous().view(-1)
 
             # all-to-all operation parameters
             all2all_tp_size = self.odp_size
@@ -724,7 +724,7 @@ def _get_row_parallel_op(
     if matmul_allreduce_enable():
         return MatmulAllreduceRowParallelOp(layer)
     if flashcomm2_enable():
-        if "o_proj" in prefix or "out_proj" in prefix:
+        if ("o_proj" in prefix or "out_proj" in prefix) and "mtp_block" not in prefix:
             if "vision_model" not in prefix:
                 return Flashcomm2OProjRowParallelOp(layer)
     if enable_sp():


### PR DESCRIPTION
### What this PR does / why we need it?
 This PR fixes two issues in the FlashComm2 (FC2) o_proj communication path (Flashcomm2OProjRowParallelOp in linear_op.py) that cause failures when running Step3.5 with MTP speculative decoding and FC2 enabled.

  1. Exclude MTP draft layers from the FC2 o_proj path _get_row_parallel_op assigns Flashcomm2OProjRowParallelOp to any layer whose prefix contains o_proj/out_proj and does not contain vision_model. The Step3.5 MTP draft decoder is nested under .mtp_block. (e.g.
  model.layers.45.mtp_block.self_attn.o_proj), so its prefix matches this condition and the draft's o_proj is erroneously assigned the FC2 op.

  This op is bound at construction time to the main model's communication state (reorgnized_batch_ids, group_indices, odp_group). When the draft forward runs through otp_maybe_quant_comm, its batch/token shapes
  don't match these main-model-bound indices, causing failures (assert batch_size % chunk_num == 0 or all-to-all shape/semantic mismatch).

  Fix: Add and "mtp_block" not in prefix to the FC2 o_proj condition so draft layers are excluded at the assignment stage.

  2. Align send_buf / recv_buf dimensions in the all-to-all

  In otp_maybe_quant_comm, recv_buf is always 1D (torch.empty(total_intermediate_size * chunk_size, ...)), but send_buf = chunked.flatten(1, 2) is multi-dimensional (2D when otp_size == 1, 3D when otp_size > 1 due
  to the group_indices advanced indexing). dist.all_to_all_single expects matching shapes; this dimension inconsistency is a latent bug that surfaces when the abnormal draft path exercises it.

  Fix: send_buf = chunked.flatten(1, 2).contiguous().view(-1) flattens to 1D to match recv_buf. .contiguous() is required before .view(-1) because the advanced-indexed tensor may not be reinterpretable as a flat view.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Step3.5 Flash model, 8× Ascend NPU, TP=8, FC1+FC2+MTP all enabled. After the fix, both PD disaggregated and PD colocated deployments start correctly and pass random dataset benchmark stress testing (batch 1–128).


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
