### PR TITLE
[BugFix][DeepSeek] Restore no-clamp shared expert group index

### DIFF
--- a/vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py
@@ -585,6 +585,11 @@ class AscendFusedMoE(FusedMoE):
                 # Execute activation concurrently with gmm2.
 
                 maybe_wait_event(fused_moe_evts.before_gmm2)
+                clamp_limit = fused_moe_evts.swiglu_limit or 0.0
+                group_index = None
+                if clamp_limit <= 0.0:
+                    group_index = torch.empty((1,), dtype=torch.int64, device=hidden_states.device)
+                    group_index.fill_(hidden_states.shape[0])
                 quantized_x, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
                     x=hidden_states,
                     weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
@@ -592,11 +597,11 @@ class AscendFusedMoE(FusedMoE):
                     bias=None,
                     quant_scale=None,
                     quant_offset=None,
-                    group_index=None,
+                    group_index=group_index,
                     activate_left=True,
                     quant_mode=1,
                     swiglu_mode=1,
-                    clamp_limit=fused_moe_evts.swiglu_limit,
+                    clamp_limit=clamp_limit,
                 )
                 # Execute the down projection concurrently with the combine
                 # communication.


### PR DESCRIPTION
### What this PR does / why we need it?

Backport for `releases/v0.23.0`.

976d576 preserved omitted `group_index` for `npu_dequant_swiglu_quant` so DeepSeek V4 clamp-enabled shared experts stay on the no-group DSK path. DeepSeek R1 configs do not set `swiglu_limit`, so the same Python call site now also enters the no-group path instead of the pre-976d576 effective behavior where the wrapper synthesized `[x.size(0)]`.

This PR restores the synthetic single-group metadata only when the shared-expert SwiGLU clamp limit is disabled. Clamp-enabled paths keep `group_index=None`, preserving the DeepSeek V4 semantics fixed by 976d576.

### Does this PR introduce _any_ user-facing change?

Yes. It restores the DeepSeek R1 W8A8 shared-expert no-clamp accuracy path. There is no API or configuration change.

### How was this patch tested?

- `git diff --check HEAD~1..HEAD`
- `python -m py_compile vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py`
- Manual code-path checks:
  - DeepSeek-R1-0528 W8A8 config has no `swiglu_limit`, so vLLM 0.23 defaults the shared-expert clamp limit to `0` and now synthesizes a single-group index.
  - Checked DeepSeek V4 Pro/Flash configs have `swiglu_limit=10.0`, so they keep `group_index=None` and remain on the post-976d576 no-group clamp path.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
