### PR TITLE
[Feature][Attention] Add DeepSeek V4 DSpark noncausal DSA/SAS support

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -110,7 +110,9 @@
   base: attention_common
   source_file_dependencies:
     - vllm_ascend/attention/dsa_v1.py
+    - vllm_ascend/attention/dsa_window.py
   tests:
+    - tests/ut/spec_decode/test_dspark_dsa_metadata.py
     - tests/e2e/pull_request/four_card/test_deepseek_v4.py
 
 - name: attention_cp

--- a/csrc/attention/sparse_attn_sharedkv/README.md
+++ b/csrc/attention/sparse_attn_sharedkv/README.md
@@ -30,7 +30,7 @@
 | q                     | 输入      | 对应公式中的$Q$。                                                     | BFLOAT16、FLOAT16  | ND |
 | ori\_kv               | 可选输入  | 对应公式中的$\tilde{K}和\tilde{V}$的一部分，为原始不经压缩的KV。          | BFLOAT16、FLOAT16 | ND |
 | cmp\_kv               | 可选输入  | 对应公式中的$\tilde{K}和\tilde{V}$的一部分，为经过压缩的KV。             | BFLOAT16、FLOAT16  | ND |
-| ori\_sparse\_indices  | 可选输入  | 代表离散取oriKvCache的索引。                                           | INT32              | ND |
+| ori\_sparse\_indices  | 可选输入  | 代表离散读取oriKvCache的物理slot索引，负数表示有效索引结束。             | INT32              | ND |
 | cmp\_sparse\_indices  | 可选输入  | 代表离散取cmpKvCache的索引。                                           | INT32              | ND |
 | ori\_block\_table     | 可选输入  | 表示PageAttention中oriKvCache存储使用的block映射表。                   | INT32               | ND |
 | cmp\_block\_table     | 可选输入  | 表示PageAttention中cmpKvCache存储使用的block映射表。                   | INT32               | ND |
@@ -57,17 +57,17 @@
 
 - 该接口支持推理场景下使用。
 - 该接口支持aclgraph模式。
-- 该接口当前支持三种计算场景：场景一，仅传入`ori_kv`时为Sliding Window Attention计算；场景二，传入`ori_kv`及`cmp_kv`时为Sliding Window Attention + Compressed Attention计算；场景三，传入`ori_kv`、`cmp_kv`及`cmp_sparse_indices`时为Sliding Window Attention + Sparse Compressed Attention计算。
+- 该接口当前支持四种计算场景：场景一，仅传入`ori_kv`时为Sliding Window Attention计算；场景二，传入`ori_kv`和`ori_sparse_indices`时按显式物理slot执行Sparse Sliding Window Attention计算；场景三，传入`ori_kv`及`cmp_kv`时为Sliding Window Attention + Compressed Attention计算；场景四，传入`ori_kv`、`cmp_kv`及`cmp_sparse_indices`时为Sliding Window Attention + Sparse Compressed Attention计算。
 
 - 当`layout_q`为TND时，功能使用限制如下：
     - `q`的shape需要为[T1,N1,D]，其中N1仅支持64。
-    - `ori_sparse_indices`的shape需要为[Q\_T, KV\_N, K1]，其中K1为对`ori_kv`一次离散选取的token数，K1仅支持512。
+    - `ori_sparse_indices`仅支持SWA模板和`PA_ND` KV layout，shape需要为[Q\_T, KV\_N, K1]，其中K1为对`ori_kv`一次离散选取的token数。K1必须为正数、128对齐且不超过2048；每行遇到第一个负数时停止读取。`ori_win_left`需要为metadata提供不小于有效索引数量的非负调度窗口，`ori_win_right`仅支持0。
     - `cmp_sparse_indices`的shape需要为[Q\_T, KV\_N, K2]，其中K2为对`cmp_kv`一次离散选取的token数，K2仅支持512。
     - `cu_seqlens_q`必须传入，输入维度为B+1，大小为参数中每个元素的值表示当前batch与之前所有batch的token数总和，即前缀和，因此后一个元素的值必须>=前一个元素的值。
 
 - 当`layout_q`为BSND时，功能使用限制如下：
     - `q`的shape需要为[B, Q\_S,N1,D]，其中N1仅支持64。
-    - `ori_sparse_indices`的shape需要为[B, Q\_S, KV\_N, K1]，其中K1为对`ori_kv`一次离散选取的token数，K1仅支持512。
+    - 当前不支持传入`ori_sparse_indices`。
     - `cmp_sparse_indices`的shape需要为[B, Q\_S, KV\_N, K2]，其中K2为对`cmp_kv`一次离散选取的token数，K2仅支持512。
 
 - PageAttention场景下，功能使用限制如下：
@@ -78,13 +78,45 @@
 - 目前暂不支持返回`softmax_lse`，`return_softmax_lse`仅支持输入False，返回值`softmax_lse`为无效值。
 - ori_mask_mode及cmp_mask_mode所表示的mask模式的详细介绍见[sparse_mode参数说明](../../../docs/zh/context/sparse_mode参数说明.md)。
 - 目前暂不支持指定`q`中参与运算的token数，因此设置`seqused_q`无效。
-- 目前暂不支持对`ori_kv`进行稀疏计算，因此设置`ori_sparse_indices`无效。
+- `ori_sparse_indices`中的非负值是`ori_kv`首两维展平后的物理slot编号，不再经过`ori_block_table`映射。
 - 目前所有输入不支持传入空tensor。
 - `q`、`ori_kv`、`cmp_kv`数据排布格式支持从多种维度解读，B（Batch）表示输入样本批量大小、S（Seq-Length）表示输入样本序列长度、H（Hidden-Size）表示隐藏层的大小、N（Head-Num）表示多头数、D（Head-Dim）表示hidden层最小的单元尺寸，且满足D=H/N、T表示所有Batch输入样本序列长度的累加和。
 - Q\_S和S1表示q shape中的S，S2表示ori_kv shape中的S，S3表示cmp_kv shape中的S；Q\_N和N1表示num\_q\_heads，KV\_N和N2表示num\_ori_kv\_heads和num\_cmp_kv\_heads；Q\_T和T1表示q shape中的输入样本序列长度的累加和。
 
 - 当`layout_kv`为BSND时，功能使用限制如下：
     - `ori_kv`和`cmp_kv`的layout都必须为BSND，ori_kv的shape为[B, S2, N2,D]，cmp_kv的shape为[B, S3, N2,D]。
+
+显式original-KV slot模式调用示例（`metadata`的构造方式与下方单算子示例相同）：
+
+```python
+ori_sparse_indices = torch.full(
+    (q.shape[0], ori_kv.shape[2], 128),
+    -1,
+    dtype=torch.int32,
+    device=q.device,
+)
+slots = torch.tensor([1, 19, 34, 17], dtype=torch.int32, device=q.device)
+ori_sparse_indices[:, 0, : slots.numel()] = slots
+
+attention_out, _ = torch.ops.custom.npu_sparse_attn_sharedkv(
+    q,
+    ori_kv=ori_kv,
+    ori_sparse_indices=ori_sparse_indices,
+    ori_block_table=ori_block_table,
+    cu_seqlens_q=cu_seqlens_q,
+    seqused_kv=seqused_kv,
+    sinks=sinks,
+    metadata=metadata,
+    softmax_scale=softmax_scale,
+    cmp_ratio=4,
+    ori_mask_mode=4,
+    cmp_mask_mode=3,
+    ori_win_left=127,
+    ori_win_right=0,
+    layout_q="TND",
+    layout_kv="PA_ND",
+)
+```
 
 ## Atlas A3 推理系列产品 调用说明
 

--- a/csrc/attention/sparse_attn_sharedkv/op_host/sparse_attn_sharedkv_tiling.cpp
+++ b/csrc/attention/sparse_attn_sharedkv/op_host/sparse_attn_sharedkv_tiling.cpp
@@ -171,9 +171,6 @@ ge::graphStatus SASInfoParser::CheckRequiredParaExistence() const
 
 ge::graphStatus SASInfoParser::CheckUnrequiredParaExistence() const
 {
-    OP_CHECK_IF(opParamInfo_.oriSparseIndices.tensor != nullptr || opParamInfo_.oriSparseIndices.desc != nullptr,
-                OP_LOGE(opName_, "Currently, ori_sparse_indices must be a nullptr"),
-                return ge::GRAPH_FAILED);
     return ge::GRAPH_SUCCESS;
 }
 
@@ -404,6 +401,17 @@ uint32_t SASInfoParser::GetAxisNum(const gert::Shape &shape, const SASAxis &axis
     return HasAxis(axis, layout, shape) ? shape.GetDim(GetAxisIdx(axis, layout)) : invalidDimValue_;
 }
 
+uint32_t SASInfoParser::GetSparseIndexWidth(const gert::Shape &shape, const SASLayout &layout) const
+{
+    if (layout == SASLayout::TND && shape.GetDimNum() == DIM_NUM_THREE) {
+        return shape.GetDim(DIM_NUM_THREE - 1);
+    }
+    if (layout == SASLayout::BSND && shape.GetDimNum() == DIM_NUM_FOUR) {
+        return shape.GetDim(DIM_NUM_FOUR - 1);
+    }
+    return 0;
+}
+
 void SASInfoParser::SetSASShape()
 {
     qShape_ = opParamInfo_.q.shape->GetStorageShape();
@@ -414,6 +422,11 @@ void SASInfoParser::SetSASShape()
     }
     if (opParamInfo_.cmpKv.tensor != nullptr) {
         cmpKvShape_ = opParamInfo_.cmpKv.tensor->GetStorageShape();
+    }
+    if (opParamInfo_.oriSparseIndices.tensor != nullptr) {
+        oriSparseIndicesShape_ = opParamInfo_.oriSparseIndices.tensor->GetStorageShape();
+        hasOriSparseIndices_ = true;
+        oriSparseIndexWidth_ = GetSparseIndexWidth(oriSparseIndicesShape_, oriSparseIndicesLayout_);
     }
     if (perfMode_ == SASTemplateMode::SCFA_TEMPLATE_MODE)
     {
@@ -788,6 +801,8 @@ void SASInfoParser::GenerateInfo(SASTilingInfo &sasInfo)
             opParamInfo_.oriKv.tensor->GetStorageShape().GetDim(0) : 0;
     }
     sasInfo.sparseBlockSize = 1;
+    sasInfo.hasOriSparseIndices = hasOriSparseIndices_;
+    sasInfo.oriSparseIndexWidth = oriSparseIndexWidth_;
     sasInfo.oriBlockSize = oriBlockSize_;
     sasInfo.cmpBlockSize = cmpBlockSize_;
     sasInfo.blockTypeSize = sizeof(float);
@@ -893,6 +908,8 @@ void SASTilingCheck::Init()
     oriWinRight_ = sasInfo_.oriWinRight;
     kvLayout_ = sasInfo_.kvLayout;
     outLayout_ = sasInfo_.outLayout;
+    hasOriSparseIndices_ = sasInfo_.hasOriSparseIndices;
+    oriSparseIndexWidth_ = sasInfo_.oriSparseIndexWidth;
 }
 
 void SASTilingCheck::LogErrorDtypeSupport(const std::vector<ge::DataType> &expectDtypeList,
@@ -1064,6 +1081,52 @@ ge::graphStatus SASTilingCheck::CheckSingleParaKvHeadNums() const
     return ge::GRAPH_SUCCESS;
 }
 
+ge::graphStatus SASTilingCheck::CheckSingleParaOriSparseIndices() const
+{
+    if (!hasOriSparseIndices_) {
+        return ge::GRAPH_SUCCESS;
+    }
+    OP_CHECK_IF(sasInfo_.perfMode != SASTemplateMode::SWA_TEMPLATE_MODE,
+                OP_LOGE(opName_, "ori_sparse_indices is only supported with SWA template mode."),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(kvLayout_ != SASLayout::PA_ND,
+                OP_LOGE(opName_, "ori_sparse_indices is only supported with PA_ND kv layout."),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(qLayout_ != SASLayout::TND,
+                OP_LOGE(opName_, "ori_sparse_indices currently supports TND query layout only."),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(opParamInfo_.oriSparseIndices.tensor->GetStorageShape().GetShapeSize() == 0,
+                OP_LOGE(opName_, "ori_sparse_indices cannot be empty tensor."),
+                return ge::GRAPH_FAILED);
+
+    const std::vector<size_t> oriSparseIndicesDimNumList = {DIM_NUM_THREE};
+    if (ge::GRAPH_SUCCESS != CheckDtypeSupport(opParamInfo_.oriSparseIndices.desc, ORI_SPARSE_INDICES) ||
+        ge::GRAPH_SUCCESS != CheckLayoutSupport(oriSparseIndicesLayout_, ORI_SPARSE_INDICES) ||
+        ge::GRAPH_SUCCESS != CheckDimNumSupport(&opParamInfo_.oriSparseIndices.tensor->GetShape(),
+                                                oriSparseIndicesDimNumList, ORI_SPARSE_INDICES) ||
+        ge::GRAPH_SUCCESS != CheckDimNumInLayoutSupport(oriSparseIndicesLayout_,
+                                                        &opParamInfo_.oriSparseIndices.tensor->GetShape(),
+                                                        ORI_SPARSE_INDICES)) {
+        return ge::GRAPH_FAILED;
+    }
+
+    const gert::Shape &shape = opParamInfo_.oriSparseIndices.tensor->GetStorageShape();
+    OP_CHECK_IF(shape.GetDim(0) != s1Size_,
+                OP_LOGE(opName_, "ori_sparse_indices T(%ld) should equal query T(%u).", shape.GetDim(0), s1Size_),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(shape.GetDim(1) != n2Size_,
+                OP_LOGE(opName_, "ori_sparse_indices N2(%ld) should equal kv head num(%u).",
+                         shape.GetDim(1), n2Size_),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(oriSparseIndexWidth_ == 0 || oriSparseIndexWidth_ > SPARSE_LIMIT ||
+                    (oriSparseIndexWidth_ % 128U) != 0U,
+                OP_LOGE(opName_,
+                        "ori_sparse_indices K should be a positive 128-aligned value not greater than %u, got %u.",
+                        SPARSE_LIMIT, oriSparseIndexWidth_),
+                return ge::GRAPH_FAILED);
+    return ge::GRAPH_SUCCESS;
+}
+
 ge::graphStatus SASTilingCheck::CheckSingleParaCmpSparseIndices() const
 {
     if (sasInfo_.perfMode == optiling::SASTemplateMode::SCFA_TEMPLATE_MODE){
@@ -1230,6 +1293,7 @@ ge::graphStatus SASTilingCheck::CheckSinglePara() const
         ge::GRAPH_SUCCESS != CheckSingleParaCmpKv() ||
         ge::GRAPH_SUCCESS != CheckSingleParaNumHeads() ||
         ge::GRAPH_SUCCESS != CheckSingleParaKvHeadNums() ||
+        ge::GRAPH_SUCCESS != CheckSingleParaOriSparseIndices() ||
         ge::GRAPH_SUCCESS != CheckSingleParaCmpSparseIndices() ||
         ge::GRAPH_SUCCESS != CheckSingleParaOriBlockTable() ||
         ge::GRAPH_SUCCESS != CheckSingleParaCmpBlockTable() ||
@@ -1362,12 +1426,21 @@ ge::graphStatus SASTilingCheck::CheckFeatureShape() const
     OP_CHECK_IF(*opParamInfo_.cmpMaskMode != 3,
                 OP_LOGE(opName_, "cmp_mask_mode should be 3, but got %d", *opParamInfo_.cmpMaskMode),
                 return ge::GRAPH_FAILED);
-    OP_CHECK_IF(oriWinLeft_ != 127,
-                OP_LOGE(opName_, "ori_win_left should be 127, but got %d", oriWinLeft_),
-                return ge::GRAPH_FAILED);
-    OP_CHECK_IF(oriWinRight_ != 0,
-                OP_LOGE(opName_, "ori_win_right should be 0, but got %d", oriWinRight_),
-                return ge::GRAPH_FAILED);
+    if (hasOriSparseIndices_) {
+        OP_CHECK_IF(oriWinLeft_ < 0,
+                    OP_LOGE(opName_, "ori_win_left should be non-negative, but got %ld", oriWinLeft_),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(oriWinRight_ != 0,
+                    OP_LOGE(opName_, "ori_win_right should be 0, but got %ld", oriWinRight_),
+                    return ge::GRAPH_FAILED);
+    } else {
+        OP_CHECK_IF(oriWinLeft_ != 127,
+                    OP_LOGE(opName_, "ori_win_left should be 127, but got %ld", oriWinLeft_),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(oriWinRight_ != 0,
+                    OP_LOGE(opName_, "ori_win_right should be 0, but got %ld", oriWinRight_),
+                    return ge::GRAPH_FAILED);
+    }
     return ge::GRAPH_SUCCESS;
 }
 
@@ -1604,6 +1677,8 @@ ge::graphStatus SparseAttnSharedkvTiling::DoOpTiling(SASTilingInfo *tilingInfo)
     tilingData_.baseParams.set_oriWinLeft(tilingInfo->oriWinLeft);
     tilingData_.baseParams.set_oriWinRight(tilingInfo->oriWinRight);
     tilingData_.baseParams.set_sparseBlockSize(tilingInfo->sparseBlockSize);
+    tilingData_.baseParams.set_hasOriSparseIndices(tilingInfo->hasOriSparseIndices);
+    tilingData_.baseParams.set_oriSparseIndexWidth(tilingInfo->oriSparseIndexWidth);
     tilingData_.baseParams.set_returnSoftmaxLse(tilingInfo->returnSoftmaxLse);
 
     tilingData_.cmpParams.set_cmpMaxBlockNumPerBatch(tilingInfo->cmpMaxBlockNumPerBatch);

--- a/csrc/attention/sparse_attn_sharedkv/op_host/sparse_attn_sharedkv_tiling.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_host/sparse_attn_sharedkv_tiling.h
@@ -148,6 +148,8 @@ TILING_DATA_FIELD_DEF(int64_t, oriKvStride)
 TILING_DATA_FIELD_DEF(int64_t, oriWinLeft)
 TILING_DATA_FIELD_DEF(int64_t, oriWinRight)
 TILING_DATA_FIELD_DEF(int64_t, sparseBlockSize)
+TILING_DATA_FIELD_DEF(bool, hasOriSparseIndices)
+TILING_DATA_FIELD_DEF(uint32_t, oriSparseIndexWidth)
 
 TILING_DATA_FIELD_DEF(uint32_t, usedCoreNum);
 
@@ -247,6 +249,8 @@ public:
     int64_t oriWinRight = 0;
     int64_t sparseBlockSize = 0;
     int64_t sparseBlockCount = 0;
+    bool hasOriSparseIndices = false;
+    uint32_t oriSparseIndexWidth = 0;
     // Mask
     int32_t sparseMode = 0;
     // Others Flag
@@ -391,6 +395,8 @@ private:
     int64_t blockSize_ = 0;
     int32_t oriBlockSize_ = 0;
     int32_t cmpBlockSize_ = 0;
+    bool hasOriSparseIndices_ = false;
+    uint32_t oriSparseIndexWidth_ = 0;
 
     uint32_t aicNum_ = 0;
     uint32_t aivNum_ = 0;
@@ -468,6 +474,7 @@ public:
     bool HasAxis(const SASAxis &axis, const SASLayout &layout, const gert::Shape &shape) const;
     size_t GetAxisIdx(const SASAxis &axis, const SASLayout &layout) const;
     uint32_t GetAxisNum(const gert::Shape &shape, const SASAxis &axis,const SASLayout &layout) const;
+    uint32_t GetSparseIndexWidth(const gert::Shape &shape, const SASLayout &layout) const;
     static constexpr int64_t invalidDimValue_ = std::numeric_limits<int64_t>::min();
 
     // BaseParams
@@ -506,6 +513,8 @@ public:
     uint32_t cmpMaxBlockNumPerBatch_ = 0;
     int32_t oriBlockSize_ = 0;
     int32_t cmpBlockSize_ = 0;
+    bool hasOriSparseIndices_ = false;
+    uint32_t oriSparseIndexWidth_ = 0;
 
     // template mode
     SASTemplateMode perfMode_ = SASTemplateMode::SWA_TEMPLATE_MODE;

--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_scfa_kernel.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_scfa_kernel.h
@@ -84,8 +84,8 @@ public:
 
     __aicore__ inline SparseAttnSharedkvScfa(){};
     __aicore__ inline void Init(__gm__ uint8_t *query, __gm__ uint8_t *oriKV, __gm__ uint8_t *cmpKV,
-                                __gm__ uint8_t *cmpSparseIndices, __gm__ uint8_t *oriBlockTable,
-                                __gm__ uint8_t *cmpBlockTable, __gm__ uint8_t *cuSeqlensQ,
+                                __gm__ uint8_t *oriSparseIndices, __gm__ uint8_t *cmpSparseIndices,
+                                __gm__ uint8_t *oriBlockTable, __gm__ uint8_t *cmpBlockTable, __gm__ uint8_t *cuSeqlensQ,
                                 __gm__ uint8_t* cuSeqlensKV, __gm__ uint8_t *cuSeqlensCmpKV,
                                 __gm__ uint8_t *seqUsedQ, __gm__ uint8_t *seqUsedKV, __gm__ uint8_t *sinks,
                                 __gm__ uint8_t *metadata, __gm__ uint8_t *attentionOut,
@@ -388,13 +388,15 @@ __aicore__ inline void SparseAttnSharedkvScfa<SAST>::UpdateInnerLoopCond()
 
 template <typename SAST>
 __aicore__ inline void SparseAttnSharedkvScfa<SAST>::Init(
-    __gm__ uint8_t *query, __gm__ uint8_t *oriKV, __gm__ uint8_t *cmpKV, __gm__ uint8_t *cmpSparseIndices,
-    __gm__ uint8_t *oriBlockTable, __gm__ uint8_t *cmpBlockTable, __gm__ uint8_t *cuSeqlensQ,
+    __gm__ uint8_t *query, __gm__ uint8_t *oriKV, __gm__ uint8_t *cmpKV, __gm__ uint8_t *oriSparseIndices,
+    __gm__ uint8_t *cmpSparseIndices, __gm__ uint8_t *oriBlockTable, __gm__ uint8_t *cmpBlockTable,
+    __gm__ uint8_t *cuSeqlensQ,
     __gm__ uint8_t* cuSeqlensKV, __gm__ uint8_t *cuSeqlensCmpKV, __gm__ uint8_t *seqUsedQ,
     __gm__ uint8_t *seqUsedKV, __gm__ uint8_t *sinks, __gm__ uint8_t *metadata, __gm__ uint8_t *attentionOut, __gm__ uint8_t *softmaxLse,
     __gm__ uint8_t *workspace, const SparseAttnSharedkvTilingData *__restrict tiling, __gm__ uint8_t *gmTiling,
     TPipe *tPipe)
 {
+    (void)oriSparseIndices;
     if ASCEND_IS_AIV {
         tmpBlockIdx = GetBlockIdx(); // vec:0-47
         aiCoreIdx = tmpBlockIdx / 2;

--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_swa_block_cube.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_swa_block_cube.h
@@ -41,7 +41,8 @@ public:
                                                GlobalTensor<OUT_T> attentionOutGm);
     __aicore__ inline void InitPageAttentionInfo(GlobalTensor<KV_T> oriKvGm, // const GlobalTensor<KV_T>& kvMergeGm,
                                                  GlobalTensor<int32_t> oriBlockTableGm,
-                                                 GlobalTensor<int32_t> cmpBlockTableGm);
+                                                 GlobalTensor<int32_t> cmpBlockTableGm,
+                                                 GlobalTensor<int32_t> oriSparseIndicesGm);
     __aicore__ inline void InitBuffers(TPipe *pipe);
 
     __aicore__ inline void AllocEventID();
@@ -113,6 +114,7 @@ private:
     // block_table
     GlobalTensor<int32_t> oriBlockTableGm;
     GlobalTensor<int32_t> cmpBlockTableGm;
+    GlobalTensor<int32_t> oriSparseIndicesGm;
 
     TBuf<TPosition::A1> bufQPL1;
     TBuf<TPosition::A1> bufKVL1;
@@ -185,10 +187,13 @@ __aicore__ inline void SWACubeBlock<SAST>::InitMm2GlobalTensor(GlobalTensor<KV_T
 template <typename SAST>
 __aicore__ inline void
 SWACubeBlock<SAST>::InitPageAttentionInfo(GlobalTensor<KV_T> oriKvGm, // const GlobalTensor<KV_T>& kvMergeGm,
-                                          GlobalTensor<int32_t> oriBlockTableGm, GlobalTensor<int32_t> cmpBlockTableGm)
+                                          GlobalTensor<int32_t> oriBlockTableGm,
+                                          GlobalTensor<int32_t> cmpBlockTableGm,
+                                          GlobalTensor<int32_t> oriSparseIndicesGm)
 {
     this->oriKvGm = oriKvGm;
     this->oriBlockTableGm = oriBlockTableGm;
+    this->oriSparseIndicesGm = oriSparseIndicesGm;
     if (constInfo.templateMode == CFA_TEMPLATE) {
         this->cmpBlockTableGm = cmpBlockTableGm;
     }
@@ -373,16 +378,11 @@ __aicore__ inline void SWACubeBlock<SAST>::ComputeMm1(const RunInfo &info, const
                     LocalTensor<KV_T> kTensor;
                     uint32_t copyRowCnt = 0;
 
-                    while (copyFinishRowCnt < nL1Size) {
-                        // 由于ori_left的存在， 即使第一块搬运也可能并非是pa_block的零点位
-                        copyRowCnt = constInfo.paOriBlockSize - curS2Offset % constInfo.paOriBlockSize;
-                        if (copyFinishRowCnt + copyRowCnt > nL1Size) {
-                            copyRowCnt = nL1Size - copyFinishRowCnt;
-                        }
+                    if (constInfo.hasOriSparseIndices) {
                         Position startPos;
                         startPos.bIdx = info.bIdx;
                         startPos.n2Idx = info.n2Idx;
-                        startPos.s2Idx = curS2Offset;
+                        startPos.s2Idx = 0;
                         // 256、32等待7buf命名更改
                         startPos.dIdx = kL1 * 256;  // mm1 右矩阵 bn2s2d, d为k轴不切; mm2 右矩阵, s2为k轴, d轴切分
                         PAShape shape;
@@ -392,13 +392,41 @@ __aicore__ inline void SWACubeBlock<SAST>::ComputeMm1(const RunInfo &info, const
                         shape.kvStride = constInfo.oriKvStride;
                         shape.actHeadDim = 256;
                         shape.maxblockNumPerBatch = constInfo.oriMaxBlockNumPerBatch;
-                        shape.copyRowNum = copyRowCnt;
+                        shape.copyRowNum = nL1Size;
                         shape.copyRowNumAlign = nL1SizeAlign;
-                        kTensor = bL1Tensor[copyFinishRowCnt * 16];
-                        DataCopyPA<KV_T>(kTensor, oriKvGm, oriBlockTableGm, shape, startPos);
-                        // 更新循环变量
-                        copyFinishRowCnt += copyRowCnt;
-                        curS2Offset += copyRowCnt;
+                        uint64_t sparseIndexBaseOffset =
+                            (info.qTokenOffset * constInfo.kvHeadNum + info.n2Idx) * constInfo.oriSparseIndexWidth;
+                        uint32_t sparseIndexStart = info.s2Idx * constInfo.s2BaseSize + nL1 * N_SPLIT_SIZE;
+                        DataCopyPABySlots<KV_T>(bL1Tensor, oriKvGm, oriSparseIndicesGm, shape, startPos,
+                                                sparseIndexBaseOffset, sparseIndexStart);
+                    } else {
+                        while (copyFinishRowCnt < nL1Size) {
+                            // 由于ori_left的存在， 即使第一块搬运也可能并非是pa_block的零点位
+                            copyRowCnt = constInfo.paOriBlockSize - curS2Offset % constInfo.paOriBlockSize;
+                            if (copyFinishRowCnt + copyRowCnt > nL1Size) {
+                                copyRowCnt = nL1Size - copyFinishRowCnt;
+                            }
+                            Position startPos;
+                            startPos.bIdx = info.bIdx;
+                            startPos.n2Idx = info.n2Idx;
+                            startPos.s2Idx = curS2Offset;
+                            // 256、32等待7buf命名更改
+                            startPos.dIdx = kL1 * 256;  // mm1 右矩阵 bn2s2d, d为k轴不切; mm2 右矩阵, s2为k轴, d轴切分
+                            PAShape shape;
+                            shape.blockSize = constInfo.paOriBlockSize;
+                            shape.headNum = constInfo.kvHeadNum;
+                            shape.headDim = constInfo.headDim;
+                            shape.kvStride = constInfo.oriKvStride;
+                            shape.actHeadDim = 256;
+                            shape.maxblockNumPerBatch = constInfo.oriMaxBlockNumPerBatch;
+                            shape.copyRowNum = copyRowCnt;
+                            shape.copyRowNumAlign = nL1SizeAlign;
+                            kTensor = bL1Tensor[copyFinishRowCnt * 16];
+                            DataCopyPA<KV_T>(kTensor, oriKvGm, oriBlockTableGm, shape, startPos);
+                            // 更新循环变量
+                            copyFinishRowCnt += copyRowCnt;
+                            curS2Offset += copyRowCnt;
+                        }
                     }
                 } else if constexpr (KV_LAYOUT_T == SAS_LAYOUT::BSND) {
                     Nd2NzParams nd2nzPara;
@@ -681,15 +709,11 @@ __aicore__ inline void SWACubeBlock<SAST>::ComputeMm2(const RunInfo &info, const
                 if (info.isOri) {
                     if constexpr (KV_LAYOUT_T == SAS_LAYOUT::PA_ND) {
                         uint32_t curS2Offset = info.s2Idx * constInfo.s2BaseSize + info.s2StartPoint + kL1 * K_L0_SPLIT_SIZE;
-                        while (copyFinishRowCnt < kL0Size) {
-                            copyRowCnt = constInfo.paOriBlockSize - curS2Offset % constInfo.paOriBlockSize;
-                            if (copyFinishRowCnt + copyRowCnt > kL0Size) {
-                                copyRowCnt = kL0Size - copyFinishRowCnt;
-                            }
+                        if (constInfo.hasOriSparseIndices) {
                             Position startPos;
                             startPos.bIdx = info.bIdx;
                             startPos.n2Idx = info.n2Idx;
-                            startPos.s2Idx = curS2Offset;
+                            startPos.s2Idx = 0;
                             startPos.dIdx = nL1 * N_SPLIT_SIZE;  // mm1 右矩阵 bn2s2d, d为k轴不切; mm2 右矩阵, s2为k轴, d轴切分
                             PAShape shape;
                             shape.blockSize = constInfo.paOriBlockSize;
@@ -698,14 +722,41 @@ __aicore__ inline void SWACubeBlock<SAST>::ComputeMm2(const RunInfo &info, const
                             shape.kvStride = constInfo.oriKvStride;
                             shape.actHeadDim = nL1Size;
                             shape.maxblockNumPerBatch = constInfo.oriMaxBlockNumPerBatch;
-                            shape.copyRowNum = copyRowCnt;
+                            shape.copyRowNum = kL0Size;
                             shape.copyRowNumAlign = kL0SizeAlign;
-                            subvTensor = bL1Tensor[(kL1 - kOffset) * K_L0_SPLIT_SIZE * N_SPLIT_SIZE + copyFinishRowCnt * 16];
-                            DataCopyPA<KV_T>(subvTensor, oriKvGm, oriBlockTableGm, shape, startPos);
+                            subvTensor = bL1Tensor[(kL1 - kOffset) * K_L0_SPLIT_SIZE * N_SPLIT_SIZE];
+                            uint64_t sparseIndexBaseOffset =
+                                (info.qTokenOffset * constInfo.kvHeadNum + info.n2Idx) * constInfo.oriSparseIndexWidth;
+                            uint32_t sparseIndexStart = info.s2Idx * constInfo.s2BaseSize + kL1 * K_L0_SPLIT_SIZE;
+                            DataCopyPABySlots<KV_T>(subvTensor, oriKvGm, oriSparseIndicesGm, shape, startPos,
+                                                    sparseIndexBaseOffset, sparseIndexStart);
+                        } else {
+                            while (copyFinishRowCnt < kL0Size) {
+                                copyRowCnt = constInfo.paOriBlockSize - curS2Offset % constInfo.paOriBlockSize;
+                                if (copyFinishRowCnt + copyRowCnt > kL0Size) {
+                                    copyRowCnt = kL0Size - copyFinishRowCnt;
+                                }
+                                Position startPos;
+                                startPos.bIdx = info.bIdx;
+                                startPos.n2Idx = info.n2Idx;
+                                startPos.s2Idx = curS2Offset;
+                                startPos.dIdx = nL1 * N_SPLIT_SIZE;  // mm1 右矩阵 bn2s2d, d为k轴不切; mm2 右矩阵, s2为k轴, d轴切分
+                                PAShape shape;
+                                shape.blockSize = constInfo.paOriBlockSize;
+                                shape.headNum = constInfo.kvHeadNum;
+                                shape.headDim = constInfo.headDim;
+                                shape.kvStride = constInfo.oriKvStride;
+                                shape.actHeadDim = nL1Size;
+                                shape.maxblockNumPerBatch = constInfo.oriMaxBlockNumPerBatch;
+                                shape.copyRowNum = copyRowCnt;
+                                shape.copyRowNumAlign = kL0SizeAlign;
+                                subvTensor = bL1Tensor[(kL1 - kOffset) * K_L0_SPLIT_SIZE * N_SPLIT_SIZE + copyFinishRowCnt * 16];
+                                DataCopyPA<KV_T>(subvTensor, oriKvGm, oriBlockTableGm, shape, startPos);
 
-                            // 更新循环变量
-                            copyFinishRowCnt += copyRowCnt;
-                            curS2Offset += copyRowCnt;
+                                // 更新循环变量
+                                copyFinishRowCnt += copyRowCnt;
+                                curS2Offset += copyRowCnt;
+                            }
                         }
                     } else if constexpr (KV_LAYOUT_T == SAS_LAYOUT::BSND) {
                         subvTensor = bL1Tensor[(kL1 - kOffset) * K_L0_SPLIT_SIZE * N_SPLIT_SIZE];

--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_swa_kernel.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_swa_kernel.h
@@ -80,8 +80,8 @@ public:
 
     __aicore__ inline SparseAttnSharedkvSwa(){};
     __aicore__ inline void Init(__gm__ uint8_t *query, __gm__ uint8_t *oriKV, __gm__ uint8_t *cmpKV,
-                                __gm__ uint8_t *cmpSparseIndices, __gm__ uint8_t *oriBlockTable,
-                                __gm__ uint8_t *cmpBlockTable, __gm__ uint8_t *cuSeqlensQ,
+                                __gm__ uint8_t *oriSparseIndices, __gm__ uint8_t *cmpSparseIndices,
+                                __gm__ uint8_t *oriBlockTable, __gm__ uint8_t *cmpBlockTable, __gm__ uint8_t *cuSeqlensQ,
                                 __gm__ uint8_t* cuSeqlensKV, __gm__ uint8_t *cuSeqlensCmpKV, __gm__ uint8_t *seqUsedQ,
                                 __gm__ uint8_t *seqUsedKV, __gm__ uint8_t *sinks, __gm__ uint8_t *metadata,
                                 __gm__ uint8_t *attentionOut, __gm__ uint8_t *softmaxLse, __gm__ uint8_t *workspace,
@@ -149,6 +149,7 @@ private:
 
     GlobalTensor<int32_t> oriBlockTableGm;
     GlobalTensor<int32_t> cmpBlockTableGm;
+    GlobalTensor<int32_t> oriSparseIndicesGm;
 
     GlobalTensor<int32_t> actualSeqLengthsQGm;
     GlobalTensor<int32_t> actualSeqLengthsKVGm;
@@ -181,6 +182,7 @@ private:
                                       RunInfo &info);
     __aicore__ inline int32_t GetActualSeqLenQ(uint32_t bIdx);
     __aicore__ inline int32_t GetActualSeqLenKV(uint32_t bIdx);
+    __aicore__ inline uint32_t GetOriSparseActualSeqLen();
     __aicore__ inline void GetBN2Idx(uint32_t bN2Idx, uint32_t &bIdx, uint32_t &n2Idx);
     // ================================Mm1==============================================
     __aicore__ inline void ComputeMm1(const RunInfo &info);
@@ -213,6 +215,8 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::InitTilingData()
     constInfo.oriKvStride = tilingData->baseParams.oriKvStride;
     constInfo.oriWinLeft = tilingData->baseParams.oriWinLeft;
     constInfo.oriWinRight = tilingData->baseParams.oriWinRight;
+    constInfo.hasOriSparseIndices = tilingData->baseParams.hasOriSparseIndices;
+    constInfo.oriSparseIndexWidth = tilingData->baseParams.oriSparseIndexWidth;
     constInfo.returnSoftmaxLse = tilingData->baseParams.returnSoftmaxLse;
 
     constInfo.actualLenDimsQ = tilingData->baseParams.actualLenDimsQ;
@@ -365,6 +369,26 @@ __aicore__ inline int32_t SparseAttnSharedkvSwa<SAST>::GetActualSeqLenKV(uint32_
 }
 
 template <typename SAST>
+__aicore__ inline uint32_t SparseAttnSharedkvSwa<SAST>::GetOriSparseActualSeqLen()
+{
+    if (!constInfo.hasOriSparseIndices || constInfo.oriSparseIndexWidth == 0 || tempLoopInfo.actOriS2Size <= 0) {
+        return 0;
+    }
+    uint64_t qTokenOffset = tempLoopInfo.actualSeqQPrefixSum + tempLoopInfo.s1StartIdx;
+    uint64_t sparseIndexBaseOffset =
+        (qTokenOffset * constInfo.kvHeadNum + tempLoopInfo.n2Idx) * constInfo.oriSparseIndexWidth;
+    uint32_t maxSparseLen = Min(static_cast<uint64_t>(constInfo.oriSparseIndexWidth),
+                                static_cast<uint64_t>(tempLoopInfo.actOriS2Size));
+    uint32_t sparseLen = 0;
+    for (; sparseLen < maxSparseLen; ++sparseLen) {
+        if (oriSparseIndicesGm.GetValue(sparseIndexBaseOffset + sparseLen) < 0) {
+            break;
+        }
+    }
+    return sparseLen;
+}
+
+template <typename SAST>
 __aicore__ inline void SparseAttnSharedkvSwa<SAST>::GetSparseActualSeqLen()
 {
     // 行无效通过ori部分判断, ori部分如果有行无效那么ori和cmp都有
@@ -384,7 +408,8 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::GetSparseActualSeqLen()
 template <typename SAST>
 __aicore__ inline void SparseAttnSharedkvSwa<SAST>::UpdateInnerLoopCond()
 {
-    if ((tempLoopInfo.actCmpS2Size == 0 && tempLoopInfo.actOriS2Size == 0) || (tempLoopInfo.actS1Size == 0)) {
+    bool hasOriWindow = tempLoopInfo.oriMaskRight >= tempLoopInfo.oriMaskLeft;
+    if ((tempLoopInfo.actCmpS2Size == 0 && !hasOriWindow) || (tempLoopInfo.actS1Size == 0)) {
         tempLoopInfo.curActSeqLenIsZero = true;
         return;
     }
@@ -396,8 +421,9 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::UpdateInnerLoopCond()
 
 template <typename SAST>
 __aicore__ inline void SparseAttnSharedkvSwa<SAST>::Init(
-    __gm__ uint8_t *query, __gm__ uint8_t *oriKV, __gm__ uint8_t *cmpKV, __gm__ uint8_t *cmpSparseIndices,
-    __gm__ uint8_t *oriBlockTable, __gm__ uint8_t *cmpBlockTable, __gm__ uint8_t *cuSeqlensQ,
+    __gm__ uint8_t *query, __gm__ uint8_t *oriKV, __gm__ uint8_t *cmpKV, __gm__ uint8_t *oriSparseIndices,
+    __gm__ uint8_t *cmpSparseIndices, __gm__ uint8_t *oriBlockTable, __gm__ uint8_t *cmpBlockTable,
+    __gm__ uint8_t *cuSeqlensQ,
     __gm__ uint8_t *cuSeqlensKV, __gm__ uint8_t *cuSeqlensCmpKV, __gm__ uint8_t *seqUsedQ,
     __gm__ uint8_t *seqUsedKV, __gm__ uint8_t *sinks, __gm__ uint8_t *metadata, __gm__ uint8_t *attentionOut, __gm__ uint8_t *softmaxLse,
     __gm__ uint8_t *workspace, const SparseAttnSharedkvTilingData *__restrict tiling, __gm__ uint8_t *gmTiling,
@@ -452,6 +478,9 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::Init(
 
     if constexpr (PAGE_ATTENTION) {
         oriBlockTableGm.SetGlobalBuffer((__gm__ int32_t *)oriBlockTable);
+        if (constInfo.hasOriSparseIndices) {
+            oriSparseIndicesGm.SetGlobalBuffer((__gm__ int32_t *)oriSparseIndices);
+        }
         if (constInfo.templateMode == CFA_TEMPLATE) {
             cmpBlockTableGm.SetGlobalBuffer((__gm__ int32_t *)cmpBlockTable);
         }
@@ -489,7 +518,7 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::Init(
         cubeBlock.InitParams(constInfo);
         cubeBlock.InitMm1GlobalTensor(queryGm, oriKvGm, cmpKvGm, mm1ResGm);
         cubeBlock.InitMm2GlobalTensor(vec1ResGm, mm2ResGm, attentionOutGm);
-        cubeBlock.InitPageAttentionInfo(oriKvGm, oriBlockTableGm, cmpBlockTableGm);
+        cubeBlock.InitPageAttentionInfo(oriKvGm, oriBlockTableGm, cmpBlockTableGm, oriSparseIndicesGm);
     }
     // 要在InitParams之后执行
     if (pipe != nullptr) {
@@ -562,6 +591,11 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::CalcParams(uint32_t loop, ui
     info.tensorBOffset = tensorBCoreOffset;
     info.tensorCmpBOffset = tensorCmpBCoreOffset;
     info.attenOutOffset = tensorACoreOffset;
+    if constexpr (LAYOUT_T == SAS_LAYOUT::TND) {
+        info.qTokenOffset = tempLoopInfo.actualSeqQPrefixSum + info.s1Idx;
+    } else {
+        info.qTokenOffset = info.bIdx * constInfo.qSeqSize + info.s1Idx;
+    }
 
     if (s2LoopIdx < tempLoopInfo.oriLoopTimes) {
         // S2首次循环只能在ori_kv
@@ -573,7 +607,7 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::CalcParams(uint32_t loop, ui
         } else {
             info.actualSingleProcessSInnerSize = constInfo.s2BaseSize;
         }
-        info.s2StartPoint = tempLoopInfo.oriMaskLeft;
+        info.s2StartPoint = constInfo.hasOriSparseIndices ? 0 : tempLoopInfo.oriMaskLeft;
         info.cmpS2IdLimit = 0;
     } else {
         if (constInfo.templateMode == CFA_TEMPLATE) {
@@ -686,11 +720,17 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::ProcessBalance()
             tempLoopInfo.s1EndIdx =
                 Min((tempLoopInfo.s1StartIdx + constInfo.mBaseSize / constInfo.gSize - 1), tempLoopInfo.actS1Size - 1);
             // 此处均为闭区间
-            tempLoopInfo.oriMaskRight = tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size +
-                                        static_cast<int32_t>(tempLoopInfo.s1EndIdx) + constInfo.oriWinRight;
-            tempLoopInfo.oriMaskLeft = Max(tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size +
-                                               static_cast<int32_t>(tempLoopInfo.s1EndIdx) - constInfo.oriWinLeft,
-                                           0);
+            if (constInfo.hasOriSparseIndices) {
+                uint32_t sparseOriS2Size = GetOriSparseActualSeqLen();
+                tempLoopInfo.oriMaskLeft = 0;
+                tempLoopInfo.oriMaskRight = sparseOriS2Size == 0 ? -1 : static_cast<int32_t>(sparseOriS2Size - 1U);
+            } else {
+                tempLoopInfo.oriMaskRight = tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size +
+                                            static_cast<int32_t>(tempLoopInfo.s1EndIdx) + constInfo.oriWinRight;
+                tempLoopInfo.oriMaskLeft = Max(tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size +
+                                                   static_cast<int32_t>(tempLoopInfo.s1EndIdx) - constInfo.oriWinLeft,
+                                               0);
+            }
             if (constInfo.templateMode == CFA_TEMPLATE) {
                 tempLoopInfo.cmpMaskRight = tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size;
             }
@@ -707,7 +747,9 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::ProcessBalance()
                     continue;
                 }
             } else {
-                oriSplitNum = CeilDiv(tempLoopInfo.oriMaskRight - tempLoopInfo.oriMaskLeft + 1, constInfo.s2BaseSize);
+                uint32_t oriS2Size = (tempLoopInfo.oriMaskRight >= tempLoopInfo.oriMaskLeft) ?
+                    static_cast<uint32_t>(tempLoopInfo.oriMaskRight - tempLoopInfo.oriMaskLeft + 1) : 0U;
+                oriSplitNum = CeilDiv(oriS2Size, constInfo.s2BaseSize);
                 s2SplitNum = oriSplitNum;
                 if (constInfo.templateMode == CFA_TEMPLATE) {
                     uint32_t cmpSplitNum = CeilDiv(tempLoopInfo.actCmpS2Size, constInfo.s2BaseSize);
@@ -718,6 +760,9 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::ProcessBalance()
             tempLoopInfo.s2LoopTimes = s2SplitNum;
             tempLoopInfo.oriLoopTimes = oriSplitNum;
             uint32_t s2LoopEnd = (isEnd && constInfo.s2End != 0) ? constInfo.s2End : tempLoopInfo.s2LoopTimes;
+            if (constInfo.hasOriSparseIndices) {
+                s2LoopEnd = Min(s2LoopEnd, s2SplitNum);
+            }
             tempLoopInfo.s2LoopTimes = s2LoopEnd;
             // 分核修改后需要打开
             // 当前s2是否被切，决定了输出是否要写到attenOut上

--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/sparse_attn_sharedkv.cpp
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/sparse_attn_sharedkv.cpp
@@ -29,7 +29,7 @@ using namespace SASKernel;
         templateClass<SASType<__VA_ARGS__>> op;                                                                        \
         GET_TILING_DATA_WITH_STRUCT(tilingdataClass, tiling_data_in, tiling);                                          \
         const tilingdataClass *__restrict tiling_data = &tiling_data_in;                                               \
-        op.Init(query, oriKV, cmpKV, cmpSparseIndices, oriBlockTable, cmpBlockTable, cuSeqlensQ,                       \
+        op.Init(query, oriKV, cmpKV, oriSparseIndices, cmpSparseIndices, oriBlockTable, cmpBlockTable, cuSeqlensQ,     \
                 cuSeqlensOriKv, cuSeqlensCmpKv, seqUsedQ, seqUsedKV,                                                   \
                 sinks, metadata, attentionOut, softmaxLse, user, tiling_data, tiling, &tPipe);                                     \
         op.Process();                                                                                                  \

--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/sparse_attn_sharedkv_common.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/sparse_attn_sharedkv_common.h
@@ -170,6 +170,34 @@ __aicore__ inline void DataCopyPA(LocalTensor<T> &dstTensor,  //l1
     }
 }
 
+template <typename T>
+__aicore__ inline void DataCopyPABySlots(LocalTensor<T> &dstTensor,  // l1
+                                         GlobalTensor<T> &srcTensor, // gm
+                                         GlobalTensor<int32_t> &sparseIndicesGm,
+                                         const PAShape &shape,
+                                         const Position &startPos,
+                                         uint64_t sparseIndexBaseOffset,
+                                         uint32_t sparseIndexStart)
+{
+    uint32_t blockElementCnt = 32 / sizeof(T);
+    for (uint32_t row = 0; row < shape.copyRowNum; ++row) {
+        int32_t slotId = sparseIndicesGm.GetValue(sparseIndexBaseOffset + sparseIndexStart + row);
+        if (slotId < 0) {
+            slotId = 0;
+        }
+        uint64_t blockId = static_cast<uint64_t>(slotId) / shape.blockSize;
+        uint64_t blockOffset = static_cast<uint64_t>(slotId) % shape.blockSize;
+        uint64_t offset = blockId * shape.kvStride;
+        offset += static_cast<uint64_t>(startPos.n2Idx * shape.headDim * shape.blockSize) +
+                  blockOffset * shape.headDim + startPos.dIdx;
+
+        LocalTensor<T> tmpDstTensor = dstTensor[row * blockElementCnt];
+        GlobalTensor<T> tmpSrcTensor = srcTensor[offset];
+        DataCopyGmNDToL1<T>(tmpDstTensor, tmpSrcTensor, 1, shape.copyRowNumAlign,
+                            shape.actHeadDim, shape.headDim);
+    }
+}
+
 struct RunInfo {
     uint32_t loop = 0;
     uint32_t cmpLoop = 0; // 用于判断取 用于merge的4块GM 中的哪一块
@@ -187,6 +215,7 @@ struct RunInfo {
     uint64_t tensorAOffset = 0;
     uint64_t tensorBOffset = 0;
     uint64_t attenOutOffset = 0;
+    uint64_t qTokenOffset = 0;
     uint64_t attenMaskOffset = 0;
     uint64_t topKBaseOffset = 0;
     uint32_t actualSingleProcessSInnerSize = 0;
@@ -302,6 +331,8 @@ struct ConstInfo {
     // sparse attr
     int64_t sparseBlockSize = 0;
     uint32_t sparseBlockCount = 0;
+    bool hasOriSparseIndices = false;
+    uint32_t oriSparseIndexWidth = 0;
 
     // cmp attr
     int64_t cmpRatio = 0;

--- a/csrc/attention/sparse_attn_sharedkv_metadata/README.md
+++ b/csrc/attention/sparse_attn_sharedkv_metadata/README.md
@@ -146,7 +146,7 @@
     <tr>
       <td>ori_win_left</td>
       <td>可选属性</td>
-      <td>表示q和ori_kv计算中q对过去token计算的数量，仅支持默认值127。</td>
+      <td>表示q和ori_kv计算中q对过去token计算的数量，支持非负值，默认值为127。</td>
       <td>INT32</td>
       <td>-</td>
     </tr>

--- a/csrc/attention/sparse_attn_sharedkv_metadata/op_kernel_aicpu/sparse_attn_sharedkv_metadata_aicpu.cpp
+++ b/csrc/attention/sparse_attn_sharedkv_metadata/op_kernel_aicpu/sparse_attn_sharedkv_metadata_aicpu.cpp
@@ -116,8 +116,8 @@ bool SparseAttnSharedkvMetadataCpuKernel::CheckSingleParam()
         return false;
     }
     // ori_win_left 校验
-    if (winLeft_ != 127) {
-        KERNEL_LOG_ERROR("ori_win_left should only be 127, but got %ld", winLeft_);
+    if (winLeft_ < 0) {
+        KERNEL_LOG_ERROR("ori_win_left should be non-negative, but got %ld", winLeft_);
         return false;
     }
     // layout_q 校验

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_attn_sharedkv_sparse_indices.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_attn_sharedkv_sparse_indices.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+from vllm_ascend.utils import enable_custom_op
+
+enable_custom_op()
+
+HEAD_DIM = 512
+NUM_Q_HEADS = 4
+NUM_KV_HEADS = 1
+SPARSE_INDEX_WIDTH = 128
+ORI_WIN_LEFT = 127
+ORI_WIN_RIGHT = 0
+
+
+def _reference_attention(
+    query: torch.Tensor,
+    kv_rows: list[torch.Tensor],
+    sinks: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    output = torch.empty_like(query)
+    for token_idx, token_kv in enumerate(kv_rows):
+        key = token_kv.expand(-1, NUM_Q_HEADS, -1).float()
+        scores = torch.einsum("hd,khd->hk", query[token_idx].float(), key) * softmax_scale
+        sink = sinks.float().view(NUM_Q_HEADS, 1)
+        scores_max = torch.maximum(scores.max(dim=-1, keepdim=True).values, sink)
+        exp_scores = torch.exp(scores - scores_max)
+        probs = exp_scores / (exp_scores.sum(dim=-1, keepdim=True) + torch.exp(sink - scores_max))
+        output[token_idx] = torch.einsum("hk,khd->hd", probs, key).to(query.dtype)
+    return output
+
+
+def _make_metadata(
+    query: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    seqused_kv: torch.Tensor,
+    ori_win_left: int,
+    ori_win_right: int,
+) -> torch.Tensor:
+    return torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
+        num_heads_q=NUM_Q_HEADS,
+        num_heads_kv=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        cu_seqlens_q=cu_seqlens_q,
+        seqused_kv=seqused_kv,
+        batch_size=1,
+        max_seqlen_q=query.shape[0],
+        max_seqlen_kv=int(seqused_kv.max().item()),
+        cmp_ratio=4,
+        ori_mask_mode=4,
+        cmp_mask_mode=3,
+        ori_win_left=ori_win_left,
+        ori_win_right=ori_win_right,
+        layout_q="TND",
+        layout_kv="PA_ND",
+        has_ori_kv=True,
+        has_cmp_kv=False,
+        device=str(query.device),
+    )
+
+
+def _run_operator(
+    query: torch.Tensor,
+    kv_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    seqused_kv: torch.Tensor,
+    sinks: torch.Tensor,
+    ori_sparse_indices: torch.Tensor | None,
+    ori_win_left: int = ORI_WIN_LEFT,
+    ori_win_right: int = ORI_WIN_RIGHT,
+) -> torch.Tensor:
+    metadata = _make_metadata(query, cu_seqlens_q, seqused_kv, ori_win_left, ori_win_right)
+    return torch.ops._C_ascend.npu_sparse_attn_sharedkv(
+        query,
+        ori_kv=kv_cache,
+        ori_sparse_indices=ori_sparse_indices,
+        ori_block_table=block_table,
+        cu_seqlens_q=cu_seqlens_q,
+        seqused_kv=seqused_kv,
+        sinks=sinks,
+        metadata=metadata,
+        softmax_scale=1.0 / math.sqrt(HEAD_DIM),
+        cmp_ratio=4,
+        ori_mask_mode=4,
+        cmp_mask_mode=3,
+        ori_win_left=ori_win_left,
+        ori_win_right=ori_win_right,
+        layout_q="TND",
+        layout_kv="PA_ND",
+    )[0]
+
+
+@torch.inference_mode()
+def test_sparse_original_indices_match_explicit_slot_reference():
+    torch.manual_seed(20260712)
+    device = torch.device("npu:0")
+    dtype = torch.bfloat16
+    cache_block_size = 16
+    query_tokens = 2
+    actual_kv_len = 64
+
+    query = (torch.randn(query_tokens, NUM_Q_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    kv_cache = (torch.randn(6, cache_block_size, NUM_KV_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    block_table = torch.tensor([[4, 1, 3, 0]], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, query_tokens], dtype=torch.int32, device=device)
+    seqused_kv = torch.tensor([actual_kv_len], dtype=torch.int32, device=device)
+    sinks = torch.linspace(-0.2, 0.2, NUM_Q_HEADS, dtype=torch.float32, device=device)
+
+    slot_rows = (
+        (1, 19, 34, 17, 80, 47, 65),
+        (63, 2, 48, 33, 79, 16),
+    )
+    sparse_indices = torch.full(
+        (query_tokens, NUM_KV_HEADS, SPARSE_INDEX_WIDTH),
+        -1,
+        dtype=torch.int32,
+        device=device,
+    )
+    for token_idx, slots in enumerate(slot_rows):
+        sparse_indices[token_idx, 0, : len(slots)] = torch.tensor(slots, dtype=torch.int32, device=device)
+
+    actual = _run_operator(
+        query,
+        kv_cache,
+        block_table,
+        cu_seqlens_q,
+        seqused_kv,
+        sinks,
+        sparse_indices,
+    )
+    flat_cache = kv_cache.reshape(-1, NUM_KV_HEADS, HEAD_DIM)
+    kv_rows = [flat_cache[torch.tensor(slots, dtype=torch.long, device=device)] for slots in slot_rows]
+    expected = _reference_attention(query, kv_rows, sinks, 1.0 / math.sqrt(HEAD_DIM))
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), atol=3e-2, rtol=3e-2)
+
+
+@torch.inference_mode()
+def test_sparse_original_indices_support_multiple_inner_loops():
+    torch.manual_seed(20260714)
+    device = torch.device("npu:0")
+    dtype = torch.bfloat16
+    cache_block_size = 16
+    actual_kv_len = 256
+    index_width = 256
+    visible_count = 140
+
+    query = (torch.randn(1, NUM_Q_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    kv_cache = (torch.randn(20, cache_block_size, NUM_KV_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    block_table = torch.arange(16, dtype=torch.int32, device=device).reshape(1, -1)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    seqused_kv = torch.tensor([actual_kv_len], dtype=torch.int32, device=device)
+    sinks = torch.zeros(NUM_Q_HEADS, dtype=torch.float32, device=device)
+    slots = (torch.arange(visible_count, dtype=torch.int32, device=device) * 37) % (
+        kv_cache.shape[0] * cache_block_size
+    )
+    sparse_indices = torch.full(
+        (1, NUM_KV_HEADS, index_width),
+        -1,
+        dtype=torch.int32,
+        device=device,
+    )
+    sparse_indices[0, 0, :visible_count] = slots
+
+    actual = _run_operator(
+        query,
+        kv_cache,
+        block_table,
+        cu_seqlens_q,
+        seqused_kv,
+        sinks,
+        sparse_indices,
+        ori_win_left=index_width - 1,
+    )
+    flat_cache = kv_cache.reshape(-1, NUM_KV_HEADS, HEAD_DIM)
+    expected = _reference_attention(
+        query,
+        [flat_cache[slots.long()]],
+        sinks,
+        1.0 / math.sqrt(HEAD_DIM),
+    )
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), atol=3e-2, rtol=3e-2)
+
+
+@torch.inference_mode()
+def test_sparse_original_indices_absent_preserves_swa_behavior():
+    torch.manual_seed(20260713)
+    device = torch.device("npu:0")
+    dtype = torch.bfloat16
+    cache_block_size = 16
+    actual_kv_len = 32
+
+    query = (torch.randn(1, NUM_Q_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    kv_cache = (torch.randn(4, cache_block_size, NUM_KV_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    block_table = torch.tensor([[2, 0]], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    seqused_kv = torch.tensor([actual_kv_len], dtype=torch.int32, device=device)
+    sinks = torch.zeros(NUM_Q_HEADS, dtype=torch.float32, device=device)
+
+    actual = _run_operator(query, kv_cache, block_table, cu_seqlens_q, seqused_kv, sinks, None)
+    logical_positions = torch.arange(actual_kv_len, device=device)
+    physical_blocks = block_table[0, logical_positions // cache_block_size].long()
+    block_offsets = logical_positions % cache_block_size
+    kv_rows = [kv_cache[physical_blocks, block_offsets]]
+    expected = _reference_attention(query, kv_rows, sinks, 1.0 / math.sqrt(HEAD_DIM))
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), atol=3e-2, rtol=3e-2)
+
+
+@torch.inference_mode()
+def test_sparse_original_indices_reject_unaligned_width():
+    device = torch.device("npu:0")
+    query = torch.zeros(1, NUM_Q_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    kv_cache = torch.zeros(1, 16, NUM_KV_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    block_table = torch.zeros(1, 1, dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    seqused_kv = torch.tensor([1], dtype=torch.int32, device=device)
+    sinks = torch.zeros(NUM_Q_HEADS, dtype=torch.float32, device=device)
+    sparse_indices = torch.zeros(1, NUM_KV_HEADS, 64, dtype=torch.int32, device=device)
+
+    with pytest.raises(RuntimeError):
+        _run_operator(query, kv_cache, block_table, cu_seqlens_q, seqused_kv, sinks, sparse_indices)

--- a/tests/ut/spec_decode/test_dspark_dsa_metadata.py
+++ b/tests/ut/spec_decode/test_dspark_dsa_metadata.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+import torch
+
+import vllm_ascend.attention.context_parallel.dsa_cp as dsa_cp
+import vllm_ascend.attention.dsa_v1 as dsa_v1
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.dsa_window import (
+    build_dspark_swa_indices,
+    build_dspark_swa_metadata_for_drafting,
+)
+
+
+def _vllm_config(window_size: int = 7, query_block_size: int = 5) -> SimpleNamespace:
+    draft_hf_config = SimpleNamespace(dspark_block_size=query_block_size)
+    return SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(sliding_window=window_size, num_attention_heads=8),
+            get_head_size=lambda: 16,
+        ),
+        speculative_config=SimpleNamespace(
+            num_speculative_tokens=query_block_size,
+            draft_model_config=SimpleNamespace(hf_config=draft_hf_config),
+        ),
+    )
+
+
+def _metadata(*, causal: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        query_start_loc=torch.tensor([0, 5], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 5], dtype=torch.int32),
+        seq_lens=torch.tensor([15], dtype=torch.int32),
+        _seq_lens_cpu=torch.tensor([15], dtype=torch.int32),
+        seq_lens_cpu=None,
+        positions=torch.arange(10, 15, dtype=torch.int32),
+        block_table_tensor=torch.tensor([[10, 11, 12]], dtype=torch.int32),
+        num_reqs=1,
+        num_input_tokens=5,
+        num_actual_tokens=5,
+        causal=causal,
+        attn_state=AscendAttentionState.SpecDecoding,
+    )
+
+
+def _physical_slots(block_table: torch.Tensor, req_idx: int, start: int, end: int) -> torch.Tensor:
+    return torch.tensor(
+        [int(block_table[req_idx, position // 64]) * 64 + position % 64 for position in range(start, end)],
+        dtype=torch.int32,
+    )
+
+
+def test_noncausal_draft_uses_explicit_full_block_visibility():
+    common_metadata = _metadata()
+    win_left, win_right, indices, lens = build_dspark_swa_metadata_for_drafting(
+        _vllm_config(),
+        common_metadata,
+        torch.arange(5, dtype=torch.int32),
+        cache_block_size=64,
+    )
+
+    assert (win_left, win_right) == (11, 0)
+    assert indices is not None and lens is not None
+    assert indices.shape == (5, 1, 128)
+    torch.testing.assert_close(lens, torch.full((5,), 12, dtype=torch.int32))
+    expected = _physical_slots(common_metadata.block_table_tensor, 0, 3, 15)
+    for row in range(5):
+        torch.testing.assert_close(indices[row, 0, :12], expected)
+        assert torch.all(indices[row, 0, 12:] == -1)
+
+
+def test_causal_draft_preserves_standard_window():
+    win_left, win_right, indices, lens = build_dspark_swa_metadata_for_drafting(
+        _vllm_config(),
+        _metadata(causal=True),
+        torch.arange(5, dtype=torch.int32),
+        cache_block_size=64,
+    )
+
+    assert (win_left, win_right) == (6, 0)
+    assert indices is None
+    assert lens is None
+
+
+def test_sparse_indices_cover_token_mapping_zero_length_and_padding():
+    block_table = torch.tensor([[10], [-1], [20]], dtype=torch.int32)
+    indices, lens = build_dspark_swa_indices(
+        block_table=block_table,
+        slot_mapping=torch.tensor([0, 1, 2, 3, -1], dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 2, 2, 4], dtype=torch.int32),
+        seq_lens=torch.tensor([12, 0, 22], dtype=torch.int32),
+        query_block_size=2,
+        window_size=4,
+        cache_block_size=64,
+        num_query_tokens=5,
+        token_to_req_indices=torch.tensor([0, 2, 0, 2, -1], dtype=torch.int32),
+    )
+
+    torch.testing.assert_close(lens, torch.tensor([6, 6, 6, 6, 0], dtype=torch.int32))
+    expected_req0 = _physical_slots(block_table, 0, 6, 12)
+    expected_req2 = _physical_slots(block_table, 2, 16, 22)
+    for row in (0, 2):
+        torch.testing.assert_close(indices[row, 0, :6], expected_req0)
+    for row in (1, 3):
+        torch.testing.assert_close(indices[row, 0, :6], expected_req2)
+    assert torch.all(indices[4] == -1)
+
+
+def test_sparse_indices_map_request_boundary_to_next_request():
+    block_table = torch.tensor([[10], [20]], dtype=torch.int32)
+    indices, lens = build_dspark_swa_indices(
+        block_table=block_table,
+        slot_mapping=torch.arange(4, dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 2, 4], dtype=torch.int32),
+        seq_lens=torch.tensor([12, 22], dtype=torch.int32),
+        query_block_size=2,
+        window_size=4,
+        cache_block_size=64,
+        num_query_tokens=4,
+    )
+
+    torch.testing.assert_close(lens, torch.full((4,), 6, dtype=torch.int32))
+    expected_req0 = _physical_slots(block_table, 0, 6, 12)
+    expected_req1 = _physical_slots(block_table, 1, 16, 22)
+    for row in (0, 1):
+        torch.testing.assert_close(indices[row, 0, :6], expected_req0)
+    for row in (2, 3):
+        torch.testing.assert_close(indices[row, 0, :6], expected_req1)
+
+
+def test_sparse_indices_reject_incomplete_token_mapping():
+    with pytest.raises(ValueError, match="token_to_req_indices"):
+        build_dspark_swa_indices(
+            block_table=torch.tensor([[0]], dtype=torch.int32),
+            slot_mapping=None,
+            query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+            seq_lens=torch.tensor([2], dtype=torch.int32),
+            query_block_size=2,
+            window_size=4,
+            cache_block_size=64,
+            num_query_tokens=2,
+            token_to_req_indices=torch.tensor([0], dtype=torch.int32),
+        )
+
+
+def _patch_metadata_ops(monkeypatch, module, captured):
+    monkeypatch.setattr(
+        module,
+        "get_cos_and_sin_dsa",
+        lambda positions, use_cache=False, draft_index=None: (
+            torch.zeros(positions.numel(), 1),
+            torch.zeros(positions.numel(), 1),
+        ),
+    )
+
+    def metadata_op(**kwargs):
+        captured.update(kwargs)
+        return torch.ones(1024, dtype=torch.int32)
+
+    monkeypatch.setattr(module.DeviceOperator, "get_dsa_sparse_attn_metadata_op", lambda: metadata_op)
+    monkeypatch.setattr(module.DeviceOperator, "get_dsa_sparse_attn_metadata_kwargs", lambda _device: {})
+
+
+def test_dsa_builder_propagates_shared_metadata(monkeypatch):
+    captured: dict[str, Any] = {}
+    _patch_metadata_ops(monkeypatch, dsa_v1, captured)
+    monkeypatch.setattr(dsa_v1, "get_tensor_model_parallel_world_size", lambda: 1)
+    config = _vllm_config()
+    builder = SimpleNamespace(
+        model_config=config.model_config,
+        vllm_config=config,
+        spec_slot_mapping=[torch.arange(5, dtype=torch.int32)],
+        spec_sas_metadata=[torch.zeros(1024, dtype=torch.int32)],
+        block_size=64,
+        seqused_q=torch.empty(0, dtype=torch.int32),
+        cu_seqlens_ori_kv=torch.empty(0, dtype=torch.int32),
+        cu_seqlens_cmp_kv=torch.empty(0, dtype=torch.int32),
+    )
+
+    result = dsa_v1.AscendDSAMetadataBuilder.build_decode_metadata_for_drafting(
+        cast(Any, builder),
+        draft_index=1,
+        common_attn_metadata=_metadata(),
+        num_decodes=1,
+        num_decode_tokens=5,
+    )
+
+    assert captured["ori_win_left"] == result.ori_win_left == 11
+    assert captured["ori_win_right"] == result.ori_win_right == 0
+    assert result.dspark_swa_indices is not None
+    torch.testing.assert_close(result.dspark_swa_lens, torch.full((5,), 12, dtype=torch.int32))
+
+
+def test_dsa_cp_builder_propagates_shared_metadata(monkeypatch):
+    captured: dict[str, Any] = {}
+    _patch_metadata_ops(monkeypatch, dsa_cp, captured)
+    monkeypatch.setattr(
+        dsa_cp.DeviceOperator,
+        "get_dsa_decode_cu_seqlens_ori_kv",
+        lambda *args, **kwargs: torch.tensor([0, 5], dtype=torch.int32),
+    )
+    monkeypatch.setattr(
+        dsa_cp.DeviceOperator,
+        "get_dsa_decode_cu_seqlens_cmp_kv",
+        lambda *args, **kwargs: torch.empty(0, dtype=torch.int32),
+    )
+    config = _vllm_config()
+    common_metadata = _metadata()
+
+    def local_metadata(**kwargs):
+        num_reqs = kwargs["num_reqs"]
+        return (
+            3,
+            6,
+            3,
+            6,
+            torch.tensor([0, 2], dtype=torch.int32),
+            kwargs["seq_lens"][:num_reqs],
+            torch.zeros(3, 1),
+            torch.zeros(3, 1),
+        )
+
+    builder = SimpleNamespace(
+        model_config=config.model_config,
+        vllm_config=config,
+        seq_lens=common_metadata.seq_lens,
+        seq_lens_cpu=common_metadata._seq_lens_cpu,
+        num_actual_tokens=5,
+        spec_slot_mapping=[torch.arange(5, dtype=torch.int32)],
+        block_table=common_metadata.block_table_tensor,
+        block_size=64,
+        spec_local_query_start_loc=[torch.zeros(2, dtype=torch.int32)],
+        spec_local_seq_lens=[torch.zeros(1, dtype=torch.int32)],
+        seqused_q=torch.empty(0, dtype=torch.int32),
+        cu_seqlens_ori_kv=torch.empty(0, dtype=torch.int32),
+        cu_seqlens_cmp_kv=torch.empty(0, dtype=torch.int32),
+        _zero_i32=torch.tensor([0], dtype=torch.int32),
+        _build_local_token_metadata=local_metadata,
+    )
+
+    result = dsa_cp.AscendDSACPMetadataBuilder.build_req_metadata_for_drafting(
+        cast(Any, builder),
+        draft_index=1,
+        common_attn_metadata=common_metadata,
+        input_positions=common_metadata.positions.long(),
+        num_input_tokens=5,
+    )
+
+    assert captured["ori_win_left"] == result.ori_win_left == 11
+    assert captured["ori_win_right"] == result.ori_win_right == 0
+    assert result.dspark_swa_indices is not None
+    assert result.dspark_swa_indices.shape == (3, 1, 128)
+    torch.testing.assert_close(result.dspark_swa_lens, torch.tensor([12, 12, 0], dtype=torch.int32))
+    assert torch.all(result.dspark_swa_indices[-1] == -1)

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -13,6 +13,7 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 
 from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.dsa_window import build_dspark_swa_metadata_for_drafting
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
@@ -98,6 +99,10 @@ class AscendDSAReqMetadata:
     qli_metadata: torch.Tensor = None
     cu_cmp_seqlen_list: torch.Tensor = None
     attn_mask: torch.Tensor | None = None
+    ori_win_left: int | None = None
+    ori_win_right: int | None = None
+    dspark_swa_indices: torch.Tensor | None = None
+    dspark_swa_lens: torch.Tensor | None = None
 
 
 @dataclass
@@ -469,6 +474,21 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
         assert self.spec_slot_mapping is not None
         slot_mapping = self.spec_slot_mapping[draft_index - 1][: self.num_actual_tokens]
+        ori_win_left, ori_win_right, dspark_swa_indices, dspark_swa_lens = build_dspark_swa_metadata_for_drafting(
+            self.vllm_config,
+            common_attn_metadata,
+            self.spec_slot_mapping[draft_index - 1],
+            self.block_size,
+        )
+        if dspark_swa_indices is not None:
+            if dspark_swa_lens is None:
+                raise ValueError("DSpark SWA indices require matching lengths")
+            pad_tokens = num_tokens_pad - dspark_swa_indices.shape[0]
+            if pad_tokens > 0:
+                dspark_swa_indices = F.pad(dspark_swa_indices, (0, 0, 0, 0, 0, pad_tokens), value=-1)
+                dspark_swa_lens = F.pad(dspark_swa_lens, (0, pad_tokens), value=0)
+            dspark_swa_indices = dspark_swa_indices[local_start:local_end_with_pad]
+            dspark_swa_lens = dspark_swa_lens[local_start:local_end_with_pad]
 
         num_heads = self.model_config.hf_config.num_attention_heads
         metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
@@ -504,8 +524,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             batch_size=num_reqs,
             cmp_ratio=1,
             ori_mask_mode=4,
-            ori_win_left=self.model_config.hf_config.sliding_window - 1,
-            ori_win_right=0,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
             layout_q="TND",
             layout_kv="PA_ND",
             has_ori_kv=True,
@@ -537,6 +557,10 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             sas_metadata=sas_metadata,
             qli_metadata=None,
             cu_cmp_seqlen_list=None,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
+            dspark_swa_indices=dspark_swa_indices,
+            dspark_swa_lens=dspark_swa_lens,
         )
 
     def _num_compressor_metadata_rows(
@@ -1431,6 +1455,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 extra_attn_kwargs, cu_seqlens_ori_kv=local_seq_lengths_query
             )
 
+        ori_win_left = self.window_size - 1 if req_metadata.ori_win_left is None else req_metadata.ori_win_left
         common_attn_kwargs = dict(
             cu_seqlens_q=local_seq_lengths_query,
             seqused_kv=local_seq_lengths_key,
@@ -1438,14 +1463,15 @@ class AscendDSACPImpl(DSAAttentionImpl):
             softmax_scale=self.softmax_scale,
             cmp_ratio=max(self.compress_ratio, 1),
             ori_mask_mode=4,
-            ori_win_left=self.window_size - 1,
-            ori_win_right=0,
+            ori_win_left=ori_win_left,
+            ori_win_right=req_metadata.ori_win_right or 0,
             layout_q="TND",
             layout_kv="PA_ND",
             **extra_attn_kwargs,
         )
 
         if self.compress_ratio <= 1:
+            common_attn_kwargs["ori_sparse_indices"] = req_metadata.dspark_swa_indices
             attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -18,6 +18,7 @@ from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.dsa_window import build_dspark_swa_metadata_for_drafting
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
@@ -251,6 +252,10 @@ class AscendDSAPrefillMetadata:
     qli_metadata: torch.Tensor = None
     cu_c4_cmp_seqlen_list: torch.Tensor = None
     cu_c128_cmp_seqlen_list: torch.Tensor = None
+    ori_win_left: int | None = None
+    ori_win_right: int | None = None
+    dspark_swa_indices: torch.Tensor | None = None
+    dspark_swa_lens: torch.Tensor | None = None
 
 
 @dataclass
@@ -281,6 +286,10 @@ class AscendDSADecodeMetadata:
     num_reqs_actual: int | None = None
     sas_metadata: torch.Tensor = None
     qli_metadata: torch.Tensor = None
+    ori_win_left: int | None = None
+    ori_win_right: int | None = None
+    dspark_swa_indices: torch.Tensor | None = None
+    dspark_swa_lens: torch.Tensor | None = None
 
 
 @dataclass
@@ -1173,6 +1182,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         reqs_start = kwargs.get("reqs_start")
         tokens_start = kwargs.get("tokens_start")
         num_prefill_tokens = kwargs.get("num_prefill_tokens")
+        if reqs_start is None or tokens_start is None or num_prefill_tokens is None:
+            raise ValueError("DSA draft prefill metadata requires request and token ranges")
         query_start_loc = common_attn_metadata.query_start_loc
         prefill_query_start_loc = query_start_loc[reqs_start:] - query_start_loc[reqs_start]
         seq_lens_q = prefill_query_start_loc[1:] - prefill_query_start_loc[:-1]
@@ -1183,7 +1194,20 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         prefill_input_positions = input_positions[tokens_start:]
         cos, sin = get_cos_and_sin_dsa(prefill_input_positions)
 
-        prefill_slot_mapping = self.spec_slot_mapping[draft_index - 1][tokens_start:num_prefill_tokens]  # type: ignore[index]
+        prefill_slot_mapping = self.spec_slot_mapping[  # type: ignore[index]
+            draft_index - 1
+        ][tokens_start : tokens_start + num_prefill_tokens]
+        ori_win_left, ori_win_right, dspark_swa_indices, dspark_swa_lens = build_dspark_swa_metadata_for_drafting(
+            self.vllm_config,
+            common_attn_metadata,
+            self.spec_slot_mapping[draft_index - 1],  # type: ignore[index]
+            self.block_size,
+        )
+        if dspark_swa_indices is not None:
+            if dspark_swa_lens is None:
+                raise ValueError("DSpark SWA indices require matching lengths")
+            dspark_swa_indices = dspark_swa_indices[tokens_start : tokens_start + num_prefill_tokens]
+            dspark_swa_lens = dspark_swa_lens[tokens_start : tokens_start + num_prefill_tokens]
         block_table = common_attn_metadata.block_table_tensor[: common_attn_metadata.num_reqs]
 
         metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
@@ -1203,8 +1227,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             batch_size=len(seq_lens),
             cmp_ratio=1,
             ori_mask_mode=4,
-            ori_win_left=self.model_config.hf_config.sliding_window - 1,
-            ori_win_right=0,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
             layout_q="TND",
             layout_kv="PA_ND",
             has_ori_kv=True,
@@ -1230,6 +1254,10 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             qli_metadata=None,
             cu_c4_cmp_seqlen_list=None,
             cu_c128_cmp_seqlen_list=None,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
+            dspark_swa_indices=dspark_swa_indices,
+            dspark_swa_lens=dspark_swa_lens,
         )
 
     def build_decode_metadata_for_drafting(
@@ -1264,6 +1292,17 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=True, draft_index=draft_index)
 
         slot_mapping = self.spec_slot_mapping[draft_index - 1][:num_decode_tokens_typed]  # type: ignore[index]
+        ori_win_left, ori_win_right, dspark_swa_indices, dspark_swa_lens = build_dspark_swa_metadata_for_drafting(
+            self.vllm_config,
+            common_attn_metadata,
+            slot_mapping,
+            self.block_size,
+        )
+        if dspark_swa_indices is not None:
+            if dspark_swa_lens is None:
+                raise ValueError("DSpark SWA indices require matching lengths")
+            dspark_swa_indices = dspark_swa_indices[:num_decode_tokens_typed]
+            dspark_swa_lens = dspark_swa_lens[:num_decode_tokens_typed]
         block_table = common_attn_metadata.block_table_tensor
 
         metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
@@ -1285,8 +1324,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             cmp_ratio=1,
             ori_mask_mode=4,
             cmp_mask_mode=3,
-            ori_win_left=self.model_config.hf_config.sliding_window - 1,
-            ori_win_right=0,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
             layout_q="TND",
             layout_kv="PA_ND",
             has_ori_kv=True,
@@ -1315,6 +1354,10 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             start_pos=None,
             sas_metadata=decode_sas_metadata,
             qli_metadata=None,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
+            dspark_swa_indices=dspark_swa_indices,
+            dspark_swa_lens=dspark_swa_lens,
         )
         return decode_metadata
 
@@ -1691,6 +1734,8 @@ class AscendDSAImpl(DSAAttentionImpl):
         decode_hidden_states = hidden_states[:decode_tokens]
 
         o_proj_input = torch.empty(o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device)
+        if actual_tokens < o_proj_input_shape[0]:
+            o_proj_input[actual_tokens:].zero_()
         assert kv_cache is not None, "kv_cache tensor tuple must be provided."
         if has_prefill:
             assert attn_metadata[0].prefill is not None
@@ -1937,9 +1982,15 @@ class AscendDSAImpl(DSAAttentionImpl):
         DeviceOperator.add_dsa_sparse_attn_extra_kwargs(extra_attn_kwargs, cu_seqlens_ori_kv=actual_seq_lengths_query)
 
         if self.compress_ratio <= 1:
+            ori_win_left = (
+                self.window_size - 1
+                if common_prefill_metadata.ori_win_left is None
+                else common_prefill_metadata.ori_win_left
+            )
             return attn_op(
                 q,
                 ori_kv=swa_kv_cache,
+                ori_sparse_indices=common_prefill_metadata.dspark_swa_indices,
                 ori_block_table=swa_prefill_metadata.block_table,
                 cu_seqlens_q=actual_seq_lengths_query,
                 seqused_kv=actual_seq_lengths_key,
@@ -1948,8 +1999,8 @@ class AscendDSAImpl(DSAAttentionImpl):
                 softmax_scale=self.softmax_scale,
                 cmp_ratio=max(self.compress_ratio, 1),
                 ori_mask_mode=4,
-                ori_win_left=self.window_size - 1,
-                ori_win_right=0,
+                ori_win_left=ori_win_left,
+                ori_win_right=common_prefill_metadata.ori_win_right or 0,
                 layout_q="TND",
                 layout_kv="PA_ND",
                 **extra_attn_kwargs,
@@ -2369,9 +2420,13 @@ class AscendDSAImpl(DSAAttentionImpl):
         extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
 
         if self.compress_ratio <= 1:
+            ori_win_left = (
+                self.window_size - 1 if swa_decode_metadata.ori_win_left is None else swa_decode_metadata.ori_win_left
+            )
             attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,
+                ori_sparse_indices=swa_decode_metadata.dspark_swa_indices,
                 ori_block_table=swa_decode_metadata.block_table,
                 cu_seqlens_q=actual_seq_lengths_query,
                 seqused_kv=actual_seq_lengths_key,
@@ -2380,8 +2435,8 @@ class AscendDSAImpl(DSAAttentionImpl):
                 softmax_scale=self.softmax_scale,
                 cmp_ratio=max(self.compress_ratio, 1),
                 ori_mask_mode=4,
-                ori_win_left=self.window_size - 1,
-                ori_win_right=0,
+                ori_win_left=ori_win_left,
+                ori_win_right=swa_decode_metadata.ori_win_right or 0,
                 layout_q="TND",
                 layout_kv="PA_ND",
                 **extra_attn_kwargs,

--- a/vllm_ascend/attention/dsa_window.py
+++ b/vllm_ascend/attention/dsa_window.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+import torch
+
+
+def _get_dspark_draft_hf_config(vllm_config: Any) -> Any | None:
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    draft_model_config = getattr(speculative_config, "draft_model_config", None)
+    return getattr(draft_model_config, "hf_config", None)
+
+
+def get_dspark_query_block_size(vllm_config: Any) -> int:
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    num_speculative_tokens = getattr(speculative_config, "num_speculative_tokens", None)
+    if num_speculative_tokens:
+        return int(num_speculative_tokens)
+
+    draft_hf_config = _get_dspark_draft_hf_config(vllm_config)
+    return int(getattr(draft_hf_config, "dspark_block_size", 0) or 0)
+
+
+def is_dspark_noncausal_draft(vllm_config: Any, common_attn_metadata: Any) -> bool:
+    if getattr(common_attn_metadata, "causal", True):
+        return False
+
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    use_dspark = getattr(speculative_config, "use_dspark", None)
+    if callable(use_dspark):
+        return bool(use_dspark())
+
+    draft_hf_config = _get_dspark_draft_hf_config(vllm_config)
+    return bool(getattr(draft_hf_config, "dspark_block_size", 0))
+
+
+def get_draft_swa_window(vllm_config: Any) -> tuple[int, int]:
+    window_size = int(vllm_config.model_config.hf_config.sliding_window)
+    return window_size - 1, 0
+
+
+def get_dspark_sparse_sas_window(vllm_config: Any) -> tuple[int, int]:
+    window_size = int(vllm_config.model_config.hf_config.sliding_window)
+    query_block_size = get_dspark_query_block_size(vllm_config)
+    return window_size + query_block_size - 1, 0
+
+
+def _valid_slot_rows(slot_mapping: torch.Tensor) -> torch.Tensor:
+    if slot_mapping.ndim == 1:
+        return slot_mapping >= 0
+    return torch.all(slot_mapping >= 0, dim=-1)
+
+
+def _aligned_index_width(window_size: int, query_block_size: int) -> int:
+    visible_upper_bound = window_size + query_block_size
+    return ((visible_upper_bound + 127) // 128) * 128
+
+
+def build_dspark_swa_indices(
+    block_table: torch.Tensor,
+    slot_mapping: torch.Tensor | None,
+    query_start_loc: torch.Tensor,
+    seq_lens: torch.Tensor,
+    query_block_size: int,
+    window_size: int,
+    cache_block_size: int,
+    num_query_tokens: int,
+    token_to_req_indices: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build physical slots for history-window plus full draft-block visibility."""
+    index_width = _aligned_index_width(window_size, query_block_size)
+    device = block_table.device
+    indices = torch.full((num_query_tokens, 1, index_width), -1, dtype=torch.int32, device=device)
+    lens = torch.zeros(num_query_tokens, dtype=torch.int32, device=device)
+    if num_query_tokens == 0:
+        return indices, lens
+    if slot_mapping is not None and slot_mapping.shape[0] < num_query_tokens:
+        raise ValueError("DSpark SWA slot_mapping must cover every query token")
+    if token_to_req_indices is not None and token_to_req_indices.numel() < num_query_tokens:
+        raise ValueError("DSpark SWA token_to_req_indices must cover every query token")
+
+    num_reqs = min(max(query_start_loc.numel() - 1, 0), block_table.shape[0], seq_lens.numel())
+    if num_reqs == 0 or block_table.shape[1] == 0:
+        return indices, lens
+
+    query_start_loc = query_start_loc[: num_reqs + 1].to(device=device, dtype=torch.long)
+    query_lens = query_start_loc[1:] - query_start_loc[:-1]
+    seq_lens = seq_lens[:num_reqs].to(device=device, dtype=torch.long)
+    visible_starts = torch.clamp(seq_lens - query_lens - window_size, min=0)
+    visible_lens = torch.clamp(seq_lens - visible_starts, min=0, max=index_width)
+
+    offsets = torch.arange(index_width, dtype=torch.long, device=device)
+    visible_positions = visible_starts[:, None] + offsets[None, :]
+    visible_mask = offsets[None, :] < visible_lens[:, None]
+    logical_blocks = torch.div(visible_positions, cache_block_size, rounding_mode="floor")
+    logical_blocks = logical_blocks.clamp(max=block_table.shape[1] - 1)
+    physical_blocks = block_table[:num_reqs].to(device=device, dtype=torch.long).gather(1, logical_blocks)
+    physical_slots = physical_blocks * cache_block_size + visible_positions % cache_block_size
+    physical_slots.masked_fill_(~visible_mask, -1)
+
+    if token_to_req_indices is None:
+        token_rows = torch.arange(num_query_tokens, dtype=torch.long, device=device)
+        token_to_req = torch.bucketize(token_rows, query_start_loc[1:], right=True)
+    else:
+        token_to_req = token_to_req_indices[:num_query_tokens].to(device=device, dtype=torch.long)
+
+    valid_rows = (token_to_req >= 0) & (token_to_req < num_reqs)
+    if slot_mapping is not None:
+        valid_rows &= _valid_slot_rows(slot_mapping[:num_query_tokens].to(device=device))
+    row_requests = token_to_req.clamp(0, num_reqs - 1)
+    indices[:, 0] = physical_slots.index_select(0, row_requests).to(torch.int32)
+    lens.copy_(visible_lens.index_select(0, row_requests).to(torch.int32))
+    indices.masked_fill_(~valid_rows[:, None, None], -1)
+    lens.masked_fill_(~valid_rows, 0)
+    return indices, lens
+
+
+def build_dspark_swa_metadata_for_drafting(
+    vllm_config: Any,
+    common_attn_metadata: Any,
+    slot_mapping: torch.Tensor | None,
+    cache_block_size: int,
+) -> tuple[int, int, torch.Tensor | None, torch.Tensor | None]:
+    if not is_dspark_noncausal_draft(vllm_config, common_attn_metadata):
+        ori_win_left, ori_win_right = get_draft_swa_window(vllm_config)
+        return ori_win_left, ori_win_right, None, None
+
+    num_reqs = int(getattr(common_attn_metadata, "num_reqs", 0) or 0)
+    num_query_tokens = int(getattr(common_attn_metadata, "num_input_tokens", 0) or 0)
+    if num_query_tokens == 0:
+        num_query_tokens = int(getattr(common_attn_metadata, "num_actual_tokens", 0) or 0)
+    query_block_size = get_dspark_query_block_size(vllm_config)
+    if query_block_size <= 0:
+        raise ValueError("DSpark noncausal drafting requires a positive query block size")
+    block_table = getattr(common_attn_metadata, "block_table_tensor", None)
+    if block_table is None:
+        raise ValueError("DSpark noncausal drafting requires a paged SWA block table")
+    indices, lens = build_dspark_swa_indices(
+        block_table[:num_reqs],
+        slot_mapping,
+        common_attn_metadata.query_start_loc[: num_reqs + 1],
+        common_attn_metadata.seq_lens[:num_reqs],
+        query_block_size,
+        int(vllm_config.model_config.hf_config.sliding_window),
+        int(cache_block_size),
+        num_query_tokens,
+        getattr(common_attn_metadata, "token_to_req_indices", None),
+    )
+    ori_win_left, ori_win_right = get_dspark_sparse_sas_window(vllm_config)
+    return ori_win_left, ori_win_right, indices, lens


### PR DESCRIPTION
### What this PR does / why we need it?

This is PR 1/4 of the DeepSeek V4 DSpark split defined in #11126. It extracts the attention contract from the end-to-end prototype #11196 and is based on `vllm-ascend/main@6556ad5af`.

This PR:

- adds optional `ori_sparse_indices` support to `SparseAttnSharedkv` and its tiling contract;
- uses explicit original-KV physical slots for the SWA path;
- builds noncausal DeepSeek V4 DSpark DSA and DSA-CP metadata;
- preserves existing causal and non-DSpark behavior when sparse indices are absent.

Incremental size: about `+1047/-83`, including owned tests.

### Does this PR introduce _any_ user-facing change?

No direct API change. This adds the attention/backend contract required by later DeepSeek V4 DSpark PRs.

### How was this patch tested?

Focused CPU/unit checks:

```bash
python -m pytest -q tests/ut/spec_decode/test_dspark_dsa_metadata.py
```

Result: `7 passed`.

Also passed:

- mypy for all PR-owned Python files;
- `ruff check` and `ruff format --check` for the changed Python files;
- `git diff --check upstream/main...HEAD`.

On the cumulative PR 1-4 stack, the native vLLM-Ascend custom-op extension built successfully, `166 passed, 1 skipped`, mypy passed for all 32 changed Python files, and `pre-commit run --all-files` passed.

Real-weight eager/ACLGraph accuracy, acceptance-rate/acceptance-length, and matched performance validation remain cumulative PR 1-4 gates. They are intentionally tracked on the complete stack rather than used as a readiness blocker for this standalone attention-contract PR.

References:

- RFC and four-PR plan: #11126
- Original end-to-end prototype: #11196
- Generic Qwen/GLM DSpark foundation: #11765

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
