### PR TITLE
[Bugfix][Scheduler] Fix encoder input return unpacking

### DIFF
--- a/vllm_ascend/core/scheduler_dynamic_batch.py
+++ b/vllm_ascend/core/scheduler_dynamic_batch.py
@@ -206,7 +206,7 @@ class SchedulerDynamicBatch(Scheduler):
             encoder_inputs_to_schedule = None
             new_encoder_compute_budget = encoder_compute_budget
             if request.has_encoder_inputs:
-                (encoder_inputs_to_schedule, num_new_tokens, new_encoder_compute_budget) = (
+                (encoder_inputs_to_schedule, num_new_tokens, new_encoder_compute_budget, _) = (
                     self._try_schedule_encoder_inputs(
                         request, request.num_computed_tokens, num_new_tokens, encoder_compute_budget
                     )


### PR DESCRIPTION
### What this PR does / why we need it?

Aligns `SchedulerDynamicBatch` with the vLLM 0.18 `_try_schedule_encoder_inputs` return signature.

The helper returns four values, but the running-request path only unpacked three. Multimodal requests using dynamic batching could therefore fail with `ValueError: too many values to unpack`. The unused fourth value is now explicitly discarded, matching the waiting-request path.

### Does this PR introduce _any_ user-facing change?

Yes. Running multimodal requests using the dynamic batch scheduler no longer fail during encoder-input scheduling because of tuple unpacking.

### How was this patch tested?

- `PYTHONPYCACHEPREFIX=/tmp/vllm-ascend-pycache python3 -m py_compile vllm_ascend/core/scheduler_dynamic_batch.py`
- `git diff --check`

Unit tests were not run locally because the current environment does not have vLLM or pytest installed. CI verification is required.

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
