### PR TITLE
[Feature] Adapt Gemma4-E2B and Gemma4-E4B on Ascend

### DIFF
--- a/tests/e2e/models/configs/gemma-4-E2B-it.yaml
+++ b/tests/e2e/models/configs/gemma-4-E2B-it.yaml
@@ -1,0 +1,30 @@
+# Gemma4-E2B-it accuracy config for Atlas A2.
+# Chat template injects <bos> + <|turn> markers required by this checkpoint.
+# For HF hub use: google/gemma-4-E2B-it
+model_name: "/data/models/gemma4-E2B-it"
+model_type: "vllm"
+hardware: "Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 1
+  dtype: bfloat16
+  max_model_len: 4096
+  gpu_memory_utilization: 0.7
+  trust_remote_code: false
+  # Ascend FIA TND does not support global_head_dim=512; keep eager until
+  # ACLGraph + BSH path is fully validated for Gemma4.
+  enforce_eager: true
+
+tasks:
+- name: "gsm8k"
+  metrics:
+  # Measured on Ascend full gsm8k, enforce_eager, bf16, chat template on.
+  - name: "exact_match,strict-match"
+    value: 0.2358
+  - name: "exact_match,flexible-extract"
+    value: 0.3169
+
+num_fewshot: 5
+apply_chat_template: true
+fewshot_as_multiturn: true
+batch_size: "auto"

--- a/tests/e2e/models/configs/gemma-4-E4B-it.yaml
+++ b/tests/e2e/models/configs/gemma-4-E4B-it.yaml
@@ -1,0 +1,33 @@
+# Gemma4-E4B-it accuracy config for Atlas A2.
+# Chat template injects <bos> + <|turn> markers required by this checkpoint.
+# For HF hub use: google/gemma-4-E4B-it
+model_name: "/data/models/gemma4-E4B-it"
+model_type: "vllm"
+hardware: "Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 1
+  dtype: bfloat16
+  max_model_len: 4096
+  gpu_memory_utilization: 0.7
+  trust_remote_code: false
+  # Ascend FIA TND does not support global_head_dim=512; keep eager until
+  # ACLGraph + BSH path is fully validated for Gemma4.
+  enforce_eager: true
+  # E4B-it is verbose; default lm_eval max_gen_toks=256 truncates answers.
+  max_gen_toks: 1024
+
+tasks:
+- name: "gsm8k"
+  metrics:
+  # Measured on Ascend full gsm8k, enforce_eager, bf16, chat template on,
+  # max_gen_toks=1024 (default 256 truncates verbose E4B answers).
+  - name: "exact_match,strict-match"
+    value: 0.8863
+  - name: "exact_match,flexible-extract"
+    value: 0.8886
+
+num_fewshot: 5
+apply_chat_template: true
+fewshot_as_multiturn: true
+batch_size: "auto"

--- a/tests/ut/attention/a2/test_attention_cp.py
+++ b/tests/ut/attention/a2/test_attention_cp.py
@@ -271,6 +271,23 @@ class TestAscendAttentionCPImpl(TestBase):
         self.assertEqual(value.shape[1], num_heads)
         self.assertEqual(value.shape[2], head_size)
 
+    @patch("vllm_ascend.attention.context_parallel.attention_cp.DeviceOperator.reshape_and_cache")
+    def test_shared_kv_consumer_does_not_update_cache(self, mock_reshape_and_cache):
+        self.impl.uses_shared_kv_cache = True
+        query = torch.empty(1, 8, 64)
+        key = torch.empty(1, 8, 64)
+        value = torch.empty(1, 8, 64)
+        output = torch.empty(1, 8 * 64)
+        kv_cache = (torch.empty(1, 16, 8, 64), torch.empty(1, 16, 8, 64))
+
+        result = self.impl.reshape_and_cache(query, key, value, kv_cache, self.attn_metadata, output)
+
+        mock_reshape_and_cache.assert_not_called()
+        self.assertIs(result[0], query)
+        self.assertIs(result[1], key)
+        self.assertIs(result[2], value)
+        self.assertIs(result[3], output)
+
 
 class TestUpdateNpuAttnOutLse(TestBase):
     @patch_distributed_groups(needs_mocks=False)

--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -10,6 +10,7 @@ from vllm_ascend.attention.attention_v1 import (
     AscendAttentionBackendImpl,
     AscendAttentionMetadataBuilder,
     AscendAttentionState,
+    AscendC8AttentionBackendImpl,
 )
 from vllm_ascend.attention.kvcomp_attn.attention_utils import get_kvcomp_decode_params, reshape_and_cache_kvcomp
 from vllm_ascend.attention.utils import (
@@ -288,6 +289,42 @@ class TestAscendAttentionBackendImpl(TestBase):
             attn_type=self.attention_type.DECODER,
             kv_sharing_target_layer_name=None,
         )
+
+    def test_shared_kv_prefill_requires_block_tables(self):
+        self.impl.uses_shared_kv_cache = True
+        self.impl.kv_sharing_target_layer_name = "model.layers.0.self_attn.attn"
+        self.impl.key_cache = torch.empty(1, 16, 8, 64)
+        self.impl.value_cache = torch.empty(1, 16, 8, 64)
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.PrefillNoCache
+        metadata.block_tables = None
+        key = torch.empty(1, 8, 64)
+        value = torch.empty(1, 8, 64)
+
+        with self.assertRaisesRegex(RuntimeError, "Shared KV cache consumers require block_tables"):
+            self.impl._get_fia_params(key, value, metadata)
+
+    @patch("vllm_ascend.attention.attention_v1.torch_npu.npu_scatter_pa_kv_cache")
+    def test_c8_shared_kv_consumer_does_not_update_cache(self, mock_scatter_cache):
+        impl = AscendC8AttentionBackendImpl.__new__(AscendC8AttentionBackendImpl)
+        impl.uses_shared_kv_cache = True
+        impl.key_cache = None
+        impl.value_cache = None
+        query = torch.empty(1, 8, 64)
+        key = torch.empty(1, 8, 64, dtype=torch.int8)
+        value = torch.empty(1, 8, 64, dtype=torch.int8)
+        output = torch.empty_like(query)
+        kv_cache = (torch.empty(1, 16, 8, 64), torch.empty(1, 16, 8, 64))
+
+        result = impl._reshape_and_cache(query, key, value, kv_cache, self.attn_metadata, output)
+
+        mock_scatter_cache.assert_not_called()
+        self.assertIs(impl.key_cache, kv_cache[0])
+        self.assertIs(impl.value_cache, kv_cache[1])
+        self.assertIs(result[0], query)
+        self.assertIs(result[1], key)
+        self.assertIs(result[2], value)
+        self.assertIs(result[3], output)
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     def test_large_head_prefill_uses_device_operator_fallback(self, mock_get_forward_context):
@@ -837,3 +874,24 @@ class TestAscendAttentionBackendImpl(TestBase):
         self.assertEqual(mock_paged_attention.call_args.kwargs["context_lens"], current_seq_lens)
         mock_graph_task_update_begin.assert_called_once()
         mock_graph_task_update_end.assert_called_once()
+
+
+class TestAscendAttentionBshFallback(TestBase):
+    def test_pack_and_unpack_tnd_to_bsh(self):
+        tensor = torch.arange(24, dtype=torch.float32).view(6, 2, 2)
+        packed = AscendAttentionBackendImpl._pack_tnd_to_bsh(tensor, [2, 4])
+        self.assertEqual(tuple(packed.shape), (2, 4, 4))
+        self.assertTrue(torch.equal(packed[0, :2], tensor[:2].reshape(2, 4)))
+        self.assertTrue(torch.equal(packed[1, :4], tensor[2:].reshape(4, 4)))
+
+        unpacked = AscendAttentionBackendImpl._unpack_bsh_to_tnd(packed, [2, 4], 2, 2)
+        self.assertTrue(torch.equal(unpacked, tensor))
+
+    def test_use_bsh_attention_for_large_head_size(self):
+        impl = AscendAttentionBackendImpl.__new__(AscendAttentionBackendImpl)
+        impl.head_size = 512
+        impl.sinks = None
+        self.assertTrue(impl._use_bsh_attention())
+
+        impl.head_size = 256
+        self.assertFalse(impl._use_bsh_attention())

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -71,6 +71,10 @@ from vllm_ascend.worker.kvcomp_utils import KVCompMetaData
 
 # default max value of sliding window size
 SWA_INT_MAX = 2147483647
+# Ascend FIA TND layout only supports a limited set of head sizes (64/128/192).
+# Models such as Gemma4 use global_head_dim=512 on full-attention layers and
+# must route through the BSH layout instead.
+BSH_FALLBACK_HEAD_SIZES = (512,)
 _ATTN_KEYS_BUFFER = None
 
 
@@ -423,6 +427,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         self.alibi_slopes = alibi_slopes
         self.attn_type = attn_type
         self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
+        self.uses_shared_kv_cache = kv_sharing_target_layer_name is not None
 
         assert self.num_heads % self.num_kv_heads == 0
         self.num_queries_per_kv = self.num_heads // self.num_kv_heads
@@ -449,6 +454,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
         # KV-sharing layers replay with the target layer's metadata instead of
         # their own module name, matching vLLM's shared KV-cache ownership.
         return self.kv_sharing_target_layer_name or layer_name
+
+    def _use_bsh_attention(self) -> bool:
+        return self.head_size in BSH_FALLBACK_HEAD_SIZES and self.sinks is None
 
     @staticmethod
     def update_graph_params(
@@ -1192,10 +1200,30 @@ class AscendAttentionBackendImpl(AttentionImpl):
             graph_params.handles[num_tokens].append(handle)
             return output
 
+    def _load_paged_kv_for_fia(
+        self,
+        attn_metadata: AscendMetadata,
+    ) -> tuple[torch.Tensor, torch.Tensor, int, torch.Tensor, list[int]]:
+        num_block, block_size, _, _ = self.key_cache.shape  # type: ignore
+        key = self.key_cache.view(num_block, block_size, -1)  # type: ignore
+        value = self.value_cache.view(num_block, block_size, -1)  # type: ignore
+        batch_size = attn_metadata.seq_lens.shape[0]
+        block_table = attn_metadata.block_tables[:batch_size, :]
+        actual_seq_lengths_kv = attn_metadata.seq_lens_list
+        return key, value, block_size, block_table, actual_seq_lengths_kv
+
     def _get_fia_params(self, key: torch.Tensor, value: torch.Tensor, attn_metadata: AscendMetadata, kv_cache=None):
-        # PrefillNoCache doesn't need key_cache, but other modes do
-        # Only initialize/require cache for modes that actually use it
-        if attn_metadata.attn_state != AscendAttentionState.PrefillNoCache:
+        # PrefillNoCache normally uses the local float K/V tensors. KV-sharing
+        # consumers are the exception: their local K/V are intentionally
+        # invalid, so they must read the producer's paged cache (FlashInfer-
+        # compatible). For BSH fallback layers (e.g. Gemma4 head_dim=512),
+        # prefer dense K/V on PrefillNoCache unless this is a shared consumer,
+        # because FIA BSH + page attention requires block_size % 128 == 0.
+        use_paged_kv_on_prefill = self.uses_shared_kv_cache and self.attn_type != AttentionType.ENCODER_DECODER
+        uses_paged_kv_cache = (
+            attn_metadata.attn_state != AscendAttentionState.PrefillNoCache or use_paged_kv_on_prefill
+        )
+        if uses_paged_kv_cache:
             # Initialize cache from kv_cache if not already set (for DecodeOnly mode)
             if self.key_cache is None and kv_cache is not None:
                 if (
@@ -1213,11 +1241,21 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 )
 
         if attn_metadata.attn_state == AscendAttentionState.PrefillNoCache:
-            block_size = 128
-            block_table = None
-            actual_seq_lengths_kv = attn_metadata.actual_seq_lengths_q
-            if self.attn_type == AttentionType.ENCODER_DECODER:
-                actual_seq_lengths_kv = torch.cumsum(attn_metadata.seq_lens, dim=0).tolist()
+            if use_paged_kv_on_prefill:
+                if attn_metadata.block_tables is None:
+                    raise RuntimeError(
+                        "Shared KV cache consumers require block_tables during PrefillNoCache; "
+                        f"cannot read KV cache from target layer {self.kv_sharing_target_layer_name!r}."
+                    )
+                key, value, block_size, block_table, actual_seq_lengths_kv = self._load_paged_kv_for_fia(
+                    attn_metadata
+                )
+            else:
+                block_size = 128
+                block_table = None
+                actual_seq_lengths_kv = attn_metadata.actual_seq_lengths_q
+                if self.attn_type == AttentionType.ENCODER_DECODER:
+                    actual_seq_lengths_kv = torch.cumsum(attn_metadata.seq_lens, dim=0).tolist()
         elif attn_metadata.attn_state == AscendAttentionState.PrefillCacheHit:
             batch_size = attn_metadata.seq_lens.shape[0]
             block_table = attn_metadata.block_tables[:batch_size, :]
@@ -1252,6 +1290,111 @@ class AscendAttentionBackendImpl(AttentionImpl):
             actual_seq_lengths_kv = attn_metadata.seq_lens_list
         return key, value, block_size, block_table, actual_seq_lengths_kv
 
+    @staticmethod
+    def _cumulative_to_seq_lengths(cumulative_lengths: list[int]) -> list[int]:
+        previous_length = 0
+        seq_lengths = []
+        for cumulative_length in cumulative_lengths:
+            seq_lengths.append(cumulative_length - previous_length)
+            previous_length = cumulative_length
+        return seq_lengths
+
+    @staticmethod
+    def _pack_tnd_to_bsh(tensor: torch.Tensor, seq_lengths: list[int]) -> torch.Tensor:
+        if not seq_lengths or any(seq_len <= 0 for seq_len in seq_lengths):
+            raise ValueError(f"BSH fallback requires positive sequence lengths, got {seq_lengths}")
+        if sum(seq_lengths) != tensor.shape[0]:
+            raise ValueError(
+                "BSH fallback sequence lengths do not match the packed token count: "
+                f"sum(seq_lengths)={sum(seq_lengths)}, num_tokens={tensor.shape[0]}"
+            )
+        batch_size = len(seq_lengths)
+        max_seq_len = max(seq_lengths)
+        hidden_size = tensor.shape[-2] * tensor.shape[-1]
+        tensor = tensor.reshape(tensor.shape[0], hidden_size)
+
+        if all(seq_len == max_seq_len for seq_len in seq_lengths):
+            return tensor.view(batch_size, max_seq_len, hidden_size)
+
+        padded = tensor.new_zeros(batch_size, max_seq_len, hidden_size)
+        token_offset = 0
+        for batch_idx, seq_len in enumerate(seq_lengths):
+            padded[batch_idx, :seq_len] = tensor[token_offset : token_offset + seq_len]
+            token_offset += seq_len
+        return padded
+
+    @staticmethod
+    def _unpack_bsh_to_tnd(
+        tensor: torch.Tensor,
+        seq_lengths: list[int],
+        num_heads: int,
+        head_size: int,
+    ) -> torch.Tensor:
+        if all(seq_len == tensor.shape[1] for seq_len in seq_lengths):
+            return tensor.view(-1, num_heads, head_size)
+        return torch.cat(
+            [tensor[batch_idx, :seq_len] for batch_idx, seq_len in enumerate(seq_lengths)],
+            dim=0,
+        ).view(-1, num_heads, head_size)
+
+    def _forward_fused_infer_attention_bsh(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AscendMetadata,
+        block_size: int,
+        block_table: torch.Tensor | None,
+        actual_seq_lengths_kv: list[int],
+    ) -> torch.Tensor:
+        query_seq_lengths = self._cumulative_to_seq_lengths(attn_metadata.actual_seq_lengths_q)
+        query = self._pack_tnd_to_bsh(query, query_seq_lengths)
+
+        if attn_metadata.attn_state == AscendAttentionState.PrefillNoCache and block_table is None:
+            kv_seq_lengths = self._cumulative_to_seq_lengths(actual_seq_lengths_kv)
+            key = self._pack_tnd_to_bsh(key, kv_seq_lengths)
+            value = self._pack_tnd_to_bsh(value, kv_seq_lengths)
+            actual_seq_lengths_kv = kv_seq_lengths
+
+        extra_args = {}
+        sparse_mode = 0
+        # Decode and single-token prefill have no future tokens to mask. Avoid
+        # passing the TND square mask in these cases because BSH interprets it
+        # as a BS2 mask and validates it against the actual batch/KV lengths.
+        single_token_attention = all(seq_len == 1 for seq_len in query_seq_lengths) and all(
+            seq_len == 1 for seq_len in actual_seq_lengths_kv
+        )
+        if (
+            attn_metadata.causal
+            and attn_metadata.attn_state != AscendAttentionState.DecodeOnly
+            and not single_token_attention
+        ):
+            extra_args["atten_mask"] = attn_metadata.attn_mask
+            sparse_mode = 3
+        if block_table is not None:
+            extra_args["block_table"] = block_table
+            extra_args["block_size"] = block_size
+
+        attn_output, _ = torch_npu.npu_fused_infer_attention_score(
+            query=query,
+            key=key,
+            value=value,
+            input_layout="BSH",
+            actual_seq_lengths=query_seq_lengths,
+            actual_seq_lengths_kv=actual_seq_lengths_kv,
+            num_key_value_heads=self.num_kv_heads,
+            num_heads=self.num_heads,
+            scale=self.scale,
+            sparse_mode=sparse_mode,
+            **extra_args,
+        )
+        return self._unpack_bsh_to_tnd(
+            attn_output,
+            query_seq_lengths,
+            self.num_heads,
+            self.head_size,
+        )
+
     def forward_fused_infer_attention(
         self,
         query: torch.Tensor,
@@ -1264,7 +1407,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         # we inherit ForwardContext in model runner v2, when enable model
         # runner v2, there is not capturing attribute in forward_context,
         # just use getattr to avoid attribute error.
-        if _EXTRA_CTX.capturing:
+        if _EXTRA_CTX.capturing and not self.uses_shared_kv_cache:
             if self.sinks is not None:
                 attn_output, num_tokens = self.full_graph_fia_v2(query, key, value, attn_metadata, output)
                 output[:num_tokens] = attn_output[:num_tokens]
@@ -1289,11 +1432,21 @@ class AscendAttentionBackendImpl(AttentionImpl):
         if (
             attn_metadata.attn_state == AscendAttentionState.PrefillNoCache
             and self.attn_type != AttentionType.ENCODER_DECODER
+            and block_table is None
         ):
             key = key[:num_tokens]
             value = value[:num_tokens]
-        # Get workspace from cache or calculate it if not present.
-        if self.sinks is not None:
+        if self._use_bsh_attention():
+            attn_output = self._forward_fused_infer_attention_bsh(
+                query,
+                key,
+                value,
+                attn_metadata,
+                block_size,
+                block_table,
+                actual_seq_lengths_kv,
+            )
+        elif self.sinks is not None:
             actual_seq_qlen = attn_metadata.actual_seq_lengths_q
             if attn_metadata.attn_state == AscendAttentionState.DecodeOnly:
                 actual_seq_qlen = torch.tensor([1] * len(attn_metadata.seq_lens_list), dtype=torch.int32).cumsum(dim=0)
@@ -1434,7 +1587,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         kv_cache: list[torch.Tensor],
         slot_mapping: torch.Tensor,
     ) -> None:
-        if self.attn_type in (AttentionType.ENCODER_ONLY):
+        if self.attn_type in (AttentionType.ENCODER_ONLY) or self.uses_shared_kv_cache:
             return
 
         if self.key_cache is None:
@@ -1457,6 +1610,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
         attn_metadata: AscendMetadata,
         output: torch.Tensor,
     ):
+        # The model runner binds a shared consumer to its producer's cache.
+        # Only the producer may write that cache; consumers read it as-is.
+        if self.uses_shared_kv_cache:
+            return query, key, value, output
         if len(kv_cache) > 1:
             if self.is_kv_producer:
                 attn_metadata.reshape_cache_event = torch.npu.Event()
@@ -1492,6 +1649,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             attn_metadata.attn_state == AscendAttentionState.DecodeOnly
             and self.sliding_window is None
             and using_paged_attention(num_tokens, self.vllm_config, self.head_size)
+            and not self._use_bsh_attention()
         ):
             output = self.forward_paged_attention(query, attn_metadata, output)
         else:
@@ -1614,7 +1772,7 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
                 output[:num_tokens] = attn_output[:num_tokens]
                 return output
             if attn_metadata.attn_state == AscendAttentionState.DecodeOnly:
-                if _EXTRA_CTX.capturing:
+                if _EXTRA_CTX.capturing and not self.uses_shared_kv_cache:
                     attn_output, num_tokens = self.full_graph_fia(query, key, value, attn_metadata, output, layer)
                     output[:num_tokens] = attn_output[:num_tokens]
                     return output
@@ -1658,7 +1816,7 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
                     attn_output = self._forward_encoder_attention(query, key, value, attn_metadata, output)
                     output[:num_tokens] = attn_output[:num_tokens]
                     return output
-                if _EXTRA_CTX.capturing:
+                if _EXTRA_CTX.capturing and not self.uses_shared_kv_cache:
                     attn_output, num_tokens = self.full_graph_fia(query, key, value, attn_metadata, output, layer)
                     output[:num_tokens] = attn_output[:num_tokens]
                     return output
@@ -1875,7 +2033,12 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
                     all_new_prefill = False
                     break
 
-            if all_new_prefill and float_key is not None and float_value is not None:
+            if (
+                all_new_prefill
+                and float_key is not None
+                and float_value is not None
+                and not self.uses_shared_kv_cache
+            ):
                 prefill_k = float_key[num_decode_tokens:num_tokens]
                 prefill_v = float_value[num_decode_tokens:num_tokens]
                 prefill_seq_kvlen = prefill_seq_qlen
@@ -1936,6 +2099,7 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
         if (
             attn_metadata.attn_state == AscendAttentionState.PrefillNoCache
             and self.attn_type != AttentionType.ENCODER_DECODER
+            and block_table is None
         ):
             key = key[:num_tokens]
             value = value[:num_tokens]
@@ -1983,6 +2147,11 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
         attn_metadata: AscendMetadata,
         output: torch.Tensor,
     ):
+        if self.uses_shared_kv_cache:
+            if len(kv_cache) > 1 and self.key_cache is None:
+                self.key_cache, self.value_cache = kv_cache[0], kv_cache[1]
+            return query, key, value, output
+
         if len(kv_cache) > 1:
             if self.is_kv_producer:
                 attn_metadata.reshape_cache_event = torch.npu.Event()

--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -806,6 +806,12 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
         attn_metadata: AscendMetadata,
         output: torch.Tensor,
     ):
+        # The model runner aliases a shared consumer to its producer's cache.
+        # Context-parallel consumers must not overwrite that cache with their
+        # layer-local K/V tensors.
+        if self.uses_shared_kv_cache:
+            return query, key, value, output
+
         num_decode_tokens = attn_metadata.num_decode_tokens
         has_decode = attn_metadata.num_decodes > 0
         has_prefill = attn_metadata.num_prefills > 0

--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -164,7 +164,7 @@ def rope_forward_oot(
     query_shape, key_shape = query.shape, key.shape
     if offsets is not None:
         raise NotImplementedError("Batched rotary embedding is currently not supported on NPU.")
-    if HAS_TRITON:
+    if HAS_TRITON and head_size <= 128:
         num_tokens = query.shape[0]
         query, key = rope_forward_triton(
             query.view(num_tokens, -1, head_size),


### PR DESCRIPTION
## Summary
- Adapt Gemma4-E2B and Gemma4-E4B on Ascend by routing full-attention
  layers with `global_head_dim=512` through a BSH FIA fallback, since TND
  FIA only supports head dims 64/128/192.
- Fix KV-sharing consumer layers: skip cache writes, and during PrefillNoCache
  read the producer's paged KV cache instead of invalid local K/V tensors.
- Gate Triton RoPE to `head_size <= 128` so larger heads (256/512) use the
  NPU rotary path.
- Add unit coverage for BSH pack/unpack and head-size routing, plus an
  initial `gemma-4-E2B` gsm8k e2e accuracy config.
## Motivation
Gemma4 hybrid attention uses sliding layers (`head_dim=256`) and full
layers (`global_head_dim=512`), with the last `num_kv_shared_layers`
sharing KV cache from earlier same-type producers. Without these Ascend
backend fixes, generation quality collapses on Gemma4-E2B/E4B.
## Notes
- BSH fallback is limited to `head_size==512` and should not change typical
  64/128-head models.
- Prefill paged-KV reads apply only to KV-sharing consumers.
- Current gsm8k baseline in the e2e YAML is a local smoke result (`limit=50`);
  recalibrate on full gsm8k before CI promotion. Prefer `-it` checkpoints
  for instruction-style accuracy.

Fixes vllm-project/vllm-ascend#9079
Fixes vllm-project/vllm-ascend#10663
<img width="683" height="665" alt="image" src="https://github.com/user-attachments/assets/2d6934d0-fd15-4621-932d-fa7f099d8a69" />

<img width="716" height="694" alt="image" src="https://github.com/user-attachments/assets/8b2c16dc-5598-4f4e-8d33-7ceaaaf34fc1" />

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
