### PR TITLE
[Doc] Standardize Docker installation section across MoE model docs (release v0.23.0)

### DIFF
--- a/docs/source/tutorials/models/MiniMax-M2.md
+++ b/docs/source/tutorials/models/MiniMax-M2.md
@@ -38,107 +38,117 @@ If you need to deploy a multi-node environment, verify the multi-node communicat
 
 ### 4.1 Docker Image Installation
 
-Select an image based on your machine type and start the container on your node. For the available image tags and published versions, refer to [Using Docker](../../installation.md#set-up-using-docker).
+You can use the official all-in-one Docker image. For the available image tags and published versions, refer to [Using Docker](../../installation.md#set-up-using-docker).
 
-**A3 series**
+:::::{tab-set}
+:sync-group: hardware
+
+::::{tab-item} A3 series
+:sync: a3
+
+**Docker Run:**
 
 ```{code-block} bash
    :substitutions:
-# Update the vllm-ascend image
-export IMAGE=m.daocloud.io/quay.io/ascend/vllm-ascend:|vllm_ascend_version|
-export NAME=vllm-ascend
 
-# Run the container using the defined variables
-# Note: If you are running bridge network with docker, please expose available ports for multiple nodes communication in advance
-docker run --rm \
---name $NAME \
---net=host \
---shm-size=1g \
---device /dev/davinci0 \
---device /dev/davinci1 \
---device /dev/davinci2 \
---device /dev/davinci3 \
---device /dev/davinci4 \
---device /dev/davinci5 \
---device /dev/davinci6 \
---device /dev/davinci7 \
---device /dev/davinci8 \
---device /dev/davinci9 \
---device /dev/davinci10 \
---device /dev/davinci11 \
---device /dev/davinci12 \
---device /dev/davinci13 \
---device /dev/davinci14 \
---device /dev/davinci15 \
---device /dev/davinci_manager \
---device /dev/devmm_svm \
---device /dev/hisi_hdc \
--v /usr/local/dcmi:/usr/local/dcmi \
--v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
--v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
--v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
--v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
--v /etc/ascend_install.info:/etc/ascend_install.info \
--v /root/.cache:/root/.cache \
--it $IMAGE bash
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|-a3
+
+docker run \
+    --name vllm-ascend-env \
+    --ipc host \
+    --net host \
+    --device /dev/davinci0 \
+    --device /dev/davinci1 \
+    --device /dev/davinci2 \
+    --device /dev/davinci3 \
+    --device /dev/davinci4 \
+    --device /dev/davinci5 \
+    --device /dev/davinci6 \
+    --device /dev/davinci7 \
+    --device /dev/davinci8 \
+    --device /dev/davinci9 \
+    --device /dev/davinci10 \
+    --device /dev/davinci11 \
+    --device /dev/davinci12 \
+    --device /dev/davinci13 \
+    --device /dev/davinci14 \
+    --device /dev/davinci15 \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /usr/local/sbin:/usr/local/sbin \
+    -it -d $IMAGE bash
 ```
 
-**A2 series**
+:::{note}
+A3 has 16 NPUs with dual-die design (`/dev/davinci[0-15]`).
+If you are on a shared machine, map only the chips you need (e.g., `/dev/davinci[0-7]` for NPU 0-3).
+:::
 
-Map your model weight directory into the container (the example maps it to `/root/.cache/`).
+::::
+
+::::{tab-item} A2 series
+:sync: a2
+
+**Docker Run:**
 
 ```{code-block} bash
-#!/bin/sh
-NAME=minimax
-IMAGE=m.daocloud.io/quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+   :substitutions:
 
-docker run -itd -u 0 --ipc=host \
-  -e VLLM_USE_MODELSCOPE=True \
-  -e PYTORCH_NPU_ALLOC_CONF=max_split_size_mb:256 \
-  --name $NAME \
-  --net=host \
-  --device /dev/davinci_manager \
-  --device /dev/devmm_svm \
-  --device /dev/hisi_hdc \
-  --device /dev/davinci0 \
-  --device /dev/davinci1 \
-  --device /dev/davinci2 \
-  --device /dev/davinci3 \
-  --device /dev/davinci4 \
-  --device /dev/davinci5 \
-  --device /dev/davinci6 \
-  --device /dev/davinci7 \
-  --shm-size=1200g \
-  -v /usr/local/dcmi:/usr/local/dcmi \
-  -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
-  -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
-  -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
-  -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
-  -v /etc/ascend_install.info:/etc/ascend_install.info \
-  -v /root/.cache:/root/.cache \
-  -it $IMAGE bash
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+
+docker run \
+    --name vllm-ascend-env \
+    --ipc host \
+    --net host \
+    --device /dev/davinci0 \
+    --device /dev/davinci1 \
+    --device /dev/davinci2 \
+    --device /dev/davinci3 \
+    --device /dev/davinci4 \
+    --device /dev/davinci5 \
+    --device /dev/davinci6 \
+    --device /dev/davinci7 \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /usr/local/sbin:/usr/local/sbin \
+    -it -d $IMAGE bash
 ```
 
-Save the script as `minimax-docker-run.sh`, then start and enter the container:
+::::
+
+:::::
+
+:::{tip}
+The mounts above are the minimum required for NPU driver access. Add additional `-v` mounts (e.g., model weight paths, datasets) as needed for your environment.
+:::
+
+The default workdir is `/workspace`. vLLM and vLLM-Ascend are installed as Python packages in site-packages.
+
+**Installation Verification:**
+
+After starting the container, run the following command to verify the installation:
 
 ```bash
-bash minimax-docker-run.sh
-docker exec -it minimax bash
+docker ps | grep vllm-ascend-env
 ```
 
-**Verification:**
-
-After starting the container, verify the installation with:
+Expected result: The container is listed with status `Up`. You can also verify the vllm-ascend version inside the container:
 
 ```bash
-# Check that the container is running
-docker ps | grep $NAME
-
-# Verify that NPU devices are visible inside the container
-docker exec $NAME npu-smi info
+pip show vllm-ascend
 ```
 
-Expected result: `docker ps` shows the container with status "Up", and `npu-smi info` lists the expected number of NPU devices.
+Expected result: The version information is displayed, matching the pulled image version.
 
 ### 4.2 Source Code Installation
 

--- a/docs/source/tutorials/models/MiniMax-M2.md
+++ b/docs/source/tutorials/models/MiniMax-M2.md
@@ -85,7 +85,7 @@ docker run \
 ```
 
 :::{note}
-A3 has 16 NPUs with dual-die design (`/dev/davinci[0-15]`).
+A3 has 8 NPUs with dual-die design (16 chips total: `/dev/davinci[0-15]`).
 If you are on a shared machine, map only the chips you need (e.g., `/dev/davinci[0-7]` for NPU 0-3).
 :::
 

--- a/docs/source/tutorials/models/Qwen3-30B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3-30B-A3B.md
@@ -49,16 +49,8 @@ You can use the official all-in-one Docker image for Qwen3 MoE models.
 :::::{tab-set}
 :sync-group: hardware
 
-::::{tab-item} Atlas 800I A3
+::::{tab-item} A3 series
 :sync: a3
-
-**Docker Pull:**
-
-```{code-block} bash
-   :substitutions:
-
-docker pull quay.io/ascend/vllm-ascend:|vllm_ascend_version|-a3
-```
 
 **Docker Run:**
 
@@ -69,9 +61,8 @@ export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|-a3
 
 docker run \
     --name vllm-ascend-env \
-    --shm-size=128g \
-    --net=host \
-    --privileged=true \
+    --ipc host \
+    --net host \
     --device /dev/davinci0 \
     --device /dev/davinci1 \
     --device /dev/davinci2 \
@@ -96,12 +87,6 @@ docker run \
     -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
     -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v /usr/local/sbin:/usr/local/sbin \
-    -v /home:/home \
-    -v /data:/data \
-    -v /tmp:/tmp \
-    -v /mnt:/mnt \
-    -v /usr/share/zoneinfo/Asia/Shanghai:/etc/localtime \
-    -v /root:/host_root \
     -it -d $IMAGE bash
 ```
 
@@ -112,16 +97,8 @@ If you are on a shared machine, map only the chips you need (e.g., `/dev/davinci
 
 ::::
 
-::::{tab-item} Atlas 800I A2
+::::{tab-item} A2 series
 :sync: a2
-
-**Docker Pull:**
-
-```{code-block} bash
-   :substitutions:
-
-docker pull quay.io/ascend/vllm-ascend:|vllm_ascend_version|
-```
 
 **Docker Run:**
 
@@ -132,9 +109,8 @@ export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 
 docker run \
     --name vllm-ascend-env \
-    --shm-size=128g \
-    --net=host \
-    --privileged=true \
+    --ipc host \
+    --net host \
     --device /dev/davinci0 \
     --device /dev/davinci1 \
     --device /dev/davinci2 \
@@ -151,18 +127,16 @@ docker run \
     -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
     -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v /usr/local/sbin:/usr/local/sbin \
-    -v /home:/home \
-    -v /data:/data \
-    -v /tmp:/tmp \
-    -v /mnt:/mnt \
-    -v /usr/share/zoneinfo/Asia/Shanghai:/etc/localtime \
-    -v /root:/host_root \
     -it -d $IMAGE bash
 ```
 
 ::::
 
 :::::
+
+:::{tip}
+The mounts above are the minimum required for NPU driver access. Add additional `-v` mounts (e.g., model weight paths, datasets) as needed for your environment.
+:::
 
 The default workdir is `/workspace`. vLLM and vLLM-Ascend are installed as Python packages in site-packages.
 

--- a/docs/source/tutorials/models/Qwen3-Coder-30B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3-Coder-30B-A3B.md
@@ -49,16 +49,8 @@ You can use the official all-in-one Docker image for Qwen3 MoE models.
 :::::{tab-set}
 :sync-group: hardware
 
-::::{tab-item} Atlas 800I A3
+::::{tab-item} A3 series
 :sync: a3
-
-**Docker Pull:**
-
-```{code-block} bash
-   :substitutions:
-
-docker pull quay.io/ascend/vllm-ascend:|vllm_ascend_version|-a3
-```
 
 **Docker Run:**
 
@@ -69,9 +61,8 @@ export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|-a3
 
 docker run \
     --name vllm-ascend-env \
-    --shm-size=128g \
-    --net=host \
-    --privileged=true \
+    --ipc host \
+    --net host \
     --device /dev/davinci0 \
     --device /dev/davinci1 \
     --device /dev/davinci2 \
@@ -96,12 +87,6 @@ docker run \
     -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
     -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v /usr/local/sbin:/usr/local/sbin \
-    -v /home:/home \
-    -v /data:/data \
-    -v /tmp:/tmp \
-    -v /mnt:/mnt \
-    -v /usr/share/zoneinfo/Asia/Shanghai:/etc/localtime \
-    -v /root:/host_root \
     -it -d $IMAGE bash
 ```
 
@@ -112,16 +97,8 @@ If you are on a shared machine, map only the chips you need (e.g., `/dev/davinci
 
 ::::
 
-::::{tab-item} Atlas 800I A2
+::::{tab-item} A2 series
 :sync: a2
-
-**Docker Pull:**
-
-```{code-block} bash
-   :substitutions:
-
-docker pull quay.io/ascend/vllm-ascend:|vllm_ascend_version|
-```
 
 **Docker Run:**
 
@@ -132,9 +109,8 @@ export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 
 docker run \
     --name vllm-ascend-env \
-    --shm-size=128g \
-    --net=host \
-    --privileged=true \
+    --ipc host \
+    --net host \
     --device /dev/davinci0 \
     --device /dev/davinci1 \
     --device /dev/davinci2 \
@@ -151,18 +127,16 @@ docker run \
     -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
     -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v /usr/local/sbin:/usr/local/sbin \
-    -v /home:/home \
-    -v /data:/data \
-    -v /tmp:/tmp \
-    -v /mnt:/mnt \
-    -v /usr/share/zoneinfo/Asia/Shanghai:/etc/localtime \
-    -v /root:/host_root \
     -it -d $IMAGE bash
 ```
 
 ::::
 
 :::::
+
+:::{tip}
+The mounts above are the minimum required for NPU driver access. Add additional `-v` mounts (e.g., model weight paths, datasets) as needed for your environment.
+:::
 
 The default workdir is `/workspace`. vLLM and vLLM-Ascend are installed as Python packages in site-packages.
 


### PR DESCRIPTION
### What this PR does / why we need it?

Backport of PR #11463 to `releases/v0.23.0`.

Standardize and simplify the Docker Image Installation section (4.1) in three MoE model docs using Sphinx syntax:

- **MiniMax-M2.md**
- **Qwen3-30B-A3B.md**
- **Qwen3-Coder-30B-A3B.md**

Changes (same as #11463, adapted to Sphinx `::::{tab-set}` format):

1. **Simplify Docker run command**: `--shm-size=...` to `--ipc host`, `--net=host` to `--net host`, remove `--privileged` (redundant with explicit `--device` mappings)
2. **Simplify volume mounts**: Keep only NPU driver essentials (driver, dcmi, npu-smi, install.info, sbin), remove `/home`, `/data`, `/tmp`, `/mnt`, timezone, `/root:/host_root`
3. **Remove redundant `docker pull`**: `docker run` auto-pulls the image
4. **Align tab names**: Use "A3 series" / "A2 series" (matches Model-Deployment-Tutorial-Template.md)
5. **Add `:::{tip}`**: Note that users can add extra `-v` mounts as needed
6. **Add Installation Verification section** (MiniMax-M2 was missing it)
7. **Convert MiniMax-M2 to Sphinx tab-set**: It previously used flat A3/A2 sections without tabs

### Does this PR introduce any user-facing change?

No. Documentation-only update.

### How was this patch tested?

Reviewed the rendered markdown to confirm Sphinx tab-set structure, code blocks, and tip display correctly. The same substantive changes were tested on S5 (Atlas 800 A3) in #11463.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
