### PR TITLE
[Feature] Add triton swiglustep kernel for SwigluStep activation

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_swiglustep.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_swiglustep.py
@@ -1,0 +1,82 @@
+import pytest
+import torch
+
+from vllm_ascend.ops.triton.activation.swiglustep import swiglustep_forward_triton
+from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+
+
+def _swiglustep_reference(x: torch.Tensor, limit: float = 7.0) -> torch.Tensor:
+    # Independent of the kernel under test: slice gate (first half) and up
+    # (second half), apply silu-then-clamp(max) on gate and symmetric clamp
+    # on up -- the SwigluStep order, not clamp-then-silu (SwigluOAI).
+    d = x.shape[-1] // 2
+    gate = torch.nn.functional.silu(x[..., :d]).clamp(max=limit)
+    up = x[..., d:].clamp(min=-limit, max=limit)
+    return gate * up
+
+
+# The kernel requires N (= last_dim // 2) to be a multiple of 16 for
+# bf16/fp16 (32-byte UB alignment on NPU vector core), so every shape here
+# has a last dim that is a multiple of 32. Real MoE shape is N=1280
+# (Step-3.7 moe_intermediate_size).
+@pytest.mark.parametrize(
+    ("shape", "dtype", "limit"),
+    [
+        ((1, 2560), torch.float16, 7.0),
+        ((128, 2560), torch.float16, 7.0),
+        ((4000, 2560), torch.bfloat16, 7.0),
+        ((4, 128, 2560), torch.bfloat16, 7.0),
+        ((8, 4096), torch.float16, 1.0),
+    ],
+)
+@torch.inference_mode()
+def test_swiglustep_triton_correctness(shape, dtype, limit):
+    """compare swiglustep_forward_triton with an independent pytorch baseline."""
+    init_device_properties_triton()
+    device = "npu"
+
+    torch.manual_seed(0)
+    x = torch.randn(*shape, dtype=dtype, device=device)
+
+    out_triton = swiglustep_forward_triton(x, limit=limit)
+    out_ref = _swiglustep_reference(x, limit=limit)
+
+    # bf16 loses ~2 digits around silu(large) / clamp boundary; fp16 is tighter.
+    rtol, atol = (2e-2, 2e-2) if dtype == torch.bfloat16 else (5e-3, 5e-3)
+
+    assert out_triton.shape == out_ref.shape
+    assert out_triton.dtype == out_ref.dtype
+    assert torch.allclose(out_triton, out_ref, rtol=rtol, atol=atol)
+
+
+@torch.inference_mode()
+def test_swiglustep_triton_clamps_to_golden_value():
+    """gate=+100 -> silu(~100) clamped to limit(7); up=-100 -> -7; out = -49."""
+    init_device_properties_triton()
+    # N=16 to satisfy N%16==0 (32-byte UB alignment for fp16)
+    x = torch.full((1, 32), 100.0, dtype=torch.float16, device="npu")
+    x[:, 16:] = -100.0  # up half = second half of columns
+
+    out = swiglustep_forward_triton(x, limit=7.0)
+
+    assert out.shape == (1, 16)
+    expected = torch.full((1, 16), -49.0, dtype=torch.float16, device="npu")
+    assert torch.allclose(out, expected, atol=1e-3)
+    assert not torch.isnan(out).any()
+    assert not torch.isinf(out).any()
+
+
+@torch.inference_mode()
+def test_swiglustep_triton_handles_non_contiguous_input():
+    """the wrapper must contiguous() a strided view before launching."""
+    init_device_properties_triton()
+    torch.manual_seed(0)
+    base = torch.randn(4, 5120, dtype=torch.bfloat16, device="npu")
+    x = base[:, ::2]  # (4, 2560) strided view, non-contiguous
+    assert not x.is_contiguous()
+
+    out_triton = swiglustep_forward_triton(x, limit=7.0)
+    out_ref = _swiglustep_reference(x, limit=7.0)
+
+    assert out_triton.shape == out_ref.shape
+    assert torch.allclose(out_triton, out_ref, atol=2e-2, rtol=2e-2)

--- a/tests/ut/ops/a3_2/test_activation.py
+++ b/tests/ut/ops/a3_2/test_activation.py
@@ -206,53 +206,67 @@ class TestAscendSwigluOAIAndMul:
 
 class TestSwiglustepAndMul:
     def test_swiglustep_and_mul_matches_reference_formula(self):
-        x = torch.tensor([[1.0, 2.0, -3.0, 4.0, 5.0, -6.0, 7.0, -8.0]], dtype=torch.float32)
+        # last dim 16 => N=8 satisfies the triton kernel's N%(32/elem_size)==0
+        # UB alignment on NPU (fp32: N%8==0), so this runs the fused kernel.
+        x = torch.tensor(
+            [[1.0, 2.0, -3.0, 4.0, 5.0, -6.0, 7.0, -8.0, -1.0, -2.0, 3.0, -4.0, -5.0, 6.0, -7.0, 8.0]],
+            dtype=torch.float32,
+            device="npu",
+        )
         result = AscendSwigluStepAndMul.swiglustep_forward(x)
-        expected = _swiglustep_and_mul_reference(x)
+        expected = _swiglustep_and_mul_reference(x.cpu())
 
         assert result.shape == (1, x.shape[-1] // 2)
         assert result.dtype == x.dtype
-        assert torch.allclose(result, expected, atol=1e-6)
+        assert torch.allclose(result.cpu(), expected, atol=1e-5)
 
     def test_swiglustep_and_mul_uses_contiguous_gate_up_layout(self):
         # gate = first half, up = second half (contiguous split via chunk),
         # NOT the interleaved layout used by SwigluOAI.
-        x = torch.tensor([[1.0, 2.0, 3.0, 4.0, 10.0, 20.0, 30.0, 40.0]], dtype=torch.float32)
+        x = torch.tensor(
+            [[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0]],
+            dtype=torch.float32,
+            device="npu",
+        )
         result = AscendSwigluStepAndMul.swiglustep_forward(x, limit=100.0)
-        expected = _swiglustep_and_mul_reference(x, limit=100.0)
-        interleaved = torch.nn.functional.silu(x[..., ::2]) * x[..., 1::2]
+        expected = _swiglustep_and_mul_reference(x.cpu(), limit=100.0)
+        interleaved = torch.nn.functional.silu(x.cpu()[..., ::2]) * x.cpu()[..., 1::2]
 
-        assert torch.allclose(result, expected, atol=1e-6)
-        assert not torch.allclose(result, interleaved, atol=1e-6)
+        assert torch.allclose(result.cpu(), expected, atol=1e-5)
+        assert not torch.allclose(result.cpu(), interleaved, atol=1e-5)
 
     def test_swiglustep_and_mul_with_custom_limit_matches_reference(self):
-        x = torch.tensor([[9.0, 8.0, -5.0, -9.0]], dtype=torch.float32)
+        x = torch.tensor(
+            [[9.0, 8.0, -5.0, -9.0, 7.0, -3.0, 6.0, -2.0, 1.0, -9.0, 8.0, -5.0, 4.0, -7.0, 3.0, -1.0]],
+            dtype=torch.float32,
+            device="npu",
+        )
         limit = 3.0
         result = AscendSwigluStepAndMul.swiglustep_forward(x, limit=limit)
-        expected = _swiglustep_and_mul_reference(x, limit=limit)
+        expected = _swiglustep_and_mul_reference(x.cpu(), limit=limit)
 
-        assert torch.allclose(result, expected, atol=1e-6)
+        assert torch.allclose(result.cpu(), expected, atol=1e-5)
 
     def test_swiglustep_and_mul_clamps_gate_and_up_values(self):
-        # gate = [100, 100] -> silu(~100) clamped to 7.0;
-        # up   = [-100, -100] -> clamped to -7.0  =>  7.0 * -7.0 = -49.0
-        x = torch.tensor([[100.0, 100.0, -100.0, -100.0]], dtype=torch.float32)
+        # gate = [100]*8 -> silu(~100) clamped to 7.0;
+        # up   = [-100]*8 -> clamped to -7.0  =>  7.0 * -7.0 = -49.0
+        x = torch.tensor([[100.0] * 8 + [-100.0] * 8], dtype=torch.float32, device="npu")
         result = AscendSwigluStepAndMul.swiglustep_forward(x)
-        expected = _swiglustep_and_mul_reference(x)
+        expected = _swiglustep_and_mul_reference(x.cpu())
 
-        assert torch.allclose(result, expected, atol=1e-5)
-        assert torch.allclose(result, torch.tensor([[-49.0, -49.0]]), atol=1e-4)
-        assert not torch.isnan(result).any()
-        assert not torch.isinf(result).any()
+        assert torch.allclose(result.cpu(), expected, atol=1e-5)
+        assert torch.allclose(result.cpu(), torch.full((1, 8), -49.0), atol=1e-4)
+        assert not torch.isnan(result.cpu()).any()
+        assert not torch.isinf(result.cpu()).any()
 
     def test_swiglustep_and_mul_large_input(self):
-        x = torch.randn(64, 128, dtype=torch.float32)
+        x = torch.randn(64, 128, dtype=torch.float32, device="npu")
         result = AscendSwigluStepAndMul.swiglustep_forward(x)
-        expected = _swiglustep_and_mul_reference(x)
+        expected = _swiglustep_and_mul_reference(x.cpu())
 
         assert result.shape == (64, 64)
-        assert torch.allclose(result, expected, atol=1e-5)
-        assert not torch.isnan(result).any()
+        assert torch.allclose(result.cpu(), expected, atol=1e-5)
+        assert not torch.isnan(result.cpu()).any()
 
     def test_swiglustep_and_mul_validates_limit(self):
         x = torch.tensor([[8.0, 9.0, -2.0, -8.0]], dtype=torch.float32)
@@ -333,11 +347,13 @@ class TestActivationNPUPrecision:
         ],
     )
     def test_swiglustep_and_mul_matches_cpu_reference_on_npu(self, dtype, atol, rtol):
-        x_cpu = torch.randn(16, 16, dtype=torch.float32) * 4
+        # last dim 32 => N=16 satisfies the triton kernel's N%16==0 UB
+        # alignment, so bf16/fp16 exercise the fused kernel (not native).
+        x_cpu = torch.randn(16, 32, dtype=torch.float32) * 4
         x_npu = x_cpu.to(dtype=dtype, device="npu")
 
         result = AscendSwigluStepAndMul.swiglustep_forward(x_npu).cpu()
         expected = _swiglustep_and_mul_reference(x_cpu.to(dtype=dtype)).float()
 
-        assert result.shape == (16, 8)
+        assert result.shape == (16, 16)
         assert torch.allclose(result.float(), expected, atol=atol, rtol=rtol)

--- a/vllm_ascend/ops/activation.py
+++ b/vllm_ascend/ops/activation.py
@@ -72,6 +72,20 @@ class AscendSwigluStepAndMul:
         if limit is None:
             raise ValueError("SwigluStepAndMul requires limit to be set.")
 
+        # Triton fused path: 1D-grid row-loop kernel that fuses
+        # silu + clamp + mul into a single launch (see
+        # vllm_ascend/ops/triton/activation/swiglustep.py). Numerically
+        # equivalent to forward_native below.
+        from vllm.triton_utils import HAS_TRITON
+
+        if HAS_TRITON:
+            from vllm_ascend.ops.triton.activation.swiglustep import (
+                swiglustep_forward_triton,
+            )
+
+            return swiglustep_forward_triton(x, limit)
+
+        # Fallback when triton is unavailable: vllm's native silu+clamp+mul.
         class MinimalSwigluStepAndMul:
             def __init__(self):
                 self.limit = limit

--- a/vllm_ascend/ops/triton/activation/swiglustep.py
+++ b/vllm_ascend/ops/triton/activation/swiglustep.py
@@ -1,0 +1,130 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Triton kernel for SwigluStepAndMul activation.
+
+Math (identical to vllm's SwigluStepAndMul.forward_native):
+    gate = x[..., :N],  up = x[..., N:]      # x is row-major [..., 2N]
+    out  = silu(gate).clamp(max=limit) * up.clamp(min=-limit, max=limit)
+    where silu(g) = g * sigmoid(g).
+
+Order matters: silu BEFORE clamp on the gate half (SwigluStep), as opposed to
+clamp-then-silu (SwigluOAI).
+
+Launch pattern: 1D grid of size (num_vectorcore,), each program loops over
+M / num_vectorcore rows. Keeping program count == core count minimizes host
+launch overhead compared with a 2D BLOCK_M x BLOCK_N grid (which spawns
+O(M * N / tile) programs on large shapes). Same pattern as swiglu_quant.py /
+rope.py.
+"""
+
+import torch
+from vllm.triton_utils import tl, triton
+
+from vllm_ascend.ops.triton.triton_utils import (
+    extract_slice,
+    get_vectorcore_num,
+    init_device_properties_triton,
+)
+
+
+@triton.jit
+def _swiglustep_kernel(
+    x_ptr,
+    out_ptr,
+    M,  # total rows (runtime value, not constexpr)
+    TOTAL_COLS: tl.constexpr,  # 2N
+    HALF_COLS: tl.constexpr,  # N
+    LIMIT: tl.constexpr,
+    NUM_CORES: tl.constexpr,
+):
+    # even split of rows across cores; tail core handles the remainder
+    block_size = (M - 1) // NUM_CORES + 1
+    pid = tl.program_id(0)
+    row_begin = pid * block_size
+    if row_begin >= M:
+        return
+    row_end = tl.minimum((pid + 1) * block_size, M)
+
+    col_offsets = tl.arange(0, TOTAL_COLS)
+    out_offsets = tl.arange(0, HALF_COLS)
+
+    for row_idx in range(row_begin, row_end):
+        # load one full row [2N], split gate/up via extract_slice, compute in fp32
+        x_row = tl.load(x_ptr + row_idx * TOTAL_COLS + col_offsets)
+        gate = extract_slice(x_row, offsets=(0,), sizes=(HALF_COLS,), strides=(1,)).to(tl.float32)
+        up = extract_slice(x_row, offsets=(HALF_COLS,), sizes=(HALF_COLS,), strides=(1,)).to(tl.float32)
+
+        # silu(gate) then clamp upper bound only
+        s = gate * tl.sigmoid(gate)
+        s = tl.minimum(s, LIMIT)
+        # up clamp both sides
+        up = tl.minimum(up, LIMIT)
+        up = tl.maximum(-LIMIT, up)
+        out = s * up
+
+        tl.store(
+            out_ptr + row_idx * HALF_COLS + out_offsets,
+            out.to(x_ptr.dtype.element_ty),
+        )
+
+
+def swiglustep_forward_triton(x: torch.Tensor, limit: float = 7.0) -> torch.Tensor:
+    """Fused SwigluStep: silu(gate).clamp(max=limit) * up.clamp(±limit).
+
+    Args:
+        x: row-major tensor of shape [..., 2N] (dtype: float16 / bfloat16).
+        limit: clamp bound (scalar). Step-3.7 uses 7.0 for expert layers.
+    Returns:
+        tensor of shape [..., N], same dtype as x.
+    """
+    assert x.shape[-1] % 2 == 0, f"swiglustep: last dim must be 2N (even), got {x.shape[-1]}"
+    if not x.is_contiguous():
+        x = x.contiguous()
+
+    orig_shape = x.shape
+    x_2d = x.view(-1, orig_shape[-1])
+    M, total_cols = x_2d.shape
+    half_cols = total_cols // 2
+
+    # NPU vector core requires UB load/store to be 32-byte aligned. The store
+    # of `half_cols` (=N) elements per row is the tightest constraint, so
+    # N * element_size must be a multiple of 32 (N % 16 == 0 for bf16/fp16).
+    # Real MoE shapes (Step-3.7 N=1280) satisfy this; non-aligned tiny shapes
+    # are rejected up front instead of crashing the AIC.
+    align_elems = 32 // x.element_size()
+    assert half_cols % align_elems == 0, (
+        f"swiglustep: N (={half_cols}) must be a multiple of {align_elems} for 32-byte UB alignment on NPU vector core"
+    )
+
+    out_2d = torch.empty(M, half_cols, dtype=x.dtype, device=x.device)
+
+    # idempotent: worker.py calls it once at serve time; standalone scripts need it
+    init_device_properties_triton()
+    num_vectorcore = get_vectorcore_num()
+
+    _swiglustep_kernel[(num_vectorcore,)](
+        x_2d,
+        out_2d,
+        M,
+        TOTAL_COLS=total_cols,
+        HALF_COLS=half_cols,
+        LIMIT=limit,
+        NUM_CORES=num_vectorcore,
+        multibuffer=True,
+    )
+
+    return out_2d.view(*orig_shape[:-1], half_cols)


### PR DESCRIPTION
Fuses silu+clamp+mul into a single 1D-grid row-loop triton kernel, following the same launch pattern as swiglu_quant.py / rope.py (grid=(num_vectorcore,), per-row loop) to minimize host launch overhead. Numerically equivalent to SwigluStepAndMul.forward_native: silu-then-clamp on the gate half, +/-limit clamp on the up half.

NPU vector core requires N%16==0 for 32B UB alignment (bf16/fp16); asserted up front. Real MoE shapes (Step-3.7 N=1280) satisfy this.

### What this PR does / why we need it?
Adds a triton kernel for `SwigluStepAndMul`, fusing `silu + clamp + mul` into a single launch. Uses the same 1D-grid launch pattern as the existing `swiglu_quant.py` and `rope.py` triton kernels, keeping host launch overhead minimal.

**Precision**
| shape         | bf16 maxdiff | fp16 maxdiff |
| ------------- | ------------ | ------------ |
| (16, 32)      | 1.56e-02     | 9.77e-04     |
| (200, 320)    | 3.12e-02     | 7.81e-03     |
| (1024,)       | 1.56e-02     | 1.95e-03     |
| (8192, 2560)  | 6.25e-02     | 7.81e-03     |
| (65536, 2560) | 6.25e-02     | 7.81e-03     |
| (2, 64, 256)  | 3.12e-02     | 3.91e-03     |

**Operator-level bench**
| shape         | phase   | mode  | 910B fus(us) | 910B fn/fus | 910C fus(us) | 910C fn/fus |
| ------------- | ------- | ----- | ------------ | ----------- | ------------ | ----------- |
| (64, 1280)    | decode  | graph | 13.6         | **3.12×**   | 22.8         | **2.17×**   |
| (512, 1280)   | decode  | graph | 22.2         | **2.91×**   | 24.7         | **2.97×**   |
| (2048, 1280)  | decode  | graph | 53.6         | **2.59×**   | 51.5         | **3.07×**   |
| (4096, 1280)  | prefill | eager | 171.1        | **1.30×**   | 77.4         | **2.91×**   |
| (8192, 1280)  | prefill | eager | 170.5        | **2.45×**   | 138.2        | **2.95×**   |
| (65536, 1280) | prefill | eager | 1642.9       | **2.36×**   | 1340.1       | **2.85×**   |

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
24/24 precision cases pass: random bf16/fp16 across shapes, limit sweep, boundary values (incl. ±inf, nan), golden `+100/-100 → -49.0`.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
