### PR TITLE
[BugFix][CI]: properly kill mooncake child processes in MooncakeLauncher cleanup

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -27,6 +27,7 @@ import logging
 import multiprocessing
 import os
 import shlex
+import signal
 import subprocess
 import sys
 import threading
@@ -227,18 +228,23 @@ class MooncakeLauncher:
         mooncake_ld_path = "/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:"
         os.environ["LD_LIBRARY_PATH"] = mooncake_ld_path + curr_ld_path
         env = os.environ.copy()
-        self.process = subprocess.Popen(cmd, env=env)
+        self.process = subprocess.Popen(cmd, env=env, start_new_session=True)
         return self
 
     def __exit__(self, exc_type, exc, tb):
         if not self.process:
             return
         logger.info("Stopping mooncake server...")
-        self.process.terminate()
         try:
+            pgid = os.getpgid(self.process.pid)
+            os.killpg(pgid, signal.SIGTERM)
             self.process.wait(timeout=5)
         except subprocess.TimeoutExpired:
-            self.process.kill()
+            logger.warning("Mooncake server did not stop gracefully, force killing...")
+            os.killpg(pgid, signal.SIGKILL)
+            self.process.wait(timeout=5)
+        except ProcessLookupError:
+            pass
 
 
 class RemoteOpenAIServer:


### PR DESCRIPTION

### What this PR does / why we need it?

fix: https://github.com/vllm-project/vllm-ascend/actions/runs/28804119140/job/85514257998

The `MooncakeLauncher.__exit__` method in `tests/e2e/conftest.py` only terminated the direct parent process (`mooncake_master`), leaving child processes (`master_service`, `rpc_service`) running as orphan zombies after test completion. These orphan processes continued printing Master Admin Metrics every 10 seconds, unnecessarily consuming resources.

This PR fixes the cleanup by:

1. Adding `start_new_session=True` to `subprocess.Popen` to isolate the mooncake process tree in its own session.
2. Replacing `process.terminate()` / `process.kill()` with `os.killpg()` to send  signals to the entire process group, ensuring all child processes are cleaned up.
3. Adding `ProcessLookupError` handling for processes that exit on their own.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
