### PR TITLE
[Feature]  Gemma4  E2B and E4B

### DIFF
--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -10,6 +10,7 @@ from vllm_ascend.attention.attention_v1 import (
     AscendAttentionBackendImpl,
     AscendAttentionMetadataBuilder,
     AscendAttentionState,
+    AscendC8AttentionBackendImpl,
 )
 from vllm_ascend.attention.kvcomp_attn.attention_utils import get_kvcomp_decode_params, reshape_and_cache_kvcomp
 from vllm_ascend.attention.utils import (
@@ -289,6 +290,32 @@ class TestAscendAttentionBackendImpl(TestBase):
             kv_sharing_target_layer_name=None,
         )
 
+        self.impl_kv_share = AscendAttentionBackendImpl(
+            num_heads=8,
+            head_size=64,
+            scale=1.0,
+            num_kv_heads=8,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="float16",
+            logits_soft_cap=None,
+            attn_type=self.attention_type.DECODER,
+            kv_sharing_target_layer_name="producer_layer",
+        )
+
+        self.impl_c8_kv_share = AscendC8AttentionBackendImpl(
+            num_heads=8,
+            head_size=64,
+            scale=1.0,
+            num_kv_heads=8,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="float16",
+            logits_soft_cap=None,
+            attn_type=self.attention_type.DECODER,
+            kv_sharing_target_layer_name="producer_layer",
+        )
+
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     def test_large_head_prefill_uses_device_operator_fallback(self, mock_get_forward_context):
         query = torch.randn(2, 8, FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE)
@@ -379,6 +406,56 @@ class TestAscendAttentionBackendImpl(TestBase):
         mock_forward.assert_not_called()
         mock_fia.assert_called_once()
         self.assertEqual(result[0].shape, query.shape)
+
+    @patch("vllm_ascend.attention.attention_v1.DeviceOperator.reshape_and_cache")
+    def test_kv_sharing_target_skips_cache_write(self, mock_reshape_and_cache):
+        query = torch.randn(2, 8, 64)
+        key = torch.randn(2, 8, 64)
+        value = torch.randn(2, 8, 64)
+        kv_cache = (
+            torch.empty(4, 128, 8, 64),
+            torch.empty(4, 128, 8, 64),
+        )
+        output = torch.empty_like(query)
+        metadata = MagicMock()
+        metadata.slot_mapping = torch.arange(2)
+        metadata.num_actual_tokens = 2
+        self.impl_kv_share.is_kv_producer = False
+
+        returned = self.impl_kv_share.reshape_and_cache(query, key, value, kv_cache, metadata, output)
+
+        mock_reshape_and_cache.assert_not_called()
+        self.assertIs(self.impl_kv_share.key_cache, kv_cache[0])
+        self.assertIs(self.impl_kv_share.value_cache, kv_cache[1])
+        self.assertIs(returned[0], query)
+        self.assertIs(returned[1], key)
+        self.assertIs(returned[2], value)
+        self.assertIs(returned[3], output)
+
+    @patch("torch_npu.npu_scatter_pa_kv_cache", create=True)
+    def test_c8_kv_sharing_target_skips_nz_cache_write(self, mock_scatter_pa_kv_cache):
+        query = torch.randn(2, 8, 64)
+        key = torch.randn(2, 8, 64)
+        value = torch.randn(2, 8, 64)
+        kv_cache = (
+            torch.empty(4, 128, 8, 64),
+            torch.empty(4, 128, 8, 64),
+        )
+        output = torch.empty_like(query)
+        metadata = MagicMock()
+        metadata.slot_mapping = torch.arange(2)
+        metadata.num_actual_tokens = 2
+        self.impl_c8_kv_share.is_kv_producer = False
+
+        returned = self.impl_c8_kv_share._reshape_and_cache(query, key, value, kv_cache, metadata, output)
+
+        mock_scatter_pa_kv_cache.assert_not_called()
+        self.assertIs(self.impl_c8_kv_share.key_cache, kv_cache[0])
+        self.assertIs(self.impl_c8_kv_share.value_cache, kv_cache[1])
+        self.assertIs(returned[0], query)
+        self.assertIs(returned[1], key)
+        self.assertIs(returned[2], value)
+        self.assertIs(returned[3], output)
 
     def test_forward_no_attn_metadata(self):
         """Test forward pass when attn_metadata is None"""

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -1462,6 +1462,12 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 attn_metadata.reshape_cache_event = torch.npu.Event()
             if self.key_cache is None:
                 self.key_cache, self.value_cache = kv_cache[0], kv_cache[1]
+            if self.kv_sharing_target_layer_name is not None:
+                # KV-sharing target layers consume another layer's cache.
+                # Writing their dummy/current K/V would overwrite shared slots.
+                if self.is_kv_producer:
+                    attn_metadata.reshape_cache_event.record()
+                return query, key, value, output
             slots = attn_metadata.slot_mapping
             encoder_decoder = self.attn_type == AttentionType.ENCODER_DECODER
             DeviceOperator.reshape_and_cache(
@@ -1988,6 +1994,11 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
                 attn_metadata.reshape_cache_event = torch.npu.Event()
             if self.key_cache is None:
                 self.key_cache, self.value_cache = kv_cache[0], kv_cache[1]
+            if self.kv_sharing_target_layer_name is not None:
+                # C8/NZ cache writes follow the same KV-sharing rule.
+                if self.is_kv_producer:
+                    attn_metadata.reshape_cache_event.record()
+                return query, key, value, output
             slots = attn_metadata.slot_mapping
 
             encoder_decoder = self.attn_type == AttentionType.ENCODER_DECODER


### PR DESCRIPTION
### What this PR does / why we need it?

Gemma4 (E2B/E4B) uses cross-layer KV sharing: certain "target" layers do not maintain their own KV cache but read from a "producer" layer's cache. On Ascend, `reshape_and_cache` was unconditionally writing K/V for every layer, so a KV-sharing target layer would overwrite the producer's shared slots with its own (dummy/current) K/V, corrupting the shared cache and breaking correctness.

This PR skips the cache write for KV-sharing target layers in the Ascend attention backend:

- In `vllm_ascend/attention/attention_v1.py`, both `AscendAttentionBackendImpl.reshape_and_cache` and `AscendC8AttentionBackendImpl._reshape_and_cache` now return early without writing K/V when the layer is a KV-sharing target (`kv_sharing_target_layer_name is not None`). The producer layer still records `reshape_cache_event` before returning so write ordering is preserved; non-producer target layers neither write nor record.

This is required to support Gemma4 E2B/E4B correctly on Ascend.

### Does this PR introduce _any_ user-facing change?

No. This is an internal correctness fix with no new public API, flag, or config. The only behavior change (internal) is that KV-sharing target layers no longer write into the shared KV cache. Users running Gemma4 E2B/E4B on Ascend get correct outputs without any config change.

### How was this patch tested?

- Added unit tests in `tests/ut/attention/a2/test_attention_v1.py`:
  - `test_kv_sharing_target_skips_cache_write`: asserts `DeviceOperator.reshape_and_cache` is **not** called for a KV-sharing target (non-producer) layer, and that `key_cache`/`value_cache` are bound without any write.
  - `test_c8_kv_sharing_target_skips_nz_cache_write`: asserts `torch_npu.npu_scatter_pa_kv_cache` is **not** called on the C8/NZ cache path.
- Validated locally on Ascend950PR (A5 / 957b) with Gemma4: KV-sharing target layers no longer overwrite the shared KV cache and inference output is correct.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/e5588e49bc2642670116664a7fc4096e27adb179
