### PR TITLE
[BugFix][310P][v0.23.0] Fix memory calculation for 310P RC

### DIFF
--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -108,9 +108,7 @@ class NPUWorker310(NPUWorker):
 
         if is_rc_device():
             vm = psutil.virtual_memory()
-            self.available_kv_cache_memory_bytes = (
-                self.requested_memory - (vm.total - vm.available)
-            ) // 2
+            self.available_kv_cache_memory_bytes = (self.requested_memory - (vm.total - vm.available)) // 2
         else:
             self.available_kv_cache_memory_bytes = (
                 self.requested_memory - profile_result.non_kv_cache_memory - non_torch_memory_cleared_by_empty_cache

--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -107,7 +107,9 @@ class NPUWorker310(NPUWorker):
         # based on the already occupied space of the system memory.
 
         if is_rc_device():
-            self.available_kv_cache_memory_bytes = (self.requested_memory - psutil.virtual_memory().used) // 2
+            self.available_kv_cache_memory_bytes = (
+                self.requested_memory - (psutil.virtual_memory().total - psutil.virtual_memory().available)
+            ) // 2
         else:
             self.available_kv_cache_memory_bytes = (
                 self.requested_memory - profile_result.non_kv_cache_memory - non_torch_memory_cleared_by_empty_cache

--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -107,8 +107,9 @@ class NPUWorker310(NPUWorker):
         # based on the already occupied space of the system memory.
 
         if is_rc_device():
+            vm = psutil.virtual_memory()
             self.available_kv_cache_memory_bytes = (
-                self.requested_memory - (psutil.virtual_memory().total - psutil.virtual_memory().available)
+                self.requested_memory - (vm.total - vm.available)
             ) // 2
         else:
             self.available_kv_cache_memory_bytes = (


### PR DESCRIPTION
### What this PR does / why we need it?
Memory Calculation Fix: Updated the memory calculation logic for 310P RC devices to use total minus available memory instead of the 'used' property, ensuring more accurate memory availability estimation.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
