### PR TITLE
[main][CI] update nightly Qwen3-30B-QuaRot buffersize

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/Qwen3-30B-QuaRot-eagle3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3-30B-QuaRot-eagle3.yaml
@@ -8,7 +8,7 @@ test_cases:
     envs:
       VLLM_WORKER_MULTIPROC_METHOD: "spawn"
       SERVER_PORT: "DEFAULT_PORT"
-      HCCL_BUFFSIZE: "512"
+      HCCL_BUFFSIZE: "768"
     server_cmd:
       - "--enforce-eager"
       - "--no-enable-prefix-caching"


### PR DESCRIPTION
### What this PR does / why we need it?
Increased the HCCL_BUFFSIZE environment variable from 512 to 768 for the Qwen3-30B-QuaRot nightly test configuration.

### Does this PR introduce _any_ user-facing change?
### How was this patch tested?
