### PR TITLE
[BugFix] Fixing compilation errors in the new version of cann vLLM Ascend

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -97,6 +97,11 @@ set(CMAKE_CXX_STANDARD 17 CACHE STRING "c++17 is needed for this project")
 set_directory_properties(PROPERTIES
     ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_BINARY_DIR}/_CPack_Packages"
 )
+set(VLLM_ASCEND_CANN_COMPAT_HEADER "${OPS_TRANSFORMER_DIR}/common/include/cann_compat.h")
+list(APPEND OPS_COMPILE_OPTIONS -include${VLLM_ASCEND_CANN_COMPAT_HEADER})
+add_compile_options(
+    $<$<COMPILE_LANGUAGE:CXX>:-include${VLLM_ASCEND_CANN_COMPAT_HEADER}>
+)
 
 include(cmake/config.cmake)
 include(cmake/func.cmake)

--- a/csrc/cmake/modules/Findaicpu.cmake
+++ b/csrc/cmake/modules/Findaicpu.cmake
@@ -21,6 +21,7 @@ if(BUILD_WITH_INSTALLED_DEPENDENCY_CANN_PKG)
     ${ASCEND_DIR}/${SYSTEM_PREFIX}/include/experiment
     ${ASCEND_DIR}/${SYSTEM_PREFIX}/include/experiment/msprof
     ${ASCEND_DIR}/${SYSTEM_PREFIX}/pkg_inc/aicpu_common/context
+    ${ASCEND_DIR}/${SYSTEM_PREFIX}/pkg_inc/aicpu
     ${ASCEND_DIR}/${SYSTEM_PREFIX}/pkg_inc/aicpu_common/context/common
     ${ASCEND_DIR}/${SYSTEM_PREFIX}/pkg_inc/aicpu_common/context/cpu_proto
     ${ASCEND_DIR}/${SYSTEM_PREFIX}/pkg_inc/aicpu_common/context/utils

--- a/csrc/common/include/cann_compat.h
+++ b/csrc/common/include/cann_compat.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <stdint.h>
+
+// B080 op_common/log/log.h stopped exposing the unqualified OP module id used
+// by inherited ops-transformer tiling/error headers. Include the CANN log type
+// header early so OP still comes from the active CANN version.
+#if defined(__has_include)
+#if __has_include("base/log_types.h")
+#include "base/log_types.h"
+#elif __has_include("toolchain/log_types.h")
+#include "toolchain/log_types.h"
+#endif
+#endif
+
+#if !defined(LOG_TYPES_H_) && !defined(OP)
+#define OP 63
+#endif
+
+#if defined(LOG_CPP) && !defined(DLOG_PUB_H_)
+#ifdef __cplusplus
+extern "C" {
+#endif
+int32_t CheckLogLevel(int32_t moduleId, int32_t logLevel);
+void DlogRecord(int32_t moduleId, int32_t level, const char *fmt, ...);
+#ifdef __cplusplus
+}
+#endif
+#define DLOG_PUB_H_
+#endif


### PR DESCRIPTION

### What this PR does / why we need it?
Fixing compilation errors in the new version of cann vLLM Ascend

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
pip install

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
