### PR TITLE
[v0.20.2rc][Performance] Avoid blocking AscendStore KV save

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -80,6 +80,7 @@ class KVTransferThread(threading.Thread):
         self.m_store.set_device()
         self.ready_event.set()
         while True:
+            request_data = None
             try:
                 request_data = self.request_queue.get()
                 if request_data is None:
@@ -88,9 +89,14 @@ class KVTransferThread(threading.Thread):
                     continue
                 self._handle_request(request_data)
             except Exception as e:
+                if request_data is not None:
+                    self._handle_request_exception(request_data)
                 logger.error("Error in KVCacheTransferThread: %s", e)
 
     def _handle_request(self, req_meta: Any):
+        pass
+
+    def _handle_request_exception(self, request_data: Any):
         pass
 
     def lookup(
@@ -240,6 +246,15 @@ class KVCacheStoreSendingThread(KVTransferThread):
         with self.done_task_lock:
             if req_id in self.stored_requests:
                 del self.stored_requests[req_id]
+
+    def _handle_request_exception(self, request_data: Any):
+        req_id = getattr(request_data, "req_id", None)
+        if req_id is not None:
+            with self.done_task_lock:
+                tracked_request = req_id in self.stored_requests
+            if tracked_request:
+                self.dec_stored_request(req_id)
+        self.request_queue.task_done()
 
     def _handle_request(self, req_meta: ReqMeta):
         token_len = req_meta.token_len_chunk

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -753,6 +753,7 @@ class KVPoolWorker:
 
     def get_and_clear_finished_requests(self, finished_req_ids, meta: AscendConnectorMetadata) -> set[str]:
         finished_sending = set()
+        pending_finished_req_ids = set()
         for req_id in meta.preempted_req_ids:
             self.kv_send_thread.delete_finished_stored_request(  # type: ignore[union-attr]
                 req_id
@@ -783,6 +784,20 @@ class KVPoolWorker:
                 )
             elif req_remain_jobs is not None:
                 self.finished_store_req.add(req_id)
+                pending_finished_req_ids.add(req_id)
+
+        if pending_finished_req_ids:
+            self.kv_send_thread.request_queue.join()  # type: ignore[union-attr]
+            for req_id in pending_finished_req_ids:
+                req_remain_jobs = self.kv_send_thread.stored_requests.get(  # type: ignore[union-attr]
+                    req_id
+                )
+                if req_remain_jobs == 0:
+                    self.finished_store_req.discard(req_id)
+                    finished_sending.add(req_id)
+                    self.kv_send_thread.delete_finished_stored_request(  # type: ignore[union-attr]
+                        req_id
+                    )
 
         return finished_sending
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -753,7 +753,6 @@ class KVPoolWorker:
 
     def get_and_clear_finished_requests(self, finished_req_ids, meta: AscendConnectorMetadata) -> set[str]:
         finished_sending = set()
-        pending_finished_req_ids = set()
         for req_id in meta.preempted_req_ids:
             self.kv_send_thread.delete_finished_stored_request(  # type: ignore[union-attr]
                 req_id
@@ -784,20 +783,6 @@ class KVPoolWorker:
                 )
             elif req_remain_jobs is not None:
                 self.finished_store_req.add(req_id)
-                pending_finished_req_ids.add(req_id)
-
-        if pending_finished_req_ids:
-            self.kv_send_thread.request_queue.join()  # type: ignore[union-attr]
-            for req_id in pending_finished_req_ids:
-                req_remain_jobs = self.kv_send_thread.stored_requests.get(  # type: ignore[union-attr]
-                    req_id
-                )
-                if req_remain_jobs == 0:
-                    self.finished_store_req.discard(req_id)
-                    finished_sending.add(req_id)
-                    self.kv_send_thread.delete_finished_stored_request(  # type: ignore[union-attr]
-                        req_id
-                    )
 
         return finished_sending
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -568,7 +568,6 @@ class KVPoolWorker:
 
     def wait_for_save(self, connector_metadata: AscendConnectorMetadata):
         current_event = None
-        has_save_request = False
         for request in connector_metadata.requests:
             can_save = request.can_save
             if can_save is None or not can_save:
@@ -587,16 +586,11 @@ class KVPoolWorker:
             self.kv_send_thread.add_stored_request(  # type: ignore[union-attr]
                 request.req_id
             )
+            # Keep store async; delay-free protects these blocks until
+            # get_finished() observes kv_send_thread completion.
             self.kv_send_thread.add_request(  # type: ignore[union-attr]
                 request,
             )
-            has_save_request = True
-
-        if has_save_request:
-            # vLLM expects wait_for_save() to make stores visible before the
-            # request is reported as finished. Without this barrier a following
-            # identical prompt can lookup before Mooncake put() has completed.
-            self.kv_send_thread.request_queue.join()  # type: ignore[union-attr]
 
     def retrieve_layer(
         self,


### PR DESCRIPTION
### What this PR does / why we need it?

This PR keeps AscendStore KV cache save asynchronous on the v0.20.2rc branch. `wait_for_save()` now enqueues save work to the sending thread and returns without draining the queue.

KV block correctness is still guarded by the existing delay-free flow: blocks are not freed or reused until `get_finished()` observes that the sending thread has completed. If no later poll is triggered immediately after the final request, the release can be deferred until the next engine step, which is a resource reclamation delay rather than a KV correctness issue.

The sending thread also decrements the stored-request counter and marks the queue task done when the backend save path raises, so delayed blocks do not remain pinned forever after a put failure.

### Does this PR introduce _any_ user-facing change?

No API change. It reduces avoidable latency from KV Pool save on AscendStore while preserving block lifetime correctness.

### How was this patch tested?

- `python3 -m py_compile vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py`
- Pre-commit hooks during commit: `ruff check`, `ruff format`, `codespell`, `typos`, and repository checks.

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
