### PR TITLE
[CI] Add Gemma4 graph and eager nightly coverage

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -164,6 +164,9 @@ a3:
       - name: gemma4
         os: linux-aarch64-a3-4
         config_file_path: Gemma4.yaml
+      - name: gemma4-31b-dense
+        os: linux-aarch64-a3-4
+        config_file_path: Gemma4-31B-Dense.yaml
   multi_card:
     test_config:
       # pytest-driven tests

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -24,6 +24,12 @@ a2:
       - name: Qwen3.5-397B-A17B-w4a8-mtp
         os: linux-aarch64-a2b3-8
         config_file_path: Qwen3.5-397B-A17B-w4a8-mtp-A2.yaml
+      - name: gemma4
+        os: linux-aarch64-a2b3-4
+        config_file_path: Gemma4.yaml
+      - name: gemma4-31b-dense
+        os: linux-aarch64-a2b3-4
+        config_file_path: Gemma4-31B-Dense.yaml
   multi_node:
     test_config:
       - name: multi-node-qwen3-235b-dp
@@ -161,12 +167,6 @@ a3:
       - name: qwen3-vl-235b-a22b-instruct-w8a8
         os: linux-aarch64-a3-16
         config_file_path: Qwen3-VL-235B-A22B-Instruct-W8A8.yaml
-      - name: gemma4
-        os: linux-aarch64-a3-4
-        config_file_path: Gemma4.yaml
-      - name: gemma4-31b-dense
-        os: linux-aarch64-a3-4
-        config_file_path: Gemma4-31B-Dense.yaml
   multi_card:
     test_config:
       # pytest-driven tests

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -161,6 +161,9 @@ a3:
       - name: qwen3-vl-235b-a22b-instruct-w8a8
         os: linux-aarch64-a3-16
         config_file_path: Qwen3-VL-235B-A22B-Instruct-W8A8.yaml
+      - name: gemma4
+        os: linux-aarch64-a3-4
+        config_file_path: Gemma4.yaml
   multi_card:
     test_config:
       # pytest-driven tests

--- a/.github/workflows/misc/model_dataset_list.json
+++ b/.github/workflows/misc/model_dataset_list.json
@@ -139,6 +139,8 @@
       "facebook/opt-125m",
       "google/gemma-2-9b",
       "google/gemma-3n-E2B-it",
+      "google/gemma-4-26B-A4B-it",
+      "google/gemma-4-31B-it",
       "google/siglip2-base-patch16-224",
       "hmellor/Ilama-3.2-1B",
       "ibm-research/PowerMoE-3b",

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
@@ -33,7 +33,9 @@ _server_cmd: &server_cmd
 
 _api_keyword_args: &api_keyword_args
   max_tokens: 64
-  temperature: 0.0
+  temperature: 1.0
+  top_p: 0.95
+  top_k: 64
 
 _benchmarks: &benchmarks
   acc_gpqa:
@@ -44,10 +46,11 @@ _benchmarks: &benchmarks
     num_prompts: 32
     max_out_len: 32768
     batch_size: 8
-    baseline: 70
+    baseline: 65
     threshold: 10
-    temperature: 0.0
-    top_p: 1.0
+    temperature: 1.0
+    top_p: 0.95
+    top_k: 64
     ignore_eos: false
 
 # ==========================================

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
@@ -44,7 +44,7 @@ _benchmarks: &benchmarks
     request_conf: vllm_api_general_chat
     dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
     num_prompts: 32
-    max_out_len: 16384
+    max_out_len: 8192
     batch_size: 8
     baseline: 65
     threshold: 10
@@ -58,22 +58,6 @@ _benchmarks: &benchmarks
 # ==========================================
 
 test_cases:
-  - name: "Gemma4-31B-dense-eager"
-    model: *model
-    envs:
-      <<: *envs
-    prompts:
-      - "Explain briefly why ACLGraph output should match eager output."
-    api_keyword_args:
-      <<: *api_keyword_args
-    server_cmd: *server_cmd
-    server_cmd_extra:
-      - "--enforce-eager"
-    test_content:
-      - "chat_completion"
-    benchmarks:
-      <<: *benchmarks
-
   - name: "Gemma4-31B-dense-full-decode-graph"
     model: *model
     envs:

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
@@ -51,6 +51,7 @@ _benchmarks: &benchmarks
     temperature: 1.0
     top_p: 0.95
     top_k: 64
+    seed: 42
     ignore_eos: false
 
 # ==========================================

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
@@ -1,0 +1,89 @@
+# ==========================================
+# Shared Configurations
+# ==========================================
+
+_model: &model "vllm-ascend/Gemma4-31B"
+
+_envs: &envs
+  VLLM_USE_MODELSCOPE: "true"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  HCCL_BUFFSIZE: "1024"
+  OMP_NUM_THREADS: "1"
+  TASK_QUEUE_ENABLE: "1"
+  SERVER_PORT: "DEFAULT_PORT"
+  VLLM_ENGINE_READY_TIMEOUT_S: "3000"
+  VLLM_RPC_TIMEOUT: "6000"
+
+_server_cmd: &server_cmd
+  - "--no-enable-prefix-caching"
+  - "--tensor-parallel-size"
+  - "4"
+  - "--port"
+  - "$SERVER_PORT"
+  - "--max-model-len"
+  - "32768"
+  - "--max-num-batched-tokens"
+  - "8192"
+  - "--max-num-seqs"
+  - "8"
+  - "--gpu-memory-utilization"
+  - "0.9"
+  - "--trust-remote-code"
+
+_api_keyword_args: &api_keyword_args
+  max_tokens: 64
+  temperature: 0.0
+
+_benchmarks: &benchmarks
+  acc_gpqa:
+    case_type: accuracy
+    dataset_path: vllm-ascend/gpqa
+    request_conf: vllm_api_general_chat
+    dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
+    num_prompts: 32
+    max_out_len: 32768
+    batch_size: 8
+    baseline: 70
+    threshold: 10
+    temperature: 0.0
+    top_p: 1.0
+    ignore_eos: false
+
+# ==========================================
+# ACTUAL TEST CASES
+# ==========================================
+
+test_cases:
+  - name: "Gemma4-31B-dense-eager"
+    model: *model
+    envs:
+      <<: *envs
+    prompts:
+      - "Explain briefly why ACLGraph output should match eager output."
+    api_keyword_args:
+      <<: *api_keyword_args
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--enforce-eager"
+    test_content:
+      - "chat_completion"
+    benchmarks:
+      <<: *benchmarks
+
+  - name: "Gemma4-31B-dense-full-decode-graph"
+    model: *model
+    envs:
+      <<: *envs
+    prompts:
+      - "Explain briefly why ACLGraph output should match eager output."
+    api_keyword_args:
+      <<: *api_keyword_args
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--compilation-config"
+      - '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8]}'
+    test_content:
+      - "chat_completion"
+    benchmarks:
+      <<: *benchmarks

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
@@ -46,7 +46,7 @@ _benchmarks: &benchmarks
     num_prompts: 64
     max_out_len: 8192
     batch_size: 8
-    baseline: 72
+    baseline: 79
     threshold: 10
     temperature: 1.0
     top_p: 0.95

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
@@ -43,7 +43,7 @@ _benchmarks: &benchmarks
     dataset_path: vllm-ascend/gpqa
     request_conf: vllm_api_general_chat
     dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
-    num_prompts: 32
+    num_prompts: 64
     max_out_len: 8192
     batch_size: 8
     baseline: 72
@@ -51,7 +51,6 @@ _benchmarks: &benchmarks
     temperature: 1.0
     top_p: 0.95
     top_k: 64
-    seed: 42
     ignore_eos: false
 
 # ==========================================

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
@@ -46,8 +46,8 @@ _benchmarks: &benchmarks
     num_prompts: 64
     max_out_len: 8192
     batch_size: 8
-    baseline: 79
-    threshold: 10
+    baseline: 78
+    threshold: 5
     temperature: 1.0
     top_p: 0.95
     top_k: 64

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
@@ -45,7 +45,7 @@ _benchmarks: &benchmarks
     dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
     max_out_len: 8192
     batch_size: 8
-    baseline: 78
+    baseline: 75
     threshold: 5
     temperature: 1.0
     top_p: 0.95

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
@@ -44,7 +44,7 @@ _benchmarks: &benchmarks
     request_conf: vllm_api_general_chat
     dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
     num_prompts: 32
-    max_out_len: 32768
+    max_out_len: 16384
     batch_size: 8
     baseline: 65
     threshold: 10

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
@@ -2,7 +2,7 @@
 # Shared Configurations
 # ==========================================
 
-_model: &model "vllm-ascend/Gemma4-31B"
+_model: &model "google/gemma-4-31B-it"
 
 _envs: &envs
   VLLM_USE_MODELSCOPE: "true"

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
@@ -43,7 +43,6 @@ _benchmarks: &benchmarks
     dataset_path: vllm-ascend/gpqa
     request_conf: vllm_api_general_chat
     dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
-    num_prompts: 64
     max_out_len: 8192
     batch_size: 8
     baseline: 78

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4-31B-Dense.yaml
@@ -46,7 +46,7 @@ _benchmarks: &benchmarks
     num_prompts: 32
     max_out_len: 8192
     batch_size: 8
-    baseline: 65
+    baseline: 72
     threshold: 10
     temperature: 1.0
     top_p: 0.95

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
@@ -2,7 +2,7 @@
 # Shared Configurations
 # ==========================================
 
-_model: &model "vllm-ascend/Gemma4-26B-MoE"
+_model: &model "google/gemma-4-26B-A4B-it"
 
 _envs: &envs
   VLLM_USE_MODELSCOPE: "true"

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
@@ -44,7 +44,6 @@ _benchmarks: &benchmarks
     dataset_path: vllm-ascend/gpqa
     request_conf: vllm_api_general_chat
     dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
-    num_prompts: 64
     max_out_len: 8192
     batch_size: 8
     baseline: 73.5

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
@@ -47,11 +47,12 @@ _benchmarks: &benchmarks
     num_prompts: 32
     max_out_len: 8192
     batch_size: 8
-    baseline: 72
+    baseline: 68
     threshold: 10
     temperature: 1.0
     top_p: 0.95
     top_k: 64
+    seed: 42
     ignore_eos: false
 
 # ==========================================

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
@@ -45,7 +45,7 @@ _benchmarks: &benchmarks
     request_conf: vllm_api_general_chat
     dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
     num_prompts: 32
-    max_out_len: 16384
+    max_out_len: 8192
     batch_size: 8
     baseline: 65
     threshold: 10
@@ -59,22 +59,6 @@ _benchmarks: &benchmarks
 # ==========================================
 
 test_cases:
-  - name: "Gemma4-eager"
-    model: *model
-    envs:
-      <<: *envs
-    prompts:
-      - "Explain briefly why ACLGraph output should match eager output."
-    api_keyword_args:
-      <<: *api_keyword_args
-    server_cmd: *server_cmd
-    server_cmd_extra:
-      - "--enforce-eager"
-    test_content:
-      - "chat_completion"
-    benchmarks:
-      <<: *benchmarks
-
   - name: "Gemma4-full-decode-graph"
     model: *model
     envs:

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
@@ -44,7 +44,7 @@ _benchmarks: &benchmarks
     dataset_path: vllm-ascend/gpqa
     request_conf: vllm_api_general_chat
     dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
-    num_prompts: 32
+    num_prompts: 64
     max_out_len: 8192
     batch_size: 8
     baseline: 68
@@ -52,7 +52,6 @@ _benchmarks: &benchmarks
     temperature: 1.0
     top_p: 0.95
     top_k: 64
-    seed: 42
     ignore_eos: false
 
 # ==========================================

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
@@ -47,7 +47,7 @@ _benchmarks: &benchmarks
     num_prompts: 64
     max_out_len: 8192
     batch_size: 8
-    baseline: 68
+    baseline: 75
     threshold: 10
     temperature: 1.0
     top_p: 0.95

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
@@ -47,8 +47,8 @@ _benchmarks: &benchmarks
     num_prompts: 64
     max_out_len: 8192
     batch_size: 8
-    baseline: 75
-    threshold: 10
+    baseline: 73.5
+    threshold: 5
     temperature: 1.0
     top_p: 0.95
     top_k: 64

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
@@ -46,7 +46,7 @@ _benchmarks: &benchmarks
     dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
     max_out_len: 8192
     batch_size: 8
-    baseline: 73.5
+    baseline: 72
     threshold: 5
     temperature: 1.0
     top_p: 0.95

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
@@ -45,7 +45,7 @@ _benchmarks: &benchmarks
     request_conf: vllm_api_general_chat
     dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
     num_prompts: 32
-    max_out_len: 32768
+    max_out_len: 16384
     batch_size: 8
     baseline: 65
     threshold: 10

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
@@ -47,7 +47,7 @@ _benchmarks: &benchmarks
     num_prompts: 32
     max_out_len: 8192
     batch_size: 8
-    baseline: 65
+    baseline: 72
     threshold: 10
     temperature: 1.0
     top_p: 0.95

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
@@ -1,0 +1,90 @@
+# ==========================================
+# Shared Configurations
+# ==========================================
+
+_model: &model "vllm-ascend/Gemma4-26B-MoE"
+
+_envs: &envs
+  VLLM_USE_MODELSCOPE: "true"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  HCCL_BUFFSIZE: "1024"
+  OMP_NUM_THREADS: "1"
+  TASK_QUEUE_ENABLE: "1"
+  SERVER_PORT: "DEFAULT_PORT"
+  VLLM_ENGINE_READY_TIMEOUT_S: "3000"
+  VLLM_RPC_TIMEOUT: "6000"
+
+_server_cmd: &server_cmd
+  - "--no-enable-prefix-caching"
+  - "--tensor-parallel-size"
+  - "4"
+  - "--port"
+  - "$SERVER_PORT"
+  - "--max-model-len"
+  - "32768"
+  - "--max-num-batched-tokens"
+  - "8192"
+  - "--max-num-seqs"
+  - "8"
+  - "--gpu-memory-utilization"
+  - "0.9"
+  - "--trust-remote-code"
+  - "--enable-expert-parallel"
+
+_api_keyword_args: &api_keyword_args
+  max_tokens: 64
+  temperature: 0.0
+
+_benchmarks: &benchmarks
+  acc_gpqa:
+    case_type: accuracy
+    dataset_path: vllm-ascend/gpqa
+    request_conf: vllm_api_general_chat
+    dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
+    num_prompts: 32
+    max_out_len: 32768
+    batch_size: 8
+    baseline: 70
+    threshold: 10
+    temperature: 0.0
+    top_p: 1.0
+    ignore_eos: false
+
+# ==========================================
+# ACTUAL TEST CASES
+# ==========================================
+
+test_cases:
+  - name: "Gemma4-eager"
+    model: *model
+    envs:
+      <<: *envs
+    prompts:
+      - "Explain briefly why ACLGraph output should match eager output."
+    api_keyword_args:
+      <<: *api_keyword_args
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--enforce-eager"
+    test_content:
+      - "chat_completion"
+    benchmarks:
+      <<: *benchmarks
+
+  - name: "Gemma4-full-decode-graph"
+    model: *model
+    envs:
+      <<: *envs
+    prompts:
+      - "Explain briefly why ACLGraph output should match eager output."
+    api_keyword_args:
+      <<: *api_keyword_args
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--compilation-config"
+      - '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8]}'
+    test_content:
+      - "chat_completion"
+    benchmarks:
+      <<: *benchmarks

--- a/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Gemma4.yaml
@@ -34,7 +34,9 @@ _server_cmd: &server_cmd
 
 _api_keyword_args: &api_keyword_args
   max_tokens: 64
-  temperature: 0.0
+  temperature: 1.0
+  top_p: 0.95
+  top_k: 64
 
 _benchmarks: &benchmarks
   acc_gpqa:
@@ -45,10 +47,11 @@ _benchmarks: &benchmarks
     num_prompts: 32
     max_out_len: 32768
     batch_size: 8
-    baseline: 70
+    baseline: 65
     threshold: 10
-    temperature: 0.0
-    top_p: 1.0
+    temperature: 1.0
+    top_p: 0.95
+    top_k: 64
     ignore_eos: false
 
 # ==========================================


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds Gemma4 nightly single-node CI coverage for both eager execution and ACLGraph `FULL_DECODE_ONLY` execution.

The new coverage includes:
- Gemma4 MoE eager and full-decode graph cases.
- Gemma4 31B dense eager and full-decode graph cases.
- GPQA-D accuracy checks with conservative settings to reduce CI variance.
- Lightweight chat completion smoke checks before accuracy evaluation.

The goal is to continuously guard Gemma4 graph execution correctness while keeping dense and MoE cases separated for easier failure diagnosis.

### Does this PR introduce _any_ user-facing change?

No. This PR only adds CI coverage.

### How was this patch tested?

Static validation was performed locally:
- Parsed the updated YAML files with `yaml.safe_load`.
- Checked that Gemma4 dense cases do not enable expert parallelism.
- Checked that eager and graph cases share the same base server configuration and only differ by `--enforce-eager` vs `--compilation-config`.
- Ran `git diff --check` on the modified CI files.

The new Gemma4 cases are expected to be validated by the nightly CI runners.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
