### PR TITLE
[Doc][BugFix] Fix dark mode logo path

### DIFF
--- a/docs/overrides/partials/logo.html
+++ b/docs/overrides/partials/logo.html
@@ -9,7 +9,7 @@
 -#}
 {% if config.theme.logo %}
   <img class="md-logo__img md-logo__img--light" src="{{ config.theme.logo | url }}#only-light" alt="logo">
-  <img class="md-logo__img md-logo__img--dark" src="logos/vllm-ascend-logo-text-dark.png#only-dark" alt="logo">
+  <img class="md-logo__img md-logo__img--dark" src="{{ 'logos/vllm-ascend-logo-text-dark.png' | url }}#only-dark" alt="logo">
 {% else %}
   {% set icon = config.theme.icon.logo or "material/library" %}
   {% include ".icons/" ~ icon ~ ".svg" %}


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes the dark mode logo path in the documentation by wrapping the static asset path with the `url` filter. This ensures the dark mode logo is correctly resolved relative to the page's URL.

Fixes #11569 

### Does this PR introduce _any_ user-facing change?

Yes, it fixes the broken dark mode logo image in the documentation.

### How was this patch tested?

Verified that the dark mode logo displays correctly.

Result:
<img width="1800" height="1088" alt="image" src="https://github.com/user-attachments/assets/8860c3e6-e314-4649-965a-54777b2894d2" />


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
