### PR TITLE
[v0.23.0][BugFix]Fix fused_infer_attention ops contiguous err in GQA

### DIFF
--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -442,8 +442,8 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
         if k_nomask is not None:
             attn_out_nomask, attn_lse_nomask = torch.ops.npu.npu_fused_infer_attention_score(
                 q,
-                k_nomask,
-                v_nomask,
+                k_nomask.contiguous(),
+                v_nomask.contiguous(),
                 num_heads=self.num_heads,
                 num_key_value_heads=self.num_kv_heads,
                 input_layout="TND",
@@ -460,8 +460,8 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
         # mask Attention
         attn_out_mask, attn_lse_mask = torch.ops.npu.npu_fused_infer_attention_score(
             q,
-            k_mask,
-            v_mask,
+            k_mask.contiguous(),
+            v_mask.contiguous(),
             num_heads=self.num_heads,
             num_key_value_heads=self.num_kv_heads,
             input_layout="TND",
@@ -761,8 +761,8 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
 
         prefix_chunk_output, prefix_chunk_lse = torch.ops.npu.npu_fused_infer_attention_score(
             query,
-            key,
-            value,
+            key.contiguous(),
+            value.contiguous(),
             num_heads=num_heads,
             num_key_value_heads=self.num_kv_heads,
             input_layout="TND",
@@ -1016,8 +1016,8 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
                 # Scenario of Enabling DCP Individually
                 attn_output_prefill, attn_lse_prefill = torch.ops.npu.npu_fused_infer_attention_score(
                     prefill_query,
-                    key,
-                    value,
+                    key.contiguous(),
+                    value.contiguous(),
                     num_heads=self.num_heads,
                     num_key_value_heads=self.num_kv_heads,
                     input_layout="TND",

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -59,8 +59,8 @@ class BaseDeviceAdaptor:
     def npu_fused_infer_attention_score(
         cls,
         query: torch.Tensor,
-        key: torch.Tensor | None,
-        value: torch.Tensor | None,
+        key: torch.Tensor,
+        value: torch.Tensor,
         attn_metadata: Any,
         *,
         key_cache: torch.Tensor | None,
@@ -95,8 +95,8 @@ class BaseDeviceAdaptor:
 
         return torch_npu.npu_fused_infer_attention_score(
             query=query,
-            key=key,
-            value=value,
+            key=key.contiguous(),
+            value=value.contiguous(),
             num_key_value_heads=num_key_value_heads,
             num_heads=num_heads,
             scale=scale,
@@ -866,8 +866,8 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
     def npu_fused_infer_attention_score(
         cls,
         query: torch.Tensor,
-        key: torch.Tensor | None,
-        value: torch.Tensor | None,
+        key: torch.Tensor,
+        value: torch.Tensor,
         attn_metadata: Any,
         *,
         key_cache: torch.Tensor | None,
@@ -883,8 +883,8 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
     ):
         return torch_npu.npu_fused_infer_attention_score(
             query=query,
-            key=key,
-            value=value,
+            key=key.contiguous(),
+            value=value.contiguous(),
             num_key_value_heads=num_key_value_heads,
             num_heads=num_heads,
             scale=scale,


### PR DESCRIPTION
### What this PR does / why we need it?
The fused_infer_attention operator added a new constraint that key and value should be contiguous when input into this FIA operator. 

### Does this PR introduce _any_ user-facing change?
NO.

### How was this patch tested?
CI passed.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
