### PR TITLE
[v0.23.0][Doc][310P] Add Atlas 200I Pro page cache cleanup tip

### DIFF
--- a/docs/source/locale/zh_CN/LC_MESSAGES/tutorials/hardwares/310p.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/tutorials/hardwares/310p.po
@@ -127,6 +127,30 @@ msgid "openEuler 24.03"
 msgstr "openEuler 24.03"
 
 #: ../../source/tutorials/hardwares/310p.md:156
+msgid "Host Page Cache Cleanup (Recommended)"
+msgstr "宿主机页缓存清理（推荐）"
+
+#: ../../source/tutorials/hardwares/310p.md:159
+msgid ""
+"On Atlas 200I Pro, if host memory is tight or you previously ran "
+"inference workloads, consider running the following commands on the "
+"**host** (requires `root`) before `vllm serve` to release reclaimable "
+"kernel page caches. This may help free host memory and reduce OOM risk "
+"during model loading. The command does not delete user files."
+msgstr ""
+"在 Atlas 200I Pro 上，如果宿主机内存紧张，或您之前运行过推理任务，可在启动 `vllm serve` "
+"之前于**宿主机**上（需要 `root` 权限）考虑执行以下命令，以释放可回收的内核页缓存。这可能有助于释放宿主机内存，并降低模型加载时的 "
+"OOM 风险。该命令不会删除用户文件。"
+
+#: ../../source/tutorials/hardwares/310p.md:165
+msgid ""
+"Whether to run this cleanup depends on your environment. Check available "
+"host memory (for example, with `free -h`) and decide based on your actual"
+" situation. Skip it if memory is already sufficient."
+msgstr ""
+"是否执行此清理取决于您的环境。请检查可用宿主机内存（例如使用 `free -h`），并根据实际情况自行判断。如果内存已充足，可跳过此步骤。"
+
+#: ../../source/tutorials/hardwares/310p.md:175
 msgid "Set up environment variables:"
 msgstr "设置环境变量："
 

--- a/docs/source/tutorials/hardwares/310p.md
+++ b/docs/source/tutorials/hardwares/310p.md
@@ -155,22 +155,22 @@ docker run --rm \
 
 #### Host Page Cache Cleanup (Recommended)
 
-!!! tip
+````{tip}
+On Atlas 200I Pro, if host memory is tight or you previously ran inference
+workloads, consider running the following commands on the **host** (requires
+`root`) before `vllm serve` to release reclaimable kernel page caches. This
+may help free host memory and reduce OOM risk during model loading. The
+command does not delete user files.
 
-    On Atlas 200I Pro, if host memory is tight or you previously ran inference
-    workloads, consider running the following commands on the **host** (requires
-    `root`) before `vllm serve` to release reclaimable kernel page caches. This
-    may help free host memory and reduce OOM risk during model loading. The
-    command does not delete user files.
-
-    Whether to run this cleanup depends on your environment. Check available
-    host memory (for example, with `free -h`) and decide based on your actual
-    situation. Skip it if memory is already sufficient.
+Whether to run this cleanup depends on your environment. Check available
+host memory (for example, with `free -h`) and decide based on your actual
+situation. Skip it if memory is already sufficient.
 
 ```bash
 sync
 echo 3 > /proc/sys/vm/drop_caches
 ```
+````
 
 Set up environment variables:
 

--- a/docs/source/tutorials/hardwares/310p.md
+++ b/docs/source/tutorials/hardwares/310p.md
@@ -153,6 +153,25 @@ docker run --rm \
 ::::
 :::::
 
+#### Host Page Cache Cleanup (Recommended)
+
+!!! tip
+
+    On Atlas 200I Pro, if host memory is tight or you previously ran inference
+    workloads, consider running the following commands on the **host** (requires
+    `root`) before `vllm serve` to release reclaimable kernel page caches. This
+    may help free host memory and reduce OOM risk during model loading. The
+    command does not delete user files.
+
+    Whether to run this cleanup depends on your environment. Check available
+    host memory (for example, with `free -h`) and decide based on your actual
+    situation. Skip it if memory is already sufficient.
+
+```bash
+sync
+echo 3 > /proc/sys/vm/drop_caches
+```
+
 Set up environment variables:
 
 ```bash


### PR DESCRIPTION
### What this PR does / why we need it?
Adds a Host Page Cache Cleanup (Recommended) section to the Atlas 200I Pro deployment guide in the 310P docs. It recommends running sync and echo 3 > /proc/sys/vm/drop_caches on the host before starting vllm serve when host memory is tight, to release page caches and reduce OOM risk during model loading. Users should check available memory (e.g. with free -h) and decide based on their environment.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
