### PR TITLE
[CI] Optimize nightly A3 scheduling: start single-node/multi-card after double-node pods launched

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -78,7 +78,24 @@ on:
         type: boolean
         default: false
         description: enable Pod AOP pipeline on failure
+      send_ready_signal:
+        required: false
+        type: boolean
+        default: false
+        description: send a commit status signal after pods are ready (used by double-node to unblock downstream jobs)
+      run_id:
+        required: false
+        type: string
+        default: ''
+        description: unique run identifier to isolate signals across concurrent runs (e.g. github.run_id)
+      signal_context_prefix:
+        required: false
+        type: string
+        default: double-node-pods-ready-a3
+        description: commit status context prefix for the pods-ready signal
     secrets:
+      PAT_TOKEN:
+        required: false
       KUBECONFIG_B64:
         required: true
       OBS_ACCESS_KEY_ID:
@@ -237,6 +254,7 @@ jobs:
           kubectl apply -f ./lws.yaml
 
       - name: Wait for pods ready
+        id: wait-pods
         run: |
           set -euo pipefail
           SIZE="${{ inputs.size }}"
@@ -278,6 +296,25 @@ jobs:
             fi
             sleep 2
           done
+
+      - name: Signal pods status via commit status
+        if: always() && inputs.send_ready_signal
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          STATUS_CONTEXT="${{ inputs.signal_context_prefix }}/${{ inputs.run_id }}/${{ inputs.name || inputs.config_file_path }}"
+          if [ "${{ steps.wait-pods.outcome }}" = "success" ]; then
+            STATE="success"
+            DESC="Pods ready"
+          else
+            STATE="failure"
+            DESC="Wait pods timeout or failed"
+          fi
+          curl -s -X POST \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+            -d "{\"state\":\"${STATE}\",\"description\":\"${DESC}\",\"context\":\"${STATUS_CONTEXT}\"}"
 
       - name: Stream logs
         id: stream_logs

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -58,6 +58,7 @@ permissions:
   contents: read
   pull-requests: read
   issues: read
+  statuses: write
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -202,6 +203,7 @@ jobs:
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       aop_multi_enabled: ${{ inputs.aop_enabled }}
       request_id: ${{ inputs.request_id || '' }}
+      send_ready_signal: false
       should_run: >-
         ${{
           needs.parse-trigger.outputs.run == 'true' && (
@@ -241,6 +243,9 @@ jobs:
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       aop_multi_enabled: ${{ inputs.aop_enabled }}
       request_id: ${{ inputs.request_id || '' }}
+      send_ready_signal: true
+      run_id: ${{ github.run_id }}
+      signal_context_prefix: double-node-pods-ready-a3
       should_run: >-
         ${{
           needs.parse-trigger.outputs.run == 'true' && (
@@ -249,13 +254,28 @@ jobs:
           )
         }}
     secrets:
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
       KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
       OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
       OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
 
+  double-node-pods-started:
+    name: Wait for all double-node pods launched
+    needs: [setup-vars, parse-trigger, build-image, multi-node-tests]
+    if: >-
+      always() &&
+      needs.parse-trigger.outputs.run == 'true' &&
+      (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
+    uses: ./.github/workflows/_nightly_wait_for_pods_ready.yaml
+    with:
+      matrix_json: ${{ needs.setup-vars.outputs.double_node }}
+      filter: ${{ needs.parse-trigger.outputs.filter }}
+      context_prefix: 'double-node-pods-ready-a3'
+      run_id: ${{ github.run_id }}
+
   single-node-tests:
     name: single-node
-    needs: [setup-vars, parse-trigger, build-image, double-node-tests]
+    needs: [setup-vars, parse-trigger, build-image, double-node-pods-started]
     if: >-
       always() &&
       needs.parse-trigger.outputs.run == 'true' &&
@@ -285,7 +305,7 @@ jobs:
 
   multi-card-tests:
     name: single-node
-    needs: [setup-vars, parse-trigger, build-image, double-node-tests]
+    needs: [setup-vars, parse-trigger, build-image, double-node-pods-started]
     if: >-
       always() &&
       needs.parse-trigger.outputs.run == 'true' &&


### PR DESCRIPTION
### What this PR does / why we need it?

Before this change, single-node-tests and multi-card-tests waited for ALL double-node-tests to finish executing (including test run, log collection, artifact upload) before starting. This could waste hours of NPU time.

With this change, single-node and multi-card tests start as soon as all double-node pods have been launched and are ready (or failed), without waiting for double-node test execution to complete.

Key changes:

1. _e2e_nightly_multi_node.yaml
   - Add send_ready_signal input (boolean, default false)
   - After "Wait for pods ready" step, POST a commit status signal (success if pods ready, failure if timeout/failed) when
     send_ready_signal is true

2. New file: _nightly_wait_for_pods_ready.yaml
   - Reusable workflow that polls GitHub commit statuses for all expected pod-launch signals
   - Dynamic timeout: pod_wait_min + testcase_timeout * (ceil(N/max_parallel) - 1) + buffer
   - Accepts both success and failure statuses (a failure signal means no pods are consuming NPUs, safe to proceed)

3. schedule_nightly_test_a3.yaml
   - Add statuses: write permission
   - double-node-tests: enable send_ready_signal
   - Add double-node-pods-started job (waits for all double-node pods launched, depends on multi-node-tests to avoid idle polling)
   - single-node-tests and multi-card-tests now depend on double-node-pods-started instead of double-node-tests
   - merge-benchmark-artifacts still depends on double-node-tests  (needs actual test results, not just pod readiness)

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
