### PR TITLE
[Performance] Reuse DP metadata sync buffers

### DIFF
--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import torch
+from vllm.config import CUDAGraphMode
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheGroupSpec, KVCacheTensor
 
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
@@ -84,6 +85,74 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
 
         self.assertEqual(k_cache.shape, (2, 16, 8, 64))
         self.assertEqual(v_cache.shape, (2, 16, 8, 64))
+
+
+class TestNPUModelRunnerDPSyncBuffers(unittest.TestCase):
+    def _build_runner(self):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.dp_size = 2
+        runner.dp_rank = 1
+        runner.vllm_config = MagicMock()
+        runner.ascend_config = SimpleNamespace(dp_allreduce_on_npu=False)
+        return runner
+
+    @patch("vllm_ascend.worker.model_runner_v1.should_skip_allreduce_across_dp_group")
+    def test_sync_metadata_reuses_padding_buffer_when_allreduce_skipped(self, mock_should_skip_allreduce):
+        mock_should_skip_allreduce.return_value = True
+        runner = self._build_runner()
+
+        _, first_tokens_after_padding, _ = runner._sync_metadata_across_dp(7)
+        _, second_tokens_after_padding, _ = runner._sync_metadata_across_dp(9)
+
+        self.assertIsNotNone(first_tokens_after_padding)
+        self.assertIsNotNone(second_tokens_after_padding)
+        self.assertEqual(
+            first_tokens_after_padding.data_ptr(),
+            second_tokens_after_padding.data_ptr(),
+        )
+        self.assertEqual(second_tokens_after_padding.tolist(), [9, 9])
+
+    @patch("vllm_ascend.worker.model_runner_v1.get_dp_group")
+    @patch("vllm_ascend.worker.model_runner_v1.dist.all_reduce")
+    @patch("vllm_ascend.worker.model_runner_v1.should_skip_allreduce_across_dp_group")
+    def test_sync_metadata_reuses_buffers_for_allreduce_path(
+        self,
+        mock_should_skip_allreduce,
+        mock_all_reduce,
+        mock_get_dp_group,
+    ):
+        mock_should_skip_allreduce.return_value = False
+        mock_get_dp_group.return_value = SimpleNamespace(cpu_group=object())
+        all_reduce_buffer_ptrs = []
+
+        def fake_all_reduce(packed_tensor, group):
+            del group
+            all_reduce_buffer_ptrs.append(packed_tensor.data_ptr())
+            if len(all_reduce_buffer_ptrs) == 1:
+                packed_tensor[0].copy_(torch.tensor([5, 11], dtype=torch.int32))
+                packed_tensor[1].fill_(CUDAGraphMode.FULL.value)
+            else:
+                packed_tensor[0].copy_(torch.tensor([13, 3], dtype=torch.int32))
+                packed_tensor[1].fill_(CUDAGraphMode.PIECEWISE.value)
+
+        mock_all_reduce.side_effect = fake_all_reduce
+        runner = self._build_runner()
+
+        first_max_tokens, first_tokens_after_padding, first_mode = runner._sync_metadata_across_dp(7)
+        second_max_tokens, second_tokens_after_padding, second_mode = runner._sync_metadata_across_dp(2)
+
+        self.assertEqual(first_max_tokens, 11)
+        self.assertEqual(second_max_tokens, 13)
+        self.assertEqual(first_mode, CUDAGraphMode.FULL)
+        self.assertEqual(second_mode, CUDAGraphMode.PIECEWISE)
+        self.assertEqual(all_reduce_buffer_ptrs[0], all_reduce_buffer_ptrs[1])
+        self.assertIsNotNone(first_tokens_after_padding)
+        self.assertIsNotNone(second_tokens_after_padding)
+        self.assertEqual(
+            first_tokens_after_padding.data_ptr(),
+            second_tokens_after_padding.data_ptr(),
+        )
+        self.assertEqual(second_tokens_after_padding.tolist(), [13, 3])
 
 
 class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -319,6 +319,7 @@ class NPUModelRunner(GPUModelRunner):
         self.max_num_reqs = self.scheduler_config.max_num_seqs
         self.dp_size = vllm_config.parallel_config.data_parallel_size
         self.dp_rank = vllm_config.parallel_config.data_parallel_rank
+        self._init_dp_metadata_buffers()
 
         self.sampler = AscendSampler()
         self.attn_state: AscendAttentionState | None = None
@@ -606,6 +607,62 @@ class NPUModelRunner(GPUModelRunner):
     def _sync_device(self) -> None:
         torch.npu.synchronize()
 
+
+    def _init_dp_metadata_buffers(self) -> None:
+        if self.dp_size <= 1:
+            self._dp_metadata_tensor = None
+            self._dp_metadata_tensor_npu = None
+            self._dp_num_tokens_after_padding = None
+            return
+
+        self._dp_metadata_tensor = torch.empty(
+            (2, self.dp_size),
+            device="cpu",
+            dtype=torch.int32,
+        )
+        self._dp_metadata_tensor_npu = None
+        self._dp_num_tokens_after_padding = torch.empty(
+            self.dp_size,
+            device="cpu",
+            dtype=torch.int32,
+        )
+
+    def _get_dp_metadata_buffers(
+        self,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        metadata_tensor = getattr(self, "_dp_metadata_tensor", None)
+        num_tokens_after_padding = getattr(
+            self, "_dp_num_tokens_after_padding", None
+        )
+        if (
+            metadata_tensor is None
+            or num_tokens_after_padding is None
+            or metadata_tensor.shape != (2, self.dp_size)
+            or num_tokens_after_padding.shape != (self.dp_size,)
+        ):
+            self._init_dp_metadata_buffers()
+            metadata_tensor = self._dp_metadata_tensor
+            num_tokens_after_padding = self._dp_num_tokens_after_padding
+
+        assert metadata_tensor is not None
+        assert num_tokens_after_padding is not None
+        return metadata_tensor, num_tokens_after_padding
+
+    def _get_dp_metadata_tensor_npu(self) -> torch.Tensor:
+        metadata_tensor_npu = getattr(self, "_dp_metadata_tensor_npu", None)
+        if (
+            metadata_tensor_npu is None
+            or metadata_tensor_npu.shape != (2, self.dp_size)
+        ):
+            metadata_tensor_npu = torch.empty(
+                (2, self.dp_size),
+                device="npu",
+                dtype=torch.int32,
+            )
+            self._dp_metadata_tensor_npu = metadata_tensor_npu
+
+        return metadata_tensor_npu
+
     def _set_up_drafter(self):
         # Set up speculative decoding.
         self.drafter: (
@@ -677,24 +734,27 @@ class NPUModelRunner(GPUModelRunner):
         if self.dp_size == 1:
             return num_tokens, None, cudagraph_mode
 
+        packed_tensor, num_tokens_after_padding = self._get_dp_metadata_buffers()
+
         if should_skip_allreduce_across_dp_group(self.vllm_config, is_draft_model):
-            num_tokens_after_padding = torch.tensor([num_tokens] * self.dp_size, device="cpu", dtype=torch.int32)
+            num_tokens_after_padding.fill_(num_tokens)
             return num_tokens, num_tokens_after_padding, cudagraph_mode
 
-        # On certain devices, CPU-side all_reduce may return dirty data. 
+        dp_group = get_dp_group()
         # When dp_allreduce_on_npu is True, route DP metadata
         # synchronization through the NPU device group to avoid data corruption.
-        device_str, group = (
-            ("npu", get_dp_group().device_group)
-            if self.ascend_config.dp_allreduce_on_npu
-            else ("cpu", get_dp_group().cpu_group)
-        )
-        packed_tensor = torch.zeros(2, self.dp_size, device=device_str, dtype=torch.int32)
-        packed_tensor[0][self.dp_rank] = num_tokens
-        packed_tensor[1][self.dp_rank] = cudagraph_mode.value
-        dist.all_reduce(packed_tensor, group=group)
-        if device_str == "npu":
-            packed_tensor = packed_tensor.cpu()
+        if self.ascend_config.dp_allreduce_on_npu:
+            reduce_tensor = self._get_dp_metadata_tensor_npu()
+            reduce_tensor.zero_()
+            reduce_tensor[0, self.dp_rank] = num_tokens
+            reduce_tensor[1, self.dp_rank] = cudagraph_mode.value
+            dist.all_reduce(reduce_tensor, group=dp_group.device_group)
+            packed_tensor.copy_(reduce_tensor.cpu())
+        else:
+            packed_tensor.zero_()
+            packed_tensor[0, self.dp_rank] = num_tokens
+            packed_tensor[1, self.dp_rank] = cudagraph_mode.value
+            dist.all_reduce(packed_tensor, group=dp_group.cpu_group)
 
         # Unpack the results
         num_tokens_across_dp = packed_tensor[0, :]
@@ -703,11 +763,9 @@ class NPUModelRunner(GPUModelRunner):
 
         # Create a tensor for num_tokens_after_padding
         if allow_dp_padding or is_draft_model:
-            num_tokens_after_padding = torch.tensor(
-                [max_tokens_across_dp] * self.dp_size, device="cpu", dtype=torch.int32
-            )
+            num_tokens_after_padding.fill_(max_tokens_across_dp)
         else:
-            num_tokens_after_padding = num_tokens_across_dp.cpu()
+            num_tokens_after_padding.copy_(num_tokens_across_dp)
 
         return max_tokens_across_dp, num_tokens_after_padding, synced_cudagraph_mode
 


### PR DESCRIPTION
This extracts the DP metadata sync buffer reuse optimization from vllm-ascend-hust for upstream review.

The current DP metadata sync path allocates fresh CPU tensors on every `_sync_metadata_across_dp` call. This PR keeps reusable per-runner buffers for:

- the packed DP metadata tensor
- the `num_tokens_after_padding` result tensor

It also preserves the existing `dp_allreduce_on_npu` correctness path by using a reusable NPU metadata tensor when that mode is enabled, then copying the reduced result back to the CPU buffer for the existing post-processing path.

Validation:

- `git diff --check`
- `python -m py_compile vllm_ascend/worker/model_runner_v1.py tests/ut/worker/a2/test_model_runner_v1.py`

Local pytest could not run in this checkout because the environment is missing the `vllm` Python package:

```text
ModuleNotFoundError: No module named 'vllm'
```

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/b9a7cd464c9ae9b1b450f8982b76d7be4de73724
