### PR TITLE
[v0.23.0][Feature][P/D][KVPool] Support PD disaggregation and KV_Pool for DCP with replicate-indexer for SFA

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -1227,6 +1227,7 @@ class TestMooncakeConnectorMetadata(unittest.TestCase):
         meta.add_new_req(
             request_id="req1",
             local_block_ids=[1, 2, 3],
+            local_full_block_ids=[0, 1, 2, 3],
             num_external_tokens=48,
             kv_transfer_params={
                 "remote_block_ids": [4, 5, 6],
@@ -1244,6 +1245,7 @@ class TestMooncakeConnectorMetadata(unittest.TestCase):
         req_meta = meta.requests["req1"]
         self.assertIsInstance(req_meta, ReqMeta)
         self.assertEqual(req_meta.local_block_ids, [1, 2, 3])
+        self.assertEqual(req_meta.local_full_block_ids, [0, 1, 2, 3])
         self.assertEqual(req_meta.remote_block_ids, [4, 5, 6])
         self.assertEqual(req_meta.remote_engine_id, "remote_engine")
         self.assertEqual(req_meta.remote_host, "localhost")
@@ -1281,9 +1283,7 @@ class TestMooncakeConnectorSchedulerMatchedTokens(unittest.TestCase):
 
     def test_build_connector_meta(self):
         request = MockRequest("req1")
-        blocks_mock = MagicMock()
-        blocks_mock.get_unhashed_block_ids.return_value = [4, 5, 6]
-        self.scheduler._reqs_need_recv["req1"] = (request, [4, 5, 6], 48)
+        self.scheduler._reqs_need_recv["req1"] = (request, [4, 5, 6], [0, 4, 5, 6], 48)
         request.kv_transfer_params = {
             "remote_block_ids": [1, 2, 3],
             "remote_engine_id": "remote",
@@ -1299,6 +1299,7 @@ class TestMooncakeConnectorSchedulerMatchedTokens(unittest.TestCase):
         self.assertIsInstance(meta, MooncakeConnectorMetadata)
         self.assertEqual(len(meta.requests), 1)
         self.assertEqual(meta.requests["req1"].local_block_ids, [4, 5, 6])
+        self.assertEqual(meta.requests["req1"].local_full_block_ids, [0, 4, 5, 6])
         self.assertEqual(meta.requests["req1"].remote_block_ids, [1, 2, 3])
         self.assertEqual(meta.requests["req1"].num_computed_tokens, 16)
         self.assertEqual(len(self.scheduler._reqs_need_recv), 0)
@@ -1399,6 +1400,9 @@ class MockKVCacheBlocks:
 
     def get_unhashed_block_ids_all_groups(self):
         return ([4, 5, 6],)
+
+    def get_block_ids(self):
+        return ([1, 2, 4, 5, 6],)
 
 
 class MockSchedulerOutput:
@@ -1539,6 +1543,7 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         self.assertEqual(len(self.scheduler._reqs_need_recv), 1)
         self.assertEqual(self.scheduler._reqs_need_recv["req1"][0], request)
         self.assertEqual(self.scheduler._reqs_need_recv["req1"][1], ([4, 5, 6],))
+        self.assertEqual(self.scheduler._reqs_need_recv["req1"][2], ([1, 2, 4, 5, 6],))
 
     def test_request_finished_no_remote_decode(self):
         request = MockRequest("req1")
@@ -1584,6 +1589,21 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         block_ids = self.scheduler._get_transfer_block_ids(([30, 31, 32, 33],), prompt_len=64)
 
         self.assertEqual(block_ids, ([30, 31],))
+
+    def test_get_transfer_block_ids_uses_cp_grouped_block_len(self):
+        self.scheduler.pcp_size = 1
+        self.scheduler.dcp_size = 4
+        self.scheduler.group_transfer_info = [
+            types.SimpleNamespace(  # type: ignore[list-item]
+                tokens_per_block=16,
+                blocks_per_window=0,
+                is_state_group=False,
+            )
+        ]
+
+        block_ids = self.scheduler._get_transfer_block_ids(([10, 11, 12, 13, 14],), prompt_len=65)
+
+        self.assertEqual(block_ids, ([10, 11],))
 
     def test_get_transfer_block_ids_trims_sliding_window_mtp_blocks(self):
         self.scheduler.group_transfer_info = [
@@ -1656,6 +1676,28 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         self.assertEqual(params["remote_block_ids"], ([10, 11, 12],))
         self.assertEqual(params["num_prompt_blocks"], 3)
         self.assertIn("req_mtp", self.scheduler._reqs_need_send)
+
+    def test_request_finished_trims_cp_grouped_mtp_blocks_in_params(self):
+        self.scheduler.pcp_size = 1
+        self.scheduler.dcp_size = 4
+        self.scheduler.group_transfer_info = [
+            types.SimpleNamespace(
+                tokens_per_block=16,
+                blocks_per_window=0,
+                is_state_group=False,
+            )
+        ]
+        request = self._make_remote_decode_request(prompt_len=65, request_id="req_cp_mtp")
+
+        delay_free, params = self.scheduler.request_finished(request, ([10, 11, 12, 13, 14],))
+
+        self.assertTrue(delay_free)
+        self.assertIsNotNone(params)
+        assert params is not None
+        self.assertEqual(params["remote_block_ids"], ([10, 11],))
+        # num_prompt_blocks stays in no-CP units for worker-side CP distribution.
+        self.assertEqual(params["num_prompt_blocks"], 5)
+        self.assertIn("req_cp_mtp", self.scheduler._reqs_need_send)
 
     def test_request_finished_clips_sliding_window_blocks_in_params(self):
         self.scheduler.group_transfer_info = [
@@ -2844,6 +2886,86 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
 
         tp_num_need_pulls = worker._get_tp_num_need_pulls(prefill_tp_size=None)
         self.assertEqual(tp_num_need_pulls, 1)
+
+    def test_sfa_replicated_indexer_remote_config_validation(self):
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.enable_sfa_dcp_replicated_indexer = True
+        worker._prefill_tp_size = 2
+
+        valid_meta = types.SimpleNamespace(
+            remote_pcp_size=1,
+            remote_dcp_size=2,
+            remote_ptp_size=2,
+        )
+        worker._validate_sfa_replicated_indexer_remote_config(cast(ReqMeta, valid_meta))
+
+        invalid_configs = [(2, 2, 2), (1, 2, 4)]
+        for remote_pcp_size, remote_dcp_size, remote_tp_size in invalid_configs:
+            with self.subTest(
+                remote_pcp_size=remote_pcp_size,
+                remote_dcp_size=remote_dcp_size,
+                remote_tp_size=remote_tp_size,
+            ):
+                invalid_meta = types.SimpleNamespace(
+                    remote_pcp_size=remote_pcp_size,
+                    remote_dcp_size=remote_dcp_size,
+                    remote_ptp_size=remote_tp_size,
+                )
+                with self.assertRaises(AssertionError):
+                    worker._validate_sfa_replicated_indexer_remote_config(cast(ReqMeta, invalid_meta))
+
+    def test_sfa_replicated_indexer_validation_is_disabled_with_feature(self):
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.enable_sfa_dcp_replicated_indexer = False
+        invalid_meta = types.SimpleNamespace(
+            remote_pcp_size=2,
+            remote_dcp_size=1,
+            remote_ptp_size=4,
+        )
+
+        worker._validate_sfa_replicated_indexer_remote_config(cast(ReqMeta, invalid_meta))
+
+    def test_get_sfa_replicated_indexer_block_ids_uses_full_blocks_for_prefix(self):
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.enable_sfa_dcp_replicated_indexer = True
+        worker.pcp_size = 1
+        worker.dcp_size = 2
+        worker.block_size = 16
+        meta = types.SimpleNamespace(
+            remote_pcp_size=1,
+            remote_dcp_size=2,
+            remote_block_ids=([10, 11],),
+            local_block_ids=([20],),
+            local_full_block_ids=([19, 20],),
+            num_external_tokens=32,
+            num_prompt_blocks=3,
+            num_computed_tokens=16,
+        )
+
+        local_ids, remote_ids = worker._get_sfa_replicate_k_block_ids(cast(ReqMeta, meta))
+
+        self.assertEqual(local_ids, ([39, 40],))
+        self.assertEqual(remote_ids, ([21, 22],))
+
+    def test_get_sfa_replicated_indexer_block_ids_requires_full_blocks_for_prefix(self):
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.enable_sfa_dcp_replicated_indexer = True
+        worker.pcp_size = 1
+        worker.dcp_size = 2
+        worker.block_size = 16
+        meta = types.SimpleNamespace(
+            remote_pcp_size=1,
+            remote_dcp_size=2,
+            remote_block_ids=([10, 11],),
+            local_block_ids=([20],),
+            local_full_block_ids=tuple(),
+            num_external_tokens=32,
+            num_prompt_blocks=3,
+            num_computed_tokens=16,
+        )
+
+        with self.assertRaises(AssertionError):
+            worker._get_sfa_replicate_k_block_ids(cast(ReqMeta, meta))
 
 
 if __name__ == "__main__":

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -941,6 +941,32 @@ class TestCoreFunctionality(unittest.TestCase):
         self.assertEqual(call_args[3], [1024, 1024])
         mock_get_meta.assert_not_called()
 
+    @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
+    def test_transfer_replicated_indexer_when_regular_kv_shard_is_empty(self, mock_get_meta):
+        req = dict(self.test_req)
+        req["local_block_ids"] = [[]]
+        req["remote_block_ids"] = [[]]
+        req["local_block_ids_replicate_k"] = ([4, 5],)
+        req["remote_block_ids_replicate_k"] = ([7, 8],)
+
+        with patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ascend_config") as mock_config:
+            mock_config.return_value.enable_kv_nz = False
+            self.thread.enable_sfa_dcp_replicated_indexer = True
+            self.thread.kv_caches_base_addr["local_engine"][5555] = [[0x1000, 0x2000]]
+            self.thread.kv_caches_base_addr["remote_engine"] = {6666: [[0x3000, 0x4000]]}
+            self.thread.block_size_scale = [[1, 2]]
+            self.thread.block_len_per_addr = [[1024, 2048]]
+            self.thread.block_stride_per_addr = [[1024, 2048]]
+            self.thread.remote_block_stride_per_addr["remote_engine"][6666] = [[4096, 8192]]
+
+            self.thread._transfer_kv_cache_all_groups(req)
+
+        call_args, _ = self.engine.batch_transfer_sync_read.call_args
+        self.assertEqual(call_args[1], [0x2000 + 4 * 2048])
+        self.assertEqual(call_args[2], [0x4000 + 7 * 8192])
+        self.assertEqual(call_args[3], [2 * 2048])
+        mock_get_meta.assert_not_called()
+
     def test_append_mamba_transfer_meta_uses_block_stride_for_block_offsets(self):
         src_list: list[int] = []
         dst_list: list[int] = []
@@ -2250,6 +2276,14 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
             ([[30000], [30008]], [[1, 3, 5], [2, 4]], [[1, 2, 3], [1, 2]]),
         )
 
+        # P cp size 4 -> D cp size 2: P block ids are per-CP local ids. D rank0
+        # must write cp0's [1,2,3] into local [1,3,5] and cp2's [1,2,3] into
+        # local [2,4,6], rather than slicing local blocks contiguously.
+        self.assertEqual(
+            get_kv_split_metadata(True, 1, 2, 8, 0, 0, 8, 1, 4, 30000, [1, 2, 3], [1, 2, 3, 4, 5, 6], 0)[:3],
+            ([[30000], [30002]], [[1, 3, 5], [2, 4, 6]], [[1, 2, 3], [1, 2, 3]]),
+        )
+
         # check remote ptp size
         self.assertEqual(
             get_kv_split_metadata(True, 1, 1, 8, 1, 0, 8, 1, 8, 30000, [1], [1], 0, 16),
@@ -2887,43 +2921,53 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
         tp_num_need_pulls = worker._get_tp_num_need_pulls(prefill_tp_size=None)
         self.assertEqual(tp_num_need_pulls, 1)
 
-    def test_sfa_replicated_indexer_remote_config_validation(self):
+    def test_start_load_kv_puts_replicated_indexer_on_existing_transfer_port(self):
         worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
-        worker.enable_sfa_dcp_replicated_indexer = True
-        worker._prefill_tp_size = 2
-
-        valid_meta = types.SimpleNamespace(
-            remote_pcp_size=1,
-            remote_dcp_size=2,
-            remote_ptp_size=2,
+        worker.kv_send_thread = None
+        worker.kv_recv_thread = MagicMock()
+        worker._prefill_tp_size = 4
+        worker.remote_port_send_num = {"remote_engine": {31001: {"num": 1, "host": "localhost"}}}
+        worker._get_sfa_replicate_k_block_ids = MagicMock(return_value=(([40],), ([20],)))
+        worker._get_kv_split_metadata = MagicMock(
+            return_value=(
+                [[31001], [31003]],
+                [([10],), ([11],)],
+                [([30],), ([31],)],
+            )
         )
-        worker._validate_sfa_replicated_indexer_remote_config(cast(ReqMeta, valid_meta))
-
-        invalid_configs = [(2, 2, 2), (1, 2, 4)]
-        for remote_pcp_size, remote_dcp_size, remote_tp_size in invalid_configs:
-            with self.subTest(
-                remote_pcp_size=remote_pcp_size,
-                remote_dcp_size=remote_dcp_size,
-                remote_tp_size=remote_tp_size,
-            ):
-                invalid_meta = types.SimpleNamespace(
-                    remote_pcp_size=remote_pcp_size,
-                    remote_dcp_size=remote_dcp_size,
-                    remote_ptp_size=remote_tp_size,
-                )
-                with self.assertRaises(AssertionError):
-                    worker._validate_sfa_replicated_indexer_remote_config(cast(ReqMeta, invalid_meta))
-
-    def test_sfa_replicated_indexer_validation_is_disabled_with_feature(self):
-        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
-        worker.enable_sfa_dcp_replicated_indexer = False
-        invalid_meta = types.SimpleNamespace(
+        worker._get_group_pulls_metadata = MagicMock(
+            return_value=[
+                [[GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1)]],
+                [[GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1)]],
+            ]
+        )
+        worker._get_remote_host_info_by_port = MagicMock(return_value=("localhost", "remote_engine"))
+        meta = types.SimpleNamespace(
+            remote_request_id="remote_req",
+            remote_engine_id="remote_engine",
+            remote_host="localhost",
+            remote_port=31000,
             remote_pcp_size=2,
-            remote_dcp_size=1,
+            remote_dcp_size=2,
             remote_ptp_size=4,
+            remote_multi_nodes_meta_mapping={},
+            remote_block_size=16,
+            local_block_ids=([10],),
+            remote_block_ids=([30],),
+            num_computed_tokens=0,
         )
+        metadata = types.SimpleNamespace(reqs_in_batch=["req"], requests={"req": meta})
 
-        worker._validate_sfa_replicated_indexer_remote_config(cast(ReqMeta, invalid_meta))
+        worker.start_load_kv(cast(MooncakeConnectorMetadata, metadata))
+
+        add_request_calls = worker.kv_recv_thread.add_request.call_args_list
+        self.assertEqual(len(add_request_calls), 2)
+        self.assertEqual(add_request_calls[0].kwargs["remote_handshake_port"], 31001)
+        self.assertEqual(add_request_calls[0].kwargs["local_block_ids_replicate_k"], ([40],))
+        self.assertEqual(add_request_calls[0].kwargs["remote_block_ids_replicate_k"], ([20],))
+        self.assertEqual(add_request_calls[1].kwargs["remote_handshake_port"], 31003)
+        self.assertIsNone(add_request_calls[1].kwargs["local_block_ids_replicate_k"])
+        self.assertIsNone(add_request_calls[1].kwargs["remote_block_ids_replicate_k"])
 
     def test_get_sfa_replicated_indexer_block_ids_uses_full_blocks_for_prefix(self):
         worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
@@ -2946,6 +2990,28 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
 
         self.assertEqual(local_ids, ([39, 40],))
         self.assertEqual(remote_ids, ([21, 22],))
+
+    def test_get_sfa_replicated_indexer_block_ids_ignores_empty_regular_kv_shard(self):
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.enable_sfa_dcp_replicated_indexer = True
+        worker.pcp_size = 1
+        worker.dcp_size = 2
+        worker.block_size = 16
+        meta = types.SimpleNamespace(
+            remote_pcp_size=1,
+            remote_dcp_size=2,
+            remote_block_ids=([10],),
+            local_block_ids=([],),
+            local_full_block_ids=([20],),
+            num_external_tokens=16,
+            num_prompt_blocks=1,
+            num_computed_tokens=0,
+        )
+
+        local_ids, remote_ids = worker._get_sfa_replicate_k_block_ids(cast(ReqMeta, meta))
+
+        self.assertEqual(local_ids, ([40],))
+        self.assertEqual(remote_ids, ([20],))
 
     def test_get_sfa_replicated_indexer_block_ids_requires_full_blocks_for_prefix(self):
         worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -2969,6 +2969,77 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
         self.assertIsNone(add_request_calls[1].kwargs["local_block_ids_replicate_k"])
         self.assertIsNone(add_request_calls[1].kwargs["remote_block_ids_replicate_k"])
 
+    def test_get_kv_split_metadata_dp1_remote_port_send_num_uses_absolute_ports(self):
+        self.vllm_config.kv_transfer_config.kv_port = 30000
+        self.vllm_config.model_config.is_deepseek_mla = True
+        self.vllm_config.kv_transfer_config.get_from_extra_config.side_effect = lambda k, d: {
+            "prefill": {"tp_size": 8, "dp_size": 2, "pp_size": 1},
+            "decode": {"tp_size": 4, "dp_size": 4, "pp_size": 1},
+        }.get(k, d)
+
+        worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id, MockKVCacheConfig())
+        worker.use_mla = True
+        worker.pcp_size = 1
+        worker.dcp_size = 1
+        worker.tp_size = 4
+        worker.tp_rank = 0
+        worker.pcp_rank = 0
+        worker.dcp_rank = 0
+        worker.side_channel_port = 40000
+        worker.handshake_port = 40000
+        worker.local_remote_block_port_mapping = {}
+        worker.remote_port_send_num = {}
+        worker.block_size = 16
+        worker.num_key_value_heads = 1
+        worker.use_sparse = False
+        worker.block_size_scale = [[1]]
+        worker.kv_group2layeridx = {
+            0: (
+                {
+                    "kv_cache_spec_type": "FullAttentionSpec",
+                    "layer_names": ["model.layers.0.self_attn"],
+                },
+                [0],
+            )
+        }
+
+        remote_mapping = {
+            str(offset): {
+                "host": f"host-{offset}",
+                "engine_id": f"engine-{offset}",
+                "handshake_port": 30000 + offset,
+            }
+            for offset in range(8, 16)
+        }
+        meta = types.SimpleNamespace(
+            remote_pcp_size=1,
+            remote_dcp_size=8,
+            remote_ptp_size=8,
+            remote_port=30008,
+            remote_block_ids=(list(range(100, 103)),),
+            local_block_ids=(list(range(200, 224)),),
+            num_external_tokens=24 * worker.block_size,
+            num_prompt_blocks=24,
+            num_computed_tokens=0,
+            remote_engine_id="remote_engine",
+            remote_host="localhost",
+            remote_multi_nodes_meta_mapping=remote_mapping,
+            remote_block_size=16,
+        )
+
+        ports, _, _ = worker._get_kv_split_metadata("req_dp1", cast(ReqMeta, meta))
+        remote_port_send_num = worker.remote_port_send_num[meta.remote_engine_id]
+
+        self.assertEqual([port for shard in ports for port in shard], list(range(30008, 30016)))
+        self.assertEqual(set(remote_port_send_num), set(range(30008, 30016)))
+        self.assertNotIn(30016, remote_port_send_num)
+        self.assertEqual(remote_port_send_num[30008]["host"], "host-8")
+        self.assertEqual(remote_port_send_num[30015]["host"], "host-15")
+        self.assertEqual(
+            worker._get_remote_host_info_by_port(30008, 30015, "localhost", "remote_engine", remote_mapping),
+            ("host-15", "engine-15"),
+        )
+
     def test_get_sfa_replicated_indexer_block_ids_uses_full_blocks_for_prefix(self):
         worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
         worker.enable_sfa_dcp_replicated_indexer = True

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -189,6 +189,28 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
             spec.page_size_bytes * num_blocks,
         )
 
+    def test_sparse_replicated_indexer_page_size_uses_expanded_storage_once(self):
+        spec = AscendMLAAttentionSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=1088,
+            sparse_head_dim=(512, 64, 128 * 4),
+            dtype=torch.bfloat16,
+            cache_dtype_str="auto",
+            sfa_dcp_replicated_indexer_size=4,
+        )
+
+        self.assertEqual(spec.page_size_bytes, 16 * (512 + 64 + 128 * 4) * 2)
+        self.assertEqual(
+            spec.sparse_kv_cache_ratio,
+            (
+                (512 + 64 + 128 * 4) / 512,
+                (512 + 64 + 128 * 4) / 64,
+                (512 + 64 + 128 * 4) / (128 * 4),
+                None,
+            ),
+        )
+
 
 class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
     def _build_runner(self):

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -137,9 +137,7 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
         return (
             self.head_size / self.sparse_head_dim[0],  # kv_cache[0]
             self.head_size / self.sparse_head_dim[1],  # kv_cache[1]
-            (
-                self.head_size / self.sparse_head_dim[2] if self.sparse_head_dim[2] > 0 else None
-            ),  # kv_cache[2]  # kv_cache[2]
+            (self.head_size / self.sparse_head_dim[2] if self.sparse_head_dim[2] > 0 else None),  # kv_cache[2]
             None,  # kv_cache[3] does not exist
         )
 

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -741,7 +741,7 @@ class KVCacheRecvingThread(threading.Thread):
         remote_block_ids: BlockIds = req_meta["remote_block_ids"]
         local_block_ids_replicate_k: BlockIds = req_meta.get("local_block_ids_replicate_k", tuple())
         remote_block_ids_replicate_k: BlockIds = req_meta.get("remote_block_ids_replicate_k", tuple())
-        has_replicate_k_blocks = bool(local_block_ids_replicate_k and remote_block_ids_replicate_k)
+        has_replicate_k_blocks = any(local_block_ids_replicate_k) and any(remote_block_ids_replicate_k)
         group_pulls: list[GroupPull] = req_meta["group_pulls"]
         remote_engine_id = req_meta["remote_engine_id"]
         remote_host = req_meta["remote_host"]
@@ -749,7 +749,7 @@ class KVCacheRecvingThread(threading.Thread):
         # Full prefix cache hit: do not need to read remote blocks, just notify
         # P worker that we have the blocks we need.
         num_local_blocks = sum(len(group_block_ids) for group_block_ids in local_block_ids)
-        if num_local_blocks == 0:
+        if num_local_blocks == 0 and not has_replicate_k_blocks:
             return
 
         # Check if we have the remote metadata cached.
@@ -772,6 +772,13 @@ class KVCacheRecvingThread(threading.Thread):
         dst_list: list[int] = []
         length_list: list[int] = []
         attention_group_reformat_block_ids: list[tuple[tuple[int, list[list[int]], int, list[int]], bool]] = []
+        grouped_remote_k_block_ids: list[list[int]] = []
+        grouped_local_k_block_ids: list[list[int]] = []
+        if self.enable_sfa_dcp_replicated_indexer and has_replicate_k_blocks:
+            grouped_remote_k_block_ids, grouped_local_k_block_ids = group_concurrent_contiguous(
+                remote_block_ids_replicate_k[0],
+                local_block_ids_replicate_k[0],
+            )
 
         def pp_layer_indices(layer_indices: list[int], prefill_pp_rank: int) -> list[int]:
             first_layer_index, end_layer_index = self.pp_layer_indices[prefill_pp_rank]
@@ -791,40 +798,38 @@ class KVCacheRecvingThread(threading.Thread):
             is_mamba_group = group_spec["kv_cache_spec_type"] == "MambaSpec"
             local_group_block_ids = local_block_ids[kv_cache_group_id]
             remote_group_block_ids = remote_block_ids[kv_cache_group_id]
-            if not local_group_block_ids:
+            has_group_blocks = bool(local_group_block_ids)
+            if not has_group_blocks and (is_mamba_group or not has_replicate_k_blocks):
                 continue
             if not is_mamba_group:
-                is_group_transfer_end = group_pull.is_group_transfer_end
-                # Block ids are already expanded to kernel granularity and truncated in
-                # _get_kv_split_metadata, so consume them directly here.
-                kernel_remote_block_ids = remote_group_block_ids
-                kernel_local_block_ids = local_group_block_ids
+                grouped_remote_block_ids: list[list[int]] = []
+                grouped_local_block_ids: list[list[int]] = []
+                if has_group_blocks:
+                    is_group_transfer_end = group_pull.is_group_transfer_end
+                    # Block ids are already expanded to kernel granularity and truncated in
+                    # _get_kv_split_metadata, so consume them directly here.
+                    kernel_remote_block_ids = remote_group_block_ids
+                    kernel_local_block_ids = local_group_block_ids
 
-                if tp_num_need_pulls == 1:
-                    grouped_remote_block_ids, grouped_local_block_ids = group_concurrent_contiguous(
-                        kernel_remote_block_ids, kernel_local_block_ids
+                    if tp_num_need_pulls == 1:
+                        grouped_remote_block_ids, grouped_local_block_ids = group_concurrent_contiguous(
+                            kernel_remote_block_ids, kernel_local_block_ids
+                        )
+                    else:
+                        grouped_remote_block_ids = [[block_id] for block_id in kernel_remote_block_ids]
+                        grouped_local_block_ids = [[block_id] for block_id in kernel_local_block_ids]
+                    attention_group_reformat_block_ids.append(
+                        (
+                            (group_idx, grouped_local_block_ids, tp_num_need_pulls, layer_indices),
+                            is_group_transfer_end,
+                        )
                     )
-                else:
-                    grouped_remote_block_ids = [[block_id] for block_id in kernel_remote_block_ids]
-                    grouped_local_block_ids = [[block_id] for block_id in kernel_local_block_ids]
-                attention_group_reformat_block_ids.append(
-                    (
-                        (group_idx, grouped_local_block_ids, tp_num_need_pulls, layer_indices),
-                        is_group_transfer_end,
-                    )
-                )
             else:
                 # When Prefix Caching is enabled on both P and D nodes, num_block should not be forced to match,
                 # as the D-node requires dynamic allocation based on its specific cache hit rate.
                 transfer_block_idx = len(remote_group_block_ids) - self.num_speculative_tokens - 1
                 grouped_remote_block_ids = [[remote_group_block_ids[transfer_block_idx]]]
                 grouped_local_block_ids = [[local_group_block_ids[0]]]
-
-            if self.enable_sfa_dcp_replicated_indexer and has_replicate_k_blocks:
-                grouped_remote_k_block_ids, grouped_local_k_block_ids = group_concurrent_contiguous(
-                    remote_block_ids_replicate_k[0],
-                    local_block_ids_replicate_k[0],
-                )
 
             if is_mamba_group:
                 for layer_idx in layer_indices:
@@ -878,6 +883,8 @@ class KVCacheRecvingThread(threading.Thread):
                         else:
                             continue
                     else:
+                        if not has_group_blocks:
+                            continue
                         transfer_remote_block_ids, transfer_local_block_ids = split_if_not_byte_contiguous(
                             grouped_remote_block_ids,
                             grouped_local_block_ids,
@@ -3220,30 +3227,6 @@ class MooncakeConnectorWorker:
             use_mla=num_key_value_heads == 1,
         )[self.tp_rank]
 
-    def _get_sfa_replicate_k_remote_handshake_port(
-        self,
-        meta: ReqMeta,
-    ) -> int | None:
-        if not self.enable_sfa_dcp_replicated_indexer:
-            return None
-        self._validate_sfa_replicated_indexer_remote_config(meta)
-        remote_cp_size = meta.remote_pcp_size * meta.remote_dcp_size
-        local_cp_size = self.pcp_size * self.dcp_size
-        if local_cp_size == 0 or remote_cp_size % local_cp_size != 0:
-            raise AssertionError(
-                f"SFA replicate-K expects remote cp size({remote_cp_size}) to be divisible by "
-                f"local cp size({local_cp_size})."
-            )
-        local_cp_rank = self.dcp_rank + self.pcp_rank * self.dcp_size
-        remote_cp_rank = local_cp_rank * (remote_cp_size // local_cp_size)
-        return meta.remote_port + remote_cp_rank
-
-    def _validate_sfa_replicated_indexer_remote_config(self, meta: ReqMeta) -> None:
-        if not self.enable_sfa_dcp_replicated_indexer:
-            return
-        prefill_tp_size = meta.remote_ptp_size if meta.remote_ptp_size is not None else self._prefill_tp_size
-        assert meta.remote_pcp_size == 1 and meta.remote_dcp_size == prefill_tp_size
-
     def _get_sfa_replicate_k_block_ids(
         self,
         meta: ReqMeta,
@@ -3281,7 +3264,6 @@ class MooncakeConnectorWorker:
 
         remote_blocks = list(meta.remote_block_ids[0])
         local_full_blocks = list((meta.local_full_block_ids or meta.local_block_ids)[0])
-        local_external_blocks = list(meta.local_block_ids[0])
         if not local_full_blocks:
             return tuple(), tuple()
 
@@ -3299,8 +3281,7 @@ class MooncakeConnectorWorker:
                 int(local_full_blocks[local_local_idx]) * local_cp_size + global_block_idx % local_cp_size
             )
 
-        max_external_blocks = min(num_external_blocks, len(local_external_blocks) * local_cp_size)
-        local_block_ids = local_block_ids[:max_external_blocks]
+        local_block_ids = local_block_ids[:num_external_blocks]
         remote_block_ids = remote_block_ids[: len(local_block_ids)]
         local_block_ids = local_block_ids[: len(remote_block_ids)]
 
@@ -3340,7 +3321,6 @@ class MooncakeConnectorWorker:
 
             remote_req_id = meta.remote_request_id
             prefill_tp_size: int = meta.remote_ptp_size if meta.remote_ptp_size is not None else self._prefill_tp_size
-            replicate_k_remote_port = self._get_sfa_replicate_k_remote_handshake_port(meta)
             (
                 local_block_ids_replicate_k,
                 remote_block_ids_replicate_k,
@@ -3351,20 +3331,11 @@ class MooncakeConnectorWorker:
                 local_block_ids_list,
                 remote_block_ids_list,
             ) = self._get_kv_split_metadata(remote_req_id, meta)
-            replicate_k_transfer_port = replicate_k_remote_port
             has_replicate_k_blocks = any(local_block_ids_replicate_k) and any(remote_block_ids_replicate_k)
-            if replicate_k_remote_port is not None and has_replicate_k_blocks:
-                remote_transfer_ports = [port for remote_ports in remote_handshake_port_list for port in remote_ports]
-                if replicate_k_remote_port not in remote_transfer_ports:
-                    replicate_k_transfer_port = remote_transfer_ports[0] if remote_transfer_ports else None
-                    if replicate_k_transfer_port is not None:
-                        logger.warning(
-                            "Mooncake SFA replicate-K remote port %s is not in normal KV transfer ports %s. "
-                            "Use existing remote port %s because K cache is replicated on P workers.",
-                            replicate_k_remote_port,
-                            remote_transfer_ports,
-                            replicate_k_transfer_port,
-                        )
+            remote_transfer_ports = [port for remote_ports in remote_handshake_port_list for port in remote_ports]
+            if has_replicate_k_blocks and not remote_transfer_ports:
+                raise AssertionError("SFA replicate-K requires at least one normal KV transfer port.")
+            replicate_k_transfer_port = remote_transfer_ports[0] if has_replicate_k_blocks else None
             group_pulls_list = self._get_group_pulls_metadata(
                 remote_req_id,
                 remote_handshake_port_list,

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -494,6 +494,10 @@ class KVCacheRecvingThread(threading.Thread):
             else 0
         )
         self.use_mla = self.model_config.is_deepseek_mla
+        self.use_sparse = hasattr(self.vllm_config.model_config.hf_text_config, "index_topk")
+        self.sfa_dcp_replicate_k = self.use_sparse and (self.vllm_config.additional_config or {}).get(
+            "sfa_dcp_replicate_k", False
+        )
         self.is_hma_required = is_hma_required
         self.block_size = self.vllm_config.cache_config.block_size
         try:
@@ -544,6 +548,8 @@ class KVCacheRecvingThread(threading.Thread):
         remote_port_send_num: dict[int, RemotePortInfo] | None = None,
         num_computed_tokens: int = 0,
         all_task_done: bool = False,
+        local_block_ids_replicate_k: BlockIds | None = None,
+        remote_block_ids_replicate_k: BlockIds | None = None,
     ):
         """Add a new request to the queue for processing."""
         if remote_port_send_num is None:
@@ -552,6 +558,8 @@ class KVCacheRecvingThread(threading.Thread):
             "request_id": request_id,
             "local_block_ids": local_block_ids,
             "remote_block_ids": remote_block_ids,
+            "local_block_ids_replicate_k": local_block_ids_replicate_k or tuple(),
+            "remote_block_ids_replicate_k": remote_block_ids_replicate_k or tuple(),
             "group_pulls": group_pulls,
             "remote_engine_id": remote_engine_id,
             "remote_request_id": remote_request_id,
@@ -733,6 +741,8 @@ class KVCacheRecvingThread(threading.Thread):
         remote_request_id = req_meta["remote_request_id"]
         local_block_ids: BlockIds = req_meta["local_block_ids"]
         remote_block_ids: BlockIds = req_meta["remote_block_ids"]
+        local_block_ids_replicate_k: BlockIds = req_meta.get("local_block_ids_replicate_k", tuple())
+        remote_block_ids_replicate_k: BlockIds = req_meta.get("remote_block_ids_replicate_k", tuple())
         group_pulls: list[GroupPull] = req_meta["group_pulls"]
         remote_engine_id = req_meta["remote_engine_id"]
         remote_host = req_meta["remote_host"]
@@ -811,6 +821,12 @@ class KVCacheRecvingThread(threading.Thread):
                 grouped_remote_block_ids = [[remote_group_block_ids[transfer_block_idx]]]
                 grouped_local_block_ids = [[local_group_block_ids[0]]]
 
+            if self.sfa_dcp_replicate_k and local_block_ids_replicate_k:
+                grouped_remote_k_block_ids, grouped_local_k_block_ids = group_concurrent_contiguous(
+                    remote_block_ids_replicate_k[0],
+                    local_block_ids_replicate_k[0],
+                )
+
             if is_mamba_group:
                 for layer_idx in layer_indices:
                     start_meta_idx = len(src_list)
@@ -856,13 +872,20 @@ class KVCacheRecvingThread(threading.Thread):
                     block_stride = self.block_stride_per_addr[layer_idx][cache_idx]
                     remote_block_stride = remote_block_stride_per_addr[layer_idx][cache_idx]
                     inner_block_len = block_len // tp_num_need_pulls
-                    transfer_remote_block_ids, transfer_local_block_ids = split_if_not_byte_contiguous(
-                        grouped_remote_block_ids,
-                        grouped_local_block_ids,
-                        src_block_stride=remote_block_stride,
-                        dst_block_stride=block_stride,
-                        block_len=inner_block_len,
-                    )
+                    if self.sfa_dcp_replicate_k and self.block_size_scale[layer_idx][cache_idx] > 1:
+                        if local_block_ids_replicate_k:
+                            transfer_remote_block_ids = grouped_remote_k_block_ids
+                            transfer_local_block_ids = grouped_local_k_block_ids
+                        else:
+                            continue
+                    else:
+                        transfer_remote_block_ids, transfer_local_block_ids = split_if_not_byte_contiguous(
+                            grouped_remote_block_ids,
+                            grouped_local_block_ids,
+                            src_block_stride=remote_block_stride,
+                            dst_block_stride=block_stride,
+                            block_len=inner_block_len,
+                        )
                     for remote_block_id, local_block_id in zip(transfer_remote_block_ids, transfer_local_block_ids):
                         src = src_layer_base_addr + local_block_id[0] * block_stride + inner_offset * inner_block_len
                         dst = dst_layer_base_addr + remote_block_id[0] * remote_block_stride
@@ -2225,6 +2248,9 @@ class MooncakeConnectorWorker:
         """Register the KV Cache data."""
         self.use_mla = self.vllm_config.model_config.is_deepseek_mla
         self.use_sparse = hasattr(self.vllm_config.model_config.hf_text_config, "index_topk")
+        self.sfa_dcp_replicate_k = self.use_sparse and (self.vllm_config.additional_config or {}).get(
+            "sfa_dcp_replicate_k", False
+        )
 
         self.num_blocks = self.kv_cache_config.num_blocks
         logger.info("num_blocks: %s", self.num_blocks)
@@ -3183,6 +3209,92 @@ class MooncakeConnectorWorker:
             tp_num_need_pulls=num_group_pulls,
             use_mla=num_key_value_heads == 1,
         )[self.tp_rank]
+    def _get_sfa_replicate_k_remote_handshake_port(
+        self,
+        meta: ReqMeta,
+    ) -> int | None:
+        if not self.sfa_dcp_replicate_k:
+            return None
+        remote_cp_size = meta.remote_pcp_size * meta.remote_dcp_size
+        local_cp_size = self.pcp_size * self.dcp_size
+        if local_cp_size == 0 or remote_cp_size % local_cp_size != 0:
+            raise AssertionError(
+                f"SFA replicate-K expects remote cp size({remote_cp_size}) to be divisible by "
+                f"local cp size({local_cp_size})."
+            )
+        local_cp_rank = self.dcp_rank + self.pcp_rank * self.dcp_size
+        remote_cp_rank = local_cp_rank * (remote_cp_size // local_cp_size)
+        return meta.remote_port + remote_cp_rank
+
+    def _get_sfa_replicate_k_block_ids(
+        self,
+        meta: ReqMeta,
+    ) -> tuple[BlockIds, BlockIds]:
+        if not self.sfa_dcp_replicate_k:
+            return tuple(), tuple()
+        if meta.num_external_tokens <= 0 or not meta.remote_block_ids or not meta.local_block_ids:
+            return tuple(), tuple()
+
+        if len(meta.remote_block_ids) != 1 or len(meta.local_block_ids) != 1:
+            raise AssertionError(
+                "SFA replicate-K currently expects exactly one KV cache group. "
+                f"Got remote groups={len(meta.remote_block_ids)}, local groups={len(meta.local_block_ids)}."
+            )
+
+        remote_cp_size = meta.remote_pcp_size * meta.remote_dcp_size
+        local_cp_size = self.pcp_size * self.dcp_size
+        if local_cp_size == 0 or remote_cp_size % local_cp_size != 0:
+            raise AssertionError(
+                f"SFA replicate-K expects remote cp size({remote_cp_size}) to be divisible by "
+                f"local cp size({local_cp_size})."
+            )
+
+        num_prefix_cached_blocks = min(meta.num_computed_tokens // self.block_size, meta.num_prompt_blocks)
+        num_external_blocks = meta.num_prompt_blocks - num_prefix_cached_blocks
+        num_external_blocks_from_tokens = math.ceil(meta.num_external_tokens / self.block_size)
+        if num_external_blocks < num_external_blocks_from_tokens:
+            raise AssertionError(
+                f"num_external_blocks({num_external_blocks}) derived from num_computed_tokens "
+                f"must cover num_external_blocks_from_tokens({num_external_blocks_from_tokens})."
+            )
+
+        def expand_cp_group_blocks(block_ids: list[int], cp_size: int) -> list[int]:
+            expanded_blocks: list[int] = []
+            for block_id in block_ids:
+                start_block = int(block_id) * cp_size
+                expanded_blocks.extend(range(start_block, start_block + cp_size))
+            return expanded_blocks
+
+        remote_expanded = expand_cp_group_blocks(list(meta.remote_block_ids[0]), remote_cp_size)
+        local_external_expanded = expand_cp_group_blocks(list(meta.local_block_ids[0]), local_cp_size)
+        local_external_expanded = local_external_expanded[:num_external_blocks]
+        local_full_expanded = [-1] * num_prefix_cached_blocks + local_external_expanded
+
+        # The expanded lists are already in no-CP block units, so the prefix
+        # offset is the original no-CP block count directly.
+        remote_start_idx = num_prefix_cached_blocks
+        remote_external_expanded = remote_expanded[remote_start_idx:]
+        remote_external_expanded = remote_external_expanded[: len(local_external_expanded)]
+        local_external_expanded = local_external_expanded[: len(remote_external_expanded)]
+
+        logger.debug(
+            "Mooncake SFA replicate-K block ids prepared. remote_cp_size=%s local_cp_size=%s "
+            "num_prompt_blocks=%s num_computed_tokens=%s num_external_blocks=%s "
+            "num_external_blocks_from_tokens=%s num_prefix_cached_blocks=%s local_full_len=%s "
+            "local_external_len=%s remote_external_len=%s",
+            remote_cp_size,
+            local_cp_size,
+            meta.num_prompt_blocks,
+            meta.num_computed_tokens,
+            num_external_blocks,
+            num_external_blocks_from_tokens,
+            num_prefix_cached_blocks,
+            len(local_full_expanded),
+            len(local_external_expanded),
+            len(remote_external_expanded),
+        )
+
+        return (local_external_expanded,), (remote_external_expanded,)
 
     def start_load_kv(self, metadata: MooncakeConnectorMetadata):
         """Start loading KV blocks from remote engine."""
@@ -3205,12 +3317,31 @@ class MooncakeConnectorWorker:
 
             remote_req_id = meta.remote_request_id
             prefill_tp_size: int = meta.remote_ptp_size if meta.remote_ptp_size is not None else self._prefill_tp_size
+            replicate_k_remote_port = self._get_sfa_replicate_k_remote_handshake_port(meta)
+            (
+                local_block_ids_replicate_k,
+                remote_block_ids_replicate_k,
+            ) = self._get_sfa_replicate_k_block_ids(meta)
 
             (
                 remote_handshake_port_list,
                 local_block_ids_list,
                 remote_block_ids_list,
             ) = self._get_kv_split_metadata(remote_req_id, meta)
+            replicate_k_transfer_port = replicate_k_remote_port
+            has_replicate_k_blocks = any(local_block_ids_replicate_k) and any(remote_block_ids_replicate_k)
+            if replicate_k_remote_port is not None and has_replicate_k_blocks:
+                remote_transfer_ports = [port for remote_ports in remote_handshake_port_list for port in remote_ports]
+                if replicate_k_remote_port not in remote_transfer_ports:
+                    replicate_k_transfer_port = remote_transfer_ports[0] if remote_transfer_ports else None
+                    if replicate_k_transfer_port is not None:
+                        logger.warning(
+                            "Mooncake SFA replicate-K remote port %s is not in normal KV transfer ports %s. "
+                            "Use existing remote port %s because K cache is replicated on P workers.",
+                            replicate_k_remote_port,
+                            remote_transfer_ports,
+                            replicate_k_transfer_port,
+                        )
             group_pulls_list = self._get_group_pulls_metadata(
                 remote_req_id,
                 remote_handshake_port_list,
@@ -3235,6 +3366,16 @@ class MooncakeConnectorWorker:
                         if meta.remote_pcp_size * meta.remote_dcp_size > 1
                         else None
                     )
+                    local_block_ids_replicate_k_for_port = (
+                        local_block_ids_replicate_k
+                        if replicate_k_transfer_port is not None and remote_handshake_port == replicate_k_transfer_port
+                        else None
+                    )
+                    remote_block_ids_replicate_k_for_port = (
+                        remote_block_ids_replicate_k
+                        if replicate_k_transfer_port is not None and remote_handshake_port == replicate_k_transfer_port
+                        else None
+                    )
                     self.kv_recv_thread.add_request(
                         request_id=req_id,
                         remote_request_id=remote_req_id,
@@ -3251,6 +3392,8 @@ class MooncakeConnectorWorker:
                             and remote_tp_offset == len(remote_ports) - 1
                         ),
                         remote_block_size=meta.remote_block_size,
+                        local_block_ids_replicate_k=local_block_ids_replicate_k_for_port,
+                        remote_block_ids_replicate_k=remote_block_ids_replicate_k_for_port,
                     )
 
         if self.kv_send_thread is not None and self.pcp_size * self.dcp_size == 1:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -68,7 +68,7 @@ from vllm_ascend.distributed.utils import (
     get_decode_context_model_parallel_rank,
     get_decode_context_model_parallel_world_size,
 )
-from vllm_ascend.utils import enable_custom_op
+from vllm_ascend.utils import enable_custom_op, enable_sfa_dcp_replicated_indexer
 
 # isort: off
 if TYPE_CHECKING:
@@ -124,6 +124,7 @@ class ReqMeta:
     remote_multi_nodes_meta_mapping: dict[str, dict[str, Any]]
     num_prompt_blocks: int
     remote_block_size: int
+    local_full_block_ids: BlockIds = tuple()
 
 
 @dataclass(frozen=True)
@@ -494,10 +495,7 @@ class KVCacheRecvingThread(threading.Thread):
             else 0
         )
         self.use_mla = self.model_config.is_deepseek_mla
-        self.use_sparse = hasattr(self.vllm_config.model_config.hf_text_config, "index_topk")
-        self.sfa_dcp_replicate_k = self.use_sparse and (self.vllm_config.additional_config or {}).get(
-            "sfa_dcp_replicate_k", False
-        )
+        self.enable_sfa_dcp_replicated_indexer = enable_sfa_dcp_replicated_indexer(self.vllm_config)
         self.is_hma_required = is_hma_required
         self.block_size = self.vllm_config.cache_config.block_size
         try:
@@ -743,6 +741,7 @@ class KVCacheRecvingThread(threading.Thread):
         remote_block_ids: BlockIds = req_meta["remote_block_ids"]
         local_block_ids_replicate_k: BlockIds = req_meta.get("local_block_ids_replicate_k", tuple())
         remote_block_ids_replicate_k: BlockIds = req_meta.get("remote_block_ids_replicate_k", tuple())
+        has_replicate_k_blocks = bool(local_block_ids_replicate_k and remote_block_ids_replicate_k)
         group_pulls: list[GroupPull] = req_meta["group_pulls"]
         remote_engine_id = req_meta["remote_engine_id"]
         remote_host = req_meta["remote_host"]
@@ -821,7 +820,7 @@ class KVCacheRecvingThread(threading.Thread):
                 grouped_remote_block_ids = [[remote_group_block_ids[transfer_block_idx]]]
                 grouped_local_block_ids = [[local_group_block_ids[0]]]
 
-            if self.sfa_dcp_replicate_k and local_block_ids_replicate_k:
+            if self.enable_sfa_dcp_replicated_indexer and has_replicate_k_blocks:
                 grouped_remote_k_block_ids, grouped_local_k_block_ids = group_concurrent_contiguous(
                     remote_block_ids_replicate_k[0],
                     local_block_ids_replicate_k[0],
@@ -872,8 +871,8 @@ class KVCacheRecvingThread(threading.Thread):
                     block_stride = self.block_stride_per_addr[layer_idx][cache_idx]
                     remote_block_stride = remote_block_stride_per_addr[layer_idx][cache_idx]
                     inner_block_len = block_len // tp_num_need_pulls
-                    if self.sfa_dcp_replicate_k and self.block_size_scale[layer_idx][cache_idx] > 1:
-                        if local_block_ids_replicate_k:
+                    if self.enable_sfa_dcp_replicated_indexer and self.block_size_scale[layer_idx][cache_idx] > 1:
+                        if has_replicate_k_blocks:
                             transfer_remote_block_ids = grouped_remote_k_block_ids
                             transfer_local_block_ids = grouped_local_k_block_ids
                         else:
@@ -1412,6 +1411,7 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
         local_block_ids: BlockIds,
         num_external_tokens: int,
         kv_transfer_params: dict[str, Any],
+        local_full_block_ids: BlockIds | None = None,
     ):
         self.requests[request_id] = ReqMeta(
             local_block_ids=local_block_ids,
@@ -1428,6 +1428,7 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
             remote_multi_nodes_meta_mapping=kv_transfer_params.get("remote_multi_nodes_meta_mapping", {}),
             num_prompt_blocks=kv_transfer_params.get("num_prompt_blocks", 0),
             remote_block_size=kv_transfer_params.get("remote_block_size", 0),
+            local_full_block_ids=local_full_block_ids or tuple(),
         )
 
 
@@ -1584,7 +1585,7 @@ class MooncakeConnectorScheduler:
         # Requests that need to start recv.
         # New requests are added by update_state_after_alloc in
         # the scheduler. Used to make metadata passed to Worker.
-        self._reqs_need_recv: dict[str, tuple[Request, BlockIds, int]] = {}
+        self._reqs_need_recv: dict[str, tuple[Request, BlockIds, BlockIds, int]] = {}
         self._reqs_need_send: dict[str, float] = {}
         self._reqs_in_batch: set[str] = set()
 
@@ -1648,11 +1649,15 @@ class MooncakeConnectorScheduler:
         assert len(block_ids) == len(self.group_transfer_info), "Number of KV cache groups must match"
 
         transfer_block_ids = []
+        cp_size = max(1, self.pcp_size * self.dcp_size)
         for blocks, group_info in zip(block_ids, self.group_transfer_info):
             if group_info.is_state_group:
                 transfer_block_ids.append(blocks)
             else:
-                num_prompt_blocks = cdiv(prompt_len, group_info.tokens_per_block)
+                # In context parallelism, each scheduler-visible block id is a
+                # CP-grouped/virtual block shared by all CP ranks. It therefore
+                # covers cp_size times the token span of one no-CP block.
+                num_prompt_blocks = cdiv(prompt_len, group_info.tokens_per_block * cp_size)
                 transfer_block_ids.append(blocks[:num_prompt_blocks])
         return tuple(transfer_block_ids)
 
@@ -1757,8 +1762,14 @@ class MooncakeConnectorScheduler:
             if params.get("remote_block_ids"):
                 if all(p in params for p in ("remote_engine_id", "remote_host", "remote_port", "remote_request_id")):
                     local_block_ids = blocks.get_unhashed_block_ids_all_groups() if num_external_tokens > 0 else []
+                    local_full_block_ids = blocks.get_block_ids() if num_external_tokens > 0 else tuple()
                     # Get unhashed blocks to pull from remote.
-                    self._reqs_need_recv[request.request_id] = (request, local_block_ids, num_external_tokens)
+                    self._reqs_need_recv[request.request_id] = (
+                        request,
+                        local_block_ids,
+                        local_full_block_ids,
+                        num_external_tokens,
+                    )
                 else:
                     logger.warning("Got invalid KVTransferParams. params=%s. ", params)
             else:
@@ -1773,7 +1784,7 @@ class MooncakeConnectorScheduler:
         meta = MooncakeConnectorMetadata()
 
         # Loop through scheduled reqs and convert to ReqMeta.
-        for req_id, (req, block_ids, num_external_tokens) in self._reqs_need_recv.items():
+        for req_id, (req, block_ids, full_block_ids, num_external_tokens) in self._reqs_need_recv.items():
             assert req.kv_transfer_params is not None
             # For the case where there are no remote blocks to pull
             # (block_ids is empty), we don't need to schedule
@@ -1781,6 +1792,7 @@ class MooncakeConnectorScheduler:
             meta.add_new_req(
                 request_id=req_id,
                 local_block_ids=block_ids,
+                local_full_block_ids=full_block_ids,
                 num_external_tokens=num_external_tokens,
                 kv_transfer_params=req.kv_transfer_params,
             )
@@ -2248,9 +2260,7 @@ class MooncakeConnectorWorker:
         """Register the KV Cache data."""
         self.use_mla = self.vllm_config.model_config.is_deepseek_mla
         self.use_sparse = hasattr(self.vllm_config.model_config.hf_text_config, "index_topk")
-        self.sfa_dcp_replicate_k = self.use_sparse and (self.vllm_config.additional_config or {}).get(
-            "sfa_dcp_replicate_k", False
-        )
+        self.enable_sfa_dcp_replicated_indexer = enable_sfa_dcp_replicated_indexer(self.vllm_config)
 
         self.num_blocks = self.kv_cache_config.num_blocks
         logger.info("num_blocks: %s", self.num_blocks)
@@ -3209,12 +3219,14 @@ class MooncakeConnectorWorker:
             tp_num_need_pulls=num_group_pulls,
             use_mla=num_key_value_heads == 1,
         )[self.tp_rank]
+
     def _get_sfa_replicate_k_remote_handshake_port(
         self,
         meta: ReqMeta,
     ) -> int | None:
-        if not self.sfa_dcp_replicate_k:
+        if not self.enable_sfa_dcp_replicated_indexer:
             return None
+        self._validate_sfa_replicated_indexer_remote_config(meta)
         remote_cp_size = meta.remote_pcp_size * meta.remote_dcp_size
         local_cp_size = self.pcp_size * self.dcp_size
         if local_cp_size == 0 or remote_cp_size % local_cp_size != 0:
@@ -3226,11 +3238,17 @@ class MooncakeConnectorWorker:
         remote_cp_rank = local_cp_rank * (remote_cp_size // local_cp_size)
         return meta.remote_port + remote_cp_rank
 
+    def _validate_sfa_replicated_indexer_remote_config(self, meta: ReqMeta) -> None:
+        if not self.enable_sfa_dcp_replicated_indexer:
+            return
+        prefill_tp_size = meta.remote_ptp_size if meta.remote_ptp_size is not None else self._prefill_tp_size
+        assert meta.remote_pcp_size == 1 and meta.remote_dcp_size == prefill_tp_size
+
     def _get_sfa_replicate_k_block_ids(
         self,
         meta: ReqMeta,
     ) -> tuple[BlockIds, BlockIds]:
-        if not self.sfa_dcp_replicate_k:
+        if not self.enable_sfa_dcp_replicated_indexer:
             return tuple(), tuple()
         if meta.num_external_tokens <= 0 or not meta.remote_block_ids or not meta.local_block_ids:
             return tuple(), tuple()
@@ -3258,43 +3276,48 @@ class MooncakeConnectorWorker:
                 f"must cover num_external_blocks_from_tokens({num_external_blocks_from_tokens})."
             )
 
-        def expand_cp_group_blocks(block_ids: list[int], cp_size: int) -> list[int]:
-            expanded_blocks: list[int] = []
-            for block_id in block_ids:
-                start_block = int(block_id) * cp_size
-                expanded_blocks.extend(range(start_block, start_block + cp_size))
-            return expanded_blocks
+        if num_prefix_cached_blocks > 0 and not meta.local_full_block_ids:
+            raise AssertionError("SFA replicate-K requires full local block ids when prefix cache is used.")
 
-        remote_expanded = expand_cp_group_blocks(list(meta.remote_block_ids[0]), remote_cp_size)
-        local_external_expanded = expand_cp_group_blocks(list(meta.local_block_ids[0]), local_cp_size)
-        local_external_expanded = local_external_expanded[:num_external_blocks]
-        local_full_expanded = [-1] * num_prefix_cached_blocks + local_external_expanded
+        remote_blocks = list(meta.remote_block_ids[0])
+        local_full_blocks = list((meta.local_full_block_ids or meta.local_block_ids)[0])
+        local_external_blocks = list(meta.local_block_ids[0])
+        if not local_full_blocks:
+            return tuple(), tuple()
 
-        # The expanded lists are already in no-CP block units, so the prefix
-        # offset is the original no-CP block count directly.
-        remote_start_idx = num_prefix_cached_blocks
-        remote_external_expanded = remote_expanded[remote_start_idx:]
-        remote_external_expanded = remote_external_expanded[: len(local_external_expanded)]
-        local_external_expanded = local_external_expanded[: len(remote_external_expanded)]
+        local_block_ids: list[int] = []
+        remote_block_ids: list[int] = []
+        for global_block_idx in range(num_prefix_cached_blocks, meta.num_prompt_blocks):
+            remote_local_idx = global_block_idx // remote_cp_size
+            local_local_idx = global_block_idx // local_cp_size
+            if remote_local_idx >= len(remote_blocks) or local_local_idx >= len(local_full_blocks):
+                break
+            remote_block_ids.append(
+                int(remote_blocks[remote_local_idx]) * remote_cp_size + global_block_idx % remote_cp_size
+            )
+            local_block_ids.append(
+                int(local_full_blocks[local_local_idx]) * local_cp_size + global_block_idx % local_cp_size
+            )
+
+        max_external_blocks = min(num_external_blocks, len(local_external_blocks) * local_cp_size)
+        local_block_ids = local_block_ids[:max_external_blocks]
+        remote_block_ids = remote_block_ids[: len(local_block_ids)]
+        local_block_ids = local_block_ids[: len(remote_block_ids)]
 
         logger.debug(
-            "Mooncake SFA replicate-K block ids prepared. remote_cp_size=%s local_cp_size=%s "
-            "num_prompt_blocks=%s num_computed_tokens=%s num_external_blocks=%s "
-            "num_external_blocks_from_tokens=%s num_prefix_cached_blocks=%s local_full_len=%s "
-            "local_external_len=%s remote_external_len=%s",
+            "Mooncake SFA replicate-K block ids prepared from aligned full blocks. "
+            "remote_cp_size=%s local_cp_size=%s num_prompt_blocks=%s num_computed_tokens=%s "
+            "num_external_blocks=%s local_len=%s remote_len=%s",
             remote_cp_size,
             local_cp_size,
             meta.num_prompt_blocks,
             meta.num_computed_tokens,
             num_external_blocks,
-            num_external_blocks_from_tokens,
-            num_prefix_cached_blocks,
-            len(local_full_expanded),
-            len(local_external_expanded),
-            len(remote_external_expanded),
+            len(local_block_ids),
+            len(remote_block_ids),
         )
 
-        return (local_external_expanded,), (remote_external_expanded,)
+        return (local_block_ids,), (remote_block_ids,)
 
     def start_load_kv(self, metadata: MooncakeConnectorMetadata):
         """Start loading KV blocks from remote engine."""

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1883,11 +1883,13 @@ class MooncakeConnectorScheduler:
             return
 
         updated_mapping: dict[str, dict[str, Any]] = {}
+        kv_port = self.vllm_config.kv_transfer_config.kv_port
         for metadata_key, rank_metadata in metadata.items():
             port_offset = self._port_offset_from_handshake_metadata(rank_metadata, metadata_key)
             updated_mapping[str(port_offset)] = {
                 "host": rank_metadata.local_ip,
                 "engine_id": rank_metadata.engine_id,
+                "handshake_port": kv_port + port_offset,
             }
 
         self.multi_nodes_meta_mapping.update(updated_mapping)
@@ -2750,21 +2752,26 @@ class MooncakeConnectorWorker:
             local_remote_block_port_mappings: dict[int, list[list[int]]],
         ) -> dict[int, RemotePortInfo]:
             remote_port_send_num: dict[int, RemotePortInfo] = {}
-            port_offsets: set[int] = set(range(prefill_tp_size * meta.remote_pcp_size))
-            for key in meta.remote_multi_nodes_meta_mapping:
-                port_offsets.add(int(key))
+            remote_ports: set[int] = set(
+                range(meta.remote_port, meta.remote_port + prefill_tp_size * meta.remote_pcp_size)
+            )
+            kv_port = self.vllm_config.kv_transfer_config.kv_port
+            for key, remote_host_info in meta.remote_multi_nodes_meta_mapping.items():
+                remote_ports.add(int(remote_host_info.get("handshake_port", kv_port + int(key))))
             for remote_port_head_list in local_remote_block_port_mappings.values():
                 for remote_port_list in remote_port_head_list:
                     for remote_port in remote_port_list:
-                        port_offsets.add(remote_port - meta.remote_port)
+                        remote_ports.add(remote_port)
 
-            for port_offset in port_offsets:
-                remote_host_info = meta.remote_multi_nodes_meta_mapping.get(str(port_offset), None)
-                if remote_host_info is None:
-                    remote_host = meta.remote_host
-                else:
-                    remote_host = remote_host_info["host"]
-                remote_port_send_num[meta.remote_port + port_offset] = {"num": 0, "host": remote_host}
+            for remote_port in remote_ports:
+                remote_host, _ = self._get_remote_host_info_by_port(
+                    meta.remote_port,
+                    remote_port,
+                    meta.remote_host,
+                    meta.remote_engine_id,
+                    meta.remote_multi_nodes_meta_mapping,
+                )
+                remote_port_send_num[remote_port] = {"num": 0, "host": remote_host}
 
             for remote_port_head_list in local_remote_block_port_mappings.values():
                 for remote_port_list in remote_port_head_list:
@@ -3424,10 +3431,17 @@ class MooncakeConnectorWorker:
         remote_engine_id: str,
         remote_multi_nodes_meta_mapping: dict,
     ):
-        rank = str(remote_handshake_port - base_port)
-        if remote_multi_nodes_meta_mapping is None or remote_multi_nodes_meta_mapping.get(rank) is None:
+        if remote_multi_nodes_meta_mapping is None:
             return remote_host, remote_engine_id
-        info = remote_multi_nodes_meta_mapping[rank]
+
+        kv_port = self.vllm_config.kv_transfer_config.kv_port
+        rank = str(remote_handshake_port - kv_port)
+        info = remote_multi_nodes_meta_mapping.get(rank)
+        if info is None:
+            rank = str(remote_handshake_port - base_port)
+            info = remote_multi_nodes_meta_mapping.get(rank)
+        if info is None:
+            return remote_host, remote_engine_id
         return info.get("host", remote_host), info.get("engine_id", remote_engine_id)
 
     def _prefill_get_remote_rank(self, req_id: str) -> list[int]:


### PR DESCRIPTION
Cherry-pick of https://github.com/vllm-project/vllm-ascend/pull/11696 onto `releases/v0.23.0`.

What changed:
- Adds P/D disaggregation support for the SFA DCP replicated-indexer path.
- Adds KV Pool replicate-K cache-role handling for SFA DCP, including token database metadata, pool worker transfer paths, and Mooncake connector handling.
- Includes the follow-up replicated-indexer KV transfer ordering fix from the source PR's final commit.
- Adds/updates unit coverage for AscendStore metadata, KV transfer, pool worker, Mooncake connector, and model runner behavior.

Conflict resolution notes:
- Kept the release branch's layerwise/GVA KV Pool startup abstraction and inserted the replicate-K buffer registration/cache-role traversal into that flow.
- Kept release-side physical-layer counting for main + MTP layers while adding replicate-K cache metadata.
- Resolved the `AscendMLAAttentionSpec.sparse_kv_cache_ratio` conflict to keep the release C8 layout logic with a single `kv_cache[2]` comment.

Validation:
- `git diff --check upstream/releases/v0.23.0..HEAD`
- `python -m py_compile` on all changed Python files
- `ruff check --output-format github` on all changed Python files
- `ruff format --check` on all changed Python files

Not run:
- Local torch/torch_npu UT, per repository instruction that Ascend/torch_npu-dependent tests should run in a remote NPU container.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
