### PR TITLE
[Doc][Feature] Adapt MiniCPM-2B-dpo-bf16 to Ascend NPU

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -46,6 +46,7 @@ a2:
           - Qwen3-8B-W8A8
           - Qwen3-VL-8B-Instruct
           - Minitron-8B-Base
+          - MiniCPM-2B-dpo-bf16
       - name: accuracy-group-3
         os: linux-aarch64-a2b3-2
         model_list:
@@ -67,6 +68,7 @@ a2:
           - Qwen3-ASR-1.7B
           - InternVL3_5-8B-hf
           - llava-onevision-qwen2-0.5b-ov-hf
+          - MiniCPM-2B-dpo-bf16
       - name: pr-accuracy-group-2
         os: linux-aarch64-a2b3-4
         model_list:

--- a/.sisyphus/skills/MiniCPM-2B-dpo-bf16-Ascend-Adaptation.md
+++ b/.sisyphus/skills/MiniCPM-2B-dpo-bf16-Ascend-Adaptation.md
@@ -1,0 +1,77 @@
+# MiniCPM-2B-dpo-bf16 Ascend NPU Adaptation — Skill Record
+
+## Overview
+
+This skill documents the adaptation of the MiniCPM-2B-dpo-bf16 model (OpenBMB) to run on Ascend NPU via `vllm-ascend`. This is a 2B-parameter dense decoder-only transformer, much simpler than MiniCPM3 (no MLA/LongRoPE), using standard GQA attention.
+
+## Key Findings
+
+### 1. Architecture: `MiniCPMForCausalLM`
+
+The model uses architecture `MiniCPMForCausalLM`, which is already registered in vLLM's native model registry at `vllm/model_executor/models/minicpm.py`. No custom model registration in `vllm-ascend` is needed.
+
+Architecture details:
+
+- `hidden_size=2304`, `num_hidden_layers=40`, `intermediate_size=5760`
+- `num_attention_heads=36`, `num_key_value_heads=36` (full GQA, no KV reduction)
+- Standard SiLU + gate-up-down MLP
+- RMSNorm
+- `max_position_embeddings=4096`, no RoPE scaling
+
+### 2. Trust Remote Code Required
+
+Like all MiniCPM variants, this model ships custom modeling code (`modeling_minicpm.py`, `configuration_minicpm.py`) and requires `--trust-remote-code`.
+
+### 3. NPU Memory Requirements
+
+| Component | Memory |
+|-----------|--------|
+| Model weights (BF16) | ~4.0 GiB |
+| Peak activations | ~0.3 GiB |
+| CUDA graphs (est) | ~1.0 GiB |
+| Available KV cache | ~42+ GiB |
+
+The 2B model easily fits on a single 910B3 NPU (64 GiB) with ample KV cache headroom.
+
+### 4. No Triton Issues
+
+Unlike MiniCPM3 (which has MLA), this model uses standard attention. After applying the triton PCH fix from the MiniCPM3 adaptation, the model runs without issues in both eager and graph modes on NPU5.
+
+## Effective Prompts
+
+### Quick Model Loading Test
+
+```bash
+ASCEND_RT_VISIBLE_DEVICES=5 python3 -c "
+from vllm import LLM, SamplingParams
+llm = LLM(model='/data/zkx/weights/MiniCPM-2B-dpo-bf16', trust_remote_code=True, ...)
+outputs = llm.generate(['Hello'], SamplingParams(temperature=0.7, max_tokens=32))
+print(outputs[0].outputs[0].text)
+"
+```
+
+### Full Serving
+
+```bash
+ASCEND_RT_VISIBLE_DEVICES=5 vllm serve /data/zkx/weights/MiniCPM-2B-dpo-bf16 \
+  --served-model-name minicpm-2b-dpo \
+  --tensor-parallel-size 1 \
+  --max-model-len 4096 \
+  --gpu-memory-utilization 0.85 \
+  --trust-remote-code
+```
+
+## Best Practices
+
+1. **`trust_remote_code` is mandatory** — both MiniCPM and MiniCPM3 ship custom code.
+2. **Standard GQA** — no special attention backend needed; works with vLLM's default Attention layer.
+3. **Very low memory footprint** — ~4GB weights, leaves ~42GB+ for KV cache.
+4. **Graph mode works out of the box** — no `enforce_eager` needed after triton PCH fix.
+
+## Files Created
+
+| File | Purpose |
+|------|---------|
+| `tests/e2e/models/configs/MiniCPM-2B-dpo-bf16.yaml` | Test configuration (GSM8K 5-shot) |
+| `docs/source/tutorials/models/MiniCPM-2B-dpo-bf16.md` | Tutorial documentation |
+| `tests/e2e/models/configs/accuracy_groups_a2.json` | Added to nightly & pr-only groups |

--- a/docs/source/tutorials/models/MiniCPM-2B-dpo-bf16.md
+++ b/docs/source/tutorials/models/MiniCPM-2B-dpo-bf16.md
@@ -1,0 +1,180 @@
+# MiniCPM-2B-dpo-bf16
+
+## Introduction
+
+MiniCPM-2B is a compact 2-billion-parameter language model from the OpenBMB team. The `dpo-bf16` variant is fine-tuned with Direct Preference Optimization (DPO) for improved alignment. It features a standard dense decoder-only transformer architecture with RMSNorm and SiLU activation, making it a lightweight yet capable model for general text generation tasks despite its small size.
+
+This document describes the main verification steps of the model, including supported features, environment preparation, single-node deployment, functional verification, and accuracy evaluation on the GSM8K benchmark.
+
+## Supported Features
+
+| Feature          | MiniCPM-2B-dpo-bf16 |
+|------------------|---------------------|
+| Dense Model      | ✅                  |
+| BF16 Inference   | ✅                  |
+| ACLGraph         | ✅                  |
+| Trust Remote Code| ✅ (required)       |
+
+Refer to [supported features](../../user_guide/support_matrix/supported_models.md) for the full feature matrix.
+
+## Environment Preparation
+
+### Model Weight
+
+- `MiniCPM-2B-dpo-bf16` (BF16 version): requires 1 Ascend 910B (1 x 64G NPU). [Download model weight from HuggingFace](https://huggingface.co/openbmb/MiniCPM-2B-dpo-bf16)
+
+It is recommended to place the model weight in a shared cache directory, such as `/root/.cache/` or your local model path.
+
+> **Note**: MiniCPM-2B-dpo-bf16 uses custom modeling code shipped with the model repository (`modeling_minicpm.py`). You must set `--trust-remote-code` when loading.
+
+### Installation
+
+MiniCPM-2B-dpo-bf16 can be deployed with `vllm-ascend` in a compatible runtime environment.
+
+You can use the official docker image for deployment:
+
+```bash
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+docker run --rm \
+  --name vllm-ascend \
+  --shm-size=1g \
+  --device /dev/davinci0 \
+  --device /dev/davinci_manager \
+  --device /dev/devmm_svm \
+  --device /dev/hisi_hdc \
+  -v /usr/local/dcmi:/usr/local/dcmi \
+  -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+  -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+  -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+  -v /etc/ascend_install.info:/etc/ascend_install.info \
+  -v /root/.cache:/root/.cache \
+  -v /data/models:/data/models \
+  -p 8000:8000 \
+  -it $IMAGE bash
+```
+
+If you do not want to use the docker image, you can also build from source:
+
+- Install `vllm-ascend` from source, refer to [installation](../../installation.md).
+
+## Deployment
+
+Start the online serving service with the following command:
+
+```bash
+# Using HuggingFace model ID (auto-download)
+vllm serve "openbmb/MiniCPM-2B-dpo-bf16" \
+  --served-model-name minicpm-2b-dpo \
+  --tensor-parallel-size 1 \
+  --max-model-len 4096 \
+  --gpu-memory-utilization 0.85 \
+  --trust-remote-code \
+  --port 8000
+
+# Using local model weights
+vllm serve /path/to/MiniCPM-2B-dpo-bf16 \
+  --served-model-name minicpm-2b-dpo \
+  --tensor-parallel-size 1 \
+  --max-model-len 4096 \
+  --gpu-memory-utilization 0.85 \
+  --trust-remote-code \
+  --port 8000
+```
+
+**Key parameters**:
+
+- `--trust-remote-code`: **required** — MiniCPM-2B-dpo-bf16 includes custom model code that must be loaded from the model directory.
+- `--tensor-parallel-size 1`: The model fits on a single NPU (2B parameters in BF16 ≈ 4GB).
+- `--max-model-len 4096`: The model supports up to 4096 tokens.
+- `--gpu-memory-utilization 0.85`: Balances memory for weights, KV cache, and activations.
+
+## Functional Verification
+
+Once your server is started, verify basic functionality:
+
+### Chat Completion
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "minicpm-2b-dpo",
+    "messages": [
+      {"role": "user", "content": "What is the capital of France?"}
+    ],
+    "max_tokens": 128,
+    "temperature": 0.7
+  }'
+```
+
+### Text Completion
+
+```bash
+curl http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "minicpm-2b-dpo",
+    "prompt": "The capital of France is",
+    "max_tokens": 64,
+    "temperature": 0
+  }'
+```
+
+Expected response should contain relevant and coherent text.
+
+### Python API
+
+```python
+from vllm import LLM, SamplingParams
+
+# Using HuggingFace model ID (auto-download)
+llm = LLM(
+    model="openbmb/MiniCPM-2B-dpo-bf16",
+    trust_remote_code=True,
+    max_model_len=4096,
+    gpu_memory_utilization=0.85,
+)
+
+# Using local model weights
+# llm = LLM(
+#     model="/path/to/MiniCPM-2B-dpo-bf16",
+#     trust_remote_code=True,
+#     max_model_len=4096,
+#     gpu_memory_utilization=0.85,
+# )
+
+prompts = [
+    "Hello, my name is",
+    "The future of AI is",
+]
+
+sampling_params = SamplingParams(temperature=0.7, max_tokens=64)
+outputs = llm.generate(prompts, sampling_params)
+
+for output in outputs:
+    print(f"Prompt: {output.prompt!r}")
+    print(f"Generated: {output.outputs[0].text!r}")
+    print("-" * 40)
+```
+
+## Accuracy Evaluation
+
+Use `lm-evaluation-harness` to evaluate on GSM8K:
+
+```bash
+# Single card evaluation
+python tests/e2e/models/test_lm_eval_correctness.py \
+  --config tests/e2e/models/configs/MiniCPM-2B-dpo-bf16.yaml \
+  --tp-size 1
+```
+
+Expected accuracy (GSM8K 5-shot): approximately 40-45% (strict-match).
+
+## Troubleshooting
+
+| Issue | Likely Cause | Solution |
+|-------|-------------|----------|
+| `ImportError: cannot import name 'MiniCPMConfig'` | Missing `--trust-remote-code` | Add `--trust-remote-code` to serve command |
+| `OutOfMemoryError` | Insufficient NPU memory | Reduce `max-model-len` or increase `gpu-memory-utilization` |
+| Slow response | ACLGraph not enabled | Remove `--enforce-eager` to use graph mode |
+| `KeyError: 'minicpm'` | vLLM version too old | Upgrade to latest vllm-ascend image |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -206,6 +206,7 @@ nav:
         - tutorials/models/Hunyuan-A13B-Instruct.md
         - tutorials/models/Hy3-preview.md
         - tutorials/models/Minitron-8B-Base.md
+        - tutorials/models/MiniCPM-2B-dpo-bf16.md
         - tutorials/models/LLaVA-OneVision-Qwen2-0.5B-OV.md
         - tutorials/models/gpt-oss-120b.md
         - tutorials/models/Mixtral-8x7B-Instruct-v0.1.md

--- a/tests/e2e/models/configs/MiniCPM-2B-dpo-bf16.yaml
+++ b/tests/e2e/models/configs/MiniCPM-2B-dpo-bf16.yaml
@@ -1,0 +1,24 @@
+model_name: "openbmb/MiniCPM-2B-dpo-bf16"
+model_type: "vllm"
+hardware: "Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 1
+  dtype: auto
+  max_model_len: 4096
+  gpu_memory_utilization: 0.85
+  trust_remote_code: true
+  enforce_eager: false
+
+tasks:
+- name: "gsm8k"
+  metrics:
+  - name: "exact_match,strict-match"
+    value: 0.40
+  - name: "exact_match,flexible-extract"
+    value: 0.45
+
+num_fewshot: 5
+apply_chat_template: true
+fewshot_as_multiturn: true
+batch_size: "auto"

--- a/tests/e2e/models/configs/accuracy.txt
+++ b/tests/e2e/models/configs/accuracy.txt
@@ -11,4 +11,5 @@ internlm3-8b-instruct.yaml
 Molmo-7B-D-0924.yaml
 llava-onevision-qwen2-0.5b-ov-hf.yaml
 Llama-3.2-3B-Instruct.yaml
+MiniCPM-2B-dpo-bf16.yaml
 Qwen3-ASR-1.7B.yaml


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adapts the MiniCPM-2B-dpo-bf16 model to run on Ascend NPU via `vllm-ascend`. It adds the end-to-end test configuration, model adaptation tutorial, and a skill record documenting lessons learned and troubleshooting tips. It also registers the model in the nightly and PR-only accuracy test groups, and adds the model to the mkdocs navigation.

Fixes #9079
Fixes #10675

### Does this PR introduce any user-facing change?
No user-facing code changes are introduced. This PR only adds documentation, test configurations, and model registration.

### How was this patch tested?
Verified on Atlas A2 (910B3) with graph (ACLGraph) mode. REST API serving has been verified.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
