### PR TITLE
[CI] Optimize nightly A3 test scheduling

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -79,22 +79,25 @@ a3:
       - name: multi-node-deepseek-v3.2-W8A8-EP
         config_file_path: DeepSeek-V3_2-W8A8-EP.yaml
         size: 4
-      - name: multi-node-deepseek-r1-w8a8-longseq
-        config_file_path: DeepSeek-R1-W8A8-longseq.yaml
+      - name: multi-node-deepseek-v3.1
+        config_file_path: DeepSeek-V3.1-BF16.yaml
+        size: 2
+      - name: multi-node-GLM-5.2-w8a8-A3
+        config_file_path: GLM5_2-W8A8-A3-dual-nodes.yaml
         size: 2
   double_node:
     test_config:
+      - name: multi-node-deepseek-r1-w8a8-longseq
+        config_file_path: DeepSeek-R1-W8A8-longseq.yaml
+        size: 2
       - name: multi-node-qwen3-dp
         config_file_path: Qwen3-235B-A22B.yaml
         size: 2
-      - name: multi-node-qwenw8a8-2node-eplb
-        config_file_path: Qwen3-235B-W8A8-EPLB.yaml
+      - name: multi-node-GLM-5.1-w8a8-A3
+        config_file_path: GLM5_1-W8A8-A3-dual-nodes.yaml
         size: 2
       - name: multi-node-dpsk3.2-2node
         config_file_path: DeepSeek-V3_2-W8A8-A3-dual-nodes.yaml
-        size: 2
-      - name: multi-node-qwenw8a8-2node-longseq
-        config_file_path: Qwen3-235B-W8A8-longseq.yaml
         size: 2
       - name: multi-node-qwen-disagg-pd
         config_file_path: Qwen3-235B-disagg-pd.yaml
@@ -102,14 +105,11 @@ a3:
       - name: multi-node-qwen-vl-disagg-pd
         config_file_path: Qwen3-VL-235B-disagg-pd.yaml
         size: 2
-      - name: multi-node-deepseek-v3.1
-        config_file_path: DeepSeek-V3.1-BF16.yaml
+      - name: multi-node-qwenw8a8-2node-eplb
+        config_file_path: Qwen3-235B-W8A8-EPLB.yaml
         size: 2
-      - name: multi-node-GLM-5.1-w8a8-A3
-        config_file_path: GLM5_1-W8A8-A3-dual-nodes.yaml
-        size: 2
-      - name: multi-node-GLM-5.2-w8a8-A3
-        config_file_path: GLM5_2-W8A8-A3-dual-nodes.yaml
+      - name: multi-node-qwenw8a8-2node-longseq
+        config_file_path: Qwen3-235B-W8A8-longseq.yaml
         size: 2
   single_node:
     test_config:
@@ -119,45 +119,45 @@ a3:
       - name: deepseek-r1-0528-w8a8
         os: linux-aarch64-a3-16
         config_file_path: DeepSeek-R1-0528-W8A8.yaml
+      - name: MiniMax-M2.5-w8a8-QuaRot-A3
+        os: linux-aarch64-a3-16
+        config_file_path: MiniMax-M2.5-w8a8-QuaRot-A3.yaml
+      - name: DeepSeek-V4-Flash-W8A8-A3
+        os: linux-aarch64-a3-16
+        config_file_path: DeepSeek-V4-Flash-W8A8-A3.yaml
       - name: kimi-k2-thinking
         os: linux-aarch64-a3-16
         config_file_path: Kimi-K2-Thinking.yaml
-      - name: qwen3-vl-235b-a22b-instruct-w8a8
-        os: linux-aarch64-a3-16
-        config_file_path: Qwen3-VL-235B-A22B-Instruct-W8A8.yaml
-      - name: deepseek-r1-0528-w8a8-prefix-cache
-        os: linux-aarch64-a3-16
-        config_file_path: Prefix-Cache-DeepSeek-R1-0528-W8A8.yaml
-      - name: deepseek-v3-2-w8a8
-        os: linux-aarch64-a3-16
-        config_file_path: DeepSeek-V3.2-W8A8.yaml
-      - name: glm-4.7-w8a8
-        os: linux-aarch64-a3-16
-        config_file_path: GLM-4.7.yaml
-      - name: glm-5.1-w8a8-prefill-mc2
-        os: linux-aarch64-a3-16
-        config_file_path: GLM-5.1-W8A8-PrefillMC2.yaml
       - name: kimi-k2.5
         os: linux-aarch64-a3-16
         config_file_path: Kimi-K2.5.yaml
+      - name: Qwen3.5-122B-A10B-W8A8-A3
+        os: linux-aarch64-a3-16
+        config_file_path: Qwen3.5-122B-A10B-W8A8-A3.yaml
+      - name: Qwen3.5-397B-A17B-w8a8-mtp-longseq
+        os: linux-aarch64-a3-16
+        config_file_path: Qwen3.5-397B-A17B-w8a8-mtp-longseq-A3.yaml
+      - name: deepseek-v3-2-w8a8
+        os: linux-aarch64-a3-16
+        config_file_path: DeepSeek-V3.2-W8A8.yaml
+      - name: glm-5.1-w8a8-prefill-mc2
+        os: linux-aarch64-a3-16
+        config_file_path: GLM-5.1-W8A8-PrefillMC2.yaml
       - name: qwen3-235b-a22b-w8a8
         os: linux-aarch64-a3-16
         config_file_path: Qwen3-235B-A22B-W8A8.yaml
       - name: Qwen3.5-397B-A17B-w8a8-mtp
         os: linux-aarch64-a3-16
         config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3.yaml
-      - name: MiniMax-M2.5-w8a8-QuaRot-A3
+      - name: deepseek-r1-0528-w8a8-prefix-cache
         os: linux-aarch64-a3-16
-        config_file_path: MiniMax-M2.5-w8a8-QuaRot-A3.yaml
-      - name: Qwen3.5-122B-A10B-W8A8-A3
+        config_file_path: Prefix-Cache-DeepSeek-R1-0528-W8A8.yaml
+      - name: glm-4.7-w8a8
         os: linux-aarch64-a3-16
-        config_file_path: Qwen3.5-122B-A10B-W8A8-A3.yaml
-      - name: DeepSeek-V4-Flash-W8A8-A3
+        config_file_path: GLM-4.7.yaml
+      - name: qwen3-vl-235b-a22b-instruct-w8a8
         os: linux-aarch64-a3-16
-        config_file_path: DeepSeek-V4-Flash-W8A8-A3.yaml
-      - name: Qwen3.5-397B-A17B-w8a8-mtp-longseq
-        os: linux-aarch64-a3-16
-        config_file_path: Qwen3.5-397B-A17B-w8a8-mtp-longseq-A3.yaml
+        config_file_path: Qwen3-VL-235B-A22B-Instruct-W8A8.yaml
   multi_card:
     test_config:
       # pytest-driven tests
@@ -165,12 +165,18 @@ a3:
         os: linux-aarch64-a3-4
         tests: tests/e2e/weekly/single_node/models/test_qwen3_30b_acc.py
       # YAML-driven tests
-      - name: qwen3-30b-a3b-w8a8
-        os: linux-aarch64-a3-4
-        config_file_path: Qwen3-30B-A3B-W8A8.yaml
+      - name: Qwen3.5-27B-w8a8-A3
+        os: linux-aarch64-a3-2
+        config_file_path: Qwen3.5-27B-w8a8-A3.yaml
       - name: qwen3-32b-int8
         os: linux-aarch64-a3-4
         config_file_path: Qwen3-32B-Int8.yaml
+      - name: Qwen3-32B-QuaRot
+        os: linux-aarch64-a3-2
+        config_file_path: Qwen3-32B-QuaRot-eagle3.yaml
+      - name: qwen3-30b-a3b-w8a8
+        os: linux-aarch64-a3-4
+        config_file_path: Qwen3-30B-A3B-W8A8.yaml
       - name: qwen3-32b-int8-prefix-cache
         os: linux-aarch64-a3-4
         config_file_path: Prefix-Cache-Qwen3-32B-Int8.yaml
@@ -180,9 +186,3 @@ a3:
       - name: Qwen3-30B-QuaRot
         os: linux-aarch64-a3-2
         config_file_path: Qwen3-30B-QuaRot-eagle3.yaml
-      - name: Qwen3-32B-QuaRot
-        os: linux-aarch64-a3-2
-        config_file_path: Qwen3-32B-QuaRot-eagle3.yaml
-      - name: Qwen3.5-27B-w8a8-A3
-        os: linux-aarch64-a3-2
-        config_file_path: Qwen3.5-27B-w8a8-A3.yaml

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -179,7 +179,7 @@ jobs:
       (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 3
       matrix:
         vllm_ascend_branch: ${{ fromJSON(needs.setup-vars.outputs.vllm_ascend_branches) }}
         test_config: ${{ fromJson(needs.setup-vars.outputs.multi_node) }}
@@ -217,7 +217,7 @@ jobs:
       (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
     strategy:
       fail-fast: false
-      max-parallel: 3
+      max-parallel: 4
       matrix:
         vllm_ascend_branch: ${{ fromJSON(needs.setup-vars.outputs.vllm_ascend_branches) }}
         test_config: ${{ fromJson(needs.setup-vars.outputs.double_node) }}
@@ -255,7 +255,7 @@ jobs:
       (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
     strategy:
       fail-fast: false
-      max-parallel: 7
+      max-parallel: 9
       matrix:
         vllm_ascend_branch: ${{ fromJSON(needs.setup-vars.outputs.vllm_ascend_branches) }}
         test_config: ${{ fromJson(needs.setup-vars.outputs.single_node) }}
@@ -277,7 +277,7 @@ jobs:
 
   multi-card-tests:
     name: single-node
-    needs: [setup-vars, parse-trigger, build-image, single-node-tests]
+    needs: [setup-vars, parse-trigger, build-image, double-node-tests]
     if: >-
       always() &&
       needs.parse-trigger.outputs.run == 'true' &&


### PR DESCRIPTION
### What this PR does / why we need it?

The current nightly-a3 test time is estimated to be about [11 hours](https://github.com/vllm-project/vllm-ascend/actions/runs/28746142984), which is too long and the NPU utilization is low. Scheduling optimization is required.

The following optimizations have been made based on the data summarized in the figure below:

1. After **22:00 (Beijing time)**, 8 CI resource machines were put into Nightly testing for multi-machine testing until 4:30 am when they were released, and the concurrency strategy was adjusted accordingly.
2. Optimized the test job execution order:
  `multi-node-tests`→ `double-node-tests` → `multi-card-tests` + `single-node-tests`  
3. Reordered test cases within each job to maximize resource utilization.
4. Improved `multi-node-tests` resource utilization by adding two `double-node-tests` test cases.

#### nightly-a3 Gantt chart of each job：
<img width="1110" height="467" alt="image" src="https://github.com/user-attachments/assets/0f0c1ded-ea31-49bf-8940-f59ecc935d15" />

#### nightly-a3 use case time-consuming Gantt chart：
<img width="745" height="1008" alt="image" src="https://github.com/user-attachments/assets/3a592976-b5f9-49eb-be93-a3ab1b5880ec" />

#### Nightly-a3 use case time consumption details chart：
<img width="790" height="691" alt="image" src="https://github.com/user-attachments/assets/90675e1a-4c41-4639-9331-6726f288a463" />
<img width="751" height="747" alt="image" src="https://github.com/user-attachments/assets/2ce83a97-f1d0-46a2-8591-7be9e91bddb8" />

<img width="796" height="455" alt="image" src="https://github.com/user-attachments/assets/34b41b66-0d9f-4b57-a7b7-21d45e363c4d" />

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
