### PR TITLE
[Test] remove DeepSeek-V3.2-W8A8-DCP-replicated-indexer from nightly config

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -140,9 +140,6 @@ a3:
       - name: deepseek-v3-2-w8a8
         os: linux-aarch64-a3-16
         config_file_path: DeepSeek-V3.2-W8A8.yaml
-      - name: deepseek-v3-2-dcp-replicated-indexer
-        os: linux-aarch64-a3-16
-        config_file_path: DeepSeek-V3.2-W8A8-DCP.yaml
       - name: glm-5.1-w8a8-prefill-mc2
         os: linux-aarch64-a3-16
         config_file_path: GLM-5.1-W8A8-PrefillMC2.yaml


### PR DESCRIPTION
### What this PR does / why we need it?
remove DeepSeek-V3.2-W8A8-DCP-replicated-indexer from nightly config before C8 sfa adapted.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
