### PR TITLE
[Feature] Support Ascend 950 CPU binding with topo clusters

### DIFF
--- a/docs/source/developer_guide/Design_Documents/cpu_binding.md
+++ b/docs/source/developer_guide/Design_Documents/cpu_binding.md
@@ -242,6 +242,17 @@ The CPU allocation plan is as follows:
 NPU0: main=[...] acl=[...] release=[...]
 ```
 
+Ascend 950 uses a different role split, so its plan log does not include ACL or
+release fields. UVB polling thread binding is reported separately when matching
+threads are found:
+
+```text
+[cpu_bind_mode] mode=topo_affinity rank=0 visible_npus=[0]
+The CPU allocation plan is as follows:
+Ascend 950 NPU0: worker=[...]
+[cpu_bind_ascend_950] uvb_poll_window_thread tids=[...] cpus=[...]
+```
+
 ## Limitations
 
 - CPU binding runs only on ARM. It is skipped on x86_64.

--- a/docs/source/developer_guide/Design_Documents/cpu_binding.md
+++ b/docs/source/developer_guide/Design_Documents/cpu_binding.md
@@ -37,6 +37,8 @@ The allocator derives its plan from runtime host state:
 | Running NPUs | `npu-smi info` process table, filtered by `ASCEND_RT_VISIBLE_DEVICES` | Identifies the logical NPUs used by this worker process. A2/A3 process rows use `NPU Chip`; Ascend 950 process rows use `NPU ID`. |
 | Topology affinity | `npu-smi info -t topo` | Provides NPU-to-CPU affinity for `topo_affinity` mode. |
 | CPU NUMA map | `lscpu -e=CPU,NODE` | Used to extend single-NUMA affinity pools to the next NUMA node. |
+| Thread topology | `lscpu` `Thread(s) per core` | Determines Ascend 950 cluster size: 8 CPUs for 1 thread per core, 16 CPUs for 2 threads per core. |
+| UVB polling threads | `ps -Te` | Finds host `uvb_poll_window_thread` threads for Ascend 950 UVB CPU binding. Docker containers must use `--pid=host` to see these host threads. |
 
 ### Strategy Selection
 
@@ -45,7 +47,7 @@ The binding strategy is selected by Ascend device type:
 | Device type | Strategy | Reason |
 | --- | --- | --- |
 | A3 | `global_slice` | A3 uses HCCS card-to-card interconnect. Each NPU is nearly equidistant from all NUMA nodes, so there is no strong NPU-to-NUMA affinity signal. Global logical NPU ID based slicing gives deterministic, non-overlapping CPU pools and CPU/NUMA isolation between workers. |
-| Ascend 950 | `global_slice` | Ascend 950 reports NPU-to-NPU/NIC topology but does not report NPU-to-CPU affinity in `npu-smi info -t topo`. It also reports process rows by `NPU ID` instead of `NPU Chip`. Global logical NPU ID based slicing keeps CPU pools deterministic without relying on missing affinity data. |
+| Ascend 950 | `topo_affinity` | Ascend 950 uses NPU-to-CPU affinity from `npu-smi info -t topo` to choose an affinity NUMA node, then assigns one CPU cluster from that NUMA node to each worker. It also reports process rows by `NPU ID` instead of `NPU Chip`, skips IRQ binding, and binds host UVB polling threads. |
 | A2 and Atlas 300 inference products | `topo_affinity` | A2 and Atlas 300 inference products provide NPU-to-CPU affinity information through `npu-smi info -t topo`, so they use this topology signal when available. |
 
 If `topo_affinity` is selected but topo affinity is unavailable, the allocator falls back to `global_slice`.
@@ -55,11 +57,10 @@ If `topo_affinity` is selected but topo affinity is unavailable, the allocator f
 #### global_slice
 
 `global_slice` is designed for devices without a useful NPU-to-CPU affinity
-signal, including A3 and Ascend 950. Because A3's **HCCS interconnect makes the distance
+signal, including A3. Because A3's **HCCS interconnect makes the distance
 from each NPU to each NUMA node nearly the same**, topology affinity is not a
-useful placement signal. Ascend 950 similarly exposes UB/NIC topology but not CPU
-affinity. The allocator therefore partitions the sorted `allowed_cpus` list by
-global logical NPU ID.
+useful placement signal. The allocator therefore partitions the sorted
+`allowed_cpus` list by global logical NPU ID.
 
 1. Determine `total_npus` in this order:
    - `total_logic_npus` from `npu-smi info -m`
@@ -84,14 +85,11 @@ does not share the same CPU or NUMA slice with another worker.
 - Devices with IRQ binding require `base >= 5`:
   2 CPUs for SQ/CQ IRQ binding, at least 1 CPU for the main worker, 1 CPU for
   ACL thread, and 1 CPU for release thread.
-- Ascend 950 skips IRQ binding and does not reserve SQ/CQ IRQ CPUs, so it requires
-  `base >= 3`: at least 1 CPU for the main worker, 1 CPU for ACL thread, and
-  1 CPU for release thread.
 
 #### topo_affinity
 
-`topo_affinity` is designed for A2, Atlas 300 inference products, and
-other non-A3 device types. A2 and Atlas 300 inference products expose
+`topo_affinity` is designed for A2, Atlas 300 inference products, Ascend 950,
+and other non-A3 device types. A2 and Atlas 300 inference products expose
 **meaningful NPU-to-CPU affinity information**, so the allocator starts from NPU
 topology affinity when it is available and then avoids overlap for shared
 affinity groups.
@@ -108,6 +106,19 @@ affinity groups.
 The non-running candidate step is intentional. It prevents two independent
 single-card workers from selecting the same CPU range when their visible NPUs
 share the same topology affinity.
+
+For Ascend 950, topology affinity is used differently:
+
+1. Bind all visible host `uvb_poll_window_thread` threads to NUMA0 CPUs except CPU0, constrained by `allowed_cpus`. Docker containers must use `--pid=host` to make these host threads visible.
+2. Use topo affinity to identify each NPU's single affinity NUMA node.
+3. Parse `Thread(s) per core` from `lscpu` and set cluster size to 8 CPUs when it is 1, or 16 CPUs when it is 2.
+4. Split each affinity NUMA's sorted allowed CPU list into contiguous clusters.
+5. Assign clusters by sorted logical NPU ID, including hidden NPUs that share the same affinity NUMA.
+6. Keep only running NPUs in the final `npu_cpu_pool`.
+
+If Ascend 950 topo affinity is missing, spans multiple NUMA nodes, has too few
+clusters, or reports an unsupported `Thread(s) per core`, worker CPU binding is
+skipped without raising to the worker process.
 
 ### Role Split
 
@@ -126,13 +137,14 @@ For Ascend 950:
 
 | Role | CPUs |
 | --- | --- |
-| Main worker process and subthreads | `pool[:-2]` |
-| ACL thread | `pool[-2]` |
-| Release thread | `pool[-1]` |
+| Main worker process and subthreads | the whole assigned cluster |
+| ACL thread | not separately pinned |
+| Release thread | not separately pinned |
 
 If a final pool has fewer CPUs than the selected role split requires, binding
 fails for this rank and the worker logs a warning from the caller. The minimum
-is 5 CPUs per NPU for devices with IRQ binding, and 3 CPUs per NPU for Ascend 950.
+is 5 CPUs per NPU for devices with IRQ binding. Ascend 950 requires one full
+cluster per worker.
 
 ## Conditional Host Tuning
 
@@ -144,7 +156,7 @@ steps when the environment supports them:
   reads and reduces remote-NUMA memory read latency.
 - IRQ binding places NPU IRQ handling on the CPUs reserved for the corresponding
   NPU when `/proc/irq` is writable and IRQ files can be resolved.
-  Ascend 950 skips this step and gives those CPUs to the main worker instead.
+  Ascend 950 skips this step.
 
 These are conditional parts of CPU binding, not separate feature switches. If a
 host prerequisite is missing, that step is skipped while CPU thread binding
@@ -234,14 +246,16 @@ NPU0: main=[...] acl=[...] release=[...]
 
 - CPU binding runs only on ARM. It is skipped on x86_64.
 - Each final NPU pool must have enough CPUs for its role split: at least 5 CPUs
-  for devices with IRQ binding, and at least 3 CPUs for Ascend 950.
+  for devices with IRQ binding. Ascend 950 requires one complete CPU cluster per worker.
 - `global_slice` is deterministic and provides CPU/NUMA isolation when the
   cpuset is NUMA-aligned, but it cannot guarantee NUMA-local pools when CPU
   numbering or cpuset layout crosses NUMA boundaries.
 - `topo_affinity` depends on usable output from `npu-smi info -t topo`.
 - IRQ binding requires writable `/proc/irq` and resolvable PCI/IRQ information.
-  Ascend 950 skips IRQ binding even when `/proc/irq` is writable, and does not reserve
-  IRQ CPUs in its role split.
+  Ascend 950 skips IRQ binding even when `/proc/irq` is writable.
+- Ascend 950 UVB polling thread binding requires visibility into the host PID
+  namespace. Docker containers must be created with `--pid=host`; otherwise
+  `uvb_poll_window_thread` may not be found.
 - Memory migration requires `migratepages`; otherwise only memory migration is
   skipped. CPU affinity still applies, but performance may degrade because
   existing pages are not moved to the target NUMA node and may be read through

--- a/docs/source/user_guide/feature_guide/cpu_binding.md
+++ b/docs/source/user_guide/feature_guide/cpu_binding.md
@@ -90,12 +90,15 @@ degrade latency or throughput.**
 For optimal locality, use a cpuset that is evenly distributed across NUMA
 nodes. Unbalanced cpusets may reduce the locality benefit of CPU binding.
 
-On Ascend 950, CPU binding uses deterministic global CPU slicing because Ascend 950 does not
-report NPU-to-CPU affinity in `npu-smi info -t topo`. Ascend 950 still pins worker,
-ACL, and release threads and can still migrate memory pages when `migratepages`
-is available. Because Ascend 950 skips IRQ binding, it does not reserve the first two
-CPUs in each NPU pool for IRQ handling. Those CPUs are assigned to the main
-worker instead.
+On Ascend 950, CPU binding uses NPU-to-CPU affinity from `npu-smi info -t topo`
+to select the worker's affinity NUMA node. Each worker main process is pinned to
+one CPU cluster from that NUMA node. The cluster size is derived from `lscpu`
+`Thread(s) per core`: 8 CPUs when it is 1, and 16 CPUs when it is 2. Ascend 950
+also pins host `uvb_poll_window_thread` threads to NUMA0 CPUs except CPU0,
+constrained by the current cpuset. In Docker deployments, add `--pid=host` when
+creating the container so vLLM Ascend can discover and bind these host threads.
+Ascend 950 still can migrate memory pages when `migratepages` is available, but
+it does not separately pin ACL/release threads and does not apply IRQ binding.
 
 For IRQ binding, the process also needs permission to read `/proc/interrupts`
 and write `/proc/irq/*/smp_affinity`. If `irqbalance` is running and the process
@@ -127,8 +130,10 @@ sudo systemctl start irqbalance
 | --- | --- | --- |
 | `CPU binding skipped: non-ARM CPU detected.` | CPU binding only runs on ARM. | No action needed on x86_64. |
 | `Can not get running npu info.` | No running NPU was found, or `ASCEND_RT_VISIBLE_DEVICES` filtered all NPUs. | Check visible NPU IDs and `npu-smi info`. |
-| `Insufficient CPUs for binding...` | Fewer CPUs are available than the role split requires. Devices with IRQ binding need at least 5 CPUs per logical NPU; Ascend 950 needs at least 3. | Expand the cpuset or reduce visible NPUs. |
-| `NPU topo affinity not found...` | Topology affinity is unavailable. | vLLM Ascend falls back to `global_slice`; check `npu-smi info -t topo` only if topology affinity is expected on this device. |
+| `Insufficient CPUs for binding...` | Fewer CPUs are available than the role split requires. Devices with IRQ binding need at least 5 CPUs per logical NPU. Ascend 950 needs one full cluster per worker. | Expand the cpuset or reduce visible NPUs. |
+| `NPU topo affinity not found...` | Topology affinity is unavailable. | On Ascend 950, worker CPU binding is skipped. On other topo-affinity devices, vLLM Ascend falls back to `global_slice`. Check `npu-smi info -t topo` when topology affinity is expected. |
+| `uvb_poll_window_thread not found... --pid=host` | Ascend 950 could not see host UVB polling threads. | Recreate the Docker container with `--pid=host`, then restart vLLM. |
+| `failed to bind uvb_poll_window_thread... --pid=host` | Ascend 950 found a UVB polling thread but failed to bind it. | Check permissions and recreate the Docker container with `--pid=host` if running in Docker. |
 | `The 'migratepages' command is not available...` | Memory migration is skipped, while CPU thread binding still proceeds. | Install `numactl` if NUMA locality or performance is affected. |
-| `[irq] IRQ binding skipped on Ascend 950.` | Ascend 950 does not use the IRQ binding step. | No action needed. Worker, ACL, release thread binding and memory migration still proceed. |
+| `[irq] IRQ binding skipped on Ascend 950.` | Ascend 950 does not use the IRQ binding step. | No action needed. Worker main binding and memory migration still proceed. |
 | `Bind cpus failed in rank...` | A binding step failed and CPU binding was skipped for that rank. | Check `taskset`, `lscpu`, `npu-smi`, cpuset size, and `/proc/irq` permissions. |

--- a/docs/source/user_guide/feature_guide/cpu_binding.md
+++ b/docs/source/user_guide/feature_guide/cpu_binding.md
@@ -110,6 +110,16 @@ Ascend 950 does not apply IRQ binding. When running on Ascend 950, the log conta
 `[irq] IRQ binding skipped on Ascend 950.` and no `/proc/irq/*/smp_affinity` files are
 written by this feature.
 
+Ascend 950 allocation logs use `worker=[...]` instead of `acl=[...]` or
+`release=[...]`, because ACL/release threads are not separately pinned on this
+device type. When UVB polling threads are found and bound, the log also reports
+their thread IDs and CPU pool:
+
+```text
+Ascend 950 NPU0: worker=[...]
+[cpu_bind_ascend_950] uvb_poll_window_thread tids=[...] cpus=[...]
+```
+
 On the host, stop `irqbalance` before starting vLLM when you need stable IRQ
 affinity:
 

--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -40,6 +40,7 @@ def make_cpu_alloc(rank_id=0):
     cpu_alloc.assign_main = {}
     cpu_alloc.assign_acl = {}
     cpu_alloc.assign_rel = {}
+    cpu_alloc.uvb_cpu_pool = []
     return cpu_alloc
 
 

--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -332,7 +332,7 @@ class TestCpuAlloc(unittest.TestCase):
         mock_get_device_type.return_value = AscendDeviceType.A3
         self.assertEqual(self.cpu_alloc._binding_mode(), "global_slice")
         mock_get_device_type.return_value = AscendDeviceType.A5
-        self.assertEqual(self.cpu_alloc._binding_mode(), "global_slice")
+        self.assertEqual(self.cpu_alloc._binding_mode(), "topo_affinity")
 
     @patch("vllm_ascend.cpu_binding.get_ascend_device_type")
     def test_build_cpu_pools_fallback_to_global_slice(self, mock_get_device_type):
@@ -495,28 +495,24 @@ class TestCpuAlloc(unittest.TestCase):
             self.cpu_alloc.allocate()
 
     @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
-    def test_allocate_ascend_950_uses_unreserved_cpus_for_main(self, _mock_get_device_type):
+    def test_allocate_ascend_950_assigns_cluster_to_main_only(self, _mock_get_device_type):
         self.cpu_alloc.device_info.running_npu_list = [0]
         self.cpu_alloc.npu_cpu_pool = {0: [0, 1, 2, 3, 4]}
 
         self.cpu_alloc.allocate()
 
-        self.assertEqual(self.cpu_alloc.assign_main[0], [0, 1, 2])
-        self.assertEqual(self.cpu_alloc.assign_acl[0], [3])
-        self.assertEqual(self.cpu_alloc.assign_rel[0], [4])
+        self.assertEqual(self.cpu_alloc.assign_main[0], [0, 1, 2, 3, 4])
+        self.assertEqual(self.cpu_alloc.assign_acl[0], [])
+        self.assertEqual(self.cpu_alloc.assign_rel[0], [])
 
         self.cpu_alloc.assign_main = {}
         self.cpu_alloc.assign_acl = {}
         self.cpu_alloc.assign_rel = {}
-        self.cpu_alloc.npu_cpu_pool = {0: [0, 1, 2]}
-        self.cpu_alloc.allocate()
-        self.assertEqual(self.cpu_alloc.assign_main[0], [0])
-        self.assertEqual(self.cpu_alloc.assign_acl[0], [1])
-        self.assertEqual(self.cpu_alloc.assign_rel[0], [2])
-
         self.cpu_alloc.npu_cpu_pool = {0: [0, 1]}
-        with self.assertRaises(RuntimeError):
-            self.cpu_alloc.allocate()
+        self.cpu_alloc.allocate()
+        self.assertEqual(self.cpu_alloc.assign_main[0], [0, 1])
+        self.assertEqual(self.cpu_alloc.assign_acl[0], [])
+        self.assertEqual(self.cpu_alloc.assign_rel[0], [])
 
     @patch("vllm_ascend.cpu_binding.execute_command")
     def test_bind_threads(self, mock_execute_command):
@@ -607,6 +603,90 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         cpu_alloc.cpu_node = {0: 0, 1: 1}
 
         self.assertEqual(cpu_alloc.extend_numa([0, 1]), [0, 1])
+
+    def test_parse_threads_per_core(self):
+        self.assertEqual(CpuAlloc.parse_threads_per_core("CPU(s): 384\nThread(s) per core: 1\n"), 1)
+        self.assertEqual(CpuAlloc.parse_threads_per_core("Thread(s) per core: 2\nCore(s) per socket: 96\n"), 2)
+        self.assertIsNone(CpuAlloc.parse_threads_per_core("CPU(s): 384\n"))
+
+    def test_get_uvb_poll_window_threads(self):
+        thread_message = (
+            "100 101 ? 00:00:01 uvb_poll_window_thread\n"
+            "200 201 ? 00:00:01 worker_thread\n"
+            "bad-line uvb_poll_window_thread\n"
+            "300 301 ? 00:00:01 uvb_poll_window_thread"
+        )
+
+        self.assertEqual(CpuAlloc.get_uvb_poll_window_threads(thread_message), ["101", "301"])
+
+    @patch("vllm_ascend.cpu_binding.execute_command")
+    def test_bind_uvb_poll_window_threads(self, mock_execute_command):
+        cpu_alloc = make_cpu_alloc()
+        cpu_alloc.numa_to_cpu_map = {0: [0, 1, 2, 3], 1: [4, 5]}
+        cpu_alloc.device_info.allowed_cpus = [0, 1, 2, 3, 4, 5]
+        mock_execute_command.return_value = (
+            "100 101 ? 00:00:01 uvb_poll_window_thread\n200 201 ? 00:00:01 uvb_poll_window_thread",
+            0,
+        )
+
+        with patch.object(cpu_alloc, "bind") as mock_bind:
+            cpu_alloc.bind_uvb_poll_window_threads()
+
+        self.assertEqual(cpu_alloc.uvb_cpu_pool, [1, 2, 3])
+        self.assertEqual(
+            mock_bind.call_args_list,
+            [
+                call("101", [1, 2, 3], False),
+                call("201", [1, 2, 3], False),
+            ],
+        )
+
+    @patch("vllm_ascend.cpu_binding.execute_command")
+    def test_bind_uvb_poll_window_threads_skips_empty_inputs(self, mock_execute_command):
+        cpu_alloc = make_cpu_alloc()
+        cpu_alloc.numa_to_cpu_map = {0: [0, 1]}
+        cpu_alloc.device_info.allowed_cpus = [0]
+
+        with patch.object(cpu_alloc, "bind") as mock_bind:
+            cpu_alloc.bind_uvb_poll_window_threads()
+        mock_execute_command.assert_not_called()
+        mock_bind.assert_not_called()
+
+        cpu_alloc.device_info.allowed_cpus = [0, 1]
+        mock_execute_command.return_value = ("100 101 ? 00:00:01 worker_thread", 0)
+        with patch.object(cpu_alloc, "bind") as mock_bind:
+            cpu_alloc.bind_uvb_poll_window_threads()
+        mock_bind.assert_not_called()
+
+    @patch("vllm_ascend.cpu_binding.logger.info")
+    @patch("vllm_ascend.cpu_binding.execute_command", return_value=("100 101 ? 00:00:01 worker_thread", 0))
+    def test_bind_uvb_poll_window_threads_logs_pid_host_when_thread_missing(
+        self, _mock_execute_command, mock_logger_info
+    ):
+        cpu_alloc = make_cpu_alloc()
+        cpu_alloc.numa_to_cpu_map = {0: [0, 1]}
+        cpu_alloc.device_info.allowed_cpus = [0, 1]
+
+        cpu_alloc.bind_uvb_poll_window_threads()
+
+        self.assertIn("--pid=host", mock_logger_info.call_args[0][0])
+
+    @patch("vllm_ascend.cpu_binding.logger.warning")
+    @patch(
+        "vllm_ascend.cpu_binding.execute_command",
+        return_value=("100 101 ? 00:00:01 uvb_poll_window_thread", 0),
+    )
+    def test_bind_uvb_poll_window_threads_logs_pid_host_when_bind_fails(
+        self, _mock_execute_command, mock_logger_warning
+    ):
+        cpu_alloc = make_cpu_alloc()
+        cpu_alloc.numa_to_cpu_map = {0: [0, 1]}
+        cpu_alloc.device_info.allowed_cpus = [0, 1]
+
+        with patch.object(cpu_alloc, "bind", side_effect=RuntimeError("failed")):
+            cpu_alloc.bind_uvb_poll_window_threads()
+
+        self.assertIn("--pid=host", mock_logger_warning.call_args[0][0])
 
     @patch("vllm_ascend.cpu_binding.execute_command")
     def test_build_cpu_node_map_skips_blank_and_header_rows(self, mock_execute_command):
@@ -721,6 +801,79 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         self.assertFalse(set(npu0_process.assign_acl[0]) & set(npu2_process.assign_acl[2]))
         self.assertFalse(set(npu0_process.assign_rel[0]) & set(npu2_process.assign_rel[2]))
 
+    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    def test_build_ascend_950_cpu_pools_assigns_hidden_global_clusters(self, _mock_get_device_type):
+        def build_dp_process(visible_npus):
+            cpu_alloc = make_cpu_alloc()
+            cpu_alloc.device_info.all_logic_npus = list(range(8))
+            cpu_alloc.device_info.running_npu_list = visible_npus
+            cpu_alloc.device_info.allowed_cpus = list(range(384))
+            cpu_alloc.device_info.npu_affinity = {
+                0: list(range(288, 384)),
+                1: list(range(288, 384)),
+                2: list(range(96, 192)),
+                3: list(range(96, 192)),
+                4: list(range(96, 192)),
+                5: list(range(96, 192)),
+                6: list(range(288, 384)),
+                7: list(range(288, 384)),
+            }
+            cpu_alloc.cpu_node = {cpu: cpu // 96 for cpu in range(384)}
+            cpu_alloc.numa_to_cpu_map = {
+                0: list(range(0, 96)),
+                1: list(range(96, 192)),
+                2: list(range(192, 288)),
+                3: list(range(288, 384)),
+            }
+
+            with patch.object(cpu_alloc, "get_ascend_950_cluster_size", return_value=16):
+                self.assertTrue(cpu_alloc.build_ascend_950_cpu_pools())
+            return cpu_alloc
+
+        dp0_process = build_dp_process([0, 1, 2, 3])
+        dp1_process = build_dp_process([4, 5, 6, 7])
+
+        self.assertEqual(dp0_process.npu_cpu_pool[0], list(range(288, 304)))
+        self.assertEqual(dp0_process.npu_cpu_pool[1], list(range(304, 320)))
+        self.assertEqual(dp0_process.npu_cpu_pool[2], list(range(96, 112)))
+        self.assertEqual(dp0_process.npu_cpu_pool[3], list(range(112, 128)))
+        self.assertEqual(dp1_process.npu_cpu_pool[4], list(range(128, 144)))
+        self.assertEqual(dp1_process.npu_cpu_pool[5], list(range(144, 160)))
+        self.assertEqual(dp1_process.npu_cpu_pool[6], list(range(320, 336)))
+        self.assertEqual(dp1_process.npu_cpu_pool[7], list(range(336, 352)))
+        dp0_cpus = set().union(*(set(cpus) for cpus in dp0_process.npu_cpu_pool.values()))
+        dp1_cpus = set().union(*(set(cpus) for cpus in dp1_process.npu_cpu_pool.values()))
+        self.assertFalse(dp0_cpus & dp1_cpus)
+
+    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    def test_build_ascend_950_cpu_pools_skips_invalid_inputs(self, _mock_get_device_type):
+        cpu_alloc = make_cpu_alloc()
+        cpu_alloc.device_info.all_logic_npus = [0]
+        cpu_alloc.device_info.running_npu_list = [0]
+        cpu_alloc.device_info.allowed_cpus = list(range(32))
+        cpu_alloc.cpu_node = {cpu: 0 for cpu in range(32)}
+        cpu_alloc.numa_to_cpu_map = {0: list(range(32))}
+
+        cpu_alloc.device_info.npu_affinity = {}
+        self.assertFalse(cpu_alloc.build_ascend_950_cpu_pools())
+
+        cpu_alloc.device_info.npu_affinity = {0: list(range(8))}
+        with patch.object(cpu_alloc, "get_ascend_950_cluster_size", return_value=None):
+            self.assertFalse(cpu_alloc.build_ascend_950_cpu_pools())
+
+        cpu_alloc.device_info.allowed_cpus = [0, 100]
+        cpu_alloc.device_info.npu_affinity = {0: [0, 100]}
+        cpu_alloc.cpu_node[100] = 1
+        with patch.object(cpu_alloc, "get_ascend_950_cluster_size", return_value=8):
+            self.assertFalse(cpu_alloc.build_ascend_950_cpu_pools())
+
+        cpu_alloc.device_info.allowed_cpus = list(range(32))
+        cpu_alloc.device_info.all_logic_npus = [0, 1, 2]
+        cpu_alloc.device_info.running_npu_list = [0]
+        cpu_alloc.device_info.npu_affinity = {0: list(range(8)), 1: list(range(8)), 2: list(range(8))}
+        with patch.object(cpu_alloc, "get_ascend_950_cluster_size", return_value=16):
+            self.assertFalse(cpu_alloc.build_ascend_950_cpu_pools())
+
     @patch("vllm_ascend.cpu_binding.logger.info")
     def test_print_plan_handles_empty_release_assignment(self, mock_logger_info):
         cpu_alloc = make_cpu_alloc()
@@ -808,6 +961,19 @@ class TestCpuBindingSupplemental(unittest.TestCase):
                 call("3000", [4], False),
             ],
         )
+        mock_bind_memory.assert_called_once_with("1000", 0)
+
+    @patch("vllm_ascend.cpu_binding.psutil.Process")
+    def test_bind_ascend_950_threads_binds_only_main_and_memory(self, mock_process):
+        cpu_alloc = make_cpu_alloc()
+        cpu_alloc.device_info.running_npu_list = [0]
+        cpu_alloc.assign_main = {0: [1, 2, 3]}
+        mock_process.return_value.pid = 1000
+
+        with patch.object(cpu_alloc, "bind") as mock_bind, patch.object(cpu_alloc, "bind_memory") as mock_bind_memory:
+            cpu_alloc.bind_ascend_950_threads()
+
+        mock_bind.assert_called_once_with("1000", [1, 2, 3], True)
         mock_bind_memory.assert_called_once_with("1000", 0)
 
     @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
@@ -991,7 +1157,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         calls = []
 
         with (
-            patch.object(cpu_alloc, "build_cpu_pools", side_effect=lambda: calls.append("build_cpu_pools")),
+            patch.object(cpu_alloc, "build_cpu_pools", side_effect=lambda: calls.append("build_cpu_pools") or True),
             patch.object(cpu_alloc, "allocate", side_effect=lambda: calls.append("allocate")),
             patch.object(cpu_alloc, "print_plan", side_effect=lambda: calls.append("print_plan")),
             patch.object(cpu_alloc, "bind_threads", side_effect=lambda: calls.append("bind_threads")),
@@ -1000,6 +1166,21 @@ class TestCpuBindingSupplemental(unittest.TestCase):
             cpu_alloc.run_all()
 
         self.assertEqual(calls, ["build_cpu_pools", "allocate", "print_plan", "bind_threads", "bind_npu_irq"])
+
+    def test_run_all_returns_when_cpu_pool_build_is_skipped(self):
+        cpu_alloc = make_cpu_alloc()
+        calls = []
+
+        with (
+            patch.object(cpu_alloc, "build_cpu_pools", side_effect=lambda: calls.append("build_cpu_pools") or False),
+            patch.object(cpu_alloc, "allocate", side_effect=lambda: calls.append("allocate")),
+            patch.object(cpu_alloc, "print_plan", side_effect=lambda: calls.append("print_plan")),
+            patch.object(cpu_alloc, "bind_threads", side_effect=lambda: calls.append("bind_threads")),
+            patch.object(cpu_alloc, "bind_npu_irq", side_effect=lambda: calls.append("bind_npu_irq")),
+        ):
+            cpu_alloc.run_all()
+
+        self.assertEqual(calls, ["build_cpu_pools"])
 
 
 class TestBindingSwitch(unittest.TestCase):

--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -629,7 +629,10 @@ class TestCpuBindingSupplemental(unittest.TestCase):
             0,
         )
 
-        with patch.object(cpu_alloc, "bind") as mock_bind:
+        with (
+            patch.object(cpu_alloc, "bind") as mock_bind,
+            patch("vllm_ascend.cpu_binding.logger.info") as mock_logger_info,
+        ):
             cpu_alloc.bind_uvb_poll_window_threads()
 
         self.assertEqual(cpu_alloc.uvb_cpu_pool, [1, 2, 3])
@@ -639,6 +642,11 @@ class TestCpuBindingSupplemental(unittest.TestCase):
                 call("101", [1, 2, 3], False),
                 call("201", [1, 2, 3], False),
             ],
+        )
+        mock_logger_info.assert_called_once_with(
+            "[cpu_bind_ascend_950] uvb_poll_window_thread tids=[%s] cpus=[%s]",
+            "101 201",
+            "1 2 3",
         )
 
     @patch("vllm_ascend.cpu_binding.execute_command")
@@ -658,10 +666,10 @@ class TestCpuBindingSupplemental(unittest.TestCase):
             cpu_alloc.bind_uvb_poll_window_threads()
         mock_bind.assert_not_called()
 
-    @patch("vllm_ascend.cpu_binding.logger.info")
+    @patch("vllm_ascend.cpu_binding.logger.warning")
     @patch("vllm_ascend.cpu_binding.execute_command", return_value=("100 101 ? 00:00:01 worker_thread", 0))
     def test_bind_uvb_poll_window_threads_logs_pid_host_when_thread_missing(
-        self, _mock_execute_command, mock_logger_info
+        self, _mock_execute_command, mock_logger_warning
     ):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.numa_to_cpu_map = {0: [0, 1]}
@@ -669,7 +677,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         cpu_alloc.bind_uvb_poll_window_threads()
 
-        self.assertIn("--pid=host", mock_logger_info.call_args[0][0])
+        self.assertIn("--pid=host", mock_logger_warning.call_args[0][0])
 
     @patch("vllm_ascend.cpu_binding.logger.warning")
     @patch(
@@ -874,8 +882,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         with patch.object(cpu_alloc, "get_ascend_950_cluster_size", return_value=16):
             self.assertFalse(cpu_alloc.build_ascend_950_cpu_pools())
 
+    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
     @patch("vllm_ascend.cpu_binding.logger.info")
-    def test_print_plan_handles_empty_release_assignment(self, mock_logger_info):
+    def test_print_plan_handles_empty_release_assignment(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [1]
         cpu_alloc.rank_id = 0
@@ -887,8 +896,29 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         self.assertEqual(mock_logger_info.call_count, 2)
 
+    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
     @patch("vllm_ascend.cpu_binding.logger.info")
-    def test_print_plan_handles_non_empty_release_assignment(self, mock_logger_info):
+    def test_print_plan_uses_ascend_950_worker_log(self, mock_logger_info, _mock_get_device_type):
+        cpu_alloc = make_cpu_alloc()
+        cpu_alloc.device_info.running_npu_list = [1]
+        cpu_alloc.rank_id = 0
+        cpu_alloc.assign_main = {1: [2, 3]}
+        cpu_alloc.assign_acl = {1: []}
+        cpu_alloc.assign_rel = {1: []}
+
+        cpu_alloc.print_plan()
+
+        self.assertEqual(
+            mock_logger_info.call_args_list,
+            [
+                call("The CPU allocation plan is as follows:"),
+                call("Ascend 950 NPU%s: worker=[%s]", 1, "2 3"),
+            ],
+        )
+
+    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch("vllm_ascend.cpu_binding.logger.info")
+    def test_print_plan_handles_non_empty_release_assignment(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [1]
         cpu_alloc.rank_id = 0

--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -1186,8 +1186,12 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         cpu_alloc = make_cpu_alloc()
         calls = []
 
+        def build_cpu_pools() -> bool:
+            calls.append("build_cpu_pools")
+            return True
+
         with (
-            patch.object(cpu_alloc, "build_cpu_pools", side_effect=lambda: calls.append("build_cpu_pools") or True),
+            patch.object(cpu_alloc, "build_cpu_pools", side_effect=build_cpu_pools),
             patch.object(cpu_alloc, "allocate", side_effect=lambda: calls.append("allocate")),
             patch.object(cpu_alloc, "print_plan", side_effect=lambda: calls.append("print_plan")),
             patch.object(cpu_alloc, "bind_threads", side_effect=lambda: calls.append("bind_threads")),
@@ -1201,8 +1205,12 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         cpu_alloc = make_cpu_alloc()
         calls = []
 
+        def build_cpu_pools() -> bool:
+            calls.append("build_cpu_pools")
+            return False
+
         with (
-            patch.object(cpu_alloc, "build_cpu_pools", side_effect=lambda: calls.append("build_cpu_pools") or False),
+            patch.object(cpu_alloc, "build_cpu_pools", side_effect=build_cpu_pools),
             patch.object(cpu_alloc, "allocate", side_effect=lambda: calls.append("allocate")),
             patch.object(cpu_alloc, "print_plan", side_effect=lambda: calls.append("print_plan")),
             patch.object(cpu_alloc, "bind_threads", side_effect=lambda: calls.append("bind_threads")),

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -371,6 +371,9 @@ class CpuAlloc:
                 " ".join(map(str, self.uvb_cpu_pool)),
             )
 
+    # TODO: Drop the vLLM Ascend implementation for Ascend 950 CPU binding and
+    # switch to the CANN affinity tool once that tool is visible in external
+    # commercial releases.
     def build_ascend_950_cpu_pools(self) -> bool:
         if not self.device_info.npu_affinity:
             logger.warning("[cpu_bind_ascend_950] NPU topo affinity not found. action: skip worker CPU binding.")

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -15,6 +15,7 @@ from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 MASK_BIT = 32  # Number of bits in a CPU affinity mask group
 MIN_CPUS_PER_NPU = 5  # 2(IRQ) + 1(main, at least 1 CPU) + 1(acl) + 1(release) = 5 CPUs per NPU
 MIN_CPUS_PER_NPU_WITHOUT_IRQ = 3  # 1(main, at least 1 CPU) + 1(acl) + 1(release)
+ASCEND_950_PHYSICAL_CPUS_PER_CLUSTER = 8
 ALLOWED_CPUS_PATH = "/proc/self/status"
 ASCEND_RT_VISIBLE_DEVICES = os.getenv("ASCEND_RT_VISIBLE_DEVICES")
 
@@ -324,7 +325,7 @@ class CpuAlloc:
                 threads_per_core,
             )
             return None
-        return 8 * threads_per_core
+        return ASCEND_950_PHYSICAL_CPUS_PER_CLUSTER * threads_per_core
 
     def get_single_numa_node(self, cpu_list: list[int]) -> int | None:
         if not cpu_list:
@@ -351,9 +352,11 @@ class CpuAlloc:
             )
             return
 
+        bound_threads = []
         for thread_id in uvb_threads:
             try:
                 self.bind(thread_id, self.uvb_cpu_pool, False)
+                bound_threads.append(thread_id)
             except RuntimeError as e:
                 logger.warning(
                     "[cpu_bind_ascend_950] failed to bind uvb_poll_window_thread %s: %s. "
@@ -361,6 +364,12 @@ class CpuAlloc:
                     thread_id,
                     e,
                 )
+        if bound_threads:
+            logger.info(
+                "[cpu_bind_ascend_950] uvb_poll_window_thread tids=[%s] cpus=[%s]",
+                " ".join(bound_threads),
+                " ".join(map(str, self.uvb_cpu_pool)),
+            )
 
     def build_ascend_950_cpu_pools(self) -> bool:
         if not self.device_info.npu_affinity:
@@ -443,13 +452,13 @@ class CpuAlloc:
           - NUMA locality is achieved only if CPU numbering aligns with NUMA layout.
           - Requires enough CPUs for each device's role split.
         """
-        running = list(self.device_info.running_npu_list)
-        if not running:
+        running_npus = list(self.device_info.running_npu_list)
+        if not running_npus:
             return
 
-        allowed = sorted(set(self.device_info.allowed_cpus))
-        total_cpu = len(allowed)
-        if total_cpu == 0:
+        allowed_cpus = sorted(set(self.device_info.allowed_cpus))
+        total_cpu_count = len(allowed_cpus)
+        if total_cpu_count == 0:
             return
 
         # Prefer mapping info (npu-smi info -m), fallback to topo keys, then visible list
@@ -458,55 +467,60 @@ class CpuAlloc:
         elif self.device_info.npu_affinity:
             total_npus = len(self.device_info.npu_affinity)
         else:
-            total_npus = len(running)
+            total_npus = len(running_npus)
 
         # Compute global per-NPU slicing
-        base = total_cpu // total_npus
-        extra = total_cpu % total_npus
+        base_cpu_count = total_cpu_count // total_npus
+        extra_cpu_count = total_cpu_count % total_npus
 
         logger.debug(
             "[cpu_global_slice] rank:%s ASCEND_RT_VISIBLE_DEVICES=%s running_npu_list:%s total_npus:%s "
             "allowed_cpus:%s base:%s extra:%s allowed_cpus_head:%s allowed_cpus_tail:%s",
             self.rank_id,
             ASCEND_RT_VISIBLE_DEVICES,
-            running,
+            running_npus,
             total_npus,
-            total_cpu,
-            base,
-            extra,
-            allowed[:16],
-            allowed[-16:],
+            total_cpu_count,
+            base_cpu_count,
+            extra_cpu_count,
+            allowed_cpus[:16],
+            allowed_cpus[-16:],
         )
 
         min_cpus_per_npu = self._min_cpus_per_npu()
         # Enforce the minimum per-NPU slice length.
         # Because with remainder distribution, some NPUs may get 'base' cores and some get 'base+1'.
         # The minimum slice size is 'base'.
-        if base < min_cpus_per_npu:
+        if base_cpu_count < min_cpus_per_npu:
             raise RuntimeError(
                 "Insufficient CPUs for binding with CPU role reservations: "
-                f"total_allowed={total_cpu}, total_npus={total_npus}, "
-                f"min_per_npu={base} (<{min_cpus_per_npu}). "
+                f"total_allowed={total_cpu_count}, total_npus={total_npus}, "
+                f"min_per_npu={base_cpu_count} (<{min_cpus_per_npu}). "
                 f"Need at least {total_npus * min_cpus_per_npu} CPUs in cpuset."
             )
 
         def _slice_for_npu(global_npu_id: int) -> list[int]:
             # start = global_npu_id*base + min(global_npu_id, extra)
-            start = global_npu_id * base + (global_npu_id if global_npu_id < extra else extra)
-            take = base + (1 if global_npu_id < extra else 0)
+            start = global_npu_id * base_cpu_count + (
+                global_npu_id if global_npu_id < extra_cpu_count else extra_cpu_count
+            )
+            take = base_cpu_count + (1 if global_npu_id < extra_cpu_count else 0)
             end = start + take
-            return allowed[start:end]
+            return allowed_cpus[start:end]
 
-        for npu in running:
+        for npu in running_npus:
             if npu < 0 or npu >= total_npus:
                 raise RuntimeError(f"Invalid NPU id {npu}, total_npus={total_npus}.")
-            cpus = _slice_for_npu(npu)
-            self.npu_cpu_pool[npu] = cpus
+            self.npu_cpu_pool[npu] = _slice_for_npu(npu)
 
     @staticmethod
     def _binding_mode() -> str:
         device_type = get_ascend_device_type()
         return DEVICE_BINDING_MODE.get(device_type, TOPO_AFFINITY_MODE)
+
+    @staticmethod
+    def _is_ascend_950() -> bool:
+        return get_ascend_device_type() == AscendDeviceType.A5
 
     @staticmethod
     def _reserve_irq_cpus() -> bool:
@@ -525,7 +539,7 @@ class CpuAlloc:
         logger.info(
             "[cpu_bind_mode] mode=%s rank=%s visible_npus=%s", mode, self.rank_id, self.device_info.running_npu_list
         )
-        if get_ascend_device_type() == AscendDeviceType.A5:
+        if self._is_ascend_950():
             self.bind_uvb_poll_window_threads()
             return self.build_ascend_950_cpu_pools()
 
@@ -533,11 +547,15 @@ class CpuAlloc:
             self.build_global_slice_cpu_pool()
             return True
 
+        self._build_topo_affinity_cpu_pool()
+        return True
+
+    def _build_topo_affinity_cpu_pool(self) -> None:
         # topo_affinity mode
         if not self.device_info.npu_affinity:
             logger.warning("NPU topo affinity not found. action: fallback to global-slice CPU binding.")
             self.build_global_slice_cpu_pool()
-            return True
+            return
 
         allowed_cpu_set = set(self.device_info.allowed_cpus)
         # Consider all logical NPUs to avoid CPU distribution overlap across worker processes.
@@ -570,25 +588,29 @@ class CpuAlloc:
                 final.update(self.average_distribute({key: npu_list}))
         # Keep only visible NPUs in the final binding pool. Non-visible NPUs are used only to avoid overlap.
         self.npu_cpu_pool = {npu: final[npu] for npu in self.device_info.running_npu_list}
-        return True
 
     def allocate(self) -> None:
-        if get_ascend_device_type() == AscendDeviceType.A5:
-            self.assign_main = {npu: pool for npu, pool in self.npu_cpu_pool.items()}
-            self.assign_acl = {npu: [] for npu in self.npu_cpu_pool}
-            self.assign_rel = {npu: [] for npu in self.npu_cpu_pool}
+        if self._is_ascend_950():
+            self._allocate_ascend_950_roles()
             return
+        self._allocate_default_roles()
 
+    def _allocate_ascend_950_roles(self) -> None:
+        self.assign_main = {npu: cpu_pool for npu, cpu_pool in self.npu_cpu_pool.items()}
+        self.assign_acl = {npu: [] for npu in self.npu_cpu_pool}
+        self.assign_rel = {npu: [] for npu in self.npu_cpu_pool}
+
+    def _allocate_default_roles(self) -> None:
         reserve_irq_cpus = self._reserve_irq_cpus()
         min_cpus_per_npu = self._min_cpus_per_npu()
-        for npu, pool in self.npu_cpu_pool.items():
-            if len(pool) >= min_cpus_per_npu:
+        for npu, cpu_pool in self.npu_cpu_pool.items():
+            if len(cpu_pool) >= min_cpus_per_npu:
                 if reserve_irq_cpus:
-                    main = pool[2:-2]
+                    main = cpu_pool[2:-2]
                 else:
-                    main = pool[:-2]
-                acl = [pool[-2]]
-                rel = [pool[-1]]
+                    main = cpu_pool[:-2]
+                acl = [cpu_pool[-2]]
+                rel = [cpu_pool[-1]]
             else:
                 raise RuntimeError(
                     f"The number of CPUs is insufficient. Each NPU requires at least {min_cpus_per_npu} CPUs."
@@ -600,6 +622,16 @@ class CpuAlloc:
     def print_plan(self) -> None:
         logger.info("The CPU allocation plan is as follows:")
         current_npu = self.device_info.running_npu_list[self.rank_id]
+        if self._is_ascend_950():
+            self._print_ascend_950_plan(current_npu)
+            return
+        self._print_default_plan(current_npu)
+
+    def _print_ascend_950_plan(self, current_npu: int) -> None:
+        main = " ".join(map(str, self.assign_main[current_npu]))
+        logger.info("Ascend 950 NPU%s: worker=[%s]", current_npu, main)
+
+    def _print_default_plan(self, current_npu: int) -> None:
         main = " ".join(map(str, self.assign_main[current_npu]))
         acl = " ".join(map(str, self.assign_acl[current_npu]))
         rel = str(self.assign_rel[current_npu]) if self.assign_rel[current_npu] else ""
@@ -640,19 +672,21 @@ class CpuAlloc:
         )
 
     def bind_threads(self) -> None:
-        if get_ascend_device_type() == AscendDeviceType.A5:
+        if self._is_ascend_950():
             self.bind_ascend_950_threads()
             return
+        self._bind_default_threads()
 
+    def _bind_default_threads(self) -> None:
         thread_message, _ = execute_command(["ps", "-Te"])
         threads_map = self.get_threads_map(thread_message)
         main_pid = str(psutil.Process().pid)
         current_npu = self.device_info.running_npu_list[self.rank_id]
         self.bind(main_pid, self.assign_main[current_npu], True)
-        for acl_thread in threads_map.get(main_pid, {}).get("acl_thread", []):
-            self.bind(acl_thread, self.assign_acl[current_npu], False)
-        for release_thread in threads_map.get(main_pid, {}).get("release_thread", []):
-            self.bind(release_thread, self.assign_rel[current_npu], False)
+        for thread_id in threads_map.get(main_pid, {}).get("acl_thread", []):
+            self.bind(thread_id, self.assign_acl[current_npu], False)
+        for thread_id in threads_map.get(main_pid, {}).get("release_thread", []):
+            self.bind(thread_id, self.assign_rel[current_npu], False)
         # Migrate memory once for the whole process, after all threads are pinned.
         self.bind_memory(main_pid, current_npu)
 

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -25,7 +25,7 @@ DEVICE_BINDING_MODE: dict["AscendDeviceType", str] = {
     AscendDeviceType.A2: TOPO_AFFINITY_MODE,
     AscendDeviceType.A3: GLOBAL_SLICE_MODE,
     AscendDeviceType._310P: TOPO_AFFINITY_MODE,
-    AscendDeviceType.A5: GLOBAL_SLICE_MODE,
+    AscendDeviceType.A5: TOPO_AFFINITY_MODE,
 }
 NO_IRQ_BINDING_DEVICE_TYPES = {AscendDeviceType.A5}
 
@@ -213,6 +213,7 @@ class CpuAlloc:
         self.assign_main: dict[int, list[int]] = {}
         self.assign_acl: dict[int, list[int]] = {}
         self.assign_rel: dict[int, list[int]] = {}
+        self.uvb_cpu_pool: list[int] = []
 
     @staticmethod
     def cpu_to_mask(cpu: int) -> str:
@@ -292,6 +293,141 @@ class CpuAlloc:
             self.numa_to_cpu_map[node].append(cpu)
         if len(self.numa_to_cpu_map) == 0:
             raise RuntimeError("lscpu command output error, no NUMA node available. Please check!")
+
+    @staticmethod
+    def parse_threads_per_core(lscpu_message: str) -> int | None:
+        for line in lscpu_message.splitlines():
+            if "Thread(s) per core:" not in line:
+                continue
+            value = line.split(":", 1)[1].strip()
+            if value.isdigit():
+                return int(value)
+        return None
+
+    @staticmethod
+    def get_uvb_poll_window_threads(thread_message: str) -> list[str]:
+        thread_ids = []
+        for line in thread_message.splitlines():
+            if "uvb_poll_window_thread" not in line:
+                continue
+            parts = line.split()
+            if len(parts) >= 2 and parts[1].isdigit():
+                thread_ids.append(parts[1])
+        return thread_ids
+
+    def get_ascend_950_cluster_size(self) -> int | None:
+        lscpu_message, _ = execute_command(["lscpu"])
+        threads_per_core = self.parse_threads_per_core(lscpu_message)
+        if threads_per_core not in {1, 2}:
+            logger.warning(
+                "[cpu_bind_ascend_950] unsupported Thread(s) per core: %s. action: skip worker CPU binding.",
+                threads_per_core,
+            )
+            return None
+        return 8 * threads_per_core
+
+    def get_single_numa_node(self, cpu_list: list[int]) -> int | None:
+        if not cpu_list:
+            return None
+        nodes = {self.cpu_node[cpu] for cpu in cpu_list}
+        if len(nodes) != 1:
+            return None
+        return next(iter(nodes))
+
+    def bind_uvb_poll_window_threads(self) -> None:
+        self.uvb_cpu_pool = [
+            cpu for cpu in self.numa_to_cpu_map.get(0, []) if cpu in self.device_info.allowed_cpus and cpu != 0
+        ]
+        if not self.uvb_cpu_pool:
+            logger.info("[cpu_bind_ascend_950] no available NUMA0 CPUs for uvb_poll_window_thread.")
+            return
+
+        thread_message, _ = execute_command(["ps", "-Te"])
+        uvb_threads = self.get_uvb_poll_window_threads(thread_message)
+        if not uvb_threads:
+            logger.warning(
+                "[cpu_bind_ascend_950] uvb_poll_window_thread not found. "
+                "If running in Docker, start the container with '--pid=host'."
+            )
+            return
+
+        for thread_id in uvb_threads:
+            try:
+                self.bind(thread_id, self.uvb_cpu_pool, False)
+            except RuntimeError as e:
+                logger.warning(
+                    "[cpu_bind_ascend_950] failed to bind uvb_poll_window_thread %s: %s. "
+                    "If running in Docker, start the container with '--pid=host'.",
+                    thread_id,
+                    e,
+                )
+
+    def build_ascend_950_cpu_pools(self) -> bool:
+        if not self.device_info.npu_affinity:
+            logger.warning("[cpu_bind_ascend_950] NPU topo affinity not found. action: skip worker CPU binding.")
+            return False
+
+        cluster_size = self.get_ascend_950_cluster_size()
+        if cluster_size is None:
+            return False
+
+        allowed_cpu_set = set(self.device_info.allowed_cpus)
+        uvb_cpu_set = set(self.uvb_cpu_pool)
+        candidate_npus = [
+            npu
+            for npu in self.device_info.all_logic_npus
+            if npu in self.device_info.running_npu_list
+            or any(cpu in allowed_cpu_set for cpu in self.device_info.npu_affinity.get(npu, []))
+        ]
+
+        numa_to_npus: dict[int, list[int]] = defaultdict(list)
+        for npu in candidate_npus:
+            base_cpu_list = [
+                cpu for cpu in self.device_info.npu_affinity.get(npu, []) if cpu in self.device_info.allowed_cpus
+            ]
+            numa_node = self.get_single_numa_node(base_cpu_list)
+            if numa_node is None:
+                logger.warning(
+                    "[cpu_bind_ascend_950] invalid topo affinity. npu=%s, cpus=%s. action: skip worker CPU binding.",
+                    npu,
+                    base_cpu_list,
+                )
+                return False
+            numa_to_npus[numa_node].append(npu)
+
+        final: dict[int, list[int]] = {}
+        for numa_node, npu_list in numa_to_npus.items():
+            cpu_list = [
+                cpu
+                for cpu in sorted(self.numa_to_cpu_map.get(numa_node, []))
+                if cpu in self.device_info.allowed_cpus and cpu not in uvb_cpu_set
+            ]
+            clusters = [
+                cpu_list[i : i + cluster_size]
+                for i in range(0, len(cpu_list) - len(cpu_list) % cluster_size, cluster_size)
+            ]
+            npu_list = sorted(npu_list)
+            if len(clusters) < len(npu_list):
+                logger.warning(
+                    "[cpu_bind_ascend_950] insufficient CPU clusters. numa=%s, clusters=%s, npus=%s. "
+                    "action: skip worker CPU binding.",
+                    numa_node,
+                    len(clusters),
+                    npu_list,
+                )
+                return False
+            for index, npu in enumerate(npu_list):
+                final[npu] = clusters[index]
+
+        try:
+            self.npu_cpu_pool = {npu: final[npu] for npu in self.device_info.running_npu_list}
+        except KeyError as e:
+            logger.warning(
+                "[cpu_bind_ascend_950] failed to build CPU pool for visible NPU %s. action: skip worker CPU binding.",
+                e,
+            )
+            return False
+        return True
 
     def build_global_slice_cpu_pool(self) -> None:
         """
@@ -382,22 +518,26 @@ class CpuAlloc:
             return MIN_CPUS_PER_NPU
         return MIN_CPUS_PER_NPU_WITHOUT_IRQ
 
-    def build_cpu_pools(self) -> None:
+    def build_cpu_pools(self) -> bool:
         self.build_cpu_node_map()
 
         mode = self._binding_mode()
         logger.info(
             "[cpu_bind_mode] mode=%s rank=%s visible_npus=%s", mode, self.rank_id, self.device_info.running_npu_list
         )
+        if get_ascend_device_type() == AscendDeviceType.A5:
+            self.bind_uvb_poll_window_threads()
+            return self.build_ascend_950_cpu_pools()
+
         if mode == GLOBAL_SLICE_MODE:
             self.build_global_slice_cpu_pool()
-            return
+            return True
 
         # topo_affinity mode
         if not self.device_info.npu_affinity:
             logger.warning("NPU topo affinity not found. action: fallback to global-slice CPU binding.")
             self.build_global_slice_cpu_pool()
-            return
+            return True
 
         allowed_cpu_set = set(self.device_info.allowed_cpus)
         # Consider all logical NPUs to avoid CPU distribution overlap across worker processes.
@@ -430,8 +570,15 @@ class CpuAlloc:
                 final.update(self.average_distribute({key: npu_list}))
         # Keep only visible NPUs in the final binding pool. Non-visible NPUs are used only to avoid overlap.
         self.npu_cpu_pool = {npu: final[npu] for npu in self.device_info.running_npu_list}
+        return True
 
     def allocate(self) -> None:
+        if get_ascend_device_type() == AscendDeviceType.A5:
+            self.assign_main = {npu: pool for npu, pool in self.npu_cpu_pool.items()}
+            self.assign_acl = {npu: [] for npu in self.npu_cpu_pool}
+            self.assign_rel = {npu: [] for npu in self.npu_cpu_pool}
+            return
+
         reserve_irq_cpus = self._reserve_irq_cpus()
         min_cpus_per_npu = self._min_cpus_per_npu()
         for npu, pool in self.npu_cpu_pool.items():
@@ -493,6 +640,10 @@ class CpuAlloc:
         )
 
     def bind_threads(self) -> None:
+        if get_ascend_device_type() == AscendDeviceType.A5:
+            self.bind_ascend_950_threads()
+            return
+
         thread_message, _ = execute_command(["ps", "-Te"])
         threads_map = self.get_threads_map(thread_message)
         main_pid = str(psutil.Process().pid)
@@ -503,6 +654,12 @@ class CpuAlloc:
         for release_thread in threads_map.get(main_pid, {}).get("release_thread", []):
             self.bind(release_thread, self.assign_rel[current_npu], False)
         # Migrate memory once for the whole process, after all threads are pinned.
+        self.bind_memory(main_pid, current_npu)
+
+    def bind_ascend_950_threads(self) -> None:
+        main_pid = str(psutil.Process().pid)
+        current_npu = self.device_info.running_npu_list[self.rank_id]
+        self.bind(main_pid, self.assign_main[current_npu], True)
         self.bind_memory(main_pid, current_npu)
 
     def bind_npu_irq(self) -> None:
@@ -596,7 +753,8 @@ class CpuAlloc:
             f.write(self.cpu_to_mask(cq_cpu))
 
     def run_all(self) -> None:
-        self.build_cpu_pools()
+        if not self.build_cpu_pools():
+            return
         self.allocate()
         self.print_plan()
         self.bind_threads()


### PR DESCRIPTION
## Summary
- Add Ascend 950 CPU binding based on topo affinity and CPU clusters.
- Bind Ascend 950 UVB polling threads and skip IRQ/ACL/release binding for Ascend 950.
- Refactor CPU binding helpers and update UT/docs/log descriptions.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
