### PR TITLE
Revert "[BugFix] Fix static_forward_context cleanup and MTP draft loading"

### DIFF
--- a/tests/ut/model_loader/netloader/test_netloader.py
+++ b/tests/ut/model_loader/netloader/test_netloader.py
@@ -39,7 +39,6 @@ class DummyVllmConfig:
     parallel_config = DummyParallelConfig()
     additional_config = None
     quant_config = None
-    speculative_config: object | None = None
 
 
 class DummyModelConfig:
@@ -134,30 +133,6 @@ def test_init_with_invalid_config(monkeypatch):
     assert loader.output_prefix is None
 
 
-def test_clear_static_forward_context_clears_current_vllm_config(monkeypatch):
-    class DummyCompilationConfig:
-        def __init__(self):
-            self.static_forward_context = {}
-
-    class ConfigWithCompilation:
-        def __init__(self):
-            self.compilation_config = DummyCompilationConfig()
-
-    passed_config = ConfigWithCompilation()
-    current_config = ConfigWithCompilation()
-    passed_config.compilation_config.static_forward_context["passed.layer"] = object()
-    current_config.compilation_config.static_forward_context["current.layer"] = object()
-    monkeypatch.setattr(
-        "vllm_ascend.model_loader.netloader.netloader.get_current_vllm_config",
-        lambda: current_config,
-    )
-
-    ModelNetLoaderElastic._clear_static_forward_context(passed_config)
-
-    assert passed_config.compilation_config.static_forward_context == {}
-    assert current_config.compilation_config.static_forward_context == {}
-
-
 @patch("vllm_ascend.model_loader.netloader.netloader.logger")
 def test_load_model_elastic_success(mock_logger, monkeypatch, tmp_path):
     monkeypatch.setattr("torch.distributed.get_rank", lambda: 0)
@@ -245,100 +220,6 @@ def _patch_loader_common(monkeypatch):
 
 
 @patch("vllm_ascend.model_loader.netloader.netloader.logger")
-def test_target_model_waits_for_all_netloader_ranks_before_draft(mock_logger, monkeypatch):
-    dummy_model = _patch_loader_common(monkeypatch)
-    monkeypatch.setattr("vllm_ascend.model_loader.netloader.netloader.elastic_load", lambda **kwargs: dummy_model)
-
-    class DummyElasticServer:
-        def __init__(*a, **k):
-            pass
-
-        def start(self):
-            pass
-
-    barrier_calls = []
-    monkeypatch.setattr("vllm_ascend.model_loader.netloader.netloader.ElasticServer", DummyElasticServer)
-    monkeypatch.setattr("torch.distributed.is_available", lambda: True)
-    monkeypatch.setattr("torch.distributed.is_initialized", lambda: True)
-    monkeypatch.setattr("torch.distributed.barrier", lambda: barrier_calls.append("barrier"))
-
-    extra = {
-        "SOURCE": [{"device_id": 0, "sources": ["127.0.0.1:5000"]}],
-        "MODEL": "dummy-model",
-        "LISTEN_PORT": 5555,
-        "INT8_CACHE": "dram",
-    }
-    loader = make_loader_with_config(extra)
-    vllm_config = DummyVllmConfig()
-    vllm_config.speculative_config = object()
-    loader.load_model(vllm_config, DummyModelConfig())
-
-    assert barrier_calls == ["barrier"]
-
-
-@patch("vllm_ascend.model_loader.netloader.netloader.logger")
-def test_failed_target_model_participates_in_barrier_before_error(mock_logger, monkeypatch):
-    _patch_loader_common(monkeypatch)
-    monkeypatch.setattr("vllm_ascend.model_loader.netloader.netloader.elastic_load", lambda **kwargs: None)
-    monkeypatch.setattr(
-        "vllm_ascend.model_loader.netloader.netloader.revert_to_default",
-        lambda *args, **kwargs: (None, False),
-    )
-
-    barrier_calls = []
-    monkeypatch.setattr("torch.distributed.is_available", lambda: True)
-    monkeypatch.setattr("torch.distributed.is_initialized", lambda: True)
-    monkeypatch.setattr("torch.distributed.barrier", lambda: barrier_calls.append("barrier"))
-
-    extra = {
-        "SOURCE": [{"device_id": 0, "sources": ["127.0.0.1:5000"]}],
-        "MODEL": "dummy-model",
-        "LISTEN_PORT": 5555,
-        "INT8_CACHE": "dram",
-    }
-    loader = make_loader_with_config(extra)
-    vllm_config = DummyVllmConfig()
-    vllm_config.speculative_config = object()
-
-    with pytest.raises(RuntimeError, match="NetLoader elastic loads model fails"):
-        loader.load_model(vllm_config, DummyModelConfig())
-
-    assert barrier_calls == ["barrier"]
-
-
-@patch("vllm_ascend.model_loader.netloader.netloader.logger")
-def test_draft_model_does_not_wait_for_target_netloader_barrier(mock_logger, monkeypatch):
-    dummy_model = _patch_loader_common(monkeypatch)
-    monkeypatch.setattr("vllm_ascend.model_loader.netloader.netloader.elastic_load", lambda **kwargs: dummy_model)
-
-    class DummyElasticServer:
-        def __init__(*a, **k):
-            pass
-
-        def start(self):
-            pass
-
-    barrier_calls = []
-    monkeypatch.setattr("vllm_ascend.model_loader.netloader.netloader.ElasticServer", DummyElasticServer)
-    monkeypatch.setattr("torch.distributed.is_available", lambda: True)
-    monkeypatch.setattr("torch.distributed.is_initialized", lambda: True)
-    monkeypatch.setattr("torch.distributed.barrier", lambda: barrier_calls.append("barrier"))
-
-    extra = {
-        "SOURCE": [{"device_id": 0, "sources": ["127.0.0.1:5000"]}],
-        "MODEL": "draft-model",
-        "LISTEN_PORT": 5555,
-        "INT8_CACHE": "dram",
-    }
-    loader = make_loader_with_config(extra)
-    vllm_config = DummyVllmConfig()
-    vllm_config.speculative_config = object()
-    loader.load_model(vllm_config, DummyDraftModelConfig())
-
-    assert barrier_calls == []
-
-
-@patch("vllm_ascend.model_loader.netloader.netloader.logger")
 def test_load_draft_model_elastic_success(mock_logger, monkeypatch, tmp_path):
     dummy_model = _patch_loader_common(monkeypatch)
     monkeypatch.setattr("vllm_ascend.model_loader.netloader.netloader.elastic_load", lambda **kwargs: dummy_model)
@@ -348,7 +229,6 @@ def test_load_draft_model_elastic_success(mock_logger, monkeypatch, tmp_path):
     class DummyElasticServer:
         def __init__(self, *args, **kwargs):
             elastic_server_instances.append(self)
-            self.int8_cache = args[7]
             self.group_name = kwargs.get("group_name")
 
         def start(self):
@@ -368,39 +248,8 @@ def test_load_draft_model_elastic_success(mock_logger, monkeypatch, tmp_path):
 
     assert isinstance(result, nn.Module)
     assert loader._draft_elastic_server is elastic_server_instances[0]
-    assert loader._draft_elastic_server.int8_cache == "no"
     assert loader._draft_elastic_server.group_name == "netloader_draft"
     assert not (tmp_path / "output_0.txt").exists()
-
-
-@patch("vllm_ascend.model_loader.netloader.netloader.logger")
-def test_load_draft_model_uses_hbm_when_int8_cache_is_dram(mock_logger, monkeypatch):
-    dummy_model = _patch_loader_common(monkeypatch)
-    monkeypatch.setattr("vllm_ascend.model_loader.netloader.netloader.elastic_load", lambda **kwargs: dummy_model)
-
-    captured = {}
-
-    class DummyElasticServer:
-        def __init__(self, *args, **kwargs):
-            captured["int8_cache"] = args[7]
-            captured["group_name"] = kwargs.get("group_name")
-
-        def start(self):
-            pass
-
-    monkeypatch.setattr("vllm_ascend.model_loader.netloader.netloader.ElasticServer", DummyElasticServer)
-
-    extra = {
-        "SOURCE": [{"device_id": 0, "sources": ["127.0.0.1:5000"]}],
-        "MODEL": "draft-model",
-        "LISTEN_PORT": 5555,
-        "INT8_CACHE": "dram",
-    }
-    loader = make_loader_with_config(extra)
-    loader.load_model(DummyVllmConfig(), DummyDraftModelConfig())
-
-    assert captured["int8_cache"] == "hbm"
-    assert captured["group_name"] == "netloader_draft"
 
 
 @patch("vllm_ascend.model_loader.netloader.netloader.logger")

--- a/vllm_ascend/model_loader/netloader/netloader.py
+++ b/vllm_ascend/model_loader/netloader/netloader.py
@@ -35,12 +35,6 @@ from .utils import find_free_port, is_valid_path_prefix
 
 DRAFT_PORT_OFFSET = 10000
 
-try:
-    # Older vLLM versions may not expose the current-config accessor.
-    from vllm.config import get_current_vllm_config
-except ImportError:
-    get_current_vllm_config = None
-
 
 @register_model_loader("netloader")
 class ModelNetLoaderElastic(BaseModelLoader):
@@ -141,61 +135,6 @@ class ModelNetLoaderElastic(BaseModelLoader):
     def _is_draft_model(model_config: ModelConfig) -> bool:
         """Check whether the model_config corresponds to a draft model for speculative decoding."""
         return getattr(model_config, "runner_type", None) == "draft"
-
-    @staticmethod
-    def _sync_target_netloader_before_draft(vllm_config: VllmConfig) -> None:
-        if getattr(vllm_config, "speculative_config", None) is None:
-            return
-        if not torch.distributed.is_available() or not torch.distributed.is_initialized():
-            return
-
-        logger.info("Waiting for all target netloader ranks before loading draft model")
-        barrier_start = time.perf_counter()
-        torch.distributed.barrier()
-        logger.info(
-            "Target netloader barrier before draft model time: %s",
-            time.perf_counter() - barrier_start,
-        )
-
-    @staticmethod
-    def _get_static_forward_context(vllm_config: VllmConfig):
-        compilation_config = getattr(vllm_config, "compilation_config", None)
-        static_forward_context = getattr(compilation_config, "static_forward_context", None)
-        if static_forward_context is None or not hasattr(static_forward_context, "clear"):
-            return None
-        return static_forward_context
-
-    @staticmethod
-    def _clear_static_forward_context(vllm_config: VllmConfig) -> None:
-        """Clear static layer registrations before rebuilding the model on fallback."""
-        candidates = [("vllm_config", vllm_config)]
-        if get_current_vllm_config is not None:
-            try:
-                candidates.append(("current_vllm_config", get_current_vllm_config()))
-            except Exception as e:
-                logger.debug("Failed to get current vLLM config while clearing static context: %s", e)
-
-        cleared_contexts = []
-        seen_context_ids = set()
-        for source, config in candidates:
-            static_forward_context = ModelNetLoaderElastic._get_static_forward_context(config)
-            if static_forward_context is None:
-                continue
-
-            context_id = id(static_forward_context)
-            if context_id in seen_context_ids:
-                continue
-            seen_context_ids.add(context_id)
-
-            try:
-                context_size = str(len(static_forward_context))
-            except TypeError:
-                context_size = "unknown"
-            static_forward_context.clear()
-            cleared_contexts.append(f"{source}:{context_size}")
-
-        if cleared_contexts:
-            logger.info("Cleared static_forward_context before fallback: %s", cleared_contexts)
 
     def load_model(self, vllm_config: VllmConfig, model_config: ModelConfig, prefix: str = "") -> nn.Module:
         """
@@ -301,9 +240,6 @@ class ModelNetLoaderElastic(BaseModelLoader):
                         logger.info("Empty CUDA cache")
                         torch.cuda.empty_cache()
 
-                    # Clear registrations from the failed initialize_model
-                    self._clear_static_forward_context(vllm_config)
-
                     model, need_process_weights_after_loading = self.revert_to_default(
                         model_config, vllm_config, device_config, prefix
                     )
@@ -357,7 +293,6 @@ class ModelNetLoaderElastic(BaseModelLoader):
                         logger.error("Unknown error: %s", e)
 
                 try:
-                    server_int8_cache = "hbm" if is_draft and self.int8_cache != "no" else self.int8_cache
                     elastic_server = ElasticServer(
                         driver_ip,
                         listen_port,
@@ -366,7 +301,7 @@ class ModelNetLoaderElastic(BaseModelLoader):
                         model_config.model,
                         parallel_config.tensor_parallel_size,
                         parallel_config.pipeline_parallel_size,
-                        server_int8_cache,
+                        self.int8_cache,
                         self.int8_cache_name,
                         group_name=group_name,
                     )
@@ -386,12 +321,9 @@ class ModelNetLoaderElastic(BaseModelLoader):
         if need_process_weights_after_loading:
             process_weights_after_loading(model, model_config, torch.device(device_config.device))
 
-        if not is_draft:
-            self._sync_target_netloader_before_draft(vllm_config)
-
         if model is None:
             logger.error("NetLoader elastic loads model fails")
-            raise RuntimeError("NetLoader elastic loads model fails")
+            return None
 
         return model.eval()
 


### PR DESCRIPTION
Reverts vllm-project/vllm-ascend#11491

#11491 breaks the ut:
```
  =================================== FAILURES ===================================
  ________ test_failed_target_model_participates_in_barrier_before_error _________
  
  obj = <module 'vllm_ascend.model_loader.netloader.netloader' from '/__w/vllm-ascend/vllm-ascend/vllm_ascend/model_loader/netloader/netloader.py'>
  name = 'revert_to_default', ann = 'vllm_ascend.model_loader.netloader.netloader'
  
      def annotated_getattr(obj: object, name: str, ann: str) -> object:
          try:
  >           obj = getattr(obj, name)
  E           AttributeError: module 'vllm_ascend.model_loader.netloader.netloader' has no attribute 'revert_to_default'
  
  /usr/local/python3.12.13/lib/python3.12/site-packages/_pytest/monkeypatch.py:90: AttributeError
  
  The above exception was the direct cause of the following exception:
  
  mock_logger = <MagicMock name='logger' id='140357720326608'>
  monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7fa7acd055e0>
  
      @patch("vllm_ascend.model_loader.netloader.netloader.logger")
      def test_failed_target_model_participates_in_barrier_before_error(mock_logger, monkeypatch):
          _patch_loader_common(monkeypatch)
          monkeypatch.setattr("vllm_ascend.model_loader.netloader.netloader.elastic_load", lambda **kwargs: None)
  >       monkeypatch.setattr(
              "vllm_ascend.model_loader.netloader.netloader.revert_to_default",
              lambda *args, **kwargs: (None, False),
          )
  
```
https://github.com/vllm-project/vllm-ascend/actions/runs/28868511976/job/85626004414?pr=11444


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
