### PR TITLE
[BugFix] Move KV layer saving to _forward_core for compilation support

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -789,6 +789,7 @@ estimated_times:
   tests/ut/kv_offload/a2/test_remote_decode_lifecycle.py: 60
   tests/ut/kv_offload/a2/test_remote_prefill_lifecycle.py: 60
   tests/ut/ops/a2/test_gdn_chunk_meta.py: 30
+  tests/ut/ops/a2/test_gdn_layerwise_kv.py: 30
   tests/ut/ops/a2/test_token_dispatcher.py: 30
   tests/ut/ops/a3_2/test_activation.py: 50
   tests/ut/ops/a3_2/test_select_experts.py: 30

--- a/tests/ut/ops/a2/test_gdn_layerwise_kv.py
+++ b/tests/ut/ops/a2/test_gdn_layerwise_kv.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import torch
+from torch._inductor import config as inductor_config
 from vllm.forward_context import ForwardContext, override_forward_context
 
 from tests.ut.ops.test_gdn_layerwise_kv import (
@@ -63,6 +64,7 @@ def test_npu_connector_observes_updated_gdn_state_after_compile():
     )
 
     with (
+        inductor_config.patch(compile_threads=1),
         override_forward_context(forward_context),
         patch("vllm_ascend.ops.gdn.get_pcp_group", return_value=SimpleNamespace(world_size=1)),
         patch("vllm_ascend.ops.gdn.DeviceOperator.fused_gdn_gating", return_value=gating),
@@ -72,6 +74,7 @@ def test_npu_connector_observes_updated_gdn_state_after_compile():
             torch.ops._C_ascend,
             "npu_causal_conv1d_custom",
             side_effect=causal_conv1d,
+            create=True,
         ),
         patch("vllm_ascend.attention.utils.has_kv_transfer_group", return_value=True),
         patch("vllm_ascend.attention.utils.is_v1_kv_transfer_group", return_value=True),

--- a/tests/ut/ops/a2/test_gdn_layerwise_kv.py
+++ b/tests/ut/ops/a2/test_gdn_layerwise_kv.py
@@ -80,14 +80,22 @@ def test_npu_connector_observes_updated_gdn_state_after_compile():
         patch("vllm_ascend.attention.utils.is_v1_kv_transfer_group", return_value=True),
         patch("vllm_ascend.attention.utils.get_kv_transfer_group", return_value=connector),
     ):
-        model(hidden_states, output)
+        # vLLM 0.24 writes to output; earlier versions return the result.
+        eager_output = model(hidden_states, output)
+        torch.testing.assert_close(
+            output if eager_output is None else eager_output,
+            hidden_states + 1,
+        )
         compiled_model = torch.compile(model, backend="inductor", fullgraph=True)
-        compiled_model(hidden_states, output)
-        compiled_model(hidden_states, output)
+        for _ in range(2):
+            compiled_output = compiled_model(hidden_states, output)
+            torch.testing.assert_close(
+                output if compiled_output is None else compiled_output,
+                hidden_states + 1,
+            )
         torch.npu.synchronize()
 
     assert connector.save_kv_layer.call_count == 3
     for execution, (conv_state, ssm_state) in enumerate(observed_states, start=1):
         torch.testing.assert_close(conv_state, torch.full_like(conv_state, execution))
         torch.testing.assert_close(ssm_state, torch.full_like(ssm_state, execution))
-    torch.testing.assert_close(output, hidden_states + 1)

--- a/tests/ut/ops/a2/test_gdn_layerwise_kv.py
+++ b/tests/ut/ops/a2/test_gdn_layerwise_kv.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+from vllm.forward_context import ForwardContext, override_forward_context
+
+from tests.ut.ops.test_gdn_layerwise_kv import (
+    _GDNForwardWrapper,
+    _make_prefill_metadata,
+)
+
+
+def test_npu_connector_observes_updated_gdn_state_after_compile():
+    device = torch.device("npu")
+    model = _GDNForwardWrapper().to(device)
+    hidden_states = torch.arange(4, dtype=torch.float32, device=device).reshape(2, 2)
+    output = torch.empty_like(hidden_states)
+    metadata = _make_prefill_metadata(device)
+    forward_context = ForwardContext(
+        no_compile_layers={model.prefix: model},
+        attn_metadata={model.prefix: metadata},
+        slot_mapping={},
+    )
+    connector = Mock()
+    observed_states = []
+
+    def record_ready_state(layer_name, kv_cache_layer, attn_metadata):
+        assert layer_name == ""
+        assert kv_cache_layer == []
+        assert attn_metadata is forward_context.attn_metadata
+        observed_states.append(tuple(state.clone() for state in model.kv_cache))
+
+    connector.save_kv_layer.side_effect = record_ready_state
+
+    def causal_conv1d(output_tensor, mixed_qkv, conv_weights, **kwargs):
+        del conv_weights, kwargs
+        output_tensor.copy_(mixed_qkv)
+        model.conv_state.add_(1)
+
+    def chunk_attention(**kwargs):
+        initial_state = kwargs["initial_state"]
+        value = kwargs["v"]
+        return value + 1, initial_state + 1
+
+    gating = (
+        torch.zeros(1, 2, 1, device=device),
+        torch.zeros(1, 2, 1, device=device),
+    )
+
+    with (
+        override_forward_context(forward_context),
+        patch("vllm_ascend.ops.gdn.get_pcp_group", return_value=SimpleNamespace(world_size=1)),
+        patch("vllm_ascend.ops.gdn.DeviceOperator.fused_gdn_gating", return_value=gating),
+        patch("vllm_ascend.ops.gdn.clear_ssm_states"),
+        patch("vllm_ascend.ops.gdn.chunk_gated_delta_rule", side_effect=chunk_attention),
+        patch.object(
+            torch.ops._C_ascend,
+            "npu_causal_conv1d_custom",
+            side_effect=causal_conv1d,
+        ),
+        patch("vllm_ascend.attention.utils.has_kv_transfer_group", return_value=True),
+        patch("vllm_ascend.attention.utils.is_v1_kv_transfer_group", return_value=True),
+        patch("vllm_ascend.attention.utils.get_kv_transfer_group", return_value=connector),
+    ):
+        model(hidden_states, output)
+        compiled_model = torch.compile(model, backend="inductor", fullgraph=True)
+        compiled_model(hidden_states, output)
+        compiled_model(hidden_states, output)
+        torch.npu.synchronize()
+
+    assert connector.save_kv_layer.call_count == 3
+    for execution, (conv_state, ssm_state) in enumerate(observed_states, start=1):
+        torch.testing.assert_close(conv_state, torch.full_like(conv_state, execution))
+        torch.testing.assert_close(ssm_state, torch.full_like(ssm_state, execution))
+    torch.testing.assert_close(output, hidden_states + 1)

--- a/tests/ut/ops/test_gdn_layerwise_kv.py
+++ b/tests/ut/ops/test_gdn_layerwise_kv.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+from torch import nn
+from vllm.forward_context import ForwardContext, override_forward_context
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+    qwen_gdn_attention_core,
+)
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
+
+from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
+from vllm_ascend.ops.gdn_attn_builder import (
+    GDNCausalConv1dMetadata,
+    GDNPrefillMetadata,
+)
+
+
+class _Linear(nn.Module):
+    def __init__(self, output_size: int):
+        super().__init__()
+        self.output_size = output_size
+
+    def forward(self, hidden_states: torch.Tensor):
+        return hidden_states[:, : self.output_size], None
+
+
+class _Norm(nn.Module):
+    def forward(self, hidden_states: torch.Tensor, z: torch.Tensor):
+        del z
+        return hidden_states
+
+
+class _OutputProjection(nn.Module):
+    def forward(self, hidden_states: torch.Tensor):
+        return hidden_states, None
+
+
+class _GDNForwardWrapper(nn.Module):
+    forward = AscendGatedDeltaNetAttention.forward
+    _forward_core = AscendGatedDeltaNetAttention._forward_core
+    _split_ba_for_tp = AscendGatedDeltaNetAttention._split_ba_for_tp
+
+    def __init__(self):
+        super().__init__()
+        self.in_proj_qkv = _Linear(2)
+        self.in_proj_ba = _Linear(2)
+        self.in_proj_z = _Linear(2)
+        self.norm = _Norm()
+        self.out_proj = _OutputProjection()
+        self.conv1d = nn.Conv1d(1, 2, kernel_size=2)
+        self.num_v_heads = 1
+        self.tp_size = 1
+        self.head_v_dim = 2
+        self.activation = None
+        self.A_log = torch.zeros(1)
+        self.dt_bias = torch.zeros(1)
+        self.prefix = "layers.0.linear_attn"
+        self.kv_cache = (
+            torch.zeros(1, 1, 2),
+            torch.zeros(1, 1, 2, 2),
+        )
+
+    def rearrange_mixed_qkv(self, mixed_qkv: torch.Tensor | None):
+        if mixed_qkv is None:
+            return None, None, None
+        projected = mixed_qkv.reshape(1, mixed_qkv.shape[0], 1, 2)
+        return projected, projected, projected
+
+
+def _make_prefill_metadata() -> GDNAttentionMetadata:
+    metadata = GDNAttentionMetadata(
+        num_prefills=1,
+        num_prefill_tokens=2,
+        num_decodes=0,
+        num_decode_tokens=0,
+        num_spec_decodes=0,
+        num_spec_decode_tokens=0,
+        num_actual_tokens=2,
+        non_spec_state_indices_tensor=torch.tensor([0], dtype=torch.int32),
+        prefill_query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        prefill_state_indices=torch.tensor([0], dtype=torch.int64),
+        prefill_has_initial_state=torch.tensor([True]),
+    )
+    metadata.non_spec_prefill_metadata = GDNPrefillMetadata(
+        causal_conv1d=GDNCausalConv1dMetadata(
+            query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+            cache_indices=torch.tensor([0], dtype=torch.int32),
+            initial_state_mode=torch.tensor([1], dtype=torch.int32),
+        ),
+        chunk=Mock(),
+    )
+    return metadata
+
+
+def test_connector_observes_updated_gdn_state_for_each_compiled_call():
+    # vLLM registers this production dispatcher for NPU only. Keep a CPU
+    # registration alive for this test so Inductor sees the same custom op.
+    cpu_impl = torch.library.Library("vllm", "IMPL", "CPU")
+    cpu_impl.impl("qwen_gdn_attention_core", qwen_gdn_attention_core)
+    model = _GDNForwardWrapper()
+    hidden_states = torch.arange(4, dtype=torch.float32).reshape(2, 2)
+    output = torch.empty_like(hidden_states)
+    metadata = _make_prefill_metadata()
+    forward_context = ForwardContext(
+        no_compile_layers={model.prefix: model},
+        attn_metadata={model.prefix: metadata},
+        slot_mapping={},
+    )
+    connector = Mock()
+    observed_states = []
+
+    def record_ready_state(layer_name, kv_cache_layer, attn_metadata):
+        assert layer_name == ""
+        assert kv_cache_layer == []
+        assert attn_metadata is forward_context.attn_metadata
+        observed_states.append(tuple(state.clone() for state in model.kv_cache))
+
+    connector.save_kv_layer.side_effect = record_ready_state
+
+    def causal_conv1d(output_tensor, mixed_qkv, conv_weights, **kwargs):
+        del conv_weights, kwargs
+        output_tensor.copy_(mixed_qkv)
+        model.kv_cache[0].add_(1)
+
+    def chunk_attention(**kwargs):
+        initial_state = kwargs["initial_state"]
+        value = kwargs["v"]
+        return value + 1, initial_state + 1
+
+    gating = (
+        torch.zeros(1, 2, 1),
+        torch.zeros(1, 2, 1),
+    )
+
+    with (
+        override_forward_context(forward_context),
+        patch.object(torch.accelerator, "is_available", return_value=False),
+        patch("vllm_ascend.ops.gdn.get_pcp_group", return_value=SimpleNamespace(world_size=1)),
+        patch("vllm_ascend.ops.gdn.DeviceOperator.fused_gdn_gating", return_value=gating),
+        patch("vllm_ascend.ops.gdn.clear_ssm_states"),
+        patch("vllm_ascend.ops.gdn.chunk_gated_delta_rule", side_effect=chunk_attention),
+        patch.object(
+            torch.ops._C_ascend,
+            "npu_causal_conv1d_custom",
+            side_effect=causal_conv1d,
+            create=True,
+        ),
+        patch("vllm_ascend.attention.utils.has_kv_transfer_group", return_value=True),
+        patch("vllm_ascend.attention.utils.is_v1_kv_transfer_group", return_value=True),
+        patch("vllm_ascend.attention.utils.get_kv_transfer_group", return_value=connector),
+    ):
+        model(hidden_states, output)
+        compiled_model = torch.compile(model, backend="inductor", fullgraph=True)
+        compiled_model(hidden_states, output)
+        compiled_model(hidden_states, output)
+
+    assert connector.save_kv_layer.call_count == 3
+    for execution, (conv_state, ssm_state) in enumerate(observed_states, start=1):
+        torch.testing.assert_close(conv_state, torch.full_like(conv_state, execution))
+        torch.testing.assert_close(ssm_state, torch.full_like(ssm_state, execution))
+    torch.testing.assert_close(output, hidden_states + 1)

--- a/tests/ut/ops/test_gdn_layerwise_kv.py
+++ b/tests/ut/ops/test_gdn_layerwise_kv.py
@@ -176,13 +176,21 @@ def test_connector_observes_updated_gdn_state_for_each_compiled_call():
         patch("vllm_ascend.attention.utils.is_v1_kv_transfer_group", return_value=True),
         patch("vllm_ascend.attention.utils.get_kv_transfer_group", return_value=connector),
     ):
-        model(hidden_states, output)
+        # vLLM 0.24 writes to output; earlier versions return the result.
+        eager_output = model(hidden_states, output)
+        torch.testing.assert_close(
+            output if eager_output is None else eager_output,
+            hidden_states + 1,
+        )
         compiled_model = torch.compile(model, backend="inductor", fullgraph=True)
-        compiled_model(hidden_states, output)
-        compiled_model(hidden_states, output)
+        for _ in range(2):
+            compiled_output = compiled_model(hidden_states, output)
+            torch.testing.assert_close(
+                output if compiled_output is None else compiled_output,
+                hidden_states + 1,
+            )
 
     assert connector.save_kv_layer.call_count == 3
     for execution, (conv_state, ssm_state) in enumerate(observed_states, start=1):
         torch.testing.assert_close(conv_state, torch.full_like(conv_state, execution))
         torch.testing.assert_close(ssm_state, torch.full_like(ssm_state, execution))
-    torch.testing.assert_close(output, hidden_states + 1)

--- a/tests/ut/ops/test_gdn_layerwise_kv.py
+++ b/tests/ut/ops/test_gdn_layerwise_kv.py
@@ -68,13 +68,15 @@ class _GDNForwardWrapper(nn.Module):
         self.tp_size = 1
         self.head_v_dim = 2
         self.activation = None
-        self.A_log = torch.zeros(1)
-        self.dt_bias = torch.zeros(1)
+        self.register_buffer("A_log", torch.zeros(1))
+        self.register_buffer("dt_bias", torch.zeros(1))
+        self.register_buffer("conv_state", torch.zeros(1, 1, 2))
+        self.register_buffer("ssm_state", torch.zeros(1, 1, 2, 2))
         self.prefix = "layers.0.linear_attn"
-        self.kv_cache = (
-            torch.zeros(1, 1, 2),
-            torch.zeros(1, 1, 2, 2),
-        )
+
+    @property
+    def kv_cache(self):
+        return self.conv_state, self.ssm_state
 
     def rearrange_mixed_qkv(self, mixed_qkv: torch.Tensor | None):
         if mixed_qkv is None:
@@ -83,7 +85,7 @@ class _GDNForwardWrapper(nn.Module):
         return projected, projected, projected
 
 
-def _make_prefill_metadata() -> GDNAttentionMetadata:
+def _make_prefill_metadata(device: torch.device | str = "cpu") -> GDNAttentionMetadata:
     metadata = GDNAttentionMetadata(
         num_prefills=1,
         num_prefill_tokens=2,
@@ -92,16 +94,16 @@ def _make_prefill_metadata() -> GDNAttentionMetadata:
         num_spec_decodes=0,
         num_spec_decode_tokens=0,
         num_actual_tokens=2,
-        non_spec_state_indices_tensor=torch.tensor([0], dtype=torch.int32),
-        prefill_query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
-        prefill_state_indices=torch.tensor([0], dtype=torch.int64),
-        prefill_has_initial_state=torch.tensor([True]),
+        non_spec_state_indices_tensor=torch.tensor([0], dtype=torch.int32, device=device),
+        prefill_query_start_loc=torch.tensor([0, 2], dtype=torch.int32, device=device),
+        prefill_state_indices=torch.tensor([0], dtype=torch.int64, device=device),
+        prefill_has_initial_state=torch.tensor([True], device=device),
     )
     metadata.non_spec_prefill_metadata = GDNPrefillMetadata(
         causal_conv1d=GDNCausalConv1dMetadata(
-            query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
-            cache_indices=torch.tensor([0], dtype=torch.int32),
-            initial_state_mode=torch.tensor([1], dtype=torch.int32),
+            query_start_loc=torch.tensor([0, 2], dtype=torch.int32, device=device),
+            cache_indices=torch.tensor([0], dtype=torch.int32, device=device),
+            initial_state_mode=torch.tensor([1], dtype=torch.int32, device=device),
         ),
         chunk=Mock(),
     )

--- a/tests/ut/ops/test_gdn_layerwise_kv.py
+++ b/tests/ut/ops/test_gdn_layerwise_kv.py
@@ -78,6 +78,12 @@ class _GDNForwardWrapper(nn.Module):
     def kv_cache(self):
         return self.conv_state, self.ssm_state
 
+    def split_ba(self, ba: torch.Tensor):
+        # Avoid torch.chunk: torch-npu's aten.split fallback conflicts with
+        # PyTorch's decomposition check when CI is set.
+        midpoint = ba.shape[-1] // 2
+        return ba[..., :midpoint], ba[..., midpoint:]
+
     def rearrange_mixed_qkv(self, mixed_qkv: torch.Tensor | None):
         if mixed_qkv is None:
             return None, None, None

--- a/tests/ut/ops/test_gdn_layerwise_kv.py
+++ b/tests/ut/ops/test_gdn_layerwise_kv.py
@@ -95,10 +95,13 @@ def _make_prefill_metadata(device: torch.device | str = "cpu") -> GDNAttentionMe
         num_spec_decode_tokens=0,
         num_actual_tokens=2,
         non_spec_state_indices_tensor=torch.tensor([0], dtype=torch.int32, device=device),
-        prefill_query_start_loc=torch.tensor([0, 2], dtype=torch.int32, device=device),
-        prefill_state_indices=torch.tensor([0], dtype=torch.int64, device=device),
-        prefill_has_initial_state=torch.tensor([True], device=device),
     )
+    # These fields are constructor arguments only in newer vLLM releases.
+    # Assigning them after construction also supports the older metadata class
+    # while exercising the same production GDN prefill path.
+    metadata.prefill_query_start_loc = torch.tensor([0, 2], dtype=torch.int32, device=device)
+    metadata.prefill_state_indices = torch.tensor([0], dtype=torch.int64, device=device)
+    metadata.prefill_has_initial_state = torch.tensor([True], device=device)
     metadata.non_spec_prefill_metadata = GDNPrefillMetadata(
         causal_conv1d=GDNCausalConv1dMetadata(
             query_start_loc=torch.tensor([0, 2], dtype=torch.int32, device=device),

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -135,7 +135,6 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
         # ============================================================
         # Part 3: Output Projection
         # ============================================================
-        maybe_save_kv_layer_to_connector("", [])
         z_shape_og = z.shape
         # Reshape input data into 2D tensor
         core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
@@ -457,3 +456,4 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             core_attn_out[:num_actual_tokens] = core_attn_out_spec.squeeze(0)
         else:
             core_attn_out[:num_actual_tokens] = core_attn_out_non_spec.squeeze(0)
+        maybe_save_kv_layer_to_connector("", [])


### PR DESCRIPTION
### What this PR does / why we need it?

This PR moves `maybe_save_kv_layer_to_connector("", [])` from
`AscendGatedDeltaNetAttention.forward()` to the end of `_forward_core()`.

Under `torch.compile`, `forward()` is traced around the opaque
`vllm::qwen_gdn_attention_core` custom op, so the Python callback is not
reliably invoked for each runtime execution. With a layerwise KV connector,
this can leave the GDN/Mamba cache group unsubmitted and cause the decode
request to wait indefinitely.

Calling the connector from `_forward_core()` keeps it inside the custom-op
runtime path and ensures it runs after the convolution and SSM states are
updated. The numerical computation and cache format are unchanged.

This fix covers eager and PIECEWISE-compiled execution. Python callbacks during
FULL ACLGraph replay remain outside the scope of this PR.

### Does this PR introduce _any_ user-facing change?

Yes. It fixes PD-disaggregated inference for hybrid GDN models, such as
Qwen3.5, when using a layerwise KV connector with a compiled prefill worker.
There are no API, configuration, or model-output changes.

### How was this patch tested?

#### Unit tests

Added CPU and NPU regression tests:

- `tests/ut/ops/test_gdn_layerwise_kv.py`
- `tests/ut/ops/a2/test_gdn_layerwise_kv.py`

The tests run one eager call and two `torch.compile` calls through the
production GDN custom-op path, with numerical kernels mocked. They verify that
the connector is called once per execution and observes the updated
convolution and SSM states.

CPU result with `torch==2.10.0+cpu`: `17 passed`.

NPU validation:

```bash
pytest -sv \
  tests/ut/ops/test_gdn_layerwise_kv.py \
  tests/ut/ops/test_gdn_attn_builder.py \
  tests/ut/ops/a2/test_gdn_chunk_meta.py \
  tests/ut/ops/a2/test_gdn_layerwise_kv.py
```

Result: `23 passed`.

#### Integration test

Re-ran the original PD-disaggregation scenario on NPU with:

- Qwen3.5-35B-A3B-W8A8 and MTP.
- `MooncakeLayerwiseConnector` with one prefill worker and one decode worker
  (TP=1, DP=1).
- Compiled prefill (`enforce_eager=False`, PIECEWISE) and
  `FULL_DECODE_ONLY` on the decode worker.

Multiple chat-completion requests returned HTTP 200. The prefill worker emitted
the layerwise `done_sending_msg` signal for each request, and decode completed
instead of remaining in `WAITING_FOR_REMOTE_KVS`.

Formatting check: `bash format.sh ci` passed.


- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
