### PR TITLE
[BugFix] Fixing compilation errors in the new version of cann vLLM Ascend

### DIFF
--- a/csrc/cmake/config.cmake
+++ b/csrc/cmake/config.cmake
@@ -30,7 +30,12 @@ else()
     set(ASCEND_CANN_PACKAGE_PATH  "/usr/local/Ascend/latest")
 endif ()
 message(STATUS "ASCEND_CANN_PACKAGE_PATH=${ASCEND_CANN_PACKAGE_PATH}")
+set(VLLM_ASCEND_CANN_ARCH_PKG_INC
+    "${ASCEND_CANN_PACKAGE_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/pkg_inc")
 
+if(NOT EXISTS "${VLLM_ASCEND_CANN_ARCH_PKG_INC}")
+    set(VLLM_ASCEND_CANN_ARCH_PKG_INC "")
+endif()
 # Detect A5-compatible SoC enum support from the CANN headers we are compiling against.
 set(_saved_CMAKE_REQUIRED_INCLUDES "${CMAKE_REQUIRED_INCLUDES}")
 set(CMAKE_REQUIRED_INCLUDES
@@ -38,6 +43,7 @@ set(CMAKE_REQUIRED_INCLUDES
         ${ASCEND_CANN_PACKAGE_PATH}/include/external
         ${ASCEND_CANN_PACKAGE_PATH}/include/experiment/platform
         ${ASCEND_CANN_PACKAGE_PATH}/include/experiment/runtime
+        ${VLLM_ASCEND_CANN_ARCH_PKG_INC}
 )
 
 check_cxx_source_compiles([[

--- a/csrc/cmake/intf_pub.cmake
+++ b/csrc/cmake/intf_pub.cmake
@@ -17,6 +17,7 @@ target_include_directories(intf_pub
             ${ASCEND_CANN_PACKAGE_PATH}/include/experiment/platform
             ${ASCEND_CANN_PACKAGE_PATH}/include/experiment/runtime
             ${ASCEND_CANN_PACKAGE_PATH}/include/experiment/msprof
+            ${VLLM_ASCEND_CANN_ARCH_PKG_INC}
 )
 target_link_directories(intf_pub
         INTERFACE

--- a/csrc/utils/CMakeLists.txt
+++ b/csrc/utils/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(ops_utils_tiling_headers INTERFACE
         $<$<BOOL:${BUILD_OPEN_PROJECT}>:$<BUILD_INTERFACE:${ASCEND_CANN_PACKAGE_PATH}/include/experiment/metadef>>
         $<$<BOOL:${BUILD_OPEN_PROJECT}>:$<BUILD_INTERFACE:${ASCEND_CANN_PACKAGE_PATH}/include/experiment/runtime>>
         $<$<BOOL:${BUILD_OPEN_PROJECT}>:$<BUILD_INTERFACE:${ASCEND_CANN_PACKAGE_PATH}/include/experiment/msprof>>
+        $<$<BOOL:${BUILD_OPEN_PROJECT}>:$<BUILD_INTERFACE:${VLLM_ASCEND_CANN_ARCH_PKG_INC}>>
         $<INSTALL_INTERFACE:include/ops_adv/utils>
 )
 


### PR DESCRIPTION
### What this PR does / why we need it?
Fixing compilation errors in the new version of cann vLLM Ascend

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
pip install

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
