### PR TITLE
[BugFix][SpecDecode] Preserve Eagle3 initializer compatibility

### DIFF
--- a/tests/ut/patch/worker/test_patch_eagle3_init.py
+++ b/tests/ut/patch/worker/test_patch_eagle3_init.py
@@ -1,0 +1,186 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from transformers import LlamaConfig
+from vllm.model_executor.models import deepseek_eagle3, llama_eagle3
+
+import vllm_ascend.patch.worker.patch_eagle3_init  # noqa: F401
+
+
+def _make_llama_config(eagle_config=...):
+    kwargs = {
+        "draft_vocab_size": 1000,
+        "hidden_size": 256,
+        "vocab_size": 32000,
+        "logit_scale": 1.0,
+    }
+    if eagle_config is not ...:
+        kwargs["eagle_config"] = eagle_config
+    return LlamaConfig(**kwargs)
+
+
+def _make_mock_hf_config(eagle_config=...):
+    config = Mock()
+    config.draft_vocab_size = 1000
+    config.hidden_size = 256
+    config.vocab_size = 32000
+    config.logit_scale = 1.0
+    if eagle_config is not ...:
+        config.eagle_config = eagle_config
+    return config
+
+
+def _make_vllm_config(hf_config, *, parallel_drafting=False):
+    model_config = Mock()
+    model_config.get_total_num_hidden_layers.return_value = 32
+    return SimpleNamespace(
+        model_config=model_config,
+        speculative_config=SimpleNamespace(
+            draft_model_config=SimpleNamespace(hf_config=hf_config),
+            parallel_drafting=parallel_drafting,
+        ),
+    )
+
+
+def _patch_llama_dependencies(monkeypatch, *, fc_input_size=768):
+    inner_model = SimpleNamespace(
+        fc_input_size=fc_input_size,
+        use_aux_hidden_state=True,
+    )
+    model_factory = Mock(return_value=inner_model)
+    lm_head_factory = Mock(return_value=Mock())
+    logits_processor_factory = Mock(return_value=Mock())
+    quant_config = Mock()
+    quant_config_getter = Mock(return_value=quant_config)
+
+    monkeypatch.setattr(llama_eagle3, "LlamaModel", model_factory)
+    monkeypatch.setattr(llama_eagle3, "ParallelLMHead", lm_head_factory)
+    monkeypatch.setattr(llama_eagle3, "LogitsProcessor", logits_processor_factory)
+    monkeypatch.setattr(llama_eagle3, "get_draft_quant_config", quant_config_getter)
+
+    return SimpleNamespace(
+        inner_model=inner_model,
+        model_factory=model_factory,
+        lm_head_factory=lm_head_factory,
+        quant_config=quant_config,
+        quant_config_getter=quant_config_getter,
+    )
+
+
+@pytest.mark.parametrize(
+    "hf_config",
+    [
+        pytest.param(_make_llama_config(), id="real-config-missing"),
+        pytest.param(_make_llama_config({}), id="real-config-empty"),
+        pytest.param(
+            _make_llama_config({"use_aux_hidden_state": False}),
+            id="real-config-use-aux-hidden-state",
+        ),
+        pytest.param(
+            SimpleNamespace(
+                draft_vocab_size=1000,
+                hidden_size=256,
+                vocab_size=32000,
+                logit_scale=1.0,
+                eagle_config={"use_aux_hidden_state": True},
+            ),
+            id="simulated-config-object",
+        ),
+        pytest.param(_make_mock_hf_config(), id="upstream-mock-fixture"),
+    ],
+)
+def test_llama_init_uses_upstream_patch_points(monkeypatch, hf_config):
+    dependencies = _patch_llama_dependencies(monkeypatch)
+    vllm_config = _make_vllm_config(hf_config)
+    original_eagle_config = getattr(hf_config, "eagle_config", None)
+
+    model = llama_eagle3.Eagle3LlamaForCausalLM(
+        vllm_config=vllm_config,
+        prefix="draft",
+    )
+
+    assert model.config is hf_config
+    assert getattr(model.config, "eagle_config", None) is original_eagle_config
+    assert model.config.target_layer_count == 32
+    vllm_config.model_config.get_total_num_hidden_layers.assert_called_once_with()
+    dependencies.model_factory.assert_called_once_with(
+        vllm_config=vllm_config,
+        prefix="draft.model",
+        start_layer_id=32,
+    )
+    dependencies.quant_config_getter.assert_called_once_with(vllm_config)
+    dependencies.lm_head_factory.assert_called_once()
+    assert dependencies.lm_head_factory.call_args.kwargs["quant_config"] is dependencies.quant_config
+    assert dependencies.lm_head_factory.call_args.kwargs["prefix"] == "draft.lm_head"
+
+
+def test_llama_parallel_drafting_uses_model_fc_input_size(monkeypatch):
+    dependencies = _patch_llama_dependencies(monkeypatch, fc_input_size=513)
+    vllm_config = _make_vllm_config(
+        _make_llama_config({"use_aux_hidden_state": False}),
+        parallel_drafting=True,
+    )
+
+    model = llama_eagle3.Eagle3LlamaForCausalLM(vllm_config=vllm_config)
+
+    assert model.model is dependencies.inner_model
+    assert model.mask_hidden.shape == (1, 513)
+
+
+def test_deepseek_init_uses_upstream_patch_points(monkeypatch):
+    hf_config = SimpleNamespace(
+        draft_vocab_size=1000,
+        hidden_size=256,
+        vocab_size=32000,
+        logit_scale=1.0,
+        eagle_config={"use_aux_hidden_state": True},
+    )
+    vllm_config = _make_vllm_config(hf_config)
+    inner_model = Mock()
+    model_factory = Mock(return_value=inner_model)
+    lm_head_factory = Mock(return_value=Mock())
+    logits_processor_factory = Mock(return_value=Mock())
+
+    monkeypatch.setattr(deepseek_eagle3, "DeepseekV2Eagle3Model", model_factory)
+    monkeypatch.setattr(deepseek_eagle3, "ParallelLMHead", lm_head_factory)
+    monkeypatch.setattr(
+        deepseek_eagle3,
+        "LogitsProcessor",
+        logits_processor_factory,
+    )
+
+    model = deepseek_eagle3.Eagle3DeepseekV2ForCausalLM(
+        vllm_config=vllm_config,
+        prefix="draft",
+    )
+
+    assert model.config is hf_config
+    assert model.config.eagle_config == {"use_aux_hidden_state": True}
+    assert model.config.target_layer_count == 32
+    vllm_config.model_config.get_total_num_hidden_layers.assert_called_once_with()
+    model_factory.assert_called_once_with(
+        vllm_config=vllm_config,
+        prefix="draft.model",
+        start_layer_id=32,
+    )
+    lm_head_factory.assert_called_once()
+    assert lm_head_factory.call_args.kwargs["prefix"] == "draft.lm_head"
+    assert "quant_config" not in lm_head_factory.call_args.kwargs

--- a/vllm_ascend/patch/worker/patch_eagle3_init.py
+++ b/vllm_ascend/patch/worker/patch_eagle3_init.py
@@ -34,24 +34,16 @@ Currently patches:
 - Eagle3LlamaForCausalLM (Qwen, LLaMA-based Eagle3 targets)
 - Eagle3DeepseekV2ForCausalLM / Eagle3DeepseekV3ForCausalLM (DeepSeek-V2/V3,
   Kimi K2/K2.6)
+
+Constructor dependencies are resolved through their upstream modules at call
+time so that vLLM overrides and test patch points remain effective.
 """
 
 import logging
 
 import torch
 import torch.nn as nn
-from vllm.model_executor.layers.logits_processor import LogitsProcessor
-from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
-from vllm.model_executor.models.deepseek_eagle3 import (
-    DeepseekV2Eagle3Model,
-    Eagle3DeepseekV2ForCausalLM,
-)
-from vllm.model_executor.models.llama_eagle3 import (
-    Eagle3LlamaForCausalLM,
-    LlamaModel,
-    get_draft_quant_config,
-)
-from vllm.model_executor.models.utils import maybe_prefix
+from vllm.model_executor.models import deepseek_eagle3, llama_eagle3
 
 logger = logging.getLogger(__name__)
 
@@ -65,16 +57,20 @@ def _patched_eagle3_llama_init(self, *, vllm_config, prefix: str = ""):
     target_layer_num = vllm_config.model_config.get_total_num_hidden_layers()
 
     self.config.target_layer_count = target_layer_num
-    self.model = LlamaModel(vllm_config=vllm_config, prefix="model", start_layer_id=target_layer_num)
+    self.model = llama_eagle3.LlamaModel(
+        vllm_config=vllm_config,
+        prefix=llama_eagle3.maybe_prefix(prefix, "model"),
+        start_layer_id=target_layer_num,
+    )
 
     logit_scale = getattr(self.config, "logit_scale", 1.0)
-    self.lm_head = ParallelLMHead(
+    self.lm_head = llama_eagle3.ParallelLMHead(
         self.config.draft_vocab_size,
         self.config.hidden_size,
-        quant_config=get_draft_quant_config(vllm_config),
-        prefix=maybe_prefix(prefix, "lm_head"),
+        quant_config=llama_eagle3.get_draft_quant_config(vllm_config),
+        prefix=llama_eagle3.maybe_prefix(prefix, "lm_head"),
     )
-    self.logits_processor = LogitsProcessor(self.config.draft_vocab_size, scale=logit_scale)
+    self.logits_processor = llama_eagle3.LogitsProcessor(self.config.draft_vocab_size, scale=logit_scale)
     self.draft_id_to_target_id = nn.Parameter(
         torch.zeros(self.config.draft_vocab_size, dtype=torch.long),
         requires_grad=False,
@@ -85,10 +81,7 @@ def _patched_eagle3_llama_init(self, *, vllm_config, prefix: str = ""):
     if self.use_parallel_drafting:
         self.register_buffer(
             "mask_hidden",
-            torch.zeros(
-                1,
-                (3 if self.model.use_aux_hidden_state else 1) * self.config.hidden_size,
-            ),
+            torch.zeros(1, self.model.fc_input_size),
             persistent=False,
         )
 
@@ -105,23 +98,27 @@ def _patched_eagle3_deepseek_v2_init(self, *, vllm_config, prefix: str = ""):
 
     self.config.target_layer_count = target_layer_num
 
-    self.model = DeepseekV2Eagle3Model(vllm_config=vllm_config, prefix="model", start_layer_id=target_layer_num)
+    self.model = deepseek_eagle3.DeepseekV2Eagle3Model(
+        vllm_config=vllm_config,
+        prefix=deepseek_eagle3.maybe_prefix(prefix, "model"),
+        start_layer_id=target_layer_num,
+    )
 
     logit_scale = getattr(self.config, "logit_scale", 1.0)
-    self.lm_head = ParallelLMHead(
+    self.lm_head = deepseek_eagle3.ParallelLMHead(
         self.config.draft_vocab_size,
         self.config.hidden_size,
-        prefix=maybe_prefix(prefix, "lm_head"),
+        prefix=deepseek_eagle3.maybe_prefix(prefix, "lm_head"),
     )
-    self.logits_processor = LogitsProcessor(self.config.draft_vocab_size, scale=logit_scale)
+    self.logits_processor = deepseek_eagle3.LogitsProcessor(self.config.draft_vocab_size, scale=logit_scale)
     self.draft_id_to_target_id = nn.Parameter(
         torch.zeros(self.config.draft_vocab_size, dtype=torch.long),
         requires_grad=False,
     )
 
 
-Eagle3LlamaForCausalLM.__init__ = _patched_eagle3_llama_init
-Eagle3DeepseekV2ForCausalLM.__init__ = _patched_eagle3_deepseek_v2_init
+llama_eagle3.Eagle3LlamaForCausalLM.__init__ = _patched_eagle3_llama_init
+deepseek_eagle3.Eagle3DeepseekV2ForCausalLM.__init__ = _patched_eagle3_deepseek_v2_init
 
 logger.info(
     "Patched Eagle3LlamaForCausalLM and Eagle3DeepseekV2ForCausalLM "

--- a/vllm_ascend/patch/worker/patch_eagle3_init.py
+++ b/vllm_ascend/patch/worker/patch_eagle3_init.py
@@ -44,6 +44,7 @@ import logging
 import torch
 import torch.nn as nn
 from vllm.model_executor.models import deepseek_eagle3, llama_eagle3
+from vllm.model_executor.models.utils import maybe_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +60,7 @@ def _patched_eagle3_llama_init(self, *, vllm_config, prefix: str = ""):
     self.config.target_layer_count = target_layer_num
     self.model = llama_eagle3.LlamaModel(
         vllm_config=vllm_config,
-        prefix=llama_eagle3.maybe_prefix(prefix, "model"),
+        prefix=maybe_prefix(prefix, "model"),
         start_layer_id=target_layer_num,
     )
 
@@ -68,7 +69,7 @@ def _patched_eagle3_llama_init(self, *, vllm_config, prefix: str = ""):
         self.config.draft_vocab_size,
         self.config.hidden_size,
         quant_config=llama_eagle3.get_draft_quant_config(vllm_config),
-        prefix=llama_eagle3.maybe_prefix(prefix, "lm_head"),
+        prefix=maybe_prefix(prefix, "lm_head"),
     )
     self.logits_processor = llama_eagle3.LogitsProcessor(self.config.draft_vocab_size, scale=logit_scale)
     self.draft_id_to_target_id = nn.Parameter(
@@ -100,7 +101,7 @@ def _patched_eagle3_deepseek_v2_init(self, *, vllm_config, prefix: str = ""):
 
     self.model = deepseek_eagle3.DeepseekV2Eagle3Model(
         vllm_config=vllm_config,
-        prefix=deepseek_eagle3.maybe_prefix(prefix, "model"),
+        prefix=maybe_prefix(prefix, "model"),
         start_layer_id=target_layer_num,
     )
 
@@ -108,7 +109,7 @@ def _patched_eagle3_deepseek_v2_init(self, *, vllm_config, prefix: str = ""):
     self.lm_head = deepseek_eagle3.ParallelLMHead(
         self.config.draft_vocab_size,
         self.config.hidden_size,
-        prefix=deepseek_eagle3.maybe_prefix(prefix, "lm_head"),
+        prefix=maybe_prefix(prefix, "lm_head"),
     )
     self.logits_processor = deepseek_eagle3.LogitsProcessor(self.config.draft_vocab_size, scale=logit_scale)
     self.draft_id_to_target_id = nn.Parameter(


### PR DESCRIPTION
### What this PR does / why we need it?

The Eagle3 initializer patch replaces the vLLM Llama and DeepSeek constructors
to use the target model's total hidden-layer count under pipeline parallelism.

Its constructor dependencies were captured as local aliases when the patch
module was imported. Later overrides of the canonical vLLM module symbols were
therefore bypassed, allowing the real inner model to receive a test-only
configuration object.

This change:

- resolves Eagle3 constructor dependencies through their canonical vLLM modules
  at call time;
- preserves the total target-layer count required by pipeline parallelism;
- aligns nested model and lm-head prefixes with vLLM;
- sizes the parallel-drafting buffer from the inner model's `fc_input_size`;
- adds Llama and DeepSeek regression coverage for real and simulated configs,
  constructor patch points, and draft quantization propagation.

Fixes #11658

### Does this PR introduce _any_ user-facing change?

No. This restores initializer compatibility and preserves existing Eagle3
runtime behavior.

### How was this patch tested?

- `pytest -q tests/ut/patch/worker/test_patch_eagle3_init.py`
- `pytest -q tests/ut/patch/worker/test_patch_eagle3_init.py tests/ut/patch/worker/test_patch_eagle3_pp_aux.py`
- Relevant CPU-safe nodes from `tests/model_executor/test_eagle_quantization.py`
- `bash format.sh changed`
- `bash format.sh ci`
- `git diff --check`

No NPU was required.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
