### PR TITLE
[CI] test

### DIFF
--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -156,7 +156,6 @@ jobs:
 
       - name: Run pre-commit
         env:
-          PRE_COMMIT_HOME: /tmp/pre-commit-cache
           PRE_COMMIT_COLOR: always
           FORCE_COLOR: "1"
           TERM: xterm-256color


### PR DESCRIPTION
## What this PR does / why we need it?

Add \PRE_COMMIT_HOME: /tmp/pre-commit-cache\ environment variable to the pre-commit step in the E2E workflow, enabling pre-commit hook caching.

## Does this PR introduce _any_ user-facing change?

No, CI changes only.

## How was this patch tested?

CI verification only.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
