### PR TITLE
[BugFix] Fix small chunk problem for pcp+qwen3.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,11 +52,11 @@ repos:
     exclude: '.*\.inc\.md$|.*report_template\.md$|.*contributors\.md$|.*PULL_REQUEST_TEMPLATE\.md$'
     stages: [manual] # Only run in CI
 
-- repo: https://github.com/rhysd/actionlint
-  rev: v1.7.7
-  hooks:
-  - id: actionlint
-    exclude: '.*\.github/workflows/(scripts|configs)/.*\.ya?ml$'
+# - repo: https://github.com/rhysd/actionlint
+#   rev: v1.7.7
+#   hooks:
+#   - id: actionlint
+#     exclude: '.*\.github/workflows/(scripts|configs)/.*\.ya?ml$'
 
 - repo: local
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,11 +52,11 @@ repos:
     exclude: '.*\.inc\.md$|.*report_template\.md$|.*contributors\.md$|.*PULL_REQUEST_TEMPLATE\.md$'
     stages: [manual] # Only run in CI
 
-# - repo: https://github.com/rhysd/actionlint
-#   rev: v1.7.7
-#   hooks:
-#   - id: actionlint
-#     exclude: '.*\.github/workflows/(scripts|configs)/.*\.ya?ml$'
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.7.7
+  hooks:
+  - id: actionlint
+    exclude: '.*\.github/workflows/(scripts|configs)/.*\.ya?ml$'
 
 - repo: local
   hooks:

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3.5-397B-A17B-w8a8-mtp-longseq-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3.5-397B-A17B-w8a8-mtp-longseq-A3.yaml
@@ -58,5 +58,5 @@ test_cases:
         num_prompts: 50
         max_out_len: 32768
         batch_size: 32
-        baseline: 84
-        threshold: 8
+        baseline: 90
+        threshold: 5

--- a/tests/ut/ops/a2/test_gdn_chunk_meta.py
+++ b/tests/ut/ops/a2/test_gdn_chunk_meta.py
@@ -159,6 +159,8 @@ def test_chunk_gated_delta_rule_fwd_threads_prebuilt_chunk_offsets(
             "update_chunk_offsets_chunk64": update_chunk_offsets,
             "final_chunk_indices_chunk64": final_chunk_indices,
             "chunk_indices_large_block": None,
+            "keep_meta": None,
+            "cu_seqlens_kern": None,
         },
     )()
 
@@ -271,6 +273,8 @@ def test_chunk_gated_delta_rule_fwd_uses_prebuilt_metadata_without_runtime_tolis
             "update_chunk_offsets_chunk64": torch.tensor([0, 2, 4], dtype=torch.int32),
             "final_chunk_indices_chunk64": torch.tensor([1, 3], dtype=torch.int32),
             "chunk_indices_large_block": None,
+            "keep_meta": None,
+            "cu_seqlens_kern": None,
         },
     )()
 
@@ -372,6 +376,8 @@ def test_chunk_gated_delta_rule_fwd_pcp_chaining_subtracts_initial_state(
             "final_chunk_indices_chunk64": torch.tensor([0], dtype=torch.int32),
             "chunk_indices_large_block": None,
             "num_decodes": 0,
+            "keep_meta": None,
+            "cu_seqlens_kern": None,
         },
     )()
 

--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -62,6 +62,8 @@ class GDNChunkedPrefillMetadata:
     chunk_indices_large_block: torch.Tensor
     block_indices_cumsum: torch.Tensor
     num_decodes: int = 0
+    cu_seqlens_kern: tuple[int, ...] | None = None
+    keep_meta: torch.Tensor | None = None
 
 
 @dataclass
@@ -113,6 +115,33 @@ def _build_actual_seq_lengths(
     return actual_seq_lengths
 
 
+def _compact_empty_segments(cu_seqlens_host, initial_state, device=None):
+    """Drop zero-length segments so AscendC fwd_h/fwd_o indexing lines up.
+
+    Returns ``(cu_seqlens_kern, initial_state_kern, keep_meta)``:
+    cu_seqlens / initial_state with empty segments removed, plus a bool
+    mask (None when nothing was removed).  The compacted ``final_state``
+    must be scattered back via ``keep_meta`` (empty segments keep their
+    initial state).
+
+    When *device* is given, ``keep_meta`` is moved to that device so that
+    callers can index NPU tensors without an extra host→device sync.
+    """
+    if cu_seqlens_host is None:
+        return None, initial_state, None
+    cu = torch.tensor(cu_seqlens_host, dtype=torch.int64)
+    keep = (cu[1:] - cu[:-1]) > 0
+    if bool(keep.all()):
+        return cu_seqlens_host, initial_state, None
+    # Compute compact cu_seqlens while keep is still on CPU (cu is CPU-only).
+    cu_kern = torch.cat([cu[:1], cu[1:][keep]]).tolist()
+    # Move keep to device only for indexing device-side tensors.
+    if device is not None:
+        keep = keep.to(device)
+    st_kern = initial_state[keep] if initial_state is not None else None
+    return cu_kern, st_kern, keep
+
+
 def _build_non_spec_chunked_prefill_metadata(
     builder,
     cu_seqlens_cpu: torch.Tensor,
@@ -138,8 +167,19 @@ def _build_non_spec_chunked_prefill_metadata(
     )
     block_indices_cumsum = prepare_chunk_indices(cu_seqlens_cpu, cumsum_chunk_size)
 
+    cu_seqlens_host = tuple(cu_seqlens_cpu.to(torch.int64).reshape(-1).tolist())
+    # Pre-compute compact cu_seqlens for AscendC kernels so each layer
+    # can reuse them instead of calling _compact_empty_segments again.
+    cu_seqlens_kern, _, keep_meta = _compact_empty_segments(
+        cu_seqlens_host, None, device=device
+    )
+    if keep_meta is None:
+        cu_seqlens_kern = None
+    else:
+        cu_seqlens_kern = tuple(cu_seqlens_kern)
+
     return GDNChunkedPrefillMetadata(
-        cu_seqlens_host=tuple(cu_seqlens_cpu.to(torch.int64).reshape(-1).tolist()),
+        cu_seqlens_host=cu_seqlens_host,
         chunk_indices_chunk64_host=tuple(chunk_indices_chunk64.to(torch.int64).reshape(-1).tolist()),
         chunk_indices_chunk64=chunk_indices_chunk64.to(device=device, non_blocking=True),
         chunk_offsets_chunk64=chunk_offsets_chunk64.to(device=device, non_blocking=True),
@@ -147,6 +187,8 @@ def _build_non_spec_chunked_prefill_metadata(
         final_chunk_indices_chunk64=final_chunk_indices_chunk64.to(device=device, non_blocking=True),
         chunk_indices_large_block=chunk_indices_large_block.to(device=device, non_blocking=True),
         block_indices_cumsum=block_indices_cumsum.to(device=device, non_blocking=True),
+        cu_seqlens_kern=cu_seqlens_kern,
+        keep_meta=keep_meta,
     )
 
 

--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -170,9 +170,7 @@ def _build_non_spec_chunked_prefill_metadata(
     cu_seqlens_host = tuple(cu_seqlens_cpu.to(torch.int64).reshape(-1).tolist())
     # Pre-compute compact cu_seqlens for AscendC kernels so each layer
     # can reuse them instead of calling _compact_empty_segments again.
-    cu_seqlens_kern, _, keep_meta = _compact_empty_segments(
-        cu_seqlens_host, None, device=device
-    )
+    cu_seqlens_kern, _, keep_meta = _compact_empty_segments(cu_seqlens_host, None, device=device)
     if keep_meta is None:
         cu_seqlens_kern = None
     else:

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -16,6 +16,8 @@ from vllm.distributed import get_pcp_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.fla.ops.utils import SUPPRESS_LEVEL
 
+from vllm_ascend.ops.gdn_attn_builder import _compact_empty_segments
+
 from .chunk_delta_h import chunk_gated_delta_rule_fwd_h  # noqa: F401
 from .chunk_delta_hupdate import chunk_gated_delta_rule_fwd_hupdate
 from .chunk_o import chunk_fwd_o  # noqa: F401
@@ -99,21 +101,46 @@ def chunk_gated_delta_rule_fwd(
         cu_seqlens_host = tuple(cu_seqlens.tolist())
     if chunk_indices_chunk64_host is None and chunk_indices is not None:
         chunk_indices_chunk64_host = tuple(chunk_indices.flatten().tolist())
+    # Compact zero-length segments for the AscendC kernels (see
+    # _compact_empty_segments).  chunk_indices_chunk64 is already compact-
+    # ranked and is reused as-is; only cu_seqlens / initial_state need
+    # compacting.
+    if prebuilt_meta is not None and hasattr(prebuilt_meta, "keep_meta"):
+        cu_seqlens_kern = cu_seqlens_host if prebuilt_meta.cu_seqlens_kern is None else prebuilt_meta.cu_seqlens_kern
+        keep_meta = prebuilt_meta.keep_meta
+        initial_state_kern = (
+            initial_state[keep_meta]
+            if initial_state is not None and keep_meta is not None
+            else initial_state
+        )
+    else:
+        cu_seqlens_kern, initial_state_kern, keep_meta = _compact_empty_segments(
+            cu_seqlens_host,
+            initial_state,
+            device=initial_state.device if initial_state is not None else None,
+        )
     h, v_new, final_state = torch.ops._C_ascend.chunk_gated_delta_rule_fwd_h(
         k_ascendc,
         w_ascendc,
         u_ascendc,
         g=g_ascendc,
         gk=None,
-        initial_state=initial_state,
+        initial_state=initial_state_kern,
         output_final_state=True,
         chunk_size=64,
         save_new_value=True,
-        cu_seqlens=cu_seqlens_host,
+        cu_seqlens=cu_seqlens_kern,
         chunk_indices=chunk_indices_chunk64_host,
         use_exp2=False,
         transpose_state_layout=False,
     )
+    if keep_meta is not None:
+        # Scatter the compacted final_state back to the original [N, H, K, V]
+        # layout the PCP state recursion expects; empty segments keep their
+        # initial state.
+        _fs_full = initial_state.clone()
+        _fs_full[keep_meta] = final_state
+        final_state = _fs_full
 
     if get_pcp_group().world_size > 1:
         # When integrating mtp, since `mix_qkv` has been split, `num_decode`

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -16,8 +16,6 @@ from vllm.distributed import get_pcp_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.fla.ops.utils import SUPPRESS_LEVEL
 
-from vllm_ascend.ops.gdn_attn_builder import _compact_empty_segments
-
 from .chunk_delta_h import chunk_gated_delta_rule_fwd_h  # noqa: F401
 from .chunk_delta_hupdate import chunk_gated_delta_rule_fwd_hupdate
 from .chunk_o import chunk_fwd_o  # noqa: F401

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -112,11 +112,7 @@ def chunk_gated_delta_rule_fwd(
             initial_state[keep_meta] if initial_state is not None and keep_meta is not None else initial_state
         )
     else:
-        cu_seqlens_kern, initial_state_kern, keep_meta = _compact_empty_segments(
-            cu_seqlens_host,
-            initial_state,
-            device=initial_state.device if initial_state is not None else None,
-        )
+        cu_seqlens_kern, initial_state_kern = cu_seqlens_host, initial_state
     h, v_new, final_state = torch.ops._C_ascend.chunk_gated_delta_rule_fwd_h(
         k_ascendc,
         w_ascendc,

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -111,6 +111,7 @@ def chunk_gated_delta_rule_fwd(
         )
     else:
         cu_seqlens_kern, initial_state_kern = cu_seqlens_host, initial_state
+        keep_meta = None
     h, v_new, final_state = torch.ops._C_ascend.chunk_gated_delta_rule_fwd_h(
         k_ascendc,
         w_ascendc,

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -109,9 +109,7 @@ def chunk_gated_delta_rule_fwd(
         cu_seqlens_kern = cu_seqlens_host if prebuilt_meta.cu_seqlens_kern is None else prebuilt_meta.cu_seqlens_kern
         keep_meta = prebuilt_meta.keep_meta
         initial_state_kern = (
-            initial_state[keep_meta]
-            if initial_state is not None and keep_meta is not None
-            else initial_state
+            initial_state[keep_meta] if initial_state is not None and keep_meta is not None else initial_state
         )
     else:
         cu_seqlens_kern, initial_state_kern, keep_meta = _compact_empty_segments(


### PR DESCRIPTION
What this PR does / why we need it
Fixes a runtime 507015 (MTE write out-of-bounds) crash in the AscendC chunk_gated_delta_rule_fwd_h / chunk_fwd_o kernels when running Qwen3.5 with PCP
(prefill-context-parallel) world_size > 1 under a mixed-length concurrent batch.

Root cause
PCP splits each request's prefill across ranks with an interleave granularity (cp_kv_cache_interleave_size, default 128). A request shorter than the interleave size
produces zero tokens on rank>0, leaving a zero-length segment in that rank's cu_seqlens.

chunk_indices carries compact (non-empty) segment ranks (empty segments are skipped when built), but the chunk_fwd_o kernel indexes gmSeqlen (= the original cu_seqlens,
with empty segments) by that same compact rank. When a zero-length segment is sandwiched between non-empty ones, the rank and the original segment index go out of sync.

Example
Suppose rank>0 has 3 requests with lengths [128, 0, 128] tokens (the middle request is shorter than the interleave size, so it gets 0 tokens on this rank):

cu_seqlens = [0, 128, 128, 256] # seg0=128, seg1=EMPTY, seg2=128
chunk_indices = [(0,0),(0,1),(1,0),(1,1)] # compact rank: seg0→0, seg2→1 (seg1 skipped)

chunk_fwd_o processing chunk3 (the last chunk of seg2, within-chunk idx=1):

tokenOffset = gmSeqlen[1] = 128 # cu_seqlens[1] (boundary of EMPTY seg1!)
batchTokens = gmSeqlen[2] - tokenOffset = 128 - 128 = 0
isFinalState = (chunkIdx == numChunks-1) = true
blockTokens = batchTokens - batchChunkIdxchunkSize
= 0 - 164 = -64 # uint32 underflow → huge value
→ MTE write out-of-bounds → runtime 507015

The fix
Add _compact_empty_segments(cu_seqlens_host, initial_state) and call it before the AscendC fwd_h / fwd_o kernels. It drops zero-length segments from cu_seqlens (and the
corresponding rows of initial_state), so the compact rank carried by chunk_indices lines up with the compacted gmSeqlen. The compacted final_state is scattered back to
the original [N, H, K, V] layout via the keep-mask (empty segments keep their initial_state). It is a no-op when there are no empty segments (rank0 / non-PCP / uniform
batch).

chunk_indices is already compact-ranked (built by skipping empty segments in gdn_attn_builder._fill_chunk_indices_cpu), so it is reused as-is; only cu_seqlens /
initial_state need compacting. Zero-length segments contribute exactly zero to the GDN math, so compaction preserves the token layout (empty segment = 0 tokens) and is
numerically equivalent.

vLLM version: v0.23.0
vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
