### PR TITLE
[CI] Add PRE_COMMIT_HOME env var for pre-commit caching

### DIFF
--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -156,6 +156,7 @@ jobs:
 
       - name: Run pre-commit
         env:
+          PRE_COMMIT_HOME: /tmp/pre-commit-cache
           PRE_COMMIT_COLOR: always
           FORCE_COLOR: "1"
           TERM: xterm-256color


### PR DESCRIPTION
## What this PR does / why we need it?

Add \PRE_COMMIT_HOME: /tmp/pre-commit-cache\ environment variable to the pre-commit step in the E2E workflow, enabling pre-commit hook caching.

## Does this PR introduce _any_ user-facing change?

No, CI changes only.

## How was this patch tested?

CI verification only.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
