### PR TITLE
[BugFix][CherryPick] w4a4mxfp quant_matmul shape error

### DIFF
--- a/tests/ut/quantization/methods/test_w4a4_mxfp4.py
+++ b/tests/ut/quantization/methods/test_w4a4_mxfp4.py
@@ -40,8 +40,6 @@ class TestAscendW4A4MXFP4LinearMethod(TestBase):
         self.scheme.process_weights_after_loading(layer)
         self.assertEqual(layer.weight.shape, (128, 128))
         self.assertEqual(layer.weight_scale.shape[0], 4)
-        self.assertTrue(layer.weight.data.is_contiguous())
-        self.assertTrue(layer.weight_scale.data.is_contiguous())
 
     @patch("vllm_ascend.quantization.methods.w4a4_mxfp4.torch_npu")
     def test_apply_3d_input(self, mock_npu):
@@ -104,10 +102,6 @@ class TestAscendW4A4MXFP4MoEMethod(TestBase):
         self.scheme.process_weights_after_loading(layer)
         self.assertEqual(layer.w13_weight.shape, (8, 64, 256))
         self.assertEqual(layer.w13_weight_scale.shape, (8, 2, 256, 2))
-        self.assertFalse(layer.w13_weight.data.is_contiguous())
-        self.assertFalse(layer.w2_weight.data.is_contiguous())
-        self.assertFalse(layer.w13_weight_scale.data.is_contiguous())
-        self.assertFalse(layer.w2_weight_scale.data.is_contiguous())
 
     @patch("vllm_ascend.quantization.methods.w4a4_mxfp4.torch_npu")
     @patch("vllm_ascend.quantization.methods.w4a4_mxfp4._EXTRA_CTX")

--- a/vllm_ascend/quantization/methods/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4_mxfp4.py
@@ -111,8 +111,8 @@ class AscendW4A4MXFP4DynamicLinearMethod(AscendLinearScheme):
 
         n_dim, k_dim = layer.weight_scale.data.shape
         layer.weight_scale.data = layer.weight_scale.data.reshape(n_dim, k_dim // 2, 2)
-        layer.weight.data = layer.weight.data.transpose(0, 1).contiguous()
-        layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1).contiguous()
+        layer.weight.data = layer.weight.data.transpose(0, 1)
+        layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1)
 
 
 @register_scheme("W4A4_MXFP4", "moe")


### PR DESCRIPTION
### What this PR does / why we need it?
The w4a4mxfp quantization is broken by https://github.com/vllm-project/vllm-ascend/pull/11068, the .contiguous() operation will cause the mismatch in the quant_matmul ops and it is also redundant in https://github.com/vllm-project/vllm-ascend/pull/11068 function.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
