### PR TITLE
[Test][Misc] Remove enforce_eager from Qwen3.5 MTP speculative config

### DIFF
--- a/tests/e2e/weekly/single_node/configs/Qwen3.5-27B-w8a8-A3.yaml
+++ b/tests/e2e/weekly/single_node/configs/Qwen3.5-27B-w8a8-A3.yaml
@@ -35,7 +35,7 @@ test_cases:
       - "--additional-config"
       - '{"enable_cpu_binding":true}'
       - "--speculative_config"
-      - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3,"enforce_eager": true}'
+      - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3}'
       - "--compilation-config"
       - '{"cudagraph_capture_sizes":[1,4,8,12,16,24,32,48,56,64,72,84,96,108,112,128,160,172,196,200,212,232,256,272,288,312,328,344,360,384,400,416,432,448,480,512], "cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--mm-processor-cache-gb"

--- a/tests/e2e/weekly/single_node/configs/Qwen3.5-27B-w8a8-A3.yaml
+++ b/tests/e2e/weekly/single_node/configs/Qwen3.5-27B-w8a8-A3.yaml
@@ -76,6 +76,7 @@ test_cases:
       - "--speculative_config"
       - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}'
       - "--trust-remote-code"
+      - "--async-scheduling"
       - "--allowed-local-media-path"
       - "/"
       - "--quantization"


### PR DESCRIPTION
### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
