### PR TITLE
[Feature][SFA] Support C8 SFA with DCP replicated indexer

### DIFF
--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
@@ -45,8 +45,8 @@ COMMON_PROMPTS = [
 ]
 
 DSV3_2_DCP_GOLDEN = [
-    "The capital of France isoint054 Rund959arki",
-    "Hello, my name is Tom, I am" + "ERIC slicpacelikeabra",
+    "The capital of France isoint054 Rund compasses",
+    "Hello, my name is Tom, I am" + "ERIC slicpacelike挂",
     "The president of United States isoint054 Rund959arki",
 ]
 

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
@@ -128,7 +128,7 @@ FULL_FEATURE_MODEL_CASES = [
             "compilation_config": FULL_DECODE_GRAPH,
             "additional_config": {
                 "enable_flashcomm1": True,
-                "enable_sparse_c8": False,
+                "enable_sparse_c8": True,
             },
             "speculative_config": {
                 "method": "mtp",

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -24,12 +24,12 @@ from vllm_ascend.attention.sfa_v1 import (
     custom_kv_rmsnorm_rope,
 )
 from vllm_ascend.attention.utils import get_sfa_qsfa_packed_head_dim
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.quantization.methods import (
     AscendW8A8DynamicLinearMethod,
     AscendW8A8LinearMethod,
     AscendW8A8MXFP8DynamicLinearMethod,
 )
-from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.utils import enable_dsa_cp
 
 

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -162,11 +162,16 @@ class TestAscendSFADeviceOperator(TestBase):
         softmax_max = torch.ones(1, 3, 4)
         softmax_sum = torch.full((1, 3, 4), 3.0)
 
-        with patch(
-            "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
+        with patch.object(
+            torch.ops._C_ascend,
+            "npu_kv_quant_sparse_flash_attention",
             create=True,
             return_value=(attn_output, softmax_max, softmax_sum),
-        ) as mock_qsfa:
+        ) as mock_qsfa, patch(
+            "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
+            create=True,
+            side_effect=AssertionError("C8 SFA with LSE must use the custom op"),
+        ):
             output, softmax_lse = DeviceOperator.execute_sparse_flash_attention_process(
                 impl,
                 ql_nope,
@@ -254,6 +259,7 @@ class TestAscendSFAKVQuantSparseAttention(TestBase):
         self.assertEqual(call_kwargs["query"].shape, (3, 2, 48))
         self.assertEqual(call_kwargs["key_quant_mode"], 2)
         self.assertEqual(call_kwargs["tile_size"], 128)
+        self.assertNotIn("return_softmax_lse", call_kwargs)
 
     def test_prolog_v3_enables_packed_int8_kv_cache(self):
         impl = AscendSFAImpl.__new__(AscendSFAImpl)

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -105,7 +105,7 @@ class TestAscendSFADeviceOperator(TestBase):
             actual_seq_lengths_key,
         )
 
-    def test_execute_sparse_flash_attention_returns_lse(self):
+    def test_execute_sparse_flash_attention_returns_softmax_components(self):
         (
             impl,
             ql_nope,
@@ -129,7 +129,7 @@ class TestAscendSFADeviceOperator(TestBase):
             create=True,
             return_value=(attn_output, softmax_max, softmax_sum),
         ) as mock_sfa:
-            output, softmax_lse = DeviceOperator.execute_sparse_flash_attention_process(
+            output, actual_softmax_max, actual_softmax_sum = DeviceOperator.execute_sparse_flash_attention_process(
                 impl,
                 ql_nope,
                 q_pe,
@@ -142,12 +142,11 @@ class TestAscendSFADeviceOperator(TestBase):
             )
 
         self.assertIs(output, attn_output)
-        self.assertEqual(softmax_lse.shape, (3, 4, 1))
-        expected_lse = torch.full((3, 4, 1), torch.log(torch.tensor(2.0)).item())
-        self.assertTrue(torch.allclose(softmax_lse, expected_lse))
+        self.assertIs(actual_softmax_max, softmax_max)
+        self.assertIs(actual_softmax_sum, softmax_sum)
         self.assertTrue(mock_sfa.call_args.kwargs["return_softmax_lse"])
 
-    def test_execute_sparse_flash_attention_c8_returns_lse(self):
+    def test_execute_sparse_flash_attention_c8_returns_softmax_components(self):
         (
             impl,
             ql_nope,
@@ -175,7 +174,7 @@ class TestAscendSFADeviceOperator(TestBase):
                 side_effect=AssertionError("C8 SFA with LSE must use the custom op"),
             ),
         ):
-            output, softmax_lse = DeviceOperator.execute_sparse_flash_attention_process(
+            output, actual_softmax_max, actual_softmax_sum = DeviceOperator.execute_sparse_flash_attention_process(
                 impl,
                 ql_nope,
                 q_pe,
@@ -189,8 +188,8 @@ class TestAscendSFADeviceOperator(TestBase):
             )
 
         self.assertIs(output, attn_output)
-        expected_lse = torch.full((3, 4, 1), 1.0 + torch.log(torch.tensor(3.0)).item())
-        self.assertTrue(torch.allclose(softmax_lse, expected_lse))
+        self.assertIs(actual_softmax_max, softmax_max)
+        self.assertIs(actual_softmax_sum, softmax_sum)
         call_kwargs = mock_qsfa.call_args.kwargs
         self.assertIs(call_kwargs["key"], packed_kv_cache[0])
         self.assertIs(call_kwargs["value"], packed_kv_cache[0])
@@ -270,7 +269,7 @@ class TestAscendSFAKVQuantSparseAttention(TestBase):
         self.assertEqual(call_kwargs["query"].shape, (3, 2, 48))
         self.assertEqual(call_kwargs["key_quant_mode"], 2)
         self.assertEqual(call_kwargs["tile_size"], 128)
-        self.assertNotIn("return_softmax_lse", call_kwargs)
+        self.assertFalse(call_kwargs["return_softmax_lse"])
 
     def test_prolog_v3_enables_packed_int8_kv_cache(self):
         impl = AscendSFAImpl.__new__(AscendSFAImpl)

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -162,15 +162,18 @@ class TestAscendSFADeviceOperator(TestBase):
         softmax_max = torch.ones(1, 3, 4)
         softmax_sum = torch.full((1, 3, 4), 3.0)
 
-        with patch.object(
-            torch.ops._C_ascend,
-            "npu_kv_quant_sparse_flash_attention",
-            create=True,
-            return_value=(attn_output, softmax_max, softmax_sum),
-        ) as mock_qsfa, patch(
-            "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
-            create=True,
-            side_effect=AssertionError("C8 SFA with LSE must use the custom op"),
+        with (
+            patch.object(
+                torch.ops._C_ascend,
+                "npu_kv_quant_sparse_flash_attention",
+                create=True,
+                return_value=(attn_output, softmax_max, softmax_sum),
+            ) as mock_qsfa,
+            patch(
+                "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
+                create=True,
+                side_effect=AssertionError("C8 SFA with LSE must use the custom op"),
+            ),
         ):
             output, softmax_lse = DeviceOperator.execute_sparse_flash_attention_process(
                 impl,

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -241,11 +241,19 @@ class TestAscendSFAKVQuantSparseAttention(TestBase):
         actual_seq_lengths = torch.tensor([3], dtype=torch.int32)
         expected = torch.randn(3, 2, 32)
 
-        with patch(
-            "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
-            create=True,
-            return_value=expected,
-        ) as mock_qsfa:
+        with (
+            patch.object(
+                torch.ops._C_ascend,
+                "npu_kv_quant_sparse_flash_attention",
+                create=True,
+                return_value=(expected, torch.empty(0), torch.empty(0)),
+            ) as mock_qsfa,
+            patch(
+                "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
+                create=True,
+                side_effect=AssertionError("Base must use _C_ascend custom op"),
+            ),
+        ):
             result = impl._execute_sparse_flash_attention_process(
                 ql_nope,
                 q_pe,

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -29,6 +29,7 @@ from vllm_ascend.quantization.methods import (
     AscendW8A8LinearMethod,
     AscendW8A8MXFP8DynamicLinearMethod,
 )
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.utils import enable_dsa_cp
 
 
@@ -79,6 +80,115 @@ class TestAscendSFABackend(TestBase):
         mock_enable_cp.return_value = True
         impl_cls = AscendSFABackend.get_impl_cls()
         self.assertIsNotNone(impl_cls)
+
+
+class TestAscendSFADeviceOperator(TestBase):
+    def _make_common_inputs(self):
+        ql_nope = torch.randn(3, 4, 8)
+        q_pe = torch.randn(3, 4, 2)
+        topk_indices = torch.zeros(3, 1, dtype=torch.int32)
+        attn_metadata = MagicMock()
+        attn_metadata.block_table = torch.zeros(1, 4, dtype=torch.int32)
+        actual_seq_lengths_query = torch.tensor([3], dtype=torch.int32)
+        actual_seq_lengths_key = torch.tensor([3], dtype=torch.int32)
+        impl = MagicMock()
+        impl.scale = 0.125
+        impl.qk_rope_head_dim = 2
+        impl.sfa_qsfa_tile_size = 128
+        return (
+            impl,
+            ql_nope,
+            q_pe,
+            topk_indices,
+            attn_metadata,
+            actual_seq_lengths_query,
+            actual_seq_lengths_key,
+        )
+
+    def test_execute_sparse_flash_attention_returns_lse(self):
+        (
+            impl,
+            ql_nope,
+            q_pe,
+            topk_indices,
+            attn_metadata,
+            actual_seq_lengths_query,
+            actual_seq_lengths_key,
+        ) = self._make_common_inputs()
+        kv_cache = (
+            torch.randn(4, 1, 1, 8),
+            torch.randn(4, 1, 1, 2),
+        )
+        attn_output = torch.randn(3, 4, 8)
+        softmax_max = torch.zeros(1, 3, 4)
+        softmax_sum = torch.full((1, 3, 4), 2.0)
+
+        with patch.object(
+            torch.ops._C_ascend,
+            "npu_sparse_flash_attention",
+            create=True,
+            return_value=(attn_output, softmax_max, softmax_sum),
+        ) as mock_sfa:
+            output, softmax_lse = DeviceOperator.execute_sparse_flash_attention_process(
+                impl,
+                ql_nope,
+                q_pe,
+                kv_cache,
+                topk_indices,
+                attn_metadata,
+                actual_seq_lengths_query,
+                actual_seq_lengths_key,
+                return_lse=True,
+            )
+
+        self.assertIs(output, attn_output)
+        self.assertEqual(softmax_lse.shape, (3, 4, 1))
+        expected_lse = torch.full((3, 4, 1), torch.log(torch.tensor(2.0)).item())
+        self.assertTrue(torch.allclose(softmax_lse, expected_lse))
+        self.assertTrue(mock_sfa.call_args.kwargs["return_softmax_lse"])
+
+    def test_execute_sparse_flash_attention_c8_returns_lse(self):
+        (
+            impl,
+            ql_nope,
+            q_pe,
+            topk_indices,
+            attn_metadata,
+            actual_seq_lengths_query,
+            actual_seq_lengths_key,
+        ) = self._make_common_inputs()
+        packed_kv_cache = (torch.empty(4, 1, 1, 12, dtype=torch.int8),)
+        attn_output = torch.randn(3, 4, 8)
+        softmax_max = torch.ones(1, 3, 4)
+        softmax_sum = torch.full((1, 3, 4), 3.0)
+
+        with patch(
+            "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
+            create=True,
+            return_value=(attn_output, softmax_max, softmax_sum),
+        ) as mock_qsfa:
+            output, softmax_lse = DeviceOperator.execute_sparse_flash_attention_process(
+                impl,
+                ql_nope,
+                q_pe,
+                packed_kv_cache,
+                topk_indices,
+                attn_metadata,
+                actual_seq_lengths_query,
+                actual_seq_lengths_key,
+                sparse_mode=0,
+                return_lse=True,
+            )
+
+        self.assertIs(output, attn_output)
+        expected_lse = torch.full((3, 4, 1), 1.0 + torch.log(torch.tensor(3.0)).item())
+        self.assertTrue(torch.allclose(softmax_lse, expected_lse))
+        call_kwargs = mock_qsfa.call_args.kwargs
+        self.assertIs(call_kwargs["key"], packed_kv_cache[0])
+        self.assertIs(call_kwargs["value"], packed_kv_cache[0])
+        self.assertEqual(call_kwargs["query"].shape, (3, 4, 10))
+        self.assertEqual(call_kwargs["sparse_mode"], 0)
+        self.assertTrue(call_kwargs["return_softmax_lse"])
 
 
 class TestAscendSFAKVQuantSparseAttention(TestBase):

--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -1516,7 +1516,7 @@ class TestAscendSFADCPImpl(TestBase):
         )
         sfa_output = torch.randn(2, 2, 8)
         softmax_max = torch.randn(2, 2, 1)
-        softmax_sum = torch.randn(2, 2, 1)
+        softmax_sum = torch.rand(2, 2, 1)
         softmax_lse = softmax_max + torch.log(softmax_sum)
         softmax_lse = softmax_lse.permute(1, 0, 2).reshape(softmax_lse.shape[1], -1, 1)
 
@@ -1544,4 +1544,7 @@ class TestAscendSFADCPImpl(TestBase):
         self.assertIs(call_kwargs["block_table"], dcp_block_table)
         self.assertEqual(call_kwargs["sparse_mode"], 0)
         self.assertTrue(call_kwargs["return_lse"])
-        impl._merge_dcp_outputs.assert_called_once_with(sfa_output, softmax_lse)
+        impl._merge_dcp_outputs.assert_called_once()
+        merge_args = impl._merge_dcp_outputs.call_args.args
+        self.assertIs(merge_args[0], sfa_output)
+        torch.testing.assert_close(merge_args[1], softmax_lse)

--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -1093,7 +1093,6 @@ class TestAscendSFACPImpl(TestBase):
         self.assertIsNotNone(result)
         self.assertEqual(result.shape[0], 5)
 
-
     @patch_distributed_groups(dcp_size=1, pcp_size=1, needs_mocks=False)
     def test_execute_sparse_flash_attention_process_decode_and_prefill_no_pcp(self):
         self.impl.pcp_size = 1
@@ -1486,11 +1485,14 @@ class TestAscendSFACPImpl(TestBase):
 
 
 class TestAscendSFADCPImpl(TestBase):
-    def test_execute_sparse_flash_attention_process_uses_device_operator_lse(self):
+    def test_execute_sparse_flash_attention_process_uses_c8_device_operator_lse(self):
         impl = AscendSFADCPImpl.__new__(AscendSFADCPImpl)
         impl.dcp_group = MagicMock()
         impl.dcp_size = 2
         impl.enable_dsa_cp = False
+        impl.use_sparse_c8_sfa = True
+        impl.qk_rope_head_dim = 4
+        impl.sfa_qsfa_tile_size = 128
         impl._remap_sparse_indices = MagicMock(side_effect=lambda x: x)
         merged_output = torch.randn(2, 2, 8)
         impl._merge_dcp_outputs = MagicMock(return_value=merged_output)
@@ -1498,10 +1500,7 @@ class TestAscendSFADCPImpl(TestBase):
         ql_nope = torch.randn(2, 2, 8)
         q_pe = torch.randn(2, 2, 4)
         impl._finish_all_gather_query_for_dcp = MagicMock(side_effect=lambda _ctx: (ql_nope, q_pe))
-        kv_cache = (
-            torch.randn(4, 1, 1, 8),
-            torch.randn(4, 1, 1, 4),
-        )
+        kv_cache = (torch.empty(4, 1, 1, 16, dtype=torch.int8),)
         topk_indices = torch.zeros(2, 1, dtype=torch.int32)
         actual_seq_lengths_query = torch.tensor([2], dtype=torch.int32)
         actual_seq_lengths_key = torch.tensor([4], dtype=torch.int32)
@@ -1535,6 +1534,9 @@ class TestAscendSFADCPImpl(TestBase):
         self.assertIs(result, merged_output)
         call_args = mock_execute_sfa.call_args.args
         call_kwargs = mock_execute_sfa.call_args.kwargs
+        self.assertTrue(call_args[0].use_sparse_c8_sfa)
+        self.assertEqual(len(call_args[3]), 1)
+        self.assertEqual(call_args[3][0].dtype, torch.int8)
         self.assertIs(call_args[7], dcp_seq_lens)
         self.assertIs(call_kwargs["block_table"], dcp_block_table)
         self.assertEqual(call_kwargs["sparse_mode"], 0)

--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -27,8 +27,12 @@ if "torch_npu._inductor" not in sys.modules:
     sys.modules["torch_npu._inductor"] = MagicMock()
 
 from vllm_ascend.attention.context_parallel.common_cp import AscendPCPMetadata
-from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFACPImpl, AscendSFACPMetadataBuilder
-from vllm_ascend.attention.sfa_v1 import AscendSFAImpl, AscendSFAMetadata
+from vllm_ascend.attention.context_parallel.sfa_cp import (
+    AscendSFACPImpl,
+    AscendSFACPMetadataBuilder,
+    AscendSFADCPImpl,
+)
+from vllm_ascend.attention.sfa_v1 import AscendSFAImpl, AscendSFAMetadata, DCPContext
 
 
 def _make_indexer_mock():
@@ -1089,6 +1093,7 @@ class TestAscendSFACPImpl(TestBase):
         self.assertIsNotNone(result)
         self.assertEqual(result.shape[0], 5)
 
+
     @patch_distributed_groups(dcp_size=1, pcp_size=1, needs_mocks=False)
     def test_execute_sparse_flash_attention_process_decode_and_prefill_no_pcp(self):
         self.impl.pcp_size = 1
@@ -1478,3 +1483,60 @@ class TestAscendSFACPImpl(TestBase):
             )
         self.assertIsNotNone(result)
         self.assertEqual(result.shape[0], 5)
+
+
+class TestAscendSFADCPImpl(TestBase):
+    def test_execute_sparse_flash_attention_process_uses_device_operator_lse(self):
+        impl = AscendSFADCPImpl.__new__(AscendSFADCPImpl)
+        impl.dcp_group = MagicMock()
+        impl.dcp_size = 2
+        impl.enable_dsa_cp = False
+        impl._remap_sparse_indices = MagicMock(side_effect=lambda x: x)
+        merged_output = torch.randn(2, 2, 8)
+        impl._merge_dcp_outputs = MagicMock(return_value=merged_output)
+
+        ql_nope = torch.randn(2, 2, 8)
+        q_pe = torch.randn(2, 2, 4)
+        impl._finish_all_gather_query_for_dcp = MagicMock(side_effect=lambda _ctx: (ql_nope, q_pe))
+        kv_cache = (
+            torch.randn(4, 1, 1, 8),
+            torch.randn(4, 1, 1, 4),
+        )
+        topk_indices = torch.zeros(2, 1, dtype=torch.int32)
+        actual_seq_lengths_query = torch.tensor([2], dtype=torch.int32)
+        actual_seq_lengths_key = torch.tensor([4], dtype=torch.int32)
+        dcp_seq_lens = torch.tensor([3], dtype=torch.int32)
+        dcp_block_table = torch.tensor([[0, 1]], dtype=torch.int32)
+
+        attn_metadata = MagicMock()
+        attn_metadata.dcp_context = DCPContext(
+            slot_mapping=torch.tensor([0, 1], dtype=torch.int32),
+            block_table=dcp_block_table,
+            seq_lens=dcp_seq_lens,
+            query_gather_context=MagicMock(),
+        )
+        sfa_output = torch.randn(2, 2, 8)
+        softmax_lse = torch.randn(2, 2, 1)
+
+        with patch(
+            "vllm_ascend.attention.context_parallel.sfa_cp.DeviceOperator.execute_sparse_flash_attention_process",
+            return_value=(sfa_output, softmax_lse),
+        ) as mock_execute_sfa:
+            result = impl._execute_sparse_flash_attention_process(
+                ql_nope,
+                q_pe,
+                kv_cache,
+                topk_indices,
+                attn_metadata,
+                actual_seq_lengths_query,
+                actual_seq_lengths_key,
+            )
+
+        self.assertIs(result, merged_output)
+        call_args = mock_execute_sfa.call_args.args
+        call_kwargs = mock_execute_sfa.call_args.kwargs
+        self.assertIs(call_args[7], dcp_seq_lens)
+        self.assertIs(call_kwargs["block_table"], dcp_block_table)
+        self.assertEqual(call_kwargs["sparse_mode"], 0)
+        self.assertTrue(call_kwargs["return_lse"])
+        impl._merge_dcp_outputs.assert_called_once_with(sfa_output, softmax_lse)

--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -1515,11 +1515,14 @@ class TestAscendSFADCPImpl(TestBase):
             query_gather_context=MagicMock(),
         )
         sfa_output = torch.randn(2, 2, 8)
-        softmax_lse = torch.randn(2, 2, 1)
+        softmax_max = torch.randn(2, 2, 1)
+        softmax_sum = torch.randn(2, 2, 1)
+        softmax_lse = softmax_max + torch.log(softmax_sum)
+        softmax_lse = softmax_lse.permute(1, 0, 2).reshape(softmax_lse.shape[1], -1, 1)
 
         with patch(
             "vllm_ascend.attention.context_parallel.sfa_cp.DeviceOperator.execute_sparse_flash_attention_process",
-            return_value=(sfa_output, softmax_lse),
+            return_value=(sfa_output, softmax_max, softmax_sum),
         ) as mock_execute_sfa:
             result = impl._execute_sparse_flash_attention_process(
                 ql_nope,

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -1163,35 +1163,24 @@ class AscendSFADCPImpl(AscendSFAImpl):
             topk_indices = self.dcp_group.all_gather(topk_indices.contiguous(), dim=0)
         topk_indices = self._remap_sparse_indices(topk_indices)
         ql_nope, q_pe = self._finish_all_gather_query_for_dcp(query_gather_context)
-        kv = kv_cache[0]
-        key_rope = kv_cache[1]
-        sfa_output, softmax_max, softmax_sum = torch.ops._C_ascend.npu_sparse_flash_attention(
-            query=ql_nope,
-            key=kv,
-            value=kv,
-            sparse_indices=topk_indices,
-            scale_value=self.scale,
-            sparse_block_size=1,
-            block_table=attn_metadata.dcp_context.block_table,
-            actual_seq_lengths_query=actual_seq_lengths_query,
-            actual_seq_lengths_kv=attn_metadata.dcp_context.seq_lens,
-            query_rope=q_pe,
-            key_rope=key_rope,
-            layout_query="TND",
-            layout_kv="PA_BSND",
+        sfa_output, softmax_lse = DeviceOperator.execute_sparse_flash_attention_process(
+            self,
+            ql_nope,
+            q_pe,
+            kv_cache,
+            topk_indices,
+            attn_metadata,
+            actual_seq_lengths_query,
+            dcp_context.seq_lens,
+            block_table=dcp_context.block_table,
             # The replicated-view indexer already applies the causal visibility rule.
             # After DCP remaps topk indices to local KV positions, local KV
             # length no longer shares the same coordinate system as global
             # query length, so SFA must not apply its right-down causal crop.
             sparse_mode=0,
-            attention_mode=2,
-            return_softmax_lse=True,
+            return_lse=True,
         )
         output_dtype = sfa_output.dtype
-        # SFA returns softmax max/sum separately. Convert them to LSE so the
-        # existing CP merge helper can combine local-KV partial outputs.
-        softmax_lse = softmax_max.to(torch.float32) + torch.log(softmax_sum.to(torch.float32))
-        softmax_lse = softmax_lse.permute(1, 0, 2).reshape(softmax_lse.shape[1], -1, 1)
         if self.enable_dsa_cp:
             output = self._merge_dsa_cp_dcp_outputs(sfa_output, softmax_lse)
             assert attn_metadata.dsa_cp_context is not None, "DSA-CP DCP output selection requires dsa_cp_context."

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -1163,7 +1163,7 @@ class AscendSFADCPImpl(AscendSFAImpl):
             topk_indices = self.dcp_group.all_gather(topk_indices.contiguous(), dim=0)
         topk_indices = self._remap_sparse_indices(topk_indices)
         ql_nope, q_pe = self._finish_all_gather_query_for_dcp(query_gather_context)
-        sfa_output, softmax_lse = DeviceOperator.execute_sparse_flash_attention_process(
+        sfa_output, softmax_max, softmax_sum = DeviceOperator.execute_sparse_flash_attention_process(
             self,
             ql_nope,
             q_pe,
@@ -1180,6 +1180,8 @@ class AscendSFADCPImpl(AscendSFAImpl):
             sparse_mode=0,
             return_lse=True,
         )
+        softmax_lse = softmax_max + torch.log(softmax_sum)
+        softmax_lse = softmax_lse.permute(1, 0, 2).reshape(softmax_lse.shape[1], -1, 1)
         output_dtype = sfa_output.dtype
         if self.enable_dsa_cp:
             output = self._merge_dsa_cp_dcp_outputs(sfa_output, softmax_lse)

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -508,7 +508,7 @@ class BaseDeviceAdaptor:
         block_table: torch.Tensor | None = None,
         sparse_mode: int = 3,
         return_lse: bool = False,
-    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if block_table is None:
             block_table = attn_metadata.block_table
         kv = kv_cache[0]
@@ -555,17 +555,7 @@ class BaseDeviceAdaptor:
             attention_mode=2,
             return_softmax_lse=return_lse,
         )
-        if not isinstance(result, tuple):
-            if return_lse:
-                raise RuntimeError("Sparse flash attention did not return softmax max/sum for DCP LSE merge.")
-            return result
-        attn_output, softmax_max, softmax_sum = result
-        return BaseDeviceAdaptor._format_sparse_flash_attention_output(
-            attn_output,
-            softmax_max,
-            softmax_sum,
-            return_lse,
-        )
+        return BaseDeviceAdaptor._format_sparse_flash_attention_output(result, return_lse)
 
     @staticmethod
     def execute_kv_quant_sparse_flash_attention(
@@ -580,64 +570,44 @@ class BaseDeviceAdaptor:
         *,
         sparse_mode: int = 3,
         return_lse: bool = False,
-    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         query = torch.cat([ql_nope, q_pe], dim=-1).contiguous()
-        common_kwargs = {
-            "query": query,
-            "key": kv,
-            "value": kv,
-            "sparse_indices": topk_indices,
-            "scale_value": sfa_impl.scale,
-            "sparse_block_size": 1,
-            "block_table": block_table,
-            "actual_seq_lengths_query": actual_seq_lengths_query,
-            "actual_seq_lengths_kv": actual_seq_lengths_key,
-            "layout_query": "TND",
-            "layout_kv": "PA_BSND",
-            "sparse_mode": sparse_mode,
-            "attention_mode": 2,
-            "quant_scale_repo_mode": 1,
-            "tile_size": getattr(sfa_impl, "sfa_qsfa_tile_size", 128),
-            "key_quant_mode": 2,
-            "value_quant_mode": 2,
-            "rope_head_dim": getattr(sfa_impl, "qk_rope_head_dim", q_pe.shape[-1]),
-        }
-        if return_lse:
-            # The torch_npu C8 SFA binding used by current images only returns
-            # attention_out and rejects return_softmax_lse.  DCP needs the
-            # softmax max/sum tensors to build LSE, so use the vllm-ascend
-            # custom op added with LSE-capable C8 SFA only on that path.
-            result = torch.ops._C_ascend.npu_kv_quant_sparse_flash_attention(
-                **common_kwargs,
-                return_softmax_lse=True,
-            )
-        else:
-            result = torch_npu.npu_kv_quant_sparse_flash_attention(**common_kwargs)
-        if not isinstance(result, tuple):
-            if return_lse:
-                raise RuntimeError("C8 sparse flash attention did not return softmax max/sum for DCP LSE merge.")
-            return result
-        attn_output, softmax_max, softmax_sum = result
-        return BaseDeviceAdaptor._format_sparse_flash_attention_output(
-            attn_output,
-            softmax_max,
-            softmax_sum,
-            return_lse,
+        result = torch.ops._C_ascend.npu_kv_quant_sparse_flash_attention(
+            query=query,
+            key=kv,
+            value=kv,
+            sparse_indices=topk_indices,
+            scale_value=sfa_impl.scale,
+            sparse_block_size=1,
+            block_table=block_table,
+            actual_seq_lengths_query=actual_seq_lengths_query,
+            actual_seq_lengths_kv=actual_seq_lengths_key,
+            layout_query="TND",
+            layout_kv="PA_BSND",
+            sparse_mode=sparse_mode,
+            attention_mode=2,
+            quant_scale_repo_mode=1,
+            tile_size=getattr(sfa_impl, "sfa_qsfa_tile_size", 128),
+            key_quant_mode=2,
+            value_quant_mode=2,
+            rope_head_dim=getattr(sfa_impl, "qk_rope_head_dim", q_pe.shape[-1]),
+            return_softmax_lse=True,
         )
+        return BaseDeviceAdaptor._format_sparse_flash_attention_output(result, return_lse)
 
     @staticmethod
     def _format_sparse_flash_attention_output(
-        attn_output: torch.Tensor,
-        softmax_max: torch.Tensor,
-        softmax_sum: torch.Tensor,
+        result: torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor],
         return_lse: bool,
-    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        if not return_lse:
-            return attn_output
-
-        softmax_lse = softmax_max.to(torch.float32) + torch.log(softmax_sum.to(torch.float32))
-        softmax_lse = softmax_lse.permute(1, 0, 2).reshape(softmax_lse.shape[1], -1, 1)
-        return attn_output, softmax_lse
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if not isinstance(result, tuple):
+            if return_lse:
+                raise RuntimeError("Sparse flash attention did not return softmax max/sum for DCP LSE merge.")
+            return result
+        if return_lse:
+            return result
+        else:
+            return result[0]
 
     @staticmethod
     def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -556,7 +556,14 @@ class BaseDeviceAdaptor:
                 attention_mode=2,
                 return_softmax_lse=return_lse,
             )
-        return BaseDeviceAdaptor._format_sparse_flash_attention_output(result, return_lse)
+        if not isinstance(result, tuple):
+            if return_lse:
+                raise RuntimeError("Sparse flash attention did not return softmax max/sum for DCP LSE merge.")
+            return result
+        if return_lse:
+            return result
+        else:
+            return result[0]
 
     @staticmethod
     def _execute_kv_quant_sparse_flash_attention(
@@ -594,20 +601,6 @@ class BaseDeviceAdaptor:
             rope_head_dim=getattr(sfa_impl, "qk_rope_head_dim", q_pe.shape[-1]),
             return_softmax_lse=return_lse,
         )
-
-    @staticmethod
-    def _format_sparse_flash_attention_output(
-        result: torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor],
-        return_lse: bool,
-    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        if not isinstance(result, tuple):
-            if return_lse:
-                raise RuntimeError("Sparse flash attention did not return softmax max/sum for DCP LSE merge.")
-            return result
-        if return_lse:
-            return result
-        else:
-            return result[0]
 
     @staticmethod
     def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -504,8 +504,13 @@ class BaseDeviceAdaptor:
         attn_metadata,
         actual_seq_lengths_query: torch.Tensor,
         actual_seq_lengths_key: torch.Tensor,
-    ) -> torch.Tensor:
-        block_table = attn_metadata.block_table
+        *,
+        block_table: torch.Tensor | None = None,
+        sparse_mode: int = 3,
+        return_lse: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if block_table is None:
+            block_table = attn_metadata.block_table
         kv = kv_cache[0]
 
         # The kv-quant sparse attention op only accepts packed quantized KV.
@@ -527,10 +532,12 @@ class BaseDeviceAdaptor:
                 topk_indices,
                 actual_seq_lengths_query,
                 actual_seq_lengths_key,
+                sparse_mode=sparse_mode,
+                return_lse=return_lse,
             )
 
         key_rope = kv_cache[1]
-        attn_output, _, _ = torch.ops._C_ascend.npu_sparse_flash_attention(
+        result = torch.ops._C_ascend.npu_sparse_flash_attention(
             query=ql_nope,
             key=kv,
             value=kv,
@@ -544,10 +551,21 @@ class BaseDeviceAdaptor:
             key_rope=key_rope,
             layout_query="TND",
             layout_kv="PA_BSND",
-            sparse_mode=3,
+            sparse_mode=sparse_mode,
             attention_mode=2,
+            return_softmax_lse=return_lse,
         )
-        return attn_output
+        if not isinstance(result, tuple):
+            if return_lse:
+                raise RuntimeError("Sparse flash attention did not return softmax max/sum for DCP LSE merge.")
+            return result
+        attn_output, softmax_max, softmax_sum = result
+        return BaseDeviceAdaptor._format_sparse_flash_attention_output(
+            attn_output,
+            softmax_max,
+            softmax_sum,
+            return_lse,
+        )
 
     @staticmethod
     def execute_kv_quant_sparse_flash_attention(
@@ -559,9 +577,12 @@ class BaseDeviceAdaptor:
         topk_indices: torch.Tensor,
         actual_seq_lengths_query: torch.Tensor,
         actual_seq_lengths_key: torch.Tensor,
-    ) -> torch.Tensor:
+        *,
+        sparse_mode: int = 3,
+        return_lse: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         query = torch.cat([ql_nope, q_pe], dim=-1).contiguous()
-        return torch_npu.npu_kv_quant_sparse_flash_attention(
+        result = torch_npu.npu_kv_quant_sparse_flash_attention(
             query=query,
             key=kv,
             value=kv,
@@ -573,14 +594,40 @@ class BaseDeviceAdaptor:
             actual_seq_lengths_kv=actual_seq_lengths_key,
             layout_query="TND",
             layout_kv="PA_BSND",
-            sparse_mode=3,
+            sparse_mode=sparse_mode,
             attention_mode=2,
             quant_scale_repo_mode=1,
             tile_size=getattr(sfa_impl, "sfa_qsfa_tile_size", 128),
             key_quant_mode=2,
             value_quant_mode=2,
-            rope_head_dim=getattr(sfa_impl, "qk_rope_head_dim", 64),
+            rope_head_dim=getattr(sfa_impl, "qk_rope_head_dim", q_pe.shape[-1]),
+            return_softmax_lse=return_lse,
         )
+        if not isinstance(result, tuple):
+            if return_lse:
+                raise RuntimeError("C8 sparse flash attention did not return softmax max/sum for DCP LSE merge.")
+            return result
+        attn_output, softmax_max, softmax_sum = result
+        return BaseDeviceAdaptor._format_sparse_flash_attention_output(
+            attn_output,
+            softmax_max,
+            softmax_sum,
+            return_lse,
+        )
+
+    @staticmethod
+    def _format_sparse_flash_attention_output(
+        attn_output: torch.Tensor,
+        softmax_max: torch.Tensor,
+        softmax_sum: torch.Tensor,
+        return_lse: bool,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if not return_lse:
+            return attn_output
+
+        softmax_lse = softmax_max.to(torch.float32) + torch.log(softmax_sum.to(torch.float32))
+        softmax_lse = softmax_lse.permute(1, 0, 2).reshape(softmax_lse.shape[1], -1, 1)
+        return attn_output, softmax_lse
 
     @staticmethod
     def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -494,8 +494,9 @@ class BaseDeviceAdaptor:
             )
         return topk_indices
 
-    @staticmethod
+    @classmethod
     def execute_sparse_flash_attention_process(
+        cls,
         sfa_impl,
         ql_nope: torch.Tensor,
         q_pe: torch.Tensor,
@@ -523,7 +524,7 @@ class BaseDeviceAdaptor:
             torch.float8_e5m2,
         )
         if use_kv_quant_sparse_attention:
-            return BaseDeviceAdaptor.execute_kv_quant_sparse_flash_attention(
+            result = cls._execute_kv_quant_sparse_flash_attention(
                 sfa_impl,
                 ql_nope,
                 q_pe,
@@ -535,30 +536,30 @@ class BaseDeviceAdaptor:
                 sparse_mode=sparse_mode,
                 return_lse=return_lse,
             )
-
-        key_rope = kv_cache[1]
-        result = torch.ops._C_ascend.npu_sparse_flash_attention(
-            query=ql_nope,
-            key=kv,
-            value=kv,
-            sparse_indices=topk_indices,
-            scale_value=sfa_impl.scale,
-            sparse_block_size=1,
-            block_table=block_table,
-            actual_seq_lengths_query=actual_seq_lengths_query,
-            actual_seq_lengths_kv=actual_seq_lengths_key,
-            query_rope=q_pe,
-            key_rope=key_rope,
-            layout_query="TND",
-            layout_kv="PA_BSND",
-            sparse_mode=sparse_mode,
-            attention_mode=2,
-            return_softmax_lse=return_lse,
-        )
+        else:
+            key_rope = kv_cache[1]
+            result = torch.ops._C_ascend.npu_sparse_flash_attention(
+                query=ql_nope,
+                key=kv,
+                value=kv,
+                sparse_indices=topk_indices,
+                scale_value=sfa_impl.scale,
+                sparse_block_size=1,
+                block_table=block_table,
+                actual_seq_lengths_query=actual_seq_lengths_query,
+                actual_seq_lengths_kv=actual_seq_lengths_key,
+                query_rope=q_pe,
+                key_rope=key_rope,
+                layout_query="TND",
+                layout_kv="PA_BSND",
+                sparse_mode=sparse_mode,
+                attention_mode=2,
+                return_softmax_lse=return_lse,
+            )
         return BaseDeviceAdaptor._format_sparse_flash_attention_output(result, return_lse)
 
     @staticmethod
-    def execute_kv_quant_sparse_flash_attention(
+    def _execute_kv_quant_sparse_flash_attention(
         sfa_impl,
         ql_nope: torch.Tensor,
         q_pe: torch.Tensor,
@@ -572,7 +573,7 @@ class BaseDeviceAdaptor:
         return_lse: bool = False,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         query = torch.cat([ql_nope, q_pe], dim=-1).contiguous()
-        result = torch.ops._C_ascend.npu_kv_quant_sparse_flash_attention(
+        return torch.ops._C_ascend.npu_kv_quant_sparse_flash_attention(
             query=query,
             key=kv,
             value=kv,
@@ -591,9 +592,8 @@ class BaseDeviceAdaptor:
             key_quant_mode=2,
             value_quant_mode=2,
             rope_head_dim=getattr(sfa_impl, "qk_rope_head_dim", q_pe.shape[-1]),
-            return_softmax_lse=True,
+            return_softmax_lse=return_lse,
         )
-        return BaseDeviceAdaptor._format_sparse_flash_attention_output(result, return_lse)
 
     @staticmethod
     def _format_sparse_flash_attention_output(
@@ -974,6 +974,48 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             scale=scale,
             **kwargs,
         )
+
+    @staticmethod
+    def _execute_kv_quant_sparse_flash_attention(
+        sfa_impl,
+        ql_nope: torch.Tensor,
+        q_pe: torch.Tensor,
+        kv: torch.Tensor,
+        block_table: torch.Tensor,
+        topk_indices: torch.Tensor,
+        actual_seq_lengths_query: torch.Tensor,
+        actual_seq_lengths_key: torch.Tensor,
+        *,
+        sparse_mode: int = 3,
+        return_lse: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        query = torch.cat([ql_nope, q_pe], dim=-1).contiguous()
+        result = torch_npu.npu_kv_quant_sparse_flash_attention(
+            query=query,
+            key=kv,
+            value=kv,
+            sparse_indices=topk_indices,
+            scale_value=sfa_impl.scale,
+            sparse_block_size=1,
+            block_table=block_table,
+            actual_seq_lengths_query=actual_seq_lengths_query,
+            actual_seq_lengths_kv=actual_seq_lengths_key,
+            layout_query="TND",
+            layout_kv="PA_BSND",
+            sparse_mode=sparse_mode,
+            attention_mode=2,
+            quant_scale_repo_mode=1,
+            tile_size=getattr(sfa_impl, "sfa_qsfa_tile_size", 128),
+            key_quant_mode=2,
+            value_quant_mode=2,
+            rope_head_dim=getattr(sfa_impl, "qk_rope_head_dim", q_pe.shape[-1]),
+        )
+        if return_lse:
+            raise RuntimeError(
+                "C8 sparse flash attention via torch_npu only returns attention_out; "
+                "cannot return softmax max/sum for DCP LSE merge."
+            )
+        return result
 
     @staticmethod
     def npu_moe_init_routing(

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -582,27 +582,37 @@ class BaseDeviceAdaptor:
         return_lse: bool = False,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         query = torch.cat([ql_nope, q_pe], dim=-1).contiguous()
-        result = torch_npu.npu_kv_quant_sparse_flash_attention(
-            query=query,
-            key=kv,
-            value=kv,
-            sparse_indices=topk_indices,
-            scale_value=sfa_impl.scale,
-            sparse_block_size=1,
-            block_table=block_table,
-            actual_seq_lengths_query=actual_seq_lengths_query,
-            actual_seq_lengths_kv=actual_seq_lengths_key,
-            layout_query="TND",
-            layout_kv="PA_BSND",
-            sparse_mode=sparse_mode,
-            attention_mode=2,
-            quant_scale_repo_mode=1,
-            tile_size=getattr(sfa_impl, "sfa_qsfa_tile_size", 128),
-            key_quant_mode=2,
-            value_quant_mode=2,
-            rope_head_dim=getattr(sfa_impl, "qk_rope_head_dim", q_pe.shape[-1]),
-            return_softmax_lse=return_lse,
-        )
+        common_kwargs = {
+            "query": query,
+            "key": kv,
+            "value": kv,
+            "sparse_indices": topk_indices,
+            "scale_value": sfa_impl.scale,
+            "sparse_block_size": 1,
+            "block_table": block_table,
+            "actual_seq_lengths_query": actual_seq_lengths_query,
+            "actual_seq_lengths_kv": actual_seq_lengths_key,
+            "layout_query": "TND",
+            "layout_kv": "PA_BSND",
+            "sparse_mode": sparse_mode,
+            "attention_mode": 2,
+            "quant_scale_repo_mode": 1,
+            "tile_size": getattr(sfa_impl, "sfa_qsfa_tile_size", 128),
+            "key_quant_mode": 2,
+            "value_quant_mode": 2,
+            "rope_head_dim": getattr(sfa_impl, "qk_rope_head_dim", q_pe.shape[-1]),
+        }
+        if return_lse:
+            # The torch_npu C8 SFA binding used by current images only returns
+            # attention_out and rejects return_softmax_lse.  DCP needs the
+            # softmax max/sum tensors to build LSE, so use the vllm-ascend
+            # custom op added with LSE-capable C8 SFA only on that path.
+            result = torch.ops._C_ascend.npu_kv_quant_sparse_flash_attention(
+                **common_kwargs,
+                return_softmax_lse=True,
+            )
+        else:
+            result = torch_npu.npu_kv_quant_sparse_flash_attention(**common_kwargs)
         if not isinstance(result, tuple):
             if return_lse:
                 raise RuntimeError("C8 sparse flash attention did not return softmax max/sum for DCP LSE merge.")


### PR DESCRIPTION
## Summary

- Route SFA DCP through `DeviceOperator.execute_sparse_flash_attention_process(..., return_lse=True)` so DCP output merging can consume LSE from both regular SFA and C8 SFA.
- Add the C8 SFA LSE path in `DeviceOperator`; when LSE is required, use the vllm-ascend custom C8 SFA op because the current `torch_npu` binding only returns attention output and rejects `return_softmax_lse`.
- Cover DCP replicated-indexer + C8 in UT/PR accuracy config, while keeping nightly DCP replicated-indexer C8 enabled.

## Validation

- `ruff check --output-format github --fix` and `ruff format` on changed Python test files: no-op after formatting fix.
- Remote GSM8K accuracy on GLM-5.2 W4A8C8 with DCP replicated indexer + C8:
  - samples: 1319
  - correct: 1255
  - accuracy: 95.1478%
  - errors: 0
  - max_tokens: 4096
  - concurrency/request_rate: 64/64
  - summary: `/vllm-workspace/scripts/pcpqcs/gsm8k_eval_4k_c64_gmu090/summary_20260712_001741.json`

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
