### PR TITLE
[Feature] Vllm-ascend supports BreakableACLGraph

### DIFF
--- a/vllm_ascend/compilation/breakable_aclgraph.py
+++ b/vllm_ascend/compilation/breakable_aclgraph.py
@@ -1,0 +1,409 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Breakable ACL graph capture/replay.
+
+This is an alternative to :class:`ACLGraphWrapper` that replaces vLLM's
+torch.compile-based FX graph splitting with runtime stream-capture
+breaks.
+
+The idea (inspired by sgl-project/sglang#19102): instead of pre-splitting
+the model into many pieces at attention boundaries, a
+single capture context drives the whole forward and intercepts
+attention / kv-cache custom ops at the dispatcher to end the current
+stream capture, run the op eagerly, and resume capture.
+
+The captured artifact is a list of zero-arg callables -- the bound
+``ACLGraph.replay`` for graph segments, or the user fn for eager
+segments -- replayed in order at inference time.
+
+Eager segments must operate on the same static buffers used during
+capture so subsequent graph segments read the same memory addresses.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+import gc
+import threading
+import weakref
+from collections.abc import Callable
+from typing import Any, ClassVar, TypeVar
+
+import torch
+import vllm.envs as envs
+from vllm.compilation.monitor import validate_cudagraph_capturing_enabled
+from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.distributed.device_communicators.pynccl_allocator import set_graph_pool_id
+from vllm.forward_context import (
+    BatchDescriptor,
+    get_forward_context,
+    is_forward_context_available,
+)
+from vllm.logger import logger
+from vllm.model_executor.offloader.base import get_offloader
+from vllm.platforms import current_platform
+
+# from vllm.utils.torch_utils import weak_ref_tensor, weak_ref_tensors
+from ..utils import weak_ref_tensor, weak_ref_tensors
+
+
+def is_breakable_aclgraph_enabled() -> bool:
+    return bool(envs.VLLM_USE_BREAKABLE_CUDAGRAPH)
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def eager_break_during_capture(fn: F) -> F:
+    """Decorator that turns a custom-op Python kernel into a "break point"
+    for the breakable aclgraph capture.
+
+    When the decorated function is invoked outside of a
+    :class:`BreakableACLGraphCapture` context, it executes normally.
+
+    When invoked inside a capture context, it ends the current aclgraph
+    segment, runs the function eagerly on the capture stream, records the
+    callable for replay, and starts a fresh segment.
+
+    **In-place output buffer required.** Decorated ops must write into a
+    caller-provided output tensor; a fresh tensor returned by ``fn`` would
+    change address each replay and break downstream graph segments.
+
+    **Decorator order matters.** Apply as the *outermost* decorator if
+    there are other decorators that introduce host-side side effects
+    around the call -- the canonical example is
+    ``@maybe_transfer_kv_layer`` for PD-disaggregation, whose
+    ``wait_for_layer_load`` and ``save_kv_layer`` calls must run in the
+    eager segment, not inside the captured aclgraph. Putting
+    ``@eager_break_during_capture`` *inside* such a decorator would
+    record those side effects into the graph and hang on replay.
+
+    The correct order is::
+
+        @eager_break_during_capture   # outermost
+        @maybe_transfer_kv_layer
+        def unified_attention_with_output(...):
+            ...
+    """
+    if not is_breakable_aclgraph_enabled():
+        return fn
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        capture = BreakableACLGraphCapture.current()
+        if capture is None:
+            return fn(*args, **kwargs)
+        if not capture._capturing:
+            return fn(*args, **kwargs)
+        if is_forward_context_available():
+            mode = get_forward_context().cudagraph_runtime_mode
+            if mode == CUDAGraphMode.FULL:
+                return fn(*args, **kwargs)
+
+        # Weak-ref args: strong refs in the replay lambda pin cudagraph-pool
+        # slots across batch descriptors. cudagraph owns the slot, so the
+        # weak_ref is safe to deref on replay.
+        weak_args = tuple(weak_ref_tensor(a) if isinstance(a, torch.Tensor) else a for a in args)
+        weak_kwargs = {k: weak_ref_tensor(v) if isinstance(v, torch.Tensor) else v for k, v in kwargs.items()}
+        return capture.add_eager(lambda: fn(*weak_args, **weak_kwargs))
+
+    return wrapper  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Capture context
+# ---------------------------------------------------------------------------
+
+
+class BreakableACLGraphCapture:
+    """Stream-capture context that supports eager breaks via :meth:`add_eager`.
+
+    Usage::
+
+        cap = BreakableACLraphCapture(pool=...)
+        with cap:
+            output = model(*static_inputs)
+        # Later, after copying new inputs into the static buffers:
+        cap.replay()
+        # Output tensors live at the same addresses as during capture.
+
+    Thread-local: only one capture may be active per thread.
+    """
+
+    _tls = threading.local()
+
+    @classmethod
+    def current(cls) -> BreakableACLGraphCapture | None:
+        return getattr(cls._tls, "active", None)
+
+    @classmethod
+    def is_active(cls) -> bool:
+        return cls.current() is not None
+
+    def __init__(self, pool: Any | None = None) -> None:
+        self.pool = pool
+        self.segments: list[Callable[[], Any]] = []
+        self._num_graphs: int = 0
+        self._num_eager_breaks: int = 0
+        self._current_graph: torch.npu.NPUGraph | None = None
+        self._capturing: bool = False
+
+    # --- context manager protocol ----------------------------------------
+
+    def __enter__(self) -> BreakableACLGraphCapture:
+        if getattr(BreakableACLGraphCapture._tls, "active", None) is not None:
+            raise RuntimeError("Nested BreakableCUDAGraphCapture is not supported.")
+        BreakableACLGraphCapture._tls.active = self
+        self._begin_segment()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        try:
+            self._end_segment()
+        finally:
+            BreakableACLGraphCapture._tls.active = None
+
+    # --- segment management ----------------------------------------------
+
+    def _begin_segment(self) -> None:
+        assert not self._capturing
+        g = torch.npu.NPUGraph()
+        if self.pool is not None:
+            g.capture_begin(pool=self.pool)
+        else:
+            g.capture_begin()
+        self._current_graph = g
+        self._capturing = True
+
+    def _end_segment(self) -> None:
+        if not self._capturing:
+            return
+        assert self._current_graph is not None
+        self._current_graph.capture_end()
+        self.segments.append(self._current_graph.replay)
+        self._num_graphs += 1
+        self._current_graph = None
+        self._capturing = False
+
+    def add_eager(self, fn: Callable[[], Any]) -> Any:
+        """End the current capture segment, run ``fn`` eagerly on the
+        capture stream, record ``fn`` for replay, and start a new segment.
+
+        Returns whatever ``fn`` returned during this (capture-time) call.
+        Replay does not return values; callers should propagate any
+        downstream dependencies via static output buffers.
+        """
+        self._end_segment()
+        result = fn()
+        self.segments.append(fn)
+        self._num_eager_breaks += 1
+        self._begin_segment()
+        return result
+
+    # --- replay ----------------------------------------------------------
+
+    def replay(self) -> None:
+        for r in self.segments:
+            r()
+
+    # --- introspection ---------------------------------------------------
+
+    @property
+    def num_graphs(self) -> int:
+        return self._num_graphs
+
+    @property
+    def num_eager_breaks(self) -> int:
+        return self._num_eager_breaks
+
+    def __repr__(self) -> str:
+        return f"BreakableACLGraphCapture(graphs={self.num_graphs}, eager_breaks={self.num_eager_breaks})"
+
+
+# ---------------------------------------------------------------------------
+# Wrapper that mirrors CUDAGraphWrapper's interface
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class _BreakableEntry:
+    batch_descriptor: BatchDescriptor
+    capture: BreakableACLGraphCapture | None = None
+    output: Any = None
+    input_addresses: list[int] | None = None
+
+
+class BreakableACLGraphWrapper:
+    """Drop-in replacement for :class:`CUDAGraphWrapper` that uses
+    :class:`BreakableCUDAGraphCapture` instead of a single monolithic
+    ``torch.cuda.graph()`` capture.
+
+    Same dispatch contract as ``CUDAGraphWrapper``:
+        * If no ``forward_context`` is available, run the underlying
+          callable eagerly.
+        * If runtime mode mismatch / NONE, run eagerly.
+        * Otherwise, lazily capture per ``batch_descriptor`` and replay
+          on subsequent invocations with the same descriptor.
+    """
+
+    _all_instances: ClassVar[weakref.WeakSet[BreakableACLGraphWrapper]] = weakref.WeakSet()
+
+    @classmethod
+    def clear_all_graphs(cls) -> None:
+        for instance in list(cls._all_instances):
+            instance.clear_graphs()
+
+    def __init__(
+        self,
+        runnable: Callable[..., Any],
+        vllm_config: VllmConfig,
+    ) -> None:
+        # Unlike the original CUDAGraphWrapper which strictly matches a
+        # single runtime_mode, this wrapper captures whatever the
+        # dispatcher emits (any non-NONE runtime_mode) -- breakable's
+        # capture is identical for prefill and decode, so there's nothing
+        # to dispatch on at the runtime_mode level. Entries are keyed by
+        # BatchDescriptor which already encodes batch shape / uniformity.
+        self.runnable = runnable
+        self.vllm_config = vllm_config
+        self.compilation_config = vllm_config.compilation_config
+        self.graph_pool = current_platform.get_global_graph_pool()
+        self.is_debugging_mode = envs.VLLM_LOGGING_LEVEL == "DEBUG"
+
+        self.entries: dict[BatchDescriptor, _BreakableEntry] = {}
+        BreakableACLGraphWrapper._all_instances.add(self)
+
+        logger.info_once("Breakable ACL graph enabled")
+
+    # --- vllm-style attribute forwarding ---------------------------------
+
+    def __getattr__(self, key: str) -> Any:
+        runnable = self.__dict__.get("runnable")
+        if runnable is not None and hasattr(runnable, key):
+            return getattr(runnable, key)
+        raise AttributeError(key)
+
+    def unwrap(self) -> Callable[..., Any]:
+        return self.runnable
+
+    @property
+    def cudagraph_wrapper(self) -> BreakableACLGraphWrapper:
+        return self
+
+    def clear_graphs(self) -> None:
+        self.entries.clear()
+
+    # --- dispatch --------------------------------------------------------
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        if not is_forward_context_available():
+            return self.runnable(*args, **kwargs)
+
+        forward_context = get_forward_context()
+        batch_descriptor = forward_context.batch_descriptor
+        cudagraph_runtime_mode = forward_context.cudagraph_runtime_mode
+
+        # Capture whenever the dispatcher says "some cudagraph mode" --
+        # breakable produces the same artifact regardless of PIECEWISE
+        # vs FULL, so we match either. Entries are keyed by batch
+        # descriptor, which already encodes prefill/decode distinctions.
+        if cudagraph_runtime_mode == CUDAGraphMode.NONE:
+            return self.runnable(*args, **kwargs)
+
+        assert batch_descriptor is not None
+        entry = self.entries.get(batch_descriptor)
+        if entry is None:
+            entry = _BreakableEntry(batch_descriptor=batch_descriptor)
+            self.entries[batch_descriptor] = entry
+
+        if entry.capture is None:
+            return self._capture(entry, args, kwargs)
+        return self._replay(entry, args, kwargs)
+
+    # --- capture / replay paths -----------------------------------------
+
+    @staticmethod
+    def _collect_tensor_addresses(args: tuple[Any, ...], kwargs: dict[str, Any]) -> list[int]:
+        """Flatten tensor data_ptrs from positional and keyword args in a
+        stable order (positionals first, then kwargs in insertion order).
+
+        Used for the DEBUG-mode address-stability check; covers both call
+        styles since vLLM models are typically invoked with kwargs.
+        """
+        addrs = [x.data_ptr() for x in args if isinstance(x, torch.Tensor)]
+        addrs.extend(v.data_ptr() for v in kwargs.values() if isinstance(v, torch.Tensor))
+        return addrs
+
+    def _capture(
+        self,
+        entry: _BreakableEntry,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        validate_cudagraph_capturing_enabled()
+
+        entry.input_addresses = self._collect_tensor_addresses(args, kwargs)
+
+        if self.graph_pool is not None:
+            set_graph_pool_id(self.graph_pool)
+        else:
+            set_graph_pool_id(current_platform.graph_pool_handle())
+
+        # Match torch.cuda.graph()'s pre-capture cleanup once per descriptor.
+        # We drive capture_begin/end directly and bypass torch.cuda.graph(),
+        # so its built-in gc + empty_cache never fire. Run them here once
+        # per _capture call -- NOT inside _begin_segment, since this capture
+        # session may issue many begin/end pairs (one per layer's break),
+        # and repeated gc would tank capture time the way it did for the
+        # pre-`gc_disable` piecewise path.
+        gc.collect()
+        torch.npu.empty_cache()
+        # Sync the offloader's copy stream before capture so any in-flight
+        # pre-capture prefetches are complete and don't leak into the graph.
+        get_offloader().sync_prev_onload()
+
+        capture = BreakableACLGraphCapture(pool=self.graph_pool)
+        with capture:
+            output = self.runnable(*args, **kwargs)
+            # Join the offloader's copy stream while we still hold the last
+            # segment open, so the join is captured into the graph (otherwise
+            # we get an "unjoined stream" error on subsequent forwards).
+            get_offloader().join_after_forward()
+            # Convert output to a weak ref *inside* the capture context so the
+            # strong ref is dropped before the last segment closes, letting
+            # the cudagraph pool reclaim/reuse that memory immediately for
+            # the next batch descriptor's capture.
+            output = weak_ref_tensors(output)
+
+        entry.capture = capture
+        entry.output = weak_ref_tensors(output)
+
+        logger.debug(
+            "Captured breakable aclgraph for %s: %r",
+            entry.batch_descriptor,
+            capture,
+        )
+        # Return the (already-weak) output from the captured run so the
+        # caller of model(...) gets a tensor pointing at the cudagraph pool's memory
+        return output
+
+    def _replay(
+        self,
+        entry: _BreakableEntry,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        if self.is_debugging_mode and entry.input_addresses is not None:
+            new_addresses = self._collect_tensor_addresses(args, kwargs)
+            assert new_addresses == entry.input_addresses, (
+                "Input tensor addresses changed between capture and replay "
+                f"for {entry.batch_descriptor}. Expected "
+                f"{entry.input_addresses}, got {new_addresses}."
+            )
+        # Sync the offloader's copy stream before replay so any external
+        # dependencies from pre-capture prefetches are satisfied.
+        get_offloader().sync_prev_onload()
+        assert entry.capture is not None
+        entry.capture.replay()
+        return entry.output

--- a/vllm_ascend/ops/dsa.py
+++ b/vllm_ascend/ops/dsa.py
@@ -30,6 +30,7 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.v1.attention.backend import AttentionMetadata
 
+from vllm_ascend.compilation.breakable_aclgraph import eager_break_during_capture
 from vllm_ascend.models.layer.attention.layer import DSAAttention
 from vllm_ascend.utils import (
     AscendDeviceType,
@@ -175,6 +176,7 @@ class AscendDeepseekSparseAttention(MultiHeadLatentAttentionWrapper):
         return output
 
 
+@eager_break_during_capture
 def dsa_forward(
     hidden_states: torch.Tensor,
     need_gather_q_kv: bool,

--- a/vllm_ascend/ops/mla.py
+++ b/vllm_ascend/ops/mla.py
@@ -33,6 +33,7 @@ from vllm.v1.attention.backend import AttentionMetadata  # type: ignore
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.compilation.breakable_aclgraph import eager_break_during_capture
 from vllm_ascend.utils import is_vl_model, parse_layer_idx
 
 
@@ -176,6 +177,7 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
         return output
 
 
+@eager_break_during_capture
 def mla_forward(
     hidden_states: torch.Tensor,
     need_gather_q_kv: bool,

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -2,18 +2,6 @@
 # Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
 # This file is a part of the vllm-ascend project.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 
 from vllm.triton_utils import HAS_TRITON
 
@@ -37,6 +25,7 @@ if HAS_TRITON:
         import vllm_ascend.patch.worker.patch_v2.patch_triton  # noqa
 
 
+import vllm_ascend.patch.worker.patch_breakable_cudagraph  # noqa
 import vllm_ascend.patch.worker.patch_process_weights_after_loading  # noqa
 import vllm_ascend.patch.worker.patch_distributed  # noqa
 import vllm_ascend.patch.worker.patch_minimax_m2  # noqa

--- a/vllm_ascend/patch/worker/patch_breakable_cudagraph.py
+++ b/vllm_ascend/patch/worker/patch_breakable_cudagraph.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Monkey-patch vLLM's eager_break_during_capture for Ascend breakable ACL graph.
+
+``sparse_attn_indexer`` does ``from vllm.compilation.breakable_cudagraph import
+eager_break_during_capture`` — this creates a local binding at import time.
+We replace the function in the original module BEFORE ``sparse_attn_indexer`` is
+loaded, so its ``from ... import`` resolves to the Ascend variant that uses
+``BreakableACLGraphCapture`` / ``torch.npu.NPUGraph`` instead of
+``BreakableCUDAGraphCapture`` / ``torch.cuda.graph``.
+"""
+
+from vllm.compilation import breakable_cudagraph
+
+from vllm_ascend.compilation.breakable_aclgraph import eager_break_during_capture
+
+breakable_cudagraph.eager_break_during_capture = eager_break_during_capture

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -53,14 +53,6 @@ from vllm_ascend.utils import (
     enable_sp,
 )
 
-# Since vllm-project/vllm#43746, DeepSeek V4 model classes no longer
-# carry @support_torch_compile. This makes vLLM auto-enable the breakable
-# cudagraph PIECEWISE path, which is not supported on Ascend yet.
-envs_vllm.VLLM_USE_BREAKABLE_CUDAGRAPH = False
-logger.info(
-    "Breakable cudagraph is force disabled on Ascend because DeepSeek V4 PIECEWISE cudagraph is not supported yet."
-)
-
 if TYPE_CHECKING:
     from vllm.config import ModelConfig, VllmConfig
     from vllm.utils import FlexibleArgumentParser
@@ -563,7 +555,7 @@ class NPUPlatform(Platform):
             ascend_config.ascend_compilation_config.enable_npugraph_ex = False
         elif compilation_config.cudagraph_mode.requires_piecewise_compilation():
             # Our is_cuda_alike is False so we cannot reuse the assertion of upstream
-            assert compilation_config.mode == CompilationMode.VLLM_COMPILE, (
+            assert compilation_config.mode == CompilationMode.VLLM_COMPILE or envs_vllm.VLLM_USE_BREAKABLE_CUDAGRAPH, (
                 "Compilation mode should be CompilationMode.VLLM_COMPILE "
                 "when cudagraph_mode piecewise cudagraphs is used, "
                 "cudagraph_mode=%s",

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -119,6 +119,7 @@ from vllm_ascend.compilation.acl_graph import (
     set_graph_params,
     update_full_graph_params,
 )
+from vllm_ascend.compilation.breakable_aclgraph import BreakableACLGraphWrapper, is_breakable_aclgraph_enabled
 from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
 from vllm_ascend.eplb.core.eplb_device_transfer_loader import D2DExpertWeightLoader
 from vllm_ascend.eplb.core.eplb_worker import EplbProcess
@@ -580,6 +581,9 @@ class NPUModelRunner(GPUModelRunner):
         self.cpu_slot_mapping = None
         self.sampling_done_event: torch.npu.Event | None = None
 
+        if self.compilation_config.cudagraph_mode.has_full_cudagraphs():
+            self.update_stream: torch.npu.Stream = torch.npu.Stream()
+
         # self.cudagraph_batch_sizes sorts in ascending order.
         if (
             self.compilation_config.cudagraph_capture_sizes
@@ -660,7 +664,8 @@ class NPUModelRunner(GPUModelRunner):
     def _use_aclgraph(self) -> bool:
         return (
             self.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
-            and self.compilation_config.mode == CompilationMode.VLLM_COMPILE
+            and (self.compilation_config.mode == CompilationMode.VLLM_COMPILE
+            or is_breakable_aclgraph_enabled())
             and not self.model_config.enforce_eager
         )
 
@@ -716,7 +721,7 @@ class NPUModelRunner(GPUModelRunner):
 
     def get_model(self) -> nn.Module:
         # get raw model out of the aclgraph wrapper.
-        if isinstance(self.model, ACLGraphWrapper):
+        if isinstance(self.model, (ACLGraphWrapper, BreakableACLGraphWrapper)):
             return self.model.unwrap()
         return self.model
 
@@ -3911,7 +3916,19 @@ class NPUModelRunner(GPUModelRunner):
         ) # type: bool
         
         # wrap the model with full graph wrapper if needed.
-        if self.compilation_config.cudagraph_mode.has_full_cudagraphs():
+        cudagraph_mode = self.compilation_config.cudagraph_mode
+        assert cudagraph_mode is not None
+        if (
+            is_breakable_aclgraph_enabled()
+            and cudagraph_mode != CUDAGraphMode.NONE
+        ):
+            self.model = BreakableACLGraphWrapper(self.model, self.vllm_config)
+            drafter = getattr(self, "drafter", None)
+            if drafter is not None and hasattr(drafter, "model"):
+                drafter.model = BreakableACLGraphWrapper(
+                    drafter.model, self.vllm_config
+                )
+        elif cudagraph_mode.has_full_cudagraphs():
             self.update_stream: torch.npu.Stream = torch.npu.Stream()
             self.model = ACLGraphWrapper(
                 self.model,
@@ -5276,6 +5293,9 @@ def _replace_gpu_model_runner_function_wrapper(target_module_name):
         if hasattr(target_module, "CUDAGraphWrapper"):
             original_attrs["CUDAGraphWrapper"] = target_module.CUDAGraphWrapper
             setattr(target_module, "CUDAGraphWrapper", ACLGraphWrapper)  # noqa: B010
+        if hasattr(target_module, "BreakableCUDAGraphWrapper"):
+            original_attrs["BreakableCUDAGraphWrapper"] = target_module.BreakableCUDAGraphWrapper
+            setattr(target_module, "BreakableCUDAGraphWrapper", BreakableACLGraphWrapper)  # noqa: B010
         yield
     except Exception as e:
         raise RuntimeError(f"NPUModelRunner failed, error is {e}")

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -35,6 +35,7 @@ from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.compilation.acl_graph import set_graph_params, update_full_graph_params
+from vllm_ascend.compilation.breakable_aclgraph import BreakableACLGraphWrapper
 from vllm_ascend.worker.v2.utils import communicator_switch
 
 
@@ -67,6 +68,10 @@ class ModelAclGraphManager(ModelCudaGraphManager):
         # so we need to set graph params before capture full graph.
         if super().needs_capture():
             set_graph_params(self.capture_sizes)
+
+    def init_breakable_cg_runner(self, model: nn.Module) -> None:
+        if self.breakable_cg_runner is None:
+            self.breakable_cg_runner = BreakableACLGraphWrapper(model, self.vllm_config)
 
     def run_fullgraph(self, desc: BatchExecutionDescriptor) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]:
         """Override run_fullgraph to update full graph params in run_fullgraph."""


### PR DESCRIPTION
### What this PR does / why we need it?
This PR enable BreakableACLGraph mode support for vllm-ascend，similar to BreakableCudaGraph in vllm.

After this change,  the piecewise aclgraph does not rely on torch.compile. Segmentation can be achieved simply by using a decorator.

### Does this PR introduce _any_ user-facing change?
Yes, users need to set `VLLM_USE_BREAKABLE_CUDAGRAPH=1`

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
