### PR TITLE
[BugFix] ignore recompute scheduler on prefill nodes

### DIFF
--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -561,11 +561,12 @@ class TestNPUPlatform(TestBase):
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
-    def test_check_and_update_config_recompute_scheduler_rejects_kv_producer(
+    def test_check_and_update_config_recompute_scheduler_warns_and_disables_kv_producer(
         self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
         mock_ascend_config.recompute_scheduler_enable = True
+        mock_ascend_config.profiling_chunk_config.enabled = False
         mock_init_ascend.return_value = mock_ascend_config
 
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -573,7 +574,8 @@ class TestNPUPlatform(TestBase):
         vllm_config.parallel_config.decode_context_parallel_size = 1
         vllm_config.parallel_config.prefill_context_parallel_size = 1
         vllm_config.parallel_config.tensor_parallel_size = 1
-        vllm_config.scheduler_config = MagicMock()
+        scheduler_config = MagicMock()
+        vllm_config.scheduler_config = scheduler_config
         mock_init_recompute.return_value = MagicMock()
 
         from vllm_ascend import platform
@@ -582,16 +584,20 @@ class TestNPUPlatform(TestBase):
         self.platform = platform.NPUPlatform()
 
         with (
-            pytest.raises(
-                ValueError,
-                match=r"recompute_scheduler_enable.*PD-disaggregated D nodes.*kv_role='kv_consumer'",
-            ),
             patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
             patch.object(platform, "check_kv_extra_config"),
+            patch.object(platform.logger, "warning") as mock_warning,
         ):
             self.platform.check_and_update_config(vllm_config)
 
         mock_init_recompute.assert_not_called()
+        self.assertFalse(mock_ascend_config.recompute_scheduler_enable)
+        self.assertIs(vllm_config.scheduler_config, scheduler_config)
+        mock_warning.assert_called_once()
+        self.assertIn(
+            "recompute_scheduler_enable is ignored on PD-disaggregated P nodes",
+            mock_warning.call_args.args[0],
+        )
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -484,6 +484,7 @@ class RecomputeScheduler(Scheduler):
                     # Get locally-cached tokens.
                     if (
                         self.connector is not None
+                        and not self.is_kv_producer
                         and self.has_mamba_layers
                         and isinstance(
                             self.kv_cache_manager.coordinator,

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -648,16 +648,24 @@ class NPUPlatform(Platform):
         if ascend_config.recompute_scheduler_enable:
             kv_transfer_config = vllm_config.kv_transfer_config
             kv_role = getattr(kv_transfer_config, "kv_role", None)
-            if kv_transfer_config is None or kv_role != "kv_consumer":
+            if kv_role == "kv_producer":
+                logger.warning(
+                    "recompute_scheduler_enable is ignored on PD-disaggregated P nodes "
+                    "(kv_role='kv_producer') and will be deprecated on P nodes in a future release. "
+                    "Please remove it from P-node configs and keep it only on PD-disaggregated D nodes "
+                    "(kv_role='kv_consumer')."
+                )
+                ascend_config.recompute_scheduler_enable = False
+            elif kv_transfer_config is None or kv_role != "kv_consumer":
                 raise ValueError(
                     "recompute_scheduler_enable can only be enabled on PD-disaggregated D nodes "
                     f"(kv_role='kv_consumer', but got kv_role={kv_role!r}), and is not supported in PD-mixed mode."
                 )
+            else:
+                from vllm_ascend.core.recompute_scheduler import RecomputeSchedulerConfig
 
-            from vllm_ascend.core.recompute_scheduler import RecomputeSchedulerConfig
-
-            recompute_scheduler_config = RecomputeSchedulerConfig.initialize_from_config(vllm_config)
-            vllm_config.scheduler_config = recompute_scheduler_config
+                recompute_scheduler_config = RecomputeSchedulerConfig.initialize_from_config(vllm_config)
+                vllm_config.scheduler_config = recompute_scheduler_config
 
         # Extend original scheduler_config to use SchedulerDynamicBatch.
         if ascend_config.SLO_limits_for_dynamic_batch != -1:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR keeps existing P/D launch scripts working when `recompute_scheduler_enable=true` is still configured on PD prefill nodes.

Previously, enabling `recompute_scheduler_enable` outside PD decode nodes caused startup to fail. This was correct for preventing the recompute scheduler from running on P nodes, but it was not smooth for users who still use older launch scripts that set the option on both P and D nodes.

This PR changes the PD prefill behavior to emit a warning and disable `recompute_scheduler_enable` on `kv_role='kv_producer'` nodes instead of failing startup. The recompute scheduler is still initialized only on PD decode nodes with `kv_role='kv_consumer'`.

Hard errors are retained for PD-mixed or non-PD configurations, and hybrid Mamba cache lookup is guarded from producer-side recompute scheduler use.

### Does this PR introduce _any_ user-facing change?

Yes. If `recompute_scheduler_enable=true` is configured on a PD prefill node, startup no longer fails immediately. The option is ignored on the P node with a warning, and users should remove it from P-node configs because it will be deprecated there.

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
