### PR TITLE
[Feature] enable EVS for Qwen3.5

### DIFF
--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -794,6 +794,20 @@
 #    Future Plan:
 #       Remove this patch when all ops in _forward_core support both Qwen3_5 and Qwen3Next.
 #
+#   2. `vllm.model_executor.models.qwen3_5.Qwen3_5ForConditionalGeneration`
+#      `vllm.model_executor.models.qwen3_5.Qwen3_5ForConditionalGeneration.__init__`
+#      `vllm.model_executor.models.qwen3_5.Qwen3_5ForConditionalGeneration.recompute_mrope_positions`
+#      `vllm.model_executor.models.qwen3_5.Qwen3_5MoeForConditionalGeneration.__init__`
+#    Why:
+#       Enables EVS (Efficient Video Sampling) feature for Qwen3.5 models
+#    How：
+#       Set the class attribute supports_multimodal_pruning to True for Qwen3.5 models.
+#       Patch the __init__ of Qwen3.5 dense and MoE models to allow using EVS.
+#       Remove the recompute_mrope_positions function defined in Qwen3.5 such that it
+#       correctly inherits the EVS implementation from Qwen3.
+#    Future Plan:
+#       Remove this patch when upstream vLLM supports EVS for Qwen3.5 models.
+#
 # ** 17a. File: worker/patch_idex_310.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.layers.fla.ops.index.prepare_chunk_indices`

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -207,3 +207,64 @@ else:
     _GDN_PATCH_TARGET.forward = AscendGatedDeltaNetAttention.forward
     _GDN_PATCH_TARGET._forward_core = AscendGatedDeltaNetAttention._forward_core
     _GDN_PATCH_TARGET._warmup_prefill_kernels = AscendGatedDeltaNetAttention._warmup_prefill_kernels
+
+
+# Enable EVS (multimodal pruning) for Qwen3.5.
+# TO-DO: Remove after upstream vLLM supports EVS for Qwen3.5
+
+import functools
+
+from vllm.model_executor.models.qwen3_5 import (
+    Qwen3_5ForConditionalGeneration,
+    Qwen3_5MoeForConditionalGeneration,
+)
+from vllm.tokenizers.registry import cached_tokenizer_from_config
+
+# supports_multimodal_pruning = False -> True
+Qwen3_5ForConditionalGeneration.supports_multimodal_pruning = True
+
+# Delete recompute_mrope_positions stub (inherits from parent)
+try:
+    del Qwen3_5ForConditionalGeneration.recompute_mrope_positions
+except AttributeError:
+    pass
+
+# config stuff used by EVS
+def _inject_evs_attrs(self, vllm_config):
+    self.is_multimodal_pruning_enabled = (
+        self.multimodal_config.is_multimodal_pruning_enabled()
+    )
+    self.video_pruning_rate = self.multimodal_config.video_pruning_rate
+    self._tokenizer = cached_tokenizer_from_config(vllm_config.model_config)
+
+    config = vllm_config.model_config.hf_config
+    self.use_deepstack = hasattr(config.vision_config, "deepstack_visual_indexes")
+    self.deepstack_num_level = (
+        len(config.vision_config.deepstack_visual_indexes)
+        if self.use_deepstack
+        else 0
+    )
+    self.visual_dim = config.vision_config.out_hidden_size
+    self.multiscale_dim = self.visual_dim * self.deepstack_num_level
+
+# wrap __init__ on both classes to inject the config stuff
+# MoE class patched separately as it does not inherit init from dense
+
+_orig_qwen35_init = Qwen3_5ForConditionalGeneration.__init__
+
+@functools.wraps(_orig_qwen35_init)
+def _patched_qwen35_init(self, *, vllm_config, prefix="model"):
+    _orig_qwen35_init(self, vllm_config=vllm_config, prefix=prefix)
+    _inject_evs_attrs(self, vllm_config)
+
+Qwen3_5ForConditionalGeneration.__init__ = _patched_qwen35_init
+
+_orig_qwen35_moe_init = Qwen3_5MoeForConditionalGeneration.__init__
+
+@functools.wraps(_orig_qwen35_moe_init)
+def _patched_qwen35_moe_init(self, *, vllm_config, prefix="model"):
+    _orig_qwen35_moe_init(self, vllm_config=vllm_config, prefix=prefix)
+    _inject_evs_attrs(self, vllm_config)
+
+
+Qwen3_5MoeForConditionalGeneration.__init__ = _patched_qwen35_moe_init

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -33,15 +33,15 @@ try:
 except ImportError:
     Qwen3_5MultiTokenPredictor = None
     IntermediateTensors = None
+
+import functools
+
 from vllm.model_executor.models.qwen3_next import Qwen3NextAttention
+from vllm.tokenizers.registry import cached_tokenizer_from_config
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
 from vllm_ascend.utils import is_310p
-
-import functools
-
-from vllm.tokenizers.registry import cached_tokenizer_from_config
 
 _GDN_PATCH_TARGET = _GDNBaseCls
 
@@ -224,10 +224,7 @@ else:
 Qwen3_5ForConditionalGeneration.supports_multimodal_pruning = True
 
 # Delete recompute_mrope_positions stub (inherits from parent)
-try:
-    del Qwen3_5ForConditionalGeneration.recompute_mrope_positions
-except AttributeError:
-    pass
+del Qwen3_5ForConditionalGeneration.recompute_mrope_positions
 
 # config stuff used by EVS
 def _inject_evs_attrs(self, vllm_config):

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -22,7 +22,7 @@ from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.distributed.parallel_state import get_pp_group
 from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import QwenGatedDeltaNetAttention as _GDNBaseCls
 from vllm.model_executor.models.qwen3_5 import (
-    Qwen3_5DecoderLayer
+    Qwen3_5DecoderLayer,
     Qwen3_5ForConditionalGeneration,
     Qwen3_5MoeForConditionalGeneration,
 )

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -226,6 +226,7 @@ Qwen3_5ForConditionalGeneration.supports_multimodal_pruning = True
 # Delete recompute_mrope_positions stub (inherits from parent)
 del Qwen3_5ForConditionalGeneration.recompute_mrope_positions
 
+
 # config stuff used by EVS
 def _inject_evs_attrs(self, vllm_config):
     self.is_multimodal_pruning_enabled = self.multimodal_config.is_multimodal_pruning_enabled()
@@ -238,23 +239,28 @@ def _inject_evs_attrs(self, vllm_config):
     self.visual_dim = config.vision_config.out_hidden_size
     self.multiscale_dim = self.visual_dim * self.deepstack_num_level
 
+
 # wrap __init__ on both classes to inject the config stuff
 # MoE class patched separately as it does not inherit init from dense
 
 _orig_qwen35_init = Qwen3_5ForConditionalGeneration.__init__
+
 
 @functools.wraps(_orig_qwen35_init)
 def _patched_qwen35_init(self, *, vllm_config, prefix="model"):
     _orig_qwen35_init(self, vllm_config=vllm_config, prefix=prefix)
     _inject_evs_attrs(self, vllm_config)
 
+
 Qwen3_5ForConditionalGeneration.__init__ = _patched_qwen35_init
 
 _orig_qwen35_moe_init = Qwen3_5MoeForConditionalGeneration.__init__
+
 
 @functools.wraps(_orig_qwen35_moe_init)
 def _patched_qwen35_moe_init(self, *, vllm_config, prefix="model"):
     _orig_qwen35_moe_init(self, vllm_config=vllm_config, prefix=prefix)
     _inject_evs_attrs(self, vllm_config)
+
 
 Qwen3_5MoeForConditionalGeneration.__init__ = _patched_qwen35_moe_init

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -21,7 +21,11 @@ import torch
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.distributed.parallel_state import get_pp_group
 from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import QwenGatedDeltaNetAttention as _GDNBaseCls
-from vllm.model_executor.models.qwen3_5 import Qwen3_5DecoderLayer
+from vllm.model_executor.models.qwen3_5 import (
+    Qwen3_5DecoderLayer
+    Qwen3_5ForConditionalGeneration,
+    Qwen3_5MoeForConditionalGeneration,
+)
 
 try:
     from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MultiTokenPredictor
@@ -34,6 +38,10 @@ from vllm.model_executor.models.qwen3_next import Qwen3NextAttention
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
 from vllm_ascend.utils import is_310p
+
+import functools
+
+from vllm.tokenizers.registry import cached_tokenizer_from_config
 
 _GDN_PATCH_TARGET = _GDNBaseCls
 
@@ -210,15 +218,7 @@ else:
 
 
 # Enable EVS (multimodal pruning) for Qwen3.5.
-# TO-DO: Remove after upstream vLLM supports EVS for Qwen3.5
-
-import functools
-
-from vllm.model_executor.models.qwen3_5 import (
-    Qwen3_5ForConditionalGeneration,
-    Qwen3_5MoeForConditionalGeneration,
-)
-from vllm.tokenizers.registry import cached_tokenizer_from_config
+# TODO: Remove after upstream vLLM supports EVS for Qwen3.5
 
 # supports_multimodal_pruning = False -> True
 Qwen3_5ForConditionalGeneration.supports_multimodal_pruning = True
@@ -231,19 +231,13 @@ except AttributeError:
 
 # config stuff used by EVS
 def _inject_evs_attrs(self, vllm_config):
-    self.is_multimodal_pruning_enabled = (
-        self.multimodal_config.is_multimodal_pruning_enabled()
-    )
+    self.is_multimodal_pruning_enabled = self.multimodal_config.is_multimodal_pruning_enabled()
     self.video_pruning_rate = self.multimodal_config.video_pruning_rate
     self._tokenizer = cached_tokenizer_from_config(vllm_config.model_config)
 
     config = vllm_config.model_config.hf_config
     self.use_deepstack = hasattr(config.vision_config, "deepstack_visual_indexes")
-    self.deepstack_num_level = (
-        len(config.vision_config.deepstack_visual_indexes)
-        if self.use_deepstack
-        else 0
-    )
+    self.deepstack_num_level = len(config.vision_config.deepstack_visual_indexes) if self.use_deepstack else 0
     self.visual_dim = config.vision_config.out_hidden_size
     self.multiscale_dim = self.visual_dim * self.deepstack_num_level
 
@@ -265,6 +259,5 @@ _orig_qwen35_moe_init = Qwen3_5MoeForConditionalGeneration.__init__
 def _patched_qwen35_moe_init(self, *, vllm_config, prefix="model"):
     _orig_qwen35_moe_init(self, vllm_config=vllm_config, prefix=prefix)
     _inject_evs_attrs(self, vllm_config)
-
 
 Qwen3_5MoeForConditionalGeneration.__init__ = _patched_qwen35_moe_init


### PR DESCRIPTION
### What this PR does / why we need it?

- It is essentially possible to enable EVS for Qwen3.5, this PR enables it by patching the qwen3.5 model file.
- Feature requested in https://github.com/vllm-project/vllm-ascend/issues/10648 and https://github.com/vllm-project/vllm-ascend/issues/9079

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

Tested on vllm0.22.1 + vllm-ascend 0.22.1rc1, A2-1card+Qwen3.5-9B, and A2-2card+Qwen3.6-35B-A3B, with a video input.
For versions earlier than 0.23, one will also need the fixes in vllm-project/vllm-ascend#9706 for vllm-ascend and vllm-project/vllm#44205 for vllm.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/e5588e49bc2642670116664a7fc4096e27adb179
