### PR TITLE
[feature] Support Gemma4 ModelSlim quantization

### DIFF
--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -17,6 +17,7 @@ from vllm_ascend.quantization.modelslim_config import (
     MODELSLIM_CONFIG_FILENAME,
     AscendModelSlimConfig,
     get_linear_quant_type,
+    get_packed_modules_mapping,
 )
 from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD, vllm_version_is
 
@@ -318,6 +319,24 @@ class TestAscendModelSlimConfig(TestBase):
         self.assertIn("model.layers.0.weight", config.quant_description)
         self.assertEqual(config.quant_description["model.layers.0.weight"], "INT8")
 
+    def test_apply_extra_quant_adaptations_does_not_add_global_moe_expert_alias(self):
+        config = AscendModelSlimConfig(
+            {
+                "model.layers.0.experts.0.gate_proj.weight": "INT8",
+            }
+        )
+
+        self.assertNotIn("model.layers.0.moe.experts.0.gate_proj.weight", config.quant_description)
+
+    def test_apply_extra_quant_adaptations_keeps_existing_moe_expert_keys(self):
+        config = AscendModelSlimConfig(
+            {
+                "model.layers.0.moe.experts.0.gate_proj.weight": "INT8",
+            }
+        )
+
+        self.assertEqual(config.quant_description["model.layers.0.moe.experts.0.gate_proj.weight"], "INT8")
+
 
 class TestApplyVllmMapper(TestBase):
     def test_apply_mapper_with_populated_quant_description(self):
@@ -378,6 +397,69 @@ class TestQuantPrefixMapper(TestBase):
                 )
 
                 self.assertEqual(prefix, expected)
+
+    def test_gemma4_moe_experts_prefix_maps_to_quant_description_keys(self):
+        quant_description = {
+            "language_model.model.layers.0.experts.0.gate_proj.weight": "W8A8_DYNAMIC",
+            "language_model.model.layers.0.experts.0.up_proj.weight": "W8A8_DYNAMIC",
+            "language_model.model.layers.0.experts.0.down_proj.weight": "W8A8_DYNAMIC",
+        }
+        for model_type in ("gemma4", "gemma4_text"):
+            with self.subTest(model_type=model_type):
+                config = AscendModelSlimConfig(quant_description)
+
+                prefix = config.quant_prefix_mapper(
+                    model_type,
+                    "language_model.model.layers.0.moe.experts",
+                )
+                packed_mapping = get_packed_modules_mapping(model_type)
+
+                self.assertEqual(prefix, "language_model.model.layers.0.experts")
+                self.assertEqual(get_linear_quant_type(quant_description, prefix, packed_mapping), "W8A8_DYNAMIC")
+                self.assertFalse(config.is_layer_skipped_ascend(prefix, packed_mapping))
+
+    def test_gemma4_packed_modules_mapping_covers_attention_mlp_and_moe(self):
+        expected_mapping = {
+            "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+            "gate_up_proj": ["gate_proj", "up_proj"],
+            "experts": ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
+        }
+        for model_type in ("gemma4", "gemma4_text"):
+            with self.subTest(model_type=model_type):
+                self.assertEqual(get_packed_modules_mapping(model_type), expected_mapping)
+
+    def test_gemma4_moe_experts_float_shards_are_skipped_together(self):
+        quant_description = {
+            "language_model.model.layers.0.experts.0.gate_proj.weight": "FLOAT",
+            "language_model.model.layers.0.experts.0.up_proj.weight": "FLOAT",
+            "language_model.model.layers.0.experts.0.down_proj.weight": "FLOAT",
+        }
+        config = AscendModelSlimConfig(quant_description)
+        prefix = config.quant_prefix_mapper("gemma4", "language_model.model.layers.0.moe.experts")
+
+        self.assertTrue(config.is_layer_skipped_ascend(prefix, get_packed_modules_mapping("gemma4")))
+
+    def test_gemma4_moe_experts_mixed_shards_still_raise(self):
+        quant_description = {
+            "language_model.model.layers.0.experts.0.gate_proj.weight": "FLOAT",
+            "language_model.model.layers.0.experts.0.up_proj.weight": "W8A8_DYNAMIC",
+            "language_model.model.layers.0.experts.0.down_proj.weight": "W8A8_DYNAMIC",
+        }
+        config = AscendModelSlimConfig(quant_description)
+        prefix = config.quant_prefix_mapper("gemma4", "language_model.model.layers.0.moe.experts")
+        packed_mapping = get_packed_modules_mapping("gemma4")
+
+        with self.assertRaises(ValueError):
+            get_linear_quant_type(quant_description, prefix, packed_mapping)
+        with self.assertRaises(ValueError):
+            config.is_layer_skipped_ascend(prefix, packed_mapping)
+
+    def test_non_gemma4_moe_experts_prefix_is_not_rewritten(self):
+        config = AscendModelSlimConfig()
+
+        prefix = config.quant_prefix_mapper("qwen3_5_moe", "model.layers.0.moe.experts")
+
+        self.assertEqual(prefix, "model.layers.0.moe.experts")
 
 
 class TestGetCacheScale(TestBase):

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -16,6 +16,7 @@ from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.quantization.modelslim_config import (
     MODELSLIM_CONFIG_FILENAME,
     AscendModelSlimConfig,
+    get_linear_quant_type,
 )
 from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD, vllm_version_is
 
@@ -208,6 +209,32 @@ class TestAscendModelSlimConfig(TestBase):
         config = AscendModelSlimConfig(bad_config)
         with self.assertRaises(ValueError):
             config.is_layer_skipped_ascend("fused_layer", fused_mapping)
+
+    def test_missing_k_eq_v_v_proj_shard_uses_present_shards(self):
+        prefix = "model.layers.5.self_attn.qkv_proj"
+        fused_mapping = {"qkv_proj": ["q_proj", "k_proj", "v_proj"]}
+        quant_description = {
+            "model.layers.5.self_attn.q_proj.weight": "W8A8_DYNAMIC",
+            "model.layers.5.self_attn.k_proj.weight": "W8A8_DYNAMIC",
+        }
+        config = AscendModelSlimConfig(quant_description)
+
+        self.assertEqual(get_linear_quant_type(quant_description, prefix, fused_mapping), "W8A8_DYNAMIC")
+        self.assertFalse(config.is_layer_skipped_ascend(prefix, fused_mapping))
+
+    def test_missing_required_packed_shard_still_raises(self):
+        prefix = "model.layers.5.self_attn.qkv_proj"
+        fused_mapping = {"qkv_proj": ["q_proj", "k_proj", "v_proj"]}
+        quant_description = {
+            "model.layers.5.self_attn.k_proj.weight": "W8A8_DYNAMIC",
+            "model.layers.5.self_attn.v_proj.weight": "W8A8_DYNAMIC",
+        }
+        config = AscendModelSlimConfig(quant_description)
+
+        with self.assertRaises(KeyError):
+            get_linear_quant_type(quant_description, prefix, fused_mapping)
+        with self.assertRaises(KeyError):
+            config.is_layer_skipped_ascend(prefix, fused_mapping)
 
     def test_init_with_default_config(self):
         config = AscendModelSlimConfig()

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -345,6 +345,19 @@ def get_packed_modules_mapping(model_type: str) -> dict[str, list[str]]:
     return packed_modules_model_mapping.get(model_type, {})
 
 
+def _is_missing_k_eq_v_shard(shard_key: str, quant_description: Mapping[str, Any]) -> bool:
+    """Return whether the missing shard matches Gemma4's k_eq_v layout.
+
+    k_eq_v layers do not have a dedicated v_proj entry because v_proj is
+    replicated from k_proj at load time. Keep q_proj/k_proj mandatory so other
+    malformed packed quant descriptions still fail as before.
+    """
+    if not shard_key.endswith(".v_proj.weight"):
+        return False
+    shard_prefix = shard_key[: -len("v_proj.weight")]
+    return f"{shard_prefix}q_proj.weight" in quant_description and f"{shard_prefix}k_proj.weight" in quant_description
+
+
 def get_linear_quant_type(
     quant_description: dict[str, Any], prefix: str, packed_modules_mapping: dict[str, Any]
 ) -> str | None:
@@ -365,7 +378,12 @@ def get_linear_quant_type(
             prefix.replace(proj_name, shard_proj_name) for shard_proj_name in packed_modules_mapping[proj_name]
         ]
         for shard_prefix in shard_prefixes:
-            shard_quant_type = quant_description[shard_prefix + ".weight"]
+            shard_key = shard_prefix + ".weight"
+            # Only Gemma4 k_eq_v is allowed to omit v_proj; other missing
+            # shards fall through to the original dictionary lookup below.
+            if shard_key not in quant_description and _is_missing_k_eq_v_shard(shard_key, quant_description):
+                continue
+            shard_quant_type = quant_description[shard_key]
 
             if quant_type is None:
                 quant_type = shard_quant_type
@@ -689,7 +707,14 @@ class AscendModelSlimConfig(QuantizationConfig):
 
             is_skipped = None
             for shard_prefix in shard_prefixes:
-                is_shard_skipped = self.quant_description[shard_prefix + ".weight"] == "FLOAT"
+                shard_key = shard_prefix + ".weight"
+                # Preserve the original failure behavior except for the known
+                # k_eq_v case where v_proj is replicated from k_proj.
+                if shard_key not in self.quant_description and _is_missing_k_eq_v_shard(
+                    shard_key, self.quant_description
+                ):
+                    continue
+                is_shard_skipped = self.quant_description[shard_key] == "FLOAT"
 
                 if is_skipped is None:
                     is_skipped = is_shard_skipped

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -185,6 +185,30 @@ packed_modules_model_mapping: dict[str, dict[str, list[str]]] = {
         ],
         "experts": ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
     },
+    "gemma4": {
+        "qkv_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
+        "experts": ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
+    },
+    "gemma4_text": {
+        "qkv_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
+        "experts": ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
+    },
     "glm4_moe_lite": {
         "gate_up_proj": ["gate_proj", "up_proj"],
         "experts": ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
@@ -328,6 +352,16 @@ QUANT_MODEL_SUBSTR_MAPPINGS = {
     # lookup matches the on-disk naming.
     "step3p5_mtp": {
         ".mtp_block.": ".",
+    },
+    # Gemma4 MoE renames ".experts." to ".moe.experts." in the vLLM module tree
+    # (gemma4.py weight mapper), but the ModelSlim quant description keeps the
+    # original ".experts." naming. Strip the ".moe" infix so the quant lookup
+    # matches the on-disk keys.
+    "gemma4": {
+        ".moe.experts": ".experts",
+    },
+    "gemma4_text": {
+        ".moe.experts": ".experts",
     },
 }
 

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -379,8 +379,8 @@ def get_packed_modules_mapping(model_type: str) -> dict[str, list[str]]:
     return packed_modules_model_mapping.get(model_type, {})
 
 
-def _is_missing_k_eq_v_shard(shard_key: str, quant_description: Mapping[str, Any]) -> bool:
-    """Return whether the missing shard matches Gemma4's k_eq_v layout.
+def _is_missing_v_shard(shard_key: str, quant_description: Mapping[str, Any]) -> bool:
+    """Return whether the missing shard is Gemma4's replicated v_proj.
 
     k_eq_v layers do not have a dedicated v_proj entry because v_proj is
     replicated from k_proj at load time. Keep q_proj/k_proj mandatory so other
@@ -415,7 +415,7 @@ def get_linear_quant_type(
             shard_key = shard_prefix + ".weight"
             # Only Gemma4 k_eq_v is allowed to omit v_proj; other missing
             # shards fall through to the original dictionary lookup below.
-            if shard_key not in quant_description and _is_missing_k_eq_v_shard(shard_key, quant_description):
+            if shard_key not in quant_description and _is_missing_v_shard(shard_key, quant_description):
                 continue
             shard_quant_type = quant_description[shard_key]
 
@@ -744,9 +744,7 @@ class AscendModelSlimConfig(QuantizationConfig):
                 shard_key = shard_prefix + ".weight"
                 # Preserve the original failure behavior except for the known
                 # k_eq_v case where v_proj is replicated from k_proj.
-                if shard_key not in self.quant_description and _is_missing_k_eq_v_shard(
-                    shard_key, self.quant_description
-                ):
+                if shard_key not in self.quant_description and _is_missing_v_shard(shard_key, self.quant_description):
                     continue
                 is_shard_skipped = self.quant_description[shard_key] == "FLOAT"
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds ModelSlim W8A8_DYNAMIC quantization support for Gemma4 / Gemma4 text models.

For Gemma4 full-attention `k_eq_v` layers, the ModelSlim quant description contains `q_proj` and `k_proj`, but does not contain a dedicated `v_proj` entry. The model loader duplicates `k_proj` into `v_proj` at load time, while the Ascend ModelSlim packed `qkv_proj` lookup previously required all `q_proj` / `k_proj` / `v_proj` quant entries to exist. As a result, loading a Gemma4 quantized checkpoint could fail with `KeyError` on the missing `v_proj.weight` quant description key.

This PR handles only that known missing-`v_proj` case when both `q_proj` and `k_proj` quant entries are present, so other malformed packed quant descriptions still keep the original failure behavior.

This PR also adds Gemma4-scoped ModelSlim mapping for MoE expert layers. vLLM routes the FusedMoE module through a `.moe.experts` prefix, while the ModelSlim quant description keeps the checkpoint-style `.experts` naming. The added prefix mapping is scoped to `gemma4` / `gemma4_text`, avoiding a global `.experts` rewrite that could affect other model types.

Related issue/RFC: N/A.

### Does this PR introduce _any_ user-facing change?

No. This only extends ModelSlim quantization config handling for Gemma4 quantized checkpoints. Existing non-Gemma4 logic is preserved, and missing packed shards still raise as before except for the Gemma4 `k_eq_v` missing-`v_proj` layout described above.

### How was this patch tested?

- `python3 -m ruff check vllm_ascend/quantization/modelslim_config.py tests/ut/quantization/test_modelslim_config.py`
- `python3 -m ruff format --check vllm_ascend/quantization/modelslim_config.py tests/ut/quantization/test_modelslim_config.py`
- `python3 -m py_compile vllm_ascend/quantization/modelslim_config.py tests/ut/quantization/test_modelslim_config.py`
- `git diff --check`

Unit coverage was added for:

- Gemma4 `k_eq_v` missing-`v_proj` handling.
- Preserving the existing error behavior for other missing packed shards.
- Gemma4 MoE expert prefix mapping.
- Keeping the MoE expert prefix adaptation scoped to Gemma4 / Gemma4 text.

Not run locally:

- `python3 -m pytest tests/ut/quantization/test_modelslim_config.py -q`, because the current local Python environment is missing `torch`.

Base references used during development:

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
