### PR TITLE
[BugFix][SFA] Scope W4A4 MXFP4 contiguous layout to o_proj

### DIFF
--- a/tests/ut/attention/test_sfa_o_proj_tp.py
+++ b/tests/ut/attention/test_sfa_o_proj_tp.py
@@ -29,13 +29,13 @@ class TestAscendSFAOProjTPParams(TestBase):
     class _OProj(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            self.weight = torch.nn.Parameter(torch.randn(4, 3), requires_grad=False)
+            self.weight = torch.nn.Parameter(torch.randn(3, 4).transpose(0, 1), requires_grad=False)
             self.aclnn_input_scale = torch.nn.Parameter(torch.randn(3), requires_grad=False)
-            self.weight_scale_second = torch.nn.Parameter(torch.randn(4, 2), requires_grad=False)
+            self.weight_scale_second = torch.nn.Parameter(torch.randn(2, 4).transpose(0, 1), requires_grad=False)
             self.weight_scale_second.input_dim = 1
-            self.weight_offset_second = torch.nn.Parameter(torch.randn(4, 2), requires_grad=False)
+            self.weight_offset_second = torch.nn.Parameter(torch.randn(2, 4).transpose(0, 1), requires_grad=False)
             self.weight_offset_second.input_dim = 1
-            self.extra_input_scale = torch.nn.Parameter(torch.randn(4, 2), requires_grad=False)
+            self.extra_input_scale = torch.nn.Parameter(torch.randn(2, 4).transpose(0, 1), requires_grad=False)
             self.extra_input_scale.input_dim = 1
             self.weight_scale = torch.nn.Parameter(torch.randn(4), requires_grad=False)
 
@@ -52,10 +52,16 @@ class TestAscendSFAOProjTPParams(TestBase):
     def test_o_proj_tp_params_alias_original_storage(self):
         impl = self._make_impl()
         o_proj = impl.o_proj
+        self.assertFalse(o_proj.weight.is_contiguous())
+        self.assertFalse(o_proj.weight_scale_second.is_contiguous())
+        self.assertFalse(o_proj.weight_offset_second.is_contiguous())
+        self.assertFalse(o_proj.extra_input_scale.is_contiguous())
 
         impl._init_o_proj_tp_full_params()
 
         self.assertEqual(impl.o_proj_tp_weight.data_ptr(), o_proj.weight.data_ptr())
+        self.assertTrue(impl.o_proj_tp_weight.is_contiguous())
+        self.assertTrue(impl.o_proj_full_pool.is_contiguous())
         self.assertEqual(
             impl.o_proj_tp_aclnn_input_params["aclnn_input_scale"].data_ptr(),
             o_proj.aclnn_input_scale.data_ptr(),
@@ -64,14 +70,17 @@ class TestAscendSFAOProjTPParams(TestBase):
             impl.o_proj_tp_input_sharded_quant_params["weight_scale_second"].data_ptr(),
             o_proj.weight_scale_second.data_ptr(),
         )
+        self.assertTrue(impl.o_proj_tp_input_sharded_quant_params["weight_scale_second"].is_contiguous())
         self.assertEqual(
             impl.o_proj_tp_input_sharded_quant_params["weight_offset_second"].data_ptr(),
             o_proj.weight_offset_second.data_ptr(),
         )
+        self.assertTrue(impl.o_proj_tp_input_sharded_quant_params["weight_offset_second"].is_contiguous())
         self.assertEqual(
             impl.o_proj_tp_input_sharded_quant_params["extra_input_scale"].data_ptr(),
             o_proj.extra_input_scale.data_ptr(),
         )
+        self.assertTrue(impl.o_proj_tp_input_sharded_quant_params["extra_input_scale"].is_contiguous())
         self.assertNotIn("weight_scale", impl.o_proj_tp_input_sharded_quant_params)
 
     def test_o_proj_full_weight_forward_restores_tp_storage(self):

--- a/tests/ut/quantization/methods/test_w4a4_mxfp4.py
+++ b/tests/ut/quantization/methods/test_w4a4_mxfp4.py
@@ -40,8 +40,8 @@ class TestAscendW4A4MXFP4LinearMethod(TestBase):
         self.scheme.process_weights_after_loading(layer)
         self.assertEqual(layer.weight.shape, (128, 128))
         self.assertEqual(layer.weight_scale.shape[0], 4)
-        self.assertTrue(layer.weight.data.is_contiguous())
-        self.assertTrue(layer.weight_scale.data.is_contiguous())
+        self.assertFalse(layer.weight.data.is_contiguous())
+        self.assertFalse(layer.weight_scale.data.is_contiguous())
 
     @patch("vllm_ascend.quantization.methods.w4a4_mxfp4.torch_npu")
     def test_apply_3d_input(self, mock_npu):

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -882,6 +882,9 @@ class AscendSFAImpl(MLAAttentionImpl):
         sample = self.o_proj.weight
         self.o_proj_full_weight_gather_dim = 1 if self._is_o_proj_unquantized() else 0
         if self.o_proj_full_weight_gather_dim == 0:
+            self._ensure_o_proj_quant_params_contiguous()
+            sample = self.o_proj.weight
+        if self.o_proj_full_weight_gather_dim == 0:
             full_shape = (sample.shape[0] * self.tp_size, sample.shape[1])
             gather_shape = full_shape
         else:
@@ -932,6 +935,11 @@ class AscendSFAImpl(MLAAttentionImpl):
             self.o_proj_full_input_sharded_quant_params[param_name] = torch.empty(
                 (param.shape[0] * self.tp_size, *param.shape[1:]), dtype=param.dtype, device=param.device
             )
+
+    def _ensure_o_proj_quant_params_contiguous(self):
+        self.o_proj.weight.data = self.o_proj.weight.data.contiguous()
+        for _, param in self._iter_o_proj_input_sharded_quant_params():
+            param.data = param.data.contiguous()
 
     def _iter_o_proj_input_sharded_quant_params(self):
         if not isinstance(self.o_proj, nn.Module):

--- a/vllm_ascend/quantization/methods/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4_mxfp4.py
@@ -111,8 +111,8 @@ class AscendW4A4MXFP4DynamicLinearMethod(AscendLinearScheme):
 
         n_dim, k_dim = layer.weight_scale.data.shape
         layer.weight_scale.data = layer.weight_scale.data.reshape(n_dim, k_dim // 2, 2)
-        layer.weight.data = layer.weight.data.transpose(0, 1).contiguous()
-        layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1).contiguous()
+        layer.weight.data = layer.weight.data.transpose(0, 1)
+        layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1)
 
 
 @register_scheme("W4A4_MXFP4", "moe")


### PR DESCRIPTION
### What this PR does / why we need it?

This PR narrows the W4A4 MXFP4 `.contiguous()` handling to the SFA `o_proj` path that actually needs it, instead of applying it to every W4A4 MXFP4 Linear weight during generic post-load processing.

The failing case is W4A4 MXFP4 MoE with shared experts. Shared expert projections (`gate_up_proj` / `down_proj`) use the normal W4A4 MXFP4 Linear method. For these packed FP4 weights, the post-load layout must preserve the transpose stride so the NPU quant matmul path interprets the packed K dimension correctly. Making the transposed weight contiguous changes that layout contract and can expose a K-axis mismatch such as:

```text
Input the size of x1's k dimension and size of x2's k dimension should be same, but x1's is 7168, x2's is 3584.
```

The stack reports through `torch_npu.npu_quant_matmul` while running shared expert consistency validation, but the validation is not the layout root cause. It only happens to execute a shared expert forward during loading. The real issue is that #11068 made `.transpose(...).contiguous()` part of the generic W4A4 MXFP4 Linear post-load path to satisfy SFA `o_proj` matmul requirements. That scope is too broad: SFA needs contiguous tensors, while shared expert MXFP4 Linear needs the transpose-only packed layout.

This PR therefore:

- restores `AscendW4A4MXFP4DynamicLinearMethod.process_weights_after_loading()` to transpose-only layout for generic W4A4 MXFP4 Linear weights;
- materializes contiguous tensors only for SFA DSA-CP `o_proj` TP/full-weight parameters via `_init_o_proj_tp_full_params()`;
- keeps the shared expert validation path intact, since removing it would hide the symptom but would not fix the layout contract;
- updates UT coverage to assert generic W4A4 MXFP4 Linear remains non-contiguous after post-load, while SFA `o_proj` local TP/full buffers are contiguous.

Context on introduction:

- #5482 introduced shared expert overlap validation.
- #11081 carried that validation into the current main2main fused MoE structure.
- #11068 introduced the broad W4A4 MXFP4 Linear `.contiguous()` change. Without that broad `.contiguous()`, the shared expert MXFP4 packed layout keeps the expected transpose stride.

### Does this PR introduce _any_ user-facing change?

No. This is an internal layout handling fix for W4A4 MXFP4 weights. It keeps SFA `o_proj` contiguous where required and avoids applying that requirement to unrelated shared expert Linear modules.

### How was this patch tested?

- `git diff --check`
- `python -m py_compile vllm_ascend/attention/sfa_v1.py vllm_ascend/quantization/methods/w4a4_mxfp4.py tests/ut/attention/test_sfa_o_proj_tp.py tests/ut/quantization/methods/test_w4a4_mxfp4.py`
- `python -m pytest tests/ut/attention/test_sfa_o_proj_tp.py tests/ut/quantization/methods/test_w4a4_mxfp4.py -q` was attempted locally but could not run because the local Python environment does not have `pytest` installed.
- `uv run --no-sync pytest tests/ut/attention/test_sfa_o_proj_tp.py tests/ut/quantization/methods/test_w4a4_mxfp4.py -q` was also attempted, but no existing uv environment with `pytest` was available.
- `python -m ruff check ...` and `python -m ruff format --check ...` were attempted locally, but the local Python environment does not have `ruff` installed.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
