### PR TITLE
[Feature] fix mtp mask for interleave size > 1 with pcp

### DIFF
--- a/tests/ut/worker/test_pcp_manager.py
+++ b/tests/ut/worker/test_pcp_manager.py
@@ -571,3 +571,187 @@ def test_adjust_cu_num_scheduled_tokens_for_pcp(
     ), (
         f"Expected {expected_cu_num_scheduled_tokens}, got {result.tolist()}"
     )
+
+
+def _ref_mtp_mask_lens(
+    history_len: int,
+    num_scheduled: int,
+    cp_rank: int,
+    cp_size: int,
+    interleave_size: int,
+) -> tuple[int, list[int]]:
+    """Reference: compute per-rank KV length and k_upper per query position.
+
+    Follows the same interleave-aware formulas as
+    ``generate_mtp_attention_mask_for_decode``.
+    """
+    total_len = history_len + num_scheduled
+    # Per-rank KV length
+    base_k = total_len // interleave_size // cp_size * interleave_size
+    remainder_k = total_len - base_k * cp_size
+    k_lens = base_k + max(0, min(remainder_k - cp_rank * interleave_size, interleave_size))
+
+    context_len = history_len
+    k_uppers: list[int] = []
+    for qi in range(num_scheduled):
+        pos = context_len + qi
+        base_q = pos // interleave_size // cp_size * interleave_size
+        remainder_q = pos - base_q * cp_size
+        local_q = base_q + max(0, min(remainder_q - cp_rank * interleave_size, interleave_size))
+        k_upper = local_q - 1
+        k_uppers.append(k_upper)
+
+    return k_lens, k_uppers
+
+
+def _build_ref_mask(
+    q_lens: int,
+    k_lens: int,
+    k_uppers: list[int],
+) -> torch.Tensor:
+    """Build the reference attention mask with the same logic as the function under test."""
+    mask = torch.zeros(q_lens, k_lens, dtype=torch.bool)
+    for qi, ku in enumerate(k_uppers):
+        if ku >= 0:
+            mask[qi, ku + 1 :] = True
+        # When ku < 0 the guard (ku >= 0) makes the AND-gate False, so mask stays False.
+    return mask
+
+
+def _make_pcp_manager(
+    pcp_world_size: int,
+    dcp_world_size: int,
+    dcp_rank: int,
+    interleave_size: int,
+    num_speculative_tokens: int = 1,
+    max_model_len: int = 4096,
+    max_num_reqs: int = 8,
+    max_num_tokens: int = 4096,
+) -> PCPManager:
+    vllm_config = MagicMock()
+    vllm_config.model_config = MagicMock()
+    vllm_config.model_config.use_mla = False
+    vllm_config.model_config.max_model_len = max_model_len
+    vllm_config.model_config.hf_config = MagicMock()
+    vllm_config.model_config.hf_config.model_type = "qwen2"
+    vllm_config.parallel_config = MagicMock()
+    vllm_config.parallel_config.cp_kv_cache_interleave_size = interleave_size
+    vllm_config.speculative_config = MagicMock()
+    vllm_config.speculative_config.num_speculative_tokens = num_speculative_tokens
+    vllm_config.scheduler_config = MagicMock()
+    vllm_config.scheduler_config.max_num_batched_tokens = max_num_tokens
+    vllm_config.scheduler_config.max_num_seqs = max_num_reqs
+
+    return PCPManager(
+        pcp_world_size=pcp_world_size,
+        pcp_rank=0,
+        dcp_world_size=dcp_world_size,
+        dcp_rank=dcp_rank,
+        max_buffer_num_tokens=max_num_tokens,
+        max_num_reqs=max_num_reqs,
+        device="cpu",
+        vllm_config=vllm_config,
+        use_async_scheduling=False,
+        pin_memory=False,
+    )
+
+
+# yapf: disable
+@pytest.mark.parametrize(
+    "dcp_world_size, dcp_rank, history_len, num_scheduled, interleave_size",
+    [
+        # interleave_size=1: token-level interleave, all cp_rank see similar counts
+        (2, 0, 200, 100, 1),
+        (2, 1, 200, 100, 1),
+        (4, 0, 300, 50, 1),
+        (4, 3, 300, 50, 1),
+        # interleave_size=128: block-level interleave
+        # total_len < 128: rank-0 owns everything, rank-1 owns nothing
+        (2, 0, 50, 10, 128),
+        (2, 1, 50, 10, 128),
+        # total_len crosses one interleave boundary (128 < L < 256)
+        (2, 0, 100, 50, 128),
+        (2, 1, 100, 50, 128),
+        # total_len crosses multiple interleave boundaries (L > 256)
+        (2, 0, 200, 100, 128),
+        (2, 1, 200, 100, 128),
+        # exactly at interleave boundary
+        (2, 0, 128, 10, 128),
+        (2, 1, 128, 10, 128),
+        # cp_size=4 with interleave_size=128
+        (4, 0, 300, 50, 128),
+        (4, 2, 300, 50, 128),
+        (4, 3, 300, 50, 128),
+    ],
+)
+# yapf: enable
+def test_generate_mtp_attention_mask_for_decode(
+    dcp_world_size: int,
+    dcp_rank: int,
+    history_len: int,
+    num_scheduled: int,
+    interleave_size: int,
+):
+    """Verify interleave-aware MTP attention masks for decode requests.
+
+    Compares the function output against a reference implementation that
+    applies the same formulas.  Covers both token-level (I=1) and
+    block-level (I=128) interleave patterns.
+    """
+    pcp_world_size = 1
+    cp_size = dcp_world_size * pcp_world_size
+    cp_rank = dcp_rank
+
+    pcp_manager = _make_pcp_manager(
+        pcp_world_size=pcp_world_size,
+        dcp_world_size=dcp_world_size,
+        dcp_rank=dcp_rank,
+        interleave_size=interleave_size,
+    )
+
+    num_scheduled_tokens = np.array([num_scheduled], dtype=np.int32)
+    num_computed_tokens = np.array([history_len], dtype=np.int32)
+    num_prompt_tokens = np.array([history_len], dtype=np.int32)
+
+    pcp_manager.init_batch_info(
+        num_scheduled_tokens,
+        num_reqs=1,
+        num_computed_tokens=num_computed_tokens,
+        num_prompt_tokens=num_prompt_tokens,
+    )
+    assert pcp_manager.num_decode_reqs == 1
+
+    result = pcp_manager.generate_mtp_attention_mask_for_decode(
+        decode_num_computed_tokens=[history_len],
+        decode_num_scheduled_tokens=num_scheduled_tokens,
+    )
+    assert result is not None
+
+    ref_k_lens, ref_k_uppers = _ref_mtp_mask_lens(
+        history_len, num_scheduled, cp_rank, cp_size, interleave_size
+    )
+    ref_mask = _build_ref_mask(num_scheduled, ref_k_lens, ref_k_uppers)
+
+    max_q = num_scheduled
+    max_k = ref_k_lens
+
+    if ref_k_lens == 0:
+        # k_lens=0 means valid.any() is False; function returns early with
+        # zero-filled mask.
+        assert result[0, :max_q, :max_k].sum() == 0, (
+            f"Expected all-False mask for k_lens=0, "
+            f"history={history_len}, scheduled={num_scheduled}, dcp_rank={dcp_rank}"
+        )
+        return
+
+    actual_mask = result[0, :max_q, :max_k]
+    assert actual_mask.shape == ref_mask.shape, (
+        f"Shape mismatch: {actual_mask.shape} vs {ref_mask.shape}"
+    )
+    assert torch.equal(actual_mask, ref_mask), (
+        f"Mask mismatch for "
+        f"history={history_len}, scheduled={num_scheduled}, "
+        f"dcp_rank={dcp_rank}, interleave={interleave_size}\n"
+        f"ref_k_lens={ref_k_lens}, ref_k_uppers={ref_k_uppers}\n"
+        f"Expected:\n{ref_mask.int()}\nGot:\n{actual_mask.int()}"
+    )

--- a/tests/ut/worker/test_pcp_manager.py
+++ b/tests/ut/worker/test_pcp_manager.py
@@ -707,6 +707,7 @@ def test_generate_mtp_attention_mask_for_decode(
         dcp_world_size=dcp_world_size,
         dcp_rank=dcp_rank,
         interleave_size=interleave_size,
+        num_speculative_tokens=num_scheduled - 1,
     )
 
     num_scheduled_tokens = np.array([num_scheduled], dtype=np.int32)

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -1505,18 +1505,24 @@ class PCPManager:
         cp_size = self.pcp_world_size * self.dcp_world_size
         assert cp_size > 1, "cp_size must be greater than 1"
 
+        interleave_size = self.vllm_config.parallel_config.cp_kv_cache_interleave_size
+
         q_lens = torch.tensor(decode_num_scheduled_tokens[: self.num_decode_reqs], dtype=torch.int32)
         global_histories = torch.tensor(decode_num_computed_tokens, dtype=torch.int32)
         total_lens = global_histories + q_lens
         context_lens = total_lens - q_lens
 
-        max_indices = total_lens - 1
-        valid = max_indices >= cp_rank
+        # Interleave-aware per-rank KV length:
+        # base = L // I // W * I, remainder = L - base * W,
+        # local = base + clip(remainder - rank * I, 0, I)
+        base_k = total_lens // interleave_size // cp_size * interleave_size
+        remainder_k = total_lens - base_k * cp_size
+        k_lens = base_k + torch.clamp(remainder_k - cp_rank * interleave_size, 0, interleave_size)
+        valid = k_lens > 0
 
         if not valid.any():
             return self.dcp_mtp_attn_mask.cpu[: self.num_decode_reqs]
 
-        k_lens = torch.div(max_indices - cp_rank, cp_size, rounding_mode="floor") + 1
         k_lens = torch.where(valid, k_lens, torch.zeros_like(k_lens))
 
         mtp_attn_mask = self.dcp_mtp_attn_mask.cpu[: self.num_decode_reqs]
@@ -1536,7 +1542,14 @@ class PCPManager:
         valid_q = valid[:, None] & (q_indices[None, :] < q_lens[:, None])
         valid_k = valid[:, None] & (k_indices[None, :] < k_lens[:, None])
 
-        k_upper = (context_lens[:, None] + q_indices - cp_rank) // cp_size
+        # Interleave-aware k_upper: for query token at global position P,
+        # the number of rank-cp_rank KV tokens before P (exclusive upper bound).
+        positions = context_lens[:, None] + q_indices[None, :]  # [num_decode_reqs, max_q]
+        base_q = positions // interleave_size // cp_size * interleave_size
+        remainder_q = positions - base_q * cp_size
+        local_q = base_q + torch.clamp(remainder_q - cp_rank * interleave_size, 0, interleave_size)
+        k_upper = local_q - 1  # inclusive upper KV index
+
         k_upper_expanded = k_upper[:, :, None]  # [num_decode_reqs, max_q, 1]
         k_idx_expanded = k_indices[None, None, :]  # [1, 1, max_k]
         full_mask = (k_idx_expanded > k_upper_expanded) & (k_upper_expanded >= 0)


### PR DESCRIPTION
### What this PR does / why we need it?
This pr support cp_kvcache_interleave_size > 1 + pcp + mtp. 
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
