### PR TITLE
[BugFix][PCP] Fix inclusive MTP decode attention mask for interleave

### DIFF
--- a/tests/ut/worker/test_pcp_manager.py
+++ b/tests/ut/worker/test_pcp_manager.py
@@ -573,6 +573,13 @@ def test_adjust_cu_num_scheduled_tokens_for_pcp(
     )
 
 
+def _local_kv_len(seq_len: int, cp_rank: int, cp_size: int, interleave_size: int) -> int:
+    """Per-rank KV length for the first ``seq_len`` global positions [0, seq_len)."""
+    base = seq_len // interleave_size // cp_size * interleave_size
+    remainder = seq_len - base * cp_size
+    return base + max(0, min(remainder - cp_rank * interleave_size, interleave_size))
+
+
 def _ref_mtp_mask_lens(
     history_len: int,
     num_scheduled: int,
@@ -582,23 +589,18 @@ def _ref_mtp_mask_lens(
 ) -> tuple[int, list[int]]:
     """Reference: compute per-rank KV length and k_upper per query position.
 
-    Follows the same interleave-aware formulas as
-    ``generate_mtp_attention_mask_for_decode``.
+    ``k_upper`` is the inclusive local index of KV tokens with global
+    ``pos <= P`` on this rank (standard causal, including self).
     """
     total_len = history_len + num_scheduled
-    # Per-rank KV length
-    base_k = total_len // interleave_size // cp_size * interleave_size
-    remainder_k = total_len - base_k * cp_size
-    k_lens = base_k + max(0, min(remainder_k - cp_rank * interleave_size, interleave_size))
+    k_lens = _local_kv_len(total_len, cp_rank, cp_size, interleave_size)
 
     context_len = history_len
     k_uppers: list[int] = []
     for qi in range(num_scheduled):
-        pos = context_len + qi
-        base_q = pos // interleave_size // cp_size * interleave_size
-        remainder_q = pos - base_q * cp_size
-        local_q = base_q + max(0, min(remainder_q - cp_rank * interleave_size, interleave_size))
-        k_upper = local_q - 1
+        # Inclusive causal: count local tokens among positions [0, P].
+        inclusive_len = context_len + qi + 1
+        k_upper = _local_kv_len(inclusive_len, cp_rank, cp_size, interleave_size) - 1
         k_uppers.append(k_upper)
 
     return k_lens, k_uppers
@@ -756,3 +758,61 @@ def test_generate_mtp_attention_mask_for_decode(
         f"ref_k_lens={ref_k_lens}, ref_k_uppers={ref_k_uppers}\n"
         f"Expected:\n{ref_mask.int()}\nGot:\n{actual_mask.int()}"
     )
+
+
+@pytest.mark.parametrize(
+    "dcp_world_size, dcp_rank, history_len, num_scheduled",
+    [
+        (2, 0, 5, 4),
+        (2, 1, 5, 4),
+        (2, 0, 200, 3),
+        (2, 1, 200, 3),
+        (4, 0, 100, 5),
+        (4, 3, 100, 5),
+    ],
+)
+def test_mtp_mask_interleave1_matches_legacy_inclusive_formula(
+    dcp_world_size: int,
+    dcp_rank: int,
+    history_len: int,
+    num_scheduled: int,
+):
+    """For interleave_size=1, k_upper must match the pre-#11492 inclusive formula.
+
+    Legacy: k_upper = (P - cp_rank) // cp_size, i.e. visible local KV with pos <= P.
+    """
+    _, k_uppers = _ref_mtp_mask_lens(
+        history_len, num_scheduled, dcp_rank, dcp_world_size, interleave_size=1
+    )
+    for qi, k_upper in enumerate(k_uppers):
+        pos = history_len + qi
+        legacy = (pos - dcp_rank) // dcp_world_size
+        assert k_upper == legacy, (
+            f"pos={pos}, rank={dcp_rank}: got k_upper={k_upper}, legacy={legacy}"
+        )
+
+    pcp_manager = _make_pcp_manager(
+        pcp_world_size=1,
+        dcp_world_size=dcp_world_size,
+        dcp_rank=dcp_rank,
+        interleave_size=1,
+        num_speculative_tokens=num_scheduled - 1,
+    )
+    num_scheduled_tokens = np.array([num_scheduled], dtype=np.int32)
+    num_computed_tokens = np.array([history_len], dtype=np.int32)
+    num_prompt_tokens = np.array([history_len], dtype=np.int32)
+    pcp_manager.init_batch_info(
+        num_scheduled_tokens,
+        num_reqs=1,
+        num_computed_tokens=num_computed_tokens,
+        num_prompt_tokens=num_prompt_tokens,
+    )
+    result = pcp_manager.generate_mtp_attention_mask_for_decode(
+        decode_num_computed_tokens=[history_len],
+        decode_num_scheduled_tokens=num_scheduled_tokens,
+    )
+    ref_k_lens, ref_k_uppers = _ref_mtp_mask_lens(
+        history_len, num_scheduled, dcp_rank, dcp_world_size, interleave_size=1
+    )
+    ref_mask = _build_ref_mask(num_scheduled, ref_k_lens, ref_k_uppers)
+    assert torch.equal(result[0, :num_scheduled, :ref_k_lens], ref_mask)

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -1608,10 +1608,14 @@ class PCPManager:
         valid_k = valid[:, None] & (k_indices[None, :] < k_lens[:, None])
 
         # Interleave-aware k_upper: for query token at global position P,
-        # the number of rank-cp_rank KV tokens before P (exclusive upper bound).
+        # count local KV tokens with global pos <= P (inclusive causal), then
+        # convert to an inclusive local index. Using P (exclusive) here would
+        # drop the query's own KV when it lives on this rank and can also make
+        # k_upper < 0, which disables masking for that row.
         positions = context_lens[:, None] + q_indices[None, :]  # [num_decode_reqs, max_q]
-        base_q = positions // interleave_size // cp_size * interleave_size
-        remainder_q = positions - base_q * cp_size
+        inclusive_positions = positions + 1
+        base_q = inclusive_positions // interleave_size // cp_size * interleave_size
+        remainder_q = inclusive_positions - base_q * cp_size
         local_q = base_q + torch.clamp(remainder_q - cp_rank * interleave_size, 0, interleave_size)
         k_upper = local_q - 1  # inclusive upper KV index
 


### PR DESCRIPTION
### What this PR does / why we need it?

#11492 made the PCP+MTP decode attention mask interleave-aware, but `k_upper` counted local KV tokens with `pos < P` (exclusive). That drops the query's own KV on the owning rank, and can leave `k_upper < 0`, which disables the row mask via `(k_upper >= 0)`.

In practice, PCP+MTP single-request generation looked fine for the first ~100 tokens, then started looping/repeating.

This PR counts local KV with `pos <= P` by using `inclusive_positions = positions + 1` before the interleave `base/remainder` formula, restoring inclusive causal behavior. For `interleave_size=1`, this matches the pre-#11492 formula `(P - rank) // cp_size`.

### Does this PR introduce _any_ user-facing change?

No API change. Fixes incorrect PCP+MTP decode attention masking that could cause repetitive/looping output.

### How was this patch tested?

- Updated the UT reference in `tests/ut/worker/test_pcp_manager.py` to inclusive causal semantics
- Added `test_mtp_mask_interleave1_matches_legacy_inclusive_formula` against the legacy inclusive formula
- Formula check: `interleave_size=1` matches legacy; owning-rank `k_upper` no longer goes negative
- Manual: PCP+MTP curl reproduction (pre-fix looping after ~100 tokens / post-fix expected normal)

AI assistance was used to diagnose and implement this fix.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
