### PR TITLE
[Cherry-pick][releases/v0.23.0][LoRA][MoE] Support LoRA with unquantified MoE models

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -677,6 +677,7 @@ estimated_times:
   tests/e2e/pull_request/one_card/lora/test_ilama_lora.py: 150
   tests/e2e/pull_request/one_card/lora/test_llama32_lora.py: 410
   tests/e2e/pull_request/one_card/lora/test_lora_with_spec_decode.py: 660
+  tests/e2e/pull_request/one_card/lora/test_olmoe_lora.py: 400
   tests/e2e/pull_request/one_card/lora/test_qwen35_densemodel_lora.py: 340
   tests/e2e/pull_request/one_card/lora/test_qwen3_multi_loras.py: 220
   tests/e2e/pull_request/one_card/lora/test_qwen3_reranker_lora.py: 370
@@ -715,6 +716,7 @@ estimated_times:
   tests/e2e/pull_request/two_card/aclgraph/test_aclgraph_capture_replay.py: 20
   tests/e2e/pull_request/two_card/lora/test_ilama_lora_tp2.py: 140
   tests/e2e/pull_request/two_card/lora/test_llama32_lora_tp2.py: 550
+  tests/e2e/pull_request/two_card/lora/test_qwen3moe_lora_tp.py: 600
   tests/e2e/pull_request/two_card/spec_decode/test_spec_decode.py: 800
   tests/e2e/pull_request/two_card/test_data_parallel.py: 480
   tests/e2e/pull_request/two_card/test_deepseek_multistream_moe.py: 150

--- a/docs/source/user_guide/feature_guide/lora.md
+++ b/docs/source/user_guide/feature_guide/lora.md
@@ -23,6 +23,8 @@ vllm serve meta-llama/Llama-2-7b \
     --lora-modules '{"name": "sql-lora", "path": "/path/to/lora", "base_model_name": "meta-llama/Llama-2-7b"}'
 ```
 
-## Custom LoRA Operators
+## Note
 
-We have implemented LoRA-related AscendC operators, such as bgmv_shrink, bgmv_expand, sgmv_shrink and sgmv_expand. You can find them under the "csrc/kernels" directory of [vllm-ascend repo](https://github.com/vllm-project/vllm-ascend/tree/main/csrc/kernels).
+- We have implemented LoRA-related AscendC operators, such as bgmv_shrink, bgmv_expand, sgmv_shrink and sgmv_expand. You can find them under the "csrc/kernels" directory of [vllm-ascend repo](https://github.com/vllm-project/vllm-ascend/tree/main/csrc/kernels).
+
+- You can enable LoRA with dense or mixture-of-experts(MoE) models now ([PR #10977](https://github.com/vllm-project/vllm-ascend/pull/10977)). However, we haven't support expert-parallel(EP) or quantification yet when you run MoE models with LoRA.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1895,6 +1895,16 @@ def qwen35_text_lora_files():
     return snapshot_download(repo_id="vllm-ascend/qwen35-4b-text-only-sql-lora")
 
 
+@pytest.fixture(scope="session")
+def qwen3moe_lora_files():
+    return snapshot_download(repo_id="vllm-ascend/qwen3-moe-text2sql-spider")
+
+
+@pytest.fixture(scope="session")
+def olmoe_lora_files():
+    return snapshot_download(repo_id="vllm-ascend/olmoe-instruct-text2sql-spider")
+
+
 def qwen_prompt(questions: list[str]) -> list[str]:
     placeholder = "<|image_pad|>"
     return [

--- a/tests/e2e/pull_request/one_card/lora/test_olmoe_lora.py
+++ b/tests/e2e/pull_request/one_card/lora/test_olmoe_lora.py
@@ -1,0 +1,106 @@
+from collections.abc import Sequence
+
+import vllm
+from vllm.lora.request import LoRARequest
+
+MODEL_PATH = "allenai/OLMoE-1B-7B-0125-Instruct"
+
+PROMPT_TEMPLATE = """I want you to act as a SQL terminal in front of an example database, you need only to return the sql command to me. Do not return any additional explanation. Below is an instruction that describes a task, Write a response that appropriately completes the request.
+"
+##Instruction:
+candidate_poll contains tables such as candidate, people. Table candidate has columns such as Candidate_ID, People_ID, Poll_Source, Date, Support_rate, Consider_rate, Oppose_rate, Unsure_rate. Candidate_ID is the primary key.
+Table people has columns such as People_ID, Sex, Name, Date_of_Birth, Height, Weight. People_ID is the primary key.
+The People_ID of candidate is the foreign key of People_ID of people.
+
+
+###Input:
+{context}
+
+###Response:"""  # noqa: E501
+
+EXPECTED_LORA_OUTPUT = [
+    "SELECT count(*) FROM candidate",
+    "SELECT count(*) FROM candidate",
+    "SELECT poll_source FROM candidate GROUP BY poll_source ORDER BY count(*) DESC LIMIT 1",  # noqa: E501
+    "SELECT poll_source FROM candidate GROUP BY poll_source ORDER BY count(*) DESC LIMIT 1",  # noqa: E501
+]
+
+EXPECTED_BASE_MODEL_OUTPUT = [
+    "SELECT COUNT(Candidate_ID) FROM candidate",
+    "SELECT COUNT(Candidate_ID) FROM candidate",
+    "SELECT Candidate_ID, COUNT(*) as Total_Candidates\nFROM candidate\nINNER JOIN people ON candidate.People_ID = people.People_ID",  # noqa: E501
+    # There are multiple acceptable responses
+    (
+        "SELECT Candidate_ID, Poll_Source FROM candidate WHERE People_ID IN (SELECT People_ID FROM people) ORDER BY COUNT(*) DESC LIMIT 1",  # noqa: E501
+        "SELECT Candidate_ID, Poll_Source FROM candidate WHERE COUNT(People_ID) = (SELECT COUNT(People_ID) FROM people) ORDER BY Candidate_ID DESC LIMIT 1",  # noqa: E501
+    ),
+]
+
+
+def _output_matches(generated: str, accepted: str | Sequence[str]) -> bool:
+    if isinstance(accepted, str):
+        accepted = (accepted,)
+    return any(generated.startswith(s) for s in accepted)
+
+
+def generate_and_test(
+    llm: vllm.LLM,
+    lora_path: str,
+    lora_id: list[int | None] | int | None,
+    compare_lower: bool = False,
+) -> None:
+    prompts = [
+        PROMPT_TEMPLATE.format(context="How many candidates are there?"),
+        PROMPT_TEMPLATE.format(context="Count the number of candidates."),
+        PROMPT_TEMPLATE.format(
+            context="Which poll resource provided the most number of candidate information?"  # noqa: E501
+        ),
+        PROMPT_TEMPLATE.format(context="Return the poll resource associated with the most candidates."),
+    ]
+
+    lora_request = None
+    if isinstance(lora_id, int):
+        lora_request = LoRARequest(str(lora_id), lora_id, lora_path)
+    elif isinstance(lora_id, list):
+        lora_request = [LoRARequest(str(i), i, lora_path) if i is not None else None for i in lora_id]
+
+    sampling_params = vllm.SamplingParams(temperature=0, max_tokens=64)
+    outputs = llm.generate(prompts, sampling_params, lora_request=lora_request)
+    # Print the outputs.
+    generated_texts: list[str] = []
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text.strip()
+        generated_texts.append(generated_text)
+        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+
+    for i in range(len(EXPECTED_LORA_OUTPUT)):
+        req_lora_id = lora_id[i] if isinstance(lora_id, list) else lora_id
+        generated_text = generated_texts[i]
+        expected_output = EXPECTED_LORA_OUTPUT[i] if req_lora_id is not None else EXPECTED_BASE_MODEL_OUTPUT[i]
+
+        if compare_lower:
+            generated_text = generated_text.lower()
+            if isinstance(expected_output, str):
+                expected_output = (expected_output.lower(),)
+            else:
+                expected_output = tuple(s.lower() for s in expected_output)
+        assert _output_matches(generated_text, expected_output), (
+            f"Output {i}: {generated_text!r} does not match any of {expected_output!r}"
+        )
+
+
+def test_olmoe_lora(olmoe_lora_files):
+    # We enable enforce_eager=True here to reduce VRAM usage for lora-test CI,
+    # Otherwise, the lora-test will fail due to CUDA OOM.
+    llm = vllm.LLM(
+        MODEL_PATH,
+        max_model_len=1024,
+        enable_lora=True,
+        max_loras=4,
+        enforce_eager=False,
+        trust_remote_code=True,
+        enable_chunked_prefill=True,
+    )
+
+    generate_and_test(llm, olmoe_lora_files, lora_id=1)

--- a/tests/e2e/pull_request/two_card/lora/test_qwen3moe_lora_tp.py
+++ b/tests/e2e/pull_request/two_card/lora/test_qwen3moe_lora_tp.py
@@ -1,0 +1,68 @@
+import vllm
+from vllm.lora.request import LoRARequest
+
+MODEL_PATH = "Qwen/Qwen3-30B-A3B"
+
+PROMPT_TEMPLATE = """<|im_start|>user
+I want you to act as a SQL terminal in front of an example database, you need only to return the sql command to me.Below is an instruction that describes a task, Write a response that appropriately completes the request.
+"
+##Instruction:
+candidate_poll contains tables such as candidate, people. Table candidate has columns such as Candidate_ID, People_ID, Poll_Source, Date, Support_rate, Consider_rate, Oppose_rate, Unsure_rate. Candidate_ID is the primary key.
+Table people has columns such as People_ID, Sex, Name, Date_of_Birth, Height, Weight. People_ID is the primary key.
+The People_ID of candidate is the foreign key of People_ID of people.
+
+
+###Input:
+{context}
+
+###Response:<|im_end|>
+<|im_start|>assistant"""  # noqa: E501
+
+EXPECTED_LORA_OUTPUT = [
+    "<think>\n\n</think>\n\nSELECT count(*) FROM candidate",
+    "<think>\n\n</think>\n\nSELECT count(*) FROM candidate",
+    "<think>\n\n</think>\n\nSELECT poll_source FROM candidate GROUP BY poll_source ORDER BY count(*) DESC LIMIT 1",  # noqa: E501
+    "<think>\n\n</think>\n\nSELECT poll_source FROM candidate GROUP BY poll_source ORDER BY count(*) DESC LIMIT 1",  # noqa: E501
+]
+
+
+def generate_and_test(llm: vllm.LLM, lora_path: str, lora_id: int) -> None:
+    prompts = [
+        PROMPT_TEMPLATE.format(context="How many candidates are there?"),
+        PROMPT_TEMPLATE.format(context="Count the number of candidates."),
+        PROMPT_TEMPLATE.format(
+            context="Which poll resource provided the most number of candidate information?"  # noqa: E501
+        ),
+        PROMPT_TEMPLATE.format(context="Return the poll resource associated with the most candidates."),
+    ]
+    sampling_params = vllm.SamplingParams(temperature=0, max_tokens=64)
+    outputs = llm.generate(
+        prompts,
+        sampling_params,
+        lora_request=LoRARequest(str(lora_id), lora_id, lora_path) if lora_id else None,
+    )
+    # Print the outputs.
+    generated_texts: list[str] = []
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text.strip()
+        generated_texts.append(generated_text)
+        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+
+    for i in range(len(EXPECTED_LORA_OUTPUT)):
+        assert generated_texts[i].startswith(EXPECTED_LORA_OUTPUT[i])
+
+
+def test_qwen3moe_lora(qwen3moe_lora_files):
+    llm = vllm.LLM(
+        MODEL_PATH,
+        max_model_len=1024,
+        enable_lora=True,
+        max_loras=4,
+        enforce_eager=True,
+        trust_remote_code=True,
+        enable_chunked_prefill=True,
+        tensor_parallel_size=2,
+    )
+
+    generate_and_test(llm, qwen3moe_lora_files, lora_id=1)

--- a/vllm_ascend/lora/fused_moe.py
+++ b/vllm_ascend/lora/fused_moe.py
@@ -1,0 +1,222 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Ascend MoE-LoRA wrapper (v1).
+
+Design (see plan in conversation history):
+
+  - Inherits weight allocation / set_lora / slice helpers from upstream
+    FusedMoEWithLoRA. Only the injection mechanism differs: upstream wraps
+    Triton modular kernel internals (`TritonExperts.activation` / `moe_sum`),
+    which do not exist on Ascend. We instead wrap the per-layer
+    `quant_method.apply` and, inside it, temporarily swap the active
+    `MoECommMethod._apply_mlp` so the LoRA delta is added on permuted
+    activations between the grouped GMMs.
+
+  - Per-layer ownership is critical: `_MoECommMethods` is a module-level
+    singleton shared by all 48 MoE layers. If we wrapped `_apply_mlp` at
+    init time, layer N+1 would compose on top of layer N's wrapper and
+    every forward would stack all layers' LoRA deltas. We bracket the swap
+    inside `apply_wrapper` so only the active layer is in effect.
+
+  - v1 deliberately limits scope to: unquant + AllGather + TP-only +
+    no shared experts + no FusedMC2 + no dynamic EPLB. These are the exact
+    conditions under which `Qwen3-30B-A3B-Thinking-2507` runs cleanly with
+    TP=4 EP=1 on 4×64GB. Other paths assert early so users get a clear
+    error rather than silently wrong outputs.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+from vllm import envs
+from vllm.distributed.parallel_state import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.lora.layers.base import BaseLayerWithLoRA
+from vllm.lora.layers.fused_moe import FusedMoE3DWithLoRA, FusedMoEWithLoRA
+from vllm.lora.layers.utils import _get_lora_device
+
+import vllm_ascend.envs as envs_ascend
+
+
+def _assert_ascend_moe_lora_supported(base_layer: nn.Module) -> None:
+    if getattr(base_layer, "use_ep", False):
+        raise AssertionError(
+            "Ascend MoE LoRA v1 does not support expert parallelism. "
+            "Launch with `--enable-expert-parallel=false` and use TP only "
+            "(e.g. TP=4 for Qwen3-30B-A3B on 4x64GB)."
+        )
+    if getattr(base_layer, "dynamic_eplb", False):
+        raise AssertionError(
+            "Ascend MoE LoRA v1 is incompatible with dynamic EPLB "
+            "(expert migration would break the per-expert LoRA layout)."
+        )
+    if int(envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2) != 0:
+        raise AssertionError(
+            "Ascend MoE LoRA v1 cannot patch FusedMC2 path "
+            "(dispatch_ffn_combine is a single fused C++ op). "
+            "Set VLLM_ASCEND_ENABLE_FUSED_MC2=0."
+        )
+    if getattr(base_layer, "_shared_experts", None) is not None:
+        raise AssertionError(
+            "Ascend MoE LoRA v1 does not wrap the shared_experts path "
+            "(it runs outside quant_method.apply). The target model "
+            "Qwen3-30B-A3B-Thinking-2507 has no shared experts; models "
+            "like DeepSeek-V3 are not yet supported."
+        )
+    if getattr(base_layer, "multistream_overlap_gate", False):
+        raise AssertionError(
+            "multistream_overlap_gate=True interleaves quant_method.apply "
+            "calls on multiple streams; the MoE LoRA path has not been "
+            "validated under this overlap. Disable it for MoE LoRA."
+        )
+
+
+def _recover_moe_lora_routing(lora_context, expanded_row_idx, topk_ids):
+    """Recover per-permuted-row (expert_id, lora_slot) for the dispatched rows.
+
+    npu_moe_init_routing semantics (verified empirically): ``expanded_row_idx``
+    is indexed by the ORIGINAL flat (token, k) position and gives where that
+    pair landed in the expert-sorted array -- not the reverse. So recovering
+    "which (token, k) pair does sorted row i hold" needs the inverse permutation
+    of ``expanded``, not a direct gather by it. ``argsort`` output shape ==
+    input shape (value-independent), so this stays graph-capturable -- no
+    ``.item()``/data-dependent host sync.
+    """
+    top_k = lora_context.top_k
+    expanded = torch.abs(expanded_row_idx)
+    inv_perm = torch.argsort(expanded)
+    expert_per_row = topk_ids.reshape(-1)[inv_perm].to(torch.long)
+
+    # token_lora_indices is a 1D LongTensor sized to max_num_batched_tokens
+    # (host-known constant). Clamping defensively to the last index is a no-op
+    # in normal operation but keeps the gather graph-safe.
+    orig_token = inv_perm // top_k
+    token_lora_indices = lora_context.punica_wrapper.token_lora_indices
+    orig_token = orig_token.clamp_(max=token_lora_indices.numel() - 1)
+    lora_per_row = token_lora_indices[orig_token]
+    return expert_per_row, lora_per_row
+
+
+def moe_lora_apply_w13(lora_context, *, gate_up_out, hidden_states, expanded_row_idx, topk_ids):
+    """Add the w13 LoRA delta into ``gate_up_out`` (in place), before activation.
+
+    Called from ``unquant_apply_mlp`` right after the base gate_up GMM. Returns
+    the recovered per-row routing so the w2 delta can reuse it.
+    """
+    routing = _recover_moe_lora_routing(lora_context, expanded_row_idx, topk_ids)
+    expert_per_row, lora_per_row = routing
+    lora_context.punica_wrapper.add_lora_fused_moe(
+        y=gate_up_out,
+        x=hidden_states,
+        lora_a_stacked=lora_context.w13_lora_a_stacked,
+        lora_b_stacked=lora_context.w13_lora_b_stacked,
+        expert_ids=expert_per_row,
+        adapter_enabled=lora_context.adapter_enabled,
+        token_lora_mapping=lora_per_row,
+    )
+    return routing
+
+
+def moe_lora_apply_w2(lora_context, *, down_out, silu_out, lora_routing):
+    """Add the w2 LoRA delta into ``down_out`` (in place), after the down GMM.
+
+    Reuses the per-row routing computed by ``moe_lora_apply_w13``; ``silu_out``
+    is the activation output that fed the base down GMM.
+    """
+    expert_per_row, lora_per_row = lora_routing
+    lora_context.punica_wrapper.add_lora_fused_moe(
+        y=down_out,
+        x=silu_out,
+        lora_a_stacked=lora_context.w2_lora_a_stacked,
+        lora_b_stacked=lora_context.w2_lora_b_stacked,
+        expert_ids=expert_per_row,
+        adapter_enabled=lora_context.adapter_enabled,
+        token_lora_mapping=lora_per_row,
+    )
+
+
+class AscendFusedMoEWithLoRA(FusedMoEWithLoRA):
+    """Ascend-native MoE-LoRA wrapper.
+
+    Reuses upstream weight allocation, set_lora, reset_lora, and slicing.
+    Instead of the GPU modular-kernel injection, it publishes a per-layer
+    ``MoELoRAContext`` onto the base layer (``_ascend_moe_lora_context``).
+    The Ascend unquant MoE path threads that context through
+    ``MoEFusedExpertsInput`` -> ``MoEMlpComputeInput`` and applies the LoRA
+    delta natively inside ``unquant_apply_mlp`` (see
+    ``moe_lora_apply_w13`` / ``moe_lora_apply_w2`` below) -- no runtime
+    monkey-patch of ``comm._apply_mlp``.
+    """
+
+    def __init__(self, base_layer: nn.Module) -> None:
+        # Skip FusedMoEWithLoRA.__init__: it immediately asserts Triton
+        # internals and calls _inject_lora_into_fused_moe which is GPU-only.
+        BaseLayerWithLoRA.__init__(self)
+        self.base_layer = base_layer
+        _assert_ascend_moe_lora_supported(base_layer)
+        self.tp_size = get_tensor_model_parallel_world_size()
+        self.tp_rank = get_tensor_model_parallel_rank()
+        self.device = _get_lora_device(base_layer)
+        self._enable_aux_cuda_stream = envs.VLLM_LORA_ENABLE_DUAL_STREAM
+        self.moe_config = base_layer.moe_config
+        self._w13_slices = 2 if base_layer.moe_config.is_act_and_mul else 1
+
+    # ------------------------------------------------------------------
+    # Mapping
+    # ------------------------------------------------------------------
+    def set_mapping(self, punica_wrapper):
+        # Upstream FusedMoEWithLoRA.set_mapping (vllm v0.22.0+) chains into
+        # ``self._moe_kernel.fused_experts.set_lora_context(...)``, but
+        # ``_moe_kernel`` is only set by the GPU modular-kernel path that we
+        # deliberately skip in __init__. We instead build the per-layer
+        # MoELoRAContext (now that punica_wrapper is available) and publish it
+        # on the module that ``AscendUnquantizedFusedMoEMethod.apply`` reads via
+        # ``getattr(layer, "_ascend_moe_lora_context", None)`` -- the base layer
+        # itself on 0.23.0, but ``base_layer.routed_experts`` on main (there the
+        # runner *is* the layer and it calls apply with ``layer=routed_experts``).
+        # The context holds stable references (the in-place-updated LoRA stacks,
+        # adapter_enabled and the punica wrapper), so building it once here is
+        # sufficient.
+        BaseLayerWithLoRA.set_mapping(self, punica_wrapper)
+        self.base_layer.set_lora_context(self._build_lora_context())
+
+
+class AscendFusedMoE3DWithLoRA(AscendFusedMoEWithLoRA, FusedMoE3DWithLoRA):
+    """For checkpoints that already fuse w1+w3 into a 3D weight (single slice)."""
+
+    def __init__(self, base_layer: nn.Module) -> None:
+        AscendFusedMoEWithLoRA.__init__(self, base_layer)
+        # Override: 3D MoE LoRA uses a single w13 slice.
+        self._w13_slices = 1
+
+
+# ----------------------------------------------------------------------
+# Upstream compatibility shim: vllm/lora/model_manager.py:create_dummy_lora
+# branches on `module.__class__.__name__ == "FusedMoEWithLoRA"` (and the
+# 3D variant). Without this override, our subclasses would skip the
+# pack_moe path and hit the generic pack() fallback, which produces a
+# flat list of N_experts * 3 sub-LoRAs -- `set_lora` then fails with
+# "too many values to unpack (expected 3)".
+#
+# Overriding only __name__ keeps the actual class object distinct (so
+# isinstance / type identity / debugging are unaffected) but lets the
+# upstream string compare hit our objects.
+# ----------------------------------------------------------------------
+AscendFusedMoEWithLoRA.__name__ = "FusedMoEWithLoRA"
+AscendFusedMoE3DWithLoRA.__name__ = "FusedMoE3DWithLoRA"

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -321,6 +321,94 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         self.add_shrink(buffer, x, lora_a_stacked, scale, **kwargs)
         self.add_expand(y, buffer, lora_b_stacked, output_slices, add_inputs=True, **kwargs)
 
+    def add_lora_fused_moe(
+        self,
+        y: torch.Tensor,
+        x: torch.Tensor,
+        lora_a_stacked: tuple[torch.Tensor, ...],
+        lora_b_stacked: tuple[torch.Tensor, ...],
+        *,
+        topk_weights: torch.Tensor | None = None,
+        sorted_token_ids: torch.Tensor | None = None,
+        expert_ids: torch.Tensor,
+        num_tokens_post_padded: torch.Tensor | None = None,
+        max_lora_rank: int = 0,
+        top_k_num: int = 1,
+        shrink_config=None,
+        expand_config=None,
+        adapter_enabled: torch.Tensor,
+        mul_routed_weight: bool = False,
+        fully_sharded: bool = False,
+        offset: int = 0,
+        token_lora_mapping: torch.Tensor | None = None,
+    ) -> None:
+        """
+        Ascend-native fused MoE LoRA (v2): static-shape per-row gather via the
+        same bgmv_shrink/bgmv_expand AscendC kernels (csrc/kernels/bgmv_*.cpp)
+        used by the dense Linear LoRA layers, instead of grouping rows by a
+        data-dependent ``torch.unique`` over active LoRA ids. The previous
+        ``torch.unique``/``nonzero`` version produced output whose *shape*
+        depended on tensor values, which ACL Graph capture cannot record
+        (it failed with an `aclnnUnique2` error as soon as `enforce_eager`
+        was turned off) -- every tensor below has a shape that depends only
+        on input shapes, never on values, so this stays graph-capturable.
+
+        Rows are already one-token-per-row (top_k_num=1). Each row needs the
+        LoRA slot for (lora_id, expert_id), so we fold both into a single
+        gather index into a ``[max_loras * num_experts, ...]`` view of the
+        existing per-(lora, expert) weight stacks:
+            combined_idx[row] = lora_id[row] * num_experts + expert_id[row]
+        or -1 when the row has no active adapter, mirroring the -1 sentinel
+        ``PunicaWrapperBase.token_lora_indices`` already uses. bgmv_shrink/
+        bgmv_expand skip any row whose index is negative (leaving the
+        zero-initialized shrink buffer / unmodified ``y`` in place), so
+        inactive rows get a zero delta for free -- no Python-level branching
+        needed.
+        """
+        del sorted_token_ids, num_tokens_post_padded, max_lora_rank
+        del shrink_config, expand_config, fully_sharded
+        assert top_k_num == 1, "Ascend MoE LoRA v1 expects pre-expanded rows (top_k_num=1)."
+        if token_lora_mapping is None:
+            token_lora_mapping = self.token_lora_indices
+
+        x2d = x.view(-1, x.shape[-1])
+        y2d = y.view(-1, y.shape[-1])
+        expert_idx = expert_ids.view(-1).to(torch.long)
+        num_experts = lora_a_stacked[0].shape[1]
+
+        lora_idx_safe = token_lora_mapping.clamp(min=0)
+        enabled = (token_lora_mapping >= 0) & adapter_enabled[lora_idx_safe].bool()
+        combined_idx = torch.where(
+            enabled,
+            lora_idx_safe * num_experts + expert_idx,
+            torch.full_like(token_lora_mapping, -1),
+        ).contiguous()
+
+        # bgmv_shrink writes fp32 (its Y_T); bgmv_expand reads fp32 (its X_T),
+        # so the shrink buffer is fp32.
+        rank = lora_a_stacked[0].shape[-2]
+        shrink_out = torch.zeros((x2d.shape[0], rank), dtype=torch.float32, device=x2d.device)
+
+        cur_offset = offset
+        for slice_idx in range(len(lora_a_stacked)):
+            # lora_a_stacked[s]/lora_b_stacked[s]: [max_loras, num_experts, rank, *].
+            # Flattening the leading two dims turns "gather by (lora, expert)"
+            # into "the plain per-row gather" to reuse bgmv_shrink/bgmv_expand.
+            a = lora_a_stacked[slice_idx]
+            b = lora_b_stacked[slice_idx]
+            out_size = b.shape[-2]
+            a_flat = a.view(-1, rank, a.shape[-1])
+            b_flat = b.view(-1, out_size, rank)
+
+            self.bgmv_shrink(x2d, a_flat, shrink_out, combined_idx, 1.0)
+
+            delta = shrink_out
+            if mul_routed_weight and topk_weights is not None:
+                delta = shrink_out * topk_weights.view(-1, 1)
+
+            self.bgmv_expand_slice(delta, b_flat, y2d, combined_idx, cur_offset, out_size, add_inputs=True)
+            cur_offset += out_size
+
     def add_lora_logits(
         self,
         y: torch.Tensor,

--- a/vllm_ascend/lora/utils.py
+++ b/vllm_ascend/lora/utils.py
@@ -10,6 +10,10 @@ from vllm.lora.layers import (
 )
 from vllm.lora.layers.utils import _fully_sharded_can_replace, _not_fully_sharded_can_replace
 
+from vllm_ascend.lora.fused_moe import (
+    AscendFusedMoE3DWithLoRA,
+    AscendFusedMoEWithLoRA,
+)
 from vllm_ascend.ops.linear import (
     AscendQKVParallelLinear,
 )
@@ -73,10 +77,12 @@ def refresh_all_lora_classes():
         AscendMergedQKVParallelLinearWithLoRA,
         AscendMergedQKVParallelLinearWithShardedLoRA,
         AscendQKVParallelLinearWithShardedLoRA,
+        AscendFusedMoEWithLoRA,
+        AscendFusedMoE3DWithLoRA,
     )
     # vLLM #35077 changed _all_lora_classes from set to ordered tuple.
     # Append the Ascend classes in a deterministic order.
     vllm.lora.utils._all_lora_classes = (
-        *vllm.lora.utils._all_lora_classes,
         *ascend_classes,
+        *vllm.lora.utils._all_lora_classes,
     )

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -277,6 +277,9 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
                 w1_scale_bias=w1_scale_bias,
                 w2_scale_bias=w2_scale_bias,
                 swiglu_limit=layer.swiglu_limit,
+                # Per-layer MoE LoRA state, set once by AscendFusedMoEWithLoRA
+                # when an adapter wraps this layer; None for non-LoRA layers.
+                lora_context=getattr(layer, "_ascend_moe_lora_context", None),
             )
         )
         if zero_expert_num > 0 and zero_expert_type is not None:
@@ -575,6 +578,9 @@ else:
         ) -> torch.Tensor:
             states = torch.ops.vllm.maybe_all_reduce_tensor_model_parallel(states)
             return states[..., :trunc_size]
+
+        def set_lora_context(self, lora_context):
+            self.routed_experts._ascend_moe_lora_context = lora_context
 
         def no_shared_forward_impl(  # type: ignore[override]
             self, hidden_states: torch.Tensor, router_logits: torch.Tensor, return_with_event: bool = False

--- a/vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py
@@ -366,6 +366,9 @@ class AscendFusedMoE(FusedMoE):
 
         return quant_type
 
+    def set_lora_context(self, lora_context):
+        self._ascend_moe_lora_context = lora_context
+
     def update_expert_map(self, new_expert_map):
         self._expert_map = new_expert_map
 

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -373,6 +373,9 @@ def unquant_apply_mlp(
     topk_scales: torch.Tensor | None = None,
     need_trans: bool = True,
     swiglu_limit: float = 0.0,
+    lora_context=None,
+    expanded_row_idx: torch.Tensor | None = None,
+    topk_ids: torch.Tensor | None = None,
 ) -> torch.Tensor:
     if need_trans:
         w1 = w1.transpose(1, 2)
@@ -387,6 +390,30 @@ def unquant_apply_mlp(
         group_type=0,
         group_list=group_list,
     )[0]
+
+    # MoE LoRA: only attempt injection when an adapter wraps this layer and the
+    # comm method provided AllGather routing metadata (expanded_row_idx). Lazy
+    # import keeps the core MLP free of any LoRA dependency on the common path.
+    lora_routing = None
+    if lora_context is not None:  # LoRA applied
+        if expanded_row_idx is None or topk_ids is None:
+            raise AssertionError(
+                "MoE LoRA requires expanded_row_idx and topk_ids metadata, "
+                "which are only available in AllGather communication mode. "
+                "Please ensure you are running in a supported configuration."
+            )
+
+        from vllm_ascend.lora.fused_moe import moe_lora_apply_w2, moe_lora_apply_w13
+
+        # LoRA w13 delta: applied to gate_up_out before activation, with the MLP
+        # input as the lora_a input (mirrors the base gate_up GMM above).
+        lora_routing = moe_lora_apply_w13(
+            lora_context,
+            gate_up_out=gate_up_out,
+            hidden_states=hidden_states,
+            expanded_row_idx=expanded_row_idx,
+            topk_ids=topk_ids,
+        )
 
     if activation == MoEActivation.SWIGLUOAI:
         num_experts, _, hidden_size = w1.shape
@@ -418,6 +445,16 @@ def unquant_apply_mlp(
         group_type=0,
         group_list=group_list,
     )[0]
+
+    # LoRA w2 delta: applied to the down-proj output, with the activation output
+    # as the lora_a input. Reuses the per-row routing computed for w13.
+    if lora_routing is not None:
+        moe_lora_apply_w2(
+            lora_context,
+            down_out=hidden_states,
+            silu_out=gate_up_out,
+            lora_routing=lora_routing,
+        )
     return hidden_states, None
 
 
@@ -460,6 +497,9 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
             topk_scales=topk_scales,
             need_trans=need_trans,
             swiglu_limit=swiglu_limit,
+            lora_context=mlp_compute_input.lora_context,
+            expanded_row_idx=mlp_compute_input.expanded_row_idx,
+            topk_ids=mlp_compute_input.topk_ids,
         )
 
     assert w1_scale is not None and w2_scale is not None

--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -147,6 +147,7 @@ def build_fused_experts_input(
     w1_offset: torch.Tensor | None = None,
     w2_offset: torch.Tensor | None = None,
     swiglu_limit: float | None = 0.0,
+    lora_context=None,
 ) -> MoEFusedExpertsInput:
     if not vllm_version_is("0.23.0") and swiglu_limit is None:
         swiglu_limit = 0.0
@@ -193,6 +194,7 @@ def build_fused_experts_input(
             is_per_channel_weight=is_per_channel_weight,
         ),
         swiglu_limit=swiglu_limit,
+        lora_context=lora_context,
     )
 
 
@@ -219,6 +221,8 @@ def build_mlp_compute_input(
     if fused_experts_input.quant.is_mxfp and fused_experts_input.quant.mxfp is None:
         raise ValueError("fused_experts_input.quant.mxfp is required for MXFP quant types.")
 
+    expanded_row_idx = getattr(token_dispatch_output.combine_metadata, "expanded_row_idx", None)
+
     return MoEMlpComputeInput(
         hidden_states=token_dispatch_output.hidden_states,
         group_list=token_dispatch_output.group_list,
@@ -241,6 +245,9 @@ def build_mlp_compute_input(
         need_trans=fused_experts_input.need_trans,
         dynamic_eplb=fused_experts_input.dynamic_eplb,
         swiglu_limit=fused_experts_input.swiglu_limit,
+        expanded_row_idx=expanded_row_idx,
+        topk_ids=fused_experts_input.topk_ids,
+        lora_context=fused_experts_input.lora_context,
     )
 
 

--- a/vllm_ascend/ops/fused_moe/moe_stage_contracts.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_contracts.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 import numpy as np
 import torch
@@ -69,6 +69,10 @@ class MoEFusedExpertsInput:
     need_trans: bool = False
     dynamic_eplb: bool = False
     swiglu_limit: float = 0.0
+    # Optional per-layer MoE LoRA state (vllm_ascend.lora MoELoRAContext).
+    # ``Any`` avoids coupling the core contracts to the LoRA module; only the
+    # unquant MLP path reads it, and only when a LoRA adapter is active.
+    lora_context: Any = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -141,6 +145,10 @@ class MoEMlpComputeInput:
     need_trans: bool = False
     dynamic_eplb: bool = False
     swiglu_limit: float = 0.0
+    expanded_row_idx: torch.Tensor | None = None
+    topk_ids: torch.Tensor | None = None
+    # Optional per-layer MoE LoRA state, propagated from MoEFusedExpertsInput.
+    lora_context: Any = None
 
 
 __all__ = [


### PR DESCRIPTION
### What this PR does / why we need it

Brings **MoE LoRA** support to the `releases/v0.23.0` line. The feature was
added on `main` in #10977 but is not present on v0.23.0, so on the release
line models such as `Qwen3-30B-A3B` currently cannot use LoRA.

By injecting LoRA w13/w2 delta logic into `unquant_apply_mlp`, MoE LoRA works
with `TP>1` and ACLGraph mode. The delta path is gated on `lora_context`
(only active when a LoRA adapter wraps the layer), so non-LoRA MoE inference
is unaffected.

Based on #10977 by @paulyu12.

### Does this PR introduce any user-facing change?

Enables MoE LoRA on the v0.23.0 release line. No change for non-LoRA paths
(the LoRA delta is only applied when an adapter is loaded).

### How was it tested?

Includes the same e2e tests as #10977
(`tests/e2e/.../lora/test_olmoe_lora.py`,
`tests/e2e/.../lora/test_qwen3moe_lora_tp.py`).

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
