### PR TITLE
[CI][UT] Fix NetLoader fallback mock binding

### DIFF
--- a/tests/ut/model_loader/netloader/test_netloader.py
+++ b/tests/ut/model_loader/netloader/test_netloader.py
@@ -281,8 +281,9 @@ def test_failed_target_model_participates_in_barrier_before_error(mock_logger, m
     _patch_loader_common(monkeypatch)
     monkeypatch.setattr("vllm_ascend.model_loader.netloader.netloader.elastic_load", lambda **kwargs: None)
     monkeypatch.setattr(
-        "vllm_ascend.model_loader.netloader.netloader.revert_to_default",
-        lambda *args, **kwargs: (None, False),
+        ModelNetLoaderElastic,
+        "revert_to_default",
+        lambda self, *args, **kwargs: (None, False),
     )
 
     barrier_calls = []


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes the NetLoader failure-path UT by patching `ModelNetLoaderElastic.revert_to_default` on the class instead of patching a module-level symbol. The production code calls `self.revert_to_default(...)`, so patching the method keeps the mocked fallback bound correctly during the test.

### Does this PR introduce _any_ user-facing change?
No. This is a unit test fix only.

### How was this patch tested?
- Stubbed local pytest for this mocked CPU UT passed: `12 passed`.
- `bash format.sh ci` passed ruff, ruff format, codespell, typos, clang-format, markdownlint, workflow lint, PNG export lint, filename spacing, package init, forbidden logger/import checks, boolean-op check, long-function-comment check, and suggestion check. The shellcheck hook reported an existing issue in unmodified `csrc/build.sh:524`, unrelated to this PR.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
