### PR TITLE
[BugFix][RFork] Fix RFork GLM fallback crashes

### DIFF
--- a/tests/ut/model_loader/rfork/test_rfork_loader.py
+++ b/tests/ut/model_loader/rfork/test_rfork_loader.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+from functools import wraps
 from types import SimpleNamespace
 
 import pytest
@@ -28,6 +29,8 @@ from vllm_ascend.model_loader.rfork.rfork_loader import (
     _is_dynamic_eplb_enabled,
     _is_layer_sharding_enabled,
     _make_fallback_load_config,
+    _reset_process_global_model_state,
+    _rfork_pre_transfer_weight_processing,
 )
 from vllm_ascend.model_loader.rfork.seed_protocol import get_local_seed_key
 
@@ -529,3 +532,191 @@ def test_rfork_native_eplb_uses_default_loader(monkeypatch):
     assert captured["load_config"] is not load_config
     assert captured["load_config"].load_format == "auto"
     assert captured["load_config"].model_loader_extra_config == {}
+
+
+def test_rfork_fallback_clears_only_failed_model_state_before_reinit(monkeypatch):
+    """RFork fallback re-runs get_model in the same process; the process-global
+    layer registries populated by the first initialize_model must be cleared
+    before re-init, otherwise DeepseekV32IndexerCache/Attention/FusedMoE raise
+    `Duplicate layer name`."""
+    import vllm.model_executor.model_loader as model_loader
+    from vllm.model_executor.layers.rotary_embedding import _ROPE_DICT
+
+    load_config = DummyLoadConfig({"model_url": "model", "model_deploy_strategy_name": "tp8"})
+    loader = RForkModelLoader(load_config)
+    model_config = SimpleNamespace(dtype=torch.float32, model="/models/test", quantization="ascend")
+    vllm_config = _vllm_config(model_config=model_config)
+    stale_attention = SimpleNamespace()
+    stale_moe = SimpleNamespace()
+    unrelated_layer = SimpleNamespace()
+    fallback_down_proj = SimpleNamespace()
+    vllm_config.compilation_config = SimpleNamespace(
+        static_forward_context={
+            "model.layers.0.self_attn.indexer.k_cache": stale_attention,
+            "unrelated.layer": unrelated_layer,
+        },
+        static_all_moe_layers=[
+            stale_moe,
+            "model.layers.0.self_attn.indexer.k_cache",
+            "unrelated.layer",
+        ],
+    )
+    _ROPE_DICT[("identity", 1.0, 32768)] = object()
+
+    class _DiscardedModel:
+        def modules(self):
+            return iter([self, stale_attention, stale_moe])
+
+    rfork_model = _DiscardedModel()
+    expected_model = SimpleNamespace()
+    get_model_calls = []
+
+    def fake_get_model(**kwargs):
+        get_model_calls.append(kwargs)
+        assert vllm_config.compilation_config.static_forward_context == {
+            "unrelated.layer": unrelated_layer,
+        }
+        assert vllm_config.compilation_config.static_all_moe_layers == ["unrelated.layer"]
+        assert _ROPE_DICT == {}
+        vllm_config.compilation_config.static_forward_context["model.layers.0.mlp.down_proj"] = fallback_down_proj
+        return expected_model
+
+    rfork_worker = SimpleNamespace(
+        is_seed_available=lambda: True,
+        pre_transfer=lambda model: True,
+        transfer=lambda model: False,
+        post_transfer=lambda: True,
+        reset_transfer_state=lambda: None,
+        start_seed_service=lambda model: None,
+    )
+
+    monkeypatch.setattr(loader, "_ensure_rfork_worker", lambda vc, mc: rfork_worker)
+    monkeypatch.setattr(model_loader, "get_model", fake_get_model)
+    monkeypatch.setattr(
+        "vllm_ascend.model_loader.rfork.rfork_loader.initialize_model",
+        lambda **kwargs: rfork_model,
+    )
+    monkeypatch.setattr(
+        "vllm_ascend.model_loader.rfork.rfork_loader.process_weights_after_loading",
+        lambda *args, **kwargs: None,
+    )
+
+    model = loader.load_model(vllm_config=vllm_config, model_config=model_config)
+
+    assert model is expected_model
+    assert len(get_model_calls) == 1
+    # Only the discarded RFork model state was removed. Unrelated state and
+    # fallback get_model registrations must remain for later profile/compile.
+    assert vllm_config.compilation_config.static_forward_context == {
+        "unrelated.layer": unrelated_layer,
+        "model.layers.0.mlp.down_proj": fallback_down_proj,
+    }
+    assert vllm_config.compilation_config.static_all_moe_layers == ["unrelated.layer"]
+    assert _ROPE_DICT == {}
+
+
+def test_rfork_seed_miss_fallback_preserves_existing_process_global_state(monkeypatch):
+    import vllm.model_executor.model_loader as model_loader
+    from vllm.model_executor.layers.rotary_embedding import _ROPE_DICT
+
+    load_config = DummyLoadConfig({"model_url": "model", "model_deploy_strategy_name": "tp8"})
+    loader = RForkModelLoader(load_config)
+    model_config = SimpleNamespace(dtype=torch.float32, model="/models/test", quantization="ascend")
+    vllm_config = _vllm_config(model_config=model_config)
+    existing_layer = SimpleNamespace()
+    vllm_config.compilation_config = SimpleNamespace(
+        static_forward_context={"existing.layer": existing_layer},
+        static_all_moe_layers=["existing.layer"],
+    )
+    rope_key = ("identity", 1.0, 32768)
+    rope_value = object()
+    _ROPE_DICT[rope_key] = rope_value
+
+    expected_model = SimpleNamespace()
+
+    def fake_get_model(**kwargs):
+        assert vllm_config.compilation_config.static_forward_context == {
+            "existing.layer": existing_layer,
+        }
+        assert vllm_config.compilation_config.static_all_moe_layers == ["existing.layer"]
+        assert _ROPE_DICT[rope_key] is rope_value
+        return expected_model
+
+    rfork_worker = SimpleNamespace(
+        is_seed_available=lambda: False,
+        post_transfer=lambda: True,
+        reset_transfer_state=lambda: None,
+        start_seed_service=lambda model: None,
+    )
+
+    monkeypatch.setattr(loader, "_ensure_rfork_worker", lambda vc, mc: rfork_worker)
+    monkeypatch.setattr(model_loader, "get_model", fake_get_model)
+    monkeypatch.setattr(
+        "vllm_ascend.model_loader.rfork.rfork_loader.initialize_model",
+        lambda **kwargs: pytest.fail("seed-miss fallback must not initialize an RFork model"),
+    )
+
+    model = loader.load_model(vllm_config=vllm_config, model_config=model_config)
+
+    assert model is expected_model
+    assert vllm_config.compilation_config.static_forward_context == {
+        "existing.layer": existing_layer,
+    }
+    assert vllm_config.compilation_config.static_all_moe_layers == ["existing.layer"]
+    assert _ROPE_DICT[rope_key] is rope_value
+
+
+def test_reset_process_global_model_state_is_safe_when_attrs_missing():
+    vllm_config = SimpleNamespace(compilation_config=SimpleNamespace())
+    # Should not raise even when static_forward_context / static_all_moe_layers
+    # are absent (some vLLM versions).
+    _reset_process_global_model_state(vllm_config)
+
+
+def test_rfork_pre_transfer_weight_processing_unwraps_and_restores_quant_methods():
+    import vllm_ascend.ops.fused_moe.fused_moe as fused_moe_module
+
+    class _FakeAscendFusedMoE:
+        def __init__(self, quant_method):
+            self.quant_method = quant_method
+
+    calls = []
+
+    def original_process_weights(*args, **kwargs):
+        calls.append("original")
+
+    @wraps(original_process_weights)
+    def wrapped_process_weights(*args, **kwargs):
+        calls.append("wrapped")
+        original_process_weights(*args, **kwargs)
+
+    quant_method = SimpleNamespace(process_weights_after_loading=wrapped_process_weights)
+    fused_moe_layer = _FakeAscendFusedMoE(quant_method)
+    other_layer = SimpleNamespace()
+
+    class _FakeModule:
+        def modules(self):
+            return iter([self, fused_moe_layer, other_layer])
+
+    fake_module = _FakeModule()
+
+    missing_marker = object()
+    real_fused_moe_cls = getattr(fused_moe_module, "AscendFusedMoE", missing_marker)
+    fused_moe_module.AscendFusedMoE = _FakeAscendFusedMoE
+    try:
+        with _rfork_pre_transfer_weight_processing(fake_module):
+            assert quant_method.process_weights_after_loading is original_process_weights
+            quant_method.process_weights_after_loading()
+        assert quant_method.process_weights_after_loading is wrapped_process_weights
+        assert calls == ["original"]
+
+        # Restoration must happen even when the wrapped block raises.
+        with pytest.raises(RuntimeError, match="boom"), _rfork_pre_transfer_weight_processing(fake_module):
+            assert quant_method.process_weights_after_loading is original_process_weights
+            raise RuntimeError("boom")
+        assert quant_method.process_weights_after_loading is wrapped_process_weights
+    finally:
+        if real_fused_moe_cls is missing_marker:
+            delattr(fused_moe_module, "AscendFusedMoE")
+        else:
+            fused_moe_module.AscendFusedMoE = real_fused_moe_cls

--- a/vllm_ascend/model_loader/rfork/rfork_loader.py
+++ b/vllm_ascend/model_loader/rfork/rfork_loader.py
@@ -17,7 +17,9 @@
 import gc
 import os
 import time
+from contextlib import contextmanager
 from copy import copy
+from typing import Any, cast
 
 import torch
 import torch.nn as nn
@@ -105,6 +107,93 @@ def _make_fallback_load_config(load_config: LoadConfig) -> LoadConfig:
     fallback_load_config.load_format = "auto"
     fallback_load_config.model_loader_extra_config = {}
     return fallback_load_config
+
+
+def _reset_process_global_model_state(vllm_config: VllmConfig, model: Module | None = None) -> None:
+    """Clear process-global registries populated by a discarded model.
+
+    RFork fallback re-runs ``get_model`` in the same worker process after
+    discarding a failed model. Layer ``__init__`` registers each prefix into
+    ``compilation_config.static_forward_context`` (used by Attention, FusedMoE,
+    DeepseekV32IndexerCache, Compressor, KDA, GDN, ...) and raises
+    ``Duplicate layer name`` if a prefix is already present. ``del model`` only
+    releases the module instance; the registries survive. Remove only entries
+    owned by the discarded model so unrelated state in the same worker remains
+    available for later profiling/compilation.
+    """
+    stale_modules = set(model.modules()) if model is not None else None
+    removed_names: set[str] = set()
+    compilation_config = getattr(vllm_config, "compilation_config", None)
+    if compilation_config is not None:
+        static_forward_context = getattr(compilation_config, "static_forward_context", None)
+        if isinstance(static_forward_context, dict):
+            if stale_modules is None:
+                removed_names.update(static_forward_context)
+                static_forward_context.clear()
+            else:
+                for name, module in list(static_forward_context.items()):
+                    if module in stale_modules:
+                        removed_names.add(name)
+                        del static_forward_context[name]
+        static_all_moe_layers = getattr(compilation_config, "static_all_moe_layers", None)
+        if isinstance(static_all_moe_layers, list):
+            if stale_modules is None:
+                static_all_moe_layers.clear()
+            else:
+                static_all_moe_layers[:] = [
+                    layer
+                    for layer in static_all_moe_layers
+                    if layer not in stale_modules and layer not in removed_names
+                ]
+
+    # ROPE instances are cached globally and keyed by config; clear them so the
+    # re-initialized model builds fresh rope rather than reusing stale entries
+    # bound to the discarded model.
+    try:
+        from vllm.model_executor.layers.rotary_embedding import _ROPE_DICT
+
+        if isinstance(_ROPE_DICT, dict):
+            _ROPE_DICT.clear()
+    except Exception as e:  # pragma: no cover - best-effort across vLLM versions
+        logger.debug("RFork fallback: skip clearing _ROPE_DICT: %s", e)
+
+
+@contextmanager
+def _rfork_pre_transfer_weight_processing(model: Module):
+    """Bypass FusedMoE post-load validation during RFork pre-transfer layout work.
+
+    AscendFusedMoE wraps quant_method.process_weights_after_loading with a
+    shared-expert consistency check. RFork's processed-layout transfer calls
+    process_weights_after_loading before receiver weights arrive, so only this
+    RFork phase should use the wrapped function's original implementation.
+    """
+    from vllm_ascend.ops.fused_moe.fused_moe import AscendFusedMoE
+
+    restored: list[tuple[Any, object]] = []
+    seen_quant_methods: set[int] = set()
+    for module in model.modules():
+        if not isinstance(module, AscendFusedMoE):
+            continue
+
+        quant_method = getattr(module, "quant_method", None) or getattr(module, "_quant_method", None)
+        if quant_method is None or id(quant_method) in seen_quant_methods:
+            continue
+
+        process_weights = getattr(quant_method, "process_weights_after_loading", None)
+        original_process_weights = getattr(process_weights, "__wrapped__", None)
+        if original_process_weights is None:
+            continue
+
+        quant_method = cast(Any, quant_method)
+        seen_quant_methods.add(id(quant_method))
+        restored.append((quant_method, process_weights))
+        quant_method.process_weights_after_loading = original_process_weights
+
+    try:
+        yield
+    finally:
+        for quant_method, process_weights in restored:
+            quant_method.process_weights_after_loading = process_weights
 
 
 def _is_layer_sharding_enabled(vllm_config: VllmConfig) -> bool:
@@ -274,7 +363,8 @@ class RForkModelLoader(BaseModelLoader):
 
                 if processed_layout_transfer:
                     logger.info("RFork uses post-load tensor layout transfer for quantized model.")
-                    process_weights_after_loading(model, model_config, target_device)
+                    with _rfork_pre_transfer_weight_processing(model):
+                        process_weights_after_loading(model, model_config, target_device)
 
                 weight_load_start_time = time.perf_counter()
                 if not rfork_worker.pre_transfer(model):
@@ -300,6 +390,13 @@ class RForkModelLoader(BaseModelLoader):
                 rfork_worker.reset_transfer_state()
 
                 if need_del:
+                    # initialize_model populates process-global layer registries
+                    # (compilation_config.static_forward_context, _ROPE_DICT)
+                    # that survive `del model` and would raise "Duplicate layer
+                    # name" on re-init. Clear only entries owned by this failed
+                    # RFork model before rebuilding in the same process.
+                    _reset_process_global_model_state(vllm_config, model)
+
                     del model
                     gc.collect()
                     torch.npu.empty_cache()


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #11409.

This PR fixes two RFork failure paths seen when processed-layout transfer is used with quantized DeepSeekV2-family models, for example GLM-5 W4A8 + MTP with `multistream_overlap_shared_expert`.

1. During the RFork pre-transfer post-process, `process_weights_after_loading` can run the `AscendFusedMoE` shared-expert consistency forward while receiver weights are still empty. That can produce NaNs and abort the transfer with `FusedMoE shared experts split computation does not match the integrated computation`. This PR keeps the workaround scoped to the RFork loader: only for the pre-transfer layout-processing call, it temporarily uses each wrapped FusedMoE quant method's original `process_weights_after_loading` implementation saved by `functools.wraps`, then restores the wrapper immediately after the call.

2. If RFork transfer fails after a worker has initialized a temporary RFork model, fallback re-runs the default loader in the same process. The failed model's process-global registrations survive `del model` and can make re-initialization fail with `Duplicate layer name`. This PR removes only the registry entries owned by that discarded RFork model before fallback re-initialization, while leaving unrelated or newly rebuilt fallback registrations intact for later profile/compile. If fallback happens before RFork model initialization, such as a seed miss, the registry cleanup is skipped.

3. CI pre-commit was failing before reaching the changed Python files because the self-hosted runner's `markdownlint-cli` hook setup used nodeenv's moving default Node version and hit missing nodeenv/node_modules files. This PR pins the markdownlint hook to Node 20.19.0 so the hook environment is deterministic.

Together these changes avoid the common pre-transfer shared-expert validation failure and keep the fallback path from taking the worker down on future RFork failures, without changing the non-RFork FusedMoE wrapper path.

### Does this PR introduce _any_ user-facing change?

No public API or configuration change.

Users running RFork with affected quantized DeepSeekV2-family models no longer hit the worker startup crash in this path. Users not using RFork, processed-layout transfer, or the affected shared-expert validation path are unchanged.

### How was this patch tested?

Unit tests were added/updated in `tests/ut/model_loader/rfork/test_rfork_loader.py` for:

- RFork fallback removing only failed-model process-global registrations before the fallback `get_model` call, while preserving unrelated state and fallback registrations needed by later profile/compile.
- Seed-miss fallback preserving existing process-global state because no RFork model was initialized yet.
- The registry reset helper remaining safe when optional attributes are absent.
- RFork pre-transfer weight processing temporarily unwrapping FusedMoE quant-method post-load wrappers and restoring them afterward, including exception paths.

Local checks run for this PR:

- `python -m ruff check vllm_ascend/model_loader/rfork/rfork_loader.py tests/ut/model_loader/rfork/test_rfork_loader.py`
- `python -m ruff format --check vllm_ascend/model_loader/rfork/rfork_loader.py tests/ut/model_loader/rfork/test_rfork_loader.py`
- `python -m py_compile vllm_ascend/model_loader/rfork/rfork_loader.py tests/ut/model_loader/rfork/test_rfork_loader.py`
- `python -m pre_commit clean; python -m pre_commit run markdownlint --hook-stage manual --files README.md`
- `git diff --check main/main...HEAD`
- `git diff --check`
- `git merge-tree --write-tree main/main HEAD`

Targeted pytest was attempted but this local Windows environment is missing the upstream `vllm` package, so collection stopped at `ModuleNotFoundError: No module named 'vllm'` before the tests could run locally.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
