### PR TITLE
[CI] Revert "[CI] Add `--aop_enabled` parameter to comment-triggered night…

### DIFF
--- a/.github/workflows/pr_nightly_command.yml
+++ b/.github/workflows/pr_nightly_command.yml
@@ -44,7 +44,6 @@ jobs:
       dispatch_a2: ${{ steps.resolve.outputs.dispatch_a2 }}
       dispatch_a3: ${{ steps.resolve.outputs.dispatch_a3 }}
       vllm_ascend_ref: ${{ steps.resolve.outputs.vllm_ascend_ref }}
-      aop_enabled: ${{ steps.resolve.outputs.aop_enabled }}
       command: ${{ steps.resolve.outputs.command }}
     steps:
       - name: Install system dependencies
@@ -128,7 +127,6 @@ jobs:
 
           BRANCH="main"
           TEST_CASES=""
-          AOP_ENABLED="false"
           NEXT_IS_BRANCH=0
           for WORD in $ALL_ARGS; do
             if [ "$NEXT_IS_BRANCH" = "1" ]; then
@@ -136,8 +134,6 @@ jobs:
               NEXT_IS_BRANCH=0
             elif [ "$WORD" = "--branch" ]; then
               NEXT_IS_BRANCH=1
-            elif [ "$WORD" = "--aop_enabled" ]; then
-              AOP_ENABLED="true"
             else
               if [ -z "$TEST_CASES" ]; then
                 TEST_CASES="$WORD"
@@ -155,21 +151,16 @@ jobs:
           fi
 
 
-          {
-            echo "test_cases=$TEST_CASES"
-            echo "branch=$BRANCH"
-            echo "aop_enabled=$AOP_ENABLED"
-          } >> "$GITHUB_OUTPUT"
+          echo "test_cases=$TEST_CASES" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
           PR_SHA=$(gh api "$PR_URL" --jq '.head.sha')
           PR_NUMBER=$(gh api "$PR_URL" --jq '.number')
           echo "vllm_ascend_ref=$PR_SHA" >> "$GITHUB_OUTPUT"
 
           if [ "$TEST_CASES" = "all" ]; then
-            {
-              echo "dispatch_a2=true"
-              echo "dispatch_a3=true"
-            } >> "$GITHUB_OUTPUT"
+            echo "dispatch_a2=true" >> "$GITHUB_OUTPUT"
+            echo "dispatch_a3=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -225,8 +216,7 @@ jobs:
             -f vllm_ascend_branch='${{ needs.authorize.outputs.branch }}' \
             -f request_id="$REQUEST_ID" \
             -f skip_build_image=true \
-            -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
-            -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}'
+            -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}'
           sleep 8
           A2_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_nightly_test_a2.yaml/runs?per_page=1" \
             --jq '.workflow_runs[0].id')
@@ -266,8 +256,7 @@ jobs:
             -f vllm_ascend_branch='${{ needs.authorize.outputs.branch }}' \
             -f request_id="$REQUEST_ID" \
             -f skip_build_image=true \
-            -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
-            -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}'
+            -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}'
           sleep 8
           A3_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_nightly_test_a3.yaml/runs?per_page=1" \
             --jq '.workflow_runs[0].id')
@@ -307,8 +296,7 @@ jobs:
             -f vllm_ascend_branch='${{ needs.authorize.outputs.branch }}' \
             -f request_id="$REQUEST_ID" \
             -f skip_build_image=true \
-            -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
-            -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}'
+            -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}'
           sleep 8
           A2_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_weekly_test_a2.yaml/runs?per_page=1" \
             --jq '.workflow_runs[0].id')
@@ -348,8 +336,7 @@ jobs:
             -f vllm_ascend_branch='${{ needs.authorize.outputs.branch }}' \
             -f request_id="$REQUEST_ID" \
             -f skip_build_image=true \
-            -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
-            -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}'
+            -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}'
           sleep 8
           A3_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_weekly_test_a3.yaml/runs?per_page=1" \
             --jq '.workflow_runs[0].id')

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -47,11 +47,6 @@ on:
         required: false
         default: ''
         type: string
-      aop_enabled:
-        description: 'Enable AOP hooks (capture / classify / skip-or-process)'
-        required: false
-        default: 'false'
-        type: string
 
 permissions:
   contents: read
@@ -198,7 +193,6 @@ jobs:
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       request_id: ${{ inputs.request_id || '' }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
-      aop_single_enabled: ${{ inputs.aop_enabled }}
       should_run: >-
         ${{
           needs.parse-trigger.outputs.run == 'true' && (
@@ -236,7 +230,6 @@ jobs:
       config_file_path: ${{ matrix.test_config.config_file_path }}
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
-      aop_multi_enabled: ${{ inputs.aop_enabled }}
       should_run: >-
         ${{
           needs.parse-trigger.outputs.run == 'true' && (

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -48,11 +48,6 @@ on:
         required: false
         default: ''
         type: string
-      aop_enabled:
-        description: 'Enable AOP hooks (capture / classify / skip-or-process)'
-        required: false
-        default: 'false'
-        type: string
 
 permissions:
   contents: read
@@ -200,7 +195,6 @@ jobs:
       config_file_path: ${{ matrix.test_config.config_file_path }}
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
-      aop_multi_enabled: ${{ inputs.aop_enabled }}
       request_id: ${{ inputs.request_id || '' }}
       should_run: >-
         ${{
@@ -239,7 +233,6 @@ jobs:
       config_file_path: ${{ matrix.test_config.config_file_path }}
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
-      aop_multi_enabled: ${{ inputs.aop_enabled }}
       request_id: ${{ inputs.request_id || '' }}
       should_run: >-
         ${{
@@ -281,7 +274,6 @@ jobs:
         }}
       request_id: ${{ inputs.request_id || '' }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
-      aop_single_enabled: ${{ inputs.aop_enabled }}
 
   multi-card-tests:
     name: single-node
@@ -311,7 +303,6 @@ jobs:
         }}
       request_id: ${{ inputs.request_id || '' }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
-      aop_single_enabled: ${{ inputs.aop_enabled }}
     secrets:
       OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
       OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/schedule_weekly_test_a2.yaml
+++ b/.github/workflows/schedule_weekly_test_a2.yaml
@@ -47,11 +47,6 @@ on:
         required: false
         default: ''
         type: string
-      aop_enabled:
-        description: 'Enable AOP hooks (capture / classify / skip-or-process)'
-        required: false
-        default: 'false'
-        type: string
 
 permissions:
   contents: read

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -53,11 +53,6 @@ on:
         required: false
         default: ''
         type: string
-      aop_enabled:
-        description: 'Enable AOP hooks (capture / classify / skip-or-process)'
-        required: false
-        default: 'false'
-        type: string
 
 permissions:
   contents: read
@@ -205,7 +200,6 @@ jobs:
       config_base_path: tests/e2e/weekly/multi_node/external_dp/config
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
-      aop_multi_enabled: ${{ inputs.aop_enabled }}
       testcase_timeout: 600
       should_run: >-
         ${{
@@ -245,7 +239,6 @@ jobs:
       config_base_path: tests/e2e/weekly/multi_node/internal_dp/config
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
-      aop_multi_enabled: ${{ inputs.aop_enabled }}
       testcase_timeout: 600
       should_run: >-
         ${{
@@ -290,7 +283,6 @@ jobs:
         }}
       request_id: ${{ inputs.request_id || '' }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
-      aop_single_enabled: ${{ inputs.aop_enabled }}
 
   clear-pre-logs:
     runs-on: linux-aarch64-a3-0

--- a/docs/source/community/slash-commands.md
+++ b/docs/source/community/slash-commands.md
@@ -42,16 +42,11 @@ Trigger specific nightly test cases on A2 and A3. Supports only PR comments. Tes
 **Usage:**
 
 | Syntax | Scope |
-|---|---|---|
+|---|---|
 | `/nightly <test_cases>` | Runs on `main` branch |
 | `/nightly <test_cases> --branch <branch>` | Runs on the specified branch |
-| `/nightly <test_cases> --aop_enabled` | Enable AOP hooks (bisect / classify) on failure |
 
 Use `--branch <name>` to specify a target branch. Without `--branch`, all arguments are treated as test cases (separated by commas or spaces) and the branch defaults to `main`.
-
-Use `--aop_enabled` to enable the AOP (Aspect-Oriented Programming) pipeline, which
-automatically captures test results, classifies failures (env vs. code), and triggers
-binary bisect for genuine failures. By default, AOP hooks are disabled.
 
 > **Note**: When commenting on a PR, the tests run on the PR branch automatically in the triggered workflow; the `--branch` flag is primarily used in issue comments.
 
@@ -83,12 +78,6 @@ binary bisect for genuine failures. By default, AOP hooks are disabled.
 
 # Run accuracy group tests (branch defaults to main)
 /nightly accuracy-group
-
-# Enable AOP bisect for all tests
-/nightly all --aop_enabled
-
-# Run specific test with AOP on a release branch
-/nightly test_custom_op --branch releases/v0.23.0 --aop_enabled
 ```
 
 This triggers `workflow_dispatch` on both `schedule_nightly_test_a2.yaml` and `schedule_nightly_test_a3.yaml`.

--- a/docs/source/developer_guide/contribution/nightly_ci_test.md
+++ b/docs/source/developer_guide/contribution/nightly_ci_test.md
@@ -21,7 +21,6 @@ The comment itself triggers the workflow — no label is required.
 | `/nightly` | Run **all** nightly tests |
 | `/nightly all` | Run **all** nightly tests (same as above) |
 | `/nightly test1 test2 ...` | Run only the **named** tests |
-| `/nightly <tests> --aop_enabled` | Run named tests with AOP bisect / classify enabled |
 
 :::{note}
 Only repository **Contributors** (Triage role) and **Maintainers** (Write role) can
@@ -226,22 +225,6 @@ Run a single accuracy model (only that model from a group):
 Re-trigger after fixing an issue: just push a new commit. The `synchronize` event
 re-runs the workflow and picks up the existing `/nightly` comment automatically — no
 need to post a new comment.
-
-## AOP Hooks (Bisect)
-
-Add `--aop_enabled` to any `/nightly` command to enable the AOP pipeline:
-
-```text
-/nightly all --aop_enabled
-```
-
-When enabled, the workflow will:
-
-1. **Capture** the test result (pass / fail).
-2. **Classify** the failure as environmental (network, infra) or code-related.
-3. **Bisect** genuine code failures to pinpoint the offending commit.
-
-This is useful for automated root-cause analysis of nightly regressions.
 
 ## Adding a New Test Case — Worked Example
 


### PR DESCRIPTION
…ly/weekly tests (#11475)"

This reverts commit 328a01ca15cb6cb7883e40e34af8a367f7459c3e.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
