### PR TITLE
[Doc] The usability of the DeepSeek-V4 documentation is improved

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V4-Flash.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Flash.md
@@ -74,6 +74,7 @@ Select an image based on your machine type and start the docker image on your no
         -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
         -v /etc/ascend_install.info:/etc/ascend_install.info \
         -v /etc/hccn.conf:/etc/hccn.conf \
+        -v /root/.cache:/root/.cache \
         -it $IMAGE bash
     ```
 
@@ -106,6 +107,7 @@ Select an image based on your machine type and start the docker image on your no
         -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
         -v /etc/ascend_install.info:/etc/ascend_install.info \
         -v /etc/hccn.conf:/etc/hccn.conf \
+        -v /root/.cache:/root/.cache \
         -it $IMAGE bash
     ```
 
@@ -123,7 +125,9 @@ If you want to deploy a multi-node environment, you need to set up the environme
 
 !!! note
 
-    In this tutorial, we suppose you downloaded the model weight to `/root/.cache/`. Feel free to change it to your own path.
+    In this tutorial, we suppose you downloaded the model weight to `/root/.cache/modelscope/hub/models/vllm-ascend/`. Feel free to change it to your own path.
+
+    It is recommended that the following service code be encapsulated in a .sh script file and executed in Bash mode.
 
 ### 5.1 Single-Node Online Deployment
 

--- a/docs/source/tutorials/models/DeepSeek-V4-Pro.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Pro.md
@@ -74,6 +74,7 @@ Select an image based on your machine type and start the docker image on your no
         -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
         -v /etc/ascend_install.info:/etc/ascend_install.info \
         -v /etc/hccn.conf:/etc/hccn.conf \
+        -v /root/.cache:/root/.cache \
         -it $IMAGE bash
     ```
 
@@ -106,6 +107,7 @@ Select an image based on your machine type and start the docker image on your no
         -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
         -v /etc/ascend_install.info:/etc/ascend_install.info \
         -v /etc/hccn.conf:/etc/hccn.conf \
+        -v /root/.cache:/root/.cache \
         -it $IMAGE bash
     ```
 
@@ -123,7 +125,9 @@ If you want to deploy a multi-node environment, you need to set up the environme
 
 !!! note
 
-    In this tutorial, we suppose you downloaded the model weight to `/root/.cache/`. Feel free to change it to your own path.
+    In this tutorial, we suppose you downloaded the model weight to `/root/.cache/modelscope/hub/models/vllm-ascend/`. Feel free to change it to your own path.
+
+    It is recommended that the following service code be encapsulated in a .sh script file and executed in Bash mode.
 
 ### 5.1 Multi-Node Online Deployment
 


### PR DESCRIPTION
### What this PR does / why we need it?

Three consistency fixes applied to both the DeepSeek-V4-Flash and DeepSeek-V4-Pro tutorials:

  1. Added missing Docker volume mount
  Added -v /root/.cache:/root/.cache to 4 docker run commands across the two docs. This exposes the host's
  ~/.cache (HuggingFace / modelscope download cache, including model weights) to the container, so previously
  downloaded weights are accessible inside the container instead of being re-downloaded.
  2. Clarified the default model weight path
  Updated the assumption in the Section 5 note from the vague /root/.cache/ to the more specific
  /root/.cache/modelscope/hub/models/vllm-ascend, matching the actual location after a modelscope download.
  3. Added a script-based execution recommendation
  Added a sentence to the note suggesting users wrap the subsequent service-deployment commands into a .sh
  script and run it in Bash mode, improving reusability and reducing copy-paste errors with multi-line
  commands.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
