### PR TITLE
[BugFix] Fix AllGather MoE finalize order with DP and PCP

### DIFF
--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -538,11 +538,11 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
         Returns:
             Tensor with shape [original_local_num_tokens, hidden_size]
         """
-        if self.moe_config.dp_size > 1 and not self.enable_shared_expert_dp:
-            hidden_states = get_dp_group().reduce_scatter(hidden_states, 0)
-            hidden_states = hidden_states[: self.num_tokens]
-
         if self.moe_config.pcp_size > 1:
             hidden_states = get_pcp_group().reduce_scatter(hidden_states, dim=0)
             hidden_states = hidden_states[: self.num_tokens_pcp]
+
+        if self.moe_config.dp_size > 1 and not self.enable_shared_expert_dp:
+            hidden_states = get_dp_group().reduce_scatter(hidden_states, 0)
+            hidden_states = hidden_states[: self.num_tokens]
         return hidden_states


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes the Ascend AllGather MoE finalize path when both DP and PCP are enabled.

The prepare path gathers inputs in this order:

```text
DP all_gather -> PCP all_gather
```

However, the finalize path reduced the output in the same order. Since the token dimension is flattened, each `reduce_scatter` must undo the matching `all_gather` in reverse order to preserve token ownership on each rank.

This PR changes the finalize order to mirror prepare in reverse:

```text
PCP reduce_scatter -> DP reduce_scatter
```

and slices the output after each corresponding `reduce_scatter` using the token count recorded before the matching `all_gather`.

Without this, the routed expert output can be scattered/sliced to the wrong token segment or wrong length when both DP and PCP are enabled, causing shape mismatches when vLLM combines routed and shared expert outputs:

```text
RuntimeError: The size of tensor a (...) must match the size of tensor b (...) at non-singleton dimension 0
```

### Does this PR introduce _any_ user-facing change?

No. This is an internal correctness fix for the Ascend AllGather MoE communication finalize path.

It does not change public APIs, configuration options, or expected user-facing behavior, except that affected DP+PCP AllGather MoE configurations no longer fail with routed/shared output shape mismatches or incorrect token ownership after finalize.

### How was this patch tested?

- [x] Run HunyuanImage-3.0 with pcp2 dp2 ep4, verify correct output


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
