### PR TITLE
[v0.23.0][BugFix] Resolve block table overflow

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4703,9 +4703,10 @@ class NPUModelRunner(GPUModelRunner):
             if isinstance(kv_cache_group.kv_cache_spec, MambaSpec):
                 mamba_blocks_per_req = (
                     max_num_blocks_per_req if self.cache_config.enable_prefix_caching else 1
-                ) + kv_cache_group.kv_cache_spec.num_speculative_blocks
+                )
 
                 max_num_blocks_per_req = max(max_num_blocks_per_req, mamba_blocks_per_req)
+                max_num_blocks_per_req += kv_cache_group.kv_cache_spec.num_speculative_blocks
             max_num_blocks.append(max_num_blocks_per_req)
 
         if (block_sizes != [self.cache_config.block_size]


### PR DESCRIPTION
### What this PR does / why we need it?

Backport #11466 to `releases/v0.23.0`.

This moves speculative block accounting for Mamba KV cache groups after the max block calculation to avoid block table overflow.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`git diff --cached --check`

During commit, pre-commit ran and passed the available hooks; `check-long-functions` could not run because the local environment does not provide a `python` executable.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
