### PR TITLE
[BugFix][GDN] Fix Qwen3.x crashes on single-token request

### DIFF
--- a/tests/ut/ops/test_gdn_attn_builder.py
+++ b/tests/ut/ops/test_gdn_attn_builder.py
@@ -15,6 +15,7 @@ from vllm.v1.kv_cache_interface import MambaSpec
 from vllm_ascend.ops import gdn_attn_builder as ascend_gdn_attn_builder
 from vllm_ascend.ops.gdn import (
     AscendGatedDeltaNetAttention,
+    get_causal_conv1d_update_host_args,
     get_non_spec_causal_conv1d_host_args,
     get_non_spec_chunked_prefill_meta,
     to_int64_tuple,
@@ -423,6 +424,38 @@ def test_get_non_spec_causal_conv1d_host_args_requires_runtime_metadata():
 
     with pytest.raises(RuntimeError, match="has_initial_state"):
         get_non_spec_causal_conv1d_host_args(attn_metadata)
+
+
+def test_get_causal_conv1d_update_host_args_accepts_single_token_prefill_fallback_meta():
+    attn_metadata = SimpleNamespace(
+        non_spec_decode_fallback_meta=None,
+        non_spec_prefill_fallback_meta=SimpleNamespace(
+            causal_conv1d=SimpleNamespace(
+                query_start_loc_cpu=torch.tensor([0, 1, 2], dtype=torch.int32),
+                cache_indices_cpu=torch.tensor([3, 9], dtype=torch.int32),
+            ),
+        ),
+    )
+
+    assert get_causal_conv1d_update_host_args(attn_metadata) == (
+        (0, 1, 2),
+        (3, 9),
+    )
+
+
+def test_get_causal_conv1d_update_host_args_rejects_multi_token_prefill_fallback_meta():
+    attn_metadata = SimpleNamespace(
+        non_spec_decode_fallback_meta=None,
+        non_spec_prefill_fallback_meta=SimpleNamespace(
+            causal_conv1d=SimpleNamespace(
+                query_start_loc_cpu=torch.tensor([0, 2], dtype=torch.int32),
+                cache_indices_cpu=torch.tensor([3], dtype=torch.int32),
+            ),
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="non_spec_decode_fallback_meta"):
+        get_causal_conv1d_update_host_args(attn_metadata)
 
 
 def test_get_non_spec_chunked_prefill_meta_allows_missing_prefill_fallback_meta():

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -92,6 +92,10 @@ def get_causal_conv1d_update_host_args(attn_metadata) -> tuple[tuple[int, ...], 
             to_int64_tuple(causal_conv1d_meta.cache_indices_cpu),
         )
 
+    # A captured non-spec decode graph task can be replayed for a runtime
+    # single-token prefill batch. In that case decode fallback metadata is not
+    # attached, so reuse the prebuilt CPU-side prefill metadata instead of
+    # reading runtime NPU tensors and forcing device-to-host synchronization.
     fallback_meta = getattr(attn_metadata, "non_spec_prefill_fallback_meta", None)
     if fallback_meta is not None:
         causal_conv1d_meta = fallback_meta.causal_conv1d

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -84,11 +84,29 @@ def get_non_spec_causal_conv1d_host_args(attn_metadata) -> tuple[tuple[int, ...]
 
 
 def get_causal_conv1d_update_host_args(attn_metadata) -> tuple[tuple[int, ...], tuple[int, ...]]:
-    fallback_meta = _check_and_get_host_args(attn_metadata, "non_spec_decode_fallback_meta", "causal_conv1d")
-    causal_conv1d_meta = fallback_meta.causal_conv1d
-    return (
-        to_int64_tuple(causal_conv1d_meta.query_start_loc_cpu),
-        to_int64_tuple(causal_conv1d_meta.cache_indices_cpu),
+    fallback_meta = getattr(attn_metadata, "non_spec_decode_fallback_meta", None)
+    if fallback_meta is not None:
+        causal_conv1d_meta = fallback_meta.causal_conv1d
+        return (
+            to_int64_tuple(causal_conv1d_meta.query_start_loc_cpu),
+            to_int64_tuple(causal_conv1d_meta.cache_indices_cpu),
+        )
+
+    fallback_meta = getattr(attn_metadata, "non_spec_prefill_fallback_meta", None)
+    if fallback_meta is not None:
+        causal_conv1d_meta = fallback_meta.causal_conv1d
+        query_start_loc_host = to_int64_tuple(causal_conv1d_meta.query_start_loc_cpu)
+        is_single_token_prefill = len(query_start_loc_host) > 1 and all(
+            end - start == 1 for start, end in zip(query_start_loc_host, query_start_loc_host[1:])
+        )
+        if is_single_token_prefill:
+            return (
+                query_start_loc_host,
+                to_int64_tuple(causal_conv1d_meta.cache_indices_cpu),
+            )
+
+    raise RuntimeError(
+        "Expected attn_metadata.non_spec_decode_fallback_meta.causal_conv1d for Ascend GDN fallback path."
     )
 
 


### PR DESCRIPTION
### What this PR does / why we need it?
Fix https://github.com/vllm-project/vllm-ascend/issues/11563:
- Allow GDN conv1d graph updates to use runtime non-spec metadata when decode fallback metadata is absent and every query contains one token.
- Keep multi-token runtime metadata rejected for the decode update path and add regression coverage for both cases.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- test with one-token request
```bash
curl --location --request POST 'http://localhost:8000/v1/completions' \
    --header 'Content-Type: application/json' \
    --data '{ 
    "model": "Qwen3.5-27B", 
    "prompt": "1", 
    "temperature": 0.1,
    "stream": false,
    "max_tokens": 100
}'
```
- Add test cases, then run pytest command:
```bash
pytest /vllm-workspace/vllm-ascend/tests/ut/ops/test_gdn_attn_builder.py
```

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
