### PR TITLE
[CI] add options for releases/v0.23.0

### DIFF
--- a/.github/workflows/nightly_image_build.yaml
+++ b/.github/workflows/nightly_image_build.yaml
@@ -30,6 +30,7 @@ on:
         type: choice
         options:
           - main
+          - releases/v0.23.0
           - releases/v0.22.1rc
           - releases/v0.18.0
 

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -41,6 +41,7 @@ on:
         type: choice
         options:
           - main
+          - releases/v0.23.0
           - releases/v0.22.1rc
           - releases/v0.21.0rc
           - releases/v0.20.2rc


### PR DESCRIPTION
### What this PR does / why we need it?
add image build and push options for releases/v0.23.0

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/e5588e49bc2642670116664a7fc4096e27adb179
