### PR TITLE
[0-day] Hy3 0-day adaptation

### DIFF
--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -124,6 +124,13 @@ def hf_config_override(hf_config: PretrainedConfig) -> PretrainedConfig:
     if initial_architecture == "MistralLarge3ForCausalLM":
         hf_config.update({"architectures": ["EagleMistralLarge3ForCausalLM"]})
 
+    if hf_config.model_type == "hy_v3":
+        hf_config.model_type = "hy_v3_mtp"
+        n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
+        hf_config.update(
+            {"n_predict": n_predict, "architectures": ["HYV3MTPModel"]}
+        )
+
     return hf_config
 
 

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -327,7 +327,22 @@ def get_linear_quant_type(
                 logger.error(err_msg)
                 raise ValueError(err_msg)
     else:
-        quant_type = quant_description[prefix + ".weight"]
+        key = prefix + ".weight"
+        if key not in quant_description:
+            # MoE layers use per-expert keys (e.g. experts.0.gate_proj.weight)
+            # instead of a single experts.weight key. Find any sub-entry.
+            prefix_dot = prefix + "."
+            for k, v in quant_description.items():
+                if k.startswith(prefix_dot) and k.endswith(".weight"):
+                    quant_type = v
+                    break
+            else:
+                raise KeyError(
+                    f"Neither '{key}' nor any key starting with "
+                    f"'{prefix_dot}' found in quant_description."
+                )
+        else:
+            quant_type = quant_description[key]
     return quant_type
 
 


### PR DESCRIPTION
### What this PR does / why we need it?
  Fix two Hunyuan3 (Hy3) compatibility issues on vllm-ascend 0.22.1rc:
  
  1. **MTP model type conversion**: `patch_speculative_config` was missing `hy_v3` → `hy_v3_mtp` conversion, causing
  `Unsupported speculative method: 'mtp'` when MTP is enabled.
  2. **MoE quant type lookup**: `get_linear_quant_type` failed with KeyError for MoE layers because it looked up
  `experts.weight` as a single key, while the quant description only has per-expert entries (`experts.0.gate_proj.weight`). 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI passed with new added/existing test.
- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
