### PR TITLE
[BugFix] Filter linear-attention keys out of FIA graph replay for hybrid models

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -72,6 +72,26 @@ SWA_INT_MAX = 2147483647
 _ATTN_KEYS_BUFFER = None
 
 
+def _filter_fia_attn_keys(attn_keys, attn_metadata):
+    """Keep only the self-attention (FIA) layers in the graph-replay key list.
+
+    Hybrid models such as Qwen3.5 / Qwen3-Next mix self-attention layers
+    (updated through npu_fused_infer_attention_score) with linear-attention
+    (GatedDeltaNet) layers. Only the self-attention layers are captured into
+    `graph_params.attn_params`; the linear-attention layers use a separate
+    conv1d update path and their metadata (`GDNAttentionMetadata`) has neither
+    `seq_lens_list` nor `actual_seq_lengths_q`. Iterating the raw key list in
+    the FIA graph-replay loop therefore reaches a linear-attention key and
+    raises ``AttributeError: 'GDNAttentionMetadata' object has no attribute
+    'seq_lens_list'``. Drop those keys so the loop only visits FIA metadata.
+    """
+    return [
+        key for key in attn_keys
+        if hasattr(attn_metadata[key], "seq_lens_list")
+        and hasattr(attn_metadata[key], "actual_seq_lengths_q")
+    ]
+
+
 @register_backend(AttentionBackendEnum.CUSTOM, "ASCEND")
 class AscendAttentionBackend(AttentionBackend):
     accept_output_buffer: bool = True
@@ -529,6 +549,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 graph_params = get_graph_params()
                 attn_metadata = forward_context.attn_metadata
                 attn_keys = list(attn_metadata.keys())
+                attn_keys = _filter_fia_attn_keys(attn_keys, attn_metadata)
             # For Qwen3-next, since the kv_cache_config has already categorized
             # linear_attn and self_attn, the attn_metadata is first arranged with
             # self_attn followed by linear_attn. Therefore, using zip directly
@@ -634,6 +655,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 graph_params = get_graph_params()
                 attn_metadata = forward_context.attn_metadata
                 attn_keys = list(attn_metadata.keys())
+                attn_keys = _filter_fia_attn_keys(attn_keys, attn_metadata)
                 if not use_layer_aware_replay:
                     # In some speculative methods (such as DFlash), the order of
                     # attn_keys in the Target model will be disrupted instead of


### PR DESCRIPTION
### What this PR does / why we need it?

Hybrid models such as Qwen3.5 / Qwen3-Next mix self-attention layers (updated through `npu_fused_infer_attention_score`, "FIA") with linear-attention (GatedDeltaNet, "GDN") layers.

In `update_graph_params`, the non-draft branch builds the key list via `list(attn_metadata.keys())`, which contains **both** the FIA and the GDN layers. Only the FIA layers are captured into `graph_params.attn_params`; the GDN layers use a separate conv1d update path and their metadata (`GDNAttentionMetadata`) has neither `seq_lens_list` nor `actual_seq_lengths_q`.

Under **full-graph decode replay** this raises, on the first request:

```
AttributeError: 'GDNAttentionMetadata' object has no attribute 'seq_lens_list'
```

which kills the worker. The existing "self_attn first + zip truncation" ordering assumption does not hold on the layer-aware replay path, where the key list is expanded to the captured op count and cycles back into the GDN keys.

### Fix

Add `_filter_fia_attn_keys`, which keeps only keys whose metadata carries both `seq_lens_list` and `actual_seq_lengths_q` (i.e. real FIA metadata), and apply it to the non-draft `attn_keys` before the FIA graph-replay loop. GDN layers are correctly skipped; their conv1d state update path is unaffected.

Single file, `vllm_ascend/attention/attention_v1.py`, filtering only.

### Does this PR introduce _any_ user-facing change?

No. It fixes a crash; there is no API or behavioural change for models that do not hit the GDN-in-FIA-replay path.

### How was this patch tested?

Verified on Ascend NPU with a hybrid Qwen3.5 model under `cudagraph_mode=FULL_DECODE_ONLY`, TP=2: without the change the first decode request crashes with the `seq_lens_list` AttributeError above; with the change graph capture and replay proceed and requests return normally.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
