### PR TITLE
[Feature] Add SwigluOAI activation variant to dispatch_ffn_combine

### DIFF
--- a/csrc/mc2/dispatch_ffn_combine/dispatch_ffn_combine_torch_adpt.h
+++ b/csrc/mc2/dispatch_ffn_combine/dispatch_ffn_combine_torch_adpt.h
@@ -32,11 +32,14 @@ std::tuple<at::Tensor&, at::Tensor&> dispatch_ffn_combine(
     at::Tensor& out,
     at::Tensor& expert_token_nums,
     const c10::optional<at::Tensor>& x_active_mask,
-    double swiglu_limit
+    double swiglu_limit,
+    double swiglu_alpha = 0.0
 ) {
     char *group_ep_ptr = const_cast<char *>(group.data());
     bool is_int8 = weight1[0].dtype() == at::kChar;
     bool is_int4 = weight1[0].dtype() == at::kInt;
+    TORCH_CHECK(is_int8 || swiglu_alpha == 0.0,
+        "swiglu_alpha is only supported for int8 (W8A8) quantization path.");
     if (is_int8) {
         EXEC_NPU_CMD(aclnnDispatchFFNCombine,
                  x,
@@ -50,6 +53,7 @@ std::tuple<at::Tensor&, at::Tensor&> dispatch_ffn_combine(
                  group_ep_ptr,
                  max_output_size,
                  swiglu_limit,
+                 swiglu_alpha,
                  out,
                  expert_token_nums);
     } else if (is_int4){

--- a/csrc/mc2/dispatch_ffn_combine/op_host/dispatch_ffn_combine_def.cpp
+++ b/csrc/mc2/dispatch_ffn_combine/op_host/dispatch_ffn_combine_def.cpp
@@ -78,6 +78,8 @@ class DispatchFFNCombine : public OpDef {
     this->Attr("transB").AttrType(OPTIONAL).Bool(false);
     this->Attr("weightNz").AttrType(OPTIONAL).Bool(false);
     this->Attr("swigluLimit").AttrType(OPTIONAL).Float(0.0f);
+    // SwigluOAI alpha: >0 uses (up+1)*gate*sigmoid(gate*alpha); ==0 falls back to standard swiglu (M2.7 compatible)
+    this->Attr("swigluAlpha").AttrType(OPTIONAL).Float(0.0f);
 
     OpAICoreConfig aicore_config;
     aicore_config.DynamicCompileStaticFlag(true)

--- a/csrc/mc2/dispatch_ffn_combine/op_host/dispatch_ffn_combine_tiling.cpp
+++ b/csrc/mc2/dispatch_ffn_combine/op_host/dispatch_ffn_combine_tiling.cpp
@@ -36,6 +36,7 @@ namespace {
     constexpr uint32_t ATTR_IS_TRANS_B = 2;
     constexpr uint32_t ATTR_WEIGHT_NZ = 3;
     constexpr uint32_t ATTR_SWIGLU_LIMIT = 4;
+    constexpr uint32_t ATTR_SWIGLU_ALPHA = 5;   // SwigluOAI alpha
     constexpr uint64_t INIT_TILINGKEY = 1000000;
     constexpr uint64_t TILINGKEY_TRANS_B = 1U;
     constexpr uint64_t TILINGKEY_WEIGHT_NZ = 10;
@@ -95,6 +96,7 @@ static ge::graphStatus DispatchFFNCombineCheckAttrAndSetTiling(gert::TilingConte
     auto is_trans_b = attrs->GetAttrPointer<bool>(ATTR_IS_TRANS_B);
     auto weight_nz = attrs->GetAttrPointer<bool>(ATTR_WEIGHT_NZ);
     auto swiglu_limit = attrs->GetAttrPointer<float>(ATTR_SWIGLU_LIMIT);
+    auto swiglu_alpha = attrs->GetAttrPointer<float>(ATTR_SWIGLU_ALPHA);
     OP_TILING_CHECK(groupPtr == nullptr || strlen(groupPtr) == 0,
     OP_LOGE(K_INNER_DEBUG, "group is invalid."), return GRAPH_FAILED);
 
@@ -107,6 +109,7 @@ static ge::graphStatus DispatchFFNCombineCheckAttrAndSetTiling(gert::TilingConte
     info.isTransposeB = *is_trans_b;
     info.isWeightNz = *weight_nz;
     info.swigluLimit = swiglu_limit != nullptr ? *swiglu_limit : 0.0f;
+    info.swigluAlpha = swiglu_alpha != nullptr ? *swiglu_alpha : 0.0f;
 
     int64_t rankSize;
     (void)ge::HcomTopoInfo::Instance().GetGroupRankSize(groupPtr, rankSize);

--- a/csrc/mc2/dispatch_ffn_combine/op_host/op_api/aclnn_dispatch_ffn_combine.cpp
+++ b/csrc/mc2/dispatch_ffn_combine/op_host/op_api/aclnn_dispatch_ffn_combine.cpp
@@ -45,7 +45,7 @@ extern aclnnStatus aclnnInnerDispatchFFNCombineGetWorkspaceSize(const aclTensor*
                                                          const aclTensor* expertId, const aclTensorList* scale1, const aclTensorList* scale2,
                                                          const aclTensor* probs, const aclTensor* xActiveMask,
                                                          const char* group, int64_t maxOutputSize,
-                                                         bool transB, bool weightNz, double swigluLimit,
+                                                         bool transB, bool weightNz, double swigluLimit, double swigluAlpha,
                                                          const aclTensor* out, const aclTensor* expertTokenNums,
                                                          uint64_t* workspaceSize, aclOpExecutor** executor);
 extern aclnnStatus aclnnInnerDispatchFFNCombine(void *workspace, uint64_t workspaceSize,
@@ -57,7 +57,7 @@ extern "C" void __attribute__((weak)) NnopbaseSetHcclServerType(void *executor, 
 aclnnStatus aclnnDispatchFFNCombineGetWorkspaceSize(const aclTensor* x, const aclTensorList* weight1, const aclTensorList* weight2,
                                                     const aclTensor* expertId, const aclTensorList* scale1, const aclTensorList* scale2,
                                                     const aclTensor* probs, const aclTensor* xActiveMask,
-                                                    const char* group, int64_t maxOutputSize, double swigluLimit,
+                                                    const char* group, int64_t maxOutputSize, double swigluLimit, double swigluAlpha,
                                                     const aclTensor* out, const aclTensor* expertTokenNums,
                                                     uint64_t* workspaceSize, aclOpExecutor** executor)
 {
@@ -65,7 +65,7 @@ aclnnStatus aclnnDispatchFFNCombineGetWorkspaceSize(const aclTensor* x, const ac
     bool weightNz = true;
 
     aclnnStatus ret = aclnnInnerDispatchFFNCombineGetWorkspaceSize(x, weight1, weight2, expertId, scale1, scale2, probs, xActiveMask, group,
-                                                                    maxOutputSize, transB, weightNz, swigluLimit,
+                                                                    maxOutputSize, transB, weightNz, swigluLimit, swigluAlpha,
                                                                     out, expertTokenNums, workspaceSize, executor);
     return ret;
 }

--- a/csrc/mc2/dispatch_ffn_combine/op_host/op_api/aclnn_dispatch_ffn_combine.h
+++ b/csrc/mc2/dispatch_ffn_combine/op_host/op_api/aclnn_dispatch_ffn_combine.h
@@ -42,7 +42,7 @@ extern "C" {
 __attribute__((visibility("default"))) aclnnStatus aclnnDispatchFFNCombineGetWorkspaceSize(const aclTensor* x, const aclTensorList* weight1, const aclTensorList* weight2,
                                                                                         const aclTensor* expertId, const aclTensorList* scale1, const aclTensorList* scale2,
                                                                                         const aclTensor* probs, const aclTensor* xActiveMask,
-                                                                                        const char* group, int64_t maxOutputSize, double swigluLimit,
+                                                                                        const char* group, int64_t maxOutputSize, double swigluLimit, double swigluAlpha,
                                                                                         const aclTensor* out, const aclTensor* expertTokenNums,
                                                                                         uint64_t* workspaceSize, aclOpExecutor** executor);
 

--- a/csrc/mc2/dispatch_ffn_combine/op_kernel/dispatch_ffn_combine.h
+++ b/csrc/mc2/dispatch_ffn_combine/op_kernel/dispatch_ffn_combine.h
@@ -104,6 +104,7 @@ private:
     int32_t EP;
     int32_t listLen;
     float swigluLimit;
+    float swigluAlpha;
 
     optiling::MoeInitRoutingQuantV2TilingData moeInitRoutingQuantV2TilingData;
     uint64_t initRoutingQuantTilingKey;
@@ -146,6 +147,7 @@ __aicore__ inline void DispatchFFNCombine<TemplateMMA2ACFunc>::Init(GM_ADDR xGM,
     maxOutputSize = tilingData.dispatchFFNCombineInfo.maxOutputSize;
     listLen = tilingData.dispatchFFNCombineInfo.listLen;
     swigluLimit = tilingData.dispatchFFNCombineInfo.swigluLimit;
+    swigluAlpha = tilingData.dispatchFFNCombineInfo.swigluAlpha;
 
     m0 = tilingData.cocTiling.m0;
     k0 = tilingData.cocTiling.k0;
@@ -281,7 +283,7 @@ __aicore__ inline void DispatchFFNCombine<TemplateMMA2ACFunc>::Process()
         outGM_, layoutD1, layoutD2,
         expertIdGM_, moeInitRoutingQuantV2Scale, moeInitRoutingQuantV2Offset,
         expertTokensBeforeCapacity, probs_,
-        workspaceGM_, gmExpertTokenNums_, ubMoveNum, xActiveMaskGM_, moeInitRoutingQuantV2TilingData, swigluLimit};
+        workspaceGM_, gmExpertTokenNums_, ubMoveNum, xActiveMaskGM_, moeInitRoutingQuantV2TilingData, swigluLimit, swigluAlpha};
     //Call kernel
     MatmulKernel kernel(params);
     kernel(params);

--- a/csrc/mc2/dispatch_ffn_combine/op_kernel/dispatch_ffn_combine_kernel.hpp
+++ b/csrc/mc2/dispatch_ffn_combine/op_kernel/dispatch_ffn_combine_kernel.hpp
@@ -140,6 +140,7 @@ public:
         uint32_t epilogueGranularity;
         optiling::MoeInitRoutingQuantV2TilingData moeInitRoutingQuantV2TilingData;
         float swigluLimit;
+        float swigluAlpha;
         //--------------
 
         // Methods
@@ -164,7 +165,8 @@ public:
             GM_ADDR ptrWorkspace_, GM_ADDR gmExpertTokenNums_, int32_t ubMoveNum_,
             GM_ADDR ptrXActiveMask_,
             optiling::MoeInitRoutingQuantV2TilingData moeInitRoutingQuantV2TilingData_,
-            float swigluLimit_
+            float swigluLimit_,
+            float swigluAlpha_
         ) : problemShape(problemShape_),
             EP(EP_), listLen(listLen_), expertPerRank(expertPerRank_), maxOutputSize(maxOutputSize_),
             rank(rank_), rankSize(rankSize_), topK(topK_),
@@ -182,7 +184,8 @@ public:
             ptrWorkspace(ptrWorkspace_), ptrExpertTokenNums(gmExpertTokenNums_), ubMoveNum(ubMoveNum_),
             ptrXActiveMask(ptrXActiveMask_),
             moeInitRoutingQuantV2TilingData(moeInitRoutingQuantV2TilingData_),
-            swigluLimit(swigluLimit_)
+            swigluLimit(swigluLimit_),
+            swigluAlpha(swigluAlpha_)
         {
         }
     };
@@ -928,7 +931,7 @@ private:
             int64_t gmOffsetC = layoutC.GetOffset(offsetC);
             int64_t gmOffsetD = params.layoutD1.GetOffset(offsetC);
             blockEpilogue1(gmC[gmOffsetC], shapeC, gmPerTokenScale1[rowStartThisCore], gmPermutedToken[gmOffsetD],
-                gmPerTokenScale2[rowStartThisCore], resource, params.epilogueCoreNum, params.swigluLimit, params.problemShape.k());
+                gmPerTokenScale2[rowStartThisCore], resource, params.epilogueCoreNum, params.swigluLimit, params.swigluAlpha, params.problemShape.k());
         }
         AscendC::SyncAll<true>();
         // Synchronization signal: SwiGLU notifies GMM2 [1]
@@ -947,7 +950,7 @@ private:
                 int64_t gmOffsetC = layoutC.GetOffset(offsetC);
                 int64_t gmOffsetD = params.layoutD1.GetOffset(offsetC);
                 blockEpilogue1(gmC[gmOffsetC], shapeC, gmPerTokenScale1[rowStartThisCore], gmPermutedToken[gmOffsetD],
-                    gmPerTokenScale2[rowStartThisCore], resource, coreNum, params.swigluLimit, params.problemShape.k());
+                    gmPerTokenScale2[rowStartThisCore], resource, coreNum, params.swigluLimit, params.swigluAlpha, params.problemShape.k());
             }
             AscendC::SyncAll<true>();
             // Synchronization signal: SwiGLU notifies GMM2 [2]

--- a/csrc/mc2/dispatch_ffn_combine/op_kernel/dispatch_ffn_combine_tiling.h
+++ b/csrc/mc2/dispatch_ffn_combine/op_kernel/dispatch_ffn_combine_tiling.h
@@ -32,6 +32,7 @@ struct DispatchFFNCombineInfo {
     uint32_t worldSize;
     uint32_t listLen;
     float swigluLimit;
+    float swigluAlpha;   // SwigluOAI alpha; 0.0=standard swiglu (compatible)
 };
 
 struct CoCTiling {

--- a/csrc/mc2/dispatch_ffn_combine/op_kernel/utils/block_epilogue_pertoken_swiglu.hpp
+++ b/csrc/mc2/dispatch_ffn_combine/op_kernel/utils/block_epilogue_pertoken_swiglu.hpp
@@ -150,6 +150,7 @@ public:
 
         uint32_t epilogueCoreNum = 40,
         float swigluLimit = 0.0f,
+        float swigluAlpha = 0.0f,
         uint32_t blockK = 1,
         Callback &&callback = Callback{}
     )
@@ -225,25 +226,54 @@ public:
             AscendC::PipeBarrier<PIPE_V>();
 
             // swiglu limit clamp
+            // gate: ClampMax(limit) [single-sided max, same for SwigluOAI/standard]
+            // up  : ClampMin(-limit) [standard, min side only]; SwigluOAI(alpha>0) additionally adds ClampMax(limit) [both sides]
             if (swigluLimit > 0.0f) {
                 AscendC::ClampMax(ubCFp32, ubCFp32, sharedTmpBuffer, swigluLimit, blockN);
                 AscendC::PipeBarrier<PIPE_V>();
                 AscendC::ClampMin(ubCFp32[ChunkTileLen], ubCFp32[ChunkTileLen], sharedTmpBuffer, -1.0f * swigluLimit, ChunkTileLen);
-                //AscendC::ClampMin(ubCFp32, ubCFp32, sharedTmpBuffer, -1.0f * swigluLimit, ChunkTileLen);
+                AscendC::PipeBarrier<PIPE_V>();
+                // SwigluOAI: up double-sided clamp (adds max side). alpha==0 takes standard path keeping original behavior (up min side only) for bit compatibility.
+                if (swigluAlpha > 0.0f) {
+                    AscendC::ClampMax(ubCFp32[ChunkTileLen], ubCFp32[ChunkTileLen], sharedTmpBuffer, swigluLimit, ChunkTileLen);
+                    AscendC::PipeBarrier<PIPE_V>();
+                }
+            }
+
+            // Activation section:
+            //   alpha > 0 -> SwigluOAI: out = (up+1) * gate * sigmoid(gate*alpha)
+            //   alpha == 0 -> standard SwiGLU: out = silu(gate) * up   (bit-compatible with legacy models, e.g. M2.7)
+            // Layout: ubCFp32[0:ChunkTileLen]=gate, ubCFp32[ChunkTileLen:2*ChunkTileLen]=up (halves)
+            // Result written back to ubCFp32ChunkN (length ChunkTileLen). up original value is not read afterwards, in-place +1 is safe.
+            if (swigluAlpha > 0.0f) {
+                // gate*sigmoid(gate*alpha) = gate / (1 + exp(-alpha*gate))
+                AscendC::Muls(ubCFp32ChunkN, ubCFp32, -1.0f * swigluAlpha, ChunkTileLen);   // t = -alpha*gate  (alpha feeds into sigmoid)
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Exp(ubCFp32ChunkN, ubCFp32ChunkN, ChunkTileLen);                   // exp(-alpha*gate)
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Adds(ubCFp32ChunkN, ubCFp32ChunkN, 1.0f, ChunkTileLen);            // 1 + exp(-alpha*gate)
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Div(ubCFp32ChunkN, ubCFp32, ubCFp32ChunkN, ChunkTileLen);          // gate*sigmoid(alpha*gate) = glu
+                AscendC::PipeBarrier<PIPE_V>();
+                // (up + 1.0)
+                AscendC::Adds(ubCFp32[ChunkTileLen], ubCFp32[ChunkTileLen], 1.0f, ChunkTileLen);
+                AscendC::PipeBarrier<PIPE_V>();
+                // out = glu * (up+1)
+                AscendC::Mul(ubCFp32ChunkN, ubCFp32ChunkN, ubCFp32[ChunkTileLen], ChunkTileLen);
+                AscendC::PipeBarrier<PIPE_V>();
+            } else {
+                // standard SwiGLU: silu(gate)*up  (original implementation, alpha==0 bit-compatible)
+                AscendC::Muls(ubCFp32ChunkN, ubCFp32, -1.0f, ChunkTileLen);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Exp(ubCFp32ChunkN, ubCFp32ChunkN, ChunkTileLen);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Adds(ubCFp32ChunkN, ubCFp32ChunkN, 1.0f, ChunkTileLen);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Div(ubCFp32ChunkN, ubCFp32, ubCFp32ChunkN, ChunkTileLen);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Mul(ubCFp32ChunkN, ubCFp32ChunkN, ubCFp32[ChunkTileLen], ChunkTileLen);
                 AscendC::PipeBarrier<PIPE_V>();
             }
-            
-            // Swiglu computation process
-            AscendC::Muls(ubCFp32ChunkN, ubCFp32, -1.0f, ChunkTileLen);
-            AscendC::PipeBarrier<PIPE_V>();
-            AscendC::Exp(ubCFp32ChunkN, ubCFp32ChunkN, ChunkTileLen);
-            AscendC::PipeBarrier<PIPE_V>();
-            AscendC::Adds(ubCFp32ChunkN, ubCFp32ChunkN, 1.0f, ChunkTileLen);
-            AscendC::PipeBarrier<PIPE_V>();
-            // TODO: confirm whether the division impacts subsequent data
-            AscendC::Div(ubCFp32ChunkN, ubCFp32, ubCFp32ChunkN, ChunkTileLen);
-            AscendC::PipeBarrier<PIPE_V>();
-            AscendC::Mul(ubCFp32ChunkN, ubCFp32ChunkN, ubCFp32[ChunkTileLen], ChunkTileLen);
             
             // Quantization process; difference between the two approaches
             AscendC::PipeBarrier<PIPE_V>();

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -2268,7 +2268,7 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
     ops.def(
         "dispatch_ffn_combine(Tensor x, Tensor[] weight1, Tensor[] weight2, Tensor expert_idx,"
         "                     Tensor[] scale1, Tensor[] scale2, Tensor[] bias1, Tensor[] bias2, Tensor probs, str group,"
-        "                     int max_output_size, Tensor! out, Tensor! expert_token_nums, Tensor? x_active_mask=None, float swiglu_limit=1000000.0) -> (Tensor out, Tensor expert_token_nums)"
+        "                     int max_output_size, Tensor! out, Tensor! expert_token_nums, Tensor? x_active_mask=None, float swiglu_limit=1000000.0, float swiglu_alpha=0.0) -> (Tensor out, Tensor expert_token_nums)"
     );
     ops.impl("dispatch_ffn_combine", torch::kPrivateUse1, &vllm_ascend::dispatch_ffn_combine);
 

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -3079,7 +3079,7 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
     ops.def(
         "dispatch_ffn_combine(Tensor x, Tensor[] weight1, Tensor[] weight2, Tensor expert_idx,"
         "                     Tensor[] scale1, Tensor[] scale2, Tensor[] bias1, Tensor[] bias2, Tensor probs, str group,"
-        "                     int max_output_size, Tensor! out, Tensor! expert_token_nums, Tensor? x_active_mask=None, float swiglu_limit=1000000.0) -> (Tensor out, Tensor expert_token_nums)"
+        "                     int max_output_size, Tensor! out, Tensor! expert_token_nums, Tensor? x_active_mask=None, float swiglu_limit=1000000.0, float swiglu_alpha=0.0) -> (Tensor out, Tensor expert_token_nums)"
     );
     ops.impl("dispatch_ffn_combine", torch::kPrivateUse1, &vllm_ascend::dispatch_ffn_combine);
 

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -199,7 +199,8 @@ std::tuple<at::Tensor&, at::Tensor&> dispatch_ffn_combine_meta(
     at::Tensor& out,
     at::Tensor& expert_token_nums,
     const c10::optional<at::Tensor> &x_active_mask,
-    double swiglu_limit
+    double swiglu_limit,
+    double swiglu_alpha
 ) {
     return {out, expert_token_nums};
 }

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -202,7 +202,8 @@ std::tuple<at::Tensor&, at::Tensor&> dispatch_ffn_combine_meta(
     at::Tensor& out,
     at::Tensor& expert_token_nums,
     const c10::optional<at::Tensor> &x_active_mask,
-    double swiglu_limit
+    double swiglu_limit,
+    double swiglu_alpha
 ) {
     return {out, expert_token_nums};
 }

--- a/vllm_ascend/ops/activation.py
+++ b/vllm_ascend/ops/activation.py
@@ -21,7 +21,6 @@ from vllm.model_executor.layers.activation import (
     QuickGELU,
     SiluAndMul,
     SiluAndMulWithClamp,
-    SwigluOAIAndMul,
     SwigluStepAndMul,
 )
 
@@ -50,13 +49,10 @@ class AscendSiluAndMulWithClamp(SiluAndMulWithClamp):
 
 class AscendSwigluOAIAndMul:
     def swiglu_oai_forward(x: torch.Tensor, alpha: float = 1.702, limit: float = 7.0) -> torch.Tensor:
-        class MinimalSwigluOAIAndMul:
-            def __init__(self):
-                self.alpha = alpha
-                self.limit = limit
-
-        layer = MinimalSwigluOAIAndMul()
-        return SwigluOAIAndMul.forward_native(layer, x)
+        d = x.shape[-1] // 2
+        gate = x[..., :d].clamp(max=limit)
+        up = x[..., d:].clamp(min=-limit, max=limit)
+        return (up + 1) * gate * torch.sigmoid(gate * alpha)
 
 
 class AscendSwigluStepAndMul:

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -480,6 +480,7 @@ class FusedMC2CommImpl(MoECommMethod):
                     group=self.token_dispatcher.moe_all_to_all_group_name,
                     max_output_size=get_ascend_config().mega_moe_max_tokens,
                     swiglu_limit=fused_experts_input.swiglu_limit,
+                    swiglu_alpha=fused_experts_input.swiglu_alpha,
                     x_active_mask=fused_experts_input.routing.mc2_mask,
                     out=out,
                     expert_token_nums=self.expert_token_nums,

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -495,6 +495,7 @@ class FusedMC2CommImpl(MoECommMethod):
                     group=self.token_dispatcher.moe_all_to_all_group_name,
                     max_output_size=get_ascend_config().mega_moe_max_tokens,
                     swiglu_limit=self.swiglu_limit,
+                    swiglu_alpha=self.swiglu_alpha,
                     x_active_mask=fused_experts_input.routing.mc2_mask,
                     out=out,
                     expert_token_nums=self.expert_token_nums,


### PR DESCRIPTION
# feat(mc2): add SwigluOAI activation variant to `dispatch_ffn_combine`

## Summary

This contributes the **SwigluOAI activation variant** of the fused
`dispatch_ffn_combine` (grouped-matmul + SwiGLU + per-token clamp)
operator on Ascend, so that models using an OAI-style SwiGLU — such as
**MiniMax-M3** — can run on a single fused kernel instead of an unfused
grouped-matmul + separate-activation path, recovering the quant-fusion
benefit.

The change is **purely additive at the operator level** and does not
register or depend on any specific model.

## Background

MiniMax-M3's MLP uses an OAI-style SwiGLU:

| path | formula | `up` clamp |
|---|---|---|
| standard SwiGLU (`alpha == 0`) | `out = silu(gate) * up` | single-sided `ClampMin(-limit)` |
| **SwigluOAI** (`alpha > 0`) | `out = (up + 1) * gate * sigmoid(gate * alpha)` | double-sided `ClampMin(-limit) + ClampMax(limit)` |

Because the currently fused `dispatch_ffn_combine` op only implements
the standard path, models using SwigluOAI had to fall back to an unfused
grouped-matmul + separate swiglu kernel, which is slower and loses the
quant-fusion benefit on Ascend.

## What this PR does

Adds an optional `swigluAlpha` attribute (default `0.0`) to the
`dispatch_ffn_combine` op:

- `alpha > 0` → kernel takes the SwigluOAI branch (new math + double-sided
  `up` clamp).
- `alpha == 0` → **bit-identical** to the existing standard SwiGLU path,
  so all current callers are unaffected.

The Python side:

- `vllm_ascend/ops/activation.py` — adds an inline native reference
  implementation of SwigluOAI (`(up+1)*gate*sigmoid(gate*alpha)`).
- `vllm_ascend/ops/fused_moe/*` + `quantization/methods/w8a8_dynamic.py`
  — threads `swiglu_alpha` (default `0.0`) from the layer config to the
  operator, and routes layers whose activation is `"swigluoai"` through
  this fused op instead of the generic gmm+swiglu fusion. Layers using
  other activations are unchanged.
- `vllm_ascend/ops/fused_moe/fused_moe.py` — for `"swigluoai"` layers the
  flashcommon3 gate-stream overlap (`multistream_overlap_gate`) is
  disabled, because the fused single-kernel `dispatch_ffn_combine` path
  is incompatible with the separate gate-stream overlap mechanism.
  Non-OAI layers keep the original `ascend_config.multistream_overlap_gate`
  behavior, so they are unaffected.

## Files (18, no new files, no binaries)

**C++ op side** (`csrc/mc2/dispatch_ffn_combine/`)
- `op_host/dispatch_ffn_combine_def.cpp` — register `swigluAlpha` attr.
- `op_host/dispatch_ffn_combine_tiling.cpp`, `op_kernel/dispatch_ffn_combine_tiling.h` — read attr into tiling info.
- `op_host/op_api/aclnn_dispatch_ffn_combine.{cpp,h}` — expose alpha in op_api.
- `dispatch_ffn_combine_torch_adpt.h` — alpha param on the torch adapter.
- `op_kernel/dispatch_ffn_combine.h`, `op_kernel/dispatch_ffn_combine_kernel.hpp` — propagate alpha to the epilogue.
- `op_kernel/utils/block_epilogue_pertoken_swiglu.hpp` — **the kernel math** (OAI branch + double-sided clamp; standard branch preserved).
- `csrc/torch_binding.cpp`, `csrc/torch_binding_meta.cpp` — python binding + schema.

**Python integration** (`vllm_ascend/`)
- `ops/activation.py` — native reference impl.
- `ops/fused_moe/{fused_moe,moe_mlp,moe_comm_method,moe_runtime_args,moe_stage_contracts}.py` — thread `swiglu_alpha`.
- `quantization/methods/w8a8_dynamic.py` — pass `swiglu_alpha` to the op.

## Out of scope (intentionally not in this PR)

This PR is scoped to the **operator contribution** only. The following
are model-specific and are intentionally excluded (they can land as a
separate PR that depends on this one):

- MiniMax-M3 model registration (`models/__init__.py`,
  `ascend_forward_context.py`) and the `minimax_m3_vl.py` model module.
- `patch/platform/patch_minimax_m3.py` and its import.
- `utils.is_minimax_m3_model()` and the M3-specific slot-mapping /
  cudagraph-skip logic in `worker/model_runner_v1.py`.
- M3 quant packed-modules mapping in `modelslim_config.py`.
- M3 triton kernels (`ops/triton/*`) and reasoning / tool parsers.

Excluding these keeps this PR self-contained: it applies cleanly to
`vllm-ascend@5f6faa0c` and `import vllm_ascend` still works without any
out-of-tree files.

## Compatibility

- `alpha == 0` is the default and is bit-compatible with the pre-PR
  kernel (the standard SwiGLU branch keeps the same ops, same order, same
  clamp sides).
- Only layers that opt in (`swiglu_alpha > 0`) take the new path;
  existing models see no change.

## Tested

- Base commit: `5f6faa0c` (vllm-ascend v0.22.1rc1).
- Built and ran on Ascend A3 910C + CANN 9.0.0, Python 3.12.
- Verified the fused SwigluOAI op produces identical outputs to the
  reference native implementation `(up+1)*gate*sigmoid(gate*alpha)`
  within fp tolerance.
- Serving benchmark (MiniMax-M3 w8a8, A3 910C ×8 (16 NPU), TP=4 DP=4, random
  16K-in / 1024-out, CON32, 32 prompts), fused `dispatch_ffn_combine`
  path (with `swiglu_alpha`) vs unfused gmm + separate SwigluOAI:

  | metric | fused | unfused | delta |
  |---|---|---|---|
  | output throughput (tok/s) | 82.10 | 60.42 | **+36%** |
  | total token throughput (tok/s) | 1409.74 | 1037.53 | +36% |
  | mean TPOT (ms) | 174.55 | 277.84 | **−37%** |
  | mean TTFT (ms) | 143571 | 255402 | −44% |
  | mean E2EL (ms) | 322135 | 539629 | −40% |

  The fused op collapses dispatch + GMM1 + activation + quant + GMM2 +
  combine into one kernel, eliminating the unfused path's repeated
  comms and intermediate buffer writes.

## Notes for reviewers

- This touches the custom MC2 `dispatch_ffn_combine` operator in
  `csrc/mc2/`. The operator is vendored into vllm-ascend's csrc, so the
  host / tiling / op_api / kernel changes all live in this repo (no
  CANN-side prerequisite).
- The change is additive: a new optional attribute + a new branch guarded
  by `alpha > 0`; the existing path is untouched and bit-compatible.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
