### PR TITLE
[Doc] The usability of the DeepSeek-V4 documentation is improved.

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V4-Flash.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Flash.md
@@ -79,6 +79,7 @@ docker run --rm \
     -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
     -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v /etc/hccn.conf:/etc/hccn.conf \
+    -v /root/.cache:/root/.cache \
     -it $IMAGE bash
 ```
 
@@ -114,6 +115,7 @@ docker run --rm \
     -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
     -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v /etc/hccn.conf:/etc/hccn.conf \
+    -v /root/.cache:/root/.cache \
     -it $IMAGE bash
 ```
 
@@ -133,7 +135,9 @@ If you want to deploy a multi-node environment, you need to set up the environme
 ## 5 Online Service Deployment
 
 :::{note}
-In this tutorial, we suppose you downloaded the model weight to `/root/.cache/`. Feel free to change it to your own path.
+In this tutorial, we suppose you downloaded the model weight to `/root/.cache/modelscope/hub/models/vllm-ascend`. Feel free to change it to your own path.
+
+It is recommended that the following service code be encapsulated in a .sh script file and executed in Bash mode.
 :::
 
 ### 5.1 Single-Node Online Deployment

--- a/docs/source/tutorials/models/DeepSeek-V4-Pro.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Pro.md
@@ -79,6 +79,7 @@ docker run --rm \
     -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
     -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v /etc/hccn.conf:/etc/hccn.conf \
+    -v /root/.cache:/root/.cache \
     -it $IMAGE bash
 ```
 
@@ -114,6 +115,7 @@ docker run --rm \
     -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
     -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v /etc/hccn.conf:/etc/hccn.conf \
+    -v /root/.cache:/root/.cache \
     -it $IMAGE bash
 ```
 
@@ -133,7 +135,9 @@ If you want to deploy a multi-node environment, you need to set up the environme
 ## 5 Online Service Deployment
 
 :::{note}
-In this tutorial, we suppose you downloaded the model weight to `/root/.cache/`. Feel free to change it to your own path.
+In this tutorial, we suppose you downloaded the model weight to `/root/.cache/modelscope/hub/models/vllm-ascend`. Feel free to change it to your own path.
+
+It is recommended that the following service code be encapsulated in a .sh script file and executed in Bash mode.
 :::
 
 ### 5.1 Multi-Node Online Deployment


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?

Three consistency fixes applied to both the DeepSeek-V4-Flash and DeepSeek-V4-Pro tutorials:

  1. Added missing Docker volume mount
  Added -v /root/.cache:/root/.cache to 4 docker run commands across the two docs. This exposes the host's
  ~/.cache (HuggingFace / modelscope download cache, including model weights) to the container, so previously
  downloaded weights are accessible inside the container instead of being re-downloaded.
  2. Clarified the default model weight path
  Updated the assumption in the Section 5 note from the vague /root/.cache/ to the more specific
  /root/.cache/modelscope/hub/models/vllm-ascend, matching the actual location after a modelscope download.
  3. Added a script-based execution recommendation
  Added a sentence to the note suggesting users wrap the subsequent service-deployment commands into a .sh
  script and run it in Bash mode, improving reusability and reducing copy-paste errors with multi-line
  commands.

