### PR TITLE
[Feature][LoRA] Enable Qwen3.5 hybrid dense LoRA (eager + full-graph)

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -74,6 +74,26 @@ SWA_INT_MAX = 2147483647
 _ATTN_KEYS_BUFFER = None
 
 
+def _filter_fia_attn_keys(attn_keys, attn_metadata):
+    """Keep only the self-attention (FIA) layers in the graph-replay key list.
+
+    Hybrid models such as Qwen3.5 / Qwen3-Next mix self-attention layers
+    (updated through npu_fused_infer_attention_score) with linear-attention
+    (GatedDeltaNet) layers. Only the self-attention layers are captured into
+    `graph_params.attn_params`; the linear-attention layers use a separate
+    conv1d update path and their metadata (`GDNAttentionMetadata`) has neither
+    `seq_lens_list` nor `actual_seq_lengths_q`. Iterating the raw key list in
+    the FIA graph-replay loop therefore reaches a linear-attention key and
+    raises ``AttributeError: 'GDNAttentionMetadata' object has no attribute
+    'seq_lens_list'``. Drop those keys so the loop only visits FIA metadata.
+    """
+    return [
+        key
+        for key in attn_keys
+        if hasattr(attn_metadata[key], "seq_lens_list") and hasattr(attn_metadata[key], "actual_seq_lengths_q")
+    ]
+
+
 @register_backend(AttentionBackendEnum.CUSTOM, "ASCEND")
 class AscendAttentionBackend(AttentionBackend):
     accept_output_buffer: bool = True
@@ -531,6 +551,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 graph_params = get_graph_params()
                 attn_metadata = forward_context.attn_metadata
                 attn_keys = list(attn_metadata.keys())
+                attn_keys = _filter_fia_attn_keys(attn_keys, attn_metadata)
             # For Qwen3-next, since the kv_cache_config has already categorized
             # linear_attn and self_attn, the attn_metadata is first arranged with
             # self_attn followed by linear_attn. Therefore, using zip directly
@@ -636,6 +657,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 graph_params = get_graph_params()
                 attn_metadata = forward_context.attn_metadata
                 attn_keys = list(attn_metadata.keys())
+                attn_keys = _filter_fia_attn_keys(attn_keys, attn_metadata)
                 if not use_layer_aware_replay:
                     # In some speculative methods (such as DFlash), the order of
                     # attn_keys in the Target model will be disrupted instead of

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -229,15 +229,28 @@ def update_conv1d_graph_params(
                     # Mark every input row as -1 so the task is a state no-op.
                     new_cache_indices = (-1,) * cap_x_dim0
                 elif branch == "non_spec_decode":
-                    non_sdq_host, non_sd_cidx_host = get_causal_conv1d_update_host_args(meta)
-                    new_query_start_loc, new_cache_indices, _ = _pad_conv1d_host_args_to_capture(
-                        non_sdq_host,
-                        non_sd_cidx_host,
-                        (),
-                        cap_x_dim0=cap_x_dim0,
-                        q_per_seq=q_per_seq,
-                        with_num_accepted=False,
-                    )
+                    # Mirror the spec branch above: the captured graph may
+                    # contain a non-spec-decode conv1d task even when this
+                    # replay's batch has no runtime non-spec decode. That
+                    # happens when spec-decode (MTP) sequences are present: the
+                    # builder folds the plain decodes into prefills and sets
+                    # num_decodes to 0, so `non_spec_decode_fallback_meta` is
+                    # None. Fetching host args off the missing meta then raises
+                    # "Expected attn_metadata.non_spec_decode_fallback_meta..."
+                    # and kills the engine. Make the task a state no-op
+                    # (cache_indices = -1) instead, exactly like the spec case.
+                    if getattr(meta, "non_spec_decode_fallback_meta", None) is None:
+                        new_cache_indices = (-1,) * cap_x_dim0
+                    else:
+                        non_sdq_host, non_sd_cidx_host = get_causal_conv1d_update_host_args(meta)
+                        new_query_start_loc, new_cache_indices, _ = _pad_conv1d_host_args_to_capture(
+                            non_sdq_host,
+                            non_sd_cidx_host,
+                            (),
+                            cap_x_dim0=cap_x_dim0,
+                            q_per_seq=q_per_seq,
+                            with_num_accepted=False,
+                        )
                     new_num_accepted = ()
 
             torch.npu.graph_task_update_begin(update_stream, handle)

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -67,6 +67,7 @@ import vllm_ascend.patch.worker.patch_cudagraph  # noqa
 import vllm_ascend.patch.worker.patch_deepseek_mtp  # noqa
 import vllm_ascend.patch.worker.patch_deepseek_v2  # noqa
 import vllm_ascend.patch.worker.patch_gqa_c8  # noqa
+import vllm_ascend.patch.worker.patch_lora_vlm_prefix  # noqa
 
 # vLLM's use_v2_model_runner may enable the v2 runner without the
 # VLLM_USE_V2_MODEL_RUNNER env var (e.g. based on model architecture).

--- a/vllm_ascend/patch/worker/patch_lora_vlm_prefix.py
+++ b/vllm_ascend/patch/worker/patch_lora_vlm_prefix.py
@@ -1,0 +1,114 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ---------------------------------------------------------------------------
+# Fix: LoRA is a no-op (delta == 0) for VLM-wrapped hybrid dense models.
+#
+# Applies to models whose text tower is wrapped under a submodule such as
+# `language_model` (e.g. Qwen3.5 dense variants).
+#
+# Root cause:
+#   * The adapter tensors load correctly, but are keyed by the adapter's bare
+#     module names, e.g.  model.layers.N.mlp.down_proj
+#   * The model registers its LoRA modules under the wrapped name, e.g.
+#     language_model.model.layers.N.mlp.down_proj
+#   The weight lookup at activation uses the wrapped model name, misses the
+#   bare-keyed adapter weights, and set_lora receives a zero buffer, so the
+#   LoRA delta is zero (LoRA output is bit-identical to the base model).
+#
+# Fix: after WorkerLoRAManager._load_adapter loads the LoRAModel (but before it
+# is registered / packed-merged), rename the loras dict keys so they line up
+# with the model's actual module names. The prefix is auto-detected from the
+# manager's own module table (LoRAModelManager.modules): find a model module
+# whose name ends with a (non-packed) adapter key and take the leading
+# difference as the prefix. This works unchanged for any wrapper depth.
+#
+# Once the keys line up:
+#   * plain modules (down_proj/o_proj) match directly, and
+#   * _create_merged_loras_inplace finds q/k/v & gate/up sub-loras and packs the
+#     non-zero qkv_proj / gate_up_proj automatically.
+#
+# Safety: only touches the real-adapter load path (dummy LoRAs already use
+# model names); leaves keys untouched if no prefix is detected (already-aligned
+# plain text models); never raises into the serving path. Disable with
+# VLLM_ASCEND_LORA_VLM_PREFIX=0.
+# ---------------------------------------------------------------------------
+import os
+
+from vllm.logger import logger
+from vllm.lora.worker_manager import WorkerLoRAManager
+
+_ENABLED = os.environ.get("VLLM_ASCEND_LORA_VLM_PREFIX", "1") not in ("0", "", "false", "False")
+
+_orig_load_adapter = WorkerLoRAManager._load_adapter
+
+
+def _detect_prefix(lora_keys, model_module_names):
+    """Return the prefix P such that some model module == P + <adapter_key>.
+
+    Uses only keys that are likely NON-packed (down_proj / o_proj / *_proj that
+    already appear verbatim as a model module suffix), so packed q/k/v vs
+    qkv_proj naming does not confuse detection. Returns "" if the adapter keys
+    already match model modules (nothing to do), or None if no prefix aligns.
+    """
+    model_set = set(model_module_names)
+    for lk in lora_keys:
+        # Already aligned? then no prefix needed.
+        if lk in model_set:
+            return ""
+        for mm in model_module_names:
+            if mm.endswith("." + lk):
+                return mm[: -len(lk)]
+    return None
+
+
+def _load_adapter(self, lora_request):
+    lora = _orig_load_adapter(self, lora_request)
+    try:
+        mgr = self._adapter_manager
+        model_module_names = list(getattr(mgr, "modules", {}).keys())
+        lora_keys = list(lora.loras.keys())
+        if not model_module_names or not lora_keys:
+            return lora
+
+        prefix = _detect_prefix(lora_keys, model_module_names)
+        if not prefix:
+            # None (no alignment) or "" (already aligned): leave keys unchanged.
+            return lora
+
+        remapped = {}
+        changed = 0
+        for key, weights in lora.loras.items():
+            new_key = key
+            if not key.startswith(prefix):
+                new_key = prefix + key
+                changed += 1
+            remapped[new_key] = weights
+        lora.loras = remapped
+
+        logger.debug(
+            "[lora-vlm-prefix] detected prefix=%r, remapped %d/%d adapter keys to align with model modules",
+            prefix,
+            changed,
+            len(lora_keys),
+        )
+    except Exception as e:  # noqa: BLE001 - never break serving on remap
+        logger.warning("[lora-vlm-prefix] remap skipped due to %s: %s", type(e).__name__, e)
+    return lora
+
+
+if _ENABLED:
+    WorkerLoRAManager._load_adapter = _load_adapter


### PR DESCRIPTION
### What this PR does / why we need it

Enables LoRA on **Qwen3.5 hybrid dense** models in both **eager** and
**full-graph (full-decode)** modes. These models wrap the text tower under a
submodule (`language_model`) and mix self-attention with GatedDeltaNet (GDN)
linear-attention layers. Three issues stop LoRA from working; this PR fixes
all three together so the model runs end-to-end.

**1. Zero LoRA delta (name mapping).**
Adapter tensors are keyed by the bare module name (`model.layers.N...`) while
the model registers LoRA modules under the wrapped name
(`language_model.model.layers.N...`). The activation-time lookup misses,
`set_lora` receives a zero buffer, and the LoRA delta is zero (LoRA output ==
base). A worker patch auto-detects the wrapper prefix from
`LoRAModelManager.modules` and remaps the `loras` dict keys right after
`WorkerLoRAManager._load_adapter`, before registration/packed-merge. Keys are
left untouched when already aligned, so plain models are unaffected. Guarded
by `VLLM_ASCEND_LORA_VLM_PREFIX` (default on).

**2. Graph-capture crash.**
Graph replay walks the full `attn_metadata` key list and reaches a GDN layer
whose `GDNAttentionMetadata` has no `seq_lens_list` / `actual_seq_lengths_q`,
raising `AttributeError`. Filter the replay key list down to the captured
self-attention (FIA) layers.

**3. Graph-replay crash under MTP.**
With spec-decode sequences present, the builder folds plain decodes into
prefills and sets `num_decodes` to 0, so `non_spec_decode_fallback_meta` is
None; the `non_spec_decode` conv1d graph update then fetches host args off the
missing meta and kills the engine. Treat the task as a state no-op
(`cache_indices = -1`) when the fallback meta is absent, mirroring the spec
branch.

### Does this PR introduce any user-facing change?

No change for existing models: the name remap is a no-op when adapter keys
already align, and the two GDN graph fixes only skip/short-circuit metadata
that is otherwise invalid. Qwen3.5 hybrid dense LoRA now runs in eager and
full-graph modes.

### How was it tested?

Verified end-to-end on a Qwen3.5 hybrid dense checkpoint: LoRA output diverges
from base as expected (non-zero delta), and the model serves in both eager and
full-decode (graph) modes without the capture/replay crashes above.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
