### PR TITLE
[BugFix]A2G3 adapted for the CH version of HDK

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,9 @@ def get_chip_type() -> str:
         elif "950" in chip_name:
             assert npu_name
             return (chip_name + "_" + npu_name).lower()
+        elif "a2g3" in chip_name.lower():
+            # A2 case: CH version of the HDK
+            return "ascend910b1"
         else:
             raise ValueError(f"Unable to recognize chip name: {chip_name}, please manually set env SOC_VERSION")
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION

### What this PR does / why we need it?
VLLM ASCEND is adapted for the overseas version of HDK A2G3. To ensure that VLLM ASCEND can be properly installed and used in scenarios where the overseas version of HDK is being used.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
the installation and operation of VLLM ASCEND in the environment of the overseas version of HDK must be carried out. After self-verification confirms no issues, the results still need to be provided by the testers.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
