### PR TITLE
[DSv4][A3] port static host-backed C128 to v0.20.2rc

### DIFF
--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -114,6 +114,14 @@ env_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
     # Whether to use MultiBlockPool for KV cache management
     "VLLM_ASCEND_APPLY_DSV4_PATCH": lambda: bool(int(os.getenv("VLLM_ASCEND_APPLY_DSV4_PATCH", "0"))),
+    # Select the DSv4 compressed KV family to place in host-backed memory.
+    # Supported values: "c128" or empty string. Default is disabled.
+    "VLLM_ASCEND_DSV4_HOST_KV_FAMILY": lambda: os.getenv("VLLM_ASCEND_DSV4_HOST_KV_FAMILY", "").strip().lower(),
+    # Total host-backed budget in bytes for the selected DSv4 KV family.
+    # If unset, host-backed DSv4 KV tiering is disabled.
+    "VLLM_ASCEND_DSV4_HOST_KV_BYTES": lambda: (
+        int(value) if (value := os.getenv("VLLM_ASCEND_DSV4_HOST_KV_BYTES")) else None
+    ),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 
 import vllm.v1.core.kv_cache_utils
 from vllm.config import VllmConfig
+from vllm_ascend import envs
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.v1.core.kv_cache_utils import _approximate_gcd, may_override_num_blocks
 from vllm.v1.kv_cache_interface import (
@@ -53,6 +54,24 @@ def _ascend_resolve_kv_cache_block_sizes(
         return scheduler_block_size, scheduler_block_size
 
     return _orig_resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
+
+
+def _get_dsv4_host_kv_budget() -> tuple[str, int] | None:
+    family = envs.VLLM_ASCEND_DSV4_HOST_KV_FAMILY
+    host_bytes = envs.VLLM_ASCEND_DSV4_HOST_KV_BYTES
+    if not family or host_bytes is None or host_bytes <= 0:
+        return None
+    return family, int(host_bytes)
+
+
+def _is_host_backed_spec(spec: KVCacheSpec, family: str) -> bool:
+    return family == "c128" and getattr(spec, "compress_ratio", None) == 128
+
+
+def _blocks_for_budget(budget_bytes: int, bytes_per_block: int) -> float:
+    if bytes_per_block <= 0:
+        return float("inf")
+    return budget_bytes // bytes_per_block
 
 
 def group_and_unify_kv_cache_specs(
@@ -226,7 +245,25 @@ def _get_kv_cache_config_deepseek_v4(
     # this equals the sub-group size (each has a single page_size).
     num_layer_tuples = max(len(layers) for b in bucketed for layers in b.values()) + len(mtp_layer_names)
 
-    num_blocks = available_memory // (layer_tuple_page_bytes * num_layer_tuples)
+    host_kv_budget = _get_dsv4_host_kv_budget()
+    if host_kv_budget is None:
+        num_blocks = available_memory // (layer_tuple_page_bytes * num_layer_tuples)
+    else:
+        family, host_bytes = host_kv_budget
+        hbm_bytes_per_block = 0
+        host_bytes_per_block = 0
+        for group in kv_cache_groups:
+            assert isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs)
+            for layer_name in group.layer_names:
+                layer_spec = group.kv_cache_spec.kv_cache_specs[layer_name]
+                if _is_host_backed_spec(layer_spec, family):
+                    host_bytes_per_block += layer_spec.page_size_bytes
+                else:
+                    hbm_bytes_per_block += layer_spec.page_size_bytes
+        num_blocks = int(min(
+            _blocks_for_budget(available_memory, hbm_bytes_per_block),
+            _blocks_for_budget(host_bytes, host_bytes_per_block),
+        ))
     num_blocks = may_override_num_blocks(vllm_config, num_blocks)
 
     kv_cache_tensors: list[KVCacheTensor] = []

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -17,6 +17,7 @@
 # Adapted from vllm-project/vllm/vllm/worker/gpu_model_runner.py
 #
 
+import ctypes
 import math
 import sys
 import time
@@ -78,6 +79,7 @@ from vllm.v1.outputs import (
 )
 from vllm.v1.worker.utils import select_common_block_size
 
+from vllm_ascend import envs
 from vllm_ascend.utils import vllm_version_is
 
 if not vllm_version_is("0.20.2"):
@@ -173,6 +175,7 @@ else:
 
 
 from vllm.model_executor.layers.attention import Attention, MLAAttention
+import torch_npu
 
 # if true, allow tensor initialization and casting with internal format (e.g., NZ)
 torch.npu.config.allow_internal_format = True
@@ -188,6 +191,85 @@ SEQ_LEN_WITH_MAX_PA_WORKSPACE = 6144
 @dataclass
 class GraphCaptureContext:
     stream: torch.npu.Stream
+
+
+def _acl_malloc_host(size: int) -> tuple[int, int]:
+    libacl = ctypes.CDLL("libascendcl.so")
+    host_ptr = ctypes.c_void_p()
+    ret = libacl.aclrtMallocHost(ctypes.byref(host_ptr), ctypes.c_size_t(size))
+    if ret != 0:
+        raise RuntimeError(f"aclrtMallocHost failed: error {ret} (size={size}).")
+
+    dev_ptr = ctypes.c_void_p()
+    ret = libacl.aclrtHostRegister(
+        host_ptr, ctypes.c_uint64(size), ctypes.c_int(0), ctypes.byref(dev_ptr)
+    )
+    if ret != 0:
+        libacl.aclrtFreeHost(host_ptr)
+        raise RuntimeError(f"aclrtHostRegister failed: error {ret}")
+    return host_ptr.value, dev_ptr.value
+
+
+def _compact_strides(shape: tuple[int, ...]) -> tuple[int, ...]:
+    strides = [1] * len(shape)
+    for i in range(len(shape) - 2, -1, -1):
+        strides[i] = strides[i + 1] * shape[i + 1]
+    return tuple(strides)
+
+
+def _make_host_tensor(dev_ptr_int: int, shape: tuple[int, ...], dtype: torch.dtype,
+                      device: torch.device, size_bytes: int) -> torch.Tensor:
+    storage = torch_npu._C._construct_storage_from_data_pointer(
+        dev_ptr_int, device, size_bytes
+    )
+    return torch.empty(0, dtype=dtype, device=device).set_(
+        storage, 0, shape, _compact_strides(shape)
+    )
+
+
+@dataclass
+class _HostKVAllocation:
+    host_ptr: int
+    size_bytes: int
+
+
+class _HostKVAllocationOwner:
+    def __init__(self, budget_bytes: int | None, device: torch.device):
+        self.budget_bytes = budget_bytes
+        self.device = device
+        self.used_bytes = 0
+        self.allocations: list[_HostKVAllocation] = []
+        self.libacl = ctypes.CDLL("libascendcl.so")
+        self.libacl.aclrtHostUnregister.argtypes = [ctypes.c_void_p]
+        self.libacl.aclrtHostUnregister.restype = ctypes.c_int
+        self.libacl.aclrtFreeHost.argtypes = [ctypes.c_void_p]
+        self.libacl.aclrtFreeHost.restype = ctypes.c_int
+
+    def alloc_int8_tensor(self, size_bytes: int) -> torch.Tensor:
+        if self.budget_bytes is not None and self.used_bytes + size_bytes > self.budget_bytes:
+            raise RuntimeError(
+                f"DSv4 host-backed KV exceeded budget: requested={self.used_bytes + size_bytes}, budget={self.budget_bytes}."
+            )
+        host_ptr, dev_ptr = _acl_malloc_host(size_bytes)
+        self.allocations.append(_HostKVAllocation(host_ptr, size_bytes))
+        self.used_bytes += size_bytes
+        return _make_host_tensor(dev_ptr, (size_bytes,), torch.int8, self.device, size_bytes)
+
+    def close(self) -> None:
+        while self.allocations:
+            allocation = self.allocations.pop()
+            ptr = ctypes.c_void_p(allocation.host_ptr)
+            try:
+                self.libacl.aclrtHostUnregister(ptr)
+            finally:
+                self.libacl.aclrtFreeHost(ptr)
+        self.used_bytes = 0
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
 
 
 @contextmanager
@@ -283,6 +365,8 @@ class NPUModelRunner(GPUModelRunner):
                 self.max_num_reqs + 1,  # type: ignore[has-type]
                 dtype=torch.int32,
             )
+
+        self._host_kv_owner: _HostKVAllocationOwner | None = None
 
         vllm_config.scheduler_config.max_num_batched_tokens -= max_pcp_pad_tokens
         self.max_num_tokens = self.scheduler_config.max_num_batched_tokens
@@ -3561,6 +3645,17 @@ class NPUModelRunner(GPUModelRunner):
 
         return kv_caches
 
+    def __del__(self):
+        host_kv_owner = getattr(self, "_host_kv_owner", None)
+        if host_kv_owner is None:
+            return
+        try:
+            host_kv_owner.close()
+        except Exception:
+            pass
+        finally:
+            self._host_kv_owner = None
+
     def _get_layer_kv_cache_specs(self, kv_cache_config: KVCacheConfig) -> dict[str, KVCacheSpec]:
         layer_kv_cache_spec: dict[str, KVCacheSpec] = {}
         for group_kv_cache_spec in kv_cache_config.kv_cache_groups:
@@ -3614,6 +3709,24 @@ class NPUModelRunner(GPUModelRunner):
         # prefill disaggregation need the addr of cache tensor be aligned with 2M
         alignment = 2 * 1024 * 1024
         layer_kv_cache_spec = self._get_layer_kv_cache_specs(kv_cache_config)
+        host_kv_family = envs.VLLM_ASCEND_DSV4_HOST_KV_FAMILY
+        host_kv_budget = envs.VLLM_ASCEND_DSV4_HOST_KV_BYTES
+        host_kv_enabled = (
+            host_kv_family == "c128"
+            and host_kv_budget is not None
+            and host_kv_budget > 0
+            and self.vllm_config.kv_transfer_config is None
+        )
+        if self._host_kv_owner is not None:
+            self._host_kv_owner.close()
+            self._host_kv_owner = None
+        if host_kv_enabled:
+            self._host_kv_owner = _HostKVAllocationOwner(host_kv_budget, self.device)
+
+        def _get_host_mapped_int8_tensor(size_bytes: int) -> torch.Tensor:
+            if self._host_kv_owner is None:
+                raise RuntimeError("DSv4 host-backed KV owner is not initialized.")
+            return self._host_kv_owner.alloc_int8_tensor(size_bytes)
         # If some tensors are shared by linear layers and attention layers,
         # the same tensor format must be maintained even if some layers
         # have only linear or attention layers, for example, the mtp layer.
@@ -3646,7 +3759,14 @@ class NPUModelRunner(GPUModelRunner):
                         # shared the kvcache for all shared layers
                         kv_cache_raw_tensors[layer_name_inner] = tensor
                 elif "attn" in layer_name and self.use_compress and layer_name not in kv_cache_raw_tensors:
-                    if self.vllm_config.kv_transfer_config is None:
+                    shared_specs = [layer_kv_cache_spec[name] for name in kv_cache_tensor.shared_by]
+                    shared_is_host_backed = (
+                        host_kv_enabled
+                        and all(getattr(spec, "compress_ratio", None) == 128 for spec in shared_specs)
+                    )
+                    if shared_is_host_backed:
+                        tensor = _get_host_mapped_int8_tensor(kv_cache_tensor.size)
+                    elif self.vllm_config.kv_transfer_config is None:
                         tensor = torch.zeros(kv_cache_tensor.size,
                                                 dtype=torch.int8,
                                                 device=self.device)


### PR DESCRIPTION
# [DSv4][A3] Port static host-backed C128 KV to v0.20.2rc

## Summary
- port the clean three-file `C128` static host-backed KV feature onto `releases/v0.20.2rc`
- preserve the feature boundary as **static tiering / larger KV address space via host-backed cold family**
- keep scope limited to `C128` only

## What this PR changes
- `vllm_ascend/envs.py`
  - add DSv4 host-backed KV env knobs
    - `VLLM_ASCEND_DSV4_HOST_KV_FAMILY`
    - `VLLM_ASCEND_DSV4_HOST_KV_BYTES`
- `vllm_ascend/patch/platform/patch_kv_cache_utils.py`
  - split DSv4 KV planning into HBM-backed vs host-backed bytes per logical block
  - compute `num_blocks` from `min(hbm_budget, host_budget)`
  - keep `C128` as the only host-backed family in this PR
- `vllm_ascend/worker/model_runner_v1.py`
  - add self-contained ACL host allocation helpers
  - add explicit host allocation ownership / cleanup
  - route host-backed compressed allocation by spec via the newer v0.20.2rc DSv4 compressed-KV surface

## Feature boundary
This PR is **not** the older swap/offload path.

This PR is only about:
- static tiering
- larger logical KV address space
- via host-backed cold family placement

In scope:
- `C128` only

Out of scope:
- `C4`
- `SWA`
- runtime swap / migration / offload semantics

## Why C128 first
For the current DSv4 config:
- `#C128 layers = 20`
- `#C4 layers = 21`
- `C128 page_size = 1024 B`
- `C4 page_size = 36928 B`
- `C4 / C128 = 36.06x`

`C128` is the smallest and coldest compressed family, so it is the correct formal baseline for static tiering.

## Expected effect / prior evidence
From the validated A3 `.204` experiments on the v0.13.0-based branch:
- hardened `C128` was slightly positive or near parity vs OFF on the tested 6656 -> 256 workload
- separate `C4` exploration was benchmark-negative from `cc4` upward and is therefore intentionally excluded from this PR

Reference docs:
- `C128_C4_RESULTS_20260629.md`
- `DSV4_KV_SIZE_IO_MODEL_20260629.md`
- https://github.com/vllm-project/vllm-ascend/pull/11469

## Validation status for this branch
- Python compile check passed for the three migrated files
- runtime validation on `releases/v0.20.2rc` is still needed after review / CI / lab run

## Follow-ups
- keep `C4` on its separate exploration branch
- do not widen to `SWA` without a separate design decision
- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
