### PR TITLE
[Doc][Misc] Update documentation header notification bar

### DIFF
--- a/docs/source/_templates/sections/header.html
+++ b/docs/source/_templates/sections/header.html
@@ -54,5 +54,5 @@
   </style>
   
   <div class="notification-bar">
-    <p>You are viewing the stable release(v0.18.0) documentation. <a href="https://docs.vllm.ai/projects/ascend/en/latest/">Click here</a> to view the latest developer preview documentation.</p>
+    <p>You are viewing the stable release (v0.18.0) documentation. <a href="https://docs.vllm.ai/projects/ascend/en/latest/">Click here</a> to view the latest developer preview documentation.</p>
   </div>

--- a/docs/source/_templates/sections/header.html
+++ b/docs/source/_templates/sections/header.html
@@ -54,5 +54,5 @@
   </style>
   
   <div class="notification-bar">
-    <p>You are viewing the latest developer preview docs. <a href="https://docs.vllm.ai/projects/ascend/en/v0.18.0">Click here</a> to view docs for the latest stable release(v0.18.0).</p>
+    <p>You are viewing the stable release(v0.18.0) documentation. <a href="https://docs.vllm.ai/projects/ascend/en/latest/">Click here</a> to view the latest developer preview documentation.</p>
   </div>


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request updates the notification bar in the documentation header template to show that the user is viewing the stable release (v0.18.0) documentation and links to the latest developer preview. 
Fixes #10382
### Does this PR introduce _any_ user-facing change?
Yes, it updates the notification bar text and links in the documentation header.

### How was this patch tested?
No tests were added as this is a documentation template change.

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
