### PR TITLE
[Feature][Model] Add DeepSeek V4 DSpark draft model and loading hooks

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -108,7 +108,9 @@
   base: attention_common
   source_file_dependencies:
     - vllm_ascend/attention/dsa_v1.py
+    - vllm_ascend/attention/dsa_window.py
   tests:
+    - tests/ut/spec_decode/test_dspark_dsa_metadata.py
     - tests/e2e/pull_request/four_card/test_deepseek_v4.py
 
 - name: attention_cp
@@ -839,7 +841,6 @@ partition:
   a3_x2: 3
   a3_x4: 3
   cpu_x0: 1
-
 
 
 

--- a/csrc/attention/sparse_attn_sharedkv/README.md
+++ b/csrc/attention/sparse_attn_sharedkv/README.md
@@ -30,7 +30,7 @@
 | q                     | 输入      | 对应公式中的$Q$。                                                     | BFLOAT16、FLOAT16  | ND |
 | ori\_kv               | 可选输入  | 对应公式中的$\tilde{K}和\tilde{V}$的一部分，为原始不经压缩的KV。          | BFLOAT16、FLOAT16 | ND |
 | cmp\_kv               | 可选输入  | 对应公式中的$\tilde{K}和\tilde{V}$的一部分，为经过压缩的KV。             | BFLOAT16、FLOAT16  | ND |
-| ori\_sparse\_indices  | 可选输入  | 代表离散取oriKvCache的索引。                                           | INT32              | ND |
+| ori\_sparse\_indices  | 可选输入  | 代表离散读取oriKvCache的物理slot索引，负数表示有效索引结束。             | INT32              | ND |
 | cmp\_sparse\_indices  | 可选输入  | 代表离散取cmpKvCache的索引。                                           | INT32              | ND |
 | ori\_block\_table     | 可选输入  | 表示PageAttention中oriKvCache存储使用的block映射表。                   | INT32               | ND |
 | cmp\_block\_table     | 可选输入  | 表示PageAttention中cmpKvCache存储使用的block映射表。                   | INT32               | ND |
@@ -57,17 +57,17 @@
 
 - 该接口支持推理场景下使用。
 - 该接口支持aclgraph模式。
-- 该接口当前支持三种计算场景：场景一，仅传入`ori_kv`时为Sliding Window Attention计算；场景二，传入`ori_kv`及`cmp_kv`时为Sliding Window Attention + Compressed Attention计算；场景三，传入`ori_kv`、`cmp_kv`及`cmp_sparse_indices`时为Sliding Window Attention + Sparse Compressed Attention计算。
+- 该接口当前支持四种计算场景：场景一，仅传入`ori_kv`时为Sliding Window Attention计算；场景二，传入`ori_kv`和`ori_sparse_indices`时按显式物理slot执行Sparse Sliding Window Attention计算；场景三，传入`ori_kv`及`cmp_kv`时为Sliding Window Attention + Compressed Attention计算；场景四，传入`ori_kv`、`cmp_kv`及`cmp_sparse_indices`时为Sliding Window Attention + Sparse Compressed Attention计算。
 
 - 当`layout_q`为TND时，功能使用限制如下：
     - `q`的shape需要为[T1,N1,D]，其中N1仅支持64。
-    - `ori_sparse_indices`的shape需要为[Q\_T, KV\_N, K1]，其中K1为对`ori_kv`一次离散选取的token数，K1仅支持512。
+    - `ori_sparse_indices`仅支持SWA模板和`PA_ND` KV layout，shape需要为[Q\_T, KV\_N, K1]，其中K1为对`ori_kv`一次离散选取的token数。K1必须为正数、128对齐且不超过2048；每行遇到第一个负数时停止读取。`ori_win_left`需要为metadata提供不小于有效索引数量的非负调度窗口，`ori_win_right`仅支持0。
     - `cmp_sparse_indices`的shape需要为[Q\_T, KV\_N, K2]，其中K2为对`cmp_kv`一次离散选取的token数，K2仅支持512。
     - `cu_seqlens_q`必须传入，输入维度为B+1，大小为参数中每个元素的值表示当前batch与之前所有batch的token数总和，即前缀和，因此后一个元素的值必须>=前一个元素的值。
 
 - 当`layout_q`为BSND时，功能使用限制如下：
     - `q`的shape需要为[B, Q\_S,N1,D]，其中N1仅支持64。
-    - `ori_sparse_indices`的shape需要为[B, Q\_S, KV\_N, K1]，其中K1为对`ori_kv`一次离散选取的token数，K1仅支持512。
+    - 当前不支持传入`ori_sparse_indices`。
     - `cmp_sparse_indices`的shape需要为[B, Q\_S, KV\_N, K2]，其中K2为对`cmp_kv`一次离散选取的token数，K2仅支持512。
 
 - PageAttention场景下，功能使用限制如下：
@@ -78,13 +78,45 @@
 - 目前暂不支持返回`softmax_lse`，`return_softmax_lse`仅支持输入False，返回值`softmax_lse`为无效值。
 - ori_mask_mode及cmp_mask_mode所表示的mask模式的详细介绍见[sparse_mode参数说明](../../../docs/zh/context/sparse_mode参数说明.md)。
 - 目前暂不支持指定`q`中参与运算的token数，因此设置`seqused_q`无效。
-- 目前暂不支持对`ori_kv`进行稀疏计算，因此设置`ori_sparse_indices`无效。
+- `ori_sparse_indices`中的非负值是`ori_kv`首两维展平后的物理slot编号，不再经过`ori_block_table`映射。
 - 目前所有输入不支持传入空tensor。
 - `q`、`ori_kv`、`cmp_kv`数据排布格式支持从多种维度解读，B（Batch）表示输入样本批量大小、S（Seq-Length）表示输入样本序列长度、H（Hidden-Size）表示隐藏层的大小、N（Head-Num）表示多头数、D（Head-Dim）表示hidden层最小的单元尺寸，且满足D=H/N、T表示所有Batch输入样本序列长度的累加和。
 - Q\_S和S1表示q shape中的S，S2表示ori_kv shape中的S，S3表示cmp_kv shape中的S；Q\_N和N1表示num\_q\_heads，KV\_N和N2表示num\_ori_kv\_heads和num\_cmp_kv\_heads；Q\_T和T1表示q shape中的输入样本序列长度的累加和。
 
 - 当`layout_kv`为BSND时，功能使用限制如下：
     - `ori_kv`和`cmp_kv`的layout都必须为BSND，ori_kv的shape为[B, S2, N2,D]，cmp_kv的shape为[B, S3, N2,D]。
+
+显式original-KV slot模式调用示例（`metadata`的构造方式与下方单算子示例相同）：
+
+```python
+ori_sparse_indices = torch.full(
+    (q.shape[0], ori_kv.shape[2], 128),
+    -1,
+    dtype=torch.int32,
+    device=q.device,
+)
+slots = torch.tensor([1, 19, 34, 17], dtype=torch.int32, device=q.device)
+ori_sparse_indices[:, 0, : slots.numel()] = slots
+
+attention_out, _ = torch.ops.custom.npu_sparse_attn_sharedkv(
+    q,
+    ori_kv=ori_kv,
+    ori_sparse_indices=ori_sparse_indices,
+    ori_block_table=ori_block_table,
+    cu_seqlens_q=cu_seqlens_q,
+    seqused_kv=seqused_kv,
+    sinks=sinks,
+    metadata=metadata,
+    softmax_scale=softmax_scale,
+    cmp_ratio=4,
+    ori_mask_mode=4,
+    cmp_mask_mode=3,
+    ori_win_left=127,
+    ori_win_right=0,
+    layout_q="TND",
+    layout_kv="PA_ND",
+)
+```
 
 ## Atlas A3 推理系列产品 调用说明
 

--- a/csrc/attention/sparse_attn_sharedkv/op_host/sparse_attn_sharedkv_tiling.cpp
+++ b/csrc/attention/sparse_attn_sharedkv/op_host/sparse_attn_sharedkv_tiling.cpp
@@ -171,9 +171,6 @@ ge::graphStatus SASInfoParser::CheckRequiredParaExistence() const
 
 ge::graphStatus SASInfoParser::CheckUnrequiredParaExistence() const
 {
-    OP_CHECK_IF(opParamInfo_.oriSparseIndices.tensor != nullptr || opParamInfo_.oriSparseIndices.desc != nullptr,
-                OP_LOGE(opName_, "Currently, ori_sparse_indices must be a nullptr"),
-                return ge::GRAPH_FAILED);
     return ge::GRAPH_SUCCESS;
 }
 
@@ -404,6 +401,17 @@ uint32_t SASInfoParser::GetAxisNum(const gert::Shape &shape, const SASAxis &axis
     return HasAxis(axis, layout, shape) ? shape.GetDim(GetAxisIdx(axis, layout)) : invalidDimValue_;
 }
 
+uint32_t SASInfoParser::GetSparseIndexWidth(const gert::Shape &shape, const SASLayout &layout) const
+{
+    if (layout == SASLayout::TND && shape.GetDimNum() == DIM_NUM_THREE) {
+        return shape.GetDim(DIM_NUM_THREE - 1);
+    }
+    if (layout == SASLayout::BSND && shape.GetDimNum() == DIM_NUM_FOUR) {
+        return shape.GetDim(DIM_NUM_FOUR - 1);
+    }
+    return 0;
+}
+
 void SASInfoParser::SetSASShape()
 {
     qShape_ = opParamInfo_.q.shape->GetStorageShape();
@@ -414,6 +422,11 @@ void SASInfoParser::SetSASShape()
     }
     if (opParamInfo_.cmpKv.tensor != nullptr) {
         cmpKvShape_ = opParamInfo_.cmpKv.tensor->GetStorageShape();
+    }
+    if (opParamInfo_.oriSparseIndices.tensor != nullptr) {
+        oriSparseIndicesShape_ = opParamInfo_.oriSparseIndices.tensor->GetStorageShape();
+        hasOriSparseIndices_ = true;
+        oriSparseIndexWidth_ = GetSparseIndexWidth(oriSparseIndicesShape_, oriSparseIndicesLayout_);
     }
     if (perfMode_ == SASTemplateMode::SCFA_TEMPLATE_MODE)
     {
@@ -788,6 +801,8 @@ void SASInfoParser::GenerateInfo(SASTilingInfo &sasInfo)
             opParamInfo_.oriKv.tensor->GetStorageShape().GetDim(0) : 0;
     }
     sasInfo.sparseBlockSize = 1;
+    sasInfo.hasOriSparseIndices = hasOriSparseIndices_;
+    sasInfo.oriSparseIndexWidth = oriSparseIndexWidth_;
     sasInfo.oriBlockSize = oriBlockSize_;
     sasInfo.cmpBlockSize = cmpBlockSize_;
     sasInfo.blockTypeSize = sizeof(float);
@@ -893,6 +908,8 @@ void SASTilingCheck::Init()
     oriWinRight_ = sasInfo_.oriWinRight;
     kvLayout_ = sasInfo_.kvLayout;
     outLayout_ = sasInfo_.outLayout;
+    hasOriSparseIndices_ = sasInfo_.hasOriSparseIndices;
+    oriSparseIndexWidth_ = sasInfo_.oriSparseIndexWidth;
 }
 
 void SASTilingCheck::LogErrorDtypeSupport(const std::vector<ge::DataType> &expectDtypeList,
@@ -1064,6 +1081,52 @@ ge::graphStatus SASTilingCheck::CheckSingleParaKvHeadNums() const
     return ge::GRAPH_SUCCESS;
 }
 
+ge::graphStatus SASTilingCheck::CheckSingleParaOriSparseIndices() const
+{
+    if (!hasOriSparseIndices_) {
+        return ge::GRAPH_SUCCESS;
+    }
+    OP_CHECK_IF(sasInfo_.perfMode != SASTemplateMode::SWA_TEMPLATE_MODE,
+                OP_LOGE(opName_, "ori_sparse_indices is only supported with SWA template mode."),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(kvLayout_ != SASLayout::PA_ND,
+                OP_LOGE(opName_, "ori_sparse_indices is only supported with PA_ND kv layout."),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(qLayout_ != SASLayout::TND,
+                OP_LOGE(opName_, "ori_sparse_indices currently supports TND query layout only."),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(opParamInfo_.oriSparseIndices.tensor->GetStorageShape().GetShapeSize() == 0,
+                OP_LOGE(opName_, "ori_sparse_indices cannot be empty tensor."),
+                return ge::GRAPH_FAILED);
+
+    const std::vector<size_t> oriSparseIndicesDimNumList = {DIM_NUM_THREE};
+    if (ge::GRAPH_SUCCESS != CheckDtypeSupport(opParamInfo_.oriSparseIndices.desc, ORI_SPARSE_INDICES) ||
+        ge::GRAPH_SUCCESS != CheckLayoutSupport(oriSparseIndicesLayout_, ORI_SPARSE_INDICES) ||
+        ge::GRAPH_SUCCESS != CheckDimNumSupport(&opParamInfo_.oriSparseIndices.tensor->GetShape(),
+                                                oriSparseIndicesDimNumList, ORI_SPARSE_INDICES) ||
+        ge::GRAPH_SUCCESS != CheckDimNumInLayoutSupport(oriSparseIndicesLayout_,
+                                                        &opParamInfo_.oriSparseIndices.tensor->GetShape(),
+                                                        ORI_SPARSE_INDICES)) {
+        return ge::GRAPH_FAILED;
+    }
+
+    const gert::Shape &shape = opParamInfo_.oriSparseIndices.tensor->GetStorageShape();
+    OP_CHECK_IF(shape.GetDim(0) != s1Size_,
+                OP_LOGE(opName_, "ori_sparse_indices T(%ld) should equal query T(%u).", shape.GetDim(0), s1Size_),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(shape.GetDim(1) != n2Size_,
+                OP_LOGE(opName_, "ori_sparse_indices N2(%ld) should equal kv head num(%u).",
+                         shape.GetDim(1), n2Size_),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(oriSparseIndexWidth_ == 0 || oriSparseIndexWidth_ > SPARSE_LIMIT ||
+                    (oriSparseIndexWidth_ % 128U) != 0U,
+                OP_LOGE(opName_,
+                        "ori_sparse_indices K should be a positive 128-aligned value not greater than %u, got %u.",
+                        SPARSE_LIMIT, oriSparseIndexWidth_),
+                return ge::GRAPH_FAILED);
+    return ge::GRAPH_SUCCESS;
+}
+
 ge::graphStatus SASTilingCheck::CheckSingleParaCmpSparseIndices() const
 {
     if (sasInfo_.perfMode == optiling::SASTemplateMode::SCFA_TEMPLATE_MODE){
@@ -1230,6 +1293,7 @@ ge::graphStatus SASTilingCheck::CheckSinglePara() const
         ge::GRAPH_SUCCESS != CheckSingleParaCmpKv() ||
         ge::GRAPH_SUCCESS != CheckSingleParaNumHeads() ||
         ge::GRAPH_SUCCESS != CheckSingleParaKvHeadNums() ||
+        ge::GRAPH_SUCCESS != CheckSingleParaOriSparseIndices() ||
         ge::GRAPH_SUCCESS != CheckSingleParaCmpSparseIndices() ||
         ge::GRAPH_SUCCESS != CheckSingleParaOriBlockTable() ||
         ge::GRAPH_SUCCESS != CheckSingleParaCmpBlockTable() ||
@@ -1362,12 +1426,21 @@ ge::graphStatus SASTilingCheck::CheckFeatureShape() const
     OP_CHECK_IF(*opParamInfo_.cmpMaskMode != 3,
                 OP_LOGE(opName_, "cmp_mask_mode should be 3, but got %d", *opParamInfo_.cmpMaskMode),
                 return ge::GRAPH_FAILED);
-    OP_CHECK_IF(oriWinLeft_ != 127,
-                OP_LOGE(opName_, "ori_win_left should be 127, but got %d", oriWinLeft_),
-                return ge::GRAPH_FAILED);
-    OP_CHECK_IF(oriWinRight_ != 0,
-                OP_LOGE(opName_, "ori_win_right should be 0, but got %d", oriWinRight_),
-                return ge::GRAPH_FAILED);
+    if (hasOriSparseIndices_) {
+        OP_CHECK_IF(oriWinLeft_ < 0,
+                    OP_LOGE(opName_, "ori_win_left should be non-negative, but got %ld", oriWinLeft_),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(oriWinRight_ != 0,
+                    OP_LOGE(opName_, "ori_win_right should be 0, but got %ld", oriWinRight_),
+                    return ge::GRAPH_FAILED);
+    } else {
+        OP_CHECK_IF(oriWinLeft_ != 127,
+                    OP_LOGE(opName_, "ori_win_left should be 127, but got %ld", oriWinLeft_),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(oriWinRight_ != 0,
+                    OP_LOGE(opName_, "ori_win_right should be 0, but got %ld", oriWinRight_),
+                    return ge::GRAPH_FAILED);
+    }
     return ge::GRAPH_SUCCESS;
 }
 
@@ -1604,6 +1677,8 @@ ge::graphStatus SparseAttnSharedkvTiling::DoOpTiling(SASTilingInfo *tilingInfo)
     tilingData_.baseParams.set_oriWinLeft(tilingInfo->oriWinLeft);
     tilingData_.baseParams.set_oriWinRight(tilingInfo->oriWinRight);
     tilingData_.baseParams.set_sparseBlockSize(tilingInfo->sparseBlockSize);
+    tilingData_.baseParams.set_hasOriSparseIndices(tilingInfo->hasOriSparseIndices);
+    tilingData_.baseParams.set_oriSparseIndexWidth(tilingInfo->oriSparseIndexWidth);
     tilingData_.baseParams.set_returnSoftmaxLse(tilingInfo->returnSoftmaxLse);
 
     tilingData_.cmpParams.set_cmpMaxBlockNumPerBatch(tilingInfo->cmpMaxBlockNumPerBatch);

--- a/csrc/attention/sparse_attn_sharedkv/op_host/sparse_attn_sharedkv_tiling.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_host/sparse_attn_sharedkv_tiling.h
@@ -148,6 +148,8 @@ TILING_DATA_FIELD_DEF(int64_t, oriKvStride)
 TILING_DATA_FIELD_DEF(int64_t, oriWinLeft)
 TILING_DATA_FIELD_DEF(int64_t, oriWinRight)
 TILING_DATA_FIELD_DEF(int64_t, sparseBlockSize)
+TILING_DATA_FIELD_DEF(bool, hasOriSparseIndices)
+TILING_DATA_FIELD_DEF(uint32_t, oriSparseIndexWidth)
 
 TILING_DATA_FIELD_DEF(uint32_t, usedCoreNum);
 
@@ -247,6 +249,8 @@ public:
     int64_t oriWinRight = 0;
     int64_t sparseBlockSize = 0;
     int64_t sparseBlockCount = 0;
+    bool hasOriSparseIndices = false;
+    uint32_t oriSparseIndexWidth = 0;
     // Mask
     int32_t sparseMode = 0;
     // Others Flag
@@ -391,6 +395,8 @@ private:
     int64_t blockSize_ = 0;
     int32_t oriBlockSize_ = 0;
     int32_t cmpBlockSize_ = 0;
+    bool hasOriSparseIndices_ = false;
+    uint32_t oriSparseIndexWidth_ = 0;
 
     uint32_t aicNum_ = 0;
     uint32_t aivNum_ = 0;
@@ -468,6 +474,7 @@ public:
     bool HasAxis(const SASAxis &axis, const SASLayout &layout, const gert::Shape &shape) const;
     size_t GetAxisIdx(const SASAxis &axis, const SASLayout &layout) const;
     uint32_t GetAxisNum(const gert::Shape &shape, const SASAxis &axis,const SASLayout &layout) const;
+    uint32_t GetSparseIndexWidth(const gert::Shape &shape, const SASLayout &layout) const;
     static constexpr int64_t invalidDimValue_ = std::numeric_limits<int64_t>::min();
 
     // BaseParams
@@ -506,6 +513,8 @@ public:
     uint32_t cmpMaxBlockNumPerBatch_ = 0;
     int32_t oriBlockSize_ = 0;
     int32_t cmpBlockSize_ = 0;
+    bool hasOriSparseIndices_ = false;
+    uint32_t oriSparseIndexWidth_ = 0;
 
     // template mode
     SASTemplateMode perfMode_ = SASTemplateMode::SWA_TEMPLATE_MODE;

--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_scfa_kernel.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_scfa_kernel.h
@@ -84,8 +84,8 @@ public:
 
     __aicore__ inline SparseAttnSharedkvScfa(){};
     __aicore__ inline void Init(__gm__ uint8_t *query, __gm__ uint8_t *oriKV, __gm__ uint8_t *cmpKV,
-                                __gm__ uint8_t *cmpSparseIndices, __gm__ uint8_t *oriBlockTable,
-                                __gm__ uint8_t *cmpBlockTable, __gm__ uint8_t *cuSeqlensQ,
+                                __gm__ uint8_t *oriSparseIndices, __gm__ uint8_t *cmpSparseIndices,
+                                __gm__ uint8_t *oriBlockTable, __gm__ uint8_t *cmpBlockTable, __gm__ uint8_t *cuSeqlensQ,
                                 __gm__ uint8_t* cuSeqlensKV, __gm__ uint8_t *cuSeqlensCmpKV,
                                 __gm__ uint8_t *seqUsedQ, __gm__ uint8_t *seqUsedKV, __gm__ uint8_t *sinks,
                                 __gm__ uint8_t *metadata, __gm__ uint8_t *attentionOut,
@@ -388,13 +388,15 @@ __aicore__ inline void SparseAttnSharedkvScfa<SAST>::UpdateInnerLoopCond()
 
 template <typename SAST>
 __aicore__ inline void SparseAttnSharedkvScfa<SAST>::Init(
-    __gm__ uint8_t *query, __gm__ uint8_t *oriKV, __gm__ uint8_t *cmpKV, __gm__ uint8_t *cmpSparseIndices,
-    __gm__ uint8_t *oriBlockTable, __gm__ uint8_t *cmpBlockTable, __gm__ uint8_t *cuSeqlensQ,
+    __gm__ uint8_t *query, __gm__ uint8_t *oriKV, __gm__ uint8_t *cmpKV, __gm__ uint8_t *oriSparseIndices,
+    __gm__ uint8_t *cmpSparseIndices, __gm__ uint8_t *oriBlockTable, __gm__ uint8_t *cmpBlockTable,
+    __gm__ uint8_t *cuSeqlensQ,
     __gm__ uint8_t* cuSeqlensKV, __gm__ uint8_t *cuSeqlensCmpKV, __gm__ uint8_t *seqUsedQ,
     __gm__ uint8_t *seqUsedKV, __gm__ uint8_t *sinks, __gm__ uint8_t *metadata, __gm__ uint8_t *attentionOut, __gm__ uint8_t *softmaxLse,
     __gm__ uint8_t *workspace, const SparseAttnSharedkvTilingData *__restrict tiling, __gm__ uint8_t *gmTiling,
     TPipe *tPipe)
 {
+    (void)oriSparseIndices;
     if ASCEND_IS_AIV {
         tmpBlockIdx = GetBlockIdx(); // vec:0-47
         aiCoreIdx = tmpBlockIdx / 2;

--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_swa_block_cube.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_swa_block_cube.h
@@ -41,7 +41,8 @@ public:
                                                GlobalTensor<OUT_T> attentionOutGm);
     __aicore__ inline void InitPageAttentionInfo(GlobalTensor<KV_T> oriKvGm, // const GlobalTensor<KV_T>& kvMergeGm,
                                                  GlobalTensor<int32_t> oriBlockTableGm,
-                                                 GlobalTensor<int32_t> cmpBlockTableGm);
+                                                 GlobalTensor<int32_t> cmpBlockTableGm,
+                                                 GlobalTensor<int32_t> oriSparseIndicesGm);
     __aicore__ inline void InitBuffers(TPipe *pipe);
 
     __aicore__ inline void AllocEventID();
@@ -113,6 +114,7 @@ private:
     // block_table
     GlobalTensor<int32_t> oriBlockTableGm;
     GlobalTensor<int32_t> cmpBlockTableGm;
+    GlobalTensor<int32_t> oriSparseIndicesGm;
 
     TBuf<TPosition::A1> bufQPL1;
     TBuf<TPosition::A1> bufKVL1;
@@ -185,10 +187,13 @@ __aicore__ inline void SWACubeBlock<SAST>::InitMm2GlobalTensor(GlobalTensor<KV_T
 template <typename SAST>
 __aicore__ inline void
 SWACubeBlock<SAST>::InitPageAttentionInfo(GlobalTensor<KV_T> oriKvGm, // const GlobalTensor<KV_T>& kvMergeGm,
-                                          GlobalTensor<int32_t> oriBlockTableGm, GlobalTensor<int32_t> cmpBlockTableGm)
+                                          GlobalTensor<int32_t> oriBlockTableGm,
+                                          GlobalTensor<int32_t> cmpBlockTableGm,
+                                          GlobalTensor<int32_t> oriSparseIndicesGm)
 {
     this->oriKvGm = oriKvGm;
     this->oriBlockTableGm = oriBlockTableGm;
+    this->oriSparseIndicesGm = oriSparseIndicesGm;
     if (constInfo.templateMode == CFA_TEMPLATE) {
         this->cmpBlockTableGm = cmpBlockTableGm;
     }
@@ -373,16 +378,11 @@ __aicore__ inline void SWACubeBlock<SAST>::ComputeMm1(const RunInfo &info, const
                     LocalTensor<KV_T> kTensor;
                     uint32_t copyRowCnt = 0;
 
-                    while (copyFinishRowCnt < nL1Size) {
-                        // 由于ori_left的存在， 即使第一块搬运也可能并非是pa_block的零点位
-                        copyRowCnt = constInfo.paOriBlockSize - curS2Offset % constInfo.paOriBlockSize;
-                        if (copyFinishRowCnt + copyRowCnt > nL1Size) {
-                            copyRowCnt = nL1Size - copyFinishRowCnt;
-                        }
+                    if (constInfo.hasOriSparseIndices) {
                         Position startPos;
                         startPos.bIdx = info.bIdx;
                         startPos.n2Idx = info.n2Idx;
-                        startPos.s2Idx = curS2Offset;
+                        startPos.s2Idx = 0;
                         // 256、32等待7buf命名更改
                         startPos.dIdx = kL1 * 256;  // mm1 右矩阵 bn2s2d, d为k轴不切; mm2 右矩阵, s2为k轴, d轴切分
                         PAShape shape;
@@ -392,13 +392,41 @@ __aicore__ inline void SWACubeBlock<SAST>::ComputeMm1(const RunInfo &info, const
                         shape.kvStride = constInfo.oriKvStride;
                         shape.actHeadDim = 256;
                         shape.maxblockNumPerBatch = constInfo.oriMaxBlockNumPerBatch;
-                        shape.copyRowNum = copyRowCnt;
+                        shape.copyRowNum = nL1Size;
                         shape.copyRowNumAlign = nL1SizeAlign;
-                        kTensor = bL1Tensor[copyFinishRowCnt * 16];
-                        DataCopyPA<KV_T>(kTensor, oriKvGm, oriBlockTableGm, shape, startPos);
-                        // 更新循环变量
-                        copyFinishRowCnt += copyRowCnt;
-                        curS2Offset += copyRowCnt;
+                        uint64_t sparseIndexBaseOffset =
+                            (info.qTokenOffset * constInfo.kvHeadNum + info.n2Idx) * constInfo.oriSparseIndexWidth;
+                        uint32_t sparseIndexStart = info.s2Idx * constInfo.s2BaseSize + nL1 * N_SPLIT_SIZE;
+                        DataCopyPABySlots<KV_T>(bL1Tensor, oriKvGm, oriSparseIndicesGm, shape, startPos,
+                                                sparseIndexBaseOffset, sparseIndexStart);
+                    } else {
+                        while (copyFinishRowCnt < nL1Size) {
+                            // 由于ori_left的存在， 即使第一块搬运也可能并非是pa_block的零点位
+                            copyRowCnt = constInfo.paOriBlockSize - curS2Offset % constInfo.paOriBlockSize;
+                            if (copyFinishRowCnt + copyRowCnt > nL1Size) {
+                                copyRowCnt = nL1Size - copyFinishRowCnt;
+                            }
+                            Position startPos;
+                            startPos.bIdx = info.bIdx;
+                            startPos.n2Idx = info.n2Idx;
+                            startPos.s2Idx = curS2Offset;
+                            // 256、32等待7buf命名更改
+                            startPos.dIdx = kL1 * 256;  // mm1 右矩阵 bn2s2d, d为k轴不切; mm2 右矩阵, s2为k轴, d轴切分
+                            PAShape shape;
+                            shape.blockSize = constInfo.paOriBlockSize;
+                            shape.headNum = constInfo.kvHeadNum;
+                            shape.headDim = constInfo.headDim;
+                            shape.kvStride = constInfo.oriKvStride;
+                            shape.actHeadDim = 256;
+                            shape.maxblockNumPerBatch = constInfo.oriMaxBlockNumPerBatch;
+                            shape.copyRowNum = copyRowCnt;
+                            shape.copyRowNumAlign = nL1SizeAlign;
+                            kTensor = bL1Tensor[copyFinishRowCnt * 16];
+                            DataCopyPA<KV_T>(kTensor, oriKvGm, oriBlockTableGm, shape, startPos);
+                            // 更新循环变量
+                            copyFinishRowCnt += copyRowCnt;
+                            curS2Offset += copyRowCnt;
+                        }
                     }
                 } else if constexpr (KV_LAYOUT_T == SAS_LAYOUT::BSND) {
                     Nd2NzParams nd2nzPara;
@@ -681,15 +709,11 @@ __aicore__ inline void SWACubeBlock<SAST>::ComputeMm2(const RunInfo &info, const
                 if (info.isOri) {
                     if constexpr (KV_LAYOUT_T == SAS_LAYOUT::PA_ND) {
                         uint32_t curS2Offset = info.s2Idx * constInfo.s2BaseSize + info.s2StartPoint + kL1 * K_L0_SPLIT_SIZE;
-                        while (copyFinishRowCnt < kL0Size) {
-                            copyRowCnt = constInfo.paOriBlockSize - curS2Offset % constInfo.paOriBlockSize;
-                            if (copyFinishRowCnt + copyRowCnt > kL0Size) {
-                                copyRowCnt = kL0Size - copyFinishRowCnt;
-                            }
+                        if (constInfo.hasOriSparseIndices) {
                             Position startPos;
                             startPos.bIdx = info.bIdx;
                             startPos.n2Idx = info.n2Idx;
-                            startPos.s2Idx = curS2Offset;
+                            startPos.s2Idx = 0;
                             startPos.dIdx = nL1 * N_SPLIT_SIZE;  // mm1 右矩阵 bn2s2d, d为k轴不切; mm2 右矩阵, s2为k轴, d轴切分
                             PAShape shape;
                             shape.blockSize = constInfo.paOriBlockSize;
@@ -698,14 +722,41 @@ __aicore__ inline void SWACubeBlock<SAST>::ComputeMm2(const RunInfo &info, const
                             shape.kvStride = constInfo.oriKvStride;
                             shape.actHeadDim = nL1Size;
                             shape.maxblockNumPerBatch = constInfo.oriMaxBlockNumPerBatch;
-                            shape.copyRowNum = copyRowCnt;
+                            shape.copyRowNum = kL0Size;
                             shape.copyRowNumAlign = kL0SizeAlign;
-                            subvTensor = bL1Tensor[(kL1 - kOffset) * K_L0_SPLIT_SIZE * N_SPLIT_SIZE + copyFinishRowCnt * 16];
-                            DataCopyPA<KV_T>(subvTensor, oriKvGm, oriBlockTableGm, shape, startPos);
+                            subvTensor = bL1Tensor[(kL1 - kOffset) * K_L0_SPLIT_SIZE * N_SPLIT_SIZE];
+                            uint64_t sparseIndexBaseOffset =
+                                (info.qTokenOffset * constInfo.kvHeadNum + info.n2Idx) * constInfo.oriSparseIndexWidth;
+                            uint32_t sparseIndexStart = info.s2Idx * constInfo.s2BaseSize + kL1 * K_L0_SPLIT_SIZE;
+                            DataCopyPABySlots<KV_T>(subvTensor, oriKvGm, oriSparseIndicesGm, shape, startPos,
+                                                    sparseIndexBaseOffset, sparseIndexStart);
+                        } else {
+                            while (copyFinishRowCnt < kL0Size) {
+                                copyRowCnt = constInfo.paOriBlockSize - curS2Offset % constInfo.paOriBlockSize;
+                                if (copyFinishRowCnt + copyRowCnt > kL0Size) {
+                                    copyRowCnt = kL0Size - copyFinishRowCnt;
+                                }
+                                Position startPos;
+                                startPos.bIdx = info.bIdx;
+                                startPos.n2Idx = info.n2Idx;
+                                startPos.s2Idx = curS2Offset;
+                                startPos.dIdx = nL1 * N_SPLIT_SIZE;  // mm1 右矩阵 bn2s2d, d为k轴不切; mm2 右矩阵, s2为k轴, d轴切分
+                                PAShape shape;
+                                shape.blockSize = constInfo.paOriBlockSize;
+                                shape.headNum = constInfo.kvHeadNum;
+                                shape.headDim = constInfo.headDim;
+                                shape.kvStride = constInfo.oriKvStride;
+                                shape.actHeadDim = nL1Size;
+                                shape.maxblockNumPerBatch = constInfo.oriMaxBlockNumPerBatch;
+                                shape.copyRowNum = copyRowCnt;
+                                shape.copyRowNumAlign = kL0SizeAlign;
+                                subvTensor = bL1Tensor[(kL1 - kOffset) * K_L0_SPLIT_SIZE * N_SPLIT_SIZE + copyFinishRowCnt * 16];
+                                DataCopyPA<KV_T>(subvTensor, oriKvGm, oriBlockTableGm, shape, startPos);
 
-                            // 更新循环变量
-                            copyFinishRowCnt += copyRowCnt;
-                            curS2Offset += copyRowCnt;
+                                // 更新循环变量
+                                copyFinishRowCnt += copyRowCnt;
+                                curS2Offset += copyRowCnt;
+                            }
                         }
                     } else if constexpr (KV_LAYOUT_T == SAS_LAYOUT::BSND) {
                         subvTensor = bL1Tensor[(kL1 - kOffset) * K_L0_SPLIT_SIZE * N_SPLIT_SIZE];

--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_swa_kernel.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_swa_kernel.h
@@ -80,8 +80,8 @@ public:
 
     __aicore__ inline SparseAttnSharedkvSwa(){};
     __aicore__ inline void Init(__gm__ uint8_t *query, __gm__ uint8_t *oriKV, __gm__ uint8_t *cmpKV,
-                                __gm__ uint8_t *cmpSparseIndices, __gm__ uint8_t *oriBlockTable,
-                                __gm__ uint8_t *cmpBlockTable, __gm__ uint8_t *cuSeqlensQ,
+                                __gm__ uint8_t *oriSparseIndices, __gm__ uint8_t *cmpSparseIndices,
+                                __gm__ uint8_t *oriBlockTable, __gm__ uint8_t *cmpBlockTable, __gm__ uint8_t *cuSeqlensQ,
                                 __gm__ uint8_t* cuSeqlensKV, __gm__ uint8_t *cuSeqlensCmpKV, __gm__ uint8_t *seqUsedQ,
                                 __gm__ uint8_t *seqUsedKV, __gm__ uint8_t *sinks, __gm__ uint8_t *metadata,
                                 __gm__ uint8_t *attentionOut, __gm__ uint8_t *softmaxLse, __gm__ uint8_t *workspace,
@@ -149,6 +149,7 @@ private:
 
     GlobalTensor<int32_t> oriBlockTableGm;
     GlobalTensor<int32_t> cmpBlockTableGm;
+    GlobalTensor<int32_t> oriSparseIndicesGm;
 
     GlobalTensor<int32_t> actualSeqLengthsQGm;
     GlobalTensor<int32_t> actualSeqLengthsKVGm;
@@ -181,6 +182,7 @@ private:
                                       RunInfo &info);
     __aicore__ inline int32_t GetActualSeqLenQ(uint32_t bIdx);
     __aicore__ inline int32_t GetActualSeqLenKV(uint32_t bIdx);
+    __aicore__ inline uint32_t GetOriSparseActualSeqLen();
     __aicore__ inline void GetBN2Idx(uint32_t bN2Idx, uint32_t &bIdx, uint32_t &n2Idx);
     // ================================Mm1==============================================
     __aicore__ inline void ComputeMm1(const RunInfo &info);
@@ -213,6 +215,8 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::InitTilingData()
     constInfo.oriKvStride = tilingData->baseParams.oriKvStride;
     constInfo.oriWinLeft = tilingData->baseParams.oriWinLeft;
     constInfo.oriWinRight = tilingData->baseParams.oriWinRight;
+    constInfo.hasOriSparseIndices = tilingData->baseParams.hasOriSparseIndices;
+    constInfo.oriSparseIndexWidth = tilingData->baseParams.oriSparseIndexWidth;
     constInfo.returnSoftmaxLse = tilingData->baseParams.returnSoftmaxLse;
 
     constInfo.actualLenDimsQ = tilingData->baseParams.actualLenDimsQ;
@@ -365,6 +369,26 @@ __aicore__ inline int32_t SparseAttnSharedkvSwa<SAST>::GetActualSeqLenKV(uint32_
 }
 
 template <typename SAST>
+__aicore__ inline uint32_t SparseAttnSharedkvSwa<SAST>::GetOriSparseActualSeqLen()
+{
+    if (!constInfo.hasOriSparseIndices || constInfo.oriSparseIndexWidth == 0 || tempLoopInfo.actOriS2Size <= 0) {
+        return 0;
+    }
+    uint64_t qTokenOffset = tempLoopInfo.actualSeqQPrefixSum + tempLoopInfo.s1StartIdx;
+    uint64_t sparseIndexBaseOffset =
+        (qTokenOffset * constInfo.kvHeadNum + tempLoopInfo.n2Idx) * constInfo.oriSparseIndexWidth;
+    uint32_t maxSparseLen = Min(static_cast<uint64_t>(constInfo.oriSparseIndexWidth),
+                                static_cast<uint64_t>(tempLoopInfo.actOriS2Size));
+    uint32_t sparseLen = 0;
+    for (; sparseLen < maxSparseLen; ++sparseLen) {
+        if (oriSparseIndicesGm.GetValue(sparseIndexBaseOffset + sparseLen) < 0) {
+            break;
+        }
+    }
+    return sparseLen;
+}
+
+template <typename SAST>
 __aicore__ inline void SparseAttnSharedkvSwa<SAST>::GetSparseActualSeqLen()
 {
     // 行无效通过ori部分判断, ori部分如果有行无效那么ori和cmp都有
@@ -384,7 +408,8 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::GetSparseActualSeqLen()
 template <typename SAST>
 __aicore__ inline void SparseAttnSharedkvSwa<SAST>::UpdateInnerLoopCond()
 {
-    if ((tempLoopInfo.actCmpS2Size == 0 && tempLoopInfo.actOriS2Size == 0) || (tempLoopInfo.actS1Size == 0)) {
+    bool hasOriWindow = tempLoopInfo.oriMaskRight >= tempLoopInfo.oriMaskLeft;
+    if ((tempLoopInfo.actCmpS2Size == 0 && !hasOriWindow) || (tempLoopInfo.actS1Size == 0)) {
         tempLoopInfo.curActSeqLenIsZero = true;
         return;
     }
@@ -396,8 +421,9 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::UpdateInnerLoopCond()
 
 template <typename SAST>
 __aicore__ inline void SparseAttnSharedkvSwa<SAST>::Init(
-    __gm__ uint8_t *query, __gm__ uint8_t *oriKV, __gm__ uint8_t *cmpKV, __gm__ uint8_t *cmpSparseIndices,
-    __gm__ uint8_t *oriBlockTable, __gm__ uint8_t *cmpBlockTable, __gm__ uint8_t *cuSeqlensQ,
+    __gm__ uint8_t *query, __gm__ uint8_t *oriKV, __gm__ uint8_t *cmpKV, __gm__ uint8_t *oriSparseIndices,
+    __gm__ uint8_t *cmpSparseIndices, __gm__ uint8_t *oriBlockTable, __gm__ uint8_t *cmpBlockTable,
+    __gm__ uint8_t *cuSeqlensQ,
     __gm__ uint8_t *cuSeqlensKV, __gm__ uint8_t *cuSeqlensCmpKV, __gm__ uint8_t *seqUsedQ,
     __gm__ uint8_t *seqUsedKV, __gm__ uint8_t *sinks, __gm__ uint8_t *metadata, __gm__ uint8_t *attentionOut, __gm__ uint8_t *softmaxLse,
     __gm__ uint8_t *workspace, const SparseAttnSharedkvTilingData *__restrict tiling, __gm__ uint8_t *gmTiling,
@@ -452,6 +478,9 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::Init(
 
     if constexpr (PAGE_ATTENTION) {
         oriBlockTableGm.SetGlobalBuffer((__gm__ int32_t *)oriBlockTable);
+        if (constInfo.hasOriSparseIndices) {
+            oriSparseIndicesGm.SetGlobalBuffer((__gm__ int32_t *)oriSparseIndices);
+        }
         if (constInfo.templateMode == CFA_TEMPLATE) {
             cmpBlockTableGm.SetGlobalBuffer((__gm__ int32_t *)cmpBlockTable);
         }
@@ -489,7 +518,7 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::Init(
         cubeBlock.InitParams(constInfo);
         cubeBlock.InitMm1GlobalTensor(queryGm, oriKvGm, cmpKvGm, mm1ResGm);
         cubeBlock.InitMm2GlobalTensor(vec1ResGm, mm2ResGm, attentionOutGm);
-        cubeBlock.InitPageAttentionInfo(oriKvGm, oriBlockTableGm, cmpBlockTableGm);
+        cubeBlock.InitPageAttentionInfo(oriKvGm, oriBlockTableGm, cmpBlockTableGm, oriSparseIndicesGm);
     }
     // 要在InitParams之后执行
     if (pipe != nullptr) {
@@ -562,6 +591,11 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::CalcParams(uint32_t loop, ui
     info.tensorBOffset = tensorBCoreOffset;
     info.tensorCmpBOffset = tensorCmpBCoreOffset;
     info.attenOutOffset = tensorACoreOffset;
+    if constexpr (LAYOUT_T == SAS_LAYOUT::TND) {
+        info.qTokenOffset = tempLoopInfo.actualSeqQPrefixSum + info.s1Idx;
+    } else {
+        info.qTokenOffset = info.bIdx * constInfo.qSeqSize + info.s1Idx;
+    }
 
     if (s2LoopIdx < tempLoopInfo.oriLoopTimes) {
         // S2首次循环只能在ori_kv
@@ -573,7 +607,7 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::CalcParams(uint32_t loop, ui
         } else {
             info.actualSingleProcessSInnerSize = constInfo.s2BaseSize;
         }
-        info.s2StartPoint = tempLoopInfo.oriMaskLeft;
+        info.s2StartPoint = constInfo.hasOriSparseIndices ? 0 : tempLoopInfo.oriMaskLeft;
         info.cmpS2IdLimit = 0;
     } else {
         if (constInfo.templateMode == CFA_TEMPLATE) {
@@ -686,11 +720,17 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::ProcessBalance()
             tempLoopInfo.s1EndIdx =
                 Min((tempLoopInfo.s1StartIdx + constInfo.mBaseSize / constInfo.gSize - 1), tempLoopInfo.actS1Size - 1);
             // 此处均为闭区间
-            tempLoopInfo.oriMaskRight = tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size +
-                                        static_cast<int32_t>(tempLoopInfo.s1EndIdx) + constInfo.oriWinRight;
-            tempLoopInfo.oriMaskLeft = Max(tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size +
-                                               static_cast<int32_t>(tempLoopInfo.s1EndIdx) - constInfo.oriWinLeft,
-                                           0);
+            if (constInfo.hasOriSparseIndices) {
+                uint32_t sparseOriS2Size = GetOriSparseActualSeqLen();
+                tempLoopInfo.oriMaskLeft = 0;
+                tempLoopInfo.oriMaskRight = sparseOriS2Size == 0 ? -1 : static_cast<int32_t>(sparseOriS2Size - 1U);
+            } else {
+                tempLoopInfo.oriMaskRight = tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size +
+                                            static_cast<int32_t>(tempLoopInfo.s1EndIdx) + constInfo.oriWinRight;
+                tempLoopInfo.oriMaskLeft = Max(tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size +
+                                                   static_cast<int32_t>(tempLoopInfo.s1EndIdx) - constInfo.oriWinLeft,
+                                               0);
+            }
             if (constInfo.templateMode == CFA_TEMPLATE) {
                 tempLoopInfo.cmpMaskRight = tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size;
             }
@@ -707,7 +747,9 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::ProcessBalance()
                     continue;
                 }
             } else {
-                oriSplitNum = CeilDiv(tempLoopInfo.oriMaskRight - tempLoopInfo.oriMaskLeft + 1, constInfo.s2BaseSize);
+                uint32_t oriS2Size = (tempLoopInfo.oriMaskRight >= tempLoopInfo.oriMaskLeft) ?
+                    static_cast<uint32_t>(tempLoopInfo.oriMaskRight - tempLoopInfo.oriMaskLeft + 1) : 0U;
+                oriSplitNum = CeilDiv(oriS2Size, constInfo.s2BaseSize);
                 s2SplitNum = oriSplitNum;
                 if (constInfo.templateMode == CFA_TEMPLATE) {
                     uint32_t cmpSplitNum = CeilDiv(tempLoopInfo.actCmpS2Size, constInfo.s2BaseSize);
@@ -718,6 +760,9 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::ProcessBalance()
             tempLoopInfo.s2LoopTimes = s2SplitNum;
             tempLoopInfo.oriLoopTimes = oriSplitNum;
             uint32_t s2LoopEnd = (isEnd && constInfo.s2End != 0) ? constInfo.s2End : tempLoopInfo.s2LoopTimes;
+            if (constInfo.hasOriSparseIndices) {
+                s2LoopEnd = Min(s2LoopEnd, s2SplitNum);
+            }
             tempLoopInfo.s2LoopTimes = s2LoopEnd;
             // 分核修改后需要打开
             // 当前s2是否被切，决定了输出是否要写到attenOut上

--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/sparse_attn_sharedkv.cpp
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/sparse_attn_sharedkv.cpp
@@ -29,7 +29,7 @@ using namespace SASKernel;
         templateClass<SASType<__VA_ARGS__>> op;                                                                        \
         GET_TILING_DATA_WITH_STRUCT(tilingdataClass, tiling_data_in, tiling);                                          \
         const tilingdataClass *__restrict tiling_data = &tiling_data_in;                                               \
-        op.Init(query, oriKV, cmpKV, cmpSparseIndices, oriBlockTable, cmpBlockTable, cuSeqlensQ,                       \
+        op.Init(query, oriKV, cmpKV, oriSparseIndices, cmpSparseIndices, oriBlockTable, cmpBlockTable, cuSeqlensQ,     \
                 cuSeqlensOriKv, cuSeqlensCmpKv, seqUsedQ, seqUsedKV,                                                   \
                 sinks, metadata, attentionOut, softmaxLse, user, tiling_data, tiling, &tPipe);                                     \
         op.Process();                                                                                                  \

--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/sparse_attn_sharedkv_common.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/sparse_attn_sharedkv_common.h
@@ -170,6 +170,34 @@ __aicore__ inline void DataCopyPA(LocalTensor<T> &dstTensor,  //l1
     }
 }
 
+template <typename T>
+__aicore__ inline void DataCopyPABySlots(LocalTensor<T> &dstTensor,  // l1
+                                         GlobalTensor<T> &srcTensor, // gm
+                                         GlobalTensor<int32_t> &sparseIndicesGm,
+                                         const PAShape &shape,
+                                         const Position &startPos,
+                                         uint64_t sparseIndexBaseOffset,
+                                         uint32_t sparseIndexStart)
+{
+    uint32_t blockElementCnt = 32 / sizeof(T);
+    for (uint32_t row = 0; row < shape.copyRowNum; ++row) {
+        int32_t slotId = sparseIndicesGm.GetValue(sparseIndexBaseOffset + sparseIndexStart + row);
+        if (slotId < 0) {
+            slotId = 0;
+        }
+        uint64_t blockId = static_cast<uint64_t>(slotId) / shape.blockSize;
+        uint64_t blockOffset = static_cast<uint64_t>(slotId) % shape.blockSize;
+        uint64_t offset = blockId * shape.kvStride;
+        offset += static_cast<uint64_t>(startPos.n2Idx * shape.headDim * shape.blockSize) +
+                  blockOffset * shape.headDim + startPos.dIdx;
+
+        LocalTensor<T> tmpDstTensor = dstTensor[row * blockElementCnt];
+        GlobalTensor<T> tmpSrcTensor = srcTensor[offset];
+        DataCopyGmNDToL1<T>(tmpDstTensor, tmpSrcTensor, 1, shape.copyRowNumAlign,
+                            shape.actHeadDim, shape.headDim);
+    }
+}
+
 struct RunInfo {
     uint32_t loop = 0;
     uint32_t cmpLoop = 0; // 用于判断取 用于merge的4块GM 中的哪一块
@@ -187,6 +215,7 @@ struct RunInfo {
     uint64_t tensorAOffset = 0;
     uint64_t tensorBOffset = 0;
     uint64_t attenOutOffset = 0;
+    uint64_t qTokenOffset = 0;
     uint64_t attenMaskOffset = 0;
     uint64_t topKBaseOffset = 0;
     uint32_t actualSingleProcessSInnerSize = 0;
@@ -302,6 +331,8 @@ struct ConstInfo {
     // sparse attr
     int64_t sparseBlockSize = 0;
     uint32_t sparseBlockCount = 0;
+    bool hasOriSparseIndices = false;
+    uint32_t oriSparseIndexWidth = 0;
 
     // cmp attr
     int64_t cmpRatio = 0;

--- a/csrc/attention/sparse_attn_sharedkv_metadata/README.md
+++ b/csrc/attention/sparse_attn_sharedkv_metadata/README.md
@@ -146,7 +146,7 @@
     <tr>
       <td>ori_win_left</td>
       <td>可选属性</td>
-      <td>表示q和ori_kv计算中q对过去token计算的数量，仅支持默认值127。</td>
+      <td>表示q和ori_kv计算中q对过去token计算的数量，支持非负值，默认值为127。</td>
       <td>INT32</td>
       <td>-</td>
     </tr>

--- a/csrc/attention/sparse_attn_sharedkv_metadata/op_kernel_aicpu/sparse_attn_sharedkv_metadata_aicpu.cpp
+++ b/csrc/attention/sparse_attn_sharedkv_metadata/op_kernel_aicpu/sparse_attn_sharedkv_metadata_aicpu.cpp
@@ -116,8 +116,8 @@ bool SparseAttnSharedkvMetadataCpuKernel::CheckSingleParam()
         return false;
     }
     // ori_win_left 校验
-    if (winLeft_ != 127) {
-        KERNEL_LOG_ERROR("ori_win_left should only be 127, but got %ld", winLeft_);
+    if (winLeft_ < 0) {
+        KERNEL_LOG_ERROR("ori_win_left should be non-negative, but got %ld", winLeft_);
         return false;
     }
     // layout_q 校验

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_attn_sharedkv_sparse_indices.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_attn_sharedkv_sparse_indices.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+from vllm_ascend.utils import enable_custom_op
+
+enable_custom_op()
+
+HEAD_DIM = 512
+NUM_Q_HEADS = 4
+NUM_KV_HEADS = 1
+SPARSE_INDEX_WIDTH = 128
+ORI_WIN_LEFT = 127
+ORI_WIN_RIGHT = 0
+
+
+def _reference_attention(
+    query: torch.Tensor,
+    kv_rows: list[torch.Tensor],
+    sinks: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    output = torch.empty_like(query)
+    for token_idx, token_kv in enumerate(kv_rows):
+        key = token_kv.expand(-1, NUM_Q_HEADS, -1).float()
+        scores = torch.einsum("hd,khd->hk", query[token_idx].float(), key) * softmax_scale
+        sink = sinks.float().view(NUM_Q_HEADS, 1)
+        scores_max = torch.maximum(scores.max(dim=-1, keepdim=True).values, sink)
+        exp_scores = torch.exp(scores - scores_max)
+        probs = exp_scores / (exp_scores.sum(dim=-1, keepdim=True) + torch.exp(sink - scores_max))
+        output[token_idx] = torch.einsum("hk,khd->hd", probs, key).to(query.dtype)
+    return output
+
+
+def _make_metadata(
+    query: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    seqused_kv: torch.Tensor,
+    ori_win_left: int,
+    ori_win_right: int,
+) -> torch.Tensor:
+    return torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
+        num_heads_q=NUM_Q_HEADS,
+        num_heads_kv=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        cu_seqlens_q=cu_seqlens_q,
+        seqused_kv=seqused_kv,
+        batch_size=1,
+        max_seqlen_q=query.shape[0],
+        max_seqlen_kv=int(seqused_kv.max().item()),
+        cmp_ratio=4,
+        ori_mask_mode=4,
+        cmp_mask_mode=3,
+        ori_win_left=ori_win_left,
+        ori_win_right=ori_win_right,
+        layout_q="TND",
+        layout_kv="PA_ND",
+        has_ori_kv=True,
+        has_cmp_kv=False,
+        device=str(query.device),
+    )
+
+
+def _run_operator(
+    query: torch.Tensor,
+    kv_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    seqused_kv: torch.Tensor,
+    sinks: torch.Tensor,
+    ori_sparse_indices: torch.Tensor | None,
+    ori_win_left: int = ORI_WIN_LEFT,
+    ori_win_right: int = ORI_WIN_RIGHT,
+) -> torch.Tensor:
+    metadata = _make_metadata(query, cu_seqlens_q, seqused_kv, ori_win_left, ori_win_right)
+    return torch.ops._C_ascend.npu_sparse_attn_sharedkv(
+        query,
+        ori_kv=kv_cache,
+        ori_sparse_indices=ori_sparse_indices,
+        ori_block_table=block_table,
+        cu_seqlens_q=cu_seqlens_q,
+        seqused_kv=seqused_kv,
+        sinks=sinks,
+        metadata=metadata,
+        softmax_scale=1.0 / math.sqrt(HEAD_DIM),
+        cmp_ratio=4,
+        ori_mask_mode=4,
+        cmp_mask_mode=3,
+        ori_win_left=ori_win_left,
+        ori_win_right=ori_win_right,
+        layout_q="TND",
+        layout_kv="PA_ND",
+    )[0]
+
+
+@torch.inference_mode()
+def test_sparse_original_indices_match_explicit_slot_reference():
+    torch.manual_seed(20260712)
+    device = torch.device("npu:0")
+    dtype = torch.bfloat16
+    cache_block_size = 16
+    query_tokens = 2
+    actual_kv_len = 64
+
+    query = (torch.randn(query_tokens, NUM_Q_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    kv_cache = (torch.randn(6, cache_block_size, NUM_KV_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    block_table = torch.tensor([[4, 1, 3, 0]], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, query_tokens], dtype=torch.int32, device=device)
+    seqused_kv = torch.tensor([actual_kv_len], dtype=torch.int32, device=device)
+    sinks = torch.linspace(-0.2, 0.2, NUM_Q_HEADS, dtype=torch.float32, device=device)
+
+    slot_rows = (
+        (1, 19, 34, 17, 80, 47, 65),
+        (63, 2, 48, 33, 79, 16),
+    )
+    sparse_indices = torch.full(
+        (query_tokens, NUM_KV_HEADS, SPARSE_INDEX_WIDTH),
+        -1,
+        dtype=torch.int32,
+        device=device,
+    )
+    for token_idx, slots in enumerate(slot_rows):
+        sparse_indices[token_idx, 0, : len(slots)] = torch.tensor(slots, dtype=torch.int32, device=device)
+
+    actual = _run_operator(
+        query,
+        kv_cache,
+        block_table,
+        cu_seqlens_q,
+        seqused_kv,
+        sinks,
+        sparse_indices,
+    )
+    flat_cache = kv_cache.reshape(-1, NUM_KV_HEADS, HEAD_DIM)
+    kv_rows = [flat_cache[torch.tensor(slots, dtype=torch.long, device=device)] for slots in slot_rows]
+    expected = _reference_attention(query, kv_rows, sinks, 1.0 / math.sqrt(HEAD_DIM))
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), atol=3e-2, rtol=3e-2)
+
+
+@torch.inference_mode()
+def test_sparse_original_indices_support_multiple_inner_loops():
+    torch.manual_seed(20260714)
+    device = torch.device("npu:0")
+    dtype = torch.bfloat16
+    cache_block_size = 16
+    actual_kv_len = 256
+    index_width = 256
+    visible_count = 140
+
+    query = (torch.randn(1, NUM_Q_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    kv_cache = (torch.randn(20, cache_block_size, NUM_KV_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    block_table = torch.arange(16, dtype=torch.int32, device=device).reshape(1, -1)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    seqused_kv = torch.tensor([actual_kv_len], dtype=torch.int32, device=device)
+    sinks = torch.zeros(NUM_Q_HEADS, dtype=torch.float32, device=device)
+    slots = (torch.arange(visible_count, dtype=torch.int32, device=device) * 37) % (
+        kv_cache.shape[0] * cache_block_size
+    )
+    sparse_indices = torch.full(
+        (1, NUM_KV_HEADS, index_width),
+        -1,
+        dtype=torch.int32,
+        device=device,
+    )
+    sparse_indices[0, 0, :visible_count] = slots
+
+    actual = _run_operator(
+        query,
+        kv_cache,
+        block_table,
+        cu_seqlens_q,
+        seqused_kv,
+        sinks,
+        sparse_indices,
+        ori_win_left=index_width - 1,
+    )
+    flat_cache = kv_cache.reshape(-1, NUM_KV_HEADS, HEAD_DIM)
+    expected = _reference_attention(
+        query,
+        [flat_cache[slots.long()]],
+        sinks,
+        1.0 / math.sqrt(HEAD_DIM),
+    )
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), atol=3e-2, rtol=3e-2)
+
+
+@torch.inference_mode()
+def test_sparse_original_indices_absent_preserves_swa_behavior():
+    torch.manual_seed(20260713)
+    device = torch.device("npu:0")
+    dtype = torch.bfloat16
+    cache_block_size = 16
+    actual_kv_len = 32
+
+    query = (torch.randn(1, NUM_Q_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    kv_cache = (torch.randn(4, cache_block_size, NUM_KV_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    block_table = torch.tensor([[2, 0]], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    seqused_kv = torch.tensor([actual_kv_len], dtype=torch.int32, device=device)
+    sinks = torch.zeros(NUM_Q_HEADS, dtype=torch.float32, device=device)
+
+    actual = _run_operator(query, kv_cache, block_table, cu_seqlens_q, seqused_kv, sinks, None)
+    logical_positions = torch.arange(actual_kv_len, device=device)
+    physical_blocks = block_table[0, logical_positions // cache_block_size].long()
+    block_offsets = logical_positions % cache_block_size
+    kv_rows = [kv_cache[physical_blocks, block_offsets]]
+    expected = _reference_attention(query, kv_rows, sinks, 1.0 / math.sqrt(HEAD_DIM))
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), atol=3e-2, rtol=3e-2)
+
+
+@torch.inference_mode()
+def test_sparse_original_indices_reject_unaligned_width():
+    device = torch.device("npu:0")
+    query = torch.zeros(1, NUM_Q_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    kv_cache = torch.zeros(1, 16, NUM_KV_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    block_table = torch.zeros(1, 1, dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    seqused_kv = torch.tensor([1], dtype=torch.int32, device=device)
+    sinks = torch.zeros(NUM_Q_HEADS, dtype=torch.float32, device=device)
+    sparse_indices = torch.zeros(1, NUM_KV_HEADS, 64, dtype=torch.int32, device=device)
+
+    with pytest.raises(RuntimeError):
+        _run_operator(query, kv_cache, block_table, cu_seqlens_q, seqused_kv, sinks, sparse_indices)

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -1,6 +1,7 @@
 import json
 import os
 import tempfile
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -37,7 +38,7 @@ class TestAscendModelSlimConfig(TestBase):
             "shard2.weight": "FLOAT",
         }
         self.ascend_config = AscendModelSlimConfig(self.sample_config)
-        self.ascend_config.packed_modules_mapping = None
+        cast(Any, self.ascend_config).packed_modules_mapping = None
 
     def test_init(self):
         self.assertEqual(self.ascend_config.quant_description, self.sample_config)
@@ -417,6 +418,63 @@ class TestQuantPrefixMapper(TestBase):
                 self.assertEqual(prefix, "language_model.model.layers.0.experts")
                 self.assertEqual(get_linear_quant_type(quant_description, prefix, packed_mapping), "W8A8_DYNAMIC")
                 self.assertFalse(config.is_layer_skipped_ascend(prefix, packed_mapping))
+
+    def test_deepseek_v4_mtp_maps_expanded_runtime_layers_to_raw_quant_keys(self):
+        config = AscendModelSlimConfig(
+            {
+                "hc_head_fn": "FLOAT",
+                "mtp.0.attn.wq_a.weight": "W8A8_DYNAMIC",
+                "mtp.0.ffn.shared_experts.w1.weight": "W8A8_DYNAMIC",
+                "mtp.0.ffn.shared_experts.w3.weight": "W8A8_DYNAMIC",
+                "mtp.0.ffn.experts.0.w1.weight": "W4A8_DYNAMIC",
+                "mtp.0.ffn.experts.0.w2.weight": "W4A8_DYNAMIC",
+                "mtp.0.ffn.experts.0.w3.weight": "W4A8_DYNAMIC",
+            }
+        )
+        cases = {
+            "model.layers.43.self_attn.wq_a": "model.mtp.0.self_attn.wq_a",
+            "model.layers.43.mlp.shared_experts.gate_up_proj": ("model.mtp.0.mlp.shared_experts.gate_up_proj"),
+            "model.layers.43.mlp.experts": "model.mtp.0.mlp.experts",
+        }
+
+        for model_type in ("deepseek_v4", "deepseek_mtp"):
+            for prefix, expected in cases.items():
+                with self.subTest(model_type=model_type, prefix=prefix):
+                    self.assertEqual(
+                        config.quant_prefix_mapper(
+                            model_type,
+                            prefix,
+                            num_hidden_layers=43,
+                        ),
+                        expected,
+                    )
+
+    def test_deepseek_v4_mtp_direct_quant_key_takes_precedence(self):
+        config = AscendModelSlimConfig(
+            {
+                "model.layers.43.self_attn.wq_a.weight": "FLOAT",
+                "model.mtp.0.self_attn.wq_a.weight": "W8A8_DYNAMIC",
+            }
+        )
+
+        prefix = config.quant_prefix_mapper(
+            "deepseek_v4",
+            "model.layers.43.self_attn.wq_a",
+            num_hidden_layers=43,
+        )
+
+        self.assertEqual(prefix, "model.layers.43.self_attn.wq_a")
+
+    def test_deepseek_v4_mtp_missing_quant_key_keeps_runtime_prefix(self):
+        config = AscendModelSlimConfig({"model.layers.42.self_attn.wq_a.weight": "W8A8_DYNAMIC"})
+
+        prefix = config.quant_prefix_mapper(
+            "deepseek_mtp",
+            "model.layers.43.self_attn.wq_a",
+            num_hidden_layers=43,
+        )
+
+        self.assertEqual(prefix, "model.layers.43.self_attn.wq_a")
 
     def test_gemma4_packed_modules_mapping_covers_attention_mlp_and_moe(self):
         expected_mapping = {

--- a/tests/ut/spec_decode/test_deepseek_v4_draft_hooks.py
+++ b/tests/ut/spec_decode/test_deepseek_v4_draft_hooks.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+
+from vllm_ascend.models.deepseek_v4 import (
+    AscendDeepseekV4ForCausalLM,
+    DeepseekV4Model,
+    _is_dspark_target_layer,
+)
+from vllm_ascend.models.deepseek_v4_draft import (
+    is_deepseek_v4_dspark_config,
+    remap_dspark_mtp_weight_name,
+)
+from vllm_ascend.patch.platform.patch_speculative_config import hf_config_override
+
+
+def _make_dspark_config() -> PretrainedConfig:
+    return PretrainedConfig(
+        model_type="deepseek_v4",
+        architectures=["DeepseekV4ForCausalLM"],
+        num_hidden_layers=43,
+        dspark_block_size=5,
+        dspark_noise_token_id=128799,
+        dspark_target_layer_ids=[40, 41, 42],
+    )
+
+
+def test_dspark_config_detection():
+    config = _make_dspark_config()
+
+    assert is_deepseek_v4_dspark_config(config)
+    assert not is_deepseek_v4_dspark_config(SimpleNamespace(model_type="deepseek_v4", dspark_block_size=0))
+
+
+def test_dspark_speculative_config_override_exposes_draft_contract():
+    config = hf_config_override(_make_dspark_config())
+
+    assert config.model_type == "deepseek_mtp"
+    assert config.architectures == ["DeepSeekV4DSparkMTPModel"]
+    assert not hasattr(config, "n_predict")
+    assert config.ptd_token_id == 128799
+    assert config.dspark_num_mtp_layers == 3
+    assert not hasattr(config, "eagle_aux_hidden_state_layer_ids")
+
+
+def test_non_dspark_deepseek_v4_keeps_existing_mtp_override():
+    config = PretrainedConfig(
+        model_type="deepseek_v4",
+        architectures=["DeepseekV4ForCausalLM"],
+        num_nextn_predict_layers=1,
+    )
+
+    overridden = hf_config_override(config)
+
+    assert overridden.architectures == ["DeepSeekV4MTPModel"]
+    assert not hasattr(overridden, "eagle_aux_hidden_state_layer_ids")
+
+
+@pytest.mark.parametrize(
+    ("source_name", "expected_name"),
+    [
+        ("mtp.0.main_proj.weight", "model.layers.43.main_proj.weight"),
+        ("mtp.0.main_norm.weight", "model.layers.43.main_norm.weight"),
+        ("mtp.0.attn.attn_sink", "model.layers.43.self_attn.attn_sink"),
+        ("mtp.0.attn.wq_a.weight", "model.layers.43.self_attn.wq_a.weight"),
+        (
+            "mtp.1.ffn.shared_experts.w1.weight",
+            "model.layers.44.mlp.shared_experts.gate_proj.weight",
+        ),
+        (
+            "mtp.1.ffn.shared_experts.w2.weight",
+            "model.layers.44.mlp.shared_experts.down_proj.weight",
+        ),
+        (
+            "mtp.1.ffn.shared_experts.w3.weight",
+            "model.layers.44.mlp.shared_experts.up_proj.weight",
+        ),
+        (
+            "mtp.1.ffn.gate.bias",
+            "model.layers.44.mlp.gate.e_score_correction_bias",
+        ),
+        ("mtp.2.hc_head_fn", "model.layers.45.hc_head_fn"),
+        (
+            "mtp.2.markov_head.markov_w2.weight",
+            "model.layers.45.markov_head.markov_w2.weight",
+        ),
+    ],
+)
+def test_remap_dspark_mtp_weight_name(source_name: str, expected_name: str):
+    assert remap_dspark_mtp_weight_name(source_name, num_hidden_layers=43) == expected_name
+
+
+def test_remap_dspark_mtp_weight_name_ignores_non_draft_weights():
+    assert remap_dspark_mtp_weight_name("model.layers.0.attn.wq_a.weight", 43) is None
+    assert remap_dspark_mtp_weight_name("mtp.2.confidence_head.proj.weight", 43) is None
+
+
+def test_dspark_target_hidden_states_use_dedicated_buffer():
+    wrapper = AscendDeepseekV4ForCausalLM.__new__(AscendDeepseekV4ForCausalLM)
+    nn.Module.__init__(wrapper)
+    model = DeepseekV4Model.__new__(DeepseekV4Model)
+    nn.Module.__init__(model)
+    model._mtp_hidden_buffer = torch.zeros((2, 16))
+    model._dspark_target_layer_ids = (40, 41, 42)
+    model._dspark_hidden_buffer = torch.ones((2, 12))
+    wrapper.model = model
+
+    assert wrapper.get_mtp_target_hidden_states() is model._dspark_hidden_buffer
+    model._dspark_target_layer_ids = ()
+    assert wrapper.get_mtp_target_hidden_states() is model._mtp_hidden_buffer
+
+
+def test_dspark_target_layer_ids_use_checkpoint_semantics():
+    target_layer_ids = {40, 41, 42}
+
+    assert not _is_dspark_target_layer(39, target_layer_ids)
+    assert _is_dspark_target_layer(40, target_layer_ids)
+    assert _is_dspark_target_layer(41, target_layer_ids)
+    assert _is_dspark_target_layer(42, target_layer_ids)

--- a/tests/ut/spec_decode/test_deepseek_v4_dspark_model.py
+++ b/tests/ut/spec_decode/test_deepseek_v4_dspark_model.py
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+import vllm_ascend.models.deepseek_v4_dspark as dspark_module
+from vllm_ascend.models.deepseek_v4_dspark import (
+    DeepseekV4DSparkModel,
+    DeepSeekV4DSparkMTP,
+    _apply_dspark_quarot_rotation,
+    _draft_quant_config,
+    _get_dspark_num_mtp_layers,
+    _load_dspark_quarot_rotation,
+)
+
+
+def test_dspark_quarot_load_and_apply(tmp_path):
+    rotation_path = tmp_path / "optional" / "quarot.safetensors"
+    rotation_path.parent.mkdir()
+    rotation = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    save_file({"global_rotation": rotation}, rotation_path)
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(model=str(tmp_path)),
+        quant_config=SimpleNamespace(
+            quant_description={
+                "optional": {"quarot": {"rotation_map": {"global_rotation": "optional/quarot.safetensors"}}}
+            }
+        ),
+    )
+
+    loaded = _load_dspark_quarot_rotation(vllm_config)
+
+    torch.testing.assert_close(loaded, rotation)
+    hidden_states = torch.tensor([[10.0, 20.0]])
+    torch.testing.assert_close(
+        _apply_dspark_quarot_rotation(hidden_states, loaded, transpose=False),
+        torch.tensor([[70.0, 100.0]]),
+    )
+    torch.testing.assert_close(
+        _apply_dspark_quarot_rotation(hidden_states, loaded, transpose=True),
+        torch.tensor([[50.0, 110.0]]),
+    )
+
+
+def test_dspark_quarot_requires_same_device():
+    with pytest.raises(RuntimeError, match="same device"):
+        _apply_dspark_quarot_rotation(
+            torch.ones(1, 2),
+            torch.empty(2, 2, device="meta"),
+            transpose=False,
+        )
+
+
+def test_dspark_draft_quant_config_and_layer_count():
+    quant_config = object()
+    draft_config = SimpleNamespace(dspark_mtp_dequantized_to_bf16=False)
+    vllm_config = SimpleNamespace(
+        quant_config=quant_config,
+        speculative_config=SimpleNamespace(draft_model_config=SimpleNamespace(hf_config=draft_config)),
+    )
+
+    assert _draft_quant_config(vllm_config) is quant_config
+    draft_config.dspark_mtp_dequantized_to_bf16 = True
+    assert _draft_quant_config(vllm_config) is None
+    assert _get_dspark_num_mtp_layers(SimpleNamespace(n_mtp_layers=4)) == 4
+    assert _get_dspark_num_mtp_layers(SimpleNamespace()) == 3
+
+
+def test_dspark_context_kv_uses_each_layer_cache(monkeypatch):
+    calls = []
+
+    class FakeProjection:
+        def __init__(self, offset):
+            self.offset = offset
+
+        def __call__(self, hidden_states):
+            return hidden_states + self.offset
+
+    def make_layer(name, offset):
+        return SimpleNamespace(
+            self_attn=SimpleNamespace(
+                wkv=FakeProjection(offset),
+                kv_norm=lambda value: value * 2,
+                head_dim=4,
+                nope_head_dim=2,
+                rotary_emb=SimpleNamespace(layername=name),
+                dsa_attn=SimpleNamespace(
+                    swa_cache_layer=SimpleNamespace(prefix=f"{name}.swa_cache", kv_cache=object()),
+                ),
+            )
+        )
+
+    layers = {
+        "43": make_layer("layer.43", 1),
+        "44": make_layer("layer.44", 2),
+    }
+    model = SimpleNamespace(
+        layers=layers,
+        combine_hidden_states=lambda hidden_states: hidden_states * 3,
+    )
+    monkeypatch.setattr(
+        dspark_module,
+        "get_cos_and_sin_dsa",
+        lambda _positions: (
+            {name: torch.ones(3, 2) for name in ("layer.43", "layer.44")},
+            {name: torch.zeros(3, 2) for name in ("layer.43", "layer.44")},
+        ),
+    )
+    monkeypatch.setattr(
+        torch.ops._C_ascend,
+        "inplace_partial_rotary_mul",
+        lambda *args, **kwargs: None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        dspark_module,
+        "_scatter_context_kv",
+        lambda cache, kv, slots: calls.append((cache, kv.clone(), slots)),
+    )
+    hidden_states = torch.arange(12, dtype=torch.float32).view(3, 4)
+    slot_mappings = [torch.tensor([1, 2, 3]), torch.tensor([4, 5, 6])]
+
+    DeepseekV4DSparkModel.precompute_and_store_context_kv(model, hidden_states, torch.tensor([5, 6, 7]), slot_mappings)
+
+    assert len(calls) == 2
+    torch.testing.assert_close(calls[0][1].squeeze(1), (hidden_states * 3 + 1) * 2)
+    torch.testing.assert_close(calls[1][1].squeeze(1), (hidden_states * 3 + 2) * 2)
+    assert calls[0][2] is slot_mappings[0]
+    assert calls[1][2] is slot_mappings[1]
+
+
+def test_dspark_context_kv_rejects_wrong_slot_mapping_count():
+    model = SimpleNamespace(layers={"43": object(), "44": object()})
+
+    with pytest.raises(ValueError, match="number of draft layers"):
+        DeepseekV4DSparkModel.precompute_and_store_context_kv(
+            model,
+            torch.ones(1, 4),
+            torch.tensor([0]),
+            [torch.tensor([0])],
+        )
+
+
+def test_dspark_context_kv_scatter_unwraps_cache(monkeypatch):
+    from vllm_ascend.device.device_op import DeviceOperator
+
+    calls = []
+    formatted_slots = torch.tensor([[0, 1], [1, 2]], dtype=torch.int64)
+    monkeypatch.setattr(
+        DeviceOperator,
+        "format_dsa_slot_mapping",
+        lambda slots, block_size: formatted_slots if block_size == 4 else None,
+    )
+    monkeypatch.setattr(
+        DeviceOperator,
+        "dsa_kv_compress_scatter",
+        lambda cache, kv, slots: calls.append((cache, kv, slots)),
+    )
+    cache = torch.empty(2, 4, 1, 3)
+    kv = torch.empty(1)
+    slots = torch.tensor([1, 6], dtype=torch.int64)
+
+    dspark_module._scatter_context_kv([[cache]], kv, slots)
+
+    assert calls == [(cache, kv, formatted_slots)]
+
+
+def test_dspark_declares_target_shared_embedding_and_lm_head():
+    assert DeepSeekV4DSparkMTP.has_own_embed_tokens is False
+    assert DeepSeekV4DSparkMTP.has_own_lm_head is False
+
+
+def test_dspark_load_weights_rejects_unmatched_mtp(monkeypatch):
+    monkeypatch.setattr(dspark_module, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(dspark_module, "get_tensor_model_parallel_rank", lambda: 0)
+    model = SimpleNamespace(
+        config=SimpleNamespace(num_hidden_layers=43, num_attention_heads=8, expert_dtype="fp4"),
+        model=SimpleNamespace(
+            num_dspark_layers=3,
+            get_expert_mapping=lambda: [],
+            finalize_mega_moe_weights=lambda: None,
+        ),
+        named_parameters=lambda: iter(()),
+    )
+
+    with pytest.raises(ValueError, match="model.layers.43.self_attn.q_norm"):
+        DeepSeekV4DSparkMTP.load_weights(cast(Any, model), [("mtp.0.attn.q_norm.weight", torch.ones(1))])
+
+
+def test_dspark_load_weights_skips_nonlocal_expert(monkeypatch):
+    monkeypatch.setattr(dspark_module, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(dspark_module, "get_tensor_model_parallel_rank", lambda: 0)
+
+    class NonlocalExpertParam:
+        def weight_loader(self, *args, **kwargs):
+            assert kwargs["return_success"] is True
+            return False
+
+    expert_name = "model.layers.43.mlp.experts.weight"
+    required_names = {
+        "model.layers.43.main_proj.weight",
+        "model.layers.43.main_norm.weight",
+        "model.layers.44.norm.weight",
+        "model.layers.45.norm.weight",
+        "model.hc_head_fn",
+        "model.hc_head_base",
+        "model.hc_head_scale",
+        "model.layers.45.markov_head.markov_w1.weight",
+        "model.layers.45.markov_head.markov_w2.weight",
+    }
+    params: dict[str, object] = {name: SimpleNamespace() for name in required_names}
+    params[expert_name] = NonlocalExpertParam()
+    model = SimpleNamespace(
+        config=SimpleNamespace(num_hidden_layers=43, num_attention_heads=8, expert_dtype="fp4"),
+        model=SimpleNamespace(
+            num_dspark_layers=3,
+            get_expert_mapping=lambda: [
+                (
+                    "model.layers.43.mlp.experts",
+                    "model.layers.43.mlp.experts.0.down_proj",
+                    0,
+                    "down_proj",
+                )
+            ],
+            finalize_mega_moe_weights=lambda: None,
+        ),
+        named_parameters=lambda: iter(params.items()),
+    )
+
+    class RequiredParam:
+        def weight_loader(self, *_args, **_kwargs):
+            return None
+
+    for name in required_names:
+        params[name] = RequiredParam()
+    weights = [
+        ("mtp.0.main_proj.weight", torch.ones(1)),
+        ("mtp.0.main_norm.weight", torch.ones(1)),
+        ("mtp.0.ffn.experts.0.w2.weight", torch.ones(1)),
+        ("mtp.1.norm.weight", torch.ones(1)),
+        ("mtp.2.norm.weight", torch.ones(1)),
+        ("mtp.2.hc_head_fn", torch.ones(1)),
+        ("mtp.2.hc_head_base", torch.ones(1)),
+        ("mtp.2.hc_head_scale", torch.ones(1)),
+        ("mtp.2.markov_head.markov_w1.weight", torch.ones(1)),
+        ("mtp.2.markov_head.markov_w2.weight", torch.ones(1)),
+    ]
+
+    loaded = DeepSeekV4DSparkMTP.load_weights(cast(Any, model), weights)
+
+    assert expert_name not in loaded
+
+
+def test_dspark_load_weights_stacks_shared_expert(monkeypatch):
+    monkeypatch.setattr(dspark_module, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(dspark_module, "get_tensor_model_parallel_rank", lambda: 0)
+    calls = []
+
+    class FakeParam:
+        def __init__(self, name):
+            self.name = name
+
+        def weight_loader(self, _param, weight, *args, **kwargs):
+            calls.append((self.name, weight.clone(), args, kwargs))
+            return True
+
+    param_names = {
+        "model.layers.43.main_proj.weight",
+        "model.layers.43.main_norm.weight",
+        "model.layers.44.mlp.shared_experts.gate_up_proj.weight",
+        "model.layers.45.norm.weight",
+        "model.hc_head_fn",
+        "model.hc_head_base",
+        "model.hc_head_scale",
+        "model.layers.45.markov_head.markov_w1.weight",
+        "model.layers.45.markov_head.markov_w2.weight",
+    }
+    params = {name: FakeParam(name) for name in param_names}
+    model = SimpleNamespace(
+        config=SimpleNamespace(num_hidden_layers=43, num_attention_heads=8, expert_dtype="fp4"),
+        model=SimpleNamespace(
+            num_dspark_layers=3,
+            get_expert_mapping=lambda: [],
+            finalize_mega_moe_weights=lambda: None,
+        ),
+        named_parameters=lambda: iter(params.items()),
+    )
+    weights = [
+        ("mtp.0.main_proj.weight", torch.ones(1)),
+        ("mtp.0.main_norm.weight", torch.ones(1)),
+        ("mtp.1.ffn.shared_experts.w1.weight", torch.ones(1)),
+        ("mtp.1.ffn.shared_experts.w3.weight", torch.ones(1) * 2),
+        ("mtp.2.norm.weight", torch.ones(1)),
+        ("mtp.2.hc_head_fn", torch.ones(1)),
+        ("mtp.2.hc_head_base", torch.ones(1)),
+        ("mtp.2.hc_head_scale", torch.ones(1)),
+        ("mtp.2.markov_head.markov_w1.weight", torch.ones(1)),
+        ("mtp.2.markov_head.markov_w2.weight", torch.ones(1)),
+    ]
+
+    loaded = DeepSeekV4DSparkMTP.load_weights(cast(Any, model), weights)
+
+    shared_name = "model.layers.44.mlp.shared_experts.gate_up_proj.weight"
+    assert shared_name in loaded
+    shared_calls = [call for call in calls if call[0] == shared_name]
+    assert [call[2] for call in shared_calls] == [(0,), (1,)]

--- a/tests/ut/spec_decode/test_dspark_dsa_metadata.py
+++ b/tests/ut/spec_decode/test_dspark_dsa_metadata.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+import torch
+
+import vllm_ascend.attention.context_parallel.dsa_cp as dsa_cp
+import vllm_ascend.attention.dsa_v1 as dsa_v1
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.dsa_window import (
+    build_dspark_swa_indices,
+    build_dspark_swa_metadata_for_drafting,
+)
+
+
+def _vllm_config(window_size: int = 7, query_block_size: int = 5) -> SimpleNamespace:
+    draft_hf_config = SimpleNamespace(dspark_block_size=query_block_size)
+    return SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(sliding_window=window_size, num_attention_heads=8),
+            get_head_size=lambda: 16,
+        ),
+        speculative_config=SimpleNamespace(
+            num_speculative_tokens=query_block_size,
+            draft_model_config=SimpleNamespace(hf_config=draft_hf_config),
+        ),
+    )
+
+
+def _metadata(*, causal: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        query_start_loc=torch.tensor([0, 5], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 5], dtype=torch.int32),
+        seq_lens=torch.tensor([15], dtype=torch.int32),
+        _seq_lens_cpu=torch.tensor([15], dtype=torch.int32),
+        seq_lens_cpu=None,
+        positions=torch.arange(10, 15, dtype=torch.int32),
+        block_table_tensor=torch.tensor([[10, 11, 12]], dtype=torch.int32),
+        num_reqs=1,
+        num_input_tokens=5,
+        num_actual_tokens=5,
+        causal=causal,
+        attn_state=AscendAttentionState.SpecDecoding,
+    )
+
+
+def _physical_slots(block_table: torch.Tensor, req_idx: int, start: int, end: int) -> torch.Tensor:
+    return torch.tensor(
+        [int(block_table[req_idx, position // 64]) * 64 + position % 64 for position in range(start, end)],
+        dtype=torch.int32,
+    )
+
+
+def test_noncausal_draft_uses_explicit_full_block_visibility():
+    common_metadata = _metadata()
+    win_left, win_right, indices, lens = build_dspark_swa_metadata_for_drafting(
+        _vllm_config(),
+        common_metadata,
+        torch.arange(5, dtype=torch.int32),
+        cache_block_size=64,
+    )
+
+    assert (win_left, win_right) == (11, 0)
+    assert indices is not None and lens is not None
+    assert indices.shape == (5, 1, 128)
+    torch.testing.assert_close(lens, torch.full((5,), 12, dtype=torch.int32))
+    expected = _physical_slots(common_metadata.block_table_tensor, 0, 3, 15)
+    for row in range(5):
+        torch.testing.assert_close(indices[row, 0, :12], expected)
+        assert torch.all(indices[row, 0, 12:] == -1)
+
+
+def test_causal_draft_preserves_standard_window():
+    win_left, win_right, indices, lens = build_dspark_swa_metadata_for_drafting(
+        _vllm_config(),
+        _metadata(causal=True),
+        torch.arange(5, dtype=torch.int32),
+        cache_block_size=64,
+    )
+
+    assert (win_left, win_right) == (6, 0)
+    assert indices is None
+    assert lens is None
+
+
+def test_sparse_indices_cover_token_mapping_zero_length_and_padding():
+    block_table = torch.tensor([[10], [-1], [20]], dtype=torch.int32)
+    indices, lens = build_dspark_swa_indices(
+        block_table=block_table,
+        slot_mapping=torch.tensor([0, 1, 2, 3, -1], dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 2, 2, 4], dtype=torch.int32),
+        seq_lens=torch.tensor([12, 0, 22], dtype=torch.int32),
+        query_block_size=2,
+        window_size=4,
+        cache_block_size=64,
+        num_query_tokens=5,
+        token_to_req_indices=torch.tensor([0, 2, 0, 2, -1], dtype=torch.int32),
+    )
+
+    torch.testing.assert_close(lens, torch.tensor([6, 6, 6, 6, 0], dtype=torch.int32))
+    expected_req0 = _physical_slots(block_table, 0, 6, 12)
+    expected_req2 = _physical_slots(block_table, 2, 16, 22)
+    for row in (0, 2):
+        torch.testing.assert_close(indices[row, 0, :6], expected_req0)
+    for row in (1, 3):
+        torch.testing.assert_close(indices[row, 0, :6], expected_req2)
+    assert torch.all(indices[4] == -1)
+
+
+def test_sparse_indices_map_request_boundary_to_next_request():
+    block_table = torch.tensor([[10], [20]], dtype=torch.int32)
+    indices, lens = build_dspark_swa_indices(
+        block_table=block_table,
+        slot_mapping=torch.arange(4, dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 2, 4], dtype=torch.int32),
+        seq_lens=torch.tensor([12, 22], dtype=torch.int32),
+        query_block_size=2,
+        window_size=4,
+        cache_block_size=64,
+        num_query_tokens=4,
+    )
+
+    torch.testing.assert_close(lens, torch.full((4,), 6, dtype=torch.int32))
+    expected_req0 = _physical_slots(block_table, 0, 6, 12)
+    expected_req1 = _physical_slots(block_table, 1, 16, 22)
+    for row in (0, 1):
+        torch.testing.assert_close(indices[row, 0, :6], expected_req0)
+    for row in (2, 3):
+        torch.testing.assert_close(indices[row, 0, :6], expected_req1)
+
+
+def test_sparse_indices_reject_incomplete_token_mapping():
+    with pytest.raises(ValueError, match="token_to_req_indices"):
+        build_dspark_swa_indices(
+            block_table=torch.tensor([[0]], dtype=torch.int32),
+            slot_mapping=None,
+            query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+            seq_lens=torch.tensor([2], dtype=torch.int32),
+            query_block_size=2,
+            window_size=4,
+            cache_block_size=64,
+            num_query_tokens=2,
+            token_to_req_indices=torch.tensor([0], dtype=torch.int32),
+        )
+
+
+def _patch_metadata_ops(monkeypatch, module, captured):
+    monkeypatch.setattr(
+        module,
+        "get_cos_and_sin_dsa",
+        lambda positions, use_cache=False, draft_index=None: (
+            torch.zeros(positions.numel(), 1),
+            torch.zeros(positions.numel(), 1),
+        ),
+    )
+
+    def metadata_op(**kwargs):
+        captured.update(kwargs)
+        return torch.ones(1024, dtype=torch.int32)
+
+    monkeypatch.setattr(module.DeviceOperator, "get_dsa_sparse_attn_metadata_op", lambda: metadata_op)
+    monkeypatch.setattr(module.DeviceOperator, "get_dsa_sparse_attn_metadata_kwargs", lambda _device: {})
+
+
+def test_dsa_builder_propagates_shared_metadata(monkeypatch):
+    captured: dict[str, Any] = {}
+    _patch_metadata_ops(monkeypatch, dsa_v1, captured)
+    monkeypatch.setattr(dsa_v1, "get_tensor_model_parallel_world_size", lambda: 1)
+    config = _vllm_config()
+    builder = SimpleNamespace(
+        model_config=config.model_config,
+        vllm_config=config,
+        spec_slot_mapping=[torch.arange(5, dtype=torch.int32)],
+        spec_sas_metadata=[torch.zeros(1024, dtype=torch.int32)],
+        block_size=64,
+        seqused_q=torch.empty(0, dtype=torch.int32),
+        cu_seqlens_ori_kv=torch.empty(0, dtype=torch.int32),
+        cu_seqlens_cmp_kv=torch.empty(0, dtype=torch.int32),
+    )
+
+    result = dsa_v1.AscendDSAMetadataBuilder.build_decode_metadata_for_drafting(
+        cast(Any, builder),
+        draft_index=1,
+        common_attn_metadata=_metadata(),
+        num_decodes=1,
+        num_decode_tokens=5,
+    )
+
+    assert captured["ori_win_left"] == result.ori_win_left == 11
+    assert captured["ori_win_right"] == result.ori_win_right == 0
+    assert result.dspark_swa_indices is not None
+    torch.testing.assert_close(result.dspark_swa_lens, torch.full((5,), 12, dtype=torch.int32))
+
+
+def test_dsa_cp_builder_propagates_shared_metadata(monkeypatch):
+    captured: dict[str, Any] = {}
+    _patch_metadata_ops(monkeypatch, dsa_cp, captured)
+    monkeypatch.setattr(
+        dsa_cp.DeviceOperator,
+        "get_dsa_decode_cu_seqlens_ori_kv",
+        lambda *args, **kwargs: torch.tensor([0, 5], dtype=torch.int32),
+    )
+    monkeypatch.setattr(
+        dsa_cp.DeviceOperator,
+        "get_dsa_decode_cu_seqlens_cmp_kv",
+        lambda *args, **kwargs: torch.empty(0, dtype=torch.int32),
+    )
+    config = _vllm_config()
+    common_metadata = _metadata()
+
+    def local_metadata(**kwargs):
+        num_reqs = kwargs["num_reqs"]
+        return (
+            3,
+            6,
+            3,
+            6,
+            torch.tensor([0, 2], dtype=torch.int32),
+            kwargs["seq_lens"][:num_reqs],
+            torch.zeros(3, 1),
+            torch.zeros(3, 1),
+        )
+
+    builder = SimpleNamespace(
+        model_config=config.model_config,
+        vllm_config=config,
+        seq_lens=common_metadata.seq_lens,
+        seq_lens_cpu=common_metadata._seq_lens_cpu,
+        num_actual_tokens=5,
+        spec_slot_mapping=[torch.arange(5, dtype=torch.int32)],
+        block_table=common_metadata.block_table_tensor,
+        block_size=64,
+        spec_local_query_start_loc=[torch.zeros(2, dtype=torch.int32)],
+        spec_local_seq_lens=[torch.zeros(1, dtype=torch.int32)],
+        seqused_q=torch.empty(0, dtype=torch.int32),
+        cu_seqlens_ori_kv=torch.empty(0, dtype=torch.int32),
+        cu_seqlens_cmp_kv=torch.empty(0, dtype=torch.int32),
+        _zero_i32=torch.tensor([0], dtype=torch.int32),
+        _build_local_token_metadata=local_metadata,
+    )
+
+    result = dsa_cp.AscendDSACPMetadataBuilder.build_req_metadata_for_drafting(
+        cast(Any, builder),
+        draft_index=1,
+        common_attn_metadata=common_metadata,
+        input_positions=common_metadata.positions.long(),
+        num_input_tokens=5,
+    )
+
+    assert captured["ori_win_left"] == result.ori_win_left == 11
+    assert captured["ori_win_right"] == result.ori_win_right == 0
+    assert result.dspark_swa_indices is not None
+    assert result.dspark_swa_indices.shape == (3, 1, 128)
+    torch.testing.assert_close(result.dspark_swa_lens, torch.tensor([12, 12, 0], dtype=torch.int32))
+    assert torch.all(result.dspark_swa_indices[-1] == -1)

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -110,3 +110,26 @@ class TestDisablePaddedDrafterBatchWithFullGraph:
         )
 
         proposer._raise_if_padded_drafter_batch_disabled_and_full_graph_enabled()
+
+
+def test_mtp_without_own_lm_head_shares_target_head():
+    proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
+    draft_head = object()
+    target_head = object()
+    proposer.method = "mtp"
+    proposer.model = SimpleNamespace(
+        has_own_lm_head=False,
+        lm_head=draft_head,
+        model=SimpleNamespace(layers={"43": SimpleNamespace()}),
+    )
+    proposer.vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(is_deepseek_mla=True),
+        compilation_config=SimpleNamespace(cudagraph_mode=CUDAGraphMode.NONE),
+    )
+    proposer.use_cuda_graph = False
+    proposer.use_eagle = False
+    proposer.enable_enpu = False
+
+    proposer._maybe_share_lm_head(SimpleNamespace(lm_head=target_head))
+
+    assert proposer.model.lm_head is target_head

--- a/typos.toml
+++ b/typos.toml
@@ -51,6 +51,7 @@ tme = "tme"
 dout = "dout"
 Pn = "Pn"
 arange = "arange"
+ptd = "ptd"
 
 [type.py]
 extend-glob = []

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -13,6 +13,7 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 
 from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.dsa_window import build_dspark_swa_metadata_for_drafting
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
@@ -98,6 +99,10 @@ class AscendDSAReqMetadata:
     qli_metadata: torch.Tensor = None
     cu_cmp_seqlen_list: torch.Tensor = None
     attn_mask: torch.Tensor | None = None
+    ori_win_left: int | None = None
+    ori_win_right: int | None = None
+    dspark_swa_indices: torch.Tensor | None = None
+    dspark_swa_lens: torch.Tensor | None = None
 
 
 @dataclass
@@ -469,6 +474,21 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
         assert self.spec_slot_mapping is not None
         slot_mapping = self.spec_slot_mapping[draft_index - 1][: self.num_actual_tokens]
+        ori_win_left, ori_win_right, dspark_swa_indices, dspark_swa_lens = build_dspark_swa_metadata_for_drafting(
+            self.vllm_config,
+            common_attn_metadata,
+            self.spec_slot_mapping[draft_index - 1],
+            self.block_size,
+        )
+        if dspark_swa_indices is not None:
+            if dspark_swa_lens is None:
+                raise ValueError("DSpark SWA indices require matching lengths")
+            pad_tokens = num_tokens_pad - dspark_swa_indices.shape[0]
+            if pad_tokens > 0:
+                dspark_swa_indices = F.pad(dspark_swa_indices, (0, 0, 0, 0, 0, pad_tokens), value=-1)
+                dspark_swa_lens = F.pad(dspark_swa_lens, (0, pad_tokens), value=0)
+            dspark_swa_indices = dspark_swa_indices[local_start:local_end_with_pad]
+            dspark_swa_lens = dspark_swa_lens[local_start:local_end_with_pad]
 
         num_heads = self.model_config.hf_config.num_attention_heads
         metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
@@ -504,8 +524,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             batch_size=num_reqs,
             cmp_ratio=1,
             ori_mask_mode=4,
-            ori_win_left=self.model_config.hf_config.sliding_window - 1,
-            ori_win_right=0,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
             layout_q="TND",
             layout_kv="PA_ND",
             has_ori_kv=True,
@@ -537,6 +557,10 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             sas_metadata=sas_metadata,
             qli_metadata=None,
             cu_cmp_seqlen_list=None,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
+            dspark_swa_indices=dspark_swa_indices,
+            dspark_swa_lens=dspark_swa_lens,
         )
 
     def _num_compressor_metadata_rows(
@@ -1431,6 +1455,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 extra_attn_kwargs, cu_seqlens_ori_kv=local_seq_lengths_query
             )
 
+        ori_win_left = self.window_size - 1 if req_metadata.ori_win_left is None else req_metadata.ori_win_left
         common_attn_kwargs = dict(
             cu_seqlens_q=local_seq_lengths_query,
             seqused_kv=local_seq_lengths_key,
@@ -1438,14 +1463,15 @@ class AscendDSACPImpl(DSAAttentionImpl):
             softmax_scale=self.softmax_scale,
             cmp_ratio=max(self.compress_ratio, 1),
             ori_mask_mode=4,
-            ori_win_left=self.window_size - 1,
-            ori_win_right=0,
+            ori_win_left=ori_win_left,
+            ori_win_right=req_metadata.ori_win_right or 0,
             layout_q="TND",
             layout_kv="PA_ND",
             **extra_attn_kwargs,
         )
 
         if self.compress_ratio <= 1:
+            common_attn_kwargs["ori_sparse_indices"] = req_metadata.dspark_swa_indices
             attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -18,6 +18,7 @@ from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.dsa_window import build_dspark_swa_metadata_for_drafting
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
@@ -251,6 +252,10 @@ class AscendDSAPrefillMetadata:
     qli_metadata: torch.Tensor = None
     cu_c4_cmp_seqlen_list: torch.Tensor = None
     cu_c128_cmp_seqlen_list: torch.Tensor = None
+    ori_win_left: int | None = None
+    ori_win_right: int | None = None
+    dspark_swa_indices: torch.Tensor | None = None
+    dspark_swa_lens: torch.Tensor | None = None
 
 
 @dataclass
@@ -281,6 +286,10 @@ class AscendDSADecodeMetadata:
     num_reqs_actual: int | None = None
     sas_metadata: torch.Tensor = None
     qli_metadata: torch.Tensor = None
+    ori_win_left: int | None = None
+    ori_win_right: int | None = None
+    dspark_swa_indices: torch.Tensor | None = None
+    dspark_swa_lens: torch.Tensor | None = None
 
 
 @dataclass
@@ -1173,6 +1182,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         reqs_start = kwargs.get("reqs_start")
         tokens_start = kwargs.get("tokens_start")
         num_prefill_tokens = kwargs.get("num_prefill_tokens")
+        if reqs_start is None or tokens_start is None or num_prefill_tokens is None:
+            raise ValueError("DSA draft prefill metadata requires request and token ranges")
         query_start_loc = common_attn_metadata.query_start_loc
         prefill_query_start_loc = query_start_loc[reqs_start:] - query_start_loc[reqs_start]
         seq_lens_q = prefill_query_start_loc[1:] - prefill_query_start_loc[:-1]
@@ -1183,7 +1194,20 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         prefill_input_positions = input_positions[tokens_start:]
         cos, sin = get_cos_and_sin_dsa(prefill_input_positions)
 
-        prefill_slot_mapping = self.spec_slot_mapping[draft_index - 1][tokens_start:num_prefill_tokens]  # type: ignore[index]
+        prefill_slot_mapping = self.spec_slot_mapping[  # type: ignore[index]
+            draft_index - 1
+        ][tokens_start : tokens_start + num_prefill_tokens]
+        ori_win_left, ori_win_right, dspark_swa_indices, dspark_swa_lens = build_dspark_swa_metadata_for_drafting(
+            self.vllm_config,
+            common_attn_metadata,
+            self.spec_slot_mapping[draft_index - 1],  # type: ignore[index]
+            self.block_size,
+        )
+        if dspark_swa_indices is not None:
+            if dspark_swa_lens is None:
+                raise ValueError("DSpark SWA indices require matching lengths")
+            dspark_swa_indices = dspark_swa_indices[tokens_start : tokens_start + num_prefill_tokens]
+            dspark_swa_lens = dspark_swa_lens[tokens_start : tokens_start + num_prefill_tokens]
         block_table = common_attn_metadata.block_table_tensor[: common_attn_metadata.num_reqs]
 
         metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
@@ -1203,8 +1227,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             batch_size=len(seq_lens),
             cmp_ratio=1,
             ori_mask_mode=4,
-            ori_win_left=self.model_config.hf_config.sliding_window - 1,
-            ori_win_right=0,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
             layout_q="TND",
             layout_kv="PA_ND",
             has_ori_kv=True,
@@ -1230,6 +1254,10 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             qli_metadata=None,
             cu_c4_cmp_seqlen_list=None,
             cu_c128_cmp_seqlen_list=None,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
+            dspark_swa_indices=dspark_swa_indices,
+            dspark_swa_lens=dspark_swa_lens,
         )
 
     def build_decode_metadata_for_drafting(
@@ -1264,6 +1292,17 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=True, draft_index=draft_index)
 
         slot_mapping = self.spec_slot_mapping[draft_index - 1][:num_decode_tokens_typed]  # type: ignore[index]
+        ori_win_left, ori_win_right, dspark_swa_indices, dspark_swa_lens = build_dspark_swa_metadata_for_drafting(
+            self.vllm_config,
+            common_attn_metadata,
+            slot_mapping,
+            self.block_size,
+        )
+        if dspark_swa_indices is not None:
+            if dspark_swa_lens is None:
+                raise ValueError("DSpark SWA indices require matching lengths")
+            dspark_swa_indices = dspark_swa_indices[:num_decode_tokens_typed]
+            dspark_swa_lens = dspark_swa_lens[:num_decode_tokens_typed]
         block_table = common_attn_metadata.block_table_tensor
 
         metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
@@ -1285,8 +1324,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             cmp_ratio=1,
             ori_mask_mode=4,
             cmp_mask_mode=3,
-            ori_win_left=self.model_config.hf_config.sliding_window - 1,
-            ori_win_right=0,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
             layout_q="TND",
             layout_kv="PA_ND",
             has_ori_kv=True,
@@ -1315,6 +1354,10 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             start_pos=None,
             sas_metadata=decode_sas_metadata,
             qli_metadata=None,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
+            dspark_swa_indices=dspark_swa_indices,
+            dspark_swa_lens=dspark_swa_lens,
         )
         return decode_metadata
 
@@ -1691,6 +1734,8 @@ class AscendDSAImpl(DSAAttentionImpl):
         decode_hidden_states = hidden_states[:decode_tokens]
 
         o_proj_input = torch.empty(o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device)
+        if actual_tokens < o_proj_input_shape[0]:
+            o_proj_input[actual_tokens:].zero_()
         assert kv_cache is not None, "kv_cache tensor tuple must be provided."
         if has_prefill:
             assert attn_metadata[0].prefill is not None
@@ -1937,9 +1982,15 @@ class AscendDSAImpl(DSAAttentionImpl):
         DeviceOperator.add_dsa_sparse_attn_extra_kwargs(extra_attn_kwargs, cu_seqlens_ori_kv=actual_seq_lengths_query)
 
         if self.compress_ratio <= 1:
+            ori_win_left = (
+                self.window_size - 1
+                if common_prefill_metadata.ori_win_left is None
+                else common_prefill_metadata.ori_win_left
+            )
             return attn_op(
                 q,
                 ori_kv=swa_kv_cache,
+                ori_sparse_indices=common_prefill_metadata.dspark_swa_indices,
                 ori_block_table=swa_prefill_metadata.block_table,
                 cu_seqlens_q=actual_seq_lengths_query,
                 seqused_kv=actual_seq_lengths_key,
@@ -1948,8 +1999,8 @@ class AscendDSAImpl(DSAAttentionImpl):
                 softmax_scale=self.softmax_scale,
                 cmp_ratio=max(self.compress_ratio, 1),
                 ori_mask_mode=4,
-                ori_win_left=self.window_size - 1,
-                ori_win_right=0,
+                ori_win_left=ori_win_left,
+                ori_win_right=common_prefill_metadata.ori_win_right or 0,
                 layout_q="TND",
                 layout_kv="PA_ND",
                 **extra_attn_kwargs,
@@ -2369,9 +2420,13 @@ class AscendDSAImpl(DSAAttentionImpl):
         extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
 
         if self.compress_ratio <= 1:
+            ori_win_left = (
+                self.window_size - 1 if swa_decode_metadata.ori_win_left is None else swa_decode_metadata.ori_win_left
+            )
             attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,
+                ori_sparse_indices=swa_decode_metadata.dspark_swa_indices,
                 ori_block_table=swa_decode_metadata.block_table,
                 cu_seqlens_q=actual_seq_lengths_query,
                 seqused_kv=actual_seq_lengths_key,
@@ -2380,8 +2435,8 @@ class AscendDSAImpl(DSAAttentionImpl):
                 softmax_scale=self.softmax_scale,
                 cmp_ratio=max(self.compress_ratio, 1),
                 ori_mask_mode=4,
-                ori_win_left=self.window_size - 1,
-                ori_win_right=0,
+                ori_win_left=ori_win_left,
+                ori_win_right=swa_decode_metadata.ori_win_right or 0,
                 layout_q="TND",
                 layout_kv="PA_ND",
                 **extra_attn_kwargs,

--- a/vllm_ascend/attention/dsa_window.py
+++ b/vllm_ascend/attention/dsa_window.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+import torch
+
+
+def _get_dspark_draft_hf_config(vllm_config: Any) -> Any | None:
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    draft_model_config = getattr(speculative_config, "draft_model_config", None)
+    return getattr(draft_model_config, "hf_config", None)
+
+
+def get_dspark_query_block_size(vllm_config: Any) -> int:
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    num_speculative_tokens = getattr(speculative_config, "num_speculative_tokens", None)
+    if num_speculative_tokens:
+        return int(num_speculative_tokens)
+
+    draft_hf_config = _get_dspark_draft_hf_config(vllm_config)
+    return int(getattr(draft_hf_config, "dspark_block_size", 0) or 0)
+
+
+def is_dspark_noncausal_draft(vllm_config: Any, common_attn_metadata: Any) -> bool:
+    if getattr(common_attn_metadata, "causal", True):
+        return False
+
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    use_dspark = getattr(speculative_config, "use_dspark", None)
+    if callable(use_dspark):
+        return bool(use_dspark())
+
+    draft_hf_config = _get_dspark_draft_hf_config(vllm_config)
+    return bool(getattr(draft_hf_config, "dspark_block_size", 0))
+
+
+def get_draft_swa_window(vllm_config: Any) -> tuple[int, int]:
+    window_size = int(vllm_config.model_config.hf_config.sliding_window)
+    return window_size - 1, 0
+
+
+def get_dspark_sparse_sas_window(vllm_config: Any) -> tuple[int, int]:
+    window_size = int(vllm_config.model_config.hf_config.sliding_window)
+    query_block_size = get_dspark_query_block_size(vllm_config)
+    return window_size + query_block_size - 1, 0
+
+
+def _valid_slot_rows(slot_mapping: torch.Tensor) -> torch.Tensor:
+    if slot_mapping.ndim == 1:
+        return slot_mapping >= 0
+    return torch.all(slot_mapping >= 0, dim=-1)
+
+
+def _aligned_index_width(window_size: int, query_block_size: int) -> int:
+    visible_upper_bound = window_size + query_block_size
+    return ((visible_upper_bound + 127) // 128) * 128
+
+
+def build_dspark_swa_indices(
+    block_table: torch.Tensor,
+    slot_mapping: torch.Tensor | None,
+    query_start_loc: torch.Tensor,
+    seq_lens: torch.Tensor,
+    query_block_size: int,
+    window_size: int,
+    cache_block_size: int,
+    num_query_tokens: int,
+    token_to_req_indices: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build physical slots for history-window plus full draft-block visibility."""
+    index_width = _aligned_index_width(window_size, query_block_size)
+    device = block_table.device
+    indices = torch.full((num_query_tokens, 1, index_width), -1, dtype=torch.int32, device=device)
+    lens = torch.zeros(num_query_tokens, dtype=torch.int32, device=device)
+    if num_query_tokens == 0:
+        return indices, lens
+    if slot_mapping is not None and slot_mapping.shape[0] < num_query_tokens:
+        raise ValueError("DSpark SWA slot_mapping must cover every query token")
+    if token_to_req_indices is not None and token_to_req_indices.numel() < num_query_tokens:
+        raise ValueError("DSpark SWA token_to_req_indices must cover every query token")
+
+    num_reqs = min(max(query_start_loc.numel() - 1, 0), block_table.shape[0], seq_lens.numel())
+    if num_reqs == 0 or block_table.shape[1] == 0:
+        return indices, lens
+
+    query_start_loc = query_start_loc[: num_reqs + 1].to(device=device, dtype=torch.long)
+    query_lens = query_start_loc[1:] - query_start_loc[:-1]
+    seq_lens = seq_lens[:num_reqs].to(device=device, dtype=torch.long)
+    visible_starts = torch.clamp(seq_lens - query_lens - window_size, min=0)
+    visible_lens = torch.clamp(seq_lens - visible_starts, min=0, max=index_width)
+
+    offsets = torch.arange(index_width, dtype=torch.long, device=device)
+    visible_positions = visible_starts[:, None] + offsets[None, :]
+    visible_mask = offsets[None, :] < visible_lens[:, None]
+    logical_blocks = torch.div(visible_positions, cache_block_size, rounding_mode="floor")
+    logical_blocks = logical_blocks.clamp(max=block_table.shape[1] - 1)
+    physical_blocks = block_table[:num_reqs].to(device=device, dtype=torch.long).gather(1, logical_blocks)
+    physical_slots = physical_blocks * cache_block_size + visible_positions % cache_block_size
+    physical_slots.masked_fill_(~visible_mask, -1)
+
+    if token_to_req_indices is None:
+        token_rows = torch.arange(num_query_tokens, dtype=torch.long, device=device)
+        token_to_req = torch.bucketize(token_rows, query_start_loc[1:], right=True)
+    else:
+        token_to_req = token_to_req_indices[:num_query_tokens].to(device=device, dtype=torch.long)
+
+    valid_rows = (token_to_req >= 0) & (token_to_req < num_reqs)
+    if slot_mapping is not None:
+        valid_rows &= _valid_slot_rows(slot_mapping[:num_query_tokens].to(device=device))
+    row_requests = token_to_req.clamp(0, num_reqs - 1)
+    indices[:, 0] = physical_slots.index_select(0, row_requests).to(torch.int32)
+    lens.copy_(visible_lens.index_select(0, row_requests).to(torch.int32))
+    indices.masked_fill_(~valid_rows[:, None, None], -1)
+    lens.masked_fill_(~valid_rows, 0)
+    return indices, lens
+
+
+def build_dspark_swa_metadata_for_drafting(
+    vllm_config: Any,
+    common_attn_metadata: Any,
+    slot_mapping: torch.Tensor | None,
+    cache_block_size: int,
+) -> tuple[int, int, torch.Tensor | None, torch.Tensor | None]:
+    if not is_dspark_noncausal_draft(vllm_config, common_attn_metadata):
+        ori_win_left, ori_win_right = get_draft_swa_window(vllm_config)
+        return ori_win_left, ori_win_right, None, None
+
+    num_reqs = int(getattr(common_attn_metadata, "num_reqs", 0) or 0)
+    num_query_tokens = int(getattr(common_attn_metadata, "num_input_tokens", 0) or 0)
+    if num_query_tokens == 0:
+        num_query_tokens = int(getattr(common_attn_metadata, "num_actual_tokens", 0) or 0)
+    query_block_size = get_dspark_query_block_size(vllm_config)
+    if query_block_size <= 0:
+        raise ValueError("DSpark noncausal drafting requires a positive query block size")
+    block_table = getattr(common_attn_metadata, "block_table_tensor", None)
+    if block_table is None:
+        raise ValueError("DSpark noncausal drafting requires a paged SWA block table")
+    indices, lens = build_dspark_swa_indices(
+        block_table[:num_reqs],
+        slot_mapping,
+        common_attn_metadata.query_start_loc[: num_reqs + 1],
+        common_attn_metadata.seq_lens[:num_reqs],
+        query_block_size,
+        int(vllm_config.model_config.hf_config.sliding_window),
+        int(cache_block_size),
+        num_query_tokens,
+        getattr(common_attn_metadata, "token_to_req_indices", None),
+    )
+    ori_win_left, ori_win_right = get_dspark_sparse_sas_window(vllm_config)
+    return ori_win_left, ori_win_right, indices, lens

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -6,5 +6,9 @@ def register_model():
 
     ModelRegistry.register_model("DeepSeekV4MTPModel", "vllm_ascend.models.deepseek_v4_mtp:DeepSeekV4MTP")
     ModelRegistry.register_model(
+        "DeepSeekV4DSparkMTPModel",
+        "vllm_ascend.models.deepseek_v4_dspark:DeepSeekV4DSparkMTP",
+    )
+    ModelRegistry.register_model(
         "LlamaForCausalLMVwnEagle3", "vllm_ascend.models.llama_eagle3_vwn:Eagle3VwnLlamaForCausalLM"
     )

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -56,7 +56,12 @@ from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead, VocabParallelEmbedding
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader, maybe_remap_kv_scale_name
-from vllm.model_executor.models.interfaces import MixtureOfExperts, SupportsEagle, SupportsLoRA, SupportsPP
+from vllm.model_executor.models.interfaces import (
+    MixtureOfExperts,
+    SupportsEagle,
+    SupportsLoRA,
+    SupportsPP,
+)
 from vllm.model_executor.models.utils import (
     PPMissingLayer,
     is_pp_missing_parameter,
@@ -88,6 +93,10 @@ from vllm_ascend.utils import (
 
 if not vllm_version_is("0.23.0"):
     from vllm.model_executor.layers.fused_moe import fused_moe_make_expert_params_mapping
+
+
+def _is_dspark_target_layer(layer_idx: int, target_layer_ids: set[int]) -> bool:
+    return layer_idx in target_layer_ids
 
 
 def _get_ascend_dsa_backend():
@@ -1085,6 +1094,14 @@ class DeepseekV4Model(nn.Module):
             dtype=vllm_config.model_config.dtype,
             device=self.device,
         )
+        self._dspark_target_layer_ids = tuple(getattr(config, "dspark_target_layer_ids", ()) or ())
+        if self._dspark_target_layer_ids:
+            self._dspark_hidden_buffer = torch.empty(
+                vllm_config.scheduler_config.max_num_batched_tokens,
+                len(self._dspark_target_layer_ids) * config.hidden_size,
+                dtype=vllm_config.model_config.dtype,
+                device=self.device,
+            )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
@@ -1130,8 +1147,12 @@ class DeepseekV4Model(nn.Module):
 
         if get_pp_group().is_first_rank:
             hidden_states = hidden_states.unsqueeze(1).repeat(1, self.hc_mult, 1)  # (b, s, h) -> (b, s, c, h)
+        dspark_hidden_states: list[torch.Tensor] = []
+        dspark_target_layer_ids = set(self._dspark_target_layer_ids)
         for layer in islice(self.layers, self.start_layer, self.end_layer):
             hidden_states, residual = layer(positions, hidden_states, residual, llama_4_scaling)
+            if _is_dspark_target_layer(layer.layer_idx, dspark_target_layer_ids):
+                dspark_hidden_states.append(hidden_states.mean(dim=1))
 
         # Stash pre-hc_head residual for the MTP draft (captured copy_).
         # When FlashComm1 (sequence parallelism) is enabled, tokens are
@@ -1153,6 +1174,14 @@ class DeepseekV4Model(nn.Module):
         else:
             num_tokens = hidden_states.shape[0]
             self._mtp_hidden_buffer[:num_tokens].copy_(hidden_states.flatten(1))
+
+        if dspark_hidden_states:
+            dspark_states = torch.cat(dspark_hidden_states, dim=-1)
+            if forward_ctx is not None and forward_ctx.flash_comm_v1_enabled:
+                dspark_states = tensor_model_parallel_all_gather(dspark_states, dim=0)
+                if forward_ctx.pad_size > 0:
+                    dspark_states = dspark_states[: -forward_ctx.pad_size]
+            self._dspark_hidden_buffer[: dspark_states.shape[0]].copy_(dspark_states)
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
@@ -1207,7 +1236,13 @@ class DeepseekV2MixtureOfExperts(MixtureOfExperts):
             moe.experts.update_expert_map()
 
 
-class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExperts, SupportsLoRA, SupportsEagle):
+class AscendDeepseekV4ForCausalLM(
+    nn.Module,
+    SupportsPP,
+    SupportsEagle,
+    DeepseekV2MixtureOfExperts,
+    SupportsLoRA,
+):
     packed_modules_mapping = {
         "gate_up_proj": ["gate_proj", "up_proj"],
     }
@@ -1305,6 +1340,8 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
         """Pre-hc_head residual stream buffer (max_num_batched_tokens,
         hc_mult * hidden_size) for the MTP draft model. Populated by
         forward(); valid after each target step."""
+        if self.model._dspark_target_layer_ids:
+            return self.model._dspark_hidden_buffer
         return getattr(self.model, "_mtp_hidden_buffer", None)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:

--- a/vllm_ascend/models/deepseek_v4_draft.py
+++ b/vllm_ascend/models/deepseek_v4_draft.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+import regex as re
+
+_MTP_WEIGHT_RE = re.compile(r"^mtp\.(\d+)\.(.+)$")
+
+
+def is_deepseek_v4_dspark_config(config: Any) -> bool:
+    return config.model_type == "deepseek_v4" and int(getattr(config, "dspark_block_size", 0) or 0) > 0
+
+
+def remap_dspark_mtp_weight_name(name: str, num_hidden_layers: int) -> str | None:
+    """Map a DeepSeek V4 checkpoint MTP name to the draft runtime layer."""
+    match = _MTP_WEIGHT_RE.match(name)
+    if match is None:
+        return None
+
+    stage_idx = int(match.group(1))
+    rest = match.group(2)
+    if rest.startswith("confidence_head."):
+        return None
+
+    name = f"model.layers.{num_hidden_layers + stage_idx}.{rest}"
+    replacements = (
+        (".attn.", ".self_attn."),
+        (".ffn_norm.", ".post_attention_layernorm."),
+        (".attn_norm.", ".input_layernorm."),
+        (".ffn.", ".mlp."),
+        (".w1.", ".gate_proj."),
+        (".w2.", ".down_proj."),
+        (".w3.", ".up_proj."),
+        (".mlp.gate.bias", ".mlp.gate.e_score_correction_bias"),
+    )
+    for source, target in replacements:
+        name = name.replace(source, target)
+    return name

--- a/vllm_ascend/models/deepseek_v4_dspark.py
+++ b/vllm_ascend/models/deepseek_v4_dspark.py
@@ -1,0 +1,516 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DeepSeek V4 DSpark draft model for Ascend."""
+
+import copy
+import typing
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+import regex as re
+import torch
+import torch.nn as nn
+from safetensors.torch import load_file
+from transformers import PretrainedConfig
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig
+from vllm.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.logger import logger
+from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.models.utils import PPMissingLayer, maybe_prefix
+from vllm.platforms import current_platform
+from vllm.sequence import IntermediateTensors
+
+from vllm_ascend.models.deepseek_v4 import (
+    DeepseekV2DecoderLayer,
+    DeepseekV2MixtureOfExperts,
+    DeepseekV4MoE,
+)
+from vllm_ascend.models.deepseek_v4_draft import remap_dspark_mtp_weight_name
+from vllm_ascend.ops.dsa import unfold_kvcache
+from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
+from vllm_ascend.utils import vllm_version_is
+
+if not vllm_version_is("0.23.0"):
+    from vllm.model_executor.layers.fused_moe import (
+        fused_moe_make_expert_params_mapping,
+    )
+
+_EXPERT_SCALE_RE = re.compile(r"\.experts\.\d+\.(gate_proj|up_proj|down_proj)\.scale$")
+_LAYER_ID_RE = re.compile(r"model\.layers\.(\d+)\.")
+
+
+def _linear_output(layer: nn.Module, hidden_states: torch.Tensor) -> torch.Tensor:
+    output = layer(hidden_states)
+    return output[0] if isinstance(output, tuple) else output
+
+
+def _draft_quant_config(vllm_config: VllmConfig):
+    assert vllm_config.speculative_config is not None
+    draft_config = vllm_config.speculative_config.draft_model_config.hf_config
+    if getattr(draft_config, "dspark_mtp_dequantized_to_bf16", False):
+        return None
+    return vllm_config.quant_config
+
+
+def _get_dspark_num_mtp_layers(config: PretrainedConfig) -> int:
+    return int(getattr(config, "n_mtp_layers", None) or getattr(config, "dspark_num_mtp_layers", None) or 3)
+
+
+def _load_dspark_quarot_rotation(
+    vllm_config: VllmConfig,
+    device: torch.device | str | None = None,
+) -> torch.Tensor | None:
+    quant_description = getattr(vllm_config.quant_config, "quant_description", None)
+    if not isinstance(quant_description, dict):
+        return None
+    try:
+        relative_path = quant_description["optional"]["quarot"]["rotation_map"]["global_rotation"]
+    except KeyError:
+        return None
+
+    rotation_path = Path(vllm_config.model_config.model) / relative_path
+    rotation = load_file(rotation_path)["global_rotation"].to(device=device, dtype=torch.float32)
+    logger.info_once("Loaded DSpark QuaRot rotation from %s", rotation_path)
+    return rotation
+
+
+def _apply_dspark_quarot_rotation(
+    hidden_states: torch.Tensor,
+    rotation: torch.Tensor | None,
+    *,
+    transpose: bool,
+) -> torch.Tensor:
+    if rotation is None:
+        return hidden_states
+    if rotation.device != hidden_states.device:
+        raise RuntimeError("DSpark QuaRot rotation must be loaded on the same device as hidden states")
+    matrix = rotation.t() if transpose else rotation
+    return torch.matmul(hidden_states.float(), matrix).to(hidden_states.dtype)
+
+
+def _hc_head(
+    hidden_states: torch.Tensor,
+    hc_fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    norm_eps: float,
+    hc_eps: float,
+) -> torch.Tensor:
+    shape, dtype = hidden_states.shape, hidden_states.dtype
+    hidden_flat = hidden_states.flatten(1).float()
+    rsqrt = torch.rsqrt(hidden_flat.square().mean(-1, keepdim=True) + norm_eps)
+    mixes = torch.nn.functional.linear(hidden_flat, hc_fn) * rsqrt
+    pre = torch.sigmoid(mixes * hc_scale + hc_base) + hc_eps
+    return torch.sum(pre.unsqueeze(-1) * hidden_flat.view(shape), dim=1).to(dtype)
+
+
+def _scatter_context_kv(cache: torch.Tensor | list, kv: torch.Tensor, slot_mapping: torch.Tensor) -> None:
+    from vllm_ascend.device.device_op import DeviceOperator
+
+    cache = unfold_kvcache(cache)
+    slot_mapping = DeviceOperator.format_dsa_slot_mapping(slot_mapping, cache.shape[1])
+    DeviceOperator.dsa_kv_compress_scatter(cache, kv, slot_mapping)
+
+
+def _make_expert_params_mapping(model: nn.Module, num_experts: int) -> list[tuple[str, str, int, str]]:
+    kwargs = dict(
+        ckpt_gate_proj_name="gate_proj",
+        ckpt_down_proj_name="down_proj",
+        ckpt_up_proj_name="up_proj",
+        num_experts=num_experts,
+        num_redundant_experts=0,
+    )
+    if vllm_version_is("0.23.0"):
+        return FusedMoE.make_expert_params_mapping(model, **kwargs)
+    return fused_moe_make_expert_params_mapping(model, **kwargs)
+
+
+class DSparkMarkovHead(nn.Module):
+    def __init__(self, config: PretrainedConfig, prefix: str) -> None:
+        super().__init__()
+        self.markov_w1 = VocabParallelEmbedding(
+            config.vocab_size,
+            config.dspark_markov_rank,
+            prefix=f"{prefix}.markov_w1",
+        )
+        self.markov_w2 = ParallelLMHead(
+            config.vocab_size,
+            config.dspark_markov_rank,
+            org_num_embeddings=config.vocab_size,
+            prefix=f"{prefix}.markov_w2",
+        )
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+
+    def embed(self, token_ids: torch.Tensor) -> torch.Tensor:
+        return self.markov_w1(token_ids)
+
+    def bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
+        return self.logits_processor(self.markov_w2, markov_embed)
+
+
+class DeepseekV4DSparkModel(nn.Module):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        assert vllm_config.speculative_config is not None
+        config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.config = config
+        self.hc_mult = config.hc_mult
+        self.target_layer_ids = tuple(config.dspark_target_layer_ids)
+        self.num_dspark_layers = _get_dspark_num_mtp_layers(config)
+        self.mtp_start_layer_idx = config.num_hidden_layers
+
+        draft_vllm_config = copy.copy(vllm_config)
+        draft_vllm_config.quant_config = _draft_quant_config(vllm_config)
+        self.embed_tokens = VocabParallelEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=draft_vllm_config.quant_config,
+            prefix=maybe_prefix(prefix, "embed_tokens"),
+        )
+        self.layers = nn.ModuleDict(
+            {
+                str(self.mtp_start_layer_idx + index): DeepseekV2DecoderLayer(
+                    draft_vllm_config,
+                    prefix=maybe_prefix(prefix, f"layers.{self.mtp_start_layer_idx + index}"),
+                    config=config,
+                    is_draft_layer=True,
+                )
+                for index in range(self.num_dspark_layers)
+            }
+        )
+
+        first_layer_idx = self.mtp_start_layer_idx
+        last_layer_idx = first_layer_idx + self.num_dspark_layers - 1
+        self.main_proj = ReplicatedLinear(
+            config.hidden_size * len(self.target_layer_ids),
+            config.hidden_size,
+            bias=False,
+            return_bias=False,
+            quant_config=None,
+            prefix=maybe_prefix(prefix, f"layers.{first_layer_idx}.main_proj"),
+        )
+        self.main_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.layers[str(first_layer_idx)].main_proj = self.main_proj
+        self.layers[str(first_layer_idx)].main_norm = self.main_norm
+
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.markov_head = DSparkMarkovHead(
+            config,
+            maybe_prefix(prefix, f"layers.{last_layer_idx}.markov_head"),
+        )
+        hc_dim = self.hc_mult * config.hidden_size
+        self.hc_head_fn = nn.Parameter(
+            torch.empty(self.hc_mult, hc_dim, dtype=torch.float32),
+            requires_grad=False,
+        )
+        self.hc_head_base = nn.Parameter(torch.empty(self.hc_mult, dtype=torch.float32), requires_grad=False)
+        self.hc_head_scale = nn.Parameter(torch.empty(1, dtype=torch.float32), requires_grad=False)
+        last_layer = self.layers[str(last_layer_idx)]
+        last_layer.norm = self.norm
+        last_layer.markov_head = self.markov_head
+        last_layer.hc_head_fn = self.hc_head_fn
+        last_layer.hc_head_base = self.hc_head_base
+        last_layer.hc_head_scale = self.hc_head_scale
+
+        device_config = getattr(vllm_config, "device_config", None)
+        rotation_device = getattr(device_config, "device", current_platform.device_type)
+        self.register_buffer(
+            "_dspark_quarot_rotation",
+            _load_dspark_quarot_rotation(vllm_config, rotation_device),
+            persistent=False,
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return _apply_dspark_quarot_rotation(
+            self.embed_tokens(input_ids),
+            self._dspark_quarot_rotation,
+            transpose=True,
+        )
+
+    def combine_hidden_states(self, aux_hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.main_norm(_linear_output(self.main_proj, aux_hidden_states))
+
+    def get_draft_kv_cache_layer_names(self) -> list[str]:
+        return [layer.self_attn.dsa_attn.swa_cache_layer.prefix for layer in self.layers.values()]
+
+    @torch.inference_mode()
+    def precompute_and_store_context_kv(
+        self,
+        main_hidden_states: torch.Tensor,
+        context_positions: torch.Tensor,
+        context_slot_mappings: Sequence[torch.Tensor | None] | None = None,
+    ) -> None:
+        if context_slot_mappings is not None and len(context_slot_mappings) != len(self.layers):
+            raise ValueError("DSpark context slot mappings must match the number of draft layers")
+        main_hidden_states = self.combine_hidden_states(main_hidden_states)
+        cos, sin = get_cos_and_sin_dsa(context_positions)
+        for index, layer in enumerate(self.layers.values()):
+            slot_mapping = None if context_slot_mappings is None else context_slot_mappings[index]
+            attn = layer.self_attn
+            kv = attn.kv_norm(_linear_output(attn.wkv, main_hidden_states))
+            kv = kv.view(-1, 1, attn.head_dim)
+            layer_name = attn.rotary_emb.layername
+            torch.ops._C_ascend.inplace_partial_rotary_mul(
+                kv.unsqueeze(1),
+                cos[layer_name],
+                sin[layer_name],
+                rotary_mode="interleave",
+                partial_slice=[attn.nope_head_dim, attn.head_dim],
+            )
+            if slot_mapping is not None:
+                _scatter_context_kv(
+                    attn.dsa_attn.swa_cache_layer.kv_cache,
+                    kv,
+                    slot_mapping,
+                )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_input_ids(input_ids)
+        hidden_states = inputs_embeds.unsqueeze(-2).repeat(1, self.hc_mult, 1)
+        for layer in self.layers.values():
+            hidden_states, _ = layer(positions, hidden_states, None)
+        return _hc_head(
+            hidden_states,
+            self.hc_head_fn,
+            self.hc_head_scale,
+            self.hc_head_base,
+            self.config.rms_norm_eps,
+            self.config.hc_eps,
+        )
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+        lm_head: ParallelLMHead,
+        logits_processor: LogitsProcessor,
+    ) -> torch.Tensor:
+        hidden_states = self.norm(hidden_states)
+        if self._dspark_quarot_rotation is not None:
+            hidden_states = hidden_states / self.norm.weight.to(device=hidden_states.device, dtype=hidden_states.dtype)
+        hidden_states = _apply_dspark_quarot_rotation(
+            hidden_states,
+            self._dspark_quarot_rotation,
+            transpose=False,
+        )
+        return logits_processor(lm_head, hidden_states)
+
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        return _make_expert_params_mapping(self, self.config.n_routed_experts)
+
+    def finalize_mega_moe_weights(self) -> None:
+        for layer in self.layers.values():
+            finalize = getattr(layer.mlp, "finalize_mega_moe_weights", None)
+            if finalize is not None:
+                finalize()
+
+
+@support_torch_compile
+class DeepSeekV4DSparkMTP(nn.Module, DeepseekV2MixtureOfExperts):
+    has_own_embed_tokens = False
+    has_own_lm_head = False
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        assert vllm_config.speculative_config is not None
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.quant_config = _draft_quant_config(vllm_config)
+        self.model = DeepseekV4DSparkModel(vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model"))
+        self.lm_head = ParallelLMHead(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
+        self.logits_processor = LogitsProcessor(self.config.vocab_size)
+        self.set_moe_parameters()
+
+    def set_moe_parameters(self) -> None:
+        self.expert_weights: list[Sequence[torch.Tensor]] = []
+        self.num_expert_groups = getattr(self.config, "n_group", 1)
+        self.moe_layers = []
+        self.moe_mlp_layers = []
+        example_moe = None
+        for layer in self.model.layers.values():
+            if isinstance(layer, PPMissingLayer):
+                continue
+            if isinstance(layer.mlp, DeepseekV4MoE):
+                example_moe = layer.mlp
+                self.moe_mlp_layers.append(layer.mlp)
+                self.moe_layers.append(layer.mlp.experts)
+        self.extract_moe_parameters(example_moe)
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def combine_hidden_states(self, aux_hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.model.combine_hidden_states(aux_hidden_states)
+
+    def get_draft_kv_cache_layer_names(self) -> list[str]:
+        return self.model.get_draft_kv_cache_layer_names()
+
+    def precompute_and_store_context_kv(
+        self,
+        main_hidden_states: torch.Tensor,
+        context_positions: torch.Tensor,
+        context_slot_mappings: Sequence[torch.Tensor | None] | None = None,
+    ) -> None:
+        self.model.precompute_and_store_context_kv(main_hidden_states, context_positions, context_slot_mappings)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor | None = None,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor:
+        del hidden_states, intermediate_tensors, spec_step_idx
+        assert input_ids is not None
+        return self.model(input_ids, positions, inputs_embeds)
+
+    def compute_logits(self, hidden_states: torch.Tensor, spec_step_idx: int = 0) -> torch.Tensor:
+        del spec_step_idx
+        return self.model.compute_logits(hidden_states, self.lm_head, self.logits_processor)
+
+    def markov_embed(self, token_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.markov_head.embed(token_ids)
+
+    def markov_bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
+        return self.model.markov_head.bias(markov_embed)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = (
+            ("mlp.gate_up_proj", "mlp.gate_proj", 0),
+            ("mlp.gate_up_proj", "mlp.up_proj", 1),
+            ("shared_experts.gate_up_proj", "shared_experts.gate_proj", 0),
+            ("shared_experts.gate_up_proj", "shared_experts.up_proj", 1),
+        )
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        missing_mtp_params: set[str] = set()
+        start_layer_idx = self.config.num_hidden_layers
+        last_layer_idx = start_layer_idx + self.model.num_dspark_layers - 1
+
+        tp_size = get_tensor_model_parallel_world_size()
+        heads_per_rank = self.config.num_attention_heads // tp_size
+        head_start = get_tensor_model_parallel_rank() * heads_per_rank
+        head_end = head_start + heads_per_rank
+        expert_mapping = self.model.get_expert_mapping()
+        expert_scale_suffix = (
+            ".weight_scale" if getattr(self.config, "expert_dtype", "fp4") == "fp4" else ".weight_scale_inv"
+        )
+
+        for name, loaded_weight in weights:
+            if name in ("embed.weight", "head.weight"):
+                continue
+            mapped_name = remap_dspark_mtp_weight_name(name, self.config.num_hidden_layers)
+            if mapped_name is None:
+                continue
+            name = mapped_name
+            if name.startswith(f"model.layers.{last_layer_idx}.hc_head_"):
+                name = name.replace(f"model.layers.{last_layer_idx}.", "model.", 1)
+            if name.endswith(".scale"):
+                suffix = expert_scale_suffix if _EXPERT_SCALE_RE.search(name) else ".weight_scale"
+                name = name.removesuffix(".scale") + suffix
+
+            for param_name, weight_name, stacked_shard_id in stacked_params_mapping:
+                if ".experts." in name or f".{weight_name}." not in name:
+                    continue
+                mapped = name.replace(weight_name, param_name)
+                param = params_dict.get(mapped)
+                if param is None:
+                    missing_mtp_params.add(mapped)
+                else:
+                    param.weight_loader(param, loaded_weight, stacked_shard_id)
+                    loaded_params.add(mapped)
+                break
+            else:
+                if ".experts." in name:
+                    matched_expert_mapping = False
+                    if "weight_scale" in name and loaded_weight.dtype == torch.float8_e8m0fnu:
+                        loaded_weight = loaded_weight.view(torch.uint8)
+                    for param_name, weight_name, expert_id, expert_shard_id in expert_mapping:
+                        if weight_name not in name:
+                            continue
+                        matched_expert_mapping = True
+                        mapped = name.replace(weight_name, param_name)
+                        param = params_dict.get(mapped)
+                        if param is None:
+                            continue
+                        weight_loader = typing.cast(typing.Callable[..., bool], param.weight_loader)
+                        if weight_loader(
+                            param,
+                            loaded_weight,
+                            mapped,
+                            shard_id=expert_shard_id,
+                            expert_id=expert_id,
+                            return_success=True,
+                        ):
+                            loaded_params.add(mapped)
+                            break
+                    if not matched_expert_mapping:
+                        missing_mtp_params.add(name)
+                    continue
+                if "attn_sink" in name:
+                    param = params_dict.get(name)
+                    if param is None:
+                        missing_mtp_params.add(name)
+                    else:
+                        with torch.no_grad():
+                            param[:heads_per_rank].copy_(loaded_weight[head_start:head_end])
+                        loaded_params.add(name)
+                    continue
+                param = params_dict.get(name)
+                if param is None:
+                    missing_mtp_params.add(name)
+                    continue
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+                loaded_params.add(name)
+
+        if missing_mtp_params:
+            raise ValueError(f"DSpark checkpoint weights did not match model parameters: {sorted(missing_mtp_params)}")
+
+        loaded_layer_ids = {
+            int(match.group(1)) for name in loaded_params if (match := _LAYER_ID_RE.search(name)) is not None
+        }
+        for layer_idx in range(start_layer_idx, last_layer_idx + 1):
+            if layer_idx not in loaded_layer_ids:
+                raise ValueError(f"DSpark layer {layer_idx} weights missing from checkpoint")
+        required_params = {
+            f"model.layers.{start_layer_idx}.main_proj.weight",
+            f"model.layers.{start_layer_idx}.main_norm.weight",
+            f"model.layers.{last_layer_idx}.norm.weight",
+            "model.hc_head_fn",
+            "model.hc_head_base",
+            "model.hc_head_scale",
+            f"model.layers.{last_layer_idx}.markov_head.markov_w1.weight",
+            f"model.layers.{last_layer_idx}.markov_head.markov_w2.weight",
+        }
+        missing_required = sorted(required_params - loaded_params)
+        if missing_required:
+            raise ValueError(f"DSpark required weights missing from checkpoint load: {missing_required}")
+        self.model.finalize_mega_moe_weights()
+        logger.info_once("DSpark draft model loaded: %d params", len(loaded_params))
+        return loaded_params
+
+
+DSparkDeepseekV4ForCausalLM = DeepSeekV4DSparkMTP

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING, Any
 from vllm.config.speculative import SpeculativeConfig
 from vllm.utils.import_utils import LazyLoader
 
+from vllm_ascend.models.deepseek_v4_draft import is_deepseek_v4_dspark_config
+
 if TYPE_CHECKING:
     import vllm.model_executor.layers.quantization as me_quant
     from transformers import PretrainedConfig
@@ -14,6 +16,16 @@ else:
 
 def hf_config_override(hf_config: PretrainedConfig) -> PretrainedConfig:
     initial_architecture = hf_config.architectures[0]
+    if is_deepseek_v4_dspark_config(hf_config):
+        hf_config.model_type = "deepseek_mtp"
+        hf_config.update(
+            {
+                "ptd_token_id": getattr(hf_config, "dspark_noise_token_id", None),
+                "dspark_num_mtp_layers": getattr(hf_config, "dspark_num_mtp_layers", 3),
+                "architectures": ["DeepSeekV4DSparkMTPModel"],
+            }
+        )
+        return hf_config
     if hf_config.model_type in ("deepseek_v3", "deepseek_v32", "deepseek_v4", "glm_moe_dsa"):
         target_model_type = hf_config.model_type
         hf_config.model_type = "deepseek_mtp"

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -365,6 +365,8 @@ QUANT_MODEL_SUBSTR_MAPPINGS = {
     },
 }
 
+_DEEPSEEK_V4_MTP_LAYER_RE = re.compile(r"^model\.layers\.(\d+)\.(.+)$")
+
 
 def get_packed_modules_mapping(model_type: str) -> dict[str, list[str]]:
     """Get packed modules mapping for a model type.
@@ -607,7 +609,30 @@ class AscendModelSlimConfig(QuantizationConfig):
             )
         return f"{prefix}.weight" in self.quant_description
 
-    def quant_prefix_mapper(self, model_type: str, prefix: str) -> str:
+    def _map_deepseek_v4_mtp_prefix(
+        self,
+        prefix: str,
+        packed_modules_mapping: Mapping[str, list[str]],
+        num_hidden_layers: int | None,
+    ) -> str | None:
+        if num_hidden_layers is None:
+            return None
+        match = _DEEPSEEK_V4_MTP_LAYER_RE.match(prefix)
+        if match is None:
+            return None
+
+        mtp_layer_idx = int(match.group(1)) - num_hidden_layers
+        if mtp_layer_idx < 0:
+            return None
+        candidate = f"model.mtp.{mtp_layer_idx}.{match.group(2)}"
+        return candidate if self._has_quant_weight(candidate, packed_modules_mapping) else None
+
+    def quant_prefix_mapper(
+        self,
+        model_type: str,
+        prefix: str,
+        num_hidden_layers: int | None = None,
+    ) -> str:
         self.model_type = model_type
         # Some model paths, e.g. qwen3-vl and qwen3_5_moe MTP drafter,
         # initialize lm_head with prefix="lm_head", while the quant description
@@ -626,6 +651,17 @@ class AscendModelSlimConfig(QuantizationConfig):
                 orig_to_new_substr=substr_mapping or {},
             )
             prefix = hf_to_vllm_mapper._map_name(prefix)
+
+        if model_type in ("deepseek_v4", "deepseek_mtp"):
+            packed_modules_mapping = get_packed_modules_mapping(model_type)
+            if not self._has_quant_weight(prefix, packed_modules_mapping):
+                mtp_prefix = self._map_deepseek_v4_mtp_prefix(
+                    prefix,
+                    packed_modules_mapping,
+                    num_hidden_layers,
+                )
+                if mtp_prefix is not None:
+                    return mtp_prefix
 
         if model_type == "step3p5_mtp" and prefix.startswith("model.layers."):
             # Step3P5 MTP and newly generated Step3P7 W8A8 MTP checkpoints use
@@ -670,7 +706,11 @@ class AscendModelSlimConfig(QuantizationConfig):
             prefix = prefix.replace("self_attn", "attention")
         if model_type in packed_modules_model_mapping:
             self.packed_modules_mapping = packed_modules_model_mapping[model_type]
-        prefix = self.quant_prefix_mapper(model_type, prefix)
+        prefix = self.quant_prefix_mapper(
+            model_type,
+            prefix,
+            num_hidden_layers=getattr(vllm_config.model_config.hf_config, "num_hidden_layers", None),
+        )
 
         if isinstance(layer, LinearBase):
             if self.is_layer_skipped_ascend(prefix, self.packed_modules_mapping):

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -3,7 +3,7 @@ import copy
 from collections.abc import Callable
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from functools import partial
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import torch
@@ -491,7 +491,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     def _maybe_share_lm_head(self, model: nn.Module) -> None:
         # some model definition do not define lm_head explicitly
         # and reuse embed_tokens for lm_head, e.g., CohereForCausalLM
-        if self.method in ("eagle", "dflash"):
+        share_target_lm_head = (
+            self.method in ("eagle", "dflash") or getattr(self.model, "has_own_lm_head", True) is False
+        )
+        if share_target_lm_head:
             # For DFlash drafters trained with a reduced draft vocabulary, the
             # draft model ships its own lm_head of shape [draft_vocab_size,
             # hidden] whose rows map to a trained subset of the target vocab via
@@ -522,7 +525,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                         " is not trained."
                     )
 
-        if self.method == "mtp" and self.vllm_config.model_config.is_deepseek_mla:
+        if (
+            self.method == "mtp"
+            and self.vllm_config.model_config.is_deepseek_mla
+            and getattr(self.model, "has_own_lm_head", True)
+        ):
             for _, layer_module in self.model.model.layers.items():
                 if torch.equal(layer_module.shared_head.head.weight, model.lm_head.weight):
                     layer_module.shared_head.head = model.lm_head
@@ -1107,7 +1114,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "num_tokens": num_tokens,
                 "is_prefill": is_prefill_batch,
             }
-            run_draft = partial(self._runnable, **model_inputs)
+            runnable = cast(Callable[..., Any], self._runnable)
+            run_draft = partial(runnable, **model_inputs)
 
             if self.enable_enpu:
                 self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)


### PR DESCRIPTION
### What this PR does / why we need it?

This is PR 2/4 of the DeepSeek V4 DSpark split defined in #11126. It depends on #12003 and extracts the target/draft model contract from #11196.

For stacked review, the owned change is commit `56f210c97` (`qj/dspark-01-attention..qj/dspark-02-model`). The temporary `main`-based GitHub diff also contains PR 1 until #12003 merges.

This PR:

- captures configured target auxiliary hidden states in layer order;
- adds the DeepSeek V4 DSpark draft model and standard-cache SAS adapter;
- maps ModelSlim target-layer prefixes to the checkpoint `model.mtp.*` namespace;
- loads BF16 and Ascend W4A8 DSpark weights, including QuaRot and FP8 QDQ metadata;
- keeps non-DSpark DeepSeek V4 behavior unchanged.

Incremental size: about `+1180/-9`, including owned tests.

### Does this PR introduce _any_ user-facing change?

Not by itself. It adds the model/loading contract consumed by the eager and ACLGraph PRs that follow.

### How was this patch tested?

```bash
python -m pytest -q \
  tests/ut/quantization/test_modelslim_config.py \
  tests/ut/spec_decode/test_deepseek_v4_draft_hooks.py \
  tests/ut/spec_decode/test_deepseek_v4_dspark_model.py
```

Result: `69 passed, 1 skipped`.

Also passed:

- mypy for all PR-owned Python files;
- `ruff check` and `ruff format --check` for the changed Python files;
- `git diff --check qj/dspark-01-attention...HEAD`.

The final real W4A8 load/serve evidence will be added after the cumulative PR 4 branch is validated.

References:

- Direct dependency: #12003
- RFC and four-PR plan: #11126
- Original end-to-end prototype: #11196
- Generic Qwen/GLM DSpark foundation: #11765

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/e5588e49bc2642670116664a7fc4096e27adb179
