### PR TITLE
[BugFix] handle PCP empty rank and chunked prefill 1-token remainder for qwen3.5

### DIFF
--- a/tests/ut/ops/a2/test_gdn_chunk_meta.py
+++ b/tests/ut/ops/a2/test_gdn_chunk_meta.py
@@ -437,3 +437,176 @@ def test_chunk_gated_delta_rule_fwd_pcp_chaining_subtracts_initial_state(
     # Sequential: Φ_1·(Φ_0·s0 + p_0) + p_1
     expected = torch.matmul(phi_1, torch.matmul(phi_0, s0) + p_0) + p_1
     torch.testing.assert_close(final_state, expected, rtol=1e-4, atol=1e-4)
+
+
+def test_chunk_gated_delta_rule_fwd_skip_pcp_all_gather(monkeypatch: pytest.MonkeyPatch):
+    """Test skip_pcp_all_gather=True skips PCP all_gather block.
+
+    When skip_pcp_all_gather=True, the PCP all_gather block should be skipped
+    even when world_size > 1. This is used when PCP rank has 0 prefill tokens.
+    """
+    prebuilt_meta = type(
+        "PrebuiltMeta",
+        (),
+        {
+            "block_indices_cumsum": None,
+            "cu_seqlens_host": (0, 4, 7),
+            "chunk_indices_chunk64_host": (0, 0, 1, 0),
+            "chunk_indices_chunk64": torch.tensor([[0, 0], [1, 0]], dtype=torch.int32),
+            "chunk_offsets_chunk64": torch.tensor([0, 1, 2], dtype=torch.int32),
+            "update_chunk_offsets_chunk64": torch.tensor([0, 2, 4], dtype=torch.int32),
+            "final_chunk_indices_chunk64": torch.tensor([1, 3], dtype=torch.int32),
+            "chunk_indices_large_block": None,
+            "keep_meta": None,
+            "cu_seqlens_kern": None,
+        },
+    )()
+
+    q = _DummyTensor("q")
+    k = _DummyTensor("k")
+    v = _DummyTensor("v")
+    g = _DummyTensor("g")
+    beta = _DummyTensor("beta")
+    initial_state = _DummyTensor("initial_state")
+
+    all_gather_called = []
+
+    def run_case(world_size: int, skip_pcp_all_gather: bool):
+        group = type(
+            "Group",
+            (),
+            {
+                "world_size": world_size,
+                "rank_in_group": 0,
+                "all_gather": lambda self, value, dim: all_gather_called.append(True) or _GatherResult([_DummyTensor("g0"), _DummyTensor("g1")]),
+            },
+        )()
+
+        monkeypatch.setattr(chunk, "get_forward_context", lambda: type("Ctx", (), {"attn_metadata": None})())
+        monkeypatch.setattr(chunk, "get_pcp_group", lambda: group)
+        monkeypatch.setattr(chunk, "chunk_local_cumsum", lambda *args, **kwargs: _DummyTensor("g_cumsum"))
+        monkeypatch.setattr(chunk, "chunk_scaled_dot_kkt_fwd", lambda *args, **kwargs: _DummyTensor("A"))
+        monkeypatch.setattr(chunk, "solve_tril", lambda *args, **kwargs: _DummyTensor("A_solved"))
+        monkeypatch.setattr(chunk, "recompute_w_u_fwd", lambda *args, **kwargs: (_DummyTensor("w"), _DummyTensor("u")))
+        monkeypatch.setattr(
+            chunk,
+            "chunk_gated_delta_rule_fwd_h",
+            lambda *args, **kwargs: (_DummyTensor("h"), _DummyTensor("v_new"), _DummyTensor("final_state")),
+        )
+        monkeypatch.setattr(
+            chunk,
+            "chunk_gated_delta_rule_fwd_hupdate",
+            lambda *args, **kwargs: _DummyTensor("h_update"),
+        )
+        monkeypatch.setattr(
+            torch.ops._C_ascend,
+            "chunk_gated_delta_rule_fwd_h",
+            lambda *args, **kwargs: (_DummyTensor("h"), _DummyTensor("v_new"), _DummyTensor("final_state")),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            torch.ops._C_ascend,
+            "chunk_fwd_o",
+            lambda *args, **kwargs: _DummyTensor("o_ascend"),
+            raising=False,
+        )
+
+        chunk.chunk_gated_delta_rule_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=1.0,
+            initial_state=initial_state,
+            output_final_state=False,
+            cu_seqlens=torch.tensor([0, 4, 7], dtype=torch.int32),
+            prebuilt_meta=prebuilt_meta,
+            skip_pcp_all_gather=skip_pcp_all_gather,
+        )
+
+    # Test 1: world_size=2, skip_pcp_all_gather=False → all_gather should be called
+    all_gather_called.clear()
+    run_case(2, False)
+    assert len(all_gather_called) > 0, "all_gather should be called when skip_pcp_all_gather=False"
+
+    # Test 2: world_size=2, skip_pcp_all_gather=True → all_gather should NOT be called
+    all_gather_called.clear()
+    run_case(2, True)
+    assert len(all_gather_called) == 0, "all_gather should NOT be called when skip_pcp_all_gather=True"
+
+
+def test_chunk_gated_delta_rule_fwd_uses_compact_cu_seqlens_kern(monkeypatch: pytest.MonkeyPatch):
+    """Test chunk_fwd_o uses cu_seqlens_kern (compact) instead of cu_seqlens_host.
+
+    When prebuilt_meta has cu_seqlens_kern (compressed version with empty segments
+    removed), chunk_fwd_o should use it to avoid indexing errors in AscendC kernels.
+    """
+    cu_seqlens_host = (0, 4, 4, 7)  # Has empty segment (4, 4)
+    cu_seqlens_kern = [0, 4, 7]  # Compressed version
+
+    prebuilt_meta = type(
+        "PrebuiltMeta",
+        (),
+        {
+            "block_indices_cumsum": None,
+            "cu_seqlens_host": cu_seqlens_host,
+            "cu_seqlens_kern": cu_seqlens_kern,
+            "chunk_indices_chunk64_host": (0, 0, 1, 0),
+            "chunk_indices_chunk64": torch.tensor([[0, 0], [1, 0]], dtype=torch.int32),
+            "chunk_offsets_chunk64": torch.tensor([0, 1, 2], dtype=torch.int32),
+            "update_chunk_offsets_chunk64": torch.tensor([0, 2, 4], dtype=torch.int32),
+            "final_chunk_indices_chunk64": torch.tensor([1, 3], dtype=torch.int32),
+            "chunk_indices_large_block": None,
+            "keep_meta": None,
+        },
+    )()
+
+    q = _DummyTensor("q")
+    k = _DummyTensor("k")
+    v = _DummyTensor("v")
+    g = _DummyTensor("g")
+    beta = _DummyTensor("beta")
+    initial_state = _DummyTensor("initial_state")
+
+    captured_cu_seqlens = []
+
+    monkeypatch.setattr(chunk, "get_forward_context", lambda: type("Ctx", (), {"attn_metadata": None})())
+    monkeypatch.setattr(
+        chunk,
+        "get_pcp_group",
+        lambda: type("Group", (), {"world_size": 1, "rank_in_group": 0})(),
+    )
+    monkeypatch.setattr(chunk, "chunk_local_cumsum", lambda *args, **kwargs: _DummyTensor("g_cumsum"))
+    monkeypatch.setattr(chunk, "chunk_scaled_dot_kkt_fwd", lambda *args, **kwargs: _DummyTensor("A"))
+    monkeypatch.setattr(chunk, "solve_tril", lambda *args, **kwargs: _DummyTensor("A_solved"))
+    monkeypatch.setattr(chunk, "recompute_w_u_fwd", lambda *args, **kwargs: (_DummyTensor("w"), _DummyTensor("u")))
+    monkeypatch.setattr(
+        torch.ops._C_ascend,
+        "chunk_gated_delta_rule_fwd_h",
+        lambda *args, **kwargs: (_DummyTensor("h"), _DummyTensor("v_new"), _DummyTensor("final_state")),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        torch.ops._C_ascend,
+        "chunk_fwd_o",
+        lambda *args, **kwargs: captured_cu_seqlens.append(kwargs["cu_seqlens"]) or _DummyTensor("o_ascend"),
+        raising=False,
+    )
+
+    chunk.chunk_gated_delta_rule_fwd(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=1.0,
+        initial_state=initial_state,
+        output_final_state=False,
+        cu_seqlens=torch.tensor([0, 4, 4, 7], dtype=torch.int32),
+        prebuilt_meta=prebuilt_meta,
+    )
+
+    # chunk_fwd_o should use cu_seqlens_kern (compressed), not cu_seqlens_host
+    assert len(captured_cu_seqlens) > 0, "chunk_fwd_o should be called"
+    assert captured_cu_seqlens[0] == cu_seqlens_kern, "chunk_fwd_o should use cu_seqlens_kern (compressed version)"

--- a/tests/ut/ops/a2/test_gdn_chunk_meta.py
+++ b/tests/ut/ops/a2/test_gdn_chunk_meta.py
@@ -472,15 +472,17 @@ def test_chunk_gated_delta_rule_fwd_skip_pcp_all_gather(monkeypatch: pytest.Monk
     all_gather_called = []
 
     def run_case(world_size: int, skip_pcp_all_gather: bool):
+        def _mock_all_gather(self, value, dim):
+            all_gather_called.append(True)
+            return _GatherResult([_DummyTensor("g0"), _DummyTensor("g1")])
+
         group = type(
             "Group",
             (),
             {
                 "world_size": world_size,
                 "rank_in_group": 0,
-                "all_gather": lambda self, value, dim: (
-                    all_gather_called.append(True) or _GatherResult([_DummyTensor("g0"), _DummyTensor("g1")])
-                ),
+                "all_gather": _mock_all_gather,
             },
         )()
 
@@ -589,10 +591,15 @@ def test_chunk_gated_delta_rule_fwd_uses_compact_cu_seqlens_kern(monkeypatch: py
         lambda *args, **kwargs: (_DummyTensor("h"), _DummyTensor("v_new"), _DummyTensor("final_state")),
         raising=False,
     )
+
+    def mock_chunk_fwd_o(*args, **kwargs):
+        captured_cu_seqlens.append(kwargs["cu_seqlens"])
+        return _DummyTensor("o_ascend")
+
     monkeypatch.setattr(
         torch.ops._C_ascend,
         "chunk_fwd_o",
-        lambda *args, **kwargs: captured_cu_seqlens.append(kwargs["cu_seqlens"]) or _DummyTensor("o_ascend"),
+        mock_chunk_fwd_o,
         raising=False,
     )
 

--- a/tests/ut/ops/a2/test_gdn_chunk_meta.py
+++ b/tests/ut/ops/a2/test_gdn_chunk_meta.py
@@ -478,8 +478,9 @@ def test_chunk_gated_delta_rule_fwd_skip_pcp_all_gather(monkeypatch: pytest.Monk
             {
                 "world_size": world_size,
                 "rank_in_group": 0,
-                "all_gather": lambda self, value, dim: all_gather_called.append(True) or
-                                                       _GatherResult([_DummyTensor("g0"), _DummyTensor("g1")]),
+                "all_gather": lambda self, value, dim: (
+                    all_gather_called.append(True) or _GatherResult([_DummyTensor("g0"), _DummyTensor("g1")])
+                ),
             },
         )()
 

--- a/tests/ut/ops/a2/test_gdn_chunk_meta.py
+++ b/tests/ut/ops/a2/test_gdn_chunk_meta.py
@@ -478,7 +478,8 @@ def test_chunk_gated_delta_rule_fwd_skip_pcp_all_gather(monkeypatch: pytest.Monk
             {
                 "world_size": world_size,
                 "rank_in_group": 0,
-                "all_gather": lambda self, value, dim: all_gather_called.append(True) or _GatherResult([_DummyTensor("g0"), _DummyTensor("g1")]),
+                "all_gather": lambda self, value, dim: all_gather_called.append(True) or
+                                                       _GatherResult([_DummyTensor("g0"), _DummyTensor("g1")]),
             },
         )()
 

--- a/tests/ut/worker/a2/test_model_runner_v1_with_device.py
+++ b/tests/ut/worker/a2/test_model_runner_v1_with_device.py
@@ -123,13 +123,14 @@ def model_runner():
 
 
 @pytest.mark.parametrize(
-    "num_computed_tokens, num_scheduled_tokens, num_tokens, num_reqs, "
+    "num_computed_tokens, num_scheduled_tokens, num_prompt_tokens, num_tokens, num_reqs, "
     "max_num_scheduled_tokens, use_cascade_attn, force_eager, "
     "force_uniform_decode, spec_decode_tokens",
     [
         # ---- force_eager=True: bypass cudagraph dispatch ----
         pytest.param(
             [0, 0, 0],
+            [10, 10, 10],
             [10, 10, 10],
             30,
             3,
@@ -143,6 +144,7 @@ def model_runner():
         pytest.param(
             [5, 10, 15],
             [1, 1, 1],
+            [5, 10, 15],
             3,
             3,
             1,
@@ -155,6 +157,7 @@ def model_runner():
         pytest.param(
             [0, 5, 10],
             [10, 1, 1],
+            [10, 5, 10],
             12,
             3,
             10,
@@ -168,6 +171,7 @@ def model_runner():
         pytest.param(
             [0, 0, 0],
             [10, 10, 10],
+            [10, 10, 10],
             30,
             3,
             10,
@@ -180,6 +184,7 @@ def model_runner():
         pytest.param(
             [5, 10, 15],
             [1, 1, 1],
+            [5, 10, 15],
             3,
             3,
             1,
@@ -192,6 +197,7 @@ def model_runner():
         pytest.param(
             [0, 5, 10],
             [10, 1, 1],
+            [10, 5, 10],
             12,
             3,
             10,
@@ -203,6 +209,7 @@ def model_runner():
         ),
         pytest.param(
             [0],
+            [50],
             [50],
             50,
             1,
@@ -216,6 +223,7 @@ def model_runner():
         pytest.param(
             [100],
             [1],
+            [100],
             1,
             1,
             1,
@@ -228,6 +236,7 @@ def model_runner():
         # ---- cascade attention ----
         pytest.param(
             [0, 0, 0],
+            [10, 10, 10],
             [10, 10, 10],
             30,
             3,
@@ -242,6 +251,7 @@ def model_runner():
         pytest.param(
             [5, 10, 15],
             [1, 1, 1],
+            [5, 10, 15],
             3,
             3,
             1,
@@ -254,6 +264,7 @@ def model_runner():
         pytest.param(
             [5, 10, 15],
             [1, 1, 1],
+            [5, 10, 15],
             3,
             3,
             1,
@@ -267,6 +278,7 @@ def model_runner():
         pytest.param(
             [5, 10, 15],
             [4, 4, 4],
+            [5, 10, 15],
             12,
             3,
             4,
@@ -278,6 +290,7 @@ def model_runner():
         ),
         pytest.param(
             [0, 0, 0],
+            [4, 4, 4],
             [4, 4, 4],
             12,
             3,
@@ -291,6 +304,7 @@ def model_runner():
         pytest.param(
             [0, 5, 10],
             [4, 4, 4],
+            [4, 5, 10],
             12,
             3,
             4,
@@ -303,6 +317,7 @@ def model_runner():
         # ---- large batch ----
         pytest.param(
             [0, 0, 0, 0, 0],
+            [20, 20, 20, 20, 20],
             [20, 20, 20, 20, 20],
             100,
             5,
@@ -319,6 +334,7 @@ def test_determine_batch_execution_and_padding(
     model_runner,
     num_computed_tokens,
     num_scheduled_tokens,
+    num_prompt_tokens,
     num_tokens,
     num_reqs,
     max_num_scheduled_tokens,
@@ -341,6 +357,10 @@ def test_determine_batch_execution_and_padding(
 
     try:
         runner.input_batch.num_computed_tokens_cpu[:num_reqs] = num_computed_tokens
+        # Set num_prompt_tokens to distinguish prefill from decode:
+        # - Prefill: num_computed < num_prompt (still prefilling)
+        # - Decode: num_computed >= num_prompt (prompt fully computed)
+        runner.input_batch.num_prompt_tokens[:num_reqs] = num_prompt_tokens
         num_scheduled_tokens_np = np.array(num_scheduled_tokens, dtype=np.int32)
 
         kwargs = dict(

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -255,9 +255,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                     # case mixed_qkv_non_spec.shape[0] > 0 (decode tokens) but
                     # the prefill segments are all empty, so extract_last_width
                     # would still crash on the empty prefill ranges.
-                    num_prefill_tokens = (
-                        mixed_qkv_non_spec.shape[0] - attn_metadata.num_decode_tokens
-                    )
+                    num_prefill_tokens = mixed_qkv_non_spec.shape[0] - attn_metadata.num_decode_tokens
                     if num_prefill_tokens == 0:
                         last_width_prefill_x = torch.zeros(
                             attn_metadata.num_prefills,
@@ -288,9 +286,9 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                         device=mixed_qkv_non_spec.device,
                         dtype=torch.int32,
                     )
-                    all_has_token_flags = get_pcp_group().all_gather(
-                        has_token_flag.unsqueeze(0).contiguous(), 0
-                    ).view(-1)
+                    all_has_token_flags = (
+                        get_pcp_group().all_gather(has_token_flag.unsqueeze(0).contiguous(), 0).view(-1)
+                    )
                     # If any PCP rank has 0 prefill tokens (e.g. PCP splits a
                     # 1-token chunk), the empty rank will early-return before
                     # chunk_gated_delta_rule. Tell chunk_gated_delta_rule_fwd
@@ -508,7 +506,8 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                     skip_pcp_all_gather=skip_pcp_all_gather,
                 )
                 ssm_state[prefill_state_indices] = (
-                    last_recurrent_state.transpose(-1, -2).contiguous().to(ssm_state.dtype))
+                    last_recurrent_state.transpose(-1, -2).contiguous().to(ssm_state.dtype)
+                )
                 if split_non_spec:
                     core_attn_out_non_spec = torch.cat(
                         [core_attn_out_decode, core_attn_out_non_spec],

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -305,9 +305,9 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                         device=mixed_qkv_non_spec.device,
                         dtype=torch.int32,
                     )
-                    all_has_any_token_flags = get_pcp_group().all_gather(
-                        has_any_token_flag.unsqueeze(0).contiguous(), 0
-                    ).view(-1)
+                    all_has_any_token_flags = (
+                        get_pcp_group().all_gather(has_any_token_flag.unsqueeze(0).contiguous(), 0).view(-1)
+                    )
                     can_sync_state = (all_has_any_token_flags > 0).all().item()
                     rank_indices = torch.arange(
                         pcp_world_size,
@@ -546,9 +546,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 gathered_state = get_pcp_group().all_gather(
                     ssm_state[prefill_state_indices].unsqueeze(0).contiguous(), 0
                 )
-                ssm_state[prefill_state_indices] = gathered_state[
-                    last_non_empty_rank
-                ].to(ssm_state.dtype)
+                ssm_state[prefill_state_indices] = gathered_state[last_non_empty_rank].to(ssm_state.dtype)
         elif attn_metadata.num_decodes > 0:
             actual_seq_lengths = attn_metadata.non_spec_decode_metadata.actual_seq_lengths
             query_non_spec = l2norm_fwd(query_non_spec)

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -294,6 +294,21 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                     # chunk_gated_delta_rule. Tell chunk_gated_delta_rule_fwd
                     # to skip its internal all_gather block to avoid deadlock.
                     skip_pcp_all_gather = (all_has_token_flags == 0).any().item()
+                    # Check if all ranks have num_actual_tokens > 0 (not
+                    # completely empty). If a rank is completely empty it
+                    # early-returns and cannot participate in the ssm_state
+                    # sync all_gather below. When can_sync_state is False,
+                    # we skip the sync to avoid deadlock (rare edge case:
+                    # 0 prefill + 0 decode tokens on a rank).
+                    has_any_token_flag = torch.tensor(
+                        [1 if num_actual_tokens > 0 else 0],
+                        device=mixed_qkv_non_spec.device,
+                        dtype=torch.int32,
+                    )
+                    all_has_any_token_flags = get_pcp_group().all_gather(
+                        has_any_token_flag.unsqueeze(0).contiguous(), 0
+                    ).view(-1)
+                    can_sync_state = (all_has_any_token_flags > 0).all().item()
                     rank_indices = torch.arange(
                         pcp_world_size,
                         device=mixed_qkv_non_spec.device,
@@ -518,6 +533,22 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 core_attn_out_non_spec = core_attn_out_decode
             else:
                 core_attn_out_non_spec = None
+
+            # When skip_pcp_all_gather=True, the all_gather inside
+            # chunk_gated_delta_rule_fwd was skipped to avoid deadlock.
+            # But the non-empty rank updated its ssm_state while the
+            # empty rank (0 prefill tokens) did not, causing state
+            # divergence. Synchronize ssm_state from last_non_empty_rank
+            # to all ranks so subsequent decode steps use the correct state.
+            # can_sync_state ensures no rank is completely empty (which
+            # would have early-returned and caused a deadlock here).
+            if skip_pcp_all_gather and can_sync_state:
+                gathered_state = get_pcp_group().all_gather(
+                    ssm_state[prefill_state_indices].unsqueeze(0).contiguous(), 0
+                )
+                ssm_state[prefill_state_indices] = gathered_state[
+                    last_non_empty_rank
+                ].to(ssm_state.dtype)
         elif attn_metadata.num_decodes > 0:
             actual_seq_lengths = attn_metadata.non_spec_decode_metadata.actual_seq_lengths
             query_non_spec = l2norm_fwd(query_non_spec)

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -507,7 +507,8 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                     use_qk_l2norm_in_kernel=True,
                     skip_pcp_all_gather=skip_pcp_all_gather,
                 )
-                ssm_state[prefill_state_indices] = last_recurrent_state.transpose(-1, -2).contiguous().to(ssm_state.dtype)
+                ssm_state[prefill_state_indices] = (
+                    last_recurrent_state.transpose(-1, -2).contiguous().to(ssm_state.dtype))
                 if split_non_spec:
                     core_attn_out_non_spec = torch.cat(
                         [core_attn_out_decode, core_attn_out_non_spec],

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -177,6 +177,14 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
         b = b[:num_actual_tokens]
         a = a[:num_actual_tokens]
 
+        # When PCP splits a 1-token prefill chunk and one rank gets 0 tokens,
+        # the empty rank early-returns below and cannot participate in the
+        # all_gather collectives inside chunk_gated_delta_rule_fwd. This flag
+        # tells chunk_gated_delta_rule_fwd to skip its PCP all_gather block,
+        # avoiding deadlock. Set in the PCP conv1d block when an empty rank is
+        # detected.
+        skip_pcp_all_gather = False
+
         # 1. Convolution sequence transformation
         conv_weights = self.conv1d.weight.view(self.conv1d.weight.size(0), self.conv1d.weight.size(2))
         if spec_sequence_masks is not None:
@@ -231,37 +239,93 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                     num_seqs = non_spec_query_start_loc.shape[0] - 1
                     prefill_seq_offset = max(0, num_seqs - attn_metadata.num_prefills)
                     prefill_cache_indices = non_spec_state_indices_tensor[prefill_seq_offset:]
-                    mixed_qkv_non_spec_T = mixed_qkv_non_spec.transpose(0, 1)
-                    last_width_prefill_x = extract_last_width(
-                        mixed_qkv_non_spec_T, non_spec_query_start_loc[prefill_seq_offset:], state_len
-                    )
                     pcp_rank = get_pcp_group().rank_in_group
+                    pcp_world_size = get_pcp_group().world_size
+                    # When PCP splits a 1-token prefill chunk across multiple
+                    # ranks, one rank gets 0 tokens. extract_last_width would
+                    # crash on the empty token dimension (IndexError: index is
+                    # out of bounds for dimension with size 0). Create a zero
+                    # dummy with the shape extract_last_width would produce so
+                    # all ranks can participate in all_gather (required to
+                    # avoid deadlock). The dummy is ignored: the state update
+                    # below pulls real data from the non-empty rank.
+                    #
+                    # Also check num_prefill_tokens: under concurrency a PCP
+                    # rank can have decode tokens but 0 prefill tokens. In that
+                    # case mixed_qkv_non_spec.shape[0] > 0 (decode tokens) but
+                    # the prefill segments are all empty, so extract_last_width
+                    # would still crash on the empty prefill ranges.
+                    num_prefill_tokens = (
+                        mixed_qkv_non_spec.shape[0] - attn_metadata.num_decode_tokens
+                    )
+                    if num_prefill_tokens == 0:
+                        last_width_prefill_x = torch.zeros(
+                            attn_metadata.num_prefills,
+                            mixed_qkv_non_spec.shape[1],
+                            state_len,
+                            device=mixed_qkv_non_spec.device,
+                            dtype=mixed_qkv_non_spec.dtype,
+                        )
+                    else:
+                        mixed_qkv_non_spec_T = mixed_qkv_non_spec.transpose(0, 1)
+                        last_width_prefill_x = extract_last_width(
+                            mixed_qkv_non_spec_T,
+                            non_spec_query_start_loc[prefill_seq_offset:],
+                            state_len,
+                        )
                     all_last_width_prefill_x = get_pcp_group().all_gather(
                         last_width_prefill_x.unsqueeze(0).contiguous(), 0
                     )
+                    # Determine the last rank with actual prefill tokens so the
+                    # final state update picks real data instead of dummy zeros
+                    # from an empty rank.  Check PREFILL tokens (not total
+                    # non-spec tokens which include decode tokens): under
+                    # concurrency a PCP rank can have decode tokens but 0
+                    # prefill tokens, and must be treated as empty so
+                    # skip_pcp_all_gather is set correctly.
+                    has_token_flag = torch.tensor(
+                        [1 if num_prefill_tokens > 0 else 0],
+                        device=mixed_qkv_non_spec.device,
+                        dtype=torch.int32,
+                    )
+                    all_has_token_flags = get_pcp_group().all_gather(
+                        has_token_flag.unsqueeze(0).contiguous(), 0
+                    ).view(-1)
+                    # If any PCP rank has 0 prefill tokens (e.g. PCP splits a
+                    # 1-token chunk), the empty rank will early-return before
+                    # chunk_gated_delta_rule. Tell chunk_gated_delta_rule_fwd
+                    # to skip its internal all_gather block to avoid deadlock.
+                    skip_pcp_all_gather = (all_has_token_flags == 0).any().item()
+                    rank_indices = torch.arange(
+                        pcp_world_size,
+                        device=mixed_qkv_non_spec.device,
+                        dtype=torch.int32,
+                    )
+                    last_non_empty_rank = (all_has_token_flags * rank_indices).argmax()
                     if pcp_rank > 0 and prefill_cache_indices.shape[0] > 0:
                         self_kv_cache[0][prefill_cache_indices, :state_len, :] = all_last_width_prefill_x[
                             pcp_rank - 1, ...
                         ].transpose(-1, -2)
-                    mixed_qkv_non_spec_output = torch.empty_like(mixed_qkv_non_spec)
-                    torch.ops._C_ascend.npu_causal_conv1d_custom(
-                        mixed_qkv_non_spec_output,
-                        mixed_qkv_non_spec,
-                        conv_weights_T,
-                        conv_state=self_kv_cache[0],
-                        bias_opt=self.conv1d.bias,
-                        query_start_loc_opt=query_start_loc_opt,
-                        cache_indices_opt=cache_indices_opt,
-                        initial_state_mode_opt=initial_state_mode_opt,
-                        num_accepted_tokens_opt=None,
-                        activation_mode=activation_num,
-                        pad_slot_id=PAD_SLOT_ID,
-                        run_mode=0,
-                    )
-                    mixed_qkv_non_spec = mixed_qkv_non_spec_output
+                    if mixed_qkv_non_spec.shape[0] > 0:
+                        mixed_qkv_non_spec_output = torch.empty_like(mixed_qkv_non_spec)
+                        torch.ops._C_ascend.npu_causal_conv1d_custom(
+                            mixed_qkv_non_spec_output,
+                            mixed_qkv_non_spec,
+                            conv_weights_T,
+                            conv_state=self_kv_cache[0],
+                            bias_opt=self.conv1d.bias,
+                            query_start_loc_opt=query_start_loc_opt,
+                            cache_indices_opt=cache_indices_opt,
+                            initial_state_mode_opt=initial_state_mode_opt,
+                            num_accepted_tokens_opt=None,
+                            activation_mode=activation_num,
+                            pad_slot_id=PAD_SLOT_ID,
+                            run_mode=0,
+                        )
+                        mixed_qkv_non_spec = mixed_qkv_non_spec_output
                     if prefill_cache_indices.shape[0] > 0:
                         self_kv_cache[0][prefill_cache_indices, :state_len, :] = all_last_width_prefill_x[
-                            -1, ...
+                            last_non_empty_rank, ...
                         ].transpose(-1, -2)
                 else:
                     conv_weights_T = conv_weights.transpose(0, 1)
@@ -304,6 +368,24 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             )
             mixed_qkv_non_spec = output_non_spec
         else:
+            mixed_qkv_non_spec = None
+
+        # On an empty PCP rank (0 tokens assigned to this rank), the PCP
+        # state sharing (all_gather) above has already completed — all
+        # ranks have participated, so no collective will deadlock. Skip
+        # all remaining computation: every NPU kernel (fused_gdn_gating,
+        # rearrange_mixed_qkv, chunk_gated_delta_rule, etc.) crashes on
+        # empty tensors (0-element tiling failure or ambiguous reshape),
+        # and there are no tokens to produce output for. core_attn_out[:0]
+        # is a no-op, so leaving it unwritten is safe.
+        if num_actual_tokens == 0:
+            return
+
+        # Defensive guard: convert any remaining empty tensors to None
+        # so rearrange_mixed_qkv doesn't crash on .view(1, 0, -1, dim).
+        if mixed_qkv_spec is not None and mixed_qkv_spec.numel() == 0:
+            mixed_qkv_spec = None
+        if mixed_qkv_non_spec is not None and mixed_qkv_non_spec.numel() == 0:
             mixed_qkv_non_spec = None
 
         query_spec, key_spec, value_spec = self.rearrange_mixed_qkv(mixed_qkv_spec)
@@ -381,7 +463,12 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             core_attn_out_decode = None
 
         # 2.3: Process the remaining part
-        if attn_metadata.num_prefills > 0:
+        # Guard: on an empty PCP rank (0 prefill tokens assigned to this
+        # rank), skip chunk_gated_delta_rule — it would crash on empty
+        # q/k/v. The ssm_state update is also skipped (no tokens to
+        # process). core_attn_out_non_spec stays None, handled by the
+        # merge step below.
+        if attn_metadata.num_prefills > 0 and num_actual_tokens > 0:
             prefill_query_start_loc = attn_metadata.prefill_query_start_loc
             prefill_state_indices = attn_metadata.prefill_state_indices
             prefill_has_initial_state = attn_metadata.prefill_has_initial_state
@@ -397,27 +484,40 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 g_non_spec = g_non_spec[:, num_decode_tokens:]
                 beta_non_spec = beta_non_spec[:, num_decode_tokens:]
 
-            initial_state = ssm_state[prefill_state_indices].transpose(-1, -2).contiguous()
-            clear_ssm_states(initial_state, prefill_has_initial_state)
-            (core_attn_out_non_spec, last_recurrent_state) = chunk_gated_delta_rule(
-                q=query_non_spec,
-                k=key_non_spec,
-                v=value_non_spec,
-                g=g_non_spec,
-                beta=beta_non_spec,
-                initial_state=initial_state,
-                output_final_state=True,
-                cu_seqlens=prefill_query_start_loc,
-                prebuilt_meta=attn_metadata.non_spec_prefill_metadata.chunk,
-                head_first=False,
-                use_qk_l2norm_in_kernel=True,
-            )
-            ssm_state[prefill_state_indices] = last_recurrent_state.transpose(-1, -2).contiguous().to(ssm_state.dtype)
-            if split_non_spec:
-                core_attn_out_non_spec = torch.cat(
-                    [core_attn_out_decode, core_attn_out_non_spec],
-                    dim=1,
+            # After split_non_spec strips decode tokens, an empty PCP rank
+            # (all prefill tokens assigned to another rank) has 0 prefill
+            # tokens. chunk_gated_delta_rule crashes on empty q/k/v
+            # (coreDim == 0 in chunk_local_cumsum). skip_pcp_all_gather is
+            # already set by the conv1d block's has_token_flag check, so
+            # rank 0 also skips the PCP all_gather — no deadlock.
+            if query_non_spec is not None and query_non_spec.shape[1] > 0:
+                initial_state = ssm_state[prefill_state_indices].transpose(-1, -2).contiguous()
+                clear_ssm_states(initial_state, prefill_has_initial_state)
+                (core_attn_out_non_spec, last_recurrent_state) = chunk_gated_delta_rule(
+                    q=query_non_spec,
+                    k=key_non_spec,
+                    v=value_non_spec,
+                    g=g_non_spec,
+                    beta=beta_non_spec,
+                    initial_state=initial_state,
+                    output_final_state=True,
+                    cu_seqlens=prefill_query_start_loc,
+                    prebuilt_meta=attn_metadata.non_spec_prefill_metadata.chunk,
+                    head_first=False,
+                    use_qk_l2norm_in_kernel=True,
+                    skip_pcp_all_gather=skip_pcp_all_gather,
                 )
+                ssm_state[prefill_state_indices] = last_recurrent_state.transpose(-1, -2).contiguous().to(ssm_state.dtype)
+                if split_non_spec:
+                    core_attn_out_non_spec = torch.cat(
+                        [core_attn_out_decode, core_attn_out_non_spec],
+                        dim=1,
+                    )
+            elif split_non_spec:
+                # 0 prefill tokens on this PCP rank; use decode output only
+                core_attn_out_non_spec = core_attn_out_decode
+            else:
+                core_attn_out_non_spec = None
         elif attn_metadata.num_decodes > 0:
             actual_seq_lengths = attn_metadata.non_spec_decode_metadata.actual_seq_lengths
             query_non_spec = l2norm_fwd(query_non_spec)
@@ -451,4 +551,5 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
         elif spec_sequence_masks is not None:
             core_attn_out[:num_actual_tokens] = core_attn_out_spec.squeeze(0)
         else:
-            core_attn_out[:num_actual_tokens] = core_attn_out_non_spec.squeeze(0)
+            if core_attn_out_non_spec is not None:
+                core_attn_out[:num_actual_tokens] = core_attn_out_non_spec.squeeze(0)

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -38,6 +38,7 @@ def chunk_gated_delta_rule_fwd(
     output_final_state: bool,
     cu_seqlens: torch.LongTensor | None = None,
     prebuilt_meta=None,
+    skip_pcp_all_gather: bool = False,
 ):
     forward_context = get_forward_context()
     num_decodes = 0
@@ -135,7 +136,7 @@ def chunk_gated_delta_rule_fwd(
         _fs_full[keep_meta] = final_state
         final_state = _fs_full
 
-    if get_pcp_group().world_size > 1:
+    if get_pcp_group().world_size > 1 and not skip_pcp_all_gather:
         # When integrating mtp, since `mix_qkv` has been split, `num_decode`
         # cannot be directly obtained from the metadata and needs to be recalculated.
         actual_num_decodes = getattr(prebuilt_meta, "num_decodes", None)
@@ -202,7 +203,7 @@ def chunk_gated_delta_rule_fwd(
         scale,
         g=g_ascendc,
         g_gamma=None,
-        cu_seqlens=cu_seqlens_host,
+        cu_seqlens=cu_seqlens_kern,
         chunk_indices=chunk_indices_chunk64_host,
         chunk_size=64,
         transpose_state_layout=False,
@@ -234,6 +235,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         cu_seqlens: torch.LongTensor | None = None,
         prebuilt_meta=None,
         use_qk_l2norm_in_kernel: bool = False,
+        skip_pcp_all_gather: bool = False,
     ):
         if use_qk_l2norm_in_kernel:
             q = l2norm_fwd(q)
@@ -249,6 +251,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
             output_final_state=output_final_state,
             cu_seqlens=cu_seqlens,
             prebuilt_meta=prebuilt_meta,
+            skip_pcp_all_gather=skip_pcp_all_gather,
         )
         ctx.scale = scale
         ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
@@ -272,6 +275,7 @@ def chunk_gated_delta_rule(
     chunk_indices: torch.Tensor | None = None,
     chunk_offsets: torch.Tensor | None = None,
     core_attn_out: torch.Tensor | None = None,
+    skip_pcp_all_gather: bool = False,
 ):
     r"""
     Args:
@@ -380,6 +384,7 @@ def chunk_gated_delta_rule(
         cu_seqlens,
         prebuilt_meta,
         use_qk_l2norm_in_kernel,
+        skip_pcp_all_gather,
     )
     if head_first:
         o = rearrange(o, "b t h ... -> b h t ...")

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3078,10 +3078,22 @@ class NPUModelRunner(GPUModelRunner):
         num_encoder_reqs: int = 0,
     ) -> tuple[CUDAGraphMode, BatchDescriptor, bool, torch.Tensor | None, CUDAGraphStat | None]:
         num_tokens_padded = self._pad_for_sequence_parallelism(num_tokens)
-        is_all_decode = np.all(self.input_batch.num_computed_tokens_cpu[:num_reqs] > 0)
+        # A request is truly decoding only once all prompt tokens are computed
+        # (num_computed_tokens >= num_prompt_tokens). Checking num_computed_tokens
+        # > 0 is insufficient: the trailing 1-token chunk of a chunked prefill
+        # also has num_computed_tokens > 0 but is still prefilling. Without this
+        # guard, that chunk is misclassified as uniform_decode and dispatched to
+        # the FULL graph path, which expects decode-only attn_metadata fields
+        # (e.g. non_spec_decode_fallback_meta / decode_meta) that are absent for
+        # prefill, crashing the worker. This applies with and without speculative
+        # decoding, so the speculative_config bypass is removed.
+        is_all_decode = np.all(
+            self.input_batch.num_computed_tokens_cpu[:num_reqs]
+            >= self.input_batch.num_prompt_tokens[:num_reqs]
+        )
         uniform_decode = (
             (
-                (is_all_decode if self.speculative_config else True)
+                    is_all_decode
                 and (max_num_scheduled_tokens == self.uniform_decode_query_len)
                 and (num_tokens == max_num_scheduled_tokens * num_reqs)
             )


### PR DESCRIPTION
### What this PR does / why we need it?

  This PR fixes two categories of crashes on Ascend NPU when running Qwen3.5-style hybrid models (with GDN/Gated Delta Net layers) under PCP (Prefill  Context Parallel) + chunked prefill:

  **1. PCP empty rank crashes in GDN attention (`gdn.py` + `chunk.py`)**

  When PCP splits a small prefill chunk (e.g. 1-token remainder with `max_num_batched_tokens=72`) across multiple PCP ranks, some ranks receive 0 prefill  tokens. This causes:
  - `coreDim == 0` crash in AscendC kernels (`chunk_local_cumsum_scalar_kernel`, `npu_causal_conv1d_custom`, `chunk_fwd_o`) when launched on empty tensors
  - `all_gather` deadlock: the empty rank early-returns and cannot participate in PCP collectives inside `chunk_gated_delta_rule_fwd`
  - `extract_last_width` IndexError on empty prefill ranges (when a rank has decode tokens but 0 prefill tokens)
  - `rearrange_mixed_qkv` crash on `.view(1, 0, -1, dim)` with empty tensors

  Fixes:
  - Add `skip_pcp_all_gather` flag propagated through `chunk_gated_delta_rule` → `ChunkGatedDeltaRuleFunction.apply` → `chunk_gated_delta_rule_fwd`, so all ranks skip the PCP `all_gather` block when any rank is empty
  - Add `has_token_flag` checking **prefill tokens** (not total tokens) to correctly identify empty ranks under concurrency (a rank can have decode tokens but 0 prefill tokens)
  - Add `last_non_empty_rank` to pull real state data instead of dummy zeros from an empty rank
  - Add empty tensor guards for `npu_causal_conv1d_custom`, `extract_last_width`, `chunk_gated_delta_rule`, and `rearrange_mixed_qkv`
  - Add `num_actual_tokens == 0` early return for completely empty PCP ranks
  - Use compact `cu_seqlens_kern` (empty segments removed) instead of `cu_seqlens_host` in `chunk_fwd_o`, matching the already-compact  `chunk_indices_chunk64` to prevent AscendC kernel OOB writes

  **2. Chunked prefill 1-token remainder misclassified as decode (`model_runner_v1.py`)**

  With `max_num_batched_tokens=72`, the trailing 1-token chunk of a chunked prefill has `num_computed_tokens > 0` but `< num_prompt_tokens` — still prefilling. The old `is_all_decode` check (`num_computed_tokens > 0`) misclassifies it as decode, dispatching to the FULL graph path which expects decode-only `attn_metadata` fields (e.g. `non_spec_decode_fallback_meta`), crashing the worker.

  Fix: Change `is_all_decode` from `> 0` to `>= num_prompt_tokens`, and remove the `speculative_config` bypass `(is_all_decode if self.speculative_config else True)` so the check applies uniformly.

  ### Does this PR introduce _any_ user-facing change?

  No.

  ### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/e5588e49bc2642670116664a7fc4096e27adb179
