### PR TITLE
[Feature] add PD dfx for releases0.23.0

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -60,6 +60,7 @@ from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_dfx import (
     MooncakeDFXEvent,
     MooncakeDFXRecord,
     MooncakeFailureReason,
+    MooncakePDState,
     is_mooncake_transfer_dfx_enabled,
     mooncake_transfer_dfx,
 )
@@ -184,11 +185,23 @@ class KVCacheTaskTracker:
 
     def add_req_to_process(self, request_id: str):
         self.reqs_to_process.add(request_id)
+        mooncake_transfer_dfx.update_state(
+            request_id,
+            MooncakePDState.SCHEDULED,
+            role="kv_transfer",
+            details={"tracker": "add_req_to_process"},
+        )
 
     def add_not_transfer_request(self, request_id: str):
         with self.done_task_lock:
             self.finished_requests.add(request_id)
             self.reqs_to_process.discard(request_id)
+        mooncake_transfer_dfx.update_state(
+            request_id,
+            MooncakePDState.FINISHED,
+            role="kv_producer",
+            details={"tracker": "add_not_transfer_request"},
+        )
 
     def update_done_task_count(self, request_id: str):
         with self.done_task_lock:
@@ -196,6 +209,12 @@ class KVCacheTaskTracker:
                 self.finished_requests.add(request_id)
                 self.reqs_to_process.discard(request_id)
                 self.delayed_free_requests.pop(request_id, None)
+                mooncake_transfer_dfx.update_state(
+                    request_id,
+                    MooncakePDState.FINISHED,
+                    role="kv_transfer",
+                    details={"tracker": "update_done_task_count"},
+                )
             else:
                 logger.warning(
                     "MooncakeConnector finish req not in reqs to process. "
@@ -223,6 +242,12 @@ class KVCacheTaskTracker:
         with self.done_task_lock:
             if request_id in self.reqs_to_process:
                 self.delayed_free_requests[request_id] = delay_start_time
+                mooncake_transfer_dfx.update_state(
+                    request_id,
+                    MooncakePDState.DELAYED_FREE,
+                    role="kv_producer",
+                    details={"delay_start_time": delay_start_time},
+                )
 
     def _retrieve_expired_requests(self):
         """Retrieve all expired delayed requests."""
@@ -243,6 +268,7 @@ class KVCacheTaskTracker:
                     request_id,
                     envs.VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT,
                 )
+                mooncake_transfer_dfx.update_state(request_id, MooncakePDState.FORCE_FREED, role="kv_producer")
             else:
                 break
         return expired_requests
@@ -364,6 +390,12 @@ class KVCacheSendingThread(threading.Thread):
 
                 msg = decoder.decode(payload[0])
                 if msg[0] == GET_META_MSG:
+                    mooncake_transfer_dfx.dump_metadata(
+                        label="send_agent_metadata",
+                        metadata=self.metadata,
+                        role="kv_producer",
+                        extra={"encoded_size_bytes": size_in_bytes},
+                    )
                     sock.send_multipart((identity, b"", encoded_data))
                 elif msg[0] == GET_KV_CACHE_CHECKSUM_MSG:
                     checksum_request = msg[1]
@@ -413,6 +445,12 @@ class KVCacheSendingThread(threading.Thread):
                     logger.debug("Got DONE_RECVING_MSG for request %s", msg[1])
                     request_id = msg[1]
                     remote_port_send_num = msg[2]
+                    mooncake_transfer_dfx.update_state(
+                        request_id,
+                        MooncakePDState.REMOTE_RELEASED,
+                        role="kv_producer",
+                        details={"remote_port_send_num": remote_port_send_num},
+                    )
                     if remote_port_send_num:
                         if request_id not in self.port_send_num:
                             self.port_send_num[request_id] = 0
@@ -429,6 +467,14 @@ class KVCacheSendingThread(threading.Thread):
                         try:
                             # Send ACK to the sender.
                             sock.send_multipart((identity, b"", b"ACK"), flags=zmq.NOBLOCK)  # type: ignore
+                            mooncake_transfer_dfx.record(
+                                MooncakeDFXRecord(
+                                    event=MooncakeDFXEvent.LIFECYCLE,
+                                    request_id=request_id,
+                                    role="kv_producer",
+                                    details={"message": "done_recving_ack_sent"},
+                                )
+                            )
                             break
                         except zmq.Again:  # type: ignore
                             # If the socket is not ready, retry sending.
@@ -437,12 +483,20 @@ class KVCacheSendingThread(threading.Thread):
                 else:
                     logger.error(
                         "Connection listener received unexpected message type. "
-                        "Expected: GET_META_MSG, GET_KV_CACHE_CHECKSUM_MSG or DONE_RECVING_MSG. "
+                        "Expected: GET_META_MSG or DONE_RECVING_MSG. "
                         "Actual: %s. "
                         "Full message: %s. "
                         "Check: Verify message protocol implementation.",
                         msg[0] if msg else "empty",
                         msg,
+                    )
+                    mooncake_transfer_dfx.record(
+                        MooncakeDFXRecord(
+                            event=MooncakeDFXEvent.FAILURE,
+                            role="kv_producer",
+                            reason=MooncakeFailureReason.UNEXPECTED_MESSAGE.value,
+                            details={"message": msg},
+                        )
                     )
             except Exception as e:
                 logger.error(
@@ -614,6 +668,29 @@ class KVCacheRecvingThread(threading.Thread):
             "remote_block_size": remote_block_size,
         }
         logger.debug("Adding request %s to the queue.Trans info:%s", request_id, trans_info)
+        flat_local_block_ids = [block_id for group_block_ids in local_block_ids for block_id in group_block_ids]
+        flat_remote_block_ids = [block_id for group_block_ids in remote_block_ids for block_id in group_block_ids]
+        mooncake_transfer_dfx.validate_block_mapping(
+            request_id=request_id,
+            remote_request_id=remote_request_id,
+            role="kv_consumer",
+            local_block_ids=flat_local_block_ids,
+            remote_block_ids=flat_remote_block_ids,
+        )
+        mooncake_transfer_dfx.update_state(
+            request_id,
+            MooncakePDState.RECV_QUEUED,
+            remote_request_id=remote_request_id,
+            role="kv_consumer",
+            details={
+                "remote_engine_id": remote_engine_id,
+                "remote_host": remote_host,
+                "remote_handshake_port": remote_handshake_port,
+                "num_computed_tokens": num_computed_tokens,
+                "group_pulls": [pull.__dict__ for pull in group_pulls],
+                "all_task_done": all_task_done,
+            },
+        )
         self.request_queue.put(trans_info)
 
     def get_and_clear_finished_requests(self) -> set[str]:
@@ -740,6 +817,16 @@ class KVCacheRecvingThread(threading.Thread):
             if transfer_failed:
                 self._mark_failed_recv_request(request_id, req_meta["local_block_ids"])
                 logger.warning("Skipping KV cache transfer for request. remote_request_id=%s. ", remote_request_id)
+                mooncake_transfer_dfx.record(
+                    MooncakeDFXRecord(
+                        event=MooncakeDFXEvent.FAILURE,
+                        request_id=request_id,
+                        remote_request_id=remote_request_id,
+                        role="kv_consumer",
+                        reason=MooncakeFailureReason.TRANSFER_ENGINE_ERROR.value,
+                        details={"message": "skip_after_previous_transfer_failure"},
+                    )
+                )
             else:
                 try:
                     logger.debug("Starting to transfer KV cache for request %s.", remote_request_id)
@@ -749,6 +836,13 @@ class KVCacheRecvingThread(threading.Thread):
                     transfer_failed = True
                     self._mark_failed_recv_request(request_id, req_meta["local_block_ids"])
                     logger.exception("Failed to transfer KV cache for request %s: %s", remote_request_id, e)
+                    mooncake_transfer_dfx.update_state(
+                        request_id,
+                        MooncakePDState.TRANSFER_FAILED,
+                        remote_request_id=remote_request_id,
+                        role="kv_consumer",
+                        details={"error": str(e)},
+                    )
         finally:
             if self._mark_request_task_done(request_id, all_task_done):
                 self.task_tracker.update_done_task_count(request_id)
@@ -958,6 +1052,19 @@ class KVCacheRecvingThread(threading.Thread):
             dst_list,
             length_list,
         )
+        mooncake_transfer_dfx.record_transfer_plan(
+            request_id=req_meta["request_id"],
+            remote_request_id=remote_request_id,
+            session_id=session_id,
+            src_list=src_list,
+            dst_list=dst_list,
+            length_list=length_list,
+            role="kv_consumer",
+            extra={
+                "num_checksum_groups": len(checksum_transfer_groups),
+                "num_local_blocks": num_local_blocks,
+            },
+        )
         source_checksum_infos: dict[int, dict[str, Any] | None] = {}
         for checksum_group_idx, checksum_group in enumerate(checksum_transfer_groups):
             source_checksum_infos[checksum_group_idx] = self._get_remote_kv_cache_checksum(
@@ -973,14 +1080,31 @@ class KVCacheRecvingThread(threading.Thread):
                     "inner_offset": checksum_group["inner_offset"],
                 },
             )
-        ret = self.engine.batch_transfer_sync_read(session_id, src_list, dst_list, length_list)
-        if ret < 0:
-            logger.error(
-                "Mooncake transfer failed for request. remote_request_id=%s, ret=%d. ",
-                req_meta["remote_request_id"],
-                ret,
-            )
-            raise RuntimeError(f"Mooncake transfer failed, ret: {ret}")
+        with mooncake_transfer_dfx.transfer_span(
+            request_id=req_meta["request_id"],
+            remote_request_id=remote_request_id,
+            session_id=session_id,
+            role="kv_consumer",
+            details={"transfer_count": len(length_list), "num_local_blocks": num_local_blocks},
+        ):
+            ret = self.engine.batch_transfer_sync_read(session_id, src_list, dst_list, length_list)
+            if ret < 0:
+                logger.error(
+                    "Mooncake transfer failed for request. remote_request_id=%s, ret=%d. ",
+                    req_meta["remote_request_id"],
+                    ret,
+                )
+                mooncake_transfer_dfx.record(
+                    MooncakeDFXRecord(
+                        event=MooncakeDFXEvent.FAILURE,
+                        request_id=req_meta["request_id"],
+                        remote_request_id=remote_request_id,
+                        role="kv_consumer",
+                        reason=MooncakeFailureReason.TRANSFER_ENGINE_ERROR.value,
+                        details={"ret": ret, "session_id": session_id},
+                    )
+                )
+                raise RuntimeError(f"Mooncake transfer failed, ret: {ret}")
 
         for checksum_group_idx, checksum_group in enumerate(checksum_transfer_groups):
             group_kv_caches = self._get_group_kv_caches(
@@ -1438,6 +1562,13 @@ class KVCacheRecvingThread(threading.Thread):
             ensure_zmq_send(sock, self.encoder.encode((GET_META_MSG, "")), f"{remote_host}:{remote_handshake_port}")
             metadata_bytes = ensure_zmq_recv(sock, f"{remote_host}:{remote_handshake_port}")
             agent_meta = self.decoder.decode(metadata_bytes)
+            mooncake_transfer_dfx.validate_agent_metadata(metadata=agent_meta, role="kv_consumer")
+            mooncake_transfer_dfx.dump_metadata(
+                label="recv_agent_metadata",
+                metadata=agent_meta,
+                role="kv_consumer",
+                extra={"remote_host": remote_host, "remote_handshake_port": remote_handshake_port},
+            )
             engine_id = agent_meta.engine_id
             assert engine_id != self.local_engine_id, (
                 f"Conflict engine id {engine_id} with local engine id {self.local_engine_id}."
@@ -1454,6 +1585,18 @@ class KVCacheRecvingThread(threading.Thread):
                 self.remote_te_port[engine_id][remote_handshake_port] = agent_meta.te_rpc_port
                 self.remote_block_size_scale[engine_id][remote_handshake_port] = agent_meta.block_size_scale
                 self.remote_block_stride_per_addr[engine_id][remote_handshake_port] = agent_meta.block_strides
+            mooncake_transfer_dfx.record(
+                MooncakeDFXRecord(
+                    event=MooncakeDFXEvent.LIFECYCLE,
+                    role="kv_consumer",
+                    state=MooncakePDState.METADATA_RECEIVED,
+                    details={
+                        "engine_id": engine_id,
+                        "remote_host": remote_host,
+                        "remote_handshake_port": remote_handshake_port,
+                    },
+                )
+            )
         except Exception:
             if isinstance(sock, zmq.Socket):  # type: ignore
                 sock.close()
@@ -1480,7 +1623,7 @@ class KVCacheRecvingThread(threading.Thread):
             sock = self._get_remote_socket(remote_host, remote_handshake_port)
             data = self.encoder.encode((GET_KV_CACHE_CHECKSUM_MSG, checksum_request))
             ensure_zmq_send(sock, data, f"{remote_host}:{remote_handshake_port}")
-            checksum_bytes = ensure_zmq_recv(sock, f"{remote_host}:{remote_handshake_port}")
+            checksum_bytes = ensure_zmq_recv(sock, self.remote_poller, f"{remote_host}:{remote_handshake_port}")
             checksum_response = msgspec.msgpack.decode(checksum_bytes)
             checksum = checksum_response.get("checksum") if isinstance(checksum_response, dict) else checksum_response
             samples = checksum_response.get("samples", []) if isinstance(checksum_response, dict) else []
@@ -1544,6 +1687,12 @@ class KVCacheRecvingThread(threading.Thread):
         logger.debug(
             "Sending done recving signal for request %s to %s:%d", request_id, remote_host, remote_handshake_port
         )
+        mooncake_transfer_dfx.update_state(
+            request_id,
+            MooncakePDState.DONE_RECVING_SENT,
+            role="kv_consumer",
+            details={"remote_host": remote_host, "remote_handshake_port": remote_handshake_port},
+        )
         sock: zmq.Socket | None = None  # type: ignore
         try:
             sock = self._get_remote_socket(remote_host, remote_handshake_port)
@@ -1559,12 +1708,36 @@ class KVCacheRecvingThread(threading.Thread):
                     remote_host,
                     remote_handshake_port,
                 )
+                mooncake_transfer_dfx.record(
+                    MooncakeDFXRecord(
+                        event=MooncakeDFXEvent.FAILURE,
+                        request_id=request_id,
+                        role="kv_consumer",
+                        reason=MooncakeFailureReason.SOCKET_ERROR.value,
+                        details={"response": resp.decode("utf-8", errors="replace")},
+                    )
+                )
                 raise RuntimeError(f"Failed to receive ACK, resp: {resp.decode('utf-8')}")
+            mooncake_transfer_dfx.update_state(
+                request_id,
+                MooncakePDState.DONE_RECVING_ACKED,
+                role="kv_consumer",
+                details={"remote_host": remote_host, "remote_handshake_port": remote_handshake_port},
+            )
         except RuntimeError as e:
             if isinstance(sock, zmq.Socket):  # type: ignore
                 sock.close()
                 sock = None
                 logger.warning("Unexpected error occurred in socket. error=%s. ", e)
+                mooncake_transfer_dfx.record(
+                    MooncakeDFXRecord(
+                        event=MooncakeDFXEvent.FAILURE,
+                        request_id=request_id,
+                        role="kv_consumer",
+                        reason=MooncakeFailureReason.SOCKET_ERROR.value,
+                        details={"error": str(e)},
+                    )
+                )
         finally:
             if sock is not None:
                 self._return_remote_socket(sock, remote_host, remote_handshake_port)
@@ -1634,6 +1807,19 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
             remote_multi_nodes_meta_mapping=kv_transfer_params.get("remote_multi_nodes_meta_mapping", {}),
             num_prompt_blocks=kv_transfer_params.get("num_prompt_blocks", 0),
             remote_block_size=kv_transfer_params.get("remote_block_size", 0),
+        )
+        mooncake_transfer_dfx.update_state(
+            request_id,
+            MooncakePDState.RECV_QUEUED,
+            remote_request_id=kv_transfer_params["remote_request_id"],
+            role="kv_consumer",
+            details={
+                "num_external_tokens": num_external_tokens,
+                "num_computed_tokens": kv_transfer_params.get("num_computed_tokens", 0),
+                "remote_engine_id": kv_transfer_params["remote_engine_id"],
+                "remote_host": kv_transfer_params["remote_host"],
+                "remote_port": kv_transfer_params["remote_port"],
+            },
         )
 
 
@@ -1940,6 +2126,18 @@ class MooncakeConnectorScheduler:
             actual = self._state_prefill_token_count(len(token_ids))
             params["num_computed_tokens"] = num_computed_tokens
             count = max(actual - num_computed_tokens, 0)
+            mooncake_transfer_dfx.update_state(
+                request.request_id,
+                MooncakePDState.SCHEDULED,
+                remote_request_id=params.get("remote_request_id"),
+                role="kv_consumer",
+                details={
+                    "num_computed_tokens": num_computed_tokens,
+                    "num_external_tokens": count,
+                    "prompt_tokens": actual,
+                    "async_load": count > 0,
+                },
+            )
             if count > 0:
                 return count, True
 
@@ -1964,6 +2162,20 @@ class MooncakeConnectorScheduler:
                 if all(p in params for p in ("remote_engine_id", "remote_host", "remote_port", "remote_request_id")):
                     local_block_ids = blocks.get_unhashed_block_ids_all_groups() if num_external_tokens > 0 else []
                     # Get unhashed blocks to pull from remote.
+                    if num_external_tokens > 0:
+                        mooncake_transfer_dfx.validate_block_mapping(
+                            request_id=request.request_id,
+                            remote_request_id=params["remote_request_id"],
+                            role="kv_consumer",
+                            local_block_ids=[
+                                block_id for group_block_ids in local_block_ids for block_id in group_block_ids
+                            ],
+                            remote_block_ids=[
+                                block_id
+                                for group_block_ids in params["remote_block_ids"]
+                                for block_id in group_block_ids
+                            ],
+                        )
                     self._reqs_need_recv[request.request_id] = (request, local_block_ids, num_external_tokens)
                 else:
                     logger.warning("Got invalid KVTransferParams. params=%s. ", params)
@@ -2030,6 +2242,16 @@ class MooncakeConnectorScheduler:
         if delay_free_blocks:
             logger.info("Delaying free of %d blocks for request %s", sum(computed_block_lens), request.request_id)
             self._reqs_need_send[request.request_id] = time.time()
+        mooncake_transfer_dfx.update_state(
+            request.request_id,
+            MooncakePDState.PREFILL_FINISHED,
+            role="kv_producer",
+            details={
+                "delay_free_blocks": delay_free_blocks,
+                "computed_block_lens": computed_block_lens,
+                "status": str(request.status),
+            },
+        )
 
         return delay_free_blocks, dict(
             do_remote_prefill=True,
@@ -2513,6 +2735,20 @@ class MooncakeConnectorWorker:
             handshake_port=self.handshake_port,
         )
         self.xfer_handshake_metadata = metadata
+        mooncake_transfer_dfx.validate_agent_metadata(
+            metadata=metadata,
+            role=self.kv_role,
+        )
+        mooncake_transfer_dfx.dump_metadata(
+            label="register_kv_caches",
+            metadata=metadata,
+            role=self.kv_role,
+            extra={
+                "registered_ptr_count": len(register_regions.ptrs),
+                "registered_total_bytes": sum(register_regions.lengths),
+                "has_mamba_group": has_mamba_group,
+            },
+        )
 
         ready_event = threading.Event()
         if self.kv_role == "kv_producer":
@@ -3380,6 +3616,18 @@ class MooncakeConnectorWorker:
 
     def start_load_kv(self, metadata: MooncakeConnectorMetadata):
         """Start loading KV blocks from remote engine."""
+        mooncake_transfer_dfx.record(
+            MooncakeDFXRecord(
+                event=MooncakeDFXEvent.LIFECYCLE,
+                role=self.kv_role,
+                details={
+                    "message": "start_load_kv",
+                    "requests": list(metadata.requests),
+                    "requests_to_send": list(metadata.requests_to_send),
+                    "reqs_in_batch": list(metadata.reqs_in_batch),
+                },
+            )
+        )
         for req_id in metadata.reqs_in_batch:
             if self.kv_send_thread is not None:
                 self.kv_send_thread.task_tracker.add_req_to_process(req_id)

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -56,6 +56,13 @@ from vllm.v1.request import RequestStatus
 
 from vllm_ascend import envs as ascend_envs
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
+from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_dfx import (
+    MooncakeDFXEvent,
+    MooncakeDFXRecord,
+    MooncakeFailureReason,
+    is_mooncake_transfer_dfx_enabled,
+    mooncake_transfer_dfx,
+)
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
 from vllm_ascend.distributed.kv_transfer.utils.utils import (
     RegisterRegions,
@@ -79,6 +86,7 @@ if TYPE_CHECKING:
 
 GET_META_MSG = b"get_meta_msg"
 DONE_RECVING_MSG = b"done_recving_msg"
+GET_KV_CACHE_CHECKSUM_MSG = b"get_kv_cache_checksum_msg"
 
 
 # A busy peer can otherwise keep a global executor worker forever when the
@@ -357,6 +365,50 @@ class KVCacheSendingThread(threading.Thread):
                 msg = decoder.decode(payload[0])
                 if msg[0] == GET_META_MSG:
                     sock.send_multipart((identity, b"", encoded_data))
+                elif msg[0] == GET_KV_CACHE_CHECKSUM_MSG:
+                    checksum_request = msg[1]
+                    request_id = checksum_request.get("request_id")
+                    remote_request_id = checksum_request.get("remote_request_id")
+                    layer_names = checksum_request.get("layer_names", [])
+                    selected_kv_caches = {
+                        layer_name: self.kv_caches[layer_name]
+                        for layer_name in layer_names
+                        if layer_name in self.kv_caches
+                    }
+                    try:
+                        checksum = mooncake_transfer_dfx.compute_kv_cache_checksum(
+                            kv_caches=selected_kv_caches,
+                            block_groups=checksum_request["block_groups"],
+                            tp_num_need_pulls=checksum_request["tp_num_need_pulls"],
+                            inner_offset=checksum_request["inner_offset"],
+                            block_lens=[],
+                        )
+                        samples = mooncake_transfer_dfx.sample_kv_cache_blocks(
+                            kv_caches=selected_kv_caches,
+                            block_groups=checksum_request["block_groups"],
+                            tp_num_need_pulls=checksum_request["tp_num_need_pulls"],
+                            inner_offset=checksum_request["inner_offset"],
+                            block_lens=[],
+                        )
+                    except Exception as err:
+                        logger.exception(
+                            "Failed to compute Mooncake source KV checksum for request %s: %s",
+                            remote_request_id,
+                            err,
+                        )
+                        checksum = {"error": str(err)}
+                        samples = []
+                        mooncake_transfer_dfx.record(
+                            MooncakeDFXRecord(
+                                event=MooncakeDFXEvent.FAILURE,
+                                request_id=request_id,
+                                remote_request_id=remote_request_id,
+                                role="kv_producer",
+                                reason=MooncakeFailureReason.KV_CONTENT_CHECKSUM_ERROR.value,
+                                details={"error": str(err), "layer_names": layer_names},
+                            )
+                        )
+                    sock.send_multipart((identity, b"", encoder.encode({"checksum": checksum, "samples": samples})))
                 elif msg[0] == DONE_RECVING_MSG:
                     logger.debug("Got DONE_RECVING_MSG for request %s", msg[1])
                     request_id = msg[1]
@@ -385,7 +437,7 @@ class KVCacheSendingThread(threading.Thread):
                 else:
                     logger.error(
                         "Connection listener received unexpected message type. "
-                        "Expected: GET_META_MSG or DONE_RECVING_MSG. "
+                        "Expected: GET_META_MSG, GET_KV_CACHE_CHECKSUM_MSG or DONE_RECVING_MSG. "
                         "Actual: %s. "
                         "Full message: %s. "
                         "Check: Verify message protocol implementation.",
@@ -762,6 +814,7 @@ class KVCacheRecvingThread(threading.Thread):
         dst_list: list[int] = []
         length_list: list[int] = []
         attention_group_reformat_block_ids: list[tuple[tuple[int, list[list[int]], int, list[int]], bool]] = []
+        checksum_transfer_groups: list[dict[str, Any]] = []
 
         def pp_layer_indices(layer_indices: list[int], prefill_pp_rank: int) -> list[int]:
             first_layer_index, end_layer_index = self.pp_layer_indices[prefill_pp_rank]
@@ -803,6 +856,19 @@ class KVCacheRecvingThread(threading.Thread):
                         is_group_transfer_end,
                     )
                 )
+                if is_mooncake_transfer_dfx_enabled():
+                    group_kv_caches = self._get_group_kv_caches(group_idx, layer_indices)
+                    checksum_transfer_groups.append(
+                        {
+                            "group_idx": group_idx,
+                            "layer_indices": layer_indices,
+                            "layer_names": list(group_kv_caches.keys()),
+                            "grouped_local_block_ids": grouped_local_block_ids,
+                            "grouped_remote_block_ids": grouped_remote_block_ids,
+                            "tp_num_need_pulls": tp_num_need_pulls,
+                            "inner_offset": inner_offset,
+                        }
+                    )
             else:
                 # When Prefix Caching is enabled on both P and D nodes, num_block should not be forced to match,
                 # as the D-node requires dynamic allocation based on its specific cache hit rate.
@@ -892,6 +958,21 @@ class KVCacheRecvingThread(threading.Thread):
             dst_list,
             length_list,
         )
+        source_checksum_infos: dict[int, dict[str, Any] | None] = {}
+        for checksum_group_idx, checksum_group in enumerate(checksum_transfer_groups):
+            source_checksum_infos[checksum_group_idx] = self._get_remote_kv_cache_checksum(
+                remote_host,
+                remote_handshake_port,
+                {
+                    "request_id": req_meta["request_id"],
+                    "remote_request_id": remote_request_id,
+                    "group_idx": checksum_group["group_idx"],
+                    "layer_names": checksum_group["layer_names"],
+                    "block_groups": checksum_group["grouped_remote_block_ids"],
+                    "tp_num_need_pulls": checksum_group["tp_num_need_pulls"],
+                    "inner_offset": checksum_group["inner_offset"],
+                },
+            )
         ret = self.engine.batch_transfer_sync_read(session_id, src_list, dst_list, length_list)
         if ret < 0:
             logger.error(
@@ -900,6 +981,90 @@ class KVCacheRecvingThread(threading.Thread):
                 ret,
             )
             raise RuntimeError(f"Mooncake transfer failed, ret: {ret}")
+
+        for checksum_group_idx, checksum_group in enumerate(checksum_transfer_groups):
+            group_kv_caches = self._get_group_kv_caches(
+                checksum_group["group_idx"],
+                checksum_group["layer_indices"],
+            )
+            source_checksum_info = source_checksum_infos.get(checksum_group_idx)
+            source_checksum = source_checksum_info.get("checksum") if source_checksum_info is not None else None
+            source_samples = source_checksum_info.get("samples", []) if source_checksum_info is not None else []
+            try:
+                target_checksum = mooncake_transfer_dfx.compute_kv_cache_checksum(
+                    kv_caches=group_kv_caches,
+                    block_groups=checksum_group["grouped_local_block_ids"],
+                    tp_num_need_pulls=checksum_group["tp_num_need_pulls"],
+                    inner_offset=checksum_group["inner_offset"],
+                    block_lens=[],
+                )
+            except Exception as err:
+                logger.exception(
+                    "Failed to compute Mooncake target KV checksum for request %s group %s: %s",
+                    remote_request_id,
+                    checksum_group["group_idx"],
+                    err,
+                )
+                target_checksum = {"error": str(err)}
+                mooncake_transfer_dfx.record(
+                    MooncakeDFXRecord(
+                        event=MooncakeDFXEvent.FAILURE,
+                        request_id=req_meta["request_id"],
+                        remote_request_id=remote_request_id,
+                        role="kv_consumer",
+                        reason=MooncakeFailureReason.KV_CONTENT_CHECKSUM_ERROR.value,
+                        details={"error": str(err), "group_idx": checksum_group["group_idx"]},
+                    )
+                )
+            checksum_match = (
+                source_checksum is not None
+                and target_checksum is not None
+                and source_checksum.get("algorithm") == target_checksum.get("algorithm")
+                and source_checksum.get("digest") == target_checksum.get("digest")
+                and source_checksum.get("bytes") == target_checksum.get("bytes")
+                and source_checksum.get("segments") == target_checksum.get("segments")
+            )
+            target_samples = []
+            if not checksum_match:
+                try:
+                    target_samples = mooncake_transfer_dfx.sample_kv_cache_blocks(
+                        kv_caches=group_kv_caches,
+                        block_groups=checksum_group["grouped_local_block_ids"],
+                        tp_num_need_pulls=checksum_group["tp_num_need_pulls"],
+                        inner_offset=checksum_group["inner_offset"],
+                        block_lens=[],
+                    )
+                except Exception as err:
+                    logger.exception(
+                        "Failed to sample Mooncake target KV cache for request %s group %s: %s",
+                        remote_request_id,
+                        checksum_group["group_idx"],
+                        err,
+                    )
+                    mooncake_transfer_dfx.record(
+                        MooncakeDFXRecord(
+                            event=MooncakeDFXEvent.FAILURE,
+                            request_id=req_meta["request_id"],
+                            remote_request_id=remote_request_id,
+                            role="kv_consumer",
+                            reason=MooncakeFailureReason.KV_CONTENT_CHECKSUM_ERROR.value,
+                            details={
+                                "error": str(err),
+                                "group_idx": checksum_group["group_idx"],
+                                "phase": "target_sample",
+                            },
+                        )
+                    )
+            mooncake_transfer_dfx.record_kv_content_check(
+                request_id=req_meta["request_id"],
+                remote_request_id=remote_request_id,
+                role="kv_consumer",
+                source_checksum=source_checksum,
+                target_checksum=target_checksum,
+                source_samples=source_samples,
+                target_samples=target_samples,
+                extra={"session_id": session_id, "group_idx": checksum_group["group_idx"]},
+            )
 
         req_end_time = time.perf_counter()
         req_transfer_elapsed = (req_end_time - req_start_time) * 1000
@@ -1298,6 +1463,76 @@ class KVCacheRecvingThread(threading.Thread):
             if sock is not None:
                 self._return_remote_socket(sock, remote_host, remote_handshake_port)
                 logger.debug("Returned socket to pool for %s:%d", remote_host, remote_handshake_port)
+
+    def _get_remote_kv_cache_checksum(
+        self,
+        remote_host: str,
+        remote_handshake_port: int,
+        checksum_request: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        if not is_mooncake_transfer_dfx_enabled():
+            return None
+
+        sock: zmq.Socket | None = None  # type: ignore
+        request_id = checksum_request.get("request_id")
+        remote_request_id = checksum_request.get("remote_request_id")
+        try:
+            sock = self._get_remote_socket(remote_host, remote_handshake_port)
+            data = self.encoder.encode((GET_KV_CACHE_CHECKSUM_MSG, checksum_request))
+            ensure_zmq_send(sock, data, f"{remote_host}:{remote_handshake_port}")
+            checksum_bytes = ensure_zmq_recv(sock, f"{remote_host}:{remote_handshake_port}")
+            checksum_response = msgspec.msgpack.decode(checksum_bytes)
+            checksum = checksum_response.get("checksum") if isinstance(checksum_response, dict) else checksum_response
+            samples = checksum_response.get("samples", []) if isinstance(checksum_response, dict) else []
+            if isinstance(checksum, dict) and "error" not in checksum:
+                mooncake_transfer_dfx.record(
+                    MooncakeDFXRecord(
+                        event=MooncakeDFXEvent.KV_CONTENT_CHECK,
+                        request_id=request_id,
+                        remote_request_id=remote_request_id,
+                        role="kv_consumer",
+                        details={
+                            "phase": "source_checksum_received",
+                            "source_checksum": checksum,
+                            "source_sample_count": len(samples),
+                            "group_idx": checksum_request.get("group_idx"),
+                        },
+                    )
+                )
+                return {"checksum": checksum, "samples": samples}
+            mooncake_transfer_dfx.record(
+                MooncakeDFXRecord(
+                    event=MooncakeDFXEvent.FAILURE,
+                    request_id=request_id,
+                    remote_request_id=remote_request_id,
+                    role="kv_consumer",
+                    reason=MooncakeFailureReason.KV_CONTENT_CHECKSUM_ERROR.value,
+                    details={"checksum_response": checksum_response},
+                )
+            )
+        except Exception as err:
+            logger.warning(
+                "Failed to get Mooncake source KV checksum for request %s from %s:%d: %s",
+                remote_request_id,
+                remote_host,
+                remote_handshake_port,
+                err,
+            )
+            mooncake_transfer_dfx.record(
+                MooncakeDFXRecord(
+                    event=MooncakeDFXEvent.FAILURE,
+                    request_id=request_id,
+                    remote_request_id=remote_request_id,
+                    role="kv_consumer",
+                    reason=MooncakeFailureReason.KV_CONTENT_CHECKSUM_ERROR.value,
+                    details={"error": str(err), "group_idx": checksum_request.get("group_idx")},
+                )
+            )
+        finally:
+            if sock is not None:
+                self._return_remote_socket(sock, remote_host, remote_handshake_port)
+                logger.debug("Returned socket to pool for %s:%d", remote_host, remote_handshake_port)
+        return None
 
     def _send_done_recv_signal(
         self,

--- a/vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_dfx.py
+++ b/vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_dfx.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import contextlib
 import hashlib
 import json
-from collections.abc import Mapping, Sequence
+import threading
+import time
+from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any
@@ -13,17 +16,47 @@ from vllm.logger import logger
 from vllm_ascend import envs as ascend_envs
 
 MAX_DUMP_ITEMS = 16
+MAX_STATE_HISTORY = 32
 MAX_KV_SAMPLE_BLOCKS = 2
 MAX_KV_SAMPLE_TENSORS = 4
 MAX_KV_SAMPLE_VALUES = 16
 
 
 class MooncakeDFXEvent(str, Enum):
+    STATE_TRANSITION = "state_transition"
+    METADATA_DUMP = "metadata_dump"
+    CONSISTENCY_CHECK = "consistency_check"
+    TRANSFER_PLAN = "transfer_plan"
+    TRANSFER_RESULT = "transfer_result"
     KV_CONTENT_CHECK = "kv_content_check"
+    LIFECYCLE = "lifecycle"
     FAILURE = "failure"
 
 
+class MooncakePDState(str, Enum):
+    SCHEDULED = "scheduled"
+    PREFILL_FINISHED = "prefill_finished"
+    DELAYED_FREE = "delayed_free"
+    FORCE_FREED = "force_freed"
+    RECV_QUEUED = "recv_queued"
+    METADATA_REQUESTED = "metadata_requested"
+    METADATA_RECEIVED = "metadata_received"
+    TRANSFER_STARTED = "transfer_started"
+    TRANSFER_SUCCEEDED = "transfer_succeeded"
+    TRANSFER_FAILED = "transfer_failed"
+    DONE_RECVING_SENT = "done_recving_sent"
+    DONE_RECVING_ACKED = "done_recving_acked"
+    REMOTE_RELEASED = "remote_released"
+    FINISHED = "finished"
+
+
 class MooncakeFailureReason(str, Enum):
+    METADATA_MISSING = "metadata_missing"
+    BLOCK_MISMATCH = "block_mismatch"
+    TRANSFER_ENGINE_ERROR = "transfer_engine_error"
+    SOCKET_ERROR = "socket_error"
+    INVALID_METADATA = "invalid_metadata"
+    UNEXPECTED_MESSAGE = "unexpected_message"
     KV_CONTENT_MISMATCH = "kv_content_mismatch"
     KV_CONTENT_CHECKSUM_ERROR = "kv_content_checksum_error"
 
@@ -34,8 +67,17 @@ class MooncakeDFXRecord:
     request_id: str | None = None
     remote_request_id: str | None = None
     role: str | None = None
+    state: MooncakePDState | None = None
+    previous_state: MooncakePDState | None = None
     reason: str | None = None
+    elapsed_ms: float | None = None
     details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RequestStateHistory:
+    current_state: MooncakePDState | None = None
+    transitions: list[tuple[float, MooncakePDState]] = field(default_factory=list)
 
 
 def is_mooncake_transfer_dfx_enabled() -> bool:
@@ -60,6 +102,8 @@ def _sanitize_for_dump(value: Any) -> Any:
         return _shorten_sequence(value)
     if isinstance(value, set):
         return _shorten_sequence(sorted(value, key=str))
+    if hasattr(value, "__dict__"):
+        return _sanitize_for_dump(vars(value))
     return value
 
 
@@ -69,6 +113,10 @@ def _record_to_dict(record: MooncakeDFXRecord) -> dict[str, Any]:
 
 
 class MooncakeTransferDFX:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._request_states: dict[str, RequestStateHistory] = {}
+
     def record(self, record: MooncakeDFXRecord) -> None:
         if not is_mooncake_transfer_dfx_enabled():
             return
@@ -76,6 +124,219 @@ class MooncakeTransferDFX:
             logger.info("[MooncakeTransferDFX] %s", json.dumps(_record_to_dict(record), sort_keys=True, default=str))
         except Exception as err:
             logger.debug("Failed to emit Mooncake transfer DFX record: %s", err)
+
+    def update_state(
+        self,
+        request_id: str,
+        state: MooncakePDState,
+        *,
+        remote_request_id: str | None = None,
+        role: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        if not is_mooncake_transfer_dfx_enabled():
+            return
+        with self._lock:
+            history = self._request_states.setdefault(request_id, RequestStateHistory())
+            previous_state = history.current_state
+            history.current_state = state
+            history.transitions.append((time.time(), state))
+            if len(history.transitions) > MAX_STATE_HISTORY:
+                history.transitions = history.transitions[-MAX_STATE_HISTORY:]
+
+        self.record(
+            MooncakeDFXRecord(
+                event=MooncakeDFXEvent.STATE_TRANSITION,
+                request_id=request_id,
+                remote_request_id=remote_request_id,
+                role=role,
+                state=state,
+                previous_state=previous_state,
+                details=details or {},
+            )
+        )
+
+    def dump_metadata(
+        self,
+        *,
+        label: str,
+        request_id: str | None = None,
+        remote_request_id: str | None = None,
+        metadata: Any,
+        role: str | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        if not is_mooncake_transfer_dfx_enabled():
+            return
+        details = {"label": label, "metadata": _sanitize_for_dump(metadata)}
+        if extra:
+            details.update(extra)
+        self.record(
+            MooncakeDFXRecord(
+                event=MooncakeDFXEvent.METADATA_DUMP,
+                request_id=request_id,
+                remote_request_id=remote_request_id,
+                role=role,
+                details=details,
+            )
+        )
+
+    def validate_block_mapping(
+        self,
+        *,
+        request_id: str,
+        local_block_ids: Sequence[Any],
+        remote_block_ids: Sequence[Any],
+        remote_request_id: str | None = None,
+        role: str | None = None,
+        allow_remote_superset: bool = True,
+    ) -> list[str]:
+        if not is_mooncake_transfer_dfx_enabled():
+            return []
+
+        issues: list[str] = []
+        local_count = len(local_block_ids)
+        remote_count = len(remote_block_ids)
+        if local_count < 0 or remote_count < 0:
+            issues.append("negative_block_count")
+        if allow_remote_superset:
+            if local_count > remote_count:
+                issues.append("local_blocks_exceed_remote_blocks")
+        elif local_count != remote_count:
+            issues.append("local_remote_block_count_mismatch")
+        if any(block_id is None for block_id in local_block_ids):
+            issues.append("local_block_id_none")
+        if any(block_id is None for block_id in remote_block_ids):
+            issues.append("remote_block_id_none")
+
+        self.record(
+            MooncakeDFXRecord(
+                event=MooncakeDFXEvent.CONSISTENCY_CHECK,
+                request_id=request_id,
+                remote_request_id=remote_request_id,
+                role=role,
+                reason=",".join(issues) if issues else None,
+                details={
+                    "check": "block_mapping",
+                    "local_block_count": local_count,
+                    "remote_block_count": remote_count,
+                    "passed": not issues,
+                },
+            )
+        )
+        return issues
+
+    def validate_agent_metadata(
+        self,
+        *,
+        metadata: Any,
+        request_id: str | None = None,
+        role: str | None = None,
+    ) -> list[str]:
+        if not is_mooncake_transfer_dfx_enabled():
+            return []
+
+        issues: list[str] = []
+        if not getattr(metadata, "engine_id", None):
+            issues.append("missing_engine_id")
+        if getattr(metadata, "te_rpc_port", None) is None:
+            issues.append("missing_te_rpc_port")
+        base_addrs = getattr(metadata, "kv_caches_base_addr", None)
+        if base_addrs is None:
+            issues.append("missing_kv_caches_base_addr")
+        elif not isinstance(base_addrs, list):
+            issues.append("invalid_kv_caches_base_addr_type")
+        block_lens = getattr(metadata, "block_lens", None)
+        if block_lens is not None and base_addrs is not None and isinstance(base_addrs, list):
+            if len(block_lens) != len(base_addrs):
+                issues.append("block_lens_base_addr_count_mismatch")
+
+        self.record(
+            MooncakeDFXRecord(
+                event=MooncakeDFXEvent.CONSISTENCY_CHECK,
+                request_id=request_id,
+                role=role,
+                reason=",".join(issues) if issues else None,
+                details={"check": "agent_metadata", "passed": not issues},
+            )
+        )
+        return issues
+
+    def validate_kv_cache_registration(
+        self,
+        *,
+        num_blocks: int,
+        block_lens: Sequence[int],
+        base_addrs: Sequence[int],
+        role: str | None = None,
+    ) -> list[str]:
+        if not is_mooncake_transfer_dfx_enabled():
+            return []
+
+        issues: list[str] = []
+        if num_blocks <= 0:
+            issues.append("non_positive_num_blocks")
+        if not block_lens:
+            issues.append("empty_block_lens")
+        if not base_addrs:
+            issues.append("empty_base_addrs")
+        if any(block_len <= 0 for block_len in block_lens):
+            issues.append("non_positive_block_len")
+        if len(set(base_addrs)) != len(base_addrs):
+            issues.append("duplicate_base_addr")
+        if block_lens and base_addrs and len(base_addrs) % len(block_lens) != 0:
+            issues.append("base_addr_count_not_multiple_of_block_lens")
+
+        self.record(
+            MooncakeDFXRecord(
+                event=MooncakeDFXEvent.CONSISTENCY_CHECK,
+                role=role,
+                reason=",".join(issues) if issues else None,
+                details={
+                    "check": "kv_cache_registration",
+                    "num_blocks": num_blocks,
+                    "block_lens": block_lens,
+                    "base_addr_count": len(base_addrs),
+                    "passed": not issues,
+                },
+            )
+        )
+        return issues
+
+    def record_transfer_plan(
+        self,
+        *,
+        request_id: str,
+        remote_request_id: str,
+        session_id: str,
+        src_list: Sequence[int],
+        dst_list: Sequence[int],
+        length_list: Sequence[int],
+        role: str | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        if not is_mooncake_transfer_dfx_enabled():
+            return
+        total_bytes = sum(length_list)
+        details = {
+            "session_id": session_id,
+            "transfer_count": len(length_list),
+            "total_bytes": total_bytes,
+            "src": src_list,
+            "dst": dst_list,
+            "length": length_list,
+        }
+        if extra:
+            details.update(extra)
+        self.record(
+            MooncakeDFXRecord(
+                event=MooncakeDFXEvent.TRANSFER_PLAN,
+                request_id=request_id,
+                remote_request_id=remote_request_id,
+                role=role,
+                details=details,
+            )
+        )
 
     @staticmethod
     def _iter_cache_tensors(kv_caches: Mapping[str, Any]) -> list[Any]:
@@ -285,6 +546,71 @@ class MooncakeTransferDFX:
             )
         )
         return match
+
+    @contextlib.contextmanager
+    def transfer_span(
+        self,
+        *,
+        request_id: str,
+        remote_request_id: str,
+        session_id: str,
+        role: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> Iterator[None]:
+        if not is_mooncake_transfer_dfx_enabled():
+            yield
+            return
+
+        start_time = time.perf_counter()
+        self.update_state(
+            request_id,
+            MooncakePDState.TRANSFER_STARTED,
+            remote_request_id=remote_request_id,
+            role=role,
+            details={"session_id": session_id, **(details or {})},
+        )
+        try:
+            yield
+        except Exception as err:
+            elapsed_ms = (time.perf_counter() - start_time) * 1000
+            self.update_state(
+                request_id,
+                MooncakePDState.TRANSFER_FAILED,
+                remote_request_id=remote_request_id,
+                role=role,
+                details={"session_id": session_id, "error": str(err)},
+            )
+            self.record(
+                MooncakeDFXRecord(
+                    event=MooncakeDFXEvent.FAILURE,
+                    request_id=request_id,
+                    remote_request_id=remote_request_id,
+                    role=role,
+                    reason=MooncakeFailureReason.TRANSFER_ENGINE_ERROR.value,
+                    elapsed_ms=elapsed_ms,
+                    details={"session_id": session_id, "error": str(err)},
+                )
+            )
+            raise
+        else:
+            elapsed_ms = (time.perf_counter() - start_time) * 1000
+            self.update_state(
+                request_id,
+                MooncakePDState.TRANSFER_SUCCEEDED,
+                remote_request_id=remote_request_id,
+                role=role,
+                details={"session_id": session_id, "elapsed_ms": elapsed_ms},
+            )
+            self.record(
+                MooncakeDFXRecord(
+                    event=MooncakeDFXEvent.TRANSFER_RESULT,
+                    request_id=request_id,
+                    remote_request_id=remote_request_id,
+                    role=role,
+                    elapsed_ms=elapsed_ms,
+                    details={"session_id": session_id, "success": True},
+                )
+            )
 
 
 mooncake_transfer_dfx = MooncakeTransferDFX()

--- a/vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_dfx.py
+++ b/vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_dfx.py
@@ -1,0 +1,290 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any
+
+import torch
+from vllm.logger import logger
+
+from vllm_ascend import envs as ascend_envs
+
+MAX_DUMP_ITEMS = 16
+MAX_KV_SAMPLE_BLOCKS = 2
+MAX_KV_SAMPLE_TENSORS = 4
+MAX_KV_SAMPLE_VALUES = 16
+
+
+class MooncakeDFXEvent(str, Enum):
+    KV_CONTENT_CHECK = "kv_content_check"
+    FAILURE = "failure"
+
+
+class MooncakeFailureReason(str, Enum):
+    KV_CONTENT_MISMATCH = "kv_content_mismatch"
+    KV_CONTENT_CHECKSUM_ERROR = "kv_content_checksum_error"
+
+
+@dataclass
+class MooncakeDFXRecord:
+    event: MooncakeDFXEvent
+    request_id: str | None = None
+    remote_request_id: str | None = None
+    role: str | None = None
+    reason: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+def is_mooncake_transfer_dfx_enabled() -> bool:
+    return bool(ascend_envs.VLLM_ASCEND_MOONCAKE_TRANSFER_DFX)
+
+
+def _shorten_sequence(value: Sequence[Any]) -> dict[str, Any]:
+    items = list(value[:MAX_DUMP_ITEMS])
+    return {
+        "len": len(value),
+        "items": [_sanitize_for_dump(item) for item in items],
+        "truncated": len(value) > MAX_DUMP_ITEMS,
+    }
+
+
+def _sanitize_for_dump(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, Mapping):
+        return {str(key): _sanitize_for_dump(item) for key, item in list(value.items())[:MAX_DUMP_ITEMS]}
+    if isinstance(value, (list, tuple)):
+        return _shorten_sequence(value)
+    if isinstance(value, set):
+        return _shorten_sequence(sorted(value, key=str))
+    return value
+
+
+def _record_to_dict(record: MooncakeDFXRecord) -> dict[str, Any]:
+    data = asdict(record)
+    return {key: _sanitize_for_dump(value) for key, value in data.items() if value is not None and value != {}}
+
+
+class MooncakeTransferDFX:
+    def record(self, record: MooncakeDFXRecord) -> None:
+        if not is_mooncake_transfer_dfx_enabled():
+            return
+        try:
+            logger.info("[MooncakeTransferDFX] %s", json.dumps(_record_to_dict(record), sort_keys=True, default=str))
+        except Exception as err:
+            logger.debug("Failed to emit Mooncake transfer DFX record: %s", err)
+
+    @staticmethod
+    def _iter_cache_tensors(kv_caches: Mapping[str, Any]) -> list[Any]:
+        cache_tensors: list[Any] = []
+        for cache_or_caches in kv_caches.values():
+            if hasattr(cache_or_caches, "data_ptr"):
+                cache_tensors.append(cache_or_caches)
+                continue
+            for cache in cache_or_caches:
+                cache_tensors.append(cache)
+        return cache_tensors
+
+    @staticmethod
+    def _block_nbytes(cache: Any) -> int:
+        return int(cache[0].numel() * cache.element_size())
+
+    @staticmethod
+    def _tensor_to_raw_bytes(tensor: Any) -> bytes:
+        return tensor.detach().contiguous().cpu().view(torch.uint8).numpy().tobytes()
+
+    @staticmethod
+    def _normalize_block_groups(block_groups: Sequence[Any]) -> list[list[int]]:
+        normalized_groups: list[list[int]] = []
+        for block_group in block_groups:
+            if isinstance(block_group, (list, tuple)):
+                normalized_groups.append([int(block_id) for block_id in block_group])
+            elif hasattr(block_group, "tolist"):
+                normalized_groups.append([int(block_id) for block_id in block_group.tolist()])
+            else:
+                normalized_groups.append([int(block_group)])
+        return normalized_groups
+
+    def compute_kv_cache_checksum(
+        self,
+        *,
+        kv_caches: Mapping[str, Any],
+        block_groups: Sequence[Any],
+        tp_num_need_pulls: int,
+        inner_offset: int,
+        block_lens: Sequence[int],
+        cache_start: int = 0,
+        cache_end: int | None = None,
+    ) -> dict[str, Any] | None:
+        if not is_mooncake_transfer_dfx_enabled():
+            return None
+
+        if tp_num_need_pulls <= 0:
+            raise ValueError(f"tp_num_need_pulls must be positive, got {tp_num_need_pulls}")
+
+        normalized_groups = self._normalize_block_groups(block_groups)
+        cache_tensors = self._iter_cache_tensors(kv_caches)
+        selected_tensors = cache_tensors[cache_start:cache_end]
+        if not selected_tensors:
+            raise ValueError("no KV cache tensors selected for checksum")
+        digest = hashlib.sha256()
+        total_bytes = 0
+        num_segments = 0
+
+        for absolute_cache_idx, cache in enumerate(selected_tensors, start=cache_start):
+            block_len = (
+                int(block_lens[absolute_cache_idx % len(block_lens)])
+                if block_lens
+                else self._block_nbytes(cache)
+            )
+            inner_block_len = block_len // tp_num_need_pulls
+            byte_start = inner_offset * inner_block_len
+            byte_end = byte_start + inner_block_len
+            for block_group in normalized_groups:
+                for block_id in block_group:
+                    block_bytes = self._tensor_to_raw_bytes(cache[block_id])
+                    segment = block_bytes[byte_start:byte_end]
+                    digest.update(segment)
+                    total_bytes += len(segment)
+                    num_segments += 1
+
+        return {
+            "algorithm": "sha256",
+            "digest": digest.hexdigest(),
+            "bytes": total_bytes,
+            "segments": num_segments,
+            "cache_tensors": len(selected_tensors),
+            "block_groups": len(normalized_groups),
+            "tp_num_need_pulls": tp_num_need_pulls,
+            "inner_offset": inner_offset,
+        }
+
+    def sample_kv_cache_blocks(
+        self,
+        *,
+        kv_caches: Mapping[str, Any],
+        block_groups: Sequence[Any],
+        tp_num_need_pulls: int,
+        inner_offset: int,
+        block_lens: Sequence[int],
+        cache_start: int = 0,
+        cache_end: int | None = None,
+        max_tensors: int = MAX_KV_SAMPLE_TENSORS,
+        max_blocks: int = MAX_KV_SAMPLE_BLOCKS,
+        max_values: int = MAX_KV_SAMPLE_VALUES,
+    ) -> list[dict[str, Any]]:
+        if not is_mooncake_transfer_dfx_enabled():
+            return []
+
+        normalized_groups = self._normalize_block_groups(block_groups)
+        block_ids = [block_id for block_group in normalized_groups for block_id in block_group][:max_blocks]
+        cache_tensors = self._iter_cache_tensors(kv_caches)
+        selected_tensors = cache_tensors[cache_start:cache_end][:max_tensors]
+        samples: list[dict[str, Any]] = []
+
+        for absolute_cache_idx, cache in enumerate(selected_tensors, start=cache_start):
+            block_len = (
+                int(block_lens[absolute_cache_idx % len(block_lens)])
+                if block_lens
+                else self._block_nbytes(cache)
+            )
+            inner_block_len = block_len // tp_num_need_pulls
+            byte_start = inner_offset * inner_block_len
+            byte_end = byte_start + inner_block_len
+            for block_id in block_ids:
+                block_tensor = cache[block_id].detach().contiguous().cpu()
+                block_nbytes = int(block_tensor.numel() * block_tensor.element_size())
+                segment_tensor = block_tensor.reshape(-1)
+                element_size = int(block_tensor.element_size())
+                elem_start = byte_start // element_size
+                elem_end = min(byte_end // element_size, segment_tensor.numel())
+                selected_values = segment_tensor[elem_start:elem_end]
+                try:
+                    sample_values = selected_values[:max_values].tolist()
+                except TypeError:
+                    sample_values = selected_values[:max_values].float().tolist()
+                if hasattr(selected_values, "float") and selected_values.numel() > 0:
+                    selected_float = selected_values.float()
+                    min_value = float(selected_float.min().item())
+                    max_value = float(selected_float.max().item())
+                    mean_value = float(selected_float.mean().item())
+                else:
+                    min_value = max_value = mean_value = None
+                samples.append(
+                    {
+                        "cache_index": absolute_cache_idx,
+                        "block_id": block_id,
+                        "dtype": str(block_tensor.dtype),
+                        "shape": list(block_tensor.shape),
+                        "byte_range": [byte_start, min(byte_end, block_nbytes)],
+                        "element_range": [elem_start, elem_end],
+                        "numel": int(selected_values.numel()),
+                        "values": sample_values,
+                        "min": min_value,
+                        "max": max_value,
+                        "mean": mean_value,
+                    }
+                )
+
+        return samples
+
+    def record_kv_content_check(
+        self,
+        *,
+        request_id: str,
+        remote_request_id: str,
+        source_checksum: Mapping[str, Any] | None,
+        target_checksum: Mapping[str, Any] | None,
+        role: str | None = None,
+        extra: dict[str, Any] | None = None,
+        source_samples: Sequence[Mapping[str, Any]] | None = None,
+        target_samples: Sequence[Mapping[str, Any]] | None = None,
+    ) -> bool:
+        if not is_mooncake_transfer_dfx_enabled():
+            return True
+
+        match = (
+            source_checksum is not None
+            and target_checksum is not None
+            and source_checksum.get("algorithm") == target_checksum.get("algorithm")
+            and source_checksum.get("digest") == target_checksum.get("digest")
+            and source_checksum.get("bytes") == target_checksum.get("bytes")
+            and source_checksum.get("segments") == target_checksum.get("segments")
+        )
+        mismatch_fields = []
+        if source_checksum is None:
+            mismatch_fields.append("source_checksum_missing")
+        if target_checksum is None:
+            mismatch_fields.append("target_checksum_missing")
+        if source_checksum is not None and target_checksum is not None:
+            for field_name in ("algorithm", "digest", "bytes", "segments"):
+                if source_checksum.get(field_name) != target_checksum.get(field_name):
+                    mismatch_fields.append(field_name)
+        details: dict[str, Any] = {
+            "passed": match,
+            "source_checksum": source_checksum,
+            "target_checksum": target_checksum,
+        }
+        if not match:
+            details["mismatch_fields"] = mismatch_fields
+            details["source_samples"] = source_samples or []
+            details["target_samples"] = target_samples or []
+        if extra:
+            details.update(extra)
+        self.record(
+            MooncakeDFXRecord(
+                event=MooncakeDFXEvent.KV_CONTENT_CHECK,
+                request_id=request_id,
+                remote_request_id=remote_request_id,
+                role=role,
+                reason=None if match else MooncakeFailureReason.KV_CONTENT_MISMATCH.value,
+                details=details,
+            )
+        )
+        return match
+
+
+mooncake_transfer_dfx = MooncakeTransferDFX()

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -110,6 +110,11 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
+    # Whether to enable Mooncake KV transfer checksum DFX diagnostics.
+    # 0: disabled by default; 1: enabled. Not sensitive.
+    "VLLM_ASCEND_MOONCAKE_TRANSFER_DFX": lambda: bool(
+        int(os.getenv("VLLM_ASCEND_MOONCAKE_TRANSFER_DFX", "0"))
+    ),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -110,7 +110,7 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
-    # Whether to enable Mooncake KV transfer checksum DFX diagnostics.
+    # Whether to enable Mooncake KV transfer DFX diagnostics.
     # 0: disabled by default; 1: enabled. Not sensitive.
     "VLLM_ASCEND_MOONCAKE_TRANSFER_DFX": lambda: bool(
         int(os.getenv("VLLM_ASCEND_MOONCAKE_TRANSFER_DFX", "0"))


### PR DESCRIPTION
Add a gated Mooncake DFX path that computes source and target KV cache SHA256 checksums around PD transfer, records mismatches with sample values, and keeps the diagnostics disabled by default.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
