### PR TITLE
[v0.23.0][BugFix] Fix layerwise KV pool IndexError when MTP is enabled

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -522,11 +522,32 @@ class KVPoolWorker:
         except AttributeError:
             return cache.storage().data_ptr()
 
+    def _extract_physical_layer_index(self, layer_name: str) -> int:
+        import regex as re
+
+        m = re.search(r"layers\.(\d+)", layer_name)
+        if m:
+            return int(m.group(1))
+        # MTP layers have names like "mtp.0.self_attn.xxx" without "layers."
+        # prefix. Map them after the main model layers.
+        if ".mtp." in f".{layer_name}.":
+            m = re.search(r"mtp\.(\d+)", layer_name)
+            if m:
+                num_hidden_layers = getattr(self.hf_config, "num_hidden_layers", self.num_layers)
+                return num_hidden_layers + int(m.group(1))
+        m = re.search(r"(\d+)", layer_name)
+        return int(m.group(1)) if m else 0
+
     def _infer_cache_group_metadata(self, group_id: int, layer_names: list[str]):
         group_addrs: list[int] = []
         group_block_lens: list[int] = []
         group_block_strides: list[int] = []
+        physical_layers = set()
         for layer_name in layer_names:
+            phys = self._extract_physical_layer_index(layer_name)
+            if phys >= self.num_layers:
+                continue
+            physical_layers.add(phys)
             cache_or_caches = self.kv_caches[layer_name]
             for cache in self._as_cache_tuple(cache_or_caches):
                 base_addr = cache.data_ptr()
@@ -537,7 +558,7 @@ class KVPoolWorker:
         self.group_kv_caches_base_addr[group_id] = group_addrs
         self.group_block_len[group_id] = group_block_lens
         self.group_block_stride[group_id] = group_block_strides
-        self.group_num_layers[group_id] = len(layer_names)
+        self.group_num_layers[group_id] = len(physical_layers)
 
     def _align_kv_ptrs(self, registered_regions: dict[int, tuple[int, int]]):
         """
@@ -1167,6 +1188,8 @@ class KVPoolWorker:
                 submitted_layers += 1
 
     def wait_for_layer_load(self) -> None:
+        if self.current_layer >= self.num_layers:
+            return
         assert self.layer_load_finished_events is not None
         reset_attention_compute_start_gate()
         self._submit_ready_layer_loads()


### PR DESCRIPTION
## Bug Fix: Layerwise KV Pool IndexError when MTP is enabled

### Problem
When using layerwise KV pool (MemCache backend) with MTP speculative decoding enabled, vLLM crashes with `IndexError: list index out of range` on the first inference request.

### Root Cause
1. `_infer_cache_group_metadata` counts ALL layer names (including MTP draft layers) in `group_num_layers`, causing `num_layers` to be inflated (e.g., 47 → 48 for GLM-4.7-Flash with 1 MTP layer).
2. `layer_save_tasks` / `layer_load_tasks` are initialized with the original `num_layers` (47), but iterated with the inflated `num_layers` (48) → **IndexError**.
3. `wait_for_layer_load` lacks the MTP guard that `save_kv_layer` already has, causing a second IndexError when MTP draft model executes.

### Fix
1. **Add `_extract_physical_layer_index` method**: identifies MTP layers by name pattern (`mtp.N.xxx` → `num_hidden_layers + N`), which maps to an index >= `num_layers`.
2. **Skip MTP layers in `_infer_cache_group_metadata`**: MTP layers (`phys >= num_layers`) are excluded from `group_num_layers`, so `num_layers` stays at the correct value (47).
3. **Add `wait_for_layer_load` MTP guard**: `if self.current_layer >= self.num_layers: return`, matching the existing guard in `save_kv_layer`.

### Verification
Tested with GLM-4.7-Flash (TP=4) + MTP + layerwise MemCache:
- Service starts successfully (no IndexError)
- Inference works correctly
- KV pool cache hits on repeated requests (`hit_blocks=8/8`, External prefix cache hit rate: 45.4%)

### Note
This fix is already validated on the `feature/multi-group-v0.23` branch (commit 170094407). This PR cherry-picks the relevant changes to `releases/v0.23.0`.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
