### PR TITLE
Fix SFA DCP replicated indexer KV transfer

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -1124,6 +1124,7 @@ class TestMooncakeConnectorMetadata(unittest.TestCase):
         meta.add_new_req(
             request_id="req1",
             local_block_ids=[1, 2, 3],
+            local_full_block_ids=[0, 1, 2, 3],
             num_external_tokens=48,
             kv_transfer_params={
                 "remote_block_ids": [4, 5, 6],
@@ -1141,6 +1142,7 @@ class TestMooncakeConnectorMetadata(unittest.TestCase):
         req_meta = meta.requests["req1"]
         self.assertIsInstance(req_meta, ReqMeta)
         self.assertEqual(req_meta.local_block_ids, [1, 2, 3])
+        self.assertEqual(req_meta.local_full_block_ids, [0, 1, 2, 3])
         self.assertEqual(req_meta.remote_block_ids, [4, 5, 6])
         self.assertEqual(req_meta.remote_engine_id, "remote_engine")
         self.assertEqual(req_meta.remote_host, "localhost")
@@ -1296,6 +1298,9 @@ class MockKVCacheBlocks:
 
     def get_unhashed_block_ids_all_groups(self):
         return ([4, 5, 6],)
+
+    def get_block_ids(self):
+        return ([1, 2, 4, 5, 6],)
 
 
 class MockSchedulerOutput:
@@ -2741,6 +2746,48 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
 
         tp_num_need_pulls = worker._get_tp_num_need_pulls(prefill_tp_size=None)
         self.assertEqual(tp_num_need_pulls, 1)
+
+    def test_get_sfa_replicated_indexer_block_ids_uses_full_blocks_for_prefix(self):
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.enable_sfa_dcp_replicated_indexer = True
+        worker.pcp_size = 1
+        worker.dcp_size = 2
+        worker.block_size = 16
+        meta = types.SimpleNamespace(
+            remote_pcp_size=1,
+            remote_dcp_size=2,
+            remote_block_ids=([10, 11],),
+            local_block_ids=([20],),
+            local_full_block_ids=([19, 20],),
+            num_external_tokens=32,
+            num_prompt_blocks=3,
+            num_computed_tokens=16,
+        )
+
+        local_ids, remote_ids = worker._get_sfa_replicate_k_block_ids(cast(ReqMeta, meta))
+
+        self.assertEqual(local_ids, ([39, 40],))
+        self.assertEqual(remote_ids, ([21, 22],))
+
+    def test_get_sfa_replicated_indexer_block_ids_requires_full_blocks_for_prefix(self):
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.enable_sfa_dcp_replicated_indexer = True
+        worker.pcp_size = 1
+        worker.dcp_size = 2
+        worker.block_size = 16
+        meta = types.SimpleNamespace(
+            remote_pcp_size=1,
+            remote_dcp_size=2,
+            remote_block_ids=([10, 11],),
+            local_block_ids=([20],),
+            local_full_block_ids=tuple(),
+            num_external_tokens=32,
+            num_prompt_blocks=3,
+            num_computed_tokens=16,
+        )
+
+        with self.assertRaises(AssertionError):
+            worker._get_sfa_replicate_k_block_ids(cast(ReqMeta, meta))
 
 
 if __name__ == "__main__":

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -211,8 +211,8 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         spec = AscendMLAAttentionSpec(
             block_size=16,
             num_kv_heads=1,
-            head_size=704,
-            sparse_head_dim=(512, 64, 128),
+            head_size=1088,
+            sparse_head_dim=(512, 64, 128 * 4),
             dtype=torch.bfloat16,
             cache_dtype_str="auto",
             sfa_dcp_replicated_indexer_size=4,
@@ -228,6 +228,66 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
                 None,
             ),
         )
+
+    def test_sparse_replicated_indexer_reshape_uses_expanded_storage_once(self):
+        runner = self._build_runner()
+        runner.use_sparse = True
+        runner.attn_backend.get_kv_cache_shape.side_effect = (
+            lambda num_blocks, block_size, num_kv_heads, head_size: (
+                num_blocks,
+                block_size,
+                num_kv_heads,
+                head_size,
+            )
+        )
+        runner._get_attention_kv_cache_dims = lambda _layer_name, _spec: (512, 64)
+        layer_name = "model.layers.1.self_attn.attn"
+        spec = AscendMLAAttentionSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=1088,
+            sparse_head_dim=(512, 64, 128 * 4),
+            dtype=torch.bfloat16,
+            cache_dtype_str="auto",
+            sfa_dcp_replicated_indexer_size=4,
+        )
+        num_blocks = 2
+        kv_cache_config = KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=spec.page_size_bytes * num_blocks,
+                    shared_by=[layer_name],
+                )
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=[layer_name],
+                    kv_cache_spec=spec,
+                )
+            ],
+        )
+
+        raw_caches = runner._allocate_kv_cache_tensors(kv_cache_config)
+        raw_k_cache, raw_v_cache, raw_indexer_cache = raw_caches[layer_name]
+
+        self.assertEqual(raw_k_cache.numel(), num_blocks * 16 * 512 * 2)
+        self.assertEqual(raw_v_cache.numel(), num_blocks * 16 * 64 * 2)
+        self.assertEqual(raw_indexer_cache.numel(), num_blocks * 16 * (128 * 4) * 2)
+
+        runner._kv_cache_spec_attn_group_iterator = lambda: [
+            SimpleNamespace(
+                kv_cache_spec=spec,
+                backend=runner.attn_backend,
+                layer_names=[layer_name],
+            )
+        ]
+        kv_caches = runner._reshape_kv_cache_tensors(kv_cache_config, raw_caches)
+        k_cache, v_cache, indexer_cache = kv_caches[layer_name]
+
+        self.assertEqual(k_cache.shape, (num_blocks, 16, 1, 512))
+        self.assertEqual(v_cache.shape, (num_blocks, 16, 1, 64))
+        self.assertEqual(indexer_cache.shape, (num_blocks * 4, 16, 1, 128))
 
 
 class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -7,6 +7,8 @@ import torch
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheGroupSpec, KVCacheTensor
 
+from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
+from vllm_ascend.utils import AscendDeviceType
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
 
@@ -26,6 +28,9 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         runner.vllm_config.kv_transfer_config = None
         runner.model_config = MagicMock()
         runner.model_config.use_mla = True
+        runner.model_config.hf_text_config = SimpleNamespace(index_head_dim=128)
+        runner.c8_k_cache_dtype = torch.int8
+        runner.c8_k_scale_cache_dtype = torch.float16
         backend = MagicMock()
         backend.get_kv_cache_shape.side_effect = lambda num_blocks, block_size, num_kv_heads, head_size: (
             2,
@@ -137,6 +142,92 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
 
         self.assertEqual(raw_k_cache.numel(), 2 * 16 * 512 * 2)
         self.assertEqual(raw_v_cache.numel(), 2 * 16 * 64 * 2)
+
+    @patch("vllm_ascend.worker.model_runner_v1.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    def test_sparse_c8_replicated_indexer_allocates_aligned_cache(self, _mock_device_type):
+        runner = self._build_runner()
+        runner.use_sparse = True
+        runner.attn_backend.get_kv_cache_shape.side_effect = (
+            lambda num_blocks, block_size, num_kv_heads, head_size: (
+                num_blocks,
+                block_size,
+                num_kv_heads,
+                head_size,
+            )
+        )
+        layer_name = "model.layers.1.self_attn.attn"
+        runner._get_attention_kv_cache_dims = lambda _layer_name, _spec: (512, 0)
+        spec = AscendMLAAttentionSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=640,
+            sparse_head_dim=(512, 0, 128),
+            dtype=torch.bfloat16,
+            cache_dtype_str="auto",
+            cache_sparse_c8=True,
+            c8_k_cache_dtype=torch.int8,
+            c8_k_scale_cache_dtype=torch.float16,
+            sfa_dcp_replicated_indexer_size=4,
+        )
+        num_blocks = 2
+        kv_cache_config = KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=spec.page_size_bytes * num_blocks,
+                    shared_by=[layer_name],
+                )
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=[layer_name],
+                    kv_cache_spec=spec,
+                )
+            ],
+        )
+
+        raw_caches = runner._allocate_kv_cache_tensors(kv_cache_config)
+        raw_k_cache, raw_indexer_cache, raw_indexer_scale_cache = raw_caches[layer_name]
+
+        self.assertEqual(raw_k_cache.numel(), num_blocks * 16 * 512)
+        self.assertEqual(raw_indexer_cache.numel(), num_blocks * 4 * 16 * 128)
+        self.assertEqual(raw_indexer_scale_cache.numel(), num_blocks * 4 * 16 * 2)
+
+        runner._kv_cache_spec_attn_group_iterator = lambda: [
+            SimpleNamespace(
+                kv_cache_spec=spec,
+                backend=runner.attn_backend,
+                layer_names=[layer_name],
+            )
+        ]
+        kv_caches = runner._reshape_kv_cache_tensors(kv_cache_config, raw_caches)
+        k_cache, indexer_cache, indexer_scale_cache = kv_caches[layer_name]
+
+        self.assertEqual(k_cache.shape, (num_blocks, 16, 1, 512))
+        self.assertEqual(indexer_cache.shape, (num_blocks * 4, 16, 1, 128))
+        self.assertEqual(indexer_scale_cache.shape, (num_blocks * 4, 16, 1, 1))
+
+    def test_sparse_replicated_indexer_page_size_includes_replicas(self):
+        spec = AscendMLAAttentionSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=704,
+            sparse_head_dim=(512, 64, 128),
+            dtype=torch.bfloat16,
+            cache_dtype_str="auto",
+            sfa_dcp_replicated_indexer_size=4,
+        )
+
+        self.assertEqual(spec.page_size_bytes, 16 * (512 + 64 + 128 * 4) * 2)
+        self.assertEqual(
+            spec.sparse_kv_cache_ratio,
+            (
+                (512 + 64 + 128 * 4) / 512,
+                (512 + 64 + 128 * 4) / 64,
+                (512 + 64 + 128 * 4) / (128 * 4),
+                None,
+            ),
+        )
 
 
 class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -87,19 +87,6 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
             )
             return ckv_bytes + qli_bytes + qli_scale_bytes
 
-        if (
-            self.sparse_head_dim is not None
-            and len(self.sparse_head_dim) == 3
-            and self.sfa_dcp_replicated_indexer_size > 1
-        ):
-            k_head_dim, v_head_dim, index_head_dim = self.sparse_head_dim
-            replicated_head_size = (
-                k_head_dim
-                + v_head_dim
-                + index_head_dim * self.sfa_dcp_replicated_indexer_size
-            )
-            return self.block_size * self.num_kv_heads * replicated_head_size * get_dtype_size(self.dtype)
-
         return (
             self.block_size
             * self.num_kv_heads
@@ -149,15 +136,13 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
                 None,  # kv_cache[3] does not exist for Sparse C8
             )
 
-        k_head_dim, v_head_dim, index_head_dim = self.sparse_head_dim
-        replicated_index_head_dim = index_head_dim * self.sfa_dcp_replicated_indexer_size
-        total_virtual_head_dim = k_head_dim + v_head_dim + replicated_index_head_dim
-
+        # Non-C8 sparse specs already store the replicated indexer width in
+        # sparse_head_dim/head_size when SFA DCP replicated indexer is enabled.
         return (
-            total_virtual_head_dim / k_head_dim,  # kv_cache[0]
-            total_virtual_head_dim / v_head_dim,  # kv_cache[1]
+            self.head_size / self.sparse_head_dim[0],  # kv_cache[0]
+            self.head_size / self.sparse_head_dim[1],  # kv_cache[1]
             (
-                total_virtual_head_dim / replicated_index_head_dim if index_head_dim > 0 else None
+                self.head_size / self.sparse_head_dim[2] if self.sparse_head_dim[2] > 0 else None
             ),  # kv_cache[2]
             None,  # kv_cache[3] does not exist
         )

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -74,13 +74,31 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
             assert qk_rope_head_dim == 0
 
             ckv_bytes = num_heads_per_page * ckv_head_dim * get_dtype_size(self.c8_k_cache_dtype)
-            qli_bytes = num_heads_per_page * index_head_dim * get_dtype_size(self.c8_k_cache_dtype)
+            qli_bytes = (
+                num_heads_per_page
+                * index_head_dim
+                * self.sfa_dcp_replicated_indexer_size
+                * get_dtype_size(self.c8_k_cache_dtype)
+            )
             qli_scale_bytes = (
                 num_heads_per_page * self.sfa_dcp_replicated_indexer_size * get_dtype_size(self.c8_k_scale_cache_dtype)
                 if index_head_dim > 0
                 else 0
             )
             return ckv_bytes + qli_bytes + qli_scale_bytes
+
+        if (
+            self.sparse_head_dim is not None
+            and len(self.sparse_head_dim) == 3
+            and self.sfa_dcp_replicated_indexer_size > 1
+        ):
+            k_head_dim, v_head_dim, index_head_dim = self.sparse_head_dim
+            replicated_head_size = (
+                k_head_dim
+                + v_head_dim
+                + index_head_dim * self.sfa_dcp_replicated_indexer_size
+            )
+            return self.block_size * self.num_kv_heads * replicated_head_size * get_dtype_size(self.dtype)
 
         return (
             self.block_size
@@ -116,7 +134,11 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
                     None,  # kv_cache[3] does not exist for Sparse C8
                 )
 
-            qli_virtual = index_k_head_dim * get_dtype_size(self.c8_k_cache_dtype)
+            qli_virtual = (
+                index_k_head_dim
+                * self.sfa_dcp_replicated_indexer_size
+                * get_dtype_size(self.c8_k_cache_dtype)
+            )
             scale_virtual = self.sfa_dcp_replicated_indexer_size * get_dtype_size(self.c8_k_scale_cache_dtype)
             total_virtual_head_dim = ckv_virtual + qli_virtual + scale_virtual
 
@@ -127,12 +149,16 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
                 None,  # kv_cache[3] does not exist for Sparse C8
             )
 
+        k_head_dim, v_head_dim, index_head_dim = self.sparse_head_dim
+        replicated_index_head_dim = index_head_dim * self.sfa_dcp_replicated_indexer_size
+        total_virtual_head_dim = k_head_dim + v_head_dim + replicated_index_head_dim
+
         return (
-            self.head_size / self.sparse_head_dim[0],  # kv_cache[0]
-            self.head_size / self.sparse_head_dim[1],  # kv_cache[1]
+            total_virtual_head_dim / k_head_dim,  # kv_cache[0]
+            total_virtual_head_dim / v_head_dim,  # kv_cache[1]
             (
-                self.head_size / self.sparse_head_dim[2] if self.sparse_head_dim[2] > 0 else None
-            ),  # kv_cache[2]  # kv_cache[2]
+                total_virtual_head_dim / replicated_index_head_dim if index_head_dim > 0 else None
+            ),  # kv_cache[2]
             None,  # kv_cache[3] does not exist
         )
 

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -67,7 +67,7 @@ from vllm_ascend.distributed.utils import (
     get_decode_context_model_parallel_rank,
     get_decode_context_model_parallel_world_size,
 )
-from vllm_ascend.utils import enable_custom_op
+from vllm_ascend.utils import enable_custom_op, enable_sfa_dcp_replicated_indexer
 
 # isort: off
 if TYPE_CHECKING:
@@ -123,6 +123,7 @@ class ReqMeta:
     remote_multi_nodes_meta_mapping: dict[str, dict[str, Any]]
     num_prompt_blocks: int
     remote_block_size: int
+    local_full_block_ids: BlockIds = tuple()
 
 
 @dataclass(frozen=True)
@@ -493,6 +494,7 @@ class KVCacheRecvingThread(threading.Thread):
             else 0
         )
         self.use_mla = self.model_config.is_deepseek_mla
+        self.enable_sfa_dcp_replicated_indexer = enable_sfa_dcp_replicated_indexer(self.vllm_config)
         self.is_hma_required = is_hma_required
         self.block_size = self.vllm_config.cache_config.block_size
         try:
@@ -543,6 +545,8 @@ class KVCacheRecvingThread(threading.Thread):
         remote_port_send_num: dict[int, RemotePortInfo] | None = None,
         num_computed_tokens: int = 0,
         all_task_done: bool = False,
+        local_block_ids_replicate_k: BlockIds | None = None,
+        remote_block_ids_replicate_k: BlockIds | None = None,
     ):
         """Add a new request to the queue for processing."""
         if remote_port_send_num is None:
@@ -551,6 +555,8 @@ class KVCacheRecvingThread(threading.Thread):
             "request_id": request_id,
             "local_block_ids": local_block_ids,
             "remote_block_ids": remote_block_ids,
+            "local_block_ids_replicate_k": local_block_ids_replicate_k or tuple(),
+            "remote_block_ids_replicate_k": remote_block_ids_replicate_k or tuple(),
             "group_pulls": group_pulls,
             "remote_engine_id": remote_engine_id,
             "remote_request_id": remote_request_id,
@@ -732,6 +738,9 @@ class KVCacheRecvingThread(threading.Thread):
         remote_request_id = req_meta["remote_request_id"]
         local_block_ids: BlockIds = req_meta["local_block_ids"]
         remote_block_ids: BlockIds = req_meta["remote_block_ids"]
+        local_block_ids_replicate_k: BlockIds = req_meta.get("local_block_ids_replicate_k", tuple())
+        remote_block_ids_replicate_k: BlockIds = req_meta.get("remote_block_ids_replicate_k", tuple())
+        has_replicate_k_blocks = bool(local_block_ids_replicate_k and remote_block_ids_replicate_k)
         group_pulls: list[GroupPull] = req_meta["group_pulls"]
         remote_engine_id = req_meta["remote_engine_id"]
         remote_host = req_meta["remote_host"]
@@ -810,6 +819,12 @@ class KVCacheRecvingThread(threading.Thread):
                 grouped_remote_block_ids = [[remote_group_block_ids[transfer_block_idx]]]
                 grouped_local_block_ids = [[local_group_block_ids[0]]]
 
+            if self.enable_sfa_dcp_replicated_indexer and has_replicate_k_blocks:
+                grouped_remote_k_block_ids, grouped_local_k_block_ids = group_concurrent_contiguous(
+                    remote_block_ids_replicate_k[0],
+                    local_block_ids_replicate_k[0],
+                )
+
             if is_mamba_group:
                 for layer_idx in layer_indices:
                     start_meta_idx = len(src_list)
@@ -855,13 +870,20 @@ class KVCacheRecvingThread(threading.Thread):
                     block_stride = self.block_stride_per_addr[layer_idx][cache_idx]
                     remote_block_stride = remote_block_stride_per_addr[layer_idx][cache_idx]
                     inner_block_len = block_len // tp_num_need_pulls
-                    transfer_remote_block_ids, transfer_local_block_ids = split_if_not_byte_contiguous(
-                        grouped_remote_block_ids,
-                        grouped_local_block_ids,
-                        src_block_stride=remote_block_stride,
-                        dst_block_stride=block_stride,
-                        block_len=inner_block_len,
-                    )
+                    if self.enable_sfa_dcp_replicated_indexer and self.block_size_scale[layer_idx][cache_idx] > 1:
+                        if has_replicate_k_blocks:
+                            transfer_remote_block_ids = grouped_remote_k_block_ids
+                            transfer_local_block_ids = grouped_local_k_block_ids
+                        else:
+                            continue
+                    else:
+                        transfer_remote_block_ids, transfer_local_block_ids = split_if_not_byte_contiguous(
+                            grouped_remote_block_ids,
+                            grouped_local_block_ids,
+                            src_block_stride=remote_block_stride,
+                            dst_block_stride=block_stride,
+                            block_len=inner_block_len,
+                        )
                     for remote_block_id, local_block_id in zip(transfer_remote_block_ids, transfer_local_block_ids):
                         src = src_layer_base_addr + local_block_id[0] * block_stride + inner_offset * inner_block_len
                         dst = dst_layer_base_addr + remote_block_id[0] * remote_block_stride
@@ -1388,6 +1410,7 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
         local_block_ids: BlockIds,
         num_external_tokens: int,
         kv_transfer_params: dict[str, Any],
+        local_full_block_ids: BlockIds | None = None,
     ):
         self.requests[request_id] = ReqMeta(
             local_block_ids=local_block_ids,
@@ -1404,6 +1427,7 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
             remote_multi_nodes_meta_mapping=kv_transfer_params.get("remote_multi_nodes_meta_mapping", {}),
             num_prompt_blocks=kv_transfer_params.get("num_prompt_blocks", 0),
             remote_block_size=kv_transfer_params.get("remote_block_size", 0),
+            local_full_block_ids=local_full_block_ids or tuple(),
         )
 
 
@@ -1560,7 +1584,7 @@ class MooncakeConnectorScheduler:
         # Requests that need to start recv.
         # New requests are added by update_state_after_alloc in
         # the scheduler. Used to make metadata passed to Worker.
-        self._reqs_need_recv: dict[str, tuple[Request, BlockIds, int]] = {}
+        self._reqs_need_recv: dict[str, tuple[Request, BlockIds, BlockIds, int]] = {}
         self._reqs_need_send: dict[str, float] = {}
         self._reqs_in_batch: set[str] = set()
 
@@ -1733,8 +1757,14 @@ class MooncakeConnectorScheduler:
             if params.get("remote_block_ids"):
                 if all(p in params for p in ("remote_engine_id", "remote_host", "remote_port", "remote_request_id")):
                     local_block_ids = blocks.get_unhashed_block_ids_all_groups() if num_external_tokens > 0 else []
+                    local_full_block_ids = blocks.get_block_ids() if num_external_tokens > 0 else tuple()
                     # Get unhashed blocks to pull from remote.
-                    self._reqs_need_recv[request.request_id] = (request, local_block_ids, num_external_tokens)
+                    self._reqs_need_recv[request.request_id] = (
+                        request,
+                        local_block_ids,
+                        local_full_block_ids,
+                        num_external_tokens,
+                    )
                 else:
                     logger.warning("Got invalid KVTransferParams. params=%s. ", params)
             else:
@@ -1749,7 +1779,7 @@ class MooncakeConnectorScheduler:
         meta = MooncakeConnectorMetadata()
 
         # Loop through scheduled reqs and convert to ReqMeta.
-        for req_id, (req, block_ids, num_external_tokens) in self._reqs_need_recv.items():
+        for req_id, (req, block_ids, full_block_ids, num_external_tokens) in self._reqs_need_recv.items():
             assert req.kv_transfer_params is not None
             # For the case where there are no remote blocks to pull
             # (block_ids is empty), we don't need to schedule
@@ -1757,6 +1787,7 @@ class MooncakeConnectorScheduler:
             meta.add_new_req(
                 request_id=req_id,
                 local_block_ids=block_ids,
+                local_full_block_ids=full_block_ids,
                 num_external_tokens=num_external_tokens,
                 kv_transfer_params=req.kv_transfer_params,
             )
@@ -2196,6 +2227,7 @@ class MooncakeConnectorWorker:
         """Register the KV Cache data."""
         self.use_mla = self.vllm_config.model_config.is_deepseek_mla
         self.use_sparse = hasattr(self.vllm_config.model_config.hf_text_config, "index_topk")
+        self.enable_sfa_dcp_replicated_indexer = enable_sfa_dcp_replicated_indexer(self.vllm_config)
 
         self.num_blocks = self.kv_cache_config.num_blocks
         logger.info("num_blocks: %s", self.num_blocks)
@@ -3154,6 +3186,98 @@ class MooncakeConnectorWorker:
             use_mla=num_key_value_heads == 1,
         )[self.tp_rank]
 
+    def _get_sfa_replicate_k_remote_handshake_port(
+        self,
+        meta: ReqMeta,
+    ) -> int | None:
+        if not self.enable_sfa_dcp_replicated_indexer:
+            return None
+        assert meta.remote_pcp_size == 1 and meta.remote_dcp_size == meta.remote_ptp_size
+        remote_cp_size = meta.remote_pcp_size * meta.remote_dcp_size
+        local_cp_size = self.pcp_size * self.dcp_size
+        if local_cp_size == 0 or remote_cp_size % local_cp_size != 0:
+            raise AssertionError(
+                f"SFA replicate-K expects remote cp size({remote_cp_size}) to be divisible by "
+                f"local cp size({local_cp_size})."
+            )
+        local_cp_rank = self.dcp_rank + self.pcp_rank * self.dcp_size
+        remote_cp_rank = local_cp_rank * (remote_cp_size // local_cp_size)
+        return meta.remote_port + remote_cp_rank
+
+    def _get_sfa_replicate_k_block_ids(
+        self,
+        meta: ReqMeta,
+    ) -> tuple[BlockIds, BlockIds]:
+        if not self.enable_sfa_dcp_replicated_indexer:
+            return tuple(), tuple()
+        if meta.num_external_tokens <= 0 or not meta.remote_block_ids or not meta.local_block_ids:
+            return tuple(), tuple()
+
+        if len(meta.remote_block_ids) != 1 or len(meta.local_block_ids) != 1:
+            raise AssertionError(
+                "SFA replicate-K currently expects exactly one KV cache group. "
+                f"Got remote groups={len(meta.remote_block_ids)}, local groups={len(meta.local_block_ids)}."
+            )
+
+        remote_cp_size = meta.remote_pcp_size * meta.remote_dcp_size
+        local_cp_size = self.pcp_size * self.dcp_size
+        if local_cp_size == 0 or remote_cp_size % local_cp_size != 0:
+            raise AssertionError(
+                f"SFA replicate-K expects remote cp size({remote_cp_size}) to be divisible by "
+                f"local cp size({local_cp_size})."
+            )
+
+        num_prefix_cached_blocks = min(meta.num_computed_tokens // self.block_size, meta.num_prompt_blocks)
+        num_external_blocks = meta.num_prompt_blocks - num_prefix_cached_blocks
+        num_external_blocks_from_tokens = math.ceil(meta.num_external_tokens / self.block_size)
+        if num_external_blocks < num_external_blocks_from_tokens:
+            raise AssertionError(
+                f"num_external_blocks({num_external_blocks}) derived from num_computed_tokens "
+                f"must cover num_external_blocks_from_tokens({num_external_blocks_from_tokens})."
+            )
+        if num_prefix_cached_blocks > 0 and not meta.local_full_block_ids:
+            raise AssertionError("SFA replicate-K requires full local block ids when prefix cache is used.")
+
+        remote_blocks = list(meta.remote_block_ids[0])
+        local_full_blocks = list((meta.local_full_block_ids or meta.local_block_ids)[0])
+        local_external_blocks = list(meta.local_block_ids[0])
+        if not local_full_blocks:
+            return tuple(), tuple()
+
+        local_block_ids: list[int] = []
+        remote_block_ids: list[int] = []
+        for global_block_idx in range(num_prefix_cached_blocks, meta.num_prompt_blocks):
+            remote_local_idx = global_block_idx // remote_cp_size
+            local_local_idx = global_block_idx // local_cp_size
+            if remote_local_idx >= len(remote_blocks) or local_local_idx >= len(local_full_blocks):
+                break
+            remote_block_ids.append(
+                int(remote_blocks[remote_local_idx]) * remote_cp_size + global_block_idx % remote_cp_size
+            )
+            local_block_ids.append(
+                int(local_full_blocks[local_local_idx]) * local_cp_size + global_block_idx % local_cp_size
+            )
+
+        max_external_blocks = min(num_external_blocks, len(local_external_blocks) * local_cp_size)
+        local_block_ids = local_block_ids[:max_external_blocks]
+        remote_block_ids = remote_block_ids[: len(local_block_ids)]
+        local_block_ids = local_block_ids[: len(remote_block_ids)]
+
+        logger.debug(
+            "Mooncake SFA replicate-K block ids prepared from aligned full blocks. "
+            "remote_cp_size=%s local_cp_size=%s num_prompt_blocks=%s num_computed_tokens=%s "
+            "num_external_blocks=%s local_len=%s remote_len=%s",
+            remote_cp_size,
+            local_cp_size,
+            meta.num_prompt_blocks,
+            meta.num_computed_tokens,
+            num_external_blocks,
+            len(local_block_ids),
+            len(remote_block_ids),
+        )
+
+        return (local_block_ids,), (remote_block_ids,)
+
     def start_load_kv(self, metadata: MooncakeConnectorMetadata):
         """Start loading KV blocks from remote engine."""
         for req_id in metadata.reqs_in_batch:
@@ -3175,12 +3299,31 @@ class MooncakeConnectorWorker:
 
             remote_req_id = meta.remote_request_id
             prefill_tp_size: int = meta.remote_ptp_size if meta.remote_ptp_size is not None else self._prefill_tp_size
+            replicate_k_remote_port = self._get_sfa_replicate_k_remote_handshake_port(meta)
+            (
+                local_block_ids_replicate_k,
+                remote_block_ids_replicate_k,
+            ) = self._get_sfa_replicate_k_block_ids(meta)
 
             (
                 remote_handshake_port_list,
                 local_block_ids_list,
                 remote_block_ids_list,
             ) = self._get_kv_split_metadata(remote_req_id, meta)
+            replicate_k_transfer_port = replicate_k_remote_port
+            has_replicate_k_blocks = any(local_block_ids_replicate_k) and any(remote_block_ids_replicate_k)
+            if replicate_k_remote_port is not None and has_replicate_k_blocks:
+                remote_transfer_ports = [port for remote_ports in remote_handshake_port_list for port in remote_ports]
+                if replicate_k_remote_port not in remote_transfer_ports:
+                    replicate_k_transfer_port = remote_transfer_ports[0] if remote_transfer_ports else None
+                    if replicate_k_transfer_port is not None:
+                        logger.warning(
+                            "Mooncake SFA replicate-K remote port %s is not in normal KV transfer ports %s. "
+                            "Use existing remote port %s because K cache is replicated on P workers.",
+                            replicate_k_remote_port,
+                            remote_transfer_ports,
+                            replicate_k_transfer_port,
+                        )
             group_pulls_list = self._get_group_pulls_metadata(
                 remote_req_id,
                 remote_handshake_port_list,
@@ -3205,6 +3348,16 @@ class MooncakeConnectorWorker:
                         if meta.remote_pcp_size * meta.remote_dcp_size > 1
                         else None
                     )
+                    local_block_ids_replicate_k_for_port = (
+                        local_block_ids_replicate_k
+                        if replicate_k_transfer_port is not None and remote_handshake_port == replicate_k_transfer_port
+                        else None
+                    )
+                    remote_block_ids_replicate_k_for_port = (
+                        remote_block_ids_replicate_k
+                        if replicate_k_transfer_port is not None and remote_handshake_port == replicate_k_transfer_port
+                        else None
+                    )
                     self.kv_recv_thread.add_request(
                         request_id=req_id,
                         remote_request_id=remote_req_id,
@@ -3221,6 +3374,8 @@ class MooncakeConnectorWorker:
                             and remote_tp_offset == len(remote_ports) - 1
                         ),
                         remote_block_size=meta.remote_block_size,
+                        local_block_ids_replicate_k=local_block_ids_replicate_k_for_port,
+                        remote_block_ids_replicate_k=remote_block_ids_replicate_k_for_port,
                     )
 
         if self.kv_send_thread is not None and self.pcp_size * self.dcp_size == 1:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4296,15 +4296,18 @@ class NPUModelRunner(GPUModelRunner):
                             )
                             v_tensor_size = None
                             if has_indexer_cache:
+                                replicated_indexer_size = kv_cache_spec.sfa_dcp_replicated_indexer_size
                                 dsa_k_tensor_size = (
                                     num_blocks
                                     * num_heads
                                     * index_head_dim
+                                    * replicated_indexer_size
                                     * get_dtype_size(kv_cache_spec.c8_k_cache_dtype)
                                 )
                                 dsa_k_scale_tensor_size = (
                                     num_blocks
                                     * num_heads
+                                    * replicated_indexer_size
                                     * get_dtype_size(kv_cache_spec.c8_k_scale_cache_dtype)
                                 )
                             else:


### PR DESCRIPTION
## What this PR does

Follow-up fix for #11696. This patch fixes SFA DCP `sfa_dcp_replicate_k` handling for P/D KV transfer when the sparse indexer K cache is replicated across DCP ranks.

It adds explicit SFA replicated-indexer cache layout metadata, applies the correct decode-to-prefill DCP rank ordering before Mooncake transfer, and fixes the non-C8 cache sizing path so the replicated indexer allocation is not over-counted.

## Why

For GLM5.2 with DCP enabled in P/D disaggregation, the sparse indexer KV cache can have a different logical rank layout from the dense KV cache. Sending/storing it without the prefill-rank-aligned order can make P/D output quality and MTP acceptance diverge from colocated serving.

## Validation

- `git diff --check origin/main..HEAD`
- Targeted remote UT on 141.61.81.181 before rebasing onto latest `main`: `3 passed, 12 deselected`
- Manual PD service investigation on 181/182 using GLM5.2 DCP scripts; 182 later became blocked by stuck NPU worker processes, so final end-to-end acceptance rerun is pending machine recovery.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
