### PR TITLE
[Ops][BugFix] Enabled deterministic computation operators for batch invariance

### DIFF
--- a/vllm_ascend/batch_invariant.py
+++ b/vllm_ascend/batch_invariant.py
@@ -84,6 +84,9 @@ def override_envs_for_invariance():
     os.environ["HCCL_DETERMINISTIC"] = "strict"
     os.environ["LCCL_DETERMINISTIC"] = "1"
 
+    # Enable deterministic computation for operators. Some operators on Ascend A5
+    # do not have deterministic mode enabled by default and must be explicitly set.
+    torch.use_deterministic_algorithms(True, warn_only=True)
 
 _batch_invariant_LIB = None
 

--- a/vllm_ascend/batch_invariant.py
+++ b/vllm_ascend/batch_invariant.py
@@ -88,6 +88,7 @@ def override_envs_for_invariance():
     # do not have deterministic mode enabled by default and must be explicitly set.
     torch.use_deterministic_algorithms(True, warn_only=True)
 
+
 _batch_invariant_LIB = None
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR enables deterministic computation algorithms in PyTorch by calling `torch.use_deterministic_algorithms(True, warn_only=True)` within `override_envs_for_invariance()`. This ensures batch-invariant behavior on Ascend NPUs by forcing deterministic operator execution where possible.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Tested via existing batch invariance tests with Qwen3 30B on A5.

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
