### PR TITLE
[BugFix] Force single-chunk GDN cumsum to fix garbled TP8 output

### DIFF
--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -445,6 +445,11 @@ def _ensure_chunk_meta_state(builder, device: torch.device) -> None:
     gdn_num_heads = _get_gdn_num_heads(builder)
     cumsum_chunks = max(1, _GDN_CUMSUM_WORKING_SET // (gdn_num_heads * builder._ascend_gdn_chunk_size))
     builder._ascend_gdn_cumsum_block_size = _next_power_of_2(cumsum_chunks)
+    # Force the single-chunk cumsum path (block == chunk size, i.e. N_CHUNKS=1). The Ascend
+    # triton backend miscompiles the multi-chunk cumsum at some per-rank head counts
+    # (e.g. TP8 H=8 is wrong for every N_CHUNKS>1), garbling output. Keep in sync with
+    # cumsum.py OPTIM_BLOCK_SIZE.
+    builder._ascend_gdn_cumsum_block_size = builder._ascend_gdn_chunk_size
     builder._ascend_gdn_chunked_prefill_pool_idx = -1
     builder._ascend_gdn_chunked_prefill_pool = []
     if device.type != "cpu":

--- a/vllm_ascend/ops/triton/fla/cumsum.py
+++ b/vllm_ascend/ops/triton/fla/cumsum.py
@@ -90,6 +90,14 @@ def chunk_local_cumsum_scalar(
         B, T, H = g.shape
     assert chunk_size == 2 ** (chunk_size.bit_length() - 1), "chunk_size must be a power of 2"
     OPTIM_BLOCK_SIZE = triton.next_power_of_2((2**18) // (H * chunk_size))
+    # Force the single-chunk path (N_CHUNKS = BLOCK_T // chunk_size == 1). The Ascend
+    # triton backend miscompiles the multi-chunk 3D reshape/trans/cumsum in the kernel
+    # below at some per-rank head counts: empirically H=8 (e.g. TP8, H=num_v_heads//tp)
+    # is wrong for *every* N_CHUNKS>1 and correct only at N_CHUNKS=1, while H=16 (TP4) is
+    # correct everywhere. This produced garbled model output at TP8. N_CHUNKS=1 is verified
+    # correct for all head counts, and cumsum is cheap so the extra blocks are negligible.
+    # Must stay in sync with gdn_attn_builder._ascend_gdn_cumsum_block_size.
+    OPTIM_BLOCK_SIZE = chunk_size
     if cu_seqlens is not None and block_indices is None:
         block_indices = prepare_chunk_indices(cu_seqlens, chunk_size=OPTIM_BLOCK_SIZE)
     num_blocks = len(block_indices) if cu_seqlens is not None else triton.cdiv(T, OPTIM_BLOCK_SIZE)


### PR DESCRIPTION
### What this PR does / why we need it?
GatedDeltaNet (Qwen3-Next / Qwen3.5 hybrid) models produced garbled output at **TP8** (truncated, incoherent, leaking reasoning scaffolding), while **TP4 / TP2** were correct.

The root cause is in `chunk_local_cumsum` (`vllm_ascend/ops/triton/fla/cumsum.py`). It picks a time block size that grows as the per-rank head count `H` (= `num_v_heads // tp`) shrinks:

```python
OPTIM_BLOCK_SIZE = triton.next_power_of_2((2**18) // (H * chunk_size))
```

so a single triton program packs `N_CHUNKS = BLOCK_T // chunk_size` chunks and does a 3D `reshape`/`trans`/`cumsum`. The Ascend triton backend miscompiles that multi-chunk path at small head counts:

| H (TP) | BLOCK_T | N_CHUNKS | result |
|--------|---------|----------|--------|
| 8 (TP8)  | 512 | 8 | **wrong** (non-deterministic garbage) |
| 16 (TP4) | 256 | 4 | correct |
| 32 (TP2) | 128 | 2 | correct |

A direct block-size sweep at `H=8` shows it is wrong for **every** `N_CHUNKS>1` and correct **only** at `N_CHUNKS=1`, whereas `H=16` is correct at every block size. Since the gate cumsum is head-independent, the corrupted result then propagates through the whole delta-rule recurrence and garbles the model output.

**Fix:** force the single-chunk path (`BLOCK_T = chunk_size`, i.e. `N_CHUNKS=1`), which is verified numerically correct for all head counts. The kernel block size (`cumsum.py`) and the prebuilt `block_indices_cumsum` (`gdn_attn_builder.py`) are updated together so they stay consistent. cumsum is cheap, so the extra blocks are negligible.

### Does this PR introduce _any_ user-facing change?
No. Internal correctness fix only; it makes TP8 GDN output correct without changing any API or behavior for already-correct configs.

### How was this patch tested?
Standalone Ascend reproduction (pure triton, no custom ops), comparing `chunk_local_cumsum` output against a `torch.cumsum` reference for a single-chunk input across head counts:

- **Before:** only `H=8` diverges (`maxΔ` on the order of several), every other `H` matches the reference (`~1e-7`).
- **Block-size sweep at `H=8`:** `BLOCK_T=64` (`N_CHUNKS=1`) matches the reference (`~1e-7`); `128/256/512/1024` are all wrong.
- **After the fix:** all head counts (including `H=8`) match the reference (`~1e-7`), and the affected model produces correct output at TP8.

Existing `tests/ut/ops/test_gdn_attn_builder.py` still passes (it derives the expected `block_indices_cumsum` from `builder._ascend_gdn_cumsum_block_size`, which stays consistent with the kernel).

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
