### PR TITLE
[Ops][BugFix] Enabled deterministic computation operators for batch invariance

### DIFF
--- a/vllm_ascend/batch_invariant.py
+++ b/vllm_ascend/batch_invariant.py
@@ -83,6 +83,8 @@ def override_envs_for_invariance():
     os.environ["HCCL_DETERMINISTIC"] = "strict"
     os.environ["LCCL_DETERMINISTIC"] = "1"
 
+    # Enable deterministic computation for operators. Some operators on Ascend A5
+    # do not have deterministic mode enabled by default and must be explicitly set.
     torch.use_deterministic_algorithms(True, warn_only=True)
 
     logger.debug(

--- a/vllm_ascend/batch_invariant.py
+++ b/vllm_ascend/batch_invariant.py
@@ -82,9 +82,12 @@ def override_envs_for_invariance():
 
     os.environ["HCCL_DETERMINISTIC"] = "strict"
     os.environ["LCCL_DETERMINISTIC"] = "1"
+
+    torch.use_deterministic_algorithms(True, warn_only=True)
+
     logger.debug(
         "Batch-invariant env override: weight_nz_mode=0, enable_matmul_allreduce=False, "
-        "HCCL_DETERMINISTIC=strict, LCCL_DETERMINISTIC=1",
+        "HCCL_DETERMINISTIC=strict, LCCL_DETERMINISTIC=1, use_deterministic_algorithms=True",
     )
 
 


### PR DESCRIPTION

### What this PR does / why we need it?

This PR enables deterministic computation algorithms in PyTorch by calling `torch.use_deterministic_algorithms(True, warn_only=True)` within `override_envs_for_invariance()`. This ensures batch-invariant behavior on Ascend NPUs by forcing deterministic operator execution where possible.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Tested via existing batch invariance tests with Qwen3 30B on A5.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
