### PR TITLE
[BugFix][CI] inline run.sh into lws.yaml.jinja2 via {% include %} to eliminate PVC file conflict

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -154,10 +154,6 @@ jobs:
             echo "benchmark_job_name=${BENCHMARK_JOB_NAME}"
           } >> $GITHUB_OUTPUT
 
-      - name: Prepare scripts
-        run: |
-          install -D tests/e2e/nightly/multi_node/scripts/run.sh /root/.cache/tests/run.sh
-
       - name: Clear resources
         run: |
           set -euo pipefail

--- a/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
+++ b/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
@@ -50,10 +50,10 @@ spec:
               - name: GOOD_TABLE
                 value: "{{ good_table | default("/root/.cache/vllm-ascend/nightly/good_table.csv") }}"
             command:
-              - sh
+              - bash
               - -c
               - |
-                bash /root/.cache/tests/run.sh
+{% include 'run.sh' %}
             resources:
               limits:
                 huawei.com/ascend-1980: {{ npu_per_node | default("16") }}
@@ -125,10 +125,10 @@ spec:
               - name: GOOD_TABLE
                 value: "{{ good_table | default("/root/.cache/vllm-ascend/nightly/good_table.csv") }}"
             command:
-              - sh
+              - bash
               - -c
               - |
-                bash /root/.cache/tests/run.sh
+{% include 'run.sh' %}
             resources:
               limits:
                 huawei.com/ascend-1980: {{ npu_per_node | default("16") }}


### PR DESCRIPTION

### What this PR does / why we need it?

fix: https://github.com/vllm-project/vllm-ascend/actions/runs/28746142319/job/85243253010

- Replace `sh -c 'bash /root/.cache/tests/run.sh'` with `bash -c '{% include "run.sh" %}'` in both leader and worker pod commands, so the script content is embedded at render time
- Remove the "Prepare scripts" step that wrote run.sh to PVC via install -D, which caused race conditions when multiple workflows
  ran concurrently on the same PVC
- Change the container entrypoint from sh to bash since run.sh uses bash-specific syntaxa 

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
