### PR TITLE
[Feature][Worker] Support saving sharded model state

### DIFF
--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -1352,6 +1352,46 @@ class TestNPUWorker(TestBase):
                 weights_path="/tmp/weights", is_checkpoint_format=True
             )
 
+    @patch("vllm.model_executor.model_loader.ShardedStateLoader.save_model")
+    def test_save_sharded_state(self, mock_save_model):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
+            worker = NPUWorker()
+            worker.model_runner = MagicMock()
+
+            worker.save_sharded_state(
+                path="/tmp/sharded-state",
+                pattern="model-rank-{rank}-part-{part}.safetensors",
+                max_size=1024,
+            )
+
+            mock_save_model.assert_called_once_with(
+                worker.model_runner.model,
+                "/tmp/sharded-state",
+                pattern="model-rank-{rank}-part-{part}.safetensors",
+                max_size=1024,
+            )
+
+    @patch("vllm.model_executor.model_loader.ShardedStateLoader.save_model")
+    def test_save_sharded_state_propagates_loader_error(self, mock_save_model):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        mock_save_model.side_effect = RuntimeError("failed to write shard")
+        with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
+            worker = NPUWorker()
+            worker.model_runner = MagicMock()
+
+            with self.assertRaisesRegex(RuntimeError, "failed to write shard"):
+                worker.save_sharded_state("/tmp/sharded-state")
+
+            mock_save_model.assert_called_once_with(
+                worker.model_runner.model,
+                "/tmp/sharded-state",
+                pattern=None,
+                max_size=None,
+            )
+
 
 class TestNPUWorkerWeightUpdate(TestBase):
     def _make_worker(self, engine=None):

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -1050,6 +1050,21 @@ class NPUWorker(WorkerBase):
             logger.error("query NPU card %s fail: %s", self.local_rank, e)
         return
 
+    def save_sharded_state(
+        self,
+        path: str,
+        pattern: str | None = None,
+        max_size: int | None = None,
+    ) -> None:
+        from vllm.model_executor.model_loader import ShardedStateLoader
+
+        ShardedStateLoader.save_model(
+            self.model_runner.model,
+            path,
+            pattern=pattern,
+            max_size=max_size,
+        )
+
 
 def parse_text_output(output) -> None:
     lines = output.strip().split("\n")


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds `save_sharded_state` support to the generic Ascend `NPUWorker`.

vLLM invokes this worker interface through the `EngineCore -> Executor.collective_rpc("save_sharded_state") -> Worker` path. The upstream GPU worker implements the interface with `ShardedStateLoader.save_model`, but the generic Ascend worker did not, so sharded state saving could not be dispatched consistently on Ascend.

The implementation mirrors the upstream worker contract and forwards:

- the underlying model from `self.model_runner.model`;
- the destination `path`;
- the optional shard filename `pattern`;
- the optional `max_size`.

The existing 310P-specific override is preserved. The change is intentionally limited to the remaining worker-contract gap; interfaces already inherited from `WorkerBase` are not duplicated.

Fixes #4112

### Does this PR introduce _any_ user-facing change?

Yes. Generic vLLM Ascend workers can now handle the `save_sharded_state` RPC used to save model weights in sharded form. This does not change model execution, scheduling, or inference results.

### How was this patch tested?

Tested against the vLLM commit declared by the current vLLM Ascend PR template:

```text
vLLM commit: 1f486d96a17303ce8db8e02be39545b2be338446
```

Commands and results:

```bash
pytest -q tests/ut/worker/a2/test_worker_v1.py
# 51 passed

bash format.sh changed
# passed

bash format.sh ci
# passed

git diff --check
# passed
```

The added unit tests verify that all arguments are forwarded to `ShardedStateLoader.save_model` and that loader exceptions propagate unchanged.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
