### PR TITLE
[BugFix][KV Pool] Fix MooncakeBackend lazy init failure on cross-thread store setup

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -61,6 +61,7 @@ def _ssd_setup_kwargs(config: "MooncakeStoreConfig") -> dict[str, object]:
 
 class MooncakeBackend(Backend):
     def __init__(self, parallel_config: ParallelConfig, lazy_init: bool = False):
+        self.parallel_config = parallel_config
         self.config = MooncakeStoreConfig.load_from_env()
         if self.config.protocol != "ascend":
             raise NotImplementedError(f"MooncakeBackend does not support protocol {self.config.protocol!r}.")
@@ -104,7 +105,7 @@ class MooncakeBackend(Backend):
         if ssd_kwargs and ssd_kwargs.get("ssd_offload_path"):
             # Per-rank SSD directory keyed by the globally unique rank so that
             # DP/TP/PP/CP replicas never share a directory (dense and MoE alike).
-            global_rank = get_global_rank()
+            global_rank = get_global_rank(self.parallel_config)
             rank_path = os.path.join(str(ssd_kwargs["ssd_offload_path"]), f"rank_{global_rank}")
             try:
                 os.makedirs(rank_path, exist_ok=True)


### PR DESCRIPTION
### What this PR does / why we need it?
Upstream PR：https://github.com/vllm-project/vllm-ascend/pull/9731
When `MooncakeBackend` is created with `lazy_init=True` (DSV4 compress model + `ASCEND_ENABLE_USE_FABRIC_MEM=1`), `_setup_store()` is deferred from `__init__` to the first `put()`, which runs on the KV transfer sending thread (`KVCacheStoreLayerSendingThread`), not the main worker thread.

`_setup_store()` calls `get_global_rank()` with no arguments. The no-arg form falls back to `get_current_vllm_config().parallel_config`, which reads the process-global `_current_vllm_config` set by `set_current_vllm_config()` on the main thread. On the KV transfer thread that global is `None`, so `get_current_vllm_config()` raises `AssertionError: Current vLLM config is not set`, the store never initializes, and every subsequent `put()` fails.

This was introduced by the per-DP-rank SSD sub-directory change (`get_global_rank()` call inside `_setup_store()`).

**Fix**: stash `parallel_config` on `self` in `__init__` and pass it explicitly to `get_global_rank(self.parallel_config)` in `_setup_store()`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Dual-node PD separation with DeepSeek-V4-Flash-w8a8-mtp, `--data-parallel-size 4 --tensor-parallel-size 4`, `kv_role=kv_producer`, `ASCEND_ENABLE_USE_FABRIC_MEM=1`, `enable_multithread_load=true`, Mooncake store with `enable_ssd_offload=true`.

Before fix: `AssertionError: Current vLLM config is not set` x43, store never initialized.
<img width="705" height="504" alt="截屏2026-07-06 10 00 57" src="https://github.com/user-attachments/assets/e45394c0-ea68-4720-86f2-1f6ce470641e" />

After fix: `AssertionError` x0.
<img width="771" height="93" alt="image" src="https://github.com/user-attachments/assets/37688958-a92d-4667-b1a2-8a05c356bfc0" />

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
