### PR TITLE
[BugFix] Revert all2all quantization

### DIFF
--- a/vllm_ascend/ops/fused_moe/moe_stage_params.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_params.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import torch
-import torch_npu
 
 from vllm_ascend.quantization.quant_type import QuantType
 
@@ -73,10 +72,6 @@ class MoEQuantParams:
         return self.quant_type in (QuantType.MXFP8, QuantType.MXFP4, QuantType.W4A8MXFP, QuantType.W4A16MXFP4)
 
     @property
-    def is_w4a4_mxfp(self) -> bool:
-        return self.quant_type == QuantType.MXFP4
-
-    @property
     def is_int_quant(self) -> bool:
         return self.quant_type in (QuantType.W8A8, QuantType.W4A8)
 
@@ -98,26 +93,6 @@ class MoEQuantParams:
             QuantType.W4A8MXFP,
             QuantType.W8A8FP8,
         )
-
-    @property
-    def get_dst_type(self):
-        if self.is_w4a4_mxfp:
-            return torch_npu.float4_e2m1fn_x2
-        elif self.is_mxfp or self.is_fp8:
-            return torch.float8_e4m3fn
-        elif self.dispatch_with_quant:
-            return torch.int8
-        else:
-            return None
-
-    @property
-    def get_scale_type(self):
-        if self.is_mxfp:
-            return torch.float8_e8m0fnu
-        elif self.dispatch_with_quant:
-            return torch.float32
-        else:
-            return None
 
 
 __all__ = [

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -474,9 +474,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         self,
         token_dispatch_input: MoETokenDispatchInput,
     ):
-        use_mxfp_quant = token_dispatch_input.quant.is_mxfp
-        with_quant = token_dispatch_input.quant.dispatch_with_quant
-        scale_type = token_dispatch_input.quant.get_scale_type
+        with_quant = token_dispatch_input.quant.is_int_quant or token_dispatch_input.quant.is_fp8
         hidden_states = token_dispatch_input.hidden_states
         topk_weights = token_dispatch_input.topk_weights
         topk_ids = token_dispatch_input.topk_ids
@@ -494,9 +492,9 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
 
         dynamic_scale_after_all2all = None
         if with_quant:
-            dst_type = token_dispatch_input.quant.get_dst_type
-            permutated_local_input_tokens, dynamic_scale = DeviceOperator.npu_dynamic_quant(
-                permutated_local_input_tokens, act_quant_type=dst_type, use_mxfp_quant=use_mxfp_quant
+            dst_type = torch.float8_e4m3fn if token_dispatch_input.quant.is_fp8 else torch.int8
+            permutated_local_input_tokens, dynamic_scale = torch_npu.npu_dynamic_quant(
+                permutated_local_input_tokens, dst_type=dst_type
             )
             _, dynamic_scale_after_all2all, permute2_ep_all_to_all_handle = async_all_to_all(
                 dynamic_scale, output_splits, input_splits, self.ep_group
@@ -517,7 +515,6 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
                 dynamic_scale_after_all2all,
                 global_input_tokens_local_experts_indices,
                 with_quant,
-                scale_type,
             )
         )
 
@@ -633,43 +630,17 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         )
 
     def _dispatch_postprocess(
-        self,
-        global_input_tokens,
-        dynamic_scale_after_all2all,
-        global_input_tokens_local_experts_indices,
-        with_quant,
-        scale_type,
+        self, global_input_tokens, dynamic_scale_after_all2all, global_input_tokens_local_experts_indices, with_quant
     ):
         # Early return if no local experts or no tokens
         if self.num_local_experts <= 1:
             return global_input_tokens, dynamic_scale_after_all2all, None
 
-        assert global_input_tokens_local_experts_indices is not None, (
-            "global_input_tokens_local_experts_indices must be provided"
-        )
-
-        experts_indices_2d_copy = global_input_tokens_local_experts_indices.reshape(
-            global_input_tokens_local_experts_indices.shape[0], 1
-        )
-
-        if scale_type == torch.float8_e8m0fnu:
-            dynamic_scale_for_routing = dynamic_scale_after_all2all.view(torch.float8_e8m0fnu)
-            global_input_tokens, reversed_global_input_permutation_mapping, _, routed_scale = (
-                torch_npu.npu_moe_init_routing_v2(
-                    global_input_tokens,
-                    experts_indices_2d_copy,
-                    scale=dynamic_scale_for_routing,
-                    active_num=experts_indices_2d_copy.shape[0],
-                    expert_num=self.num_local_experts,
-                    expert_tokens_num_type=1,
-                    expert_tokens_num_flag=True,
-                    active_expert_range=[0, self.num_local_experts],
-                )
+        # Handle quantized case
+        if with_quant:
+            assert global_input_tokens_local_experts_indices is not None, (
+                "global_input_tokens_local_experts_indices must be provided"
             )
-            dynamic_scale_after_all2all = routed_scale.view(torch.uint8)
-            experts_indices_2d_copy.untyped_storage().resize_(0)
-            return global_input_tokens, dynamic_scale_after_all2all, reversed_global_input_permutation_mapping
-        elif with_quant:
             dynamic_scale_after_all2all, _ = torch_npu.npu_moe_token_permute(
                 dynamic_scale_after_all2all.unsqueeze(-1), global_input_tokens_local_experts_indices
             )


### PR DESCRIPTION
### What this PR does / why we need it?
This commit caused incorrect behavior in the MXFP4 quantization
scenario, since operation npu_moe_init_routing_v2 can not get the
correct data type.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
