### PR TITLE
[Misc] Remove spaces in record_function_or_nullcontext names

### DIFF
--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -277,7 +277,7 @@ class RecomputeScheduler(Scheduler):
                 continue
 
             # Schedule newly needed KV blocks for the request.
-            with record_function_or_nullcontext("schedule: allocate_slots"):
+            with record_function_or_nullcontext("schedule:allocate_slots"):
                 while True:
                     new_blocks = self.kv_cache_manager.allocate_slots(
                         request,
@@ -744,7 +744,7 @@ class RecomputeScheduler(Scheduler):
         # Get the longest common prefix among all requests in the running queue.
         # This can be potentially used for cascade attention.
         num_common_prefix_blocks = [0] * len(self.kv_cache_config.kv_cache_groups)
-        with record_function_or_nullcontext("schedule: get_num_common_prefix_blocks"):
+        with record_function_or_nullcontext("schedule:get_num_common_prefix_blocks"):
             if self.running:
                 any_request_id = self.running[0].request_id
                 num_common_prefix_blocks = self.kv_cache_manager.get_num_common_prefix_blocks(any_request_id)
@@ -767,7 +767,7 @@ class RecomputeScheduler(Scheduler):
                 for req in scheduled_new_reqs
             ]
 
-        with record_function_or_nullcontext("schedule: make_cached_request_data"):
+        with record_function_or_nullcontext("schedule:make_cached_request_data"):
             cached_reqs_data = self._make_cached_request_data(
                 scheduled_running_reqs,
                 scheduled_resumed_reqs,
@@ -817,7 +817,7 @@ class RecomputeScheduler(Scheduler):
             ec_meta: ECConnectorMetadata = self.ec_connector.build_connector_meta(scheduler_output)
             scheduler_output.ec_connector_metadata = ec_meta
 
-        with record_function_or_nullcontext("schedule: update_after_schedule"):
+        with record_function_or_nullcontext("schedule:update_after_schedule"):
             self._update_after_schedule(scheduler_output)
         return scheduler_output
 

--- a/vllm_ascend/core/scheduler_profiling_chunk.py
+++ b/vllm_ascend/core/scheduler_profiling_chunk.py
@@ -349,7 +349,7 @@ class ProfilingChunkScheduler(Scheduler):
                 continue
 
             # Schedule newly needed KV blocks for the request.
-            with record_function_or_nullcontext("schedule: allocate_slots"):
+            with record_function_or_nullcontext("schedule:allocate_slots"):
                 while True:
                     new_blocks = self.kv_cache_manager.allocate_slots(
                         request,
@@ -690,7 +690,7 @@ class ProfilingChunkScheduler(Scheduler):
 
         # Get the longest common prefix among all requests in the running queue.
         num_common_prefix_blocks = [0] * len(self.kv_cache_config.kv_cache_groups)
-        with record_function_or_nullcontext("schedule: get_num_common_prefix_blocks"):
+        with record_function_or_nullcontext("schedule:get_num_common_prefix_blocks"):
             if self.running:
                 any_request_id = self.running[0].request_id
                 num_common_prefix_blocks = self.kv_cache_manager.get_num_common_prefix_blocks(any_request_id)
@@ -713,7 +713,7 @@ class ProfilingChunkScheduler(Scheduler):
                 for req in scheduled_new_reqs
             ]
 
-        with record_function_or_nullcontext("schedule: make_cached_request_data"):
+        with record_function_or_nullcontext("schedule:make_cached_request_data"):
             cached_reqs_data = self._make_cached_request_data(
                 scheduled_running_reqs,
                 scheduled_resumed_reqs,
@@ -751,6 +751,6 @@ class ProfilingChunkScheduler(Scheduler):
             ec_meta = self.ec_connector.build_connector_meta(scheduler_output)
             scheduler_output.ec_connector_metadata = ec_meta
 
-        with record_function_or_nullcontext("schedule: update_after_schedule"):
+        with record_function_or_nullcontext("schedule:update_after_schedule"):
             self._update_after_schedule(scheduler_output)
         return scheduler_output

--- a/vllm_ascend/eplb/core/eplb_device_transfer_loader.py
+++ b/vllm_ascend/eplb/core/eplb_device_transfer_loader.py
@@ -101,7 +101,7 @@ class D2DExpertWeightLoader:
 
         # Waiting for send/recv tasks finish
         if reqs:
-            with record_function_or_nullcontext("EPLB weight D2D wait"):
+            with record_function_or_nullcontext("EPLB_weight_D2D_wait"):
                 for req in reqs:
                     req.wait()
 

--- a/vllm_ascend/eplb/eplb_updator.py
+++ b/vllm_ascend/eplb/eplb_updator.py
@@ -108,7 +108,7 @@ class EplbUpdator:
         if self.get_update_info_flag():
             self.update_info_all = self.eplb_process.block_update_q.get()
         if self.update_expert_weight_flag():
-            with record_function_or_nullcontext("EPLB generate p2p task"):
+            with record_function_or_nullcontext("EPLB_generate_p2p_task"):
                 (expert_send_info, expert_recv_info, updated_expert_map, log2phy_map, layer_id) = (
                     self.update_info_all.pop(0)
                 )

--- a/vllm_ascend/eplb/eplb_updator.py
+++ b/vllm_ascend/eplb/eplb_updator.py
@@ -128,7 +128,7 @@ class EplbUpdator:
 
     def forward_end(self, eplb_heat_collection_status: bool = True):
         if self.wakeup_eplb_worker_flag():
-            with record_function_or_nullcontext("EPLB gather moe load"):
+            with record_function_or_nullcontext("EPLB_gather_moe_load"):
                 self.compute_and_set_moe_load()
                 self.wakeup_eplb_worker()
 

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -192,7 +192,7 @@ class BalanceScheduler(Scheduler):
                 continue
 
             # Schedule newly needed KV blocks for the request.
-            with record_function_or_nullcontext("schedule: allocate_slots"):
+            with record_function_or_nullcontext("schedule:allocate_slots"):
                 while True:
                     new_blocks = self.kv_cache_manager.allocate_slots(
                         request,
@@ -541,7 +541,7 @@ class BalanceScheduler(Scheduler):
         # Get the longest common prefix among all requests in the running queue.
         # This can be potentially used for cascade attention.
         num_common_prefix_blocks = [0] * len(self.kv_cache_config.kv_cache_groups)
-        with record_function_or_nullcontext("schedule: get_num_common_prefix_blocks"):
+        with record_function_or_nullcontext("schedule:get_num_common_prefix_blocks"):
             if self.running:
                 any_request_id = self.running[0].request_id
                 num_common_prefix_blocks = self.kv_cache_manager.get_num_common_prefix_blocks(any_request_id)
@@ -564,7 +564,7 @@ class BalanceScheduler(Scheduler):
                 for req in scheduled_new_reqs
             ]
 
-        with record_function_or_nullcontext("schedule: make_cached_request_data"):
+        with record_function_or_nullcontext("schedule:make_cached_request_data"):
             cached_reqs_data = self._make_cached_request_data(
                 scheduled_running_reqs,
                 scheduled_resumed_reqs,
@@ -607,7 +607,7 @@ class BalanceScheduler(Scheduler):
             ec_meta: ECConnectorMetadata = self.ec_connector.build_connector_meta(scheduler_output)
             scheduler_output.ec_connector_metadata = ec_meta
 
-        with record_function_or_nullcontext("schedule: update_after_schedule"):
+        with record_function_or_nullcontext("schedule:update_after_schedule"):
             self._update_after_schedule(scheduler_output)
         return scheduler_output
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2117,7 +2117,7 @@ class NPUModelRunner(GPUModelRunner):
             get_kv_transfer_group().handle_preemptions(kv_connector_metadata)
 
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
-        with record_function_or_nullcontext("prepare input"):
+        with record_function_or_nullcontext("prepare_input"):
             with self.synchronize_input_prep():
                 # Fix up prev_req_id_to_index for requests that were discarded
                 # in the previous sample_tokens step. If a request has
@@ -2415,7 +2415,7 @@ class NPUModelRunner(GPUModelRunner):
             hidden_states = self._model_forward(
                 num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds, **model_kwargs
             )
-        with record_function_or_nullcontext("post process"):
+        with record_function_or_nullcontext("post_process"):
             aux_hidden_states = None
             if self.use_aux_hidden_state_outputs:
                 hidden_states, aux_hidden_states = hidden_states


### PR DESCRIPTION
### What this PR does / why we need it?
Fix #11033 
This PR removes spaces or replaces them with underscores in the event names used with `record_function_or_nullcontext` across several files (including schedulers, EPLB, and model runner). This standardizes profiling event names and avoids potential issues with profiling tools that do not handle spaces well.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
