### PR TITLE
[Feature] Support Gemma4 graph execution on A2/A3

### DIFF
--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -10,6 +10,7 @@ from vllm_ascend.attention.attention_v1 import (
     AscendAttentionBackendImpl,
     AscendAttentionMetadataBuilder,
     AscendAttentionState,
+    PagedAttentionGraphParam,
 )
 from vllm_ascend.attention.kvcomp_attn.attention_utils import get_kvcomp_decode_params, reshape_and_cache_kvcomp
 from vllm_ascend.attention.utils import (
@@ -772,3 +773,67 @@ class TestAscendAttentionBackendImpl(TestBase):
         ]
         self.assertEqual(attn_module._ATTN_KEYS_BUFFER, expected)
         self.assertEqual(mock_fia.out.call_count, 3)
+
+    @patch("torch.npu.stream")
+    @patch("torch.npu.graph_task_update_begin")
+    @patch("torch.npu.graph_task_update_end")
+    @patch("torch_npu._npu_paged_attention")
+    @patch("torch_npu._npu_paged_attention_get_workspace", return_value=MagicMock())
+    @patch("vllm_ascend.attention.attention_v1.get_graph_params")
+    @patch("vllm_ascend.attention.attention_v1._EXTRA_CTX")
+    @patch("vllm_ascend.attention.attention_v1.using_paged_attention", return_value=False)
+    @patch("vllm_ascend.attention.attention_v1.needs_layer_aware_fia_graph_replay", return_value=False)
+    @patch("vllm_ascend.attention.attention_v1._ATTN_KEYS_BUFFER", new=[])
+    def test_update_graph_params_handles_captured_paged_attention_params(
+        self,
+        mock_needs_layer_aware_fia_graph_replay,
+        mock_using_paged_attention,
+        mock_EXTRA_CTX,
+        mock_get_graph_params,
+        mock_get_workspace,
+        mock_paged_attention,
+        mock_graph_task_update_end,
+        mock_graph_task_update_begin,
+        mock_stream,
+    ):
+        mock_EXTRA_CTX.sinks = False
+        mock_EXTRA_CTX.is_draft_model = False
+
+        query = MagicMock()
+        key_cache = MagicMock()
+        value_cache = MagicMock()
+        block_table = MagicMock()
+        output = MagicMock()
+        captured_seq_lens = MagicMock()
+        current_seq_lens = MagicMock()
+        pa_param = PagedAttentionGraphParam(
+            (
+                query,
+                key_cache,
+                value_cache,
+                8,
+                8,
+                1.0,
+                block_table,
+                captured_seq_lens,
+                output,
+            ),
+            "model.layers.0.self_attn.attn",
+        )
+
+        mock_get_graph_params.return_value.attn_params = {1: [pa_param]}
+        mock_get_graph_params.return_value.handles = {1: [MagicMock()]}
+        mock_get_graph_params.return_value.events = {1: [MagicMock()]}
+
+        forward_context = MagicMock()
+        forward_context.attn_metadata = {
+            "model.layers.0.self_attn.attn": MagicMock(seq_lens=current_seq_lens),
+        }
+
+        self.impl.update_graph_params(self.mock_stream, forward_context, 1, self.mock_vllm_config)
+
+        mock_get_workspace.assert_called_once()
+        mock_paged_attention.assert_called_once()
+        self.assertEqual(mock_paged_attention.call_args.kwargs["context_lens"], current_seq_lens)
+        mock_graph_task_update_begin.assert_called_once()
+        mock_graph_task_update_end.assert_called_once()

--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -51,6 +51,64 @@ class TestAttentionGraphHelpers(TestBase):
         with patch("vllm_ascend.attention.utils.get_ascend_device_type", return_value=AscendDeviceType.A2):
             self.assertTrue(using_paged_attention(1, vllm_config, head_size=FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE))
 
+    @patch("vllm_ascend.attention.attention_v1.update_paged_attention_graph_param")
+    @patch("vllm_ascend.attention.attention_v1.needs_layer_aware_fia_graph_replay", return_value=True)
+    @patch("vllm_ascend.attention.attention_v1.using_paged_attention", return_value=False)
+    @patch("vllm_ascend.attention.attention_v1.get_graph_params")
+    def test_fia_graph_update_dispatches_paged_attention_param(
+        self,
+        mock_get_graph_params,
+        _mock_using_paged_attention,
+        _mock_needs_layer_aware_replay,
+        mock_update_pa_param,
+    ):
+        layer_name = "model.layers.0.self_attn.attn"
+        block_table = torch.zeros(1, 1, dtype=torch.int32)
+        seq_lens = torch.tensor([1], dtype=torch.int32)
+        param = PagedAttentionGraphParam(params=(), layer_name=layer_name)
+        handle = MagicMock()
+        event = MagicMock()
+        graph_params = SimpleNamespace(
+            attn_params={1: [param]},
+            handles={1: [handle]},
+            events={1: [event]},
+            workspaces={},
+        )
+        mock_get_graph_params.return_value = graph_params
+        forward_context = SimpleNamespace(
+            attn_metadata={
+                layer_name: SimpleNamespace(
+                    block_tables=block_table,
+                    seq_lens=seq_lens,
+                )
+            }
+        )
+        stream_context = MagicMock()
+        stream_context.__enter__.return_value = None
+        stream_context.__exit__.return_value = None
+        update_stream = MagicMock()
+
+        with (
+            patch("vllm_ascend.attention.attention_v1.torch.npu.stream", return_value=stream_context, create=True),
+            patch.object(attn_module._EXTRA_CTX, "is_draft_model", False, create=True),
+            patch.object(attn_module._EXTRA_CTX, "sinks", False, create=True),
+        ):
+            AscendAttentionBackendImpl.update_graph_params(
+                update_stream=update_stream,
+                forward_context=forward_context,
+                num_tokens=1,
+                vllm_config=MagicMock(),
+            )
+
+        mock_update_pa_param.assert_called_once_with(
+            update_stream,
+            handle,
+            event,
+            param,
+            block_table,
+            seq_lens,
+        )
+
 
 class TestAscendAttentionBackend(TestBase):
     def setUp(self):

--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -10,11 +10,11 @@ from vllm_ascend.attention.attention_v1 import (
     AscendAttentionBackendImpl,
     AscendAttentionMetadataBuilder,
     AscendAttentionState,
-    PagedAttentionGraphParam,
 )
 from vllm_ascend.attention.kvcomp_attn.attention_utils import get_kvcomp_decode_params, reshape_and_cache_kvcomp
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
+    PagedAttentionGraphParam,
     cache_graph_workspace,
     needs_layer_aware_fia_graph_replay,
     using_paged_attention,

--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -51,64 +51,6 @@ class TestAttentionGraphHelpers(TestBase):
         with patch("vllm_ascend.attention.utils.get_ascend_device_type", return_value=AscendDeviceType.A2):
             self.assertTrue(using_paged_attention(1, vllm_config, head_size=FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE))
 
-    @patch("vllm_ascend.attention.attention_v1.update_paged_attention_graph_param")
-    @patch("vllm_ascend.attention.attention_v1.needs_layer_aware_fia_graph_replay", return_value=True)
-    @patch("vllm_ascend.attention.attention_v1.using_paged_attention", return_value=False)
-    @patch("vllm_ascend.attention.attention_v1.get_graph_params")
-    def test_fia_graph_update_dispatches_paged_attention_param(
-        self,
-        mock_get_graph_params,
-        _mock_using_paged_attention,
-        _mock_needs_layer_aware_replay,
-        mock_update_pa_param,
-    ):
-        layer_name = "model.layers.0.self_attn.attn"
-        block_table = torch.zeros(1, 1, dtype=torch.int32)
-        seq_lens = torch.tensor([1], dtype=torch.int32)
-        param = PagedAttentionGraphParam(params=(), layer_name=layer_name)
-        handle = MagicMock()
-        event = MagicMock()
-        graph_params = SimpleNamespace(
-            attn_params={1: [param]},
-            handles={1: [handle]},
-            events={1: [event]},
-            workspaces={},
-        )
-        mock_get_graph_params.return_value = graph_params
-        forward_context = SimpleNamespace(
-            attn_metadata={
-                layer_name: SimpleNamespace(
-                    block_tables=block_table,
-                    seq_lens=seq_lens,
-                )
-            }
-        )
-        stream_context = MagicMock()
-        stream_context.__enter__.return_value = None
-        stream_context.__exit__.return_value = None
-        update_stream = MagicMock()
-
-        with (
-            patch("vllm_ascend.attention.attention_v1.torch.npu.stream", return_value=stream_context, create=True),
-            patch.object(attn_module._EXTRA_CTX, "is_draft_model", False, create=True),
-            patch.object(attn_module._EXTRA_CTX, "sinks", False, create=True),
-        ):
-            AscendAttentionBackendImpl.update_graph_params(
-                update_stream=update_stream,
-                forward_context=forward_context,
-                num_tokens=1,
-                vllm_config=MagicMock(),
-            )
-
-        mock_update_pa_param.assert_called_once_with(
-            update_stream,
-            handle,
-            event,
-            param,
-            block_table,
-            seq_lens,
-        )
-
 
 class TestAscendAttentionBackend(TestBase):
     def setUp(self):

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -49,10 +49,12 @@ from vllm_ascend.attention.kvcomp_attn.attention_utils import (
 )
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
+    PagedAttentionGraphParam,
     cache_graph_workspace,
     enable_cp,
     needs_layer_aware_fia_graph_replay,
     split_decodes_and_prefills,
+    update_paged_attention_graph_param,
     using_paged_attention,
 )
 from vllm_ascend.compilation.acl_graph import (
@@ -70,14 +72,6 @@ from vllm_ascend.worker.kvcomp_utils import KVCompMetaData
 # default max value of sliding window size
 SWA_INT_MAX = 2147483647
 _ATTN_KEYS_BUFFER = None
-
-
-@dataclass
-class PagedAttentionGraphParam:
-    """Mark PA params when PA and FIA share one graph replay list."""
-
-    params: tuple
-    layer_name: str | None
 
 
 @register_backend(AttentionBackendEnum.CUSTOM, "ASCEND")
@@ -576,17 +570,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     events,
                 ):
                     if isinstance(param, PagedAttentionGraphParam):
-                        (
-                            query,
-                            key_cache,
-                            value_cache,
-                            num_kv_heads,
-                            num_heads,
-                            scale,
-                            block_table,
-                            seq_lens,
-                            output,
-                        ) = param.params
                         if _EXTRA_CTX.is_draft_model:
                             draft_step, key = draft_attn_key_steps[attn_count]
                             block_table = attn_metadata[draft_step][key].block_tables
@@ -597,32 +580,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                             metadata_key = layer_name if layer_name is not None and layer_name in attn_metadata else key
                             block_table = attn_metadata[metadata_key].block_tables
                             seq_lens = attn_metadata[metadata_key].seq_lens
-                        workspace = torch_npu._npu_paged_attention_get_workspace(
-                            query=query,
-                            key_cache=key_cache,
-                            value_cache=value_cache,
-                            num_kv_heads=num_kv_heads,
-                            num_heads=num_heads,
-                            scale_value=scale,
-                            block_table=block_table,
-                            context_lens=seq_lens,
-                            out=output,
-                        )
-                        torch.npu.graph_task_update_begin(update_stream, handle)
-                        torch_npu._npu_paged_attention(
-                            query=query,
-                            key_cache=key_cache,
-                            value_cache=value_cache,
-                            num_kv_heads=num_kv_heads,
-                            num_heads=num_heads,
-                            scale_value=scale,
-                            block_table=block_table,
-                            context_lens=seq_lens,
-                            out=output,
-                            workspace=workspace,
-                        )
-                        torch.npu.graph_task_update_end(update_stream)
-                        event.record(update_stream)
+                        update_paged_attention_graph_param(update_stream, handle, event, param, block_table, seq_lens)
                         continue
                     (
                         query,

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -477,8 +477,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     graph_params.handles[num_tokens],
                     graph_params.events[num_tokens],
                 ):
-                    if isinstance(param, PagedAttentionGraphParam):
-                        param = param.params
                     (
                         query,
                         key_cache,
@@ -569,26 +567,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     handles,
                     events,
                 ):
-                    if isinstance(param, PagedAttentionGraphParam):
-                        if _EXTRA_CTX.is_draft_model:
-                            draft_step, key = draft_attn_key_steps[attn_count]
-                            block_table = attn_metadata[draft_step][key].block_tables
-                            seq_lens = attn_metadata[draft_step][key].seq_lens
-                            attn_count = attn_count + 1
-                        else:
-                            layer_name = param.layer_name
-                            metadata_key = layer_name if layer_name is not None and layer_name in attn_metadata else key
-                            block_table = attn_metadata[metadata_key].block_tables
-                            seq_lens = attn_metadata[metadata_key].seq_lens
-                        update_paged_attention_graph_param(
-                            update_stream,
-                            handle,
-                            event,
-                            param,
-                            block_table,
-                            seq_lens,
-                        )
-                        continue
                     (
                         query,
                         key_cache,

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -72,6 +72,14 @@ SWA_INT_MAX = 2147483647
 _ATTN_KEYS_BUFFER = None
 
 
+@dataclass
+class PagedAttentionGraphParam:
+    """Mark PA params when PA and FIA share one graph replay list."""
+
+    params: tuple
+    layer_name: str | None
+
+
 @register_backend(AttentionBackendEnum.CUSTOM, "ASCEND")
 class AscendAttentionBackend(AttentionBackend):
     accept_output_buffer: bool = True
@@ -475,6 +483,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     graph_params.handles[num_tokens],
                     graph_params.events[num_tokens],
                 ):
+                    if isinstance(param, PagedAttentionGraphParam):
+                        param = param.params
                     (
                         query,
                         key_cache,
@@ -565,6 +575,55 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     handles,
                     events,
                 ):
+                    if isinstance(param, PagedAttentionGraphParam):
+                        (
+                            query,
+                            key_cache,
+                            value_cache,
+                            num_kv_heads,
+                            num_heads,
+                            scale,
+                            block_table,
+                            seq_lens,
+                            output,
+                        ) = param.params
+                        if _EXTRA_CTX.is_draft_model:
+                            draft_step, key = draft_attn_key_steps[attn_count]
+                            block_table = attn_metadata[draft_step][key].block_tables
+                            seq_lens = attn_metadata[draft_step][key].seq_lens
+                            attn_count = attn_count + 1
+                        else:
+                            layer_name = param.layer_name
+                            metadata_key = layer_name if layer_name is not None and layer_name in attn_metadata else key
+                            block_table = attn_metadata[metadata_key].block_tables
+                            seq_lens = attn_metadata[metadata_key].seq_lens
+                        workspace = torch_npu._npu_paged_attention_get_workspace(
+                            query=query,
+                            key_cache=key_cache,
+                            value_cache=value_cache,
+                            num_kv_heads=num_kv_heads,
+                            num_heads=num_heads,
+                            scale_value=scale,
+                            block_table=block_table,
+                            context_lens=seq_lens,
+                            out=output,
+                        )
+                        torch.npu.graph_task_update_begin(update_stream, handle)
+                        torch_npu._npu_paged_attention(
+                            query=query,
+                            key_cache=key_cache,
+                            value_cache=value_cache,
+                            num_kv_heads=num_kv_heads,
+                            num_heads=num_heads,
+                            scale_value=scale,
+                            block_table=block_table,
+                            context_lens=seq_lens,
+                            out=output,
+                            workspace=workspace,
+                        )
+                        torch.npu.graph_task_update_end(update_stream)
+                        event.record(update_stream)
+                        continue
                     (
                         query,
                         key_cache,
@@ -1137,16 +1196,19 @@ class AscendAttentionBackendImpl(AttentionImpl):
             event.reset(stream)
             graph_params.events[num_tokens].append(event)
             graph_params.attn_params[num_tokens].append(
-                (
-                    weak_ref_tensors(query),
-                    weak_ref_tensors(self.key_cache),
-                    weak_ref_tensors(self.value_cache),
-                    self.num_kv_heads,
-                    self.num_heads,
-                    self.scale,
-                    attn_metadata.block_tables,
-                    attn_metadata.seq_lens,
-                    weak_ref_tensors(output),
+                PagedAttentionGraphParam(
+                    (
+                        weak_ref_tensors(query),
+                        weak_ref_tensors(self.key_cache),
+                        weak_ref_tensors(self.value_cache),
+                        self.num_kv_heads,
+                        self.num_heads,
+                        self.scale,
+                        attn_metadata.block_tables,
+                        attn_metadata.seq_lens,
+                        weak_ref_tensors(output),
+                    ),
+                    self._graph_metadata_layer_name() if self._use_layer_aware_fia_graph_replay else None,
                 )
             )
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -580,7 +580,14 @@ class AscendAttentionBackendImpl(AttentionImpl):
                             metadata_key = layer_name if layer_name is not None and layer_name in attn_metadata else key
                             block_table = attn_metadata[metadata_key].block_tables
                             seq_lens = attn_metadata[metadata_key].seq_lens
-                        update_paged_attention_graph_param(update_stream, handle, event, param, block_table, seq_lens)
+                        update_paged_attention_graph_param(
+                            update_stream,
+                            handle,
+                            event,
+                            param,
+                            block_table,
+                            seq_lens,
+                        )
                         continue
                     (
                         query,
@@ -727,6 +734,26 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     handles,
                     events,
                 ):
+                    if isinstance(param, PagedAttentionGraphParam):
+                        if _EXTRA_CTX.is_draft_model:
+                            draft_step, key = draft_attn_key_steps[attn_count]
+                            block_table = attn_metadata[draft_step][key].block_tables
+                            seq_lens = attn_metadata[draft_step][key].seq_lens
+                            attn_count = attn_count + 1
+                        else:
+                            layer_name = param.layer_name
+                            metadata_key = layer_name if layer_name is not None and layer_name in attn_metadata else key
+                            block_table = attn_metadata[metadata_key].block_tables
+                            seq_lens = attn_metadata[metadata_key].seq_lens
+                        update_paged_attention_graph_param(
+                            update_stream,
+                            handle,
+                            event,
+                            param,
+                            block_table,
+                            seq_lens,
+                        )
+                        continue
                     (
                         query,
                         key_cache,

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -27,6 +27,9 @@ class PagedAttentionGraphParam:
     params: tuple
     layer_name: str | None
 
+    def __iter__(self):
+        return iter(self.params)
+
 
 def update_paged_attention_graph_param(
     update_stream,

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import torch
 import torch.nn.functional as F
+import torch_npu
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group, is_v1_kv_transfer_group
 from vllm.forward_context import ForwardContext, get_forward_context
@@ -17,6 +18,61 @@ from vllm_ascend.utils import (
     is_pd_decode_recompute_scheduler_enabled,
 )
 from vllm_ascend.worker.kvcomp_utils import KVCompMetaData
+
+
+@dataclass
+class PagedAttentionGraphParam:
+    """Mark PA params when PA and FIA share one graph replay list."""
+
+    params: tuple
+    layer_name: str | None
+
+
+def update_paged_attention_graph_param(
+    update_stream,
+    handle,
+    event,
+    param: PagedAttentionGraphParam,
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+) -> None:
+    (
+        query,
+        key_cache,
+        value_cache,
+        num_kv_heads,
+        num_heads,
+        scale,
+        _captured_block_table,
+        _captured_seq_lens,
+        output,
+    ) = param.params
+    workspace = torch_npu._npu_paged_attention_get_workspace(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        num_kv_heads=num_kv_heads,
+        num_heads=num_heads,
+        scale_value=scale,
+        block_table=block_table,
+        context_lens=seq_lens,
+        out=output,
+    )
+    torch.npu.graph_task_update_begin(update_stream, handle)
+    torch_npu._npu_paged_attention(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        num_kv_heads=num_kv_heads,
+        num_heads=num_heads,
+        scale_value=scale,
+        block_table=block_table,
+        context_lens=seq_lens,
+        out=output,
+        workspace=workspace,
+    )
+    torch.npu.graph_task_update_end(update_stream)
+    event.record(update_stream)
 
 
 def cache_graph_workspace(

--- a/vllm_ascend/ops/triton/rope.py
+++ b/vllm_ascend/ops/triton/rope.py
@@ -275,6 +275,12 @@ def rope_forward_triton(
         BLOCK_SIZE_HEAD = 64
     else:
         BLOCK_SIZE_HEAD = 32
+    # LOCAL WORKAROUND (not for commit): gemma4 large head_dim (256 sliding /
+    # 512 full-attention) overflows the A2 (Ascend910B3) unified buffer at the
+    # default head tile ("ub overflow, requires 1581056 bits while 1572864
+    # bits available"). Shrink the head tile for large head_dim.
+    if head_dim > 128:
+        BLOCK_SIZE_HEAD = min(BLOCK_SIZE_HEAD, 16)
     num_vectorcore = get_vectorcore_num()
     n_row = min(num_tokens, num_vectorcore)
 

--- a/vllm_ascend/ops/triton/rope.py
+++ b/vllm_ascend/ops/triton/rope.py
@@ -275,12 +275,11 @@ def rope_forward_triton(
         BLOCK_SIZE_HEAD = 64
     else:
         BLOCK_SIZE_HEAD = 32
-    # LOCAL WORKAROUND (not for commit): gemma4 large head_dim (256 sliding /
-    # 512 full-attention) overflows the A2 (Ascend910B3) unified buffer at the
-    # default head tile ("ub overflow, requires 1581056 bits while 1572864
-    # bits available"). Shrink the head tile for large head_dim.
-    if head_dim > 128:
-        BLOCK_SIZE_HEAD = min(BLOCK_SIZE_HEAD, 16)
+    # Large head_dim RoPE can overflow UB with the default tile on A2/A3.
+    # Keep the original tile for common head_dim models.
+    large_head_dim_threshold, large_head_block_size = 256, 16
+    if head_dim >= large_head_dim_threshold:
+        BLOCK_SIZE_HEAD = min(BLOCK_SIZE_HEAD, large_head_block_size)
     num_vectorcore = get_vectorcore_num()
     n_row = min(num_tokens, num_vectorcore)
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR enables Gemma4 graph execution on Ascend A2/A3 by addressing two graph-mode issues:

- Handles mixed PagedAttention and FusedInferAttention graph replay params in the same decode graph. Gemma4 has mixed attention layer shapes, and A2/A3 route the 512-dim global attention decode path through PagedAttention while other layers can still use FIA. The replay params now carry an explicit PA marker and are updated through the matching PA/FIA update path.
- Reduces RoPE Triton head tiling for `head_dim >= 256` large-head RoPE to avoid A2/A3 unified-buffer overflow during compilation, while keeping the original tile for common head-dim models.

### Does this PR introduce _any_ user-facing change?

No API change. This fixes Gemma4 graph-mode execution on Ascend A2/A3.

### How was this patch tested?

- Verified Gemma4 W8A8 serving on 4 * Ascend 910B3 with TP=4 and `cudagraph_mode=FULL_DECODE_ONLY`.
- Verified smoke prompts in graph mode, including arithmetic and Chinese generation, without RoPE UB overflow or graph replay unpack errors.
- Added unit coverage for mixed PA/FIA graph replay param update.
- Ran local static checks:
  - `python3 -m ruff format --check vllm_ascend/ops/triton/rope.py tests/ut/attention/a2/test_attention_v1.py vllm_ascend/attention/attention_v1.py vllm_ascend/attention/utils.py`
  - `python3 -m ruff check vllm_ascend/ops/triton/rope.py tests/ut/attention/a2/test_attention_v1.py vllm_ascend/attention/attention_v1.py vllm_ascend/attention/utils.py`
  - `python3 -m compileall vllm_ascend/ops/triton/rope.py vllm_ascend/attention/attention_v1.py vllm_ascend/attention/utils.py tests/ut/attention/a2/test_attention_v1.py`

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
