### PR TITLE
[v0.23.0][BugFix][GDN] Fix PD, PCP and DCP accuracy regressions

### DIFF
--- a/tests/ut/_310p/ops/test_gdn_310.py
+++ b/tests/ut/_310p/ops/test_gdn_310.py
@@ -99,3 +99,43 @@ def test_builder310_pads_spec_decode_metadata_with_dummy_requests():
     assert spec_meta.cache_indices.data_ptr() == attn_metadata.spec_state_indices_tensor.data_ptr()
     assert spec_meta.num_accepted_tokens.data_ptr() == attn_metadata.num_accepted_tokens.data_ptr()
     assert attn_metadata.spec_decode_metadata.actual_seq_lengths.tolist() == [0, 4, 4, 0, 0]
+
+
+def test_builder310_refreshes_non_spec_decode_graph_metadata():
+    builder = object.__new__(AscendGDNAttentionMetadataBuilder310)
+    builder.non_spec_state_indices_tensor = torch.full((4,), 77, dtype=torch.int32)
+    builder.non_spec_query_start_loc = torch.full((5,), 77, dtype=torch.int32)
+    builder.non_spec_actual_seq_lengths = torch.full((5,), 77, dtype=torch.int32)
+    builder.use_full_cuda_graph = True
+    attn_metadata = SimpleNamespace(
+        num_prefills=0,
+        num_decodes=4,
+        num_decode_tokens=2,
+        num_spec_decodes=0,
+        non_spec_state_indices_tensor=torch.tensor(
+            [10, 11, 98, 99],
+            dtype=torch.int32,
+        ),
+        non_spec_query_start_loc=torch.tensor(
+            [0, 1, 2, 2, 2],
+            dtype=torch.int32,
+        ),
+    )
+
+    builder._pad_decode_metadata(attn_metadata, graph_batch_size=4)
+
+    assert attn_metadata.non_spec_state_indices_tensor.tolist() == [
+        10,
+        11,
+        NULL_BLOCK_ID,
+        NULL_BLOCK_ID,
+    ]
+    assert attn_metadata.non_spec_query_start_loc.tolist() == [0, 1, 2, 2, 2]
+    assert attn_metadata.non_spec_state_indices_tensor.data_ptr() == builder.non_spec_state_indices_tensor.data_ptr()
+    assert attn_metadata.non_spec_query_start_loc.data_ptr() == builder.non_spec_query_start_loc.data_ptr()
+    decode_meta = attn_metadata.non_spec_decode_metadata
+    conv_meta = decode_meta.causal_conv1d
+    assert conv_meta.query_start_loc.data_ptr() == attn_metadata.non_spec_query_start_loc.data_ptr()
+    assert conv_meta.cache_indices.data_ptr() == attn_metadata.non_spec_state_indices_tensor.data_ptr()
+    assert decode_meta.actual_seq_lengths.data_ptr() == builder.non_spec_actual_seq_lengths.data_ptr()
+    assert decode_meta.actual_seq_lengths.tolist() == [0, 1, 1, 0, 0]

--- a/tests/ut/ops/test_gdn_attn_builder.py
+++ b/tests/ut/ops/test_gdn_attn_builder.py
@@ -9,6 +9,7 @@ import torch
 from vllm.config.compilation import CUDAGraphMode
 from vllm.model_executor.layers.fla.ops import index as _fla_index
 from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.kv_cache_interface import MambaSpec
 
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
@@ -242,7 +243,9 @@ def _assert_chunk_meta_matches_runtime(builder, chunk_meta, cu_seqlens: torch.Te
         ascend_gdn_attn_builder._GDN_CUMSUM_WORKING_SET // (gdn_num_heads * ascend_gdn_attn_builder._GDN_CHUNK_SIZE),
     )
     cumsum_chunk_size = 1 if cumsum_chunks <= 1 else 1 << (cumsum_chunks - 1).bit_length()
+    sequence_lengths = cu_seqlens[1:] - cu_seqlens[:-1]
 
+    assert chunk_meta.num_decodes == (sequence_lengths == 1).sum().item()
     assert torch.equal(
         chunk_meta.chunk_indices_chunk64,
         runtime_prepare_chunk_indices(cu_seqlens, ascend_gdn_attn_builder._GDN_CHUNK_SIZE),
@@ -444,6 +447,36 @@ def test_non_spec_prefill_metadata_uses_prefill_tail_for_chunk_metadata(
     )
 
 
+def test_mixed_spec_prefill_chunk_metadata_preserves_single_token_count(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _patch_missing_runtime_cdiv(monkeypatch)
+    batch_spec = BatchSpec(
+        seq_lens=[1, 4, 8],
+        query_lens=[1, 4, 8],
+        name="mixed_spec_prefill_with_single_token_non_spec",
+    )
+    builder, _, attn_metadata = _build_attn_metadata(
+        batch_spec,
+        num_speculative_tokens=3,
+        num_decode_draft_tokens_cpu=torch.tensor([-1, 3, -1], dtype=torch.int32),
+    )
+
+    assert attn_metadata.num_decodes == 0
+    assert attn_metadata.num_prefills == 2
+    assert torch.equal(
+        attn_metadata.prefill_query_start_loc,
+        torch.tensor([0, 1, 9], dtype=torch.int32),
+    )
+    chunk_metadata = attn_metadata.non_spec_prefill_metadata.chunk
+    assert chunk_metadata.num_decodes == 1
+    _assert_chunk_meta_matches_runtime(
+        builder,
+        chunk_metadata,
+        attn_metadata.prefill_query_start_loc,
+    )
+
+
 def test_spec_conv1d_args_use_device_cache_and_accepted_tokens():
     batch_spec = BatchSpec(
         seq_lens=[4, 4],
@@ -573,10 +606,86 @@ def test_full_graph_spec_actual_seq_lengths_use_padded_builder_buffer():
     )
 
 
-def test_full_graph_non_spec_actual_seq_lengths_use_padded_builder_buffer():
+def test_full_graph_without_runtime_spec_resets_captured_spec_inputs():
+    capture_batch = BatchSpec(
+        seq_lens=[4, 4],
+        query_lens=[4, 4],
+        name="full_graph_spec_capture",
+    )
+    capture_common_metadata = create_common_attn_metadata(
+        batch_spec=capture_batch,
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    capture_common_metadata.num_reqs = 4
+    capture_common_metadata.block_table_tensor = torch.tensor(
+        [[10, 11, 12, 13], [20, 21, 22, 23]],
+        dtype=torch.int32,
+    )
+    builder = _make_builder(
+        device=torch.device("cpu"),
+        num_heads=32,
+        num_speculative_tokens=3,
+        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+    )
+    captured_metadata = builder.build(
+        0,
+        capture_common_metadata,
+        num_accepted_tokens=torch.tensor([2, 4], dtype=torch.int32),
+        num_decode_draft_tokens_cpu=torch.tensor([3, 3], dtype=torch.int32),
+    )
+    captured_spec_metadata = captured_metadata.spec_decode_metadata
+    captured_conv1d_metadata = captured_spec_metadata.spec_causal_conv1d
+
+    assert torch.count_nonzero(captured_conv1d_metadata.query_start_loc) > 0
+    assert torch.count_nonzero(captured_spec_metadata.actual_seq_lengths) > 0
+
+    replay_batch = BatchSpec(
+        seq_lens=[1, 1, 0, 0],
+        query_lens=[1, 1, 0, 0],
+        name="full_graph_replay_without_spec",
+    )
+    replay_common_metadata = create_common_attn_metadata(
+        batch_spec=replay_batch,
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    replay_metadata = builder.build(
+        0,
+        replay_common_metadata,
+        num_accepted_tokens=torch.ones(4, dtype=torch.int32),
+        num_decode_draft_tokens_cpu=torch.full((4,), -1, dtype=torch.int32),
+    )
+
+    assert replay_metadata.spec_sequence_masks is None
+    assert replay_metadata.spec_decode_metadata is None
+    assert torch.equal(
+        captured_conv1d_metadata.cache_indices,
+        torch.full((4, 4), PAD_SLOT_ID, dtype=torch.int32),
+    )
+    assert torch.count_nonzero(captured_conv1d_metadata.query_start_loc) == 0
+    assert torch.count_nonzero(captured_conv1d_metadata.num_accepted_tokens) == 0
+    assert torch.count_nonzero(captured_spec_metadata.actual_seq_lengths) == 0
+
+
+@pytest.mark.parametrize(
+    ("num_speculative_tokens", "num_decode_draft_tokens_cpu"),
+    [
+        pytest.param(0, None, id="without_mtp"),
+        pytest.param(
+            3,
+            torch.full((4,), -1, dtype=torch.int32),
+            id="mtp_without_spec_requests",
+        ),
+    ],
+)
+def test_full_graph_non_spec_metadata_nulls_padded_state_indices(
+    num_speculative_tokens: int,
+    num_decode_draft_tokens_cpu: torch.Tensor | None,
+):
     batch_spec = BatchSpec(
-        seq_lens=[1, 1],
-        query_lens=[1, 1],
+        seq_lens=[1, 1, 0, 0],
+        query_lens=[1, 1, 0, 0],
         name="full_graph_padded_non_spec_actual_seq_lengths",
     )
     common_attn_metadata = create_common_attn_metadata(
@@ -584,26 +693,42 @@ def test_full_graph_non_spec_actual_seq_lengths_use_padded_builder_buffer():
         block_size=16,
         device=torch.device("cpu"),
     )
-    common_attn_metadata.num_actual_tokens = 4
+    # PCP leaves padded block-table rows untouched. Model the stale valid
+    # state slots that can remain there after the preceding decode batch.
+    common_attn_metadata.block_table_tensor[:, 0] = torch.tensor([10, 11, 98, 99])
     builder = _make_builder(
         device=torch.device("cpu"),
         num_heads=32,
-        num_speculative_tokens=0,
+        num_speculative_tokens=num_speculative_tokens,
         cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
     )
+    builder.non_spec_state_indices_tensor.fill_(77)
+    builder.non_spec_query_start_loc.fill_(77)
+    builder.non_spec_actual_seq_lengths.fill_(77)
 
-    attn_metadata = builder.build(0, common_attn_metadata)
+    attn_metadata = builder.build(
+        0,
+        common_attn_metadata,
+        num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+    )
 
+    assert attn_metadata.num_decodes == 4
+    assert attn_metadata.num_decode_tokens == 2
     assert torch.equal(
         attn_metadata.non_spec_query_start_loc,
         torch.tensor([0, 1, 2, 2, 2], dtype=torch.int32),
     )
-    assert (
-        attn_metadata.non_spec_decode_metadata.actual_seq_lengths.data_ptr()
-        == builder.non_spec_actual_seq_lengths.data_ptr()
-    )
     assert torch.equal(
-        attn_metadata.non_spec_decode_metadata.actual_seq_lengths,
+        attn_metadata.non_spec_state_indices_tensor,
+        torch.tensor([10, 11, 0, 0], dtype=torch.int32),
+    )
+    decode_metadata = attn_metadata.non_spec_decode_metadata
+    conv1d_metadata = decode_metadata.causal_conv1d
+    assert conv1d_metadata.query_start_loc.data_ptr() == attn_metadata.non_spec_query_start_loc.data_ptr()
+    assert conv1d_metadata.cache_indices.data_ptr() == attn_metadata.non_spec_state_indices_tensor.data_ptr()
+    assert decode_metadata.actual_seq_lengths.data_ptr() == builder.non_spec_actual_seq_lengths.data_ptr()
+    assert torch.equal(
+        decode_metadata.actual_seq_lengths,
         torch.tensor([0, 1, 1, 0, 0], dtype=torch.int32),
     )
 

--- a/tests/ut/worker/a2/test_model_runner_v1_with_device.py
+++ b/tests/ut/worker/a2/test_model_runner_v1_with_device.py
@@ -341,6 +341,13 @@ def test_determine_batch_execution_and_padding(
 
     try:
         runner.input_batch.num_computed_tokens_cpu[:num_reqs] = num_computed_tokens
+        computed_tokens = np.asarray(num_computed_tokens, dtype=np.int32)
+        scheduled_tokens = np.asarray(num_scheduled_tokens, dtype=np.int32)
+        runner.input_batch.num_prompt_tokens[:num_reqs] = np.where(
+            computed_tokens == 0,
+            scheduled_tokens,
+            computed_tokens,
+        )
         num_scheduled_tokens_np = np.array(num_scheduled_tokens, dtype=np.int32)
 
         kwargs = dict(
@@ -391,3 +398,37 @@ def test_determine_batch_execution_and_padding(
     finally:
         runner.speculative_config = saved_spec_config
         runner.uniform_decode_query_len = saved_query_len
+
+
+@pytest.mark.parametrize(
+    ("num_prompt_tokens", "expected_uniform_decode"),
+    [
+        pytest.param(8, False, id="one_token_pd_prefill"),
+        pytest.param(7, True, id="decode_after_prompt"),
+    ],
+)
+def test_uniform_decode_requires_completed_prompt_without_mtp(
+    model_runner,
+    num_prompt_tokens: int,
+    expected_uniform_decode: bool,
+):
+    runner = model_runner
+    runner.speculative_config = None
+    runner.uniform_decode_query_len = 1
+    runner.input_batch.num_computed_tokens_cpu[0] = 7
+    runner.input_batch.num_prompt_tokens[0] = num_prompt_tokens
+
+    with patch.object(
+        runner.cudagraph_dispatcher,
+        "dispatch",
+        wraps=runner.cudagraph_dispatcher.dispatch,
+    ) as dispatch:
+        runner._determine_batch_execution_and_padding(
+            num_tokens=1,
+            num_reqs=1,
+            num_scheduled_tokens_np=np.array([1], dtype=np.int32),
+            max_num_scheduled_tokens=1,
+            use_cascade_attn=False,
+        )
+
+    assert bool(dispatch.call_args.kwargs["uniform_decode"]) is expected_uniform_decode

--- a/vllm_ascend/_310p/ops/gdn_attn_builder_310.py
+++ b/vllm_ascend/_310p/ops/gdn_attn_builder_310.py
@@ -177,30 +177,20 @@ class GDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
         attn_metadata: GDNAttentionMetadata,
         graph_batch_size: int,
     ) -> None:
-        num_decodes = attn_metadata.num_decodes
         state_indices = attn_metadata.non_spec_state_indices_tensor
         query_start_loc = attn_metadata.non_spec_query_start_loc
         assert state_indices is not None
         assert query_start_loc is not None
 
-        self.non_spec_state_indices_tensor[:num_decodes].copy_(
+        (
+            attn_metadata.non_spec_state_indices_tensor,
+            attn_metadata.non_spec_query_start_loc,
+        ) = self._pad_non_spec_decode_graph_inputs(
             state_indices,
-            non_blocking=True,
-        )
-        attn_metadata.non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[:graph_batch_size]
-        attn_metadata.non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
-
-        self.non_spec_query_start_loc[: num_decodes + 1].copy_(
             query_start_loc,
-            non_blocking=True,
+            num_decode_tokens=attn_metadata.num_decode_tokens,
+            graph_batch_size=graph_batch_size,
         )
-        attn_metadata.non_spec_query_start_loc = self.non_spec_query_start_loc[: graph_batch_size + 1]
-        query_padding = attn_metadata.non_spec_query_start_loc[num_decodes + 1 :]
-        if query_padding.numel() > 0:
-            query_padding.copy_(
-                query_start_loc[-1].expand_as(query_padding),
-                non_blocking=True,
-            )
         self._attach_non_spec_decode_metadata(
             attn_metadata,
             attn_metadata.non_spec_state_indices_tensor,

--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -26,6 +26,7 @@ from vllm.v1.attention.backends.gdn_attn import (
 )
 from vllm.v1.attention.backends.utils import (
     NULL_BLOCK_ID,
+    PAD_SLOT_ID,
     compute_causal_conv1d_metadata,
     mamba_get_block_table_tensor,
     split_decodes_and_prefills,
@@ -61,7 +62,7 @@ class GDNChunkedPrefillMetadata:
     final_chunk_indices_chunk64: torch.Tensor
     chunk_indices_large_block: torch.Tensor
     block_indices_cumsum: torch.Tensor
-    num_decodes: int = 0
+    num_decodes: int
     cu_seqlens_kern: tuple[int, ...] | None = None
     keep_meta: torch.Tensor | None = None
 
@@ -168,6 +169,7 @@ def _build_non_spec_chunked_prefill_metadata(
     block_indices_cumsum = prepare_chunk_indices(cu_seqlens_cpu, cumsum_chunk_size)
 
     cu_seqlens_host = tuple(cu_seqlens_cpu.to(torch.int64).reshape(-1).tolist())
+    num_decodes = sum(1 for seq_start, seq_end in zip(cu_seqlens_host, cu_seqlens_host[1:]) if seq_end - seq_start == 1)
     # Pre-compute compact cu_seqlens for AscendC kernels so each layer
     # can reuse them instead of calling _compact_empty_segments again.
     cu_seqlens_kern, _, keep_meta = _compact_empty_segments(cu_seqlens_host, None, device=device)
@@ -185,6 +187,7 @@ def _build_non_spec_chunked_prefill_metadata(
         final_chunk_indices_chunk64=final_chunk_indices_chunk64.to(device=device, non_blocking=True),
         chunk_indices_large_block=chunk_indices_large_block.to(device=device, non_blocking=True),
         block_indices_cumsum=block_indices_cumsum.to(device=device, non_blocking=True),
+        num_decodes=num_decodes,
         cu_seqlens_kern=cu_seqlens_kern,
         keep_meta=keep_meta,
     )
@@ -294,6 +297,58 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
         non_spec_indices.copy_(non_spec_indices_cpu, non_blocking=True)
 
         return spec_indices, non_spec_indices
+
+    def _pad_non_spec_decode_graph_inputs(
+        self,
+        state_indices: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        *,
+        num_decode_tokens: int,
+        graph_batch_size: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Refresh the fixed inputs consumed by a non-spec decode graph.
+
+        ``num_decodes`` includes graph dummy requests, while every real
+        non-spec decode contributes exactly one token.  Therefore
+        ``num_decode_tokens`` is the real request count.  Dummy state rows must
+        be null and repeated terminal query offsets must produce zero-length
+        rows for both causal conv1d and recurrent GDN consumers.
+        """
+        assert num_decode_tokens <= graph_batch_size
+
+        padded_state_indices = self.non_spec_state_indices_tensor[:graph_batch_size]
+        padded_state_indices[num_decode_tokens:].fill_(NULL_BLOCK_ID)
+        padded_state_indices[:num_decode_tokens].copy_(
+            state_indices[:num_decode_tokens],
+            non_blocking=True,
+        )
+
+        padded_query_start_loc = self.non_spec_query_start_loc[: graph_batch_size + 1]
+        padded_query_start_loc[: num_decode_tokens + 1].copy_(
+            query_start_loc[: num_decode_tokens + 1],
+            non_blocking=True,
+        )
+        query_padding = padded_query_start_loc[num_decode_tokens + 1 :]
+        if query_padding.numel() > 0:
+            query_padding.copy_(
+                padded_query_start_loc[num_decode_tokens].expand_as(query_padding),
+                non_blocking=True,
+            )
+
+        return padded_state_indices, padded_query_start_loc
+
+    def _reset_spec_decode_graph_inputs(self, graph_batch_size: int) -> None:
+        """Make a captured spec branch a state no-op for this replay.
+
+        Full-graph capture always builds speculative GDN metadata when MTP is
+        enabled. A DP rank can later replay that graph without any runtime spec
+        requests. Refresh every persistent spec input consumed by the captured
+        conv1d/recurrent tasks so capture-time values cannot advance GDN state.
+        """
+        self.spec_state_indices_tensor[:graph_batch_size].fill_(PAD_SLOT_ID)
+        self.spec_query_start_loc[: graph_batch_size + 1].zero_()
+        self.num_accepted_tokens[:graph_batch_size].zero_()
+        self.spec_actual_seq_lengths[: graph_batch_size + 1].zero_()
 
     def _attach_non_spec_prefill_metadata(
         self,
@@ -640,8 +695,6 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
             f"num_decodes: {num_decodes}, num_spec_decodes: {num_spec_decodes}"
         )
 
-        batch_size = m.num_actual_tokens
-
         if (
             self.use_full_cuda_graph
             and num_prefills == 0
@@ -705,22 +758,19 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
             and num_spec_decodes == 0
             and num_decodes <= self.decode_cudagraph_max_bs
         ):
-            self.non_spec_state_indices_tensor[batch_size:].fill_(NULL_BLOCK_ID)
-            self.non_spec_state_indices_tensor[:num_decodes].copy_(
+            graph_batch_size = m.num_reqs
+            if self.use_spec_decode:
+                self._reset_spec_decode_graph_inputs(graph_batch_size)
+            (
                 non_spec_state_indices_tensor,
-                non_blocking=True,
-            )
-            non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[:batch_size]
-            non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
-            non_spec_conv1d_cache_indices = non_spec_state_indices_tensor
-
-            self.non_spec_query_start_loc[: num_decodes + 1].copy_(
                 non_spec_query_start_loc,
-                non_blocking=True,
+            ) = self._pad_non_spec_decode_graph_inputs(
+                non_spec_state_indices_tensor,
+                non_spec_query_start_loc,
+                num_decode_tokens=num_decode_tokens,
+                graph_batch_size=graph_batch_size,
             )
-            non_spec_num_query_tokens = non_spec_query_start_loc[-1]
-            non_spec_query_start_loc = self.non_spec_query_start_loc[: batch_size + 1]
-            non_spec_query_start_loc[num_decodes + 1 :].fill_(non_spec_num_query_tokens)
+            non_spec_conv1d_cache_indices = non_spec_state_indices_tensor
 
         attn_metadata = GDNAttentionMetadata(
             num_prefills=num_prefills,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2894,10 +2894,15 @@ class NPUModelRunner(GPUModelRunner):
         num_encoder_reqs: int = 0,
     ) -> tuple[CUDAGraphMode, BatchDescriptor, bool, torch.Tensor | None, CUDAGraphStat | None]:
         num_tokens_padded = self._pad_for_sequence_parallelism(num_tokens)
-        is_all_decode = np.all(self.input_batch.num_computed_tokens_cpu[:num_reqs] > 0)
+        # A one-token chunk can still be a prefill, notably at a PD handoff.
+        # Dispatch a decode graph only after every prompt is fully computed.
+        is_all_decode = np.all(
+            self.input_batch.num_computed_tokens_cpu[:num_reqs]
+            >= self.input_batch.num_prompt_tokens[:num_reqs]
+        )
         uniform_decode = (
             (
-                (is_all_decode if self.speculative_config else True)
+                is_all_decode
                 and (max_num_scheduled_tokens == self.uniform_decode_query_len)
                 and (num_tokens == max_num_scheduled_tokens * num_reqs)
             )


### PR DESCRIPTION
### What this PR does / why we need it?

This is a minimal `releases/v0.23.0` forward fix for four Qwen3.5 GDN correctness regressions exposed after #11735, the release backport of #11161:

1. PD disaggregation without MTP can enter a decode graph before the prompt is complete and return early.
2. PCP with `FULL_DECODE_ONLY` can replay stale padded non-spec GDN metadata and corrupt output.
3. PCP + MTP mixed batches can lose the chunk-local single-token count used by PCP state propagation.
4. With MTP + DCP, a rank with no runtime speculative requests can replay capture-time spec metadata and advance stale GDN state.

The fix keeps construction ownership in the model runner/GDN metadata builders and leaves GDN forward consumers and kernels unchanged.

### Root-cause analysis and fix

#### 1. Decode graph selection

`num_computed_tokens > 0` is not sufficient to identify decode. A chunked prefill or PD handoff can have a computed prefix and a final one-token prompt chunk. The release code also bypassed `is_all_decode` when speculative decoding was disabled.

Uniform decode is now selected only after every request satisfies:

```text
num_computed_tokens >= num_prompt_tokens
```

This applies with and without MTP. An unfinished one-token prompt chunk remains on the prefill path; a completed prompt still enters the decode graph.

#### 2. Non-spec graph metadata construction

In pure non-spec decode, every real request contributes one token, but graph replay may append dummy requests. The counters therefore have distinct meanings:

| Value | Meaning during full-graph replay |
| --- | --- |
| `num_decodes` | Decode classification count, including graph dummy requests |
| `num_decode_tokens` | Real non-spec decode tokens and the real request boundary |
| `num_reqs` | Request-shaped graph input size, including dummy requests |
| `num_actual_tokens` | Real token count, not the captured request shape |

The builder refreshes all fixed-shape rows at `num_reqs`, using `num_decode_tokens` as the real boundary:

```text
state_indices       = [id0, id1, NULL, NULL]
query_start_loc     = [0, 1, 2, 2, 2]
actual_seq_lengths  = [0, 1, 1, 0, 0]
```

The same helper is used by the common and 310P builders. Dummy state rows are `NULL_BLOCK_ID`; repeated terminal offsets produce zero-length dummy recurrent rows.

#### 3. PCP chunk-local single-token count

In an MTP mixed batch, single-token non-spec requests are moved into the non-spec prefill tensor so spec and non-spec decode are not consumed together. The top-level `attn_metadata.num_decodes` is therefore intentionally reset to zero, but PCP still needs the number of leading single-token sequences when it builds `h_update` and replaces the prefill state slice.

#11195 stored that value in `GDNChunkedPrefillMetadata.num_decodes`. #11735 removed the producer while retaining a default value of zero, so the consumer silently received the wrong boundary.

The chunk metadata builder now recomputes the value from its authoritative `cu_seqlens`, passes it explicitly, and makes the dataclass field required so a future producer omission fails immediately.

#### 4. Empty runtime spec rank during graph replay

Full-graph capture can retain references to the builder's speculative input buffers. On a later MTP + DCP replay, a rank may have no runtime spec requests, so the newly returned metadata has no spec branch, but the captured spec task still sees the same stable buffer addresses. Before this patch those buffers retained capture-time values.

The no-spec graph path now refreshes those captured inputs as a state no-op:

```text
spec_state_indices      = PAD_SLOT_ID
spec_query_start_loc    = 0
num_accepted_tokens     = 0
spec_actual_seq_lengths = 0
```

`PAD_SLOT_ID` prevents causal-conv state writes, while zero actual lengths prevent recurrent state updates. This restores the device-tensor equivalent of the empty-spec protection introduced by #10901 and removed with the old host graph-task update path.

### `actual_seq_lengths` ownership

The previously proposed graph-internal derivation remains removed. `actual_seq_lengths` is derived by the GDN builder from `query_start_loc` and written into stable builder-owned buffers before replay. The only additional write in this revision is the zero-length reset for a captured spec branch when the current rank has no spec work.

### Scope and related PRs

- #12009 contains the completed-prompt graph predicate on `main` together with broader PCP empty-rank and chunk-kernel work. This release PR carries only the focused predicate and regression test.
- #11670 covers a separate PD + MTP scheduler/input issue and is not included here.
- #12180 and #12181 revert #11735. This PR is the minimal forward fix if #11735 remains; the revert alternatives should not be merged together with it.
- No GDN forward consumer, causal-conv/recurrent kernel, tiling, host graph-task hook, DCP attention kernel, or public configuration is changed.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. It prevents invalid graph dispatch and restores Qwen3.5 GDN metadata invariants for PD, PCP, MTP, and DCP combinations.

### How was this patch tested?

Local checks on commit `9cfbe3c8b`:

- focused pre-commit hooks for the changed GDN builder/tests;
- `uvx ruff check` and `uvx ruff format --check`;
- `python -m py_compile`;
- `git diff --check origin/releases/v0.23.0...HEAD`;
- exactly one signed commit on the current `releases/v0.23.0` head.

All available local checks passed.

Regression coverage verifies:

- without MTP, an unfinished one-token prompt chunk is not uniform decode, while a completed prompt remains uniform decode;
- common GDN graph padding with stale block-table/builder rows, both without MTP and with MTP configured but no speculative requests;
- the same non-spec padding contract on 310P;
- an MTP mixed batch preserves its chunk-local single-token count for PCP;
- a no-spec replay clears every stable spec input retained by a preceding full-graph spec capture.

Target-environment testing of the preceding revision confirmed the PCP and PD-without-MTP scenarios were fixed.

Earlier hardware validation of the non-spec builder portion reported:

- targeted common/310P builder tests: 22 passed in a nightly container;
- PCP=2 plus `FULL_DECODE_ONLY`, 198 prompts: baseline produced 178 corrupted responses; the fixed metadata path produced 198/198 valid JSON responses and 0 garbled responses;
- focused 16-prompt run with up to 4096 output tokens: 0 corrupted responses.

The local Mac does not have the target pytest/vLLM/NPU runtime, so the new mixed MTP + PCP and empty-spec MTP + DCP regressions still require CI and target-hardware accuracy validation.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
