### PR TITLE
[Doc] Fix incorrect A3 NPU count in MiniMax-M2 tutorial

### DIFF
--- a/docs/source/tutorials/models/MiniMax-M2.md
+++ b/docs/source/tutorials/models/MiniMax-M2.md
@@ -81,7 +81,7 @@ You can use the official all-in-one Docker image. For the available image tags a
 
     !!! note
 
-        A3 has 16 NPUs with dual-die design (`/dev/davinci[0-15]`).
+        A3 has 8 NPUs with dual-die design (16 chips total: `/dev/davinci[0-15]`).
         If you are on a shared machine, map only the chips you need (e.g., `/dev/davinci[0-7]` for NPU 0-3).
 
 === "A2 series"


### PR DESCRIPTION
### What this PR does / why we need it?

Fix incorrect NPU count in MiniMax-M2 documentation. A3 has **8 NPUs** with dual-die design (16 chips total), not 16 NPUs.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only update.

### How was this patch tested?

Reviewed the rendered markdown.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/e5588e49bc2642670116664a7fc4096e27adb179
