### PR TITLE
[Ops][BugFix]revert "get torch_reserved_memory" in model forward

### DIFF
--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -139,8 +139,6 @@ class NPUWorker(WorkerBase):
         # Profiler is lazily initialized on first profile(is_start=True) call (RFC #6954)
         self.profiler_config = vllm_config.profiler_config
         self.profiler: TorchNPUProfilerWrapper | None = None
-        self.torch_reserved = 0
-        self.torch_allocated = 0
         self.npugraph_memory_bytes = 0
         if vllm_config.model_config and vllm_config.model_config.enable_sleep_mode:
             # Buffers saved before sleep
@@ -598,22 +596,10 @@ class NPUWorker(WorkerBase):
 
         return int(self.available_kv_cache_memory_bytes)
 
-    def profile_memory(self) -> None:
-        """Profiles the torch reserved memory, torch allocated memory in execute_model()."""
-        self.torch_reserved = torch.npu.memory_reserved()
-        self.torch_allocated = torch.npu.memory_allocated()
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(
-                "torch reserved memory: %.2f GiB, torch allocated memory: %.2f GiB",
-                self.torch_reserved / GiB_bytes,
-                self.torch_allocated / GiB_bytes,
-            )
-
     def execute_model(
         self,
         scheduler_output: "SchedulerOutput",
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput | None:
-        self.profile_memory()
         # enable msMonitor to monitor the performance of vllm-ascend
         if get_ascend_config().msmonitor_use_daemon:
             dp.step()
@@ -984,7 +970,6 @@ class NPUWorker(WorkerBase):
         self.model_runner.reset_encoder_cache()
 
     def execute_dummy_batch(self) -> None:
-        self.profile_memory()
         self.model_runner._dummy_run(num_tokens=self.model_runner.decode_token_per_req, uniform_decode=True)
 
     def _init_worker_distributed_environment(self) -> None:


### PR DESCRIPTION
… TPOT

### What this PR does / why we need it?
revert "get torch_reserved_memory" in model forward, it cost 0.5ms in TPOT

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
