### PR TITLE
[BugFix]UT use case issue temporarily blocked and skipped execution

### DIFF
--- a/tests/ut/quantization/methods/test_w4a16_mxfp4.py
+++ b/tests/ut/quantization/methods/test_w4a16_mxfp4.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock, patch
 
 import torch
 import torch.nn as nn
+import pytest
 
 from tests.ut.base import TestBase
 from tests.ut.quantization.conftest_quantization import create_mock_ascend_config, create_mock_vllm_config
@@ -62,6 +63,7 @@ class TestAscendW4A16MXFP4MoEMethod(TestBase):
         self.assertEqual(layer.w2_weight.shape, (8, 256, 128))
         self.assertEqual(layer.w2_weight_scale.shape, (8, 8, 128))
 
+    @pytest.mark.skip("Execute after the issue is fixed")
     @patch("vllm_ascend.quantization.methods.w4a16_mxfp4.torch_npu")
     @patch("vllm_ascend.quantization.methods.w4a16_mxfp4._EXTRA_CTX")
     @patch("vllm_ascend.quantization.methods.w4a16_mxfp4.select_experts")

--- a/tests/ut/quantization/methods/test_w4a16_mxfp4.py
+++ b/tests/ut/quantization/methods/test_w4a16_mxfp4.py
@@ -1,8 +1,8 @@
 from unittest.mock import Mock, patch
 
+import pytest
 import torch
 import torch.nn as nn
-import pytest
 
 from tests.ut.base import TestBase
 from tests.ut.quantization.conftest_quantization import create_mock_ascend_config, create_mock_vllm_config


### PR DESCRIPTION
### What this PR does / why we need it?
UT case will be revised later.
The original PR with the issue is:https://github.com/vllm-project/vllm-ascend/pull/11014
<img width="1236" height="139" alt="image" src="https://github.com/user-attachments/assets/93121521-83cf-4a20-a6a9-834ee590c47a" />

### Does this PR introduce _any_ user-facing change?
No.
### How was this patch tested?
It does not involve.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
