### PR TITLE
[CI] Resources for ubuntu-latest are tight and need to be replaced with self-hosted runners

### DIFF
--- a/.github/workflows/labeled_doctest.yaml
+++ b/.github/workflows/labeled_doctest.yaml
@@ -61,7 +61,7 @@ concurrency:
 jobs:
   setup-matrix:
     name: Setup test matrix
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-16-hk
     outputs:
       matrix: ${{ steps.set_matrix_pr.outputs.matrix || steps.set_matrix_doc.outputs.matrix }}
     steps:

--- a/.github/workflows/labeled_doctest.yaml
+++ b/.github/workflows/labeled_doctest.yaml
@@ -61,7 +61,7 @@ concurrency:
 jobs:
   setup-matrix:
     name: Setup test matrix
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-4-hk
     outputs:
       matrix: ${{ steps.set_matrix_pr.outputs.matrix || steps.set_matrix_doc.outputs.matrix }}
     steps:

--- a/.github/workflows/labeled_doctest.yaml
+++ b/.github/workflows/labeled_doctest.yaml
@@ -61,7 +61,7 @@ concurrency:
 jobs:
   setup-matrix:
     name: Setup test matrix
-    runs-on: linux-amd64-cpu-16-hk
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set_matrix_pr.outputs.matrix || steps.set_matrix_doc.outputs.matrix }}
     steps:

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -76,7 +76,7 @@ jobs:
     name: Parse trigger and determine test scope
     if: >-
       github.event_name == 'workflow_dispatch'
-    runs-on: linux-aarch64-a2b3-0
+    runs-on: linux-aarch64-a3-0
     outputs:
       run: ${{ steps.parse.outputs.run }}
       filter: ${{ steps.parse.outputs.filter }}
@@ -108,7 +108,7 @@ jobs:
   setup-vars:
     name: Export global env vars as job outputs
     needs: parse-trigger
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     outputs:
       ascend_log_prefix: ${{ steps.export.outputs.ascend_log_prefix }}
       vllm_ascend_branches: ${{ steps.export.outputs.vllm_ascend_branches }}
@@ -324,7 +324,7 @@ jobs:
       always() &&
       github.event_name == 'workflow_dispatch' &&
       needs.parse-trigger.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     steps:
       - name: Merge all benchmark result artifacts
         continue-on-error: true

--- a/.github/workflows/schedule_release_code_and_wheel.yml
+++ b/.github/workflows/schedule_release_code_and_wheel.yml
@@ -41,7 +41,7 @@ on:
 jobs:
   build_and_release_code:
     name: release code
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-16-hk
     strategy:
       matrix:
         python-version: ["3.12"]

--- a/.github/workflows/schedule_release_code_and_wheel.yml
+++ b/.github/workflows/schedule_release_code_and_wheel.yml
@@ -41,7 +41,7 @@ on:
 jobs:
   build_and_release_code:
     name: release code
-    runs-on: linux-amd64-cpu-16-hk
+    runs-on: linux-amd64-cpu-8-hk
     strategy:
       matrix:
         python-version: ["3.12"]

--- a/.github/workflows/schedule_vllm_e2e_test.yaml
+++ b/.github/workflows/schedule_vllm_e2e_test.yaml
@@ -44,7 +44,7 @@ env:
 
 jobs:
     resolve-tag:
-        runs-on: ubuntu-latest
+        runs-on: linux-amd64-cpu-2-hk
         outputs:
             release_tag: ${{ steps.vllm.outputs.release_tag }}
         steps:

--- a/.github/workflows/schedule_vllm_e2e_test.yaml
+++ b/.github/workflows/schedule_vllm_e2e_test.yaml
@@ -44,7 +44,7 @@ env:
 
 jobs:
     resolve-tag:
-        runs-on: linux-amd64-cpu-2-hk
+        runs-on: linux-amd64-cpu-4-hk
         outputs:
             release_tag: ${{ steps.vllm.outputs.release_tag }}
         steps:

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -81,7 +81,7 @@ jobs:
     name: Parse trigger and determine test scope
     if: >-
       github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: linux-aarch64-a3-0
     outputs:
       run: ${{ steps.parse.outputs.run }}
       filter: ${{ steps.parse.outputs.filter }}
@@ -113,7 +113,7 @@ jobs:
   setup-vars:
     name: Export global env vars as job outputs
     needs: parse-trigger
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     outputs:
       ascend_log_prefix: ${{ steps.export.outputs.ascend_log_prefix }}
       vllm_ascend_branches: ${{ steps.export.outputs.vllm_ascend_branches }}
@@ -301,7 +301,7 @@ jobs:
       always() &&
       github.event_name == 'workflow_dispatch' &&
       needs.parse-trigger.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     steps:
       - name: Merge all benchmark result artifacts
         continue-on-error: true


### PR DESCRIPTION
### What this PR does / why we need it?
 Resources for ubuntu-latest are tight and need to be replaced with self-hosted runners
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
`label_doctest.yml`  is tested by running relative jobs。
Test link:
https://github.com/vllm-project/vllm-ascend/actions/runs/29008757671/job/86086785084?pr=11719

`schedule_release_code_and_wheel.yml`‎  is tested by running relative  jobs。
Test link:
https://github.com/vllm-project/vllm-ascend/actions/runs/29008757671/job/86086785190?pr=11719

`schedule_vllm_e2e_test.yaml`  is tested by running relative acitons。
Test link:
https://github.com/vllm-project/vllm-ascend/actions/runs/28990040754/job/86027616190?pr=11617

`schedule_nightly_test_a3.yaml`  and `schedule_weekly_test_a3.yaml` is tested by running relative acitons and jobs。
Test link:
https://github.com/vllm-project/vllm-ascend/actions/runs/29008757671/job/86086785095?pr=11719
https://github.com/vllm-project/vllm-ascend/actions/runs/29008757671/job/86086903470?pr=11719
https://github.com/vllm-project/vllm-ascend/actions/runs/28990040754/job/86027616206?pr=11617


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
