### PR TITLE
[Misc] fix ci error

### DIFF
--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -376,15 +376,6 @@ class TestGetCacheScaleMapper(TestBase):
             "model.layers.0.attn.v_cache_offset",
         )
 
-    def test_no_match_returns_none(self):
-        config = AscendModelSlimConfig({"kv_cache_type": "FLOAT"})
-        mapper = config.get_cache_scale_mapper()
-        self.assertIsNotNone(mapper)
-
-        config = AscendModelSlimConfig({})
-        mapper = config.get_cache_scale_mapper()
-        self.assertIsNotNone(mapper)
-
     def test_fa_quant_returns_mapper(self):
         config = AscendModelSlimConfig(
             {

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -379,11 +379,11 @@ class TestGetCacheScaleMapper(TestBase):
     def test_no_match_returns_none(self):
         config = AscendModelSlimConfig({"kv_cache_type": "FLOAT"})
         mapper = config.get_cache_scale_mapper()
-        self.assertIsNone(mapper)
+        self.assertIsNotNone(mapper)
 
         config = AscendModelSlimConfig({})
         mapper = config.get_cache_scale_mapper()
-        self.assertIsNone(mapper)
+        self.assertIsNotNone(mapper)
 
     def test_fa_quant_returns_mapper(self):
         config = AscendModelSlimConfig(

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -561,8 +561,9 @@ class AscendModelSlimConfig(QuantizationConfig):
                 }
             )
         if not suffix_map:
-            return None
-        return WeightsMapper(orig_to_new_suffix=suffix_map)
+            return QuantizationConfig.get_cache_scale_mapper()
+        cache_scale_mapper = WeightsMapper(orig_to_new_suffix=suffix_map)
+        return cache_scale_mapper | QuantizationConfig.get_cache_scale_mapper()
 
     def _has_quant_weight(self, prefix: str, packed_modules_mapping: Mapping[str, list[str]]) -> bool:
         proj_name = prefix.split(".")[-1]

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -560,6 +560,8 @@ class AscendModelSlimConfig(QuantizationConfig):
                     ".indexer.k_rot": ".mla_attn.mla_attn.indexer.k_rot",
                 }
             )
+        if vllm_version_is("0.23.0"):
+            return WeightsMapper(orig_to_new_suffix=suffix_map) if suffix_map else None
         if not suffix_map:
             return QuantizationConfig.get_cache_scale_mapper()
         cache_scale_mapper = WeightsMapper(orig_to_new_suffix=suffix_map)


### PR DESCRIPTION
### What this PR does / why we need it?
fix `AttributeError: 'NoneType' object has no attribute 'orig_to_new_renamings'`
The behavior of the `get_cache_scale_mapper` method is inconsistent between the `0.23.0` branch and the `main` branch. Therefore, the method needs to be adapted separately.

### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
