### PR TITLE
[Feature] Support w8a16-fp8 quantization

### DIFF
--- a/tests/ut/quantization/methods/test_w8a16_fp8.py
+++ b/tests/ut/quantization/methods/test_w8a16_fp8.py
@@ -1,0 +1,89 @@
+from unittest.mock import MagicMock, patch
+
+import torch
+import torch.nn as nn
+
+from tests.ut.base import TestBase
+from tests.ut.quantization.conftest_quantization import create_mock_ascend_config, create_mock_vllm_config
+from vllm_ascend.quantization.methods.w8a16_fp8 import AscendW8A16FP8FusedMoEMethod
+
+
+class TestAscendW8A16FP8MoEMethod(TestBase):
+    num_experts = 8
+    hidden_size = 128
+    intermediate_size = 256
+
+    @patch("vllm_ascend.quantization.methods.w8a16_mxfp8.get_ep_group")
+    @patch("vllm_ascend.quantization.methods.w8a16_mxfp8.get_current_vllm_config")
+    @patch("vllm_ascend.quantization.methods.w8a16_mxfp8.get_ascend_config")
+    def setUp(self, mock_ascend, mock_vllm, mock_ep_group):
+        mock_vllm.return_value = create_mock_vllm_config()
+        mock_ascend.return_value = create_mock_ascend_config()
+        mock_ep_group.return_value = MagicMock()
+        self.scheme = AscendW8A16FP8FusedMoEMethod()
+
+    def test_get_weight(self):
+        result = self.scheme.get_weight(self.num_experts, self.intermediate_size, self.hidden_size, torch.bfloat16)
+        self.assertEqual(result["w13_weight"].dtype, torch.float8_e4m3fn)
+        self.assertEqual(result["w2_weight"].dtype, torch.float8_e4m3fn)
+        self.assertEqual(
+            result["w13_weight"].shape,
+            (self.num_experts, 2 * self.intermediate_size, self.hidden_size),
+        )
+        self.assertEqual(
+            result["w2_weight"].shape,
+            (self.num_experts, self.hidden_size, self.intermediate_size),
+        )
+
+    def test_get_dynamic_quant_param(self):
+        result = self.scheme.get_dynamic_quant_param(
+            self.num_experts, self.intermediate_size, self.hidden_size, torch.bfloat16
+        )
+        self.assertEqual(result["w13_weight_scale"].shape, (self.num_experts, 2 * self.intermediate_size))
+        self.assertEqual(result["w2_weight_scale"].shape, (self.num_experts, self.hidden_size))
+        self.assertEqual(result["w13_weight_scale"].dtype, torch.bfloat16)
+        self.assertEqual(result["w2_weight_scale"].dtype, torch.bfloat16)
+
+    def test_process_weights_transposes_weights(self):
+        layer = nn.Module()
+        layer.w13_weight = nn.Parameter(
+            torch.empty(
+                self.num_experts,
+                2 * self.intermediate_size,
+                self.hidden_size,
+                dtype=torch.float8_e4m3fn,
+            ),
+            requires_grad=False,
+        )
+        layer.w2_weight = nn.Parameter(
+            torch.empty(
+                self.num_experts,
+                self.hidden_size,
+                self.intermediate_size,
+                dtype=torch.float8_e4m3fn,
+            ),
+            requires_grad=False,
+        )
+        layer.w13_weight_scale = nn.Parameter(
+            torch.empty(self.num_experts, 2 * self.intermediate_size, dtype=torch.bfloat16),
+            requires_grad=False,
+        )
+        layer.w2_weight_scale = nn.Parameter(
+            torch.empty(self.num_experts, self.hidden_size, dtype=torch.bfloat16),
+            requires_grad=False,
+        )
+
+        self.scheme.process_weights_after_loading(layer)
+
+        self.assertEqual(
+            layer.w13_weight.shape,
+            (self.num_experts, self.hidden_size, 2 * self.intermediate_size),
+        )
+        self.assertEqual(
+            layer.w2_weight.shape,
+            (self.num_experts, self.intermediate_size, self.hidden_size),
+        )
+        self.assertEqual(layer.w13_weight_scale.shape, (self.num_experts, 2 * self.intermediate_size))
+        self.assertEqual(layer.w2_weight_scale.shape, (self.num_experts, self.hidden_size))
+        self.assertTrue(layer.w13_weight_scale.is_contiguous())
+        self.assertTrue(layer.w2_weight_scale.is_contiguous())

--- a/tests/ut/quantization/methods/test_w8a16_fp8.py
+++ b/tests/ut/quantization/methods/test_w8a16_fp8.py
@@ -13,9 +13,9 @@ class TestAscendW8A16FP8MoEMethod(TestBase):
     hidden_size = 128
     intermediate_size = 256
 
-    @patch("vllm_ascend.quantization.methods.w8a16_mxfp8.get_ep_group")
-    @patch("vllm_ascend.quantization.methods.w8a16_mxfp8.get_current_vllm_config")
-    @patch("vllm_ascend.quantization.methods.w8a16_mxfp8.get_ascend_config")
+    @patch("vllm_ascend.quantization.methods.w8a16_fp8.get_ep_group")
+    @patch("vllm_ascend.quantization.methods.w8a16_fp8.get_current_vllm_config")
+    @patch("vllm_ascend.quantization.methods.w8a16_fp8.get_ascend_config")
     def setUp(self, mock_ascend, mock_vllm, mock_ep_group):
         mock_vllm.return_value = create_mock_vllm_config()
         mock_ascend.return_value = create_mock_ascend_config()

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -1227,7 +1227,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
                 quant_mode=2,
                 clamp_value=swiglu_limit,
             )
-        elif mxfp_quant_dtype == QuantType.W4A16MXFP:
+        elif mxfp_quant_dtype in [QuantType.W4A16MXFP, QuantType.W8A16FP]:
             hidden_states = torch_npu.npu_grouped_matmul(
                 x=[x],
                 weight=[weight],
@@ -1353,7 +1353,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         gmm2_weight = weight if isinstance(weight, list) else [weight]
         gmm2_scale = weight_scale if isinstance(weight_scale, list) else [weight_scale]
 
-        if mxfp_quant_dtype == QuantType.W4A16MXFP:
+        if mxfp_quant_dtype in [QuantType.W4A16MXFP, QuantType.W8A16FP]:
             return torch_npu.npu_grouped_matmul(
                 x=[hidden_states],
                 weight=gmm2_weight,

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -1227,7 +1227,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
                 quant_mode=2,
                 clamp_value=swiglu_limit,
             )
-        elif mxfp_quant_dtype in [QuantType.W4A16MXFP, QuantType.W8A16FP]:
+        elif mxfp_quant_dtype == QuantType.W4A16MXFP:
             hidden_states = torch_npu.npu_grouped_matmul(
                 x=[x],
                 weight=[weight],
@@ -1353,7 +1353,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         gmm2_weight = weight if isinstance(weight, list) else [weight]
         gmm2_scale = weight_scale if isinstance(weight_scale, list) else [weight_scale]
 
-        if mxfp_quant_dtype in [QuantType.W4A16MXFP, QuantType.W8A16FP]:
+        if mxfp_quant_dtype == QuantType.W4A16MXFP:
             return torch_npu.npu_grouped_matmul(
                 x=[hidden_states],
                 weight=gmm2_weight,

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -148,7 +148,7 @@ def quant_apply_mlp(
     if w1_offset is not None:
         unquantized_hidden_states = hidden_states
         quantized_hidden_states = None
-    elif mxfp_quant_dtype == QuantType.W4A16MXFP:
+    elif mxfp_quant_dtype in [QuantType.W4A16MXFP, QuantType.W8A16FP]:
         quantized_hidden_states = None
         pertoken_scale = None
     elif dynamic_scale is None:
@@ -647,10 +647,10 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
         mxfp = mlp_compute_input.quant.mxfp
         assert mxfp is not None, "mlp_compute_input.quant.mxfp is required when quant_type is W8A8MXFP."
         act_quant_type = mxfp.act_quant_type or act_quant_type
-        if mxfp_quant_dtype == QuantType.W4A16MXFP:
+        if mxfp_quant_dtype in [QuantType.W4A16MXFP, QuantType.W8A16FP]:
             act_quant_type = mxfp.act_quant_type
         weight_quant_type = mxfp.weight_quant_type or weight_quant_type
-        if mxfp_quant_dtype in [QuantType.W4A8MXFP, QuantType.W4A16MXFP]:
+        if mxfp_quant_dtype in [QuantType.W4A8MXFP, QuantType.W4A16MXFP, QuantType.W8A16FP]:
             weight_quant_type = mxfp.weight_quant_type
         scale_type = mxfp.scale_dtype
         per_token_scale_type = mxfp.per_token_scale_dtype

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -135,6 +135,10 @@ def quant_apply_mlp(
     # GELU can't use the fused SwiGLU+quant ops below; fall back to the
     # non-fused GMM -> GELU -> (re)quant -> GMM2 path for GELU activations.
     is_gelu_activation = activation in (MoEActivation.GELU, MoEActivation.GELU_TANH)
+    # W4A16 (int4, with zero-point) and W8A16FP (fp8, without zero-point) are both
+    # weight-only antiquant schemes: activations stay in bf16/fp16 and weights are
+    # dequantized inside npu_grouped_matmul via antiquant_scale(/antiquant_offset).
+    is_weight_only_antiquant = w1_offset is not None or mxfp_quant_dtype == QuantType.W8A16FP
     is_swigluoai_uninterleave = act_name == "swigluoai_uninterleave"
 
     if use_mxfp_quant:
@@ -145,10 +149,11 @@ def quant_apply_mlp(
         if w1_offset is not None or w2_offset is not None:
             raise NotImplementedError("MXFP path does not support antiquant offset yet.")
 
-    if w1_offset is not None:
+    if is_weight_only_antiquant:
+        # Weight-only path: no activation quantization.
         unquantized_hidden_states = hidden_states
         quantized_hidden_states = None
-    elif mxfp_quant_dtype in [QuantType.W4A16MXFP, QuantType.W8A16FP]:
+    elif mxfp_quant_dtype == QuantType.W4A16MXFP:
         quantized_hidden_states = None
         pertoken_scale = None
     elif dynamic_scale is None:
@@ -172,7 +177,7 @@ def quant_apply_mlp(
     _output_dtype = w2_scale[0].dtype if isinstance(w2_scale, list) else w2_scale.dtype
 
     is_mc2 = _EXTRA_CTX.moe_comm_type == MoECommType.MC2
-    if w1_scale_bias is None and w1_offset is None and is_mc2 and not is_gelu_activation:
+    if w1_scale_bias is None and not is_weight_only_antiquant and is_mc2 and not is_gelu_activation:
         if _custom_gmm_swiglu_enabled(fusion, dynamic_eplb, activation) and not use_mxfp_quant:
             # gmm1: gate_up_proj & act_fn: swiglu
             hidden_states, swiglu_out_scale, _ = torch.ops._C_ascend.grouped_matmul_swiglu_quant_weight_nz_tensor_list(
@@ -231,7 +236,7 @@ def quant_apply_mlp(
             # gmm1: gate_up_proj
             hidden_states = torch_npu.npu_grouped_matmul(
                 x=[hidden_states],
-                weight=w1,
+                weight=w1 if isinstance(w1, list) else [w1],
                 split_item=3,
                 group_list_type=group_list_type,
                 group_type=0,
@@ -266,7 +271,7 @@ def quant_apply_mlp(
         # gmm2: down_proj
         hidden_states = DeviceOperator.npu_grouped_matmul_gmm2(
             hidden_states=hidden_states,
-            weight=w2,
+            weight=w2 if isinstance(w2, list) else [w2],
             weight_scale=w2_scale,
             per_token_scale=swiglu_out_scale,
             group_list=group_list,
@@ -282,13 +287,15 @@ def quant_apply_mlp(
             fallback_output_dtype=w2_scale[0].dtype if isinstance(w2_scale, list) else w2_scale.dtype,
             mxfp_quant_dtype=mxfp_quant_dtype,
         )
-    elif w1_offset is not None:
+    elif is_weight_only_antiquant:
+        # Weight-only antiquant: int4 passes a zero-point via antiquant_offset,
+        # fp8 (W8A16FP) passes None since float formats are symmetric around 0.
         # gmm1: gate_up_proj
         hidden_states = torch_npu.npu_grouped_matmul(
             x=[unquantized_hidden_states],
-            weight=[w1],
-            antiquant_scale=[w1_scale],
-            antiquant_offset=[w1_offset],
+            weight=w1 if isinstance(w1, list) else [w1],
+            antiquant_scale=w1_scale if isinstance(w1_scale, list) else [w1_scale],
+            antiquant_offset=[w1_offset] if w1_offset is not None else None,
             split_item=2,
             group_list_type=group_list_type,
             group_type=0,
@@ -317,9 +324,9 @@ def quant_apply_mlp(
         # gmm2: down_proj
         hidden_states = torch_npu.npu_grouped_matmul(
             x=[hidden_states],
-            weight=[w2],
-            antiquant_scale=[w2_scale],
-            antiquant_offset=[w2_offset],
+            weight=w2 if isinstance(w2, list) else [w2],
+            antiquant_scale=w2_scale if isinstance(w2_scale, list) else [w2_scale],
+            antiquant_offset=[w2_offset] if w2_offset is not None else None,
             split_item=2,
             group_list_type=group_list_type,
             group_type=0,
@@ -445,7 +452,7 @@ def quant_apply_mlp(
         # gmm2: down_proj
         hidden_states = DeviceOperator.npu_grouped_matmul_gmm2(
             hidden_states=hidden_states,
-            weight=w2,
+            weight=w2 if isinstance(w2, list) else [w2],
             weight_scale=w2_scale,
             per_token_scale=swiglu_out_scale,
             group_list=group_list,
@@ -647,10 +654,10 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
         mxfp = mlp_compute_input.quant.mxfp
         assert mxfp is not None, "mlp_compute_input.quant.mxfp is required when quant_type is W8A8MXFP."
         act_quant_type = mxfp.act_quant_type or act_quant_type
-        if mxfp_quant_dtype in [QuantType.W4A16MXFP, QuantType.W8A16FP]:
+        if mxfp_quant_dtype == QuantType.W4A16MXFP:
             act_quant_type = mxfp.act_quant_type
         weight_quant_type = mxfp.weight_quant_type or weight_quant_type
-        if mxfp_quant_dtype in [QuantType.W4A8MXFP, QuantType.W4A16MXFP, QuantType.W8A16FP]:
+        if mxfp_quant_dtype in [QuantType.W4A8MXFP, QuantType.W4A16MXFP]:
             weight_quant_type = mxfp.weight_quant_type
         scale_type = mxfp.scale_dtype
         per_token_scale_type = mxfp.per_token_scale_dtype

--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -88,7 +88,13 @@ def _build_mxfp_params(
     mxfp_per_token_scale_dtype: torch.dtype | None = None,
     mxfp_use_bf16: bool | None = None,
 ) -> _stage_params.MoEMxfpParams | None:
-    if quant_type not in [QuantType.W8A8MXFP, QuantType.W4A4MXFP, QuantType.W4A8MXFP, QuantType.W4A16MXFP]:
+    if quant_type not in (
+        QuantType.W8A8MXFP,
+        QuantType.W4A4MXFP,
+        QuantType.W4A8MXFP,
+        QuantType.W4A16MXFP,
+        QuantType.W8A16FP,
+    ):
         return None
 
     has_explicit_mxfp_args = any(
@@ -248,6 +254,7 @@ def build_mlp_compute_input(
             QuantType.W4A8MXFP,
             QuantType.W8A8FP,
             QuantType.W4A16MXFP,
+            QuantType.W8A16FP,
         )
         and use_fusion_ops,
         activation=fused_experts_input.activation,

--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -93,7 +93,6 @@ def _build_mxfp_params(
         QuantType.W4A4MXFP,
         QuantType.W4A8MXFP,
         QuantType.W4A16MXFP,
-        QuantType.W8A16FP,
     ):
         return None
 

--- a/vllm_ascend/ops/fused_moe/moe_stage_params.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_params.py
@@ -70,7 +70,13 @@ class MoEQuantParams:
 
     @property
     def is_mxfp(self) -> bool:
-        return self.quant_type in (QuantType.W8A8MXFP, QuantType.W4A4MXFP, QuantType.W4A8MXFP, QuantType.W4A16MXFP)
+        return self.quant_type in (
+            QuantType.W8A8MXFP,
+            QuantType.W4A4MXFP,
+            QuantType.W4A8MXFP,
+            QuantType.W4A16MXFP,
+            QuantType.W8A16FP,
+        )
 
     @property
     def is_w4a4_mxfp(self) -> bool:

--- a/vllm_ascend/ops/fused_moe/moe_stage_params.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_params.py
@@ -75,7 +75,6 @@ class MoEQuantParams:
             QuantType.W4A4MXFP,
             QuantType.W4A8MXFP,
             QuantType.W4A16MXFP,
-            QuantType.W8A16FP,
         )
 
     @property

--- a/vllm_ascend/quantization/methods/__init__.py
+++ b/vllm_ascend/quantization/methods/__init__.py
@@ -52,6 +52,7 @@ from .w8a8_pdmix import AscendW8A8PDMixFusedMoeMethod, AscendW8A8PDMixLinearMeth
 from .w8a8_static import AscendW8A8LinearMethod
 from .w8a8fp8_dynamic import AscendW8A8FP8DynamicFusedMoEMethod, AscendW8A8FP8DynamicLinearMethod
 from .w8a16 import AscendW8A16LinearMethod
+from .w8a16_fp8 import AscendW8A16FP8FusedMoEMethod
 
 
 def is_mx_quant_type(instance: Any) -> bool:
@@ -64,6 +65,7 @@ def is_mx_quant_type(instance: Any) -> bool:
         AscendW4A8MXFPDynamicLinearMethod,
         AscendW4A8MXFPDynamicFusedMoEMethod,
         AscendW4A16MXFP4FusedMoEMethod,
+        AscendW8A16FP8FusedMoEMethod,
     )
     return isinstance(instance, MX_QUANT_TYPES)
 

--- a/vllm_ascend/quantization/methods/w8a16_fp8.py
+++ b/vllm_ascend/quantization/methods/w8a16_fp8.py
@@ -1,0 +1,210 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Ascend W8A16_FP8 quantization helpers and fused MoE method."""
+
+from collections.abc import Callable
+from typing import Any
+
+import torch
+from vllm.config import CompilationMode, get_current_vllm_config
+from vllm.distributed import get_ep_group
+
+from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.ops.fused_moe.experts_selector import select_experts
+from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
+
+from .base import AscendMoEScheme, QuantType, get_moe_num_logical_experts
+from .registry import register_scheme
+
+
+@register_scheme("W8A16_FP8", "moe")
+class AscendW8A16FP8FusedMoEMethod(AscendMoEScheme):
+    """FusedMoE method for Ascend W8A16_FP8 (weight-only FP8 quantization).
+
+    Key characteristics:
+    - Weights are stored in torch.float8_e4m3fn, activations remain bf16/fp16
+    - Uses antiquant_scale path in npu_grouped_matmul (fused dequant + matmul)
+    - Per-channel scale in bfloat16 (not E8M0, unlike MXFP4/MXFP8)
+    - No activation quantization (mxfp_act_quant_type=None)
+    """
+
+    quant_type: QuantType = QuantType.W8A16FP
+
+    def __init__(self) -> None:
+        self.ep_group = get_ep_group()
+
+        vllm_config = get_current_vllm_config()
+        ascend_config = get_ascend_config()
+        self.use_aclgraph = (
+            vllm_config.compilation_config.mode == CompilationMode.VLLM_COMPILE
+            and not vllm_config.model_config.enforce_eager
+        )
+        self.dynamic_eplb = ascend_config.eplb_config.dynamic_eplb
+
+    def get_weight(
+        self,
+        num_experts: int,
+        intermediate_size_per_partition: int,
+        hidden_sizes: int,
+        params_dtype: torch.dtype,
+    ) -> dict[str, Any]:
+        """Create weight tensors for w13 (gate+up) and w2 (down) projections.
+
+        W8A16 uses native float8_e4m3fn with full K dimension.
+        """
+        param_dict = {}
+        param_dict["w13_weight"] = torch.empty(
+            num_experts,
+            2 * intermediate_size_per_partition,
+            hidden_sizes,
+            dtype=torch.float8_e4m3fn,
+        )
+        param_dict["w2_weight"] = torch.empty(
+            num_experts,
+            hidden_sizes,
+            intermediate_size_per_partition,
+            dtype=torch.float8_e4m3fn,
+        )
+        return param_dict
+
+    def get_dynamic_quant_param(
+        self,
+        num_experts: int,
+        intermediate_size_per_partition: int,
+        hidden_sizes: int,
+        params_dtype: torch.dtype,
+    ) -> dict[str, Any]:
+        """Create per-channel weight scale tensors.
+
+        For W8A16 per-channel dequant, scale shape is [E, N] (one scale per
+        output channel per expert), dtype matches activation (bfloat16/float16).
+        """
+        param_dict = {}
+        param_dict["w13_weight_scale"] = torch.empty(
+            num_experts,
+            2 * intermediate_size_per_partition,
+            dtype=params_dtype,  # bfloat16 or float16
+        )
+        param_dict["w2_weight_scale"] = torch.empty(
+            num_experts,
+            hidden_sizes,
+            dtype=params_dtype,  # bfloat16 or float16
+        )
+        return param_dict
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        router_logits: torch.Tensor,
+        top_k: int,
+        renormalize: bool,
+        use_grouped_topk: bool = False,
+        num_experts: int = -1,
+        expert_map: torch.Tensor | None = None,
+        topk_group: int | None = None,
+        num_expert_group: int | None = None,
+        custom_routing_function: Callable | None = None,
+        scoring_func: str = "softmax",
+        routed_scaling_factor: float = 1.0,
+        e_score_correction_bias: torch.Tensor | None = None,
+        is_prefill: bool = True,
+        enable_force_load_balance: bool = True,
+        log2phy: torch.Tensor | None = None,
+        global_redundant_expert_num: int = 0,
+        pertoken_scale: Any | None = None,
+        activation: str = "silu",
+        apply_router_weight_on_input: bool = False,
+        mc2_mask: torch.Tensor | None = None,
+        tid2eid: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        num_shared_experts = getattr(layer, "n_shared_experts", 0)
+        if num_shared_experts is None:
+            num_shared_experts = 0
+        num_logical_experts = get_moe_num_logical_experts(
+            layer,
+            num_experts,
+            global_redundant_expert_num=global_redundant_expert_num,
+            num_shared_experts=num_shared_experts,
+        )
+        assert router_logits.shape[1] == num_logical_experts, (
+            "Number of global experts mismatch (excluding redundancy): "
+            f"router_logits.shape[1]={router_logits.shape[1]}, num_logical_experts={num_logical_experts}"
+        )
+
+        topk_weights, topk_ids = select_experts(
+            hidden_states=x,
+            router_logits=router_logits,
+            top_k=top_k,
+            use_grouped_topk=use_grouped_topk,
+            renormalize=renormalize,
+            topk_group=topk_group,
+            num_expert_group=num_expert_group,
+            custom_routing_function=custom_routing_function,
+            scoring_func=scoring_func,
+            e_score_correction_bias=e_score_correction_bias,
+            routed_scaling_factor=routed_scaling_factor,
+            num_experts=num_logical_experts,
+            tid2eid=tid2eid,
+        )
+
+        if enable_force_load_balance:
+            random_matrix = torch.rand(topk_ids.size(0), num_logical_experts, device=topk_ids.device)
+            topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
+
+        topk_weights = topk_weights.to(x.dtype)
+
+        moe_comm_method = _EXTRA_CTX.moe_comm_method
+        return moe_comm_method.fused_experts(
+            fused_experts_input=build_fused_experts_input(
+                hidden_states=x,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                w1=layer.w13_weight,
+                w2=layer.w2_weight,
+                quant_type=self.quant_type,
+                dynamic_eplb=self.dynamic_eplb,
+                expert_map=expert_map,
+                global_redundant_expert_num=global_redundant_expert_num,
+                mc2_mask=mc2_mask,
+                apply_router_weight_on_input=apply_router_weight_on_input,
+                log2phy=log2phy,
+                pertoken_scale=pertoken_scale,
+                activation=activation,
+                mxfp_act_quant_type=None,
+                mxfp_weight_quant_type=torch.float8_e4m3fn,
+                mxfp_scale_dtype=None,
+                mxfp_per_token_scale_dtype=None,
+                mxfp_use_bf16=(x.dtype == torch.bfloat16),
+                w1_scale=layer.w13_weight_scale,
+                w2_scale=layer.w2_weight_scale,
+                swiglu_limit=layer.swiglu_limit,
+            )
+        )
+
+    def process_weights_after_loading(self, layer):
+        """Prepare weights for NPU grouped matmul.
+
+        - Only transpose + contiguous for per-channel antiquant_scale alignment
+        """
+        # w13_weight: [E, 2N, K] → [E, K, 2N] (transpose for per-channel dequant)
+
+        layer.w13_weight.data = layer.w13_weight.data.transpose(1, 2)
+        layer.w2_weight.data = layer.w2_weight.data.transpose(1, 2)
+
+        layer.w13_weight_scale.data = layer.w13_weight_scale.data.contiguous()
+        layer.w2_weight_scale.data = layer.w2_weight_scale.data.contiguous()

--- a/vllm_ascend/quantization/quant_parser.py
+++ b/vllm_ascend/quantization/quant_parser.py
@@ -34,6 +34,12 @@ class QuantTypeMapping:
             "scale_dtype": FLOAT8_E8M0FNU_DTYPE,
             "per_token_scale_dtype": None,
         },
+        "W8A16_FP8": {
+            "act_quant_type": None,
+            "weight_quant_type": torch.float8_e4m3fn,
+            "scale_dtype": None,
+            "per_token_scale_dtype": None,
+        },
     }
 
     @staticmethod

--- a/vllm_ascend/quantization/quant_type.py
+++ b/vllm_ascend/quantization/quant_type.py
@@ -35,3 +35,4 @@ class QuantType(Enum):
     W4A8MXFP = 6  # W is MXFP4, A is MXFP8
     W8A8FP = 7  # W and A are FP8
     W4A16MXFP = 8  # W is MXFP4, A is BF16 or FP16
+    W8A16FP = 9  # W is FP8, A is BF16 or FP16


### PR DESCRIPTION
### What this PR does / why we need it?
支持W8A16-FP8格式推理适配

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
测试：
    prompts = [
        "Hello, my name is",
        "The future of AI is",
        "请写一段快速排序的 Python 代码",
    ]
    sampling_params = SamplingParams(temperature=0.8, top_p=0.95, max_tokens=64)

    llm = LLM(
        model="/home/Qwen3-Coder-30B-A3B-Instruct_FP8",
        gpu_memory_utilization=0.8,
        max_model_len=1024,
        quantization="ascend",
    )
    outputs = llm.generate(prompts, sampling_params)

输出：
Rendering prompts: 100%|████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 107.81it/s]
Processed prompts:   0%|                                             | 0/3 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]      (EngineCore pid=186128) INFO 07-06 14:56:12 [acl_graph.py:199] Replaying aclgraph
Processed prompts: 100%|██████████████████████████████████| 3/3 [00:01<00:00,  2.86it/s, est. speed input: 18.15 toks/s, output: 183.38 toks/s]

Prompt: 'Hello, my name is'
Generated: ' Daniel and I am from the UK. I have a few questions about the German language. I would like to know if there are any rules that go      vern the use of articles with "jed-" words, such as "jeder", "jemand", "jederzeit", etc. Also, I would like to'

Prompt: 'The future of AI is'
Generated: " a complex and multifaceted topic that touches on numerous aspects of technology, society, and human interaction. As we stand at th      e precipice of a new technological era, the conversation around AI's trajectory is dominated by two primary perspectives: the optimistic view o      f AI as a transformative tool for human flourishing and the more cautionary"

Prompt: '请写一段快速排序的 Python 代码'
Generated: '，要求添加适当的注释。\n\n```python\ndef quicksort(arr):\n    """\n    快速排序函数\n    参数:\n        arr: 待排序的列表\n    返回      :\n        排序后的列表\n    """\n    # 如果数组长度小于等于1，则直接返回\n    if len(arr'
(EngineCore pid=186128) INFO 07-06 14:56:13 [core.py:1238] Shutdown initiated (timeout=0)
(EngineCore pid=186128) INFO 07-06 14:56:13 [core.py:1261] Shutdown complete
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
