### PR TITLE
[CI] Test mypy

### DIFF
--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -120,6 +120,12 @@ jobs:
           path: ./vllm-empty
           ref: ${{ steps.vllm.outputs.main_commit }}
 
+      - name: Install vllm-project/vllm from source
+        working-directory: ./vllm-empty
+        run: |
+          VLLM_TARGET_DEVICE=empty pip install .
+          pip uninstall -y triton
+
       - uses: dorny/paths-filter@v4
         id: filter
         with:
@@ -170,12 +176,6 @@ jobs:
           git config --global --add safe.directory /__w/vllm-ascend/vllm-ascend
           pre-commit run --all-files --hook-stage manual --show-diff-on-failure
 
-      - name: Install vllm-project/vllm from source
-        working-directory: ./vllm-empty
-        run: |
-          VLLM_TARGET_DEVICE=empty uv pip install .
-          pip uninstall -y triton
-          
       - name: Run mypy
         run: |
           PYTHONPATH="$PYTHONPATH:$(pwd)/vllm-empty"

--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -170,6 +170,12 @@ jobs:
           git config --global --add safe.directory /__w/vllm-ascend/vllm-ascend
           pre-commit run --all-files --hook-stage manual --show-diff-on-failure
 
+      - name: Install vllm-project/vllm from source
+        working-directory: ./vllm-empty
+        run: |
+          VLLM_TARGET_DEVICE=empty uv pip install .
+          pip uninstall -y triton
+          
       - name: Run mypy
         run: |
           PYTHONPATH="$PYTHONPATH:$(pwd)/vllm-empty"

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -35,7 +35,7 @@ if vllm_version_is("0.23.0"):
     import vllm_ascend.patch.platform.patch_glm47_tool_call_parser  # noqa
     import vllm_ascend.patch.platform.patch_minimax_m2_tool_call_parser  # noqa
     import vllm_ascend.patch.platform.patch_minimax_usage_accounting  # noqa
-import vllm_ascend.patch.platform.patch_deepseek_v4_tool_call_parser  # noqa
+    import vllm_ascend.patch.platform.patch_deepseek_v4_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_weight_transfer_engine  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa
 import vllm_ascend.patch.platform.patch_tool_choice_none_content  # noqa


### PR DESCRIPTION
- Indent `patch_deepseek_v4_tool_call_parser` import into the `vllm_version_is("0.23.0")` guard — upstream main replaced DeepSeekV4ToolParser with DeepSeekV4EngineToolParser, so the patch is only needed on 0.23.0.
- Add `VLLM_TARGET_DEVICE=empty uv pip install .` for vllm-empty in pr_test.yaml (matching _selected_tests.yaml), so mypy can resolve vllm imports.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
