### PR TITLE
[v0.23.0][Feature][SFA] Support C8 SFA with DCP replicated indexer

### DIFF
--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
@@ -395,7 +395,7 @@ FULL_FEATURE_MODEL_CASES = [
             "compilation_config": FULL_DECODE_GRAPH,
             "additional_config": {
                 "enable_flashcomm1": True,
-                "enable_sparse_c8": False,
+                "enable_sparse_c8": True,
             },
             "speculative_config": {
                 "method": "mtp",

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
@@ -101,7 +101,7 @@ DSV3_2_GOLDEN_BACKUPS = (
 )
 
 DSV3_2_DCP_GOLDEN = [
-    "The capital of France isoint054 Rund959arki",
+    "The capital of France isoint054 Rund compasses",
     "Hello, my name is Tom, I am" + "ERIC slicpacelikeabra",
     "The president of United States isoint054 Rund959arki",
 ]

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
@@ -102,7 +102,7 @@ DSV3_2_GOLDEN_BACKUPS = (
 
 DSV3_2_DCP_GOLDEN = [
     "The capital of France isoint054 Rund compasses",
-    "Hello, my name is Tom, I am" + "ERIC slicpacelikeabra",
+    "Hello, my name is Tom, I am" + "ERIC slicpacelike挂",
     "The president of United States isoint054 Rund959arki",
 ]
 

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -155,11 +155,16 @@ class TestAscendSFADeviceOperator(TestBase):
         softmax_max = torch.ones(1, 3, 4)
         softmax_sum = torch.full((1, 3, 4), 3.0)
 
-        with patch(
-            "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
+        with patch.object(
+            torch.ops._C_ascend,
+            "npu_kv_quant_sparse_flash_attention",
             create=True,
             return_value=(attn_output, softmax_max, softmax_sum),
-        ) as mock_qsfa:
+        ) as mock_qsfa, patch(
+            "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
+            create=True,
+            side_effect=AssertionError("C8 SFA with LSE must use the custom op"),
+        ):
             output, softmax_lse = DeviceOperator.execute_sparse_flash_attention_process(
                 impl,
                 ql_nope,
@@ -252,6 +257,7 @@ class TestAscendSFAKVQuantSparseAttention(TestBase):
         self.assertEqual(call_kwargs["query"].shape, (3, 2, 48))
         self.assertEqual(call_kwargs["key_quant_mode"], 2)
         self.assertEqual(call_kwargs["tile_size"], 128)
+        self.assertNotIn("return_softmax_lse", call_kwargs)
 
     def test_prolog_v3_enables_packed_int8_kv_cache(self):
         impl = AscendSFAImpl.__new__(AscendSFAImpl)

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -155,15 +155,18 @@ class TestAscendSFADeviceOperator(TestBase):
         softmax_max = torch.ones(1, 3, 4)
         softmax_sum = torch.full((1, 3, 4), 3.0)
 
-        with patch.object(
-            torch.ops._C_ascend,
-            "npu_kv_quant_sparse_flash_attention",
-            create=True,
-            return_value=(attn_output, softmax_max, softmax_sum),
-        ) as mock_qsfa, patch(
-            "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
-            create=True,
-            side_effect=AssertionError("C8 SFA with LSE must use the custom op"),
+        with (
+            patch.object(
+                torch.ops._C_ascend,
+                "npu_kv_quant_sparse_flash_attention",
+                create=True,
+                return_value=(attn_output, softmax_max, softmax_sum),
+            ) as mock_qsfa,
+            patch(
+                "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
+                create=True,
+                side_effect=AssertionError("C8 SFA with LSE must use the custom op"),
+            ),
         ):
             output, softmax_lse = DeviceOperator.execute_sparse_flash_attention_process(
                 impl,

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -22,6 +22,7 @@ from vllm_ascend.attention.sfa_v1 import (
     custom_kv_rmsnorm_rope,
 )
 from vllm_ascend.attention.utils import get_sfa_qsfa_packed_head_dim
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.utils import enable_dsa_cp
 
 
@@ -72,6 +73,115 @@ class TestAscendSFABackend(TestBase):
         mock_enable_cp.return_value = True
         impl_cls = AscendSFABackend.get_impl_cls()
         self.assertIsNotNone(impl_cls)
+
+
+class TestAscendSFADeviceOperator(TestBase):
+    def _make_common_inputs(self):
+        ql_nope = torch.randn(3, 4, 8)
+        q_pe = torch.randn(3, 4, 2)
+        topk_indices = torch.zeros(3, 1, dtype=torch.int32)
+        attn_metadata = MagicMock()
+        attn_metadata.block_table = torch.zeros(1, 4, dtype=torch.int32)
+        actual_seq_lengths_query = torch.tensor([3], dtype=torch.int32)
+        actual_seq_lengths_key = torch.tensor([3], dtype=torch.int32)
+        impl = MagicMock()
+        impl.scale = 0.125
+        impl.qk_rope_head_dim = 2
+        impl.sfa_qsfa_tile_size = 128
+        return (
+            impl,
+            ql_nope,
+            q_pe,
+            topk_indices,
+            attn_metadata,
+            actual_seq_lengths_query,
+            actual_seq_lengths_key,
+        )
+
+    def test_execute_sparse_flash_attention_returns_lse(self):
+        (
+            impl,
+            ql_nope,
+            q_pe,
+            topk_indices,
+            attn_metadata,
+            actual_seq_lengths_query,
+            actual_seq_lengths_key,
+        ) = self._make_common_inputs()
+        kv_cache = (
+            torch.randn(4, 1, 1, 8),
+            torch.randn(4, 1, 1, 2),
+        )
+        attn_output = torch.randn(3, 4, 8)
+        softmax_max = torch.zeros(1, 3, 4)
+        softmax_sum = torch.full((1, 3, 4), 2.0)
+
+        with patch.object(
+            torch.ops._C_ascend,
+            "npu_sparse_flash_attention",
+            create=True,
+            return_value=(attn_output, softmax_max, softmax_sum),
+        ) as mock_sfa:
+            output, softmax_lse = DeviceOperator.execute_sparse_flash_attention_process(
+                impl,
+                ql_nope,
+                q_pe,
+                kv_cache,
+                topk_indices,
+                attn_metadata,
+                actual_seq_lengths_query,
+                actual_seq_lengths_key,
+                return_lse=True,
+            )
+
+        self.assertIs(output, attn_output)
+        self.assertEqual(softmax_lse.shape, (3, 4, 1))
+        expected_lse = torch.full((3, 4, 1), torch.log(torch.tensor(2.0)).item())
+        self.assertTrue(torch.allclose(softmax_lse, expected_lse))
+        self.assertTrue(mock_sfa.call_args.kwargs["return_softmax_lse"])
+
+    def test_execute_sparse_flash_attention_c8_returns_lse(self):
+        (
+            impl,
+            ql_nope,
+            q_pe,
+            topk_indices,
+            attn_metadata,
+            actual_seq_lengths_query,
+            actual_seq_lengths_key,
+        ) = self._make_common_inputs()
+        packed_kv_cache = (torch.empty(4, 1, 1, 12, dtype=torch.int8),)
+        attn_output = torch.randn(3, 4, 8)
+        softmax_max = torch.ones(1, 3, 4)
+        softmax_sum = torch.full((1, 3, 4), 3.0)
+
+        with patch(
+            "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
+            create=True,
+            return_value=(attn_output, softmax_max, softmax_sum),
+        ) as mock_qsfa:
+            output, softmax_lse = DeviceOperator.execute_sparse_flash_attention_process(
+                impl,
+                ql_nope,
+                q_pe,
+                packed_kv_cache,
+                topk_indices,
+                attn_metadata,
+                actual_seq_lengths_query,
+                actual_seq_lengths_key,
+                sparse_mode=0,
+                return_lse=True,
+            )
+
+        self.assertIs(output, attn_output)
+        expected_lse = torch.full((3, 4, 1), 1.0 + torch.log(torch.tensor(3.0)).item())
+        self.assertTrue(torch.allclose(softmax_lse, expected_lse))
+        call_kwargs = mock_qsfa.call_args.kwargs
+        self.assertIs(call_kwargs["key"], packed_kv_cache[0])
+        self.assertIs(call_kwargs["value"], packed_kv_cache[0])
+        self.assertEqual(call_kwargs["query"].shape, (3, 4, 10))
+        self.assertEqual(call_kwargs["sparse_mode"], 0)
+        self.assertTrue(call_kwargs["return_softmax_lse"])
 
 
 class TestAscendSFAKVQuantSparseAttention(TestBase):

--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -1096,7 +1096,6 @@ class TestAscendSFACPImpl(TestBase):
         self.assertIsNotNone(result)
         self.assertEqual(result.shape[0], 5)
 
-
     @patch_distributed_groups(dcp_size=1, pcp_size=1, needs_mocks=False)
     def test_execute_sparse_flash_attention_process_decode_and_prefill_no_pcp(self):
         self.impl.pcp_size = 1
@@ -1489,11 +1488,14 @@ class TestAscendSFACPImpl(TestBase):
 
 
 class TestAscendSFADCPImpl(TestBase):
-    def test_execute_sparse_flash_attention_process_uses_device_operator_lse(self):
+    def test_execute_sparse_flash_attention_process_uses_c8_device_operator_lse(self):
         impl = AscendSFADCPImpl.__new__(AscendSFADCPImpl)
         impl.dcp_group = MagicMock()
         impl.dcp_size = 2
         impl.enable_dsa_cp = False
+        impl.use_sparse_c8_sfa = True
+        impl.qk_rope_head_dim = 4
+        impl.sfa_qsfa_tile_size = 128
         impl._remap_sparse_indices = MagicMock(side_effect=lambda x: x)
         merged_output = torch.randn(2, 2, 8)
         impl._merge_dcp_outputs = MagicMock(return_value=merged_output)
@@ -1501,10 +1503,7 @@ class TestAscendSFADCPImpl(TestBase):
         ql_nope = torch.randn(2, 2, 8)
         q_pe = torch.randn(2, 2, 4)
         impl._finish_all_gather_query_for_dcp = MagicMock(side_effect=lambda _ctx: (ql_nope, q_pe))
-        kv_cache = (
-            torch.randn(4, 1, 1, 8),
-            torch.randn(4, 1, 1, 4),
-        )
+        kv_cache = (torch.empty(4, 1, 1, 16, dtype=torch.int8),)
         topk_indices = torch.zeros(2, 1, dtype=torch.int32)
         actual_seq_lengths_query = torch.tensor([2], dtype=torch.int32)
         actual_seq_lengths_key = torch.tensor([4], dtype=torch.int32)
@@ -1538,6 +1537,9 @@ class TestAscendSFADCPImpl(TestBase):
         self.assertIs(result, merged_output)
         call_args = mock_execute_sfa.call_args.args
         call_kwargs = mock_execute_sfa.call_args.kwargs
+        self.assertTrue(call_args[0].use_sparse_c8_sfa)
+        self.assertEqual(len(call_args[3]), 1)
+        self.assertEqual(call_args[3][0].dtype, torch.int8)
         self.assertIs(call_args[7], dcp_seq_lens)
         self.assertIs(call_kwargs["block_table"], dcp_block_table)
         self.assertEqual(call_kwargs["sparse_mode"], 0)

--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -27,8 +27,12 @@ if "torch_npu._inductor" not in sys.modules:
     sys.modules["torch_npu._inductor"] = MagicMock()
 
 from vllm_ascend.attention.context_parallel.common_cp import AscendPCPMetadata
-from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFACPImpl, AscendSFACPMetadataBuilder
-from vllm_ascend.attention.sfa_v1 import AscendSFAImpl, AscendSFAMetadata
+from vllm_ascend.attention.context_parallel.sfa_cp import (
+    AscendSFACPImpl,
+    AscendSFACPMetadataBuilder,
+    AscendSFADCPImpl,
+)
+from vllm_ascend.attention.sfa_v1 import AscendSFAImpl, AscendSFAMetadata, DCPContext
 
 
 def _make_indexer_mock():
@@ -1092,6 +1096,7 @@ class TestAscendSFACPImpl(TestBase):
         self.assertIsNotNone(result)
         self.assertEqual(result.shape[0], 5)
 
+
     @patch_distributed_groups(dcp_size=1, pcp_size=1, needs_mocks=False)
     def test_execute_sparse_flash_attention_process_decode_and_prefill_no_pcp(self):
         self.impl.pcp_size = 1
@@ -1481,3 +1486,60 @@ class TestAscendSFACPImpl(TestBase):
             )
         self.assertIsNotNone(result)
         self.assertEqual(result.shape[0], 5)
+
+
+class TestAscendSFADCPImpl(TestBase):
+    def test_execute_sparse_flash_attention_process_uses_device_operator_lse(self):
+        impl = AscendSFADCPImpl.__new__(AscendSFADCPImpl)
+        impl.dcp_group = MagicMock()
+        impl.dcp_size = 2
+        impl.enable_dsa_cp = False
+        impl._remap_sparse_indices = MagicMock(side_effect=lambda x: x)
+        merged_output = torch.randn(2, 2, 8)
+        impl._merge_dcp_outputs = MagicMock(return_value=merged_output)
+
+        ql_nope = torch.randn(2, 2, 8)
+        q_pe = torch.randn(2, 2, 4)
+        impl._finish_all_gather_query_for_dcp = MagicMock(side_effect=lambda _ctx: (ql_nope, q_pe))
+        kv_cache = (
+            torch.randn(4, 1, 1, 8),
+            torch.randn(4, 1, 1, 4),
+        )
+        topk_indices = torch.zeros(2, 1, dtype=torch.int32)
+        actual_seq_lengths_query = torch.tensor([2], dtype=torch.int32)
+        actual_seq_lengths_key = torch.tensor([4], dtype=torch.int32)
+        dcp_seq_lens = torch.tensor([3], dtype=torch.int32)
+        dcp_block_table = torch.tensor([[0, 1]], dtype=torch.int32)
+
+        attn_metadata = MagicMock()
+        attn_metadata.dcp_context = DCPContext(
+            slot_mapping=torch.tensor([0, 1], dtype=torch.int32),
+            block_table=dcp_block_table,
+            seq_lens=dcp_seq_lens,
+            query_gather_context=MagicMock(),
+        )
+        sfa_output = torch.randn(2, 2, 8)
+        softmax_lse = torch.randn(2, 2, 1)
+
+        with patch(
+            "vllm_ascend.attention.context_parallel.sfa_cp.DeviceOperator.execute_sparse_flash_attention_process",
+            return_value=(sfa_output, softmax_lse),
+        ) as mock_execute_sfa:
+            result = impl._execute_sparse_flash_attention_process(
+                ql_nope,
+                q_pe,
+                kv_cache,
+                topk_indices,
+                attn_metadata,
+                actual_seq_lengths_query,
+                actual_seq_lengths_key,
+            )
+
+        self.assertIs(result, merged_output)
+        call_args = mock_execute_sfa.call_args.args
+        call_kwargs = mock_execute_sfa.call_args.kwargs
+        self.assertIs(call_args[7], dcp_seq_lens)
+        self.assertIs(call_kwargs["block_table"], dcp_block_table)
+        self.assertEqual(call_kwargs["sparse_mode"], 0)
+        self.assertTrue(call_kwargs["return_lse"])
+        impl._merge_dcp_outputs.assert_called_once_with(sfa_output, softmax_lse)

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -7,6 +7,7 @@ import torch
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheGroupSpec, KVCacheTensor
 
+from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
 
@@ -137,6 +138,56 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
 
         self.assertEqual(raw_k_cache.numel(), 2 * 16 * 512 * 2)
         self.assertEqual(raw_v_cache.numel(), 2 * 16 * 64 * 2)
+
+    def test_sparse_c8_replicated_indexer_allocation_matches_page_size(self):
+        runner = self._build_runner()
+        runner.use_sparse = True
+        runner.use_sparse_c8 = True
+        runner.c8_k_cache_dtype = torch.int8
+        runner.c8_k_scale_cache_dtype = torch.float16
+        runner.model_config.hf_text_config = SimpleNamespace(index_head_dim=128)
+
+        layer_name = "model.layers.0.self_attn.attn"
+        num_blocks = 2
+        dcp_size = 2
+        spec = AscendMLAAttentionSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=704,
+            sparse_head_dim=(576, 0, 128),
+            dtype=torch.bfloat16,
+            cache_dtype_str="auto",
+            cache_sparse_c8=True,
+            c8_k_cache_dtype=torch.int8,
+            c8_k_scale_cache_dtype=torch.float16,
+            sfa_dcp_replicated_indexer_size=dcp_size,
+        )
+        kv_cache_config = KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=spec.page_size_bytes * num_blocks,
+                    shared_by=[layer_name],
+                )
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=[layer_name],
+                    kv_cache_spec=spec,
+                )
+            ],
+        )
+
+        raw_caches = runner._allocate_kv_cache_tensors(kv_cache_config)
+        raw_k_cache, raw_indexer_cache, raw_indexer_scale_cache = raw_caches[layer_name]
+
+        self.assertEqual(raw_k_cache.numel(), num_blocks * 16 * 576)
+        self.assertEqual(raw_indexer_cache.numel(), num_blocks * dcp_size * 16 * 128)
+        self.assertEqual(raw_indexer_scale_cache.numel(), num_blocks * dcp_size * 16 * 2)
+        self.assertEqual(
+            raw_k_cache.numel() + raw_indexer_cache.numel() + raw_indexer_scale_cache.numel(),
+            spec.page_size_bytes * num_blocks,
+        )
 
 
 class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -1163,35 +1163,24 @@ class AscendSFADCPImpl(AscendSFAImpl):
             topk_indices = self.dcp_group.all_gather(topk_indices.contiguous(), dim=0)
         topk_indices = self._remap_sparse_indices(topk_indices)
         ql_nope, q_pe = self._finish_all_gather_query_for_dcp(query_gather_context)
-        kv = kv_cache[0]
-        key_rope = kv_cache[1]
-        sfa_output, softmax_max, softmax_sum = torch.ops._C_ascend.npu_sparse_flash_attention(
-            query=ql_nope,
-            key=kv,
-            value=kv,
-            sparse_indices=topk_indices,
-            scale_value=self.scale,
-            sparse_block_size=1,
-            block_table=attn_metadata.dcp_context.block_table,
-            actual_seq_lengths_query=actual_seq_lengths_query,
-            actual_seq_lengths_kv=attn_metadata.dcp_context.seq_lens,
-            query_rope=q_pe,
-            key_rope=key_rope,
-            layout_query="TND",
-            layout_kv="PA_BSND",
+        sfa_output, softmax_lse = DeviceOperator.execute_sparse_flash_attention_process(
+            self,
+            ql_nope,
+            q_pe,
+            kv_cache,
+            topk_indices,
+            attn_metadata,
+            actual_seq_lengths_query,
+            dcp_context.seq_lens,
+            block_table=dcp_context.block_table,
             # The replicated-view indexer already applies the causal visibility rule.
             # After DCP remaps topk indices to local KV positions, local KV
             # length no longer shares the same coordinate system as global
             # query length, so SFA must not apply its right-down causal crop.
             sparse_mode=0,
-            attention_mode=2,
-            return_softmax_lse=True,
+            return_lse=True,
         )
         output_dtype = sfa_output.dtype
-        # SFA returns softmax max/sum separately. Convert them to LSE so the
-        # existing CP merge helper can combine local-KV partial outputs.
-        softmax_lse = softmax_max.to(torch.float32) + torch.log(softmax_sum.to(torch.float32))
-        softmax_lse = softmax_lse.permute(1, 0, 2).reshape(softmax_lse.shape[1], -1, 1)
         if self.enable_dsa_cp:
             output = self._merge_dsa_cp_dcp_outputs(sfa_output, softmax_lse)
             assert attn_metadata.dsa_cp_context is not None, "DSA-CP DCP output selection requires dsa_cp_context."

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -74,7 +74,12 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
             assert qk_rope_head_dim == 0
 
             ckv_bytes = num_heads_per_page * ckv_head_dim * get_dtype_size(self.c8_k_cache_dtype)
-            qli_bytes = num_heads_per_page * index_head_dim * get_dtype_size(self.c8_k_cache_dtype)
+            qli_bytes = (
+                num_heads_per_page
+                * index_head_dim
+                * self.sfa_dcp_replicated_indexer_size
+                * get_dtype_size(self.c8_k_cache_dtype)
+            )
             qli_scale_bytes = (
                 num_heads_per_page * self.sfa_dcp_replicated_indexer_size * get_dtype_size(self.c8_k_scale_cache_dtype)
                 if index_head_dim > 0
@@ -116,7 +121,11 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
                     None,  # kv_cache[3] does not exist for Sparse C8
                 )
 
-            qli_virtual = index_k_head_dim * get_dtype_size(self.c8_k_cache_dtype)
+            qli_virtual = (
+                index_k_head_dim
+                * self.sfa_dcp_replicated_indexer_size
+                * get_dtype_size(self.c8_k_cache_dtype)
+            )
             scale_virtual = self.sfa_dcp_replicated_indexer_size * get_dtype_size(self.c8_k_scale_cache_dtype)
             total_virtual_head_dim = ckv_virtual + qli_virtual + scale_virtual
 

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -122,9 +122,7 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
                 )
 
             qli_virtual = (
-                index_k_head_dim
-                * self.sfa_dcp_replicated_indexer_size
-                * get_dtype_size(self.c8_k_cache_dtype)
+                index_k_head_dim * self.sfa_dcp_replicated_indexer_size * get_dtype_size(self.c8_k_cache_dtype)
             )
             scale_virtual = self.sfa_dcp_replicated_indexer_size * get_dtype_size(self.c8_k_scale_cache_dtype)
             total_virtual_head_dim = ckv_virtual + qli_virtual + scale_virtual

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -705,27 +705,37 @@ class BaseDeviceAdaptor:
         return_lse: bool = False,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         query = torch.cat([ql_nope, q_pe], dim=-1).contiguous()
-        result = torch_npu.npu_kv_quant_sparse_flash_attention(
-            query=query,
-            key=kv,
-            value=kv,
-            sparse_indices=topk_indices,
-            scale_value=sfa_impl.scale,
-            sparse_block_size=1,
-            block_table=block_table,
-            actual_seq_lengths_query=actual_seq_lengths_query,
-            actual_seq_lengths_kv=actual_seq_lengths_key,
-            layout_query="TND",
-            layout_kv="PA_BSND",
-            sparse_mode=sparse_mode,
-            attention_mode=2,
-            quant_scale_repo_mode=1,
-            tile_size=getattr(sfa_impl, "sfa_qsfa_tile_size", 128),
-            key_quant_mode=2,
-            value_quant_mode=2,
-            rope_head_dim=getattr(sfa_impl, "qk_rope_head_dim", q_pe.shape[-1]),
-            return_softmax_lse=return_lse,
-        )
+        common_kwargs = {
+            "query": query,
+            "key": kv,
+            "value": kv,
+            "sparse_indices": topk_indices,
+            "scale_value": sfa_impl.scale,
+            "sparse_block_size": 1,
+            "block_table": block_table,
+            "actual_seq_lengths_query": actual_seq_lengths_query,
+            "actual_seq_lengths_kv": actual_seq_lengths_key,
+            "layout_query": "TND",
+            "layout_kv": "PA_BSND",
+            "sparse_mode": sparse_mode,
+            "attention_mode": 2,
+            "quant_scale_repo_mode": 1,
+            "tile_size": getattr(sfa_impl, "sfa_qsfa_tile_size", 128),
+            "key_quant_mode": 2,
+            "value_quant_mode": 2,
+            "rope_head_dim": getattr(sfa_impl, "qk_rope_head_dim", q_pe.shape[-1]),
+        }
+        if return_lse:
+            # The torch_npu C8 SFA binding used by current images only returns
+            # attention_out and rejects return_softmax_lse.  DCP needs the
+            # softmax max/sum tensors to build LSE, so use the vllm-ascend
+            # custom op added with LSE-capable C8 SFA only on that path.
+            result = torch.ops._C_ascend.npu_kv_quant_sparse_flash_attention(
+                **common_kwargs,
+                return_softmax_lse=True,
+            )
+        else:
+            result = torch_npu.npu_kv_quant_sparse_flash_attention(**common_kwargs)
         if not isinstance(result, tuple):
             if return_lse:
                 raise RuntimeError("C8 sparse flash attention did not return softmax max/sum for DCP LSE merge.")

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -627,8 +627,13 @@ class BaseDeviceAdaptor:
         attn_metadata,
         actual_seq_lengths_query: torch.Tensor,
         actual_seq_lengths_key: torch.Tensor,
-    ) -> torch.Tensor:
-        block_table = attn_metadata.block_table
+        *,
+        block_table: torch.Tensor | None = None,
+        sparse_mode: int = 3,
+        return_lse: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if block_table is None:
+            block_table = attn_metadata.block_table
         kv = kv_cache[0]
 
         # The kv-quant sparse attention op only accepts packed quantized KV.
@@ -650,10 +655,12 @@ class BaseDeviceAdaptor:
                 topk_indices,
                 actual_seq_lengths_query,
                 actual_seq_lengths_key,
+                sparse_mode=sparse_mode,
+                return_lse=return_lse,
             )
 
         key_rope = kv_cache[1]
-        attn_output, _, _ = torch.ops._C_ascend.npu_sparse_flash_attention(
+        result = torch.ops._C_ascend.npu_sparse_flash_attention(
             query=ql_nope,
             key=kv,
             value=kv,
@@ -667,10 +674,21 @@ class BaseDeviceAdaptor:
             key_rope=key_rope,
             layout_query="TND",
             layout_kv="PA_BSND",
-            sparse_mode=3,
+            sparse_mode=sparse_mode,
             attention_mode=2,
+            return_softmax_lse=return_lse,
         )
-        return attn_output
+        if not isinstance(result, tuple):
+            if return_lse:
+                raise RuntimeError("Sparse flash attention did not return softmax max/sum for DCP LSE merge.")
+            return result
+        attn_output, softmax_max, softmax_sum = result
+        return BaseDeviceAdaptor._format_sparse_flash_attention_output(
+            attn_output,
+            softmax_max,
+            softmax_sum,
+            return_lse,
+        )
 
     @staticmethod
     def execute_kv_quant_sparse_flash_attention(
@@ -682,9 +700,12 @@ class BaseDeviceAdaptor:
         topk_indices: torch.Tensor,
         actual_seq_lengths_query: torch.Tensor,
         actual_seq_lengths_key: torch.Tensor,
-    ) -> torch.Tensor:
+        *,
+        sparse_mode: int = 3,
+        return_lse: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         query = torch.cat([ql_nope, q_pe], dim=-1).contiguous()
-        return torch_npu.npu_kv_quant_sparse_flash_attention(
+        result = torch_npu.npu_kv_quant_sparse_flash_attention(
             query=query,
             key=kv,
             value=kv,
@@ -696,14 +717,40 @@ class BaseDeviceAdaptor:
             actual_seq_lengths_kv=actual_seq_lengths_key,
             layout_query="TND",
             layout_kv="PA_BSND",
-            sparse_mode=3,
+            sparse_mode=sparse_mode,
             attention_mode=2,
             quant_scale_repo_mode=1,
             tile_size=getattr(sfa_impl, "sfa_qsfa_tile_size", 128),
             key_quant_mode=2,
             value_quant_mode=2,
-            rope_head_dim=getattr(sfa_impl, "qk_rope_head_dim", 64),
+            rope_head_dim=getattr(sfa_impl, "qk_rope_head_dim", q_pe.shape[-1]),
+            return_softmax_lse=return_lse,
         )
+        if not isinstance(result, tuple):
+            if return_lse:
+                raise RuntimeError("C8 sparse flash attention did not return softmax max/sum for DCP LSE merge.")
+            return result
+        attn_output, softmax_max, softmax_sum = result
+        return BaseDeviceAdaptor._format_sparse_flash_attention_output(
+            attn_output,
+            softmax_max,
+            softmax_sum,
+            return_lse,
+        )
+
+    @staticmethod
+    def _format_sparse_flash_attention_output(
+        attn_output: torch.Tensor,
+        softmax_max: torch.Tensor,
+        softmax_sum: torch.Tensor,
+        return_lse: bool,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if not return_lse:
+            return attn_output
+
+        softmax_lse = softmax_max.to(torch.float32) + torch.log(softmax_sum.to(torch.float32))
+        softmax_lse = softmax_lse.permute(1, 0, 2).reshape(softmax_lse.shape[1], -1, 1)
+        return attn_output, softmax_lse
 
     @staticmethod
     def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4208,11 +4208,13 @@ class NPUModelRunner(GPUModelRunner):
                                     num_blocks
                                     * num_heads
                                     * index_head_dim
+                                    * kv_cache_spec.sfa_dcp_replicated_indexer_size
                                     * get_dtype_size(kv_cache_spec.c8_k_cache_dtype)
                                 )
                                 dsa_k_scale_tensor_size = (
                                     num_blocks
                                     * num_heads
+                                    * kv_cache_spec.sfa_dcp_replicated_indexer_size
                                     * get_dtype_size(kv_cache_spec.c8_k_scale_cache_dtype)
                                 )
                             else:


### PR DESCRIPTION
## Summary

- Backport SFA DCP C8 LSE support to `releases/v0.23.0`.
- Route SFA DCP through `DeviceOperator.execute_sparse_flash_attention_process(..., return_lse=True)` so DCP output merging can consume LSE from both regular SFA and C8 SFA.
- Add the C8 SFA LSE path in `DeviceOperator`; when LSE is required, use the vllm-ascend custom C8 SFA op because the current `torch_npu` binding only returns attention output and rejects `return_softmax_lse`.
- Cover DCP replicated-indexer + C8 in UT/PR accuracy config, while keeping nightly DCP replicated-indexer C8 enabled.

## Validation

- `ruff check --output-format github --fix` and `ruff format` on changed Python test files: no-op after formatting fix.
- Remote GSM8K accuracy on GLM-5.2 W4A8C8 with DCP replicated indexer + C8:
  - samples: 1319
  - correct: 1255
  - accuracy: 95.1478%
  - errors: 0
  - max_tokens: 4096
  - concurrency/request_rate: 64/64
  - summary: `/vllm-workspace/scripts/pcpqcs/gsm8k_eval_4k_c64_gmu090/summary_20260712_001741.json`

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
