### PR TITLE
[v0.23.0][BugFix][Worker] Reset slot_mapping to pad id for dummy graph capture

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3554,6 +3554,9 @@ class NPUModelRunner(GPUModelRunner):
                 for_cudagraph_capture=is_graph_capturing,
                 num_scheduled_tokens_np=num_scheduled_tokens,
             )
+            for kv_cache_gid in range(len(self.kv_cache_config.kv_cache_groups)):
+                blk_table = self.input_batch.block_table[kv_cache_gid]
+                blk_table.slot_mapping.gpu.fill_(-1)
 
         with self.maybe_dummy_run_with_lora(
             self.lora_config,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3554,9 +3554,10 @@ class NPUModelRunner(GPUModelRunner):
                 for_cudagraph_capture=is_graph_capturing,
                 num_scheduled_tokens_np=num_scheduled_tokens,
             )
-            for kv_cache_gid in range(len(self.kv_cache_config.kv_cache_groups)):
-                blk_table = self.input_batch.block_table[kv_cache_gid]
-                blk_table.slot_mapping.gpu.fill_(-1)
+            if not is_graph_capturing:
+                for kv_cache_gid in range(len(self.kv_cache_config.kv_cache_groups)):
+                    blk_table = self.input_batch.block_table[kv_cache_gid]
+                    blk_table.slot_mapping.gpu.fill_(-1)
 
         with self.maybe_dummy_run_with_lora(
             self.lora_config,


### PR DESCRIPTION

### What this PR does / why we need it?
Clear stale slot_mapping for all kv cache groups during dummy/graph-capture runs, where slot_mapping is not populated via _prepare_inputs(), to avoid graph capture reading uninitialized values.

Backport of #11774
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
