### PR TITLE
[Doc] add issue feedback button

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% set t = config.extra.i18n[config.extra.docs_lang] %}
+
 {% block announce %}
 <style>
   .md-banner {
@@ -21,9 +23,64 @@
 </style>
 {% if not config.extra.is_release %}
 <div class="md-announce">
-  You are viewing the latest developer preview docs.
-  <a href="https://docs.vllm.ai/projects/ascend/en/v0.18.0">Click here</a>
-  to view docs for the latest stable release (v0.18.0).
+  {{ t.banner_preview }}
+  <a href="https://docs.vllm.ai/projects/ascend/en/v0.18.0">{{ t.banner_link }}</a>
+  {{ t.banner_suffix }}
 </div>
 {% endif %}
+
+{% set lang_path = "/zh-cn/" if config.extra.docs_lang == "zh" else "/en/" %}
+{% set page_path = page.url if page.url else "" %}
+{% set full_path = lang_path ~ config.extra.rtd_version ~ "/" ~ page_path %}
+{% set issue_title = "[Doc]: Feedback for `" ~ full_path ~ "`" %}
+{% set issue_url = "https://github.com/vllm-project/vllm-ascend/issues/new?template=100-documentation.yml&title=" ~ issue_title | urlencode %}
+<a href="{{ issue_url }}"
+   class="issues-float-btn"
+   target="_blank" rel="noopener" aria-label="{{ t.aria_report }}">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M20 8h-2.81c-.45-.78-1.07-1.45-1.82-1.96L17 4.41 15.59 3l-2.17 2.17a6.002 6.002 0 0 0-5.83 0L5.41 3 4 4.41 5.62 6.04C4.88 6.55 4.26 7.22 3.81 8H1v2h2.09c-.05.33-.09.66-.09 1v1H1v2h2v1c0 .34.04.67.09 1H1v2h2.81c1.04 1.79 2.97 3 5.19 3s4.15-1.21 5.19-3H17v-2h-2.09c.05-.33.09-.66.09-1v-1h2v-2h-2v-1c0-.34-.04-.67-.09-1H20V8zm-6 8h-4v-2h4v2zm0-4h-4v-2h4v2z"/>
+  </svg>
+  <span>{{ t.btn_report }}</span>
+</a>
+<style>
+  .issues-float-btn {
+    position: fixed;
+    bottom: 4.5rem;
+    right: 1.5rem;
+    z-index: 1100;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.55rem 1.1rem;
+    border-radius: 999px;
+    background-color: var(--md-accent-fg-color);
+    color: #fff !important;
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1;
+    text-decoration: none;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, .25);
+    transition: background-color 0.2s, transform 0.2s, box-shadow 0.2s;
+  }
+  .issues-float-btn:hover {
+    background-color: var(--md-accent-fg-color);
+    filter: brightness(1.15);
+    transform: translateY(-1px);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, .3);
+  }
+  .issues-float-btn:focus-visible {
+    outline: 2px solid var(--md-accent-fg-color);
+    outline-offset: 2px;
+  }
+  .issues-float-btn svg {
+    width: 1.1em;
+    height: 1.1em;
+    fill: currentColor;
+  }
+  @media print {
+    .issues-float-btn {
+      display: none;
+    }
+  }
+</style>
 {% endblock %}

--- a/docs/overrides/partials/logo.html
+++ b/docs/overrides/partials/logo.html
@@ -1,0 +1,16 @@
+{#-
+  Override Material's logo partial to render BOTH light and dark variants
+  so the header / sidebar logo switches with the color scheme. Material 9.x
+  ignores the per-palette `logo:` setting in mkdocs.yml and only reads
+  `config.theme.logo`, so we emit two <img> tags and rely on Material's
+  built-in `[src$="#only-dark"]{display:none}` (light mode hides the dark
+  variant) plus a custom `[src$="#only-light"]` rule in extra.css that does
+  the same in dark mode.
+-#}
+{% if config.theme.logo %}
+  <img class="md-logo__img md-logo__img--light" src="{{ config.theme.logo | url }}#only-light" alt="logo">
+  <img class="md-logo__img md-logo__img--dark" src="logos/vllm-ascend-logo-text-dark.png#only-dark" alt="logo">
+{% else %}
+  {% set icon = config.theme.icon.logo or "material/library" %}
+  {% include ".icons/" ~ icon ~ ".svg" %}
+{% endif %}

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -4,7 +4,10 @@ hide:
   - toc
 ---
 
-![vLLM](./logos/vllm-ascend-logo-text-light.png)
+<p class="home-hero">
+<img class="md-logo__img--light" src="./logos/vllm-ascend-logo-text-light.png#only-light" alt="vLLM">
+<img class="md-logo__img--dark" src="./logos/vllm-ascend-logo-text-dark.png#only-dark" alt="vLLM">
+</p>
 
 <p style="text-align:center">
 <strong>vLLM Ascend Plugin

--- a/docs/source/stylesheets/extra.css
+++ b/docs/source/stylesheets/extra.css
@@ -7,6 +7,38 @@
   align-items: center;
 }
 
+/* Theme-aware logo swap. The .md-logo wrapper in main.css forces
+   .md-logo img to display:block, so the two <img> elements would
+   stack vertically and overlap visually if neither were hidden.
+   Material's [src$="#only-dark"]{display:none} only covers one half
+   of the swap, so we add explicit class-based rules here for both
+   halves. The class selectors win on specificity (.class > [attr])
+   and don't depend on URL fragment matching. */
+[data-md-color-scheme="default"] .md-logo__img--dark,
+[data-md-color-scheme="default"] .home-hero img[src$="#only-dark"] {
+  display: none !important;
+}
+[data-md-color-scheme="slate"] .md-logo__img--light,
+[data-md-color-scheme="slate"] .home-hero img[src$="#only-light"] {
+  display: none !important;
+}
+
+/* Centered hero logo on the home page. The previous .md-typeset .figure
+   rule didn't match the <p> wrapper mkdocs emits for markdown images,
+   so the logo rendered left-aligned and visually overlapped the header
+   logo. Use a dedicated class with explicit centering and spacing. */
+.home-hero {
+  text-align: center;
+  margin: 2rem 0 2.5rem;
+}
+.home-hero img {
+  display: block;
+  margin: 0 auto;
+  max-width: 720px;
+  width: 100%;
+  height: auto;
+}
+
 /* Make tables more compact */
 .md-typeset table:not([class]) th,
 .md-typeset table:not([class]) td {

--- a/main.py
+++ b/main.py
@@ -6,6 +6,28 @@ Variables are defined in the 'extra' section of mkdocs.yml.
 
 from pathlib import Path
 
+# UI string translations keyed by DOCS_LANG. Injected into config.extra.i18n
+# in define_env() so override templates (e.g. docs/overrides/main.html) can
+# read them via config.extra.i18n[config.extra.docs_lang]. The macros
+# plugin's env.variables are only available in markdown content, not in
+# override templates, hence the detour through config.extra.
+UI_STRINGS = {
+    "en": {
+        "banner_preview": "You are viewing the latest developer preview docs.",
+        "banner_link": "Click here",
+        "banner_suffix": "to view docs for the latest stable release (v0.18.0).",
+        "btn_report": "report issue",
+        "aria_report": "Report a documentation issue",
+    },
+    "zh": {
+        "banner_preview": "您正在查看最新的开发者预览版文档。",
+        "banner_link": "点击此处",
+        "banner_suffix": "查看最新稳定版（v0.18.0）的文档。",
+        "btn_report": "反馈问题",
+        "aria_report": "报告文档问题",
+    },
+}
+
 
 def define_env(env):
     """Define environment variables and macros for mkdocs-macros plugin."""
@@ -37,6 +59,12 @@ def define_env(env):
     env.variables["main_triton_ascend_version"] = env.variables.get("main_triton_ascend_version", "3.2.1")
     env.variables["main_vllm_commit"] = main_vllm_commit
     env.variables["main_vllm_tag"] = main_vllm_tag
+
+    # Expose UI translations to override templates by attaching the dict
+    # to config.extra. See module docstring for the rationale.
+    config = env.variables.get("config")
+    if config is not None:
+        config.extra["i18n"] = UI_STRINGS
 
     @env.macro
     def include_code(file_path, start_after=None, end_before=None, language="python"):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,10 @@ extra_css:
 extra:
   # Toggle via DOCS_IS_RELEASE env var (set by .readthedocs.yaml for tag builds).
   is_release: !ENV [DOCS_IS_RELEASE, false]
+  # Read the Docs build context, exposed to override templates (e.g. the
+  # floating "report issue" button in docs/overrides/main.html).
+  rtd_version: !ENV [READTHEDOCS_VERSION, latest]
+  docs_lang: !ENV [DOCS_LANG, en]
   # Version substitutions used by macros plugin
   vllm_version: v0.22.1
   vllm_ascend_version: v0.22.1rc1

--- a/tools/rtd_build.sh
+++ b/tools/rtd_build.sh
@@ -53,6 +53,15 @@ if [ "$DOCS_LANG" = "zh" ]; then
     # DOCS_DIR.
     echo "[rtd-build] Generating Chinese sources from .po files..."
     python tools/generate_zh_docs.py
+
+    # Mirror shared static assets into the Chinese DOCS_DIR. mkdocs resolves
+    # `extra_css` and other static paths relative to DOCS_DIR, so anything
+    # we want served on both language builds must physically live under
+    # docs/source/zh/. The English DOCS_DIR is docs/source/, so the source
+    # of truth stays there and we copy at build time.
+    echo "[rtd-build] Mirroring shared static assets into docs/source/zh/..."
+    mkdir -p docs/source/zh/stylesheets
+    cp docs/source/stylesheets/extra.css docs/source/zh/stylesheets/extra.css
 fi
 
 # --- Output directory ------------------------------------------------------


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds a floating "report issue" button to the documentation pages. It dynamically constructs the issue URL using the current language path (`/zh-cn/` or `/en/`) and the Read the Docs version. The necessary environment variables (`READTHEDOCS_VERSION` and `DOCS_LANG`) are exposed in `mkdocs.yml` to support this.

Feedback: The "report issue" button text and its `aria-label` are currently hardcoded in English. Since the repository supports both English and Chinese documentation, these strings should be localized based on the `docs_lang` configuration.

### Does this PR introduce _any_ user-facing change?
Yes, a floating "report issue" button is added to the bottom right of the documentation pages.

### How was this patch tested?
No tests were added.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
