### PR TITLE
[Doc][Misc] Fix MkDocs block quote syntax in installation guide

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -67,7 +67,7 @@ Refer to [Ascend Environment Setup Guide](https://ascend.github.io/docs/sources/
         -it $IMAGE bash
     ```
 
-    ??? 'Click here to see "Install CANN manually"'
+    ??? "Click here to see 'Install CANN manually'"
 
         You can also install CANN manually:
 
@@ -173,7 +173,7 @@ Then you can install `vllm` and `vllm-ascend` from a **pre-built wheel** using o
 
             uv cache clean
 
-??? 'Click here to see "Build from source code"'
+??? "Click here to see 'Build from source code'"
 
     or build from **source code**:
 
@@ -235,7 +235,7 @@ Supported images as following.
 | vllm-ascend:{{ vllm_ascend_version }}-310p | Atlas 300I | Ubuntu |
 | vllm-ascend:{{ vllm_ascend_version }}-310p-openeuler | Atlas 300I | openEuler |
 
-??? 'Click here to see "Build from Dockerfile"'
+??? "Click here to see 'Build from Dockerfile'"
 
     or build IMAGE from **source code**:
 


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #11532

This PR fixes the quoting style in `docs/source/installation.md` for collapsible blocks (`???`). It changes outer single quotes with inner double quotes to outer double quotes with inner single quotes, ensuring correct rendering in MkDocs.

<img width="1421" height="598" alt="image" src="https://github.com/user-attachments/assets/39b97d51-80ce-4416-9e80-42e432a4216b" />

<img width="1403" height="640" alt="image" src="https://github.com/user-attachments/assets/0bc673ca-d05b-42a8-9f30-3b23b253d3ae" />

<img width="1405" height="358" alt="image" src="https://github.com/user-attachments/assets/3180c7f9-d99e-4dc5-ada9-5ceb87a17f7e" />


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
