### PR TITLE
[Attention][Misc] Replace PA KV cache operators

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_pa_kv_cache_ops.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_pa_kv_cache_ops.py
@@ -1,0 +1,64 @@
+import unittest
+
+import torch
+import torch_npu
+
+
+class TestPaKvCacheOps(unittest.TestCase):
+    def test_scatter_pa_kv_cache_slot_mapping_zero_and_minus_one(self):
+        torch.manual_seed(20260709)
+
+        dtype = torch.float16
+        block_size = 4
+        num_blocks = 2
+        num_heads = 1
+        head_dim = 8
+        slot_mapping = torch.tensor([0, -1, 3], dtype=torch.int32, device="npu")
+        key = torch.arange(3 * num_heads * head_dim, dtype=dtype, device="npu").view(3, num_heads, head_dim)
+        value = key + 100
+        key_cache = torch.randn(num_blocks, block_size, num_heads, head_dim, dtype=dtype, device="npu")
+        value_cache = torch.randn_like(key_cache)
+
+        expected_key_cache = key_cache.clone()
+        expected_value_cache = value_cache.clone()
+        for token_idx, slot in enumerate(slot_mapping.cpu().tolist()):
+            if slot < 0:
+                continue
+            expected_key_cache[slot // block_size, slot % block_size] = key[token_idx]
+            expected_value_cache[slot // block_size, slot % block_size] = value[token_idx]
+
+        torch_npu.npu_scatter_pa_kv_cache(
+            key=key,
+            value=value,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            slot_mapping=slot_mapping,
+            cache_mode="Norm",
+        )
+        torch.npu.synchronize()
+
+        torch.testing.assert_close(key_cache, expected_key_cache, atol=0, rtol=0)
+        torch.testing.assert_close(value_cache, expected_value_cache, atol=0, rtol=0)
+
+    def test_scatter_pa_kv_cache_all_minus_one_leaves_cache_unchanged(self):
+        dtype = torch.float16
+        key = torch.randn(2, 1, 8, dtype=dtype, device="npu")
+        value = torch.randn_like(key)
+        key_cache = torch.randn(2, 4, 1, 8, dtype=dtype, device="npu")
+        value_cache = torch.randn_like(key_cache)
+        expected_key_cache = key_cache.clone()
+        expected_value_cache = value_cache.clone()
+        slot_mapping = torch.tensor([-1, -1], dtype=torch.int32, device="npu")
+
+        torch_npu.npu_scatter_pa_kv_cache(
+            key=key,
+            value=value,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            slot_mapping=slot_mapping,
+            cache_mode="Norm",
+        )
+        torch.npu.synchronize()
+
+        torch.testing.assert_close(key_cache, expected_key_cache, atol=0, rtol=0)
+        torch.testing.assert_close(value_cache, expected_value_cache, atol=0, rtol=0)

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_transpose_kv_cache_by_block.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_transpose_kv_cache_by_block.py
@@ -40,12 +40,12 @@ class TestTransposeKvCacheByBlock(unittest.TestCase):
             k_cache_layer = k_caches[layer]
             v_cache_layer = v_caches[layer]
 
-            torch_npu.atb.npu_paged_cache_load(
+            torch_npu.npu_gather_pa_kv_cache(
                 k_cache_layer,
                 v_cache_layer,
                 block_table,
                 block_len_tensor,
-                seq_starts=seq_start_tensor,
+                seq_offset=seq_start_tensor,
                 key=k,
                 value=v,
             )
@@ -58,12 +58,13 @@ class TestTransposeKvCacheByBlock(unittest.TestCase):
             v.transpose_(1, 2)
             v = v.contiguous().view(block_len, num_kv_head, -1)
 
-            torch_npu._npu_reshape_and_cache(
+            torch_npu.npu_scatter_pa_kv_cache(
                 key=k,
                 value=v,
                 key_cache=k_cache_layer,
                 value_cache=v_cache_layer,
-                slot_indices=slot_mapping,
+                slot_mapping=slot_mapping,
+                cache_mode="Norm",
             )
         del k, v
 

--- a/tests/ut/attention/a2/test_attention_cp.py
+++ b/tests/ut/attention/a2/test_attention_cp.py
@@ -198,8 +198,8 @@ class TestAscendAttentionCPImpl(TestBase):
         self.assertEqual(result_lse.shape[1], self.impl.num_heads)
         self.assertEqual(result_lse.shape[2], 1)
 
-    @patch("torch_npu.atb.npu_paged_cache_load")
-    def test_load_kv_for_chunk(self, mock_npu_paged_cache_load):
+    @patch("torch_npu.npu_gather_pa_kv_cache")
+    def test_load_kv_for_chunk(self, mock_npu_gather_pa_kv_cache):
         block_num = 100
         block_size = 128
         num_heads = 1
@@ -227,9 +227,9 @@ class TestAscendAttentionCPImpl(TestBase):
         self.assertEqual(value.shape[2], head_size)
 
     @patch("torch_npu.Event", create=True)
-    @patch("torch_npu._npu_reshape_and_cache")
+    @patch("torch_npu.npu_scatter_pa_kv_cache")
     @patch_distributed_groups(dcp_size=2, pcp_size=2, needs_mocks=False)
-    def test_reshape_and_cache(self, mock_event_class, mock_npu_reshape_and_cache):
+    def test_reshape_and_cache(self, mock_event_class, mock_npu_scatter_pa_kv_cache):
         num_tokens = 4
         block_num = 100
         block_size = 128

--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -393,11 +393,11 @@ class TestAscendAttentionBackendImpl(TestBase):
 
         assert output.shape == (10, 8 * 64)
 
-    @patch("torch_npu._npu_reshape_and_cache")
+    @patch("torch_npu.npu_scatter_pa_kv_cache")
     @patch("torch_npu.npu_fused_infer_attention_score")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     def test_forward_fused_infer_attention(
-        self, mock_get_forward_context, mock_npu_fused_infer_attention_score, mock_npu_reshape_and_cache
+        self, mock_get_forward_context, mock_npu_fused_infer_attention_score, mock_npu_scatter_pa_kv_cache
     ):
         """Test forward pass in PrefillCacheHit state"""
         query = torch.randn(10, 8, 64)
@@ -428,10 +428,10 @@ class TestAscendAttentionBackendImpl(TestBase):
 
     @patch("vllm_ascend.attention.attention_v1.using_paged_attention")
     @patch("torch_npu._npu_paged_attention")
-    @patch("torch_npu._npu_reshape_and_cache")
+    @patch("torch_npu.npu_scatter_pa_kv_cache")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     def test_forward_paged_attention(
-        self, mock_get_forward_context, mock_npu_reshape_and_cache, mock_paged_attention, mock_using_paged_attention
+        self, mock_get_forward_context, mock_npu_scatter_pa_kv_cache, mock_paged_attention, mock_using_paged_attention
     ):
         """Test forward pass in DecodeOnly state"""
         query = torch.randn(4, 8 * 64)
@@ -460,9 +460,9 @@ class TestAscendAttentionBackendImpl(TestBase):
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("torch_npu.npu_fused_infer_attention_score")
-    @patch("torch_npu._npu_reshape_and_cache")
+    @patch("torch_npu.npu_scatter_pa_kv_cache")
     def test_forward_decode_only_swa(
-        self, mock_npu_reshape_and_cache, mock_fused_infer_attention_score, mock_get_forward_context
+        self, mock_npu_scatter_pa_kv_cache, mock_fused_infer_attention_score, mock_get_forward_context
     ):
         """Test forward pass in DecodeOnly state"""
         query = torch.randn(10, 8 * 64)
@@ -491,9 +491,9 @@ class TestAscendAttentionBackendImpl(TestBase):
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("torch_npu.npu_fused_infer_attention_score_v2")
-    @patch("torch_npu._npu_reshape_and_cache")
+    @patch("torch_npu.npu_scatter_pa_kv_cache")
     def test_forward_decode_only_swa_sink(
-        self, mock_npu_reshape_and_cache, mock_fused_infer_attention_score, mock_get_forward_context
+        self, mock_npu_scatter_pa_kv_cache, mock_fused_infer_attention_score, mock_get_forward_context
     ):
         """Test forward pass in DecodeOnly state"""
         query = torch.randn(10, 8 * 64)
@@ -523,10 +523,10 @@ class TestAscendAttentionBackendImpl(TestBase):
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("torch_npu._npu_paged_attention")
     @patch("torch_npu.npu_fused_infer_attention_score")
-    @patch("torch_npu._npu_reshape_and_cache")
+    @patch("torch_npu.npu_scatter_pa_kv_cache")
     def test_forward_decode_only_swa_seq_len_mismatch(
         self,
-        mock_npu_reshape_and_cache,
+        mock_npu_scatter_pa_kv_cache,
         mock_fused_infer_attention_score,
         mock_paged_attention,
         mock_get_forward_context,

--- a/tests/ut/attention/a2/test_mla_cp.py
+++ b/tests/ut/attention/a2/test_mla_cp.py
@@ -325,12 +325,12 @@ class TestAscendMLAImpl(TestBase):
         self.assertIsNotNone(decode_res)
         self.assertIsNone(prefill_res)
 
-    @patch("torch_npu._npu_reshape_and_cache")
+    @patch("torch_npu.npu_scatter_pa_kv_cache")
     @patch("torch.ops.vllm.maybe_all_gather_and_maybe_unpad")
     @patch("vllm_ascend.attention.mla_v1.get_weight_prefetch_method", return_value=MagicMock())
     @patch_distributed_groups(dcp_size=2, pcp_size=2, needs_mocks=False)
     def test_mla_preprocess_pcp(
-        self, mock_get_weight_prefetch_method, mock_maybe_all_gather_and_maybe_unpad, mock_npu_reshape_and_cache
+        self, mock_get_weight_prefetch_method, mock_maybe_all_gather_and_maybe_unpad, mock_npu_scatter_pa_kv_cache
     ):
         self.impl.num_kv_heads = 1
         self.impl.num_heads = 16
@@ -492,7 +492,7 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(result.shape[0], B)
         self.assertEqual(result.shape[1], self.impl.v_head_dim)
 
-    @patch("torch_npu.atb.npu_paged_cache_load")
+    @patch("torch_npu.npu_gather_pa_kv_cache")
     @patch("torch_npu.npu_attention_update")
     @patch("torch_npu.npu_fused_infer_attention_score")
     @patch_distributed_groups(dcp_size=2, pcp_size=2)

--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -1895,7 +1895,7 @@ class TestAscendMLAImpl(TestBase):
         self.assertTrue(torch.equal(prefix_out, out))
         self.assertTrue(torch.equal(prefix_lse, lse))
 
-    @patch("torch_npu.atb.npu_paged_cache_load")
+    @patch("torch_npu.npu_gather_pa_kv_cache")
     @patch("torch_npu.npu_attention_update")
     @patch("torch_npu.npu_fused_infer_attention_score")
     def test_compute_prefill_context(self, mock_fia, mock_update, mock_load):
@@ -1943,7 +1943,7 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(out.shape, prefix_out.shape)
 
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
-    @patch("torch_npu.atb.npu_paged_cache_load")
+    @patch("torch_npu.npu_gather_pa_kv_cache")
     @patch("torch_npu.npu_attention_update")
     @patch("torch_npu.npu_fused_infer_attention_score")
     def test_compute_prefill_context_non_power_of_two_heads(

--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -881,9 +881,9 @@ class TestAscendSFACPImpl(TestBase):
         mock_super.assert_called_once()
         self.assertEqual(result, ("a", "b"))
 
-    @patch("vllm_ascend.attention.context_parallel.sfa_cp.torch_npu")
+    @patch("vllm_ascend.attention.context_parallel.sfa_cp.DeviceOperator.reshape_and_cache")
     @patch_distributed_groups(dcp_size=1, pcp_size=2, needs_mocks=False)
-    def test_exec_kv_with_pcp(self, mock_torch_npu):
+    def test_exec_kv_with_pcp(self, mock_reshape_and_cache):
         self.impl.pcp_size = 2
         # Configure dimensions
         self.impl.kv_lora_rank = 32
@@ -910,7 +910,7 @@ class TestAscendSFACPImpl(TestBase):
 
         result = self.impl.exec_kv(kv_no_split, cos, sin, kv_cache, slots, attn_metadata)
         self.assertEqual(result, (None, None))
-        mock_torch_npu._npu_reshape_and_cache.assert_called_once()
+        mock_reshape_and_cache.assert_called_once()
 
     @patch_distributed_groups(dcp_size=1, pcp_size=1, needs_mocks=False)
     def test_execute_sparse_flash_attention_process_decode_only(self):

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -105,6 +105,8 @@ if not _npu_available:
     sys.modules["torch_npu"]._npu_flash_attention = MagicMock()  # type: ignore[attr-defined]
     sys.modules["torch_npu"]._npu_paged_attention_splitfuse = MagicMock()  # type: ignore[attr-defined]
     sys.modules["torch_npu"]._npu_reshape_and_cache = MagicMock()  # type: ignore[attr-defined]
+    sys.modules["torch_npu"].npu_scatter_pa_kv_cache = MagicMock()  # type: ignore[attr-defined]
+    sys.modules["torch_npu"].npu_gather_pa_kv_cache = MagicMock()  # type: ignore[attr-defined]
     sys.modules["torch_npu"].npu_moe_gating_top_k_softmax = MagicMock()  # type: ignore[attr-defined]
     sys.modules["torch_npu"].npu_quant_matmul = MagicMock()  # type: ignore[attr-defined]
     sys.modules["torch_npu"].npu_rms_norm = MagicMock()  # type: ignore[attr-defined]

--- a/tests/ut/device/test_device_op.py
+++ b/tests/ut/device/test_device_op.py
@@ -6,6 +6,71 @@ import torch
 from vllm_ascend.device.device_op import A5DeviceAdaptor, BaseDeviceAdaptor
 
 
+def test_reshape_and_cache_makes_scatter_inputs_contiguous():
+    key = torch.randn(2, 3, 4).transpose(0, 1)
+    value = torch.randn(2, 3, 4).transpose(0, 1)
+    slot_mapping = torch.arange(8, dtype=torch.int32)[::2]
+    key_cache = object()
+    value_cache = object()
+
+    assert not key.is_contiguous()
+    assert not value.is_contiguous()
+    assert not slot_mapping.is_contiguous()
+
+    with mock.patch("vllm_ascend.device.device_op.torch_npu.npu_scatter_pa_kv_cache") as mock_scatter:
+        BaseDeviceAdaptor.reshape_and_cache(key, value, key_cache, value_cache, slot_mapping)
+
+    mock_scatter.assert_called_once()
+    call_kwargs = mock_scatter.call_args.kwargs
+    assert call_kwargs["key"] is not key
+    assert call_kwargs["value"] is not value
+    assert call_kwargs["slot_mapping"] is not slot_mapping
+    assert call_kwargs["key"].is_contiguous()
+    assert call_kwargs["value"].is_contiguous()
+    assert call_kwargs["slot_mapping"].is_contiguous()
+    torch.testing.assert_close(call_kwargs["key"], key)
+    torch.testing.assert_close(call_kwargs["value"], value)
+    torch.testing.assert_close(call_kwargs["slot_mapping"], slot_mapping)
+    assert call_kwargs["key_cache"] is key_cache
+    assert call_kwargs["value_cache"] is value_cache
+    assert call_kwargs["cache_mode"] == "Norm"
+
+
+def test_kv_cache_load_makes_seq_lens_contiguous():
+    cache_kv_c = object()
+    cache_k_pe = object()
+    block_table = object()
+    context_seq_len_npu = torch.arange(8, dtype=torch.int32)[::2]
+    seq_starts = object()
+    key = object()
+    value = object()
+
+    assert not context_seq_len_npu.is_contiguous()
+
+    with mock.patch("vllm_ascend.device.device_op.torch_npu.npu_gather_pa_kv_cache") as mock_gather:
+        BaseDeviceAdaptor.kv_cache_load(
+            cache_kv_c,
+            cache_k_pe,
+            block_table,
+            context_seq_len_npu,
+            seq_starts,
+            key,
+            value,
+        )
+
+    mock_gather.assert_called_once()
+    call_args = mock_gather.call_args.args
+    assert call_args[0] is cache_kv_c
+    assert call_args[1] is cache_k_pe
+    assert call_args[2] is block_table
+    assert call_args[3] is not context_seq_len_npu
+    assert call_args[3].is_contiguous()
+    torch.testing.assert_close(call_args[3], context_seq_len_npu)
+    assert mock_gather.call_args.kwargs["seq_offset"] is seq_starts
+    assert mock_gather.call_args.kwargs["key"] is key
+    assert mock_gather.call_args.kwargs["value"] is value
+
+
 def test_npu_flash_attention_uses_fusion_attention_for_fp32():
     query = torch.randn(5, 4, 64, dtype=torch.float32)
     key = torch.randn_like(query)

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -22,6 +22,7 @@ from vllm_ascend.attention.sfa_v1 import (
     DCPQueryGatherContext,
 )
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, enabling_mlapo, split_decodes_and_prefills
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.utils import (
     all_gather_async,
 )
@@ -580,8 +581,12 @@ class AscendSFACPImpl(AscendSFAImpl):
         kv_c_k_pe = torch.index_select(kv_c_k_pe, 0, attn_metadata.sfa_cp_metadata.pcp_allgather_restore_idx)
         kv_c_normed, k_pe = kv_c_k_pe.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
         slot_mapping = attn_metadata.slot_mapping
-        torch_npu._npu_reshape_and_cache(
-            key=kv_c_normed, value=k_pe, key_cache=kv_cache[0], value_cache=kv_cache[1], slot_indices=slot_mapping
+        DeviceOperator.reshape_and_cache(
+            key=kv_c_normed,
+            value=k_pe,
+            key_cache=kv_cache[0],
+            value_cache=kv_cache[1],
+            slot_mapping=slot_mapping,
         )
         return None, None
 

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -46,8 +46,13 @@ else:
 class BaseDeviceAdaptor:
     @classmethod
     def reshape_and_cache(cls, key, value, key_cache, value_cache, slot_mapping):
-        torch_npu._npu_reshape_and_cache(
-            key=key, value=value, key_cache=key_cache, value_cache=value_cache, slot_indices=slot_mapping
+        torch_npu.npu_scatter_pa_kv_cache(
+            key=key.contiguous(),
+            value=value.contiguous(),
+            key_cache=key_cache,
+            value_cache=value_cache,
+            slot_mapping=slot_mapping.contiguous(),
+            cache_mode="Norm",
         )
 
     @classmethod
@@ -261,12 +266,12 @@ class BaseDeviceAdaptor:
 
     @staticmethod
     def kv_cache_load(cache_kv_c, cache_k_pe, block_table, context_seq_len_npu, seq_starts, key, value):
-        torch_npu.atb.npu_paged_cache_load(
+        torch_npu.npu_gather_pa_kv_cache(
             cache_kv_c,
             cache_k_pe,
             block_table,
-            context_seq_len_npu,
-            seq_starts=seq_starts,
+            context_seq_len_npu.contiguous(),
+            seq_offset=seq_starts,
             key=key,
             value=value,
         )
@@ -857,17 +862,6 @@ class BaseDeviceAdaptor:
 
 
 class A5DeviceAdaptor(BaseDeviceAdaptor):
-    @classmethod
-    def reshape_and_cache(cls, key, value, key_cache, value_cache, slot_mapping):
-        torch_npu.npu_scatter_pa_kv_cache(
-            key=key.contiguous(),
-            value=value.contiguous(),
-            key_cache=key_cache,
-            value_cache=value_cache,
-            slot_mapping=slot_mapping.contiguous(),
-            cache_mode="Norm",
-        )
-
     @classmethod
     def npu_fused_infer_attention_score(
         cls,
@@ -1813,6 +1807,16 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
 
 
 class Ascend310PDeviceAdaptor(BaseDeviceAdaptor):
+    @classmethod
+    def reshape_and_cache(cls, key, value, key_cache, value_cache, slot_mapping):
+        torch_npu._npu_reshape_and_cache(
+            key=key,
+            value=value,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            slot_indices=slot_mapping,
+        )
+
     @staticmethod
     def index_fill(
         tensor: torch.Tensor,

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1184,12 +1184,12 @@ class KVCacheRecvingThread(threading.Thread):
         # Process each layer in the KV cache
         for _, (k_cache_layer, v_cache_layer) in kv_caches.items():
             # Load cache data into buffers
-            torch_npu.atb.npu_paged_cache_load(
+            torch_npu.npu_gather_pa_kv_cache(
                 k_cache_layer,
                 v_cache_layer,
                 block_table,
                 block_len_tensor,
-                seq_starts=seq_start_tensor,
+                seq_offset=seq_start_tensor,
                 key=k_buffer,
                 value=v_buffer,
             )
@@ -1241,8 +1241,13 @@ class KVCacheRecvingThread(threading.Thread):
         v_buffer = _transpose_kv_cache_between_head(v_buffer)
 
         # Reshape and cache the processed buffers
-        torch_npu._npu_reshape_and_cache(
-            key=k_buffer, value=v_buffer, key_cache=k_cache_layer, value_cache=v_cache_layer, slot_indices=slot_mapping
+        torch_npu.npu_scatter_pa_kv_cache(
+            key=k_buffer,
+            value=v_buffer,
+            key_cache=k_cache_layer,
+            value_cache=v_cache_layer,
+            slot_mapping=slot_mapping,
+            cache_mode="Norm",
         )
 
     def _nz_kv_cache(

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -889,12 +889,12 @@ class KVCacheRecvingThread(threading.Thread):
         # Process each layer in the KV cache
         for _, (k_cache_layer, v_cache_layer) in self.kv_caches.items():
             # Load cache data into buffers
-            torch_npu.atb.npu_paged_cache_load(
+            torch_npu.npu_gather_pa_kv_cache(
                 k_cache_layer,
                 v_cache_layer,
                 block_table,
                 block_len_tensor,
-                seq_starts=seq_start_tensor,
+                seq_offset=seq_start_tensor,
                 key=k_buffer,
                 value=v_buffer,
             )
@@ -927,8 +927,13 @@ class KVCacheRecvingThread(threading.Thread):
         v_buffer = _transpose_kv_cache_between_head(v_buffer)
 
         # Reshape and cache the processed buffers
-        torch_npu._npu_reshape_and_cache(
-            key=k_buffer, value=v_buffer, key_cache=k_cache_layer, value_cache=v_cache_layer, slot_indices=slot_mapping
+        torch_npu.npu_scatter_pa_kv_cache(
+            key=k_buffer,
+            value=v_buffer,
+            key_cache=k_cache_layer,
+            value_cache=v_cache_layer,
+            slot_mapping=slot_mapping,
+            cache_mode="Norm",
         )
 
     def _nz_kv_cache(self, k_cache_layer, v_cache_layer, k_buffer, v_buffer, slot_mapping):

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -1744,12 +1744,12 @@ class MooncakeLayerwiseConnectorWorker:
                     )
 
                     # Load cache data into buffers
-                    torch_npu.atb.npu_paged_cache_load(
+                    torch_npu.npu_gather_pa_kv_cache(
                         kv_layer[0],
                         kv_layer[1],
                         send_task.group_block_table[layer_group_idx],
                         send_task.group_block_len_tensor[layer_group_idx],
-                        seq_starts=send_task.group_seq_start_tensor[layer_group_idx],
+                        seq_offset=send_task.group_seq_start_tensor[layer_group_idx],
                         key=keys,
                         value=values,
                     )


### PR DESCRIPTION
## Summary
- Replace `_npu_reshape_and_cache` call sites with `torch_npu.npu_scatter_pa_kv_cache` for ND PA cache writes, using `cache_mode="Norm"`.
- Replace `torch_npu.atb.npu_paged_cache_load` call sites with `torch_npu.npu_gather_pa_kv_cache` and `seq_offset`.
- Route the SFA CP KV write path through `DeviceOperator.reshape_and_cache` and update related mocks/tests.
- Add a single-op coverage case for `slot_mapping == 0` and `slot_mapping == -1` behavior on `npu_scatter_pa_kv_cache`.
- Keep individual call sites free of layout handling; normalize scatter inputs and gather `seq_lens` centrally in `BaseDeviceAdaptor` because the PA operators reject non-contiguous views.
- Add regression coverage for non-contiguous scatter inputs and sliced `seq_lens` tensors.

## Validation
- Local: `python -m compileall -q vllm_ascend tests/ut/conftest.py tests/e2e/nightly/single_node/ops/singlecard_ops/test_transpose_kv_cache_by_block.py tests/e2e/nightly/single_node/ops/singlecard_ops/test_pa_kv_cache_ops.py`
- Local: `uvx ruff check vllm_ascend/device/device_op.py tests/ut/device/test_device_op.py`
- Local: `git diff --check origin/main...HEAD`
- Local: `rg -n "_npu_reshape_and_cache\(|npu_paged_cache_load\(" vllm_ascend tests -g "*.py"` returned no target-call matches.
- Remote A3 container on `80.5.17.106`, image `vllm-ascend:dev-26.1.0.day20260707-800I-A3-py311-Ubuntu24.04-lts-aarch64`: PA scatter/gather Norm single-op validation passed.
- Remote A3 container: old `_npu_reshape_and_cache` and new `npu_scatter_pa_kv_cache(cache_mode="Norm")` produced identical cache results for `slot_mapping=[0, -1, 3]` and `slot_mapping=[-1, -1]`.
- Remote A3 container after removing call-site data-tensor layout conversions: `python -m unittest tests.e2e.nightly.single_node.ops.singlecard_ops.test_pa_kv_cache_ops -v` passed.
- Remote A3 container after removing call-site data-tensor layout conversions: targeted A2/MLA tests passed (`9 passed`).

## Notes
- e2e pytest collection in the container is blocked by missing `modelscope`; the new single-op test was run directly with `unittest` to avoid that unrelated conftest dependency.
- Direct unittest execution of `test_transpose_kv_cache_by_block.py` requires the local `vllm_ascend_C` extension to be built; this source-tree container did not have that extension registered.
- The local macOS environment does not provide `torch_npu`, so the new device-adaptor UT is delegated to CI.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
