### PR TITLE
[BugFix][KV Pool][KV offload] Skip SSD offload registration for scheduler-only Mooncake clients

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -103,11 +103,18 @@ class MooncakeBackend(Backend):
         store = MooncakeDistributedStore()
         local_hostname = get_ip()
         ssd_kwargs = _ssd_setup_kwargs(self.config)
+        # Scheduler-only clients (contribute_memory=False) do not contribute
+        # KV cache memory and therefore do not need SSD offload. Passing
+        # enable_ssd_offload=True for them would cause Mooncake to register
+        # an extra active client on the master, inflating both the client
+        # count and the reported SSD storage usage.
+        if ssd_kwargs and not self._contribute_memory:
+            ssd_kwargs = {}
         # Each rank that contributes memory to the pool uses its own SSD
         # directory to avoid bucket file collisions. Key by the globally unique
         # rank so that DP/TP/PP/CP replicas never share a directory (dense and
         # MoE alike); only ranks that contribute memory need an offload dir.
-        if ssd_kwargs and ssd_kwargs.get("ssd_offload_path") and self._contribute_memory:
+        if ssd_kwargs and ssd_kwargs.get("ssd_offload_path"):
             global_rank = get_global_rank(self.parallel_config)
             rank_path = os.path.join(str(ssd_kwargs["ssd_offload_path"]), f"rank_{global_rank}")
             try:


### PR DESCRIPTION
### What this PR does / why we need it?
Scheduler-only clients (contribute_memory=False) do not contribute KV cache memory to the pool. However, the current code unconditionally passes enable_ssd_offload to MooncakeDistributedStore.setup(), which causes Mooncake to register an extra active client on the master for each scheduler rank. This inflates both the perceived client count and the reported SSD storage usage.

This PR ensures that when _contribute_memory is False, SSD offload parameters are stripped before calling setup(), so schedulers are not counted as SSD-enabled clients.

### Does this PR introduce _any_ user-facing change?
No. The change only affects internal Mooncake store initialization.

### How was this patch tested?
CI with new/existing tests.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
