### PR TITLE
[Feature] Add qwen/glm dspark for mrv1

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -501,6 +501,14 @@
   tests:
     - tests/e2e/pull_request/one_card/spec_decode/test_dflash.py
 
+- name: spec_decode_dspark
+  optional: false
+  base: spec_decode_base
+  source_file_dependencies:
+    - vllm_ascend/spec_decode/dspark_proposer.py
+  tests:
+    - tests/e2e/pull_request/one_card/spec_decode/test_dspark.py
+
 - name: spec_decode_extract_hidden_states
   optional: false
   base: spec_decode_base
@@ -696,6 +704,7 @@ estimated_times:
   tests/e2e/pull_request/one_card/pooling/test_embedding.py: 510
   tests/e2e/pull_request/one_card/pooling/test_scoring.py: 670
   tests/e2e/pull_request/one_card/spec_decode/test_dflash.py: 350
+  tests/e2e/pull_request/one_card/spec_decode/test_dspark.py: 150
   tests/e2e/pull_request/one_card/spec_decode/test_draft_parallel.py: 230
   tests/e2e/pull_request/one_card/spec_decode/test_eagle.py: 470
   tests/e2e/pull_request/one_card/spec_decode/test_extract_hidden_states.py: 360

--- a/tests/e2e/pull_request/one_card/spec_decode/test_dspark.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/test_dspark.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import pytest
+from transformers import AutoTokenizer
+from vllm import SamplingParams
+from vllm.config import CompilationConfig
+from vllm.v1.metrics.reader import Counter, Vector
+
+from tests.e2e.conftest import VllmRunner
+from tests.e2e.pull_request.one_card.spec_decode.utils import BASELINES, DSPARK, calculate_acceptance_per_pos
+from vllm_ascend.utils import vllm_version_is
+
+pytestmark = pytest.mark.skipif(
+    vllm_version_is("0.23.0"),
+    reason="The community has not yet incorporated the dspark feature in 0.23.0",
+)
+
+
+@pytest.mark.parametrize("method", DSPARK.keys())
+@pytest.mark.parametrize("num_speculative_tokens", [7])
+def test_dspark_acceptance(
+    method: str,
+    num_speculative_tokens: int,
+):
+    main_model_name = DSPARK[method]["main"]
+    spec_model_name = DSPARK[method]["spec"]
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        main_model_name,
+        trust_remote_code=True,
+    )
+    sampling_params = SamplingParams(
+        temperature=0,
+        ignore_eos=False,
+        max_tokens=256,
+    )
+
+    prompts = [{"role": "user", "content": "Hello, your name is"}]
+    prompts = [
+        tokenizer.apply_chat_template(
+            [prompt],
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=False,
+        )
+        for prompt in prompts
+    ]
+
+    speculative_config = {
+        "method": "dspark",
+        "model": spec_model_name,
+        "num_speculative_tokens": num_speculative_tokens,
+    }
+
+    compilation_config = CompilationConfig(cudagraph_mode="PIECEWISE", cudagraph_capture_sizes=[7, 8])
+
+    with VllmRunner(
+        main_model_name,
+        max_model_len=4096,
+        disable_log_stats=False,
+        tensor_parallel_size=1,
+        max_num_seqs=256,
+        distributed_executor_backend="mp",
+        gpu_memory_utilization=0.8,
+        speculative_config=speculative_config,
+        compilation_config=compilation_config,
+        enable_prefix_caching=False,
+    ) as llm:
+        outputs = llm.model.generate(prompts, sampling_params)
+        metrics = llm.model.get_metrics()
+
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        output_tokens = output.outputs[0].token_ids
+        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+        print(f"Output tokens: {output_tokens}")
+
+    acceptance_per_pos = calculate_acceptance_per_pos(metrics, num_speculative_tokens, Counter, Vector)
+    golden = BASELINES[method]
+
+    match = all(abs(a - b) < 0.1 for a, b in zip(acceptance_per_pos, golden))
+    if not match:
+        print(f"acceptance_per_pos: {acceptance_per_pos}")
+        print(f"golden: {golden}")
+
+    assert match

--- a/tests/e2e/pull_request/one_card/spec_decode/utils.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/utils.py
@@ -26,11 +26,19 @@ DFLASH = {
     }
 }
 
+DSPARK = {
+    "dspark": {
+        "main": "Qwen/Qwen3-8B",
+        "spec": "deepseek-ai/dspark_qwen3_8b_block7",
+    }
+}
+
 BASELINES = {
     "eagle": [0.74, 0.44, 0.29],
     "eagle3": [0.68, 0.40, 0.18],
     "draft_parallel": [0.83, 0.50, 0.33, 0.17, 0.17, 0.17, 0.17, 0.00],
     "dflash": [0.60, 0.50, 0.30, 0.20, 0.20, 0.10, 0.00, 0.00],
+    "dspark": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.75],
 }
 
 

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -66,7 +66,7 @@ def prepare_inputs_padded_kernel(
 
 
 @triton.jit
-def copy_and_expand_dflash_inputs_kernel_single_grid(
+def copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid(
     # Inputs
     next_token_ids_ptr,  # [num_reqs]
     target_positions_ptr,  # [num_context]
@@ -93,6 +93,7 @@ def copy_and_expand_dflash_inputs_kernel_single_grid(
     total_input_tokens,  # tl.int32
     batch_size,  # tl.int32
     HAS_NUM_REJECTED: tl.constexpr = False,
+    SAMPLE_FROM_ANCHOR: tl.constexpr = False,
 ):
     for req_idx in range(0, batch_size):
         ctx_start = tl.load(query_start_loc_ptr + req_idx)
@@ -136,5 +137,10 @@ def copy_and_expand_dflash_inputs_kernel_single_grid(
             else:
                 tl.store(out_input_ids_ptr + query_out_idx, parallel_drafting_token_id)
 
-                sample_out_idx = req_idx * num_speculative_tokens + (q_idx - 1)
+            if SAMPLE_FROM_ANCHOR:
+                sample_out_idx = req_idx * num_speculative_tokens + q_idx
                 tl.store(out_token_indices_ptr + sample_out_idx, query_out_idx)
+            else:
+                if q_idx > 0:
+                    sample_out_idx = req_idx * num_speculative_tokens + (q_idx - 1)
+                    tl.store(out_token_indices_ptr + sample_out_idx, query_out_idx)

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -1138,3 +1138,21 @@
 #       runner and can rely on upstream's default enablement heuristics
 #       (model architecture, Triton, feature checks) without crashes or
 #       degraded functionality.
+#
+# ** 31. File: worker/patch_qwen3_dspark.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.v1.spec_decode.llm_base_proposer.SpecDecodeBaseProposer`
+#    Why:
+#       The config.json of the open-source dspark contains two types of
+#       "mask_token_id" with different variable names and indentation.
+#       Currently, the vllm community has only added support for deepseek,
+#       but not for the qwen/glm series. In model_runner_v1, since the
+#       initialization of vllm/eagle_proposer is performed first, followed
+#       by the initialization of vllm-ascend/llm_base_proposer, this
+#       modification cannot be implemented in vllm-ascend/llm_base_proposer.
+#    How:
+#       Override the `SpecDecodeBaseProposer._init_parallel_drafting_params`
+#       method and add the reading of the `dspark config.json` for `qwen/glm`
+#    Future Plan:
+#       Remove this patch once vllm-ascend fully supports the v2 model
+#       runner.

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -48,6 +48,7 @@ import vllm_ascend.patch.worker.patch_qwen3_next_mtp  # noqa
 if not is_310p():
     import vllm_ascend.patch.worker.patch_qwen3_5  # noqa
     import vllm_ascend.patch.worker.patch_qwen3_dflash  # noqa
+    import vllm_ascend.patch.worker.patch_qwen3_dspark  # noqa
     import vllm_ascend.patch.worker.patch_qwen3vl  # noqa
 else:
     import vllm_ascend.patch.worker.patch_idex_310  # noqa

--- a/vllm_ascend/patch/worker/patch_qwen3_dspark.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_dspark.py
@@ -1,0 +1,15 @@
+from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
+
+ori_init_parallel_drafting_params = SpecDecodeBaseProposer._init_parallel_drafting_params
+
+
+def new_init_parallel_drafting_params(self):
+    spec_config = self.vllm_config.speculative_config
+    model_hf_config = self.draft_model_config.hf_config
+    if spec_config.method == "dspark" and hasattr(model_hf_config, "mask_token_id"):
+        self.parallel_drafting_token_id = model_hf_config.mask_token_id
+    else:
+        ori_init_parallel_drafting_params(self)
+
+
+SpecDecodeBaseProposer._init_parallel_drafting_params = new_init_parallel_drafting_params

--- a/vllm_ascend/spec_decode/__init__.py
+++ b/vllm_ascend/spec_decode/__init__.py
@@ -20,6 +20,7 @@
 
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
+from vllm_ascend.spec_decode.dspark_proposer import AscendDsparkProposer
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
 from vllm_ascend.spec_decode.extract_hidden_states_proposer import (
     AscendExtractHiddenStatesProposer,
@@ -47,6 +48,8 @@ def get_spec_decode_method(method, vllm_config, device, runner):
         return AscendEagleProposer(vllm_config, device, runner)
     elif method == "dflash":
         return AscendDflashProposer(vllm_config, device, runner)
+    elif method == "dspark":
+        return AscendDsparkProposer(vllm_config, device, runner)
     elif method == "draft_model":
         return AscendDraftModelProposer(vllm_config, device, runner)
     elif method == "extract_hidden_states":

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -2,17 +2,15 @@ from typing import Any
 
 import torch
 from vllm.config import CUDAGraphMode, VllmConfig
-from vllm.forward_context import get_forward_context
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
+from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid
-from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
+from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 
 
-class AscendDflashProposer(AscendEagleProposer):
+class AscendDsparkProposer(AscendDflashProposer):
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -25,40 +23,10 @@ class AscendDflashProposer(AscendEagleProposer):
             runner=runner,
         )
 
-        self.max_query_tokens = self.max_batch_size * (1 + self.num_speculative_tokens)
-        self.max_positions = self.max_num_tokens + self.max_query_tokens
-
-        self._context_slot_mapping_buffer = torch.zeros(
-            self.max_num_tokens,
-            dtype=torch.int32,
-            device=device,
-        )
-
-        self._slot_mapping_buffer = torch.zeros(
-            self.max_query_tokens,
-            dtype=torch.int32,
-            device=device,
-        )
-
-        self._context_positions_buffer = torch.zeros(
-            self.max_num_tokens,
-            dtype=torch.int32,
-            device=device,
-        )
-
-        self.positions = torch.zeros(
-            self.max_query_tokens,
-            dtype=torch.int32,
-            device=device,
-        )
-
-        self.arange_dflash = torch.arange(self.max_positions + 1, device=device, dtype=torch.int32)
-
-        self._dflash_hidden_states = torch.zeros(
-            (self.max_num_tokens, self.hidden_size), dtype=self.dtype, device=self.device
-        )
-
-        self.parallel_drafting_hidden_state_tensor = None
+        # Initialize and establish static address for graph mode
+        blk = 1 + self.num_speculative_tokens
+        self._dspark_seed_buffer = torch.zeros(self.max_batch_size, dtype=torch.int64, device=device)
+        self._dspark_draft_buffer = torch.zeros((self.max_batch_size, blk), dtype=torch.int64, device=device)
 
     def set_inputs_first_pass(
         self,
@@ -74,15 +42,25 @@ class AscendDflashProposer(AscendEagleProposer):
         num_prefill_reqs=0,
         num_decode_reqs=0,
     ) -> tuple[int, torch.Tensor, CommonAttentionMetadata, tuple[Any, Any] | None]:
-        # DFlash cross-attention: context K/V from target hidden states,
-        # Q from query embeddings (bonus + mask tokens).
+        # Dspark cross-attention: context K/V from target hidden states,
+        # Q from query embeddings (next token + mask tokens).
+
         batch_size = cad.num_reqs
-        num_context = target_token_ids.shape[0]
-        num_query_per_req = 1 + self.num_speculative_tokens
+
+        # Query length of a single request and the whole batch
+        num_query_per_req = self.num_speculative_tokens
         num_query_total = batch_size * num_query_per_req
 
+        # Newly added hidden_states, need to convert to KV Cache
+        num_context = target_token_ids.shape[0]
         self._dflash_num_context = num_context
         self._dflash_hidden_states[:num_context] = target_hidden_states
+
+        # The initial input token of markovHead is the next token
+        n = next_token_ids.shape[0]
+        self._dspark_seed_buffer[:n].copy_(next_token_ids)
+        if n < self._dspark_seed_buffer.shape[0]:
+            self._dspark_seed_buffer[n:].fill_(0)
 
         token_indices_to_sample = torch.empty(
             batch_size * self.num_speculative_tokens,
@@ -92,6 +70,7 @@ class AscendDflashProposer(AscendEagleProposer):
 
         has_num_rejected = num_rejected_tokens_gpu is not None
 
+        # Remove the rejected token to avoid polluting cross-attention
         copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid[1,](
             # Inputs
             next_token_ids_ptr=next_token_ids,
@@ -119,8 +98,10 @@ class AscendDflashProposer(AscendEagleProposer):
             total_input_tokens=num_context,
             batch_size=batch_size,
             HAS_NUM_REJECTED=has_num_rejected,
+            SAMPLE_FROM_ANCHOR=True,
         )
 
+        # Build attn_metadata
         query_slot_mapping = self._slot_mapping_buffer[:num_query_total]
         new_query_start_loc = self.arange_dflash[: batch_size + 1] * num_query_per_req
 
@@ -161,7 +142,12 @@ class AscendDflashProposer(AscendEagleProposer):
         is_profile=False,
         **kwargs,
     ) -> None:
-        num_query_tokens = min(num_tokens, self.max_query_tokens)
+        # Run dummy_run at full load: the query length of each request is self.num_speculative_tokens
+        # Unlike DFlash, where the query length is self.num_speculative_tokens + 1.
+        # Ensure that the maximum batch token is within the limit of self.max_query_tokens.
+        num_query_per_req = self.num_speculative_tokens
+        num_query_total = num_reqs * num_query_per_req
+        num_query_tokens = min(num_query_total if num_reqs > 0 else num_tokens, self.max_query_tokens)
 
         (
             num_input_tokens,
@@ -171,51 +157,14 @@ class AscendDflashProposer(AscendEagleProposer):
 
         if not self.use_cuda_graph:
             aclgraph_runtime_mode = CUDAGraphMode.NONE
-        num_query_per_req = 1 + self.num_speculative_tokens
-        num_query_total = num_reqs * num_query_per_req
 
         context_positions = self._context_positions_buffer[:num_input_tokens]
         context_states = self.hidden_states[:num_input_tokens]
 
-        multi_steps_attn_metadata = []
-        if aclgraph_runtime_mode == CUDAGraphMode.FULL and len(self.runner.attn_groups) > 0:
-            builder = self.draft_attn_groups[0].get_metadata_builder()
-            common_attn_metadata = AscendCommonAttentionMetadata(
-                query_start_loc=self.arange_dflash[: num_reqs + 1] * num_query_per_req,
-                query_start_loc_cpu=torch.from_numpy(self.token_arange_np[: num_reqs + 1]).clone() * num_query_per_req,
-                seq_lens_cpu=self.runner.optimistic_seq_lens_cpu,
-                seq_lens_cpu_upper_bound=self.runner.optimistic_seq_lens_cpu,
-                seq_lens=self.runner.seq_lens[:num_reqs],
-                num_reqs=num_reqs,
-                num_actual_tokens=num_query_tokens,
-                max_query_len=num_query_per_req,
-                max_seq_len=0,
-                slot_mapping=self._slot_mapping_buffer[:num_query_total],
-                attn_state=AscendAttentionState.ChunkedPrefill,
-                causal=False,
-                is_prefilling=torch.zeros(num_reqs, dtype=torch.bool),
-                block_table_tensor=self.runner.input_batch.block_table[self.kv_cache_gid].get_device_tensor()[
-                    :num_reqs
-                ],
-            )
-
-            attn_metadata_dflash = builder.build_for_graph_capture(
-                common_attn_metadata,
-                AscendAttentionState.ChunkedPrefill,
-            )
-
-            attn_metadata_dflash.attn_mask = None
-            attn_metadata_dflash.attn_state = AscendAttentionState.ChunkedPrefill
-
-            per_layer_attn_metadata = dict()
-            for layer_name in self.attn_layer_names:
-                per_layer_attn_metadata[layer_name] = attn_metadata_dflash
-            multi_steps_attn_metadata.append(per_layer_attn_metadata)
-
         self.token_indices_to_sample.fill_(0)
 
         with set_ascend_forward_context(
-            multi_steps_attn_metadata[0] if multi_steps_attn_metadata else None,
+            None,
             self.vllm_config,
             num_tokens=num_input_tokens,
             num_tokens_across_dp=num_tokens_across_dp,
@@ -224,7 +173,7 @@ class AscendDflashProposer(AscendEagleProposer):
             batch_descriptor=batch_descriptor,
             aclgraph_runtime_mode=aclgraph_runtime_mode,
             is_draft_model=True,
-            draft_attn_metadatas=multi_steps_attn_metadata,
+            draft_attn_metadatas=[],
         ):
             if is_profile:
                 self.model.precompute_and_store_context_kv(context_states, context_positions)
@@ -242,29 +191,6 @@ class AscendDflashProposer(AscendEagleProposer):
                     token_indices_to_sample=self.token_indices_to_sample[: num_reqs * self.num_speculative_tokens],
                     target_positions=self._get_positions(num_input_tokens),
                     inputs_embeds=None,
-                    multi_steps_attn_metadata=multi_steps_attn_metadata,
+                    multi_steps_attn_metadata=[],
                     num_tokens=num_input_tokens,
                 )
-
-            forward_context = get_forward_context()
-            if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing:
-                self._update_full_graph_params(forward_context, num_tokens, multi_steps_attn_metadata)
-
-    def build_model_inputs_first_pass(
-        self,
-        num_input_tokens: int,
-    ) -> dict[str, Any]:
-        num_context = self._dflash_num_context
-
-        self.model.precompute_and_store_context_kv(
-            self._dflash_hidden_states[:num_context],
-            self._context_positions_buffer[:num_context],
-            self._context_slot_mapping_buffer[:num_context],
-        )
-
-        return dict(
-            input_ids=self.input_ids[:num_input_tokens], positions=self.positions[:num_input_tokens], inputs_embeds=None
-        )
-
-    def _raise_if_multimodal(self):
-        pass

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -55,7 +55,12 @@ from vllm_ascend.distributed.parallel_state import get_lmhead_tp_group
 from vllm_ascend.models.llama_eagle3_vwn import Eagle3VwnLlamaForCausalLM
 from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
-from vllm_ascend.utils import enable_sp, lmhead_tp_enable, shared_expert_dp_enabled
+from vllm_ascend.utils import enable_sp, lmhead_tp_enable, shared_expert_dp_enabled, vllm_version_is
+
+if not vllm_version_is("0.23.0"):
+    from vllm.model_executor.models.qwen3_dspark import Qwen3DSparkForCausalLM
+else:
+    Qwen3DSparkForCausalLM = None
 
 
 @contextmanager
@@ -760,12 +765,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         if token_indices_to_sample is None:
             token_indices_to_sample = common_attn_metadata.query_start_loc[1:] - 1
 
-        if self.method in ("eagle3", "dflash"):
+        if self.method in ("eagle3", "dflash", "dspark"):
             assert isinstance(
                 self.get_model(),
                 (
                     Eagle3LlamaForCausalLM,
                     DFlashQwen3ForCausalLM,
+                    Qwen3DSparkForCausalLM,
                     Eagle3VwnLlamaForCausalLM,
                     Eagle3DeepseekV2ForCausalLM,
                 ),
@@ -1082,7 +1088,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         return draft_token_ids
 
     def compute_draft_token_ids(self, hidden_states: torch.Tensor):
-        if self.method in ("eagle3", "dflash"):
+        if self.method in ("eagle3", "dflash", "dspark"):
             logits = self.model.logits_processor(self.model.lm_head, hidden_states)
             if not hasattr(self.model, "draft_id_to_target_id") or self.model.draft_id_to_target_id is None:
                 return greedy_sample(logits)
@@ -1113,7 +1119,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         model_input_ids = self.input_ids[:num_input_tokens]
         model_positions = self._get_positions(num_input_tokens)
 
-        if self.method == "dflash":
+        if self.method == "dflash" or self.method == "dspark":
             model_kwargs = self.build_model_inputs_first_pass(num_input_tokens)
         else:
             model_kwargs = {
@@ -1224,21 +1230,39 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     )
                 draft_token_ids = logits.argmax(dim=-1)
         else:
-            logits = self.model.compute_logits(sample_hidden_states)
-            if lmhead_tp_enable():
-                logits, token_indices_to_sample = self._align_tensor_and_indices(
-                    logits,
-                    num_indices,
-                    token_indices_to_sample,
-                    ori_token_indices_to_sample,
-                    is_logits=True,
-                )
-            draft_token_ids = logits.argmax(dim=-1)
+            if self.method == "dspark":
+                # Dspark speculation requires autoregressive applications of MarkovHead and ConfidenceHead.
+                # The MarkovHead performs bias correction on logits.
+                # The ConfidenceHead predicts the expected acceptance length of tokens(Not yet achieved).
+                raw_logits = self.model.compute_logits(last_hidden_states)
+                logits = raw_logits.view(-1, self.num_speculative_tokens, raw_logits.shape[-1])
+                num_blk = logits.shape[0]
+                draft_token_ids = self._dspark_draft_buffer[:num_blk]
+                draft_token_ids[:, 0].copy_(self._dspark_seed_buffer[:num_blk])
+                for idx in range(self.num_speculative_tokens):
+                    markov_emb = self.model.markov_embed(draft_token_ids[:, idx])
+                    logits_bias = self.model.markov_bias(markov_emb)
+                    logits[:, idx].add_(logits_bias)
+                    draft_token_ids[:, idx + 1].copy_(logits[:, idx].argmax(dim=-1))
+            else:
+                logits = self.model.compute_logits(sample_hidden_states)
+                if lmhead_tp_enable():
+                    logits, token_indices_to_sample = self._align_tensor_and_indices(
+                        logits,
+                        num_indices,
+                        token_indices_to_sample,
+                        ori_token_indices_to_sample,
+                        is_logits=True,
+                    )
+                draft_token_ids = logits.argmax(dim=-1)
 
         # Early exit if there is only one draft token to be generated.
         if self.num_speculative_tokens == 1 or self.parallel_drafting:
-            # [batch_size, 1]
-            return draft_token_ids.view(-1, self.num_speculative_tokens)
+            if self.method == "dspark":
+                return draft_token_ids[:, 1:]
+            else:
+                # [batch_size, 1]
+                return draft_token_ids.view(-1, self.num_speculative_tokens)
 
         if self.pcp_size * self.dcp_size > 1 and is_prefill:
             draft_token_ids_list = []
@@ -1360,7 +1384,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
             sample_hidden_states = last_hidden_states[token_indices_to_sample]
             if get_ascend_config().enable_reduce_sample:
-                if self.method in ("eagle3", "dflash", "mtp"):
+                if self.method in ("eagle3", "dflash", "dspark", "mtp"):
                     draft_token_ids = self.compute_draft_token_ids(sample_hidden_states)
                     if lmhead_tp_enable() and num_indices < draft_token_ids.shape[0]:
                         draft_token_ids = draft_token_ids[:num_indices]
@@ -1616,7 +1640,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             hf_config = getattr(draft_model_config, "hf_config", None)
             architectures = getattr(hf_config, "architectures", []) or []
             return "DeepSeekMTPModel" in architectures
-        return self.method not in ("mtp", "draft_model", "dflash")
+        return self.method not in ("mtp", "draft_model", "dflash", "dspark")
 
     def attn_update_stack_num_spec_norm(
         self,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -133,6 +133,7 @@ from vllm_ascend.sample.sampler import AscendSampler
 from vllm_ascend.spec_decode import get_spec_decode_method
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
+from vllm_ascend.spec_decode.dspark_proposer import AscendDsparkProposer
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
 from vllm_ascend.spec_decode.extract_hidden_states_proposer import (
     AscendExtractHiddenStatesProposer,
@@ -483,6 +484,9 @@ class NPUModelRunner(GPUModelRunner):
             if vllm_config.speculative_config
             else None
         )
+        if not vllm_version_is("0.23.0"):
+            if vllm_config.speculative_config and vllm_config.speculative_config.use_dspark():
+                self.use_aux_hidden_state_outputs = True
         # When True, run update_full_graph_params before self.model (ENPU / graph capture order).
         # Internal / non-public toggle: read C getenv ``ENPU_ENABLE`` from enpu code (not in envs.py).
         _enpu = get_c_env("ENPU_ENABLE")
@@ -631,6 +635,7 @@ class NPUModelRunner(GPUModelRunner):
             | AscendStep3p5MTPProposer
             | AscendDraftModelProposer
             | AscendDflashProposer
+            | AscendDsparkProposer
             | AscendSuffixDecodingProposer
             | AscendMedusaProposer
             | AscendExtractHiddenStatesProposer
@@ -3434,7 +3439,8 @@ class NPUModelRunner(GPUModelRunner):
                 self.drafter.set_per_group_attn_metadata(
                     kv_cache_gid, cm.block_table_tensor, cm.slot_mapping)
             if self.speculative_config and spec_decode_common_attn_metadata is None:
-                if isinstance(self.drafter, AscendEagleProposer | AscendDraftModelProposer | AscendDflashProposer):
+                if isinstance(self.drafter, AscendEagleProposer | AscendDraftModelProposer | AscendDflashProposer 
+                    | AscendDsparkProposer):
                     if self.drafter.attn_layer_names[0] in kv_cache_group.layer_names:
                         spec_decode_common_attn_metadata = cm
                 else:
@@ -3954,6 +3960,19 @@ class NPUModelRunner(GPUModelRunner):
             load_model_total_time,
         )
 
+    def _get_eagle3_aux_layers_from_config(self) -> tuple[int, ...] | None:
+        # add additional logic for dspark-config
+        if not (self.speculative_config and self.speculative_config.draft_model_config):
+            return None
+        hf_config = self.speculative_config.draft_model_config.hf_config
+        if hasattr(hf_config, 'target_layer_ids'):
+            layer_ids = [
+                i for i in (hf_config.target_layer_ids or [])
+            ]
+            if layer_ids and isinstance(layer_ids, (list, tuple)):
+                return tuple(layer_ids)
+        return super()._get_eagle3_aux_layers_from_config()
+
     def _start_dump_data(self) -> None:
         if self.debugger is None or self._debugger_started:
             return
@@ -4003,7 +4022,7 @@ class NPUModelRunner(GPUModelRunner):
         ):
             assert isinstance(
                 self.drafter,
-                AscendEagleProposer | AscendDflashProposer | AscendDraftModelProposer,
+                AscendEagleProposer | AscendDflashProposer | AscendDsparkProposer | AscendDraftModelProposer,
             )
             block_size = (self.kernel_block_sizes[0] if isinstance(
                 self.kernel_block_sizes, list) else self.kernel_block_sizes)


### PR DESCRIPTION
This PR comes from PR-[11153 ](https://github.com/vllm-project/vllm-ascend/pull/11153), and is based on the latest vllm community for main2main refactoring. The old PR will be closed.
### What this PR does / why we need it?
add Qwen/GLM DSpark speculation method for morel_runner_v1.
**Performance Test**
The first 100 requests from gsm8k dataset, num_speculative_tokens=7, temperature=0 and without topk/topp, output_len=2048

| Model | Spec Method | Acc Length | Acc Rate per Position | Requests per Second | Accuracy |
|-----|-----|-----|-----|-----|-----|
| Qwen3-8B | DFlash | 4.73 | [0.85, 0.71, 0.59, 0.50, 0.42, 0.36, 0.30] | 4.73 | 0.85 |
| Qwen3-8B | **Dspark** | 6.30 | [0.94, 0.87, 0.81, 0.74, 0.69, 0.63, 0.59] | 6.62 | 0.85 |

### Does this PR introduce _any_ user-facing change?
Inherited from dflash_proposer and created dspark_proposer.

### How was this patch tested?
Version Compatibility: Use the vLLM version or commit after July 3.

--speculative-config '{"num_speculative_tokens": K,"method":"dspark","model":"drafter_path"}'
--compilation-config '{"cudagraph_capture_sizes":[bs * K, bs * (K+1)],"cudagraph_mode": "PIECEWISE"}'

Support EAGER or PIECEWISE 

### Next Plan
Through confidenceHead, we can achieve dynamic speculation. However, currently: we have already obtained algorithmic gains, and after applying confidenceHead, the acceptance length has increased by approximately 0.x, but performance has degraded.
We are investigating the reasons (algorithms/framework/operators, etc.).

### Other Things   
- DSpark has two parallel modules: the Qwen/GLM series use DFlash, while the Deepseek series use a modified MTP. This PR only targets the former and serves model_runner_v1.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
