### PR TITLE
[Feature] Add mxfp quant for token dispatch to fit low acc communication with MXFP4 fixed

### DIFF
--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -1190,6 +1190,10 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
                 output_dtype=output_dtype,
             )[0]
 
+        if mxfp_quant_dtype == QuantType.W4A8MXFP:
+            gmm2_scale = None  # type: ignore[assignment]
+            gmm2_kwargs.update({"antiquant_scale": [weight_scale]})
+
         return torch_npu.npu_grouped_matmul(
             x=[hidden_states],
             weight=gmm2_weight,

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -1190,10 +1190,6 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
                 output_dtype=output_dtype,
             )[0]
 
-        if mxfp_quant_dtype == QuantType.W4A8MXFP:
-            gmm2_scale = None  # type: ignore[assignment]
-            gmm2_kwargs.update({"antiquant_scale": [weight_scale]})
-
         return torch_npu.npu_grouped_matmul(
             x=[hidden_states],
             weight=gmm2_weight,

--- a/vllm_ascend/ops/fused_moe/moe_stage_params.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_params.py
@@ -76,10 +76,6 @@ class MoEQuantParams:
         return self.quant_type in (QuantType.W8A8, QuantType.W4A8)
 
     @property
-    def is_mxfp_quant(self) -> bool:
-        return self.quant_type in (QuantType.MXFP8, QuantType.MXFP4)
-
-    @property
     def is_fp8(self) -> bool:
         return self.quant_type == QuantType.W8A8FP8
 

--- a/vllm_ascend/ops/fused_moe/moe_stage_params.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_params.py
@@ -118,6 +118,7 @@ class MoEQuantParams:
         else:
             return None
 
+
 __all__ = [
     "MoERoutingParams",
     "MoEMxfpParams",

--- a/vllm_ascend/ops/fused_moe/moe_stage_params.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_params.py
@@ -101,7 +101,7 @@ class MoEQuantParams:
     @property
     def get_dst_type(self):
         if self.is_w4a4_mxfp:
-            return torch.float4_e2m1fn_x2
+            return torch_npu.float4_e2m1fn_x2
         elif self.is_mxfp or self.is_fp8:
             return torch.float8_e4m3fn
         elif self.dispatch_with_quant:

--- a/vllm_ascend/ops/fused_moe/moe_stage_params.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_params.py
@@ -113,7 +113,7 @@ class MoEQuantParams:
     @property
     def get_scale_type(self):
         if self.is_mxfp:
-            return torch.float8_e8m0fn
+            return torch.float8_e8m0fnu
         elif self.dispatch_with_quant:
             return torch.float32
         else:

--- a/vllm_ascend/ops/fused_moe/moe_stage_params.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_params.py
@@ -76,6 +76,10 @@ class MoEQuantParams:
         return self.quant_type in (QuantType.W8A8, QuantType.W4A8)
 
     @property
+    def is_mxfp_quant(self) -> bool:
+        return self.quant_type in (QuantType.MXFP8, QuantType.MXFP4)
+
+    @property
     def is_fp8(self) -> bool:
         return self.quant_type == QuantType.W8A8FP8
 

--- a/vllm_ascend/ops/fused_moe/moe_stage_params.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_params.py
@@ -72,6 +72,10 @@ class MoEQuantParams:
         return self.quant_type in (QuantType.MXFP8, QuantType.MXFP4, QuantType.W4A8MXFP, QuantType.W4A16MXFP4)
 
     @property
+    def is_w4a4_mxfp(self) -> bool:
+        return self.quant_type == QuantType.MXFP4
+
+    @property
     def is_int_quant(self) -> bool:
         return self.quant_type in (QuantType.W8A8, QuantType.W4A8)
 
@@ -94,6 +98,25 @@ class MoEQuantParams:
             QuantType.W8A8FP8,
         )
 
+    @property
+    def get_dst_type(self):
+        if self.is_w4a4_mxfp:
+            return torch.float4_e2m1fn_x2
+        elif self.is_mxfp or self.is_fp8:
+            return torch.float8_e4m3fn
+        elif self.dispatch_with_quant:
+            return torch.int8
+        else:
+            return None
+
+    @property
+    def get_scale_type(self):
+        if self.is_mxfp:
+            return torch.float8_e8m0fn
+        elif self.dispatch_with_quant:
+            return torch.float32
+        else:
+            return None
 
 __all__ = [
     "MoERoutingParams",

--- a/vllm_ascend/ops/fused_moe/moe_stage_params.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_params.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import torch
+import torch_npu
 
 from vllm_ascend.quantization.quant_type import QuantType
 

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -474,8 +474,8 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         self,
         token_dispatch_input: MoETokenDispatchInput,
     ):
-        use_mxfp_quant = token_dispatch_input.quant.is_mxfp
         with_quant = token_dispatch_input.quant.dispatch_with_quant
+        scale_type = token_dispatch_input.quant.get_scale_type()
         hidden_states = token_dispatch_input.hidden_states
         topk_weights = token_dispatch_input.topk_weights
         topk_ids = token_dispatch_input.topk_ids
@@ -493,11 +493,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
 
         dynamic_scale_after_all2all = None
         if with_quant:
-            dst_type = (
-                torch.float8_e4m3fn
-                if token_dispatch_input.quant.is_fp8 or token_dispatch_input.quant.is_mxfp
-                else torch.int8
-            )
+            dst_type = token_dispatch_input.quant.get_dst_type()
             permutated_local_input_tokens, dynamic_scale = DeviceOperator.npu_dynamic_quant(
                 permutated_local_input_tokens, act_quant_type=dst_type, use_mxfp_quant=use_mxfp_quant
             )
@@ -520,7 +516,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
                 dynamic_scale_after_all2all,
                 global_input_tokens_local_experts_indices,
                 with_quant,
-                use_mxfp_quant,
+                scale_type,
             )
         )
 
@@ -641,7 +637,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         dynamic_scale_after_all2all,
         global_input_tokens_local_experts_indices,
         with_quant,
-        use_mxfp_quant,
+        scale_type,
     ):
         # Early return if no local experts or no tokens
         if self.num_local_experts <= 1:
@@ -655,7 +651,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
             global_input_tokens_local_experts_indices.shape[0], 1
         )
 
-        if use_mxfp_quant:
+        if scale_type == torch.float8_e8m0fnu:
             dynamic_scale_for_routing = dynamic_scale_after_all2all.view(torch.float8_e8m0fnu)
         elif with_quant:
             dynamic_scale_for_routing = dynamic_scale_after_all2all
@@ -675,7 +671,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
             )
         )
 
-        if use_mxfp_quant:
+        if scale_type == torch.float8_e8m0fnu:
             dynamic_scale_after_all2all = routed_scale.view(torch.uint8)
         elif with_quant:
             dynamic_scale_after_all2all = routed_scale

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -474,7 +474,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         self,
         token_dispatch_input: MoETokenDispatchInput,
     ):
-        use_mxfp_quant = token_dispatch_input.quant.is_mxfp_quant
+        use_mxfp_quant = token_dispatch_input.quant.is_mxfp
         with_quant = token_dispatch_input.quant.is_int_quant or token_dispatch_input.quant.is_fp8 or use_mxfp_quant
         hidden_states = token_dispatch_input.hidden_states
         topk_weights = token_dispatch_input.topk_weights
@@ -495,7 +495,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         if with_quant:
             dst_type = (
                 torch.float8_e4m3fn
-                if token_dispatch_input.quant.is_fp8 or token_dispatch_input.quant.is_mxfp_quant
+                if token_dispatch_input.quant.is_fp8 or token_dispatch_input.quant.is_mxfp
                 else torch.int8
             )
             permutated_local_input_tokens, dynamic_scale = DeviceOperator.npu_dynamic_quant(

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -475,7 +475,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         token_dispatch_input: MoETokenDispatchInput,
     ):
         use_mxfp_quant = token_dispatch_input.quant.is_mxfp
-        with_quant = token_dispatch_input.quant.is_int_quant or token_dispatch_input.quant.is_fp8 or use_mxfp_quant
+        with_quant = token_dispatch_input.quant.dispatch_with_quant
         hidden_states = token_dispatch_input.hidden_states
         topk_weights = token_dispatch_input.topk_weights
         topk_ids = token_dispatch_input.topk_ids

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -474,7 +474,8 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         self,
         token_dispatch_input: MoETokenDispatchInput,
     ):
-        with_quant = token_dispatch_input.quant.is_int_quant or token_dispatch_input.quant.is_fp8
+        use_mxfp_quant = token_dispatch_input.quant.is_mxfp_quant
+        with_quant = token_dispatch_input.quant.is_int_quant or token_dispatch_input.quant.is_fp8 or use_mxfp_quant
         hidden_states = token_dispatch_input.hidden_states
         topk_weights = token_dispatch_input.topk_weights
         topk_ids = token_dispatch_input.topk_ids
@@ -492,9 +493,11 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
 
         dynamic_scale_after_all2all = None
         if with_quant:
-            dst_type = torch.float8_e4m3fn if token_dispatch_input.quant.is_fp8 else torch.int8
-            permutated_local_input_tokens, dynamic_scale = torch_npu.npu_dynamic_quant(
-                permutated_local_input_tokens, dst_type=dst_type
+            dst_type = torch.float8_e4m3fn \
+                if token_dispatch_input.quant.is_fp8 or token_dispatch_input.quant.is_mxfp_quant \
+                else torch.int8
+            permutated_local_input_tokens, dynamic_scale = DeviceOperator.npu_dynamic_quant(
+                permutated_local_input_tokens, dst_type=dst_type, use_mxfp_quant=use_mxfp_quant
             )
             _, dynamic_scale_after_all2all, permute2_ep_all_to_all_handle = async_all_to_all(
                 dynamic_scale, output_splits, input_splits, self.ep_group
@@ -515,6 +518,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
                 dynamic_scale_after_all2all,
                 global_input_tokens_local_experts_indices,
                 with_quant,
+                use_mxfp_quant,
             )
         )
 
@@ -630,17 +634,44 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         )
 
     def _dispatch_postprocess(
-        self, global_input_tokens, dynamic_scale_after_all2all, global_input_tokens_local_experts_indices, with_quant
+        self,
+        global_input_tokens,
+        dynamic_scale_after_all2all,
+        global_input_tokens_local_experts_indices,
+        with_quant,
+        use_mxfp_quant
     ):
         # Early return if no local experts or no tokens
         if self.num_local_experts <= 1:
             return global_input_tokens, dynamic_scale_after_all2all, None
 
+        assert global_input_tokens_local_experts_indices is not None, (
+            "global_input_tokens_local_experts_indices must be provided"
+        )
+
+        # Handle MXFP case
+        if use_mxfp_quant:
+                experts_indices_2d_copy = global_input_tokens_local_experts_indices.reshape(
+                    global_input_tokens_local_experts_indices.shape[0], 1)
+            dynamic_scale_fp8_copy = dynamic_scale_after_all2all.view(torch.float8_e8m0fnu)
+
+            global_input_tokens, reversed_global_input_permutation_mapping, _, dynamic_scale_fp8_copy = \
+                torch_npu.npu_moe_init_routing_v2(
+                    global_input_tokens, experts_indices_2d_copy,
+                    scale=dynamic_scale_fp8_copy,
+                    active_num=experts_indices_2d_copy.shape[0],
+                    expert_num=self.num_local_experts,
+                    expert_tokens_num_type=1,
+                    expert_tokens_num_flag=True,
+                    active_expert_range=[0, self.num_local_experts]
+                )
+            dynamic_scale_after_all2all = dynamic_scale_fp8_copy.view(torch.uint8)
+
+            experts_indices_2d_copy.untyped_storage().resize_(0)
+            return global_input_tokens, dynamic_scale_after_all2all, reversed_global_input_permutation_mapping
+
         # Handle quantized case
         if with_quant:
-            assert global_input_tokens_local_experts_indices is not None, (
-                "global_input_tokens_local_experts_indices must be provided"
-            )
             dynamic_scale_after_all2all, _ = torch_npu.npu_moe_token_permute(
                 dynamic_scale_after_all2all.unsqueeze(-1), global_input_tokens_local_experts_indices
             )

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -651,8 +651,8 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
 
         # Handle MXFP case
         if use_mxfp_quant:
-                experts_indices_2d_copy = global_input_tokens_local_experts_indices.reshape(
-                    global_input_tokens_local_experts_indices.shape[0], 1)
+            experts_indices_2d_copy = global_input_tokens_local_experts_indices.reshape(
+                global_input_tokens_local_experts_indices.shape[0], 1)
             dynamic_scale_fp8_copy = dynamic_scale_after_all2all.view(torch.float8_e8m0fnu)
 
             global_input_tokens, reversed_global_input_permutation_mapping, _, dynamic_scale_fp8_copy = \

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -476,7 +476,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
     ):
         use_mxfp_quant = token_dispatch_input.quant.is_mxfp
         with_quant = token_dispatch_input.quant.dispatch_with_quant
-        scale_type = token_dispatch_input.quant.get_scale_type()
+        scale_type = token_dispatch_input.quant.get_scale_type
         hidden_states = token_dispatch_input.hidden_states
         topk_weights = token_dispatch_input.topk_weights
         topk_ids = token_dispatch_input.topk_ids
@@ -494,7 +494,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
 
         dynamic_scale_after_all2all = None
         if with_quant:
-            dst_type = token_dispatch_input.quant.get_dst_type()
+            dst_type = token_dispatch_input.quant.get_dst_type
             permutated_local_input_tokens, dynamic_scale = DeviceOperator.npu_dynamic_quant(
                 permutated_local_input_tokens, act_quant_type=dst_type, use_mxfp_quant=use_mxfp_quant
             )

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -474,6 +474,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         self,
         token_dispatch_input: MoETokenDispatchInput,
     ):
+        use_mxfp_quant = token_dispatch_input.quant.is_mxfp
         with_quant = token_dispatch_input.quant.dispatch_with_quant
         scale_type = token_dispatch_input.quant.get_scale_type()
         hidden_states = token_dispatch_input.hidden_states

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -476,6 +476,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
     ):
         use_mxfp_quant = token_dispatch_input.quant.is_mxfp
         with_quant = token_dispatch_input.quant.dispatch_with_quant
+        dst_type = token_dispatch_input.quant.get_dst_type
         scale_type = token_dispatch_input.quant.get_scale_type
         hidden_states = token_dispatch_input.hidden_states
         topk_weights = token_dispatch_input.topk_weights
@@ -494,7 +495,6 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
 
         dynamic_scale_after_all2all = None
         if with_quant:
-            dst_type = token_dispatch_input.quant.get_dst_type
             permutated_local_input_tokens, dynamic_scale = DeviceOperator.npu_dynamic_quant(
                 permutated_local_input_tokens, act_quant_type=dst_type, use_mxfp_quant=use_mxfp_quant
             )
@@ -517,6 +517,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
                 dynamic_scale_after_all2all,
                 global_input_tokens_local_experts_indices,
                 with_quant,
+                dst_type,
                 scale_type,
             )
         )
@@ -638,6 +639,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         dynamic_scale_after_all2all,
         global_input_tokens_local_experts_indices,
         with_quant,
+        dst_type,
         scale_type,
     ):
         # Early return if no local experts or no tokens
@@ -648,11 +650,10 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
             "global_input_tokens_local_experts_indices must be provided"
         )
 
-        experts_indices_2d_copy = global_input_tokens_local_experts_indices.reshape(
-            global_input_tokens_local_experts_indices.shape[0], 1
-        )
-
         if scale_type == torch.float8_e8m0fnu:
+            experts_indices_2d_copy = global_input_tokens_local_experts_indices.reshape(
+                global_input_tokens_local_experts_indices.shape[0], 1
+            )
             dynamic_scale_for_routing = dynamic_scale_after_all2all.view(torch.float8_e8m0fnu)
             global_input_tokens, reversed_global_input_permutation_mapping, _, routed_scale = (
                 torch_npu.npu_moe_init_routing_v2(
@@ -664,6 +665,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
                     expert_tokens_num_type=1,
                     expert_tokens_num_flag=True,
                     active_expert_range=[0, self.num_local_experts],
+                    x_dtype=dst_type,
                 )
             )
             dynamic_scale_after_all2all = routed_scale.view(torch.uint8)

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -495,7 +495,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         if with_quant:
             dst_type = (
                 torch.float8_e4m3fn
-                if token_dispatch_input.quant.is_fp8 or token_dispatch_input.quant.is_mxfp_quant \
+                if token_dispatch_input.quant.is_fp8 or token_dispatch_input.quant.is_mxfp_quant
                 else torch.int8
             )
             permutated_local_input_tokens, dynamic_scale = DeviceOperator.npu_dynamic_quant(
@@ -660,13 +660,14 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
 
             global_input_tokens, reversed_global_input_permutation_mapping, _, dynamic_scale_fp8_copy = (
                 torch_npu.npu_moe_init_routing_v2(
-                    global_input_tokens, experts_indices_2d_copy,
+                    global_input_tokens,
+                    experts_indices_2d_copy,
                     scale=dynamic_scale_fp8_copy,
                     active_num=experts_indices_2d_copy.shape[0],
                     expert_num=self.num_local_experts,
                     expert_tokens_num_type=1,
                     expert_tokens_num_flag=True,
-                    active_expert_range=[0, self.num_local_experts]
+                    active_expert_range=[0, self.num_local_experts],
                 )
             )
             dynamic_scale_after_all2all = dynamic_scale_fp8_copy.view(torch.uint8)

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -669,8 +669,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
             dynamic_scale_after_all2all = routed_scale.view(torch.uint8)
             experts_indices_2d_copy.untyped_storage().resize_(0)
             return global_input_tokens, dynamic_scale_after_all2all, reversed_global_input_permutation_mapping
-        
-        if with_quant:
+        elif with_quant:
             dynamic_scale_after_all2all, _ = torch_npu.npu_moe_token_permute(
                 dynamic_scale_after_all2all.unsqueeze(-1), global_input_tokens_local_experts_indices
             )

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -651,41 +651,38 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
             "global_input_tokens_local_experts_indices must be provided"
         )
 
-        # Handle MXFP case
-        if use_mxfp_quant:
-            experts_indices_2d_copy = global_input_tokens_local_experts_indices.reshape(
-                global_input_tokens_local_experts_indices.shape[0], 1
-            )
-            dynamic_scale_fp8_copy = dynamic_scale_after_all2all.view(torch.float8_e8m0fnu)
-
-            global_input_tokens, reversed_global_input_permutation_mapping, _, dynamic_scale_fp8_copy = (
-                torch_npu.npu_moe_init_routing_v2(
-                    global_input_tokens,
-                    experts_indices_2d_copy,
-                    scale=dynamic_scale_fp8_copy,
-                    active_num=experts_indices_2d_copy.shape[0],
-                    expert_num=self.num_local_experts,
-                    expert_tokens_num_type=1,
-                    expert_tokens_num_flag=True,
-                    active_expert_range=[0, self.num_local_experts],
-                )
-            )
-            dynamic_scale_after_all2all = dynamic_scale_fp8_copy.view(torch.uint8)
-
-            experts_indices_2d_copy.untyped_storage().resize_(0)
-            return global_input_tokens, dynamic_scale_after_all2all, reversed_global_input_permutation_mapping
-
-        # Handle quantized case
-        if with_quant:
-            dynamic_scale_after_all2all, _ = torch_npu.npu_moe_token_permute(
-                dynamic_scale_after_all2all.unsqueeze(-1), global_input_tokens_local_experts_indices
-            )
-            dynamic_scale_after_all2all = dynamic_scale_after_all2all.squeeze(-1)
-
-        # Non-quantized case
-        global_input_tokens, reversed_global_input_permutation_mapping = torch_npu.npu_moe_token_permute(
-            global_input_tokens, global_input_tokens_local_experts_indices
+        experts_indices_2d_copy = global_input_tokens_local_experts_indices.reshape(
+            global_input_tokens_local_experts_indices.shape[0], 1
         )
+
+        if use_mxfp_quant:
+            dynamic_scale_for_routing = dynamic_scale_after_all2all.view(torch.float8_e8m0fnu)
+        elif with_quant:
+            dynamic_scale_for_routing = dynamic_scale_after_all2all
+        else:
+            dynamic_scale_for_routing = None
+
+        global_input_tokens, reversed_global_input_permutation_mapping, _, routed_scale = (
+            torch_npu.npu_moe_init_routing_v2(
+                global_input_tokens,
+                experts_indices_2d_copy,
+                scale=dynamic_scale_for_routing,
+                active_num=experts_indices_2d_copy.shape[0],
+                expert_num=self.num_local_experts,
+                expert_tokens_num_type=1,
+                expert_tokens_num_flag=True,
+                active_expert_range=[0, self.num_local_experts],
+            )
+        )
+
+        if use_mxfp_quant:
+            dynamic_scale_after_all2all = routed_scale.view(torch.uint8)
+        elif with_quant:
+            dynamic_scale_after_all2all = routed_scale
+        else:
+            dynamic_scale_after_all2all = None
+
+        experts_indices_2d_copy.untyped_storage().resize_(0)
         return global_input_tokens, dynamic_scale_after_all2all, reversed_global_input_permutation_mapping
 
     def _combine_preprocess(

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -493,11 +493,13 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
 
         dynamic_scale_after_all2all = None
         if with_quant:
-            dst_type = torch.float8_e4m3fn \
+            dst_type = (
+                torch.float8_e4m3fn
                 if token_dispatch_input.quant.is_fp8 or token_dispatch_input.quant.is_mxfp_quant \
                 else torch.int8
+            )
             permutated_local_input_tokens, dynamic_scale = DeviceOperator.npu_dynamic_quant(
-                permutated_local_input_tokens, dst_type=dst_type, use_mxfp_quant=use_mxfp_quant
+                permutated_local_input_tokens, act_quant_type=dst_type, use_mxfp_quant=use_mxfp_quant
             )
             _, dynamic_scale_after_all2all, permute2_ep_all_to_all_handle = async_all_to_all(
                 dynamic_scale, output_splits, input_splits, self.ep_group
@@ -639,7 +641,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         dynamic_scale_after_all2all,
         global_input_tokens_local_experts_indices,
         with_quant,
-        use_mxfp_quant
+        use_mxfp_quant,
     ):
         # Early return if no local experts or no tokens
         if self.num_local_experts <= 1:
@@ -652,10 +654,11 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         # Handle MXFP case
         if use_mxfp_quant:
             experts_indices_2d_copy = global_input_tokens_local_experts_indices.reshape(
-                global_input_tokens_local_experts_indices.shape[0], 1)
+                global_input_tokens_local_experts_indices.shape[0], 1
+            )
             dynamic_scale_fp8_copy = dynamic_scale_after_all2all.view(torch.float8_e8m0fnu)
 
-            global_input_tokens, reversed_global_input_permutation_mapping, _, dynamic_scale_fp8_copy = \
+            global_input_tokens, reversed_global_input_permutation_mapping, _, dynamic_scale_fp8_copy = (
                 torch_npu.npu_moe_init_routing_v2(
                     global_input_tokens, experts_indices_2d_copy,
                     scale=dynamic_scale_fp8_copy,
@@ -665,6 +668,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
                     expert_tokens_num_flag=True,
                     active_expert_range=[0, self.num_local_experts]
                 )
+            )
             dynamic_scale_after_all2all = dynamic_scale_fp8_copy.view(torch.uint8)
 
             experts_indices_2d_copy.untyped_storage().resize_(0)

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -653,32 +653,32 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
 
         if scale_type == torch.float8_e8m0fnu:
             dynamic_scale_for_routing = dynamic_scale_after_all2all.view(torch.float8_e8m0fnu)
-        elif with_quant:
-            dynamic_scale_for_routing = dynamic_scale_after_all2all
-        else:
-            dynamic_scale_for_routing = None
-
-        global_input_tokens, reversed_global_input_permutation_mapping, _, routed_scale = (
-            torch_npu.npu_moe_init_routing_v2(
-                global_input_tokens,
-                experts_indices_2d_copy,
-                scale=dynamic_scale_for_routing,
-                active_num=experts_indices_2d_copy.shape[0],
-                expert_num=self.num_local_experts,
-                expert_tokens_num_type=1,
-                expert_tokens_num_flag=True,
-                active_expert_range=[0, self.num_local_experts],
+            global_input_tokens, reversed_global_input_permutation_mapping, _, routed_scale = (
+                torch_npu.npu_moe_init_routing_v2(
+                    global_input_tokens,
+                    experts_indices_2d_copy,
+                    scale=dynamic_scale_for_routing,
+                    active_num=experts_indices_2d_copy.shape[0],
+                    expert_num=self.num_local_experts,
+                    expert_tokens_num_type=1,
+                    expert_tokens_num_flag=True,
+                    active_expert_range=[0, self.num_local_experts],
+                )
             )
-        )
-
-        if scale_type == torch.float8_e8m0fnu:
             dynamic_scale_after_all2all = routed_scale.view(torch.uint8)
-        elif with_quant:
-            dynamic_scale_after_all2all = routed_scale
-        else:
-            dynamic_scale_after_all2all = None
+            experts_indices_2d_copy.untyped_storage().resize_(0)
+            return global_input_tokens, dynamic_scale_after_all2all, reversed_global_input_permutation_mapping
+        
+        if with_quant:
+            dynamic_scale_after_all2all, _ = torch_npu.npu_moe_token_permute(
+                dynamic_scale_after_all2all.unsqueeze(-1), global_input_tokens_local_experts_indices
+            )
+            dynamic_scale_after_all2all = dynamic_scale_after_all2all.squeeze(-1)
 
-        experts_indices_2d_copy.untyped_storage().resize_(0)
+        # Non-quantized case
+        global_input_tokens, reversed_global_input_permutation_mapping = torch_npu.npu_moe_token_permute(
+            global_input_tokens, global_input_tokens_local_experts_indices
+        )
         return global_input_tokens, dynamic_scale_after_all2all, reversed_global_input_permutation_mapping
 
     def _combine_preprocess(

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -652,7 +652,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
             global_input_tokens_local_experts_indices.shape[0], 1
         )
 
-        if scale_type == torch.float8_e8m0fnu:
+        if scale_type == torch.float8_e8m0fn:
             dynamic_scale_for_routing = dynamic_scale_after_all2all.view(torch.float8_e8m0fnu)
             global_input_tokens, reversed_global_input_permutation_mapping, _, routed_scale = (
                 torch_npu.npu_moe_init_routing_v2(

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -652,7 +652,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
             global_input_tokens_local_experts_indices.shape[0], 1
         )
 
-        if scale_type == torch.float8_e8m0fn:
+        if scale_type == torch.float8_e8m0fnu:
             dynamic_scale_for_routing = dynamic_scale_after_all2all.view(torch.float8_e8m0fnu)
             global_input_tokens, reversed_global_input_permutation_mapping, _, routed_scale = (
                 torch_npu.npu_moe_init_routing_v2(


### PR DESCRIPTION
### What this PR does / why we need it?

1. Added is_mxfp_quant to moe_stage_params
2. Added logic for mxfp quant during low acc communication throw all2all

### Does this PR introduce _any_ user-facing change?

1. This change will allow users to use mxfp quant on low acc communication and increase performance on prefill layers


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
