### PR TITLE
[CI] del atb  _npu_reshape_and_cache ops

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_store_kv_block.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_store_kv_block.py
@@ -36,39 +36,6 @@ def cal_scatternd(key, key_cache, slot_mapping, block_size):
     return key_expect.npu()
 
 
-# slot_mapping[].shape=torch.Size([4])
-@pytest.mark.parametrize("num_tokens", [16])  # 6398
-@pytest.mark.parametrize("num_head", [1])  # 512
-@pytest.mark.parametrize("block_size", [128])  # 128
-@pytest.mark.parametrize("num_blocks", [1773])  # 1599
-@pytest.mark.parametrize("count", [1])
-def test_siso(num_tokens, num_head, block_size, num_blocks, count):
-    head_size_k = 1
-    key = torch.rand((num_tokens, num_head, head_size_k), dtype=torch.float16).npu()
-    # key = torch.randint(low=0,high=128,size=(num_tokens,head_size_k), dtype=torch.int8 )
-    key_cache = torch.rand((num_blocks, block_size, num_head, head_size_k), dtype=torch.float16).npu()
-    # key_cache = torch.randint(low=0,high=128,size=(num_blocks, block_size, num_head,head_size_k), dtype=torch.int8 )
-
-    slot_list = []
-    for i in range(0, num_tokens):
-        slot_list.append(2 + i)
-    assert num_tokens == len(slot_list)
-    slot_list_np = np.array(slot_list)
-    slot_mapping_npu = torch.from_numpy(slot_list_np).to(torch.int32).npu()
-
-    key_expect = cal_slot(key, key_cache, slot_mapping_npu, block_size)
-
-    warm_up = 0
-    for _ in range(warm_up):
-        torch_npu._npu_reshape_and_cache_siso(key, key_cache, slot_mapping_npu)
-    N = 101
-
-    for _ in range(N):
-        torch_npu._npu_reshape_and_cache_siso(key, key_cache, slot_mapping_npu)
-
-    torch.testing.assert_close(key_expect, key_cache, atol=0.001, rtol=0.1)
-
-
 @pytest.mark.parametrize("num_tokens", [16])  # 6398
 @pytest.mark.parametrize("num_head", [1])  # 512
 @pytest.mark.parametrize("block_size", [128])  # 128
@@ -77,12 +44,11 @@ def test_siso(num_tokens, num_head, block_size, num_blocks, count):
 def test_scatter(num_tokens, num_head, block_size, num_blocks, count):
     head_size_k = 64
     key = torch.randint(low=0, high=128, size=(num_tokens, num_head, head_size_k), dtype=torch.int8).npu()
-    # key = torch.rand((num_tokens, num_head,head_size_k), dtype=torch.float16).npu()
 
     key_cache = torch.randint(
         low=0, high=128, size=(num_blocks * block_size, num_head, head_size_k), dtype=torch.int8
     ).npu()
-    # key_cache = torch.rand((num_blocks* block_size, num_head,head_size_k), dtype=torch.float16).npu()
+
     slot_list = []
     for i in range(0, num_tokens):
         slot_list.append([2 + i])
@@ -105,7 +71,6 @@ def test_scatter(num_tokens, num_head, block_size, num_blocks, count):
 @pytest.mark.parametrize("count", [1])
 def test_myops(num_tokens, num_head, block_size, num_blocks, count):
     head_size_k = 2
-    # key_cache = torch.rand((num_blocks, block_size, num_head,head_size_k), dtype=torch.float16)
     key_cache = torch.randint(low=0, high=128, size=(num_blocks, block_size, num_head, head_size_k), dtype=torch.int8)
     key_cache_npu = key_cache.npu()
 
@@ -116,7 +81,6 @@ def test_myops(num_tokens, num_head, block_size, num_blocks, count):
     slot_list_np = np.array(slot_list)
     slot_mapping_npu = torch.from_numpy(slot_list_np).to(torch.int32).npu()
 
-    # key = torch.rand((num_tokens, num_head,head_size_k), dtype=torch.float16)
     key = torch.randint(low=0, high=128, size=(num_tokens, head_size_k), dtype=torch.int8)
     key_npu = key.npu()
     key_expect = cal_slot(key_npu, key_cache_npu, slot_list_np, block_size)


### PR DESCRIPTION

### What this PR does / why we need it?
Delete the `torch_npu._reshape_and_cache_siso` operator from the test cases. This operator is only used as a benchmark and has a replacement, so its removal will not have an impact.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
nightly test

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
