### PR TITLE
Support SFA DCP C8 LSE path

### DIFF
--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -13,6 +13,7 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 if "torch_npu._inductor" not in sys.modules:
     sys.modules["torch_npu._inductor"] = MagicMock()
 
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.attention.sfa_v1 import AscendSFABackend, AscendSFAImpl, AscendSFAMetadata, AscendSFAMetadataBuilder
 from vllm_ascend.utils import enable_dsa_cp
 
@@ -64,6 +65,115 @@ class TestAscendSFABackend(TestBase):
         mock_enable_cp.return_value = True
         impl_cls = AscendSFABackend.get_impl_cls()
         self.assertIsNotNone(impl_cls)
+
+
+class TestAscendSFADeviceOperator(TestBase):
+    def _make_common_inputs(self):
+        ql_nope = torch.randn(3, 4, 8)
+        q_pe = torch.randn(3, 4, 2)
+        topk_indices = torch.zeros(3, 1, dtype=torch.int32)
+        attn_metadata = MagicMock()
+        attn_metadata.block_table = torch.zeros(1, 4, dtype=torch.int32)
+        actual_seq_lengths_query = torch.tensor([3], dtype=torch.int32)
+        actual_seq_lengths_key = torch.tensor([3], dtype=torch.int32)
+        impl = MagicMock()
+        impl.scale = 0.125
+        impl.qk_rope_head_dim = 2
+        impl.sfa_qsfa_tile_size = 128
+        return (
+            impl,
+            ql_nope,
+            q_pe,
+            topk_indices,
+            attn_metadata,
+            actual_seq_lengths_query,
+            actual_seq_lengths_key,
+        )
+
+    def test_execute_sparse_flash_attention_returns_lse(self):
+        (
+            impl,
+            ql_nope,
+            q_pe,
+            topk_indices,
+            attn_metadata,
+            actual_seq_lengths_query,
+            actual_seq_lengths_key,
+        ) = self._make_common_inputs()
+        kv_cache = (
+            torch.randn(4, 1, 1, 8),
+            torch.randn(4, 1, 1, 2),
+        )
+        attn_output = torch.randn(3, 4, 8)
+        softmax_max = torch.zeros(1, 3, 4)
+        softmax_sum = torch.full((1, 3, 4), 2.0)
+
+        with patch.object(
+            torch.ops._C_ascend,
+            "npu_sparse_flash_attention",
+            create=True,
+            return_value=(attn_output, softmax_max, softmax_sum),
+        ) as mock_sfa:
+            output, softmax_lse = DeviceOperator.execute_sparse_flash_attention_process(
+                impl,
+                ql_nope,
+                q_pe,
+                kv_cache,
+                topk_indices,
+                attn_metadata,
+                actual_seq_lengths_query,
+                actual_seq_lengths_key,
+                return_lse=True,
+            )
+
+        self.assertIs(output, attn_output)
+        self.assertEqual(softmax_lse.shape, (3, 4, 1))
+        expected_lse = torch.full((3, 4, 1), torch.log(torch.tensor(2.0)).item())
+        self.assertTrue(torch.allclose(softmax_lse, expected_lse))
+        self.assertTrue(mock_sfa.call_args.kwargs["return_softmax_lse"])
+
+    def test_execute_sparse_flash_attention_c8_returns_lse(self):
+        (
+            impl,
+            ql_nope,
+            q_pe,
+            topk_indices,
+            attn_metadata,
+            actual_seq_lengths_query,
+            actual_seq_lengths_key,
+        ) = self._make_common_inputs()
+        packed_kv_cache = (torch.empty(4, 1, 1, 12, dtype=torch.int8),)
+        attn_output = torch.randn(3, 4, 8)
+        softmax_max = torch.ones(1, 3, 4)
+        softmax_sum = torch.full((1, 3, 4), 3.0)
+
+        with patch(
+            "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
+            create=True,
+            return_value=(attn_output, softmax_max, softmax_sum),
+        ) as mock_qsfa:
+            output, softmax_lse = DeviceOperator.execute_sparse_flash_attention_process(
+                impl,
+                ql_nope,
+                q_pe,
+                packed_kv_cache,
+                topk_indices,
+                attn_metadata,
+                actual_seq_lengths_query,
+                actual_seq_lengths_key,
+                sparse_mode=0,
+                return_lse=True,
+            )
+
+        self.assertIs(output, attn_output)
+        expected_lse = torch.full((3, 4, 1), 1.0 + torch.log(torch.tensor(3.0)).item())
+        self.assertTrue(torch.allclose(softmax_lse, expected_lse))
+        call_kwargs = mock_qsfa.call_args.kwargs
+        self.assertIs(call_kwargs["key"], packed_kv_cache[0])
+        self.assertIs(call_kwargs["value"], packed_kv_cache[0])
+        self.assertEqual(call_kwargs["query"].shape, (3, 4, 10))
+        self.assertEqual(call_kwargs["sparse_mode"], 0)
+        self.assertTrue(call_kwargs["return_softmax_lse"])
 
 
 class TestAscendSFAMetadata(TestBase):

--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -27,8 +27,12 @@ if "torch_npu._inductor" not in sys.modules:
     sys.modules["torch_npu._inductor"] = MagicMock()
 
 from vllm_ascend.attention.context_parallel.common_cp import AscendPCPMetadata
-from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFACPImpl, AscendSFACPMetadataBuilder
-from vllm_ascend.attention.sfa_v1 import AscendSFAImpl, AscendSFAMetadata
+from vllm_ascend.attention.context_parallel.sfa_cp import (
+    AscendSFACPImpl,
+    AscendSFACPMetadataBuilder,
+    AscendSFADCPImpl,
+)
+from vllm_ascend.attention.sfa_v1 import AscendSFAImpl, AscendSFAMetadata, DCPContext
 
 
 def _make_indexer_mock():
@@ -1482,3 +1486,60 @@ class TestAscendSFACPImpl(TestBase):
             )
         self.assertIsNotNone(result)
         self.assertEqual(result.shape[0], 5)
+
+
+class TestAscendSFADCPImpl(TestBase):
+    def test_execute_sparse_flash_attention_process_uses_device_operator_lse(self):
+        impl = AscendSFADCPImpl.__new__(AscendSFADCPImpl)
+        impl.dcp_group = MagicMock()
+        impl.dcp_size = 2
+        impl.enable_dsa_cp = False
+        impl._remap_sparse_indices = MagicMock(side_effect=lambda x: x)
+        merged_output = torch.randn(2, 2, 8)
+        impl._merge_dcp_outputs = MagicMock(return_value=merged_output)
+
+        ql_nope = torch.randn(2, 2, 8)
+        q_pe = torch.randn(2, 2, 4)
+        impl._finish_all_gather_query_for_dcp = MagicMock(side_effect=lambda _ctx: (ql_nope, q_pe))
+        kv_cache = (
+            torch.randn(4, 1, 1, 8),
+            torch.randn(4, 1, 1, 4),
+        )
+        topk_indices = torch.zeros(2, 1, dtype=torch.int32)
+        actual_seq_lengths_query = torch.tensor([2], dtype=torch.int32)
+        actual_seq_lengths_key = torch.tensor([4], dtype=torch.int32)
+        dcp_seq_lens = torch.tensor([3], dtype=torch.int32)
+        dcp_block_table = torch.tensor([[0, 1]], dtype=torch.int32)
+
+        attn_metadata = MagicMock()
+        attn_metadata.dcp_context = DCPContext(
+            slot_mapping=torch.tensor([0, 1], dtype=torch.int32),
+            block_table=dcp_block_table,
+            seq_lens=dcp_seq_lens,
+            query_gather_context=MagicMock(),
+        )
+        sfa_output = torch.randn(2, 2, 8)
+        softmax_lse = torch.randn(2, 2, 1)
+
+        with patch(
+            "vllm_ascend.attention.context_parallel.sfa_cp.DeviceOperator.execute_sparse_flash_attention_process",
+            return_value=(sfa_output, softmax_lse),
+        ) as mock_execute_sfa:
+            result = impl._execute_sparse_flash_attention_process(
+                ql_nope,
+                q_pe,
+                kv_cache,
+                topk_indices,
+                attn_metadata,
+                actual_seq_lengths_query,
+                actual_seq_lengths_key,
+            )
+
+        self.assertIs(result, merged_output)
+        call_args = mock_execute_sfa.call_args.args
+        call_kwargs = mock_execute_sfa.call_args.kwargs
+        self.assertIs(call_args[7], dcp_seq_lens)
+        self.assertIs(call_kwargs["block_table"], dcp_block_table)
+        self.assertEqual(call_kwargs["sparse_mode"], 0)
+        self.assertTrue(call_kwargs["return_lse"])
+        impl._merge_dcp_outputs.assert_called_once_with(sfa_output, softmax_lse)

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -1174,35 +1174,24 @@ class AscendSFADCPImpl(AscendSFAImpl):
             topk_indices = self.dcp_group.all_gather(topk_indices.contiguous(), dim=0)
         topk_indices = self._remap_sparse_indices(topk_indices)
         ql_nope, q_pe = self._finish_all_gather_query_for_dcp(query_gather_context)
-        kv = kv_cache[0]
-        key_rope = kv_cache[1]
-        sfa_output, softmax_max, softmax_sum = torch.ops._C_ascend.npu_sparse_flash_attention(
-            query=ql_nope,
-            key=kv,
-            value=kv,
-            sparse_indices=topk_indices,
-            scale_value=self.scale,
-            sparse_block_size=1,
-            block_table=attn_metadata.dcp_context.block_table,
-            actual_seq_lengths_query=actual_seq_lengths_query,
-            actual_seq_lengths_kv=attn_metadata.dcp_context.seq_lens,
-            query_rope=q_pe,
-            key_rope=key_rope,
-            layout_query="TND",
-            layout_kv="PA_BSND",
+        sfa_output, softmax_lse = DeviceOperator.execute_sparse_flash_attention_process(
+            self,
+            ql_nope,
+            q_pe,
+            kv_cache,
+            topk_indices,
+            attn_metadata,
+            actual_seq_lengths_query,
+            dcp_context.seq_lens,
+            block_table=dcp_context.block_table,
             # The replicated-view indexer already applies the causal visibility rule.
             # After DCP remaps topk indices to local KV positions, local KV
             # length no longer shares the same coordinate system as global
             # query length, so SFA must not apply its right-down causal crop.
             sparse_mode=0,
-            attention_mode=2,
-            return_softmax_lse=True,
+            return_lse=True,
         )
         output_dtype = sfa_output.dtype
-        # SFA returns softmax max/sum separately. Convert them to LSE so the
-        # existing CP merge helper can combine local-KV partial outputs.
-        softmax_lse = softmax_max.to(torch.float32) + torch.log(softmax_sum.to(torch.float32))
-        softmax_lse = softmax_lse.permute(1, 0, 2).reshape(softmax_lse.shape[1], -1, 1)
         if self.enable_dsa_cp:
             output = self._merge_dsa_cp_dcp_outputs(sfa_output, softmax_lse)
             assert attn_metadata.dsa_cp_context is not None, "DSA-CP DCP output selection requires dsa_cp_context."

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -501,12 +501,37 @@ class BaseDeviceAdaptor:
         attn_metadata,
         actual_seq_lengths_query: torch.Tensor,
         actual_seq_lengths_key: torch.Tensor,
-    ) -> torch.Tensor:
-        block_table = attn_metadata.block_table
+        *,
+        block_table: torch.Tensor | None = None,
+        sparse_mode: int = 3,
+        return_lse: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if block_table is None:
+            block_table = attn_metadata.block_table
         kv = kv_cache[0]
+
+        use_kv_quant_sparse_attention = kv.dtype in (
+            torch.int8,
+            torch.float8_e4m3fn,
+            torch.float8_e5m2,
+        )
+        if use_kv_quant_sparse_attention:
+            return BaseDeviceAdaptor.execute_kv_quant_sparse_flash_attention(
+                sfa_impl,
+                ql_nope,
+                q_pe,
+                kv,
+                block_table,
+                topk_indices,
+                actual_seq_lengths_query,
+                actual_seq_lengths_key,
+                sparse_mode=sparse_mode,
+                return_lse=return_lse,
+            )
+
         key_rope = kv_cache[1]
 
-        attn_output, _, _ = torch.ops._C_ascend.npu_sparse_flash_attention(
+        attn_output, softmax_max, softmax_sum = torch.ops._C_ascend.npu_sparse_flash_attention(
             query=ql_nope,
             key=kv,
             value=kv,
@@ -520,10 +545,78 @@ class BaseDeviceAdaptor:
             key_rope=key_rope,
             layout_query="TND",
             layout_kv="PA_BSND",
-            sparse_mode=3,
+            sparse_mode=sparse_mode,
             attention_mode=2,
+            return_softmax_lse=return_lse,
         )
-        return attn_output
+        return BaseDeviceAdaptor._format_sparse_flash_attention_output(
+            attn_output,
+            softmax_max,
+            softmax_sum,
+            return_lse,
+        )
+
+    @staticmethod
+    def execute_kv_quant_sparse_flash_attention(
+        sfa_impl,
+        ql_nope: torch.Tensor,
+        q_pe: torch.Tensor,
+        kv: torch.Tensor,
+        block_table: torch.Tensor,
+        topk_indices: torch.Tensor,
+        actual_seq_lengths_query: torch.Tensor,
+        actual_seq_lengths_key: torch.Tensor,
+        *,
+        sparse_mode: int = 3,
+        return_lse: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        query = torch.cat([ql_nope, q_pe], dim=-1).contiguous()
+        result = torch_npu.npu_kv_quant_sparse_flash_attention(
+            query=query,
+            key=kv,
+            value=kv,
+            sparse_indices=topk_indices,
+            scale_value=sfa_impl.scale,
+            sparse_block_size=1,
+            block_table=block_table,
+            actual_seq_lengths_query=actual_seq_lengths_query,
+            actual_seq_lengths_kv=actual_seq_lengths_key,
+            layout_query="TND",
+            layout_kv="PA_BSND",
+            sparse_mode=sparse_mode,
+            attention_mode=2,
+            quant_scale_repo_mode=1,
+            tile_size=getattr(sfa_impl, "sfa_qsfa_tile_size", 128),
+            key_quant_mode=2,
+            value_quant_mode=2,
+            rope_head_dim=getattr(sfa_impl, "qk_rope_head_dim", q_pe.shape[-1]),
+            return_softmax_lse=return_lse,
+        )
+        if not isinstance(result, tuple):
+            if return_lse:
+                raise RuntimeError("C8 sparse flash attention did not return softmax max/sum for DCP LSE merge.")
+            return result
+        attn_output, softmax_max, softmax_sum = result
+        return BaseDeviceAdaptor._format_sparse_flash_attention_output(
+            attn_output,
+            softmax_max,
+            softmax_sum,
+            return_lse,
+        )
+
+    @staticmethod
+    def _format_sparse_flash_attention_output(
+        attn_output: torch.Tensor,
+        softmax_max: torch.Tensor,
+        softmax_sum: torch.Tensor,
+        return_lse: bool,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if not return_lse:
+            return attn_output
+
+        softmax_lse = softmax_max.to(torch.float32) + torch.log(softmax_sum.to(torch.float32))
+        softmax_lse = softmax_lse.permute(1, 0, 2).reshape(softmax_lse.shape[1], -1, 1)
+        return attn_output, softmax_lse
 
     @staticmethod
     def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):
@@ -1639,53 +1732,54 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         attn_metadata,
         actual_seq_lengths_query: torch.Tensor,
         actual_seq_lengths_key: torch.Tensor,
-    ) -> torch.Tensor:
-        block_table = attn_metadata.block_table
+        *,
+        block_table: torch.Tensor | None = None,
+        sparse_mode: int = 3,
+        return_lse: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if block_table is None:
+            block_table = attn_metadata.block_table
         kv = kv_cache[0]
+
+        if kv.dtype in (torch.int8, torch.float8_e4m3fn, torch.float8_e5m2):
+            return BaseDeviceAdaptor.execute_kv_quant_sparse_flash_attention(
+                sfa_impl,
+                ql_nope,
+                q_pe,
+                kv,
+                block_table,
+                topk_indices,
+                actual_seq_lengths_query,
+                actual_seq_lengths_key,
+                sparse_mode=sparse_mode,
+                return_lse=return_lse,
+            )
+
         key_rope = kv_cache[1]
-
-        if kv.dtype in [torch.float8_e4m3fn, torch.float8_e5m2]:
-            query = torch.cat([ql_nope, q_pe], dim=-1)
-
-            attn_output = torch_npu.npu_kv_quant_sparse_flash_attention(
-                query=query,
-                key=kv,
-                value=kv,
-                sparse_indices=topk_indices,
-                scale_value=sfa_impl.scale,
-                sparse_block_size=1,
-                block_table=block_table,
-                actual_seq_lengths_query=actual_seq_lengths_query,
-                actual_seq_lengths_kv=actual_seq_lengths_key,
-                layout_query="TND",
-                layout_kv="PA_BSND",
-                sparse_mode=3,
-                attention_mode=2,
-                quant_scale_repo_mode=1,
-                tile_size=128,
-                key_quant_mode=2,
-                value_quant_mode=2,
-                rope_head_dim=64,
-            )
-        else:
-            attn_output, _, _ = torch_npu.npu_sparse_flash_attention(
-                query=ql_nope,
-                key=kv,
-                value=kv,
-                sparse_indices=topk_indices,
-                scale_value=sfa_impl.scale,
-                sparse_block_size=1,
-                block_table=block_table,
-                actual_seq_lengths_query=actual_seq_lengths_query,
-                actual_seq_lengths_kv=actual_seq_lengths_key,
-                query_rope=q_pe,
-                key_rope=key_rope,
-                layout_query="TND",
-                layout_kv="PA_BSND",
-                sparse_mode=3,
-                attention_mode=2,
-            )
-        return attn_output
+        attn_output, softmax_max, softmax_sum = torch_npu.npu_sparse_flash_attention(
+            query=ql_nope,
+            key=kv,
+            value=kv,
+            sparse_indices=topk_indices,
+            scale_value=sfa_impl.scale,
+            sparse_block_size=1,
+            block_table=block_table,
+            actual_seq_lengths_query=actual_seq_lengths_query,
+            actual_seq_lengths_kv=actual_seq_lengths_key,
+            query_rope=q_pe,
+            key_rope=key_rope,
+            layout_query="TND",
+            layout_kv="PA_BSND",
+            sparse_mode=sparse_mode,
+            attention_mode=2,
+            return_softmax_lse=return_lse,
+        )
+        return BaseDeviceAdaptor._format_sparse_flash_attention_output(
+            attn_output,
+            softmax_max,
+            softmax_sum,
+            return_lse,
+        )
 
     @staticmethod
     def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):


### PR DESCRIPTION
## Summary

- Add an optional `return_lse` path to `DeviceOperator.execute_sparse_flash_attention_process`.
- Route packed C8 KV cache to `npu_kv_quant_sparse_flash_attention` while preserving the ordinary SFA path.
- Update `AscendSFADCPImpl` to call through `DeviceOperator` with DCP-local metadata so replicated-indexer DCP can merge ordinary SFA and C8 SFA outputs with LSE.
- Add unit coverage for ordinary SFA LSE, C8 SFA LSE, and the DCP call contract.

## Context

This follows the packed sparse C8 SFA direction from vllm-project/vllm-ascend#11228 and keeps the DCP replicated-indexer path from binding directly to only the ordinary SFA operator.

## Validation

- `python -m py_compile vllm_ascend/device/device_op.py vllm_ascend/attention/context_parallel/sfa_cp.py tests/ut/attention/a2/test_sfa_v1.py tests/ut/attention/test_sfa_cp.py`
- `git diff --check --cached`

Not run: pytest/NPU execution; this workspace requires torch_npu tests to run in a remote NPU container.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
