### PR TITLE
[LoRA] Register Ascend dense-linear LoRA wrappers for MLP/o_proj under TP>1

### DIFF
--- a/vllm_ascend/lora/utils.py
+++ b/vllm_ascend/lora/utils.py
@@ -3,15 +3,24 @@ from torch import nn
 from transformers import PretrainedConfig
 from vllm.config import LoRAConfig
 from vllm.lora.layers import (
+    ColumnParallelLinearWithLoRA,
+    ColumnParallelLinearWithShardedLoRA,
+    MergedColumnParallelLinearWithLoRA,
+    MergedColumnParallelLinearWithShardedLoRA,
     MergedQKVParallelLinearWithLoRA,
     MergedQKVParallelLinearWithShardedLoRA,
     QKVParallelLinearWithLoRA,
     QKVParallelLinearWithShardedLoRA,
+    RowParallelLinearWithLoRA,
+    RowParallelLinearWithShardedLoRA,
 )
 from vllm.lora.layers.utils import _fully_sharded_can_replace, _not_fully_sharded_can_replace
 
 from vllm_ascend.ops.linear import (
+    AscendColumnParallelLinear,
+    AscendMergedColumnParallelLinear,
     AscendQKVParallelLinear,
+    AscendRowParallelLinear,
 )
 
 
@@ -67,12 +76,113 @@ class AscendQKVParallelLinearWithShardedLoRA(QKVParallelLinearWithShardedLoRA):
         return type(source_layer) is AscendQKVParallelLinear and len(packed_modules_list) == 1
 
 
+# ---------------------------------------------------------------------------
+# Dense-linear LoRA wrappers.
+#
+# Upstream MergedColumn/Row/Column ``*WithLoRA.can_replace_layer`` gate on a
+# strict ``type(source_layer) is <upstream base>`` check (or, for the merged
+# column class, a ``tp_size == 1`` fallback for subclasses). vllm-ascend swaps
+# in ``AscendMergedColumnParallelLinear`` / ``AscendRowParallelLinear`` /
+# ``AscendColumnParallelLinear`` subclasses, so under TP>1 none of them match
+# and the MLP (gate_up_proj / down_proj) + o_proj LoRA deltas are silently
+# dropped -- the adapter appears to have no effect. The QKV wrappers above are
+# the reason attention still gets LoRA. These subclasses extend the same
+# coverage to the dense linears by matching the Ascend concrete types.
+# ---------------------------------------------------------------------------
+class AscendMergedColumnParallelLinearWithLoRA(MergedColumnParallelLinearWithLoRA):
+    @classmethod
+    @_not_fully_sharded_can_replace
+    def can_replace_layer(
+        cls,
+        source_layer: nn.Module,
+        lora_config: LoRAConfig,
+        packed_modules_list: list,
+        model_config: PretrainedConfig | None,
+    ) -> bool:
+        return type(source_layer) is AscendMergedColumnParallelLinear and len(packed_modules_list) == 2
+
+
+class AscendMergedColumnParallelLinearWithShardedLoRA(MergedColumnParallelLinearWithShardedLoRA):
+    @classmethod
+    @_fully_sharded_can_replace
+    def can_replace_layer(
+        cls,
+        source_layer: nn.Module,
+        lora_config: LoRAConfig,
+        packed_modules_list: list,
+        model_config: PretrainedConfig | None = None,
+    ) -> bool:
+        return type(source_layer) is AscendMergedColumnParallelLinear and len(packed_modules_list) == 2
+
+
+class AscendRowParallelLinearWithLoRA(RowParallelLinearWithLoRA):
+    @classmethod
+    @_not_fully_sharded_can_replace
+    def can_replace_layer(
+        cls,
+        source_layer: nn.Module,
+        lora_config: LoRAConfig,
+        packed_modules_list: list,
+        model_config: PretrainedConfig | None,
+    ) -> bool:
+        return type(source_layer) is AscendRowParallelLinear
+
+
+class AscendRowParallelLinearWithShardedLoRA(RowParallelLinearWithShardedLoRA):
+    @classmethod
+    @_fully_sharded_can_replace
+    def can_replace_layer(
+        cls,
+        source_layer: nn.Module,
+        lora_config: LoRAConfig,
+        packed_modules_list: list,
+        model_config: PretrainedConfig | None = None,
+    ) -> bool:
+        return type(source_layer) is AscendRowParallelLinear
+
+
+class AscendColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
+    @classmethod
+    @_not_fully_sharded_can_replace
+    def can_replace_layer(
+        cls,
+        source_layer: nn.Module,
+        lora_config: LoRAConfig,
+        packed_modules_list: list,
+        model_config: PretrainedConfig | None,
+    ) -> bool:
+        return type(source_layer) is AscendColumnParallelLinear and len(packed_modules_list) == 1
+
+
+class AscendColumnParallelLinearWithShardedLoRA(ColumnParallelLinearWithShardedLoRA):
+    @classmethod
+    @_fully_sharded_can_replace
+    def can_replace_layer(
+        cls,
+        source_layer: nn.Module,
+        lora_config: LoRAConfig,
+        packed_modules_list: list,
+        model_config: PretrainedConfig | None = None,
+    ) -> bool:
+        return type(source_layer) is AscendColumnParallelLinear and len(packed_modules_list) == 1
+
+
 def refresh_all_lora_classes():
     ascend_classes = (
+        # Attention QKV.
         AscendQKVParallelLinearWithLoRA,
         AscendMergedQKVParallelLinearWithLoRA,
         AscendMergedQKVParallelLinearWithShardedLoRA,
         AscendQKVParallelLinearWithShardedLoRA,
+        # MLP gate_up_proj (merged column).
+        AscendMergedColumnParallelLinearWithLoRA,
+        AscendMergedColumnParallelLinearWithShardedLoRA,
+        # MLP down_proj / attention o_proj (row parallel).
+        AscendRowParallelLinearWithLoRA,
+        AscendRowParallelLinearWithShardedLoRA,
+        # Standalone column parallel (unpacked gate/up, etc.).
+        AscendColumnParallelLinearWithLoRA,
+        AscendColumnParallelLinearWithShardedLoRA,
     )
     # vLLM #35077 changed _all_lora_classes from set to ordered tuple.
     # Append the Ascend classes in a deterministic order.


### PR DESCRIPTION
## Summary

On the `v0.21.0rc` line, `refresh_all_lora_classes()` registers only the four QKV Ascend LoRA wrappers. The dense linear layers (`gate_up_proj` / `down_proj` / `o_proj`) are `AscendMergedColumnParallelLinear` / `AscendRowParallelLinear` / `AscendColumnParallelLinear` subclasses, but the upstream `MergedColumn* / Row* / Column*WithLoRA.can_replace_layer` gate on a strict `type(source_layer) is <upstream base>` check (the merged-column class additionally has a `tp_size == 1` fallback for subclasses).

Under **TP > 1**, none of these match the Ascend concrete types, so the MLP + `o_proj` LoRA deltas are silently dropped and the adapter appears to have no effect (LoRA output == base output).

## Fix

Add six Ascend dense-linear LoRA wrappers mirroring the existing QKV ones (plain + sharded variants for MergedColumn / Row / Column) whose `can_replace_layer` matches the Ascend concrete types, and register them in `refresh_all_lora_classes()`. The LoRA math is fully reused from the upstream wrappers — this change only fixes layer replacement/registration, not the compute path.

## Effect

Fixes dense (MLP / `o_proj`) LoRA being ineffective at TP > 1 for Qwen3.5-27B (Qwen3-Next hybrid GDN, dense). In our testing, an r=8 adapter under TP=2 in eager mode now yields a non-zero LoRA delta with this change, whereas before the outputs were bit-identical to the base model.

## Scope

- Single file: `vllm_ascend/lora/utils.py` (+110), registration only.
- Verified in eager (single-operator) mode. Graph modes (piecewise / full-decode) have separate, unrelated issues and are out of scope for this PR.

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
