### PR TITLE
[Performance][SpecDecode] Add FULL ACLGraph for DeepSeek V4 DSpark drafter

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -108,7 +108,9 @@
   base: attention_common
   source_file_dependencies:
     - vllm_ascend/attention/dsa_v1.py
+    - vllm_ascend/attention/dsa_window.py
   tests:
+    - tests/ut/spec_decode/test_dspark_dsa_metadata.py
     - tests/e2e/pull_request/four_card/test_deepseek_v4.py
 
 - name: attention_cp
@@ -839,7 +841,6 @@ partition:
   a3_x2: 3
   a3_x4: 3
   cpu_x0: 1
-
 
 
 

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -507,6 +507,7 @@
   optional: false
   base: spec_decode_base
   source_file_dependencies:
+    - vllm_ascend/spec_decode/deepseek_v4_dspark_proposer.py
     - vllm_ascend/spec_decode/dspark_proposer.py
   tests:
     - tests/e2e/pull_request/one_card/spec_decode/test_dspark.py
@@ -802,6 +803,7 @@ estimated_times:
   tests/ut/quantization/methods/a2/test_w8a8_dynamic.py: 40
   tests/ut/quantization/methods/a2/test_w8a8_static.py: 40
   tests/ut/sample/a2/test_gumbel_sampling.py: 80
+  tests/ut/sample/a2/test_probabilistic_rejection.py: 30
   tests/ut/spec_decode/a2/test_eagle_proposer.py: 50
   tests/ut/worker/a2/test_block_table.py: 30
   tests/ut/worker/a2/test_kvcomp_utils.py: 50
@@ -841,7 +843,6 @@ partition:
   a3_x2: 3
   a3_x4: 3
   cpu_x0: 1
-
 
 
 

--- a/csrc/attention/sparse_attn_sharedkv/README.md
+++ b/csrc/attention/sparse_attn_sharedkv/README.md
@@ -30,7 +30,7 @@
 | q                     | 输入      | 对应公式中的$Q$。                                                     | BFLOAT16、FLOAT16  | ND |
 | ori\_kv               | 可选输入  | 对应公式中的$\tilde{K}和\tilde{V}$的一部分，为原始不经压缩的KV。          | BFLOAT16、FLOAT16 | ND |
 | cmp\_kv               | 可选输入  | 对应公式中的$\tilde{K}和\tilde{V}$的一部分，为经过压缩的KV。             | BFLOAT16、FLOAT16  | ND |
-| ori\_sparse\_indices  | 可选输入  | 代表离散取oriKvCache的索引。                                           | INT32              | ND |
+| ori\_sparse\_indices  | 可选输入  | 代表离散读取oriKvCache的物理slot索引，负数表示有效索引结束。             | INT32              | ND |
 | cmp\_sparse\_indices  | 可选输入  | 代表离散取cmpKvCache的索引。                                           | INT32              | ND |
 | ori\_block\_table     | 可选输入  | 表示PageAttention中oriKvCache存储使用的block映射表。                   | INT32               | ND |
 | cmp\_block\_table     | 可选输入  | 表示PageAttention中cmpKvCache存储使用的block映射表。                   | INT32               | ND |
@@ -57,17 +57,17 @@
 
 - 该接口支持推理场景下使用。
 - 该接口支持aclgraph模式。
-- 该接口当前支持三种计算场景：场景一，仅传入`ori_kv`时为Sliding Window Attention计算；场景二，传入`ori_kv`及`cmp_kv`时为Sliding Window Attention + Compressed Attention计算；场景三，传入`ori_kv`、`cmp_kv`及`cmp_sparse_indices`时为Sliding Window Attention + Sparse Compressed Attention计算。
+- 该接口当前支持四种计算场景：场景一，仅传入`ori_kv`时为Sliding Window Attention计算；场景二，传入`ori_kv`和`ori_sparse_indices`时按显式物理slot执行Sparse Sliding Window Attention计算；场景三，传入`ori_kv`及`cmp_kv`时为Sliding Window Attention + Compressed Attention计算；场景四，传入`ori_kv`、`cmp_kv`及`cmp_sparse_indices`时为Sliding Window Attention + Sparse Compressed Attention计算。
 
 - 当`layout_q`为TND时，功能使用限制如下：
     - `q`的shape需要为[T1,N1,D]，其中N1仅支持64。
-    - `ori_sparse_indices`的shape需要为[Q\_T, KV\_N, K1]，其中K1为对`ori_kv`一次离散选取的token数，K1仅支持512。
+    - `ori_sparse_indices`仅支持SWA模板和`PA_ND` KV layout，shape需要为[Q\_T, KV\_N, K1]，其中K1为对`ori_kv`一次离散选取的token数。K1必须为正数、128对齐且不超过2048；每行遇到第一个负数时停止读取。`ori_win_left`需要为metadata提供不小于有效索引数量的非负调度窗口，`ori_win_right`仅支持0。
     - `cmp_sparse_indices`的shape需要为[Q\_T, KV\_N, K2]，其中K2为对`cmp_kv`一次离散选取的token数，K2仅支持512。
     - `cu_seqlens_q`必须传入，输入维度为B+1，大小为参数中每个元素的值表示当前batch与之前所有batch的token数总和，即前缀和，因此后一个元素的值必须>=前一个元素的值。
 
 - 当`layout_q`为BSND时，功能使用限制如下：
     - `q`的shape需要为[B, Q\_S,N1,D]，其中N1仅支持64。
-    - `ori_sparse_indices`的shape需要为[B, Q\_S, KV\_N, K1]，其中K1为对`ori_kv`一次离散选取的token数，K1仅支持512。
+    - 当前不支持传入`ori_sparse_indices`。
     - `cmp_sparse_indices`的shape需要为[B, Q\_S, KV\_N, K2]，其中K2为对`cmp_kv`一次离散选取的token数，K2仅支持512。
 
 - PageAttention场景下，功能使用限制如下：
@@ -78,13 +78,45 @@
 - 目前暂不支持返回`softmax_lse`，`return_softmax_lse`仅支持输入False，返回值`softmax_lse`为无效值。
 - ori_mask_mode及cmp_mask_mode所表示的mask模式的详细介绍见[sparse_mode参数说明](../../../docs/zh/context/sparse_mode参数说明.md)。
 - 目前暂不支持指定`q`中参与运算的token数，因此设置`seqused_q`无效。
-- 目前暂不支持对`ori_kv`进行稀疏计算，因此设置`ori_sparse_indices`无效。
+- `ori_sparse_indices`中的非负值是`ori_kv`首两维展平后的物理slot编号，不再经过`ori_block_table`映射。
 - 目前所有输入不支持传入空tensor。
 - `q`、`ori_kv`、`cmp_kv`数据排布格式支持从多种维度解读，B（Batch）表示输入样本批量大小、S（Seq-Length）表示输入样本序列长度、H（Hidden-Size）表示隐藏层的大小、N（Head-Num）表示多头数、D（Head-Dim）表示hidden层最小的单元尺寸，且满足D=H/N、T表示所有Batch输入样本序列长度的累加和。
 - Q\_S和S1表示q shape中的S，S2表示ori_kv shape中的S，S3表示cmp_kv shape中的S；Q\_N和N1表示num\_q\_heads，KV\_N和N2表示num\_ori_kv\_heads和num\_cmp_kv\_heads；Q\_T和T1表示q shape中的输入样本序列长度的累加和。
 
 - 当`layout_kv`为BSND时，功能使用限制如下：
     - `ori_kv`和`cmp_kv`的layout都必须为BSND，ori_kv的shape为[B, S2, N2,D]，cmp_kv的shape为[B, S3, N2,D]。
+
+显式original-KV slot模式调用示例（`metadata`的构造方式与下方单算子示例相同）：
+
+```python
+ori_sparse_indices = torch.full(
+    (q.shape[0], ori_kv.shape[2], 128),
+    -1,
+    dtype=torch.int32,
+    device=q.device,
+)
+slots = torch.tensor([1, 19, 34, 17], dtype=torch.int32, device=q.device)
+ori_sparse_indices[:, 0, : slots.numel()] = slots
+
+attention_out, _ = torch.ops.custom.npu_sparse_attn_sharedkv(
+    q,
+    ori_kv=ori_kv,
+    ori_sparse_indices=ori_sparse_indices,
+    ori_block_table=ori_block_table,
+    cu_seqlens_q=cu_seqlens_q,
+    seqused_kv=seqused_kv,
+    sinks=sinks,
+    metadata=metadata,
+    softmax_scale=softmax_scale,
+    cmp_ratio=4,
+    ori_mask_mode=4,
+    cmp_mask_mode=3,
+    ori_win_left=127,
+    ori_win_right=0,
+    layout_q="TND",
+    layout_kv="PA_ND",
+)
+```
 
 ## Atlas A3 推理系列产品 调用说明
 

--- a/csrc/attention/sparse_attn_sharedkv/op_host/sparse_attn_sharedkv_tiling.cpp
+++ b/csrc/attention/sparse_attn_sharedkv/op_host/sparse_attn_sharedkv_tiling.cpp
@@ -171,9 +171,6 @@ ge::graphStatus SASInfoParser::CheckRequiredParaExistence() const
 
 ge::graphStatus SASInfoParser::CheckUnrequiredParaExistence() const
 {
-    OP_CHECK_IF(opParamInfo_.oriSparseIndices.tensor != nullptr || opParamInfo_.oriSparseIndices.desc != nullptr,
-                OP_LOGE(opName_, "Currently, ori_sparse_indices must be a nullptr"),
-                return ge::GRAPH_FAILED);
     return ge::GRAPH_SUCCESS;
 }
 
@@ -404,6 +401,17 @@ uint32_t SASInfoParser::GetAxisNum(const gert::Shape &shape, const SASAxis &axis
     return HasAxis(axis, layout, shape) ? shape.GetDim(GetAxisIdx(axis, layout)) : invalidDimValue_;
 }
 
+uint32_t SASInfoParser::GetSparseIndexWidth(const gert::Shape &shape, const SASLayout &layout) const
+{
+    if (layout == SASLayout::TND && shape.GetDimNum() == DIM_NUM_THREE) {
+        return shape.GetDim(DIM_NUM_THREE - 1);
+    }
+    if (layout == SASLayout::BSND && shape.GetDimNum() == DIM_NUM_FOUR) {
+        return shape.GetDim(DIM_NUM_FOUR - 1);
+    }
+    return 0;
+}
+
 void SASInfoParser::SetSASShape()
 {
     qShape_ = opParamInfo_.q.shape->GetStorageShape();
@@ -414,6 +422,11 @@ void SASInfoParser::SetSASShape()
     }
     if (opParamInfo_.cmpKv.tensor != nullptr) {
         cmpKvShape_ = opParamInfo_.cmpKv.tensor->GetStorageShape();
+    }
+    if (opParamInfo_.oriSparseIndices.tensor != nullptr) {
+        oriSparseIndicesShape_ = opParamInfo_.oriSparseIndices.tensor->GetStorageShape();
+        hasOriSparseIndices_ = true;
+        oriSparseIndexWidth_ = GetSparseIndexWidth(oriSparseIndicesShape_, oriSparseIndicesLayout_);
     }
     if (perfMode_ == SASTemplateMode::SCFA_TEMPLATE_MODE)
     {
@@ -788,6 +801,8 @@ void SASInfoParser::GenerateInfo(SASTilingInfo &sasInfo)
             opParamInfo_.oriKv.tensor->GetStorageShape().GetDim(0) : 0;
     }
     sasInfo.sparseBlockSize = 1;
+    sasInfo.hasOriSparseIndices = hasOriSparseIndices_;
+    sasInfo.oriSparseIndexWidth = oriSparseIndexWidth_;
     sasInfo.oriBlockSize = oriBlockSize_;
     sasInfo.cmpBlockSize = cmpBlockSize_;
     sasInfo.blockTypeSize = sizeof(float);
@@ -893,6 +908,8 @@ void SASTilingCheck::Init()
     oriWinRight_ = sasInfo_.oriWinRight;
     kvLayout_ = sasInfo_.kvLayout;
     outLayout_ = sasInfo_.outLayout;
+    hasOriSparseIndices_ = sasInfo_.hasOriSparseIndices;
+    oriSparseIndexWidth_ = sasInfo_.oriSparseIndexWidth;
 }
 
 void SASTilingCheck::LogErrorDtypeSupport(const std::vector<ge::DataType> &expectDtypeList,
@@ -1064,6 +1081,52 @@ ge::graphStatus SASTilingCheck::CheckSingleParaKvHeadNums() const
     return ge::GRAPH_SUCCESS;
 }
 
+ge::graphStatus SASTilingCheck::CheckSingleParaOriSparseIndices() const
+{
+    if (!hasOriSparseIndices_) {
+        return ge::GRAPH_SUCCESS;
+    }
+    OP_CHECK_IF(sasInfo_.perfMode != SASTemplateMode::SWA_TEMPLATE_MODE,
+                OP_LOGE(opName_, "ori_sparse_indices is only supported with SWA template mode."),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(kvLayout_ != SASLayout::PA_ND,
+                OP_LOGE(opName_, "ori_sparse_indices is only supported with PA_ND kv layout."),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(qLayout_ != SASLayout::TND,
+                OP_LOGE(opName_, "ori_sparse_indices currently supports TND query layout only."),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(opParamInfo_.oriSparseIndices.tensor->GetStorageShape().GetShapeSize() == 0,
+                OP_LOGE(opName_, "ori_sparse_indices cannot be empty tensor."),
+                return ge::GRAPH_FAILED);
+
+    const std::vector<size_t> oriSparseIndicesDimNumList = {DIM_NUM_THREE};
+    if (ge::GRAPH_SUCCESS != CheckDtypeSupport(opParamInfo_.oriSparseIndices.desc, ORI_SPARSE_INDICES) ||
+        ge::GRAPH_SUCCESS != CheckLayoutSupport(oriSparseIndicesLayout_, ORI_SPARSE_INDICES) ||
+        ge::GRAPH_SUCCESS != CheckDimNumSupport(&opParamInfo_.oriSparseIndices.tensor->GetShape(),
+                                                oriSparseIndicesDimNumList, ORI_SPARSE_INDICES) ||
+        ge::GRAPH_SUCCESS != CheckDimNumInLayoutSupport(oriSparseIndicesLayout_,
+                                                        &opParamInfo_.oriSparseIndices.tensor->GetShape(),
+                                                        ORI_SPARSE_INDICES)) {
+        return ge::GRAPH_FAILED;
+    }
+
+    const gert::Shape &shape = opParamInfo_.oriSparseIndices.tensor->GetStorageShape();
+    OP_CHECK_IF(shape.GetDim(0) != s1Size_,
+                OP_LOGE(opName_, "ori_sparse_indices T(%ld) should equal query T(%u).", shape.GetDim(0), s1Size_),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(shape.GetDim(1) != n2Size_,
+                OP_LOGE(opName_, "ori_sparse_indices N2(%ld) should equal kv head num(%u).",
+                         shape.GetDim(1), n2Size_),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(oriSparseIndexWidth_ == 0 || oriSparseIndexWidth_ > SPARSE_LIMIT ||
+                    (oriSparseIndexWidth_ % 128U) != 0U,
+                OP_LOGE(opName_,
+                        "ori_sparse_indices K should be a positive 128-aligned value not greater than %u, got %u.",
+                        SPARSE_LIMIT, oriSparseIndexWidth_),
+                return ge::GRAPH_FAILED);
+    return ge::GRAPH_SUCCESS;
+}
+
 ge::graphStatus SASTilingCheck::CheckSingleParaCmpSparseIndices() const
 {
     if (sasInfo_.perfMode == optiling::SASTemplateMode::SCFA_TEMPLATE_MODE){
@@ -1230,6 +1293,7 @@ ge::graphStatus SASTilingCheck::CheckSinglePara() const
         ge::GRAPH_SUCCESS != CheckSingleParaCmpKv() ||
         ge::GRAPH_SUCCESS != CheckSingleParaNumHeads() ||
         ge::GRAPH_SUCCESS != CheckSingleParaKvHeadNums() ||
+        ge::GRAPH_SUCCESS != CheckSingleParaOriSparseIndices() ||
         ge::GRAPH_SUCCESS != CheckSingleParaCmpSparseIndices() ||
         ge::GRAPH_SUCCESS != CheckSingleParaOriBlockTable() ||
         ge::GRAPH_SUCCESS != CheckSingleParaCmpBlockTable() ||
@@ -1362,12 +1426,21 @@ ge::graphStatus SASTilingCheck::CheckFeatureShape() const
     OP_CHECK_IF(*opParamInfo_.cmpMaskMode != 3,
                 OP_LOGE(opName_, "cmp_mask_mode should be 3, but got %d", *opParamInfo_.cmpMaskMode),
                 return ge::GRAPH_FAILED);
-    OP_CHECK_IF(oriWinLeft_ != 127,
-                OP_LOGE(opName_, "ori_win_left should be 127, but got %d", oriWinLeft_),
-                return ge::GRAPH_FAILED);
-    OP_CHECK_IF(oriWinRight_ != 0,
-                OP_LOGE(opName_, "ori_win_right should be 0, but got %d", oriWinRight_),
-                return ge::GRAPH_FAILED);
+    if (hasOriSparseIndices_) {
+        OP_CHECK_IF(oriWinLeft_ < 0,
+                    OP_LOGE(opName_, "ori_win_left should be non-negative, but got %ld", oriWinLeft_),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(oriWinRight_ != 0,
+                    OP_LOGE(opName_, "ori_win_right should be 0, but got %ld", oriWinRight_),
+                    return ge::GRAPH_FAILED);
+    } else {
+        OP_CHECK_IF(oriWinLeft_ != 127,
+                    OP_LOGE(opName_, "ori_win_left should be 127, but got %ld", oriWinLeft_),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(oriWinRight_ != 0,
+                    OP_LOGE(opName_, "ori_win_right should be 0, but got %ld", oriWinRight_),
+                    return ge::GRAPH_FAILED);
+    }
     return ge::GRAPH_SUCCESS;
 }
 
@@ -1604,6 +1677,8 @@ ge::graphStatus SparseAttnSharedkvTiling::DoOpTiling(SASTilingInfo *tilingInfo)
     tilingData_.baseParams.set_oriWinLeft(tilingInfo->oriWinLeft);
     tilingData_.baseParams.set_oriWinRight(tilingInfo->oriWinRight);
     tilingData_.baseParams.set_sparseBlockSize(tilingInfo->sparseBlockSize);
+    tilingData_.baseParams.set_hasOriSparseIndices(tilingInfo->hasOriSparseIndices);
+    tilingData_.baseParams.set_oriSparseIndexWidth(tilingInfo->oriSparseIndexWidth);
     tilingData_.baseParams.set_returnSoftmaxLse(tilingInfo->returnSoftmaxLse);
 
     tilingData_.cmpParams.set_cmpMaxBlockNumPerBatch(tilingInfo->cmpMaxBlockNumPerBatch);

--- a/csrc/attention/sparse_attn_sharedkv/op_host/sparse_attn_sharedkv_tiling.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_host/sparse_attn_sharedkv_tiling.h
@@ -148,6 +148,8 @@ TILING_DATA_FIELD_DEF(int64_t, oriKvStride)
 TILING_DATA_FIELD_DEF(int64_t, oriWinLeft)
 TILING_DATA_FIELD_DEF(int64_t, oriWinRight)
 TILING_DATA_FIELD_DEF(int64_t, sparseBlockSize)
+TILING_DATA_FIELD_DEF(bool, hasOriSparseIndices)
+TILING_DATA_FIELD_DEF(uint32_t, oriSparseIndexWidth)
 
 TILING_DATA_FIELD_DEF(uint32_t, usedCoreNum);
 
@@ -247,6 +249,8 @@ public:
     int64_t oriWinRight = 0;
     int64_t sparseBlockSize = 0;
     int64_t sparseBlockCount = 0;
+    bool hasOriSparseIndices = false;
+    uint32_t oriSparseIndexWidth = 0;
     // Mask
     int32_t sparseMode = 0;
     // Others Flag
@@ -391,6 +395,8 @@ private:
     int64_t blockSize_ = 0;
     int32_t oriBlockSize_ = 0;
     int32_t cmpBlockSize_ = 0;
+    bool hasOriSparseIndices_ = false;
+    uint32_t oriSparseIndexWidth_ = 0;
 
     uint32_t aicNum_ = 0;
     uint32_t aivNum_ = 0;
@@ -468,6 +474,7 @@ public:
     bool HasAxis(const SASAxis &axis, const SASLayout &layout, const gert::Shape &shape) const;
     size_t GetAxisIdx(const SASAxis &axis, const SASLayout &layout) const;
     uint32_t GetAxisNum(const gert::Shape &shape, const SASAxis &axis,const SASLayout &layout) const;
+    uint32_t GetSparseIndexWidth(const gert::Shape &shape, const SASLayout &layout) const;
     static constexpr int64_t invalidDimValue_ = std::numeric_limits<int64_t>::min();
 
     // BaseParams
@@ -506,6 +513,8 @@ public:
     uint32_t cmpMaxBlockNumPerBatch_ = 0;
     int32_t oriBlockSize_ = 0;
     int32_t cmpBlockSize_ = 0;
+    bool hasOriSparseIndices_ = false;
+    uint32_t oriSparseIndexWidth_ = 0;
 
     // template mode
     SASTemplateMode perfMode_ = SASTemplateMode::SWA_TEMPLATE_MODE;

--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_scfa_kernel.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_scfa_kernel.h
@@ -84,8 +84,8 @@ public:
 
     __aicore__ inline SparseAttnSharedkvScfa(){};
     __aicore__ inline void Init(__gm__ uint8_t *query, __gm__ uint8_t *oriKV, __gm__ uint8_t *cmpKV,
-                                __gm__ uint8_t *cmpSparseIndices, __gm__ uint8_t *oriBlockTable,
-                                __gm__ uint8_t *cmpBlockTable, __gm__ uint8_t *cuSeqlensQ,
+                                __gm__ uint8_t *oriSparseIndices, __gm__ uint8_t *cmpSparseIndices,
+                                __gm__ uint8_t *oriBlockTable, __gm__ uint8_t *cmpBlockTable, __gm__ uint8_t *cuSeqlensQ,
                                 __gm__ uint8_t* cuSeqlensKV, __gm__ uint8_t *cuSeqlensCmpKV,
                                 __gm__ uint8_t *seqUsedQ, __gm__ uint8_t *seqUsedKV, __gm__ uint8_t *sinks,
                                 __gm__ uint8_t *metadata, __gm__ uint8_t *attentionOut,
@@ -388,13 +388,15 @@ __aicore__ inline void SparseAttnSharedkvScfa<SAST>::UpdateInnerLoopCond()
 
 template <typename SAST>
 __aicore__ inline void SparseAttnSharedkvScfa<SAST>::Init(
-    __gm__ uint8_t *query, __gm__ uint8_t *oriKV, __gm__ uint8_t *cmpKV, __gm__ uint8_t *cmpSparseIndices,
-    __gm__ uint8_t *oriBlockTable, __gm__ uint8_t *cmpBlockTable, __gm__ uint8_t *cuSeqlensQ,
+    __gm__ uint8_t *query, __gm__ uint8_t *oriKV, __gm__ uint8_t *cmpKV, __gm__ uint8_t *oriSparseIndices,
+    __gm__ uint8_t *cmpSparseIndices, __gm__ uint8_t *oriBlockTable, __gm__ uint8_t *cmpBlockTable,
+    __gm__ uint8_t *cuSeqlensQ,
     __gm__ uint8_t* cuSeqlensKV, __gm__ uint8_t *cuSeqlensCmpKV, __gm__ uint8_t *seqUsedQ,
     __gm__ uint8_t *seqUsedKV, __gm__ uint8_t *sinks, __gm__ uint8_t *metadata, __gm__ uint8_t *attentionOut, __gm__ uint8_t *softmaxLse,
     __gm__ uint8_t *workspace, const SparseAttnSharedkvTilingData *__restrict tiling, __gm__ uint8_t *gmTiling,
     TPipe *tPipe)
 {
+    (void)oriSparseIndices;
     if ASCEND_IS_AIV {
         tmpBlockIdx = GetBlockIdx(); // vec:0-47
         aiCoreIdx = tmpBlockIdx / 2;

--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_swa_block_cube.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_swa_block_cube.h
@@ -41,7 +41,8 @@ public:
                                                GlobalTensor<OUT_T> attentionOutGm);
     __aicore__ inline void InitPageAttentionInfo(GlobalTensor<KV_T> oriKvGm, // const GlobalTensor<KV_T>& kvMergeGm,
                                                  GlobalTensor<int32_t> oriBlockTableGm,
-                                                 GlobalTensor<int32_t> cmpBlockTableGm);
+                                                 GlobalTensor<int32_t> cmpBlockTableGm,
+                                                 GlobalTensor<int32_t> oriSparseIndicesGm);
     __aicore__ inline void InitBuffers(TPipe *pipe);
 
     __aicore__ inline void AllocEventID();
@@ -113,6 +114,7 @@ private:
     // block_table
     GlobalTensor<int32_t> oriBlockTableGm;
     GlobalTensor<int32_t> cmpBlockTableGm;
+    GlobalTensor<int32_t> oriSparseIndicesGm;
 
     TBuf<TPosition::A1> bufQPL1;
     TBuf<TPosition::A1> bufKVL1;
@@ -185,10 +187,13 @@ __aicore__ inline void SWACubeBlock<SAST>::InitMm2GlobalTensor(GlobalTensor<KV_T
 template <typename SAST>
 __aicore__ inline void
 SWACubeBlock<SAST>::InitPageAttentionInfo(GlobalTensor<KV_T> oriKvGm, // const GlobalTensor<KV_T>& kvMergeGm,
-                                          GlobalTensor<int32_t> oriBlockTableGm, GlobalTensor<int32_t> cmpBlockTableGm)
+                                          GlobalTensor<int32_t> oriBlockTableGm,
+                                          GlobalTensor<int32_t> cmpBlockTableGm,
+                                          GlobalTensor<int32_t> oriSparseIndicesGm)
 {
     this->oriKvGm = oriKvGm;
     this->oriBlockTableGm = oriBlockTableGm;
+    this->oriSparseIndicesGm = oriSparseIndicesGm;
     if (constInfo.templateMode == CFA_TEMPLATE) {
         this->cmpBlockTableGm = cmpBlockTableGm;
     }
@@ -373,16 +378,11 @@ __aicore__ inline void SWACubeBlock<SAST>::ComputeMm1(const RunInfo &info, const
                     LocalTensor<KV_T> kTensor;
                     uint32_t copyRowCnt = 0;
 
-                    while (copyFinishRowCnt < nL1Size) {
-                        // 由于ori_left的存在， 即使第一块搬运也可能并非是pa_block的零点位
-                        copyRowCnt = constInfo.paOriBlockSize - curS2Offset % constInfo.paOriBlockSize;
-                        if (copyFinishRowCnt + copyRowCnt > nL1Size) {
-                            copyRowCnt = nL1Size - copyFinishRowCnt;
-                        }
+                    if (constInfo.hasOriSparseIndices) {
                         Position startPos;
                         startPos.bIdx = info.bIdx;
                         startPos.n2Idx = info.n2Idx;
-                        startPos.s2Idx = curS2Offset;
+                        startPos.s2Idx = 0;
                         // 256、32等待7buf命名更改
                         startPos.dIdx = kL1 * 256;  // mm1 右矩阵 bn2s2d, d为k轴不切; mm2 右矩阵, s2为k轴, d轴切分
                         PAShape shape;
@@ -392,13 +392,41 @@ __aicore__ inline void SWACubeBlock<SAST>::ComputeMm1(const RunInfo &info, const
                         shape.kvStride = constInfo.oriKvStride;
                         shape.actHeadDim = 256;
                         shape.maxblockNumPerBatch = constInfo.oriMaxBlockNumPerBatch;
-                        shape.copyRowNum = copyRowCnt;
+                        shape.copyRowNum = nL1Size;
                         shape.copyRowNumAlign = nL1SizeAlign;
-                        kTensor = bL1Tensor[copyFinishRowCnt * 16];
-                        DataCopyPA<KV_T>(kTensor, oriKvGm, oriBlockTableGm, shape, startPos);
-                        // 更新循环变量
-                        copyFinishRowCnt += copyRowCnt;
-                        curS2Offset += copyRowCnt;
+                        uint64_t sparseIndexBaseOffset =
+                            (info.qTokenOffset * constInfo.kvHeadNum + info.n2Idx) * constInfo.oriSparseIndexWidth;
+                        uint32_t sparseIndexStart = info.s2Idx * constInfo.s2BaseSize + nL1 * N_SPLIT_SIZE;
+                        DataCopyPABySlots<KV_T>(bL1Tensor, oriKvGm, oriSparseIndicesGm, shape, startPos,
+                                                sparseIndexBaseOffset, sparseIndexStart);
+                    } else {
+                        while (copyFinishRowCnt < nL1Size) {
+                            // 由于ori_left的存在， 即使第一块搬运也可能并非是pa_block的零点位
+                            copyRowCnt = constInfo.paOriBlockSize - curS2Offset % constInfo.paOriBlockSize;
+                            if (copyFinishRowCnt + copyRowCnt > nL1Size) {
+                                copyRowCnt = nL1Size - copyFinishRowCnt;
+                            }
+                            Position startPos;
+                            startPos.bIdx = info.bIdx;
+                            startPos.n2Idx = info.n2Idx;
+                            startPos.s2Idx = curS2Offset;
+                            // 256、32等待7buf命名更改
+                            startPos.dIdx = kL1 * 256;  // mm1 右矩阵 bn2s2d, d为k轴不切; mm2 右矩阵, s2为k轴, d轴切分
+                            PAShape shape;
+                            shape.blockSize = constInfo.paOriBlockSize;
+                            shape.headNum = constInfo.kvHeadNum;
+                            shape.headDim = constInfo.headDim;
+                            shape.kvStride = constInfo.oriKvStride;
+                            shape.actHeadDim = 256;
+                            shape.maxblockNumPerBatch = constInfo.oriMaxBlockNumPerBatch;
+                            shape.copyRowNum = copyRowCnt;
+                            shape.copyRowNumAlign = nL1SizeAlign;
+                            kTensor = bL1Tensor[copyFinishRowCnt * 16];
+                            DataCopyPA<KV_T>(kTensor, oriKvGm, oriBlockTableGm, shape, startPos);
+                            // 更新循环变量
+                            copyFinishRowCnt += copyRowCnt;
+                            curS2Offset += copyRowCnt;
+                        }
                     }
                 } else if constexpr (KV_LAYOUT_T == SAS_LAYOUT::BSND) {
                     Nd2NzParams nd2nzPara;
@@ -681,15 +709,11 @@ __aicore__ inline void SWACubeBlock<SAST>::ComputeMm2(const RunInfo &info, const
                 if (info.isOri) {
                     if constexpr (KV_LAYOUT_T == SAS_LAYOUT::PA_ND) {
                         uint32_t curS2Offset = info.s2Idx * constInfo.s2BaseSize + info.s2StartPoint + kL1 * K_L0_SPLIT_SIZE;
-                        while (copyFinishRowCnt < kL0Size) {
-                            copyRowCnt = constInfo.paOriBlockSize - curS2Offset % constInfo.paOriBlockSize;
-                            if (copyFinishRowCnt + copyRowCnt > kL0Size) {
-                                copyRowCnt = kL0Size - copyFinishRowCnt;
-                            }
+                        if (constInfo.hasOriSparseIndices) {
                             Position startPos;
                             startPos.bIdx = info.bIdx;
                             startPos.n2Idx = info.n2Idx;
-                            startPos.s2Idx = curS2Offset;
+                            startPos.s2Idx = 0;
                             startPos.dIdx = nL1 * N_SPLIT_SIZE;  // mm1 右矩阵 bn2s2d, d为k轴不切; mm2 右矩阵, s2为k轴, d轴切分
                             PAShape shape;
                             shape.blockSize = constInfo.paOriBlockSize;
@@ -698,14 +722,41 @@ __aicore__ inline void SWACubeBlock<SAST>::ComputeMm2(const RunInfo &info, const
                             shape.kvStride = constInfo.oriKvStride;
                             shape.actHeadDim = nL1Size;
                             shape.maxblockNumPerBatch = constInfo.oriMaxBlockNumPerBatch;
-                            shape.copyRowNum = copyRowCnt;
+                            shape.copyRowNum = kL0Size;
                             shape.copyRowNumAlign = kL0SizeAlign;
-                            subvTensor = bL1Tensor[(kL1 - kOffset) * K_L0_SPLIT_SIZE * N_SPLIT_SIZE + copyFinishRowCnt * 16];
-                            DataCopyPA<KV_T>(subvTensor, oriKvGm, oriBlockTableGm, shape, startPos);
+                            subvTensor = bL1Tensor[(kL1 - kOffset) * K_L0_SPLIT_SIZE * N_SPLIT_SIZE];
+                            uint64_t sparseIndexBaseOffset =
+                                (info.qTokenOffset * constInfo.kvHeadNum + info.n2Idx) * constInfo.oriSparseIndexWidth;
+                            uint32_t sparseIndexStart = info.s2Idx * constInfo.s2BaseSize + kL1 * K_L0_SPLIT_SIZE;
+                            DataCopyPABySlots<KV_T>(subvTensor, oriKvGm, oriSparseIndicesGm, shape, startPos,
+                                                    sparseIndexBaseOffset, sparseIndexStart);
+                        } else {
+                            while (copyFinishRowCnt < kL0Size) {
+                                copyRowCnt = constInfo.paOriBlockSize - curS2Offset % constInfo.paOriBlockSize;
+                                if (copyFinishRowCnt + copyRowCnt > kL0Size) {
+                                    copyRowCnt = kL0Size - copyFinishRowCnt;
+                                }
+                                Position startPos;
+                                startPos.bIdx = info.bIdx;
+                                startPos.n2Idx = info.n2Idx;
+                                startPos.s2Idx = curS2Offset;
+                                startPos.dIdx = nL1 * N_SPLIT_SIZE;  // mm1 右矩阵 bn2s2d, d为k轴不切; mm2 右矩阵, s2为k轴, d轴切分
+                                PAShape shape;
+                                shape.blockSize = constInfo.paOriBlockSize;
+                                shape.headNum = constInfo.kvHeadNum;
+                                shape.headDim = constInfo.headDim;
+                                shape.kvStride = constInfo.oriKvStride;
+                                shape.actHeadDim = nL1Size;
+                                shape.maxblockNumPerBatch = constInfo.oriMaxBlockNumPerBatch;
+                                shape.copyRowNum = copyRowCnt;
+                                shape.copyRowNumAlign = kL0SizeAlign;
+                                subvTensor = bL1Tensor[(kL1 - kOffset) * K_L0_SPLIT_SIZE * N_SPLIT_SIZE + copyFinishRowCnt * 16];
+                                DataCopyPA<KV_T>(subvTensor, oriKvGm, oriBlockTableGm, shape, startPos);
 
-                            // 更新循环变量
-                            copyFinishRowCnt += copyRowCnt;
-                            curS2Offset += copyRowCnt;
+                                // 更新循环变量
+                                copyFinishRowCnt += copyRowCnt;
+                                curS2Offset += copyRowCnt;
+                            }
                         }
                     } else if constexpr (KV_LAYOUT_T == SAS_LAYOUT::BSND) {
                         subvTensor = bL1Tensor[(kL1 - kOffset) * K_L0_SPLIT_SIZE * N_SPLIT_SIZE];

--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_swa_kernel.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_swa_kernel.h
@@ -80,8 +80,8 @@ public:
 
     __aicore__ inline SparseAttnSharedkvSwa(){};
     __aicore__ inline void Init(__gm__ uint8_t *query, __gm__ uint8_t *oriKV, __gm__ uint8_t *cmpKV,
-                                __gm__ uint8_t *cmpSparseIndices, __gm__ uint8_t *oriBlockTable,
-                                __gm__ uint8_t *cmpBlockTable, __gm__ uint8_t *cuSeqlensQ,
+                                __gm__ uint8_t *oriSparseIndices, __gm__ uint8_t *cmpSparseIndices,
+                                __gm__ uint8_t *oriBlockTable, __gm__ uint8_t *cmpBlockTable, __gm__ uint8_t *cuSeqlensQ,
                                 __gm__ uint8_t* cuSeqlensKV, __gm__ uint8_t *cuSeqlensCmpKV, __gm__ uint8_t *seqUsedQ,
                                 __gm__ uint8_t *seqUsedKV, __gm__ uint8_t *sinks, __gm__ uint8_t *metadata,
                                 __gm__ uint8_t *attentionOut, __gm__ uint8_t *softmaxLse, __gm__ uint8_t *workspace,
@@ -149,6 +149,7 @@ private:
 
     GlobalTensor<int32_t> oriBlockTableGm;
     GlobalTensor<int32_t> cmpBlockTableGm;
+    GlobalTensor<int32_t> oriSparseIndicesGm;
 
     GlobalTensor<int32_t> actualSeqLengthsQGm;
     GlobalTensor<int32_t> actualSeqLengthsKVGm;
@@ -181,6 +182,7 @@ private:
                                       RunInfo &info);
     __aicore__ inline int32_t GetActualSeqLenQ(uint32_t bIdx);
     __aicore__ inline int32_t GetActualSeqLenKV(uint32_t bIdx);
+    __aicore__ inline uint32_t GetOriSparseActualSeqLen();
     __aicore__ inline void GetBN2Idx(uint32_t bN2Idx, uint32_t &bIdx, uint32_t &n2Idx);
     // ================================Mm1==============================================
     __aicore__ inline void ComputeMm1(const RunInfo &info);
@@ -213,6 +215,8 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::InitTilingData()
     constInfo.oriKvStride = tilingData->baseParams.oriKvStride;
     constInfo.oriWinLeft = tilingData->baseParams.oriWinLeft;
     constInfo.oriWinRight = tilingData->baseParams.oriWinRight;
+    constInfo.hasOriSparseIndices = tilingData->baseParams.hasOriSparseIndices;
+    constInfo.oriSparseIndexWidth = tilingData->baseParams.oriSparseIndexWidth;
     constInfo.returnSoftmaxLse = tilingData->baseParams.returnSoftmaxLse;
 
     constInfo.actualLenDimsQ = tilingData->baseParams.actualLenDimsQ;
@@ -365,6 +369,26 @@ __aicore__ inline int32_t SparseAttnSharedkvSwa<SAST>::GetActualSeqLenKV(uint32_
 }
 
 template <typename SAST>
+__aicore__ inline uint32_t SparseAttnSharedkvSwa<SAST>::GetOriSparseActualSeqLen()
+{
+    if (!constInfo.hasOriSparseIndices || constInfo.oriSparseIndexWidth == 0 || tempLoopInfo.actOriS2Size <= 0) {
+        return 0;
+    }
+    uint64_t qTokenOffset = tempLoopInfo.actualSeqQPrefixSum + tempLoopInfo.s1StartIdx;
+    uint64_t sparseIndexBaseOffset =
+        (qTokenOffset * constInfo.kvHeadNum + tempLoopInfo.n2Idx) * constInfo.oriSparseIndexWidth;
+    uint32_t maxSparseLen = Min(static_cast<uint64_t>(constInfo.oriSparseIndexWidth),
+                                static_cast<uint64_t>(tempLoopInfo.actOriS2Size));
+    uint32_t sparseLen = 0;
+    for (; sparseLen < maxSparseLen; ++sparseLen) {
+        if (oriSparseIndicesGm.GetValue(sparseIndexBaseOffset + sparseLen) < 0) {
+            break;
+        }
+    }
+    return sparseLen;
+}
+
+template <typename SAST>
 __aicore__ inline void SparseAttnSharedkvSwa<SAST>::GetSparseActualSeqLen()
 {
     // 行无效通过ori部分判断, ori部分如果有行无效那么ori和cmp都有
@@ -384,7 +408,8 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::GetSparseActualSeqLen()
 template <typename SAST>
 __aicore__ inline void SparseAttnSharedkvSwa<SAST>::UpdateInnerLoopCond()
 {
-    if ((tempLoopInfo.actCmpS2Size == 0 && tempLoopInfo.actOriS2Size == 0) || (tempLoopInfo.actS1Size == 0)) {
+    bool hasOriWindow = tempLoopInfo.oriMaskRight >= tempLoopInfo.oriMaskLeft;
+    if ((tempLoopInfo.actCmpS2Size == 0 && !hasOriWindow) || (tempLoopInfo.actS1Size == 0)) {
         tempLoopInfo.curActSeqLenIsZero = true;
         return;
     }
@@ -396,8 +421,9 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::UpdateInnerLoopCond()
 
 template <typename SAST>
 __aicore__ inline void SparseAttnSharedkvSwa<SAST>::Init(
-    __gm__ uint8_t *query, __gm__ uint8_t *oriKV, __gm__ uint8_t *cmpKV, __gm__ uint8_t *cmpSparseIndices,
-    __gm__ uint8_t *oriBlockTable, __gm__ uint8_t *cmpBlockTable, __gm__ uint8_t *cuSeqlensQ,
+    __gm__ uint8_t *query, __gm__ uint8_t *oriKV, __gm__ uint8_t *cmpKV, __gm__ uint8_t *oriSparseIndices,
+    __gm__ uint8_t *cmpSparseIndices, __gm__ uint8_t *oriBlockTable, __gm__ uint8_t *cmpBlockTable,
+    __gm__ uint8_t *cuSeqlensQ,
     __gm__ uint8_t *cuSeqlensKV, __gm__ uint8_t *cuSeqlensCmpKV, __gm__ uint8_t *seqUsedQ,
     __gm__ uint8_t *seqUsedKV, __gm__ uint8_t *sinks, __gm__ uint8_t *metadata, __gm__ uint8_t *attentionOut, __gm__ uint8_t *softmaxLse,
     __gm__ uint8_t *workspace, const SparseAttnSharedkvTilingData *__restrict tiling, __gm__ uint8_t *gmTiling,
@@ -452,6 +478,9 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::Init(
 
     if constexpr (PAGE_ATTENTION) {
         oriBlockTableGm.SetGlobalBuffer((__gm__ int32_t *)oriBlockTable);
+        if (constInfo.hasOriSparseIndices) {
+            oriSparseIndicesGm.SetGlobalBuffer((__gm__ int32_t *)oriSparseIndices);
+        }
         if (constInfo.templateMode == CFA_TEMPLATE) {
             cmpBlockTableGm.SetGlobalBuffer((__gm__ int32_t *)cmpBlockTable);
         }
@@ -489,7 +518,7 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::Init(
         cubeBlock.InitParams(constInfo);
         cubeBlock.InitMm1GlobalTensor(queryGm, oriKvGm, cmpKvGm, mm1ResGm);
         cubeBlock.InitMm2GlobalTensor(vec1ResGm, mm2ResGm, attentionOutGm);
-        cubeBlock.InitPageAttentionInfo(oriKvGm, oriBlockTableGm, cmpBlockTableGm);
+        cubeBlock.InitPageAttentionInfo(oriKvGm, oriBlockTableGm, cmpBlockTableGm, oriSparseIndicesGm);
     }
     // 要在InitParams之后执行
     if (pipe != nullptr) {
@@ -562,6 +591,11 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::CalcParams(uint32_t loop, ui
     info.tensorBOffset = tensorBCoreOffset;
     info.tensorCmpBOffset = tensorCmpBCoreOffset;
     info.attenOutOffset = tensorACoreOffset;
+    if constexpr (LAYOUT_T == SAS_LAYOUT::TND) {
+        info.qTokenOffset = tempLoopInfo.actualSeqQPrefixSum + info.s1Idx;
+    } else {
+        info.qTokenOffset = info.bIdx * constInfo.qSeqSize + info.s1Idx;
+    }
 
     if (s2LoopIdx < tempLoopInfo.oriLoopTimes) {
         // S2首次循环只能在ori_kv
@@ -573,7 +607,7 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::CalcParams(uint32_t loop, ui
         } else {
             info.actualSingleProcessSInnerSize = constInfo.s2BaseSize;
         }
-        info.s2StartPoint = tempLoopInfo.oriMaskLeft;
+        info.s2StartPoint = constInfo.hasOriSparseIndices ? 0 : tempLoopInfo.oriMaskLeft;
         info.cmpS2IdLimit = 0;
     } else {
         if (constInfo.templateMode == CFA_TEMPLATE) {
@@ -686,11 +720,17 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::ProcessBalance()
             tempLoopInfo.s1EndIdx =
                 Min((tempLoopInfo.s1StartIdx + constInfo.mBaseSize / constInfo.gSize - 1), tempLoopInfo.actS1Size - 1);
             // 此处均为闭区间
-            tempLoopInfo.oriMaskRight = tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size +
-                                        static_cast<int32_t>(tempLoopInfo.s1EndIdx) + constInfo.oriWinRight;
-            tempLoopInfo.oriMaskLeft = Max(tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size +
-                                               static_cast<int32_t>(tempLoopInfo.s1EndIdx) - constInfo.oriWinLeft,
-                                           0);
+            if (constInfo.hasOriSparseIndices) {
+                uint32_t sparseOriS2Size = GetOriSparseActualSeqLen();
+                tempLoopInfo.oriMaskLeft = 0;
+                tempLoopInfo.oriMaskRight = sparseOriS2Size == 0 ? -1 : static_cast<int32_t>(sparseOriS2Size - 1U);
+            } else {
+                tempLoopInfo.oriMaskRight = tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size +
+                                            static_cast<int32_t>(tempLoopInfo.s1EndIdx) + constInfo.oriWinRight;
+                tempLoopInfo.oriMaskLeft = Max(tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size +
+                                                   static_cast<int32_t>(tempLoopInfo.s1EndIdx) - constInfo.oriWinLeft,
+                                               0);
+            }
             if (constInfo.templateMode == CFA_TEMPLATE) {
                 tempLoopInfo.cmpMaskRight = tempLoopInfo.actOriS2Size - tempLoopInfo.actS1Size;
             }
@@ -707,7 +747,9 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::ProcessBalance()
                     continue;
                 }
             } else {
-                oriSplitNum = CeilDiv(tempLoopInfo.oriMaskRight - tempLoopInfo.oriMaskLeft + 1, constInfo.s2BaseSize);
+                uint32_t oriS2Size = (tempLoopInfo.oriMaskRight >= tempLoopInfo.oriMaskLeft) ?
+                    static_cast<uint32_t>(tempLoopInfo.oriMaskRight - tempLoopInfo.oriMaskLeft + 1) : 0U;
+                oriSplitNum = CeilDiv(oriS2Size, constInfo.s2BaseSize);
                 s2SplitNum = oriSplitNum;
                 if (constInfo.templateMode == CFA_TEMPLATE) {
                     uint32_t cmpSplitNum = CeilDiv(tempLoopInfo.actCmpS2Size, constInfo.s2BaseSize);
@@ -718,6 +760,9 @@ __aicore__ inline void SparseAttnSharedkvSwa<SAST>::ProcessBalance()
             tempLoopInfo.s2LoopTimes = s2SplitNum;
             tempLoopInfo.oriLoopTimes = oriSplitNum;
             uint32_t s2LoopEnd = (isEnd && constInfo.s2End != 0) ? constInfo.s2End : tempLoopInfo.s2LoopTimes;
+            if (constInfo.hasOriSparseIndices) {
+                s2LoopEnd = Min(s2LoopEnd, s2SplitNum);
+            }
             tempLoopInfo.s2LoopTimes = s2LoopEnd;
             // 分核修改后需要打开
             // 当前s2是否被切，决定了输出是否要写到attenOut上

--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/sparse_attn_sharedkv.cpp
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/sparse_attn_sharedkv.cpp
@@ -29,7 +29,7 @@ using namespace SASKernel;
         templateClass<SASType<__VA_ARGS__>> op;                                                                        \
         GET_TILING_DATA_WITH_STRUCT(tilingdataClass, tiling_data_in, tiling);                                          \
         const tilingdataClass *__restrict tiling_data = &tiling_data_in;                                               \
-        op.Init(query, oriKV, cmpKV, cmpSparseIndices, oriBlockTable, cmpBlockTable, cuSeqlensQ,                       \
+        op.Init(query, oriKV, cmpKV, oriSparseIndices, cmpSparseIndices, oriBlockTable, cmpBlockTable, cuSeqlensQ,     \
                 cuSeqlensOriKv, cuSeqlensCmpKv, seqUsedQ, seqUsedKV,                                                   \
                 sinks, metadata, attentionOut, softmaxLse, user, tiling_data, tiling, &tPipe);                                     \
         op.Process();                                                                                                  \

--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/sparse_attn_sharedkv_common.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/sparse_attn_sharedkv_common.h
@@ -170,6 +170,34 @@ __aicore__ inline void DataCopyPA(LocalTensor<T> &dstTensor,  //l1
     }
 }
 
+template <typename T>
+__aicore__ inline void DataCopyPABySlots(LocalTensor<T> &dstTensor,  // l1
+                                         GlobalTensor<T> &srcTensor, // gm
+                                         GlobalTensor<int32_t> &sparseIndicesGm,
+                                         const PAShape &shape,
+                                         const Position &startPos,
+                                         uint64_t sparseIndexBaseOffset,
+                                         uint32_t sparseIndexStart)
+{
+    uint32_t blockElementCnt = 32 / sizeof(T);
+    for (uint32_t row = 0; row < shape.copyRowNum; ++row) {
+        int32_t slotId = sparseIndicesGm.GetValue(sparseIndexBaseOffset + sparseIndexStart + row);
+        if (slotId < 0) {
+            slotId = 0;
+        }
+        uint64_t blockId = static_cast<uint64_t>(slotId) / shape.blockSize;
+        uint64_t blockOffset = static_cast<uint64_t>(slotId) % shape.blockSize;
+        uint64_t offset = blockId * shape.kvStride;
+        offset += static_cast<uint64_t>(startPos.n2Idx * shape.headDim * shape.blockSize) +
+                  blockOffset * shape.headDim + startPos.dIdx;
+
+        LocalTensor<T> tmpDstTensor = dstTensor[row * blockElementCnt];
+        GlobalTensor<T> tmpSrcTensor = srcTensor[offset];
+        DataCopyGmNDToL1<T>(tmpDstTensor, tmpSrcTensor, 1, shape.copyRowNumAlign,
+                            shape.actHeadDim, shape.headDim);
+    }
+}
+
 struct RunInfo {
     uint32_t loop = 0;
     uint32_t cmpLoop = 0; // 用于判断取 用于merge的4块GM 中的哪一块
@@ -187,6 +215,7 @@ struct RunInfo {
     uint64_t tensorAOffset = 0;
     uint64_t tensorBOffset = 0;
     uint64_t attenOutOffset = 0;
+    uint64_t qTokenOffset = 0;
     uint64_t attenMaskOffset = 0;
     uint64_t topKBaseOffset = 0;
     uint32_t actualSingleProcessSInnerSize = 0;
@@ -302,6 +331,8 @@ struct ConstInfo {
     // sparse attr
     int64_t sparseBlockSize = 0;
     uint32_t sparseBlockCount = 0;
+    bool hasOriSparseIndices = false;
+    uint32_t oriSparseIndexWidth = 0;
 
     // cmp attr
     int64_t cmpRatio = 0;

--- a/csrc/attention/sparse_attn_sharedkv_metadata/README.md
+++ b/csrc/attention/sparse_attn_sharedkv_metadata/README.md
@@ -146,7 +146,7 @@
     <tr>
       <td>ori_win_left</td>
       <td>可选属性</td>
-      <td>表示q和ori_kv计算中q对过去token计算的数量，仅支持默认值127。</td>
+      <td>表示q和ori_kv计算中q对过去token计算的数量，支持非负值，默认值为127。</td>
       <td>INT32</td>
       <td>-</td>
     </tr>

--- a/csrc/attention/sparse_attn_sharedkv_metadata/op_kernel_aicpu/sparse_attn_sharedkv_metadata_aicpu.cpp
+++ b/csrc/attention/sparse_attn_sharedkv_metadata/op_kernel_aicpu/sparse_attn_sharedkv_metadata_aicpu.cpp
@@ -116,8 +116,8 @@ bool SparseAttnSharedkvMetadataCpuKernel::CheckSingleParam()
         return false;
     }
     // ori_win_left 校验
-    if (winLeft_ != 127) {
-        KERNEL_LOG_ERROR("ori_win_left should only be 127, but got %ld", winLeft_);
+    if (winLeft_ < 0) {
+        KERNEL_LOG_ERROR("ori_win_left should be non-negative, but got %ld", winLeft_);
         return false;
     }
     // layout_q 校验

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_attn_sharedkv_sparse_indices.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_attn_sharedkv_sparse_indices.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+from vllm_ascend.utils import enable_custom_op
+
+enable_custom_op()
+
+HEAD_DIM = 512
+NUM_Q_HEADS = 4
+NUM_KV_HEADS = 1
+SPARSE_INDEX_WIDTH = 128
+ORI_WIN_LEFT = 127
+ORI_WIN_RIGHT = 0
+
+
+def _reference_attention(
+    query: torch.Tensor,
+    kv_rows: list[torch.Tensor],
+    sinks: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    output = torch.empty_like(query)
+    for token_idx, token_kv in enumerate(kv_rows):
+        key = token_kv.expand(-1, NUM_Q_HEADS, -1).float()
+        scores = torch.einsum("hd,khd->hk", query[token_idx].float(), key) * softmax_scale
+        sink = sinks.float().view(NUM_Q_HEADS, 1)
+        scores_max = torch.maximum(scores.max(dim=-1, keepdim=True).values, sink)
+        exp_scores = torch.exp(scores - scores_max)
+        probs = exp_scores / (exp_scores.sum(dim=-1, keepdim=True) + torch.exp(sink - scores_max))
+        output[token_idx] = torch.einsum("hk,khd->hd", probs, key).to(query.dtype)
+    return output
+
+
+def _make_metadata(
+    query: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    seqused_kv: torch.Tensor,
+    ori_win_left: int,
+    ori_win_right: int,
+) -> torch.Tensor:
+    return torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
+        num_heads_q=NUM_Q_HEADS,
+        num_heads_kv=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        cu_seqlens_q=cu_seqlens_q,
+        seqused_kv=seqused_kv,
+        batch_size=1,
+        max_seqlen_q=query.shape[0],
+        max_seqlen_kv=int(seqused_kv.max().item()),
+        cmp_ratio=4,
+        ori_mask_mode=4,
+        cmp_mask_mode=3,
+        ori_win_left=ori_win_left,
+        ori_win_right=ori_win_right,
+        layout_q="TND",
+        layout_kv="PA_ND",
+        has_ori_kv=True,
+        has_cmp_kv=False,
+        device=str(query.device),
+    )
+
+
+def _run_operator(
+    query: torch.Tensor,
+    kv_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    seqused_kv: torch.Tensor,
+    sinks: torch.Tensor,
+    ori_sparse_indices: torch.Tensor | None,
+    ori_win_left: int = ORI_WIN_LEFT,
+    ori_win_right: int = ORI_WIN_RIGHT,
+) -> torch.Tensor:
+    metadata = _make_metadata(query, cu_seqlens_q, seqused_kv, ori_win_left, ori_win_right)
+    return torch.ops._C_ascend.npu_sparse_attn_sharedkv(
+        query,
+        ori_kv=kv_cache,
+        ori_sparse_indices=ori_sparse_indices,
+        ori_block_table=block_table,
+        cu_seqlens_q=cu_seqlens_q,
+        seqused_kv=seqused_kv,
+        sinks=sinks,
+        metadata=metadata,
+        softmax_scale=1.0 / math.sqrt(HEAD_DIM),
+        cmp_ratio=4,
+        ori_mask_mode=4,
+        cmp_mask_mode=3,
+        ori_win_left=ori_win_left,
+        ori_win_right=ori_win_right,
+        layout_q="TND",
+        layout_kv="PA_ND",
+    )[0]
+
+
+@torch.inference_mode()
+def test_sparse_original_indices_match_explicit_slot_reference():
+    torch.manual_seed(20260712)
+    device = torch.device("npu:0")
+    dtype = torch.bfloat16
+    cache_block_size = 16
+    query_tokens = 2
+    actual_kv_len = 64
+
+    query = (torch.randn(query_tokens, NUM_Q_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    kv_cache = (torch.randn(6, cache_block_size, NUM_KV_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    block_table = torch.tensor([[4, 1, 3, 0]], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, query_tokens], dtype=torch.int32, device=device)
+    seqused_kv = torch.tensor([actual_kv_len], dtype=torch.int32, device=device)
+    sinks = torch.linspace(-0.2, 0.2, NUM_Q_HEADS, dtype=torch.float32, device=device)
+
+    slot_rows = (
+        (1, 19, 34, 17, 80, 47, 65),
+        (63, 2, 48, 33, 79, 16),
+    )
+    sparse_indices = torch.full(
+        (query_tokens, NUM_KV_HEADS, SPARSE_INDEX_WIDTH),
+        -1,
+        dtype=torch.int32,
+        device=device,
+    )
+    for token_idx, slots in enumerate(slot_rows):
+        sparse_indices[token_idx, 0, : len(slots)] = torch.tensor(slots, dtype=torch.int32, device=device)
+
+    actual = _run_operator(
+        query,
+        kv_cache,
+        block_table,
+        cu_seqlens_q,
+        seqused_kv,
+        sinks,
+        sparse_indices,
+    )
+    flat_cache = kv_cache.reshape(-1, NUM_KV_HEADS, HEAD_DIM)
+    kv_rows = [flat_cache[torch.tensor(slots, dtype=torch.long, device=device)] for slots in slot_rows]
+    expected = _reference_attention(query, kv_rows, sinks, 1.0 / math.sqrt(HEAD_DIM))
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), atol=3e-2, rtol=3e-2)
+
+
+@torch.inference_mode()
+def test_sparse_original_indices_support_multiple_inner_loops():
+    torch.manual_seed(20260714)
+    device = torch.device("npu:0")
+    dtype = torch.bfloat16
+    cache_block_size = 16
+    actual_kv_len = 256
+    index_width = 256
+    visible_count = 140
+
+    query = (torch.randn(1, NUM_Q_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    kv_cache = (torch.randn(20, cache_block_size, NUM_KV_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    block_table = torch.arange(16, dtype=torch.int32, device=device).reshape(1, -1)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    seqused_kv = torch.tensor([actual_kv_len], dtype=torch.int32, device=device)
+    sinks = torch.zeros(NUM_Q_HEADS, dtype=torch.float32, device=device)
+    slots = (torch.arange(visible_count, dtype=torch.int32, device=device) * 37) % (
+        kv_cache.shape[0] * cache_block_size
+    )
+    sparse_indices = torch.full(
+        (1, NUM_KV_HEADS, index_width),
+        -1,
+        dtype=torch.int32,
+        device=device,
+    )
+    sparse_indices[0, 0, :visible_count] = slots
+
+    actual = _run_operator(
+        query,
+        kv_cache,
+        block_table,
+        cu_seqlens_q,
+        seqused_kv,
+        sinks,
+        sparse_indices,
+        ori_win_left=index_width - 1,
+    )
+    flat_cache = kv_cache.reshape(-1, NUM_KV_HEADS, HEAD_DIM)
+    expected = _reference_attention(
+        query,
+        [flat_cache[slots.long()]],
+        sinks,
+        1.0 / math.sqrt(HEAD_DIM),
+    )
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), atol=3e-2, rtol=3e-2)
+
+
+@torch.inference_mode()
+def test_sparse_original_indices_absent_preserves_swa_behavior():
+    torch.manual_seed(20260713)
+    device = torch.device("npu:0")
+    dtype = torch.bfloat16
+    cache_block_size = 16
+    actual_kv_len = 32
+
+    query = (torch.randn(1, NUM_Q_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    kv_cache = (torch.randn(4, cache_block_size, NUM_KV_HEADS, HEAD_DIM, device=device) * 0.02).to(dtype)
+    block_table = torch.tensor([[2, 0]], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    seqused_kv = torch.tensor([actual_kv_len], dtype=torch.int32, device=device)
+    sinks = torch.zeros(NUM_Q_HEADS, dtype=torch.float32, device=device)
+
+    actual = _run_operator(query, kv_cache, block_table, cu_seqlens_q, seqused_kv, sinks, None)
+    logical_positions = torch.arange(actual_kv_len, device=device)
+    physical_blocks = block_table[0, logical_positions // cache_block_size].long()
+    block_offsets = logical_positions % cache_block_size
+    kv_rows = [kv_cache[physical_blocks, block_offsets]]
+    expected = _reference_attention(query, kv_rows, sinks, 1.0 / math.sqrt(HEAD_DIM))
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), atol=3e-2, rtol=3e-2)
+
+
+@torch.inference_mode()
+def test_sparse_original_indices_reject_unaligned_width():
+    device = torch.device("npu:0")
+    query = torch.zeros(1, NUM_Q_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    kv_cache = torch.zeros(1, 16, NUM_KV_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    block_table = torch.zeros(1, 1, dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    seqused_kv = torch.tensor([1], dtype=torch.int32, device=device)
+    sinks = torch.zeros(NUM_Q_HEADS, dtype=torch.float32, device=device)
+    sparse_indices = torch.zeros(1, NUM_KV_HEADS, 64, dtype=torch.int32, device=device)
+
+    with pytest.raises(RuntimeError):
+        _run_operator(query, kv_cache, block_table, cu_seqlens_q, seqused_kv, sinks, sparse_indices)

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_prepare_inputs_padded.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_prepare_inputs_padded.py
@@ -2,11 +2,11 @@ import gc
 
 import pytest
 import torch
-from vllm.triton_utils import triton
 
-from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
-from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
-from vllm_ascend.spec_decode.llm_base_proposer import _PREPARE_INPUTS_BLOCK_SIZE as BLOCK_SIZE
+from vllm_ascend.ops.triton.spec_decode.utils import (
+    prepare_inputs_padded_kernel,
+    prepare_next_token_padded_kernel,
+)
 
 
 def prepare_inputs_padded_ref(
@@ -55,22 +55,53 @@ def test_prepare_inputs_padded(num_reqs):
     # Run Triton kernel
     out_tri = torch.empty(num_reqs, dtype=torch.int32, device=device)
     num_rejected_tokens = torch.empty(num_reqs, dtype=torch.int32, device=device)
-    num_blocks_needed = triton.cdiv(num_reqs, BLOCK_SIZE)
-    num_vector_core = get_vectorcore_num()
-    grid_size = min(num_blocks_needed, num_vector_core)
-    grid = (grid_size,)
-
-    prepare_inputs_padded_kernel[grid](
+    prepare_inputs_padded_kernel[(num_reqs,)](
         cu_num_draft_tokens,
         valid_sampled_tokens_count,
         query_start_loc,
         out_tri,
         num_rejected_tokens,
         num_reqs,
-        BLOCK_SIZE=BLOCK_SIZE,
     )
 
     torch.testing.assert_close(out_tri, out_ref)
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()
+
+
+def test_prepare_next_token_padded():
+    sampled_token_ids = torch.tensor(
+        [
+            [10, 11, 12, 13, 14, 15],
+            [20, 21, 22, -1, -1, -1],
+            [30, -1, -1, -1, -1, -1],
+            [-1, -1, -1, -1, -1, -1],
+        ],
+        dtype=torch.int32,
+        device="npu",
+    )
+    backup_token_ids = torch.tensor([40, 41, 42, 43], dtype=torch.int32, device="npu")
+    next_token_ids = torch.empty(4, dtype=torch.int32, device="npu")
+    valid_sampled_tokens_count = torch.empty(4, dtype=torch.int32, device="npu")
+
+    prepare_next_token_padded_kernel[(4,)](
+        sampled_token_ids,
+        backup_token_ids,
+        next_token_ids,
+        valid_sampled_tokens_count,
+        128000,
+        6,
+        4,
+        sampled_token_ids.stride(0),
+        BLOCK_SIZE_TOKENS=8,
+    )
+
+    torch.testing.assert_close(
+        next_token_ids,
+        torch.tensor([15, 22, 30, 43], dtype=torch.int32, device="npu"),
+    )
+    torch.testing.assert_close(
+        valid_sampled_tokens_count,
+        torch.tensor([6, 3, 1, 0], dtype=torch.int32, device="npu"),
+    )

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -1,6 +1,7 @@
 import json
 import os
 import tempfile
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -37,7 +38,7 @@ class TestAscendModelSlimConfig(TestBase):
             "shard2.weight": "FLOAT",
         }
         self.ascend_config = AscendModelSlimConfig(self.sample_config)
-        self.ascend_config.packed_modules_mapping = None
+        cast(Any, self.ascend_config).packed_modules_mapping = None
 
     def test_init(self):
         self.assertEqual(self.ascend_config.quant_description, self.sample_config)
@@ -417,6 +418,63 @@ class TestQuantPrefixMapper(TestBase):
                 self.assertEqual(prefix, "language_model.model.layers.0.experts")
                 self.assertEqual(get_linear_quant_type(quant_description, prefix, packed_mapping), "W8A8_DYNAMIC")
                 self.assertFalse(config.is_layer_skipped_ascend(prefix, packed_mapping))
+
+    def test_deepseek_v4_mtp_maps_expanded_runtime_layers_to_raw_quant_keys(self):
+        config = AscendModelSlimConfig(
+            {
+                "hc_head_fn": "FLOAT",
+                "mtp.0.attn.wq_a.weight": "W8A8_DYNAMIC",
+                "mtp.0.ffn.shared_experts.w1.weight": "W8A8_DYNAMIC",
+                "mtp.0.ffn.shared_experts.w3.weight": "W8A8_DYNAMIC",
+                "mtp.0.ffn.experts.0.w1.weight": "W4A8_DYNAMIC",
+                "mtp.0.ffn.experts.0.w2.weight": "W4A8_DYNAMIC",
+                "mtp.0.ffn.experts.0.w3.weight": "W4A8_DYNAMIC",
+            }
+        )
+        cases = {
+            "model.layers.43.self_attn.wq_a": "model.mtp.0.self_attn.wq_a",
+            "model.layers.43.mlp.shared_experts.gate_up_proj": ("model.mtp.0.mlp.shared_experts.gate_up_proj"),
+            "model.layers.43.mlp.experts": "model.mtp.0.mlp.experts",
+        }
+
+        for model_type in ("deepseek_v4", "deepseek_mtp"):
+            for prefix, expected in cases.items():
+                with self.subTest(model_type=model_type, prefix=prefix):
+                    self.assertEqual(
+                        config.quant_prefix_mapper(
+                            model_type,
+                            prefix,
+                            num_hidden_layers=43,
+                        ),
+                        expected,
+                    )
+
+    def test_deepseek_v4_mtp_direct_quant_key_takes_precedence(self):
+        config = AscendModelSlimConfig(
+            {
+                "model.layers.43.self_attn.wq_a.weight": "FLOAT",
+                "model.mtp.0.self_attn.wq_a.weight": "W8A8_DYNAMIC",
+            }
+        )
+
+        prefix = config.quant_prefix_mapper(
+            "deepseek_v4",
+            "model.layers.43.self_attn.wq_a",
+            num_hidden_layers=43,
+        )
+
+        self.assertEqual(prefix, "model.layers.43.self_attn.wq_a")
+
+    def test_deepseek_v4_mtp_missing_quant_key_keeps_runtime_prefix(self):
+        config = AscendModelSlimConfig({"model.layers.42.self_attn.wq_a.weight": "W8A8_DYNAMIC"})
+
+        prefix = config.quant_prefix_mapper(
+            "deepseek_mtp",
+            "model.layers.43.self_attn.wq_a",
+            num_hidden_layers=43,
+        )
+
+        self.assertEqual(prefix, "model.layers.43.self_attn.wq_a")
 
     def test_gemma4_packed_modules_mapping_covers_attention_mlp_and_moe(self):
         expected_mapping = {

--- a/tests/ut/sample/a2/test_probabilistic_rejection.py
+++ b/tests/ut/sample/a2/test_probabilistic_rejection.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID
+
+from vllm_ascend.sample.rejection_sampler import rejection_random_sample_logits_pytorch
+from vllm_ascend.worker.v2.spec_decode.rejection_sampler_utils import rejection_sample
+
+
+def _run_extreme_rejection_case() -> tuple[torch.Tensor, torch.Tensor]:
+    num_requests = 16
+    vocab_size = 4
+    num_speculative_steps = 1
+    device = torch.device("npu")
+
+    target_logits = torch.full((num_requests * 2, vocab_size), -8.0, device=device)
+    target_logits[0::2, 1] = 8.0
+    target_logits[1::2, 2] = 8.0
+    draft_logits = torch.full((num_requests, num_speculative_steps, vocab_size), -8.0, device=device)
+    draft_logits[:, 0, 0] = 8.0
+
+    draft_sampled = torch.zeros(num_requests * 2, dtype=torch.int64, device=device)
+    cu_num_logits = torch.arange(0, num_requests * 2 + 1, 2, dtype=torch.int32, device=device)
+    idx_mapping = torch.arange(num_requests, dtype=torch.int32, device=device)
+    expanded_idx_mapping = idx_mapping.repeat_interleave(2)
+    expanded_local_pos = torch.tensor([0, 1], dtype=torch.int32, device=device).repeat(num_requests)
+    positions = torch.arange(num_requests * 2, dtype=torch.int32, device=device)
+    temperature = torch.ones(num_requests, device=device)
+    seeds = torch.arange(100, 100 + num_requests, dtype=torch.int64, device=device)
+
+    return rejection_sample(
+        target_logits,
+        draft_logits,
+        draft_sampled,
+        cu_num_logits,
+        positions,
+        idx_mapping,
+        expanded_idx_mapping,
+        expanded_local_pos,
+        temperature,
+        seeds,
+        num_speculative_steps,
+    )
+
+
+def test_probabilistic_rejection_uses_nonzero_uniform_and_is_repeatable():
+    sampled_first, num_sampled_first = _run_extreme_rejection_case()
+    sampled_second, num_sampled_second = _run_extreme_rejection_case()
+    torch.npu.synchronize()
+
+    assert torch.equal(num_sampled_first, num_sampled_second)
+    assert torch.equal(sampled_first[:, 0], sampled_second[:, 0])
+    assert (sampled_first[:, 0] == 1).all()
+    assert (num_sampled_first == 1).all()
+
+
+def test_logits_space_recovered_token_on_npu():
+    device = torch.device("npu")
+    output_token_ids = torch.full((1, 3), PLACEHOLDER_TOKEN_ID, dtype=torch.int32, device=device)
+    draft_probs = torch.tensor([[0.5, 0.4, 0.1], [0.8, 0.1, 0.1]], device=device)
+    target_probs = torch.tensor([[0.7, 0.2, 0.1], [0.2, 0.1, 0.7]], device=device)
+
+    rejection_random_sample_logits_pytorch(
+        output_token_ids,
+        torch.tensor([2], dtype=torch.int32, device=device),
+        torch.tensor([0, 0], dtype=torch.int32, device=device),
+        draft_probs.log(),
+        target_probs.log(),
+        torch.tensor([[9]], dtype=torch.int32, device=device),
+        torch.tensor([0.8, 0.5], dtype=torch.float64, device=device),
+        torch.tensor([False], device=device),
+        max_spec_len=2,
+        num_draft_tokens=[2],
+        generators={},
+    )
+    torch.npu.synchronize()
+
+    assert output_token_ids.cpu().tolist() == [[0, 2, PLACEHOLDER_TOKEN_ID]]

--- a/tests/ut/sample/test_gumbel_noise.py
+++ b/tests/ut/sample/test_gumbel_noise.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+from vllm_ascend.worker.v2.sample.gumbel import flipped_gumbel_noise
+
+
+def test_flipped_gumbel_noise_matches_fp32_formula():
+    uniform = torch.tensor(
+        [4.6566127342e-10, 1e-6, 0.25, 0.5, 0.999],
+        dtype=torch.float32,
+    )
+
+    actual = flipped_gumbel_noise(uniform)
+    expected = -torch.log(-torch.log1p(-uniform.clamp_min(4.6566127342e-10)))
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_flipped_gumbel_noise_preserves_winning_tail():
+    smallest_uniform = torch.tensor([4.6566127342e-10], dtype=torch.float32)
+    rounded_complement = torch.tensor([1.0 - 2.0**-24], dtype=torch.float32)
+
+    flipped_tail = flipped_gumbel_noise(smallest_uniform)
+    naive_tail = -torch.log(-torch.log(rounded_complement))
+
+    assert flipped_tail.item() > 20.0
+    assert naive_tail.item() < 17.0

--- a/tests/ut/sample/test_rejection_sampler.py
+++ b/tests/ut/sample/test_rejection_sampler.py
@@ -1,14 +1,24 @@
-from unittest.mock import patch
+import inspect
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 
 from tests.ut.base import TestBase
+from vllm_ascend.ops.triton.reject_sample import (
+    rejection_greedy_sample_triton,
+    rejection_greedy_sample_with_triton,
+)
 from vllm_ascend.sample.rejection_sampler import (
+    _residual_logprobs_from_logits,
     expand_batch_to_tokens,
     expand_pytorch,
     rejection_greedy_sample_pytorch,
     rejection_random_sample_block_verify_pytorch,
+    rejection_random_sample_logits_pytorch,
     rejection_random_sample_pytorch,
+    rejection_sample,
     sample_recovered_tokens_blockwise_pytorch,
     sample_recovered_tokens_pytorch,
 )
@@ -29,6 +39,196 @@ def mock_pin_memory(original_func):
 
 
 class TestAscendRejectionSampler(TestBase):
+    def test_greedy_triton_uses_safe_first_previous_cumsum_address(self):
+        source = inspect.getsource(rejection_greedy_sample_triton.fn)
+
+        assert "has_prev = offset > 0" in source
+        assert "prev_offset = tl.where(has_prev, offset - 1, 0)" in source
+        assert "cu_num_draft_tokens_ptr + prev_offset" in source
+        assert "mask=is_greedy_mask & has_prev" in source
+
+    @patch("vllm_ascend.ops.triton.reject_sample.rejection_greedy_sample_spec_len_1_triton")
+    @patch("vllm_ascend.ops.triton.reject_sample.rejection_greedy_sample_triton")
+    def test_spec_len_one_kernel_requires_configured_spec_len_one(self, mock_kernel, mock_spec_len_one_kernel):
+        tensors = [MagicMock() for _ in range(5)]
+        tensors[0].shape = (2, 6)
+
+        rejection_greedy_sample_with_triton(
+            tensors[0],
+            [1, 1],
+            tensors[1],
+            tensors[2],
+            tensors[3],
+            tensors[4],
+            None,
+            max_spec_len=5,
+            grid=2,
+            block_size=1,
+        )
+
+        mock_kernel.__getitem__.return_value.assert_called_once()
+        mock_spec_len_one_kernel.__getitem__.assert_not_called()
+
+    def test_residual_logprobs_match_probability_reference(self):
+        draft_probs = torch.tensor([[0.6, 0.3, 0.1]], dtype=torch.float32)
+        target_probs = torch.tensor([[0.2, 0.5, 0.3]], dtype=torch.float32)
+
+        target_logprobs, residual_logprobs = _residual_logprobs_from_logits(draft_probs.log(), target_probs.log())
+
+        torch.testing.assert_close(target_logprobs.exp(), target_probs)
+        torch.testing.assert_close(
+            residual_logprobs.exp(),
+            (target_probs - draft_probs).clamp_min(0),
+        )
+
+    def test_residual_logprobs_handle_masked_logits(self):
+        draft_logits = torch.tensor([[0.0, float("-inf"), float("-inf")]])
+        target_logits = torch.tensor([[0.0, -1.0, float("-inf")]])
+
+        _, residual_logprobs = _residual_logprobs_from_logits(draft_logits, target_logits)
+
+        assert torch.isfinite(residual_logprobs[0, 1])
+        assert torch.isneginf(residual_logprobs[0, 0])
+        assert torch.isneginf(residual_logprobs[0, 2])
+        assert not torch.isnan(residual_logprobs).any()
+
+    @patch(
+        "vllm_ascend.sample.rejection_sampler.sample_recovered_tokens_from_logits_pytorch",
+        return_value=torch.tensor([2, 1], dtype=torch.int32),
+    )
+    def test_logits_rejection_stops_at_first_rejected_token(self, _mock_recovered):
+        output_token_ids = torch.full((1, 3), PLACEHOLDER_TOKEN_ID, dtype=torch.int32)
+        draft_token_ids = torch.tensor([0, 0], dtype=torch.int32)
+        draft_logits = torch.tensor([[0.5, 0.4, 0.1], [0.8, 0.1, 0.1]]).log()
+        target_logits = torch.tensor([[0.7, 0.2, 0.1], [0.2, 0.1, 0.7]]).log()
+
+        rejection_random_sample_logits_pytorch(
+            output_token_ids,
+            torch.tensor([2], dtype=torch.int32),
+            draft_token_ids,
+            draft_logits,
+            target_logits,
+            torch.tensor([[9]], dtype=torch.int32),
+            torch.tensor([0.8, 0.5], dtype=torch.float64),
+            torch.tensor([False]),
+            max_spec_len=2,
+            num_draft_tokens=[2],
+            generators={},
+        )
+
+        assert output_token_ids.tolist() == [[0, 1, PLACEHOLDER_TOKEN_ID]]
+
+    def test_logits_rejection_adds_bonus_after_accepting_all(self):
+        output_token_ids = torch.full((1, 3), PLACEHOLDER_TOKEN_ID, dtype=torch.int32)
+        probs = torch.tensor([[0.6, 0.4], [0.3, 0.7]], dtype=torch.float32)
+
+        rejection_random_sample_logits_pytorch(
+            output_token_ids,
+            torch.tensor([2], dtype=torch.int32),
+            torch.tensor([0, 1], dtype=torch.int32),
+            probs.log(),
+            probs.log(),
+            torch.tensor([[9]], dtype=torch.int32),
+            torch.tensor([0.99, 0.99], dtype=torch.float64),
+            torch.tensor([False]),
+            max_spec_len=2,
+            num_draft_tokens=[2],
+            generators={},
+        )
+
+        assert output_token_ids.tolist() == [[0, 1, 9]]
+
+    def test_logits_rejection_zero_draft_returns_bonus(self):
+        output_token_ids = torch.full((1, 2), PLACEHOLDER_TOKEN_ID, dtype=torch.int32)
+
+        rejection_random_sample_logits_pytorch(
+            output_token_ids,
+            torch.tensor([0], dtype=torch.int32),
+            torch.empty(0, dtype=torch.int32),
+            torch.empty(0, 3),
+            torch.empty(0, 3),
+            torch.tensor([[7]], dtype=torch.int32),
+            torch.empty(0, dtype=torch.float64),
+            torch.tensor([False]),
+            max_spec_len=1,
+            num_draft_tokens=[0],
+            generators={},
+        )
+
+        assert output_token_ids.tolist() == [[7, PLACEHOLDER_TOKEN_ID]]
+
+    @patch(
+        "vllm_ascend.sample.rejection_sampler.sample_recovered_tokens_from_logits_pytorch",
+        return_value=torch.tensor([2], dtype=torch.int32),
+    )
+    @patch("vllm_ascend.sample.rejection_sampler.generate_uniform_probs")
+    @patch("vllm_ascend.sample.rejection_sampler.get_ascend_config")
+    @patch("vllm_ascend.sample.rejection_sampler.HAS_TRITON", False)
+    def test_rejection_sample_uses_logits_without_draft_probs(
+        self,
+        mock_ascend_config,
+        mock_uniform,
+        _mock_recovered,
+    ):
+        mock_ascend_config.return_value = SimpleNamespace(
+            enable_reduce_sample=False,
+            rejection_sampler_config=SimpleNamespace(
+                enable_block_verify=False,
+                enable_entropy_verify=False,
+                posterior_threshold=0.95,
+                posterior_alpha=0.4,
+            ),
+        )
+        mock_uniform.return_value = torch.tensor([0.5], dtype=torch.float64)
+        output = rejection_sample(
+            torch.tensor([0], dtype=torch.int32),
+            [1],
+            1,
+            torch.tensor([1], dtype=torch.int32),
+            None,
+            torch.tensor([[0.2, 0.1, 0.7]], dtype=torch.float32).log().contiguous(),
+            torch.tensor([[9]], dtype=torch.int32),
+            SimpleNamespace(
+                all_greedy=False,
+                all_random=True,
+                temperature=torch.tensor([1.0]),
+                generators={},
+            ),
+            draft_logits=torch.tensor([[0.8, 0.1, 0.1]], dtype=torch.float32).log().contiguous(),
+        )
+
+        assert output.tolist() == [[2, PLACEHOLDER_TOKEN_ID]]
+
+    @patch("vllm_ascend.sample.rejection_sampler.get_ascend_config")
+    @patch("vllm_ascend.sample.rejection_sampler.HAS_TRITON", False)
+    def test_rejection_sample_rejects_mismatched_logits_shape(self, mock_ascend_config):
+        mock_ascend_config.return_value = SimpleNamespace(
+            enable_reduce_sample=False,
+            rejection_sampler_config=SimpleNamespace(
+                enable_block_verify=False,
+                enable_entropy_verify=False,
+                posterior_threshold=0.95,
+                posterior_alpha=0.4,
+            ),
+        )
+        with pytest.raises(ValueError, match="must have the same shape"):
+            rejection_sample(
+                torch.tensor([0], dtype=torch.int32),
+                [1],
+                1,
+                torch.tensor([1], dtype=torch.int32),
+                None,
+                torch.zeros(1, 3),
+                torch.tensor([[9]], dtype=torch.int32),
+                SimpleNamespace(
+                    all_greedy=False,
+                    all_random=True,
+                    temperature=torch.tensor([1.0]),
+                    generators={},
+                ),
+                draft_logits=torch.zeros(1, 2),
+            )
+
     @patch("torch.arange", new=mock_pin_memory(torch.arange))
     @patch("torch.ones", new=mock_pin_memory(torch.ones))
     @patch("torch.full", new=mock_pin_memory(torch.full))

--- a/tests/ut/spec_decode/test_deepseek_v4_draft_hooks.py
+++ b/tests/ut/spec_decode/test_deepseek_v4_draft_hooks.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+
+from vllm_ascend.models.deepseek_v4 import (
+    AscendDeepseekV4ForCausalLM,
+    DeepseekV4Model,
+    _is_dspark_target_layer,
+)
+from vllm_ascend.models.deepseek_v4_draft import (
+    is_deepseek_v4_dspark_config,
+    remap_dspark_mtp_weight_name,
+)
+from vllm_ascend.patch.platform.patch_speculative_config import hf_config_override
+
+
+def _make_dspark_config() -> PretrainedConfig:
+    return PretrainedConfig(
+        model_type="deepseek_v4",
+        architectures=["DeepseekV4ForCausalLM"],
+        num_hidden_layers=43,
+        dspark_block_size=5,
+        dspark_noise_token_id=128799,
+        dspark_target_layer_ids=[40, 41, 42],
+    )
+
+
+def test_dspark_config_detection():
+    config = _make_dspark_config()
+
+    assert is_deepseek_v4_dspark_config(config)
+    assert not is_deepseek_v4_dspark_config(SimpleNamespace(model_type="deepseek_v4", dspark_block_size=0))
+
+
+def test_dspark_speculative_config_override_exposes_draft_contract():
+    config = hf_config_override(_make_dspark_config())
+
+    assert config.model_type == "deepseek_mtp"
+    assert config.architectures == ["DeepSeekV4DSparkMTPModel"]
+    assert not hasattr(config, "n_predict")
+    assert config.ptd_token_id == 128799
+    assert config.dspark_num_mtp_layers == 3
+    assert not hasattr(config, "eagle_aux_hidden_state_layer_ids")
+
+
+def test_non_dspark_deepseek_v4_keeps_existing_mtp_override():
+    config = PretrainedConfig(
+        model_type="deepseek_v4",
+        architectures=["DeepseekV4ForCausalLM"],
+        num_nextn_predict_layers=1,
+    )
+
+    overridden = hf_config_override(config)
+
+    assert overridden.architectures == ["DeepSeekV4MTPModel"]
+    assert not hasattr(overridden, "eagle_aux_hidden_state_layer_ids")
+
+
+@pytest.mark.parametrize(
+    ("source_name", "expected_name"),
+    [
+        ("mtp.0.main_proj.weight", "model.layers.43.main_proj.weight"),
+        ("mtp.0.main_norm.weight", "model.layers.43.main_norm.weight"),
+        ("mtp.0.attn.attn_sink", "model.layers.43.self_attn.attn_sink"),
+        ("mtp.0.attn.wq_a.weight", "model.layers.43.self_attn.wq_a.weight"),
+        (
+            "mtp.1.ffn.shared_experts.w1.weight",
+            "model.layers.44.mlp.shared_experts.gate_proj.weight",
+        ),
+        (
+            "mtp.1.ffn.shared_experts.w2.weight",
+            "model.layers.44.mlp.shared_experts.down_proj.weight",
+        ),
+        (
+            "mtp.1.ffn.shared_experts.w3.weight",
+            "model.layers.44.mlp.shared_experts.up_proj.weight",
+        ),
+        (
+            "mtp.1.ffn.gate.bias",
+            "model.layers.44.mlp.gate.e_score_correction_bias",
+        ),
+        ("mtp.2.hc_head_fn", "model.layers.45.hc_head_fn"),
+        (
+            "mtp.2.markov_head.markov_w2.weight",
+            "model.layers.45.markov_head.markov_w2.weight",
+        ),
+    ],
+)
+def test_remap_dspark_mtp_weight_name(source_name: str, expected_name: str):
+    assert remap_dspark_mtp_weight_name(source_name, num_hidden_layers=43) == expected_name
+
+
+def test_remap_dspark_mtp_weight_name_ignores_non_draft_weights():
+    assert remap_dspark_mtp_weight_name("model.layers.0.attn.wq_a.weight", 43) is None
+    assert remap_dspark_mtp_weight_name("mtp.2.confidence_head.proj.weight", 43) is None
+
+
+def test_dspark_target_hidden_states_use_dedicated_buffer():
+    wrapper = AscendDeepseekV4ForCausalLM.__new__(AscendDeepseekV4ForCausalLM)
+    nn.Module.__init__(wrapper)
+    model = DeepseekV4Model.__new__(DeepseekV4Model)
+    nn.Module.__init__(model)
+    model._mtp_hidden_buffer = torch.zeros((2, 16))
+    model._dspark_target_layer_ids = (40, 41, 42)
+    model._dspark_hidden_buffer = torch.ones((2, 12))
+    wrapper.model = model
+
+    assert wrapper.get_mtp_target_hidden_states() is model._dspark_hidden_buffer
+    model._dspark_target_layer_ids = ()
+    assert wrapper.get_mtp_target_hidden_states() is model._mtp_hidden_buffer
+
+
+def test_dspark_target_layer_ids_use_checkpoint_semantics():
+    target_layer_ids = {40, 41, 42}
+
+    assert not _is_dspark_target_layer(39, target_layer_ids)
+    assert _is_dspark_target_layer(40, target_layer_ids)
+    assert _is_dspark_target_layer(41, target_layer_ids)
+    assert _is_dspark_target_layer(42, target_layer_ids)

--- a/tests/ut/spec_decode/test_deepseek_v4_dspark_model.py
+++ b/tests/ut/spec_decode/test_deepseek_v4_dspark_model.py
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+import vllm_ascend.models.deepseek_v4_dspark as dspark_module
+from vllm_ascend.models.deepseek_v4_dspark import (
+    DeepseekV4DSparkModel,
+    DeepSeekV4DSparkMTP,
+    _apply_dspark_quarot_rotation,
+    _draft_quant_config,
+    _get_dspark_num_mtp_layers,
+    _load_dspark_quarot_rotation,
+)
+
+
+def test_dspark_quarot_load_and_apply(tmp_path):
+    rotation_path = tmp_path / "optional" / "quarot.safetensors"
+    rotation_path.parent.mkdir()
+    rotation = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    save_file({"global_rotation": rotation}, rotation_path)
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(model=str(tmp_path)),
+        quant_config=SimpleNamespace(
+            quant_description={
+                "optional": {"quarot": {"rotation_map": {"global_rotation": "optional/quarot.safetensors"}}}
+            }
+        ),
+    )
+
+    loaded = _load_dspark_quarot_rotation(vllm_config)
+
+    torch.testing.assert_close(loaded, rotation)
+    hidden_states = torch.tensor([[10.0, 20.0]])
+    torch.testing.assert_close(
+        _apply_dspark_quarot_rotation(hidden_states, loaded, transpose=False),
+        torch.tensor([[70.0, 100.0]]),
+    )
+    torch.testing.assert_close(
+        _apply_dspark_quarot_rotation(hidden_states, loaded, transpose=True),
+        torch.tensor([[50.0, 110.0]]),
+    )
+
+
+def test_dspark_quarot_requires_same_device():
+    with pytest.raises(RuntimeError, match="same device"):
+        _apply_dspark_quarot_rotation(
+            torch.ones(1, 2),
+            torch.empty(2, 2, device="meta"),
+            transpose=False,
+        )
+
+
+def test_dspark_draft_quant_config_and_layer_count():
+    quant_config = object()
+    draft_config = SimpleNamespace(dspark_mtp_dequantized_to_bf16=False)
+    vllm_config = SimpleNamespace(
+        quant_config=quant_config,
+        speculative_config=SimpleNamespace(draft_model_config=SimpleNamespace(hf_config=draft_config)),
+    )
+
+    assert _draft_quant_config(vllm_config) is quant_config
+    draft_config.dspark_mtp_dequantized_to_bf16 = True
+    assert _draft_quant_config(vllm_config) is None
+    assert _get_dspark_num_mtp_layers(SimpleNamespace(n_mtp_layers=4)) == 4
+    assert _get_dspark_num_mtp_layers(SimpleNamespace()) == 3
+
+
+def test_dspark_context_kv_uses_each_layer_cache(monkeypatch):
+    calls = []
+
+    class FakeProjection:
+        def __init__(self, offset):
+            self.offset = offset
+
+        def __call__(self, hidden_states):
+            return hidden_states + self.offset
+
+    def make_layer(name, offset):
+        return SimpleNamespace(
+            self_attn=SimpleNamespace(
+                wkv=FakeProjection(offset),
+                kv_norm=lambda value: value * 2,
+                head_dim=4,
+                nope_head_dim=2,
+                rotary_emb=SimpleNamespace(layername=name),
+                dsa_attn=SimpleNamespace(
+                    swa_cache_layer=SimpleNamespace(prefix=f"{name}.swa_cache", kv_cache=object()),
+                ),
+            )
+        )
+
+    layers = {
+        "43": make_layer("layer.43", 1),
+        "44": make_layer("layer.44", 2),
+    }
+    model = SimpleNamespace(
+        layers=layers,
+        combine_hidden_states=lambda hidden_states: hidden_states * 3,
+    )
+    monkeypatch.setattr(
+        dspark_module,
+        "get_cos_and_sin_dsa",
+        lambda _positions: (
+            {name: torch.ones(3, 2) for name in ("layer.43", "layer.44")},
+            {name: torch.zeros(3, 2) for name in ("layer.43", "layer.44")},
+        ),
+    )
+    monkeypatch.setattr(
+        torch.ops._C_ascend,
+        "inplace_partial_rotary_mul",
+        lambda *args, **kwargs: None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        dspark_module,
+        "_scatter_context_kv",
+        lambda cache, kv, slots: calls.append((cache, kv.clone(), slots)),
+    )
+    hidden_states = torch.arange(12, dtype=torch.float32).view(3, 4)
+    slot_mappings = [torch.tensor([1, 2, 3]), torch.tensor([4, 5, 6])]
+
+    DeepseekV4DSparkModel.precompute_and_store_context_kv(model, hidden_states, torch.tensor([5, 6, 7]), slot_mappings)
+
+    assert len(calls) == 2
+    torch.testing.assert_close(calls[0][1].squeeze(1), (hidden_states * 3 + 1) * 2)
+    torch.testing.assert_close(calls[1][1].squeeze(1), (hidden_states * 3 + 2) * 2)
+    assert calls[0][2] is slot_mappings[0]
+    assert calls[1][2] is slot_mappings[1]
+
+
+def test_dspark_context_kv_rejects_wrong_slot_mapping_count():
+    model = SimpleNamespace(layers={"43": object(), "44": object()})
+
+    with pytest.raises(ValueError, match="number of draft layers"):
+        DeepseekV4DSparkModel.precompute_and_store_context_kv(
+            model,
+            torch.ones(1, 4),
+            torch.tensor([0]),
+            [torch.tensor([0])],
+        )
+
+
+def test_dspark_context_kv_scatter_unwraps_cache(monkeypatch):
+    from vllm_ascend.device.device_op import DeviceOperator
+
+    calls = []
+    formatted_slots = torch.tensor([[0, 1], [1, 2]], dtype=torch.int64)
+    monkeypatch.setattr(
+        DeviceOperator,
+        "format_dsa_slot_mapping",
+        lambda slots, block_size: formatted_slots if block_size == 4 else None,
+    )
+    monkeypatch.setattr(
+        DeviceOperator,
+        "dsa_kv_compress_scatter",
+        lambda cache, kv, slots: calls.append((cache, kv, slots)),
+    )
+    cache = torch.empty(2, 4, 1, 3)
+    kv = torch.empty(1)
+    slots = torch.tensor([1, 6], dtype=torch.int64)
+
+    dspark_module._scatter_context_kv([[cache]], kv, slots)
+
+    assert calls == [(cache, kv, formatted_slots)]
+
+
+def test_dspark_declares_target_shared_embedding_and_lm_head():
+    assert DeepSeekV4DSparkMTP.has_own_embed_tokens is False
+    assert DeepSeekV4DSparkMTP.has_own_lm_head is False
+
+
+def test_dspark_load_weights_rejects_unmatched_mtp(monkeypatch):
+    monkeypatch.setattr(dspark_module, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(dspark_module, "get_tensor_model_parallel_rank", lambda: 0)
+    model = SimpleNamespace(
+        config=SimpleNamespace(num_hidden_layers=43, num_attention_heads=8, expert_dtype="fp4"),
+        model=SimpleNamespace(
+            num_dspark_layers=3,
+            get_expert_mapping=lambda: [],
+            finalize_mega_moe_weights=lambda: None,
+        ),
+        named_parameters=lambda: iter(()),
+    )
+
+    with pytest.raises(ValueError, match="model.layers.43.self_attn.q_norm"):
+        DeepSeekV4DSparkMTP.load_weights(cast(Any, model), [("mtp.0.attn.q_norm.weight", torch.ones(1))])
+
+
+def test_dspark_load_weights_skips_nonlocal_expert(monkeypatch):
+    monkeypatch.setattr(dspark_module, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(dspark_module, "get_tensor_model_parallel_rank", lambda: 0)
+
+    class NonlocalExpertParam:
+        def weight_loader(self, *args, **kwargs):
+            assert kwargs["return_success"] is True
+            return False
+
+    expert_name = "model.layers.43.mlp.experts.weight"
+    required_names = {
+        "model.layers.43.main_proj.weight",
+        "model.layers.43.main_norm.weight",
+        "model.layers.44.norm.weight",
+        "model.layers.45.norm.weight",
+        "model.hc_head_fn",
+        "model.hc_head_base",
+        "model.hc_head_scale",
+        "model.layers.45.markov_head.markov_w1.weight",
+        "model.layers.45.markov_head.markov_w2.weight",
+    }
+    params: dict[str, object] = {name: SimpleNamespace() for name in required_names}
+    params[expert_name] = NonlocalExpertParam()
+    model = SimpleNamespace(
+        config=SimpleNamespace(num_hidden_layers=43, num_attention_heads=8, expert_dtype="fp4"),
+        model=SimpleNamespace(
+            num_dspark_layers=3,
+            get_expert_mapping=lambda: [
+                (
+                    "model.layers.43.mlp.experts",
+                    "model.layers.43.mlp.experts.0.down_proj",
+                    0,
+                    "down_proj",
+                )
+            ],
+            finalize_mega_moe_weights=lambda: None,
+        ),
+        named_parameters=lambda: iter(params.items()),
+    )
+
+    class RequiredParam:
+        def weight_loader(self, *_args, **_kwargs):
+            return None
+
+    for name in required_names:
+        params[name] = RequiredParam()
+    weights = [
+        ("mtp.0.main_proj.weight", torch.ones(1)),
+        ("mtp.0.main_norm.weight", torch.ones(1)),
+        ("mtp.0.ffn.experts.0.w2.weight", torch.ones(1)),
+        ("mtp.1.norm.weight", torch.ones(1)),
+        ("mtp.2.norm.weight", torch.ones(1)),
+        ("mtp.2.hc_head_fn", torch.ones(1)),
+        ("mtp.2.hc_head_base", torch.ones(1)),
+        ("mtp.2.hc_head_scale", torch.ones(1)),
+        ("mtp.2.markov_head.markov_w1.weight", torch.ones(1)),
+        ("mtp.2.markov_head.markov_w2.weight", torch.ones(1)),
+    ]
+
+    loaded = DeepSeekV4DSparkMTP.load_weights(cast(Any, model), weights)
+
+    assert expert_name not in loaded
+
+
+def test_dspark_load_weights_stacks_shared_expert(monkeypatch):
+    monkeypatch.setattr(dspark_module, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(dspark_module, "get_tensor_model_parallel_rank", lambda: 0)
+    calls = []
+
+    class FakeParam:
+        def __init__(self, name):
+            self.name = name
+
+        def weight_loader(self, _param, weight, *args, **kwargs):
+            calls.append((self.name, weight.clone(), args, kwargs))
+            return True
+
+    param_names = {
+        "model.layers.43.main_proj.weight",
+        "model.layers.43.main_norm.weight",
+        "model.layers.44.mlp.shared_experts.gate_up_proj.weight",
+        "model.layers.45.norm.weight",
+        "model.hc_head_fn",
+        "model.hc_head_base",
+        "model.hc_head_scale",
+        "model.layers.45.markov_head.markov_w1.weight",
+        "model.layers.45.markov_head.markov_w2.weight",
+    }
+    params = {name: FakeParam(name) for name in param_names}
+    model = SimpleNamespace(
+        config=SimpleNamespace(num_hidden_layers=43, num_attention_heads=8, expert_dtype="fp4"),
+        model=SimpleNamespace(
+            num_dspark_layers=3,
+            get_expert_mapping=lambda: [],
+            finalize_mega_moe_weights=lambda: None,
+        ),
+        named_parameters=lambda: iter(params.items()),
+    )
+    weights = [
+        ("mtp.0.main_proj.weight", torch.ones(1)),
+        ("mtp.0.main_norm.weight", torch.ones(1)),
+        ("mtp.1.ffn.shared_experts.w1.weight", torch.ones(1)),
+        ("mtp.1.ffn.shared_experts.w3.weight", torch.ones(1) * 2),
+        ("mtp.2.norm.weight", torch.ones(1)),
+        ("mtp.2.hc_head_fn", torch.ones(1)),
+        ("mtp.2.hc_head_base", torch.ones(1)),
+        ("mtp.2.hc_head_scale", torch.ones(1)),
+        ("mtp.2.markov_head.markov_w1.weight", torch.ones(1)),
+        ("mtp.2.markov_head.markov_w2.weight", torch.ones(1)),
+    ]
+
+    loaded = DeepSeekV4DSparkMTP.load_weights(cast(Any, model), weights)
+
+    shared_name = "model.layers.44.mlp.shared_experts.gate_up_proj.weight"
+    assert shared_name in loaded
+    shared_calls = [call for call in calls if call[0] == shared_name]
+    assert [call[2] for call in shared_calls] == [(0,), (1,)]

--- a/tests/ut/spec_decode/test_dspark_aclgraph.py
+++ b/tests/ut/spec_decode/test_dspark_aclgraph.py
@@ -1,0 +1,643 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import nullcontext
+from copy import copy
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+import pytest
+import torch
+from vllm.config import CompilationMode, CUDAGraphMode
+from vllm.forward_context import BatchDescriptor
+
+import vllm_ascend.spec_decode.deepseek_v4_dspark_proposer as dspark_module
+import vllm_ascend.worker.model_runner_v1 as model_runner_module
+from vllm_ascend.spec_decode.deepseek_v4_dspark_proposer import (
+    AscendDeepSeekV4DSparkProposer,
+)
+from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+
+@dataclass
+class _DraftConfig:
+    compilation_config: object
+    parallel_config: object
+    scheduler_config: object
+    speculative_config: object
+    lora_config: object | None = None
+    model_config: object | None = None
+
+
+class _CompilationConfig:
+    def __init__(self):
+        self.cudagraph_capture_sizes = [6, 12, 18]
+        self.max_cudagraph_capture_size = 18
+
+    def __copy__(self):
+        result = type(self)()
+        result.cudagraph_capture_sizes = copy(self.cudagraph_capture_sizes)
+        result.max_cudagraph_capture_size = self.max_cudagraph_capture_size
+        return result
+
+    def adjust_cudagraph_sizes_for_spec_decode(self, query_len, tp_size):
+        del tp_size
+        self.cudagraph_capture_sizes = [query_len, query_len * 2]
+        self.max_cudagraph_capture_size = query_len * 2
+
+
+@pytest.mark.parametrize("block_size", [5, 7])
+def test_draft_dispatcher_uses_target_request_rows(monkeypatch, block_size):
+    created = []
+
+    class FakeDispatcher:
+        def __init__(self, config):
+            self.config = config
+            self.mode = None
+            self.query_len = None
+            self.uniform_decode_query_len = 6
+            created.append(self)
+
+        def initialize_cudagraph_keys(self, mode, query_len):
+            self.mode = mode
+            self.query_len = query_len
+
+        def get_capture_descs(self):
+            sizes = self.config.compilation_config.cudagraph_capture_sizes
+            return [
+                (
+                    CUDAGraphMode.FULL,
+                    [BatchDescriptor(size, size // self.query_len, True) for size in sizes],
+                )
+            ]
+
+    monkeypatch.setattr(dspark_module, "CudagraphDispatcher", FakeDispatcher)
+    target_dispatcher = SimpleNamespace(
+        get_capture_descs=lambda: [
+            (
+                CUDAGraphMode.FULL,
+                [
+                    BatchDescriptor(6, 1, True),
+                    BatchDescriptor(18, 3, True),
+                    BatchDescriptor(24, 4, True),
+                ],
+            )
+        ]
+    )
+    proposer = cast(Any, object.__new__(AscendDeepSeekV4DSparkProposer))
+    proposer.block_size = block_size
+    proposer.use_cuda_graph = True
+    proposer.runner = SimpleNamespace(cudagraph_dispatcher=target_dispatcher)
+    proposer.vllm_config = _DraftConfig(
+        compilation_config=_CompilationConfig(),
+        parallel_config=SimpleNamespace(tensor_parallel_size=4),
+        scheduler_config=SimpleNamespace(max_num_seqs=8),
+        speculative_config=SimpleNamespace(num_speculative_tokens=block_size),
+    )
+
+    proposer.initialize_cudagraph_keys(CUDAGraphMode.FULL)
+
+    assert created[0].mode == CUDAGraphMode.FULL_DECODE_ONLY
+    assert created[0].query_len == block_size
+    assert created[0].uniform_decode_query_len == block_size
+    assert created[0].config.compilation_config.cudagraph_capture_sizes == [
+        block_size,
+        block_size * 3,
+        block_size * 4,
+    ]
+    assert proposer.get_cudagraph_capture_sizes() == [block_size, block_size * 3, block_size * 4]
+
+
+def test_load_model_uses_dspark_graph_runnable(monkeypatch):
+    base_graph_flags = []
+    wrappers = []
+
+    class FakeWrapper:
+        def __init__(self, runnable, config, runtime_mode, *, use_eagle, enable_enpu):
+            wrappers.append((runnable, config, runtime_mode, use_eagle, enable_enpu))
+
+    def fake_load_model(self, model):
+        del model
+        base_graph_flags.append(self.use_cuda_graph)
+
+    monkeypatch.setattr(dspark_module.AscendDsparkProposer, "load_model", fake_load_model)
+    monkeypatch.setattr(dspark_module, "ACLGraphWrapper", FakeWrapper)
+    monkeypatch.setattr(
+        dspark_module.torch,
+        "npu",
+        SimpleNamespace(Stream=lambda: "stream"),
+        raising=False,
+    )
+
+    proposer = cast(Any, object.__new__(AscendDeepSeekV4DSparkProposer))
+    proposer._draft_aclgraph_enabled = True
+    proposer.use_cuda_graph = True
+    proposer.vllm_config = SimpleNamespace()
+    proposer.use_eagle = False
+    proposer.enable_enpu = True
+
+    proposer.load_model(object())
+
+    assert base_graph_flags == [False]
+    assert proposer.use_cuda_graph is True
+    assert proposer.update_stream == "stream"
+    assert len(wrappers) == 1
+    assert wrappers[0][0].__func__ is AscendDeepSeekV4DSparkProposer._run_model_from_graph_buffers
+    assert wrappers[0][2:] == (CUDAGraphMode.FULL, False, True)
+
+
+def test_eager_drafter_config_does_not_mutate_target(monkeypatch):
+    target_model_config = SimpleNamespace(enforce_eager=False)
+    target_compilation_config = SimpleNamespace(
+        mode=CompilationMode.VLLM_COMPILE,
+        cudagraph_mode=CUDAGraphMode.FULL,
+    )
+    target_config = _DraftConfig(
+        compilation_config=target_compilation_config,
+        parallel_config=SimpleNamespace(),
+        scheduler_config=SimpleNamespace(),
+        speculative_config=SimpleNamespace(),
+        model_config=target_model_config,
+    )
+    monkeypatch.setattr(
+        dspark_module.AscendDsparkProposer,
+        "_create_draft_vllm_config",
+        lambda self: target_config,
+    )
+    proposer = cast(Any, object.__new__(AscendDeepSeekV4DSparkProposer))
+    proposer._draft_aclgraph_enabled = False
+
+    draft_config = proposer._create_draft_vllm_config()
+    draft_config.model_config.enforce_eager = True
+    draft_config.compilation_config.mode = CompilationMode.NONE
+    draft_config.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+
+    assert target_model_config.enforce_eager is False
+    assert target_compilation_config.mode == CompilationMode.VLLM_COMPILE
+    assert target_compilation_config.cudagraph_mode == CUDAGraphMode.FULL
+
+
+def test_padding_uses_complete_inactive_request_rows_and_stable_buffers():
+    proposer = cast(Any, object.__new__(AscendDeepSeekV4DSparkProposer))
+    proposer.block_size = 3
+    proposer.max_batch_size = 4
+    proposer.max_query_tokens = 12
+    proposer.parallel_drafting_token_id = 99
+    proposer.input_ids = torch.tensor([1, 2, 3, 7, 7, 7, 7, 7, 7, 7, 7, 7])
+    proposer.positions = torch.arange(12, dtype=torch.int32)
+    proposer._token_to_req_buffer = torch.tensor([0, 0, 0, 8, 8, 8, 8, 8, 8, 8, 8, 8], dtype=torch.int32)
+    proposer._seed_buffer = torch.tensor([11, 22, 33, 44])
+    proposer._query_start_loc_buffer = torch.tensor([0, 3, 9, 9, 9], dtype=torch.int32)
+    proposer._query_start_loc_cpu_buffer = proposer._query_start_loc_buffer.cpu().clone()
+    proposer._query_start_loc_cpu_base = torch.arange(5, dtype=torch.int32) * proposer.block_size
+    proposer.arange_dspark = torch.arange(12, dtype=torch.int32)
+    proposer._seq_lens_buffer = torch.tensor([10, 20, 30, 40], dtype=torch.int32)
+    proposer._seq_lens_cpu_buffer = proposer._seq_lens_buffer.cpu().clone()
+    proposer._query_slot_buffers = {0: torch.tensor([100, 101, 102, 8, 8, 8, 8, 8, 8, 8, 8, 8], dtype=torch.int32)}
+    proposer._context_slot_buffers = {}
+    proposer._query_slots_by_gid = {0: proposer._query_slot_buffers[0][:3]}
+    proposer._block_table_buffers = {0: torch.tensor([[10, 11], [9, 9], [9, 9], [9, 9]], dtype=torch.int32)}
+    proposer._block_tables_by_gid = {0: proposer._block_table_buffers[0][:1]}
+    proposer.draft_attn_groups = [SimpleNamespace(kv_cache_group_id=0)]
+    cad = SimpleNamespace(actual_seq_lengths_q=[3])
+    pointers = (
+        proposer._query_start_loc_buffer.data_ptr(),
+        proposer._seq_lens_buffer.data_ptr(),
+        proposer._query_slot_buffers[0].data_ptr(),
+        proposer._block_table_buffers[0].data_ptr(),
+    )
+
+    model_tokens = proposer._pad_request_rows(cad, actual_num_reqs=1, model_num_reqs=2)
+
+    assert model_tokens == 6
+    torch.testing.assert_close(cad.query_start_loc, torch.tensor([0, 3, 6], dtype=torch.int32))
+    torch.testing.assert_close(cad.seq_lens, torch.tensor([10, 3], dtype=torch.int32))
+    torch.testing.assert_close(proposer.input_ids[:6], torch.tensor([1, 2, 3, 99, 99, 99]))
+    torch.testing.assert_close(proposer.positions[:6], torch.tensor([0, 1, 2, 0, 0, 0], dtype=torch.int32))
+    torch.testing.assert_close(cad.token_to_req_indices, torch.tensor([0, 0, 0, 1, 1, 1], dtype=torch.int32))
+    torch.testing.assert_close(cad.slot_mapping, torch.tensor([100, 101, 102, -1, -1, -1], dtype=torch.int32))
+    torch.testing.assert_close(proposer._block_tables_by_gid[0], torch.tensor([[10, 11], [0, 0]], dtype=torch.int32))
+    assert cad.actual_seq_lengths_q == [3, 3]
+    assert pointers == (
+        proposer._query_start_loc_buffer.data_ptr(),
+        proposer._seq_lens_buffer.data_ptr(),
+        proposer._query_slot_buffers[0].data_ptr(),
+        proposer._block_table_buffers[0].data_ptr(),
+    )
+
+
+def test_dsa_metadata_tensors_keep_addresses_between_steps():
+    proposer = cast(Any, object.__new__(AscendDeepSeekV4DSparkProposer))
+    proposer._stable_attn_buffers = {}
+    first = SimpleNamespace(
+        prefill=SimpleNamespace(
+            dspark_swa_indices=torch.ones((2, 1, 4), dtype=torch.int32),
+            dspark_swa_lens=torch.ones(2, dtype=torch.int32),
+            sas_metadata=torch.ones(3, dtype=torch.int32),
+        )
+    )
+    proposer._stabilize_attn_metadata({"draft.swa": first})
+    pointers = (
+        first.prefill.dspark_swa_indices.data_ptr(),
+        first.prefill.dspark_swa_lens.data_ptr(),
+        first.prefill.sas_metadata.data_ptr(),
+    )
+    second = SimpleNamespace(
+        prefill=SimpleNamespace(
+            dspark_swa_indices=torch.full((2, 1, 4), 2, dtype=torch.int32),
+            dspark_swa_lens=torch.full((2,), 2, dtype=torch.int32),
+            sas_metadata=torch.full((3,), 2, dtype=torch.int32),
+        )
+    )
+
+    proposer._stabilize_attn_metadata({"draft.swa": second})
+
+    assert pointers == (
+        second.prefill.dspark_swa_indices.data_ptr(),
+        second.prefill.dspark_swa_lens.data_ptr(),
+        second.prefill.sas_metadata.data_ptr(),
+    )
+    torch.testing.assert_close(second.prefill.dspark_swa_indices, torch.full((2, 1, 4), 2, dtype=torch.int32))
+
+
+def test_graph_output_is_sliced_before_sampling(monkeypatch):
+    context_calls = []
+    graph_updates = []
+    sample_calls = []
+
+    def fake_context(metadata, config, **kwargs):
+        del metadata, config
+        context_calls.append(kwargs)
+        return nullcontext()
+
+    monkeypatch.setattr(dspark_module, "set_ascend_forward_context", fake_context)
+    monkeypatch.setattr(dspark_module, "get_forward_context", lambda: SimpleNamespace(moe_layer_index=-1))
+    monkeypatch.setattr(dspark_module, "_EXTRA_CTX", SimpleNamespace(capturing=False))
+    proposer = cast(Any, object.__new__(AscendDeepSeekV4DSparkProposer))
+    proposer.block_size = 5
+    proposer.use_cuda_graph = True
+    proposer.dp_rank = 0
+    proposer.vllm_config = SimpleNamespace()
+    proposer.input_ids = torch.arange(10)
+    proposer.positions = torch.arange(10, dtype=torch.int32)
+    proposer.draft_attn_groups = [SimpleNamespace()]
+    proposer._graph_model_inputs = None
+    proposer.cudagraph_dispatcher = SimpleNamespace(
+        dispatch=lambda **kwargs: (
+            CUDAGraphMode.FULL,
+            BatchDescriptor(10, 2, True),
+        )
+    )
+    proposer.runner = SimpleNamespace(
+        input_batch=SimpleNamespace(lora_id_to_lora_request={}),
+        dp_rank=0,
+        _num_reqs_across_dp=torch.tensor([1, 2], dtype=torch.int32),
+        _sync_metadata_across_dp=lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("draft metadata must reuse target request counts")
+        ),
+    )
+    cad = SimpleNamespace(num_reqs=1, num_actual_tokens=5)
+
+    def pad_request_rows(metadata, actual, model):
+        del actual
+        metadata.num_reqs = model
+        return model * proposer.block_size
+
+    proposer.set_inputs_first_pass = lambda *args, **kwargs: (5, None, cad, None)
+    proposer._pad_request_rows = pad_request_rows
+    proposer._build_attn_metadata = lambda metadata: [{"draft": metadata}]
+    proposer._precompute_context_kv = lambda: None
+    proposer._update_full_graph_params = lambda *args: graph_updates.append(args)
+    proposer._runnable = lambda: torch.arange(20, dtype=torch.float32).view(10, 2)
+
+    def sample(hidden_states, num_reqs, metadata):
+        del metadata
+        sample_calls.append((hidden_states.clone(), num_reqs))
+        return torch.tensor([[1, 2, 3, 4, 5]])
+
+    proposer._sample_sequential = sample
+
+    result = AscendDeepSeekV4DSparkProposer._propose(
+        proposer,
+        target_token_ids=torch.arange(1),
+        target_positions=torch.arange(1),
+        target_hidden_states=torch.zeros((1, 2)),
+        next_token_ids=torch.tensor([7]),
+        token_indices_to_sample=None,
+        common_attn_metadata=cad,
+        target_model_batch_desc=BatchDescriptor(1),
+        sampling_metadata=SimpleNamespace(),
+    )
+
+    torch.testing.assert_close(result, torch.tensor([[1, 2, 3, 4, 5]]))
+    assert sample_calls[0][0].shape == (5, 2)
+    assert sample_calls[0][1] == 1
+    graph_model_inputs = proposer._graph_model_inputs
+    assert graph_model_inputs is not None
+    assert graph_model_inputs["input_ids"].shape[0] == 10
+    assert context_calls[0]["aclgraph_runtime_mode"] == CUDAGraphMode.FULL
+    assert len(graph_updates) == 1
+
+
+@pytest.mark.parametrize("dp_rank", range(4))
+@pytest.mark.parametrize(
+    ("graph_modes", "expected_mode"),
+    [
+        (
+            [
+                CUDAGraphMode.PIECEWISE,
+                CUDAGraphMode.FULL,
+                CUDAGraphMode.PIECEWISE,
+                CUDAGraphMode.FULL,
+            ],
+            CUDAGraphMode.NONE,
+        ),
+        ([CUDAGraphMode.FULL] * 4, CUDAGraphMode.FULL),
+    ],
+)
+def test_uneven_dspark_dp_batch_uses_only_safe_graph_modes(monkeypatch, dp_rank, graph_modes, expected_mode):
+    runner = cast(Any, object.__new__(NPUModelRunner))
+    runner.dp_size = 4
+    runner.dp_rank = dp_rank
+    runner.input_batch = SimpleNamespace(num_reqs=[2, 1, 0, 1][dp_rank])
+    runner.ascend_config = SimpleNamespace(dp_allreduce_on_npu=False)
+    runner.vllm_config = SimpleNamespace()
+    runner.drafter = cast(Any, object.__new__(AscendDeepSeekV4DSparkProposer))
+    runner._num_reqs_across_dp = None
+
+    monkeypatch.setattr(
+        model_runner_module,
+        "should_skip_allreduce_across_dp_group",
+        lambda *args, **kwargs: False,
+    )
+    monkeypatch.setattr(
+        model_runner_module,
+        "get_dp_group",
+        lambda: SimpleNamespace(cpu_group="cpu-group", device_group="device-group"),
+    )
+
+    def fake_all_reduce(packed, group):
+        assert group == "cpu-group"
+        packed[0] = torch.tensor([48, 6, 0, 6], dtype=torch.int32)
+        packed[1] = torch.tensor([mode.value for mode in graph_modes], dtype=torch.int32)
+        packed[2] = torch.tensor([2, 1, 0, 1], dtype=torch.int32)
+
+    monkeypatch.setattr(model_runner_module.dist, "all_reduce", fake_all_reduce)
+
+    max_tokens, num_tokens_across_dp, graph_mode = NPUModelRunner._sync_metadata_across_dp(
+        runner,
+        num_tokens=[48, 6, 0, 6][dp_rank],
+        cudagraph_mode=graph_modes[dp_rank],
+    )
+
+    assert max_tokens == 48
+    assert graph_mode == expected_mode
+    torch.testing.assert_close(num_tokens_across_dp, torch.full((4,), 48, dtype=torch.int32))
+    torch.testing.assert_close(runner._num_reqs_across_dp, torch.tensor([2, 1, 0, 1], dtype=torch.int32))
+
+
+def test_eager_dp_padding_adds_a_dummy_query_range():
+    runner = cast(Any, object.__new__(NPUModelRunner))
+    runner.use_compress = False
+    runner.compilation_config = SimpleNamespace(cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE)
+    runner.uniform_decode_query_len = 6
+    runner.arange_np = np.arange(8, dtype=np.int32)
+    query_start_loc = SimpleNamespace(
+        np=np.array([0, 6, 0], dtype=np.int32),
+        copy_to_gpu=lambda: None,
+    )
+
+    num_reqs_padded = runner._pad_query_start_loc_for_fia(
+        query_start_loc,
+        num_tokens_padded=116,
+        num_reqs_padded=1,
+        num_reqs=1,
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+    )
+
+    assert num_reqs_padded == 2
+    np.testing.assert_array_equal(query_start_loc.np, np.array([0, 6, 116], dtype=np.int32))
+
+
+def test_dsa_dp_padding_keeps_the_active_query_range():
+    runner = cast(Any, object.__new__(NPUModelRunner))
+    runner.use_compress = True
+    query_start_loc = SimpleNamespace(
+        np=np.array([0, 6, 0], dtype=np.int32),
+        copy_to_gpu=lambda: None,
+    )
+
+    num_reqs_padded = runner._pad_query_start_loc_for_fia(
+        query_start_loc,
+        num_tokens_padded=116,
+        num_reqs_padded=1,
+        num_reqs=1,
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+    )
+
+    assert num_reqs_padded == 1
+    np.testing.assert_array_equal(query_start_loc.np, np.array([0, 6, 0], dtype=np.int32))
+
+
+def test_idle_dspark_dummy_run_marks_rank_inactive(monkeypatch):
+    context_calls = []
+
+    def capture_forward_context(metadata, config, **kwargs):
+        del metadata, config
+        context_calls.append(kwargs)
+        return nullcontext()
+
+    monkeypatch.setattr(
+        model_runner_module,
+        "set_ascend_forward_context",
+        capture_forward_context,
+    )
+    monkeypatch.setattr(model_runner_module, "update_cos_sin", lambda positions: None)
+    monkeypatch.setattr(
+        model_runner_module,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True),
+    )
+    monkeypatch.setattr(model_runner_module, "lmhead_tp_enable", lambda: False)
+
+    runner = cast(Any, object.__new__(NPUModelRunner))
+    runner.uniform_decode_query_len = 6
+    runner.scheduler_config = SimpleNamespace(max_num_batched_tokens=2048, max_num_seqs=4)
+    runner.max_num_tokens = 2048
+    runner.dynamic_eplb = False
+    runner.pcp_size = 1
+    runner.dcp_size = 1
+    runner._determine_batch_execution_and_padding = lambda **kwargs: (
+        CUDAGraphMode.NONE,
+        BatchDescriptor(116, 2, False),
+        False,
+        torch.tensor([116, 116], dtype=torch.int32),
+        None,
+    )
+    runner._should_build_dummy_attn_metadata = lambda *args, **kwargs: False
+    runner.maybe_dummy_run_with_lora = lambda *args, **kwargs: nullcontext()
+    runner.lora_config = None
+    runner.supports_mm_inputs = False
+    runner.enable_prompt_embeds = False
+    runner.input_ids = SimpleNamespace(gpu=torch.zeros(116, dtype=torch.int64))
+    runner.uses_mrope = False
+    runner.uses_xdrope_dim = 0
+    runner.positions = torch.zeros(116, dtype=torch.int64)
+    runner.vllm_config = SimpleNamespace()
+    runner.model = SimpleNamespace()
+    runner._has_sinks = False
+    runner._model_forward = lambda *args, **kwargs: torch.zeros((116, 4))
+    runner.use_aux_hidden_state_outputs = False
+    runner.drafter = cast(Any, object.__new__(AscendDeepSeekV4DSparkProposer))
+    runner.drafter.dummy_run = lambda *args, **kwargs: None
+    runner.dp_rank = 2
+    runner._num_reqs_across_dp = torch.tensor([2, 1, 0, 0], dtype=torch.int32)
+    runner._finalize_dump_data = lambda **kwargs: None
+    runner.use_compress = False
+
+    runner._dummy_run(num_tokens=6, uniform_decode=True)
+
+    assert context_calls[0]["num_tokens"] == 116
+    assert context_calls[0]["num_actual_tokens"] == 0
+
+
+def test_runtime_dummy_run_reuses_target_request_shape(monkeypatch):
+    context_calls = []
+    dispatcher_calls = []
+    runnable_calls: list[dict[str, Any]] = []
+
+    def capture_forward_context(metadata, config, **kwargs):
+        del metadata, config
+        context_calls.append(kwargs)
+        return nullcontext()
+
+    monkeypatch.setattr(
+        dspark_module,
+        "set_ascend_forward_context",
+        capture_forward_context,
+    )
+    monkeypatch.setattr(dspark_module, "get_forward_context", lambda: SimpleNamespace())
+    monkeypatch.setattr(dspark_module, "_EXTRA_CTX", SimpleNamespace(capturing=False))
+    proposer = cast(Any, object.__new__(AscendDeepSeekV4DSparkProposer))
+    proposer.block_size = 5
+    proposer.max_query_tokens = 20
+    proposer.use_cuda_graph = True
+    proposer.dp_rank = 0
+    proposer.device = torch.device("cpu")
+    proposer.vllm_config = SimpleNamespace()
+    proposer.parallel_drafting_token_id = 99
+    proposer.input_ids = torch.zeros(20, dtype=torch.int64)
+    proposer.positions = torch.zeros(20, dtype=torch.int32)
+    proposer._token_to_req_buffer = torch.zeros(20, dtype=torch.int32)
+    proposer._query_start_loc_buffer = torch.zeros(5, dtype=torch.int32)
+    proposer._query_start_loc_cpu_buffer = torch.zeros(5, dtype=torch.int32)
+    proposer._query_start_loc_cpu_base = torch.arange(5, dtype=torch.int32) * 5
+    proposer._seq_lens_buffer = torch.zeros(4, dtype=torch.int32)
+    proposer._seq_lens_cpu_buffer = torch.zeros(4, dtype=torch.int32)
+    proposer.arange_dspark = torch.arange(32, dtype=torch.int32)
+    proposer._query_slot_buffers = {}
+    proposer._context_slot_buffers = {}
+    proposer._block_tables_by_gid = {}
+    proposer._graph_model_inputs = None
+    proposer.draft_attn_groups = [SimpleNamespace(kv_cache_group_id=0)]
+    proposer.runner = SimpleNamespace(
+        input_batch=SimpleNamespace(lora_id_to_lora_request={}),
+        dp_rank=0,
+        _num_reqs_across_dp=torch.tensor([2, 1, 0, 0], dtype=torch.int32),
+        _sync_metadata_across_dp=lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("target dummy metadata is already synchronized")
+        ),
+    )
+
+    def dispatch(num_tokens, **kwargs):
+        dispatcher_calls.append((num_tokens, kwargs))
+        return CUDAGraphMode.FULL, BatchDescriptor(num_tokens, num_tokens // 5, True)
+
+    proposer.cudagraph_dispatcher = SimpleNamespace(dispatch=dispatch)
+    proposer._get_block_table = lambda gid, cad, reqs: torch.zeros((reqs, 2), dtype=torch.int32)
+    proposer._build_attn_metadata = lambda cad: [{"draft": cad}]
+    proposer._update_full_graph_params = lambda *args: None
+
+    def run_graph():
+        graph_model_inputs = proposer._graph_model_inputs
+        assert graph_model_inputs is not None
+        runnable_calls.append(graph_model_inputs)
+
+    proposer._runnable = run_graph
+
+    proposer.dummy_run(
+        12,
+        num_reqs=1,
+        num_tokens_across_dp=torch.tensor([12, 12], dtype=torch.int32),
+        aclgraph_runtime_mode=CUDAGraphMode.FULL,
+        is_graph_capturing=False,
+    )
+
+    assert dispatcher_calls[0][0] == 10
+    assert runnable_calls[0]["input_ids"].shape[0] == 10
+    assert context_calls[0]["batch_descriptor"] == BatchDescriptor(10, 2, True)
+    torch.testing.assert_close(
+        context_calls[0]["num_tokens_across_dp"],
+        torch.tensor([10, 10], dtype=torch.int32),
+    )
+
+
+def test_model_runner_merges_dspark_capture_sizes(monkeypatch):
+    graph_params = []
+    draft_graph_params = []
+    drafter_modes = []
+
+    class FakeDrafter:
+        def initialize_cudagraph_keys(self, mode):
+            drafter_modes.append(mode)
+
+        def get_cudagraph_capture_sizes(self):
+            return [5, 10]
+
+    class FakeCompilationConfig:
+        def resolve_cudagraph_mode_and_sizes(self, **kwargs):
+            del kwargs
+            return CUDAGraphMode.FULL
+
+    monkeypatch.setattr(model_runner_module, "AscendDflashProposer", FakeDrafter)
+    monkeypatch.setattr(model_runner_module, "AscendDeepSeekV4DSparkProposer", FakeDrafter)
+    monkeypatch.setattr(model_runner_module, "update_pass_config", lambda runner: nullcontext())
+    monkeypatch.setattr(model_runner_module, "set_graph_params", lambda sizes: graph_params.append(sizes))
+    monkeypatch.setattr(
+        model_runner_module,
+        "set_draft_graph_params",
+        lambda sizes: draft_graph_params.append(sizes),
+    )
+    target_dispatcher = SimpleNamespace(
+        initialize_cudagraph_keys=lambda *args: None,
+        get_capture_descs=lambda: [
+            (
+                CUDAGraphMode.FULL,
+                [BatchDescriptor(6, 1, True), BatchDescriptor(12, 2, True)],
+            )
+        ],
+    )
+    runner = cast(
+        Any,
+        SimpleNamespace(
+            compilation_config=FakeCompilationConfig(),
+            uniform_decode_query_len=6,
+            parallel_config=SimpleNamespace(tensor_parallel_size=4),
+            kv_cache_config=SimpleNamespace(),
+            max_num_reqs=8,
+            cudagraph_dispatcher=target_dispatcher,
+            speculative_config=SimpleNamespace(
+                use_eagle=lambda: False,
+                uses_extract_hidden_states=lambda: False,
+            ),
+            drafter=FakeDrafter(),
+            use_aclgraph=True,
+        ),
+    )
+
+    NPUModelRunner._check_and_update_cudagraph_mode(runner, [], [])
+
+    assert drafter_modes == [CUDAGraphMode.FULL]
+    assert graph_params == [[6, 12]]
+    assert draft_graph_params == [[5, 6, 10, 12]]

--- a/tests/ut/spec_decode/test_dspark_dsa_metadata.py
+++ b/tests/ut/spec_decode/test_dspark_dsa_metadata.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+import torch
+
+import vllm_ascend.attention.context_parallel.dsa_cp as dsa_cp
+import vllm_ascend.attention.dsa_v1 as dsa_v1
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.dsa_window import (
+    build_dspark_swa_indices,
+    build_dspark_swa_metadata_for_drafting,
+)
+
+
+def _vllm_config(window_size: int = 7, query_block_size: int = 5) -> SimpleNamespace:
+    draft_hf_config = SimpleNamespace(dspark_block_size=query_block_size)
+    return SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(sliding_window=window_size, num_attention_heads=8),
+            get_head_size=lambda: 16,
+        ),
+        speculative_config=SimpleNamespace(
+            num_speculative_tokens=query_block_size,
+            draft_model_config=SimpleNamespace(hf_config=draft_hf_config),
+        ),
+    )
+
+
+def _metadata(*, causal: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        query_start_loc=torch.tensor([0, 5], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 5], dtype=torch.int32),
+        seq_lens=torch.tensor([15], dtype=torch.int32),
+        _seq_lens_cpu=torch.tensor([15], dtype=torch.int32),
+        seq_lens_cpu=None,
+        positions=torch.arange(10, 15, dtype=torch.int32),
+        block_table_tensor=torch.tensor([[10, 11, 12]], dtype=torch.int32),
+        num_reqs=1,
+        num_input_tokens=5,
+        num_actual_tokens=5,
+        causal=causal,
+        attn_state=AscendAttentionState.SpecDecoding,
+    )
+
+
+def _physical_slots(block_table: torch.Tensor, req_idx: int, start: int, end: int) -> torch.Tensor:
+    return torch.tensor(
+        [int(block_table[req_idx, position // 64]) * 64 + position % 64 for position in range(start, end)],
+        dtype=torch.int32,
+    )
+
+
+def test_noncausal_draft_uses_explicit_full_block_visibility():
+    common_metadata = _metadata()
+    win_left, win_right, indices, lens = build_dspark_swa_metadata_for_drafting(
+        _vllm_config(),
+        common_metadata,
+        torch.arange(5, dtype=torch.int32),
+        cache_block_size=64,
+    )
+
+    assert (win_left, win_right) == (11, 0)
+    assert indices is not None and lens is not None
+    assert indices.shape == (5, 1, 128)
+    torch.testing.assert_close(lens, torch.full((5,), 12, dtype=torch.int32))
+    expected = _physical_slots(common_metadata.block_table_tensor, 0, 3, 15)
+    for row in range(5):
+        torch.testing.assert_close(indices[row, 0, :12], expected)
+        assert torch.all(indices[row, 0, 12:] == -1)
+
+
+def test_causal_draft_preserves_standard_window():
+    win_left, win_right, indices, lens = build_dspark_swa_metadata_for_drafting(
+        _vllm_config(),
+        _metadata(causal=True),
+        torch.arange(5, dtype=torch.int32),
+        cache_block_size=64,
+    )
+
+    assert (win_left, win_right) == (6, 0)
+    assert indices is None
+    assert lens is None
+
+
+def test_sparse_indices_cover_token_mapping_zero_length_and_padding():
+    block_table = torch.tensor([[10], [-1], [20]], dtype=torch.int32)
+    indices, lens = build_dspark_swa_indices(
+        block_table=block_table,
+        slot_mapping=torch.tensor([0, 1, 2, 3, -1], dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 2, 2, 4], dtype=torch.int32),
+        seq_lens=torch.tensor([12, 0, 22], dtype=torch.int32),
+        query_block_size=2,
+        window_size=4,
+        cache_block_size=64,
+        num_query_tokens=5,
+        token_to_req_indices=torch.tensor([0, 2, 0, 2, -1], dtype=torch.int32),
+    )
+
+    torch.testing.assert_close(lens, torch.tensor([6, 6, 6, 6, 0], dtype=torch.int32))
+    expected_req0 = _physical_slots(block_table, 0, 6, 12)
+    expected_req2 = _physical_slots(block_table, 2, 16, 22)
+    for row in (0, 2):
+        torch.testing.assert_close(indices[row, 0, :6], expected_req0)
+    for row in (1, 3):
+        torch.testing.assert_close(indices[row, 0, :6], expected_req2)
+    assert torch.all(indices[4] == -1)
+
+
+def test_sparse_indices_map_request_boundary_to_next_request():
+    block_table = torch.tensor([[10], [20]], dtype=torch.int32)
+    indices, lens = build_dspark_swa_indices(
+        block_table=block_table,
+        slot_mapping=torch.arange(4, dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 2, 4], dtype=torch.int32),
+        seq_lens=torch.tensor([12, 22], dtype=torch.int32),
+        query_block_size=2,
+        window_size=4,
+        cache_block_size=64,
+        num_query_tokens=4,
+    )
+
+    torch.testing.assert_close(lens, torch.full((4,), 6, dtype=torch.int32))
+    expected_req0 = _physical_slots(block_table, 0, 6, 12)
+    expected_req1 = _physical_slots(block_table, 1, 16, 22)
+    for row in (0, 1):
+        torch.testing.assert_close(indices[row, 0, :6], expected_req0)
+    for row in (2, 3):
+        torch.testing.assert_close(indices[row, 0, :6], expected_req1)
+
+
+def test_sparse_indices_reject_incomplete_token_mapping():
+    with pytest.raises(ValueError, match="token_to_req_indices"):
+        build_dspark_swa_indices(
+            block_table=torch.tensor([[0]], dtype=torch.int32),
+            slot_mapping=None,
+            query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+            seq_lens=torch.tensor([2], dtype=torch.int32),
+            query_block_size=2,
+            window_size=4,
+            cache_block_size=64,
+            num_query_tokens=2,
+            token_to_req_indices=torch.tensor([0], dtype=torch.int32),
+        )
+
+
+def _patch_metadata_ops(monkeypatch, module, captured):
+    monkeypatch.setattr(
+        module,
+        "get_cos_and_sin_dsa",
+        lambda positions, use_cache=False, draft_index=None: (
+            torch.zeros(positions.numel(), 1),
+            torch.zeros(positions.numel(), 1),
+        ),
+    )
+
+    def metadata_op(**kwargs):
+        captured.update(kwargs)
+        return torch.ones(1024, dtype=torch.int32)
+
+    monkeypatch.setattr(module.DeviceOperator, "get_dsa_sparse_attn_metadata_op", lambda: metadata_op)
+    monkeypatch.setattr(module.DeviceOperator, "get_dsa_sparse_attn_metadata_kwargs", lambda _device: {})
+
+
+def test_dsa_builder_propagates_shared_metadata(monkeypatch):
+    captured: dict[str, Any] = {}
+    _patch_metadata_ops(monkeypatch, dsa_v1, captured)
+    monkeypatch.setattr(dsa_v1, "get_tensor_model_parallel_world_size", lambda: 1)
+    config = _vllm_config()
+    builder = SimpleNamespace(
+        model_config=config.model_config,
+        vllm_config=config,
+        spec_slot_mapping=[torch.arange(5, dtype=torch.int32)],
+        spec_sas_metadata=[torch.zeros(1024, dtype=torch.int32)],
+        block_size=64,
+        seqused_q=torch.empty(0, dtype=torch.int32),
+        cu_seqlens_ori_kv=torch.empty(0, dtype=torch.int32),
+        cu_seqlens_cmp_kv=torch.empty(0, dtype=torch.int32),
+    )
+
+    result = dsa_v1.AscendDSAMetadataBuilder.build_decode_metadata_for_drafting(
+        cast(Any, builder),
+        draft_index=1,
+        common_attn_metadata=_metadata(),
+        num_decodes=1,
+        num_decode_tokens=5,
+    )
+
+    assert captured["ori_win_left"] == result.ori_win_left == 11
+    assert captured["ori_win_right"] == result.ori_win_right == 0
+    assert result.dspark_swa_indices is not None
+    torch.testing.assert_close(result.dspark_swa_lens, torch.full((5,), 12, dtype=torch.int32))
+
+
+def test_dsa_cp_builder_propagates_shared_metadata(monkeypatch):
+    captured: dict[str, Any] = {}
+    _patch_metadata_ops(monkeypatch, dsa_cp, captured)
+    monkeypatch.setattr(
+        dsa_cp.DeviceOperator,
+        "get_dsa_decode_cu_seqlens_ori_kv",
+        lambda *args, **kwargs: torch.tensor([0, 5], dtype=torch.int32),
+    )
+    monkeypatch.setattr(
+        dsa_cp.DeviceOperator,
+        "get_dsa_decode_cu_seqlens_cmp_kv",
+        lambda *args, **kwargs: torch.empty(0, dtype=torch.int32),
+    )
+    config = _vllm_config()
+    common_metadata = _metadata()
+
+    def local_metadata(**kwargs):
+        num_reqs = kwargs["num_reqs"]
+        return (
+            3,
+            6,
+            3,
+            6,
+            torch.tensor([0, 2], dtype=torch.int32),
+            kwargs["seq_lens"][:num_reqs],
+            torch.zeros(3, 1),
+            torch.zeros(3, 1),
+        )
+
+    builder = SimpleNamespace(
+        model_config=config.model_config,
+        vllm_config=config,
+        seq_lens=common_metadata.seq_lens,
+        seq_lens_cpu=common_metadata._seq_lens_cpu,
+        num_actual_tokens=5,
+        spec_slot_mapping=[torch.arange(5, dtype=torch.int32)],
+        block_table=common_metadata.block_table_tensor,
+        block_size=64,
+        spec_local_query_start_loc=[torch.zeros(2, dtype=torch.int32)],
+        spec_local_seq_lens=[torch.zeros(1, dtype=torch.int32)],
+        seqused_q=torch.empty(0, dtype=torch.int32),
+        cu_seqlens_ori_kv=torch.empty(0, dtype=torch.int32),
+        cu_seqlens_cmp_kv=torch.empty(0, dtype=torch.int32),
+        _zero_i32=torch.tensor([0], dtype=torch.int32),
+        _build_local_token_metadata=local_metadata,
+    )
+
+    result = dsa_cp.AscendDSACPMetadataBuilder.build_req_metadata_for_drafting(
+        cast(Any, builder),
+        draft_index=1,
+        common_attn_metadata=common_metadata,
+        input_positions=common_metadata.positions.long(),
+        num_input_tokens=5,
+    )
+
+    assert captured["ori_win_left"] == result.ori_win_left == 11
+    assert captured["ori_win_right"] == result.ori_win_right == 0
+    assert result.dspark_swa_indices is not None
+    assert result.dspark_swa_indices.shape == (3, 1, 128)
+    torch.testing.assert_close(result.dspark_swa_lens, torch.tensor([12, 12, 0], dtype=torch.int32))
+    assert torch.all(result.dspark_swa_indices[-1] == -1)

--- a/tests/ut/spec_decode/test_dspark_eager_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_eager_proposer.py
@@ -1,0 +1,374 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+import torch
+
+import vllm_ascend.spec_decode as spec_decode_module
+import vllm_ascend.spec_decode.deepseek_v4_dspark_proposer as dspark_proposer_module
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+from vllm_ascend.spec_decode.deepseek_v4_dspark_proposer import (
+    AscendDeepSeekV4DSparkProposer,
+)
+from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+
+def _group(gid: int, block_size: int = 8):
+    return SimpleNamespace(
+        kv_cache_group_id=gid,
+        kv_cache_spec=SimpleNamespace(block_size=block_size),
+        layer_names=[f"draft.layer.{gid}"],
+    )
+
+
+@pytest.mark.parametrize("method", ["mtp", "dspark"])
+def test_dspark_registration_precedes_generic_mtp(monkeypatch, method):
+    marker = object()
+    monkeypatch.setattr(
+        spec_decode_module,
+        "AscendDeepSeekV4DSparkProposer",
+        lambda *args: marker,
+    )
+    config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            draft_model_config=SimpleNamespace(hf_config=SimpleNamespace(dspark_block_size=5))
+        )
+    )
+
+    assert spec_decode_module.get_spec_decode_method(method, config, "npu", "runner") is marker
+
+
+def test_anchor_first_inputs_use_each_cache_group_and_rejected_anchor():
+    proposer = AscendDeepSeekV4DSparkProposer.__new__(AscendDeepSeekV4DSparkProposer)
+    proposer.device = torch.device("cpu")
+    proposer.block_size = proposer.num_speculative_tokens = 3
+    proposer.max_model_len = 64
+    proposer.max_num_tokens = 16
+    proposer.max_query_tokens = 6
+    proposer.draft_attn_groups = [_group(0), _group(1)]
+    proposer._draft_attn_layer_names_ordered = ["draft.layer.0", "draft.layer.1"]
+    proposer._per_group_block_tables = {
+        0: torch.tensor([[10, 11, 12, 13, 14], [20, 21, 22, 23, 24]], dtype=torch.int32),
+        1: torch.tensor([[30, 31, 32, 33, 34], [40, 41, 42, 43, 44]], dtype=torch.int32),
+    }
+    proposer._query_slot_buffers = {}
+    proposer._context_slot_buffers = {}
+    proposer.runner = None
+    proposer._seed_buffer = torch.zeros(2, dtype=torch.int64)
+    proposer._draft_buffer = torch.zeros((2, 3), dtype=torch.int64)
+    proposer._token_to_req_buffer = torch.zeros(6, dtype=torch.int32)
+    proposer._dflash_hidden_states = torch.zeros((8, 2))
+    proposer._context_positions_buffer = torch.zeros(8, dtype=torch.int32)
+    proposer.positions = torch.zeros(6, dtype=torch.int32)
+    proposer.input_ids = torch.zeros(6, dtype=torch.int64)
+    proposer.parallel_drafting_token_id = 99
+    proposer.arange_dspark = torch.arange(32, dtype=torch.int32)
+
+    target_positions = torch.tensor([10, 11, 12, 13, 30, 31, 32, 33], dtype=torch.int32)
+    target_hidden = torch.arange(16, dtype=torch.float32).view(8, 2)
+    cad = AscendCommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 4, 8], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 4, 8], dtype=torch.int32),
+        seq_lens=torch.tensor([14, 34], dtype=torch.int32),
+        _seq_lens_cpu=torch.tensor([14, 34], dtype=torch.int32),
+        seq_lens_cpu=None,
+        num_computed_tokens_cpu=None,
+        num_reqs=2,
+        num_actual_tokens=8,
+        num_input_tokens=8,
+        max_query_len=4,
+        actual_seq_lengths_q=[4, 4],
+        block_table_tensor=None,
+        slot_mapping=torch.arange(8, dtype=torch.int32),
+        positions=target_positions,
+        attn_state=AscendAttentionState.SpecDecoding,
+        decode_token_per_req=1,
+        max_seq_len=34,
+    )
+
+    num_tokens, indices, returned, _ = proposer.set_inputs_first_pass(
+        torch.arange(8),
+        torch.tensor([101, 202]),
+        target_positions,
+        target_hidden,
+        torch.tensor([2, 5], dtype=torch.int32),
+        cad,
+        torch.full((2,), torch.iinfo(torch.int32).max, dtype=torch.int32),
+    )
+
+    assert num_tokens == 6
+    torch.testing.assert_close(indices, torch.arange(6, dtype=torch.int32))
+    torch.testing.assert_close(proposer.input_ids, torch.tensor([101, 99, 99, 202, 99, 99]))
+    torch.testing.assert_close(proposer.positions, torch.tensor([13, 14, 15, 32, 33, 34], dtype=torch.int32))
+    torch.testing.assert_close(returned.seq_lens, torch.tensor([16, 35], dtype=torch.int32))
+    torch.testing.assert_close(returned.query_start_loc, torch.tensor([0, 3, 6], dtype=torch.int32))
+    assert proposer._dflash_num_context == 8
+    assert proposer._query_slots_by_gid[0].data_ptr() != proposer._query_slots_by_gid[1].data_ptr()
+    torch.testing.assert_close(proposer._dflash_hidden_states[:8], target_hidden)
+
+
+def test_dspark_masks_draft_tokens_past_max_model_len():
+    proposer = AscendDeepSeekV4DSparkProposer.__new__(AscendDeepSeekV4DSparkProposer)
+    proposer.device = torch.device("cpu")
+    proposer.block_size = proposer.num_speculative_tokens = 3
+    proposer.max_model_len = 64
+    proposer.max_num_tokens = 4
+    proposer.max_query_tokens = 3
+    proposer.draft_attn_groups = [_group(0)]
+    proposer._draft_attn_layer_names_ordered = ["draft.layer.0"]
+    proposer._per_group_block_tables = {0: torch.arange(8, dtype=torch.int32).view(1, 8)}
+    proposer._query_slot_buffers = {}
+    proposer._context_slot_buffers = {}
+    proposer.runner = None
+    proposer._seed_buffer = torch.zeros(1, dtype=torch.int64)
+    proposer._token_to_req_buffer = torch.zeros(3, dtype=torch.int32)
+    proposer._dflash_hidden_states = torch.zeros((4, 2))
+    proposer._context_positions_buffer = torch.zeros(4, dtype=torch.int32)
+    proposer.positions = torch.zeros(3, dtype=torch.int32)
+    proposer.input_ids = torch.zeros(3, dtype=torch.int64)
+    proposer.parallel_drafting_token_id = 99
+    proposer.arange_dspark = torch.arange(8, dtype=torch.int32)
+    target_positions = torch.tensor([61, 62], dtype=torch.int32)
+    cad = AscendCommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 2], dtype=torch.int32),
+        seq_lens=torch.tensor([63], dtype=torch.int32),
+        _seq_lens_cpu=torch.tensor([63], dtype=torch.int32),
+        seq_lens_cpu=None,
+        num_computed_tokens_cpu=None,
+        num_reqs=1,
+        num_actual_tokens=2,
+        num_input_tokens=2,
+        max_query_len=2,
+        actual_seq_lengths_q=[2],
+        block_table_tensor=None,
+        slot_mapping=torch.arange(2, dtype=torch.int32),
+        positions=target_positions,
+        attn_state=AscendAttentionState.SpecDecoding,
+        decode_token_per_req=1,
+        max_seq_len=63,
+    )
+
+    proposer.set_inputs_first_pass(
+        torch.arange(2),
+        torch.tensor([101]),
+        target_positions,
+        torch.zeros((2, 2)),
+        None,
+        cad,
+        None,
+    )
+
+    torch.testing.assert_close(proposer.positions, torch.tensor([63, 0, 0], dtype=torch.int32))
+    torch.testing.assert_close(proposer._query_slots_by_gid[0], torch.tensor([63, -1, -1], dtype=torch.int32))
+    torch.testing.assert_close(cad.seq_lens, torch.tensor([64], dtype=torch.int32))
+
+
+def test_dspark_rejects_input_without_valid_anchor():
+    proposer = AscendDeepSeekV4DSparkProposer.__new__(AscendDeepSeekV4DSparkProposer)
+    proposer.device = torch.device("cpu")
+    proposer.block_size = proposer.num_speculative_tokens = 2
+    proposer.max_model_len = 64
+    proposer.max_num_tokens = 2
+    proposer.max_query_tokens = 2
+    proposer.draft_attn_groups = [_group(0)]
+    proposer._per_group_block_tables = {0: torch.arange(8, dtype=torch.int32).view(1, 8)}
+    proposer.runner = None
+    proposer._seed_buffer = torch.zeros(1, dtype=torch.int64)
+    proposer.arange_dspark = torch.arange(8, dtype=torch.int32)
+    positions = torch.tensor([4, 5], dtype=torch.int32)
+    cad = SimpleNamespace(
+        num_reqs=1,
+        query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 2], dtype=torch.int32),
+    )
+
+    try:
+        proposer.set_inputs_first_pass(
+            torch.arange(2),
+            torch.tensor([101]),
+            positions,
+            torch.zeros((2, 2)),
+            None,
+            cad,
+            torch.tensor([2], dtype=torch.int32),
+        )
+    except ValueError as error:
+        assert "valid anchor token" in str(error)
+    else:
+        raise AssertionError("expected invalid DSpark anchor metadata to fail")
+
+
+def test_dspark_ignores_padded_rows_on_idle_dp_rank():
+    proposer = AscendDeepSeekV4DSparkProposer.__new__(AscendDeepSeekV4DSparkProposer)
+    proposer.device = torch.device("cpu")
+    proposer.dp_rank = 1
+    proposer.block_size = proposer.num_speculative_tokens = 2
+    proposer.max_model_len = 64
+    proposer.max_num_tokens = 2
+    proposer.max_query_tokens = 2
+    proposer.draft_attn_groups = [_group(0)]
+    proposer._draft_attn_layer_names_ordered = ["draft.layer.0"]
+    proposer._per_group_block_tables = {0: torch.arange(8, dtype=torch.int32).view(1, 8)}
+    proposer._query_slot_buffers = {}
+    proposer._context_slot_buffers = {}
+    proposer.runner = SimpleNamespace(_num_reqs_across_dp=torch.tensor([1, 0]), dp_rank=1)
+    proposer._seed_buffer = torch.zeros(1, dtype=torch.int64)
+    proposer._token_to_req_buffer = torch.zeros(2, dtype=torch.int32)
+    proposer._dflash_hidden_states = torch.zeros((2, 2))
+    proposer._context_positions_buffer = torch.zeros(2, dtype=torch.int32)
+    proposer.positions = torch.zeros(2, dtype=torch.int32)
+    proposer.input_ids = torch.zeros(2, dtype=torch.int64)
+    proposer.parallel_drafting_token_id = 99
+    proposer.arange_dspark = torch.arange(8, dtype=torch.int32)
+    positions = torch.tensor([4], dtype=torch.int32)
+    cad = AscendCommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 1], dtype=torch.int32),
+        seq_lens=torch.tensor([5], dtype=torch.int32),
+        _seq_lens_cpu=torch.tensor([5], dtype=torch.int32),
+        seq_lens_cpu=None,
+        num_computed_tokens_cpu=None,
+        num_reqs=1,
+        num_actual_tokens=1,
+        num_input_tokens=1,
+        max_query_len=1,
+        actual_seq_lengths_q=[1],
+        block_table_tensor=None,
+        slot_mapping=torch.zeros(1, dtype=torch.int32),
+        positions=positions,
+        attn_state=AscendAttentionState.SpecDecoding,
+        decode_token_per_req=1,
+        max_seq_len=5,
+    )
+
+    num_tokens, indices, returned, _ = proposer.set_inputs_first_pass(
+        torch.zeros(1, dtype=torch.int64),
+        torch.tensor([101]),
+        positions,
+        torch.zeros((1, 2)),
+        torch.tensor([-1057308040], dtype=torch.int32),
+        cad,
+        torch.tensor([1057308040], dtype=torch.int32),
+    )
+
+    assert num_tokens == 0
+    assert indices.numel() == 0
+    assert returned.num_reqs == 0
+    assert returned.query_start_loc.tolist() == [0]
+
+
+def test_sequential_markov_sampling_uses_previous_draft_token():
+    class FakeModel:
+        def compute_logits(self, hidden_states):
+            return torch.zeros((hidden_states.shape[0], 5))
+
+        def markov_embed(self, token_ids):
+            return token_ids
+
+        def markov_bias(self, token_ids):
+            logits = torch.zeros((token_ids.shape[0], 5))
+            logits.scatter_(1, ((token_ids + 1) % 5).unsqueeze(1), 10)
+            return logits
+
+    proposer = AscendDeepSeekV4DSparkProposer.__new__(AscendDeepSeekV4DSparkProposer)
+    proposer.model = FakeModel()
+    proposer.runner = SimpleNamespace(input_batch=SimpleNamespace(idx_mapping=None))
+    proposer.block_size = 2
+    proposer._probabilistic = False
+    proposer._seed_buffer = torch.tensor([1, 3])
+    proposer._draft_buffer = torch.zeros((2, 2), dtype=torch.int64)
+    proposer.positions = torch.arange(4, dtype=torch.int32)
+
+    tokens = proposer._sample_sequential(
+        torch.zeros((4, 3)),
+        2,
+        SimpleNamespace(all_greedy=True),
+    )
+
+    torch.testing.assert_close(tokens, torch.tensor([[2, 3], [4, 0]]))
+    assert proposer.take_last_draft_logits() is None
+
+
+def test_probabilistic_sampling_caches_processed_draft_logits(monkeypatch):
+    class FakeModel:
+        def compute_logits(self, hidden_states):
+            return torch.arange(hidden_states.shape[0] * 5, dtype=torch.float32).view(-1, 5)
+
+        def markov_embed(self, token_ids):
+            return token_ids
+
+        def markov_bias(self, token_ids):
+            return torch.zeros((token_ids.shape[0], 5))
+
+    calls = []
+
+    def fake_gumbel_sample(
+        logits,
+        idx_mapping,
+        temperature,
+        seeds,
+        positions,
+        *,
+        output_processed_logits,
+        output_processed_logits_col,
+        **kwargs,
+    ):
+        del kwargs
+        step = int(output_processed_logits_col)
+        output_processed_logits[:, step].copy_(logits)
+        calls.append((idx_mapping.clone(), temperature.clone(), seeds.clone(), positions.clone()))
+        return logits.argmax(dim=-1)
+
+    monkeypatch.setattr(dspark_proposer_module, "gumbel_sample", fake_gumbel_sample)
+    proposer = AscendDeepSeekV4DSparkProposer.__new__(AscendDeepSeekV4DSparkProposer)
+    proposer.model = FakeModel()
+    proposer.runner = SimpleNamespace(input_batch=SimpleNamespace(idx_mapping=torch.tensor([1, 0])), sampler=None)
+    proposer.vllm_config = SimpleNamespace(model_config=SimpleNamespace(seed=7))
+    proposer.block_size = 2
+    proposer._probabilistic = True
+    proposer._seed_buffer = torch.tensor([1, 3])
+    proposer._draft_buffer = torch.zeros((2, 2), dtype=torch.int64)
+    proposer._sampling_seed_buffer = torch.zeros(2, dtype=torch.int64)
+    proposer._idx_mapping_buffer = torch.arange(2, dtype=torch.int32)
+    proposer.positions = torch.arange(4, dtype=torch.int32)
+    proposer.arange_dspark = torch.arange(8, dtype=torch.int32)
+
+    tokens = proposer._sample_sequential(
+        torch.zeros((4, 3)),
+        2,
+        SimpleNamespace(
+            all_greedy=False,
+            temperature=torch.tensor([0.5, 0.75]),
+            generators={},
+        ),
+    )
+    draft_logits = proposer.take_last_draft_logits()
+
+    torch.testing.assert_close(tokens, torch.tensor([[4, 4], [4, 4]]))
+    assert draft_logits is not None
+    torch.testing.assert_close(
+        draft_logits,
+        torch.arange(20, dtype=torch.float32).view(2, 2, 5),
+    )
+    assert len(calls) == 2
+    torch.testing.assert_close(calls[0][0], torch.tensor([1, 0], dtype=torch.int32))
+    torch.testing.assert_close(calls[0][1], torch.tensor([0.5, 0.75]))
+    torch.testing.assert_close(calls[0][2], torch.tensor([7, 9980], dtype=torch.int64))
+
+
+def test_runner_flattens_cached_logits_by_active_request():
+    runner = SimpleNamespace(
+        _draft_logits=torch.arange(2 * 3 * 4, dtype=torch.float32).view(2, 3, 4),
+        _draft_logits_req_ids=["req-b", "req-a"],
+        input_batch=SimpleNamespace(req_ids=["req-a", "req-c", "req-b"]),
+    )
+    metadata = SimpleNamespace(num_draft_tokens=[2, 0, 1])
+
+    logits = NPUModelRunner._get_spec_decode_draft_logits(cast(Any, runner), metadata)
+
+    expected = torch.cat((runner._draft_logits[1, :2], runner._draft_logits[0, :1]))
+    torch.testing.assert_close(logits, expected)

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -110,3 +110,26 @@ class TestDisablePaddedDrafterBatchWithFullGraph:
         )
 
         proposer._raise_if_padded_drafter_batch_disabled_and_full_graph_enabled()
+
+
+def test_mtp_without_own_lm_head_shares_target_head():
+    proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
+    draft_head = object()
+    target_head = object()
+    proposer.method = "mtp"
+    proposer.model = SimpleNamespace(
+        has_own_lm_head=False,
+        lm_head=draft_head,
+        model=SimpleNamespace(layers={"43": SimpleNamespace()}),
+    )
+    proposer.vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(is_deepseek_mla=True),
+        compilation_config=SimpleNamespace(cudagraph_mode=CUDAGraphMode.NONE),
+    )
+    proposer.use_cuda_graph = False
+    proposer.use_eagle = False
+    proposer.enable_enpu = False
+
+    proposer._maybe_share_lm_head(SimpleNamespace(lm_head=target_head))
+
+    assert proposer.model.lm_head is target_head

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -18,11 +18,18 @@
 
 from __future__ import annotations
 
+import inspect
 from types import SimpleNamespace
 
 import pytest
+import torch
 from vllm.config import CUDAGraphMode
 
+import vllm_ascend.spec_decode.llm_base_proposer as proposer_module
+from vllm_ascend.ops.triton.spec_decode.utils import (
+    prepare_inputs_padded_kernel,
+    prepare_next_token_padded_kernel,
+)
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
 
 # CUDAGraphMode values whose ``has_full_cudagraphs()`` is True: FULL plus the
@@ -38,6 +45,67 @@ NON_FULL_CUDAGRAPH_MODES = [
     CUDAGraphMode.NONE,
     CUDAGraphMode.PIECEWISE,
 ]
+
+
+def test_prepare_inputs_padded_uses_one_program_per_request():
+    source = inspect.getsource(prepare_inputs_padded_kernel.fn)
+
+    assert "req_idx = tl.program_id(axis=0)" in source
+    assert "if req_idx == 0" in source
+    assert "cu_num_draft_tokens_ptr + req_idx - 1" in source
+    assert "tl.arange" not in source
+
+
+def test_prepare_next_token_padded_counts_int32_mask_values():
+    source = inspect.getsource(prepare_next_token_padded_kernel.fn)
+
+    assert "tl.sum(is_valid.to(tl.int32), axis=0)" in source
+
+
+def test_prepare_inputs_padded_ignores_graph_only_request_rows(monkeypatch):
+    monkeypatch.setattr(proposer_module, "HAS_TRITON", False)
+    proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
+    proposer.pcp_size = 1
+    proposer.arange = torch.arange(8, dtype=torch.int32)
+    proposer.runner = SimpleNamespace(
+        actual_seq_lengths_q=[3, 3],
+        attn_state=None,
+        decode_token_per_req=1,
+    )
+    metadata = SimpleNamespace(
+        query_start_loc=torch.tensor([0, 3, 6], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 3, 6], dtype=torch.int32),
+        seq_lens=torch.tensor([5, 0], dtype=torch.int32),
+        seq_lens_cpu=torch.tensor([5, 0], dtype=torch.int32),
+        _seq_lens_cpu=torch.tensor([5, 0], dtype=torch.int32),
+        seq_lens_cpu_upper_bound=torch.tensor([5, 0], dtype=torch.int32),
+        num_computed_tokens_cpu=None,
+        _num_computed_tokens_cpu=None,
+        num_reqs=2,
+        num_actual_tokens=3,
+        num_input_tokens=6,
+        block_table_tensor=None,
+        slot_mapping=torch.tensor([0, 1, 2, -1, -1, -1], dtype=torch.int32),
+        positions=torch.arange(6, dtype=torch.int32),
+        positions_cpu=None,
+        is_prefilling=None,
+        group_len=None,
+        group_key_idx=None,
+        group_key_cache_idx=None,
+    )
+    spec_metadata = SimpleNamespace(
+        cu_num_draft_tokens=torch.tensor([2], dtype=torch.int32),
+    )
+
+    _, token_indices, token_indices_to_sample, num_rejected = proposer.prepare_inputs_padded(
+        metadata,
+        spec_metadata,
+        torch.tensor([1], dtype=torch.int32),
+    )
+
+    assert token_indices.tolist() == [0, 1, 2, 3, 4, 5]
+    assert token_indices_to_sample.tolist() == [0]
+    assert num_rejected.tolist() == [2]
 
 
 class TestDisablePaddedDrafterBatchWithFullGraph:

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -281,6 +281,7 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
                 [10, 11, 12, 13, 14, 999],
                 [20, 21, 22, 23, 24, 25],
                 [30, 777, 778, 779, 780, 781],
+                [40, 888, 889, 890, 891, 892],
             ],
             dtype=torch.int64,
         )
@@ -300,6 +301,7 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
                     [10, 11, 12, 13, 14, -1],
                     [20, 21, 22, 23, 24, 25],
                     [30, -1, -1, -1, -1, -1],
+                    [40, -1, -1, -1, -1, -1],
                 ],
                 dtype=torch.int64,
             ),

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -244,9 +244,15 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
 
     def test_mtp3_placeholder_metadata_is_preserved_before_sanitizing_forward(self):
         runner = self._build_runner()
+        runner.pin_memory = False
         runner.pcp_size = 1
         runner.arange_np = np.arange(8, dtype=np.int32)
         runner._arange_scratch = np.empty(8, dtype=np.int32)
+        runner._spec_cu_num_draft_tokens = runner._make_buffer(1, dtype=torch.int32)
+        runner._spec_cu_num_sampled_tokens = runner._make_buffer(1, dtype=torch.int32)
+        runner._spec_logits_indices = runner._make_buffer(4, dtype=torch.int32)
+        runner._spec_target_logits_indices = runner._make_buffer(3, dtype=torch.int32)
+        runner._spec_bonus_logits_indices = runner._make_buffer(1, dtype=torch.int32)
         runner.input_ids = SimpleNamespace(
             cpu=torch.tensor([11, -1, -1, -1], dtype=torch.int32),
             gpu=torch.tensor([11, -1, -1, -1], dtype=torch.int32),
@@ -268,6 +274,43 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
         self.assertEqual(spec_decode_metadata.draft_token_ids.tolist(), [-1, -1, -1])
         self.assertEqual(runner.input_ids.gpu.tolist(), [11, 0, 0, 0])
         self.assertEqual(runner.input_ids.cpu.tolist(), [11, -1, -1, -1])
+
+    def test_mask_sampled_token_ids_respects_scheduled_draft_width(self):
+        sampled_token_ids = torch.tensor(
+            [
+                [10, 11, 12, 13, 14, 999],
+                [20, 21, 22, 23, 24, 25],
+                [30, 777, 778, 779, 780, 781],
+            ],
+            dtype=torch.int64,
+        )
+        metadata = SimpleNamespace(
+            cu_num_draft_tokens=torch.tensor([4, 9, 9], dtype=torch.int32),
+        )
+
+        masked = NPUModelRunner._mask_sampled_token_ids_to_scheduled_width(
+            sampled_token_ids,
+            metadata,
+        )
+
+        torch.testing.assert_close(
+            masked,
+            torch.tensor(
+                [
+                    [10, 11, 12, 13, 14, -1],
+                    [20, 21, 22, 23, 24, 25],
+                    [30, -1, -1, -1, -1, -1],
+                ],
+                dtype=torch.int64,
+            ),
+        )
+        self.assertIs(
+            NPUModelRunner._mask_sampled_token_ids_to_scheduled_width(
+                sampled_token_ids,
+                None,
+            ),
+            sampled_token_ids,
+        )
 
 
 class TestNPUModelRunnerDebugger(unittest.TestCase):
@@ -441,6 +484,88 @@ class TestCorrectOptimisticSeqLensCpu(unittest.TestCase):
         runner.valid_sampled_token_count_event = None
         with self.assertRaises(AssertionError):
             runner._correct_optimistic_seq_lens_cpu(1)
+
+
+class TestNPUModelRunnerSpecDecodeMetadata(unittest.TestCase):
+    def _build_runner(self):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.device = torch.device("cpu")
+        runner.pin_memory = False
+        runner.pcp_size = 1
+        runner.arange_np = np.arange(32, dtype=np.int64)
+        runner._arange_scratch = np.empty(32, dtype=np.int64)
+        runner.input_ids = runner._make_buffer(32, dtype=torch.int32)
+        runner.input_ids.gpu.copy_(torch.arange(32, dtype=torch.int32))
+        runner._spec_cu_num_draft_tokens = runner._make_buffer(5, dtype=torch.int32)
+        runner._spec_cu_num_sampled_tokens = runner._make_buffer(5, dtype=torch.int32)
+        runner._spec_logits_indices = runner._make_buffer(32, dtype=torch.int32)
+        runner._spec_target_logits_indices = runner._make_buffer(32, dtype=torch.int32)
+        runner._spec_bonus_logits_indices = runner._make_buffer(5, dtype=torch.int32)
+        return runner
+
+    def test_calc_spec_decode_metadata_reuses_stable_buffers(self):
+        runner = self._build_runner()
+
+        metadata = runner._calc_spec_decode_metadata(
+            np.array([3, 0, 2, 0, 1], dtype=np.int32),
+            np.array([4, 14, 17, 27, 29], dtype=np.int32),
+            num_pcp_pads=None,
+        )
+
+        torch.testing.assert_close(
+            metadata.cu_num_draft_tokens,
+            torch.tensor([3, 3, 5, 5, 6], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            metadata.cu_num_sampled_tokens,
+            torch.tensor([4, 5, 8, 9, 11], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            metadata.logits_indices,
+            torch.tensor(
+                [0, 1, 2, 3, 13, 14, 15, 16, 26, 27, 28],
+                dtype=torch.int32,
+            ),
+        )
+        torch.testing.assert_close(
+            metadata.target_logits_indices,
+            torch.tensor([0, 1, 2, 5, 6, 9], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            metadata.bonus_logits_indices,
+            torch.tensor([3, 4, 7, 8, 10], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            metadata.draft_token_ids,
+            torch.tensor([1, 2, 3, 15, 16, 28], dtype=torch.int32),
+        )
+        self.assertEqual(
+            metadata.cu_num_draft_tokens.data_ptr(),
+            runner._spec_cu_num_draft_tokens.gpu.data_ptr(),
+        )
+
+        metadata = runner._calc_spec_decode_metadata(
+            np.array([1], dtype=np.int32),
+            np.array([2], dtype=np.int32),
+            num_pcp_pads=None,
+        )
+
+        torch.testing.assert_close(
+            metadata.cu_num_draft_tokens,
+            torch.tensor([1], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            metadata.logits_indices,
+            torch.tensor([0, 1], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            metadata.draft_token_ids,
+            torch.tensor([1], dtype=torch.int32),
+        )
+        self.assertEqual(
+            metadata.cu_num_draft_tokens.data_ptr(),
+            runner._spec_cu_num_draft_tokens.gpu.data_ptr(),
+        )
 
 
 if __name__ == "__main__":

--- a/typos.toml
+++ b/typos.toml
@@ -51,6 +51,7 @@ tme = "tme"
 dout = "dout"
 Pn = "Pn"
 arange = "arange"
+ptd = "ptd"
 
 [type.py]
 extend-glob = []

--- a/vllm_ascend/_310p/sample/rejection_sampler.py
+++ b/vllm_ascend/_310p/sample/rejection_sampler.py
@@ -50,9 +50,16 @@ class AscendRejectionSampler310(AscendRejectionSampler):
         draft_probs: torch.Tensor | None,
         logits: torch.Tensor,
         sampling_metadata: SamplingMetadata,
+        draft_logits: torch.Tensor | None = None,
     ) -> SamplerOutput:
         with _bind_sample_recovered_tokens(self.sample_recovered_tokens):
-            return super().forward(metadata, draft_probs, logits, sampling_metadata)
+            return super().forward(
+                metadata,
+                draft_probs,
+                logits,
+                sampling_metadata,
+                draft_logits=draft_logits,
+            )
 
     def sample_recovered_tokens(
         self,

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -13,6 +13,7 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 
 from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.dsa_window import build_dspark_swa_metadata_for_drafting
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
@@ -98,6 +99,10 @@ class AscendDSAReqMetadata:
     qli_metadata: torch.Tensor = None
     cu_cmp_seqlen_list: torch.Tensor = None
     attn_mask: torch.Tensor | None = None
+    ori_win_left: int | None = None
+    ori_win_right: int | None = None
+    dspark_swa_indices: torch.Tensor | None = None
+    dspark_swa_lens: torch.Tensor | None = None
 
 
 @dataclass
@@ -469,6 +474,21 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
         assert self.spec_slot_mapping is not None
         slot_mapping = self.spec_slot_mapping[draft_index - 1][: self.num_actual_tokens]
+        ori_win_left, ori_win_right, dspark_swa_indices, dspark_swa_lens = build_dspark_swa_metadata_for_drafting(
+            self.vllm_config,
+            common_attn_metadata,
+            self.spec_slot_mapping[draft_index - 1],
+            self.block_size,
+        )
+        if dspark_swa_indices is not None:
+            if dspark_swa_lens is None:
+                raise ValueError("DSpark SWA indices require matching lengths")
+            pad_tokens = num_tokens_pad - dspark_swa_indices.shape[0]
+            if pad_tokens > 0:
+                dspark_swa_indices = F.pad(dspark_swa_indices, (0, 0, 0, 0, 0, pad_tokens), value=-1)
+                dspark_swa_lens = F.pad(dspark_swa_lens, (0, pad_tokens), value=0)
+            dspark_swa_indices = dspark_swa_indices[local_start:local_end_with_pad]
+            dspark_swa_lens = dspark_swa_lens[local_start:local_end_with_pad]
 
         num_heads = self.model_config.hf_config.num_attention_heads
         metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
@@ -504,8 +524,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             batch_size=num_reqs,
             cmp_ratio=1,
             ori_mask_mode=4,
-            ori_win_left=self.model_config.hf_config.sliding_window - 1,
-            ori_win_right=0,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
             layout_q="TND",
             layout_kv="PA_ND",
             has_ori_kv=True,
@@ -537,6 +557,10 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             sas_metadata=sas_metadata,
             qli_metadata=None,
             cu_cmp_seqlen_list=None,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
+            dspark_swa_indices=dspark_swa_indices,
+            dspark_swa_lens=dspark_swa_lens,
         )
 
     def _num_compressor_metadata_rows(
@@ -1431,6 +1455,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 extra_attn_kwargs, cu_seqlens_ori_kv=local_seq_lengths_query
             )
 
+        ori_win_left = self.window_size - 1 if req_metadata.ori_win_left is None else req_metadata.ori_win_left
         common_attn_kwargs = dict(
             cu_seqlens_q=local_seq_lengths_query,
             seqused_kv=local_seq_lengths_key,
@@ -1438,14 +1463,15 @@ class AscendDSACPImpl(DSAAttentionImpl):
             softmax_scale=self.softmax_scale,
             cmp_ratio=max(self.compress_ratio, 1),
             ori_mask_mode=4,
-            ori_win_left=self.window_size - 1,
-            ori_win_right=0,
+            ori_win_left=ori_win_left,
+            ori_win_right=req_metadata.ori_win_right or 0,
             layout_q="TND",
             layout_kv="PA_ND",
             **extra_attn_kwargs,
         )
 
         if self.compress_ratio <= 1:
+            common_attn_kwargs["ori_sparse_indices"] = req_metadata.dspark_swa_indices
             attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -18,6 +18,7 @@ from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.dsa_window import build_dspark_swa_metadata_for_drafting
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
@@ -251,6 +252,10 @@ class AscendDSAPrefillMetadata:
     qli_metadata: torch.Tensor = None
     cu_c4_cmp_seqlen_list: torch.Tensor = None
     cu_c128_cmp_seqlen_list: torch.Tensor = None
+    ori_win_left: int | None = None
+    ori_win_right: int | None = None
+    dspark_swa_indices: torch.Tensor | None = None
+    dspark_swa_lens: torch.Tensor | None = None
 
 
 @dataclass
@@ -281,6 +286,10 @@ class AscendDSADecodeMetadata:
     num_reqs_actual: int | None = None
     sas_metadata: torch.Tensor = None
     qli_metadata: torch.Tensor = None
+    ori_win_left: int | None = None
+    ori_win_right: int | None = None
+    dspark_swa_indices: torch.Tensor | None = None
+    dspark_swa_lens: torch.Tensor | None = None
 
 
 @dataclass
@@ -1173,6 +1182,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         reqs_start = kwargs.get("reqs_start")
         tokens_start = kwargs.get("tokens_start")
         num_prefill_tokens = kwargs.get("num_prefill_tokens")
+        if reqs_start is None or tokens_start is None or num_prefill_tokens is None:
+            raise ValueError("DSA draft prefill metadata requires request and token ranges")
         query_start_loc = common_attn_metadata.query_start_loc
         prefill_query_start_loc = query_start_loc[reqs_start:] - query_start_loc[reqs_start]
         seq_lens_q = prefill_query_start_loc[1:] - prefill_query_start_loc[:-1]
@@ -1183,7 +1194,20 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         prefill_input_positions = input_positions[tokens_start:]
         cos, sin = get_cos_and_sin_dsa(prefill_input_positions)
 
-        prefill_slot_mapping = self.spec_slot_mapping[draft_index - 1][tokens_start:num_prefill_tokens]  # type: ignore[index]
+        prefill_slot_mapping = self.spec_slot_mapping[  # type: ignore[index]
+            draft_index - 1
+        ][tokens_start : tokens_start + num_prefill_tokens]
+        ori_win_left, ori_win_right, dspark_swa_indices, dspark_swa_lens = build_dspark_swa_metadata_for_drafting(
+            self.vllm_config,
+            common_attn_metadata,
+            self.spec_slot_mapping[draft_index - 1],  # type: ignore[index]
+            self.block_size,
+        )
+        if dspark_swa_indices is not None:
+            if dspark_swa_lens is None:
+                raise ValueError("DSpark SWA indices require matching lengths")
+            dspark_swa_indices = dspark_swa_indices[tokens_start : tokens_start + num_prefill_tokens]
+            dspark_swa_lens = dspark_swa_lens[tokens_start : tokens_start + num_prefill_tokens]
         block_table = common_attn_metadata.block_table_tensor[: common_attn_metadata.num_reqs]
 
         metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
@@ -1203,8 +1227,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             batch_size=len(seq_lens),
             cmp_ratio=1,
             ori_mask_mode=4,
-            ori_win_left=self.model_config.hf_config.sliding_window - 1,
-            ori_win_right=0,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
             layout_q="TND",
             layout_kv="PA_ND",
             has_ori_kv=True,
@@ -1230,6 +1254,10 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             qli_metadata=None,
             cu_c4_cmp_seqlen_list=None,
             cu_c128_cmp_seqlen_list=None,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
+            dspark_swa_indices=dspark_swa_indices,
+            dspark_swa_lens=dspark_swa_lens,
         )
 
     def build_decode_metadata_for_drafting(
@@ -1264,6 +1292,17 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=True, draft_index=draft_index)
 
         slot_mapping = self.spec_slot_mapping[draft_index - 1][:num_decode_tokens_typed]  # type: ignore[index]
+        ori_win_left, ori_win_right, dspark_swa_indices, dspark_swa_lens = build_dspark_swa_metadata_for_drafting(
+            self.vllm_config,
+            common_attn_metadata,
+            slot_mapping,
+            self.block_size,
+        )
+        if dspark_swa_indices is not None:
+            if dspark_swa_lens is None:
+                raise ValueError("DSpark SWA indices require matching lengths")
+            dspark_swa_indices = dspark_swa_indices[:num_decode_tokens_typed]
+            dspark_swa_lens = dspark_swa_lens[:num_decode_tokens_typed]
         block_table = common_attn_metadata.block_table_tensor
 
         metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
@@ -1285,8 +1324,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             cmp_ratio=1,
             ori_mask_mode=4,
             cmp_mask_mode=3,
-            ori_win_left=self.model_config.hf_config.sliding_window - 1,
-            ori_win_right=0,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
             layout_q="TND",
             layout_kv="PA_ND",
             has_ori_kv=True,
@@ -1315,6 +1354,10 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             start_pos=None,
             sas_metadata=decode_sas_metadata,
             qli_metadata=None,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
+            dspark_swa_indices=dspark_swa_indices,
+            dspark_swa_lens=dspark_swa_lens,
         )
         return decode_metadata
 
@@ -1691,6 +1734,8 @@ class AscendDSAImpl(DSAAttentionImpl):
         decode_hidden_states = hidden_states[:decode_tokens]
 
         o_proj_input = torch.empty(o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device)
+        if actual_tokens < o_proj_input_shape[0]:
+            o_proj_input[actual_tokens:].zero_()
         assert kv_cache is not None, "kv_cache tensor tuple must be provided."
         if has_prefill:
             assert attn_metadata[0].prefill is not None
@@ -1937,9 +1982,15 @@ class AscendDSAImpl(DSAAttentionImpl):
         DeviceOperator.add_dsa_sparse_attn_extra_kwargs(extra_attn_kwargs, cu_seqlens_ori_kv=actual_seq_lengths_query)
 
         if self.compress_ratio <= 1:
+            ori_win_left = (
+                self.window_size - 1
+                if common_prefill_metadata.ori_win_left is None
+                else common_prefill_metadata.ori_win_left
+            )
             return attn_op(
                 q,
                 ori_kv=swa_kv_cache,
+                ori_sparse_indices=common_prefill_metadata.dspark_swa_indices,
                 ori_block_table=swa_prefill_metadata.block_table,
                 cu_seqlens_q=actual_seq_lengths_query,
                 seqused_kv=actual_seq_lengths_key,
@@ -1948,8 +1999,8 @@ class AscendDSAImpl(DSAAttentionImpl):
                 softmax_scale=self.softmax_scale,
                 cmp_ratio=max(self.compress_ratio, 1),
                 ori_mask_mode=4,
-                ori_win_left=self.window_size - 1,
-                ori_win_right=0,
+                ori_win_left=ori_win_left,
+                ori_win_right=common_prefill_metadata.ori_win_right or 0,
                 layout_q="TND",
                 layout_kv="PA_ND",
                 **extra_attn_kwargs,
@@ -2369,9 +2420,13 @@ class AscendDSAImpl(DSAAttentionImpl):
         extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
 
         if self.compress_ratio <= 1:
+            ori_win_left = (
+                self.window_size - 1 if swa_decode_metadata.ori_win_left is None else swa_decode_metadata.ori_win_left
+            )
             attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,
+                ori_sparse_indices=swa_decode_metadata.dspark_swa_indices,
                 ori_block_table=swa_decode_metadata.block_table,
                 cu_seqlens_q=actual_seq_lengths_query,
                 seqused_kv=actual_seq_lengths_key,
@@ -2380,8 +2435,8 @@ class AscendDSAImpl(DSAAttentionImpl):
                 softmax_scale=self.softmax_scale,
                 cmp_ratio=max(self.compress_ratio, 1),
                 ori_mask_mode=4,
-                ori_win_left=self.window_size - 1,
-                ori_win_right=0,
+                ori_win_left=ori_win_left,
+                ori_win_right=swa_decode_metadata.ori_win_right or 0,
                 layout_q="TND",
                 layout_kv="PA_ND",
                 **extra_attn_kwargs,

--- a/vllm_ascend/attention/dsa_window.py
+++ b/vllm_ascend/attention/dsa_window.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+import torch
+
+
+def _get_dspark_draft_hf_config(vllm_config: Any) -> Any | None:
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    draft_model_config = getattr(speculative_config, "draft_model_config", None)
+    return getattr(draft_model_config, "hf_config", None)
+
+
+def get_dspark_query_block_size(vllm_config: Any) -> int:
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    num_speculative_tokens = getattr(speculative_config, "num_speculative_tokens", None)
+    if num_speculative_tokens:
+        return int(num_speculative_tokens)
+
+    draft_hf_config = _get_dspark_draft_hf_config(vllm_config)
+    return int(getattr(draft_hf_config, "dspark_block_size", 0) or 0)
+
+
+def is_dspark_noncausal_draft(vllm_config: Any, common_attn_metadata: Any) -> bool:
+    if getattr(common_attn_metadata, "causal", True):
+        return False
+
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    use_dspark = getattr(speculative_config, "use_dspark", None)
+    if callable(use_dspark):
+        return bool(use_dspark())
+
+    draft_hf_config = _get_dspark_draft_hf_config(vllm_config)
+    return bool(getattr(draft_hf_config, "dspark_block_size", 0))
+
+
+def get_draft_swa_window(vllm_config: Any) -> tuple[int, int]:
+    window_size = int(vllm_config.model_config.hf_config.sliding_window)
+    return window_size - 1, 0
+
+
+def get_dspark_sparse_sas_window(vllm_config: Any) -> tuple[int, int]:
+    window_size = int(vllm_config.model_config.hf_config.sliding_window)
+    query_block_size = get_dspark_query_block_size(vllm_config)
+    return window_size + query_block_size - 1, 0
+
+
+def _valid_slot_rows(slot_mapping: torch.Tensor) -> torch.Tensor:
+    if slot_mapping.ndim == 1:
+        return slot_mapping >= 0
+    return torch.all(slot_mapping >= 0, dim=-1)
+
+
+def _aligned_index_width(window_size: int, query_block_size: int) -> int:
+    visible_upper_bound = window_size + query_block_size
+    return ((visible_upper_bound + 127) // 128) * 128
+
+
+def build_dspark_swa_indices(
+    block_table: torch.Tensor,
+    slot_mapping: torch.Tensor | None,
+    query_start_loc: torch.Tensor,
+    seq_lens: torch.Tensor,
+    query_block_size: int,
+    window_size: int,
+    cache_block_size: int,
+    num_query_tokens: int,
+    token_to_req_indices: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build physical slots for history-window plus full draft-block visibility."""
+    index_width = _aligned_index_width(window_size, query_block_size)
+    device = block_table.device
+    indices = torch.full((num_query_tokens, 1, index_width), -1, dtype=torch.int32, device=device)
+    lens = torch.zeros(num_query_tokens, dtype=torch.int32, device=device)
+    if num_query_tokens == 0:
+        return indices, lens
+    if slot_mapping is not None and slot_mapping.shape[0] < num_query_tokens:
+        raise ValueError("DSpark SWA slot_mapping must cover every query token")
+    if token_to_req_indices is not None and token_to_req_indices.numel() < num_query_tokens:
+        raise ValueError("DSpark SWA token_to_req_indices must cover every query token")
+
+    num_reqs = min(max(query_start_loc.numel() - 1, 0), block_table.shape[0], seq_lens.numel())
+    if num_reqs == 0 or block_table.shape[1] == 0:
+        return indices, lens
+
+    query_start_loc = query_start_loc[: num_reqs + 1].to(device=device, dtype=torch.long)
+    query_lens = query_start_loc[1:] - query_start_loc[:-1]
+    seq_lens = seq_lens[:num_reqs].to(device=device, dtype=torch.long)
+    visible_starts = torch.clamp(seq_lens - query_lens - window_size, min=0)
+    visible_lens = torch.clamp(seq_lens - visible_starts, min=0, max=index_width)
+
+    offsets = torch.arange(index_width, dtype=torch.long, device=device)
+    visible_positions = visible_starts[:, None] + offsets[None, :]
+    visible_mask = offsets[None, :] < visible_lens[:, None]
+    logical_blocks = torch.div(visible_positions, cache_block_size, rounding_mode="floor")
+    logical_blocks = logical_blocks.clamp(max=block_table.shape[1] - 1)
+    physical_blocks = block_table[:num_reqs].to(device=device, dtype=torch.long).gather(1, logical_blocks)
+    physical_slots = physical_blocks * cache_block_size + visible_positions % cache_block_size
+    physical_slots.masked_fill_(~visible_mask, -1)
+
+    if token_to_req_indices is None:
+        token_rows = torch.arange(num_query_tokens, dtype=torch.long, device=device)
+        token_to_req = torch.bucketize(token_rows, query_start_loc[1:], right=True)
+    else:
+        token_to_req = token_to_req_indices[:num_query_tokens].to(device=device, dtype=torch.long)
+
+    valid_rows = (token_to_req >= 0) & (token_to_req < num_reqs)
+    if slot_mapping is not None:
+        valid_rows &= _valid_slot_rows(slot_mapping[:num_query_tokens].to(device=device))
+    row_requests = token_to_req.clamp(0, num_reqs - 1)
+    indices[:, 0] = physical_slots.index_select(0, row_requests).to(torch.int32)
+    lens.copy_(visible_lens.index_select(0, row_requests).to(torch.int32))
+    indices.masked_fill_(~valid_rows[:, None, None], -1)
+    lens.masked_fill_(~valid_rows, 0)
+    return indices, lens
+
+
+def build_dspark_swa_metadata_for_drafting(
+    vllm_config: Any,
+    common_attn_metadata: Any,
+    slot_mapping: torch.Tensor | None,
+    cache_block_size: int,
+) -> tuple[int, int, torch.Tensor | None, torch.Tensor | None]:
+    if not is_dspark_noncausal_draft(vllm_config, common_attn_metadata):
+        ori_win_left, ori_win_right = get_draft_swa_window(vllm_config)
+        return ori_win_left, ori_win_right, None, None
+
+    num_reqs = int(getattr(common_attn_metadata, "num_reqs", 0) or 0)
+    num_query_tokens = int(getattr(common_attn_metadata, "num_input_tokens", 0) or 0)
+    if num_query_tokens == 0:
+        num_query_tokens = int(getattr(common_attn_metadata, "num_actual_tokens", 0) or 0)
+    query_block_size = get_dspark_query_block_size(vllm_config)
+    if query_block_size <= 0:
+        raise ValueError("DSpark noncausal drafting requires a positive query block size")
+    block_table = getattr(common_attn_metadata, "block_table_tensor", None)
+    if block_table is None:
+        raise ValueError("DSpark noncausal drafting requires a paged SWA block table")
+    indices, lens = build_dspark_swa_indices(
+        block_table[:num_reqs],
+        slot_mapping,
+        common_attn_metadata.query_start_loc[: num_reqs + 1],
+        common_attn_metadata.seq_lens[:num_reqs],
+        query_block_size,
+        int(vllm_config.model_config.hf_config.sliding_window),
+        int(cache_block_size),
+        num_query_tokens,
+        getattr(common_attn_metadata, "token_to_req_indices", None),
+    )
+    ori_win_left, ori_win_right = get_dspark_sparse_sas_window(vllm_config)
+    return ori_win_left, ori_win_right, indices, lens

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -6,5 +6,9 @@ def register_model():
 
     ModelRegistry.register_model("DeepSeekV4MTPModel", "vllm_ascend.models.deepseek_v4_mtp:DeepSeekV4MTP")
     ModelRegistry.register_model(
+        "DeepSeekV4DSparkMTPModel",
+        "vllm_ascend.models.deepseek_v4_dspark:DeepSeekV4DSparkMTP",
+    )
+    ModelRegistry.register_model(
         "LlamaForCausalLMVwnEagle3", "vllm_ascend.models.llama_eagle3_vwn:Eagle3VwnLlamaForCausalLM"
     )

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -56,7 +56,12 @@ from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead, VocabParallelEmbedding
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader, maybe_remap_kv_scale_name
-from vllm.model_executor.models.interfaces import MixtureOfExperts, SupportsEagle, SupportsLoRA, SupportsPP
+from vllm.model_executor.models.interfaces import (
+    MixtureOfExperts,
+    SupportsEagle,
+    SupportsLoRA,
+    SupportsPP,
+)
 from vllm.model_executor.models.utils import (
     PPMissingLayer,
     is_pp_missing_parameter,
@@ -88,6 +93,10 @@ from vllm_ascend.utils import (
 
 if not vllm_version_is("0.23.0"):
     from vllm.model_executor.layers.fused_moe import fused_moe_make_expert_params_mapping
+
+
+def _is_dspark_target_layer(layer_idx: int, target_layer_ids: set[int]) -> bool:
+    return layer_idx in target_layer_ids
 
 
 def _get_ascend_dsa_backend():
@@ -1085,6 +1094,14 @@ class DeepseekV4Model(nn.Module):
             dtype=vllm_config.model_config.dtype,
             device=self.device,
         )
+        self._dspark_target_layer_ids = tuple(getattr(config, "dspark_target_layer_ids", ()) or ())
+        if self._dspark_target_layer_ids:
+            self._dspark_hidden_buffer = torch.empty(
+                vllm_config.scheduler_config.max_num_batched_tokens,
+                len(self._dspark_target_layer_ids) * config.hidden_size,
+                dtype=vllm_config.model_config.dtype,
+                device=self.device,
+            )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
@@ -1130,8 +1147,12 @@ class DeepseekV4Model(nn.Module):
 
         if get_pp_group().is_first_rank:
             hidden_states = hidden_states.unsqueeze(1).repeat(1, self.hc_mult, 1)  # (b, s, h) -> (b, s, c, h)
+        dspark_hidden_states: list[torch.Tensor] = []
+        dspark_target_layer_ids = set(self._dspark_target_layer_ids)
         for layer in islice(self.layers, self.start_layer, self.end_layer):
             hidden_states, residual = layer(positions, hidden_states, residual, llama_4_scaling)
+            if _is_dspark_target_layer(layer.layer_idx, dspark_target_layer_ids):
+                dspark_hidden_states.append(hidden_states.mean(dim=1))
 
         # Stash pre-hc_head residual for the MTP draft (captured copy_).
         # When FlashComm1 (sequence parallelism) is enabled, tokens are
@@ -1153,6 +1174,14 @@ class DeepseekV4Model(nn.Module):
         else:
             num_tokens = hidden_states.shape[0]
             self._mtp_hidden_buffer[:num_tokens].copy_(hidden_states.flatten(1))
+
+        if dspark_hidden_states:
+            dspark_states = torch.cat(dspark_hidden_states, dim=-1)
+            if forward_ctx is not None and forward_ctx.flash_comm_v1_enabled:
+                dspark_states = tensor_model_parallel_all_gather(dspark_states, dim=0)
+                if forward_ctx.pad_size > 0:
+                    dspark_states = dspark_states[: -forward_ctx.pad_size]
+            self._dspark_hidden_buffer[: dspark_states.shape[0]].copy_(dspark_states)
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
@@ -1207,7 +1236,13 @@ class DeepseekV2MixtureOfExperts(MixtureOfExperts):
             moe.experts.update_expert_map()
 
 
-class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExperts, SupportsLoRA, SupportsEagle):
+class AscendDeepseekV4ForCausalLM(
+    nn.Module,
+    SupportsPP,
+    SupportsEagle,
+    DeepseekV2MixtureOfExperts,
+    SupportsLoRA,
+):
     packed_modules_mapping = {
         "gate_up_proj": ["gate_proj", "up_proj"],
     }
@@ -1305,6 +1340,8 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
         """Pre-hc_head residual stream buffer (max_num_batched_tokens,
         hc_mult * hidden_size) for the MTP draft model. Populated by
         forward(); valid after each target step."""
+        if self.model._dspark_target_layer_ids:
+            return self.model._dspark_hidden_buffer
         return getattr(self.model, "_mtp_hidden_buffer", None)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:

--- a/vllm_ascend/models/deepseek_v4_draft.py
+++ b/vllm_ascend/models/deepseek_v4_draft.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+import regex as re
+
+_MTP_WEIGHT_RE = re.compile(r"^mtp\.(\d+)\.(.+)$")
+
+
+def is_deepseek_v4_dspark_config(config: Any) -> bool:
+    return config.model_type == "deepseek_v4" and int(getattr(config, "dspark_block_size", 0) or 0) > 0
+
+
+def remap_dspark_mtp_weight_name(name: str, num_hidden_layers: int) -> str | None:
+    """Map a DeepSeek V4 checkpoint MTP name to the draft runtime layer."""
+    match = _MTP_WEIGHT_RE.match(name)
+    if match is None:
+        return None
+
+    stage_idx = int(match.group(1))
+    rest = match.group(2)
+    if rest.startswith("confidence_head."):
+        return None
+
+    name = f"model.layers.{num_hidden_layers + stage_idx}.{rest}"
+    replacements = (
+        (".attn.", ".self_attn."),
+        (".ffn_norm.", ".post_attention_layernorm."),
+        (".attn_norm.", ".input_layernorm."),
+        (".ffn.", ".mlp."),
+        (".w1.", ".gate_proj."),
+        (".w2.", ".down_proj."),
+        (".w3.", ".up_proj."),
+        (".mlp.gate.bias", ".mlp.gate.e_score_correction_bias"),
+    )
+    for source, target in replacements:
+        name = name.replace(source, target)
+    return name

--- a/vllm_ascend/models/deepseek_v4_dspark.py
+++ b/vllm_ascend/models/deepseek_v4_dspark.py
@@ -1,0 +1,516 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DeepSeek V4 DSpark draft model for Ascend."""
+
+import copy
+import typing
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+import regex as re
+import torch
+import torch.nn as nn
+from safetensors.torch import load_file
+from transformers import PretrainedConfig
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig
+from vllm.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.logger import logger
+from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.models.utils import PPMissingLayer, maybe_prefix
+from vllm.platforms import current_platform
+from vllm.sequence import IntermediateTensors
+
+from vllm_ascend.models.deepseek_v4 import (
+    DeepseekV2DecoderLayer,
+    DeepseekV2MixtureOfExperts,
+    DeepseekV4MoE,
+)
+from vllm_ascend.models.deepseek_v4_draft import remap_dspark_mtp_weight_name
+from vllm_ascend.ops.dsa import unfold_kvcache
+from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
+from vllm_ascend.utils import vllm_version_is
+
+if not vllm_version_is("0.23.0"):
+    from vllm.model_executor.layers.fused_moe import (
+        fused_moe_make_expert_params_mapping,
+    )
+
+_EXPERT_SCALE_RE = re.compile(r"\.experts\.\d+\.(gate_proj|up_proj|down_proj)\.scale$")
+_LAYER_ID_RE = re.compile(r"model\.layers\.(\d+)\.")
+
+
+def _linear_output(layer: nn.Module, hidden_states: torch.Tensor) -> torch.Tensor:
+    output = layer(hidden_states)
+    return output[0] if isinstance(output, tuple) else output
+
+
+def _draft_quant_config(vllm_config: VllmConfig):
+    assert vllm_config.speculative_config is not None
+    draft_config = vllm_config.speculative_config.draft_model_config.hf_config
+    if getattr(draft_config, "dspark_mtp_dequantized_to_bf16", False):
+        return None
+    return vllm_config.quant_config
+
+
+def _get_dspark_num_mtp_layers(config: PretrainedConfig) -> int:
+    return int(getattr(config, "n_mtp_layers", None) or getattr(config, "dspark_num_mtp_layers", None) or 3)
+
+
+def _load_dspark_quarot_rotation(
+    vllm_config: VllmConfig,
+    device: torch.device | str | None = None,
+) -> torch.Tensor | None:
+    quant_description = getattr(vllm_config.quant_config, "quant_description", None)
+    if not isinstance(quant_description, dict):
+        return None
+    try:
+        relative_path = quant_description["optional"]["quarot"]["rotation_map"]["global_rotation"]
+    except KeyError:
+        return None
+
+    rotation_path = Path(vllm_config.model_config.model) / relative_path
+    rotation = load_file(rotation_path)["global_rotation"].to(device=device, dtype=torch.float32)
+    logger.info_once("Loaded DSpark QuaRot rotation from %s", rotation_path)
+    return rotation
+
+
+def _apply_dspark_quarot_rotation(
+    hidden_states: torch.Tensor,
+    rotation: torch.Tensor | None,
+    *,
+    transpose: bool,
+) -> torch.Tensor:
+    if rotation is None:
+        return hidden_states
+    if rotation.device != hidden_states.device:
+        raise RuntimeError("DSpark QuaRot rotation must be loaded on the same device as hidden states")
+    matrix = rotation.t() if transpose else rotation
+    return torch.matmul(hidden_states.float(), matrix).to(hidden_states.dtype)
+
+
+def _hc_head(
+    hidden_states: torch.Tensor,
+    hc_fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    norm_eps: float,
+    hc_eps: float,
+) -> torch.Tensor:
+    shape, dtype = hidden_states.shape, hidden_states.dtype
+    hidden_flat = hidden_states.flatten(1).float()
+    rsqrt = torch.rsqrt(hidden_flat.square().mean(-1, keepdim=True) + norm_eps)
+    mixes = torch.nn.functional.linear(hidden_flat, hc_fn) * rsqrt
+    pre = torch.sigmoid(mixes * hc_scale + hc_base) + hc_eps
+    return torch.sum(pre.unsqueeze(-1) * hidden_flat.view(shape), dim=1).to(dtype)
+
+
+def _scatter_context_kv(cache: torch.Tensor | list, kv: torch.Tensor, slot_mapping: torch.Tensor) -> None:
+    from vllm_ascend.device.device_op import DeviceOperator
+
+    cache = unfold_kvcache(cache)
+    slot_mapping = DeviceOperator.format_dsa_slot_mapping(slot_mapping, cache.shape[1])
+    DeviceOperator.dsa_kv_compress_scatter(cache, kv, slot_mapping)
+
+
+def _make_expert_params_mapping(model: nn.Module, num_experts: int) -> list[tuple[str, str, int, str]]:
+    kwargs = dict(
+        ckpt_gate_proj_name="gate_proj",
+        ckpt_down_proj_name="down_proj",
+        ckpt_up_proj_name="up_proj",
+        num_experts=num_experts,
+        num_redundant_experts=0,
+    )
+    if vllm_version_is("0.23.0"):
+        return FusedMoE.make_expert_params_mapping(model, **kwargs)
+    return fused_moe_make_expert_params_mapping(model, **kwargs)
+
+
+class DSparkMarkovHead(nn.Module):
+    def __init__(self, config: PretrainedConfig, prefix: str) -> None:
+        super().__init__()
+        self.markov_w1 = VocabParallelEmbedding(
+            config.vocab_size,
+            config.dspark_markov_rank,
+            prefix=f"{prefix}.markov_w1",
+        )
+        self.markov_w2 = ParallelLMHead(
+            config.vocab_size,
+            config.dspark_markov_rank,
+            org_num_embeddings=config.vocab_size,
+            prefix=f"{prefix}.markov_w2",
+        )
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+
+    def embed(self, token_ids: torch.Tensor) -> torch.Tensor:
+        return self.markov_w1(token_ids)
+
+    def bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
+        return self.logits_processor(self.markov_w2, markov_embed)
+
+
+class DeepseekV4DSparkModel(nn.Module):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        assert vllm_config.speculative_config is not None
+        config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.config = config
+        self.hc_mult = config.hc_mult
+        self.target_layer_ids = tuple(config.dspark_target_layer_ids)
+        self.num_dspark_layers = _get_dspark_num_mtp_layers(config)
+        self.mtp_start_layer_idx = config.num_hidden_layers
+
+        draft_vllm_config = copy.copy(vllm_config)
+        draft_vllm_config.quant_config = _draft_quant_config(vllm_config)
+        self.embed_tokens = VocabParallelEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=draft_vllm_config.quant_config,
+            prefix=maybe_prefix(prefix, "embed_tokens"),
+        )
+        self.layers = nn.ModuleDict(
+            {
+                str(self.mtp_start_layer_idx + index): DeepseekV2DecoderLayer(
+                    draft_vllm_config,
+                    prefix=maybe_prefix(prefix, f"layers.{self.mtp_start_layer_idx + index}"),
+                    config=config,
+                    is_draft_layer=True,
+                )
+                for index in range(self.num_dspark_layers)
+            }
+        )
+
+        first_layer_idx = self.mtp_start_layer_idx
+        last_layer_idx = first_layer_idx + self.num_dspark_layers - 1
+        self.main_proj = ReplicatedLinear(
+            config.hidden_size * len(self.target_layer_ids),
+            config.hidden_size,
+            bias=False,
+            return_bias=False,
+            quant_config=None,
+            prefix=maybe_prefix(prefix, f"layers.{first_layer_idx}.main_proj"),
+        )
+        self.main_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.layers[str(first_layer_idx)].main_proj = self.main_proj
+        self.layers[str(first_layer_idx)].main_norm = self.main_norm
+
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.markov_head = DSparkMarkovHead(
+            config,
+            maybe_prefix(prefix, f"layers.{last_layer_idx}.markov_head"),
+        )
+        hc_dim = self.hc_mult * config.hidden_size
+        self.hc_head_fn = nn.Parameter(
+            torch.empty(self.hc_mult, hc_dim, dtype=torch.float32),
+            requires_grad=False,
+        )
+        self.hc_head_base = nn.Parameter(torch.empty(self.hc_mult, dtype=torch.float32), requires_grad=False)
+        self.hc_head_scale = nn.Parameter(torch.empty(1, dtype=torch.float32), requires_grad=False)
+        last_layer = self.layers[str(last_layer_idx)]
+        last_layer.norm = self.norm
+        last_layer.markov_head = self.markov_head
+        last_layer.hc_head_fn = self.hc_head_fn
+        last_layer.hc_head_base = self.hc_head_base
+        last_layer.hc_head_scale = self.hc_head_scale
+
+        device_config = getattr(vllm_config, "device_config", None)
+        rotation_device = getattr(device_config, "device", current_platform.device_type)
+        self.register_buffer(
+            "_dspark_quarot_rotation",
+            _load_dspark_quarot_rotation(vllm_config, rotation_device),
+            persistent=False,
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return _apply_dspark_quarot_rotation(
+            self.embed_tokens(input_ids),
+            self._dspark_quarot_rotation,
+            transpose=True,
+        )
+
+    def combine_hidden_states(self, aux_hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.main_norm(_linear_output(self.main_proj, aux_hidden_states))
+
+    def get_draft_kv_cache_layer_names(self) -> list[str]:
+        return [layer.self_attn.dsa_attn.swa_cache_layer.prefix for layer in self.layers.values()]
+
+    @torch.inference_mode()
+    def precompute_and_store_context_kv(
+        self,
+        main_hidden_states: torch.Tensor,
+        context_positions: torch.Tensor,
+        context_slot_mappings: Sequence[torch.Tensor | None] | None = None,
+    ) -> None:
+        if context_slot_mappings is not None and len(context_slot_mappings) != len(self.layers):
+            raise ValueError("DSpark context slot mappings must match the number of draft layers")
+        main_hidden_states = self.combine_hidden_states(main_hidden_states)
+        cos, sin = get_cos_and_sin_dsa(context_positions)
+        for index, layer in enumerate(self.layers.values()):
+            slot_mapping = None if context_slot_mappings is None else context_slot_mappings[index]
+            attn = layer.self_attn
+            kv = attn.kv_norm(_linear_output(attn.wkv, main_hidden_states))
+            kv = kv.view(-1, 1, attn.head_dim)
+            layer_name = attn.rotary_emb.layername
+            torch.ops._C_ascend.inplace_partial_rotary_mul(
+                kv.unsqueeze(1),
+                cos[layer_name],
+                sin[layer_name],
+                rotary_mode="interleave",
+                partial_slice=[attn.nope_head_dim, attn.head_dim],
+            )
+            if slot_mapping is not None:
+                _scatter_context_kv(
+                    attn.dsa_attn.swa_cache_layer.kv_cache,
+                    kv,
+                    slot_mapping,
+                )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_input_ids(input_ids)
+        hidden_states = inputs_embeds.unsqueeze(-2).repeat(1, self.hc_mult, 1)
+        for layer in self.layers.values():
+            hidden_states, _ = layer(positions, hidden_states, None)
+        return _hc_head(
+            hidden_states,
+            self.hc_head_fn,
+            self.hc_head_scale,
+            self.hc_head_base,
+            self.config.rms_norm_eps,
+            self.config.hc_eps,
+        )
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+        lm_head: ParallelLMHead,
+        logits_processor: LogitsProcessor,
+    ) -> torch.Tensor:
+        hidden_states = self.norm(hidden_states)
+        if self._dspark_quarot_rotation is not None:
+            hidden_states = hidden_states / self.norm.weight.to(device=hidden_states.device, dtype=hidden_states.dtype)
+        hidden_states = _apply_dspark_quarot_rotation(
+            hidden_states,
+            self._dspark_quarot_rotation,
+            transpose=False,
+        )
+        return logits_processor(lm_head, hidden_states)
+
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        return _make_expert_params_mapping(self, self.config.n_routed_experts)
+
+    def finalize_mega_moe_weights(self) -> None:
+        for layer in self.layers.values():
+            finalize = getattr(layer.mlp, "finalize_mega_moe_weights", None)
+            if finalize is not None:
+                finalize()
+
+
+@support_torch_compile
+class DeepSeekV4DSparkMTP(nn.Module, DeepseekV2MixtureOfExperts):
+    has_own_embed_tokens = False
+    has_own_lm_head = False
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        assert vllm_config.speculative_config is not None
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.quant_config = _draft_quant_config(vllm_config)
+        self.model = DeepseekV4DSparkModel(vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model"))
+        self.lm_head = ParallelLMHead(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
+        self.logits_processor = LogitsProcessor(self.config.vocab_size)
+        self.set_moe_parameters()
+
+    def set_moe_parameters(self) -> None:
+        self.expert_weights: list[Sequence[torch.Tensor]] = []
+        self.num_expert_groups = getattr(self.config, "n_group", 1)
+        self.moe_layers = []
+        self.moe_mlp_layers = []
+        example_moe = None
+        for layer in self.model.layers.values():
+            if isinstance(layer, PPMissingLayer):
+                continue
+            if isinstance(layer.mlp, DeepseekV4MoE):
+                example_moe = layer.mlp
+                self.moe_mlp_layers.append(layer.mlp)
+                self.moe_layers.append(layer.mlp.experts)
+        self.extract_moe_parameters(example_moe)
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def combine_hidden_states(self, aux_hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.model.combine_hidden_states(aux_hidden_states)
+
+    def get_draft_kv_cache_layer_names(self) -> list[str]:
+        return self.model.get_draft_kv_cache_layer_names()
+
+    def precompute_and_store_context_kv(
+        self,
+        main_hidden_states: torch.Tensor,
+        context_positions: torch.Tensor,
+        context_slot_mappings: Sequence[torch.Tensor | None] | None = None,
+    ) -> None:
+        self.model.precompute_and_store_context_kv(main_hidden_states, context_positions, context_slot_mappings)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor | None = None,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor:
+        del hidden_states, intermediate_tensors, spec_step_idx
+        assert input_ids is not None
+        return self.model(input_ids, positions, inputs_embeds)
+
+    def compute_logits(self, hidden_states: torch.Tensor, spec_step_idx: int = 0) -> torch.Tensor:
+        del spec_step_idx
+        return self.model.compute_logits(hidden_states, self.lm_head, self.logits_processor)
+
+    def markov_embed(self, token_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.markov_head.embed(token_ids)
+
+    def markov_bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
+        return self.model.markov_head.bias(markov_embed)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = (
+            ("mlp.gate_up_proj", "mlp.gate_proj", 0),
+            ("mlp.gate_up_proj", "mlp.up_proj", 1),
+            ("shared_experts.gate_up_proj", "shared_experts.gate_proj", 0),
+            ("shared_experts.gate_up_proj", "shared_experts.up_proj", 1),
+        )
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        missing_mtp_params: set[str] = set()
+        start_layer_idx = self.config.num_hidden_layers
+        last_layer_idx = start_layer_idx + self.model.num_dspark_layers - 1
+
+        tp_size = get_tensor_model_parallel_world_size()
+        heads_per_rank = self.config.num_attention_heads // tp_size
+        head_start = get_tensor_model_parallel_rank() * heads_per_rank
+        head_end = head_start + heads_per_rank
+        expert_mapping = self.model.get_expert_mapping()
+        expert_scale_suffix = (
+            ".weight_scale" if getattr(self.config, "expert_dtype", "fp4") == "fp4" else ".weight_scale_inv"
+        )
+
+        for name, loaded_weight in weights:
+            if name in ("embed.weight", "head.weight"):
+                continue
+            mapped_name = remap_dspark_mtp_weight_name(name, self.config.num_hidden_layers)
+            if mapped_name is None:
+                continue
+            name = mapped_name
+            if name.startswith(f"model.layers.{last_layer_idx}.hc_head_"):
+                name = name.replace(f"model.layers.{last_layer_idx}.", "model.", 1)
+            if name.endswith(".scale"):
+                suffix = expert_scale_suffix if _EXPERT_SCALE_RE.search(name) else ".weight_scale"
+                name = name.removesuffix(".scale") + suffix
+
+            for param_name, weight_name, stacked_shard_id in stacked_params_mapping:
+                if ".experts." in name or f".{weight_name}." not in name:
+                    continue
+                mapped = name.replace(weight_name, param_name)
+                param = params_dict.get(mapped)
+                if param is None:
+                    missing_mtp_params.add(mapped)
+                else:
+                    param.weight_loader(param, loaded_weight, stacked_shard_id)
+                    loaded_params.add(mapped)
+                break
+            else:
+                if ".experts." in name:
+                    matched_expert_mapping = False
+                    if "weight_scale" in name and loaded_weight.dtype == torch.float8_e8m0fnu:
+                        loaded_weight = loaded_weight.view(torch.uint8)
+                    for param_name, weight_name, expert_id, expert_shard_id in expert_mapping:
+                        if weight_name not in name:
+                            continue
+                        matched_expert_mapping = True
+                        mapped = name.replace(weight_name, param_name)
+                        param = params_dict.get(mapped)
+                        if param is None:
+                            continue
+                        weight_loader = typing.cast(typing.Callable[..., bool], param.weight_loader)
+                        if weight_loader(
+                            param,
+                            loaded_weight,
+                            mapped,
+                            shard_id=expert_shard_id,
+                            expert_id=expert_id,
+                            return_success=True,
+                        ):
+                            loaded_params.add(mapped)
+                            break
+                    if not matched_expert_mapping:
+                        missing_mtp_params.add(name)
+                    continue
+                if "attn_sink" in name:
+                    param = params_dict.get(name)
+                    if param is None:
+                        missing_mtp_params.add(name)
+                    else:
+                        with torch.no_grad():
+                            param[:heads_per_rank].copy_(loaded_weight[head_start:head_end])
+                        loaded_params.add(name)
+                    continue
+                param = params_dict.get(name)
+                if param is None:
+                    missing_mtp_params.add(name)
+                    continue
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+                loaded_params.add(name)
+
+        if missing_mtp_params:
+            raise ValueError(f"DSpark checkpoint weights did not match model parameters: {sorted(missing_mtp_params)}")
+
+        loaded_layer_ids = {
+            int(match.group(1)) for name in loaded_params if (match := _LAYER_ID_RE.search(name)) is not None
+        }
+        for layer_idx in range(start_layer_idx, last_layer_idx + 1):
+            if layer_idx not in loaded_layer_ids:
+                raise ValueError(f"DSpark layer {layer_idx} weights missing from checkpoint")
+        required_params = {
+            f"model.layers.{start_layer_idx}.main_proj.weight",
+            f"model.layers.{start_layer_idx}.main_norm.weight",
+            f"model.layers.{last_layer_idx}.norm.weight",
+            "model.hc_head_fn",
+            "model.hc_head_base",
+            "model.hc_head_scale",
+            f"model.layers.{last_layer_idx}.markov_head.markov_w1.weight",
+            f"model.layers.{last_layer_idx}.markov_head.markov_w2.weight",
+        }
+        missing_required = sorted(required_params - loaded_params)
+        if missing_required:
+            raise ValueError(f"DSpark required weights missing from checkpoint load: {missing_required}")
+        self.model.finalize_mega_moe_weights()
+        logger.info_once("DSpark draft model loaded: %d params", len(loaded_params))
+        return loaded_params
+
+
+DSparkDeepseekV4ForCausalLM = DeepSeekV4DSparkMTP

--- a/vllm_ascend/ops/triton/reject_sample.py
+++ b/vllm_ascend/ops/triton/reject_sample.py
@@ -88,8 +88,14 @@ def rejection_greedy_sample_triton(
         is_greedy = tl.load(is_greedy_ptr + offset, mask=mask, other=0)
         is_greedy_mask = mask & (is_greedy != 0)
 
-    start_idx = tl.where(offset == 0, 0, tl.load(cu_num_draft_tokens_ptr + offset - 1, is_greedy_mask))
-    end_idx = tl.load(cu_num_draft_tokens_ptr + offset, is_greedy_mask)
+    has_prev = offset > 0
+    prev_offset = tl.where(has_prev, offset - 1, 0)
+    start_idx = tl.load(
+        cu_num_draft_tokens_ptr + prev_offset,
+        mask=is_greedy_mask & has_prev,
+        other=0,
+    )
+    end_idx = tl.load(cu_num_draft_tokens_ptr + offset, mask=is_greedy_mask, other=0)
     num_draft_tokens = end_idx - start_idx
 
     for pos in tl.range(0, BLOCK_SIZE):
@@ -454,7 +460,7 @@ def rejection_greedy_sample_with_triton(
 ):
     vec_len = output_token_ids.shape[0]
 
-    if min(num_draft_tokens) == 1 and max(num_draft_tokens) == 1 and is_greedy is None:
+    if max_spec_len == 1 and min(num_draft_tokens) == 1 and max(num_draft_tokens) == 1 and is_greedy is None:
         rejection_greedy_sample_spec_len_1_triton[(grid,)](
             output_token_ids,
             draft_token_ids,

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -18,7 +18,38 @@
 from vllm.triton_utils import tl, triton
 
 
-@triton.jit(do_not_specialize=["num_reqs"])
+@triton.jit
+def prepare_next_token_padded_kernel(
+    sampled_token_ids_ptr,
+    backup_next_token_ids_ptr,
+    next_token_ids_ptr,
+    valid_sampled_tokens_count_ptr,
+    vocab_size,
+    num_sampled_tokens_per_req,
+    num_reqs,
+    stride_sampled_token_ids,
+    BLOCK_SIZE_TOKENS: tl.constexpr,
+):
+    req_idx = tl.program_id(axis=0)
+    if req_idx >= num_reqs:
+        return
+
+    token_offsets = tl.arange(0, BLOCK_SIZE_TOKENS)
+    token_mask = token_offsets < num_sampled_tokens_per_req
+    row_ptr = sampled_token_ids_ptr + req_idx * stride_sampled_token_ids
+    token_ids = tl.load(row_ptr + token_offsets, mask=token_mask, other=-1)
+    is_valid = (token_ids != -1) & (token_ids < vocab_size) & token_mask
+    valid_count = tl.sum(is_valid.to(tl.int32), axis=0)
+    last_valid_index = tl.max(tl.where(is_valid, token_offsets, -1), axis=0)
+    last_valid_token = tl.sum(tl.where(token_offsets == last_valid_index, token_ids, 0), axis=0)
+    backup_token = tl.load(backup_next_token_ids_ptr + req_idx)
+    next_token = tl.where(valid_count > 0, last_valid_token, backup_token)
+
+    tl.store(next_token_ids_ptr + req_idx, next_token)
+    tl.store(valid_sampled_tokens_count_ptr + req_idx, valid_count)
+
+
+@triton.jit
 def prepare_inputs_padded_kernel(
     cu_num_draft_tokens_ptr,  # [num_reqs]
     valid_sampled_tokens_count_ptr,  # [num_reqs]
@@ -26,43 +57,26 @@ def prepare_inputs_padded_kernel(
     token_indices_to_sample_ptr,  # [num_reqs] (output)
     num_rejected_tokens_gpu_ptr,
     num_reqs,  # tl.int32
-    BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(axis=0)
-    num_programs = tl.num_programs(axis=0)
+    req_idx = tl.program_id(axis=0)
+    if req_idx >= num_reqs:
+        return
 
-    # Grid-Stride Loop:
-    block_start_step = num_programs * BLOCK_SIZE
+    cu_draft_curr = tl.load(cu_num_draft_tokens_ptr + req_idx)
+    if req_idx == 0:
+        num_draft_tokens = cu_draft_curr
+    else:
+        cu_draft_prev = tl.load(cu_num_draft_tokens_ptr + req_idx - 1)
+        num_draft_tokens = cu_draft_curr - cu_draft_prev
 
-    for block_start in tl.range(pid * BLOCK_SIZE, num_reqs, block_start_step):
-        offsets = block_start + tl.arange(0, BLOCK_SIZE)
-        mask = offsets < num_reqs
+    valid_count = tl.load(valid_sampled_tokens_count_ptr + req_idx)
+    num_rejected = num_draft_tokens + 1 - valid_count
+    num_rejected = tl.where(num_draft_tokens > 0, num_rejected, 0)
 
-        # Calculate num_draft_tokens from cu_num_draft_tokens, which is an inclusive
-        # cumulative sum (first entry is the first value, not zero).
-        cu_draft_curr = tl.load(cu_num_draft_tokens_ptr + offsets, mask=mask)
-
-        prev_indices = offsets - 1
-        has_prev = offsets > 0
-        cu_draft_prev = tl.load(
-            cu_num_draft_tokens_ptr + prev_indices,
-            mask=mask & has_prev,
-            other=0,
-        )
-
-        num_draft_tokens = tl.where(has_prev, cu_draft_curr - cu_draft_prev, cu_draft_curr)
-
-        valid_count = tl.load(valid_sampled_tokens_count_ptr + offsets, mask=mask)
-        num_rejected = num_draft_tokens + 1 - valid_count
-        num_rejected = tl.where(num_draft_tokens > 0, num_rejected, 0)
-
-        # query_start_loc[req_idx + 1] is the start position of the next request,
-        # which is one past the last token of this request.
-        q_last_tok_idx = tl.load(query_start_loc_gpu_ptr + offsets + 1, mask=mask) - 1
-
-        index_to_sample = q_last_tok_idx - num_rejected
-        tl.store(token_indices_to_sample_ptr + offsets, index_to_sample, mask=mask)
-        tl.store(num_rejected_tokens_gpu_ptr + offsets, num_rejected, mask=mask)
+    q_last_tok_idx = tl.load(query_start_loc_gpu_ptr + req_idx + 1) - 1
+    index_to_sample = q_last_tok_idx - num_rejected
+    tl.store(token_indices_to_sample_ptr + req_idx, index_to_sample)
+    tl.store(num_rejected_tokens_gpu_ptr + req_idx, num_rejected)
 
 
 @triton.jit

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING, Any
 from vllm.config.speculative import SpeculativeConfig
 from vllm.utils.import_utils import LazyLoader
 
+from vllm_ascend.models.deepseek_v4_draft import is_deepseek_v4_dspark_config
+
 if TYPE_CHECKING:
     import vllm.model_executor.layers.quantization as me_quant
     from transformers import PretrainedConfig
@@ -14,6 +16,16 @@ else:
 
 def hf_config_override(hf_config: PretrainedConfig) -> PretrainedConfig:
     initial_architecture = hf_config.architectures[0]
+    if is_deepseek_v4_dspark_config(hf_config):
+        hf_config.model_type = "deepseek_mtp"
+        hf_config.update(
+            {
+                "ptd_token_id": getattr(hf_config, "dspark_noise_token_id", None),
+                "dspark_num_mtp_layers": getattr(hf_config, "dspark_num_mtp_layers", 3),
+                "architectures": ["DeepSeekV4DSparkMTPModel"],
+            }
+        )
+        return hf_config
     if hf_config.model_type in ("deepseek_v3", "deepseek_v32", "deepseek_v4", "glm_moe_dsa"):
         target_model_type = hf_config.model_type
         hf_config.model_type = "deepseek_mtp"

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -365,6 +365,8 @@ QUANT_MODEL_SUBSTR_MAPPINGS = {
     },
 }
 
+_DEEPSEEK_V4_MTP_LAYER_RE = re.compile(r"^model\.layers\.(\d+)\.(.+)$")
+
 
 def get_packed_modules_mapping(model_type: str) -> dict[str, list[str]]:
     """Get packed modules mapping for a model type.
@@ -607,7 +609,30 @@ class AscendModelSlimConfig(QuantizationConfig):
             )
         return f"{prefix}.weight" in self.quant_description
 
-    def quant_prefix_mapper(self, model_type: str, prefix: str) -> str:
+    def _map_deepseek_v4_mtp_prefix(
+        self,
+        prefix: str,
+        packed_modules_mapping: Mapping[str, list[str]],
+        num_hidden_layers: int | None,
+    ) -> str | None:
+        if num_hidden_layers is None:
+            return None
+        match = _DEEPSEEK_V4_MTP_LAYER_RE.match(prefix)
+        if match is None:
+            return None
+
+        mtp_layer_idx = int(match.group(1)) - num_hidden_layers
+        if mtp_layer_idx < 0:
+            return None
+        candidate = f"model.mtp.{mtp_layer_idx}.{match.group(2)}"
+        return candidate if self._has_quant_weight(candidate, packed_modules_mapping) else None
+
+    def quant_prefix_mapper(
+        self,
+        model_type: str,
+        prefix: str,
+        num_hidden_layers: int | None = None,
+    ) -> str:
         self.model_type = model_type
         # Some model paths, e.g. qwen3-vl and qwen3_5_moe MTP drafter,
         # initialize lm_head with prefix="lm_head", while the quant description
@@ -626,6 +651,17 @@ class AscendModelSlimConfig(QuantizationConfig):
                 orig_to_new_substr=substr_mapping or {},
             )
             prefix = hf_to_vllm_mapper._map_name(prefix)
+
+        if model_type in ("deepseek_v4", "deepseek_mtp"):
+            packed_modules_mapping = get_packed_modules_mapping(model_type)
+            if not self._has_quant_weight(prefix, packed_modules_mapping):
+                mtp_prefix = self._map_deepseek_v4_mtp_prefix(
+                    prefix,
+                    packed_modules_mapping,
+                    num_hidden_layers,
+                )
+                if mtp_prefix is not None:
+                    return mtp_prefix
 
         if model_type == "step3p5_mtp" and prefix.startswith("model.layers."):
             # Step3P5 MTP and newly generated Step3P7 W8A8 MTP checkpoints use
@@ -670,7 +706,11 @@ class AscendModelSlimConfig(QuantizationConfig):
             prefix = prefix.replace("self_attn", "attention")
         if model_type in packed_modules_model_mapping:
             self.packed_modules_mapping = packed_modules_model_mapping[model_type]
-        prefix = self.quant_prefix_mapper(model_type, prefix)
+        prefix = self.quant_prefix_mapper(
+            model_type,
+            prefix,
+            num_hidden_layers=getattr(vllm_config.model_config.hf_config, "num_hidden_layers", None),
+        )
 
         if isinstance(layer, LinearBase):
             if self.is_layer_skipped_ascend(prefix, self.packed_modules_mapping):

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -151,6 +151,7 @@ class AscendRejectionSampler(RejectionSampler):
         # [num_tokens + batch_size, vocab_size]
         logits: torch.Tensor,
         sampling_metadata: SamplingMetadata,
+        draft_logits: torch.Tensor | None = None,
     ) -> SamplerOutput:
         """
         Args:
@@ -169,6 +170,11 @@ class AscendRejectionSampler(RejectionSampler):
             sampling_metadata (vllm.v1.sample.metadata.SamplingMetadata):
                 Additional metadata needed for sampling, such as temperature,
                 top-k/top-p parameters, or other relevant information.
+            draft_logits (Optional[torch.Tensor]):
+                Processed draft logits with shape [num_tokens, vocab_size].
+                When provided, standard probabilistic verification runs in
+                logits space without materializing the full draft probability
+                tensor.
         Returns:
             SamplerOutput:
                 Contains the final output token IDs and their logprobs if
@@ -227,6 +233,7 @@ class AscendRejectionSampler(RejectionSampler):
             bonus_token_ids,
             sampling_metadata,
             ori_target_logits=raw_target_logits,
+            draft_logits=draft_logits,
         )
 
         logprobs_tensors = None
@@ -354,6 +361,7 @@ def rejection_sample(
     synthetic_mode: bool = False,
     synthetic_conditional_rates: torch.Tensor | None = None,
     ori_target_logits: torch.Tensor | None = None,
+    draft_logits: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     Rejection sampling for speculative decoding in distributed setting.
@@ -371,6 +379,9 @@ def rejection_sample(
                 - indices: [num_tokens, top_k*tp_size] global vocabulary indices or None
         bonus_token_ids: Bonus token IDs [batch_size, 1]
         sampling_metadata: Sampling metadata
+        draft_logits: Processed draft logits for logits-space rejection
+            sampling. Unsupported verification modes fall back to probability
+            space.
 
     Returns:
         output_token_ids: [batch_size, max_spec_len + 1]
@@ -384,6 +395,7 @@ def rejection_sample(
 
     assert draft_token_ids.ndim == 1
     assert draft_probs is None or draft_probs.ndim == 2
+    assert draft_logits is None or draft_logits.ndim == 2
     assert cu_num_draft_tokens.ndim == 1
     assert target_logits.ndim == 2
 
@@ -392,6 +404,7 @@ def rejection_sample(
     device = target_logits.device
     assert draft_token_ids.is_contiguous()
     assert draft_probs is None or draft_probs.is_contiguous()
+    assert draft_logits is None or draft_logits.is_contiguous()
     assert target_logits.is_contiguous()
     assert bonus_token_ids.is_contiguous()
     assert target_logits.shape[0] == num_tokens
@@ -489,6 +502,49 @@ def rejection_sample(
                 )
         if sampling_metadata.all_greedy:
             return output_token_ids
+
+    use_logits_rejection = (
+        draft_logits is not None
+        and target_indices is None
+        and not using_block_verify
+        and not using_entropy_verify
+        and not synthetic_mode
+    )
+    if use_logits_rejection:
+        assert draft_logits is not None
+        if target_logits.shape != draft_logits.shape:
+            raise ValueError(
+                "draft_logits and target_logits must have the same shape for "
+                f"logits-space rejection sampling, got {draft_logits.shape} and {target_logits.shape}."
+            )
+        uniform_probs = generate_uniform_probs(
+            num_tokens,
+            num_draft_tokens,
+            sampling_metadata.generators,
+            device,
+        )
+        rejection_random_sample_logits_pytorch(
+            output_token_ids,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            draft_logits,
+            target_logits,
+            bonus_token_ids,
+            uniform_probs,
+            is_greedy,
+            max_spec_len,
+            num_draft_tokens,
+            sampling_metadata.generators,
+        )
+        return output_token_ids
+
+    if draft_probs is None and draft_logits is not None:
+        logger.warning_once(
+            "[sample/rejection_sampler] Falling back to probability-space "
+            "rejection because logits-space verification does not support "
+            "the active reduce-sample, block, entropy, or synthetic mode."
+        )
+        draft_probs = draft_logits.softmax(dim=-1, dtype=torch.float32).contiguous()
 
     # For random sampling with selected logits
     # target_logits is [num_tokens, top_k*tp_size] with indices [num_tokens, top_k*tp_size]
@@ -770,6 +826,141 @@ def rejection_sample(
                 )
 
     return output_token_ids
+
+
+def _residual_logprobs_from_logits(
+    draft_logits: torch.Tensor,
+    target_logits: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return target log-probs and log(max(target_prob - draft_prob, 0))."""
+    target_logprobs = torch.log_softmax(target_logits.float(), dim=-1)
+    draft_logprobs = torch.log_softmax(draft_logits.float(), dim=-1)
+    log_ratio = draft_logprobs - target_logprobs
+    both_finite = torch.isfinite(target_logprobs) & torch.isfinite(draft_logprobs)
+    target_only = torch.isfinite(target_logprobs) & ~torch.isfinite(draft_logprobs)
+    positive_residual = both_finite & (log_ratio < 0)
+    safe_log_ratio = torch.where(positive_residual, log_ratio, -1.0)
+    finite_residual = target_logprobs + torch.log1p(-torch.exp(safe_log_ratio))
+    residual_logprobs = torch.where(positive_residual, finite_residual, target_logprobs)
+    residual_logprobs = residual_logprobs.masked_fill(~(positive_residual | target_only), float("-inf"))
+    return target_logprobs, residual_logprobs
+
+
+def sample_recovered_tokens_from_logits_pytorch(
+    draft_token_ids: torch.Tensor,
+    cu_num_draft_tokens: torch.Tensor,
+    num_draft_tokens: list[int],
+    draft_logits: torch.Tensor,
+    target_logits: torch.Tensor,
+    generators: dict[int, torch.Generator],
+) -> torch.Tensor:
+    """Sample from max(target_prob - draft_prob, 0) without softmax tensors."""
+    num_tokens, vocab_size = target_logits.shape
+    if num_tokens == 0:
+        return torch.empty_like(draft_token_ids)
+
+    target_logprobs, residual_logprobs = _residual_logprobs_from_logits(draft_logits, target_logits)
+    valid_draft_mask = draft_token_ids != PLACEHOLDER_TOKEN_ID
+    residual_logprobs = torch.where(valid_draft_mask[:, None], residual_logprobs, target_logprobs)
+
+    batch_size = len(num_draft_tokens)
+    q = torch.empty((batch_size, vocab_size), dtype=torch.float32, device=target_logits.device)
+    q.exponential_()
+    for req_idx, generator in generators.items():
+        if num_draft_tokens[req_idx] > 0:
+            q[req_idx].exponential_(generator=generator)
+
+    token_indices = torch.arange(num_tokens, device=target_logits.device, dtype=cu_num_draft_tokens.dtype)
+    token_to_request = torch.searchsorted(cu_num_draft_tokens, token_indices, right=True).long()
+    q_log = q.clamp_min(torch.finfo(q.dtype).tiny).log()
+    scores = residual_logprobs - q_log[token_to_request]
+    has_residual = torch.isfinite(scores).any(dim=-1)
+    fallback_scores = target_logprobs - q_log[token_to_request]
+    scores = torch.where(has_residual[:, None], scores, fallback_scores)
+    return scores.argmax(dim=-1).to(draft_token_ids.dtype)
+
+
+def rejection_random_sample_logits_pytorch(
+    output_token_ids: torch.Tensor,
+    cu_num_draft_tokens: torch.Tensor,
+    draft_token_ids: torch.Tensor,
+    draft_logits: torch.Tensor,
+    target_logits: torch.Tensor,
+    bonus_token_ids: torch.Tensor,
+    uniform_probs: torch.Tensor,
+    is_greedy: torch.Tensor,
+    max_spec_len: int,
+    num_draft_tokens: list[int],
+    generators: dict[int, torch.Generator],
+) -> None:
+    """Run standard probabilistic verification directly from processed logits."""
+    batch_size = output_token_ids.shape[0]
+    num_tokens = draft_token_ids.shape[0]
+    device = output_token_ids.device
+    if num_tokens == 0:
+        output_token_ids[~is_greedy, 0] = bonus_token_ids[~is_greedy, 0]
+        return
+
+    cu_start = torch.cat([cu_num_draft_tokens.new_zeros(1), cu_num_draft_tokens[:-1]])
+    num_draft_per_batch = cu_num_draft_tokens - cu_start
+    positions = torch.arange(max_spec_len, device=device, dtype=cu_num_draft_tokens.dtype)[None, :]
+    valid_mask = positions < num_draft_per_batch[:, None]
+    token_indices = (cu_start[:, None] + positions).clamp(0, num_tokens - 1).long()
+
+    draft_tokens = draft_token_ids[token_indices]
+    placeholder_mask = draft_tokens == PLACEHOLDER_TOKEN_ID
+    safe_draft_tokens = draft_tokens.masked_fill(placeholder_mask, 0).long()
+    target_logprobs = torch.log_softmax(target_logits.float(), dim=-1)
+    draft_logprobs = torch.log_softmax(draft_logits.float(), dim=-1)
+
+    flat_token_indices = token_indices.flatten()
+    flat_draft_tokens = safe_draft_tokens.flatten()
+    target_token_logprobs = target_logprobs[flat_token_indices, flat_draft_tokens].view(batch_size, max_spec_len)
+    draft_token_logprobs = draft_logprobs[flat_token_indices, flat_draft_tokens].view(batch_size, max_spec_len)
+    uniform_logprobs = uniform_probs[token_indices].clamp_min(torch.finfo(uniform_probs.dtype).tiny).log()
+    accepted = (target_token_logprobs >= uniform_logprobs + draft_token_logprobs) & valid_mask & ~placeholder_mask
+
+    first_rejection = (~accepted) & valid_mask
+    no_rejection_pos = torch.full(
+        (batch_size, 1),
+        max_spec_len,
+        dtype=positions.dtype,
+        device=device,
+    )
+    first_reject_pos = torch.where(
+        first_rejection.any(dim=1, keepdim=True),
+        first_rejection.float().argmax(dim=1, keepdim=True).to(positions.dtype),
+        no_rejection_pos,
+    )
+    accepted &= positions < first_reject_pos
+
+    recovered_token_ids = sample_recovered_tokens_from_logits_pytorch(
+        draft_token_ids,
+        cu_num_draft_tokens,
+        num_draft_tokens,
+        draft_logits,
+        target_logits,
+        generators,
+    )
+    recovered_tokens = recovered_token_ids[token_indices]
+    random_requests = ~is_greedy
+    output_token_ids[:, :max_spec_len] = torch.where(
+        random_requests[:, None] & accepted,
+        draft_tokens.to(output_token_ids.dtype),
+        output_token_ids[:, :max_spec_len],
+    )
+    first_reject_mask = random_requests[:, None] & valid_mask & (positions == first_reject_pos)
+    output_token_ids[:, :max_spec_len] = torch.where(
+        first_reject_mask,
+        recovered_tokens.to(output_token_ids.dtype),
+        output_token_ids[:, :max_spec_len],
+    )
+
+    add_bonus = random_requests & (first_reject_pos.squeeze(1) >= num_draft_per_batch)
+    bonus_positions = torch.arange(max_spec_len + 1, device=device, dtype=positions.dtype)[None, :]
+    bonus_mask = add_bonus[:, None] & (bonus_positions == num_draft_per_batch[:, None])
+    bonus_values = bonus_token_ids.expand(-1, max_spec_len + 1)
+    output_token_ids[:] = torch.where(bonus_mask, bonus_values.to(output_token_ids.dtype), output_token_ids)
 
 
 def expand_batch_to_tokens(

--- a/vllm_ascend/spec_decode/__init__.py
+++ b/vllm_ascend/spec_decode/__init__.py
@@ -18,6 +18,9 @@
 #
 
 
+from vllm_ascend.spec_decode.deepseek_v4_dspark_proposer import (
+    AscendDeepSeekV4DSparkProposer,
+)
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
 from vllm_ascend.spec_decode.dspark_proposer import AscendDsparkProposer
@@ -41,6 +44,12 @@ def get_spec_decode_method(method, vllm_config, device, runner):
         return AscendSuffixDecodingProposer(vllm_config, runner)
     elif method == "medusa":
         return AscendMedusaProposer(vllm_config, device)
+    elif method in ("mtp", "dspark") and getattr(
+        vllm_config.speculative_config.draft_model_config.hf_config,
+        "dspark_block_size",
+        False,
+    ):
+        return AscendDeepSeekV4DSparkProposer(vllm_config, device, runner)
     elif method in ("eagle", "eagle3", "mtp"):
         speculative_config = vllm_config.speculative_config
         if speculative_config is not None and speculative_config.use_step3p5_mtp():

--- a/vllm_ascend/spec_decode/deepseek_v4_dspark_proposer.py
+++ b/vllm_ascend/spec_decode/deepseek_v4_dspark_proposer.py
@@ -1,0 +1,505 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections import defaultdict
+from copy import copy
+from typing import Any
+
+import torch
+from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
+from vllm.forward_context import BatchDescriptor, get_forward_context
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.v1.attention.backends.utils import CommonAttentionMetadata
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.worker.utils import AttentionGroup
+
+from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.ascend_forward_context import set_ascend_forward_context
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.spec_decode.dspark_proposer import AscendDsparkProposer
+from vllm_ascend.spec_decode.llm_base_proposer import greedy_sample
+from vllm_ascend.worker.v2.sample.gumbel import gumbel_sample
+
+
+def _greedy_sample(logits: torch.Tensor) -> torch.Tensor:
+    try:
+        reduce_sample = get_ascend_config().enable_reduce_sample
+    except RuntimeError:
+        reduce_sample = False
+    return greedy_sample(logits) if reduce_sample else logits.argmax(dim=-1)
+
+
+class AscendDeepSeekV4DSparkProposer(AscendDsparkProposer):
+    """Eager DeepSeek V4 DSpark proposer using the standard DSA cache."""
+
+    def __init__(self, vllm_config: VllmConfig, device: torch.device, runner=None):
+        super().__init__(vllm_config, device, runner=runner)
+        assert vllm_config.speculative_config is not None
+        draft_config = vllm_config.speculative_config.draft_model_config.hf_config
+        target_layers = tuple(draft_config.dspark_target_layer_ids)
+        self.hidden_size = vllm_config.speculative_config.draft_model_config.get_hidden_size() * len(target_layers)
+        self.hidden_states = torch.zeros((self.max_num_tokens, self.hidden_size), dtype=self.dtype, device=device)
+        self._dflash_hidden_states = torch.zeros_like(self.hidden_states)
+
+        self.use_cuda_graph = False
+        self.method = "dflash"
+        self.parallel_drafting = True
+        self.block_size = self.num_speculative_tokens
+        self.extra_slots_per_request = self.block_size
+        self.net_num_new_slots_per_request = self.block_size
+        self.needs_extra_input_slots = True
+        self.parallel_drafting_token_id = getattr(
+            draft_config,
+            "ptd_token_id",
+            getattr(draft_config, "dspark_noise_token_id", 0),
+        )
+        self.max_query_tokens = self.max_batch_size * self.block_size
+        self.positions = torch.zeros(self.max_query_tokens, dtype=torch.int32, device=device)
+        self._seed_buffer = torch.zeros(self.max_batch_size, dtype=torch.int64, device=device)
+        self._draft_buffer = torch.zeros(
+            (self.max_batch_size, self.block_size),
+            dtype=torch.int64,
+            device=device,
+        )
+        self._sampling_seed_buffer = torch.zeros_like(self._seed_buffer)
+        self._idx_mapping_buffer = torch.arange(self.max_batch_size, dtype=torch.int32, device=device)
+        self._token_to_req_buffer = torch.zeros(self.max_query_tokens, dtype=torch.int32, device=device)
+        self._per_group_block_tables: dict[int, torch.Tensor] = {}
+        self._query_slots_by_gid: dict[int, torch.Tensor] = {}
+        self._context_slots_by_gid: dict[int, torch.Tensor] = {}
+        self._query_slot_buffers: dict[int, torch.Tensor] = {}
+        self._context_slot_buffers: dict[int, torch.Tensor] = {}
+        self._block_tables_by_gid: dict[int, torch.Tensor] = {}
+        self._last_draft_logits: torch.Tensor | None = None
+        self._probabilistic = vllm_config.speculative_config.draft_sample_method == "probabilistic"
+        self.arange_dspark = torch.arange(
+            self.max_num_tokens + self.max_query_tokens + 1,
+            dtype=torch.int32,
+            device=device,
+        )
+
+    def take_last_draft_logits(self) -> torch.Tensor | None:
+        logits = self._last_draft_logits
+        self._last_draft_logits = None
+        return logits
+
+    def initialize_attn_backend(self, kv_cache_config, kernel_block_sizes=None) -> None:
+        del kernel_block_sizes
+        layer_names = list(self.model.get_draft_kv_cache_layer_names())
+        if not layer_names:
+            raise RuntimeError("DSpark requires registered draft DSA cache layers")
+        self._draft_attn_layer_names = set(layer_names)
+        self._draft_attn_layer_names_ordered = layer_names
+        self.attn_layer_names = sorted(layer_names)
+        self.piece_all_attn_layer_name = [self.attn_layer_names[:] for _ in range(self.block_size)]
+        self.draft_attn_groups = []
+
+        layers = get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase)
+        wanted = set(layer_names)
+        for gid, group_spec in enumerate(kv_cache_config.kv_cache_groups):
+            group_layers = [name for name in group_spec.layer_names if name in wanted]
+            if not group_layers:
+                continue
+            backend_layers: dict[tuple[str, Any], list[str]] = defaultdict(list)
+            backends: dict[tuple[str, Any], tuple[type[Any], Any]] = {}
+            for name in group_layers:
+                backend = layers[name].get_attn_backend()
+                cache_spec = group_spec.kv_cache_spec
+                if isinstance(cache_spec, UniformTypeKVCacheSpecs):
+                    cache_spec = cache_spec.kv_cache_specs[name]
+                key = (backend.full_cls_name(), cache_spec)
+                backend_layers[key].append(name)
+                backends[key] = (backend, cache_spec)
+            for key, names in backend_layers.items():
+                backend, cache_spec = backends[key]
+                builder = backend.get_builder_cls()(cache_spec, names, self.vllm_config, self.device)
+                if hasattr(builder, "block_size"):
+                    builder.block_size = int(cache_spec.block_size)
+                self.draft_attn_groups.append(AttentionGroup(backend, names, cache_spec, gid, [builder]))
+        if not self.draft_attn_groups:
+            raise RuntimeError(f"DSpark draft cache groups are missing for layers: {layer_names}")
+
+    def set_per_group_attn_metadata(
+        self,
+        gid: int,
+        block_table: torch.Tensor,
+        slot_mapping: torch.Tensor,
+    ) -> None:
+        del slot_mapping
+        self._per_group_block_tables[gid] = block_table
+
+    @staticmethod
+    def _block_table_tensor(block_table, batch_size: int) -> torch.Tensor:
+        try:
+            return block_table.get_device_tensor(batch_size)
+        except TypeError:
+            return block_table.get_device_tensor()
+
+    def _get_block_table(self, gid: int, cad: CommonAttentionMetadata, batch_size: int) -> torch.Tensor:
+        table = self._per_group_block_tables.get(gid)
+        input_batch = getattr(self.runner, "input_batch", None)
+        runner_tables = getattr(input_batch, "block_table", None)
+        if table is None and runner_tables is not None:
+            try:
+                table = self._block_table_tensor(runner_tables[gid], batch_size)
+            except (IndexError, KeyError, TypeError):
+                table = None
+        if table is None and self.draft_attn_groups[0].kv_cache_group_id == gid:
+            table = cad.block_table_tensor
+        if table is None:
+            raise ValueError(f"DSpark requires a block table for draft cache group {gid}")
+        return table[:batch_size]
+
+    def _slot_buffer(self, gid: int, *, context: bool) -> torch.Tensor:
+        buffers = self._context_slot_buffers if context else self._query_slot_buffers
+        buffer = buffers.get(gid)
+        size = self.max_num_tokens if context else self.max_query_tokens
+        if buffer is None:
+            buffer = torch.zeros(size, dtype=torch.int32, device=self.device)
+            buffers[gid] = buffer
+        return buffer
+
+    @staticmethod
+    def _slots_from_table(
+        positions: torch.Tensor,
+        req_idx: int,
+        block_table: torch.Tensor,
+        block_size: int,
+    ) -> torch.Tensor:
+        logical_blocks = torch.div(positions, block_size, rounding_mode="floor")
+        offsets = positions % block_size
+        physical_blocks = block_table[req_idx].index_select(0, logical_blocks.long())
+        return physical_blocks.to(torch.int32) * block_size + offsets
+
+    def _layer_values(self, values_by_gid: dict[int, torch.Tensor], num_tokens: int | None = None):
+        values: dict[str, torch.Tensor] = {}
+        for group in self.draft_attn_groups:
+            value = values_by_gid[group.kv_cache_group_id]
+            for name in group.layer_names:
+                values[name] = value
+        ordered = []
+        for name in self._draft_attn_layer_names_ordered:
+            value = values[name]
+            ordered.append(value if num_tokens is None else value[:num_tokens])
+        return tuple(ordered)
+
+    def set_inputs_first_pass(
+        self,
+        target_token_ids: torch.Tensor,
+        next_token_ids: torch.Tensor,
+        target_positions: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        token_indices_to_sample: torch.Tensor | None,
+        cad: CommonAttentionMetadata,
+        num_rejected_tokens_gpu: torch.Tensor | None,
+        req_scheduled_tokens=None,
+        long_seq_metadata=None,
+        num_prefill_reqs=0,
+        num_decode_reqs=0,
+    ) -> tuple[int, torch.Tensor, CommonAttentionMetadata, None]:
+        del target_token_ids, req_scheduled_tokens, long_seq_metadata, num_prefill_reqs, num_decode_reqs
+        batch_size = cad.num_reqs
+        num_reqs_across_dp = getattr(self.runner, "_num_reqs_across_dp", None)
+        if num_reqs_across_dp is not None:
+            dp_rank = getattr(self, "dp_rank", getattr(self.runner, "dp_rank", 0))
+            actual_batch_size = int(num_reqs_across_dp[dp_rank].item())
+            if actual_batch_size > batch_size:
+                raise ValueError(
+                    f"DSpark actual request count exceeds target shape: actual={actual_batch_size}, target={batch_size}"
+                )
+            batch_size = actual_batch_size
+        num_query_tokens = batch_size * self.block_size
+        query_start_cpu = getattr(cad, "query_start_loc_cpu", None)
+        sample_indices_cpu = None
+        effective_rejected_tokens = None
+        if token_indices_to_sample is not None:
+            sample_indices_cpu = token_indices_to_sample[:batch_size].to(device="cpu", dtype=torch.int32)
+            effective_rejected_tokens = (
+                cad.query_start_loc[1 : batch_size + 1] - 1 - token_indices_to_sample[:batch_size]
+            )
+        rejected_cpu = None
+        if sample_indices_cpu is None and num_rejected_tokens_gpu is not None:
+            rejected_cpu = num_rejected_tokens_gpu[:batch_size].to(device="cpu", dtype=torch.int32)
+
+        self._block_tables_by_gid = {
+            group.kv_cache_group_id: self._get_block_table(group.kv_cache_group_id, cad, batch_size)
+            for group in self.draft_attn_groups
+        }
+        self._seed_buffer[:batch_size].copy_(next_token_ids[:batch_size])
+        context_cursor = 0
+        for req_idx in range(batch_size):
+            if query_start_cpu is None:
+                start = int(cad.query_start_loc[req_idx].item())
+                end = int(cad.query_start_loc[req_idx + 1].item())
+            else:
+                start = int(query_start_cpu[req_idx])
+                end = int(query_start_cpu[req_idx + 1])
+            if sample_indices_cpu is not None:
+                valid_end = int(sample_indices_cpu[req_idx]) + 1
+            else:
+                valid_end = end if rejected_cpu is None else end - int(rejected_cpu[req_idx])
+            if valid_end <= start:
+                gpu_query_range = cad.query_start_loc[req_idx : req_idx + 2].to(device="cpu").tolist()
+                rejected = (
+                    None
+                    if num_rejected_tokens_gpu is None
+                    else int(num_rejected_tokens_gpu[req_idx].to(device="cpu").item())
+                )
+                raise ValueError(
+                    "DSpark input must retain a valid anchor token: "
+                    f"req={req_idx}, cpu_range=({start}, {end}), "
+                    f"gpu_range={gpu_query_range}, anchor_end={valid_end}, "
+                    f"rejected={rejected}"
+                )
+            if valid_end > end:
+                raise ValueError(
+                    f"DSpark anchor token exceeds request range: req={req_idx}, end={end}, anchor={valid_end}"
+                )
+            context_end = context_cursor + end - start
+            self._dflash_hidden_states[context_cursor:context_end].copy_(target_hidden_states[start:end])
+            self._context_positions_buffer[context_cursor:context_end].copy_(target_positions[start:end])
+            for group in self.draft_attn_groups:
+                gid = group.kv_cache_group_id
+                self._slot_buffer(gid, context=True)[context_cursor:context_end] = self._slots_from_table(
+                    target_positions[start:end],
+                    req_idx,
+                    self._block_tables_by_gid[gid],
+                    int(group.kv_cache_spec.block_size),
+                )
+            context_cursor = context_end
+
+            out_start = req_idx * self.block_size
+            out_end = out_start + self.block_size
+            draft_positions = target_positions[valid_end - 1] + 1 + self.arange_dspark[: self.block_size]
+            max_model_len = int(self.max_model_len)
+            invalid = draft_positions >= max_model_len
+            self.positions[out_start:out_end] = torch.where(invalid, 0, draft_positions)
+            self.input_ids[out_start] = next_token_ids[req_idx]
+            self.input_ids[out_start + 1 : out_end] = self.parallel_drafting_token_id
+            self._token_to_req_buffer[out_start:out_end] = req_idx
+            for group in self.draft_attn_groups:
+                gid = group.kv_cache_group_id
+                slots = self._slots_from_table(
+                    self.positions[out_start:out_end],
+                    req_idx,
+                    self._block_tables_by_gid[gid],
+                    int(group.kv_cache_spec.block_size),
+                )
+                slots.masked_fill_(invalid, -1)
+                self._slot_buffer(gid, context=False)[out_start:out_end] = slots
+
+        self._dflash_num_context = context_cursor
+        self._context_slots_by_gid = {
+            gid: self._slot_buffer(gid, context=True)[:context_cursor] for gid in self._block_tables_by_gid
+        }
+        self._query_slots_by_gid = {
+            gid: self._slot_buffer(gid, context=False)[:num_query_tokens] for gid in self._block_tables_by_gid
+        }
+        cad.query_start_loc = self.arange_dspark[: batch_size + 1] * self.block_size
+        cad.query_start_loc_cpu = torch.arange(batch_size + 1, dtype=torch.int32) * self.block_size
+        effective_seq_lens = cad.seq_lens[:batch_size]
+        if effective_rejected_tokens is not None:
+            effective_seq_lens = effective_seq_lens - effective_rejected_tokens
+        elif num_rejected_tokens_gpu is not None:
+            effective_seq_lens = effective_seq_lens - num_rejected_tokens_gpu[:batch_size]
+        cad.seq_lens = (effective_seq_lens + self.block_size).clamp(max=self.max_model_len)
+        cad.num_reqs = batch_size
+        cad.num_actual_tokens = num_query_tokens
+        cad.num_input_tokens = num_query_tokens
+        cad.max_query_len = self.block_size
+        cad.max_seq_len = min(cad.max_seq_len + self.block_size, self.max_model_len)
+        cad.positions = self.positions[:num_query_tokens]
+        cad.slot_mapping = self._query_slots_by_gid[self.draft_attn_groups[0].kv_cache_group_id]
+        cad.causal = False
+        cad.attn_mask = None
+        cad.attn_state = AscendAttentionState.ChunkedPrefill
+        cad.token_to_req_indices = self._token_to_req_buffer[:num_query_tokens]
+        if hasattr(cad, "actual_seq_lengths_q"):
+            cad.actual_seq_lengths_q = [self.block_size] * batch_size
+        if hasattr(cad, "decode_token_per_req"):
+            cad.decode_token_per_req = self.block_size
+        return num_query_tokens, torch.arange(num_query_tokens, dtype=torch.int32, device=self.device), cad, None
+
+    def _build_attn_metadata(self, cad: CommonAttentionMetadata) -> list[dict[str, Any]]:
+        per_layer: dict[str, Any] = {}
+        for group in self.draft_attn_groups:
+            gid = group.kv_cache_group_id
+            group_cad = copy(cad)
+            group_cad.block_table_tensor = self._block_tables_by_gid[gid]
+            group_cad.slot_mapping = self._query_slots_by_gid[gid]
+            metadata = group.get_metadata_builder().build_for_drafting(
+                group_cad,
+                draft_index=1,
+                block_size=group.kv_cache_spec.block_size,
+            )
+            for name in group.layer_names:
+                per_layer[name] = metadata
+        return [per_layer]
+
+    def _precompute_context_kv(self) -> None:
+        self.model.precompute_and_store_context_kv(
+            self._dflash_hidden_states[: self._dflash_num_context],
+            self._context_positions_buffer[: self._dflash_num_context],
+            self._layer_values(self._context_slots_by_gid, self._dflash_num_context),
+        )
+
+    def _sampling_temperature(
+        self,
+        metadata: SamplingMetadata,
+        num_reqs: int,
+        device: torch.device,
+    ) -> torch.Tensor:
+        if metadata.temperature is None:
+            default = 0.0 if metadata.all_greedy else 1.0
+            return torch.full((num_reqs,), default, dtype=torch.float32, device=device)
+        return metadata.temperature[:num_reqs].to(device=device, dtype=torch.float32).contiguous()
+
+    def _sampling_seeds(self, metadata: SamplingMetadata, num_reqs: int, device: torch.device) -> torch.Tensor:
+        sampler = getattr(getattr(self.runner, "sampler", None), "sampling_states", None)
+        seeds = getattr(getattr(sampler, "seeds", None), "gpu", None)
+        idx_mapping = getattr(getattr(self.runner, "input_batch", None), "idx_mapping", None)
+        if isinstance(seeds, torch.Tensor):
+            if isinstance(idx_mapping, torch.Tensor):
+                seeds = seeds.index_select(0, idx_mapping[:num_reqs].to(device=seeds.device, dtype=torch.long))
+            return seeds[:num_reqs].to(device=device, dtype=torch.int64).contiguous()
+        out = self._sampling_seed_buffer[:num_reqs]
+        base_seed = int(getattr(self.vllm_config.model_config, "seed", 0) or 0)
+        for req_idx in range(num_reqs):
+            generator = metadata.generators.get(req_idx)
+            out[req_idx] = generator.initial_seed() if generator is not None else base_seed + req_idx * 9973
+        return out
+
+    def _sample_sequential(
+        self,
+        hidden_states: torch.Tensor,
+        num_reqs: int,
+        metadata: SamplingMetadata,
+    ) -> torch.Tensor:
+        base_logits = self.model.compute_logits(hidden_states).view(num_reqs, self.block_size, -1)
+        probabilistic = self._probabilistic and not metadata.all_greedy
+        draft_logits = torch.empty_like(base_logits, dtype=torch.float32) if probabilistic else None
+        prev_ids = self._seed_buffer[:num_reqs]
+        gumbel_positions = self.positions[: num_reqs * self.block_size].view(num_reqs, self.block_size) - 1
+        idx_mapping = None
+        temperatures = None
+        seeds = None
+        if probabilistic:
+            idx_mapping = getattr(getattr(self.runner, "input_batch", None), "idx_mapping", None)
+            if not isinstance(idx_mapping, torch.Tensor):
+                idx_mapping = self._idx_mapping_buffer
+            idx_mapping = idx_mapping[:num_reqs].to(device=base_logits.device, dtype=torch.int32).contiguous()
+            temperatures = self._sampling_temperature(metadata, num_reqs, base_logits.device)
+            seeds = self._sampling_seeds(metadata, num_reqs, base_logits.device)
+        for step in range(self.block_size):
+            logits = base_logits[:, step] + self.model.markov_bias(self.model.markov_embed(prev_ids))
+            if probabilistic:
+                assert draft_logits is not None
+                assert idx_mapping is not None
+                assert temperatures is not None
+                assert seeds is not None
+                draft_ids = gumbel_sample(
+                    logits.contiguous(),
+                    idx_mapping,
+                    temperatures,
+                    seeds,
+                    gumbel_positions[:, step].to(dtype=torch.int32).contiguous(),
+                    apply_temperature=True,
+                    output_processed_logits=draft_logits,
+                    output_processed_logits_col=self.arange_dspark[step],
+                    use_fp64=getattr(self, "use_fp64_gumbel", False),
+                )
+            else:
+                draft_ids = _greedy_sample(logits)
+            self._draft_buffer[:num_reqs, step].copy_(draft_ids)
+            prev_ids = self._draft_buffer[:num_reqs, step]
+        self._last_draft_logits = None if draft_logits is None else draft_logits.contiguous()
+        return self._draft_buffer[:num_reqs]
+
+    def _propose(
+        self,
+        target_token_ids: torch.Tensor,
+        target_positions: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        next_token_ids: torch.Tensor,
+        token_indices_to_sample: torch.Tensor | None,
+        common_attn_metadata: CommonAttentionMetadata,
+        target_model_batch_desc: BatchDescriptor,
+        sampling_metadata: SamplingMetadata,
+        mm_embed_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
+        req_scheduled_tokens=None,
+        long_seq_metadata=None,
+        num_prefill_reqs=0,
+        num_decode_reqs=0,
+        scheduler_output: SchedulerOutput = None,
+        num_scheduled_tokens: int = 0,
+        num_rejected_tokens_gpu: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del (
+            target_model_batch_desc,
+            mm_embed_inputs,
+            req_scheduled_tokens,
+            long_seq_metadata,
+            num_prefill_reqs,
+            num_decode_reqs,
+            scheduler_output,
+            num_scheduled_tokens,
+        )
+        num_tokens, _, cad, _ = self.set_inputs_first_pass(
+            target_token_ids,
+            next_token_ids,
+            target_positions,
+            target_hidden_states,
+            token_indices_to_sample,
+            common_attn_metadata,
+            num_rejected_tokens_gpu,
+        )
+        assert self.runner is not None
+        num_tokens, num_tokens_across_dp, _ = self.runner._sync_metadata_across_dp(
+            num_tokens,
+            is_draft_model=True,
+        )
+        if num_tokens != cad.num_actual_tokens:
+            raise RuntimeError("Eager DSpark does not support DP token padding")
+        attn_metadata = self._build_attn_metadata(cad)
+        self._precompute_context_kv()
+        with set_ascend_forward_context(
+            attn_metadata[0],
+            self.vllm_config,
+            num_tokens=num_tokens,
+            num_tokens_across_dp=num_tokens_across_dp,
+            num_actual_tokens=num_tokens,
+            aclgraph_runtime_mode=CUDAGraphMode.NONE,
+            is_draft_model=True,
+            draft_attn_metadatas=attn_metadata,
+        ):
+            forward_context = get_forward_context()
+            if forward_context is not None:
+                forward_context.moe_layer_index = 0
+            hidden_states = self.model(
+                input_ids=self.input_ids[:num_tokens],
+                positions=self.positions[:num_tokens],
+                inputs_embeds=None,
+            )
+            return self._sample_sequential(hidden_states, cad.num_reqs, sampling_metadata)
+
+    @torch.inference_mode()
+    def dummy_run(
+        self,
+        num_tokens: int,
+        num_reqs: int = 0,
+        num_tokens_across_dp: torch.Tensor | None = None,
+        aclgraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+        batch_descriptor=None,
+        is_profile=False,
+        **kwargs,
+    ) -> None:
+        del num_tokens_across_dp, aclgraph_runtime_mode, batch_descriptor, is_profile, kwargs
+        if not self.draft_attn_groups or num_reqs == 0:
+            return
+        num_query_tokens = min(num_reqs * self.block_size, num_tokens, self.max_query_tokens)
+        if num_query_tokens == 0:
+            return
+        self.input_ids[:num_query_tokens].fill_(self.parallel_drafting_token_id)
+        self.positions[:num_query_tokens].zero_()

--- a/vllm_ascend/spec_decode/deepseek_v4_dspark_proposer.py
+++ b/vllm_ascend/spec_decode/deepseek_v4_dspark_proposer.py
@@ -3,21 +3,26 @@
 
 from collections import defaultdict
 from copy import copy
+from dataclasses import replace
 from typing import Any
 
 import torch
-from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
+from vllm.config import CompilationMode, CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
 from vllm.forward_context import BatchDescriptor, get_forward_context
+from vllm.logger import logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
 from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.ascend_forward_context import set_ascend_forward_context
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+from vllm_ascend.compilation.acl_graph import ACLGraphWrapper
 from vllm_ascend.spec_decode.dspark_proposer import AscendDsparkProposer
 from vllm_ascend.spec_decode.llm_base_proposer import greedy_sample
 from vllm_ascend.worker.v2.sample.gumbel import gumbel_sample
@@ -43,7 +48,12 @@ class AscendDeepSeekV4DSparkProposer(AscendDsparkProposer):
         self.hidden_states = torch.zeros((self.max_num_tokens, self.hidden_size), dtype=self.dtype, device=device)
         self._dflash_hidden_states = torch.zeros_like(self.hidden_states)
 
-        self.use_cuda_graph = False
+        target_has_full_graph = vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs()
+        base_use_cuda_graph = bool(getattr(self, "use_cuda_graph", False))
+        self._draft_aclgraph_enabled = base_use_cuda_graph and target_has_full_graph
+        if base_use_cuda_graph and not target_has_full_graph:
+            logger.warning_once("DSpark drafter ACLGraph requires FULL graph mode; using the eager drafter")
+        self.use_cuda_graph = self._draft_aclgraph_enabled
         self.method = "dflash"
         self.parallel_drafting = True
         self.block_size = self.num_speculative_tokens
@@ -72,12 +82,98 @@ class AscendDeepSeekV4DSparkProposer(AscendDsparkProposer):
         self._query_slot_buffers: dict[int, torch.Tensor] = {}
         self._context_slot_buffers: dict[int, torch.Tensor] = {}
         self._block_tables_by_gid: dict[int, torch.Tensor] = {}
+        self._block_table_buffers: dict[int, torch.Tensor] = {}
+        self._stable_attn_buffers: dict[tuple[str, tuple[int, ...], torch.dtype, str], torch.Tensor] = {}
+        self._query_start_loc_buffer = torch.zeros(self.max_batch_size + 1, dtype=torch.int32, device=device)
+        self._query_start_loc_cpu_buffer = torch.zeros(self.max_batch_size + 1, dtype=torch.int32)
+        self._query_start_loc_cpu_base = torch.arange(self.max_batch_size + 1, dtype=torch.int32) * self.block_size
+        self._seq_lens_buffer = torch.zeros(self.max_batch_size, dtype=torch.int32, device=device)
+        self._seq_lens_cpu_buffer = torch.zeros(self.max_batch_size, dtype=torch.int32)
+        self._draft_capture_sizes: list[int] = []
+        self._graph_model_inputs: dict[str, Any] | None = None
         self._last_draft_logits: torch.Tensor | None = None
         self._probabilistic = vllm_config.speculative_config.draft_sample_method == "probabilistic"
         self.arange_dspark = torch.arange(
             self.max_num_tokens + self.max_query_tokens + 1,
             dtype=torch.int32,
             device=device,
+        )
+
+    def initialize_cudagraph_keys(self, cudagraph_mode: CUDAGraphMode) -> None:
+        dispatcher_mode = (
+            CUDAGraphMode.FULL_DECODE_ONLY
+            if self.use_cuda_graph and cudagraph_mode.has_full_cudagraphs()
+            else CUDAGraphMode.NONE
+        )
+        compilation_config = copy(self.vllm_config.compilation_config)
+        if compilation_config.cudagraph_capture_sizes is not None:
+            compilation_config.cudagraph_capture_sizes = list(compilation_config.cudagraph_capture_sizes)
+        if dispatcher_mode != CUDAGraphMode.NONE:
+            capture_sizes = self._derive_draft_capture_sizes()
+            if capture_sizes:
+                compilation_config.cudagraph_capture_sizes = capture_sizes
+                compilation_config.max_cudagraph_capture_size = capture_sizes[-1]
+            else:
+                compilation_config.adjust_cudagraph_sizes_for_spec_decode(
+                    self.block_size,
+                    self.vllm_config.parallel_config.tensor_parallel_size,
+                )
+        draft_config = replace(self.vllm_config, compilation_config=compilation_config)
+        self.cudagraph_dispatcher = CudagraphDispatcher(draft_config)
+        self.cudagraph_dispatcher.uniform_decode_query_len = self.block_size
+        self.cudagraph_dispatcher.initialize_cudagraph_keys(dispatcher_mode, self.block_size)
+        self._draft_capture_sizes = sorted(
+            {desc.num_tokens for _, descs in self.cudagraph_dispatcher.get_capture_descs() for desc in descs}
+        )
+
+    def _derive_draft_capture_sizes(self) -> list[int]:
+        dispatcher = getattr(self.runner, "cudagraph_dispatcher", None)
+        if dispatcher is None:
+            return []
+        sizes = {
+            int(desc.num_reqs) * self.block_size
+            for mode, descs in dispatcher.get_capture_descs()
+            if mode == CUDAGraphMode.FULL
+            for desc in descs
+            if desc.uniform and desc.num_reqs is not None
+        }
+        return sorted(size for size in sizes if size > 0)
+
+    def get_cudagraph_capture_sizes(self) -> list[int]:
+        return list(self._draft_capture_sizes)
+
+    def load_model(self, model: torch.nn.Module) -> None:
+        graph_enabled = self._draft_aclgraph_enabled
+        self.use_cuda_graph = False
+        try:
+            super().load_model(model)
+        finally:
+            self.use_cuda_graph = graph_enabled
+
+        if graph_enabled:
+            self.update_stream = torch.npu.Stream()
+            self._runnable = ACLGraphWrapper(
+                self._run_model_from_graph_buffers,
+                self.vllm_config,
+                runtime_mode=CUDAGraphMode.FULL,
+                use_eagle=self.use_eagle,
+                enable_enpu=self.enable_enpu,
+            )
+            logger.info_once("DSpark drafter ACLGraph is enabled; speculative_config.enforce_eager=true disables it")
+        else:
+            self._runnable = self._run_model
+
+    def _create_draft_vllm_config(self) -> VllmConfig:
+        draft_config = super()._create_draft_vllm_config()
+        model_config = copy(draft_config.model_config)
+        compilation_config = copy(draft_config.compilation_config)
+        if self._draft_aclgraph_enabled:
+            model_config.enforce_eager = True
+            compilation_config.mode = CompilationMode.NONE
+        return replace(
+            draft_config,
+            model_config=model_config,
+            compilation_config=compilation_config,
         )
 
     def take_last_draft_logits(self) -> torch.Tensor | None:
@@ -150,7 +246,32 @@ class AscendDeepSeekV4DSparkProposer(AscendDsparkProposer):
             table = cad.block_table_tensor
         if table is None:
             raise ValueError(f"DSpark requires a block table for draft cache group {gid}")
-        return table[:batch_size]
+        table = table[:batch_size]
+        if not getattr(self, "use_cuda_graph", False):
+            return table
+        buffer = self._block_table_buffers.get(gid)
+        required_shape = (self.max_batch_size, *table.shape[1:])
+        if buffer is None:
+            buffer = torch.zeros(required_shape, dtype=table.dtype, device=table.device)
+            self._block_table_buffers[gid] = buffer
+        elif buffer.shape != required_shape or buffer.dtype != table.dtype or buffer.device != table.device:
+            raise RuntimeError(f"DSpark block table shape changed after graph initialization for cache group {gid}")
+        buffer[:batch_size].zero_()
+        buffer[:batch_size].copy_(table)
+        return buffer[:batch_size]
+
+    def _ensure_query_metadata_buffers(self, num_reqs: int) -> None:
+        capacity = max(int(getattr(self, "max_batch_size", 0)), num_reqs)
+        device = getattr(self, "device", None)
+        if device is None:
+            device = self.positions.device
+        if not hasattr(self, "_query_start_loc_buffer") or self._query_start_loc_buffer.numel() < capacity + 1:
+            self._query_start_loc_buffer = torch.zeros(capacity + 1, dtype=torch.int32, device=device)
+            self._query_start_loc_cpu_buffer = torch.zeros(capacity + 1, dtype=torch.int32)
+            self._query_start_loc_cpu_base = torch.arange(capacity + 1, dtype=torch.int32) * self.block_size
+        if not hasattr(self, "_seq_lens_buffer") or self._seq_lens_buffer.numel() < capacity:
+            self._seq_lens_buffer = torch.zeros(capacity, dtype=torch.int32, device=device)
+            self._seq_lens_cpu_buffer = torch.zeros(capacity, dtype=torch.int32)
 
     def _slot_buffer(self, gid: int, *, context: bool) -> torch.Tensor:
         buffers = self._context_slot_buffers if context else self._query_slot_buffers
@@ -210,6 +331,7 @@ class AscendDeepSeekV4DSparkProposer(AscendDsparkProposer):
                     f"DSpark actual request count exceeds target shape: actual={actual_batch_size}, target={batch_size}"
                 )
             batch_size = actual_batch_size
+        self._ensure_query_metadata_buffers(batch_size)
         num_query_tokens = batch_size * self.block_size
         query_start_cpu = getattr(cad, "query_start_loc_cpu", None)
         sample_indices_cpu = None
@@ -250,8 +372,7 @@ class AscendDeepSeekV4DSparkProposer(AscendDsparkProposer):
                 raise ValueError(
                     "DSpark input must retain a valid anchor token: "
                     f"req={req_idx}, cpu_range=({start}, {end}), "
-                    f"gpu_range={gpu_query_range}, anchor_end={valid_end}, "
-                    f"rejected={rejected}"
+                    f"gpu_range={gpu_query_range}, anchor_end={valid_end}, rejected={rejected}"
                 )
             if valid_end > end:
                 raise ValueError(
@@ -297,14 +418,19 @@ class AscendDeepSeekV4DSparkProposer(AscendDsparkProposer):
         self._query_slots_by_gid = {
             gid: self._slot_buffer(gid, context=False)[:num_query_tokens] for gid in self._block_tables_by_gid
         }
-        cad.query_start_loc = self.arange_dspark[: batch_size + 1] * self.block_size
-        cad.query_start_loc_cpu = torch.arange(batch_size + 1, dtype=torch.int32) * self.block_size
+        self._query_start_loc_buffer[: batch_size + 1].copy_(self.arange_dspark[: batch_size + 1] * self.block_size)
+        self._query_start_loc_cpu_buffer[: batch_size + 1].copy_(self._query_start_loc_cpu_base[: batch_size + 1])
+        cad.query_start_loc = self._query_start_loc_buffer[: batch_size + 1]
+        cad.query_start_loc_cpu = self._query_start_loc_cpu_buffer[: batch_size + 1]
         effective_seq_lens = cad.seq_lens[:batch_size]
         if effective_rejected_tokens is not None:
             effective_seq_lens = effective_seq_lens - effective_rejected_tokens
         elif num_rejected_tokens_gpu is not None:
             effective_seq_lens = effective_seq_lens - num_rejected_tokens_gpu[:batch_size]
-        cad.seq_lens = (effective_seq_lens + self.block_size).clamp(max=self.max_model_len)
+        self._seq_lens_buffer[:batch_size].copy_((effective_seq_lens + self.block_size).clamp(max=self.max_model_len))
+        self._seq_lens_cpu_buffer[:batch_size].copy_(self._seq_lens_buffer[:batch_size].to(device="cpu"))
+        cad.seq_lens = self._seq_lens_buffer[:batch_size]
+        cad._seq_lens_cpu = self._seq_lens_cpu_buffer[:batch_size]
         cad.num_reqs = batch_size
         cad.num_actual_tokens = num_query_tokens
         cad.num_input_tokens = num_query_tokens
@@ -322,6 +448,104 @@ class AscendDeepSeekV4DSparkProposer(AscendDsparkProposer):
             cad.decode_token_per_req = self.block_size
         return num_query_tokens, torch.arange(num_query_tokens, dtype=torch.int32, device=self.device), cad, None
 
+    def _pad_request_rows(
+        self,
+        cad: CommonAttentionMetadata,
+        actual_num_reqs: int,
+        model_num_reqs: int,
+    ) -> int:
+        if model_num_reqs < actual_num_reqs or model_num_reqs > self.max_batch_size:
+            raise ValueError(f"Invalid DSpark padded request count: actual={actual_num_reqs}, model={model_num_reqs}")
+        actual_tokens = actual_num_reqs * self.block_size
+        model_tokens = model_num_reqs * self.block_size
+        if model_tokens > actual_tokens:
+            self.input_ids[actual_tokens:model_tokens].fill_(self.parallel_drafting_token_id)
+            self.positions[actual_tokens:model_tokens].zero_()
+            self._token_to_req_buffer[actual_tokens:model_tokens].copy_(
+                self.arange_dspark[actual_num_reqs:model_num_reqs].repeat_interleave(self.block_size)
+            )
+            self._seed_buffer[actual_num_reqs:model_num_reqs].zero_()
+            for gid in self._query_slots_by_gid:
+                self._slot_buffer(gid, context=False)[actual_tokens:model_tokens].fill_(-1)
+
+        self._query_start_loc_buffer[: model_num_reqs + 1].copy_(
+            self.arange_dspark[: model_num_reqs + 1] * self.block_size
+        )
+        self._query_start_loc_cpu_buffer[: model_num_reqs + 1].copy_(
+            self._query_start_loc_cpu_base[: model_num_reqs + 1]
+        )
+        self._seq_lens_buffer[actual_num_reqs:model_num_reqs].fill_(self.block_size)
+        self._seq_lens_cpu_buffer[actual_num_reqs:model_num_reqs].fill_(self.block_size)
+        for gid, table in tuple(self._block_tables_by_gid.items()):
+            buffer = self._block_table_buffers.get(gid)
+            if buffer is not None:
+                buffer[actual_num_reqs:model_num_reqs].zero_()
+                self._block_tables_by_gid[gid] = buffer[:model_num_reqs]
+            elif model_num_reqs != actual_num_reqs:
+                padded = table.new_zeros((model_num_reqs, *table.shape[1:]))
+                padded[:actual_num_reqs].copy_(table[:actual_num_reqs])
+                self._block_tables_by_gid[gid] = padded
+        self._query_slots_by_gid = {
+            gid: self._slot_buffer(gid, context=False)[:model_tokens] for gid in self._block_tables_by_gid
+        }
+
+        cad.num_reqs = model_num_reqs
+        cad.num_input_tokens = model_tokens
+        cad.num_actual_tokens = model_tokens
+        cad.query_start_loc = self._query_start_loc_buffer[: model_num_reqs + 1]
+        cad.query_start_loc_cpu = self._query_start_loc_cpu_buffer[: model_num_reqs + 1]
+        cad.seq_lens = self._seq_lens_buffer[:model_num_reqs]
+        cad._seq_lens_cpu = self._seq_lens_cpu_buffer[:model_num_reqs]
+        cad.positions = self.positions[:model_tokens]
+        cad.token_to_req_indices = self._token_to_req_buffer[:model_tokens]
+        cad.slot_mapping = self._query_slots_by_gid[self.draft_attn_groups[0].kv_cache_group_id]
+        if hasattr(cad, "actual_seq_lengths_q"):
+            cad.actual_seq_lengths_q = [self.block_size] * model_num_reqs
+        return model_tokens
+
+    def _stable_attn_tensor(self, key: str, tensor: torch.Tensor) -> torch.Tensor:
+        buffer_key = (key, tuple(tensor.shape), tensor.dtype, str(tensor.device))
+        buffer = self._stable_attn_buffers.get(buffer_key)
+        if buffer is None:
+            buffer = torch.empty_like(tensor)
+            self._stable_attn_buffers[buffer_key] = buffer
+        buffer.copy_(tensor)
+        return buffer
+
+    def _stabilize_attn_metadata(self, per_layer: dict[str, Any]) -> None:
+        attrs = (
+            "block_table",
+            "cos",
+            "dspark_swa_indices",
+            "dspark_swa_lens",
+            "full_compress_cos",
+            "full_compress_sin",
+            "input_positions",
+            "qli_metadata",
+            "query_start_loc",
+            "query_start_loc_cpu",
+            "sas_metadata",
+            "seq_lens",
+            "sin",
+            "slot_mapping",
+            "start_pos",
+        )
+        seen: set[int] = set()
+
+        def stabilize(obj: Any, prefix: str) -> None:
+            if obj is None or id(obj) in seen:
+                return
+            seen.add(id(obj))
+            for attr in attrs:
+                value = getattr(obj, attr, None)
+                if isinstance(value, torch.Tensor):
+                    setattr(obj, attr, self._stable_attn_tensor(f"{prefix}.{attr}", value))
+            for attr in ("cp_metadata", "decode", "prefill", "req_metadata"):
+                stabilize(getattr(obj, attr, None), f"{prefix}.{attr}")
+
+        for layer_name, metadata in per_layer.items():
+            stabilize(metadata, layer_name)
+
     def _build_attn_metadata(self, cad: CommonAttentionMetadata) -> list[dict[str, Any]]:
         per_layer: dict[str, Any] = {}
         for group in self.draft_attn_groups:
@@ -336,6 +560,8 @@ class AscendDeepSeekV4DSparkProposer(AscendDsparkProposer):
             )
             for name in group.layer_names:
                 per_layer[name] = metadata
+        if self.use_cuda_graph:
+            self._stabilize_attn_metadata(per_layer)
         return [per_layer]
 
     def _precompute_context_kv(self) -> None:
@@ -456,33 +682,66 @@ class AscendDeepSeekV4DSparkProposer(AscendDsparkProposer):
             num_rejected_tokens_gpu,
         )
         assert self.runner is not None
-        num_tokens, num_tokens_across_dp, _ = self.runner._sync_metadata_across_dp(
-            num_tokens,
-            is_draft_model=True,
+        actual_num_reqs = cad.num_reqs
+        num_reqs_across_dp = self.runner._num_reqs_across_dp
+        model_num_reqs = int(num_reqs_across_dp.max().item()) if num_reqs_across_dp is not None else actual_num_reqs
+        num_input_tokens = model_num_reqs * self.block_size
+        has_lora = bool(getattr(self.runner.input_batch, "lora_id_to_lora_request", {}))
+        if self.use_cuda_graph:
+            aclgraph_runtime_mode, batch_descriptor = self.cudagraph_dispatcher.dispatch(
+                num_tokens=num_input_tokens,
+                uniform_decode=True,
+                has_lora=has_lora,
+            )
+            num_input_tokens = batch_descriptor.num_tokens
+        else:
+            aclgraph_runtime_mode = CUDAGraphMode.NONE
+            batch_descriptor = None
+        num_tokens_across_dp = (
+            torch.full_like(num_reqs_across_dp, num_input_tokens) if num_reqs_across_dp is not None else None
         )
-        if num_tokens != cad.num_actual_tokens:
-            raise RuntimeError("Eager DSpark does not support DP token padding")
+        if num_input_tokens % self.block_size:
+            raise RuntimeError("DSpark DP padding must preserve complete draft request rows")
+        model_num_reqs = num_input_tokens // self.block_size
+        num_input_tokens = self._pad_request_rows(cad, actual_num_reqs, model_num_reqs)
         attn_metadata = self._build_attn_metadata(cad)
         self._precompute_context_kv()
         with set_ascend_forward_context(
             attn_metadata[0],
             self.vllm_config,
-            num_tokens=num_tokens,
+            num_tokens=num_input_tokens,
             num_tokens_across_dp=num_tokens_across_dp,
-            num_actual_tokens=num_tokens,
-            aclgraph_runtime_mode=CUDAGraphMode.NONE,
+            num_actual_tokens=num_input_tokens,
+            batch_descriptor=batch_descriptor,
+            aclgraph_runtime_mode=aclgraph_runtime_mode,
             is_draft_model=True,
             draft_attn_metadatas=attn_metadata,
         ):
             forward_context = get_forward_context()
             if forward_context is not None:
                 forward_context.moe_layer_index = 0
-            hidden_states = self.model(
-                input_ids=self.input_ids[:num_tokens],
-                positions=self.positions[:num_tokens],
+            if aclgraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing and self.draft_attn_groups:
+                self._update_full_graph_params(forward_context, num_input_tokens, attn_metadata)
+            model_inputs = dict(
+                input_ids=self.input_ids[:num_input_tokens],
+                positions=self.positions[:num_input_tokens],
                 inputs_embeds=None,
             )
-            return self._sample_sequential(hidden_states, cad.num_reqs, sampling_metadata)
+            if self.use_cuda_graph:
+                self._graph_model_inputs = model_inputs
+                hidden_states = self._runnable()
+            else:
+                hidden_states = self._runnable(**model_inputs)
+            hidden_states = hidden_states[:num_tokens]
+            return self._sample_sequential(hidden_states, actual_num_reqs, sampling_metadata)
+
+    def _run_model(self, **model_inputs: Any) -> torch.Tensor:
+        return self.model(**model_inputs)
+
+    def _run_model_from_graph_buffers(self) -> torch.Tensor:
+        if self._graph_model_inputs is None:
+            raise RuntimeError("DSpark ACLGraph inputs were not prepared")
+        return self._run_model(**self._graph_model_inputs)
 
     @torch.inference_mode()
     def dummy_run(
@@ -493,13 +752,106 @@ class AscendDeepSeekV4DSparkProposer(AscendDsparkProposer):
         aclgraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
         batch_descriptor=None,
         is_profile=False,
+        is_graph_capturing=False,
         **kwargs,
     ) -> None:
-        del num_tokens_across_dp, aclgraph_runtime_mode, batch_descriptor, is_profile, kwargs
+        del batch_descriptor, kwargs
         if not self.draft_attn_groups or num_reqs == 0:
             return
-        num_query_tokens = min(num_reqs * self.block_size, num_tokens, self.max_query_tokens)
-        if num_query_tokens == 0:
+        num_reqs_across_dp = getattr(self.runner, "_num_reqs_across_dp", None)
+        if not is_profile and not is_graph_capturing and num_reqs_across_dp is not None:
+            num_reqs = max(num_reqs, int(num_reqs_across_dp.max().item()))
+        num_query_tokens = min(num_reqs * self.block_size, self.max_query_tokens)
+        if num_query_tokens == 0 or num_query_tokens % self.block_size:
             return
+        has_lora = bool(getattr(self.runner.input_batch, "lora_id_to_lora_request", {}))
+        use_graph = self.use_cuda_graph and aclgraph_runtime_mode == CUDAGraphMode.FULL
+        if use_graph:
+            aclgraph_runtime_mode, batch_descriptor = self.cudagraph_dispatcher.dispatch(
+                num_query_tokens,
+                uniform_decode=True,
+                has_lora=has_lora,
+                valid_modes={CUDAGraphMode.FULL},
+            )
+            num_query_tokens = batch_descriptor.num_tokens
+        else:
+            aclgraph_runtime_mode = CUDAGraphMode.NONE
+            batch_descriptor = None
+        draft_tokens_across_dp = None
+        if num_tokens_across_dp is not None:
+            draft_tokens_across_dp = torch.full_like(num_tokens_across_dp, num_query_tokens)
+        if num_query_tokens % self.block_size:
+            raise RuntimeError("DSpark graph capture size must contain complete request rows")
+        model_num_reqs = num_query_tokens // self.block_size
         self.input_ids[:num_query_tokens].fill_(self.parallel_drafting_token_id)
         self.positions[:num_query_tokens].zero_()
+        self._token_to_req_buffer[:num_query_tokens].copy_(
+            torch.arange(model_num_reqs, dtype=torch.int32, device=self.device).repeat_interleave(self.block_size)
+        )
+        self._query_start_loc_buffer[: model_num_reqs + 1].copy_(
+            self.arange_dspark[: model_num_reqs + 1] * self.block_size
+        )
+        self._query_start_loc_cpu_buffer[: model_num_reqs + 1].copy_(
+            self._query_start_loc_cpu_base[: model_num_reqs + 1]
+        )
+        self._seq_lens_buffer[:model_num_reqs].fill_(self.block_size)
+        self._seq_lens_cpu_buffer[:model_num_reqs].fill_(self.block_size)
+        cad = AscendCommonAttentionMetadata(
+            query_start_loc=self._query_start_loc_buffer[: model_num_reqs + 1],
+            query_start_loc_cpu=self._query_start_loc_cpu_buffer[: model_num_reqs + 1],
+            seq_lens=self._seq_lens_buffer[:model_num_reqs],
+            _seq_lens_cpu=self._seq_lens_cpu_buffer[:model_num_reqs],
+            seq_lens_cpu=None,
+            num_computed_tokens_cpu=None,
+            num_reqs=model_num_reqs,
+            num_actual_tokens=num_query_tokens,
+            num_input_tokens=num_query_tokens,
+            max_query_len=self.block_size,
+            actual_seq_lengths_q=[self.block_size] * model_num_reqs,
+            block_table_tensor=None,
+            slot_mapping=self._slot_buffer(self.draft_attn_groups[0].kv_cache_group_id, context=False)[
+                :num_query_tokens
+            ],
+            positions=self.positions[:num_query_tokens],
+            attn_state=AscendAttentionState.ChunkedPrefill,
+            decode_token_per_req=self.block_size,
+            max_seq_len=self.block_size,
+            causal=False,
+        )
+        cad.token_to_req_indices = self._token_to_req_buffer[:num_query_tokens]
+        self._block_tables_by_gid = {
+            group.kv_cache_group_id: self._get_block_table(group.kv_cache_group_id, cad, model_num_reqs)
+            for group in self.draft_attn_groups
+        }
+        self._query_slots_by_gid = {}
+        for gid in self._block_tables_by_gid:
+            slots = self._slot_buffer(gid, context=False)
+            slots[:num_query_tokens].fill_(-1)
+            self._query_slots_by_gid[gid] = slots[:num_query_tokens]
+        cad.block_table_tensor = self._block_tables_by_gid[self.draft_attn_groups[0].kv_cache_group_id]
+        cad.slot_mapping = self._query_slots_by_gid[self.draft_attn_groups[0].kv_cache_group_id]
+        attn_metadata = self._build_attn_metadata(cad)
+        with set_ascend_forward_context(
+            attn_metadata[0],
+            self.vllm_config,
+            num_tokens=num_query_tokens,
+            num_tokens_across_dp=draft_tokens_across_dp,
+            num_actual_tokens=num_query_tokens,
+            batch_descriptor=batch_descriptor,
+            aclgraph_runtime_mode=aclgraph_runtime_mode,
+            is_draft_model=True,
+            draft_attn_metadatas=attn_metadata,
+        ):
+            forward_context = get_forward_context()
+            if aclgraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing and self.draft_attn_groups:
+                self._update_full_graph_params(forward_context, num_query_tokens, attn_metadata)
+            model_inputs = dict(
+                input_ids=self.input_ids[:num_query_tokens],
+                positions=self.positions[:num_query_tokens],
+                inputs_embeds=None,
+            )
+            if self.use_cuda_graph:
+                self._graph_model_inputs = model_inputs
+                self._runnable()
+            else:
+                self._runnable(**model_inputs)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -3,7 +3,7 @@ import copy
 from collections.abc import Callable
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from functools import partial
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import torch
@@ -491,7 +491,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     def _maybe_share_lm_head(self, model: nn.Module) -> None:
         # some model definition do not define lm_head explicitly
         # and reuse embed_tokens for lm_head, e.g., CohereForCausalLM
-        if self.method in ("eagle", "dflash"):
+        share_target_lm_head = (
+            self.method in ("eagle", "dflash") or getattr(self.model, "has_own_lm_head", True) is False
+        )
+        if share_target_lm_head:
             # For DFlash drafters trained with a reduced draft vocabulary, the
             # draft model ships its own lm_head of shape [draft_vocab_size,
             # hidden] whose rows map to a trained subset of the target vocab via
@@ -522,7 +525,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                         " is not trained."
                     )
 
-        if self.method == "mtp" and self.vllm_config.model_config.is_deepseek_mla:
+        if (
+            self.method == "mtp"
+            and self.vllm_config.model_config.is_deepseek_mla
+            and getattr(self.model, "has_own_lm_head", True)
+        ):
             for _, layer_module in self.model.model.layers.items():
                 if torch.equal(layer_module.shared_head.head.weight, model.lm_head.weight):
                     layer_module.shared_head.head = model.lm_head
@@ -1107,7 +1114,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "num_tokens": num_tokens,
                 "is_prefill": is_prefill_batch,
             }
-            run_draft = partial(self._runnable, **model_inputs)
+            runnable = cast(Callable[..., Any], self._runnable)
+            run_draft = partial(runnable, **model_inputs)
 
             if self.enable_enpu:
                 self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -53,8 +53,10 @@ from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.parallel_state import get_lmhead_tp_group
 from vllm_ascend.models.llama_eagle3_vwn import Eagle3VwnLlamaForCausalLM
-from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
-from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
+from vllm_ascend.ops.triton.spec_decode.utils import (
+    prepare_inputs_padded_kernel,
+    prepare_next_token_padded_kernel,
+)
 from vllm_ascend.spec_decode.utils import SlidingWindowAdapter
 from vllm_ascend.utils import enable_sp, lmhead_tp_enable, shared_expert_dp_enabled, vllm_version_is
 
@@ -79,10 +81,6 @@ def patch_tensor_parallel_group(tp_group):
     finally:
         _ps._TP_STATE_PATCHED = False
         _ps._TP = old_tp_group
-
-
-# Currently we will fix block size to a small one since `num_reqs` can't be too large
-_PREPARE_INPUTS_BLOCK_SIZE = 4
 
 
 # TODO: Remove it when the bug of fx-graph is solved
@@ -330,6 +328,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         from vllm.compilation.backends import set_model_tag
 
         draft_vllm_config = self._create_draft_vllm_config()
+        if self.speculative_config.enforce_eager:
+            draft_vllm_config.model_config.enforce_eager = True
+            draft_vllm_config.compilation_config.mode = CompilationMode.NONE
         draft_load_config = self.speculative_config.draft_load_config
         logger.info(
             "[spec_decode/base] Loading draft model: method=%s, load_format=%s, model=%s",
@@ -1929,27 +1930,37 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             -1,
         )
 
-        # Generate a mask for all valid tokens within those requests
-        valid_mask = (valid_sampled_token_ids_gpu != -1) & (valid_sampled_token_ids_gpu < gpu_input_batch.vocab_size)
-
-        # Count the number of valid tokens in each request
-        valid_sampled_tokens_count = valid_mask.sum(dim=1)
-
-        # Get the rightmost valid index per row
-        last_valid_indices = valid_sampled_tokens_count - 1
-        last_valid_indices_safe = torch.clamp(last_valid_indices, min=0)
-
-        # Get last valid token from each row
-        # (assume undefined state where there is no valid token)
-        selected_tokens = torch.gather(valid_sampled_token_ids_gpu, 1, last_valid_indices_safe.unsqueeze(1)).squeeze(1)
-
-        # Use last token if valid, pre-computed backup if not
-        batch_size = valid_sampled_token_ids_gpu.shape[0]
-        next_token_ids = torch.where(
-            last_valid_indices != -1,
-            selected_tokens,
-            self.backup_next_token_ids.gpu[:batch_size],
-        )
+        batch_size, num_sampled_tokens = valid_sampled_token_ids_gpu.shape
+        if HAS_TRITON:
+            next_token_ids = torch.empty(batch_size, dtype=torch.int32, device=sampled_token_ids.device)
+            valid_sampled_tokens_count = torch.empty_like(next_token_ids)
+            prepare_next_token_padded_kernel[(batch_size,)](
+                valid_sampled_token_ids_gpu,
+                self.backup_next_token_ids.gpu,
+                next_token_ids,
+                valid_sampled_tokens_count,
+                gpu_input_batch.vocab_size,
+                num_sampled_tokens,
+                batch_size,
+                valid_sampled_token_ids_gpu.stride(0),
+                BLOCK_SIZE_TOKENS=triton.next_power_of_2(num_sampled_tokens),
+            )
+        else:
+            valid_mask = (valid_sampled_token_ids_gpu != -1) & (
+                valid_sampled_token_ids_gpu < gpu_input_batch.vocab_size
+            )
+            valid_sampled_tokens_count = valid_mask.sum(dim=1).to(torch.int32)
+            last_valid_indices = valid_sampled_tokens_count - 1
+            selected_tokens = torch.gather(
+                valid_sampled_token_ids_gpu,
+                1,
+                last_valid_indices.clamp(min=0).unsqueeze(1),
+            ).squeeze(1)
+            next_token_ids = torch.where(
+                last_valid_indices >= 0,
+                selected_tokens,
+                self.backup_next_token_ids.gpu[:batch_size],
+            )
 
         return next_token_ids, valid_sampled_tokens_count
 
@@ -2094,25 +2105,19 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         used as padding and filtered out later by `token_indices_to_sample`.
         No blocking CPU operations should be introduced in this function.
         """
+        num_reqs = valid_sampled_tokens_count.shape[0]
         if HAS_TRITON:
-            num_reqs = common_attn_metadata.num_reqs
             device = valid_sampled_tokens_count.device
 
             token_indices_to_sample = torch.empty((num_reqs,), dtype=torch.int32, device=device)
             num_rejected_tokens_gpu = torch.empty((num_reqs,), dtype=torch.int32, device=device)
-            num_blocks_needed = triton.cdiv(num_reqs, _PREPARE_INPUTS_BLOCK_SIZE)
-            num_vector_core = get_vectorcore_num()
-            grid_size = min(num_blocks_needed, num_vector_core)
-            grid = (grid_size,)
-
-            prepare_inputs_padded_kernel[grid](
+            prepare_inputs_padded_kernel[(num_reqs,)](
                 spec_decode_metadata.cu_num_draft_tokens,
                 valid_sampled_tokens_count,
                 common_attn_metadata.query_start_loc,
                 token_indices_to_sample,
                 num_rejected_tokens_gpu,
                 num_reqs,
-                BLOCK_SIZE=_PREPARE_INPUTS_BLOCK_SIZE,
             )
         else:
             num_draft_tokens_gpu = torch.cat(
@@ -2128,7 +2133,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 torch.zeros_like(num_draft_tokens_gpu),
             )
 
-            token_indices_to_sample = common_attn_metadata.query_start_loc[1:] - 1 - num_rejected_tokens_gpu
+            token_indices_to_sample = (
+                common_attn_metadata.query_start_loc[1 : num_reqs + 1] - 1 - num_rejected_tokens_gpu
+            )
 
         query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -130,6 +130,9 @@ from vllm_ascend.patch.worker.patch_draft_quarot import patch_load_weights
 from vllm_ascend.quantization.utils import enable_fa_quant
 from vllm_ascend.sample.sampler import AscendSampler
 from vllm_ascend.spec_decode import get_spec_decode_method
+from vllm_ascend.spec_decode.deepseek_v4_dspark_proposer import (
+    AscendDeepSeekV4DSparkProposer,
+)
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
 from vllm_ascend.spec_decode.dspark_proposer import AscendDsparkProposer
@@ -333,6 +336,7 @@ class NPUModelRunner(GPUModelRunner):
         self.max_num_reqs = self.scheduler_config.max_num_seqs
         self.dp_size = vllm_config.parallel_config.data_parallel_size
         self.dp_rank = vllm_config.parallel_config.data_parallel_rank
+        self._num_reqs_across_dp: torch.Tensor | None = None
 
         self.sampler = AscendSampler()
         self.attn_state: AscendAttentionState | None = None
@@ -714,9 +718,19 @@ class NPUModelRunner(GPUModelRunner):
         # FIXME: Restore the `or self.vllm_config.model_config.enforce_eager` here
         # immediately once the other two flags are no longer needed.
         if self.dp_size == 1:
+            if not is_draft_model:
+                self._num_reqs_across_dp = torch.tensor(
+                    [self.input_batch.num_reqs], device="cpu", dtype=torch.int32
+                )
             return num_tokens, None, cudagraph_mode
 
         if should_skip_allreduce_across_dp_group(self.vllm_config, is_draft_model):
+            if not is_draft_model:
+                self._num_reqs_across_dp = torch.tensor(
+                    [self.input_batch.num_reqs] * self.dp_size,
+                    device="cpu",
+                    dtype=torch.int32,
+                )
             num_tokens_after_padding = torch.tensor([num_tokens] * self.dp_size, device="cpu", dtype=torch.int32)
             return num_tokens, num_tokens_after_padding, cudagraph_mode
 
@@ -728,9 +742,11 @@ class NPUModelRunner(GPUModelRunner):
             if self.ascend_config.dp_allreduce_on_npu
             else ("cpu", get_dp_group().cpu_group)
         )
-        packed_tensor = torch.zeros(2, self.dp_size, device=device_str, dtype=torch.int32)
+        packed_tensor = torch.zeros(3, self.dp_size, device=device_str, dtype=torch.int32)
         packed_tensor[0][self.dp_rank] = num_tokens
         packed_tensor[1][self.dp_rank] = cudagraph_mode.value
+        if not is_draft_model:
+            packed_tensor[2][self.dp_rank] = self.input_batch.num_reqs
         dist.all_reduce(packed_tensor, group=group)
         if device_str == "npu":
             packed_tensor = packed_tensor.cpu()
@@ -739,9 +755,30 @@ class NPUModelRunner(GPUModelRunner):
         num_tokens_across_dp = packed_tensor[0, :]
         max_tokens_across_dp = int(num_tokens_across_dp.max().item())
         synced_cudagraph_mode = CUDAGraphMode(_post_process_cudagraph_mode(packed_tensor))
-
-        # Create a tensor for num_tokens_after_padding
-        if allow_dp_padding or is_draft_model:
+        if not is_draft_model:
+            self._num_reqs_across_dp = packed_tensor[2, :].cpu()
+        uneven_dspark_batch = (
+            not is_draft_model
+            and isinstance(
+                getattr(self, "drafter", None),
+                AscendDeepSeekV4DSparkProposer,
+            )
+            and not torch.equal(
+                num_tokens_across_dp,
+                num_tokens_across_dp[:1].expand_as(num_tokens_across_dp),
+            )
+        )
+        if (
+            uneven_dspark_batch
+            and synced_cudagraph_mode == CUDAGraphMode.PIECEWISE
+        ):
+            synced_cudagraph_mode = CUDAGraphMode.NONE
+        if (
+            synced_cudagraph_mode != CUDAGraphMode.NONE
+            or allow_dp_padding
+            or is_draft_model
+            or uneven_dspark_batch
+        ):
             num_tokens_after_padding = torch.tensor(
                 [max_tokens_across_dp] * self.dp_size, device="cpu", dtype=torch.int32
             )
@@ -855,6 +892,8 @@ class NPUModelRunner(GPUModelRunner):
         This function is only designed to satisfied the constraint that when the layout is TND,
         the first dimension of `hidden_states` must equal the last element of `actual_seq_lengths_q`.
         """
+        if self.use_compress and cudagraph_runtime_mode == CUDAGraphMode.NONE:
+            return num_reqs
         # TODO: need refactor later, related to vllm PR #34043 this pr delete func
         # relax_for_mixed_batch_cudagraphs, num_reqs no longer equals the actual number of requests.
         if cudagraph_runtime_mode == CUDAGraphMode.FULL and \
@@ -1813,7 +1852,13 @@ class NPUModelRunner(GPUModelRunner):
         num_draft_tokens = torch.empty_like(cu_num_draft_tokens)
         num_draft_tokens[:1] = cu_num_draft_tokens[:1]
         num_draft_tokens[1:] = cu_num_draft_tokens[1:] - cu_num_draft_tokens[:-1]
-        max_valid_width = num_draft_tokens[: sampled_token_ids.shape[0]] + 1
+        num_sampled_rows = sampled_token_ids.shape[0]
+        if num_draft_tokens.shape[0] < num_sampled_rows:
+            num_draft_tokens = nn.functional.pad(
+                num_draft_tokens,
+                (0, num_sampled_rows - num_draft_tokens.shape[0]),
+            )
+        max_valid_width = num_draft_tokens[:num_sampled_rows] + 1
         columns = torch.arange(
             sampled_token_ids.shape[1],
             device=sampled_token_ids.device,
@@ -2422,6 +2467,7 @@ class NPUModelRunner(GPUModelRunner):
 
                 if (
                     cudagraph_mode == CUDAGraphMode.FULL
+                    or num_tokens_padded != num_tokens_unpadded
                     or (enable_sp() and not self.model_config.use_mla)
                     and self.pcp_size * self.dcp_size == 1
                 ):
@@ -3225,8 +3271,7 @@ class NPUModelRunner(GPUModelRunner):
             _, num_tokens_across_dp, synced_cudagraph_mode = self._sync_metadata_across_dp(
                 num_tokens=num_tokens_padded,
                 cudagraph_mode=cudagraph_mode,
-                allow_dp_padding=((cudagraph_mode != CUDAGraphMode.NONE)
-                                  or enable_sp(self.vllm_config)
+                allow_dp_padding=(enable_sp(self.vllm_config)
                                   or oproj_tp_enable()
                                   or embedding_tp_enable()),
             )
@@ -3837,13 +3882,24 @@ class NPUModelRunner(GPUModelRunner):
                 if hasattr(self.drafter, "model") and hasattr(self.drafter.model, "compute_logits"):
                     return self.drafter.model.compute_logits(hidden_states[dummy_indices])
 
+            num_actual_tokens = num_tokens_padded
+            if (
+                isinstance(
+                    getattr(self, "drafter", None),
+                    AscendDeepSeekV4DSparkProposer,
+                )
+                and self._num_reqs_across_dp is not None
+                and int(self._num_reqs_across_dp[self.dp_rank].item()) == 0
+            ):
+                num_actual_tokens = 0
+
             with set_ascend_forward_context(
                 attn_metadata,
                 self.vllm_config,
                 num_tokens=num_tokens_padded,
                 num_tokens_across_dp=num_tokens_across_dp,
                 in_profile_run=is_profile,
-                num_actual_tokens=num_tokens_padded,
+                num_actual_tokens=num_actual_tokens,
                 aclgraph_runtime_mode=cudagraph_runtime_mode,
                 batch_descriptor=batch_desc,
                 model_instance=self.model,
@@ -3861,7 +3917,7 @@ class NPUModelRunner(GPUModelRunner):
             dummy_compute_logits(hidden_states)
 
             if self.drafter and not profile_cpp:
-                self.drafter.dummy_run(
+                drafter_dummy_run_kwargs: dict[str, Any] = dict(
                     num_tokens=num_tokens_padded,
                     with_prefill=with_prefill,
                     num_reqs=num_reqs_padded,
@@ -3872,6 +3928,9 @@ class NPUModelRunner(GPUModelRunner):
                     in_graph_capturing=not force_attention,
                     is_profile=is_profile,
                 )
+                if isinstance(self.drafter, AscendDeepSeekV4DSparkProposer):
+                    drafter_dummy_run_kwargs["is_graph_capturing"] = is_graph_capturing
+                self.drafter.dummy_run(**drafter_dummy_run_kwargs)
             if is_profile and self.dynamic_eplb:
                 self.eplb_updator.adaptor.clear_all_moe_loads()
             if not is_profile and self.dynamic_eplb:
@@ -5284,12 +5343,16 @@ class NPUModelRunner(GPUModelRunner):
             and self.drafter is not None
             and (
                 self.speculative_config.use_eagle()
+                or isinstance(self.drafter, AscendDeepSeekV4DSparkProposer)
                 or self.speculative_config.uses_extract_hidden_states()
             )
         ):
             assert isinstance(
                 self.drafter,
-                AscendEagleProposer | AscendDflashProposer | AscendExtractHiddenStatesProposer,
+                AscendEagleProposer
+                | AscendDflashProposer
+                | AscendDeepSeekV4DSparkProposer
+                | AscendExtractHiddenStatesProposer,
             )
             self.drafter.initialize_cudagraph_keys(cudagraph_mode)
 
@@ -5299,13 +5362,22 @@ class NPUModelRunner(GPUModelRunner):
             for _, descs in capture_descs
             for desc in descs
         })
+        draft_capture_sizes = capture_sizes
+        if self.speculative_config and self.drafter is not None:
+            get_draft_capture_sizes = getattr(
+                self.drafter, "get_cudagraph_capture_sizes", None
+            )
+            if get_draft_capture_sizes is not None:
+                draft_capture_sizes = sorted(
+                    set(capture_sizes).union(get_draft_capture_sizes())
+                )
 
         # NOTE: Since aclgraph_batch_sizes cannot be determined until here,
         # we set the graph params right before initializing the keys.
         if self.use_aclgraph:
             set_graph_params(capture_sizes)
             if self.speculative_config:
-                set_draft_graph_params(capture_sizes)
+                set_draft_graph_params(draft_capture_sizes)
 
     def capture_model(self) -> int:
         """Capture NPU graphs and return actual graph pool memory bytes consumed."""

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -89,7 +89,7 @@ from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID, RejectionSamp
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.spec_decode.ngram_proposer_gpu import copy_num_valid_draft_tokens
 from vllm.v1.structured_output.utils import apply_grammar_bitmask
-from vllm.v1.utils import record_function_or_nullcontext
+from vllm.v1.utils import CpuGpuBuffer, record_function_or_nullcontext
 from vllm.v1.worker import mamba_utils
 from vllm.v1.worker.cp_utils import (
     get_total_cp_world_size,
@@ -577,6 +577,26 @@ class NPUModelRunner(GPUModelRunner):
             cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
         )
         self.num_draft_tokens = self._make_buffer(self.max_num_reqs, dtype=torch.int32)
+        if self.speculative_config is not None:
+            self._spec_cu_num_draft_tokens = self._make_buffer(
+                self.max_num_reqs, dtype=torch.int32
+            )
+            self._spec_cu_num_sampled_tokens = self._make_buffer(
+                self.max_num_reqs, dtype=torch.int32
+            )
+            self._spec_logits_indices = self._make_buffer(
+                self.max_num_tokens, dtype=torch.int32
+            )
+            self._spec_target_logits_indices = self._make_buffer(
+                self.max_num_tokens, dtype=torch.int32
+            )
+            self._spec_bonus_logits_indices = self._make_buffer(
+                self.max_num_reqs, dtype=torch.int32
+            )
+            if self.pcp_size > 1:
+                self._spec_pcp_logits_indices = self._make_buffer(
+                    self.max_num_tokens, dtype=torch.int32
+                )
         # here we use int32
         self.sampled_token_ids_pinned_cpu = torch.empty(
             (self.max_num_reqs, 1),
@@ -592,6 +612,8 @@ class NPUModelRunner(GPUModelRunner):
         self.long_seq_metadata = None
         self.query_lens: torch.Tensor | None = None
         self.sampling_done_event: torch.npu.Event | None = None
+        self._draft_logits: torch.Tensor | None = None
+        self._draft_logits_req_ids: list[str | None] | None = None
 
         # self.cudagraph_batch_sizes sorts in ascending order.
         if (
@@ -1670,9 +1692,6 @@ class NPUModelRunner(GPUModelRunner):
                 cu_num_scheduled_tokens = cu_num_scheduled_tokens * self.pcp_size - num_pcp_pads
             logits_indices_pcp = np.repeat(cu_num_scheduled_tokens - num_sampled_tokens, num_sampled_tokens)
             logits_indices_pcp += self._arange_scratch[: cu_num_sampled_tokens[-1]]
-            logits_indices_pcp = torch.from_numpy(logits_indices_pcp).pin_memory().to(self.device, non_blocking=True)
-
-
 
         # Compute the bonus logits indices.
         bonus_logits_indices = cu_num_sampled_tokens - 1
@@ -1690,19 +1709,30 @@ class NPUModelRunner(GPUModelRunner):
         # [0, 1, 2, 5, 6, 9]
         target_logits_indices += arange
 
-        # TODO: Optimize the CPU -> NPU copy.
-        cu_num_draft_tokens = torch.from_numpy(cu_num_draft_tokens).pin_memory().to(self.device, non_blocking=True)
-        cu_num_sampled_tokens = torch.from_numpy(cu_num_sampled_tokens).pin_memory().to(self.device, non_blocking=True)
-        logits_indices = torch.from_numpy(logits_indices).pin_memory().to(self.device, non_blocking=True)
-        target_logits_indices = torch.from_numpy(target_logits_indices).pin_memory().to(self.device, non_blocking=True)
-        bonus_logits_indices = torch.from_numpy(bonus_logits_indices).pin_memory().to(self.device, non_blocking=True)
+        cu_num_draft_tokens = self._copy_spec_metadata_to_device(
+            cu_num_draft_tokens, self._spec_cu_num_draft_tokens
+        )
+        cu_num_sampled_tokens = self._copy_spec_metadata_to_device(
+            cu_num_sampled_tokens, self._spec_cu_num_sampled_tokens
+        )
+        logits_indices = self._copy_spec_metadata_to_device(
+            logits_indices, self._spec_logits_indices
+        )
+        target_logits_indices = self._copy_spec_metadata_to_device(
+            target_logits_indices, self._spec_target_logits_indices
+        )
+        bonus_logits_indices = self._copy_spec_metadata_to_device(
+            bonus_logits_indices, self._spec_bonus_logits_indices
+        )
 
         # Compute the draft token ids.
         # draft_token_indices:      [  1,   2,   3, 105, 106, 208]
         draft_token_ids = self.input_ids.gpu[logits_indices]
         draft_token_ids = draft_token_ids[target_logits_indices + 1]
         if self.pcp_size > 1:
-            logits_indices = logits_indices_pcp
+            logits_indices = self._copy_spec_metadata_to_device(
+                logits_indices_pcp, self._spec_pcp_logits_indices
+            )
         return SpecDecodeMetadata(
             draft_token_ids=draft_token_ids,
             num_draft_tokens=num_draft_tokens.tolist(),
@@ -1712,6 +1742,15 @@ class NPUModelRunner(GPUModelRunner):
             bonus_logits_indices=bonus_logits_indices,
             logits_indices=logits_indices,
         )
+
+    @staticmethod
+    def _copy_spec_metadata_to_device(
+        values: np.ndarray, buffer: CpuGpuBuffer
+    ) -> torch.Tensor:
+        num_values = values.shape[0]
+        buffer.np[:num_values] = values
+        buffer.copy_to_gpu(num_values)
+        return buffer.gpu[:num_values]
 
     def _correct_optimistic_seq_lens_cpu(self, num_reqs: int) -> None:
         """Correct ``optimistic_seq_lens_cpu`` for async spec-decode drift.
@@ -1762,6 +1801,30 @@ class NPUModelRunner(GPUModelRunner):
             # Stash for GPU-side correction in _prepare_inputs.
             self.valid_sampled_token_count_gpu = valid_sampled_tokens_count # type: ignore[no-redef]
         self.input_batch.prev_sampled_token_ids = next_token_ids.unsqueeze(1)
+
+    @staticmethod
+    def _mask_sampled_token_ids_to_scheduled_width(
+        sampled_token_ids: torch.Tensor,
+        spec_decode_metadata: SpecDecodeMetadata | None,
+    ) -> torch.Tensor:
+        if spec_decode_metadata is None:
+            return sampled_token_ids
+        cu_num_draft_tokens = spec_decode_metadata.cu_num_draft_tokens
+        num_draft_tokens = torch.empty_like(cu_num_draft_tokens)
+        num_draft_tokens[:1] = cu_num_draft_tokens[:1]
+        num_draft_tokens[1:] = cu_num_draft_tokens[1:] - cu_num_draft_tokens[:-1]
+        max_valid_width = num_draft_tokens[: sampled_token_ids.shape[0]] + 1
+        columns = torch.arange(
+            sampled_token_ids.shape[1],
+            device=sampled_token_ids.device,
+            dtype=max_valid_width.dtype,
+        )
+        valid_columns = columns.unsqueeze(0) < max_valid_width.unsqueeze(1)
+        return torch.where(
+            valid_columns,
+            sampled_token_ids,
+            sampled_token_ids.new_full((), -1),
+        )
 
     # TODO: Once the PCP features are complete, it will fully inherit the classes from the VLLM community.
     def propose_draft_token_ids(
@@ -1877,7 +1940,10 @@ class NPUModelRunner(GPUModelRunner):
                 )
             next_token_ids, valid_sampled_tokens_count = (
                 self.drafter.prepare_next_token_ids_padded(
-                    valid_sampled_token_ids,
+                    self._mask_sampled_token_ids_to_scheduled_width(
+                        valid_sampled_token_ids,
+                        spec_decode_metadata,
+                    ),
                     self.requests,
                     self.input_batch,
                     self.discard_request_indices.gpu,
@@ -1909,6 +1975,10 @@ class NPUModelRunner(GPUModelRunner):
                     "sampled_token_ids should be a torch.Tensor whenpadded-batch is enabled."
                 )
                 assert self.drafter is not None
+                sampled_token_ids = self._mask_sampled_token_ids_to_scheduled_width(
+                    sampled_token_ids,
+                    spec_decode_metadata,
+                )
                 next_token_ids, valid_sampled_tokens_count = self.drafter.prepare_next_token_ids_padded(
                     sampled_token_ids,
                     self.requests,
@@ -2021,10 +2091,37 @@ class NPUModelRunner(GPUModelRunner):
                 if draft_probs is not None:
                     self._draft_probs = draft_probs
                     self._draft_prob_req_ids = self.input_batch.req_ids.copy()
+            self._draft_logits = None
+            self._draft_logits_req_ids = None
+            take_draft_logits = getattr(self.drafter, "take_last_draft_logits", None)
+            if take_draft_logits is not None:
+                draft_logits = take_draft_logits()
+                if draft_logits is not None:
+                    self._draft_logits = draft_logits
+                    self._draft_logits_req_ids = list(
+                        self.input_batch.req_ids[: self.input_batch.num_reqs]
+                    )
         else:
             raise ValueError(f"Unknown speculative decoding method: {self.speculative_config.method}")
 
         return draft_token_ids
+
+    def _get_spec_decode_draft_logits(self, metadata: SpecDecodeMetadata) -> torch.Tensor | None:
+        if self._draft_logits is None or self._draft_logits_req_ids is None:
+            return None
+        req_id_to_idx = {req_id: idx for idx, req_id in enumerate(self._draft_logits_req_ids)}
+        logits = []
+        for req_idx, num_draft_tokens in enumerate(metadata.num_draft_tokens):
+            if num_draft_tokens == 0:
+                continue
+            req_id = self.input_batch.req_ids[req_idx]
+            draft_idx = req_id_to_idx.get(req_id)
+            if draft_idx is None:
+                raise ValueError(f"Missing DSpark draft logits for active request {req_id}")
+            if num_draft_tokens > self._draft_logits.shape[1]:
+                raise ValueError("DSpark draft logits are shorter than speculative metadata")
+            logits.append(self._draft_logits[draft_idx, :num_draft_tokens])
+        return torch.cat(logits).contiguous() if logits else None
 
     def _copy_draft_token_ids_to_cpu(
         self, scheduler_output: "SchedulerOutput", zeros_only: bool = False
@@ -2764,7 +2861,8 @@ class NPUModelRunner(GPUModelRunner):
         if self.input_batch.sampling_metadata.top_k is not None and get_ascend_config().enable_reduce_sample:
             max_topk = self.input_batch.top_k_cpu[self.input_batch.top_k_cpu < logits.shape[1]].max()
             self.rejection_sampler.prepare_sampling(max_topk)
-        draft_probs = (
+        draft_logits = self._get_spec_decode_draft_logits(spec_decode_metadata)
+        draft_probs = None if draft_logits is not None else (
             self._get_spec_decode_draft_probs(spec_decode_metadata)
             if get_pp_group().world_size > 1
             else None
@@ -2774,6 +2872,7 @@ class NPUModelRunner(GPUModelRunner):
             draft_probs,
             logits,
             sampling_metadata,
+            draft_logits=draft_logits,
         )
         return sampler_output
 
@@ -3429,12 +3528,10 @@ class NPUModelRunner(GPUModelRunner):
                 cm.block_table_tensor, cm.slot_mapping = _get_block_table_and_slot_mapping(
                     kv_cache_gid
                 )
-            if self.speculative_config and isinstance(self.drafter, AscendStep3p5MTPProposer):
-                # step3p5 MTP draft layers span multiple KV cache groups; capture
-                # each group's block table / slot mapping so the proposer can
-                # build per-step attention metadata for the active MTP layer.
-                self.drafter.set_per_group_attn_metadata(
-                    kv_cache_gid, cm.block_table_tensor, cm.slot_mapping)
+            if self.speculative_config and self.drafter is not None:
+                set_group_metadata = getattr(self.drafter, "set_per_group_attn_metadata", None)
+                if set_group_metadata is not None:
+                    set_group_metadata(kv_cache_gid, cm.block_table_tensor, cm.slot_mapping)
             if self.speculative_config and spec_decode_common_attn_metadata is None:
                 if isinstance(self.drafter, AscendEagleProposer | AscendDraftModelProposer | AscendDflashProposer 
                     | AscendDsparkProposer):
@@ -4006,15 +4103,18 @@ class NPUModelRunner(GPUModelRunner):
             and (
                 self.speculative_config.use_eagle()
                 or self.speculative_config.uses_draft_model()
+                or getattr(
+                    self.speculative_config.draft_model_config.hf_config,
+                    "dspark_block_size",
+                    0,
+                )
             )
         ):
             assert isinstance(
                 self.drafter,
                 AscendEagleProposer | AscendDflashProposer | AscendDsparkProposer | AscendDraftModelProposer,
             )
-            block_size = (self.kernel_block_sizes[0] if isinstance(
-                self.kernel_block_sizes, list) else self.kernel_block_sizes)
-            self.drafter.initialize_attn_backend(kv_cache_config, block_size)
+            self.drafter.initialize_attn_backend(kv_cache_config, self.kernel_block_sizes)
 
         if has_kv_transfer_group():
             get_kv_transfer_group().register_kv_caches(kv_caches)

--- a/vllm_ascend/worker/v2/sample/gumbel.py
+++ b/vllm_ascend/worker/v2/sample/gumbel.py
@@ -18,7 +18,23 @@
 # This file is a part of the vllm-ascend project.
 
 import torch
-from vllm.triton_utils import tl, triton
+from vllm.triton_utils import HAS_TRITON, tl, triton
+
+_TL_RAND_MIN = tl.constexpr(4.6566127342e-10) if HAS_TRITON else 4.6566127342e-10
+
+
+def flipped_gumbel_noise(u: torch.Tensor) -> torch.Tensor:
+    """Apply the fp32 flipped-Gumbel transform without losing its upper tail."""
+    return -torch.log(-torch.log1p(-u.float().clamp_min(4.6566127342e-10)))
+
+
+@triton.jit
+def _tl_log1p_neg(x):
+    return tl.where(
+        x < 0.01,
+        -x * (1.0 + x * (0.5 + x * (0.3333333333333333 + x * 0.25))),
+        tl.log(1.0 - x),
+    )
 
 
 @triton.jit(do_not_specialize=["logits_stride", "vocab_size"])
@@ -140,8 +156,8 @@ def _gumbel_sample_kernel(
 
         # NOTE(Ronald1995): r is tl.float64 in vllm, change it to tl.float32,
         # because triton-ascend's compiler does not support float64.
-        r = tl.rand(gumbel_seed, block).to(tl.float32)
-        gumbel_noise = -tl.log(-tl.log(r + 1e-20) + 1e-20)
+        r = tl.maximum(tl.rand(gumbel_seed, block).to(tl.float32), _TL_RAND_MIN)
+        gumbel_noise = -tl.log(-_tl_log1p_neg(r))
 
         # Apply gumbel noise.
         logits = tl.where(mask, logits + gumbel_noise, float("-inf"))

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -18,16 +18,43 @@
 # This file is a part of the vllm-ascend project.
 
 import torch
-from vllm.triton_utils import tl, triton
-from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
-    _compute_global_logsumexp as _compute_global_lse,
-)
-from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
-    _compute_local_logits_stats_kernel as _compute_block_stats_kernel,
-)
-from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
-    _insert_resampled_kernel,
-)
+from vllm.triton_utils import HAS_TRITON, tl, triton
+
+from vllm_ascend.utils import vllm_version_is
+
+if not vllm_version_is("0.23.0"):
+    from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
+        _compute_global_logsumexp as _compute_global_lse,
+    )
+    from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
+        _compute_local_logits_stats_kernel as _compute_block_stats_kernel,
+    )
+    from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
+        _insert_resampled_kernel,
+    )
+else:
+    from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
+        _compute_block_stats_kernel,
+        _compute_global_lse,
+        _insert_resampled_kernel,
+    )
+
+_TL_RAND_MIN = tl.constexpr(4.6566127342e-10) if HAS_TRITON else 4.6566127342e-10
+
+
+@triton.jit
+def _tl_log1p_neg(x):
+    return tl.where(
+        x < 0.01,
+        -x * (1.0 + x * (0.5 + x * (0.3333333333333333 + x * 0.25))),
+        tl.log(1.0 - x),
+    )
+
+
+@triton.jit
+def _npu_uniform(seed, pos):
+    uniform_seed = tl.randint(seed, pos.to(tl.int32))
+    return tl.maximum(tl.rand(uniform_seed, 0).to(tl.float32), _TL_RAND_MIN)
 
 
 @triton.jit
@@ -70,8 +97,8 @@ def _npu_gumbel_block_argmax(
         pos = tl.load(pos_ptr + token_idx).to(tl.int32)
         gumbel_seed = tl.randint(seed, pos)
         # NPU: use tl.rand (float32) instead of tl_rand64 (float64 not supported)
-        r = tl.rand(gumbel_seed, block).to(tl.float32)
-        gumbel_noise = -tl.log(-tl.log(r + 1e-20) + 1e-20)
+        r = tl.maximum(tl.rand(gumbel_seed, block).to(tl.float32), _TL_RAND_MIN)
+        gumbel_noise = -tl.log(-_tl_log1p_neg(r))
         logits = tl.where(mask, logits + gumbel_noise, float("-inf"))
 
     value, idx = tl.max(logits, axis=0, return_indices=True)
@@ -284,8 +311,7 @@ def _probabilistic_rejection_kernel(
                     PADDED_VOCAB_NUM_BLOCKS,
                 )
                 target_log_prob = target_logit - target_lse
-                # NPU does not support tl_rand64; always accept the draft token.
-                u = tl.full([], 0.0, dtype=tl.float32)
+                u = _npu_uniform(seed, tl.load(pos_ptr + logit_idx))
                 if HAS_DRAFT_LOGITS:
                     draft_logit = tl.load(
                         draft_logits_ptr


### PR DESCRIPTION
### What this PR does / why we need it?

This is PR 4/4 of the DeepSeek V4 DSpark split defined in #11126. It depends on #12005 and adds graph optimization only after the eager path is independently established.

For stacked review, the owned change is commit `386530d12` (`qj/dspark-03-eager..qj/dspark-04-aclgraph`). The temporary `main`-based GitHub diff also contains PRs 1-3 until their dependencies merge.

This PR:

- derives drafter capture sizes from complete target request rows;
- uses persistent graph input, attention metadata, sampling, and output buffers;
- pads complete inactive request rows across DP ranks;
- pads missing speculative-width metadata for graph-added request rows before masking sampled tokens;
- disables unsafe PIECEWISE replay during uneven DeepSeek V4 DSpark DP turnover while preserving FULL mode when all ranks agree;
- captures/replays the fixed-shape draft forward and slices outputs back to actual requests;
- keeps `speculative_config.enforce_eager=true` as the eager isolation path.

Incremental size: about `+1104/-35`, including 643 lines of focused graph/DP regression tests.

### Does this PR introduce _any_ user-facing change?

Yes. When the target model uses FULL ACLGraph, the DeepSeek V4 DSpark drafter uses FULL capture/replay by default. Users can set `speculative_config.enforce_eager=true` to isolate or disable the drafter graph.

### How was this patch tested?

PR 4 graph/runner-focused result: `36 passed`.

Cumulative PR 1-4 unit result:

```bash
python -m pytest -q \
  tests/ut/quantization/test_modelslim_config.py \
  tests/ut/sample/a2/test_probabilistic_rejection.py \
  tests/ut/sample/test_gumbel_noise.py \
  tests/ut/sample/test_rejection_sampler.py \
  tests/ut/spec_decode/test_deepseek_v4_draft_hooks.py \
  tests/ut/spec_decode/test_deepseek_v4_dspark_model.py \
  tests/ut/spec_decode/test_dspark_dsa_metadata.py \
  tests/ut/spec_decode/test_dspark_eager_proposer.py \
  tests/ut/spec_decode/test_dspark_aclgraph.py \
  tests/ut/spec_decode/test_llm_base_proposer.py \
  tests/ut/worker/a2/test_model_runner_v1.py
```

Result: `166 passed, 1 skipped`.

Also passed:

- mypy for all 32 Python files changed by the four-PR stack;
- `pre-commit run --all-files`;
- `ruff check` and `ruff format --check` for all changed Python files;
- `python -m py_compile` for the proposer and runner paths;
- `git diff --check qj/dspark-03-eager...HEAD`.

The final real W4A8 TP4/DP4/EP16 service, FULL replay, SPEED-Bench, coding80 AR/AL, and fixed 8k/1k performance evidence will be added before this draft is marked ready.

References:

- Direct dependency: #12005
- RFC and four-PR plan: #11126
- Original end-to-end prototype: #11196
- Generic Qwen/GLM DSpark foundation: #11765

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/e5588e49bc2642670116664a7fc4096e27adb179
