### PR TITLE
[BugFix][310P] Fix shared experts linear when out_dim=1

### DIFF
--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -45,6 +45,7 @@ from vllm_ascend.utils import (
     AscendDeviceType,
     enable_sp,
     get_ascend_device_type,
+    is_310p,
     maybe_trans_nz,
 )
 
@@ -75,16 +76,26 @@ direct_register_custom_op(
 )
 
 
+def _should_keep_nd_for_310p_weight(weight: torch.Tensor) -> bool:
+    return is_310p() and weight.ndim >= 2 and (weight.shape[-1] == 1 or weight.shape[-2] == 1)
+
+
 class AscendUnquantizedLinearMethod(UnquantizedLinearMethod):
     """Linear method without quantization"""
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         super().process_weights_after_loading(layer)
+        keep_nd_weight = _should_keep_nd_for_310p_weight(layer.weight.data)
         # must use fp32 to avoid accuracy degradation in dsv4.
         if getattr(layer, "precast_fp32_weight", False):
-            layer.weight_fp32 = maybe_trans_nz(layer.weight.data.to(torch.float32))
+            weight_fp32 = layer.weight.data.to(torch.float32)
+            layer.weight_fp32 = weight_fp32 if keep_nd_weight else maybe_trans_nz(weight_fp32)
         if "conv1d" not in layer.prefix:
-            layer.weight.data = maybe_trans_nz(layer.weight.data)
+            # 310P torch_npu rejects FRACTAL_NZ matmul when the weight-side
+            # matrix has n=1 or k=1. Keep scalar gates such as Qwen MoE's
+            # shared_expert_gate in ND format, leaving non-310P policy intact.
+            if not keep_nd_weight:
+                layer.weight.data = maybe_trans_nz(layer.weight.data)
 
     def apply(
         self,


### PR DESCRIPTION
## What

This PR backports the 310P shared-experts linear fix to the `releases/v0.23.0` branch.

It keeps 310P weights in ND format when the weight-side matrix has `n=1` or `k=1`, including scalar gates such as Qwen MoE `shared_expert_gate`, while leaving the existing non-310P behavior unchanged.

## Why

On 310P, `torch_npu` can reject FRACTAL_NZ matmul for these degenerate linear shapes. The release branch needs the same fix without bringing in unrelated commits from `main`.

## Scope / history hygiene

Created a clean branch from `upstream/releases/v0.23.0` and cherry-picked only the original fix commit from `7-9-fix-linear-sharedexperts`.

PR diff contains only:

- `vllm_ascend/ops/linear.py`

## Validation

- `git diff --check upstream/releases/v0.23.0...HEAD`
- Python AST parse check for `vllm_ascend/ops/linear.py`
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
