### PR TITLE
[Refactor][Model] Unify Qwen3.5 GDN metadata and operator paths

### DIFF
--- a/csrc/attention/recurrent_gated_delta_rule_v310/op_host/op_api/aclnn_recurrent_gated_delta_rule_v310.h
+++ b/csrc/attention/recurrent_gated_delta_rule_v310/op_host/op_api/aclnn_recurrent_gated_delta_rule_v310.h
@@ -23,7 +23,7 @@ extern "C" {
  * @param [in] value: float16
  * @param [in] beta: float16
  * @param [in] state: float16
- * @param [in] actualSeqLengths: int32
+ * @param [in] actualSeqLengths: int32, [start_offset, seq_len_0, ..., seq_len_n]
  * @param [in] ssmStateIndices: int32
  * @param [in] g: float32
  * @param [in] gk: float32

--- a/csrc/attention/recurrent_gated_delta_rule_v310/op_host/recurrent_gated_delta_rule_v310_tiling.cpp
+++ b/csrc/attention/recurrent_gated_delta_rule_v310/op_host/recurrent_gated_delta_rule_v310_tiling.cpp
@@ -279,7 +279,7 @@ void RecurrentGatedDeltaRuleV310Tiling::FillTilingShapeData(const gert::Shape &q
     tilingData_.nv = valueShape.GetDim(DIM_1);
     tilingData_.dv = valueShape.GetDim(DIM_2);
     tilingData_.sBlockNum = stateShape.GetDim(DIM_0);
-    tilingData_.b = cuSeqlensShape.GetDim(DIM_0);
+    tilingData_.b = cuSeqlensShape.GetDim(DIM_0) - 1;
 }
 
 ge::graphStatus RecurrentGatedDeltaRuleV310Tiling::CheckShapeValueRangeAndRule()

--- a/csrc/attention/recurrent_gated_delta_rule_v310/op_kernel/recurrent_gated_delta_rule_v310.h
+++ b/csrc/attention/recurrent_gated_delta_rule_v310/op_kernel/recurrent_gated_delta_rule_v310.h
@@ -282,7 +282,8 @@ public:
     __aicore__ inline void ComputeAvgload()
     {
         uint64_t realT = 0;
-        for (uint64_t batch_i = 0; batch_i < B_; batch_i++) {
+        // Match the common recurrent operator layout: [start_offset, seq_len_0, ..., seq_len_n].
+        for (uint64_t batch_i = 1; batch_i < B_ + 1; batch_i++) {
             realT += cuSeqlensGm_.GetValue(batch_i);
         }
         avgload = Ceil(realT * NV_, GetBlockNum());
@@ -291,9 +292,9 @@ public:
     __aicore__ inline void Process()
     {
         ComputeAvgload();
-        int32_t seq1 = 0;
+        int32_t seq1 = cuSeqlensGm_.GetValue(0);
         for (uint64_t batch_i = 0; batch_i < B_; batch_i++) {
-            int32_t seqLen = cuSeqlensGm_.GetValue(batch_i);
+            int32_t seqLen = cuSeqlensGm_.GetValue(batch_i + 1);
             if (seqLen <= 0) {
                 continue;
             }

--- a/tests/e2e/nightly/310p/single_node/ops/singlecard_ops/test_recurrent_gated_delta_rule_v310.py
+++ b/tests/e2e/nightly/310p/single_node/ops/singlecard_ops/test_recurrent_gated_delta_rule_v310.py
@@ -106,6 +106,8 @@ def golden(query, key, value, state, beta, scale, seq_lens, indices, g, nat):
     q = q * scale
     seq_start = 0
     for i in range(len(seq_lens)):
+        if seq_lens[i] <= 0:
+            continue
         init_idx = indices[seq_start + nat[i] - 1] if nat is not None else indices[seq_start]
         for head in range(nv):
             s = S[init_idx][head].clone()
@@ -124,21 +126,22 @@ def golden(query, key, value, state, beta, scale, seq_lens, indices, g, nat):
 
 
 @pytest.mark.parametrize(
-    "batch_size,mtp,nk,nv,dk,dv,num_slots",
+    "sequence_lengths,nk,nv,dk,dv,num_slots",
     [
-        (1, 1, 8, 16, 128, 128, 444),
-        (2, 2, 8, 16, 128, 128, 444),
-        (4, 2, 4, 4, 64, 64, 32),
+        ((1,), 8, 16, 128, 128, 444),
+        ((2, 2), 8, 16, 128, 128, 444),
+        ((2, 0, 1), 4, 4, 64, 64, 32),
     ],
 )
-def test_recurrent_gated_delta_rule_v310(batch_size, mtp, nk, nv, dk, dv, num_slots):
+def test_recurrent_gated_delta_rule_v310(sequence_lengths, nk, nv, dk, dv, num_slots):
     torch.manual_seed(42)
     scale = dk**-0.5
-    seq_lens = torch.ones(batch_size, dtype=torch.int32) * mtp
+    seq_lens = torch.tensor(sequence_lengths, dtype=torch.int32)
+    actual_seq_lengths = torch.cat([torch.zeros(1, dtype=torch.int32), seq_lens])
     T = int(seq_lens.sum())
     state = torch.rand(num_slots, nv, dv, dk, dtype=torch.float16)
     indices = torch.randperm(num_slots, dtype=torch.int32)[:T]
-    nat = torch.ones(batch_size, dtype=torch.int32)
+    nat = torch.where(seq_lens > 0, torch.ones_like(seq_lens), torch.zeros_like(seq_lens))
     query = torch.nn.functional.normalize(torch.randn(T, nk, dk), dim=-1).to(torch.float16)
     key = torch.nn.functional.normalize(torch.randn(T, nk, dk), dim=-1).to(torch.float16)
     value = torch.randn(T, nv, dv, dtype=torch.float16)
@@ -154,7 +157,7 @@ def test_recurrent_gated_delta_rule_v310(batch_size, mtp, nk, nv, dk, dv, num_sl
         value.npu(),
         beta.npu(),
         state_npu,
-        seq_lens.npu(),
+        actual_seq_lengths.npu(),
         indices.npu(),
         g.npu(),
         nat.npu(),

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_recurrent_gated_delta_rule_310.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_recurrent_gated_delta_rule_310.py
@@ -39,7 +39,7 @@ def npu_recurrent_gated_delta_rule_310(
 
 
 def golden_recurrent_gated_delta_rule(
-    query, key, value, state, beta, scale, actual_seq_lengths, ssm_state_indices, g, num_accepted_tokens
+    query, key, value, state, beta, scale, sequence_lengths, ssm_state_indices, g, num_accepted_tokens
 ):
     q = query.to(torch.float32)
     k = key.to(torch.float32)
@@ -56,7 +56,9 @@ def golden_recurrent_gated_delta_rule(
     q = q * scale
 
     seq_start = 0
-    for i in range(len(actual_seq_lengths)):
+    for i in range(len(sequence_lengths)):
+        if sequence_lengths[i] <= 0:
+            continue
         if num_accepted_tokens is None:
             init_state = initial_state[ssm_state_indices[seq_start]]
         else:
@@ -64,7 +66,7 @@ def golden_recurrent_gated_delta_rule(
 
         for head_id in range(n_heads_v):
             S = init_state[head_id]
-            for slot_id in range(seq_start, seq_start + actual_seq_lengths[i]):
+            for slot_id in range(seq_start, seq_start + sequence_lengths[i]):
                 q_i = q[slot_id][head_id // (n_heads_v // n_heads_k)]
                 k_i = k[slot_id][head_id // (n_heads_v // n_heads_k)]
                 v_i = v[slot_id][head_id]
@@ -77,7 +79,7 @@ def golden_recurrent_gated_delta_rule(
                 S = S + S_
                 initial_state[ssm_state_indices[slot_id]][head_id] = S
                 o[slot_id][head_id] = (S * q_i.unsqueeze(-2)).sum(dim=-1)
-        seq_start += actual_seq_lengths[i]
+        seq_start += sequence_lengths[i]
 
     return o.to(query.dtype), initial_state.to(query.dtype)
 
@@ -92,8 +94,9 @@ def test_fused_recurrent_gated_delta_rule_310(batch_size, mtp, headnum, headdim_
     enable_custom_op()
     dtype = torch.float16
     headnum_k, headnum_v = headnum
-    actual_seq_lengths = torch.ones(batch_size, dtype=torch.int32) * mtp
-    T = int(torch.sum(actual_seq_lengths))
+    sequence_lengths = torch.ones(batch_size, dtype=torch.int32) * mtp
+    actual_seq_lengths = torch.cat([torch.zeros(1, dtype=torch.int32), sequence_lengths])
+    T = int(torch.sum(sequence_lengths))
     state = torch.rand((T, headnum_v, headdim_v, headdim_k)).to(dtype)
     query = torch.nn.functional.normalize(torch.rand((T, headnum_k, headdim_k)), p=2, dim=-1).to(dtype)
     key = torch.nn.functional.normalize(torch.rand((T, headnum_k, headdim_k)), p=2, dim=-1).to(dtype)
@@ -105,7 +108,7 @@ def test_fused_recurrent_gated_delta_rule_310(batch_size, mtp, headnum, headdim_
     scale = headdim_k**-0.5
 
     out_golden, state_golden = golden_recurrent_gated_delta_rule(
-        query, key, value, state, beta, scale, actual_seq_lengths, ssm_state_indices, g, num_accepted_tokens
+        query, key, value, state, beta, scale, sequence_lengths, ssm_state_indices, g, num_accepted_tokens
     )
     out_golden = out_golden.to(torch.float32)
     state_golden = state_golden.to(torch.float32)

--- a/tests/ut/_310p/ops/test_gdn_310.py
+++ b/tests/ut/_310p/ops/test_gdn_310.py
@@ -15,25 +15,32 @@
 # This file is a part of the vllm-ascend project.
 #
 
-from types import SimpleNamespace
-
 import torch
-from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 
 from vllm_ascend._310p.ops.fla.gdn_310 import (
     AscendGatedDeltaNetAttention310,
-    _mask_padded_recurrent_accepted_tokens,
+    AscendQwenGatedDeltaNetAttention310,
     _zero_padded_tokens,
 )
 from vllm_ascend._310p.ops.gdn_attn_builder_310 import (
     AscendGDNAttentionBackend310,
     AscendGDNAttentionMetadataBuilder310,
 )
+from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionMetadataBuilder
 
 
 def test_ascend_gdn_attention_310_uses_310p_backend():
     assert AscendGatedDeltaNetAttention310.get_attn_backend(object()) is AscendGDNAttentionBackend310
     assert AscendGDNAttentionBackend310.get_builder_cls() is AscendGDNAttentionMetadataBuilder310
+
+
+def test_qwen_gdn_uses_oot_310p_layer():
+    from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import QwenGatedDeltaNetAttention
+
+    assert issubclass(AscendQwenGatedDeltaNetAttention310, QwenGatedDeltaNetAttention)
+    assert AscendQwenGatedDeltaNetAttention310.forward is QwenGatedDeltaNetAttention.forward
+    assert AscendQwenGatedDeltaNetAttention310._forward_core is AscendGatedDeltaNetAttention310._forward_core
+    assert AscendQwenGatedDeltaNetAttention310.get_attn_backend is AscendGatedDeltaNetAttention310.get_attn_backend
 
 
 def test_zero_padded_tokens_masks_only_padded_token_positions():
@@ -45,57 +52,6 @@ def test_zero_padded_tokens_masks_only_padded_token_positions():
     assert torch.count_nonzero(masked[:, 2:]) == 0
 
 
-def test_mask_padded_recurrent_accepted_tokens_zeros_dummy_requests():
-    accepted_tokens = torch.tensor([2, 3, 4], dtype=torch.int64)
-    actual_seq_lengths = torch.tensor([4, 0, 1], dtype=torch.int32)
-
-    masked = _mask_padded_recurrent_accepted_tokens(
-        accepted_tokens,
-        actual_seq_lengths,
-    )
-
-    assert masked.dtype == torch.int32
-    assert masked.tolist() == [2, 0, 4]
-
-
-def test_builder310_pads_spec_decode_metadata_with_dummy_requests():
-    builder = object.__new__(AscendGDNAttentionMetadataBuilder310)
-    builder.spec_state_indices_tensor = torch.full((4, 2), -1, dtype=torch.int32)
-    builder.spec_sequence_masks = torch.empty(4, dtype=torch.bool)
-    builder.non_spec_token_indx = torch.empty(0, dtype=torch.int32)
-    builder.spec_token_indx = torch.empty(8, dtype=torch.int32)
-    builder.spec_query_start_loc = torch.empty(5, dtype=torch.int32)
-    builder.num_accepted_tokens = torch.empty(4, dtype=torch.int32)
-    builder.spec_actual_seq_lengths = torch.empty(5, dtype=torch.int32)
-    builder.use_full_cuda_graph = True
-    attn_metadata = SimpleNamespace(
-        num_prefills=0,
-        num_decodes=0,
-        num_spec_decodes=2,
-        spec_state_indices_tensor=torch.tensor(
-            [[3, 30], [4, 40]],
-            dtype=torch.int32,
-        ),
-        spec_sequence_masks=torch.tensor([True, True]),
-        spec_query_start_loc=torch.tensor([0, 4, 8], dtype=torch.int32),
-        num_accepted_tokens=torch.tensor([2, 3], dtype=torch.int32),
-        non_spec_token_indx=torch.empty(0, dtype=torch.int32),
-        spec_token_indx=torch.arange(8, dtype=torch.int32),
-    )
-
-    builder._pad_spec_decode_metadata(attn_metadata, graph_batch_size=4)
-
-    assert attn_metadata.spec_state_indices_tensor.tolist() == [
-        [3, 30],
-        [4, 40],
-        [NULL_BLOCK_ID, NULL_BLOCK_ID],
-        [NULL_BLOCK_ID, NULL_BLOCK_ID],
-    ]
-    assert attn_metadata.spec_sequence_masks.tolist() == [True, True, False, False]
-    assert attn_metadata.spec_query_start_loc.tolist() == [0, 4, 8, 8, 8]
-    assert attn_metadata.num_accepted_tokens.tolist() == [2, 3, 0, 0]
-    spec_meta = attn_metadata.spec_decode_metadata.spec_causal_conv1d
-    assert spec_meta.query_start_loc.data_ptr() == attn_metadata.spec_query_start_loc.data_ptr()
-    assert spec_meta.cache_indices.data_ptr() == attn_metadata.spec_state_indices_tensor.data_ptr()
-    assert spec_meta.num_accepted_tokens.data_ptr() == attn_metadata.num_accepted_tokens.data_ptr()
-    assert attn_metadata.spec_decode_metadata.actual_seq_lengths.tolist() == [0, 4, 4, 0, 0]
+def test_builder310_reuses_common_graph_padding():
+    assert AscendGDNAttentionMetadataBuilder310.build is AscendGDNAttentionMetadataBuilder.build
+    assert "build" not in AscendGDNAttentionMetadataBuilder310.__dict__

--- a/tests/ut/device/test_device_op.py
+++ b/tests/ut/device/test_device_op.py
@@ -2,8 +2,235 @@ from unittest import mock
 
 import pytest
 import torch
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
-from vllm_ascend.device.device_op import A5DeviceAdaptor, BaseDeviceAdaptor
+from vllm_ascend.device.device_op import (
+    A5DeviceAdaptor,
+    Ascend310PDeviceAdaptor,
+    BaseDeviceAdaptor,
+)
+
+
+def _gdn_causal_conv1d_inputs():
+    return {
+        "x": torch.arange(6, dtype=torch.float32).reshape(2, 3),
+        "weight": torch.ones(2, 3),
+        "conv_state": torch.zeros(2, 2, 3),
+        "bias": None,
+        "query_start_loc": torch.tensor([0, 1, 2], dtype=torch.int32),
+        "cache_indices": torch.tensor([2, 3], dtype=torch.int32),
+        "initial_state_mode": torch.tensor([False, True]),
+        "num_accepted_tokens": torch.tensor([1, 2], dtype=torch.int32),
+        "activation_mode": 1,
+        "run_mode": 0,
+    }
+
+
+def test_base_gdn_causal_conv1d_uses_common_operator(monkeypatch):
+    captured = {}
+
+    def fake_causal_conv1d(output, x, weight, **kwargs):
+        captured.update(kwargs)
+        captured["weight"] = weight
+        output.copy_(x + 1)
+
+    monkeypatch.setattr(
+        torch.ops._C_ascend,
+        "npu_causal_conv1d_custom",
+        fake_causal_conv1d,
+        raising=False,
+    )
+    inputs = _gdn_causal_conv1d_inputs()
+
+    output = BaseDeviceAdaptor.gdn_causal_conv1d(**inputs)
+
+    assert torch.equal(output, inputs["x"] + 1)
+    assert captured["weight"] is inputs["weight"]
+    assert captured["conv_state"] is inputs["conv_state"]
+    assert captured["bias_opt"] is None
+    assert captured["query_start_loc_opt"] is inputs["query_start_loc"]
+    assert captured["cache_indices_opt"] is inputs["cache_indices"]
+    assert captured["initial_state_mode_opt"] is inputs["initial_state_mode"]
+    assert captured["num_accepted_tokens_opt"] is inputs["num_accepted_tokens"]
+    assert captured["activation_mode"] == 1
+    assert captured["pad_slot_id"] == PAD_SLOT_ID
+    assert captured["run_mode"] == 0
+
+
+def test_310p_gdn_causal_conv1d_uses_310p_operator(monkeypatch):
+    captured = {}
+
+    def fake_causal_conv1d(x, weight, **kwargs):
+        captured.update(kwargs)
+        captured["weight"] = weight
+        return x + 1
+
+    monkeypatch.setattr(
+        torch.ops._C_ascend,
+        "npu_causal_conv1d_310",
+        fake_causal_conv1d,
+        raising=False,
+    )
+    inputs = _gdn_causal_conv1d_inputs()
+
+    output = Ascend310PDeviceAdaptor.gdn_causal_conv1d(**inputs)
+
+    assert torch.equal(output, inputs["x"] + 1)
+    assert captured["weight"] is inputs["weight"]
+    assert captured["conv_states"] is inputs["conv_state"]
+    assert captured["bias"] is None
+    assert captured["query_start_loc"] is inputs["query_start_loc"]
+    assert captured["cache_indices"] is inputs["cache_indices"]
+    assert captured["initial_state_mode"] is inputs["initial_state_mode"]
+    assert captured["num_accepted_tokens"] is inputs["num_accepted_tokens"]
+    assert captured["activation_mode"] == 1
+    assert captured["pad_slot_id"] == PAD_SLOT_ID
+    assert captured["run_mode"] == 0
+
+
+def test_base_gdn_recurrent_decode_normalizes_operator_contract(monkeypatch):
+    captured = {}
+
+    def fake_recurrent(**kwargs):
+        captured.update(kwargs)
+        return kwargs["value"]
+
+    monkeypatch.setattr(
+        torch.ops._C_ascend,
+        "npu_recurrent_gated_delta_rule",
+        fake_recurrent,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.fla.ops.l2norm.l2norm_fwd",
+        lambda tensor: tensor,
+    )
+    query = torch.randn(1, 2, 3, 4)
+    key = torch.randn(1, 2, 3, 4)
+    value = torch.randn(1, 2, 3, 5)
+    g = torch.randn(1, 2, 3, 4)
+    beta = torch.randn(1, 2, 3)
+    state = torch.randn(4, 3, 4, 5)
+    actual_seq_lengths = torch.tensor([0, 1, 1], dtype=torch.int32)
+    state_indices = torch.tensor([4, 5], dtype=torch.int32)
+    accepted_tokens = torch.tensor([1, 2], dtype=torch.int64)
+
+    output = BaseDeviceAdaptor.gdn_recurrent_decode(
+        query,
+        key,
+        value,
+        g,
+        beta,
+        state,
+        actual_seq_lengths,
+        state_indices,
+        accepted_tokens,
+    )
+
+    assert output.shape == value.shape
+    assert captured["query"].shape == query.shape[1:]
+    assert captured["key"].shape == key.shape[1:]
+    assert captured["value"].shape == value.shape[1:]
+    assert captured["g"].shape == g.shape[1:]
+    assert captured["beta"].shape == beta.shape[1:]
+    assert captured["scale"] == key.shape[-1] ** -0.5
+    assert captured["actual_seq_lengths"] is actual_seq_lengths
+    assert captured["ssm_state_indices"] is state_indices
+    assert captured["num_accepted_tokens"].dtype == torch.int32
+
+
+def test_310p_gdn_recurrent_metadata_adaptation():
+    accepted_tokens = torch.tensor([2, 3, 4], dtype=torch.int64)
+    actual_seq_lengths = torch.tensor([0, 4, 0, 1], dtype=torch.int32)
+    masked = Ascend310PDeviceAdaptor._mask_gdn_accepted_tokens(
+        accepted_tokens,
+        actual_seq_lengths,
+    )
+    state_indices = torch.tensor(
+        [[10, 11], [20, 21], [30, 31]],
+        dtype=torch.int32,
+    )
+    uniform_seq_lengths = torch.tensor([0, 2, 2, 2], dtype=torch.int32)
+    flattened = Ascend310PDeviceAdaptor._flatten_gdn_state_indices(
+        state_indices,
+        uniform_seq_lengths,
+        total_tokens=6,
+    )
+
+    assert masked.dtype == torch.int32
+    assert masked.tolist() == [2, 0, 4]
+    assert flattened.tolist() == [10, 11, 20, 21, 30, 31]
+
+
+def test_310p_gdn_recurrent_decode_uses_adapted_operator_contract(monkeypatch):
+    captured = {}
+
+    def fake_recurrent(**kwargs):
+        captured.update(kwargs)
+        return kwargs["value"]
+
+    monkeypatch.setattr(
+        torch.ops._C_ascend,
+        "npu_recurrent_gated_delta_rule_310",
+        fake_recurrent,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "vllm_ascend._310p.ops.fla.l2norm.l2norm_310p",
+        lambda tensor: tensor,
+    )
+    query = torch.randn(1, 4, 2, 3)
+    key = torch.randn(1, 4, 2, 3)
+    value = torch.randn(1, 4, 2, 5)
+    g = torch.randn(1, 4, 2, 3)
+    beta = torch.randn(1, 4, 2)
+    state = torch.randn(32, 2, 5, 3)
+    actual_seq_lengths = torch.tensor([0, 2, 2], dtype=torch.int64)
+    state_indices = torch.tensor([[10, 11], [20, 21]], dtype=torch.int64)
+    accepted_tokens = torch.tensor([2, 1], dtype=torch.int64)
+
+    output = Ascend310PDeviceAdaptor.gdn_recurrent_decode(
+        query,
+        key,
+        value,
+        g,
+        beta,
+        state,
+        actual_seq_lengths,
+        state_indices,
+        accepted_tokens,
+    )
+
+    assert output.shape == value.shape
+    assert captured["query"].dtype == torch.float16
+    assert captured["key"].dtype == torch.float16
+    assert captured["value"].dtype == torch.float16
+    assert captured["g"].dtype == torch.float32
+    assert captured["beta"].dtype == torch.float16
+    assert captured["actual_seq_lengths"].dtype == torch.int32
+    assert captured["actual_seq_lengths"].tolist() == [0, 2, 2]
+    assert captured["ssm_state_indices"].dtype == torch.int32
+    assert captured["ssm_state_indices"].tolist() == [10, 11, 20, 21]
+    assert captured["num_accepted_tokens"].dtype == torch.int32
+    assert captured["num_accepted_tokens"].tolist() == [2, 1]
+    assert captured["scale_value"] == key.shape[-1] ** -0.5
+
+
+def test_310p_fused_gdn_gating_uses_pytorch_fallback():
+    A_log = torch.randn(2)
+    a = torch.randn(3, 2)
+    b = torch.randn(3, 2)
+    dt_bias = torch.randn(2)
+    expected = (torch.randn(1, 3, 2), torch.randn(1, 3, 2))
+
+    with mock.patch(
+        "vllm_ascend._310p.ops.fla.fused_gdn_gating.fused_gdn_gating_pytorch",
+        return_value=expected,
+    ) as mock_gating:
+        output = Ascend310PDeviceAdaptor.fused_gdn_gating(A_log, a, b, dt_bias)
+
+    assert output is expected
+    mock_gating.assert_called_once_with(A_log, a, b, dt_bias)
 
 
 def test_npu_flash_attention_uses_fusion_attention_for_fp32():

--- a/tests/ut/ops/a2/test_gdn_chunk_meta.py
+++ b/tests/ut/ops/a2/test_gdn_chunk_meta.py
@@ -372,6 +372,7 @@ def test_chunk_gated_delta_rule_fwd_pcp_chaining_subtracts_initial_state(
             "final_chunk_indices_chunk64": torch.tensor([0], dtype=torch.int32),
             "chunk_indices_large_block": None,
             "num_decodes": 0,
+            "prefill_seq_offset": 0,
         },
     )()
 

--- a/tests/ut/ops/test_gdn_attn_builder.py
+++ b/tests/ut/ops/test_gdn_attn_builder.py
@@ -13,7 +13,7 @@ from vllm.v1.kv_cache_interface import MambaSpec
 
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.ops import gdn_attn_builder as ascend_gdn_attn_builder
-from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
+from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention, AscendQwenGatedDeltaNetAttention
 from vllm_ascend.ops.gdn_attn_builder import (
     AscendGDNAttentionBackend,
     AscendGDNAttentionMetadataBuilder,
@@ -297,6 +297,15 @@ def test_ascend_gdn_attention_uses_ascend_backend():
     assert AscendGDNAttentionBackend.get_builder_cls() is AscendGDNAttentionMetadataBuilder
 
 
+def test_qwen_gdn_uses_oot_ascend_layer():
+    from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import QwenGatedDeltaNetAttention
+
+    assert issubclass(AscendQwenGatedDeltaNetAttention, QwenGatedDeltaNetAttention)
+    assert AscendQwenGatedDeltaNetAttention.forward is AscendGatedDeltaNetAttention.forward
+    assert AscendQwenGatedDeltaNetAttention._forward_core is AscendGatedDeltaNetAttention._forward_core
+    assert AscendQwenGatedDeltaNetAttention.get_attn_backend is AscendGatedDeltaNetAttention.get_attn_backend
+
+
 def test_sequence_index_buffers_cover_spec_decode_when_cudagraph_disabled():
     builder = _make_builder(
         device=torch.device("cpu"),
@@ -437,11 +446,35 @@ def test_non_spec_prefill_metadata_uses_prefill_tail_for_chunk_metadata(
     assert torch.equal(_cache_index_first_column(conv1d_meta.cache_indices), torch.tensor([0, 1, 2], dtype=torch.int32))
     assert torch.equal(conv1d_meta.initial_state_mode, torch.tensor([True, True, True]))
     assert prefill_metadata.chunk.num_decodes == 0
+    assert prefill_metadata.chunk.prefill_seq_offset == 0
     _assert_chunk_meta_matches_runtime(
         builder,
         prefill_metadata.chunk,
         attn_metadata.prefill_query_start_loc,
     )
+
+
+def test_chunk_metadata_precomputes_pcp_sequence_offset_on_host():
+    parallel_config = SimpleNamespace(tensor_parallel_size=1)
+    model_config = SimpleNamespace(
+        hf_text_config=None,
+        get_num_attention_heads=lambda _: 8,
+    )
+    builder = SimpleNamespace(
+        vllm_config=SimpleNamespace(
+            model_config=model_config,
+            parallel_config=parallel_config,
+        )
+    )
+
+    chunk_metadata = ascend_gdn_attn_builder._build_non_spec_chunked_prefill_metadata(
+        builder,
+        torch.tensor([0, 1, 2, 6], dtype=torch.int32),
+        torch.device("cpu"),
+    )
+
+    assert chunk_metadata.num_decodes == 0
+    assert chunk_metadata.prefill_seq_offset == 2
 
 
 def test_spec_conv1d_args_use_device_cache_and_accepted_tokens():
@@ -571,6 +604,10 @@ def test_full_graph_spec_actual_seq_lengths_use_padded_builder_buffer():
         attn_metadata.spec_decode_metadata.actual_seq_lengths,
         torch.tensor([0, 4, 4, 0, 0], dtype=torch.int32),
     )
+    assert torch.equal(
+        attn_metadata.num_accepted_tokens,
+        torch.tensor([2, 4, 1, 1], dtype=torch.int32),
+    )
 
 
 def test_full_graph_non_spec_actual_seq_lengths_use_padded_builder_buffer():
@@ -596,7 +633,7 @@ def test_full_graph_non_spec_actual_seq_lengths_use_padded_builder_buffer():
 
     assert torch.equal(
         attn_metadata.non_spec_query_start_loc,
-        torch.tensor([0, 1, 2, 2, 2], dtype=torch.int32),
+        torch.tensor([0, 1, 2], dtype=torch.int32),
     )
     assert (
         attn_metadata.non_spec_decode_metadata.actual_seq_lengths.data_ptr()
@@ -604,7 +641,7 @@ def test_full_graph_non_spec_actual_seq_lengths_use_padded_builder_buffer():
     )
     assert torch.equal(
         attn_metadata.non_spec_decode_metadata.actual_seq_lengths,
-        torch.tensor([0, 1, 1, 0, 0], dtype=torch.int32),
+        torch.tensor([0, 1, 1], dtype=torch.int32),
     )
 
 

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -22,7 +22,6 @@ import torch
 
 from tests.ut.base import TestBase
 from vllm_ascend import utils
-from vllm_ascend.utils import REGISTERED_ASCEND_OPS
 
 
 class TestUtils(TestBase):
@@ -303,22 +302,34 @@ class TestUtils(TestBase):
             self.assertTrue(utils.is_drafter_moe_model(vllm_config))
 
     @mock.patch("vllm.model_executor.custom_op.CustomOp")
+    @mock.patch("vllm.model_executor.custom_op.PluggableLayer")
     @mock.patch("vllm_ascend.ops.activation.AscendQuickGELU")
     @mock.patch("vllm_ascend.ops.activation.AscendSiluAndMul")
     @mock.patch("vllm_ascend.ops.layernorm.AscendRMSNorm")
     def test_register_ascend_customop(
-        self, mock_ascend_rmsnorm, mock_ascend_silu_and_mul, mock_ascend_quick_gelu, mock_customop
+        self,
+        mock_ascend_rmsnorm,
+        mock_ascend_silu_and_mul,
+        mock_ascend_quick_gelu,
+        mock_pluggable_layer,
+        mock_customop,
     ):
         utils._ASCEND_CUSTOMOP_IS_REIGISTERED = False
 
         # ascend custom op is not registered
         utils.register_ascend_customop()
-        self.assertEqual(mock_customop.register_oot.call_count, len(REGISTERED_ASCEND_OPS))
+        self.assertEqual(mock_pluggable_layer.register_oot.call_count, 2)
+        self.assertEqual(
+            {call.kwargs["name"] for call in mock_pluggable_layer.register_oot.call_args_list},
+            {"GatedDeltaNetAttention", "QwenGatedDeltaNetAttention"},
+        )
+        self.assertEqual(mock_customop.register_oot.call_count, len(utils.REGISTERED_ASCEND_OPS) - 2)
         self.assertTrue(utils._ASCEND_CUSTOMOP_IS_REIGISTERED)
 
         # ascend custom op is already registered
         utils.register_ascend_customop()
-        self.assertEqual(mock_customop.register_oot.call_count, len(REGISTERED_ASCEND_OPS))
+        self.assertEqual(mock_pluggable_layer.register_oot.call_count, 2)
+        self.assertEqual(mock_customop.register_oot.call_count, len(utils.REGISTERED_ASCEND_OPS) - 2)
 
     @mock.patch("torch_npu.npu_format_cast")
     def test_maybe_trans_nz(self, mock_npu_format_cast):

--- a/vllm_ascend/_310p/ops/fla/gdn_310.py
+++ b/vllm_ascend/_310p/ops/fla/gdn_310.py
@@ -20,15 +20,14 @@
 import torch
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.mamba.gdn.base import GatedDeltaNetAttention
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import QwenGatedDeltaNetAttention
 from vllm.v1.attention.backend import AttentionMetadata  # type: ignore
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
-from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
 from vllm_ascend._310p.ops.fla.chunk_gated_delta_rule import chunk_gated_delta_rule_310
-from vllm_ascend._310p.ops.fla.fused_gdn_gating import fused_gdn_gating_pytorch
-from vllm_ascend._310p.ops.fla.l2norm import l2norm_310p
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.utils import maybe_save_kv_layer_to_connector
+from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
 from vllm_ascend.utils import enable_sp
 
 
@@ -53,97 +52,6 @@ def _zero_padded_tokens(
     mask_shape = [1] * tensor.ndim
     mask_shape[token_dim] = token_count
     return tensor * valid_mask.reshape(mask_shape).to(dtype=tensor.dtype)
-
-
-def _flatten_state_indices(
-    ssm_state_indices: torch.Tensor,
-    cu_seqlens: torch.Tensor,
-    total_tokens: int,
-) -> torch.Tensor:
-    if ssm_state_indices.ndim == 1:
-        return ssm_state_indices[:total_tokens].to(torch.int32).contiguous()
-
-    num_seqs = (cu_seqlens[1:] - cu_seqlens[:-1]).shape[0]
-    seq_lens = cu_seqlens[1 : num_seqs + 1] - cu_seqlens[:num_seqs]
-    ssm_state_indices = ssm_state_indices[:num_seqs]
-
-    # Uniform spec-decode ACL graph uses fixed q_len per request; reshape avoids
-    # NPU masked_select which breaks stream capture (aclnnMaskedSelect / 107027).
-    if _EXTRA_CTX.capturing or (seq_lens.numel() > 0 and torch.all(seq_lens == seq_lens[0])):
-        q_per_seq = ssm_state_indices.shape[1]
-        flat = ssm_state_indices[:, :q_per_seq].reshape(-1)
-        return flat[:total_tokens].to(torch.int32).contiguous()
-
-    # Eager mixed batches with variable seq_lens: compact on CPU, copy back async.
-    ssm_cpu = ssm_state_indices.cpu()
-    seq_lens_cpu = seq_lens.cpu()
-    q_per_seq = ssm_cpu.shape[1]
-    positions = torch.arange(q_per_seq)
-    valid = positions.unsqueeze(0) < seq_lens_cpu.unsqueeze(1)
-    flat_cpu = ssm_cpu.masked_select(valid).to(torch.int32).contiguous()[:total_tokens]
-    if not flat_cpu.is_pinned:
-        flat_cpu = flat_cpu.pin_memory()
-    flat_dev = torch.empty(flat_cpu.numel(), dtype=torch.int32, device=ssm_state_indices.device)
-    flat_dev.copy_(flat_cpu, non_blocking=True)
-    return flat_dev.contiguous()
-
-
-def _mask_padded_recurrent_accepted_tokens(
-    num_accepted_tokens: torch.Tensor,
-    actual_seq_lengths: torch.Tensor,
-) -> torch.Tensor:
-    accepted_tokens = num_accepted_tokens[: actual_seq_lengths.shape[0]].to(torch.int32).contiguous()
-    return torch.where(
-        actual_seq_lengths > 0,
-        accepted_tokens,
-        torch.zeros_like(accepted_tokens),
-    ).contiguous()
-
-
-def npu_recurrent_gated_delta_rule_310(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    g: torch.Tensor | None,
-    beta: torch.Tensor,
-    state: torch.Tensor,
-    cu_seqlens: torch.Tensor,
-    ssm_state_indices: torch.Tensor,
-    num_accepted_tokens: torch.Tensor | None = None,
-    use_qk_l2norm_in_kernel: bool = True,
-) -> torch.Tensor:
-    if use_qk_l2norm_in_kernel:
-        q = l2norm_310p(q)
-        k = l2norm_310p(k)
-
-    total_tokens = v.shape[1]
-    flat_state_indices = _flatten_state_indices(ssm_state_indices, cu_seqlens, total_tokens)
-    actual_seq_lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).to(torch.int32).contiguous()
-    flat_state_indices = torch.clamp_min(
-        flat_state_indices,
-        0,
-    ).contiguous()
-    accepted_tokens = None
-    if num_accepted_tokens is not None:
-        accepted_tokens = _mask_padded_recurrent_accepted_tokens(
-            num_accepted_tokens,
-            actual_seq_lengths,
-        )
-
-    out = torch.ops._C_ascend.npu_recurrent_gated_delta_rule_310(
-        query=q.squeeze(0).to(torch.float16).contiguous(),
-        key=k.squeeze(0).to(torch.float16).contiguous(),
-        value=v.squeeze(0).to(torch.float16).contiguous(),
-        g=None if g is None else g.squeeze(0).to(torch.float32).contiguous(),
-        gk=None,
-        beta=beta.squeeze(0).to(torch.float16).contiguous(),
-        state=state,
-        actual_seq_lengths=actual_seq_lengths,
-        ssm_state_indices=flat_state_indices,
-        num_accepted_tokens=accepted_tokens,
-        scale_value=k.shape[-1] ** -0.5,
-    ).unsqueeze(0)
-    return out
 
 
 def _310p_get_state_dtype(self) -> tuple[torch.dtype, torch.dtype]:
@@ -217,7 +125,6 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
         attn_metadata = attn_metadata[self.prefix]
         assert isinstance(attn_metadata, GDNAttentionMetadata)
         has_initial_state = attn_metadata.has_initial_state
-        spec_query_start_loc = attn_metadata.spec_query_start_loc
         non_spec_query_start_loc = attn_metadata.non_spec_query_start_loc
         spec_sequence_masks = attn_metadata.spec_sequence_masks
         spec_token_indx = attn_metadata.spec_token_indx
@@ -262,48 +169,45 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
                     spec_valid_tokens,
                     token_dim=0,
                 )
-            mixed_qkv_spec = torch.ops._C_ascend.npu_causal_conv1d_310(
-                mixed_qkv_spec,
-                conv_weights,
+            mixed_qkv_spec = DeviceOperator.gdn_causal_conv1d(
+                x=mixed_qkv_spec,
+                weight=conv_weights,
+                conv_state=conv_state,
                 bias=self.conv1d.bias,
-                conv_states=conv_state,
                 query_start_loc=spec_query_start_loc_device,
                 cache_indices=spec_causal_conv1d_meta.cache_indices,
                 initial_state_mode=None,
                 num_accepted_tokens=spec_causal_conv1d_meta.num_accepted_tokens,
                 activation_mode=activation_num,
-                pad_slot_id=PAD_SLOT_ID,
                 run_mode=1,
             )
 
         # 1.2: Process the remaining part
         if attn_metadata.num_prefills > 0:
             if mixed_qkv_non_spec is not None:
-                mixed_qkv_non_spec = torch.ops._C_ascend.npu_causal_conv1d_310(
-                    mixed_qkv_non_spec,
-                    conv_weights,
+                mixed_qkv_non_spec = DeviceOperator.gdn_causal_conv1d(
+                    x=mixed_qkv_non_spec,
+                    weight=conv_weights,
+                    conv_state=conv_state,
                     bias=self.conv1d.bias,
-                    conv_states=conv_state,
                     query_start_loc=non_spec_query_start_loc,
                     cache_indices=non_spec_state_indices_tensor,
                     initial_state_mode=has_initial_state,
                     num_accepted_tokens=None,
                     activation_mode=activation_num,
-                    pad_slot_id=PAD_SLOT_ID,
                     run_mode=0,
                 )
         elif attn_metadata.num_decodes > 0:
-            mixed_qkv_non_spec = torch.ops._C_ascend.npu_causal_conv1d_310(
-                mixed_qkv_non_spec,
-                conv_weights,
+            mixed_qkv_non_spec = DeviceOperator.gdn_causal_conv1d(
+                x=mixed_qkv_non_spec,
+                weight=conv_weights,
+                conv_state=conv_state,
                 bias=self.conv1d.bias,
-                conv_states=conv_state,
                 query_start_loc=None,
                 cache_indices=non_spec_state_indices_tensor[: attn_metadata.num_actual_tokens],
                 initial_state_mode=None,
                 num_accepted_tokens=None,
                 activation_mode=activation_num,
-                pad_slot_id=PAD_SLOT_ID,
                 run_mode=1,
             )
         else:
@@ -311,7 +215,7 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
         query_spec, key_spec, value_spec = self.rearrange_mixed_qkv(mixed_qkv_spec)
         query_non_spec, key_non_spec, value_non_spec = self.rearrange_mixed_qkv(mixed_qkv_non_spec)
 
-        g, beta = fused_gdn_gating_pytorch(self.A_log, a, b, self.dt_bias)
+        g, beta = DeviceOperator.fused_gdn_gating(self.A_log, a, b, self.dt_bias)
         if attn_metadata.num_prefills > 0 or spec_sequence_masks is not None:
             if spec_sequence_masks is not None:
                 if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
@@ -334,17 +238,18 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
 
             # 2.1: Process the multi-query part
             if spec_sequence_masks is not None:
-                core_attn_out_spec = npu_recurrent_gated_delta_rule_310(
-                    q=query_spec,
-                    k=key_spec,
-                    v=value_spec,
+                spec_decode_metadata = attn_metadata.spec_decode_metadata
+                assert spec_decode_metadata is not None
+                core_attn_out_spec = DeviceOperator.gdn_recurrent_decode(
+                    query=query_spec,
+                    key=key_spec,
+                    value=value_spec,
                     g=g_spec,
                     beta=beta_spec,
                     state=ssm_state,
-                    cu_seqlens=spec_query_start_loc[: attn_metadata.num_spec_decodes + 1],
-                    ssm_state_indices=spec_state_indices_tensor,
+                    actual_seq_lengths=spec_decode_metadata.actual_seq_lengths,
+                    state_indices=spec_state_indices_tensor,
                     num_accepted_tokens=spec_causal_conv1d_meta.num_accepted_tokens,
-                    use_qk_l2norm_in_kernel=True,
                 )
             else:
                 core_attn_out_spec = None
@@ -372,31 +277,33 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
                 # Init cache
                 ssm_state[non_spec_state_indices_tensor] = last_recurrent_state.to(ssm_state.dtype)
             elif attn_metadata.num_decodes > 0:
-                core_attn_out_non_spec = npu_recurrent_gated_delta_rule_310(
-                    q=query_non_spec,
-                    k=key_non_spec,
-                    v=value_non_spec,
+                non_spec_decode_metadata = attn_metadata.non_spec_decode_metadata
+                assert non_spec_decode_metadata is not None
+                core_attn_out_non_spec = DeviceOperator.gdn_recurrent_decode(
+                    query=query_non_spec,
+                    key=key_non_spec,
+                    value=value_non_spec,
                     g=g_non_spec,
                     beta=beta_non_spec,
                     state=ssm_state,
-                    cu_seqlens=non_spec_query_start_loc[: attn_metadata.num_decodes + 1],
-                    ssm_state_indices=non_spec_state_indices_tensor,
-                    use_qk_l2norm_in_kernel=True,
+                    actual_seq_lengths=non_spec_decode_metadata.actual_seq_lengths,
+                    state_indices=non_spec_state_indices_tensor,
                 )
             else:
                 core_attn_out_non_spec = None
 
         elif attn_metadata.num_decodes > 0:
-            core_attn_out_non_spec = npu_recurrent_gated_delta_rule_310(
-                q=query_non_spec,
-                k=key_non_spec,
-                v=value_non_spec,
+            non_spec_decode_metadata = attn_metadata.non_spec_decode_metadata
+            assert non_spec_decode_metadata is not None
+            core_attn_out_non_spec = DeviceOperator.gdn_recurrent_decode(
+                query=query_non_spec,
+                key=key_non_spec,
+                value=value_non_spec,
                 g=g,
                 beta=beta,
                 state=ssm_state,
-                cu_seqlens=non_spec_query_start_loc,
-                ssm_state_indices=non_spec_state_indices_tensor,
-                use_qk_l2norm_in_kernel=True,
+                actual_seq_lengths=non_spec_decode_metadata.actual_seq_lengths,
+                state_indices=non_spec_state_indices_tensor,
             )
         # 3. Merge core attention output
         if spec_sequence_masks is not None and core_attn_out_non_spec is not None:
@@ -427,3 +334,14 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
                 )
             )
         maybe_save_kv_layer_to_connector("", [])
+
+
+class AscendQwenGatedDeltaNetAttention310(QwenGatedDeltaNetAttention):
+    """Out-of-tree Qwen GDN layer using the 310P implementation."""
+
+    _warmup_prefill_kernels = AscendGatedDeltaNetAttention._warmup_prefill_kernels
+    _split_ba_for_tp = AscendGatedDeltaNetAttention._split_ba_for_tp
+    get_state_shape = AscendGatedDeltaNetAttention.get_state_shape
+    _forward_core = AscendGatedDeltaNetAttention310._forward_core
+    get_state_dtype = AscendGatedDeltaNetAttention310.get_state_dtype
+    get_attn_backend = AscendGatedDeltaNetAttention310.get_attn_backend

--- a/vllm_ascend/_310p/ops/gdn_attn_builder_310.py
+++ b/vllm_ascend/_310p/ops/gdn_attn_builder_310.py
@@ -12,18 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""310P RC GDN metadata builder.
-
-This 310P-specific builder keeps the upstream RC-safe prefill metadata path
-and adds ACL graph replay padding for decode / speculative decode metadata.
-"""
+"""310P GDN metadata builder overrides."""
 
 from __future__ import annotations
 
 import torch
 from vllm.v1.attention.backend import CommonAttentionMetadata
-from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
-from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 
 from vllm_ascend._310p.ops.fla.cumpute_causal_conv1d_metadata_310 import (
     compute_causal_conv1d_metadata,
@@ -35,13 +29,7 @@ from vllm_ascend.ops.gdn_attn_builder import (
 
 
 class GDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
-    """310P overrides on top of :class:`AscendGDNAttentionMetadataBuilder`.
-
-    310P does not support Triton, so fallback metadata attachment is skipped.
-    For ACL graph replay, decode metadata is padded into fixed graph buffers.
-    """
-
-    use_full_cuda_graph: bool
+    """310P-specific metadata policies and prefill preparation."""
 
     def _build_prefill_has_initial_state_and_causal_conv1d_meta(
         self,
@@ -80,171 +68,6 @@ class GDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
             batch_ptr,
             token_chunk_offset_ptr,
         )
-
-    def _attach_non_spec_prefill_fallback_meta(
-        self,
-        attn_metadata: GDNAttentionMetadata,
-        common_attn_metadata: CommonAttentionMetadata,
-        non_spec_query_start_loc_cpu: torch.Tensor | None,
-    ) -> GDNAttentionMetadata:
-        del common_attn_metadata, non_spec_query_start_loc_cpu
-        return attn_metadata
-
-    def _attach_spec_decode_fallback_meta(
-        self,
-        attn_metadata: GDNAttentionMetadata,
-        common_attn_metadata: CommonAttentionMetadata,
-        num_decode_draft_tokens_cpu: torch.Tensor | None,
-    ) -> GDNAttentionMetadata:
-        del common_attn_metadata, num_decode_draft_tokens_cpu
-        return attn_metadata
-
-    def _attach_non_spec_decode_fallback_meta(
-        self,
-        attn_metadata: GDNAttentionMetadata,
-        common_attn_metadata: CommonAttentionMetadata,
-        num_decode_draft_tokens_cpu: torch.Tensor | None,
-    ) -> GDNAttentionMetadata:
-        del common_attn_metadata, num_decode_draft_tokens_cpu
-        return attn_metadata
-
-    def _pad_spec_decode_metadata(
-        self,
-        attn_metadata: GDNAttentionMetadata,
-        graph_batch_size: int,
-    ) -> None:
-        num_spec_decodes = attn_metadata.num_spec_decodes
-        spec_state_indices = attn_metadata.spec_state_indices_tensor
-        spec_sequence_masks = attn_metadata.spec_sequence_masks
-        spec_query_start_loc = attn_metadata.spec_query_start_loc
-        num_accepted_tokens = attn_metadata.num_accepted_tokens
-        assert spec_state_indices is not None
-        assert spec_sequence_masks is not None
-        assert spec_query_start_loc is not None
-        assert num_accepted_tokens is not None
-
-        self.spec_state_indices_tensor[:num_spec_decodes].copy_(
-            spec_state_indices,
-            non_blocking=True,
-        )
-        attn_metadata.spec_state_indices_tensor = self.spec_state_indices_tensor[:graph_batch_size]
-        attn_metadata.spec_state_indices_tensor[num_spec_decodes:].fill_(NULL_BLOCK_ID)
-
-        self.spec_sequence_masks[:num_spec_decodes].copy_(
-            spec_sequence_masks[:num_spec_decodes],
-            non_blocking=True,
-        )
-        attn_metadata.spec_sequence_masks = self.spec_sequence_masks[:graph_batch_size]
-        attn_metadata.spec_sequence_masks[num_spec_decodes:].fill_(False)
-
-        assert attn_metadata.non_spec_token_indx is not None
-        assert attn_metadata.spec_token_indx is not None
-        non_spec_tokens = attn_metadata.non_spec_token_indx
-        spec_tokens = attn_metadata.spec_token_indx
-        self.non_spec_token_indx[: non_spec_tokens.size(0)].copy_(
-            non_spec_tokens,
-            non_blocking=True,
-        )
-        self.spec_token_indx[: spec_tokens.size(0)].copy_(
-            spec_tokens,
-            non_blocking=True,
-        )
-        attn_metadata.non_spec_token_indx = self.non_spec_token_indx[: non_spec_tokens.size(0)]
-        attn_metadata.spec_token_indx = self.spec_token_indx[: spec_tokens.size(0)]
-
-        self.spec_query_start_loc[: num_spec_decodes + 1].copy_(
-            spec_query_start_loc,
-            non_blocking=True,
-        )
-        attn_metadata.spec_query_start_loc = self.spec_query_start_loc[: graph_batch_size + 1]
-        query_padding = attn_metadata.spec_query_start_loc[num_spec_decodes + 1 :]
-        if query_padding.numel() > 0:
-            query_padding.copy_(
-                spec_query_start_loc[-1].expand_as(query_padding),
-                non_blocking=True,
-            )
-
-        self.num_accepted_tokens[:num_spec_decodes].copy_(
-            num_accepted_tokens,
-            non_blocking=True,
-        )
-        attn_metadata.num_accepted_tokens = self.num_accepted_tokens[:graph_batch_size]
-        attn_metadata.num_accepted_tokens[num_spec_decodes:].fill_(0)
-        self._attach_spec_decode_metadata(attn_metadata)
-
-    def _pad_decode_metadata(
-        self,
-        attn_metadata: GDNAttentionMetadata,
-        graph_batch_size: int,
-    ) -> None:
-        num_decodes = attn_metadata.num_decodes
-        state_indices = attn_metadata.non_spec_state_indices_tensor
-        query_start_loc = attn_metadata.non_spec_query_start_loc
-        assert state_indices is not None
-        assert query_start_loc is not None
-
-        self.non_spec_state_indices_tensor[:num_decodes].copy_(
-            state_indices,
-            non_blocking=True,
-        )
-        attn_metadata.non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[:graph_batch_size]
-        attn_metadata.non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
-
-        self.non_spec_query_start_loc[: num_decodes + 1].copy_(
-            query_start_loc,
-            non_blocking=True,
-        )
-        attn_metadata.non_spec_query_start_loc = self.non_spec_query_start_loc[: graph_batch_size + 1]
-        query_padding = attn_metadata.non_spec_query_start_loc[num_decodes + 1 :]
-        if query_padding.numel() > 0:
-            query_padding.copy_(
-                query_start_loc[-1].expand_as(query_padding),
-                non_blocking=True,
-            )
-        self._attach_non_spec_decode_metadata(
-            attn_metadata,
-            attn_metadata.non_spec_state_indices_tensor,
-        )
-
-    def build(  # type: ignore[override]
-        self,
-        common_prefix_len: int,
-        common_attn_metadata: CommonAttentionMetadata,
-        num_accepted_tokens: torch.Tensor | None = None,
-        num_decode_draft_tokens_cpu: torch.Tensor | None = None,
-        fast_build: bool = False,
-    ) -> GDNAttentionMetadata:
-        use_full_graph = self.use_full_cuda_graph
-        self.use_full_cuda_graph = False
-        try:
-            attn_metadata = super().build(
-                common_prefix_len,
-                common_attn_metadata,
-                num_accepted_tokens,
-                num_decode_draft_tokens_cpu,
-                fast_build,
-            )
-        finally:
-            self.use_full_cuda_graph = use_full_graph
-
-        if not use_full_graph:
-            return attn_metadata
-
-        graph_batch_size = common_attn_metadata.num_reqs
-        if (
-            attn_metadata.num_prefills == 0
-            and attn_metadata.num_decodes == 0
-            and attn_metadata.num_spec_decodes <= self.decode_cudagraph_max_bs
-            and attn_metadata.num_spec_decode_tokens <= self.decode_cudagraph_max_bs
-        ):
-            self._pad_spec_decode_metadata(attn_metadata, graph_batch_size)
-        elif (
-            attn_metadata.num_prefills == 0
-            and attn_metadata.num_spec_decodes == 0
-            and attn_metadata.num_decodes <= self.decode_cudagraph_max_bs
-        ):
-            self._pad_decode_metadata(attn_metadata, graph_batch_size)
-        return attn_metadata
 
 
 # Keep the name introduced by the 310P ACL graph padding patch so existing

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -21,6 +21,7 @@ import torch
 import torch.nn.functional as F
 import torch_npu
 from vllm.triton_utils import HAS_TRITON
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
 from vllm_ascend.device import utils as device_utils
 from vllm_ascend.device.mxfp_compat import (
@@ -805,6 +806,70 @@ class BaseDeviceAdaptor:
     def npu_gemma_rms_norm(x, weight, variance_epsilon):
         x, _ = torch.ops._C_ascend.npu_gemma_rms_norm(x, weight, variance_epsilon)
         return x
+
+    @staticmethod
+    def gdn_causal_conv1d(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        conv_state: torch.Tensor,
+        bias: torch.Tensor | None,
+        query_start_loc: torch.Tensor | None,
+        cache_indices: torch.Tensor,
+        initial_state_mode: torch.Tensor | None,
+        num_accepted_tokens: torch.Tensor | None,
+        activation_mode: int,
+        run_mode: int,
+    ) -> torch.Tensor:
+        """Run GDN causal convolution using a backend-neutral contract."""
+        output = torch.empty_like(x)
+        torch.ops._C_ascend.npu_causal_conv1d_custom(
+            output,
+            x,
+            weight,
+            conv_state=conv_state,
+            bias_opt=bias,
+            query_start_loc_opt=query_start_loc,
+            cache_indices_opt=cache_indices,
+            initial_state_mode_opt=initial_state_mode,
+            num_accepted_tokens_opt=num_accepted_tokens,
+            activation_mode=activation_mode,
+            pad_slot_id=PAD_SLOT_ID,
+            run_mode=run_mode,
+        )
+        return output
+
+    @staticmethod
+    def gdn_recurrent_decode(
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        g: torch.Tensor | None,
+        beta: torch.Tensor | None,
+        state: torch.Tensor,
+        actual_seq_lengths: torch.Tensor,
+        state_indices: torch.Tensor,
+        num_accepted_tokens: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Run normalized recurrent GDN decode and preserve the input rank."""
+        from vllm.model_executor.layers.fla.ops.l2norm import l2norm_fwd
+
+        if beta is None:
+            raise RuntimeError("GDN recurrent decode requires beta.")
+        query = l2norm_fwd(query)
+        key = l2norm_fwd(key)
+        accepted_tokens = None if num_accepted_tokens is None else num_accepted_tokens.to(torch.int32)
+        return torch.ops._C_ascend.npu_recurrent_gated_delta_rule(
+            query=query.squeeze(0),
+            key=key.squeeze(0),
+            value=value.squeeze(0),
+            g=None if g is None else g.squeeze(0),
+            beta=beta.squeeze(0),
+            state=state,
+            scale=key.shape[-1] ** -0.5,
+            actual_seq_lengths=actual_seq_lengths,
+            ssm_state_indices=state_indices,
+            num_accepted_tokens=accepted_tokens,
+        ).unsqueeze(0)
 
     @staticmethod
     def fused_gdn_gating(A_log: torch.Tensor, a: torch.Tensor, b: torch.Tensor, dt_bias: torch.Tensor):
@@ -1813,6 +1878,135 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
 
 
 class Ascend310PDeviceAdaptor(BaseDeviceAdaptor):
+    @staticmethod
+    def gdn_causal_conv1d(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        conv_state: torch.Tensor,
+        bias: torch.Tensor | None,
+        query_start_loc: torch.Tensor | None,
+        cache_indices: torch.Tensor,
+        initial_state_mode: torch.Tensor | None,
+        num_accepted_tokens: torch.Tensor | None,
+        activation_mode: int,
+        run_mode: int,
+    ) -> torch.Tensor:
+        return torch.ops._C_ascend.npu_causal_conv1d_310(
+            x,
+            weight,
+            bias=bias,
+            conv_states=conv_state,
+            query_start_loc=query_start_loc,
+            cache_indices=cache_indices,
+            initial_state_mode=initial_state_mode,
+            num_accepted_tokens=num_accepted_tokens,
+            activation_mode=activation_mode,
+            pad_slot_id=PAD_SLOT_ID,
+            run_mode=run_mode,
+        )
+
+    @staticmethod
+    def _flatten_gdn_state_indices(
+        state_indices: torch.Tensor,
+        actual_seq_lengths: torch.Tensor,
+        total_tokens: int,
+    ) -> torch.Tensor:
+        from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+
+        if state_indices.ndim == 1:
+            return state_indices[:total_tokens].to(torch.int32).contiguous()
+
+        seq_lens = actual_seq_lengths[1:]
+        num_seqs = seq_lens.shape[0]
+        state_indices = state_indices[:num_seqs]
+
+        # Uniform spec-decode ACL graph uses fixed q_len per request; reshape
+        # avoids NPU masked_select which breaks stream capture.
+        if _EXTRA_CTX.capturing or (seq_lens.numel() > 0 and torch.all(seq_lens == seq_lens[0])):
+            q_per_seq = state_indices.shape[1]
+            flat = state_indices[:, :q_per_seq].reshape(-1)
+            return flat[:total_tokens].to(torch.int32).contiguous()
+
+        # Eager variable-length batches compact on CPU, then copy back async.
+        state_indices_cpu = state_indices.cpu()
+        seq_lens_cpu = seq_lens.cpu()
+        q_per_seq = state_indices_cpu.shape[1]
+        positions = torch.arange(q_per_seq)
+        valid = positions.unsqueeze(0) < seq_lens_cpu.unsqueeze(1)
+        flat_cpu = state_indices_cpu.masked_select(valid).to(torch.int32).contiguous()[:total_tokens]
+        if not flat_cpu.is_pinned:
+            flat_cpu = flat_cpu.pin_memory()
+        flat_device = torch.empty(flat_cpu.numel(), dtype=torch.int32, device=state_indices.device)
+        flat_device.copy_(flat_cpu, non_blocking=True)
+        return flat_device.contiguous()
+
+    @staticmethod
+    def _mask_gdn_accepted_tokens(
+        num_accepted_tokens: torch.Tensor,
+        actual_seq_lengths: torch.Tensor,
+    ) -> torch.Tensor:
+        sequence_lengths = actual_seq_lengths[1:]
+        accepted_tokens = num_accepted_tokens[: sequence_lengths.shape[0]].to(torch.int32).contiguous()
+        return torch.where(
+            sequence_lengths > 0,
+            accepted_tokens,
+            torch.zeros_like(accepted_tokens),
+        ).contiguous()
+
+    @classmethod
+    def gdn_recurrent_decode(
+        cls,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        g: torch.Tensor | None,
+        beta: torch.Tensor | None,
+        state: torch.Tensor,
+        actual_seq_lengths: torch.Tensor,
+        state_indices: torch.Tensor,
+        num_accepted_tokens: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        from vllm_ascend._310p.ops.fla.l2norm import l2norm_310p
+
+        if beta is None:
+            raise RuntimeError("GDN recurrent decode requires beta.")
+        query = l2norm_310p(query)
+        key = l2norm_310p(key)
+        total_tokens = value.shape[1]
+        actual_seq_lengths = actual_seq_lengths.to(torch.int32).contiguous()
+        flat_state_indices = cls._flatten_gdn_state_indices(
+            state_indices,
+            actual_seq_lengths,
+            total_tokens,
+        )
+        flat_state_indices = torch.clamp_min(flat_state_indices, 0).contiguous()
+        accepted_tokens = None
+        if num_accepted_tokens is not None:
+            accepted_tokens = cls._mask_gdn_accepted_tokens(
+                num_accepted_tokens,
+                actual_seq_lengths,
+            )
+
+        return torch.ops._C_ascend.npu_recurrent_gated_delta_rule_310(
+            query=query.squeeze(0).to(torch.float16).contiguous(),
+            key=key.squeeze(0).to(torch.float16).contiguous(),
+            value=value.squeeze(0).to(torch.float16).contiguous(),
+            g=None if g is None else g.squeeze(0).to(torch.float32).contiguous(),
+            gk=None,
+            beta=beta.squeeze(0).to(torch.float16).contiguous(),
+            state=state,
+            actual_seq_lengths=actual_seq_lengths,
+            ssm_state_indices=flat_state_indices,
+            num_accepted_tokens=accepted_tokens,
+            scale_value=key.shape[-1] ** -0.5,
+        ).unsqueeze(0)
+
+    @staticmethod
+    def fused_gdn_gating(A_log: torch.Tensor, a: torch.Tensor, b: torch.Tensor, dt_bias: torch.Tensor):
+        from vllm_ascend._310p.ops.fla.fused_gdn_gating import fused_gdn_gating_pytorch
+
+        return fused_gdn_gating_pytorch(A_log, a, b, dt_bias)
+
     @staticmethod
     def index_fill(
         tensor: torch.Tensor,

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -19,13 +19,12 @@ import torch
 from einops import rearrange
 from vllm.distributed import get_pcp_group
 from vllm.forward_context import get_forward_context
-from vllm.model_executor.layers.fla.ops.l2norm import l2norm_fwd
 from vllm.model_executor.layers.mamba.gdn.base import GatedDeltaNetAttention
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import QwenGatedDeltaNetAttention
 from vllm.model_executor.layers.mamba.mamba_utils import MambaStateShapeCalculator
 from vllm.triton_utils import triton
 from vllm.v1.attention.backend import AttentionBackend, AttentionMetadata  # type: ignore
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
-from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
 from vllm_ascend.attention.utils import maybe_save_kv_layer_to_connector
 from vllm_ascend.device.device_op import DeviceOperator
@@ -179,6 +178,8 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         # 1. Convolution sequence transformation
         conv_weights = self.conv1d.weight.view(self.conv1d.weight.size(0), self.conv1d.weight.size(2))
+        conv_weights_t = conv_weights.transpose(0, 1)
+        activation_mode = 1 if self.activation else 0
         if spec_sequence_masks is not None:
             if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
                 mixed_qkv_spec = mixed_qkv
@@ -192,26 +193,19 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         # 1.1: Process the multi-query part
         if spec_sequence_masks is not None:
-            conv_weights_T = conv_weights.transpose(0, 1)
-            activation_num = 1 if self.activation else 0
             spec_causal_conv1d_meta = attn_metadata.spec_decode_metadata.spec_causal_conv1d
-            spec_query_start_loc_device = spec_causal_conv1d_meta.query_start_loc
-            output_spec = torch.empty_like(mixed_qkv_spec)
-            torch.ops._C_ascend.npu_causal_conv1d_custom(
-                output_spec,
-                mixed_qkv_spec,
-                conv_weights_T,
+            mixed_qkv_spec = DeviceOperator.gdn_causal_conv1d(
+                x=mixed_qkv_spec,
+                weight=conv_weights_t,
                 conv_state=self_kv_cache[0],
-                bias_opt=self.conv1d.bias,
-                query_start_loc_opt=spec_query_start_loc_device,
-                cache_indices_opt=spec_causal_conv1d_meta.cache_indices,
-                initial_state_mode_opt=None,
-                num_accepted_tokens_opt=spec_causal_conv1d_meta.num_accepted_tokens,
-                activation_mode=activation_num,
-                pad_slot_id=PAD_SLOT_ID,
+                bias=self.conv1d.bias,
+                query_start_loc=spec_causal_conv1d_meta.query_start_loc,
+                cache_indices=spec_causal_conv1d_meta.cache_indices,
+                initial_state_mode=None,
+                num_accepted_tokens=spec_causal_conv1d_meta.num_accepted_tokens,
+                activation_mode=activation_mode,
                 run_mode=1,
             )
-            mixed_qkv_spec = output_spec
 
         # 1.2: Process the remaining part
         if attn_metadata.num_prefills > 0:
@@ -221,8 +215,6 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 cache_indices_opt = non_spec_causal_conv1d_meta.cache_indices
                 initial_state_mode_opt = non_spec_causal_conv1d_meta.initial_state_mode
                 if get_pcp_group().world_size > 1:
-                    conv_weights_T = conv_weights.transpose(0, 1)
-                    activation_num = 1 if self.activation else 0
                     non_spec_query_start_loc = attn_metadata.non_spec_query_start_loc
                     assert non_spec_query_start_loc is not None
                     non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor
@@ -243,66 +235,49 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                         self_kv_cache[0][prefill_cache_indices, :state_len, :] = all_last_width_prefill_x[
                             pcp_rank - 1, ...
                         ].transpose(-1, -2)
-                    mixed_qkv_non_spec_output = torch.empty_like(mixed_qkv_non_spec)
-                    torch.ops._C_ascend.npu_causal_conv1d_custom(
-                        mixed_qkv_non_spec_output,
-                        mixed_qkv_non_spec,
-                        conv_weights_T,
+                    mixed_qkv_non_spec = DeviceOperator.gdn_causal_conv1d(
+                        x=mixed_qkv_non_spec,
+                        weight=conv_weights_t,
                         conv_state=self_kv_cache[0],
-                        bias_opt=self.conv1d.bias,
-                        query_start_loc_opt=query_start_loc_opt,
-                        cache_indices_opt=cache_indices_opt,
-                        initial_state_mode_opt=initial_state_mode_opt,
-                        num_accepted_tokens_opt=None,
-                        activation_mode=activation_num,
-                        pad_slot_id=PAD_SLOT_ID,
+                        bias=self.conv1d.bias,
+                        query_start_loc=query_start_loc_opt,
+                        cache_indices=cache_indices_opt,
+                        initial_state_mode=initial_state_mode_opt,
+                        num_accepted_tokens=None,
+                        activation_mode=activation_mode,
                         run_mode=0,
                     )
-                    mixed_qkv_non_spec = mixed_qkv_non_spec_output
                     if prefill_cache_indices.shape[0] > 0:
                         self_kv_cache[0][prefill_cache_indices, :state_len, :] = all_last_width_prefill_x[
                             -1, ...
                         ].transpose(-1, -2)
                 else:
-                    conv_weights_T = conv_weights.transpose(0, 1)
-                    activation_num = 1 if self.activation else 0
-                    mixed_qkv_non_spec_output = torch.empty_like(mixed_qkv_non_spec)
-                    torch.ops._C_ascend.npu_causal_conv1d_custom(
-                        mixed_qkv_non_spec_output,
-                        mixed_qkv_non_spec,
-                        conv_weights_T,
+                    mixed_qkv_non_spec = DeviceOperator.gdn_causal_conv1d(
+                        x=mixed_qkv_non_spec,
+                        weight=conv_weights_t,
                         conv_state=self_kv_cache[0],
-                        bias_opt=self.conv1d.bias,
-                        query_start_loc_opt=query_start_loc_opt,
-                        cache_indices_opt=cache_indices_opt,
-                        initial_state_mode_opt=initial_state_mode_opt,
-                        num_accepted_tokens_opt=None,
-                        activation_mode=activation_num,
-                        pad_slot_id=PAD_SLOT_ID,
+                        bias=self.conv1d.bias,
+                        query_start_loc=query_start_loc_opt,
+                        cache_indices=cache_indices_opt,
+                        initial_state_mode=initial_state_mode_opt,
+                        num_accepted_tokens=None,
+                        activation_mode=activation_mode,
                         run_mode=0,
                     )
-                    mixed_qkv_non_spec = mixed_qkv_non_spec_output
         elif attn_metadata.num_decodes > 0:
-            conv_weights_T = conv_weights.transpose(0, 1)
-            activation_num = 1 if self.activation else 0
             non_spec_causal_conv1d_meta = attn_metadata.non_spec_decode_metadata.causal_conv1d
-            non_spec_query_start_loc_device = non_spec_causal_conv1d_meta.query_start_loc
-            output_non_spec = torch.empty_like(mixed_qkv_non_spec)
-            torch.ops._C_ascend.npu_causal_conv1d_custom(
-                output_non_spec,
-                mixed_qkv_non_spec,
-                conv_weights_T,
+            mixed_qkv_non_spec = DeviceOperator.gdn_causal_conv1d(
+                x=mixed_qkv_non_spec,
+                weight=conv_weights_t,
                 conv_state=self_kv_cache[0],
-                bias_opt=self.conv1d.bias,
-                query_start_loc_opt=non_spec_query_start_loc_device,
-                cache_indices_opt=non_spec_causal_conv1d_meta.cache_indices,
-                initial_state_mode_opt=None,
-                num_accepted_tokens_opt=None,
-                activation_mode=activation_num,
-                pad_slot_id=PAD_SLOT_ID,
+                bias=self.conv1d.bias,
+                query_start_loc=non_spec_causal_conv1d_meta.query_start_loc,
+                cache_indices=non_spec_causal_conv1d_meta.cache_indices,
+                initial_state_mode=None,
+                num_accepted_tokens=None,
+                activation_mode=activation_mode,
                 run_mode=1,
             )
-            mixed_qkv_non_spec = output_non_spec
         else:
             mixed_qkv_non_spec = None
 
@@ -336,24 +311,17 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
         # 2.1: Process the multi-query part
         if spec_sequence_masks is not None:
             actual_seq_lengths = attn_metadata.spec_decode_metadata.actual_seq_lengths
-            query_spec = l2norm_fwd(query_spec)
-            key_spec = l2norm_fwd(key_spec)
-            # Dispatches to the vllm-ascend AscendC custom operator
-            # (csrc/recurrent_gated_delta_rule), NOT the built-in CANN operator.
-            # The custom op extends dtype support (e.g. float32 state) and is
-            # loaded at runtime via ASCEND_CUSTOM_OPP_PATH.
-            core_attn_out_spec = torch.ops._C_ascend.npu_recurrent_gated_delta_rule(
-                query=query_spec.squeeze(0),
-                key=key_spec.squeeze(0),
-                value=value_spec.squeeze(0),
-                g=g_spec.squeeze(0),
-                beta=beta_spec.squeeze(0),
+            core_attn_out_spec = DeviceOperator.gdn_recurrent_decode(
+                query=query_spec,
+                key=key_spec,
+                value=value_spec,
+                g=g_spec,
+                beta=beta_spec,
                 state=ssm_state,
-                scale=key_spec.shape[-1] ** -0.5,
                 actual_seq_lengths=actual_seq_lengths,
-                ssm_state_indices=spec_state_indices_tensor.flatten(),
-                num_accepted_tokens=spec_causal_conv1d_meta.num_accepted_tokens.to(torch.int32),
-            ).unsqueeze(0)
+                state_indices=spec_state_indices_tensor.flatten(),
+                num_accepted_tokens=spec_causal_conv1d_meta.num_accepted_tokens,
+            )
         else:
             core_attn_out_spec, last_recurrent_state = None, None
 
@@ -364,19 +332,16 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             assert beta_non_spec is not None
             query_decode, key_decode, value_decode = self.rearrange_mixed_qkv(mixed_qkv_non_spec[:num_decode_tokens])
             actual_seq_lengths = attn_metadata.non_spec_decode_metadata.actual_seq_lengths
-            query_decode = l2norm_fwd(query_decode)
-            key_decode = l2norm_fwd(key_decode)
-            core_attn_out_decode = torch.ops._C_ascend.npu_recurrent_gated_delta_rule(
-                query=query_decode.squeeze(0),
-                key=key_decode.squeeze(0),
-                value=value_decode.squeeze(0),
-                g=g_non_spec[:, :num_decode_tokens].squeeze(0),
-                beta=beta_non_spec[:, :num_decode_tokens].squeeze(0),
+            core_attn_out_decode = DeviceOperator.gdn_recurrent_decode(
+                query=query_decode,
+                key=key_decode,
+                value=value_decode,
+                g=g_non_spec[:, :num_decode_tokens],
+                beta=beta_non_spec[:, :num_decode_tokens],
                 state=ssm_state,
-                scale=key_decode.shape[-1] ** -0.5,
                 actual_seq_lengths=actual_seq_lengths,
-                ssm_state_indices=non_spec_state_indices_tensor[: attn_metadata.num_decodes],
-            ).unsqueeze(0)
+                state_indices=non_spec_state_indices_tensor[: attn_metadata.num_decodes],
+            )
         else:
             core_attn_out_decode = None
 
@@ -420,21 +385,16 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 )
         elif attn_metadata.num_decodes > 0:
             actual_seq_lengths = attn_metadata.non_spec_decode_metadata.actual_seq_lengths
-            query_non_spec = l2norm_fwd(query_non_spec)
-            key_non_spec = l2norm_fwd(key_non_spec)
-            # Dispatches to the vllm-ascend AscendC custom operator
-            # (csrc/recurrent_gated_delta_rule), NOT the built-in CANN operator.
-            core_attn_out_non_spec = torch.ops._C_ascend.npu_recurrent_gated_delta_rule(
-                query=query_non_spec.squeeze(0),
-                key=key_non_spec.squeeze(0),
-                value=value_non_spec.squeeze(0),
-                g=g_non_spec.squeeze(0) if g_non_spec is not None else g_non_spec,
-                beta=beta_non_spec.squeeze(0) if beta_non_spec is not None else beta_non_spec,
+            core_attn_out_non_spec = DeviceOperator.gdn_recurrent_decode(
+                query=query_non_spec,
+                key=key_non_spec,
+                value=value_non_spec,
+                g=g_non_spec,
+                beta=beta_non_spec,
                 state=ssm_state,
-                scale=key_non_spec.shape[-1] ** -0.5,
                 actual_seq_lengths=actual_seq_lengths,
-                ssm_state_indices=non_spec_state_indices_tensor,
-            ).unsqueeze(0)
+                state_indices=non_spec_state_indices_tensor,
+            )
         else:
             core_attn_out_non_spec, last_recurrent_state = None, None
 
@@ -452,3 +412,14 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             core_attn_out[:num_actual_tokens] = core_attn_out_spec.squeeze(0)
         else:
             core_attn_out[:num_actual_tokens] = core_attn_out_non_spec.squeeze(0)
+
+
+class AscendQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
+    """Out-of-tree Qwen GDN layer using the Ascend implementation."""
+
+    _split_ba_for_tp = AscendGatedDeltaNetAttention._split_ba_for_tp
+    get_state_shape = AscendGatedDeltaNetAttention.get_state_shape
+    get_attn_backend = AscendGatedDeltaNetAttention.get_attn_backend
+    forward = AscendGatedDeltaNetAttention.forward
+    _forward_core = AscendGatedDeltaNetAttention._forward_core
+    _warmup_prefill_kernels = AscendGatedDeltaNetAttention._warmup_prefill_kernels

--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -62,6 +62,7 @@ class GDNChunkedPrefillMetadata:
     chunk_indices_large_block: torch.Tensor
     block_indices_cumsum: torch.Tensor
     num_decodes: int = 0
+    prefill_seq_offset: int = 0
 
 
 @dataclass
@@ -138,8 +139,12 @@ def _build_non_spec_chunked_prefill_metadata(
     )
     block_indices_cumsum = prepare_chunk_indices(cu_seqlens_cpu, cumsum_chunk_size)
 
+    cu_seqlens_host = tuple(cu_seqlens_cpu.to(torch.int64).reshape(-1).tolist())
+    sequence_lengths = tuple(end - start for start, end in zip(cu_seqlens_host, cu_seqlens_host[1:]))
+    prefill_seq_offset = sum(1 for seq_len in sequence_lengths if 0 < seq_len <= 1)
+
     return GDNChunkedPrefillMetadata(
-        cu_seqlens_host=tuple(cu_seqlens_cpu.to(torch.int64).reshape(-1).tolist()),
+        cu_seqlens_host=cu_seqlens_host,
         chunk_indices_chunk64_host=tuple(chunk_indices_chunk64.to(torch.int64).reshape(-1).tolist()),
         chunk_indices_chunk64=chunk_indices_chunk64.to(device=device, non_blocking=True),
         chunk_offsets_chunk64=chunk_offsets_chunk64.to(device=device, non_blocking=True),
@@ -147,6 +152,7 @@ def _build_non_spec_chunked_prefill_metadata(
         final_chunk_indices_chunk64=final_chunk_indices_chunk64.to(device=device, non_blocking=True),
         chunk_indices_large_block=chunk_indices_large_block.to(device=device, non_blocking=True),
         block_indices_cumsum=block_indices_cumsum.to(device=device, non_blocking=True),
+        prefill_seq_offset=prefill_seq_offset,
     )
 
 
@@ -600,7 +606,9 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
             f"num_decodes: {num_decodes}, num_spec_decodes: {num_spec_decodes}"
         )
 
-        batch_size = m.num_actual_tokens
+        # GDN state and sequence metadata is indexed by request, while
+        # num_actual_tokens can be token-padded for full graph replay.
+        batch_size = m.num_reqs
 
         if (
             self.use_full_cuda_graph
@@ -610,25 +618,19 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
             and num_spec_decode_tokens <= self.decode_cudagraph_max_bs
         ):
             assert spec_sequence_masks is not None
-            # Spec decode has multiple tokens per request. Keep the metadata
-            # passed to conv1d/recurrent kernels at request granularity; padding
-            # it to the token count makes the conv1d update kernel treat every
-            # token as an independent decode sequence.
-            spec_batch_size = m.num_reqs
-
-            self.spec_state_indices_tensor[spec_batch_size:].fill_(NULL_BLOCK_ID)
+            self.spec_state_indices_tensor[batch_size:].fill_(NULL_BLOCK_ID)
             self.spec_state_indices_tensor[:num_spec_decodes].copy_(
                 spec_state_indices_tensor,
                 non_blocking=True,
             )
-            spec_state_indices_tensor = self.spec_state_indices_tensor[:spec_batch_size]
+            spec_state_indices_tensor = self.spec_state_indices_tensor[:batch_size]
             spec_state_indices_tensor[num_spec_decodes:].fill_(NULL_BLOCK_ID)
 
             self.spec_sequence_masks[:num_spec_decodes].copy_(
                 spec_sequence_masks[:num_spec_decodes],
                 non_blocking=True,
             )
-            spec_sequence_masks = self.spec_sequence_masks[:spec_batch_size]
+            spec_sequence_masks = self.spec_sequence_masks[:batch_size]
             spec_sequence_masks[num_spec_decodes:].fill_(False)
 
             assert non_spec_token_indx is not None and spec_token_indx is not None
@@ -649,14 +651,14 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
                 non_blocking=True,
             )
             spec_num_query_tokens = spec_query_start_loc[-1]  # type: ignore
-            spec_query_start_loc = self.spec_query_start_loc[: spec_batch_size + 1]
+            spec_query_start_loc = self.spec_query_start_loc[: batch_size + 1]
             spec_query_start_loc[num_spec_decodes + 1 :].fill_(spec_num_query_tokens)
 
             self.num_accepted_tokens[:num_spec_decodes].copy_(
                 num_accepted_tokens,
                 non_blocking=True,
             )
-            num_accepted_tokens = self.num_accepted_tokens[:spec_batch_size]
+            num_accepted_tokens = self.num_accepted_tokens[:batch_size]
             num_accepted_tokens[num_spec_decodes:].fill_(1)
 
         if (

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -121,6 +121,7 @@ def chunk_gated_delta_rule_fwd(
         actual_num_decodes = getattr(prebuilt_meta, "num_decodes", None)
         if actual_num_decodes is None:
             actual_num_decodes = num_decodes
+        prefill_seq_offset = getattr(prebuilt_meta, "prefill_seq_offset", actual_num_decodes)
         h_update = chunk_gated_delta_rule_fwd_hupdate(
             k=k,
             w=w,
@@ -157,10 +158,7 @@ def chunk_gated_delta_rule_fwd(
 
         if get_pcp_group().rank_in_group > 0:
             rerun_initial_state = initial_state.clone()
-            if cu_seqlens is not None:
-                _ns_lens = cu_seqlens[1:] - cu_seqlens[:-1]
-                prefill_seq_offset = int(((_ns_lens > 0) & (_ns_lens <= 1)).sum().item())
-            else:
+            if prebuilt_meta is None:
                 prefill_seq_offset = num_decodes
             prefill_slice = slice(prefill_seq_offset, final_state.shape[0])
             rerun_initial_state[prefill_slice] = updated_h_state[prefill_slice]

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -763,14 +763,15 @@
 #
 # ** 17. File: worker/patch_qwen3_5.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#   1. `vllm.model_executor.models.qwen3_5.Qwen3_5GatedDeltaNet._forward_core`
+#   1. Qwen3.5 decoder, full-attention, and MTP forward compatibility
 #    Why:
-#       The class Qwen3_5GatedDeltaNet reuse the `_forward_core` method of Qwen3NextGatedDeltaNet,
-#       but the ascendC ops of Qwen3NextGatedDeltaNet do not support ssm_state with float32 format.
+#       These forward paths require Ascend-specific tensor layouts and MTP pipeline behavior.
 #    How：
-#       patch Qwen3_5GatedDeltaNet._forward_core to use triton ops like `fused_recurrent_gated_delta_rule`.
+#       Patch only the model forward methods that do not expose an out-of-tree replacement hook.
 #    Future Plan:
-#       Remove this patch when all ops in _forward_core support both Qwen3_5 and Qwen3Next.
+#       Remove these patches as upstream exposes stable model-level extension points.
+#    Note:
+#       Qwen GDN itself is registered through PluggableLayer and is no longer patched here.
 #
 # ** 17a. File: worker/patch_idex_310.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -787,20 +788,6 @@
 #       GatherV2 corruption from persistent drafter input buffers.
 #    How:
 #       Reuse the 310P proposer implementation for the first-pass input shift.
-#
-#   3. `vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn.QwenGatedDeltaNetAttention`
-#    Why:
-#       Qwen GDN needs 310P-specific state helpers, forward core, state dtype,
-#       and attention backend/builder wiring.
-#    How:
-#       Patch Qwen GDN methods to use Ascend GDN implementations and the 310P
-#       GDN attention backend. RC devices also route upstream GDNAttentionBackend
-#       to the 310P metadata builder.
-#    Related PR (if no, explain why):
-#       No, 310P custom operator and backend behavior are vllm-ascend specific.
-#    Future Plan:
-#       Remove this patch when upstream exposes stable hooks for 310P GDN
-#       chunk metadata, spec-decode input layout, and backend selection.
 #
 # ** 18. File: worker/patch_cudagraph.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/worker/patch_idex_310.py
+++ b/vllm_ascend/patch/worker/patch_idex_310.py
@@ -1,13 +1,10 @@
 import vllm
-from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import QwenGatedDeltaNetAttention
 
-from vllm_ascend._310p.ops.fla.gdn_310 import AscendGatedDeltaNetAttention310
 from vllm_ascend._310p.ops.fla.idex import (
     prepare_chunk_indices_310,
     prepare_chunk_offsets_310,
 )
 from vllm_ascend._310p.spec_decode.llm_base_proposer_310 import AscendSpecDecodeBaseProposer310
-from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
 from vllm_ascend.utils import is_rc_device
 
@@ -21,30 +18,11 @@ vllm.model_executor.layers.fla.ops.index.prepare_chunk_offsets = prepare_chunk_o
 AscendSpecDecodeBaseProposer.set_inputs_first_pass = (  # type: ignore[method-assign]
     AscendSpecDecodeBaseProposer310.set_inputs_first_pass
 )
-# Patch _warmup_prefill_kernels to no-op on 310P: triton.next_power_of_2 does
-# not exist in the triton version used on 310P CI, and NPU does not use these
-# CUDA warmup kernel anyway.
-QwenGatedDeltaNetAttention._warmup_prefill_kernels = lambda self, qkv_or_qkvz, v_dim: None  # type: ignore[method-assign]
-QwenGatedDeltaNetAttention._split_ba_for_tp = AscendGatedDeltaNetAttention._split_ba_for_tp
-QwenGatedDeltaNetAttention.get_state_shape = AscendGatedDeltaNetAttention.get_state_shape
-QwenGatedDeltaNetAttention._forward_core = AscendGatedDeltaNetAttention310._forward_core
-QwenGatedDeltaNetAttention.get_state_dtype = AscendGatedDeltaNetAttention310.get_state_dtype
-
-# 310P: make Qwen GDN use the 310P attention backend, including the
-# MTP ACL graph padding replay fixes provided by gdn_attn_builder_310.py.
-QwenGatedDeltaNetAttention.get_attn_backend = AscendGatedDeltaNetAttention310.get_attn_backend
 
 if is_rc_device():
     from vllm.model_executor.models.qwen3_vl import Qwen3_VisionTransformer
-    from vllm.v1.attention.backends.gdn_attn import GDNAttentionBackend
 
-    from vllm_ascend._310p.ops.gdn_attn_builder_310 import GDNAttentionMetadataBuilder310
     from vllm_ascend._310p.ops.qwen3vl_310 import rot_pos_emb_310
 
     # 310P RC: use blocking H2D in rot_pos_emb to avoid race with subsequent indexing.
     Qwen3_VisionTransformer.rot_pos_emb = rot_pos_emb_310  # type: ignore[method-assign]
-
-    # Qwen3.5 on 310P RC uses upstream GDNAttentionBackend via MambaBase.get_attn_backend().
-    GDNAttentionBackend.get_builder_cls = staticmethod(  # type: ignore[method-assign]
-        lambda: GDNAttentionMetadataBuilder310
-    )

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -20,7 +20,6 @@
 import torch
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.distributed.parallel_state import get_pp_group
-from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import QwenGatedDeltaNetAttention as _GDNBaseCls
 from vllm.model_executor.models.qwen3_5 import Qwen3_5DecoderLayer
 
 try:
@@ -32,10 +31,6 @@ except ImportError:
 from vllm.model_executor.models.qwen3_next import Qwen3NextAttention
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
-from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
-from vllm_ascend.utils import is_310p
-
-_GDN_PATCH_TARGET = _GDNBaseCls
 
 
 class AscendQwen3NextAttention(Qwen3NextAttention):
@@ -194,16 +189,3 @@ if Qwen3_5MultiTokenPredictor is not None:
 
 Qwen3_5DecoderLayer.forward = AscendQwen3_5DecoderLayer.forward
 Qwen3NextAttention.forward = AscendQwen3NextAttention.forward
-_GDN_PATCH_TARGET._split_ba_for_tp = AscendGatedDeltaNetAttention._split_ba_for_tp
-_GDN_PATCH_TARGET.get_state_shape = AscendGatedDeltaNetAttention.get_state_shape
-_GDN_PATCH_TARGET.get_attn_backend = AscendGatedDeltaNetAttention.get_attn_backend
-
-if is_310p():
-    from vllm_ascend._310p.ops.fla.gdn_310 import AscendGatedDeltaNetAttention310
-
-    _GDN_PATCH_TARGET._forward_core = AscendGatedDeltaNetAttention310._forward_core
-    _GDN_PATCH_TARGET.get_state_dtype = AscendGatedDeltaNetAttention310.get_state_dtype
-else:
-    _GDN_PATCH_TARGET.forward = AscendGatedDeltaNetAttention.forward
-    _GDN_PATCH_TARGET._forward_core = AscendGatedDeltaNetAttention._forward_core
-    _GDN_PATCH_TARGET._warmup_prefill_kernels = AscendGatedDeltaNetAttention._warmup_prefill_kernels

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -696,7 +696,7 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
     global _ASCEND_CUSTOMOP_IS_REIGISTERED
     if _ASCEND_CUSTOMOP_IS_REIGISTERED:
         return
-    from vllm.model_executor.custom_op import CustomOp
+    from vllm.model_executor.custom_op import CustomOp, PluggableLayer
 
     from vllm_ascend.ops.activation import (
         AscendQuickGELU,
@@ -705,7 +705,7 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
     )
     from vllm_ascend.ops.bailing_moe_linear_attn import AscendBailingMoELinearAttention
     from vllm_ascend.ops.conv import AscendConv3dLayer
-    from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
+    from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention, AscendQwenGatedDeltaNetAttention
     from vllm_ascend.ops.layernorm import AscendGemmaRMSNorm, AscendRMSNorm, AscendRMSNormGated
     from vllm_ascend.ops.linear import (
         AscendColumnParallelLinear,
@@ -758,6 +758,7 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
         "RelPosAttention": AscendRelPosAttention,
         "CustomQwen2Decoder": AscendCustomQwen2Decoder,
         "GatedDeltaNetAttention": AscendGatedDeltaNetAttention,
+        "QwenGatedDeltaNetAttention": AscendQwenGatedDeltaNetAttention,
         "BailingMoELinearAttention": AscendBailingMoELinearAttention,
     }
     if vllm_version_is("0.23.0"):
@@ -781,7 +782,10 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
     if is_310p():
         from vllm_ascend._310p.ops.activation import AscendSiluAndMul310
         from vllm_ascend._310p.ops.conv import AscendConv3dLayer310
-        from vllm_ascend._310p.ops.fla.gdn_310 import AscendGatedDeltaNetAttention310
+        from vllm_ascend._310p.ops.fla.gdn_310 import (
+            AscendGatedDeltaNetAttention310,
+            AscendQwenGatedDeltaNetAttention310,
+        )
         from vllm_ascend._310p.ops.layernorm import (
             AscendGemmaRMSNorm310,
             AscendRMSNorm310,
@@ -806,6 +810,7 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
                 "MMEncoderAttention": AscendMMEncoderAttention310,
                 "Conv3dLayer": AscendConv3dLayer310,
                 "GatedDeltaNetAttention": AscendGatedDeltaNetAttention310,
+                "QwenGatedDeltaNetAttention": AscendQwenGatedDeltaNetAttention310,
                 "MRotaryEmbedding": AscendMRotaryEmbedding310,
             }
         )
@@ -814,8 +819,15 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
 
             REGISTERED_ASCEND_OPS["FusedMoE"] = AscendFusedMoE310
 
+    pluggable_layer_names = {
+        "GatedDeltaNetAttention",
+        "QwenGatedDeltaNetAttention",
+    }
     for name, op_cls in REGISTERED_ASCEND_OPS.items():
-        CustomOp.register_oot(_decorated_op_cls=op_cls, name=name)
+        if name in pluggable_layer_names:
+            PluggableLayer.register_oot(_decorated_layer_cls=op_cls, name=name)
+        else:
+            CustomOp.register_oot(_decorated_op_cls=op_cls, name=name)
 
     # NOTE: Keep this at last to ensure all custom actions are registered
     _ASCEND_CUSTOMOP_IS_REIGISTERED = True


### PR DESCRIPTION
### What this PR does / why we need it?

This PR refactors the Qwen3.5 GDN paths shared by Ascend A2/A3/A5 and 310P:

- precomputes the PCP prefill sequence offset in builder-owned host metadata, removing a device `sum().item()` synchronization from the chunked-prefill consumer;
- reuses the common graph-padding implementation on 310P, keeps GDN metadata request-granular through `num_reqs`, and aligns the 310P recurrent operator with the common `[start_offset, seq_len_0, ..., seq_len_n]` contract;
- registers concrete Qwen GDN replacements through `PluggableLayer` and removes the GDN method/backend monkey patches;
- routes causal-convolution, recurrent decode, and gating hardware differences through the existing `DeviceOperator` dispatch contract; A2/A3/A5 use the base adaptor and 310P provides device-specific overrides.

The previous 310P builder copied the full graph-padding flow and temporarily changed builder state before delegating to the common implementation. That copy had already drifted from the request-granular behavior used upstream. GDN layer behavior was also installed through global monkey patches, while the current pinned vLLM exposes `PluggableLayer` specifically for out-of-tree layer replacement. The operator API differences now live in `DeviceOperator` instead of free wrappers inside the model execution flow.

### Does this PR introduce _any_ user-facing change?

No. This is an internal GDN metadata/operator refactor. Existing Qwen3.5 serving interfaces are unchanged.

### How was this patch tested?

Completed locally:

```bash
uvx pre-commit run --files $(git diff --name-only origin/main...HEAD)
python3 -m compileall -q $(git diff --name-only origin/main...HEAD -- '*.py')
git diff --check origin/main...HEAD
```

Added or updated coverage for:

- builder-owned PCP sequence offsets;
- request-granular full-graph padding and dummy accepted-token metadata;
- base and 310P `DeviceOperator` contracts for causal convolution, recurrent decode, and gating;
- common/310P Qwen GDN out-of-tree layer selection;
- padded zero-length requests in the 310P recurrent operator.

Hardware execution is still pending because the local development machine does not provide `torch_npu` or an Ascend device. The following should be run on the corresponding NPU environments:

```bash
pytest -sv tests/ut/device/test_device_op.py \
  tests/ut/ops/test_gdn_attn_builder.py \
  tests/ut/_310p/ops/test_gdn_310.py

pytest -sv \
  tests/e2e/nightly/310p/single_node/ops/singlecard_ops/test_recurrent_gated_delta_rule_v310.py \
  tests/e2e/nightly/single_node/ops/singlecard_ops/test_recurrent_gated_delta_rule_310.py
```

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
