### PR TITLE
[Bugfix] Add error log, eplb not support w4a8mxfp

### DIFF
--- a/vllm_ascend/eplb/adaptor/vllm_adaptor.py
+++ b/vllm_ascend/eplb/adaptor/vllm_adaptor.py
@@ -129,6 +129,8 @@ class VllmEplbAdaptor:
         for local_idx, layer in enumerate(self.moe_layers):
             quant_type = QuantType.NONE if self.model.quant_config is None else layer.quant_type
             expert_weight_key = (quant_type, get_ascend_config().enable_fused_mc2 == 1)
+            if expert_weight_key[0] == QuantType.W4A8MXFP:
+                raise RuntimeError(f"EPLB not support {quant_type}")
             if expert_weight_key not in EPLB_EXPERT_WEIGHT_NAMES:
                 raise ValueError(f"EPLB not support {quant_type} with fused MC2 {expert_weight_key[1]}")
             expert_weight_names = EPLB_EXPERT_WEIGHT_NAMES[expert_weight_key]


### PR DESCRIPTION
### What this PR does / why we need it?
Error Handling: Added an explicit check to raise a RuntimeError when the quantization type is set to W4A8MXFP, as it is currently unsupported by EPLB.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
