### PR TITLE
[Feature]Printing of the reserved and allocated values after warmup

### DIFF
--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -758,7 +758,9 @@ class NPUWorker(WorkerBase):
                 f"memory, or `--kv-cache-memory={suggested_to_gpu_limit}` "
                 f"({format_gib(suggested_to_gpu_limit)} GiB) to fully utilize NPU "
                 f"free memory. Current KV cache memory: "
-                f"{format_gib(self.available_kv_cache_memory_bytes)} GiB."
+                f"{format_gib(self.available_kv_cache_memory_bytes)} GiB. "
+                f"After warmup: torch reserved memory {format_gib(torch.npu.memory_reserved())} GiB, "
+                f"torch allocated memory {format_gib(torch.npu.memory_allocated())} GiB."
             )
             logger.info(msg)
 


### PR DESCRIPTION
### What this PR does / why we need it?
1. Optimize memory profiling logic: Replace local `profile_torch_peak` variable with instance attribute `self.profile_torch_peak` to avoid variable scope issues, use pre-graph-capture peak value to exclude NPU graph pool memory from activation peak calculation.
2. Enhance `profile_memory()` method:
   - Update docstring to cover peak allocated memory stats
   - Collect `torch_peak_allocated` via NPU memory stats API
   - Extend debug log to print reserved / allocated / peak allocated three memory metrics together
3. Add warmup stage memory print: Output real-time torch reserved & allocated memory in warmup completion info log.
4. Add peak memory reset after warmup: Call `torch.npu.reset_peak_memory_stats()` to reset NPU peak counter, guarantee accurate inference activation peak value collected by `torch_memory_log` decorator.

This patch provides complete NPU memory statistics for warmup and inference phase, helping developers debug activation peak memory OOM issues on Ascend NPU.

### Does this PR introduce _any_ user-facing change?
No. Only add extra debug & info memory logs for profiling, no functional behavior change for model inference.

### How was this patch tested?
- Base upstream commit: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
1. Local syntax & indent check: Fixed SyntaxError / IndentationError in worker.py, pass local linter verification.
2. Local Ascend NPU test: Deploy Qwen3-Coder-480B model, run warmup + inference service, verify warmup memory info log and inference debug memory logs output normally.
3. Memory data validation: The printed reserved/allocated/peak memory values match `torch.npu` memory stats API real return data.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
