### PR TITLE
[BugFix][MRV2] Fix quant and DP full graph mode for mrv2

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -567,6 +567,7 @@
   tests:
     - tests/ut/worker
     - tests/e2e/pull_request/one_card/model_runner_v2
+    - tests/e2e/pull_request/two_card/model_runner_v2
 
 # XLite
 - name: xlite
@@ -735,6 +736,7 @@ estimated_times:
   tests/e2e/pull_request/two_card/lora/test_ilama_lora_tp2.py: 160
   tests/e2e/pull_request/two_card/lora/test_llama32_lora_tp2.py: 510
   tests/e2e/pull_request/two_card/lora/test_qwen3moe_lora_tp.py: 170
+  tests/e2e/pull_request/two_card/model_runner_v2/test_data_parallel.py: 130
   tests/e2e/pull_request/two_card/spec_decode/test_spec_decode.py: 760
   tests/e2e/pull_request/two_card/test_data_parallel.py: 500
   tests/e2e/pull_request/two_card/test_deepseek_multistream_moe.py: 140

--- a/tests/e2e/pull_request/two_card/model_runner_v2/test_data_parallel.py
+++ b/tests/e2e/pull_request/two_card/model_runner_v2/test_data_parallel.py
@@ -17,7 +17,7 @@
 """
 Data parallel inference with Model Runner V2.
 
-Run `pytest tests/e2e/pull_request/two_card/model_runner_v2/test_data_parallel.py`.
+Run `pytest -sv tests/e2e/pull_request/two_card/model_runner_v2/test_data_parallel.py`.
 """
 
 import os
@@ -54,8 +54,42 @@ def test_dsv2_w8a8_dp_eager_mode():
         tensor_parallel_size=1,
         enable_expert_parallel=True,
         max_model_len=1024,
-        enforce_eager=True,  # Note: currently graph mode is not supported for dp in model runner v2
+        enforce_eager=True,
         quantization="ascend",
         distributed_executor_backend="mp",
+    ) as vllm_model:
+        vllm_model.generate(example_prompts, sampling_params=sampling_params)
+
+
+@pytest.mark.parametrize(
+    "compilation_config",
+    [
+        pytest.param(
+            {"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 8]},
+            id="full_decode_only",
+        ),
+        pytest.param({}, id="default_full_and_piecewise"),
+    ],
+)
+@patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
+@wait_until_npu_memory_free(target_free_percentage=0.7)
+def test_dsv2_w8a8_dp_graph_mode(compilation_config: dict):
+    example_prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+    max_tokens = 20
+    sampling_params = SamplingParams(max_tokens=max_tokens, temperature=0.6, top_p=0.95)
+    with DPVllmRunner(
+        MODELS[0],
+        data_parallel_size=2,
+        tensor_parallel_size=1,
+        enable_expert_parallel=True,
+        max_model_len=1024,
+        quantization="ascend",
+        distributed_executor_backend="mp",
+        compilation_config=compilation_config,
     ) as vllm_model:
         vllm_model.generate(example_prompts, sampling_params=sampling_params)

--- a/tests/e2e/pull_request/two_card/model_runner_v2/test_data_parallel.py
+++ b/tests/e2e/pull_request/two_card/model_runner_v2/test_data_parallel.py
@@ -1,0 +1,61 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Data parallel inference with Model Runner V2.
+
+Run `pytest tests/e2e/pull_request/two_card/model_runner_v2/test_data_parallel.py`.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from vllm import SamplingParams
+
+from tests.e2e.conftest import DPVllmRunner, wait_until_npu_memory_free
+from vllm_ascend.utils import vllm_version_is
+
+MODELS = ["vllm-ascend/DeepSeek-V2-Lite-W8A8"]
+
+pytestmark = pytest.mark.skipif(
+    vllm_version_is("0.23.0"),
+    reason="v2 model runner patches not supported on v0.23.0",
+)
+
+
+@patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
+@wait_until_npu_memory_free(target_free_percentage=0.7)
+def test_dsv2_w8a8_dp_eager_mode():
+    example_prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+    max_tokens = 32
+    sampling_params = SamplingParams(max_tokens=max_tokens, temperature=0.6, top_k=10)
+    with DPVllmRunner(
+        MODELS[0],
+        data_parallel_size=2,
+        tensor_parallel_size=1,
+        enable_expert_parallel=True,
+        max_model_len=1024,
+        enforce_eager=True,  # Note: currently graph mode is not supported for dp in model runner v2
+        quantization="ascend",
+        distributed_executor_backend="mp",
+    ) as vllm_model:
+        vllm_model.generate(example_prompts, sampling_params=sampling_params)

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -526,16 +526,14 @@ class TestNPUWorker(TestBase):
             worker.compilation_config = MagicMock()
             worker.compilation_config.cudagraph_mode = MagicMock()
             mock_model_runner = MagicMock()
-            mock_decode_token_per_req = mock_model_runner.decode_token_per_req
+            mock_uniform_decode_query_len = mock_model_runner.uniform_decode_query_len
             worker.model_runner = mock_model_runner
 
             # Test execute_dummy_batch
             worker.execute_dummy_batch()
 
             # Verify call
-            mock_model_runner._dummy_run.assert_called_once_with(
-                num_tokens=mock_decode_token_per_req, uniform_decode=True
-            )
+            mock_model_runner._dummy_run.assert_called_once_with(mock_uniform_decode_query_len, uniform_decode=True)
 
     @patch("vllm_ascend.worker.worker.memory_profiling")
     @patch("torch.npu.reset_peak_memory_stats")

--- a/vllm_ascend/quantization/method_adapters.py
+++ b/vllm_ascend/quantization/method_adapters.py
@@ -213,6 +213,15 @@ class AscendFusedMoEMethod(FusedMoEMethodBase):
         self.quant_method = scheme
         self.tid2eid = tid2eid
 
+    @property
+    def is_monolithic(self) -> bool:
+        return False
+
+    def maybe_make_prepare_finalize(self, routing_tables=None):
+        # Ascend uses its own MoE communication and forward_impl path.
+        # Do not let upstream modular-kernel initialization replace it.
+        return None
+
     def create_weights(
         self,
         layer: torch.nn.Module,

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -77,7 +77,7 @@ class ModelAclGraphManager(ModelCudaGraphManager):
         positions = self.model_runner.input_buffers.positions[:num_tokens]
         # refer to vllm.v1.worker.gpu.dp_utils.sync_cudagraph_and_dp_padding to
         # calculate num_tokens_across_dp.
-        num_tokens_across_dp = torch.full([self.model_runner.dp_size], num_tokens, device=self.device)
+        num_tokens_across_dp = torch.full([self.model_runner.dp_size], num_tokens)
         with set_forward_context(
             self.model_runner.model_state.attn_metadata,
             self.vllm_config,

--- a/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
@@ -88,7 +88,7 @@ class PrefillEagleAclGraphManager(PrefillSpeculatorCudaGraphManager):
         positions = self.speculator.input_buffers.positions[:num_tokens]
         # refer to vllm.v1.worker.gpu.dp_utils.sync_cudagraph_and_dp_padding to
         # calculate num_tokens_across_dp.
-        num_tokens_across_dp = torch.full([self.speculator.dp_size], num_tokens, device=self.device)
+        num_tokens_across_dp = torch.full([self.speculator.dp_size], num_tokens)
         with set_forward_context(
             self.speculator.model_state.attn_metadata,
             self.vllm_config,
@@ -204,7 +204,7 @@ class DecodeEagleAclGraphManager(DecodeSpeculatorCudaGraphManager):
         positions = self.speculator.input_buffers.positions[:num_tokens]
         # refer to vllm.v1.worker.gpu.dp_utils.sync_cudagraph_and_dp_padding to
         # calculate num_tokens_across_dp.
-        num_tokens_across_dp = torch.full([self.speculator.dp_size], num_tokens, device=self.device)
+        num_tokens_across_dp = torch.full([self.speculator.dp_size], num_tokens)
         with set_forward_context(
             self.speculator.model_state.attn_metadata,
             self.vllm_config,

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -978,7 +978,8 @@ class NPUWorker(WorkerBase):
         self.model_runner.reset_encoder_cache()
 
     def execute_dummy_batch(self) -> None:
-        self.model_runner._dummy_run(num_tokens=self.model_runner.decode_token_per_req, uniform_decode=True)
+        num_tokens = getattr(self.model_runner, "uniform_decode_query_len", 1)
+        self.model_runner._dummy_run(num_tokens, uniform_decode=True)
 
     def _init_worker_distributed_environment(self) -> None:
         """Initialize the distributed environment."""


### PR DESCRIPTION
### What this PR does / why we need it?
- MoE Initialization: Added the is_monolithic property and the maybe_make_prepare_finalize method to AscendMoEScheme to ensure Ascend-specific MoE communication and forward paths are preserved during initialization.
- Dummy Batch Execution: Updated the execute_dummy_batch function to dynamically retrieve the token count via uniform_decode_query_len, improving the accuracy of dummy runs.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
unset https_proxy
unset http_proxy
export PYTHONPATH=/mnt/share/z00909740/dev/vllm:$PYTHONPATH
export VLLM_VERSION=0.24.0
export HCCL_OP_EXPANSION_MODE="AIV"
#open MC2
#export VLLM_ASCEND_ENABLE_CHUNK_MC2=1
#export VLLM_ASCEND_FUSED_MOE_MC2_CHUNK_SIZE=128
export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"

export VLLM_ASCEND_BALANCE_SCHEDULING=1
export OMP_PROC_BIND=false
export OMP_NUM_THREADS=10

export VLLM_TORCH_PROFILER_WITH_STACK=0
export HCCL_BUFFSIZE=500
export VLLM_ASCEND_ENABLE_MLAPO=1
export TASK_QUEUE_ENABLE=1
export VLLM_ENGINE_READY_TIMEOUT_S=6000
export VLLM_USE_V2_MODEL_RUNNER=1

vllm serve /mnt/weight/DeepSeek-V3.1-w4a8-perchannle \
    --host xxxxx \
    --port 1046 \
    --data-parallel-size 2 \
    --tensor-parallel-size 8 \
    --quantization ascend \
    --seed 1024 \
    --served-model-name deepseek_v3 \
    --enable-expert-parallel \
    --max-num-seqs 96 \
    --max-model-len 32768 \
    --max-num-batched-tokens 6000 \
    --trust-remote-code \
    --no-enable-prefix-caching \
    --gpu-memory-utilization 0.9 \
    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/e5588e49bc2642670116664a7fc4096e27adb179
