### PR TITLE
[BugFix][Ops] Preserve symbolic shapes in kv quant sparse flash attention meta

### DIFF
--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -366,7 +366,6 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_kv_quant_sparse_flash_attenti
     int64_t rope_head_dim,
     bool return_softmax_lse)
 {
-    constexpr int64_t SIZE = 8;
     constexpr int64_t DIM_0 = 0;
     constexpr int64_t DIM_1 = 1;
     constexpr int64_t DIM_2 = 2;
@@ -378,45 +377,40 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_kv_quant_sparse_flash_attenti
     TORCH_CHECK(layout_query_str == "BSND" || layout_query_str == "TND",
                 "The layout of query only support BSND and TND, but got ",
                 layout_query_str);
-    for (size_t i = 0; i < query.sizes().size(); i++) {
-        TORCH_CHECK(query.size(i) > 0, "All values within query's shape should be greater "
-                                       "than 0, but shape[", i, "] is ", query.size(i));
-    }
-
-    at::SmallVector<int64_t, SIZE> output_size;
+    c10::SymDimVector output_size;
     if (layout_query_str == "BSND") {
         TORCH_CHECK(query.dim() == DIM_4,
                     "When the layout of query is BSND, the query dimension must be 4, but got ",
                     query.dim());
-        output_size = {query.size(DIM_0), query.size(DIM_1), query.size(DIM_2),
-                       query.size(DIM_3) - rope_head_dim};
+        output_size = {query.sym_size(DIM_0), query.sym_size(DIM_1), query.sym_size(DIM_2),
+                       query.sym_size(DIM_3) - c10::SymInt(rope_head_dim)};
     } else {
         TORCH_CHECK(query.dim() == DIM_3,
                     "When the layout of query is TND, the query dimension must be 3, but got ",
                     query.dim());
-        output_size = {query.size(DIM_0), query.size(DIM_1),
-                       query.size(DIM_2) - rope_head_dim};
+        output_size = {query.sym_size(DIM_0), query.sym_size(DIM_1),
+                       query.sym_size(DIM_2) - c10::SymInt(rope_head_dim)};
     }
 
-    at::Tensor output = at::empty(output_size, query.options().dtype(query.dtype()));
-    at::SmallVector<int64_t, SIZE> softmax_size;
+    at::Tensor output = at::empty_symint(output_size, query.options().dtype(query.dtype()));
+    c10::SymDimVector softmax_size;
     if (return_softmax_lse) {
         if (query.dim() == DIM_3) {
-            const int64_t kv_head_dim =
-                layout_kv_str == "PA_BSND" ? key.size(DIM_2) : key.size(DIM_1);
-            softmax_size = {kv_head_dim, query.size(DIM_0),
-                            query.size(DIM_1) / kv_head_dim};
+            const c10::SymInt kv_head_dim =
+                layout_kv_str == "PA_BSND" ? key.sym_size(DIM_2) : key.sym_size(DIM_1);
+            softmax_size = {kv_head_dim, query.sym_size(DIM_0),
+                            query.sym_size(DIM_1) / kv_head_dim};
         } else {
             softmax_size = {
-                query.size(DIM_0), key.size(DIM_2), query.size(DIM_1),
-                query.size(DIM_2) / key.size(DIM_2)};
+                query.sym_size(DIM_0), key.sym_size(DIM_2), query.sym_size(DIM_1),
+                query.sym_size(DIM_2) / key.sym_size(DIM_2)};
         }
     } else {
-        softmax_size = {0};
+        softmax_size = {c10::SymInt(0)};
     }
 
-    at::Tensor softmax_max = at::empty(softmax_size, query.options().dtype(at::kFloat));
-    at::Tensor softmax_sum = at::empty(softmax_size, query.options().dtype(at::kFloat));
+    at::Tensor softmax_max = at::empty_symint(softmax_size, query.options().dtype(at::kFloat));
+    at::Tensor softmax_sum = at::empty_symint(softmax_size, query.options().dtype(at::kFloat));
     return std::tuple<at::Tensor, at::Tensor, at::Tensor>(output, softmax_max, softmax_sum);
 }
 


### PR DESCRIPTION
### What this PR does / why we need it?

Fix the post-merge symbolic-shape CI regression from #11626.

`npu_kv_quant_sparse_flash_attention_meta` used concrete `.size()` values, `SmallVector<int64_t>`, and `at::empty()` for tensor-derived output shapes. This patch preserves symbolic dimensions end-to-end with `sym_size()`, `c10::SymDimVector`, and `at::empty_symint()`, matching the adjacent sparse-flash-attention meta implementation.

The operator kernel and runtime output contract are unchanged.

Root cause: #11626's original CI completed before #11345 added the symbolic-meta check to `main`. #11626 then merged after #11345, so a later full pre-commit run on top of main correctly detected the meta implementation.

### Does this PR introduce _any_ user-facing change?

No. This only fixes meta-dispatch symbolic-shape handling for the existing internal custom op.

### How was this patch tested?

- `python tools/check_symbolic_meta.py csrc/torch_binding_meta.cpp`
- `git diff --check`
- `uvx --from pre-commit==4.0.1 pre-commit run --hook-stage manual --files csrc/torch_binding_meta.cpp`

Also ran the full manual pre-commit suite. All checks relevant to this change passed; the suite still reports pre-existing actionlint findings in unrelated `.github/workflows/` files.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
