### PR TITLE
[BugFix][PD] Carry explicit total KV heads in Mooncake transfer groups

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -299,6 +299,46 @@ class TestKVCacheSendingThread(unittest.TestCase):
 
 
 class TestMooncakeTransferGroups(unittest.TestCase):
+    def test_attention_group_heads_are_globalized_for_unequal_pd_tp(self):
+        decode_worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        decode_worker.tp_size = 2
+        decode_worker.num_key_value_heads = 8
+        mla_group = {
+            "kv_cache_spec_type": "AscendMLAAttentionSpec",
+            "kv_cache_spec": {"num_kv_heads": 1},
+        }
+        full_attention_decode_group = {
+            "kv_cache_spec_type": "FullAttentionSpec",
+            "kv_cache_spec": {"num_kv_heads": 4},
+        }
+
+        self.assertEqual(decode_worker._get_attention_group_num_key_value_heads(mla_group), 1)
+        self.assertEqual(
+            decode_worker._get_attention_group_num_key_value_heads(full_attention_decode_group),
+            8,
+        )
+        self.assertEqual(
+            decode_worker._get_attention_group_num_need_pulls_for_decode_tp(full_attention_decode_group, 8, 2),
+            4,
+        )
+
+        prefill_worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        prefill_worker.tp_size = 8
+        prefill_worker.num_key_value_heads = 8
+        full_attention_prefill_group = {
+            "kv_cache_spec_type": "FullAttentionSpec",
+            "kv_cache_spec": {"num_kv_heads": 1},
+        }
+
+        self.assertEqual(
+            prefill_worker._get_attention_group_num_key_value_heads(full_attention_prefill_group),
+            8,
+        )
+        self.assertEqual(
+            prefill_worker._get_attention_group_num_need_pulls_for_decode_tp(full_attention_prefill_group, 8, 2),
+            4,
+        )
+
     def test_build_kv_group2layeridx_splits_uniform_group_by_kv_heads(self):
         mla_spec = FullAttentionSpec(
             block_size=16,
@@ -323,6 +363,8 @@ class TestMooncakeTransferGroups(unittest.TestCase):
 
         worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
         worker.vllm_config = MockVllmConfig()
+        worker.tp_size = 1
+        worker.num_key_value_heads = 8
         worker.total_layers = 32
         worker.kv_cache_config = MockKVCacheConfig(
             kv_cache_groups=[

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -14,7 +14,7 @@ import msgspec
 import torch
 import zmq
 from vllm.utils.network_utils import make_zmq_path
-from vllm.v1.kv_cache_interface import FullAttentionSpec, UniformTypeKVCacheSpecs
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MLAAttentionSpec, UniformTypeKVCacheSpecs
 from vllm.v1.request import RequestStatus
 
 fake_engine = types.ModuleType("mooncake.engine")
@@ -299,72 +299,66 @@ class TestKVCacheSendingThread(unittest.TestCase):
 
 
 class TestMooncakeTransferGroups(unittest.TestCase):
-    def test_attention_group_heads_are_globalized_for_unequal_pd_tp(self):
-        decode_worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
-        decode_worker.tp_size = 2
-        decode_worker.num_key_value_heads = 8
+    def test_attention_group_uses_explicit_total_heads_for_unequal_pd_tp(self):
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.num_key_value_heads = 16
         mla_group = {
             "kv_cache_spec_type": "AscendMLAAttentionSpec",
-            "kv_cache_spec": {"num_kv_heads": 1},
+            "kv_cache_spec": {"num_kv_heads": 1, "total_num_kv_heads": 1},
         }
         full_attention_decode_group = {
             "kv_cache_spec_type": "FullAttentionSpec",
-            "kv_cache_spec": {"num_kv_heads": 4},
+            "kv_cache_spec": {"num_kv_heads": 4, "total_num_kv_heads": 8},
         }
-
-        self.assertEqual(decode_worker._get_attention_group_num_key_value_heads(mla_group), 1)
-        self.assertEqual(
-            decode_worker._get_attention_group_num_key_value_heads(full_attention_decode_group),
-            8,
-        )
-        self.assertEqual(
-            decode_worker._get_attention_group_num_need_pulls_for_decode_tp(full_attention_decode_group, 8, 2),
-            4,
-        )
-
-        prefill_worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
-        prefill_worker.tp_size = 8
-        prefill_worker.num_key_value_heads = 8
-        full_attention_prefill_group = {
+        replicated_prefill_group = {
             "kv_cache_spec_type": "FullAttentionSpec",
-            "kv_cache_spec": {"num_kv_heads": 1},
+            "kv_cache_spec": {"num_kv_heads": 1, "total_num_kv_heads": 8},
         }
 
+        self.assertEqual(worker._get_attention_group_num_key_value_heads(mla_group), 1)
         self.assertEqual(
-            prefill_worker._get_attention_group_num_key_value_heads(full_attention_prefill_group),
+            worker._get_attention_group_num_key_value_heads(full_attention_decode_group),
             8,
         )
         self.assertEqual(
-            prefill_worker._get_attention_group_num_need_pulls_for_decode_tp(full_attention_prefill_group, 8, 2),
+            worker._get_attention_group_num_key_value_heads(replicated_prefill_group),
+            8,
+        )
+        self.assertEqual(
+            worker._get_attention_group_num_need_pulls_for_decode_tp(full_attention_decode_group, 8, 2),
             4,
         )
 
     def test_build_kv_group2layeridx_splits_uniform_group_by_kv_heads(self):
-        mla_spec = FullAttentionSpec(
+        mla_spec = MLAAttentionSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=64,
+            dtype=torch.float16,
+        )
+        qga_spec = FullAttentionSpec(
             block_size=16,
             num_kv_heads=1,
             head_size=64,
             head_size_v=64,
             dtype=torch.float16,
         )
-        qga_spec = FullAttentionSpec(
-            block_size=16,
-            num_kv_heads=8,
-            head_size=64,
-            head_size_v=64,
-            dtype=torch.float16,
-        )
         layer_specs = {
-            "model.layers.0.self_attn": mla_spec,
-            "model.layers.1.self_attn": qga_spec,
+            "language_model.model.layers.0.self_attn": mla_spec,
+            "model.layers.32.self_attn": qga_spec,
         }
-        uniform_spec = UniformTypeKVCacheSpecs.from_specs(layer_specs)
-        assert uniform_spec is not None
+        uniform_spec = UniformTypeKVCacheSpecs(block_size=16, kv_cache_specs=layer_specs)
 
         worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
         worker.vllm_config = MockVllmConfig()
-        worker.tp_size = 1
-        worker.num_key_value_heads = 8
+        worker.vllm_config.model_config.hf_text_config.num_key_value_heads = 128
+        worker.vllm_config.model_config.get_total_num_kv_heads = MagicMock(return_value=128)
+        worker.vllm_config.speculative_config = types.SimpleNamespace(
+            draft_model_config=types.SimpleNamespace(
+                hf_text_config=types.SimpleNamespace(num_key_value_heads=8),
+                get_total_num_kv_heads=MagicMock(return_value=8),
+            ),
+        )
         worker.total_layers = 32
         worker.kv_cache_config = MockKVCacheConfig(
             kv_cache_groups=[
@@ -382,6 +376,67 @@ class TestMooncakeTransferGroups(unittest.TestCase):
         self.assertEqual(kv_group2layeridx[1][0]["kv_cache_group_id"], 0)
         self.assertEqual(worker._get_attention_group_num_key_value_heads(kv_group2layeridx[0][0]), 1)
         self.assertEqual(worker._get_attention_group_num_key_value_heads(kv_group2layeridx[1][0]), 8)
+        self.assertEqual(kv_group2layeridx[0][0]["kv_cache_spec"]["num_kv_heads"], 1)
+        self.assertEqual(kv_group2layeridx[1][0]["kv_cache_spec"]["num_kv_heads"], 1)
+
+    def test_build_kv_group2layeridx_splits_equal_local_heads_by_total_heads(self):
+        shared_local_spec = FullAttentionSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=64,
+            head_size_v=64,
+            dtype=torch.float16,
+        )
+        layer_names = [
+            "model.layers.0.self_attn",
+            "eagle.model.layers.0.self_attn",
+        ]
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.vllm_config = MockVllmConfig()
+        worker.vllm_config.model_config.hf_text_config.num_key_value_heads = 16
+        worker.vllm_config.model_config.get_total_num_kv_heads = MagicMock(return_value=16)
+        worker.vllm_config.speculative_config = types.SimpleNamespace(
+            draft_model_config=types.SimpleNamespace(
+                hf_text_config=types.SimpleNamespace(num_key_value_heads=8),
+                get_total_num_kv_heads=MagicMock(return_value=8),
+            ),
+        )
+        worker.total_layers = 32
+        worker.kv_cache_config = MockKVCacheConfig(
+            kv_cache_groups=[
+                MockKVCacheGroup(
+                    layer_names=layer_names,
+                    kv_cache_spec=shared_local_spec,
+                )
+            ]
+        )
+
+        kv_group2layeridx = worker._build_kv_group2layeridx()
+
+        self.assertEqual(len(kv_group2layeridx), 2)
+        self.assertEqual(kv_group2layeridx[0][1], [0])
+        self.assertEqual(kv_group2layeridx[1][1], [32])
+        self.assertEqual(kv_group2layeridx[0][0]["kv_cache_spec"]["total_num_kv_heads"], 16)
+        self.assertEqual(kv_group2layeridx[1][0]["kv_cache_spec"]["total_num_kv_heads"], 8)
+        self.assertEqual(kv_group2layeridx[0][0]["kv_cache_spec"]["num_kv_heads"], 1)
+        self.assertEqual(kv_group2layeridx[1][0]["kv_cache_spec"]["num_kv_heads"], 1)
+        worker.kv_group2layeridx = kv_group2layeridx
+        self.assertTrue(worker._requires_group_aware_attention_transfer())
+
+        worker.tp_rank = 0
+        worker.tp_size = 8
+        worker._decode_tp_size = 8
+        worker._prefill_tp_size = 16
+        worker._prefill_pp_size = 1
+        worker.use_sparse = False
+        _, rank_group_pulls = worker._get_hybrid_remote_rank_group_pulls("req-1", prefill_tp_size=16)
+        pulls = [pull for group_pulls in rank_group_pulls.values() for pull in group_pulls]
+        target_pulls = [pull for pull in pulls if pull.group_id == 0]
+        draft_pulls = [pull for pull in pulls if pull.group_id == 1]
+        self.assertEqual(len(target_pulls), 2)
+        self.assertTrue(all(pull.num_group_pulls == 2 for pull in target_pulls))
+        self.assertEqual(len(draft_pulls), 1)
+        self.assertEqual(draft_pulls[0].num_group_pulls, 1)
 
     def test_hybrid_rank_pulls_use_transfer_group_kv_heads(self):
         worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
@@ -399,7 +454,10 @@ class TestMooncakeTransferGroups(unittest.TestCase):
                 {
                     "kv_cache_spec_type": "UniformTypeKVCacheSpecs",
                     "kv_cache_group_id": 0,
-                    "kv_cache_spec": {"model.layers.0.self_attn": {"num_kv_heads": 1}},
+                    "kv_cache_spec": {
+                        "total_num_kv_heads": 1,
+                        "model.layers.0.self_attn": {"num_kv_heads": 1},
+                    },
                 },
                 [0],
             ),
@@ -407,7 +465,10 @@ class TestMooncakeTransferGroups(unittest.TestCase):
                 {
                     "kv_cache_spec_type": "UniformTypeKVCacheSpecs",
                     "kv_cache_group_id": 0,
-                    "kv_cache_spec": {"model.layers.1.self_attn": {"num_kv_heads": 8}},
+                    "kv_cache_spec": {
+                        "total_num_kv_heads": 8,
+                        "model.layers.1.self_attn": {"num_kv_heads": 8},
+                    },
                 },
                 [1],
             ),

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -3123,19 +3123,27 @@ class MooncakeConnectorWorker:
         return num_d_block_heads // num_p_block_heads
 
     def _get_attention_group_num_key_value_heads(self, group_spec: dict[str, Any]) -> int:
+        def to_global_num_heads(local_num_heads: int) -> int:
+            if "MLA" in group_spec.get("kv_cache_spec_type", ""):
+                return local_num_heads
+            # FullAttentionSpec stores the rank-local head count after TP
+            # sharding. Recover the global count so P and D derive the same
+            # pull mapping when their TP sizes differ.
+            return min(local_num_heads * self.tp_size, self.num_key_value_heads)
+
         kv_cache_spec = group_spec.get("kv_cache_spec", {})
         if isinstance(kv_cache_spec, dict):
             for key in ("num_kv_heads", "num_key_value_heads"):
                 num_key_value_heads = kv_cache_spec.get(key)
                 if isinstance(num_key_value_heads, int):
-                    return num_key_value_heads
+                    return to_global_num_heads(num_key_value_heads)
             for spec in kv_cache_spec.values():
                 if not isinstance(spec, dict):
                     continue
                 for key in ("num_kv_heads", "num_key_value_heads"):
                     num_key_value_heads = spec.get(key)
                     if isinstance(num_key_value_heads, int):
-                        return num_key_value_heads
+                        return to_global_num_heads(num_key_value_heads)
         return self.num_key_value_heads
 
     def _get_attention_group_remote_rank(

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -49,6 +49,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     MambaSpec,
+    MLAAttentionSpec,
     SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
 )
@@ -1980,6 +1981,7 @@ class MooncakeConnectorWorker:
         layer_names: list[str] | None = None,
         kv_cache_spec: Any | None = None,
         kv_cache_group_id: int | None = None,
+        total_num_kv_heads: int | None = None,
     ) -> dict[str, Any]:
         def to_msgpackable(value: Any) -> Any:
             if value is None or isinstance(value, (str, int, float, bool)):
@@ -2010,6 +2012,8 @@ class MooncakeConnectorWorker:
         if num_key_value_heads is not None:
             serialized_kv_cache_spec["num_kv_heads"] = num_key_value_heads
             serialized_kv_cache_spec["num_key_value_heads"] = num_key_value_heads
+        if total_num_kv_heads is not None:
+            serialized_kv_cache_spec["total_num_kv_heads"] = total_num_kv_heads
 
         serialized = {
             "layer_names": layer_names,
@@ -2035,11 +2039,34 @@ class MooncakeConnectorWorker:
         return None
 
     @classmethod
-    def _get_kv_transfer_spec_key(cls, spec: Any) -> tuple[str, int | None]:
+    def _get_kv_transfer_spec_key(
+        cls,
+        spec: Any,
+        total_num_kv_heads: int | None,
+    ) -> tuple[str, int | None, int | None]:
         # TODO: Extand this key with KV cache layout fields (for example num_dims)
         # if a future model has layers with the same number of kv heads but incompatiible
         # cache shapes.
-        return (type(spec).__name__, cls._get_spec_num_key_value_heads(spec))
+        return (
+            type(spec).__name__,
+            cls._get_spec_num_key_value_heads(spec),
+            total_num_kv_heads,
+        )
+
+    def _get_spec_total_num_kv_heads(self, spec: Any, layer_idx: int) -> int | None:
+        local_num_kv_heads = self._get_spec_num_key_value_heads(spec)
+        if local_num_kv_heads is None or isinstance(spec, MLAAttentionSpec):
+            return local_num_kv_heads
+
+        model_config = self.vllm_config.model_config
+        speculative_config = self.vllm_config.speculative_config
+        if (
+            layer_idx >= self.total_layers
+            and speculative_config is not None
+            and speculative_config.draft_model_config is not None
+        ):
+            model_config = speculative_config.draft_model_config
+        return model_config.get_total_num_kv_heads()
 
     def _build_kv_group2layeridx(self) -> dict[int, tuple[dict[str, Any], list[int]]]:
         from vllm.v1.worker.utils import extract_layer_index
@@ -2068,52 +2095,54 @@ class MooncakeConnectorWorker:
                 assigned_indices.add(layer_idx)
                 layer_entries.append((layer_name, layer_idx))
 
-            if isinstance(group_spec.kv_cache_spec, UniformTypeKVCacheSpecs):
-                spec_groups: OrderedDict[tuple[str, int | None], list[tuple[str, int]]] = OrderedDict()
-                for layer_name, layer_idx in layer_entries:
-                    layer_spec = group_spec.kv_cache_spec.kv_cache_specs[layer_name]
-                    spec_key = self._get_kv_transfer_spec_key(layer_spec)
-                    spec_groups.setdefault(spec_key, []).append((layer_name, layer_idx))
+            spec_groups: OrderedDict[
+                tuple[str, int | None, int | None],
+                list[tuple[str, int, Any, int | None]],
+            ] = OrderedDict()
+            for layer_name, layer_idx in layer_entries:
+                kv_cache_spec = group_spec.kv_cache_spec
+                if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+                    kv_cache_spec = kv_cache_spec.kv_cache_specs[layer_name]
+                total_num_kv_heads = self._get_spec_total_num_kv_heads(kv_cache_spec, layer_idx)
+                spec_key = self._get_kv_transfer_spec_key(kv_cache_spec, total_num_kv_heads)
+                spec_groups.setdefault(spec_key, []).append((layer_name, layer_idx, kv_cache_spec, total_num_kv_heads))
 
-                if len(spec_groups) > 1:
-                    logger.info(
-                        "Split KV cache manager group %d into %d Mooncake transfer groups by KV spec: %s",
-                        kv_cache_group_id,
-                        len(spec_groups),
-                        list(spec_groups),
-                    )
+            if len(spec_groups) > 1:
+                logger.info(
+                    "Split KV cache manager group %d into %d Mooncake transfer groups by KV spec: %s",
+                    kv_cache_group_id,
+                    len(spec_groups),
+                    list(spec_groups),
+                )
 
-                for entries in spec_groups.values():
-                    layer_names = [layer_name for layer_name, _ in entries]
-                    layer_indices = [layer_idx for _, layer_idx in entries]
-                    kv_cache_spec = group_spec.kv_cache_spec.kv_cache_specs[layer_names[0]]
-                    kv_group2layeridx[transfer_group_id] = (
-                        self._serialize_kv_group_spec(
-                            group_spec,
-                            layer_names=layer_names,
-                            kv_cache_spec=kv_cache_spec,
-                            kv_cache_group_id=kv_cache_group_id,
-                        ),
-                        layer_indices,
-                    )
-                    transfer_group_id += 1
-                continue
-
-            layer_names = [layer_name for layer_name, _ in layer_entries]
-            layer_indices = [layer_idx for _, layer_idx in layer_entries]
-            kv_group2layeridx[transfer_group_id] = (
-                self._serialize_kv_group_spec(
-                    group_spec,
-                    layer_names=layer_names,
-                    kv_cache_group_id=kv_cache_group_id,
-                ),
-                layer_indices,
-            )
-            transfer_group_id += 1
+            for entries in spec_groups.values():
+                layer_names = [layer_name for layer_name, _, _, _ in entries]
+                layer_indices = [layer_idx for _, layer_idx, _, _ in entries]
+                kv_cache_spec = entries[0][2]
+                total_num_kv_heads = entries[0][3]
+                kv_group2layeridx[transfer_group_id] = (
+                    self._serialize_kv_group_spec(
+                        group_spec,
+                        layer_names=layer_names,
+                        kv_cache_spec=kv_cache_spec,
+                        kv_cache_group_id=kv_cache_group_id,
+                        total_num_kv_heads=total_num_kv_heads,
+                    ),
+                    layer_indices,
+                )
+                transfer_group_id += 1
         return kv_group2layeridx
 
     def _has_mamba_group(self) -> bool:
         return any(group_spec["kv_cache_spec_type"] == "MambaSpec" for group_spec, _ in self.kv_group2layeridx.values())
+
+    def _requires_group_aware_attention_transfer(self) -> bool:
+        total_num_kv_heads = {
+            self._get_attention_group_num_key_value_heads(group_spec)
+            for group_spec, layer_indices in self.kv_group2layeridx.values()
+            if layer_indices and group_spec["kv_cache_spec_type"] != "MambaSpec"
+        }
+        return len(total_num_kv_heads) > 1
 
     @staticmethod
     def _as_kv_cache_tuple(kv_cache_tuple: Any) -> list[torch.Tensor]:
@@ -2203,6 +2232,7 @@ class MooncakeConnectorWorker:
         # Maps each KV cache group to its serialized group spec and physical
         # layer indices: {group_id: (group_spec, [layer_idx0, layer_idx1, ...])}.
         self.kv_group2layeridx = self._build_kv_group2layeridx()
+        self._is_hma_required = self._is_hma_required or self._requires_group_aware_attention_transfer()
         has_mamba_group = self._has_mamba_group()
         layer_name_to_idx = {
             layer_name: layer_idx
@@ -3123,27 +3153,19 @@ class MooncakeConnectorWorker:
         return num_d_block_heads // num_p_block_heads
 
     def _get_attention_group_num_key_value_heads(self, group_spec: dict[str, Any]) -> int:
-        def to_global_num_heads(local_num_heads: int) -> int:
-            if "MLA" in group_spec.get("kv_cache_spec_type", ""):
-                return local_num_heads
-            # FullAttentionSpec stores the rank-local head count after TP
-            # sharding. Recover the global count so P and D derive the same
-            # pull mapping when their TP sizes differ.
-            return min(local_num_heads * self.tp_size, self.num_key_value_heads)
-
         kv_cache_spec = group_spec.get("kv_cache_spec", {})
         if isinstance(kv_cache_spec, dict):
-            for key in ("num_kv_heads", "num_key_value_heads"):
+            for key in ("total_num_kv_heads", "num_kv_heads", "num_key_value_heads"):
                 num_key_value_heads = kv_cache_spec.get(key)
                 if isinstance(num_key_value_heads, int):
-                    return to_global_num_heads(num_key_value_heads)
+                    return num_key_value_heads
             for spec in kv_cache_spec.values():
                 if not isinstance(spec, dict):
                     continue
-                for key in ("num_kv_heads", "num_key_value_heads"):
+                for key in ("total_num_kv_heads", "num_kv_heads", "num_key_value_heads"):
                     num_key_value_heads = spec.get(key)
                     if isinstance(num_key_value_heads, int):
-                        return to_global_num_heads(num_key_value_heads)
+                        return num_key_value_heads
         return self.num_key_value_heads
 
     def _get_attention_group_remote_rank(


### PR DESCRIPTION
### What this PR does / why we need it?

`num_kv_heads` in a serialized KV cache spec describes the rank-local cache layout. It cannot reliably recover the model-level head count with `local_heads * TP`: heads may be replicated when TP exceeds the global KV-head count, and a speculative group may belong to a draft model whose KV-head count differs from the target model.

This PR adds an explicit `total_num_kv_heads` field to each serialized attention KV spec:

- `num_kv_heads` remains the rank-local physical layout;
- `total_num_kv_heads` is read from the owning model config: the target `ModelConfig` for target layers and `draft_model_config` for speculative layers;
- Mooncake transfer groups are keyed by `(spec type, local heads, total heads)`, so target and draft groups remain distinct even when both have one local head;
- heterogeneous rank pulls and reformatting use the explicit group-level total head count;
- MLA keeps its existing single-head transfer semantics;
- metadata without the new field still falls back to the existing local-head fields.

For example, a target model with 16 KV heads and a draft model with 8 KV heads can both expose one rank-local head at high TP. The new metadata preserves `16` versus `8`, splits the two transfer groups, and derives their rank pulls independently.

Fixes #11885
Related: #10991, #11877

### Does this PR introduce _any_ user-facing change?

Yes. Mooncake P/D disaggregation now supports unequal Prefill/Decode TP sizes when target and draft attention groups have different global KV-head counts. There is no API change.

### How was this fix tested?

Unit and static checks:

```text
PYTHONPATH=$PWD python -m unittest tests.ut.kv_offload.test_mooncake_connector
Ran 95 tests in 2.474s
OK

ruff check tests/ut/kv_offload/test_mooncake_connector.py vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
ruff format --check tests/ut/kv_offload/test_mooncake_connector.py vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
python -m py_compile vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py tests/ut/kv_offload/test_mooncake_connector.py
git diff --check HEAD^ HEAD
```

The regression tests cover:

- unequal P/D TP with Prefill local 1 / Decode local 4 and explicit total 8;
- target total 16 / draft total 8 when both rank-local specs report one head;
- transfer-group splitting and group-aware rank pulls for the unequal target/draft case.

Real-model validation used four Ascend A2 nodes with Kimi K2.7 Code W4A8 plus Kimi-K2.5-DFlash, Prefill DP2 x TP8, Decode DP8 x TP2, and the same serial 65,542-token request that reproduced the issue:

- all ten Prefill/Decode `/v1/models` endpoints returned HTTP 200;
- the short request returned HTTP 200 and valid JSON;
- Prefill logged `FullAttentionSpec(local=1, total=8)` and Decode logged `FullAttentionSpec(local=4, total=8)`;
- the 6-request gate passed `6/6`, including the former failure rounds 3 and 6;
- the full regression passed `20/20`, including former failure rounds `3/6/9/12/15/18`;
- all four server logs contained zero HCCL batch-get, Mooncake transfer, KV load, traceback, or error matches.

Co-authored-by: ltdo111 <1061328217@qq.com>

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
