### PR TITLE
[BugFix] Avoid scatter overflow for large slot mappings

### DIFF
--- a/csrc/moe/scatter_nd_update_v2/op_host/scatter_nd_update_v2_tiling.cpp
+++ b/csrc/moe/scatter_nd_update_v2/op_host/scatter_nd_update_v2_tiling.cpp
@@ -92,16 +92,19 @@ private:
 
 inline void ScatterNdUpdateV2Tiling::SetTilingKeyMode()
 {
-    // tilingKey: indexType * 10 + sortFlag (indexType: 1=int32, 2=int64(cast), 3=int64(large))
+    // tilingKey: indexType * 10 + sortFlag
+    // indexType: 1=int32, 2=int64(cast), 3=int64(large), 4=int32(large)
     uint64_t indexType;
-    if (!isInt64Indices_) {
-        indexType = 1;
-    } else if (needLargeIndexKernel_) {
+    if (needLargeIndexKernel_ && isInt64Indices_) {
         indexType = 3;
+    } else if (needLargeIndexKernel_) {
+        indexType = 4;
+    } else if (!isInt64Indices_) {
+        indexType = 1;
     } else {
         indexType = 2;
     }
-    uint64_t sortFlag = (indexType == 3) ? 0 : (isSort_ ? 1 : 0);
+    uint64_t sortFlag = needLargeIndexKernel_ ? 0 : (isSort_ ? 1 : 0);
     tilingKey_ = indexType * 10 + sortFlag;
 
     tilingContext_->SetTilingKey(tilingKey_);
@@ -260,6 +263,9 @@ inline size_t ScatterNdUpdateV2Tiling::CalcWorkSpaceSize(uint64_t indexRow)
     if (isSort_) {
         totalWorkspace += sortWorkspace_ * SORT_USE_GM_NUM * sizeof(int);
     }
+    if (needLargeIndexKernel_) {
+        totalWorkspace += ALIGNED_SIZE;
+    }
     return totalWorkspace;
 }
 
@@ -350,8 +356,12 @@ ge::graphStatus ScatterNdUpdateV2Tiling::Init()
         maxPhysicalOffset += (varRefShape.GetDim(i) - 1) * indicesMask_[i];
     }
     uint64_t totalPhysicalRange = maxPhysicalOffset + scatterLength_;
+    needLargeIndexKernel_ = needLargeIndexKernel_ || !IsLinearIndex(totalPhysicalRange);
     if (!needLargeIndexKernel_) {
         isSort_ = IsSort(totalPhysicalRange, indexRow);
+    } else {
+        isSort_ = false;
+        isLinearIndex_ = false;
     }
     SetTilingKeyMode();
     tilingContext_->SetScheduleMode(1);

--- a/csrc/moe/scatter_nd_update_v2/op_kernel/scatter_nd_update_large_index.h
+++ b/csrc/moe/scatter_nd_update_v2/op_kernel/scatter_nd_update_large_index.h
@@ -19,7 +19,7 @@
 
 namespace ScatterNdUpdateV2 {
 
-template<typename T>
+template<typename T, typename IndicesT = int64_t>
 class LargeIndexKernel {
 public:
     __aicore__ inline LargeIndexKernel() = delete;
@@ -40,9 +40,6 @@ public:
                               tiling.scatterTiling.tailRow, computeRow_, start_);
         end_ = start_ + computeRow_;
 
-        startInt64_ = static_cast<int64_t>(start_);
-        endInt64_ = static_cast<int64_t>(end_);
-
         indexDim_ = tiling.linearIndexTiling.indexDim;
         blockLength_ = tiling.linearIndexTiling.blockLength;
         blockNum_ = tiling.linearIndexTiling.blockNum;
@@ -61,20 +58,20 @@ public:
 
     __aicore__ inline void InitBuffers(TPipe& pipe)
     {
-        uint64_t indicesInt64Size = ((blockLength_ * indexDim_ * 2) + ALIGN_NUM - 1) & ~(ALIGN_NUM - 1);
+        uint64_t indicesBytes = (blockLength_ * indexDim_ * sizeof(IndicesT) + 31) & ~31ULL;
         uint64_t updateBufBytes = (ubLengthForUpdates_ * sizeof(T) + 31) & ~31ULL;
 
-        pipe.InitBuffer(indicesBuf, indicesInt64Size * sizeof(int));
+        pipe.InitBuffer(indicesBuf, indicesBytes);
         pipe.InitBuffer(updateBuf, updateBufBytes);
 
-        indicesInt64Local = indicesBuf.Get<int>().ReinterpretCast<int64_t>();
+        indicesLocal = indicesBuf.Get<IndicesT>();
         updateLocal = updateBuf.Get<T>();
     }
 
     __aicore__ inline void SetGmAddr(GM_ADDR indices, GM_ADDR updates, GM_ADDR output,
                                       const ScatterNdUpdateV2TilingData& tiling)
     {
-        indicesGmInt64_.SetGlobalBuffer((__gm__ int64_t*)indices);
+        indicesGm_.SetGlobalBuffer((__gm__ IndicesT*)indices);
         updatesGm_.SetGlobalBuffer((__gm__ T*)updates);
         outputGm_.SetGlobalBuffer((__gm__ T*)output);
     }
@@ -92,39 +89,41 @@ public:
     __aicore__ inline void ProcessOneBlock(uint64_t blockIdx, bool isTail)
     {
         uint64_t copyRow = isTail ? blockRemainLength_ : blockLength_;
-        CopyInInt64(blockIdx, isTail);
+        CopyInIndices(blockIdx, isTail);
 
         for (uint64_t i = 0; i < copyRow; ++i) {
-            int64_t linearIndex = ComputeLinearIndex(i);
-            if (linearIndex >= startInt64_ && linearIndex < endInt64_) {
+            uint64_t linearIndex = 0;
+            if (ComputeLinearIndex(i, linearIndex) && linearIndex >= start_ && linearIndex < end_) {
                 ScatterUpdate(i, linearIndex);
             }
         }
     }
 
-    __aicore__ inline void CopyInInt64(uint64_t blockIdx, bool isTail)
+    __aicore__ inline void CopyInIndices(uint64_t blockIdx, bool isTail)
     {
         uint64_t indicesOffset = blockIdx * blockLength_ * indexDim_;
         uint64_t copyRow = isTail ? blockRemainLength_ : blockLength_;
 
-        DataCopyExtParams copyParams{1, static_cast<uint32_t>(copyRow * indexDim_ * sizeof(int64_t)), 0, 0, 0};
-        DataCopyPadExtParams<int64_t> padParams{true, 0, 0, 0};
-        DataCopyPad(indicesInt64Local, indicesGmInt64_[indicesOffset], copyParams, padParams);
+        DataCopyExtParams copyParams{1, static_cast<uint32_t>(copyRow * indexDim_ * sizeof(IndicesT)), 0, 0, 0};
+        DataCopyPadExtParams<IndicesT> padParams{true, 0, 0, 0};
+        DataCopyPad(indicesLocal, indicesGm_[indicesOffset], copyParams, padParams);
         PipeMte2ToS();
     }
 
-    __aicore__ inline int64_t ComputeLinearIndex(uint64_t rowIdx)
+    __aicore__ inline bool ComputeLinearIndex(uint64_t rowIdx, uint64_t& linearIndex)
     {
-        int64_t linearIndex = 0;
+        linearIndex = 0;
         for (uint64_t dim = 0; dim < indexDim_; ++dim) {
-            int64_t idxValue = indicesInt64Local.GetValue(rowIdx * indexDim_ + dim);
-            int64_t stride = static_cast<int64_t>(indicesMask_[dim]);
-            linearIndex += idxValue * stride;
+            int64_t idxValue = static_cast<int64_t>(indicesLocal.GetValue(rowIdx * indexDim_ + dim));
+            if (idxValue < 0) {
+                return false;
+            }
+            linearIndex += static_cast<uint64_t>(idxValue) * indicesMask_[dim];
         }
-        return linearIndex;
+        return true;
     }
 
-    __aicore__ inline void ScatterUpdate(uint64_t rowIdx, int64_t linearIndex)
+    __aicore__ inline void ScatterUpdate(uint64_t rowIdx, uint64_t linearIndex)
     {
         for (uint64_t tileIdx = 0; tileIdx < scatterTileNum_; ++tileIdx) {
             uint64_t tileLength = (tileIdx == scatterTileNum_ - 1) ? scatterTileTail_ : scatterTileLength_;
@@ -142,23 +141,20 @@ public:
     }
 
 private:
-    GlobalTensor<int64_t> indicesGmInt64_;
+    GlobalTensor<IndicesT> indicesGm_;
     GlobalTensor<T> updatesGm_;
     GlobalTensor<T> outputGm_;
 
     TBuf<TPosition::VECCALC> indicesBuf;
     TBuf<TPosition::VECCALC> updateBuf;
 
-    LocalTensor<int64_t> indicesInt64Local;
+    LocalTensor<IndicesT> indicesLocal;
     LocalTensor<T> updateLocal;
 
     uint64_t blockIdx_;
     uint64_t computeRow_;
     uint64_t start_;
     uint64_t end_;
-    int64_t startInt64_;
-    int64_t endInt64_;
-
     uint64_t indexDim_;
     uint64_t blockLength_;
     uint64_t blockNum_;

--- a/csrc/moe/scatter_nd_update_v2/op_kernel/scatter_nd_update_v2.cpp
+++ b/csrc/moe/scatter_nd_update_v2/op_kernel/scatter_nd_update_v2.cpp
@@ -30,7 +30,8 @@ extern "C" __global__ __aicore__ void scatter_nd_update_v2(GM_ADDR varRef, GM_AD
     AscendC::TPipe tpipe;
 #if (defined(DTYPE_VAR))
     // tilingKey: indexType * 10 + sortFlag
-    // indexType: 1=int32, 2=int64(cast), 3=int64(large); sortFlag: 0=非排序, 1=排序
+    // indexType: 1=int32, 2=int64(cast), 3=int64(large), 4=int32(large);
+    // sortFlag: 0=非排序, 1=排序
     if (TILING_KEY_IS(11)) {
         ScatterNdUpdateV2::LinearIndexKernel<true, int> op1(indices, workSpace, tilingData, tpipe);
         op1.Process();
@@ -64,7 +65,10 @@ extern "C" __global__ __aicore__ void scatter_nd_update_v2(GM_ADDR varRef, GM_AD
         ScatterNdUpdateV2::ScatterNdUpdateV2KernelNoSort<DTYPE_VAR> op2(updates, output, workSpace, tilingData, pipe);
         op2.Process();
     } else if (TILING_KEY_IS(30)) {
-        ScatterNdUpdateV2::LargeIndexKernel<DTYPE_VAR> op(indices, updates, output, tilingData, tpipe);
+        ScatterNdUpdateV2::LargeIndexKernel<DTYPE_VAR, int64_t> op(indices, updates, output, tilingData, tpipe);
+        op.Process();
+    } else if (TILING_KEY_IS(40)) {
+        ScatterNdUpdateV2::LargeIndexKernel<DTYPE_VAR, int32_t> op(indices, updates, output, tilingData, tpipe);
         op.Process();
     }
 #endif


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes a large slot mapping overflow issue in `ScatterNdUpdateV2`. The existing linear-index path stores computed physical offsets in int32 intermediate buffers. When a slot maps to a high block id, such as `[[40000, 0], [40000, 1]]`, multiplying the block id by the cache stride can exceed the int32 range before the cache update is written.

Changes:
- Route scatter updates to the large-index kernel when the computed physical cache range exceeds int32.
- Add a large-index path for int32 `slot_mapping` inputs.
- Compute large scatter offsets with `uint64_t`.
- Skip negative padding indices in the large-index path.
- Reserve minimal user workspace for the large-index path so the kernel entry does not return early.

### Does this PR introduce _any_ user-facing change?

No API change. This fixes cache writes for large physical slot offsets in custom scatter update paths.

### How was this patch tested?

- `git diff --check`

NPU custom op build/runtime verification has not been run yet. This PR is draft pending validation on Ascend hardware with a large slot mapping case.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
