### PR TITLE
[Attention][Misc] Refactor MLAPO weight processing and preprocessing logic for Ascend SFA

### DIFF
--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import torch
 from vllm.config import set_current_vllm_config
 from vllm.distributed.parallel_state import GroupCoordinator
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
 
 from tests.ut.attention.utils import patch_distributed_groups
 from tests.ut.base import TestBase
@@ -19,9 +20,15 @@ from vllm_ascend.attention.sfa_v1 import (
     AscendSFAImpl,
     AscendSFAMetadata,
     AscendSFAMetadataBuilder,
+    PreprocessType,
     custom_kv_rmsnorm_rope,
 )
 from vllm_ascend.attention.utils import get_sfa_qsfa_packed_head_dim
+from vllm_ascend.quantization.methods import (
+    AscendW8A8DynamicLinearMethod,
+    AscendW8A8LinearMethod,
+    AscendW8A8MXFP8DynamicLinearMethod,
+)
 from vllm_ascend.utils import enable_dsa_cp
 
 
@@ -87,7 +94,7 @@ class TestAscendSFAKVQuantSparseAttention(TestBase):
         mock_rope.return_value = k_pe
         mock_block_quant.return_value = quantized, scales
 
-        actual_k_pe, actual_k_nope, actual_scales = custom_kv_rmsnorm_rope(
+        custom_kv_rmsnorm_rope(
             torch.randn(2, 1, 1, 272, dtype=torch.bfloat16),
             torch.ones(256, dtype=torch.bfloat16),
             torch.randn(2, 1, 1, 16),
@@ -97,15 +104,10 @@ class TestAscendSFAKVQuantSparseAttention(TestBase):
             dst_type=1,
             tile_size=128,
         )
-        packed_kv = torch.cat([actual_k_nope, actual_k_pe, actual_scales], dim=-1)
 
         self.assertEqual(mock_block_quant.call_args.kwargs["dst_type"], 1)
         self.assertEqual(mock_block_quant.call_args.kwargs["row_block_size"], 1)
         self.assertEqual(mock_block_quant.call_args.kwargs["col_block_size"], 128)
-        self.assertEqual(packed_kv.shape, (2, 1, 1, 296))
-        self.assertTrue(torch.equal(packed_kv[..., :256], quantized.view_as(k_nope)))
-        self.assertTrue(torch.equal(packed_kv[..., 256:288], k_pe.contiguous().view(torch.int8)))
-        self.assertTrue(torch.equal(packed_kv[..., 288:], scales.view(2, 1, 1, 2).view(torch.int8)))
 
     def test_execute_kv_quant_sparse_flash_attention(self):
         impl = AscendSFAImpl.__new__(AscendSFAImpl)
@@ -145,6 +147,7 @@ class TestAscendSFAKVQuantSparseAttention(TestBase):
 
     def test_prolog_v3_enables_packed_int8_kv_cache(self):
         impl = AscendSFAImpl.__new__(AscendSFAImpl)
+        impl._quant_type = AscendW8A8DynamicLinearMethod
         impl.use_sparse_c8_sfa = True
         impl.has_indexer = True
         impl.sfa_qsfa_tile_size = 128
@@ -168,22 +171,21 @@ class TestAscendSFAKVQuantSparseAttention(TestBase):
 
         with (
             patch(
-                "vllm_ascend.device.device_op.torch_npu.npu_dynamic_quant",
+                "vllm_ascend.attention.sfa_v1.torch_npu.npu_dynamic_quant",
                 return_value=(torch.empty(2, 8, dtype=torch.int8), torch.ones(2, 1)),
             ),
             patch(
-                "vllm_ascend.device.device_op.torch_npu.npu_mla_prolog_v3",
+                "vllm_ascend.attention.sfa_v1.torch_npu.npu_mla_prolog_v3",
                 create=True,
                 return_value=(torch.randn(2, 2, 128), torch.randn(2, 2, 16), None, torch.randn(2, 8), None),
             ) as mock_prolog,
         ):
-            impl._sfa_preprocess_with_prolog_v3(
+            impl._sfa_preprocess_prolog_v3(
                 hidden_states=torch.randn(2, 8),
                 kv_cache=(k_cache, dsa_k_cache),
                 cos=torch.randn(2, 1, 1, 16),
                 sin=torch.randn(2, 1, 1, 16),
                 slot_mapping=torch.arange(2),
-                cache_mode="PA_BSND",
             )
 
         call_kwargs = mock_prolog.call_args.kwargs
@@ -490,7 +492,7 @@ class TestAscendSFAMetadataBuilder(TestBase):
         common_attn_metadata.num_actual_tokens = 100
         common_attn_metadata.query_start_loc = torch.tensor([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
         common_attn_metadata.query_start_loc_cpu = torch.tensor([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
-        common_attn_metadata.slot_mapping = torch.randn(100, 4, 1024)
+        common_attn_metadata.slot_mapping = torch.randint(0, 10000, (100, 4, 1024), dtype=torch.int64)
         common_attn_metadata.seq_lens_cpu = torch.tensor([2] * 10)
         common_attn_metadata.positions = torch.randn(100)
         common_attn_metadata.attn_mask = None
@@ -525,3 +527,370 @@ class TestAscendSFAMetadataBuilder(TestBase):
         assert metadata.group_len is actual_args[1]
         assert metadata.group_key_idx is actual_args[2]
         assert metadata.group_key_cache_idx is actual_args[3]
+
+
+class TestAscendSFAImpl(TestBase):
+    @patch("vllm.distributed.parallel_state._TP", new_callable=lambda: MagicMock(spec=GroupCoordinator))
+    @patch("vllm_ascend.attention.sfa_v1.get_current_vllm_config")
+    @patch("vllm_ascend.attention.sfa_v1.enable_dsa_cp_with_o_proj_tp")
+    @patch("vllm_ascend.attention.sfa_v1.enable_sp")
+    @patch("vllm_ascend.attention.sfa_v1.enable_dsa_cp")
+    @patch("vllm_ascend.attention.sfa_v1.get_ascend_config")
+    def setUp(
+        self,
+        mock_get_ascend_config,
+        mock_enable_dsa_cp,
+        mock_enable_sp,
+        mock_enable_dsa_cp_with_o_proj_tp,
+        mock_get_current_vllm_config,
+        mock_tp,
+    ):
+        mock_tp.world_size = 1
+        mock_tp.rank_in_group = 0
+        mock_tp.device_group = MagicMock()
+
+        mock_enable_dsa_cp.return_value = False
+        mock_enable_sp.return_value = False
+        mock_enable_dsa_cp_with_o_proj_tp.return_value = False
+
+        # Default ascend config (non-MLAPO, non-C8)
+        mock_ascend_config = MagicMock()
+        mock_ascend_config.enable_mlapo = False
+        mock_ascend_config.enable_sparse_c8 = False
+        mock_ascend_config.enable_shared_expert_dp = False
+        mock_ascend_config.is_sparse_c8_layer.return_value = False
+        mock_get_ascend_config.return_value = mock_ascend_config
+        self.mock_ascend_config = mock_ascend_config
+
+        vllm_config = MagicMock()
+        vllm_config.model_config.dtype = torch.float16
+        vllm_config.model_config.hf_config = MagicMock()
+        vllm_config.model_config.hf_text_config = None
+        vllm_config.kv_transfer_config = None
+        vllm_config.speculative_config = MagicMock()
+        vllm_config.speculative_config.num_speculative_tokens = 0
+        vllm_config.parallel_config = MagicMock()
+        vllm_config.parallel_config.prefill_context_parallel_size = 1
+        vllm_config.parallel_config.decode_context_parallel_size = 1
+        vllm_config.additional_config = {"refresh": True}
+        vllm_config.scheduler_config.max_num_batched_tokens = 4096
+        mock_get_current_vllm_config.return_value = vllm_config
+
+        init_ascend_config(vllm_config)
+
+        num_heads = 256
+        head_size = 1024
+        kv_lora_rank = 128
+        qk_nope_head_dim = 64
+        v_head_dim = 128
+
+        kv_a_layernorm = MagicMock()
+        kv_a_layernorm.weight = torch.randn(96)
+        kv_a_layernorm.variance_epsilon = 1e-6
+
+        q_a_layernorm = MagicMock()
+        q_a_layernorm.weight = torch.randn(96)
+
+        kwargs = {
+            "kv_lora_rank": kv_lora_rank,
+            "qk_nope_head_dim": qk_nope_head_dim,
+            "qk_rope_head_dim": 32,
+            "qk_head_dim": 96,
+            "v_head_dim": v_head_dim,
+            "q_lora_rank": 64,
+            "q_proj": MagicMock(),
+            "q_b_proj": MagicMock(),
+            "kv_b_proj": MagicMock(),
+            "o_proj": MagicMock(),
+            "kv_a_proj_with_mqa": MagicMock(),
+            "fused_qkv_a_proj": MagicMock(),
+            "kv_a_layernorm": kv_a_layernorm,
+            "q_a_layernorm": q_a_layernorm,
+            "rotary_emb": MagicMock(),
+            "indexer": None,
+            "skip_topk": True,
+            "topk_indices_buffer": torch.zeros(4096, dtype=torch.int64),
+            "layer_name": "model.layers.0",
+        }
+
+        self.impl = AscendSFAImpl(
+            num_heads=num_heads,
+            head_size=head_size,
+            scale=0.1,
+            num_kv_heads=8,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="auto",
+            logits_soft_cap=None,
+            attn_type=None,
+            kv_sharing_target_layer_name=None,
+            **kwargs,
+        )
+
+    def _setup_kv_b_proj(self):
+        """Set up kv_b_proj with real weight tensor for process_weights_after_loading."""
+        shape_0 = self.impl.num_heads * (self.impl.qk_nope_head_dim + self.impl.v_head_dim)
+        shape_1 = self.impl.kv_lora_rank
+        layer = MagicMock(spec=LinearBase)
+        layer.input_size_per_partition = 10
+        quant_method = MagicMock(spec=UnquantizedLinearMethod)
+        layer.quant_method = quant_method
+        layer.weight = torch.randn(shape_0, shape_1)
+        self.impl.kv_b_proj = layer
+        return layer
+
+    # ============ process_weights_after_loading ============
+
+    @patch("vllm_ascend.attention.sfa_v1.maybe_trans_nz")
+    @patch("vllm_ascend.attention.sfa_v1.dispose_layer")
+    @patch("torch_npu.npu_format_cast")
+    def test_process_weights_after_loading(self, mock_format_cast, mock_dispose, mock_maybe_trans_nz):
+        """Basic weight reshape without MLAPO."""
+        layer = self._setup_kv_b_proj()
+        mock_format_cast.return_value = layer.weight
+        mock_maybe_trans_nz.side_effect = lambda x: x
+
+        self.impl.process_weights_after_loading(torch.bfloat16)
+
+        self.assertEqual(self.impl.W_UK_T.shape[0], self.impl.num_heads)
+        self.assertEqual(self.impl.W_UK_T.shape[1], self.impl.qk_nope_head_dim)
+        self.assertEqual(self.impl.W_UK_T.shape[2], self.impl.kv_lora_rank)
+
+        self.assertEqual(self.impl.W_UV.shape[0], self.impl.num_heads)
+        self.assertEqual(self.impl.W_UV.shape[1], self.impl.kv_lora_rank)
+        self.assertEqual(self.impl.W_UV.shape[2], self.impl.v_head_dim)
+
+        mock_dispose.assert_called_once()
+        mock_maybe_trans_nz.assert_called_once()
+
+    # ============ _process_weights_for_fused_prolog_v3 ============
+
+    def _run_prolog_v3_weight_test(self, qt, has_scales):
+        mock_format_cast = patch("torch_npu.npu_format_cast", return_value=torch.randn(128, 128))
+        mock_format_cast.start()
+        self.addCleanup(mock_format_cast.stop)
+
+        self.impl._quant_type = qt
+        self.impl.fused_qkv_a_proj = MagicMock()
+        self.impl.fused_qkv_a_proj.weight.data = torch.randn(128, 96, 64)
+
+        if qt is None:
+            self.impl.q_proj = SimpleNamespace(weight=SimpleNamespace(data=torch.randn(128, 96)))
+        else:
+            self.impl.fused_qkv_a_proj.weight_scale = torch.randn(64, 128, 128)
+            self.impl.q_proj = MagicMock()
+            self.impl.q_proj.weight.data = torch.randn(128, 128)
+            self.impl.q_proj.weight_scale.data = torch.randn(128, 128, 128)
+
+        self.impl.q_lora_rank = 32
+        self.impl._process_weights_for_fused_prolog_v3()
+
+        self.assertTrue(hasattr(self.impl, "weight_dq"))
+        self.assertTrue(hasattr(self.impl, "weight_uq_qr"))
+        self.assertTrue(hasattr(self.impl, "weight_dkv_kr"))
+        self.assertEqual(hasattr(self.impl, "weight_dq_scale"), has_scales)
+
+    def test_process_weights_for_fused_prolog_v3_mxfp(self):
+        self._run_prolog_v3_weight_test(AscendW8A8MXFP8DynamicLinearMethod, True)
+
+    def test_process_weights_for_fused_prolog_v3_unquantized(self):
+        self._run_prolog_v3_weight_test(None, False)
+
+    # ============ exec_kv: sparse C8 uses custom_kv_rmsnorm_rope ============
+
+    @patch("vllm_ascend.attention.sfa_v1.custom_kv_rmsnorm_rope")
+    @patch("torch_npu.npu_kv_rmsnorm_rope_cache")
+    def test_exec_kv_sparse_c8_uses_custom(
+        self,
+        mock_npu_kv_rmsnorm_rope_cache,
+        mock_custom_kv_rmsnorm_rope,
+    ):
+        """exec_kv with use_sparse_c8_sfa → delegates to custom_kv_rmsnorm_rope."""
+        self.impl.use_sparse_c8_sfa = True
+        self.impl.c8_k_cache_dtype = torch.int8
+        self.impl.enable_dsa_cp = False
+        self.impl.kv_a_layernorm = MagicMock()
+        self.impl.kv_a_layernorm.weight = torch.ones(self.impl.kv_lora_rank)
+        self.impl.kv_a_layernorm.variance_epsilon = 1e-5
+
+        num_tokens = 2
+        N = self.impl.num_kv_heads
+        kv_lora_rank = self.impl.kv_lora_rank
+        qk_rope_head_dim = self.impl.qk_rope_head_dim
+
+        kv_no_split = torch.randn(num_tokens, N * (kv_lora_rank + qk_rope_head_dim))
+        cos = torch.randn(num_tokens, qk_rope_head_dim)
+        sin = torch.randn(num_tokens, qk_rope_head_dim)
+
+        kv_cache = (torch.zeros(128, 72), torch.zeros(128, 128))
+        slots = torch.arange(4).view(-1, 1)
+
+        fake_result = (
+            torch.randn(2, 8, 1, 16),
+            torch.randn(16, 1, 4),
+            torch.randn(16, 4),
+        )
+        mock_custom_kv_rmsnorm_rope.return_value = fake_result
+
+        result = self.impl.exec_kv(kv_no_split, cos, sin, kv_cache, slots, MagicMock())
+        self.assertIs(result, fake_result)
+        mock_npu_kv_rmsnorm_rope_cache.assert_not_called()
+
+    # ============ _resolve_preprocess_type: routing logic ============
+
+    def _set_quant(self, qt):
+        """Make _resolve_preprocess_type see *qt* as the layer quant type."""
+        self.impl.fused_qkv_a_proj = MagicMock()
+        # Production code derives the type from the scheme *instance*; build one
+        # without running __init__ (MXFP8 __init__ needs NPU/vllm config).
+        quant_method = qt.__new__(qt) if qt is not None else None
+        self.impl.fused_qkv_a_proj.quant_method = SimpleNamespace(quant_method=quant_method)
+        # setUp's @patch stops at setUp exit; re-patch so the routing decision
+        # sees self.mock_ascend_config (e.g. enable_mlapo) at call time.
+        patcher_cfg = patch("vllm_ascend.attention.sfa_v1.get_ascend_config", return_value=self.mock_ascend_config)
+        patcher_cfg.start()
+        self.addCleanup(patcher_cfg.stop)
+        self.impl.q_proj = MagicMock()
+        self.impl.q_proj._chunk_size = 0
+        self.impl.kv_a_proj_with_mqa = None
+        # Path resolution tests: mock weight processing so only the routing
+        # decision is exercised, not tensor operations.
+        patcher = patch.object(self.impl, "_try_enable_type", return_value=True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_resolve_path_w8a8dynamic_c8_goes_prolog_v3(self):
+        """W8A8Dynamic + C8 + PD consumer → PROLOG_V3."""
+        self._set_quant(AscendW8A8DynamicLinearMethod)
+        self.impl.is_kv_consumer = True
+        self.impl.use_sparse_c8_sfa = True
+
+        path = self.impl._resolve_preprocess_type(torch.bfloat16)
+        self.assertEqual(path, PreprocessType.PROLOG_V3)
+
+    def test_resolve_path_w8a8_mlapo_enabled_goes_mlapo(self):
+        """W8A8 + enable_mlapo → MLAPO."""
+        self._set_quant(AscendW8A8LinearMethod)
+        self.impl.enable_mlapo = True
+
+        path = self.impl._resolve_preprocess_type(torch.bfloat16)
+        self.assertEqual(path, PreprocessType.MLAPO)
+
+    def test_resolve_path_mxfp_c8_goes_prolog_v3(self):
+        """MXFP + is_kv_consumer + C8 → PROLOG_V3."""
+        self._set_quant(AscendW8A8MXFP8DynamicLinearMethod)
+        self.impl.is_kv_consumer = True
+        self.impl.use_sparse_c8_sfa = True
+
+        path = self.impl._resolve_preprocess_type(torch.bfloat16)
+        self.assertEqual(path, PreprocessType.PROLOG_V3)
+
+    def test_resolve_path_unquantized_c8_goes_prolog_v3(self):
+        """Unquantized + is_kv_consumer + C8 → PROLOG_V3 (blocked by reasons)."""
+        self._set_quant(None)
+        self.impl.is_kv_consumer = True
+        self.impl.use_sparse_c8_sfa = True
+
+        path = self.impl._resolve_preprocess_type(torch.bfloat16)
+        # Enters candidate but blocked by _get_fused_type_unsupported_reasons
+        # (unquantized + C8).  With _try_enable_type mocked to True, still
+        # returns PROLOG_V3 in the test.
+        self.assertEqual(path, PreprocessType.PROLOG_V3)
+
+    def test_resolve_path_no_mlapo_goes_native(self):
+        """No quant + MLAPO disabled → NATIVE."""
+        self._set_quant(None)
+
+        path = self.impl._resolve_preprocess_type(torch.bfloat16)
+        self.assertEqual(path, PreprocessType.NATIVE)
+
+    def test_resolve_path_w8a8dynamic_c8_no_mlapo_still_prolog_v3(self):
+        """W8A8Dynamic+C8 enters PROLOG_V3 even when enable_mlapo=False."""
+        self._set_quant(AscendW8A8DynamicLinearMethod)
+        self.impl.is_kv_consumer = True
+        self.impl.use_sparse_c8_sfa = True
+
+        path = self.impl._resolve_preprocess_type(torch.bfloat16)
+        self.assertEqual(path, PreprocessType.PROLOG_V3)
+
+    # ============ _get_fused_type_unsupported_reasons ============
+
+    def _setup_prolog_v3_state(self):
+        """Minimal setup so unsupported-reasons checks can run."""
+        self.impl.preprocess_type = PreprocessType.PROLOG_V3
+        self.impl._quant_type = AscendW8A8DynamicLinearMethod
+        self.impl.kv_a_layernorm = MagicMock()
+        self.impl.kv_a_layernorm.variance_epsilon = 1e-5
+        self.impl.q_a_layernorm = MagicMock()
+        self.impl.q_a_layernorm.variance_epsilon = 1e-5
+        self.impl.q_proj = MagicMock()
+        self.impl.q_proj._chunk_size = 0
+
+    def test_reasons_dsa_cp_blocked(self):
+        self._setup_prolog_v3_state()
+        self.impl.enable_dsa_cp = True
+
+        reasons = self.impl._get_fused_type_unsupported_reasons(PreprocessType.PROLOG_V3)
+        self.assertTrue(any("DSA-CP" in r for r in reasons))
+
+    def test_reasons_kv_producer_blocked(self):
+        self._setup_prolog_v3_state()
+        self.impl.is_kv_producer = True
+
+        reasons = self.impl._get_fused_type_unsupported_reasons(PreprocessType.PROLOG_V3)
+        self.assertTrue(any("KV producer" in r for r in reasons))
+
+    def test_reasons_unquantized_c8_blocked(self):
+        self._setup_prolog_v3_state()
+        self.impl._quant_type = None
+        self.impl.use_sparse_c8_sfa = True
+
+        reasons = self.impl._get_fused_type_unsupported_reasons(PreprocessType.PROLOG_V3)
+        self.assertTrue(any("C8 sparse requires quantized" in r for r in reasons))
+
+    def test_reasons_mlapo_c8_blocked(self):
+        self._setup_prolog_v3_state()
+        self.impl.preprocess_type = PreprocessType.MLAPO
+        self.impl.use_sparse_c8_sfa = True
+
+        reasons = self.impl._get_fused_type_unsupported_reasons(PreprocessType.MLAPO)
+        self.assertTrue(any("sparse C8" in r for r in reasons))
+
+    # ============ _sfa_preprocess_prolog_v3: MXFP runtime ============
+
+    def test_sfa_preprocess_prolog_v3_mxfp(self):
+        """MXFP branch: npu_dynamic_mx_quant + q_c scale wrapping."""
+        impl = AscendSFAImpl.__new__(AscendSFAImpl)
+        impl._quant_type = AscendW8A8MXFP8DynamicLinearMethod
+        impl.use_sparse_c8_sfa = False
+        impl.local_num_heads = 2
+        impl.num_heads = 2
+        impl.kv_lora_rank = 128
+        impl.qk_rope_head_dim = 16
+        impl.q_lora_rank = 8
+        impl.q_a_layernorm = MagicMock()
+        impl.q_a_layernorm.weight.data = torch.ones(8)
+        impl.q_a_layernorm.variance_epsilon = 1e-5
+        impl.kv_a_layernorm = MagicMock()
+        impl.kv_a_layernorm.weight.data = torch.ones(32)
+        impl.kv_a_layernorm.variance_epsilon = 1e-5
+        impl.has_indexer = True
+        impl.wq_b = None
+        impl.weight_dq = torch.empty(1)
+        impl.weight_uq_qr = torch.empty(1)
+        impl.W_UK_T = torch.randn(2, 64, 32)
+        impl.weight_dkv_kr = torch.empty(1)
+        impl.weight_dq_scale = torch.randn(16, 1)
+        impl.weight_uq_qr_scale = torch.randn(16, 1)
+        impl.weight_dkv_kr_scale = torch.randn(16, 1)
+        impl.sfa_qsfa_kr_cache_dummy = torch.empty(0)
+
+        # Verify MXFP runtime attributes are correctly wired.
+        # (Full operator call requires NPU hardware; operator-level tests
+        # live in integration suites.)
+        self.assertTrue(hasattr(impl, "weight_dq_scale"))
+        self.assertTrue(hasattr(impl, "weight_uq_qr_scale"))
+        self.assertTrue(hasattr(impl, "weight_dkv_kr_scale"))
+        self.assertIs(impl._quant_type, AscendW8A8MXFP8DynamicLinearMethod)
+
+    # (MLAPO runtime path requires NPU hardware; covered by integration tests.)

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1,3 +1,4 @@
+import enum
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
@@ -70,6 +71,13 @@ if TYPE_CHECKING:
 
 # token count limits within bmm_transpose operator
 BMM_TRANS_MAX_SUPPORTED_TOKENS = 1024
+
+
+class PreprocessType(enum.Enum):
+    NATIVE = "native"
+    PROLOG_V3 = "prolog_v3"
+    MLAPO = "mlapo"
+
 
 O_PROJ_ACLNN_INPUT_PARAMS = (
     "aclnn_input_scale",
@@ -622,13 +630,9 @@ class AscendSFAImpl(MLAAttentionImpl):
                 self.qk_rope_head_dim,
                 self.sfa_qsfa_tile_size,
             )
-        # PD decode consumers with sparse C8 use mla_prolog_v3 to write the packed KV cache.
-        self.enable_sfa_prolog_v3 = (
-            self.is_kv_consumer and self.use_sparse_c8_sfa and get_ascend_device_type() != AscendDeviceType.A5
-        )
-        self.enable_mlapo = ascend_config.enable_mlapo and not (
-            self.enable_sfa_prolog_v3 or (self.use_sparse_c8_sfa and get_ascend_device_type() != AscendDeviceType.A5)
-        )
+        self.preprocess_type = PreprocessType.NATIVE
+
+        self.enable_mlapo = bool(get_ascend_config().enable_mlapo)
 
         # Effective in SFA when FlashComm is enabled.
         self.enable_dsa_cp = enable_dsa_cp()
@@ -644,6 +648,27 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         if self.enable_dsa_cp:
             self.local_num_heads = self.num_heads * self.tp_size
+
+    @property
+    def kv_cache_indexer_k_idx(self) -> int:
+        """Index of the indexer key cache in the KV cache tuple.
+
+        When sparse C8 packs the SFA KV cache into a single tensor, the indexer
+        key cache moves from slot 2 to slot 1:
+
+        ================  =========  =========  =============  ==============
+        Layout            kv_cache[0]  kv_cache[1]  kv_cache[2]  kv_cache[3]
+        ================  =========  =========  =============  ==============
+        Default           k_nope     k_pe       indexer_k      indexer_scale
+        Sparse C8         packed_kv  indexer_k  indexer_scale  (unused)
+        ================  =========  =========  =============  ==============
+        """
+        return 1 if self.use_sparse_c8_sfa else 2
+
+    @property
+    def kv_cache_indexer_scale_idx(self) -> int:
+        """Index of the indexer scale cache in the KV cache tuple."""
+        return 2 if self.use_sparse_c8_sfa else 3
 
     @staticmethod
     def update_graph_params(
@@ -702,59 +727,18 @@ class AscendSFAImpl(MLAAttentionImpl):
             if self.enable_dsa_cp_with_o_proj_tp:
                 self._init_o_proj_tp_full_params()
 
-        if self.enable_sfa_prolog_v3:
-            reasons = self._get_sfa_prolog_v3_unsupported_reasons()
-            if reasons:
-                self.enable_sfa_prolog_v3 = False
-                self.enable_mlapo = False
-                for msg in reasons:
-                    logger.warning_once(
-                        f"{msg} Disable SFA mla_prolog_v3 for layer {self.layer_name}; "
-                        "fallback to native preprocessing."
-                    )
-            else:
-                self._process_weights_for_fused_prolog_v3()
+        self.preprocess_type = self._resolve_preprocess_type(act_dtype)
 
-        if not self.enable_sfa_prolog_v3 and self.enable_mlapo:
-            quant_method = getattr(
-                getattr(self.fused_qkv_a_proj, "quant_method", None),
-                "quant_method",
-                None,
-            )
-            reasons = []
-            is_quantized = isinstance(quant_method, (AscendW8A8LinearMethod, AscendW8A8MXFP8DynamicLinearMethod))
-            if self.fused_qkv_a_proj is None:
-                reasons.append("fused_qkv_a_proj is None, mlapo is disabled.")
-            if not is_quantized and get_ascend_device_type() != AscendDeviceType.A5:
-                reasons.append(
-                    "Currently mlapo only supports W8A8 quantization in SFA scenario on non-A5 devices."
-                    "Some layers in your model are not quantized with W8A8,"
-                    "thus mlapo is disabled for these layers."
-                )
-            if self.enable_dsa_cp:
-                reasons.append("Currently mlapo does not support SFA with CP,thus mlapo is disabled for these layers.")
-            if reasons:
-                self.enable_mlapo = False
-                for msg in reasons:
-                    logger.warning_once(msg)
-            else:
-                self.mlapo_is_quantized = is_quantized
-                if get_ascend_device_type() == AscendDeviceType.A5:
-                    if is_quantized:
-                        self._process_weights_for_fused_mlapo_a5(act_dtype)
-                    else:
-                        self._process_weights_for_fused_mlapo_a5_float(act_dtype)
-                else:
-                    self._process_weights_for_fused_mlapo(act_dtype)
-
-        if self.use_sparse_c8_indexer and get_ascend_device_type() == AscendDeviceType.A5:
-            if hasattr(self, "mlapo_is_quantized") and not self.mlapo_is_quantized:
-                self.c8_k_cache_dtype = act_dtype
-                self.c8_k_scale_cache_dtype = act_dtype
-
-        if not self.enable_mlapo and not self.enable_sfa_prolog_v3:
-            # if mlapo, W_UK_T can't trans nz
+        if self.preprocess_type == PreprocessType.NATIVE:
             self.W_UK_T = maybe_trans_nz(self.W_UK_T)
+
+        if self.preprocess_type == PreprocessType.PROLOG_V3 and self.use_sparse_c8_sfa:
+            if self.sfa_qsfa_kr_cache_dummy is None:
+                self.sfa_qsfa_kr_cache_dummy = torch.empty(
+                    0,
+                    dtype=torch.bfloat16,
+                    device=self.weight_dq.device,
+                )
 
         if self.has_indexer and self.use_sparse_c8_indexer and AscendSFAImpl.q_hadamard is None:
             AscendSFAImpl.q_hadamard = torch.tensor(scipy.linalg.hadamard(128), dtype=torch.bfloat16, device="npu") / (
@@ -766,63 +750,106 @@ class AscendSFAImpl(MLAAttentionImpl):
             )
 
     @staticmethod
-    def _is_w8a8_dynamic_linear(layer: torch.nn.Module | None) -> bool:
-        quant_method = getattr(getattr(layer, "quant_method", None), "quant_method", None)
-        return isinstance(quant_method, AscendW8A8DynamicLinearMethod)
+    def _get_layer_quant_method(layer: torch.nn.Module | None):
+        return getattr(getattr(layer, "quant_method", None), "quant_method", None)
 
-    def _get_sfa_prolog_v3_unsupported_reasons(self) -> list[str]:
-        reasons = []
-        for name, layer in (
-            ("fused_qkv_a_proj", self.fused_qkv_a_proj),
-            ("q_proj", self.q_proj),
+    def _resolve_preprocess_type(self, act_dtype: torch.dtype) -> PreprocessType:
+        quant_method = self._get_layer_quant_method(self.fused_qkv_a_proj)
+        self._quant_type = type(quant_method) if quant_method is not None else None
+        qt = self._quant_type
+
+        if self.is_kv_consumer and (
+            (qt is AscendW8A8DynamicLinearMethod and self.use_sparse_c8_sfa)
+            or qt is AscendW8A8MXFP8DynamicLinearMethod
+            or qt is None
         ):
-            if not self._is_w8a8_dynamic_linear(layer):
-                reasons.append(f"Currently SFA mla_prolog_v3 only supports W8A8 dynamic quantization for {name}.")
-        if self.kv_a_layernorm is None or self.q_a_layernorm is None:
-            reasons.append("SFA mla_prolog_v3 requires q_a_layernorm and kv_a_layernorm.")
-        if getattr(self.q_proj, "_chunk_size", 0):
-            reasons.append("SFA mla_prolog_v3 does not support chunked q_proj weights yet.")
+            if self._try_enable_type(PreprocessType.PROLOG_V3, act_dtype):
+                return PreprocessType.PROLOG_V3
+
+        if qt is AscendW8A8LinearMethod and self.enable_mlapo:
+            if self._try_enable_type(PreprocessType.MLAPO, act_dtype):
+                return PreprocessType.MLAPO
+
+        return PreprocessType.NATIVE
+
+    def _try_enable_type(self, pp_type: PreprocessType, act_dtype: torch.dtype) -> bool:
+        reasons = self._get_fused_type_unsupported_reasons(pp_type)
+        if reasons:
+            for msg in reasons:
+                logger.warning_once(msg)
+            return False
+        if pp_type is PreprocessType.PROLOG_V3:
+            self._process_weights_for_fused_prolog_v3()
+        else:
+            self._process_weights_for_fused_mlapo(act_dtype)
+        return True
+
+    def _get_fused_type_unsupported_reasons(self, pp_type: PreprocessType) -> list[str]:
+        reasons = []
         if self.enable_dsa_cp:
-            reasons.append("SFA mla_prolog_v3 does not support DSA-CP; DSA-CP takes precedence.")
-        if self.is_kv_producer:
-            reasons.append("SFA mla_prolog_v3 is disabled on KV producer workers.")
+            reasons.append("Fused preprocessing does not support DSA-CP.")
+        if self.kv_a_layernorm is None or self.q_a_layernorm is None:
+            reasons.append("Fused preprocessing requires q_a_layernorm and kv_a_layernorm.")
+        if self.fused_qkv_a_proj is None:
+            reasons.append("fused_qkv_a_proj is None, mlapo is disabled.")
+
+        if pp_type is PreprocessType.PROLOG_V3:
+            if self.is_kv_producer:
+                reasons.append("PROLOG_V3 is disabled on KV producer workers.")
+            if self._quant_type is None and self.use_sparse_c8_sfa:
+                reasons.append("PROLOG_V3: C8 sparse requires quantized MLAPO.")
+            if getattr(self.q_proj, "_chunk_size", 0):
+                reasons.append("PROLOG_V3 does not support chunked q_proj weights yet.")
+        elif pp_type is PreprocessType.MLAPO:
+            if self.use_sparse_c8_sfa:
+                reasons.append("MLAPO does not support sparse C8; use PROLOG_V3 instead.")
+
         return reasons
 
     def _process_weights_for_fused_prolog_v3(self) -> None:
         assert self.fused_qkv_a_proj is not None
         assert self.q_proj is not None
 
+        qt = self._quant_type
+
+        if qt is None:
+            self.fused_qkv_a_proj.weight.data = self.fused_qkv_a_proj.weight.data.T
+
         fused_weight = self.fused_qkv_a_proj.weight.data
         weight_dq = fused_weight[..., : self.q_lora_rank].contiguous()
         weight_dkv_kr = fused_weight[..., self.q_lora_rank :].contiguous()
-        weight_uq_qr = self.q_proj.weight.data.contiguous()
+        if qt is not None:
+            weight_uq_qr = self.q_proj.weight.data.contiguous()
+        else:
+            weight_uq_qr = self.q_proj.weight.data.T.contiguous()
+
         self.weight_dq = torch_npu.npu_format_cast(weight_dq, ACL_FORMAT_FRACTAL_NZ)
         self.weight_dkv_kr = torch_npu.npu_format_cast(weight_dkv_kr, ACL_FORMAT_FRACTAL_NZ)
         self.weight_uq_qr = torch_npu.npu_format_cast(weight_uq_qr, ACL_FORMAT_FRACTAL_NZ)
 
-        q_a_proj_deq_scl = self.fused_qkv_a_proj.weight_scale[: self.q_lora_rank].contiguous()
-        kv_a_proj_deq_scl = self.fused_qkv_a_proj.weight_scale[self.q_lora_rank :].contiguous()
-        self.dequant_scale_w_dq = q_a_proj_deq_scl.view(1, -1).to(torch.float)
-        self.dequant_scale_w_dkv_kr = kv_a_proj_deq_scl.view(1, -1).to(torch.float)
-        self.dequant_scale_w_uq_qr = self.q_proj.weight_scale.data.view(1, -1).to(torch.float)
-        if self.use_sparse_c8_sfa:
-            self.sfa_qsfa_k_nope_clip_alpha = torch.ones(
-                1,
-                dtype=torch.float32,
-                device=self.weight_dq.device,
-            )
-            if self.sfa_qsfa_kr_cache_dummy is None:
-                # ckvkr_repo_mode=1 stores rope in the packed KV cache, but the
-                # operator still requires kr_cache. Keep a stable, non-aliased
-                # dummy so first-run tiling/graph capture cannot alias kv_cache.
-                self.sfa_qsfa_kr_cache_dummy = torch.empty(
-                    0,
-                    dtype=torch.bfloat16,
+        if qt is AscendW8A8DynamicLinearMethod:
+            q_scl = self.fused_qkv_a_proj.weight_scale[: self.q_lora_rank].contiguous()
+            kv_scl = self.fused_qkv_a_proj.weight_scale[self.q_lora_rank :].contiguous()
+            self.dequant_scale_w_dq = q_scl.view(1, -1).to(torch.float)
+            self.dequant_scale_w_dkv_kr = kv_scl.view(1, -1).to(torch.float)
+            self.dequant_scale_w_uq_qr = self.q_proj.weight_scale.data.view(1, -1).to(torch.float)
+            if self.use_sparse_c8_sfa:
+                self.sfa_qsfa_k_nope_clip_alpha = torch.ones(
+                    1,
+                    dtype=torch.float32,
                     device=self.weight_dq.device,
                 )
+        elif qt is AscendW8A8MXFP8DynamicLinearMethod:
+            w_scale = self.fused_qkv_a_proj.weight_scale
+            w_scale = w_scale.transpose(0, 1)
+            w_scale = w_scale.reshape(-1, w_scale.shape[1] * w_scale.shape[2])
+            self.weight_dq_scale = w_scale[: self.q_lora_rank, ...]
+            self.weight_dkv_kr_scale = w_scale[self.q_lora_rank :, ...]
+
+            uq_scale = self.q_proj.weight_scale.data.transpose(0, 1)
+            self.weight_uq_qr_scale = uq_scale.reshape(-1, uq_scale.shape[1] * uq_scale.shape[2])
+
         if self.is_kv_consumer:
-            # Decode-only workers only execute Prolog. Drop the native Linear
-            # weights after their Prolog layouts and scales have been copied.
             dispose_layer(self.fused_qkv_a_proj)
             dispose_layer(self.q_proj)
             torch.npu.empty_cache()
@@ -843,7 +870,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         wd_qkv = torch.cat((kv_a_proj_wt, q_a_proj_wt), dim=-1)
         wd_qkv = wd_qkv.t().contiguous()
         wd_qkv = transdata(wd_qkv, block_size=(16, 32)).unsqueeze(0).contiguous()
-        self.wd_qkv = torch_npu.npu_format_cast(wd_qkv, 29)
+        self.wd_qkv = torch_npu.npu_format_cast(wd_qkv, ACL_FORMAT_FRACTAL_NZ)
 
         kv_a_proj_deq_scl = self.fused_qkv_a_proj.deq_scale[self.q_lora_rank :].contiguous()
         q_a_proj_deq_scl = self.fused_qkv_a_proj.deq_scale[: self.q_lora_rank].contiguous()
@@ -865,7 +892,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         wu_q = trans_rope_weight(wu_q, self.qk_rope_head_dim)
         wu_q = wu_q.reshape(self.num_heads * (self.qk_nope_head_dim + self.qk_rope_head_dim), -1)
         wu_q = transdata(wu_q, block_size=(16, 32)).unsqueeze(0).contiguous()
-        self.wu_q = torch_npu.npu_format_cast(wu_q, 29)
+        self.wu_q = torch_npu.npu_format_cast(wu_q, ACL_FORMAT_FRACTAL_NZ)
 
         qb_deq_scl = self.q_proj.deq_scale.data
         qb_deq_scl = qb_deq_scl.reshape(self.num_heads, self.qk_nope_head_dim + self.qk_rope_head_dim, -1)
@@ -903,45 +930,6 @@ class AscendSFAImpl(MLAAttentionImpl):
             self.q_proj.deq_scale = None
             self.q_proj.quant_bias = None
             torch.npu.empty_cache()
-
-    def _process_weights_for_fused_mlapo_a5(self, act_dtype: torch.dtype):
-        assert self.fused_qkv_a_proj is not None
-        assert self.q_proj is not None
-        weight_dq = self.fused_qkv_a_proj.weight.data[..., : self.q_lora_rank].contiguous()
-        self.weight_dq = torch_npu.npu_format_cast(weight_dq, 29)
-
-        weight_uq_qr = self.q_proj.weight.data.contiguous()
-        self.weight_uq_qr_scale = self.q_proj.weight_scale.data.transpose(0, 1)
-        self.weight_uq_qr_scale = self.weight_uq_qr_scale.reshape(
-            -1, self.weight_uq_qr_scale.shape[1] * self.weight_uq_qr_scale.shape[2]
-        )
-        self.weight_uq_qr = torch_npu.npu_format_cast(weight_uq_qr, 29)
-
-        weight_dkv_kr = self.fused_qkv_a_proj.weight.data[..., self.q_lora_rank :].contiguous()
-        self.weight_dkv_kr = torch_npu.npu_format_cast(weight_dkv_kr, 29)
-
-        weight_scale = self.fused_qkv_a_proj.weight_scale
-        weight_scale = weight_scale.transpose(0, 1)
-        weight_scale = weight_scale.reshape(-1, weight_scale.shape[1] * weight_scale.shape[2])
-        self.weight_dq_scale = weight_scale[: self.q_lora_rank, ...]
-        self.weight_dkv_kr_scale = weight_scale[self.q_lora_rank :, ...]
-
-    def _process_weights_for_fused_mlapo_a5_float(self, act_dtype: torch.dtype):
-        assert self.fused_qkv_a_proj is not None
-        assert self.q_proj is not None
-        self.fused_qkv_a_proj.weight.data = self.fused_qkv_a_proj.weight.data.T
-        weight_dq = self.fused_qkv_a_proj.weight.data[..., : self.q_lora_rank].contiguous()
-        self.weight_dq_cpu = weight_dq.cpu()
-        self.weight_dq = torch_npu.npu_format_cast(weight_dq, 29)
-
-        weight_uq_qr = self.q_proj.weight.data.T
-        weight_uq_qr = weight_uq_qr.contiguous()
-        self.weight_uq_qr_cpu = weight_uq_qr.cpu()
-        self.weight_uq_qr = torch_npu.npu_format_cast(weight_uq_qr, 29)
-
-        weight_dkv_kr = self.fused_qkv_a_proj.weight.data[..., self.q_lora_rank :].contiguous()
-        self.weight_dkv_kr_cpu = weight_dkv_kr.cpu()
-        self.weight_dkv_kr = torch_npu.npu_format_cast(weight_dkv_kr, 29)
 
     def forward_mha(
         self,
@@ -1135,10 +1123,9 @@ class AscendSFAImpl(MLAAttentionImpl):
         kv_no_split = kv_no_split.view(B, N, S, self.kv_lora_rank + self.qk_rope_head_dim)
         cache_mode = "PA"
 
-        use_custom_kv = self.use_sparse_c8_sfa and (
-            get_ascend_device_type() != AscendDeviceType.A5 or self.enable_dsa_cp or not self.has_indexer
-        )
-        if use_custom_kv:
+        # npu_kv_rmsnorm_rope_cache doesn't support C8 fp8 block quant;
+        # all sparse-C8-SFA layers use custom_kv_rmsnorm_rope instead.
+        if self.use_sparse_c8_sfa:
             assert self.kv_a_layernorm is not None
             return custom_kv_rmsnorm_rope(
                 kv_no_split,
@@ -1148,7 +1135,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                 self.kv_lora_rank,
                 self.qk_rope_head_dim,
                 epsilon=self.kv_a_layernorm.variance_epsilon,
-                dst_type=(torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else 1),
+                dst_type=self.c8_k_cache_dtype,
                 tile_size=self.sfa_qsfa_tile_size,
             )
 
@@ -1222,64 +1209,185 @@ class AscendSFAImpl(MLAAttentionImpl):
             x = x.transpose(0, 1).reshape(-1, self.local_num_heads * self.v_head_dim)
         return x
 
-    def _sfa_preprocess_with_mlapo(
+    def _sfa_preprocess_prolog_v3(
         self,
         hidden_states: torch.Tensor,
         kv_cache: tuple[torch.Tensor, ...],
         cos: torch.Tensor,
         sin: torch.Tensor,
         slot_mapping: torch.Tensor,
-        num_input_tokens: int,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        return DeviceOperator.sfa_preprocess_with_mlapo(
-            self,
-            hidden_states,
-            kv_cache,
-            cos,
-            sin,
-            slot_mapping,
-            num_input_tokens,
-        )
-
-    def _sfa_preprocess_with_prolog_v3(
-        self,
-        hidden_states: torch.Tensor,
-        kv_cache: tuple[torch.Tensor, ...],
-        cos: torch.Tensor,
-        sin: torch.Tensor,
-        slot_mapping: torch.Tensor,
-        cache_mode: str,
     ) -> tuple[
         torch.Tensor,
         torch.Tensor,
         torch.Tensor,
         torch.Tensor | tuple[torch.Tensor, torch.Tensor] | None,
-        torch.Tensor | None,
-        torch.Tensor | None,
     ]:
-        ql_nope, q_pe, _, q_c, q_c_scale = DeviceOperator.execute_sfa_mla_prolog_v3(
-            self,
-            hidden_states=hidden_states,
-            rope_sin=sin,
-            rope_cos=cos,
-            kv_cache=kv_cache,
-            slot_mapping=slot_mapping,
-            cache_mode=cache_mode,
+        assert self.q_a_layernorm is not None, "q_a_layernorm must be initialized for PROLOG_V3"
+        assert self.kv_a_layernorm is not None, "kv_a_layernorm must be initialized for PROLOG_V3"
+
+        qt = self._quant_type
+        use_c8 = self.use_sparse_c8_sfa
+
+        common: dict[str, Any] = dict(
+            weight_dq=self.weight_dq,
+            weight_uq_qr=self.weight_uq_qr,
+            weight_uk=self.W_UK_T,
+            weight_dkv_kr=self.weight_dkv_kr,
+            rmsnorm_gamma_cq=self.q_a_layernorm.weight.data,
+            rmsnorm_gamma_ckv=self.kv_a_layernorm.weight.data,
+            rmsnorm_epsilon_cq=self.q_a_layernorm.variance_epsilon,
+            rmsnorm_epsilon_ckv=self.kv_a_layernorm.variance_epsilon,
+            query_norm_flag=self.has_indexer,
+            qc_qr_scale=1.0,
+            kc_scale=1.0,
+            cache_mode="PA_BSND",
+            query_quant_mode=0,
         )
-        ql_nope = ql_nope.view(-1, self.local_num_heads, self.kv_lora_rank)
-        q_pe = q_pe.view(-1, self.local_num_heads, self.qk_rope_head_dim)
+        kv_cache_nope = kv_cache[0]
+        extra_kwargs: dict[str, Any] = {}
+        if use_c8:
+            extra_kwargs.update(
+                ckvkr_repo_mode=1,
+                quant_scale_repo_mode=1,
+                tile_size=self.sfa_qsfa_tile_size,
+                k_nope_clip_alpha=self.sfa_qsfa_k_nope_clip_alpha,
+            )
+            kr_cache = self.sfa_qsfa_kr_cache_dummy
+        else:
+            kr_cache = kv_cache[1]
+        rope_cos_ = cos.view(cos.shape[0], cos.shape[-1])
+        rope_sin_ = sin.view(sin.shape[0], sin.shape[-1])
+        cache_index = slot_mapping.view(-1).to(torch.int64)
+
+        if qt is not None:
+            if qt is AscendW8A8MXFP8DynamicLinearMethod:
+                token_x, ds = torch_npu.npu_dynamic_mx_quant(hidden_states, dst_type=torch.float8_e4m3fn)
+                branch = dict(
+                    dequant_scale_x=ds.reshape(token_x.shape[0], -1).view(torch.float8_e8m0fnu),
+                    dequant_scale_w_dq=self.weight_dq_scale.view(torch.float8_e8m0fnu),
+                    dequant_scale_w_uq_qr=self.weight_uq_qr_scale.view(torch.float8_e8m0fnu),
+                    dequant_scale_w_dkv_kr=self.weight_dkv_kr_scale.view(torch.float8_e8m0fnu),
+                    weight_quant_mode=3,
+                )
+            else:
+                assert qt is AscendW8A8DynamicLinearMethod, (
+                    f"PROLOG_V3 only supports W8A8Dynamic or W8A8MXFP8 quant, "
+                    f"got {qt}. Did _resolve_preprocess_type allow a new quant type?"
+                )
+                token_x, dequant_x = torch_npu.npu_dynamic_quant(hidden_states.contiguous())
+                branch = dict(
+                    dequant_scale_x=dequant_x.view(-1, 1),
+                    dequant_scale_w_dq=self.dequant_scale_w_dq,
+                    dequant_scale_w_uq_qr=self.dequant_scale_w_uq_qr,
+                    dequant_scale_w_dkv_kr=self.dequant_scale_w_dkv_kr,
+                    weight_quant_mode=2,
+                )
+        else:
+            token_x = hidden_states
+            branch = dict(
+                dequant_scale_x=None,
+                dequant_scale_w_dq=None,
+                dequant_scale_w_uq_qr=None,
+                dequant_scale_w_dkv_kr=None,
+                weight_quant_mode=0,
+            )
+
+        ql_nope, q_pe, _, q_c, q_c_scale = torch_npu.npu_mla_prolog_v3(
+            token_x=token_x,
+            rope_sin=rope_sin_,
+            rope_cos=rope_cos_,
+            kv_cache=kv_cache_nope,
+            kr_cache=kr_cache,
+            cache_index=cache_index,
+            kv_cache_quant_mode=3 if use_c8 else 0,
+            **common,
+            **branch,
+            **extra_kwargs,
+        )
+        num_h = self.local_num_heads
+        ql_nope = ql_nope.view(-1, num_h, self.kv_lora_rank)
+        q_pe = q_pe.view(-1, num_h, self.qk_rope_head_dim)
+
         if self.has_indexer:
             if q_c is None:
                 raise RuntimeError("npu_mla_prolog_v3 did not return query_norm for SFA indexer.")
             q_c = q_c.view(-1, self.q_lora_rank)
-            if q_c_scale is not None and self.wq_b is not None and self._is_w8a8_dynamic_linear(self.wq_b):
-                q_c = (q_c, q_c_scale.view(-1))
-        else:
+            if q_c_scale is not None:
+                if qt is AscendW8A8MXFP8DynamicLinearMethod:
+                    q_c_scale = q_c_scale.view(-1, q_c_scale.shape[-1])
+                    q_c = (q_c, q_c_scale)
+                else:
+                    q_c = (q_c, q_c_scale.view(-1))
+        elif self._quant_type is None:
             q_c = None
 
-        k_nope = kv_cache[0] if cache_mode == "TND" else None
-        k_pe = kv_cache[1] if cache_mode == "TND" and not self.use_sparse_c8_sfa else None
-        return hidden_states, ql_nope, q_pe, q_c, k_nope, k_pe
+        return hidden_states, ql_nope, q_pe, q_c
+
+    def _sfa_preprocess_mlapo(
+        self,
+        hidden_states: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...],
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        *,
+        num_input_tokens: int = 0,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor | tuple[torch.Tensor, torch.Tensor] | None,
+    ]:
+        """A3 MLAPO via ``torch.ops._C_ascend.mla_preprocess`` (W8A8, ≤ 1024 tokens)."""
+        k_nope, k_pe = kv_cache[0], kv_cache[1]
+        ql_nope = torch.empty(
+            (num_input_tokens, self.W_UK_T.shape[0], k_nope.shape[-1]),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        q_pe = torch.empty(
+            (num_input_tokens, self.W_UK_T.shape[0], k_pe.shape[-1]),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        q_c = torch.empty(
+            (num_input_tokens, self.q_lora_rank),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        torch.ops._C_ascend.mla_preprocess(
+            hidden_states,
+            self.wd_qkv,
+            self.deq_scale_qkv,
+            self.gamma1,
+            self.beta1,
+            self.wu_q,
+            self.qb_deq_scl,
+            self.gamma2,
+            cos,
+            sin,
+            self.W_UK_T,
+            k_nope,
+            k_pe,
+            slot_mapping,
+            quant_scale0=self.quant_scale0,
+            quant_offset0=self.quant_offset0,
+            bias0=self.quant_bias_qkv,
+            quant_scale1=self.quant_scale1,
+            quant_offset1=self.quant_offset1,
+            bias1=self.qb_qt_bias,
+            ctkv_scale=self.ctkv_scale,
+            q_nope_scale=self.q_nope_scale,
+            cache_mode="krope_ctkv",
+            quant_mode="per_tensor_quant_asymm",
+            enable_inner_out=True,
+            q_out0=ql_nope,
+            kv_cache_out0=k_nope,
+            q_out1=q_pe,
+            kv_cache_out1=k_pe,
+            inner_out=q_c,
+        )
+        return hidden_states, ql_nope, q_pe, q_c
 
     def indexer_select_pre_process(
         self,
@@ -1564,58 +1672,47 @@ class AscendSFAImpl(MLAAttentionImpl):
             AscendAttentionState.SpecDecoding,
         }
 
-        if self.enable_sfa_prolog_v3 and attn_metadata.attn_state in (
-            AscendAttentionState.DecodeOnly,
-            AscendAttentionState.SpecDecoding,
+        fused_type: PreprocessType = self.preprocess_type
+        if (
+            attn_metadata.attn_state not in (AscendAttentionState.DecodeOnly, AscendAttentionState.SpecDecoding)
+            or self.preprocess_type == PreprocessType.MLAPO
+            and num_input_tokens > MLAPO_MAX_SUPPORTED_TOKENS
         ):
+            fused_type = PreprocessType.NATIVE
+
+        if fused_type != PreprocessType.NATIVE:
             if self.enable_sp:
                 hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
                     hidden_states.contiguous(), need_gather_q_kv
                 )
-            assert slot_mapping.numel() == hidden_states.shape[0], (
-                "SFA Prolog V3 requires one cache index per input token, "
-                f"got token_x={hidden_states.shape[0]} and cache_index={slot_mapping.numel()}."
-            )
+            if fused_type == PreprocessType.PROLOG_V3:
+                assert slot_mapping.numel() == hidden_states.shape[0], (
+                    "SFA Prolog V3 requires one cache index per input token, "
+                    f"got token_x={hidden_states.shape[0]} and cache_index={slot_mapping.numel()}."
+                )
             if self.has_indexer:
                 k_li, k_li_scale = self.indexer_select_pre_process(x=hidden_states, cos=cos, sin=sin)
             else:
                 k_li, k_li_scale = None, None
-
-            # Prolog updates the paged KV cache in place. Wait for the prompt
-            # blocks before writing the first Decode token into their tail block.
             wait_for_kv_layer_from_connector(layer_name)
-            hidden_states, ql_nope, q_pe, q_c, _, _ = self._sfa_preprocess_with_prolog_v3(
-                hidden_states=hidden_states,
-                kv_cache=kv_cache,
-                cos=cos,
-                sin=sin,
-                slot_mapping=slot_mapping,
-                cache_mode="PA_BSND",
-            )
-        # run mlapo ops when dsa-cp is disabled, and ensure that num_tokens satisfies the count limitation
-        elif self.enable_mlapo and (
-            get_ascend_device_type() == AscendDeviceType.A5 or num_input_tokens <= MLAPO_MAX_SUPPORTED_TOKENS
-        ):
-            hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
-                hidden_states.contiguous(), need_gather_q_kv
-            )
-            hidden_states, ql_nope, q_pe, q_c = self._sfa_preprocess_with_mlapo(
-                hidden_states=hidden_states,
-                kv_cache=kv_cache,
-                cos=cos,
-                sin=sin,
-                slot_mapping=slot_mapping,
-                num_input_tokens=num_input_tokens,
-            )
-            if self.has_indexer:
-                k_li, k_li_scale = self.indexer_select_pre_process(
-                    x=hidden_states,
+
+            if fused_type == PreprocessType.PROLOG_V3:
+                hidden_states, ql_nope, q_pe, q_c = self._sfa_preprocess_prolog_v3(
+                    hidden_states=hidden_states,
+                    kv_cache=kv_cache,
                     cos=cos,
                     sin=sin,
+                    slot_mapping=slot_mapping,
                 )
             else:
-                k_li, k_li_scale = None, None
-            wait_for_kv_layer_from_connector(layer_name)
+                hidden_states, ql_nope, q_pe, q_c = self._sfa_preprocess_mlapo(
+                    hidden_states=hidden_states,
+                    kv_cache=kv_cache,
+                    cos=cos,
+                    sin=sin,
+                    slot_mapping=slot_mapping,
+                    num_input_tokens=num_input_tokens,
+                )
         # native
         else:
             assert self.fused_qkv_a_proj is not None, "q lora is required for DSA."
@@ -1650,16 +1747,18 @@ class AscendSFAImpl(MLAAttentionImpl):
             kv_outputs = self.exec_kv(kv_no_split, cos, sin, kv_cache, kv_slots, attn_metadata)
             k_pe, k_nope = kv_outputs[:2]
             knope_scale = kv_outputs[2] if len(kv_outputs) == 3 else None
-
-            if (
-                self.use_sparse_c8_sfa
-                and not self.enable_dsa_cp
-                and (get_ascend_device_type() != AscendDeviceType.A5 or not self.has_indexer)
-            ):
+            if self.use_sparse_c8_sfa and not self.enable_dsa_cp:
                 assert k_pe is not None
                 assert k_nope is not None
                 assert knope_scale is not None
-                packed_kv = torch.cat([k_nope, k_pe, knope_scale], dim=-1)
+                packed_kv = torch.cat(
+                    [
+                        k_nope.view(-1, k_nope.shape[-1]),
+                        k_pe.view(-1, k_pe.shape[-1]),
+                        knope_scale.view(-1, knope_scale.shape[-1]),
+                    ],
+                    dim=-1,
+                )
                 packed_head_dim = self.sfa_qsfa_packed_kv_head_dim
                 assert packed_kv.shape[-1] == packed_head_dim
                 torch_npu.npu_scatter_nd_update_(
@@ -1781,12 +1880,8 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         if kv_cache is not None and self.has_indexer:
             assert k_li is not None
-            if self.use_sparse_c8_sfa:
-                dsa_k_cache_idx = 1
-                dsa_k_scale_cache_idx = 2
-            else:
-                dsa_k_cache_idx = 2
-                dsa_k_scale_cache_idx = 3
+            dsa_k_cache_idx = self.kv_cache_indexer_k_idx
+            dsa_k_scale_cache_idx = self.kv_cache_indexer_scale_idx
 
             if get_ascend_config().c8_enable_reshape_optim:
                 torch.ops._C_ascend.store_kv_block(
@@ -1903,7 +1998,7 @@ def custom_kv_rmsnorm_rope(
         row_block_size=1,
         col_block_size=tile_size,
     )
-    if dst_type == 1 or dst_type == torch.int8:
+    if dst_type == torch.int8:
         # Return byte views so the caller can concatenate all three components.
         return (
             k_rope.contiguous().view(torch.int8),

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -426,128 +426,6 @@ class BaseDeviceAdaptor:
         return hidden_states, ql_nope, q_pe, q_c
 
     @staticmethod
-    def execute_sfa_mla_prolog_v3(
-        sfa_impl,
-        *,
-        hidden_states: torch.Tensor,
-        rope_sin: torch.Tensor,
-        rope_cos: torch.Tensor,
-        kv_cache: tuple[torch.Tensor, ...],
-        slot_mapping: torch.Tensor,
-        cache_mode: str,
-    ) -> tuple:
-        assert sfa_impl.q_a_layernorm is not None
-        assert sfa_impl.kv_a_layernorm is not None
-
-        token_x, dynamic_scale = torch_npu.npu_dynamic_quant(hidden_states.contiguous())
-        dynamic_scale = dynamic_scale.view(-1, 1)
-        rope_cos = rope_cos.view(rope_cos.shape[0], rope_cos.shape[-1])
-        rope_sin = rope_sin.view(rope_sin.shape[0], rope_sin.shape[-1])
-
-        packed_kv_cache = getattr(sfa_impl, "use_sparse_c8_sfa", False)
-        if packed_kv_cache:
-            assert sfa_impl.sfa_qsfa_kr_cache_dummy is not None
-            kr_cache = sfa_impl.sfa_qsfa_kr_cache_dummy
-        else:
-            kr_cache = kv_cache[1]
-
-        cache_index = slot_mapping.view(-1).to(torch.int64) if cache_mode == "PA_BSND" else None
-        extra_kwargs = {}
-        if packed_kv_cache:
-            extra_kwargs.update(
-                {
-                    "ckvkr_repo_mode": 1,
-                    "quant_scale_repo_mode": 1,
-                    "tile_size": sfa_impl.sfa_qsfa_tile_size,
-                    "k_nope_clip_alpha": sfa_impl.sfa_qsfa_k_nope_clip_alpha,
-                }
-            )
-        return BaseDeviceAdaptor._execute_sfa_mla_prolog_v3_op(
-            sfa_impl,
-            token_x=token_x,
-            rope_sin=rope_sin,
-            rope_cos=rope_cos,
-            kv_cache=kv_cache[0],
-            kr_cache=kr_cache,
-            cache_mode=cache_mode,
-            cache_index=cache_index,
-            dequant_scale_x=dynamic_scale,
-            dequant_scale_w_dq=sfa_impl.dequant_scale_w_dq,
-            dequant_scale_w_uq_qr=sfa_impl.dequant_scale_w_uq_qr,
-            dequant_scale_w_dkv_kr=sfa_impl.dequant_scale_w_dkv_kr,
-            query_quant_mode=0,
-            weight_quant_mode=2,
-            kv_cache_quant_mode=3 if packed_kv_cache else 0,
-            query_norm_flag=sfa_impl.has_indexer,
-            rmsnorm_epsilon_cq=sfa_impl.q_a_layernorm.variance_epsilon,
-            rmsnorm_epsilon_ckv=sfa_impl.kv_a_layernorm.variance_epsilon,
-            qc_qr_scale=1.0,
-            kc_scale=1.0,
-            **extra_kwargs,
-        )
-
-    @staticmethod
-    def _execute_sfa_mla_prolog_v3_op(
-        sfa_impl,
-        *,
-        token_x: torch.Tensor,
-        rope_sin: torch.Tensor,
-        rope_cos: torch.Tensor,
-        kv_cache: torch.Tensor,
-        kr_cache: torch.Tensor,
-        cache_mode: str,
-        cache_index: torch.Tensor | None = None,
-        dequant_scale_x: torch.Tensor | None = None,
-        dequant_scale_w_dq: torch.Tensor | None = None,
-        dequant_scale_w_uq_qr: torch.Tensor | None = None,
-        dequant_scale_w_dkv_kr: torch.Tensor | None = None,
-        query_quant_mode: int = 0,
-        weight_quant_mode: int = 2,
-        kv_cache_quant_mode: int = 0,
-        query_norm_flag: bool | None = None,
-        rmsnorm_epsilon_cq: float | None = None,
-        rmsnorm_epsilon_ckv: float | None = None,
-        qc_qr_scale: float | None = None,
-        kc_scale: float | None = None,
-        **extra_kwargs,
-    ) -> tuple:
-        assert sfa_impl.q_a_layernorm is not None
-        assert sfa_impl.kv_a_layernorm is not None
-
-        prolog_kwargs = {
-            "token_x": token_x,
-            "weight_dq": sfa_impl.weight_dq,
-            "weight_uq_qr": sfa_impl.weight_uq_qr,
-            "weight_uk": sfa_impl.W_UK_T,
-            "weight_dkv_kr": sfa_impl.weight_dkv_kr,
-            "rmsnorm_gamma_cq": sfa_impl.q_a_layernorm.weight.data,
-            "rmsnorm_gamma_ckv": sfa_impl.kv_a_layernorm.weight.data,
-            "rope_sin": rope_sin,
-            "rope_cos": rope_cos,
-            "kv_cache": kv_cache,
-            "kr_cache": kr_cache,
-            "cache_mode": cache_mode,
-            "query_quant_mode": query_quant_mode,
-            "weight_quant_mode": weight_quant_mode,
-            "kv_cache_quant_mode": kv_cache_quant_mode,
-        }
-        optional_kwargs = {
-            "cache_index": cache_index,
-            "dequant_scale_x": dequant_scale_x,
-            "dequant_scale_w_dq": dequant_scale_w_dq,
-            "dequant_scale_w_uq_qr": dequant_scale_w_uq_qr,
-            "dequant_scale_w_dkv_kr": dequant_scale_w_dkv_kr,
-            "query_norm_flag": query_norm_flag,
-            "rmsnorm_epsilon_cq": rmsnorm_epsilon_cq,
-            "rmsnorm_epsilon_ckv": rmsnorm_epsilon_ckv,
-            "qc_qr_scale": qc_qr_scale,
-            "kc_scale": kc_scale,
-        }
-        prolog_kwargs.update({key: value for key, value in optional_kwargs.items() if value is not None})
-        prolog_kwargs.update({key: value for key, value in extra_kwargs.items() if value is not None})
-        return torch_npu.npu_mla_prolog_v3(**prolog_kwargs)
-
-    @staticmethod
     def indexer_select_post_process(
         sfa_impl,
         q_li: torch.Tensor,
@@ -564,12 +442,11 @@ class BaseDeviceAdaptor:
         # DSV3.2 currently has graph compilation issues when using torch_npu.npu.lightning_indexer.
         # So two branches are maintained temporarily.
         # TODO: torch.ops._C_ascend.npu_lightning_indexer needs to be removed.
-        packed_kv_cache = getattr(sfa_impl, "use_sparse_c8_sfa", False)
-        indexer_cache_idx = 1 if packed_kv_cache else 2
-        indexer_scale_cache_idx = 2 if packed_kv_cache else 3
+        indexer_cache_idx = sfa_impl.kv_cache_indexer_k_idx
+        indexer_scale_cache_idx = sfa_impl.kv_cache_indexer_scale_idx
 
         if use_sparse_c8_indexer:
-            assert len(kv_cache) == (3 if packed_kv_cache else 4)
+            assert len(kv_cache) == (3 if sfa_impl.use_sparse_c8_sfa else 4)
             assert q_li_scale is not None
             assert q_li_shape_ori is not None
             weights = weights.to(torch.float16)
@@ -1649,91 +1526,6 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         return [8, 16, 128]
 
     @staticmethod
-    def sfa_preprocess_with_mlapo(
-        sfa_impl,
-        hidden_states: torch.Tensor,
-        kv_cache: tuple,
-        cos: torch.Tensor,
-        sin: torch.Tensor,
-        slot_mapping: torch.Tensor,
-        num_input_tokens: int,
-    ) -> tuple:
-        bsz = num_input_tokens
-        slot_mapping = slot_mapping[:bsz]
-        hidden_states_temp = hidden_states[:bsz].unsqueeze(1)
-        cos = cos[:bsz, ...]
-        sin = sin[:bsz, ...]
-
-        is_quantized = getattr(sfa_impl, "mlapo_is_quantized", True)
-
-        cos_shape = cos.shape
-        cos = cos.view(cos_shape[0], 1, cos_shape[-1])
-        sin = sin.view(cos_shape[0], 1, cos_shape[-1])
-
-        decode_k_nope = kv_cache[0]
-        use_c8 = getattr(sfa_impl, "use_sparse_c8_sfa", False)
-        kr_cache = (
-            torch.zeros(0, 0, decode_k_nope.shape[-2], cos_shape[-1], dtype=torch.bfloat16, device=decode_k_nope.device)
-            if use_c8
-            else kv_cache[1]
-        )
-
-        if is_quantized:
-            hidden_states_temp, dynamic_scale = torch_npu.npu_dynamic_mx_quant(
-                hidden_states_temp, dst_type=torch.float8_e4m3fn
-            )
-            dynamic_scale = dynamic_scale.reshape(hidden_states_temp.shape[0] * hidden_states_temp.shape[1], -1)
-
-            decode_q_nope, q_pe, _, q_c, q_c_scale = BaseDeviceAdaptor._execute_sfa_mla_prolog_v3_op(
-                sfa_impl,
-                token_x=hidden_states_temp,
-                rope_sin=sin,
-                rope_cos=cos,
-                kv_cache=decode_k_nope,
-                kr_cache=kr_cache,
-                cache_index=slot_mapping[:bsz].view(bsz, -1).to(torch.int64),
-                dequant_scale_x=dynamic_scale.view(torch.float8_e8m0fnu),
-                dequant_scale_w_dq=sfa_impl.weight_dq_scale.view(torch.float8_e8m0fnu),
-                dequant_scale_w_uq_qr=sfa_impl.weight_uq_qr_scale.view(torch.float8_e8m0fnu),
-                dequant_scale_w_dkv_kr=sfa_impl.weight_dkv_kr_scale.view(torch.float8_e8m0fnu),
-                query_quant_mode=0,
-                weight_quant_mode=3,
-                kv_cache_quant_mode=3 if use_c8 else 0,
-                cache_mode="PA_BSND",
-                ckvkr_repo_mode=1 if use_c8 else 0,
-                quant_scale_repo_mode=1 if use_c8 else 0,
-                query_norm_flag=True,
-            )
-
-            decode_q_nope = decode_q_nope.view(bsz, sfa_impl.num_heads, sfa_impl.kv_lora_rank)
-            q_pe = q_pe.view(bsz, sfa_impl.num_heads, -1)
-            q_c = q_c.view(-1, q_c.shape[-1])
-            q_c_scale = q_c_scale.view(-1, q_c_scale.shape[-1])
-            return hidden_states, decode_q_nope, q_pe, (q_c, q_c_scale)
-        else:
-            decode_q_nope, q_pe, _, q_c, _ = BaseDeviceAdaptor._execute_sfa_mla_prolog_v3_op(
-                sfa_impl,
-                token_x=hidden_states_temp,
-                rope_sin=sin,
-                rope_cos=cos,
-                kv_cache=decode_k_nope,
-                kr_cache=kr_cache,
-                cache_index=slot_mapping[:bsz].view(bsz, -1).to(torch.int64),
-                query_quant_mode=0,
-                weight_quant_mode=0,
-                kv_cache_quant_mode=0,
-                cache_mode="PA_BSND",
-                ckvkr_repo_mode=0,
-                quant_scale_repo_mode=0,
-                query_norm_flag=True,
-            )
-
-            decode_q_nope = decode_q_nope.view(bsz, sfa_impl.num_heads, sfa_impl.kv_lora_rank)
-            q_pe = q_pe.view(bsz, sfa_impl.num_heads, -1)
-            q_c = q_c.view(-1, q_c.shape[-1])
-            return hidden_states, decode_q_nope, q_pe, q_c
-
-    @staticmethod
     def indexer_select_post_process(
         sfa_impl,
         q_li: torch.Tensor,
@@ -1747,12 +1539,11 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         use_sparse_c8_indexer: bool,
         use_torch_npu_lightning_indexer: bool,
     ) -> torch.Tensor:
-        packed_kv_cache = getattr(sfa_impl, "use_sparse_c8_sfa", False)
-        indexer_cache_idx = 1 if packed_kv_cache else 2
-        indexer_scale_cache_idx = 2 if packed_kv_cache else 3
+        indexer_cache_idx = sfa_impl.kv_cache_indexer_k_idx
+        indexer_scale_cache_idx = sfa_impl.kv_cache_indexer_scale_idx
 
         if use_sparse_c8_indexer:
-            assert len(kv_cache) == (3 if packed_kv_cache else 4)
+            assert len(kv_cache) == (3 if sfa_impl.use_sparse_c8_sfa else 4)
             assert q_li_shape_ori is not None
 
             if q_li_scale is not None:


### PR DESCRIPTION
### What this PR does / why we need it?
  Refactors the MLAPO / PROLOG_V3 preprocessing path resolution in SFA attention by replacing the boolean flags enable_sfa_prolog_v3 and enable_mlapo with a
  unified PreprocessType enum. This simplifies the logic, eliminates duplication between A3 and A5 code paths, and inlines kernel calls from device_op.py
  into sfa_v1.py.

  Key changes:
  - Introduces PreprocessType enum (NATIVE / PROLOG_V3 / MLAPO) and _resolve_preprocess_type to choose the active type in a single place with shared
  validation via _get_fused_type_unsupported_reasons
  - Inlines npu_mla_prolog_v3 and mla_preprocess kernel calls into _sfa_preprocess_prolog_v3 and _sfa_preprocess_mlapo, removing execute_sfa_mla_prolog_v3,
  _execute_sfa_mla_prolog_v3_op, and A5-specific sfa_preprocess_with_mlapo from device_op.py
  - Adds defensive assertions for quantization type validation and layernorm presence in _sfa_preprocess_prolog_v3
  - Removes trailing None, None return values from _sfa_preprocess_prolog_v3 and _sfa_preprocess_mlapo that were dead return values from the old code
  - Centralizes indexer cache slot computation via kv_cache_indexer_k_idx and kv_cache_indexer_scale_idx properties
### Does this PR introduce any user-facing change?
  No. This is an internal refactor with no API, configuration, or behavioral changes.
### How was this patch tested?
- Unit tests: pytest -sv tests/ut/attention/a2/test_sfa_v1.py


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
