### PR TITLE
[BugFix] Fix static_forward_context cleanup and MTP draft loading

### DIFF
--- a/tests/ut/model_loader/netloader/test_netloader.py
+++ b/tests/ut/model_loader/netloader/test_netloader.py
@@ -148,7 +148,7 @@ def test_clear_static_forward_context_clears_current_vllm_config(monkeypatch):
     passed_config.compilation_config.static_forward_context["passed.layer"] = object()
     current_config.compilation_config.static_forward_context["current.layer"] = object()
     monkeypatch.setattr(
-        "vllm_ascend.model_loader.netloader.netloader.get_current_vllm_config",
+        "vllm_ascend.model_loader.netloader.netloader.get_current_vllm_config_or_none",
         lambda: current_config,
     )
 

--- a/vllm_ascend/model_loader/netloader/netloader.py
+++ b/vllm_ascend/model_loader/netloader/netloader.py
@@ -21,7 +21,7 @@ from copy import deepcopy
 
 import torch
 from torch import nn
-from vllm.config import LoadConfig, ModelConfig, VllmConfig
+from vllm.config import LoadConfig, ModelConfig, VllmConfig, get_current_vllm_config_or_none
 from vllm.logger import logger
 from vllm.model_executor.model_loader import register_model_loader
 from vllm.model_executor.model_loader.base_loader import BaseModelLoader
@@ -34,12 +34,6 @@ from .load import elastic_load
 from .utils import find_free_port, is_valid_path_prefix
 
 DRAFT_PORT_OFFSET = 10000
-
-try:
-    # Older vLLM versions may not expose the current-config accessor.
-    from vllm.config import get_current_vllm_config
-except ImportError:
-    get_current_vllm_config = None
 
 
 @register_model_loader("netloader")
@@ -169,11 +163,9 @@ class ModelNetLoaderElastic(BaseModelLoader):
     def _clear_static_forward_context(vllm_config: VllmConfig) -> None:
         """Clear static layer registrations before rebuilding the model on fallback."""
         candidates = [("vllm_config", vllm_config)]
-        if get_current_vllm_config is not None:
-            try:
-                candidates.append(("current_vllm_config", get_current_vllm_config()))
-            except Exception as e:
-                logger.debug("Failed to get current vLLM config while clearing static context: %s", e)
+        current_vllm_config = get_current_vllm_config_or_none()
+        if current_vllm_config is not None:
+            candidates.append(("current_vllm_config", current_vllm_config))
 
         cleared_contexts = []
         seen_context_ids = set()


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes two issues in ModelNetLoaderElastic when loading models via D2D netloader, especially in MTP / speculative decoding scenarios.
1. Clear static_forward_context before fallback
When elastic loading fails and the loader falls back to DefaultModelLoader, initialize_model may have already registered attention layers into compilation_config.static_forward_context. Without clearing these registrations, revert_to_default() can hit duplicate-registration errors or leave stale layer state.
Changes:
Add _get_static_forward_context() and _clear_static_forward_context() helpers.
Clear both the passed vllm_config and the global get_current_vllm_config() (when available), with deduplication by object id.
Invoke cleanup in the fallback path, right before revert_to_default().
2. Improve MTP draft model netloader efficiency and synchronization
In MTP scenarios, target and draft models are loaded sequentially via netloader. Two problems were observed:
DRAM cache inefficiency for draft model: When INT8_CACHE=dram, the draft model's ElasticServer also cached int8 weights to CPU DRAM. Draft models are typically much smaller; keeping int8 cache in HBM avoids unnecessary CPU↔NPU transfers during weight serving and improves startup/serving efficiency.
Race across ranks: Draft model loading could start before all ranks finished target model netloader setup. A torch.distributed.barrier() is added after target model loading (only when speculative_config is set) so all ranks synchronize before draft loading proceeds.
Changes:
Draft ElasticServer uses int8_cache="hbm" when user config is not "no" (overrides "dram" for draft only).
Add _sync_target_netloader_before_draft() barrier after target model load completes.
Draft model path does not trigger the barrier.

### Does this PR introduce _any_ user-facing change?
No API or CLI changes.

### How was this patch tested?
Pre-commit passed
Unit tests passed
E2E verified: Elastic server start time has been significantly reduced under netloader + MTP with 'int8_cache=dram' serving on 4 * Ascend 800I A3 scenario.
**fix1**
before:
<img width="1711" height="653" alt="image" src="https://github.com/user-attachments/assets/7dc841fd-d6d5-488f-a7f7-5baa6ca1ea32" />
after:
<img width="1944" height="644" alt="image" src="https://github.com/user-attachments/assets/42240d25-470b-4845-bde8-f63e4209c57f" />
curl coordinator:
<img width="1140" height="551" alt="image" src="https://github.com/user-attachments/assets/16216a57-002d-41b9-8edd-45931ff8fcae" />
**fix2**
before:
<img width="1017" height="503" alt="image" src="https://github.com/user-attachments/assets/0d613f62-482b-4001-8d0c-ff921aab202e" />
after:
<img width="1003" height="494" alt="image" src="https://github.com/user-attachments/assets/fdad0e86-ef66-4099-8227-a9552f103ed3" />
curl coordinator:
<img width="1032" height="635" alt="image" src="https://github.com/user-attachments/assets/053ba98a-0fec-43eb-b80f-6d62dc57d1fd" />


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
