### PR TITLE
[Bugfix][310P] Adapt unified spec decoding method and fix spec decoding accuracy issue.

### DIFF
--- a/tests/ut/_310p/attention/test_attention_v1_310.py
+++ b/tests/ut/_310p/attention/test_attention_v1_310.py
@@ -264,8 +264,10 @@ class TestAscendAttentionMetadataBuilder310(TestBase):
         builder = object.__new__(AscendMetadataBuilder310Direct)
         builder._query_lens_cpu_buffer = torch.zeros(10, dtype=torch.int32, device="cpu")
         builder.device = torch.device("cpu")
-        from vllm_ascend._310p.attention.attention_mask import AttentionMaskBuilder310
         from vllm.v1.kv_cache_interface import AttentionSpec
+
+        from vllm_ascend._310p.attention.attention_mask import AttentionMaskBuilder310
+
         builder.attn_mask_builder = AttentionMaskBuilder310(torch.device("cpu"), 4096)
         builder.kv_cache_spec = AttentionSpec(
             block_size=128,

--- a/tests/ut/_310p/attention/test_attention_v1_310.py
+++ b/tests/ut/_310p/attention/test_attention_v1_310.py
@@ -24,6 +24,9 @@ from vllm_ascend._310p.attention.attention_v1 import (
     AscendAttentionMetadataBuilder310,
     AscendAttentionState,
 )
+from vllm_ascend._310p.attention.metadata_builder import (
+    AscendAttentionMetadataBuilder310 as AscendMetadataBuilder310Direct,
+)
 
 
 class TestAscendAttentionBackend310(TestBase):
@@ -225,3 +228,63 @@ class TestAscendAttentionBackendImpl310(TestBase):
 
         mock_chunked_prefill.assert_called_once_with(query, metadata, output)
         self.assertIs(result, output)
+
+
+class TestAscendAttentionMetadataBuilder310(TestBase):
+    def test_fill_query_lens_cpu_without_buffer(self):
+        builder = AscendMetadataBuilder310Direct.__new__(AscendMetadataBuilder310Direct)
+        builder._query_lens_cpu_buffer = None
+        query_start_loc_cpu = torch.tensor([0, 1, 5, 11, 20], dtype=torch.int32)
+        result = builder._fill_query_lens_cpu(num_reqs=3, query_start_loc_cpu=query_start_loc_cpu, is_drafting=False)
+        expected = torch.tensor([1, 4, 6], dtype=torch.int32)
+        torch.testing.assert_close(result, expected)
+
+    def test_fill_query_lens_cpu_with_buffer_not_drafting(self):
+        builder = AscendMetadataBuilder310Direct.__new__(AscendMetadataBuilder310Direct)
+        builder._query_lens_cpu_buffer = torch.zeros(10, dtype=torch.int32, device="cpu")
+        query_start_loc_cpu = torch.tensor([0, 1, 5, 11, 20], dtype=torch.int32)
+        result = builder._fill_query_lens_cpu(num_reqs=3, query_start_loc_cpu=query_start_loc_cpu, is_drafting=False)
+        expected = torch.tensor([1, 4, 6], dtype=torch.int32)
+        torch.testing.assert_close(result, expected)
+        assert result.data_ptr() == builder._query_lens_cpu_buffer[:3].data_ptr()
+
+    def test_fill_query_lens_cpu_with_buffer_is_drafting(self):
+        builder = AscendMetadataBuilder310Direct.__new__(AscendMetadataBuilder310Direct)
+        builder._query_lens_cpu_buffer = torch.zeros(10, dtype=torch.int32, device="cpu")
+        query_start_loc_cpu = torch.tensor([0, 1, 5, 11, 20], dtype=torch.int32)
+        result1 = builder._fill_query_lens_cpu(num_reqs=3, query_start_loc_cpu=query_start_loc_cpu, is_drafting=True)
+        result2 = builder._fill_query_lens_cpu(num_reqs=3, query_start_loc_cpu=query_start_loc_cpu, is_drafting=True)
+        expected = torch.tensor([1, 4, 6], dtype=torch.int32)
+        torch.testing.assert_close(result1, expected)
+        torch.testing.assert_close(result2, expected)
+        assert result1.data_ptr() != builder._query_lens_cpu_buffer[:3].data_ptr()
+        assert result2.data_ptr() != builder._query_lens_cpu_buffer[:3].data_ptr()
+
+    def test_build_for_drafting_calls_build_with_is_drafting_true(self):
+        builder = object.__new__(AscendMetadataBuilder310Direct)
+        builder._query_lens_cpu_buffer = torch.zeros(10, dtype=torch.int32, device="cpu")
+        builder.device = torch.device("cpu")
+        from vllm_ascend._310p.attention.attention_mask import AttentionMaskBuilder310
+        from vllm.v1.kv_cache_interface import AttentionSpec
+        builder.attn_mask_builder = AttentionMaskBuilder310(torch.device("cpu"), 4096)
+        builder.kv_cache_spec = AttentionSpec(
+            block_size=128,
+            num_kv_heads=2,
+            head_size=64,
+            dtype=torch.float16,
+        )
+        builder.layer_names = []
+        builder.vllm_config = MagicMock()
+        builder.vllm_config.model_config.max_model_len = 4096
+        builder.vllm_config.scheduler_config.max_num_seqs = 8
+
+        common_attn_metadata = MagicMock()
+        common_attn_metadata.num_reqs = 2
+        common_attn_metadata.query_start_loc = torch.tensor([0, 1, 3])
+        common_attn_metadata.query_start_loc_cpu = torch.tensor([0, 1, 3])
+        common_attn_metadata.seq_lens = torch.tensor([1, 2])
+
+        with patch.object(AscendMetadataBuilder310Direct.__bases__[0], "build", return_value=MagicMock()) as mock_build:
+            result = builder.build_for_drafting(common_attn_metadata=common_attn_metadata, draft_index=0)
+            mock_build.assert_called_once_with(0, common_attn_metadata, True)
+            assert result is not None

--- a/tests/ut/_310p/ops/test_rotary_embedding_310.py
+++ b/tests/ut/_310p/ops/test_rotary_embedding_310.py
@@ -18,7 +18,9 @@ import torch
 from vllm_ascend._310p.ops import rotary_embedding as rotary_310
 from vllm_ascend._310p.ops.rotary_embedding import (
     AscendMRotaryEmbedding310,
+    AscendRotaryEmbedding310,
     set_mrope_apply_rotary_slices,
+    set_rope_position_flag_310p,
 )
 
 
@@ -73,3 +75,20 @@ def test_set_mrope_apply_rotary_slices_reuses_buffer_address():
     second_ptr = rotary_310._mrope_cos_slice.data_ptr()
 
     assert first_ptr == second_ptr
+
+
+def test_set_rope_position_flag_310p_sets_global_flag():
+    rotary_310._ROPE_310P_UPDATE_FLAG = False
+    set_rope_position_flag_310p(True)
+    assert rotary_310._ROPE_310P_UPDATE_FLAG is True
+    set_rope_position_flag_310p(False)
+    assert rotary_310._ROPE_310P_UPDATE_FLAG is False
+
+
+def test_ascend_rotary_embedding_310_drafting_flag():
+    assert hasattr(AscendRotaryEmbedding310, "_is_drafting_update_enabled")
+    assert AscendRotaryEmbedding310._is_drafting_update_enabled is False
+    AscendRotaryEmbedding310.set_rope_position_flag_310p(True)
+    assert AscendRotaryEmbedding310._is_drafting_update_enabled is True
+    AscendRotaryEmbedding310.set_rope_position_flag_310p(False)
+    assert AscendRotaryEmbedding310._is_drafting_update_enabled is False

--- a/tests/ut/_310p/ops/test_rotary_embedding_310.py
+++ b/tests/ut/_310p/ops/test_rotary_embedding_310.py
@@ -20,7 +20,6 @@ from vllm_ascend._310p.ops.rotary_embedding import (
     AscendMRotaryEmbedding310,
     AscendRotaryEmbedding310,
     set_mrope_apply_rotary_slices,
-    set_rope_position_flag_310p,
 )
 
 
@@ -75,14 +74,6 @@ def test_set_mrope_apply_rotary_slices_reuses_buffer_address():
     second_ptr = rotary_310._mrope_cos_slice.data_ptr()
 
     assert first_ptr == second_ptr
-
-
-def test_set_rope_position_flag_310p_sets_global_flag():
-    rotary_310._ROPE_310P_UPDATE_FLAG = False
-    set_rope_position_flag_310p(True)
-    assert rotary_310._ROPE_310P_UPDATE_FLAG is True
-    set_rope_position_flag_310p(False)
-    assert rotary_310._ROPE_310P_UPDATE_FLAG is False
 
 
 def test_ascend_rotary_embedding_310_drafting_flag():

--- a/tests/ut/_310p/spec_decode/test_llm_base_proposer_310.py
+++ b/tests/ut/_310p/spec_decode/test_llm_base_proposer_310.py
@@ -26,12 +26,19 @@ from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBasePropos
 class TestAscendSpecDecodeBaseProposer310(TestBase):
 
     def test_run_merged_draft_sets_rope_flag_before_call(self):
-        from vllm_ascend._310p.spec_decode.llm_base_proposer_310 import _original_run_merged_draft
-        
         flag_states = []
         
-        def mock_original(self, num_input_tokens, batch_size, token_indices_to_sample, target_positions,
-                          inputs_embeds, multi_steps_attn_metadata, num_tokens, is_prefill=None):
+        def mock_original(
+            self,
+            num_input_tokens,
+            batch_size,
+            token_indices_to_sample,
+            target_positions,
+            inputs_embeds,
+            multi_steps_attn_metadata,
+            num_tokens,
+            is_prefill=None,
+        ):
             flag_states.append(AscendRotaryEmbedding310._is_drafting_update_enabled)
             return torch.zeros(num_tokens, dtype=torch.long)
 

--- a/tests/ut/_310p/spec_decode/test_llm_base_proposer_310.py
+++ b/tests/ut/_310p/spec_decode/test_llm_base_proposer_310.py
@@ -41,8 +41,10 @@ class TestAscendSpecDecodeBaseProposer310(TestBase):
             flag_states.append(AscendRotaryEmbedding310._is_drafting_update_enabled)
             return torch.zeros(num_tokens, dtype=torch.long)
 
-        with patch.object(AscendSpecDecodeBaseProposer, "_run_merged_draft", mock_original), \
-             patch("vllm_ascend._310p.spec_decode.llm_base_proposer_310._original_run_merged_draft", mock_original):
+        with (
+            patch.object(AscendSpecDecodeBaseProposer, "_run_merged_draft", mock_original),
+            patch("vllm_ascend._310p.spec_decode.llm_base_proposer_310._original_run_merged_draft", mock_original),
+        ):
             proposer = object.__new__(AscendSpecDecodeBaseProposer310)
             proposer._run_merged_draft(
                 num_input_tokens=4,
@@ -62,8 +64,10 @@ class TestAscendSpecDecodeBaseProposer310(TestBase):
         def mock_original(*args, **kwargs):
             raise RuntimeError("Test exception")
 
-        with patch.object(AscendSpecDecodeBaseProposer, "_run_merged_draft", mock_original), \
-             patch("vllm_ascend._310p.spec_decode.llm_base_proposer_310._original_run_merged_draft", mock_original):
+        with (
+            patch.object(AscendSpecDecodeBaseProposer, "_run_merged_draft", mock_original),
+            patch("vllm_ascend._310p.spec_decode.llm_base_proposer_310._original_run_merged_draft", mock_original),
+        ):
             proposer = object.__new__(AscendSpecDecodeBaseProposer310)
             with self.assertRaises(RuntimeError):
                 proposer._run_merged_draft(

--- a/tests/ut/_310p/spec_decode/test_llm_base_proposer_310.py
+++ b/tests/ut/_310p/spec_decode/test_llm_base_proposer_310.py
@@ -1,0 +1,73 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, writing
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import torch
+
+from tests.ut.base import TestBase
+from vllm_ascend._310p.ops.rotary_embedding import AscendRotaryEmbedding310
+from vllm_ascend._310p.spec_decode.llm_base_proposer_310 import AscendSpecDecodeBaseProposer310
+from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
+
+
+class TestAscendSpecDecodeBaseProposer310(TestBase):
+
+    def test_run_merged_draft_sets_rope_flag_before_call(self):
+        from vllm_ascend._310p.spec_decode.llm_base_proposer_310 import _original_run_merged_draft
+        
+        flag_states = []
+        
+        def mock_original(self, num_input_tokens, batch_size, token_indices_to_sample, target_positions,
+                          inputs_embeds, multi_steps_attn_metadata, num_tokens, is_prefill=None):
+            flag_states.append(AscendRotaryEmbedding310._is_drafting_update_enabled)
+            return torch.zeros(num_tokens, dtype=torch.long)
+
+        with patch.object(AscendSpecDecodeBaseProposer, "_run_merged_draft", mock_original):
+            with patch("vllm_ascend._310p.spec_decode.llm_base_proposer_310._original_run_merged_draft", mock_original):
+                proposer = object.__new__(AscendSpecDecodeBaseProposer310)
+                result = proposer._run_merged_draft(
+                    num_input_tokens=4,
+                    batch_size=2,
+                    token_indices_to_sample=torch.tensor([0, 1]),
+                    target_positions=torch.tensor([0, 1, 2, 3]),
+                    inputs_embeds=torch.zeros(4, 128),
+                    multi_steps_attn_metadata=None,
+                    num_tokens=4,
+                )
+
+        self.assertEqual(len(flag_states), 1)
+        self.assertTrue(flag_states[0])
+        self.assertFalse(AscendRotaryEmbedding310._is_drafting_update_enabled)
+
+    def test_run_merged_draft_restores_rope_flag_after_exception(self):
+        def mock_original(*args, **kwargs):
+            raise RuntimeError("Test exception")
+
+        with patch.object(AscendSpecDecodeBaseProposer, "_run_merged_draft", mock_original):
+            with patch("vllm_ascend._310p.spec_decode.llm_base_proposer_310._original_run_merged_draft", mock_original):
+                proposer = object.__new__(AscendSpecDecodeBaseProposer310)
+                with self.assertRaises(RuntimeError):
+                    proposer._run_merged_draft(
+                        num_input_tokens=4,
+                        batch_size=2,
+                        token_indices_to_sample=torch.tensor([0, 1]),
+                        target_positions=torch.tensor([0, 1, 2, 3]),
+                        inputs_embeds=torch.zeros(4, 128),
+                        multi_steps_attn_metadata=None,
+                        num_tokens=4,
+                    )
+
+        self.assertFalse(AscendRotaryEmbedding310._is_drafting_update_enabled)

--- a/tests/ut/_310p/spec_decode/test_llm_base_proposer_310.py
+++ b/tests/ut/_310p/spec_decode/test_llm_base_proposer_310.py
@@ -24,7 +24,6 @@ from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBasePropos
 
 
 class TestAscendSpecDecodeBaseProposer310(TestBase):
-
     def test_run_merged_draft_sets_rope_flag_before_call(self):
         flag_states = []
 

--- a/tests/ut/_310p/spec_decode/test_llm_base_proposer_310.py
+++ b/tests/ut/_310p/spec_decode/test_llm_base_proposer_310.py
@@ -41,18 +41,18 @@ class TestAscendSpecDecodeBaseProposer310(TestBase):
             flag_states.append(AscendRotaryEmbedding310._is_drafting_update_enabled)
             return torch.zeros(num_tokens, dtype=torch.long)
 
-        with patch.object(AscendSpecDecodeBaseProposer, "_run_merged_draft", mock_original):
-            with patch("vllm_ascend._310p.spec_decode.llm_base_proposer_310._original_run_merged_draft", mock_original):
-                proposer = object.__new__(AscendSpecDecodeBaseProposer310)
-                result = proposer._run_merged_draft(
-                    num_input_tokens=4,
-                    batch_size=2,
-                    token_indices_to_sample=torch.tensor([0, 1]),
-                    target_positions=torch.tensor([0, 1, 2, 3]),
-                    inputs_embeds=torch.zeros(4, 128),
-                    multi_steps_attn_metadata=None,
-                    num_tokens=4,
-                )
+        with patch.object(AscendSpecDecodeBaseProposer, "_run_merged_draft", mock_original), \
+             patch("vllm_ascend._310p.spec_decode.llm_base_proposer_310._original_run_merged_draft", mock_original):
+            proposer = object.__new__(AscendSpecDecodeBaseProposer310)
+            proposer._run_merged_draft(
+                num_input_tokens=4,
+                batch_size=2,
+                token_indices_to_sample=torch.tensor([0, 1]),
+                target_positions=torch.tensor([0, 1, 2, 3]),
+                inputs_embeds=torch.zeros(4, 128),
+                multi_steps_attn_metadata=None,
+                num_tokens=4,
+            )
 
         self.assertEqual(len(flag_states), 1)
         self.assertTrue(flag_states[0])
@@ -62,18 +62,18 @@ class TestAscendSpecDecodeBaseProposer310(TestBase):
         def mock_original(*args, **kwargs):
             raise RuntimeError("Test exception")
 
-        with patch.object(AscendSpecDecodeBaseProposer, "_run_merged_draft", mock_original):
-            with patch("vllm_ascend._310p.spec_decode.llm_base_proposer_310._original_run_merged_draft", mock_original):
-                proposer = object.__new__(AscendSpecDecodeBaseProposer310)
-                with self.assertRaises(RuntimeError):
-                    proposer._run_merged_draft(
-                        num_input_tokens=4,
-                        batch_size=2,
-                        token_indices_to_sample=torch.tensor([0, 1]),
-                        target_positions=torch.tensor([0, 1, 2, 3]),
-                        inputs_embeds=torch.zeros(4, 128),
-                        multi_steps_attn_metadata=None,
-                        num_tokens=4,
-                    )
+        with patch.object(AscendSpecDecodeBaseProposer, "_run_merged_draft", mock_original), \
+             patch("vllm_ascend._310p.spec_decode.llm_base_proposer_310._original_run_merged_draft", mock_original):
+            proposer = object.__new__(AscendSpecDecodeBaseProposer310)
+            with self.assertRaises(RuntimeError):
+                proposer._run_merged_draft(
+                    num_input_tokens=4,
+                    batch_size=2,
+                    token_indices_to_sample=torch.tensor([0, 1]),
+                    target_positions=torch.tensor([0, 1, 2, 3]),
+                    inputs_embeds=torch.zeros(4, 128),
+                    multi_steps_attn_metadata=None,
+                    num_tokens=4,
+                )
 
         self.assertFalse(AscendRotaryEmbedding310._is_drafting_update_enabled)

--- a/tests/ut/_310p/spec_decode/test_llm_base_proposer_310.py
+++ b/tests/ut/_310p/spec_decode/test_llm_base_proposer_310.py
@@ -27,7 +27,7 @@ class TestAscendSpecDecodeBaseProposer310(TestBase):
 
     def test_run_merged_draft_sets_rope_flag_before_call(self):
         flag_states = []
-        
+
         def mock_original(
             self,
             num_input_tokens,

--- a/vllm_ascend/_310p/attention/metadata_builder.py
+++ b/vllm_ascend/_310p/attention/metadata_builder.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import torch
 from vllm.config import VllmConfig
+from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.kv_cache_interface import AttentionSpec
 
 from vllm_ascend._310p.attention.attention_mask import (
@@ -85,27 +86,31 @@ class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
             self._query_lens_cpu_buffer = torch.empty(max_num_seqs, dtype=torch.int32, device="cpu", pin_memory=True)
 
     def _fill_query_lens_cpu(
-        self,
-        num_reqs: int,
-        query_start_loc_cpu: torch.Tensor,
+        self, num_reqs: int, query_start_loc_cpu: torch.Tensor, is_drafting: bool = False
     ) -> torch.Tensor:
         """Pinned CPU per-request query lengths for ATB splitfuse (host qLensTensor)."""
         if self._query_lens_cpu_buffer is None:
             return (query_start_loc_cpu[1 : num_reqs + 1] - query_start_loc_cpu[:num_reqs]).contiguous()
-
-        buffer = self._query_lens_cpu_buffer
+        if is_drafting:
+            # We are using the same buffer for multi step drafting,
+            # so we have to clone the buffer or the q lens of step 0
+            # will be overwritten by the following steps.
+            buffer = self._query_lens_cpu_buffer[:num_reqs].clone()
+        else:
+            buffer = self._query_lens_cpu_buffer[:num_reqs]
         torch.sub(
             query_start_loc_cpu[1 : num_reqs + 1],
             query_start_loc_cpu[:num_reqs],
-            out=buffer[:num_reqs],
+            out=buffer,
         )
-        return buffer[:num_reqs]
+        return buffer
 
     def build(
         self,
         common_prefix_len: int,
         common_attn_metadata: AscendCommonAttentionMetadata,
         fast_build: bool = False,
+        is_drafting: bool = False,
     ) -> AscendMetadata:
         attn_metadata = super().build(common_prefix_len, common_attn_metadata, fast_build)
 
@@ -122,7 +127,7 @@ class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
         # ATB splitfuse qLensTensor must be host; filled here (outside graph forward).
         set_query_lens_cpu(
             attn_metadata,
-            self._fill_query_lens_cpu(num_reqs, query_start_loc_cpu),
+            self._fill_query_lens_cpu(num_reqs, query_start_loc_cpu, is_drafting),
         )
 
         # Bind device-side views for in-place graph replay updates.
@@ -133,3 +138,13 @@ class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
             attn_metadata.attn_mask = AttentionMaskBuilder310.get_compressed_splitfuse_mask(self.device)
 
         return attn_metadata
+
+    def build_for_drafting(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        draft_index: int,
+    ):
+        # override build_for_drafting for passing status.
+        return self.build(
+            common_prefix_len=0, common_attn_metadata=common_attn_metadata, fast_build=True, is_drafting=True
+        )

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -76,7 +76,7 @@ class NPUModelRunner310(NPUModelRunner):
 
     # Inherited from parent runner; annotated here to satisfy strict type checks.
     uniform_decode_query_len: int
-    _mtp_spec_dummy_capture: bool = False
+    _spec_dummy_capture: bool = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -152,18 +152,16 @@ class NPUModelRunner310(NPUModelRunner):
         force_num_active_loras: int | None = None,
         num_encoder_reqs: int = 0,
     ):
+        is_all_decode = np.all(self.input_batch.num_computed_tokens_cpu[:num_reqs] > 0)
+
         if self.attn_state in (AscendAttentionState.ChunkedPrefill, AscendAttentionState.PrefillCacheHit):
             force_eager = True
 
-        # MTP graph replay is only valid for uniform spec-decode batches (q_len = 1 + K).
-        if (
-            self.speculative_config is not None
-            and self.speculative_config.method == "mtp"
-            and (
-                self.attn_state != AscendAttentionState.SpecDecoding
-                or max_num_scheduled_tokens != self.uniform_decode_query_len
-                or num_tokens != max_num_scheduled_tokens * num_reqs
-            )
+        # Spec decoding graph replay is only valid for uniform spec-decode batches (q_len = 1 + K).
+        if self.speculative_config is not None and (
+            self.attn_state != AscendAttentionState.SpecDecoding
+            or max_num_scheduled_tokens != self.uniform_decode_query_len
+            or num_tokens != max_num_scheduled_tokens * num_reqs
         ):
             force_eager = True
 
@@ -172,7 +170,7 @@ class NPUModelRunner310(NPUModelRunner):
             if (
                 max_num_scheduled_tokens == decode_query_len
                 and num_tokens == max_num_scheduled_tokens * num_reqs
-                and np.all(self.input_batch.num_computed_tokens_cpu[:num_reqs] > 0)
+                and is_all_decode
             ):
                 # Respect explicit caller override: only force when unset.
                 force_uniform_decode = True
@@ -193,8 +191,8 @@ class NPUModelRunner310(NPUModelRunner):
 
     def _build_attention_metadata(self, *args: Any, **kwargs: Any):
         # Parent dummy_run assigns ChunkedPrefill for non-MLA MTP (910B FIA graph).
-        # 310P must capture SpecDecoding + splitfuse for MTP uniform decode graphs.
-        if self._mtp_spec_dummy_capture:
+        # 310P must capture SpecDecoding + splitfuse for SpecDecoding uniform decode graphs.
+        if self._spec_dummy_capture:
             self.attn_state = AscendAttentionState.SpecDecoding
         return super()._build_attention_metadata(*args, **kwargs)
 
@@ -236,7 +234,6 @@ class NPUModelRunner310(NPUModelRunner):
         attn_state = super()._build_attn_state(num_reqs, num_scheduled_tokens, num_valid_tokens)
         if (
             self.speculative_config is not None
-            and self.speculative_config.method == "mtp"
             and not np.all(self.input_batch.num_computed_tokens_cpu[:num_reqs] == 0)
             and np.all(num_scheduled_tokens == self.uniform_decode_query_len)
         ):
@@ -280,6 +277,60 @@ class NPUModelRunner310(NPUModelRunner):
         self.with_prefill = with_prefill
 
         cu_num_tokens = self._get_cumsum_and_arange(num_scheduled_tokens, self.query_pos.np)
+        prev_req_id_to_index = self.input_batch.prev_req_id_to_index
+        self._compute_prev_positions(num_reqs)
+
+        if self.num_accepted_tokens_event is not None:
+            self.num_accepted_tokens_event.synchronize()
+            if self.use_async_scheduling and prev_req_id_to_index:
+                prev_idx = self.prev_positions.np[:num_reqs]
+                new_mask = prev_idx < 0
+                self.num_accepted_tokens.np[:num_reqs] = self.input_batch.num_accepted_tokens_cpu[
+                    np.where(new_mask, 0, prev_idx)
+                ]
+                self.num_accepted_tokens.np[:num_reqs][new_mask] = 1
+                self.input_batch.num_accepted_tokens_cpu[:num_reqs] = self.num_accepted_tokens.np[:num_reqs]
+            else:
+                self.num_accepted_tokens.np[:num_reqs] = self.input_batch.num_accepted_tokens_cpu[:num_reqs]
+            self.num_accepted_tokens.np[num_reqs:].fill(1)
+            self.num_accepted_tokens.copy_to_gpu()
+        else:
+            if is_rc_device():
+                self.num_accepted_tokens.np[num_reqs:].fill(1)
+                self.num_accepted_tokens.copy_to_gpu()
+            else:
+                self.num_accepted_tokens.np.fill(1)
+                self.num_accepted_tokens.gpu.fill_(1)
+
+        need_async_num_computed_update = (
+            self.use_async_spec_decode and self.valid_sampled_token_count_gpu is not None and prev_req_id_to_index
+        )
+
+        if need_async_num_computed_update:
+            self.prev_positions.copy_to_gpu(num_reqs)
+            self.prev_num_draft_tokens.copy_to_gpu()
+            cpu_values = self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs].to(
+                device=self.device, non_blocking=True
+            )
+            update_num_computed_tokens_for_batch_change(
+                self.num_computed_tokens,
+                self.num_accepted_tokens.gpu[:num_reqs],
+                self.prev_positions.gpu[:num_reqs],
+                self.valid_sampled_token_count_gpu,
+                self.prev_num_draft_tokens.gpu,
+                cpu_values,
+            )
+            # Make sure D2H is synchronized.
+            self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs].copy_(
+                self.num_computed_tokens[:num_reqs], non_blocking=False
+            )
+        else:
+            self.num_computed_tokens[:num_reqs].copy_(
+                self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs],
+                non_blocking=True,
+            )
+        # Make sure when you update the positions and slot mapping, num_computed_tokens_cpu
+        # has been corrected.
         positions_np = self._positions_np_buf[:total_num_scheduled_tokens]
         np.add(
             self.input_batch.num_computed_tokens_cpu[req_indices],
@@ -300,13 +351,6 @@ class NPUModelRunner310(NPUModelRunner):
                 self.input_batch.num_prompt_tokens,
             )
 
-        prev_req_id_to_index = self.input_batch.prev_req_id_to_index
-        self._compute_prev_positions(num_reqs)
-        prev_positions_gpu = None
-        if self.use_async_scheduling and self.input_batch.prev_sampled_token_ids is not None and prev_req_id_to_index:
-            self.prev_positions.copy_to_gpu(num_reqs)
-            prev_positions_gpu = self.prev_positions.gpu[:num_reqs]
-
         if self.speculative_config and self.use_cp:
             self.pcp_manager.generate_pcp_mtp_input(
                 total_num_scheduled_tokens,
@@ -320,7 +364,6 @@ class NPUModelRunner310(NPUModelRunner):
                 self._draft_token_ids,  # type: ignore[has-type]
                 scheduler_output,
                 self.num_spec_tokens,
-                prev_positions=prev_positions_gpu,
             )
 
         if self.pcp_size > 1:
@@ -450,52 +493,6 @@ class NPUModelRunner310(NPUModelRunner):
         self.num_discarded_requests = len(discard_request_indices)
         self.discard_request_indices.np[: self.num_discarded_requests] = discard_request_indices
         self.discard_request_indices.copy_to_gpu(self.num_discarded_requests)
-
-        if self.num_accepted_tokens_event is not None:
-            self.num_accepted_tokens_event.synchronize()
-            if self.use_async_scheduling and prev_req_id_to_index:
-                prev_idx = self.prev_positions.np[:num_reqs]
-                new_mask = prev_idx < 0
-                self.num_accepted_tokens.np[:num_reqs] = self.input_batch.num_accepted_tokens_cpu[
-                    np.where(new_mask, 0, prev_idx)
-                ]
-                self.num_accepted_tokens.np[:num_reqs][new_mask] = 1
-                self.input_batch.num_accepted_tokens_cpu[:num_reqs] = self.num_accepted_tokens.np[:num_reqs]
-            else:
-                self.num_accepted_tokens.np[:num_reqs] = self.input_batch.num_accepted_tokens_cpu[:num_reqs]
-            self.num_accepted_tokens.np[num_reqs:].fill(1)
-            self.num_accepted_tokens.copy_to_gpu()
-        else:
-            if is_rc_device():
-                self.num_accepted_tokens.np[num_reqs:].fill(1)
-                self.num_accepted_tokens.copy_to_gpu()
-            else:
-                self.num_accepted_tokens.np.fill(1)
-                self.num_accepted_tokens.gpu.fill_(1)
-
-        need_async_num_computed_update = (
-            self.use_async_spec_decode and self.valid_sampled_token_count_gpu is not None and prev_req_id_to_index
-        )
-        if need_async_num_computed_update:
-            if prev_positions_gpu is None:
-                self.prev_positions.copy_to_gpu(num_reqs)
-            self.prev_num_draft_tokens.copy_to_gpu()
-            cpu_values = self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs].to(
-                device=self.device, non_blocking=True
-            )
-            update_num_computed_tokens_for_batch_change(
-                self.num_computed_tokens,
-                self.num_accepted_tokens.gpu[:num_reqs],
-                self.prev_positions.gpu[:num_reqs],
-                self.valid_sampled_token_count_gpu,
-                self.prev_num_draft_tokens.gpu,
-                cpu_values,
-            )
-        else:
-            self.num_computed_tokens[:num_reqs].copy_(
-                self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs],
-                non_blocking=True,
-            )
 
         self.req_indices.np[:total_num_scheduled_tokens] = req_indices
         self.req_indices.copy_to_gpu(total_num_scheduled_tokens)
@@ -628,15 +625,15 @@ class NPUModelRunner310(NPUModelRunner):
         profile_seq_lens: int | None = None,
     ):
         temporary_context = self.temporary_modify_uniform_decode_query_len() if uniform_decode else nullcontext()
-        mtp_spec_dummy_capture = (
+        # All the spec decoding cases has to run splitfuse op on 310P.
+        is_spec_graph_capture = (
             uniform_decode
             and not is_profile
             and self.speculative_config is not None
-            and self.speculative_config.method == "mtp"
             and not self.vllm_config.model_config.use_mla
         )
         with temporary_context:
-            self._mtp_spec_dummy_capture = mtp_spec_dummy_capture
+            self._spec_dummy_capture = is_spec_graph_capture
             try:
                 return super()._dummy_run(
                     num_tokens=num_tokens,
@@ -654,7 +651,7 @@ class NPUModelRunner310(NPUModelRunner):
                     profile_seq_lens=profile_seq_lens,
                 )
             finally:
-                self._mtp_spec_dummy_capture = False
+                self._spec_dummy_capture = False
 
     def _model_forward(
         self,
@@ -682,7 +679,6 @@ class NPUModelRunner310(NPUModelRunner):
         run_model = partial(self.model, **model_inputs)
         update_before_replay = (
             self.speculative_config is not None
-            and self.speculative_config.method == "mtp"
             and not self.enable_enpu
             and forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL
             and not forward_context.capturing

--- a/vllm_ascend/_310p/ops/rotary_embedding.py
+++ b/vllm_ascend/_310p/ops/rotary_embedding.py
@@ -25,11 +25,18 @@ from vllm.model_executor.layers.rotary_embedding import MRotaryEmbedding
 from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
 from vllm.model_executor.layers.rotary_embedding.mrope import apply_interleaved_rope
 
-from vllm_ascend.ops.rotary_embedding import AscendRotaryEmbedding, get_cos_and_sin_slice
+from vllm_ascend.ops.rotary_embedding import AscendRotaryEmbedding, get_cos_and_sin_slice, update_cos_sin
 
 # Filled once per model forward in NPUModelRunner310._model_forward; read by every MRoPE layer.
 _mrope_cos_slice: torch.Tensor | None = None
 _mrope_sin_slice: torch.Tensor | None = None
+
+_ROPE_310P_UPDATE_FLAG = False
+
+
+def set_rope_position_flag_310p(state):
+    global _ROPE_310P_UPDATE_FLAG
+    _ROPE_310P_UPDATE_FLAG = state
 
 
 def _apply_rotary_mrope_torch(
@@ -131,6 +138,12 @@ def _rope_forward_oot(
         self.cos_sin_cache = self.cos_sin_cache.to(query.device)
     if self.cos_sin_cache.dtype != query.dtype:
         self.cos_sin_cache = self.cos_sin_cache.to(query.dtype)
+
+    # This flag should set to True when doing drafting.
+    global _ROPE_310P_UPDATE_FLAG
+    if _ROPE_310P_UPDATE_FLAG:
+        update_cos_sin(positions)
+
     cos, sin = get_cos_and_sin_slice()
     if offsets is not None:
         raise NotImplementedError("Batched rotary embedding is currently not supported on NPU.")

--- a/vllm_ascend/_310p/ops/rotary_embedding.py
+++ b/vllm_ascend/_310p/ops/rotary_embedding.py
@@ -260,7 +260,6 @@ def prepare_mrope_cos_sin_slices_from_runner(runner: Any, positions: torch.Tenso
 
 
 class AscendRotaryEmbedding310(AscendRotaryEmbedding):
-
     _is_drafting_update_enabled: bool = False
 
     @classmethod

--- a/vllm_ascend/_310p/ops/rotary_embedding.py
+++ b/vllm_ascend/_310p/ops/rotary_embedding.py
@@ -140,8 +140,7 @@ def _rope_forward_oot(
         self.cos_sin_cache = self.cos_sin_cache.to(query.dtype)
 
     # This flag should set to True when doing drafting.
-    global _ROPE_310P_UPDATE_FLAG
-    if _ROPE_310P_UPDATE_FLAG:
+    if getattr(self, "_is_drafting_update_enabled", False):
         update_cos_sin(positions)
 
     cos, sin = get_cos_and_sin_slice()
@@ -261,6 +260,13 @@ def prepare_mrope_cos_sin_slices_from_runner(runner: Any, positions: torch.Tenso
 
 
 class AscendRotaryEmbedding310(AscendRotaryEmbedding):
+
+    _is_drafting_update_enabled: bool = False
+
+    @classmethod
+    def set_rope_position_flag_310p(cls, state: bool):
+        cls._is_drafting_update_enabled = state
+
     def forward_oot(
         self,
         positions: torch.Tensor,

--- a/vllm_ascend/_310p/ops/rotary_embedding.py
+++ b/vllm_ascend/_310p/ops/rotary_embedding.py
@@ -31,13 +31,6 @@ from vllm_ascend.ops.rotary_embedding import AscendRotaryEmbedding, get_cos_and_
 _mrope_cos_slice: torch.Tensor | None = None
 _mrope_sin_slice: torch.Tensor | None = None
 
-_ROPE_310P_UPDATE_FLAG = False
-
-
-def set_rope_position_flag_310p(state):
-    global _ROPE_310P_UPDATE_FLAG
-    _ROPE_310P_UPDATE_FLAG = state
-
 
 def _apply_rotary_mrope_torch(
     q_rot: torch.Tensor,

--- a/vllm_ascend/_310p/spec_decode/llm_base_proposer_310.py
+++ b/vllm_ascend/_310p/spec_decode/llm_base_proposer_310.py
@@ -20,7 +20,7 @@ from typing import Any
 import torch
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 
-from vllm_ascend._310p.ops.rotary_embedding import set_rope_position_flag_310p
+from vllm_ascend._310p.ops.rotary_embedding import AscendRotaryEmbedding310
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
 
 _original_run_merged_draft = AscendSpecDecodeBaseProposer._run_merged_draft
@@ -40,7 +40,7 @@ class AscendSpecDecodeBaseProposer310(AscendSpecDecodeBaseProposer):
         num_tokens,
         is_prefill=None,
     ) -> torch.Tensor:
-        set_rope_position_flag_310p(True)
+        AscendRotaryEmbedding310.set_rope_position_flag_310p(True)
         try:
             result = _original_run_merged_draft(
                 self,
@@ -54,7 +54,7 @@ class AscendSpecDecodeBaseProposer310(AscendSpecDecodeBaseProposer):
                 is_prefill,
             )
         finally:
-            set_rope_position_flag_310p(False)
+            AscendRotaryEmbedding310.set_rope_position_flag_310p(False)
         return result
 
     def set_inputs_first_pass(

--- a/vllm_ascend/_310p/spec_decode/llm_base_proposer_310.py
+++ b/vllm_ascend/_310p/spec_decode/llm_base_proposer_310.py
@@ -20,11 +20,42 @@ from typing import Any
 import torch
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 
+from vllm_ascend._310p.ops.rotary_embedding import set_rope_position_flag_310p
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
+
+_original_run_merged_draft = AscendSpecDecodeBaseProposer._run_merged_draft
 
 
 class AscendSpecDecodeBaseProposer310(AscendSpecDecodeBaseProposer):
     """310P proposer overrides for NPU-specific spec-decode workarounds."""
+
+    def _run_merged_draft(
+        self,
+        num_input_tokens,
+        batch_size,
+        token_indices_to_sample,
+        target_positions,
+        inputs_embeds,
+        multi_steps_attn_metadata,
+        num_tokens,
+        is_prefill=None,
+    ) -> torch.Tensor:
+        set_rope_position_flag_310p(True)
+        try:
+            result = _original_run_merged_draft(
+                self,
+                num_input_tokens,
+                batch_size,
+                token_indices_to_sample,
+                target_positions,
+                inputs_embeds,
+                multi_steps_attn_metadata,
+                num_tokens,
+                is_prefill,
+            )
+        finally:
+            set_rope_position_flag_310p(False)
+        return result
 
     def set_inputs_first_pass(
         self,

--- a/vllm_ascend/patch/worker/patch_idex_310.py
+++ b/vllm_ascend/patch/worker/patch_idex_310.py
@@ -21,6 +21,10 @@ vllm.model_executor.layers.fla.ops.index.prepare_chunk_offsets = prepare_chunk_o
 AscendSpecDecodeBaseProposer.set_inputs_first_pass = (  # type: ignore[method-assign]
     AscendSpecDecodeBaseProposer310.set_inputs_first_pass
 )
+AscendSpecDecodeBaseProposer._run_merged_draft = (  # type: ignore[method-assign]
+    AscendSpecDecodeBaseProposer310._run_merged_draft
+)
+
 # Patch _warmup_prefill_kernels to no-op on 310P: triton.next_power_of_2 does
 # not exist in the triton version used on 310P CI, and NPU does not use these
 # CUDA warmup kernel anyway.
@@ -35,14 +39,9 @@ QwenGatedDeltaNetAttention.get_state_dtype = AscendGatedDeltaNetAttention310.get
 QwenGatedDeltaNetAttention.get_attn_backend = AscendGatedDeltaNetAttention310.get_attn_backend
 
 if is_rc_device():
-    from vllm.model_executor.models.qwen3_vl import Qwen3_VisionTransformer
     from vllm.v1.attention.backends.gdn_attn import GDNAttentionBackend
 
     from vllm_ascend._310p.ops.gdn_attn_builder_310 import GDNAttentionMetadataBuilder310
-    from vllm_ascend._310p.ops.qwen3vl_310 import rot_pos_emb_310
-
-    # 310P RC: use blocking H2D in rot_pos_emb to avoid race with subsequent indexing.
-    Qwen3_VisionTransformer.rot_pos_emb = rot_pos_emb_310  # type: ignore[method-assign]
 
     # Qwen3.5 on 310P RC uses upstream GDNAttentionBackend via MambaBase.get_attn_backend().
     GDNAttentionBackend.get_builder_cls = staticmethod(  # type: ignore[method-assign]


### PR DESCRIPTION
### What this PR does / why we need it?
Backports #11918 to releases/v0.23.0

This PR resolve some bugs on 310P in spec-decoding cases.
**(1) The rope misalignment issue in non-MTP scenarios on the 310p.**
**(2) ACLGraph support for non MTP spec-decoding cases.**
**(3) Incorrect metadata generation in spec-decoding:**
- **wrong slot-mapping calculation:** Solved by updating after the 'num_computed_token' is corrected in model runner 310P.
- **wrong query lens calculation for splitfuse OP of the step 0 of drafting:** Solved by avoiding reusing the same buffer in metadata builder. In this case the query lens of the step will not be the overwritten by the following step.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Local machine tested.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
