### PR TITLE
[Performance][Attention] Optimize PCP FA restore and output merge

### DIFF
--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -221,6 +221,7 @@ class AscendAttentionCPMetadataBuilder(AscendAttentionMetadataBuilder):
                 pcp_fa_query_idx=common_long_seq_metadata.pcp_fa_query_idx,
                 pcp_padded_tokens_fla=common_long_seq_metadata.pcp_padded_tokens_fla,
                 pcp_enter_fa_restore_idx=common_long_seq_metadata.pcp_enter_fa_restore_idx,
+                pcp_fa_padding_restore_idx=common_long_seq_metadata.pcp_fa_padding_restore_idx,
                 max_num_tokens_across_pcp=common_long_seq_metadata.max_num_tokens_across_pcp,
                 total_num_scheduled_tokens=common_long_seq_metadata.total_num_scheduled_tokens,
             )
@@ -894,18 +895,18 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
             attn_metadata.prefill.pcp_metadata.pcp_enter_fa_restore_idx if attn_metadata.prefill.pcp_metadata else None
         )
         actual_qkv = torch.index_select(all_qkv, 0, pcp_enter_fa_restore_idx)
-        qkv_fa_padding_workspace = query.new_empty(
-            (num_actual_tokens_pcp_padded, (self.num_heads + 2 * self.num_kv_heads) * self.head_size)
-        )
-
         decode_offset = attn_metadata.num_decode_tokens * self.pcp_size
-        qkv_fa_padding_workspace[:decode_offset] = actual_qkv[:decode_offset]
-
-        pcp_unpad_mask = attn_metadata.prefill.pcp_metadata.pcp_unpad_mask[
-            attn_metadata.num_decode_tokens * self.pcp_size :
-        ]
-        qkv_fa_padding_workspace[decode_offset:][pcp_unpad_mask] = actual_qkv[decode_offset:]
-        qkv_fa_padding_workspace[decode_offset:][~pcp_unpad_mask] = 0
+        pcp_fa_padding_restore_idx = attn_metadata.prefill.pcp_metadata.pcp_fa_padding_restore_idx
+        if actual_qkv.shape[0] == num_actual_tokens_pcp_padded:
+            qkv_fa_padding_workspace = actual_qkv[:num_actual_tokens_pcp_padded]
+        else:
+            assert pcp_fa_padding_restore_idx is not None
+            actual_qkv_with_zero = F.pad(actual_qkv, pad=(0, 0, 0, 1), mode="constant", value=0)
+            qkv_fa_padding_workspace = torch.index_select(
+                actual_qkv_with_zero,
+                0,
+                pcp_fa_padding_restore_idx,
+            )
 
         q, k, v = qkv_fa_padding_workspace.split(
             [

--- a/vllm_ascend/attention/context_parallel/common_cp.py
+++ b/vllm_ascend/attention/context_parallel/common_cp.py
@@ -38,6 +38,7 @@ class AscendPCPMetadata:
     pcp_fa_query_idx: torch.Tensor = None
     pcp_padded_tokens_fla: int = 0
     pcp_enter_fa_restore_idx: torch.Tensor = None
+    pcp_fa_padding_restore_idx: torch.Tensor = None
     block_table_cp: torch.Tensor = None
     valid_block_ids: torch.Tensor = None
     prefill_q_cum_seqlens: torch.Tensor = None

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -230,6 +230,9 @@ class AscendPrefillContextParallelMetadata:
     # when entering from linear-attention to attention
     pcp_enter_fa_restore_idx: torch.Tensor = None
 
+    # restore the original FA padded layout without boolean-mask scatter
+    pcp_fa_padding_restore_idx: torch.Tensor = None
+
     # scatter the full sequence across all pcp ranks
     # when exiting from attention to linear-attention
     pcp_exit_fa_scatter_idx: torch.Tensor = None

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -157,11 +157,7 @@ def chunk_gated_delta_rule_fwd(
 
         if get_pcp_group().rank_in_group > 0:
             rerun_initial_state = initial_state.clone()
-            if cu_seqlens is not None:
-                _ns_lens = cu_seqlens[1:] - cu_seqlens[:-1]
-                prefill_seq_offset = int(((_ns_lens > 0) & (_ns_lens <= 1)).sum().item())
-            else:
-                prefill_seq_offset = num_decodes
+            prefill_seq_offset = actual_num_decodes
             prefill_slice = slice(prefill_seq_offset, final_state.shape[0])
             rerun_initial_state[prefill_slice] = updated_h_state[prefill_slice]
             h, v_new, _ = chunk_gated_delta_rule_fwd_h(

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -136,6 +136,9 @@ class PCPManager:
         self.pcp_enter_fa_restore_idx = torch.zeros(
             self.max_num_tokens + 2 * self.pcp_world_size * self.max_num_reqs, dtype=torch.int32, device=self.device
         )
+        self.pcp_fa_padding_restore_idx = torch.zeros(
+            self.max_num_tokens + 2 * self.pcp_world_size * self.max_num_reqs, dtype=torch.int32, device=self.device
+        )
         self.pcp_use_hybrid_attn = self.vllm_config.model_config.hf_config.model_type in (
             "qwen3_next",
             "qwen3_5",
@@ -177,6 +180,41 @@ class PCPManager:
             self.use_async_scheduling,
             self.pcp_use_hybrid_attn,
         )
+
+    @staticmethod
+    def _build_fa_padding_restore_idx(
+        pcp_unpad_mask: np.ndarray,
+        decode_offset: int,
+        actual_qkv_len: int,
+    ) -> np.ndarray | None:
+        target_len = pcp_unpad_mask.shape[0]
+        if actual_qkv_len > target_len:
+            raise ValueError(f"actual_qkv_len ({actual_qkv_len}) must not exceed FA padded length ({target_len}).")
+        if actual_qkv_len == target_len:
+            return None
+        if decode_offset > target_len or actual_qkv_len < decode_offset:
+            raise ValueError(
+                f"Invalid PCP restore layout: decode_offset={decode_offset}, "
+                f"actual_qkv_len={actual_qkv_len}, target_len={target_len}."
+            )
+
+        restore_idx = np.empty(target_len, dtype=np.int32)
+        restore_idx[:decode_offset] = np.arange(decode_offset, dtype=np.int32)
+
+        prefill_unpad_mask = pcp_unpad_mask[decode_offset:]
+        prefill_real_tokens = int(prefill_unpad_mask.sum())
+        expected_actual_qkv_len = decode_offset + prefill_real_tokens
+        if expected_actual_qkv_len != actual_qkv_len:
+            raise ValueError(f"PCP unpad mask expects {expected_actual_qkv_len} QKV rows, but got {actual_qkv_len}.")
+
+        prefill_restore_idx = restore_idx[decode_offset:]
+        prefill_restore_idx.fill(actual_qkv_len)
+        prefill_restore_idx[prefill_unpad_mask] = np.arange(
+            decode_offset,
+            actual_qkv_len,
+            dtype=np.int32,
+        )
+        return restore_idx
 
     def _get_cumsum_and_arange(
         self,
@@ -822,6 +860,17 @@ class PCPManager:
             self.pcp_enter_fa_restore_idx[: pcp_enter_fa_restore_idx.shape[0]].copy_(
                 pcp_enter_fa_restore_idx.long(), non_blocking=True
             )
+            pcp_unpad_mask = self.pcp_unpad_mask_cpu[: self.pcp_padded_tokens_length]
+            pcp_fa_padding_restore_idx = self._build_fa_padding_restore_idx(
+                pcp_unpad_mask,
+                self.num_decode_tokens * self.pcp_world_size,
+                pcp_enter_fa_restore_idx.shape[0],
+            )
+            if pcp_fa_padding_restore_idx is not None:
+                self.pcp_fa_padding_restore_idx[: pcp_fa_padding_restore_idx.shape[0]].copy_(
+                    torch.from_numpy(pcp_fa_padding_restore_idx),
+                    non_blocking=True,
+                )
 
             if self.num_reqs > self.num_decode_reqs:
                 all_positions_prefill = [
@@ -1315,18 +1364,27 @@ class PCPManager:
                     long_seq_metadata.pcp_fa_query_idx = self.pcp_fa_query_idx[
                         : num_actual_tokens_pcp_padded // self.pcp_world_size - self.num_decode_tokens
                     ]
-                    long_seq_metadata.pcp_enter_fa_restore_idx = self.pcp_enter_fa_restore_idx[
-                        : pcp_unpad_mask.sum() + self.num_decode_tokens * (self.pcp_world_size - 1)
-                    ]
+                    actual_qkv_len = int(pcp_unpad_mask.sum()) + self.num_decode_tokens * (self.pcp_world_size - 1)
+                    long_seq_metadata.pcp_enter_fa_restore_idx = self.pcp_enter_fa_restore_idx[:actual_qkv_len]
+                    if actual_qkv_len < num_actual_tokens_pcp_padded:
+                        long_seq_metadata.pcp_fa_padding_restore_idx = self.pcp_fa_padding_restore_idx[
+                            :num_actual_tokens_pcp_padded
+                        ]
+                    else:
+                        long_seq_metadata.pcp_fa_padding_restore_idx = None
                     if logger.isEnabledFor(logging.DEBUG):
                         logger.debug(
                             "[PCP][DFX] long_seq_metadata reorder idx: "
                             "pcp_allgather_restore_idx=%s, "
                             "pcp_exit_fa_scatter_idx=%s, "
-                            "pcp_enter_fa_restore_idx=%s",
+                            "pcp_enter_fa_restore_idx=%s, "
+                            "pcp_fa_padding_restore_idx=%s",
                             long_seq_metadata.pcp_allgather_restore_idx.detach().cpu().tolist(),
                             long_seq_metadata.pcp_exit_fa_scatter_idx.detach().cpu().tolist(),
                             long_seq_metadata.pcp_enter_fa_restore_idx.detach().cpu().tolist(),
+                            long_seq_metadata.pcp_fa_padding_restore_idx.detach().cpu().tolist()
+                            if long_seq_metadata.pcp_fa_padding_restore_idx is not None
+                            else None,
                         )
                     long_seq_metadata.max_num_tokens_across_pcp = self.max_num_tokens_across_pcp
                     long_seq_metadata.total_num_scheduled_tokens = self.total_num_scheduled_tokens

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -137,7 +137,9 @@ class PCPManager:
             self.max_num_tokens + 2 * self.pcp_world_size * self.max_num_reqs, dtype=torch.int32, device=self.device
         )
         self.pcp_fa_padding_restore_idx = torch.zeros(
-            self.max_num_tokens + 2 * self.pcp_world_size * self.max_num_reqs, dtype=torch.int32, device=self.device
+            self.max_num_tokens * self.pcp_world_size + 2 * self.pcp_world_size * self.max_num_reqs,
+            dtype=torch.int32,
+            device=self.device,
         )
         self.pcp_use_hybrid_attn = self.vllm_config.model_config.hf_config.model_type in (
             "qwen3_next",


### PR DESCRIPTION
### What this PR does / why we need it?

This PR optimizes the PCP hybrid attention path:

- Builds and passes `pcp_fa_padding_restore_idx` so the FA QKV restore path can use `index_select` with a zero-padding row instead of boolean scatter into a workspace.
- Fixes PCP FA padding calculation for improved memory management.

These changes reduce restore overhead in PCP attention while keeping the behavior unchanged.

### Does this PR introduce _any_ user-facing change?

No. This is an internal performance optimization for PCP attention.

### How was this patch tested?

- Qwen3.5-35B-A3B-w8a8-org, A3, Tp=2, PCP=2, EP=true

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
