### PR TITLE
[v0.23.0][BugFix] Fix fused_infer_attention ops contiguous err in mla_cp

### DIFF
--- a/vllm_ascend/attention/context_parallel/mla_cp.py
+++ b/vllm_ascend/attention/context_parallel/mla_cp.py
@@ -588,10 +588,10 @@ class AscendMlaCPImpl(AscendMLAImpl):
 
         attn_out, attn_lse = torch.ops.npu.npu_fused_infer_attention_score(
             q_nope,
-            k_nope_attn,
-            value_attn,
+            k_nope_attn.contiguous(),
+            value_attn.contiguous(),
             query_rope=q_pe,
-            key_rope=k_pe_attn,
+            key_rope=k_pe_attn.contiguous(),
             num_heads=self.num_heads,
             num_key_value_heads=self.num_heads,
             input_layout="TND",


### PR DESCRIPTION

### What this PR does / why we need it?
Cherry pick from #11986 he fused_infer_attention ops doesn't support make the input contiguous automatic, so we need to make the some input tensor contiguous in framework, which is also need in Ascend950 hardware

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
