### PR TITLE
[BugFix][Worker] Reset slot_mapping to pad id for dummy graph capture

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3655,6 +3655,9 @@ class NPUModelRunner(GPUModelRunner):
                 for_cudagraph_capture=is_graph_capturing,
                 num_scheduled_tokens_np=num_scheduled_tokens,
             )
+            for kv_cache_gid in range(len(self.kv_cache_config.kv_cache_groups)):
+                blk_table = self.input_batch.block_table[kv_cache_gid]
+                blk_table.slot_mapping.gpu.fill_(-1)
 
         with self.maybe_dummy_run_with_lora(
             self.lora_config,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3655,9 +3655,10 @@ class NPUModelRunner(GPUModelRunner):
                 for_cudagraph_capture=is_graph_capturing,
                 num_scheduled_tokens_np=num_scheduled_tokens,
             )
-            for kv_cache_gid in range(len(self.kv_cache_config.kv_cache_groups)):
-                blk_table = self.input_batch.block_table[kv_cache_gid]
-                blk_table.slot_mapping.gpu.fill_(-1)
+            if not is_graph_capturing:
+                for kv_cache_gid in range(len(self.kv_cache_config.kv_cache_groups)):
+                    blk_table = self.input_batch.block_table[kv_cache_gid]
+                    blk_table.slot_mapping.gpu.fill_(-1)
 
         with self.maybe_dummy_run_with_lora(
             self.lora_config,


### PR DESCRIPTION
### What this PR does / why we need it?
Clear stale slot_mapping for all kv cache groups during dummy/graph-capture runs, where slot_mapping is not populated via _prepare_inputs(), to avoid graph capture reading uninitialized values.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
