### PR TITLE
[Feature][Refator] Decouple the allocation of SFA kv and indexer cache

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -97,8 +97,10 @@
   optional: false
   base: attention_common
   source_file_dependencies:
+    - vllm_ascend/attention/indexer.py
     - vllm_ascend/attention/sfa_v1.py
   tests:
+    - tests/ut/attention/test_indexer.py
     - tests/ut/attention/a2/test_sfa_v1.py
     - tests/ut/attention/a2/test_sfa_v1_precision.py
     - tests/e2e/pull_request/four_card/test_deepseek_v3_2_w8a8_pruning.py
@@ -839,12 +841,3 @@ partition:
   a3_x2: 3
   a3_x4: 3
   cpu_x0: 1
-
-
-
-
-
-
-
-
-

--- a/tests/ut/attention/test_indexer.py
+++ b/tests/ut/attention/test_indexer.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import MagicMock
+
+import torch
+from vllm.v1.attention.backend import AttentionCGSupport
+from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+from vllm_ascend.attention.indexer import (
+    AscendSFAIndexerBackend,
+    AscendSFAIndexerMetadataBuilder,
+)
+
+
+def test_sfa_indexer_backend_contract():
+    assert AscendSFAIndexerBackend.accept_output_buffer
+    assert AscendSFAIndexerBackend.get_name() == "ASCEND_SFA_INDEXER"
+    assert AscendSFAIndexerBackend.get_builder_cls() is AscendSFAIndexerMetadataBuilder
+    assert AscendSFAIndexerBackend.get_kv_cache_shape(8, 128, 1, 160) == (
+        8,
+        128,
+        1,
+        160,
+    )
+    assert AscendSFAIndexerBackend.get_supported_kernel_block_sizes() == [128]
+
+
+def test_sfa_indexer_metadata_builder_is_cache_only():
+    kv_cache_spec = FullAttentionSpec(
+        block_size=128,
+        num_kv_heads=1,
+        head_size=160,
+        dtype=torch.uint8,
+    )
+    layer_names = ["model.layers.0.self_attn.indexer.k_cache"]
+    vllm_config = MagicMock()
+    device = torch.device("cpu")
+    builder = AscendSFAIndexerMetadataBuilder(
+        kv_cache_spec,
+        layer_names,
+        vllm_config,
+        device,
+    )
+
+    assert builder.kv_cache_spec is kv_cache_spec
+    assert builder.layer_names is layer_names
+    assert builder.vllm_config is vllm_config
+    assert builder.device == device
+    assert builder.reorder_batch_threshold is None
+    assert builder.get_cudagraph_support(vllm_config, kv_cache_spec) is AttentionCGSupport.UNIFORM_BATCH
+
+    common_attn_metadata = MagicMock()
+    assert builder.build(0, common_attn_metadata) is None
+    assert builder.build_for_cudagraph_capture(common_attn_metadata) is None

--- a/tests/ut/ops/test_mla.py
+++ b/tests/ut/ops/test_mla.py
@@ -34,9 +34,9 @@ class TestIndexerWrapper(TestBase):
         self.assertIs(wrapper.wk_weights_proj, mock_indexer.wk_weights_proj)
         self.assertIs(wrapper.k_norm, mock_indexer.k_norm)
         self.assertEqual(wrapper.softmax_scale, 0.123)
+        self.assertIs(wrapper.k_cache, mock_indexer.k_cache)
 
         self.assertIsNone(mock_indexer.topk_indices_buffer)
-        self.assertIsNone(mock_indexer.k_cache)
 
     def test_forward(self):
         mock_indexer = MagicMock()

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -1,12 +1,21 @@
 import unittest
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import numpy as np
 import torch
 from vllm.model_executor.layers.attention import MLAAttention
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheGroupSpec, KVCacheTensor
+from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    KVCacheTensor,
+    UniformTypeKVCacheSpecs,
+)
 
+from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
+from vllm_ascend.utils import AscendDeviceType
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
 
@@ -97,7 +106,6 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         runner = self._build_runner()
         runner.use_sparse = True
         runner.block_size = 16
-        runner.sparse_head_dim = (512, 64, 128)
         runner.kv_cache_dtype = torch.bfloat16
         runner.shared_kv_cache_layers = {}
         runner.ascend_config = MagicMock()
@@ -109,12 +117,21 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
 
         attn_module = MLAAttention.__new__(MLAAttention)
         torch.nn.Module.__init__(attn_module)
-        attn_module.impl = SimpleNamespace(has_indexer=False, use_sparse_c8=False)
+        attn_module.impl = SimpleNamespace(
+            has_indexer=False,
+            use_sparse_c8_sfa=False,
+            use_sparse_c8_indexer=False,
+        )
+        attn_module.kv_lora_rank = 512
+        attn_module.qk_rope_head_dim = 64
         layer_name = "model.layers.1.self_attn.attn"
         mock_get_layers.return_value = {layer_name: attn_module}
 
-        spec = runner.get_kv_cache_spec()[layer_name]
-        self.assertEqual(spec.sparse_head_dim, (512, 64, 0))
+        specs = runner.get_kv_cache_spec()
+        self.assertEqual(set(specs), {layer_name})
+        spec = specs[layer_name]
+        self.assertEqual(spec.head_size, 512 + 64)
+        self.assertFalse(hasattr(spec, "separate_sfa_indexer_cache"))
 
         kv_cache_config = KVCacheConfig(
             num_blocks=2,
@@ -137,6 +154,247 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
 
         self.assertEqual(raw_k_cache.numel(), 2 * 16 * 512 * 2)
         self.assertEqual(raw_v_cache.numel(), 2 * 16 * 64 * 2)
+
+    @patch("vllm_ascend.worker.model_runner_v1.has_ec_transfer", return_value=False)
+    @patch("vllm_ascend.worker.model_runner_v1.get_layers_from_vllm_config")
+    def test_sparse_indexer_allocates_separate_replicated_cache_tensor(
+        self,
+        mock_get_layers,
+        _mock_has_ec_transfer,
+    ):
+        runner = self._build_runner()
+        runner.use_sparse = True
+        runner.block_size = 16
+        runner.sfa_dcp_replicated_indexer_size = 2
+        runner.kv_cache_dtype = torch.bfloat16
+        runner.shared_kv_cache_layers = {}
+        runner.ascend_config = MagicMock()
+        runner.ascend_config.is_sparse_c8_layer.return_value = False
+        runner.model_config.hf_text_config = SimpleNamespace(
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+            index_head_dim=128,
+        )
+        runner.vllm_config.cache_config.cache_dtype = "auto"
+
+        attn_module = MLAAttention.__new__(MLAAttention)
+        torch.nn.Module.__init__(attn_module)
+        attn_module.impl = SimpleNamespace(
+            has_indexer=True,
+            use_sparse_c8_sfa=False,
+            use_sparse_c8_indexer=False,
+        )
+        attn_module.kv_lora_rank = 512
+        attn_module.qk_rope_head_dim = 64
+        indexer_module = DeepseekV32IndexerCache.__new__(DeepseekV32IndexerCache)
+        torch.nn.Module.__init__(indexer_module)
+        attn_layer_name = "model.layers.1.self_attn.attn"
+        indexer_layer_name = "model.layers.1.self_attn.indexer.k_cache"
+        mock_get_layers.return_value = {
+            attn_layer_name: attn_module,
+            indexer_layer_name: indexer_module,
+        }
+
+        specs = runner.get_kv_cache_spec()
+        main_spec = specs[attn_layer_name]
+        indexer_spec = specs[indexer_layer_name]
+        self.assertIsInstance(indexer_spec, AscendSFAIndexerCacheSpec)
+        self.assertEqual(main_spec.page_size_bytes, 16 * (512 + 64) * 2)
+        self.assertEqual(indexer_spec.page_size_bytes, 2 * 16 * 128 * 2)
+
+        group_spec = UniformTypeKVCacheSpecs.from_specs(specs)
+        self.assertIsNotNone(group_spec)
+        kv_cache_config = KVCacheConfig(
+            num_blocks=2,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=main_spec.page_size_bytes * 2,
+                    shared_by=[attn_layer_name],
+                ),
+                KVCacheTensor(
+                    size=indexer_spec.page_size_bytes * 2,
+                    shared_by=[indexer_layer_name],
+                ),
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=[attn_layer_name, indexer_layer_name],
+                    kv_cache_spec=group_spec,
+                )
+            ],
+        )
+
+        raw_caches = runner._allocate_kv_cache_tensors(kv_cache_config)
+        raw_k_cache, raw_v_cache = raw_caches[attn_layer_name]
+        (raw_indexer_cache,) = raw_caches[indexer_layer_name]
+
+        self.assertEqual(raw_k_cache.numel(), 2 * 16 * 512 * 2)
+        self.assertEqual(raw_v_cache.numel(), 2 * 16 * 64 * 2)
+        self.assertEqual(raw_indexer_cache.numel(), 2 * 2 * 16 * 128 * 2)
+
+        backend = MagicMock()
+        backend.get_kv_cache_shape.side_effect = lambda num_blocks, block_size, num_kv_heads, head_size: (
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            head_size,
+        )
+        runner._kv_cache_spec_attn_group_iterator = lambda: [
+            SimpleNamespace(
+                kv_cache_spec=main_spec,
+                backend=backend,
+                layer_names=[attn_layer_name],
+            ),
+            SimpleNamespace(
+                kv_cache_spec=indexer_spec,
+                backend=backend,
+                layer_names=[indexer_layer_name],
+            ),
+        ]
+
+        caches = runner._reshape_kv_cache_tensors(kv_cache_config, raw_caches)
+        k_cache, v_cache = caches[attn_layer_name]
+        (indexer_cache,) = caches[indexer_layer_name]
+
+        self.assertEqual(k_cache.shape, (2, 16, 1, 512))
+        self.assertEqual(v_cache.shape, (2, 16, 1, 64))
+        self.assertEqual(indexer_cache.shape, (4, 16, 1, 128))
+
+    def test_sparse_c8_indexer_owns_quantized_cache_accounting(self):
+        main_spec = AscendMLAAttentionSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=512 + 64,
+            dtype=torch.bfloat16,
+            cache_sparse_c8=True,
+        )
+        indexer_spec = AscendSFAIndexerCacheSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.int8,
+            scale_dim=1,
+            scale_dtype=torch.float16,
+            cache_sparse_c8=True,
+            sfa_dcp_replicated_indexer_size=2,
+        )
+
+        self.assertEqual(main_spec.page_size_bytes, 16 * (512 + 64) * 2)
+        self.assertEqual(indexer_spec.page_size_bytes, 2 * 16 * (128 + 2))
+        self.assertFalse(hasattr(main_spec, "sfa_dcp_replicated_indexer_size"))
+
+    @patch("vllm_ascend.worker.model_runner_v1.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch("vllm_ascend.worker.model_runner_v1.has_ec_transfer", return_value=False)
+    @patch("vllm_ascend.worker.model_runner_v1.get_layers_from_vllm_config")
+    def test_a5_sparse_c8_specs_keep_main_and_indexer_layouts_separate(
+        self,
+        mock_get_layers,
+        _mock_has_ec_transfer,
+        _mock_get_device_type,
+    ):
+        runner = self._build_runner()
+        runner.use_sparse = True
+        runner.block_size = 16
+        runner.kv_cache_dtype = torch.bfloat16
+        runner.c8_k_cache_dtype = torch.float8_e4m3fn
+        runner.c8_k_scale_cache_dtype = torch.float32
+        runner.shared_kv_cache_layers = {}
+        runner.ascend_config = MagicMock()
+        runner.ascend_config.is_sparse_c8_layer.return_value = True
+        runner.model_config.hf_text_config = SimpleNamespace(
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+            index_head_dim=128,
+        )
+        runner.vllm_config.cache_config.cache_dtype = "auto"
+
+        attn_module = MLAAttention.__new__(MLAAttention)
+        torch.nn.Module.__init__(attn_module)
+        attn_module.impl = SimpleNamespace(
+            has_indexer=True,
+            use_sparse_c8_sfa=True,
+            use_sparse_c8_indexer=True,
+        )
+        attn_module.kv_lora_rank = 512
+        attn_module.qk_rope_head_dim = 64
+        indexer_module = DeepseekV32IndexerCache.__new__(DeepseekV32IndexerCache)
+        torch.nn.Module.__init__(indexer_module)
+        attn_layer_name = "model.layers.1.self_attn.attn"
+        indexer_layer_name = "model.layers.1.self_attn.indexer.k_cache"
+        mock_get_layers.return_value = {
+            attn_layer_name: attn_module,
+            indexer_layer_name: indexer_module,
+        }
+
+        specs = runner.get_kv_cache_spec()
+        main_spec = specs[attn_layer_name]
+        indexer_spec = specs[indexer_layer_name]
+
+        self.assertEqual(
+            runner.ascend_config.is_sparse_c8_layer.call_args_list,
+            [call(indexer_layer_name)],
+        )
+        self.assertEqual(main_spec.head_size, 512 + 64 * 2 + 4 * 4)
+        self.assertEqual(main_spec.dtype, torch.float8_e4m3fn)
+        self.assertEqual(main_spec.page_size_bytes, 16 * (512 + 64 * 2 + 4 * 4))
+        self.assertEqual(indexer_spec.dtype, torch.float8_e4m3fn)
+        self.assertEqual(indexer_spec.scale_dtype, torch.float32)
+        self.assertEqual(indexer_spec.page_size_bytes, 16 * (128 + 4))
+
+    def test_deepseek_v4_indexer_keeps_compressed_mla_layout(self):
+        runner = self._build_runner()
+        runner.use_compress = True
+        layer_name = "model.layers.1.self_attn.indexer.k_cache"
+        indexer_spec = AscendMLAAttentionSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.int8,
+            model_version="deepseek_v4",
+            compress_ratio=4,
+            scale_dim=1,
+            scale_dtype=torch.float16,
+        )
+        kv_cache_config = KVCacheConfig(
+            num_blocks=2,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=indexer_spec.page_size_bytes * 2,
+                    shared_by=[layer_name],
+                )
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=[layer_name],
+                    kv_cache_spec=indexer_spec,
+                )
+            ],
+        )
+
+        raw_caches = runner._allocate_kv_cache_tensors(kv_cache_config)
+        self.assertEqual(raw_caches[layer_name].numel(), 2 * 16 * (128 + 2))
+
+        backend = MagicMock()
+        backend.get_kv_cache_shape.side_effect = lambda num_blocks, block_size, num_kv_heads, head_size: (
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            head_size,
+        )
+        runner.attn_backend = backend
+        runner._kv_cache_spec_attn_group_iterator = lambda: [
+            SimpleNamespace(
+                kv_cache_spec=indexer_spec,
+                backend=backend,
+                layer_names=[layer_name],
+            )
+        ]
+
+        indexer_k_cache, indexer_scale_cache = runner._reshape_kv_cache_tensors(kv_cache_config, raw_caches)[layer_name]
+        self.assertEqual(indexer_k_cache.shape, (2, 16, 1, 128))
+        self.assertEqual(indexer_k_cache.dtype, torch.int8)
+        self.assertEqual(indexer_scale_cache.shape, (2, 16, 1, 1))
+        self.assertEqual(indexer_scale_cache.dtype, torch.float16)
 
 
 class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):

--- a/vllm_ascend/attention/indexer.py
+++ b/vllm_ascend/attention/indexer.py
@@ -1,0 +1,85 @@
+from typing import Any
+
+import torch
+from vllm.config import VllmConfig
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionCGSupport,
+    AttentionMetadataBuilder,
+    CommonAttentionMetadata,
+)
+from vllm.v1.kv_cache_interface import AttentionSpec
+
+
+class AscendSFAIndexerBackend(AttentionBackend):
+    """Placeholder backend for split SFA indexer cache layers.
+
+    The SFA indexer cache is represented as its own AttentionLayerBase so the
+    KV-cache planner can assign an independent physical tensor while sharing
+    block ids with the main MLA cache group. The current SFA forward path still
+    consumes metadata from the real ``*.attn`` layer and recomposes the legacy
+    cache tuple before calling the kernel, so this backend only needs to make
+    the indexer cache visible to cache initialization.
+
+    Do not reuse AscendSFAMetadataBuilder here. It inherits vLLM's
+    MLACommonMetadataBuilder, whose initializer assumes layer_names[0] points to
+    a real MLAAttention object with ``prefill_backend`` in static_forward_context.
+    The indexer cache layer points to DeepseekV32IndexerCache instead, which has
+    no ``prefill_backend``. Keeping a cache-only builder avoids that false
+    attention-layer assumption and avoids building unused indexer metadata.
+    """
+
+    accept_output_buffer: bool = True
+
+    @staticmethod
+    def get_name() -> str:
+        return "ASCEND_SFA_INDEXER"
+
+    @staticmethod
+    def get_builder_cls():
+        return AscendSFAIndexerMetadataBuilder
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_type: str = "",
+    ) -> tuple[int, ...]:
+        return (num_blocks, block_size, num_kv_heads, head_size)
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int]:
+        return [128]
+
+
+class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[Any]):
+    """Cache-only metadata builder for split SFA indexer cache layers."""
+
+    reorder_batch_threshold = None
+
+    def __init__(
+        self,
+        kv_cache_spec: AttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ):
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+
+    @classmethod
+    def get_cudagraph_support(
+        cls,
+        vllm_config: VllmConfig,
+        kv_cache_spec: AttentionSpec,
+    ) -> AttentionCGSupport:
+        return AttentionCGSupport.UNIFORM_BATCH
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> None:
+        return None

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -613,7 +613,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         self.use_sparse_c8_sfa = self.use_sparse_c8_indexer or (
             ascend_config.enable_sparse_c8 and not self.has_indexer and self.skip_topk
         )
-        if self.use_sparse_c8_sfa or self.use_sparse_c8_indexer:
+        if self.use_sparse_c8_sfa:
             if get_ascend_device_type() == AscendDeviceType.A5:
                 self.c8_k_cache_dtype = torch.float8_e4m3fn
                 self.c8_k_scale_cache_dtype = torch.float32

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -609,7 +609,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         # - C8 indexer cache for lightning indexer.
         # GLM5.2 can skip creating indexer on some layers, but these layers
         # still need the packed KV cache when sparse C8 is enabled.
-        self.use_sparse_c8_indexer = self.has_indexer and ascend_config.is_sparse_c8_layer(self.layer_name)
+        self.use_sparse_c8_indexer = self.has_indexer and ascend_config.is_sparse_c8_layer(self.indexer.k_cache.prefix)
         self.use_sparse_c8_sfa = self.use_sparse_c8_indexer or (
             ascend_config.enable_sparse_c8 and not self.has_indexer and self.skip_topk
         )
@@ -1479,6 +1479,61 @@ class AscendSFAImpl(MLAAttentionImpl):
     ) -> None:
         return
 
+    def _compose_sfa_kv_cache(self, kv_cache) -> tuple[torch.Tensor, ...] | None:
+        """Compose split cache handles into the tuple expected by SFA kernels.
+
+        ``kv_cache`` contains only the main MLA cache owned by the attention
+        layer, while ``self.indexer.k_cache.kv_cache`` contains the cache owned
+        by the indexer layer. Their possible layouts are:
+
+        - non-C8:
+          main ``(k_cache, v_cache)`` + indexer ``(indexer_k_cache,)``
+          -> ``(k_cache, v_cache, indexer_k_cache)``
+        - Sparse C8:
+          main ``(packed_kv_cache,)`` +
+          indexer ``(indexer_k_cache, indexer_scale_cache)``
+          -> ``(packed_kv_cache, indexer_k_cache, indexer_scale_cache)``
+
+        Layers that reuse another layer's top-k indices have no local indexer;
+        for those layers, the main cache tuple is returned unchanged.
+        """
+        # TODO: Remove this recomposition once SFA kernels accept split
+        # main/indexer cache handles directly. The allocator now owns them as
+        # separate cache specs, while the current kernel path still expects the
+        # legacy combined tuple layout.
+        main_cache = kv_cache
+        if main_cache is None or not self.has_indexer:
+            return main_cache
+
+        indexer_cache = self.indexer.k_cache.kv_cache
+        if indexer_cache is None:
+            raise RuntimeError(f"SFA indexer cache is not initialized or bound. layer_name={self.layer_name}.")
+
+        if self.use_sparse_c8_indexer:
+            if len(indexer_cache) != 2:
+                raise RuntimeError(
+                    "Sparse C8 SFA indexer cache expects (k_cache, scale_cache), "
+                    f"got {len(indexer_cache)} tensors for layer_name={self.layer_name}."
+                )
+            if len(main_cache) != 1:
+                raise RuntimeError(
+                    "Sparse C8 SFA main cache expects one packed KV tensor, "
+                    f"got {len(main_cache)} tensors for layer_name={self.layer_name}."
+                )
+            return (main_cache[0], indexer_cache[0], indexer_cache[1])
+
+        if len(indexer_cache) != 1:
+            raise RuntimeError(
+                "SFA indexer cache expects one k_cache tensor, "
+                f"got {len(indexer_cache)} tensors for layer_name={self.layer_name}."
+            )
+        if len(main_cache) != 2:
+            raise RuntimeError(
+                "SFA main cache expects (k_cache, v_cache), "
+                f"got {len(main_cache)} tensors for layer_name={self.layer_name}."
+            )
+        return (main_cache[0], main_cache[1], indexer_cache[0])
+
     def forward(
         self,
         layer_name,
@@ -1496,6 +1551,10 @@ class AscendSFAImpl(MLAAttentionImpl):
                     if is_hidden_layer(layer):
                         reach_layer_for_shard_weight_series(layer)
             return output.fill_(0)
+
+        composed_kv_cache = self._compose_sfa_kv_cache(kv_cache)
+        assert composed_kv_cache is not None
+        kv_cache = composed_kv_cache
 
         cos = attn_metadata.cos
         sin = attn_metadata.sin

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -1,139 +1,42 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 import torch
 from typing_extensions import Self
 from vllm.config import VllmConfig
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import get_dtype_size
-from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
+from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager, SlidingWindowManager
 from vllm.v1.kv_cache_interface import FullAttentionSpec, MLAAttentionSpec, SlidingWindowMLASpec
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 
 from vllm_ascend.core.single_type_kv_cache_manager import CompressAttentionManager
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
-
-
-def _get_c8_k_cache_dtype() -> torch.dtype:
-    return torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else torch.int8
-
-
-def _get_c8_k_scale_cache_dtype() -> torch.dtype:
-    return torch.float32 if get_ascend_device_type() == AscendDeviceType.A5 else torch.float16
 
 
 @dataclass(frozen=True, kw_only=True)
 class AscendMLAAttentionSpec(MLAAttentionSpec):
-    """MLAAttentionSpec extended to support DSA models, with optional Sparse C8 support.
+    """MLA cache spec with Ascend-specific layout metadata.
 
-    When Sparse C8 is enabled, the KV cache tuple changes from
-    (kv_cache[0]: bfloat16, kv_cache[1]: bfloat16, kv_cache[2]: bfloat16)
-    to
-    (kv_cache[0]: bfloat16, kv_cache[1]: bfloat16, kv_cache[2]: int8, kv_cache[3]: float16).
-
-    The semantic meaning of each native KV cache entry is as follows:
-    1. kv_cache[0] stores kv_lora.
-    2. kv_cache[1] stores k_rope.
-    3. kv_cache[2] stores the key tensor from the indexer module.
-    4. kv_cache[3] stores the key scale tensor from the indexer module,
-       and exists only when Sparse C8 is enabled.
-
-    With SFA KV-quant sparse attention, kv_lora, k_rope, and per-tile
-    quantization scales are packed into kv_cache[0]. The resulting cache is
-    (packed_kv, indexer_k) or (packed_kv, indexer_k, indexer_scale) when
-    Sparse C8 indexer cache is enabled.
-
-    The main changes are as follows:
-    1. The key tensor from the indexer module stored in kv_cache[2] is
-       converted from bf16 to int8 to reduce memory usage. It is then
-       processed with int8 precision in Lightning_indexer computation
-       to improve computational efficiency.
-    2. The quantization scale of the key tensor in the indexer module
-       must also be stored for the Lightning_indexer_quant operator,
-       and is therefore saved in kv_cache[3].
+    For SFA, this spec describes only the main MLA cache. The indexer K
+    tensor, its quantization scale, and DCP replication are described by a
+    separate :class:`AscendSFAIndexerCacheSpec`.
     """
 
     scale_dim: int = 0
     scale_dtype: torch.dtype = torch.int8
-    sparse_head_dim: tuple[int, ...] | None = None
+    # Sparse C8 changes the main cache into one packed byte tensor. Keep that
+    # main-cache property here; indexer-specific C8 properties belong to the
+    # indexer spec.
     cache_sparse_c8: bool = False
-    c8_k_cache_dtype: torch.dtype = field(default_factory=_get_c8_k_cache_dtype)
-    c8_k_scale_cache_dtype: torch.dtype = field(default_factory=_get_c8_k_scale_cache_dtype)
-    sfa_dcp_replicated_indexer_size: int = 1
 
     @property
     def page_size_bytes(self) -> int:
-        if self.cache_sparse_c8:
-            assert self.sparse_head_dim is not None
-            assert len(self.sparse_head_dim) == 3
-            num_heads_per_page = self.block_size * self.num_kv_heads
-
-            ckv_head_dim, qk_rope_head_dim, index_head_dim = self.sparse_head_dim
-            assert qk_rope_head_dim == 0
-
-            ckv_bytes = num_heads_per_page * ckv_head_dim * get_dtype_size(self.c8_k_cache_dtype)
-            qli_bytes = num_heads_per_page * index_head_dim * get_dtype_size(self.c8_k_cache_dtype)
-            qli_scale_bytes = (
-                num_heads_per_page * self.sfa_dcp_replicated_indexer_size * get_dtype_size(self.c8_k_scale_cache_dtype)
-                if index_head_dim > 0
-                else 0
-            )
-            return ckv_bytes + qli_bytes + qli_scale_bytes
-
         return (
             self.block_size
             * self.num_kv_heads
             * (self.head_size * get_dtype_size(self.dtype) + self.scale_dim * get_dtype_size(self.scale_dtype))
-        )
-
-    @property
-    def sparse_kv_cache_ratio(self) -> tuple[float, float | None, float | None, float | None]:
-        """
-        Compute the relative byte share of each KV cache entry.
-
-        Returns:
-            A tuple containing the ratios for:
-            - kv_cache[0]
-            - kv_cache[1]
-            - kv_cache[2]
-            - kv_cache[3] (None if Sparse C8 is disabled or Sparse C8 on A5 device)
-        """
-
-        assert self.sparse_head_dim is not None
-
-        if self.cache_sparse_c8:
-            ckv_head_dim, qk_rope_head_dim, index_k_head_dim = self.sparse_head_dim
-            assert qk_rope_head_dim == 0
-
-            ckv_virtual = ckv_head_dim * get_dtype_size(self.c8_k_cache_dtype)
-            if index_k_head_dim == 0:
-                return (
-                    1.0,  # kv_cache[0]: ckv / packed_kv
-                    None,  # kv_cache[1] does not exist without indexer cache
-                    None,  # kv_cache[2] does not exist without indexer cache
-                    None,  # kv_cache[3] does not exist for Sparse C8
-                )
-
-            qli_virtual = index_k_head_dim * get_dtype_size(self.c8_k_cache_dtype)
-            scale_virtual = self.sfa_dcp_replicated_indexer_size * get_dtype_size(self.c8_k_scale_cache_dtype)
-            total_virtual_head_dim = ckv_virtual + qli_virtual + scale_virtual
-
-            return (
-                total_virtual_head_dim / ckv_virtual,  # kv_cache[0]: ckv / packed_kv
-                total_virtual_head_dim / qli_virtual,  # kv_cache[1]: qli
-                total_virtual_head_dim / scale_virtual,  # kv_cache[2]: qli_scale
-                None,  # kv_cache[3] does not exist for Sparse C8
-            )
-
-        return (
-            self.head_size / self.sparse_head_dim[0],  # kv_cache[0]
-            self.head_size / self.sparse_head_dim[1],  # kv_cache[1]
-            (
-                self.head_size / self.sparse_head_dim[2] if self.sparse_head_dim[2] > 0 else None
-            ),  # kv_cache[2]  # kv_cache[2]
-            None,  # kv_cache[3] does not exist
         )
 
     @classmethod
@@ -148,7 +51,6 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
                 spec.head_size,
                 spec.scale_dim,
                 spec.scale_dtype,
-                spec.sparse_head_dim,
                 spec.dtype,
             )
             for spec in specs
@@ -164,22 +66,15 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
         assert len(cache_sparse_c8_set) == 1, (
             "All attention layers in the same KV cache group must use the same sparse C8 setting."
         )
-        sfa_dcp_replicated_indexer_size_set = set(spec.sfa_dcp_replicated_indexer_size for spec in specs)
-        assert len(sfa_dcp_replicated_indexer_size_set) == 1, (
-            "All attention layers in the same KV cache group must use the same SFA DCP replicated indexer size."
-        )
-
         return cls(
             block_size=specs[0].block_size,
             num_kv_heads=specs[0].num_kv_heads,
             head_size=specs[0].head_size,
             scale_dim=specs[0].scale_dim,
             scale_dtype=specs[0].scale_dtype,
-            sparse_head_dim=specs[0].sparse_head_dim,
             dtype=specs[0].dtype,
             cache_dtype_str=cache_dtype_str_set.pop(),
             cache_sparse_c8=specs[0].cache_sparse_c8,
-            sfa_dcp_replicated_indexer_size=sfa_dcp_replicated_indexer_size_set.pop(),
         )
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
@@ -191,6 +86,70 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
         if dcp_world_size * pcp_world_size > 1:
             max_model_len = cdiv(max_model_len, dcp_world_size * pcp_world_size)
         return cdiv(max_model_len, self.block_size * self.compress_ratio) * self.page_size_bytes
+
+
+@dataclass(frozen=True, kw_only=True)
+class AscendSFAIndexerCacheSpec(FullAttentionSpec):
+    """KV cache spec for SFA indexer K/scale cache.
+
+    The scheduler should treat this as a full-attention-compatible cache so it
+    can share block ids with the MLA cache in the same UniformType group. The
+    model runner still allocates it as an independent physical cache tensor.
+    """
+
+    scale_dim: int = 0
+    scale_dtype: torch.dtype = torch.int8
+    cache_sparse_c8: bool = False
+    cache_dtype_str: str | None = None
+    sfa_dcp_replicated_indexer_size: int = 1
+
+    @property
+    def page_size_bytes(self) -> int:
+        return self.real_page_size_bytes
+
+    @property
+    def real_page_size_bytes(self) -> int:
+        num_heads_per_page = self.block_size * self.num_kv_heads
+        return (
+            self.sfa_dcp_replicated_indexer_size
+            * num_heads_per_page
+            * (self.head_size * get_dtype_size(self.dtype) + self.scale_dim * get_dtype_size(self.scale_dtype))
+        )
+
+    @classmethod
+    def merge(cls, specs: list[Self]) -> Self:
+        assert all(isinstance(spec, AscendSFAIndexerCacheSpec) for spec in specs), (
+            "All attention layers in the same KV cache group must be AscendSFAIndexerCacheSpec."
+        )
+        cache_dtype_str_set = set(spec.cache_dtype_str for spec in specs)
+        dtype_set = set(spec.dtype for spec in specs)
+        scale_dim_set = set(spec.scale_dim for spec in specs)
+        scale_dtype_set = set(spec.scale_dtype for spec in specs)
+        cache_sparse_c8_set = set(spec.cache_sparse_c8 for spec in specs)
+        sfa_dcp_replicated_indexer_size_set = set(spec.sfa_dcp_replicated_indexer_size for spec in specs)
+        assert (
+            len(cache_dtype_str_set) == 1
+            and len(dtype_set) == 1
+            and len(scale_dim_set) == 1
+            and len(scale_dtype_set) == 1
+            and len(cache_sparse_c8_set) == 1
+            and len(sfa_dcp_replicated_indexer_size_set) == 1
+        ), (
+            "All SFA indexer cache layers in the same KV cache group must use "
+            "the same dtype, scale layout, quantization method, sparse C8 "
+            "setting and DCP replication size."
+        )
+        return cls(
+            block_size=specs[0].block_size,
+            num_kv_heads=specs[0].num_kv_heads,
+            head_size=specs[0].head_size,
+            dtype=dtype_set.pop(),
+            cache_dtype_str=cache_dtype_str_set.pop(),
+            scale_dim=scale_dim_set.pop(),
+            scale_dtype=scale_dtype_set.pop(),
+            cache_sparse_c8=cache_sparse_c8_set.pop(),
+            sfa_dcp_replicated_indexer_size=sfa_dcp_replicated_indexer_size_set.pop(),
+        )
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -250,6 +209,11 @@ def register_ascend_kv_cache_specs() -> None:
     KVCacheSpecRegistry.register(
         kvcache_spec_cls=AscendMLAAttentionSpec,
         manager_class=CompressAttentionManager,
+        uniform_type_base_spec=FullAttentionSpec,
+    )
+    KVCacheSpecRegistry.register(
+        kvcache_spec_cls=AscendSFAIndexerCacheSpec,
+        manager_class=FullAttentionManager,
         uniform_type_base_spec=FullAttentionSpec,
     )
     KVCacheSpecRegistry.register(

--- a/vllm_ascend/ops/mla.py
+++ b/vllm_ascend/ops/mla.py
@@ -42,7 +42,7 @@ class IndexerWrapper(nn.Module):
     This wrapper is currently used to solve the fp8 hard code issue of vllm's deepseek_v2.py.
     It wraps the original Indexer, inherits its module weights
     (including wq_b, wk_weights_proj or wk/weights_proj, k_norm)
-    while deletes the unused topk_indices_buffer and k_cache to save memory.
+    while deleting the unused topk_indices_buffer to save memory.
     TODO: Will be removed once original Indexer supports different quantization methods.
     """
 
@@ -57,8 +57,8 @@ class IndexerWrapper(nn.Module):
         self.wk_weights_proj = vllm_indexer.wk_weights_proj
         self.k_norm = vllm_indexer.k_norm
         self.softmax_scale = vllm_indexer.softmax_scale
+        self.k_cache = getattr(vllm_indexer, "k_cache", None)
         vllm_indexer.topk_indices_buffer = None  # delete topk_indices_buffer
-        vllm_indexer.k_cache = None  # delete k_cache
 
     def forward(self):
         return

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -41,7 +41,6 @@ from vllm_ascend.ascend_config import WeightPrefetchConfig, get_ascend_config
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
-    from vllm.v1.kv_cache_interface import AttentionSpec
 else:
     VllmConfig = None
 
@@ -1719,11 +1718,6 @@ def kv_cache_spec_uses_sparse_c8(kv_cache_spec) -> bool:
     from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 
     return isinstance(kv_cache_spec, AscendMLAAttentionSpec) and bool(getattr(kv_cache_spec, "cache_sparse_c8", False))
-
-
-def sparse_kv_cache_has_indexer(kv_cache_spec: AttentionSpec) -> bool:
-    sparse_head_dim = getattr(kv_cache_spec, "sparse_head_dim", None)
-    return sparse_head_dim is not None and len(sparse_head_dim) == 3 and sparse_head_dim[2] > 0
 
 
 def is_hidden_state_cache_spec(spec) -> bool:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4065,46 +4065,15 @@ class NPUModelRunner(GPUModelRunner):
                 self.compilation_config.static_forward_context[
                     layer_name].kv_cache = [kv_cache]
         else:
-            from vllm.v1.worker.utils import bind_kv_cache, extract_layer_index
+            from vllm.v1.worker.utils import bind_kv_cache
 
             num_attn_module = 2 if self.model_config.hf_text_config.model_type == "longcat_flash" else 1
-            has_sfa_indexer_cache = any(
-                layer_name.endswith(".indexer.k_cache")
-                for layer_name in kv_caches
+            bind_kv_cache(
+                kv_caches,
+                self.compilation_config.static_forward_context,
+                self.kv_caches,
+                num_attn_module,
             )
-            if self.use_sparse and has_sfa_indexer_cache:
-                # TODO: Remove this custom binding once Ascend can use a
-                # module-role-aware bind_kv_cache. Upstream groups caches by
-                # extracted layer index, but split SFA has both attn and
-                # indexer.k_cache under the same transformer layer. Until the
-                # binder can distinguish those roles, the runner-level
-                # self.kv_caches list must only contain the real attention
-                # cache for each layer index.
-                assert len(self.kv_caches) == 0
-                index2name = defaultdict(list)
-                for layer_name in kv_caches:
-                    if layer_name.endswith(".indexer.k_cache"):
-                        # TODO: Keep the indexer cache bound through
-                        # static_forward_context, but leave it out of the
-                        # flattened attention cache list until downstream
-                        # Ascend code can consume role-tagged cache entries.
-                        continue
-                    index2name[extract_layer_index(layer_name, num_attn_module)].append(layer_name)
-
-                for layer_index in sorted(index2name.keys()):
-                    for layer_name in index2name[layer_index]:
-                        self.kv_caches.append(kv_caches[layer_name])
-
-                for layer_name, kv_cache in kv_caches.items():
-                    self.compilation_config.static_forward_context[
-                        layer_name].kv_cache = kv_cache
-            else:
-                bind_kv_cache(
-                    kv_caches,
-                    self.compilation_config.static_forward_context,
-                    self.kv_caches,
-                    num_attn_module,
-                )
 
         if self.enable_hamming_sparse is True:
             from vllm_ascend.worker.kvcomp_utils import init_and_bind_hashk_cache
@@ -4346,20 +4315,13 @@ class NPUModelRunner(GPUModelRunner):
                     # and rope head dim.
                     current_kv_cache_spec = layer_kv_cache_spec[layer_name]
                     assert isinstance(current_kv_cache_spec, AttentionSpec)
+                    current_sparse_c8 = self.use_sparse and kv_cache_spec_uses_sparse_c8(
+                        current_kv_cache_spec
+                    )
 
-                    if self.use_sparse:
-                        current_sparse_c8 = kv_cache_spec_uses_sparse_c8(current_kv_cache_spec)
-                        if current_sparse_c8:
-                            k_tensor_size = kv_cache_tensor.size
-                            v_tensor_size = None
-                        else:
-                            k_dim, v_dim = self._get_attention_kv_cache_dims(
-                                layer_name, current_kv_cache_spec)
-                            assert k_dim > 0 and v_dim > 0
-                            k_tensor_split_factor, v_tensor_split_factor = calc_split_factor(
-                                [k_dim, v_dim])
-                            k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
-                            v_tensor_size = int(kv_cache_tensor.size // v_tensor_split_factor)
+                    if current_sparse_c8:
+                        k_tensor_size = kv_cache_tensor.size
+                        v_tensor_size = None
                     else:
                         k_dim, v_dim = self._get_attention_kv_cache_dims(layer_name, current_kv_cache_spec)
                         assert k_dim > 0 and v_dim > 0
@@ -4367,14 +4329,12 @@ class NPUModelRunner(GPUModelRunner):
                             k_dim,
                             v_dim,
                         ]
-                        if enable_fa_quant(self.vllm_config):
+                        if not self.use_sparse and enable_fa_quant(self.vllm_config):
                             k_tensor_split_factor, v_tensor_split_factor = (
                                 self.vllm_config.quant_config.get_kv_quant_split_factor(layer_name, kv_head_dim_list)
                             )
                         else:
                             k_tensor_split_factor, v_tensor_split_factor = calc_split_factor(kv_head_dim_list)
-
-                    if not self.use_sparse:
                         k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
                         v_tensor_size = int(kv_cache_tensor.size // v_tensor_split_factor)
                     # Allocate raw int8 tensors. Even bf16/fp16 KV cache entries
@@ -4394,12 +4354,8 @@ class NPUModelRunner(GPUModelRunner):
                     for layer_name_inner in kv_cache_tensor.shared_by:
                         # shared the attn kvcache for all shared layers
                         if "attn" in layer_name_inner and "linear_attn" not in layer_name_inner:
-                            if self.use_sparse:
-                                if current_sparse_c8:
-                                    kv_cache_raw_tensors[layer_name_inner] = (k_tensor,)
-                                else:
-                                    assert v_tensor is not None
-                                    kv_cache_raw_tensors[layer_name_inner] = (k_tensor, v_tensor)
+                            if current_sparse_c8:
+                                kv_cache_raw_tensors[layer_name_inner] = (k_tensor,)
                             else:
                                 assert v_tensor is not None
                                 kv_cache_raw_tensors[layer_name_inner] = (k_tensor, v_tensor)
@@ -4572,8 +4528,10 @@ class NPUModelRunner(GPUModelRunner):
                     # _allocate_kv_cache_tensors; route them to the dedicated
                     # elif branch below before the sparse branch tries to
                     # unpack them as a K/V tuple.
+                    current_sparse_c8 = self.use_sparse and kv_cache_spec_uses_sparse_c8(
+                        current_kv_cache_spec
+                    )
                     if self.use_sparse and "cache_only_layers" not in layer_name:
-                        current_sparse_c8 = kv_cache_spec_uses_sparse_c8(current_kv_cache_spec)
                         raw_cache = kv_cache_raw_tensors[layer_name]
                         assert isinstance(raw_cache, tuple)
                         if current_sparse_c8:
@@ -4703,7 +4661,7 @@ class NPUModelRunner(GPUModelRunner):
                             num_kv_heads,
                             k_dim,
                         )
-                        if self.use_sparse and current_sparse_c8:
+                        if current_sparse_c8:
                             k_shape = (
                                 mla_num_blocks,
                                 mla_block_size,
@@ -4723,23 +4681,20 @@ class NPUModelRunner(GPUModelRunner):
                             layer_name, current_kv_cache_spec.dtype, self.model_config
                         )
 
-                    if self.use_sparse and current_sparse_c8:
+                    if current_sparse_c8:
                         k_cache_dtype = self.c8_k_cache_dtype
 
                     k_cache = raw_k_tensor.view(k_cache_dtype).view(k_shape)
-                    if self.use_sparse and current_sparse_c8:
+                    if current_sparse_c8:
                         v_cache = None
                     else:
                         assert raw_v_tensor is not None
                         v_cache = raw_v_tensor.view(v_cache_dtype).view(v_shape)
 
-                    if self.use_sparse:
-                        if current_sparse_c8:
-                            kv_caches[layer_name] = (k_cache,)
-                        else:
-                            assert v_cache is not None
-                            kv_caches[layer_name] = (k_cache, v_cache)
+                    if current_sparse_c8:
+                        kv_caches[layer_name] = (k_cache,)
                     else:
+                        assert v_cache is not None
                         kv_caches[layer_name] = (k_cache, v_cache)
                 elif isinstance(current_kv_cache_spec, MambaSpec):
                     raw_tensor = kv_cache_raw_tensors[layer_name]
@@ -5057,7 +5012,7 @@ class NPUModelRunner(GPUModelRunner):
                     )
                     attn_layer_names.add(layer_name)
 
-            elif self.use_sparse and isinstance(attn_module, DeepseekV32IndexerCache):
+            elif isinstance(attn_module, DeepseekV32IndexerCache):
                 # TODO: This mirrors upstream's separated KV/indexer specs for
                 # SFA, but keeps Ascend-specific shape/block-size accounting.
                 # Remove this special case once the generic vLLM spec/backend

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -164,7 +164,6 @@ from vllm_ascend.utils import (
     set_potential_max_tokens,
     set_weight_prefetch_method,
     should_skip_allreduce_across_dp_group,
-    sparse_kv_cache_has_indexer,
     vllm_version_is,
 )
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
@@ -193,7 +192,11 @@ else:
 
 from vllm.model_executor.layers.attention import Attention, MLAAttention
 
-from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSlidingWindowMLASpec
+from vllm_ascend.core.kv_cache_interface import (
+    AscendMLAAttentionSpec,
+    AscendSFAIndexerCacheSpec,
+    AscendSlidingWindowMLASpec,
+)
 
 # if true, allow tensor initialization and casting with internal format (e.g., NZ)
 torch.npu.config.allow_internal_format = True
@@ -372,25 +375,6 @@ class NPUModelRunner(GPUModelRunner):
         ) and not hasattr(
             vllm_config.model_config.hf_text_config, "compress_ratios"
         )
-        if self.use_sparse:
-            if get_ascend_device_type() == AscendDeviceType.A5 and self.ascend_config.enable_sparse_c8:
-                # A5 sparse C8 uses the same merged/packed KV layout as SFA QSFA.
-                # qk_rope_head_dim = 0 signals the merged layout.
-                packed_kv_head_dim = get_sfa_qsfa_packed_head_dim(
-                    self.model_config.hf_text_config.kv_lora_rank,
-                    self.model_config.hf_text_config.qk_rope_head_dim,
-                )
-                self.sparse_head_dim = (
-                    packed_kv_head_dim,
-                    0,
-                    self.model_config.hf_text_config.index_head_dim,
-                )
-            else:
-                self.sparse_head_dim = (
-                    self.model_config.hf_text_config.kv_lora_rank,
-                    self.model_config.hf_text_config.qk_rope_head_dim,
-                    self.model_config.hf_text_config.index_head_dim,
-                )
         # dsa c8
         self.use_sparse_c8 = self.ascend_config.enable_sparse_c8
         if self.use_sparse_c8:
@@ -459,7 +443,6 @@ class NPUModelRunner(GPUModelRunner):
         self.sfa_dcp_replicated_indexer_size = 1
         if enable_sfa_dcp_replicated_indexer():
             self.sfa_dcp_replicated_indexer_size = self.dcp_size
-            self.sparse_head_dim = (*self.sparse_head_dim[:-1], self.sparse_head_dim[-1] * self.dcp_size)
             
         # Create a CPU numpy buffer for positions computation when
         # self.positions is a plain tensor (non-CpuGpuBuffer case).
@@ -4082,10 +4065,46 @@ class NPUModelRunner(GPUModelRunner):
                 self.compilation_config.static_forward_context[
                     layer_name].kv_cache = [kv_cache]
         else:
-            from vllm.v1.worker.utils import bind_kv_cache
+            from vllm.v1.worker.utils import bind_kv_cache, extract_layer_index
 
             num_attn_module = 2 if self.model_config.hf_text_config.model_type == "longcat_flash" else 1
-            bind_kv_cache(kv_caches, self.compilation_config.static_forward_context, self.kv_caches, num_attn_module)
+            has_sfa_indexer_cache = any(
+                layer_name.endswith(".indexer.k_cache")
+                for layer_name in kv_caches
+            )
+            if self.use_sparse and has_sfa_indexer_cache:
+                # TODO: Remove this custom binding once Ascend can use a
+                # module-role-aware bind_kv_cache. Upstream groups caches by
+                # extracted layer index, but split SFA has both attn and
+                # indexer.k_cache under the same transformer layer. Until the
+                # binder can distinguish those roles, the runner-level
+                # self.kv_caches list must only contain the real attention
+                # cache for each layer index.
+                assert len(self.kv_caches) == 0
+                index2name = defaultdict(list)
+                for layer_name in kv_caches:
+                    if layer_name.endswith(".indexer.k_cache"):
+                        # TODO: Keep the indexer cache bound through
+                        # static_forward_context, but leave it out of the
+                        # flattened attention cache list until downstream
+                        # Ascend code can consume role-tagged cache entries.
+                        continue
+                    index2name[extract_layer_index(layer_name, num_attn_module)].append(layer_name)
+
+                for layer_index in sorted(index2name.keys()):
+                    for layer_name in index2name[layer_index]:
+                        self.kv_caches.append(kv_caches[layer_name])
+
+                for layer_name, kv_cache in kv_caches.items():
+                    self.compilation_config.static_forward_context[
+                        layer_name].kv_cache = kv_cache
+            else:
+                bind_kv_cache(
+                    kv_caches,
+                    self.compilation_config.static_forward_context,
+                    self.kv_caches,
+                    num_attn_module,
+                )
 
         if self.enable_hamming_sparse is True:
             from vllm_ascend.worker.kvcomp_utils import init_and_bind_hashk_cache
@@ -4231,7 +4250,7 @@ class NPUModelRunner(GPUModelRunner):
             to their corresponding memory buffer for K cache and V cache.
         """
         # init kv cache tensors
-        kv_cache_raw_tensors: dict[str, torch.Tensor | torch.Tensor | None | None] = {}
+        kv_cache_raw_tensors: dict[str, torch.Tensor | tuple[torch.Tensor, ...]] = {}
         # prefill disaggregation need the addr of cache tensor be aligned with 2M
         alignment = 2 * 1024 * 1024
         layer_kv_cache_spec = self._get_layer_kv_cache_specs(kv_cache_config)
@@ -4279,6 +4298,46 @@ class NPUModelRunner(GPUModelRunner):
                     for layer_name_inner in kv_cache_tensor.shared_by:
                         # shared the kvcache between the self_attn specs in the same group
                         kv_cache_raw_tensors[layer_name_inner] = tensor
+                elif (
+                    isinstance(layer_kv_cache_spec[layer_name], AscendSFAIndexerCacheSpec)
+                    and layer_name not in kv_cache_raw_tensors
+                ):
+                    current_kv_cache_spec = layer_kv_cache_spec[layer_name]
+                    raw_cache: tuple[torch.Tensor, ...]
+                    num_blocks = kv_cache_tensor.size // current_kv_cache_spec.page_size_bytes
+                    k_tensor_size = (
+                        num_blocks
+                        * current_kv_cache_spec.sfa_dcp_replicated_indexer_size
+                        * current_kv_cache_spec.block_size
+                        * current_kv_cache_spec.num_kv_heads
+                        * current_kv_cache_spec.head_size
+                        * get_dtype_size(current_kv_cache_spec.dtype)
+                    )
+                    if current_kv_cache_spec.scale_dim:
+                        scale_tensor_size = (
+                            num_blocks
+                            * current_kv_cache_spec.sfa_dcp_replicated_indexer_size
+                            * current_kv_cache_spec.block_size
+                            * current_kv_cache_spec.num_kv_heads
+                            * current_kv_cache_spec.scale_dim
+                            * get_dtype_size(current_kv_cache_spec.scale_dtype)
+                        )
+                        k_tensor, scale_tensor = self._allocate_sparse_c8_indexer_tensors(
+                            dsa_k_tensor_size=k_tensor_size,
+                            dsa_k_scale_tensor_size=scale_tensor_size,
+                            alignment=alignment,
+                            scale_dtype=current_kv_cache_spec.scale_dtype,
+                        )
+                        raw_cache = (k_tensor, scale_tensor)
+                    else:
+                        k_tensor = self._allocate_int8_cache_tensor(
+                            k_tensor_size,
+                            alignment,
+                        )
+                        raw_cache = (k_tensor,)
+
+                    for layer_name_inner in kv_cache_tensor.shared_by:
+                        kv_cache_raw_tensors[layer_name_inner] = raw_cache
                 elif "attn" in layer_name and layer_name not in kv_cache_raw_tensors and not use_mamba:
                     # NOTE: We need to init k cache tensor (nope cache tensor in mla) and
                     # v cache tensor (rope cache tensor in mla) separately to support prefill disaggregation,
@@ -4288,52 +4347,19 @@ class NPUModelRunner(GPUModelRunner):
                     current_kv_cache_spec = layer_kv_cache_spec[layer_name]
                     assert isinstance(current_kv_cache_spec, AttentionSpec)
 
-                    dsa_k_tensor_split_factor = None
                     if self.use_sparse:
-                        # for deepseek v3.2, we split the kv cache according to the corresponding ratio
-                        kv_cache_spec = layer_kv_cache_spec[layer_name]
-                        current_sparse_c8 = kv_cache_spec_uses_sparse_c8(kv_cache_spec)
-                        assert isinstance(kv_cache_spec, AscendMLAAttentionSpec)
-                        assert kv_cache_spec.sparse_head_dim is not None
-                        has_indexer_cache = sparse_kv_cache_has_indexer(kv_cache_spec)
-
+                        current_sparse_c8 = kv_cache_spec_uses_sparse_c8(current_kv_cache_spec)
                         if current_sparse_c8:
-                            assert kv_cache_tensor.size % kv_cache_spec.page_size_bytes == 0
-                            num_blocks = kv_cache_tensor.size // kv_cache_spec.page_size_bytes
-                            num_heads = kv_cache_spec.block_size * kv_cache_spec.num_kv_heads
-                            packed_kv_head_dim, _, index_head_dim = kv_cache_spec.sparse_head_dim
-                            k_tensor_split_factor = 1.0
-                            k_tensor_size = (
-                                num_blocks
-                                * num_heads
-                                * packed_kv_head_dim
-                                * get_dtype_size(kv_cache_spec.c8_k_cache_dtype)
-                            )
+                            k_tensor_size = kv_cache_tensor.size
                             v_tensor_size = None
-                            if has_indexer_cache:
-                                dsa_k_tensor_size = (
-                                    num_blocks
-                                    * num_heads
-                                    * index_head_dim
-                                    * get_dtype_size(kv_cache_spec.c8_k_cache_dtype)
-                                )
-                                dsa_k_scale_tensor_size = (
-                                    num_blocks
-                                    * num_heads
-                                    * get_dtype_size(kv_cache_spec.c8_k_scale_cache_dtype)
-                                )
-                            else:
-                                dsa_k_tensor_size = None
-                                dsa_k_scale_tensor_size = None
-                            dsa_k_tensor_split_factor = None
-                        elif has_indexer_cache:
-                            sparse_kv_cache_ratio = kv_cache_spec.sparse_kv_cache_ratio
-                            k_tensor_split_factor = sparse_kv_cache_ratio[0]
-                            v_tensor_split_factor = sparse_kv_cache_ratio[1]
-                            dsa_k_tensor_split_factor = sparse_kv_cache_ratio[2]
                         else:
-                            k_dim, v_dim, _ = kv_cache_spec.sparse_head_dim
-                            k_tensor_split_factor, v_tensor_split_factor = calc_split_factor([k_dim, v_dim])
+                            k_dim, v_dim = self._get_attention_kv_cache_dims(
+                                layer_name, current_kv_cache_spec)
+                            assert k_dim > 0 and v_dim > 0
+                            k_tensor_split_factor, v_tensor_split_factor = calc_split_factor(
+                                [k_dim, v_dim])
+                            k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
+                            v_tensor_size = int(kv_cache_tensor.size // v_tensor_split_factor)
                     else:
                         k_dim, v_dim = self._get_attention_kv_cache_dims(layer_name, current_kv_cache_spec)
                         assert k_dim > 0 and v_dim > 0
@@ -4348,24 +4374,12 @@ class NPUModelRunner(GPUModelRunner):
                         else:
                             k_tensor_split_factor, v_tensor_split_factor = calc_split_factor(kv_head_dim_list)
 
-                    if not (self.use_sparse and current_sparse_c8):
+                    if not self.use_sparse:
                         k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
-                        v_tensor_size = (
-                            int(kv_cache_tensor.size // v_tensor_split_factor)
-                            if v_tensor_split_factor is not None
-                            else None
-                        )
-                        dsa_k_tensor_size = None
-                        dsa_k_scale_tensor_size = None
-                    #### for deepseek sparse attention
-                    if self.use_sparse and has_indexer_cache and not current_sparse_c8:
-                        assert dsa_k_tensor_split_factor is not None
-                        dsa_k_tensor_size = int(kv_cache_tensor.size // dsa_k_tensor_split_factor)
+                        v_tensor_size = int(kv_cache_tensor.size // v_tensor_split_factor)
                     # Allocate raw int8 tensors. Even bf16/fp16 KV cache entries
                     # are allocated as int8 raw bytes first and then viewed as
                     # the target dtype in _reshape_kv_cache_tensors.
-                    dsa_k_tensor = None
-                    dsa_k_scale_tensor = None
                     v_tensor = None
                     k_tensor = self._allocate_int8_cache_tensor(
                         k_tensor_size,
@@ -4377,49 +4391,17 @@ class NPUModelRunner(GPUModelRunner):
                             alignment,
                         )
 
-                    if self.use_sparse and dsa_k_tensor_size is not None:
-                        if current_sparse_c8:
-                            assert dsa_k_scale_tensor_size is not None
-
-                            (
-                                dsa_k_tensor,
-                                dsa_k_scale_tensor,
-                            ) = self._allocate_sparse_c8_indexer_tensors(
-                                dsa_k_tensor_size=dsa_k_tensor_size,
-                                dsa_k_scale_tensor_size=dsa_k_scale_tensor_size,
-                                alignment=alignment,
-                                scale_dtype=current_kv_cache_spec.c8_k_scale_cache_dtype,
-                            )
-                        else:
-                            dsa_k_tensor = self._allocate_int8_cache_tensor(
-                                dsa_k_tensor_size,
-                                alignment,
-                            )
-
                     for layer_name_inner in kv_cache_tensor.shared_by:
                         # shared the attn kvcache for all shared layers
                         if "attn" in layer_name_inner and "linear_attn" not in layer_name_inner:
                             if self.use_sparse:
                                 if current_sparse_c8:
-                                    if has_indexer_cache:
-                                        # Sparse C8 with indexer: packed KV, indexer K, and indexer K scale.
-                                        kv_cache_raw_tensors[layer_name_inner] = (
-                                            k_tensor, dsa_k_tensor, dsa_k_scale_tensor
-                                        )
-                                    else:
-                                        # Sparse C8 without indexer: packed KV only.
-                                        kv_cache_raw_tensors[layer_name_inner] = (k_tensor,)
+                                    kv_cache_raw_tensors[layer_name_inner] = (k_tensor,)
                                 else:
-                                    if has_indexer_cache:
-                                        # Sparse non-C8 with indexer: regular K/V plus indexer K.
-                                        kv_cache_raw_tensors[layer_name_inner] = (
-                                            k_tensor, v_tensor, dsa_k_tensor
-                                        )
-                                    else:
-                                        # Sparse non-C8 without indexer: regular K/V only.
-                                        kv_cache_raw_tensors[layer_name_inner] = (k_tensor, v_tensor)
+                                    assert v_tensor is not None
+                                    kv_cache_raw_tensors[layer_name_inner] = (k_tensor, v_tensor)
                             else:
-                                # Dense attention: regular K/V only.
+                                assert v_tensor is not None
                                 kv_cache_raw_tensors[layer_name_inner] = (k_tensor, v_tensor)
         layer_names = set()
         for group in kv_cache_config.kv_cache_groups:
@@ -4547,41 +4529,59 @@ class NPUModelRunner(GPUModelRunner):
                                            )
 
                     kv_caches[layer_name] = kv_cache
+                elif isinstance(current_kv_cache_spec, AscendSFAIndexerCacheSpec):
+                    raw_cache = kv_cache_raw_tensors[layer_name]
+                    assert isinstance(raw_cache, tuple)
+                    if current_kv_cache_spec.scale_dim:
+                        raw_k_tensor, raw_scale_tensor = raw_cache
+                        sum_page_size_bytes = raw_k_tensor.numel() + raw_scale_tensor.numel()
+                    else:
+                        (raw_k_tensor,) = raw_cache
+                        raw_scale_tensor = None
+                        sum_page_size_bytes = raw_k_tensor.numel()
+
+                    assert sum_page_size_bytes % current_kv_cache_spec.page_size_bytes == 0
+                    num_blocks = sum_page_size_bytes // current_kv_cache_spec.page_size_bytes
+                    assert num_blocks >= kv_cache_config.num_blocks
+
+                    kv_cache_shape = attn_backend.get_kv_cache_shape(
+                        num_blocks * current_kv_cache_spec.sfa_dcp_replicated_indexer_size,
+                        current_kv_cache_spec.block_size,
+                        current_kv_cache_spec.num_kv_heads,
+                        current_kv_cache_spec.head_size,
+                    )
+                    indexer_k_cache = raw_k_tensor.view(current_kv_cache_spec.dtype).view(kv_cache_shape)
+                    if raw_scale_tensor is None:
+                        kv_caches[layer_name] = (indexer_k_cache,)
+                    else:
+                        indexer_scale_cache_shape = attn_backend.get_kv_cache_shape(
+                            num_blocks * current_kv_cache_spec.sfa_dcp_replicated_indexer_size,
+                            current_kv_cache_spec.block_size,
+                            current_kv_cache_spec.num_kv_heads,
+                            current_kv_cache_spec.scale_dim,
+                        )
+                        indexer_scale_cache = (
+                            raw_scale_tensor
+                            .view(current_kv_cache_spec.scale_dtype)
+                            .view(indexer_scale_cache_shape)
+                        )
+                        kv_caches[layer_name] = (indexer_k_cache, indexer_scale_cache)
                 elif isinstance(current_kv_cache_spec, AttentionSpec):
                     # cache_only_layers (extract_hidden_states) are allocated
                     # as a single tensor by the branch at the top of
                     # _allocate_kv_cache_tensors; route them to the dedicated
-                    current_sparse_c8 = kv_cache_spec_uses_sparse_c8(current_kv_cache_spec)
-                    has_indexer_cache = sparse_kv_cache_has_indexer(current_kv_cache_spec)
-                    raw_dsa_k_tensor = None
-                    raw_dsa_k_scale_tensor = None
-                    if self.use_sparse and has_indexer_cache and "cache_only_layers" not in layer_name:
-                        assert isinstance(current_kv_cache_spec, AscendMLAAttentionSpec)
-                        assert current_kv_cache_spec.sparse_head_dim is not None
+                    # elif branch below before the sparse branch tries to
+                    # unpack them as a K/V tuple.
+                    if self.use_sparse and "cache_only_layers" not in layer_name:
+                        current_sparse_c8 = kv_cache_spec_uses_sparse_c8(current_kv_cache_spec)
+                        raw_cache = kv_cache_raw_tensors[layer_name]
+                        assert isinstance(raw_cache, tuple)
                         if current_sparse_c8:
-                            raw_k_tensor, raw_dsa_k_tensor, raw_dsa_k_scale_tensor = (
-                                kv_cache_raw_tensors[layer_name]  # type: ignore
-                            )
-                            assert raw_dsa_k_tensor is not None
-                            assert raw_dsa_k_scale_tensor is not None
-                            sum_page_size_bytes = (
-                                raw_k_tensor.numel()
-                                + raw_dsa_k_tensor.numel()
-                                + raw_dsa_k_scale_tensor.numel()
-                            )
-                        else:
-                            raw_k_tensor, raw_v_tensor, raw_dsa_k_tensor = kv_cache_raw_tensors[  # type: ignore
-                                layer_name]
-                            assert raw_dsa_k_tensor is not None
-                            sum_page_size_bytes = raw_k_tensor.numel() + raw_v_tensor.numel() + raw_dsa_k_tensor.numel()
-                    elif self.use_sparse and "cache_only_layers" not in layer_name:
-                        assert isinstance(current_kv_cache_spec, AscendMLAAttentionSpec)
-                        assert current_kv_cache_spec.sparse_head_dim is not None
-                        if current_sparse_c8:
-                            (raw_k_tensor,) = kv_cache_raw_tensors[layer_name]  # type: ignore
+                            (raw_k_tensor,) = raw_cache
+                            raw_v_tensor = None
                             sum_page_size_bytes = raw_k_tensor.numel()
                         else:
-                            raw_k_tensor, raw_v_tensor = kv_cache_raw_tensors[layer_name]  # type: ignore
+                            raw_k_tensor, raw_v_tensor = raw_cache
                             sum_page_size_bytes = raw_k_tensor.numel() + raw_v_tensor.numel()
                     elif (
                         self.use_hybrid_blocks
@@ -4704,12 +4704,11 @@ class NPUModelRunner(GPUModelRunner):
                             k_dim,
                         )
                         if self.use_sparse and current_sparse_c8:
-                            assert current_kv_cache_spec.sparse_head_dim is not None
                             k_shape = (
                                 mla_num_blocks,
                                 mla_block_size,
                                 num_kv_heads,
-                                current_kv_cache_spec.sparse_head_dim[0],
+                                current_kv_cache_spec.head_size,
                             )
                             v_dim = 0
                         v_shape = (
@@ -4731,44 +4730,15 @@ class NPUModelRunner(GPUModelRunner):
                     if self.use_sparse and current_sparse_c8:
                         v_cache = None
                     else:
+                        assert raw_v_tensor is not None
                         v_cache = raw_v_tensor.view(v_cache_dtype).view(v_shape)
 
-                    if self.use_sparse and has_indexer_cache:
-                        assert raw_dsa_k_tensor is not None
-                        dsa_k_cache_shape = (
-                            num_blocks * current_kv_cache_spec.sfa_dcp_replicated_indexer_size,
-                            current_kv_cache_spec.block_size,
-                            current_kv_cache_spec.num_kv_heads,
-                            self.model_config.hf_text_config.index_head_dim,
-                        )
+                    if self.use_sparse:
                         if current_sparse_c8:
-                            # dsa_k
-                            dsa_k_cache = raw_dsa_k_tensor.view(self.c8_k_cache_dtype).view(dsa_k_cache_shape)
-                            # dsa_k_scale
-                            dsa_k_scale_cache_shape = (
-                                num_blocks * current_kv_cache_spec.sfa_dcp_replicated_indexer_size,
-                                current_kv_cache_spec.block_size,
-                                current_kv_cache_spec.num_kv_heads,
-                                1,
-                            )
-                            assert raw_dsa_k_scale_tensor is not None
-                            dsa_k_scale_cache = (
-                                raw_dsa_k_scale_tensor
-                                .view(self.c8_k_scale_cache_dtype)
-                                .view(dsa_k_scale_cache_shape)
-                            )
-                            if get_ascend_device_type() == AscendDeviceType.A5:
-                                kv_caches[layer_name] = (k_cache, dsa_k_cache, dsa_k_scale_cache)
-                            elif v_cache is not None:
-                                kv_caches[layer_name] = (k_cache, v_cache, dsa_k_cache, dsa_k_scale_cache)
-                            else:
-                                kv_caches[layer_name] = (k_cache, dsa_k_cache, dsa_k_scale_cache)
+                            kv_caches[layer_name] = (k_cache,)
                         else:
-                            # dsa_k
-                            dsa_k_cache = raw_dsa_k_tensor.view(current_kv_cache_spec.dtype).view(dsa_k_cache_shape)
-                            kv_caches[layer_name] = (k_cache, v_cache, dsa_k_cache)
-                    elif self.use_sparse and current_sparse_c8:
-                        kv_caches[layer_name] = (k_cache,)
+                            assert v_cache is not None
+                            kv_caches[layer_name] = (k_cache, v_cache)
                     else:
                         kv_caches[layer_name] = (k_cache, v_cache)
                 elif isinstance(current_kv_cache_spec, MambaSpec):
@@ -4926,11 +4896,16 @@ class NPUModelRunner(GPUModelRunner):
             # they are cached correctly, there will be different objects per
             # layer.
             for layer_name in kv_cache_group_spec.layer_names:
-                attn_backend = layers[layer_name].get_attn_backend()
-                full_cls_name = attn_backend.full_cls_name()
                 layer_kv_cache_spec = kv_cache_group_spec.kv_cache_spec
                 if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
                     layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[layer_name]
+                if isinstance(layer_kv_cache_spec, AscendSFAIndexerCacheSpec):
+                    from vllm_ascend.attention.indexer import AscendSFAIndexerBackend
+
+                    attn_backend = AscendSFAIndexerBackend
+                else:
+                    attn_backend = layers[layer_name].get_attn_backend()
+                full_cls_name = attn_backend.full_cls_name()
                 key = (full_cls_name, layer_kv_cache_spec)
                 attn_backends[key] = AttentionGroupKey(attn_backend, layer_kv_cache_spec)
                 attn_backend_layers[key].append(layer_name)
@@ -5014,6 +4989,8 @@ class NPUModelRunner(GPUModelRunner):
 
         kv_cache_spec: dict[str, list[KVCacheSpec]] = defaultdict(list)
         attn_layers = get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase)
+        from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
+
         # NOTE: Must process Attention/MLAAttention before MambaBase to maintain
         # ordering expected by graph parameter update logic in attention backends.
         mamba_layers: dict[str, MambaBase] = {}
@@ -5042,44 +5019,28 @@ class NPUModelRunner(GPUModelRunner):
             elif isinstance(attn_module, MLAAttention):
                 if self.use_sparse:
                     impl = attn_module.impl
-                    has_indexer = bool(getattr(impl, "has_indexer", False))
-                    use_sparse_c8_sfa_for_layer = bool(getattr(impl, "use_sparse_c8_sfa", False))
-                    use_sparse_c8_indexer_for_layer = bool(getattr(impl, "use_sparse_c8_indexer", False))
-
-                    if use_sparse_c8_sfa_for_layer:
-                        packed_kv_head_dim = get_sfa_qsfa_packed_head_dim(
+                    cache_sparse_c8 = bool(
+                        getattr(impl, "use_sparse_c8_sfa", False)
+                    )
+                    if cache_sparse_c8:
+                        head_size = get_sfa_qsfa_packed_head_dim(
                             self.model_config.hf_text_config.kv_lora_rank,
                             self.model_config.hf_text_config.qk_rope_head_dim,
                         )
-                        sparse_head_dim = (
-                            packed_kv_head_dim,
-                            0,
-                            (
-                                self.model_config.hf_text_config.index_head_dim
-                                if use_sparse_c8_indexer_for_layer
-                                else 0
-                            ),
-                        )
-                    elif has_indexer:
-                        sparse_head_dim = self.sparse_head_dim
+                        dtype = self.c8_k_cache_dtype
                     else:
-                        # Layers that reuse another layer's top-k indices only
-                        # need the MLA latent and RoPE caches.
-                        sparse_head_dim = (
-                            self.model_config.hf_text_config.kv_lora_rank,
-                            self.model_config.hf_text_config.qk_rope_head_dim,
-                            0,
+                        head_size = (
+                            self.model_config.hf_text_config.kv_lora_rank
+                            + self.model_config.hf_text_config.qk_rope_head_dim
                         )
-
+                        dtype = self.kv_cache_dtype
                     kv_cache_spec[layer_name] = AscendMLAAttentionSpec(
                         block_size=self.block_size,
                         num_kv_heads=1,
-                        head_size=sum(sparse_head_dim),
-                        sparse_head_dim=sparse_head_dim,
-                        dtype=self.kv_cache_dtype,
+                        head_size=head_size,
+                        dtype=dtype,
                         cache_dtype_str=self.vllm_config.cache_config.cache_dtype,
-                        cache_sparse_c8=use_sparse_c8_sfa_for_layer,
-                        sfa_dcp_replicated_indexer_size=self.sfa_dcp_replicated_indexer_size,
+                        cache_sparse_c8=cache_sparse_c8,
                     )
                 elif spec := attn_module.get_kv_cache_spec(self.vllm_config):
                     if getattr(attn_module.impl, "fa_quant_layer", False):
@@ -5096,15 +5057,30 @@ class NPUModelRunner(GPUModelRunner):
                     )
                     attn_layer_names.add(layer_name)
 
+            elif self.use_sparse and isinstance(attn_module, DeepseekV32IndexerCache):
+                # TODO: This mirrors upstream's separated KV/indexer specs for
+                # SFA, but keeps Ascend-specific shape/block-size accounting.
+                # Remove this special case once the generic vLLM spec/backend
+                # path can describe the Ascend SFA indexer layout directly.
+                cache_sparse_c8 = self.ascend_config.is_sparse_c8_layer(layer_name)
+                kv_cache_spec[layer_name] = AscendSFAIndexerCacheSpec(
+                    block_size=self.block_size,
+                    num_kv_heads=1,
+                    head_size=self.model_config.hf_text_config.index_head_dim,
+                    dtype=self.c8_k_cache_dtype if cache_sparse_c8 else self.kv_cache_dtype,
+                    cache_dtype_str=self.vllm_config.cache_config.cache_dtype,
+                    scale_dim=1 if cache_sparse_c8 else 0,
+                    scale_dtype=self.c8_k_scale_cache_dtype if cache_sparse_c8 else torch.int8,
+                    cache_sparse_c8=cache_sparse_c8,
+                    sfa_dcp_replicated_indexer_size=self.sfa_dcp_replicated_indexer_size,
+                )
+
             elif isinstance(attn_module, MambaBase):
                 mamba_layers[layer_name] = attn_module
 
             elif isinstance(attn_module, CacheOnlyAttentionLayer):
                 # Only CacheOnlyAttentionLayer (extract_hidden_states draft model)
-                # is handled here. Other AttentionLayerBase subclasses such as
-                # DeepseekV32IndexerCache are intentionally skipped: on Ascend,
-                # the indexer's k_cache is replaced by IndexerWrapper, so its
-                # KV cache is unused.
+                # is handled here.
                 if spec := attn_module.get_kv_cache_spec(self.vllm_config):
                     # Rebuild to a fresh, picklable spec (the returned one
                     # references a stale MLAAttentionSpec class shadowed by


### PR DESCRIPTION
### What this PR does / why we need it?

This PR allocate SFA MLA and indexer caches through separate KV cache specs while keeping Ascend-specific physical tensor layout and binding. We add a cache-only indexer metadata backend so split indexer cache groups do not construct SFA attention metadata. In our earlier implementation, the allocation of  physical indexer cache tensor is along with normal SFA kv cache, i.e. :

```
layers.0.self_attn.attn --> AscendMLAAttentionSpec --> (raw_k_tensor, raw_v_tensor, dsa_k_tensor)
layers.1.self_attn.attn --> AscendMLAAttentionSpec --> (raw_k_tensor, raw_v_tensor, dsa_k_tensor)
layers.2.self_attn.attn --> AscendMLAAttentionSpec --> (raw_k_tensor, raw_v_tensor, dsa_k_tensor)
...
```

**proposed change**

This PR follows the design in vLLM. We introduce a new **AscendSFAIndexerCacheSpec** for SFA indexer cache alone.  AscendSFAIndexerCacheSpec and AscendMLAAttentionSpec are grouped into a UniformTypeKVCacheSpecs. Now the allocation is like:

```
layers.0.self_attn.attn --> AscendMLAAttentionSpec --> (raw_k_tensor, raw_v_tensor)
layers.0.self_attn.indexer.k_cache --> AscendSFAIndexerCacheSpec --> dsa_k_tensor  # Full indexer layer
layers.1.self_attn.attn --> AscendMLAAttentionSpec --> (raw_k_tensor, raw_v_tensor)
layers.1.self_attn.indexer.k_cache --> AscendSFAIndexerCacheSpec --> dsa_k_tensor  # Full indexer layer
layers.2.self_attn.attn --> AscendMLAAttentionSpec --> (raw_k_tensor, raw_v_tensor)
layers.2.self_attn  # Sharing indexer, no physical indexer allocation
...
``` 
In terms of saving indexer cache, this PR takes the same effects as #11065 . The main benefit of PR is to serve as a primitive for later work that might operate SFA KV or indexer at different methods, such as SFA kv offload (see [#48203](https://github.com/vllm-project/vllm/issues/48203)).

**future work**
1. To make a quick change for the cache allocation, we yet do not allocate a single physical tensor for KV. This might require the SFA operator to support non-continuous KV.
2. We does not change DSA C4 specs and remain some arguments for compatibility. But the specs should align in the future.

We leave these as future work.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/e5588e49bc2642670116664a7fc4096e27adb179
