### PR TITLE
[Ascend950][Bugfix]Fix allgatherEP MXFPW4A8 quantization

### DIFF
--- a/vllm_ascend/quantization/methods/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8_mxfp4.py
@@ -199,7 +199,8 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
             random_matrix = torch.rand(topk_ids.size(0), num_logical_experts, device=topk_ids.device)
             topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
 
-        topk_weights = topk_weights.to(x.dtype)
+        if x.dtype not in [torch.float8_e4m3fn]:
+            topk_weights = topk_weights.to(x.dtype)
 
         moe_comm_method = get_forward_context().moe_comm_method
         return moe_comm_method.fused_experts(
@@ -222,7 +223,7 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
                 mxfp_weight_quant_type=torch_npu.float4_e2m1fn_x2,
                 mxfp_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
                 mxfp_per_token_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
-                mxfp_use_bf16=(x.dtype == torch.bfloat16),
+                mxfp_use_bf16=(x.dtype in [torch.bfloat16, torch.float8_e4m3fn]),
                 w1_scale=layer.w13_weight_scale,
                 w2_scale=layer.w2_weight_scale,
                 swiglu_limit=layer.swiglu_limit,


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes the allgatherEP W4A8_MXFP4 quantization path on Ascend 950.

For `torch.float8_e4m3fn` inputs, the previous logic cast `topk_weights` to the same dtype as the hidden states. However, routing weights should not be forced to float8 for the downstream fused experts kernel. This PR skips the float8 cast for `topk_weights` and enables the bf16-compatible MXFP execution mode when the input dtype is `torch.float8_e4m3fn`.

This is needed to make W4A8_MXFP4 MoE inference work correctly with allgatherEP quantization on Ascend 950.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
