### PR TITLE
[Doc][Model] Remove trailing comma in PaddleOCR-VL tutorial

### DIFF
--- a/docs/source/tutorials/models/PaddleOCR-VL.md
+++ b/docs/source/tutorials/models/PaddleOCR-VL.md
@@ -305,7 +305,7 @@ TASKS = {
     "ocr": "OCR:",
     "table": "Table Recognition:",
     "formula": "Formula Recognition:",
-    "chart": "Chart Recognition:",
+    "chart": "Chart Recognition:"
 }
 
 messages = [


### PR DESCRIPTION
### What this PR does / why we need it?

Removes the trailing comma from the final `TASKS` entry in the PaddleOCR-VL tutorial code snippet.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only snippet cleanup.

### How was this patch tested?

- Ran `git diff --check HEAD~1 HEAD`.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/b9a7cd464c9ae9b1b450f8982b76d7be4de73724
