### PR TITLE
[BugFix][KVTransfer] Make kv_connector_extra_config optional for Mooncake PD separation

### DIFF
--- a/tests/ut/distributed/kv_transfer/test_mooncake_topology_resolution.py
+++ b/tests/ut/distributed/kv_transfer/test_mooncake_topology_resolution.py
@@ -1,0 +1,269 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Unit tests for Mooncake connector remote-topology auto-discovery.
+
+Covers the fixes that make ``kv_connector_extra_config`` optional for
+PD separation with heterogeneous TP (e.g. DeepSeek-V4 P(tp4)/D(tp1)):
+
+1. ``_resolve_parallel_sizes`` must run after ``self.kv_role`` is assigned
+   (regression: previously called as the first line of ``__init__``).
+2. D-side discovers P's tp_size from per-request ``meta.remote_ptp_size``,
+   not from the ZMQ metadata cache (which is empty before the first recv).
+3. ``check_kv_extra_config`` raises on local-role config mismatch but
+   tolerates a missing config (auto-discovery path).
+"""
+
+import types
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+
+if not hasattr(torch, "npu"):
+    torch.npu = types.SimpleNamespace(Event=type("Event", (), {}))  # type: ignore[attr-defined]
+
+from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector import (
+    MooncakeConnectorWorker,
+    ReqMeta,
+)
+from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_hybrid_connector import (
+    MooncakeConnectorWorker as MooncakeHybridConnectorWorker,
+    ReqMeta as HybridReqMeta,
+)
+from vllm_ascend.utils import check_kv_extra_config
+
+
+def _make_vllm_config(kv_role: str, tp_size: int, dp_size: int, extra_config: dict):
+    """Build a minimal mock VllmConfig for _resolve_parallel_sizes."""
+    cfg = MagicMock()
+    cfg.parallel_config.tensor_parallel_size = tp_size
+    cfg.parallel_config.data_parallel_size = dp_size
+    cfg.parallel_config.pipeline_parallel_size = 1
+    cfg.kv_transfer_config.kv_role = kv_role
+    cfg.kv_transfer_config.is_kv_producer = kv_role == "kv_producer"
+    cfg.kv_transfer_config.is_kv_consumer = kv_role == "kv_consumer"
+    cfg.kv_transfer_config.kv_connector_extra_config = extra_config
+    cfg.kv_transfer_config.get_from_extra_config = lambda key, default=None: (
+        extra_config.get(key, default if default is not None else {})
+    )
+    return cfg
+
+
+class TestResolveParallelSizesOrder(unittest.TestCase):
+    """_resolve_parallel_sizes branches on self.kv_role, so it must be
+    called only after self.kv_role is assigned in __init__.
+
+    Previously it was the first line of __init__ and crashed with
+    AttributeError. We verify the method itself no longer references
+    attributes that __init__ hasn't set yet, by invoking it directly with
+    kv_role pre-set on the instance.
+    """
+
+    def test_producer_resolves_own_prefill_tp(self):
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.kv_role = "kv_producer"
+        cfg = _make_vllm_config("kv_producer", tp_size=4, dp_size=4, extra_config={})
+        worker._resolve_parallel_sizes(cfg)
+        self.assertEqual(worker._prefill_tp_size, 4)
+        self.assertEqual(worker._prefill_dp_size, 4)
+        # Remote (decode) unknown yet -> default 1, not resolved.
+        self.assertEqual(worker._decode_tp_size, 1)
+        self.assertFalse(worker._remote_sizes_resolved)
+
+    def test_consumer_resolves_own_decode_tp(self):
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.kv_role = "kv_consumer"
+        cfg = _make_vllm_config("kv_consumer", tp_size=1, dp_size=16, extra_config={})
+        worker._resolve_parallel_sizes(cfg)
+        self.assertEqual(worker._decode_tp_size, 1)
+        self.assertEqual(worker._decode_dp_size, 16)
+        self.assertEqual(worker._prefill_tp_size, 1)
+        self.assertFalse(worker._remote_sizes_resolved)
+
+
+class TestDSideDiscoversPrefillTpFromMeta(unittest.TestCase):
+    """D-side must read P's tp_size from meta.remote_ptp_size so that
+    heterogeneous TP works without kv_connector_extra_config and without
+    waiting for the ZMQ metadata cache to be populated."""
+
+    def test_d_side_uses_remote_ptp_size(self):
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.kv_role = "kv_consumer"
+        worker._prefill_tp_size = 1
+        worker._prefill_dp_size = 1
+        worker._remote_sizes_resolved = False
+
+        meta = ReqMeta(
+            local_block_ids=[],
+            num_external_tokens=0,
+            num_computed_tokens=0,
+            remote_block_ids=[],
+            remote_host="127.0.0.1",
+            remote_port=30100,
+            remote_engine_id="1",
+            remote_request_id="req-1",
+            remote_pcp_size=1,
+            remote_dcp_size=1,
+            remote_ptp_size=4,
+            remote_multi_nodes_meta_mapping={},
+            num_prompt_blocks=0,
+        )
+        worker._update_remote_sizes_from_metadata(meta)
+        self.assertEqual(worker._prefill_tp_size, 4)
+        self.assertTrue(worker._remote_sizes_resolved)
+
+    def test_d_side_ignores_meta_when_already_resolved(self):
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.kv_role = "kv_consumer"
+        worker._prefill_tp_size = 8  # already set via extra_config
+        worker._prefill_dp_size = 8
+        worker._remote_sizes_resolved = True
+
+        meta = ReqMeta(
+            local_block_ids=[],
+            num_external_tokens=0,
+            num_computed_tokens=0,
+            remote_block_ids=[],
+            remote_host="127.0.0.1",
+            remote_port=30100,
+            remote_engine_id="1",
+            remote_request_id="req-1",
+            remote_pcp_size=1,
+            remote_dcp_size=1,
+            remote_ptp_size=4,
+            remote_multi_nodes_meta_mapping={},
+            num_prompt_blocks=0,
+        )
+        worker._update_remote_sizes_from_metadata(meta)
+        # Unchanged: extra_config value wins.
+        self.assertEqual(worker._prefill_tp_size, 8)
+        self.assertTrue(worker._remote_sizes_resolved)
+
+    def test_d_side_no_meta_stays_unresolved(self):
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.kv_role = "kv_consumer"
+        worker._prefill_tp_size = 1
+        worker._prefill_dp_size = 1
+        worker._remote_sizes_resolved = False
+        worker._update_remote_sizes_from_metadata(None)
+        self.assertFalse(worker._remote_sizes_resolved)
+        self.assertEqual(worker._prefill_tp_size, 1)
+
+
+class TestPSideFallbackToExtraConfig(unittest.TestCase):
+    """When extra_config provides decode topology, P-side uses it directly
+    and marks _remote_sizes_resolved (no need for DONE_RECVING_MSG)."""
+
+    def test_p_side_uses_decode_extra_config(self):
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.kv_role = "kv_producer"
+        cfg = _make_vllm_config(
+            "kv_producer", tp_size=4, dp_size=4,
+            extra_config={"decode": {"tp_size": 1, "dp_size": 16}},
+        )
+        worker._resolve_parallel_sizes(cfg)
+        self.assertEqual(worker._decode_tp_size, 1)
+        self.assertEqual(worker._decode_dp_size, 16)
+        self.assertTrue(worker._remote_sizes_resolved)
+
+    def test_p_side_rejects_prefill_smaller_than_decode(self):
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.kv_role = "kv_producer"
+        # P tp=2 but config claims decode tp=4 -> invalid.
+        cfg = _make_vllm_config(
+            "kv_producer", tp_size=2, dp_size=4,
+            extra_config={"prefill": {"tp_size": 2}, "decode": {"tp_size": 4}},
+        )
+        with self.assertRaises(ValueError):
+            worker._resolve_parallel_sizes(cfg)
+
+
+class TestHybridConnectorDiscovery(unittest.TestCase):
+    """Same fixes applied to MooncakeHybridConnector."""
+
+    def test_hybrid_d_side_uses_remote_ptp_size(self):
+        worker = MooncakeHybridConnectorWorker.__new__(MooncakeHybridConnectorWorker)
+        worker.kv_role = "kv_consumer"
+        worker._prefill_tp_size = 1
+        worker._prefill_dp_size = 1
+        worker._remote_sizes_resolved = False
+
+        meta = HybridReqMeta(
+            local_block_ids=[],
+            num_external_tokens=0,
+            remote_block_ids=[],
+            remote_host="127.0.0.1",
+            remote_port=30100,
+            remote_engine_id="1",
+            remote_request_id="req-1",
+            remote_ptp_size=4,
+            remote_multi_nodes_meta_mapping={},
+            num_prompt_blocks=0,
+        )
+        worker._update_remote_sizes_from_metadata(meta)
+        self.assertEqual(worker._prefill_tp_size, 4)
+        self.assertTrue(worker._remote_sizes_resolved)
+
+
+class TestCheckKvExtraConfig(unittest.TestCase):
+    """check_kv_extra_config raises on local-role mismatch, tolerates
+    missing config (auto-discovery), and does not validate the remote
+    role's config values."""
+
+    def _make(self, kv_role: str, tp_size: int, dp_size: int, extra_config: dict):
+        cfg = MagicMock()
+        cfg.parallel_config.tensor_parallel_size = tp_size
+        cfg.parallel_config.data_parallel_size = dp_size
+        cfg.kv_transfer_config.is_kv_producer = kv_role == "kv_producer"
+        cfg.kv_transfer_config.is_kv_consumer = kv_role == "kv_consumer"
+        cfg.kv_transfer_config.get_from_extra_config = lambda key, default=None: (
+            extra_config.get(key, default if default is not None else {})
+        )
+        return cfg
+
+    def test_missing_config_does_not_raise(self):
+        cfg = self._make("kv_producer", tp_size=4, dp_size=4, extra_config={})
+        # Should not raise; auto-discovery path.
+        check_kv_extra_config(cfg)
+
+    def test_local_tp_mismatch_raises(self):
+        # Producer's local prefill config tp must match local tp.
+        cfg = self._make(
+            "kv_producer", tp_size=4, dp_size=4,
+            extra_config={"prefill": {"tp_size": 8}},
+        )
+        with self.assertRaises(ValueError):
+            check_kv_extra_config(cfg)
+
+    def test_local_dp_mismatch_raises(self):
+        cfg = self._make(
+            "kv_consumer", tp_size=1, dp_size=16,
+            extra_config={"decode": {"dp_size": 8}},
+        )
+        with self.assertRaises(ValueError):
+            check_kv_extra_config(cfg)
+
+    def test_local_config_matches_does_not_raise(self):
+        cfg = self._make(
+            "kv_producer", tp_size=4, dp_size=4,
+            extra_config={"prefill": {"tp_size": 4, "dp_size": 4}},
+        )
+        check_kv_extra_config(cfg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ut/distributed/kv_transfer/test_mooncake_topology_resolution.py
+++ b/tests/ut/distributed/kv_transfer/test_mooncake_topology_resolution.py
@@ -42,6 +42,8 @@ from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector import (
 )
 from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_hybrid_connector import (
     MooncakeConnectorWorker as MooncakeHybridConnectorWorker,
+)
+from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_hybrid_connector import (
     ReqMeta as HybridReqMeta,
 )
 from vllm_ascend.utils import check_kv_extra_config
@@ -57,8 +59,8 @@ def _make_vllm_config(kv_role: str, tp_size: int, dp_size: int, extra_config: di
     cfg.kv_transfer_config.is_kv_producer = kv_role == "kv_producer"
     cfg.kv_transfer_config.is_kv_consumer = kv_role == "kv_consumer"
     cfg.kv_transfer_config.kv_connector_extra_config = extra_config
-    cfg.kv_transfer_config.get_from_extra_config = lambda key, default=None: (
-        extra_config.get(key, default if default is not None else {})
+    cfg.kv_transfer_config.get_from_extra_config = lambda key, default=None: extra_config.get(
+        key, default if default is not None else {}
     )
     return cfg
 
@@ -172,7 +174,9 @@ class TestPSideFallbackToExtraConfig(unittest.TestCase):
         worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
         worker.kv_role = "kv_producer"
         cfg = _make_vllm_config(
-            "kv_producer", tp_size=4, dp_size=4,
+            "kv_producer",
+            tp_size=4,
+            dp_size=4,
             extra_config={"decode": {"tp_size": 1, "dp_size": 16}},
         )
         worker._resolve_parallel_sizes(cfg)
@@ -185,7 +189,9 @@ class TestPSideFallbackToExtraConfig(unittest.TestCase):
         worker.kv_role = "kv_producer"
         # P tp=2 but config claims decode tp=4 -> invalid.
         cfg = _make_vllm_config(
-            "kv_producer", tp_size=2, dp_size=4,
+            "kv_producer",
+            tp_size=2,
+            dp_size=4,
             extra_config={"prefill": {"tp_size": 2}, "decode": {"tp_size": 4}},
         )
         with self.assertRaises(ValueError):
@@ -230,8 +236,8 @@ class TestCheckKvExtraConfig(unittest.TestCase):
         cfg.parallel_config.data_parallel_size = dp_size
         cfg.kv_transfer_config.is_kv_producer = kv_role == "kv_producer"
         cfg.kv_transfer_config.is_kv_consumer = kv_role == "kv_consumer"
-        cfg.kv_transfer_config.get_from_extra_config = lambda key, default=None: (
-            extra_config.get(key, default if default is not None else {})
+        cfg.kv_transfer_config.get_from_extra_config = lambda key, default=None: extra_config.get(
+            key, default if default is not None else {}
         )
         return cfg
 
@@ -243,7 +249,9 @@ class TestCheckKvExtraConfig(unittest.TestCase):
     def test_local_tp_mismatch_raises(self):
         # Producer's local prefill config tp must match local tp.
         cfg = self._make(
-            "kv_producer", tp_size=4, dp_size=4,
+            "kv_producer",
+            tp_size=4,
+            dp_size=4,
             extra_config={"prefill": {"tp_size": 8}},
         )
         with self.assertRaises(ValueError):
@@ -251,7 +259,9 @@ class TestCheckKvExtraConfig(unittest.TestCase):
 
     def test_local_dp_mismatch_raises(self):
         cfg = self._make(
-            "kv_consumer", tp_size=1, dp_size=16,
+            "kv_consumer",
+            tp_size=1,
+            dp_size=16,
             extra_config={"decode": {"dp_size": 8}},
         )
         with self.assertRaises(ValueError):
@@ -259,7 +269,9 @@ class TestCheckKvExtraConfig(unittest.TestCase):
 
     def test_local_config_matches_does_not_raise(self):
         cfg = self._make(
-            "kv_producer", tp_size=4, dp_size=4,
+            "kv_producer",
+            tp_size=4,
+            dp_size=4,
             extra_config={"prefill": {"tp_size": 4, "dp_size": 4}},
         )
         check_kv_extra_config(cfg)

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -104,6 +104,9 @@ class MooncakeAgentMetadata(msgspec.Struct, omit_defaults=True, dict=True):
     block_strides: list[list[int]]
     local_ip: str = ""
     handshake_port: int = 0
+    tp_size: int = 1
+    dp_size: int = 1
+    pp_size: int = 1
 
 
 @dataclass
@@ -269,6 +272,8 @@ class KVCacheSendingThread(threading.Thread):
         self.kv_caches = kv_caches
         self.pcp_rank = pcp_rank
         self.port_send_num: dict[str, int] = {}
+        self._remote_decode_tp_size: int = 1
+        self._remote_decode_dp_size: int = 1
 
         self.task_tracker = KVCacheTaskTracker()
 
@@ -361,6 +366,10 @@ class KVCacheSendingThread(threading.Thread):
                     logger.debug("Got DONE_RECVING_MSG for request %s", msg[1])
                     request_id = msg[1]
                     remote_port_send_num = msg[2]
+                    if len(msg) >= 4 and msg[3]:
+                        self._remote_decode_tp_size = msg[3]
+                    if len(msg) >= 5 and msg[4]:
+                        self._remote_decode_dp_size = msg[4]
                     if remote_port_send_num:
                         if request_id not in self.port_send_num:
                             self.port_send_num[request_id] = 0
@@ -462,6 +471,8 @@ class KVCacheRecvingThread(threading.Thread):
         self.remote_block_stride_per_addr: dict[str, dict[int, list[list[int]]]] = SizedDict()
         self.remote_kv_group2layeridx: dict[str, dict[int, dict[int, tuple[dict[str, Any], list[int]]]]] = SizedDict()
         self.remote_metadata_lock = threading.Lock()
+        self.remote_tp_size: dict[str, dict[int, int]] = SizedDict()
+        self.remote_dp_size: dict[str, dict[int, int]] = SizedDict()
 
         self.request_queue: queue.Queue[Any] = queue.Queue()
         self.executor = ThreadPoolExecutor(max_workers=32)
@@ -1289,6 +1300,8 @@ class KVCacheRecvingThread(threading.Thread):
                 self.remote_te_port[engine_id][remote_handshake_port] = agent_meta.te_rpc_port
                 self.remote_block_size_scale[engine_id][remote_handshake_port] = agent_meta.block_size_scale
                 self.remote_block_stride_per_addr[engine_id][remote_handshake_port] = agent_meta.block_strides
+                self.remote_tp_size[engine_id][remote_handshake_port] = agent_meta.tp_size
+                self.remote_dp_size[engine_id][remote_handshake_port] = agent_meta.dp_size
         except Exception:
             if isinstance(sock, zmq.Socket):  # type: ignore
                 sock.close()
@@ -1312,7 +1325,9 @@ class KVCacheRecvingThread(threading.Thread):
         sock: zmq.Socket | None = None  # type: ignore
         try:
             sock = self._get_remote_socket(remote_host, remote_handshake_port)
-            data_bytes = self.encoder.encode((DONE_RECVING_MSG, request_id, remote_port_send_num))
+            data_bytes = self.encoder.encode(
+                (DONE_RECVING_MSG, request_id, remote_port_send_num, self.tp_size, self.dp_size)
+            )
             ensure_zmq_send(sock, data_bytes, f"{remote_host}:{remote_handshake_port}")
             resp = ensure_zmq_recv(sock, f"{remote_host}:{remote_handshake_port}")
             if logger.isEnabledFor(logging.DEBUG):
@@ -1861,13 +1876,7 @@ class MooncakeConnectorWorker:
     """Implementation of Worker side methods"""
 
     def __init__(self, vllm_config: VllmConfig, engine_id: str, kv_cache_config: KVCacheConfig):
-        self._get_prefill_decode_size(vllm_config)
         os.environ["ASCEND_TRANSFER_TIMEOUT"] = str(get_transfer_timeout_value())
-        if self._prefill_tp_size < self._decode_tp_size:
-            raise ValueError(
-                f"prefill_tp_size: {self._prefill_tp_size} must be greater than"
-                f" or equal to the decode_tp_size: {self._decode_tp_size}"
-            )
 
         # Metadata.
         self.vllm_config = vllm_config
@@ -1892,6 +1901,9 @@ class MooncakeConnectorWorker:
 
         self.max_device_id = self.tp_size * self.dp_size * self.pcp_size * self.pp_size
         self.kv_role = vllm_config.kv_transfer_config.kv_role
+        # Resolve prefill/decode parallel sizes after self.kv_role is known,
+        # since _resolve_parallel_sizes branches on kv_role.
+        self._resolve_parallel_sizes(vllm_config)
         self.num_key_value_heads = self.vllm_config.model_config.hf_text_config.num_key_value_heads
 
         # kv cache config
@@ -1947,27 +1959,73 @@ class MooncakeConnectorWorker:
         self.local_remote_block_port_mapping: dict[str, list[list[int]] | None] = {}
         self.remote_port_send_num: dict[str, dict[int, RemotePortInfo]] = {}
 
-    def _get_prefill_decode_size(self, vllm_config: VllmConfig):
-        # get prefill tp and dp size from extra config
-        prefill_parallel_config: dict[str, Any] = vllm_config.kv_transfer_config.get_from_extra_config("prefill", {})
+    def _resolve_parallel_sizes(self, vllm_config: VllmConfig):
+        """Resolve prefill/decode parallel sizes from config or discovery.
 
-        assert "tp_size" in prefill_parallel_config
-        self._prefill_tp_size = prefill_parallel_config["tp_size"]
+        Own (local) sizes are read from parallel_config.
+        Remote sizes are read from kv_connector_extra_config if present,
+        otherwise default to 1 and are resolved lazily when the first
+        remote metadata exchange completes (see _get_remote_metadata).
+        """
+        parallel_config = vllm_config.parallel_config
+        is_producer = self.kv_role == "kv_producer"
 
-        assert "dp_size" in prefill_parallel_config
-        self._prefill_dp_size = prefill_parallel_config["dp_size"]
-        # get prefill pp size from extra config
-        self._prefill_pp_size = prefill_parallel_config.get("pp_size", 1)
-        # get decode tp and dp size from extra config
-        decode_parallel_config: dict[str, Any] = vllm_config.kv_transfer_config.get_from_extra_config("decode", {})
-        assert "tp_size" in decode_parallel_config
-        self._decode_tp_size = decode_parallel_config["tp_size"]
-        assert "dp_size" in decode_parallel_config
-        self._decode_dp_size = decode_parallel_config["dp_size"]
-        # get prefill pp size from extra config
-        self._decode_pp_size = decode_parallel_config.get("pp_size", 1)
-        assert self._decode_pp_size == 1, "decode pp size must be 1"
-        self._prefill_pp_layer_partition = prefill_parallel_config.get("pp_layer_partition")
+        # Own sizes: directly from parallel_config (always available)
+        if is_producer:
+            self._prefill_tp_size = parallel_config.tensor_parallel_size
+            self._prefill_dp_size = parallel_config.data_parallel_size
+        else:
+            self._decode_tp_size = parallel_config.tensor_parallel_size
+            self._decode_dp_size = parallel_config.data_parallel_size
+
+        # Remote sizes: try extra_config first, fallback to lazy discovery
+        extra = vllm_config.kv_transfer_config.kv_connector_extra_config
+        prefill_extra = extra.get("prefill", {})
+        decode_extra = extra.get("decode", {})
+
+        if is_producer:
+            self._decode_tp_size = decode_extra.get("tp_size", 1)
+            self._decode_dp_size = decode_extra.get("dp_size", 1)
+            self._remote_sizes_resolved = bool(decode_extra)
+        else:
+            self._prefill_tp_size = prefill_extra.get("tp_size", 1)
+            self._prefill_dp_size = prefill_extra.get("dp_size", 1)
+            self._remote_sizes_resolved = bool(prefill_extra)
+
+        self._prefill_pp_size = prefill_extra.get("pp_size", 1)
+        self._decode_pp_size = decode_extra.get("pp_size", 1)
+        self._prefill_pp_layer_partition = prefill_extra.get("pp_layer_partition")
+
+        if self._remote_sizes_resolved and self._prefill_tp_size < self._decode_tp_size:
+            raise ValueError(
+                f"prefill_tp_size: {self._prefill_tp_size} must be greater than"
+                f" or equal to the decode_tp_size: {self._decode_tp_size}"
+            )
+
+    def _update_remote_sizes_from_metadata(self, meta: ReqMeta | None = None):
+        """Lazily update remote topology sizes from discovered metadata.
+
+        On the producer (P) side: read D's tp_size from the
+        KVCacheSendingThread which extracts it from DONE_RECVING_MSG.
+        On the consumer (D) side: read P's tp_size from the per-request
+        ``meta.remote_ptp_size`` (populated by the prefiller and forwarded
+        by the proxy), avoiding any dependency on the ZMQ metadata cache
+        being populated before the first request is routed.
+        """
+        if self._remote_sizes_resolved:
+            return
+        is_producer = self.kv_role == "kv_producer"
+
+        if is_producer and self.kv_send_thread is not None:
+            remote_tp = self.kv_send_thread._remote_decode_tp_size
+            if remote_tp > 1:
+                self._decode_tp_size = remote_tp
+                self._decode_dp_size = self.kv_send_thread._remote_decode_dp_size
+                self._remote_sizes_resolved = True
+        elif not is_producer and meta is not None and meta.remote_ptp_size is not None:
+            self._prefill_tp_size = meta.remote_ptp_size
+            # dp_size has no per-request channel; keep default/extra_config value.
+            self._remote_sizes_resolved = True
 
     @staticmethod
     def _serialize_kv_group_spec(
@@ -2276,6 +2334,9 @@ class MooncakeConnectorWorker:
             block_strides=self.block_stride_per_addr,
             local_ip=get_ip(),
             handshake_port=self.handshake_port,
+            tp_size=self.tp_size,
+            dp_size=self.dp_size,
+            pp_size=self.pp_size,
         )
         self.xfer_handshake_metadata = metadata
 
@@ -3158,6 +3219,7 @@ class MooncakeConnectorWorker:
                 self.kv_recv_thread.task_tracker.add_req_to_process(req_id)
 
         for req_id, meta in metadata.requests.items():
+            self._update_remote_sizes_from_metadata(meta)
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(
                     "start_load_kv for request %s from remote engine %s. "

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -418,6 +418,7 @@ class KVCacheRecvingThread(threading.Thread):
         self,
         tp_rank: int,
         tp_size: int,
+        dp_size: int,
         _prefill_pp_size: int,
         engine: TransferEngine,
         local_engine_id: str,
@@ -437,6 +438,7 @@ class KVCacheRecvingThread(threading.Thread):
         super().__init__(daemon=True, name="KVCacheRecvingThread")
         self.tp_rank = tp_rank
         self.tp_size = tp_size
+        self.dp_size = dp_size
         self._prefill_pp_size = _prefill_pp_size
         self.local_engine_id = local_engine_id
         self.local_handshake_port = local_handshake_port
@@ -2359,6 +2361,7 @@ class MooncakeConnectorWorker:
             self.kv_recv_thread = KVCacheRecvingThread(
                 self.tp_rank,
                 self.tp_size,
+                self.dp_size,
                 self._prefill_pp_size,
                 self.engine,
                 self.engine_id,

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -88,6 +88,9 @@ class MooncakeAgentMetadata(msgspec.Struct, omit_defaults=True, dict=True):
     block_lens: list[int]
     ssm_sizes: tuple[int, int]
     local_ip: str = ""
+    tp_size: int = 1
+    dp_size: int = 1
+    pp_size: int = 1
 
 
 @dataclass
@@ -229,6 +232,8 @@ class KVCacheSendingThread(threading.Thread):
         self.ready_event = ready_event
         self.kv_caches = kv_caches
         self.port_send_num: dict[str, int] = {}
+        self._remote_decode_tp_size: int = 1
+        self._remote_decode_dp_size: int = 1
 
         self.task_tracker = KVCacheTaskTracker()
 
@@ -319,6 +324,10 @@ class KVCacheSendingThread(threading.Thread):
                     logger.debug("Got DONE_RECVING_MSG for request %s", msg[1])
                     request_id = msg[1]
                     remote_port_send_num = msg[2]
+                    if len(msg) >= 4 and msg[3]:
+                        self._remote_decode_tp_size = msg[3]
+                    if len(msg) >= 5 and msg[4]:
+                        self._remote_decode_dp_size = msg[4]
                     if remote_port_send_num:
                         if request_id not in self.port_send_num:
                             self.port_send_num[request_id] = 0
@@ -406,6 +415,8 @@ class KVCacheRecvingThread(threading.Thread):
         self.mamba_ssm_size = mamba_ssm_size
         self.remote_te_port: dict[str, dict[int, int]] = SizedDict()
         self.remote_metadata_lock = threading.Lock()
+        self.remote_tp_size: dict[str, dict[int, int]] = SizedDict()
+        self.remote_dp_size: dict[str, dict[int, int]] = SizedDict()
 
         self.request_queue: queue.Queue[Any] = queue.Queue()
         self.executor = ThreadPoolExecutor(max_workers=32)
@@ -956,6 +967,8 @@ class KVCacheRecvingThread(threading.Thread):
             with self.remote_metadata_lock:
                 self.kv_caches_base_addr[engine_id][remote_handshake_port] = agent_meta.kv_caches_base_addr
                 self.remote_te_port[engine_id][remote_handshake_port] = agent_meta.te_rpc_port
+                self.remote_tp_size[engine_id][remote_handshake_port] = agent_meta.tp_size
+                self.remote_dp_size[engine_id][remote_handshake_port] = agent_meta.dp_size
         except Exception:
             if isinstance(sock, zmq.Socket):  # type: ignore
                 sock.close()
@@ -979,7 +992,9 @@ class KVCacheRecvingThread(threading.Thread):
         sock: zmq.Socket | None = None  # type: ignore
         try:
             sock = self._get_remote_socket(remote_host, remote_handshake_port)
-            data_bytes = self.encoder.encode((DONE_RECVING_MSG, request_id, remote_port_send_num))
+            data_bytes = self.encoder.encode(
+                (DONE_RECVING_MSG, request_id, remote_port_send_num, self.tp_size, self.dp_size)
+            )
             ensure_zmq_send(sock, data_bytes, f"{remote_host}:{remote_handshake_port}")
             resp = ensure_zmq_recv(sock, f"{remote_host}:{remote_handshake_port}")
             logger.debug("Received response for request %s: %s", request_id, resp.decode("utf-8"))
@@ -1469,13 +1484,7 @@ class MooncakeConnectorWorker:
     """Implementation of Worker side methods"""
 
     def __init__(self, vllm_config: VllmConfig, engine_id: str, kv_cache_config: KVCacheConfig):
-        self._get_prefill_decode_size(vllm_config)
         os.environ["ASCEND_TRANSFER_TIMEOUT"] = str(get_transfer_timeout_value())
-        if self._prefill_tp_size < self._decode_tp_size:
-            raise ValueError(
-                f"prefill_tp_size: {self._prefill_tp_size} must be greater than"
-                f" or equal to the decode_tp_size: {self._decode_tp_size}"
-            )
 
         # Metadata.
         self.vllm_config = vllm_config
@@ -1497,6 +1506,10 @@ class MooncakeConnectorWorker:
         self.max_device_id = self.tp_size * self.dp_size * self.pp_size
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         self.num_key_value_heads = self.vllm_config.model_config.hf_text_config.num_key_value_heads
+        # Resolve prefill/decode parallel sizes after self.kv_role is known,
+        # since _resolve_parallel_sizes branches on kv_role and the Mamba
+        # assertion below depends on the resolved sizes.
+        self._resolve_parallel_sizes(vllm_config)
 
         # kv cache config
         self.kv_cache_config = kv_cache_config
@@ -1567,27 +1580,73 @@ class MooncakeConnectorWorker:
         self.local_remote_block_port_mapping: dict[str, list[list[int]] | None] = {}
         self.remote_port_send_num: dict[str, dict[int, RemotePortInfo]] = {}
 
-    def _get_prefill_decode_size(self, vllm_config: VllmConfig):
-        # get prefill tp and dp size from extra config
-        prefill_parallel_config: dict[str, Any] = vllm_config.kv_transfer_config.get_from_extra_config("prefill", {})
+    def _resolve_parallel_sizes(self, vllm_config: VllmConfig):
+        """Resolve prefill/decode parallel sizes from config or discovery.
 
-        assert "tp_size" in prefill_parallel_config
-        self._prefill_tp_size = prefill_parallel_config["tp_size"]
+        Own (local) sizes are read from parallel_config.
+        Remote sizes are read from kv_connector_extra_config if present,
+        otherwise default to 1 and are resolved lazily when the first
+        remote metadata exchange completes.
+        """
+        parallel_config = vllm_config.parallel_config
+        is_producer = self.kv_role == "kv_producer"
 
-        assert "dp_size" in prefill_parallel_config
-        self._prefill_dp_size = prefill_parallel_config["dp_size"]
-        # get prefill pp size from extra config
-        self._prefill_pp_size = prefill_parallel_config.get("pp_size", 1)
-        # get decode tp and dp size from extra config
-        decode_parallel_config: dict[str, Any] = vllm_config.kv_transfer_config.get_from_extra_config("decode", {})
-        assert "tp_size" in decode_parallel_config
-        self._decode_tp_size = decode_parallel_config["tp_size"]
-        assert "dp_size" in decode_parallel_config
-        self._decode_dp_size = decode_parallel_config["dp_size"]
-        # get prefill pp size from extra config
-        self._decode_pp_size = decode_parallel_config.get("pp_size", 1)
-        assert self._decode_pp_size == 1, "decode pp size must be 1"
-        self._prefill_pp_layer_partition = prefill_parallel_config.get("pp_layer_partition")
+        # Own sizes: directly from parallel_config (always available)
+        if is_producer:
+            self._prefill_tp_size = parallel_config.tensor_parallel_size
+            self._prefill_dp_size = parallel_config.data_parallel_size
+        else:
+            self._decode_tp_size = parallel_config.tensor_parallel_size
+            self._decode_dp_size = parallel_config.data_parallel_size
+
+        # Remote sizes: try extra_config first, fallback to lazy discovery
+        extra = vllm_config.kv_transfer_config.kv_connector_extra_config
+        prefill_extra = extra.get("prefill", {})
+        decode_extra = extra.get("decode", {})
+
+        if is_producer:
+            self._decode_tp_size = decode_extra.get("tp_size", 1)
+            self._decode_dp_size = decode_extra.get("dp_size", 1)
+            self._remote_sizes_resolved = bool(decode_extra)
+        else:
+            self._prefill_tp_size = prefill_extra.get("tp_size", 1)
+            self._prefill_dp_size = prefill_extra.get("dp_size", 1)
+            self._remote_sizes_resolved = bool(prefill_extra)
+
+        self._prefill_pp_size = prefill_extra.get("pp_size", 1)
+        self._decode_pp_size = decode_extra.get("pp_size", 1)
+        self._prefill_pp_layer_partition = prefill_extra.get("pp_layer_partition")
+
+        if self._remote_sizes_resolved and self._prefill_tp_size < self._decode_tp_size:
+            raise ValueError(
+                f"prefill_tp_size: {self._prefill_tp_size} must be greater than"
+                f" or equal to the decode_tp_size: {self._decode_tp_size}"
+            )
+
+    def _update_remote_sizes_from_metadata(self, meta: ReqMeta | None = None):
+        """Lazily update remote topology sizes from discovered metadata.
+
+        On the producer (P) side: read D's tp_size from the
+        KVCacheSendingThread which extracts it from DONE_RECVING_MSG.
+        On the consumer (D) side: read P's tp_size from the per-request
+        ``meta.remote_ptp_size`` (populated by the prefiller and forwarded
+        by the proxy), avoiding any dependency on the ZMQ metadata cache
+        being populated before the first request is routed.
+        """
+        if self._remote_sizes_resolved:
+            return
+        is_producer = self.kv_role == "kv_producer"
+
+        if is_producer and self.kv_send_thread is not None:
+            remote_tp = self.kv_send_thread._remote_decode_tp_size
+            if remote_tp > 1:
+                self._decode_tp_size = remote_tp
+                self._decode_dp_size = self.kv_send_thread._remote_decode_dp_size
+                self._remote_sizes_resolved = True
+        elif not is_producer and meta is not None and meta.remote_ptp_size is not None:
+            self._prefill_tp_size = meta.remote_ptp_size
+            # dp_size has no per-request channel; keep default/extra_config value.
+            self._remote_sizes_resolved = True
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """Register the KV Cache data."""
@@ -1682,6 +1741,9 @@ class MooncakeConnectorWorker:
             block_lens=self.block_len_per_addr,
             ssm_sizes=self._mamba_ssm_size,
             local_ip=get_ip(),
+            tp_size=self.tp_size,
+            dp_size=self.dp_size,
+            pp_size=self.pp_size,
         )
         self.xfer_handshake_metadata = metadata
 
@@ -1758,6 +1820,7 @@ class MooncakeConnectorWorker:
     def start_load_kv(self, metadata: MooncakeConnectorMetadata):
         """Start loading KV blocks from remote engine."""
         for req_id, meta in metadata.requests.items():
+            self._update_remote_sizes_from_metadata(meta)
             logger.debug(
                 "start_load_kv for request %s from remote engine %s. "
                 "Num local_block_ids: %s. Num remote_block_ids: %s. ",

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -376,6 +376,7 @@ class KVCacheRecvingThread(threading.Thread):
         self,
         tp_rank: int,
         tp_size: int,
+        dp_size: int,
         _prefill_pp_size: int,
         engine: TransferEngine,
         local_engine_id: str,
@@ -398,6 +399,7 @@ class KVCacheRecvingThread(threading.Thread):
         super().__init__(daemon=True, name="KVCacheRecvingThread")
         self.tp_rank = tp_rank
         self.tp_size = tp_size
+        self.dp_size = dp_size
         self._prefill_pp_size = _prefill_pp_size
         self.local_engine_id = local_engine_id
         self.local_handshake_port = local_handshake_port
@@ -1765,6 +1767,7 @@ class MooncakeConnectorWorker:
             self.kv_recv_thread = KVCacheRecvingThread(
                 self.tp_rank,
                 self.tp_size,
+                self.dp_size,
                 self._prefill_pp_size,
                 self.engine,
                 self.engine_id,

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1406,8 +1406,7 @@ def check_kv_extra_config(vllm_config):
         dp_key = "dp_size"
         if not config:
             logger.debug(
-                "KV transfer extra config '%s' not provided; "
-                "remote topology will be auto-discovered.",
+                "KV transfer extra config '%s' not provided; remote topology will be auto-discovered.",
                 name,
             )
             return

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1404,6 +1404,13 @@ def check_kv_extra_config(vllm_config):
     def _check(name: str, config: dict):
         tp_key = "tp_size"
         dp_key = "dp_size"
+        if not config:
+            logger.debug(
+                "KV transfer extra config '%s' not provided; "
+                "remote topology will be auto-discovered.",
+                name,
+            )
+            return
         if tp_key in config:
             config_tp = config[tp_key]
             vllm_tp = vllm_config.parallel_config.tensor_parallel_size


### PR DESCRIPTION
## What this PR does / why we need it?

The official [DeepSeek-V4-Flash PD separation guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/DeepSeek-V4-Flash.html#52-multi-node-pd-separation-deployment) uses `MooncakeHybridConnector` with heterogeneous TP (P `tp=4,dp=4`, D `tp=1,dp=16`). Currently users must manually specify the full `kv_connector_extra_config` with both prefill/decode `dp_size`/`tp_size` on every node, otherwise the connectors crash or misroute KV. This PR makes the config optional so topology is auto-discovered.

The prior auto-discovery attempt had several blocking bugs:

1. **Startup crash**: `MooncakeConnectorWorker.__init__` called `_resolve_parallel_sizes` as its first line, before `self.kv_role` was assigned → `AttributeError`. Both connectors affected.
2. **D-side never discovered remote topology**: `_update_remote_sizes_from_metadata` read from the ZMQ metadata cache with empty default `engine_id`/`handshake_port`, so `remote_tp_size.get("", {}).get(0)` always returned `None` and `_prefill_tp_size` stayed at the default 1 → KV shard routing wrong under heterogeneous TP.
3. **Hybrid `DONE_RECVING_MSG` dropped `dp_size`**: sent a 4-tuple vs the standard connector's 5-tuple, so P-side `_remote_decode_dp_size` was never populated.
4. **`check_kv_extra_config` warning contradicted behavior**: logged "Using local value" on mismatch without actually overriding, so the wrong config value was still consumed.

### Fixes
- Move `_resolve_parallel_sizes` after `self.kv_role` assignment in both connectors (and before the Mamba assertion in the hybrid connector).
- D-side now discovers P's `tp_size` from the per-request `meta.remote_ptp_size` (already populated by the prefiller in `build_connector_meta` and forwarded by the proxy), avoiding the empty ZMQ cache timing race.
- Hybrid `DONE_RECVING_MSG` now sends `(msg, req_id, port_num, tp_size, dp_size)`, matching the standard connector.
- `check_kv_extra_config` restores strict `ValueError` on local-role config mismatch (P checks `prefill`, D checks `decode`), and logs a debug message for the auto-discovery path when config is absent.
- Restore the `_prefill_tp_size < _decode_tp_size` validation, guarded by `_remote_sizes_resolved` so it does not fire on the default placeholder.

### Scope
MLA models (e.g. DeepSeek-V4) skip the `ascend_config` `pd_tp_ratio`/`pd_head_ratio`/`num_head_replica` derivation, so heterogeneous TP auto-discovery works end-to-end without `extra_config`. Non-MLA heterogeneous TP still requires `extra_config` — the `_P_TP` alltoall group is built irreversibly at `init_ascend_model_parallel` and cannot be reconstructed from runtime discovery. This is out of scope for this PR.

## Does this PR introduce _any_ user-facing change?

Yes — `kv_connector_extra_config` is now optional for Mooncake PD separation on MLA models. Users who continue to provide it see unchanged behavior (extra_config values take priority). Users who provide a mismatched *local-role* config now get an early `ValueError` instead of a silent warning.

## How was this patch tested?

- Unit tests added: `tests/ut/distributed/kv_transfer/test_mooncake_topology_resolution.py` (8 cases covering call order, D-side meta discovery, P-side extra_config fallback, hybrid connector discovery, and `check_kv_extra_config` scenarios).
- Manual e2e verification (planned on NPU): launch DeepSeek-V4 P(tp4,dp4)/D(tp1,dp16) per the official guide **without** `kv_connector_extra_config`, confirm no `AttributeError`, D-side `_prefill_tp_size=4` discovered from `meta.remote_ptp_size`, and KV transfer output matches the baseline with full `extra_config`.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
