### PR TITLE
[BugFix] Fix A5 C8 SFA Comsumer

### DIFF
--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -628,7 +628,9 @@ class AscendSFAImpl(MLAAttentionImpl):
                 self.sfa_qsfa_tile_size,
             )
         # PD decode consumers with sparse C8 use mla_prolog_v3 to write the packed KV cache.
-        self.enable_sfa_prolog_v3 = self.is_kv_consumer and self.use_sparse_c8_sfa
+        self.enable_sfa_prolog_v3 = (
+            self.is_kv_consumer and self.use_sparse_c8_sfa and get_ascend_device_type() != AscendDeviceType.A5
+        )
         self.enable_mlapo = ascend_config.enable_mlapo and not (
             self.enable_sfa_prolog_v3 or (self.use_sparse_c8_sfa and get_ascend_device_type() != AscendDeviceType.A5)
         )


### PR DESCRIPTION
### What this PR does / why we need it?
  On A5 PD decode (consumer) workers with sparse C8 enabled (enable_sparse_c8=True), the enable_sfa_prolog_v3 flag was unconditionally set to True for all consumers with use_sparse_c8_sfa=True, regardless of device type. Since enable_mlapo is disabled whenever enable_sfa_prolog_v3 is True, the mlapo fast path was completely unavailable on A5 consumer C8 nodes — even though the A5 mlapo implementation (sfa_preprocess_with_mlapo) already handles sparse C8.

Fix this by excluding A5 devices from enable_sfa_prolog_v3 so that mlapo can take effect on A5 consumers with sparse C8:
  self.enable_sfa_prolog_v3 = (
      self.is_kv_consumer
      and self.use_sparse_c8_sfa
      and get_ascend_device_type() != AscendDeviceType.A5
  )

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
