### PR TITLE
[Doc] Correct the interpretation of `dflash`

### DIFF
--- a/docs/source/user_guide/feature_guide/speculative_decoding.md
+++ b/docs/source/user_guide/feature_guide/speculative_decoding.md
@@ -19,7 +19,7 @@ The following speculative decoding methods are supported:
 | `eagle` | EAGLE-based draft model |
 | `eagle3` | EAGLE-3 based draft model |
 | `mtp` | Multi-Token Prediction with shared embedding head |
-| `dflash` | Draft-and-Flash with cross-attention |
+| `dflash` | Block diffusion-based parallel draft model |
 | `draft_model` | Generic external draft LLM |
 | `extract_hidden_states` | Extract hidden states for EAGLE training |
 


### PR DESCRIPTION
### What this PR does / why we need it?
Current interpretation of `dflash` is inaccurate.
This pr corrects it.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
