### PR TITLE
[Cherry-pick][releases/v0.23.0][Doc][Misc] Remove invalid fuse_muls_add from additional-config

### DIFF
--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -148,7 +148,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8 \
 --gpu-memory-utilization 0.95 \
 --quantization ascend \
 --async-scheduling \
---additional-config '{"fuse_muls_add":true,"multistream_overlap_shared_expert":true}' \
+--additional-config '{"multistream_overlap_shared_expert":true}' \
 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
 --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
 
@@ -219,7 +219,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8 \
 --enable-prefix-caching \
 --async-scheduling \
 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---additional-config '{"fuse_muls_add":true,"multistream_overlap_shared_expert":true}' \
+--additional-config '{"multistream_overlap_shared_expert":true}' \
 --speculative-config '{"num_speculative_tokens": 5, "method": "deepseek_mtp"}'
 ```
 
@@ -271,7 +271,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8 \
 --enable-prefix-caching \
 --async-scheduling \
 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---additional-config '{"fuse_muls_add":true,"multistream_overlap_shared_expert":true}' \
+--additional-config '{"multistream_overlap_shared_expert":true}' \
 --speculative-config '{"num_speculative_tokens": 5, "method": "deepseek_mtp"}'
 ```
 
@@ -333,7 +333,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8 \
 --safetensors-load-strategy 'prefetch' \
 --block-size 128 \
 --async-scheduling \
---additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true}' \
+--additional-config '{"multistream_overlap_shared_expert": true}' \
 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
 --speculative-config '{"num_speculative_tokens": 5, "method": "deepseek_mtp"}'
 ```
@@ -391,7 +391,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8 \
 --safetensors-load-strategy 'prefetch' \
 --block-size 128 \
 --async-scheduling \
---additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true}' \
+--additional-config '{"multistream_overlap_shared_expert": true}' \
 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
 --speculative-config '{"num_speculative_tokens": 5, "method": "deepseek_mtp"}'
 ```
@@ -455,7 +455,7 @@ vllm serve <MODEL_PATH> \
   --enable-chunked-prefill \
   --no-enable-prefix-caching \
   --async-scheduling \
-  --additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true}' \
+  --additional-config '{"multistream_overlap_shared_expert": true}' \
   --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
   --speculative-config '{"num_speculative_tokens": 5, "method": "deepseek_mtp"}'
 ```
@@ -514,7 +514,7 @@ vllm serve <MODEL_PATH> \
   --enable-chunked-prefill \
   --no-enable-prefix-caching \
   --async-scheduling \
-  --additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true}' \
+  --additional-config '{"multistream_overlap_shared_expert": true}' \
   --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
   --speculative-config '{"num_speculative_tokens": 5, "method": "deepseek_mtp"}'
 ```
@@ -674,7 +674,7 @@ Before you start, please
             --served-model-name glm-52 \
             --max-model-len 135000 \
             --speculative-config '{"num_speculative_tokens": 5, "method":"deepseek_mtp"}' \
-            --additional-config '{"enable_sparse_c8":false,"fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_dsa_cp": true}' \
+            --additional-config '{"enable_sparse_c8":false,"multistream_overlap_shared_expert": true, "enable_dsa_cp": true}' \
             --max-num-batched-tokens 4096 \
             --trust-remote-code \
             --max-num-seqs 64 \
@@ -744,7 +744,7 @@ Before you start, please
             --served-model-name glm-52 \
             --max-model-len 135000 \
             --speculative-config '{"num_speculative_tokens": 5, "method":"deepseek_mtp"}' \
-            --additional-config '{"enable_sparse_c8":false,"fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_dsa_cp": true}' \
+            --additional-config '{"enable_sparse_c8":false,"multistream_overlap_shared_expert": true, "enable_dsa_cp": true}' \
             --max-num-batched-tokens 4096 \
             --trust-remote-code \
             --max-num-seqs 64 \
@@ -816,7 +816,7 @@ Before you start, please
             --max-num-batched-tokens 164 \
             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
             --speculative-config '{"num_speculative_tokens": 5, "method":"deepseek_mtp"}' \
-            --additional-config '{"enable_sparse_c8":false,"fuse_muls_add": true, "multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+            --additional-config '{"enable_sparse_c8":false,"multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
             --trust-remote-code \
             --max-num-seqs 48 \
             --gpu-memory-utilization 0.92 \
@@ -886,7 +886,7 @@ Before you start, please
             --max-num-batched-tokens 164 \
             --speculative-config '{"num_speculative_tokens": 5, "method":"deepseek_mtp"}' \
             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-            --additional-config '{"enable_sparse_c8":false,"fuse_muls_add": true, "multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+            --additional-config '{"enable_sparse_c8":false,"multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
             --trust-remote-code \
             --max-num-seqs 48 \
             --gpu-memory-utilization 0.92 \
@@ -1050,7 +1050,6 @@ vllm serve <MODEL_PATH> \
   --additional-config \
   '{
     "enable_sparse_c8": false,
-    "fuse_muls_add": true,
     "multistream_overlap_shared_expert": true,
     "enable_dsa_cp": true
   }' \
@@ -1133,7 +1132,6 @@ vllm serve <MODEL_PATH> \
   --additional-config \
   '{
     "enable_sparse_c8": false,
-    "fuse_muls_add": true,
     "multistream_overlap_shared_expert": true,
     "recompute_scheduler_enable": true
   }' \

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -183,7 +183,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a8 \
 --quantization ascend \
 --enable-chunked-prefill \
 --enable-prefix-caching \
---additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true}' \
+--additional-config '{"multistream_overlap_shared_expert": true}' \
 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
 --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}' 
 ```
@@ -219,7 +219,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
 --quantization ascend \
 --enable-chunked-prefill \
 --enable-prefix-caching \
---additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true}' \
+--additional-config '{"multistream_overlap_shared_expert": true}' \
 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
 --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}' 
 ```
@@ -261,7 +261,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a8 \
 --enable-chunked-prefill \
 --enable-prefix-caching \
 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true}' \
+--additional-config '{"multistream_overlap_shared_expert": true}' \
 --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
 ```
 
@@ -430,7 +430,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a8 \
 --trust-remote-code \
 --gpu-memory-utilization 0.95 \
 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true}' \
+--additional-config '{"multistream_overlap_shared_expert": true}' \
 --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
 ```
 
@@ -479,7 +479,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a8 \
 --trust-remote-code \
 --gpu-memory-utilization 0.95 \
 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true}' \
+--additional-config '{"multistream_overlap_shared_expert": true}' \
 --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
 ```
 
@@ -600,7 +600,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
 --enable-chunked-prefill \
 --enable-prefix-caching \
 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true}' \
+--additional-config '{"multistream_overlap_shared_expert": true}' \
 --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
 ```
 
@@ -652,7 +652,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
 --enable-chunked-prefill \
 --enable-prefix-caching \
 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true}' \
+--additional-config '{"multistream_overlap_shared_expert": true}' \
 --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
 ```
 
@@ -819,7 +819,7 @@ Before you start, please
             --seed 1024 \
             --served-model-name glm-5 \
             --max-model-len 131072 \
-            --additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_dsa_cp": true}' \
+            --additional-config '{"multistream_overlap_shared_expert": true, "enable_dsa_cp": true}' \
             --max-num-batched-tokens 4096 \
             --trust-remote-code \
             --max-num-seqs 64 \
@@ -899,7 +899,7 @@ Before you start, please
             --seed 1024 \
             --served-model-name glm-5 \
             --max-model-len 131072 \
-            --additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_dsa_cp": true}' \
+            --additional-config '{"multistream_overlap_shared_expert": true, "enable_dsa_cp": true}' \
             --max-num-batched-tokens 4096 \
             --trust-remote-code \
             --max-num-seqs 64 \
@@ -983,7 +983,7 @@ Before you start, please
             --max-model-len 200000 \
             --max-num-batched-tokens 32 \
             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-            --additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+            --additional-config '{"multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
             --trust-remote-code \
             --max-num-seqs 8 \
             --gpu-memory-utilization 0.92 \
@@ -1063,7 +1063,7 @@ Before you start, please
              --max-model-len 200000 \
              --max-num-batched-tokens 32 \
              --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-             --additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+             --additional-config '{"multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
              --trust-remote-code \
              --max-num-seqs 8 \
              --gpu-memory-utilization 0.92 \
@@ -1143,7 +1143,7 @@ Before you start, please
              --max-model-len 200000 \
              --max-num-batched-tokens 32 \
              --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-             --additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+             --additional-config '{"multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
              --trust-remote-code \
              --max-num-seqs 8 \
              --gpu-memory-utilization 0.92 \
@@ -1223,7 +1223,7 @@ Before you start, please
              --max-model-len 200000 \
              --max-num-batched-tokens 32 \
              --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-             --additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+             --additional-config '{"multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
              --trust-remote-code \
              --max-num-seqs 8 \
              --gpu-memory-utilization 0.92 \

--- a/tests/e2e/nightly/multi_node/external_dp/config/GLM5_1-W8A8-EP-external.yaml
+++ b/tests/e2e/nightly/multi_node/external_dp/config/GLM5_1-W8A8-EP-external.yaml
@@ -100,7 +100,7 @@ templates:
       - --max-model-len
       - "131072"
       - --additional-config
-      - '{"fuse_muls_add": true, "ascend_compilation_config": {"enable_npugraph_ex": true}}'
+      - '{"ascend_compilation_config": {"enable_npugraph_ex": true}}'
       - --max-num-batched-tokens
       - "4096"
       - --trust-remote-code
@@ -161,7 +161,7 @@ templates:
       - --max-model-len
       - "131072"
       - --additional-config
-      - '{"fuse_muls_add": true, "ascend_compilation_config": {"enable_npugraph_ex": true}}'
+      - '{"ascend_compilation_config": {"enable_npugraph_ex": true}}'
       - --max-num-batched-tokens
       - "4096"
       - --trust-remote-code
@@ -225,7 +225,7 @@ templates:
       - --max-num-batched-tokens
       - "32"
       - --additional-config
-      - '{"recompute_scheduler_enable": true, "fuse_muls_add": true, "ascend_compilation_config": {"enable_npugraph_ex": true}}'
+      - '{"recompute_scheduler_enable": true, "ascend_compilation_config": {"enable_npugraph_ex": true}}'
       - --max-num-batched-tokens
       - "4096"
       - --trust-remote-code
@@ -289,7 +289,7 @@ templates:
       - --max-num-batched-tokens
       - "32"
       - --additional-config
-      - '{"recompute_scheduler_enable": true, "fuse_muls_add": true, "ascend_compilation_config": {"enable_npugraph_ex": true}}'
+      - '{"recompute_scheduler_enable": true, "ascend_compilation_config": {"enable_npugraph_ex": true}}'
       - --max-num-batched-tokens
       - "4096"
       - --trust-remote-code

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A2-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A2-dual-nodes.yaml
@@ -41,7 +41,7 @@ deployment:
       --gpu-memory-utilization 0.95
       --quantization ascend
       --no-enable-prefix-caching
-      --additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true, "ascend_compilation_config": {"fuse_qknorm_rope": false}}'
+      --additional-config '{"multistream_overlap_shared_expert": true, "ascend_compilation_config": {"fuse_qknorm_rope": false}}'
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY","cudagraph_capture_sizes": [1,4,8,12,16,20,24,28,32,36,48,60,72]}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
   -
@@ -67,7 +67,7 @@ deployment:
       --gpu-memory-utilization 0.95
       --quantization ascend
       --no-enable-prefix-caching
-      --additional-config '{"fuse_muls_add": true, "multistream_overlap_shared_expert": true, "ascend_compilation_config": {"fuse_qknorm_rope": false}}'
+      --additional-config '{"multistream_overlap_shared_expert": true, "ascend_compilation_config": {"fuse_qknorm_rope": false}}'
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY","cudagraph_capture_sizes": [1,4,8,12,16,20,24,28,32,36,48,60,72]}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
 benchmarks:

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A3-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A3-dual-nodes.yaml
@@ -43,7 +43,7 @@ deployment:
       --enable-chunked-prefill
       --enable-prefix-caching
       --async-scheduling
-      --additional-config '{"fuse_muls_add":true,"multistream_overlap_shared_expert":true}'
+      --additional-config '{"multistream_overlap_shared_expert":true}'
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
   -
@@ -71,7 +71,7 @@ deployment:
       --enable-chunked-prefill
       --enable-prefix-caching
       --async-scheduling
-      --additional-config '{"fuse_muls_add":true,"multistream_overlap_shared_expert":true}'
+      --additional-config '{"multistream_overlap_shared_expert":true}'
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
 benchmarks:

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-EP.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-EP.yaml
@@ -53,7 +53,7 @@ deployment:
           "torch_profiler_with_stack": false}'
           --seed 1024
           --max-model-len 131072
-          --additional-config '{"fuse_muls_add": true, "ascend_compilation_config": {"enable_npugraph_ex": true}}'
+          --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": true}}'
           --max-num-batched-tokens 4096
           --trust-remote-code
           --max-num-seqs 64
@@ -101,7 +101,7 @@ deployment:
           "torch_profiler_with_stack": false}'
           --seed 1024
           --max-model-len 131072
-          --additional-config '{"fuse_muls_add": true, "ascend_compilation_config": {"enable_npugraph_ex": true}}'
+          --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": true}}'
           --max-num-batched-tokens 4096
           --trust-remote-code
           --max-num-seqs 64
@@ -152,7 +152,7 @@ deployment:
           --max-model-len 202752
           --max-num-batched-tokens 32
           --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY", "cudagraph_capture_sizes":[4, 8, 12, 16,20,24,28, 32]}'
-          --additional-config '{"recompute_scheduler_enable": true, "fuse_muls_add": true, "ascend_compilation_config": {"enable_npugraph_ex": true}}'
+          --additional-config '{"recompute_scheduler_enable": true, "ascend_compilation_config": {"enable_npugraph_ex": true}}'
           --trust-remote-code
           --max-num-seqs 8
           --gpu-memory-utilization 0.92
@@ -202,7 +202,7 @@ deployment:
           --max-model-len 202752
           --max-num-batched-tokens 32
           --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY", "cudagraph_capture_sizes":[4, 8, 12, 16,20,24,28, 32]}'
-          --additional-config '{"recompute_scheduler_enable": true, "fuse_muls_add": true, "ascend_compilation_config": {"enable_npugraph_ex": true}}'
+          --additional-config '{"recompute_scheduler_enable": true, "ascend_compilation_config": {"enable_npugraph_ex": true}}'
           --trust-remote-code
           --max-num-seqs 8
           --gpu-memory-utilization 0.92

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_2-W8A8-A3-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_2-W8A8-A3-dual-nodes.yaml
@@ -39,7 +39,7 @@ deployment:
       --trust-remote-code
       --gpu-memory-utilization 0.95
       --quantization ascend
-      --additional-config '{"fuse_muls_add":true,"multistream_overlap_shared_expert":true}'
+      --additional-config '{"multistream_overlap_shared_expert":true}'
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager":true}'
   -
@@ -64,7 +64,7 @@ deployment:
       --trust-remote-code
       --gpu-memory-utilization 0.95
       --quantization ascend
-      --additional-config '{"fuse_muls_add":true,"multistream_overlap_shared_expert":true}'
+      --additional-config '{"multistream_overlap_shared_expert":true}'
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager":true}'
 benchmarks:

--- a/tests/e2e/nightly/single_node/models/configs/DeepSeek-V3.2-W8A8-DCP.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/DeepSeek-V3.2-W8A8-DCP.yaml
@@ -65,7 +65,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes":[4, 16, 64, 128]}'
       - "--additional-config"
-      - '{"enable_dsa_cp": true, "ascend_compilation_config":{"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false}'
+      - '{"enable_dsa_cp": true, "ascend_compilation_config":{"enable_npugraph_ex": true, "enable_static_kernel": false}, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false}'
       - "--speculative-config"
       - '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
     test_content: []

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM_5_1_PD_in32k_bs16-0.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM_5_1_PD_in32k_bs16-0.yaml
@@ -95,7 +95,7 @@ templates:
       - --max-model-len
       - "65536"
       - --additional-config
-      - '{"fuse_muls_add":true,"multistream_overlap_shared_expert": true,"enable_dsa_cp": true}'
+      - '{"multistream_overlap_shared_expert": true,"enable_dsa_cp": true}'
       - --max-num-batched-tokens
       - "4096"
       - --no-enable-prefix-caching
@@ -157,7 +157,7 @@ templates:
       - --max-model-len
       - "65536"
       - --additional-config
-      - '{"fuse_muls_add":true,"multistream_overlap_shared_expert": true,"enable_dsa_cp": true}'
+      - '{"multistream_overlap_shared_expert": true,"enable_dsa_cp": true}'
       - --max-num-batched-tokens
       - "4096"
       - --no-enable-prefix-caching
@@ -224,7 +224,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true,"eplb_config":{"dynamic_eplb":true,"expert_heat_collection_interval":2000,"algorithm_execution_interval":50, "eplb_policy_type":3, "num_redundant_experts":32}}'
+      - '{"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true,"eplb_config":{"dynamic_eplb":true,"expert_heat_collection_interval":2000,"algorithm_execution_interval":50, "eplb_policy_type":3, "num_redundant_experts":32}}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"
@@ -288,7 +288,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true}'
+      - '{"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM_5_1_PD_in32k_bs20-90.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM_5_1_PD_in32k_bs20-90.yaml
@@ -95,7 +95,7 @@ templates:
       - --max-model-len
       - "65536"
       - --additional-config
-      - '{"fuse_muls_add":true,"multistream_overlap_shared_expert": true,"enable_dsa_cp": true}'
+      - '{"multistream_overlap_shared_expert": true,"enable_dsa_cp": true}'
       - --max-num-batched-tokens
       - "4096"
       - --trust-remote-code
@@ -156,7 +156,7 @@ templates:
       - --max-model-len
       - "65536"
       - --additional-config
-      - '{"fuse_muls_add":true,"multistream_overlap_shared_expert": true,"enable_dsa_cp": true}'
+      - '{"multistream_overlap_shared_expert": true,"enable_dsa_cp": true}'
       - --max-num-batched-tokens
       - "4096"
       - --trust-remote-code
@@ -222,7 +222,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true}'
+      - '{"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"
@@ -285,7 +285,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true}'
+      - '{"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM_5_1_PD_in64k_bs16-90.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM_5_1_PD_in64k_bs16-90.yaml
@@ -97,7 +97,7 @@ templates:
       - --max-model-len
       - "140000"
       - --additional-config
-      - '{"fuse_muls_add":true,"multistream_overlap_shared_expert":true,"enable_dsa_cp": true}'
+      - '{"multistream_overlap_shared_expert":true,"enable_dsa_cp": true}'
       - --max-num-batched-tokens
       - "4096"
       - --trust-remote-code
@@ -158,7 +158,7 @@ templates:
       - --max-model-len
       - "140000"
       - --additional-config
-      - '{"fuse_muls_add":true,"multistream_overlap_shared_expert":true,"enable_dsa_cp": true}'
+      - '{"multistream_overlap_shared_expert":true,"enable_dsa_cp": true}'
       - --max-num-batched-tokens
       - "4096"
       - --trust-remote-code
@@ -224,7 +224,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[4,8,12,16,20,24,28,32,64,96,128]}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true}'
+      - '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"
@@ -287,7 +287,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[4,8,12,16,20,24,28,32,64,96,128]}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true}'
+      - '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"

--- a/tests/e2e/weekly/single_node/configs/GLM-5.yaml
+++ b/tests/e2e/weekly/single_node/configs/GLM-5.yaml
@@ -30,7 +30,7 @@ _server_cmd: &server_cmd
   - "--quantization"
   - "ascend"
   - "--additional-config"
-  - '{"fuse_muls_add": true, "multistream_overlap_shared_expert": false, "ascend_compilation_config": {"enable_npugraph_ex": true}}'
+  - '{"multistream_overlap_shared_expert": false, "ascend_compilation_config": {"enable_npugraph_ex": true}}'
   - "--speculative-config"
   - '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
 

--- a/tests/e2e/weekly/single_node/configs/GLM-5_1-W8A8_A3_weekly.yaml
+++ b/tests/e2e/weekly/single_node/configs/GLM-5_1-W8A8_A3_weekly.yaml
@@ -29,7 +29,7 @@ _server_cmd: &server_cmd
   - "ascend"
   - "--enable-chunked-prefill"
   - "--additional-config"
-  - '{"fuse_muls_add":true,"multistream_overlap_shared_expert":true}'
+  - '{"multistream_overlap_shared_expert":true}'
   - "--compilation-config"
   - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
   - "--speculative-config"


### PR DESCRIPTION


### What this PR does / why we need it?
Cherry-pick of PR #11911 onto releases/v0.23.0.

Original PR: #11911

The fuse_muls_add parameter only takes effect inside ascend_compilation_config, not at the top level of additional-config. All examples and test configs that placed it at the top level were ineffective. Since the default value is already True, these invalid entries are removed rather than moved, keeping configs clean without changing behavior.
### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
