### PR TITLE
[BugFix] [MLAPO] Keep worker alive instead of crashing when kv_consumer must local-prefill (fixes #11882)

### DIFF
--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1051,19 +1051,24 @@ class AscendMLAImpl(MLAAttentionImpl):
         self.q_nope_scale = torch.tensor([1], dtype=act_dtype, device=device)
 
         # On KV consumers (decode-only) MLAPO uses the transformed weights built above;
-        # the original fused_qkv_a_proj/q_proj weights and quant params are no longer
-        # referenced, so drop them to save memory.
+        # the original fused_qkv_a_proj/q_proj weights and quant params are not
+        # referenced by the MLAPO decode fast path, so offload them to CPU to save
+        # NPU memory. They are lazily restored to NPU in forward() if D must
+        # local-prefill (recompute / fallback / preempt, see issue #11882).
         if (
             self.vllm_config.kv_transfer_config is not None
             and self.vllm_config.kv_transfer_config.is_kv_consumer
             and self.vllm_config.scheduler_config.max_num_batched_tokens <= MLAPO_MAX_SUPPORTED_TOKENS
         ):
-            self.fused_qkv_a_proj.weight = None  # type: ignore[union-attr]
-            self.fused_qkv_a_proj.deq_scale = None  # type: ignore[union-attr]
-            self.fused_qkv_a_proj.quant_bias = None  # type: ignore[union-attr]
-            self.q_proj.weight = None
-            self.q_proj.deq_scale = None
-            self.q_proj.quant_bias = None
+            cpu_device = torch.device("cpu")
+            for module in (self.fused_qkv_a_proj, self.q_proj):
+                if module is None:
+                    continue
+                for attr in ("weight", "deq_scale", "quant_bias"):
+                    val = getattr(module, attr, None)
+                    if val is not None:
+                        val.data = val.data.to(cpu_device, non_blocking=True)
+            self._prefill_weights_offloaded = True
             torch.npu.empty_cache()
 
     def _process_weights_for_fused_mlapo_a5(self, act_dtype: torch.dtype):
@@ -1734,6 +1739,30 @@ class AscendMLAImpl(MLAAttentionImpl):
                 self, hidden_states, kv_cache, attn_metadata
             )
         else:
+            # On a kv_consumer with MLAPO, the prefill weights were offloaded to CPU
+            # to save NPU memory. This branch is reached when D must local-prefill
+            # (recompute / fallback / preempt, or miss-parametrized kv_transfer_params
+            # without valid remote KV, see #11882). Lazily restore them to NPU once
+            # per layer on the first such step, then clear the flag so subsequent
+            # steps pay no copy cost.
+            if getattr(self, "_prefill_weights_offloaded", False):
+                logger.warning(
+                    "Layer %s: restoring MLAPO prefill weights from CPU to NPU for "
+                    "local prefill on kv_consumer (see issue #11882).",
+                    layer_name,
+                )
+                device = hidden_states.device
+                for module in (self.fused_qkv_a_proj, self.q_proj):
+                    if module is None:
+                        continue
+                    for attr in ("weight", "deq_scale", "quant_bias"):
+                        val = getattr(module, attr, None)
+                        if val is not None and val.device.type == "cpu":
+                            # Synchronous copy: _mla_preprocess dereferences these
+                            # weights immediately after, so the transfer must be
+                            # complete before we proceed.
+                            val.data = val.data.to(device)
+                self._prefill_weights_offloaded = False
             decode_preprocess_res, prefill_preprocess_res = self._mla_preprocess(
                 layer_name, hidden_states, kv_cache, attn_metadata, need_gather_q_kv
             )


### PR DESCRIPTION
## What & Why

Fixes #11882.

On `kv_consumer` (decode-only D) with MLAPO enabled and `max_num_batched_tokens <= MLAPO_MAX_SUPPORTED_TOKENS` (1024), `_process_weights_for_fused_mlapo` freed the original `fused_qkv_a_proj`/`q_proj` weights (set to `None`) to save NPU memory.

This breaks **local prefill on D**: vLLM has several normal paths where D must local-prefill (recompute on KV load failure, P2P session fallback, preempt resume), and a mis-parametrized request (e.g. proxy forwards un-flipped `kv_transfer_params` without valid remote KV) also forces D to local-prefill. In all these cases `_mla_preprocess` dereferences the freed weights and the **entire D worker crashes** with `Cannot access storage of UndefinedTensorImpl` — taking down all in-flight requests on that instance.

## Fix

Keep the NPU memory saving during normal decode, but make the weights **recoverable**:

1. In `_process_weights_for_fused_mlapo`, **offload** the 6 tensors (`fused_qkv_a_proj.{weight,deq_scale,quant_bias}` + `q_proj.{weight,deq_scale,quant_bias}`) **to CPU** (instead of freeing to `None`), and set `self._prefill_weights_offloaded = True`. NPU memory is still saved during normal decode.
2. **Lazily restore** them to NPU (synchronous `.to(device)`) at the top of `forward()`'s else branch — the only place they are referenced — on the first step where D must local-prefill. Restored **once per layer**; afterwards the flag is cleared and the weights stay on NPU. Subsequent steps pay no copy cost.

This converts a worker-fatal crash into a successful (if slow) local recompute.

## Properties

- **Normal decode**: unchanged. The MLAPO fast path never touches these weights; they sit on CPU. Zero perf impact, NPU memory saved.
- **First local-prefill step** (recompute / fallback / preempt / mis-parametrized): one-time synchronous CPU→NPU copy of the 6 tensors per layer, then they stay on NPU. The prefill completes normally.
- **Memory**: trades the previous "free to None" (0 memory, but crashes on any prefill) for "offload to CPU" (1 CPU copy of `fused_qkv_a_proj`+`q_proj` per layer, reclaimable NPU memory). After the first recompute, NPU memory converges to the "keep weights" state.
- **No vllm-core changes** — fully contained in vllm-ascend.

## Why this approach over alternatives

- **Free to None (original code)**: simplest, saves the most NPU memory, but crashes the worker on any prefill path. This is the bug being fixed.
- **Keep weights on NPU (don't free)**: simplest and safest, but pays the NPU memory cost unconditionally. This PR preserves the NPU saving during normal operation and only pays it after the first recompute (rare).
- **Zero-fill output on guard**: keeps the worker alive but produces empty/garbage output for the affected request (and the rest of the batch in that step). The offload-and-restore approach produces correct results instead.

## Testing

- `python -c "import ast; ast.parse(open('vllm_ascend/attention/mla_v1.py').read())"` passes.
- **Validated on real Ascend NPU hardware (Atlas 800T A2 / 910B3).** In a PD-disaggregated deployment (kv_consumer + MLAPO), the original crash (`UndefinedTensorImpl` in `_mla_preprocess` dereferencing freed `fused_qkv_a_proj.weight`) was reproduced and confirmed fixed: with this patch the D worker survives, the prefill weights are restored from CPU on the first local-prefill step, and the request completes normally instead of crashing the worker.

## Related

- Issue: #11882
- The proximate trigger is often a proxy bug (prefill not capped to 1 token → P does not push KV). The upstream `examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py` already mitigates the `max_completion_tokens`-overrides-`max_tokens=1` case. This PR is the engine-side robustness fix so that a single bad request does not crash the whole D worker regardless of proxy correctness.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
