### PR TITLE
[Bugfix]fix indexput bug caused by multimodal merge

### DIFF
--- a/tests/ut/_310p/models/test_merge_multimodal_embeddings_310.py
+++ b/tests/ut/_310p/models/test_merge_multimodal_embeddings_310.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+pytest.importorskip("vllm")
+
+from vllm_ascend.patch.worker.patch_multimodal_merge_310 import (
+    merge_multimodal_embeddings_310,
+)
+
+
+def test_merge_multimodal_embeddings_310() -> None:
+    inputs_embeds = torch.arange(48, dtype=torch.float32).reshape(2, 6, 4)
+    expected = inputs_embeds.clone()
+    is_multimodal = torch.tensor(
+        [
+            [False, True, True, False, False, True],
+            [True, False, False, True, False, False],
+        ]
+    )
+    mm_embeds = torch.tensor(
+        [
+            [10.0, 11.0, 12.0, 13.0],
+            [20.0, 21.0, 22.0, 23.0],
+            [30.0, 31.0, 32.0, 33.0],
+            [40.0, 41.0, 42.0, 43.0],
+            [50.0, 51.0, 52.0, 53.0],
+        ]
+    )
+    expected[is_multimodal] = mm_embeds
+
+    result = merge_multimodal_embeddings_310(
+        inputs_embeds.clone(),
+        [mm_embeds],
+        is_multimodal,
+    )
+    torch.testing.assert_close(result, expected)

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -50,6 +50,7 @@ if not is_310p():
     import vllm_ascend.patch.worker.patch_qwen3vl  # noqa
 else:
     import vllm_ascend.patch.worker.patch_idex_310  # noqa
+    import vllm_ascend.patch.worker.patch_multimodal_merge_310  # noqa
 import vllm_ascend.patch.worker.patch_rejection_sampler  # noqa
 
 # torchair/npugraph_ex is only available on NPU; silently skip when missing

--- a/vllm_ascend/patch/worker/patch_multimodal_merge_310.py
+++ b/vllm_ascend/patch/worker/patch_multimodal_merge_310.py
@@ -1,0 +1,61 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+import torch
+import vllm.model_executor.models.utils as models_utils
+from vllm.model_executor.models.utils import (
+    _embedding_count_expression,
+    _flatten_embeddings,
+)
+from vllm.multimodal import NestedTensors
+
+
+def merge_multimodal_embeddings_310(
+    inputs_embeds: torch.Tensor,
+    multimodal_embeddings: NestedTensors,
+    is_multimodal: torch.Tensor,
+) -> torch.Tensor:
+    if len(multimodal_embeddings) == 0:
+        return inputs_embeds
+
+    mm_embeds_flat = _flatten_embeddings(multimodal_embeddings)
+    input_dtype = inputs_embeds.dtype
+
+    try:
+        # Boolean IndexPut fails on 310P; use integer indices instead.
+        positions = is_multimodal.reshape(-1).cpu().nonzero(as_tuple=False).flatten()
+        positions = positions.to(device=inputs_embeds.device)
+        inputs_embeds.reshape(-1, inputs_embeds.shape[-1]).index_copy_(
+            0, positions, mm_embeds_flat.to(dtype=input_dtype)
+        )
+    except RuntimeError as e:
+        num_actual_tokens = len(mm_embeds_flat)
+        num_expected_tokens = is_multimodal.sum().item()
+
+        if num_actual_tokens != num_expected_tokens:
+            expr = _embedding_count_expression(multimodal_embeddings)
+            raise ValueError(
+                f"Attempted to assign {expr} = {num_actual_tokens} "
+                f"multimodal tokens to {num_expected_tokens} placeholders"
+            ) from e
+
+        raise ValueError("Error during index put operation") from e
+
+    return inputs_embeds
+
+
+models_utils._merge_multimodal_embeddings = merge_multimodal_embeddings_310


### PR DESCRIPTION
### What this PR does / why we need it?
On 310P, the upstream _merge_multimodal_embeddings (vLLM vllm/model_executor/models/utils.py) fails because the boolean index assignment inputs_embeds[is_multimodal] = mm_embeds_flat.to(...) is lowered to AICPU IndexPut, which fails with Aicpu kernel execute failed, kernelName=IndexPut / RuntimeError: 507018.

This blocks all multimodal models on 310P (e.g. test_qwen3_vl_8b_tp2_fp16).

This PR adds a 310P-only patch (vllm_ascend/patch/worker/patch_multimodal_merge_310.py) that replaces the boolean IndexPut
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
No
test testvqa precision (Qwen3-vl-8b):
| dataset | version | metric | mode | vllm-api-general-chat |
|----- | ----- | ----- | ----- | -----|
| textvqa | e9d882 | accuracy | gen | 79.98 |

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/b9a7cd464c9ae9b1b450f8982b76d7be4de73724
