### PR TITLE
[DSv4][A3] Static host-backed C128 KV tiering

### DIFF
--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -142,6 +142,13 @@ env_variables: Dict[str, Callable[[], Any]] = {
     # Whether to use MultiBlockPool for KV cache management
     "USE_MULTI_BLOCK_POOL":
     lambda: bool(int(os.getenv("USE_MULTI_BLOCK_POOL", '0'))),
+    # Default-off DSv4 static host-backed KV prototype.
+    # Supported family values: "c128" or empty string.
+    "VLLM_ASCEND_DSV4_HOST_KV_FAMILY":
+    lambda: os.getenv("VLLM_ASCEND_DSV4_HOST_KV_FAMILY", "").strip().lower(),
+    # Total host DRAM budget, in bytes, for the selected DSv4 host-backed KV family.
+    "VLLM_ASCEND_DSV4_HOST_KV_BYTES":
+    lambda: (int(value) if (value := os.getenv("VLLM_ASCEND_DSV4_HOST_KV_BYTES")) else None),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 
 import vllm
 from vllm.config import VllmConfig
+from vllm_ascend import envs
 from vllm.v1.core.kv_cache_utils import (create_kv_cache_group_specs,
                                          get_num_blocks, get_uniform_page_size,
                                          may_override_num_blocks,
@@ -40,6 +41,37 @@ def check_uniform_page_size(kv_cache_groups: list[KVCacheGroupSpec]) -> bool:
     return len(page_sizes) == 1
 
 
+def _has_ascend_kv_cache_spec(
+        kv_cache_spec: dict[str, KVCacheSpec]) -> bool:
+    """Use Ascend grouping for Ascend-only KV specs unknown to upstream.
+
+    DSv4 A3 uses Compress*AttentionSpec classes from
+    vllm_ascend.core.kv_cache_spec. Upstream
+    UniformTypeKVCacheSpecs.is_uniform_type raises NotImplementedError for
+    those classes before the Ascend grouping code can handle them.
+    """
+    return any(type(spec).__module__ == "vllm_ascend.core.kv_cache_spec"
+               for spec in kv_cache_spec.values())
+
+
+def _get_dsv4_host_kv_budget() -> tuple[str, int] | None:
+    family = envs.VLLM_ASCEND_DSV4_HOST_KV_FAMILY
+    host_bytes = envs.VLLM_ASCEND_DSV4_HOST_KV_BYTES
+    if not family or host_bytes is None or host_bytes <= 0:
+        return None
+    return family, int(host_bytes)
+
+
+def _is_host_backed_spec(spec: KVCacheSpec, family: str) -> bool:
+    return family == "c128" and getattr(spec, "compress_ratio", None) == 128
+
+
+def _blocks_for_budget(budget_bytes: int, bytes_per_block: int) -> float:
+    if bytes_per_block <= 0:
+        return float("inf")
+    return budget_bytes // bytes_per_block
+
+
 def get_kv_cache_groups(
         vllm_config: VllmConfig,
         kv_cache_spec: dict[str, KVCacheSpec]) -> list[KVCacheGroupSpec]:
@@ -54,7 +86,8 @@ def get_kv_cache_groups(
         The generated KVCacheGroups
     """
 
-    if vllm_config.scheduler_config.disable_hybrid_kv_cache_manager:
+    if (vllm_config.scheduler_config.disable_hybrid_kv_cache_manager
+            and not _has_ascend_kv_cache_spec(kv_cache_spec)):
         unify_hybrid_kv_cache_specs(kv_cache_spec)
 
     # kv cache group spec with multi groups and same block size without share hybrid blocks
@@ -92,10 +125,25 @@ def get_kv_cache_config_from_groups(
         # Special case: all layers have the same type of KV cache but with
         # different hidden size. Allocate different amount of memory for each
         # layer based on its hidden size.
-        num_blocks = (available_memory //
-                      kv_cache_groups[0].kv_cache_spec.page_size_bytes)
-        num_blocks = may_override_num_blocks(vllm_config, num_blocks)
         per_layer_specs = kv_cache_groups[0].kv_cache_spec.kv_cache_specs
+        host_kv_budget = _get_dsv4_host_kv_budget()
+        if host_kv_budget is None:
+            num_blocks = (available_memory //
+                          kv_cache_groups[0].kv_cache_spec.page_size_bytes)
+        else:
+            family, host_bytes = host_kv_budget
+            hbm_bytes_per_block = 0
+            host_bytes_per_block = 0
+            for layer_spec in per_layer_specs.values():
+                if _is_host_backed_spec(layer_spec, family):
+                    host_bytes_per_block += layer_spec.page_size_bytes
+                else:
+                    hbm_bytes_per_block += layer_spec.page_size_bytes
+            num_blocks = int(min(
+                _blocks_for_budget(available_memory, hbm_bytes_per_block),
+                _blocks_for_budget(host_bytes, host_bytes_per_block),
+            ))
+        num_blocks = may_override_num_blocks(vllm_config, num_blocks)
         kv_cache_tensors = [
             KVCacheTensor(
                 size=per_layer_specs[layer_name].page_size_bytes * num_blocks,
@@ -106,12 +154,30 @@ def get_kv_cache_config_from_groups(
         # Special case: there are multiple groups of KV cache, and the block
         # size of them keeps the same. We will still have `num_layers` memory
         # pools, this means the memory pools won't be shared across the groups.
-        total_page_size_bytes = 0
-        for kv_cache_group in kv_cache_groups:
-            num_layers = len(kv_cache_group.layer_names)
-            page_size = kv_cache_group.kv_cache_spec.page_size_bytes
-            total_page_size_bytes += page_size * num_layers
-        num_blocks = available_memory // total_page_size_bytes
+        host_kv_budget = _get_dsv4_host_kv_budget()
+        if host_kv_budget is None:
+            total_page_size_bytes = 0
+            for kv_cache_group in kv_cache_groups:
+                num_layers = len(kv_cache_group.layer_names)
+                page_size = kv_cache_group.kv_cache_spec.page_size_bytes
+                total_page_size_bytes += page_size * num_layers
+            num_blocks = available_memory // total_page_size_bytes
+        else:
+            family, host_bytes = host_kv_budget
+            hbm_bytes_per_block = 0
+            host_bytes_per_block = 0
+            for kv_cache_group in kv_cache_groups:
+                num_layers = len(kv_cache_group.layer_names)
+                page_size = kv_cache_group.kv_cache_spec.page_size_bytes
+                total_bytes = page_size * num_layers
+                if _is_host_backed_spec(kv_cache_group.kv_cache_spec, family):
+                    host_bytes_per_block += total_bytes
+                else:
+                    hbm_bytes_per_block += total_bytes
+            num_blocks = int(min(
+                _blocks_for_budget(available_memory, hbm_bytes_per_block),
+                _blocks_for_budget(host_bytes, host_bytes_per_block),
+            ))
         # TODO(zxr): DONT use magic number
         num_blocks = num_blocks // 128 * 128
         assert num_blocks > 0

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -86,7 +86,6 @@ from vllm_ascend.attention.dsa_v1 import (AscendDSAMetadata,
                                           AscendDSAMetadataBuilder)
 from vllm_ascend.attention.utils import (AscendCommonAttentionMetadata,
                                          using_paged_attention)
-from vllm_ascend.kv_offload.shmem_host import _acl_malloc_host, _make_host_tensor
 # yapf conflicts with isort for this block
 # yapf: disable
 from vllm_ascend.compilation.acl_graph import (ACLGraphWrapper,
@@ -151,6 +150,45 @@ U32_MAX = 0xFFFFFFFF
 @dataclass
 class GraphCaptureContext:
     stream: torch.npu.Stream
+
+
+def _acl_malloc_host(size: int) -> tuple[int, int]:
+    libacl = ctypes.CDLL("libascendcl.so")
+
+    host_ptr = ctypes.c_void_p()
+    ret = libacl.aclrtMallocHost(ctypes.byref(host_ptr), ctypes.c_size_t(size))
+    if ret != 0:
+        raise RuntimeError(
+            f"aclrtMallocHost failed: error {ret} (size={size})."
+        )
+
+    dev_ptr = ctypes.c_void_p()
+    ret = libacl.aclrtHostRegister(
+        host_ptr, ctypes.c_uint64(size), ctypes.c_int(0), ctypes.byref(dev_ptr)
+    )
+    if ret != 0:
+        libacl.aclrtFreeHost(host_ptr)
+        raise RuntimeError(f"aclrtHostRegister failed: error {ret}")
+
+    return host_ptr.value, dev_ptr.value
+
+
+def _compact_strides(shape: tuple[int, ...]) -> tuple[int, ...]:
+    strides = [1] * len(shape)
+    for i in range(len(shape) - 2, -1, -1):
+        strides[i] = strides[i + 1] * shape[i + 1]
+    return tuple(strides)
+
+
+def _make_host_tensor(dev_ptr_int: int, shape: tuple[int, ...],
+                      dtype: torch.dtype, device: torch.device,
+                      size_bytes: int) -> torch.Tensor:
+    storage = torch_npu._C._construct_storage_from_data_pointer(
+        dev_ptr_int, device, size_bytes
+    )
+    return torch.empty(0, dtype=dtype, device=device).set_(
+        storage, 0, shape, _compact_strides(shape)
+    )
 
 
 @dataclass

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -19,6 +19,7 @@
 
 import ctypes
 import math
+import os
 import sys
 from collections import defaultdict
 from contextlib import contextmanager, nullcontext
@@ -78,12 +79,14 @@ from vllm.v1.worker.gpu_model_runner import (AsyncGPUModelRunnerOutput,
 from vllm.v1.worker.kv_connector_model_runner_mixin import KVConnectorOutput
 from vllm.v1.worker.utils import AttentionGroup
 
+from vllm_ascend import envs
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.dsa_v1 import (AscendDSAMetadata,
                                           AscendDSAMetadataBuilder)
 from vllm_ascend.attention.utils import (AscendCommonAttentionMetadata,
                                          using_paged_attention)
+from vllm_ascend.kv_offload.shmem_host import _acl_malloc_host, _make_host_tensor
 # yapf conflicts with isort for this block
 # yapf: disable
 from vllm_ascend.compilation.acl_graph import (ACLGraphWrapper,
@@ -2098,6 +2101,27 @@ class NPUModelRunner(GPUModelRunner):
             invalid_req_indices,
         )
 
+    def __del__(self):
+        allocations = getattr(self, "_host_kv_allocations", None)
+        if not allocations:
+            return
+        try:
+            libacl = ctypes.CDLL("libascendcl.so")
+            libacl.aclrtHostUnregister.argtypes = [ctypes.c_void_p]
+            libacl.aclrtHostUnregister.restype = ctypes.c_int
+            libacl.aclrtFreeHost.argtypes = [ctypes.c_void_p]
+            libacl.aclrtFreeHost.restype = ctypes.c_int
+            for host_ptr, _size in allocations:
+                ptr = ctypes.c_void_p(host_ptr)
+                try:
+                    libacl.aclrtHostUnregister(ptr)
+                finally:
+                    libacl.aclrtFreeHost(ptr)
+        except Exception:
+            pass
+        finally:
+            allocations.clear()
+
     def _build_dummy_attn_metadata(
         self,
         with_prefill: bool,
@@ -2607,8 +2631,18 @@ class NPUModelRunner(GPUModelRunner):
 
         if has_kv_transfer_group():
             if self.use_compress:
-                get_kv_transfer_group().register_kv_caches(
-                    kv_caches, kv_states)
+                if os.environ.get("VLLM_ASCEND_KV_HOST_SIDE") == "1":
+                    kv_transfer_group = get_kv_transfer_group()
+                    connector_worker = getattr(kv_transfer_group,
+                                               "connector_worker", None)
+                    if connector_worker is not None and hasattr(
+                            connector_worker, "_register_handlers"):
+                        connector_worker._register_handlers(kv_caches, {})
+                    else:
+                        kv_transfer_group.register_kv_caches(kv_caches)
+                else:
+                    get_kv_transfer_group().register_kv_caches(
+                        kv_caches, kv_states)
             else:
                 get_kv_transfer_group().register_kv_caches(kv_caches)
 
@@ -2783,6 +2817,17 @@ class NPUModelRunner(GPUModelRunner):
                                               Optional[torch.Tensor]]] = {}
         # prefill disaggregation need the addr of cache tensor be aligned with 2M
         alignment = 2 * 1024 * 1024
+        host_kv_family = envs.VLLM_ASCEND_DSV4_HOST_KV_FAMILY
+        host_kv_budget = envs.VLLM_ASCEND_DSV4_HOST_KV_BYTES
+        host_kv_enabled = (
+            host_kv_family == "c128"
+            and host_kv_budget is not None
+            and host_kv_budget > 0
+            and self.vllm_config.kv_transfer_config is None
+        )
+        host_kv_used = 0
+        if not hasattr(self, "_host_kv_allocations"):
+            self._host_kv_allocations = []
 
         def _get_aligned_tensor(size: torch.Size,
                                 dtype: torch.dtype,
@@ -2794,6 +2839,19 @@ class NPUModelRunner(GPUModelRunner):
             aligned_tensor = self._align_memory(original_tensor,
                                                 alignment)[:tensor_size]
             return aligned_tensor.view(dtype).view(size)
+
+        def _get_host_mapped_int8_tensor(size_bytes: int) -> torch.Tensor:
+            nonlocal host_kv_used
+            if host_kv_budget is not None and host_kv_used + size_bytes > host_kv_budget:
+                raise RuntimeError(
+                    f"DSv4 host-backed KV exceeded budget: requested={host_kv_used + size_bytes}, "
+                    f"budget={host_kv_budget}."
+                )
+            host_ptr, dev_ptr = _acl_malloc_host(size_bytes)
+            self._host_kv_allocations.append((host_ptr, size_bytes))
+            host_kv_used += size_bytes
+            return _make_host_tensor(dev_ptr, (size_bytes,), torch.int8,
+                                     self.device, size_bytes)
 
         for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
             # TODO: REFACTOR ME to sharing hybrid cache
@@ -2860,7 +2918,12 @@ class NPUModelRunner(GPUModelRunner):
                             indexer_scale_tensor)
 
                     elif exact_layer_id % 2 != 0:
-                        if self.vllm_config.kv_transfer_config is None:
+                        # ponytail: DSv4 C128 currently maps to odd exact_layer_id;
+                        # switch this branch to spec-based routing if layer ordering changes.
+                        if host_kv_enabled:
+                            c128_kv_tensor = _get_host_mapped_int8_tensor(
+                                kv_cache_tensor.size)
+                        elif self.vllm_config.kv_transfer_config is None:
                             c128_kv_tensor = torch.zeros(
                                 kv_cache_tensor.size,
                                 dtype=torch.int8,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -153,6 +153,54 @@ class GraphCaptureContext:
     stream: torch.npu.Stream
 
 
+@dataclass
+class _HostKVAllocation:
+    host_ptr: int
+    size_bytes: int
+
+
+class _HostKVAllocationOwner:
+
+    def __init__(self, budget_bytes: Optional[int], device: torch.device):
+        self.budget_bytes = budget_bytes
+        self.device = device
+        self.used_bytes = 0
+        self.allocations: list[_HostKVAllocation] = []
+        self.libacl = ctypes.CDLL("libascendcl.so")
+        self.libacl.aclrtHostUnregister.argtypes = [ctypes.c_void_p]
+        self.libacl.aclrtHostUnregister.restype = ctypes.c_int
+        self.libacl.aclrtFreeHost.argtypes = [ctypes.c_void_p]
+        self.libacl.aclrtFreeHost.restype = ctypes.c_int
+
+    def alloc_int8_tensor(self, size_bytes: int) -> torch.Tensor:
+        if self.budget_bytes is not None and self.used_bytes + size_bytes > self.budget_bytes:
+            raise RuntimeError(
+                f"DSv4 host-backed KV exceeded budget: requested={self.used_bytes + size_bytes}, "
+                f"budget={self.budget_bytes}."
+            )
+        host_ptr, dev_ptr = _acl_malloc_host(size_bytes)
+        self.allocations.append(_HostKVAllocation(host_ptr, size_bytes))
+        self.used_bytes += size_bytes
+        return _make_host_tensor(dev_ptr, (size_bytes,), torch.int8,
+                                 self.device, size_bytes)
+
+    def close(self) -> None:
+        while self.allocations:
+            allocation = self.allocations.pop()
+            ptr = ctypes.c_void_p(allocation.host_ptr)
+            try:
+                self.libacl.aclrtHostUnregister(ptr)
+            finally:
+                self.libacl.aclrtFreeHost(ptr)
+        self.used_bytes = 0
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
 @contextmanager
 def graph_capture(device: torch.device):
     """
@@ -2102,25 +2150,15 @@ class NPUModelRunner(GPUModelRunner):
         )
 
     def __del__(self):
-        allocations = getattr(self, "_host_kv_allocations", None)
-        if not allocations:
+        host_kv_owner = getattr(self, "_host_kv_owner", None)
+        if host_kv_owner is None:
             return
         try:
-            libacl = ctypes.CDLL("libascendcl.so")
-            libacl.aclrtHostUnregister.argtypes = [ctypes.c_void_p]
-            libacl.aclrtHostUnregister.restype = ctypes.c_int
-            libacl.aclrtFreeHost.argtypes = [ctypes.c_void_p]
-            libacl.aclrtFreeHost.restype = ctypes.c_int
-            for host_ptr, _size in allocations:
-                ptr = ctypes.c_void_p(host_ptr)
-                try:
-                    libacl.aclrtHostUnregister(ptr)
-                finally:
-                    libacl.aclrtFreeHost(ptr)
+            host_kv_owner.close()
         except Exception:
             pass
         finally:
-            allocations.clear()
+            self._host_kv_owner = None
 
     def _build_dummy_attn_metadata(
         self,
@@ -2815,6 +2853,11 @@ class NPUModelRunner(GPUModelRunner):
         # init kv cache tensors
         kv_cache_raw_tensors: dict[str, Union[torch.Tensor,
                                               Optional[torch.Tensor]]] = {}
+        layer_kv_cache_spec = {}
+        for group in kv_cache_config.kv_cache_groups:
+            for layer_name in group.layer_names:
+                layer_kv_cache_spec[layer_name] = group.kv_cache_spec
+
         # prefill disaggregation need the addr of cache tensor be aligned with 2M
         alignment = 2 * 1024 * 1024
         host_kv_family = envs.VLLM_ASCEND_DSV4_HOST_KV_FAMILY
@@ -2825,9 +2868,14 @@ class NPUModelRunner(GPUModelRunner):
             and host_kv_budget > 0
             and self.vllm_config.kv_transfer_config is None
         )
-        host_kv_used = 0
-        if not hasattr(self, "_host_kv_allocations"):
-            self._host_kv_allocations = []
+        host_kv_owner = getattr(self, "_host_kv_owner", None)
+        if host_kv_owner is not None:
+            host_kv_owner.close()
+            self._host_kv_owner = None
+        if host_kv_enabled:
+            host_kv_owner = _HostKVAllocationOwner(host_kv_budget,
+                                                   self.device)
+            self._host_kv_owner = host_kv_owner
 
         def _get_aligned_tensor(size: torch.Size,
                                 dtype: torch.dtype,
@@ -2841,17 +2889,9 @@ class NPUModelRunner(GPUModelRunner):
             return aligned_tensor.view(dtype).view(size)
 
         def _get_host_mapped_int8_tensor(size_bytes: int) -> torch.Tensor:
-            nonlocal host_kv_used
-            if host_kv_budget is not None and host_kv_used + size_bytes > host_kv_budget:
-                raise RuntimeError(
-                    f"DSv4 host-backed KV exceeded budget: requested={host_kv_used + size_bytes}, "
-                    f"budget={host_kv_budget}."
-                )
-            host_ptr, dev_ptr = _acl_malloc_host(size_bytes)
-            self._host_kv_allocations.append((host_ptr, size_bytes))
-            host_kv_used += size_bytes
-            return _make_host_tensor(dev_ptr, (size_bytes,), torch.int8,
-                                     self.device, size_bytes)
+            if host_kv_owner is None:
+                raise RuntimeError("DSv4 host-backed KV owner is not initialized.")
+            return host_kv_owner.alloc_int8_tensor(size_bytes)
 
         for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
             # TODO: REFACTOR ME to sharing hybrid cache
@@ -2877,49 +2917,46 @@ class NPUModelRunner(GPUModelRunner):
                         if "linear_attn" in layer_name_inner:
                             kv_cache_raw_tensors[layer_name_inner] = tensor
                 elif "attn" in layer_name and self.use_compress:
-                    c4_spec = kv_cache_config.kv_cache_groups[0].kv_cache_spec
+                    layer_spec = layer_kv_cache_spec[layer_name]
                     num_blocks = kv_cache_config.num_blocks
-                    exact_layer_id = extract_layer_index(layer_name)
 
-                    if exact_layer_id % 2 == 0:
+                    if isinstance(layer_spec, Compress4AttentionSpec):
                         if self.vllm_config.kv_transfer_config is None:
                             c4_kv_tensor = torch.zeros(
-                                num_blocks * c4_spec.compress_kv_size_bytes,
+                                num_blocks * layer_spec.compress_kv_size_bytes,
                                 dtype=torch.int8,
                                 device=self.device,
                             )
                             indexer_k_tensor = torch.zeros(
-                                num_blocks * c4_spec.indexer_k_size_bytes,
+                                num_blocks * layer_spec.indexer_k_size_bytes,
                                 dtype=torch.int8,
                                 device=self.device,
                             )
                             indexer_scale_tensor = torch.zeros(
-                                num_blocks * c4_spec.indexer_scale_size_bytes,
+                                num_blocks * layer_spec.indexer_scale_size_bytes,
                                 dtype=torch.int8,
                                 device=self.device,
                             )
                         else:
                             c4_kv_tensor = _get_aligned_tensor(
                                 torch.Size([
-                                    num_blocks * c4_spec.compress_kv_size_bytes
+                                    num_blocks * layer_spec.compress_kv_size_bytes
                                 ]), torch.int8, alignment)
                             indexer_k_tensor = _get_aligned_tensor(
                                 torch.Size([
-                                    num_blocks * c4_spec.indexer_k_size_bytes
+                                    num_blocks * layer_spec.indexer_k_size_bytes
                                 ]), torch.int8, alignment)
                             indexer_scale_tensor = _get_aligned_tensor(
                                 torch.Size([
                                     num_blocks *
-                                    c4_spec.indexer_scale_size_bytes
+                                    layer_spec.indexer_scale_size_bytes
                                 ]), torch.int8, alignment)
 
                         kv_cache_raw_tensors[layer_name] = (
                             c4_kv_tensor, indexer_k_tensor,
                             indexer_scale_tensor)
 
-                    elif exact_layer_id % 2 != 0:
-                        # ponytail: DSv4 C128 currently maps to odd exact_layer_id;
-                        # switch this branch to spec-based routing if layer ordering changes.
+                    elif isinstance(layer_spec, Compress128AttentionSpec):
                         if host_kv_enabled:
                             c128_kv_tensor = _get_host_mapped_int8_tensor(
                                 kv_cache_tensor.size)
@@ -2934,6 +2971,11 @@ class NPUModelRunner(GPUModelRunner):
                                 torch.Size([kv_cache_tensor.size]), torch.int8,
                                 alignment)
                         kv_cache_raw_tensors[layer_name] = c128_kv_tensor
+                    else:
+                        raise TypeError(
+                            f"Unsupported compressed KV spec for {layer_name}: "
+                            f"{type(layer_spec).__name__}"
+                        )
 
                 elif "attn" in layer_name and layer_name not in kv_cache_raw_tensors.keys(
                 ):
@@ -3040,13 +3082,6 @@ class NPUModelRunner(GPUModelRunner):
             Dict[str, torch.Tensor]: A map between layer names to their
             corresponding memory buffer for KV cache.
         """
-        c4_layers: list[int] | None = None
-        c128_layers: list[int] | None = None
-        if hasattr(self.model_config.hf_config, "num_hidden_layers"):
-            num_hidden_layers = self.model_config.hf_config.num_hidden_layers
-            c4_layers = list(range(0, num_hidden_layers, 2))
-            c128_layers = list(range(1, num_hidden_layers, 2))
-
         kv_caches: Dict[str, torch.Tensor] = {}
         for group in self._kv_cache_spec_attn_group_iterator():
             kv_cache_spec = group.kv_cache_spec
@@ -3055,56 +3090,55 @@ class NPUModelRunner(GPUModelRunner):
                 if layer_name in self.runner_only_attn_layers:
                     continue
 
-                if isinstance(kv_cache_spec, CompressAttentionSpec):
-                    dtype = kv_cache_spec.dtype
-                    layer_index = extract_layer_index(layer_name)
-                    assert c4_layers is not None
-                    assert c128_layers is not None
-                    if layer_index in c4_layers:
-                        c4_kv_tensor, indexer_k_tensor, indexer_scale_tensor = kv_cache_raw_tensors[
-                            layer_name]
-                        sum_page_size_bytes = c4_kv_tensor.numel(
-                        ) + indexer_k_tensor.numel(
-                        ) + indexer_scale_tensor.numel()
+                if isinstance(kv_cache_spec, Compress4AttentionSpec):
+                    c4_kv_tensor, indexer_k_tensor, indexer_scale_tensor = kv_cache_raw_tensors[
+                        layer_name]
+                    sum_page_size_bytes = c4_kv_tensor.numel(
+                    ) + indexer_k_tensor.numel(
+                    ) + indexer_scale_tensor.numel()
 
-                        num_blocks = sum_page_size_bytes // kv_cache_spec.page_size_bytes
-                        assert num_blocks == kv_cache_config.num_blocks, f"num_blocks: {num_blocks} kv_cache_config.num_blocks: {kv_cache_config.num_blocks}"
-                        c4_kv_cache_shape = self.attn_backend.get_kv_cache_shape(
-                            num_blocks // 4, kv_cache_spec.block_size,
-                            kv_cache_spec.num_kv_heads,
-                            kv_cache_spec.head_size)
-                        indexer_k_cache_shape = self.attn_backend.get_kv_cache_shape(
-                            num_blocks // 4, kv_cache_spec.block_size,
-                            kv_cache_spec.num_kv_heads,
-                            kv_cache_spec.indexer_head_size)
-                        indexer_scale_shape = self.attn_backend.get_scale_shape(
-                            num_blocks // 4,
-                            kv_cache_spec.block_size,
-                            scale_size=1)
+                    num_blocks = sum_page_size_bytes // kv_cache_spec.page_size_bytes
+                    assert num_blocks == kv_cache_config.num_blocks, f"num_blocks: {num_blocks} kv_cache_config.num_blocks: {kv_cache_config.num_blocks}"
+                    c4_kv_cache_shape = self.attn_backend.get_kv_cache_shape(
+                        num_blocks // 4, kv_cache_spec.block_size,
+                        kv_cache_spec.num_kv_heads,
+                        kv_cache_spec.head_size)
+                    indexer_k_cache_shape = self.attn_backend.get_kv_cache_shape(
+                        num_blocks // 4, kv_cache_spec.block_size,
+                        kv_cache_spec.num_kv_heads,
+                        kv_cache_spec.indexer_head_size)
+                    indexer_scale_shape = self.attn_backend.get_scale_shape(
+                        num_blocks // 4,
+                        kv_cache_spec.block_size,
+                        scale_size=1)
 
-                        c4_kv_cache = c4_kv_tensor.view(
-                            kv_cache_spec.nope_dtype).view(c4_kv_cache_shape)
-                        indexer_k_cache = indexer_k_tensor.view(
-                            kv_cache_spec.indexer_dtype).view(
-                                indexer_k_cache_shape)
-                        indexer_scale_cache = indexer_scale_tensor.view(
-                            kv_cache_spec.indexer_scale_dtype).view(
-                                indexer_scale_shape)
+                    c4_kv_cache = c4_kv_tensor.view(
+                        kv_cache_spec.nope_dtype).view(c4_kv_cache_shape)
+                    indexer_k_cache = indexer_k_tensor.view(
+                        kv_cache_spec.indexer_dtype).view(
+                            indexer_k_cache_shape)
+                    indexer_scale_cache = indexer_scale_tensor.view(
+                        kv_cache_spec.indexer_scale_dtype).view(
+                            indexer_scale_shape)
 
-                        kv_caches[layer_name] = (c4_kv_cache, indexer_k_cache,
-                                                 indexer_scale_cache)
-                    elif layer_index in c128_layers:
-                        c128_kv_tensor = kv_cache_raw_tensors[layer_name]
-                        sum_page_size_bytes = c128_kv_tensor.numel()
-                        num_blocks = sum_page_size_bytes // kv_cache_spec.page_size_bytes
-                        # TODO: now the block size of c128 layer is 16. Adapt me later
-                        c128_kv_cache_shape = self.attn_backend.get_kv_cache_shape(
-                            num_blocks // 128, kv_cache_spec.block_size,
-                            kv_cache_spec.num_kv_heads,
-                            kv_cache_spec.head_size)
-                        c128_kv_cache = c128_kv_tensor.view(dtype).view(
-                            c128_kv_cache_shape)
-                        kv_caches[layer_name] = (c128_kv_cache, )
+                    kv_caches[layer_name] = (c4_kv_cache, indexer_k_cache,
+                                             indexer_scale_cache)
+                elif isinstance(kv_cache_spec, Compress128AttentionSpec):
+                    c128_kv_tensor = kv_cache_raw_tensors[layer_name]
+                    sum_page_size_bytes = c128_kv_tensor.numel()
+                    num_blocks = sum_page_size_bytes // kv_cache_spec.page_size_bytes
+                    c128_kv_cache_shape = self.attn_backend.get_kv_cache_shape(
+                        num_blocks // 128, kv_cache_spec.block_size,
+                        kv_cache_spec.num_kv_heads,
+                        kv_cache_spec.head_size)
+                    c128_kv_cache = c128_kv_tensor.view(kv_cache_spec.dtype).view(
+                        c128_kv_cache_shape)
+                    kv_caches[layer_name] = (c128_kv_cache, )
+                elif isinstance(kv_cache_spec, CompressAttentionSpec):
+                    raise TypeError(
+                        f"Unsupported compressed KV spec for {layer_name}: "
+                        f"{type(kv_cache_spec).__name__}"
+                    )
 
                 # TODO: remove this after the OOM issue is located and fixed, otherwise, some model may
                 # encounter OOM issue


### PR DESCRIPTION
# [DSv4][A3] Static host-backed C128 KV tiering

## Summary
- add a static host-backed `C128` KV tiering path for DSv4 on A3
- grow logical KV address space by moving the cold `C128` family off HBM into host-backed memory
- harden the feature by using spec-based routing instead of layer-id parity and by making host allocation ownership explicit

## What this PR changes
- `vllm_ascend/envs.py`
  - add DSv4 host-backed KV env knobs
    - `VLLM_ASCEND_DSV4_HOST_KV_FAMILY`
    - `VLLM_ASCEND_DSV4_HOST_KV_BYTES`
- `vllm_ascend/patch/platform/patch_kv_cache_utils.py`
  - split KV planning into HBM-backed vs host-backed bytes per logical block
  - compute `num_blocks` from `min(hbm_budget, host_budget)`
  - keep `C128` as the only host-backed family in this PR
- `vllm_ascend/worker/model_runner_v1.py`
  - allocate host-backed `C128` tensors with ACL host registration
  - route compressed KV by spec type instead of temporary odd/even layer-id assumptions
  - make host allocation ownership and cleanup explicit
  - inline the tiny host allocation helpers so the branch is self-contained

## Feature boundary
This PR is **static tiering / larger KV address space via host-backed cold family**.
It is **not** the older swap/offload path.

In scope:
- `C128` only

Explicitly out of scope:
- `C4`
- `SWA`
- swap/offload-style runtime migration

## Why `C128` first
For the current DSv4 config:
- `#C128 layers = 20`
- `#C4 layers = 21`
- `C128 page_size = 1024 B`
- `C4 page_size = 36928 B`
- `C4 / C128 = 36.06x`

`C128` is the smallest and coldest compressed family, so it is the right formal baseline for static tiering.

## Benchmark summary
Workload: DSv4 A3, `6656 -> 256`, `cc=1,2,4,8,16,24,32`

### OFF vs hardened C128
| cc | OFF tok/s | C128 tok/s | C128/OFF |
|---:|---:|---:|---:|
| 1  | 6.377 | 6.596 | 1.03x |
| 2  | 10.334 | 10.698 | 1.04x |
| 4  | 20.012 | 21.602 | 1.08x |
| 8  | 38.171 | 39.509 | 1.04x |
| 16 | 66.596 | 68.967 | 1.04x |
| 24 | 71.850 | 73.889 | 1.03x |
| 32 | 90.342 | 88.778 | 0.98x |

Interpretation:
- hardened `C128` is the right PR baseline
- it is slightly positive or near parity on this surface
- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
