### PR TITLE
[Ascend950][Bugfix][v0.23.0] Fix allgatherEP MXFPW4A4 without sp

### DIFF
--- a/tests/ut/ops/a2/test_token_dispatcher.py
+++ b/tests/ut/ops/a2/test_token_dispatcher.py
@@ -413,28 +413,77 @@ def test_allgather_token_dispatch_quant_mode_without_dynamic_scale():
         torch.randn(6, 4),
     )
 
-    cases = (
-        (QuantType.MXFP8, torch.float8_e4m3fn, 3),
-        (QuantType.MXFP4, MXFP4_TEST_DTYPE, 9),
-    )
-    for quant_type, act_quant_type, expected_quant_mode in cases:
+    cases = [
+        {
+            "quant_type": QuantType.MXFP8,
+            "act_quant_type": torch.float8_e4m3fn,
+            "expected_quant_mode": 3,
+            "expected_act_quant_type": torch.float8_e4m3fn,
+            "expect_dynamic_scale": True,
+        },
+        {
+            "quant_type": QuantType.MXFP4,
+            "act_quant_type": MXFP4_TEST_DTYPE,
+            "expected_quant_mode": -1,
+            "expected_act_quant_type": None,
+            "expect_dynamic_scale": False,
+        },
+    ]
+    for case in cases:
         token_dispatch_input = build_token_dispatch_input_fixture(
             hidden_states=hidden_states,
             topk_weights=topk_weights,
             topk_ids=topk_ids,
-            quant_type=quant_type,
-            act_quant_type=act_quant_type,
+            quant_type=case["quant_type"],
+            act_quant_type=case["act_quant_type"],
         )
 
         with patch(
             "vllm_ascend.ops.fused_moe.token_dispatcher.DeviceOperator.npu_moe_init_routing",
             return_value=init_routing_output,
         ) as mock_init_routing:
-            dispatcher.token_dispatch(token_dispatch_input=token_dispatch_input)
+            output = dispatcher.token_dispatch(token_dispatch_input=token_dispatch_input)
 
         init_kwargs = mock_init_routing.call_args.kwargs
-        assert init_kwargs["quant_mode"] == expected_quant_mode
-        assert init_kwargs["act_quant_type"] == act_quant_type
+        assert init_kwargs["quant_mode"] == case["expected_quant_mode"]
+        assert init_kwargs["act_quant_type"] == case["expected_act_quant_type"]
+        assert (output.dynamic_scale is not None) == case["expect_dynamic_scale"]
+
+
+def test_allgather_token_dispatch_mxfp4_keeps_prequantized_scale():
+    dispatcher = TokenDispatcherWithAllGather(top_k=2, num_experts=128)
+    hidden_states = torch.randn(3, 128)
+    topk_weights = torch.tensor([[0.7, 0.3], [0.6, 0.4], [0.5, 0.5]])
+    topk_ids = torch.tensor([[0, 1], [1, 2], [2, 3]], dtype=torch.int32)
+    pertoken_scale = torch.randn(3, 4)
+    returned_scale = torch.randn(6, 4)
+    init_routing_output = (
+        torch.randn(6, 128),
+        torch.tensor([0, 1, 2, 3, 4, 5], dtype=torch.int32),
+        torch.tensor([2, 2, 2], dtype=torch.int32),
+        returned_scale,
+    )
+
+    token_dispatch_input = build_token_dispatch_input_fixture(
+        hidden_states=hidden_states,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        pertoken_scale=pertoken_scale,
+        quant_type=QuantType.MXFP4,
+        act_quant_type=MXFP4_TEST_DTYPE,
+    )
+
+    with patch(
+        "vllm_ascend.ops.fused_moe.token_dispatcher.DeviceOperator.npu_moe_init_routing",
+        return_value=init_routing_output,
+    ) as mock_init_routing:
+        output = dispatcher.token_dispatch(token_dispatch_input=token_dispatch_input)
+
+    init_kwargs = mock_init_routing.call_args.kwargs
+    assert init_kwargs["scale"] is pertoken_scale
+    assert init_kwargs["quant_mode"] == -1
+    assert init_kwargs["act_quant_type"] == MXFP4_TEST_DTYPE
+    assert output.dynamic_scale is returned_scale
 
 
 class TestTokenDispatcherWithAllGather(TestBase):

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -352,21 +352,22 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
         self,
         token_dispatch_input: MoETokenDispatchInput,
     ):
-        # TODO: After AllGather MXFP4 communication quantization thorough verification, remove this judgment.
-        #  MXFP4 keeps dispatch unquantized in AllGather path, and quantizes again inside the MLP path.
-        with_quant = (
-            token_dispatch_input.quant.dispatch_with_quant
-            and token_dispatch_input.quant.quant_type != QuantType.W8A8FP8
-        )
+        quant_type = token_dispatch_input.quant.quant_type
+        dynamic_scale = token_dispatch_input.routing.pertoken_scale
+        unquantized_mxfp4_dispatch = quant_type == QuantType.MXFP4 and dynamic_scale is None
+        # Without prepare-stage scales, MXFP4 stays unquantized in dispatch and
+        # is quantized again inside the MLP path.
+        with_quant = token_dispatch_input.quant.dispatch_with_quant and quant_type != QuantType.W8A8FP8
+        with_quant = with_quant and not unquantized_mxfp4_dispatch
         is_mxfp = token_dispatch_input.quant.is_mxfp
         hidden_states = token_dispatch_input.hidden_states
         topk_weights = token_dispatch_input.topk_weights
         topk_ids = token_dispatch_input.topk_ids
         expert_map = token_dispatch_input.routing.expert_map
-        dynamic_scale = token_dispatch_input.routing.pertoken_scale
-        quant_type = token_dispatch_input.quant.quant_type
         act_quant_type = (
-            token_dispatch_input.quant.mxfp.act_quant_type if token_dispatch_input.quant.mxfp is not None else None
+            token_dispatch_input.quant.mxfp.act_quant_type
+            if token_dispatch_input.quant.mxfp is not None and not unquantized_mxfp4_dispatch
+            else None
         )
         global_redundant_expert_num = token_dispatch_input.routing.global_redundant_expert_num
         restore_shape = hidden_states.shape


### PR DESCRIPTION
### What this PR does / why we need it?
Backport #11924 to releases/v0.23.0

This PR fixes W4A4/MXFP4 MoE execution in the AllGather EP path when FlashComm1/SP is not enabled.

When FlashComm1/SP is disabled, the AllGather prepare path does not pre-quantize `hidden_states` or produce `pertoken_scale`. However, the token dispatcher still treated W4A4/MXFP4 as dispatch-time quantized and passed MXFP4 dtype information to `npu_moe_init_routing_v2`. This made the routing op infer the FP4 packed activation shape from an unquantized BF16/FP16 tensor, which could trigger a `MoeInitRoutingV3` tiling error such as `expanded_x dim1 should be 7168, current is 14336`.

This PR updates the AllGather token dispatch logic so that MXFP4 remains unquantized during dispatch when no prepare-stage per-token scale is available. In that case, quantization is deferred to the MLP path, where the activation tensor and scale are generated together. The pre-quantized path is still preserved when `pertoken_scale` is available, such as the FlashComm1/SP path.

It also makes MXFP4 quant-type detection compatible with both current and legacy enum names, and adds unit tests for:
- MXFP4 dispatch without prepare-stage scale.
- MXFP4 dispatch with pre-quantized scale.
- Current and legacy MXFP4 quant type names.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446