### PR TITLE
[BugFix] mega moe max token default value fix

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -294,8 +294,8 @@ class AscendConfig:
         # are dropped and skipped from computation, degrading accuracy.
         # Do not set this too large: workspace memory scales linearly with this value, which matters
         # especially under long-context scenarios where the operator should not hold too much memory.
-        # Default 65536.
-        self.mega_moe_max_tokens = additional_config.get("mega_moe_max_tokens", 65536)
+        # Default 131072.
+        self.mega_moe_max_tokens = additional_config.get("mega_moe_max_tokens", 131072)
         if not isinstance(self.mega_moe_max_tokens, int):
             raise ValueError(
                 f"mega_moe_max_tokens must be an integer, got {type(self.mega_moe_max_tokens).__name__}: "


### PR DESCRIPTION
### What this PR does / why we need it?
Change the default value of mega_moe_max_tokens from 65536 to 131072.

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
Configurable parameter, no extra testing needed.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
