### PR TITLE
[BugFix] Avoid config lookup in FIA graph replay

### DIFF
--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -772,9 +772,10 @@ class TestAscendAttentionBackendImpl(TestBase):
         mock_EXTRA_CTX.sinks = False
         mock_EXTRA_CTX.is_draft_model = False
 
-        param: list[MagicMock | None] = [MagicMock()] * 21
-        param[16] = None
-        param[20] = None
+        param: list[MagicMock | None] = [MagicMock()] * 22
+        param[16] = None  # sliding_window
+        param[17] = None  # c8_k_aq_scale
+        param[21] = None  # layer_name
 
         mock_get_graph_params.return_value.attn_params = {1: [tuple(param)] * 3}
         mock_get_graph_params.return_value.handles = {1: [MagicMock()] * 3}

--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -805,9 +805,10 @@ class TestAscendAttentionBackendImpl(TestBase):
         mock_EXTRA_CTX.sinks = False
         mock_EXTRA_CTX.is_draft_model = False
 
-        param: list[MagicMock | None] = [MagicMock()] * 21
-        param[16] = None
-        param[20] = None
+        param: list[MagicMock | None] = [MagicMock()] * 22
+        param[16] = None  # sliding_window
+        param[17] = None  # c8_k_aq_scale
+        param[21] = None  # layer_name
 
         mock_get_graph_params.return_value.attn_params = {1: [tuple(param)] * 3}
         mock_get_graph_params.return_value.handles = {1: [MagicMock()] * 3}

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -672,6 +672,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         sparse_mode,
                         pre_tokens,
                         next_tokens,
+                        sliding_window,
                         c8_k_aq_scale,
                         c8_k_aq_offset,
                         c8_v_aq_scale,
@@ -707,7 +708,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                             and obj.kvcomp_metadata.hashk_caches[layer_count] is not None
                         ):
                             seq_lens = obj.kvcomp_metadata.seq_lens_from_hamming
-                        elif not hasattr(vllm_config.model_config.hf_text_config, "sliding_window"):
+                        elif sliding_window is None:
                             block_tables = attn_metadata[metadata_key].block_tables
                     layer_count += 1
 
@@ -889,6 +890,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             sparse_mode,
             pre_tokens,
             next_tokens,
+            self.sliding_window,
         )
         if self.enable_c8_quant and layer is not None:
             attn_params = attn_params + (

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -847,6 +847,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         sparse_mode,
                         pre_tokens,
                         next_tokens,
+                        sliding_window,
                         c8_k_aq_scale,
                         c8_k_aq_offset,
                         c8_v_aq_scale,
@@ -875,7 +876,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         # Keep the captured block_tables tensor on this affected path.
                         # Non-SWA models preserve the original behavior and continue to refresh
                         # block_tables from attn_metadata.
-                        if not getattr(vllm_config.model_config.hf_text_config, "sliding_window", None):
+                        if not sliding_window:
                             block_tables = attn_metadata[metadata_key].block_tables
                     layer_count += 1
 
@@ -1048,6 +1049,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             sparse_mode,
             pre_tokens,
             next_tokens,
+            self.sliding_window,
         )
         if self.enable_c8_quant and layer is not None:
             attn_params = attn_params + (


### PR DESCRIPTION
### What
- Store sliding_window in full_graph_fia captured attention params.
- Use the captured value during graph replay instead of reading hf_text_config with hasattr.

### Why
Avoids config lookup overhead in the FIA full-graph replay path while preserving the SWA block table handling.

### Tests
- Fix Qwen3 30B single batch performance reduces 0.5ms
- Step3.5 AIME accuracy 96.67


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
