### PR TITLE
[Feature][Test] Enable "c8_enable_reshape_optim" for A5 and add ut coverage

### DIFF
--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -217,6 +217,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend950 ]]; then
         "recurrent_gated_delta_rule"
         "chunk_fwd_o"
         "chunk_gated_delta_rule_fwd_h"
+        "store_kv_block"
     )
 
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -308,3 +308,86 @@ class TestAscendSFAMetadataBuilder(TestBase):
 
         assert isinstance(attn_metadata, AscendSFAMetadata)
         assert attn_metadata.attn_state == AscendAttentionState.DecodeOnly
+
+    @patch("vllm_ascend.attention.sfa_v1.get_current_vllm_config")
+    @patch("vllm_ascend.attention.sfa_v1.get_cos_and_sin_mla")
+    @patch("vllm_ascend.attention.sfa_v1.enable_dsa_cp", return_value=False)
+    @patch("torch.ops._C_ascend.store_kv_block_pre", create=True)
+    def test_ascend_sfa_metadata_builder_build_with_c8_reshape_optim(
+        self,
+        mock_store_kv_block_pre,
+        mock_enable_dsa_cp,
+        mock_get_cos_and_sin_mla,
+        mock_get_current_vllm_config,
+    ):
+        cfg = MagicMock()
+        cfg.model_config = MagicMock()
+        cfg.model_config.hf_text_config = MagicMock()
+
+        mock_get_current_vllm_config.return_value = cfg
+        kv_cache_spec = MagicMock()
+        layer_names = ["layer1", "layer2"]
+        vllm_config = MagicMock()
+        vllm_config.cache_config.block_size = 16
+        vllm_config.model_config.max_model_len = 1024
+        vllm_config.model_config.get_head_size.return_value = 64
+        vllm_config.model_config.dtype = torch.float16
+        vllm_config.model_config.hf_text_config.qk_rope_head_dim = 64
+        speculative_config = MagicMock()
+        speculative_config.num_speculative_tokens = 4
+        vllm_config.speculative_config = speculative_config
+        device = torch.device("cpu")
+
+        builder = AscendSFAMetadataBuilder(
+            kv_cache_spec=kv_cache_spec, layer_names=layer_names, vllm_config=vllm_config, device=device
+        )
+
+        slot_mapping_cpu = torch.randint(0, 10000, (100,))
+
+        common_attn_metadata = MagicMock()
+        common_attn_metadata.num_reqs = 10
+        common_attn_metadata.num_actual_tokens = 100
+        common_attn_metadata.query_start_loc = torch.tensor([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+        common_attn_metadata.query_start_loc_cpu = torch.tensor([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+        common_attn_metadata.slot_mapping = torch.randn(100, 4, 1024)
+        common_attn_metadata.slot_mapping_cpu = slot_mapping_cpu
+        common_attn_metadata.seq_lens_cpu = torch.tensor([2] * 10)
+        common_attn_metadata.positions = torch.randn(100)
+        common_attn_metadata.attn_mask = None
+        common_attn_metadata.attn_state = AscendAttentionState.ChunkedPrefill
+        common_attn_metadata.block_table_tensor = torch.randn(100, 4)
+        common_attn_metadata.cos = None
+        common_attn_metadata.sin = None
+        common_attn_metadata.num_input_tokens = 100
+
+        mock_get_cos_and_sin_mla.return_value = (torch.randn(100), torch.randn(100))
+
+        mock_group_len = torch.tensor([1, 2, 3])
+        mock_group_key_idx = torch.tensor([0, 1, 2])
+        mock_group_key_cache_idx = torch.tensor([4, 5, 6])
+        mock_store_kv_block_pre.return_value = (mock_group_len, mock_group_key_idx, mock_group_key_cache_idx)
+
+        with patch("vllm_ascend.attention.sfa_v1.get_ascend_config") as mock_get_ascend_config:
+            mock_ascend_config = MagicMock()
+            mock_ascend_config.c8_enable_reshape_optim = True
+            mock_get_ascend_config.return_value = mock_ascend_config
+
+            metadata = builder.build(
+                common_prefix_len=10,
+                common_attn_metadata=common_attn_metadata,
+            )
+
+        assert isinstance(metadata, AscendSFAMetadata)
+        assert metadata.num_actual_tokens == common_attn_metadata.num_actual_tokens
+        assert metadata.slot_mapping.shape == (100, 4, 1024)
+
+        mock_store_kv_block_pre.assert_called_once()
+        actual_args, _ = mock_store_kv_block_pre.call_args
+        assert torch.equal(actual_args[0], common_attn_metadata.slot_mapping)
+        assert actual_args[1] == slot_mapping_cpu.tolist()
+        assert actual_args[2] == 128
+
+        assert metadata.block_size == 128
+        assert metadata.group_len is mock_group_len
+        assert metadata.group_key_idx is mock_group_key_idx
+        assert metadata.group_key_cache_idx is mock_group_key_cache_idx


### PR DESCRIPTION
### What this PR does / why we need it?
This PR addresses two items:

1. **Add unit test for the `c8_enable_reshape_optim = True` code path**

   When `c8_enable_reshape_optim` is `True`, `AscendSFAMetadataBuilder._build()` reads `slot_mapping_cpu`, invokes `torch.ops._C_ascend.store_kv_block_pre`, and populates the returned `group_len`, `group_key_idx`, and `group_key_cache_idx` into the metadata. This branch previously had no UT coverage. The new test verifies:

   - `slot_mapping_cpu` is correctly sliced and forwarded to the op
   - The op is called with the expected arguments (`slot_mapping`, `slot_mapping_cpu.tolist()`, `block_size`)
   - The return values are correctly propagated to `metadata.group_len` / `group_key_idx` / `group_key_cache_idx`
   - `block_size=128` behavior is as expected

   The test runs under a pure TP setup without DCP/PCP group dependencies.

2. **Enable `store_kv_block` custom operator compilation for A5**

   Adds `store_kv_block` to the Ascend950 (A5) `CUSTOM_OPS_ARRAY` in `csrc/build_aclnn.sh` so the operator compiles correctly on A5 hardware, supporting downstream E2E testing and inference.
### Does this PR introduce _any_ user-facing change?
No. Test and build configuration changes only.
### How was this patch tested?
- UT: `pytest -sv tests/ut/attention/a2/test_sfa_v1.py::TestAscendSFAMetadataBuilder::test_ascend_sfa_metadata_builder_build_with_c8_reshape_optim`

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
