### PR TITLE
[Doc][Misc] Add Ascend recipes prototype

### DIFF
--- a/docs/source/recipes/format.md
+++ b/docs/source/recipes/format.md
@@ -1,0 +1,61 @@
+# Recipe Format
+
+This page defines the proposed vLLM Ascend recipe format.
+
+Recipes should be short, operational, and linked back to the authoritative
+vLLM Ascend documentation. They should not replace the existing model
+tutorials, feature guides, support matrix, installation guide, or evaluation
+docs.
+
+## Metadata
+
+Each recipe starts with a metadata table.
+
+| Field | Description |
+|-------|-------------|
+| Model | Model or model family covered by the recipe. |
+| Hardware | Ascend hardware target, for example Atlas 800 A3 or Atlas 800I A2. |
+| Precision | BF16, W8A8, W4A8, or other precision mode. |
+| Parallelism | Recommended DP, TP, PP, EP, or single-card shape. |
+| Image | Recommended vLLM Ascend image tag or installation path. |
+| Source tutorial | Existing vLLM Ascend tutorial used as the source of truth. |
+| Support matrix | Link to the model or feature support matrix. |
+| vLLM recipes target | Proposed path or model page if exported to `vllm-project/recipes`. |
+| Validation status | Smoke-tested, benchmarked, hardware-required, or draft. |
+
+## Required Sections
+
+Use these sections unless a recipe has a clear reason to omit one.
+
+1. `When to use this recipe`
+2. `Prerequisites`
+3. `Launch container`
+4. `Serve the model`
+5. `Smoke test`
+6. `Benchmark or evaluation hooks`
+7. `Tuning notes`
+8. `Promotion checklist`
+
+## Authoring Rules
+
+- Keep commands copy-pasteable.
+- Keep hardware assumptions explicit.
+- Prefer links over duplicating long explanations from model tutorials.
+- Keep environment variables close to the command that needs them.
+- Mark optional tuning knobs as optional.
+- Keep model paths, image tags, ports, and device lists easy to replace.
+- Preserve vLLM CLI conventions so stable recipes can later be adapted for
+  `vllm-project/recipes`.
+
+## Promotion Checklist
+
+Before proposing a recipe for `vllm-project/recipes`, confirm:
+
+- The command is runnable on the stated hardware.
+- The model is listed in the vLLM Ascend support matrix.
+- The recipe states image or installation requirements.
+- The recipe has a smoke test.
+- The recipe has at least one benchmark or evaluation hook.
+- The recipe links back to the vLLM Ascend source tutorial for detailed tuning.
+- Ascend-specific settings are isolated so the upstream recipe can keep a
+  clean platform section.

--- a/docs/source/recipes/index.md
+++ b/docs/source/recipes/index.md
@@ -1,0 +1,18 @@
+# Recipes
+
+Recipes are concise, end-to-end guides for running a specific model on a
+specific Ascend hardware target with vLLM Ascend.
+
+The goal is to turn the existing vLLM Ascend documentation into a standard,
+operational format that is easy to review, validate, and later contribute to
+the upstream [vLLM recipes](https://github.com/vllm-project/recipes) project
+when a recipe is mature.
+
+Use recipes when you want a short path from "which model and hardware?" to a
+working serving command, smoke test, and validation checklist. Use the linked
+model tutorials and feature guides when you need the full explanation.
+
+## Contents
+
+- [Recipe Format](format.md)
+- [Qwen3 Dense on Atlas A3](qwen3_dense_a3.md)

--- a/docs/source/recipes/qwen3_dense_a3.md
+++ b/docs/source/recipes/qwen3_dense_a3.md
@@ -1,0 +1,152 @@
+# Qwen3 Dense on Atlas A3
+
+This sample recipe shows the proposed recipe format for serving Qwen3 Dense
+models on Atlas A3 with vLLM Ascend.
+
+It is derived from the existing
+[Qwen3 Dense tutorial](../tutorials/models/Qwen3-Dense.md). The tutorial remains
+the source of truth for full tuning explanations, accuracy data, and performance
+notes.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Model | Qwen3 Dense, sample command uses `vllm-ascend/Qwen3-32B-W8A8`. |
+| Hardware | Atlas 800 A3, four NPUs for the sample command. |
+| Precision | W8A8 quantized model. |
+| Parallelism | Tensor parallel size 4. |
+| Image | `quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3`. |
+| Source tutorial | [Qwen3 Dense tutorial](../tutorials/models/Qwen3-Dense.md). |
+| Support matrix | [Supported models](../user_guide/support_matrix/supported_models.md). |
+| vLLM recipes target | `Qwen/Qwen3.md` with an Ascend platform section. |
+| Validation status | Prototype recipe; requires Atlas A3 hardware for runtime validation. |
+
+## When to Use This Recipe
+
+Use this recipe when you want a short serving path for Qwen3 Dense on Atlas A3
+and already have the model weights available on the host.
+
+For the full model list, accuracy results, and tuning discussion, use the
+[Qwen3 Dense tutorial](../tutorials/models/Qwen3-Dense.md).
+
+## Prerequisites
+
+- Atlas 800 A3 environment with Ascend drivers installed.
+- Qwen3 model weights downloaded to a host directory, for example
+  `/root/.cache`.
+- vLLM Ascend image available from
+  [quay.io/ascend/vllm-ascend](https://quay.io/repository/ascend/vllm-ascend?tab=tags).
+
+## Launch Container
+
+```bash
+export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
+
+docker run --rm \
+  --name vllm-ascend-qwen3 \
+  --shm-size=1g \
+  --privileged=true \
+  --net=host \
+  --device /dev/davinci0 \
+  --device /dev/davinci1 \
+  --device /dev/davinci2 \
+  --device /dev/davinci3 \
+  --device /dev/davinci_manager \
+  --device /dev/devmm_svm \
+  --device /dev/hisi_hdc \
+  -v /usr/local/dcmi:/usr/local/dcmi \
+  -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+  -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+  -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+  -v /etc/ascend_install.info:/etc/ascend_install.info \
+  -v /root/.cache:/root/.cache \
+  -it "${IMAGE}" bash
+```
+
+## Serve the Model
+
+Run the server inside the container.
+
+```bash
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
+export TASK_QUEUE_ENABLE=1
+export HCCL_OP_EXPANSION_MODE=AIV
+export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+
+vllm serve vllm-ascend/Qwen3-32B-W8A8 \
+  --served-model-name qwen3 \
+  --trust-remote-code \
+  --quantization ascend \
+  --distributed-executor-backend mp \
+  --tensor-parallel-size 4 \
+  --max-model-len 5500 \
+  --max-num-batched-tokens 40960 \
+  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+  --additional-config '{"pa_shape_list":[48,64,72,80], "weight_prefetch_config":{"enabled":true}}' \
+  --port 8113 \
+  --block-size 128 \
+  --gpu-memory-utilization 0.9
+```
+
+For non-quantized Qwen3 Dense models, remove `--quantization ascend` and update
+the model path.
+
+## Smoke Test
+
+```bash
+curl http://localhost:8113/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Give me a short introduction to large language models."
+      }
+    ],
+    "temperature": 0.6,
+    "top_p": 0.95,
+    "top_k": 20,
+    "max_completion_tokens": 256
+  }'
+```
+
+## Benchmark or Evaluation Hooks
+
+Use `vllm bench serve` for a quick serving benchmark.
+
+```bash
+vllm bench serve \
+  --model vllm-ascend/Qwen3-32B-W8A8 \
+  --served-model-name qwen3 \
+  --port 8113 \
+  --dataset-name random \
+  --random-input 200 \
+  --num-prompts 200 \
+  --request-rate 1 \
+  --save-result \
+  --result-dir ./
+```
+
+For accuracy evaluation, see
+[Using AISBench](../developer_guide/evaluation/using_ais_bench.md).
+
+## Tuning Notes
+
+- `VLLM_ASCEND_ENABLE_FLASHCOMM1=1` is useful for tensor parallel serving in
+  high-concurrency scenarios.
+- `max-num-batched-tokens` should be tuned with memory usage and request shape.
+- `pa_shape_list` and `weight_prefetch_config` are optional tuning knobs. See
+  the [Qwen3 Dense tutorial](../tutorials/models/Qwen3-Dense.md) before using
+  them for production tuning.
+- `cudagraph_mode` is set to `FULL_DECODE_ONLY` to match the source tutorial.
+
+## Promotion Checklist
+
+- [ ] Runtime validated on Atlas A3.
+- [ ] Smoke test completed.
+- [ ] Benchmark or accuracy result recorded.
+- [ ] Model support matrix entry checked.
+- [ ] Ascend-specific settings isolated for a future `vllm-project/recipes`
+      platform section.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -173,6 +173,10 @@ nav:
     - getting_started.md
     - quick_start.md
     - installation.md
+    - Recipes:
+        - recipes/index.md
+        - recipes/format.md
+        - recipes/qwen3_dense_a3.md
     - Model Tutorials:
         - tutorials/models/index.md
         - tutorials/models/Qwen3-Dense.md


### PR DESCRIPTION
### What this PR does / why we need it?

Refs #11722.

This PR adds a docs-only prototype for a vLLM Ascend recipes section, inspired by the Google TPU recipes flow and shaped so mature recipes can later be adapted for `vllm-project/recipes`.

It intentionally keeps the scope small:

- Adds a new `docs/source/recipes/` section.
- Defines a standard recipe format and promotion checklist.
- Adds one sample recipe, `Qwen3 Dense on Atlas A3`, derived from the existing Qwen3 Dense tutorial.
- Adds the recipes section to the MkDocs navigation under Getting Started.

The sample recipe links back to existing authoritative docs instead of moving or rewriting the full model tutorial.

### Does this PR introduce _any_ user-facing change?

No runtime behavior changes. This is a documentation-only prototype. It adds a new recipes navigation entry and sample documentation page.

### How was this patch tested?

- `pre-commit run markdownlint --hook-stage manual --files docs/source/recipes/index.md docs/source/recipes/format.md docs/source/recipes/qwen3_dense_a3.md`
- `python .github/workflows/scripts/check_md_links.py docs/source/recipes/index.md docs/source/recipes/format.md docs/source/recipes/qwen3_dense_a3.md`
- `python -m pip install -r docs/requirements-docs.txt`
- `python -m mkdocs build --strict --site-dir site-recipes-check`

Notes:

- The MkDocs build completed successfully.
- MkDocs printed existing INFO-level documentation messages unrelated to this PR, including an existing page not in nav and an existing anchor warning.
- Runtime serving commands in the sample recipe require Atlas A3 hardware and were not executed locally.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
