### PR TITLE
[v0.23.0][Feature][Ops] Increase MAX_MTP from 8 to 16 for recurrent_gated_delta_rule

### DIFF
--- a/csrc/attention/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.cpp
+++ b/csrc/attention/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.cpp
@@ -49,7 +49,7 @@ const size_t DIM_1 = 1;
 const size_t DIM_2 = 2;
 const size_t DIM_3 = 3;
 
-const size_t MAX_MTP = 8;
+const size_t MAX_MTP = 16;
 
 template <typename T1, typename T2>
 static T1 CeilDiv(T1 a, T2 b)

--- a/csrc/attention/recurrent_gated_delta_rule/op_kernel/arch35/recurrent_gated_delta_rule.h
+++ b/csrc/attention/recurrent_gated_delta_rule/op_kernel/arch35/recurrent_gated_delta_rule.h
@@ -25,7 +25,7 @@ using namespace AscendC;
 using namespace AscendC::MicroAPI;
 constexpr uint64_t BUFFER_NUM = 1;
 constexpr uint32_t MAX_OUT_BUFFER_NUM = 2;
-constexpr uint64_t MAX_MTP = 8;
+constexpr uint64_t MAX_MTP = 16;
 constexpr uint64_t BF16_NUM_PER_BLOCK = 16;
 constexpr uint64_t FP32_NUM_PER_BLOCK = 8;
 constexpr uint32_t REPEAT_LENTH = 64; // 256Byte for float

--- a/csrc/attention/recurrent_gated_delta_rule/op_kernel/arch35/recurrent_gated_delta_rule.h
+++ b/csrc/attention/recurrent_gated_delta_rule/op_kernel/arch35/recurrent_gated_delta_rule.h
@@ -116,7 +116,6 @@ public:
         uint32_t vSize = MAX_MTP * alignV_ * sizeof(float);
         uint32_t kSize = MAX_MTP * alignK_ * sizeof(float);
         uint32_t betaNumAlign = Ceil(MAX_MTP * NV_, BF16_NUM_PER_BLOCK) * BF16_NUM_PER_BLOCK;
-        uint32_t betaUbSize = betaNumAlign * sizeof(float); //  8: 8 * 4 = 32B;
         pipe_->InitBuffer(qInQueue_, BUFFER_NUM, MAX_MTP * alignK_ * sizeof(inType));
         pipe_->InitBuffer(kInQueue_, BUFFER_NUM, MAX_MTP * alignK_ * sizeof(inType));
         pipe_->InitBuffer(vInQueue_, BUFFER_NUM, MAX_MTP * alignV_ * sizeof(inType));
@@ -147,8 +146,11 @@ public:
         broadTmpInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(alignK_ * vStep_), buffOffset);
         buffOffset += cubeSize;
         betaInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(betaNumAlign), buffOffset);
-        buffOffset += betaUbSize;
-        gamaInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(betaNumAlign), buffOffset);
+        // gamaInUb is NOT carved from tmpBuff. It reuses the gamaInQueue_ tensor
+        // directly (see CopyInGamaBeta), matching the generic kernel. Otherwise
+        // the host-side UB accounting (CalcWorkingUbBytes, which reserves beta
+        // but not gama in tmpBuff) under-counts by betaNumAlign floats, and the
+        // shortfall doubles with MAX_MTP -> risk of tmpBuff overflow.
     }
 
     __aicore__ inline void ComputeAvgload()
@@ -197,6 +199,9 @@ public:
                     CopyInGamaBeta(seq0, seq1);
                 }
                 ProcessHead(seq0, seq1, head_i, stateOffset);
+            }
+            if (hasGama_ && copyFlag != 0) {
+                gamaInQueue_.FreeTensor(gamaInUb);
             }
         }
     }
@@ -478,9 +483,11 @@ private:
             DataCopyParams gamaInParams{1, static_cast<uint16_t>(seqLen * NV_ * sizeof(float)), 0, 0};
             DataCopyPad(gamaLocal, gamaGm_[seq0 * NV_], gamaInParams, padParams);
             gamaInQueue_.EnQue<float>(gamaLocal);
-            gamaLocal = gamaInQueue_.DeQue<float>();
-            Exp(gamaInUb, gamaLocal, seqLen * NV_);
-            gamaInQueue_.FreeTensor(gamaLocal);
+            gamaInUb = gamaInQueue_.DeQue<float>();
+            Exp(gamaInUb, gamaInUb, seqLen * NV_);
+            AscendC::PipeBarrier<PIPE_V>();
+            // gamaInUb (the queue tensor) stays live until the batch-boundary
+            // FreeTensor in Process(), mirroring the generic kernel.
         }
     }
 

--- a/csrc/attention/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule.h
+++ b/csrc/attention/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule.h
@@ -25,7 +25,7 @@ using namespace matmul;
 using namespace AscendC;
 constexpr uint64_t BUFFER_NUM = 1;
 constexpr uint32_t MAX_OUT_BUFFER_NUM = 2;
-constexpr uint64_t MAX_MTP = 8;
+constexpr uint64_t MAX_MTP = 16;
 constexpr uint64_t BF16_NUM_PER_BLOCK = 16;
 constexpr uint64_t FP32_NUM_PER_BLOCK = 8;
 constexpr uint32_t REPEAT_LENTH = 64; // 256Byte for float


### PR DESCRIPTION
## What this PR does

Backports #11236 to `releases/v0.23.0`. Bumps the `MAX_MTP` tiling constant in the `recurrent_gated_delta_rule` op from **8 → 16** in three files:

- `csrc/attention/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.cpp`
- `csrc/attention/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule.h`
- `csrc/attention/recurrent_gated_delta_rule/op_kernel/arch35/recurrent_gated_delta_rule.h`

Plus the arch35 gama UB accounting fix from the review round on #11236.

## Why

The old cap of 8 blocks MTP-3/5/7 speculative-decoding block sizes on Qwen3.5 GDN-style targets — the kernel silently rejects or misbehaves once the per-request MTP-consumed token count exceeds 8.

## Scope

- **A2 / A3 (910b / 910c) and arch35 (950)**: covered by this PR.
- **310P (`recurrent_gated_delta_rule_v310`)**: intentionally **out of scope**. Qwen3.5-GDN MTP speculative decoding targets A2/A3, so `v310` keeps `MAX_MTP = 8` in both its host tiling and kernel. If 310P MTP > 8 is needed later, it should be a separate change (and a separate UB re-check for the v310 kernel).

## arch35 gama UB accounting fix (from review)

The arch35 kernel carved an extra `gamaInUb` slice from `tmpBuff` (`InitLocalBuffers`) that the host-side UB sizing never reserved — `CalcWorkingUbBytes` accounts for the beta working buffer but not a gama one. With `MAX_MTP` doubled to 16, this unaccounted `betaNumAlign`-float requirement also doubles, so tiling could pick a `vStep` that leaves insufficient `tmpBuff` when `hasGama_` is true → risk of UB overflow / silent corruption.

Fix (aligns arch35 with the generic kernel rather than growing host accounting):
- Reuse `gamaInQueue_` directly: `gamaInUb = gamaInQueue_.DeQue<float>()` → in-place `Exp` → `PipeBarrier<PIPE_V>` → free at the batch boundary.
- Drop the `tmpBuff` `gamaInUb` carve-out (and the now-unused `betaUbSize`).
- `gamaInQueue_` is already counted in `CalcFixedUbBytes`, so the shared host UB accounting is now correct for both kernels.

## User-facing change

None (compile-time constant).

## Test plan

- [x] Compiles with the new constant on A2/A3.
- [ ] Regression: existing MTP-1/2 workloads unchanged.
- [ ] MTP-3/5 on Qwen3.5-GDN targets no longer capped.
- [ ] `seqLen > 8` on the arch35 (950) path with `hasGama_ = true` — validates the UB-accounting fix (no overflow / correct output vs. reference).

## Reference

- Main-branch PR: #11236 (MERGED, merge commit `2b0605fb`)
- Cherry-picks: `9fc9da39` + `b49d6ae7`

Co-authored with @mazhixin000 and @wangzhao-11a

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
