### PR TITLE
[BugFix] Avoid async logits indices race

### DIFF
--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -1611,7 +1611,7 @@ class TestEagleProposerPropose:
                             'token_indices_to_sample', 'common_attn_metadata', 'target_model_batch_desc',
                             'sampling_metadata', 'mm_embed_inputs', 'req_scheduled_tokens', 'long_seq_metadata',
                             'num_prefill_reqs', 'num_decode_reqs', 'scheduler_output', 'num_scheduled_tokens',
-                            'num_rejected_tokens_gpu'
+                            'num_rejected_tokens_gpu', 'main_logits_indices'
                         ]
 
 
@@ -3827,8 +3827,8 @@ class TestEagleProposerSetInputsFirstPass:
         self.runner.query_lens = torch.tensor(query_lens, dtype=torch.int32, device=self.device)
         self.runner.input_batch = MagicMock()
         self.runner.input_batch.req_ids = req_ids
-        # maybe not reasonable just to run test
-        self.runner.logits_indices = torch.arange(12, dtype=torch.int32, device=self.device)
+        main_logits_indices = torch.arange(12, dtype=torch.int32, device=self.device)
+        self.runner.logits_indices = main_logits_indices + 100
         self.runner.pcp_manager.pcp_use_hybrid_attn = False
 
         proposer, vllm_config = self._create_proposer(
@@ -3883,6 +3883,7 @@ class TestEagleProposerSetInputsFirstPass:
                 long_seq_metadata=long_seq_metadata,
                 num_prefill_reqs=num_prefill_reqs,
                 num_decode_reqs=num_decode_reqs,
+                main_logits_indices=main_logits_indices,
             )
         )
 

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -248,7 +248,7 @@ class NPUModelRunner310(NPUModelRunner):
         self,
         scheduler_output: SchedulerOutput,
         num_scheduled_tokens: np.ndarray,
-    ) -> tuple[torch.Tensor, SpecDecodeMetadata | None, int]:
+    ) -> tuple[torch.Tensor, torch.Tensor, SpecDecodeMetadata | None, int]:
         """
         310P cannot use the Triton slot-mapping kernel or the generic NPU Add
         kernels used by the base runner for decode metadata. Keep those pieces
@@ -577,7 +577,7 @@ class NPUModelRunner310(NPUModelRunner):
             self.num_decode_draft_tokens.np[num_reqs:].fill(-1)
             self.num_decode_draft_tokens.copy_to_gpu()
 
-        self.logits_indices = logits_indices
+        unpadded_logits_indices = logits_indices
 
         if self.lora_config:
             assert np.sum(num_sampled_tokens) <= self.vllm_config.scheduler_config.max_num_batched_tokens
@@ -600,6 +600,7 @@ class NPUModelRunner310(NPUModelRunner):
 
         return (
             logits_indices,
+            unpadded_logits_indices,
             spec_decode_metadata,
             total_num_scheduled_tokens,
         )

--- a/vllm_ascend/_310p/spec_decode/llm_base_proposer_310.py
+++ b/vllm_ascend/_310p/spec_decode/llm_base_proposer_310.py
@@ -39,6 +39,7 @@ class AscendSpecDecodeBaseProposer310(AscendSpecDecodeBaseProposer):
         long_seq_metadata=None,
         num_prefill_reqs=0,
         num_decode_reqs=0,
+        main_logits_indices: torch.Tensor | None = None,
     ) -> tuple[int, torch.Tensor, CommonAttentionMetadata, tuple[Any, Any] | None]:
         if not self.needs_extra_input_slots:
             # 310P workaround for MTP:
@@ -85,4 +86,5 @@ class AscendSpecDecodeBaseProposer310(AscendSpecDecodeBaseProposer):
             long_seq_metadata=long_seq_metadata,
             num_prefill_reqs=num_prefill_reqs,
             num_decode_reqs=num_decode_reqs,
+            main_logits_indices=main_logits_indices,
         )

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -73,6 +73,7 @@ class AscendDflashProposer(AscendEagleProposer):
         long_seq_metadata=None,
         num_prefill_reqs=0,
         num_decode_reqs=0,
+        main_logits_indices: torch.Tensor | None = None,
     ) -> tuple[int, torch.Tensor, CommonAttentionMetadata, tuple[Any, Any] | None]:
         # DFlash cross-attention: context K/V from target hidden states,
         # Q from query embeddings (bonus + mask tokens).

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -751,6 +751,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         scheduler_output: SchedulerOutput = None,
         num_scheduled_tokens: int = 0,
         num_rejected_tokens_gpu: torch.Tensor | None = None,
+        main_logits_indices: torch.Tensor | None = None,
     ) -> torch.Tensor:
         batch_size = common_attn_metadata.batch_size()
 
@@ -782,6 +783,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             long_seq_metadata=long_seq_metadata,
             num_prefill_reqs=num_prefill_reqs,
             num_decode_reqs=num_decode_reqs,
+            main_logits_indices=main_logits_indices,
         )
         if self.pcp_size * self.dcp_size > 1:
             assert long_seq_args is not None
@@ -1397,6 +1399,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         long_seq_metadata=None,
         num_prefill_reqs=0,
         num_decode_reqs=0,
+        main_logits_indices: torch.Tensor | None = None,
     ) -> tuple[int, torch.Tensor, CommonAttentionMetadata, tuple[Any, Any] | None]:
         if not self.needs_extra_input_slots:
             # Default EAGLE pathway: no reshaping of input tensors needed.
@@ -1471,12 +1474,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 self.input_ids[:num_tokens].copy_(torch.cat([input_ids_d, input_ids_p], dim=0))
                 target_hidden_states = torch.cat([target_hidden_states_d, target_hidden_states_p], dim=0)
                 # 2. update sample_indices according to main model
+                if main_logits_indices is None:
+                    raise RuntimeError("main_logits_indices must be provided when PCP is enabled.")
                 if num_decode_reqs:
-                    token_indices_to_sample[:num_decode_reqs] = self.runner.logits_indices[
+                    token_indices_to_sample[:num_decode_reqs] = main_logits_indices[
                         token_indices_to_sample[:num_decode_reqs]
                     ]
                 if num_prefill_reqs:
-                    token_indices_to_sample[-num_prefill_reqs:] = self.runner.logits_indices[-num_prefill_reqs:]
+                    token_indices_to_sample[-num_prefill_reqs:] = main_logits_indices[-num_prefill_reqs:]
                     # 3. update attn_metadata params that may be influenced by pcp
                     cad.num_actual_tokens = num_tokens
                     cad.max_query_len = max(self.decode_threshold, max_query_len_p)

--- a/vllm_ascend/spec_decode/step3p5.py
+++ b/vllm_ascend/spec_decode/step3p5.py
@@ -344,6 +344,7 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
         scheduler_output: SchedulerOutput = None,
         num_scheduled_tokens: int = 0,
         num_rejected_tokens_gpu: torch.Tensor | None = None,
+        main_logits_indices: torch.Tensor | None = None,
     ) -> torch.Tensor:
         self._last_draft_probs = None
         batch_size = common_attn_metadata.batch_size()
@@ -363,6 +364,7 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
             long_seq_metadata=long_seq_metadata,
             num_prefill_reqs=num_prefill_reqs,
             num_decode_reqs=num_decode_reqs,
+            main_logits_indices=main_logits_indices,
         )
         if self.pcp_size * self.dcp_size > 1:
             assert long_seq_args is not None

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -245,6 +245,7 @@ class ExecuteModelState(NamedTuple):
 
     scheduler_output: "SchedulerOutput"
     logits: torch.Tensor
+    unpadded_logits_indices: torch.Tensor
     spec_decode_metadata: SpecDecodeMetadata | None
     spec_decode_common_attn_metadata: AscendCommonAttentionMetadata | None
     hidden_states: torch.Tensor
@@ -860,12 +861,14 @@ class NPUModelRunner(GPUModelRunner):
         num_scheduled_tokens: np.ndarray,
     ) -> tuple[
         torch.Tensor,
+        torch.Tensor,
         SpecDecodeMetadata | None,
         int,
     ]:
         """
         :return: tuple[
             logits_indices,
+            unpadded_logits_indices,
             spec_decode_metadata,
             total_num_scheduled_tokens,
         ]
@@ -1392,8 +1395,7 @@ class NPUModelRunner(GPUModelRunner):
             self.num_decode_draft_tokens.np[:num_reqs] = num_decode_draft_tokens
             self.num_decode_draft_tokens.np[num_reqs:].fill(-1)
             self.num_decode_draft_tokens.copy_to_gpu()
-        # save logits_indices for pcp spec decode usage
-        self.logits_indices = logits_indices
+        unpadded_logits_indices = logits_indices
 
         # Hot-Swap lora model
         if self.lora_config:
@@ -1418,6 +1420,7 @@ class NPUModelRunner(GPUModelRunner):
 
         return (
             logits_indices,
+            unpadded_logits_indices,
             spec_decode_metadata,
             total_num_scheduled_tokens,
         )
@@ -1762,6 +1765,7 @@ class NPUModelRunner(GPUModelRunner):
         aux_hidden_states: torch.Tensor = None,
         sample_hidden_states: torch.Tensor = None,
         target_model_batch_desc: BatchDescriptor = None,
+        main_logits_indices: torch.Tensor | None = None,
     ) -> list[list[int]] | None:
         if not self.drafter:
             # Speculative decoding is not enabled.
@@ -1998,6 +2002,7 @@ class NPUModelRunner(GPUModelRunner):
                 scheduler_output=scheduler_output,
                 num_scheduled_tokens=num_scheduled_tokens,
                 num_rejected_tokens_gpu=num_rejected_tokens_gpu,
+                main_logits_indices=main_logits_indices,
             )
             if get_pp_group().world_size > 1 and hasattr(
                 self.drafter, "take_last_draft_probs"
@@ -2186,6 +2191,7 @@ class NPUModelRunner(GPUModelRunner):
                 max_num_scheduled_tokens = int(num_scheduled_tokens_np.max())
                 (
                     logits_indices,
+                    unpadded_logits_indices,
                     spec_decode_metadata,
                     total_num_scheduled_tokens,
                 ) = self._prepare_inputs(
@@ -2475,6 +2481,7 @@ class NPUModelRunner(GPUModelRunner):
             self.execute_model_state = ExecuteModelState(
                 scheduler_output,
                 logits,
+                unpadded_logits_indices,
                 spec_decode_metadata,
                 spec_decode_common_attn_metadata,
                 hidden_states,
@@ -2520,6 +2527,7 @@ class NPUModelRunner(GPUModelRunner):
         (
             scheduler_output,
             logits,
+            unpadded_logits_indices,
             spec_decode_metadata,
             spec_decode_common_attn_metadata,
             hidden_states,
@@ -2569,6 +2577,7 @@ class NPUModelRunner(GPUModelRunner):
                 aux_hidden_states,
                 sample_hidden_states,
                 batch_desc,
+                main_logits_indices=unpadded_logits_indices,
             )
             self._copy_draft_token_ids_to_cpu(scheduler_output)
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes an async scheduling race in the v1 model runner.

When async scheduling is enabled, the next batch can enter `_prepare_inputs` before the previous batch finishes `compute_logits`. The old PCP proposer path later reads `self.runner.logits_indices`, which is a mutable runner-level attribute and may already have been refreshed by the next batch. This can make the previous batch use stale or mismatched logits indices and lead to invalid `hidden_states[logits_indices]` indexing.

This PR makes logits indices batch-local instead of reading them from mutable runner state:

- Return both padded and unpadded logits indices from `_prepare_inputs`.
- Keep padded logits indices for LM head TP `compute_logits`.
- Store unpadded logits indices in `ExecuteModelState`.
- Pass the batch-local unpadded logits indices through `sample_tokens` / `propose_draft_token_ids` into the PCP proposer.
- Stop the PCP proposer from reading `self.runner.logits_indices`.
- Align the 310P model runner signature with the v1 runner change.
- Add a regression check that verifies the proposer uses the passed-in batch-local indices rather than a stale runner attribute.

### Does this PR introduce _any_ user-facing change?

No.

This is an internal correctness fix for async scheduling / speculative decoding metadata lifetime. It does not change public APIs, configuration, or user-visible behavior except avoiding the async race.

### How was this patch tested?

- `python -m compileall -q vllm_ascend/worker/model_runner_v1.py vllm_ascend/_310p/model_runner_310p.py vllm_ascend/spec_decode/llm_base_proposer.py tests/ut/spec_decode/a2/test_eagle_proposer.py`
- `python -m ruff check vllm_ascend/worker/model_runner_v1.py vllm_ascend/_310p/model_runner_310p.py vllm_ascend/spec_decode/llm_base_proposer.py tests/ut/spec_decode/a2/test_eagle_proposer.py`
- `git diff --cached --check`

A targeted regression test was updated in `tests/ut/spec_decode/a2/test_eagle_proposer.py`.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
