### PR TITLE
[CI][310p]: Optimize 310P E2E test duration

### DIFF
--- a/tests/e2e/pull_request/four_card/_310p/test_moe_model_310p.py
+++ b/tests/e2e/pull_request/four_card/_310p/test_moe_model_310p.py
@@ -16,7 +16,6 @@
 # This file is a part of the vllm-ascend project.
 
 
-
 from tests.e2e.conftest import VllmRunner
 
 

--- a/tests/e2e/pull_request/four_card/_310p/test_moe_model_310p.py
+++ b/tests/e2e/pull_request/four_card/_310p/test_moe_model_310p.py
@@ -16,26 +16,8 @@
 # This file is a part of the vllm-ascend project.
 
 
-import pytest
 
 from tests.e2e.conftest import VllmRunner
-
-
-def test_qwen3_moe_tp4_fp16():
-    example_prompts = [
-        "Hello, my name is",
-    ]
-    max_tokens = 5
-    with VllmRunner(
-        "Qwen/Qwen3-30B-A3B",
-        tensor_parallel_size=4,
-        enforce_eager=True,
-        dtype="float16",
-        max_model_len=16384,
-        max_num_batched_tokens=2048,
-        max_num_seqs=256,
-    ) as vllm_model:
-        vllm_model.generate_greedy(example_prompts, max_tokens)
 
 
 def test_qwen3_moe_tp2_w8a8():
@@ -56,7 +38,6 @@ def test_qwen3_moe_tp2_w8a8():
         vllm_model.generate_greedy(example_prompts, max_tokens)
 
 
-@pytest.mark.skip("Probabilistic failure, need fix")
 def test_qwen3_5_moe_tp4_fp16():
     example_prompts = [
         "Hello, my name is",

--- a/tests/e2e/pull_request/one_card/_310p/test_dense_model_310p.py
+++ b/tests/e2e/pull_request/one_card/_310p/test_dense_model_310p.py
@@ -68,70 +68,25 @@ def _generate_qwen3_5_prefix_mamba_outputs(enable_prefix_caching: bool) -> list[
     return outputs
 
 
-def test_qwen3_dense_tp1_fp16():
-    example_prompts = [
-        "Hello, my name is",
-    ]
-    max_tokens = 5
-    with VllmRunner(
-        "Qwen/Qwen3-8B",
-        tensor_parallel_size=1,
-        enforce_eager=True,
-        dtype="float16",
-        max_model_len=16384,
-    ) as vllm_model:
-        vllm_model.generate_greedy(example_prompts, max_tokens)
-
-
 @wait_until_npu_memory_free(0.7)
-def test_qwen3_dense_tp1_fp16_aclgraph():
+def test_qwen3_dense_tp1_w8a8_aclgraph():
     example_prompts = [
         "Hello, my name is",
     ] * 8
     max_tokens = 2
     with VllmRunner(
-        "Qwen/Qwen3-8B",
+        "vllm-ascend/Qwen3-8B-W8A8",
         tensor_parallel_size=1,
         dtype="float16",
         max_num_seqs=16,
         max_model_len=16384,
         gpu_memory_utilization=0.80,
+        quantization="ascend",
         additional_config={"ascend_compilation_config": {"fuse_norm_quant": False}},
         compilation_config={
             "cudagraph_mode": "FULL_DECODE_ONLY",
             "cudagraph_capture_sizes": [1, 2, 4, 8, 16],
         },
-    ) as vllm_model:
-        vllm_model.generate_greedy(example_prompts, max_tokens)
-
-
-def test_qwen3_dense_tp1_w8a8():
-    example_prompts = [
-        "Hello, my name is",
-    ]
-    max_tokens = 5
-    with VllmRunner(
-        "vllm-ascend/Qwen3-8B-W8A8",
-        tensor_parallel_size=1,
-        enforce_eager=True,
-        dtype="float16",
-        quantization="ascend",
-        max_model_len=16384,
-    ) as vllm_model:
-        vllm_model.generate_greedy(example_prompts, max_tokens)
-
-
-def test_qwen3_5_dense_tp1_fp16():
-    example_prompts = [
-        "Hello, my name is",
-    ]
-    max_tokens = 5
-    with VllmRunner(
-        "Qwen/Qwen3.5-4B",
-        tensor_parallel_size=1,
-        enforce_eager=True,
-        dtype="float16",
-        max_model_len=16384,
     ) as vllm_model:
         vllm_model.generate_greedy(example_prompts, max_tokens)
 


### PR DESCRIPTION
### What this PR does / why we need it?

To reduce the 310P CI runtime, this PR optimizes the test cases and removes redundant coverage.

### Does this PR introduce _any_ user-facing change?

NA

### How was this patch tested?

CI
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
