### PR TITLE
[BugFix] Fix all2all in MXFP4 scenario

### DIFF
--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -493,8 +493,8 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         ) = self._dispatch_preprocess(hidden_states, topk_ids)
 
         dynamic_scale_after_all2all = None
+        dst_type = token_dispatch_input.quant.get_dst_type
         if with_quant:
-            dst_type = token_dispatch_input.quant.get_dst_type
             permutated_local_input_tokens, dynamic_scale = DeviceOperator.npu_dynamic_quant(
                 permutated_local_input_tokens, act_quant_type=dst_type, use_mxfp_quant=use_mxfp_quant
             )
@@ -517,6 +517,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
                 dynamic_scale_after_all2all,
                 global_input_tokens_local_experts_indices,
                 with_quant,
+                dst_type,
                 scale_type,
             )
         )
@@ -638,6 +639,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         dynamic_scale_after_all2all,
         global_input_tokens_local_experts_indices,
         with_quant,
+        dst_type,
         scale_type,
     ):
         # Early return if no local experts or no tokens
@@ -664,6 +666,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
                     expert_tokens_num_type=1,
                     expert_tokens_num_flag=True,
                     active_expert_range=[0, self.num_local_experts],
+                    x_dtype=dst_type,
                 )
             )
             dynamic_scale_after_all2all = routed_scale.view(torch.uint8)


### PR DESCRIPTION
### What this PR does / why we need it?
  Fix the all-to-all MoE token dispatch path where npu_moe_init_routing_v2 was missing the x_dtype argument. This caused incorrect behavior in the MXFP4 quantization scenario, since operation init_routing can not get the correct data type.

  Changes:
  - Move dst_type = token_dispatch_input.quant.get_dst_type outside the if with_quant: branch so it is always available.
  - Pass dst_type through to _dispatch_postprocess and supply it as x_dtype to npu_moe_init_routing_v2.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
