### PR TITLE
[BugFix] Resolve block table overflow

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4709,9 +4709,10 @@ class NPUModelRunner(GPUModelRunner):
             if isinstance(kv_cache_group.kv_cache_spec, MambaSpec):
                 mamba_blocks_per_req = (
                     max_num_blocks_per_req if self.cache_config.enable_prefix_caching else 1
-                ) + kv_cache_group.kv_cache_spec.num_speculative_blocks
+                ) 
 
                 max_num_blocks_per_req = max(max_num_blocks_per_req, mamba_blocks_per_req)
+                max_num_blocks_per_req += kv_cache_group.kv_cache_spec.num_speculative_blocks
             max_num_blocks.append(max_num_blocks_per_req)
 
         if (block_sizes != [self.cache_config.block_size]


### PR DESCRIPTION

## PR Description

```markdown
### What this PR does / why we need it?

This PR fixes a block table overflow in `may_reinitialize_input_batch()` in `model_runner_v1.py`.

**Scope:** Although the change is in `model_runner_v1.py`, it only affects requests that use a **`MambaSpec` KV cache group with speculative decoding enabled** (`num_speculative_blocks > 0`, e.g. MTP/EAGLE). Pure attention models, pooling models, Mamba without speculative decoding, and other features are unaffected.

**Why this is the right fix for our default setup:** On Ascend, hybrid Mamba models commonly run with `mamba_cache_mode=align` (our default, especially with KV transfer). In this mode, Mamba blocks are allocated proportionally to sequence length (`cdiv(tokens, block_size)`), even when prefix caching is disabled. With speculative decoding enabled, the runtime also needs trailing speculative blocks on top of content blocks:

```python
num_blocks = cdiv(num_computed_tokens + num_scheduled_tokens, block_size) + num_speculative_blocks
```

So at max sequence length, a request needs `content_blocks + num_speculative_blocks` slots in the block table, not just `content_blocks`.

**Root cause:** When sizing the block table, `max_num_blocks_per_req` was under-counted for `MambaSpec` groups. Previously, `num_speculative_blocks` was folded into `mamba_blocks_per_req` before `max()`:

```python
mamba_blocks_per_req = (
    max_num_blocks_per_req if self.cache_config.enable_prefix_caching else 1
) + kv_cache_group.kv_cache_spec.num_speculative_blocks
max_num_blocks_per_req = max(max_num_blocks_per_req, mamba_blocks_per_req)
```

For long-context models with prefix caching disabled, the content block count (`cdiv(max_model_len, block_size)`) is much larger than `1 + num_speculative_blocks`, so speculative blocks were silently dropped. The block table row was sized for `content_blocks` only, but the scheduler later tried to append trailing speculative block IDs. This failed in `BlockTable.append_row()`:

```text
ValueError: could not broadcast input array from shape (2,) into shape (0,)
```

because the row was already full (`start == max_num_blocks_per_req`) while `block_ids` still had 2 elements.

**Fix:** Reserve speculative blocks after the `max()` call, so they are always added on top of the content block count:

```python
mamba_blocks_per_req = (
    max_num_blocks_per_req if self.cache_config.enable_prefix_caching else 1
)
max_num_blocks_per_req = max(max_num_blocks_per_req, mamba_blocks_per_req)
max_num_blocks_per_req += kv_cache_group.kv_cache_spec.num_speculative_blocks
```

This matches the runtime allocation formula used by Mamba speculative decoding paths (e.g. `preprocess_mamba()`).

**When this does not apply:**
- No speculative decoding (`num_speculative_blocks = 0`): no behavior change.
- Prefix caching enabled: the old logic already reserved enough slots in practice.
- Non-`MambaSpec` KV cache groups: the `if isinstance(..., MambaSpec)` branch is not taken.

### Does this PR introduce _any_ user-facing change?

Yes. Users running **Mamba-based models with speculative decoding** (especially with `mamba_cache_mode=align`, our default) and prefix caching disabled will no longer hit block table overflow errors near `max_model_len`.

No API, CLI, or configuration interface changes.

### How was this patch tested?

- Manual testing on Ascend NPU with a Mamba + MTP model (`mamba_cache_mode=align`), prefix caching disabled, and sequence length near `max_model_len`
- Reproduced the original failure in `BlockTable.append_row()` (`could not broadcast input array from shape (2,) into shape (0,)`) before the fix
- Verified the issue no longer reproduces after the fix
- Smoke tested the same model path without MTP to confirm no regression
```
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
