### PR TITLE
[BugFix][v0.23.0] Guard mixed structured output backends

### DIFF
--- a/tests/e2e/pull_request/one_card/test_guided_decoding.py
+++ b/tests/e2e/pull_request/one_card/test_guided_decoding.py
@@ -207,6 +207,47 @@ def test_guided_regex_guidance(sample_regex, vllm_runner):
 @pytest.mark.model(
     model_name=MODEL_NAME,
     compilation_config={"cudagraph_capture_sizes": [1, 2, 4, 8]},
+    extra_kwargs={"seed": 0, "structured_outputs_config": {"backend": "auto"}},
+)
+def test_guided_auto_rejects_mixed_structured_output_backends(vllm_runner):
+    xgrammar_schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+    }
+    guidance_schema = {
+        "type": "object",
+        "properties": {"count": {"type": "integer", "multipleOf": 2}},
+        "required": ["count"],
+    }
+
+    xgrammar_params = SamplingParams(
+        temperature=0.0,
+        max_tokens=32,
+        structured_outputs=StructuredOutputsParams(json=xgrammar_schema),
+    )
+    prompts = [f"Give an example JSON that fits this schema: {xgrammar_schema}"]
+    inputs = vllm_runner.get_inputs(prompts)
+    outputs = vllm_runner.model.generate(inputs, sampling_params=xgrammar_params)
+
+    assert outputs is not None
+    assert outputs[0] is not None
+
+    guidance_params = SamplingParams(
+        temperature=0.0,
+        max_tokens=32,
+        structured_outputs=StructuredOutputsParams(json=guidance_schema),
+    )
+    prompts = [f"Give an example JSON that fits this schema: {guidance_schema}"]
+    inputs = vllm_runner.get_inputs(prompts)
+    with pytest.raises(ValueError, match="already using 'xgrammar'.*'guidance'"):
+        vllm_runner.model.generate(inputs, sampling_params=guidance_params)
+
+
+@pytest.mark.timeout(1000)
+@pytest.mark.model(
+    model_name=MODEL_NAME,
+    compilation_config={"cudagraph_capture_sizes": [1, 2, 4, 8]},
     extra_kwargs={"seed": 0, "structured_outputs_config": {"backend": "outlines"}},
 )
 def test_guided_json_completion_outlines(sample_json_schema, request):

--- a/tests/ut/patch/platform/test_patch_structured_output.py
+++ b/tests/ut/patch/platform/test_patch_structured_output.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+import vllm.v1.structured_output as structured_output
+from vllm.config.structured_outputs import StructuredOutputsConfig
+from vllm.sampling_params import SamplingParams, StructuredOutputsParams
+from vllm.v1.structured_output import StructuredOutputManager, backend_guidance, backend_xgrammar
+from vllm.v1.structured_output.backend_types import StructuredOutputOptions
+
+from vllm_ascend.patch.platform import patch_structured_output  # noqa: F401
+
+
+class FakeBackend:
+    def __init__(self, vllm_config, tokenizer, vocab_size):
+        self.vllm_config = vllm_config
+        self.tokenizer = tokenizer
+        self.vocab_size = vocab_size
+
+    def compile_grammar(self, request_type, grammar_spec):
+        return (type(self).__name__, request_type, grammar_spec)
+
+
+class FakeXgrammarBackend(FakeBackend):
+    pass
+
+
+class FakeGuidanceBackend(FakeBackend):
+    pass
+
+
+def make_manager() -> StructuredOutputManager:
+    manager = object.__new__(StructuredOutputManager)
+    manager.backend = None
+    manager.vllm_config = SimpleNamespace(model_config=SimpleNamespace(get_vocab_size=lambda: 128))
+    manager.tokenizer = object()
+    manager._use_async_grammar_compilation = False
+    return manager
+
+
+def make_request(backend: str):
+    return SimpleNamespace(
+        sampling_params=SimpleNamespace(structured_outputs=SimpleNamespace(_backend=backend)),
+        structured_output_request=SimpleNamespace(
+            structured_output_key=(StructuredOutputOptions.JSON, "{}"),
+            grammar=None,
+        ),
+    )
+
+
+def test_sampling_params_rejects_mixed_structured_output_backends(monkeypatch):
+    def fake_validate_xgrammar(sampling_params):
+        schema = sampling_params.structured_outputs.json
+        if schema.get("force_guidance"):
+            raise ValueError("xgrammar unsupported")
+
+    monkeypatch.setattr(
+        backend_xgrammar,
+        "validate_xgrammar_grammar",
+        fake_validate_xgrammar,
+    )
+    monkeypatch.setattr(
+        backend_guidance,
+        "has_guidance_unsupported_json_features",
+        lambda schema: False,
+    )
+    monkeypatch.setattr(
+        backend_guidance,
+        "validate_guidance_grammar",
+        lambda sampling_params, tokenizer=None: None,
+    )
+
+    config = StructuredOutputsConfig(backend="auto")
+    xgrammar_params = SamplingParams(structured_outputs=StructuredOutputsParams(json={"type": "object"}))
+    xgrammar_params._validate_structured_outputs(config, tokenizer=object())
+
+    assert xgrammar_params.structured_outputs._backend == "xgrammar"
+    assert getattr(config, patch_structured_output._BACKEND_ATTR) == "xgrammar"
+
+    guidance_params = SamplingParams(structured_outputs=StructuredOutputsParams(json={"force_guidance": True}))
+    with pytest.raises(ValueError, match="already using 'xgrammar'.*'guidance'"):
+        guidance_params._validate_structured_outputs(config, tokenizer=object())
+
+
+def test_sampling_params_allows_consistent_guidance_backend(monkeypatch):
+    monkeypatch.setattr(
+        backend_guidance,
+        "has_guidance_unsupported_json_features",
+        lambda schema: False,
+    )
+    monkeypatch.setattr(
+        backend_guidance,
+        "validate_guidance_grammar",
+        lambda sampling_params, tokenizer=None: None,
+    )
+
+    config = StructuredOutputsConfig(backend="guidance")
+    for _ in range(2):
+        params = SamplingParams(structured_outputs=StructuredOutputsParams(json={"type": "array"}))
+        params._validate_structured_outputs(config, tokenizer=object())
+
+        assert params.structured_outputs._backend == "guidance"
+        assert getattr(config, patch_structured_output._BACKEND_ATTR) == "guidance"
+
+
+def test_failed_first_validation_does_not_lock_config(monkeypatch):
+    monkeypatch.setattr(
+        backend_xgrammar,
+        "validate_xgrammar_grammar",
+        lambda sampling_params: (_ for _ in ()).throw(ValueError("xgrammar error")),
+    )
+    monkeypatch.setattr(
+        backend_guidance,
+        "has_guidance_unsupported_json_features",
+        lambda schema: False,
+    )
+    monkeypatch.setattr(
+        backend_guidance,
+        "validate_guidance_grammar",
+        lambda sampling_params, tokenizer=None: (_ for _ in ()).throw(ValueError("guidance error")),
+    )
+
+    config = StructuredOutputsConfig(backend="auto")
+    params = SamplingParams(structured_outputs=StructuredOutputsParams(json={"force_guidance": True}))
+    with pytest.raises(ValueError, match="guidance error"):
+        params._validate_structured_outputs(config, tokenizer=object())
+
+    assert not hasattr(config, patch_structured_output._BACKEND_ATTR)
+
+
+def test_manager_rejects_mixed_structured_output_backends(monkeypatch):
+    monkeypatch.setattr(structured_output, "XgrammarBackend", FakeXgrammarBackend)
+    monkeypatch.setattr(structured_output, "GuidanceBackend", FakeGuidanceBackend)
+
+    manager = make_manager()
+    xgrammar_request = make_request("xgrammar")
+    manager.grammar_init(xgrammar_request)
+
+    assert isinstance(manager.backend, FakeXgrammarBackend)
+    assert (
+        getattr(
+            manager,
+            patch_structured_output._BACKEND_ATTR,
+        )
+        == "xgrammar"
+    )
+    assert xgrammar_request.structured_output_request.grammar == (
+        "FakeXgrammarBackend",
+        StructuredOutputOptions.JSON,
+        "{}",
+    )
+
+    guidance_request = make_request("guidance")
+    with pytest.raises(ValueError, match="already using 'xgrammar'.*'guidance'"):
+        manager.grammar_init(guidance_request)
+
+
+def test_manager_rejects_mixed_backend_after_subclassed_backend_is_initialized():
+    manager = make_manager()
+    manager.backend = FakeXgrammarBackend(
+        manager.vllm_config,
+        manager.tokenizer,
+        manager.vllm_config.model_config.get_vocab_size(),
+    )
+
+    with pytest.raises(ValueError, match="already using 'xgrammar'.*'guidance'"):
+        manager.grammar_init(make_request("guidance"))
+
+
+def test_manager_allows_consistent_guidance_backend(monkeypatch):
+    monkeypatch.setattr(structured_output, "GuidanceBackend", FakeGuidanceBackend)
+
+    manager = make_manager()
+    for _ in range(2):
+        request = make_request("guidance")
+        manager.grammar_init(request)
+
+        assert isinstance(manager.backend, FakeGuidanceBackend)
+        assert getattr(manager, patch_structured_output._BACKEND_ATTR) == "guidance"
+        assert request.structured_output_request.grammar == (
+            "FakeGuidanceBackend",
+            StructuredOutputOptions.JSON,
+            "{}",
+        )
+
+
+def test_failed_first_backend_does_not_lock_manager(monkeypatch):
+    monkeypatch.setattr(structured_output, "XgrammarBackend", FakeXgrammarBackend)
+
+    manager = make_manager()
+    with pytest.raises(ValueError, match="Unsupported structured output backend"):
+        manager.grammar_init(make_request("unsupported"))
+
+    assert not hasattr(manager, patch_structured_output._BACKEND_ATTR)
+
+    request = make_request("xgrammar")
+    manager.grammar_init(request)
+
+    assert isinstance(manager.backend, FakeXgrammarBackend)
+    assert getattr(manager, patch_structured_output._BACKEND_ATTR) == "xgrammar"

--- a/tests/ut/patch/platform/test_patch_structured_output.py
+++ b/tests/ut/patch/platform/test_patch_structured_output.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from inspect import signature
 from types import SimpleNamespace
 
 import pytest
@@ -52,7 +53,14 @@ def make_request(backend: str):
 
 
 def validate_structured_outputs(params, config):
-    params._validate_structured_outputs(MODEL_CONFIG, config, tokenizer=object())
+    original_validate = getattr(
+        SamplingParams,
+        patch_structured_output._ORIGINAL_VALIDATE_ATTR,
+    )
+    if "model_config" in signature(original_validate).parameters:
+        params._validate_structured_outputs(MODEL_CONFIG, config, tokenizer=object())
+    else:
+        params._validate_structured_outputs(config, tokenizer=object())
 
 
 def test_sampling_params_rejects_mixed_structured_output_backends(monkeypatch):

--- a/tests/ut/patch/platform/test_patch_structured_output.py
+++ b/tests/ut/patch/platform/test_patch_structured_output.py
@@ -11,6 +11,8 @@ from vllm.v1.structured_output.backend_types import StructuredOutputOptions
 
 from vllm_ascend.patch.platform import patch_structured_output  # noqa: F401
 
+MODEL_CONFIG = SimpleNamespace(is_diffusion=False)
+
 
 class FakeBackend:
     def __init__(self, vllm_config, tokenizer, vocab_size):
@@ -49,6 +51,10 @@ def make_request(backend: str):
     )
 
 
+def validate_structured_outputs(params, config):
+    params._validate_structured_outputs(MODEL_CONFIG, config, tokenizer=object())
+
+
 def test_sampling_params_rejects_mixed_structured_output_backends(monkeypatch):
     def fake_validate_xgrammar(sampling_params):
         schema = sampling_params.structured_outputs.json
@@ -73,14 +79,14 @@ def test_sampling_params_rejects_mixed_structured_output_backends(monkeypatch):
 
     config = StructuredOutputsConfig(backend="auto")
     xgrammar_params = SamplingParams(structured_outputs=StructuredOutputsParams(json={"type": "object"}))
-    xgrammar_params._validate_structured_outputs(config, tokenizer=object())
+    validate_structured_outputs(xgrammar_params, config)
 
     assert xgrammar_params.structured_outputs._backend == "xgrammar"
     assert getattr(config, patch_structured_output._BACKEND_ATTR) == "xgrammar"
 
     guidance_params = SamplingParams(structured_outputs=StructuredOutputsParams(json={"force_guidance": True}))
     with pytest.raises(ValueError, match="already using 'xgrammar'.*'guidance'"):
-        guidance_params._validate_structured_outputs(config, tokenizer=object())
+        validate_structured_outputs(guidance_params, config)
 
 
 def test_sampling_params_allows_consistent_guidance_backend(monkeypatch):
@@ -98,7 +104,7 @@ def test_sampling_params_allows_consistent_guidance_backend(monkeypatch):
     config = StructuredOutputsConfig(backend="guidance")
     for _ in range(2):
         params = SamplingParams(structured_outputs=StructuredOutputsParams(json={"type": "array"}))
-        params._validate_structured_outputs(config, tokenizer=object())
+        validate_structured_outputs(params, config)
 
         assert params.structured_outputs._backend == "guidance"
         assert getattr(config, patch_structured_output._BACKEND_ATTR) == "guidance"
@@ -124,7 +130,7 @@ def test_failed_first_validation_does_not_lock_config(monkeypatch):
     config = StructuredOutputsConfig(backend="auto")
     params = SamplingParams(structured_outputs=StructuredOutputsParams(json={"force_guidance": True}))
     with pytest.raises(ValueError, match="guidance error"):
-        params._validate_structured_outputs(config, tokenizer=object())
+        validate_structured_outputs(params, config)
 
     assert not hasattr(config, patch_structured_output._BACKEND_ATTR)
 

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -338,6 +338,28 @@
 #       Remove this patch once the supported vLLM version contains the upstream
 #       MiniMax-M2 incremental tool-call streaming fix.
 #
+# ** 12b. File: platform/patch_structured_output.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.sampling_params.SamplingParams._validate_structured_outputs`
+#      `vllm.v1.structured_output.StructuredOutputManager.grammar_init`
+#    Why:
+#       V1 structured outputs use one engine-level backend, while `backend=auto`
+#       resolves the backend per request. After one request initializes
+#       `xgrammar`, a later request that resolves to `guidance` can still reach
+#       the initialized `xgrammar` backend and crash during grammar compilation.
+#    How:
+#       Record the first resolved backend on the structured-output config and
+#       reject later requests that resolve to a different backend. Also guard
+#       `grammar_init` so requests that bypass API-side validation fail before
+#       backend grammar compilation.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/issues/43920
+#       https://github.com/vllm-project/vllm/pull/44401
+#    Future Plan:
+#       Remove this patch once upstream vLLM either enforces backend consistency
+#       before grammar compilation or safely handles mixed-backend grammar
+#       failures without killing the engine.
+#
 # ** 13. File: platform/patch_camem_allocator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.model.is_cumem_allocator_available`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -36,6 +36,7 @@ if vllm_version_is("0.23.0"):
     import vllm_ascend.patch.platform.patch_minimax_m2_tool_call_parser  # noqa
     import vllm_ascend.patch.platform.patch_minimax_usage_accounting  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_tool_call_parser  # noqa
+import vllm_ascend.patch.platform.patch_structured_output  # noqa
 import vllm_ascend.patch.platform.patch_weight_transfer_engine  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa
 import vllm_ascend.patch.platform.patch_tool_choice_none_content  # noqa

--- a/vllm_ascend/patch/platform/patch_structured_output.py
+++ b/vllm_ascend/patch/platform/patch_structured_output.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from __future__ import annotations
+
+from typing import Any
+
+from vllm.exceptions import VLLMValidationError
+from vllm.sampling_params import SamplingParams
+from vllm.v1.structured_output import StructuredOutputManager
+
+_BACKEND_ATTR = "_vllm_ascend_structured_output_backend"
+_ORIGINAL_GRAMMAR_INIT_ATTR = "_vllm_ascend_original_grammar_init"
+_ORIGINAL_VALIDATE_ATTR = "_vllm_ascend_original_validate_structured_outputs"
+_PATCHED_MANAGER_ATTR = "_vllm_ascend_backend_guard_patched"
+_PATCHED_SAMPLING_PARAMS_ATTR = "_vllm_ascend_backend_validation_guard_patched"
+
+
+def _request_backend(request: Any) -> str | None:
+    if getattr(request, "structured_output_request", None) is None:
+        return None
+
+    sampling_params = getattr(request, "sampling_params", None)
+    structured_outputs = getattr(sampling_params, "structured_outputs", None)
+    backend = getattr(structured_outputs, "_backend", None)
+    return backend if isinstance(backend, str) else None
+
+
+def _backend_name_from_instance(backend: Any) -> str | None:
+    if backend is None:
+        return None
+
+    backend_names = {
+        "XgrammarBackend": "xgrammar",
+        "GuidanceBackend": "guidance",
+        "OutlinesBackend": "outlines",
+        "LMFormatEnforcerBackend": "lm-format-enforcer",
+    }
+    for backend_cls in type(backend).__mro__:
+        for class_name, backend_name in backend_names.items():
+            if class_name in backend_cls.__name__:
+                return backend_name
+    return None
+
+
+def _raise_mixed_backend(initialized_backend: str, request_backend: str) -> None:
+    raise VLLMValidationError(
+        "V1 structured outputs only supports one backend per engine. "
+        f"The engine is already using '{initialized_backend}', but "
+        f"this request resolved to '{request_backend}'. Configure "
+        "`structured_outputs_config.backend` explicitly or use schemas "
+        "supported by the initialized backend."
+    )
+
+
+def _sampling_params_backend(sampling_params: SamplingParams) -> str | None:
+    structured_outputs = getattr(sampling_params, "structured_outputs", None)
+    backend = getattr(structured_outputs, "_backend", None)
+    return backend if isinstance(backend, str) else None
+
+
+def _patch_sampling_params_validation() -> None:
+    if getattr(SamplingParams, _PATCHED_SAMPLING_PARAMS_ATTR, False):
+        return
+
+    original_validate = SamplingParams._validate_structured_outputs
+    setattr(SamplingParams, _ORIGINAL_VALIDATE_ATTR, original_validate)
+
+    def _validate_structured_outputs(
+        self: SamplingParams,
+        structured_outputs_config: Any,
+        tokenizer: Any,
+    ) -> None:
+        result = original_validate(self, structured_outputs_config, tokenizer)
+        request_backend = _sampling_params_backend(self)
+        if structured_outputs_config is None or request_backend is None:
+            return result
+
+        initialized_backend = getattr(structured_outputs_config, _BACKEND_ATTR, None)
+        if initialized_backend is not None and request_backend != initialized_backend:
+            _raise_mixed_backend(initialized_backend, request_backend)
+
+        setattr(structured_outputs_config, _BACKEND_ATTR, request_backend)
+        return result
+
+    SamplingParams._validate_structured_outputs = _validate_structured_outputs
+    setattr(SamplingParams, _PATCHED_SAMPLING_PARAMS_ATTR, True)
+
+
+def _patch_structured_output_manager() -> None:
+    if getattr(StructuredOutputManager, _PATCHED_MANAGER_ATTR, False):
+        return
+
+    original_grammar_init = StructuredOutputManager.grammar_init
+    setattr(StructuredOutputManager, _ORIGINAL_GRAMMAR_INIT_ATTR, original_grammar_init)
+
+    def grammar_init(self: StructuredOutputManager, request: Any) -> None:
+        request_backend = _request_backend(request)
+        if request_backend is None:
+            return original_grammar_init(self, request)
+
+        initialized_backend = getattr(self, _BACKEND_ATTR, None)
+        if initialized_backend is None:
+            initialized_backend = _backend_name_from_instance(getattr(self, "backend", None))
+            if initialized_backend is not None:
+                setattr(self, _BACKEND_ATTR, initialized_backend)
+
+        if initialized_backend is not None and request_backend != initialized_backend:
+            _raise_mixed_backend(initialized_backend, request_backend)
+
+        result = original_grammar_init(self, request)
+        if getattr(self, "backend", None) is not None:
+            setattr(self, _BACKEND_ATTR, request_backend)
+        return result
+
+    StructuredOutputManager.grammar_init = grammar_init
+    setattr(StructuredOutputManager, _PATCHED_MANAGER_ATTR, True)
+
+
+_patch_sampling_params_validation()
+_patch_structured_output_manager()

--- a/vllm_ascend/patch/platform/patch_structured_output.py
+++ b/vllm_ascend/patch/platform/patch_structured_output.py
@@ -14,8 +14,6 @@ from vllm.v1.structured_output import StructuredOutputManager
 _BACKEND_ATTR = "_vllm_ascend_structured_output_backend"
 _ORIGINAL_GRAMMAR_INIT_ATTR = "_vllm_ascend_original_grammar_init"
 _ORIGINAL_VALIDATE_ATTR = "_vllm_ascend_original_validate_structured_outputs"
-_PATCHED_MANAGER_ATTR = "_vllm_ascend_backend_guard_patched"
-_PATCHED_SAMPLING_PARAMS_ATTR = "_vllm_ascend_backend_validation_guard_patched"
 
 
 def _request_backend(request: Any) -> str | None:
@@ -76,9 +74,6 @@ def _structured_outputs_config_from_call(
 
 
 def _patch_sampling_params_validation() -> None:
-    if getattr(SamplingParams, _PATCHED_SAMPLING_PARAMS_ATTR, False):
-        return
-
     original_validate = SamplingParams._validate_structured_outputs
     validate_signature = signature(original_validate)
     setattr(SamplingParams, _ORIGINAL_VALIDATE_ATTR, original_validate)
@@ -107,13 +102,9 @@ def _patch_sampling_params_validation() -> None:
         return result
 
     SamplingParams._validate_structured_outputs = _validate_structured_outputs
-    setattr(SamplingParams, _PATCHED_SAMPLING_PARAMS_ATTR, True)
 
 
 def _patch_structured_output_manager() -> None:
-    if getattr(StructuredOutputManager, _PATCHED_MANAGER_ATTR, False):
-        return
-
     original_grammar_init = StructuredOutputManager.grammar_init
     setattr(StructuredOutputManager, _ORIGINAL_GRAMMAR_INIT_ATTR, original_grammar_init)
 
@@ -137,7 +128,6 @@ def _patch_structured_output_manager() -> None:
         return result
 
     StructuredOutputManager.grammar_init = grammar_init
-    setattr(StructuredOutputManager, _PATCHED_MANAGER_ATTR, True)
 
 
 _patch_sampling_params_validation()

--- a/vllm_ascend/patch/platform/patch_structured_output.py
+++ b/vllm_ascend/patch/platform/patch_structured_output.py
@@ -69,10 +69,16 @@ def _patch_sampling_params_validation() -> None:
 
     def _validate_structured_outputs(
         self: SamplingParams,
+        model_config: Any,
         structured_outputs_config: Any,
         tokenizer: Any,
     ) -> None:
-        result = original_validate(self, structured_outputs_config, tokenizer)
+        result = original_validate(
+            self,
+            model_config,
+            structured_outputs_config,
+            tokenizer,
+        )
         request_backend = _sampling_params_backend(self)
         if structured_outputs_config is None or request_backend is None:
             return result

--- a/vllm_ascend/patch/platform/patch_structured_output.py
+++ b/vllm_ascend/patch/platform/patch_structured_output.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from inspect import Signature, signature
 from typing import Any
 
 from vllm.exceptions import VLLMValidationError
@@ -60,24 +61,39 @@ def _sampling_params_backend(sampling_params: SamplingParams) -> str | None:
     return backend if isinstance(backend, str) else None
 
 
+def _structured_outputs_config_from_call(
+    validate_signature: Signature,
+    sampling_params: SamplingParams,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
+    bound_arguments = validate_signature.bind_partial(
+        sampling_params,
+        *args,
+        **kwargs,
+    )
+    return bound_arguments.arguments.get("structured_outputs_config")
+
+
 def _patch_sampling_params_validation() -> None:
     if getattr(SamplingParams, _PATCHED_SAMPLING_PARAMS_ATTR, False):
         return
 
     original_validate = SamplingParams._validate_structured_outputs
+    validate_signature = signature(original_validate)
     setattr(SamplingParams, _ORIGINAL_VALIDATE_ATTR, original_validate)
 
     def _validate_structured_outputs(
         self: SamplingParams,
-        model_config: Any,
-        structured_outputs_config: Any,
-        tokenizer: Any,
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
-        result = original_validate(
+        result = original_validate(self, *args, **kwargs)
+        structured_outputs_config = _structured_outputs_config_from_call(
+            validate_signature,
             self,
-            model_config,
-            structured_outputs_config,
-            tokenizer,
+            args,
+            kwargs,
         )
         request_backend = _sampling_params_backend(self)
         if structured_outputs_config is None or request_backend is None:


### PR DESCRIPTION
Backport #11589 to `releases/v0.23.0`.

This keeps the vLLM-Ascend patch behavior aligned with main, with the release-specific wrapper signature required by the vLLM commit pinned by this branch.

Matched vLLM:

The matched vLLM commit comes from `.github/vllm-main-verified.commit`; it is intentionally not the generic vLLM `releases/v0.23.0` branch head.

Validation:
- `python -m py_compile vllm_ascend/patch/__init__.py vllm_ascend/patch/platform/patch_structured_output.py tests/ut/patch/platform/test_patch_structured_output.py`
- `ruff check vllm_ascend/patch/__init__.py vllm_ascend/patch/platform/patch_structured_output.py tests/ut/patch/platform/test_patch_structured_output.py`
- `ruff format --check vllm_ascend/patch/__init__.py vllm_ascend/patch/platform/patch_structured_output.py tests/ut/patch/platform/test_patch_structured_output.py`
- `python -m pytest -q tests/ut/patch/platform/test_patch_structured_output.py` (7 passed)

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
