### PR TITLE
[BugFix][Core] Fix schedule new_tokens when num_computed_tokens approching max_model_len

### DIFF
--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -219,6 +219,7 @@ class RecomputeScheduler(Scheduler):
                 # they are all rejected.
                 and request.num_computed_tokens + 2 - request.num_output_placeholders
                 >= request.num_prompt_tokens + request.max_tokens
+                or request.num_computed_tokens >= self.max_model_len
             ):
                 # Async scheduling: Avoid scheduling an extra step when we are sure that
                 # the previous step has reached request.max_tokens. We don't schedule


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes an issue in the recompute scheduler where requests are scheduled for extra steps even when the number of computed tokens has already reached or exceeded the maximum model length (`max_model_len`). By adding a check `request.num_computed_tokens >= self.max_model_len`, we avoid scheduling unnecessary steps for requests that have already reached the model's limit.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested with existing CI and unit tests.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
