### PR TITLE
[BugFix][v0.23.0] Avoid partial MiniMax parameter arguments

### DIFF
--- a/tests/ut/patch/platform/test_patch_minimax_m2_tool_call_parser.py
+++ b/tests/ut/patch/platform/test_patch_minimax_m2_tool_call_parser.py
@@ -108,6 +108,17 @@ def test_plain_content_before_tool_call_is_preserved():
     assert len(parser.prev_tool_call_arr) == 1
 
 
+def test_plain_content_before_partial_tool_call_omits_tool_calls_payload():
+    parser = MinimaxM2ToolParser(FakeTokenizer())
+    results = _feed(parser, ["Let me check. <minimax:tool_call>"])
+
+    assert len(results) == 1
+    assert results[0].content == "Let me check. "
+    assert results[0].tool_calls == []
+    assert "tool_calls" not in results[0].model_dump(exclude_unset=True)
+    assert "tool_calls" not in results[0].model_dump_json(exclude_unset=True)
+
+
 def test_streaming_emits_tool_name_before_argument_fragments():
     parser = MinimaxM2ToolParser(FakeTokenizer())
     results = _feed(
@@ -128,11 +139,11 @@ def test_streaming_emits_tool_name_before_argument_fragments():
     assert _collect_content(results) == "Let me check. "
     assert tool_deltas[0].function.name == "get_weather"
     assert tool_deltas[0].function.arguments is None
-    assert argument_fragments == ['{"city":"Sea', 'ttle"', "}"]
+    assert argument_fragments == ['{"city":"Seattle"', "}"]
     assert "".join(argument_fragments) == '{"city":"Seattle"}'
 
 
-def test_streaming_partial_arguments_before_invoke_closes():
+def test_streaming_waits_for_parameter_close_before_arguments():
     parser = MinimaxM2ToolParser(FakeTokenizer())
     results = _feed(
         parser,
@@ -147,8 +158,80 @@ def test_streaming_partial_arguments_before_invoke_closes():
 
     assert tool_deltas[0].function.name == "get_weather"
     assert tool_deltas[0].function.arguments is None
-    assert tool_deltas[1].function.arguments == '{"city":"Sea'
+    assert len(tool_deltas) == 1
     assert parser.prev_tool_call_arr == []
+
+
+def test_parameter_end_tag_token_pieces_not_streamed_as_arguments():
+    parser = MinimaxM2ToolParser(
+        FakeTokenizer(),
+        tools=[
+            ChatCompletionToolsParam(
+                function=FunctionDefinition(
+                    name="write_file",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "content": {"type": "string"},
+                            "path": {"type": "string"},
+                        },
+                    },
+                ),
+            )
+        ],
+    )
+
+    results = _feed(
+        parser,
+        [
+            ("", [TC_START_ID]),
+            "\n",
+            "<",
+            "invoke",
+            " name",
+            '="',
+            "write",
+            "_file",
+            '">\n',
+            "<",
+            "parameter",
+            " name",
+            '="',
+            "path",
+            '">',
+            "a",
+            ".txt",
+            "</",
+            "parameter",
+            ">\n",
+            "<",
+            "parameter",
+            " name",
+            '="',
+            "content",
+            '">',
+            "123",
+            "</",
+            "parameter",
+            ">\n",
+            "</",
+            "invoke",
+            ">\n",
+            ("", [TC_END_ID]),
+            ("", [EOS_ID]),
+        ],
+    )
+
+    args = _collect_tool_calls(results)[0]["arguments"]
+
+    assert "</parameter" not in args
+    assert json.loads(args) == {"path": "a.txt", "content": "123"}
+    assert parser.prev_tool_call_arr == [
+        {
+            "name": "write_file",
+            "arguments": {"path": "a.txt", "content": "123"},
+        }
+    ]
 
 
 def test_complete_single_chunk_still_reconstructs_tool_call():

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -629,15 +629,13 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.models.minimax_m2.MiniMaxM2MoE.forward`
 #    Why:
-#       In TP mode, MiniMax-M2 MoE needs a backend-aware reduction path to avoid
-#       unnecessary communication / maintain correctness on NPU.
+#       MiniMax-M2 routing should keep router logits in fp32 on NPU.
 #    How：
-#       Replace the forward to call `experts.maybe_all_reduce_tensor_model_parallel`
-#       when `tp_size > 1`.
+#       Replace the forward to cast hidden states to fp32 before the gate.
 #    Related PR (if no, explain why):
 #       No, model-specific behavior.
 #    Future Plan:
-#       Move this behavior upstream once a generic MoE reduce hook exists.
+#       Remove this patch once upstream behavior is sufficient for Ascend.
 #
 #   2. `vllm.model_executor.models.minimax_m2.MiniMaxM2Attention.forward`
 #    Why:

--- a/vllm_ascend/patch/platform/patch_minimax_m2_tool_call_parser.py
+++ b/vllm_ascend/patch/platform/patch_minimax_m2_tool_call_parser.py
@@ -235,35 +235,10 @@ def _serialize_partial_param_value(
     self: MinimaxM2ToolParser,
     value: str,
     param_types: list[str],
-    *,
-    is_complete: bool,
 ) -> str:
     value = value.strip()
-    if is_complete:
-        converted = _coerce_param_value(value, param_types)
-        return json.dumps(converted, ensure_ascii=False)
-
-    if not value:
-        return ""
-
-    normalized_types = {t.lower() for t in param_types}
-    string_types = {"string", "str", "text"}
-
-    if "null" in normalized_types and not (normalized_types & string_types) and "null".startswith(value.lower()):
-        return value.lower()
-
-    if {"boolean", "bool"} & normalized_types:
-        lower_value = value.lower()
-        if any(candidate.startswith(lower_value) for candidate in ("true", "false")):
-            return lower_value
-
-    if {"integer", "int", "number", "float"} & normalized_types:
-        return value
-
-    if {"object", "array"} & normalized_types and value[:1] in "{[":
-        return value
-
-    return json.dumps(value, ensure_ascii=False)[:-1]
+    converted = _coerce_param_value(value, param_types)
+    return json.dumps(converted, ensure_ascii=False)
 
 
 def _build_partial_arguments(
@@ -290,29 +265,21 @@ def _build_partial_arguments(
         value_start = name_end + 1
         value_end = invoke_body.find("</parameter>", value_start)
         param_complete = value_end != -1
-        if param_complete:
-            param_value = invoke_body[value_start:value_end]
-            search_pos = value_end + len("</parameter>")
-        else:
-            param_value = invoke_body[value_start:]
-            search_pos = len(invoke_body)
-
-        if not param_complete and not param_value.strip():
+        if not param_complete:
             break
+
+        param_value = invoke_body[value_start:value_end]
+        search_pos = value_end + len("</parameter>")
 
         param_types = _get_param_types_from_config(param_name, param_config)
         serialized_value = self._serialize_partial_param_value(
             param_value,
             param_types,
-            is_complete=param_complete,
         )
         if not serialized_value:
             break
 
         args_parts.append(f"{json.dumps(param_name, ensure_ascii=False)}:{serialized_value}")
-
-        if not param_complete:
-            break
 
     if not args_parts:
         return "{}" if invoke_complete else ""
@@ -490,11 +457,14 @@ def _patched_extract_tool_calls_streaming(
 
     delta_tool_call = self._extract_delta_tool_call(current_text)
 
-    if delta_tool_call or content_before:
+    if delta_tool_call:
         return DeltaMessage(
             content=content_before,
-            tool_calls=[delta_tool_call] if delta_tool_call else None,
+            tool_calls=[delta_tool_call],
         )
+
+    if content_before:
+        return DeltaMessage(content=content_before)
 
     if (
         not delta_text

--- a/vllm_ascend/patch/worker/patch_minimax_m2.py
+++ b/vllm_ascend/patch/worker/patch_minimax_m2.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# MiniMax-M2 on Ascend: MoE all_reduce, fused attention, fp8 load dequant.
+# MiniMax-M2 on Ascend: MoE router logits, fused attention, fp8 load dequant.
 #
 
 from collections.abc import Iterable
@@ -43,7 +43,7 @@ FP8_DTYPES = tuple(
 
 
 # ---------------------------------------------------------------------------
-# MiniMaxM2MoE.forward: use maybe_all_reduce_tensor_model_parallel
+# MiniMaxM2MoE.forward: keep router logits in fp32 on NPU.
 # ---------------------------------------------------------------------------
 def _patched_moe_forward(
     self,
@@ -55,8 +55,6 @@ def _patched_moe_forward(
     # router_logits: (num_tokens, n_experts)
     router_logits, _ = self.gate(hidden_states.to(torch.float32))
     final_hidden_states = self.experts(hidden_states=hidden_states, router_logits=router_logits)
-    if self.tp_size > 1:
-        final_hidden_states = self.experts.maybe_all_reduce_tensor_model_parallel(final_hidden_states)
     return final_hidden_states.view(num_tokens, hidden_dim)
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #10758. Backports the MiniMax streaming fixes from #11384 to `releases/v0.23.0`.

The main-branch #11384 can remove the stale local MiniMax parser patch because main has moved to the newer vLLM parser-engine MiniMax path. The `releases/v0.23.0` branch is pinned to vLLM `v0.23.0`, where that MiniMax parser-engine module is not available, so this release PR keeps the local MiniMax parser patch and ports the two reproduced #10758 fixes into it:

- stream MiniMax-M2 argument deltas only after the current `<parameter>` has a complete `</parameter>` end tag, preventing split tag pieces such as `</`, `parameter`, and `>` from leaking into JSON arguments
- avoid constructing `DeltaMessage(tool_calls=None)` when plain content and a partial tool-call start arrive in the same streaming chunk; the resulting content-only delta serializes without `tool_calls`, matching https://github.com/vllm-project/vllm/issues/44105

This PR also removes the obsolete MiniMax worker-side manual TP all-reduce call while keeping the NPU fp32 router-logits behavior. The verified vLLM MoE runner no longer exposes that manual reduction hook, and leaving it in the release branch blocks MiniMax TP8+EP startup.

This intentionally does not copy #10377's broad empty-list workaround.

### Does this PR introduce _any_ user-facing change?

Yes. Streaming MiniMax-M2 tool-call argument deltas are emitted after each parameter closes instead of while a parameter is still open. This prevents malformed partial XML tag pieces from appearing in streamed JSON arguments. Content-only deltas before a partial tool call also serialize without empty `tool_calls`.

The worker-side change is a compatibility cleanup for MiniMax TP/EP serving on the verified vLLM stack; it removes a stale manual reduction call that the current MoE runner no longer supports.

### How was this patch tested?

- `python -m pytest -q tests/ut/patch/platform/test_patch_minimax_m2_tool_call_parser.py tests/ut/patch/platform/test_patch_minimax_usage_accounting.py`
- Replayed the #10758 raw completion with the MiniMax-M2.5 tokenizer; streamed fragments reconstructed `{"path":"a.txt","content":"123"}` without `</parameter>` leakage.
- Reproduced the leading-content plus partial-tool-call-start path and verified it returns content with an empty internal default while serialized payloads omit `tool_calls`.
- `ruff check vllm_ascend/patch/platform/patch_minimax_m2_tool_call_parser.py tests/ut/patch/platform/test_patch_minimax_m2_tool_call_parser.py`
- `python -m py_compile vllm_ascend/patch/platform/patch_minimax_m2_tool_call_parser.py`
- `ruff check vllm_ascend/patch/worker/patch_minimax_m2.py vllm_ascend/patch/__init__.py`
- `python -m py_compile vllm_ascend/patch/worker/patch_minimax_m2.py vllm_ascend/patch/__init__.py`
- Live MiniMax-M2.5 real-weight service on TP8+EP with the verified vLLM main commit:
  - `/v1/models` returned 200
  - text chat request returned 200 with non-empty output
  - non-streaming auto `write_file` tool request returned 200 with arguments `{"path": "a.txt", "content": "123"}`
  - streaming auto `write_file` tool request returned 200; 30 SSE chunks / 3 argument fragments reconstructed `{"path": "a.txt", "content": "123"}` with no `<parameter>` / `</parameter>` leakage and no `tool_calls: null` deltas

Note: live validation used `xgrammar==0.2.1`, matching the verified vLLM checkout requirement.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
