### PR TITLE
[Doc][Feature] Adapt MiniCPM3-4B to Ascend NPU

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -46,6 +46,7 @@ a2:
           - Qwen3-8B-W8A8
           - Qwen3-VL-8B-Instruct
           - Minitron-8B-Base
+          - MiniCPM3-4B
       - name: accuracy-group-3
         os: linux-aarch64-a2b3-2
         model_list:
@@ -67,6 +68,7 @@ a2:
           - Qwen3-ASR-1.7B
           - InternVL3_5-8B-hf
           - llava-onevision-qwen2-0.5b-ov-hf
+          - MiniCPM3-4B
       - name: pr-accuracy-group-2
         os: linux-aarch64-a2b3-4
         model_list:

--- a/.sisyphus/skills/MiniCPM3-4B-Ascend-Adaptation.md
+++ b/.sisyphus/skills/MiniCPM3-4B-Ascend-Adaptation.md
@@ -1,0 +1,106 @@
+# MiniCPM3-4B Ascend NPU Adaptation — Skill Record
+
+## Overview
+
+This skill documents the process of adapting the MiniCPM3-4B model (OpenBMB) to run on Ascend NPU via `vllm-ascend`. The model uses Multi-head Latent Attention (MLA) similar to DeepSeek-V2 and LongRoPE position encoding.
+
+## Key Findings
+
+### 1. Model Natively Supported in vLLM
+
+`MiniCPM3ForCausalLM` is already registered in vLLM's model registry (`vllm/model_executor/models/minicpm3.py`). No custom model registration in `vllm-ascend/models/` is needed — it works through vLLM's native model support.
+
+**Model architecture:** Inherits from `MiniCPMForCausalLM` → `MiniCPMModel` with custom `MiniCPM3Attention` (MLA).
+
+### 2. Critical Requirement: `trust_remote_code=True`
+
+MiniCPM3-4B ships custom modeling code in its repository (`modeling_minicpm.py`, `configuration_minicpm.py`). You **must** pass `--trust-remote-code` when loading the model. Without it, the model fails with `ImportError: cannot import name 'MiniCPM3Config'`.
+
+### 3. Model Config Issues with `rope_parameters`
+
+The model's `config.json` has `rope_scaling` (not `rope_parameters`). vLLM internally normalizes this, but warnings appear:
+```
+`rope_parameters`'s short_factor field must have length 48, got 16
+```
+These warnings are benign — the model works correctly despite them. The MiniCPM3-4B uses `qk_rope_head_dim=32`, so the factor arrays should have `32/2=16` elements, not 48.
+
+### 4. Triton-Ascend PCH Compilation Bug
+
+**Symptoms:** Runtime crash with:
+```
+RuntimeError: Failed to compile ... precompiled.h.gch, error: ,cmd=['...', '-shared', '-fPIC', '-o', gch_path]
+```
+
+**Root cause:** `triton/backends/ascend/utils.py` passes `-shared -fPIC` flags for precompiled header (`.gch`) compilation. clang++ rejects `-shared` for header compilation.
+
+**Fix:** Remove `-shared` from line 357 (keep `-fPIC` for PIE consistency):
+```python
+# BEFORE:
+cc_cmd += ["-std=c++17", "-shared", "-fPIC", "-o", gch_path]
+# AFTER:
+cc_cmd += ["-std=c++17", "-fPIC", "-o", gch_path]
+```
+
+**Why `-fPIC` is needed:** Without `-fPIC`, the subsequent `.so` compilation using this PCH fails with `is pie differs in PCH file vs. current file`.
+
+### 5. NPU Memory Requirements
+
+| Component | Memory |
+|-----------|--------|
+| Model weights (BF16) | ~7.6 GiB |
+| Peak activations | ~0.5 GiB |
+| CUDA graphs (est) | ~1.9 GiB |
+| Total (gpu_mem_util=0.85) | ~48.8 GiB budget |
+| Available KV cache | ~38.6 GiB |
+
+The 4B model fits comfortably on a single 910B3 NPU (64 GiB).
+
+## Effective Prompts
+
+### Initial Model Loading Test
+```
+ASCEND_RT_VISIBLE_DEVICES=5 python3 -c "
+from vllm import LLM, SamplingParams
+llm = LLM(model='/data/zkx/weigths/MiniCPM3-4B', trust_remote_code=True, ...)
+outputs = llm.generate(['Hello'], SamplingParams(temperature=0.7, max_tokens=32))
+print(outputs[0].outputs[0].text)
+"
+```
+
+### Debugging Triton PCH Issue
+```
+# Reproduce manually:
+/usr/bin/clang++ -x c++-header precompiled.h ... -shared -fPIC -o precompiled.h.gch
+# → clang++: error: cannot specify -o when generating multiple output files
+```
+
+### Full Serving Test
+```
+ASCEND_RT_VISIBLE_DEVICES=5 vllm serve /path/to/MiniCPM3-4B \
+  --served-model-name minicpm3-4b \
+  --tensor-parallel-size 1 \
+  --max-model-len 4096 \
+  --gpu-memory-utilization 0.85 \
+  --trust-remote-code
+```
+
+## Best Practices
+
+1. **Always use `--trust-remote-code`** for MiniCPM3 — the custom model code is required.
+2. **Triton cache:** When debugging triton compilation issues, clear both caches:
+   ```bash
+   rm -rf /root/.triton/cache/* /tmp/triton/*
+   ```
+3. **Graph mode vs Eager:** The model works in both modes. Graph mode (default) is faster but requires the triton PCH fix. Use `--enforce-eager` as a fallback.
+4. **NPU selection:** Use `ASCEND_RT_VISIBLE_DEVICES=5` to target NPU5 (or adjust for your setup).
+5. **Test YAML config** follows the standard `vllm-ascend` pattern — `model_name` refers to the HuggingFace ID; override locally by editing the YAML.
+6. **Accuracy targets:** GSM8K 5-shot: ~45% strict-match, ~50% flexible-extract.
+
+## Files Modified / Created
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `triton/backends/ascend/utils.py:357` | Fixed | Remove `-shared` from GCH compilation flags |
+| `tests/e2e/models/configs/MiniCPM3-4B.yaml` | Verified | Test configuration |
+| `tests/e2e/models/configs/accuracy_groups_a2.json` | Updated | Added to nightly & pr-only groups |
+| `docs/source/tutorials/models/MiniCPM3-4B.md` | Updated | Added local path examples & triton troubleshooting |

--- a/docs/source/tutorials/models/MiniCPM3-4B.md
+++ b/docs/source/tutorials/models/MiniCPM3-4B.md
@@ -1,0 +1,184 @@
+# MiniCPM3-4B
+
+## Introduction
+
+MiniCPM3-4B is the third-generation small language model from the OpenBMB team, featuring Multi-head Latent Attention (MLA) architecture similar to DeepSeek-V2. Despite its compact 4B parameter size, it delivers competitive performance through efficient attention mechanisms and the LongRoPE position encoding strategy supporting up to 32K context length.
+
+This document describes the main verification steps of the model, including supported features, environment preparation, single-node deployment, functional verification, and accuracy evaluation on the GSM8K benchmark.
+
+## Supported Features
+
+| Feature          | MiniCPM3-4B |
+|------------------|-------------|
+| Dense Model      | ✅          |
+| MLA(Multi-head Latent Attention) | ✅ |
+| LongRoPE         | ✅          |
+| BF16 Inference   | ✅          |
+| ACLGraph         | ✅          |
+| Trust Remote Code| ✅ (required)|
+
+Refer to [supported features](../../user_guide/support_matrix/supported_models.md) for the full feature matrix.
+
+## Environment Preparation
+
+### Model Weight
+
+- `MiniCPM3-4B`(BF16 version): requires 1 Ascend 910B (1 x 64G NPU). [Download model weight from HuggingFace](https://huggingface.co/openbmb/MiniCPM3-4B)
+
+It is recommended to place the model weight in a shared cache directory, such as `/root/.cache/` or your local model path.
+
+> **Note**: MiniCPM3-4B uses custom modeling code shipped with the model repository (`modeling_minicpm.py`). You must set `--trust-remote-code` when loading.
+
+### Installation
+
+MiniCPM3-4B can be deployed with `vllm-ascend` in a compatible runtime environment.
+
+You can use the official docker image for deployment:
+
+```bash
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+docker run --rm \
+  --name vllm-ascend \
+  --shm-size=1g \
+  --device /dev/davinci0 \
+  --device /dev/davinci_manager \
+  --device /dev/devmm_svm \
+  --device /dev/hisi_hdc \
+  -v /usr/local/dcmi:/usr/local/dcmi \
+  -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+  -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+  -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+  -v /etc/ascend_install.info:/etc/ascend_install.info \
+  -v /root/.cache:/root/.cache \
+  -v /data/models:/data/models \
+  -p 8000:8000 \
+  -it $IMAGE bash
+```
+
+If you do not want to use the docker image, you can also build from source:
+
+- Install `vllm-ascend` from source, refer to [installation](../../installation.md).
+
+## Deployment
+
+Start the online serving service with the following command:
+
+```bash
+# Using HuggingFace model ID (auto-download)
+vllm serve "openbmb/MiniCPM3-4B" \
+  --served-model-name minicpm3-4b \
+  --tensor-parallel-size 1 \
+  --max-model-len 4096 \
+  --gpu-memory-utilization 0.85 \
+  --trust-remote-code \
+  --port 8000
+
+# Using local model weights
+vllm serve /path/to/MiniCPM3-4B \
+  --served-model-name minicpm3-4b \
+  --tensor-parallel-size 1 \
+  --max-model-len 4096 \
+  --gpu-memory-utilization 0.85 \
+  --trust-remote-code \
+  --port 8000
+```
+
+**Key parameters**:
+
+- `--trust-remote-code`: **required** — MiniCPM3-4B includes custom model code that must be loaded from the model directory.
+- `--tensor-parallel-size 1`: The model fits on a single NPU (4B parameters in BF16 ≈ 8GB).
+- `--max-model-len 4096`: Conservative setting; the model supports up to 32768 tokens via LongRoPE.
+- `--gpu-memory-utilization 0.85`: Balances memory for weights, KV cache, and activations.
+
+## Functional Verification
+
+Once your server is started, verify basic functionality:
+
+### Chat Completion
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "minicpm3-4b",
+    "messages": [
+      {"role": "user", "content": "What is the capital of France?"}
+    ],
+    "max_tokens": 128,
+    "temperature": 0.7
+  }'
+```
+
+### Text Completion
+
+```bash
+curl http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "minicpm3-4b",
+    "prompt": "The capital of France is",
+    "max_tokens": 64,
+    "temperature": 0
+  }'
+```
+
+Expected response should contain relevant and coherent text.
+
+### Python API
+
+```python
+from vllm import LLM, SamplingParams
+
+# Using HuggingFace model ID (auto-download)
+llm = LLM(
+    model="openbmb/MiniCPM3-4B",
+    trust_remote_code=True,
+    max_model_len=4096,
+    gpu_memory_utilization=0.85,
+)
+
+# Using local model weights
+# llm = LLM(
+#     model="/path/to/MiniCPM3-4B",
+#     trust_remote_code=True,
+#     max_model_len=4096,
+#     gpu_memory_utilization=0.85,
+# )
+
+prompts = [
+    "Hello, my name is",
+    "The future of AI is",
+]
+
+sampling_params = SamplingParams(temperature=0.7, max_tokens=64)
+outputs = llm.generate(prompts, sampling_params)
+
+for output in outputs:
+    print(f"Prompt: {output.prompt!r}")
+    print(f"Generated: {output.outputs[0].text!r}")
+    print("-" * 40)
+```
+
+## Accuracy Evaluation
+
+Use `lm-evaluation-harness` to evaluate on GSM8K:
+
+```bash
+# Single card evaluation
+python tests/e2e/models/test_lm_eval_correctness.py \
+  --config tests/e2e/models/configs/MiniCPM3-4B.yaml \
+  --tp-size 1
+```
+
+Expected accuracy (GSM8K 5-shot): approximately 45-50% (strict-match).
+
+## Troubleshooting
+
+| Issue | Likely Cause | Solution |
+|-------|-------------|----------|
+| `ImportError: cannot import name 'MiniCPM3Config'` | Missing `--trust-remote-code` | Add `--trust-remote-code` to serve command |
+| `OutOfMemoryError` | Insufficient GPU memory | Reduce `max-model-len` or increase `gpu-memory-utilization` |
+| Slow response | ACLGraph not enabled | Remove `--enforce-eager` to use graph mode |
+| `KeyError: 'minicpm3'` | vLLM version too old | Upgrade to latest vllm-ascend image |
+| `RuntimeError: Failed to compile ... precompiled.h.gch` | Triton-Ascend PCH compilation bug | Update triton-ascend driver, remove `-shared` from GCH compilation flags in `triton/backends/ascend/utils.py` |
+| `is pie differs in PCH file vs. current file` | PCH compiled without `-fPIC`, but launcher uses `-fPIC` | Use `-fPIC` (not `-shared`) for GCH compilation in `triton/backends/ascend/utils.py` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -206,6 +206,7 @@ nav:
         - tutorials/models/Hunyuan-A13B-Instruct.md
         - tutorials/models/Hy3-preview.md
         - tutorials/models/Minitron-8B-Base.md
+        - tutorials/models/MiniCPM3-4B.md
         - tutorials/models/LLaVA-OneVision-Qwen2-0.5B-OV.md
         - tutorials/models/gpt-oss-120b.md
         - tutorials/models/Mixtral-8x7B-Instruct-v0.1.md

--- a/tests/e2e/models/configs/MiniCPM3-4B.yaml
+++ b/tests/e2e/models/configs/MiniCPM3-4B.yaml
@@ -1,0 +1,24 @@
+model_name: "openbmb/MiniCPM3-4B"
+model_type: "vllm"
+hardware: "Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 1
+  dtype: auto
+  max_model_len: 4096
+  gpu_memory_utilization: 0.85
+  trust_remote_code: true
+  enforce_eager: false
+
+tasks:
+- name: "gsm8k"
+  metrics:
+  - name: "exact_match,strict-match"
+    value: 0.45
+  - name: "exact_match,flexible-extract"
+    value: 0.50
+
+num_fewshot: 5
+apply_chat_template: true
+fewshot_as_multiturn: true
+batch_size: "auto"

--- a/tests/e2e/models/configs/accuracy.txt
+++ b/tests/e2e/models/configs/accuracy.txt
@@ -11,4 +11,5 @@ internlm3-8b-instruct.yaml
 Molmo-7B-D-0924.yaml
 llava-onevision-qwen2-0.5b-ov-hf.yaml
 Llama-3.2-3B-Instruct.yaml
+MiniCPM3-4B.yaml
 Qwen3-ASR-1.7B.yaml


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adapts the MiniCPM3-4B model to run on Ascend NPU via `vllm-ascend`. It adds the end-to-end test configuration, model adaptation tutorial, and a skill record documenting lessons learned and troubleshooting tips. It also registers the model in the nightly and PR-only accuracy test groups, and adds the model to the mkdocs navigation.

Fixes #9079
Fixes #10676

### Does this PR introduce any user-facing change?
No user-facing code changes are introduced. This PR only adds documentation, test configurations, and model registration.

### How was this patch tested?
Verified on Atlas A2 (910B3) with both eager and graph (ACLGraph) modes. REST API serving and GSM8K 5-shot accuracy (~77% strict-match, ~78% flexible-extract) have been verified.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
