### PR TITLE
[BugFix][Worker] Restore DSA compress dummy metadata zeroing

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3166,6 +3166,7 @@ class NPUModelRunner(GPUModelRunner):
         logits_indices: torch.Tensor | None = None,
         use_spec_decode: bool = False,
         for_cudagraph_capture: bool = False,
+        is_dummy_run: bool = False,
         num_scheduled_tokens: dict[str, int] | None = None,
         num_scheduled_tokens_np: np.ndarray | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
@@ -3247,8 +3248,16 @@ class NPUModelRunner(GPUModelRunner):
                 # Fill unused with -1. Needed for reshape_and_cache in full cuda
                 # graph mode. `blk_table_tensor` -1 to match mamba PAD_SLOT_ID
                 if self.pcp_size == 1:
-                    slot_mapping[num_tokens:num_tokens_padded].fill_(-1)
-                    blk_table_tensor[num_reqs:num_reqs_padded].fill_(0)
+                    if self.use_compress and is_dummy_run:
+                        # Do not remove this initialization. During compress dummy
+                        # runs, slot mappings and block tables may contain invalid
+                        # values because _prepare_inputs() is skipped. Reset them to
+                        # zero to avoid NPU hangs.
+                        slot_mapping[:num_tokens_padded].fill_(0)
+                        blk_table_tensor[:num_reqs_padded].fill_(0)
+                    else:
+                        slot_mapping[num_tokens:num_tokens_padded].fill_(-1)
+                        blk_table_tensor[num_reqs:num_reqs_padded].fill_(0)
             if self.pcp_size > 1:
                 slot_mapping = self.pcp_manager.get_padded_slot_mapping(
                     num_tokens,
@@ -3669,6 +3678,7 @@ class NPUModelRunner(GPUModelRunner):
                 max_query_len=max_query_len,
                 ubatch_slices=ubatch_slices_padded if pad_attn else ubatch_slices,
                 for_cudagraph_capture=is_graph_capturing,
+                is_dummy_run=True,
                 num_scheduled_tokens_np=num_scheduled_tokens,
             )
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR restores explicit cache-metadata initialization for DSA/compress dummy runs.

Compress dummy and ACL graph-capture runs do not go through the normal `_prepare_inputs()` path. Their `slot_mapping` and block-table buffers can therefore retain values from a previous real request. Feeding those stale block and `[block, offset]` scatter indices into DSA kernels can cause intermittent accuracy errors, hangs, or out-of-bounds accesses.

The fix:

- marks `_build_attention_metadata()` calls from `_dummy_run()` explicitly;
- zeroes the complete dummy-run `slot_mapping` and block-table ranges only when compression is enabled;
- preserves the existing `-1` padding behavior for normal requests;
- includes a prominent `Do not remove` comment explaining the safety requirement.

This restores the safety behavior originally introduced by #9818 and lost during the synchronization in #11513.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. It prevents DSA/compress dummy runs from consuming stale cache metadata.

### How was this patch tested?

- `python -m py_compile vllm_ascend/worker/model_runner_v1.py tests/ut/worker/a2/test_model_runner_v1.py`
- `PATH="$PWD/.venv/bin:$PATH" bash format.sh ci`
- `git diff --check`

No dedicated unit test was added because this branch mutates NPU-backed cache metadata inside the complete attention-metadata builder. The relevant DSA/compress dummy ACL graph path requires validation in the supported Ascend runtime; this macOS checkout does not have `pytest`, `torch`, `vllm`, or NPU hardware.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
