### PR TITLE
[Misc]Update torch_npu to 2.10.0.post2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For detailed information on supported models, please refer to [supported models]
 - Software:
     - Python >= 3.10, < 3.12
     - CANN == 9.0.0 (For Ascend HDK version, please refer to the [Release Notes](https://www.hiascend.com/document/detail/zh/canncommercial/900/releasenote/releasenote_0000.html))
-    - PyTorch == 2.10.0, torch-npu == 2.10.0
+    - PyTorch == 2.10.0, torch-npu == 2.10.0.post2
     - vLLM (the same version as vllm-ascend)
 
 ## Accessing Ascend NPU

--- a/README.zh.md
+++ b/README.zh.md
@@ -57,7 +57,7 @@ vLLM 昇腾插件 (`vllm-ascend`) 是一个由社区维护的让vLLM在Ascend NP
 - 软件：
     - Python >= 3.10, < 3.12
     - CANN == 9.0.0 (Ascend HDK 版本详见 [版本说明](https://www.hiascend.com/document/detail/zh/canncommercial/900/releasenote/releasenote_0000.html))
-    - PyTorch == 2.10.0, torch-npu == 2.10.0
+    - PyTorch == 2.10.0, torch-npu == 2.10.0.post2
     - vLLM (与vllm-ascend版本一致)
 
 ## 访问昇腾NPU

--- a/docs/hooks/macros_main.py
+++ b/docs/hooks/macros_main.py
@@ -54,7 +54,7 @@ def define_env(env):
     env.variables["main_python_version"] = env.variables.get("main_python_version", ">= 3.10, < 3.13")
     env.variables["main_cann_version"] = env.variables.get("main_cann_version", "9.0.0")
     env.variables["main_pytorch_torch_npu_version"] = env.variables.get(
-        "main_pytorch_torch_npu_version", "2.10.0 / 2.10.0"
+        "main_pytorch_torch_npu_version", "2.10.0 / 2.10.0.post2"
     )
     env.variables["main_triton_ascend_version"] = env.variables.get("main_triton_ascend_version", "3.2.1")
     env.variables["main_vllm_commit"] = main_vllm_commit

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -13,7 +13,7 @@ This document describes how to install vllm-ascend manually.
     |---------------|----------------------------------|-------------------------------------------|
     | Ascend HDK    | Refer to the documentation [CANN 9.0.0](https://www.hiascend.com/document/detail/zh/canncommercial/900/releasenote/releasenote_0000.html) | Required for CANN |
     | CANN          | == 9.0.0                        | Required for vllm-ascend and torch-npu    |
-    | torch-npu     | == 2.10.0                       | Required for vllm-ascend, No need to install manually, it will be auto installed in below steps |
+    | torch-npu     | == 2.10.0.post2                 | Required for vllm-ascend, No need to install manually, it will be auto installed in below steps |
     | torch         | == 2.10.0                       | Required for torch-npu and vllm, No need to install manually, it will be auto installed in below steps |
     | NNAL          | == 9.0.0                        | Required for libatb.so, enables advanced tensor operations |
 

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -28,7 +28,7 @@ This section guides you through container-based environment setup and large mode
     |---------------|----------------------------------|-------------------------------------------|
     | Ascend HDK    | Refer to the documentation [CANN 9.0.0](https://www.hiascend.com/document/detail/zh/canncommercial/900/releasenote/releasenote_0000.html) | Required for CANN |
     | CANN          | == 9.0.0                        | Required for vllm-ascend and torch-npu    |
-    | torch-npu     | == 2.10.0                       | Required for vllm-ascend, No need to install manually, it will be auto installed in below steps |
+    | torch-npu     | == 2.10.0.post2                 | Required for vllm-ascend, No need to install manually, it will be auto installed in below steps |
     | torch         | == 2.10.0                       | Required for torch-npu and vllm, No need to install manually, it will be auto installed in below steps |
     | NNAL          | == 9.0.0                        | Required for libatb.so, enables advanced tensor operations |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,7 +156,7 @@ extra:
   cann_image_tag: 9.0.0-910b-ubuntu22.04-py3.12
   main_python_version: ">= 3.10, < 3.13"
   main_cann_version: "9.0.0"
-  main_pytorch_torch_npu_version: "2.10.0 / 2.10.0"
+  main_pytorch_torch_npu_version: "2.10.0 / 2.10.0.post2"
   main_triton_ascend_version: "3.2.1"
   social:
     - icon: fontawesome/brands/github

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires = [
     "setuptools>=64",
     "setuptools-scm>=8",
     "transformers==5.13.0",
-    "torch-npu==2.10.0",
+    "torch-npu==2.10.0.post2",
     "torch==2.10.0",
     "torchvision",
     "wheel",

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ psutil
 setuptools>=64
 setuptools-scm>=8
 torch==2.10.0
-torch-npu==2.10.0
+torch-npu==2.10.0.post2
 torchvision==0.25.0
 torchaudio==2.10.0
 triton-ascend==3.2.1


### PR DESCRIPTION
### What this PR does / why we need it?
The `torch_npu==2.10.0.post2` can fix inconsistent output when enable dynamic eplb in`tests/e2e/pull_request/two_card/test_qwen3_moe_eplb.py::test_qwen3_moe_w8a8_distributed_tp2_ep_dynamic_eplb` for A3 560T (A3 752T is fine).

Related CI pipeline error: https://github.com/vllm-project/vllm-ascend/actions/runs/29082193253/job/86328339837?pr=11666

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/e5588e49bc2642670116664a7fc4096e27adb179
