### PR TITLE
[BugFix] Fix symbolic shapes in npu_kv_quant_sparse_flash_attention_meta

### DIFF
--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -378,45 +378,45 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_kv_quant_sparse_flash_attenti
     TORCH_CHECK(layout_query_str == "BSND" || layout_query_str == "TND",
                 "The layout of query only support BSND and TND, but got ",
                 layout_query_str);
-    for (size_t i = 0; i < query.sizes().size(); i++) {
-        TORCH_CHECK(query.size(i) > 0, "All values within query's shape should be greater "
-                                       "than 0, but shape[", i, "] is ", query.size(i));
+    for (size_t i = 0; i < static_cast<size_t>(query.dim()); i++) {
+        TORCH_CHECK(query.sym_size(i) > 0, "All values within query's shape should be greater "
+                                       "than 0, but shape[", i, "] is ", query.sym_size(i));
     }
 
-    at::SmallVector<int64_t, SIZE> output_size;
+    c10::SymDimVector output_size;
     if (layout_query_str == "BSND") {
         TORCH_CHECK(query.dim() == DIM_4,
                     "When the layout of query is BSND, the query dimension must be 4, but got ",
                     query.dim());
-        output_size = {query.size(DIM_0), query.size(DIM_1), query.size(DIM_2),
-                       query.size(DIM_3) - rope_head_dim};
+        output_size = {query.sym_size(DIM_0), query.sym_size(DIM_1), query.sym_size(DIM_2),
+                       query.sym_size(DIM_3) - rope_head_dim};
     } else {
         TORCH_CHECK(query.dim() == DIM_3,
                     "When the layout of query is TND, the query dimension must be 3, but got ",
                     query.dim());
-        output_size = {query.size(DIM_0), query.size(DIM_1),
-                       query.size(DIM_2) - rope_head_dim};
+        output_size = {query.sym_size(DIM_0), query.sym_size(DIM_1),
+                       query.sym_size(DIM_2) - rope_head_dim};
     }
 
-    at::Tensor output = at::empty(output_size, query.options().dtype(query.dtype()));
-    at::SmallVector<int64_t, SIZE> softmax_size;
+    at::Tensor output = at::empty_symint(output_size, query.options().dtype(query.dtype()));
+    c10::SymDimVector softmax_size;
     if (return_softmax_lse) {
         if (query.dim() == DIM_3) {
-            const int64_t kv_head_dim =
-                layout_kv_str == "PA_BSND" ? key.size(DIM_2) : key.size(DIM_1);
-            softmax_size = {kv_head_dim, query.size(DIM_0),
-                            query.size(DIM_1) / kv_head_dim};
+            const auto kv_head_dim =
+                layout_kv_str == "PA_BSND" ? key.sym_size(DIM_2) : key.sym_size(DIM_1);
+            softmax_size = {kv_head_dim, query.sym_size(DIM_0),
+                            query.sym_size(DIM_1) / kv_head_dim};
         } else {
             softmax_size = {
-                query.size(DIM_0), key.size(DIM_2), query.size(DIM_1),
-                query.size(DIM_2) / key.size(DIM_2)};
+                query.sym_size(DIM_0), key.sym_size(DIM_2), query.sym_size(DIM_1),
+                query.sym_size(DIM_2) / key.sym_size(DIM_2)};
         }
     } else {
-        softmax_size = {0};
+        softmax_size = {c10::SymInt(0)};
     }
 
-    at::Tensor softmax_max = at::empty(softmax_size, query.options().dtype(at::kFloat));
-    at::Tensor softmax_sum = at::empty(softmax_size, query.options().dtype(at::kFloat));
+    at::Tensor softmax_max = at::empty_symint(softmax_size, query.options().dtype(at::kFloat));
+    at::Tensor softmax_sum = at::empty_symint(softmax_size, query.options().dtype(at::kFloat));
     return std::tuple<at::Tensor, at::Tensor, at::Tensor>(output, softmax_max, softmax_sum);
 }
 


### PR DESCRIPTION

## Description

Fixes the `check-symbolic-meta` pre-commit hook violations in `npu_kv_quant_sparse_flash_attention_meta`.

Fixes #11782

## Changes

- `.size(i)` → `.sym_size(i)` for tensor-derived output dimensions
- `at::SmallVector<int64_t, N>` → `c10::SymDimVector` for shape vectors
- `at::empty()` → `at::empty_symint()` for symbolic shape tensors
- `query.sizes().size()` → `query.dim()` to avoid `.sizes(` pattern in validation loop

## Verification

```
python tools/check_symbolic_meta.py csrc/torch_binding_meta.cpp
# All 14 violations resolved, exit code 0
