### PR TITLE
[BugFix][Ops] chunk_scaled_dot_kkt_fwd_kernel recompile issues

### DIFF
--- a/vllm_ascend/ops/triton/fla/chunk_scaled_dot_kkt.py
+++ b/vllm_ascend/ops/triton/fla/chunk_scaled_dot_kkt.py
@@ -23,7 +23,7 @@ from .utils import prepare_chunk_indices, safe_exp
         "USE_G": lambda args: args["g_cumsum"] is not None,
     }
 )
-@triton.jit(do_not_specialize=["T", "B"])
+@triton.jit(do_not_specialize=["T", "B", "bh_step", "task_num", "num_core"])
 def chunk_scaled_dot_kkt_fwd_kernel(
     k,
     beta,  # [H, B, T]

--- a/vllm_ascend/ops/triton/fla/chunk_scaled_dot_kkt.py
+++ b/vllm_ascend/ops/triton/fla/chunk_scaled_dot_kkt.py
@@ -33,6 +33,9 @@ def chunk_scaled_dot_kkt_fwd_kernel(
     chunk_indices,
     T,
     B,
+    bh_step,
+    task_num,
+    num_core,
     H: tl.constexpr,
     Hg: tl.constexpr,
     K: tl.constexpr,
@@ -40,9 +43,6 @@ def chunk_scaled_dot_kkt_fwd_kernel(
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
-    bh_step: tl.constexpr,
-    task_num: tl.constexpr,
-    num_core: tl.constexpr,
 ):
     bt_stride = B * T
     core_id = tl.program_id(0)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes recompilation issues in the `chunk_scaled_dot_kkt_fwd_kernel` Triton kernel. The parameters `bh_step`, `task_num`, and `num_core` were previously defined as `tl.constexpr`, which caused Triton to recompile the kernel whenever these values changed. By changing them to regular arguments, we avoid recompilation when these values change.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
