### PR TITLE
[Performance][Worker] Add fine-grained replay-sync (opt-in, default off)

### DIFF
--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -21,6 +21,7 @@ from vllm.logger import logger
 from vllm.platforms import current_platform
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+import vllm_ascend.envs as envs_ascend
 
 from ..utils import weak_ref_tensors
 
@@ -114,7 +115,41 @@ class ACLGraphWrapper:
         self.concrete_aclgraph_entries: dict[BatchDescriptor, ACLGraphEntry] = {}
         self.enable_enpu = enable_enpu
         self.use_eagle = use_eagle
+        # Fine-grained replay-sync (VLLM_ASCEND_FINE_GRAIN_REPLAY_SYNC): per
+        # batch_descriptor double-buffered replay-done events + step counter.
+        # After each replay, the slot for the current step is recorded on
+        # current_stream. The NEXT step's update waits the PREVIOUS step's
+        # replay-done event on update_stream. Double-buffering avoids a single
+        # reused event being overwritten before its wait is consumed.
+        #
+        # State machine (two slots so update[i] waits replay[i-1], NOT replay[i]):
+        #   _fg_pending_wait_event : the event the CURRENT step's update should
+        #                            wait = the PREVIOUS step's replay event.
+        #   _fg_just_recorded      : the event the CURRENT step's replay just
+        #                            recorded; promoted to pending at the start
+        #                            of the NEXT step's __call__.
+        # __call__ order: promote just_recorded -> pending; replay; record new.
+        self._fg_replay_events: dict[BatchDescriptor, list[torch.npu.Event]] = {}
+        self._fg_replay_step: dict[BatchDescriptor, int] = {}
+        self._fg_pending_wait_event: torch.npu.Event | None = None
+        self._fg_just_recorded: torch.npu.Event | None = None
         _acl_graph_wrappers.add(self)
+
+    def _fg_get_slots(self, batch_descriptor: BatchDescriptor) -> list[torch.npu.Event]:
+        slots = self._fg_replay_events.get(batch_descriptor)
+        if slots is None:
+            slots = [torch.npu.Event() for _ in range(2)]
+            self._fg_replay_events[batch_descriptor] = slots
+            self._fg_replay_step[batch_descriptor] = 0
+        return slots
+
+    def consume_fg_pending_wait_event(self) -> torch.npu.Event | None:
+        """Return (and clear) the replay-done event the next update must wait
+        on. Called by the model_runner right before issuing the graph-param
+        update on update_stream."""
+        ev = self._fg_pending_wait_event
+        self._fg_pending_wait_event = None
+        return ev
 
     def __getattr__(self, key: str):
         # allow accessing the attributes of the runnable.
@@ -261,9 +296,25 @@ class ACLGraphWrapper:
         # When FULL + EAGLE draft (merge path), replay does not need this barrier.
         is_draft_eagle = _EXTRA_CTX.is_draft_model and self.use_eagle
         need_sync = self.runtime_mode == CUDAGraphMode.FULL and not is_draft_eagle
-        if not self.enable_enpu and need_sync:
+        fg_sync = envs_ascend.VLLM_ASCEND_FINE_GRAIN_REPLAY_SYNC
+        if fg_sync and need_sync:
+            # Promote the PREVIOUS step's just-recorded replay event to be the
+            # one THIS step's update will wait. This makes update[i] wait
+            # replay[i-1] (cross-iteration), never replay[i] (same-iteration,
+            # which would deadlock the ExternalEvent value-rendezvous).
+            self._fg_pending_wait_event = self._fg_just_recorded
+            self._fg_just_recorded = None
+        elif not self.enable_enpu and need_sync:
             torch.npu.current_stream().synchronize()
         entry.aclgraph.replay()
+        if fg_sync and need_sync:
+            # Record a replay-done marker on current_stream (double-buffered,
+            # cycled per step). It becomes the NEXT step's pending-wait event.
+            slots = self._fg_get_slots(batch_descriptor)
+            step = self._fg_replay_step[batch_descriptor]
+            slots[step % 2].record(torch.npu.current_stream())
+            self._fg_replay_step[batch_descriptor] = step + 1
+            self._fg_just_recorded = slots[step % 2]
         return entry.output
 
 

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -20,8 +20,8 @@ from vllm.forward_context import BatchDescriptor, get_forward_context
 from vllm.logger import logger
 from vllm.platforms import current_platform
 
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 import vllm_ascend.envs as envs_ascend
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 
 from ..utils import weak_ref_tensors
 

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -122,8 +122,7 @@ env_variables: dict[str, Callable[[], Any]] = {
     # device side WITHOUT blocking the host and WITHOUT touching the same-step
     # update[i]/replay[i] value-rendezvous (which must stay concurrent, see
     # optimization-record doc 12.3.1). Default 0 = baseline barrier.
-    "VLLM_ASCEND_FINE_GRAIN_REPLAY_SYNC": lambda: bool(
-        int(os.getenv("VLLM_ASCEND_FINE_GRAIN_REPLAY_SYNC", "0"))),
+    "VLLM_ASCEND_FINE_GRAIN_REPLAY_SYNC": lambda: bool(int(os.getenv("VLLM_ASCEND_FINE_GRAIN_REPLAY_SYNC", "0"))),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -110,6 +110,20 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
+    # EXPERIMENTAL: replace the pre-replay host current_stream().synchronize()
+    # with a fine-grained, device-side cross-iteration dependency. The baseline
+    # barrier drains the whole current_stream every step to prevent update[i+1]
+    # from clobbering the param slot while replay[i] is still reading it (same
+    # task-group handle, single slot). This opt-in instead: after each replay,
+    # records a reusable torch.npu.Event on current_stream (double-buffered,
+    # cycled per step); before the NEXT step's graph-param update, makes
+    # update_stream wait the PREVIOUS step's replay-done event. That protects
+    # the cross-iteration slot race (update[i+1] vs replay[i] read) on the
+    # device side WITHOUT blocking the host and WITHOUT touching the same-step
+    # update[i]/replay[i] value-rendezvous (which must stay concurrent, see
+    # optimization-record doc 12.3.1). Default 0 = baseline barrier.
+    "VLLM_ASCEND_FINE_GRAIN_REPLAY_SYNC": lambda: bool(
+        int(os.getenv("VLLM_ASCEND_FINE_GRAIN_REPLAY_SYNC", "0"))),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -101,9 +101,10 @@ from vllm.v1.worker.ubatch_utils import (
 )
 from vllm.v1.worker.utils import AttentionGroup, select_common_block_size
 
+import vllm_ascend.envs as envs_ascend
+
 # yapf: enable
 from vllm_ascend.ascend_config import get_ascend_config
-import vllm_ascend.envs as envs_ascend
 from vllm_ascend.attention.attention_v1 import AscendAttentionBackend, AscendAttentionState
 from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSACPMetadataBuilder
 from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFADCPMetadataBuilder

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -103,6 +103,7 @@ from vllm.v1.worker.utils import AttentionGroup, select_common_block_size
 
 # yapf: enable
 from vllm_ascend.ascend_config import get_ascend_config
+import vllm_ascend.envs as envs_ascend
 from vllm_ascend.attention.attention_v1 import AscendAttentionBackend, AscendAttentionState
 from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSACPMetadataBuilder
 from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFADCPMetadataBuilder
@@ -2958,6 +2959,19 @@ class NPUModelRunner(GPUModelRunner):
         ):
             if self.enable_enpu:
                 torch.npu.current_stream().synchronize()
+            elif envs_ascend.VLLM_ASCEND_FINE_GRAIN_REPLAY_SYNC and isinstance(
+                self.model, ACLGraphWrapper
+            ):
+                # Fine-grained cross-iteration sync: make update_stream wait
+                # the PREVIOUS step's replay-done event before writing the
+                # shared param slot. This replaces the host current_stream
+                # drain with a device-side wait, so the host is not blocked and
+                # update[i+1] still cannot clobber the slot while replay[i] is
+                # reading it. Same-step update[i]/replay[i] concurrency is
+                # untouched (the ExternalEvent value-rendezvous still drives it).
+                wait_ev = self.model.consume_fg_pending_wait_event()
+                if wait_ev is not None:
+                    self.update_stream.wait_event(wait_ev)
 
             assert positions is not None
             update_full_graph_params(


### PR DESCRIPTION
### What this PR does / why we need it?

This PR introduces an **opt-in, default-off** experimental flag `VLLM_ASCEND_FINE_GRAIN_REPLAY_SYNC` that replaces the pre-replay host-side `current_stream().synchronize()` barrier with a **device-side cross-iteration dependency**, so the host is no longer blocked while still protecting the graph-param slot race.

**Background.** In FULL graph mode (non-ENPU, non-EAGLE-draft-merge), `ACLGraphWrapper.__call__` calls `torch.npu.current_stream().synchronize()` before every `aclgraph.replay()`. This host barrier drains the entire current stream each step just to prevent the *next* step's graph-param update (`update[i+1]`) from clobbering the shared param slot while `replay[i]` is still reading it. The barrier is conservative: it blocks the host on every replay even though the actual hazard is a narrow cross-iteration slot race.

**What this PR changes.** When the flag is on, instead of the host barrier:

1. After each `replay()`, record a reusable `torch.npu.Event` on `current_stream` — double-buffered (two slots) and cycled per step, keyed per `batch_descriptor`.
2. At the start of the **next** step's `__call__`, promote the previous step's just-recorded event to be the one the update will wait on.
3. Right before issuing the graph-param update on `update_stream`, the model runner makes `update_stream.wait_event(<previous step's replay-done event>)`.

**Why this is safe (the key invariant).** `update[i]` waits `replay[i-1]` (**cross-iteration**), never `replay[i]` (same-step). The same-step `update[i]`/`replay[i]` concurrency — driven by the existing `ExternalEvent` value-rendezvous — is left completely untouched, so this does **not** introduce a same-iteration circular wait. The double-buffering + two-slot state machine (`_fg_pending_wait_event` / `_fg_just_recorded`) ensures `update[i]` consumes the *previous* step's event, not the current one (the v1 single-variable bug that deadlocked at same-step is fixed by promoting `just_recorded -> pending` at the start of `__call__`).

**Scope.**
- Default `0` -> baseline host barrier; no behavior change for existing users.
- ENPU path and EAGLE draft merge path are mutually exclusive / unchanged via the existing `need_sync` (`runtime_mode == FULL and not is_draft_eagle`).
- Touches v1 model runner only (`model_runner_v1.py`); v2 runner is unaffected.

### Does this PR introduce _any_ user-facing change?

Yes — a new **opt-in** environment variable `VLLM_ASCEND_FINE_GRAIN_REPLAY_SYNC` (default `0`, off). No change to default behavior. Users who want to try the fine-grained sync set `VLLM_ASCEND_FINE_GRAIN_REPLAY_SYNC=1`; otherwise behavior is identical to before.

### How was this patch tested?

**Benchmark.** `evalscope perf` stress test, model `qwen3-8b`, 512 output tokens, 1024 prompt length, random dataset, streaming. Validated on `releases/v0.22.1rc` (stable: 0 deadlock, 0 error across the full concurrency sweep), then adapted to `main`.

Command (model/tokenizer paths redacted):

```bash
evalscope perf \
  --parallel 1 4 8 16 32 64 \
  --number 40 80 80 160 320 640 \
  --warmup-num 20 \
  --model <your-model> \
  --url http://127.0.0.1:5001/v1/chat/completions \
  --api openai \
  --stream \
  --dataset random \
  --max-tokens 512 \
  --min-tokens 512 \
  --min-prompt-length 1024 \
  --max-prompt-length 1024 \
  --prefix-length 0 \
  --tokenizer-path <path-to-tokenizer> \
  --outputs-dir "./my_output"
```

Decode-phase TPOT drops across **all** concurrency levels, with the **most pronounced relative gain at low-to-mid concurrency (c=1/4/8)** — e.g. c=1 improves 5.6% (10.27 -> 9.69 ms). This matches the mechanism: at low concurrency the host has little other work to overlap, so releasing it from the per-step barrier yields the clearest per-request latency win; the absolute gain grows with concurrency as the freed host overlaps more. Gen tok/s improves across all levels and Success Rate stays 100%.

**Before** (`VLLM_ASCEND_FINE_GRAIN_REPLAY_SYNC=0`):

| Conc. | Rate | RPS | Avg Lat.(s) | P99 Lat.(s) | Avg TTFT(ms) | P99 TTFT(ms) | Avg TPOT(ms) | P99 TPOT(ms) | Gen. tok/s | Success Rate |
|-------|------|-----|-------------|-------------|--------------|--------------|--------------|--------------|------------|--------------|
| 1     | INF  | 0.1882 | 5.312 | 5.400 | 64.20 | 68.46 | 10.27 | 10.44 | 96.38 | 100.0% |
| 4     | INF  | 0.6957 | 5.748 | 5.830 | 144.67 | 209.59 | 10.97 | 11.19 | 356.19 | 100.0% |
| 8     | INF  | 1.2423 | 6.436 | 6.500 | 225.90 | 375.95 | 12.15 | 12.48 | 636.04 | 100.0% |
| 16    | INF  | 2.1451 | 7.453 | 7.820 | 286.97 | 686.71 | 14.02 | 14.42 | 1098.31 | 100.0% |
| 32    | INF  | 3.3527 | 9.533 | 10.510 | 383.09 | 1303.80 | 17.91 | 18.41 | 1716.60 | 100.0% |
| 64    | INF  | 4.9483 | 12.906 | 15.110 | 462.19 | 2509.69 | 24.35 | 25.12 | 2533.54 | 100.0% |

**After** (`VLLM_ASCEND_FINE_GRAIN_REPLAY_SYNC=1`):

| Conc. | Rate | RPS | Avg Lat.(s) | P99 Lat.(s) | Avg TTFT(ms) | P99 TTFT(ms) | Avg TPOT(ms) | P99 TPOT(ms) | Gen. tok/s | Success Rate |
|-------|------|-----|-------------|-------------|--------------|--------------|--------------|--------------|------------|--------------|
| 1     | INF  | 0.1994 | 5.015 | 5.060 | 64.19 | 72.91 | 9.69 | 9.77 | 102.08 | 100.0% |
| 4     | INF  | 0.7116 | 5.620 | 5.640 | 146.14 | 199.81 | 10.71 | 10.85 | 364.33 | 100.0% |
| 8     | INF  | 1.2783 | 6.254 | 6.320 | 207.35 | 377.66 | 11.83 | 12.07 | 654.50 | 100.0% |
| 16    | INF  | 2.2058 | 7.248 | 7.570 | 298.01 | 674.88 | 13.60 | 14.00 | 1129.38 | 100.0% |
| 32    | INF  | 3.4529 | 9.256 | 10.260 | 367.08 | 1305.69 | 17.40 | 17.89 | 1767.89 | 100.0% |
| 64    | INF  | 5.0731 | 12.590 | 14.660 | 465.85 | 2443.14 | 23.73 | 24.36 | 2597.41 | 100.0% |

**Summary (Success Rate 100% across all levels, both runs):**

| Conc. | Gen tok/s (before -> after) | Avg TPOT ms (before -> after) |
|-------|-----------------------------|------------------------------|
| 1     | 96.38 -> 102.08             | 10.27 -> 9.69                |
| 4     | 356.19 -> 364.33            | 10.97 -> 10.71               |
| 8     | 636.04 -> 654.50            | 12.15 -> 11.83               |
| 16    | 1098.31 -> 1129.38         | 14.02 -> 13.60               |
| 32    | 1716.60 -> 1767.89         | 17.91 -> 17.40               |
| 64    | 2533.54 -> 2597.41         | 24.35 -> 23.73               |

No unit test added: this is a device-side synchronization micro-optimization gated behind a default-off env flag; correctness is validated end-to-end by the 100%-success-rate stress sweep with no deadlock across all concurrency levels. CI verification is requested.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
