### PR TITLE
[CI] Improve format.sh changed-files mode

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -64,7 +64,16 @@ check_command pre-commit
 export SHELLCHECK_OPTS="--exclude=SC2046,SC2006,SC2086"
 case "${1:-changed}" in
     changed)
-        mapfile -t changed_files < <(
+        check_command git
+        if ! git rev-parse --is-inside-work-tree &> /dev/null; then
+            echo "Error: not inside a git work tree." >&2
+            exit 1
+        fi
+
+        changed_files=()
+        while IFS= read -r line; do
+            changed_files+=("$line")
+        done < <(
             {
                 git diff --name-only --diff-filter=ACMR --cached
                 git diff --name-only --diff-filter=ACMR

--- a/format.sh
+++ b/format.sh
@@ -19,6 +19,31 @@
 # Adapted from https://github.com/vllm-project/vllm/tree/main/tools
 #
 
+show_help() {
+    cat <<'EOF'
+Usage: bash format.sh [changed|all|ci]
+
+Modes:
+  changed  Run pre-commit on files changed in the working tree. This is the
+           default and is intended for fast local iteration.
+  all      Run pre-commit on every tracked file with local hook stages.
+  ci       Run pre-commit on every tracked file, including manual CI hooks.
+
+Examples:
+  bash format.sh
+  bash format.sh changed
+  bash format.sh all
+  bash format.sh ci
+EOF
+}
+
+case "${1:-changed}" in
+    -h|--help|help)
+        show_help
+        exit 0
+        ;;
+esac
+
 check_command() {
     if ! command -v "$1" &> /dev/null; then
         echo "❓❓$1 is not installed, please run:"
@@ -37,8 +62,32 @@ check_command pre-commit
 
 # TODO: cleanup SC exclude
 export SHELLCHECK_OPTS="--exclude=SC2046,SC2006,SC2086"
-if [[ "$1" != 'ci' ]]; then
-    pre-commit run --all-files
-else
-    pre-commit run --all-files --hook-stage manual
-fi
+case "${1:-changed}" in
+    changed)
+        mapfile -t changed_files < <(
+            {
+                git diff --name-only --diff-filter=ACMR --cached
+                git diff --name-only --diff-filter=ACMR
+                git ls-files --others --exclude-standard
+            } | sort -u
+        )
+
+        if [[ ${#changed_files[@]} -eq 0 ]]; then
+            echo "No changed files to format."
+            exit 0
+        fi
+
+        pre-commit run --files "${changed_files[@]}"
+        ;;
+    all)
+        pre-commit run --all-files
+        ;;
+    ci)
+        pre-commit run --all-files --hook-stage manual
+        ;;
+    *)
+        echo "Unknown format mode: $1" >&2
+        show_help >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
### What this PR does / why we need it?

This PR improves `format.sh` by splitting the formatting workflow into explicit modes:

- `bash format.sh` / `bash format.sh changed`: run pre-commit only on changed files.
- `bash format.sh all`: run pre-commit on all tracked files.
- `bash format.sh ci`: run all-file checks including manual CI hooks.
- `bash format.sh --help`: show usage information.

Previously, the default local workflow ran `pre-commit run --all-files`, which made normal contributor iteration slower than necessary. This change keeps the CI path strict while making local development faster and more predictable.

Fixes #11098

### Does this PR introduce _any_ user-facing change?

No. This only changes the contributor/developer tooling workflow. It does not affect vLLM Ascend runtime behavior, APIs, model execution, or serving behavior.

### How was this patch tested?

Tested with:

```bash
bash -n format.sh
bash format.sh changed
bash format.sh ci
pre-commit run shellcheck --files format.sh

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
