### PR TITLE
[Performance][SpecDecode] Avoid H2D sync in CP proposer metadata

### DIFF
--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -22,6 +22,7 @@ from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
 from vllm_ascend.utils import enable_custom_op
+from vllm_ascend.worker.pcp_utils import PCPManager, PCPSpecDecodeFirstPassInputs
 
 enable_custom_op()
 
@@ -143,6 +144,7 @@ def test_prepare_inputs_padded_preserves_internal_seq_lens_cpu():
     proposer.pcp_size = 1
     proposer.arange = torch.arange(16, dtype=torch.int32)
     proposer.runner = MagicMock()
+    proposer.runner.pcp_manager = None
     proposer.runner.actual_seq_lengths_q = [3, 3]
     proposer.runner.attn_state = AscendAttentionState.SpecDecoding
     proposer.runner.decode_token_per_req = 4
@@ -199,6 +201,7 @@ class TestEagleProposerInitialization(TestBase):
         self.runner.pin_memory = False
         self.runner.pcp_size = 1
         self.runner.dcp_size = 1
+        self.runner.pcp_manager = None
 
         self.vllm_config.cache_config.block_size = 16
         self.vllm_config.scheduler_config.max_num_batched_tokens = 1024
@@ -343,6 +346,7 @@ class TestEagleProposerLoadModel(TestBase):
         self.runner.pin_memory = False
         self.runner.pcp_size = 1
         self.runner.dcp_size = 1
+        self.runner.pcp_manager = None
 
         self.vllm_config.cache_config.block_size = 16
         self.vllm_config.scheduler_config.max_num_batched_tokens = 1024
@@ -490,6 +494,7 @@ class TestEagleProposerDummyRun(TestBase):
         self.runner = MagicMock()
         self.runner.pcp_size = 1
         self.runner.dcp_size = 1
+        self.runner.pcp_manager = None
         self.runner.pin_memory = False
         self.runner._sync_metadata_across_dp.return_value = (8, torch.tensor([8]), CUDAGraphMode.NONE)
 
@@ -672,6 +677,7 @@ class TestEagleProposerHelperMethods(TestBase):
         self.runner.pin_memory = False
         self.runner.pcp_size = 1
         self.runner.dcp_size = 1
+        self.runner.pcp_manager = None
 
         self.vllm_config.cache_config.block_size = 16
         self.vllm_config.scheduler_config.max_num_batched_tokens = 1024
@@ -989,6 +995,7 @@ class TestEagleProposerPropose:
         self.runner.max_num_tokens = 8192
         self.runner.max_num_reqs = 256
         self.runner.pin_memory = False
+        self.runner.pcp_manager = None
 
         self.vllm_config.scheduler_config.max_num_batched_tokens = 1024
         self.vllm_config.scheduler_config.max_num_seqs = 32
@@ -1786,6 +1793,7 @@ class TestPrepareNextTokenIdsPadded(TestBase):
         self.runner.pin_memory = False
         self.runner.pcp_size = 1
         self.runner.dcp_size = 1
+        self.runner.pcp_manager = None
 
         self.vllm_config.cache_config.block_size = 16
         self.vllm_config.scheduler_config.max_num_batched_tokens = 1024
@@ -2261,6 +2269,7 @@ class TestRunMergedDraft(TestBase):
         self.runner.dcp_size = 1
         self.runner.pcp_rank = 0
         self.runner.dcp_rank = 0
+        self.runner.pcp_manager = None
         self.runner.max_num_tokens = 64
         self.runner.max_num_reqs = 8
         self.runner.uniform_decode_query_len = 2
@@ -2802,6 +2811,7 @@ class TestDraftProposerHelperMethods(TestBase):
         self.runner.pin_memory = False
         self.runner.pcp_size = 1
         self.runner.dcp_size = 1
+        self.runner.pcp_manager = None
 
         self.vllm_config.cache_config.block_size = 16
         self.vllm_config.scheduler_config.max_num_batched_tokens = 1024
@@ -2914,6 +2924,7 @@ class TestEagleProposerPrepareInputs:
         self.runner.attn_state = AscendAttentionState.ChunkedPrefill
         self.runner.decode_token_per_req = 1
         self.runner.actual_seq_lengths_q = []
+        self.runner.pcp_manager = None
 
         self.mock_cpugpubuffer = patch(_CPU_GPU_BUFFER_TARGET, MockCpuGpuBuffer)
         self.mock_cpugpubuffer.start()
@@ -3267,6 +3278,7 @@ class TestEagleProposerPrepareInputsPadded:
         self.runner.attn_state = AscendAttentionState.ChunkedPrefill
         self.runner.decode_token_per_req = 1
         self.runner.actual_seq_lengths_q = []
+        self.runner.pcp_manager = None
 
         self.mock_cpugpubuffer = patch(_CPU_GPU_BUFFER_TARGET, MockCpuGpuBuffer)
         self.mock_cpugpubuffer.start()
@@ -3629,6 +3641,7 @@ class TestEagleProposerSetInputsFirstPass:
         self.runner.dcp_size = 1
         self.runner.max_num_tokens = 8192
         self.runner.max_num_reqs = 256
+        self.runner.pcp_manager = None
 
         self.mock_cpugpubuffer = patch(_CPU_GPU_BUFFER_TARGET, MockCpuGpuBuffer)
         self.mock_cpugpubuffer.start()
@@ -3793,7 +3806,7 @@ class TestEagleProposerSetInputsFirstPass:
         expected_token_indices = torch.tensor([2, 4, 8], dtype=torch.int32, device=self.device)
         assert torch.equal(out_token_indices, expected_token_indices)
         assert out_cad is common_attn_metadata  # returned as-is
-        assert long_seq_args == (None, None)
+        assert long_seq_args is None
 
         # assert proposer internal state
         expected_proposer = MagicMock()
@@ -3829,7 +3842,8 @@ class TestEagleProposerSetInputsFirstPass:
         self.runner.input_batch.req_ids = req_ids
         # maybe not reasonable just to run test
         self.runner.logits_indices = torch.arange(12, dtype=torch.int32, device=self.device)
-        self.runner.pcp_manager.pcp_use_hybrid_attn = False
+        pcp_manager = MagicMock()
+        self.runner.pcp_manager = pcp_manager
 
         proposer, vllm_config = self._create_proposer(
             method="eagle",
@@ -3869,6 +3883,46 @@ class TestEagleProposerSetInputsFirstPass:
         target_hidden_states = torch.randn(18, proposer.hidden_size, dtype=proposer.dtype, device=self.device)
 
         long_seq_metadata = MagicMock()
+        expected_token_indices = torch.tensor([2, 4, 10, 11], dtype=torch.int32, device=self.device)
+        expected_query_lens_d = torch.tensor([3, 2], dtype=torch.int32, device=self.device)
+        expected_ori_token_indices_to_sample = torch.tensor([2, 4, 8, 11], dtype=torch.int32, device=self.device)
+        expected_input_ids = torch.tensor(
+            [11, 12, 100, 21, 200, 31, 300, 41, 0],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        expected_positions = target_positions[:9]
+        expected_hidden_indices = torch.tensor([0, 1, 2, 6, 7, 10, 13, 14, 17], dtype=torch.long, device=self.device)
+        expected_hidden_states = target_hidden_states[expected_hidden_indices]
+
+        def prepare_first_pass_inputs(**kwargs):
+            assert torch.equal(
+                kwargs["input_ids"],
+                torch.tensor(
+                    [11, 12, 100, 21, 200, 31, 32, 33, 300, 41, 42, 400],
+                    dtype=torch.int32,
+                    device=self.device,
+                ),
+            )
+            assert kwargs["common_attn_metadata"] is common_attn_metadata
+            assert kwargs["long_seq_metadata"] is long_seq_metadata
+            assert kwargs["req_scheduled_tokens"] == req_scheduled_tokens
+            assert kwargs["req_ids"] == req_ids
+            common_attn_metadata.prefill_context_parallel_metadata = long_seq_metadata
+            common_attn_metadata.num_actual_tokens = 9
+            common_attn_metadata.seq_lens = torch.tensor([10, 8, 2, 2], dtype=torch.int32, device=self.device)
+            common_attn_metadata.query_start_loc = torch.tensor([0, 3, 5, 7, 9], dtype=torch.int32, device=self.device)
+            common_attn_metadata.max_query_len = 4
+            return PCPSpecDecodeFirstPassInputs(
+                num_tokens=9,
+                input_ids=expected_input_ids,
+                target_positions=expected_positions,
+                target_hidden_states=expected_hidden_states,
+                token_indices_to_sample=expected_token_indices,
+                long_seq_args=(expected_query_lens_d, expected_ori_token_indices_to_sample),
+            )
+
+        pcp_manager.prepare_spec_decode_first_pass_inputs.side_effect = prepare_first_pass_inputs
 
         out_num_tokens, out_token_indices, out_cad, (query_lens_d, ori_token_indices_to_sample) = (
             proposer.set_inputs_first_pass(
@@ -3888,23 +3942,18 @@ class TestEagleProposerSetInputsFirstPass:
 
         # assert function computed outputs
         assert out_num_tokens == 9
-        expected_token_indices = torch.tensor([2, 4, 10, 11], dtype=torch.int32, device=self.device)
         assert torch.equal(out_token_indices, expected_token_indices)
+        pcp_manager.prepare_spec_decode_first_pass_inputs.assert_called_once()
 
         # assert query_lens_d and ori_token_indices_to_sample
-        expected_query_lens_d = torch.tensor([3, 2], dtype=torch.int32, device=self.device)
-        expected_ori_token_indices_to_sample = torch.tensor([2, 4, 8, 11], dtype=torch.int32, device=self.device)
         assert torch.equal(query_lens_d, expected_query_lens_d)
         assert torch.equal(ori_token_indices_to_sample, expected_ori_token_indices_to_sample)
 
         # assert proposer internal state
-        indices = torch.tensor([0, 1, 2, 6, 7, 10, 13, 14, 17], dtype=torch.long, device=self.device)
         expected_proposer = MagicMock()
-        expected_proposer.input_ids = torch.tensor(
-            [11, 12, 100, 21, 200, 31, 300, 41, 0], dtype=torch.int32, device=self.device
-        )
-        expected_proposer.positions = target_positions[:out_num_tokens]
-        expected_proposer.hidden_states = target_hidden_states[indices]
+        expected_proposer.input_ids = expected_input_ids
+        expected_proposer.positions = expected_positions
+        expected_proposer.hidden_states = expected_hidden_states
 
         attrs_from_proposer: list[str | tuple[str, Any, Any]] = [
             ("input_ids", None, slice(None, out_num_tokens)),
@@ -4315,7 +4364,7 @@ def _build_split_pcp_input_hybrid_inputs(req_scheduled_tokens: dict[str, int], h
     ],
 )
 # yapf: enable
-def test_split_pcp_input_hybrid(
+def test_split_spec_decode_pcp_prefill_input_hybrid(
     pcp_size,
     pcp_rank,
     req_scheduled_tokens,
@@ -4331,12 +4380,12 @@ def test_split_pcp_input_hybrid(
         req_scheduled_tokens, hidden_size
     )
 
-    # _split_pcp_input_hybrid only reads self.pcp_size and self.pcp_rank,
+    # _split_spec_decode_pcp_prefill_input_hybrid only reads PCP rank/size,
     # so a MagicMock with just those attributes is enough to drive the
-    # unbound method without instantiating the full proposer.
+    # unbound manager method without instantiating the full manager.
     mock_self = MagicMock()
-    mock_self.pcp_size = pcp_size
-    mock_self.pcp_rank = pcp_rank
+    mock_self.pcp_world_size = pcp_size
+    mock_self.pcp_world_rank = pcp_rank
 
     (
         num_tokens,
@@ -4345,7 +4394,7 @@ def test_split_pcp_input_hybrid(
         max_query_len,
         seq_lens,
         cu_num_tokens,
-    ) = llm_base_proposer.AscendSpecDecodeBaseProposer._split_pcp_input_hybrid(
+    ) = PCPManager._split_spec_decode_pcp_prefill_input_hybrid(
         mock_self, req_scheduled_tokens, input_ids, target_hidden_states
     )
 
@@ -4367,7 +4416,7 @@ def test_split_pcp_input_hybrid(
     )
 
 
-def test_split_pcp_input_hybrid_preserves_hidden_size():
+def test_split_spec_decode_pcp_prefill_input_hybrid_preserves_hidden_size():
     """Hidden states must come back with the same hidden dim as the input."""
     hidden_size = 7
     req_scheduled_tokens = {"0": 6}
@@ -4376,11 +4425,11 @@ def test_split_pcp_input_hybrid_preserves_hidden_size():
     )
 
     mock_self = MagicMock()
-    mock_self.pcp_size = 2
-    mock_self.pcp_rank = 0
+    mock_self.pcp_world_size = 2
+    mock_self.pcp_world_rank = 0
 
     _, _, out_hidden_states, _, _, _ = (
-        llm_base_proposer.AscendSpecDecodeBaseProposer._split_pcp_input_hybrid(
+        PCPManager._split_spec_decode_pcp_prefill_input_hybrid(
             mock_self, req_scheduled_tokens, input_ids, target_hidden_states
         )
     )
@@ -4401,6 +4450,7 @@ class TestDeepSeekMTPIndicesSharing(unittest.TestCase):
         self.vllm_config.speculative_config.draft_model_config.hf_config = MagicMock()
         self.device = torch.device("cpu")
         self.runner = MagicMock()
+        self.runner.pcp_manager = None
 
     def test_init_mtp_indices_flag(self):
         """Test whether index_share_for_mtp_iteration is correctly read in __init__."""

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -303,11 +303,7 @@ class NPUModelRunner310(NPUModelRunner):
         prev_req_id_to_index = self.input_batch.prev_req_id_to_index
         self._compute_prev_positions(num_reqs)
         prev_positions_gpu = None
-        if (
-            self.use_async_scheduling
-            and self.input_batch.prev_sampled_token_ids is not None
-            and prev_req_id_to_index
-        ):
+        if self.use_async_scheduling and self.input_batch.prev_sampled_token_ids is not None and prev_req_id_to_index:
             self.prev_positions.copy_to_gpu(num_reqs)
             prev_positions_gpu = self.prev_positions.gpu[:num_reqs]
 

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -300,6 +300,17 @@ class NPUModelRunner310(NPUModelRunner):
                 self.input_batch.num_prompt_tokens,
             )
 
+        prev_req_id_to_index = self.input_batch.prev_req_id_to_index
+        self._compute_prev_positions(num_reqs)
+        prev_positions_gpu = None
+        if (
+            self.use_async_scheduling
+            and self.input_batch.prev_sampled_token_ids is not None
+            and prev_req_id_to_index
+        ):
+            self.prev_positions.copy_to_gpu(num_reqs)
+            prev_positions_gpu = self.prev_positions.gpu[:num_reqs]
+
         if self.speculative_config and self.use_cp:
             self.pcp_manager.generate_pcp_mtp_input(
                 total_num_scheduled_tokens,
@@ -313,6 +324,7 @@ class NPUModelRunner310(NPUModelRunner):
                 self._draft_token_ids,  # type: ignore[has-type]
                 scheduler_output,
                 self.num_spec_tokens,
+                prev_positions=prev_positions_gpu,
             )
 
         if self.pcp_size > 1:
@@ -407,9 +419,6 @@ class NPUModelRunner310(NPUModelRunner):
         )
         self.optimistic_seq_lens_cpu[num_reqs:].fill_(0)
 
-        prev_req_id_to_index = self.input_batch.prev_req_id_to_index
-        self._compute_prev_positions(num_reqs)
-
         if not is_rc_device():
             self.query_start_loc.gpu[num_reqs + 1 :].fill_(-1)
 
@@ -472,7 +481,8 @@ class NPUModelRunner310(NPUModelRunner):
             self.use_async_spec_decode and self.valid_sampled_token_count_gpu is not None and prev_req_id_to_index
         )
         if need_async_num_computed_update:
-            self.prev_positions.copy_to_gpu(num_reqs)
+            if prev_positions_gpu is None:
+                self.prev_positions.copy_to_gpu(num_reqs)
             self.prev_num_draft_tokens.copy_to_gpu()
             cpu_values = self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs].to(
                 device=self.device, non_blocking=True

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -980,11 +980,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 if ori_seq_len_cpu is not None:
                     ori_seq_len_cpu = ori_seq_len_cpu[:batch_size].clone()
                 slot_idx_base = (
-                    query_start_loc_pcp_full[:num_decode_reqs].to(torch.int64) * self.pcp_size
+                    query_start_loc_pcp_full[:num_decode_reqs] * self.pcp_size
                     + torch.arange(num_decode_reqs, device=self.device, dtype=torch.int64)
                     * (self.num_speculative_tokens - 1)
                     * self.pcp_size
-                    + (num_accept_tokens.to(torch.int64) - 1) * self.pcp_size
+                    + (num_accept_tokens - 1) * self.pcp_size
                 )
                 slot_indices = (
                     slot_idx_base[:, None]
@@ -1452,8 +1452,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                         target_hidden_states_d = target_hidden_states_d_padded[:num_tokens_d]
                     else:
                         # Keep decode unpadding indices on device to avoid a host index list.
-                        decode_req_starts = query_start_loc_pcp_full[:num_decode_reqs].to(torch.int64)
-                        decode_query_lens = query_lens_d_device.to(torch.int64)
+                        decode_req_starts = query_start_loc_pcp_full[:num_decode_reqs]
+                        decode_query_lens = query_lens_d_device
                         decode_padded_starts = decode_req_starts * self.pcp_size
                         decode_req_starts_per_token = torch.repeat_interleave(
                             decode_req_starts,
@@ -1465,7 +1465,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                             decode_query_lens,
                             output_size=num_tokens_d,
                         )
-                        decode_offsets = self.arange[:num_tokens_d].to(torch.int64) - decode_req_starts_per_token
+                        decode_offsets = self.arange[:num_tokens_d] - decode_req_starts_per_token
                         decode_hidden_state_indices = decode_padded_starts_per_token + decode_offsets
                         target_hidden_states_d = target_hidden_states_d_padded[decode_hidden_state_indices]
                 else:

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -183,6 +183,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             self.runner.max_num_tokens * self.pcp_size * self.dcp_size
             + self.pcp_size * self.dcp_size * self.runner.max_num_reqs
         )
+        self.cp_slot_offsets = torch.arange(self.pcp_size, dtype=torch.int64, device=device)
 
         self.use_sparse = hasattr(vllm_config.model_config.hf_text_config, "index_topk")
 
@@ -963,35 +964,30 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 # Instead, we pre-allocate mtp slot_mapping in model_runner
                 # (_generate_pcp_mtp_input), and use updated slot_indices
                 # to get corresponding slot_mapping in each step.
-                num_reject_tokens = (
-                    torch.tensor(self.runner.pcp_manager.cu_num_tokens_pcp_full, dtype=torch.int32).to(self.device)
-                    - ori_token_indices_to_sample
-                    - 1
+                query_start_loc_pcp_full = self.runner.pcp_manager.query_start_loc_pcp_full.gpu
+                cu_num_tokens_pcp_full = query_start_loc_pcp_full[1 : num_decode_reqs + 1]
+                query_lens_d_device = (
+                    query_start_loc_pcp_full[1 : num_decode_reqs + 1]
+                    - query_start_loc_pcp_full[:num_decode_reqs]
                 )
-                num_accept_tokens = query_lens_d.to(self.device) - num_reject_tokens
-                ori_seq_len = attn_metadata_i.seq_lens_cpu[:batch_size].clone()
-                mtp_slot_mapping = self.runner.pcp_manager.mtp_slot_pad
-
-                # slot_mapping index base offset:
-                # scheduled tokens + pre-allocated mtp tokens + accepted tokens
+                num_reject_tokens = cu_num_tokens_pcp_full - ori_token_indices_to_sample - 1
+                num_accept_tokens = query_lens_d_device - num_reject_tokens
+                ori_seq_len = getattr(attn_metadata_i, "seq_lens", None)
+                if ori_seq_len is None:
+                    ori_seq_len = attn_metadata_i.seq_lens_cpu
+                ori_seq_len = ori_seq_len[:batch_size].clone()
                 slot_idx_base = (
-                    torch.cat(
-                        [
-                            torch.tensor([0], dtype=torch.int32, device=self.device),
-                            (torch.cumsum(query_lens_d, dim=0)[:-1] * self.pcp_size).to(self.device),
-                        ]
-                    )
-                    + torch.arange(num_decode_reqs, device=self.device)
+                    query_start_loc_pcp_full[:num_decode_reqs].to(torch.int64) * self.pcp_size
+                    + torch.arange(num_decode_reqs, device=self.device, dtype=torch.int64)
                     * (self.num_speculative_tokens - 1)
                     * self.pcp_size
-                    + (num_accept_tokens - 1) * self.pcp_size
+                    + (num_accept_tokens.to(torch.int64) - 1) * self.pcp_size
                 )
-                slot_indices_list = []
-                for req_id in range(num_decode_reqs):
-                    slot_indices_list.append(
-                        torch.arange(slot_idx_base[req_id], slot_idx_base[req_id] + self.pcp_size, device=self.device)
-                    )
-                slot_indices = torch.cat(slot_indices_list, dim=0)
+                slot_indices = (
+                    slot_idx_base[:, None]
+                    + self.cp_slot_offsets[: self.pcp_size].to(slot_idx_base.device)
+                ).reshape(-1)
+                mtp_slot_mapping = self.runner.pcp_manager.mtp_slot_pad
 
                 common_attn_metadata.block_table_tensor = common_attn_metadata.block_table_tensor[:batch_size]
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -3,7 +3,7 @@ import copy
 from collections.abc import Callable
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from functools import partial
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import torch
@@ -554,6 +554,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             num_tokens_across_dp,
             _,
         ) = self.runner._sync_metadata_across_dp(num_tokens, is_draft_model=True)
+        pcp_manager = getattr(self.runner, "pcp_manager", None)
 
         multi_steps_attn_metadata = []
         if not self.use_cuda_graph:
@@ -609,9 +610,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 is_prefilling=torch.zeros(num_reqs, dtype=torch.bool),
                 max_seq_len=0,
             )
-            if self.pcp_size * self.dcp_size > 1:
+            if pcp_manager is not None:
                 # update long_seq related params and flatten block_table
-                common_attn_metadata.prefill_context_parallel_metadata = self.runner.pcp_manager.long_seq_metadata
+                common_attn_metadata.prefill_context_parallel_metadata = pcp_manager.long_seq_metadata
 
             assert len(self.draft_attn_groups) > 0
             builder = self.draft_attn_groups[0].get_metadata_builder()
@@ -773,10 +774,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             num_prefill_reqs=num_prefill_reqs,
             num_decode_reqs=num_decode_reqs,
         )
-        if self.pcp_size * self.dcp_size > 1:
+        assert self.runner is not None
+        pcp_manager = getattr(self.runner, "pcp_manager", None)
+        if pcp_manager is not None:
             assert long_seq_args is not None
             _, ori_token_indices_to_sample = long_seq_args
-        assert self.runner is not None
 
         has_lora = len(self.runner.input_batch.lora_id_to_lora_request) > 0
         uniform_decode = target_model_batch_desc.uniform
@@ -850,8 +852,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     common_attn_metadata.num_computed_tokens_cpu, num_reqs_padded
                 )
 
-            if self.pcp_size > 1:
-                self.runner.pcp_manager.mask_spec_decode_restore_idx_for_graph(
+            if pcp_manager is not None and self.pcp_size > 1:
+                pcp_manager.mask_spec_decode_restore_idx_for_graph(
                     common_attn_metadata.prefill_context_parallel_metadata.pcp_allgather_restore_idx
                 )
         else:
@@ -944,8 +946,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             "slot_indices": None,
             "mtp_slot_mapping": None,
         }
-        if self.pcp_size * self.dcp_size > 1:
-            pcp_mtp_inputs = self.runner.pcp_manager.prepare_spec_decode_mtp_drafting_inputs(
+        if pcp_manager is not None:
+            pcp_mtp_inputs = pcp_manager.prepare_spec_decode_mtp_drafting_inputs(
                 common_attn_metadata=common_attn_metadata,
                 attn_metadata=attn_metadata_i,
                 ori_token_indices_to_sample=ori_token_indices_to_sample,
@@ -1018,7 +1020,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "num_tokens": num_tokens,
                 "is_prefill": is_prefill_batch,
             }
-            run_draft = partial(self._runnable, **model_inputs)
+            runnable = cast(Callable[..., Any], self._runnable)
+            run_draft: Callable[[], Any] = partial(runnable, **model_inputs)
 
             if self.enable_enpu:
                 self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
@@ -1110,9 +1113,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             else:
                 ori_token_indices_to_sample = None
 
-        if self.pcp_size > 1:
+        pcp_manager = getattr(self.runner, "pcp_manager", None)
+        if pcp_manager is not None and self.pcp_size > 1:
             # remove graph padding before all_gather
-            hidden_states = self.runner.pcp_manager.get_restore_hidden_states(
+            hidden_states = pcp_manager.get_restore_hidden_states(
                 hidden_states,
                 num_input_tokens=num_input_tokens,
             )
@@ -1120,7 +1124,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 last_hidden_states = hidden_states
             else:
                 # eagle and eagle3 need allgather last_hidden_states.
-                last_hidden_states = self.runner.pcp_manager.get_restore_hidden_states(
+                last_hidden_states = pcp_manager.get_restore_hidden_states(
                     last_hidden_states,
                     num_input_tokens=num_input_tokens,
                 )
@@ -1355,26 +1359,30 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             self.input_ids[token_indices_to_sample] = next_token_ids
 
             assert self.runner is not None
-            first_pass_inputs = self.runner.pcp_manager.prepare_spec_decode_first_pass_inputs(
-                input_ids=self.input_ids[:num_tokens],
-                target_positions=target_positions,
-                target_hidden_states=target_hidden_states,
-                token_indices_to_sample=token_indices_to_sample,
-                common_attn_metadata=cad,
-                long_seq_metadata=long_seq_metadata,
-                req_scheduled_tokens=req_scheduled_tokens,
-                req_ids=self.runner.input_batch.req_ids,
-                logits_indices=self.runner.logits_indices,
-                num_tokens=num_tokens,
-                num_prefill_reqs=num_prefill_reqs,
-                num_decode_reqs=num_decode_reqs,
-                uses_mrope=self.uses_mrope,
-            )
-            num_tokens = first_pass_inputs.num_tokens
-            target_positions = first_pass_inputs.target_positions
-            target_hidden_states = first_pass_inputs.target_hidden_states
-            token_indices_to_sample = first_pass_inputs.token_indices_to_sample
-            self.input_ids[:num_tokens].copy_(first_pass_inputs.input_ids)
+            pcp_manager = getattr(self.runner, "pcp_manager", None)
+            long_seq_args = None
+            if pcp_manager is not None:
+                first_pass_inputs = pcp_manager.prepare_spec_decode_first_pass_inputs(
+                    input_ids=self.input_ids[:num_tokens],
+                    target_positions=target_positions,
+                    target_hidden_states=target_hidden_states,
+                    token_indices_to_sample=token_indices_to_sample,
+                    common_attn_metadata=cad,
+                    long_seq_metadata=long_seq_metadata,
+                    req_scheduled_tokens=req_scheduled_tokens,
+                    req_ids=self.runner.input_batch.req_ids,
+                    logits_indices=self.runner.logits_indices,
+                    num_tokens=num_tokens,
+                    num_prefill_reqs=num_prefill_reqs,
+                    num_decode_reqs=num_decode_reqs,
+                    uses_mrope=self.uses_mrope,
+                )
+                num_tokens = first_pass_inputs.num_tokens
+                target_positions = first_pass_inputs.target_positions
+                target_hidden_states = first_pass_inputs.target_hidden_states
+                token_indices_to_sample = first_pass_inputs.token_indices_to_sample
+                self.input_ids[:num_tokens].copy_(first_pass_inputs.input_ids)
+                long_seq_args = first_pass_inputs.long_seq_args
 
             # copy inputs to buffer for cudagraph
             if self.uses_xdrope_dim > 0 and self.draft_uses_xdrope_dim == 0:
@@ -1383,7 +1391,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             self._set_positions(num_tokens, target_positions)
             self.hidden_states[:num_tokens] = target_hidden_states.view(num_tokens, -1)
 
-            return num_tokens, token_indices_to_sample, cad, first_pass_inputs.long_seq_args
+            return num_tokens, token_indices_to_sample, cad, long_seq_args
         else:
             assert self.is_rejected_token_mask is not None
             assert self.is_masked_token_mask is not None
@@ -1612,7 +1620,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         else:
             common_attn_metadata.positions[:batch_size].copy_(clamped_positions)
 
-        if self.pcp_size * self.dcp_size > 1:
+        pcp_manager = getattr(self.runner, "pcp_manager", None)
+        if pcp_manager is not None:
             kv_cache_spec = getattr(attn_group, "kv_cache_spec", self.draft_attn_groups[0].kv_cache_spec)
             # update slot_mapping
             slot_indices += self.pcp_size
@@ -1677,8 +1686,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             **extra_attn_metadata_args,
         )
 
-        if self.pcp_size * self.dcp_size > 1:
-            self.runner.pcp_manager.update_spec_decode_drafting_cp_metadata(
+        if pcp_manager is not None:
+            pcp_manager.update_spec_decode_drafting_cp_metadata(
                 attn_metadata=attn_metadata,
                 kv_cache_spec=kv_cache_spec,
                 seq_lens=ori_seq_len,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -27,7 +27,6 @@ from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
 from vllm.model_executor.models.qwen3_dflash import DFlashQwen3ForCausalLM
 from vllm.triton_utils import HAS_TRITON, triton
-from vllm.utils.math_utils import cdiv
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -173,14 +172,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         self.pcp_size = self.runner.pcp_size
         self.dcp_size = self.runner.dcp_size
-        self.pcp_rank = self.runner.pcp_rank
-        self.dcp_rank = self.runner.dcp_rank
-
-        self.full_indices = range(
-            self.runner.max_num_tokens * self.pcp_size * self.dcp_size
-            + self.pcp_size * self.dcp_size * self.runner.max_num_reqs
-        )
-        self.cp_slot_offsets = torch.arange(self.pcp_size, dtype=torch.int64, device=device)
 
         self.use_sparse = hasattr(vllm_config.model_config.hf_text_config, "index_topk")
 
@@ -1364,73 +1355,26 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             self.input_ids[token_indices_to_sample] = next_token_ids
 
             assert self.runner is not None
-            # update pcp related params
-            ori_token_indices_to_sample = None
-            query_lens_d = None
-            query_lens_d_device = None
-            if self.pcp_size * self.dcp_size > 1:
-                assert long_seq_metadata is not None
-                cad.prefill_context_parallel_metadata = long_seq_metadata
-                ori_token_indices_to_sample = token_indices_to_sample.clone()
-                query_lens_d = self.runner.query_lens[:num_decode_reqs]
-                query_start_loc_pcp_full = self.runner.pcp_manager.query_start_loc_pcp_full.gpu
-                query_lens_d_device = (
-                    query_start_loc_pcp_full[1 : num_decode_reqs + 1]
-                    - query_start_loc_pcp_full[:num_decode_reqs]
-                )
-            if self.pcp_size > 1:
-                # 1. preprocess decode/prefill input_ids & target_hidden_states
-                # decode input_ids: keep unchanged
-                # decode target_hidden_states: remove padding
-                # prefill input_ids: add padding and pcp split
-                # prefill target_hidden_states: pcp split
-                assert query_lens_d is not None
-                num_tokens_d = self.runner.pcp_manager.num_decode_tokens
-                num_tokens_d_padded = num_tokens_d * self.pcp_size
-                input_ids_d = self.input_ids[:num_tokens_d]
-                input_ids_p = self.input_ids[num_tokens_d:num_tokens]
-                target_hidden_states_d_padded = target_hidden_states[:num_tokens_d_padded]
-                if num_tokens_d:
-                    target_hidden_states_d = self.runner.pcp_manager.get_spec_decode_decode_hidden_states(
-                        target_hidden_states_d_padded,
-                        num_decode_reqs,
-                        num_tokens_d,
-                    )
-                else:
-                    target_hidden_states_d = target_hidden_states_d_padded
-                target_hidden_states_p = target_hidden_states[num_tokens_d_padded:]
-                req_scheduled_tokens_p = {}
-                for i, req_id in enumerate(self.runner.input_batch.req_ids):
-                    if i >= num_decode_reqs:
-                        req_scheduled_tokens_p[req_id] = req_scheduled_tokens[req_id]
-                (num_tokens_p, input_ids_p, target_hidden_states_p, max_query_len_p, seq_lens_p, cu_num_tokens_p) = (
-                    self._split_pcp_input(req_scheduled_tokens_p, input_ids_p, target_hidden_states_p)
-                )
-                num_tokens = num_tokens_d + num_tokens_p
-                if self.uses_mrope:
-                    target_positions = target_positions[:, :num_tokens]
-                else:
-                    target_positions = target_positions[:num_tokens]
-                self.input_ids[:num_tokens].copy_(torch.cat([input_ids_d, input_ids_p], dim=0))
-                target_hidden_states = torch.cat([target_hidden_states_d, target_hidden_states_p], dim=0)
-                # 2. update sample_indices according to main model
-                if num_decode_reqs:
-                    token_indices_to_sample[:num_decode_reqs] = self.runner.logits_indices[
-                        token_indices_to_sample[:num_decode_reqs]
-                    ]
-                if num_prefill_reqs:
-                    token_indices_to_sample[-num_prefill_reqs:] = self.runner.logits_indices[-num_prefill_reqs:]
-                    # 3. update attn_metadata params that may be influenced by pcp
-                    cad.num_actual_tokens = num_tokens
-                    cad.max_query_len = max(self.decode_threshold, max_query_len_p)
-                    cad.seq_lens[-num_prefill_reqs:] = seq_lens_p
-                    if cad.seq_lens_cpu is not None:
-                        cad.seq_lens_cpu[-num_prefill_reqs:] = seq_lens_p
-                    if cad._seq_lens_cpu is not None:
-                        cad._seq_lens_cpu[-num_prefill_reqs:] = seq_lens_p
-                    query_start_loc_p = cu_num_tokens_p[1:] + cad.query_start_loc_cpu[num_decode_reqs].item()
-                    cad.query_start_loc[-num_prefill_reqs:] = query_start_loc_p
-                    cad.query_start_loc_cpu[-num_prefill_reqs:] = query_start_loc_p
+            first_pass_inputs = self.runner.pcp_manager.prepare_spec_decode_first_pass_inputs(
+                input_ids=self.input_ids[:num_tokens],
+                target_positions=target_positions,
+                target_hidden_states=target_hidden_states,
+                token_indices_to_sample=token_indices_to_sample,
+                common_attn_metadata=cad,
+                long_seq_metadata=long_seq_metadata,
+                req_scheduled_tokens=req_scheduled_tokens,
+                req_ids=self.runner.input_batch.req_ids,
+                logits_indices=self.runner.logits_indices,
+                num_tokens=num_tokens,
+                num_prefill_reqs=num_prefill_reqs,
+                num_decode_reqs=num_decode_reqs,
+                uses_mrope=self.uses_mrope,
+            )
+            num_tokens = first_pass_inputs.num_tokens
+            target_positions = first_pass_inputs.target_positions
+            target_hidden_states = first_pass_inputs.target_hidden_states
+            token_indices_to_sample = first_pass_inputs.token_indices_to_sample
+            self.input_ids[:num_tokens].copy_(first_pass_inputs.input_ids)
 
             # copy inputs to buffer for cudagraph
             if self.uses_xdrope_dim > 0 and self.draft_uses_xdrope_dim == 0:
@@ -1439,7 +1383,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             self._set_positions(num_tokens, target_positions)
             self.hidden_states[:num_tokens] = target_hidden_states.view(num_tokens, -1)
 
-            return num_tokens, token_indices_to_sample, cad, (query_lens_d, ori_token_indices_to_sample)
+            return num_tokens, token_indices_to_sample, cad, first_pass_inputs.long_seq_args
         else:
             assert self.is_rejected_token_mask is not None
             assert self.is_masked_token_mask is not None
@@ -2025,112 +1969,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         )
 
         return spec_common_attn_metadata, token_indices, token_indices_to_sample, num_rejected_tokens_gpu
-
-    def _split_pcp_input(self, req_scheduled_tokens, input_ids, target_hidden_states):
-        """
-        Split prefill input_ids and target_hidden_states in pcp group.
-        1. input_ids padding: [t0, t1, t2, t3, t4, t5] -> [t0, t1, t2, t3, t4, t5, pad, pad]
-        2. split input_ids: pcp0 [t0, t1, pad, pad], pcp1 [t2, t3, t4, t5]
-        3. split target_hidden_states (already include pcp padding):
-        [h0, h1, h2, h3, h4, h5, pad, pad] -> pcp0 [h0, h1, pad, pad], pcp1 [h2, h3, h4, h5]
-        4. also update max_query_len, seq_lens, cu_num_tokens according to pcp split.
-        """
-        if len(req_scheduled_tokens) == 0:
-            # no prefill inputs to split, return empty result
-            return (
-                0,
-                torch.zeros([0], device="npu"),
-                torch.zeros([0, target_hidden_states.size(1)], device="npu"),
-                0,
-                torch.zeros([0]),
-                torch.tensor([0], dtype=torch.int32),
-            )
-
-        if self.runner.pcp_manager.pcp_use_hybrid_attn:
-            return self._split_pcp_input_hybrid(req_scheduled_tokens, input_ids, target_hidden_states)
-
-        def _pcp_pad_and_split(num_tokens):
-            num_pcp_padded_scheduled_tokens = cdiv(num_tokens, 2 * self.pcp_size) * 2 * self.pcp_size
-            pcp_pad = num_pcp_padded_scheduled_tokens - num_tokens
-            chunk_size = num_pcp_padded_scheduled_tokens // (2 * self.pcp_size)
-
-            # split position_ids (and use split position_ids to split input_ids afterwards)
-            req_position_cp: list[int] = []
-            req_position_cp.extend(self.full_indices[self.pcp_rank * chunk_size : (self.pcp_rank + 1) * chunk_size])
-            req_position_cp.extend(
-                self.full_indices[
-                    num_pcp_padded_scheduled_tokens - (self.pcp_rank + 1) * chunk_size : num_pcp_padded_scheduled_tokens
-                    - self.pcp_rank * chunk_size
-                ]
-            )
-
-            return req_position_cp, num_pcp_padded_scheduled_tokens, pcp_pad
-
-        num_pcp_scheduled_tokens = []
-        ori_start_index = 0
-        pad_start_index = 0
-        pcp_split_input_ids_list = []
-        pcp_split_hidden_states_list = []
-        for ori_num_tokens in req_scheduled_tokens.values():
-            req_position_pcp, num_pcp_padded_scheduled_tokens, num_pcp_pad = _pcp_pad_and_split(ori_num_tokens)
-            actual_num_tokens = len(req_position_pcp)
-            num_pcp_scheduled_tokens.append(actual_num_tokens)
-            pad_input_ids = F.pad(input_ids[ori_start_index : ori_start_index + ori_num_tokens], (0, num_pcp_pad))
-            ori_start_index += ori_num_tokens
-            pcp_chunk_indices = [pad_start_index + pos for pos in req_position_pcp]
-            pcp_split_input_ids = pad_input_ids[req_position_pcp]
-            pcp_split_hidden_states = target_hidden_states[pcp_chunk_indices]
-            pcp_split_input_ids_list.append(pcp_split_input_ids)
-            pcp_split_hidden_states_list.append(pcp_split_hidden_states)
-            pad_start_index += num_pcp_padded_scheduled_tokens
-        num_tokens = sum(num_pcp_scheduled_tokens)
-        input_ids = torch.cat(pcp_split_input_ids_list)
-        target_hidden_states = torch.cat(pcp_split_hidden_states_list, dim=0)
-        max_query_len = max(num_pcp_scheduled_tokens)
-        seq_lens = torch.tensor(num_pcp_scheduled_tokens, dtype=torch.int32)
-        cu_num_tokens = torch.tensor(np.insert(np.cumsum(np.array(num_pcp_scheduled_tokens)), 0, 0))
-        return num_tokens, input_ids, target_hidden_states, max_query_len, seq_lens, cu_num_tokens
-
-    def _split_pcp_input_hybrid(self, req_scheduled_tokens, input_ids, target_hidden_states):
-        """
-        Linear-split prefill input_ids and target_hidden_states for hybrid attn PCP.
-
-        Uses the same alignment as DualChunkSwap (pad to 2*pcp_size multiple)
-        so each rank gets an equal number of tokens, but splits linearly
-        (contiguous slices) instead of interleaved head/tail chunks.
-
-        Example: ori_num_tokens=7, pcp_size=2 → padded=8, pcp_tokens=4
-          rank 0: [0,1,2,3]  (4 valid)
-          rank 1: [4,5,6,7]  (3 valid + 1 pad at position 7)
-        """
-        num_pcp_scheduled_tokens = []
-        global_offset = 0
-        pcp_split_input_ids_list = []
-        pcp_split_hidden_states_list = []
-        for ori_num_tokens in req_scheduled_tokens.values():
-            padded_tokens = cdiv(ori_num_tokens, 2 * self.pcp_size) * 2 * self.pcp_size
-            pcp_tokens = padded_tokens // self.pcp_size
-            num_pads = padded_tokens - ori_num_tokens
-            rank_start = self.pcp_rank * pcp_tokens
-            num_pcp_scheduled_tokens.append(pcp_tokens)
-            # Pad and slice input_ids
-            req_input_ids = input_ids[global_offset : global_offset + ori_num_tokens]
-            if num_pads > 0:
-                req_input_ids = F.pad(req_input_ids, (0, num_pads))
-            pcp_split_input_ids_list.append(req_input_ids[rank_start : rank_start + pcp_tokens])
-            # Pad and slice target_hidden_states
-            req_hidden = target_hidden_states[global_offset : global_offset + ori_num_tokens]
-            if num_pads > 0:
-                req_hidden = F.pad(req_hidden, (0, 0, 0, num_pads))
-            pcp_split_hidden_states_list.append(req_hidden[rank_start : rank_start + pcp_tokens])
-            global_offset += ori_num_tokens
-        num_tokens = sum(num_pcp_scheduled_tokens)
-        input_ids = torch.cat(pcp_split_input_ids_list)
-        target_hidden_states = torch.cat(pcp_split_hidden_states_list, dim=0)
-        max_query_len = max(num_pcp_scheduled_tokens)
-        seq_lens = torch.tensor(num_pcp_scheduled_tokens, dtype=torch.int32)
-        cu_num_tokens = torch.tensor(np.insert(np.cumsum(np.array(num_pcp_scheduled_tokens)), 0, 0))
-        return num_tokens, input_ids, target_hidden_states, max_query_len, seq_lens, cu_num_tokens
 
     # update full-graph params for one spec token
     def _update_full_graph_params(self, forward_context, num_tokens, draft_attn_metadatas=None):

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -12,7 +12,6 @@ import torch.nn.functional as F
 import vllm.distributed.parallel_state as _ps  # type: ignore[import-not-found]
 from vllm.config import CompilationMode, CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
 from vllm.distributed.parallel_state import (
-    get_pcp_group,
     get_pp_group,
     get_tp_group,
     get_world_group,
@@ -46,10 +45,8 @@ from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFADCPMetadataBuilder
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.compilation.acl_graph import ACLGraphWrapper, update_full_graph_params
-from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.parallel_state import get_lmhead_tp_group
 from vllm_ascend.models.llama_eagle3_vwn import Eagle3VwnLlamaForCausalLM
@@ -787,7 +784,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         )
         if self.pcp_size * self.dcp_size > 1:
             assert long_seq_args is not None
-            query_lens_d, ori_token_indices_to_sample = long_seq_args
+            _, ori_token_indices_to_sample = long_seq_args
         assert self.runner is not None
 
         has_lora = len(self.runner.input_batch.lora_id_to_lora_request) > 0
@@ -863,16 +860,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 )
 
             if self.pcp_size > 1:
-                pcp_allgather_restore_idx = (
+                self.runner.pcp_manager.mask_spec_decode_restore_idx_for_graph(
                     common_attn_metadata.prefill_context_parallel_metadata.pcp_allgather_restore_idx
                 )
-                index = torch.arange(pcp_allgather_restore_idx.shape[0], device=pcp_allgather_restore_idx.device)
-                mask = (index % (self.pcp_size * self.decode_threshold)) >= self.decode_threshold
-                pcp_allgather_restore_idx[mask] = 0
-                self.runner.pcp_manager.pcp_allgather_restore_idx.gpu[: pcp_allgather_restore_idx.shape[0]] = (
-                    pcp_allgather_restore_idx
-                )
-                self.runner.pcp_manager.pcp_allgather_restore_idx.gpu[pcp_allgather_restore_idx.shape[0] :] = 0
         else:
             num_reqs_padded = common_attn_metadata.num_reqs
             # In the below scenario, padding has been applied by _pad_query_start_loc_for_fia in the model runner.
@@ -956,85 +946,53 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         metadata_has_prefill = bool(getattr(attn_metadata_i, "num_prefills", 0))
         is_prefill_batch = num_prefill_reqs > 0 or metadata_has_prefill
+        pcp_mtp_inputs = None
+        draft_cp_kwargs = {
+            "ori_seq_len": None,
+            "ori_seq_len_cpu": None,
+            "slot_indices": None,
+            "mtp_slot_mapping": None,
+        }
         if self.pcp_size * self.dcp_size > 1:
-            is_decode_only_batch = num_decode_reqs > 0 and not is_prefill_batch
-            if self.num_speculative_tokens > 1 and is_decode_only_batch:
-                # For pcp/dcp, tokens are split across different cp ranks,
-                # so we can not simply update slot_mapping by += 1.
-                # Instead, we pre-allocate mtp slot_mapping in model_runner
-                # (_generate_pcp_mtp_input), and use updated slot_indices
-                # to get corresponding slot_mapping in each step.
-                query_start_loc_pcp_full = self.runner.pcp_manager.query_start_loc_pcp_full.gpu
-                cu_num_tokens_pcp_full = query_start_loc_pcp_full[1 : num_decode_reqs + 1]
-                query_lens_d_device = (
-                    query_start_loc_pcp_full[1 : num_decode_reqs + 1]
-                    - query_start_loc_pcp_full[:num_decode_reqs]
+            pcp_mtp_inputs = self.runner.pcp_manager.prepare_spec_decode_mtp_drafting_inputs(
+                common_attn_metadata=common_attn_metadata,
+                attn_metadata=attn_metadata_i,
+                ori_token_indices_to_sample=ori_token_indices_to_sample,
+                batch_size=batch_size,
+                num_decode_reqs=num_decode_reqs,
+                is_prefill_batch=is_prefill_batch,
+                num_speculative_tokens=self.num_speculative_tokens,
+            )
+            if pcp_mtp_inputs is not None:
+                draft_cp_kwargs.update(
+                    ori_seq_len=pcp_mtp_inputs.seq_lens,
+                    ori_seq_len_cpu=pcp_mtp_inputs.seq_lens_cpu,
+                    slot_indices=pcp_mtp_inputs.slot_indices,
+                    mtp_slot_mapping=pcp_mtp_inputs.slot_mapping,
                 )
-                num_reject_tokens = cu_num_tokens_pcp_full - ori_token_indices_to_sample - 1
-                num_accept_tokens = query_lens_d_device - num_reject_tokens
-                ori_seq_len = getattr(attn_metadata_i, "seq_lens", None)
-                ori_seq_len_cpu = getattr(attn_metadata_i, "seq_lens_cpu", None)
-                if ori_seq_len is None:
-                    ori_seq_len = ori_seq_len_cpu
-                ori_seq_len = ori_seq_len[:batch_size].clone()
-                if ori_seq_len_cpu is not None:
-                    ori_seq_len_cpu = ori_seq_len_cpu[:batch_size].clone()
-                slot_idx_base = (
-                    query_start_loc_pcp_full[:num_decode_reqs] * self.pcp_size
-                    + torch.arange(num_decode_reqs, device=self.device, dtype=torch.int64)
-                    * (self.num_speculative_tokens - 1)
-                    * self.pcp_size
-                    + (num_accept_tokens - 1) * self.pcp_size
-                )
-                slot_indices = (
-                    slot_idx_base[:, None]
-                    + self.cp_slot_offsets[: self.pcp_size].to(slot_idx_base.device)
-                ).reshape(-1)
-                mtp_slot_mapping = self.runner.pcp_manager.mtp_slot_pad
 
-                common_attn_metadata.block_table_tensor = common_attn_metadata.block_table_tensor[:batch_size]
-
-                # Copy the old attn_metadata and update
-                if not self.parallel_drafting:
-                    for draft_index in range(1, self.num_speculative_tokens):
-                        per_layer_attn_metadata = dict()
-                        for attn_group in self.draft_attn_groups:
-                            common_attn_metadata, attn_metadata = self.attn_update_stack_num_spec_norm(
-                                draft_index,
-                                attn_metadata,
-                                common_attn_metadata,
-                                batch_size,
-                                num_input_tokens,
-                                used_update_positions,
-                                aclgraph_runtime_mode,
-                                ori_seq_len,
-                                ori_seq_len_cpu,
-                                slot_indices,
-                                mtp_slot_mapping,
-                                attn_group=attn_group,
-                            )
-                            for layer_name in self.attn_layer_names:
-                                per_layer_attn_metadata[layer_name] = attn_metadata
-                        multi_steps_attn_metadata.append(per_layer_attn_metadata)
-        else:
+        should_update_next_steps = not self.parallel_drafting and (
+            self.pcp_size * self.dcp_size == 1 or pcp_mtp_inputs is not None
+        )
+        if should_update_next_steps:
             # Copy the old attn_metadata and update
-            if not self.parallel_drafting:
-                for draft_index in range(1, self.num_speculative_tokens):
-                    per_layer_attn_metadata = dict()
-                    for attn_group in self.draft_attn_groups:
-                        common_attn_metadata, attn_metadata = self.attn_update_stack_num_spec_norm(
-                            draft_index,
-                            attn_metadata,
-                            common_attn_metadata,
-                            batch_size,
-                            num_input_tokens,
-                            used_update_positions,
-                            aclgraph_runtime_mode,
-                            attn_group=attn_group,
-                        )
-                        for layer_name in self.attn_layer_names:
-                            per_layer_attn_metadata[layer_name] = attn_metadata
-                    multi_steps_attn_metadata.append(per_layer_attn_metadata)
+            for draft_index in range(1, self.num_speculative_tokens):
+                per_layer_attn_metadata = dict()
+                for attn_group in self.draft_attn_groups:
+                    common_attn_metadata, attn_metadata = self.attn_update_stack_num_spec_norm(
+                        draft_index,
+                        attn_metadata,
+                        common_attn_metadata,
+                        batch_size,
+                        num_input_tokens,
+                        used_update_positions,
+                        aclgraph_runtime_mode,
+                        **draft_cp_kwargs,
+                        attn_group=attn_group,
+                    )
+                    for layer_name in self.attn_layer_names:
+                        per_layer_attn_metadata[layer_name] = attn_metadata
+                multi_steps_attn_metadata.append(per_layer_attn_metadata)
 
         token_indices_to_sample_len = token_indices_to_sample.shape[0]
         self.token_indices_to_sample[:token_indices_to_sample_len].copy_(token_indices_to_sample)
@@ -1163,30 +1121,18 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         if self.pcp_size > 1:
             # remove graph padding before all_gather
-            hidden_states = hidden_states[:num_input_tokens]
-            if self.runner.pcp_manager.pcp_use_hybrid_attn:
-                hidden_states = self.runner.pcp_manager.get_restore_hidden_states(hidden_states)
-            else:
-                hidden_states = get_pcp_group().all_gather(hidden_states, 0)
-                hidden_states = torch.index_select(
-                    hidden_states,
-                    0,
-                    self.runner.pcp_manager.pcp_allgather_restore_idx.gpu[: num_input_tokens * self.pcp_size],
-                )
+            hidden_states = self.runner.pcp_manager.get_restore_hidden_states(
+                hidden_states,
+                num_input_tokens=num_input_tokens,
+            )
             if self.method == "mtp":
                 last_hidden_states = hidden_states
             else:
                 # eagle and eagle3 need allgather last_hidden_states.
-                last_hidden_states = last_hidden_states[:num_input_tokens]
-                if self.runner.pcp_manager.pcp_use_hybrid_attn:
-                    last_hidden_states = self.runner.pcp_manager.get_restore_hidden_states(last_hidden_states)
-                else:
-                    last_hidden_states = get_pcp_group().all_gather(last_hidden_states, 0)
-                    last_hidden_states = torch.index_select(
-                        last_hidden_states,
-                        0,
-                        self.runner.pcp_manager.pcp_allgather_restore_idx.gpu[: num_input_tokens * self.pcp_size],
-                    )
+                last_hidden_states = self.runner.pcp_manager.get_restore_hidden_states(
+                    last_hidden_states,
+                    num_input_tokens=num_input_tokens,
+                )
 
         if lmhead_tp_enable():
             token_indices_to_sample = nn.functional.pad(
@@ -1439,35 +1385,17 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 # prefill input_ids: add padding and pcp split
                 # prefill target_hidden_states: pcp split
                 assert query_lens_d is not None
-                assert query_lens_d_device is not None
                 num_tokens_d = self.runner.pcp_manager.num_decode_tokens
                 num_tokens_d_padded = num_tokens_d * self.pcp_size
                 input_ids_d = self.input_ids[:num_tokens_d]
                 input_ids_p = self.input_ids[num_tokens_d:num_tokens]
                 target_hidden_states_d_padded = target_hidden_states[:num_tokens_d_padded]
                 if num_tokens_d:
-                    if self.runner.pcp_manager.pcp_use_hybrid_attn:
-                        # Hybrid PCP restores decode hidden states rank-major:
-                        # [rank0 all decode tokens, rank1 all decode tokens, ...].
-                        target_hidden_states_d = target_hidden_states_d_padded[:num_tokens_d]
-                    else:
-                        # Keep decode unpadding indices on device to avoid a host index list.
-                        decode_req_starts = query_start_loc_pcp_full[:num_decode_reqs]
-                        decode_query_lens = query_lens_d_device
-                        decode_padded_starts = decode_req_starts * self.pcp_size
-                        decode_req_starts_per_token = torch.repeat_interleave(
-                            decode_req_starts,
-                            decode_query_lens,
-                            output_size=num_tokens_d,
-                        )
-                        decode_padded_starts_per_token = torch.repeat_interleave(
-                            decode_padded_starts,
-                            decode_query_lens,
-                            output_size=num_tokens_d,
-                        )
-                        decode_offsets = self.arange[:num_tokens_d] - decode_req_starts_per_token
-                        decode_hidden_state_indices = decode_padded_starts_per_token + decode_offsets
-                        target_hidden_states_d = target_hidden_states_d_padded[decode_hidden_state_indices]
+                    target_hidden_states_d = self.runner.pcp_manager.get_spec_decode_decode_hidden_states(
+                        target_hidden_states_d_padded,
+                        num_decode_reqs,
+                        num_tokens_d,
+                    )
                 else:
                     target_hidden_states_d = target_hidden_states_d_padded
                 target_hidden_states_p = target_hidden_states[num_tokens_d_padded:]
@@ -1742,17 +1670,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         if self.pcp_size * self.dcp_size > 1:
             kv_cache_spec = getattr(attn_group, "kv_cache_spec", self.draft_attn_groups[0].kv_cache_spec)
-            seq_len_for_cp_metadata = ori_seq_len
-            if not isinstance(kv_cache_spec, AscendMLAAttentionSpec) and ori_seq_len_cpu is not None:
-                # Non-MLA CP metadata is numpy-backed, so keep this path on CPU.
-                seq_len_for_cp_metadata = ori_seq_len_cpu
-            num_computed_tokens_of_pcp_dcp = self.runner.pcp_manager._get_cp_local_seq_lens(
-                seq_len_for_cp_metadata + draft_index + 1,
-                self.pcp_size,
-                self.dcp_size,
-                self.runner.parallel_config.cp_kv_cache_interleave_size,
-            )
-            cp_seq_len = num_computed_tokens_of_pcp_dcp[:, self.pcp_rank, self.dcp_rank]
             # update slot_mapping
             slot_indices += self.pcp_size
             slot_mapping = mtp_slot_mapping[slot_indices]
@@ -1817,22 +1734,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         )
 
         if self.pcp_size * self.dcp_size > 1:
-            if isinstance(attn_metadata_builder, AscendSFADCPMetadataBuilder):
-                assert attn_metadata.dcp_context is not None
-                dcp_seq_lens = attn_metadata.dcp_context.seq_lens
-                sfa_cp_seq_len = cp_seq_len.to(
-                    device=dcp_seq_lens.device,
-                    dtype=dcp_seq_lens.dtype,
-                    non_blocking=True,
-                )
-                dcp_seq_lens[: sfa_cp_seq_len.shape[0]].copy_(sfa_cp_seq_len, non_blocking=True)
-                dcp_seq_lens[sfa_cp_seq_len.shape[0] :].fill_(0)
-            else:
-                kv_cache_spec = self.draft_attn_groups[0].kv_cache_spec
-                if isinstance(kv_cache_spec, AscendMLAAttentionSpec):
-                    attn_metadata.decode.cp_seq_len = cp_seq_len
-                else:
-                    attn_metadata.decode_meta.num_computed_tokens_of_pcp_dcp = num_computed_tokens_of_pcp_dcp.numpy()
+            self.runner.pcp_manager.update_spec_decode_drafting_cp_metadata(
+                attn_metadata=attn_metadata,
+                kv_cache_spec=kv_cache_spec,
+                seq_lens=ori_seq_len,
+                draft_index=draft_index,
+                seq_lens_cpu=ori_seq_len_cpu,
+                attn_metadata_builder=attn_metadata_builder,
+            )
 
         return common_attn_metadata, attn_metadata
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -27,7 +27,6 @@ from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
 from vllm.model_executor.models.qwen3_dflash import DFlashQwen3ForCausalLM
 from vllm.triton_utils import HAS_TRITON, triton
-from vllm.utils.math_utils import cdiv
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -53,7 +52,6 @@ from vllm_ascend.models.llama_eagle3_vwn import Eagle3VwnLlamaForCausalLM
 from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 from vllm_ascend.utils import enable_sp, lmhead_tp_enable, shared_expert_dp_enabled
-from vllm_ascend.worker.pcp_utils import PCPManager
 
 
 @contextmanager
@@ -504,18 +502,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 enable_enpu=self.enable_enpu,
             )
 
-    def _get_pcp_manager(self) -> PCPManager | None:
-        pcp_manager = getattr(self.runner, "pcp_manager", None)
-        return pcp_manager if isinstance(pcp_manager, PCPManager) else None
-
-    def _pcp_use_hybrid_attn(self) -> bool:
-        pcp_manager = self._get_pcp_manager()
-        if pcp_manager is not None:
-            return pcp_manager.pcp_use_hybrid_attn
-        maybe_pcp_manager = getattr(self.runner, "pcp_manager", None)
-        value = getattr(maybe_pcp_manager, "pcp_use_hybrid_attn", False)
-        return value if isinstance(value, bool) else False
-
     def _maybe_share_topk_indices(self, target_language_model: nn.Module) -> None:
         if hasattr(target_language_model.model, "topk_indices_buffer"):
             if hasattr(self.model.model, "topk_indices_buffer"):
@@ -568,7 +554,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             num_tokens_across_dp,
             _,
         ) = self.runner._sync_metadata_across_dp(num_tokens, is_draft_model=True)
-        pcp_manager = self._get_pcp_manager()
+        pcp_manager = getattr(self.runner, "pcp_manager", None)
 
         multi_steps_attn_metadata = []
         if not self.use_cuda_graph:
@@ -789,7 +775,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             num_decode_reqs=num_decode_reqs,
         )
         assert self.runner is not None
-        pcp_manager = self._get_pcp_manager()
+        pcp_manager = getattr(self.runner, "pcp_manager", None)
         if pcp_manager is not None:
             assert long_seq_args is not None
             _, ori_token_indices_to_sample = long_seq_args
@@ -1127,7 +1113,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             else:
                 ori_token_indices_to_sample = None
 
-        pcp_manager = self._get_pcp_manager()
+        pcp_manager = getattr(self.runner, "pcp_manager", None)
         if pcp_manager is not None and self.pcp_size > 1:
             # remove graph padding before all_gather
             hidden_states = pcp_manager.get_restore_hidden_states(
@@ -1373,8 +1359,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             self.input_ids[token_indices_to_sample] = next_token_ids
 
             assert self.runner is not None
-            pcp_manager = self._get_pcp_manager()
-            long_seq_args = (None, None)
+            pcp_manager = getattr(self.runner, "pcp_manager", None)
+            long_seq_args = None
             if pcp_manager is not None:
                 first_pass_inputs = pcp_manager.prepare_spec_decode_first_pass_inputs(
                     input_ids=self.input_ids[:num_tokens],
@@ -1397,24 +1383,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 token_indices_to_sample = first_pass_inputs.token_indices_to_sample
                 self.input_ids[:num_tokens].copy_(first_pass_inputs.input_ids)
                 long_seq_args = first_pass_inputs.long_seq_args
-            elif self.pcp_size * self.dcp_size > 1:
-                (
-                    num_tokens,
-                    target_positions,
-                    target_hidden_states,
-                    token_indices_to_sample,
-                    long_seq_args,
-                ) = self._prepare_spec_decode_first_pass_inputs_without_manager(
-                    num_tokens=num_tokens,
-                    target_positions=target_positions,
-                    target_hidden_states=target_hidden_states,
-                    token_indices_to_sample=token_indices_to_sample,
-                    cad=cad,
-                    long_seq_metadata=long_seq_metadata,
-                    req_scheduled_tokens=req_scheduled_tokens,
-                    num_prefill_reqs=num_prefill_reqs,
-                    num_decode_reqs=num_decode_reqs,
-                )
 
             # copy inputs to buffer for cudagraph
             if self.uses_xdrope_dim > 0 and self.draft_uses_xdrope_dim == 0:
@@ -1652,7 +1620,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         else:
             common_attn_metadata.positions[:batch_size].copy_(clamped_positions)
 
-        pcp_manager = self._get_pcp_manager()
+        pcp_manager = getattr(self.runner, "pcp_manager", None)
         if pcp_manager is not None:
             kv_cache_spec = getattr(attn_group, "kv_cache_spec", self.draft_attn_groups[0].kv_cache_spec)
             # update slot_mapping
@@ -2010,245 +1978,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         )
 
         return spec_common_attn_metadata, token_indices, token_indices_to_sample, num_rejected_tokens_gpu
-
-    def _prepare_spec_decode_first_pass_inputs_without_manager(
-        self,
-        num_tokens: int,
-        target_positions: torch.Tensor,
-        target_hidden_states: torch.Tensor,
-        token_indices_to_sample: torch.Tensor,
-        cad: CommonAttentionMetadata,
-        long_seq_metadata: Any | None,
-        req_scheduled_tokens: dict[str, int] | None,
-        num_prefill_reqs: int,
-        num_decode_reqs: int,
-    ) -> tuple[int, torch.Tensor, torch.Tensor, torch.Tensor, tuple[Any, Any]]:
-        assert self.runner is not None
-        assert long_seq_metadata is not None
-        cad.prefill_context_parallel_metadata = long_seq_metadata
-
-        ori_token_indices_to_sample = token_indices_to_sample.clone()
-        query_lens_d = self.runner.query_lens[:num_decode_reqs]
-        long_seq_args = (query_lens_d, ori_token_indices_to_sample)
-        if self.pcp_size <= 1:
-            return (
-                num_tokens,
-                target_positions,
-                target_hidden_states,
-                token_indices_to_sample,
-                long_seq_args,
-            )
-
-        num_tokens_d = int(query_lens_d.sum().item()) if num_decode_reqs else 0
-        num_tokens_d_padded = num_tokens_d * self.pcp_size
-        input_ids_d = self.input_ids[:num_tokens_d]
-        input_ids_p = self.input_ids[num_tokens_d:num_tokens]
-        target_hidden_states_d_padded = target_hidden_states[:num_tokens_d_padded]
-        if num_tokens_d:
-            target_hidden_states_d = self._get_spec_decode_decode_hidden_states_without_manager(
-                target_hidden_states_d_padded,
-                query_lens_d,
-                num_tokens_d,
-            )
-        else:
-            target_hidden_states_d = target_hidden_states_d_padded
-        target_hidden_states_p = target_hidden_states[num_tokens_d_padded:]
-
-        req_scheduled_tokens_p: dict[str, int] = {}
-        if num_prefill_reqs:
-            assert req_scheduled_tokens is not None
-            num_reqs = num_decode_reqs + num_prefill_reqs
-            for i, req_id in enumerate(self.runner.input_batch.req_ids[:num_reqs]):
-                if i >= num_decode_reqs:
-                    req_scheduled_tokens_p[req_id] = req_scheduled_tokens[req_id]
-
-        (
-            num_tokens_p,
-            input_ids_p,
-            target_hidden_states_p,
-            max_query_len_p,
-            seq_lens_p,
-            cu_num_tokens_p,
-        ) = self._split_pcp_input(
-            req_scheduled_tokens_p,
-            input_ids_p,
-            target_hidden_states_p,
-        )
-        num_tokens = num_tokens_d + num_tokens_p
-        if self.uses_mrope:
-            target_positions = target_positions[:, :num_tokens]
-        else:
-            target_positions = target_positions[:num_tokens]
-        self.input_ids[:num_tokens].copy_(torch.cat([input_ids_d, input_ids_p], dim=0))
-        target_hidden_states = torch.cat([target_hidden_states_d, target_hidden_states_p], dim=0)
-
-        if num_decode_reqs:
-            token_indices_to_sample[:num_decode_reqs] = self.runner.logits_indices[
-                token_indices_to_sample[:num_decode_reqs]
-            ]
-        if num_prefill_reqs:
-            token_indices_to_sample[-num_prefill_reqs:] = self.runner.logits_indices[-num_prefill_reqs:]
-            cad.num_actual_tokens = num_tokens
-            cad.max_query_len = max(self.decode_threshold, max_query_len_p)
-            seq_lens_p_device = seq_lens_p.to(cad.seq_lens.device, non_blocking=True)
-            cad.seq_lens[-num_prefill_reqs:] = seq_lens_p_device
-            if cad.seq_lens_cpu is not None:
-                cad.seq_lens_cpu[-num_prefill_reqs:] = seq_lens_p
-            if cad._seq_lens_cpu is not None:
-                cad._seq_lens_cpu[-num_prefill_reqs:] = seq_lens_p
-            query_start_loc_p_cpu = cu_num_tokens_p[1:] + cad.query_start_loc_cpu[num_decode_reqs].item()
-            query_start_loc_p = query_start_loc_p_cpu.to(cad.query_start_loc.device, non_blocking=True)
-            cad.query_start_loc[-num_prefill_reqs:] = query_start_loc_p
-            cad.query_start_loc_cpu[-num_prefill_reqs:] = query_start_loc_p_cpu
-
-        return (
-            num_tokens,
-            target_positions,
-            target_hidden_states,
-            token_indices_to_sample,
-            long_seq_args,
-        )
-
-    def _get_spec_decode_decode_hidden_states_without_manager(
-        self,
-        target_hidden_states_d_padded: torch.Tensor,
-        query_lens_d: torch.Tensor,
-        num_decode_tokens: int,
-    ) -> torch.Tensor:
-        if num_decode_tokens == 0:
-            return target_hidden_states_d_padded
-        if self._pcp_use_hybrid_attn():
-            return target_hidden_states_d_padded[:num_decode_tokens]
-
-        device = target_hidden_states_d_padded.device
-        decode_query_lens = query_lens_d.to(device=device, dtype=torch.int64)
-        query_start_loc = torch.zeros(
-            decode_query_lens.shape[0] + 1,
-            dtype=torch.int64,
-            device=device,
-        )
-        query_start_loc[1:] = torch.cumsum(decode_query_lens, dim=0)
-        decode_req_starts = query_start_loc[:-1]
-        decode_padded_starts = decode_req_starts * self.pcp_size
-        decode_req_starts_per_token = torch.repeat_interleave(
-            decode_req_starts,
-            decode_query_lens,
-            output_size=num_decode_tokens,
-        )
-        decode_padded_starts_per_token = torch.repeat_interleave(
-            decode_padded_starts,
-            decode_query_lens,
-            output_size=num_decode_tokens,
-        )
-        decode_offsets = (
-            torch.arange(
-                num_decode_tokens,
-                dtype=torch.int64,
-                device=device,
-            )
-            - decode_req_starts_per_token
-        )
-        decode_hidden_state_indices = decode_padded_starts_per_token + decode_offsets
-        return target_hidden_states_d_padded[decode_hidden_state_indices]
-
-    def _split_pcp_input(
-        self,
-        req_scheduled_tokens: dict[str, int],
-        input_ids: torch.Tensor,
-        target_hidden_states: torch.Tensor,
-    ) -> tuple[int, torch.Tensor, torch.Tensor, int, torch.Tensor, torch.Tensor]:
-        """
-        Split prefill input_ids and target_hidden_states in the PCP group.
-        """
-        if len(req_scheduled_tokens) == 0:
-            return (
-                0,
-                input_ids.new_zeros((0,)),
-                target_hidden_states.new_zeros((0, target_hidden_states.size(1))),
-                0,
-                torch.zeros((0,), dtype=torch.int32),
-                torch.tensor([0], dtype=torch.int32),
-            )
-
-        if self._pcp_use_hybrid_attn():
-            return self._split_pcp_input_hybrid(req_scheduled_tokens, input_ids, target_hidden_states)
-
-        def _pcp_pad_and_split(num_tokens: int) -> tuple[list[int], int, int]:
-            num_pcp_padded_scheduled_tokens = cdiv(num_tokens, 2 * self.pcp_size) * 2 * self.pcp_size
-            pcp_pad = num_pcp_padded_scheduled_tokens - num_tokens
-            chunk_size = num_pcp_padded_scheduled_tokens // (2 * self.pcp_size)
-
-            req_position_cp: list[int] = []
-            req_position_cp.extend(self.full_indices[self.pcp_rank * chunk_size : (self.pcp_rank + 1) * chunk_size])
-            req_position_cp.extend(
-                self.full_indices[
-                    num_pcp_padded_scheduled_tokens - (self.pcp_rank + 1) * chunk_size : num_pcp_padded_scheduled_tokens
-                    - self.pcp_rank * chunk_size
-                ]
-            )
-
-            return req_position_cp, num_pcp_padded_scheduled_tokens, pcp_pad
-
-        num_pcp_scheduled_tokens = []
-        ori_start_index = 0
-        pad_start_index = 0
-        pcp_split_input_ids_list = []
-        pcp_split_hidden_states_list = []
-        for ori_num_tokens in req_scheduled_tokens.values():
-            req_position_pcp, num_pcp_padded_scheduled_tokens, num_pcp_pad = _pcp_pad_and_split(ori_num_tokens)
-            actual_num_tokens = len(req_position_pcp)
-            num_pcp_scheduled_tokens.append(actual_num_tokens)
-            pad_input_ids = F.pad(input_ids[ori_start_index : ori_start_index + ori_num_tokens], (0, num_pcp_pad))
-            ori_start_index += ori_num_tokens
-            pcp_chunk_indices = [pad_start_index + pos for pos in req_position_pcp]
-            pcp_split_input_ids = pad_input_ids[req_position_pcp]
-            pcp_split_hidden_states = target_hidden_states[pcp_chunk_indices]
-            pcp_split_input_ids_list.append(pcp_split_input_ids)
-            pcp_split_hidden_states_list.append(pcp_split_hidden_states)
-            pad_start_index += num_pcp_padded_scheduled_tokens
-        num_tokens = sum(num_pcp_scheduled_tokens)
-        input_ids = torch.cat(pcp_split_input_ids_list)
-        target_hidden_states = torch.cat(pcp_split_hidden_states_list, dim=0)
-        max_query_len = max(num_pcp_scheduled_tokens)
-        seq_lens = torch.tensor(num_pcp_scheduled_tokens, dtype=torch.int32)
-        cu_num_tokens = torch.tensor(np.insert(np.cumsum(np.array(num_pcp_scheduled_tokens)), 0, 0))
-        return num_tokens, input_ids, target_hidden_states, max_query_len, seq_lens, cu_num_tokens
-
-    def _split_pcp_input_hybrid(
-        self,
-        req_scheduled_tokens: dict[str, int],
-        input_ids: torch.Tensor,
-        target_hidden_states: torch.Tensor,
-    ) -> tuple[int, torch.Tensor, torch.Tensor, int, torch.Tensor, torch.Tensor]:
-        """Linear-split prefill inputs for hybrid-attention PCP models."""
-        num_pcp_scheduled_tokens = []
-        global_offset = 0
-        pcp_split_input_ids_list = []
-        pcp_split_hidden_states_list = []
-        for ori_num_tokens in req_scheduled_tokens.values():
-            padded_tokens = cdiv(ori_num_tokens, 2 * self.pcp_size) * 2 * self.pcp_size
-            pcp_tokens = padded_tokens // self.pcp_size
-            num_pads = padded_tokens - ori_num_tokens
-            rank_start = self.pcp_rank * pcp_tokens
-            num_pcp_scheduled_tokens.append(pcp_tokens)
-
-            req_input_ids = input_ids[global_offset : global_offset + ori_num_tokens]
-            if num_pads > 0:
-                req_input_ids = F.pad(req_input_ids, (0, num_pads))
-            pcp_split_input_ids_list.append(req_input_ids[rank_start : rank_start + pcp_tokens])
-
-            req_hidden = target_hidden_states[global_offset : global_offset + ori_num_tokens]
-            if num_pads > 0:
-                req_hidden = F.pad(req_hidden, (0, 0, 0, num_pads))
-            pcp_split_hidden_states_list.append(req_hidden[rank_start : rank_start + pcp_tokens])
-            global_offset += ori_num_tokens
-        num_tokens = sum(num_pcp_scheduled_tokens)
-        input_ids = torch.cat(pcp_split_input_ids_list)
-        target_hidden_states = torch.cat(pcp_split_hidden_states_list, dim=0)
-        max_query_len = max(num_pcp_scheduled_tokens)
-        seq_lens = torch.tensor(num_pcp_scheduled_tokens, dtype=torch.int32)
-        cu_num_tokens = torch.tensor(np.insert(np.cumsum(np.array(num_pcp_scheduled_tokens)), 0, 0))
-        return num_tokens, input_ids, target_hidden_states, max_query_len, seq_lens, cu_num_tokens
 
     # update full-graph params for one spec token
     def _update_full_graph_params(self, forward_context, num_tokens, draft_attn_metadatas=None):

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -973,9 +973,12 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 num_reject_tokens = cu_num_tokens_pcp_full - ori_token_indices_to_sample - 1
                 num_accept_tokens = query_lens_d_device - num_reject_tokens
                 ori_seq_len = getattr(attn_metadata_i, "seq_lens", None)
+                ori_seq_len_cpu = getattr(attn_metadata_i, "seq_lens_cpu", None)
                 if ori_seq_len is None:
-                    ori_seq_len = attn_metadata_i.seq_lens_cpu
+                    ori_seq_len = ori_seq_len_cpu
                 ori_seq_len = ori_seq_len[:batch_size].clone()
+                if ori_seq_len_cpu is not None:
+                    ori_seq_len_cpu = ori_seq_len_cpu[:batch_size].clone()
                 slot_idx_base = (
                     query_start_loc_pcp_full[:num_decode_reqs].to(torch.int64) * self.pcp_size
                     + torch.arange(num_decode_reqs, device=self.device, dtype=torch.int64)
@@ -1005,6 +1008,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                                 used_update_positions,
                                 aclgraph_runtime_mode,
                                 ori_seq_len,
+                                ori_seq_len_cpu,
                                 slot_indices,
                                 mtp_slot_mapping,
                                 attn_group=attn_group,
@@ -1417,11 +1421,17 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             # update pcp related params
             ori_token_indices_to_sample = None
             query_lens_d = None
+            query_lens_d_device = None
             if self.pcp_size * self.dcp_size > 1:
                 assert long_seq_metadata is not None
                 cad.prefill_context_parallel_metadata = long_seq_metadata
                 ori_token_indices_to_sample = token_indices_to_sample.clone()
                 query_lens_d = self.runner.query_lens[:num_decode_reqs]
+                query_start_loc_pcp_full = self.runner.pcp_manager.query_start_loc_pcp_full.gpu
+                query_lens_d_device = (
+                    query_start_loc_pcp_full[1 : num_decode_reqs + 1]
+                    - query_start_loc_pcp_full[:num_decode_reqs]
+                )
             if self.pcp_size > 1:
                 # 1. preprocess decode/prefill input_ids & target_hidden_states
                 # decode input_ids: keep unchanged
@@ -1429,7 +1439,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 # prefill input_ids: add padding and pcp split
                 # prefill target_hidden_states: pcp split
                 assert query_lens_d is not None
-                num_tokens_d = query_lens_d.sum().item()
+                assert query_lens_d_device is not None
+                num_tokens_d = self.runner.pcp_manager.num_decode_tokens
                 num_tokens_d_padded = num_tokens_d * self.pcp_size
                 input_ids_d = self.input_ids[:num_tokens_d]
                 input_ids_p = self.input_ids[num_tokens_d:num_tokens]
@@ -1440,19 +1451,23 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                         # [rank0 all decode tokens, rank1 all decode tokens, ...].
                         target_hidden_states_d = target_hidden_states_d_padded[:num_tokens_d]
                     else:
-                        # remove padding (from pcp all-gather) in decode part
-                        mask_start_loc = torch.cat(
-                            [
-                                torch.tensor([0], dtype=torch.int32, device=query_lens_d.device),
-                                torch.cumsum(query_lens_d * self.pcp_size, dim=0)[:-1],
-                            ]
+                        # Keep decode unpadding indices on device to avoid a host index list.
+                        decode_req_starts = query_start_loc_pcp_full[:num_decode_reqs].to(torch.int64)
+                        decode_query_lens = query_lens_d_device.to(torch.int64)
+                        decode_padded_starts = decode_req_starts * self.pcp_size
+                        decode_req_starts_per_token = torch.repeat_interleave(
+                            decode_req_starts,
+                            decode_query_lens,
+                            output_size=num_tokens_d,
                         )
-                        mask_len = query_lens_d
-                        mask = []
-                        for req_id in range(num_decode_reqs):
-                            assert None not in (mask_start_loc, mask_len)
-                            mask += list(range(mask_start_loc[req_id], mask_start_loc[req_id] + mask_len[req_id]))
-                        target_hidden_states_d = target_hidden_states_d_padded[mask]
+                        decode_padded_starts_per_token = torch.repeat_interleave(
+                            decode_padded_starts,
+                            decode_query_lens,
+                            output_size=num_tokens_d,
+                        )
+                        decode_offsets = self.arange[:num_tokens_d].to(torch.int64) - decode_req_starts_per_token
+                        decode_hidden_state_indices = decode_padded_starts_per_token + decode_offsets
+                        target_hidden_states_d = target_hidden_states_d_padded[decode_hidden_state_indices]
                 else:
                     target_hidden_states_d = target_hidden_states_d_padded
                 target_hidden_states_p = target_hidden_states[num_tokens_d_padded:]
@@ -1485,7 +1500,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                         cad.seq_lens_cpu[-num_prefill_reqs:] = seq_lens_p
                     if cad._seq_lens_cpu is not None:
                         cad._seq_lens_cpu[-num_prefill_reqs:] = seq_lens_p
-                    query_start_loc_p = cu_num_tokens_p[1:] + cad.query_start_loc[num_decode_reqs].item()
+                    query_start_loc_p = cu_num_tokens_p[1:] + cad.query_start_loc_cpu[num_decode_reqs].item()
                     cad.query_start_loc[-num_prefill_reqs:] = query_start_loc_p
                     cad.query_start_loc_cpu[-num_prefill_reqs:] = query_start_loc_p
 
@@ -1623,6 +1638,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         used_update_positions,
         aclgraph_runtime_mode,
         ori_seq_len=None,
+        ori_seq_len_cpu=None,
         slot_indices=None,
         mtp_slot_mapping=None,
         attn_group=None,
@@ -1725,8 +1741,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             common_attn_metadata.positions[:batch_size].copy_(clamped_positions)
 
         if self.pcp_size * self.dcp_size > 1:
+            kv_cache_spec = getattr(attn_group, "kv_cache_spec", self.draft_attn_groups[0].kv_cache_spec)
+            seq_len_for_cp_metadata = ori_seq_len
+            if not isinstance(kv_cache_spec, AscendMLAAttentionSpec) and ori_seq_len_cpu is not None:
+                # Non-MLA CP metadata is numpy-backed, so keep this path on CPU.
+                seq_len_for_cp_metadata = ori_seq_len_cpu
             num_computed_tokens_of_pcp_dcp = self.runner.pcp_manager._get_cp_local_seq_lens(
-                ori_seq_len + draft_index + 1,
+                seq_len_for_cp_metadata + draft_index + 1,
                 self.pcp_size,
                 self.dcp_size,
                 self.runner.parallel_config.cp_kv_cache_interleave_size,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -27,6 +27,7 @@ from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
 from vllm.model_executor.models.qwen3_dflash import DFlashQwen3ForCausalLM
 from vllm.triton_utils import HAS_TRITON, triton
+from vllm.utils.math_utils import cdiv
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -52,6 +53,7 @@ from vllm_ascend.models.llama_eagle3_vwn import Eagle3VwnLlamaForCausalLM
 from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 from vllm_ascend.utils import enable_sp, lmhead_tp_enable, shared_expert_dp_enabled
+from vllm_ascend.worker.pcp_utils import PCPManager
 
 
 @contextmanager
@@ -502,6 +504,18 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 enable_enpu=self.enable_enpu,
             )
 
+    def _get_pcp_manager(self) -> PCPManager | None:
+        pcp_manager = getattr(self.runner, "pcp_manager", None)
+        return pcp_manager if isinstance(pcp_manager, PCPManager) else None
+
+    def _pcp_use_hybrid_attn(self) -> bool:
+        pcp_manager = self._get_pcp_manager()
+        if pcp_manager is not None:
+            return pcp_manager.pcp_use_hybrid_attn
+        maybe_pcp_manager = getattr(self.runner, "pcp_manager", None)
+        value = getattr(maybe_pcp_manager, "pcp_use_hybrid_attn", False)
+        return value if isinstance(value, bool) else False
+
     def _maybe_share_topk_indices(self, target_language_model: nn.Module) -> None:
         if hasattr(target_language_model.model, "topk_indices_buffer"):
             if hasattr(self.model.model, "topk_indices_buffer"):
@@ -554,7 +568,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             num_tokens_across_dp,
             _,
         ) = self.runner._sync_metadata_across_dp(num_tokens, is_draft_model=True)
-        pcp_manager = getattr(self.runner, "pcp_manager", None)
+        pcp_manager = self._get_pcp_manager()
 
         multi_steps_attn_metadata = []
         if not self.use_cuda_graph:
@@ -775,7 +789,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             num_decode_reqs=num_decode_reqs,
         )
         assert self.runner is not None
-        pcp_manager = getattr(self.runner, "pcp_manager", None)
+        pcp_manager = self._get_pcp_manager()
         if pcp_manager is not None:
             assert long_seq_args is not None
             _, ori_token_indices_to_sample = long_seq_args
@@ -1113,7 +1127,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             else:
                 ori_token_indices_to_sample = None
 
-        pcp_manager = getattr(self.runner, "pcp_manager", None)
+        pcp_manager = self._get_pcp_manager()
         if pcp_manager is not None and self.pcp_size > 1:
             # remove graph padding before all_gather
             hidden_states = pcp_manager.get_restore_hidden_states(
@@ -1359,8 +1373,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             self.input_ids[token_indices_to_sample] = next_token_ids
 
             assert self.runner is not None
-            pcp_manager = getattr(self.runner, "pcp_manager", None)
-            long_seq_args = None
+            pcp_manager = self._get_pcp_manager()
+            long_seq_args = (None, None)
             if pcp_manager is not None:
                 first_pass_inputs = pcp_manager.prepare_spec_decode_first_pass_inputs(
                     input_ids=self.input_ids[:num_tokens],
@@ -1383,6 +1397,24 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 token_indices_to_sample = first_pass_inputs.token_indices_to_sample
                 self.input_ids[:num_tokens].copy_(first_pass_inputs.input_ids)
                 long_seq_args = first_pass_inputs.long_seq_args
+            elif self.pcp_size * self.dcp_size > 1:
+                (
+                    num_tokens,
+                    target_positions,
+                    target_hidden_states,
+                    token_indices_to_sample,
+                    long_seq_args,
+                ) = self._prepare_spec_decode_first_pass_inputs_without_manager(
+                    num_tokens=num_tokens,
+                    target_positions=target_positions,
+                    target_hidden_states=target_hidden_states,
+                    token_indices_to_sample=token_indices_to_sample,
+                    cad=cad,
+                    long_seq_metadata=long_seq_metadata,
+                    req_scheduled_tokens=req_scheduled_tokens,
+                    num_prefill_reqs=num_prefill_reqs,
+                    num_decode_reqs=num_decode_reqs,
+                )
 
             # copy inputs to buffer for cudagraph
             if self.uses_xdrope_dim > 0 and self.draft_uses_xdrope_dim == 0:
@@ -1620,7 +1652,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         else:
             common_attn_metadata.positions[:batch_size].copy_(clamped_positions)
 
-        pcp_manager = getattr(self.runner, "pcp_manager", None)
+        pcp_manager = self._get_pcp_manager()
         if pcp_manager is not None:
             kv_cache_spec = getattr(attn_group, "kv_cache_spec", self.draft_attn_groups[0].kv_cache_spec)
             # update slot_mapping
@@ -1978,6 +2010,245 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         )
 
         return spec_common_attn_metadata, token_indices, token_indices_to_sample, num_rejected_tokens_gpu
+
+    def _prepare_spec_decode_first_pass_inputs_without_manager(
+        self,
+        num_tokens: int,
+        target_positions: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        token_indices_to_sample: torch.Tensor,
+        cad: CommonAttentionMetadata,
+        long_seq_metadata: Any | None,
+        req_scheduled_tokens: dict[str, int] | None,
+        num_prefill_reqs: int,
+        num_decode_reqs: int,
+    ) -> tuple[int, torch.Tensor, torch.Tensor, torch.Tensor, tuple[Any, Any]]:
+        assert self.runner is not None
+        assert long_seq_metadata is not None
+        cad.prefill_context_parallel_metadata = long_seq_metadata
+
+        ori_token_indices_to_sample = token_indices_to_sample.clone()
+        query_lens_d = self.runner.query_lens[:num_decode_reqs]
+        long_seq_args = (query_lens_d, ori_token_indices_to_sample)
+        if self.pcp_size <= 1:
+            return (
+                num_tokens,
+                target_positions,
+                target_hidden_states,
+                token_indices_to_sample,
+                long_seq_args,
+            )
+
+        num_tokens_d = int(query_lens_d.sum().item()) if num_decode_reqs else 0
+        num_tokens_d_padded = num_tokens_d * self.pcp_size
+        input_ids_d = self.input_ids[:num_tokens_d]
+        input_ids_p = self.input_ids[num_tokens_d:num_tokens]
+        target_hidden_states_d_padded = target_hidden_states[:num_tokens_d_padded]
+        if num_tokens_d:
+            target_hidden_states_d = self._get_spec_decode_decode_hidden_states_without_manager(
+                target_hidden_states_d_padded,
+                query_lens_d,
+                num_tokens_d,
+            )
+        else:
+            target_hidden_states_d = target_hidden_states_d_padded
+        target_hidden_states_p = target_hidden_states[num_tokens_d_padded:]
+
+        req_scheduled_tokens_p: dict[str, int] = {}
+        if num_prefill_reqs:
+            assert req_scheduled_tokens is not None
+            num_reqs = num_decode_reqs + num_prefill_reqs
+            for i, req_id in enumerate(self.runner.input_batch.req_ids[:num_reqs]):
+                if i >= num_decode_reqs:
+                    req_scheduled_tokens_p[req_id] = req_scheduled_tokens[req_id]
+
+        (
+            num_tokens_p,
+            input_ids_p,
+            target_hidden_states_p,
+            max_query_len_p,
+            seq_lens_p,
+            cu_num_tokens_p,
+        ) = self._split_pcp_input(
+            req_scheduled_tokens_p,
+            input_ids_p,
+            target_hidden_states_p,
+        )
+        num_tokens = num_tokens_d + num_tokens_p
+        if self.uses_mrope:
+            target_positions = target_positions[:, :num_tokens]
+        else:
+            target_positions = target_positions[:num_tokens]
+        self.input_ids[:num_tokens].copy_(torch.cat([input_ids_d, input_ids_p], dim=0))
+        target_hidden_states = torch.cat([target_hidden_states_d, target_hidden_states_p], dim=0)
+
+        if num_decode_reqs:
+            token_indices_to_sample[:num_decode_reqs] = self.runner.logits_indices[
+                token_indices_to_sample[:num_decode_reqs]
+            ]
+        if num_prefill_reqs:
+            token_indices_to_sample[-num_prefill_reqs:] = self.runner.logits_indices[-num_prefill_reqs:]
+            cad.num_actual_tokens = num_tokens
+            cad.max_query_len = max(self.decode_threshold, max_query_len_p)
+            seq_lens_p_device = seq_lens_p.to(cad.seq_lens.device, non_blocking=True)
+            cad.seq_lens[-num_prefill_reqs:] = seq_lens_p_device
+            if cad.seq_lens_cpu is not None:
+                cad.seq_lens_cpu[-num_prefill_reqs:] = seq_lens_p
+            if cad._seq_lens_cpu is not None:
+                cad._seq_lens_cpu[-num_prefill_reqs:] = seq_lens_p
+            query_start_loc_p_cpu = cu_num_tokens_p[1:] + cad.query_start_loc_cpu[num_decode_reqs].item()
+            query_start_loc_p = query_start_loc_p_cpu.to(cad.query_start_loc.device, non_blocking=True)
+            cad.query_start_loc[-num_prefill_reqs:] = query_start_loc_p
+            cad.query_start_loc_cpu[-num_prefill_reqs:] = query_start_loc_p_cpu
+
+        return (
+            num_tokens,
+            target_positions,
+            target_hidden_states,
+            token_indices_to_sample,
+            long_seq_args,
+        )
+
+    def _get_spec_decode_decode_hidden_states_without_manager(
+        self,
+        target_hidden_states_d_padded: torch.Tensor,
+        query_lens_d: torch.Tensor,
+        num_decode_tokens: int,
+    ) -> torch.Tensor:
+        if num_decode_tokens == 0:
+            return target_hidden_states_d_padded
+        if self._pcp_use_hybrid_attn():
+            return target_hidden_states_d_padded[:num_decode_tokens]
+
+        device = target_hidden_states_d_padded.device
+        decode_query_lens = query_lens_d.to(device=device, dtype=torch.int64)
+        query_start_loc = torch.zeros(
+            decode_query_lens.shape[0] + 1,
+            dtype=torch.int64,
+            device=device,
+        )
+        query_start_loc[1:] = torch.cumsum(decode_query_lens, dim=0)
+        decode_req_starts = query_start_loc[:-1]
+        decode_padded_starts = decode_req_starts * self.pcp_size
+        decode_req_starts_per_token = torch.repeat_interleave(
+            decode_req_starts,
+            decode_query_lens,
+            output_size=num_decode_tokens,
+        )
+        decode_padded_starts_per_token = torch.repeat_interleave(
+            decode_padded_starts,
+            decode_query_lens,
+            output_size=num_decode_tokens,
+        )
+        decode_offsets = (
+            torch.arange(
+                num_decode_tokens,
+                dtype=torch.int64,
+                device=device,
+            )
+            - decode_req_starts_per_token
+        )
+        decode_hidden_state_indices = decode_padded_starts_per_token + decode_offsets
+        return target_hidden_states_d_padded[decode_hidden_state_indices]
+
+    def _split_pcp_input(
+        self,
+        req_scheduled_tokens: dict[str, int],
+        input_ids: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+    ) -> tuple[int, torch.Tensor, torch.Tensor, int, torch.Tensor, torch.Tensor]:
+        """
+        Split prefill input_ids and target_hidden_states in the PCP group.
+        """
+        if len(req_scheduled_tokens) == 0:
+            return (
+                0,
+                input_ids.new_zeros((0,)),
+                target_hidden_states.new_zeros((0, target_hidden_states.size(1))),
+                0,
+                torch.zeros((0,), dtype=torch.int32),
+                torch.tensor([0], dtype=torch.int32),
+            )
+
+        if self._pcp_use_hybrid_attn():
+            return self._split_pcp_input_hybrid(req_scheduled_tokens, input_ids, target_hidden_states)
+
+        def _pcp_pad_and_split(num_tokens: int) -> tuple[list[int], int, int]:
+            num_pcp_padded_scheduled_tokens = cdiv(num_tokens, 2 * self.pcp_size) * 2 * self.pcp_size
+            pcp_pad = num_pcp_padded_scheduled_tokens - num_tokens
+            chunk_size = num_pcp_padded_scheduled_tokens // (2 * self.pcp_size)
+
+            req_position_cp: list[int] = []
+            req_position_cp.extend(self.full_indices[self.pcp_rank * chunk_size : (self.pcp_rank + 1) * chunk_size])
+            req_position_cp.extend(
+                self.full_indices[
+                    num_pcp_padded_scheduled_tokens - (self.pcp_rank + 1) * chunk_size : num_pcp_padded_scheduled_tokens
+                    - self.pcp_rank * chunk_size
+                ]
+            )
+
+            return req_position_cp, num_pcp_padded_scheduled_tokens, pcp_pad
+
+        num_pcp_scheduled_tokens = []
+        ori_start_index = 0
+        pad_start_index = 0
+        pcp_split_input_ids_list = []
+        pcp_split_hidden_states_list = []
+        for ori_num_tokens in req_scheduled_tokens.values():
+            req_position_pcp, num_pcp_padded_scheduled_tokens, num_pcp_pad = _pcp_pad_and_split(ori_num_tokens)
+            actual_num_tokens = len(req_position_pcp)
+            num_pcp_scheduled_tokens.append(actual_num_tokens)
+            pad_input_ids = F.pad(input_ids[ori_start_index : ori_start_index + ori_num_tokens], (0, num_pcp_pad))
+            ori_start_index += ori_num_tokens
+            pcp_chunk_indices = [pad_start_index + pos for pos in req_position_pcp]
+            pcp_split_input_ids = pad_input_ids[req_position_pcp]
+            pcp_split_hidden_states = target_hidden_states[pcp_chunk_indices]
+            pcp_split_input_ids_list.append(pcp_split_input_ids)
+            pcp_split_hidden_states_list.append(pcp_split_hidden_states)
+            pad_start_index += num_pcp_padded_scheduled_tokens
+        num_tokens = sum(num_pcp_scheduled_tokens)
+        input_ids = torch.cat(pcp_split_input_ids_list)
+        target_hidden_states = torch.cat(pcp_split_hidden_states_list, dim=0)
+        max_query_len = max(num_pcp_scheduled_tokens)
+        seq_lens = torch.tensor(num_pcp_scheduled_tokens, dtype=torch.int32)
+        cu_num_tokens = torch.tensor(np.insert(np.cumsum(np.array(num_pcp_scheduled_tokens)), 0, 0))
+        return num_tokens, input_ids, target_hidden_states, max_query_len, seq_lens, cu_num_tokens
+
+    def _split_pcp_input_hybrid(
+        self,
+        req_scheduled_tokens: dict[str, int],
+        input_ids: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+    ) -> tuple[int, torch.Tensor, torch.Tensor, int, torch.Tensor, torch.Tensor]:
+        """Linear-split prefill inputs for hybrid-attention PCP models."""
+        num_pcp_scheduled_tokens = []
+        global_offset = 0
+        pcp_split_input_ids_list = []
+        pcp_split_hidden_states_list = []
+        for ori_num_tokens in req_scheduled_tokens.values():
+            padded_tokens = cdiv(ori_num_tokens, 2 * self.pcp_size) * 2 * self.pcp_size
+            pcp_tokens = padded_tokens // self.pcp_size
+            num_pads = padded_tokens - ori_num_tokens
+            rank_start = self.pcp_rank * pcp_tokens
+            num_pcp_scheduled_tokens.append(pcp_tokens)
+
+            req_input_ids = input_ids[global_offset : global_offset + ori_num_tokens]
+            if num_pads > 0:
+                req_input_ids = F.pad(req_input_ids, (0, num_pads))
+            pcp_split_input_ids_list.append(req_input_ids[rank_start : rank_start + pcp_tokens])
+
+            req_hidden = target_hidden_states[global_offset : global_offset + ori_num_tokens]
+            if num_pads > 0:
+                req_hidden = F.pad(req_hidden, (0, 0, 0, num_pads))
+            pcp_split_hidden_states_list.append(req_hidden[rank_start : rank_start + pcp_tokens])
+            global_offset += ori_num_tokens
+        num_tokens = sum(num_pcp_scheduled_tokens)
+        input_ids = torch.cat(pcp_split_input_ids_list)
+        target_hidden_states = torch.cat(pcp_split_hidden_states_list, dim=0)
+        max_query_len = max(num_pcp_scheduled_tokens)
+        seq_lens = torch.tensor(num_pcp_scheduled_tokens, dtype=torch.int32)
+        cu_num_tokens = torch.tensor(np.insert(np.cumsum(np.array(num_pcp_scheduled_tokens)), 0, 0))
+        return num_tokens, input_ids, target_hidden_states, max_query_len, seq_lens, cu_num_tokens
 
     # update full-graph params for one spec token
     def _update_full_graph_params(self, forward_context, num_tokens, draft_attn_metadatas=None):

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -193,6 +193,18 @@ class BlockTable:
                 positions = torch.from_numpy(positions)
             self._compute_pcp_dcp_slot_mapping(req_indices, positions)
         else:
+            if isinstance(req_indices, torch.Tensor):
+                if req_indices.device.type != "cpu":
+                    raise ValueError(
+                        "Device tensor inputs are only supported for CP draft slot mapping."
+                    )
+                req_indices = req_indices.numpy()
+            if isinstance(positions, torch.Tensor):
+                if positions.device.type != "cpu":
+                    raise ValueError(
+                        "Device tensor inputs are only supported for CP draft slot mapping."
+                    )
+                positions = positions.numpy()
             assert self.kernel_sizes is not None
             assert self.block_size == self.kernel_sizes[0]
             # IMPORTANT: In hybrid mode, positions are in logical block space,
@@ -208,22 +220,13 @@ class BlockTable:
             )
 
             block_offsets = positions % self.block_size
-            if isinstance(req_indices, torch.Tensor) and req_indices.device.type != "cpu":
-                block_numbers = self.block_table.gpu.flatten()[block_table_indices]
-                self.slot_mapping.gpu[: req_indices.shape[0]] = (
-                    block_numbers * self.block_size + block_offsets
-                )
-            else:
-                if isinstance(req_indices, torch.Tensor):
-                    block_table_indices = block_table_indices.numpy()
-                    block_offsets = block_offsets.numpy()
-                block_numbers = self.block_table.np.ravel()[block_table_indices]
-                np.add(
-                    block_numbers * self.block_size,
-                    block_offsets,
-                    out=self.slot_mapping.np[: req_indices.shape[0]],
-                )
-                self.slot_mapping.copy_to_gpu(req_indices.shape[0])
+            block_numbers = self.block_table.np.ravel()[block_table_indices]
+            np.add(
+                block_numbers * self.block_size,
+                block_offsets,
+                out=self.slot_mapping.np[: req_indices.shape[0]],
+            )
+            self.slot_mapping.copy_to_gpu(req_indices.shape[0])
 
     def _compute_pcp_dcp_slot_mapping(
         self,

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -154,6 +154,7 @@ class BlockTable:
             req_indices = torch.repeat_interleave(
                 torch.arange(num_reqs, dtype=torch.int32, device=query_start_loc.device),
                 query_start_loc[1:] - query_start_loc[:-1],
+                output_size=num_tokens,
             )
             self._compute_pcp_dcp_slot_mapping(req_indices, positions)
         else:
@@ -173,7 +174,11 @@ class BlockTable:
                 BLOCK_SIZE=1024,
             )
 
-    def compute_slot_mapping_draft(self, req_indices: np.ndarray, positions: np.ndarray) -> None:
+    def compute_slot_mapping_draft(
+        self,
+        req_indices: np.ndarray | torch.Tensor,
+        positions: np.ndarray | torch.Tensor,
+    ) -> None:
         # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
         # -> [0, 0, K, K, K + 1, K + 1, K + 2, 2 * K, 2 * K, 2 * K + 1]
         # where K is the max_num_blocks_per_req and the block size is 2.
@@ -182,7 +187,11 @@ class BlockTable:
         # block_size.
 
         if self.dcp_world_size * self.pcp_world_size > 1:
-            self._compute_pcp_dcp_slot_mapping(torch.from_numpy(req_indices), torch.from_numpy(positions))
+            if not isinstance(req_indices, torch.Tensor):
+                req_indices = torch.from_numpy(req_indices)
+            if not isinstance(positions, torch.Tensor):
+                positions = torch.from_numpy(positions)
+            self._compute_pcp_dcp_slot_mapping(req_indices, positions)
         else:
             assert self.kernel_sizes is not None
             assert self.block_size == self.kernel_sizes[0]
@@ -198,10 +207,23 @@ class BlockTable:
                 req_indices * self.max_num_blocks_per_req * self.blocks_per_phys_block + logical_block_idx
             )
 
-            block_numbers = self.block_table.np.ravel()[block_table_indices]
             block_offsets = positions % self.block_size
-            np.add(block_numbers * self.block_size, block_offsets, out=self.slot_mapping.np[: req_indices.shape[0]])
-            self.slot_mapping.copy_to_gpu(req_indices.shape[0])
+            if isinstance(req_indices, torch.Tensor) and req_indices.device.type != "cpu":
+                block_numbers = self.block_table.gpu.flatten()[block_table_indices]
+                self.slot_mapping.gpu[: req_indices.shape[0]] = (
+                    block_numbers * self.block_size + block_offsets
+                )
+            else:
+                if isinstance(req_indices, torch.Tensor):
+                    block_table_indices = block_table_indices.numpy()
+                    block_offsets = block_offsets.numpy()
+                block_numbers = self.block_table.np.ravel()[block_table_indices]
+                np.add(
+                    block_numbers * self.block_size,
+                    block_offsets,
+                    out=self.slot_mapping.np[: req_indices.shape[0]],
+                )
+                self.slot_mapping.copy_to_gpu(req_indices.shape[0])
 
     def _compute_pcp_dcp_slot_mapping(
         self,
@@ -407,8 +429,8 @@ class MultiGroupBlockTable:
 
     def compute_slot_mapping_draft(
         self,
-        req_indices: np.ndarray,
-        positions: np.ndarray,
+        req_indices: np.ndarray | torch.Tensor,
+        positions: np.ndarray | torch.Tensor,
         positions_compressed_list: list[np.ndarray] | None = None,
         req_indices_compressed_list: list[np.ndarray] | None = None,
     ) -> None:

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -195,15 +195,11 @@ class BlockTable:
         else:
             if isinstance(req_indices, torch.Tensor):
                 if req_indices.device.type != "cpu":
-                    raise ValueError(
-                        "Device tensor inputs are only supported for CP draft slot mapping."
-                    )
+                    raise ValueError("Device tensor inputs are only supported for CP draft slot mapping.")
                 req_indices = req_indices.numpy()
             if isinstance(positions, torch.Tensor):
                 if positions.device.type != "cpu":
-                    raise ValueError(
-                        "Device tensor inputs are only supported for CP draft slot mapping."
-                    )
+                    raise ValueError("Device tensor inputs are only supported for CP draft slot mapping.")
                 positions = positions.numpy()
             assert self.kernel_sizes is not None
             assert self.block_size == self.kernel_sizes[0]

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1226,8 +1226,34 @@ class NPUModelRunner(GPUModelRunner):
             and prev_req_id_to_index
             and self.pcp_manager.num_decode_reqs > 0
         )
+        device_rebuild_async_inputs = (
+            should_rebuild_async_inputs
+            and prev_positions_gpu is not None
+            and not with_prefill
+            and not self.enable_prompt_embeds
+            and not self.input_batch.req_prompt_embeds
+            and not self.supports_mm_inputs
+        )
         base_num_computed_tokens_np = None
-        if should_rebuild_async_inputs:
+        if device_rebuild_async_inputs:
+            if self.pcp_size > 1:
+                position_offsets_gpu = torch.from_numpy(
+                    position_pcp[:total_num_scheduled_tokens]
+                ).pin_memory().to(
+                    dtype=torch.int64,
+                    device=self.device,
+                    non_blocking=True,
+                )
+            else:
+                position_offsets_gpu = self.query_pos.gpu[
+                    :total_num_scheduled_tokens
+                ].to(torch.int64)
+            positions_gpu = (
+                self.num_computed_tokens[req_indices_gpu].to(torch.int64)
+                + position_offsets_gpu
+            )
+            self.positions[:total_num_scheduled_tokens].copy_(positions_gpu)
+        elif should_rebuild_async_inputs:
             # Rebuild CPU-side inputs from async-corrected decode lengths. The
             # valid counts were already copied on a side stream in the previous
             # step, so avoid pulling num_computed_tokens back from the device.
@@ -1262,7 +1288,9 @@ class NPUModelRunner(GPUModelRunner):
                 base_num_computed_tokens_np,
             )
 
-        if self.pcp_size > 1 or should_rebuild_async_inputs:
+        if device_rebuild_async_inputs:
+            pass
+        elif self.pcp_size > 1 or should_rebuild_async_inputs:
             # PCP and async rebuild both compute the correct positions on CPU.
             # Copy positions_np to GPU so input_ids and positions stay aligned.
 
@@ -1288,47 +1316,128 @@ class NPUModelRunner(GPUModelRunner):
             cu_num_tokens_full = self.pcp_manager.async_rebuild_cu_num_tokens_full
             num_tokens_full = self.pcp_manager.async_rebuild_num_tokens_full
 
-            assert base_num_computed_tokens_np is not None
-            base = base_num_computed_tokens_np
-
-            token_counts = np.diff(np.concatenate(([0], cu_num_tokens_full)))
-            token_starts = np.repeat(cu_num_tokens_full - token_counts, token_counts)
-            query_pos = self.arange_np[:num_tokens_full] - token_starts
-
-            positions_full = np.empty(num_tokens_full, dtype=np.int64)
-            np.add(base[req_indices_full], query_pos, out=positions_full)
-
-            if self.pcp_size > 1:
-                pre_pcp_query_start_loc = torch.zeros(
-                    num_reqs + 1,
-                    dtype=torch.int32,
+            if device_rebuild_async_inputs:
+                query_start_loc_full = (
+                    self.pcp_manager.query_start_loc_pcp_full.gpu[: num_reqs + 1]
+                )
+                query_lens_full = (
+                    query_start_loc_full[1:] - query_start_loc_full[:-1]
+                ).to(torch.int64)
+                req_indices_full_gpu = torch.repeat_interleave(
+                    self.pcp_manager.pcp_req_offsets[:num_reqs],
+                    query_lens_full,
+                    output_size=num_tokens_full,
+                )
+                token_offsets_full = torch.arange(
+                    num_tokens_full,
+                    dtype=torch.int64,
                     device=self.device,
                 )
-                pre_pcp_query_start_loc[1 : num_reqs + 1] = torch.from_numpy(
-                    cu_num_tokens_full
-                ).to(dtype=torch.int32, device=self.device)
-
-                self.input_batch.block_table.compute_slot_mapping(
-                    num_reqs,
-                    pre_pcp_query_start_loc,
-                    torch.from_numpy(positions_full).to(self.device),
+                positions_full_gpu = (
+                    self.num_computed_tokens[req_indices_full_gpu].to(torch.int64)
+                    + token_offsets_full
+                    - query_start_loc_full[req_indices_full_gpu].to(torch.int64)
                 )
 
-            self.pcp_manager.generate_pcp_mtp_input(
-                num_tokens_full,
-                scheduler_output.num_scheduled_tokens,
-                with_prefill,
-                self.input_batch,
-                self.arange_np,
-                req_indices_full,
-                positions_full,
-                cu_num_tokens_full,
-                self._draft_token_ids,  # type: ignore[has-type]
-                scheduler_output,
-                self.num_spec_tokens,
-                precomputed_positions_np=positions_full,
-                prev_positions=prev_positions_gpu,
-            )
+                if self.pcp_size > 1:
+                    self.input_batch.block_table.compute_slot_mapping(
+                        num_reqs,
+                        query_start_loc_full,
+                        positions_full_gpu,
+                    )
+
+                extra_tokens = self.pcp_manager.decode_threshold - 2
+                if extra_tokens > 0 and not with_prefill:
+                    mtp_lens = query_lens_full + extra_tokens
+                    num_tokens_mtp = num_tokens_full + num_reqs * extra_tokens
+                    req_indices_mtp = torch.repeat_interleave(
+                        self.pcp_manager.pcp_req_offsets[:num_reqs],
+                        mtp_lens,
+                        output_size=num_tokens_mtp,
+                    )
+                    mtp_start_loc = torch.empty(
+                        num_reqs + 1,
+                        dtype=torch.int64,
+                        device=self.device,
+                    )
+                    mtp_start_loc[0].fill_(0)
+                    mtp_start_loc[1:] = torch.cumsum(mtp_lens, dim=0)
+                    mtp_offsets = torch.arange(
+                        num_tokens_mtp,
+                        dtype=torch.int64,
+                        device=self.device,
+                    )
+                    positions_mtp = (
+                        self.num_computed_tokens[req_indices_mtp].to(torch.int64)
+                        + mtp_offsets
+                        - mtp_start_loc[req_indices_mtp]
+                    )
+                    self.input_batch.block_table.compute_slot_mapping_draft(
+                        req_indices_mtp,
+                        positions_mtp,
+                    )
+                    mtp_slot_ori = (
+                        self.input_batch.block_table.block_tables[0]
+                        .slot_mapping.gpu[:num_tokens_mtp]
+                    )
+                    num_tokens_mtp_pad = num_tokens_mtp * self.pcp_size
+                    if (
+                        self.pcp_manager.mtp_slot_pad is None
+                        or self.pcp_manager.mtp_slot_pad.numel()
+                        < num_tokens_mtp_pad
+                    ):
+                        self.pcp_manager.mtp_slot_pad = torch.empty(
+                            num_tokens_mtp_pad,
+                            dtype=torch.int32,
+                            device=self.device,
+                        )
+                    mtp_slot_pad = self.pcp_manager.mtp_slot_pad[
+                        :num_tokens_mtp_pad
+                    ]
+                    mtp_slot_pad.fill_(-1)
+                    mtp_slot_pad[:: self.pcp_size].copy_(mtp_slot_ori)
+            else:
+                assert base_num_computed_tokens_np is not None
+                base = base_num_computed_tokens_np
+
+                token_counts = np.diff(np.concatenate(([0], cu_num_tokens_full)))
+                token_starts = np.repeat(cu_num_tokens_full - token_counts, token_counts)
+                query_pos = self.arange_np[:num_tokens_full] - token_starts
+
+                positions_full = np.empty(num_tokens_full, dtype=np.int64)
+                np.add(base[req_indices_full], query_pos, out=positions_full)
+
+                if self.pcp_size > 1:
+                    pre_pcp_query_start_loc = torch.zeros(
+                        num_reqs + 1,
+                        dtype=torch.int32,
+                        device=self.device,
+                    )
+                    pre_pcp_query_start_loc[1 : num_reqs + 1] = torch.from_numpy(
+                        cu_num_tokens_full
+                    ).to(dtype=torch.int32, device=self.device)
+
+                    self.input_batch.block_table.compute_slot_mapping(
+                        num_reqs,
+                        pre_pcp_query_start_loc,
+                        torch.from_numpy(positions_full).to(self.device),
+                    )
+
+                self.pcp_manager.generate_pcp_mtp_input(
+                    num_tokens_full,
+                    scheduler_output.num_scheduled_tokens,
+                    with_prefill,
+                    self.input_batch,
+                    self.arange_np,
+                    req_indices_full,
+                    positions_full,
+                    cu_num_tokens_full,
+                    self._draft_token_ids,  # type: ignore[has-type]
+                    scheduler_output,
+                    self.num_spec_tokens,
+                    precomputed_positions_np=positions_full,
+                    prev_positions=prev_positions_gpu,
+                )
 
         # In async spec decode mode, optimistic_seq_lens_cpu assumes all
         # tokens from the previous speculative step were accepted. Correct it

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -167,7 +167,7 @@ from vllm_ascend.utils import (
     vllm_version_is,
 )
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
-from vllm_ascend.worker.pcp_utils import PCPManager
+from vllm_ascend.worker.pcp_utils import PCPAsyncSpecDecodeRebuildResult, PCPManager
 from vllm_ascend.worker.utils import AscendKVBlockZeroer
 
 from vllm_ascend.ascend_forward_context import (  # isort: skip
@@ -1220,39 +1220,46 @@ class NPUModelRunner(GPUModelRunner):
         self.num_scheduled_tokens.copy_to_gpu(num_reqs)
         num_scheduled_tokens_gpu = self.num_scheduled_tokens.gpu[:num_reqs]
 
-        cp_async_rebuild = self.pcp_manager.rebuild_async_spec_decode_inputs(
-            use_async_spec_decode=self.use_async_spec_decode,
-            valid_sampled_token_count_gpu=valid_sampled_token_count_gpu,
-            prev_req_id_to_index=prev_req_id_to_index,
-            prev_positions_gpu=prev_positions_gpu,
-            with_prefill=with_prefill,
-            enable_prompt_embeds=self.enable_prompt_embeds,
-            has_req_prompt_embeds=bool(self.input_batch.req_prompt_embeds),
-            supports_mm_inputs=self.supports_mm_inputs,
-            num_reqs=num_reqs,
-            total_num_scheduled_tokens=total_num_scheduled_tokens,
-            req_indices=req_indices,
-            req_indices_gpu=req_indices_gpu,
-            position_pcp=position_pcp if self.pcp_size > 1 else None,
-            query_pos_gpu=self.query_pos.gpu,
-            query_pos_np=self.query_pos.np,
-            positions=self.positions,
-            positions_np=positions_np,
-            num_computed_tokens=self.num_computed_tokens,
-            num_computed_tokens_cpu=self.input_batch.num_computed_tokens_cpu,
-            prev_positions_np=self.prev_positions.np,
-            prev_num_draft_tokens_np=self.prev_num_draft_tokens.np,
-            valid_sampled_token_count_event=self.valid_sampled_token_count_event,
-            valid_sampled_token_count_cpu=self.valid_sampled_token_count_cpu,
-            input_batch=self.input_batch,
-            input_ids=self.input_ids,
-            scheduler_output=scheduler_output,
-            arange_np=self.arange_np,
-            cu_num_tokens=cu_num_tokens,
-            draft_token_ids=self._draft_token_ids,  # type: ignore[has-type]
-            num_spec_tokens=self.num_spec_tokens,
-            prepare_input_ids=self._prepare_input_ids,
-        )
+        pcp_manager = getattr(self, "pcp_manager", None)
+        if pcp_manager is not None:
+            cp_async_rebuild = pcp_manager.rebuild_async_spec_decode_inputs(
+                use_async_spec_decode=self.use_async_spec_decode,
+                valid_sampled_token_count_gpu=valid_sampled_token_count_gpu,
+                prev_req_id_to_index=prev_req_id_to_index,
+                prev_positions_gpu=prev_positions_gpu,
+                with_prefill=with_prefill,
+                enable_prompt_embeds=self.enable_prompt_embeds,
+                has_req_prompt_embeds=bool(self.input_batch.req_prompt_embeds),
+                supports_mm_inputs=self.supports_mm_inputs,
+                num_reqs=num_reqs,
+                total_num_scheduled_tokens=total_num_scheduled_tokens,
+                req_indices=req_indices,
+                req_indices_gpu=req_indices_gpu,
+                position_pcp=position_pcp if self.pcp_size > 1 else None,
+                query_pos_gpu=self.query_pos.gpu,
+                query_pos_np=self.query_pos.np,
+                positions=self.positions,
+                positions_np=positions_np,
+                num_computed_tokens=self.num_computed_tokens,
+                num_computed_tokens_cpu=self.input_batch.num_computed_tokens_cpu,
+                prev_positions_np=self.prev_positions.np,
+                prev_num_draft_tokens_np=self.prev_num_draft_tokens.np,
+                valid_sampled_token_count_event=self.valid_sampled_token_count_event,
+                valid_sampled_token_count_cpu=self.valid_sampled_token_count_cpu,
+                input_batch=self.input_batch,
+                input_ids=self.input_ids,
+                scheduler_output=scheduler_output,
+                arange_np=self.arange_np,
+                cu_num_tokens=cu_num_tokens,
+                draft_token_ids=self._draft_token_ids,  # type: ignore[has-type]
+                num_spec_tokens=self.num_spec_tokens,
+                prepare_input_ids=self._prepare_input_ids,
+            )
+        else:
+            cp_async_rebuild = PCPAsyncSpecDecodeRebuildResult(
+                rebuilt=False,
+                positions_ready_on_device=False,
+            )
 
         if cp_async_rebuild.positions_ready_on_device:
             pass

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -588,6 +588,7 @@ class NPUModelRunner(GPUModelRunner):
         self.query_lens: torch.Tensor | None = None
         self.cpu_slot_mapping = None
         self.sampling_done_event: torch.npu.Event | None = None
+        self.valid_sampled_token_count_gpu: torch.Tensor | None = None
 
         # self.cudagraph_batch_sizes sorts in ascending order.
         if (
@@ -1183,13 +1184,14 @@ class NPUModelRunner(GPUModelRunner):
         # CPU values are optimistic (all drafts accepted). The kernel
         # corrects on GPU using the previous step's
         # valid_sampled_token_count_gpu. Otherwise, just copy from CPU.
+        valid_sampled_token_count_gpu = self.valid_sampled_token_count_gpu
         if self.use_async_spec_decode:
             computed_token_tensor_cpu = self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs].to(
                 device=self.device, non_blocking=True
             )
         if (
             self.use_async_spec_decode
-            and self.valid_sampled_token_count_gpu is not None # type: ignore[has-type]
+            and valid_sampled_token_count_gpu is not None
             and prev_req_id_to_index
         ):
             if prev_positions_gpu is None:
@@ -1199,7 +1201,7 @@ class NPUModelRunner(GPUModelRunner):
                 self.num_computed_tokens,
                 self.num_accepted_tokens.gpu[:num_reqs],
                 self.prev_positions.gpu[:num_reqs],
-                self.valid_sampled_token_count_gpu, # type: ignore[has-type]
+                valid_sampled_token_count_gpu,
                 self.prev_num_draft_tokens.gpu,
                 computed_token_tensor_cpu,
             )
@@ -1220,7 +1222,7 @@ class NPUModelRunner(GPUModelRunner):
 
         cp_async_rebuild = self.pcp_manager.rebuild_async_spec_decode_inputs(
             use_async_spec_decode=self.use_async_spec_decode,
-            valid_sampled_token_count_gpu=self.valid_sampled_token_count_gpu,
+            valid_sampled_token_count_gpu=valid_sampled_token_count_gpu,
             prev_req_id_to_index=prev_req_id_to_index,
             prev_positions_gpu=prev_positions_gpu,
             with_prefill=with_prefill,
@@ -1283,7 +1285,7 @@ class NPUModelRunner(GPUModelRunner):
         # Mirrors update_num_computed_tokens_for_batch_change on the GPU side.
         async_spec_decode_active = (
             self.use_async_spec_decode
-            and self.valid_sampled_token_count_gpu is not None  # type: ignore[has-type]
+            and valid_sampled_token_count_gpu is not None
             and prev_req_id_to_index
         )
         if self._needs_seq_lens_cpu_sync and async_spec_decode_active:
@@ -2479,7 +2481,7 @@ class NPUModelRunner(GPUModelRunner):
             assert self.sampling_done_event is not None
             self.sampling_done_event.record()
 
-        self.valid_sampled_token_count_gpu: torch.Tensor | None = None # type: ignore[no-redef]
+        self.valid_sampled_token_count_gpu = None
 
         def propose_draft_token_ids(sampled_token_ids):
             assert spec_decode_common_attn_metadata is not None

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1218,79 +1218,43 @@ class NPUModelRunner(GPUModelRunner):
         self.num_scheduled_tokens.copy_to_gpu(num_reqs)
         num_scheduled_tokens_gpu = self.num_scheduled_tokens.gpu[:num_reqs]
 
-        # Rebuild CP/spec inputs after async accepted-token correction.
-        should_rebuild_async_inputs = (
-            self.use_cp
-            and self.use_async_spec_decode
-            and self.valid_sampled_token_count_gpu is not None # type: ignore[has-type]
-            and prev_req_id_to_index
-            and self.pcp_manager.num_decode_reqs > 0
+        cp_async_rebuild = self.pcp_manager.rebuild_async_spec_decode_inputs(
+            use_async_spec_decode=self.use_async_spec_decode,
+            valid_sampled_token_count_gpu=self.valid_sampled_token_count_gpu,
+            prev_req_id_to_index=prev_req_id_to_index,
+            prev_positions_gpu=prev_positions_gpu,
+            with_prefill=with_prefill,
+            enable_prompt_embeds=self.enable_prompt_embeds,
+            has_req_prompt_embeds=bool(self.input_batch.req_prompt_embeds),
+            supports_mm_inputs=self.supports_mm_inputs,
+            num_reqs=num_reqs,
+            total_num_scheduled_tokens=total_num_scheduled_tokens,
+            req_indices=req_indices,
+            req_indices_gpu=req_indices_gpu,
+            position_pcp=position_pcp if self.pcp_size > 1 else None,
+            query_pos_gpu=self.query_pos.gpu,
+            query_pos_np=self.query_pos.np,
+            positions=self.positions,
+            positions_np=positions_np,
+            num_computed_tokens=self.num_computed_tokens,
+            num_computed_tokens_cpu=self.input_batch.num_computed_tokens_cpu,
+            prev_positions_np=self.prev_positions.np,
+            prev_num_draft_tokens_np=self.prev_num_draft_tokens.np,
+            valid_sampled_token_count_event=self.valid_sampled_token_count_event,
+            valid_sampled_token_count_cpu=self.valid_sampled_token_count_cpu,
+            input_batch=self.input_batch,
+            input_ids=self.input_ids,
+            scheduler_output=scheduler_output,
+            arange_np=self.arange_np,
+            cu_num_tokens=cu_num_tokens,
+            draft_token_ids=self._draft_token_ids,  # type: ignore[has-type]
+            num_spec_tokens=self.num_spec_tokens,
+            prepare_input_ids=self._prepare_input_ids,
         )
-        device_rebuild_async_inputs = (
-            should_rebuild_async_inputs
-            and prev_positions_gpu is not None
-            and not with_prefill
-            and not self.enable_prompt_embeds
-            and not self.input_batch.req_prompt_embeds
-            and not self.supports_mm_inputs
-        )
-        base_num_computed_tokens_np = None
-        if device_rebuild_async_inputs:
-            if self.pcp_size > 1:
-                position_offsets_gpu = torch.from_numpy(
-                    position_pcp[:total_num_scheduled_tokens]
-                ).pin_memory().to(
-                    dtype=torch.int64,
-                    device=self.device,
-                    non_blocking=True,
-                )
-            else:
-                position_offsets_gpu = self.query_pos.gpu[
-                    :total_num_scheduled_tokens
-                ].to(torch.int64)
-            positions_gpu = (
-                self.num_computed_tokens[req_indices_gpu].to(torch.int64)
-                + position_offsets_gpu
-            )
-            self.positions[:total_num_scheduled_tokens].copy_(positions_gpu)
-        elif should_rebuild_async_inputs:
-            # Rebuild CPU-side inputs from async-corrected decode lengths. The
-            # valid counts were already copied on a side stream in the previous
-            # step, so avoid pulling num_computed_tokens back from the device.
-            base_num_computed_tokens_np = (
-                self.input_batch.num_computed_tokens_cpu[:num_reqs].copy()
-            )
-            assert self.valid_sampled_token_count_event is not None
-            assert self.valid_sampled_token_count_cpu is not None
-            self.valid_sampled_token_count_event.synchronize()
-            correct_optimistic_seq_lens_cpu(
-                base_num_computed_tokens_np,
-                self.prev_positions.np,
-                self.prev_num_draft_tokens.np,
-                self.valid_sampled_token_count_cpu.numpy(),
-                num_reqs,
-            )
 
-            position_offsets = (
-                position_pcp
-                if self.pcp_size > 1
-                else self.query_pos.np
-            )
-
-            self._rebuild_input_ids_with_corrected_positions(
-                scheduler_output,
-                num_reqs,
-                total_num_scheduled_tokens,
-                req_indices,
-                position_offsets,
-                positions_np,
-                cu_num_tokens,
-                base_num_computed_tokens_np,
-            )
-
-        if device_rebuild_async_inputs:
+        if cp_async_rebuild.positions_ready_on_device:
             pass
-        elif self.pcp_size > 1 or should_rebuild_async_inputs:
+        elif self.pcp_size > 1 or cp_async_rebuild.rebuilt:
             # PCP and async rebuild both compute the correct positions on CPU.
             # Copy positions_np to GPU so input_ids and positions stay aligned.
 
@@ -1310,134 +1274,6 @@ class NPUModelRunner(GPUModelRunner):
             self.num_computed_tokens[:num_reqs] + num_scheduled_tokens_gpu
         )
         self.seq_lens[num_reqs:].fill_(0)
-
-        if should_rebuild_async_inputs:
-            req_indices_full = self.pcp_manager.async_rebuild_req_indices_full
-            cu_num_tokens_full = self.pcp_manager.async_rebuild_cu_num_tokens_full
-            num_tokens_full = self.pcp_manager.async_rebuild_num_tokens_full
-
-            if device_rebuild_async_inputs:
-                query_start_loc_full = (
-                    self.pcp_manager.query_start_loc_pcp_full.gpu[: num_reqs + 1]
-                )
-                query_lens_full = (
-                    query_start_loc_full[1:] - query_start_loc_full[:-1]
-                ).to(torch.int64)
-                req_indices_full_gpu = torch.repeat_interleave(
-                    self.pcp_manager.pcp_req_offsets[:num_reqs],
-                    query_lens_full,
-                    output_size=num_tokens_full,
-                )
-                token_offsets_full = torch.arange(
-                    num_tokens_full,
-                    dtype=torch.int64,
-                    device=self.device,
-                )
-                positions_full_gpu = (
-                    self.num_computed_tokens[req_indices_full_gpu].to(torch.int64)
-                    + token_offsets_full
-                    - query_start_loc_full[req_indices_full_gpu].to(torch.int64)
-                )
-
-                if self.pcp_size > 1:
-                    self.input_batch.block_table.compute_slot_mapping(
-                        num_reqs,
-                        query_start_loc_full,
-                        positions_full_gpu,
-                    )
-
-                extra_tokens = self.pcp_manager.decode_threshold - 2
-                if extra_tokens > 0 and not with_prefill:
-                    mtp_lens = query_lens_full + extra_tokens
-                    num_tokens_mtp = num_tokens_full + num_reqs * extra_tokens
-                    req_indices_mtp = torch.repeat_interleave(
-                        self.pcp_manager.pcp_req_offsets[:num_reqs],
-                        mtp_lens,
-                        output_size=num_tokens_mtp,
-                    )
-                    mtp_start_loc = torch.empty(
-                        num_reqs + 1,
-                        dtype=torch.int64,
-                        device=self.device,
-                    )
-                    mtp_start_loc[0].fill_(0)
-                    mtp_start_loc[1:] = torch.cumsum(mtp_lens, dim=0)
-                    mtp_offsets = torch.arange(
-                        num_tokens_mtp,
-                        dtype=torch.int64,
-                        device=self.device,
-                    )
-                    positions_mtp = (
-                        self.num_computed_tokens[req_indices_mtp].to(torch.int64)
-                        + mtp_offsets
-                        - mtp_start_loc[req_indices_mtp]
-                    )
-                    self.input_batch.block_table.compute_slot_mapping_draft(
-                        req_indices_mtp,
-                        positions_mtp,
-                    )
-                    mtp_slot_ori = (
-                        self.input_batch.block_table.block_tables[0]
-                        .slot_mapping.gpu[:num_tokens_mtp]
-                    )
-                    num_tokens_mtp_pad = num_tokens_mtp * self.pcp_size
-                    if (
-                        self.pcp_manager.mtp_slot_pad is None
-                        or self.pcp_manager.mtp_slot_pad.numel()
-                        < num_tokens_mtp_pad
-                    ):
-                        self.pcp_manager.mtp_slot_pad = torch.empty(
-                            num_tokens_mtp_pad,
-                            dtype=torch.int32,
-                            device=self.device,
-                        )
-                    mtp_slot_pad = self.pcp_manager.mtp_slot_pad[
-                        :num_tokens_mtp_pad
-                    ]
-                    mtp_slot_pad.fill_(-1)
-                    mtp_slot_pad[:: self.pcp_size].copy_(mtp_slot_ori)
-            else:
-                assert base_num_computed_tokens_np is not None
-                base = base_num_computed_tokens_np
-
-                token_counts = np.diff(np.concatenate(([0], cu_num_tokens_full)))
-                token_starts = np.repeat(cu_num_tokens_full - token_counts, token_counts)
-                query_pos = self.arange_np[:num_tokens_full] - token_starts
-
-                positions_full = np.empty(num_tokens_full, dtype=np.int64)
-                np.add(base[req_indices_full], query_pos, out=positions_full)
-
-                if self.pcp_size > 1:
-                    pre_pcp_query_start_loc = torch.zeros(
-                        num_reqs + 1,
-                        dtype=torch.int32,
-                        device=self.device,
-                    )
-                    pre_pcp_query_start_loc[1 : num_reqs + 1] = torch.from_numpy(
-                        cu_num_tokens_full
-                    ).to(dtype=torch.int32, device=self.device)
-
-                    self.input_batch.block_table.compute_slot_mapping(
-                        num_reqs,
-                        pre_pcp_query_start_loc,
-                        torch.from_numpy(positions_full).to(self.device),
-                    )
-
-                self.pcp_manager.generate_pcp_mtp_input(
-                    num_tokens_full,
-                    scheduler_output.num_scheduled_tokens,
-                    with_prefill,
-                    self.input_batch,
-                    self.arange_np,
-                    req_indices_full,
-                    positions_full,
-                    cu_num_tokens_full,
-                    self._draft_token_ids,  # type: ignore[has-type]
-                    scheduler_output,
-                    self.num_spec_tokens,
-                    precomputed_positions_np=positions_full,
-                    prev_positions=prev_positions_gpu,
-                )
 
         # In async spec decode mode, optimistic_seq_lens_cpu assumes all
         # tokens from the previous speculative step were accepted. Correct it
@@ -1547,45 +1383,6 @@ class NPUModelRunner(GPUModelRunner):
             logits_indices,
             spec_decode_metadata,
             total_num_scheduled_tokens,
-        )
-
-    def _rebuild_input_ids_with_corrected_positions(
-        self,
-        scheduler_output,
-        num_reqs,
-        total_num_scheduled_tokens,
-        req_indices,
-        position_offsets,
-        positions_np,
-        cu_num_tokens,
-        base_num_computed_tokens_np,
-    ) -> None:
-        # base_num_computed_tokens_np contains per-request starts:
-        # decode requests use async-corrected lengths, prefill requests use CPU lengths.
-        base = base_num_computed_tokens_np
-        np.add(
-            base[req_indices],
-            position_offsets[:total_num_scheduled_tokens],
-            out=positions_np,
-        )
-
-        token_indices = (
-            positions_np[:total_num_scheduled_tokens]
-            + req_indices * self.input_batch.token_ids_cpu.shape[1]
-        )
-        torch.index_select(
-            self.input_batch.token_ids_cpu_tensor.flatten(),
-            0,
-            torch.from_numpy(token_indices),
-            out=self.input_ids.cpu[:total_num_scheduled_tokens],
-        )
-
-        self.input_ids.copy_to_gpu(total_num_scheduled_tokens)
-        self._prepare_input_ids(
-            scheduler_output,
-            num_reqs,
-            total_num_scheduled_tokens,
-            cu_num_tokens,
         )
 
     def _preprocess(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -947,6 +947,19 @@ class NPUModelRunner(GPUModelRunner):
                 self.input_batch.num_prompt_tokens,
             )
 
+        # Build prev_positions before PCP prepares full-layout spec inputs so
+        # PCP can repair async sampled/draft ids with device-side index math.
+        prev_req_id_to_index = self.input_batch.prev_req_id_to_index
+        self._compute_prev_positions(num_reqs)
+        prev_positions_gpu = None
+        if (
+            self.use_async_scheduling
+            and self.input_batch.prev_sampled_token_ids is not None
+            and prev_req_id_to_index
+        ):
+            self.prev_positions.copy_to_gpu(num_reqs)
+            prev_positions_gpu = self.prev_positions.gpu[:num_reqs]
+
         # for pcp, prefill mtp should use origin scheduleroutput ,
         if self.speculative_config and self.use_cp:
             self.pcp_manager.generate_pcp_mtp_input(
@@ -961,6 +974,7 @@ class NPUModelRunner(GPUModelRunner):
                 self._draft_token_ids,  # type: ignore[has-type]
                 scheduler_output,
                 self.num_spec_tokens,
+                prev_positions=prev_positions_gpu,
             )
 
         if self.pcp_size > 1:
@@ -1080,11 +1094,6 @@ class NPUModelRunner(GPUModelRunner):
         )
         self.optimistic_seq_lens_cpu[num_reqs:].fill_(0)
 
-        # Build prev_positions mapping: current pos -> prev pos (-1 if new).
-        # Used for gathering from previous iteration's GPU tensors.
-        prev_req_id_to_index = self.input_batch.prev_req_id_to_index
-        self._compute_prev_positions(num_reqs)
-
         # Fill unused with -1. Needed for reshape_and_cache in attention_cp
         self.query_start_loc.gpu[num_reqs + 1 :].fill_(-1)
 
@@ -1183,7 +1192,8 @@ class NPUModelRunner(GPUModelRunner):
             and self.valid_sampled_token_count_gpu is not None # type: ignore[has-type]
             and prev_req_id_to_index
         ):
-            self.prev_positions.copy_to_gpu(num_reqs)
+            if prev_positions_gpu is None:
+                self.prev_positions.copy_to_gpu(num_reqs)
             self.prev_num_draft_tokens.copy_to_gpu()
             update_num_computed_tokens_for_batch_change(
                 self.num_computed_tokens,
@@ -1320,6 +1330,7 @@ class NPUModelRunner(GPUModelRunner):
                 scheduler_output,
                 self.num_spec_tokens,
                 precomputed_positions_np=positions_full,
+                prev_positions=prev_positions_gpu,
             )
 
         # In async spec decode mode, optimistic_seq_lens_cpu assumes all

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1219,33 +1219,30 @@ class NPUModelRunner(GPUModelRunner):
         num_scheduled_tokens_gpu = self.num_scheduled_tokens.gpu[:num_reqs]
 
         # Rebuild CP/spec inputs after async accepted-token correction.
-        has_decode_req = bool(np.any(
-            self.input_batch.num_computed_tokens_cpu[:num_reqs]
-            >= self.input_batch.num_prompt_tokens[:num_reqs]
-        ))
         should_rebuild_async_inputs = (
             self.use_cp
             and self.use_async_spec_decode
             and self.valid_sampled_token_count_gpu is not None # type: ignore[has-type]
             and prev_req_id_to_index
-            and has_decode_req
+            and self.pcp_manager.num_decode_reqs > 0
         )
         base_num_computed_tokens_np = None
         if should_rebuild_async_inputs:
-            # Async spec decode corrects num_computed_tokens on device.
-            # Rebuild CPU-side inputs from the corrected positions.
-            corrected_num_computed_tokens_np = (
-                self.num_computed_tokens[:num_reqs].cpu().numpy()
-            )
-
-            # Mixed batch: only decode requests use async-corrected lengths.
-            # Prefill requests keep CPU-side prompt progress.
+            # Rebuild CPU-side inputs from async-corrected decode lengths. The
+            # valid counts were already copied on a side stream in the previous
+            # step, so avoid pulling num_computed_tokens back from the device.
             base_num_computed_tokens_np = (
                 self.input_batch.num_computed_tokens_cpu[:num_reqs].copy()
             )
-            num_decode_reqs = self.pcp_manager.num_decode_reqs
-            base_num_computed_tokens_np[:num_decode_reqs] = (
-                corrected_num_computed_tokens_np[:num_decode_reqs]
+            assert self.valid_sampled_token_count_event is not None
+            assert self.valid_sampled_token_count_cpu is not None
+            self.valid_sampled_token_count_event.synchronize()
+            correct_optimistic_seq_lens_cpu(
+                base_num_computed_tokens_np,
+                self.prev_positions.np,
+                self.prev_num_draft_tokens.np,
+                self.valid_sampled_token_count_cpu.numpy(),
+                num_reqs,
             )
 
             position_offsets = (

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -30,6 +30,7 @@ import torch.nn.functional as F
 from vllm.config import VllmConfig
 from vllm.logger import logger
 from vllm.utils import length_from_prompt_token_ids_or_embeds
+from vllm.utils.math_utils import cdiv
 from vllm.v1.utils import CpuGpuBuffer
 
 from vllm_ascend.utils import is_pd_decode_recompute_scheduler_enabled
@@ -47,6 +48,18 @@ class PCPSpecDecodeMTPInputs:
     seq_lens_cpu: torch.Tensor | None
     slot_indices: torch.Tensor
     slot_mapping: torch.Tensor
+
+
+@dataclass(frozen=True)
+class PCPSpecDecodeFirstPassInputs:
+    """PCP-adjusted inputs for the first speculative draft pass."""
+
+    num_tokens: int
+    input_ids: torch.Tensor
+    target_positions: torch.Tensor
+    target_hidden_states: torch.Tensor
+    token_indices_to_sample: torch.Tensor
+    long_seq_args: tuple[torch.Tensor | None, torch.Tensor | None] | None
 
 
 class PCPManager:
@@ -1032,6 +1045,239 @@ class PCPManager:
         )
         decode_hidden_state_indices = decode_padded_starts_per_token + decode_offsets
         return target_hidden_states_d_padded[decode_hidden_state_indices]
+
+    def prepare_spec_decode_first_pass_inputs(
+        self,
+        input_ids: torch.Tensor,
+        target_positions: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        token_indices_to_sample: torch.Tensor,
+        common_attn_metadata: Any,
+        long_seq_metadata: Any | None,
+        req_scheduled_tokens: dict[str, int] | None,
+        req_ids: list[str],
+        logits_indices: torch.Tensor,
+        num_tokens: int,
+        num_prefill_reqs: int,
+        num_decode_reqs: int,
+        uses_mrope: bool,
+    ) -> PCPSpecDecodeFirstPassInputs:
+        """Prepare CP-adjusted proposer inputs for the first draft pass."""
+        long_seq_args: tuple[torch.Tensor | None, torch.Tensor | None] | None = None
+        if self.pcp_world_size * self.dcp_world_size <= 1:
+            return PCPSpecDecodeFirstPassInputs(
+                num_tokens=num_tokens,
+                input_ids=input_ids,
+                target_positions=target_positions,
+                target_hidden_states=target_hidden_states,
+                token_indices_to_sample=token_indices_to_sample,
+                long_seq_args=long_seq_args,
+            )
+
+        assert long_seq_metadata is not None
+        common_attn_metadata.prefill_context_parallel_metadata = long_seq_metadata
+        ori_token_indices_to_sample = token_indices_to_sample.clone()
+        query_lens_d = self.query_lens_pcp_full.cpu[:num_decode_reqs]
+        long_seq_args = (query_lens_d, ori_token_indices_to_sample)
+
+        if self.pcp_world_size <= 1:
+            return PCPSpecDecodeFirstPassInputs(
+                num_tokens=num_tokens,
+                input_ids=input_ids,
+                target_positions=target_positions,
+                target_hidden_states=target_hidden_states,
+                token_indices_to_sample=token_indices_to_sample,
+                long_seq_args=long_seq_args,
+            )
+
+        num_tokens_d = self.num_decode_tokens
+        num_tokens_d_padded = num_tokens_d * self.pcp_world_size
+        input_ids_d = input_ids[:num_tokens_d]
+        input_ids_p = input_ids[num_tokens_d:num_tokens]
+        target_hidden_states_d_padded = target_hidden_states[:num_tokens_d_padded]
+        if num_tokens_d:
+            target_hidden_states_d = self.get_spec_decode_decode_hidden_states(
+                target_hidden_states_d_padded,
+                num_decode_reqs,
+                num_tokens_d,
+            )
+        else:
+            target_hidden_states_d = target_hidden_states_d_padded
+        target_hidden_states_p = target_hidden_states[num_tokens_d_padded:]
+
+        req_scheduled_tokens_p: dict[str, int] = {}
+        if num_prefill_reqs:
+            assert req_scheduled_tokens is not None
+            num_reqs = num_decode_reqs + num_prefill_reqs
+            for i, req_id in enumerate(req_ids[:num_reqs]):
+                if i >= num_decode_reqs:
+                    req_scheduled_tokens_p[req_id] = req_scheduled_tokens[req_id]
+
+        (
+            num_tokens_p,
+            input_ids_p,
+            target_hidden_states_p,
+            max_query_len_p,
+            seq_lens_p,
+            cu_num_tokens_p,
+        ) = self._split_spec_decode_pcp_prefill_input(
+            req_scheduled_tokens_p,
+            input_ids_p,
+            target_hidden_states_p,
+        )
+        num_tokens = num_tokens_d + num_tokens_p
+        if uses_mrope:
+            target_positions = target_positions[:, :num_tokens]
+        else:
+            target_positions = target_positions[:num_tokens]
+        input_ids = torch.cat([input_ids_d, input_ids_p], dim=0)
+        target_hidden_states = torch.cat([target_hidden_states_d, target_hidden_states_p], dim=0)
+
+        if num_decode_reqs:
+            token_indices_to_sample[:num_decode_reqs] = logits_indices[
+                token_indices_to_sample[:num_decode_reqs]
+            ]
+        if num_prefill_reqs:
+            token_indices_to_sample[-num_prefill_reqs:] = logits_indices[-num_prefill_reqs:]
+            common_attn_metadata.num_actual_tokens = num_tokens
+            common_attn_metadata.max_query_len = max(self.decode_threshold, max_query_len_p)
+            common_attn_metadata.seq_lens[-num_prefill_reqs:] = seq_lens_p
+            if common_attn_metadata.seq_lens_cpu is not None:
+                common_attn_metadata.seq_lens_cpu[-num_prefill_reqs:] = seq_lens_p
+            if common_attn_metadata._seq_lens_cpu is not None:
+                common_attn_metadata._seq_lens_cpu[-num_prefill_reqs:] = seq_lens_p
+            query_start_loc_p = (
+                cu_num_tokens_p[1:]
+                + common_attn_metadata.query_start_loc_cpu[num_decode_reqs].item()
+            )
+            common_attn_metadata.query_start_loc[-num_prefill_reqs:] = query_start_loc_p
+            common_attn_metadata.query_start_loc_cpu[-num_prefill_reqs:] = query_start_loc_p
+
+        return PCPSpecDecodeFirstPassInputs(
+            num_tokens=num_tokens,
+            input_ids=input_ids,
+            target_positions=target_positions,
+            target_hidden_states=target_hidden_states,
+            token_indices_to_sample=token_indices_to_sample,
+            long_seq_args=long_seq_args,
+        )
+
+    def _split_spec_decode_pcp_prefill_input(
+        self,
+        req_scheduled_tokens: dict[str, int],
+        input_ids: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+    ) -> tuple[int, torch.Tensor, torch.Tensor, int, torch.Tensor, torch.Tensor]:
+        """
+        Split prefill input_ids and target_hidden_states in the PCP group.
+
+        The target hidden states already include PCP padding; this method
+        selects only the local PCP rank's prefill tokens and returns the
+        attention metadata fields affected by that split.
+        """
+        if len(req_scheduled_tokens) == 0:
+            return (
+                0,
+                input_ids.new_zeros((0,)),
+                target_hidden_states.new_zeros((0, target_hidden_states.size(1))),
+                0,
+                torch.zeros((0,), dtype=torch.int32),
+                torch.tensor([0], dtype=torch.int32),
+            )
+
+        if self.pcp_use_hybrid_attn:
+            return self._split_spec_decode_pcp_prefill_input_hybrid(
+                req_scheduled_tokens,
+                input_ids,
+                target_hidden_states,
+            )
+
+        def _pcp_pad_and_split(num_tokens: int) -> tuple[list[int], int, int]:
+            num_pcp_padded_scheduled_tokens = (
+                cdiv(num_tokens, 2 * self.pcp_world_size) * 2 * self.pcp_world_size
+            )
+            pcp_pad = num_pcp_padded_scheduled_tokens - num_tokens
+            chunk_size = num_pcp_padded_scheduled_tokens // (2 * self.pcp_world_size)
+
+            req_position_cp: list[int] = []
+            req_position_cp.extend(
+                self.full_indices[
+                    self.pcp_world_rank * chunk_size : (self.pcp_world_rank + 1) * chunk_size
+                ]
+            )
+            req_position_cp.extend(
+                self.full_indices[
+                    num_pcp_padded_scheduled_tokens
+                    - (self.pcp_world_rank + 1) * chunk_size : num_pcp_padded_scheduled_tokens
+                    - self.pcp_world_rank * chunk_size
+                ]
+            )
+
+            return req_position_cp, num_pcp_padded_scheduled_tokens, pcp_pad
+
+        num_pcp_scheduled_tokens = []
+        ori_start_index = 0
+        pad_start_index = 0
+        pcp_split_input_ids_list = []
+        pcp_split_hidden_states_list = []
+        for ori_num_tokens in req_scheduled_tokens.values():
+            req_position_pcp, num_pcp_padded_scheduled_tokens, num_pcp_pad = _pcp_pad_and_split(ori_num_tokens)
+            actual_num_tokens = len(req_position_pcp)
+            num_pcp_scheduled_tokens.append(actual_num_tokens)
+            pad_input_ids = F.pad(
+                input_ids[ori_start_index : ori_start_index + ori_num_tokens],
+                (0, num_pcp_pad),
+            )
+            ori_start_index += ori_num_tokens
+            pcp_chunk_indices = [pad_start_index + pos for pos in req_position_pcp]
+            pcp_split_input_ids = pad_input_ids[req_position_pcp]
+            pcp_split_hidden_states = target_hidden_states[pcp_chunk_indices]
+            pcp_split_input_ids_list.append(pcp_split_input_ids)
+            pcp_split_hidden_states_list.append(pcp_split_hidden_states)
+            pad_start_index += num_pcp_padded_scheduled_tokens
+        num_tokens = sum(num_pcp_scheduled_tokens)
+        input_ids = torch.cat(pcp_split_input_ids_list)
+        target_hidden_states = torch.cat(pcp_split_hidden_states_list, dim=0)
+        max_query_len = max(num_pcp_scheduled_tokens)
+        seq_lens = torch.tensor(num_pcp_scheduled_tokens, dtype=torch.int32)
+        cu_num_tokens = torch.tensor(np.insert(np.cumsum(np.array(num_pcp_scheduled_tokens)), 0, 0))
+        return num_tokens, input_ids, target_hidden_states, max_query_len, seq_lens, cu_num_tokens
+
+    def _split_spec_decode_pcp_prefill_input_hybrid(
+        self,
+        req_scheduled_tokens: dict[str, int],
+        input_ids: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+    ) -> tuple[int, torch.Tensor, torch.Tensor, int, torch.Tensor, torch.Tensor]:
+        """Linear-split prefill inputs for hybrid-attention PCP models."""
+        num_pcp_scheduled_tokens = []
+        global_offset = 0
+        pcp_split_input_ids_list = []
+        pcp_split_hidden_states_list = []
+        for ori_num_tokens in req_scheduled_tokens.values():
+            padded_tokens = cdiv(ori_num_tokens, 2 * self.pcp_world_size) * 2 * self.pcp_world_size
+            pcp_tokens = padded_tokens // self.pcp_world_size
+            num_pads = padded_tokens - ori_num_tokens
+            rank_start = self.pcp_world_rank * pcp_tokens
+            num_pcp_scheduled_tokens.append(pcp_tokens)
+
+            req_input_ids = input_ids[global_offset : global_offset + ori_num_tokens]
+            if num_pads > 0:
+                req_input_ids = F.pad(req_input_ids, (0, num_pads))
+            pcp_split_input_ids_list.append(req_input_ids[rank_start : rank_start + pcp_tokens])
+
+            req_hidden = target_hidden_states[global_offset : global_offset + ori_num_tokens]
+            if num_pads > 0:
+                req_hidden = F.pad(req_hidden, (0, 0, 0, num_pads))
+            pcp_split_hidden_states_list.append(req_hidden[rank_start : rank_start + pcp_tokens])
+            global_offset += ori_num_tokens
+        num_tokens = sum(num_pcp_scheduled_tokens)
+        input_ids = torch.cat(pcp_split_input_ids_list)
+        target_hidden_states = torch.cat(pcp_split_hidden_states_list, dim=0)
+        max_query_len = max(num_pcp_scheduled_tokens)
+        seq_lens = torch.tensor(num_pcp_scheduled_tokens, dtype=torch.int32)
+        cu_num_tokens = torch.tensor(np.insert(np.cumsum(np.array(num_pcp_scheduled_tokens)), 0, 0))
+        return num_tokens, input_ids, target_hidden_states, max_query_len, seq_lens, cu_num_tokens
 
     def _get_spec_decode_mtp_slot_inputs(
         self,

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -20,6 +20,7 @@
 import copy
 import logging
 from collections.abc import Callable
+from dataclasses import dataclass
 from itertools import accumulate
 from typing import TYPE_CHECKING, Any
 
@@ -36,6 +37,16 @@ from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
+
+
+@dataclass(frozen=True)
+class PCPSpecDecodeMTPInputs:
+    """Device-side PCP state needed by proposer MTP draft steps."""
+
+    seq_lens: torch.Tensor
+    seq_lens_cpu: torch.Tensor | None
+    slot_indices: torch.Tensor
+    slot_mapping: torch.Tensor
 
 
 class PCPManager:
@@ -79,6 +90,11 @@ class PCPManager:
         )
         self.pcp_req_offsets = torch.arange(
             max_num_reqs,
+            dtype=torch.int64,
+            device=device,
+        )
+        self.pcp_rank_offsets = torch.arange(
+            pcp_world_size,
             dtype=torch.int64,
             device=device,
         )
@@ -920,14 +936,24 @@ class PCPManager:
     def get_restore_hidden_states(
         self,
         hidden_states: torch.Tensor,
-    ):
-        # NOTE we must `slice` hidden_states because pcp_allgather_restore_idx
-        # ignores the padding from CUDA Graph.
+        num_input_tokens: int | None = None,
+    ) -> torch.Tensor:
+        """Gather PCP hidden states and restore the original token order.
+
+        ``num_input_tokens`` is explicit for spec decode, where draft graph
+        padding can differ from the main-model PCP scheduled-token length.
+        Main-model callers omit it and use the PCP metadata length.
+        """
         from vllm.distributed.parallel_state import get_pcp_group
 
         if not self.pcp_use_hybrid_attn:
+            local_num_tokens = (
+                num_input_tokens
+                if num_input_tokens is not None
+                else self.num_actual_tokens_pcp_padded // self.pcp_world_size
+            )
             hidden_states = get_pcp_group().all_gather(
-                hidden_states[: self.num_actual_tokens_pcp_padded // self.pcp_world_size],
+                hidden_states[:local_num_tokens],
                 0,
             )
             restore_idx = self.pcp_allgather_restore_idx.gpu[: hidden_states.shape[0]]
@@ -937,6 +963,8 @@ class PCPManager:
                 restore_idx,
             )
         else:
+            if num_input_tokens is not None:
+                hidden_states = hidden_states[:num_input_tokens]
             if hidden_states.shape[0] == self.total_num_scheduled_tokens and self.pcp_padded_tokens_fla > 0:
                 hidden_states = F.pad(
                     hidden_states, pad=(0, 0, 0, self.pcp_padded_tokens_fla), mode="constant", value=0
@@ -947,6 +975,126 @@ class PCPManager:
             hidden_states = get_pcp_group().all_gather(hidden_states.contiguous(), dim=0)
             restore_idx = self.pcp_enter_fa_restore_idx[: hidden_states.shape[0] - self.total_pcp_padding_tokens_fla]
             return torch.index_select(hidden_states, 0, restore_idx)
+
+    def mask_spec_decode_restore_idx_for_graph(
+        self,
+        pcp_allgather_restore_idx: torch.Tensor,
+    ) -> None:
+        """Mask graph-only PCP restore slots used by padded draft batches."""
+        index = torch.arange(
+            pcp_allgather_restore_idx.shape[0],
+            dtype=torch.int64,
+            device=pcp_allgather_restore_idx.device,
+        )
+        mask = (index % (self.pcp_world_size * self.decode_threshold)) >= self.decode_threshold
+        pcp_allgather_restore_idx[mask] = 0
+        restore_len = pcp_allgather_restore_idx.shape[0]
+        self.pcp_allgather_restore_idx.gpu[:restore_len].copy_(pcp_allgather_restore_idx)
+        self.pcp_allgather_restore_idx.gpu[restore_len:].fill_(0)
+
+    def get_spec_decode_decode_hidden_states(
+        self,
+        target_hidden_states_d_padded: torch.Tensor,
+        num_decode_reqs: int,
+        num_decode_tokens: int | None = None,
+    ) -> torch.Tensor:
+        """Remove PCP decode padding from target hidden states for proposer input."""
+        if num_decode_tokens is None:
+            num_decode_tokens = self.num_decode_tokens
+        if num_decode_tokens == 0:
+            return target_hidden_states_d_padded
+        if self.pcp_use_hybrid_attn:
+            return target_hidden_states_d_padded[:num_decode_tokens]
+
+        query_start_loc = self.query_start_loc_pcp_full.gpu[: num_decode_reqs + 1]
+        decode_req_starts = query_start_loc[:num_decode_reqs].to(torch.int64)
+        decode_query_lens = (
+            query_start_loc[1 : num_decode_reqs + 1] - query_start_loc[:num_decode_reqs]
+        ).to(torch.int64)
+        decode_padded_starts = decode_req_starts * self.pcp_world_size
+        decode_req_starts_per_token = torch.repeat_interleave(
+            decode_req_starts,
+            decode_query_lens,
+            output_size=num_decode_tokens,
+        )
+        decode_padded_starts_per_token = torch.repeat_interleave(
+            decode_padded_starts,
+            decode_query_lens,
+            output_size=num_decode_tokens,
+        )
+        decode_offsets = (
+            torch.arange(
+                num_decode_tokens,
+                dtype=torch.int64,
+                device=target_hidden_states_d_padded.device,
+            )
+            - decode_req_starts_per_token
+        )
+        decode_hidden_state_indices = decode_padded_starts_per_token + decode_offsets
+        return target_hidden_states_d_padded[decode_hidden_state_indices]
+
+    def _get_spec_decode_mtp_slot_inputs(
+        self,
+        ori_token_indices_to_sample: torch.Tensor,
+        num_decode_reqs: int,
+        num_speculative_tokens: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build device-side PCP slot indices for decode-only MTP draft steps."""
+        assert self.mtp_slot_pad is not None
+        query_start_loc = self.query_start_loc_pcp_full.gpu[: num_decode_reqs + 1]
+        decode_req_starts = query_start_loc[:num_decode_reqs].to(torch.int64)
+        cu_num_tokens = query_start_loc[1 : num_decode_reqs + 1].to(torch.int64)
+        query_lens = cu_num_tokens - decode_req_starts
+        num_reject_tokens = cu_num_tokens - ori_token_indices_to_sample.to(torch.int64) - 1
+        num_accept_tokens = query_lens - num_reject_tokens
+        slot_idx_base = (
+            decode_req_starts * self.pcp_world_size
+            + self.pcp_req_offsets[:num_decode_reqs]
+            * (num_speculative_tokens - 1)
+            * self.pcp_world_size
+            + (num_accept_tokens - 1) * self.pcp_world_size
+        )
+        slot_indices = (slot_idx_base[:, None] + self.pcp_rank_offsets[: self.pcp_world_size]).reshape(-1)
+        return slot_indices, self.mtp_slot_pad
+
+    def prepare_spec_decode_mtp_drafting_inputs(
+        self,
+        common_attn_metadata: Any,
+        attn_metadata: Any,
+        ori_token_indices_to_sample: torch.Tensor | None,
+        batch_size: int,
+        num_decode_reqs: int,
+        is_prefill_batch: bool,
+        num_speculative_tokens: int,
+    ) -> PCPSpecDecodeMTPInputs | None:
+        """Prepare CP-specific inputs for decode-only MTP draft metadata."""
+        is_decode_only_batch = num_decode_reqs > 0 and not is_prefill_batch
+        if num_speculative_tokens <= 1 or not is_decode_only_batch:
+            return None
+
+        assert ori_token_indices_to_sample is not None
+        slot_indices, slot_mapping = self._get_spec_decode_mtp_slot_inputs(
+            ori_token_indices_to_sample,
+            num_decode_reqs,
+            num_speculative_tokens,
+        )
+
+        seq_lens = getattr(attn_metadata, "seq_lens", None)
+        seq_lens_cpu = getattr(attn_metadata, "seq_lens_cpu", None)
+        if seq_lens is None:
+            assert seq_lens_cpu is not None
+            seq_lens = seq_lens_cpu
+        seq_lens = seq_lens[:batch_size].clone()
+        if seq_lens_cpu is not None:
+            seq_lens_cpu = seq_lens_cpu[:batch_size].clone()
+
+        common_attn_metadata.block_table_tensor = common_attn_metadata.block_table_tensor[:batch_size]
+        return PCPSpecDecodeMTPInputs(
+            seq_lens=seq_lens,
+            seq_lens_cpu=seq_lens_cpu,
+            slot_indices=slot_indices,
+            slot_mapping=slot_mapping,
+        )
 
     def generate_pcp_mtp_input(
         self,
@@ -1239,6 +1387,60 @@ class PCPManager:
         )
         dcp_local_seq_lens = (base + remainder).reshape([-1, pcp_world_size, dcp_world_size])
         return dcp_local_seq_lens
+
+    @staticmethod
+    def _is_mla_kv_cache_spec(kv_cache_spec: Any) -> bool:
+        from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
+
+        return isinstance(kv_cache_spec, AscendMLAAttentionSpec)
+
+    @staticmethod
+    def _is_sfa_dcp_metadata_builder(attn_metadata_builder: Any | None) -> bool:
+        if attn_metadata_builder is None:
+            return False
+        from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFADCPMetadataBuilder
+
+        return isinstance(attn_metadata_builder, AscendSFADCPMetadataBuilder)
+
+    def update_spec_decode_drafting_cp_metadata(
+        self,
+        attn_metadata: Any,
+        kv_cache_spec: Any,
+        seq_lens: torch.Tensor,
+        draft_index: int,
+        seq_lens_cpu: torch.Tensor | None = None,
+        attn_metadata_builder: Any | None = None,
+    ) -> None:
+        """Update per-draft-step CP seq-len metadata after metadata build."""
+        is_mla = self._is_mla_kv_cache_spec(kv_cache_spec)
+        is_sfa_dcp = self._is_sfa_dcp_metadata_builder(attn_metadata_builder)
+        seq_lens_for_cp = seq_lens
+        if not is_mla and seq_lens_cpu is not None:
+            seq_lens_for_cp = seq_lens_cpu
+
+        num_computed_tokens_of_pcp_dcp = self._get_cp_local_seq_lens(
+            seq_lens_for_cp + draft_index + 1,
+            self.pcp_world_size,
+            self.dcp_world_size,
+            self.vllm_config.parallel_config.cp_kv_cache_interleave_size,
+        )
+        cp_seq_len = num_computed_tokens_of_pcp_dcp[:, self.pcp_world_rank, self.dcp_world_rank]
+
+        if is_sfa_dcp:
+            dcp_context = attn_metadata.dcp_context
+            assert dcp_context is not None
+            dcp_seq_lens = dcp_context.seq_lens
+            sfa_cp_seq_len = cp_seq_len.to(
+                device=dcp_seq_lens.device,
+                dtype=dcp_seq_lens.dtype,
+                non_blocking=True,
+            )
+            dcp_seq_lens[: sfa_cp_seq_len.shape[0]].copy_(sfa_cp_seq_len, non_blocking=True)
+            dcp_seq_lens[sfa_cp_seq_len.shape[0] :].fill_(0)
+        elif is_mla:
+            attn_metadata.decode.cp_seq_len = cp_seq_len
+        else:
+            attn_metadata.decode_meta.num_computed_tokens_of_pcp_dcp = num_computed_tokens_of_pcp_dcp.numpy()
 
     def generate_pcp_metadata(
         self,

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -1093,8 +1093,8 @@ class PCPManager:
             # So input_ids.cpu will have all the input ids.
             return
         # Upload the index tensors asynchronously so the scatter can be non-blocking.
-        sampled_tokens_index_tensor = torch.tensor(sample_flattened_indices, dtype=torch.int64)
-        prev_common_req_indices_tensor = torch.tensor(prev_common_req_indices, dtype=torch.int64)
+        sampled_tokens_index_tensor = torch.tensor(sample_flattened_indices, dtype=torch.int64, device=self.device)
+        prev_common_req_indices_tensor = torch.tensor(prev_common_req_indices, dtype=torch.int64, device=self.device)
         self.input_ids_pcp_full.gpu.scatter_(
             dim=0,
             index=sampled_tokens_index_tensor,
@@ -1106,8 +1106,8 @@ class PCPManager:
             return
 
         assert isinstance(draft_token_ids, torch.Tensor)
-        draft_tokens_index_tensor = torch.tensor(spec_flattened_indices, dtype=torch.int64)
-        prev_draft_token_indices_tensor = torch.tensor(prev_draft_token_indices, dtype=torch.int64)
+        draft_tokens_index_tensor = torch.tensor(spec_flattened_indices, dtype=torch.int64, device=self.device)
+        prev_draft_token_indices_tensor = torch.tensor(prev_draft_token_indices, dtype=torch.int64, device=self.device)
 
         # because input_ids dtype is torch.int32,
         # so convert draft_token_ids to torch.int32 here.

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -33,6 +33,7 @@ from vllm.utils import length_from_prompt_token_ids_or_embeds
 from vllm.utils.math_utils import cdiv
 from vllm.v1.utils import CpuGpuBuffer
 
+from vllm_ascend.spec_decode.utils import correct_optimistic_seq_lens_cpu
 from vllm_ascend.utils import is_pd_decode_recompute_scheduler_enabled
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 
@@ -60,6 +61,14 @@ class PCPSpecDecodeFirstPassInputs:
     target_hidden_states: torch.Tensor
     token_indices_to_sample: torch.Tensor
     long_seq_args: tuple[torch.Tensor | None, torch.Tensor | None] | None
+
+
+@dataclass(frozen=True)
+class PCPAsyncSpecDecodeRebuildResult:
+    """Status returned after trying to rebuild async spec decode CP inputs."""
+
+    rebuilt: bool
+    positions_ready_on_device: bool
 
 
 class PCPManager:
@@ -1340,6 +1349,257 @@ class PCPManager:
             seq_lens_cpu=seq_lens_cpu,
             slot_indices=slot_indices,
             slot_mapping=slot_mapping,
+        )
+
+    def rebuild_async_spec_decode_inputs(
+        self,
+        *,
+        use_async_spec_decode: bool,
+        valid_sampled_token_count_gpu: torch.Tensor | None,
+        prev_req_id_to_index: Any,
+        prev_positions_gpu: torch.Tensor | None,
+        with_prefill: bool,
+        enable_prompt_embeds: bool,
+        has_req_prompt_embeds: bool,
+        supports_mm_inputs: bool,
+        num_reqs: int,
+        total_num_scheduled_tokens: int,
+        req_indices: np.ndarray,
+        req_indices_gpu: torch.Tensor,
+        position_pcp: np.ndarray | None,
+        query_pos_gpu: torch.Tensor,
+        query_pos_np: np.ndarray,
+        positions: torch.Tensor,
+        positions_np: np.ndarray,
+        num_computed_tokens: torch.Tensor,
+        num_computed_tokens_cpu: np.ndarray,
+        prev_positions_np: np.ndarray,
+        prev_num_draft_tokens_np: np.ndarray,
+        valid_sampled_token_count_event: Any | None,
+        valid_sampled_token_count_cpu: torch.Tensor | None,
+        input_batch: NPUInputBatch,
+        input_ids: CpuGpuBuffer,
+        scheduler_output: "SchedulerOutput",
+        arange_np: np.ndarray,
+        cu_num_tokens: np.ndarray,
+        draft_token_ids: torch.Tensor | None,
+        num_spec_tokens: int,
+        prepare_input_ids: Callable[["SchedulerOutput", int, int, np.ndarray], None],
+    ) -> PCPAsyncSpecDecodeRebuildResult:
+        """Rebuild CP/spec inputs after async accepted-token correction."""
+        should_rebuild = (
+            self.pcp_world_size * self.dcp_world_size > 1
+            and use_async_spec_decode
+            and valid_sampled_token_count_gpu is not None
+            and bool(prev_req_id_to_index)
+            and self.num_decode_reqs > 0
+        )
+        if not should_rebuild:
+            return PCPAsyncSpecDecodeRebuildResult(
+                rebuilt=False,
+                positions_ready_on_device=False,
+            )
+
+        can_rebuild_on_device = (
+            prev_positions_gpu is not None
+            and not with_prefill
+            and not enable_prompt_embeds
+            and not has_req_prompt_embeds
+            and not supports_mm_inputs
+        )
+        if can_rebuild_on_device:
+            if self.pcp_world_size > 1:
+                assert position_pcp is not None
+                position_offsets_gpu = torch.from_numpy(
+                    position_pcp[:total_num_scheduled_tokens]
+                ).pin_memory().to(
+                    dtype=torch.int64,
+                    device=self.device,
+                    non_blocking=True,
+                )
+            else:
+                position_offsets_gpu = query_pos_gpu[:total_num_scheduled_tokens].to(
+                    torch.int64
+                )
+            positions_gpu = (
+                num_computed_tokens[req_indices_gpu].to(torch.int64)
+                + position_offsets_gpu
+            )
+            positions[:total_num_scheduled_tokens].copy_(positions_gpu)
+
+            num_tokens_full = self.async_rebuild_num_tokens_full
+            query_start_loc_full = self.query_start_loc_pcp_full.gpu[: num_reqs + 1]
+            query_lens_full = (
+                query_start_loc_full[1:] - query_start_loc_full[:-1]
+            ).to(torch.int64)
+            req_indices_full_gpu = torch.repeat_interleave(
+                self.pcp_req_offsets[:num_reqs],
+                query_lens_full,
+                output_size=num_tokens_full,
+            )
+            token_offsets_full = torch.arange(
+                num_tokens_full,
+                dtype=torch.int64,
+                device=self.device,
+            )
+            positions_full_gpu = (
+                num_computed_tokens[req_indices_full_gpu].to(torch.int64)
+                + token_offsets_full
+                - query_start_loc_full[req_indices_full_gpu].to(torch.int64)
+            )
+
+            if self.pcp_world_size > 1:
+                input_batch.block_table.compute_slot_mapping(
+                    num_reqs,
+                    query_start_loc_full,
+                    positions_full_gpu,
+                )
+
+            extra_tokens = self.decode_threshold - 2
+            if extra_tokens > 0 and not with_prefill:
+                mtp_lens = query_lens_full + extra_tokens
+                num_tokens_mtp = num_tokens_full + num_reqs * extra_tokens
+                req_indices_mtp = torch.repeat_interleave(
+                    self.pcp_req_offsets[:num_reqs],
+                    mtp_lens,
+                    output_size=num_tokens_mtp,
+                )
+                mtp_start_loc = torch.empty(
+                    num_reqs + 1,
+                    dtype=torch.int64,
+                    device=self.device,
+                )
+                mtp_start_loc[0].fill_(0)
+                mtp_start_loc[1:] = torch.cumsum(mtp_lens, dim=0)
+                mtp_offsets = torch.arange(
+                    num_tokens_mtp,
+                    dtype=torch.int64,
+                    device=self.device,
+                )
+                positions_mtp = (
+                    num_computed_tokens[req_indices_mtp].to(torch.int64)
+                    + mtp_offsets
+                    - mtp_start_loc[req_indices_mtp]
+                )
+                input_batch.block_table.compute_slot_mapping_draft(
+                    req_indices_mtp,
+                    positions_mtp,
+                )
+                mtp_slot_ori = input_batch.block_table.block_tables[0].slot_mapping.gpu[
+                    :num_tokens_mtp
+                ]
+                num_tokens_mtp_pad = num_tokens_mtp * self.pcp_world_size
+                if (
+                    self.mtp_slot_pad is None
+                    or self.mtp_slot_pad.numel() < num_tokens_mtp_pad
+                ):
+                    self.mtp_slot_pad = torch.empty(
+                        num_tokens_mtp_pad,
+                        dtype=torch.int32,
+                        device=self.device,
+                    )
+                mtp_slot_pad = self.mtp_slot_pad[:num_tokens_mtp_pad]
+                mtp_slot_pad.fill_(-1)
+                mtp_slot_pad[:: self.pcp_world_size].copy_(mtp_slot_ori)
+
+            return PCPAsyncSpecDecodeRebuildResult(
+                rebuilt=True,
+                positions_ready_on_device=True,
+            )
+
+        base_num_computed_tokens_np = num_computed_tokens_cpu[:num_reqs].copy()
+        assert valid_sampled_token_count_event is not None
+        assert valid_sampled_token_count_cpu is not None
+        valid_sampled_token_count_event.synchronize()
+        correct_optimistic_seq_lens_cpu(
+            base_num_computed_tokens_np,
+            prev_positions_np,
+            prev_num_draft_tokens_np,
+            valid_sampled_token_count_cpu.numpy(),
+            num_reqs,
+        )
+
+        if self.pcp_world_size > 1:
+            assert position_pcp is not None
+            position_offsets = position_pcp
+        else:
+            position_offsets = query_pos_np
+        np.add(
+            base_num_computed_tokens_np[req_indices],
+            position_offsets[:total_num_scheduled_tokens],
+            out=positions_np,
+        )
+
+        token_indices = (
+            positions_np[:total_num_scheduled_tokens]
+            + req_indices * input_batch.token_ids_cpu.shape[1]
+        )
+        torch.index_select(
+            input_batch.token_ids_cpu_tensor.flatten(),
+            0,
+            torch.from_numpy(token_indices),
+            out=input_ids.cpu[:total_num_scheduled_tokens],
+        )
+        input_ids.copy_to_gpu(total_num_scheduled_tokens)
+        prepare_input_ids(
+            scheduler_output,
+            num_reqs,
+            total_num_scheduled_tokens,
+            cu_num_tokens,
+        )
+
+        req_indices_full = self.async_rebuild_req_indices_full
+        cu_num_tokens_full = self.async_rebuild_cu_num_tokens_full
+        num_tokens_full = self.async_rebuild_num_tokens_full
+        assert req_indices_full is not None
+        assert cu_num_tokens_full is not None
+
+        token_counts = np.diff(np.concatenate(([0], cu_num_tokens_full)))
+        token_starts = np.repeat(cu_num_tokens_full - token_counts, token_counts)
+        query_pos = arange_np[:num_tokens_full] - token_starts
+
+        positions_full = np.empty(num_tokens_full, dtype=np.int64)
+        np.add(
+            base_num_computed_tokens_np[req_indices_full],
+            query_pos,
+            out=positions_full,
+        )
+
+        if self.pcp_world_size > 1:
+            pre_pcp_query_start_loc = torch.zeros(
+                num_reqs + 1,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            pre_pcp_query_start_loc[1 : num_reqs + 1] = torch.from_numpy(
+                cu_num_tokens_full
+            ).to(dtype=torch.int32, device=self.device)
+
+            input_batch.block_table.compute_slot_mapping(
+                num_reqs,
+                pre_pcp_query_start_loc,
+                torch.from_numpy(positions_full).to(self.device),
+            )
+
+        self.generate_pcp_mtp_input(
+            num_tokens_full,
+            scheduler_output.num_scheduled_tokens,
+            with_prefill,
+            input_batch,
+            arange_np,
+            req_indices_full,
+            positions_full,
+            cu_num_tokens_full,
+            draft_token_ids,
+            scheduler_output,
+            num_spec_tokens,
+            precomputed_positions_np=positions_full,
+            prev_positions=prev_positions_gpu,
+        )
+
+        return PCPAsyncSpecDecodeRebuildResult(
+            rebuilt=True,
+            positions_ready_on_device=False,
         )
 
     def generate_pcp_mtp_input(

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -1030,9 +1030,9 @@ class PCPManager:
 
         query_start_loc = self.query_start_loc_pcp_full.gpu[: num_decode_reqs + 1]
         decode_req_starts = query_start_loc[:num_decode_reqs].to(torch.int64)
-        decode_query_lens = (
-            query_start_loc[1 : num_decode_reqs + 1] - query_start_loc[:num_decode_reqs]
-        ).to(torch.int64)
+        decode_query_lens = (query_start_loc[1 : num_decode_reqs + 1] - query_start_loc[:num_decode_reqs]).to(
+            torch.int64
+        )
         decode_padded_starts = decode_req_starts * self.pcp_world_size
         decode_req_starts_per_token = torch.repeat_interleave(
             decode_req_starts,
@@ -1143,9 +1143,7 @@ class PCPManager:
         target_hidden_states = torch.cat([target_hidden_states_d, target_hidden_states_p], dim=0)
 
         if num_decode_reqs:
-            token_indices_to_sample[:num_decode_reqs] = logits_indices[
-                token_indices_to_sample[:num_decode_reqs]
-            ]
+            token_indices_to_sample[:num_decode_reqs] = logits_indices[token_indices_to_sample[:num_decode_reqs]]
         if num_prefill_reqs:
             token_indices_to_sample[-num_prefill_reqs:] = logits_indices[-num_prefill_reqs:]
             common_attn_metadata.num_actual_tokens = num_tokens
@@ -1155,10 +1153,7 @@ class PCPManager:
                 common_attn_metadata.seq_lens_cpu[-num_prefill_reqs:] = seq_lens_p
             if common_attn_metadata._seq_lens_cpu is not None:
                 common_attn_metadata._seq_lens_cpu[-num_prefill_reqs:] = seq_lens_p
-            query_start_loc_p = (
-                cu_num_tokens_p[1:]
-                + common_attn_metadata.query_start_loc_cpu[num_decode_reqs].item()
-            )
+            query_start_loc_p = cu_num_tokens_p[1:] + common_attn_metadata.query_start_loc_cpu[num_decode_reqs].item()
             common_attn_metadata.query_start_loc[-num_prefill_reqs:] = query_start_loc_p
             common_attn_metadata.query_start_loc_cpu[-num_prefill_reqs:] = query_start_loc_p
 
@@ -1202,17 +1197,13 @@ class PCPManager:
             )
 
         def _pcp_pad_and_split(num_tokens: int) -> tuple[list[int], int, int]:
-            num_pcp_padded_scheduled_tokens = (
-                cdiv(num_tokens, 2 * self.pcp_world_size) * 2 * self.pcp_world_size
-            )
+            num_pcp_padded_scheduled_tokens = cdiv(num_tokens, 2 * self.pcp_world_size) * 2 * self.pcp_world_size
             pcp_pad = num_pcp_padded_scheduled_tokens - num_tokens
             chunk_size = num_pcp_padded_scheduled_tokens // (2 * self.pcp_world_size)
 
             req_position_cp: list[int] = []
             req_position_cp.extend(
-                self.full_indices[
-                    self.pcp_world_rank * chunk_size : (self.pcp_world_rank + 1) * chunk_size
-                ]
+                self.full_indices[self.pcp_world_rank * chunk_size : (self.pcp_world_rank + 1) * chunk_size]
             )
             req_position_cp.extend(
                 self.full_indices[
@@ -1304,9 +1295,7 @@ class PCPManager:
         num_accept_tokens = query_lens - num_reject_tokens
         slot_idx_base = (
             decode_req_starts * self.pcp_world_size
-            + self.pcp_req_offsets[:num_decode_reqs]
-            * (num_speculative_tokens - 1)
-            * self.pcp_world_size
+            + self.pcp_req_offsets[:num_decode_reqs] * (num_speculative_tokens - 1) * self.pcp_world_size
             + (num_accept_tokens - 1) * self.pcp_world_size
         )
         slot_indices = (slot_idx_base[:, None] + self.pcp_rank_offsets[: self.pcp_world_size]).reshape(-1)
@@ -1410,28 +1399,23 @@ class PCPManager:
         if can_rebuild_on_device:
             if self.pcp_world_size > 1:
                 assert position_pcp is not None
-                position_offsets_gpu = torch.from_numpy(
-                    position_pcp[:total_num_scheduled_tokens]
-                ).pin_memory().to(
-                    dtype=torch.int64,
-                    device=self.device,
-                    non_blocking=True,
+                position_offsets_gpu = (
+                    torch.from_numpy(position_pcp[:total_num_scheduled_tokens])
+                    .pin_memory()
+                    .to(
+                        dtype=torch.int64,
+                        device=self.device,
+                        non_blocking=True,
+                    )
                 )
             else:
-                position_offsets_gpu = query_pos_gpu[:total_num_scheduled_tokens].to(
-                    torch.int64
-                )
-            positions_gpu = (
-                num_computed_tokens[req_indices_gpu].to(torch.int64)
-                + position_offsets_gpu
-            )
+                position_offsets_gpu = query_pos_gpu[:total_num_scheduled_tokens].to(torch.int64)
+            positions_gpu = num_computed_tokens[req_indices_gpu].to(torch.int64) + position_offsets_gpu
             positions[:total_num_scheduled_tokens].copy_(positions_gpu)
 
             num_tokens_full = self.async_rebuild_num_tokens_full
             query_start_loc_full = self.query_start_loc_pcp_full.gpu[: num_reqs + 1]
-            query_lens_full = (
-                query_start_loc_full[1:] - query_start_loc_full[:-1]
-            ).to(torch.int64)
+            query_lens_full = (query_start_loc_full[1:] - query_start_loc_full[:-1]).to(torch.int64)
             req_indices_full_gpu = torch.repeat_interleave(
                 self.pcp_req_offsets[:num_reqs],
                 query_lens_full,
@@ -1477,22 +1461,15 @@ class PCPManager:
                     device=self.device,
                 )
                 positions_mtp = (
-                    num_computed_tokens[req_indices_mtp].to(torch.int64)
-                    + mtp_offsets
-                    - mtp_start_loc[req_indices_mtp]
+                    num_computed_tokens[req_indices_mtp].to(torch.int64) + mtp_offsets - mtp_start_loc[req_indices_mtp]
                 )
                 input_batch.block_table.compute_slot_mapping_draft(
                     req_indices_mtp,
                     positions_mtp,
                 )
-                mtp_slot_ori = input_batch.block_table.block_tables[0].slot_mapping.gpu[
-                    :num_tokens_mtp
-                ]
+                mtp_slot_ori = input_batch.block_table.block_tables[0].slot_mapping.gpu[:num_tokens_mtp]
                 num_tokens_mtp_pad = num_tokens_mtp * self.pcp_world_size
-                if (
-                    self.mtp_slot_pad is None
-                    or self.mtp_slot_pad.numel() < num_tokens_mtp_pad
-                ):
+                if self.mtp_slot_pad is None or self.mtp_slot_pad.numel() < num_tokens_mtp_pad:
                     self.mtp_slot_pad = torch.empty(
                         num_tokens_mtp_pad,
                         dtype=torch.int32,
@@ -1530,10 +1507,7 @@ class PCPManager:
             out=positions_np,
         )
 
-        token_indices = (
-            positions_np[:total_num_scheduled_tokens]
-            + req_indices * input_batch.token_ids_cpu.shape[1]
-        )
+        token_indices = positions_np[:total_num_scheduled_tokens] + req_indices * input_batch.token_ids_cpu.shape[1]
         torch.index_select(
             input_batch.token_ids_cpu_tensor.flatten(),
             0,
@@ -1571,9 +1545,9 @@ class PCPManager:
                 dtype=torch.int32,
                 device=self.device,
             )
-            pre_pcp_query_start_loc[1 : num_reqs + 1] = torch.from_numpy(
-                cu_num_tokens_full
-            ).to(dtype=torch.int32, device=self.device)
+            pre_pcp_query_start_loc[1 : num_reqs + 1] = torch.from_numpy(cu_num_tokens_full).to(
+                dtype=torch.int32, device=self.device
+            )
 
             input_batch.block_table.compute_slot_mapping(
                 num_reqs,
@@ -1767,10 +1741,7 @@ class PCPManager:
                 draft_lens.to(torch.int64),
                 max=num_spec_tokens,
             )
-            spec_mask = (
-                common_mask.unsqueeze(1)
-                & (spec_offsets < draft_lens.unsqueeze(1))
-            )
+            spec_mask = common_mask.unsqueeze(1) & (spec_offsets < draft_lens.unsqueeze(1))
             sample_indices_2d = sample_indices.unsqueeze(1)
             spec_dst = sample_indices_2d + 1 + spec_offsets
             safe_dst = torch.where(
@@ -1778,10 +1749,7 @@ class PCPManager:
                 spec_dst,
                 sample_indices_2d.expand(-1, num_spec_tokens),
             )
-            spec_src_indices = (
-                safe_prev_positions.unsqueeze(1) * num_spec_tokens
-                + spec_offsets
-            )
+            spec_src_indices = safe_prev_positions.unsqueeze(1) * num_spec_tokens + spec_offsets
 
             draft_token_ids = draft_token_ids.to(dtype=torch.int32)
             spec_src = draft_token_ids.flatten()[spec_src_indices]

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -990,6 +990,8 @@ class PCPManager:
             torch.from_numpy(token_indices_pcp_full),
             out=self.input_ids_pcp_full.cpu[:total_num_scheduled_tokens_pcp_full],
         )
+        self.input_ids_pcp_full.copy_to_gpu(total_num_scheduled_tokens_pcp_full)
+        self.query_start_loc_pcp_full.copy_to_gpu()
         if self.use_async_scheduling:
             self._update_input_ids_pcp_full_ids(
                 input_batch,
@@ -999,8 +1001,6 @@ class PCPManager:
                 cu_num_tokens_pcp_full,
                 num_spec_tokens,
             )
-        self.query_start_loc_pcp_full.copy_to_gpu()
-        self.input_ids_pcp_full.copy_to_gpu(total_num_scheduled_tokens_pcp_full)
         self.cu_num_tokens_pcp_full = cu_num_tokens_pcp_full
 
         if self.use_async_scheduling and precomputed_positions_np is None:
@@ -1032,9 +1032,9 @@ class PCPManager:
             mtp_slot_ori = input_batch.block_table.block_tables[0].slot_mapping.cpu[:num_tokens_mtp]
             unpad_mask = np.repeat(False, num_tokens_mtp_pad)
             unpad_mask[:: self.pcp_world_size] = True
-            mtp_slot_pad = torch.full([num_tokens_mtp_pad], -1, dtype=torch.int32)
-            mtp_slot_pad[unpad_mask] = mtp_slot_ori
-            self.mtp_slot_pad = mtp_slot_pad.to(self.device, non_blocking=True)
+            self.mtp_slot_pad = torch.full([num_tokens_mtp_pad], -1, dtype=torch.int32, pin_memory=True)
+            self.mtp_slot_pad[unpad_mask] = mtp_slot_ori
+            self.mtp_slot_pad = self.mtp_slot_pad.to(self.device, non_blocking=True)
 
     def _update_input_ids_pcp_full_ids(
         self,
@@ -1095,10 +1095,10 @@ class PCPManager:
         # Upload the index tensors asynchronously so the scatter can be non-blocking.
         sampled_tokens_index_tensor = torch.tensor(sample_flattened_indices, dtype=torch.int64)
         prev_common_req_indices_tensor = torch.tensor(prev_common_req_indices, dtype=torch.int64)
-        self.input_ids_pcp_full.cpu.scatter_(
+        self.input_ids_pcp_full.gpu.scatter_(
             dim=0,
             index=sampled_tokens_index_tensor,
-            src=input_batch.prev_sampled_token_ids[prev_common_req_indices_tensor, 0].cpu(),
+            src=input_batch.prev_sampled_token_ids[prev_common_req_indices_tensor, 0],
         )
 
         # Scatter the draft tokens after the sampled tokens are scattered.
@@ -1113,10 +1113,10 @@ class PCPManager:
         # so convert draft_token_ids to torch.int32 here.
         draft_token_ids = draft_token_ids.to(dtype=torch.int32)
 
-        self.input_ids_pcp_full.cpu.scatter_(
+        self.input_ids_pcp_full.gpu.scatter_(
             dim=0,
             index=draft_tokens_index_tensor,
-            src=draft_token_ids.flatten()[prev_draft_token_indices_tensor].cpu(),
+            src=draft_token_ids.flatten()[prev_draft_token_indices_tensor],
         )
 
     def _get_cp_local_seq_lens(

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -1133,7 +1133,11 @@ class PCPManager:
         total_world_size = pcp_world_size * dcp_world_size
         seq_lens_tiled = seq_lens.unsqueeze(-1).repeat(1, total_world_size)
         rank_offsets = (
-            torch.arange(total_world_size, dtype=seq_lens.dtype, device=seq_lens.device)
+            torch.arange(
+                total_world_size,
+                dtype=seq_lens.dtype,
+                device=seq_lens.device,
+            )
             .unsqueeze(0)
             .repeat(num_requests, 1)
         )

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -72,6 +72,16 @@ class PCPManager:
         self.dcp_world_rank = dcp_rank
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1 + (self.speculative_config.num_speculative_tokens if self.speculative_config else 0)
+        self.pcp_spec_token_offsets = torch.arange(
+            max(self.decode_threshold - 1, 1),
+            dtype=torch.int64,
+            device=device,
+        )
+        self.pcp_req_offsets = torch.arange(
+            max_num_reqs,
+            dtype=torch.int64,
+            device=device,
+        )
         self.mtp_slot_pad: torch.Tensor | None = None
         self.vllm_config = vllm_config
         self.pd_decode_recompute_scheduler_enabled = is_pd_decode_recompute_scheduler_enabled(vllm_config)
@@ -952,6 +962,7 @@ class PCPManager:
         scheduler_output=None,
         num_spec_tokens=None,
         precomputed_positions_np=None,
+        prev_positions: torch.Tensor | None = None,
     ):
         """
         While pcp > 1, model inputs (input_ids, position, etc.) are split across pcp group,
@@ -1000,6 +1011,7 @@ class PCPManager:
                 total_num_scheduled_tokens,
                 cu_num_tokens_pcp_full,
                 num_spec_tokens,
+                prev_positions,
             )
         self.cu_num_tokens_pcp_full = cu_num_tokens_pcp_full
 
@@ -1044,6 +1056,7 @@ class PCPManager:
         total_num_scheduled_tokens: int,
         cu_num_tokens: np.ndarray,
         num_spec_tokens: int,
+        prev_positions: torch.Tensor | None = None,
     ) -> None:
         """Prepare the input IDs for the current batch.
 
@@ -1052,6 +1065,82 @@ class PCPManager:
         GPU need to be copied into the corresponding slots into input_ids."""
 
         if input_batch.prev_sampled_token_ids is None or input_batch.prev_req_id_to_index is None:
+            return
+
+        if prev_positions is not None:
+            num_reqs = self.num_reqs
+            query_start_loc = self.query_start_loc_pcp_full.gpu[: num_reqs + 1]
+            query_lens = query_start_loc[1:] - query_start_loc[:-1]
+            is_decode_req = self.pcp_req_offsets[:num_reqs] < self.num_decode_reqs
+            draft_lens = torch.where(
+                is_decode_req,
+                torch.clamp(query_lens - 1, min=0),
+                torch.zeros_like(query_lens),
+            )
+
+            sample_indices = (query_start_loc[1:] - 1 - draft_lens).to(torch.int64)
+            prev_positions = prev_positions[:num_reqs].to(torch.int64)
+            common_mask = prev_positions >= 0
+            safe_prev_positions = prev_positions.clamp(min=0)
+
+            sampled_src = input_batch.prev_sampled_token_ids[safe_prev_positions, 0]
+            sampled_src = sampled_src.to(dtype=self.input_ids_pcp_full.gpu.dtype)
+            sampled_src = torch.where(
+                common_mask,
+                sampled_src,
+                self.input_ids_pcp_full.gpu[sample_indices],
+            )
+            self.input_ids_pcp_full.gpu.scatter_(
+                dim=0,
+                index=sample_indices,
+                src=sampled_src,
+            )
+
+            if draft_token_ids is None or not num_spec_tokens:
+                return
+
+            assert isinstance(draft_token_ids, torch.Tensor)
+            if num_spec_tokens > self.pcp_spec_token_offsets.numel():
+                spec_offsets = torch.arange(
+                    num_spec_tokens,
+                    dtype=torch.int64,
+                    device=self.device,
+                )
+            else:
+                spec_offsets = self.pcp_spec_token_offsets[:num_spec_tokens]
+            spec_offsets = spec_offsets.unsqueeze(0)
+            draft_lens = torch.clamp(
+                draft_lens.to(torch.int64),
+                max=num_spec_tokens,
+            )
+            spec_mask = (
+                common_mask.unsqueeze(1)
+                & (spec_offsets < draft_lens.unsqueeze(1))
+            )
+            sample_indices_2d = sample_indices.unsqueeze(1)
+            spec_dst = sample_indices_2d + 1 + spec_offsets
+            safe_dst = torch.where(
+                spec_mask,
+                spec_dst,
+                sample_indices_2d.expand(-1, num_spec_tokens),
+            )
+            spec_src_indices = (
+                safe_prev_positions.unsqueeze(1) * num_spec_tokens
+                + spec_offsets
+            )
+
+            draft_token_ids = draft_token_ids.to(dtype=torch.int32)
+            spec_src = draft_token_ids.flatten()[spec_src_indices]
+            spec_src = torch.where(
+                spec_mask,
+                spec_src,
+                self.input_ids_pcp_full.gpu[safe_dst],
+            )
+            self.input_ids_pcp_full.gpu.scatter_(
+                dim=0,
+                index=safe_dst.reshape(-1),
+                src=spec_src.reshape(-1),
+            )
             return
 
         # Async scheduling case, where some decode requests from the previous


### PR DESCRIPTION
### What this PR does / why we need it?

This PR reduces host/device synchronization in the CP speculative proposer metadata path.

The first commit keeps CP proposer metadata calculations on device by deriving `cu_num_tokens_pcp_full`, decode query lengths, reject/accept counts, and slot index bases from `query_start_loc_pcp_full.gpu`. It also precomputes CP slot offsets and builds slot indices with a vectorized device operation instead of per-request Python `torch.arange` calls. `_get_cp_local_seq_lens` now creates rank offsets on the same device and dtype as `seq_lens`, avoiding a CPU tensor in the device path.

The follow-up pass removes additional CP-only sync candidates in `llm_base_proposer.py`: decode hidden-state unpadding indices now stay on device instead of using a host Python index list, CP prefill query-start offsets use the existing CPU mirror instead of `cad.query_start_loc[...] .item()`, and non-MLA CP sequence metadata uses the CPU seq-lens mirror when it must be converted to numpy.

### Does this PR introduce _any_ user-facing change?

No. This is an internal performance-path optimization for CP speculative decoding metadata construction.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
