### PR TITLE
[v0.23.0][BugFix][310P] Fix sdma error caused by asynchronous copy

### DIFF
--- a/vllm_ascend/_310p/ops/qwen3vl_310.py
+++ b/vllm_ascend/_310p/ops/qwen3vl_310.py
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import torch
+
+
+# 310P RC: non_blocking H2D copy in rot_pos_emb can race with subsequent indexing.
+def rot_pos_emb_310(self, grid_thw: list[list[int]]):
+    max_grid_size = max(max(h, w) for _, h, w in grid_thw)
+    pos_ids = [
+        self.rot_pos_ids(h, w, self.spatial_merge_size)
+        if t == 1
+        else self.rot_pos_ids(h, w, self.spatial_merge_size).repeat(t, 1)
+        for t, h, w in grid_thw
+    ]
+    pos_ids = torch.cat(pos_ids, dim=0).to(self.device, non_blocking=False)
+
+    cos, sin = self.rotary_pos_emb.get_cos_sin(max_grid_size)
+    cos_combined = cos[pos_ids].flatten(1)
+    sin_combined = sin[pos_ids].flatten(1)
+    return cos_combined, sin_combined

--- a/vllm_ascend/patch/worker/patch_idex_310.py
+++ b/vllm_ascend/patch/worker/patch_idex_310.py
@@ -39,9 +39,14 @@ QwenGatedDeltaNetAttention.get_state_dtype = AscendGatedDeltaNetAttention310.get
 QwenGatedDeltaNetAttention.get_attn_backend = AscendGatedDeltaNetAttention310.get_attn_backend
 
 if is_rc_device():
+    from vllm.model_executor.models.qwen3_vl import Qwen3_VisionTransformer
     from vllm.v1.attention.backends.gdn_attn import GDNAttentionBackend
 
     from vllm_ascend._310p.ops.gdn_attn_builder_310 import GDNAttentionMetadataBuilder310
+    from vllm_ascend._310p.ops.qwen3vl_310 import rot_pos_emb_310
+
+    # 310P RC: use blocking H2D in rot_pos_emb to avoid race with subsequent indexing.
+    Qwen3_VisionTransformer.rot_pos_emb = rot_pos_emb_310  # type: ignore[method-assign]
 
     # Qwen3.5 on 310P RC uses upstream GDNAttentionBackend via MambaBase.get_attn_backend().
     GDNAttentionBackend.get_builder_cls = staticmethod(  # type: ignore[method-assign]


### PR DESCRIPTION
### What this PR does / why we need it?
Fixing Race Condition: Replaced non-blocking H2D copy with blocking copy in the rot_pos_emb method to prevent race conditions during subsequent indexing on 310P devices.
Method Patching: Implemented a new rot_pos_emb_310 function and applied it to Qwen3_VisionTransformer via the worker patch module to ensure stable execution on 310P hardware.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
