### PR TITLE
[CI] Set PRE_COMMIT_HOME environment variable for pre-commit

### DIFF
--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -156,6 +156,7 @@ jobs:
 
       - name: Run pre-commit
         env:
+          PRE_COMMIT_HOME: /tmp/pre-commit-cache
           PRE_COMMIT_COLOR: always
           FORCE_COLOR: "1"
           TERM: xterm-256color


### PR DESCRIPTION

  ### What this PR does / why we need it?
  
  Fixes an intermittent CI failure in the `lint-and-select-tests` job where the `Run pre-commit` step fails with errors like:
  
  FileNotFoundError: [Errno 2] No such file or directory:
    '.../linux64-s390x/no-asm/include'
  
  InvalidManifestError:
    =====> .../repo2jwlna9l/.pre-commit-hooks.yaml is not a file
  
  **Root Cause:** `/root/.cache/pre-commit/` is mounted from a shared NFS PVC (`vllm-project-hk001`, SFS Turbo). Multiple runner pods within the `vllm-project` namespace run pre-commit concurrently. Pre-commit uses `fcntl.flock` on `/root/.cache/pre-commit/.lock` to serialize hook environment installations, but
  `flock` does not work across NFS clients. This allows concurrent writes to the same hook environment directory (e.g., `repo2jwlna9l/node_env-default/` for markdownlint-cli), corrupting `nodeenv`'s `copytree` output.
  
  **Fix:** Set `PRE_COMMIT_HOME=/tmp/pre-commit-cache` to redirect the pre-commit cache to a pod-local tmpfs, isolating each pod's cache and eliminating the cross-pod race condition. The trade-off is ~30s additional hook environment installation time per run (acceptable for a CI lint job), in exchange for
  deterministic results.
  
  ### Does this PR introduce _any_ user-facing change?
  
  No.

  ### How was this patch tested?
  
  - Confirmed the shared PVC configuration by inspecting the EphemeralRunner pod spec:
    ```yaml
    volumeMounts:
      - mountPath: /root/.cache
        name: shared-volume
    volumes:
      - name: shared-volume
        persistentVolumeClaim:
          claimName: vllm-project-hk001
  
  - Confirmed flock unreliability on NFS by examining the shared pre-commit.log, which captured a InvalidManifestError caused by concurrent manifest reads/writes (/root/.cache/pre-commit/pre-commit.log on the shared volume).
  - Verified that different CI runs on different pods hit different missing files (e.g., linux64-s390x/no-asm/include vs .pre-commit-hooks.yaml), consistent with race-condition timing rather than a deterministic code bug.
  - The fix will be validated by the E2E workflow passing consistently after merge.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
