### PR TITLE
[cherry-pick][v0.23.0][Feature][Attention] Support compact KV gather for SFA DCP prefill

### DIFF
--- a/docs/source/developer_guide/Design_Documents/context_parallel.md
+++ b/docs/source/developer_guide/Design_Documents/context_parallel.md
@@ -75,6 +75,52 @@ After computing the results with the local KV cache, the results are updated via
 
 ![DCP-Decode](../../assets/cp/dcp-decode.png)
 
+### GLM-5.2 SFA DCP Replicated Indexer
+
+GLM-5.2 uses Sparse Flash Attention (SFA) with a LightningIndexer.  For DCP,
+the indexer needs a full-sequence view to select the same sparse top-k blocks
+as non-DCP SFA, while the much larger SFA KV cache should remain sharded to
+retain DCP's memory benefit.  The replicated-indexer path provides this split
+layout:
+
+- The LightningIndexer cache is replicated on every DCP rank.  Index selection
+  therefore uses the complete sequence and produces globally consistent sparse
+  top-k indices.
+- The SFA KV cache remains DCP-local.  The global indices from the replicated
+  indexer view are remapped to local KV indices before SFA runs.
+- During prefill or a mixed batch, only the KV blocks referenced by the sparse
+  block table are compacted and all-gathered after the current layer has
+  written its KV cache.  The gathered KV uses a remapped block table for SFA,
+  so this path does not all-gather Q and does not need LSE or output
+  post-processing.
+- Decode-only batches retain the DCP SFA Q-gather and result-merge path.
+
+This mode is selected automatically for SFA sparse models when
+`prefill_context_parallel_size=1` and `decode_context_parallel_size>1`.  It
+requires `decode_context_parallel_size == tensor_parallel_size`; PCP combined
+with this replicated-indexer path is not supported.
+
+For a GLM-5.2 DSA-CP deployment, enable FlashComm1 and DSA CP and keep the CP
+interleave size equal to the KV-cache block size:
+
+```bash
+export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+
+vllm serve <glm-5.2-model> \
+  --tensor-parallel-size <N> \
+  --prefill-context-parallel-size 1 \
+  --decode-context-parallel-size <N> \
+  --block-size <B> \
+  --cp-kv-cache-interleave-size <B> \
+  --additional-config '{"enable_dsa_cp": true}'
+```
+
+The replicated indexer increases indexer-cache memory in proportion to the
+DCP world size; the SFA KV cache itself remains sharded.  For this SFA CP path,
+`cp_kv_cache_interleave_size` must equal `block_size`.  A mismatched setting is
+overridden during configuration validation, but deployments should set both
+values explicitly to avoid relying on that fallback.
+
 ### Prefill Context Parallel (PCP)
 
 **Tokens Partition in Head-Tail Style**

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
@@ -397,6 +397,7 @@ FULL_FEATURE_MODEL_CASES = [
             "compilation_config": FULL_DECODE_GRAPH,
             "additional_config": {
                 "enable_flashcomm1": True,
+                "enable_dsa_cp": True,
                 "enable_sparse_c8": True,
             },
             "speculative_config": {

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
@@ -43,6 +43,7 @@ FULL_DECODE_GRAPH = {
     "cudagraph_capture_sizes": [MAX_NUM_SEQS],
 }
 
+
 COMMON_PROMPTS = [
     "The capital of France is",
     "Hello, my name is Tom, I am",

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
@@ -102,7 +102,7 @@ DSV3_2_GOLDEN_BACKUPS = (
 )
 
 DSV3_2_DCP_GOLDEN = [
-    "The capital of France isoint054 Rund compasses",
+    "The capital of France isoint054 Rund959arki",
     "Hello, my name is Tom, I am" + "ERIC slicpacelike挂",
     "The president of United States isoint054 Rund959arki",
 ]

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -239,11 +239,19 @@ class TestAscendSFAKVQuantSparseAttention(TestBase):
         actual_seq_lengths = torch.tensor([3], dtype=torch.int32)
         expected = torch.randn(3, 2, 32)
 
-        with patch(
-            "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
-            create=True,
-            return_value=expected,
-        ) as mock_qsfa:
+        with (
+            patch.object(
+                torch.ops._C_ascend,
+                "npu_kv_quant_sparse_flash_attention",
+                create=True,
+                return_value=(expected, torch.empty(0), torch.empty(0)),
+            ) as mock_qsfa,
+            patch(
+                "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
+                create=True,
+                side_effect=AssertionError("C8 SFA must use the custom op"),
+            ),
+        ):
             result = impl._execute_sparse_flash_attention_process(
                 ql_nope,
                 q_pe,
@@ -260,7 +268,7 @@ class TestAscendSFAKVQuantSparseAttention(TestBase):
         self.assertEqual(call_kwargs["query"].shape, (3, 2, 48))
         self.assertEqual(call_kwargs["key_quant_mode"], 2)
         self.assertEqual(call_kwargs["tile_size"], 128)
-        self.assertNotIn("return_softmax_lse", call_kwargs)
+        self.assertTrue(call_kwargs["return_softmax_lse"])
 
     def test_prolog_v3_enables_packed_int8_kv_cache(self):
         impl = AscendSFAImpl.__new__(AscendSFAImpl)

--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -1502,7 +1502,7 @@ class TestAscendSFADCPImpl(TestBase):
 
         ql_nope = torch.randn(2, 2, 8)
         q_pe = torch.randn(2, 2, 4)
-        impl._finish_all_gather_query_for_dcp = MagicMock(side_effect=lambda _ctx: (ql_nope, q_pe))
+        impl._finish_dcp_gather = MagicMock(side_effect=lambda _ctx: (ql_nope, q_pe))
         kv_cache = (torch.empty(4, 1, 1, 16, dtype=torch.int8),)
         topk_indices = torch.zeros(2, 1, dtype=torch.int32)
         actual_seq_lengths_query = torch.tensor([2], dtype=torch.int32)
@@ -1511,11 +1511,12 @@ class TestAscendSFADCPImpl(TestBase):
         dcp_block_table = torch.tensor([[0, 1]], dtype=torch.int32)
 
         attn_metadata = MagicMock()
+        attn_metadata.num_prefills = 0
         attn_metadata.dcp_context = DCPContext(
             slot_mapping=torch.tensor([0, 1], dtype=torch.int32),
             block_table=dcp_block_table,
             seq_lens=dcp_seq_lens,
-            query_gather_context=MagicMock(),
+            gather_context=MagicMock(),
         )
         sfa_output = torch.randn(2, 2, 8)
         softmax_lse = torch.randn(2, 2, 1)

--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -1488,6 +1488,38 @@ class TestAscendSFACPImpl(TestBase):
 
 
 class TestAscendSFADCPImpl(TestBase):
+    def test_record_dcp_kv_gather_context_c8_only_gathers_packed_kv(self):
+        impl = AscendSFADCPImpl.__new__(AscendSFADCPImpl)
+        impl.dcp_group = MagicMock()
+        impl.use_sparse_c8_sfa = True
+        gather_context = MagicMock()
+        impl._start_dcp_gather = MagicMock(return_value=gather_context)
+
+        packed_kv = torch.arange(4 * 16, dtype=torch.int8).view(4, 1, 1, 16)
+        indexer_k = torch.zeros(8, 1, 1, 8, dtype=torch.int8)
+        indexer_scale = torch.zeros(8, 1, 1, 1, dtype=torch.float16)
+        valid_block_ids = torch.tensor([1, 3], dtype=torch.int64)
+        attn_metadata = MagicMock()
+        attn_metadata.num_prefills = 1
+        attn_metadata.dcp_context = DCPContext(
+            slot_mapping=torch.tensor([0], dtype=torch.int32),
+            block_table=torch.tensor([[0]], dtype=torch.int32),
+            seq_lens=torch.tensor([1], dtype=torch.int32),
+            kv_gather_block_ids=valid_block_ids,
+            kv_gather_block_table=torch.tensor([[0, 1]], dtype=torch.int32),
+        )
+
+        impl._record_dcp_kv_gather_context(
+            (packed_kv, indexer_k, indexer_scale),
+            attn_metadata,
+        )
+
+        gather_input = impl._start_dcp_gather.call_args.args[0]
+        self.assertTrue(torch.equal(gather_input, packed_kv.index_select(0, valid_block_ids)))
+        self.assertEqual(impl._start_dcp_gather.call_args.kwargs["dim"], 0)
+        self.assertEqual(impl._start_dcp_gather.call_args.kwargs["split_sizes"], (16,))
+        self.assertIs(attn_metadata.dcp_context.gather_context, gather_context)
+
     def test_execute_sparse_flash_attention_process_uses_c8_device_operator_lse(self):
         impl = AscendSFADCPImpl.__new__(AscendSFADCPImpl)
         impl.dcp_group = MagicMock()

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -211,6 +211,74 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
             ),
         )
 
+    def test_sparse_replicated_indexer_only_expands_indexer_cache(self):
+        runner = self._build_runner()
+        runner.use_sparse = True
+        runner.model_config.hf_text_config = SimpleNamespace(index_head_dim=128)
+        runner.attn_backend.get_kv_cache_shape.side_effect = (
+            lambda num_blocks, block_size, num_kv_heads, head_size: (
+                num_blocks,
+                block_size,
+                num_kv_heads,
+                head_size,
+            )
+        )
+
+        layer_name = "model.layers.0.self_attn.attn"
+        num_blocks = 2
+        dcp_size = 4
+        spec = AscendMLAAttentionSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=704,
+            sparse_head_dim=(512, 64, 128),
+            dtype=torch.bfloat16,
+            cache_dtype_str="auto",
+            sfa_dcp_replicated_indexer_size=dcp_size,
+        )
+        kv_cache_config = KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=spec.page_size_bytes * num_blocks,
+                    shared_by=[layer_name],
+                )
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=[layer_name],
+                    kv_cache_spec=spec,
+                )
+            ],
+        )
+
+        raw_caches = runner._allocate_kv_cache_tensors(kv_cache_config)
+        raw_k_cache, raw_v_cache, raw_indexer_cache = raw_caches[layer_name]
+
+        self.assertEqual(raw_k_cache.numel(), num_blocks * 16 * 512 * 2)
+        self.assertEqual(raw_v_cache.numel(), num_blocks * 16 * 64 * 2)
+        self.assertEqual(raw_indexer_cache.numel(), num_blocks * dcp_size * 16 * 128 * 2)
+        self.assertEqual(
+            raw_k_cache.numel() + raw_v_cache.numel() + raw_indexer_cache.numel(),
+            spec.page_size_bytes * num_blocks,
+        )
+
+        runner._kv_cache_spec_attn_group_iterator = lambda: [
+            SimpleNamespace(
+                kv_cache_spec=spec,
+                backend=runner.attn_backend,
+                layer_names=[layer_name],
+            )
+        ]
+        k_cache, v_cache, indexer_cache = runner._reshape_kv_cache_tensors(
+            kv_cache_config,
+            raw_caches,
+        )[layer_name]
+
+        self.assertEqual(k_cache.shape, (num_blocks, 16, 1, 512))
+        self.assertEqual(v_cache.shape, (num_blocks, 16, 1, 64))
+        self.assertEqual(indexer_cache.shape, (num_blocks * dcp_size, 16, 1, 128))
+
 
 class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
     def _build_runner(self):

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -216,13 +216,11 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         runner.use_sparse = True
         runner.model_config.hf_text_config = SimpleNamespace(index_head_dim=128)
         runner._get_attention_kv_cache_dims = lambda _layer_name, _spec: (512, 64)
-        runner.attn_backend.get_kv_cache_shape.side_effect = (
-            lambda num_blocks, block_size, num_kv_heads, head_size: (
-                num_blocks,
-                block_size,
-                num_kv_heads,
-                head_size,
-            )
+        runner.attn_backend.get_kv_cache_shape.side_effect = lambda num_blocks, block_size, num_kv_heads, head_size: (
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            head_size,
         )
 
         layer_name = "model.layers.0.self_attn.attn"

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -190,23 +190,30 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         )
 
     def test_sparse_replicated_indexer_page_size_uses_expanded_storage_once(self):
+        block_size = 16
+        k_head_dim = 512
+        v_head_dim = 64
+        index_head_dim = 128
+        dcp_size = 4
+        expected_head_size = k_head_dim + v_head_dim + index_head_dim * dcp_size
+
         spec = AscendMLAAttentionSpec(
-            block_size=16,
+            block_size=block_size,
             num_kv_heads=1,
-            head_size=1088,
-            sparse_head_dim=(512, 64, 128 * 4),
+            head_size=k_head_dim + v_head_dim + index_head_dim,
+            sparse_head_dim=(k_head_dim, v_head_dim, index_head_dim),
             dtype=torch.bfloat16,
             cache_dtype_str="auto",
-            sfa_dcp_replicated_indexer_size=4,
+            sfa_dcp_replicated_indexer_size=dcp_size,
         )
 
-        self.assertEqual(spec.page_size_bytes, 16 * (512 + 64 + 128 * 4) * 2)
+        self.assertEqual(spec.page_size_bytes, block_size * expected_head_size * 2)
         self.assertEqual(
             spec.sparse_kv_cache_ratio,
             (
-                (512 + 64 + 128 * 4) / 512,
-                (512 + 64 + 128 * 4) / 64,
-                (512 + 64 + 128 * 4) / (128 * 4),
+                expected_head_size / k_head_dim,
+                expected_head_size / v_head_dim,
+                expected_head_size / (index_head_dim * dcp_size),
                 None,
             ),
         )

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -215,6 +215,7 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         runner = self._build_runner()
         runner.use_sparse = True
         runner.model_config.hf_text_config = SimpleNamespace(index_head_dim=128)
+        runner._get_attention_kv_cache_dims = lambda _layer_name, _spec: (512, 64)
         runner.attn_backend.get_kv_cache_shape.side_effect = (
             lambda num_blocks, block_size, num_kv_heads, head_size: (
                 num_blocks,

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -1015,19 +1015,27 @@ class AscendSFADCPImpl(AscendSFAImpl):
         block_table = attn_metadata.dcp_context.kv_gather_block_table
         assert valid_block_ids is not None and block_table is not None
         kv = torch.index_select(kv_cache[0], 0, valid_block_ids)
-        if len(kv_cache) < 2:
-            raise RuntimeError("DCP SFA KV all-gather requires nope and rope KV caches.")
-        key_rope = torch.index_select(kv_cache[1], 0, valid_block_ids)
-        if kv.shape[:-1] != key_rope.shape[:-1] or kv.dtype != key_rope.dtype:
-            raise RuntimeError(
-                "Cannot fuse DCP KV gather for KV/nope and KV/rope caches with "
-                f"shapes {tuple(kv.shape)} / {tuple(key_rope.shape)} and dtypes {kv.dtype} / {key_rope.dtype}."
-            )
-        fused_kv = torch.cat([kv, key_rope], dim=-1).contiguous()
+        if self.use_sparse_c8_sfa:
+            # Sparse C8 stores nope, rope, and quantization data in one packed
+            # SFA KV cache. The remaining cache entries belong to the indexer
+            # and must not participate in the DCP SFA KV all-gather.
+            gather_input = kv.contiguous()
+            split_sizes = (kv.shape[-1],)
+        else:
+            if len(kv_cache) < 2:
+                raise RuntimeError("DCP SFA KV all-gather requires nope and rope KV caches.")
+            key_rope = torch.index_select(kv_cache[1], 0, valid_block_ids)
+            if kv.shape[:-1] != key_rope.shape[:-1] or kv.dtype != key_rope.dtype:
+                raise RuntimeError(
+                    "Cannot fuse DCP KV gather for KV/nope and KV/rope caches with "
+                    f"shapes {tuple(kv.shape)} / {tuple(key_rope.shape)} and dtypes {kv.dtype} / {key_rope.dtype}."
+                )
+            gather_input = torch.cat([kv, key_rope], dim=-1).contiguous()
+            split_sizes = (kv.shape[-1], key_rope.shape[-1])
         attn_metadata.dcp_context.gather_context = self._start_dcp_gather(
-            fused_kv,
+            gather_input,
             dim=0,
-            split_sizes=(kv.shape[-1], key_rope.shape[-1]),
+            split_sizes=split_sizes,
         )
 
     def _start_dcp_gather(

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -1015,6 +1015,7 @@ class AscendSFADCPImpl(AscendSFAImpl):
         block_table = attn_metadata.dcp_context.kv_gather_block_table
         assert valid_block_ids is not None and block_table is not None
         kv = torch.index_select(kv_cache[0], 0, valid_block_ids)
+        split_sizes: tuple[int, ...]
         if self.use_sparse_c8_sfa:
             # Sparse C8 stores nope, rope, and quantization data in one packed
             # SFA KV cache. The remaining cache entries belong to the indexer

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -18,7 +18,7 @@ from vllm_ascend.attention.sfa_v1 import (
     AscendSFAMetadata,
     AscendSFAMetadataBuilder,
     DCPContext,
-    DCPQueryGatherContext,
+    DCPGatherContext,
 )
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, enabling_mlapo, split_decodes_and_prefills
 from vllm_ascend.device.device_op import DeviceOperator
@@ -815,6 +815,20 @@ class AscendSFADCPMetadataBuilder(AscendSFAMetadataBuilder):
             slot_mapping = slot_mapping[: dsa_cp_context.num_tokens_pad]
         dsa_cp_context.slot_mapping_cp = slot_mapping[dsa_cp_context.local_start : dsa_cp_context.local_end_with_pad]
 
+    def _build_compact_kv_gather_metadata(
+        self,
+        dcp_block_table: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build the compact cross-DCP KV view used by prefill attention."""
+        valid_block_ids, compact_block_table = dcp_block_table.flatten().unique(return_inverse=True)
+        compact_block_table = compact_block_table.view_as(dcp_block_table)
+        num_blocks = valid_block_ids.shape[0]
+        dcp_rank_arange = self.arange_buffer[: self.dcp_size]
+        remapped_block_table = (
+            compact_block_table.unsqueeze(-1) + (dcp_rank_arange * num_blocks).view(1, 1, -1).to(dcp_block_table)
+        ).reshape(dcp_block_table.shape[0], -1)
+        return valid_block_ids, remapped_block_table.to(torch.int32)
+
     def _build_with_replicated_view_metadata(
         self,
         common_attn_metadata: AscendCommonAttentionMetadata,
@@ -853,11 +867,26 @@ class AscendSFADCPMetadataBuilder(AscendSFAMetadataBuilder):
         self.dcp_local_seq_lens_buf[:num_reqs].copy_(local_seq_lens_src, non_blocking=True)
         local_seq_lens = self.dcp_local_seq_lens_buf[:num_reqs]
 
+        num_decodes, num_prefills, num_decode_tokens, _ = split_decodes_and_prefills(
+            common_attn_metadata,
+            decode_threshold=self.decode_threshold,
+            treat_short_extends_as_decodes=False,
+        )
+        dcp_block_table = dcp_block_table[:num_reqs]
+        kv_gather_block_ids = None
+        kv_gather_block_table = None
+        if num_prefills > 0:
+            kv_gather_block_ids, kv_gather_block_table = self._build_compact_kv_gather_metadata(dcp_block_table)
         metadata.dcp_context = DCPContext(
             slot_mapping=dcp_slot_mapping[:num_input_tokens],
-            block_table=dcp_block_table[:num_reqs],
+            block_table=dcp_block_table,
             seq_lens=local_seq_lens,
+            kv_gather_block_ids=kv_gather_block_ids,
+            kv_gather_block_table=kv_gather_block_table,
         )
+        metadata.num_decodes = num_decodes
+        metadata.num_decode_tokens = num_decode_tokens
+        metadata.num_prefills = num_prefills
         self._update_dsa_cp_slot_mapping_for_dcp(metadata, dcp_slot_mapping, num_input_tokens)
         return metadata
 
@@ -966,6 +995,65 @@ class AscendSFADCPImpl(AscendSFAImpl):
         device = self.q_proj.weight.device
         self._remap_order = torch.arange(self._dcp_index_topk, dtype=torch.float32, device=device)
         self._remap_invalid_index = torch.tensor(-1.0, dtype=torch.float32, device=device)
+
+    @staticmethod
+    def _has_prefill(attn_metadata: M) -> bool:
+        return attn_metadata.num_prefills > 0
+
+    def _record_dcp_kv_gather_context(
+        self,
+        kv_cache: tuple[torch.Tensor, ...],
+        attn_metadata: M,
+    ) -> None:
+        """Start the compact KV all-gather used by prefill/mixed DCP batches."""
+        if not self._has_prefill(attn_metadata):
+            return
+        assert attn_metadata.dcp_context is not None, "DCP SFA requires attn_metadata.dcp_context."
+        assert self.dcp_group is not None, "DCP SFA requires dcp_group when dcp_size > 1."
+
+        valid_block_ids = attn_metadata.dcp_context.kv_gather_block_ids
+        block_table = attn_metadata.dcp_context.kv_gather_block_table
+        assert valid_block_ids is not None and block_table is not None
+        kv = torch.index_select(kv_cache[0], 0, valid_block_ids)
+        if len(kv_cache) < 2:
+            raise RuntimeError("DCP SFA KV all-gather requires nope and rope KV caches.")
+        key_rope = torch.index_select(kv_cache[1], 0, valid_block_ids)
+        if kv.shape[:-1] != key_rope.shape[:-1] or kv.dtype != key_rope.dtype:
+            raise RuntimeError(
+                "Cannot fuse DCP KV gather for KV/nope and KV/rope caches with "
+                f"shapes {tuple(kv.shape)} / {tuple(key_rope.shape)} and dtypes {kv.dtype} / {key_rope.dtype}."
+            )
+        fused_kv = torch.cat([kv, key_rope], dim=-1).contiguous()
+        attn_metadata.dcp_context.gather_context = self._start_dcp_gather(
+            fused_kv,
+            dim=0,
+            split_sizes=(kv.shape[-1], key_rope.shape[-1]),
+        )
+
+    def _start_dcp_gather(
+        self,
+        x: torch.Tensor,
+        dim: int,
+        split_sizes: tuple[int, ...],
+    ) -> DCPGatherContext:
+        gathered, handle, restore_perm = self._all_gather_dim_async(x, dim)
+        return DCPGatherContext(
+            gathered=gathered,
+            handle=handle,
+            restore_perm=restore_perm,
+            split_sizes=split_sizes,
+        )
+
+    @staticmethod
+    def _finish_dcp_gather(
+        context: DCPGatherContext,
+    ) -> tuple[torch.Tensor, ...]:
+        if context.handle is not None:
+            context.handle.wait()
+        gathered = context.gathered
+        if context.restore_perm is not None:
+            gathered = gathered.permute(context.restore_perm).contiguous()
+        return torch.split(gathered, context.split_sizes, dim=-1)
 
     def _all_gather_dim_async(
         self,
@@ -1096,7 +1184,7 @@ class AscendSFADCPImpl(AscendSFAImpl):
         self,
         ql_nope: torch.Tensor,
         q_pe: torch.Tensor,
-    ) -> DCPQueryGatherContext:
+    ) -> DCPGatherContext:
         query_gather_dim = 0 if self.enable_dsa_cp else 1
         assert self.dcp_group is not None, "DCP query gather requires dcp_group when dcp_size > 1."
         if ql_nope.shape[:-1] != q_pe.shape[:-1] or ql_nope.dtype != q_pe.dtype:
@@ -1106,15 +1194,16 @@ class AscendSFADCPImpl(AscendSFAImpl):
                 f"and dtypes {ql_nope.dtype} / {q_pe.dtype}."
             )
 
-        ql_nope_dim = ql_nope.shape[-1]
-        q_pe_dim = q_pe.shape[-1]
         # Avoid back-to-back DCP all_gather calls for the two SFA query
         # fragments. On Ascend the separate gathers can leave SFA with an
         # incomplete stream dependency on the first prefill. DSA-CP restores
         # token shards on dim 0; native DCP restores query shards on dim 1.
         fused_q = torch.cat([ql_nope, q_pe], dim=-1).contiguous()
-        gathered, handle, restore_perm = self._all_gather_dim_async(fused_q, query_gather_dim)
-        return DCPQueryGatherContext(gathered, handle, restore_perm, ql_nope_dim, q_pe_dim)
+        return self._start_dcp_gather(
+            fused_q,
+            dim=query_gather_dim,
+            split_sizes=(ql_nope.shape[-1], q_pe.shape[-1]),
+        )
 
     def _record_dcp_query_gather_context(
         self,
@@ -1122,19 +1211,13 @@ class AscendSFADCPImpl(AscendSFAImpl):
         q_pe: torch.Tensor,
         attn_metadata: M,
     ) -> None:
+        # Prefill/mixed batches gather compact KV after its cache write instead.
+        # Keeping Q local avoids a full query all-gather and the subsequent LSE
+        # output merge in the all-KV attention path.
+        if self._has_prefill(attn_metadata):
+            return
         assert attn_metadata.dcp_context is not None, "DCP SFA requires attn_metadata.dcp_context."
-        attn_metadata.dcp_context.query_gather_context = self._start_dcp_query_gather(ql_nope, q_pe)
-
-    def _finish_all_gather_query_for_dcp(
-        self,
-        context: DCPQueryGatherContext,
-    ) -> tuple[torch.Tensor, ...]:
-        if context.handle is not None:
-            context.handle.wait()
-        gathered = context.gathered
-        if context.restore_perm is not None:
-            gathered = gathered.permute(context.restore_perm).contiguous()
-        return torch.split(gathered, [context.ql_nope_dim, context.q_pe_dim], dim=-1)
+        attn_metadata.dcp_context.gather_context = self._start_dcp_query_gather(ql_nope, q_pe)
 
     def _execute_sparse_flash_attention_process(
         self,
@@ -1149,10 +1232,43 @@ class AscendSFADCPImpl(AscendSFAImpl):
         assert attn_metadata.dcp_context is not None, "DCP SFA requires attn_metadata.dcp_context."
         assert self.dcp_group is not None, "DCP SFA requires dcp_group when dcp_size > 1."
         dcp_context = attn_metadata.dcp_context
-        query_gather_context = dcp_context.query_gather_context
-        dcp_context.query_gather_context = None
-        if query_gather_context is None:
-            query_gather_context = self._start_dcp_query_gather(ql_nope, q_pe)
+        if self._has_prefill(attn_metadata):
+            gather_context = dcp_context.gather_context
+            dcp_context.gather_context = None
+            if gather_context is None:
+                # The normal forward path starts this after KV writes so it can
+                # overlap indexer selection. Keep a synchronous fallback for
+                # callers that invoke this method outside that path.
+                self._record_dcp_kv_gather_context(kv_cache, attn_metadata)
+                gather_context = dcp_context.gather_context
+                dcp_context.gather_context = None
+            assert gather_context is not None
+            gathered_kv_cache = self._finish_dcp_gather(gather_context)
+            block_table = dcp_context.kv_gather_block_table
+            assert block_table is not None
+            # The gathered KV cache is complete, so each rank can attend with
+            # its local Q heads/tokens directly. In particular, DSA-CP keeps
+            # its token shard local; no Q all-gather, sparse-index remap, LSE,
+            # or output all-to-all merge is required.
+            attn_output = DeviceOperator.execute_sparse_flash_attention_process(
+                self,
+                ql_nope,
+                q_pe,
+                gathered_kv_cache,
+                topk_indices,
+                attn_metadata,
+                actual_seq_lengths_query,
+                actual_seq_lengths_key,
+                block_table=block_table,
+                sparse_mode=3,
+                return_lse=False,
+            )
+            return attn_output
+
+        gather_context = dcp_context.gather_context
+        dcp_context.gather_context = None
+        if gather_context is None:
+            gather_context = self._start_dcp_query_gather(ql_nope, q_pe)
         if self.enable_dsa_cp:
             # DSA-CP shards the token sequence. Restore the flat token order for
             # SFA, and use the original full query lengths for varlen metadata.
@@ -1162,7 +1278,7 @@ class AscendSFADCPImpl(AscendSFAImpl):
             # DCP-local KV shard.
             topk_indices = self.dcp_group.all_gather(topk_indices.contiguous(), dim=0)
         topk_indices = self._remap_sparse_indices(topk_indices)
-        ql_nope, q_pe = self._finish_all_gather_query_for_dcp(query_gather_context)
+        ql_nope, q_pe = self._finish_dcp_gather(gather_context)
         sfa_output, softmax_lse = DeviceOperator.execute_sparse_flash_attention_process(
             self,
             ql_nope,

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -87,18 +87,17 @@ O_PROJ_ACLNN_INPUT_PARAMS = (
 )
 
 
-class DCPQueryGatherContext(NamedTuple):
-    """State needed to finish the async fused DCP query all-gather."""
+class DCPGatherContext(NamedTuple):
+    """State needed to finish an async fused DCP all-gather."""
 
-    # The gathered fused query tensor: cat([ql_nope, q_pe], dim=-1).
+    # The gathered fused tensor.
     gathered: torch.Tensor
     # Async all-gather work handle. None means the gather completed synchronously.
     handle: torch.distributed.Work | None
     # Permutation that restores the original dimension order after dim>0 gather.
     restore_perm: tuple[int, ...] | None
-    # Last-dimension sizes used to split the fused query back into ql_nope/q_pe.
-    ql_nope_dim: int
-    q_pe_dim: int
+    # Last-dimension sizes used to split the fused tensor after gather.
+    split_sizes: tuple[int, ...]
 
 
 def _get_indexer_types(configs: tuple[Any, ...]) -> Any | None:
@@ -179,7 +178,9 @@ class DCPContext:
     slot_mapping: torch.Tensor
     block_table: torch.Tensor
     seq_lens: torch.Tensor
-    query_gather_context: DCPQueryGatherContext | None = None
+    kv_gather_block_ids: torch.Tensor | None = None
+    kv_gather_block_table: torch.Tensor | None = None
+    gather_context: DCPGatherContext | None = None
 
 
 @dataclass
@@ -1490,6 +1491,18 @@ class AscendSFAImpl(MLAAttentionImpl):
     ) -> None:
         return
 
+    def _record_dcp_kv_gather_context(
+        self,
+        kv_cache: tuple[torch.Tensor, ...],
+        attn_metadata: M,
+    ) -> None:
+        """Start a DCP KV gather after this layer has populated its cache.
+
+        The base implementation deliberately does nothing. The replicated-indexer
+        DCP implementation overrides it for batches containing prefill requests.
+        """
+        return
+
     def forward(
         self,
         layer_name,
@@ -1757,6 +1770,12 @@ class AscendSFAImpl(MLAAttentionImpl):
                             value_cache=kv_cache[1],
                             slot_mapping=slot_mapping_sfa[: attn_metadata.num_actual_tokens],
                         )
+
+            # DCP's prefill path may all-gather only the blocks referenced by
+            # this batch. It must start after the current layer's SFA KV write,
+            # but before the indexer/top-k work so communication can overlap it.
+            if kv_cache is not None:
+                self._record_dcp_kv_gather_context(kv_cache, attn_metadata)
 
             if self.has_indexer:
                 assert k_li is not None

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -87,6 +87,26 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
             )
             return ckv_bytes + qli_bytes + qli_scale_bytes
 
+        if (
+            self.sparse_head_dim is not None
+            and len(self.sparse_head_dim) == 3
+            and self.sfa_dcp_replicated_indexer_size > 1
+        ):
+            k_head_dim, v_head_dim, index_head_dim = self.sparse_head_dim
+            replicated_head_size = (
+                k_head_dim
+                + v_head_dim
+                + index_head_dim * self.sfa_dcp_replicated_indexer_size
+            )
+            return (
+                self.block_size
+                * self.num_kv_heads
+                * (
+                    replicated_head_size * get_dtype_size(self.dtype)
+                    + self.scale_dim * get_dtype_size(self.scale_dtype)
+                )
+            )
+
         return (
             self.block_size
             * self.num_kv_heads
@@ -134,10 +154,16 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
                 None,  # kv_cache[3] does not exist for Sparse C8
             )
 
+        k_head_dim, v_head_dim, index_head_dim = self.sparse_head_dim
+        replicated_index_head_dim = index_head_dim * self.sfa_dcp_replicated_indexer_size
+        total_virtual_head_dim = k_head_dim + v_head_dim + replicated_index_head_dim
+
         return (
-            self.head_size / self.sparse_head_dim[0],  # kv_cache[0]
-            self.head_size / self.sparse_head_dim[1],  # kv_cache[1]
-            (self.head_size / self.sparse_head_dim[2] if self.sparse_head_dim[2] > 0 else None),  # kv_cache[2]
+            total_virtual_head_dim / k_head_dim,  # kv_cache[0]
+            total_virtual_head_dim / v_head_dim,  # kv_cache[1]
+            (
+                total_virtual_head_dim / replicated_index_head_dim if replicated_index_head_dim > 0 else None
+            ),  # kv_cache[2]
             None,  # kv_cache[3] does not exist
         )
 

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -93,11 +93,7 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
             and self.sfa_dcp_replicated_indexer_size > 1
         ):
             k_head_dim, v_head_dim, index_head_dim = self.sparse_head_dim
-            replicated_head_size = (
-                k_head_dim
-                + v_head_dim
-                + index_head_dim * self.sfa_dcp_replicated_indexer_size
-            )
+            replicated_head_size = k_head_dim + v_head_dim + index_head_dim * self.sfa_dcp_replicated_indexer_size
             return (
                 self.block_size
                 * self.num_kv_heads

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -705,37 +705,27 @@ class BaseDeviceAdaptor:
         return_lse: bool = False,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         query = torch.cat([ql_nope, q_pe], dim=-1).contiguous()
-        common_kwargs = {
-            "query": query,
-            "key": kv,
-            "value": kv,
-            "sparse_indices": topk_indices,
-            "scale_value": sfa_impl.scale,
-            "sparse_block_size": 1,
-            "block_table": block_table,
-            "actual_seq_lengths_query": actual_seq_lengths_query,
-            "actual_seq_lengths_kv": actual_seq_lengths_key,
-            "layout_query": "TND",
-            "layout_kv": "PA_BSND",
-            "sparse_mode": sparse_mode,
-            "attention_mode": 2,
-            "quant_scale_repo_mode": 1,
-            "tile_size": getattr(sfa_impl, "sfa_qsfa_tile_size", 128),
-            "key_quant_mode": 2,
-            "value_quant_mode": 2,
-            "rope_head_dim": getattr(sfa_impl, "qk_rope_head_dim", q_pe.shape[-1]),
-        }
-        if return_lse:
-            # The torch_npu C8 SFA binding used by current images only returns
-            # attention_out and rejects return_softmax_lse.  DCP needs the
-            # softmax max/sum tensors to build LSE, so use the vllm-ascend
-            # custom op added with LSE-capable C8 SFA only on that path.
-            result = torch.ops._C_ascend.npu_kv_quant_sparse_flash_attention(
-                **common_kwargs,
-                return_softmax_lse=True,
-            )
-        else:
-            result = torch_npu.npu_kv_quant_sparse_flash_attention(**common_kwargs)
+        result = torch.ops._C_ascend.npu_kv_quant_sparse_flash_attention(
+            query=query,
+            key=kv,
+            value=kv,
+            sparse_indices=topk_indices,
+            scale_value=sfa_impl.scale,
+            sparse_block_size=1,
+            block_table=block_table,
+            actual_seq_lengths_query=actual_seq_lengths_query,
+            actual_seq_lengths_kv=actual_seq_lengths_key,
+            layout_query="TND",
+            layout_kv="PA_BSND",
+            sparse_mode=sparse_mode,
+            attention_mode=2,
+            quant_scale_repo_mode=1,
+            tile_size=getattr(sfa_impl, "sfa_qsfa_tile_size", 128),
+            key_quant_mode=2,
+            value_quant_mode=2,
+            rope_head_dim=getattr(sfa_impl, "qk_rope_head_dim", q_pe.shape[-1]),
+            return_softmax_lse=True,
+        )
         if not isinstance(result, tuple):
             if return_lse:
                 raise RuntimeError("C8 sparse flash attention did not return softmax max/sum for DCP LSE merge.")

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -740,14 +740,9 @@ class NPUPlatform(Platform):
                 "needs to be equal if use pcp or dcp > 1 in P/D disaggregate and kv pool scenario."
             )
 
-        if (
-            use_sparse
-            and cp_size > 1
-            and parallel_config.cp_kv_cache_interleave_size != cache_config.block_size
-            and not sfa_dcp_replicated_indexer
-        ):
+        if use_sparse and cp_size > 1 and parallel_config.cp_kv_cache_interleave_size != cache_config.block_size:
             logger.warning_once(
-                "The current SFA's PCP implementation requires "
+                "The current SFA CP implementation requires "
                 f"cp_kv_cache_interleave_size({parallel_config.cp_kv_cache_interleave_size})"
                 f" == block_size({cache_config.block_size}). "
                 f"Override cp_kv_cache_interleave_size to {cache_config.block_size}."

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -458,7 +458,6 @@ class NPUModelRunner(GPUModelRunner):
         self.sfa_dcp_replicated_indexer_size = 1
         if enable_sfa_dcp_replicated_indexer():
             self.sfa_dcp_replicated_indexer_size = self.dcp_size
-            self.sparse_head_dim = (*self.sparse_head_dim[:-1], self.sparse_head_dim[-1] * self.dcp_size)
 
         # Create a CPU numpy buffer for positions computation when
         # self.positions is a plain tensor (non-CpuGpuBuffer case).


### PR DESCRIPTION
### What this PR does / why we need it?
cherry-pick from #11980
Backports the compact KV-cache all-gather path for SFA DCP prefill and mixed batches to v0.23.0. The path gathers only referenced blocks after KV-cache writes, remaps the block table for the gathered cache, and keeps Q local to avoid DCP LSE/output merging. DCP SFA invocations are routed through `DeviceOperator`.

This allows prefill TTFT to benefit from DSA-CP: in the 1M-token scenario, TTFT decreases from about 23 to about 3.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
