### PR TITLE
[Feature][LoRA][MoE] Support MoE LoRA on models with shared experts (opt-in)

### DIFF
--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -100,6 +100,19 @@ env_variables: dict[str, Callable[[], Any]] = {
     # `dispatch_gmm_combine_decode` can be used only for **decode node** moe layer
     # with W8A8. And MTP layer must be W8A8.
     "VLLM_ASCEND_ENABLE_FUSED_MC2": lambda: int(os.getenv("VLLM_ASCEND_ENABLE_FUSED_MC2", "0")),
+    # Allow MoE LoRA on models with shared experts (e.g. Qwen3.5-MoE,
+    # DeepSeek-V3). The shared-experts LoRA runs through vLLM's dense
+    # wrappers, whose expand-slice path does not match the
+    # _C_ascend.sgmv_expand stacked lora_b layout (and vLLM's torch_ops
+    # einsum fallback fails on the same layout). When set to 1,
+    # PunicaWrapperNPU._expand_slice_prefill / _expand_slice_decode bypass
+    # sgmv/bgmv_expand_slice and compute the LoRA expand via a per-token
+    # gather + torch.bmm instead. Experimental; expect a throughput drop.
+    # Leave off for models without shared experts (e.g. Qwen3-30B-A3B),
+    # whose expand-slice path stays on _C_ascend and is unaffected.
+    "VLLM_ASCEND_MOE_LORA_ALLOW_SHARED_EXPERTS": lambda: bool(
+        int(os.getenv("VLLM_ASCEND_MOE_LORA_ALLOW_SHARED_EXPERTS", "0"))
+    ),
     # DEPRECATED: VLLM_ASCEND_BALANCE_SCHEDULING env var will be removed in a future release.
     # Use --additional-config '{"enable_balance_scheduling": true}' instead.
     "VLLM_ASCEND_BALANCE_SCHEDULING": lambda: bool(int(os.getenv("VLLM_ASCEND_BALANCE_SCHEDULING", "0"))),

--- a/vllm_ascend/lora/fused_moe.py
+++ b/vllm_ascend/lora/fused_moe.py
@@ -47,6 +47,7 @@ from vllm.distributed.parallel_state import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
+from vllm.logger import logger
 from vllm.lora.layers.base import BaseLayerWithLoRA
 from vllm.lora.layers.fused_moe import FusedMoE3DWithLoRA, FusedMoEWithLoRA
 from vllm.lora.layers.utils import _get_lora_device
@@ -73,11 +74,33 @@ def _assert_ascend_moe_lora_supported(base_layer: nn.Module) -> None:
             "Set VLLM_ASCEND_ENABLE_FUSED_MC2=0."
         )
     if getattr(base_layer, "_shared_experts", None) is not None:
-        raise AssertionError(
-            "Ascend MoE LoRA v1 does not wrap the shared_experts path "
-            "(it runs outside quant_method.apply). The target model "
-            "Qwen3-30B-A3B-Thinking-2507 has no shared experts; models "
-            "like DeepSeek-V3 are not yet supported."
+        # Models with shared experts (e.g. Qwen3.5-MoE, DeepSeek-V3) run the
+        # shared-experts LoRA through vLLM's standard dense wrappers, whose
+        # expand-slice path does not match the _C_ascend.sgmv_expand stacked
+        # lora_b layout (and vLLM's torch_ops einsum fallback fails on the
+        # same layout). By default this is rejected up-front.
+        #
+        # Set VLLM_ASCEND_MOE_LORA_ALLOW_SHARED_EXPERTS=1 to route the
+        # expand-slice path through PunicaWrapperNPU's torch.bmm fallback
+        # (per-token gather + bmm), which avoids both ops. This is
+        # experimental and adds overhead (a throughput drop vs the fused NPU
+        # op); the routed-experts LoRA delta is applied by this wrapper while
+        # shared-experts/dense LoRA is handled by vLLM's dense wrappers.
+        if not envs_ascend.VLLM_ASCEND_MOE_LORA_ALLOW_SHARED_EXPERTS:
+            raise AssertionError(
+                "Ascend MoE LoRA v1 does not wrap the shared_experts path by "
+                "default (Qwen3-30B-A3B-Thinking-2507 has no shared experts). "
+                "For models with shared experts (e.g. Qwen3.5-MoE, "
+                "DeepSeek-V3), set VLLM_ASCEND_MOE_LORA_ALLOW_SHARED_EXPERTS=1 "
+                "to route the expand-slice path through a torch.bmm fallback "
+                "(experimental; expect ~30-40% throughput drop)."
+            )
+        logger.warning_once(
+            "Ascend MoE LoRA: shared_experts detected and "
+            "VLLM_ASCEND_MOE_LORA_ALLOW_SHARED_EXPERTS=1. Routed-experts LoRA "
+            "delta is applied by this wrapper; shared-experts/dense LoRA is "
+            "handled by vLLM's standard dense wrappers, with the expand-slice "
+            "path routed to an experimental torch.bmm fallback."
         )
     if getattr(base_layer, "multistream_overlap_gate", False):
         raise AssertionError(

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -5,8 +5,70 @@ from collections.abc import Callable
 import torch
 from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
 
+import vllm_ascend.envs as envs_ascend
 from vllm_ascend.lora.utils import refresh_all_lora_classes
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
+
+@torch.library.custom_op("vllm_ascend::moe_lora_bmm_expand_slice", mutates_args={"y"})
+def _moe_lora_bmm_expand_slice_op(
+    y: torch.Tensor,
+    x: torch.Tensor,
+    w_t_all: torch.Tensor,
+    indices: torch.Tensor,
+    y_offset: int,
+    y_slice_size: int,
+    add_inputs: bool,
+) -> None:
+    rows = x.shape[0]
+    if indices.shape[0] != rows:
+        indices = indices[:rows]
+    safe_indices = indices.clamp(min=0).to(torch.long)
+    # w_t_all is (max_loras+1, 1, output_size_i, active_rank); [safe_indices, 0]
+    # collapses the legacy stacking dim 1. Cast to y.dtype to match upstream
+    # torch_ops.bgmv_expand_slice.
+    gathered = w_t_all[safe_indices, 0].to(y.dtype)
+
+    # The shrink buffer can be padded to the rank bucket while lora_b only
+    # carries the active rank. Slice x, not gathered, to preserve the loaded
+    # weight layout.
+    active_rank = gathered.shape[-1]
+    if x.shape[-1] != active_rank:
+        x_active = x[..., :active_rank].to(y.dtype).contiguous()
+    else:
+        x_active = x.to(y.dtype)
+
+    # profile_run / dummy_run can hand us empty tensors; downstream NPU ops
+    # trip index errors in that case.
+    if x_active.shape[0] == 0 or gathered.shape[1] == 0:
+        return
+
+    # Equivalent to einsum("br, bor -> bo"), rewritten to avoid the
+    # aclnnBatchMatMul path on NPU.
+    delta = (x_active.unsqueeze(1) * gathered).sum(dim=-1)
+    valid_mask = (indices >= 0).unsqueeze(-1)
+    delta = torch.where(valid_mask, delta, torch.zeros_like(delta))
+
+    y_slice = y.narrow(1, y_offset, y_slice_size)
+    if y_slice.shape[0] != delta.shape[0]:
+        y_slice = y_slice[: delta.shape[0]]
+    if add_inputs:
+        y_slice.add_(delta)
+    else:
+        y_slice.copy_(delta)
+
+
+@_moe_lora_bmm_expand_slice_op.register_fake
+def _moe_lora_bmm_expand_slice_fake(
+    y: torch.Tensor,
+    x: torch.Tensor,
+    w_t_all: torch.Tensor,
+    indices: torch.Tensor,
+    y_offset: int,
+    y_slice_size: int,
+    add_inputs: bool,
+) -> None:
+    return None
 
 
 # The platforms that are compatible with the PyTorch-native implementation can
@@ -115,6 +177,9 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         # No LoRA request, so return directly
         if self.no_lora:
             return
+        if envs_ascend.VLLM_ASCEND_MOE_LORA_ALLOW_SHARED_EXPERTS:
+            self._bmm_expand_slice(y, x, w_t_all, y_offset, y_slice_size, add_inputs)
+            return
         self.sgmv_expand_slice(
             x,
             w_t_all,
@@ -134,10 +199,39 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         y_slice_size: int,
         add_inputs: bool,
     ):
+        if envs_ascend.VLLM_ASCEND_MOE_LORA_ALLOW_SHARED_EXPERTS:
+            self._bmm_expand_slice(y, x, w_t_all, y_offset, y_slice_size, add_inputs)
+            return
         self.bgmv_expand_slice(
             x,
             w_t_all,
             y,
+            self._get_token_lora_indices(x),
+            y_offset,
+            y_slice_size,
+            add_inputs,
+        )
+
+    def _bmm_expand_slice(
+        self,
+        y: torch.Tensor,
+        x: torch.Tensor,
+        w_t_all: torch.Tensor,
+        y_offset: int,
+        y_slice_size: int,
+        add_inputs: bool,
+    ):
+        """Drop-in expand-slice replacement for shared-experts LoRA.
+
+        Replaces both sgmv_expand_slice and bgmv_expand_slice under
+        VLLM_ASCEND_MOE_LORA_ALLOW_SHARED_EXPERTS=1. It is dispatched through
+        a mutating torch custom op so Dynamo fullgraph keeps it opaque instead
+        of tracing the dynamic size nodes that trip vLLM graph splitting.
+        """
+        _moe_lora_bmm_expand_slice_op(
+            y,
+            x,
+            w_t_all,
             self._get_token_lora_indices(x),
             y_offset,
             y_slice_size,


### PR DESCRIPTION
### What this PR does / why we need it

vllm-ascend MoE LoRA (added in #10977) currently **rejects** models with
**shared experts** up-front — it raises `AssertionError` when
`base_layer._shared_experts is not None`. This excludes models such as
**Qwen3.5-MoE** and **DeepSeek-V3**.

The reason is that the shared-experts LoRA runs through vLLM's standard dense
LoRA wrappers, whose expand-slice path does not match the
`_C_ascend.sgmv_expand` stacked `lora_b` layout, and vLLM's `torch_ops` einsum
fallback fails on the same padded `lora_b_stacked` layout.

This PR adds an **opt-in** path so those models can run:

- New env `VLLM_ASCEND_MOE_LORA_ALLOW_SHARED_EXPERTS` (default **off**).
- When set to `1`, `_assert_ascend_moe_lora_supported` no longer rejects
  shared-experts layers, and
  `PunicaWrapperNPU._expand_slice_prefill` / `_expand_slice_decode` route the
  expand step through a **`torch.bmm` fallback** (per-token gather + bmm),
  dispatched via a mutating `torch.library` custom op so it stays opaque to
  Dynamo fullgraph. This bypasses both `sgmv_expand_slice` and
  `bgmv_expand_slice`.
- Default off means models **without** shared experts (e.g. `Qwen3-30B-A3B`)
  keep the fused `_C_ascend` path and are completely unaffected.

### Does this PR introduce any user-facing change?

Only behind an opt-in env var. With `VLLM_ASCEND_MOE_LORA_ALLOW_SHARED_EXPERTS`
unset/`0` (the default), behavior is unchanged. When `1`, MoE LoRA becomes
usable on shared-experts models at the cost of throughput (the `torch.bmm`
fallback is slower than the fused NPU op).

### How was it tested?

Validated that a shared-experts MoE model serves and activates LoRA
end-to-end through the fallback path without errors (the `bmm` expand-slice
op is exercised on every decode step). This path is **experimental** and its
numerical parity against a production adapter is still being validated, hence
the opt-in gating and the throughput caveat — feedback welcome.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
