### PR TITLE
[CI] Remove aime2025 accuracy benchmark

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3_2-W8A8-A3-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3_2-W8A8-A3-dual-nodes.yaml
@@ -116,12 +116,3 @@ benchmarks:
     baseline: 95
     threshold: 10
 
-  acc_aime2025:
-    case_type: accuracy
-    dataset_path: vllm-ascend/aime2025
-    request_conf: vllm_api_general_chat
-    dataset_conf: aime2025/aime2025_gen_0_shot_chat_prompt
-    max_out_len: 80000
-    batch_size: 32
-    baseline: 57 
-    threshold: 10


### PR DESCRIPTION
### What this PR does / why we need it?

Remove the `acc_aime2025` accuracy benchmark from the DeepSeek-V3.2 W8A8 dual-node E2E test config. This benchmark is not part of the required accuracy validation suite for this setup.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446