### PR TITLE
[v0.23.0][BugFix]Fix hc_pre ops issue (#11825)

### DIFF
--- a/csrc/moe/hc_pre/op_kernel/hc_pre_m_k_split_core_arch35.h
+++ b/csrc/moe/hc_pre/op_kernel/hc_pre_m_k_split_core_arch35.h
@@ -346,7 +346,7 @@ public:
                     CopyIn(
                         xGm[xGmBaseOffset + rowOuterIdx * tilingData->stage2RowFactor * tilingData->hcMult * tilingData->d +
                             dLoopIdx * tilingData->dFactor],
-                        xLocal, tilingData->stage2RowFactor * tilingData->hcMult, curDFactor, tilingData->d - curDFactor);
+                        xLocal, curRowFactor * tilingData->hcMult, curDFactor, tilingData->d - curDFactor);
                     xQue.template EnQue(xLocal);
                     xLocal = xQue.template DeQue<T>();
 


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes a critical out-of-bounds memory access in the `HcPreMKSplitCorePart2` kernel by correctly using `curRowFactor` instead of `tilingData->stage2RowFactor` when copying input data `xGm` to `xLocal`.

Additionally, it addresses a potential data corruption/misalignment bug when `curDFactor` is not aligned to the 32-byte boundary (e.g., when `dFactor_` is not a multiple of 16/32).

Backport of https://github.com/vllm-project/vllm-ascend/pull/11825
### Does this PR introduce _any_ user-facing change? No.

### How was this patch tested?
Tested with operator unit tests and CI.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
