### PR TITLE
[Ops][BugFix] Fix parent block hash chain exception in AscendStore KV event

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -423,6 +423,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
                         )
                         if block_size is not None:
                             block_idx = start // group_block_size
+                            if block_idx >= len(all_hashes):
+                                continue
                             current_hash = all_hashes[block_idx]
                             parent_hash = all_hashes[block_idx - 1] if block_idx > 0 else None
                             stored_event = BlockStored(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -401,8 +401,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 addrs = []
                 sizes = []
                 stored_events: list[BlockStored] = []
-                prev_key = None
-                new_block_hashes = [maybe_convert_block_hash(bh) for bh in block_hashes]
+                all_hashes = [maybe_convert_block_hash(bh) for bh in group_block_hashes]
                 for index, start in enumerate(starts):
                     addr, size, _ = self._prepare_value(
                         start,
@@ -423,9 +422,12 @@ class KVCacheStoreSendingThread(KVTransferThread):
                             else req_meta.original_block_size
                         )
                         if block_size is not None:
+                            block_idx = start // group_block_size
+                            current_hash = all_hashes[block_idx]
+                            parent_hash = all_hashes[block_idx - 1] if block_idx > 0 else None
                             stored_event = BlockStored(
-                                block_hashes=[new_block_hashes[index]],
-                                parent_block_hash=prev_key,
+                                block_hashes=[current_hash],
+                                parent_block_hash=parent_hash,
                                 token_ids=token_ids,
                                 block_size=block_size,
                                 lora_id=None,
@@ -433,7 +435,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
                                 lora_name=None,
                             )
                             stored_events.append(stored_event)
-                            prev_key = new_block_hashes[index]
                             logger.debug("Added kv cache event '%s' to kv cache events queue", stored_event)
 
                 if self.kv_role == "kv_consumer":


### PR DESCRIPTION
### What this PR does / why we need it?
Fixes issue：https://github.com/vllm-project/vllm-ascend/issues/12002
This PR fixes an exception in the parent block hash chain for `AscendStore` KV events. Previously, `prev_key` was tracked across loop iterations of only the missing blocks being stored. This caused incorrect parent-child relationships or exceptions when some blocks in the sequence were already cached and thus skipped.
This change resolves the issue by pre-computing all block hashes for the group (`all_hashes`) and looking up the parent block hash directly using the block index (`block_idx - 1`), ensuring correct parent-child chain tracking.

### Does this PR introduce _any_ user-facing change?

No. This is an internal bugfix for KV transfer event tracking on Ascend devices.

### How was this patch tested?

Tested with existing unit tests and integration tests for KV transfer.


- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
