### PR TITLE
[Test](nightly): reduce max out len to 4096 in DeepSeek-V3.2-W8A8-DCP.yaml

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/DeepSeek-V3.2-W8A8-DCP.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/DeepSeek-V3.2-W8A8-DCP.yaml
@@ -75,7 +75,7 @@ test_cases:
         dataset_path: vllm-ascend/gsm8k-lite
         request_conf: vllm_api_general_chat
         dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_chat_prompt
-        max_out_len: 8192
+        max_out_len: 4096
         batch_size: 32
         baseline: 95
         threshold: 5


### PR DESCRIPTION
### What this PR does / why we need it?

Fix error max out len in DeepSeek-V3.2-W8A8-DCP.yaml.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
