### PR TITLE
[Feature][Model] Support NVIDIA Nemotron 3 Super on Ascend

### DIFF
--- a/docs/source/tutorials/models/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.md
+++ b/docs/source/tutorials/models/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.md
@@ -1,0 +1,449 @@
+# NVIDIA-Nemotron-3-Super-120B-A12B-BF16 Deployment Tutorial
+
+## 1 Introduction
+
+`NVIDIA-Nemotron-3-Super-120B-A12B-BF16` is a 120B-parameter,
+12B-active text-generation model based on the Nemotron-H architecture. It
+combines Mamba2, attention, and latent Mixture-of-Experts (MoE) layers. This
+tutorial describes the verified BF16 deployment path on Atlas A2, including
+chunked prefill, eager execution, `FULL_DECODE_ONLY` ACLGraph execution, and
+contexts up to 1M tokens.
+
+Support is experimental. The configuration in this tutorial was validated on
+one server with eight Ascend 910B3 NPUs and tensor parallel size 8.
+
+## 2 Supported Features
+
+Refer to [Supported Models](../../user_guide/support_matrix/supported_models.md)
+for the project-wide feature matrix.
+
+The following configuration has been validated:
+
+| Feature | Status | Notes |
+| ------- | ------ | ----- |
+| BF16 | Supported | BF16 model weights with FP32 Mamba state cache. |
+| Tensor parallelism | Supported | `--tensor-parallel-size 8`. |
+| Chunked prefill | Supported | Validated with `--max-num-batched-tokens 1024`. |
+| Eager execution | Supported | Use `--enforce-eager`. |
+| ACLGraph | Supported | `FULL_DECODE_ONLY`, capture sizes 1, 2, and 4. |
+| OpenAI-compatible API | Supported | Chat completions and completions endpoints. |
+| Maximum context | Supported | 1,048,576 configured; 1,048,448 input tokens validated. |
+
+Features not marked as supported for this model in the support matrix have not
+been validated by this integration.
+
+## 3 Prerequisites
+
+### 3.1 Hardware
+
+The verified BF16 configuration uses eight Ascend 910B3 NPUs with 64 GiB HBM
+per NPU. Other device counts and HBM capacities may require different parallel
+and cache settings.
+
+### 3.2 Model Weight
+
+Download the model from
+[Hugging Face](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16)
+or prepare an equivalent local directory. The directory must include the
+model-provided `chat_template.jinja` and `super_v3_reasoning_parser.py` files.
+
+The model configuration defaults to a 256K context. NVIDIA documents up to a
+1M context when `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` and
+`--max-model-len 1048576` are set explicitly.
+
+### 3.3 Runtime Environment
+
+Use a vLLM Ascend image or source installation compatible with the current
+main branch. Follow the [Installation Guide](../../installation.md) to prepare
+the driver, CANN toolkit, PyTorch NPU, vLLM, and vLLM Ascend versions.
+
+For this model, disable vLLM batch-invariant mode before starting the server:
+
+```shell
+export VLLM_BATCH_INVARIANT=0
+```
+
+The model uses Ascend custom operators that are disabled when batch-invariant
+mode is enabled. Set this variable in every server process, including spawned
+workers.
+
+## 4 Installation
+
+Install vLLM Ascend from the main branch when validating a source change:
+
+```shell
+git clone https://github.com/vllm-project/vllm-ascend.git
+cd vllm-ascend
+pip install -e .
+```
+
+Verify that all eight devices are visible before deployment:
+
+```shell
+npu-smi info
+```
+
+## 5 Online Service Deployment
+
+Set the model path once for the commands below:
+
+```shell
+export MODEL=/data/models/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+export VLLM_BATCH_INVARIANT=0
+```
+
+### 5.1 Eager Mode
+
+Use eager mode as the functional baseline:
+
+```shell
+vllm serve "${MODEL}" \
+  --served-model-name nemotron-super \
+  --trust-remote-code \
+  --chat-template "${MODEL}/chat_template.jinja" \
+  --default-chat-template-kwargs '{"enable_thinking": false}' \
+  --reasoning-parser super_v3 \
+  --reasoning-parser-plugin "${MODEL}/super_v3_reasoning_parser.py" \
+  --tensor-parallel-size 8 \
+  --dtype bfloat16 \
+  --mamba-ssm-cache-dtype float32 \
+  --max-model-len 262144 \
+  --max-num-batched-tokens 1024 \
+  --max-num-seqs 4 \
+  --enable-chunked-prefill \
+  --enforce-eager \
+  --host 0.0.0.0 \
+  --port 8000
+```
+
+### 5.2 `FULL_DECODE_ONLY` ACLGraph Mode
+
+Use `FULL_DECODE_ONLY` to capture decode at the configured batch sizes while
+keeping prefill outside the graph:
+
+```shell
+vllm serve "${MODEL}" \
+  --served-model-name nemotron-super \
+  --trust-remote-code \
+  --chat-template "${MODEL}/chat_template.jinja" \
+  --default-chat-template-kwargs '{"enable_thinking": false}' \
+  --reasoning-parser super_v3 \
+  --reasoning-parser-plugin "${MODEL}/super_v3_reasoning_parser.py" \
+  --tensor-parallel-size 8 \
+  --dtype bfloat16 \
+  --mamba-ssm-cache-dtype float32 \
+  --max-model-len 262144 \
+  --max-num-batched-tokens 1024 \
+  --max-num-seqs 4 \
+  --enable-chunked-prefill \
+  --compilation-config \
+    '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4]}' \
+  --host 0.0.0.0 \
+  --port 8000
+```
+
+The first request at a newly encountered capture size can include graph
+compilation overhead. Warm up capture sizes 1, 2, and 4 before measuring steady
+state latency.
+
+### 5.3 1M Context Deployment
+
+For 1M context, set the model-length override and reserve enough HBM for model
+execution. The following cache settings are the validated 8x64 GiB profile:
+
+```shell
+export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
+
+vllm serve "${MODEL}" \
+  --served-model-name nemotron-super \
+  --trust-remote-code \
+  --chat-template "${MODEL}/chat_template.jinja" \
+  --default-chat-template-kwargs '{"enable_thinking": false}' \
+  --reasoning-parser super_v3 \
+  --reasoning-parser-plugin "${MODEL}/super_v3_reasoning_parser.py" \
+  --tensor-parallel-size 8 \
+  --dtype bfloat16 \
+  --mamba-ssm-cache-dtype float32 \
+  --max-model-len 1048576 \
+  --max-num-batched-tokens 1024 \
+  --max-num-seqs 4 \
+  --gpu-memory-utilization 0.70 \
+  --kv-cache-memory 8589934592 \
+  --enable-chunked-prefill \
+  --compilation-config \
+    '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4]}' \
+  --host 0.0.0.0 \
+  --port 8000
+```
+
+For eager execution at 1M context, replace `--compilation-config ...` with
+`--enforce-eager`. The 8 GiB KV-cache value is in bytes and is a reference for
+the validated hardware, not a universal recommendation. Reduce
+`--max-num-seqs` or adjust cache allocation if the target system has less HBM.
+
+## 6 Functional Verification
+
+### 6.1 Basic Chat Completion
+
+Send a deterministic request with thinking disabled:
+
+```shell
+curl http://127.0.0.1:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "nemotron-super",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Compute 23 * 19. Reply with only the integer."
+      }
+    ],
+    "max_tokens": 16,
+    "temperature": 0,
+    "chat_template_kwargs": {"enable_thinking": false}
+  }'
+```
+
+The expected `message.content` is `437`.
+
+The integration validation also checks exact answers for an English factual
+prompt and a Chinese instruction. These checks are run with concurrency 1, 2,
+and 4 in both eager and ACLGraph modes.
+
+### 6.2 Long Context
+
+Long-context validation uses an exact needle-retrieval prompt. A unique
+passphrase is inserted at 25% of the prompt and the model must return only that
+passphrase. Token counts are measured after applying the model chat template.
+
+The following cases are part of the integration validation:
+
+| Prompt tokens | Concurrency | Purpose |
+| ------------- | ----------- | ------- |
+| 32,768 | 1, 2, and 4 | Chunked-prefill and concurrent retrieval. |
+| 1,048,448 | 1 | Near-maximum 1M-context retrieval. |
+
+A successful HTTP response alone is insufficient. Verify the exact passphrase,
+`usage.prompt_tokens`, and `finish_reason` for every request.
+
+The validated TP8 BF16 configuration produced the following results on vLLM
+Ascend base `92ff388f`. Short checks contain two sequential waves at each
+concurrency to exercise cache reuse. The 32K row contains one wave at each
+concurrency.
+
+| Mode | Short exact match | 32K exact retrieval | 1,048,448-token retrieval |
+| ---- | ----------------- | ------------------- | ------------------------- |
+| Eager | 14 / 14 | 7 / 7 | 1 / 1 in 405.02 seconds |
+| `FULL_DECODE_ONLY` | 14 / 14 | 7 / 7 | 1 / 1 in 398.18 seconds |
+
+Every long-context response reported the requested prompt-token count and
+`finish_reason=stop`. The near-maximum request returned the exact passphrase in
+both modes.
+
+## 7 Accuracy Evaluation
+
+NVIDIA's published evaluation uses MMLU-Pro with the
+`eval/aai/mcq-10choices-boxed` prompt, one sample, thinking enabled,
+`temperature=1.0`, `top_p=0.95`, and special-token skipping disabled. The
+[NVIDIA reproducibility guide](https://github.com/NVIDIA-NeMo/Evaluator/blob/main/packages/nemo-evaluator-launcher/examples/nemotron/nemotron-3-super/reproducibility.md)
+contains the complete evaluator configuration.
+
+To run the complete official task with NeMo Evaluator Launcher:
+
+```shell
+nemo-evaluator-launcher run \
+  --config local_nemotron-3-super-120b-a12b.yaml \
+  -t nemo_skills.ns_mmlu_pro \
+  -o target.api_endpoint.url=http://127.0.0.1:8000/v1/chat/completions
+```
+
+For a shorter integration check, use a fixed, stratified subset of the official
+MMLU-Pro test split and preserve all of the following in the report:
+
+- Dataset revision and SHA-256.
+- Selection seed and complete question-ID list.
+- Prompt template and generation parameters.
+- Per-category results and a 95% confidence interval.
+- Request errors, unparsed answers, and finish-reason counts.
+
+Do not present a subset result as the full official score. Unparsed or truncated
+responses must count as incorrect. NVIDIA reports 83.73 on the complete
+MMLU-Pro evaluation for this checkpoint; a small subset should be interpreted
+with its confidence interval.
+
+The following result is a reproducible integration check collected with
+`FULL_DECODE_ONLY` at concurrency 4, not a replacement for NVIDIA's complete
+evaluation. Four responses reached the initial 32,768-token output limit. A
+diagnostic retry raised the limit only for those four samples; the latest
+result for every question is shown in the second row.
+
+The subset was collected on vLLM Ascend `731436a1` with vLLM `e5588e49`.
+The 18-case performance matrix in Section 8 was collected after the
+source-changing rebase to vLLM Ascend `b266da5d`, using vLLM `ee0da84a`
+(`v0.24.0`). The deterministic service matrix in Section 6 was rerun on vLLM
+Ascend `92ff388f`; eager and `FULL_DECODE_ONLY` each passed 22/22 exact-content
+requests. After subsequent latest-main rebases, the targeted unit suite was
+rerun and overlapping upstream changes were audited before each branch update.
+This provenance is explicit because the accuracy subset was not rerun after
+the source-changing runtime rebase and the performance matrix was not rerun
+after the final-base rebase.
+
+| Output limit | Samples | Correct | Accuracy | Wilson 95% CI | Errors | Unparsed |
+| ------------ | ------- | ------- | -------- | ------------- | ------ | -------- |
+| 32,768 tokens | 70 | 63 | 90.00% | 80.77%-95.07% | 0 | 4 |
+| Truncated-only retry at 65,536 | 70 | 64 | 91.43% | 82.53%-96.01% | 0 | 2 |
+
+The subset contains five deterministic samples from each of the 14 categories,
+selected with seed `20260710`. It uses the MMLU-Pro test parquet at revision
+`b189ec765aa7ed75c8acfea42df31fdae71f97be`, whose SHA-256 is
+`0e24a191921c2f453518a537a8b2117bd137e7714d4ef1565e9ba06c1ecb9ad8`.
+Generation uses a fixed per-question seed and an initial 32,768-token limit.
+All 70 selected samples are included in the denominator. The initial run had
+66 parsed answers with `finish_reason=stop`; four responses reached the token
+limit and were counted as incorrect. Retrying only those four at 65,536 tokens
+produced two additional parsed answers, one correct and one incorrect. The
+other two responses again reached the output limit. Sampling at
+`temperature=1.0` is sensitive to runtime scheduling, so the retry is reported
+as a diagnostic rather than merged into an official benchmark claim.
+
+The per-category scores below use the latest result after the diagnostic
+retry.
+
+| Category | Question IDs | Correct |
+| -------- | ------------ | ------- |
+| Biology | 2973, 2995, 3161, 3169, 3325 | 5 / 5 |
+| Business | 169, 184, 408, 488, 561 | 4 / 5 |
+| Chemistry | 3527, 3559, 3825, 3915, 4065 | 5 / 5 |
+| Computer science | 10424, 10452, 10573, 10648, 10748 | 5 / 5 |
+| Economics | 6829, 6957, 6980, 7209, 7645 | 4 / 5 |
+| Engineering | 11446, 11652, 11937, 12162, 12234 | 4 / 5 |
+| Health | 6043, 6122, 6155, 6331, 6533 | 5 / 5 |
+| History | 4698, 4800, 4894, 4957, 5023 | 4 / 5 |
+| Law | 945, 1056, 1140, 1149, 1566 | 4 / 5 |
+| Math | 8388, 8568, 8666, 8706, 8975 | 5 / 5 |
+| Other | 5123, 5278, 5788, 5960, 5974 | 4 / 5 |
+| Philosophy | 10975, 11140, 11168, 11177, 11228 | 5 / 5 |
+| Physics | 9057, 9163, 9569, 9778, 10284 | 5 / 5 |
+| Psychology | 2036, 2340, 2375, 2543, 2800 | 5 / 5 |
+
+## 8 Performance Evaluation
+
+Use `vllm bench serve` against a warmed server. Keep server flags, prompt
+distribution, output length, and request count identical when comparing eager
+and ACLGraph modes.
+
+The integration performance matrix uses three workloads:
+
+| Workload | Input / output tokens | Requests | Reported metrics |
+| -------- | --------------------- | -------- | ---------------- |
+| Prefill | 32,768 / 1 | One wave at concurrency 1, 2, and 4 | Input throughput and TTFT. |
+| Decode | 256 / 512 | Two waves at concurrency 1, 2, and 4 | Output throughput and TPOT. |
+| Mixed | 8,192 / 512 | Two waves at concurrency 1, 2, and 4 | TTFT, TPOT, and total throughput. |
+
+Use `--ignore-eos` so every performance request produces the requested output
+length. Run deterministic functional requests separately, because benchmark
+throughput does not prove output correctness.
+
+Performance depends on the device SKU, software stack, graph warmup, model
+storage, scheduler configuration, and request distribution. Treat measured
+values as a reference for a specific environment, not a guaranteed baseline.
+
+The following warmed results were collected on vLLM Ascend base `b266da5d`
+with vLLM `ee0da84a` (`v0.24.0`), on one server with eight Ascend 910B3 64 GiB
+NPUs, TP8, BF16 weights, FP32 Mamba state cache,
+`--max-num-batched-tokens 1024`, and `--max-num-seqs 4`. Each cell reports the
+mean for the corresponding concurrency.
+
+| Workload and metric | Mode | C1 | C2 | C4 |
+| ------------------- | ---- | -- | -- | -- |
+| Prefill total tok/s | Eager | 2,969.66 | 2,957.19 | 2,980.94 |
+| Prefill TTFT (ms) | Eager | 11,034.29 | 16,657.73 | 27,525.14 |
+| Prefill total tok/s | `FULL_DECODE_ONLY` | 2,937.30 | 2,964.44 | 3,022.39 |
+| Prefill TTFT (ms) | `FULL_DECODE_ONLY` | 11,155.79 | 16,662.76 | 27,119.68 |
+| Decode output tok/s | Eager | 4.47 | 8.91 | 17.29 |
+| Decode TPOT (ms) | Eager | 223.32 | 223.39 | 227.32 |
+| Decode output tok/s | `FULL_DECODE_ONLY` | 32.94 | 68.82 | 88.47 |
+| Decode TPOT (ms) | `FULL_DECODE_ONLY` | 24.40 | 28.06 | 40.00 |
+| Mixed output tok/s | Eager | 4.38 | 8.34 | 15.61 |
+| Mixed total tok/s | Eager | 74.49 | 141.75 | 265.35 |
+| Mixed TTFT / TPOT (ms) | Eager | 2,810.81 / 223.16 | 7,198.60 / 225.27 | 8,238.03 / 237.95 |
+| Mixed output tok/s | `FULL_DECODE_ONLY` | 33.33 | 38.76 | 44.33 |
+| Mixed total tok/s | `FULL_DECODE_ONLY` | 566.65 | 658.88 | 753.59 |
+| Mixed TTFT / TPOT (ms) | `FULL_DECODE_ONLY` | 2,790.39 / 24.60 | 7,176.87 / 37.57 | 10,209.55 / 70.11 |
+
+All 18 performance cases completed without request errors. Every decode and
+mixed request produced exactly 512 output tokens. Relative to eager mode,
+`FULL_DECODE_ONLY` improved decode output throughput by 7.36x at C1, 7.72x at
+C2, and 5.12x at C4 while leaving prefill throughput approximately unchanged,
+as expected for decode-only graph capture.
+
+## 9 Performance Tuning
+
+The Mamba path uses Triton kernels adapted for Ascend according to the
+[Triton-Ascend migration guide](https://github.com/triton-lang/triton-ascend/tree/main/docs/zh/migration_guide).
+
+### 9.1 SSD Chunk Scan
+
+The upstream GPU kernel launches a logical program for each chunk and head. On
+Ascend, the physical `coreDim` is limited, so a 1M request can exceed a single
+launch. The Ascend implementation:
+
+- Uses an NPU-specific `M=128`, `N=64`, `K=64`, `num_stages=1` tile.
+- Preserves tail masks and FP32 accumulation.
+- Splits the chunk axis into launches capped at 32,768 programs.
+- Passes valid non-null pointers for compile-time-disabled optional branches.
+- Supports both zero and non-zero initial Mamba states.
+
+For the model's TP-local shape, a 1M request has 8,192 chunks and 131,072
+logical programs. It is executed as four launches without a host-side device
+synchronization.
+
+### 9.2 Selective State Update
+
+The upstream SSU heuristic is retained as the fallback for unrecognized shapes.
+For the model's Ascend 910B3 shape (`head_dim=64`, `dstate=128`, FP32 state
+cache), the following TP-local effective-batch configurations were tuned and
+validated against the upstream reference:
+
+| Effective batch | Upstream heuristic | Tuned config | Kernel speedup | Validation |
+| --------------- | ------------------ | ------------ | -------------- | ---------- |
+| 16 | `M=4, warps=4` | `M=64, warps=1` | 5.52x | Pass |
+| 32 | `M=4, warps=4` | `M=64, warps=4` | 7.24x | Pass |
+| 64 | `M=4, warps=4` | `M=64, warps=1` | 8.89x | Pass |
+
+The dispatcher applies these settings only to the exact validated device,
+shape, and cache dtype. All production configs passed the upstream reference
+comparison with `atol=1e-2` and `rtol=1e-2` across three fixed random seeds.
+
+## 10 FAQs
+
+### 10.1 Why are custom operators disabled at startup?
+
+Confirm that `VLLM_BATCH_INVARIANT=0` is exported in the API server and worker
+environment. Batch-invariant mode disables custom operators that this model
+uses on Ascend.
+
+### 10.2 Why does vLLM warn about a model length greater than 256K?
+
+The checkpoint configuration defaults to 256K while the model card documents
+an explicit 1M override. Set `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` only when 1M
+serving is required and validate the target memory configuration.
+
+### 10.3 Why does a 1M request run out of memory?
+
+Model weights, attention KV cache, Mamba state cache, graph captures, and
+prefill workspace all consume HBM. Start from the validated TP8 profile, lower
+`--max-num-seqs`, and tune `--kv-cache-memory` while retaining HBM headroom.
+
+### 10.4 Why is the first graph request slower?
+
+ACLGraph capture and Triton compilation occur on first use of a new shape or
+capture size. Warm up concurrency 1, 2, and 4 before collecting performance
+results.
+
+### 10.5 Why is `message.content` empty when thinking is enabled?
+
+Use the model-provided reasoning parser and plugin. Thinking tokens may be
+returned in `reasoning_content`, while the parsed final answer is returned in
+`content`. For deterministic functional checks, set
+`chat_template_kwargs.enable_thinking` to `false`.

--- a/docs/source/user_guide/support_matrix/supported_models.md
+++ b/docs/source/user_guide/support_matrix/supported_models.md
@@ -27,6 +27,7 @@ Get the latest info here: <https://github.com/vllm-project/vllm-ascend/issues/16
 | Qwen3-Coder-30B-A3B | ✅ |  | ✅ | A2/A3 | ✅ | ✅ | ✅ |  | ✅ | ✅ | ✅ |  | ✅ | ✅ |  | ✅ | ✅ |  | [Qwen3-Coder-30B-A3B](../../tutorials/models/Qwen3-Coder-30B-A3B.md) |
 | Qwen3-235B-A22B | ✅ |  | ✅ | A2/A3 | ✅ | ✅ | ✅ |  |  | ✅ | ✅ |  | ✅ | ✅ | ✅ | ✅ | ✅ | 256k | [Qwen3-235B-A22B](../../tutorials/models/Qwen3-235B-A22B.md) |
 | Qwen3-Next | 🔵 |  | ✅ | A2/A3 | ✅ |  |  |  |  |  | ✅ |  |  | ✅ |  | ✅ | ✅ |  | [Qwen3-Next](../../tutorials/models/Qwen3-Next.md) |
+| NVIDIA Nemotron-3 Super | 🔵 | Nemotron-H hybrid Mamba2/attention/latent MoE; TP8 eager, FULL_DECODE_ONLY, and 1M context validated | ✅ | A2 | 🟡 | ✅ | 🟡 | 🟡 | 🟡 | 🟡 | ✅ | 🟡 | 🟡 | 🟡 | 🟡 | 🟡 | ✅ | 1M | [NVIDIA-Nemotron-3-Super-120B-A12B-BF16](../../tutorials/models/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.md) |
 | GLM-4.x | 🔵 |  |  | A2/A3 | ✅ | ✅ | ✅ |  | ✅ | ✅ | ✅ |  | ✅ | ✅ | ✅ | ✅ | ✅ | 198k | [GLM-4.x](../../tutorials/models/GLM4.x.md) |
 | GLM-5/5.1 | 🔵 |  | ✅ | A2/A3 | ✅ | ✅ | ✅ |  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 200k | [GLM-5](../../tutorials/models/GLM5.md) |
 | GLM-5.2 | 🔵 |  | ✅ | A2/A3 | ✅ | ✅ | ✅ |  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 200k | [GLM-5.2](../../tutorials/models/GLM5.2.md) |

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -169,6 +169,20 @@ class _Gate(nn.Module):
         return torch.zeros((*hidden_states.shape[:-1], 1), dtype=hidden_states.dtype), None
 
 
+def test_shared_experts_part1_supports_up_proj_without_gate_up_proj():
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    hidden_states = torch.tensor([[1.0, -1.0]])
+    up_out = torch.tensor([[2.0, -2.0]])
+    shared_experts = SimpleNamespace(up_proj=MagicMock(return_value=(up_out, None)))
+    runner._shared_experts = shared_experts
+
+    output = runner._shared_experts_part1(hidden_states)
+
+    torch.testing.assert_close(output, up_out)
+    shared_experts.up_proj.assert_called_once_with(hidden_states)
+
+
 @pytest.mark.parametrize("with_gate", [False, True])
 def test_shared_experts_part2_applies_optional_gate(with_gate):
     runner = AscendMoERunner.__new__(AscendMoERunner)
@@ -195,6 +209,7 @@ def test_shared_forward_impl_returns_current_runner_contract(monkeypatch, has_sh
     nn.Module.__init__(runner)
     runner._shared_experts = object() if has_shared_experts else None
     hidden_states = torch.randn(2, 4)
+    shared_experts_input = torch.randn(2, 6)
     router_logits = torch.randn(2, 3)
     routed_out = torch.randn(2, 4)
     shared_out = torch.randn(2, 4)
@@ -212,7 +227,7 @@ def test_shared_forward_impl_returns_current_runner_contract(monkeypatch, has_sh
     monkeypatch.setattr(AscendMoERunner, "is_internal_router", property(lambda _: False))
     monkeypatch.setattr(fused_moe_module.torch.npu, "current_stream", lambda: current_stream)
 
-    result = runner.shared_forward_impl(hidden_states, router_logits)
+    result = runner.shared_forward_impl(hidden_states, router_logits, shared_experts_input)
 
     runner.no_shared_forward_impl.assert_called_once_with(
         hidden_states,
@@ -223,6 +238,7 @@ def test_shared_forward_impl_returns_current_runner_contract(monkeypatch, has_sh
         assert result[0] is shared_out
         assert result[1] is routed_out
         runner._forward_shared_experts.assert_called_once()
+        assert runner._forward_shared_experts.call_args.args[0] is shared_experts_input
     else:
         assert result is routed_out
         runner._forward_shared_experts.assert_not_called()

--- a/tests/ut/ops/test_mamba_causal_conv1d.py
+++ b/tests/ut/ops/test_mamba_causal_conv1d.py
@@ -1,0 +1,176 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import inspect
+
+import torch
+
+import vllm_ascend.ops.triton.mamba.causal_conv1d as causal_conv
+
+causal_conv1d_fn = causal_conv.causal_conv1d_fn
+
+
+def test_causal_conv1d_fn_accepts_vllm_block_cache_kwargs():
+    signature = inspect.signature(causal_conv1d_fn)
+
+    signature.bind(
+        torch.empty(4, 8),
+        torch.empty(4, 3),
+        None,
+        activation="silu",
+        conv_states=torch.empty(1, 4, 2),
+        has_initial_state=torch.empty(1, dtype=torch.bool),
+        cache_indices=torch.empty(1, dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 8], dtype=torch.int32),
+        block_idx_first_scheduled_token=torch.empty(1, dtype=torch.int32),
+        block_idx_last_scheduled_token=torch.empty(1, dtype=torch.int32),
+        initial_state_idx=torch.empty(1, dtype=torch.int32),
+        num_computed_tokens=torch.empty(1, dtype=torch.int32),
+        block_size_to_align=8,
+        metadata=None,
+    )
+
+
+def test_causal_conv1d_fn_handles_decode_only_batch(monkeypatch):
+    class _FakePCPGroup:
+        world_size = 1
+
+    monkeypatch.setattr(causal_conv, "get_pcp_group", _FakePCPGroup)
+
+    x = torch.tensor([[2.0, 3.0], [5.0, 7.0]])
+    weight = torch.tensor([[0.5, 1.0, 1.5], [1.0, -0.5, 0.25]])
+    bias = torch.tensor([0.25, -1.0])
+    conv_states = torch.tensor(
+        [
+            [[10.0, 11.0], [12.0, 13.0]],
+            [[20.0, 21.0], [22.0, 23.0]],
+        ]
+    )
+    initial_states = conv_states.clone()
+
+    output = causal_conv1d_fn(
+        x,
+        weight,
+        bias,
+        activation=None,
+        conv_states=conv_states,
+        cache_indices=torch.tensor([0, 1], dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
+    )
+
+    expected = torch.empty_like(x)
+    for batch_index in range(2):
+        window = torch.cat(
+            [initial_states[batch_index], x[:, batch_index : batch_index + 1]],
+            dim=-1,
+        )
+        expected[:, batch_index] = (window * weight).sum(dim=-1) + bias
+
+    torch.testing.assert_close(output, expected)
+    torch.testing.assert_close(
+        conv_states[:, :, 0],
+        initial_states[:, :, 1],
+    )
+    torch.testing.assert_close(conv_states[0, :, 1], x[:, 0])
+    torch.testing.assert_close(conv_states[1, :, 1], x[:, 1])
+
+
+def test_causal_conv1d_fn_ignores_stale_state_without_initial_state(monkeypatch):
+    class _FakePCPGroup:
+        world_size = 1
+
+    monkeypatch.setattr(causal_conv, "get_pcp_group", _FakePCPGroup)
+
+    x = torch.tensor([[2.0, 3.0], [5.0, 7.0]])
+    weight = torch.tensor([[0.5, 1.0, 1.5], [1.0, -0.5, 0.25]])
+    bias = torch.tensor([0.25, -1.0])
+    conv_states = torch.full((1, 2, 2), 1000.0)
+
+    output = causal_conv1d_fn(
+        x,
+        weight,
+        bias,
+        activation=None,
+        conv_states=conv_states,
+        has_initial_state=torch.tensor([False]),
+        cache_indices=torch.tensor([0], dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+    )
+
+    expected, expected_state = causal_conv.causal_conv1d_ref(
+        x.unsqueeze(0),
+        weight,
+        bias,
+        activation=None,
+        return_final_states=True,
+    )
+    torch.testing.assert_close(output, expected.squeeze(0))
+    torch.testing.assert_close(conv_states, expected_state)
+
+
+def test_causal_conv1d_fn_handles_all_padding(monkeypatch):
+    class _FakePCPGroup:
+        world_size = 1
+
+    monkeypatch.setattr(causal_conv, "get_pcp_group", _FakePCPGroup)
+
+    x = torch.empty(2, 0)
+    output = causal_conv1d_fn(
+        x,
+        torch.empty(2, 3),
+        conv_states=torch.empty(1, 2, 2),
+        cache_indices=torch.tensor([causal_conv.PAD_SLOT_ID], dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 0], dtype=torch.int32),
+    )
+
+    assert output.shape == x.shape
+    assert output.dtype == x.dtype
+    assert output.device == x.device
+
+
+def test_causal_conv1d_fn_delegates_block_cache_to_vllm(monkeypatch):
+    class _FakePCPGroup:
+        world_size = 1
+
+    sentinel = torch.tensor([123.0])
+    captured_kwargs = {}
+
+    def upstream_causal_conv1d_fn(**kwargs):
+        captured_kwargs.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(causal_conv, "get_pcp_group", _FakePCPGroup)
+    monkeypatch.setattr(
+        causal_conv,
+        "_ORIGINAL_CAUSAL_CONV1D_FN",
+        upstream_causal_conv1d_fn,
+    )
+
+    output = causal_conv1d_fn(
+        torch.empty(2, 1),
+        torch.empty(2, 3),
+        None,
+        conv_states=torch.empty(2, 2, 2),
+        has_initial_state=torch.tensor([True]),
+        cache_indices=torch.tensor([[0, 1]], dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        block_size_to_align=8,
+    )
+
+    assert output is sentinel
+    assert captured_kwargs["cache_indices"].shape == (1, 2)
+    assert captured_kwargs["block_size_to_align"] == 8

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -110,6 +110,27 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
         self.assertEqual(first_call.kwargs["weight"][0].shape, torch.Size([2, 16, 8]))
         self.assertEqual(second_call.kwargs["weight"][0].shape, torch.Size([2, 8, 8]))
 
+    def test_unquant_apply_mlp_supports_relu2_no_mul(self):
+        gate_up = torch.tensor([[-1.0, 2.0], [3.0, -4.0]])
+        expected_act = torch.tensor([[0.0, 4.0], [9.0, 0.0]])
+        expected_out = torch.ones_like(gate_up)
+
+        with patch("vllm_ascend.ops.fused_moe.moe_mlp.torch_npu.npu_grouped_matmul", create=True) as mock_gmm:
+            mock_gmm.side_effect = [[gate_up], [expected_out]]
+
+            output, event = unquant_apply_mlp(
+                hidden_states=torch.randn(2, 2),
+                w1=torch.randn(1, 2, 2),
+                w2=torch.randn(1, 2, 2),
+                group_list=torch.tensor([2], dtype=torch.int64),
+                activation="relu2_no_mul",
+                need_trans=False,
+            )
+
+        self.assertIsNone(event)
+        torch.testing.assert_close(output, expected_out)
+        torch.testing.assert_close(mock_gmm.call_args_list[1].kwargs["x"][0], expected_act)
+
     def test_request_unquant_path(self):
         hidden_states = torch.randn(2, 8)
         expected = torch.randn(2, 8)

--- a/tests/ut/patch/platform/test_patch_fused_moe.py
+++ b/tests/ut/patch/platform/test_patch_fused_moe.py
@@ -1,0 +1,65 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "moe_kwargs",
+    [
+        {"is_act_and_mul": False},
+        {"activation": "silu_no_mul"},
+    ],
+)
+def test_fused_moe_factory_allows_nongated_moe_constructor(monkeypatch, moe_kwargs):
+    import vllm.model_executor.layers.fused_moe.config as vllm_moe_config
+
+    import vllm_ascend.patch.platform.patch_fused_moe as patch_fused_moe
+
+    calls = []
+
+    def fake_fused_moe(*args, runner_cls=None, runner_args=None, **kwargs):
+        calls.append(
+            {
+                "is_cuda_alike": vllm_moe_config.current_platform.is_cuda_alike(),
+                "runner_cls": runner_cls,
+                "runner_args": runner_args,
+                "kwargs": kwargs,
+            }
+        )
+        return "moe"
+
+    monkeypatch.setattr(vllm_moe_config.current_platform, "is_cuda_alike", lambda: False)
+    monkeypatch.setattr(patch_fused_moe, "_original_FusedMoE", fake_fused_moe)
+    monkeypatch.setattr(patch_fused_moe, "_DefaultAscendMoERunner", MagicMock())
+
+    assert not vllm_moe_config.current_platform.is_cuda_alike()
+
+    result = patch_fused_moe._ascend_FusedMoE(**moe_kwargs, tid2eid="map")
+
+    assert result == "moe"
+    assert calls == [
+        {
+            "is_cuda_alike": True,
+            "runner_cls": patch_fused_moe._DefaultAscendMoERunner,
+            "runner_args": {"tid2eid": "map"},
+            "kwargs": moe_kwargs,
+        }
+    ]
+    assert not vllm_moe_config.current_platform.is_cuda_alike()

--- a/tests/ut/patch/platform/test_patch_torch_accelerator.py
+++ b/tests/ut/patch/platform/test_patch_torch_accelerator.py
@@ -1,0 +1,61 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from importlib import reload
+
+import torch
+
+import vllm_ascend.patch.platform.patch_torch_accelerator as patch_torch_accelerator
+
+
+def test_patch_torch_accelerator_redirects_memory_apis(monkeypatch):
+    def npu_empty_cache():
+        empty_cache_calls.append(True)
+
+    def npu_memory_stats():
+        return {"allocated_bytes.all.peak": 1024}
+
+    def npu_memory_reserved():
+        return 2048
+
+    def npu_reset_peak_memory_stats():
+        reset_calls.append(True)
+
+    empty_cache_calls: list[bool] = []
+    reset_calls: list[bool] = []
+
+    with monkeypatch.context() as patch:
+        patch.setattr(torch.npu, "empty_cache", npu_empty_cache, raising=False)
+        patch.setattr(torch.npu, "memory_stats", npu_memory_stats, raising=False)
+        patch.setattr(torch.npu, "memory_reserved", npu_memory_reserved, raising=False)
+        patch.setattr(
+            torch.npu,
+            "reset_peak_memory_stats",
+            npu_reset_peak_memory_stats,
+            raising=False,
+        )
+
+        reload(patch_torch_accelerator)
+
+        assert torch.accelerator.memory_stats is npu_memory_stats
+        assert torch.accelerator.memory_reserved is npu_memory_reserved
+        assert torch.accelerator.reset_peak_memory_stats is npu_reset_peak_memory_stats
+
+        torch.accelerator.empty_cache()
+        assert empty_cache_calls == [True]
+
+    reload(patch_torch_accelerator)

--- a/tests/ut/patch/worker/test_patch_triton_mamba.py
+++ b/tests/ut/patch/worker/test_patch_triton_mamba.py
@@ -1,0 +1,309 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+import torch
+import vllm.model_executor.layers.mamba.ops.mamba_ssm as mamba_ssm
+import vllm.model_executor.layers.mamba.ops.ssd_chunk_scan as ssd_chunk_scan
+import vllm.model_executor.layers.mamba.ops.ssd_combined as ssd_combined
+
+import vllm_ascend.ops.triton.mamba.selective_state_update as ascend_ssu
+import vllm_ascend.ops.triton.mamba.ssd_chunk_scan as ascend_ssd_chunk_scan
+from vllm_ascend.patch.worker import patch_triton
+
+
+@pytest.fixture(autouse=True)
+def clear_ssu_config_cache():
+    ascend_ssu._get_optimal_ssm_config_npu_cached.cache_clear()
+    yield
+    ascend_ssu._get_optimal_ssm_config_npu_cached.cache_clear()
+
+
+def _contiguous_strides(shape):
+    stride = 1
+    strides = []
+    for dim in reversed(shape):
+        strides.append(stride)
+        stride *= dim
+    return tuple(reversed(strides))
+
+
+class _FakeNPUTensor:
+    class _Device:
+        type = "npu"
+        index = 0
+
+    def __init__(self, shape):
+        self.shape = shape
+        self.device = self._Device()
+        self.dtype = torch.float16
+        self._strides = _contiguous_strides(shape)
+
+    def stride(self, dim):
+        return self._strides[dim]
+
+    def dim(self):
+        return len(self.shape)
+
+    def new_empty(self, shape):
+        return _FakeNPUTensor(shape)
+
+
+def test_chunk_scan_dummy_optional_kernel_args_are_non_null():
+    reference = torch.empty(2, 3)
+
+    actual = ascend_ssd_chunk_scan._chunk_scan_optional_kernel_args(reference, None, (1, 1))
+
+    assert actual.shape == (1, 1)
+    assert actual.device == reference.device
+    assert actual.dtype == reference.dtype
+
+
+def test_chunk_scan_initial_states_dummy_reuses_states_pointer():
+    states = torch.empty(2, 3, 4, 5)
+
+    actual = ascend_ssd_chunk_scan._chunk_scan_initial_states_kernel_arg(states, None)
+
+    assert actual is states
+    assert actual.data_ptr() == states.data_ptr()
+
+
+def test_chunk_scan_initial_states_arg_uses_real_tensor():
+    states = torch.empty(2, 3, 4, 5)
+    initial_states = torch.empty(6, 3, 4, 5)
+
+    actual = ascend_ssd_chunk_scan._chunk_scan_initial_states_kernel_arg(states, initial_states)
+
+    assert actual is initial_states
+
+
+def test_chunk_scan_initial_states_strides():
+    initial_states = torch.empty(6, 3, 4, 5)
+
+    actual = ascend_ssd_chunk_scan._chunk_scan_initial_states_strides(initial_states)
+
+    assert actual == initial_states.stride()
+
+
+def test_chunk_scan_default_context_fits_in_one_launch():
+    meta = {
+        "BLOCK_SIZE_M": ascend_ssd_chunk_scan._CHUNK_SCAN_BLOCK_SIZE_M,
+        "BLOCK_SIZE_N": ascend_ssd_chunk_scan._CHUNK_SCAN_BLOCK_SIZE_N,
+    }
+    launch_ranges = list(
+        ascend_ssd_chunk_scan._chunk_scan_launch_ranges(
+            chunk_size=128,
+            headdim=64,
+            nchunks=2048,
+            nheads=16,
+        )
+    )
+    grid = ascend_ssd_chunk_scan._chunk_scan_grid(
+        chunk_size=128,
+        headdim=64,
+        nchunks=launch_ranges[0][1],
+        nheads=16,
+    )(meta)
+
+    assert meta["BLOCK_SIZE_M"] == 128
+    assert launch_ranges == [(0, 2048)]
+    assert grid == (1, 2048, 16)
+    assert grid[0] * grid[1] * grid[2] <= ascend_ssd_chunk_scan._ASCEND_MAX_CORE_DIM
+
+
+def test_chunk_scan_one_million_context_is_split_below_npu_coredim():
+    meta = {
+        "BLOCK_SIZE_M": ascend_ssd_chunk_scan._CHUNK_SCAN_BLOCK_SIZE_M,
+        "BLOCK_SIZE_N": ascend_ssd_chunk_scan._CHUNK_SCAN_BLOCK_SIZE_N,
+    }
+    launch_ranges = list(
+        ascend_ssd_chunk_scan._chunk_scan_launch_ranges(
+            chunk_size=128,
+            headdim=64,
+            nchunks=8192,
+            nheads=16,
+        )
+    )
+
+    assert launch_ranges == [
+        (0, 2048),
+        (2048, 2048),
+        (4096, 2048),
+        (6144, 2048),
+    ]
+    assert sum(nchunks for _, nchunks in launch_ranges) == 8192
+    for _, nchunks in launch_ranges:
+        grid = ascend_ssd_chunk_scan._chunk_scan_grid(
+            chunk_size=128,
+            headdim=64,
+            nchunks=nchunks,
+            nheads=16,
+        )(meta)
+        assert grid[0] * grid[1] * grid[2] <= ascend_ssd_chunk_scan._CHUNK_SCAN_MAX_PROGRAMS_PER_LAUNCH
+        assert grid[0] * grid[1] * grid[2] <= ascend_ssd_chunk_scan._ASCEND_MAX_CORE_DIM
+
+
+def test_chunk_scan_npu_without_initial_states_uses_ascend_kernel(monkeypatch):
+    captured = {}
+
+    class FakeKernel:
+        def __getitem__(self, grid):
+            captured["grid"] = grid
+            return self
+
+        def __call__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(ascend_ssd_chunk_scan, "_chunk_scan_fwd_kernel_npu", FakeKernel())
+
+    seqlen = 16
+    nheads = 2
+    headdim = 4
+    ngroups = 1
+    dstate = 8
+    nchunks = 2
+    chunk_size = 8
+
+    cb = _FakeNPUTensor((nchunks, ngroups, chunk_size, chunk_size))
+    x = _FakeNPUTensor((seqlen, nheads, headdim))
+    dt = _FakeNPUTensor((nheads, nchunks, chunk_size))
+    dA_cumsum = _FakeNPUTensor((nheads, nchunks, chunk_size))
+    C = _FakeNPUTensor((seqlen, ngroups, dstate))
+    states = _FakeNPUTensor((nchunks, nheads, headdim, dstate))
+    cu_chunk_seqlens = _FakeNPUTensor((nchunks + 1,))
+    out = _FakeNPUTensor((seqlen, nheads, headdim))
+    seq_idx = _FakeNPUTensor((nchunks,))
+
+    ascend_ssd_chunk_scan._chunk_scan_fwd_npu(
+        cb,
+        x,
+        dt,
+        dA_cumsum,
+        C,
+        states,
+        cu_chunk_seqlens,
+        out,
+        seq_idx,
+    )
+
+    assert captured["HAS_INITSTATES"] is False
+    assert captured["chunk_start"] == 0
+    assert captured["initstates_ptr"] is states
+    assert captured["stride_init_states_batch"] == 0
+    assert captured["stride_init_states_head"] == 0
+    assert captured["stride_init_states_hdim"] == 0
+    assert captured["stride_init_states_dstate"] == 0
+
+
+def test_chunk_scan_npu_initial_states_uses_ascend_kernel(monkeypatch):
+    captured = {}
+
+    class FakeKernel:
+        def __getitem__(self, grid):
+            captured["grid"] = grid
+            return self
+
+        def __call__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(ascend_ssd_chunk_scan, "_chunk_scan_fwd_kernel_npu", FakeKernel())
+
+    seqlen = 16
+    nheads = 2
+    headdim = 4
+    ngroups = 1
+    dstate = 8
+    nchunks = 2
+    chunk_size = 8
+    batch = 2
+
+    cb = _FakeNPUTensor((nchunks, ngroups, chunk_size, chunk_size))
+    x = _FakeNPUTensor((seqlen, nheads, headdim))
+    dt = _FakeNPUTensor((nheads, nchunks, chunk_size))
+    dA_cumsum = _FakeNPUTensor((nheads, nchunks, chunk_size))
+    C = _FakeNPUTensor((seqlen, ngroups, dstate))
+    states = _FakeNPUTensor((nchunks, nheads, headdim, dstate))
+    cu_chunk_seqlens = _FakeNPUTensor((nchunks + 1,))
+    out = _FakeNPUTensor((seqlen, nheads, headdim))
+    seq_idx = _FakeNPUTensor((nchunks,))
+    initial_states = _FakeNPUTensor((batch, nheads, headdim, dstate))
+
+    ascend_ssd_chunk_scan._chunk_scan_fwd_npu(
+        cb,
+        x,
+        dt,
+        dA_cumsum,
+        C,
+        states,
+        cu_chunk_seqlens,
+        out,
+        seq_idx,
+        initial_states=initial_states,
+    )
+
+    assert captured["HAS_INITSTATES"] is True
+    assert captured["chunk_start"] == 0
+    assert captured["initstates_ptr"] is initial_states
+    assert captured["stride_init_states_batch"] == initial_states.stride(0)
+    assert captured["stride_init_states_head"] == initial_states.stride(1)
+    assert captured["stride_init_states_hdim"] == initial_states.stride(2)
+    assert captured["stride_init_states_dstate"] == initial_states.stride(3)
+
+
+def test_chunk_scan_patch_updates_combined_import_binding():
+    assert ssd_chunk_scan._chunk_scan_fwd is patch_triton._chunk_scan_fwd_npu
+    assert ssd_combined._chunk_scan_fwd is patch_triton._chunk_scan_fwd_npu
+
+
+def test_ssu_patch_uses_ascend_910b3_tuned_configs(monkeypatch):
+    monkeypatch.setattr(ascend_ssu.mamba_ssm, "get_ssm_device_name", lambda: "Ascend910B3")
+    ascend_ssu._get_optimal_ssm_config_npu_cached.cache_clear()
+
+    assert ascend_ssu.try_get_optimal_ssm_config_npu(64, 128, 1, 16, "float32", False) == (64, 1)
+    assert ascend_ssu.try_get_optimal_ssm_config_npu(64, 128, 2, 16, "float32", False) == (64, 4)
+    assert ascend_ssu.try_get_optimal_ssm_config_npu(64, 128, 4, 16, "float32", False) == (64, 1)
+
+
+def test_ssu_config_falls_back_for_other_shapes(monkeypatch):
+    sentinel = (8, 2)
+    monkeypatch.setattr(ascend_ssu, "_ORIGINAL_TRY_GET_OPTIMAL_SSM_CONFIG", lambda *args: sentinel)
+    monkeypatch.setattr(ascend_ssu.mamba_ssm, "get_ssm_device_name", lambda: "Ascend910B3")
+    ascend_ssu._get_optimal_ssm_config_npu_cached.cache_clear()
+
+    assert ascend_ssu.try_get_optimal_ssm_config_npu(128, 128, 1, 16, "float32", False) == sentinel
+    assert ascend_ssu.try_get_optimal_ssm_config_npu(64, 128, 1, 16, "float16", False) == sentinel
+
+
+def test_ssu_config_honors_upstream_benchmark_override_after_cache(monkeypatch):
+    monkeypatch.setattr(ascend_ssu.mamba_ssm, "get_ssm_device_name", lambda: "Ascend910B3")
+    ascend_ssu._get_optimal_ssm_config_npu_cached.cache_clear()
+
+    args = (64, 128, 1, 16, "float32", False)
+    assert ascend_ssu.try_get_optimal_ssm_config_npu(*args) == (64, 1)
+
+    monkeypatch.setattr(ascend_ssu.mamba_ssm, "_ssm_config_override", (8, 2))
+    monkeypatch.setattr(
+        ascend_ssu,
+        "_ORIGINAL_TRY_GET_OPTIMAL_SSM_CONFIG",
+        lambda *unused: ascend_ssu.mamba_ssm._ssm_config_override,
+    )
+
+    assert ascend_ssu.try_get_optimal_ssm_config_npu(*args) == (8, 2)
+
+
+def test_ssu_patch_updates_vllm_binding():
+    assert mamba_ssm.try_get_optimal_ssm_config is patch_triton.try_get_optimal_ssm_config_npu

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -396,6 +396,36 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         self.assertEqual(indexer_scale_cache.shape, (2, 16, 1, 1))
         self.assertEqual(indexer_scale_cache.dtype, torch.float16)
 
+    @patch("vllm_ascend.worker.model_runner_v1.has_kv_transfer_group", return_value=False)
+    @patch("vllm_ascend.worker.model_runner_v1.initialize_mamba_ssu_backend")
+    def test_initialize_kv_cache_initializes_mamba_ssu_backend(
+        self,
+        mock_initialize_mamba_ssu_backend,
+        mock_has_kv_transfer_group,
+    ):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        mamba_config = object()
+        runner.vllm_config = SimpleNamespace(kv_transfer_config=None, mamba_config=mamba_config)
+        runner.model_config = SimpleNamespace(enable_return_routed_experts=False)
+        runner.speculative_config = None
+        runner.may_add_encoder_only_layers_to_kv_cache_config = MagicMock()
+        runner.maybe_add_kv_sharing_layers_to_kv_cache_groups = MagicMock()
+        runner.initialize_attn_backend = MagicMock()
+        runner.attn_groups = []
+        runner.may_reinitialize_input_batch = MagicMock()
+        runner.initialize_kv_cache_tensors = MagicMock(return_value={})
+
+        kv_cache_config = KVCacheConfig(
+            num_blocks=0,
+            kv_cache_tensors=[],
+            kv_cache_groups=[],
+        )
+
+        runner.initialize_kv_cache(kv_cache_config)
+
+        mock_initialize_mamba_ssu_backend.assert_called_once_with(mamba_config, kv_cache_config)
+        mock_has_kv_transfer_group.assert_called_once()
+
 
 class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
     def _build_runner(self):

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -472,7 +472,11 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         )
 
     def _shared_experts_part1(self, hidden_states: torch.Tensor):
-        shared_gate_up, _ = self._shared_experts.gate_up_proj(hidden_states)  # type: ignore
+        assert self._shared_experts is not None
+        shared_up_proj = getattr(self._shared_experts, "gate_up_proj", None)
+        if shared_up_proj is None:
+            shared_up_proj = self._shared_experts.up_proj
+        shared_gate_up, _ = shared_up_proj(hidden_states)  # type: ignore
         return shared_gate_up
 
     def _shared_experts_part2(self, hidden_states: torch.Tensor, shared_gate_up: torch.Tensor):
@@ -636,7 +640,8 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             return routed_out
 
     def _forward_shared_experts(self, hidden_states: torch.Tensor, fused_moe_evts: FusedMoEEvents):
-        if self._shared_experts is None:
+        shared_experts = self._shared_experts
+        if shared_experts is None:
             return None
 
         def maybe_wait_event(evt: torch.npu.Event | None):
@@ -645,10 +650,16 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
 
         with npu_stream_switch(shared_experts_calculation_stream(), enabled=self.multistream_overlap_shared_expert):
             # Only used for int quantization
-            has_quantized_shared = hasattr(self._shared_experts.gate_up_proj, "weight_scale") and hasattr(
-                self._shared_experts.down_proj, "weight_scale"
+            shared_up_proj = getattr(shared_experts, "gate_up_proj", None)
+            if shared_up_proj is None:
+                shared_up_proj = getattr(shared_experts, "up_proj", None)
+            has_quantized_shared = (
+                shared_up_proj is not None
+                and hasattr(shared_up_proj, "weight_scale")
+                and hasattr(shared_experts.down_proj, "weight_scale")
             )
             if has_quantized_shared and self.quant_type in (QuantType.W8A8, QuantType.W4A8):
+                assert shared_up_proj is not None
                 original_dtype = hidden_states.dtype
                 # Execute dynamic quant concurrently with MoE gate.
                 torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
@@ -658,8 +669,8 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 maybe_wait_event(fused_moe_evts.after_routed_experts)
                 hidden_states = torch_npu.npu_quant_matmul(
                     quantized_x,
-                    self._shared_experts.gate_up_proj.weight,
-                    self._shared_experts.gate_up_proj.weight_scale,
+                    shared_up_proj.weight,
+                    shared_up_proj.weight_scale,
                     pertoken_scale=None,
                     bias=None,
                     output_dtype=torch.int32,
@@ -669,7 +680,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 maybe_wait_event(fused_moe_evts.before_gmm2)
                 quantized_x, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
                     x=hidden_states,
-                    weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
+                    weight_scale=shared_up_proj.weight_scale_fp32,
                     activation_scale=pertoken_scale,
                     bias=None,
                     quant_scale=None,
@@ -685,13 +696,14 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 maybe_wait_event(fused_moe_evts.before_combine)
                 shared_out = torch_npu.npu_quant_matmul(
                     quantized_x,
-                    self._shared_experts.down_proj.weight,
-                    self._shared_experts.down_proj.weight_scale,
+                    shared_experts.down_proj.weight,
+                    shared_experts.down_proj.weight_scale,
                     pertoken_scale=swiglu_out_scale,
                     bias=None,
                     output_dtype=original_dtype,
                 )
             elif has_quantized_shared and self.quant_type == QuantType.W4A8MXFP:
+                assert shared_up_proj is not None
                 original_dtype = hidden_states.dtype
                 # Execute dynamic quant concurrently with MoE gate.
                 torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
@@ -701,7 +713,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 # Execute the gate projection and activation concurrently with the
                 # dispatch communication.
                 maybe_wait_event(fused_moe_evts.before_dispatch)
-                hidden_states = self._shared_experts.gate_up_proj((quantized_x, pertoken_scale))[0]
+                hidden_states = shared_up_proj((quantized_x, pertoken_scale))[0]
                 # Execute activation concurrently with gmm2.
                 maybe_wait_event(fused_moe_evts.before_gmm2)
                 quantized_x, swiglu_out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
@@ -715,7 +727,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 # Execute the down projection concurrently with the combine
                 # communication.
                 maybe_wait_event(fused_moe_evts.before_combine)
-                shared_out = self._shared_experts.down_proj((quantized_x, swiglu_out_scale))[0]
+                shared_out = shared_experts.down_proj((quantized_x, swiglu_out_scale))[0]
             else:
                 # Ensure the shared experts wait for hidden_states to be ready.
                 torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
@@ -744,8 +756,12 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         return shared_out
 
     def shared_forward_impl(  # type: ignore[override]
-        self, hidden_states: torch.Tensor, router_logits: torch.Tensor
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        shared_experts_input: torch.Tensor | None = None,
     ):
+        shared_experts_input = shared_experts_input if shared_experts_input is not None else hidden_states
         if self.is_internal_router:
             gate = self.gate
             assert gate is not None
@@ -753,7 +769,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             # increase with extra hidden states. We also assume that all gate
             # linear is unquantized so that we the weight is pre-casted in
             # process_weights_after_loading of AscendUnquantizedLinearMethod.
-            hidden_states_fp32 = hidden_states.float()
+            hidden_states_fp32 = shared_experts_input.float()
             before_routed_experts = torch.npu.current_stream().record_event()
             router_logits = F.linear(hidden_states_fp32, gate.weight_fp32)
             after_routed_experts = torch.npu.current_stream().record_event()
@@ -772,7 +788,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             return routed_out
 
         shared_out = self._forward_shared_experts(
-            hidden_states,
+            shared_experts_input,
             FusedMoEEvents(
                 after_routed_experts=after_routed_experts,
                 before_routed_experts=before_routed_experts,
@@ -795,4 +811,4 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             if self.shared_experts is None:
                 return self.no_shared_forward_impl(hidden_states, router_logits)
             else:
-                return self.shared_forward_impl(hidden_states, router_logits)
+                return self.shared_forward_impl(hidden_states, router_logits, shared_experts_input)

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -16,6 +16,7 @@
 
 
 import torch
+import torch.nn.functional as F
 import torch_npu
 from torch.nn.functional import pad
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
@@ -464,11 +465,21 @@ def unquant_apply_mlp(
             topk_ids=topk_ids,
         )
 
+    activation_value = activation.value if isinstance(activation, MoEActivation) else activation
+
     if activation == MoEActivation.SWIGLUOAI:
         num_experts, _, hidden_size = w1.shape
         gate_up_out = AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out.view(-1, hidden_size))
     elif activation == MoEActivation.SWIGLUSTEP:
         gate_up_out = AscendSwigluStepAndMul.swiglustep_forward(gate_up_out, limit=swiglu_limit or 7.0)
+    elif activation_value == "silu_no_mul":
+        gate_up_out = F.silu(gate_up_out)
+    elif activation_value == "gelu_no_mul":
+        gate_up_out = F.gelu(gate_up_out)
+    elif activation_value == "gelu_tanh_no_mul":
+        gate_up_out = F.gelu(gate_up_out, approximate="tanh")
+    elif activation_value == "relu2_no_mul":
+        gate_up_out = F.relu(gate_up_out).pow(2)
     elif activation == MoEActivation.GELU:
         gate, up = gate_up_out.chunk(2, dim=-1)
         gate_up_out = torch.nn.functional.gelu(gate) * up

--- a/vllm_ascend/ops/triton/mamba/causal_conv1d.py
+++ b/vllm_ascend/ops/triton/mamba/causal_conv1d.py
@@ -7,7 +7,13 @@
 # and https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
 # mypy: ignore-errors
 
+from typing import Any
+
 import torch
+import torch.nn.functional as F
+import vllm.model_executor.layers.mamba.ops.causal_conv1d as _causal_conv1d
+from vllm.distributed import get_pcp_group
+from vllm.logger import logger
 from vllm.triton_utils import HAS_TRITON, tl, triton
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID  # type: ignore
 
@@ -20,12 +26,144 @@ if not HAS_TRITON:
 else:
     _pytorch_update = None
 
+_ORIGINAL_CAUSAL_CONV1D_FN = _causal_conv1d.causal_conv1d_fn
+
+
+def causal_conv1d_ref(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    initial_states: torch.Tensor | None = None,
+    return_final_states: bool = False,
+    final_states_out: torch.Tensor | None = None,
+    activation: str | None = "silu",
+):
+    """
+    x: (batch, dim, seqlen)
+    weight: (dim, width)
+    bias: (dim,)
+    initial_states: (batch, dim, width - 1)
+    final_states_out: (batch, dim, width - 1)
+    out: (batch, dim, seqlen)
+    """
+    if activation not in [None, "silu", "swish"]:
+        logger.error("[TritonOps] activation must be None, silu, or swish, got activation=%s.", activation)
+        raise NotImplementedError("activation must be None, silu, or swish, got activation=%s.", activation)
+    dtype_in = x.dtype
+    x = x.to(weight.dtype)
+    seqlen = x.shape[-1]
+    dim, width = weight.shape
+
+    if initial_states is None:
+        out = F.conv1d(x, weight.unsqueeze(1), bias, padding=width - 1, groups=dim)
+    else:
+        x = torch.cat([initial_states, x], dim=-1)
+        out = F.conv1d(x, weight.unsqueeze(1), bias, padding=0, groups=dim)
+    out = out[..., :seqlen]
+
+    if return_final_states:
+        final_states = F.pad(x, (width - 1 - x.shape[-1], 0)).to(dtype_in)
+        if final_states_out is not None:
+            final_states_out.copy_(final_states)
+        else:
+            final_states_out = final_states
+    out = (out if activation is None else F.silu(out)).to(dtype=dtype_in)
+    return (out, None) if not return_final_states else (out, final_states_out)
+
+
+def causal_conv1d_fn(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    activation: str | None = "silu",
+    conv_states: torch.Tensor | None = None,
+    has_initial_state: torch.Tensor | None = None,
+    cache_indices: torch.Tensor | None = None,
+    query_start_loc: torch.Tensor | None = None,
+    metadata: Any | None = None,
+    pad_slot_id: int = PAD_SLOT_ID,
+    null_block_id: int | None = None,
+    block_idx_first_scheduled_token: torch.Tensor | None = None,
+    block_idx_last_scheduled_token: torch.Tensor | None = None,
+    initial_state_idx: torch.Tensor | None = None,
+    num_computed_tokens: torch.Tensor | None = None,
+    block_size_to_align: int = 0,
+    validate_data: bool = False,
+):
+    """
+    x: (batch, dim, seqlen) or (dim, cu_seq_len) for varlen
+    weight: (dim, width)
+    bias: (dim,)
+    query_start_loc: (batch + 1) int32
+    cache_indices: (batch) int32
+    conv_states: (..., dim, width - 1), updated in place if provided
+    activation: either None or "silu" or "swish"
+    out: (batch, dim, seqlen)
+    """
+    if cache_indices is None or cache_indices.dim() != 1 or get_pcp_group().world_size > 1:
+        return _ORIGINAL_CAUSAL_CONV1D_FN(
+            x=x,
+            weight=weight,
+            bias=bias,
+            conv_states=conv_states,
+            query_start_loc=query_start_loc,
+            cache_indices=cache_indices,
+            has_initial_state=has_initial_state,
+            activation=activation,
+            pad_slot_id=pad_slot_id,
+            null_block_id=null_block_id,
+            block_idx_first_scheduled_token=block_idx_first_scheduled_token,
+            block_idx_last_scheduled_token=block_idx_last_scheduled_token,
+            initial_state_idx=initial_state_idx,
+            num_computed_tokens=num_computed_tokens,
+            block_size_to_align=block_size_to_align,
+            metadata=metadata,
+            validate_data=validate_data,
+        )
+
+    if activation not in [None, "silu", "swish"]:
+        logger.error("[TritonOps] activation must be None, silu, or swish, got activation=%s.", activation)
+        raise NotImplementedError("[TritonOps] activation must be None, silu, or swish, got activation=%s.", activation)
+    if x.stride(-1) != 1:
+        x = x.contiguous()
+    bias = bias.contiguous() if bias is not None else None
+
+    assert conv_states is not None
+    assert query_start_loc is not None
+
+    seqlens = query_start_loc[1:] - query_start_loc[:-1]
+    splits = torch.split(x, seqlens.tolist(), dim=-1)
+    width = weight.shape[1]
+    state_len = width - 1
+
+    out_ref_b = []
+    for idx, x_s in enumerate(splits):
+        state_index = int(cache_indices[idx].item())
+        if state_index == pad_slot_id or (null_block_id is not None and state_index == null_block_id):
+            continue
+        cached_state = conv_states[state_index][..., :state_len]
+        use_initial_state = has_initial_state is None or bool(has_initial_state[idx].item())
+        out_ref_b.append(
+            causal_conv1d_ref(
+                x_s,
+                weight,
+                bias,
+                activation=activation,
+                return_final_states=True,
+                final_states_out=cached_state.unsqueeze(0),
+                initial_states=cached_state if use_initial_state else None,
+            )
+        )
+
+    if not out_ref_b:
+        return x[..., :0]
+    return torch.cat([item[0] for item in out_ref_b], dim=-1)
+
 
 def extract_last_width(x, start_loc, width):
     end_loc = start_loc[1:]
     offsets = torch.arange(width, device=x.device)
-    indices = end_loc.unsqueeze(1) - width + offsets.unsqueeze(0)  # (num_seqs, width)
-
+    indices = end_loc.unsqueeze(1) - width + offsets.unsqueeze(0)
     return x[:, indices].permute(1, 0, 2)
 
 

--- a/vllm_ascend/ops/triton/mamba/selective_state_update.py
+++ b/vllm_ascend/ops/triton/mamba/selective_state_update.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+import functools
+
+from vllm.logger import logger
+from vllm.model_executor.layers.mamba.ops import mamba_ssm
+
+_ORIGINAL_TRY_GET_OPTIMAL_SSM_CONFIG = mamba_ssm.try_get_optimal_ssm_config
+
+# Tuned with vLLM's selective-state-update benchmark on Ascend 910B3. The
+# keys are effective batch sizes (batch * TP-local heads).
+_ASCEND_910B3_FP32_CONFIGS = {
+    16: (64, 1),
+    32: (64, 4),
+    64: (64, 1),
+}
+
+
+@functools.cache
+def _get_optimal_ssm_config_npu_cached(
+    headdim: int,
+    dstate: int,
+    batch: int,
+    nheads: int,
+    cache_dtype: str,
+    is_blackwell: bool,
+) -> tuple[int, int]:
+    if (
+        headdim == 64
+        and dstate == 128
+        and cache_dtype == "float32"
+        and mamba_ssm.get_ssm_device_name() == "Ascend910B3"
+    ):
+        logger.info_once(
+            "Using tuned Ascend 910B3 Mamba SSU config for headdim=64, dstate=128, and float32 state cache.",
+            scope="global",
+        )
+        effective_batch = batch * nheads
+        closest = min(
+            _ASCEND_910B3_FP32_CONFIGS,
+            key=lambda candidate: abs(candidate - effective_batch),
+        )
+        return _ASCEND_910B3_FP32_CONFIGS[closest]
+
+    return _ORIGINAL_TRY_GET_OPTIMAL_SSM_CONFIG(
+        headdim,
+        dstate,
+        batch,
+        nheads,
+        cache_dtype,
+        is_blackwell,
+    )
+
+
+def try_get_optimal_ssm_config_npu(
+    headdim: int,
+    dstate: int,
+    batch: int,
+    nheads: int,
+    cache_dtype: str,
+    is_blackwell: bool,
+) -> tuple[int, int]:
+    # Keep vLLM's benchmark override authoritative even after a production
+    # config for the same shape has been cached.
+    if getattr(mamba_ssm, "_ssm_config_override", None) is not None:
+        return _ORIGINAL_TRY_GET_OPTIMAL_SSM_CONFIG(
+            headdim,
+            dstate,
+            batch,
+            nheads,
+            cache_dtype,
+            is_blackwell,
+        )
+    return _get_optimal_ssm_config_npu_cached(
+        headdim,
+        dstate,
+        batch,
+        nheads,
+        cache_dtype,
+        is_blackwell,
+    )

--- a/vllm_ascend/ops/triton/mamba/ssd_chunk_scan.py
+++ b/vllm_ascend/ops/triton/mamba/ssd_chunk_scan.py
@@ -1,0 +1,628 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Copyright (c) 2024, Tri Dao, Albert Gu.
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Adapted from vLLM's Mamba SSD chunk scan kernel for Ascend NPU.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import vllm.model_executor.layers.mamba.ops.ssd_chunk_scan as _ssd_chunk_scan
+from vllm.model_executor.layers.mamba.ops.triton_helpers import fast_exp
+from vllm.triton_utils import tl, triton
+
+_ORIGINAL_CHUNK_SCAN_FWD = _ssd_chunk_scan._chunk_scan_fwd
+_ASCEND_MAX_CORE_DIM = 65535
+_CHUNK_SCAN_MAX_PROGRAMS_PER_LAUNCH = 32768
+_CHUNK_SCAN_BLOCK_SIZE_M = 128
+_CHUNK_SCAN_BLOCK_SIZE_N = 64
+_CHUNK_SCAN_BLOCK_SIZE_K = 64
+_CHUNK_SCAN_NPU_CONFIGS = [
+    triton.Config(
+        {
+            "BLOCK_SIZE_M": _CHUNK_SCAN_BLOCK_SIZE_M,
+            "BLOCK_SIZE_N": _CHUNK_SCAN_BLOCK_SIZE_N,
+            "BLOCK_SIZE_K": _CHUNK_SCAN_BLOCK_SIZE_K,
+        },
+        num_stages=1,
+        num_warps=4,
+    )
+]
+
+
+def _chunk_scan_optional_kernel_args(reference, optional_tensor, shape):
+    if optional_tensor is not None:
+        return optional_tensor
+    return reference.new_empty(shape)
+
+
+def _chunk_scan_initial_states_kernel_arg(states, initial_states):
+    if initial_states is not None:
+        return initial_states
+    return states
+
+
+def _chunk_scan_initial_states_strides(initial_states):
+    if initial_states is None:
+        return (0, 0, 0, 0)
+    return (
+        initial_states.stride(0),
+        initial_states.stride(1),
+        initial_states.stride(2),
+        initial_states.stride(3),
+    )
+
+
+def _chunk_scan_grid(chunk_size, headdim, nchunks, nheads):
+    return lambda meta: (
+        triton.cdiv(chunk_size, meta["BLOCK_SIZE_M"]) * triton.cdiv(headdim, meta["BLOCK_SIZE_N"]),
+        nchunks,
+        nheads,
+    )
+
+
+def _chunk_scan_launch_ranges(chunk_size, headdim, nchunks, nheads):
+    programs_per_chunk = (
+        triton.cdiv(chunk_size, _CHUNK_SCAN_BLOCK_SIZE_M) * triton.cdiv(headdim, _CHUNK_SCAN_BLOCK_SIZE_N) * nheads
+    )
+    chunks_per_launch = (
+        min(
+            _ASCEND_MAX_CORE_DIM,
+            _CHUNK_SCAN_MAX_PROGRAMS_PER_LAUNCH,
+        )
+        // programs_per_chunk
+    )
+    if chunks_per_launch < 1:
+        raise ValueError("chunk scan tile requires more programs than Ascend supports in one launch")
+    for chunk_start in range(0, nchunks, chunks_per_launch):
+        yield chunk_start, min(chunks_per_launch, nchunks - chunk_start)
+
+
+@triton.autotune(
+    # The upstream CUDA kernel autotunes a large configuration set. On
+    # Triton-Ascend this makes the first chunked-prefill request compile many
+    # kernel variants across TP ranks. Keep the NPU path fixed to a stable
+    # tile for Mamba2's chunk_size=128, head_dim=64, dstate=128 profile.
+    # BLOCK_SIZE_M=128 keeps the common 262,144-token request in one launch.
+    # Longer requests are split along the chunk axis to stay below Ascend's
+    # coreDim limit without adding a device synchronization. Keep each 3D grid
+    # at 32,768 programs: grids close to the 65,535 hard limit can trigger an
+    # MTE out-of-range fault on Ascend 910B with Triton-Ascend 3.2.x.
+    configs=_CHUNK_SCAN_NPU_CONFIGS,
+    key=["chunk_size", "hdim", "dstate", "IS_CAUSAL"],
+)
+@triton.jit
+def _chunk_scan_fwd_kernel_npu(
+    # Pointers to matrices
+    cb_ptr,
+    x_ptr,
+    z_ptr,
+    out_ptr,
+    dt_ptr,
+    dA_cumsum_ptr,
+    seq_idx_ptr,
+    C_ptr,
+    states_ptr,
+    D_ptr,
+    initstates_ptr,
+    cu_chunk_seqlens_ptr,
+    # Matrix dimensions
+    chunk_start: tl.int64,
+    chunk_size: tl.constexpr,
+    hdim: tl.constexpr,
+    dstate: tl.constexpr,
+    nheads_ngroups_ratio: tl.constexpr,
+    # Strides
+    stride_cb_chunk: tl.int64,
+    stride_cb_head: tl.int64,
+    stride_cb_csize_m: tl.int64,
+    stride_cb_csize_k: tl.constexpr,
+    stride_x_seqlen: tl.int64,
+    stride_x_head: tl.int64,
+    stride_x_hdim: tl.constexpr,
+    stride_z_seqlen: tl.int64,
+    stride_z_head: tl.int64,
+    stride_z_hdim: tl.constexpr,
+    stride_out_seqlen: tl.int64,
+    stride_out_head: tl.int64,
+    stride_out_hdim: tl.constexpr,
+    stride_dt_chunk: tl.int64,
+    stride_dt_head: tl.int64,
+    stride_dt_csize: tl.constexpr,
+    stride_dA_cs_chunk: tl.int64,
+    stride_dA_cs_head: tl.int64,
+    stride_dA_cs_csize: tl.constexpr,
+    stride_seq_idx_chunk: tl.constexpr,
+    stride_C_seqlen: tl.int64,
+    stride_C_head: tl.int64,
+    stride_C_dstate: tl.constexpr,
+    stride_states_chunk: tl.int64,
+    stride_states_head: tl.int64,
+    stride_states_hdim: tl.int64,
+    stride_states_dstate: tl.constexpr,
+    stride_init_states_batch: tl.int64,
+    stride_init_states_head: tl.int64,
+    stride_init_states_hdim: tl.int64,
+    stride_init_states_dstate: tl.constexpr,
+    stride_D_head: tl.constexpr,
+    # Meta-parameters
+    IS_CAUSAL: tl.constexpr,
+    HAS_D: tl.constexpr,
+    D_HAS_HDIM: tl.constexpr,
+    HAS_Z: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    BLOCK_SIZE_DSTATE: tl.constexpr,
+    IS_TRITON_22: tl.constexpr,
+    HAS_INITSTATES: tl.constexpr,
+):
+    pid_c = tl.program_id(axis=1).to(tl.int64) + chunk_start
+    pid_h = tl.program_id(axis=2)
+    num_pid_n = tl.cdiv(hdim, BLOCK_SIZE_N)
+    pid_m = tl.program_id(axis=0) // num_pid_n
+    pid_n = tl.program_id(axis=0) % num_pid_n
+    cb_ptr += pid_c * stride_cb_chunk + (pid_h // nheads_ngroups_ratio) * stride_cb_head
+    chunk_seqlen_start = tl.load(cu_chunk_seqlens_ptr + pid_c)
+    chunk_seqlen_end = tl.load(cu_chunk_seqlens_ptr + pid_c + 1)
+    x_ptr += chunk_seqlen_start * stride_x_seqlen + pid_h * stride_x_head
+    dt_ptr += pid_c * stride_dt_chunk + pid_h * stride_dt_head
+    dA_cumsum_ptr += pid_c * stride_dA_cs_chunk + pid_h * stride_dA_cs_head
+    C_ptr += chunk_seqlen_start * stride_C_seqlen + (pid_h // nheads_ngroups_ratio) * stride_C_head
+
+    # M-block offsets and prev states
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+
+    seq_idx_ptr += pid_c * stride_seq_idx_chunk
+    seq_idx = tl.load(seq_idx_ptr)
+    seq_idx_prev = tl.load(seq_idx_ptr - stride_seq_idx_chunk, mask=pid_c >= 1, other=-1)
+    starts_new_sequence = seq_idx != seq_idx_prev
+
+    if HAS_INITSTATES:
+        # Triton-Ascend rejects selecting between pointer values that originate
+        # from different tensors. Keep the init-state path valid by loading
+        # both candidate states and selecting the value, not the pointer.
+        safe_prev_chunk = tl.where(pid_c >= 1, pid_c - 1, 0)
+        state_prev_states_ptr = states_ptr + safe_prev_chunk * stride_states_chunk + pid_h * stride_states_head
+        init_prev_states_ptr = initstates_ptr + seq_idx * stride_init_states_batch + pid_h * stride_init_states_head
+    else:
+        safe_prev_chunk = tl.where(pid_c >= 1, pid_c - 1, 0)
+        prev_states_ptr = states_ptr + safe_prev_chunk * stride_states_chunk + pid_h * stride_states_head
+        prev_states_hdim = stride_states_hdim
+        prev_states_dstate = stride_states_dstate
+
+    chunk_size_limit = chunk_seqlen_end - chunk_seqlen_start
+
+    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    dA_cs_m = tl.load(dA_cumsum_ptr + offs_m * stride_dA_cs_csize, mask=offs_m < chunk_size, other=0.0).to(tl.float32)
+
+    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    offs_out_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_out_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+
+    # Faster to just do 1 iteration with larger BLOCK_SIZE_K, up to block size 128
+    offs_k_dstate = tl.arange(0, BLOCK_SIZE_DSTATE if BLOCK_SIZE_DSTATE <= 128 else BLOCK_SIZE_K)
+    C_ptrs = C_ptr + (offs_m[:, None] * stride_C_seqlen + offs_k_dstate[None, :] * stride_C_dstate)
+
+    scale_m = fast_exp(dA_cs_m)
+    if BLOCK_SIZE_DSTATE <= 128:
+        C = tl.load(
+            C_ptrs,
+            mask=(offs_m[:, None] < chunk_size_limit) & (offs_k_dstate[None, :] < dstate),
+            other=0.0,
+        )
+
+        if HAS_INITSTATES:
+            state_prev_states_ptrs = (
+                state_prev_states_ptr
+                + offs_n[None, :] * stride_states_hdim
+                + offs_k_dstate[:, None] * stride_states_dstate
+            )
+            state_prev_states = tl.load(
+                state_prev_states_ptrs,
+                mask=(offs_k_dstate[:, None] < dstate) & (offs_n[None, :] < hdim),
+                other=0.0,
+            )
+            state_prev_states = state_prev_states.to(C_ptr.dtype.element_ty)
+            init_prev_states_ptrs = (
+                init_prev_states_ptr
+                + offs_n[None, :] * stride_init_states_hdim
+                + offs_k_dstate[:, None] * stride_init_states_dstate
+            )
+            init_prev_states = tl.load(
+                init_prev_states_ptrs,
+                mask=(offs_k_dstate[:, None] < dstate) & (offs_n[None, :] < hdim),
+                other=0.0,
+            )
+            init_prev_states = init_prev_states.to(C_ptr.dtype.element_ty)
+            prev_states = tl.where(starts_new_sequence, init_prev_states, state_prev_states)
+        else:
+            if seq_idx != seq_idx_prev:
+                prev_states = tl.zeros(
+                    (BLOCK_SIZE_DSTATE, BLOCK_SIZE_N),
+                    dtype=C_ptr.dtype.element_ty,
+                )
+            else:
+                prev_states_ptrs = (
+                    prev_states_ptr + offs_n[None, :] * prev_states_hdim + offs_k_dstate[:, None] * prev_states_dstate
+                )
+                prev_states = tl.load(
+                    prev_states_ptrs,
+                    mask=(offs_k_dstate[:, None] < dstate) & (offs_n[None, :] < hdim),
+                    other=0.0,
+                )
+                prev_states = prev_states.to(C_ptr.dtype.element_ty)
+
+        acc = tl.dot(C, prev_states) * scale_m[:, None]
+
+    else:
+        if HAS_INITSTATES:
+            state_prev_states_ptrs = (
+                state_prev_states_ptr
+                + offs_n[None, :] * stride_states_hdim
+                + offs_k_dstate[:, None] * stride_states_dstate
+            )
+            init_prev_states_ptrs = (
+                init_prev_states_ptr
+                + offs_n[None, :] * stride_init_states_hdim
+                + offs_k_dstate[:, None] * stride_init_states_dstate
+            )
+        else:
+            prev_states_ptrs = (
+                prev_states_ptr + offs_n[None, :] * prev_states_hdim + offs_k_dstate[:, None] * prev_states_dstate
+            )
+        for k in range(0, dstate, BLOCK_SIZE_K):
+            C = tl.load(
+                C_ptrs,
+                mask=(offs_m[:, None] < chunk_size_limit) & (offs_k_dstate[None, :] < dstate - k),
+                other=0.0,
+            )
+            if HAS_INITSTATES:
+                state_prev_states = tl.load(
+                    state_prev_states_ptrs,
+                    mask=(offs_k_dstate[:, None] < dstate - k) & (offs_n[None, :] < hdim),
+                    other=0.0,
+                )
+                state_prev_states = state_prev_states.to(C_ptr.dtype.element_ty)
+                init_prev_states = tl.load(
+                    init_prev_states_ptrs,
+                    mask=(offs_k_dstate[:, None] < dstate - k) & (offs_n[None, :] < hdim),
+                    other=0.0,
+                )
+                init_prev_states = init_prev_states.to(C_ptr.dtype.element_ty)
+                prev_states = tl.where(starts_new_sequence, init_prev_states, state_prev_states)
+                state_prev_states_ptrs += BLOCK_SIZE_K
+                init_prev_states_ptrs += BLOCK_SIZE_K
+            else:
+                if seq_idx != seq_idx_prev:
+                    prev_states = tl.zeros((BLOCK_SIZE_K, BLOCK_SIZE_N), dtype=C_ptr.dtype.element_ty)
+                else:
+                    prev_states = tl.load(
+                        prev_states_ptrs,
+                        mask=(offs_k_dstate[:, None] < dstate - k) & (offs_n[None, :] < hdim),
+                        other=0.0,
+                    )
+                    prev_states = prev_states.to(C_ptr.dtype.element_ty)
+                prev_states_ptrs += BLOCK_SIZE_K
+            acc += tl.dot(C, prev_states)
+            C_ptrs += BLOCK_SIZE_K
+        acc *= scale_m[:, None]
+
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    cb_ptrs = cb_ptr + (offs_m[:, None] * stride_cb_csize_m + offs_k[None, :] * stride_cb_csize_k)
+    x_ptrs = x_ptr + (offs_k[:, None] * stride_x_seqlen + offs_n[None, :] * stride_x_hdim)
+    dt_ptrs = dt_ptr + offs_k * stride_dt_csize
+    dA_cumsum_ptrs = dA_cumsum_ptr + offs_k * stride_dA_cs_csize
+    K_MAX = chunk_size_limit if not IS_CAUSAL else min((pid_m + 1) * BLOCK_SIZE_M, chunk_size_limit)
+    for k in range(0, K_MAX, BLOCK_SIZE_K):
+        cb = tl.load(
+            cb_ptrs,
+            mask=(offs_m[:, None] < chunk_size) & (offs_k[None, :] < chunk_size - k),
+            other=0.0,
+        ).to(tl.float32)
+        dA_cs_k = tl.load(dA_cumsum_ptrs, mask=offs_k < chunk_size - k, other=0.0).to(tl.float32)
+        cb *= fast_exp(tl.minimum(dA_cs_m[:, None] - dA_cs_k[None, :], 0.0))
+        dt_k = tl.load(dt_ptrs, mask=offs_k < chunk_size - k, other=0.0).to(tl.float32)
+        cb *= dt_k
+        if IS_CAUSAL:
+            mask = offs_m[:, None] >= k + offs_k[None, :]
+            cb = tl.where(mask, cb, 0.0)
+        cb = cb.to(x_ptr.dtype.element_ty)
+        x = tl.load(
+            x_ptrs,
+            mask=(offs_k[:, None] < chunk_size_limit - k) & (offs_n[None, :] < hdim),
+            other=0.0,
+        )
+        acc += tl.dot(cb, x)
+        cb_ptrs += BLOCK_SIZE_K * stride_cb_csize_k
+        x_ptrs += BLOCK_SIZE_K * stride_x_seqlen
+        dt_ptrs += BLOCK_SIZE_K * stride_dt_csize
+        dA_cumsum_ptrs += BLOCK_SIZE_K * stride_dA_cs_csize
+
+    offs_out_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_out_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+
+    if HAS_D:
+        if D_HAS_HDIM:
+            D = tl.load(D_ptr + pid_h * stride_D_head + offs_n, mask=offs_n < hdim, other=0.0).to(tl.float32)
+        else:
+            D = tl.load(D_ptr + pid_h * stride_D_head).to(tl.float32)
+        x_residual = tl.load(
+            x_ptr + (offs_m[:, None] * stride_x_seqlen + offs_n[None, :] * stride_x_hdim),
+            mask=(offs_m[:, None] < chunk_size_limit) & (offs_n[None, :] < hdim),
+            other=0.0,
+        ).to(tl.float32)
+        acc += x_residual * D
+
+    if HAS_Z:
+        z_ptr += chunk_seqlen_start * stride_z_seqlen + pid_h * stride_z_head
+        z_ptrs = z_ptr + (stride_z_seqlen * offs_out_m[:, None] + stride_z_hdim * offs_out_n[None, :])
+        z = tl.load(
+            z_ptrs,
+            mask=(offs_out_m[:, None] < chunk_size_limit) & (offs_out_n[None, :] < hdim),
+            other=0.0,
+        ).to(tl.float32)
+        acc *= z * tl.sigmoid(z)
+
+    out_ptr += chunk_seqlen_start * stride_out_seqlen + pid_h * stride_out_head
+    out_ptrs = out_ptr + (stride_out_seqlen * offs_out_m[:, None] + offs_out_n[None, :] * stride_out_hdim)
+    tl.store(
+        out_ptrs,
+        acc,
+        mask=(offs_out_m[:, None] < chunk_size_limit) & (offs_out_n[None, :] < hdim),
+    )
+
+
+def _chunk_scan_fwd_no_initial_states_npu(
+    cb,
+    x,
+    dt,
+    dA_cumsum,
+    C,
+    states,
+    cu_chunk_seqlens,
+    out,
+    seq_idx,
+    D=None,
+    z=None,
+):
+    assert seq_idx is not None, "this implementation requires seq_idx"
+
+    seqlen, nheads, headdim = x.shape
+    _, nchunks, chunk_size = dt.shape
+    _, ngroups, dstate = C.shape
+    assert nheads % ngroups == 0
+    assert C.shape == (seqlen, ngroups, dstate)
+    assert cb.shape == (nchunks, ngroups, chunk_size, chunk_size)
+    if D is not None:
+        assert D.shape == (nheads, headdim) or D.shape == (nheads,)
+    if z is not None:
+        assert z.shape == x.shape
+    assert dt.shape == (nheads, nchunks, chunk_size)
+    assert dA_cumsum.shape == (nheads, nchunks, chunk_size)
+    assert states.shape == (nchunks, nheads, headdim, dstate)
+    assert seq_idx.shape == (nchunks,)
+
+    z_strides = (z.stride(0), z.stride(1), z.stride(2)) if z is not None else (0, 0, 0)
+
+    # Triton-Ascend may type-check pointers in constexpr-false branches. Keep
+    # semantic flags false, but pass non-null tensors for optional pointers.
+    # The initstates branch selects between initstates_ptr and states_ptr, so
+    # the dummy pointer must share the states base to satisfy pointer-source
+    # checks even when HAS_INITSTATES is false.
+    z_ptr = _chunk_scan_optional_kernel_args(x, z, (1, 1, 1))
+    D_ptr = _chunk_scan_optional_kernel_args(x, D, (1,))
+    initstates_ptr = _chunk_scan_initial_states_kernel_arg(states, None)
+
+    for chunk_start, launch_nchunks in _chunk_scan_launch_ranges(chunk_size, headdim, nchunks, nheads):
+        grid = _chunk_scan_grid(chunk_size, headdim, launch_nchunks, nheads)
+        _chunk_scan_fwd_kernel_npu[grid](
+            cb_ptr=cb,
+            x_ptr=x,
+            z_ptr=z_ptr,
+            out_ptr=out,
+            dt_ptr=dt,
+            dA_cumsum_ptr=dA_cumsum,
+            seq_idx_ptr=seq_idx,
+            C_ptr=C,
+            states_ptr=states,
+            D_ptr=D_ptr,
+            initstates_ptr=initstates_ptr,
+            cu_chunk_seqlens_ptr=cu_chunk_seqlens,
+            chunk_start=chunk_start,
+            chunk_size=chunk_size,
+            hdim=headdim,
+            dstate=dstate,
+            nheads_ngroups_ratio=nheads // ngroups,
+            stride_cb_chunk=cb.stride(0),
+            stride_cb_head=cb.stride(1),
+            stride_cb_csize_m=cb.stride(2),
+            stride_cb_csize_k=cb.stride(3),
+            stride_x_seqlen=x.stride(0),
+            stride_x_head=x.stride(1),
+            stride_x_hdim=x.stride(2),
+            stride_z_seqlen=z_strides[0],
+            stride_z_head=z_strides[1],
+            stride_z_hdim=z_strides[2],
+            stride_out_seqlen=out.stride(0),
+            stride_out_head=out.stride(1),
+            stride_out_hdim=out.stride(2),
+            stride_dt_chunk=dt.stride(1),
+            stride_dt_head=dt.stride(0),
+            stride_dt_csize=dt.stride(2),
+            stride_dA_cs_chunk=dA_cumsum.stride(1),
+            stride_dA_cs_head=dA_cumsum.stride(0),
+            stride_dA_cs_csize=dA_cumsum.stride(2),
+            stride_seq_idx_chunk=seq_idx.stride(0),
+            stride_C_seqlen=C.stride(0),
+            stride_C_head=C.stride(1),
+            stride_C_dstate=C.stride(2),
+            stride_states_chunk=states.stride(0),
+            stride_states_head=states.stride(1),
+            stride_states_hdim=states.stride(2),
+            stride_states_dstate=states.stride(3),
+            stride_init_states_batch=0,
+            stride_init_states_head=0,
+            stride_init_states_hdim=0,
+            stride_init_states_dstate=0,
+            stride_D_head=D.stride(0) if D is not None else 0,
+            IS_CAUSAL=True,
+            HAS_D=D is not None,
+            D_HAS_HDIM=D.dim() == 2 if D is not None else True,
+            HAS_Z=z is not None,
+            BLOCK_SIZE_DSTATE=max(triton.next_power_of_2(dstate), 16),
+            IS_TRITON_22=_ssd_chunk_scan.TRITON_22,
+            HAS_INITSTATES=False,
+        )
+    return None
+
+
+def _chunk_scan_fwd_npu(
+    cb,
+    x,
+    dt,
+    dA_cumsum,
+    C,
+    states,
+    cu_chunk_seqlens,
+    out,
+    seq_idx,
+    D=None,
+    z=None,
+    initial_states=None,
+):
+    if x.device.type != "npu":
+        return _ORIGINAL_CHUNK_SCAN_FWD(
+            cb,
+            x,
+            dt,
+            dA_cumsum,
+            C,
+            states,
+            cu_chunk_seqlens,
+            out,
+            seq_idx,
+            D=D,
+            z=z,
+            initial_states=initial_states,
+        )
+    if initial_states is None:
+        return _chunk_scan_fwd_no_initial_states_npu(
+            cb,
+            x,
+            dt,
+            dA_cumsum,
+            C,
+            states,
+            cu_chunk_seqlens,
+            out,
+            seq_idx,
+            D=D,
+            z=z,
+        )
+
+    assert seq_idx is not None, "this implementation requires seq_idx"
+
+    seqlen, nheads, headdim = x.shape
+    _, nchunks, chunk_size = dt.shape
+    _, ngroups, dstate = C.shape
+    assert nheads % ngroups == 0
+    assert C.shape == (seqlen, ngroups, dstate)
+    assert cb.shape == (nchunks, ngroups, chunk_size, chunk_size)
+    if D is not None:
+        assert D.shape == (nheads, headdim) or D.shape == (nheads,)
+    if z is not None:
+        assert z.shape == x.shape
+    if initial_states is not None:
+        assert initial_states.shape[1:] == (nheads, headdim, dstate)
+    assert dt.shape == (nheads, nchunks, chunk_size)
+    assert dA_cumsum.shape == (nheads, nchunks, chunk_size)
+    assert states.shape == (nchunks, nheads, headdim, dstate)
+    assert seq_idx.shape == (nchunks,)
+
+    z_strides = (z.stride(0), z.stride(1), z.stride(2)) if z is not None else (0, 0, 0)
+    initial_states_strides = _chunk_scan_initial_states_strides(initial_states)
+
+    # Triton-Ascend may type-check pointers in constexpr-false branches. Keep
+    # semantic flags false, but pass non-null tensors for optional pointers.
+    z_ptr = _chunk_scan_optional_kernel_args(x, z, (1, 1, 1))
+    D_ptr = _chunk_scan_optional_kernel_args(x, D, (1,))
+    initstates_ptr = _chunk_scan_initial_states_kernel_arg(states, initial_states)
+
+    has_initstates = initial_states is not None
+
+    for chunk_start, launch_nchunks in _chunk_scan_launch_ranges(chunk_size, headdim, nchunks, nheads):
+        grid = _chunk_scan_grid(chunk_size, headdim, launch_nchunks, nheads)
+        _chunk_scan_fwd_kernel_npu[grid](
+            cb_ptr=cb,
+            x_ptr=x,
+            z_ptr=z_ptr,
+            out_ptr=out,
+            dt_ptr=dt,
+            dA_cumsum_ptr=dA_cumsum,
+            seq_idx_ptr=seq_idx,
+            C_ptr=C,
+            states_ptr=states,
+            D_ptr=D_ptr,
+            initstates_ptr=initstates_ptr,
+            cu_chunk_seqlens_ptr=cu_chunk_seqlens,
+            chunk_start=chunk_start,
+            chunk_size=chunk_size,
+            hdim=headdim,
+            dstate=dstate,
+            nheads_ngroups_ratio=nheads // ngroups,
+            stride_cb_chunk=cb.stride(0),
+            stride_cb_head=cb.stride(1),
+            stride_cb_csize_m=cb.stride(2),
+            stride_cb_csize_k=cb.stride(3),
+            stride_x_seqlen=x.stride(0),
+            stride_x_head=x.stride(1),
+            stride_x_hdim=x.stride(2),
+            stride_z_seqlen=z_strides[0],
+            stride_z_head=z_strides[1],
+            stride_z_hdim=z_strides[2],
+            stride_out_seqlen=out.stride(0),
+            stride_out_head=out.stride(1),
+            stride_out_hdim=out.stride(2),
+            stride_dt_chunk=dt.stride(1),
+            stride_dt_head=dt.stride(0),
+            stride_dt_csize=dt.stride(2),
+            stride_dA_cs_chunk=dA_cumsum.stride(1),
+            stride_dA_cs_head=dA_cumsum.stride(0),
+            stride_dA_cs_csize=dA_cumsum.stride(2),
+            stride_seq_idx_chunk=seq_idx.stride(0),
+            stride_C_seqlen=C.stride(0),
+            stride_C_head=C.stride(1),
+            stride_C_dstate=C.stride(2),
+            stride_states_chunk=states.stride(0),
+            stride_states_head=states.stride(1),
+            stride_states_hdim=states.stride(2),
+            stride_states_dstate=states.stride(3),
+            stride_init_states_batch=initial_states_strides[0],
+            stride_init_states_head=initial_states_strides[1],
+            stride_init_states_hdim=initial_states_strides[2],
+            stride_init_states_dstate=initial_states_strides[3],
+            stride_D_head=D.stride(0) if D is not None else 0,
+            IS_CAUSAL=True,
+            HAS_D=D is not None,
+            D_HAS_HDIM=D.dim() == 2 if D is not None else True,
+            HAS_Z=z is not None,
+            BLOCK_SIZE_DSTATE=max(triton.next_power_of_2(dstate), 16),
+            IS_TRITON_22=_ssd_chunk_scan.TRITON_22,
+            HAS_INITSTATES=has_initstates,
+        )
+    return None

--- a/vllm_ascend/patch/platform/patch_fused_moe.py
+++ b/vllm_ascend/patch/platform/patch_fused_moe.py
@@ -27,7 +27,10 @@
 #   2. from vllm_ascend import ops
 #   3. model loading  ->  deepseek_v2 imported  ->  gets patched FusedMoE  ✓
 
+from contextlib import contextmanager
+
 import vllm.model_executor.layers.fused_moe as _fused_moe_pkg
+import vllm.model_executor.layers.fused_moe.config as _fused_moe_config
 import vllm.model_executor.layers.fused_moe.layer as _fused_moe_layer
 
 from vllm_ascend.utils import is_310p
@@ -38,7 +41,42 @@ _original_FusedMoE = _fused_moe_layer.FusedMoE
 if is_310p():
     from vllm_ascend._310p.fused_moe.fused_moe import AscendMoERunner310 as _DefaultAscendMoERunner
 else:
-    from vllm_ascend.ops.fused_moe.fused_moe import AscendMoERunner as _DefaultAscendMoERunner
+    from vllm_ascend.ops.fused_moe.fused_moe import (
+        AscendMoERunner as _DefaultAscendMoERunner,
+    )
+
+
+@contextmanager
+def _allow_nongated_moe_constructor_on_ascend():
+    # vLLM gates non-gated MoE construction by backend. Ascend provides its own
+    # execution path, so bypass only the constructor capability check.
+    platform = _fused_moe_config.current_platform
+    original_is_cuda_alike = platform.is_cuda_alike
+    platform.is_cuda_alike = lambda: True
+    try:
+        yield
+    finally:
+        platform.is_cuda_alike = original_is_cuda_alike
+
+
+def _is_nongated_moe_kwargs(kwargs):
+    if "is_act_and_mul" in kwargs:
+        return not kwargs["is_act_and_mul"]
+
+    activation = kwargs.get("activation")
+    if activation is None:
+        return False
+
+    is_gated = getattr(activation, "is_gated", None)
+    if is_gated is not None:
+        return not is_gated
+
+    try:
+        from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+
+        return not MoEActivation.from_str(activation).is_gated
+    except (ImportError, AttributeError, ValueError):
+        return False
 
 
 def _ascend_FusedMoE(*args, runner_cls=None, runner_args=None, **kwargs):
@@ -51,6 +89,9 @@ def _ascend_FusedMoE(*args, runner_cls=None, runner_args=None, **kwargs):
     if tid2eid is not None:
         runner_args = dict(runner_args) if runner_args is not None else {}
         runner_args["tid2eid"] = tid2eid
+    if _is_nongated_moe_kwargs(kwargs):
+        with _allow_nongated_moe_constructor_on_ascend():
+            return _original_FusedMoE(*args, runner_cls=runner_cls, runner_args=runner_args, **kwargs)
     return _original_FusedMoE(*args, runner_cls=runner_cls, runner_args=runner_args, **kwargs)
 
 

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -17,6 +17,9 @@
 
 from vllm.triton_utils import HAS_TRITON
 
+# Worker processes can reach vLLM memory profiling before the platform-level
+# patch is applied in that process.
+import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa
 from vllm_ascend.utils import is_310p, vllm_version_is
 
 # The v2 model runner tracks only the verified vLLM main commit. The v0.24.0

--- a/vllm_ascend/patch/worker/patch_triton.py
+++ b/vllm_ascend/patch/worker/patch_triton.py
@@ -1,5 +1,8 @@
 import vllm.model_executor.layers.fla.ops
 import vllm.model_executor.layers.mamba.ops.causal_conv1d
+import vllm.model_executor.layers.mamba.ops.mamba_ssm
+import vllm.model_executor.layers.mamba.ops.ssd_chunk_scan
+import vllm.model_executor.layers.mamba.ops.ssd_combined
 import vllm.v1.worker.gpu.sample.gumbel
 from vllm.triton_utils import HAS_TRITON, triton
 from vllm.utils.math_utils import next_power_of_2
@@ -7,11 +10,24 @@ from vllm.utils.math_utils import next_power_of_2
 from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
 from vllm_ascend.ops.triton.fla.layernorm_guard import LayerNormFn
 from vllm_ascend.ops.triton.fla.sigmoid_gating import fused_recurrent_gated_delta_rule_fwd_kernel
-from vllm_ascend.ops.triton.mamba.causal_conv1d import causal_conv1d_update_npu
+from vllm_ascend.ops.triton.mamba.causal_conv1d import causal_conv1d_fn, causal_conv1d_update_npu
+from vllm_ascend.ops.triton.mamba.selective_state_update import try_get_optimal_ssm_config_npu
+from vllm_ascend.ops.triton.mamba.ssd_chunk_scan import (
+    _chunk_scan_fwd_npu,
+)
 
 triton.next_power_of_2 = next_power_of_2
 
+_ssd_chunk_scan = vllm.model_executor.layers.mamba.ops.ssd_chunk_scan
+_ssd_combined = vllm.model_executor.layers.mamba.ops.ssd_combined
+_mamba_ssm = vllm.model_executor.layers.mamba.ops.mamba_ssm
+
+
 vllm.model_executor.layers.mamba.ops.causal_conv1d.causal_conv1d_update = causal_conv1d_update_npu
+vllm.model_executor.layers.mamba.ops.causal_conv1d.causal_conv1d_fn = causal_conv1d_fn
+_ssd_chunk_scan._chunk_scan_fwd = _chunk_scan_fwd_npu
+_ssd_combined._chunk_scan_fwd = _chunk_scan_fwd_npu
+_mamba_ssm.try_get_optimal_ssm_config = try_get_optimal_ssm_config_npu
 vllm.model_executor.layers.fla.ops.fused_recurrent.fused_recurrent_gated_delta_rule_fwd_kernel = (
     fused_recurrent_gated_delta_rule_fwd_kernel
 )

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -45,6 +45,7 @@ from vllm.forward_context import BatchDescriptor, ForwardContext, get_forward_co
 from vllm.logger import logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.mamba.abstract import MambaBase
+from vllm.model_executor.layers.mamba.ops.ssu_dispatch import initialize_mamba_ssu_backend
 from vllm.model_executor.model_loader import get_model
 from vllm.model_executor.models.extract_hidden_states import CacheOnlyAttentionLayer
 from vllm.model_executor.offloader.base import get_offloader, set_offloader
@@ -3891,6 +3892,7 @@ class NPUModelRunner(GPUModelRunner):
         self.maybe_add_kv_sharing_layers_to_kv_cache_groups(kv_cache_config)
         # NOTE(cmq): initialize_attn_backend must before using self.attn_groups
         self.initialize_attn_backend(kv_cache_config)
+        initialize_mamba_ssu_backend(self.vllm_config.mamba_config, kv_cache_config)
         self.use_hybrid_blocks = len(self.attn_groups) > 1
         # NOTE: Currently, we determine whether we need `num_accepted_tokens` through `MambaSpec`.
         self.need_accepted_tokens = any(


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds verified BF16 inference support for
`NVIDIA-Nemotron-3-Super-120B-A12B-BF16` on Atlas A2. The model combines
Mamba2, attention, and non-gated latent MoE layers, so the existing Ascend
paths needed several general runtime extensions rather than a model-name
special case.

The changes are split into three reviewable commits:

1. Support non-gated latent MoE activations, separate shared-expert input,
   routed output transforms, and routed output scaling.
2. Add the Ascend Mamba SSD chunk-scan prefill kernel, causal-conv prefill
   compatibility, tuned selective-state-update dispatch, worker memory API
   initialization, and Mamba SSU backend initialization.
3. Add the support-matrix entry and a deployment/validation tutorial.

The Triton kernels follow the
[Triton-Ascend migration guide](https://github.com/triton-lang/triton-ascend/tree/main/docs/zh/migration_guide):
tail masks and FP32 accumulation are retained, optional pointers remain valid
for Triton-Ascend type checking, and 1M chunk scan is split below the Ascend
`coreDim`/MTE launch limit.

Review feedback from the previous revision is addressed:

- causal-conv block-cache and PCP paths delegate to the current upstream vLLM
  implementation; the Ascend fallback also respects `has_initial_state`;
- batch-invariant mode is now a documented launch-time requirement instead of
  a late mutation of vLLM's cached environment state;
- Mamba SSU initialization uses the passed `kv_cache_config` and has a matching
  unit test;
- the SSU tuning wrapper preserves vLLM's `override_ssm_config` benchmark
  semantics even after a production config has been cached.

### Does this PR introduce _any_ user-facing change?

Yes. Users can deploy the BF16 checkpoint with TP8 in eager mode or
`FULL_DECODE_ONLY` ACLGraph mode, with chunked prefill and contexts up to
1,048,576 tokens. The validated launch commands and memory settings are in the
new model tutorial.

### How was this patch tested?

#### Environment

- Hardware: 8 x Ascend 910B3, 64 GiB HBM per NPU
- Image: `358cee59a3de`
- vLLM: `ee0da84ab9e04ac7610e28580af62c365e898389` (`v0.24.0`)
  `b266da5d6cb1557c2a2c2f172729f3bf1cfe2f37`
- torch-npu: 2.10.0.post2; Transformers: 5.13.0
- Triton-Ascend package: 3.2.1 (`triton.__version__=3.2.0`)
- Model: BF16, TP8, FP32 Mamba state cache
- Scheduler: `--max-num-batched-tokens 1024 --max-num-seqs 4`
- Graph: `FULL_DECODE_ONLY`, capture sizes 1, 2, and 4
- Maximum context: 1,048,576 configured

#### Service correctness

Responses were checked for exact content, token counts, HTTP status, and finish
reason. Short checks use two sequential waves at each concurrency to exercise
state/cache reuse. The 32K checks use a deterministic needle at 25% of the
prompt and run at concurrency 1, 2, and 4.

| Mode | Short exact | 32K exact | 1,048,448-token exact |
| ---- | ----------- | --------- | --------------------- |
| Eager | 14/14 | 7/7 | 1/1, 405.02 s |
| `FULL_DECODE_ONLY` | 14/14 | 7/7 | 1/1, 398.18 s |

Both 1M requests reported exactly 1,048,448 prompt tokens and returned
`ASCEND-NEPTUNE-7319` with `finish_reason=stop`. These are fresh results on
final base `92ff388f`: each mode passed 22/22 exact-content requests, including
concurrency 1/2/4. The graph startup used a fresh cache and captured sizes
1/2/4 in 5 s, consuming 0.26 GiB. After the runtime rebase to `093ce8cb7`,
eager and graph C4 smoke checks each passed 8/8 exact responses with the same
1M configuration. The fresh graph cache again captured sizes 1/2/4 in 5 s, and
all eight workers selected the Triton Mamba SSU backend. The subsequent final
rebase to `bb474a6a9` adds only MathJax documentation assets; the targeted suite
was rerun on that final base.

#### Accuracy

NVIDIA publishes **83.73** for the complete MMLU-Pro evaluation. The following
is a smaller integration check using NVIDIA's documented thinking-enabled,
10-choice boxed-answer prompt and generation settings. It is not presented as
the official full score.

This subset was collected on vLLM Ascend `731436a1` with vLLM `e5588e49`.
After the source-changing rebase to vLLM Ascend `b266da5d` with vLLM
`ee0da84a` (`v0.24.0`), the deterministic service and 18-case performance
matrices were rerun. The full service matrix and targeted unit suite were rerun
again on `92ff388f`; the targeted suite and eager/graph C4 smoke checks were
rerun after the runtime rebase to `093ce8cb7`. The targeted suite was rerun
again after the docs-only final rebase to `bb474a6a9`. The subset provenance is
explicit rather than being mislabeled as a final-base full score; the
performance matrix below likewise retains its `b266da5d` provenance.

| Output cap | N | Correct | Accuracy | Wilson 95% CI | Errors | Unparsed |
| ---------- | - | ------- | -------- | ------------- | ------ | -------- |
| Initial 32,768 | 70 | 63 | 90.00% | 80.77%-95.07% | 0 | 4 |
| Truncated-only retry at 65,536 | 70 | 64 | 91.43% | 82.53%-96.01% | 0 | 2 |

Reproducibility data:

- 5 samples from each of 14 categories, selection seed `20260710`
- dataset revision `b189ec765aa7ed75c8acfea42df31fdae71f97be`
- parquet SHA-256
  `0e24a191921c2f453518a537a8b2117bd137e7714d4ef1565e9ba06c1ecb9ad8`
- `temperature=1.0`, `top_p=0.95`, thinking enabled, one sample,
  `skip_special_tokens=false`, fixed per-question seed
- the initial run had 66 `stop` and 4 `length`; all truncated responses count
  as incorrect in the 70-sample denominator
- retrying only those four samples at 65,536 tokens produced one additional
  correct answer, one parsed incorrect answer, and two `length` responses;
  the service remained healthy throughout
- the fixed per-question seeds are not bitwise invariant to concurrent runtime
  scheduling at `temperature=1.0`, so the retry is diagnostic and is not
  presented as a separate official benchmark score

The complete selected question-ID list and per-category scores are recorded in
the tutorial. The generation settings follow NVIDIA's
[Nemotron 3 Super reproducibility guide](https://github.com/NVIDIA-NeMo/Evaluator/blob/main/packages/nemo-evaluator-launcher/examples/nemotron/nemotron-3-super/reproducibility.md).

#### Serving performance

All cases were collected on vLLM Ascend base `b266da5d` using
`vllm bench serve`, a warmed server, deterministic random token lengths,
infinite request rate, and `--ignore-eos`. All 18 eager/graph cases completed
without errors; every decode/mixed request generated exactly 512 tokens.

| Workload / metric | Mode | C1 | C2 | C4 |
| ----------------- | ---- | -- | -- | -- |
| 32,768/1 total tok/s | Eager | 2,969.66 | 2,957.19 | 2,980.94 |
| 32,768/1 total tok/s | Graph | 2,937.30 | 2,964.44 | 3,022.39 |
| 32,768/1 TTFT ms | Eager | 11,034.29 | 16,657.73 | 27,525.14 |
| 32,768/1 TTFT ms | Graph | 11,155.79 | 16,662.76 | 27,119.68 |
| 256/512 output tok/s | Eager | 4.47 | 8.91 | 17.29 |
| 256/512 output tok/s | Graph | 32.94 | 68.82 | 88.47 |
| 256/512 TPOT ms | Eager | 223.32 | 223.39 | 227.32 |
| 256/512 TPOT ms | Graph | 24.40 | 28.06 | 40.00 |
| 8,192/512 output tok/s | Eager | 4.38 | 8.34 | 15.61 |
| 8,192/512 output tok/s | Graph | 33.33 | 38.76 | 44.33 |
| 8,192/512 total tok/s | Eager | 74.49 | 141.75 | 265.35 |
| 8,192/512 total tok/s | Graph | 566.65 | 658.88 | 753.59 |

`FULL_DECODE_ONLY` improves pure-decode output throughput over eager by 7.36x
at C1, 7.72x at C2, and 5.12x at C4. Prefill remains approximately unchanged,
as expected for decode-only graph capture. Mixed-workload TTFT/TPOT details are
included in the tutorial.

#### Triton operator validation

- SSD chunk scan matches the reference on NPU (small-shape max abs error
  `1.925e-5`; forced split exact). TP-local timings were 20.8018 ms at 262K and
  88.9442 ms at 1M. The 1M shape executes 131,072 logical programs as four
  launches capped at 32,768 programs.
- Selective state update production configs pass the upstream reference check
  across three fixed random seeds. For the model's 910B3 shape, they improve
  the kernel by 5.52x at effective batch 16, 7.24x at 32, and 8.89x at 64.

#### Unit and static checks

- Targeted vLLM 0.24 suite on final base `bb474a6a9`: `76 passed, 1 deselected`
- The deselected `SWIGLUSTEP` test uses an unaligned four-element synthetic
  shape on a real NPU. The identical failure was independently reproduced on
  clean `origin/main@dbcbf025`; this PR does not change that quantized branch.
- `pre-commit run --all-files` passed every available hook: Ruff check/format,
  codespell, typos, clang-format, Excalidraw, filename/package-init, logger,
  forbidden-import, boolean-context-manager, long-function, symbolic-meta,
  and suggestion checks.
- `actionlint` could not be installed locally because `proxy.golang.org` timed
  out; `shellcheck` is not installed in the image. This PR changes neither
  workflow nor shell files, and the previous GitHub Actions run passed.
- DCO sign-off as `Ewing <cyyooooo00@gmail.com>` is present on all three
  commits.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
